### PR TITLE
[python] fix list-variable unpacking on untyped Subscript RHS (#3811)

### DIFF
--- a/regression/python/github_3811/main.py
+++ b/regression/python/github_3811/main.py
@@ -1,0 +1,22 @@
+# Regression test for issue #3811: list-variable tuple unpacking with an
+# untyped function parameter (e.g. `w, v = items[i - 1]`) used to abort the
+# conversion with `Cannot determine element type for list variable unpacking`.
+# The frontend now falls back to `any_type()` when no annotation or
+# list_type_map entry is available, matching how plain subscript reads degrade.
+
+
+def f(items):
+    w, v = items[0]
+    return int(w) + int(v)
+
+
+def g(items):
+    total = 0
+    for i in range(1, len(items) + 1):
+        w, v = items[i - 1]
+        total += int(w) + int(v)
+    return total
+
+
+assert f([[1, 2]]) == 3
+assert g([[1, 2], [3, 4]]) == 10

--- a/regression/python/github_3811/test.desc
+++ b/regression/python/github_3811/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3811_fail/main.py
+++ b/regression/python/github_3811_fail/main.py
@@ -1,0 +1,10 @@
+# Failing variant of issue #3811: ensures the conversion-time fallback does
+# not mask genuine assertion violations downstream.
+
+
+def f(items):
+    w, v = items[0]
+    return int(w) + int(v)
+
+
+assert f([[1, 2]]) == 99

--- a/regression/python/github_3811_fail/test.desc
+++ b/regression/python/github_3811_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4670,9 +4670,10 @@ void python_list::handle_list_var_unpacking(
   // Subscript whose base Name carries a list[list[T]]-style annotation.
   // Walk down the chain and peel one extra annotation layer (the unpacked
   // tuple/list is the element of the innermost subscript).
-  if (elem_type == typet() && ast_node["value"].is_object() &&
-      ast_node["value"].contains("_type") &&
-      ast_node["value"]["_type"] == "Subscript")
+  if (
+    elem_type == typet() && ast_node["value"].is_object() &&
+    ast_node["value"].contains("_type") &&
+    ast_node["value"]["_type"] == "Subscript")
   {
     size_t subscript_depth = 0;
     const nlohmann::json *cur = &ast_node["value"];
@@ -4711,8 +4712,8 @@ void python_list::handle_list_var_unpacking(
         {
           nlohmann::json synth;
           synth["annotation"] = drilled;
-          elem_type = get_elem_type_from_annotation(
-            synth, converter_.get_type_handler());
+          elem_type =
+            get_elem_type_from_annotation(synth, converter_.get_type_handler());
         }
       }
     }

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4665,9 +4665,64 @@ void python_list::handle_list_var_unpacking(
     elem_type =
       get_elem_type_from_annotation(decl, converter_.get_type_handler());
   }
+
+  // Subscript-chain fallback: e.g. `w, v = items[i-1]` where the RHS is a
+  // Subscript whose base Name carries a list[list[T]]-style annotation.
+  // Walk down the chain and peel one extra annotation layer (the unpacked
+  // tuple/list is the element of the innermost subscript).
+  if (elem_type == typet() && ast_node["value"].is_object() &&
+      ast_node["value"].contains("_type") &&
+      ast_node["value"]["_type"] == "Subscript")
+  {
+    size_t subscript_depth = 0;
+    const nlohmann::json *cur = &ast_node["value"];
+    while (cur->is_object() && cur->contains("value") &&
+           (*cur)["value"].is_object() && (*cur)["value"].contains("_type") &&
+           (*cur)["value"]["_type"] == "Subscript")
+    {
+      ++subscript_depth;
+      cur = &(*cur)["value"];
+    }
+    if (
+      cur->is_object() && cur->contains("value") &&
+      (*cur)["value"].is_object() && (*cur)["value"].contains("id") &&
+      (*cur)["value"]["id"].is_string())
+    {
+      const std::string base_name = (*cur)["value"]["id"].get<std::string>();
+      nlohmann::json base_decl = json_utils::find_var_decl(
+        base_name, converter_.current_function_name(), converter_.ast());
+      if (!base_decl.is_null() && base_decl.contains("annotation"))
+      {
+        nlohmann::json drilled = base_decl["annotation"];
+        // Peel one layer per Subscript node plus one more for the unpacked
+        // element itself.
+        for (size_t k = 0; k <= subscript_depth; ++k)
+        {
+          if (
+            !drilled.is_object() || !drilled.contains("_type") ||
+            drilled["_type"] != "Subscript" || !drilled.contains("slice"))
+          {
+            drilled = nlohmann::json();
+            break;
+          }
+          drilled = drilled["slice"];
+        }
+        if (!drilled.is_null())
+        {
+          nlohmann::json synth;
+          synth["annotation"] = drilled;
+          elem_type = get_elem_type_from_annotation(
+            synth, converter_.get_type_handler());
+        }
+      }
+    }
+  }
+
+  // Final fallback: treat elements as Any rather than aborting the conversion.
+  // Mirrors the subscript-read path which falls back to any_type() when the
+  // element type cannot be inferred (see `python_list::get_expr`).
   if (elem_type == typet())
-    throw std::runtime_error(
-      "Cannot determine element type for list variable unpacking");
+    elem_type = any_type();
 
   // Helper: find or create a variable symbol and assign an expression to it
   auto assign_to_target = [&](


### PR DESCRIPTION
`handle_list_var_unpacking` aborted conversion with `Cannot determine element type for list variable unpacking` whenever the RHS of a list-style tuple unpack was a `Subscript` on an untyped parameter (e.g. `w, v = items[i - 1]` inside `def f(items): ...`). The existing fallbacks only consulted `list_type_map` on a symbol RHS and `ast_node["value"]["id"]` annotations on a Name RHS — neither applies to a Subscript.

This patch walks the Subscript chain to the base Name, drills its annotation by `subscript_depth + 1` layers, and finally falls back to `any_type()` so conversion completes for fully untyped code, matching how plain subscript reads already degrade at `python_list.cpp:2212`.

Adds `regression/python/github_3811` (SUCCESSFUL) and `github_3811_fail` (FAILED) covering the untyped-parameter pattern from `quixbugs/knapsack`. The quixbugs knapsack test still hits a separate downstream issue (#3915) and remains `KNOWNBUG`.

Fixes #3811