### PR TITLE
[python] handle PEP 604 'T | None' class attributes

### DIFF
--- a/regression/python/github_4745_pep604_class_attr/main.py
+++ b/regression/python/github_4745_pep604_class_attr/main.py
@@ -1,0 +1,13 @@
+class Box:
+    def __init__(self) -> None:
+        self.x: int | None = None
+        self.flag: int = 7
+
+
+def main() -> None:
+    b = Box()
+    _ = b.x
+    assert b.flag == 7
+
+
+main()

--- a/regression/python/github_4745_pep604_class_attr/test.desc
+++ b/regression/python/github_4745_pep604_class_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4745_pep604_class_attr_fail/main.py
+++ b/regression/python/github_4745_pep604_class_attr_fail/main.py
@@ -1,0 +1,13 @@
+class Box:
+    def __init__(self) -> None:
+        self.x: int | None = None
+        self.flag: int = 0
+
+
+def main() -> None:
+    b = Box()
+    _ = b.x
+    assert b.flag == 7
+
+
+main()

--- a/regression/python/github_4745_pep604_class_attr_fail/test.desc
+++ b/regression/python/github_4745_pep604_class_attr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 1
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -414,11 +414,15 @@ void python_converter::get_attributes_from_self(
       }
       else if (
         stmt["annotation"].contains("_type") &&
-        stmt["annotation"]["_type"] == "Subscript")
+        (stmt["annotation"]["_type"] == "Subscript" ||
+         stmt["annotation"]["_type"] == "BinOp"))
       {
-        // Subscript annotation like dict[str, int] or list[int]
+        // Subscript annotation like dict[str, int], list[int], Optional[int]
+        // or PEP 604 union BinOp like int | None (get_type_from_annotation
+        // already maps `T | None` to gen_pointer_type(T), the same shape it
+        // produces for Optional[T]).
         typet type = get_type_from_annotation(stmt["annotation"], stmt);
-        if (type.is_nil())
+        if (type.is_nil() || type.is_empty())
         {
           log_warning(
             "Skipping attribute '{}' with unsupported annotation type",


### PR DESCRIPTION
self.x: int | None annotations are encoded as BinOp in the Python AST. get_attributes_from_self only dispatched on Name/Attribute/Subscript and silently dropped BinOp, causing 'Attribute not found' on subsequent access. Route BinOp annotations to get_type_from_annotation, which already maps PEP 604 unions to the same pointer-to-T encoding it produces for Optional[T]. Tightens the nil-only guard to also reject empty_typet. C-Live discharged by the new github_4745 regression tests, which exercise the added branch.

Fixes #4745