### PR TITLE
[regression] humaneval_104: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_104/test.desc
+++ b/regression/humaneval/humaneval_104/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 3 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`unique_digits(x)` walks the input list and on each element runs `all(int(c) % 2 == 1 for c in str(i))`. The per-element `str(i)` materialises a char array via `__python_int_to_str`, and the subsequent per-char `int(c)` traverses that buffer with `strlen`. The `__python_int_to_str` loop and the `strlen` loop both unroll unbounded (`Not unwinding loop 75` inside `__python_int_to_str` and `Not unwinding loop 87` inside `strlen` at `--unwind 1`); the existing `--unwind 3` budget does not let either terminate.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899), humaneval_99 (#4900), humaneval_117 (#4901), humaneval_15 (#4902), humaneval_11 (#4903) and humaneval_19 (#4904); not a frontend / soundness bug.

Draining umbrella #4807.
