### PR TITLE
[util] remove mutable symbolt getters; route writes via setters (B2 S4a)

### DIFF
--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -695,7 +695,7 @@ void add_cprover_library(contextt &context, const languaget *language)
       exprt value = exprt(
         "sideeffect", get_complete_type(s.get_type(), namespacet{context}));
       value.statement("nondet");
-      s.get_value() = value;
+      s.set_value(value);
     }
   });
 }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -34,7 +34,11 @@ bool clang_c_adjust::adjust()
   {
     symbolt &symbol = **it;
     if (symbol.is_type)
-      adjust_type(symbol.get_type());
+    {
+      typet t = symbol.get_type();
+      adjust_type(t);
+      symbol.set_type(std::move(t));
+    }
   }
 
   Forall_symbol_list(it, symbol_list)
@@ -52,14 +56,22 @@ bool clang_c_adjust::adjust()
 void clang_c_adjust::adjust_symbol(symbolt &symbol)
 {
   if (!symbol.get_value().is_nil())
-    adjust_expr(symbol.get_value());
+  {
+    exprt v = symbol.get_value();
+    adjust_expr(v);
+    symbol.set_value(std::move(v));
+  }
 
   if (
     symbol.get_type().is_code() &&
     has_prefix(symbol.id.as_string(), "c:@F@main"))
     adjust_argc_argv(symbol);
 
-  adjust_type(symbol.get_type());
+  {
+    typet t = symbol.get_type();
+    adjust_type(t);
+    symbol.set_type(std::move(t));
+  }
 }
 
 void clang_c_adjust::adjust_expr(exprt &expr)
@@ -827,7 +839,7 @@ void clang_c_adjust::adjust_side_effect_function_call(
           param_symbol.id = id2string(identifier_with_type) + "::" + base_name;
           param_symbol.name = base_name;
           param_symbol.location = f_op.location();
-          param_symbol.get_type() = arguments[i].type();
+          param_symbol.set_type(arguments[i].type());
           param_symbol.lvalue = true;
           param_symbol.is_parameter = true;
           param_symbol.file_local = true;
@@ -842,10 +854,10 @@ void clang_c_adjust::adjust_side_effect_function_call(
         new_symbol.id = identifier_with_type;
         new_symbol.name = f_op.name();
         new_symbol.location = expr.location();
-        new_symbol.get_type() = poly.type();
+        new_symbol.set_type(poly.type());
         code_blockt implementation =
           instantiate_gcc_polymorphic_builtin(identifier, to_symbol_expr(poly));
-        new_symbol.get_value() = implementation;
+        new_symbol.set_value(implementation);
 
         context.add(new_symbol);
       }
@@ -881,11 +893,15 @@ void clang_c_adjust::adjust_side_effect_function_call(
         new_symbol.id = identifier;
         new_symbol.name = f_op.name();
         new_symbol.location = expr.location();
-        new_symbol.get_type() = f_op.type();
+        new_symbol.set_type(f_op.type());
         new_symbol.mode = "C";
 
         // Adjust type
-        to_code_type(new_symbol.get_type()).make_ellipsis();
+        {
+          typet t = new_symbol.get_type();
+          to_code_type(t).make_ellipsis();
+          new_symbol.set_type(std::move(t));
+        }
         to_code_type(f_op.type()).make_ellipsis();
         context.add(new_symbol);
       }
@@ -1404,7 +1420,7 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
   symbolt argc_symbol;
   argc_symbol.name = "argc";
   argc_symbol.id = "argc'";
-  argc_symbol.get_type() = op0.type();
+  argc_symbol.set_type(op0.type());
   argc_symbol.static_lifetime = true;
   argc_symbol.lvalue = true;
 
@@ -1421,7 +1437,7 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
   symbolt argv_symbol;
   argv_symbol.name = "argv";
   argv_symbol.id = "argv'";
-  argv_symbol.get_type() = array_typet(op1.type().subtype(), size_expr);
+  argv_symbol.set_type(array_typet(op1.type().subtype(), size_expr));
   argv_symbol.static_lifetime = true;
   argv_symbol.lvalue = true;
 
@@ -1435,7 +1451,7 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
     symbolt envp_size_symbol;
     envp_size_symbol.name = "envp_size";
     envp_size_symbol.id = "envp_size'";
-    envp_size_symbol.get_type() = op0.type(); // same type as argc!
+    envp_size_symbol.set_type(op0.type()); // same type as argc!
     envp_size_symbol.static_lifetime = true;
 
     symbolt *envp_new_size_symbol;
@@ -1444,11 +1460,11 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
     symbolt envp_symbol;
     envp_symbol.name = "envp";
     envp_symbol.id = "envp'";
-    envp_symbol.get_type() = op2.type();
+    envp_symbol.set_type(op2.type());
     envp_symbol.static_lifetime = true;
     exprt size_expr = symbol_expr(*envp_new_size_symbol);
-    envp_symbol.get_type() =
-      array_typet(envp_symbol.get_type().subtype(), size_expr);
+    envp_symbol.set_type(
+      array_typet(envp_symbol.get_type().subtype(), size_expr));
 
     symbolt *envp_new_symbol;
     context.move(envp_symbol, envp_new_symbol);
@@ -1501,7 +1517,7 @@ void clang_c_adjust::adjust_builtin_va_arg(exprt &expr)
   symbolt symbol;
   symbol.name = "__ESBMC_va_arg";
   symbol.id = "__ESBMC_va_arg";
-  symbol.get_type() = symbol_type;
+  symbol.set_type(symbol_type);
 
   context.move(symbol);
 }

--- a/src/clang-c-frontend/clang_c_adjust_polymorphic_functions.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_polymorphic_functions.cpp
@@ -218,7 +218,7 @@ result_symbol(const irep_idt &identifier, const typet &type, contextt &context)
   symbolt symbol;
   symbol.id = id2string(identifier) + "::1::result";
   symbol.name = "result";
-  symbol.get_type() = type;
+  symbol.set_type(type);
 
   context.add(symbol);
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -373,7 +373,11 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
     !sym->get_type().incomplete() &&
     sym->get_type().id() != "incomplete_struct")
     return false;
-  sym->get_type().remove(irept::a_incomplete);
+  {
+    typet t = sym->get_type();
+    t.remove(irept::a_incomplete);
+    sym->set_type(std::move(t));
+  }
 
   clang::RecordDecl *rd_def = rd.getDefinition();
   assert(rd_def);
@@ -429,11 +433,18 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
   assert(sym && "symbol disappeared from context during field conversion");
   symbolt symbol = *sym;
   context.erase_symbol(symbol.id);
-  symbol.get_type() = t;
+  symbol.set_type(t);
   sym = context.move_symbol_to_context(symbol);
 
-  if (get_struct_union_class_methods_decls(*rd_def, sym->get_type()))
-    return true;
+  {
+    typet t = sym->get_type();
+    if (get_struct_union_class_methods_decls(*rd_def, t))
+    {
+      sym->set_type(std::move(t));
+      return true;
+    }
+    sym->set_type(std::move(t));
+  }
 
   return false;
 }
@@ -547,8 +558,11 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
     // Initialize with zero value, if the symbol has initial value,
     // it will be added later on in this method
-    symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
-    symbol.get_value().zero_initializer(true);
+    {
+      exprt v = gen_zero(get_complete_type(t, ns), true);
+      v.zero_initializer(true);
+      symbol.set_value(std::move(v));
+    }
   }
 
   symbolt *added_symbol = nullptr;
@@ -618,7 +632,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
     added_symbol = context.move_symbol_to_context(symbol);
     gen_typecast(ns, val, t);
     if (!aggregate_without_init)
-      added_symbol->get_value() = val;
+      added_symbol->set_value(val);
 
     code_declt decl(symbol_expr(*added_symbol));
     decl.location() = location_begin;
@@ -645,7 +659,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
       gen_typecast(ns, val, t);
 
-      added_symbol->get_value() = val;
+      added_symbol->set_value(val);
       decl.operands().push_back(val);
     }
 
@@ -740,15 +754,22 @@ bool clang_c_convertert::get_function(
     }
   }
 
-  added_symbol.get_type() = type;
+  added_symbol.set_type(type);
   new_expr.type() = type;
 
   // We need: a type, a name, and an optional body.
   // Always call get_function_body so overrides (e.g. the C++ frontend) can
   // synthesise a body for bodyless declarations such as trivial destructors.
   // The base implementation returns immediately when fd.hasBody() is false.
-  if (get_function_body(fd, added_symbol.get_value(), type))
-    return true;
+  {
+    exprt v = added_symbol.get_value();
+    if (get_function_body(fd, v, type))
+    {
+      added_symbol.set_value(std::move(v));
+      return true;
+    }
+    added_symbol.set_value(std::move(v));
+  }
 
   // Restore old functionDecl
   current_functionDecl = old_functionDecl;
@@ -2140,7 +2161,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     cl.static_lifetime = !current_block || compound.isFileScope();
     cl.is_extern = false;
     cl.file_local = true;
-    cl.get_value() = initializer;
+    cl.set_value(initializer);
 
     new_expr = symbol_expr(cl);
 
@@ -4245,7 +4266,7 @@ void clang_c_convertert::get_default_symbol(
   symbol.mode = mode;
   symbol.module = module_name;
   symbol.location = std::move(location);
-  symbol.get_type() = std::move(type);
+  symbol.set_type(std::move(type));
   symbol.name = name;
   symbol.id = id;
 }

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -262,7 +262,7 @@ bool clang_c_maint::clang_main()
         symbolt len_sym;
         len_sym.name = irep_idt(lname);
         len_sym.id = irep_idt("c:@" + lname);
-        len_sym.get_type() = uint_type();
+        len_sym.set_type(uint_type());
         len_sym.static_lifetime = true;
         len_sym.lvalue = true;
         symbolt *len_ptr = nullptr;
@@ -285,7 +285,7 @@ bool clang_c_maint::clang_main()
         symbolt str_sym;
         str_sym.name = irep_idt(sname);
         str_sym.id = irep_idt("c:@" + sname);
-        str_sym.get_type() = array_typet(char_t, len);
+        str_sym.set_type(array_typet(char_t, len));
         str_sym.static_lifetime = true;
         str_sym.lvalue = true;
         symbolt *str_ptr = nullptr;
@@ -433,8 +433,16 @@ bool clang_c_maint::clang_main()
 
   new_symbol.id = "__ESBMC_main";
   new_symbol.name = "__ESBMC_main";
-  new_symbol.get_type().swap(main_type);
-  new_symbol.get_value().swap(init_code);
+  {
+    typet t = new_symbol.get_type();
+    t.swap(main_type);
+    new_symbol.set_type(std::move(t));
+  }
+  {
+    exprt v = new_symbol.get_value();
+    v.swap(init_code);
+    new_symbol.set_value(std::move(v));
+  }
 
   if (context.move(new_symbol))
   {

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -31,8 +31,7 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
    *  - a ctor symbol shall contain a function body modelled by code_blockt
    *  - symbol should be of code type
    */
-  code_typet &ctor_type = to_code_type(symbol.get_type());
-  code_blockt &ctor_body = to_code_block(to_code(symbol.get_value()));
+  const code_typet &ctor_type = to_code_type(symbol.get_type());
 
   /*
    *  vptr initializations shall be done in ctor
@@ -50,6 +49,10 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
   const struct_typet::componentst &components =
     to_struct_type(ctor_class_symb->get_type()).components();
 
+  // Read-modify-set the value to mutate the body and clear need_vptr_init.
+  exprt value = symbol.get_value();
+  code_blockt &ctor_body = to_code_block(to_code(value));
+
   // iterate over the `components` and initialize each virtual pointers
   for (const auto &comp : components)
   {
@@ -63,7 +66,8 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
     ctor_body.operands().push_back(code_expr);
   }
 
-  symbol.get_value().need_vptr_init(false);
+  value.need_vptr_init(false);
+  symbol.set_value(std::move(value));
 }
 
 void clang_cpp_adjust::gen_vptr_init_code(

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -16,27 +16,29 @@ void clang_cpp_adjust::gen_implicit_union_copy_move_constructor(symbolt &symbol)
   if (!symbol.get_type().is_code())
     return;
 
-  code_typet &ctor_type = to_code_type(symbol.get_type());
+  const code_typet &ctor_type = to_code_type(symbol.get_type());
 
   if (
     ctor_type.return_type().id() != "constructor" ||
     !ctor_type.return_type().get_bool("#implicit_union_copy_move_constructor"))
     return;
 
+  // Read-modify-set the value to mutate its body.
+  exprt value;
   if (symbol.get_value().is_not_nil())
   {
-    code_blockt &ctor_body = to_code_block(to_code(symbol.get_value()));
+    value = symbol.get_value();
+    const code_blockt &existing_body = to_code_block(to_code(value));
     assert(
-      ctor_body.operands().size() == 1 &&
-      ctor_body.op0().statement() ==
+      existing_body.operands().size() == 1 &&
+      existing_body.op0().statement() ==
         "throw_decl"); // just a sanity check that we don't accidentally change any clang generated body in the future
   }
   else
   {
-    code_blockt ctor_body;
-    symbol.get_value() = ctor_body;
+    value = code_blockt();
   }
-  code_blockt &ctor_body = to_code_block(to_code(symbol.get_value()));
+  code_blockt &ctor_body = to_code_block(to_code(value));
   /* https://en.cppreference.com/w/cpp/language/copy_constructor#Implicitly-defined_copy_constructor
    * > If the implicitly-declared copy constructor is not deleted, it is defined (that is, a function body is generated and compiled)
    * > by the compiler if odr-used or needed for constant evaluation(since C++11).
@@ -58,6 +60,8 @@ void clang_cpp_adjust::gen_implicit_union_copy_move_constructor(symbolt &symbol)
   copy_ctor_assign.location() = ctor_body.location();
   adjust_assign(copy_ctor_assign);
   ctor_body.operands().push_back(copy_ctor_assign);
+
+  symbol.set_value(std::move(value));
 }
 
 void clang_cpp_adjust::adjust_symbol(symbolt &symbol)

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1818,7 +1818,7 @@ bool clang_cpp_convertert::get_function_body(
             symbolt new_symbol;
             new_symbol.name = "array_init$";
             new_symbol.id = id2string(this_ptr.identifier()) + "_array_init$";
-            new_symbol.get_type() = this_type;
+            new_symbol.set_type(this_type);
             if (context.move(new_symbol, array_init_sym))
             {
               log_error(
@@ -2339,12 +2339,16 @@ bool clang_cpp_convertert::annotate_class_method(
     symbolt *fd_symb = get_fd_symbol(cxxmdd);
     if (fd_symb)
     {
-      fd_symb->get_type() = component_type;
+      fd_symb->set_type(component_type);
       /*
        * we indicate the need for vptr initializations in contructor.
        * vptr initializations will be added in the adjuster.
        */
-      fd_symb->get_value().need_vptr_init(has_vptr_component);
+      {
+        exprt v = fd_symb->get_value();
+        v.need_vptr_init(has_vptr_component);
+        fd_symb->set_value(std::move(v));
+      }
     }
   }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -190,9 +190,12 @@ symbolt *clang_cpp_convertert::add_vtable_type_symbol(
   vt_type_symb.id = vt_name;
   vt_type_symb.name = vtable_type_prefix + type.tag().as_string();
   vt_type_symb.mode = mode;
-  vt_type_symb.get_type() = struct_typet();
+  {
+    struct_typet st;
+    st.set("name", vt_type_symb.id);
+    vt_type_symb.set_type(std::move(st));
+  }
   vt_type_symb.is_type = true;
-  vt_type_symb.get_type().set("name", vt_type_symb.id);
   vt_type_symb.location = comp.location();
   vt_type_symb.module =
     get_modulename_from_path(comp.location().file().as_string());
@@ -266,8 +269,12 @@ void clang_cpp_convertert::add_vtable_type_entry(
   vt_entry.location() = comp.location();
   // add an entry to the virtual table
   assert(vtable_type_symbol);
-  struct_typet &vtable_type = to_struct_type(vtable_type_symbol->get_type());
-  vtable_type.components().push_back(vt_entry);
+  {
+    typet t = vtable_type_symbol->get_type();
+    struct_typet &vtable_type = to_struct_type(t);
+    vtable_type.components().push_back(vt_entry);
+    vtable_type_symbol->set_type(std::move(t));
+  }
 }
 
 void clang_cpp_convertert::add_thunk_method(
@@ -340,7 +347,7 @@ void clang_cpp_convertert::add_thunk_method(
   thunk_func_symb.name = component.base_name();
   thunk_func_symb.mode = mode;
   thunk_func_symb.location = component.location();
-  thunk_func_symb.get_type() = component.type();
+  thunk_func_symb.set_type(component.type());
   thunk_func_symb.module =
     get_modulename_from_path(component.location().file().as_string());
 
@@ -348,7 +355,11 @@ void clang_cpp_convertert::add_thunk_method(
   set_thunk_name(thunk_func_symb, base_class_id);
 
   // update the type of `this` argument in thunk
-  update_thunk_this_type(thunk_func_symb.get_type(), base_class_id);
+  {
+    typet t = thunk_func_symb.get_type();
+    update_thunk_this_type(t, base_class_id);
+    thunk_func_symb.set_type(std::move(t));
+  }
 
   // add symbols for arguments of this thunk function
   add_thunk_method_arguments(thunk_func_symb);
@@ -411,7 +422,8 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
    * Each argument symbol's id is of the form - "<thunk_func_symbol_ID>::<argument_base_name>"
    */
 
-  code_typet &code_type = to_code_type(thunk_func_symb.get_type());
+  typet thunk_type = thunk_func_symb.get_type();
+  code_typet &code_type = to_code_type(thunk_type);
   code_typet::argumentst &args = code_type.arguments();
   for (unsigned i = 0; i < args.size(); i++)
   {
@@ -423,7 +435,7 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
     arg_symb.name = base_name;
     arg_symb.mode = mode;
     arg_symb.location = thunk_func_symb.location;
-    arg_symb.get_type() = arg.type();
+    arg_symb.set_type(arg.type());
 
     // Change argument identifier field to thunk function
     arg.set("#identifier", arg_symb.id);
@@ -441,6 +453,7 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
       abort();
     }
   }
+  thunk_func_symb.set_type(std::move(thunk_type));
 }
 
 void clang_cpp_convertert::add_thunk_method_body(
@@ -448,8 +461,8 @@ void clang_cpp_convertert::add_thunk_method_body(
   const struct_typet::componentt &component,
   uint64_t base_offset)
 {
-  code_typet &code_type = to_code_type(thunk_func_symb.get_type());
-  code_typet::argumentst &args = code_type.arguments();
+  const code_typet &code_type = to_code_type(thunk_func_symb.get_type());
+  const code_typet::argumentst &args = code_type.arguments();
 
   // Build the adjusted 'this' to pass to the overriding method.
   // The thunk receives a Base*, but the overriding method expects Derived*.
@@ -493,7 +506,7 @@ void clang_cpp_convertert::add_thunk_method_body_return(
    *  RETURN: return_value;
    * END_FUNCTION
    */
-  code_typet::argumentst &args =
+  const code_typet::argumentst &args =
     to_code_type(thunk_func_symb.get_type()).arguments();
 
   side_effect_expr_function_callt expr_call;
@@ -512,7 +525,7 @@ void clang_cpp_convertert::add_thunk_method_body_return(
   code_returnt code_return;
   code_return.return_value() = expr_call;
 
-  thunk_func_symb.get_value() = code_return;
+  thunk_func_symb.set_value(code_return);
 }
 
 void clang_cpp_convertert::add_thunk_method_body_no_return(
@@ -526,7 +539,7 @@ void clang_cpp_convertert::add_thunk_method_body_no_return(
    *  FUNCTION_CALL: do_something((Derived*)this);
    * END_FUNCTION
    */
-  code_typet::argumentst &args =
+  const code_typet::argumentst &args =
     to_code_type(thunk_func_symb.get_type()).arguments();
 
   code_function_callt code_func;
@@ -541,7 +554,7 @@ void clang_cpp_convertert::add_thunk_method_body_no_return(
       symbol_expr(*namespacet(context).lookup(args[i].cmt_identifier())));
   }
 
-  thunk_func_symb.get_value() = code_func;
+  thunk_func_symb.set_value(code_func);
 }
 
 void clang_cpp_convertert::add_thunk_component_to_type(
@@ -656,7 +669,7 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
     vt_symb_var.module =
       get_modulename_from_path(type.location().file().as_string());
     vt_symb_var.location = vt_symb_type->location;
-    vt_symb_var.get_type() = symbol_typet(vt_symb_type->id);
+    vt_symb_var.set_type(symbol_typet(vt_symb_type->id));
     vt_symb_var.lvalue = true;
     vt_symb_var.static_lifetime = true;
 
@@ -672,7 +685,7 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
       assert(value.type().id() == compo.type().id());
       values.operands().push_back(value);
     }
-    vt_symb_var.get_value() = values;
+    vt_symb_var.set_value(values);
 
     if (context.move(vt_symb_var))
     {

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -31,10 +31,14 @@ public:
     symbolt new_symbol;
     new_symbol.id = identifier;
     new_symbol.name = identifier;
-    new_symbol.get_type() =
-      original_expr.is_index() ? migrate_type_back(index) : typet("bool");
+    new_symbol.set_type(
+      original_expr.is_index() ? migrate_type_back(index) : typet("bool"));
     new_symbol.static_lifetime = true;
-    new_symbol.get_value().make_false();
+    {
+      exprt v = new_symbol.get_value();
+      v.make_false();
+      new_symbol.set_value(std::move(v));
+    }
 
     symbolt *symbol_ptr;
     context.move(new_symbol, symbol_ptr);
@@ -80,7 +84,11 @@ void w_guardst::add_initialization(goto_programt &goto_program)
   new_symbol.name = identifier;
   set_symbol_type(new_symbol, arrayt);
   new_symbol.static_lifetime = true;
-  new_symbol.get_value().make_false();
+  {
+    exprt v = new_symbol.get_value();
+    v.make_false();
+    new_symbol.set_value(std::move(v));
+  }
   context.move_symbol_to_context(new_symbol);
 
   for (const auto &w_guard : w_guards)

--- a/src/goto-programs/assign_params_as_non_det.cpp
+++ b/src/goto-programs/assign_params_as_non_det.cpp
@@ -8,7 +8,7 @@ symbolt *assign_params_as_non_det::get_default_symbol(
 {
   symbolt symbol;
   symbol.location = std::move(location);
-  symbol.get_type() = std::move(type);
+  symbol.set_type(std::move(type));
   symbol.name = name;
   symbol.id = id;
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -1404,9 +1404,9 @@ void goto_convertt::do_function_call_symbol(
   {
     symbolt new_symbol;
     new_symbol.name = "__ESBMC_unexpected";
-    new_symbol.get_type() = arguments[0].type();
+    new_symbol.set_type(arguments[0].type());
     new_symbol.id = "c:@F@" + id2string(new_symbol.name);
-    new_symbol.get_value() = arguments[0].op0().op0();
+    new_symbol.set_value(arguments[0].op0().op0());
     new_name(new_symbol);
     return;
   }

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -1282,7 +1282,7 @@ goto_programt code_contractst::generate_checking_wrapper(
       symbolt ret_val_symbol;
       ret_val_symbol.name = ret_val_id;
       ret_val_symbol.id = ret_val_id;
-      ret_val_symbol.get_type() = return_type_irep1;
+      ret_val_symbol.set_type(return_type_irep1);
       ret_val_symbol.lvalue = true;
       ret_val_symbol.static_lifetime = false;
       ret_val_symbol.location = location;
@@ -1892,8 +1892,8 @@ expr2tc code_contractst::create_snapshot_variable(
   symbolt snapshot_symbol;
   snapshot_symbol.name = snapshot_name;
   snapshot_symbol.id = snapshot_name;
-  snapshot_symbol.get_type() =
-    migrate_type_back(expr->type); // IRep2 → IRep1 conversion
+  snapshot_symbol.set_type(
+    migrate_type_back(expr->type)); // IRep2 → IRep1 conversion
   snapshot_symbol.lvalue = true;
   snapshot_symbol.static_lifetime = false;
   snapshot_symbol.file_local = false;

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -673,7 +673,7 @@ void goto_convertt::convert_decl(const codet &code, goto_programt &dest)
   {
     // This means that it was a VLA declaration and we need to
     // to rewrite the symbol as well
-    s->get_type() = var.type();
+    s->set_type(var.type());
   }
 
   exprt initializer = nil_exprt();

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -395,7 +395,9 @@ void goto_convert_functionst::wallop_type_impl(
   symbolt *s = context.find_symbol(name);
   if (s != nullptr)
   {
-    rename_types(s->get_type(), *s, sname);
+    typet t = s->get_type();
+    rename_types(t, *s, sname);
+    s->set_type(std::move(t));
   }
 
   deps.clear();
@@ -447,7 +449,11 @@ void goto_convert_functionst::thrash_type_symbols()
 
   // And now all the types have a fixed form, rename types in all existing code.
   context.Foreach_operand([this](symbolt &s) {
-    rename_types(s.get_type(), s, s.id);
-    rename_exprs(s.get_value(), s, s.id);
+    typet t = s.get_type();
+    rename_types(t, s, s.id);
+    s.set_type(std::move(t));
+    exprt v = s.get_value();
+    rename_exprs(v, s, s.id);
+    s.set_value(std::move(v));
   });
 }

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -1009,7 +1009,7 @@ void goto_convertt::remove_function_call(
   symbolt new_symbol;
 
   new_symbol.name = "return_value$";
-  new_symbol.get_type() = expr.type();
+  new_symbol.set_type(expr.type());
   new_symbol.location = expr.location();
 
   // get name of function, if available
@@ -1122,7 +1122,7 @@ void goto_convertt::remove_cpp_new(
   symbolt new_symbol;
 
   new_symbol.name = "new_ptr$" + std::to_string(++tmp_symbol.counter);
-  new_symbol.get_type() = expr.type();
+  new_symbol.set_type(expr.type());
   new_symbol.id = tmp_symbol.prefix + id2string(new_symbol.name);
 
   new_name(new_symbol);

--- a/src/goto-symex/builtin_functions/cpp_memory.cpp
+++ b/src/goto-symex/builtin_functions/cpp_memory.cpp
@@ -39,9 +39,11 @@ void goto_symext::symex_cpp_new(
                       ? type2tc(array_type2tc(renamedtype2, code.size, false))
                       : renamedtype2;
 
-  set_symbol_type(symbol, newtype);
-
-  symbol.get_type().dynamic(true);
+  {
+    typet t = migrate_type_back(newtype);
+    t.dynamic(true);
+    symbol.set_type(std::move(t));
+  }
 
   new_context.add(symbol);
 

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -42,12 +42,15 @@ expr2tc goto_symext::create_dynamic_memory_symbol(
   symbol.mode = "C";
 
   typet renamedtype = ns.follow(migrate_type_back(elem_type));
-  symbol.get_type() = typet(typet::t_array);
-  symbol.get_type().subtype() = renamedtype;
-  symbol.get_type().size(migrate_expr_back(size_expr));
-  symbol.get_type().dynamic(true);
-  symbol.get_type().set(
-    "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
+  {
+    typet t(typet::t_array);
+    t.subtype() = renamedtype;
+    t.size(migrate_expr_back(size_expr));
+    t.dynamic(true);
+    t.set(
+      "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
+    symbol.set_type(std::move(t));
+  }
 
   new_context.add(symbol);
   type2tc new_type = migrate_symbol_type(symbol);
@@ -440,10 +443,13 @@ expr2tc goto_symext::symex_mem_inf(
 
   typet renamedtype = ns.follow(migrate_type_back(type));
 
-  symbol.get_type() = array_typet(renamedtype, exprt("infinity", size_type()));
-  symbol.get_type().dynamic(true);
-  symbol.get_type().set(
-    "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
+  {
+    typet t = array_typet(renamedtype, exprt("infinity", size_type()));
+    t.dynamic(true);
+    t.set(
+      "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
+    symbol.set_type(std::move(t));
+  }
   symbol.mode = "C";
   new_context.add(symbol);
 
@@ -561,19 +567,21 @@ expr2tc goto_symext::symex_mem(
   symbol.lvalue = true;
 
   typet renamedtype = ns.follow(migrate_type_back(type));
-  if (size_is_one)
-    symbol.get_type() = renamedtype;
-  else
   {
-    symbol.get_type() = typet(typet::t_array);
-    symbol.get_type().subtype() = renamedtype;
-    symbol.get_type().size(migrate_expr_back(size));
+    typet t;
+    if (size_is_one)
+      t = renamedtype;
+    else
+    {
+      t = typet(typet::t_array);
+      t.subtype() = renamedtype;
+      t.size(migrate_expr_back(size));
+    }
+    t.dynamic(true);
+    t.set(
+      "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
+    symbol.set_type(std::move(t));
   }
-
-  symbol.get_type().dynamic(true);
-
-  symbol.get_type().set(
-    "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
 
   symbol.mode = "C";
 

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -29,7 +29,7 @@ reachability_treet::reachability_treet(
 {
   // Put a few useful symbols in the symbol table.
   symbolt sym;
-  sym.get_type() = bool_typet();
+  sym.set_type(bool_typet());
   sym.id = "execution_statet::\\guard_exec";
   sym.name = "execution_statet::\\guard_exec";
   context.move(sym);

--- a/src/jimple-frontend/AST/jimple_ast.h
+++ b/src/jimple-frontend/AST/jimple_ast.h
@@ -65,7 +65,7 @@ protected:
     symbol.mode = "C";
     symbol.module = module;
     symbol.location = std::move(get_location(module, function_name));
-    symbol.get_type() = std::move(t);
+    symbol.set_type(std::move(t));
     symbol.name = name;
     symbol.id = id;
     return symbol;
@@ -119,7 +119,7 @@ protected:
     code_type.arguments().push_back(uint_type());
     symbolt symbol;
     symbol.mode = "C";
-    symbol.get_type() = code_type;
+    symbol.set_type(code_type);
     symbol.name = allocation_function;
     symbol.id = allocation_function;
     symbol.is_extern = false;
@@ -143,7 +143,7 @@ protected:
     code_type.arguments().push_back(pointer_typet(empty_typet()));
     symbolt symbol;
     symbol.mode = "C";
-    symbol.get_type() = code_type;
+    symbol.set_type(code_type);
     symbol.name = func;
     symbol.id = func;
     symbol.is_extern = false;

--- a/src/jimple-frontend/AST/jimple_file.cpp
+++ b/src/jimple-frontend/AST/jimple_file.cpp
@@ -156,7 +156,7 @@ exprt jimple_file::to_exprt(contextt &ctx) const
 
   // Finally, the structure is ready. Lets add it
   t.set("width", total_size);
-  added_symbol->get_type() = t;
+  added_symbol->set_type(t);
 
   // Add the methods and definitions
   for (auto const &field : body)

--- a/src/jimple-frontend/AST/jimple_method.cpp
+++ b/src/jimple-frontend/AST/jimple_method.cpp
@@ -87,8 +87,8 @@ exprt jimple_method::to_exprt(
   if (!method_type.arguments().size())
     method_type.make_ellipsis();
 
-  added_symbol.get_type() = method_type;
-  added_symbol.get_value() = body->to_exprt(ctx, class_name, this->name);
+  added_symbol.set_type(method_type);
+  added_symbol.set_value(body->to_exprt(ctx, class_name, this->name));
 
   return dummy;
 }

--- a/src/jimple-frontend/jimple-language.cpp
+++ b/src/jimple-frontend/jimple-language.cpp
@@ -94,7 +94,7 @@ add_global_static_variable(contextt &ctx, const typet t, std::string name)
   std::string id = "c:@" + name;
   symbolt symbol;
   symbol.mode = "C";
-  symbol.get_type() = std::move(t);
+  symbol.set_type(std::move(t));
   symbol.name = name;
   symbol.id = id;
 
@@ -102,8 +102,11 @@ add_global_static_variable(contextt &ctx, const typet t, std::string name)
   symbol.static_lifetime = true;
   symbol.is_extern = false;
   symbol.file_local = false;
-  symbol.get_value() = gen_zero(t, true);
-  symbol.get_value().zero_initializer(true);
+  {
+    exprt v = gen_zero(t, true);
+    v.zero_initializer(true);
+    symbol.set_value(std::move(v));
+  }
 
   symbolt &added_symbol = *ctx.move_symbol_to_context(symbol);
   code_declt decl(symbol_expr(added_symbol));
@@ -191,8 +194,8 @@ void jimple_languaget::setup_main(contextt &context)
 
   new_symbol.id = "__ESBMC_main";
   new_symbol.name = "__ESBMC_main";
-  new_symbol.get_type().swap(main_type);
-  new_symbol.get_value().swap(init_code);
+  new_symbol.set_type(std::move(main_type));
+  new_symbol.set_value(std::move(init_code));
 
   if (context.move(new_symbol))
   {

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -49,8 +49,8 @@ exprt python_converter::make_enum_member_struct_expr(
     symbolt str_sym;
     str_sym.id = str_id;
     str_sym.name = "_name_" + member_name;
-    str_sym.get_type() = str_val.type();
-    str_sym.get_value() = str_val;
+    str_sym.set_type(str_val.type());
+    str_sym.set_value(str_val);
     str_sym.static_lifetime = true;
     str_sym.is_extern = false;
     str_sym.file_local = true;

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -778,8 +778,10 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         throw std::runtime_error(msg.str());
       }
 
-      struct_typet &class_type =
-        static_cast<struct_typet &>(class_symbol->get_type());
+      // Read-modify-set: we may push_back a new component into the class
+      // type, so own it locally and set it back at the end.
+      typet class_symbol_type = class_symbol->get_type();
+      struct_typet &class_type = static_cast<struct_typet &>(class_symbol_type);
       auto build_member_expr_from_class = [&](const typet &attr_type) -> exprt {
         typet clean_type = clean_attribute_type(attr_type);
         exprt base = symbol_expr(*symbol);
@@ -819,6 +821,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           struct_typet::componentt comp = python_frontend::build_component(
             class_type.tag().as_string(), attr_name, current_element_type);
           class_type.components().push_back(comp);
+          // Persist the mutation back to the symbol (read-modify-set).
+          class_symbol->set_type(class_symbol_type);
         }
 
         // Register instance attribute for both regular and normalized keys

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -100,7 +100,7 @@ symbolt python_converter::create_return_temp_variable(
   symbolt temp_symbol;
   temp_symbol.id = temp_sid.to_string();
   temp_symbol.name = temp_sid.to_string();
-  temp_symbol.get_type() = return_type;
+  temp_symbol.set_type(return_type);
   temp_symbol.lvalue = true;
   temp_symbol.static_lifetime = false;
   temp_symbol.location = location;
@@ -609,7 +609,7 @@ void python_converter::process_function_arguments(
               {
                 symbolt *param_sym = symbol_table_.find_symbol(param_id);
                 if (param_sym)
-                  param_sym->get_type() = default_expr.type();
+                  param_sym->set_type(default_expr.type());
               }
             }
           }
@@ -666,7 +666,7 @@ void python_converter::process_function_arguments(
       {
         symbolt *param_sym = symbol_table_.find_symbol(param_id);
         if (param_sym)
-          param_sym->get_type() = list_t;
+          param_sym->set_type(list_t);
       }
     }
   }
@@ -702,7 +702,7 @@ void python_converter::process_function_arguments(
     {
       symbolt *param_sym = symbol_table_.find_symbol(param_id);
       if (param_sym)
-        param_sym->get_type() = ptr_type;
+        param_sym->set_type(ptr_type);
     }
   }
 }
@@ -994,7 +994,7 @@ void python_converter::get_function_definition(
         typet optional_type = type_handler_.build_optional_type(value_type);
         type.return_type() = optional_type;
         current_element_type = optional_type;
-        added_symbol->get_type() = type;
+        added_symbol->set_type(type);
       }
     }
     else
@@ -1005,7 +1005,7 @@ void python_converter::get_function_definition(
         type_handler_.build_optional_type(type.return_type());
       type.return_type() = optional_type;
       current_element_type = optional_type;
-      added_symbol->get_type() = type;
+      added_symbol->set_type(type);
     }
   }
 
@@ -1018,7 +1018,7 @@ void python_converter::get_function_definition(
     {
       type.return_type() = inferred_type;
       current_element_type = inferred_type;
-      added_symbol->get_type() = type;
+      added_symbol->set_type(type);
     }
   }
 
@@ -1039,7 +1039,7 @@ void python_converter::get_function_definition(
     if (!inferred_type.is_empty())
     {
       type.return_type() = inferred_type;
-      added_symbol->get_type() = type; // Update the symbol's type
+      added_symbol->set_type(type); // Update the symbol's type
     }
   }
 
@@ -1063,7 +1063,7 @@ void python_converter::get_function_definition(
           if (!ret_type.is_empty())
           {
             type.return_type() = ret_type;
-            added_symbol->get_type() = type;
+            added_symbol->set_type(type);
             break;
           }
         }
@@ -1089,7 +1089,7 @@ void python_converter::get_function_definition(
   // Validate return paths
   validate_return_paths(function_node, type, function_body);
 
-  added_symbol->get_value() = function_body;
+  added_symbol->set_value(function_body);
 
   scope_stack_.pop_back();
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -289,7 +289,7 @@ void python_converter::handle_assignment_type_adjustments(
   {
     rhs = address_of_exprt(rhs);
     if (lhs_symbol && !is_ctor_call)
-      lhs_symbol->get_value() = rhs;
+      lhs_symbol->set_value(rhs);
     return;
   }
 
@@ -303,7 +303,7 @@ void python_converter::handle_assignment_type_adjustments(
     rhs.type().subtype().is_code() &&
     !(lhs.type().is_pointer() && lhs.type().subtype().is_code()))
   {
-    lhs_symbol->get_type() = rhs.type();
+    lhs_symbol->set_type(rhs.type());
     lhs.type() = rhs.type();
   }
 
@@ -324,9 +324,9 @@ void python_converter::handle_assignment_type_adjustments(
     if (rhs_struct.tag().as_string().find("tag-tuple") == 0)
     {
       // Update symbol type from empty to concrete tuple type
-      lhs_symbol->get_type() = rhs.type();
+      lhs_symbol->set_type(rhs.type());
       lhs.type() = rhs.type();
-      lhs_symbol->get_value() = rhs;
+      lhs_symbol->set_value(rhs);
     }
   }
   else if (lhs_symbol)
@@ -380,7 +380,7 @@ void python_converter::handle_assignment_type_adjustments(
         rhs = typecast_exprt(rhs, lhs.type());
       }
       if (!rhs.type().is_empty() && !is_ctor_call)
-        lhs_symbol->get_value() = rhs;
+        lhs_symbol->set_value(rhs);
       return;
     }
     // Handle string-to-string variable assignments
@@ -392,7 +392,7 @@ void python_converter::handle_assignment_type_adjustments(
         rhs_symbol->get_value().type().is_array())
       {
         rhs = rhs_symbol->get_value();
-        lhs_symbol->get_type() = rhs.type();
+        lhs_symbol->set_type(rhs.type());
         lhs.type() = rhs.type();
       }
     }
@@ -403,7 +403,7 @@ void python_converter::handle_assignment_type_adjustments(
       // Should we model it uniformly using char* ?
       const typet &element_type = to_array_type(rhs.type()).subtype();
       typet pointer_type = gen_pointer_type(element_type);
-      lhs_symbol->get_type() = pointer_type;
+      lhs_symbol->set_type(pointer_type);
       lhs.type() = pointer_type;
       rhs = string_handler_.get_array_base_address(rhs);
     }
@@ -435,7 +435,7 @@ void python_converter::handle_assignment_type_adjustments(
           lhs_symbol->get_type() != type_handler_.get_list_type();
         if (!is_incompatible)
         {
-          lhs_symbol->get_type() = rhs.type();
+          lhs_symbol->set_type(rhs.type());
           lhs.type() = rhs.type();
         }
       }
@@ -443,7 +443,7 @@ void python_converter::handle_assignment_type_adjustments(
     else if (rhs.type() == none_type())
     {
       // Adjust pointer_type() to pointer_typet(empty_typet())
-      lhs_symbol->get_type() = rhs.type();
+      lhs_symbol->set_type(rhs.type());
       lhs.type() = rhs.type();
     }
     // No annotation or preprocessor-inferred Any: propagate rhs type to lhs.
@@ -455,12 +455,12 @@ void python_converter::handle_assignment_type_adjustments(
       !rhs.type().is_code() &&
       !(rhs.type().is_pointer() && rhs.type().subtype().id() == "empty"))
     {
-      lhs_symbol->get_type() = rhs.type();
+      lhs_symbol->set_type(rhs.type());
       lhs.type() = rhs.type();
     }
 
     if (!rhs.type().is_empty() && !is_ctor_call)
-      lhs_symbol->get_value() = rhs;
+      lhs_symbol->set_value(rhs);
   }
 }
 
@@ -1032,7 +1032,7 @@ void python_converter::handle_function_call_rhs(
     symbolt *func_symbol =
       symbol_table_.find_symbol(rhs.op1().identifier().c_str());
     assert(func_symbol);
-    if (!static_cast<code_typet &>(func_symbol->get_type())
+    if (!static_cast<const code_typet &>(func_symbol->get_type())
            .return_type()
            .is_empty())
     {
@@ -1862,7 +1862,7 @@ void python_converter::get_var_assign(
       thetype.size().is_constant();
       assert(thetype.size().is_nil());
 #endif
-      lhs_symbol->get_type() = rhs.type();
+      lhs_symbol->set_type(rhs.type());
 
       code_declt decl(symbol_expr(*lhs_symbol), rhs);
       decl.location() = location_begin;
@@ -1892,8 +1892,11 @@ void python_converter::get_var_assign(
   }
   else
   {
-    lhs_symbol->get_value() = gen_zero(current_element_type, true);
-    lhs_symbol->get_value().zero_initializer(true);
+    {
+      exprt v = gen_zero(current_element_type, true);
+      v.zero_initializer(true);
+      lhs_symbol->set_value(std::move(v));
+    }
 
     code_declt decl(symbol_expr(*lhs_symbol));
     decl.location() = location_begin;
@@ -2068,7 +2071,7 @@ void python_converter::get_compound_assign(
       if (symbol)
       {
         // Update the symbol's type to pointer if concatenated returns pointer
-        symbol->get_type() = concatenated.type();
+        symbol->set_type(concatenated.type());
 
         // Update LHS to be a symbol with the new type
         lhs = symbol_exprt(symbol->id, symbol->get_type());
@@ -2077,7 +2080,7 @@ void python_converter::get_compound_assign(
         // (it will be assigned via the assignment statement)
         if (concatenated.type().is_array())
         {
-          symbol->get_value() = concatenated;
+          symbol->set_value(concatenated);
         }
       }
     }

--- a/src/python-frontend/converter/converter_symbols.cpp
+++ b/src/python-frontend/converter/converter_symbols.cpp
@@ -33,8 +33,12 @@ void python_converter::update_symbol(const exprt &expr) const
 
   // Update the type of the symbol and its value.
   const typet &expr_type = expr.type();
-  sym->get_type() = expr_type;
-  sym->get_value().type() = expr_type;
+  sym->set_type(expr_type);
+  {
+    exprt v = sym->get_value();
+    v.type() = expr_type;
+    sym->set_value(std::move(v));
+  }
 
   // Check if the symbol has a constant or bitvector value.
   if (
@@ -65,7 +69,7 @@ void python_converter::update_symbol(const exprt &expr) const
         exprt new_value = from_integer(int_val, expr_type);
 
         // Assign the new value to the symbol.
-        sym->get_value() = new_value;
+        sym->set_value(new_value);
       }
       catch (const std::exception &e)
       {
@@ -360,7 +364,7 @@ symbolt &python_converter::create_tmp_symbol(
   cl.is_extern = false;
   cl.file_local = true;
   if (symbol_value != exprt())
-    cl.get_value() = symbol_value;
+    cl.set_value(symbol_value);
 
   return cl;
 }

--- a/src/python-frontend/converter/converter_util.cpp
+++ b/src/python-frontend/converter/converter_util.cpp
@@ -29,7 +29,7 @@ symbolt python_converter::create_symbol(
   symbol.mode = "Python";
   symbol.module = module;
   symbol.location = location;
-  symbol.get_type() = type;
+  symbol.set_type(type);
   symbol.name = name;
   symbol.id = id;
   return symbol;

--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -1171,13 +1171,13 @@ exprt function_call_expr::handle_complex() const
             const exprt &cond = sym_val.operands()[0];
 
             symbolt true_sym;
-            true_sym.get_value() = sym_val.operands()[1];
-            true_sym.get_type() = true_sym.get_value().type();
+            true_sym.set_value(sym_val.operands()[1]);
+            true_sym.set_type(true_sym.get_value().type());
             auto true_text = extract_string_from_symbol(&true_sym);
 
             symbolt false_sym;
-            false_sym.get_value() = sym_val.operands()[2];
-            false_sym.get_type() = false_sym.get_value().type();
+            false_sym.set_value(sym_val.operands()[2]);
+            false_sym.set_type(false_sym.get_value().type());
             auto false_text = extract_string_from_symbol(&false_sym);
 
             auto parse_complex_text =

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -745,13 +745,13 @@ function_call_expr::extract_string_from_symbol(const symbolt *sym) const
     const exprt &cond = val.operands()[0];
 
     symbolt true_sym;
-    true_sym.get_value() = val.operands()[1];
-    true_sym.get_type() = true_sym.get_value().type();
+    true_sym.set_value(val.operands()[1]);
+    true_sym.set_type(true_sym.get_value().type());
     auto true_text = extract_string_from_symbol(&true_sym);
 
     symbolt false_sym;
-    false_sym.get_value() = val.operands()[2];
-    false_sym.get_type() = false_sym.get_value().type();
+    false_sym.set_value(val.operands()[2]);
+    false_sym.set_type(false_sym.get_value().type());
     auto false_text = extract_string_from_symbol(&false_sym);
 
     if (cond.is_true())

--- a/src/python-frontend/python_class_builder.cpp
+++ b/src/python-frontend/python_class_builder.cpp
@@ -60,7 +60,7 @@ bool python_class_builder::get_bases(struct_typet &st)
 
     ids.emplace_back(bsym->id);
 
-    auto &bty = static_cast<struct_typet &>(bsym->get_type());
+    const auto &bty = static_cast<const struct_typet &>(bsym->get_type());
     for (const auto &c : bty.components())
       st.components().push_back(c);
   }
@@ -192,7 +192,7 @@ void python_class_builder::gen_ctor(bool has_ud_base, struct_typet &st)
 
   symbolt ctor = conv_.create_symbol(
     mod, conv_.current_class_name_, sid.to_string(), loc, f);
-  ctor.get_value() = code_blockt();
+  ctor.set_value(code_blockt());
   ctor.lvalue = true;
 
   conv_.symbol_table_.add(ctor);
@@ -231,7 +231,11 @@ void python_class_builder::build(codet &out)
       return;
   }
 
-  sym->get_type().remove(irept::a_incomplete);
+  {
+    typet t = sym->get_type();
+    t.remove(irept::a_incomplete);
+    sym->set_type(std::move(t));
+  }
 
   // Handle TypedDict classes: they should be treated as dict types
   // TypedDict provides type hints for dictionaries but at runtime
@@ -241,7 +245,7 @@ void python_class_builder::build(codet &out)
     // Create a dict type alias for this TypedDict class
     // The dict handler provides the canonical dict struct type
     typet dict_type = conv_.get_dict_handler()->get_dict_struct_type();
-    sym->get_type() = dict_type;
+    sym->set_type(dict_type);
     conv_.current_class_name_.clear();
     return;
   }
@@ -256,13 +260,13 @@ void python_class_builder::build(codet &out)
   add_self_attrs(st);
 
   // Partial commit allows nested lookups while building members
-  sym->get_type() = st;
+  sym->set_type(st);
 
   // Add methods, class attributes, and default constructor
   get_members(st, out);
   gen_ctor(has_ud_base, st);
 
   // Finalize type and clear context
-  sym->get_type() = st;
+  sym->set_type(st);
   conv_.current_class_name_.clear();
 }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -120,7 +120,7 @@ static void add_global_static_variable(
   std::string id = "c:@" + name;
   symbolt symbol;
   symbol.mode = "C";
-  symbol.get_type() = std::move(t);
+  symbol.set_type(std::move(t));
   symbol.name = name;
   symbol.id = id;
 
@@ -128,8 +128,11 @@ static void add_global_static_variable(
   symbol.static_lifetime = true;
   symbol.is_extern = false;
   symbol.file_local = false;
-  symbol.get_value() = gen_zero(t, true);
-  symbol.get_value().zero_initializer(true);
+  {
+    exprt v = gen_zero(t, true);
+    v.zero_initializer(true);
+    symbol.set_value(std::move(v));
+  }
 
   symbolt *added_symbol = ctx.move_symbol_to_context(symbol);
   assert(added_symbol);
@@ -189,7 +192,7 @@ void python_converter::create_builtin_symbols()
         integer2binary(BigInt(0), bv_width(char_type_ref)),
         integer2string(BigInt(0)),
         char_type_ref);
-      sym.get_value() = value_expr;
+      sym.set_value(value_expr);
 
       symbol_table_.add(sym);
     };
@@ -641,7 +644,7 @@ void python_converter::convert()
     symbolt init_symbol;
     init_symbol.id = "python_init";
     init_symbol.name = "python_init";
-    init_symbol.get_type() = init_type;
+    init_symbol.set_type(init_type);
     init_symbol.lvalue = true;
     init_symbol.is_extern = false;
     init_symbol.file_local = false;
@@ -655,7 +658,11 @@ void python_converter::convert()
     code_blockt init_body;
     init_body.copy_to_operands(esbmc_hide);
     init_body.copy_to_operands(init_code);
-    init_symbol.get_value().swap(init_body);
+    {
+      exprt v = init_symbol.get_value();
+      v.swap(init_body);
+      init_symbol.set_value(std::move(v));
+    }
 
     if (symbol_table_.move(init_symbol))
     {
@@ -670,12 +677,12 @@ void python_converter::convert()
   symbolt user_main_symbol;
   user_main_symbol.id = "python_user_main";
   user_main_symbol.name = "python_user_main";
-  user_main_symbol.get_type() = user_main_type;
+  user_main_symbol.set_type(user_main_type);
   user_main_symbol.lvalue = true;
   user_main_symbol.is_extern = false;
   user_main_symbol.file_local = false;
   user_main_symbol.location = get_location_from_decl(*ast_json);
-  user_main_symbol.get_value() = user_code;
+  user_main_symbol.set_value(user_code);
 
   if (symbol_table_.move(user_main_symbol))
   {
@@ -690,7 +697,7 @@ void python_converter::convert()
   symbolt main_symbol;
   main_symbol.id = "__ESBMC_main";
   main_symbol.name = "__ESBMC_main";
-  main_symbol.get_type() = main_type;
+  main_symbol.set_type(main_type);
   main_symbol.lvalue = true;
   main_symbol.is_extern = false;
   main_symbol.file_local = false;
@@ -776,7 +783,11 @@ void python_converter::convert()
 
   main_body.copy_to_operands(make_hook_call("__ESBMC_pthread_end_main_hook"));
 
-  main_symbol.get_value().swap(main_body);
+  {
+    exprt v = main_symbol.get_value();
+    v.swap(main_body);
+    main_symbol.set_value(std::move(v));
+  }
 
   if (symbol_table_.move(main_symbol))
   {

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -107,7 +107,7 @@ struct_typet python_dict_handler::get_dict_struct_type()
   symbolt type_symbol;
   type_symbol.id = dict_type_name;
   type_symbol.name = dict_type_name;
-  type_symbol.get_type() = dict_struct;
+  type_symbol.set_type(dict_struct);
   type_symbol.mode = "Python";
   type_symbol.is_type = true;
   symbol_table_.add(type_symbol);

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -430,7 +430,7 @@ symbolt python_exception_handler::create_assert_temp_variable(
   symbolt temp_symbol;
   temp_symbol.id = temp_sid_str;
   temp_symbol.name = temp_sid_str;
-  temp_symbol.get_type() = bool_type();
+  temp_symbol.set_type(bool_type());
   temp_symbol.lvalue = true;
   temp_symbol.static_lifetime = false;
   temp_symbol.location = location;

--- a/src/python-frontend/python_lambda.cpp
+++ b/src/python-frontend/python_lambda.cpp
@@ -44,7 +44,7 @@ void python_lambda::handle_lambda_assignment(
 
   // Create function pointer type
   typet func_ptr_type = gen_pointer_type(lambda_func_symbol->get_type());
-  lhs_symbol->get_type() = func_ptr_type;
+  lhs_symbol->set_type(func_ptr_type);
   lhs.type() = func_ptr_type;
 
   // Convert lambda symbol to address
@@ -180,7 +180,7 @@ symbolt python_lambda::create_symbol(
   symbolt symbol;
   symbol.id = id;
   symbol.name = name;
-  symbol.get_type() = type;
+  symbol.set_type(type);
   symbol.location = location;
   symbol.mode = "Python";
   symbol.module = module_name;
@@ -401,7 +401,11 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
         if (
           (actual_ret.is_pointer() && actual_ret.subtype().is_code()) ||
           is_optional_struct)
-          to_code_type(added_symbol->get_type()).return_type() = actual_ret;
+        {
+          typet t = added_symbol->get_type();
+          to_code_type(t).return_type() = actual_ret;
+          added_symbol->set_type(std::move(t));
+        }
       }
     }
 
@@ -436,7 +440,7 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
       lambda_body = closure_body;
     }
 
-    added_symbol->get_value() = lambda_body;
+    added_symbol->set_value(lambda_body);
   }
 
   // Restore context only if we changed it (top-level lambda only)

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1089,7 +1089,7 @@ exprt python_list::build_split_list(
     symbolt new_symbol;
     new_symbol.name = func_name;
     new_symbol.id = func_name;
-    new_symbol.get_type() = func_type;
+    new_symbol.set_type(func_type);
     new_symbol.mode = "C";
     new_symbol.module = "python";
     new_symbol.location = location;
@@ -1209,7 +1209,7 @@ const symbolt &python_list::get_str_slice_sym()
     slice_type.arguments().push_back(code_typet::argumentt(ll_type));
     slice_type.arguments().push_back(code_typet::argumentt(ll_type));
     slice_type.arguments().push_back(code_typet::argumentt(ll_type));
-    new_symbol.get_type() = slice_type;
+    new_symbol.set_type(slice_type);
     converter_.symbol_table().add(new_symbol);
     sym = converter_.symbol_table().find_symbol(id);
   }
@@ -2599,7 +2599,7 @@ exprt python_list::compare(
       typet list_ptr = converter_.get_type_handler().get_list_type();
       func_type.arguments().push_back(code_typet::argumentt(list_ptr));
       func_type.arguments().push_back(code_typet::argumentt(list_ptr));
-      new_symbol.get_type() = func_type;
+      new_symbol.set_type(func_type);
 
       converter_.symbol_table().add(new_symbol);
       set_eq_func =
@@ -2822,7 +2822,7 @@ exprt python_list::compare(
       func_type.arguments().push_back(code_typet::argumentt(list_ptr));
       func_type.arguments().push_back(code_typet::argumentt(int_type()));
       func_type.arguments().push_back(code_typet::argumentt(size_type()));
-      new_symbol.get_type() = func_type;
+      new_symbol.set_type(func_type);
 
       converter_.symbol_table().add(new_symbol);
       list_lt_func_sym =

--- a/src/python-frontend/string/string_builder.cpp
+++ b/src/python-frontend/string/string_builder.cpp
@@ -392,7 +392,7 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
       repeat_type.arguments().push_back(arg1);
       repeat_type.arguments().push_back(arg2);
 
-      new_symbol.get_type() = repeat_type;
+      new_symbol.set_type(repeat_type);
       get_symbol_table().add(new_symbol);
       repeat_symbol = get_symbol_table().find_symbol(func_symbol_id);
     }
@@ -546,7 +546,7 @@ exprt string_builder::concatenate_strings_via_c_function(
     concat_type.arguments().push_back(arg1);
     concat_type.arguments().push_back(arg2);
 
-    new_symbol.get_type() = concat_type;
+    new_symbol.set_type(concat_type);
 
     get_symbol_table().add(new_symbol);
     concat_symbol = get_symbol_table().find_symbol(func_symbol_id);
@@ -581,7 +581,7 @@ exprt string_builder::build_runtime_str_conversion_call(
     code_typet fn_type;
     fn_type.return_type() = gen_pointer_type(char_type());
     fn_type.arguments().push_back(code_typet::argumentt(arg_type));
-    new_symbol.get_type() = fn_type;
+    new_symbol.set_type(fn_type);
 
     get_symbol_table().add(new_symbol);
     fn_symbol = get_symbol_table().find_symbol(func_symbol_id);

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1116,7 +1116,7 @@ exprt string_handler::handle_string_membership(
       strchr_type.return_type() = char_ptr;
       strchr_type.arguments().push_back(code_typet::argumentt(char_ptr));
       strchr_type.arguments().push_back(code_typet::argumentt(int_type()));
-      new_symbol.get_type() = strchr_type;
+      new_symbol.set_type(strchr_type);
 
       symbol_table_.add(new_symbol);
       strchr_symbol = find_cached_c_function_symbol("c:@F@strchr");

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -497,7 +497,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
       symbolt type_symbol;
       type_symbol.id = complex_type_id;
       type_symbol.name = "complex";
-      type_symbol.get_type() = get_complex_struct_type();
+      type_symbol.set_type(get_complex_struct_type());
       type_symbol.mode = "Python";
       type_symbol.is_type = true;
       symbol_table.move_symbol_to_context(type_symbol);
@@ -965,7 +965,8 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
     symbolt *func_symbol = converter_.find_symbol(sid.to_string());
 
     assert(func_symbol);
-    return static_cast<code_typet &>(func_symbol->get_type()).return_type();
+    return static_cast<const code_typet &>(func_symbol->get_type())
+      .return_type();
   }
 
   if (list_value.contains("_type") && list_value["_type"] == "BinOp")

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -847,7 +847,7 @@ bool solidity_convertert::populate_auxiliary_vars()
     s.static_lifetime = true; // static
     symbolt &_sym = *move_symbol_to_context(s);
     solidity_gen_typecast(ns, string, ct);
-    _sym.get_value() = string;
+    _sym.set_value(string);
   }
 
   /* populate _bind_cname_list
@@ -905,8 +905,11 @@ bool solidity_convertert::populate_auxiliary_vars()
     s.static_lifetime = true;
     s.lvalue = true;
     symbolt &sym = *move_symbol_to_context(s);
-    sym.get_value() = gen_zero(get_complete_type(_t, ns), true);
-    sym.get_value().zero_initializer(true);
+    {
+      exprt _v = gen_zero(get_complete_type(_t, ns), true);
+      _v.zero_initializer(true);
+      sym.set_value(std::move(_v));
+    }
 
     // f: initialize_bind_list
     std::string fname, fid;
@@ -952,7 +955,7 @@ bool solidity_convertert::populate_auxiliary_vars()
       fbody.copy_to_operands(ass_expr);
       ++i;
     }
-    fsym.get_value() = fbody;
+    fsym.set_value(fbody);
   }
 
   // pupulate a function call _sol_init_()
@@ -988,7 +991,7 @@ bool solidity_convertert::populate_auxiliary_vars()
   is_init_sym.lvalue = true;
   is_init_sym.file_local = true;
   is_init_sym.static_lifetime = true;
-  is_init_sym.get_value() = false_exprt();
+  is_init_sym.set_value(false_exprt());
   symbolt &final_is_init_sym = *move_symbol_to_context(is_init_sym);
 
   // 2. add body
@@ -1064,7 +1067,7 @@ bool solidity_convertert::populate_auxiliary_vars()
   init_func_body.move_to_operands(if_expr);
 
   // assign body to function symbol
-  final_init_func_sym.get_value() = init_func_body;
+  final_init_func_sym.set_value(init_func_body);
 
   // for mapping
   extract_new_contracts();

--- a/src/solidity-frontend/solidity_convert_builtin.cpp
+++ b/src/solidity-frontend/solidity_convert_builtin.cpp
@@ -255,7 +255,11 @@ void solidity_convertert::move_builtin_to_contract(
     struct_typet::componentt comp(sym.name(), sym.name(), sym.type());
     comp.set_access(access);
     comp.type().set("#member_name", c_sym.get_type().tag());
-    to_struct_type(c_sym.get_type()).components().push_back(comp);
+    {
+      typet t = c_sym.get_type();
+      to_struct_type(t).components().push_back(comp);
+      c_sym.set_type(std::move(t));
+    }
   }
   else
   {
@@ -274,7 +278,11 @@ void solidity_convertert::move_builtin_to_contract(
     comp.pretty_name(sym.name());
     comp.set_access(access);
     comp.id("symbol");
-    to_struct_type(c_sym.get_type()).methods().push_back(comp);
+    {
+      typet t = c_sym.get_type();
+      to_struct_type(t).methods().push_back(comp);
+      c_sym.set_type(std::move(t));
+    }
   }
 }
 
@@ -295,12 +303,16 @@ void solidity_convertert::get_builtin_symbol(
 
   symbolt sym;
   get_default_symbol(sym, "C++", t, name, id, l);
-  sym.get_type().set("#sol_state_var", "1");
+  {
+    typet st = sym.get_type();
+    st.set("#sol_state_var", "1");
+    sym.set_type(std::move(st));
+  }
   sym.file_local = true;
   sym.lvalue = true;
   auto &added_sym = *move_symbol_to_context(sym);
   code_declt decl(symbol_expr(added_sym));
-  added_sym.get_value() = val;
+  added_sym.set_value(val);
   decl.operands().push_back(val);
   move_to_initializer(decl);
 
@@ -373,7 +385,7 @@ void solidity_convertert::get_aux_property_function(
   type.arguments().push_back(param);
 
   // populate param
-  added_symbol.get_type() = type;
+  added_symbol.set_type(type);
   // move to struct symbol
   move_builtin_to_contract(cname, symbol_expr(added_symbol), true);
 
@@ -454,7 +466,7 @@ void solidity_convertert::get_aux_property_function(
   _block.move_to_operands(ret_uint);
 
   // populate body
-  added_symbol.get_value() = _block;
+  added_symbol.set_value(_block);
 
   // do function call
   side_effect_expr_function_callt _call;

--- a/src/solidity-frontend/solidity_convert_call.cpp
+++ b/src/solidity-frontend/solidity_convert_call.cpp
@@ -747,7 +747,7 @@ bool solidity_convertert::get_high_level_member_access(
   ft.arguments().push_back(base_param);
   exprt new_base = symbol_expr(*context.find_symbol(base_id));
 
-  added_fsymbol.get_type() = ft;
+  added_fsymbol.set_type(ft);
   //! we need to move it to the struct symbol
   // this is because we use the member from the contract
   move_builtin_to_contract(cname, symbol_expr(added_fsymbol), true);
@@ -930,7 +930,7 @@ bool solidity_convertert::get_high_level_member_access(
     func_body.move_to_operands(_ret);
   }
 
-  added_fsymbol.get_value() = func_body;
+  added_fsymbol.set_value(func_body);
 
   // construct function call
   side_effect_expr_function_callt _call;
@@ -1552,7 +1552,7 @@ bool solidity_convertert::get_typed_call_definition(
 
     arg_param_ids.push_back(pid);
   }
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   // Body construction.
   code_blockt func_body;
@@ -1625,7 +1625,7 @@ bool solidity_convertert::get_typed_call_definition(
     func_body.move_to_operands(ret_false);
   }
 
-  added_symbol.get_value() = func_body;
+  added_symbol.set_value(func_body);
   out_sym = &added_symbol;
   return false;
 }
@@ -1859,7 +1859,7 @@ bool solidity_convertert::try_inline_delegate_shadow_helper_call(
     ls.lvalue = true;
     ls.file_local = true;
     auto &added_local = *move_symbol_to_context(ls);
-    added_local.get_value() = arg_exprs[i];
+    added_local.set_value(arg_exprs[i]);
 
     code_declt decl(symbol_expr(added_local));
     decl.operands().push_back(arg_exprs[i]);
@@ -1888,7 +1888,7 @@ bool solidity_convertert::try_inline_delegate_shadow_helper_call(
       get_default_symbol(rs, debug_modulename, rt, rname, rid, loc);
       rs.lvalue = true;
       rs.file_local = true;
-      rs.get_value() = gen_zero(get_complete_type(rt, ns), true);
+      rs.set_value(gen_zero(get_complete_type(rt, ns), true));
       auto &added_ret = *move_symbol_to_context(rs);
       code_declt rdecl(symbol_expr(added_ret));
       rdecl.operands().push_back(gen_zero(get_complete_type(rt, ns), true));
@@ -2040,7 +2040,7 @@ bool solidity_convertert::try_get_delegate_shadow_call(
     ls.lvalue = true;
     ls.file_local = true;
     auto &added_local = *move_symbol_to_context(ls);
-    added_local.get_value() = arg_exprs[i];
+    added_local.set_value(arg_exprs[i]);
 
     code_declt decl(symbol_expr(added_local));
     decl.operands().push_back(arg_exprs[i]);
@@ -2058,7 +2058,7 @@ bool solidity_convertert::try_get_delegate_shadow_call(
   ss.lvalue = true;
   ss.file_local = true;
   auto &added_succ = *move_symbol_to_context(ss);
-  added_succ.get_value() = false_exprt();
+  added_succ.set_value(false_exprt());
   {
     code_declt decl(symbol_expr(added_succ));
     decl.operands().push_back(false_exprt());
@@ -2139,7 +2139,7 @@ bool solidity_convertert::try_get_delegate_shadow_call(
         get_default_symbol(rs, debug_modulename, rt, rname, rid, loc);
         rs.lvalue = true;
         rs.file_local = true;
-        rs.get_value() = gen_zero(get_complete_type(rt, ns), true);
+        rs.set_value(gen_zero(get_complete_type(rt, ns), true));
         auto &added_ret = *move_symbol_to_context(rs);
         code_declt rdecl(symbol_expr(added_ret));
         rdecl.operands().push_back(gen_zero(get_complete_type(rt, ns), true));
@@ -2327,7 +2327,7 @@ bool solidity_convertert::get_call_definition(
   param.cmt_identifier(addr_id);
   t.arguments().push_back(param);
 
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   // body:
   /*
@@ -2369,7 +2369,7 @@ bool solidity_convertert::get_call_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.get_value() = msg_sender;
+  added_old_sender.set_value(msg_sender);
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -2450,7 +2450,7 @@ bool solidity_convertert::get_call_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.get_value() = func_body;
+  added_symbol.set_value(func_body);
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -2511,7 +2511,7 @@ bool solidity_convertert::model_transaction(
     loc);
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.get_value() = msg_value;
+  added_old_value.set_value(msg_value);
   old_val_decl.operands().push_back(msg_value);
   front_block.move_to_operands(old_val_decl);
 
@@ -2602,7 +2602,7 @@ bool solidity_convertert::get_call_value_definition(
   param.cmt_identifier(val_id);
   t.arguments().push_back(param);
 
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   // body:
   /*
@@ -2658,7 +2658,7 @@ bool solidity_convertert::get_call_value_definition(
     locationt());
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.get_value() = msg_value;
+  added_old_value.set_value(msg_value);
   old_val_decl.operands().push_back(msg_value);
   func_body.move_to_operands(old_val_decl);
 
@@ -2673,7 +2673,7 @@ bool solidity_convertert::get_call_value_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.get_value() = msg_sender;
+  added_old_sender.set_value(msg_sender);
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -2804,7 +2804,7 @@ bool solidity_convertert::get_call_value_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.get_value() = func_body;
+  added_symbol.set_value(func_body);
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -2853,7 +2853,7 @@ bool solidity_convertert::get_transfer_definition(
   param.cmt_identifier(val_id);
   t.arguments().push_back(param);
 
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   code_blockt func_body;
   exprt addr_expr = symbol_expr(addr_added_symbol);
@@ -2884,7 +2884,7 @@ bool solidity_convertert::get_transfer_definition(
     locationt());
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.get_value() = msg_value;
+  added_old_value.set_value(msg_value);
   old_val_decl.operands().push_back(msg_value);
   func_body.move_to_operands(old_val_decl);
 
@@ -2900,7 +2900,7 @@ bool solidity_convertert::get_transfer_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.get_value() = msg_sender;
+  added_old_sender.set_value(msg_sender);
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -3049,7 +3049,7 @@ bool solidity_convertert::get_transfer_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.get_value() = func_body;
+  added_symbol.set_value(func_body);
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -3099,7 +3099,7 @@ bool solidity_convertert::get_send_definition(
   param.cmt_identifier(val_id);
   t.arguments().push_back(param);
 
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   code_blockt func_body;
   exprt addr_expr = symbol_expr(addr_added_symbol);
@@ -3129,7 +3129,7 @@ bool solidity_convertert::get_send_definition(
     locationt());
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.get_value() = msg_value;
+  added_old_value.set_value(msg_value);
   old_val_decl.operands().push_back(msg_value);
   func_body.move_to_operands(old_val_decl);
 
@@ -3144,7 +3144,7 @@ bool solidity_convertert::get_send_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.get_value() = msg_sender;
+  added_old_sender.set_value(msg_sender);
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -3277,7 +3277,7 @@ bool solidity_convertert::get_send_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.get_value() = func_body;
+  added_symbol.set_value(func_body);
   new_expr = symbol_expr(added_symbol);
 
   return false;
@@ -3317,7 +3317,7 @@ bool solidity_convertert::get_staticcall_definition(
   param.cmt_identifier(addr_id);
   t.arguments().push_back(param);
 
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   // body: same as call#0
   code_blockt func_body;
@@ -3344,7 +3344,7 @@ bool solidity_convertert::get_staticcall_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.get_value() = msg_sender;
+  added_old_sender.set_value(msg_sender);
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -3380,7 +3380,7 @@ bool solidity_convertert::get_staticcall_definition(
         std::to_string(aux_counter++),
       locationt());
     symbolt &added_snap = *move_symbol_to_context(snap_sym);
-    added_snap.get_value() = static_ins;
+    added_snap.set_value(static_ins);
     code_declt snap_decl(symbol_expr(added_snap));
     snap_decl.operands().push_back(static_ins);
     then.move_to_operands(snap_decl);
@@ -3437,7 +3437,7 @@ bool solidity_convertert::get_staticcall_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.get_value() = func_body;
+  added_symbol.set_value(func_body);
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -3479,7 +3479,7 @@ bool solidity_convertert::get_delegatecall_definition(
   param.cmt_identifier(addr_id);
   t.arguments().push_back(param);
 
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   // body:
   // Unlike call, delegatecall does NOT change msg.sender or msg.value.
@@ -3554,7 +3554,7 @@ bool solidity_convertert::get_delegatecall_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.get_value() = func_body;
+  added_symbol.set_value(func_body);
   new_expr = symbol_expr(added_symbol);
   return false;
 }

--- a/src/solidity-frontend/solidity_convert_constructor.cpp
+++ b/src/solidity-frontend/solidity_convert_constructor.cpp
@@ -98,13 +98,13 @@ bool solidity_convertert::add_implicit_constructor(
   auto &sym = *move_symbol_to_context(symbol);
 
   code_blockt body_exprt = code_blockt();
-  sym.get_value() = body_exprt;
+  sym.set_value(body_exprt);
 
   // add this pointer
   get_function_this_pointer_param(
     contract_name, id, debug_modulename, location_begin, type);
 
-  sym.get_type() = type;
+  sym.set_type(type);
   return false;
 }
 
@@ -339,8 +339,8 @@ bool solidity_convertert::get_unbound_function(
     // no params
     h_type.make_ellipsis();
 
-    added_sym.get_type() = h_type;
-    added_sym.get_value() = func_body;
+    added_sym.set_type(h_type);
+    added_sym.set_value(func_body);
     h_sym = added_sym;
   }
 
@@ -446,6 +446,9 @@ bool solidity_convertert::move_initializer_to_ctor(
     return true;
   }
   symbolt &sym = *context.find_symbol(ctor_id);
+  // Read-modify-set: many inserts into sym.value.operands() below; restored
+  // via sym.set_value(...) before each return.
+  exprt sym_value = sym.get_value();
 
   // get this pointer
   exprt base;
@@ -475,8 +478,7 @@ bool solidity_convertert::move_initializer_to_ctor(
       {
         // auxiliary local variable we created
         exprt tmp = *it;
-        sym.get_value().operands().insert(
-          sym.get_value().operands().begin(), tmp);
+        sym_value.operands().insert(sym_value.operands().begin(), tmp);
         continue;
       }
       if (is_aux_ctor)
@@ -518,8 +520,7 @@ bool solidity_convertert::move_initializer_to_ctor(
       convert_expression_to_code(_assign);
 
       // insert before the sym.value.operands
-      sym.get_value().operands().insert(
-        sym.get_value().operands().begin(), _assign);
+      sym_value.operands().insert(sym_value.operands().begin(), _assign);
 
       // we might need to insert some expression
       // due to the convert_type_expr and get_string_assignment
@@ -528,8 +529,7 @@ bool solidity_convertert::move_initializer_to_ctor(
         for (auto &op : ctor_frontBlockDecl.operands())
         {
           convert_expression_to_code(op);
-          sym.get_value().operands().insert(
-            sym.get_value().operands().begin(), op);
+          sym_value.operands().insert(sym_value.operands().begin(), op);
         }
         ctor_frontBlockDecl.clear();
       }
@@ -538,14 +538,15 @@ bool solidity_convertert::move_initializer_to_ctor(
     {
       exprt tmp = *it;
       convert_expression_to_code(tmp);
-      sym.get_value().operands().insert(
-        sym.get_value().operands().begin(), tmp);
+      sym_value.operands().insert(sym_value.operands().begin(), tmp);
     }
   }
 
   // insert parent ctor call in the front
+  sym.set_value(sym_value);
   if (move_inheritance_to_ctor(based_contracts, contract_name, ctor_id, sym))
     return true;
+  sym_value = sym.get_value();
 
   if (is_aux_ctor)
   {
@@ -553,8 +554,7 @@ bool solidity_convertert::move_initializer_to_ctor(
     code_labelt label;
     label.set_label("__ESBMC_HIDE");
     label.code() = code_skipt();
-    sym.get_value().operands().insert(
-      sym.get_value().operands().begin(), label);
+    sym_value.operands().insert(sym_value.operands().begin(), label);
   }
 
   // _sol_init_
@@ -562,9 +562,9 @@ bool solidity_convertert::move_initializer_to_ctor(
   get_library_function_call_no_args(
     "_sol_init_", "sol:@F@_sol_init_", empty_typet(), locationt(), init_call);
   convert_expression_to_code(init_call);
-  sym.get_value().operands().insert(
-    sym.get_value().operands().begin(), init_call);
+  sym_value.operands().insert(sym_value.operands().begin(), init_call);
 
+  sym.set_value(std::move(sym_value));
   return false;
 }
 
@@ -601,6 +601,10 @@ bool solidity_convertert::move_inheritance_to_ctor(
     return true;
   }
   exprt this_expr = symbol_expr(*context.find_symbol(this_id));
+
+  // Read-modify-set: mutate sym.value operands via this local, then write back
+  // before each return.
+  exprt sym_value = sym.get_value();
 
   // As we are handling the constructor
   const std::string old_fname = current_functionName;
@@ -730,8 +734,8 @@ bool solidity_convertert::move_inheritance_to_ctor(
               }
 
               convert_expression_to_code(_assign);
-              sym.get_value().operands().insert(
-                sym.get_value().operands().begin(), _assign);
+              sym_value.operands().insert(
+                sym_value.operands().begin(), _assign);
               break;
             }
           }
@@ -740,13 +744,13 @@ bool solidity_convertert::move_inheritance_to_ctor(
         // insert ctor call
         code_declt dl(symbol_expr(added_ctor_symbol));
         dl.operands().push_back(added_ctor_symbol.get_value());
-        sym.get_value().operands().insert(
-          sym.get_value().operands().begin(), dl);
+        sym_value.operands().insert(sym_value.operands().begin(), dl);
       }
     }
   }
 
   current_functionName = old_fname;
+  sym.set_value(std::move(sym_value));
   return false;
 }
 

--- a/src/solidity-frontend/solidity_convert_contract.cpp
+++ b/src/solidity-frontend/solidity_convert_contract.cpp
@@ -142,7 +142,7 @@ void solidity_convertert::add_static_contract_instance(const std::string c_name)
     abort();
   }
 
-  added_sym.get_value() = ctor;
+  added_sym.set_value(ctor);
 }
 
 void solidity_convertert::get_inherit_static_contract_instance_name(
@@ -240,7 +240,7 @@ void solidity_convertert::get_inherit_ctor_definition(
   param.cmt_identifier(aid);
   param.location() = l;
   ft.arguments().push_back(param);
-  add_sym.get_type() = ft;
+  add_sym.set_type(ft);
 
   // body
   exprt func_body = code_blockt();
@@ -292,7 +292,7 @@ void solidity_convertert::get_inherit_ctor_definition(
   current_functionDecl = old_current_functionDecl;
   current_functionName = old_current_functionName;
 
-  add_sym.get_value() = func_body;
+  add_sym.set_value(func_body);
 
   new_expr = symbol_expr(add_sym);
   move_builtin_to_contract(c_name, new_expr, "public", true);
@@ -393,7 +393,7 @@ void solidity_convertert::get_inherit_static_contract_instance(
   call.location().line(1);
   exprt val;
   get_temporary_object(call, val);
-  added_ctor_symbol.get_value() = val;
+  added_ctor_symbol.set_value(val);
   sym = added_ctor_symbol;
 
   log_debug("solidity", "finish get_inherit_static_contract_instance");
@@ -468,7 +468,7 @@ bool solidity_convertert::get_high_level_call_wrapper(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.get_value() = msg_sender;
+  added_old_sender.set_value(msg_sender);
   old_sender_decl.operands().push_back(msg_sender);
   front_block.move_to_operands(old_sender_decl);
 
@@ -653,8 +653,8 @@ bool solidity_convertert::multi_transaction_verification(
   // no params
   main_type.make_ellipsis();
 
-  main_sym.get_type() = main_type;
-  main_sym.get_value() = func_body;
+  main_sym.set_type(main_type);
+  main_sym.set_value(func_body);
 
   // set "_ESBMC_Main_X" as the main function
   // this will be overwrite in multi-contract mode.
@@ -733,8 +733,8 @@ bool solidity_convertert::register_harness_main(
 
   symbolt &added_symbol = *context.move_symbol_to_context(new_symbol);
   main_type.make_ellipsis();
-  added_symbol.get_type() = main_type;
-  added_symbol.get_value() = func_body;
+  added_symbol.set_type(main_type);
+  added_symbol.set_value(func_body);
   config.main = sol_name;
   return false;
 }

--- a/src/solidity-frontend/solidity_convert_decl.cpp
+++ b/src/solidity-frontend/solidity_convert_decl.cpp
@@ -360,8 +360,11 @@ bool solidity_convertert::get_var_decl(
   if (!set_init && !(is_mapping && is_new_expr && is_byte_static))
   {
     // for both state and non-state variables, set default value as zero
-    symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
-    symbol.get_value().zero_initializer(true);
+    {
+      exprt _v = gen_zero(get_complete_type(t, ns), true);
+      _v.zero_initializer(true);
+      symbol.set_value(std::move(_v));
+    }
   }
 
   // 6. add symbol into the context
@@ -386,8 +389,11 @@ bool solidity_convertert::get_var_decl(
     len_sym.static_lifetime = true;
     len_sym.file_local = true;
     len_sym.is_extern = false;
-    len_sym.get_value() = gen_zero(unsignedbv_typet(256));
-    len_sym.get_value().zero_initializer(true);
+    {
+      exprt _v = gen_zero(unsignedbv_typet(256));
+      _v.zero_initializer(true);
+      len_sym.set_value(std::move(_v));
+    }
     move_symbol_to_context(len_sym);
   }
 
@@ -408,8 +414,11 @@ bool solidity_convertert::get_var_decl(
     len_sym.static_lifetime = true;
     len_sym.file_local = true;
     len_sym.is_extern = false;
-    len_sym.get_value() = gen_zero(unsignedbv_typet(256));
-    len_sym.get_value().zero_initializer(true);
+    {
+      exprt _v = gen_zero(unsignedbv_typet(256));
+      _v.zero_initializer(true);
+      len_sym.set_value(std::move(_v));
+    }
     move_symbol_to_context(len_sym);
   }
 
@@ -485,7 +494,7 @@ bool solidity_convertert::get_var_decl(
       solidity_gen_typecast(ns, acpy_call, t);
       acpy_call.type().set("#sol_array_size", arr_size);
       // set as rvalue
-      added_symbol.get_value() = acpy_call;
+      added_symbol.set_value(acpy_call);
       decl.operands().push_back(acpy_call);
     }
     else
@@ -498,7 +507,7 @@ bool solidity_convertert::get_var_decl(
       // typecast
       solidity_gen_typecast(ns, calc_call, t);
       // set as rvalue
-      added_symbol.get_value() = calc_call;
+      added_symbol.set_value(calc_call);
       decl.operands().push_back(calc_call);
     }
   }
@@ -524,11 +533,14 @@ bool solidity_convertert::get_var_decl(
       const symbolt *len_sym = context.find_symbol(len_id);
       assert(len_sym);
       symbolt &len_mut = const_cast<symbolt &>(*len_sym);
-      len_mut.get_value() = size_expr;
+      len_mut.set_value(size_expr);
     }
     // Zero-initialize the infinite array so elements read as 0
-    added_symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
-    added_symbol.get_value().zero_initializer(true);
+    {
+      exprt _v = gen_zero(get_complete_type(t, ns), true);
+      _v.zero_initializer(true);
+      added_symbol.set_value(std::move(_v));
+    }
   }
   else if (t_sol_type == SolidityGrammar::SolType::DYNARRAY && set_init)
   {
@@ -547,7 +559,7 @@ bool solidity_convertert::get_var_decl(
       //=> uint* zz = (uint *)calloc(10, sizeof(uint));
       //=> uint* zz = (uint *)calloc(len, sizeof(uint));
       solidity_gen_typecast(ns, val, t);
-      added_symbol.get_value() = val;
+      added_symbol.set_value(val);
       decl.operands().push_back(val);
 
       // get rhs size, e.g. 10
@@ -597,7 +609,7 @@ bool solidity_convertert::get_var_decl(
       // typecast
       solidity_gen_typecast(ns, acpy_call, t);
       // set as rvalue
-      added_symbol.get_value() = acpy_call;
+      added_symbol.set_value(acpy_call);
       decl.operands().push_back(acpy_call);
 
       // store length
@@ -647,7 +659,7 @@ bool solidity_convertert::get_var_decl(
     arr_s.file_local = true;
     arr_s.lvalue = true;
     auto &add_added_s = *move_symbol_to_context(arr_s);
-    add_added_s.get_value() = gen_zero(get_complete_type(arr_t, ns), true);
+    add_added_s.set_value(gen_zero(get_complete_type(arr_t, ns), true));
 
     // 2. construct mapping_t struct instance's value
     typet map_t;
@@ -677,7 +689,7 @@ bool solidity_convertert::get_var_decl(
     solidity_gen_typecast(ns, addr_expr, comps[addr_idx].type());
     inits.operands()[addr_idx] = addr_expr;
 
-    added_symbol.get_value() = inits;
+    added_symbol.set_value(inits);
     decl.operands().push_back(inits);
   }
   else if (!set_init && is_byte_static)
@@ -693,7 +705,7 @@ bool solidity_convertert::get_var_decl(
     exprt len = from_integer(
       std::stoul(t.get("#sol_bytesn_size").as_string()), uint_type());
     call.arguments().push_back(len);
-    added_symbol.get_value() = call;
+    added_symbol.set_value(call);
     decl.operands().push_back(call);
   }
   // now we have rule out other special cases
@@ -701,7 +713,7 @@ bool solidity_convertert::get_var_decl(
   {
     if (get_init_expr(init_value, literal_type, t, val))
       return true;
-    added_symbol.get_value() = val;
+    added_symbol.set_value(val);
     decl.operands().push_back(val);
   }
 
@@ -882,7 +894,7 @@ bool solidity_convertert::get_struct_class(const nlohmann::json &struct_def)
   }
 
   t.location() = location_begin;
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   return false;
 }
@@ -1322,7 +1334,7 @@ bool solidity_convertert::get_error_definition(const nlohmann::json &ast_node)
       type.arguments().push_back(param);
     }
   }
-  added_symbol.get_type() = type;
+  added_symbol.set_type(type);
 
   // construct a "__ESBMC_assume(false)" statement
   typet return_type = empty_typet();
@@ -1339,7 +1351,7 @@ bool solidity_convertert::get_error_definition(const nlohmann::json &ast_node)
   // insert it to the body
   code_blockt body;
   body.operands().push_back(call);
-  added_symbol.get_value() = body;
+  added_symbol.set_value(body);
 
   // restore
   current_functionDecl = old_functionDecl;

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -362,7 +362,7 @@ bool solidity_convertert::get_expr(
         arr_sym.file_local = true;
         arr_sym.lvalue = true;
         auto &added = *move_symbol_to_context(arr_sym);
-        added.get_value() = gen_zero(get_complete_type(arr_t, ns), true);
+        added.set_value(gen_zero(get_complete_type(arr_t, ns), true));
       }
 
       new_expr = symbol_expr(*context.find_symbol(arr_id));
@@ -1840,7 +1840,7 @@ bool solidity_convertert::get_contract_member_call_expr(
         locationt());
       symbolt &added_old_sender = *move_symbol_to_context(old_sender);
       code_declt old_sender_decl(symbol_expr(added_old_sender));
-      added_old_sender.get_value() = msg_sender;
+      added_old_sender.set_value(msg_sender);
       old_sender_decl.operands().push_back(msg_sender);
       move_to_front_block(old_sender_decl);
 
@@ -2026,7 +2026,7 @@ bool solidity_convertert::get_index_access_expr(
       temp_sym.file_local = true;
       temp_sym.lvalue = true;
       auto &tmp_added_sym = *move_symbol_to_context(temp_sym);
-      tmp_added_sym.get_value() = array;
+      tmp_added_sym.set_value(array);
       code_declt decl(symbol_expr(tmp_added_sym));
       decl.operands().push_back(array);
       move_to_front_block(decl);
@@ -2047,7 +2047,7 @@ bool solidity_convertert::get_index_access_expr(
           get_call);
         get_call.arguments().push_back(address_of_exprt(arg_val));
         get_call.arguments().push_back(pos);
-        added_sym.get_value() = get_call;
+        added_sym.set_value(get_call);
 
         code_declt decl(symbol_expr(added_sym));
         decl.operands().push_back(get_call);
@@ -2091,7 +2091,7 @@ bool solidity_convertert::get_index_access_expr(
         get_call.arguments().push_back(address_of_exprt(arg_val));
         get_call.arguments().push_back(dynamic_pool);
         get_call.arguments().push_back(pos);
-        added_sym.get_value() = get_call;
+        added_sym.set_value(get_call);
 
         code_declt decl(symbol_expr(added_sym));
         decl.operands().push_back(get_call);

--- a/src/solidity-frontend/solidity_convert_mapping.cpp
+++ b/src/solidity-frontend/solidity_convert_mapping.cpp
@@ -427,7 +427,7 @@ bool solidity_convertert::get_new_mapping_index_access(
     get_call.arguments().push_back(address_of_exprt(array));
     get_call.arguments().push_back(pos);
     solidity_gen_typecast(ns, get_call, aux_type);
-    added_sym.get_value() = get_call;
+    added_sym.set_value(get_call);
     decl.operands().push_back(get_call);
     move_to_front_block(decl);
 
@@ -475,7 +475,7 @@ bool solidity_convertert::get_new_mapping_index_access(
       value_t, struct_contract_name, call, map_struct_get);
 
     // struct temp = map_users_get(&array, pos);
-    added_sym.get_value() = map_struct_get;
+    added_sym.set_value(map_struct_get);
     decl.operands().push_back(map_struct_get);
     move_to_front_block(decl);
 
@@ -556,7 +556,7 @@ void solidity_convertert::get_mapping_struct_function(
   // for typcast
   side_effect_expr_function_callt temp_call = gen_call;
   solidity_gen_typecast(ns, temp_call, aux_type);
-  added_sym.get_value() = temp_call;
+  added_sym.set_value(temp_call);
   decl.operands().push_back(temp_call);
   // move to func body
   func_body.operands().push_back(decl);
@@ -584,7 +584,7 @@ void solidity_convertert::get_mapping_struct_function(
   code_declt decl2(symbol_expr(added_sym2));
   // zero value
   exprt inits = gen_zero(get_complete_type(aux_type2, ns), true);
-  added_sym2.get_value() = inits;
+  added_sym2.set_value(inits);
   decl2.operands().push_back(inits);
   // move to func body
   func_body.operands().push_back(decl2);
@@ -602,7 +602,7 @@ void solidity_convertert::get_mapping_struct_function(
   ret.return_value() = if_expr;
   func_body.operands().push_back(ret);
 
-  func_sym.get_value() = func_body;
+  func_sym.set_value(func_body);
 
   // func call
   call.function() = symbol_expr(func_sym);

--- a/src/solidity-frontend/solidity_convert_modifier.cpp
+++ b/src/solidity-frontend/solidity_convert_modifier.cpp
@@ -175,7 +175,7 @@ bool solidity_convertert::get_function_definition(
     }
   }
 
-  added_symbol.get_type() = type;
+  added_symbol.set_type(type);
 
   // 11.3 Declare named return parameters as local variables.
   // Solidity allows `returns (uint result) { result = 42; }` where `result`
@@ -311,8 +311,8 @@ bool solidity_convertert::get_function_definition(
           location_begin);
         out_sym.static_lifetime = true;
         out_sym.lvalue = true;
-        out_sym.get_value() =
-          gen_zero(get_complete_type(param_sym->get_type(), ns), true);
+        out_sym.set_value(
+          gen_zero(get_complete_type(param_sym->get_type(), ns), true));
         move_symbol_to_context(out_sym);
       }
 
@@ -321,7 +321,7 @@ bool solidity_convertert::get_function_definition(
     }
   }
 
-  added_symbol.get_value() = body_exprt;
+  added_symbol.set_value(body_exprt);
 
   // 13. Restore current_functionDecl
   log_debug("solidity", "@@@ Finish parsing function {}", current_functionName);
@@ -584,7 +584,7 @@ bool solidity_convertert::get_func_modifier(
         return true;
       aux_type.arguments().push_back(arg);
     }
-    a_sym.get_type() = aux_type;
+    a_sym.set_type(aux_type);
     move_builtin_to_contract(c_name, symbol_expr(a_sym), "internal", true);
 
     // same as origin function body
@@ -666,7 +666,7 @@ bool solidity_convertert::get_func_modifier(
       mod_body.move_to_operands(return_expr);
     }
 
-    a_sym.get_value() = mod_body;
+    a_sym.set_value(mod_body);
 
     // reset
     current_functionDecl = old_decl;

--- a/src/solidity-frontend/solidity_convert_ref.cpp
+++ b/src/solidity-frontend/solidity_convert_ref.cpp
@@ -680,7 +680,7 @@ bool solidity_convertert::get_sol_builtin_ref(
             aux_sym.file_local = true;
 
             auto &inserted = *move_symbol_to_context(aux_sym);
-            inserted.get_value() = default_value;
+            inserted.set_value(default_value);
 
             code_declt decl(symbol_expr(inserted));
             decl.operands().push_back(default_value);
@@ -714,7 +714,7 @@ bool solidity_convertert::get_sol_builtin_ref(
               l);
             auto &added_aux = *move_symbol_to_context(aux_idx);
             code_declt decl(symbol_expr(added_aux));
-            added_aux.get_value() = args;
+            added_aux.set_value(args);
             decl.operands().push_back(args);
             move_to_front_block(decl);
             args = address_of_exprt(symbol_expr(added_aux));
@@ -919,7 +919,7 @@ bool solidity_convertert::get_sol_builtin_ref(
         // since all the current support built-in vars are uint type.
         // we just set the value to c:@F@nondet_uint
         symbolt &r = *context.find_symbol("c:@F@nondet_uint");
-        sym.get_value() = r.get_value();
+        sym.set_value(r.get_value());
       }
       new_expr = symbol_expr(sym);
     }

--- a/src/solidity-frontend/solidity_convert_tuple.cpp
+++ b/src/solidity-frontend/solidity_convert_tuple.cpp
@@ -101,7 +101,7 @@ bool solidity_convertert::get_tuple_definition(const nlohmann::json &ast_node)
   }
 
   t.location() = location_begin;
-  added_symbol.get_type() = t;
+  added_symbol.set_type(t);
 
   return false;
 }
@@ -139,8 +139,11 @@ bool solidity_convertert::get_tuple_instance(
   symbol.static_lifetime = true;
   symbol.file_local = true;
 
-  symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
-  symbol.get_value().zero_initializer(true);
+  {
+    exprt _v = gen_zero(get_complete_type(t, ns), true);
+    _v.zero_initializer(true);
+    symbol.set_value(std::move(_v));
+  }
   symbolt &added_symbol = *move_symbol_to_context(symbol);
   new_expr = symbol_expr(added_symbol);
   new_expr.identifier(id);
@@ -342,7 +345,7 @@ void solidity_convertert::get_llc_ret_tuple(symbolt &s)
   }
   inits.op0() = bool_val;
   inits.op1() = nondet_uint_expr;
-  added_sym.get_value() = inits;
+  added_sym.set_value(inits);
   s = added_sym;
 }
 

--- a/src/solidity-frontend/solidity_convert_util.cpp
+++ b/src/solidity-frontend/solidity_convert_util.cpp
@@ -192,7 +192,7 @@ void solidity_convertert::get_default_symbol(
   symbol.mode = mode;
   symbol.module = module_name;
   symbol.location = std::move(location);
-  symbol.get_type() = std::move(type);
+  symbol.set_type(std::move(type));
   symbol.name = name;
   symbol.id = id;
 }
@@ -676,7 +676,7 @@ void solidity_convertert::get_aux_array(
 
   symbolt &added_symbol = *move_symbol_to_context(sym);
 
-  added_symbol.get_value() = new_src_expr;
+  added_symbol.set_value(new_src_expr);
   new_expr = symbol_expr(added_symbol);
 }
 
@@ -795,7 +795,7 @@ exprt solidity_convertert::make_aux_var(exprt &val, const locationt &location)
   aux_sym.file_local = true;
 
   auto &added_sym = *move_symbol_to_context(aux_sym);
-  added_sym.get_value() = val;
+  added_sym.set_value(val);
 
   code_declt decl(symbol_expr(added_sym));
   decl.operands().push_back(val);

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -376,7 +376,7 @@ bool solidity_languaget::typecheck(contextt &context, const std::string &module)
   {
     symbolt *s = new_context.find_symbol(id);
     if (s)
-      s->get_value() = std::move(val);
+      s->set_value(std::move(val));
   }
 
   if (c_link(

--- a/src/util/c_link.cpp
+++ b/src/util/c_link.cpp
@@ -106,7 +106,7 @@ void c_linkt::duplicate_type(symbolt &in_context, symbolt &new_symbol)
       new_symbol.get_type().id() == "struct")
     {
       // replace old symbol
-      in_context.get_type() = new_symbol.get_type();
+      in_context.set_type(new_symbol.get_type());
     }
     else if (
       in_context.get_type().id() == "struct" &&
@@ -119,7 +119,7 @@ void c_linkt::duplicate_type(symbolt &in_context, symbolt &new_symbol)
       ns.follow(new_symbol.get_type()).is_array())
     {
       // store new type
-      in_context.get_type() = new_symbol.get_type();
+      in_context.set_type(new_symbol.get_type());
     }
     else if (
       ns.follow(in_context.get_type()).is_array() &&
@@ -179,9 +179,16 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       if (in_context.get_value().is_nil())
       {
         // the one with body wins!
-        in_context.get_value().swap(new_symbol.get_value());
-        in_context.get_type().swap(
-          new_symbol.get_type()); // for argument identifiers
+        exprt v = in_context.get_value();
+        exprt nv = new_symbol.get_value();
+        v.swap(nv);
+        in_context.set_value(std::move(v));
+        new_symbol.set_value(std::move(nv));
+        typet t = in_context.get_type();
+        typet nt = new_symbol.get_type();
+        t.swap(nt); // for argument identifiers
+        in_context.set_type(std::move(t));
+        new_symbol.set_type(std::move(nt));
       }
       else if (in_context.get_type().inlined())
       {
@@ -235,12 +242,12 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       if (old_type.is_incomplete_array() && new_type.is_array())
       {
         // store new type
-        in_context.get_type() = new_symbol.get_type();
+        in_context.set_type(new_symbol.get_type());
       }
       else if (old_type.is_pointer() && new_type.is_array())
       {
         // store new type
-        in_context.get_type() = new_symbol.get_type();
+        in_context.set_type(new_symbol.get_type());
       }
       else if (old_type.is_array() && new_type.is_pointer())
       {
@@ -253,7 +260,7 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       else if (old_type.id() == "incomplete_struct" && new_type.is_struct())
       {
         // store new type
-        in_context.get_type() = new_symbol.get_type();
+        in_context.set_type(new_symbol.get_type());
       }
       else if (old_type.is_struct() && new_type.id() == "incomplete_struct")
       {
@@ -307,7 +314,11 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       }
       else
       {
-        in_context.get_value().swap(new_symbol.get_value());
+        exprt v = in_context.get_value();
+        exprt nv = new_symbol.get_value();
+        v.swap(nv);
+        in_context.set_value(std::move(v));
+        new_symbol.set_value(std::move(nv));
         in_context.is_extern = false;
       }
     }

--- a/src/util/fix_symbol.cpp
+++ b/src/util/fix_symbol.cpp
@@ -6,8 +6,12 @@ void fix_symbolt::fix_symbol(symbolt &symbol)
   if (it != type_map.end())
     symbol.id = it->second.id();
 
-  replace(symbol.get_type());
-  replace(symbol.get_value());
+  typet t = symbol.get_type();
+  replace(t);
+  symbol.set_type(std::move(t));
+  exprt v = symbol.get_value();
+  replace(v);
+  symbol.set_value(std::move(v));
 }
 
 void fix_symbolt::fix_context(contextt &context)

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -26,7 +26,7 @@ inline code_function_callt invoke_intrinsic(
 
   symbolt symbol;
   symbol.mode = "C";
-  symbol.get_type() = code_type;
+  symbol.set_type(code_type);
   symbol.name = name;
   symbol.id = name;
   symbol.is_extern = false;
@@ -417,8 +417,8 @@ void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 void set_symbol_type(symbolt &sym, const type2tc &t)
 {
   // Today: back-migrate and store the legacy field. When storage flips to
-  // IREP2-native (S4) only this function changes -- the 14+ callers stay put.
-  sym.get_type() = migrate_type_back(t);
+  // IREP2-native (S4b) only this function changes -- the callers stay put.
+  sym.set_type(migrate_type_back(t));
 }
 
 static const typet &decide_on_expr_type(const exprt &side1, const exprt &side2)

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -40,17 +40,32 @@ public:
   {
     return type;
   }
-  typet &get_type()
-  {
-    return type;
-  }
   const exprt &get_value() const
   {
     return value;
   }
-  exprt &get_value()
+
+  // Setters for the (private) type/value fields. The mutable accessors were
+  // removed in B2 S4a (esbmc/esbmc#4715): all writes go through these so the
+  // storage can later become IREP2-native (S4b) -- mutable get_type()/get_value()
+  // returning references would let writes bypass the eventual IREP2-cache
+  // invalidation. For IREP2-side writes use set_symbol_type / set_symbol_value
+  // in migrate.h (they call these legacy setters internally).
+  void set_type(const typet &t)
   {
-    return value;
+    type = t;
+  }
+  void set_type(typet &&t)
+  {
+    type = std::move(t);
+  }
+  void set_value(const exprt &v)
+  {
+    value = v;
+  }
+  void set_value(exprt &&v)
+  {
+    value = std::move(v);
   }
 
   void clear();

--- a/src/util/symbol_generator.cpp
+++ b/src/util/symbol_generator.cpp
@@ -14,7 +14,7 @@ symbolt &symbol_generator::new_symbol(
     new_symbol.name = name_prefix + i2string(++counter);
     new_symbol.id = prefix + id2string(new_symbol.name);
     new_symbol.lvalue = true;
-    new_symbol.get_type() = type;
+    new_symbol.set_type(type);
   } while (context.move(new_symbol, symbol_ptr));
 
   return *symbol_ptr;

--- a/unit/python-frontend/function_call_expr_error_test.cpp
+++ b/unit/python-frontend/function_call_expr_error_test.cpp
@@ -599,8 +599,8 @@ TEST_CASE(
       make_char('\0'));
 
     symbolt sym;
-    sym.get_value() = value;
-    sym.get_type() = arr_t;
+    sym.set_value(value);
+    sym.set_type(arr_t);
 
     auto extracted =
       function_call_expr_test_access::extract_string_from_symbol(fce, &sym);
@@ -618,8 +618,8 @@ TEST_CASE(
       make_char('\0'));
 
     symbolt sym;
-    sym.get_value() = value;
-    sym.get_type() = arr_t;
+    sym.set_value(value);
+    sym.set_type(arr_t);
 
     auto extracted =
       function_call_expr_test_access::extract_string_from_symbol(fce, &sym);

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -38,7 +38,7 @@ contextt &test_context()
   {
     symbolt x;
     x.id = x.name = "x";
-    x.get_type() = migrate_type_back(get_int_type(32));
+    x.set_type(migrate_type_back(get_int_type(32)));
     x.lvalue = true;
     ctx.add(x);
     initialised = true;


### PR DESCRIPTION
S4a of the symbol-table migration (#4715) — the audit-and-convert step that prepares the way for S4b (the actual storage flip to native IREP2).

## What this changes
- Remove the mutable overloads `typet &symbolt::get_type()` and `exprt &symbolt::get_value()`.
- Add public `set_type(const typet&)` / `set_type(typet&&)` and `set_value(const exprt&)` / `set_value(exprt&&)` on `symbolt`.
- Route ~200 write sites across **every** frontend through the new setters or through read-modify-set patterns where in-place mutation was used (`.swap`, `.zero_initializer`, `.make_*`, `.dynamic`, `.set`, `.push_back`, `.insert`, ...).
- Update `migrate.cpp` so `set_symbol_type(symbolt&, const type2tc&)` (from S3) calls the new method internally.

## How to review
Mechanical and **compiler-verified end-to-end**. Same technique as the original encapsulation (#4724): removing the mutable getter makes the compiler reject both missed sites and wrong rewrites (a returned `const typet&` cannot be assigned to, swapped, or have `.set()` called on it). The build is the proof of completeness.

## Why this is a prerequisite for S4b
With every write now flowing through a setter, S4b can safely:
- store IREP2 (`type2tc`/`expr2tc`) natively,
- derive the legacy `typet`/`exprt` lazily for `to_irep`/`from_irep` (no goto-binary format change — `to_irep` is opaque),
- invalidate the legacy cache from the setter without losing writes.

## Validation
- Full build green (all targets including unit tests), zero remaining `symbolt`-write errors.
- Unit tests pass: `migratetest` (17/17), `irep2test` (104/104), `base_typetest`, `symboltest`.
- Sanity verdicts unchanged: C assert SUCCESSFUL, C OOB FAILED, data-race SUCCESSFUL.
- Behaviour-preserving by construction — every change either substitutes an equivalent setter call or extracts an in-place mutation into a `local; mutate; sym.set_*(std::move(local));` triple.

## One catch worth flagging
My initial bulk perl had two bugs caught by sanity testing:
  1. matched `==` (comparison) as `=` (assignment); reverted the one damaged file and re-applied with `(?!=)`.
  2. when introducing a local `sym_value = sym.get_value();` and then replacing all `sym.get_value()` in range, the replacement also clobbered the initialiser itself (`exprt sym_value = sym_value;`). Both were caught immediately by the next build / by running `--data-races-check` (the first attempt segfaulted because `set_symbol_type` had recursed into itself via the rewrite — see the S3 commit) and fixed before pushing.

~514 insertions / 325 deletions across 56 files.