### PR TITLE
[goto-programs] enable goto_loop_simplify by default

### DIFF
--- a/regression/bitwuzla/get_model_values/main.cpp
+++ b/regression/bitwuzla/get_model_values/main.cpp
@@ -1,7 +1,11 @@
 int Contains(float value)
 {
-  for (;;)
-    ;
+  // Force a counterexample so ESBMC emits a trace; the test checks that
+  // bitwuzla extracts the assumed bitvector/float values correctly. A plain
+  // reachable failure (not an infinite loop) keeps this robust to the
+  // goto-level loop-simplification pass.
+  __ESBMC_assert(0, "unreachable");
+  return 0;
 }
 float main_min = -0.0f;
 int main()

--- a/src/goto-programs/goto_loop_simplify.cpp
+++ b/src/goto-programs/goto_loop_simplify.cpp
@@ -578,22 +578,29 @@ bool simplify_function_once(goto_functiont &fn, const optionst &options)
     // in place. Mirrors goto_loopst::find_function_loops's rewrite,
     // which only fires when a loop-discovering pass is enabled
     // (interval-analysis, k-induction, loop-invariant, contractor).
-    // Doing it here makes the rewrite unconditional for plain BMC.
-    // symex_goto.cpp's self-loop handler stays as a defensive fallback
-    // for modes that skip this pass (--termination, --unwinding-
-    // assertions).
+    // symex_goto.cpp's self-loop handler stays as a defensive fallback.
     if (loop_head == loop_exit)
     {
+      // A bare self-loop has no body, so its guard's truth value never
+      // changes: `A: IF cond GOTO A` spins forever exactly when cond holds,
+      // and `A: GOTO A` always spins. We rewrite the head to an ASSUME
+      // (assume(false) unconditionally, assume(!cond) conditionally),
+      // killing the non-terminating path. This intentionally suppresses the
+      // back-edge unwinding-assertion signal (knowing a program merely needs
+      // more unwinding is rarely actionable), but under --termination the
+      // same rewrite would mask a real non-termination verdict, so skip it.
+      if (options.get_bool_option("termination"))
+        continue;
+
       if (is_true(it->guard))
       {
-        // Unconditional infinite loop: kill the path.
         it->make_assumption(gen_false_expr());
       }
       else
       {
-        // `IF cond GOTO self` exits exactly when !cond; the post-loop
-        // state is constrained by !cond. Copy the guard out before
-        // make_assumption (clear() runs first, resetting it).
+        // `IF cond GOTO self` exits exactly when !cond; constrain the
+        // post-state to !cond. Copy the guard out before make_assumption
+        // (clear() runs first, resetting it).
         expr2tc cond = it->guard;
         make_not(cond);
         it->make_assumption(cond);
@@ -726,43 +733,31 @@ void goto_loop_simplify(
   goto_functionst &goto_functions,
   const optionst &options)
 {
-  // Gated on the user explicitly opting out of the unwinding-
-  // assertion signal (--no-unwinding-assertions) or opting into the
-  // termination reduction (--termination). Outside these two modes
-  // the pass is a no-op.
+  // Enabled by default. Removing a loop we can prove has no observable
+  // effect (Path 1), whose exact post-state we can compute (Path 2), or
+  // that is a bare self-loop, removes the single biggest obstacle a BMC
+  // engine faces. The pass runs in every mode except the two where a loop
+  // rewrite is genuinely unsound or destroys a needed signal:
   //
-  // Why the gate matters: by default, ESBMC emits an unwinding
-  // assertion at every loop back-edge that fires when the loop
-  // hasn't fully unwound within --unwind k. That assertion is the
-  // user-visible non-termination signal at the chosen depth.
-  // Erasing or rewriting a loop in goto_loop_simplify would suppress
-  // that signal even when the loop body is otherwise side-effect-
-  // free, breaking the verification contract (cf. regression/
-  // bitwuzla/get_model_values, regression/parallel-solving/uthash-1).
+  //   - --termination: Path 1 and the self-loop rewrite are skipped. They
+  //     rewrite an infinite empty loop's head to assume(false), which would
+  //     mask the non-termination verdict (LTL(F end) violation) that is the
+  //     property under test. Path 2 still runs: it only matches
+  //     strictly-terminating, overflow-checked counter loops, so it can
+  //     never turn a non-terminating shape into a terminating one.
   //
-  // What each mode does:
-  //   --no-unwinding-assertions: Path 1 (erase dead loops with no
-  //     escaping side effects) and Path 2 (step recognition for
-  //     constant-bound counter loops) run. The self-loop and
-  //     constant-false-exit-guard rewrites stay off — symex's loop
-  //     handling already does the right thing in that mode.
+  //   - Coverage modes: skipped entirely — erasing loops drops branch
+  //     points the coverage instrumentation needs to count.
   //
-  //   --termination: Path 1 is skipped (it would erase non-terminating
-  //     `while (1) {}` to assume(false), masking the verdict). Path 2
-  //     runs — step recognition only matches strictly-terminating
-  //     counter loops with constant bounds and refuses the rewrite
-  //     when the post-value would overflow, so it cannot convert a
-  //     non-terminating shape into a terminating one. The
-  //     single-instruction self-loop rewrite also fires (gated inside
-  //     simplify_function_once).
-  //
-  // Coverage modes: also skipped — erasing loops drops branch points
-  // the coverage instrumentation needs to count.
-  if (
-    !options.get_bool_option("no-unwinding-assertions") &&
-    !options.get_bool_option("termination"))
-    return;
-
+  // We deliberately DO NOT gate on the unwinding-assertion signal. By
+  // default ESBMC emits an unwinding assertion at each loop back-edge that
+  // fails when the loop is not fully unwound within --unwind k; rewriting a
+  // loop away suppresses that failure. That is acceptable: an
+  // unwinding-assertion failure only tells the user to unwind more, which is
+  // rarely actionable, whereas removing the loop lets the program verify
+  // outright. (cf. regression/bitwuzla/get_model_values,
+  // regression/parallel-solving/uthash-1, whose expectations change
+  // accordingly.)
   if (
     options.get_bool_option("assertion-coverage") ||
     options.get_bool_option("assertion-coverage-claims") ||

--- a/src/goto-programs/goto_loop_simplify.h
+++ b/src/goto-programs/goto_loop_simplify.h
@@ -18,12 +18,18 @@
 ///
 /// Iterates to a fixed point so nested no-op loops collapse outward.
 ///
-/// Gated on @p options: the dead-loop erasure (Path 1) is skipped under
-/// --termination (would erase non-terminating `while (1) {}`) and under
-/// coverage modes (drops branch points the instrumentation needs).
-/// Step recognition (Path 2) is safe under --termination because the
-/// pattern only matches strictly-terminating counter loops with
-/// overflow-checked bounds.
+/// Enabled by default. Skipped only where a loop rewrite is unsound or
+/// destroys a needed signal:
+///   - --termination: dead-loop erasure (Path 1) and the self-loop rewrite
+///     are skipped — rewriting an infinite empty loop to assume(false) would
+///     mask the non-termination verdict under test. Constant-bound counter
+///     step recognition (Path 2) still runs (it only matches strictly-
+///     terminating, overflow-checked loops).
+///   - Coverage modes: skipped entirely (erasing loops drops branch points
+///     the instrumentation needs).
+/// The unwinding-assertion signal is intentionally not preserved: removing a
+/// loop suppresses the "needs more unwinding" failure, which is preferable to
+/// leaving the loop unverifiable.
 void goto_loop_simplify(
   goto_functionst &goto_functions,
   const optionst &options);


### PR DESCRIPTION
## Summary

`goto_loop_simplify` previously ran only under `--no-unwinding-assertions` or `--termination`. Removing or reducing a loop is the single biggest lever a BMC engine has, so this enables it by default. The pass now runs in every mode except the two where a loop rewrite is unsound or destroys a needed signal:

- **`--termination`**: dead-loop erasure (Path 1) and the self-loop rewrite are skipped — rewriting an infinite empty loop to `assume(false)` would mask the non-termination verdict under test. Constant-bound counter step recognition (Path 2) still runs (it only matches strictly-terminating, overflow-checked loops).
- **Coverage modes**: skipped entirely (erasing loops drops branch points the instrumentation needs).

The unwinding-assertion signal is **intentionally not preserved**: removing a loop suppresses the "needs more unwinding" failure, which is rarely actionable and is outweighed by being able to verify the program outright.

## Test impact

- `regression/bitwuzla/get_model_values`: used `for(;;)` only as scaffolding to force a bitwuzla counterexample. The pass would rewrite that to `assume(false)`, gutting the trace the test inspects. Rewritten to a reachable `__ESBMC_assert(0)` so it still produces the same `VERIFICATION FAILED` trace without depending on an infinite loop. Verdict unchanged.
- `regression/parallel-solving/uthash-1`: empirically **unaffected** — its loops match neither Path 1/2 nor the self-loop case (non-empty body, live modified var). Still FAILs via unwinding assertions; still stresses the parallel-solving race it was written for.

## Caveat for reviewers / CI

I have **not** run the full regression suite locally, so the complete set of tests whose verdict changes under default-on simplification is not yet known. CI will surface any others; they should be triaged the same way as `get_model_values` (preserve test intent, not just flip the expected verdict). The local build here lacks the Bitwuzla backend, so `get_model_values` itself was verified at the GOTO level (assert reached, loop not rewritten) and with Z3 as a stand-in.