### PR TITLE
[python] stage RHS into temps for cross-binding tuple unpacking

### DIFF
--- a/regression/humaneval/humaneval_13/test.desc
+++ b/regression/humaneval/humaneval_13/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 15 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1973,6 +1973,18 @@ class LoopMixin:
             target_node.end_col_offset = source_node.end_col_offset
         return target_node
 
+    def _next_unpack_tmp_id(self):
+        """Monotonic counter for staged-temp names emitted by tuple unpacking.
+
+        Avoids using `id(source_node)` (CPython object id), which gets recycled
+        after GC and yields non-stable names across runs. The counter lives on
+        the preprocessor instance so it persists across visits within a single
+        pass.
+        """
+        current = getattr(self, "_unpack_tmp_counter", 0)
+        self._unpack_tmp_counter = current + 1
+        return current
+
     def _create_individual_assignment(self, target, value, source_node):
         """Create a single assignment node with proper location info"""
         individual_assign = ast.Assign(targets=[target], value=value)
@@ -2015,12 +2027,45 @@ class LoopMixin:
             # Don't transform unsupported unpacking shapes - let converter handle it
             return source_node
 
-        for target_node, value_node in leaf_pairs:
+        # Python's `a, b = b, a % b` evaluates the RHS tuple first and then
+        # binds each target, so a swap like `a, b = b, a` works. Lowering to
+        # naive sequential `a = b; b = a % b` reads the *new* `a` in the
+        # second assignment and is wrong (e.g. gcd loop terminates after one
+        # iteration). Stage each RHS into a fresh temp before the binds, so
+        # later target writes don't observe earlier ones.
+        target_names = {tn.id for tn, _ in leaf_pairs if isinstance(tn, ast.Name)}
+
+        def value_reads_target(value_node):
+            for sub in ast.walk(value_node):
+                if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load):
+                    if sub.id in target_names:
+                        return True
+            return False
+
+        need_staging = bool(target_names) and any(
+            value_reads_target(vn) for _, vn in leaf_pairs)
+        if need_staging:
+            base = self._next_unpack_tmp_id()
+            staged_values = []
+            for i, (_, value_node) in enumerate(leaf_pairs):
+                tmp_name = f"ESBMC_unpack_tmp_{base}_{i}"
+                tmp_assign = self._create_individual_assignment(
+                    ast.Name(id=tmp_name, ctx=ast.Store()),
+                    copy.deepcopy(value_node),
+                    source_node,
+                )
+                assignments.append(tmp_assign)
+                staged_name = ast.Name(id=tmp_name, ctx=ast.Load())
+                self._copy_location_info(source_node, staged_name)
+                staged_values.append(staged_name)
+        else:
+            staged_values = [copy.deepcopy(vn) for _, vn in leaf_pairs]
+
+        for (target_node, value_node), staged in zip(leaf_pairs, staged_values):
             target_copy = copy.deepcopy(target_node)
-            value_copy = copy.deepcopy(value_node)
-            individual_assign = self._create_individual_assignment(target_copy, value_copy,
+            individual_assign = self._create_individual_assignment(target_copy, staged,
                                                                    source_node)
-            self._update_variable_types_simple(target_copy, value_copy)
+            self._update_variable_types_simple(target_copy, value_node)
             assignments.append(individual_assign)
 
         return assignments

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -2042,8 +2042,7 @@ class LoopMixin:
                         return True
             return False
 
-        need_staging = bool(target_names) and any(
-            value_reads_target(vn) for _, vn in leaf_pairs)
+        need_staging = bool(target_names) and any(value_reads_target(vn) for _, vn in leaf_pairs)
         if need_staging:
             base = self._next_unpack_tmp_id()
             staged_values = []
@@ -2063,8 +2062,7 @@ class LoopMixin:
 
         for (target_node, value_node), staged in zip(leaf_pairs, staged_values):
             target_copy = copy.deepcopy(target_node)
-            individual_assign = self._create_individual_assignment(target_copy, staged,
-                                                                   source_node)
+            individual_assign = self._create_individual_assignment(target_copy, staged, source_node)
             self._update_variable_types_simple(target_copy, value_node)
             assignments.append(individual_assign)
 


### PR DESCRIPTION
`_handle_tuple_unpacking` lowered `a, b = b, a % b` to sequential `a = b; b = a % b`, which reads the *new* `a` in the second binding. Python evaluates the entire RHS tuple first and then binds, so the naive sequential lowering is wrong for any tuple unpacking where an RHS expression reads one of the target names. Concretely, the Euclid GCD loop `while b: a, b = b, a % b` terminates after one iteration with `a = old_b` because `b` is reassigned to `b % b = 0`.

Detect when any RHS reads a target name (`Load`-context match against the set of target ids) and, if so, stage each RHS into a fresh temp before any target is bound. The common non-cross-binding shape (`x, y = 1, 2`) keeps the original direct lowering. Temp names use a monotonic per-preprocessor counter so they are stable across runs and free of CPython object-id recycling concerns.

Demote `humaneval_13` `KNOWNBUG → CORE` (`gcd(3,7)` now returns `1`). Part of draining #4807.
