### PR TITLE
[python] guard lhs_symbol before dereference in local_loads check

### DIFF
--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1494,13 +1494,16 @@ void python_converter::get_var_assign(
     }
 
     // Check for uninitialized usage
-    for (std::string &s : local_loads)
+    if (lhs_symbol)
     {
-      if (lhs_symbol->id.as_string() == s)
+      for (std::string &s : local_loads)
       {
-        throw std::runtime_error(
-          "Variable " + sid.get_object() + " in function " +
-          current_func_name_ + " is uninitialized.");
+        if (lhs_symbol->id.as_string() == s)
+        {
+          throw std::runtime_error(
+            "Variable " + sid.get_object() + " in function " +
+            current_func_name_ + " is uninitialized.");
+        }
       }
     }
 


### PR DESCRIPTION
lhs_symbol may legitimately be null after symbol creation (every other use in the same block treats it as nullable), so the uninitialized-usage loop must guard the dereference. Fixes a Codacy HIGH null-deref warning in converter_stmt.cpp:1499.