### PR TITLE
[goto-programs] use pre-increment for iterator in find_function_loops

### DIFF
--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -44,7 +44,7 @@ void goto_loopst::find_function_loops()
   for (goto_programt::instructionst::iterator it =
          goto_function.body.instructions.begin();
        it != goto_function.body.instructions.end();
-       it++)
+       ++it)
   {
     // We found a loop, let's record its instructions
     if (it->is_backwards_goto())


### PR DESCRIPTION
The for-loop step in goto_loopst::find_function_loops used post-increment on a std::list<…>::iterator, which constructs a temporary copy of the iterator each turn. Switch to pre-increment, matching the rest of the file (e.g. line 94). The return value of the increment is unused, so the change is semantically identical.