### PR TITLE
[python] fix migrate-expr crashes on empty char[1] and list() ctor

### DIFF
--- a/regression/python/github_4807_empty_str_append/main.py
+++ b/regression/python/github_4807_empty_str_append/main.py
@@ -1,0 +1,29 @@
+# Regression for #4807: appending an empty string literal to a list used to
+# crash GOTO conversion with `migrate expr failed` on a malformed
+# constant{type=char*, op0=char '\0'} produced by the `char[1] -> char*`
+# in-place type rewrite in handle_list_append. The same shape was reached
+# whenever `''.join(<empty>)` returned the empty char[1] string.
+#
+# This test only checks that conversion completes and the list has the
+# expected length; element-equality semantics for empty / join-produced
+# strings are tracked separately and are not the point of this fix.
+
+def f():
+    result = []
+    result.append("")
+    return result
+
+
+def g():
+    current = []
+    out = []
+    out.append(''.join(current))  # ''.join(<empty>) used to crash on append
+    return out
+
+
+if __name__ == "__main__":
+    a = f()
+    assert len(a) == 1
+
+    b = g()
+    assert len(b) == 1

--- a/regression/python/github_4807_empty_str_append/test.desc
+++ b/regression/python/github_4807_empty_str_append/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4807_empty_str_append_fail/main.py
+++ b/regression/python/github_4807_empty_str_append_fail/main.py
@@ -1,0 +1,13 @@
+# Negative companion to github_4807_empty_str_append: the crash fix exposed
+# a real verification path, so an assertion that contradicts the result
+# must now reach the solver and fail (rather than aborting in GOTO conversion).
+
+def f():
+    result = []
+    result.append("")
+    return result
+
+
+if __name__ == "__main__":
+    a = f()
+    assert len(a) == 99  # must fail: list has exactly one element

--- a/regression/python/github_4807_empty_str_append_fail/test.desc
+++ b/regression/python/github_4807_empty_str_append_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/github_4807_list_ctor/main.py
+++ b/regression/python/github_4807_list_ctor/main.py
@@ -1,0 +1,20 @@
+# Regression for #4807: `x = list()` (zero-argument constructor) used to
+# crash GOTO conversion with `migrate expr failed` on a malformed
+# constant{type=PyListObj*} produced by the generic call builder, because
+# converter_funcall's `list(...)` dispatcher required args.size() == 1.
+# The fix lowers `list()` to the same empty `[]` literal path used elsewhere.
+
+
+def f():
+    return list()
+
+
+def g():
+    lis = list()
+    lis.append(7)
+    return lis
+
+
+if __name__ == "__main__":
+    assert f() == []
+    assert g() == [7]

--- a/regression/python/github_4807_list_ctor/test.desc
+++ b/regression/python/github_4807_list_ctor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -289,6 +289,22 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     return set_handler.get_empty_set();
   }
 
+  // list() with no args — empty list. Lower to a List literal so it routes
+  // through the well-tested `[]` path (python_list::get()).
+  if (
+    element["func"]["_type"] == "Name" && element["func"]["id"] == "list" &&
+    (!element.contains("args") || element["args"].empty()))
+  {
+    nlohmann::json list_node;
+    list_node["_type"] = "List";
+    list_node["elts"] = nlohmann::json::array();
+    for (const char *k :
+         {"lineno", "col_offset", "end_lineno", "end_col_offset"})
+      if (element.contains(k))
+        list_node[k] = element[k];
+    return get_expr(list_node);
+  }
+
   // Handle list(...) calls
   if (
     element["func"]["_type"] == "Name" && element["func"]["id"] == "list" &&

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -1751,12 +1751,19 @@ exprt function_call_expr::handle_list_append() const
     value_to_append = symbol_expr(tmp_var);
   }
 
+  // Treat a single-element char array (`char[1]`) as a `char *` for storage
+  // semantics — list elements of string type are stored as pointer values
+  // (see build_push_list_call). The in-place type rewrite is safe for a
+  // symbol-expr value (a real variable whose storage decays to char*), but
+  // would corrupt a constant char[1] expression: rewriting the type produces
+  // a malformed `constant{type=char *, op0=char '\0'}` that crashes
+  // migrate_expr at GOTO-program generation (#4807). Keep constants on the
+  // generic array path; build_push_list_call then takes their address.
   if (
-    value_to_append.type().is_array() &&
+    !value_to_append.is_constant() && value_to_append.type().is_array() &&
     value_to_append.type().subtype() == char_type())
   {
     const array_typet &array_type = to_array_type(value_to_append.type());
-    // Only convert single-element char arrays (string literals)
     if (array_type.size().is_constant())
     {
       const constant_exprt &size_const = to_constant_expr(array_type.size());


### PR DESCRIPTION
Fix two GOTO-generation crashes that abort ESBMC with `migrate expr failed`
on legal Python code. Both surfaced in the #4807 humaneval umbrella:
`humaneval_1`, `humaneval_1-1`, `humaneval_67`. They are now reduced to
real verification failures (loop-bound / encoding) rather than crashes,
and stay `KNOWNBUG` for the residual reasons.

1. `result.append("")` and `result.append("".join(<empty>))`:
   `handle_list_append` rewrote a `char[1]` value's type to `char*` in
   place, producing a malformed `constant{type=char*, op0=char '\0'}`
   for constant values. Guard the rewrite on non-constant values; constants
   take the generic array path.
2. `x = list()` (zero-arg ctor): `converter_funcall` only matched
   `list(iterable)` with `args.size()==1`; the no-arg form fell through and
   the generic call builder emitted a malformed `constant{type=PyListObj*}`.
   Lower `list()` to a `List` literal, mirroring `frozenset()`.

Refs #4807.
