### PR TITLE
[termination] enable interval-analysis for SV-COMP; complete the post-kind bound pass

### DIFF
--- a/regression/k-induction/interval_transitive_bound/main.c
+++ b/regression/k-induction/interval_transitive_bound/main.c
@@ -1,0 +1,55 @@
+/* Post-k-induction interval bound for a TRANSITIVELY-modified loop
+ * variable.
+ *
+ * `state` is a global that main's loop modifies only indirectly, via
+ * the call to step(). It never appears textually in main's loop body
+ * (the body just reads `in` and calls step(in)). The interval domain
+ * proves state stays in [0,2] (step assigns it only the constants
+ * 0/1/2 under guards).
+ *
+ * k-induction's make_nondet_assign havocs state (it's in the loop's
+ * transitively-modified set), emitting `state = NONDET()` in the havoc
+ * block before the loop head. instrument_loop_bounds_after_kind must
+ * then pin state to its interval at the inductive-step loop head.
+ * Before the fix, that pass collected only symbols appearing textually
+ * in the loop body, so the callee-modified `state` was missed and the
+ * inductive step ran from an arbitrary state value. The fix also
+ * collects the targets of the havoc block, so state gets bounded.
+ *
+ * The test inspects the transformed GOTO program: an
+ * ASSUME(0 <= state <= 2) must be present (the post-havoc bound on the
+ * transitively-modified variable). */
+
+extern int __VERIFIER_nondet_int(void);
+
+int state = 0;
+
+void step(int in)
+{
+  if (state == 0)
+  {
+    if (in)
+      state = 1;
+  }
+  else if (state == 1)
+  {
+    if (in)
+      state = 2;
+    else
+      state = 0;
+  }
+  else
+  {
+    state = 0;
+  }
+}
+
+int main()
+{
+  while (1)
+  {
+    int in = __VERIFIER_nondet_int();
+    step(in);
+  }
+  return 0;
+}

--- a/regression/k-induction/interval_transitive_bound/test.desc
+++ b/regression/k-induction/interval_transitive_bound/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --no-vla-size-check --32 --no-pointer-check --no-bounds-check --no-assertions --termination --max-inductive-step 3 --interval-analysis --goto-functions-only
+ASSUME state <= 2 && 0 <= state

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -271,7 +271,12 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
   # Special case for termination, it runs regardless of the strategy
   if prop == Property.termination:
     command_line += "--no-pointer-check --no-bounds-check --no-assertions "
-    command_line += "--termination --max-inductive-step 3 "
+    # --interval-analysis strengthens the inductive step: the post-havoc
+    # bound pass pins each havoced loop variable (including ones modified
+    # only through a callee) to its interval, so IS reasons from the
+    # reachable state space instead of an arbitrary havoc. +52 correct-
+    # false on the termination set with no new wrong results.
+    command_line += "--termination --max-inductive-step 3 --interval-analysis "
     return command_line
 
   if prop == Property.overflow:

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -292,6 +292,39 @@ void instrument_loop_bounds_after_kind(
         get_symbols(body_it->code, symbols);
         get_symbols(body_it->guard, symbols);
       }
+
+      // Also collect the targets of k-induction's havoc block, which
+      // make_nondet_assign emits *before* loop_head (the back-edge
+      // target): a run of `x = NONDET()` inductive_step assigns, one
+      // per loop variable INCLUDING those modified only transitively
+      // through a callee (e.g. the eca state-machine globals
+      // a17/a28/... mutated inside calculate_output, never named
+      // textually in main's loop body). These are exactly the havoced
+      // variables whose post-havoc value we want to pin to their
+      // interval; the textual body scan above misses them because the
+      // call site only references the argument, not the callee-modified
+      // globals. Without bounding them the inductive step runs from an
+      // arbitrary state-machine configuration and finds spurious
+      // non-terminating / counterexample states.
+      //
+      // Walk backward from loop_head over the contiguous run of
+      // inductive_step nondet-assigns. Stop at the first instruction
+      // that isn't such an assign (or at the function start).
+      if (loop_head != f_it->second.body.instructions.begin())
+      {
+        goto_programt::instructionst::iterator pre_it = loop_head;
+        do
+        {
+          --pre_it;
+          if (!pre_it->inductive_step_instruction || !pre_it->is_assign())
+            break;
+          const code_assign2t &a = to_code_assign2t(pre_it->code);
+          if (
+            is_symbol2t(a.target) && is_sideeffect2t(a.source) &&
+            to_sideeffect2t(a.source).kind == sideeffect2t::allockind::nondet)
+            symbols.insert(a.target);
+        } while (pre_it != f_it->second.body.instructions.begin());
+      }
       if (symbols.empty())
         continue;
 


### PR DESCRIPTION
## Summary

Two changes to the termination / k-induction interval pipeline.

### 1. SV-COMP wrapper: enable `--interval-analysis` for termination (the actual win)

The termination command line in `esbmc-wrapper.py` did not pass
`--interval-analysis`, so the post-k-induction interval bound injection
never ran in competition (the reachability category already passed it).
Enabling it strengthens the inductive step with per-instruction interval
bounds.

**Measured on the full SV-COMP termination set (30s/benchmark):**

| | without `--interval-analysis` | with |
|---|---|---|
| raw score | 1813 | 1859 |
| correct-false | 371 | 423 |
| wrong-false | 1 | 1 |
| wrong-true | 1 | 1 |

**+52 correct-false / +46 raw, no new wrong results** (both remaining
wrongs are pre-existing). This is entirely attributable to the existing
`--interval-analysis` machinery; the wrapper simply wasn't using it for
this category.

### 2. Complete `instrument_loop_bounds_after_kind` for transitively-modified vars (sound, currently verdict-neutral)

The post-kind bound pass collected the symbols to bound only from
instructions appearing **textually** in the loop body, missing loop
variables modified only **through a call** (e.g. a state-machine global
mutated inside a callee, never named in the caller's loop body). It now
also walks k-induction's havoc block (the `x = NONDET()` inductive-step
assigns emitted before the back-edge target) and bounds those targets
too.

**Soundness:** the injected `ASSUME` is flagged
`inductive_step_instruction`, so base case and forward condition skip it
(`execution_state.cpp:235`) — only the inductive hypothesis is
tightened, never concrete BC/FC reasoning. The bound comes from the same
transparency-aware interval re-analysis the existing textual-scan bounds
use, applied to additional symbols at the same program point.

**Honest scope:** measured marginal impact on the current termination set
is **zero** — removing this change while keeping `--interval-analysis`
gives the identical 1859 / 423 result. The added bounds are real and
sound but no current benchmark's verdict depends on them: the eca cluster
needs a *relational* recurrent-set invariant (an interval box still admits
error-reaching states), and elsewhere `--interval-analysis`'s existing
per-instruction guard bounds already suffice. This commit lands it as a
sound completion of a latent incompleteness in the bound pass (it
strengthens the inductive hypothesis and becomes load-bearing for future
relational/ranking work); it is **not** the source of the +46. Reviewers
who prefer to defer verdict-neutral changes can take commit 2
(`b67f66312b`, the wrapper) alone.

## Testing

`regression/k-induction/interval_transitive_bound` pins that the bound on
a transitively-modified global appears in the transformed GOTO (a
transformation pin, not a verdict pin — there is no verdict change to
assert, by the scope note above). 182/182 k-induction, 26/26 termination,
143/143 interval-analysis regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)