### PR TITLE
[python] fix Optional[T] return type and inline-call `is None` (humaneval_12)

### DIFF
--- a/regression/humaneval/humaneval_12/test.desc
+++ b/regression/humaneval/humaneval_12/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 15 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4807_optional_call_is_none/main.py
+++ b/regression/python/github_4807_optional_call_is_none/main.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+
+def maybe_str(flag: bool) -> Optional[str]:
+    if not flag:
+        return None
+    return "hi"
+
+
+# Direct-call `is None` / `== None`: lhs arrives as code_function_call, not
+# side_effect, so the isnone simplifier saw an operand with empty type and
+# fell through to `False`. The frontend must promote the call to a value
+# expression. Without the fix, both asserts below trip.
+assert maybe_str(False) is None
+assert maybe_str(False) == None
+assert maybe_str(True) is not None
+assert maybe_str(True) != None

--- a/regression/python/github_4807_optional_call_is_none/test.desc
+++ b/regression/python/github_4807_optional_call_is_none/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4807_optional_call_is_none_fail/main.py
+++ b/regression/python/github_4807_optional_call_is_none_fail/main.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+
+def maybe_str(flag: bool) -> Optional[str]:
+    if not flag:
+        return None
+    return "hi"
+
+
+# Negative variant: maybe_str(True) returns "hi", so `is None` must be False.
+# Used to catch a regression where the simplifier returns gen_true_expr
+# unconditionally for Optional[str] return values.
+assert maybe_str(True) is None

--- a/regression/python/github_4807_optional_call_is_none_fail/test.desc
+++ b/regression/python/github_4807_optional_call_is_none_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/re6/test.desc
+++ b/regression/python/re6/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---unwind 1
+--unwind 7
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -410,7 +410,15 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   }
 
   if (lhs.type() == none_type() || rhs.type() == none_type())
+  {
+    // A direct call like `f() is None` arrives as code_function_callt — a
+    // statement, not a value. Promote to side_effect_expr_function_callt so
+    // it carries the return type and downstream isnone simplification can
+    // type-check it as a pointer/struct rather than as empty code.
+    lhs = to_value_expr(lhs, ns);
+    rhs = to_value_expr(rhs, ns);
     return handle_none_comparison(op, lhs, rhs);
+  }
 
   // Handle exceptions
   if (lhs.statement() == "cpp-throw")

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -935,6 +935,11 @@ void python_converter::get_function_definition(
   code_typet type;
   const nlohmann::json &return_node = function_node["returns"];
 
+  // Tracks annotations that already encode Optional (e.g. Optional[T] or
+  // T | None). When true, the later body_has_none_return pass must not
+  // re-wrap the return type as Optional<existing-type>.
+  bool annotation_is_optional = false;
+
   // Determine return type
   if (
     return_node.is_null() ||
@@ -985,6 +990,17 @@ void python_converter::get_function_definition(
     {
       type.return_type() =
         tuple_handler_->get_tuple_type_from_annotation(return_node);
+    }
+    else if (return_type == "Optional" && return_node["_type"] == "Subscript")
+    {
+      // Optional[T]: delegate to the annotation handler, which builds either
+      // an Optional<T> struct (for primitive T) or a T* pointer (for str /
+      // class T, where None is encoded as NULL). The previous fallthrough to
+      // get_typet("Optional") returned a bare pointer_type() (unsignedbv),
+      // which the later body_has_none_return pass then re-wrapped as
+      // Optional<unsignedbv> — a struct unrelated to the annotated T.
+      type.return_type() = get_type_from_annotation(return_node, function_node);
+      annotation_is_optional = true;
     }
     else
     {
@@ -1095,10 +1111,11 @@ void python_converter::get_function_definition(
   };
 
   bool already_optional =
-    type.return_type().is_struct() && to_struct_type(type.return_type())
-                                        .tag()
-                                        .as_string()
-                                        .starts_with("tag-Optional_");
+    annotation_is_optional ||
+    (type.return_type().is_struct() && to_struct_type(type.return_type())
+                                         .tag()
+                                         .as_string()
+                                         .starts_with("tag-Optional_"));
   if (!already_optional && body_has_none_return(function_node["body"]))
   {
     if (type.return_type().is_empty())


### PR DESCRIPTION
Fixes the two coupled bugs that kept `humaneval_12` (`assert longest([]) == None`) — and the minimal `assert f() is None` where `f -> Optional[T]` — failing verification.

**Root cause.** `Optional[str]` annotation was lowered to a bare `pointer_type()` (= `unsignedbv`), which the body-has-None-return wrap then re-wrapped as `Optional<unsignedbv>` — a struct unrelated to the annotated `T`. Independently, `f() is None` arrived in `handle_none_comparison` with `lhs` as a `code_function_callt` carrying empty `code` type, so the `isnone` simplifier saw a non-pointer non-struct operand and fell through to `gen_false_expr`.

**Fix.**
1. `converter_funcdef.cpp` recognises `Subscript(Optional[T])` and delegates to `get_type_from_annotation`, producing `Optional<T>` for primitive `T` and `T*` for str/class `T`. Tracked via `annotation_is_optional` so the wrap step does not double-wrap.
2. `converter_binop.cpp` promotes both sides via `to_value_expr` before lowering to `isnone`, so a direct call carries the function's return type.

**Tests.** `regression/humaneval/humaneval_12` reclassified `CORE` (was `KNOWNBUG`). New `regression/python/github_4807_optional_call_is_none{,_fail}` cover the inline-call `is None` / `== None` / `is not None` / `!= None` paths against `Optional[str]`.

Refs #4807.
