### PR TITLE
[regression] humaneval_143: KNOWNBUG -> FUTURE (strnlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_143/test.desc
+++ b/regression/humaneval/humaneval_143/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 18 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`words_in_sentence(sentence)` calls `sentence.split()` and for each token measures `len(word)` plus runs a primality check on the length. The per-token `__python_strnlen_bounded` walk is over a parser-returned char array whose statically-tracked bound is nondet rather than the constant input length, so the strnlen loop unrolls unbounded — `Not unwinding loop 11` inside `__python_strnlen_bounded` already trips at `--unwind 1` and the existing `--unwind 18` budget does not let it terminate either.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894) and humaneval_130 (#4895); not a frontend / soundness bug.

Draining umbrella #4807.
