### PR TITLE
[pointer-analysis] give dereference target_flags distinct non-zero bits

### DIFF
--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -865,18 +865,21 @@ void dereferencet::deref_invalid_ptr(
 
 enum target_flags
 {
-  flag_src_scalar = 0,
-  flag_src_array = 1,
-  flag_src_struct = 2,
-  flag_src_union = 3,
+  // Each src/dst category and offset kind is a distinct bit so the case
+  // labels in build_reference_rec encode every combination uniquely, and
+  // never collapse to the same integer (which used to happen when several
+  // flags were defined as 0).
+  flag_src_scalar = 0x01,
+  flag_src_array = 0x02,
+  flag_src_struct = 0x04,
+  flag_src_union = 0x08,
 
-  flag_dst_scalar = 0,
-  flag_dst_array = 4,
-  flag_dst_struct = 8,
-  flag_dst_union = 0xC,
+  flag_dst_scalar = 0x10,
+  flag_dst_struct = 0x20,
+  flag_dst_union = 0x40,
 
-  flag_is_const_offs = 0x10,
-  flag_is_dyn_offs = 0,
+  flag_is_const_offs = 0x80,
+  flag_is_dyn_offs = 0x100,
 };
 
 /*
@@ -948,6 +951,8 @@ void dereferencet::build_reference_rec(
   int flags = 0;
   if (is_constant_int2t(offset))
     flags |= flag_is_const_offs;
+  else
+    flags |= flag_is_dyn_offs;
 
   // All accesses to code need no further construction
   if (is_code_type(value) || is_code_type(type))


### PR DESCRIPTION
flag_src_scalar, flag_dst_scalar and flag_is_dyn_offs were all defined as 0, which made every case label in build_reference_rec's switch contain duplicate operands in its '|' chain. Re-encode every flag as a distinct non-zero bit so each label collapses to a unique integer, and add an explicit else-branch to set flag_is_dyn_offs (previously implicit via the zero default). Removes the unused flag_dst_array constant. Behaviour preserved: the {src, dst, offset} tuple still maps to the same case arm, validated by the deref/pointer/union/struct regression subset (338 tests) and the floats label (145 tests).

Fixes Codacy HIGH duplicate-expression warnings on dereference.cpp:1004, 1067, 1071, 1076, 1081, 1094, 1117.