### PR TITLE
[regression] humaneval_160: KNOWNBUG -> FUTURE (BMC scalability + eval)

### DIFF
--- a/regression/humaneval/humaneval_160/test.desc
+++ b/regression/humaneval/humaneval_160/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 7 --smt-symex-guard --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --smt-symex-guard --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`do_algebra(operator, operand)` builds `expression = str(operand[0])` then concatenates `oprt + str(oprn)` per zipped pair, finally calls `eval(expression)`. Two distinct dead-ends fire:

1. Each `str(int)` materialises a char array via `__python_int_to_str` whose loop unrolls unbounded — `Not unwinding loop 75 / loop 94 (__memcpy_impl)` at `--unwind 1`, and at the existing `--unwind 7` budget the strnlen / memcpy still do not converge.
2. Python `eval()` is not modelled in the frontend; even if BMC scaling improved, the final dynamic-evaluation step would still block verification.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895) and humaneval_143 (#4897); not a frontend / soundness bug.

Draining umbrella #4807.
