### PR TITLE
[cleanup] address six Codacy findings across python and C++ sources

### DIFF
--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -784,7 +784,6 @@ ibex::Function *
 expr_to_ibex_parser::create_function_from_expr2t(const expr2tc &expr)
 {
   ibex::Function *f = nullptr;
-  ibex::Function *g, *h;
 
   if (is_comp_expr(expr))
   {
@@ -801,8 +800,10 @@ expr_to_ibex_parser::create_function_from_expr2t(const expr2tc &expr)
     if (!is_arith_expr(expr))
       return nullptr;
     const expr2tc &arith_base = get_base_object(expr);
-    g = create_function_from_expr2t(*arith_base->get_sub_expr(0));
-    h = create_function_from_expr2t(*arith_base->get_sub_expr(1));
+    ibex::Function *g =
+      create_function_from_expr2t(*arith_base->get_sub_expr(0));
+    ibex::Function *h =
+      create_function_from_expr2t(*arith_base->get_sub_expr(1));
     if (g == nullptr || h == nullptr)
       return nullptr;
 
@@ -827,7 +828,7 @@ expr_to_ibex_parser::create_function_from_expr2t(const expr2tc &expr)
   }
   case expr2t::expr_ids::neg_id:
   {
-    h = create_function_from_expr2t(to_neg2t(expr).value);
+    ibex::Function *h = create_function_from_expr2t(to_neg2t(expr).value);
     if (h == nullptr)
       return nullptr;
     f = new ibex::Function(*vars, -(*h)(*vars));

--- a/src/goto2c/expr2c.cpp
+++ b/src/goto2c/expr2c.cpp
@@ -389,7 +389,8 @@ std::string expr2ct::convert_rec(
   }
 
   unsigned precedence;
-  return convert_norep((exprt &)src, precedence);
+  return convert_norep(
+    static_cast<const exprt &>(static_cast<const irept &>(src)), precedence);
 }
 
 std::string expr2ct::convert_code_printf(const codet &src, unsigned indent)
@@ -1399,7 +1400,7 @@ std::string expr2ct::convert_realloc(const exprt &src, unsigned &precedence)
 
   unsigned p0, p1;
   std::string op0 = convert(src.op0(), p0);
-  std::string size = convert((const exprt &)src.cmt_size(), p1);
+  std::string size = convert(static_cast<const exprt &>(src.cmt_size()), p1);
 
   std::string dest = "realloc";
   dest += '(';

--- a/src/python-frontend/models/collections.py
+++ b/src/python-frontend/models/collections.py
@@ -1,6 +1,6 @@
 # Operational model for collections module
 # pylint: disable=function-redefined  # intentional stdlib shadow for ESBMC models
-# pylint: disable=keyword-arg-before-vararg,unused-argument
+# pylint: disable=keyword-arg-before-vararg,unused-argument,undefined-variable
 # defaultdict's signature is pinned: callers in regression/python/
 # (e.g. github_3841_*) pass `default_factory` positionally as in
 # `defaultdict(int)`, so it must come first; and the no-arg form

--- a/src/python-frontend/parser/parser.py
+++ b/src/python-frontend/parser/parser.py
@@ -1868,8 +1868,7 @@ def _compute_output_json_path(python_filename, output_dir, module_qualname):
     if python_filename.endswith('__init__.py'):
         dir_name = os.path.basename(os.path.dirname(python_filename))
         return os.path.join(output_dir, f"{dir_name}.json")
-    return os.path.join(output_dir,
-                        f"{os.path.basename(python_filename[:-3])}.json")
+    return os.path.join(output_dir, f"{os.path.basename(python_filename[:-3])}.json")
 
 
 def generate_ast_json(tree, python_filename, elements_to_import, output_dir, module_qualname=None):

--- a/src/python-frontend/parser/parser.py
+++ b/src/python-frontend/parser/parser.py
@@ -1815,6 +1815,63 @@ def _propagate_range_aliases_across_modules(parsed_trees):
             return
 
 
+def _filter_nodes_for_import(tree, elements_to_import):
+    """Return the subset of ``tree.body`` selected by ``elements_to_import``.
+
+    Returns an empty list when no filtering applies (caller should then
+    serialise the original tree).
+    """
+    if not elements_to_import:
+        return []
+
+    explicitly_imported = {elem_info.name for elem_info in elements_to_import}
+
+    # Collect names referenced by the explicitly-imported functions/classes
+    # so transitive dependencies survive the filter.
+    referenced_names = set()
+    for node in tree.body:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef)) \
+                and node.name in explicitly_imported:
+            referenced_names.update(get_referenced_names(node))
+
+    filtered_nodes = []
+    for node in tree.body:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef)):
+            if node.name in ('ESBMC_range_has_next_', 'ESBMC_range_next_') \
+                    or node.name in explicitly_imported \
+                    or node.name in referenced_names:
+                filtered_nodes.append(node)
+        elif isinstance(node, ast.AnnAssign) \
+                and isinstance(node.target, ast.Name) \
+                and node.target.id in explicitly_imported:
+            filtered_nodes.append(node)
+        elif isinstance(node, ast.Assign):
+            # Tuple/list unpacking is treated atomically: if any bound name
+            # matches an explicit import, the whole statement survives
+            # because the unpacking is one indivisible binding (GitHub #4744).
+            bound = {n for tgt in node.targets for n in _assign_target_names(tgt)}
+            if bound & explicitly_imported:
+                filtered_nodes.append(node)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            # Preserve imports so the C++ converter can resolve calls into
+            # transitively-imported modules via the parser-attached
+            # ``full_path`` / ``module_not_found`` attributes.
+            filtered_nodes.append(node)
+    return filtered_nodes
+
+
+def _compute_output_json_path(python_filename, output_dir, module_qualname):
+    """Return the on-disk JSON output path for a parsed Python source file."""
+    if module_qualname:
+        parts = module_qualname.split(".")
+        return os.path.join(output_dir, *parts[:-1], f"{parts[-1]}.json")
+    if python_filename.endswith('__init__.py'):
+        dir_name = os.path.basename(os.path.dirname(python_filename))
+        return os.path.join(output_dir, f"{dir_name}.json")
+    return os.path.join(output_dir,
+                        f"{os.path.basename(python_filename[:-3])}.json")
+
+
 def generate_ast_json(tree, python_filename, elements_to_import, output_dir, module_qualname=None):
     """
     Generate AST JSON from the given Python AST tree.
@@ -1835,79 +1892,18 @@ def generate_ast_json(tree, python_filename, elements_to_import, output_dir, mod
         (e.g. ``pkg.sub.mod``); ``None`` means top-level module.
 
     """
-    # Remove verification-agnostic testing framework imports
     tree = import_resolver.filter_imports(tree)
+    filtered_nodes = _filter_nodes_for_import(tree, elements_to_import)
 
-    # Filter elements to be imported from the module
-    filtered_nodes = []
-    if elements_to_import is not None and elements_to_import:
-        # First pass: collect explicitly imported element names
-        explicitly_imported = {elem_info.name for elem_info in elements_to_import}
-
-        # Collect all referenced names (functions and classes) from explicitly imported functions/classes
-        referenced_names = set()
-        for node in tree.body:
-            if isinstance(node, (ast.ClassDef, ast.FunctionDef)):
-                if node.name in explicitly_imported:
-                    referenced_names.update(get_referenced_names(node))
-
-        # Second pass: include explicitly imported items and their referenced functions/classes
-        for node in tree.body:
-            if isinstance(node, (ast.ClassDef, ast.FunctionDef)):
-                # Always include ESBMC helper functions
-                if node.name in ['ESBMC_range_has_next_', 'ESBMC_range_next_']:
-                    filtered_nodes.append(node)
-                # Include explicitly imported items
-                elif node.name in explicitly_imported:
-                    filtered_nodes.append(node)
-                # Include functions/classes referenced by imported items
-                elif node.name in referenced_names:
-                    filtered_nodes.append(node)
-
-            # Include annotated assignments (e.g., x: int = 42)
-            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-                if node.target.id in explicitly_imported:
-                    filtered_nodes.append(node)
-
-            # Include plain assignments whose target binds an imported name
-            # (e.g., ``INT_BOUND = 1024`` in ``from M import f, INT_BOUND``).
-            # GitHub #4744. Tuple/list unpacking is treated atomically: if any
-            # bound name matches, the whole statement must survive because the
-            # unpacking is one indivisible binding.
-            elif isinstance(node, ast.Assign):
-                bound = {n for tgt in node.targets for n in _assign_target_names(tgt)}
-                if bound & explicitly_imported:
-                    filtered_nodes.append(node)
-
-            # Preserve Import/ImportFrom nodes: the C++ converter needs them
-            # (with the parser-attached ``full_path``/``module_not_found``
-            # attributes) to resolve calls into transitively-imported modules.
-            elif isinstance(node, (ast.Import, ast.ImportFrom)):
-                filtered_nodes.append(node)
-
-    # Convert AST to JSON
     ast_json = ast2json_func(
         ast.Module(body=filtered_nodes, type_ignores=[]) if filtered_nodes else tree)
     ast_json["filename"] = python_filename
     ast_json["ast_output_dir"] = output_dir
     _tag_bignum_constants(ast_json)
 
-    # Build JSON path
-    if module_qualname:
-        parts = module_qualname.split(".")
-        json_dir = os.path.join(output_dir, *parts[:-1])  # package subdirs
-        json_filename = os.path.join(json_dir, f"{parts[-1]}.json")
-    else:
-        if python_filename.endswith('__init__.py'):
-            dir_name = os.path.basename(os.path.dirname(python_filename))
-            json_filename = os.path.join(output_dir, f"{dir_name}.json")
-        else:
-            json_filename = os.path.join(output_dir,
-                                         f"{os.path.basename(python_filename[:-3])}.json")
-
+    json_filename = _compute_output_json_path(python_filename, output_dir, module_qualname)
     os.makedirs(os.path.dirname(json_filename), exist_ok=True)
 
-    # Write AST JSON to file
     try:
         with open(json_filename, "w", encoding="utf-8") as json_file:
             json.dump(ast_json, json_file, indent=4, ensure_ascii=False)


### PR DESCRIPTION
  - `[python]` Suppress `undefined-variable` in `models/collections.py` so the `__ESBMC_assert` intrinsic stops tripping pylint (matches the convention already used by `os.py`, `numpy.py`, `random.py`, etc.).
  - `[python]` Extract `_filter_nodes_for_import` and `_compute_output_json_path` helpers from `parser.generate_ast_json`, bringing it under the pylint `too-many-locals` (17→<15) and `too-many-branches` (18→<15) thresholds. Pure refactor — no behaviour change. 
  - `[goto-programs]` Narrow `ibex::Function *g, *h;` in `goto_contractor.cpp::create_function_from_expr2t` from function scope to the case blocks that actually use them (Codacy "scope can be reduced").
  - `[goto2c]` Replace two C-style reference casts in `expr2c.cpp` with `static_cast`: the `cmt_size()` cast now matches the established pattern in `c_expr2string.cpp:675` / `cpp_expr2string.cpp:321`; the `typet → exprt` sibling cast routes through the common `irept` base and restores the lost `const` on `src`.