### PR TITLE
[python] support subscript/attribute targets in tuple unpacking

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -342,6 +342,14 @@ set(_slow_regression_tests
     # marked FUTURE (BMC scalability); the larger inner timeout lets
     # testing_tool record the FUTURE verdict instead of ctest hard-killing it.
     "regression/python-intensive/problem1_fail"
+    # next_permutation(_fail) used to fast-crash with "Tuple unpacking only
+    # supports simple names, not Subscript". With subscript-target unpacking
+    # support (#4792) the swap converts and ESBMC reaches the real nested-loop
+    # symex (plus reversed()/slice-assign), which does not converge. These stay
+    # KNOWNBUG; the larger inner timeout lets testing_tool record the KNOWNBUG
+    # verdict instead of ctest hard-killing the run.
+    "regression/quixbugs/next_permutation"
+    "regression/quixbugs/next_permutation_fail"
 )
 math(EXPR ESBMC_REGRESS_CTEST_TIMEOUT_SLOW
      "${ESBMC_REGRESS_TIMEOUT_SLOW} + 30")

--- a/regression/python/github_4792/main.py
+++ b/regression/python/github_4792/main.py
@@ -1,0 +1,28 @@
+# Tuple unpacking with subscript/attribute targets (the swap idiom) used to
+# crash the frontend: "Tuple unpacking only supports simple names, not
+# Subscript". The store now routes through the normal single-assignment path
+# and the literal const-fold is invalidated for tuple-target subscript
+# mutations, so reads see the swap (#4792).
+a = [1, 2]
+a[0], a[1] = a[1], a[0]
+assert a[0] == 2 and a[1] == 1
+
+b = [10, 20, 30]
+i = 0
+k = 2
+b[i], b[k] = b[k], b[i]
+assert b[0] == 30 and b[2] == 10
+
+
+def swap(p, x, y):
+    p[x], p[y] = p[y], p[x]
+    return p
+
+
+r = swap([1, 2, 3], 0, 2)
+assert r[0] == 3 and r[1] == 2 and r[2] == 1
+
+# Three-way rotation through subscript targets.
+c = [1, 2, 3]
+c[0], c[1], c[2] = c[2], c[0], c[1]
+assert c[0] == 3 and c[1] == 1 and c[2] == 2

--- a/regression/python/github_4792/test.desc
+++ b/regression/python/github_4792/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4792_fail/main.py
+++ b/regression/python/github_4792_fail/main.py
@@ -1,0 +1,5 @@
+# Companion to github_4792: the swap is resolved correctly, so a wrong
+# expected value must be caught.
+a = [1, 2]
+a[0], a[1] = a[1], a[0]
+assert a[0] == 1

--- a/regression/python/github_4792_fail/test.desc
+++ b/regression/python/github_4792_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -814,6 +814,37 @@ bool python_converter::handle_unpacking_assignment(
   if (target_type != "Tuple" && target_type != "List")
     return false;
 
+  // Targets that write through an lvalue (a[i], obj.attr) need the normal
+  // single-assignment store semantics (e.g. invalidating literal const-folding
+  // so later reads see the write). When such a target is present and the RHS
+  // is a tuple/list literal of matching arity, desugar into temp-mediated
+  // single assignments so the swap a[i], a[j] = a[j], a[i] is sound (#4792).
+  {
+    const auto &targets = target["elts"];
+    const auto &value = ast_node["value"];
+    bool has_lvalue_target = false;
+    bool only_name_or_lvalue = true;
+    for (const auto &t : targets)
+    {
+      const auto &tt = t["_type"];
+      if (tt == "Subscript" || tt == "Attribute")
+        has_lvalue_target = true;
+      else if (tt != "Name")
+        only_name_or_lvalue = false; // Starred etc. — leave to existing paths
+    }
+    const bool rhs_is_literal_seq =
+      value.is_object() && value.contains("_type") &&
+      (value["_type"] == "Tuple" || value["_type"] == "List") &&
+      value.contains("elts") && value["elts"].is_array();
+    if (
+      has_lvalue_target && only_name_or_lvalue && rhs_is_literal_seq &&
+      value["elts"].size() == targets.size())
+    {
+      desugar_unpacking_with_lvalue_targets(ast_node, target, target_block);
+      return true;
+    }
+  }
+
   // Get RHS
   is_converting_rhs = true;
   exprt rhs = get_expr(ast_node["value"]);
@@ -864,6 +895,66 @@ bool python_converter::handle_unpacking_assignment(
   throw std::runtime_error(
     "Cannot unpack " + rhs.type().id_string() +
     " - only tuples and arrays can be unpacked");
+}
+
+void python_converter::desugar_unpacking_with_lvalue_targets(
+  const nlohmann::json &ast_node,
+  const nlohmann::json &target,
+  codet &target_block)
+{
+  const auto &targets = target["elts"];
+  const auto &values = ast_node["value"]["elts"];
+  const size_t n = targets.size();
+
+  // Per-statement-stable temp prefix; reusing the same names across repeated
+  // evaluations of the statement (loops, repeated calls) is fine — they are
+  // simply reassigned, like other frontend temporaries.
+  const std::string prefix =
+    "__ESBMC_unpack_" + std::to_string(reinterpret_cast<uintptr_t>(&ast_node)) +
+    "_";
+
+  // Build a Name AST node, cloning location fields from a nearby node.
+  auto make_name =
+    [&](const std::string &id, const nlohmann::json &loc_src, const char *ctx) {
+      nlohmann::json node;
+      node["_type"] = "Name";
+      node["id"] = id;
+      node["ctx"] = {{"_type", ctx}};
+      copy_location_fields_from_decl(loc_src, node);
+      return node;
+    };
+
+  // Build an `Assign` AST node for `tgt = val`.
+  auto make_assign = [&](const nlohmann::json &tgt, const nlohmann::json &val) {
+    nlohmann::json node;
+    node["_type"] = "Assign";
+    node["targets"] = nlohmann::json::array({tgt});
+    node["value"] = val;
+    copy_location_fields_from_decl(ast_node, node);
+    return node;
+  };
+
+  // Phase 1: evaluate every RHS element into its own temporary. Python
+  // evaluates the entire RHS before any assignment, so this snapshots the
+  // values before the (possibly aliasing) stores below.
+  std::vector<nlohmann::json> temps;
+  temps.reserve(n);
+  for (size_t i = 0; i < n; i++)
+  {
+    nlohmann::json tmp_tgt =
+      make_name(prefix + std::to_string(i), values[i], "Store");
+    nlohmann::json assign = make_assign(tmp_tgt, values[i]);
+    get_var_assign(assign, target_block);
+    temps.push_back(make_name(prefix + std::to_string(i), targets[i], "Load"));
+  }
+
+  // Phase 2: store each target from its snapshot temp via the normal
+  // single-assignment path.
+  for (size_t i = 0; i < n; i++)
+  {
+    nlohmann::json assign = make_assign(targets[i], temps[i]);
+    get_var_assign(assign, target_block);
+  }
 }
 
 symbolt *python_converter::create_symbol_for_unannotated_assign(

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -52,10 +52,23 @@ class CoreVisitorsMixin:
     }
 
     def _invalidate_list_literals_for_assign_targets(self, targets):
-        for target in targets:
-            if (isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name)
-                    and target.value.id in self.list_literal_values):
+
+        def invalidate(target):
+            # Recurse into tuple/list unpacking targets so a subscript store
+            # nested in a swap (a[i], a[j] = a[j], a[i]) still invalidates the
+            # literal const-fold for its container; otherwise later reads fold
+            # to the stale original element (#4792).
+            if isinstance(target, (ast.Tuple, ast.List)):
+                for elt in target.elts:
+                    invalidate(elt)
+            elif isinstance(target, ast.Starred):
+                invalidate(target.value)
+            elif (isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name)
+                  and target.value.id in self.list_literal_values):
                 self.list_literal_values.pop(target.value.id, None)
+
+        for target in targets:
+            invalidate(target)
 
     def _maybe_record_type_alias_assign(self, node):
         if (len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -666,6 +666,19 @@ private:
     const nlohmann::json &target,
     codet &target_block);
 
+  /**
+   * Desugar a tuple/list unpacking whose targets include lvalues (a[i],
+   * obj.attr) into temp-mediated single assignments routed through the normal
+   * single-assignment path. Evaluates every RHS element into a temporary
+   * first (Python evaluates the whole RHS before assigning), then stores each
+   * target, so the swap a[i], a[j] = a[j], a[i] is handled soundly (#4792).
+   * Requires the RHS to be a Tuple/List literal of matching arity.
+   */
+  void desugar_unpacking_with_lvalue_targets(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &target,
+    codet &target_block);
+
   // =========================================================================
   // Symbol creation helper methods
   // =========================================================================


### PR DESCRIPTION
Addresses the tuple-unpacking crash behind #4792 / #4793.

## Problem

The swap idiom — and any tuple/list assignment whose targets include a subscript or attribute — crashed the Python frontend during conversion:

```python
a[i], a[j] = a[j], a[i]
# ERROR: Tuple unpacking only supports simple names, not Subscript
```

## Root cause (two layers)

1. **Store:** `tuple_handler::handle_tuple_unpacking` only accepted `Name` targets and threw on `Subscript`/`Attribute`.
2. **Read:** even once the store was emitted, a *literal* list's `a[const]` reads stayed folded to the original element. The preprocessor invalidates that const-fold (`list_literal_values`) only for a *direct* `Subscript` assignment target — it did not recurse into `Tuple`/`List` targets, so a subscript store nested in a swap left later reads stale (a silent wrong-verdict).

## Fix

- **converter** (`converter_stmt.cpp`, `python_converter.h`): when a tuple/list assignment target contains an lvalue element and the RHS is a tuple/list literal of matching arity, desugar into temp-mediated single assignments routed through the normal single-assignment path. Phase 1 snapshots every RHS element into a temp (Python evaluates the whole RHS before assigning — correct swap aliasing); phase 2 stores each target. Starred targets and non-literal RHS fall through to the existing paths unchanged.
- **preprocessor** (`core_visitors_mixin.py`): `_invalidate_list_literals_for_assign_targets` now recurses into `Tuple`/`List`/`Starred` targets, so a nested subscript store invalidates the literal const-fold for its container.

## Validation

- Literal **and** parameter-list swaps, variable-index swaps, 3-way rotation, and mixed name+subscript targets all verify correctly — correct expectation → SUCCESSFUL, wrong expectation → FAILED — under both **Bitwuzla and Z3**.
- New regression tests `regression/python/github_4792` (SUCCESSFUL) and `github_4792_fail` (FAILED); CPython sanity passes.
- Ran the tuple/unpack/list/assign regression subset: no regressions (only `list_pop11_nondet` fails, which needs the Boolector solver not built in this environment — identical on master).

## Scope note

This removes the *unpacking* crash that blocks the QuixBugs `next_permutation`/`next_permutation_fail` tests; those remain KNOWNBUG for **separate** unsupported features (`reversed()` and slice-assignment `p[i+1:] = …`), so the tests are not promoted here.
