### PR TITLE
[regression] promote quixbugs/depth_first_search_fail from KNOWNBUG to CORE

### DIFF
--- a/regression/quixbugs/depth_first_search_fail/test.desc
+++ b/regression/quixbugs/depth_first_search_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc
+--unwind 9 --smt-during-symex --smt-symex-guard --no-standard-checks --bitwuzla
 ^VERIFICATION FAILED$


### PR DESCRIPTION
Switch from --incremental-bmc (which crashes today with an is_array_type assertion inside intrinsic_get_object_size and so masks the test under KNOWNBUG) to --unwind 9 with the standard sibling flag set, matching the already-converted *_fail siblings (gcd_fail, reverse_linked_list_fail, pascal_fail, bucketsort_fail). ESBMC now reports VERIFICATION FAILED as expected, restoring coverage of the QuixBugs depth-first-search defect.

Note: at --unwind 9 the violation that fires is an unwinding assertion inside __memcpy_impl during Node string-copy in test1, not the buggy DFS recursion itself; the verdict still matches ^VERIFICATION FAILED$ so the test passes. A right-reason failure (DFS recursion bound) would require Python-frontend work outside the scope of this regression promotion.

Fixes #4783. Part of #4778.