### PR TITLE
[python] infer float return type for expr / float-literal BinOp

### DIFF
--- a/regression/humaneval/humaneval_45/test.desc
+++ b/regression/humaneval/humaneval_45/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -798,6 +798,32 @@ std::string python_annotation<Json>::get_type_from_binary_expr(
   const Json &lhs =
     stmt.contains("value") ? stmt["value"]["left"] : stmt["left"];
 
+  // True division (`/`) by a float literal yields float regardless of the
+  // LHS arithmetic operands, covering the `a * h / 2.0` shape that
+  // otherwise truncates the call-site return to long_long_int. Limited to
+  // a numeric LHS (Name/BinOp/UnaryOp/int-Constant) so a complex-typed
+  // dividend like `complex(6.0, 4.0) / 2.0` falls through to the LHS-type
+  // path below, which correctly preserves "complex".
+  if (
+    stmt.contains("value") && stmt["value"].contains("op") &&
+    stmt["value"]["op"].contains("_type") &&
+    stmt["value"]["op"]["_type"] == "Div")
+  {
+    const auto &rhs = stmt["value"]["right"];
+    bool rhs_is_float_literal = rhs.contains("_type") &&
+                                rhs["_type"] == "Constant" &&
+                                rhs.contains("value") &&
+                                rhs["value"].is_number_float();
+    bool lhs_is_numeric_shape =
+      lhs.contains("_type") &&
+      (lhs["_type"] == "Name" || lhs["_type"] == "BinOp" ||
+       lhs["_type"] == "UnaryOp" ||
+       (lhs["_type"] == "Constant" && lhs.contains("value") &&
+        (lhs["value"].is_number_integer() || lhs["value"].is_number_float())));
+    if (rhs_is_float_literal && lhs_is_numeric_shape)
+      return "float";
+  }
+
   if (lhs["_type"] == "BinOp")
     type = get_type_from_binary_expr(lhs, body);
   else if (lhs["_type"] == "List")


### PR DESCRIPTION
`get_type_from_binary_expr` walked only the LHS operand of a BinOp and had a special case for `FloorDiv → "int"` but none for true division. For an unannotated `def triangle_area(a, h): return a * h / 2.0`, the annotation pass therefore inferred `"int"` for the return type and injected `returns = ast.Name(id="int")` into the AST. The converter then declared the call-site return temp as `long_long_int`, truncating the actual `7.5` to `7` and breaking `assert triangle_area(5, 3) == 7.5`.

Recognise the `Div` case with a guard tight enough to avoid the obvious pitfalls: fire only when the RHS is a float `Constant` literal AND the LHS is a numeric-shape AST node (`Name` / `BinOp` / `UnaryOp` / numeric `Constant`). The dual guard preserves `complex(...) / 2.0 → complex` semantics that pre-existing `complex_*` tests rely on; an LHS resolving to `"complex"` via `complex(...)` Call falls through to the existing LHS-walk path which correctly returns `"complex"`.

Demote `humaneval_45` `KNOWNBUG → CORE`. Part of draining #4807.
