### PR TITLE
[regression] humaneval_130: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_130/test.desc
+++ b/regression/humaneval/humaneval_130/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---bitwuzla --unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard
+--bitwuzla --unwind 1 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`tri(n)` builds the Tribonacci-like sequence with `for i in range(2, n + 1)` and on odd indices reads back two prior elements (`my_tri[i - 1] + my_tri[i - 2]`). The outer loop already trips `Not unwinding loop 143` inside `tri` and the recurrence makes each iteration depend on materialised prior list entries, so symex blow-up scales with the unwind plus the per-iteration list-grow cost.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893) and humaneval_129 (#4894); not a frontend / soundness bug.

Draining umbrella #4807.
