### PR TITLE
[python] prefer local binding over imported module on attribute access

### DIFF
--- a/regression/python/import_shadowed_by_param/main.py
+++ b/regression/python/import_shadowed_by_param/main.py
@@ -1,0 +1,10 @@
+from node import Node
+
+
+def get_value(node):
+    return node.value
+
+
+head = Node(42)
+
+assert get_value(head) == 42

--- a/regression/python/import_shadowed_by_param/node.py
+++ b/regression/python/import_shadowed_by_param/node.py
@@ -1,0 +1,4 @@
+class Node:
+    def __init__(self, value):
+        self.value = value
+        self.successor = None

--- a/regression/python/import_shadowed_by_param/test.desc
+++ b/regression/python/import_shadowed_by_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import_shadowed_by_param_fail/main.py
+++ b/regression/python/import_shadowed_by_param_fail/main.py
@@ -1,0 +1,10 @@
+from node import Node
+
+
+def get_value(node):
+    return node.value
+
+
+head = Node(42)
+
+assert get_value(head) == 0

--- a/regression/python/import_shadowed_by_param_fail/node.py
+++ b/regression/python/import_shadowed_by_param_fail/node.py
@@ -1,0 +1,4 @@
+class Node:
+    def __init__(self, value):
+        self.value = value
+        self.successor = None

--- a/regression/python/import_shadowed_by_param_fail/test.desc
+++ b/regression/python/import_shadowed_by_param_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/quixbugs/breadth_first_search/node.py
+++ b/regression/quixbugs/breadth_first_search/node.py
@@ -6,13 +6,3 @@ class Node:
         self.predecessors = predecessors
         self.incoming_nodes = incoming_nodes
         self.outgoing_nodes = outgoing_nodes
-
-    def successor(self):
-        return self.successor
-
-    def successors(self):
-        return self.successors
-
-    def predecessors(self):
-        return self.predecessors
-

--- a/regression/quixbugs/depth_first_search/node.py
+++ b/regression/quixbugs/depth_first_search/node.py
@@ -6,13 +6,3 @@ class Node:
         self.predecessors = predecessors
         self.incoming_nodes = incoming_nodes
         self.outgoing_nodes = outgoing_nodes
-
-    def successor(self):
-        return self.successor
-
-    def successors(self):
-        return self.successors
-
-    def predecessors(self):
-        return self.predecessors
-

--- a/regression/quixbugs/detect_cycle/node.py
+++ b/regression/quixbugs/detect_cycle/node.py
@@ -6,13 +6,3 @@ class Node:
         self.predecessors = predecessors
         self.incoming_nodes = incoming_nodes
         self.outgoing_nodes = outgoing_nodes
-
-    def successor(self):
-        return self.successor
-
-    def successors(self):
-        return self.successors
-
-    def predecessors(self):
-        return self.predecessors
-

--- a/regression/quixbugs/reverse_linked_list/node.py
+++ b/regression/quixbugs/reverse_linked_list/node.py
@@ -6,13 +6,3 @@ class Node:
         self.predecessors = predecessors
         self.incoming_nodes = incoming_nodes
         self.outgoing_nodes = outgoing_nodes
-
-    def successor(self):
-        return self.successor
-
-    def successors(self):
-        return self.successors
-
-    def predecessors(self):
-        return self.predecessors
-

--- a/regression/quixbugs/shortest_path_length/node.py
+++ b/regression/quixbugs/shortest_path_length/node.py
@@ -6,13 +6,3 @@ class Node:
         self.predecessors = predecessors
         self.incoming_nodes = incoming_nodes
         self.outgoing_nodes = outgoing_nodes
-
-    def successor(self):
-        return self.successor
-
-    def successors(self):
-        return self.successors
-
-    def predecessors(self):
-        return self.predecessors
-

--- a/regression/quixbugs/topological_ordering/node.py
+++ b/regression/quixbugs/topological_ordering/node.py
@@ -6,13 +6,3 @@ class Node:
         self.predecessors = predecessors
         self.incoming_nodes = incoming_nodes
         self.outgoing_nodes = outgoing_nodes
-
-    def successor(self):
-        return self.successor
-
-    def successors(self):
-        return self.successors
-
-    def predecessors(self):
-        return self.predecessors
-

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -536,8 +536,25 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         abort();
       }
 
-      // Handle module attribute access (e.g., math.inf)
-      if (is_imported_module(var_name))
+      // Handle module attribute access (e.g., math.inf) — unless the module
+      // name is shadowed by a local binding in the current scope (e.g. a
+      // parameter named `node` when `from node import Node` is in scope).
+      // Python's scoping rules give precedence to the local binding.
+      auto name_has_local_binding = [&](const std::string &name) {
+        symbol_id sid = create_symbol_id();
+        sid.set_object(name);
+        if (find_symbol(sid.to_string()))
+          return true;
+        if (!current_func_name_.empty())
+        {
+          sid.set_function("");
+          if (find_symbol(sid.to_string()))
+            return true;
+        }
+        return false;
+      };
+
+      if (is_imported_module(var_name) && !name_has_local_binding(var_name))
       {
         std::string attr_name = element["attr"].get<std::string>();
         std::string module_path = imported_modules[var_name];


### PR DESCRIPTION
## Summary
The Python frontend mis-resolved `name.attr` as a module-member lookup whenever `name` matched an imported module, even when the local scope had shadowed it (e.g. `def f(node): return node.value` with `from node import Node` in scope). The converter now checks for a local-symbol binding before taking the module branch, matching Python's LEGB rule. Same patch drops six copies of a buggy `node.py` in `regression/quixbugs/` whose same-named methods and attributes recurse infinitely.

This is a precondition for unblocking the umbrella issue #4778 (quixbugs KNOWNBUG tests). No KNOWNBUG tags flip in this PR — each affected test hits a further downstream bug — but two new positive/negative regression tests pin the scoping fix in isolation.

## Test plan
- [x] `ctest -R import_shadowed --output-on-failure` (both new tests pass)
- [x] `ctest -L python -E regression/quixbugs` (no new regressions; only pre-existing Boolector-build failures)
- [x] `scripts/check_python_tests.sh import_shadowed` (CPython sanity on both variants)
- [x] clang-format clean (Clang 11)
