### PR TITLE
[regression] humaneval_141: KNOWNBUG -> FUTURE (strnlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_141/test.desc
+++ b/regression/humaneval/humaneval_141/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`file_name_check(file_name)` calls `file_name.split(sep='.')` then iterates the resulting list with multiple `in` / equality comparisons against literal strings. Each comparison lowers to a `__python_strnlen_bounded` walk over parser-returned char arrays whose statically-tracked bound is nondet rather than the constant input length. Even at `--unwind 50` the run does not complete inside a 5-minute budget locally.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885) and humaneval_112 (#4887); not a frontend / soundness bug.

Draining umbrella #4807.
