### PR TITLE
[ci] address Codacy Bandit findings: scope exclusions and fix scripts/

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -52,6 +52,32 @@ engines:
       # removed in optimised bytecode") does not apply.
       - 'src/python-frontend/models/**'
 
+      # Regression test fixtures. Every .py file under regression/ is an
+      # input that ESBMC's Python frontend parses and symbolically
+      # executes — none of it is run as a host-side Python program, none
+      # is compiled to optimised bytecode (`python -O`), and none is
+      # exposed to network input. The `assert` statements ARE the
+      # verification properties: ESBMC lowers Python `ast.Assert` to a
+      # GOTO ASSERT directly (see src/python-frontend/python_converter
+      # .cpp), so rewriting them as `if not <cond>: raise AssertionError`
+      # would change the AST shape and silently weaken the suite. Same
+      # rationale as the cppcheck exclusion above. Likewise, idioms such
+      # as `popen("ls /tmp")` in regression/python/import-os/main.py and
+      # `rand.random()` in regression/python/div6_fail/main.py are
+      # fixtures exercising specific operational-model code paths in the
+      # frontend — their presence is the point. Real bandit issues in
+      # src/, unit/ (excluding pytest), and scripts/ are still surfaced.
+      - 'regression/**'
+
+      # Pytest property-based tests for the Python frontend. Pytest's
+      # assertion-rewriting machinery requires plain `assert` (Bandit
+      # B101 is incompatible with the pytest idiom), and these suites
+      # are never executed under `python -O`. They validate ESBMC's
+      # Decimal / dataclass / preprocessor models against CPython using
+      # hypothesis — see unit/python-frontend/test_decimal_model.py and
+      # siblings.
+      - 'unit/python-frontend/**'
+
   cppcheck:
     enabled: true
     exclude_paths:

--- a/scripts/competitions/testcomp/esbmc-wrapper.py
+++ b/scripts/competitions/testcomp/esbmc-wrapper.py
@@ -1,7 +1,20 @@
 #!/usr/bin/env python3
 
 import os.path  # To check if file exists
-import xml.etree.ElementTree as ET  # To parse XML
+# Harden the stdlib XML parser against malformed witness input (Bandit
+# B320). defusedxml.defuse_stdlib() monkey-patches xml.etree.ElementTree
+# .parse / fromstring with safe variants while leaving the Element /
+# SubElement / write APIs intact — we use those below to generate the
+# Test-Comp testcase XML. If defusedxml is unavailable (older
+# competition images), fall back to the stdlib: in the Test-Comp
+# harness the only XML we ever parse is ESBMC's own witness output,
+# never network input.
+try:
+    import defusedxml
+    defusedxml.defuse_stdlib()
+except ImportError:
+    pass  # nosec B411 — see comment above
+import xml.etree.ElementTree as ET  # nosec B405 — parse paths hardened above
 import os
 import argparse
 import shlex
@@ -35,8 +48,10 @@ class AssumptionHolder(object):
         assumption : str
             Assumption string from ESBMC.
         """
-        assert(line >= 0)
-        assert(len(assumption) > 0)
+        if line < 0:
+            raise ValueError(f"line must be non-negative, got {line}")
+        if not assumption:
+            raise ValueError("assumption must be a non-empty string")
         self.line = line
         self.assumption = assumption
 
@@ -59,7 +74,8 @@ class AssumptionParser(object):
         witness : str
             Path to witness file (absolute/relative)
         """
-        assert(os.path.isfile(witness))
+        if not os.path.isfile(witness):
+            raise FileNotFoundError(f"witness file not found: {witness}")
         self.__xml__ = None
         self.assumptions = list()
         self.__witness__ = witness
@@ -108,7 +124,8 @@ class MetadataParser(object):
         witness : str
             Path to witness file (absolute/relative)
         """
-        assert(os.path.isfile(witness))
+        if not os.path.isfile(witness):
+            raise FileNotFoundError(f"witness file not found: {witness}")
         self.__xml__ = None
         self.metadata = {}
         self.__witness__ = witness
@@ -136,9 +153,10 @@ class NonDeterministicCall(object):
         Parameters
         ----------
         value : str
-            String containing value from input        
+            String containing value from input
         """
-        assert(len(value) > 0)
+        if not value:
+            raise ValueError("value must be a non-empty string")
         self.value = value
 
     @staticmethod
@@ -175,7 +193,6 @@ class NonDeterministicCall(object):
         """
         _, right = assumption.assumption.split("=")
         left, _ = right.split(";")
-        assert(len(right) > 0)
         if left[-1] == "f" or left[-1] == "l":
             left = left[:-1]
         value = NonDeterministicCall.extract_byte_little_endian(left.strip())
@@ -201,8 +218,10 @@ class SourceCodeChecker(object):
         assumptions : [AssumptionHolder]
             List containing all assumptions of the witness
         """
-        assert(os.path.isfile(source))
-        assert(assumptions is not None)
+        if not os.path.isfile(source):
+            raise FileNotFoundError(f"source file not found: {source}")
+        if assumptions is None:
+            raise ValueError("assumptions must not be None")
         self.source = source
         self.assumptions = assumptions
         self.__lines__ = None
@@ -605,7 +624,12 @@ benchmark = args.benchmark
 strategy = args.strategy
 
 if version:
-    print (os.popen(esbmc_path + "--version").read()[6:]),
+    # Drop the leading "ESBMC " prefix from the version string.
+    result = subprocess.run(
+        [esbmc_path.strip(), "--version"],
+        capture_output=True, text=True, check=True,
+    )
+    print(result.stdout[6:], end="")
     exit(0)
 
 if property_file is None:

--- a/scripts/competitions/testcomp/esbmc-wrapper.py
+++ b/scripts/competitions/testcomp/esbmc-wrapper.py
@@ -625,7 +625,10 @@ strategy = args.strategy
 
 if version:
     # Drop the leading "ESBMC " prefix from the version string.
-    result = subprocess.run(
+    # nosec B603 — argv is two literals (the hard-coded esbmc_path defined
+    # at module top and the constant string "--version"); no user input
+    # reaches this call.
+    result = subprocess.run(  # nosec B603
         [esbmc_path.strip(), "--version"],
         capture_output=True, text=True, check=True,
     )

--- a/scripts/dev/find_duplicate_tests.py
+++ b/scripts/dev/find_duplicate_tests.py
@@ -54,7 +54,7 @@ def cluster_tests(root):
         if not os.path.exists(src_path):
             continue
         with open(src_path, "rb") as sf:
-            src_hash = hashlib.sha1(sf.read()).hexdigest()
+            src_hash = hashlib.sha1(sf.read(), usedforsecurity=False).hexdigest()
         groups[(src_hash, args, regex)].append(tdir)
     return {k: v for k, v in groups.items() if len(v) > 1}
 

--- a/scripts/sv-comp-graph/sv_comp_history.py
+++ b/scripts/sv-comp-graph/sv_comp_history.py
@@ -326,7 +326,10 @@ def main(argv: list[str] | None = None) -> int:
         default=script_dir,
         help="directory for sv-comp-hist-*.png files",
     )
-    ap.add_argument("--cache-dir", type=Path, default=Path("/tmp/esbmc-svcomp-hist"))
+    # Default cache lives under /tmp so multiple runs on the same host
+    # share rendered intermediates; user can override with --cache-dir.
+    ap.add_argument("--cache-dir", type=Path,
+                    default=Path("/tmp/esbmc-svcomp-hist"))  # nosec B108
     ap.add_argument(
         "--scale",
         choices=("log", "linear"),


### PR DESCRIPTION
Most of Bandit's ~9,149 issues are false positives from ESBMC regression .py files and unit/python-frontend/test_*.py suites (which need plain assert), so .codacy.yaml's bandit exclude_paths is extended to cover both alongside the existing flawfinder/cppcheck entries.