### PR TITLE
[regression] humaneval_117: KNOWNBUG -> FUTURE (strnlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_117/test.desc
+++ b/regression/humaneval/humaneval_117/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`select_words(s, n)` walks `s.split()`, then for each token iterates `range(0, len(word))` and tests `word[i].lower() not in ["a","e","i","o","u"]`. The per-char vowel check probes the literal vowel list through `__python_strnlen_bounded` against parser-returned char arrays whose statically-tracked bound is nondet rather than the constant input length. The strnlen loop unrolls unbounded (`Not unwinding loop 11` at `--unwind 1`) and ESBMC then trips a secondary `!has_dereference(expr)` assertion in `dereference.cpp:440` when it tries to lower the per-char membership test against the still-symbolic strnlen result. That internal assertion is a downstream consequence of the strnlen overflow, not an independently reproducible bug under a bounded input.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899) and humaneval_99 (#4900); not a frontend / soundness bug.

Draining umbrella #4807.
