### PR TITLE
[goto-programs] mark w_guardst single-arg constructor explicit

### DIFF
--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -9,7 +9,7 @@
 class w_guardst
 {
 public:
-  w_guardst(contextt &_context) : context(_context)
+  explicit w_guardst(contextt &_context) : context(_context)
   {
   }
 


### PR DESCRIPTION
Prevents accidental implicit conversion from contextt& to w_guardst. Fixes a Codacy HIGH warning in add_race_assertions.cpp:12.