### PR TITLE
[util] irep2 migration Phase 2.5: drop vestigial util/type.h; frontend boundary reached

### DIFF
--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -3,7 +3,6 @@
 
 #include <optional>
 #include <irep2/irep2.h>
-#include <util/type.h>
 
 // Forward-declare a concrete <kind>_type2t class for every entry in
 // type_kinds.inc. The same manifest drives the type_ids enum in


### PR DESCRIPTION
## What

**Phase 2.5 — DUAL_API_THEN_DROP** (`docs/irep2-migration.md` Part II §6).
This PR lands the one piece of Phase 2.5 that is cleanly achievable
without touching the permanent frontend boundary:

- **Commit 23:** drop the vestigial `<util/type.h>` include from
  `irep2_type.h`. The legacy `typet` is referenced **0×** across
  `src/irep2/` (the IREP2 type layer is purely `type2tc`). The full build —
  which recompiles all of `irep2_type.h`'s many transitive includers —
  links cleanly with it gone, confirming nothing relied on the transitive
  pull-in. Include-only; verdict sanity over `regression/{esbmc,floats}`
  shows only pre-existing platform failures.

## Why this is all of Phase 2.5 (boundary reached)

Phase 2.5's remaining commits are frontend-gated, risky, or premature —
the non-frontend migration surface was drained by Phases 2.1–2.4 (#4935,
#4938, #4941, #4944) and #4946. Grounded against the tree at this commit:

- **Commit 20** (`goto2c/expr2c.cpp:314` `base_type(typet)`): low value —
  goto2c is the legacy C-emitter; migrating its lone caller needs a
  migrate round-trip (or a local `typet` convert) and unblocks nothing,
  since the overload drop (24) is frontend-gated regardless.
- **Commit 21** (`c_link.cpp` ×3 + `c_typecast.cpp:691`): **risky (R2).**
  The `typet` and `type2tc` `base_type_eq` paths differ on
  `incomplete_struct` / `incomplete_array` / `subtype`, and `c_link` does
  link-merge of *incomplete* (forward-declared) types. Migrating could
  change link-merge behaviour; it needs the deferred DUAL_API
  equivalence-test harness plus targeted incomplete-type re-verification —
  not a clean drop.
- **Commit 22** (add 13 `*_type2` C-type siblings; migrate
  `size_type`/`bool_type`/`char_type`): premature — the missing siblings'
  legacy counterparts (`enum_type`, `wchar_type`, `char16/32_type`,
  `half_float_type`, `uint256_type`, short/char variants) are
  frontend-called, so the siblings would be dead-until-frontend; and the
  only non-frontend `size_type()` call sites are in `memory_alloc`'s
  legacy dynamic-array path, which is itself blocked (the `array_typet`
  carries the `dynamic`/`alignment` attributes `symex_valid_object` reads
  and `array_type2t` has no field for — Phase 2.4 commit 16).
- **Commit 24** (drop the legacy `base_type_eq` / `c_typecast` /
  `arith_tools` overloads): **frontend-blocked** — explicitly "after the
  above + frontends," and the frontends are the declared permanent legacy
  boundary (Part I, B1).

This matches the plan's own framing: the DUAL_API drop is gated on the
frontend boundary. The util→IREP2 migration's clean non-frontend scope is
effectively complete; the residual legacy surface is exactly the
RETAIN_BOUNDARY set (IR core, on-disk format, migrate seam) plus the
MIGRATE_CALLERS_FIRST set pinned by the frontends.
