### PR TITLE
[regression] humaneval_99: KNOWNBUG -> FUTURE (strnlen scalability + float)

### DIFF
--- a/regression/humaneval/humaneval_99/test.desc
+++ b/regression/humaneval/humaneval_99/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`closest_integer(value)` runs `value.count('.')`, then a `while value[-1] == '0'` trailing-zero strip, then `float(value)` and `round(num)`. The `count` / index walks lower to `__python_strnlen_bounded` over a parser-returned char array whose statically-tracked bound is nondet rather than the constant input length, so the strnlen loop unrolls unbounded — `Not unwinding loop 11` inside `__python_strnlen_bounded` at `--unwind 1`, and the existing `--unwind 20` budget does not let it terminate either. `float(string)` then raises a `ValueError` exception in the current frontend model, which would also need a real string-to-float implementation before the test could succeed.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898) and humaneval_124 (#4899); not a frontend / soundness bug.

Draining umbrella #4807.
