### PR TITLE
[python] runtime operational model for str.isalnum

### DIFF
--- a/regression/python/python_str_isalnum_runtime_model/main.py
+++ b/regression/python/python_str_isalnum_runtime_model/main.py
@@ -1,0 +1,29 @@
+# Runtime operational model for str.isalnum.
+#
+# Before this change, handle_string_isalnum required a compile-time
+# constant receiver; non-constant receivers fell back to a nondet bool
+# (useless for proving anything specific).
+#
+# __python_str_isalnum(const char *) -- added to
+# src/c2goto/library/python/string.c -- is a bounded ASCII predicate
+# that returns True iff the string is non-empty and every character is
+# a letter or digit. Matches Python's behaviour on the ASCII subset;
+# broader Unicode coverage is deliberately out of scope, consistent
+# with the existing isalpha/isdigit/isspace models.
+#
+# Pins exact-value assertions through a parameterised wrapper -- only
+# pass if the model actually computes the predicate.
+
+
+def is_alnum(s: str) -> bool:
+    return s.isalnum()
+
+
+if __name__ == "__main__":
+    assert is_alnum("abc123") == True
+    assert is_alnum("ABC") == True
+    assert is_alnum("123") == True
+    assert is_alnum("abc 123") == False   # space breaks it
+    assert is_alnum("") == False          # Python: empty -> False
+    assert is_alnum("hello!") == False    # punctuation
+    assert is_alnum("_var") == False      # underscore is NOT alnum

--- a/regression/python/python_str_isalnum_runtime_model/test.desc
+++ b/regression/python/python_str_isalnum_runtime_model/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 10 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_str_isalnum_runtime_model_fail/main.py
+++ b/regression/python/python_str_isalnum_runtime_model_fail/main.py
@@ -1,0 +1,12 @@
+# Negative companion: pin the runtime model's actual semantics. A
+# wrong expected predicate must reach the solver and fail rather than
+# spuriously succeed (which would happen if the handler quietly
+# returned nondet).
+
+
+def is_alnum(s: str) -> bool:
+    return s.isalnum()
+
+
+if __name__ == "__main__":
+    assert is_alnum("hello!") == True  # actually False; must fail

--- a/regression/python/python_str_isalnum_runtime_model_fail/test.desc
+++ b/regression/python/python_str_isalnum_runtime_model_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 10 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -184,6 +184,7 @@ const static std::vector<std::string> python_c_models = {
   "__python_char_isdigit",
   "__python_str_isalpha",
   "__python_char_isalpha",
+  "__python_str_isalnum",
   "__python_str_isspace",
   "isspace",
   "__python_str_lstrip",

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -113,6 +113,28 @@ __ESBMC_HIDE:;
   return 1;
 }
 
+// Python string isalnum - true iff the string is non-empty and every
+// character is a letter (ASCII A-Z / a-z) or a digit (0-9). Matches
+// Python's CPython behaviour on the ASCII subset; broader Unicode
+// category coverage is deliberately out of scope (consistent with the
+// existing isalpha/isdigit/isspace models in this file).
+_Bool __python_str_isalnum(const char *s)
+{
+__ESBMC_HIDE:;
+  if (!s || !*s)
+    return 0;
+
+  while (*s)
+  {
+    unsigned char c = (unsigned char)*s;
+    if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+          (c >= '0' && c <= '9')))
+      return 0;
+    s++;
+  }
+  return 1;
+}
+
 // Python string isspace: checks if all characters are whitespace
 _Bool __python_str_isspace(const char *s)
 {

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -2544,6 +2544,25 @@ exprt string_handler::handle_string_isalnum(
   std::string input;
   if (!try_extract_const_string_expr(string_obj, input))
   {
+    // Prefer the runtime operational model __python_str_isalnum when
+    // available -- symex's CP folds the call on concrete arguments
+    // and otherwise produces a real symbolic predicate rather than
+    // an unconstrained nondet bool.
+    const symbolt *isalnum_sym =
+      find_cached_c_function_symbol("c:@F@__python_str_isalnum");
+    if (isalnum_sym)
+    {
+      exprt s_copy = string_obj;
+      exprt s_expr = ensure_null_terminated_string(s_copy);
+      exprt s_addr = get_array_base_address(s_expr);
+
+      side_effect_expr_function_callt call;
+      call.function() = symbol_expr(*isalnum_sym);
+      call.arguments().push_back(s_addr);
+      call.location() = location;
+      call.type() = bool_type();
+      return call;
+    }
     log_debug(
       "python-string", "isalnum() on non-constant receiver: nondet bool");
     side_effect_expr_nondett nondet(bool_type());


### PR DESCRIPTION
Third runtime operational model following the pattern from
#4818 (`str.count`) and #4821 (`str.isupper`).

## What it does

Adds `__python_str_isalnum(const char *)` in
`src/c2goto/library/python/string.c` -- bounded ASCII predicate that
returns true iff the string is non-empty and every character is a
letter (`A-Z` / `a-z`) or a digit (`0-9`). Matches Python's behaviour
on the ASCII subset; broader Unicode coverage is deliberately out of
scope, consistent with the existing `isalpha` / `isdigit` / `isspace`
models in the same file.

`handle_string_isalnum` now dispatches to the runtime model for
non-constant receivers, replacing the nondet bool fallback.
Concrete call-site arguments fold via symex's existing constant
propagation; symbolic inputs get a real symbolic predicate.

## Tests

- `python_str_isalnum_runtime_model` -- seven exact-value assertions
  through a parameterised `is_alnum(s)` wrapper. Covers the alpha,
  digit, mixed, empty, space, punctuation, and underscore cases.
  Only pass if the model actually computes the predicate. SUCCESSFUL.
- `python_str_isalnum_runtime_model_fail` -- contradictory expected
  predicate; must FAILED (proves the model isn't silently nondet).

Full `regression/python/(string-|github_4807|github_3127|python_)`
(380 tests) passes locally with no regressions. clang-format 11 clean.

Refs #4807. Same approach as #4818 and #4821.
