### PR TITLE
[python] nondet bool fallback for unresolvable comparisons

### DIFF
--- a/regression/python/github_4807_cmp_pointer_mixed_nondet/main.py
+++ b/regression/python/github_4807_cmp_pointer_mixed_nondet/main.py
@@ -1,0 +1,25 @@
+# Regression for #4807: the pointer-vs-non-pointer arm of the comparison
+# guard used to abort when one operand was inferred as pointer-backed
+# (e.g. a variable rebound from int to list in the same scope) and the
+# other wasn't. The handler now returns a sound nondet bool fallback so
+# GOTO conversion proceeds.
+#
+# Minimal pattern: a parameter `n` is compared with `0` and then later
+# reassigned to a list -- the frontend infers a list (pointer) type at
+# the comparison site. Previously this aborted with "pointer-backed and
+# non-pointer". This test only checks that conversion completes; the
+# nondet result is unconstrained by design.
+
+
+def digits_sum(n):
+    if n < 0:                                # was abort -- now nondet bool
+        n, _neg = -1 * n, -1
+    n = [int(i) for i in "12"]
+    n[0] = n[0]
+    return sum(n)
+
+
+if __name__ == "__main__":
+    # Never actually call digits_sum -- the test exercises the conversion
+    # of its body. Absence of an abort during conversion is the assertion.
+    pass

--- a/regression/python/github_4807_cmp_pointer_mixed_nondet/test.desc
+++ b/regression/python/github_4807_cmp_pointer_mixed_nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4807_cmp_unresolved_nondet/main.py
+++ b/regression/python/github_4807_cmp_unresolved_nondet/main.py
@@ -1,0 +1,21 @@
+# Regression for #4807: relational ops over operands of unresolved type
+# (e.g. the result of an undispatched `tuple(<list>)` call) used to abort
+# GOTO conversion with "Unsupported comparison with unresolved operand
+# type". The handler now returns a sound nondet bool fallback, so GOTO
+# conversion succeeds and verification proceeds against the symbolic
+# comparison result.
+#
+# This test exercises the conversion path itself -- evaluating the
+# comparison must no longer abort. The nondet bool value is intentionally
+# not asserted on (its outcome is unconstrained); a separate _fail test
+# pins the unconstrained behaviour.
+
+
+if __name__ == "__main__":
+    a = tuple([1, 2, 3])
+    b = tuple([1, 2, 3])
+    # Previously aborted; now lowers to a nondet bool. Bind to a name so
+    # the comparison expression is actually emitted in GOTO.
+    cmp_result = (a == b)
+    # No assertion on cmp_result: this test only checks that conversion
+    # completed and the program has no other VCCs that would fail.

--- a/regression/python/github_4807_cmp_unresolved_nondet/test.desc
+++ b/regression/python/github_4807_cmp_unresolved_nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4807_cmp_unresolved_nondet_fail/main.py
+++ b/regression/python/github_4807_cmp_unresolved_nondet_fail/main.py
@@ -1,0 +1,11 @@
+# Negative companion to github_4807_cmp_unresolved_nondet: under the nondet
+# fallback the solver can pick the comparison result freely, so an assertion
+# that forces a specific outcome reaches VERIFICATION FAILED instead of the
+# old hard abort. This demonstrates the fallback is unconstrained (not
+# accidentally folded to a constant).
+
+
+if __name__ == "__main__":
+    a = tuple([1, 2, 3])
+    b = tuple([1, 2, 3])
+    assert a == b  # nondet bool -- may be false -- must fail

--- a/regression/python/github_4807_cmp_unresolved_nondet_fail/test.desc
+++ b/regression/python/github_4807_cmp_unresolved_nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/quixbugs/kheapsort_fail/test.desc
+++ b/regression/quixbugs/kheapsort_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -701,26 +701,38 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     const bool lhs_invalid = lhs.type().is_empty() || lhs.type().is_nil();
     const bool rhs_invalid = rhs.type().is_empty() || rhs.type().is_nil();
     locationt loc = get_location_from_decl(element);
+
+    // Sound over-approximation when the comparison cannot be lowered to a
+    // typed binop: either an operand's type is unresolvable, or one side is
+    // a pointer-backed value (e.g. a list/dict variable that has been
+    // reassigned across incompatible types in the same scope) and the
+    // other isn't. Aborting here loses an entire verification run for what
+    // is often a frontend type-inference gap, not a real soundness issue;
+    // returning nondet bool lets symbolic execution explore both outcomes
+    // and keeps safety verification sound (we cannot conclude SAFE when
+    // the real comparison would fail). See #4807.
+    auto nondet_comparison = [&](const char *reason) {
+      log_debug(
+        "python-binop",
+        "{} at {}:{} -- falling back to nondet bool",
+        reason,
+        loc.is_nil() ? std::string("<unknown>") : loc.get_file().as_string(),
+        loc.is_nil() ? std::string("?") : loc.get_line().as_string());
+      side_effect_expr_nondett nondet(bool_type());
+      nondet.location() = loc;
+      return nondet;
+    };
+
     if (lhs_invalid || rhs_invalid)
-    {
-      std::ostringstream msg;
-      msg << "Unsupported comparison with unresolved operand type";
-      if (!loc.is_nil())
-        msg << " at " << loc.get_file() << ":" << loc.get_line();
-      throw std::runtime_error(msg.str());
-    }
+      return nondet_comparison(
+        "unsupported comparison with unresolved operand type");
 
     const bool lhs_ptr = lhs.type().is_pointer();
     const bool rhs_ptr = rhs.type().is_pointer();
     if (lhs_ptr != rhs_ptr)
-    {
-      std::ostringstream msg;
-      msg << "Unsupported comparison between pointer-backed and non-pointer "
-             "values";
-      if (!loc.is_nil())
-        msg << " at " << loc.get_file() << ":" << loc.get_line();
-      throw std::runtime_error(msg.str());
-    }
+      return nondet_comparison(
+        "unsupported comparison between pointer-backed and non-pointer "
+        "values");
   }
 
   // Build the binary expression


### PR DESCRIPTION
Replace two `throw std::runtime_error` aborts in the Python relational-op
handler with a sound `side_effect_expr_nondett(bool_type())` fallback:

1. **Unresolved operand type** — one or both sides have `nil`/`empty`
   type, typically because an upstream call (e.g. `tuple(<list>)`) has
   no dispatcher and returns a type-less expression.
2. **Pointer-backed vs non-pointer** — the frontend's whole-function
   type inference has merged incompatible reassignments to the same
   name (e.g. `n` rebound from int to list inside the same scope), so
   the inferred type at a `n < 0` site is a pointer while the other
   side is an int.

Both cases were aborting GOTO conversion for what is, on the verifier's
end, a frontend type-inference gap, not a real soundness issue.

The fallback returns a fresh nondet bool — symbolic execution explores
both outcomes, which is sound for safety properties.

## Results

All 5 humaneval tests stop crashing on the comparison error:

| Test | Before | After |
|---|---|---|
| humaneval_33 (tuple==tuple) | CRASH | VFAILED (downstream nondet outcome; stays KNOWNBUG) |
| humaneval_37 (tuple==tuple) | CRASH | VFAILED (same) |
| humaneval_108 (n<0 pointer-mixed) | CRASH | shifts to a separate "str() expects string" abort |
| humaneval_145 (n<0 pointer-mixed) | CRASH | same as _108 |
| humaneval_151 (n<0 pointer-mixed) | CRASH | same as _108 |

## Tests

Three new regression cases under `regression/python/`:

- `github_4807_cmp_unresolved_nondet` — `tuple([...]) == tuple([...])`,
  conversion succeeds, no assertion on the nondet result; SUCCESSFUL
- `github_4807_cmp_unresolved_nondet_fail` — same setup, but asserts the
  nondet equality; must reach FAILED (proves the fallback is unconstrained)
- `github_4807_cmp_pointer_mixed_nondet` — function body with the
  `n<0` pattern, body convert without crash; SUCCESSFUL

Full `regression/python/(binop|relational|comparison|github_3127|github_4807|string-|list-|tuple|dict)` (633 tests) passes locally with no regressions.

Refs #4807.
