### PR TITLE
[python] fix json crash on negative list index with variable operand

### DIFF
--- a/regression/python/github_4926/main.py
+++ b/regression/python/github_4926/main.py
@@ -1,0 +1,10 @@
+# Negative list index with a non-constant operand (a[-i]) crashed the
+# frontend with a json operator[] assertion during GOTO conversion
+# (#4926). The negated value is only known at runtime; list_at must
+# normalize it via __ESBMC_list_size.
+a = [1, 2, 3]
+i = 1
+assert a[-i] == 3
+
+j = 2
+assert a[-j] == 2

--- a/regression/python/github_4926/test.desc
+++ b/regression/python/github_4926/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4926_fail/main.py
+++ b/regression/python/github_4926_fail/main.py
@@ -1,0 +1,5 @@
+# Negative variable index resolves to the correct element, so a wrong
+# expected value must be caught (companion to github_4926).
+a = [1, 2, 3]
+i = 1
+assert a[-i] == 999

--- a/regression/python/github_4926_fail/test.desc
+++ b/regression/python/github_4926_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1819,10 +1819,25 @@ exprt python_list::handle_index_access(
   // Handle negative indices
   if (slice_node.contains("op") && slice_node["op"]["_type"] == "USub")
   {
+    // Both compile-time branches below assume the negated operand is a
+    // constant literal (a[-1]). For a non-constant operand (a[-i]) the value
+    // is only known at runtime, so leave pos_expr (= -i) and index untouched:
+    // build_list_at_call normalizes the negative index at runtime via
+    // __ESBMC_list_size, and the element-type lookup falls back to element 0,
+    // which is correct for the homogeneous lists ESBMC models (#4926).
+    const bool operand_is_constant =
+      slice_node.contains("operand") &&
+      slice_node["operand"]["_type"] == "Constant" &&
+      slice_node["operand"].contains("value");
+
+    if (!operand_is_constant)
+    {
+      // Nothing to do: runtime normalization handles a[-i].
+    }
     // For char* (string parameters), skip compile-time normalization: the size
     // is not known statically, so normalization happens at runtime in the
     // char* indexing block below.
-    if (
+    else if (
       !array.type().is_pointer() &&
       (list_node.is_null() || list_node["value"]["_type"] != "List"))
     {


### PR DESCRIPTION
Fixes #4926.

`handle_index_access` assumed the operand of a unary-minus subscript (`a[-x]`) was a constant literal. For a non-constant operand like `a[-i]` it read `slice_node["operand"]["value"]` (and `pos_expr.op0().value()`), keys that do not exist for a `Name` node, tripping the `nlohmann::json operator[]` assertion (`json.hpp:2147`) during GOTO conversion — before any verification.

The fix guards the compile-time index normalization on a constant operand. A non-constant negative index is left untouched and resolved at runtime by `build_list_at_call`, which already normalizes `index < 0 ? size + index : index` via `__ESBMC_list_size`; the element-type lookup falls back to element 0, correct for the homogeneous lists ESBMC models.

Verified that `a[-i]` resolves to the correct element (`==3` SUCCESSFUL, `==999` FAILED, `i=2`→`2`) under both Bitwuzla and Z3, and that `a[-1]` (constant) and `a[3 - i]` (BinOp) still work. Adds passing/failing regression tests; all 65 existing negative-index python tests still pass.
