### PR TITLE
[python] add runtime __python_str_join OM and demote humaneval_28

### DIFF
--- a/regression/humaneval/humaneval_28/test.desc
+++ b/regression/humaneval/humaneval_28/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -214,6 +214,7 @@ const static std::vector<std::string> python_c_models = {
   "__python_int",
   "__python_chr",
   "__python_str_concat",
+  "__python_str_join",
   "__python_str_repeat",
   "__python_str_slice",
   "__python_int_to_str",

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -1301,6 +1301,62 @@ __ESBMC_HIDE:;
   return buffer;
 }
 
+// Python str.join - concatenates the elements of `list` separated by `sep`.
+// Empty / NULL list returns "". NULL sep is treated as "". An element whose
+// `value` is NULL is silently skipped; CPython raises TypeError there, but the
+// rest of the str.* OM family takes the same lenient stance and well-typed
+// `List[str]` programs never hit this path. Mirrors the 511-byte fixed-buffer
+// pattern used by __python_str_concat: overflow is detected by checking that
+// the input was fully drained when an inner loop exits, not by inspecting the
+// final pos.
+char *__python_str_join(const char *sep, struct __ESBMC_PyListObj *list)
+{
+__ESBMC_HIDE:;
+  char *buffer = __ESBMC_alloca(512);
+  buffer[0] = '\0';
+
+  if (!list || list->size == 0)
+    return buffer;
+
+  if (!sep)
+    sep = "";
+
+  size_t pos = 0;
+  size_t i = 0;
+  while (i < list->size)
+  {
+    if (i > 0)
+    {
+      size_t j = 0;
+      while (pos < 511 && sep[j])
+      {
+        buffer[pos] = sep[j];
+        pos++;
+        j++;
+      }
+      __ESBMC_assert(sep[j] == '\0', "join: result exceeds 511 characters");
+    }
+
+    const char *s = (const char *)list->items[i].value;
+    if (s)
+    {
+      size_t k = 0;
+      while (pos < 511 && s[k])
+      {
+        buffer[pos] = s[k];
+        pos++;
+        k++;
+      }
+      __ESBMC_assert(s[k] == '\0', "join: result exceeds 511 characters");
+    }
+
+    i++;
+  }
+
+  buffer[pos] = '\0';
+  return buffer;
+}
+
 // Python string repetition - repeats a string count times
 char *__python_str_repeat(const char *s, long long count)
 {

--- a/src/python-frontend/string/string_builder.cpp
+++ b/src/python-frontend/string/string_builder.cpp
@@ -598,3 +598,47 @@ exprt string_builder::build_runtime_str_conversion_call(
 
   return call;
 }
+
+exprt string_builder::build_runtime_str_join_call(
+  const exprt &separator,
+  const exprt &list_expr)
+{
+  const std::string fn_name = "__python_str_join";
+  const std::string func_symbol_id = "c:@F@" + fn_name;
+  const typet char_ptr = gen_pointer_type(char_type());
+  const typet list_ptr = get_type_handler().get_list_type();
+
+  symbolt *fn_symbol = get_symbol_table().find_symbol(func_symbol_id);
+  if (!fn_symbol)
+  {
+    symbolt new_symbol;
+    new_symbol.name = fn_name;
+    new_symbol.id = func_symbol_id;
+    new_symbol.mode = "C";
+    new_symbol.is_extern = true;
+
+    code_typet fn_type;
+    fn_type.return_type() = char_ptr;
+    fn_type.arguments().push_back(code_typet::argumentt(char_ptr));
+    fn_type.arguments().push_back(code_typet::argumentt(list_ptr));
+    new_symbol.set_type(fn_type);
+
+    get_symbol_table().add(new_symbol);
+    fn_symbol = get_symbol_table().find_symbol(func_symbol_id);
+  }
+
+  exprt sep_arg = str_handler_->get_array_base_address(separator);
+
+  exprt list_arg =
+    list_expr.type().is_pointer() ? list_expr : address_of_exprt(list_expr);
+  if (list_arg.type() != list_ptr)
+    list_arg = typecast_exprt(list_arg, list_ptr);
+
+  side_effect_expr_function_callt call;
+  call.function() = symbol_expr(*fn_symbol);
+  call.arguments().push_back(sep_arg);
+  call.arguments().push_back(list_arg);
+  call.type() = char_ptr;
+
+  return call;
+}

--- a/src/python-frontend/string/string_builder.h
+++ b/src/python-frontend/string/string_builder.h
@@ -78,9 +78,8 @@ public:
   /// model. `separator` is decayed to `const char *` and `list_expr` is passed
   /// as `__ESBMC_PyListObj *` (taking the address if needed). Used by
   /// `handle_str_join` when compile-time folding of the iterable fails.
-  exprt build_runtime_str_join_call(
-    const exprt &separator,
-    const exprt &list_expr);
+  exprt
+  build_runtime_str_join_call(const exprt &separator, const exprt &list_expr);
 
 private:
   python_converter &converter_;

--- a/src/python-frontend/string/string_builder.h
+++ b/src/python-frontend/string/string_builder.h
@@ -74,6 +74,14 @@ public:
     const typet &arg_type,
     const exprt &arg);
 
+  /// Build a side-effect call to the runtime `__python_str_join` operational
+  /// model. `separator` is decayed to `const char *` and `list_expr` is passed
+  /// as `__ESBMC_PyListObj *` (taking the address if needed). Used by
+  /// `handle_str_join` when compile-time folding of the iterable fails.
+  exprt build_runtime_str_join_call(
+    const exprt &separator,
+    const exprt &list_expr);
+
 private:
   python_converter &converter_;
   string_handler *str_handler_;

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2145,15 +2145,15 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
     {
       // Variable is declared but its initialiser is opaque (e.g. an
       // unannotated parameter, or a function call result we cannot
-      // fold). The legacy abort gave up the whole call; fall back to a
-      // sound nondet `char *` instead so GOTO conversion proceeds.
-      // Same pattern as the other str.*() handler fallbacks.
+      // fold). Dispatch to the runtime __python_str_join model with the
+      // resolved list variable; it returns "" for an empty list and joins
+      // element-by-element otherwise.
       log_debug(
         "python-string",
-        "join() variable '{}' has no foldable initialiser: nondet fallback",
+        "join() variable '{}' has no foldable initialiser: runtime dispatch",
         var_name);
-      return build_nondet_string_fallback(
-        converter_.get_location_from_decl(call_json));
+      exprt list_expr = converter_.get_expr(list_arg);
+      return string_builder_->build_runtime_str_join_call(separator, list_expr);
     }
 
     list_node = &var_decl["value"];


### PR DESCRIPTION
Before this change, `handle_str_join` folded the call at compile time when both the separator and the iterable were constant, and returned a nondet `char *` otherwise (the fallback added in #4848). That made `''.join(opaque_list)` symbolic even for the trivially-known empty case: `concatenate([])` returned `NONDET`, so `assert concatenate([]) == ''` failed for many models.

Add a runtime operational model `__python_str_join(sep, list)` in `string.c` that returns `""` for NULL/empty input and otherwise iterates the `PyListObj` items, separating with `sep`. Mirrors the 511-byte fixed-buffer pattern of `__python_str_concat`. Overflow is caught by asserting the input string was fully drained when each inner copy loop exits.

Wire-up:
- Register the OM in `cprover_library.cpp` so the body links into the GOTO blob.
- New `string_builder::build_runtime_str_join_call` constructs the side-effect call.
- Dispatch from the first nondet fallback in `handle_str_join` (the `Name` reference to a variable whose initialiser cannot be folded — e.g. a function parameter typed `List[str]`). The second fallback (`ListComp`/`Call` iterables) is left untouched: it needs an upstream type-resolution fix that's out of scope here.

Demote `humaneval_28` `KNOWNBUG → CORE`. It now verifies SUCCESSFUL. Part of draining #4807.
