### PR TITLE
[regression] humaneval_17: KNOWNBUG -> FUTURE (strnlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_17/test.desc
+++ b/regression/humaneval/humaneval_17/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-symex-guard --smt-during-symex
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check --smt-symex-guard --smt-during-symex
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`parse_music(music_string)` calls `music_string.split(' ')` then `[note_map[x] for x in ... if x]`, which probes each split fragment via `__python_strnlen_bounded` against the `'o' / 'o|' / '.|'` dict keys. The walk is over a parser-returned char array whose statically-tracked bound is nondet rather than the constant input length. The test's own banner comment already records that the run is _"too slow for this case"_ and asks for an improved split + a "reasonable" unwind.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889) and humaneval_161 (#4890); not a frontend / soundness bug.

Draining umbrella #4807.
