### PR TITLE
[python] nondet fallback for second batch of str.*() methods

### DIFF
--- a/regression/python/github_4807_str_methods_nondet_fallback2/main.py
+++ b/regression/python/github_4807_str_methods_nondet_fallback2/main.py
@@ -1,0 +1,56 @@
+# Regression for #4807: a second batch of str.*() methods that previously
+# aborted GOTO conversion with "X() requires constant string" on a non-
+# constant receiver. The handlers now fall back to a sound symbolic value
+# via string_handler::build_nondet_string_fallback (string-returning) or
+# side_effect_expr_nondett(bool_type()) (predicate-returning), so the
+# function bodies convert and verification proceeds.
+#
+# Methods covered here: removeprefix, removesuffix, isnumeric, isidentifier,
+# center, ljust, rjust, zfill, expandtabs.
+#
+# Each wrapper takes a non-constant parameter and exercises one method. The
+# call sites are not asserted on — the test only proves that conversion
+# completes without aborting, which is the regression this PR closes.
+
+
+def f_removeprefix(s: str, p: str) -> str:
+    return s.removeprefix(p)
+
+
+def f_removesuffix(s: str, x: str) -> str:
+    return s.removesuffix(x)
+
+
+def f_isnumeric(s: str) -> bool:
+    return s.isnumeric()
+
+
+def f_isidentifier(s: str) -> bool:
+    return s.isidentifier()
+
+
+def f_center(s: str, w: int) -> str:
+    return s.center(w)
+
+
+def f_ljust(s: str, w: int) -> str:
+    return s.ljust(w)
+
+
+def f_rjust(s: str, w: int) -> str:
+    return s.rjust(w)
+
+
+def f_zfill(s: str, w: int) -> str:
+    return s.zfill(w)
+
+
+def f_expandtabs(s: str) -> str:
+    return s.expandtabs(4)
+
+
+if __name__ == "__main__":
+    # No call sites: the function bodies above are emitted into GOTO and
+    # previously aborted conversion. Successful conversion + zero VCCs ==
+    # verification succeeds.
+    pass

--- a/regression/python/github_4807_str_methods_nondet_fallback2/test.desc
+++ b/regression/python/github_4807_str_methods_nondet_fallback2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4807_str_methods_nondet_fallback2_fail/main.py
+++ b/regression/python/github_4807_str_methods_nondet_fallback2_fail/main.py
@@ -1,0 +1,16 @@
+# Negative companion to github_4807_str_methods_nondet_fallback2: prove the
+# nondet fallback is genuinely unconstrained -- an assertion pinning the
+# isidentifier() result against a non-constant receiver must fail under at
+# least one model the solver picks.
+
+
+def f_isidentifier(s: str) -> bool:
+    return s.isidentifier()
+
+
+if __name__ == "__main__":
+    # Pre-#4807 batch 2: this aborted GOTO conversion. Now: conversion
+    # completes, isidentifier(s) is a nondet bool, and the assertion below
+    # can be falsified -- so VERIFICATION FAILED is the expected verdict.
+    s = "abc"
+    assert f_isidentifier(s)

--- a/regression/python/github_4807_str_methods_nondet_fallback2_fail/test.desc
+++ b/regression/python/github_4807_str_methods_nondet_fallback2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -299,6 +299,18 @@ bool string_handler::try_extract_const_string_expr(
   return false;
 }
 
+exprt string_handler::build_nondet_string_fallback(const locationt &location)
+{
+  // Bare nondet `char *`. Used as a sound over-approximation when a
+  // str.*() handler cannot extract a compile-time constant receiver.
+  // Subsequent string ops over this value see arbitrary content, which
+  // preserves soundness for safety properties (we cannot conclude a
+  // specific functional result, but we cannot wrongly conclude SAFE).
+  side_effect_expr_nondett nondet(gen_pointer_type(char_type()));
+  nondet.location() = location;
+  return nondet;
+}
+
 BigInt string_handler::get_string_size(const exprt &expr)
 {
   if (!expr.type().is_array())

--- a/src/python-frontend/string/string_handler.h
+++ b/src/python-frontend/string/string_handler.h
@@ -734,6 +734,19 @@ private:
   bool try_extract_const_string_expr(const exprt &expr, std::string &out);
 
   /**
+   * @brief Build a sound symbolic fallback for a `char *` string value when
+   *        a str.*() handler cannot compile-time-fold its receiver.
+   *
+   * Replaces the historical `throw "X() requires constant string"` aborts so
+   * that GOTO conversion can proceed. Returns a `side_effect_expr_nondett`
+   * of pointer-to-char type; subsequent string ops see arbitrary content,
+   * which is sound over-approximation for safety properties (we cannot
+   * conclude a specific functional result, but we cannot wrongly conclude
+   * SAFE either).
+   */
+  exprt build_nondet_string_fallback(const locationt &location);
+
+  /**
    * @brief Create a character array expression
    * @param chars Character data
    * @param type Array type

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -2184,7 +2184,10 @@ exprt string_handler::handle_string_removeprefix(
     !try_extract_const_string_expr(string_obj, input) ||
     !try_extract_const_string_expr(prefix_arg, prefix))
   {
-    throw std::runtime_error("removeprefix() requires constant strings");
+    log_debug(
+      "python-string",
+      "removeprefix() on non-constant receiver/prefix: nondet string");
+    return build_nondet_string_fallback(location);
   }
 
   if (!prefix.empty() && input.rfind(prefix, 0) == 0)
@@ -2209,7 +2212,10 @@ exprt string_handler::handle_string_removesuffix(
     !try_extract_const_string_expr(string_obj, input) ||
     !try_extract_const_string_expr(suffix_arg, suffix))
   {
-    throw std::runtime_error("removesuffix() requires constant strings");
+    log_debug(
+      "python-string",
+      "removesuffix() on non-constant receiver/suffix: nondet string");
+    return build_nondet_string_fallback(location);
   }
 
   if (
@@ -2477,11 +2483,17 @@ exprt string_handler::handle_string_isupper(
 
 exprt string_handler::handle_string_isnumeric(
   const exprt &string_obj,
-  [[maybe_unused]] const locationt &location)
+  const locationt &location)
 {
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
-    throw std::runtime_error("isnumeric() requires constant string");
+  {
+    log_debug(
+      "python-string", "isnumeric() on non-constant receiver: nondet bool");
+    side_effect_expr_nondett nondet(bool_type());
+    nondet.location() = location;
+    return nondet;
+  }
   if (input.empty())
     return from_integer(0, bool_type());
 
@@ -2495,11 +2507,17 @@ exprt string_handler::handle_string_isnumeric(
 
 exprt string_handler::handle_string_isidentifier(
   const exprt &string_obj,
-  [[maybe_unused]] const locationt &location)
+  const locationt &location)
 {
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
-    throw std::runtime_error("isidentifier() requires constant string");
+  {
+    log_debug(
+      "python-string", "isidentifier() on non-constant receiver: nondet bool");
+    side_effect_expr_nondett nondet(bool_type());
+    nondet.location() = location;
+    return nondet;
+  }
   if (input.empty())
     return from_integer(0, bool_type());
 
@@ -2523,13 +2541,20 @@ exprt string_handler::handle_string_center(
 {
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
-    throw std::runtime_error("center() requires constant string");
+  {
+    log_debug(
+      "python-string", "center() on non-constant receiver: nondet string");
+    return build_nondet_string_fallback(location);
+  }
   if (!string_builder_)
     throw std::runtime_error("string_builder not set for center()");
 
   long long width = 0;
   if (!get_constant_int(width_arg, width))
-    throw std::runtime_error("center() requires constant width");
+  {
+    log_debug("python-string", "center() on non-constant width: nondet string");
+    return build_nondet_string_fallback(location);
+  }
 
   char fill = ' ';
   if (!fill_arg.is_nil())
@@ -2567,13 +2592,20 @@ exprt string_handler::handle_string_ljust(
 {
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
-    throw std::runtime_error("ljust() requires constant string");
+  {
+    log_debug(
+      "python-string", "ljust() on non-constant receiver: nondet string");
+    return build_nondet_string_fallback(location);
+  }
   if (!string_builder_)
     throw std::runtime_error("string_builder not set for ljust()");
 
   long long width = 0;
   if (!get_constant_int(width_arg, width))
-    throw std::runtime_error("ljust() requires constant width");
+  {
+    log_debug("python-string", "ljust() on non-constant width: nondet string");
+    return build_nondet_string_fallback(location);
+  }
 
   char fill = ' ';
   if (!fill_arg.is_nil())
@@ -2606,13 +2638,20 @@ exprt string_handler::handle_string_rjust(
 {
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
-    throw std::runtime_error("rjust() requires constant string");
+  {
+    log_debug(
+      "python-string", "rjust() on non-constant receiver: nondet string");
+    return build_nondet_string_fallback(location);
+  }
   if (!string_builder_)
     throw std::runtime_error("string_builder not set for rjust()");
 
   long long width = 0;
   if (!get_constant_int(width_arg, width))
-    throw std::runtime_error("rjust() requires constant width");
+  {
+    log_debug("python-string", "rjust() on non-constant width: nondet string");
+    return build_nondet_string_fallback(location);
+  }
 
   char fill = ' ';
   if (!fill_arg.is_nil())
@@ -2644,13 +2683,20 @@ exprt string_handler::handle_string_zfill(
 {
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
-    throw std::runtime_error("zfill() requires constant string");
+  {
+    log_debug(
+      "python-string", "zfill() on non-constant receiver: nondet string");
+    return build_nondet_string_fallback(location);
+  }
   if (!string_builder_)
     throw std::runtime_error("string_builder not set for zfill()");
 
   long long width = 0;
   if (!get_constant_int(width_arg, width))
-    throw std::runtime_error("zfill() requires constant width");
+  {
+    log_debug("python-string", "zfill() on non-constant width: nondet string");
+    return build_nondet_string_fallback(location);
+  }
 
   if (width <= static_cast<long long>(input.size()))
     return string_builder_->build_string_literal(input);
@@ -2681,7 +2727,11 @@ exprt string_handler::handle_string_expandtabs(
 {
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
-    throw std::runtime_error("expandtabs() requires constant string");
+  {
+    log_debug(
+      "python-string", "expandtabs() on non-constant receiver: nondet string");
+    return build_nondet_string_fallback(location);
+  }
   if (!string_builder_)
     throw std::runtime_error("string_builder not set for expandtabs()");
 


### PR DESCRIPTION
Second batch of `X() requires constant string` aborts retired from the
Python frontend, following the same nondet-fallback strategy as #4811.

## Handlers patched

| Method | Fallback shape |
|---|---|
| `removeprefix`, `removesuffix` | nondet `char *` |
| `isnumeric`, `isidentifier` | nondet `bool` |
| `center`, `ljust`, `rjust` | nondet `char *` (both receiver and width arg) |
| `zfill` | nondet `char *` (both receiver and width arg) |
| `expandtabs` | nondet `char *` |

Sound over-approximation for safety properties; specific functional
results are not preserved. Tests with constant-arg call sites still need
a corresponding `python_consteval` extension to actually fold the call
(out of scope here; #4811 covered the previous batch).

Also adds `string_handler::build_nondet_string_fallback` -- the same
helper introduced in #4811. When both PRs merge the duplicate
definition resolves trivially in favour of either copy.

## Tests

Two regression cases under `regression/python/`:

- `github_4807_str_methods_nondet_fallback2` -- each method wrapped in a
  parameterised function whose body must convert without aborting;
  SUCCESSFUL (no asserts, conversion completion is the regression).
- `github_4807_str_methods_nondet_fallback2_fail` -- pins an
  `isidentifier()` result against a non-constant receiver to confirm
  the fallback is genuinely unconstrained; FAILED.

Full `regression/python/(string-|github_4807|github_3127)` (371 tests)
passes locally with no regressions. clang-format 11 clean.

Refs #4807.
