### PR TITLE
[solidity] encapsulate #sol_bytesn_size behind typed accessors

### DIFF
--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -90,6 +90,27 @@ public:
     return !t.get("#sol_array_size").empty();
   }
 
+  // Set/get/test the Solidity fixed-bytes (bytesN) width carried on a typet
+  // via the #sol_bytesn_size irep attribute, stored in its decimal form. Two
+  // setter overloads mirror irept::set: integral widths use the long form,
+  // already-stringified widths (copied between types) use the irep_idt form.
+  static void set_sol_bytesn_size(typet &t, long size)
+  {
+    t.set("#sol_bytesn_size", size);
+  }
+  static void set_sol_bytesn_size(typet &t, const irep_idt &size)
+  {
+    t.set("#sol_bytesn_size", size);
+  }
+  static std::string get_sol_bytesn_size(const typet &t)
+  {
+    return t.get("#sol_bytesn_size").as_string();
+  }
+  static bool has_sol_bytesn_size(const typet &t)
+  {
+    return !t.get("#sol_bytesn_size").empty();
+  }
+
   // json nodes that always empty
   // used as the return value for find_constructor_ref when
   // dealing with the implicit constructor call

--- a/src/solidity-frontend/solidity_convert_decl.cpp
+++ b/src/solidity-frontend/solidity_convert_decl.cpp
@@ -701,9 +701,8 @@ bool solidity_convertert::get_var_decl(
       t,
       location_begin,
       call);
-    assert(!t.get("#sol_bytesn_size").empty());
-    exprt len = from_integer(
-      std::stoul(t.get("#sol_bytesn_size").as_string()), uint_type());
+    assert(has_sol_bytesn_size(t));
+    exprt len = from_integer(std::stoul(get_sol_bytesn_size(t)), uint_type());
     call.arguments().push_back(len);
     added_symbol.set_value(call);
     decl.operands().push_back(call);

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -861,8 +861,8 @@ bool solidity_convertert::get_literal_expr(
     std::string expected_size;
     if (is_static)
     {
-      assert(!byte_t.get("#sol_bytesn_size").empty());
-      expected_size = byte_t.get("#sol_bytesn_size").as_string();
+      assert(has_sol_bytesn_size(byte_t));
+      expected_size = get_sol_bytesn_size(byte_t);
     }
 
     if (type_name == SolidityGrammar::ElementaryTypeNameT::INT_LITERAL)
@@ -906,7 +906,7 @@ bool solidity_convertert::get_literal_expr(
           byte_t,
           location,
           call);
-        assert(!byte_t.get("#sol_bytesn_size").empty());
+        assert(has_sol_bytesn_size(byte_t));
         exprt len = from_integer(std::stoul(expected_size), uint_type());
         call.arguments().push_back(len);
       }
@@ -917,7 +917,7 @@ bool solidity_convertert::get_literal_expr(
         return true;
       }
       set_sol_type(call.type(), SolidityGrammar::SolType::BYTES_STATIC);
-      call.type().set("#sol_bytesn_size", expected_size);
+      set_sol_bytesn_size(call.type(), expected_size);
       new_expr = make_aux_var(call, location);
       return false;
     }
@@ -934,7 +934,7 @@ bool solidity_convertert::get_literal_expr(
       // add padding
       if (is_static && is_hex_string)
       {
-        assert(!byte_t.get("#sol_bytesn_size").empty());
+        assert(has_sol_bytesn_size(byte_t));
         size_t actual_len = val_str.length() / 2;
         size_t expected_len = std::stoul(expected_size);
 
@@ -985,7 +985,7 @@ bool solidity_convertert::get_literal_expr(
       else
       {
         set_sol_type(str_call.type(), SolidityGrammar::SolType::BYTES_STATIC);
-        str_call.type().set("#sol_bytesn_size", byte_t.get("#sol_bytesn_size"));
+        set_sol_bytesn_size(str_call.type(), get_sol_bytesn_size(byte_t));
       }
       new_expr = make_aux_var(str_call, location);
       return false;
@@ -2002,7 +2002,7 @@ bool solidity_convertert::get_index_access_expr(
   {
     bool is_bytes_set = is_mapping_set_lvalue(expr); // set vs get
     typet result_type = byte_static_t;
-    result_type.set("#sol_bytesn_size", 1);
+    set_sol_bytesn_size(result_type, 1);
 
     std::string aux_name, aux_id;
     get_aux_var(aux_name, aux_id);

--- a/src/solidity-frontend/solidity_convert_literals.cpp
+++ b/src/solidity-frontend/solidity_convert_literals.cpp
@@ -150,7 +150,7 @@ bool solidity_convertert::convert_hex_literal(
     integer2binary(hex_addr, bv_width(type)), integer2string(hex_addr), type);
 
   dest.swap(the_val);
-  dest.type().set("#sol_bytesn_size", the_value.length() / 2);
+  set_sol_bytesn_size(dest.type(), the_value.length() / 2);
   return false;
 }
 

--- a/src/solidity-frontend/solidity_convert_mapping.cpp
+++ b/src/solidity-frontend/solidity_convert_mapping.cpp
@@ -75,7 +75,7 @@ void solidity_convertert::get_bytesN_size(
   const exprt &src_expr,
   exprt &len_expr)
 {
-  std::string byte_size = src_expr.type().get("#sol_bytesn_size").as_string();
+  std::string byte_size = get_sol_bytesn_size(src_expr.type());
   if (!byte_size.empty())
     len_expr = from_integer(std::stoul(byte_size), size_type());
   else

--- a/src/solidity-frontend/solidity_convert_type.cpp
+++ b/src/solidity-frontend/solidity_convert_type.cpp
@@ -914,7 +914,7 @@ bool solidity_convertert::get_elementary_type_name(
   case SolidityGrammar::ElementaryTypeNameT::BYTES32:
   {
     new_type = byte_static_t;
-    new_type.set("#sol_bytesn_size", bytesn_type_name_to_size(type));
+    set_sol_bytesn_size(new_type, bytesn_type_name_to_size(type));
     break;
   }
   case SolidityGrammar::ElementaryTypeNameT::BYTES:
@@ -1137,8 +1137,7 @@ void solidity_convertert::convert_type_expr(
   {
     if (src_sol_type != dest_sol_type)
       not_same_type = true;
-    else if (
-      src_type.get("#sol_bytesn_size") != dest_type.get("#sol_bytesn_size"))
+    else if (get_sol_bytesn_size(src_type) != get_sol_bytesn_size(dest_type))
       // including unset situation
       not_same_type = true;
     else if (get_sol_array_size(src_type) != get_sol_array_size(dest_type))
@@ -1300,10 +1299,9 @@ void solidity_convertert::convert_type_expr(
 
         // e.g. bytes3(0x1234); "BYTES3" => 3
         exprt len_expr;
-        if (!dest_type.get("#sol_bytesn_size").empty())
+        if (has_sol_bytesn_size(dest_type))
           len_expr = from_integer(
-            std::stoul(dest_type.get("#sol_bytesn_size").as_string()),
-            size_type());
+            std::stoul(get_sol_bytesn_size(dest_type)), size_type());
         else
         {
           log_error("got unexpected bytes typecast");


### PR DESCRIPTION
## Summary

Encapsulates all access to the `#sol_bytesn_size` irep attribute (the Solidity fixed-bytes `bytesN` width) behind typed static helpers on `solidity_convertert`:

```cpp
static void        set_sol_bytesn_size(typet &t, long size);            // integral widths
static void        set_sol_bytesn_size(typet &t, const irep_idt &size); // copied/stringified widths
static std::string get_sol_bytesn_size(const typet &t);
static bool        has_sol_bytesn_size(const typet &t);
```

The 5 set sites and 12 get sites that previously poked the attribute directly now go through this seam. No raw access remains outside the four helper bodies.

Follow-up to #4951; same pattern, next attribute. Phase 3.1 of the Solidity → irep2 plan (`docs/irep2-migration.md`, Part III).

> **Stacked on #4951.** Base branch is `refactor/sol-array-size-accessors`; GitHub will retarget this PR to `master` automatically once #4951 merges. Review just this PR's own diff.

## Rationale

Same as #4951: `migrate_type` silently drops `#sol_*` attributes, so each must be funneled through an accessor that can later be repointed at a typed off-IR companion without re-touching call sites.

`#sol_bytesn_size` is stored as an **integer** at most sites (`set(name, long)`), but two sites copy an already-stored width between types as a string/`irep_idt`. To preserve every site's exact semantics with zero added conversions, the setter has two overloads mirroring the two `irept::set` overloads in use (`long` and `const irep_idt&`). Overload resolution is unambiguous at every call site (integers → `long`; `std::string`/`irep_idt` → `irep_idt`), which the successful build confirms.

## Remaining legacy dependencies

- The width is still stored on the legacy `typet` under the `#sol_bytesn_size` key; this PR only centralizes access.
- `get_sol_bytesn_size` returns the decimal-string form (matching prior `.as_string()` usage); numeric consumers still `std::stoul` it. A future phase will fold `bytesN` width into the chosen irep2 representation (plan §6, Q-S3) once the off-IR companion exists.

## Testing performed

- **Compiles cleanly**: incremental `ninja -C build esbmc` succeeds (Z3 + Bitwuzla, `-DENABLE_SOLIDITY_FRONTEND=On`), no new warnings/errors. The build is also the overload-resolution check for the two `set_sol_bytesn_size` forms.
- **Formatting**: added block and edits match project style; `clang-format` shows no diff on changed regions.
- **Equivalence**: each edit is a 1:1 substitution preserving the same key, the same underlying `irept::set` overload, and the same stored decimal value; the `!=` comparison site is equivalent (`irep_idt` equality ⇔ string equality via interning).
- **Regression verdicts**: as in #4951, the `esbmc-solidity` suite can't run locally on macOS (empty `sol64` models — `_BitInt(256)` unavailable on Apple aarch64); verdict validation relies on **Linux CI**. The change is a mechanical no-op on the IR.

## Recommended next steps

1. **PR3+**: encapsulate the remaining raw attributes — `#sol_contract`, `#sol_data_loc`, `#sol_state_var`, `#sol_name`, `#sol_mapping_array`, `#sol_dynarray_state`, `#member_name`, and the marker flags (`#is_sol_virtual`, `#is_sol_override`, `#inlined`, `#sol_unchecked`, …), grouped coherently per PR.
2. Introduce the off-IR `sol_typeinfo` companion and repoint all accessors at it (Phase 3.1), then begin migrating type construction to `type2tc` (Phase 3.3).
