### PR TITLE
[util] flip symbolt::value source of truth to IREP2 (B2 V2)

### DIFF
--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -398,14 +398,19 @@ type2tc migrate_symbol_type(const symbolt &sym)
 
 void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 {
-  // S4b: read from the symbol's cached IREP2 form (lazy-populated; see
-  // get_value2). Eliminates the per-call migrate_expr() that previously ran on
-  // every read of a symbol value.
+  // V2: read the symbol's IREP2 value form directly. After the value-side
+  // flip (esbmc/esbmc#4715, V-track V2) the IREP2 expr2tc is the dominant
+  // representation on IREP2-side writes and is derived lazily from the legacy
+  // cache when the caller wrote on the legacy side.
   dest = sym.get_value2();
 #ifndef NDEBUG
-  // Cross-check is guarded: function bodies skip because migrate_expr_back
-  // cannot reconstruct a code_block (a body is migrated forward only -- see
-  // unit/util/migrate.test.cpp); nil values are vacuous.
+  // Cross-check: assert the IREP2 value form is stable under the
+  // migration round-trip migrate_expr(migrate_expr_back(e)) == e. V1
+  // (#4737) closed the back-migration coverage gap so this is safe for
+  // every expr2t kind, but we still skip function bodies (no caller goes
+  // through this path on them today, and the assertion would force a
+  // potentially-large body round-trip for no signal) and nil values
+  // (vacuous).
   if (!sym.get_type().is_code() && !sym.get_value().is_nil())
   {
     expr2tc roundtrip;

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -10,29 +10,30 @@ symbolt::symbolt()
 
 void symbolt::clear()
 {
-  value.make_nil();
   location.make_nil();
   lvalue = static_lifetime = file_local = is_extern = is_type = is_parameter =
     is_macro = is_thread_local = false;
   is_set = false;
   python_annotation_types.clear();
   id = module = name = mode = "";
-  // Both type representations reset to nil consistently; no migration is
-  // invoked here -- reading either side returns a nil/default form.
+  // Both representations on each side reset to nil consistently; no
+  // migration is invoked. Reading either side returns a nil/default form.
   type_ = type2tc();
   legacy_type_cache_ = typet();
   legacy_type_valid_ = true;
   type2_valid_ = true;
-  value2_cache = expr2tc();
-  value2_valid = false;
+  value_ = expr2tc();
+  legacy_value_cache_.make_nil();
+  legacy_value_valid_ = true;
+  value2_valid_ = true;
 }
 
 // Type setters. Each setter writes one side and invalidates the other;
 // the read side derives lazily via migrate_type_back / migrate_type on
-// first access. The lazy split matches the value-side shape (S4b) and
-// avoids forward-migrating typets whose sub-expressions (e.g. an array
-// size built from a legacy binary_exprt with no type set) would not
-// survive the recursive descent.
+// first access. The lazy split matches the value-side shape (post-V2)
+// and avoids forward-migrating typets whose sub-expressions (e.g. an
+// array size built from a legacy binary_exprt with no type set) would
+// not survive the recursive descent.
 void symbolt::set_type(const typet &t)
 {
   legacy_type_cache_ = t;
@@ -54,16 +55,29 @@ void symbolt::set_type(const type2tc &t)
   legacy_type_valid_ = false;
 }
 
+// Value setters. Mirror of the type setters after B2 V2: each writes one
+// side and invalidates the other; the read side derives lazily via
+// migrate_expr / migrate_expr_back (the back direction is safe for all
+// expr2t kinds after V1, #4737).
 void symbolt::set_value(const exprt &v)
 {
-  value = v;
-  value2_valid = false;
+  legacy_value_cache_ = v;
+  legacy_value_valid_ = true;
+  value2_valid_ = false;
 }
 
 void symbolt::set_value(exprt &&v)
 {
-  value = std::move(v);
-  value2_valid = false;
+  legacy_value_cache_ = std::move(v);
+  legacy_value_valid_ = true;
+  value2_valid_ = false;
+}
+
+void symbolt::set_value(const expr2tc &v)
+{
+  value_ = v;
+  value2_valid_ = true;
+  legacy_value_valid_ = false;
 }
 
 const typet &symbolt::get_type() const
@@ -94,21 +108,44 @@ const type2tc &symbolt::get_type2() const
   return type_;
 }
 
+const exprt &symbolt::get_value() const
+{
+  if (!legacy_value_valid_)
+  {
+    // Mirror of get_type(): a nil IREP2 value must not be fed to
+    // migrate_expr_back (it derefs the held pointer). Return a nil exprt
+    // instead -- the shape a freshly-cleared symbolt has on the legacy
+    // side. V1 (#4737) closed the back-migration coverage gap so
+    // non-nil values back-migrate cleanly for every expr2t kind a
+    // symbol value may hold, including function bodies.
+    if (is_nil_expr(value_))
+      legacy_value_cache_.make_nil();
+    else
+      legacy_value_cache_ = migrate_expr_back(value_);
+    legacy_value_valid_ = true;
+  }
+  return legacy_value_cache_;
+}
+
 const expr2tc &symbolt::get_value2() const
 {
-  if (!value2_valid)
+  if (!value2_valid_)
   {
-    migrate_expr(value, value2_cache);
-    value2_valid = true;
+    // Symmetric to get_type2(). A nil or empty-id legacy exprt maps to a
+    // nil IREP2 value -- the only inputs migrate_expr cannot consume.
+    if (legacy_value_cache_.is_nil() || legacy_value_cache_.id().empty())
+      value_ = expr2tc();
+    else
+      migrate_expr(legacy_value_cache_, value_);
+    value2_valid_ = true;
   }
-  return value2_cache;
+  return value_;
 }
 
 void symbolt::swap(symbolt &b)
 {
 #define SYM_SWAP1(x) x.swap(b.x)
 
-  SYM_SWAP1(value);
   SYM_SWAP1(id);
   SYM_SWAP1(module);
   SYM_SWAP1(name);
@@ -116,6 +153,7 @@ void symbolt::swap(symbolt &b)
   SYM_SWAP1(location);
   SYM_SWAP1(python_annotation_types);
   SYM_SWAP1(legacy_type_cache_);
+  SYM_SWAP1(legacy_value_cache_);
 
 #define SYM_SWAP2(x) std::swap(x, b.x)
 
@@ -131,8 +169,9 @@ void symbolt::swap(symbolt &b)
   SYM_SWAP2(type_);
   SYM_SWAP2(legacy_type_valid_);
   SYM_SWAP2(type2_valid_);
-  SYM_SWAP2(value2_cache);
-  SYM_SWAP2(value2_valid);
+  SYM_SWAP2(value_);
+  SYM_SWAP2(legacy_value_valid_);
+  SYM_SWAP2(value2_valid_);
 }
 
 void symbolt::dump() const
@@ -149,13 +188,14 @@ void symbolt::show(std::ostream &out) const
   out << "Module......: " << module << "\n";
   out << "Mode........: " << mode << " (" << mode << ")"
       << "\n";
-  // Read the type through the accessor: the legacy `typet` is a derived
-  // cache after S5a, so a direct field reference would expose stale data.
+  // Read the type/value through the accessors: the legacy fields are now
+  // derived caches, so direct references would expose stale data.
   const typet &t = get_type();
   if (t.is_not_nil())
     out << "Type........: " << t.pretty(4) << "\n";
-  if (value.is_not_nil())
-    out << "Value.......: " << value.pretty(4) << "\n";
+  const exprt &v = get_value();
+  if (v.is_not_nil())
+    out << "Value.......: " << v.pretty(4) << "\n";
 
   out << "Flags.......:";
 
@@ -189,10 +229,11 @@ std::ostream &operator<<(std::ostream &out, const symbolt &symbol)
 void symbolt::to_irep(irept &dest) const
 {
   dest.clear();
-  // Derive the legacy `typet` from the IREP2 source via get_type() and
-  // serialize as before -- same on-disk format, no goto-binary change.
+  // Derive the legacy `typet` and `exprt` from the IREP2 source via
+  // get_type() / get_value() and serialize as before -- same on-disk
+  // format, no goto-binary change.
   dest.type() = get_type();
-  dest.symvalue(value);
+  dest.symvalue(get_value());
   dest.location(location);
   dest.name(id);
   dest.module(module);
@@ -228,15 +269,17 @@ void symbolt::to_irep(irept &dest) const
 
 void symbolt::from_irep(const irept &src)
 {
-  // Bridge the on-disk legacy form into the legacy cache; the IREP2
-  // representation is derived lazily on the next get_type2() call
-  // (matching the setter semantics -- forward migration is never eager).
+  // Bridge the on-disk legacy form into the legacy caches; the IREP2
+  // representations are derived lazily on the next get_type2() /
+  // get_value2() call (matching the setter semantics -- forward migration
+  // is never eager).
   legacy_type_cache_ = src.type();
   legacy_type_valid_ = true;
   type2_valid_ = false;
 
-  value = static_cast<const exprt &>(src.symvalue());
-  value2_valid = false;
+  legacy_value_cache_ = static_cast<const exprt &>(src.symvalue());
+  legacy_value_valid_ = true;
+  value2_valid_ = false;
 
   location = static_cast<const locationt &>(src.location());
 

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -29,39 +29,39 @@ public:
 
   symbolt();
 
-  // Type accessors. After the B2 S5a source-of-truth flip
-  // (esbmc/esbmc#4715), the IREP2 form is the stored field; the legacy
-  // `typet` is derived lazily via migrate_type_back and cached.
+  // Type and value accessors. After B2 S5a (#4735, lazy variant restored in
+  // #4739) and B2 V2 (esbmc/esbmc#4715, the value-side flip below) both
+  // representations are *caches* sharing the same storage layout: whichever
+  // setter last wrote marks its side valid and invalidates the other; the
+  // const reader on the invalidated side lazily derives via the migration
+  // layer on first access.
   //
-  //   get_type()  - lazy legacy cache populated from the IREP2 source on
-  //                 first read; invalidated by any IREP2-side write.
-  //   get_type2() - the IREP2 source of truth directly (O(1), no cache
-  //                 logic on this side).
-  //
-  // Value accessors keep the dual-storage shape that S4b shipped: legacy
-  // authoritative, IREP2 lazy cache. The value-side flip is out of scope
-  // for Phase 5 (see docs/irep2-symbol-table-phase5-plan.md V-track).
+  // The lazy split is deliberate: an eager forward migrate at set_type /
+  // set_value would walk legacy sub-expressions that the existing frontends
+  // sometimes build without populating intermediate types or kinds. The
+  // post-#4739 design tolerates those latent holes as long as nothing reads
+  // the IREP2 side of the affected symbol -- which, in practice, no current
+  // pipeline path does for the tmp symbols involved.
   const typet &get_type() const;
-  const exprt &get_value() const
-  {
-    return value;
-  }
+  const exprt &get_value() const;
   const type2tc &get_type2() const;
   const expr2tc &get_value2() const;
 
-  // Type setters. The legacy setter forward-migrates to the IREP2 source
-  // and populates the legacy cache eagerly with its input (no
-  // back-migration needed for the next get_type() read). The IREP2 setter
-  // stores `t` as the source and invalidates the legacy cache; the next
-  // get_type() back-migrates (with the nil case handled explicitly).
+  // Type setters. Each writes one side and invalidates the other; the read
+  // side derives lazily on first access (with the nil/empty-id case guarded
+  // inside the readers).
   void set_type(const typet &t);
   void set_type(typet &&t);
   void set_type(const type2tc &t);
 
-  // Value setters keep the S4b semantics: write legacy, invalidate the
-  // IREP2 lazy cache.
+  // Value setters. Mirror of the type setters after B2 V2: legacy variants
+  // store the legacy form and invalidate the IREP2 side; the IREP2-side
+  // setter stores expr2tc directly and invalidates the legacy side. V1
+  // (#4737) is the precondition that makes the back-migration safe for
+  // function-body symbols (code_block2t round-trips).
   void set_value(const exprt &v);
   void set_value(exprt &&v);
+  void set_value(const expr2tc &v);
 
   void clear();
 
@@ -81,31 +81,21 @@ private:
   // other. Reading the other side lazily derives via migrate_type /
   // migrate_type_back. Both fields are mutable so the const getters can
   // populate from the other side on demand.
-  //
-  // S5a (esbmc/esbmc#4735) originally forward-migrated eagerly inside
-  // set_type(const typet&). The python frontend builds legacy `exprt`s
-  // with unset types (e.g. `minus_exprt(lhs, rhs)` whose result `typet`
-  // is default-constructed with empty id), which the eager migration
-  // could not tolerate -- a chain of recursive migrate_expr calls inside
-  // migrate_type ended up constructing arithmetic IREP2 nodes with an
-  // empty-typed result, tripping assert_arith_2ops_consistency in
-  // irep2_expr.cpp. The lazy variant matches the value-side shape (S4b)
-  // and never exposes those latent holes unless something actually reads
-  // get_type2() on the affected symbol -- which, in practice, no current
-  // pipeline path does for those tmp symbols.
   mutable type2tc type_;
   mutable typet legacy_type_cache_;
   mutable bool legacy_type_valid_;
   mutable bool type2_valid_;
 
-  // Value: legacy authoritative; IREP2 is a lazy cache (S4b shape,
-  // unchanged by Phase 5). Function bodies cannot round-trip through
-  // migrate_expr_back today, which is why the value side is deliberately
-  // not flipped - see docs/irep2-symbol-table-phase5-plan.md for the
-  // V-track.
-  exprt value;
-  mutable expr2tc value2_cache;
-  mutable bool value2_valid;
+  // Value: same shape as the type side after B2 V2. expr2tc is the dominant
+  // form on IREP2-side writes; legacy `exprt` is derived lazily via
+  // migrate_expr_back. V1 (#4737) closed the back-migration coverage gap so
+  // function bodies (code_block2t and the four other previously-missing
+  // kinds) can round-trip, which is the precondition for the V2 flip to be
+  // safe.
+  mutable expr2tc value_;
+  mutable exprt legacy_value_cache_;
+  mutable bool legacy_value_valid_;
+  mutable bool value2_valid_;
 };
 
 std::ostream &operator<<(std::ostream &out, const symbolt &symbol);


### PR DESCRIPTION
V2 of the V-track of the symbol-table migration (#4715), per the plan in #4736. Completes the migration that S5a (#4735) started on the type side: `expr2tc value_` becomes the dominant representation on IREP2-side writes; the legacy `exprt` is derived lazily via `migrate_expr_back` — which V1 (#4737) made safe for every `expr2t` kind a symbol value can hold (including `code_block2t` for function bodies). **Designed lazy from day one** per the #4739 hotfix lesson on S5a.

## Field layout transition

```
Before V2 (S4b shape)                  After V2
─────────────────────────────────────  ─────────────────────────────────────
exprt   value;            <source>      mutable expr2tc value_;             <source>
mutable expr2tc value2_cache;          mutable exprt   legacy_value_cache_;
mutable bool    value2_valid;          mutable bool    legacy_value_valid_;
                                       mutable bool    value2_valid_;
```

`symbolt` is now uniformly IREP2-storage-with-lazy-legacy on both sides — symmetric design end-to-end.

## Accessor / setter semantics
Mirror of the post-#4739 type side, point-by-point:

- `get_value()` — lazily back-migrates from `value_` on first call (nil case guarded — `migrate_expr_back` null-derefs on a nil source). Returns the cache on subsequent calls.
- `get_value2()` — lazily forward-migrates from `legacy_value_cache_` when the IREP2 cache is invalid (nil / empty-id case guarded — the only inputs `migrate_expr` cannot consume).
- `set_value(const exprt&)` / `set_value(exprt&&)` — write the legacy cache and invalidate the IREP2 side.
- `set_value(const expr2tc&)` — **new in V2** — writes `value_` directly and invalidates the legacy side.
- `swap()`, `clear()`, `to_irep()`, `from_irep()` — keep both representations consistent.

## Serialization seam — no on-disk format change

- `to_irep` derives the legacy `exprt` via `get_value()` and serialises as before.
- `from_irep` reads `src.symvalue()` into the legacy cache; the IREP2 representation is derived lazily on the next `get_value2()` call.
- Goto-binary format unchanged; old binaries still load.

## Why this is safe
- **V1 (#4737)** closed the back-migration coverage gap. `migrate_expr_back` covers all 109 `expr2t` kinds via the case labels added there. Function-body symbols (the canonical hazard) round-trip cleanly through `code_block2t`.
- **Pre-V2 tests (#4740)** pinned the value-side `is_code` discriminator parity on every write path V2 reshapes. Those 6 `TEST_CASE`s **stayed green** under the flipped storage — exactly the gate they were written for.
- **Lazy by design.** No eager forward-migrate at `set_value(const exprt&)` — the latent type holes the python frontend builds (`minus_exprt(lhs, rhs)` without a result type) cannot trip the migration layer unless a caller actually reads the IREP2 form, which no current pipeline path does for those tmp symbols. This is the S5a lesson applied from the start.

## Validation
- `symboltest` — 13 cases / 55 assertions, all pass.
- `migratetest` 12/23, `irep2test` 9/104 — unchanged.
- Sanity verdicts unchanged: C assert SUCCESSFUL, data-race SUCCESSFUL on safe program.
- The Python regression slice that surfaced the S5a regression in #4737's CI (`string-indexing`, `string-slice1`, `string-many-ops`, `github_3082`, `github_3578`) returns the expected verdicts locally.
- Full build green (esbmc + jimple).

## Migration position
✅ S0–S5a · ✅ #4731 closeout · ✅ #4732 Phase 5 plan · ✅ #4733 dual-role tests · ✅ #4735 S5a type flip · ✅ #4736 V-track plan · ✅ #4737 V1 migration-layer extension · ✅ #4739 lazy-migration hotfix · ✅ #4740 pre-V2 parity tests · ▶ **this PR — V2 value flip**

The symbol-table migration (B2) is now uniformly IREP2-storage-with-lazy-legacy on both sides. **S6** (drop the legacy caches and finalise the accessor ABI — `const T&` vs `T` return on `get_type()`/`get_value()`) is the only remaining slice in B2, and it's an ABI decision rather than new migration work.

~118 insertions / 80 deletions across 3 files (`util/symbol.{h,cpp}`, `util/migrate.cpp`).