### PR TITLE
[python] restore problem1_fail real body, mark FUTURE (scalability)

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -327,6 +327,11 @@ set(_slow_regression_tests
     "regression/quixbugs/next_palindrome"
     "regression/quixbugs/pascal"
     "regression/ai-generated-code/two_sum"
+    # problem1_fail runs the real DP body (nested loops + dp[-1] + max over a
+    # defaultdict-free list). It does not converge under --unwind 9, so it is
+    # marked FUTURE (BMC scalability); the larger inner timeout lets
+    # testing_tool record the FUTURE verdict instead of ctest hard-killing it.
+    "regression/python-intensive/problem1_fail"
 )
 math(EXPR ESBMC_REGRESS_CTEST_TIMEOUT_SLOW
      "${ESBMC_REGRESS_TIMEOUT_SLOW} + 30")

--- a/regression/python-intensive/problem1_fail/main.py
+++ b/regression/python-intensive/problem1_fail/main.py
@@ -1,11 +1,14 @@
 def lengthOfLongestSubsequence(nums: list[int], target: int) -> int:
-    # dp=[-1]*(target+1)
-    # dp[0]=0
-    # for a in nums:
-    #     for i in range(target-a,-1,-1):
-    #         if dp[i]==-1:continue
-    #         dp[i+a]=max(dp[i+a],dp[i]+1)
-    # return dp[-1]
-    return 3
+    dp = [-1] * (target + 1)
+    dp[0] = 0
+    for a in nums:
+        for i in range(target - a, -1, -1):
+            if dp[i] == -1:
+                continue
+            dp[i + a] = max(dp[i + a], dp[i] + 1)
+    return dp[-1]
 
+
+# Real answer: the longest subsequence of [1, 2, 3] summing to target 2 is
+# [2] (length 1), so this asserts the wrong value and must verify FAILED.
 assert lengthOfLongestSubsequence([1, 2, 3], 2) == 3

--- a/regression/python-intensive/problem1_fail/test.desc
+++ b/regression/python-intensive/problem1_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.py
 --force-malloc-success --unwind 9
 ^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes #4777.

`regression/python-intensive/problem1_fail` had its DP body stubbed to `return 3` and asserted `== 3`, so ESBMC reported `VERIFICATION SUCCESSFUL`, contradicting its `_fail` / KNOWNBUG desc (`^VERIFICATION FAILED$`).

Per the resolution chosen in #4777, this restores the **real algorithm**. For the test input, the longest subsequence of `[1, 2, 3]` summing to `target=2` is `[2]` (length 1), so the unchanged `assert ... == 3` is genuinely violated and the intended verdict is `VERIFICATION FAILED`.

ESBMC cannot discharge the nested-loop DP (with `dp[-1]` and `max`) within `--unwind 9` — it does not converge — so the test is marked **FUTURE** (BMC scalability) and added to the slow-test budget list, so `testing_tool.py` records the FUTURE verdict on the inner timeout instead of ctest hard-killing the run (same mechanism used for `shortest_path_lengths`/#4765).

Validation:
- CPython: `python3 main.py` exits non-zero (assertion fires) — correct for a `_fail` case.
- `ESBMC_REGRESS_TIMEOUT=40 testing_tool.py --modes FUTURE --file=problem1_fail` → "TIMEOUT after limit 40s -- accepted under FUTURE", exit 0.