### PR TITLE
[util] extend migrate_expr / migrate_expr_back to cover the 5 missing kinds (B2 V1)

### DIFF
--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2102,6 +2102,56 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     return;
   }
 
+  // V1 of the symbol-table V-track (esbmc/esbmc#4715). Four kinds had only
+  // a back-arm (or neither direction) and could not round-trip through the
+  // migration layer. Adding the forward arms here -- with the matching back
+  // arms in migrate_expr_back -- makes IREP2 -> legacy -> IREP2 idempotent on
+  // each, the gate the V-track plan named for the value-side flip (V2). These
+  // arms are dead code in the pipeline today; nothing constructs the matching
+  // legacy form until V2 routes symbol bodies through the migration layer.
+  if (expr.id() == "code" && expr.statement() == "block")
+  {
+    std::vector<expr2tc> ops;
+    ops.reserve(expr.operands().size());
+    for (const auto &op : expr.operands())
+    {
+      expr2tc o;
+      migrate_expr(op, o);
+      ops.push_back(o);
+    }
+    new_expr_ref = code_block2tc(ops);
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "cpp-catch")
+  {
+    std::vector<irep_idt> expr_list;
+    const irept::subt &exceptions = expr.find("exception_list").get_sub();
+    for (const auto &e_it : exceptions)
+      expr_list.push_back(e_it.id());
+    new_expr_ref = code_cpp_catch2tc(expr_list);
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "throw_decl_end")
+  {
+    std::vector<irep_idt> expr_list;
+    const irept::subt &throw_list = expr.find("throw_list").get_sub();
+    for (const auto &e_it : throw_list)
+      expr_list.push_back(e_it.id());
+    new_expr_ref = code_cpp_throw_decl_end2tc(expr_list);
+    return;
+  }
+
+  if (expr.id() == "pointer_capability")
+  {
+    expr2tc theval;
+    migrate_expr(expr.op0(), theval);
+    type2tc type = migrate_type(expr.type());
+    new_expr_ref = pointer_capability2tc(type, theval);
+    return;
+  }
+
   if (expr.id() == "isinf")
   {
     expr2tc theval;
@@ -3513,6 +3563,59 @@ exprt migrate_expr_back(const expr2tc &ref)
 
     codeexpr.copy_to_operands(migrate_expr_back(ref2.operand));
     return codeexpr;
+  }
+  // V1 of the symbol-table V-track (esbmc/esbmc#4715): five expr2t kinds
+  // were uncovered in this switch. Adding back-arms here -- and matching
+  // forward arms in migrate_expr where needed -- lets unit/util/migrate.test.cpp
+  // assert the IREP2 round-trip property on each kind, which is the precondition
+  // for the value-side source-of-truth flip (V2). The arms are dead code in the
+  // pipeline today; they become live when V2 routes symbol values through them.
+  case expr2t::code_block_id:
+  {
+    const code_block2t &ref2 = to_code_block2t(ref);
+    exprt block("code");
+    block.statement("block");
+    for (auto const &op : ref2.operands)
+      block.copy_to_operands(migrate_expr_back(op));
+    return block;
+  }
+  case expr2t::code_cpp_catch_id:
+  {
+    const code_cpp_catch2t &ref2 = to_code_cpp_catch2t(ref);
+    exprt codeexpr("code");
+    codeexpr.statement("cpp-catch");
+    irept::subt &exceptions = codeexpr.add("exception_list").get_sub();
+    for (auto const &it : ref2.exception_list)
+      exceptions.emplace_back(it);
+    return codeexpr;
+  }
+  case expr2t::code_cpp_throw_decl_id:
+  {
+    const code_cpp_throw_decl2t &ref2 = to_code_cpp_throw_decl2t(ref);
+    exprt codeexpr("code");
+    codeexpr.statement("throw-decl");
+    irept::subt &throw_list = codeexpr.add("throw_list").get_sub();
+    for (auto const &it : ref2.exception_list)
+      throw_list.emplace_back(it);
+    return codeexpr;
+  }
+  case expr2t::code_cpp_throw_decl_end_id:
+  {
+    const code_cpp_throw_decl_end2t &ref2 = to_code_cpp_throw_decl_end2t(ref);
+    exprt codeexpr("code");
+    codeexpr.statement("throw_decl_end");
+    irept::subt &throw_list = codeexpr.add("throw_list").get_sub();
+    for (auto const &it : ref2.exception_list)
+      throw_list.emplace_back(it);
+    return codeexpr;
+  }
+  case expr2t::pointer_capability_id:
+  {
+    const pointer_capability2t &ref2 = to_pointer_capability2t(ref);
+    typet thetype = migrate_type_back(ref->type);
+    exprt pointer_capval("pointer_capability", thetype);
+    pointer_capval.copy_to_operands(migrate_expr_back(ref2.ptr_obj));
+    return pointer_capval;
   }
   case expr2t::isinf_id:
   {

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -141,12 +141,75 @@ TEST_CASE("migrate expr round-trips for symbol and address-of", "[migrate]")
 TEST_CASE("migrate expr round-trips for code statements", "[migrate]")
 {
   // Individual code statements round-trip (goto2c back-migrates instructions
-  // one at a time). Note: migrate_expr_back deliberately does NOT support a
-  // whole code_block2t — a function body's legacy codet block is migrated
-  // forward only (it is the source of truth), so the symbol-table migration
-  // never needs to reconstruct a block from IREP2.
+  // one at a time).
   use_test_ns();
   expr2tc lhs = symbol2tc(get_int_type(32), "x");
   expr2tc rhs = constant_int2tc(get_int_type(32), BigInt(7));
   require_expr_roundtrip(code_assign2tc(lhs, rhs));
+}
+
+// V1 of the symbol-table V-track (esbmc/esbmc#4715): five expr2t kinds had
+// gaps in the migration layer (no back-arm, or no forward-arm, or neither).
+// These tests pin the round-trip property -- migrate_expr_back followed by
+// migrate_expr returns an equal IREP2 node -- that the value-side flip (V2)
+// relies on. The arms are dead code in the pipeline today; nothing constructs
+// the matching legacy form. The tests exercise them via the IREP2 constructors
+// directly, so the gate is independent of which frontend produces a body.
+
+TEST_CASE("migrate expr round-trips for code_block", "[migrate][b2-vtrack]")
+{
+  use_test_ns();
+  expr2tc lhs = symbol2tc(get_int_type(32), "x");
+  expr2tc rhs = constant_int2tc(get_int_type(32), BigInt(1));
+  std::vector<expr2tc> stmts{
+    code_assign2tc(lhs, rhs),
+    code_assign2tc(lhs, constant_int2tc(get_int_type(32), BigInt(2)))};
+  require_expr_roundtrip(code_block2tc(stmts));
+}
+
+TEST_CASE(
+  "migrate expr round-trips for code_block (empty)",
+  "[migrate][b2-vtrack]")
+{
+  // The zero-operand corner is the one a freshly-emitted empty body would hit;
+  // pinning it explicitly is cheap insurance against an iterator-on-empty bug.
+  require_expr_roundtrip(code_block2tc(std::vector<expr2tc>{}));
+}
+
+TEST_CASE("migrate expr round-trips for code_cpp_catch", "[migrate][b2-vtrack]")
+{
+  std::vector<irep_idt> exceptions{"std::exception", "std::runtime_error"};
+  require_expr_roundtrip(code_cpp_catch2tc(exceptions));
+}
+
+TEST_CASE(
+  "migrate expr round-trips for code_cpp_throw_decl",
+  "[migrate][b2-vtrack]")
+{
+  // Forward direction already existed pre-V1; V1 added the back-arm so this
+  // round-trips here without the legacy form being constructed by hand.
+  std::vector<irep_idt> exceptions{"std::bad_alloc"};
+  require_expr_roundtrip(code_cpp_throw_decl2tc(exceptions));
+}
+
+TEST_CASE(
+  "migrate expr round-trips for code_cpp_throw_decl_end",
+  "[migrate][b2-vtrack]")
+{
+  std::vector<irep_idt> exceptions{"std::bad_alloc"};
+  require_expr_roundtrip(code_cpp_throw_decl_end2tc(exceptions));
+}
+
+TEST_CASE(
+  "migrate expr round-trips for pointer_capability",
+  "[migrate][b2-vtrack]")
+{
+  // pointer_capability is the only V1 kind that had no legacy form at all
+  // before this PR: it is constructed solver-side via pointer_capability2tc.
+  // V1 picks the legacy id "pointer_capability" symmetrically with
+  // pointer_object's existing pair, so back-then-forward round-trips.
+  use_test_ns();
+  expr2tc base = symbol2tc(get_int_type(32), "x");
+  type2tc cap_t = unsignedbv_type2tc(64);
+  require_expr_roundtrip(pointer_capability2tc(cap_t, base));
 }


### PR DESCRIPTION
V1 of the symbol-table V-track (#4715), per the plan in #4736. The audit there showed `migrate_expr_back` covers 104 of 109 `expr2t` kinds; the 5 outliers were `code_block`, `code_cpp_catch`, `code_cpp_throw_decl`, `code_cpp_throw_decl_end`, and `pointer_capability`. This PR closes the gap.

## What this adds

- **`migrate_expr_back`** — 5 new case labels (~50 lines), each a small inverse of its IREP2 class layout:
  - `code_block` — iterate `ref2.operands`, build a legacy `codet("block")` and back-migrate each operand into it.
  - `code_cpp_catch` — emit `codet("cpp-catch")` with the exception names in an `exception_list` sub.
  - `code_cpp_throw_decl` / `code_cpp_throw_decl_end` — emit the matching legacy `codet` with the names in a `throw_list` sub.
  - `pointer_capability` — mirror of the existing `pointer_object` back-arm.

- **`migrate_expr`** — 4 new forward arms (skipping `code_cpp_throw_decl`, which already had one). Symmetric construction; `pointer_capability` picks the legacy id `"pointer_capability"` to mirror `pointer_object`'s existing pair.

- **`unit/util/migrate.test.cpp`** — 6 new `TEST_CASE`s pinning `migrate_expr(migrate_expr_back(e)) == e` on each new kind, including the empty-operands corner for `code_block` (the shape a freshly-emitted empty body would hit).

## Why this is dead code today
Nothing in the pipeline constructs the matching legacy form: function bodies stay in legacy `exprt` storage on `symbolt::value`; `code_cpp_catch2t`, `code_cpp_throw_decl*2t` are never built (their legacy `codet` analogues are consumed at goto-convert time); `pointer_capability2t` is constructed solver-side only. These arms become **live** when V2 routes symbol values through the migration layer and the value-side flip lands.

## Why it is mergeable in isolation
The new switch arms are reachable only via the new IREP2 constructors (now exercised by the unit tests) and via `migrate_expr` if a frontend ever emits the matching legacy id. Behaviour change for the existing pipeline is **zero**:

- `migratetest` — 12 cases, 23 assertions, all pass (6 pre-existing + 6 new).
- `symboltest` 7 cases / 29 assertions, `irep2test` 9 cases / 104 assertions — unchanged.
- Sanity verdicts unchanged: C assert SUCCESSFUL, C OOB FAILED, W/W data race FAILED.
- Full build green (esbmc + jimple).

## Migration position
✅ S0–S5a · ✅ #4731 closeout · ✅ #4732 Phase 5 plan · ✅ #4733 dual-role tests · ✅ #4735 S5a type flip · ✅ #4736 V-track plan · ▶ **#?? V1 migration-layer extension**

Next is the pre-V2 value-side discriminator-parity unit tests (mirror of #4733), then V2 itself (mirror of S5a on the value side).

~170 insertions / 4 deletions across 2 files (`src/util/migrate.cpp`, `unit/util/migrate.test.cpp`).