### PR TITLE
[python] fix json crash on aliased/expr list element type inference

### DIFF
--- a/regression/python/github_4909/main.py
+++ b/regression/python/github_4909/main.py
@@ -1,0 +1,15 @@
+# A list initialised with an element from a *derived* binding (alias or
+# expression) and then mutated by indexed assignment inside a for loop
+# crashed the GOTO converter with a json operator[] assertion: get_typet
+# assumed the aliased RHS was a Constant carrying a nested "value" (#4909).
+Y = 1
+X = Y
+a = [X]
+for i in range(1):
+    a[i] = -1
+assert a[0] == -1
+
+# Expression (BinOp) RHS variant from the same report.
+b0 = 1 + 0
+b = [b0]
+assert b[0] == 1

--- a/regression/python/github_4909/test.desc
+++ b/regression/python/github_4909/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4909_fail/main.py
+++ b/regression/python/github_4909_fail/main.py
@@ -1,0 +1,8 @@
+# Companion to github_4909: the mutated value is resolved correctly, so a
+# wrong expected value must be caught.
+Y = 1
+X = Y
+a = [X]
+for i in range(1):
+    a[i] = -1
+assert a[0] == 999

--- a/regression/python/github_4909_fail/test.desc
+++ b/regression/python/github_4909_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -740,6 +740,19 @@ typet type_handler::get_typet(const nlohmann::json &elem) const
       return get_typet(elem["operand"]);
     }
 
+    // Handle Python AST BinOp node (e.g., 1 + 0): the result type follows the
+    // operands, promoting to float when either side is float (#4909).
+    if (
+      elem["_type"] == "BinOp" && elem.contains("left") &&
+      elem.contains("right"))
+    {
+      typet lhs_type = get_typet(elem["left"]);
+      typet rhs_type = get_typet(elem["right"]);
+      if (lhs_type.is_floatbv() || rhs_type.is_floatbv())
+        return double_type();
+      return lhs_type;
+    }
+
     // Handle Python AST List node
     if (elem["_type"] == "List" && elem.contains("elts"))
     {
@@ -796,20 +809,37 @@ typet type_handler::get_typet(const nlohmann::json &elem) const
 
   if (elem["_type"] == "Name")
   {
-    const nlohmann::json &var = json_utils::find_var_decl(
-      elem["id"], converter_.current_function_name(), converter_.ast());
-
-    if (!var.empty() && var.contains("value") && !var["value"].is_null())
+    // Resolve the type from the variable's RHS. The RHS is not always a
+    // Constant (which carries a nested "value"): it can be an alias (Name),
+    // an expression (BinOp), etc. Reading var["value"]["value"] asserted in
+    // nlohmann::json for those shapes (#4909). Walk alias chains
+    // (x = y = ... = literal) iteratively, guarding against cyclic aliases
+    // (a = b; b = a) so resolution cannot recurse without bound.
+    nlohmann::json node = elem;
+    std::set<std::string> seen;
+    while (node.is_object() && node.contains("_type") &&
+           node["_type"] == "Name")
     {
-      if (var["value"]["_type"] != "Call")
-        return get_typet(var["value"]["value"]);
+      const std::string id = node["id"].get<std::string>();
+      if (!seen.insert(id).second)
+        return empty_typet(); // cyclic alias
 
-      if (var["value"].contains("func"))
-        return get_typet_from_call_func(var["value"]["func"]);
+      const nlohmann::json &var = json_utils::find_var_decl(
+        id, converter_.current_function_name(), converter_.ast());
 
-      throw std::runtime_error("Invalid type");
+      if (var.empty() || !var.contains("value") || var["value"].is_null())
+        return empty_typet();
+
+      if (var["value"]["_type"] == "Call")
+      {
+        if (var["value"].contains("func"))
+          return get_typet_from_call_func(var["value"]["func"]);
+        throw std::runtime_error("Invalid type");
+      }
+
+      node = var["value"];
     }
-    return empty_typet();
+    return get_typet(node);
   }
 
   if (elem["_type"] == "Call")


### PR DESCRIPTION
Fixes #4909.

## Problem

ESBMC aborted during GOTO conversion with a `nlohmann::json::operator[]` assertion (`json.hpp:2147`) when a list was initialised with an element drawn from a *derived* binding (an alias or an expression) and then mutated by indexed assignment inside a `for` loop:

```python
Y = 1
X = Y
a = [X]
for i in range(1):
    a[i] = -1
```

## Root cause

`type_handler::get_typet`'s `Name` branch resolved the type via `get_typet(var["value"]["value"])`, assuming the variable's RHS was a `Constant` (which carries a nested `"value"`). For an alias (`X = Y`, RHS is a `Name`) or an expression (`X = 1 + 0`, RHS is a `BinOp`), `var["value"]` has no `"value"` key, so `operator[]` asserted. A bare literal (`X = 1`) has a `Constant` RHS, which is why only the derived-binding variants crashed.

## Fix

- Resolve the type from the RHS node itself (`get_typet(var["value"])`) instead of `var["value"]["value"]`.
- Walk alias chains (`x = y = … = literal`) iteratively, with a visited-set guard so cyclic aliases (`a = b; b = a`) cannot recurse without bound (they now report a clean "Variable not defined" error instead of overflowing).
- Add a `BinOp` case to `get_typet` (previously unhandled), returning the operand type and promoting to `float` when either side is float.

## Validation

- Both issue reproducers (alias and expression) now reach `VERIFICATION SUCCESSFUL`; the bare-literal variant still works; alias chains `X = Y = Z` resolve; cyclic aliases no longer hang.
- Verified under both Bitwuzla and Z3.
- Adds `regression/python/github_4909` (SUCCESSFUL) and `regression/python/github_4909_fail` (FAILED).
- Ran the `get_typet`-affected regression subset (~500 list/type-inference/range/for tests): no regressions (the only non-pass is `list_pop11_nondet`, which requires the Boolector solver not built in this environment — fails identically on master).
