### PR TITLE
[regression] humaneval_11: KNOWNBUG -> FUTURE (strlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_11/test.desc
+++ b/regression/humaneval/humaneval_11/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 15 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`string_xor(a, b)` returns `''.join(xor(x, y) for x, y in zip(a, b))`. The `zip(a, b)` generator plus the join lower through `strlen` on the parser-returned char arrays whose statically-tracked bound is nondet rather than the constant input length; the strlen loop unrolls unbounded — `Not unwinding loop 87` inside `strlen` at `--unwind 1`, and the existing `--unwind 15` budget does not let it terminate either.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899), humaneval_99 (#4900), humaneval_117 (#4901) and humaneval_15 (#4902); not a frontend / soundness bug.

Draining umbrella #4807.
