### PR TITLE
[docs] add Solidity frontend IREP2 migration plan (Part III)

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -780,3 +780,572 @@ seam (kept with its cross-check), and the frontend-pinned helper layer
 (`MIGRATE_CALLERS_FIRST`). Further progress requires migrating the
 frontends themselves — the permanent boundary Part I declared out of
 scope — and so belongs to its own, much larger tracking effort.
+
+---
+
+# Part III — Solidity frontend → IREP2 (forward plan)
+
+> **Status: planning.** Parts I and II are closed records. This part is a
+> *forward plan* that deliberately **reopens boundary B1** ("Frontend →
+> goto input", marked *Deferred indefinitely* in Part I) for **one
+> frontend only — Solidity**. Nothing here has landed. Tracking issue:
+> **to be filed.** It must not be opened under the umbrella issue that
+> closed with the Part I retrospective; B1 was declared out of scope
+> there, and this plan changes that scope deliberately and with evidence.
+
+This part is written to be executable by an engineer who has *not* worked
+on the Solidity frontend before. Every load-bearing claim carries a
+`file:line` anchor and a re-verification command so you can confirm the
+tree has not drifted since this was written.
+
+## 1. Scope, motivation, and the non-negotiable constraint
+
+`src/solidity-frontend/` is ~23.5 kLOC across 27 files. Its docstrings
+already *claim* it is an "AST-to-irep2 converter" (`solidity_convert.h:1-9`)
+— that is aspirational, not factual: the converter is **100 % legacy
+IR** today (`exprt`/`typet`/`codet`/`symbolt`). This plan closes the gap
+between the docstring and reality, **for the parts that can be closed
+soundly**, and documents precisely which parts cannot move without
+prerequisite infrastructure shared with the clang frontends.
+
+Why Solidity is the right pilot for reopening B1:
+
+- It is the most self-contained pure-legacy frontend. Unlike clang-c /
+  clang-cpp it has no Clang AST objects flowing through it (it consumes a
+  solc JSON AST), and unlike the python frontend it does not also drive a
+  large operational-model surface from the same converter.
+- Smart-contract verification is a soundness-critical domain where the
+  compile-time-typing benefit of IREP2 (Part I §"Why this mattered") pays
+  off directly: a misclassified expression (mapping vs array, `bytesN`
+  width, storage vs memory aliasing) is a *silent verdict corruption*,
+  not a crash.
+- It carries the largest concentration of **Solidity-specific irep
+  string attributes** (§4, F4) — the exact construct IREP2 was designed
+  to make impossible. De-risking that surface is valuable on its own,
+  independent of how far the migration ultimately goes.
+
+**The constraint is Part I's constraint, restated and non-negotiable:**
+ESBMC is a verifier; **every step must be behaviour-preserving** —
+identical pass/fail verdicts, identical counterexample-visible text where
+`test.desc` matches it, dual-solver agreement, no on-disk goto-binary
+format change. A step that is merely "more IREP2" but shifts one
+Solidity verdict is a regression, not progress. Where this plan and
+implementation convenience conflict, correctness wins — the user has
+made this explicit and it is the governing rule of this part.
+
+## 2. How this plan was derived (reproducibility)
+
+Same method as Part II §2, re-run against the Solidity tree:
+
+- **Idiom census** — `grep` over `src/solidity-frontend/**` for legacy
+  builders (`symbol_expr`, `side_effect_expr_function_callt`,
+  `code_*t`, `member_exprt`, …), for direct irep surgery
+  (`move_to_operands`, `copy_to_operands`, `.operands()`, `.find(`,
+  `.id()`), and for every `.set("#…")` / `.get("#…")` attribute key.
+- **Seam trace** — read `symbol.{h,cpp}`, `migrate.{h,cpp}`,
+  `solidity_language.cpp`, `clang_c_adjust_expr.cpp`, `c_link.cpp`,
+  `goto_convert_functions.cpp` to fix exactly where legacy becomes IREP2.
+- **IREP2 API audit** — read `irep2_expr.h`, `irep2_type.h`,
+  `expr_kinds.inc`, `type_kinds.inc`, `c_types.h` for the available
+  factories and the representational gaps.
+- **Adversarial re-check** — every load-bearing fact in §4 was
+  re-derived by an independent pass instructed to refute it; the figures
+  below are the post-correction ones.
+
+Re-run before acting on any phase; counts are a snapshot.
+
+## 3. Where the legacy→IREP2 boundary sits today (the seam)
+
+The symbol table is the pivot (Part I, B2). `symbolt` stores
+`type2tc`/`expr2tc` as the source of truth with **lazy legacy caches**
+(`symbol.h:71-85`). The two setters behave asymmetrically:
+
+- `set_type(const typet&)` / `set_value(const exprt&)` store the **legacy**
+  form and invalidate the IREP2 side (`symbol.cpp:36-41`). *No eager
+  forward-migration* (Part I, S5a hotfix rationale).
+- `set_type(const type2tc&)` / `set_value(const expr2tc&)` store **IREP2**
+  and invalidate the legacy side.
+
+The Solidity converter exclusively uses the **legacy** setters via
+`get_default_symbol` + `move_symbol_to_context`
+(`solidity_convert_util.cpp:200`; it never touches `get_type2()` /
+`get_value2()` / `set_type(type2tc)`). So a Solidity symbol enters the
+table legacy-valid / IREP2-invalid.
+
+After the converter runs, **two shared legacy passes run over its output**
+inside `solidity_languaget::typecheck` (`solidity_language.cpp:333-387`):
+
+1. `clang_cpp_adjust adjuster(new_context); adjuster.adjust();`
+   (`solidity_language.cpp:370`). Adjust reads `get_value()`/`get_type()`
+   (legacy form, lazily back-migrated if needed), mutates **in place as
+   legacy**, and writes the legacy form back
+   (`clang_c_adjust_expr.cpp:56-75`). It does not consult IREP2.
+2. `c_link(context, new_context, module)` (`solidity_language.cpp:382`).
+   Link compares and merges symbols using `base_type_eq` on the **legacy
+   `typet`** and reads `get_value()` for body swaps (`c_link.cpp`).
+
+Only later, in `goto_convert`, does legacy become IREP2 for good:
+`convert_function` reads the body as **legacy `codet`**
+(`to_code(symbol.get_value())`, `goto_convert_functions.cpp:116`) and
+`goto_convert_rec` lowers it (`:139`); `goto_convertt::copy` calls
+`migrate_expr(code, t->code)` per instruction. The function *type* goes
+through the `migrate_symbol_type` chokepoint (`:104`).
+
+```
+solc JSON ──► solidity_convertert ──► symbolt (LEGACY valid)
+                                          │
+                       clang_cpp_adjust  ─┤  reads/writes LEGACY in place
+                              c_link     ─┘  compares LEGACY typet
+                                          ▼
+                       goto_convert: to_code(get_value())  ← LEGACY codet
+                       goto_convert_rec lowers structured CF
+                       migrate_expr per-instruction        ──► IREP2 (permanent)
+```
+
+## 4. Architectural findings that bound this plan
+
+Each is verified; the re-check command is given.
+
+**F1 — Symbol table is IREP2-source-of-truth with lazy legacy caches.**
+`symbol.h:71-85`, `symbol.cpp:36-55,82-141`. A frontend *may* legally
+call `set_type(type2tc)` / `set_value(expr2tc)`. Re-check:
+`sed -n '60,160p' src/util/symbol.cpp`.
+
+**F2 — Function bodies are hard-pinned to legacy `codet`; IREP2 has no
+structured control flow.** `goto_convert_functions.cpp:110-139` reads the
+body as `codet` and `goto_convert_rec` lowers it. `expr_kinds.inc`
+contains only the **lowered, goto-level** code kinds — `code_block`,
+`code_assign`, `code_decl`, `code_dead`, `code_expression`,
+`code_return`, `code_skip`, `code_goto`, `code_function_call`,
+`code_printf`, `code_comma`, `code_asm`, and the `code_cpp_*` exception
+forms. There is **no** `code_ifthenelse2t`, `code_while2t`,
+`code_for2t`, `code_switch2t`, `code_dowhile2t`, `code_break2t`,
+`code_continue2t`, or `code_label2t`. The Solidity emitter currently
+produces all of these structured forms (`code_whilet` ×2,
+`code_switcht`, `code_fort`, `code_dowhilet`, `code_breakt` ×2,
+`code_continuet`, `code_labelt` ×19, plus `if`). **Lowering structured
+control flow to goto is `goto_convert`'s job and lives below the frontend
+boundary.** Re-check: `grep -E 'IREP2_EXPR\(code_' src/irep2/expr_kinds.inc`
+and `grep -roE 'code_[a-z]+t' src/solidity-frontend | sort -u`.
+
+→ **Consequence (PIN P1):** the frontend cannot emit IREP2 *function
+bodies* and feed them to `goto_convert`. Bodies remain legacy `codet`
+until an IREP2-native goto-convert input language exists — a separate,
+much larger project, explicitly out of scope here.
+
+**F3 — Two shared legacy passes post-process Solidity output.**
+`clang_cpp_adjust` and `c_link` (§3) are shared verbatim with the clang
+frontends and operate on legacy IR. Even if the converter stored IREP2,
+adjust would read it back as legacy (`migrate_*_back`), mutate legacy,
+and re-store legacy — round-tripping it immediately, **and dropping any
+Solidity attribute on the way (see F4).** Re-check:
+`grep -n 'clang_cpp_adjust\|c_link' src/solidity-frontend/solidity_language.cpp`.
+
+→ **Consequence (PIN P2):** "emit IREP2 directly from the converter"
+delivers nothing — and is actively *unsound* w.r.t. F4 — while adjust/link
+remain legacy passes. Migrating them is shared infrastructure work, out
+of scope here.
+
+**F4 — `migrate_type`/`migrate_expr` silently drop every Solidity irep
+attribute. THIS IS THE CENTRAL SOUNDNESS HAZARD.** `migrate_type`
+dispatches on `type.id()` and builds a fixed-field `type2tc`; the struct
+arm (`migrate.cpp:191-214`) copies only `members`, `names` (`a_name`),
+`pretty_names` (`a_pretty_name`), `tag`/`name`, and `packed`. There is no
+code path anywhere in `migrate.cpp` that copies a `#`-prefixed attribute,
+because `type2t`/`expr2t` have **no generic string-attribute map** — their
+fields are fixed at construction (`irep2.h`, the `fields` tuple per kind).
+The Solidity frontend attaches ≥20 distinct semantic attributes to
+`typet`/`exprt`:
+
+| Attribute | Carries | Set / Read | Migrates? |
+|---|---|---|---|
+| `#sol_type` | Solidity type class (CONTRACT, MAPPING, DYNARRAY, BYTES, …) | 1 set / **~43 read** | **dropped** |
+| `#sol_array_size` | array / dynarray length | 8 / 13 | maps → `array_type2t.array_size` |
+| `#sol_bytesn_size` | `bytes1`..`bytes32` width | 5 / 11 | **dropped** (no field) |
+| `#sol_contract` | contract name on contract types | 1 / 6 | **dropped** |
+| `#sol_data_loc` | `memory` / `storage` / `calldata` | 3 / 0 | **dropped** |
+| `#sol_state_var` | state-variable flag | 2 / 1 | **dropped** |
+| `#sol_name`, `#sol_mapping_array`, `#sol_dynarray_state`, `#sol_tuple_id`, `#sol_unchecked`, `#is_sol_virtual`, `#is_sol_override`, `#inlined`, `#member_name`, `#cpp_type`/`cpp_type`, `#zero_initializer`, `#is_modifier_placeholder`, `#c_sizeof_type`, `#cformat` | misc semantics & markers | various | **dropped** |
+
+Today this is invisible **only because** the converter writes legacy into
+the symbol's legacy cache and every `get_sol_type` / `.get("#…")` read is
+served from that same un-round-tripped legacy `typet`. The instant a
+Solidity type or expression crosses the IREP2 boundary (a `set_type(type2tc)`,
+a `migrate_type`, or a symbol whose IREP2 side becomes source-of-truth),
+the Solidity semantics **vanish without a diagnostic**. Re-check:
+`grep -rn 'set("#sol\|get("#sol\|set_sol_type\|get_sol_type' src/solidity-frontend | wc -l`
+and confirm `migrate.cpp` has no `#sol` handling:
+`grep -n '#sol\|#member_name\|#is_sol' src/util/migrate.cpp` (returns nothing).
+
+→ **Consequence:** the *first and most important* phase is to remove the
+frontend's dependence on IR-carried Solidity semantics (§7, Phase 3.1),
+**before** any node migrates. This is a soundness hardening even if no
+further migration ever happens.
+
+**F5 — The IREP2 construction API is largely present; the gaps are
+enumerable.** Factories exist for every type/expr the frontend needs as
+typed builders (`irep2_type.h:16-506`, `irep2_expr.h:104-1900`,
+`c_types.h:65-79`). The confirmed gaps are listed in §6.
+
+## 5. Target end-state: "IREP2-internal, legacy-at-the-seam"
+
+Given P1+P2+F4, the **achievable, sound** target for frontend-scoped work
+is *not* "the converter emits IREP2 end-to-end." It is:
+
+> The converter computes and carries Solidity semantics in a **typed,
+> off-IR companion structure** (never in irep string attributes), and
+> constructs **types and the expression operands of statements** using
+> IREP2 typed factories. Structured control-flow statements and the
+> function-body `codet` handed to `goto_convert` remain legacy by design
+> (P1). The single legacy hand-off is localized and documented.
+
+```
+                       ┌─────────────────── frontend scope ──────────────────┐
+solc JSON ──► classify (typed sol_typeinfo, off-IR)
+                  │                                            PIN P1: bodies
+                  ▼                                            stay legacy codet
+            build type2tc / expr2tc operands  ──► lower to legacy codet body
+                                                    at ONE hand-off (migrate_back)
+                       └──────────────────────────────────────────────────────┘
+                                                    │
+                            clang_cpp_adjust, c_link │ (PIN P2: shared legacy)
+                                                    ▼
+                                         goto_convert ──► IREP2 (permanent)
+```
+
+This buys the IREP2 compile-time-typing soundness benefit *inside the
+converter* (a mis-built node fails to compile, not at symex), eliminates
+the attribute hazard (F4) entirely, and leaves the externally-observable
+behaviour bit-identical because the bytes that reach `clang_cpp_adjust`
+are the same legacy `codet`/`typet` as today — just produced through a
+typed path. The deeper boundary (P1/P2) is then a *clean, single, audited
+seam* rather than a diffuse one, which is the precondition any future
+"push the boundary below adjust/link/goto-convert" project would need.
+
+### 5.1 The `sol_typeinfo` companion (replaces all `#sol_*` on IR)
+
+Introduce one typed, frontend-local value type (proposed
+`src/solidity-frontend/sol_typeinfo.h`):
+
+```cpp
+struct sol_typeinfo {
+  SolidityGrammar::SolType cls = SolType::SolTypeError; // was #sol_type
+  std::string contract_name;            // was #sol_contract
+  data_location loc = data_location::none; // was #sol_data_loc
+  unsigned bytesn_width = 0;            // was #sol_bytesn_size (bytes)
+  bool is_state_var = false;           // was #sol_state_var
+  bool is_mapping_backed_array = false;// was #sol_mapping_array
+  // … one typed field per surviving attribute …
+};
+```
+
+Carry it **keyed by a stable identity that does not depend on the IR
+node surviving migration**:
+
+- For symbols: a side-table `std::unordered_map<irep_idt, sol_typeinfo>`
+  keyed by the symbol `id`. The python frontend already uses this
+  pattern (`std::unordered_map<std::string, const symbolt*>` caches, e.g.
+  `python-frontend/function_call/expr.h:437`).
+- For transient sub-expressions during a single conversion: thread the
+  `sol_typeinfo` as an explicit out-parameter / local alongside the
+  `typet` being built, mirroring how `get_type_description(json, typet&)`
+  already threads the JSON node.
+
+The design rule that makes this *sound*: **classification must be
+derivable from the solc JSON (or the companion), never read back off an
+irep node.** Once that holds, the IR types are "plain" C-like types that
+`migrate_type` converts losslessly — there is nothing left to drop.
+
+> **Rejected alternative — extend `type2t`/`expr2t` with a generic
+> attribute map.** This would re-introduce exactly the string-keyed,
+> parse-at-every-access escape hatch IREP2 was built to abolish (Part I
+> §"Why this mattered"), forfeiting the determinism and compile-time
+> soundness that justify the whole migration. Do not do this. The
+> companion structure is typed and frontend-local; it never enters the
+> verifier core.
+
+## 6. IREP2 API gaps to close before migrating construction
+
+From the F5 audit. Build these (with unit round-trip tests) **before**
+the phase that needs them; each is small.
+
+| Gap | Needed by | Disposition |
+|---|---|---|
+| No `type2t`/`expr2t` attribute map | all `#sol_*` reads | **By design** — solved by §5.1 companion, not by extending IREP2. |
+| `bytesN` width has no type field | `#sol_bytesn_size` consumers | Carry width in `sol_typeinfo`; represent the value as `unsignedbv_type2t(8*N)` or the existing `bytesN` operational-model struct — **decide once** (Q3) and apply uniformly. |
+| Structured control-flow code kinds | function bodies | **Out of scope (P1).** Bodies stay legacy `codet`. |
+| Expression-context function call | the 195 `side_effect_expr_function_callt` sites | Use `sideeffect2t(..., sideeffect_allockind::function_call)` (`irep2_expr.h:1743-1760`); statement-level uses `code_function_call2t` (`:1891-1900`). |
+| `string_constant::mb_value` | string/bytes literals | `constant_string2t` lacks `mb_value` (Part II Phase 2.6, R10); port the decoder **verbatim** or keep string-literal lowering legacy at the seam. Gated by Q4. |
+| 256-bit integer types | every Solidity `uintN`/`intN` | `unsignedbv_type2tc(256)` / `signedbv_type2tc(256)` already work; no new factory needed. Verify BigInt/SMT width handling under overflow checks (R-S5). |
+| `symbol2tc` from a `symbolt` | the 179 `symbol_expr(symbolt)` sites | Trivial convenience helper (Part II §5 lists the same gap). |
+
+## 7. Phased, commit-sized decomposition
+
+Ordered soundness-first / lowest-risk-first. Each numbered item is one
+reviewable commit; **apply and test one at a time** (incremental patch
+testing); do not batch. Every commit is gated by §10.
+
+### Phase 3.0 — Baseline & harness (no behaviour change)
+1. Capture the golden **verdict + matched-text** set over the full
+   `regression/esbmc-solidity` suite (512 tests; §10) on clean `master`,
+   on an **asserts-enabled build** (keeps the `migrate.cpp:386-396`
+   cross-check live). Record which tests fail pre-change (platform/solver
+   baseline). The suite is `.solast`-driven and needs **no `solc`**
+   (§10.1) — confirm `solc` absence does not change the set.
+2. Add a `sol_typeinfo` round-trip / equivalence unit harness skeleton
+   under `unit/solidity-frontend/` (none exists today): asserts that
+   classification computed from JSON equals the legacy `#sol_*` value for
+   a corpus of nodes. This is the durable contract regression for 3.1.
+
+### Phase 3.1 — De-attribute: move Solidity semantics off the IR (THE key phase)
+*No change to emitted IR shape; pure relocation of metadata. This is the
+soundness hardening and the prerequisite for every later phase.*
+
+3. Introduce `sol_typeinfo` + the symbol-keyed side-table and the
+   threading parameter; populate it wherever a `#sol_*` is currently
+   `set`. Leave the `#sol_*` writes in place (dual-write) so reads are
+   unaffected.
+4. Migrate **`#sol_type` reads** (~43 sites) from `get_sol_type(typet)`
+   to the companion. Do this in dependency order: type/decl converters
+   first, then expression/call converters. After the last read is
+   migrated, delete the `#sol_type` write and the `set_sol_type`/
+   `get_sol_type` helpers (`solidity_convert.h:68-75`).
+5. Migrate `#sol_contract`, `#sol_data_loc`, `#sol_state_var`,
+   `#sol_name`, `#sol_mapping_array`, `#sol_dynarray_state`,
+   `#sol_tuple_id` reads → companion; delete each write once its last read
+   is gone (one commit per attribute or tight cluster).
+6. Fold `#sol_array_size` into the real `array_type2t.array_size` path
+   (it is genuine type shape, not metadata) and drop the attribute.
+7. Decide and apply the `bytesN` representation (Q3); move
+   `#sol_bytesn_size` into `sol_typeinfo.bytesn_width`; drop the attribute.
+8. Reclassify the markers `#is_sol_virtual`, `#is_sol_override`,
+   `#inlined`, `#sol_unchecked`, `#member_name`, `#cpp_type`/`cpp_type`,
+   `#is_modifier_placeholder`, `#zero_initializer`: either move to the
+   companion (if read) or delete (if set-only / dead — several are, per
+   §4). Each deletion is a branch-shape change → C-Dead discharge or a
+   cited zero-read grep.
+
+*Exit 3.1: `grep -rn '"#sol' src/solidity-frontend` returns only genuine
+type-shape uses already mapped to IREP2 fields, or nothing. `migrate_type`
+applied to any Solidity-produced type now loses no information.*
+
+### Phase 3.2 — Enabling infrastructure (§6 gaps)
+9. Add the `symbol2tc`-from-`symbolt` helper and the
+   `sideeffect2t(function_call)` / `code_function_call2t` builder wrappers
+   the converter will use, with unit tests. No converter call sites change
+   yet.
+10. Resolve the string/`bytes` literal decoder question (Q4): either port
+    `mb_value` onto `constant_string2t` (verbatim; R10) or fix the seam to
+    keep literal lowering legacy. Land whichever with property tests
+    against the existing CPython-style oracle where applicable.
+
+### Phase 3.3 — Migrate type construction to `type2tc` (internal)
+11. Rewrite `get_type_description` / `get_elementary_type_name` /
+    `get_parameter_list` and the `solidity_convert_type.cpp` builders to
+    produce `type2tc` (companion alongside), back-migrating to `typet`
+    only at `get_default_symbol`/`move_symbol_to_context`. One converter
+    family per commit (elementary → array/mapping → struct/contract →
+    function/code types). `code_type2t` requires `args.size() ==
+    argument_names.size()` (`irep2_type.h:229-241`) — supply names.
+
+### Phase 3.4 — Migrate expression construction to `expr2tc` (internal)
+12. Rewrite the expression converters (`solidity_convert_expr.cpp`,
+    `_ref`, `_call`, `_mapping`, `_tuple`, `_literals`) to build `expr2tc`
+    via typed factories instead of `exprt`/`symbol_expr`/
+    `side_effect_expr_function_callt`/`member_exprt`/`index_exprt`/
+    `address_of_exprt`/`typecast_exprt`. `solidity_convert_call.cpp` is
+    the hotspot (98 of 124 `move_to_operands`); split it across several
+    commits by handler. Back-migrate expressions to `exprt` only where
+    they are stitched into a legacy `codet` body (Phase 3.5 boundary).
+
+### Phase 3.5 — The body boundary (what stays legacy, made explicit)
+13. Localize the legacy hand-off: statement assembly
+    (`solidity_convert_stmt.cpp`) keeps emitting structured legacy `codet`
+    (P1), but its *operands* are now IREP2 lowered via a single
+    `migrate_expr_back` helper at the point each statement is built.
+    Document this as the durable Solidity frontend boundary — the analogue
+    of Part I's `migrate_expr`-at-goto-convert seam.
+
+### Phase 3.6 — Tighten & census
+14. Remove now-dead legacy includes and helpers (`typecast.cpp` wraps
+    `c_typecastt` on legacy `exprt` — keep only if still on the legacy
+    side of the seam; otherwise retire). Snapshot the Solidity IREP2-share
+    census and record it here as Part III's outcome section, mirroring
+    Part II §11.
+
+### Out of scope — separate tracking issues (the deep pins)
+- **IREP2-native goto-convert input** (structured control-flow code
+  kinds + an IREP2 `goto_convert_rec`). Removes P1. Large; affects every
+  frontend.
+- **IREP2-native `clang_cpp_adjust` / `c_link`** (or a Solidity-specific
+  adjust that does not round-trip through legacy). Removes P2. Shared
+  infrastructure.
+- **IREP2-native C printer for Solidity counterexamples** (Part II Phase
+  2.7). Witness/`test.desc` text parity bar.
+
+Until those three land, the Solidity frontend's *bodies* and the
+*adjust/link* post-processing remain legacy, exactly as for every other
+frontend. Part III's deliverable is the de-attributed, IREP2-internal
+converter with a single audited legacy seam — genuine forward progress
+that is fully behaviour-preserving.
+
+## 7.1 Acceptance criteria per phase
+
+| Phase | Done when |
+|---|---|
+| 3.0 | Golden verdict+text set captured on asserts build; `solc`-free run reproduces it; `sol_typeinfo` unit harness compiles and passes against legacy `#sol_*` values. |
+| 3.1 | `grep '"#sol' src/solidity-frontend` empty (or only IREP2-field-backed shape); a deliberate `migrate_type`→`migrate_type_back` round-trip of any Solidity type in a unit test loses no classification; full suite verdict+text set unchanged; dual-solver agreement. |
+| 3.2 | New factories/helpers have round-trip unit tests; no converter call site changed; suite unchanged. |
+| 3.3 | Type converters return `type2tc`; back-migration confined to symbol store; suite verdict+text set unchanged on both solvers; asserts-build cross-check silent. |
+| 3.4 | Expression converters build `expr2tc`; legacy `symbol_expr`/`side_effect_expr_function_callt`/`*_exprt` count in `src/solidity-frontend` strictly decreasing PR-over-PR; suite unchanged. |
+| 3.5 | Exactly one documented `migrate_expr_back` hand-off feeds legacy `codet` bodies; structured CF still lowered by `goto_convert`; suite unchanged. |
+| 3.6 | Census recorded; dead legacy retired with C-Dead discharge; suite unchanged. |
+
+The bar for **every** phase: identical pass/fail set and identical
+matched output text under **both Bitwuzla and Z3**, on an asserts-enabled
+build, over the full `esbmc-solidity` suite.
+
+## 8. Dependencies and prerequisites
+
+- **3.1 blocks everything.** No node may migrate while it still carries
+  semantics that `migrate_type`/`migrate_expr` would drop (F4). This
+  ordering is the single most important correctness decision in the plan.
+- **3.2 blocks 3.3/3.4** (factories must exist and be tested first — the
+  V-track lesson from Part I: land the dead-but-tested infrastructure as
+  its own PR so the wiring PR has zero coverage-axis risk).
+- **3.3 blocks 3.4** (expressions carry their `type2tc`; types must be
+  buildable first).
+- **3.5 depends on P1 staying pinned.** If the out-of-scope IREP2
+  goto-convert ever lands, 3.5's hand-off is where it would connect.
+- **3.4's string/`bytes` work depends on Q4** (mb_value).
+- The whole plan depends on the **goto-binary on-disk format not
+  changing** (Part I, B4) and on the `.solast` input contract (§11).
+
+## 9. Risk register (Solidity-specific; extends Part II §7)
+
+| # | Area | Risk | Sev | Mitigation |
+|---|------|------|-----|------------|
+| RS1 | **soundness** | Attribute drop (F4): any `#sol_*` surviving into a migrated node silently loses Solidity semantics → wrong operational model selected → **silent wrong verdict**. | **critical** | Phase 3.1 first; unit test that round-trips every Solidity type through `migrate_type`/`_back` and asserts the companion is sufficient; `grep '"#sol'` empty as a CI gate. |
+| RS2 | soundness | **Data location** (`#sol_data_loc`): losing `storage` vs `memory` collapses an aliasing write into a local copy (or vice-versa) → missed state-mutation bug (false SUCCESSFUL) or spurious failure. | critical | Model `storage`/`memory`/`calldata` explicitly in `sol_typeinfo`; add focused regression contracts exercising storage-alias vs memory-copy that must keep their current verdicts. |
+| RS3 | soundness | **Type-class confusion** (`#sol_type` MAPPING vs DYNARRAY vs BYTES): drives which c2goto operational model is called; a wrong class emits wrong-semantics code. | critical | 3.1 migrates reads in dependency order with the verdict+text gate after each; the 512-test suite already exercises mapping/array/bytes heavily (`mapping_*`, `bytes_*`, `abi_*`). |
+| RS4 | soundness | **`bytesN` width loss** (`#sol_bytesn_size`): wrong masking/comparison width on fixed-byte types. | high | Decide one `bytesN` representation (Q3); width lives in `sol_typeinfo`; `bytes_*` regression set is the oracle. |
+| RS5 | soundness | **256-bit arithmetic & overflow**: `uint256`/`int256` must map to `*bv_type2t(256)` and overflow/`unchecked` (`#sol_unchecked`) must wrap exactly; a width or check-suppression error flips overflow verdicts. | high | Verify width plumbing end-to-end; keep `--overflow-check` / `--unsigned-overflow-check` Solidity tests green; preserve the `in_unchecked_block` suppression path (`solidity_convert.h:861`). |
+| RS6 | soundness | **Overload binding** between name-identical legacy/IREP2 builders (`gen_zero`, `member`, `symbol_expr` vs `symbol2tc`) — both compile, wrong one binds. | med | Per-site review; lean on `-Werror`; unit equivalence tests (Part II R12). |
+| RS7 | correctness | **`code_type2t` arity assertion** (`assert(args.size()==names.size())`, `irep2_type.h:240`) — Solidity sometimes builds function types without names; will assert at construction. | med | Supply synthesized parameter names in 3.3; covered by asserts build. |
+| RS8 | compatibility | **Counterexample text**: ~21 % of Solidity tests match more than the bare verdict (function names, assertion-coverage counts, line numbers). A construction change that alters symbol naming or pretty-printed types breaks `test.desc` regexes. | high | §10 captures matched text, not just verdict; diff per phase; keep the legacy C printer for Solidity (Part II 2.7 out of scope). |
+| RS9 | scope-creep | The "real" migration tempts touching P1/P2 (goto-convert / adjust). Doing so inside this plan blows the blast radius across all frontends. | med | P1/P2 are separate tracking issues; Part III's seam (3.5) stops at the body boundary. |
+| RS10 | process | `clang_cpp_adjust` already special-cases Solidity (`solidity_language.cpp:362-380` saves/restores sol64 bodies); a construction change can perturb what adjust mutates. | med | Keep the save/restore logic; re-verify the intrinsic + sol64 library bodies are byte-identical post-adjust. |
+
+## 10. Validation, regression & equivalence strategy
+
+Reuse the Part II universal gate, specialized for Solidity. The suite is
+`regression/esbmc-solidity` — **512 test directories**, label
+`esbmc-solidity` (registered when `-DENABLE_SOLIDITY_FRONTEND=On`;
+`regression/CMakeLists.txt`). Distribution: ~312 CORE, ~192 THOROUGH
+(Linux-only), ~8 KNOWNBUG. Per-test timeout default 1200 s.
+
+**Per-phase gate (all must hold, both Bitwuzla and Z3):**
+1. **Verdict set identical** to the 3.0 baseline — same `VERIFICATION
+   SUCCESSFUL`/`FAILED` per test. Verdicts are immune to the
+   model-naming nondeterminism that makes `diff_goto_baseline` unreliable
+   across rebuilds (Part II §8.1), so this is the primary oracle.
+2. **Matched-text identical.** ~21 % of `test.desc` files assert more than
+   the verdict — function names (`github_497_*`: `function func_sat`),
+   assertion-coverage counts (`sol_cov_*`: `Total Asserts:`,
+   `Assertion Instances Coverage: N%`), line numbers. Capture and diff the
+   *matched* lines, not just the verdict. This is the backstop for RS8.
+3. **Asserts-enabled build** so the `migrate.cpp:386-396` symbol round-trip
+   cross-check stays live across the corpus — it is the strongest
+   evidence that whatever the converter now produces is still losslessly
+   convertible.
+4. **Affected unit suites** green, including the new
+   `unit/solidity-frontend/` `sol_typeinfo` equivalence tests.
+5. **Run subset first, full last.** CORE subset (`ctest -L esbmc-solidity
+   -R '<subset>'`) on every commit; the full 512 (THOROUGH included) on
+   phase close. Respect the project 5-minute full-suite cap — narrow scope
+   per commit; the full THOROUGH run is a phase-boundary activity.
+
+**Phase-3.1-specific equivalence test (the load-bearing one):** a unit
+test that, for a representative corpus of solc JSON type nodes, asserts
+`classify_from_json(node) == legacy_#sol_type(node)` for *every* node, and
+that `migrate_type_back(migrate_type(built_type))` followed by re-reading
+the companion yields the same `sol_typeinfo`. This pins RS1.
+
+### 10.1 `solc` and the `.solast` input contract
+The suite ships pre-generated `.solast` JSON (482/512 dirs) and reads it
+directly (`test.desc` line 2); the `--sol contract.sol` flag is
+informational. **No `solc` binary is required to run the regression
+suite** — confirmed: `solc` is absent in this environment and the suite is
+designed to run off committed `.solast`. A frontend refactor is therefore
+validated entirely on committed inputs; regenerating `.solast` is a
+separate upstream concern. Do **not** regenerate `.solast` as part of this
+migration (it would conflate solc-version drift with refactor effects).
+
+## 11. Backward-compatibility considerations
+
+- **Goto-binary on-disk format: unchanged** (Part I, B4 / RETAIN_BOUNDARY).
+  Old `.goto` binaries must still load; the Solidity path produces the
+  same serialized IR.
+- **`.solast` input format: unchanged.** The converter still consumes solc
+  `--ast-compact-json`; §10.1.
+- **CLI surface unchanged:** `--sol`, `--contract`, `--function`,
+  `--focus-function`, `--solc-bin`, `$SOLC` (`solidity_language.cpp:58-79,
+  116-147`).
+- **Counterexample / diagnostic text: must be preserved** where
+  `test.desc` matches it (RS8). The legacy C printer stays (Part II 2.7
+  out of scope), so pretty-printed types and symbol names are stable.
+- **Operational models (sol64, `src/c2goto/library/`):** unchanged; the
+  converter still emits calls into them. The model-selection *logic* is
+  what 3.1 hardens (it must pick the same model), but the models
+  themselves are untouched.
+
+## 12. Success metrics and exit criteria
+
+- **Primary (soundness):** `grep -rn '"#sol' src/solidity-frontend`
+  reaches empty (or only IREP2-field-backed shape), proving no Solidity
+  semantics ride on droppable irep attributes. This is the metric that
+  matters; it closes RS1–RS4 by construction.
+- **Secondary:** the legacy-builder census in `src/solidity-frontend`
+  (`symbol_expr`, `side_effect_expr_function_callt`, `*_exprt`, `code_*t`
+  for non-control-flow) strictly decreasing PR-over-PR; the Solidity
+  IREP2-share rising from <1 % (Part I surface table).
+- **Exit (this plan):** the converter computes Solidity semantics in the
+  typed companion, builds types and statement-operand expressions in
+  IREP2, and hands off to `clang_cpp_adjust`/`goto_convert` through one
+  documented legacy seam (3.5). Function-body control-flow lowering
+  (P1), the shared adjust/link passes (P2), and the Solidity C printer
+  remain legacy under their own tracking issues. Verdict+text parity
+  holds across the full 512-test suite on both solvers.
+
+The bar is Part I's bar: **behaviour-preserving at every step, proven,
+not assumed** — and for a smart-contract verifier, "proven" specifically
+means no `#sol_*` attribute can ever be silently dropped on the way to
+the solver.
+
+## 13. Open questions (resolve before the cited commit)
+
+- **Q-S1** — Is the symbol-`id`-keyed `sol_typeinfo` side-table sufficient,
+  or are there `#sol_*` reads on sub-expression types that never become a
+  named symbol (so need JSON-derived classification instead)? Audit the
+  ~43 `#sol_type` read sites in 3.1 commit 4 and bucket each as
+  "symbol-reachable" vs "must reclassify from JSON." (blocks 3.1)
+- **Q-S2** — Does `clang_cpp_adjust` read any `#sol_*` attribute itself
+  (i.e. is any Solidity semantics consumed *after* the converter, in the
+  shared pass)? If yes, that attribute cannot be made purely
+  frontend-local and the companion must outlive the converter. Grep
+  `clang-cpp-frontend` for `#sol`. (blocks 3.1 / re-scopes P2)
+- **Q-S3** — Canonical `bytesN` representation: `8N`-bit `unsignedbv` vs
+  the existing `bytesN` operational-model struct? Whichever the c2goto
+  models expect; must match to keep `bytes_*` verdicts. (blocks 3.1
+  commit 7)
+- **Q-S4** — Can `constant_string2t` carry the `mb_value` decode the
+  Solidity string/`bytes` literals need, or must literal lowering stay
+  legacy at the seam? (Part II R10/2.6) (blocks 3.4 string work)
+- **Q-S5** — Do any Solidity `test.desc` regexes match counterexample
+  *values* (not just verdict/function-name/coverage)? Sample-grep before
+  3.4; if so, symbol-naming stability becomes a hard 3.4 gate. (sets the
+  RS8 bar)
+- **Q-S6** — Are `#is_sol_virtual` / `#is_sol_override` / `#inlined` /
+  `#sol_tuple_id` ever read, or purely set-only (dead)? §4 shows several
+  with 0 read sites; confirm per-attribute before deleting vs relocating.
+  (blocks 3.1 commit 8)


### PR DESCRIPTION
## What

Extends `docs/irep2-migration.md` with **Part III — Solidity frontend → IREP2 (forward plan)**: an implementation-oriented, phased plan to migrate the Solidity frontend (`src/solidity-frontend/`, ~23.5 kLOC) toward IREP2.

This deliberately **reopens boundary B1** (frontend → goto input), which the Part I retrospective marked *"Deferred indefinitely"* — and says so explicitly, with the evidence that justifies revisiting it for this one frontend.

## Why this shape

The plan is grounded in findings verified against the tree (each carries a `file:line` anchor and a re-verification command in the doc):

- The converter is **100% legacy IR** today, despite its docstring claiming "AST-to-irep2."
- **Function bodies are hard-pinned to legacy `codet`** — `goto_convert_rec` lowers structured control flow that has **no IREP2 representation** (`expr_kinds.inc` carries only the lowered goto-level code kinds). See `goto_convert_functions.cpp:110-139`.
- **`clang_cpp_adjust` + `c_link` run over the converter's output** as shared *legacy* passes (`solidity_language.cpp:370,382`).
- **`migrate_type` silently drops every `#sol_*` attribute** (`migrate.cpp:191-214`) — IREP2 typed nodes have no attribute map. This is the **central verification-soundness hazard**: ~20 Solidity attributes (`#sol_type`, `#sol_data_loc` storage/memory aliasing, `#sol_bytesn_size`, `#sol_contract`, …) encode load-bearing semantics that vanish without diagnostic the moment a node crosses the IREP2 boundary.

## Plan structure

Soundness-first ordering, behaviour-preserving at every step:

- **3.0** baseline (verdict + matched-text capture over the 512-test `esbmc-solidity` suite, asserts build, `solc`-free)
- **3.1 de-attribute** — move all `#sol_*` semantics into a typed off-IR `sol_typeinfo` companion (the prerequisite for everything else)
- **3.2** close IREP2 API gaps → **3.3** types → **3.4** expressions → **3.5** single documented legacy body seam → **3.6** census

It defines the achievable **"IREP2-internal, legacy-at-the-seam"** end-state, scopes the three deep pins (IREP2 goto-convert input, IREP2 adjust/link, native C printer) to their own tracking issues, and includes per-phase **acceptance criteria**, a Solidity-specific **risk register** (RS1–RS10), **validation/regression strategy**, **backward-compatibility** notes, and **open questions**.

## Scope

Documentation only — no code changes. One file, `docs/irep2-migration.md` (+569 lines).
