### PR TITLE
fix: workflow weekly release name and description and also constant tag `weekly`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Do the release
         uses: softprops/action-gh-release@v3
         with:
-          name: 'ESBMC nightly'
-          body: 'This is an automated nightly release of ESBMC.'
-          tag_name: nightly-${{ github.sha }}
+          name: 'ESBMC Weekly Pre-release'
+          body: 'This is an automated weekly pre-release of ESBMC. Please report any bugs to https://github.com/esbmc/esbmc/issues'
+          tag_name: weekly
           target_commitish: ${{ github.sha }}
           prerelease: true
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           name: 'ESBMC Weekly Pre-release'
-          body: 'This is an automated weekly pre-release of ESBMC. Please report any bugs to https://github.com/esbmc/esbmc/issues'
+          body: 'This is an automated weekly pre-release of ESBMC. Please report any bugs to our [Issues](https://github.com/esbmc/esbmc/issues) tracking page.'
           tag_name: weekly
           target_commitish: ${{ github.sha }}
           prerelease: true


### PR DESCRIPTION
Fixes:

- Weekly release name and description.
-  Constant tag from now on `weekly` which is standard for OSS.

---

```
1. Preview what would be deleted

gh release list --repo esbmc/esbmc --limit 1000 \
  --json tagName --jq '.[].tagName | select(startswith("nightly-"))'

Eyeball that list — confirm it's only the old nightly-<sha> entries and nothing you want to keep.

2. Delete the releases + their tags

--cleanup-tag removes the git tag along with the release, so this handles both in one pass:

gh release list --repo esbmc/esbmc --limit 1000 \
  --json tagName --jq '.[].tagName | select(startswith("nightly-"))' \
| while read -r tag; do
    gh release delete "$tag" --repo esbmc/esbmc --cleanup-tag --yes
  done

3. Sweep up any orphan tags (tags with no release)

In case some nightly-* tags exist without an associated release:

# remote
git ls-remote --tags origin 'refs/tags/nightly-*' \
  | sed 's#.*refs/tags/##' \
  | xargs -r -n1 git push origin --delete

# local copies
git tag -l 'nightly-*' | xargs -r git tag -d
```