### PR TITLE
[python] allow Optional[T] vs T equality after `is not None`

### DIFF
--- a/regression/python/github_4746/main.py
+++ b/regression/python/github_4746/main.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+
+class Box:
+
+    def __init__(self, x: Optional[int] = None) -> None:
+        self.x = x
+
+
+def main() -> None:
+    b = Box(None)
+    if b.x is not None:
+        assert b.x == 0  # unreachable: b.x is None
+
+    c = Box(5)
+    if c.x is not None:
+        assert c.x == 5
+
+
+main()

--- a/regression/python/github_4746/test.desc
+++ b/regression/python/github_4746/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4746_fail/main.py
+++ b/regression/python/github_4746_fail/main.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+
+class Box:
+
+    def __init__(self, x: Optional[int] = None) -> None:
+        self.x = x
+
+
+def main() -> None:
+    b = Box(5)
+    if b.x is not None:
+        assert b.x == 7  # must fail: actual value is 5
+
+
+main()

--- a/regression/python/github_4746_fail/test.desc
+++ b/regression/python/github_4746_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -659,6 +659,34 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
       else
         cast_to_void_ptr(lhs, rhs.type()); // cast integer to void*
     }
+
+    // Optional[T] is lowered to T* (see converter_types.cpp:457) and a
+    // non-None T value is round-tripped through (T*) at the call site
+    // (e.g. foo(5) -> y = (int*)5). Make equality with a matching primitive
+    // work by casting the primitive side to the pointer type, so the
+    // resulting comparison matches the round-tripped address. Skip ordered
+    // comparisons: they would silently compare addresses, not values.
+    auto is_primitive_ptr = [](const exprt &e) {
+      if (!e.type().is_pointer())
+        return false;
+      const typet &sub = e.type().subtype();
+      return sub.is_signedbv() || sub.is_unsignedbv() || sub.is_floatbv();
+    };
+    auto is_primitive = [](const exprt &e) {
+      return e.type().is_signedbv() || e.type().is_unsignedbv() ||
+             e.type().is_floatbv();
+    };
+    if (op == "Eq" || op == "NotEq" || op == "Is" || op == "IsNot")
+    {
+      if (
+        is_primitive_ptr(lhs) && is_primitive(rhs) &&
+        lhs.type().subtype() == rhs.type())
+        cast_to_void_ptr(rhs, lhs.type());
+      else if (
+        is_primitive_ptr(rhs) && is_primitive(lhs) &&
+        rhs.type().subtype() == lhs.type())
+        cast_to_void_ptr(lhs, rhs.type());
+    }
   }
 
   // Handle special mathematical operations


### PR DESCRIPTION
`Optional[T]` annotations are lowered to `T*` and a non-None value is round-tripped through `(T*)` at the call site (e.g. `foo(5)` → `y = (int*)5`). Equality (`==`/`!=`/`is`/`is not`) between such a pointer and a matching primitive previously tripped the pointer-vs-non-pointer guard in `get_binary_operator_expr` with `Unsupported comparison between pointer-backed and non-pointer values`. Cast the primitive side to the pointer type — the same treatment already applied to `void*` — so the comparison matches the round-tripped address. Ordered comparisons are deliberately left alone (they would silently compare addresses, not values).

Fixes #4746
