### PR TITLE
[python] suppress Bandit B404/B603 in parser.py with rationale

### DIFF
--- a/src/python-frontend/parser/parser.py
+++ b/src/python-frontend/parser/parser.py
@@ -30,7 +30,10 @@ import glob
 import base64
 import importlib
 import shutil
-import subprocess
+# Bandit B404: subprocess is needed to invoke mypy out-of-process. The
+# only call site is run_mypy_strict() below; arguments are not derived
+# from untrusted input and `shell=False` is used.
+import subprocess  # nosec B404
 import tempfile
 
 # parser.py now lives under python-frontend/parser/. Ensure the parent
@@ -103,7 +106,10 @@ def run_mypy_strict(filename):
         return 0, ""
 
     with tempfile.TemporaryDirectory(prefix="esbmc-mypy-cache-") as cache_dir:
-        result = subprocess.run(
+        # Bandit B603: argv is a fixed list — `mypy_path` comes from
+        # shutil.which (PATH lookup, not user input), `filename` is the
+        # caller's source path. `shell=False` is implicit (list argv).
+        result = subprocess.run(  # nosec B603
             [mypy_path, "--strict", "--cache-dir", cache_dir, filename],
             capture_output=True,
             text=True,


### PR DESCRIPTION
Add `# nosec` markers (with the specific Bandit rule IDs) and a one-line comment explaining why the subprocess import and the subprocess.run call in run_mypy_strict() are safe: the argv is a fixed list whose first element comes from shutil.which() (PATH lookup, not user input) and shell=False is implicit through the list form.