### PR TITLE
fix(ir-ieee): round integer-to-floating casts

### DIFF
--- a/regression/floats/int-to-float-prec-boundary-ir-ieee/main.c
+++ b/regression/floats/int-to-float-prec-boundary-ir-ieee/main.c
@@ -1,0 +1,21 @@
+/* Round-trip int -> float -> int across the float precision boundary (2^24).
+ * Integers above 2^24 are not all representable as float; specifically 2^24+1
+ * rounds to 2^24 under IEEE round-to-nearest-even.  After the round-trip the
+ * result can therefore never equal 2^24+1.
+ *
+ * Regression: under --ir-ieee, symbolic integer-to-float casts must apply
+ * target-type precision rounding rather than preserving the integer as an
+ * exact SMT real. */
+#include <assert.h>
+
+int nondet_int(void);
+
+int main(void)
+{
+  int i = nondet_int();
+  __ESBMC_assume(i >= 16777216 && i <= 16777218);
+  float f = (float)i;
+  int j = (int)f;
+  assert(j != 16777217);
+  return 0;
+}

--- a/regression/floats/int-to-float-prec-boundary-ir-ieee/test.desc
+++ b/regression/floats/int-to-float-prec-boundary-ir-ieee/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/int-to-float-prec-boundary-round-up-ir-ieee/main.c
+++ b/regression/floats/int-to-float-prec-boundary-round-up-ir-ieee/main.c
@@ -1,0 +1,23 @@
+/* Round-trip int -> float -> int across the float precision boundary (2^24),
+ * round-up tie case.
+ * At binade k=1 (values in [2^24, 2^25)), representable floats are spaced by 2.
+ * 16777219 = 2^24 + 3 is halfway between 16777218 and 16777220.
+ * Its floor significand index is 16777218/2 = 8388609 (odd), so RNE rounds UP
+ * to 16777220.  After the round-trip the result cannot equal 16777219.
+ *
+ * Regression: under --ir-ieee, symbolic integer-to-float casts must apply
+ * target-type precision rounding rather than preserving the integer as an
+ * exact SMT real. */
+#include <assert.h>
+
+int nondet_int(void);
+
+int main(void)
+{
+  int i = nondet_int();
+  __ESBMC_assume(i >= 16777218 && i <= 16777220);
+  float f = (float)i;
+  int j = (int)f;
+  assert(j != 16777219);
+  return 0;
+}

--- a/regression/floats/int-to-float-prec-boundary-round-up-ir-ieee/test.desc
+++ b/regression/floats/int-to-float-prec-boundary-round-up-ir-ieee/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/int-to-float-prec-boundary-round-up/main.c
+++ b/regression/floats/int-to-float-prec-boundary-round-up/main.c
@@ -1,0 +1,19 @@
+/* Round-trip int -> float -> int across the float precision boundary (2^24),
+ * round-up tie case.
+ * At binade k=1 (values in [2^24, 2^25)), representable floats are spaced by 2.
+ * 16777219 = 2^24 + 3 is halfway between 16777218 and 16777220.
+ * Its floor significand index is 16777218/2 = 8388609 (odd), so RNE rounds UP
+ * to 16777220.  After the round-trip the result cannot equal 16777219. */
+#include <assert.h>
+
+int nondet_int(void);
+
+int main(void)
+{
+  int i = nondet_int();
+  __ESBMC_assume(i >= 16777218 && i <= 16777220);
+  float f = (float)i;
+  int j = (int)f;
+  assert(j != 16777219);
+  return 0;
+}

--- a/regression/floats/int-to-float-prec-boundary-round-up/test.desc
+++ b/regression/floats/int-to-float-prec-boundary-round-up/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/int-to-float-prec-boundary/main.c
+++ b/regression/floats/int-to-float-prec-boundary/main.c
@@ -1,0 +1,17 @@
+/* Round-trip int -> float -> int across the float precision boundary (2^24).
+ * Integers above 2^24 are not all representable as float; specifically 2^24+1
+ * rounds to 2^24 under IEEE round-to-nearest-even.  After the round-trip the
+ * result can therefore never equal 2^24+1. */
+#include <assert.h>
+
+int nondet_int(void);
+
+int main(void)
+{
+  int i = nondet_int();
+  __ESBMC_assume(i >= 16777216 && i <= 16777218);
+  float f = (float)i;
+  int j = (int)f;
+  assert(j != 16777217);
+  return 0;
+}

--- a/regression/floats/int-to-float-prec-boundary/test.desc
+++ b/regression/floats/int-to-float-prec-boundary/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/long-to-double-prec-boundary-ir-ieee/main.c
+++ b/regression/floats/long-to-double-prec-boundary-ir-ieee/main.c
@@ -1,0 +1,21 @@
+/* Round-trip long long -> double -> long long across the double precision
+ * boundary (2^53).  Integers above 2^53 are not all representable as double;
+ * specifically 2^53+1 rounds to 2^53 under IEEE round-to-nearest-even.  After
+ * the round-trip the result can therefore never equal 2^53+1.
+ *
+ * Regression: under --ir-ieee, symbolic integer-to-double casts must apply
+ * target-type precision rounding rather than preserving the integer as an
+ * exact SMT real. */
+#include <assert.h>
+
+long long nondet_longlong(void);
+
+int main(void)
+{
+  long long x = nondet_longlong();
+  __ESBMC_assume(x >= 9007199254740992LL && x <= 9007199254740994LL);
+  double d = (double)x;
+  long long y = (long long)d;
+  assert(y != 9007199254740993LL);
+  return 0;
+}

--- a/regression/floats/long-to-double-prec-boundary-ir-ieee/test.desc
+++ b/regression/floats/long-to-double-prec-boundary-ir-ieee/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/long-to-double-prec-boundary-round-up-ir-ieee/main.c
+++ b/regression/floats/long-to-double-prec-boundary-round-up-ir-ieee/main.c
@@ -1,0 +1,25 @@
+/* Round-trip long long -> double -> long long across the double precision
+ * boundary (2^53), round-up tie case.
+ * At binade k=1 (values in [2^53, 2^54)), representable doubles are spaced by 2.
+ * 9007199254740995 = 2^53 + 3 is halfway between 9007199254740994 and
+ * 9007199254740996.  Its floor significand index is
+ * 9007199254740994/2 = 4503599627370497 (odd), so RNE rounds UP to
+ * 9007199254740996.  After the round-trip the result cannot equal
+ * 9007199254740995.
+ *
+ * Regression: under --ir-ieee, symbolic integer-to-double casts must apply
+ * target-type precision rounding rather than preserving the integer as an
+ * exact SMT real. */
+#include <assert.h>
+
+long long nondet_longlong(void);
+
+int main(void)
+{
+  long long x = nondet_longlong();
+  __ESBMC_assume(x >= 9007199254740994LL && x <= 9007199254740996LL);
+  double d = (double)x;
+  long long y = (long long)d;
+  assert(y != 9007199254740995LL);
+  return 0;
+}

--- a/regression/floats/long-to-double-prec-boundary-round-up-ir-ieee/test.desc
+++ b/regression/floats/long-to-double-prec-boundary-round-up-ir-ieee/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/long-to-double-prec-boundary-round-up/main.c
+++ b/regression/floats/long-to-double-prec-boundary-round-up/main.c
@@ -1,0 +1,21 @@
+/* Round-trip long long -> double -> long long across the double precision
+ * boundary (2^53), round-up tie case.
+ * At binade k=1 (values in [2^53, 2^54)), representable doubles are spaced by 2.
+ * 9007199254740995 = 2^53 + 3 is halfway between 9007199254740994 and
+ * 9007199254740996.  Its floor significand index is
+ * 9007199254740994/2 = 4503599627370497 (odd), so RNE rounds UP to
+ * 9007199254740996.  After the round-trip the result cannot equal
+ * 9007199254740995. */
+#include <assert.h>
+
+long long nondet_longlong(void);
+
+int main(void)
+{
+  long long x = nondet_longlong();
+  __ESBMC_assume(x >= 9007199254740994LL && x <= 9007199254740996LL);
+  double d = (double)x;
+  long long y = (long long)d;
+  assert(y != 9007199254740995LL);
+  return 0;
+}

--- a/regression/floats/long-to-double-prec-boundary-round-up/test.desc
+++ b/regression/floats/long-to-double-prec-boundary-round-up/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/long-to-double-prec-boundary/main.c
+++ b/regression/floats/long-to-double-prec-boundary/main.c
@@ -1,0 +1,17 @@
+/* Round-trip long long -> double -> long long across the double precision
+ * boundary (2^53).  Integers above 2^53 are not all representable as double;
+ * specifically 2^53+1 rounds to 2^53 under IEEE round-to-nearest-even.  After
+ * the round-trip the result can therefore never equal 2^53+1. */
+#include <assert.h>
+
+long long nondet_longlong(void);
+
+int main(void)
+{
+  long long x = nondet_longlong();
+  __ESBMC_assume(x >= 9007199254740992LL && x <= 9007199254740994LL);
+  double d = (double)x;
+  long long y = (long long)d;
+  assert(y != 9007199254740993LL);
+  return 0;
+}

--- a/regression/floats/long-to-double-prec-boundary/test.desc
+++ b/regression/floats/long-to-double-prec-boundary/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -708,16 +708,17 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
   }
 
   // int -> fp: lift integer to float under integer encoding.
-  // For plain integer (bv) sources, apply IEEE 754 RNE quantization so that
-  // values above the target significand boundary are correctly rounded.
-  // fixedbv sources (fixed-point) retain the previous exact-lift behaviour.
+  // Under --ir-ieee, plain integer (bv) sources apply IEEE 754 RNE
+  // quantization so that values above the target significand boundary are
+  // correctly rounded.  Plain --ir and fixedbv sources retain the previous
+  // exact-lift behaviour.
   if (
     int_encoding &&
     (is_bv_type(cast.from->type) || is_fixedbv_type(cast.from->type)) &&
     is_floatbv_type(cast.type))
   {
     smt_astt from_int = convert_ast(cast.from);
-    if (is_bv_type(cast.from->type))
+    if (ir_ieee && is_bv_type(cast.from->type))
     {
       const floatbv_type2t &fbv_type = to_floatbv_type(cast.type);
       return round_int_to_fp(from_int, fbv_type, cast.from->type->get_width());

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -707,13 +707,21 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
     }
   }
 
-  // int -> fp: lift integer to real
+  // int -> fp: lift integer to float under integer encoding.
+  // For plain integer (bv) sources, apply IEEE 754 RNE quantization so that
+  // values above the target significand boundary are correctly rounded.
+  // fixedbv sources (fixed-point) retain the previous exact-lift behaviour.
   if (
     int_encoding &&
     (is_bv_type(cast.from->type) || is_fixedbv_type(cast.from->type)) &&
     is_floatbv_type(cast.type))
   {
     smt_astt from_int = convert_ast(cast.from);
+    if (is_bv_type(cast.from->type))
+    {
+      const floatbv_type2t &fbv_type = to_floatbv_type(cast.type);
+      return round_int_to_fp(from_int, fbv_type, cast.from->type->get_width());
+    }
     return mk_int2real(from_int);
   }
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2313,6 +2313,75 @@ smt_astt smt_convt::round_real_to_int(smt_astt a)
   return mk_ite(is_lt_zero, selected, as_int);
 }
 
+smt_astt smt_convt::round_int_to_fp(
+  smt_astt int_val,
+  const floatbv_type2t &fbv_type,
+  unsigned int source_width)
+{
+  // IEEE 754 round-to-nearest-even for integer-to-float casts under
+  // --ir-ieee.  Integers with |i| < 2^S are exactly representable (S is the
+  // total significand width).  For larger values, we compute the RNE-rounded
+  // result exactly using SMT integer div/mod, building a cascaded ITE over
+  // binade ranges [2^(S-1+k), 2^(S+k)) for k = 1..max_k.
+  const unsigned int S = fbv_type.fraction + 1;
+
+  // All source values fit within the significand: exact lift suffices.
+  if (source_width <= S)
+    return mk_int2real(int_val);
+
+  // max_k: the highest binade index we need to cover.
+  // For a W-bit source the maximum |i| is 2^(W-1) (signed, from INT_MIN) or
+  // 2^W - 1 (unsigned), both of which sit in binade k = W - S.
+  const unsigned int max_k = source_width - S;
+
+  smt_astt zero_i = mk_smt_int(BigInt(0));
+  smt_astt is_neg = mk_lt(int_val, zero_i);
+  smt_astt abs_val = mk_ite(is_neg, mk_neg(int_val), int_val);
+
+  // Base: exact conversion for values below the precision threshold.
+  smt_astt result_abs = abs_val;
+
+  smt_astt two = mk_smt_int(BigInt(2));
+
+  // Build ITEs from k = 1 up to max_k.  Each step wraps the previous result:
+  //   result_abs = ite(abs_val >= lo_k, quantized_k, result_abs)
+  // When expanded, the outermost true condition dominates, so the highest
+  // matching k (the correct binade) determines the final value.
+  for (unsigned int k = 1; k <= max_k; k++)
+  {
+    BigInt lo     = power(BigInt(2), BigInt(S - 1 + k)); // lower bound of binade
+    BigInt ulp    = power(BigInt(2), BigInt(k));          // unit of least precision
+    BigInt half_u = power(BigInt(2), BigInt(k - 1));      // ulp / 2
+
+    smt_astt lo_expr   = mk_smt_int(lo);
+    smt_astt ulp_expr  = mk_smt_int(ulp);
+    smt_astt half_expr = mk_smt_int(half_u);
+
+    smt_astt remainder = mk_mod(abs_val, ulp_expr);
+    smt_astt floor_val = mk_sub(abs_val, remainder);         // round down
+    smt_astt ceil_val  = mk_add(floor_val, ulp_expr);        // round up
+
+    // Tie-breaking: when remainder == ulp/2, choose the even neighbour
+    // (the one whose index floor_val/ulp is even).
+    smt_astt quotient   = mk_div(floor_val, ulp_expr);
+    smt_astt floor_even = mk_eq(mk_mod(quotient, two), zero_i);
+    smt_astt tie_val    = mk_ite(floor_even, floor_val, ceil_val);
+
+    smt_astt quantized = mk_ite(
+      mk_eq(remainder, zero_i),
+      abs_val, // exactly on a representable value
+      mk_ite(
+        mk_lt(remainder, half_expr),
+        floor_val, // closer to floor
+        mk_ite(mk_gt(remainder, half_expr), ceil_val, tie_val)));
+
+    result_abs = mk_ite(mk_le(lo_expr, abs_val), quantized, result_abs);
+  }
+
+  smt_astt signed_result = mk_ite(is_neg, mk_neg(result_abs), result_abs);
+  return mk_int2real(signed_result);
+}
+
 smt_astt smt_convt::round_fixedbv_to_int(
   smt_astt a,
   unsigned int fromwidth,

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -73,6 +73,7 @@ smt_convt::smt_convt(const namespacet &_ns, const optionst &_options)
   : ctx_level(0), boolean_sort(nullptr), ns(_ns), options(_options)
 {
   int_encoding = options.get_bool_option("int-encoding");
+  ir_ieee = options.get_bool_option("ir-ieee");
   tuple_api = nullptr;
   array_api = nullptr;
   fp_api = nullptr;
@@ -2349,23 +2350,23 @@ smt_astt smt_convt::round_int_to_fp(
   // matching k (the correct binade) determines the final value.
   for (unsigned int k = 1; k <= max_k; k++)
   {
-    BigInt lo     = power(BigInt(2), BigInt(S - 1 + k)); // lower bound of binade
-    BigInt ulp    = power(BigInt(2), BigInt(k));          // unit of least precision
-    BigInt half_u = power(BigInt(2), BigInt(k - 1));      // ulp / 2
+    BigInt lo = power(BigInt(2), BigInt(S - 1 + k)); // lower bound of binade
+    BigInt ulp = power(BigInt(2), BigInt(k));        // unit of least precision
+    BigInt half_u = power(BigInt(2), BigInt(k - 1)); // ulp / 2
 
-    smt_astt lo_expr   = mk_smt_int(lo);
-    smt_astt ulp_expr  = mk_smt_int(ulp);
+    smt_astt lo_expr = mk_smt_int(lo);
+    smt_astt ulp_expr = mk_smt_int(ulp);
     smt_astt half_expr = mk_smt_int(half_u);
 
     smt_astt remainder = mk_mod(abs_val, ulp_expr);
-    smt_astt floor_val = mk_sub(abs_val, remainder);         // round down
-    smt_astt ceil_val  = mk_add(floor_val, ulp_expr);        // round up
+    smt_astt floor_val = mk_sub(abs_val, remainder); // round down
+    smt_astt ceil_val = mk_add(floor_val, ulp_expr); // round up
 
     // Tie-breaking: when remainder == ulp/2, choose the even neighbour
     // (the one whose index floor_val/ulp is even).
-    smt_astt quotient   = mk_div(floor_val, ulp_expr);
+    smt_astt quotient = mk_div(floor_val, ulp_expr);
     smt_astt floor_even = mk_eq(mk_mod(quotient, two), zero_i);
-    smt_astt tie_val    = mk_ite(floor_even, floor_val, ceil_val);
+    smt_astt tie_val = mk_ite(floor_even, floor_val, ceil_val);
 
     smt_astt quantized = mk_ite(
       mk_eq(remainder, zero_i),

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -794,6 +794,13 @@ public:
   /** Round a fixedbv to an integer. */
   smt_astt
   round_fixedbv_to_int(smt_astt a, unsigned int width, unsigned int towidth);
+  /** Round an SMT integer to the nearest representable float/double using
+   *  IEEE 754 round-to-nearest-even. Used for int->fp casts under --ir-ieee.
+   *  source_width is the bit-width of the source integer type. */
+  smt_astt round_int_to_fp(
+    smt_astt int_val,
+    const floatbv_type2t &fbv_type,
+    unsigned int source_width);
 
   /** Prep call for creating a tuple array */
   smt_astt tuple_array_create_despatch(const expr2tc &expr, smt_sortt domain);

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -906,6 +906,8 @@ public:
   smt_sortt boolean_sort;
   /** Whether we are encoding expressions in integer mode or not. */
   bool int_encoding;
+  /** Whether --ir-ieee mode is active (integer encoding with IEEE float semantics). */
+  bool ir_ieee;
   /** A namespace containing all the types in the program. Used to resolve the
    *  rare case where we're doing some pointer arithmetic and need to have the
    *  concrete type of a pointer. */


### PR DESCRIPTION
This PR fixes spurious counterexamples in symbolic integer-to-floating-point casts under `--ir-ieee`.

Under `--ir-ieee`, ESBMC models floats as SMT reals under integer-real encoding. The `int -> fp` cast path previously lifted integer values directly with `mk_int2real()`, preserving them as exact SMT reals with no precision rounding. This caused ESBMC to believe that non-representable values such as `2^24 + 1` could survive an `int -> float -> int` round trip, producing spurious counterexamples for properties that are always true under IEEE round-to-nearest-even semantics.

The patch adds IEEE 754 round-to-nearest-even quantization for plain integer bit-vector sources casting to `float` or `double` within the `--ir-ieee` path. For each binade above the target significand boundary, the cast computes the RNE-rounded result exactly using SMT integer division and modulo, then lifts the rounded integer to a real. Fixed-point (`fixedbv`) sources retain the previous exact-lift behaviour.

Regression tests cover:
- `int -> float -> int` around the float precision boundary (`2^24`);
- `long long -> double -> long long` around the double precision boundary (`2^53`);
- both tie directions: ties that round to the smaller representable value and ties that round to the larger representable value.

Note: this patch models the default round-to-nearest-even behaviour for this cast path within `--ir-ieee`. Other IEEE 754 rounding modes are not handled here.