### PR TITLE
[goto] make __ESBMC_unroll matching robust and warn when misplaced

### DIFF
--- a/regression/esbmc-cpp/cpp/intrinsic_unroll_while_decl_true/main.cpp
+++ b/regression/esbmc-cpp/cpp/intrinsic_unroll_while_decl_true/main.cpp
@@ -1,0 +1,23 @@
+/* Test that __ESBMC_unroll(N) binds to a while loop that declares a variable
+ * in its condition (`while (int v = e)`). The loop preamble holds the DECL
+ * (and the side-effecting computation) of the condition, all of which must be
+ * skipped when binding the intrinsic to the loop. This used to silently fail
+ * to match, leaving the loop unbounded.
+ *
+ * Note: the C++ frontend currently hoists the condition's computation out of
+ * such loops, so unwinding assertions are disabled here; the point of the
+ * test is that the intrinsic is applied to the right loop (see the expected
+ * "#pragma unroll" line).
+ */
+
+int main()
+{
+  int sum = 0;
+  int n = 5;
+
+  __ESBMC_unroll(5);
+  while(int v = n--)
+    sum += v;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/intrinsic_unroll_while_decl_true/test.desc
+++ b/regression/esbmc-cpp/cpp/intrinsic_unroll_while_decl_true/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--no-unwinding-assertions --verbosity 9
+Applying #pragma unroll 6 to loop
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/intrinsic_unroll_for_multivar_fail/main.c
+++ b/regression/esbmc/intrinsic_unroll_for_multivar_fail/main.c
@@ -1,0 +1,15 @@
+/* Test __ESBMC_unroll(N) with N smaller than the iteration count of a
+ * multi-variable for loop. The loop runs 5 times but the intrinsic only
+ * unrolls 2 times, so an unwinding assertion must fail.
+ */
+
+int main()
+{
+  int sum = 0;
+
+  __ESBMC_unroll(2);
+  for(int i = 0, j = 10; i < j; i++, j--)
+    sum += i;
+
+  return 0;
+}

--- a/regression/esbmc/intrinsic_unroll_for_multivar_fail/test.desc
+++ b/regression/esbmc/intrinsic_unroll_for_multivar_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--verbosity 9
+Applying #pragma unroll 3 to loop
+^VERIFICATION FAILED$

--- a/regression/esbmc/intrinsic_unroll_for_multivar_true/main.c
+++ b/regression/esbmc/intrinsic_unroll_for_multivar_true/main.c
@@ -1,0 +1,17 @@
+/* Test __ESBMC_unroll(N) with a for loop that declares and updates
+ * several induction variables. The preamble between the intrinsic and the
+ * loop head holds multiple DECL/ASSIGN instructions, all of which must be
+ * skipped when binding the intrinsic to the loop.
+ * The loop runs 5 times, so unroll(10) fully covers it.
+ */
+
+int main()
+{
+  int sum = 0;
+
+  __ESBMC_unroll(10);
+  for(int i = 0, j = 10; i < j; i++, j--)
+    sum += i;
+
+  return 0;
+}

--- a/regression/esbmc/intrinsic_unroll_for_multivar_true/test.desc
+++ b/regression/esbmc/intrinsic_unroll_for_multivar_true/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--verbosity 9
+Applying #pragma unroll 11 to loop
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/intrinsic_unroll_misplaced_call_warning/main.c
+++ b/regression/esbmc/intrinsic_unroll_misplaced_call_warning/main.c
@@ -1,0 +1,19 @@
+/* Test that __ESBMC_unroll(N) is reported as misplaced when an unrelated
+ * statement (here a function call) sits between the intrinsic and the loop:
+ * the intrinsic must directly precede the loop. The loop is still bounded
+ * by --unwind so verification succeeds, but the intrinsic is not applied.
+ */
+
+void g();
+
+int main()
+{
+  int sum = 0;
+
+  __ESBMC_unroll(2);
+  g();
+  for(int i = 0, j = 10; i < j; i++, j--)
+    sum += i;
+
+  return 0;
+}

--- a/regression/esbmc/intrinsic_unroll_misplaced_call_warning/test.desc
+++ b/regression/esbmc/intrinsic_unroll_misplaced_call_warning/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 6 --verbosity 9
+__ESBMC_unroll at .* is not directly followed by a loop
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/intrinsic_unroll_misplaced_warning/main.c
+++ b/regression/esbmc/intrinsic_unroll_misplaced_warning/main.c
@@ -1,0 +1,15 @@
+/* Test that a misplaced __ESBMC_unroll(N) that is not directly followed by
+ * a loop produces a warning instead of being silently ignored.
+ */
+
+int nondet_int();
+
+int main()
+{
+  __ESBMC_unroll(5);
+  int x = nondet_int();
+  if(x > 0)
+    x = 1;
+
+  return x;
+}

--- a/regression/esbmc/intrinsic_unroll_misplaced_warning/test.desc
+++ b/regression/esbmc/intrinsic_unroll_misplaced_warning/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--verbosity 9
+__ESBMC_unroll at .* is not directly followed by a loop
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/intrinsic_unroll_nested_true/main.c
+++ b/regression/esbmc/intrinsic_unroll_nested_true/main.c
@@ -1,0 +1,19 @@
+/* Test that __ESBMC_unroll(N) binds to the inner of two nested loops and
+ * never to the enclosing loop. The intrinsic sits inside the outer loop,
+ * immediately before the inner loop. Only the inner loop must be annotated.
+ * The outer loop is bounded so the program still verifies.
+ */
+
+int main()
+{
+  int sum = 0;
+
+  for(int k = 0; k < 3; k++)
+  {
+    __ESBMC_unroll(10);
+    for(int i = 0, j = 10; i < j; i++, j--)
+      sum += i;
+  }
+
+  return 0;
+}

--- a/regression/esbmc/intrinsic_unroll_nested_true/test.desc
+++ b/regression/esbmc/intrinsic_unroll_nested_true/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 4 --verbosity 9
+Applying #pragma unroll 11 to loop
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/loop_unroll.cpp
+++ b/src/goto-programs/loop_unroll.cpp
@@ -1,4 +1,5 @@
 #include <goto-programs/loop_unroll.h>
+#include <util/prefix.h>
 
 bool unsound_loop_unroller::runOnLoop(loopst &loop, goto_programt &goto_program)
 {
@@ -167,66 +168,157 @@ int bounded_loop_unroller::get_loop_bounds(loopst &loop)
   return bound;
 }
 
+// Recognises a call to the __ESBMC_unroll intrinsic. The symbol name is
+// matched by prefix so that mangled C++ names (e.g. with a signature suffix)
+// are handled the same way symex does.
+static bool is_unroll_intrinsic(const goto_programt::instructiont &instruction)
+{
+  if (!instruction.is_function_call())
+    return false;
+
+  const expr2tc &function = to_code_function_call2t(instruction.code).function;
+  return is_symbol2t(function) &&
+         has_prefix(
+           to_symbol2t(function).get_symbol_name(), "c:@F@__ESBMC_unroll");
+}
+
+// Instructions that may legitimately sit between an __ESBMC_unroll call and
+// the head of the loop it annotates, i.e. the loop preamble. This covers
+// declarations and initialisers of for-loops with several induction
+// variables as well as condition side-effects of while-loops with a
+// declaration in their condition (e.g. `while (int v = f())`).
+//
+// A loop's own setup normally shares the source line of the loop head (the
+// line of the `for`/`while` keyword), so we use line equality as a heuristic
+// to tell setup apart from an unrelated statement (such as a bare `f();` or
+// assignment) placed between the intrinsic and the loop, which is instead
+// reported as misplaced. This is line-granular: it cannot distinguish setup
+// from a stray statement collapsed onto the same line, and a loop header split
+// across lines is conservatively treated as misplaced. A scope-based signal
+// (instructiont::scope_id) would be more robust but is only populated on the
+// goto2c path, not in this preprocessing pass. Instructions without a source
+// location are compiler-generated no-ops and are always skippable.
+static bool is_loop_preamble(
+  const goto_programt::instructiont &instruction,
+  const goto_programt::instructiont &head)
+{
+  switch (instruction.type)
+  {
+  case DECL:
+  case ASSIGN:
+  case FUNCTION_CALL:
+  case SKIP:
+  case LOCATION:
+  case OTHER:
+    break;
+  default:
+    return false;
+  }
+
+  const irep_idt &line = instruction.location.get_line();
+  if (line.empty())
+    return true;
+
+  return line == head.location.get_line() &&
+         instruction.location.get_file() == head.location.get_file();
+}
+
+bool apply_intrinsic_unroller::apply_unroll(
+  goto_programt::targett call,
+  loopst &loop)
+{
+  const code_function_call2t &func_call = to_code_function_call2t(call->code);
+
+  if (func_call.operands.size() != 1)
+  {
+    log_error("Invoking __ESBMC_unroll with wrong signature");
+    call->dump();
+    abort();
+  }
+
+  expr2tc n_unwind = func_call.operands[0];
+  simplify(n_unwind);
+
+  if (!is_constant_int2t(n_unwind))
+  {
+    log_error("Invoking __ESBMC_unroll with invalid (non-constant) argument");
+    call->dump();
+    n_unwind->dump();
+    abort();
+  }
+
+  const long unwinds = to_constant_int2t(n_unwind).as_long();
+  if (unwinds < 0)
+  {
+    log_error("Invoking __ESBMC_unroll with a negative argument");
+    call->dump();
+    abort();
+  }
+
+  goto_programt::targett loop_exit = loop.get_original_loop_exit();
+  loop_exit->pragma_unroll_count =
+    unwinds + 1; // add extra one to match pragma unroll behavior
+  matched_calls.insert(&*call);
+  return true;
+}
+
 bool apply_intrinsic_unroller::runOnLoop(
   loopst &loop,
   goto_programt &goto_program)
 {
-  auto instrument_function = [&loop](goto_programt::targett &it) -> bool {
-    if (!(is_symbol2t(to_code_function_call2t(it->code).function) &&
-          to_symbol2t(to_code_function_call2t(it->code).function)
-              .get_symbol_name() == "c:@F@__ESBMC_unroll"))
-      return false;
+  // Walk backwards from the loop head across the loop preamble. The intrinsic
+  // must directly precede the loop (modulo declarations/initialisers), so we
+  // stop as soon as we reach an instruction that is not part of the preamble.
+  // This binds the call to the nearest following loop head, which also avoids
+  // accidentally annotating an enclosing loop for nested constructs such as:
+  //
+  //   while (1) {
+  //     __ESBMC_unroll(10);
+  //     for (int i = 0, j = 10; i < j; i++, j--) ;
+  //   }
+  goto_programt::targett head = loop.get_original_loop_head();
+  for (goto_programt::targett it = head;
+       it != goto_program.instructions.begin();)
+  {
+    --it;
 
-    if (to_code_function_call2t(it->code).operands.size() != 1)
-    {
-      log_error("Invoking __ESBMC_unroll with wrong signature");
-      it->dump();
-      abort();
-    }
-    expr2tc n_unwind = to_code_function_call2t(it->code).operands[0];
-    simplify(n_unwind);
+    if (is_unroll_intrinsic(*it))
+      return apply_unroll(it, loop);
 
-    if (!is_constant_int2t(n_unwind))
-    {
-      log_error("Invoking __ESBMC_unroll with invalid argument");
-      it->dump();
-      n_unwind->dump();
-      abort();
-    }
-    const long unwinds = to_constant_int2t(n_unwind).as_long();
-
-    goto_programt::targett loop_exit = loop.get_original_loop_exit();
-    loop_exit->pragma_unroll_count =
-      unwinds + 1; // add extra one to match pragma unroll behavior
-    return true;
-  };
-  goto_programt::targett program_counter = loop.get_original_loop_head();
-
-  // Two cases that we are trying to solve at the same time. Wheter we
-  // are dealing with an initialization (e.g. for(int i = 0;;)) or a
-  // while loop.
-
-  if (program_counter-- == goto_program.instructions.begin())
-    return false; // loop is in the begginning of the function
-
-  if (program_counter->is_function_call())
-    return instrument_function(program_counter);
-
-  if (
-    !program_counter->is_assign() ||
-    program_counter-- == goto_program.instructions.begin())
-    return false;
-
-  if (program_counter->is_function_call())
-    return instrument_function(program_counter);
-
-  if (
-    !program_counter->is_decl() ||
-    program_counter-- == goto_program.instructions.begin())
-    return false;
-
-  if (program_counter->is_function_call())
-    return instrument_function(program_counter);
+    if (!is_loop_preamble(*it, *head))
+      break;
+  }
 
   return false;
+}
+
+// We override run() rather than a runOnFunction/runOnProgram hook because the
+// misplacement warning can only be emitted once every loop has been visited
+// (a misplaced call may live in a loop-free function that runOnLoop never
+// reaches), and the framework offers no "after all loops" hook.
+bool apply_intrinsic_unroller::run(goto_functionst &goto_functions)
+{
+  matched_calls.clear();
+
+  // The base implementation visits every loop and calls runOnLoop, which
+  // binds each __ESBMC_unroll call to its loop.
+  goto_functions_algorithm::run(goto_functions);
+
+  // Any __ESBMC_unroll call that was not bound to a loop is misplaced: warn
+  // the user instead of silently ignoring it.
+  forall_goto_functions (fit, goto_functions)
+  {
+    if (!fit->second.body_available)
+      continue;
+
+    forall_goto_program_instructions (iit, fit->second.body)
+      if (is_unroll_intrinsic(*iit) && !matched_calls.count(&*iit))
+        log_warning(
+          "__ESBMC_unroll at {} is not directly followed by a loop; the "
+          "annotation will be ignored. Place it immediately before the loop "
+          "it should apply to.",
+          iit->location.as_string());
+  }
+
+  return true;
 }

--- a/src/goto-programs/loop_unroll.h
+++ b/src/goto-programs/loop_unroll.h
@@ -3,6 +3,7 @@
 
 #include <util/algorithms.h>
 #include <util/message.h>
+#include <unordered_set>
 
 /**
  * @brief This is the base class that unroll
@@ -99,8 +100,13 @@ private:
  * DECL i
  * i = 0
  * 1: ...
- * 
+ *
  * We want to automatically set the next loop unwinding to 4.
+ *
+ * The intrinsic is bound to the loop whose head immediately follows it,
+ * skipping over the loop preamble (variable declarations, initialisers and
+ * condition side-effects such as `while (int v = f())`). Any __ESBMC_unroll
+ * call that is not directly followed by a loop is reported as misplaced.
  */
 class apply_intrinsic_unroller : public goto_functions_algorithm
 {
@@ -109,8 +115,19 @@ public:
   {
   }
 
+  bool run(goto_functionst &goto_functions) override;
+
 protected:
   bool runOnLoop(loopst &loop, goto_programt &goto_program) override;
+
+private:
+  /// Bind the __ESBMC_unroll call at `call` to `loop` and record it as
+  /// matched. Returns true on success.
+  bool apply_unroll(goto_programt::targett call, loopst &loop);
+
+  /// __ESBMC_unroll calls that were successfully bound to a loop. Used after
+  /// the loop walk to warn about the ones that were left unmatched.
+  std::unordered_set<const goto_programt::instructiont *> matched_calls;
 };
 
 #endif

--- a/unit/goto-programs/loop_unroll.test.cpp
+++ b/unit/goto-programs/loop_unroll.test.cpp
@@ -266,4 +266,93 @@ SCENARIO("the intrinsic unroller detects __ESBMC_unroll calls", "[algorithms]")
     REQUIRE(count_pragma_unroll_instructions(goto_functions) == 2);
     REQUIRE(max_pragma_unroll_count(goto_functions) == 11);
   }
+
+  GIVEN("A for loop with several induction variables")
+  {
+    // The preamble has several DECL/ASSIGN instructions between the
+    // intrinsic and the loop head; they must all be skipped.
+    std::istringstream src(
+      "void __ESBMC_unroll(int N);"
+      "int main() {"
+      "  __ESBMC_unroll(10);"
+      "  for(int i = 0, j = 10; i < j; i++, j--) ;"
+      "  return 0;"
+      "}");
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
+
+    apply_intrinsic_unroller unroller;
+    unroller.run(goto_functions);
+
+    // pragma_unroll_count = 10 + 1 = 11
+    REQUIRE(count_pragma_unroll_instructions(goto_functions) == 1);
+    REQUIRE(max_pragma_unroll_count(goto_functions) == 11);
+  }
+
+  GIVEN("An intrinsic before the inner of two nested loops")
+  {
+    // The intrinsic must bind to the inner loop, never the enclosing one.
+    std::istringstream src(
+      "void __ESBMC_unroll(int N);"
+      "int main() {"
+      "  while(1) {"
+      "    __ESBMC_unroll(10);"
+      "    for(int i = 0, j = 10; i < j; i++, j--) ;"
+      "  }"
+      "  return 0;"
+      "}");
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
+
+    apply_intrinsic_unroller unroller;
+    unroller.run(goto_functions);
+
+    // Only the inner loop is annotated: pragma_unroll_count = 10 + 1 = 11.
+    REQUIRE(count_pragma_unroll_instructions(goto_functions) == 1);
+    REQUIRE(max_pragma_unroll_count(goto_functions) == 11);
+  }
+
+  GIVEN("A misplaced intrinsic not followed by any loop")
+  {
+    // No loop follows the intrinsic, so nothing should be annotated.
+    std::istringstream src(
+      "void __ESBMC_unroll(int N);"
+      "int main() {"
+      "  __ESBMC_unroll(5);"
+      "  int x = 3;"
+      "  return x;"
+      "}");
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
+
+    apply_intrinsic_unroller unroller;
+    unroller.run(goto_functions);
+
+    REQUIRE(count_pragma_unroll_instructions(goto_functions) == 0);
+  }
+
+  GIVEN("An intrinsic separated from the loop by an unrelated statement")
+  {
+    // A bare call sits between the intrinsic and the loop: the intrinsic
+    // does not directly precede the loop, so nothing must be annotated.
+    // Newlines matter here: the misplacement is detected by the loop setup
+    // sharing the loop head's source line, which the stray call does not.
+    // The std::string overload preserves newlines (the istream one does not).
+    std::string src =
+      "void __ESBMC_unroll(int N);\n"
+      "void g();\n"
+      "int main() {\n"
+      "  __ESBMC_unroll(5);\n"
+      "  g();\n"
+      "  for(int i = 0; i < 5; i++) ;\n"
+      "  return 0;\n"
+      "}\n";
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
+
+    apply_intrinsic_unroller unroller;
+    unroller.run(goto_functions);
+
+    REQUIRE(count_pragma_unroll_instructions(goto_functions) == 0);
+  }
 }

--- a/website/content/docs/constructs.md
+++ b/website/content/docs/constructs.md
@@ -150,3 +150,21 @@ int main() {
     return 0;
 }
 ```
+
+The intrinsic must be placed immediately before the loop it applies to. Only
+the loop's own setup (the declarations and initialisers of a `for` loop, or the
+declaration in a condition such as `while (int v = f())`) may appear between the
+intrinsic and the loop header. It binds to the nearest following loop, so for
+nested loops it annotates the inner loop:
+
+```c
+while (1) {
+    __ESBMC_unroll(10);
+    for (int i = 0, j = 10; i < j; i++, j--) // annotated with 10
+        ;
+}
+```
+
+If an `__ESBMC_unroll` call is not directly followed by a loop (for example, an
+unrelated statement is placed in between), ESBMC reports a warning and ignores
+the annotation.


### PR DESCRIPTION
The intrinsic matcher used a fixed backward-pattern scan that only handled a function call optionally preceded by one assign and one decl. This failed for for-loops with several induction variables and while-loops that declare a variable in their condition, and gave no feedback when the intrinsic was misplaced.

Replace it with a backward walk over the loop preamble: skip the loop's own setup (declarations, initialisers and condition side-effects, identified by sharing the loop head's source line) until the __ESBMC_unroll call is found. This binds the call to the nearest following loop head, so for nested loops the inner loop is annotated. Any __ESBMC_unroll call not directly followed by a loop is now reported as misplaced instead of being silently ignored.

Fixes #3892