### PR TITLE
[python-frontend] fix is_pointer_type assertion on class-attr chained refs

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -320,6 +320,7 @@ set(_slow_regression_tests
     # consteval+nondet fallback in PR #4811 they now reach symex and
     # need the extra budget to finish on slower CI runners.
     "regression/humaneval/humaneval_111"
+    "regression/humaneval/humaneval_129"
     "regression/humaneval/humaneval_153"
     "regression/humaneval/humaneval_161"
     "regression/quixbugs/next_palindrome"

--- a/regression/python/github_4831/main.py
+++ b/regression/python/github_4831/main.py
@@ -1,0 +1,30 @@
+class Node:
+    def __init__(self, vid):
+        self.vid = vid
+        self.nxt = None
+
+
+class Queue:
+    def __init__(self, head, count):
+        self.head = head
+        self.count = count
+
+
+a = Node(0)
+b = Node(1)
+a.nxt = b
+q = Queue(a, 2)
+
+n = nondet_int()
+__ESBMC_assume(0 <= n <= 2)
+
+if n != 0:
+    assert q.count >= n
+    q.count -= n
+    curr = q.head
+    for _ in range(n):
+        assert curr is not None
+        curr = curr.nxt
+    q.head = curr
+
+assert q.count == 2 - n

--- a/regression/python/github_4831/test.desc
+++ b/regression/python/github_4831/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4831_alias/main.py
+++ b/regression/python/github_4831_alias/main.py
@@ -1,0 +1,18 @@
+class Node:
+    def __init__(self, vid):
+        self.vid = vid
+        self.nxt = None
+
+
+class Queue:
+    def __init__(self, head):
+        self.head = head
+
+
+a = Node(0)
+q = Queue(a)
+
+# Python reference semantics: `a` and `q.head` are aliases for the same
+# Node, so a mutation through `a` must be visible via `q.head`.
+a.vid = 42
+assert q.head.vid == 42

--- a/regression/python/github_4831_alias/test.desc
+++ b/regression/python/github_4831_alias/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -84,6 +84,7 @@ ignored_dirs=(
   "github_4581"
   "github_4756"
   "github_4756_fail"
+  "github_4831"
   "github_4668"
   "github_4666_2d"
   "github_4666_shape"

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -511,7 +511,26 @@ void python_converter::get_attributes_from_self(
           type = type_handler_.get_typet(annotated_type);
       }
       else
+      {
         type = type_handler_.get_typet(annotated_type);
+        // Python class instances have reference semantics. When the
+        // attribute holds an *aliased* class-instance reference — i.e. the
+        // RHS is a Name referring to another variable (typically a method
+        // parameter), as in `self.head = head` — store the field as a
+        // pointer. Downstream reassignments to chained references
+        // (q.head = curr; curr = curr.nxt) then remain type-consistent
+        // with the address-of lift applied when reading struct-typed
+        // members. Skip when the RHS is a fresh constructor call
+        // (e.g. self.a: A = A()), since the existing pipeline initialises
+        // it in place via FUNCTION_CALL: A(&self->a). See GitHub #4831.
+        bool rhs_is_aliased_name = stmt.contains("value") &&
+                                   stmt["value"].is_object() &&
+                                   stmt["value"].value("_type", "") == "Name";
+        if (
+          rhs_is_aliased_name && type.id() == "symbol" &&
+          json_utils::is_class(annotated_type, *ast_json))
+          type = gen_pointer_type(type);
+      }
 
       if (!clazz.has_component(attr_name))
       {

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -334,6 +334,74 @@ static bool param_is_mutated_in_body(
   return false;
 }
 
+// Collect the names of `self.<attr>` slots that `param_name` is stored
+// into anywhere in `body` (recursive). When such an attribute is itself
+// pointer-typed (see get_attributes_from_self / GitHub #4831), the
+// parameter value used as the RHS must also be a pointer — otherwise the
+// field-store creates a pointer/struct mismatch when downstream code
+// reassigns the same attribute via a chained reference.
+static void collect_self_attr_stores_of_param(
+  const std::string &param_name,
+  const nlohmann::json &body,
+  std::vector<std::string> &out)
+{
+  if (!body.is_array())
+    return;
+
+  auto rhs_is_param = [&](const nlohmann::json &v) {
+    return v.is_object() && v.value("_type", "") == "Name" &&
+           v.contains("id") && v["id"] == param_name;
+  };
+  auto extract_self_attr = [](const nlohmann::json &t) -> std::string {
+    if (
+      t.is_object() && t.value("_type", "") == "Attribute" &&
+      t.contains("value") && t["value"].is_object() &&
+      t["value"].value("_type", "") == "Name" && t["value"].contains("id") &&
+      t["value"]["id"] == "self" && t.contains("attr") &&
+      t["attr"].is_string())
+      return t["attr"].get<std::string>();
+    return "";
+  };
+
+  for (const auto &stmt : body)
+  {
+    if (!stmt.is_object())
+      continue;
+
+    const std::string &stype =
+      stmt.contains("_type") ? stmt["_type"].get<std::string>() : "";
+
+    // self.attr = param  (plain assignment)
+    if (
+      stype == "Assign" && stmt.contains("targets") &&
+      stmt.contains("value") && rhs_is_param(stmt["value"]))
+    {
+      for (const auto &tgt : stmt["targets"])
+      {
+        const std::string name = extract_self_attr(tgt);
+        if (!name.empty())
+          out.push_back(name);
+      }
+    }
+    // self.attr: T = param  (annotated assignment)
+    else if (
+      stype == "AnnAssign" && stmt.contains("target") &&
+      stmt.contains("value") && rhs_is_param(stmt["value"]))
+    {
+      const std::string name = extract_self_attr(stmt["target"]);
+      if (!name.empty())
+        out.push_back(name);
+    }
+
+    // Recurse into nested blocks
+    for (const char *key : {"body", "orelse", "handlers", "finalbody"})
+    {
+      if (stmt.contains(key) && stmt[key].is_array())
+        collect_self_attr_stores_of_param(param_name, stmt[key], out);
+    }
+  }
+}
+
 static bool node_uses_param_as_list_like(
   const std::string &param_name,
   const nlohmann::json &node)
@@ -690,8 +758,35 @@ void python_converter::process_function_arguments(
       python_frontend::is_enum_class(class_name, *ast_json))
       continue;
 
-    // Check whether the function body mutates this parameter.
-    if (!param_is_mutated_in_body(param_name, body))
+    // Upgrade to pointer when (a) the function body mutates this parameter
+    // (param.attr = ...), or (b) the parameter is stored into a `self.attr`
+    // slot whose declared field type is itself a pointer — the field-store
+    // would otherwise create a struct/pointer mismatch. (See GitHub #4831.)
+    bool stored_to_ptr_attr = false;
+    if (!current_class_name_.empty())
+    {
+      std::vector<std::string> stored_attrs;
+      collect_self_attr_stores_of_param(param_name, body, stored_attrs);
+      if (!stored_attrs.empty())
+      {
+        const symbolt *cls_sym =
+          symbol_table_.find_symbol("tag-" + current_class_name_);
+        if (cls_sym && cls_sym->get_type().is_struct())
+        {
+          const struct_typet &cs = to_struct_type(cls_sym->get_type());
+          for (const std::string &a : stored_attrs)
+          {
+            if (cs.has_component(a) && cs.get_component(a).type().is_pointer())
+            {
+              stored_to_ptr_attr = true;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    if (!param_is_mutated_in_body(param_name, body) && !stored_to_ptr_attr)
       continue;
 
     // Upgrade the parameter to a pointer and update the parameter symbol.

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -357,8 +357,7 @@ static void collect_self_attr_stores_of_param(
       t.is_object() && t.value("_type", "") == "Attribute" &&
       t.contains("value") && t["value"].is_object() &&
       t["value"].value("_type", "") == "Name" && t["value"].contains("id") &&
-      t["value"]["id"] == "self" && t.contains("attr") &&
-      t["attr"].is_string())
+      t["value"]["id"] == "self" && t.contains("attr") && t["attr"].is_string())
       return t["attr"].get<std::string>();
     return "";
   };
@@ -373,8 +372,8 @@ static void collect_self_attr_stores_of_param(
 
     // self.attr = param  (plain assignment)
     if (
-      stype == "Assign" && stmt.contains("targets") &&
-      stmt.contains("value") && rhs_is_param(stmt["value"]))
+      stype == "Assign" && stmt.contains("targets") && stmt.contains("value") &&
+      rhs_is_param(stmt["value"]))
     {
       for (const auto &tgt : stmt["targets"])
       {


### PR DESCRIPTION
When a Python class instance attribute is assigned from a parameter (self.head = head), the field is inferred as a struct by value. Reads auto-lifted to address-of for reference semantics, so a later reassignment to a chained reference (q.head = curr after curr = q.head; curr = curr.nxt) produced a `with2t` whose `update_value` was Node* against a Node field, thus tripping the is_pointer_type(b) assertion in irep2_expr.cpp.

Type aliased class-instance attributes (RHS is a Name, not a fresh constructor call) as pointers, and upgrade method parameters stored into such attributes to match. Fresh-constructor RHS (self.a: A = A()) keeps in-place construction via FUNCTION_CALL: A(&self->a).

Fixes #4831