### PR TITLE
[regression] humaneval_81: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_81/test.desc
+++ b/regression/humaneval/humaneval_81/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`numerical_letter_grade(grades)` iterates the input list, on each gpa runs an 11-arm if/elif chain, and `append`s a grade label string into a python list. The list-build path materialises char arrays per label and the outer loop already trips `Not unwinding loop 143` inside `numerical_letter_grade` at `--unwind 50`. Symex blow-up grows roughly product-wise with the list-grow cost.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890) and humaneval_17 (#4891); not a frontend / soundness bug.

Draining umbrella #4807.
