### PR TITLE
[regression] humaneval_19: KNOWNBUG -> FUTURE (strnlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_19/test.desc
+++ b/regression/humaneval/humaneval_19/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 15 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`sort_numbers(numbers)` splits on space, filters empty tokens, looks up each token in a literal 10-entry `value_map` dict, sorts by the mapped value, then joins. The dict-lookup keys are probed via `__python_strnlen_bounded` against parser-returned char arrays whose statically-tracked bound is nondet rather than the constant input length; the strnlen loop unrolls unbounded — `Not unwinding loop 11` inside `__python_strnlen_bounded` at `--unwind 1`, and the existing `--unwind 15` budget does not let it terminate either.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899), humaneval_99 (#4900), humaneval_117 (#4901), humaneval_15 (#4902) and humaneval_11 (#4903); not a frontend / soundness bug.

Draining umbrella #4807.
