### PR TITLE
[goto2c] drop redundant scope_syms_stack.back().size() > 0 check

### DIFF
--- a/src/goto2c/goto2c_preprocess.cpp
+++ b/src/goto2c/goto2c_preprocess.cpp
@@ -349,7 +349,7 @@ void goto2ct::assign_scope_ids(goto_programt &goto_program)
         // to the list of scopes and clear the current scope.
         // Otherwise, just continue.
         // !!! Also probably need to check whether it == instructions.rend()
-        if (std::next(it)->type != DEAD && scope_syms_stack.back().size() > 0)
+        if (std::next(it)->type != DEAD)
         {
           scope_syms_stack.push_back({});
         }


### PR DESCRIPTION
push_back on the same vector immediately precedes the size check, so size() > 0 is always true. Fixes a Codacy HIGH warning in goto2c_preprocess.cpp:352.