### PR TITLE
refactor smt conversion split from smt_conv

### DIFF
--- a/src/solvers/smt/CMakeLists.txt
+++ b/src/solvers/smt/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(smt
   smt_byteops.cpp
   smt_casts.cpp
   smt_conv.cpp
+  smt_fp_conv.cpp
   smt_memspace.cpp
   smt_overflow.cpp
   smt_bitcast.cpp

--- a/src/solvers/smt/CMakeLists.txt
+++ b/src/solvers/smt/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(smt
   smt_byteops.cpp
   smt_casts.cpp
   smt_conv.cpp
+  # IEEE754 constants/semantics and FP predicates extracted from smt_conv.cpp
   smt_fp_conv.cpp
   smt_memspace.cpp
   smt_overflow.cpp

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <solvers/prop/literal.h>
 #include <solvers/smt/smt_conv.h>
+#include <solvers/smt/smt_fp_rounding_utils.h>
 #include <sstream>
 #include <util/arith_tools.h>
 #include <util/base_type.h>
@@ -203,9 +204,8 @@ static void replace_name_in_body(
       body = replacement;
     return;
   }
-  body->Foreach_operand([&lhs, &replacement](expr2tc &e) {
-    replace_name_in_body(lhs, replacement, e);
-  });
+  body->Foreach_operand([&lhs, &replacement](expr2tc &e)
+                        { replace_name_in_body(lhs, replacement, e); });
 }
 
 /** Recursively expand any symbol in @p e that is a key in @p defs, replacing
@@ -226,8 +226,8 @@ static void expand_quantifier_defs_in(
     }
     return;
   }
-  e->Foreach_operand(
-    [&defs](expr2tc &sub) { expand_quantifier_defs_in(sub, defs); });
+  e->Foreach_operand([&defs](expr2tc &sub)
+                     { expand_quantifier_defs_in(sub, defs); });
 }
 
 void smt_convt::pop_ctx()
@@ -362,996 +362,6 @@ smt_astt smt_convt::convert_assign(const expr2tc &expr)
   return side2;
 }
 
-smt_astt smt_convt::get_zero_real()
-{
-  // Returns SMT representation of zero (0.0)
-  return mk_smt_real("0");
-}
-
-smt_astt smt_convt::get_double_min_normal()
-{
-  // IEEE 754 double precision minimum normal positive value (2^-1022)
-  return mk_smt_real("2.2250738585072014e-308");
-}
-
-smt_astt smt_convt::get_double_min_subnormal()
-{
-  // IEEE 754 double precision minimum positive subnormal value (2^-1074)
-  // Rounded UP at the last digit to ensure the enclosure is conservative.
-  return mk_smt_real("4.9406564584124655e-324");
-}
-
-// Returns true iff the rounding mode expression is a concrete integer constant
-// equal to ieee_floatt::ROUND_TO_EVEN (round-to-nearest-ties-to-even).
-// Directed modes (ROUND_TO_PLUS_INF, ROUND_TO_MINUS_INF, ROUND_TO_ZERO),
-// ROUND_TO_AWAY (handled by its own guard), symbolic rounding modes, and nil
-// expr2tc all return false.
-static bool is_nearest_rounding_mode(const expr2tc &rounding_mode)
-{
-  if (is_nil_expr(rounding_mode))
-    return false;
-  if (!is_constant_int2t(rounding_mode))
-    return false;
-  return to_constant_int2t(rounding_mode).value ==
-         BigInt(ieee_floatt::ROUND_TO_EVEN);
-}
-
-static bool is_round_to_plus_inf(const expr2tc &rounding_mode)
-{
-  if (is_nil_expr(rounding_mode))
-    return false;
-  if (!is_constant_int2t(rounding_mode))
-    return false;
-  return to_constant_int2t(rounding_mode).value ==
-         BigInt(ieee_floatt::ROUND_TO_PLUS_INF);
-}
-
-static bool is_round_to_minus_inf(const expr2tc &rounding_mode)
-{
-  if (is_nil_expr(rounding_mode))
-    return false;
-  if (!is_constant_int2t(rounding_mode))
-    return false;
-  return to_constant_int2t(rounding_mode).value ==
-         BigInt(ieee_floatt::ROUND_TO_MINUS_INF);
-}
-
-static bool is_round_to_zero(const expr2tc &rounding_mode)
-{
-  if (is_nil_expr(rounding_mode))
-    return false;
-  if (!is_constant_int2t(rounding_mode))
-    return false;
-  return to_constant_int2t(rounding_mode).value ==
-         BigInt(ieee_floatt::ROUND_TO_ZERO);
-}
-
-static bool is_round_to_away(const expr2tc &rounding_mode)
-{
-  if (is_nil_expr(rounding_mode))
-    return false;
-  if (!is_constant_int2t(rounding_mode))
-    return false;
-  return to_constant_int2t(rounding_mode).value ==
-         BigInt(ieee_floatt::ROUND_TO_AWAY);
-}
-
-std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rne_enclosure(
-  smt_astt real_result,
-  smt_astt lo_r,
-  smt_astt hi_r,
-  const floatbv_type2t &fbv_type)
-{
-  const auto double_spec = ieee_float_spect::double_precision();
-  const auto single_spec = ieee_float_spect::single_precision();
-  smt_astt eps_rel, eps_abs;
-  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-  {
-    eps_rel = get_double_eps_rel();       // 2^-53
-    eps_abs = get_double_min_subnormal(); // 2^-1074
-  }
-  else if (
-    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-  {
-    eps_rel = get_single_eps_rel();       // 2^-24
-    eps_abs = get_single_min_subnormal(); // 2^-149
-  }
-  else
-  {
-    assert(!"apply_ieee754_rne_enclosure: unsupported FP format");
-  }
-
-  smt_sortt rs = mk_real_sort();
-  smt_astt zero = mk_smt_real("0.0");
-
-  // B_near^-(R) = eps_rel * |lo_r| + eps_abs  (bound using lower endpoint)
-  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
-  smt_astt bound_lo = mk_add(mk_mul(eps_rel, abs_lo), eps_abs);
-
-  // B_near^+(R) = eps_rel * |hi_r| + eps_abs  (bound using upper endpoint)
-  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
-  smt_astt bound_hi = mk_add(mk_mul(eps_rel, abs_hi), eps_abs);
-
-  // ra_lo = lo_r - B_near^-(R),  ra_hi = hi_r + B_near^+(R)
-  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo);
-  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi);
-
-  // Named enclosure variables, pinned via bidirectional inequalities to
-  // survive Z3's solve-eqs tactic (same technique as the single-step path).
-  smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
-  smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
-
-  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= lo_r - B_near^-(R)
-  assert_ast(mk_le(ra_lo_expr, ra_lo)); // lo_r - B_near^-(R) <= ra_lo
-  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= hi_r + B_near^+(R)
-  assert_ast(mk_le(ra_hi_expr, ra_hi)); // hi_r + B_near^+(R) <= ra_hi
-
-  // Containment: ra_lo <= real_result <= ra_hi  and  ra_lo <= ra_hi
-  assert_ast(mk_le(ra_lo, real_result));
-  assert_ast(mk_le(real_result, ra_hi));
-  assert_ast(mk_le(ra_lo, ra_hi));
-
-  return {ra_lo, ra_hi};
-}
-
-std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rna_enclosure(
-  smt_astt real_result,
-  smt_astt lo_r,
-  smt_astt hi_r,
-  const floatbv_type2t &fbv_type)
-{
-  // Parallel to apply_ieee754_rne_enclosure.
-  // ROUND_TO_AWAY uses the same B_near constants and formula shape as
-  // ROUND_TO_EVEN (same unit roundoff); the only difference is the symbol
-  // name prefix: ra_lo_aw:: / ra_hi_aw:: to match the RNA single-step path.
-  const auto double_spec = ieee_float_spect::double_precision();
-  const auto single_spec = ieee_float_spect::single_precision();
-  smt_astt eps_rel, eps_abs;
-  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-  {
-    eps_rel = get_double_eps_rel();       // 2^-53
-    eps_abs = get_double_min_subnormal(); // 2^-1074
-  }
-  else if (
-    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-  {
-    eps_rel = get_single_eps_rel();       // 2^-24
-    eps_abs = get_single_min_subnormal(); // 2^-149
-  }
-  else
-  {
-    assert(!"apply_ieee754_rna_enclosure: unsupported FP format");
-  }
-
-  smt_sortt rs = mk_real_sort();
-  smt_astt zero = mk_smt_real("0.0");
-
-  // B_near^-(R) = eps_rel * |lo_r| + eps_abs  (bound using lower endpoint)
-  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
-  smt_astt bound_lo = mk_add(mk_mul(eps_rel, abs_lo), eps_abs);
-
-  // B_near^+(R) = eps_rel * |hi_r| + eps_abs  (bound using upper endpoint)
-  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
-  smt_astt bound_hi = mk_add(mk_mul(eps_rel, abs_hi), eps_abs);
-
-  // ra_lo = lo_r - B_near^-(R),  ra_hi = hi_r + B_near^+(R)
-  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo);
-  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi);
-
-  // RNA-named enclosure variables, pinned via bidirectional inequalities to
-  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
-  smt_astt ra_lo = mk_fresh(rs, "ra_lo_aw::", nullptr);
-  smt_astt ra_hi = mk_fresh(rs, "ra_hi_aw::", nullptr);
-
-  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo_aw <= lo_r - B_near^-(R)
-  assert_ast(mk_le(ra_lo_expr, ra_lo)); // lo_r - B_near^-(R) <= ra_lo_aw
-  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi_aw <= hi_r + B_near^+(R)
-  assert_ast(mk_le(ra_hi_expr, ra_hi)); // hi_r + B_near^+(R) <= ra_hi_aw
-
-  // Containment: ra_lo_aw <= real_result <= ra_hi_aw  and  ra_lo_aw <= ra_hi_aw
-  assert_ast(mk_le(ra_lo, real_result));
-  assert_ast(mk_le(real_result, ra_hi));
-  assert_ast(mk_le(ra_lo, ra_hi));
-
-  return {ra_lo, ra_hi};
-}
-
-std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rup_enclosure(
-  smt_astt real_result,
-  smt_astt lo_r,
-  smt_astt hi_r,
-  const floatbv_type2t &fbv_type)
-{
-  // EbRUP([LR, UR]) = [LR, UR + B_dir(UR)]
-  // fl_RUP(r) >= r for all r, so the lower bound is exact: ra_lo = lo_r.
-  // fl_RUP(r) <= r + B_dir(r) <= UR + B_dir(UR) for r in [LR, UR],
-  // so the upper bound is hi_r + B_dir(hi_r).
-  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
-  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
-  const auto double_spec = ieee_float_spect::double_precision();
-  const auto single_spec = ieee_float_spect::single_precision();
-  smt_astt eps_rel_dir, eps_abs;
-  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-  {
-    eps_rel_dir = get_double_eps_up(); // 2^-52
-    eps_abs = get_double_min_subnormal();
-  }
-  else if (
-    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-  {
-    eps_rel_dir = get_single_eps_up(); // 2^-23
-    eps_abs = get_single_min_subnormal();
-  }
-  else
-  {
-    assert(!"apply_ieee754_rup_enclosure: unsupported FP format");
-  }
-
-  smt_sortt rs = mk_real_sort();
-  smt_astt zero = mk_smt_real("0.0");
-
-  // B_dir(hi_r) = eps_rel_dir * |hi_r| + eps_abs  (bound at upper endpoint)
-  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
-  smt_astt bound_hi = mk_add(mk_mul(eps_rel_dir, abs_hi), eps_abs);
-  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi); // UR + B_dir(UR)
-
-  // RUP-named enclosure variables, pinned via bidirectional inequalities to
-  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
-  smt_astt ra_lo = mk_fresh(rs, "ra_lo_up::", nullptr);
-  smt_astt ra_hi = mk_fresh(rs, "ra_hi_up::", nullptr);
-
-  // Pin ra_lo = lo_r  (exact lower bound: RUP never rounds below the true value)
-  assert_ast(mk_le(ra_lo, lo_r)); // ra_lo_up <= LR
-  assert_ast(mk_le(lo_r, ra_lo)); // LR <= ra_lo_up  =>  ra_lo_up == LR
-
-  // Pin ra_hi = hi_r + B_dir(hi_r)
-  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi_up <= UR + B_dir(UR)
-  assert_ast(mk_le(ra_hi_expr, ra_hi)); // UR + B_dir(UR) <= ra_hi_up
-
-  // Containment: ra_lo_up <= real_result <= ra_hi_up  and  ra_lo_up <= ra_hi_up
-  assert_ast(mk_le(ra_lo, real_result));
-  assert_ast(mk_le(real_result, ra_hi));
-  assert_ast(mk_le(ra_lo, ra_hi));
-
-  return {ra_lo, ra_hi};
-}
-
-std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rdn_enclosure(
-  smt_astt real_result,
-  smt_astt lo_r,
-  smt_astt hi_r,
-  const floatbv_type2t &fbv_type)
-{
-  // EbRDN([LR, UR]) = [LR - B_dir(LR), UR]
-  // fl_RDN(r) <= r for all r, so the upper bound is exact: ra_hi = hi_r.
-  // fl_RDN(r) >= r - B_dir(r) >= LR - B_dir(LR) for r in [LR, UR],
-  // so the lower bound is lo_r - B_dir(lo_r).
-  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
-  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
-  const auto double_spec = ieee_float_spect::double_precision();
-  const auto single_spec = ieee_float_spect::single_precision();
-  smt_astt eps_rel_dir, eps_abs;
-  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-  {
-    eps_rel_dir = get_double_eps_up(); // 2^-52
-    eps_abs = get_double_min_subnormal();
-  }
-  else if (
-    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-  {
-    eps_rel_dir = get_single_eps_up(); // 2^-23
-    eps_abs = get_single_min_subnormal();
-  }
-  else
-  {
-    assert(!"apply_ieee754_rdn_enclosure: unsupported FP format");
-  }
-
-  smt_sortt rs = mk_real_sort();
-  smt_astt zero = mk_smt_real("0.0");
-
-  // B_dir(lo_r) = eps_rel_dir * |lo_r| + eps_abs  (bound at lower endpoint)
-  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
-  smt_astt bound_lo = mk_add(mk_mul(eps_rel_dir, abs_lo), eps_abs);
-  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo); // LR - B_dir(LR)
-
-  // RDN-named enclosure variables, pinned via bidirectional inequalities to
-  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
-  smt_astt ra_lo = mk_fresh(rs, "ra_lo_dn::", nullptr);
-  smt_astt ra_hi = mk_fresh(rs, "ra_hi_dn::", nullptr);
-
-  // Pin ra_lo = lo_r - B_dir(lo_r)
-  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo_dn <= LR - B_dir(LR)
-  assert_ast(mk_le(ra_lo_expr, ra_lo)); // LR - B_dir(LR) <= ra_lo_dn
-
-  // Pin ra_hi = hi_r  (exact upper bound: RDN never rounds above the true value)
-  assert_ast(mk_le(ra_hi, hi_r)); // ra_hi_dn <= UR
-  assert_ast(mk_le(hi_r, ra_hi)); // UR <= ra_hi_dn  =>  ra_hi_dn == UR
-
-  // Containment: ra_lo_dn <= real_result <= ra_hi_dn  and  ra_lo_dn <= ra_hi_dn
-  assert_ast(mk_le(ra_lo, real_result));
-  assert_ast(mk_le(real_result, ra_hi));
-  assert_ast(mk_le(ra_lo, ra_hi));
-
-  return {ra_lo, ra_hi};
-}
-
-std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rtz_enclosure(
-  smt_astt real_result,
-  smt_astt lo_r,
-  smt_astt hi_r,
-  const floatbv_type2t &fbv_type)
-{
-  // RTZ (truncation toward zero) is sign-dependent.
-  // For an interval hull [LR, UR] = [lo_r, hi_r]:
-  //
-  //   Case 1 -- LR >= 0 (all non-negative): fl_RTZ acts like RDN
-  //     EbRTZ([LR,UR]) = [LR - B_dir(LR), UR]   (exact upper bound)
-  //
-  //   Case 2 -- UR <= 0 (all non-positive): fl_RTZ acts like RUP
-  //     EbRTZ([LR,UR]) = [LR, UR + B_dir(UR)]   (exact lower bound)
-  //
-  //   Case 3 -- LR < 0 < UR (hull crosses zero): sign of actual result
-  //     is unknown at encode time; use conservative symmetric bound:
-  //     B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs
-  //     EbRTZ([LR,UR]) = [LR - B_dir_max, UR + B_dir_max]
-  //
-  // The three cases are encoded as nested ITE on lo_nonneg / hi_nonpos.
-  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
-  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
-  const auto double_spec = ieee_float_spect::double_precision();
-  const auto single_spec = ieee_float_spect::single_precision();
-  smt_astt eps_rel_dir, eps_abs;
-  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-  {
-    eps_rel_dir = get_double_eps_up(); // 2^-52
-    eps_abs = get_double_min_subnormal();
-  }
-  else if (
-    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-  {
-    eps_rel_dir = get_single_eps_up(); // 2^-23
-    eps_abs = get_single_min_subnormal();
-  }
-  else
-  {
-    assert(!"apply_ieee754_rtz_enclosure: unsupported FP format");
-  }
-
-  smt_sortt rs = mk_real_sort();
-  smt_astt zero = mk_smt_real("0.0");
-
-  // |LR| and |UR|
-  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
-  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
-
-  // B_dir at each endpoint
-  smt_astt bound_lo = mk_add(mk_mul(eps_rel_dir, abs_lo), eps_abs); // B_dir(LR)
-  smt_astt bound_hi = mk_add(mk_mul(eps_rel_dir, abs_hi), eps_abs); // B_dir(UR)
-
-  // B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs  (crossing-zero case)
-  smt_astt abs_max = mk_ite(mk_le(abs_lo, abs_hi), abs_hi, abs_lo);
-  smt_astt bound_max = mk_add(mk_mul(eps_rel_dir, abs_max), eps_abs);
-
-  // Case selectors
-  smt_astt lo_nonneg = mk_le(zero, lo_r); // LR >= 0
-  smt_astt hi_nonpos = mk_le(hi_r, zero); // UR <= 0
-
-  // ra_lo_expr:
-  //   LR >= 0 -> LR - B_dir(LR)    (truncate-down: lower gets error)
-  //   UR <= 0 -> LR                 (truncate-up: lower is exact)
-  //   else    -> LR - B_dir_max    (crossing zero: conservative)
-  smt_astt ra_lo_expr = mk_ite(
-    lo_nonneg,
-    mk_sub(lo_r, bound_lo),
-    mk_ite(hi_nonpos, lo_r, mk_sub(lo_r, bound_max)));
-
-  // ra_hi_expr:
-  //   LR >= 0 -> UR                 (truncate-down: upper is exact)
-  //   UR <= 0 -> UR + B_dir(UR)    (truncate-up: upper gets error)
-  //   else    -> UR + B_dir_max    (crossing zero: conservative)
-  smt_astt ra_hi_expr = mk_ite(
-    lo_nonneg,
-    hi_r,
-    mk_ite(hi_nonpos, mk_add(hi_r, bound_hi), mk_add(hi_r, bound_max)));
-
-  // RTZ-named enclosure variables, pinned via bidirectional inequalities to
-  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
-  smt_astt ra_lo = mk_fresh(rs, "ra_lo_tz::", nullptr);
-  smt_astt ra_hi = mk_fresh(rs, "ra_hi_tz::", nullptr);
-
-  // Pin ra_lo = ra_lo_expr
-  assert_ast(mk_le(ra_lo, ra_lo_expr));
-  assert_ast(mk_le(ra_lo_expr, ra_lo));
-
-  // Pin ra_hi = ra_hi_expr
-  assert_ast(mk_le(ra_hi, ra_hi_expr));
-  assert_ast(mk_le(ra_hi_expr, ra_hi));
-
-  // Containment: ra_lo_tz <= real_result <= ra_hi_tz  and  ra_lo_tz <= ra_hi_tz
-  assert_ast(mk_le(ra_lo, real_result));
-  assert_ast(mk_le(real_result, ra_hi));
-  assert_ast(mk_le(ra_lo, ra_hi));
-
-  return {ra_lo, ra_hi};
-}
-
-smt_astt smt_convt::apply_ieee754_semantics(
-  smt_astt real_result,
-  const floatbv_type2t &fbv_type,
-  smt_astt operand_zero_check,
-  const expr2tc &rounding_mode)
-{
-  if (this->options.get_bool_option("ir-ieee"))
-  {
-    if (is_nearest_rounding_mode(rounding_mode))
-    {
-      // Tight path: rounding mode is concrete round-to-nearest.
-      // Attach a sound symmetric enclosure around the real semantic
-      // term `r` for nearest rounding mode.
-      //
-      // For an FP operation whose exact real value is r, the round-to-nearest
-      // error satisfies:
-      //   |fl(r) - r| <= eps_rel * |r| + eps_abs
-      //
-      // So we define:
-      //   B(r)  = eps_rel * |r| + eps_abs
-      //   ra_lo = r - B(r)
-      //   ra_hi = r + B(r)
-      //
-      // and assert  ra_lo <= result <= ra_hi  and  ra_lo <= ra_hi.
-      //
-      // TODO: extend to non-standard FP formats beyond single and double.
-
-      unsigned int fraction_bits = fbv_type.fraction;
-      unsigned int exponent_bits = fbv_type.exponent;
-
-      auto double_spec = ieee_float_spect::double_precision();
-      auto single_spec = ieee_float_spect::single_precision();
-
-      smt_astt eps_rel, eps_abs;
-
-      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
-      {
-        eps_rel = get_double_eps_rel(); // 2^-53
-        eps_abs =
-          get_double_min_subnormal(); // 2^-1074 (covers underflow region)
-      }
-      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
-      {
-        eps_rel = get_single_eps_rel();       // 2^-24
-        eps_abs = get_single_min_subnormal(); // 2^-149
-      }
-      else
-      {
-        // TODO: theorem-driven bounds for non-standard formats are not yet
-        // implemented; fall back to unconstrained enclosure (sound but weak).
-        smt_sortt rs = mk_real_sort();
-        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
-        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
-        assert_ast(mk_le(ra_lo, real_result));
-        assert_ast(mk_le(real_result, ra_hi));
-        assert_ast(mk_le(ra_lo, ra_hi));
-        return real_result;
-      }
-
-      smt_sortt rs = mk_real_sort();
-      smt_astt zero = mk_smt_real("0.0");
-
-      // |r| = r >= 0 ? r : -r
-      smt_astt abs_r = mk_ite(
-        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
-
-      // B(r) = eps_rel * |r| + eps_abs
-      smt_astt bound = mk_add(mk_mul(eps_rel, abs_r), eps_abs);
-
-      // ra_lo = r - B(r),  ra_hi = r + B(r)
-      smt_astt ra_lo_expr = mk_sub(real_result, bound);
-      smt_astt ra_hi_expr = mk_add(real_result, bound);
-
-      // Introduce named enclosure variables and pin them to the bound expressions
-      // via bidirectional inequalities.  A plain mk_eq(ra_lo, ra_lo_expr) is
-      // correct but the Z3 tactic pipeline (solve-eqs) eliminates definitional
-      // equalities from the visible assertion set, making them invisible in the
-      // SMT output.  Two mk_le assertions are logically equivalent and are not
-      // targeted by solve-eqs, so they survive in the final formula.
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
-      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B(r)
-      assert_ast(
-        mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo  =>  ra_lo == r - B(r)
-      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B(r)
-      assert_ast(
-        mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi  =>  ra_hi == r + B(r)
-
-      // Containment: ra_lo <= result <= ra_hi
-      assert_ast(mk_le(ra_lo, real_result));
-      assert_ast(mk_le(real_result, ra_hi));
-      assert_ast(mk_le(ra_lo, ra_hi));
-
-      return real_result;
-    }
-    else if (is_round_to_plus_inf(rounding_mode))
-    {
-      // Asymmetric tight enclosure for ROUND_TO_PLUS_INF:
-      //   fl_RUP(r) >= r  (exact lower bound; round-up never undershoots)
-      //   fl_RUP(r) <= r + B_dir(r)
-      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
-      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- the full machine epsilon
-
-      unsigned int fraction_bits = fbv_type.fraction;
-      unsigned int exponent_bits = fbv_type.exponent;
-
-      auto double_spec = ieee_float_spect::double_precision();
-      auto single_spec = ieee_float_spect::single_precision();
-
-      smt_sortt rs = mk_real_sort();
-      smt_astt eps_up, eps_abs;
-
-      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
-      {
-        eps_up = get_double_eps_up();
-        eps_abs = get_double_min_subnormal();
-      }
-      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
-      {
-        eps_up = get_single_eps_up();
-        eps_abs = get_single_min_subnormal();
-      }
-      else
-      {
-        // Unsupported format: fall back to unconstrained weak enclosure.
-        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
-        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
-        assert_ast(mk_le(ra_lo, real_result));
-        assert_ast(mk_le(real_result, ra_hi));
-        assert_ast(mk_le(ra_lo, ra_hi));
-        return real_result;
-      }
-
-      smt_astt zero = mk_smt_real("0.0");
-      smt_astt abs_r = mk_ite(
-        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
-
-      // B_dir(r) = eps_rel_dir * |r| + eps_abs
-      smt_astt b_dir = mk_add(mk_mul(eps_up, abs_r), eps_abs);
-      smt_astt ra_hi_expr = mk_add(real_result, b_dir);
-
-      // Introduce named enclosure variables. Use bidirectional inequalities to
-      // survive Z3's solve-eqs tactic (same technique as the nearest-mode path).
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo_up::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi_up::", nullptr);
-
-      // Pin ra_lo = r (the exact lower bound for round-up)
-      assert_ast(mk_le(ra_lo, real_result)); // ra_lo <= r
-      assert_ast(mk_le(real_result, ra_lo)); // r <= ra_lo  =>  ra_lo == r
-
-      // Pin ra_hi = r + B_dir(r)
-      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B_dir(r)
-      assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B_dir(r) <= ra_hi
-
-      // Containment: ra_lo <= result <= ra_hi
-      assert_ast(mk_le(ra_lo, real_result));
-      assert_ast(mk_le(real_result, ra_hi));
-      assert_ast(mk_le(ra_lo, ra_hi));
-
-      return real_result;
-    }
-    else if (is_round_to_minus_inf(rounding_mode))
-    {
-      // Asymmetric tight enclosure for ROUND_TO_MINUS_INF:
-      //   fl_RDN(r) <= r  (exact upper bound; round-down never overshoots)
-      //   fl_RDN(r) >= r - B_dir(r)
-      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
-      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single)
-      //   This is the directed-mode error constant, the same value used for
-      //   ROUND_TO_PLUS_INF; the bound shape is the mirror image.
-
-      unsigned int fraction_bits = fbv_type.fraction;
-      unsigned int exponent_bits = fbv_type.exponent;
-
-      auto double_spec = ieee_float_spect::double_precision();
-      auto single_spec = ieee_float_spect::single_precision();
-
-      smt_sortt rs = mk_real_sort();
-      smt_astt eps_rel_dir, eps_abs;
-
-      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
-      {
-        eps_rel_dir = get_double_eps_up(); // 2^-52, same value as RUP
-        eps_abs = get_double_min_subnormal();
-      }
-      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
-      {
-        eps_rel_dir = get_single_eps_up(); // 2^-23, same value as RUP
-        eps_abs = get_single_min_subnormal();
-      }
-      else
-      {
-        // Unsupported format: fall back to unconstrained weak enclosure.
-        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
-        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
-        assert_ast(mk_le(ra_lo, real_result));
-        assert_ast(mk_le(real_result, ra_hi));
-        assert_ast(mk_le(ra_lo, ra_hi));
-        return real_result;
-      }
-
-      smt_astt zero = mk_smt_real("0.0");
-      smt_astt abs_r = mk_ite(
-        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
-
-      // B_dir(r) = eps_rel_dir * |r| + eps_abs
-      smt_astt b_dir = mk_add(mk_mul(eps_rel_dir, abs_r), eps_abs);
-      smt_astt ra_lo_expr = mk_sub(real_result, b_dir); // r - B_dir(r)
-
-      // Introduce named enclosure variables. Use bidirectional inequalities to
-      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo_dn::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi_dn::", nullptr);
-
-      // Pin ra_lo = r - B_dir(r)  (the computed lower bound)
-      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B_dir(r)
-      assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B_dir(r) <= ra_lo
-
-      // Pin ra_hi = r  (exact upper bound for round-down)
-      assert_ast(mk_le(ra_hi, real_result)); // ra_hi <= r
-      assert_ast(mk_le(real_result, ra_hi)); // r <= ra_hi  =>  ra_hi == r
-
-      // Containment: ra_lo <= result <= ra_hi
-      assert_ast(mk_le(ra_lo, real_result));
-      assert_ast(mk_le(real_result, ra_hi));
-      assert_ast(mk_le(ra_lo, ra_hi));
-
-      return real_result;
-    }
-    else if (is_round_to_zero(rounding_mode))
-    {
-      // Asymmetric tight enclosure for ROUND_TO_ZERO (truncation toward zero).
-      //
-      // RTZ is sign-dependent: it rounds down for r >= 0 and rounds up for r < 0.
-      //   r >= 0:  fl_RTZ(r) in [r - B_dir(r),  r]   (same shape as RDN)
-      //   r <  0:  fl_RTZ(r) in [r,  r + B_dir(r)]   (same shape as RUP)
-      //
-      // Unified via ITE on sign:
-      //   ra_lo = ite(r >= 0,  r - B_dir(r),  r)
-      //   ra_hi = ite(r >= 0,  r,              r + B_dir(r))
-      //
-      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
-      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon
-
-      unsigned int fraction_bits = fbv_type.fraction;
-      unsigned int exponent_bits = fbv_type.exponent;
-
-      auto double_spec = ieee_float_spect::double_precision();
-      auto single_spec = ieee_float_spect::single_precision();
-
-      smt_sortt rs = mk_real_sort();
-      smt_astt eps_rel_dir, eps_abs;
-
-      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
-      {
-        eps_rel_dir = get_double_eps_up(); // 2^-52, same value as RUP/RDN
-        eps_abs = get_double_min_subnormal();
-      }
-      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
-      {
-        eps_rel_dir = get_single_eps_up(); // 2^-23, same value as RUP/RDN
-        eps_abs = get_single_min_subnormal();
-      }
-      else
-      {
-        // Unsupported format: fall back to unconstrained weak enclosure.
-        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
-        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
-        assert_ast(mk_le(ra_lo, real_result));
-        assert_ast(mk_le(real_result, ra_hi));
-        assert_ast(mk_le(ra_lo, ra_hi));
-        return real_result;
-      }
-
-      smt_astt zero = mk_smt_real("0.0");
-      smt_astt abs_r = mk_ite(
-        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
-
-      // B_dir(r) = eps_rel_dir * |r| + eps_abs
-      smt_astt b_dir = mk_add(mk_mul(eps_rel_dir, abs_r), eps_abs);
-
-      // Sign-dependent enclosure bounds via ITE:
-      //   r >= 0: lower is computed, upper is exact (truncate-down shape)
-      //   r <  0: lower is exact,    upper is computed (truncate-up shape)
-      smt_astt r_nonneg = mk_le(zero, real_result); // r >= 0
-      smt_astt ra_lo_expr =
-        mk_ite(r_nonneg, mk_sub(real_result, b_dir), real_result);
-      smt_astt ra_hi_expr =
-        mk_ite(r_nonneg, real_result, mk_add(real_result, b_dir));
-
-      // Introduce named enclosure variables. Use bidirectional inequalities to
-      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo_tz::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi_tz::", nullptr);
-
-      // Pin ra_lo = ite(r >= 0, r - B_dir(r), r)
-      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= ra_lo_expr
-      assert_ast(mk_le(ra_lo_expr, ra_lo)); // ra_lo_expr <= ra_lo
-
-      // Pin ra_hi = ite(r >= 0, r, r + B_dir(r))
-      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= ra_hi_expr
-      assert_ast(mk_le(ra_hi_expr, ra_hi)); // ra_hi_expr <= ra_hi
-
-      // Containment: ra_lo <= result <= ra_hi
-      assert_ast(mk_le(ra_lo, real_result));
-      assert_ast(mk_le(real_result, ra_hi));
-      assert_ast(mk_le(ra_lo, ra_hi));
-
-      return real_result;
-    }
-    else if (is_round_to_away(rounding_mode))
-    {
-      // Tight path for ROUND_TO_AWAY (round-to-nearest, ties away from zero).
-      //
-      // ROUND_TO_AWAY is a nearest-rounding mode: the rounding error is
-      // bounded by the unit roundoff u = 1/2 * machine-epsilon, exactly as
-      // for ROUND_TO_EVEN.  The enclosure is therefore symmetric:
-      //   |fl_RTA(r) - r| <= eps_rel * |r| + eps_abs
-      //
-      // So:
-      //   B(r)  = eps_rel * |r| + eps_abs    (same formula as nearest)
-      //   ra_lo = r - B(r)
-      //   ra_hi = r + B(r)
-      //
-      // The epsilon constants are the same as ROUND_TO_EVEN:
-      //   eps_rel = 2^-53 (double) or 2^-24 (single) -- unit roundoff u
-      //
-      // NOTE: the Z3 numerator for eps_rel is the same as for the nearest
-      // path (5551115123125783 for double, 5960464477539063 for single).
-      // This is expected and correct -- the bound is identical.
-
-      unsigned int fraction_bits = fbv_type.fraction;
-      unsigned int exponent_bits = fbv_type.exponent;
-
-      auto double_spec = ieee_float_spect::double_precision();
-      auto single_spec = ieee_float_spect::single_precision();
-
-      smt_sortt rs = mk_real_sort();
-      smt_astt eps_rel, eps_abs;
-
-      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
-      {
-        eps_rel = get_double_eps_rel(); // 2^-53, same as ROUND_TO_EVEN
-        eps_abs = get_double_min_subnormal();
-      }
-      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
-      {
-        eps_rel = get_single_eps_rel(); // 2^-24, same as ROUND_TO_EVEN
-        eps_abs = get_single_min_subnormal();
-      }
-      else
-      {
-        // Unsupported format: fall back to unconstrained weak enclosure.
-        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
-        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
-        assert_ast(mk_le(ra_lo, real_result));
-        assert_ast(mk_le(real_result, ra_hi));
-        assert_ast(mk_le(ra_lo, ra_hi));
-        return real_result;
-      }
-
-      smt_astt zero = mk_smt_real("0.0");
-      smt_astt abs_r = mk_ite(
-        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
-
-      // B(r) = eps_rel * |r| + eps_abs
-      smt_astt bound = mk_add(mk_mul(eps_rel, abs_r), eps_abs);
-      smt_astt ra_lo_expr = mk_sub(real_result, bound);
-      smt_astt ra_hi_expr = mk_add(real_result, bound);
-
-      // Introduce named enclosure variables. Use bidirectional inequalities to
-      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo_aw::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi_aw::", nullptr);
-
-      // Pin ra_lo = r - B(r)
-      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B(r)
-      assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo
-
-      // Pin ra_hi = r + B(r)
-      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B(r)
-      assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi
-
-      // Containment: ra_lo <= result <= ra_hi
-      assert_ast(mk_le(ra_lo, real_result));
-      assert_ast(mk_le(real_result, ra_hi));
-      assert_ast(mk_le(ra_lo, ra_hi));
-
-      return real_result;
-    }
-    else
-    {
-      // weak fallback: symbolic or unrecognised rounding mode
-      smt_sortt rs = mk_real_sort();
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
-      assert_ast(mk_le(ra_lo, real_result));
-      assert_ast(mk_le(real_result, ra_hi));
-      assert_ast(mk_le(ra_lo, ra_hi));
-      return real_result;
-    }
-  }
-  else
-  {
-    unsigned int fraction_bits = fbv_type.fraction;
-    unsigned int exponent_bits = fbv_type.exponent;
-
-    auto double_spec = ieee_float_spect::double_precision();
-    auto single_spec = ieee_float_spect::single_precision();
-
-    smt_astt min_normal, min_subnormal, max_normal;
-
-    // IEEE 754 double precision (64-bit): 11 exponent bits, 52 fraction bits
-    if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
-    {
-      // Exact rationals: 1/2^1022, 1/2^1074, (2^53-1)*2^971
-      static const std::string dbl_min_normal =
-        "1/" + integer2string(power(2, 1022));
-      static const std::string dbl_min_subnormal =
-        "1/" + integer2string(power(2, 1074));
-      static const std::string dbl_max_normal =
-        integer2string((power(2, 53) - 1) * power(2, 971));
-      min_normal = mk_smt_real(dbl_min_normal);
-      min_subnormal = mk_smt_real(dbl_min_subnormal);
-      max_normal = mk_smt_real(dbl_max_normal);
-    }
-    // IEEE 754 single precision (32-bit): 8 exponent bits, 23 fraction bits
-    else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
-    {
-      // Exact rationals: 1/2^126, 1/2^149, (2^24-1)*2^104
-      static const std::string sgl_min_normal =
-        "1/" + integer2string(power(2, 126));
-      static const std::string sgl_min_subnormal =
-        "1/" + integer2string(power(2, 149));
-      static const std::string sgl_max_normal =
-        integer2string((power(2, 24) - 1) * power(2, 104));
-      min_normal = mk_smt_real(sgl_min_normal);
-      min_subnormal = mk_smt_real(sgl_min_subnormal);
-      max_normal = mk_smt_real(sgl_max_normal);
-    }
-    // Unsupported format - return original result
-    else
-    {
-      log_warning(
-        "Unsupported IEEE 754 format: exponent bits = {}, fraction bits = {}",
-        exponent_bits,
-        fraction_bits);
-      return real_result;
-    }
-
-    smt_astt zero = mk_smt_real("0.0");
-
-    // Get absolute value of result
-    smt_astt abs_result =
-      mk_ite(mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
-
-    // Check for overflow
-    smt_astt overflows = mk_gt(abs_result, max_normal);
-
-    // Check for underflow to zero
-    smt_astt underflows_to_zero = mk_and(
-      mk_lt(abs_result, min_subnormal), mk_not(mk_eq(real_result, zero)));
-
-    // If we have a special zero check (like for multiplication), use it
-    if (operand_zero_check)
-      underflows_to_zero =
-        mk_and(underflows_to_zero, mk_not(operand_zero_check));
-
-    // Check if result is in subnormal range
-    smt_astt is_subnormal =
-      mk_and(mk_ge(abs_result, min_subnormal), mk_lt(abs_result, min_normal));
-
-    // For subnormal values, return the exact real result.
-    // Subnormal arithmetic is exact when results are representable, and the
-    // real arithmetic value already captures the correct value. No floor-based
-    // quantization is applied here because ESBMC's SMT API has no floor/to_int
-    // for reals; adding 0.5 without floor gives a wrong non-integer multiple.
-    smt_astt subnormal_result = real_result;
-
-    // Overflow result (approximate infinity)
-    smt_astt overflow_result =
-      mk_ite(mk_lt(real_result, zero), mk_sub(zero, max_normal), max_normal);
-
-    // Apply IEEE 754 semantics: overflow > underflow > subnormal > normal
-    smt_astt ieee_result = mk_ite(
-      overflows,
-      overflow_result,
-      mk_ite(
-        underflows_to_zero,
-        zero,
-        mk_ite(is_subnormal, subnormal_result, real_result)));
-
-    // Handle special operand zero case for multiplication
-    if (operand_zero_check)
-      return mk_ite(operand_zero_check, zero, ieee_result);
-
-    return ieee_result;
-  }
-}
-
-smt_astt smt_convt::get_double_max_normal()
-{
-  // IEEE 754 double: (2^53-1)*2^971 (exact rational, no rounding)
-  static const std::string val =
-    integer2string((power(2, 53) - 1) * power(2, 971));
-  return mk_smt_real(val);
-}
-
-smt_astt smt_convt::get_single_min_normal()
-{
-  // IEEE 754 single precision minimum normal positive value (2^-126)
-  return mk_smt_real("1.1754943508222875e-38");
-}
-
-smt_astt smt_convt::get_single_min_subnormal()
-{
-  // IEEE 754 single precision minimum positive subnormal value (2^-149)
-  return mk_smt_real("1.4012984643248171e-45");
-}
-
-smt_astt smt_convt::get_single_max_normal()
-{
-  // IEEE 754 single: (2^24-1)*2^104 (exact rational, no rounding)
-  static const std::string val =
-    integer2string((power(2, 24) - 1) * power(2, 104));
-  return mk_smt_real(val);
-}
-
-smt_astt smt_convt::get_double_inf_sentinel()
-{
-  // One above double max_normal: used to represent ±∞ in integer encoding.
-  // This value satisfies |x| > max_normal, so isinf/isfinite predicates fire.
-  static const std::string val =
-    integer2string((power(2, 53) - 1) * power(2, 971) + 1);
-  return mk_smt_real(val);
-}
-
-smt_astt smt_convt::get_single_inf_sentinel()
-{
-  // One above single max_normal: used to represent ±∞ in integer encoding.
-  static const std::string val =
-    integer2string((power(2, 24) - 1) * power(2, 104) + 1);
-  return mk_smt_real(val);
-}
-
-smt_astt smt_convt::get_double_eps_rel()
-{
-  // Relative error bound for IEEE 754 double under round-to-nearest:
-  // half machine epsilon = 2^-53; rounded UP at the last digit to ensure
-  // the enclosure is conservative.
-  return mk_smt_real("1.1102230246251566e-16");
-}
-
-smt_astt smt_convt::get_single_eps_rel()
-{
-  // Relative error bound for IEEE 754 single under round-to-nearest:
-  // half machine epsilon = 2^-24
-  return mk_smt_real("5.960464477539063e-08");
-}
-
-smt_astt smt_convt::get_double_eps_up()
-{
-  // B_dir relative error bound for IEEE 754 double under round-toward-+inf:
-  // eps_rel_dir = 2^-52 (the full machine epsilon for double, DBL_EPSILON).
-  // Conservative decimal: strictly greater than 2^-52 to preserve soundness.
-  return mk_smt_real("2.2204460492503131e-16");
-}
-
-smt_astt smt_convt::get_single_eps_up()
-{
-  // B_dir relative error bound for IEEE 754 single under round-toward-+inf:
-  // eps_rel_dir = 2^-23 (the full machine epsilon for single, FLT_EPSILON).
-  // Exact decimal representation of 2^-23; no rounding required.
-  return mk_smt_real("1.1920928955078125e-07");
-}
-
 smt_astt smt_convt::convert_ast(const expr2tc &expr)
 {
   {
@@ -1437,8 +447,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   {
     // Convert all the arguments and store them in 'args'.
     args.reserve(expr->get_num_sub_exprs());
-    expr->foreach_operand(
-      [this, &args](const expr2tc &e) { args.push_back(convert_ast(e)); });
+    expr->foreach_operand([this, &args](const expr2tc &e)
+                          { args.push_back(convert_ast(e)); });
   }
   }
 
@@ -1665,11 +675,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
-        (is_nearest_rounding_mode(rounding_mode) ||
-         is_round_to_away(rounding_mode) ||
-         is_round_to_plus_inf(rounding_mode) ||
-         is_round_to_minus_inf(rounding_mode) ||
-         is_round_to_zero(rounding_mode)))
+        (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_away(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_zero(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1680,7 +690,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
            fbv_type.fraction == single_spec.f))
         {
           // Lookup with unconditional point-interval fallback.
-          auto get_iv = [this](smt_astt t) -> ra_interval_t {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t
+          {
             auto it = ir_ra_interval_map.find(t);
             return it != ir_ra_interval_map.end() ? it->second
                                                   : ra_interval_t{t, t};
@@ -1690,16 +701,16 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           smt_astt lo_r = mk_add(iv1.lo, iv2.lo); // L_R = L_x + L_y
           smt_astt hi_r = mk_add(iv1.hi, iv2.hi); // U_R = U_x + U_y
           std::pair<smt_astt, smt_astt> bounds;
-          if (is_nearest_rounding_mode(rounding_mode))
+          if (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode))
             bounds =
               apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_away(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_away(rounding_mode))
             bounds =
               apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_plus_inf(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode))
             bounds =
               apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_minus_inf(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode))
             bounds =
               apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
           else
@@ -1758,11 +769,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
-        (is_nearest_rounding_mode(rounding_mode) ||
-         is_round_to_away(rounding_mode) ||
-         is_round_to_plus_inf(rounding_mode) ||
-         is_round_to_minus_inf(rounding_mode) ||
-         is_round_to_zero(rounding_mode)))
+        (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_away(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_zero(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1773,7 +784,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
            fbv_type.fraction == single_spec.f))
         {
           // Lookup with unconditional point-interval fallback.
-          auto get_iv = [this](smt_astt t) -> ra_interval_t {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t
+          {
             auto it = ir_ra_interval_map.find(t);
             return it != ir_ra_interval_map.end() ? it->second
                                                   : ra_interval_t{t, t};
@@ -1783,16 +795,16 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           smt_astt lo_r = mk_sub(iv1.lo, iv2.hi); // L_R = L_x - U_y
           smt_astt hi_r = mk_sub(iv1.hi, iv2.lo); // U_R = U_x - L_y
           std::pair<smt_astt, smt_astt> bounds;
-          if (is_nearest_rounding_mode(rounding_mode))
+          if (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode))
             bounds =
               apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_away(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_away(rounding_mode))
             bounds =
               apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_plus_inf(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode))
             bounds =
               apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_minus_inf(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode))
             bounds =
               apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
           else
@@ -1837,11 +849,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
-        (is_nearest_rounding_mode(rounding_mode) ||
-         is_round_to_away(rounding_mode) ||
-         is_round_to_plus_inf(rounding_mode) ||
-         is_round_to_minus_inf(rounding_mode) ||
-         is_round_to_zero(rounding_mode)))
+        (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_away(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_zero(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1851,7 +863,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           (fbv_type.exponent == single_spec.e &&
            fbv_type.fraction == single_spec.f))
         {
-          auto get_iv = [this](smt_astt t) -> ra_interval_t {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t
+          {
             auto it = ir_ra_interval_map.find(t);
             return it != ir_ra_interval_map.end() ? it->second
                                                   : ra_interval_t{t, t};
@@ -1885,16 +898,16 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
               mk_ite(mk_le(p4, p2), p2, p4),
               mk_ite(mk_le(p4, p3), p3, p4)));
           std::pair<smt_astt, smt_astt> bounds;
-          if (is_nearest_rounding_mode(rounding_mode))
+          if (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode))
             bounds =
               apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_away(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_away(rounding_mode))
             bounds =
               apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_plus_inf(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode))
             bounds =
               apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_minus_inf(rounding_mode))
+          else if (smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode))
             bounds =
               apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
           else
@@ -1971,13 +984,14 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
-        (is_nearest_rounding_mode(rounding_mode) ||
-         is_round_to_away(rounding_mode) ||
-         is_round_to_plus_inf(rounding_mode) ||
-         is_round_to_minus_inf(rounding_mode) ||
-         is_round_to_zero(rounding_mode)))
+        (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_away(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_zero(rounding_mode)))
       {
-        auto get_iv = [this](smt_astt t) -> ra_interval_t {
+        auto get_iv = [this](smt_astt t) -> ra_interval_t
+        {
           auto it = ir_ra_interval_map.find(t);
           return it != ir_ra_interval_map.end() ? it->second
                                                 : ra_interval_t{t, t};
@@ -2026,13 +1040,13 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         smt_astt hi_r = mk_ite(denom_admissible, hi_r_full, hi_r_point);
 
         std::pair<smt_astt, smt_astt> bounds =
-          is_nearest_rounding_mode(rounding_mode)
+          smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode)
             ? apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type)
-          : is_round_to_away(rounding_mode)
+          : smt_fp_rounding_utils::is_round_to_away(rounding_mode)
             ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
-          : is_round_to_plus_inf(rounding_mode)
+          : smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode)
             ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
-          : is_round_to_minus_inf(rounding_mode)
+          : smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode)
             ? apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type)
             : apply_ieee754_rtz_enclosure(real_result, lo_r, hi_r, fbv_type);
         a = mk_ite(div_by_zero, inf_result, real_result);
@@ -3139,182 +2153,6 @@ smt_astt smt_convt::mk_fresh(
   return mk_smt_symbol(newname, s);
 }
 
-smt_astt smt_convt::convert_is_nan(const expr2tc &expr)
-{
-  const isnan2t &isnan = to_isnan2t(expr);
-
-  // Anything other than floats will never be NaNs
-  if (!is_floatbv_type(isnan.value) || int_encoding)
-    return mk_smt_bool(false);
-
-  smt_astt operand = convert_ast(isnan.value);
-  return fp_api->mk_smt_fpbv_is_nan(operand);
-}
-
-// Returns the max-normal SMT real for single/double floatbv, or nullptr for
-// any other format (caller must handle the unsupported case explicitly).
-static smt_astt get_max_normal(smt_convt &conv, const floatbv_type2t &fbv_type)
-{
-  const auto single_spec = ieee_float_spect::single_precision();
-  const auto double_spec = ieee_float_spect::double_precision();
-  if (fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-    return conv.get_single_max_normal();
-  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-    return conv.get_double_max_normal();
-  return nullptr;
-}
-
-// Returns the min-normal SMT real for single/double floatbv, or nullptr.
-static smt_astt get_min_normal(smt_convt &conv, const floatbv_type2t &fbv_type)
-{
-  const auto single_spec = ieee_float_spect::single_precision();
-  const auto double_spec = ieee_float_spect::double_precision();
-  if (fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-    return conv.get_single_min_normal();
-  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-    return conv.get_double_min_normal();
-  return nullptr;
-}
-
-smt_astt smt_convt::convert_is_inf(const expr2tc &expr)
-{
-  const isinf2t &isinf = to_isinf2t(expr);
-
-  // Anything other than floats will never be infs
-  if (!is_floatbv_type(isinf.value))
-    return mk_smt_bool(false);
-
-  if (int_encoding)
-  {
-    // In integer/real encoding a float is "infinite" when its real value
-    // exceeds the maximum finite float magnitude: |f| > max_normal.
-    const floatbv_type2t &fbv_type = to_floatbv_type(isinf.value->type);
-    smt_astt max_val = get_max_normal(*this, fbv_type);
-    if (!max_val)
-    {
-      log_warning(
-        "isinf: unsupported float format (exp={}, frac={}); returning false",
-        fbv_type.exponent,
-        fbv_type.fraction);
-      return mk_smt_bool(false);
-    }
-    smt_astt operand = convert_ast(isinf.value);
-    smt_astt pos_inf = mk_gt(operand, max_val);
-    smt_astt neg_inf = mk_lt(operand, mk_sub(get_zero_real(), max_val));
-    return mk_or(pos_inf, neg_inf);
-  }
-
-  smt_astt operand = convert_ast(isinf.value);
-  return fp_api->mk_smt_fpbv_is_inf(operand);
-}
-
-smt_astt smt_convt::convert_is_normal(const expr2tc &expr)
-{
-  const isnormal2t &isnormal = to_isnormal2t(expr);
-
-  // Anything other than floats will always be normal
-  if (!is_floatbv_type(isnormal.value))
-    return mk_smt_bool(true);
-
-  if (int_encoding)
-  {
-    // In integer/real encoding a float is normal when min_normal <= |f| <=
-    // max_normal.  Zero and subnormals (|f| < min_normal) are not normal.
-    const floatbv_type2t &fbv_type = to_floatbv_type(isnormal.value->type);
-    smt_astt max_val = get_max_normal(*this, fbv_type);
-    smt_astt min_val = get_min_normal(*this, fbv_type);
-    if (!max_val || !min_val)
-    {
-      log_warning(
-        "isnormal: unsupported float format (exp={}, frac={}); returning true",
-        fbv_type.exponent,
-        fbv_type.fraction);
-      return mk_smt_bool(true);
-    }
-    smt_astt zero = get_zero_real();
-    smt_astt neg_max = mk_sub(zero, max_val);
-    smt_astt neg_min = mk_sub(zero, min_val);
-    smt_astt operand = convert_ast(isnormal.value);
-    // |f| >= min_normal: f >= min_normal || f <= -min_normal
-    smt_astt above_min =
-      mk_or(mk_ge(operand, min_val), mk_le(operand, neg_min));
-    // |f| <= max_normal: f <= max_normal && f >= -max_normal
-    smt_astt below_max =
-      mk_and(mk_le(operand, max_val), mk_ge(operand, neg_max));
-    return mk_and(above_min, below_max);
-  }
-
-  smt_astt operand = convert_ast(isnormal.value);
-  return fp_api->mk_smt_fpbv_is_normal(operand);
-}
-
-smt_astt smt_convt::convert_is_finite(const expr2tc &expr)
-{
-  const isfinite2t &isfinite = to_isfinite2t(expr);
-
-  // Anything other than floats will always be finite
-  if (!is_floatbv_type(isfinite.value))
-    return mk_smt_bool(true);
-
-  if (int_encoding)
-  {
-    // In integer/real encoding a float is finite when |f| <= max_normal.
-    const floatbv_type2t &fbv_type = to_floatbv_type(isfinite.value->type);
-    smt_astt max_val = get_max_normal(*this, fbv_type);
-    if (!max_val)
-    {
-      log_warning(
-        "isfinite: unsupported float format (exp={}, frac={}); returning true",
-        fbv_type.exponent,
-        fbv_type.fraction);
-      return mk_smt_bool(true);
-    }
-    smt_astt operand = convert_ast(isfinite.value);
-    smt_astt pos_ok = mk_le(operand, max_val);
-    smt_astt neg_ok = mk_ge(operand, mk_sub(get_zero_real(), max_val));
-    return mk_and(pos_ok, neg_ok);
-  }
-
-  smt_astt value = convert_ast(isfinite.value);
-
-  // isfinite = !(isinf || isnan)
-  smt_astt isinf = fp_api->mk_smt_fpbv_is_inf(value);
-  smt_astt isnan = fp_api->mk_smt_fpbv_is_nan(value);
-
-  smt_astt or_op = mk_or(isinf, isnan);
-  return mk_not(or_op);
-}
-
-smt_astt smt_convt::convert_signbit(const expr2tc &expr)
-{
-  const signbit2t &signbit = to_signbit2t(expr);
-
-  // Extract the top bit
-  auto value = convert_ast(signbit.operand);
-
-  smt_astt is_neg;
-
-  if (int_encoding)
-  {
-    // In integer/real encoding mode, floating-point values are represented as reals
-    // We can't extract bits, so check the sign mathematically
-    is_neg = mk_lt(value, mk_smt_real("0"));
-  }
-  else
-  {
-    // In bitvector mode, extract the sign bit
-    const auto width = value->sort->get_data_width();
-    is_neg =
-      mk_eq(mk_extract(value, width - 1, width - 1), mk_smt_bv(BigInt(1), 1));
-  }
-
-  // If it's true, return 1. Return 0, othewise.
-  return mk_ite(
-    is_neg,
-    convert_ast(gen_one(signbit.type)),
-    convert_ast(gen_zero(signbit.type)));
-}
-
 smt_astt smt_convt::convert_popcount(const expr2tc &expr)
 {
   expr2tc op = to_popcount2t(expr).operand;
@@ -3376,50 +2214,6 @@ smt_astt smt_convt::convert_bswap(const expr2tc &expr)
     swap = concat2tc(get_uint_type((i + 1) * 8), swap, thebytes[i]);
 
   return convert_ast(swap);
-}
-
-smt_astt smt_convt::convert_rounding_mode(const expr2tc &expr)
-{
-  // We don't actually care about rounding mode when in integer/real mode, as
-  // it is discarded when encoding it in SMT
-  if (int_encoding)
-    return nullptr;
-
-  // Easy case, we know the rounding mode
-  if (is_constant_int2t(expr))
-  {
-    ieee_floatt::rounding_modet rm = static_cast<ieee_floatt::rounding_modet>(
-      to_constant_int2t(expr).value.to_int64());
-    return fp_api->mk_smt_fpbv_rm(rm);
-  }
-
-  assert(is_symbol2t(expr));
-  // 0 is round to Nearest/even
-  // 2 is round to +oo
-  // 3 is round to -oo
-  // 4 is round to zero
-
-  smt_astt symbol = convert_ast(expr);
-
-  smt_astt is_0 =
-    mk_eq(symbol, mk_smt_bv(BigInt(0), symbol->sort->get_data_width()));
-
-  smt_astt is_2 =
-    mk_eq(symbol, mk_smt_bv(BigInt(2), symbol->sort->get_data_width()));
-
-  smt_astt is_3 =
-    mk_eq(symbol, mk_smt_bv(BigInt(3), symbol->sort->get_data_width()));
-
-  smt_astt ne = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_EVEN);
-  smt_astt mi = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_MINUS_INF);
-  smt_astt pi = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_PLUS_INF);
-  smt_astt ze = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_ZERO);
-
-  smt_astt ite2 = mk_ite(is_3, mi, ze);
-  smt_astt ite1 = mk_ite(is_2, pi, ite2);
-  smt_astt ite0 = mk_ite(is_0, ne, ite1);
-
-  return ite0;
 }
 
 smt_astt smt_convt::convert_member(const expr2tc &expr)
@@ -4234,7 +3028,8 @@ expr2tc smt_convt::get(const expr2tc &expr)
     // changed, then rebuild res with that type. Mirrors the original two-level
     // walk (outer array + its immediate subtype if also array); preserves the
     // historic behaviour of not recursing further.
-    auto resolve_size = [this](const expr2tc &s) {
+    auto resolve_size = [this](const expr2tc &s)
+    {
       if (!is_nil_expr(s) && is_symbol2t(s))
         return get(s);
       return s;
@@ -4263,20 +3058,22 @@ expr2tc smt_convt::get(const expr2tc &expr)
   bool have_all = true;
   bool has_null_operands = false;
 
-  res->Foreach_operand([this, &have_all, &has_null_operands](expr2tc &e) {
-    if (!e)
+  res->Foreach_operand(
+    [this, &have_all, &has_null_operands](expr2tc &e)
     {
-      has_null_operands = true;
-      have_all = false;
-      return;
-    }
+      if (!e)
+      {
+        has_null_operands = true;
+        have_all = false;
+        return;
+      }
 
-    expr2tc new_e = get(e);
-    if (new_e)
-      e = new_e;
-    else
-      have_all = false;
-  });
+      expr2tc new_e = get(e);
+      if (new_e)
+        e = new_e;
+      else
+        have_all = false;
+    });
 
   // If we have null operands, return early to avoid crashes in simplify()
   if (has_null_operands)
@@ -4401,7 +3198,8 @@ double smt_convt::convert_rational_to_double(
   // Populate the buffer with the decimal representation of `value`, growing the
   // buffer as needed. We keep the legacy fixed-size path to avoid extra
   // allocations on the common fast path.
-  auto ensure_string = [&](const BigInt &value, std::vector<char> &buffer) {
+  auto ensure_string = [&](const BigInt &value, std::vector<char> &buffer)
+  {
     while (true)
     {
       // 1) Try to reuse the current buffer (may already be large).

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -204,8 +204,9 @@ static void replace_name_in_body(
       body = replacement;
     return;
   }
-  body->Foreach_operand([&lhs, &replacement](expr2tc &e)
-                        { replace_name_in_body(lhs, replacement, e); });
+  body->Foreach_operand([&lhs, &replacement](expr2tc &e) {
+    replace_name_in_body(lhs, replacement, e);
+  });
 }
 
 /** Recursively expand any symbol in @p e that is a key in @p defs, replacing
@@ -226,8 +227,8 @@ static void expand_quantifier_defs_in(
     }
     return;
   }
-  e->Foreach_operand([&defs](expr2tc &sub)
-                     { expand_quantifier_defs_in(sub, defs); });
+  e->Foreach_operand(
+    [&defs](expr2tc &sub) { expand_quantifier_defs_in(sub, defs); });
 }
 
 void smt_convt::pop_ctx()
@@ -447,8 +448,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   {
     // Convert all the arguments and store them in 'args'.
     args.reserve(expr->get_num_sub_exprs());
-    expr->foreach_operand([this, &args](const expr2tc &e)
-                          { args.push_back(convert_ast(e)); });
+    expr->foreach_operand(
+      [this, &args](const expr2tc &e) { args.push_back(convert_ast(e)); });
   }
   }
 
@@ -690,8 +691,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
            fbv_type.fraction == single_spec.f))
         {
           // Lookup with unconditional point-interval fallback.
-          auto get_iv = [this](smt_astt t) -> ra_interval_t
-          {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t {
             auto it = ir_ra_interval_map.find(t);
             return it != ir_ra_interval_map.end() ? it->second
                                                   : ra_interval_t{t, t};
@@ -784,8 +784,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
            fbv_type.fraction == single_spec.f))
         {
           // Lookup with unconditional point-interval fallback.
-          auto get_iv = [this](smt_astt t) -> ra_interval_t
-          {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t {
             auto it = ir_ra_interval_map.find(t);
             return it != ir_ra_interval_map.end() ? it->second
                                                   : ra_interval_t{t, t};
@@ -863,8 +862,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           (fbv_type.exponent == single_spec.e &&
            fbv_type.fraction == single_spec.f))
         {
-          auto get_iv = [this](smt_astt t) -> ra_interval_t
-          {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t {
             auto it = ir_ra_interval_map.find(t);
             return it != ir_ra_interval_map.end() ? it->second
                                                   : ra_interval_t{t, t};
@@ -990,8 +988,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
          smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode) ||
          smt_fp_rounding_utils::is_round_to_zero(rounding_mode)))
       {
-        auto get_iv = [this](smt_astt t) -> ra_interval_t
-        {
+        auto get_iv = [this](smt_astt t) -> ra_interval_t {
           auto it = ir_ra_interval_map.find(t);
           return it != ir_ra_interval_map.end() ? it->second
                                                 : ra_interval_t{t, t};
@@ -3028,8 +3025,7 @@ expr2tc smt_convt::get(const expr2tc &expr)
     // changed, then rebuild res with that type. Mirrors the original two-level
     // walk (outer array + its immediate subtype if also array); preserves the
     // historic behaviour of not recursing further.
-    auto resolve_size = [this](const expr2tc &s)
-    {
+    auto resolve_size = [this](const expr2tc &s) {
       if (!is_nil_expr(s) && is_symbol2t(s))
         return get(s);
       return s;
@@ -3058,22 +3054,20 @@ expr2tc smt_convt::get(const expr2tc &expr)
   bool have_all = true;
   bool has_null_operands = false;
 
-  res->Foreach_operand(
-    [this, &have_all, &has_null_operands](expr2tc &e)
+  res->Foreach_operand([this, &have_all, &has_null_operands](expr2tc &e) {
+    if (!e)
     {
-      if (!e)
-      {
-        has_null_operands = true;
-        have_all = false;
-        return;
-      }
+      has_null_operands = true;
+      have_all = false;
+      return;
+    }
 
-      expr2tc new_e = get(e);
-      if (new_e)
-        e = new_e;
-      else
-        have_all = false;
-    });
+    expr2tc new_e = get(e);
+    if (new_e)
+      e = new_e;
+    else
+      have_all = false;
+  });
 
   // If we have null operands, return early to avoid crashes in simplify()
   if (has_null_operands)
@@ -3198,8 +3192,7 @@ double smt_convt::convert_rational_to_double(
   // Populate the buffer with the decimal representation of `value`, growing the
   // buffer as needed. We keep the legacy fixed-size path to avoid extra
   // allocations on the common fast path.
-  auto ensure_string = [&](const BigInt &value, std::vector<char> &buffer)
-  {
+  auto ensure_string = [&](const BigInt &value, std::vector<char> &buffer) {
     while (true)
     {
       // 1) Try to reuse the current buffer (may already be large).

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -1,0 +1,1165 @@
+#include "irep2/irep2_expr.h"
+#include <solvers/smt/smt_conv.h>
+#include <solvers/smt/smt_fp_rounding_utils.h>
+#include <util/arith_tools.h>
+#include <util/expr_util.h>
+#include <util/message.h>
+#include <util/message/format.h>
+
+// Floating-point specific SMT conversion code extracted from smt_conv.cpp.
+// Keep this file focused on IEEE754 constants/semantics and FP predicates.
+
+smt_astt smt_convt::get_zero_real()
+{
+  // Returns SMT representation of zero (0.0)
+  return mk_smt_real("0");
+}
+
+smt_astt smt_convt::get_double_min_normal()
+{
+  // IEEE 754 double precision minimum normal positive value (2^-1022)
+  return mk_smt_real("2.2250738585072014e-308");
+}
+
+smt_astt smt_convt::get_double_min_subnormal()
+{
+  // IEEE 754 double precision minimum positive subnormal value (2^-1074)
+  // Rounded UP at the last digit to ensure the enclosure is conservative.
+  return mk_smt_real("4.9406564584124655e-324");
+}
+
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rne_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel = get_double_eps_rel();       // 2^-53
+    eps_abs = get_double_min_subnormal(); // 2^-1074
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel = get_single_eps_rel();       // 2^-24
+    eps_abs = get_single_min_subnormal(); // 2^-149
+  }
+  else
+  {
+    assert(!"apply_ieee754_rne_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // B_near^-(R) = eps_rel * |lo_r| + eps_abs  (bound using lower endpoint)
+  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
+  smt_astt bound_lo = mk_add(mk_mul(eps_rel, abs_lo), eps_abs);
+
+  // B_near^+(R) = eps_rel * |hi_r| + eps_abs  (bound using upper endpoint)
+  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
+  smt_astt bound_hi = mk_add(mk_mul(eps_rel, abs_hi), eps_abs);
+
+  // ra_lo = lo_r - B_near^-(R),  ra_hi = hi_r + B_near^+(R)
+  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo);
+  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi);
+
+  // Named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as the single-step path).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+
+  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= lo_r - B_near^-(R)
+  assert_ast(mk_le(ra_lo_expr, ra_lo)); // lo_r - B_near^-(R) <= ra_lo
+  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= hi_r + B_near^+(R)
+  assert_ast(mk_le(ra_hi_expr, ra_hi)); // hi_r + B_near^+(R) <= ra_hi
+
+  // Containment: ra_lo <= real_result <= ra_hi  and  ra_lo <= ra_hi
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rna_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // Parallel to apply_ieee754_rne_enclosure.
+  // ROUND_TO_AWAY uses the same B_near constants and formula shape as
+  // ROUND_TO_EVEN (same unit roundoff); the only difference is the symbol
+  // name prefix: ra_lo_aw:: / ra_hi_aw:: to match the RNA single-step path.
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel = get_double_eps_rel();       // 2^-53
+    eps_abs = get_double_min_subnormal(); // 2^-1074
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel = get_single_eps_rel();       // 2^-24
+    eps_abs = get_single_min_subnormal(); // 2^-149
+  }
+  else
+  {
+    assert(!"apply_ieee754_rna_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // B_near^-(R) = eps_rel * |lo_r| + eps_abs  (bound using lower endpoint)
+  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
+  smt_astt bound_lo = mk_add(mk_mul(eps_rel, abs_lo), eps_abs);
+
+  // B_near^+(R) = eps_rel * |hi_r| + eps_abs  (bound using upper endpoint)
+  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
+  smt_astt bound_hi = mk_add(mk_mul(eps_rel, abs_hi), eps_abs);
+
+  // ra_lo = lo_r - B_near^-(R),  ra_hi = hi_r + B_near^+(R)
+  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo);
+  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi);
+
+  // RNA-named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo_aw::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi_aw::", nullptr);
+
+  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo_aw <= lo_r - B_near^-(R)
+  assert_ast(mk_le(ra_lo_expr, ra_lo)); // lo_r - B_near^-(R) <= ra_lo_aw
+  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi_aw <= hi_r + B_near^+(R)
+  assert_ast(mk_le(ra_hi_expr, ra_hi)); // hi_r + B_near^+(R) <= ra_hi_aw
+
+  // Containment: ra_lo_aw <= real_result <= ra_hi_aw  and  ra_lo_aw <= ra_hi_aw
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rup_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // EbRUP([LR, UR]) = [LR, UR + B_dir(UR)]
+  // fl_RUP(r) >= r for all r, so the lower bound is exact: ra_lo = lo_r.
+  // fl_RUP(r) <= r + B_dir(r) <= UR + B_dir(UR) for r in [LR, UR],
+  // so the upper bound is hi_r + B_dir(hi_r).
+  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
+  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel_dir, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel_dir = get_double_eps_up(); // 2^-52
+    eps_abs = get_double_min_subnormal();
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel_dir = get_single_eps_up(); // 2^-23
+    eps_abs = get_single_min_subnormal();
+  }
+  else
+  {
+    assert(!"apply_ieee754_rup_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // B_dir(hi_r) = eps_rel_dir * |hi_r| + eps_abs  (bound at upper endpoint)
+  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
+  smt_astt bound_hi = mk_add(mk_mul(eps_rel_dir, abs_hi), eps_abs);
+  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi); // UR + B_dir(UR)
+
+  // RUP-named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo_up::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi_up::", nullptr);
+
+  // Pin ra_lo = lo_r  (exact lower bound: RUP never rounds below the true value)
+  assert_ast(mk_le(ra_lo, lo_r)); // ra_lo_up <= LR
+  assert_ast(mk_le(lo_r, ra_lo)); // LR <= ra_lo_up  =>  ra_lo_up == LR
+
+  // Pin ra_hi = hi_r + B_dir(hi_r)
+  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi_up <= UR + B_dir(UR)
+  assert_ast(mk_le(ra_hi_expr, ra_hi)); // UR + B_dir(UR) <= ra_hi_up
+
+  // Containment: ra_lo_up <= real_result <= ra_hi_up  and  ra_lo_up <= ra_hi_up
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rdn_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // EbRDN([LR, UR]) = [LR - B_dir(LR), UR]
+  // fl_RDN(r) <= r for all r, so the upper bound is exact: ra_hi = hi_r.
+  // fl_RDN(r) >= r - B_dir(r) >= LR - B_dir(LR) for r in [LR, UR],
+  // so the lower bound is lo_r - B_dir(lo_r).
+  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
+  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel_dir, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel_dir = get_double_eps_up(); // 2^-52
+    eps_abs = get_double_min_subnormal();
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel_dir = get_single_eps_up(); // 2^-23
+    eps_abs = get_single_min_subnormal();
+  }
+  else
+  {
+    assert(!"apply_ieee754_rdn_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // B_dir(lo_r) = eps_rel_dir * |lo_r| + eps_abs  (bound at lower endpoint)
+  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
+  smt_astt bound_lo = mk_add(mk_mul(eps_rel_dir, abs_lo), eps_abs);
+  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo); // LR - B_dir(LR)
+
+  // RDN-named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo_dn::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi_dn::", nullptr);
+
+  // Pin ra_lo = lo_r - B_dir(lo_r)
+  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo_dn <= LR - B_dir(LR)
+  assert_ast(mk_le(ra_lo_expr, ra_lo)); // LR - B_dir(LR) <= ra_lo_dn
+
+  // Pin ra_hi = hi_r  (exact upper bound: RDN never rounds above the true value)
+  assert_ast(mk_le(ra_hi, hi_r)); // ra_hi_dn <= UR
+  assert_ast(mk_le(hi_r, ra_hi)); // UR <= ra_hi_dn  =>  ra_hi_dn == UR
+
+  // Containment: ra_lo_dn <= real_result <= ra_hi_dn  and  ra_lo_dn <= ra_hi_dn
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rtz_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // RTZ (truncation toward zero) is sign-dependent.
+  // For an interval hull [LR, UR] = [lo_r, hi_r]:
+  //
+  //   Case 1 -- LR >= 0 (all non-negative): fl_RTZ acts like RDN
+  //     EbRTZ([LR,UR]) = [LR - B_dir(LR), UR]   (exact upper bound)
+  //
+  //   Case 2 -- UR <= 0 (all non-positive): fl_RTZ acts like RUP
+  //     EbRTZ([LR,UR]) = [LR, UR + B_dir(UR)]   (exact lower bound)
+  //
+  //   Case 3 -- LR < 0 < UR (hull crosses zero): sign of actual result
+  //     is unknown at encode time; use conservative symmetric bound:
+  //     B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs
+  //     EbRTZ([LR,UR]) = [LR - B_dir_max, UR + B_dir_max]
+  //
+  // The three cases are encoded as nested ITE on lo_nonneg / hi_nonpos.
+  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
+  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel_dir, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel_dir = get_double_eps_up(); // 2^-52
+    eps_abs = get_double_min_subnormal();
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel_dir = get_single_eps_up(); // 2^-23
+    eps_abs = get_single_min_subnormal();
+  }
+  else
+  {
+    assert(!"apply_ieee754_rtz_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // |LR| and |UR|
+  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
+  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
+
+  // B_dir at each endpoint
+  smt_astt bound_lo = mk_add(mk_mul(eps_rel_dir, abs_lo), eps_abs); // B_dir(LR)
+  smt_astt bound_hi = mk_add(mk_mul(eps_rel_dir, abs_hi), eps_abs); // B_dir(UR)
+
+  // B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs  (crossing-zero case)
+  smt_astt abs_max = mk_ite(mk_le(abs_lo, abs_hi), abs_hi, abs_lo);
+  smt_astt bound_max = mk_add(mk_mul(eps_rel_dir, abs_max), eps_abs);
+
+  // Case selectors
+  smt_astt lo_nonneg = mk_le(zero, lo_r); // LR >= 0
+  smt_astt hi_nonpos = mk_le(hi_r, zero); // UR <= 0
+
+  // ra_lo_expr:
+  //   LR >= 0 -> LR - B_dir(LR)    (truncate-down: lower gets error)
+  //   UR <= 0 -> LR                 (truncate-up: lower is exact)
+  //   else    -> LR - B_dir_max    (crossing zero: conservative)
+  smt_astt ra_lo_expr = mk_ite(
+    lo_nonneg,
+    mk_sub(lo_r, bound_lo),
+    mk_ite(hi_nonpos, lo_r, mk_sub(lo_r, bound_max)));
+
+  // ra_hi_expr:
+  //   LR >= 0 -> UR                 (truncate-down: upper is exact)
+  //   UR <= 0 -> UR + B_dir(UR)    (truncate-up: upper gets error)
+  //   else    -> UR + B_dir_max    (crossing zero: conservative)
+  smt_astt ra_hi_expr = mk_ite(
+    lo_nonneg,
+    hi_r,
+    mk_ite(hi_nonpos, mk_add(hi_r, bound_hi), mk_add(hi_r, bound_max)));
+
+  // RTZ-named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo_tz::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi_tz::", nullptr);
+
+  // Pin ra_lo = ra_lo_expr
+  assert_ast(mk_le(ra_lo, ra_lo_expr));
+  assert_ast(mk_le(ra_lo_expr, ra_lo));
+
+  // Pin ra_hi = ra_hi_expr
+  assert_ast(mk_le(ra_hi, ra_hi_expr));
+  assert_ast(mk_le(ra_hi_expr, ra_hi));
+
+  // Containment: ra_lo_tz <= real_result <= ra_hi_tz  and  ra_lo_tz <= ra_hi_tz
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
+smt_astt smt_convt::apply_ieee754_semantics(
+  smt_astt real_result,
+  const floatbv_type2t &fbv_type,
+  smt_astt operand_zero_check,
+  const expr2tc &rounding_mode)
+{
+  if (this->options.get_bool_option("ir-ieee"))
+  {
+    if (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode))
+    {
+      // Tight path: rounding mode is concrete round-to-nearest.
+      // Attach a sound symmetric enclosure around the real semantic
+      // term `r` for nearest rounding mode.
+      //
+      // For an FP operation whose exact real value is r, the round-to-nearest
+      // error satisfies:
+      //   |fl(r) - r| <= eps_rel * |r| + eps_abs
+      //
+      // So we define:
+      //   B(r)  = eps_rel * |r| + eps_abs
+      //   ra_lo = r - B(r)
+      //   ra_hi = r + B(r)
+      //
+      // and assert  ra_lo <= result <= ra_hi  and  ra_lo <= ra_hi.
+      //
+      // TODO: extend to non-standard FP formats beyond single and double.
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_astt eps_rel, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_rel = get_double_eps_rel(); // 2^-53
+        eps_abs =
+          get_double_min_subnormal(); // 2^-1074 (covers underflow region)
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_rel = get_single_eps_rel();       // 2^-24
+        eps_abs = get_single_min_subnormal(); // 2^-149
+      }
+      else
+      {
+        // TODO: theorem-driven bounds for non-standard formats are not yet
+        // implemented; fall back to unconstrained enclosure (sound but weak).
+        smt_sortt rs = mk_real_sort();
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt zero = mk_smt_real("0.0");
+
+      // |r| = r >= 0 ? r : -r
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B(r) = eps_rel * |r| + eps_abs
+      smt_astt bound = mk_add(mk_mul(eps_rel, abs_r), eps_abs);
+
+      // ra_lo = r - B(r),  ra_hi = r + B(r)
+      smt_astt ra_lo_expr = mk_sub(real_result, bound);
+      smt_astt ra_hi_expr = mk_add(real_result, bound);
+
+      // Introduce named enclosure variables and pin them to the bound expressions
+      // via bidirectional inequalities.  A plain mk_eq(ra_lo, ra_lo_expr) is
+      // correct but the Z3 tactic pipeline (solve-eqs) eliminates definitional
+      // equalities from the visible assertion set, making them invisible in the
+      // SMT output.  Two mk_le assertions are logically equivalent and are not
+      // targeted by solve-eqs, so they survive in the final formula.
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B(r)
+      assert_ast(
+        mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo  =>  ra_lo == r - B(r)
+      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B(r)
+      assert_ast(
+        mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi  =>  ra_hi == r + B(r)
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
+    else if (smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode))
+    {
+      // Asymmetric tight enclosure for ROUND_TO_PLUS_INF:
+      //   fl_RUP(r) >= r  (exact lower bound; round-up never undershoots)
+      //   fl_RUP(r) <= r + B_dir(r)
+      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
+      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- the full machine epsilon
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt eps_up, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_up = get_double_eps_up();
+        eps_abs = get_double_min_subnormal();
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_up = get_single_eps_up();
+        eps_abs = get_single_min_subnormal();
+      }
+      else
+      {
+        // Unsupported format: fall back to unconstrained weak enclosure.
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B_dir(r) = eps_rel_dir * |r| + eps_abs
+      smt_astt b_dir = mk_add(mk_mul(eps_up, abs_r), eps_abs);
+      smt_astt ra_hi_expr = mk_add(real_result, b_dir);
+
+      // Introduce named enclosure variables. Use bidirectional inequalities to
+      // survive Z3's solve-eqs tactic (same technique as the nearest-mode path).
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_up::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_up::", nullptr);
+
+      // Pin ra_lo = r (the exact lower bound for round-up)
+      assert_ast(mk_le(ra_lo, real_result)); // ra_lo <= r
+      assert_ast(mk_le(real_result, ra_lo)); // r <= ra_lo  =>  ra_lo == r
+
+      // Pin ra_hi = r + B_dir(r)
+      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B_dir(r)
+      assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B_dir(r) <= ra_hi
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
+    else if (smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode))
+    {
+      // Asymmetric tight enclosure for ROUND_TO_MINUS_INF:
+      //   fl_RDN(r) <= r  (exact upper bound; round-down never overshoots)
+      //   fl_RDN(r) >= r - B_dir(r)
+      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
+      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single)
+      //   This is the directed-mode error constant, the same value used for
+      //   ROUND_TO_PLUS_INF; the bound shape is the mirror image.
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt eps_rel_dir, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_rel_dir = get_double_eps_up(); // 2^-52, same value as RUP
+        eps_abs = get_double_min_subnormal();
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_rel_dir = get_single_eps_up(); // 2^-23, same value as RUP
+        eps_abs = get_single_min_subnormal();
+      }
+      else
+      {
+        // Unsupported format: fall back to unconstrained weak enclosure.
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B_dir(r) = eps_rel_dir * |r| + eps_abs
+      smt_astt b_dir = mk_add(mk_mul(eps_rel_dir, abs_r), eps_abs);
+      smt_astt ra_lo_expr = mk_sub(real_result, b_dir); // r - B_dir(r)
+
+      // Introduce named enclosure variables. Use bidirectional inequalities to
+      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_dn::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_dn::", nullptr);
+
+      // Pin ra_lo = r - B_dir(r)  (the computed lower bound)
+      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B_dir(r)
+      assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B_dir(r) <= ra_lo
+
+      // Pin ra_hi = r  (exact upper bound for round-down)
+      assert_ast(mk_le(ra_hi, real_result)); // ra_hi <= r
+      assert_ast(mk_le(real_result, ra_hi)); // r <= ra_hi  =>  ra_hi == r
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
+    else if (smt_fp_rounding_utils::is_round_to_zero(rounding_mode))
+    {
+      // Asymmetric tight enclosure for ROUND_TO_ZERO (truncation toward zero).
+      //
+      // RTZ is sign-dependent: it rounds down for r >= 0 and rounds up for r < 0.
+      //   r >= 0:  fl_RTZ(r) in [r - B_dir(r),  r]   (same shape as RDN)
+      //   r <  0:  fl_RTZ(r) in [r,  r + B_dir(r)]   (same shape as RUP)
+      //
+      // Unified via ITE on sign:
+      //   ra_lo = ite(r >= 0,  r - B_dir(r),  r)
+      //   ra_hi = ite(r >= 0,  r,              r + B_dir(r))
+      //
+      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
+      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt eps_rel_dir, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_rel_dir = get_double_eps_up(); // 2^-52, same value as RUP/RDN
+        eps_abs = get_double_min_subnormal();
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_rel_dir = get_single_eps_up(); // 2^-23, same value as RUP/RDN
+        eps_abs = get_single_min_subnormal();
+      }
+      else
+      {
+        // Unsupported format: fall back to unconstrained weak enclosure.
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B_dir(r) = eps_rel_dir * |r| + eps_abs
+      smt_astt b_dir = mk_add(mk_mul(eps_rel_dir, abs_r), eps_abs);
+
+      // Sign-dependent enclosure bounds via ITE:
+      //   r >= 0: lower is computed, upper is exact (truncate-down shape)
+      //   r <  0: lower is exact,    upper is computed (truncate-up shape)
+      smt_astt r_nonneg = mk_le(zero, real_result); // r >= 0
+      smt_astt ra_lo_expr =
+        mk_ite(r_nonneg, mk_sub(real_result, b_dir), real_result);
+      smt_astt ra_hi_expr =
+        mk_ite(r_nonneg, real_result, mk_add(real_result, b_dir));
+
+      // Introduce named enclosure variables. Use bidirectional inequalities to
+      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_tz::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_tz::", nullptr);
+
+      // Pin ra_lo = ite(r >= 0, r - B_dir(r), r)
+      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= ra_lo_expr
+      assert_ast(mk_le(ra_lo_expr, ra_lo)); // ra_lo_expr <= ra_lo
+
+      // Pin ra_hi = ite(r >= 0, r, r + B_dir(r))
+      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= ra_hi_expr
+      assert_ast(mk_le(ra_hi_expr, ra_hi)); // ra_hi_expr <= ra_hi
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
+    else if (smt_fp_rounding_utils::is_round_to_away(rounding_mode))
+    {
+      // Tight path for ROUND_TO_AWAY (round-to-nearest, ties away from zero).
+      //
+      // ROUND_TO_AWAY is a nearest-rounding mode: the rounding error is
+      // bounded by the unit roundoff u = 1/2 * machine-epsilon, exactly as
+      // for ROUND_TO_EVEN.  The enclosure is therefore symmetric:
+      //   |fl_RTA(r) - r| <= eps_rel * |r| + eps_abs
+      //
+      // So:
+      //   B(r)  = eps_rel * |r| + eps_abs    (same formula as nearest)
+      //   ra_lo = r - B(r)
+      //   ra_hi = r + B(r)
+      //
+      // The epsilon constants are the same as ROUND_TO_EVEN:
+      //   eps_rel = 2^-53 (double) or 2^-24 (single) -- unit roundoff u
+      //
+      // NOTE: the Z3 numerator for eps_rel is the same as for the nearest
+      // path (5551115123125783 for double, 5960464477539063 for single).
+      // This is expected and correct -- the bound is identical.
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt eps_rel, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_rel = get_double_eps_rel(); // 2^-53, same as ROUND_TO_EVEN
+        eps_abs = get_double_min_subnormal();
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_rel = get_single_eps_rel(); // 2^-24, same as ROUND_TO_EVEN
+        eps_abs = get_single_min_subnormal();
+      }
+      else
+      {
+        // Unsupported format: fall back to unconstrained weak enclosure.
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B(r) = eps_rel * |r| + eps_abs
+      smt_astt bound = mk_add(mk_mul(eps_rel, abs_r), eps_abs);
+      smt_astt ra_lo_expr = mk_sub(real_result, bound);
+      smt_astt ra_hi_expr = mk_add(real_result, bound);
+
+      // Introduce named enclosure variables. Use bidirectional inequalities to
+      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_aw::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_aw::", nullptr);
+
+      // Pin ra_lo = r - B(r)
+      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B(r)
+      assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo
+
+      // Pin ra_hi = r + B(r)
+      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B(r)
+      assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
+    else
+    {
+      // weak fallback: symbolic or unrecognised rounding mode
+      smt_sortt rs = mk_real_sort();
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+      return real_result;
+    }
+  }
+  else
+  {
+    unsigned int fraction_bits = fbv_type.fraction;
+    unsigned int exponent_bits = fbv_type.exponent;
+
+    auto double_spec = ieee_float_spect::double_precision();
+    auto single_spec = ieee_float_spect::single_precision();
+
+    smt_astt min_normal, min_subnormal, max_normal;
+
+    // IEEE 754 double precision (64-bit): 11 exponent bits, 52 fraction bits
+    if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+    {
+      // Exact rationals: 1/2^1022, 1/2^1074, (2^53-1)*2^971
+      static const std::string dbl_min_normal =
+        "1/" + integer2string(power(2, 1022));
+      static const std::string dbl_min_subnormal =
+        "1/" + integer2string(power(2, 1074));
+      static const std::string dbl_max_normal =
+        integer2string((power(2, 53) - 1) * power(2, 971));
+      min_normal = mk_smt_real(dbl_min_normal);
+      min_subnormal = mk_smt_real(dbl_min_subnormal);
+      max_normal = mk_smt_real(dbl_max_normal);
+    }
+    // IEEE 754 single precision (32-bit): 8 exponent bits, 23 fraction bits
+    else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+    {
+      // Exact rationals: 1/2^126, 1/2^149, (2^24-1)*2^104
+      static const std::string sgl_min_normal =
+        "1/" + integer2string(power(2, 126));
+      static const std::string sgl_min_subnormal =
+        "1/" + integer2string(power(2, 149));
+      static const std::string sgl_max_normal =
+        integer2string((power(2, 24) - 1) * power(2, 104));
+      min_normal = mk_smt_real(sgl_min_normal);
+      min_subnormal = mk_smt_real(sgl_min_subnormal);
+      max_normal = mk_smt_real(sgl_max_normal);
+    }
+    // Unsupported format - return original result
+    else
+    {
+      log_warning(
+        "Unsupported IEEE 754 format: exponent bits = {}, fraction bits = {}",
+        exponent_bits,
+        fraction_bits);
+      return real_result;
+    }
+
+    smt_astt zero = mk_smt_real("0.0");
+
+    // Get absolute value of result
+    smt_astt abs_result =
+      mk_ite(mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+    // Check for overflow
+    smt_astt overflows = mk_gt(abs_result, max_normal);
+
+    // Check for underflow to zero
+    smt_astt underflows_to_zero = mk_and(
+      mk_lt(abs_result, min_subnormal), mk_not(mk_eq(real_result, zero)));
+
+    // If we have a special zero check (like for multiplication), use it
+    if (operand_zero_check)
+      underflows_to_zero =
+        mk_and(underflows_to_zero, mk_not(operand_zero_check));
+
+    // Check if result is in subnormal range
+    smt_astt is_subnormal =
+      mk_and(mk_ge(abs_result, min_subnormal), mk_lt(abs_result, min_normal));
+
+    // For subnormal values, return the exact real result.
+    // Subnormal arithmetic is exact when results are representable, and the
+    // real arithmetic value already captures the correct value. No floor-based
+    // quantization is applied here because ESBMC's SMT API has no floor/to_int
+    // for reals; adding 0.5 without floor gives a wrong non-integer multiple.
+    smt_astt subnormal_result = real_result;
+
+    // Overflow result (approximate infinity)
+    smt_astt overflow_result =
+      mk_ite(mk_lt(real_result, zero), mk_sub(zero, max_normal), max_normal);
+
+    // Apply IEEE 754 semantics: overflow > underflow > subnormal > normal
+    smt_astt ieee_result = mk_ite(
+      overflows,
+      overflow_result,
+      mk_ite(
+        underflows_to_zero,
+        zero,
+        mk_ite(is_subnormal, subnormal_result, real_result)));
+
+    // Handle special operand zero case for multiplication
+    if (operand_zero_check)
+      return mk_ite(operand_zero_check, zero, ieee_result);
+
+    return ieee_result;
+  }
+}
+
+smt_astt smt_convt::get_double_max_normal()
+{
+  // IEEE 754 double: (2^53-1)*2^971 (exact rational, no rounding)
+  static const std::string val =
+    integer2string((power(2, 53) - 1) * power(2, 971));
+  return mk_smt_real(val);
+}
+
+smt_astt smt_convt::get_single_min_normal()
+{
+  // IEEE 754 single precision minimum normal positive value (2^-126)
+  return mk_smt_real("1.1754943508222875e-38");
+}
+
+smt_astt smt_convt::get_single_min_subnormal()
+{
+  // IEEE 754 single precision minimum positive subnormal value (2^-149)
+  return mk_smt_real("1.4012984643248171e-45");
+}
+
+smt_astt smt_convt::get_single_max_normal()
+{
+  // IEEE 754 single: (2^24-1)*2^104 (exact rational, no rounding)
+  static const std::string val =
+    integer2string((power(2, 24) - 1) * power(2, 104));
+  return mk_smt_real(val);
+}
+
+smt_astt smt_convt::get_double_inf_sentinel()
+{
+  // One above double max_normal: used to represent ±∞ in integer encoding.
+  // This value satisfies |x| > max_normal, so isinf/isfinite predicates fire.
+  static const std::string val =
+    integer2string((power(2, 53) - 1) * power(2, 971) + 1);
+  return mk_smt_real(val);
+}
+
+smt_astt smt_convt::get_single_inf_sentinel()
+{
+  // One above single max_normal: used to represent ±∞ in integer encoding.
+  static const std::string val =
+    integer2string((power(2, 24) - 1) * power(2, 104) + 1);
+  return mk_smt_real(val);
+}
+
+smt_astt smt_convt::get_double_eps_rel()
+{
+  // Relative error bound for IEEE 754 double under round-to-nearest:
+  // half machine epsilon = 2^-53; rounded UP at the last digit to ensure
+  // the enclosure is conservative.
+  return mk_smt_real("1.1102230246251566e-16");
+}
+
+smt_astt smt_convt::get_single_eps_rel()
+{
+  // Relative error bound for IEEE 754 single under round-to-nearest:
+  // half machine epsilon = 2^-24
+  return mk_smt_real("5.960464477539063e-08");
+}
+
+smt_astt smt_convt::get_double_eps_up()
+{
+  // B_dir relative error bound for IEEE 754 double under round-toward-+inf:
+  // eps_rel_dir = 2^-52 (the full machine epsilon for double, DBL_EPSILON).
+  // Conservative decimal: strictly greater than 2^-52 to preserve soundness.
+  return mk_smt_real("2.2204460492503131e-16");
+}
+
+smt_astt smt_convt::get_single_eps_up()
+{
+  // B_dir relative error bound for IEEE 754 single under round-toward-+inf:
+  // eps_rel_dir = 2^-23 (the full machine epsilon for single, FLT_EPSILON).
+  // Exact decimal representation of 2^-23; no rounding required.
+  return mk_smt_real("1.1920928955078125e-07");
+}
+
+smt_astt smt_convt::convert_is_nan(const expr2tc &expr)
+{
+  const isnan2t &isnan = to_isnan2t(expr);
+
+  // Anything other than floats will never be NaNs
+  if (!is_floatbv_type(isnan.value) || int_encoding)
+    return mk_smt_bool(false);
+
+  smt_astt operand = convert_ast(isnan.value);
+  return fp_api->mk_smt_fpbv_is_nan(operand);
+}
+
+// Returns the max-normal SMT real for single/double floatbv, or nullptr for
+// any other format (caller must handle the unsupported case explicitly).
+static smt_astt get_max_normal(smt_convt &conv, const floatbv_type2t &fbv_type)
+{
+  const auto single_spec = ieee_float_spect::single_precision();
+  const auto double_spec = ieee_float_spect::double_precision();
+  if (fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+    return conv.get_single_max_normal();
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+    return conv.get_double_max_normal();
+  return nullptr;
+}
+
+// Returns the min-normal SMT real for single/double floatbv, or nullptr.
+static smt_astt get_min_normal(smt_convt &conv, const floatbv_type2t &fbv_type)
+{
+  const auto single_spec = ieee_float_spect::single_precision();
+  const auto double_spec = ieee_float_spect::double_precision();
+  if (fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+    return conv.get_single_min_normal();
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+    return conv.get_double_min_normal();
+  return nullptr;
+}
+
+smt_astt smt_convt::convert_is_inf(const expr2tc &expr)
+{
+  const isinf2t &isinf = to_isinf2t(expr);
+
+  // Anything other than floats will never be infs
+  if (!is_floatbv_type(isinf.value))
+    return mk_smt_bool(false);
+
+  if (int_encoding)
+  {
+    // In integer/real encoding a float is "infinite" when its real value
+    // exceeds the maximum finite float magnitude: |f| > max_normal.
+    const floatbv_type2t &fbv_type = to_floatbv_type(isinf.value->type);
+    smt_astt max_val = get_max_normal(*this, fbv_type);
+    if (!max_val)
+    {
+      log_warning(
+        "isinf: unsupported float format (exp={}, frac={}); returning false",
+        fbv_type.exponent,
+        fbv_type.fraction);
+      return mk_smt_bool(false);
+    }
+    smt_astt operand = convert_ast(isinf.value);
+    smt_astt pos_inf = mk_gt(operand, max_val);
+    smt_astt neg_inf = mk_lt(operand, mk_sub(get_zero_real(), max_val));
+    return mk_or(pos_inf, neg_inf);
+  }
+
+  smt_astt operand = convert_ast(isinf.value);
+  return fp_api->mk_smt_fpbv_is_inf(operand);
+}
+
+smt_astt smt_convt::convert_is_normal(const expr2tc &expr)
+{
+  const isnormal2t &isnormal = to_isnormal2t(expr);
+
+  // Anything other than floats will always be normal
+  if (!is_floatbv_type(isnormal.value))
+    return mk_smt_bool(true);
+
+  if (int_encoding)
+  {
+    // In integer/real encoding a float is normal when min_normal <= |f| <=
+    // max_normal.  Zero and subnormals (|f| < min_normal) are not normal.
+    const floatbv_type2t &fbv_type = to_floatbv_type(isnormal.value->type);
+    smt_astt max_val = get_max_normal(*this, fbv_type);
+    smt_astt min_val = get_min_normal(*this, fbv_type);
+    if (!max_val || !min_val)
+    {
+      log_warning(
+        "isnormal: unsupported float format (exp={}, frac={}); returning true",
+        fbv_type.exponent,
+        fbv_type.fraction);
+      return mk_smt_bool(true);
+    }
+    smt_astt zero = get_zero_real();
+    smt_astt neg_max = mk_sub(zero, max_val);
+    smt_astt neg_min = mk_sub(zero, min_val);
+    smt_astt operand = convert_ast(isnormal.value);
+    // |f| >= min_normal: f >= min_normal || f <= -min_normal
+    smt_astt above_min =
+      mk_or(mk_ge(operand, min_val), mk_le(operand, neg_min));
+    // |f| <= max_normal: f <= max_normal && f >= -max_normal
+    smt_astt below_max =
+      mk_and(mk_le(operand, max_val), mk_ge(operand, neg_max));
+    return mk_and(above_min, below_max);
+  }
+
+  smt_astt operand = convert_ast(isnormal.value);
+  return fp_api->mk_smt_fpbv_is_normal(operand);
+}
+
+smt_astt smt_convt::convert_is_finite(const expr2tc &expr)
+{
+  const isfinite2t &isfinite = to_isfinite2t(expr);
+
+  // Anything other than floats will always be finite
+  if (!is_floatbv_type(isfinite.value))
+    return mk_smt_bool(true);
+
+  if (int_encoding)
+  {
+    // In integer/real encoding a float is finite when |f| <= max_normal.
+    const floatbv_type2t &fbv_type = to_floatbv_type(isfinite.value->type);
+    smt_astt max_val = get_max_normal(*this, fbv_type);
+    if (!max_val)
+    {
+      log_warning(
+        "isfinite: unsupported float format (exp={}, frac={}); returning true",
+        fbv_type.exponent,
+        fbv_type.fraction);
+      return mk_smt_bool(true);
+    }
+    smt_astt operand = convert_ast(isfinite.value);
+    smt_astt pos_ok = mk_le(operand, max_val);
+    smt_astt neg_ok = mk_ge(operand, mk_sub(get_zero_real(), max_val));
+    return mk_and(pos_ok, neg_ok);
+  }
+
+  smt_astt value = convert_ast(isfinite.value);
+
+  // isfinite = !(isinf || isnan)
+  smt_astt isinf = fp_api->mk_smt_fpbv_is_inf(value);
+  smt_astt isnan = fp_api->mk_smt_fpbv_is_nan(value);
+
+  smt_astt or_op = mk_or(isinf, isnan);
+  return mk_not(or_op);
+}
+
+smt_astt smt_convt::convert_signbit(const expr2tc &expr)
+{
+  const signbit2t &signbit = to_signbit2t(expr);
+
+  // Extract the top bit
+  auto value = convert_ast(signbit.operand);
+
+  smt_astt is_neg;
+
+  if (int_encoding)
+  {
+    // In integer/real encoding mode, floating-point values are represented as reals
+    // We can't extract bits, so check the sign mathematically
+    is_neg = mk_lt(value, mk_smt_real("0"));
+  }
+  else
+  {
+    // In bitvector mode, extract the sign bit
+    const auto width = value->sort->get_data_width();
+    is_neg =
+      mk_eq(mk_extract(value, width - 1, width - 1), mk_smt_bv(BigInt(1), 1));
+  }
+
+  // If it's true, return 1. Return 0, othewise.
+  return mk_ite(
+    is_neg,
+    convert_ast(gen_one(signbit.type)),
+    convert_ast(gen_zero(signbit.type)));
+}
+
+smt_astt smt_convt::convert_rounding_mode(const expr2tc &expr)
+{
+  // We don't actually care about rounding mode when in integer/real mode, as
+  // it is discarded when encoding it in SMT
+  if (int_encoding)
+    return nullptr;
+
+  // Easy case, we know the rounding mode
+  if (is_constant_int2t(expr))
+  {
+    ieee_floatt::rounding_modet rm = static_cast<ieee_floatt::rounding_modet>(
+      to_constant_int2t(expr).value.to_int64());
+    return fp_api->mk_smt_fpbv_rm(rm);
+  }
+
+  assert(is_symbol2t(expr));
+  // 0 is round to Nearest/even
+  // 2 is round to +oo
+  // 3 is round to -oo
+  // 4 is round to zero
+
+  smt_astt symbol = convert_ast(expr);
+
+  smt_astt is_0 =
+    mk_eq(symbol, mk_smt_bv(BigInt(0), symbol->sort->get_data_width()));
+
+  smt_astt is_2 =
+    mk_eq(symbol, mk_smt_bv(BigInt(2), symbol->sort->get_data_width()));
+
+  smt_astt is_3 =
+    mk_eq(symbol, mk_smt_bv(BigInt(3), symbol->sort->get_data_width()));
+
+  smt_astt ne = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_EVEN);
+  smt_astt mi = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_MINUS_INF);
+  smt_astt pi = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_PLUS_INF);
+  smt_astt ze = fp_api->mk_smt_fpbv_rm(ieee_floatt::ROUND_TO_ZERO);
+
+  smt_astt ite2 = mk_ite(is_3, mi, ze);
+  smt_astt ite1 = mk_ite(is_2, pi, ite2);
+  smt_astt ite0 = mk_ite(is_0, ne, ite1);
+
+  return ite0;
+}

--- a/src/solvers/smt/smt_fp_rounding_utils.h
+++ b/src/solvers/smt/smt_fp_rounding_utils.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "irep2/irep2_expr.h"
+#include <util/ieee_float.h>
+
+namespace smt_fp_rounding_utils
+{
+// Shared rounding-mode predicates used by both smt_conv.cpp and smt_fp_conv.cpp.
+// Keeping these in one place avoids semantic drift between interval enclosure
+// paths and IEEE754 post-processing paths.
+inline bool is_nearest_rounding_mode(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_EVEN);
+}
+
+inline bool is_round_to_plus_inf(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_PLUS_INF);
+}
+
+inline bool is_round_to_minus_inf(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_MINUS_INF);
+}
+
+inline bool is_round_to_zero(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_ZERO);
+}
+
+inline bool is_round_to_away(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_AWAY);
+}
+} // namespace smt_fp_rounding_utils


### PR DESCRIPTION
- extract IEEE754 conversion logic from smt_conv.cpp into smt_fp_conv.cpp
- add shared FP rounding helpers, and wire the new file in CMake.