### PR TITLE
[ci] address Codacy performance warnings in unit tests and scope cppcheck

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -51,3 +51,20 @@ engines:
       # Python code that runs under `python -O`, so Bandit B101 ("assert
       # removed in optimised bytecode") does not apply.
       - 'src/python-frontend/models/**'
+
+  cppcheck:
+    enabled: true
+    exclude_paths:
+      # Regression test fixtures. Every C/C++ file under regression/ is
+      # an input that ESBMC parses and symbolically executes — none of
+      # it is compiled into the ESBMC binary or run on the host. The
+      # files are written to exercise specific frontend / operational-
+      # model paths (e.g. postfix `it++` on STL iterators goes through a
+      # different operator overload than prefix `++it`; `strcmp("a","a")`
+      # is the literal subject of github_1351; `std::string` pass-by-
+      # value mirrors the signatures of textbooks the fixtures are
+      # derived from). Rewriting these for host-side style would change
+      # what is being verified and silently weaken the test suite.
+      # Real cppcheck findings in src/, unit/, and scripts/ are still
+      # surfaced.
+      - 'regression/**'

--- a/unit/testing-utils/goto_factory.cpp
+++ b/unit/testing-utils/goto_factory.cpp
@@ -118,7 +118,7 @@ program goto_factory::get_goto_functions_internal(
   return goto_factory::get_goto_functions(cmd, opts);
 }
 
-cmdlinet goto_factory::get_default_cmdline(const std::string filename)
+cmdlinet goto_factory::get_default_cmdline(const std::string &filename)
 {
   cmdlinet cmdline;
   cmdline.args.push_back(filename);

--- a/unit/testing-utils/goto_factory.h
+++ b/unit/testing-utils/goto_factory.h
@@ -45,7 +45,7 @@ public:
     goto_factory::Architecture arch = goto_factory::Architecture::BIT_16,
     const std::string &test_name = "test.c");
 
-  static cmdlinet get_default_cmdline(const std::string filename);
+  static cmdlinet get_default_cmdline(const std::string &filename);
   static optionst get_default_options(cmdlinet cmd);
 
 private:

--- a/unit/util/config_file_test.cpp
+++ b/unit/util/config_file_test.cpp
@@ -39,8 +39,8 @@ std::string const right_conf_file =
 
 void check_option(
   boost::program_options::option option,
-  std::string key,
-  std::string value)
+  const std::string &key,
+  const std::string &value)
 {
   INFO("key: " << key << " value: " << value);
   REQUIRE(option.string_key == key);


### PR DESCRIPTION
Pass std::string parameters by const reference in goto_factory and config_file_test — these are real Codacy findings in ESBMC host-side code.

The remaining ~390 warnings of the same shape live in regression/ test fixtures. Those files are inputs ESBMC parses and symbolically executes — they are not compiled into the binary, and rewriting them (e.g. postfix `it++` → prefix `++it` on STL iterators) would change the verification path through the operational model and silently weaken the test suite. The fixtures around github_1351 deliberately use strcmp on equal literals because that is the subject of the issue. Exclude regression/** from cppcheck with a rationale, mirroring the existing flawfinder/bandit scoping in this file.