### PR TITLE
[regression] humaneval_107: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_107/test.desc
+++ b/regression/humaneval/humaneval_107/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`even_odd_palindrome(123)` iterates `range(1, n+1)` — 123 iterations — and on each call invokes `str(n) == str(n)[::-1]`, which materialises two char arrays via `__python_int_to_str` plus a reverse traversal. At `--unwind 50` the outer loop is still not unrolled past iteration 50 (`unwinding assertion loop 143`), and the symex blow-up grows roughly product-wise as `unwind × <inner palindrome cost>`.

Same shape as humaneval_75 (#4859), humaneval_71 (#4881) and humaneval_134 (#4882): BMC scalability dead-end on a numerically small but iteration-heavy benchmark, not a frontend / soundness bug. Move from `KNOWNBUG` → `FUTURE` so it stops blocking the umbrella checklist and stays opt-in until k-induction or interval analysis discharges the outer counter.

Draining umbrella #4807.
