### PR TITLE
[om] set/multiset: take iterator copy ctor/op= args by const ref

### DIFF
--- a/regression/esbmc-cpp/multiset/github_4758/main.cpp
+++ b/regression/esbmc-cpp/multiset/github_4758/main.cpp
@@ -1,0 +1,17 @@
+// Regression for issue #4758: std::multiset::reverse_iterator copy ctor must
+// take a const reference, otherwise copying the prvalue returned by
+// rbegin()/rend() fails to parse under --std c++14.
+#include <set>
+#include <cassert>
+
+int main()
+{
+  std::multiset<int> s;
+  for (int i = 0; i < 5; ++i)
+    s.insert(i);
+
+  int highest = *s.rbegin();
+  assert(highest == 4);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/multiset/github_4758/test.desc
+++ b/regression/esbmc-cpp/multiset/github_4758/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc --std c++14
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/set/github_4758/main.cpp
+++ b/regression/esbmc-cpp/set/github_4758/main.cpp
@@ -1,0 +1,21 @@
+// Regression for issue #4758: std::set::reverse_iterator copy ctor must take
+// a const reference, otherwise copying the prvalue returned by rbegin()/rend()
+// fails to parse under --std c++14 (where mandatory copy elision does not
+// hide the missing const).
+#include <set>
+#include <cassert>
+
+int main()
+{
+  std::set<int> s;
+  for (int i = 0; i < 5; ++i)
+    s.insert(i);
+
+  // Forces the copy ctor of reverse_iterator on the prvalue returned by
+  // rbegin(): pre-fix this fails with "candidate constructor not viable:
+  // expects an lvalue for 1st argument".
+  int highest = *s.rbegin();
+  assert(highest == 4);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/set/github_4758/test.desc
+++ b/regression/esbmc-cpp/set/github_4758/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc --std c++14
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -224,7 +224,7 @@ public:
     int pos;
     key_type *base;
 
-    reverse_iterator(reverse_iterator &i)
+    reverse_iterator(const reverse_iterator &i)
     {
       pos = i.pos;
       base = i.base;
@@ -308,7 +308,7 @@ public:
     int pos;
     key_type *base;
 
-    const_reverse_iterator(const_reverse_iterator &i)
+    const_reverse_iterator(const const_reverse_iterator &i)
     {
       pos = i.pos;
       base = i.base;
@@ -324,7 +324,7 @@ public:
     const_reverse_iterator()
     {
     }
-    const_reverse_iterator &operator=(const_reverse_iterator &i)
+    const_reverse_iterator &operator=(const const_reverse_iterator &i)
     {
       this->pos = i.pos;
       this->base = i.base;
@@ -939,7 +939,7 @@ public:
     int pos;
     key_type *base;
 
-    reverse_iterator(reverse_iterator &i)
+    reverse_iterator(const reverse_iterator &i)
     {
       pos = i.pos;
       base = i.base;
@@ -1023,7 +1023,7 @@ public:
     int pos;
     key_type *base;
 
-    const_reverse_iterator(const_reverse_iterator &i)
+    const_reverse_iterator(const const_reverse_iterator &i)
     {
       pos = i.pos;
       base = i.base;
@@ -1039,7 +1039,7 @@ public:
     const_reverse_iterator()
     {
     }
-    const_reverse_iterator &operator=(const_reverse_iterator &i)
+    const_reverse_iterator &operator=(const const_reverse_iterator &i)
     {
       this->pos = i.pos;
       this->base = i.base;


### PR DESCRIPTION
Fixes #4758.

The reverse_iterator / const_reverse_iterator copy ctors (and the const_reverse_iterator copy-assignment) in `<set>` declared their argument by non-const lvalue reference, so they could not bind to the prvalue returned by `rbegin()` / `rend()`. Code as innocuous as `int hi = *s.rbegin();` failed to parse under `--std c++14` and earlier; C++17+ mandatory copy elision happened to hide the same bug. Mirrors the pattern already used by `<vector>`, `<deque>`, and `<map>`. Adds focused regression tests for `std::set` and `std::multiset` under `--std c++14`.