### PR TITLE
[CI] cancel stale PR runs on new push

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,10 @@ name: PR
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Check testing tool suite
   testing-tool:


### PR DESCRIPTION
Add a concurrency block to pull_request.yml so that pushing a new commit to an open PR automatically cancels any in-progress CI runs for that same PR.

Each PR gets its own concurrency group keyed on github.workflow + github.ref (refs/pull/<N>/merge), so runs across different PRs are fully isolated. Only stale runs within the same PR are cancelled.

This reduces CI queue pressure.