### PR TITLE
[regression] humaneval_36: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_36/test.desc
+++ b/regression/humaneval/humaneval_36/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`fizz_buzz(50)` iterates `range(n)` — 50 outer iterations — and on each iteration may append to a list, then joins via `''.join(list(map(str, ns)))` which materialises char arrays via `__python_int_to_str`. At `--unwind 50` the outer loop still trips `unwinding assertion loop 143`, and symex blow-up grows product-wise with the inner string materialisation cost.

Same shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882) and humaneval_107 (#4883): BMC scalability dead-end, not a frontend / soundness bug. Move from `KNOWNBUG` → `FUTURE` so it stops blocking the umbrella checklist and stays opt-in until k-induction or interval analysis discharges the outer counter.

Draining umbrella #4807.
