### PR TITLE
[util] make symbolt::set_type(typet) lazy again (fixes #4735 regression)

### DIFF
--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -22,32 +22,35 @@ void symbolt::clear()
   type_ = type2tc();
   legacy_type_cache_ = typet();
   legacy_type_valid_ = true;
+  type2_valid_ = true;
   value2_cache = expr2tc();
   value2_valid = false;
 }
 
-// Type setters. The legacy variants forward-migrate to the IREP2 source
-// and keep the cache fresh with the input -- no later back-migration is
-// needed for get_type(). The IREP2 setter stores the source directly and
-// invalidates the cache; the next get_type() back-migrates (nil case
-// handled inside get_type()).
+// Type setters. Each setter writes one side and invalidates the other;
+// the read side derives lazily via migrate_type_back / migrate_type on
+// first access. The lazy split matches the value-side shape (S4b) and
+// avoids forward-migrating typets whose sub-expressions (e.g. an array
+// size built from a legacy binary_exprt with no type set) would not
+// survive the recursive descent.
 void symbolt::set_type(const typet &t)
 {
-  type_ = migrate_type(t);
   legacy_type_cache_ = t;
   legacy_type_valid_ = true;
+  type2_valid_ = false;
 }
 
 void symbolt::set_type(typet &&t)
 {
-  type_ = migrate_type(t);
   legacy_type_cache_ = std::move(t);
   legacy_type_valid_ = true;
+  type2_valid_ = false;
 }
 
 void symbolt::set_type(const type2tc &t)
 {
   type_ = t;
+  type2_valid_ = true;
   legacy_type_valid_ = false;
 }
 
@@ -76,6 +79,19 @@ const typet &symbolt::get_type() const
     legacy_type_valid_ = true;
   }
   return legacy_type_cache_;
+}
+
+const type2tc &symbolt::get_type2() const
+{
+  if (!type2_valid_)
+  {
+    // Symmetric to get_type(): an empty-id legacy typet is the only safe
+    // input migrate_type cannot consume, so it maps to a nil IREP2 form.
+    type_ = legacy_type_cache_.id().empty() ? type2tc()
+                                            : migrate_type(legacy_type_cache_);
+    type2_valid_ = true;
+  }
+  return type_;
 }
 
 const expr2tc &symbolt::get_value2() const
@@ -114,6 +130,7 @@ void symbolt::swap(symbolt &b)
   SYM_SWAP2(is_set);
   SYM_SWAP2(type_);
   SYM_SWAP2(legacy_type_valid_);
+  SYM_SWAP2(type2_valid_);
   SYM_SWAP2(value2_cache);
   SYM_SWAP2(value2_valid);
 }
@@ -211,16 +228,12 @@ void symbolt::to_irep(irept &dest) const
 
 void symbolt::from_irep(const irept &src)
 {
-  // Bridge the on-disk legacy form into both representations: the legacy
-  // cache takes src.type() verbatim, the IREP2 source eagerly forward-
-  // migrates. A serialized symbol whose type lacks an id (e.g.
-  // default-constructed at write time) maps to a nil IREP2 source,
-  // matching the pre-S5a state where the legacy field was default-
-  // constructed.
+  // Bridge the on-disk legacy form into the legacy cache; the IREP2
+  // representation is derived lazily on the next get_type2() call
+  // (matching the setter semantics -- forward migration is never eager).
   legacy_type_cache_ = src.type();
-  type_ = legacy_type_cache_.id().empty() ? type2tc()
-                                          : migrate_type(legacy_type_cache_);
   legacy_type_valid_ = true;
+  type2_valid_ = false;
 
   value = static_cast<const exprt &>(src.symvalue());
   value2_valid = false;

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -46,10 +46,7 @@ public:
   {
     return value;
   }
-  const type2tc &get_type2() const
-  {
-    return type_;
-  }
+  const type2tc &get_type2() const;
   const expr2tc &get_value2() const;
 
   // Type setters. The legacy setter forward-migrates to the IREP2 source
@@ -79,13 +76,27 @@ public:
   irep_idt get_function_name() const;
 
 private:
-  // Type: IREP2 is the source of truth (B2 S5a). The legacy field is a
-  // lazy cache derived via migrate_type_back; mutable so get_type() can
-  // populate it from a const method. Consistency is guaranteed by the
-  // public setter contract.
-  type2tc type_;
+  // Type: both representations are caches sharing the S5a storage layout.
+  // The setter that wrote last marks its side valid and invalidates the
+  // other. Reading the other side lazily derives via migrate_type /
+  // migrate_type_back. Both fields are mutable so the const getters can
+  // populate from the other side on demand.
+  //
+  // S5a (esbmc/esbmc#4735) originally forward-migrated eagerly inside
+  // set_type(const typet&). The python frontend builds legacy `exprt`s
+  // with unset types (e.g. `minus_exprt(lhs, rhs)` whose result `typet`
+  // is default-constructed with empty id), which the eager migration
+  // could not tolerate -- a chain of recursive migrate_expr calls inside
+  // migrate_type ended up constructing arithmetic IREP2 nodes with an
+  // empty-typed result, tripping assert_arith_2ops_consistency in
+  // irep2_expr.cpp. The lazy variant matches the value-side shape (S4b)
+  // and never exposes those latent holes unless something actually reads
+  // get_type2() on the affected symbol -- which, in practice, no current
+  // pipeline path does for those tmp symbols.
+  mutable type2tc type_;
   mutable typet legacy_type_cache_;
   mutable bool legacy_type_valid_;
+  mutable bool type2_valid_;
 
   // Value: legacy authoritative; IREP2 is a lazy cache (S4b shape,
   // unchanged by Phase 5). Function bodies cannot round-trip through


### PR DESCRIPTION
Hotfix for the regression #4735 (S5a, the type-side source-of-truth flip) introduced into the Python regression suite.

## Symptom
19 Python tests failed on macOS CI for #4737 — all involving symbol types built from legacy `exprt` trees whose intermediate nodes have no type set. Representative failure:

```
Assertion failed: (p2 || (is_bv_type(t) == is_bv_type(v1->type) && t->get_width() == v1->type->get_width())),
  function assert_arith_2ops_consistency, file irep2_expr.cpp, line 618.
```

Stack (truncated):
```
#5  sub2t::sub2t
#9  migrate_expr (legacy minus_exprt → sub2tc) at migrate.cpp:1194
#16 migrate_expr (array size sub-tree)         at migrate.cpp:1175
#17 migrate_type0 (array case)                  at migrate.cpp:154
#19 symbolt::set_type(const typet &t)           at symbol.cpp:36
#20 symbol_generator::new_symbol
#21 python_converter::create_tmp_symbol         (python_list.cpp:1425 for `$array_slice$`)
```

## Cause
`binary_exprt(lhs, "-", rhs)` does not propagate a result type; the result `typet` is default-constructed (empty id). The python frontend builds `minus_exprt(upper_expr, lower_expr)` inside an array size, then calls `set_type(array_typet)` on a tmp symbol. **S5a (#4735) made that setter forward-migrate eagerly**, which recursively walked the array size and called `migrate_expr` on the `minus_exprt`. `migrate_expr` then constructed `sub2tc(empty_type, unsignedbv_v1, unsignedbv_v2)` — empty result with non-empty operands — tripping the arithmetic consistency assertion at IREP2 construction.

Pre-S5a (#4730 S4b) the bug did not surface because migration was lazy: `get_type2()` migrated on first read, and **nothing reads `get_type2()` on those tmp symbols today**.

## Fix
Restore the lazy shape on the type side, matching the value-side shape that S4b shipped (which has been live in master since #4730 with no equivalent regression):

- Both representations now have a `_valid_` bit. The setter that wrote last marks its side valid and invalidates the other.
- `get_type()` / `get_type2()` lazily derive from the opposite side via `migrate_type_back` / `migrate_type` on first access; the nil/empty-id case is guarded symmetrically on both sides.
- `type_` becomes `mutable` so the const `get_type2()` can populate it.
- `swap()` and `from_irep()` updated to keep both `_valid_` bits consistent.

S5a's storage layout is preserved (`type2tc` is the dominant form on IREP2-side writes); only the eager forward migration goes.

## Validation
- The 11 representative Python tests that failed on #4737's macOS CI (string-indexing[2-4], string-slice1/2, github_3082/3553_reverse/3578/3595, bin_subscript_symbolic, string-many-ops) all return their expected verdicts locally.
- `symboltest` 7/29, `migratetest` 6/17, `irep2test` 9/104 — all pass.
- Sanity verdicts unchanged.
- Full build green (esbmc + jimple).

## Notes for review
- This is a behaviour fix on `master`. #4737 (V1) sits on top and inherits the regression; once this lands, #4737 needs a rebase and will go green.
- The V-track plan (#4736) is unaffected — V1 is still the next code step; V2 (value-side flip) will mirror this lazy design from day one.

~48 insertions / 24 deletions across 2 files (`util/symbol.{h,cpp}`).