### PR TITLE
[python] add runtime operational model for str.count

### DIFF
--- a/regression/python/python_str_count_runtime_model/main.py
+++ b/regression/python/python_str_count_runtime_model/main.py
@@ -1,0 +1,32 @@
+# Runtime operational model for str.count.
+#
+# Before this change, handle_string_count required both the receiver and
+# the needle to be compile-time constant strings; non-constant arguments
+# fell back to a nondet int (precise but useless) or, before the
+# nondet-fallback PRs, aborted GOTO conversion entirely.
+#
+# __python_str_count(const char*, const char*) -- added to
+# src/c2goto/library/python/string.c -- is a bounded operational model
+# of str.count. The handler dispatches to it whenever both operands are
+# addressable strings and start/end are at default. Symex then folds
+# the call when concrete values flow in (as it does for all C library
+# calls), and explores symbolically when they don't.
+#
+# This test pins exact-value assertions through a parameterised wrapper
+# -- the only way they hold is if the runtime model actually computes
+# the count rather than returning a nondet value.
+
+
+def count_in(s: str, sub: str) -> int:
+    return s.count(sub)
+
+
+if __name__ == "__main__":
+    # Receiver and needle are parameters; previously aborted/nondet.
+    # Now: handler emits __python_str_count(s, sub); symex folds with
+    # the concrete call-site arguments.
+    assert count_in("hello", "l") == 2
+    assert count_in("abcabc", "ab") == 2
+    assert count_in("xxx", "y") == 0
+    assert count_in("aaaa", "aa") == 2     # non-overlapping
+    assert count_in("hello", "") == 6      # empty needle: len(s)+1

--- a/regression/python/python_str_count_runtime_model/test.desc
+++ b/regression/python/python_str_count_runtime_model/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 30 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_str_count_runtime_model_fail/main.py
+++ b/regression/python/python_str_count_runtime_model_fail/main.py
@@ -1,0 +1,12 @@
+# Negative companion: pin the runtime model's actual semantics. A wrong
+# expected count must reach the solver and fail rather than spuriously
+# succeed (which is what would happen if the handler quietly returned
+# nondet again).
+
+
+def count_in(s: str, sub: str) -> int:
+    return s.count(sub)
+
+
+if __name__ == "__main__":
+    assert count_in("hello", "l") == 99  # actual is 2; must fail

--- a/regression/python/python_str_count_runtime_model_fail/test.desc
+++ b/regression/python/python_str_count_runtime_model_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 30 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -204,6 +204,7 @@ const static std::vector<std::string> python_c_models = {
   "__python_str_rfind_range",
   "__python_str_replace",
   "__python_str_split",
+  "__python_str_count",
   "__ESBMC_create_inf_obj",
   "__python_int",
   "__python_chr",

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -501,6 +501,46 @@ __ESBMC_HIDE:;
   return buffer;
 }
 
+// Python string count - count non-overlapping occurrences of `sub` in `s`.
+// Matches the Python semantics: empty `sub` returns len(s) + 1 (counts
+// gaps including before-first and after-last). Bounded to 256 chars on
+// the receiver to keep the symbolic loop tractable for BMC; longer
+// strings trip an explicit assertion rather than silently truncating.
+size_t __python_str_count(const char *s, const char *sub)
+{
+__ESBMC_HIDE:;
+  if (!s || !sub)
+    return 0;
+
+  size_t s_len = __python_strnlen_bounded(s, 256);
+  size_t sub_len = __python_strnlen_bounded(sub, 256);
+
+  if (sub_len == 0)
+    return s_len + 1;
+
+  if (sub_len > s_len)
+    return 0;
+
+  size_t count = 0;
+  size_t i = 0;
+  while (i + sub_len <= s_len)
+  {
+    size_t j = 0;
+    while (j < sub_len && s[i + j] == sub[j])
+      j++;
+    if (j == sub_len)
+    {
+      count++;
+      i += sub_len;
+    }
+    else
+    {
+      i++;
+    }
+  }
+  return count;
+}
+
 int __python_str_find(const char *s1, const char *s2)
 {
 __ESBMC_HIDE:;

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -2137,10 +2137,39 @@ exprt string_handler::handle_string_count(
 {
   std::string input;
   std::string sub;
-  if (
-    !try_extract_const_string_expr(string_obj, input) ||
-    !try_extract_const_string_expr(sub_arg, sub))
+  const bool input_const = try_extract_const_string_expr(string_obj, input);
+  const bool sub_const = try_extract_const_string_expr(sub_arg, sub);
+  if (!input_const || !sub_const)
   {
+    // Prefer the runtime operational model __python_str_count when
+    // start/end are at default (the model doesn't yet handle Python's
+    // slice arguments). Symex's own constant propagation can fold the
+    // call when concrete values flow in, so this is more precise than
+    // a blanket nondet -- and on truly symbolic inputs the result is
+    // a real symbolic count rather than an unconstrained nondet.
+    if (start_arg.is_nil() && end_arg.is_nil())
+    {
+      const symbolt *count_sym =
+        find_cached_c_function_symbol("c:@F@__python_str_count");
+      if (count_sym)
+      {
+        exprt s_copy = string_obj;
+        exprt s_expr = ensure_null_terminated_string(s_copy);
+        exprt s_addr = get_array_base_address(s_expr);
+
+        exprt sub_copy = sub_arg;
+        exprt sub_expr = ensure_null_terminated_string(sub_copy);
+        exprt sub_addr = get_array_base_address(sub_expr);
+
+        side_effect_expr_function_callt call;
+        call.function() = symbol_expr(*count_sym);
+        call.arguments().push_back(s_addr);
+        call.arguments().push_back(sub_addr);
+        call.location() = location;
+        call.type() = size_type();
+        return call;
+      }
+    }
     log_debug(
       "python-string", "count() on non-constant receiver/needle: nondet int");
     side_effect_expr_nondett nondet(long_long_int_type());


### PR DESCRIPTION
Add `__python_str_count(const char *, const char *)` in `src/c2goto/library/python/string.c` — a bounded (256-char) non-overlapping substring counter matching Python's `str.count` semantics (empty needle returns `len(s)+1`). `handle_string_count` now dispatches to this model whenever the receiver/needle aren't both compile-time constant strings and `start`/`end` are at default, so concrete call-site arguments fold via symex's existing constant propagation and symbolic inputs get a real symbolic count instead of the previous unconstrained nondet.

This moves const-prop to the correct layer (symex) and keeps soundness on symbolic inputs while improving precision on concrete ones. Adds positive (`python_str_count_runtime_model`) and negative (`_fail`) regression tests. Refs #4807; relates to #4817.
