### PR TITLE
[esbmc] document boundedness of POSIX read() sites in parseoptions

### DIFF
--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -152,6 +152,9 @@ static void segfault_handler(int sig)
   if (fd != -1)
   {
     dprintf(STDERR_FILENO, "\nMemory map:\n");
+    // Bounded read: `buffer` is a fixed-size stack array and the loop
+    // passes its exact size to read(2), so no overflow is possible.
+    // Loop terminates on EOF (rd == 0) or on a non-EINTR error.
     for (ssize_t rd; (rd = read(fd, buffer, sizeof(buffer))) > 0 ||
                      (rd == -1 && errno == EINTR);)
       rd = write(STDERR_FILENO, buffer, rd < 0 ? 0 : rd);
@@ -1056,7 +1059,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
       !(finished[BASE_CASE] && finished[FORWARD_CONDITION] &&
         finished[INDUCTIVE_STEP]))
     {
-      // Perform read and interpret the number of bytes read
+      // Bounded read: destination is a single resultt on the stack and
+      // the read length is its exact sizeof. Short reads (EOF, error,
+      // EAGAIN) are checked explicitly below.
       bool valid_read = true;
       int read_size = read(forward_pipe[0], &a_result, sizeof(resultt));
       if (read_size != sizeof(resultt))
@@ -1288,7 +1293,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 
       // Check if the parent process is asking questions
 
-      // Perform read and interpret the number of bytes read
+      // Bounded read: destination is a single resultt on the stack and
+      // the read length is its exact sizeof. Short reads (EOF, error,
+      // EAGAIN) are checked explicitly below.
       struct resultt a_result;
       int read_size = read(backward_pipe[0], &a_result, sizeof(resultt));
       if (read_size != sizeof(resultt))


### PR DESCRIPTION
Add inline comments at the three POSIX read(2) call sites flagged by flawfinder (CWE-120) explaining why each one is bounded:

  * segfault_handler /proc/self/maps loop: destination is a fixed-size stack buffer, read length is its exact sizeof.
  * k-induction forward/backward pipe reads: destination is a single resultt on the stack, read length is its exact sizeof, short reads are checked explicitly on the next line.

No behaviour change — comments only.