### PR TITLE
[contracts] free pointer-param backing on enforce-contract exit

### DIFF
--- a/regression/function_contract/memleak_check_enforce_addrof_pass/main.c
+++ b/regression/function_contract/memleak_check_enforce_addrof_pass/main.c
@@ -1,0 +1,16 @@
+/* memleak_check_enforce_addrof_pass: covers the address-of surface form of
+ * __ESBMC_is_fresh combined with --memory-leak-check. The bare-pointer form
+ * is covered by memleak_check_enforce_pass; this case exercises the
+ * address-of peel branch (stripped = &p -> ptr_var = p) at the same time as
+ * the wrapper-free fix for issue #4908.
+ */
+__ESBMC_contract
+int read_thru_addrof(const int *p)
+{
+    __ESBMC_requires(__ESBMC_is_fresh(&p, sizeof(*p)));
+    __ESBMC_ensures(__ESBMC_return_value == *p);
+    __ESBMC_assigns();
+    return *p;
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/memleak_check_enforce_addrof_pass/test.desc
+++ b/regression/function_contract/memleak_check_enforce_addrof_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function read_thru_addrof --enforce-contract read_thru_addrof --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/memleak_check_enforce_fail/main.c
+++ b/regression/function_contract/memleak_check_enforce_fail/main.c
@@ -1,0 +1,24 @@
+/* memleak_check_enforce_fail: --memory-leak-check must still catch real
+ * user-introduced leaks inside a contract-enforced function. Companion to
+ * memleak_check_enforce_pass: ensures the wrapper-free fix for issue #4908
+ * does not over-suppress and hide genuine CWE-401 violations.
+ *
+ * The body mallocs a buffer and never frees it; the only auto-allocation the
+ * wrapper does (for p) is freed by the fix, so the leaked buffer reported by
+ * the checker must be the body's malloc — confirming the checker is alive.
+ */
+#include <stdlib.h>
+
+__ESBMC_contract
+int read_thru(const int *p)
+{
+    __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(*p)));
+    __ESBMC_assigns();
+
+    int *leaked = (int *)malloc(sizeof(int));
+    if (leaked)
+        *leaked = *p;
+    return *p;
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/memleak_check_enforce_fail/test.desc
+++ b/regression/function_contract/memleak_check_enforce_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function read_thru --enforce-contract read_thru --memory-leak-check
+^VERIFICATION FAILED$
+^\s*dereference failure: forgotten memory:

--- a/regression/function_contract/memleak_check_enforce_pass/main.c
+++ b/regression/function_contract/memleak_check_enforce_pass/main.c
@@ -1,0 +1,16 @@
+/* memleak_check_enforce_pass: --enforce-contract + --memory-leak-check must
+ * compose. The wrapper allocates a buffer for the pointer parameter so the
+ * body can dereference it; that allocation is wrapper-internal and must be
+ * freed before the wrapper returns. Without the matching free the leak
+ * checker reports CWE-401 against the user's function (issue #4908).
+ */
+__ESBMC_contract
+int read_thru(const int *p)
+{
+    __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(*p)));
+    __ESBMC_ensures(__ESBMC_return_value == *p);
+    __ESBMC_assigns();
+    return *p;
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/memleak_check_enforce_pass/test.desc
+++ b/regression/function_contract/memleak_check_enforce_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function read_thru --enforce-contract read_thru --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -960,6 +960,13 @@ goto_programt code_contractst::generate_checking_wrapper(
   };
   std::vector<is_fresh_info> is_fresh_calls;
 
+  // Pointer-typed lvalues that received a heap allocation in this wrapper
+  // (is_fresh requires-side mallocs and add_pointer_validity_assumptions
+  // mallocs). Each gets a matching free() before the wrapper returns so that
+  // --memory-leak-check does not blame the user's function for the
+  // wrapper-internal allocation (CWE-401, see GitHub issue #4908).
+  std::vector<expr2tc> wrapper_heap_ptrs;
+
   forall_goto_program_instructions (it, original_body)
   {
     if (it->is_function_call() && is_code_function_call2t(it->code))
@@ -1046,6 +1053,9 @@ goto_programt code_contractst::generate_checking_wrapper(
     assign_inst->location = location;
     assign_inst->location.comment("__ESBMC_is_fresh memory allocation");
 
+    // Remember the allocation so the wrapper can free it before returning.
+    wrapper_heap_ptrs.push_back(ptr_var);
+
     // Assume the pointer is non-null: __ESBMC_is_fresh guarantees a fresh,
     // valid memory block.  Without this, symex_mem's non-deterministic
     // malloc-failure path can produce NULL, causing later dereferences to fail.
@@ -1109,7 +1119,8 @@ goto_programt code_contractst::generate_checking_wrapper(
       original_func,
       location,
       array_param_ids,
-      is_fresh_allocated_params);
+      is_fresh_allocated_params,
+      &wrapper_heap_ptrs);
   }
 
   // 2. Extract and create snapshots for __ESBMC_old() expressions.
@@ -1433,6 +1444,20 @@ goto_programt code_contractst::generate_checking_wrapper(
     t->location = location;
     t->location.comment("contract ensures");
     t->location.property("contract ensures");
+  }
+
+  // 4b. Free every heap allocation the wrapper performed for the parameters
+  //     (is_fresh requires-side mallocs and add_pointer_validity_assumptions
+  //     mallocs). Must happen AFTER the ensures assertion — which may
+  //     dereference these buffers — and BEFORE the RETURN, so that
+  //     --memory-leak-check no longer attributes a CWE-401 forgotten-memory
+  //     leak to the user's function (issue #4908).
+  for (const expr2tc &ptr : wrapper_heap_ptrs)
+  {
+    goto_programt::targett free_inst = wrapper.add_instruction(OTHER);
+    free_inst->code = code_free2tc(ptr);
+    free_inst->location = location;
+    free_inst->location.comment("contract: free wrapper-allocated backing");
   }
 
   // 5. Return the value (if function has return type)
@@ -3659,7 +3684,8 @@ void code_contractst::add_pointer_validity_assumptions(
   const symbolt &func,
   const locationt &location,
   const std::set<irep_idt> &array_params,
-  const std::set<irep_idt> &skip_params)
+  const std::set<irep_idt> &skip_params,
+  std::vector<expr2tc> *allocated_ptrs)
 {
   if (!func.get_type().is_code())
     return;
@@ -3726,6 +3752,9 @@ void code_contractst::add_pointer_validity_assumptions(
         "contracts",
         "add_pointer_validity_assumptions: malloc (array) for parameter {}",
         id2string(param.get_identifier()));
+
+      if (allocated_ptrs)
+        allocated_ptrs->push_back(p);
     }
     else
     {
@@ -3834,6 +3863,9 @@ void code_contractst::add_pointer_validity_assumptions(
           "add_pointer_validity_assumptions: malloc (primitive) for parameter "
           "{}",
           id2string(param.get_identifier()));
+
+        if (allocated_ptrs)
+          allocated_ptrs->push_back(p);
       }
     }
   }

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -520,12 +520,18 @@ private:
   /// \param location Location information
   /// \param array_params Set of param IDs that need array allocation (ARRAY_ALLOC_ELEMS elements)
   /// \param skip_params Set of param IDs already allocated by __ESBMC_is_fresh
+  /// \param allocated_ptrs Optional output: pointer-typed lvalues that received
+  ///        a heap allocation. Stack-backed struct params are not appended.
+  ///        Callers use this to emit matching free() calls at wrapper exit so
+  ///        --memory-leak-check does not blame the user's function for
+  ///        wrapper-internal allocations (CWE-401).
   void add_pointer_validity_assumptions(
     goto_programt &wrapper,
     const symbolt &func,
     const locationt &location,
     const std::set<irep_idt> &array_params = {},
-    const std::set<irep_idt> &skip_params = {});
+    const std::set<irep_idt> &skip_params = {},
+    std::vector<expr2tc> *allocated_ptrs = nullptr);
 };
 
 #endif // ESBMC_CONTRACTS_H


### PR DESCRIPTION
The synthesised `--enforce-contract` wrapper mallocs backing storage for each pointer parameter (so the body can dereference it) but never freed it; `--memory-leak-check` then reported CWE-401 forgotten-memory against the user's function. Track every wrapper-internal heap allocation (is_fresh requires-side mallocs and `add_pointer_validity_assumptions` mallocs) in `wrapper_heap_ptrs`, and emit `code_free2tc(p)` for each just before the wrapper's RETURN — after the ensures ASSERT, which may still need to dereference the buffer.

Fixes #4908