### PR TITLE
[clang-c-frontend] implement __atomic_compare_exchange{,_n} (#4436)

### DIFF
--- a/regression/esbmc-unix/github_4436/main.c
+++ b/regression/esbmc-unix/github_4436/main.c
@@ -1,0 +1,63 @@
+// Regression test for github.com/esbmc/esbmc/issues/4436.
+//
+// libvsync's HCLH lock (SV-COMP c/libvsync/hclhlock.yml) builds its
+// queue-splice on __atomic_compare_exchange_n. Before the fix, ESBMC
+// treated that builtin as a no-op: *ptr was never written, *expected
+// was never refreshed, and the returned bool was unconstrained. That
+// turned every CAS into a silent NOP and made the HCLH acquire path
+// see a NULL `pred`, producing a spurious reach_error counterexample
+// at k = 5 in the SV-COMP benchmark.
+//
+// We pin the contract of the strong CAS (both the `_n` value variant
+// and the pointer variant) so the modelled semantics cannot regress.
+#include <assert.h>
+#include <stddef.h>
+
+typedef struct node
+{
+  int payload;
+} node_t;
+
+static node_t a = {1};
+static node_t b = {2};
+static node_t *head;
+
+int main(void)
+{
+  // Success path (value variant): *head == NULL == expected, write &a,
+  // return true. expected is left unchanged.
+  head = NULL;
+  node_t *expected = NULL;
+  int ok = __atomic_compare_exchange_n(&head, &expected, &a, 0, 5, 5);
+  assert(ok);
+  assert(head == &a);
+  assert(expected == NULL);
+
+  // Failure path (value variant): head now == &a, expected stale NULL.
+  // Return false, refresh expected to actual current head value.
+  expected = NULL;
+  ok = __atomic_compare_exchange_n(&head, &expected, &b, 0, 5, 5);
+  assert(!ok);
+  assert(head == &a);
+  assert(expected == &a);
+
+  // Success path (pointer variant): __atomic_compare_exchange takes
+  // `desired` by address. Expected matches → write *desired into *ptr.
+  head = NULL;
+  expected = NULL;
+  node_t *desired = &b;
+  ok = __atomic_compare_exchange(&head, &expected, &desired, 0, 5, 5);
+  assert(ok);
+  assert(head == &b);
+  assert(expected == NULL);
+
+  // Failure path (pointer variant): expected stale, refresh from *ptr.
+  expected = NULL;
+  node_t *other = &a;
+  ok = __atomic_compare_exchange(&head, &expected, &other, 0, 5, 5);
+  assert(!ok);
+  assert(head == &b);
+  assert(expected == &b);
+
+  return 0;
+}

--- a/regression/esbmc-unix/github_4436/test.desc
+++ b/regression/esbmc-unix/github_4436/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_4436/test.desc
+++ b/regression/esbmc-unix/github_4436/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---bitwuzla
+
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_polymorphic_functions.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_polymorphic_functions.cpp
@@ -155,11 +155,14 @@ exprt clang_c_adjust::is_gcc_polymorphic_builtin(
     parameters.push_back(code_typet::argumentt(ptr_arg.type()));
     parameters.push_back(code_typet::argumentt(ptr_arg.type()));
 
-    if (has_prefix(identifier.as_string(), "c:@F@__atomic_compare_exchange"))
-      parameters.push_back(code_typet::argumentt(ptr_arg.type()));
-    else
+    // __atomic_compare_exchange_n takes `desired` by value; the non-_n variant
+    // takes a pointer. has_prefix("__atomic_compare_exchange") also matches
+    // the _n suffix, so check the more specific name first.
+    if (has_prefix(identifier.as_string(), "c:@F@__atomic_compare_exchange_n"))
       parameters.push_back(
         code_typet::argumentt(to_pointer_type(ptr_arg.type()).subtype()));
+    else
+      parameters.push_back(code_typet::argumentt(ptr_arg.type()));
 
     parameters.push_back(code_typet::argumentt(bool_type()));
     parameters.push_back(code_typet::argumentt(int_type()));
@@ -506,15 +509,80 @@ code_blockt clang_c_adjust::instantiate_gcc_polymorphic_builtin(
   {
     // TODO
   }
-  else if (has_prefix(
-             identifier.as_string(), "c:@F@__atomic_compare_exchange_n"))
+  else if (
+    has_prefix(identifier.as_string(), "c:@F@__atomic_compare_exchange_n") ||
+    has_prefix(identifier.as_string(), "c:@F@__atomic_compare_exchange"))
   {
-    // TODO
-  }
-  else if (has_prefix(
-             identifier.as_string(), "c:@F@__atomic_compare_exchange_n"))
-  {
-    // TODO
+    // GCC __atomic_compare_exchange{,_n} - strong CAS modelled atomically.
+    // See https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html.
+    //
+    //   bool __atomic_compare_exchange_n(T *ptr, T *expected, T desired,
+    //                                    bool weak, int success_mo,
+    //                                    int failure_mo);
+    //   bool __atomic_compare_exchange  (T *ptr, T *expected, T *desired,
+    //                                    bool weak, int success_mo,
+    //                                    int failure_mo);
+    //
+    // Modelled (under __ESBMC_atomic_begin/_end) as:
+    //   result = (*ptr == *expected);
+    //   if (result) *ptr = desired_value; else *expected = *ptr;
+    //   return result;
+    //
+    // We treat the CAS as strong regardless of `weak` (a weak CAS that can
+    // spuriously fail is a sound under-approximation of strong, but libvsync
+    // - the motivating consumer - issues only strong CASes).
+    const bool is_n =
+      has_prefix(identifier.as_string(), "c:@F@__atomic_compare_exchange_n");
+
+    const typet &ret_type = code_type.return_type();
+    const exprt &result =
+      symbol_expr(result_symbol(identifier_with_type, ret_type, context));
+
+    code_declt decl(result);
+    block.operands().push_back(decl);
+
+    code_typet::argumentt arg0 = code_type.arguments()[0];
+    code_typet::argumentt arg1 = code_type.arguments()[1];
+    code_typet::argumentt arg2 = code_type.arguments()[2];
+
+    dereference_exprt ptr_deref(
+      symbol_exprt(arg0.cmt_identifier(), arg0.type()), arg0.type());
+    dereference_exprt exp_deref(
+      symbol_exprt(arg1.cmt_identifier(), arg1.type()), arg1.type());
+
+    exprt desired = symbol_exprt(arg2.cmt_identifier(), arg2.type());
+    if (!is_n)
+      desired = dereference_exprt(desired, arg2.type());
+
+    exprt eq("=", ret_type);
+    eq.copy_to_operands(ptr_deref, exp_deref);
+    code_assignt assign_result(result, eq);
+    assign_result.location() = new_loc;
+    block.operands().push_back(assign_result);
+
+    code_ifthenelset cond;
+    cond.cond() = result;
+
+    code_assignt assign_ptr(ptr_deref, desired);
+    assign_ptr.location() = new_loc;
+    cond.then_case() = assign_ptr;
+
+    code_assignt assign_exp(exp_deref, ptr_deref);
+    assign_exp.location() = new_loc;
+    cond.else_case() = assign_exp;
+
+    block.operands().push_back(cond);
+
+    // atomic scope end
+    side_effect_expr_function_callt atomic_end;
+    atomic_end.function() = symbol_exprt("c:@F@__ESBMC_atomic_end");
+    convert_expression_to_code(atomic_end);
+    block.operands().push_back(atomic_end);
+
+    code_returnt ret;
+    ret.return_value() = result;
+    ret.location() = new_loc;
+    block.operands().push_back(ret);
   }
   else if (
     has_prefix(identifier.as_string(), "c:@F@__atomic_add_fetch") ||

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1107,61 +1107,63 @@ void value_sett::assign(
 
   if (is_struct_type(lhs_type) || is_union_type(lhs_type))
   {
-    if (lhs_type->type_id == rhs->type->type_id)
+    /* Types do not agree (different kind, or same kind but structurally
+     * incompatible). The latter happens when a single translation unit ends
+     * up with two declarations of the same struct tag that differ in members
+     * - e.g. glibc's `struct tm` (with `__tm_gmtoff`/`__tm_zone`) versus
+     * ESBMC's operational `time.h` (`tm_gmtoff`/`tm_zone`) - or for
+     * dereferences like:
+     *
+     *   struct S { int x; } a;
+     *   int b;
+     *   a = *(struct S *)&b;
+     *
+     * which build_reference_to() reports as a dereference_failure. For
+     * value-set tracking we simply drop the assignment.
+     */
+    if (lhs_type->type_id != rhs->type->type_id)
+      return;
+    const bool rhs_concrete = !is_unknown2t(rhs) && !is_invalid2t(rhs);
+    if (
+      rhs_concrete && !base_type_eq(rhs->type, lhs_type, ns) &&
+      !is_subclass_of(lhs_type, rhs->type, ns))
+      return;
+
+    // Assign the values of all members of the rhs thing to the lhs. It's
+    // sort-of-valid for the right hand side to be a superclass of the subclass,
+    // in which case there are some fields not common between them, so we
+    // iterate over the superclasses members.
+    const std::vector<type2tc> &members = struct_union_members(rhs->type);
+    const std::vector<irep_idt> &member_names =
+      struct_union_member_names(rhs->type);
+
+    for (size_t i = 0; i < members.size(); i++)
     {
-      /* either both union or both struct */
-      assert(lhs_type->type_id == rhs->type->type_id);
+      const type2tc &subtype = members[i];
+      const irep_idt &name = member_names[i];
 
-      // Assign the values of all members of the rhs thing to the lhs. It's
-      // sort-of-valid for the right hand side to be a superclass of the subclass,
-      // in which case there are some fields not common between them, so we
-      // iterate over the superclasses members.
-      const std::vector<type2tc> &members = struct_union_members(rhs->type);
-      const std::vector<irep_idt> &member_names =
-        struct_union_member_names(rhs->type);
+      // ignore methods
+      if (is_code_type(subtype))
+        continue;
 
-      for (size_t i = 0; i < members.size(); i++)
+      expr2tc lhs_member = member2tc(subtype, lhs, name);
+
+      expr2tc rhs_member;
+      if (is_unknown2t(rhs))
       {
-        const type2tc &subtype = members[i];
-        const irep_idt &name = member_names[i];
-
-        // ignore methods
-        if (is_code_type(subtype))
-          continue;
-
-        expr2tc lhs_member = member2tc(subtype, lhs, name);
-
-        expr2tc rhs_member;
-        if (is_unknown2t(rhs))
-        {
-          rhs_member = unknown2tc(subtype);
-        }
-        else if (is_invalid2t(rhs))
-        {
-          rhs_member = invalid2tc(subtype);
-        }
-        else
-        {
-          assert(
-            base_type_eq(rhs->type, lhs_type, ns) ||
-            is_subclass_of(lhs_type, rhs->type, ns));
-          expr2tc rhs_member = make_member(rhs, name);
-
-          // XXX -- shouldn't this be one level of indentation up?
-          assign(lhs_member, rhs_member, add_to_sets);
-        }
+        rhs_member = unknown2tc(subtype);
       }
-    }
-    else
-    {
-      /* types do not agree, this can happen during dereferences like this:
-       *   struct S { int x; } a;
-       *   int b;
-       *   a = *(struct S *)&b;
-       * and is caught as a dereference_failure by build_reference_to().
-       *
-       * Thus, we ignore this value-set assignment request here.
-       */
+      else if (is_invalid2t(rhs))
+      {
+        rhs_member = invalid2tc(subtype);
+      }
+      else
+      {
+        expr2tc rhs_member = make_member(rhs, name);
+
+        // XXX -- shouldn't this be one level of indentation up?
+        assign(lhs_member, rhs_member, add_to_sets);
+      }
     }
     return;
   }


### PR DESCRIPTION
Model `__atomic_compare_exchange` and `__atomic_compare_exchange_n` under `__ESBMC_atomic_begin/_end` with the GCC strong-CAS contract; both were previously NOPs, so any CAS-based primitive silently left `*ptr` unchanged and the return value unconstrained — the direct cause of the SV-COMP libvsync `hclhlock` false alarm.

Also drops a `value_sett::assign` assert that fired when two TUs declare structs with the same tag but different members (e.g. glibc `struct tm` vs. ESBMC's operational `time.h`), since the libvsync repro cannot even reach the CAS bug otherwise, and adds a focused CORE regression pinning the success/failure contract for both variants.

Fixes #4436.
