### PR TITLE
[python] hoist class-method default-helper assignments to module scope

### DIFF
--- a/regression/python/github_4747/main.py
+++ b/regression/python/github_4747/main.py
@@ -1,0 +1,17 @@
+NO_OVERRIDE = -1
+
+
+class Cfg:
+
+    def __init__(self, override: int = NO_OVERRIDE) -> None:
+        self.override = override
+
+
+def main() -> None:
+    c = Cfg()
+    assert c.override == NO_OVERRIDE
+    d = Cfg(42)
+    assert d.override == 42
+
+
+main()

--- a/regression/python/github_4747/test.desc
+++ b/regression/python/github_4747/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4747_fail/main.py
+++ b/regression/python/github_4747_fail/main.py
@@ -1,0 +1,15 @@
+NO_OVERRIDE = -1
+
+
+class Cfg:
+
+    def __init__(self, override: int = NO_OVERRIDE) -> None:
+        self.override = override
+
+
+def main() -> None:
+    c = Cfg()
+    assert c.override != NO_OVERRIDE  # must fail: default propagates correctly
+
+
+main()

--- a/regression/python/github_4747_fail/test.desc
+++ b/regression/python/github_4747_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/class_context_mixin.py
+++ b/src/python-frontend/preprocessor/class_context_mixin.py
@@ -8,6 +8,7 @@ class ClassContextMixin:
         """Track class context for method definitions."""
         old_class_name = getattr(self, "current_class_name", None)
         self.current_class_name = node.name
+        inits_before = len(self._pending_method_default_inits)
 
         node = self.expand_dataclass(node)
         self._collect_class_attr_annotations(node)
@@ -16,6 +17,14 @@ class ClassContextMixin:
         self.generic_visit(node)
 
         self.current_class_name = old_class_name
+
+        # Hoist method default-helper assignments past the outermost ClassDef
+        # so they become module-level statements visible at call sites. For
+        # nested classes, keep them pending until the outer ClassDef exits.
+        if old_class_name is None and len(self._pending_method_default_inits) > inits_before:
+            hoisted = self._pending_method_default_inits[inits_before:]
+            del self._pending_method_default_inits[inits_before:]
+            return [node, *hoisted]
         return node
 
     def _record_exit_suppresses_all(self, class_node):

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -562,6 +562,7 @@ class CoreVisitorsMixin:
 
     def _store_function_defaults(self, node, qualified_name):
         return_nodes = []
+        is_method = "." in qualified_name
         for i in range(1, len(node.args.defaults) + 1):
             arg_index = len(node.args.args) - i
             if arg_index < 0:
@@ -574,7 +575,10 @@ class CoreVisitorsMixin:
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.args[-i], default_node)
                 self.functionDefaults[(qualified_name, arg_name)] = target_var
-                return_nodes.append(assignment_node)
+                if is_method:
+                    self._pending_method_default_inits.append(assignment_node)
+                else:
+                    return_nodes.append(assignment_node)
             else:
                 self.functionDefaults[(qualified_name, arg_name)] = default_node
         for i, default in enumerate(node.args.kw_defaults):
@@ -587,7 +591,10 @@ class CoreVisitorsMixin:
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.kwonlyargs[i], default)
                 self.functionDefaults[(qualified_name, kwarg_name)] = target_var
-                return_nodes.append(assignment_node)
+                if is_method:
+                    self._pending_method_default_inits.append(assignment_node)
+                else:
+                    return_nodes.append(assignment_node)
             else:
                 self.functionDefaults[(qualified_name, kwarg_name)] = default
         return return_nodes

--- a/src/python-frontend/preprocessor/preprocessor_state_mixin.py
+++ b/src/python-frontend/preprocessor/preprocessor_state_mixin.py
@@ -72,3 +72,4 @@ class PreprocessorStateMixin:
         self.exported_range_aliases = set()
         self.exported_range_wrappers = {}
         self.module_dunder_all = None
+        self._pending_method_default_inits = []


### PR DESCRIPTION
Hoist the `ESBMC_default_*` helper assignments synthesised for class-method
Name defaults past the enclosing `ClassDef` so they become module-level
statements visible at call sites. Previously they were emitted inside the
class body, which turned them into class attributes and produced
`Variable 'ESBMC_default_*' is not defined` at `Cfg()` call sites.

Fixes #4747
