### PR TITLE
[regression] humaneval_144: KNOWNBUG -> FUTURE (strnlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_144/test.desc
+++ b/regression/humaneval/humaneval_144/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`simplify(x, n)` calls `x.split("/")` / `n.split("/")` and parses each half through `int(...)`. Both walk `__python_strnlen_bounded` over parser-returned char arrays whose statically-tracked bound is nondet rather than the constant input length. Even at `--unwind 50` ESBMC still emits `Not unwinding loop 11` inside `__python_strnlen_bounded`.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887) and humaneval_141 (#4888); not a frontend / soundness bug.

Draining umbrella #4807.
