### PR TITLE
[regression] humaneval_109: KNOWNBUG -> FUTURE (BMC scalability)

### DIFF
--- a/regression/humaneval/humaneval_109/test.desc
+++ b/regression/humaneval/humaneval_109/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --unwind 1 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`move_one_ball(arr)` calls `sorted(arr)`, `min(arr)`, `arr.index(...)`, slices `arr[min_index:] + arr[0:min_index]`, then walks `for i in range(len(arr))`. The test calls `move_one_ball([4, 3, 1, 2])` (len 4), so each helper plus the trailing comparison loop needs ≥4 honest iterations. At `--unwind 1` ESBMC already trips both `Not unwinding loop 132` inside `sorted` and `Not unwinding loop 123` inside `min`. Raising the unwind to 4+ pushes symex into a product-wise blow-up across the sort, the slice-concat list build, and the final equality scan that does not converge under a 5-minute budget.

Same BMC scalability dead-end shape as humaneval_75 (#4859), humaneval_71 (#4881), humaneval_134 (#4882), humaneval_107 (#4883), humaneval_36 (#4884), humaneval_111 (#4885), humaneval_112 (#4887), humaneval_141 (#4888), humaneval_144 (#4889), humaneval_161 (#4890), humaneval_17 (#4891), humaneval_81 (#4892), humaneval_94 (#4893), humaneval_129 (#4894), humaneval_130 (#4895), humaneval_143 (#4897), humaneval_160 (#4898), humaneval_124 (#4899), humaneval_99 (#4900), humaneval_117 (#4901), humaneval_15 (#4902), humaneval_11 (#4903), humaneval_19 (#4904), humaneval_104 (#4905), humaneval_113 (#4906), humaneval_153 (#4907) and humaneval_69 (#4910); not a frontend / soundness bug. Unwind stays at 1 (already minimal).

Draining umbrella #4807.
