### PR TITLE
[util] irep2 migration Phase 2.4: eliminate core migrate-seam round-trips

### DIFF
--- a/src/irep2/irep2_dispatch.h
+++ b/src/irep2/irep2_dispatch.h
@@ -21,7 +21,6 @@
 #include <util/i2string.h>
 #include <util/ieee_float.h>
 #include <util/migrate.h>
-#include <util/std_types.h>
 #include <irep2/irep2_type.h>
 #include <irep2/irep2_expr.h>
 #include <irep2/irep2_utils.h>

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -8,7 +8,6 @@
 #include <irep2/irep2_dispatch.h>
 #include <util/message/format.h>
 #include <util/migrate.h>
-#include <util/std_types.h>
 
 // Pretty names indexed by expr2t::expr_ids. Driven by expr_kinds.inc;
 // adding a new expression kind there automatically populates this

--- a/src/irep2/irep2_guard.cpp
+++ b/src/irep2/irep2_guard.cpp
@@ -2,7 +2,6 @@
 #include <unordered_set>
 #include <irep2/irep2_guard.h>
 #include <irep2/irep2_utils.h>
-#include <util/std_expr.h>
 
 expr2tc guard2tc::as_expr() const
 {

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -9,7 +9,6 @@
 #include <util/message.h>
 #include <util/message/format.h>
 #include <util/migrate.h>
-#include <util/std_types.h>
 
 /*************************** Base type2t definitions **************************/
 

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -9,7 +9,6 @@
 #include <util/expr_util.h>
 #include <util/i2string.h>
 #include <irep2/irep2.h>
-#include <util/migrate.h>
 #include <util/message.h>
 #include <util/message/format.h>
 #include <util/prefix.h>

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -575,10 +575,6 @@ void value_sett::get_value_set_rec(
     if (sym.thename == "NULL" && is_pointer_type(expr))
     {
       const pointer_type2t &ptr_ref = to_pointer_type(expr->type);
-      typet subtype = migrate_type_back(ptr_ref.subtype);
-      if (subtype.id() == "symbol")
-        subtype = ns.follow(subtype);
-
       expr2tc tmp = null_object2tc(ptr_ref.subtype);
       insert(dest, tmp, BigInt(0));
       return;
@@ -1399,11 +1395,9 @@ void value_sett::do_function_call(
   const symbolt &symbol,
   const std::vector<expr2tc> &arguments)
 {
-  const code_typet &type = to_code_type(symbol.get_type());
-
-  type2tc tmp_migrated_type = migrate_type(type);
-  const code_type2t &migrated_type =
-    dynamic_cast<const code_type2t &>(*tmp_migrated_type.get());
+  // The symbol stores its type as IREP2 natively (Part I); read it directly
+  // rather than back-migrating the legacy cache and re-migrating it.
+  const code_type2t &migrated_type = to_code_type(symbol.get_type2());
 
   const std::vector<type2tc> &argument_types = migrated_type.arguments;
   const std::vector<irep_idt> &argument_names = migrated_type.argument_names;

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -3781,19 +3781,21 @@ expr2tc smt_convt::get_by_value(const type2tc &type, BigInt value)
 
   case type2t::fixedbv_id:
   {
-    fixedbvt fbv(constant_exprt(
-      integer2binary(value, type->get_width()),
-      integer2string(value),
-      migrate_type_back(type)));
+    // Build the fixedbv from its spec + raw bit pattern directly, mirroring
+    // fixedbvt::from_expr (spec from the type, v = the value's signed binary
+    // round-trip) without staging a legacy constant_exprt / type back-migration.
+    fixedbvt fbv(fixedbv_spect(to_fixedbv_type(type)));
+    fbv.set_value(
+      binary2integer(integer2binary(value, type->get_width()), true));
     return constant_fixedbv2tc(fbv);
   }
 
   case type2t::floatbv_id:
   {
-    ieee_floatt f(constant_exprt(
-      integer2binary(value, type->get_width()),
-      integer2string(value),
-      migrate_type_back(type)));
+    // Likewise mirror ieee_floatt::from_expr: spec from the type, then unpack
+    // the raw IEEE bit pattern (the value's unsigned binary round-trip).
+    ieee_floatt f(ieee_float_spect(to_floatbv_type(type)));
+    f.unpack(binary2integer(integer2binary(value, type->get_width()), false));
     return constant_floatbv2tc(f);
   }
 


### PR DESCRIPTION
## What

Implements the achievable scope of **Phase 2.4 — core migrate-seam
round-trip elimination** (`docs/irep2-migration.md` Part II §6). Removes
`migrate_*`/`migrate_*_back` round-trips from the verifier core
(pointer-analysis / solver / IREP2), reading the IREP2 source of truth
directly. Strictly behaviour-preserving.

## Commits

| # | Commit | What |
|---|--------|------|
| 15 | value_set off the seam | `value_sett::do_function_call` reads `to_code_type(symbol.get_type2())` directly instead of `migrate_type(to_code_type(symbol.get_type()))` + a `dynamic_cast`; also drops a dead `migrate_type_back` in the NULL-pointer value-set path (the local was computed but unused). value_set.cpp now has zero `migrate_*` sites. |
| 17 | smt_conv native model builders | `smt_convt::get_by_value` builds model `fixedbv`/`floatbv` constants from the IREP2 type directly (`fixedbv_spect(to_fixedbv_type(type))` + `set_value`, `ieee_float_spect(to_floatbv_type(type))` + `unpack`) instead of staging a legacy `constant_exprt(binary, value, migrate_type_back(type))` parsed via `from_expr`. |
| 19 | prune stale legacy includes | Remove 4 stale `std_*` includes from `irep2/{irep2_expr,irep2_type,irep2_guard,irep2_dispatch}` (they use the `type2tc` `to_*_type` overloads, not the legacy ones) and the now-unused `<util/migrate.h>` from value_set.cpp. |

## Behaviour equivalence

- **value_set:** `migrate_type(symbol.get_type()) == symbol.get_type2()`
  by the symbol's lazy-cache round-trip invariant; `get_type2()` returns a
  reference whose lifetime covers the use (the symbol is a const&
  parameter, no setter runs in the call). The checked `to_code_type`
  replaces the manual `dynamic_cast`.
- **smt_conv:** the native builders mirror `fixedbvt::from_expr` /
  `ieee_floatt::from_expr` bit-for-bit — same spec (the `*_spect` `type2tc`
  ctors read the same fields the migrated-back legacy type carried, cf.
  Phase 2.3) and the same raw `v` / unpacked bit pattern; spec is set
  before `unpack` (which depends on it).
- **includes:** the full build links cleanly with all five removed
  (proof of staleness, incl. no transitive-includer breakage from the
  `irep2_dispatch.h` header).

## Intentionally omitted (blocked — resolved gates, not deferred)

- **Commit 16 (memory_alloc):** would build `array_type2t` directly, but
  that drops the legacy array's `dynamic(true)` flag, which
  `symex_valid_object.cpp:52,93` reads via `symbol.get_type().dynamic()`
  for dynamic-memory valid-object checks. `array_type2t` has no such
  field, so this would be a behaviour change, not a refactor. Left as-is.
- **Commit 18 (symex_catch):** the C++ base-class `bases` sub-irep is
  legacy-only — `struct_type2t` has no `bases` field and `migrate_type`
  never copies it (open question Q3, now resolved) — so the base-class
  walks must keep reading the legacy `get_type().find("bases")`. Left
  as-is, per the plan's "if it does not [survive], this site stays."

## Scope / metric note

Phase 2.4 touches the verifier core (pointer-analysis / goto-symex /
solvers / irep2), not `src/util`, so it does not move the `src/util`
migrate-census scoreboard; the value is removing 4 core-seam round-trips,
two of them hot (per function call; per fixedbv/float model readback).

## Verification

The goto-baseline harness is unreliable here (ESBMC re-bakes its
operational models non-deterministically per build — `docs/irep2-migration.md`
§8.1), so each commit was gated on **deterministic regression-verdict
equivalence vs clean `master`** over a stratified
`regression/{esbmc,floats,esbmc-cpp,python}` subset, plus the full floats
corpus (144/145, only pre-existing `isinf_ir_ieee`) and the affected unit
suites (`simplify2ttest` 236, `arith_tools_test`, `base_type`, `migrate`,
`symbol`). Every gate is identical to clean master. `code-reviewer` agent:
clean, no findings.