### PR TITLE
[python] runtime operational model for str.isupper

### DIFF
--- a/regression/python/python_str_isupper_runtime_model/main.py
+++ b/regression/python/python_str_isupper_runtime_model/main.py
@@ -1,0 +1,28 @@
+# Runtime operational model for str.isupper.
+#
+# Before this change, handle_string_isupper required the receiver to be
+# a compile-time constant; non-constant receivers fell back to a nondet
+# bool (precise but useless for proving anything).
+#
+# __python_str_isupper(const char *) -- added to
+# src/c2goto/library/python/string.c -- is a bounded predicate that
+# mirrors __python_str_islower with the cases swapped. The handler now
+# dispatches to it for non-constant receivers; symex's existing CP
+# folds the call on concrete arguments.
+#
+# Pins exact-value assertions through a parameterised wrapper -- only
+# pass if the model actually computes the predicate.
+
+
+def is_upper(s: str) -> bool:
+    return s.isupper()
+
+
+if __name__ == "__main__":
+    assert is_upper("HELLO") == True
+    assert is_upper("Hello") == False
+    assert is_upper("hello") == False
+    assert is_upper("ABC") == True
+    assert is_upper("") == False          # Python: empty -> False
+    assert is_upper("123") == False       # no cased chars
+    assert is_upper("ABC123") == True     # cased chars all upper

--- a/regression/python/python_str_isupper_runtime_model/test.desc
+++ b/regression/python/python_str_isupper_runtime_model/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 10 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_str_isupper_runtime_model_fail/main.py
+++ b/regression/python/python_str_isupper_runtime_model_fail/main.py
@@ -1,0 +1,12 @@
+# Negative companion: pin the runtime model's actual semantics. A wrong
+# expected predicate must reach the solver and fail rather than
+# spuriously succeed (which would happen if the handler quietly
+# returned nondet).
+
+
+def is_upper(s: str) -> bool:
+    return s.isupper()
+
+
+if __name__ == "__main__":
+    assert is_upper("hello") == True  # actually False; must fail

--- a/regression/python/python_str_isupper_runtime_model_fail/test.desc
+++ b/regression/python/python_str_isupper_runtime_model_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 10 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -194,6 +194,7 @@ const static std::vector<std::string> python_c_models = {
   "__python_str_strip_chars",
   "__python_char_islower",
   "__python_str_islower",
+  "__python_str_isupper",
   "__python_char_lower",
   "__python_str_lower",
   "__python_char_upper",

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -417,6 +417,45 @@ __ESBMC_HIDE:;
   return has_cased;
 }
 
+// Python string isupper - true iff every cased character is uppercase
+// and there is at least one cased character. Mirrors __python_str_islower
+// with the cases swapped; UTF-8 continuation bytes after a 0xC2..0xDF
+// lead are treated as cased (best-effort Latin-1 supplement coverage).
+_Bool __python_str_isupper(const char *s)
+{
+__ESBMC_HIDE:;
+  if (!s || !*s)
+    return 0;
+
+  _Bool has_cased = 0;
+
+  while (*s)
+  {
+    unsigned char c = (unsigned char)*s;
+
+    if (c >= 'a' && c <= 'z')
+      return 0;
+
+    if (c >= 'A' && c <= 'Z')
+      has_cased = 1;
+
+    if (c >= 0xC2 && c <= 0xDF)
+    {
+      unsigned char next = (unsigned char)*(s + 1);
+      if (next >= 0x80 && next <= 0xBF)
+      {
+        has_cased = 1;
+        s += 2;
+        continue;
+      }
+    }
+
+    s++;
+  }
+
+  return has_cased;
+}
+
 // Python character lower - converts a single character to lowercase
 int __python_char_lower(int c)
 {

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -2568,6 +2568,25 @@ exprt string_handler::handle_string_isupper(
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
   {
+    // Prefer the runtime operational model __python_str_isupper when
+    // available -- symex's CP folds the call when concrete values flow
+    // in, and otherwise produces a real symbolic predicate rather than
+    // an unconstrained nondet bool.
+    const symbolt *isupper_sym =
+      find_cached_c_function_symbol("c:@F@__python_str_isupper");
+    if (isupper_sym)
+    {
+      exprt s_copy = string_obj;
+      exprt s_expr = ensure_null_terminated_string(s_copy);
+      exprt s_addr = get_array_base_address(s_expr);
+
+      side_effect_expr_function_callt call;
+      call.function() = symbol_expr(*isupper_sym);
+      call.arguments().push_back(s_addr);
+      call.location() = location;
+      call.type() = bool_type();
+      return call;
+    }
     log_debug(
       "python-string", "isupper() on non-constant receiver: nondet bool");
     side_effect_expr_nondett nondet(bool_type());


### PR DESCRIPTION
Second runtime operational model following the pattern established in
PR #4818 (str.count).

## What it does

Adds `__python_str_isupper(const char *)` in
`src/c2goto/library/python/string.c` -- mirrors `__python_str_islower`
with the cases swapped. Returns true iff every cased character is
uppercase AND at least one cased character is present, matching
Python's semantics (empty string -> False, all-digits -> False).

`handle_string_isupper` now dispatches to the runtime model when the
receiver isn't a compile-time constant, replacing the nondet bool
fallback. Concrete call-site arguments fold via symex's existing
constant propagation; symbolic inputs get a real symbolic predicate.

## Outcome

| Test | Before | After |
|---|---|---|
| `humaneval_95` | CRASH on `key.isupper()` | VFAILED (conversion now succeeds; residual failure is the dict iteration's `isinstance`/comparison encoding -- separate work) |
| Parameterised `is_upper(s)` wrapper with concrete args | nondet (assertions unreliable) | exact values fold |

## Tests

- `python_str_isupper_runtime_model` -- seven exact-value assertions
  through a wrapper. Only pass if the model actually computes the
  predicate. SUCCESSFUL.
- `python_str_isupper_runtime_model_fail` -- contradictory predicate.
  Must FAILED (proves the model isn't quietly nondet).

Full `regression/python/(string-|github_4807|github_3127|python_)`
(380 tests) passes locally with no regressions. clang-format 11
clean.

Refs #4807. Same approach as #4818.
