### PR TITLE
[python] bound bit_length OM loop by length so symbolic n terminates

### DIFF
--- a/regression/python/github_4756/main.py
+++ b/regression/python/github_4756/main.py
@@ -1,0 +1,6 @@
+x = nondet_int()
+__ESBMC_assume(1 <= x)
+__ESBMC_assume(x <= 16)
+b = x.bit_length()
+assert b >= 1
+assert b <= 5

--- a/regression/python/github_4756/test.desc
+++ b/regression/python/github_4756/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4756_fail/main.py
+++ b/regression/python/github_4756_fail/main.py
@@ -1,0 +1,5 @@
+x = nondet_int()
+__ESBMC_assume(1 <= x)
+__ESBMC_assume(x <= 16)
+b = x.bit_length()
+assert b == 99  # must fail: bit_length(x in [1,16]) is in [1,5]

--- a/regression/python/github_4756_fail/test.desc
+++ b/regression/python/github_4756_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -82,6 +82,8 @@ ignored_dirs=(
   "github_4548_floordiv_call_arg"
   "github_4548_floordiv_negative"
   "github_4581"
+  "github_4756"
+  "github_4756_fail"
   "github_4668"
   "github_4666_2d"
   "github_4666_shape"

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -53,6 +53,10 @@ class int:
     # first k that proves the property.
     def bit_length(cls, n: IntWide) -> int:
         length: int = 0
+        # The literal 512 matches kPythonBignumWidth in
+        # src/python-frontend/type_handler.cpp; revisit if that constant
+        # changes or when truly unbounded ints land (#4642), otherwise
+        # bit_length will silently cap at the wrong width.
         while length < 512 and n > 0:
             n: IntWide = n >> 1
             length = length + 1

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -42,11 +42,18 @@ class int:
     # by ** under --ir (e.g. 2**64) without truncating at the call boundary.
     # Narrow int inputs sign-extend on entry. `length` stays `int` — the
     # bit count itself fits trivially. Issues #1964 (Part 2) and #4642.
+    #
+    # Implementation: loop bounded by `length`, not by the symbolic input n.
+    # The previous `while n > 0: n >>= 1` form forced ESBMC to unwind one
+    # symex iteration per bit for any symbolic n, which does not terminate
+    # without `--unwind` (issue #4756). Adding `length < 512` to the loop
+    # condition gives the unwinder a literal termination bound covering the
+    # full --ir bignum IntWide width (512-bit), and narrow callsites still
+    # exit at n == 0 well before that — incremental BMC terminates at the
+    # first k that proves the property.
     def bit_length(cls, n: IntWide) -> int:
         length: int = 0
-
-        while n > 0:
+        while length < 512 and n > 0:
             n: IntWide = n >> 1
-            length: int = length + 1  # Count how many times the number is shifted
-
+            length = length + 1
         return length

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -53,10 +53,12 @@ class int:
     # first k that proves the property.
     def bit_length(cls, n: IntWide) -> int:
         length: int = 0
-        # The literal 512 matches kPythonBignumWidth in
-        # src/python-frontend/type_handler.cpp; revisit if that constant
-        # changes or when truly unbounded ints land (#4642), otherwise
-        # bit_length will silently cap at the wrong width.
+        # Soundness: the literal 512 must be >= kPythonBitLengthCap in
+        # src/python-frontend/type_handler.cpp, which a static_assert ties
+        # to kPythonBignumWidth. The OM is FLAIL-mangled before the C++
+        # side is touched, so the literal cannot read the constant — bump
+        # both together when widening Python int (#4642). The static_assert
+        # turns a silently-wrong bit_length into a build break.
         while length < 512 and n > 0:
             n: IntWide = n >> 1
             length = length + 1

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -21,6 +21,20 @@ namespace
 // the value space is unbounded — the width here only sizes constant-fold
 // intermediates. Issue #4642.
 constexpr unsigned kPythonBignumWidth = 512;
+
+// The bit_length OM (`src/python-frontend/models/int.py`) caps its loop at
+// `length < kPythonBitLengthCap` so symex terminates without `--unwind`
+// (issue #4756). For soundness the cap must be at least
+// kPythonBignumWidth: any input representable in IntWide has bit_length
+// strictly less than kPythonBignumWidth, so the loop exits via `n == 0`
+// and never via the cap. If kPythonBignumWidth grows past the cap, the OM
+// silently underreports — bump kPythonBitLengthCap and the OM literal
+// together (the OM literal cannot read this constant; it is FLAIL-mangled
+// before the C++ side is touched).
+constexpr unsigned kPythonBitLengthCap = 512;
+static_assert(
+  kPythonBignumWidth <= kPythonBitLengthCap,
+  "bit_length OM cap (models/int.py) must cover the full Python int width");
 } // namespace
 
 unsigned type_handler::python_int_width()


### PR DESCRIPTION
The `bit_length` OM was `while n > 0: n >>= 1`. For symbolic `n` the unwinder has no termination bound and runs indefinitely without an explicit `--unwind` (87 000+ iterations reported on the issue's reproducer). Adding `length < 512` to the loop condition gives the unwinder a literal cap that covers both narrow `IntWide` (64-bit, max bit_length 63) and `--ir` bignum `IntWide` (512-bit). Narrow callsites still exit at `n == 0` well before 512; incremental BMC stops at the first k that proves the property.

Verified: the issue's reproducer now verifies SUCCESSFUL without `--unwind`. The existing `github_1964_bit_length_bignum` test (`bit_length(2**64) == 65` under `--ir --unwind 70`) continues to pass.

Fixes #4756
