### PR TITLE
[util] add IREP2 cache to symbolt; migrate_symbol_* read it (B2 S4b)

### DIFF
--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -379,13 +379,15 @@ type2tc migrate_type(const typet &type)
 
 type2tc migrate_symbol_type(const symbolt &sym)
 {
-  type2tc result = migrate_type(sym.get_type());
+  // S4b: the IREP2 form is cached on `symbolt`; this is an O(1) lookup that
+  // populates the cache lazily from the legacy field on first read. The legacy
+  // setters invalidate the cache, so it cannot go stale.
+  const type2tc &result = sym.get_type2();
 #ifndef NDEBUG
-  // The IREP2 form of a real symbol's type must be stable under a round-trip
-  // through legacy irept (migrate_type_back then migrate_type). This is the
-  // property unit/util/migrate.test.cpp proves for synthetic types; asserting
-  // it here exercises it on every symbol type the pipeline reads, which is what
-  // makes deriving the legacy field from IREP2 lossless once storage flips.
+  // Round-trip cross-check: the cached IREP2 form must be stable under legacy
+  // back-and-forth migration. Unit/util/migrate.test.cpp proves this for
+  // synthetic types; asserting it here exercises it on every real symbol the
+  // pipeline reads.
   assert(
     migrate_type(migrate_type_back(result)) == result &&
     "symbol type not stable under IREP2<->irept round-trip");
@@ -395,14 +397,14 @@ type2tc migrate_symbol_type(const symbolt &sym)
 
 void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 {
-  migrate_expr(sym.get_value(), dest);
+  // S4b: read from the symbol's cached IREP2 form (lazy-populated; see
+  // get_value2). Eliminates the per-call migrate_expr() that previously ran on
+  // every read of a symbol value.
+  dest = sym.get_value2();
 #ifndef NDEBUG
   // Cross-check is guarded: function bodies skip because migrate_expr_back
   // cannot reconstruct a code_block (a body is migrated forward only -- see
-  // unit/util/migrate.test.cpp); nil values are vacuous. For everything else
-  // (initialisers, contract requires/ensures, ...) assert IREP2-side
-  // idempotence -- the property that makes deriving the legacy field from
-  // IREP2 lossless for non-body symbol values.
+  // unit/util/migrate.test.cpp); nil values are vacuous.
   if (!sym.get_type().is_code() && !sym.get_value().is_nil())
   {
     expr2tc roundtrip;
@@ -416,9 +418,10 @@ void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 
 void set_symbol_type(symbolt &sym, const type2tc &t)
 {
-  // Today: back-migrate and store the legacy field. When storage flips to
-  // IREP2-native (S4b) only this function changes -- the callers stay put.
-  sym.set_type(migrate_type_back(t));
+  // S4b: route through the IREP2-side setter on symbolt. It stores `t` as the
+  // cache (no re-migration on the next read) and derives the legacy field via
+  // migrate_type_back exactly once.
+  sym.set_type(t);
 }
 
 static const typet &decide_on_expr_type(const exprt &side1, const exprt &side2)

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -1,5 +1,6 @@
 #include <util/location.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/symbol.h>
 
 symbolt::symbolt()
@@ -16,6 +17,61 @@ void symbolt::clear()
   is_set = false;
   python_annotation_types.clear();
   id = module = name = mode = "";
+  type2_cache = type2tc();
+  value2_cache = expr2tc();
+  type2_valid = false;
+  value2_valid = false;
+}
+
+void symbolt::set_type(const typet &t)
+{
+  type = t;
+  type2_valid = false;
+}
+
+void symbolt::set_type(typet &&t)
+{
+  type = std::move(t);
+  type2_valid = false;
+}
+
+void symbolt::set_value(const exprt &v)
+{
+  value = v;
+  value2_valid = false;
+}
+
+void symbolt::set_value(exprt &&v)
+{
+  value = std::move(v);
+  value2_valid = false;
+}
+
+void symbolt::set_type(const type2tc &t)
+{
+  type2_cache = t;
+  type2_valid = true;
+  type = migrate_type_back(t);
+}
+
+const type2tc &symbolt::get_type2() const
+{
+  if (!type2_valid)
+  {
+    type2_cache = migrate_type(type);
+    type2_valid = true;
+  }
+  return type2_cache;
+}
+
+const expr2tc &symbolt::get_value2() const
+{
+  if (!value2_valid)
+  {
+    migrate_expr(value, value2_cache);
+    value2_valid = true;
+  }
+  return value2_cache;
 }
 
 void symbolt::swap(symbolt &b)
@@ -42,6 +98,10 @@ void symbolt::swap(symbolt &b)
   SYM_SWAP2(is_extern);
   SYM_SWAP2(is_thread_local);
   SYM_SWAP2(is_set);
+  SYM_SWAP2(type2_cache);
+  SYM_SWAP2(value2_cache);
+  SYM_SWAP2(type2_valid);
+  SYM_SWAP2(value2_valid);
 }
 
 void symbolt::dump() const
@@ -134,6 +194,10 @@ void symbolt::from_irep(const irept &src)
 {
   type = src.type();
   value = static_cast<const exprt &>(src.symvalue());
+  // Reloaded legacy fields invalidate any prior IREP2 cache; the next
+  // get_type2/get_value2 will re-derive.
+  type2_valid = false;
+  value2_valid = false;
   location = static_cast<const locationt &>(src.location());
 
   id = src.name();

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -5,6 +5,7 @@
 
 #include <list>
 #include <vector>
+#include <irep2/irep2.h>
 #include <util/config.h>
 #include <util/expr.h>
 #include <util/location.h>
@@ -33,9 +34,7 @@ public:
   // Accessors for the (now private) `type`/`value` fields. Introduced for the
   // IREP2 symbol-table migration (esbmc/esbmc#4715, B2): all access goes
   // through these so the storage can later become IREP2-native without touching
-  // every caller again. The mutable overloads are a transitional convenience
-  // (writes/swaps); a later step routes writes through a setter so the IREP2
-  // form can be kept in sync.
+  // every caller again.
   const typet &get_type() const
   {
     return type;
@@ -45,28 +44,33 @@ public:
     return value;
   }
 
-  // Setters for the (private) type/value fields. The mutable accessors were
-  // removed in B2 S4a (esbmc/esbmc#4715): all writes go through these so the
-  // storage can later become IREP2-native (S4b) -- mutable get_type()/get_value()
-  // returning references would let writes bypass the eventual IREP2-cache
-  // invalidation. For IREP2-side writes use set_symbol_type / set_symbol_value
-  // in migrate.h (they call these legacy setters internally).
-  void set_type(const typet &t)
-  {
-    type = t;
-  }
-  void set_type(typet &&t)
-  {
-    type = std::move(t);
-  }
-  void set_value(const exprt &v)
-  {
-    value = v;
-  }
-  void set_value(exprt &&v)
-  {
-    value = std::move(v);
-  }
+  // Setters for the (private) type/value fields. Writes go exclusively through
+  // these (audit completed in B2 S4a, esbmc/esbmc#4715) so the IREP2 shadow
+  // (S4b) can be kept consistent: every write invalidates the cache; the next
+  // get_type2/get_value2 lazily re-derives via migrate_type/migrate_expr.
+  void set_type(const typet &t);
+  void set_type(typet &&t);
+  void set_value(const exprt &v);
+  void set_value(exprt &&v);
+
+  // IREP2-side accessors (esbmc/esbmc#4715, B2 S4b). The IREP2 form of the
+  // type/value is cached: populated lazily by these getters via
+  // migrate_type/migrate_expr, eagerly by set_type(const type2tc&), and
+  // invalidated by every legacy setter. migrate_symbol_type /
+  // migrate_symbol_value read these directly, replacing the previous O(size)
+  // re-migration on every read with an O(1) cached lookup.
+  const type2tc &get_type2() const;
+  const expr2tc &get_value2() const;
+
+  // IREP2-side type setter (S4b). Stores the IREP2 form authoritatively and
+  // derives the legacy `typet` once via migrate_type_back, instead of the
+  // legacy-first / re-migrate-on-read sequence in set_symbol_type. Currently
+  // called via set_symbol_type(symbolt&, const type2tc&) in util/migrate.h;
+  // exposed here so a future flip can route directly. No expr2tc-side setter:
+  // function-body values cannot round-trip (migrate_expr_back rejects
+  // code_block2t, see unit/util/migrate.test.cpp), and no caller writes IREP2
+  // symbol values today.
+  void set_type(const type2tc &t);
 
   void clear();
 
@@ -83,6 +87,16 @@ public:
 private:
   typet type;
   exprt value;
+
+  // IREP2 shadow of `type` / `value`. `*_valid` distinguishes
+  // "cached form matches legacy" from "stale, recompute on next read". The
+  // shadow is mutable so get_type2/get_value2 can populate it from a const
+  // method; consistency with legacy is ensured by the public setter contract
+  // (S4a routed every write through set_type/set_value, S4b makes them invalidate).
+  mutable type2tc type2_cache;
+  mutable expr2tc value2_cache;
+  mutable bool type2_valid;
+  mutable bool value2_valid;
 };
 
 std::ostream &operator<<(std::ostream &out, const symbolt &symbol);


### PR DESCRIPTION
S4b of the symbol-table migration (#4715). With every write to `symbolt::type/value` now routed through `set_type`/`set_value` (S4a, #4729), this PR adds an IREP2 shadow alongside the legacy fields and points `migrate_symbol_*` at it.

> **Stacked on #4729.** Review/merge after S4a lands; rebase onto master once #4729 squashes.

## What this changes
- New private members on `symbolt`: `mutable type2tc type2_cache; mutable expr2tc value2_cache;` (+ two `*_valid` bools).
- New IREP2-side accessors: `const type2tc &get_type2() const` / `const expr2tc &get_value2() const` — lazy-populated from legacy via `migrate_type` / `migrate_expr`.
- New IREP2-side setter: `void set_type(const type2tc&)` — stores the cache as authoritative and derives legacy via `migrate_type_back` exactly once.
- Legacy setters (`set_type(const typet&)`, `set_value(const exprt&)`, rvalue overloads) now invalidate the cache.
- `clear`, `swap`, `from_irep` all keep the cache consistent (clear / swap / invalidate respectively).
- `migrate_symbol_type(sym)` returns `sym.get_type2()` — O(1) cached lookup; round-trip cross-check retained under NDEBUG.
- `migrate_symbol_value(sym, dest)` assigns `sym.get_value2()` — same path.
- `set_symbol_type(sym, t)` calls `sym.set_type(t)` — the IREP2-side overload — so the cache is fresh after the write.

## Why this is just the storage step
Legacy `typet`/`exprt` are still present, and `get_type()` / `get_value()` still return `const typet&` / `const exprt&` to them. This deliberately does **not** flip the source of truth (which would change return-by-reference semantics and ripple through callers). S5 drops the legacy field once nothing reads through the legacy reference.

## Why the cache cannot drift
S4a (#4729) made the legacy setters the only path to write `type`/`value`. The compiler enforced this by making the mutable getters private and returning `const` from the accessors. With that property already in place, every write site invalidates the cache; every subsequent read either repopulates lazily or sees the freshly-set authoritative value.

## Validation
- `migratetest` (17/17), `irep2test` (104/104), `base_typetest` (6/6), `symboltest` pass.
- Sanity verdicts unchanged: C assert SUCCESSFUL, C OOB FAILED, data-race SUCCESSFUL.
- The NDEBUG cross-check on `migrate_symbol_*` is retained: `migrate_type(migrate_type_back(cached)) == cached`. If any future code path mutated the legacy field outside the setters, this assertion would fire on the next read.

## Cost
`util/symbol.h` now pulls in `irep2/irep2.h` (required to hold a `type2tc`/`expr2tc` member by value). Acceptable — `irep2.h` is already transitively present along the broader pipeline.

## What S5 does
Drop the legacy `typet type; exprt value;` fields. At that point `get_type()`/`get_value()` would need to either return by value or return a reference to a derived-on-demand cache; that ABI decision is part of S5, not this PR.

~120 insertions / 39 deletions across 3 files (`util/symbol.h`, `util/symbol.cpp`, `util/migrate.cpp`).