### PR TITLE
[python] defer tuple-return type inference for non-constant elements

### DIFF
--- a/regression/python/github_4807_tuple_return_locals/main.py
+++ b/regression/python/github_4807_tuple_return_locals/main.py
@@ -1,0 +1,27 @@
+# Regression for #4807: returning a tuple whose elements reference
+# function-local variables used to abort GOTO conversion with
+# "Variable 'X' is not defined". The cause was that
+# infer_return_type_from_body ran *before* the function body was
+# processed, but tuple_handler->get_tuple_expr eagerly called get_expr
+# on each element; for a local-var Name the symbol wasn't in the
+# table yet, so get_expr aborted.
+#
+# The fix restricts the pre-body tuple inference to all-Constant
+# tuples and defers the rest to the post-body second-pass inference.
+
+
+def f():
+    a = 5
+    b = 7
+    return (a, b)
+
+
+def g(x):
+    p = x + 1
+    q = x * 2
+    return (p, q)
+
+
+if __name__ == "__main__":
+    assert f() == (5, 7)
+    assert g(3) == (4, 6)

--- a/regression/python/github_4807_tuple_return_locals/test.desc
+++ b/regression/python/github_4807_tuple_return_locals/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4807_tuple_return_locals_fail/main.py
+++ b/regression/python/github_4807_tuple_return_locals_fail/main.py
@@ -1,0 +1,14 @@
+# Negative companion to github_4807_tuple_return_locals: the fix lets
+# the function body emit so an assertion that contradicts the actual
+# tuple value reaches the solver and fails (rather than aborting in
+# conversion).
+
+
+def f():
+    a = 5
+    b = 7
+    return (a, b)
+
+
+if __name__ == "__main__":
+    assert f() == (1, 2)  # must fail: actual return is (5, 7)

--- a/regression/python/github_4807_tuple_return_locals_fail/test.desc
+++ b/regression/python/github_4807_tuple_return_locals_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -766,9 +766,35 @@ typet python_converter::infer_return_type_from_body(const nlohmann::json &body)
         ret_val["id"] == "self" && !current_class_name_.empty())
         return type_handler_.get_typet(current_class_name_);
 
-      // If returning a tuple, infer its type
+      // If returning a tuple, infer its type. This routine runs twice:
+      // once before function body conversion (so return statements can
+      // be typed in the right context), and once afterwards.
+      // tuple_handler evaluates each element via get_expr, which aborts
+      // on a Name that refers to a function-local variable not yet
+      // declared in the symbol table. Restrict the pre-body call to
+      // tuples whose elements are all Constants (or otherwise
+      // resolvable without symbol lookup); for tuples containing
+      // locals, leave the return type empty and let the post-body
+      // second pass infer it. See #4807.
       if (ret_val["_type"] == "Tuple")
-        return tuple_handler_->get_tuple_expr(ret_val).type();
+      {
+        bool all_constant = true;
+        if (ret_val.contains("elts") && ret_val["elts"].is_array())
+        {
+          for (const auto &elt : ret_val["elts"])
+          {
+            if (!elt.contains("_type") || elt["_type"] != "Constant")
+            {
+              all_constant = false;
+              break;
+            }
+          }
+        }
+        if (all_constant)
+          return tuple_handler_->get_tuple_expr(ret_val).type();
+        // Fall through -- post-body inference will pick up the real
+        // type once the local symbols have been declared.
+      }
 
       // Constant returns (including strings)
       if (ret_val["_type"] == "Constant" && ret_val.contains("value"))


### PR DESCRIPTION
Fixes 3 of the 4 "Variable not defined" aborts in the #4807 humaneval
bucket. Root cause: `infer_return_type_from_body` runs twice during a
function def -- once before the body is processed (so return
expressions can be typed in context) and once afterwards. For a
`return (a, b)` whose tuple elements are function-local Names, the
pre-body call invoked `tuple_handler::get_tuple_expr`, which calls
`get_expr` on each element; the local symbols aren't in the table
yet, so `get_expr` aborted with `"Variable 'X' is not defined in
function 'F'"`.

Restrict the pre-body tuple inference to all-Constant tuples and
defer the rest to the post-body second pass.

## Outcome

| Test | Before | After |
|---|---|---|
| `humaneval_107` (`return (even_palindrome_count, odd_palindrome_count)`) | CRASH | VFAILED (residual, stays KNOWNBUG) |
| `humaneval_136` (`return (max(smallest) if smallest else None, ...)`) | CRASH | VFAILED (residual) |
| `humaneval_155` (`return (even_count, odd_count)`) | CRASH | VFAILED (residual) |
| `humaneval_32` (`assert math.fabs(poly(coeffs, solution)) < 1e-4`) | CRASH | still CRASH — `coeffs` and `solution` are genuinely undefined in the test source (CPython would raise NameError); not the bug fixed here |

## Tests

Two regression cases under `regression/python/`:

- `github_4807_tuple_return_locals` -- two functions returning tuples
  of locals; assertions pin the actual values; SUCCESSFUL.
- `github_4807_tuple_return_locals_fail` -- same shape with a
  contradictory expected tuple; FAILED.

Full `regression/python/(tuple|string-|github_4807|github_3127)` (398
tests) passes locally with no regressions. clang-format 11 clean.

Refs #4807.
