### PR TITLE
[docs] document --k-path-coverage for Python pytest test generation (#4337)

### DIFF
--- a/regression/witnesses/test_case_generation/pytest_gen_k_path/main.py
+++ b/regression/witnesses/test_case_generation/pytest_gen_k_path/main.py
@@ -1,0 +1,16 @@
+# Regression for issue #4337: --k-path-coverage drives
+# --generate-pytest-testcase end-to-end on a Python program with
+# correlated branches. Exercises one witness per (prior-direction,
+# current-direction) combination rather than only per branch direction.
+
+
+def f(a: int, b: int) -> int:
+    x = 0
+    if a > 0:
+        x += 1
+    if b > 0:
+        x += 1
+    return x
+
+
+f(__VERIFIER_nondet_int(), __VERIFIER_nondet_int())

--- a/regression/witnesses/test_case_generation/pytest_gen_k_path/test.desc
+++ b/regression/witnesses/test_case_generation/pytest_gen_k_path/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--k-path-coverage=2 --unwind 4 --no-unwinding-assertions --generate-pytest-testcase
+^k-Path Coverage: 100%
+^Generated pytest test case with \d+ test\(s\)\: test_main\.py
+^VERIFICATION FAILED$

--- a/website/content/docs/python/pytest-testgen.md
+++ b/website/content/docs/python/pytest-testgen.md
@@ -251,6 +251,67 @@ def test_sum_of_positive_elements(dict0):
     sum_of_positive_elements(dict0)
 ```
 
+## Higher-Coverage Test Discovery with `--k-path-coverage`
+
+`--branch-coverage` only instruments one witness per branch direction, so two
+test inputs are enough to satisfy a program with two independent branches —
+even when those branches are correlated. `--k-path-coverage` instruments one
+witness per *combination* of the previous `N − 1` branch directions and the
+current direction, so the generated pytest suite exercises bounded-path
+combinations rather than only branch parity. See
+[Coverage > K-Path Coverage](../coverage#k-path-coverage) for the underlying
+metric.
+
+```python
+# example.py
+def f(a: int, b: int) -> int:
+    x = 0
+    if a > 0:
+        x += 1
+    if b > 0:
+        x += 1
+    return x
+
+f(__VERIFIER_nondet_int(), __VERIFIER_nondet_int())
+```
+
+Running with k-path coverage instead of branch coverage:
+
+```bash
+esbmc example.py --k-path-coverage=2 --unwind 4 \
+    --no-unwinding-assertions --generate-pytest-testcase
+```
+
+```
+k-Path Witnesses : 6
+Spanning Set : 4
+Reached : 4
+k-Path Coverage: 100%
+Generated pytest test case with 6 test(s): test_example.py
+```
+
+The generated file contains one parametrised case per witness — covering both
+branches for *each* combination of the prior branch outcome — rather than the
+two cases that `--branch-coverage` would emit:
+
+```python
+@pytest.mark.parametrize("a,b", [
+    (-1, 9223372036854775807),
+    (-1, -1),
+    (9223372036854775807, 9223372036854775807),
+    (9223372036854775807, -1),
+    (9223372036854775807, 0),
+    (-1, 0),
+])
+def test_f(a, b):
+    """Auto-generated test cases for f"""
+    f(a, b)
+```
+
+The witness-depth and per-function goal caps are controllable with
+`--k-path-witness-depth=D` and `--k-path-max-goals=M` respectively when
+exploring deeper paths or correlated-branch hot spots.
+
 ## Comparison with C Test Generation
 
 This feature is similar to the existing `--generate-testcase` flag for C programs, but outputs pytest-compatible Python test files instead of XML.

--- a/website/content/docs/python/usage.md
+++ b/website/content/docs/python/usage.md
@@ -34,6 +34,9 @@ esbmc main.py --unwind 10
 | `--multi-property` | Continue verification after the first failure, reporting all violated properties |
 | `--strict-types` | Enable strict type checking for function arguments at verification time |
 | `--branch-coverage` | Instrument branch-coverage properties (useful with `--generate-pytest-testcase`) |
+| `--k-path-coverage[=N]` | Instrument k-path coverage with prefix length `N` (see [Coverage](../coverage#k-path-coverage)). Use with `--generate-pytest-testcase` for higher-coverage test discovery. |
+| `--k-path-witness-depth=D` | Cap post-simplification guard depth for k-path witnesses (default 8). |
+| `--k-path-max-goals=M` | Per-function goal cap for k-path coverage (default 10000). |
 | `--generate-pytest-testcase` | Generate pytest test cases from counterexamples (see [Pytest Test Generation](./pytest-testgen)) |
 
 ## Writing Verification Harnesses


### PR DESCRIPTION
\`--k-path-coverage\` already drives \`--generate-pytest-testcase\` end-to-end for Python sources, but the Python usage and pytest-testgen pages only mention \`--branch-coverage\`. This patch:

- Adds \`--k-path-coverage[=N]\` and its \`--k-path-witness-depth\` / \`--k-path-max-goals\` knobs to the Useful Flags table in \`website/content/docs/python/usage.md\`.
- Adds a worked example to \`website/content/docs/python/pytest-testgen.md\` showing that k-path coverage generates one test per (prior-direction, current-direction) combination rather than per branch direction, with the resulting parametrised pytest output.
- Adds regression test \`regression/witnesses/test_case_generation/pytest_gen_k_path\` that exercises \`--k-path-coverage=2 --generate-pytest-testcase\` on a small two-branch Python program and asserts 100% k-path coverage plus pytest file generation.

No frontend or coverage-engine code is touched — the wiring already exists; this PR only closes the documentation and regression gap.

Fixes #4337