### PR TITLE
[python] Fix json abort in get_typet on derived list elements

### DIFF
--- a/regression/python/github_4909/main.py
+++ b/regression/python/github_4909/main.py
@@ -1,0 +1,5 @@
+Y = 1
+X = Y
+a = [X]
+for i in range(1):
+    a[i] = -1

--- a/regression/python/github_4909/test.desc
+++ b/regression/python/github_4909/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4909_binop/main.py
+++ b/regression/python/github_4909_binop/main.py
@@ -1,0 +1,4 @@
+X = 1 + 0
+a = [X]
+for i in range(1):
+    a[i] = -1

--- a/regression/python/github_4909_binop/test.desc
+++ b/regression/python/github_4909_binop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4909_fail/main.py
+++ b/regression/python/github_4909_fail/main.py
@@ -1,0 +1,6 @@
+Y = 1
+X = Y
+a = [X]
+for i in range(1):
+    a[i] = -1
+assert a[0] == 1

--- a/regression/python/github_4909_fail/test.desc
+++ b/regression/python/github_4909_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -740,6 +740,13 @@ typet type_handler::get_typet(const nlohmann::json &elem) const
       return get_typet(elem["operand"]);
     }
 
+    // Handle Python AST BinOp node (e.g., 1 + 0, a * b). Reuse
+    // get_operand_type, which recursively resolves the operand types, then
+    // map the type name back to a typet. Without this, an expression-derived
+    // binding used as a list element aborted (issue #4909).
+    if (elem["_type"] == "BinOp")
+      return get_typet(get_operand_type(elem));
+
     // Handle Python AST List node
     if (elem["_type"] == "List" && elem.contains("elts"))
     {
@@ -801,8 +808,13 @@ typet type_handler::get_typet(const nlohmann::json &elem) const
 
     if (!var.empty() && var.contains("value") && !var["value"].is_null())
     {
+      // Resolve the type of the binding's right-hand side. Dispatch on the
+      // whole RHS node rather than assuming it is a Constant wrapper: a derived
+      // binding such as `X = Y` (alias) or `X = 1 + 0` (expression) has no
+      // nested "value" key, so the old `var["value"]["value"]` aborted. See
+      // issue #4909.
       if (var["value"]["_type"] != "Call")
-        return get_typet(var["value"]["value"]);
+        return get_typet(var["value"]);
 
       if (var["value"].contains("func"))
         return get_typet_from_call_func(var["value"]["func"]);


### PR DESCRIPTION
Fixes #4909.

`type_handler::get_typet`'s `Name` branch resolved a binding's type by indexing `var["value"]["value"]`, assuming the right-hand side was a `Constant` (which carries a nested `"value"`). When the list element came from a *derived* binding — an alias (`X = Y`) or an expression (`X = 1 + 0`) — the RHS is a `Name`/`BinOp` with no nested `"value"`, so the access aborted with a `nlohmann::json::operator[]` assertion (json.hpp:2147) during GOTO conversion. It only surfaced when the list was then mutated by indexed assignment inside a loop (`a[i] = ...`), which routes element-type inference through this branch.

The fix dispatches on the whole RHS node (`get_typet(var["value"])`) — the dispatcher already handles `Constant` (identically, via the wrapper-unwrap), `Name` (recursion), `UnaryOp`, `List`/`Tuple`/`Dict` — and adds a `BinOp` case that reuses the existing `get_operand_type`. The `Call` sub-branch is deliberately kept: it routes through `get_typet_from_call_func`, which safely handles `Attribute`-func calls that the dispatcher's unguarded `elem["func"]["id"]` would abort on.

Tests (`regression/python/`): `github_4909` (alias) and `github_4909_binop` (expression) verify SUCCESSFUL; `github_4909_fail` confirms the loop mutation actually takes effect (the assertion `a[0] == 1` fails because `a[0]` is now `-1`).