### PR TITLE
[regression] humaneval_129: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_129/test.desc
+++ b/regression/humaneval/humaneval_129/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`minPath(grid, k)` walks `range(n)` twice nested, builds neighbour candidate lists, then loops `k` times appending into `ans`. With even a small grid the run already trips both `Not unwinding loop 143` and `Not unwinding loop 144` inside `minPath` at `--unwind 50`. Symex blow-up scales as the cross-product of the two outer counters times the per-step list grow.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892) and humaneval_94 (#4893); not a frontend / soundness bug.

Draining umbrella #4807.
