### PR TITLE
[regression] humaneval_124: KNOWNBUG -> FUTURE (str_strip scalability)

### DIFF
--- a/regression/humaneval/humaneval_124/test.desc
+++ b/regression/humaneval/humaneval_124/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`valid_date(date)` calls `date.strip()`, then `date.split('-')`, then parses each of month/day/year through `int(...)`. The strip lowers to `__python_str_strip`, which walks the input char array with `__python_strnlen_bounded` on both ends; the subsequent `split` + `int` runs more `strnlen` passes. Each `__python_strnlen_bounded` walk is over a parser-returned char array whose statically-tracked bound is nondet rather than the constant input length, so the loops unroll unbounded — `Not unwinding loop 44` inside `__python_str_strip` and `Not unwinding loop 11` inside `__python_strnlen_bounded` at `--unwind 1`, and the existing `--unwind 20` budget does not let it terminate either.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897) and humaneval_160 (#4898); not a frontend / soundness bug.

Draining umbrella #4807.
