### PR TITLE
[ci] cancel in-flight PR CI when the PR is merged

### DIFF
--- a/.github/workflows/cancel-merged-pr-ci.yml
+++ b/.github/workflows/cancel-merged-pr-ci.yml
@@ -1,0 +1,45 @@
+name: Cancel CI on merged PR
+
+# When a PR is merged, GitHub does not cancel the CI runs that are still
+# in progress or queued for that PR's head branch. Those runs are now
+# pointless (the code has already landed on master, which triggers its own
+# CI), so they only waste runner time. This workflow cancels them.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    # Only act when the PR actually landed, not when it was closed unmerged.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-slim
+    steps:
+      - name: Cancel in-progress and queued runs for the merged PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Match on the PR's head commit, not the branch name: this is the
+          # only identifier that is unique to this PR and that is recorded the
+          # same way for both same-repo and forked-PR runs. Branch-name
+          # matching misses forks and can collide with shared bot branches.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          SELF_RUN_ID: ${{ github.run_id }}
+        run: |
+          for status in queued waiting in_progress; do
+            gh run list \
+              --repo "$REPO" \
+              --status "$status" \
+              --limit 100 \
+              --json databaseId,headSha \
+              --jq ".[] | select(.headSha == \"$HEAD_SHA\") | .databaseId" \
+            | while read -r run_id; do
+                [ "$run_id" = "$SELF_RUN_ID" ] && continue
+                echo "Cancelling run $run_id ($status)"
+                gh run cancel "$run_id" --repo "$REPO" || true
+              done
+          done
+          echo "Done cancelling runs for $HEAD_SHA"


### PR DESCRIPTION
## Problem

When a PR is merged, GitHub does **not** cancel that PR's still-running or queued CI runs. The main PR workflow (`pull_request.yml`) has `concurrency: cancel-in-progress` keyed on `github.ref`, which only evicts superseded runs when a *new commit is pushed to the same open PR* — nothing pushes into that group on merge, so the in-flight runs keep burning runner time after the code is already on `master` (where it triggers its own CI).

## Fix

Add a small workflow that triggers on `pull_request: [closed]`, gated to `merged == true`, which lists in-progress / queued / waiting runs and cancels those matching the merged PR's head commit.

Key design choice: **match on head SHA, not branch name.** The head SHA is unique to this PR's tip and is recorded the same way for both same-repo and forked-PR runs. Branch-name matching (`--branch`) misses fork PRs (their runs live in the base repo under the merge ref) and can collide with shared bot branches like `dependabot/...`, cancelling an unrelated open PR's runs.

The cleanup run skips its own `run_id`, and `gh run cancel` failures are tolerated (`|| true`) so a run that finishes between listing and cancelling doesn't fail the job.

## Testing

Pure CI-config change — no ESBMC build/regression impact. Validated locally: YAML parses, the `jq` head-SHA filter selects correctly, and the embedded shell passes `bash -n`. The `gh run list`/`gh run cancel` flags used are confirmed against the installed `gh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)