### PR TITLE
[python] type str(x) iterables as str so for-loops use strlen bound

### DIFF
--- a/regression/humaneval/humaneval_131/test.desc
+++ b/regression/humaneval/humaneval_131/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/humaneval/humaneval_155/test.desc
+++ b/regression/humaneval/humaneval_155/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1710,8 +1710,14 @@ class LoopMixin:
 
     def _create_iter_assignment(self, node, annotation_id, iter_var_name, element_type):
         """Create assignment for iterator variable with proper type annotation."""
+        # str iterables (`for c in str(x)`, `for c in some_str_var`) must be
+        # annotated as str so the converter lowers loop bounds via strlen
+        # rather than the list-style get_object_size, which overshoots and
+        # trips IndexError.
+        if annotation_id == "str":
+            iter_annotation = ast.Name(id="str", ctx=ast.Load())
         # Create proper list[T] annotation instead of just 'list'
-        if element_type and element_type != "Any":
+        elif element_type and element_type != "Any":
             # Create Subscript: list[element_type]
             iter_annotation = ast.Subscript(
                 value=ast.Name(id="list", ctx=ast.Load()),

--- a/src/python-frontend/preprocessor/type_inference_mixin.py
+++ b/src/python-frontend/preprocessor/type_inference_mixin.py
@@ -85,6 +85,15 @@ class TypeInferenceMixin:
             if known_type and known_type != "Any":
                 return known_type
             return "list"
+        # `for c in str(x)` / `for c in str(abs(x))` etc. The iterable is the
+        # str(...) call whose return type is `str`; without this branch we
+        # fall through to "list" and lower the loop as a list iteration,
+        # which trips an IndexError because the str length is shorter than
+        # the list-style get_object_size bound.
+        if (isinstance(iterable, ast.Call)
+                and isinstance(iterable.func, ast.Name)
+                and iterable.func.id == "str"):
+            return "str"
         return "list"
 
     def _get_element_type_from_container(self, container_type, iterable_node=None):  # pylint: disable=too-many-branches,too-many-nested-blocks

--- a/src/python-frontend/preprocessor/type_inference_mixin.py
+++ b/src/python-frontend/preprocessor/type_inference_mixin.py
@@ -90,8 +90,7 @@ class TypeInferenceMixin:
         # fall through to "list" and lower the loop as a list iteration,
         # which trips an IndexError because the str length is shorter than
         # the list-style get_object_size bound.
-        if (isinstance(iterable, ast.Call)
-                and isinstance(iterable.func, ast.Name)
+        if (isinstance(iterable, ast.Call) and isinstance(iterable.func, ast.Name)
                 and iterable.func.id == "str"):
             return "str"
         return "list"


### PR DESCRIPTION
`_get_iterable_type_annotation` in `type_inference_mixin.py` had no case for `ast.Call` and fell through to the default `"list"`. So `for digit in str(n)` was annotated as a list, and the loop-lowering sourced its bound from `get_object_size(ESBMC_iter)` (the struct's allocation size) instead of `strlen`. Since `get_object_size > strlen` for the resulting `char *`, the synthesized index range overshoots and the lowered IndexError check throws `"string index out of range"`.

Recognise `ast.Call(func=ast.Name("str"))` as a str iterable. Mirror the existing handling for `ast.Constant(str)` and known-typed str variables.

Knock-on fix in `loop_mixin.py`: when `annotation_id == "str"`, `_create_iter_assignment` must emit `Name("str")` for the iterator's annotation, not `Subscript(list, ...)` or bare `Any` — otherwise the converter still types `ESBMC_iter_N` as `PyListObj*` and the bound sourcing path doesn't change. The new branch must come before the existing element-type and list/tuple checks since they would otherwise wrap the str in `list[str]`.

Demote `humaneval_131` and `humaneval_155` `KNOWNBUG → CORE`. Both iterate `for c in str(int)` and now verify SUCCESSFUL. Part of draining #4807.
