### PR TITLE
[symex] model __thread storage class with per-thread SSA chains

### DIFF
--- a/regression/esbmc-unix/github_4433_thread_local_dynamic/main.c
+++ b/regression/esbmc-unix/github_4433_thread_local_dynamic/main.c
@@ -1,0 +1,36 @@
+// Regression test for github.com/esbmc/esbmc/issues/4433.
+//
+// Sibling of #4434: same `__thread` modelling but with a pointer-typed
+// TLS variable and a per-thread dynamic allocation. Each thread starts
+// with `data == NULL`, allocates its own buffer via calloc, asserts
+// it is zero-initialized, writes to it, and frees. Without the fix
+// (see renaming.cpp + intrinsic_init_thread_local), thread 2's first
+// read of `data` resolved to thread 1's calloc'd pointer, breaking
+// the assertion. The fix gives `__thread int *data = NULL` per-thread
+// SSA storage seeded with NULL at thread start.
+#include <pthread.h>
+#include <stdlib.h>
+#include <assert.h>
+
+__thread int *data = 0;
+
+void *worker(void *arg)
+{
+  data = (int *)calloc(2, sizeof(int));
+  assert(data != 0);
+  assert(data[0] == 0);
+  data[0] = 1;
+  assert(data[0] == 1);
+  free(data);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, worker, 0);
+  pthread_create(&t2, 0, worker, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4433_thread_local_dynamic/test.desc
+++ b/regression/esbmc-unix/github_4433_thread_local_dynamic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-check --no-bounds-check --no-div-by-zero-check --force-malloc-success --unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_4434_thread_local/main.c
+++ b/regression/esbmc-unix/github_4434_thread_local/main.c
@@ -1,0 +1,38 @@
+// Regression test for github.com/esbmc/esbmc/issues/4434.
+//
+// The C `__thread` (GCC) / `_Thread_local` (C11) storage class gives
+// each thread its own instance of the variable, initialized to the
+// static initializer at thread start. Before the fix, ESBMC's frontend
+// set symbolt::is_thread_local from clang::VarDecl::getTLSKind() but
+// the symex layer routed every access through the shared
+// level1_global SSA chain, so a write in one thread was visible to
+// another. The pthread-race-challenges/thread-local-value SV-COMP
+// benchmark reported a spurious unreach-call violation because
+// thread 2's first read of `data` resolved to thread 1's prior write.
+//
+// The fix gives `__thread` globals a per-thread level1 instance (see
+// renaming.cpp::is_thread_local) and seeds the initial value from
+// pthread_trampoline via __ESBMC_init_thread_local() so the first
+// read in each spawned thread sees the static initializer (here, 0).
+#include <pthread.h>
+#include <assert.h>
+
+__thread int data = 0;
+
+void *worker(void *arg)
+{
+  assert(data == 0);
+  data = 1;
+  assert(data == 1);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, worker, 0);
+  pthread_create(&t2, 0, worker, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4434_thread_local/test.desc
+++ b/regression/esbmc-unix/github_4434_thread_local/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-check --no-bounds-check --no-div-by-zero-check --unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -7,6 +7,7 @@
 typedef void *(*__ESBMC_thread_start_func_type)(void *);
 void __ESBMC_terminate_thread(void);
 unsigned int __ESBMC_spawn_thread(void (*)(void));
+void __ESBMC_init_thread_local(void);
 
 struct __pthread_start_data
 {
@@ -189,6 +190,12 @@ __ESBMC_HIDE:;
 void pthread_trampoline(void)
 {
 __ESBMC_HIDE:;
+  // Seed each TLS (`__thread`) global to its static initializer in this
+  // thread's renaming scope; without this, the per-thread SSA chain
+  // (renaming.cpp) starts unconstrained and the first read in the
+  // worker function would resolve to nondet (#4434, #4433).
+  __ESBMC_init_thread_local();
+
   pthread_t threadid = __ESBMC_get_thread_id();
   struct __pthread_start_data startdata =
     __ESBMC_get_thread_internal_data(threadid);

--- a/src/goto-symex/builtin_functions/threads.cpp
+++ b/src/goto-symex/builtin_functions/threads.cpp
@@ -6,11 +6,13 @@
 #include <util/arith_tools.h>
 #include <util/base_type.h>
 #include <util/c_types.h>
+#include <util/context.h>
 #include <util/expr_util.h>
 #include <irep2/irep2.h>
 #include <util/message.h>
 #include <util/migrate.h>
 #include <util/std_types.h>
+#include <util/symbol.h>
 
 void goto_symext::intrinsic_yield(reachability_treet &art)
 {
@@ -186,6 +188,25 @@ void goto_symext::intrinsic_terminate_thread(reachability_treet &art)
   art.get_cur_state().end_thread();
   // No need to force a context switch; an ended thread will cause the run to
   // end and the switcher to be invoked.
+}
+
+void goto_symext::intrinsic_init_thread_local(reachability_treet &)
+{
+  // Seed each `__thread`-qualified global to its static initializer in the
+  // active thread's renaming scope. Called from pthread_trampoline before
+  // the user worker runs; without this, level1's per-thread routing (see
+  // renaming.cpp::is_thread_local) leaves the first read unconstrained.
+  // The main thread gets its TLS init from clang_c_maint::static_lifetime_init
+  // in __ESBMC_main, so we don't need to special-case it here.
+  new_context.foreach_operand([this](const symbolt &sym) {
+    if (!sym.is_thread_local || !sym.static_lifetime)
+      return;
+    expr2tc lhs = symbol2tc(migrate_type(sym.get_type()), sym.id);
+    const exprt &init = sym.get_value();
+    expr2tc rhs;
+    migrate_expr(init.is_nil() ? gen_zero(sym.get_type()) : init, rhs);
+    symex_assign(code_assign2tc(lhs, rhs), true);
+  });
 }
 
 void goto_symext::intrinsic_really_atomic_begin(reachability_treet &art)

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -464,6 +464,9 @@ protected:
     reachability_treet &art);
   /** Perform terminate_thread; Record thread as terminated. */
   void intrinsic_terminate_thread(reachability_treet &art);
+  /** Perform init_thread_local; seeds each `__thread`-qualified global
+   *  to its static initializer in the active thread's renaming scope. */
+  void intrinsic_init_thread_local(reachability_treet &art);
   /** Really atomic start/end - atomic blocks that just disable ileaves. */
   void intrinsic_really_atomic_begin(reachability_treet &art);
   /** Really atomic start/end - atomic blocks that just disable ileaves. */

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -221,10 +221,11 @@ public:
     /** The stack size of the frame. */
     BigInt stack_frame_total;
 
-    framet(unsigned int thread_id)
+    framet(unsigned int thread_id, const namespacet *ns = nullptr)
       : return_value(expr2tc()), hidden(false), stack_frame_total(0)
     {
       level1.thread_id = thread_id;
+      level1.ns = ns;
     }
   };
 
@@ -309,7 +310,7 @@ public:
    */
   inline framet &new_frame(unsigned int thread_id)
   {
-    call_stack.emplace_back(thread_id);
+    call_stack.emplace_back(thread_id, &ns);
     return call_stack.back();
   }
 

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -3,7 +3,23 @@
 #include <irep2/irep2.h>
 #include <util/message.h>
 #include <util/migrate.h>
+#include <util/namespace.h>
 #include <util/prefix.h>
+#include <util/symbol.h>
+
+namespace
+{
+/** Treat a symbol with the `__thread` / `_Thread_local` qualifier as a
+ *  per-thread instance instead of a shared global. The C frontend already
+ *  sets symbolt::is_thread_local from clang::VarDecl::getTLSKind(). */
+bool is_thread_local(const namespacet *ns, const irep_idt &name)
+{
+  if (!ns)
+    return false;
+  const symbolt *sym = ns->lookup(name);
+  return sym && sym->is_thread_local;
+}
+} // namespace
 
 unsigned renaming::level2t::current_number(const expr2tc &symbol) const
 {
@@ -35,8 +51,18 @@ void renaming::level1t::get_ident_name(expr2tc &sym) const
 
   if (it == current_names.end())
   {
-    // can not find; it's a global symbol.
-    symbol.rlevel = symbol_renaming_level::level1_global;
+    // Not in this frame's locals. Either a regular global (shared across
+    // threads) or a `__thread`-qualified global (per-thread). For TLS,
+    // route to level1 with the active thread_id so level2 keys it
+    // separately for each thread.
+    if (is_thread_local(ns, symbol.thename))
+    {
+      symbol.rlevel = symbol_renaming_level::level1;
+      symbol.level1_num = 0;
+      symbol.thread_num = thread_id;
+    }
+    else
+      symbol.rlevel = symbol_renaming_level::level1_global;
     return;
   }
 
@@ -96,6 +122,19 @@ void renaming::level1t::rename(expr2tc &expr)
         sym.thename,
         symbol_renaming_level::level1,
         it->second,
+        0,
+        thread_id,
+        0);
+    }
+    else if (is_thread_local(ns, sym.thename))
+    {
+      // `__thread` global: give each thread its own level1 instance so
+      // level2 keys the SSA chain separately per thread.
+      expr = symbol2tc(
+        sym.type,
+        sym.thename,
+        symbol_renaming_level::level1,
+        0,
         0,
         thread_id,
         0);

--- a/src/goto-symex/renaming.h
+++ b/src/goto-symex/renaming.h
@@ -10,6 +10,8 @@
 #include <irep2/irep2_expr.h>
 #include <util/std_expr.h>
 
+class namespacet;
+
 namespace renaming
 {
 struct renaming_levelt
@@ -97,6 +99,10 @@ public:
     current_namest;
   current_namest current_names;
   unsigned int thread_id;
+  // Set externally (alongside thread_id) so rename() / get_ident_name()
+  // can check is_thread_local on globals and route them per-thread
+  // instead of to the shared level1_global bucket (issue #4434, #4433).
+  const namespacet *ns = nullptr;
 
   void rename(expr2tc &expr) override;
   void get_ident_name(expr2tc &symbol) const override;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -619,6 +619,12 @@ void goto_symext::run_intrinsic(
     return;
   }
 
+  if (symname == "c:@F@__ESBMC_init_thread_local")
+  {
+    intrinsic_init_thread_local(art);
+    return;
+  }
+
   if (symname == "c:@F@__ESBMC_really_atomic_begin")
   {
     intrinsic_really_atomic_begin(art);


### PR DESCRIPTION
The frontend already set `symbolt::is_thread_local` from
`clang::VarDecl::getTLSKind()`, but the symex routed every access to
`__thread` globals through the shared `level1_global` SSA chain — so
threads saw each other's writes. Make `level1t` route TLS globals to
per-thread `level1` instances (existing `thread_num` keying gives the
split for free) and seed the static initializer in each spawned
thread via a new `__ESBMC_init_thread_local` intrinsic called from
`pthread_trampoline`.

Fixes #4434, fixes #4433.
