### PR TITLE
[cpp] skip C++20 ConceptDecl in clang frontend converter

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4760/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4760/main.cpp
@@ -1,0 +1,57 @@
+// Regression for issue #4760: C++20 concept declarations triggered a
+// CONVERSION ERROR ("unrecognized / unimplemented clang declaration
+// Concept"). ConceptDecls have no runtime form — clang resolves the
+// constraint at template instantiation time — so the converter just
+// needs to skip the declaration, like it already does for
+// CXXDeductionGuide.
+//
+// Exercises every shape from the audit (#4377) that was blocked
+// pre-fix: bare concept, concept built on a concept, concept in a
+// requires-clause, concept as type constraint, concept on a class
+// template, and concept in if constexpr.
+#include <cassert>
+#include <type_traits>
+
+template <typename T>
+concept Integral = std::is_integral_v<T>;
+
+template <typename T>
+concept Signed = Integral<T> && std::is_signed_v<T>;
+
+template <typename T>
+requires Integral<T>
+T abs_val(T x)
+{
+  return x < 0 ? -x : x;
+}
+
+template <Signed T>
+T negate(T x)
+{
+  return -x;
+}
+
+template <Integral T>
+struct Wrapper
+{
+  T value;
+};
+
+template <typename T>
+T twice(T x)
+{
+  if constexpr (Integral<T>)
+    return x + x;
+  else
+    return x * T(2);
+}
+
+int main()
+{
+  assert(abs_val(-5) == 5);
+  assert(negate(3) == -3);
+  Wrapper<int> w{42};
+  assert(w.value == 42);
+  assert(twice(7) == 14);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4760/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4760/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc --std c++20
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -272,6 +272,10 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
   // CTAD deduction guides (C++17): clang materialises specialisations
   // through the guide, so the guide itself has no runtime form.
   case clang::Decl::CXXDeductionGuide:
+
+  // C++20 concept definitions: clang evaluates the constraint at template
+  // instantiation time, so the ConceptDecl itself has no runtime form.
+  case clang::Decl::Concept:
     break;
 
   // We pretty much ignore this information, clang does the expansion for us.


### PR DESCRIPTION
ConceptDecl carries no runtime state — clang resolves the constraint at template instantiation time — but `get_decl` was dropping it to the unrecognised-decl error path and aborting with CONVERSION ERROR. Add it to the existing skip list alongside `CXXDeductionGuide`, the C++17 compile-time-only equivalent.

Unblocks programs that use named concepts in any of the audit shapes flagged in #4377: bare concept, concept built on a concept, concept in requires-clause, concept as type constraint, concept on a class template, and concept in `if constexpr`. Regression test under `regression/esbmc-cpp/cpp/github_4760/` verifies under Bitwuzla.

Refs #4377.