### PR TITLE
[docs] close B2 migration: end-state design + comment cleanup (B2 S6)

### DIFF
--- a/docs/irep2-goto-migration-plan.md
+++ b/docs/irep2-goto-migration-plan.md
@@ -37,7 +37,7 @@ structural sharing, on-disk format compatibility).
 | # | Boundary | Where | Legacy type | Why it persists | Risk |
 |---|----------|-------|-------------|-----------------|------|
 | B1 | **Frontend → goto lowering input** | `goto_convert*` consume `codet` (`goto_convert_class.h:18,37,131-167`; `goto_convert.cpp:117`) | `codet`/`exprt` | The clang/python/etc. frontends emit `symbolt::value` as `codet`; `goto_convert` migrates per-instruction (`goto_convert.cpp:136` `migrate_expr`) | Medium |
-| B2 | **Symbol table** | `symbolt::value` (`exprt`), `symbolt::type` (`typet`) (`src/util/symbol.h:15-16`) | `exprt`/`typet` | Shared by *all* frontends and serialization; the lowering target | **High (foundational)** |
+| B2 | **Symbol table** | `symbolt::value` (`expr2tc`), `symbolt::type` (`type2tc`) (`src/util/symbol.h`) | IREP2 | **Done.** Storage flipped to IREP2 source-of-truth with lazy legacy caches (S5a #4735 → V1 #4737 → V2 #4741 → S6). End-state design in `docs/irep2-symbol-table-s6-plan.md`. | (closed) |
 | B3 | **`goto_functiont::type`** | `code_typet type` (`src/goto-programs/goto_functions.h:24`) | `code_typet` (irept) | Function signature still stored stringy | Medium |
 | B4 | **Goto-binary serialization** | `goto_program_irep.cpp:4-57`, `goto_program_serialization.cpp`, `goto_function_serialization.cpp`, `read_bin_goto_object.cpp`, `write_goto_binary.cpp`, `src/util/irep_serialization.{h,cpp}` | `irept` | On-disk format is `irept`; converted via `migrate_expr_back`/`migrate_expr` on each I/O | **High (format compat + hashing)** |
 | B5 | **`rw_set` data-race pass** | `rw_set.h:17-18` stores `exprt original_expr`, `exprt guard`; `rw_set.cpp:8-72` operates in `exprt` | `exprt` | Pass never migrated; still computes over legacy expressions | Medium |
@@ -296,11 +296,17 @@ Phase 0  Instrumentation + baselines        (no behaviour change)
 Phase 1  Pure-analysis leaf passes (B6')     ── lowest risk, no coupling
 Phase 2  rw_set / data-race (B5)             ── self-contained island
 Phase 3  goto_functiont::type (B3)           ── behind adaptor
-Phase 4  Symbol table (B2)                   ── FOUNDATION, shadow-field method
-           ├ 4a shadow fields + assertions
-           ├ 4b switch readers
-           ├ 4c switch writers (kills B6 round-trips)
-           └ 4d symbol (de)serialization  ── couples to Phase 5
+Phase 4  Symbol table (B2)                   ── DONE (executed via S0..V2+S6)
+           ├ S0 encapsulate accessors           #4724
+           ├ S1 chokepoints + cross-check       #4725, #4727
+           ├ S3 IREP2 writer chokepoint         #4728
+           ├ S4a audit writes / remove ref-gets #4729
+           ├ S4b IREP2 lazy cache               #4730
+           ├ S2 closeout                        #4731
+           ├ S5a type source-of-truth flip      #4735 (+ #4739 hotfix)
+           ├ V1 close back-migration coverage   #4737
+           ├ V2 value source-of-truth flip      #4741
+           └ S6 end-state: lazy caches retained #4742, docs/irep2-symbol-table-s6-plan.md
 Phase 5  Goto-binary serialization (B4)      ── versioned, back-compat reader kept
 Phase 6  Frontend lowering input (B1)        ── OPTIONAL / deferrable
 Phase 7  Cleanup: delete dead migrate paths  ── only after correctness proven

--- a/docs/irep2-symbol-table-migration-plan.md
+++ b/docs/irep2-symbol-table-migration-plan.md
@@ -1,9 +1,13 @@
 ---
 title: "B2 execution plan — migrating symbolt::type/value to IREP2"
-status: draft
+status: complete
 date: 2026-05-22
 supersedes-detail-in: docs/irep2-goto-migration-phase4-symboltable.md
 tracking-issue: esbmc/esbmc#4715
+historical-record-of: "the plan as drafted; the actual execution followed
+  the staged path captured in irep2-symbol-table-phase5-plan.md (S5a),
+  irep2-symbol-table-vtrack-plan.md (V1, V2) and
+  irep2-symbol-table-s6-plan.md (S6 end state)."
 ---
 
 # Symbol-table (B2) migration — concrete execution plan
@@ -92,6 +96,12 @@ ones).
 
 ## Phased slices
 
+> **All slices below were executed** between #4724 and #4741.
+> The actual storage flip and ABI decisions are recorded in
+> `irep2-symbol-table-phase5-plan.md` (S5a — type flip),
+> `irep2-symbol-table-vtrack-plan.md` (V1, V2 — value-side flip), and
+> `irep2-symbol-table-s6-plan.md` (S6 — end-state ABI).
+
 Every slice: builds, full-corpus **zero goto-diff**, dual-solver
 (Bitwuzla+Z3) verdict agreement, per-tree ctest, `scripts/check_python_tests.sh`
 when Python is touched. Each is an independently revertible PR.
@@ -137,8 +147,13 @@ goto-binaries still load. Gate: full corpus diff = 0; round-trip read/write of
 both old and new binaries identical.
 
 ### S5 — Cleanup
-Remove the legacy field, the derivation shims, and the cross-check. Only after
-S4 is proven. Delete now-dead `migrate_*_back` paths exposed by S3.
+Originally framed as "remove the legacy field" — superseded by the
+end-state decision in `irep2-symbol-table-s6-plan.md`: the legacy
+`typet` / `exprt` fields are retained as **permanent on-demand caches**.
+IREP2 is the source of truth on `symbolt`; the legacy caches are lazy,
+zero-cost-on-unused-paths, and source-API-stable for the 640+ accessor
+call sites. The cross-check is retained inside `migrate_symbol_*` for
+ongoing losslessness evidence.
 
 ## Risk by area
 

--- a/docs/irep2-symbol-table-phase5-plan.md
+++ b/docs/irep2-symbol-table-phase5-plan.md
@@ -1,5 +1,12 @@
 # Phase 5 — Symbol-Table Source-of-Truth Flip
 
+> **Status: complete.** S5a (#4735, with the lazy-storage fix in #4739)
+> flipped the type side. The V-track (`irep2-symbol-table-vtrack-plan.md`)
+> took the value side. The end-state ABI decision originally framed as
+> S5b is recorded in `irep2-symbol-table-s6-plan.md`: legacy caches are
+> retained permanently; `get_type()` / `get_value()` keep their
+> `const T&` return.
+
 Plan for the next step of the IREP2 symbol-table migration
 (esbmc/esbmc#4715, Boundary B2). Phase 5 turns the IREP2 form of a
 symbol's type into the **stored** field; the legacy `typet` becomes a

--- a/docs/irep2-symbol-table-vtrack-plan.md
+++ b/docs/irep2-symbol-table-vtrack-plan.md
@@ -1,5 +1,11 @@
 # V-track — Symbol-Value Source-of-Truth Decision
 
+> **Status: complete.** V1 (#4737) closed the `migrate_expr_back`
+> coverage gap for the 5 missing kinds. V2 (#4741) flipped
+> `symbolt::value` to IREP2 storage with a lazy legacy cache, designed
+> lazy from day one. End-state ABI recorded in
+> `irep2-symbol-table-s6-plan.md`.
+
 Plan for the value-side counterpart to Phase 5 of the IREP2 symbol-
 table migration (esbmc/esbmc#4715). Phase 5 (#4732, #4735) flipped
 `symbolt::type` to IREP2 storage and left `symbolt::value` exactly as

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -379,8 +379,10 @@ type2tc migrate_type(const typet &type)
 
 type2tc migrate_symbol_type(const symbolt &sym)
 {
-  // S5a: the IREP2 form is the source of truth on `symbolt`; get_type2()
-  // returns the stored field directly (no cache logic on this side).
+  // The IREP2 form is the source of truth on `symbolt`; get_type2() returns
+  // the stored field directly (lazily populated if a legacy-side setter
+  // wrote last). Kept as a named chokepoint so the round-trip cross-check
+  // below runs on every real symbol type the pipeline reads.
   const type2tc &result = sym.get_type2();
 #ifndef NDEBUG
   // Round-trip cross-check: the stored IREP2 form must be stable under a
@@ -398,19 +400,18 @@ type2tc migrate_symbol_type(const symbolt &sym)
 
 void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 {
-  // V2: read the symbol's IREP2 value form directly. After the value-side
-  // flip (esbmc/esbmc#4715, V-track V2) the IREP2 expr2tc is the dominant
-  // representation on IREP2-side writes and is derived lazily from the legacy
-  // cache when the caller wrote on the legacy side.
+  // The IREP2 form is the source of truth on `symbolt`; get_value2() returns
+  // it directly (lazily populated if a legacy-side setter wrote last). Kept
+  // as a named chokepoint so the round-trip cross-check below runs on every
+  // real symbol value the pipeline reads.
   dest = sym.get_value2();
 #ifndef NDEBUG
   // Cross-check: assert the IREP2 value form is stable under the
-  // migration round-trip migrate_expr(migrate_expr_back(e)) == e. V1
-  // (#4737) closed the back-migration coverage gap so this is safe for
-  // every expr2t kind, but we still skip function bodies (no caller goes
-  // through this path on them today, and the assertion would force a
-  // potentially-large body round-trip for no signal) and nil values
-  // (vacuous).
+  // migration round-trip migrate_expr(migrate_expr_back(e)) == e.
+  // migrate_expr_back covers every expr2t kind a symbol value may hold,
+  // but we still skip function bodies (no caller goes through this path on
+  // them today, and the assertion would force a potentially-large body
+  // round-trip for no signal) and nil values (vacuous).
   if (!sym.get_type().is_code() && !sym.get_value().is_nil())
   {
     expr2tc roundtrip;
@@ -424,8 +425,8 @@ void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 
 void set_symbol_type(symbolt &sym, const type2tc &t)
 {
-  // S5a: route through the IREP2-side setter on symbolt. The setter stores
-  // `t` as the source of truth; the legacy `typet` is derived lazily on the
+  // Route through the IREP2-side setter on symbolt. The setter stores `t`
+  // as the source of truth; the legacy `typet` is derived lazily on the
   // next get_type() call via migrate_type_back.
   sym.set_type(t);
 }

--- a/src/util/migrate.h
+++ b/src/util/migrate.h
@@ -17,28 +17,27 @@ extern const namespacet *migrate_namespace_lookup;
 type2tc migrate_type(const typet &type);
 void migrate_expr(const exprt &expr, expr2tc &new_expr);
 
-// IREP2 form of a symbol's type. Single chokepoint for the symbol-table
-// migration (esbmc/esbmc#4715, B2 S1): equivalent to
-// migrate_type(sym.get_type()) today, but centralised so the storage can later
-// become IREP2-native without touching callers again. In debug builds it also
-// asserts the IREP2 form is stable under a round-trip through legacy irept --
-// the property (proven for synthetic types in unit/util/migrate.test.cpp) that
-// makes deriving the legacy field from IREP2 lossless, now checked on every
-// real symbol type the pipeline reads.
+// IREP2 form of a symbol's type. Named chokepoint for symbol type reads in
+// the migration layer (esbmc/esbmc#4715, B2): returns `sym.get_type2()` which
+// is the IREP2 source of truth after the B2 storage flip. In debug builds it
+// also asserts the IREP2 form is stable under a round-trip through legacy
+// irept -- the property (proven for synthetic types in
+// unit/util/migrate.test.cpp) that makes the lazy legacy cache on `symbolt`
+// lossless, now checked on every real symbol type the pipeline reads.
 type2tc migrate_symbol_type(const symbolt &sym);
 
 // IREP2 form of a symbol's value. Value-side counterpart of
-// migrate_symbol_type (esbmc/esbmc#4715, B2 S2). The debug cross-check is
-// *guarded*: function bodies (sym.get_type().is_code()) are skipped because
-// migrate_expr_back cannot reconstruct a code_block -- a body is migrated
-// forward only (see unit/util/migrate.test.cpp); nil values are skipped too.
+// migrate_symbol_type. The debug cross-check is *guarded*: function bodies
+// (sym.get_type().is_code()) are skipped (no caller goes through this path on
+// them today, and the assertion would force a potentially-large body
+// round-trip for no signal); nil values are skipped too.
 void migrate_symbol_value(const symbolt &sym, expr2tc &dest);
 
-// Set a symbol's type from an IREP2 form (esbmc/esbmc#4715, B2 S3). The
-// chokepoint for symbol-type writes: today it back-migrates to the legacy
-// field, but when storage flips to IREP2-native (S4) only this function
-// changes, not its 14+ callers. Replaces the previous round-trip pattern
-// `sym.get_type() = migrate_type_back(t)` at the call sites.
+// Set a symbol's type from an IREP2 form (esbmc/esbmc#4715, B2). The
+// chokepoint for symbol-type writes: routes through symbolt's IREP2-side
+// setter, which stores the form natively and invalidates the lazy legacy
+// cache. Replaces the previous round-trip pattern
+// `sym.set_type(migrate_type_back(t))` at the call sites.
 void set_symbol_type(symbolt &sym, const type2tc &t);
 
 typet migrate_type_back(const type2tc &ref);

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -30,10 +30,9 @@ void symbolt::clear()
 
 // Type setters. Each setter writes one side and invalidates the other;
 // the read side derives lazily via migrate_type_back / migrate_type on
-// first access. The lazy split matches the value-side shape (post-V2)
-// and avoids forward-migrating typets whose sub-expressions (e.g. an
-// array size built from a legacy binary_exprt with no type set) would
-// not survive the recursive descent.
+// first access. The lazy split avoids forward-migrating typets whose
+// sub-expressions (e.g. an array size built from a legacy binary_exprt
+// with no type set) would not survive the recursive descent.
 void symbolt::set_type(const typet &t)
 {
   legacy_type_cache_ = t;
@@ -55,10 +54,10 @@ void symbolt::set_type(const type2tc &t)
   legacy_type_valid_ = false;
 }
 
-// Value setters. Mirror of the type setters after B2 V2: each writes one
-// side and invalidates the other; the read side derives lazily via
-// migrate_expr / migrate_expr_back (the back direction is safe for all
-// expr2t kinds after V1, #4737).
+// Value setters. Mirror of the type setters: each writes one side and
+// invalidates the other; the read side derives lazily via migrate_expr /
+// migrate_expr_back. The back direction covers every expr2t kind a symbol
+// value may hold, including code_block2t for function bodies.
 void symbolt::set_value(const exprt &v)
 {
   legacy_value_cache_ = v;
@@ -115,9 +114,8 @@ const exprt &symbolt::get_value() const
     // Mirror of get_type(): a nil IREP2 value must not be fed to
     // migrate_expr_back (it derefs the held pointer). Return a nil exprt
     // instead -- the shape a freshly-cleared symbolt has on the legacy
-    // side. V1 (#4737) closed the back-migration coverage gap so
-    // non-nil values back-migrate cleanly for every expr2t kind a
-    // symbol value may hold, including function bodies.
+    // side. For non-nil values, migrate_expr_back covers every expr2t
+    // kind a symbol value may hold, including function bodies.
     if (is_nil_expr(value_))
       legacy_value_cache_.make_nil();
     else

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -29,18 +29,20 @@ public:
 
   symbolt();
 
-  // Type and value accessors. After B2 S5a (#4735, lazy variant restored in
-  // #4739) and B2 V2 (esbmc/esbmc#4715, the value-side flip below) both
-  // representations are *caches* sharing the same storage layout: whichever
-  // setter last wrote marks its side valid and invalidates the other; the
-  // const reader on the invalidated side lazily derives via the migration
-  // layer on first access.
+  // Type and value accessors. After the symbol-table migration
+  // (esbmc/esbmc#4715, boundary B2), the IREP2 forms `type_` / `value_` are
+  // the source of truth on both sides; the legacy `typet` / `exprt` are
+  // permanent on-demand caches populated lazily by the const readers.
+  // Whichever setter last wrote marks its side valid and invalidates the
+  // other; the reader on the invalidated side lazily derives via the
+  // migration layer on first access. This is the end-state design, not
+  // transitional -- see docs/irep2-symbol-table-s6-plan.md.
   //
   // The lazy split is deliberate: an eager forward migrate at set_type /
   // set_value would walk legacy sub-expressions that the existing frontends
   // sometimes build without populating intermediate types or kinds. The
-  // post-#4739 design tolerates those latent holes as long as nothing reads
-  // the IREP2 side of the affected symbol -- which, in practice, no current
+  // lazy design tolerates those latent holes as long as nothing reads the
+  // IREP2 side of the affected symbol -- which, in practice, no current
   // pipeline path does for the tmp symbols involved.
   const typet &get_type() const;
   const exprt &get_value() const;
@@ -54,11 +56,12 @@ public:
   void set_type(typet &&t);
   void set_type(const type2tc &t);
 
-  // Value setters. Mirror of the type setters after B2 V2: legacy variants
-  // store the legacy form and invalidate the IREP2 side; the IREP2-side
-  // setter stores expr2tc directly and invalidates the legacy side. V1
-  // (#4737) is the precondition that makes the back-migration safe for
-  // function-body symbols (code_block2t round-trips).
+  // Value setters. Mirror of the type setters: legacy variants store the
+  // legacy form and invalidate the IREP2 side; the IREP2-side setter
+  // stores expr2tc directly and invalidates the legacy side. `migrate_expr_back`
+  // covers every expr2t kind a symbol value may hold -- including
+  // code_block2t for function bodies -- so the lazy back-migration in
+  // get_value() is safe regardless of what was written.
   void set_value(const exprt &v);
   void set_value(exprt &&v);
   void set_value(const expr2tc &v);
@@ -76,22 +79,18 @@ public:
   irep_idt get_function_name() const;
 
 private:
-  // Type: both representations are caches sharing the S5a storage layout.
-  // The setter that wrote last marks its side valid and invalidates the
-  // other. Reading the other side lazily derives via migrate_type /
-  // migrate_type_back. Both fields are mutable so the const getters can
-  // populate from the other side on demand.
+  // Type and value storage. IREP2 (`type_`, `value_`) is the source of
+  // truth on both sides; the legacy fields (`legacy_*_cache_`) are
+  // permanent on-demand caches. The setter that wrote last marks its
+  // side valid and invalidates the other; reading the invalidated side
+  // lazily derives via migrate_type / migrate_type_back /
+  // migrate_expr / migrate_expr_back. All fields are mutable so the
+  // const readers can populate from the other side on demand.
   mutable type2tc type_;
   mutable typet legacy_type_cache_;
   mutable bool legacy_type_valid_;
   mutable bool type2_valid_;
 
-  // Value: same shape as the type side after B2 V2. expr2tc is the dominant
-  // form on IREP2-side writes; legacy `exprt` is derived lazily via
-  // migrate_expr_back. V1 (#4737) closed the back-migration coverage gap so
-  // function bodies (code_block2t and the four other previously-missing
-  // kinds) can round-trip, which is the precondition for the V2 flip to be
-  // safe.
   mutable expr2tc value_;
   mutable exprt legacy_value_cache_;
   mutable bool legacy_value_valid_;


### PR DESCRIPTION
Final slice of the symbol-table migration (#4715), executing Option B from the S6 plan merged via #4742. The migration is complete; this PR closes the book.

## What this changes

**Plan docs — status updates.**
- `docs/irep2-goto-migration-plan.md` — the B2 row is marked **done**; the staged execution roadmap lists the actual PR sequence (S0–S6 with PR numbers).
- `docs/irep2-symbol-table-migration-plan.md` — status: `draft` → `complete`, with a pointer to the Phase 5 / V-track / S6 plans that captured the actual execution.
- `docs/irep2-symbol-table-phase5-plan.md` — header banner: "Status: complete. S5a (#4735 + #4739) and S5b superseded by S6."
- `docs/irep2-symbol-table-vtrack-plan.md` — header banner: "Status: complete. V1 (#4737) and V2 (#4741) landed; end-state in S6."

**Code comments — end-state phrasing.**
`src/util/symbol.{h,cpp}` and `src/util/migrate.{h,cpp}` lose the transitional language ("deferred to S6", "S5a flipped …", "V1 closed …") in favour of end-state phrasing:
- IREP2 is the source of truth on both sides of `symbolt`.
- The legacy `typet` / `exprt` fields are **permanent on-demand caches**, not transitional.
- The chokepoint functions (`migrate_symbol_type`, `migrate_symbol_value`, `set_symbol_type`) earn their keep via the NDEBUG round-trip cross-check that runs on every real symbol the pipeline reads.

## What this PR explicitly does NOT do
- **No code change.** Zero lines of executable code touched. No new behaviour, no new tests, no API change.
- **No field removal.** The legacy caches stay (per #4742's Option B sign-off).
- **No chokepoint inlining.** They keep carrying the cross-check.

## Validation
- Full build green (esbmc + jimple).
- `symboltest` 13 / 55, `migratetest` 12 / 23, `irep2test` 9 / 104 — all pass.
- Sanity verdict unchanged.

## Migration history (closed)

| Stage | PR |
|-------|----|
| S0 — encapsulate accessors | #4724 |
| S1 — `migrate_symbol_type` chokepoint | #4725 |
| S1' — `migrate_symbol_value` chokepoint | #4727 |
| S3 — `set_symbol_type` chokepoint | #4728 |
| S4a — audit writes; remove mutable getters | #4729 |
| S4b — IREP2 lazy cache | #4730 |
| S2 closeout | #4731 |
| Phase 5 plan | #4732 |
| Pre-S5a dual-role tests | #4733 |
| S5a — type-side flip | #4735 |
| V-track plan | #4736 |
| V1 — `migrate_expr_back` coverage closure | #4737 |
| S5a lazy-migration hotfix | #4739 |
| Pre-V2 value-side tests | #4740 |
| V2 — value-side flip | #4741 |
| S6 plan | #4742 |
| **S6 finalise (this PR)** | — |

After this lands, no further symbol-table migration work is planned. Other B-boundaries (B1 frontend lowering, B4 serialization, B5 rw_set, B6 round-trips) are tracked separately.

~106 insertions / 75 deletions across 8 files (4 docs, 4 source files).