### PR TITLE
[python] handle_str_join: nondet fallback for non-foldable iterable

### DIFF
--- a/regression/python/python_str_join_nondet_fallback/main.py
+++ b/regression/python/python_str_join_nondet_fallback/main.py
@@ -1,0 +1,33 @@
+# Nondet fallback for str.join() when its iterable arg can't be
+# folded to a literal List at conversion time.
+#
+# Before this change, handle_str_join aborted with
+# "join() argument must be a list of strings" whenever the iterable
+# was anything other than a literal List or a Name resolving to one
+# (e.g. a `sorted(...)`, a list comprehension, an unannotated
+# parameter, or a function-call result). The two abort sites now fall
+# back to a sound nondet `char *` via build_nondet_string_fallback so
+# GOTO conversion proceeds. Same pattern as the str.*() handler
+# fallbacks in PRs #4814 (splitlines), #4815 (partition/format), and
+# the runtime-model series #4818..#4826.
+
+
+def join_sorted(parts):
+    # Iterable is a sorted() call -- not a List literal, not a Name
+    # with a foldable initialiser. Previously: handler abort.
+    return ' '.join(sorted(parts))
+
+
+def join_param(parts):
+    # Iterable is a function parameter -- legacy var_decl had no
+    # foldable initialiser. Previously: handler abort on the second
+    # error path ("join() requires a list").
+    return ' '.join(parts)
+
+
+if __name__ == "__main__":
+    # No assertions on the join result -- only checks that conversion
+    # completes. The actual returned string is a sound symbolic value
+    # (nondet `char *`); precise functional results require flow-
+    # sensitive type inference, which is separate work.
+    pass

--- a/regression/python/python_str_join_nondet_fallback/test.desc
+++ b/regression/python/python_str_join_nondet_fallback/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_str_join_nondet_fallback_fail/main.py
+++ b/regression/python/python_str_join_nondet_fallback_fail/main.py
@@ -1,0 +1,14 @@
+# Negative companion: when join() falls back to a nondet `char *`, an
+# assertion that pins a specific result must reach the solver and
+# fail rather than silently succeeding.
+
+
+def join_sorted(parts):
+    return ' '.join(sorted(parts))
+
+
+if __name__ == "__main__":
+    # The nondet fallback can be any string; the strcmp against a
+    # specific literal is falsifiable.
+    result = join_sorted(["a", "b"])
+    assert result == "a b"

--- a/regression/python/python_str_join_nondet_fallback_fail/test.desc
+++ b/regression/python/python_str_join_nondet_fallback_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2142,7 +2142,19 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
         "NameError: name '" + var_name + "' is not defined");
 
     if (!var_decl.contains("value"))
-      throw std::runtime_error("join() requires a list");
+    {
+      // Variable is declared but its initialiser is opaque (e.g. an
+      // unannotated parameter, or a function call result we cannot
+      // fold). The legacy abort gave up the whole call; fall back to a
+      // sound nondet `char *` instead so GOTO conversion proceeds.
+      // Same pattern as the other str.*() handler fallbacks.
+      log_debug(
+        "python-string",
+        "join() variable '{}' has no foldable initialiser: nondet fallback",
+        var_name);
+      return build_nondet_string_fallback(
+        converter_.get_location_from_decl(call_json));
+    }
 
     list_node = &var_decl["value"];
   }
@@ -2233,7 +2245,18 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
   if (
     !list_node || !list_node->contains("_type") ||
     (*list_node)["_type"] != "List" || !list_node->contains("elts"))
-    throw std::runtime_error("join() argument must be a list of strings");
+  {
+    // Iterable arg isn't a literal `List` and couldn't be folded (e.g.
+    // a `sorted(...)`, list comprehension, or unannotated parameter).
+    // Fall back to a sound nondet `char *` instead of aborting GOTO
+    // conversion. Same pattern as PRs #4814 (splitlines), #4815
+    // (partition/format), #4818..#4826 (str.* runtime models).
+    log_debug(
+      "python-string",
+      "join() iterable arg not a foldable List literal: nondet fallback");
+    return build_nondet_string_fallback(
+      converter_.get_location_from_decl(call_json));
+  }
 
   // Get the list elements from the AST
   const auto &elements = (*list_node)["elts"];


### PR DESCRIPTION
`handle_str_join` had two abort paths when its iterable arg couldn't
be statically resolved to a literal `List`:

1. The arg was a `Name` whose AST `var_decl` had no `value` field
   (`"join() requires a list"`).
2. The arg resolved to a node that wasn't a `List` literal
   (`"join() argument must be a list of strings"`) — e.g. a
   `sorted(...)`, a list comprehension, or a function-call result.

Both now fall back to `build_nondet_string_fallback` so GOTO
conversion proceeds; the result is a sound symbolic `char *`. Same
pattern as the splitlines / partition / format nondet fallbacks
(#4814, #4815) and the runtime-model series (#4818..#4826).

## Outcome on the humaneval bucket

| Test | Before | After |
|---|---|---|
| `humaneval_19` (`' '.join(sorted([...]))`) | ERROR: `join() argument must be a list of strings` | VFAILED (residual; stays KNOWNBUG) |
| `humaneval_28` (`'-'.join([...comp...])`) | ERROR: `join() requires a list` | VFAILED (residual; stays KNOWNBUG) |
| `humaneval_86` (`' '.join(...)`) | ERROR | VFAILED (residual; stays KNOWNBUG) |
| `humaneval_38` | ERROR: `join()` | stops at next abort (`Variable 'encoded_str' is not defined`) — separate work |

## Tests

- `python_str_join_nondet_fallback` — `' '.join(sorted(parts))` and
  `' '.join(parts)` through a parameter wrapper. Only checks
  conversion completes; SUCCESSFUL.
- `python_str_join_nondet_fallback_fail` — pins a specific result
  against the nondet fallback; FAILED (proves the fallback is
  genuinely unconstrained).

Full `regression/python/(string-|github_4807|github_3127|python_)`
(394 tests) passes locally with no regressions. clang-format 11 clean.

Refs #4807.
