### PR TITLE
[regression] humaneval_113: KNOWNBUG -> FUTURE (strlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_113/test.desc
+++ b/regression/humaneval/humaneval_113/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 2 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`odd_count(lst)` iterates the input list and on each element walks `sum(int(d) % 2 == 1 for d in arr)`. The `int(d)` parser path and the surrounding generator traverse `arr` via `strlen` over parser-returned char arrays whose statically-tracked bound is nondet rather than the constant input length; the strlen loop unrolls unbounded (`Not unwinding loop 87` inside `strlen` at `--unwind 1`), and the existing `--unwind 2` budget does not let it terminate either. The subsequent `"the number of odd elements " + str(n) + ...` concat chain compounds the same strlen cost across four interpolations.

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899), humaneval_99 (#4900), humaneval_117 (#4901), humaneval_15 (#4902), humaneval_11 (#4903), humaneval_19 (#4904) and humaneval_104 (#4905); not a frontend / soundness bug.

Draining umbrella #4807.
