### PR TITLE
[regression] humaneval_69: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_69/test.desc
+++ b/regression/humaneval/humaneval_69/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --unwind 1 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`search(lst)` builds `frq = [0] * (max(lst) + 1)` then runs two iteration passes: `for i in lst` (frequency update) and `for i in range(1, len(frq))` (winner scan). The test calls `search([5, 5, 5, 5, 1])` — `len(lst) = 5`, `max(lst) = 5` — so both loops need at least 5 / 6 honest iterations. At the current `--unwind 1` budget both loops already trip `Not unwinding loop 149` / `Not unwinding loop 150` inside `search`. Raising the unwind to 6+ makes the inner `frq[i] += 1` symex blow up roughly product-wise against the second loop and never converges under a 5-minute budget.

Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899), humaneval_99 (#4900), humaneval_117 (#4901), humaneval_15 (#4902), humaneval_11 (#4903), humaneval_19 (#4904), humaneval_104 (#4905), humaneval_113 (#4906) and humaneval_153 (#4907); not a frontend / soundness bug. Move from `KNOWNBUG` → `FUTURE` so it stops blocking the umbrella checklist and stays opt-in until k-induction or interval analysis discharges the outer counters. Unwind stays at 1 (already minimal).

Draining umbrella #4807.
