### PR TITLE
[regression] promote quixbugs/gcd_fail from KNOWNBUG to CORE

### DIFF
--- a/regression/quixbugs/gcd_fail/test.desc
+++ b/regression/quixbugs/gcd_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc
+--unwind 9 --smt-during-symex --smt-symex-guard --no-standard-checks --bitwuzla
 ^VERIFICATION FAILED$


### PR DESCRIPTION
Switch from --incremental-bmc (which does not produce the expected VERIFICATION FAILED verdict on the buggy gcd's infinite recursion) to --unwind 9 with the standard sibling flag set, matching the already-converted *_fail siblings (reverse_linked_list_fail, pascal_fail, bucketsort_fail). The recursion unwinding assertion now fires and ESBMC reports VERIFICATION FAILED as expected, restoring coverage of the QuixBugs gcd defect.

Fixes #4787. Part of #4778.