### PR TITLE
[regression] humaneval_71: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_71/test.desc
+++ b/regression/humaneval/humaneval_71/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`triangle_area` computes `(s*(s-a)*(s-b)*(s-c)) ** 0.5`. The `** 0.5` lowers to `pow(x, 0.5)`, whose libm implementation iterates through `expm1` (`src/c2goto/library/libm/exp.c:48`). Even at `--unwind 50` the loop still isn't fully unrolled (verified locally: `Not unwinding loop 48 iteration 50`), and the cost grows linearly with the unwind budget while symex blow-up grows roughly exponentially.

Same shape as humaneval_75 (retagged in #4859): BMC scalability dead-end, not a frontend / soundness bug. Move from `KNOWNBUG` → `FUTURE` so the test stops blocking the umbrella checklist and stays opt-in until a k-induction or shorter-unwind libm model lands.

Draining umbrella #4807.
