### PR TITLE
[util] flip symbolt::type source of truth to IREP2 (B2 S5a)

### DIFF
--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -379,17 +379,18 @@ type2tc migrate_type(const typet &type)
 
 type2tc migrate_symbol_type(const symbolt &sym)
 {
-  // S4b: the IREP2 form is cached on `symbolt`; this is an O(1) lookup that
-  // populates the cache lazily from the legacy field on first read. The legacy
-  // setters invalidate the cache, so it cannot go stale.
+  // S5a: the IREP2 form is the source of truth on `symbolt`; get_type2()
+  // returns the stored field directly (no cache logic on this side).
   const type2tc &result = sym.get_type2();
 #ifndef NDEBUG
-  // Round-trip cross-check: the cached IREP2 form must be stable under legacy
-  // back-and-forth migration. Unit/util/migrate.test.cpp proves this for
-  // synthetic types; asserting it here exercises it on every real symbol the
-  // pipeline reads.
+  // Round-trip cross-check: the stored IREP2 form must be stable under a
+  // legacy back-and-forth migration. Unit/util/migrate.test.cpp proves this
+  // for synthetic types; asserting it here exercises it on every real symbol
+  // the pipeline reads. Skip nil sources -- migrate_type_back null-derefs on
+  // them, and a nil source has no legacy form to compare against anyway.
   assert(
-    migrate_type(migrate_type_back(result)) == result &&
+    (is_nil_type(result) ||
+     migrate_type(migrate_type_back(result)) == result) &&
     "symbol type not stable under IREP2<->irept round-trip");
 #endif
   return result;
@@ -418,9 +419,9 @@ void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 
 void set_symbol_type(symbolt &sym, const type2tc &t)
 {
-  // S4b: route through the IREP2-side setter on symbolt. It stores `t` as the
-  // cache (no re-migration on the next read) and derives the legacy field via
-  // migrate_type_back exactly once.
+  // S5a: route through the IREP2-side setter on symbolt. The setter stores
+  // `t` as the source of truth; the legacy `typet` is derived lazily on the
+  // next get_type() call via migrate_type_back.
   sym.set_type(t);
 }
 

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -17,22 +17,38 @@ void symbolt::clear()
   is_set = false;
   python_annotation_types.clear();
   id = module = name = mode = "";
-  type2_cache = type2tc();
+  // Both type representations reset to nil consistently; no migration is
+  // invoked here -- reading either side returns a nil/default form.
+  type_ = type2tc();
+  legacy_type_cache_ = typet();
+  legacy_type_valid_ = true;
   value2_cache = expr2tc();
-  type2_valid = false;
   value2_valid = false;
 }
 
+// Type setters. The legacy variants forward-migrate to the IREP2 source
+// and keep the cache fresh with the input -- no later back-migration is
+// needed for get_type(). The IREP2 setter stores the source directly and
+// invalidates the cache; the next get_type() back-migrates (nil case
+// handled inside get_type()).
 void symbolt::set_type(const typet &t)
 {
-  type = t;
-  type2_valid = false;
+  type_ = migrate_type(t);
+  legacy_type_cache_ = t;
+  legacy_type_valid_ = true;
 }
 
 void symbolt::set_type(typet &&t)
 {
-  type = std::move(t);
-  type2_valid = false;
+  type_ = migrate_type(t);
+  legacy_type_cache_ = std::move(t);
+  legacy_type_valid_ = true;
+}
+
+void symbolt::set_type(const type2tc &t)
+{
+  type_ = t;
+  legacy_type_valid_ = false;
 }
 
 void symbolt::set_value(const exprt &v)
@@ -47,21 +63,19 @@ void symbolt::set_value(exprt &&v)
   value2_valid = false;
 }
 
-void symbolt::set_type(const type2tc &t)
+const typet &symbolt::get_type() const
 {
-  type2_cache = t;
-  type2_valid = true;
-  type = migrate_type_back(t);
-}
-
-const type2tc &symbolt::get_type2() const
-{
-  if (!type2_valid)
+  if (!legacy_type_valid_)
   {
-    type2_cache = migrate_type(type);
-    type2_valid = true;
+    // A nil IREP2 source must not be fed to migrate_type_back (it derefs
+    // the held pointer). Return a default `typet` instead; this matches
+    // the pre-S5a behaviour of a freshly-cleared symbolt whose legacy
+    // `type` field was default-constructed.
+    legacy_type_cache_ =
+      is_nil_type(type_) ? typet() : migrate_type_back(type_);
+    legacy_type_valid_ = true;
   }
-  return type2_cache;
+  return legacy_type_cache_;
 }
 
 const expr2tc &symbolt::get_value2() const
@@ -78,7 +92,6 @@ void symbolt::swap(symbolt &b)
 {
 #define SYM_SWAP1(x) x.swap(b.x)
 
-  SYM_SWAP1(type);
   SYM_SWAP1(value);
   SYM_SWAP1(id);
   SYM_SWAP1(module);
@@ -86,6 +99,7 @@ void symbolt::swap(symbolt &b)
   SYM_SWAP1(mode);
   SYM_SWAP1(location);
   SYM_SWAP1(python_annotation_types);
+  SYM_SWAP1(legacy_type_cache_);
 
 #define SYM_SWAP2(x) std::swap(x, b.x)
 
@@ -98,9 +112,9 @@ void symbolt::swap(symbolt &b)
   SYM_SWAP2(is_extern);
   SYM_SWAP2(is_thread_local);
   SYM_SWAP2(is_set);
-  SYM_SWAP2(type2_cache);
+  SYM_SWAP2(type_);
+  SYM_SWAP2(legacy_type_valid_);
   SYM_SWAP2(value2_cache);
-  SYM_SWAP2(type2_valid);
   SYM_SWAP2(value2_valid);
 }
 
@@ -118,8 +132,11 @@ void symbolt::show(std::ostream &out) const
   out << "Module......: " << module << "\n";
   out << "Mode........: " << mode << " (" << mode << ")"
       << "\n";
-  if (type.is_not_nil())
-    out << "Type........: " << type.pretty(4) << "\n";
+  // Read the type through the accessor: the legacy `typet` is a derived
+  // cache after S5a, so a direct field reference would expose stale data.
+  const typet &t = get_type();
+  if (t.is_not_nil())
+    out << "Type........: " << t.pretty(4) << "\n";
   if (value.is_not_nil())
     out << "Value.......: " << value.pretty(4) << "\n";
 
@@ -155,7 +172,9 @@ std::ostream &operator<<(std::ostream &out, const symbolt &symbol)
 void symbolt::to_irep(irept &dest) const
 {
   dest.clear();
-  dest.type() = type;
+  // Derive the legacy `typet` from the IREP2 source via get_type() and
+  // serialize as before -- same on-disk format, no goto-binary change.
+  dest.type() = get_type();
   dest.symvalue(value);
   dest.location(location);
   dest.name(id);
@@ -192,12 +211,20 @@ void symbolt::to_irep(irept &dest) const
 
 void symbolt::from_irep(const irept &src)
 {
-  type = src.type();
+  // Bridge the on-disk legacy form into both representations: the legacy
+  // cache takes src.type() verbatim, the IREP2 source eagerly forward-
+  // migrates. A serialized symbol whose type lacks an id (e.g.
+  // default-constructed at write time) maps to a nil IREP2 source,
+  // matching the pre-S5a state where the legacy field was default-
+  // constructed.
+  legacy_type_cache_ = src.type();
+  type_ = legacy_type_cache_.id().empty() ? type2tc()
+                                          : migrate_type(legacy_type_cache_);
+  legacy_type_valid_ = true;
+
   value = static_cast<const exprt &>(src.symvalue());
-  // Reloaded legacy fields invalidate any prior IREP2 cache; the next
-  // get_type2/get_value2 will re-derive.
-  type2_valid = false;
   value2_valid = false;
+
   location = static_cast<const locationt &>(src.location());
 
   id = src.name();

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -1,8 +1,6 @@
 #ifndef CPROVER_SYMBOL_H
 #define CPROVER_SYMBOL_H
 
-#include <algorithm>
-
 #include <list>
 #include <vector>
 #include <irep2/irep2.h>
@@ -31,46 +29,42 @@ public:
 
   symbolt();
 
-  // Accessors for the (now private) `type`/`value` fields. Introduced for the
-  // IREP2 symbol-table migration (esbmc/esbmc#4715, B2): all access goes
-  // through these so the storage can later become IREP2-native without touching
-  // every caller again.
-  const typet &get_type() const
-  {
-    return type;
-  }
+  // Type accessors. After the B2 S5a source-of-truth flip
+  // (esbmc/esbmc#4715), the IREP2 form is the stored field; the legacy
+  // `typet` is derived lazily via migrate_type_back and cached.
+  //
+  //   get_type()  - lazy legacy cache populated from the IREP2 source on
+  //                 first read; invalidated by any IREP2-side write.
+  //   get_type2() - the IREP2 source of truth directly (O(1), no cache
+  //                 logic on this side).
+  //
+  // Value accessors keep the dual-storage shape that S4b shipped: legacy
+  // authoritative, IREP2 lazy cache. The value-side flip is out of scope
+  // for Phase 5 (see docs/irep2-symbol-table-phase5-plan.md V-track).
+  const typet &get_type() const;
   const exprt &get_value() const
   {
     return value;
   }
-
-  // Setters for the (private) type/value fields. Writes go exclusively through
-  // these (audit completed in B2 S4a, esbmc/esbmc#4715) so the IREP2 shadow
-  // (S4b) can be kept consistent: every write invalidates the cache; the next
-  // get_type2/get_value2 lazily re-derives via migrate_type/migrate_expr.
-  void set_type(const typet &t);
-  void set_type(typet &&t);
-  void set_value(const exprt &v);
-  void set_value(exprt &&v);
-
-  // IREP2-side accessors (esbmc/esbmc#4715, B2 S4b). The IREP2 form of the
-  // type/value is cached: populated lazily by these getters via
-  // migrate_type/migrate_expr, eagerly by set_type(const type2tc&), and
-  // invalidated by every legacy setter. migrate_symbol_type /
-  // migrate_symbol_value read these directly, replacing the previous O(size)
-  // re-migration on every read with an O(1) cached lookup.
-  const type2tc &get_type2() const;
+  const type2tc &get_type2() const
+  {
+    return type_;
+  }
   const expr2tc &get_value2() const;
 
-  // IREP2-side type setter (S4b). Stores the IREP2 form authoritatively and
-  // derives the legacy `typet` once via migrate_type_back, instead of the
-  // legacy-first / re-migrate-on-read sequence in set_symbol_type. Currently
-  // called via set_symbol_type(symbolt&, const type2tc&) in util/migrate.h;
-  // exposed here so a future flip can route directly. No expr2tc-side setter:
-  // function-body values cannot round-trip (migrate_expr_back rejects
-  // code_block2t, see unit/util/migrate.test.cpp), and no caller writes IREP2
-  // symbol values today.
+  // Type setters. The legacy setter forward-migrates to the IREP2 source
+  // and populates the legacy cache eagerly with its input (no
+  // back-migration needed for the next get_type() read). The IREP2 setter
+  // stores `t` as the source and invalidates the legacy cache; the next
+  // get_type() back-migrates (with the nil case handled explicitly).
+  void set_type(const typet &t);
+  void set_type(typet &&t);
   void set_type(const type2tc &t);
+
+  // Value setters keep the S4b semantics: write legacy, invalidate the
+  // IREP2 lazy cache.
+  void set_value(const exprt &v);
+  void set_value(exprt &&v);
 
   void clear();
 
@@ -85,17 +79,21 @@ public:
   irep_idt get_function_name() const;
 
 private:
-  typet type;
-  exprt value;
+  // Type: IREP2 is the source of truth (B2 S5a). The legacy field is a
+  // lazy cache derived via migrate_type_back; mutable so get_type() can
+  // populate it from a const method. Consistency is guaranteed by the
+  // public setter contract.
+  type2tc type_;
+  mutable typet legacy_type_cache_;
+  mutable bool legacy_type_valid_;
 
-  // IREP2 shadow of `type` / `value`. `*_valid` distinguishes
-  // "cached form matches legacy" from "stale, recompute on next read". The
-  // shadow is mutable so get_type2/get_value2 can populate it from a const
-  // method; consistency with legacy is ensured by the public setter contract
-  // (S4a routed every write through set_type/set_value, S4b makes them invalidate).
-  mutable type2tc type2_cache;
+  // Value: legacy authoritative; IREP2 is a lazy cache (S4b shape,
+  // unchanged by Phase 5). Function bodies cannot round-trip through
+  // migrate_expr_back today, which is why the value side is deliberately
+  // not flipped - see docs/irep2-symbol-table-phase5-plan.md for the
+  // V-track.
+  exprt value;
   mutable expr2tc value2_cache;
-  mutable bool type2_valid;
   mutable bool value2_valid;
 };
 


### PR DESCRIPTION
Phase 5 of the IREP2 symbol-table migration (#4715), executing **Option B** from the plan in `docs/irep2-symbol-table-phase5-plan.md` (#4732). The IREP2 form becomes the stored field for `symbolt::type`; the legacy `typet` is derived lazily via `migrate_type_back` and cached. The value side is deliberately not flipped — that decision is tracked separately as the V-track.

## Field layout transition

```
Before (S4b)                          After (S5a)
─────────────────────────────────────  ─────────────────────────────────────
typet  type;            <source>      type2tc type_;             <source>
exprt  value;           <source>      mutable typet legacy_type_cache_;
mutable type2tc t2_cache;             mutable bool  legacy_type_valid_;
mutable expr2tc v2_cache;             exprt   value;             <source>
mutable bool t2_valid, v2_valid;      mutable expr2tc v2_cache;
                                      mutable bool    v2_valid;
```

## Accessor / setter semantics

- `get_type()` — lazily back-migrates from `type_` on first call (the **nil case is guarded**: `migrate_type_back` would null-deref on a nil source). Returns the cache on subsequent calls.
- `get_type2()` — returns `type_` directly. O(1), no cache logic on this side any more.
- `set_type(const typet&)` / `set_type(typet&&)` — forward-migrate to `type_` **and** populate the legacy cache eagerly with the input. The next `get_type()` is free — no back-migration needed.
- `set_type(const type2tc&)` — stores `t` as the source; invalidates the legacy cache.
- Value-side accessors / setters unchanged from S4b.

## Serialization seam — no on-disk format change

- `to_irep` derives the legacy `typet` via `get_type()` and writes it exactly as before. Goto-binary format is unchanged.
- `from_irep` reads `src.type()`, populates the legacy cache verbatim, **eagerly** forward-migrates into `type_`. An empty-id legacy `src.type()` maps to a nil IREP2 source — matching the pre-S5a state where the legacy field stayed default-constructed if the binary did not include one.
- `show()`/`dump()` now read through `get_type()`; a direct field reference would surface stale data once writes route through the IREP2 setter.

## Why the cross-check stays meaningful
After S5a, `migrate_symbol_type` returns `type_` directly; the NDEBUG cross-check is now `migrate_type(migrate_type_back(type_)) == type_` — same property, reversed orientation. It still fires on every real symbol the pipeline reads, with a `is_nil_type` guard for symbols whose type has not yet been set.

## Validation
- `symboltest` — 7 cases, 29 assertions (the dual-role parity tests added in #4733 stay green under the flipped storage).
- `migratetest` 17/17, `irep2test` 104/104.
- Sanity verdicts unchanged on the same reproducers used through Phases 2–S4: C assert SUCCESSFUL, C OOB FAILED, W/W data race on a shared int FAILED.
- Full build green (esbmc + jimple frontends).
- No goto-binary format change; old binaries still load.

## Migration position
✅ S0–S4b · ✅ #4731 chokepoint closeout · ✅ #4732 plan · ✅ #4733 dual-role tests · **▶ this PR — S5a type-side flip**

Next is S5b (drop the legacy `typet` cache or keep it as a permanent on-demand cache — an ABI decision deferred per the plan). The V-track (value-side decision) is a separate workstream.

~107 insertions / 81 deletions across 3 files (`util/symbol.{h,cpp}`, `util/migrate.cpp`).