### PR TITLE
[python] handle nested tuple targets in for ... in d.items()

### DIFF
--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1119,12 +1119,8 @@ class LoopMixin:
         target = node.target
         body = []
         if isinstance(target, (ast.Tuple, ast.List)) and len(target.elts) == 2:
-            key_var_name = target.elts[0].id
-            val_var_name = target.elts[1].id
-            body.append(
-                self._create_var_subscript_assign(node, key_var_name, keys_var, index_var, key_ann))
-            body.append(
-                self._create_var_subscript_assign(node, val_var_name, vals_var, index_var, val_ann))
+            self._emit_items_unpack(node, body, target.elts[0], keys_var, index_var, key_ann)
+            self._emit_items_unpack(node, body, target.elts[1], vals_var, index_var, val_ann)
         else:
             # Single variable: d.items() yields (key, value) tuples per Python semantics.
             single_var = self._name_id_or_none(target) or "ESBMC_loop_var"
@@ -1332,6 +1328,34 @@ class LoopMixin:
         )
         self.ensure_all_locations(assign, node)
         return assign
+
+    def _emit_items_unpack(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+            self, node, body, target_elt, list_var, index_var, elem_ann):
+        """Append the assignment that binds the i-th key/value of d.items() to ``target_elt``.
+
+        Simple Name target — emits ``name: elem_ann = list_var[index_var]``.
+        Tuple/List target (nested unpacking, e.g. ``for (u, v), w in d.items():``) —
+        emits a destructuring Assign ``target_elt = list_var[index_var]`` so the
+        converter's normal tuple-unpacking-from-subscript path handles it.
+        """
+        name = self._name_id_or_none(target_elt)
+        if name is not None:
+            body.append(
+                self._create_var_subscript_assign(node, name, list_var, index_var, elem_ann))
+            return
+
+        subscript = ast.Subscript(
+            value=ast.Name(id=list_var, ctx=ast.Load()),
+            slice=ast.Name(id=index_var, ctx=ast.Load()),
+            ctx=ast.Load(),
+        )
+        self.ensure_all_locations(subscript, node)
+        unpack = ast.Assign(
+            targets=[target_elt],
+            value=subscript,
+        )
+        self.ensure_all_locations(unpack, node)
+        body.append(unpack)
 
     def _create_dict_size_assertion(self, node, keys_var, length_var):
         """Create dict-size check to detect mutation during iteration."""

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1340,8 +1340,8 @@ class LoopMixin:
         """
         name = self._name_id_or_none(target_elt)
         if name is not None:
-            body.append(
-                self._create_var_subscript_assign(node, name, list_var, index_var, elem_ann))
+            body.append(self._create_var_subscript_assign(node, name, list_var, index_var,
+                                                          elem_ann))
             return
 
         subscript = ast.Subscript(


### PR DESCRIPTION
## Summary
`_transform_items_for` in `loop_mixin.py` accessed `target.elts[0].id` and `target.elts[1].id` directly when rewriting `for k, v in d.items():`, assuming each side of the unpacking was a plain `Name`. Loops with a nested target like `for (u, v), w in d.items():` (used by `regression/quixbugs/shortest_paths`) instead crashed in the preprocessor with `AttributeError: 'Tuple' object has no attribute 'id'`. Route the simple Name case and the Tuple/List case through one helper so nested patterns become a destructuring assignment that the converter handles via its normal tuple-unpacking path.

This unblocks the preprocessor for nested-tuple targets and turns the previous Python AttributeError stack trace into a clean ESBMC diagnostic when downstream limits are reached. Doesn't yet flip any quixbugs KNOWNBUG by itself — `shortest_paths` now hits a separate dict-comprehension limit after the preprocessor crash is gone — but it removes one stacked failure from the umbrella #4778 set.

## Test plan
- [x] `ctest -L python -E regression/quixbugs --timeout 120` — no regressions (only pre-existing Boolector-unavailable and slow-test timeouts unrelated to this change)
- [x] Manual: `for k, v in d.items():` (existing form) still verifies — `regression/python/dict63` passes
- [x] Manual: `for (u, v), w in d.items():` no longer crashes with `AttributeError`; reports a clear ESBMC limitation message instead
