### PR TITLE
[tests] pin IREP2 rw_set paths via unit + regression tests (B5 Phase 2.3)

### DIFF
--- a/regression/esbmc/github_4715_rwset/main.c
+++ b/regression/esbmc/github_4715_rwset/main.c
@@ -1,0 +1,46 @@
+// Race-safe companion to github_4715_rwset_fail: the same three IREP2
+// rw_set paths (array index / member / if-guarded) are exercised, but
+// each thread writes its OWN disjoint locations. The only shared
+// global is `cond`, which is read-only across the two threads
+// (concurrent reads are not races). --data-races-check must NOT fire.
+
+#include <pthread.h>
+
+int arr_t1[2];
+int arr_t2[2];
+
+struct S
+{
+  int x;
+  int y;
+};
+struct S s_t1;
+struct S s_t2;
+
+int cond; // shared but read-only across the two threads
+
+void *thread1(void *_)
+{
+  arr_t1[0] = 1;
+  s_t1.x = 1;
+  if (cond)
+    s_t1.y = 1;
+  return 0;
+}
+
+void *thread2(void *_)
+{
+  arr_t2[0] = 2;
+  s_t2.x = 2;
+  if (cond)
+    s_t2.y = 2;
+  return 0;
+}
+
+int main()
+{
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+  return 0;
+}

--- a/regression/esbmc/github_4715_rwset/test.desc
+++ b/regression/esbmc/github_4715_rwset/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_rwset_fail/main.c
+++ b/regression/esbmc/github_4715_rwset_fail/main.c
@@ -1,0 +1,52 @@
+// Regression for the IREP2-native rw_set data-race analysis (#4715, B5
+// Phase 2.1/2.2 -- #4718/#4719). Exercises three of the four expr2tc
+// paths the migration reshaped from a single race-positive program:
+//   - array-index access  (is_index2t)
+//   - struct member       (is_member2t)
+//   - if-guarded write    (is_if2t with the true/false guard split)
+// The fourth path (call-site read via is_code_function_call2t) is
+// covered by the companion unit test in unit/goto-programs/rw_set.test.cpp.
+//
+// Two threads concurrently write the same locations on each path, so
+// --data-races-check must fire. Pins the FAIL verdict to the IREP2 path.
+// Modelled after regression/esbmc-unix/00_race01 -- no joins, so the
+// interleaving search converges quickly.
+
+#include <pthread.h>
+
+int shared_arr[2];
+
+struct S
+{
+  int x;
+  int y;
+};
+struct S shared_struct;
+
+int cond;
+
+void *writer1(void *_)
+{
+  shared_arr[0] = 1;       // array-index race target
+  shared_struct.x = 1;     // member race target
+  if (cond)                // if-guarded race target
+    shared_struct.y = 1;
+  return 0;
+}
+
+void *writer2(void *_)
+{
+  shared_arr[0] = 2;       // races with writer1's shared_arr[0]
+  shared_struct.x = 2;     // races with writer1's shared_struct.x
+  if (cond)
+    shared_struct.y = 2;   // races with writer1's shared_struct.y
+  return 0;
+}
+
+int main()
+{
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, writer1, 0);
+  pthread_create(&t2, 0, writer2, 0);
+  return 0;
+}

--- a/regression/esbmc/github_4715_rwset_fail/test.desc
+++ b/regression/esbmc/github_4715_rwset_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION FAILED$
+^.*data race on .*$

--- a/unit/goto-programs/CMakeLists.txt
+++ b/unit/goto-programs/CMakeLists.txt
@@ -6,3 +6,4 @@ new_unit_test(interval-analysis-test "interval_analysis.test.cpp" "test_goto_fac
 new_unit_test(available-expressions-test "available_expressions.test.cpp" "test_goto_factory;gotoalgorithms;abstract-interpretation;langapi")
 new_unit_test(interval-symex-guard-test "interval_symex_guard.test.cpp" "mode_table_obj;abstract-interpretation;langapi")
 new_unit_test(k-path-spanning-test "k_path_spanning.test.cpp" "gotoprograms;langapi")
+new_unit_test(rw-set-test "rw_set.test.cpp" "gotoprograms;pointeranalysis;solve")

--- a/unit/goto-programs/rw_set.test.cpp
+++ b/unit/goto-programs/rw_set.test.cpp
@@ -1,0 +1,229 @@
+// Targeted unit tests for the IREP2-native rw_set data-race analysis
+// (esbmc/esbmc#4715, B5 Phase 2.1/2.2 -- #4718/#4719). Exercise
+// `rw_sett::read_rec` / `compute` on hand-built `expr2tc` trees and
+// assert the `entries` map content directly, with no frontend in the
+// loop. Pin the paths the migration reshaped:
+//   - plain symbol read/write registration
+//   - is_index2t      : array access, suffix unchanged, object = base name
+//   - is_member2t     : struct member, suffix = "." + member name
+//   - is_if2t         : guard split (both branches recorded with their
+//                       respective true/false guards)
+//   - is_address_of2t : taking an address does NOT register an access
+//   - is_code_assign2t: rhs read + lhs write via compute()
+// Companion regression in regression/esbmc/github_4715_rwset[_fail]/
+// covers the end-to-end behaviour via --data-races-check on the
+// index/member/if paths.
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <goto-programs/rw_set.h>
+#include <irep2/irep2.h>
+#include <irep2/irep2_expr.h>
+#include <irep2/irep2_type.h>
+#include <irep2/irep2_utils.h>
+#include <util/c_types.h>
+#include <util/context.h>
+#include <util/migrate.h>
+#include <util/namespace.h>
+
+namespace
+{
+// Build a contextt with the symbols the tests reference, all marked
+// static_lifetime so rw_set's filter at read_write_rec accepts them as
+// race-eligible (the legacy filter only registers shared state).
+contextt &rwset_test_context()
+{
+  static contextt ctx;
+  static bool initialised = false;
+  if (!initialised)
+  {
+    auto add_global = [](contextt &c, const std::string &n, const type2tc &t) {
+      symbolt s;
+      s.id = s.name = n;
+      s.mode = "C";
+      s.static_lifetime = true;
+      s.lvalue = true;
+      set_symbol_type(s, t);
+      c.add(s);
+    };
+
+    type2tc int32 = get_int_type(32);
+    type2tc arr_t = array_type2tc(
+      int32, constant_int2tc(get_uint_type(64), BigInt(4)), /*inf=*/false);
+    type2tc struct_t = struct_type2tc(
+      std::vector<type2tc>{int32, int32},
+      std::vector<irep_idt>{"x", "y"},
+      std::vector<irep_idt>{"x", "y"},
+      "s");
+
+    add_global(ctx, "x", int32);
+    add_global(ctx, "y", int32);
+    add_global(ctx, "arr", arr_t);
+    add_global(ctx, "g_struct", struct_t);
+    add_global(ctx, "cond", get_bool_type());
+
+    initialised = true;
+  }
+  return ctx;
+}
+
+// Point the migrate layer at our namespace (rw_set lookups go through it).
+const namespacet &rwset_test_ns()
+{
+  static namespacet ns(rwset_test_context());
+  migrate_namespace_lookup = &ns;
+  return ns;
+}
+
+// Build a minimal goto_programt with one ASSERT instruction so the
+// rw_sett constructor has a valid `const_targett` to store. `read_rec`
+// never dereferences `target`, so the instruction kind is immaterial
+// for these tests -- but the iterator must be non-singular.
+goto_programt &rwset_test_program()
+{
+  static goto_programt prog;
+  static bool initialised = false;
+  if (!initialised)
+  {
+    auto t = prog.add_instruction();
+    t->type = ASSERT;
+    initialised = true;
+  }
+  return prog;
+}
+
+// Convenience: build an rw_sett bound to the test namespace and program.
+rw_sett make_rw_set()
+{
+  return rw_sett(rwset_test_ns(), rwset_test_program().instructions.begin());
+}
+
+// Convenience: a symbol2tc for one of the globals registered above.
+expr2tc sym(const std::string &name)
+{
+  const symbolt *s = rwset_test_context().find_symbol(name);
+  REQUIRE(s != nullptr);
+  return symbol2tc(s->get_type2(), name);
+}
+} // namespace
+
+TEST_CASE(
+  "rw_set: plain symbol read registers an r entry",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  rw_sett rw = make_rw_set();
+  rw.read_rec(sym("x"));
+
+  REQUIRE(rw.entries.size() == 1);
+  auto it = rw.entries.find("x");
+  REQUIRE(it != rw.entries.end());
+  REQUIRE(it->second.object == irep_idt("x"));
+  REQUIRE(it->second.r);
+  REQUIRE_FALSE(it->second.w);
+  REQUIRE_FALSE(it->second.deref);
+}
+
+TEST_CASE(
+  "rw_set: array-index access registers the base symbol, suffix unchanged",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // arr[0]: is_index2t around symbol2tc(arr). Per rw_set.cpp the recursion
+  // descends into source_value and DROPS the index from the suffix -- the
+  // object key is "arr" verbatim.
+  expr2tc idx_zero = constant_int2tc(get_uint_type(64), BigInt(0));
+  expr2tc index_expr = index2tc(get_int_type(32), sym("arr"), idx_zero);
+
+  rw_sett rw = make_rw_set();
+  rw.read_rec(index_expr);
+
+  REQUIRE(rw.entries.size() == 1);
+  auto it = rw.entries.find("arr");
+  REQUIRE(it != rw.entries.end());
+  REQUIRE(it->second.r);
+  REQUIRE_FALSE(it->second.w);
+  // original_expr is preserved as the index expression so downstream
+  // race-check instrumentation knows the access shape.
+  REQUIRE(it->second.original_expr == index_expr);
+}
+
+TEST_CASE(
+  "rw_set: struct member access registers the symbol with .field suffix",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // g_struct.x: is_member2t around symbol2tc(g_struct). The recursion
+  // appends "." + member_name to the suffix as it descends.
+  expr2tc member_expr =
+    member2tc(get_int_type(32), sym("g_struct"), irep_idt("x"));
+
+  rw_sett rw = make_rw_set();
+  rw.read_rec(member_expr);
+
+  REQUIRE(rw.entries.size() == 1);
+  // Key is "g_struct.x" (symbol id + ".x" suffix).
+  auto it = rw.entries.find("g_struct.x");
+  REQUIRE(it != rw.entries.end());
+  REQUIRE(it->second.r);
+  REQUIRE_FALSE(it->second.w);
+}
+
+TEST_CASE(
+  "rw_set: if-expression splits the guard on the two branches",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // if (cond) x else y -- read the result. Per rw_set.cpp the cond is
+  // read unconditionally; the branches each get a guard with the cond
+  // and its negation respectively.
+  expr2tc if_expr = if2tc(get_int_type(32), sym("cond"), sym("x"), sym("y"));
+
+  rw_sett rw = make_rw_set();
+  rw.read_rec(if_expr);
+
+  // Three entries: cond (the discriminator) plus x and y on the two branches.
+  REQUIRE(rw.entries.size() == 3);
+  REQUIRE(rw.entries.find("cond") != rw.entries.end());
+  REQUIRE(rw.entries.find("x") != rw.entries.end());
+  REQUIRE(rw.entries.find("y") != rw.entries.end());
+
+  // The cond entry's guard is the empty / outer guard (no parent if-split
+  // is in scope on the top-level call).
+  // The x branch carries a guard with cond; the y branch carries a guard
+  // with not(cond). Both guards must be non-trivial (their as_expr() form
+  // is not the bare cond, because the guard is the accumulated chain).
+  REQUIRE(rw.entries["x"].guard != rw.entries["y"].guard);
+}
+
+TEST_CASE(
+  "rw_set: address-of does NOT register a read",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // &x in expression position is not a read of x; rw_set.cpp explicitly
+  // short-circuits is_address_of2t.
+  expr2tc addr = address_of2tc(pointer_type2tc(get_int_type(32)), sym("x"));
+
+  rw_sett rw = make_rw_set();
+  rw.read_rec(addr);
+
+  REQUIRE(rw.entries.empty());
+}
+
+TEST_CASE(
+  "rw_set: code_assign separates rhs (read) from lhs (write)",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // x = y -- via the public assign() helper that compute() would call
+  // for a code_assign2t. Asserts the rhs registers as r-only and the
+  // lhs as w-only.
+  rw_sett rw = make_rw_set();
+  // Use the protected path via rw_set::compute on a code_assign2tc.
+  // compute() reads instruction.is_goto()/is_assert()/is_assume() only on
+  // the read_rec fallback arm; for code_assign2t it dispatches directly.
+  expr2tc assign = code_assign2tc(sym("x"), sym("y"));
+  rw.compute(assign);
+
+  REQUIRE(rw.entries.size() == 2);
+  REQUIRE(rw.entries["y"].r);
+  REQUIRE_FALSE(rw.entries["y"].w);
+  REQUIRE(rw.entries["x"].w);
+  REQUIRE_FALSE(rw.entries["x"].r);
+}


### PR DESCRIPTION
PR 2.3 of the Phase 2 rw_set migration plan (`docs/irep2-goto-migration-phase2-rwset.md`): the focused regression and unit tests that pin the IREP2 paths #4718 (rw_sett internals) and #4719 (w_guardst building) reshaped. Closes the open work item in the B5 plan; no behaviour change.

## Regression (`regression/esbmc/github_4715_rwset[_fail]/`)

- **`github_4715_rwset_fail/main.c`** — two writer threads concurrently write the same shared array element (`is_index2t`), struct member (`is_member2t`), and if-guarded location (`is_if2t` with the guard split). Exercises three of the four migration-reshaped paths in a single race-positive program. `test.desc` expects `VERIFICATION FAILED` plus a `data race on` diagnostic.
- **`github_4715_rwset/main.c`** — race-safe companion exercising the same three paths with each thread writing its **own disjoint** locations; `cond` is shared but read-only. `test.desc` expects `VERIFICATION SUCCESSFUL`. Modelled on `regression/esbmc-unix/00_race01` (no joins) so the interleaving search converges in under 3s on macOS.

## Unit (`unit/goto-programs/rw_set.test.cpp`)

Six `TEST_CASE`s constructing `expr2tc` trees and a small `contextt` with `static_lifetime` symbols, asserting the `rw_sett::entries` map content directly. No frontend in the loop -- the test exercises the IREP2 paths standalone:

| Test | Pins |
|------|------|
| plain symbol read | object key = symbol name, `r=true,w=false` |
| `is_index2t` | object key drops the index; suffix unchanged |
| `is_member2t` | suffix `".x"` (member name) |
| `is_if2t` | three entries (cond + two branches), branch guards distinct |
| `is_address_of2t` | no entry (taking an address is not a read) |
| `compute(code_assign2tc)` | rhs `r`-only, lhs `w`-only |

## Validation
- `./unit/goto-programs/rw-set-test` — 6 cases / 35 assertions, all pass.
- `ctest -R github_4715_rwset` — 2/2 passed, 3.5s wall time on macOS arm64.
- Sister suites unchanged: `symboltest` 13/55, `migratetest` 12/23, `irep2test` 9/104.

## Migration position
Closes B5 Phase 2.3. After this lands the rw_set migration plan is fully executed (PR 2.1 #4718, PR 2.2 #4719, this PR for 2.3; PR 2.4 was deferred to Phase 4 and is now obsolete -- B2 closed in #4743).

~337 insertions across 6 files (2 regression dirs + 1 unit test + CMake glue). No source changes.