### PR TITLE
[solidity] encapsulate #sol_array_size behind typed accessors

### DIFF
--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -891,7 +891,7 @@ bool solidity_convertert::populate_auxiliary_vars()
     ct.cmt_constant(true);
     array_typet arr_t(ct, size_expr);
     set_sol_type(arr_t, SolidityGrammar::SolType::ARRAY);
-    arr_t.set("#sol_array_size", std::to_string(length));
+    set_sol_array_size(arr_t, std::to_string(length));
 
     std::string aux_name, aux_id;
     aux_name = "$" + _cname + "_bind_cname_list";

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -74,6 +74,22 @@ public:
     return SolidityGrammar::str_to_sol_type(t.get("#sol_type").as_string());
   }
 
+  // Set/get/test the Solidity array length carried on a typet via the
+  // #sol_array_size irep attribute. The size is stored in its decimal
+  // string form; an absent attribute reads back as the empty string.
+  static void set_sol_array_size(typet &t, const std::string &size)
+  {
+    t.set("#sol_array_size", size);
+  }
+  static std::string get_sol_array_size(const typet &t)
+  {
+    return t.get("#sol_array_size").as_string();
+  }
+  static bool has_sol_array_size(const typet &t)
+  {
+    return !t.get("#sol_array_size").empty();
+  }
+
   // json nodes that always empty
   // used as the return value for find_constructor_ref when
   // dealing with the implicit constructor call

--- a/src/solidity-frontend/solidity_convert_decl.cpp
+++ b/src/solidity-frontend/solidity_convert_decl.cpp
@@ -462,10 +462,10 @@ bool solidity_convertert::get_var_decl(
 
     // get size
     std::string arr_size = "0";
-    if (!t.get("#sol_array_size").empty())
-      arr_size = t.get("#sol_array_size").as_string();
-    else if (t.has_subtype() && !t.subtype().get("#sol_array_size").empty())
-      arr_size = t.subtype().get("#sol_array_size").as_string();
+    if (has_sol_array_size(t))
+      arr_size = get_sol_array_size(t);
+    else if (t.has_subtype() && has_sol_array_size(t.subtype()))
+      arr_size = get_sol_array_size(t.subtype());
     else
     {
       log_error("cannot get the size of fixed array");
@@ -492,7 +492,7 @@ bool solidity_convertert::get_var_decl(
       acpy_call.arguments().push_back(size_of_expr);
       // typecast
       solidity_gen_typecast(ns, acpy_call, t);
-      acpy_call.type().set("#sol_array_size", arr_size);
+      set_sol_array_size(acpy_call.type(), arr_size);
       // set as rvalue
       added_symbol.set_value(acpy_call);
       decl.operands().push_back(acpy_call);

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -1109,7 +1109,7 @@ bool solidity_convertert::get_tuple_expr(
     exprt inits;
     inits = gen_zero(arr_type);
     set_sol_type(inits.type(), SolidityGrammar::SolType::ARRAY_LITERAL);
-    inits.type().set("#sol_array_size", size.cformat().as_string());
+    set_sol_array_size(inits.type(), size.cformat().as_string());
 
     // populate array
     int i = 0;

--- a/src/solidity-frontend/solidity_convert_ref.cpp
+++ b/src/solidity-frontend/solidity_convert_ref.cpp
@@ -508,7 +508,7 @@ bool solidity_convertert::get_sol_builtin_ref(
           else
           {
             // static array:  uint[2] arr; arr.length = 2;
-            std::string arr_size = base_t.get("#sol_array_size").as_string();
+            std::string arr_size = get_sol_array_size(base_t);
             assert(!arr_size.empty());
             new_expr = constant_exprt(
               integer2binary(string2integer(arr_size), bv_width(uint_type())),

--- a/src/solidity-frontend/solidity_convert_type.cpp
+++ b/src/solidity-frontend/solidity_convert_type.cpp
@@ -302,7 +302,7 @@ bool solidity_convertert::get_type_description(
             integer2binary(z_ext_value, bv_width(int_type())),
             integer2string(z_ext_value),
             int_type()));
-        new_type.set("#sol_array_size", outer_size_str);
+        set_sol_array_size(new_type, outer_size_str);
         set_sol_type(new_type, SolidityGrammar::SolType::ARRAY);
       }
     }
@@ -349,7 +349,7 @@ bool solidity_convertert::get_type_description(
           integer2binary(z_ext_value, bv_width(int_type())),
           integer2string(z_ext_value),
           int_type()));
-      new_type.set("#sol_array_size", the_size);
+      set_sol_array_size(new_type, the_size);
       set_sol_type(new_type, SolidityGrammar::SolType::ARRAY_LITERAL);
     }
     else
@@ -1064,7 +1064,7 @@ bool solidity_convertert::get_array_pointer_type(
             decl["typeName"]["length"]["referencedDeclaration"], length))
         return true;
     }
-    new_type.set("#sol_array_size", length);
+    set_sol_array_size(new_type, length);
     set_sol_type(new_type, SolidityGrammar::SolType::ARRAY);
   }
   else
@@ -1141,8 +1141,7 @@ void solidity_convertert::convert_type_expr(
       src_type.get("#sol_bytesn_size") != dest_type.get("#sol_bytesn_size"))
       // including unset situation
       not_same_type = true;
-    else if (
-      src_type.get("#sol_array_size") != dest_type.get("#sol_array_size"))
+    else if (get_sol_array_size(src_type) != get_sol_array_size(dest_type))
       not_same_type = true;
   }
 
@@ -1478,7 +1477,7 @@ void solidity_convertert::convert_type_expr(
       // the goal is to convert the rhs constant array to a static global var
 
       // get rhs constant array size
-      const std::string src_size = src_type.get("#sol_array_size").as_string();
+      const std::string src_size = get_sol_array_size(src_type);
       if (src_size.empty())
       {
         // e.g. a = new uint[](len);
@@ -1490,7 +1489,7 @@ void solidity_convertert::convert_type_expr(
       unsigned z_src_size = std::stoul(src_size, nullptr);
 
       // get lhs array size
-      std::string dest_size = dest_type.get("#sol_array_size").as_string();
+      std::string dest_size = get_sol_array_size(dest_type);
       if (dest_size.empty())
       {
         if (dest_sol_type == SolidityGrammar::SolType::ARRAY)
@@ -1518,7 +1517,7 @@ void solidity_convertert::convert_type_expr(
         // - dest_type: uint*
         array_typet arr_t = array_typet(dest_type.subtype(), dest_array_size);
         set_sol_type(arr_t, SolidityGrammar::SolType::ARRAY);
-        arr_t.set("#sol_array_size", src_size);
+        set_sol_array_size(arr_t, src_size);
         exprt new_arr = exprt(irept::id_array, arr_t);
 
         exprt arr_comp;
@@ -1574,7 +1573,7 @@ void solidity_convertert::convert_type_expr(
 
           // update "#sol_array_size"
           assert(!dest_size.empty());
-          src_expr.type().set("#sol_array_size", dest_size);
+          set_sol_array_size(src_expr.type(), dest_size);
         }
       }
 

--- a/src/solidity-frontend/solidity_convert_util.cpp
+++ b/src/solidity-frontend/solidity_convert_util.cpp
@@ -666,7 +666,7 @@ void solidity_convertert::get_aux_array(
   std::string debug_modulename =
     get_modulename_from_path(loc.file().as_string());
 
-  assert(!new_src_expr.type().get("#sol_array_size").empty());
+  assert(has_sol_array_size(new_src_expr.type()));
   typet t = new_src_expr.type();
 
   symbolt sym;
@@ -685,10 +685,10 @@ void solidity_convertert::get_size_expr(const exprt &rhs, exprt &size_expr)
   typet rt = rhs.type();
 
   unsigned int arr_size = 0;
-  if (!rt.get("#sol_array_size").empty())
-    arr_size = std::stoi(rt.get("#sol_array_size").as_string());
-  else if (rt.has_subtype() && !rt.subtype().get("#sol_array_size").empty())
-    arr_size = std::stoi(rt.subtype().get("#sol_array_size").as_string());
+  if (has_sol_array_size(rt))
+    arr_size = std::stoi(get_sol_array_size(rt));
+  else if (rt.has_subtype() && has_sol_array_size(rt.subtype()))
+    arr_size = std::stoi(get_sol_array_size(rt.subtype()));
   else
   {
     // arr_size = _ESBMC_array_length(rhs);


### PR DESCRIPTION
## Summary

Encapsulates all access to the `#sol_array_size` irep attribute in the Solidity frontend behind three typed static helpers on `solidity_convertert`:

```cpp
static void        set_sol_array_size(typet &t, const std::string &size);
static std::string get_sol_array_size(const typet &t);
static bool        has_sol_array_size(const typet &t);
```

The 8 set sites and 13 get sites that previously called `t.set("#sol_array_size", …)` / `t.get("#sol_array_size")` directly now go through this single seam. No raw access to the attribute string remains outside the three helper bodies.

This is the first concrete step of **Phase 3.1** of the Solidity → irep2 migration plan (`docs/irep2-migration.md`, Part III, merged in #4950).

## Rationale

The plan's central finding (F4) is that `migrate_type` **silently drops** every `#sol_*` attribute — they have no field on the typed `type2t` classes. So before any Solidity type can be migrated to `type2tc`, the frontend's dependence on IR-carried metadata must be funneled through accessors that can later be repointed at a typed, off-IR companion **without touching call sites again**.

`#sol_type` was already encapsulated (`get_sol_type`/`set_sol_type`); this PR brings `#sol_array_size` to the same standard. The approach is deliberately mechanical — a chokepoint refactor, not a behaviour change — to keep it trivially reviewable and low risk, per the migration's "behaviour-preserving at every step" constraint.

## Remaining legacy dependencies

- The attribute is still stored on the legacy `typet` (string key `#sol_array_size`); this PR only centralizes access. Moving storage off-IR is a later phase, now a localized change behind these helpers.
- `get_sol_array_size` returns the decimal-string form (matching the previous `.as_string()` usage); callers still `std::stoi`/`string2integer` it. Genuine type-shape sizes will fold into `array_type2t.array_size` in Phase 3.1 (plan §7, commit 6).
- Adjacent attributes (`#sol_bytesn_size`, `#sol_contract`, …) are untouched and handled in follow-up PRs.

## Testing performed

- **Compiles cleanly**: incremental `ninja -C build esbmc` succeeds (Z3 + Bitwuzla, `-DENABLE_SOLIDITY_FRONTEND=On`), no new warnings.
- **Formatting**: the added accessor block and all edits match the project style (identical to the existing `get_sol_type` helpers); `clang-format` reports no diff on the changed regions.
- **Equivalence**: every edit is a 1:1 substitution preserving the same key, storage, and indentation; the one comparison site (`get_sol_array_size(a) != get_sol_array_size(b)`) is equivalent to the prior `irep_idt` comparison because interning makes `irep_idt` equality ⇔ string equality.
- **Note on regression verdicts**: the `esbmc-solidity` suite cannot run locally on macOS — the `sol64` operational models are stubbed to empty there (`_BitInt(256)` is unavailable on Apple's aarch64 target; see `src/c2goto/CMakeLists.txt`), so every contract test fails with `'' is not a goto-binary` regardless of the patch. Verdict validation therefore relies on **Linux CI**, where the change — being a mechanical no-op on the IR — is expected to leave all verdicts unchanged.

## Recommended next steps

1. **PR2**: same encapsulation for `#sol_bytesn_size` (17 raw sites).
2. **PR3+**: `#sol_contract`, `#sol_data_loc`, `#sol_state_var`, `#sol_name`, `#sol_mapping_array`, `#sol_dynarray_state`, `#member_name`, and the marker flags.
3. Once every `#sol_*` is behind a typed accessor, introduce the off-IR `sol_typeinfo` companion and repoint the accessors at it (Phase 3.1), unblocking the type-construction migration to `type2tc` (Phase 3.3).
