### PR TITLE
[regression] make FUTURE behave as expected-fail and align fixtures

### DIFF
--- a/regression/cstd/strxfrm_bug/test.desc
+++ b/regression/cstd/strxfrm_bug/test.desc
@@ -1,4 +1,4 @@
 FUTURE
 main.c
 --unwind 50 -Wno-error=implicit-function-declaration
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/cstd/strxfrm_bug/test.desc
+++ b/regression/cstd/strxfrm_bug/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.c
 --unwind 50 -Wno-error=implicit-function-declaration
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/esbmc/struct_bitfields_03/test.desc
+++ b/regression/esbmc/struct_bitfields_03/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.c
 --force-malloc-success -Wno-error=implicit-function-declaration
 ^VERIFICATION SUCCESSFUL$

--- a/regression/humaneval/humaneval_75/test.desc
+++ b/regression/humaneval/humaneval_75/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --incremental-bmc --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/nested-1-nested_loop_invariants/test.desc
+++ b/regression/loop-invariants/nested-1-nested_loop_invariants/test.desc
@@ -1,4 +1,4 @@
 FUTURE
 main.c
 --loop-invariant-check 
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/nested-1-nested_loop_invariants/test.desc
+++ b/regression/loop-invariants/nested-1-nested_loop_invariants/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.c
---loop-invariant-check 
-^VERIFICATION SUCCESSFUL$
+--loop-invariant-check
+^VERIFICATION FAILED$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -39,7 +39,9 @@ _MEMORY_LIMIT_ENVVAR = "ESBMC_REGRESS_MEMORY_LIMIT"
 # FUTURE -> Test that are known to fail due to missing implementation
 # ALL -> Run all tests
 SUPPORTED_TEST_MODES = ["CORE", "FUTURE", "THOROUGH", "KNOWNBUG", "ALL"]
-FAIL_MODES = ["KNOWNBUG"]
+# FAIL_MODES: regex describes desired post-fix output; current run must NOT
+# match. Matching = test now passes -> exit 77, prompting reclassification.
+FAIL_MODES = ["KNOWNBUG", "FUTURE"]
 
 # Bring up a single benchmark
 BENCHMARK_BRINGUP = False
@@ -286,7 +288,7 @@ def _add_test(test_case, executor):
         if (test_case.test_mode in FAIL_MODES) and matches_regex:
             rel_path = os.path.relpath(test_case.test_dir, os.path.dirname(__file__))
             print(
-                f"\033[33mERROR: Test '{rel_path}' passed but is marked as KNOWNBUG. Consider reclassifying it as CORE.\033[0m"
+                f"\033[33mERROR: Test '{rel_path}' passed but is marked as {test_case.test_mode}. Consider reclassifying it as CORE.\033[0m"
             )
             sys.exit(77)
         elif (test_case.test_mode not in FAIL_MODES) and (not matches_regex):


### PR DESCRIPTION
`testing_tool.py` listed `FUTURE` in `SUPPORTED_TEST_MODES` with the docstring _"tests known to fail due to missing implementation"_, but `FAIL_MODES` held only `KNOWNBUG`. FUTURE tests therefore ran under normal pass/fail semantics — and authors locked in their current (broken) output as the "expected" regex to make the test pass anyway. Add `FUTURE` to `FAIL_MODES` so its regex now describes the desired post-fix output and matching trips the exit-77 reclassify-to-CORE warning, mirroring KNOWNBUG. Also generalise the "passed but is marked as KNOWNBUG" warning to interpolate `test_case.test_mode`.

Audit and realign the 5 existing FUTURE fixtures against the new semantics:
- `esbmc/struct_bitfields_03` already verifies `SUCCESSFUL` and the bitfield support has caught up — **FUTURE → CORE**.
- `cstd/strxfrm_bug` and `loop-invariants/nested-1-nested_loop_invariants` produce `VERIFICATION FAILED` today and would continue to do so post-fix (strxfrm_bug: under correctly-modelled `strxfrm` Czech `ch > h` makes the assertion `strcmp(out1, out2) >= 0` provably fail; nested-1: the loop body modifies `secret` but no invariant mentions it, so `assert(secret == 50042)` is unprovable under any working nested-loop-invariant implementation). FAILED is the genuine verdict either way — **FUTURE → CORE**, regex restored to `^VERIFICATION FAILED$`.
- `esbmc-solidity/github_497_2` and `esbmc-solidity/import_2` already had correct regexes that fail to match today — **stay FUTURE unchanged**.

Re-tag `humaneval_75` `KNOWNBUG → FUTURE`: the 3-deep prime sieve to 101 is a BMC scalability dead-end, not a bug. Part of draining #4807.
