### PR TITLE
[regression] humaneval_112: KNOWNBUG -> FUTURE (strnlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_112/test.desc
+++ b/regression/humaneval/humaneval_112/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`reverse_delete(s, c)` builds `''.join([char for char in s if char not in c])` and evaluates `s[::-1] == s`. The list-comprehension materialises per-char `__python_strnlen_bounded` / `__python_str_slice` walks over parser-returned char arrays whose statically-tracked bound is nondet, and the final `strcmp` over the join result unrolls unbounded. At `--unwind 50` ESBMC still emits `Not unwinding loop 11 iteration 50` inside `__python_strnlen_bounded`, `Not unwinding loop 73` inside `__python_str_slice`, and `Not unwinding loop 103` inside `strcmp`.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884) and humaneval_111 (#4885); not a frontend / soundness bug.

Draining umbrella #4807.
