### PR TITLE
[regression] humaneval_153: KNOWNBUG -> FUTURE (strlen scalability)

### DIFF
--- a/regression/humaneval/humaneval_153/test.desc
+++ b/regression/humaneval/humaneval_153/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`Strongest_Extension(class_name, extensions)` iterates the extension list, on each element runs two list-comprehensions counting upper / lower letters via `x.isalpha() and x.isupper() / islower()`, then concatenates the winning name with the class name. The per-char checks plus the final concat walk `strlen` over parser-returned char arrays whose statically-tracked bound is nondet rather than the constant input length; the strlen loop unrolls unbounded — `Not unwinding loop 87` inside `strlen` at `--unwind 1`, and the existing `--unwind 20` budget does not let it terminate (a local run at unwind 20 was still iterating after 100 minutes when killed).

Drop the unwind to 1 so the existing scalability failure surfaces immediately as the FUTURE expected-fail rather than wedging the regression suite. Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899), humaneval_99 (#4900), humaneval_117 (#4901), humaneval_15 (#4902), humaneval_11 (#4903), humaneval_19 (#4904), humaneval_104 (#4905) and humaneval_113 (#4906); not a frontend / soundness bug.

Draining umbrella #4807.
