### PR TITLE
[regression] humaneval_161: KNOWNBUG -> FUTURE (strlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_161/test.desc
+++ b/regression/humaneval/humaneval_161/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`solve(s)` materialises `list(s)` and iterates char-by-char calling `i.isalpha()` / `i.swapcase()`, then builds the result string back out. The traversal walks `strlen` over a parser-returned char array whose statically-tracked bound is nondet rather than the constant input length, plus `__python_strnlen_bounded` for the per-char character checks. Even at `--unwind 50` ESBMC still emits `Not unwinding loop 83` inside `strlen`.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888) and humaneval_144 (#4889); not a frontend / soundness bug.

Draining umbrella #4807.
