### PR TITLE
[regression] humaneval_94: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_94/test.desc
+++ b/regression/humaneval/humaneval_94/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`skjkasdkd(lst)` walks the input list with an outer `while i < len(lst)` and on each prime candidate calls `isPrime(n)`, which loops `for i in range(2, int(n**0.5)+1)`. The outer loop trips `Not unwinding loop 143` inside `skjkasdkd` and the inner range path takes the digit-sum result back through `str(maxx)` / `int(c)` which adds `strlen` over a parser-returned char array (`Not unwinding loop 83` inside `strlen`). Symex blow-up grows product-wise with the inner-prime cost.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891) and humaneval_81 (#4892); not a frontend / soundness bug.

Draining umbrella #4807.
