### PR TITLE
[refactor] use prefix increment for iterators in hot paths

### DIFF
--- a/src/clang-c-frontend/padding.cpp
+++ b/src/clang-c-frontend/padding.cpp
@@ -162,7 +162,7 @@ static void add_padding(struct_typet &type, const namespacet &ns)
 
     for (struct_typet::componentst::iterator it = components.begin();
          it != components.end();
-         it++)
+         ++it)
     {
       bool is_bitfield = it->type().get_bool("#bitfield");
       bool is_extint = it->type().get_bool("#extint");

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -281,15 +281,15 @@ bool reachability_treet::reset_to_unexplored_state()
 void reachability_treet::go_next_state()
 {
   std::list<std::shared_ptr<execution_statet>>::iterator it = cur_state_it;
-  it++;
+  ++it;
   if (it != execution_states.end())
-    cur_state_it++;
+    ++cur_state_it;
   else
   {
     while (execution_states.size() > 0 && !step_next_state())
     {
       it = cur_state_it;
-      cur_state_it--;
+      --cur_state_it;
 
       // For the last one. Only fire the leak walker when every thread has
       // reached a terminal state — otherwise a still-running spawned thread
@@ -303,7 +303,7 @@ void reachability_treet::go_next_state()
     }
 
     if (execution_states.size() > 0)
-      cur_state_it++;
+      ++cur_state_it;
   }
 }
 

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -135,7 +135,7 @@ void goto_program_dereferencet::dereference_program(
     {
       goto_program.insert_swap(it, new_code.instructions.front());
       new_code.instructions.pop_front();
-      it++;
+      ++it;
     }
   }
 }

--- a/src/util/cpp_expr2string.cpp
+++ b/src/util/cpp_expr2string.cpp
@@ -92,7 +92,7 @@ cpp_expr2stringt::convert_struct(const exprt &src, unsigned &precedence)
       dest += tmp;
     }
 
-    o_it++;
+    ++o_it;
   }
 
   dest += " }";

--- a/src/util/fix_symbol.cpp
+++ b/src/util/fix_symbol.cpp
@@ -18,7 +18,7 @@ void fix_symbolt::fix_context(contextt &context)
 {
   for (type_mapt::const_iterator t_it = type_map.begin();
        t_it != type_map.end();
-       t_it++)
+       ++t_it)
   {
     symbolt *symb = context.find_symbol(t_it->first);
     assert(symb != nullptr);


### PR DESCRIPTION
Postfix operator++ on iterator types constructs a throwaway copy of the iterator before returning the pre-increment value; prefix avoids the copy. The eight sites changed here all discard the returned value (statement or for-loop step), so the swap is behaviour-preserving. Addresses linter findings in pointer-analysis, util, goto-symex, and clang-c-frontend.