### PR TITLE
[regression] humaneval_134: KNOWNBUG -> FUTURE (strlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_134/test.desc
+++ b/regression/humaneval/humaneval_134/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`check_if_last_char_is_a_letter` calls `txt.split(' ')[-1]`. The `__python_str_split` operational model iterates `strlen` over the parser-returned buffer, whose statically-tracked length is the parameter's symbolic bound rather than the constant input length. Even at `--unwind 50` the `strlen` loop still hits `Not unwinding loop 83 iteration 50`.

Increasing the unwind cost grows linearly while symex blow-up grows roughly exponentially — same shape as humaneval_71 (#4881) and humaneval_75 (#4859): BMC scalability dead-end, not a frontend / soundness bug. Move from `KNOWNBUG` → `FUTURE` so it stops blocking the umbrella checklist and stays opt-in until a bounded-strlen model or k-induction-based proof lands.

Draining umbrella #4807.
