### PR TITLE
[python] rewrite sum(range(EXPR)) to Gauss closed form

### DIFF
--- a/regression/humaneval/humaneval_60/test.desc
+++ b/regression/humaneval/humaneval_60/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/expression_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/expression_rewrite_mixin.py
@@ -130,11 +130,9 @@ class ExpressionRewriteMixin:
             # matches the convention of the surrounding ListComp / genexpr
             # rewrites and is safe for the side-effect-free expressions seen
             # in practice (variables, integer arithmetic).
-            if (isinstance(node.func, ast.Name) and node.func.id == "sum"
-                    and len(node.args) == 1 and not node.keywords
-                    and isinstance(node.args[0], ast.Call)
-                    and isinstance(node.args[0].func, ast.Name)
-                    and node.args[0].func.id == "range"
+            if (isinstance(node.func, ast.Name) and node.func.id == "sum" and len(node.args) == 1
+                    and not node.keywords and isinstance(node.args[0], ast.Call)
+                    and isinstance(node.args[0].func, ast.Name) and node.args[0].func.id == "range"
                     and len(node.args[0].args) == 1):
                 stop = node.args[0].args[0]
                 # Build: stop * (stop - 1) // 2
@@ -147,8 +145,7 @@ class ExpressionRewriteMixin:
                         right=ast.Constant(value=1),
                     ),
                 )
-                gauss = ast.BinOp(left=product, op=ast.FloorDiv(),
-                                  right=ast.Constant(value=2))
+                gauss = ast.BinOp(left=product, op=ast.FloorDiv(), right=ast.Constant(value=2))
                 # Python: sum(range(n)) == 0 for n <= 0. Guard the formula so
                 # the rewrite is exact for the full integer domain, not just
                 # the positive case.

--- a/src/python-frontend/preprocessor/expression_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/expression_rewrite_mixin.py
@@ -121,6 +121,50 @@ class ExpressionRewriteMixin:
                     self.statements.extend(prefix)
                     return result
 
+            # sum(range(EXPR)) -> (EXPR * (EXPR - 1) // 2 if EXPR > 0 else 0).
+            # Without this, range(EXPR) creates a PyListObj with size=EXPR but
+            # unpopulated items; sum() then reads nondet via list[i], so
+            # `sum_to_n(1) = sum(range(2))` returns nondet instead of 1.
+            # Limited to single-argument range and single-argument sum.
+            # EXPR is evaluated multiple times in the rewritten tree; this
+            # matches the convention of the surrounding ListComp / genexpr
+            # rewrites and is safe for the side-effect-free expressions seen
+            # in practice (variables, integer arithmetic).
+            if (isinstance(node.func, ast.Name) and node.func.id == "sum"
+                    and len(node.args) == 1 and not node.keywords
+                    and isinstance(node.args[0], ast.Call)
+                    and isinstance(node.args[0].func, ast.Name)
+                    and node.args[0].func.id == "range"
+                    and len(node.args[0].args) == 1):
+                stop = node.args[0].args[0]
+                # Build: stop * (stop - 1) // 2
+                product = ast.BinOp(
+                    left=copy.deepcopy(stop),
+                    op=ast.Mult(),
+                    right=ast.BinOp(
+                        left=copy.deepcopy(stop),
+                        op=ast.Sub(),
+                        right=ast.Constant(value=1),
+                    ),
+                )
+                gauss = ast.BinOp(left=product, op=ast.FloorDiv(),
+                                  right=ast.Constant(value=2))
+                # Python: sum(range(n)) == 0 for n <= 0. Guard the formula so
+                # the rewrite is exact for the full integer domain, not just
+                # the positive case.
+                formula = ast.IfExp(
+                    test=ast.Compare(
+                        left=copy.deepcopy(stop),
+                        ops=[ast.Gt()],
+                        comparators=[ast.Constant(value=0)],
+                    ),
+                    body=gauss,
+                    orelse=ast.Constant(value=0),
+                )
+                ast.copy_location(formula, node)
+                ast.fix_missing_locations(formula)
+                return self.visit(formula)
+
             lowered_sorted = self.preprocessor._lower_sorted_with_key_call(node)
             if lowered_sorted is not None:
                 prefix, result = lowered_sorted


### PR DESCRIPTION
`handle_symbolic_range` in `python_list.cpp` creates a `PyListObject` with the requested size but never populates its `items`. `for i in range(n)` works because the for-lowering uses `i` directly, but `sum(range(n))` does not: the Python-level `sum` model in `models/builtins.py` reads `iterable[i]` and gets `NONDET` from the unpopulated items, so `sum_to_n(1) = sum(range(2))` returns nondet instead of 1.

Add an AST-level rewrite in `expression_rewrite_mixin.py` that recognises `sum(range(EXPR))` and emits the closed form `EXPR * (EXPR - 1) // 2 if EXPR > 0 else 0`. The guard preserves Python's `sum(range(n)) == 0 for n <= 0` semantics; without it the bare formula yields a spurious non-zero result for negative `EXPR` (e.g. `sum(range(-3)) → -3 * -4 // 2 = 6` vs the correct `0`). The rewrite is narrow: only single-arg `range` and single-arg `sum`.

Demote `humaneval_60` `KNOWNBUG → CORE`. Part of draining #4807.
