### PR TITLE
[util] route remaining symbol type reads/writes via chokepoints (B2)

### DIFF
--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -31,8 +31,8 @@ public:
     symbolt new_symbol;
     new_symbol.id = identifier;
     new_symbol.name = identifier;
-    new_symbol.set_type(
-      original_expr.is_index() ? migrate_type_back(index) : typet("bool"));
+    set_symbol_type(
+      new_symbol, original_expr.is_index() ? index : get_bool_type());
     new_symbol.static_lifetime = true;
     {
       exprt v = new_symbol.get_value();

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -1887,13 +1887,13 @@ expr2tc code_contractst::create_snapshot_variable(
   // Note: symbolt uses IRep1 (typet) while we work with IRep2 (type2tc).
   // This is ESBMC's architecture: Symbol Table is IRep1-based for global state,
   // while modern code (GOTO programs, contracts) uses IRep2 for local logic.
-  // Migration is needed at the boundary when adding symbols to context.
-  // If ESBMC migrates Symbol Table to IRep2, update this to use expr->type directly.
+  // Set the symbol's IREP2 type directly via the migrate-layer chokepoint;
+  // set_symbol_type stores the cache authoritatively and derives the legacy
+  // field via migrate_type_back exactly once (esbmc/esbmc#4715, B2 S4b).
   symbolt snapshot_symbol;
   snapshot_symbol.name = snapshot_name;
   snapshot_symbol.id = snapshot_name;
-  snapshot_symbol.set_type(
-    migrate_type_back(expr->type)); // IRep2 → IRep1 conversion
+  set_symbol_type(snapshot_symbol, expr->type);
   snapshot_symbol.lvalue = true;
   snapshot_symbol.static_lifetime = false;
   snapshot_symbol.file_local = false;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -581,7 +581,7 @@ expr2tc sym_name_to_symbol(const irep_idt &init, const type2tc &type)
     // Fix this by ensuring that /all/ symbols with the same name use the type
     // from the global symbol table.
     return symbol2tc(
-      migrate_type(sym->get_type()),
+      migrate_symbol_type(*sym),
       init,
       symbol_renaming_level::level0,
       0,


### PR DESCRIPTION
Tidy-up step in the symbol-table migration (#4715): converts the last three sites that bypassed the migrate-layer chokepoints.

## What this changes
- `util/migrate.cpp:584` — `migrate_type(sym->get_type())` → `migrate_symbol_type(*sym)`. Last reader bypass.
- `goto-programs/contracts/contracts.cpp` — `snapshot_symbol.set_type(migrate_type_back(expr->type))` → `set_symbol_type(snapshot_symbol, expr->type)`. The setter stores the IREP2 cache authoritatively (S4b, #4730) and derives legacy via `migrate_type_back` exactly once — same end state, one fewer round-trip.
- `goto-programs/add_race_assertions.cpp` — ternary writer (`set_type(... is_index() ? migrate_type_back(index) : typet("bool"))`) → `set_symbol_type(new_symbol, is_index() ? index : get_bool_type())`. Both ternary branches now stay native IREP2.

## Why this matters
With these three sites gone, **every symbol type read and write in the pipeline goes through `migrate_symbol_type` / `set_symbol_type`**. Two consequences:
1. The NDEBUG round-trip cross-check (`migrate_type(migrate_type_back(cached)) == cached`) now fires on every real symbol type access — the maximum corpus-wide evidence of migrate losslessness, which is the gate the plan documents for the source-of-truth flip (S5).
2. The S4b cache hits cleanly for every read, so the path is uniformly O(1) instead of mixing chokepoint and bypass calls.

## Behaviour preservation
Each rewrite is a literal substitution of the chokepoint for the bypass call. The contracts/race symbols see the same final legacy `typet` (the setter goes via `migrate_type_back`); the chokepoint reader returns the same `type2tc` the explicit `migrate_type` produced before.

## Validation
- Full build green (esbmc + jimple).
- `migratetest` 17/17, `irep2test` 104/104.
- Sanity: C assert SUCCESSFUL; data-race SUCCESSFUL on safe program; FAILED on real W/W race in both scalar and array-indexed shapes (the latter exercises the `is_index()` branch this PR rewrote).

~7 insertions / 7 deletions across 3 files.