### PR TITLE
[clang-c-frontend] use prefix increment for iterator in add_padding loop

### DIFF
--- a/src/clang-c-frontend/padding.cpp
+++ b/src/clang-c-frontend/padding.cpp
@@ -225,7 +225,7 @@ static void add_padding(struct_typet &type, const namespacet &ns)
 
   for (struct_typet::componentst::iterator it = components.begin();
        it != components.end();
-       it++)
+       ++it)
   {
     const typet it_type = it->type();
     BigInt a = 1;


### PR DESCRIPTION
struct_typet::componentst::iterator is a non-primitive type; the postfix it++ constructs a discarded copy each iteration. Switch to ++it, matching the surrounding code and silencing a Codacy MEDIUM performance finding on padding.cpp:228.