### PR TITLE
[regression] github_4440: cover_proof shape for __assert_fail noreturn

### DIFF
--- a/regression/esbmc/github_4440/main.c
+++ b/regression/esbmc/github_4440/main.c
@@ -1,0 +1,65 @@
+/* Regression for #4440.
+ *
+ * Reduced from c/coreutils-v9.5-units/seq_cmp_antisymmetry_cover_proof.i
+ * (SV-COMP 26).  The cover_proof variant interposes a postcondition step
+ * (fv_assert) between the local malloc and the unconditional cover_check
+ * that ends in reach_error() -> __assert_fail() — the shape #4441's
+ * regression (the cover_target variant) does not exercise.
+ *
+ * __assert_fail is __noreturn, so under --no-assertions the call must
+ * still terminate the path; otherwise the end-of-main memcleanup walker
+ * spuriously reports "forgotten memory" on heap that is only unreachable
+ * on the post-noreturn fall-through path.  Fixed by #4442.
+ *
+ * The postcondition operand is derived from __VERIFIER_nondet_int so both
+ * arms of fv_assert are reachable: result < 0 takes the inner reach_error
+ * path, result >= 0 falls through to main's unconditional reach_error.
+ * Both paths must be truncated by ASSUME(false) for verification to
+ * succeed.
+ *
+ * Expected: VERIFICATION SUCCESSFUL on valid-memsafety semantics
+ * (--memory-leak-check --no-reachable-memory-leak --no-assertions
+ * --no-abnormal-memory-leak — the SV-COMP valid-memsafety wrapper flags).
+ */
+
+#include <stdlib.h>
+
+extern int __VERIFIER_nondet_int(void);
+extern void __assert_fail(const char *, const char *, unsigned int,
+                          const char *)
+    __attribute__((__nothrow__)) __attribute__((__noreturn__));
+
+void reach_error(void)
+{
+  __assert_fail("0", __FILE__, __LINE__, __func__);
+}
+
+static void fv_assert(int condition)
+{
+  if (!condition)
+    reach_error();
+}
+
+static int result;
+
+static void do_work(void)
+{
+  int *p = malloc(sizeof(int));
+  if (!p)
+    return;
+  *p = __VERIFIER_nondet_int();
+  result = *p;
+}
+
+static void postcond(void)
+{
+  fv_assert(result >= 0);
+}
+
+int main(void)
+{
+  do_work();
+  postcond();
+  reach_error();
+  return 0;
+}

--- a/regression/esbmc/github_4440/test.desc
+++ b/regression/esbmc/github_4440/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --no-assertions --incremental-bmc --k-step 2 --64
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Add a fast CORE regression mirroring SV-COMP benchmark seq_cmp_antisymmetry_cover_proof.i: postcondition step via fv_assert interposed before the unconditional cover_check that ends in __assert_fail. The existing github_4441 only covers the cover_target variant (no postcond), and the full benchmark is gated behind THOROUGH.

Locks in PR #4442's __noreturn lowering of __assert_fail under --no-assertions; without it the end-of-main leak walker spuriously reports "forgotten memory" on the post-noreturn fall-through path. Verified locally that disabling the ASSUME(false) truncation makes this test fail with that exact diagnostic.

Fixes #4440