### PR TITLE
[solidity] encapsulate #sol_contract behind typed accessors

### DIFF
--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -111,6 +111,21 @@ public:
     return !t.get("#sol_bytesn_size").empty();
   }
 
+  // Set/get/test the Solidity contract name carried on a typet via the
+  // #sol_contract irep attribute (the declaring contract of a contract type).
+  static void set_sol_contract(typet &t, const irep_idt &cname)
+  {
+    t.set("#sol_contract", cname);
+  }
+  static std::string get_sol_contract(const typet &t)
+  {
+    return t.get("#sol_contract").as_string();
+  }
+  static bool has_sol_contract(const typet &t)
+  {
+    return !t.get("#sol_contract").empty();
+  }
+
   // json nodes that always empty
   // used as the return value for find_constructor_ref when
   // dealing with the implicit constructor call

--- a/src/solidity-frontend/solidity_convert_call.cpp
+++ b/src/solidity-frontend/solidity_convert_call.cpp
@@ -281,7 +281,7 @@ void solidity_convertert::extract_new_contracts()
           }
           if (get_sol_type(new_type) == SolidityGrammar::SolType::CONTRACT)
           {
-            std::string contract_name = new_type.get("#sol_contract").c_str();
+            std::string contract_name = get_sol_contract(new_type);
             newContractSet.insert(contract_name);
           }
         }
@@ -322,13 +322,13 @@ bool solidity_convertert::get_base_contract_name(
 {
   log_debug("solidity", "\t\t@@@ get_base_contract_name");
 
-  if (base.type().get("#sol_contract").as_string().empty())
+  if (!has_sol_contract(base.type()))
   {
     log_error("cannot find base contract name");
     return true;
   }
 
-  cname = base.type().get("#sol_contract").as_string();
+  cname = get_sol_contract(base.type());
   return false;
 }
 
@@ -441,7 +441,7 @@ bool solidity_convertert::assign_param_nondet(
               / / where its cname = ["Base", "Derive"]
             }
           */
-        std::string base_cname = t.get("#sol_contract").as_string();
+        std::string base_cname = get_sol_contract(t);
         assert(!base_cname.empty());
         exprt s;
         get_static_contract_instance_ref(base_cname, s);

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -1686,7 +1686,7 @@ bool solidity_convertert::get_contract_member_call_expr(
   {
     if (get_var_decl_ref(base_expr_json, true, base))
       return true;
-    base_cname = base.type().get("#sol_contract").as_string();
+    base_cname = get_sol_contract(base.type());
     assert(!base_cname.empty());
   }
 

--- a/src/solidity-frontend/solidity_convert_type.cpp
+++ b/src/solidity-frontend/solidity_convert_type.cpp
@@ -436,7 +436,7 @@ bool solidity_convertert::get_type_description(
 
     new_type = pointer_typet(symbol_typet(id));
     set_sol_type(new_type, SolidityGrammar::SolType::CONTRACT);
-    new_type.set("#sol_contract", cname);
+    set_sol_contract(new_type, cname);
     break;
   }
   case SolidityGrammar::TypeNameT::TypeConversionName:
@@ -1436,7 +1436,7 @@ void solidity_convertert::convert_type_expr(
       exprt original_addr = src_expr;
 
       exprt c_ins;
-      std::string _cname = dest_type.get("#sol_contract").as_string();
+      std::string _cname = get_sol_contract(dest_type);
       get_static_contract_instance_ref(_cname, c_ins);
 
       // Propagate the cast address into the singleton's $address member


### PR DESCRIPTION
## Summary

Encapsulates all access to the `#sol_contract` irep attribute (the declaring contract name carried on a contract `typet`) behind typed static helpers on `solidity_convertert`:

```cpp
static void        set_sol_contract(typet &t, const irep_idt &cname);
static std::string get_sol_contract(const typet &t);
static bool        has_sol_contract(const typet &t);
```

The 1 set site and 6 get sites that previously poked the attribute directly now go through this seam. No raw access remains outside the three helper bodies.

Third in the series (follows #4951 `#sol_array_size`, #4952 `#sol_bytesn_size`); first non-size, purely-metadata attribute, showing the pattern generalizes. Phase 3.1 of the Solidity → irep2 plan (`docs/irep2-migration.md`, Part III).

> **Stacked on #4952 → #4951.** Base branch is `refactor/sol-bytesn-size-accessors`; GitHub retargets to `master` automatically as the parents merge. Review just this PR's own diff.

## Rationale

`#sol_contract` drives contract-member-call dispatch and `new`-expression handling — semantics that `migrate_type` would silently drop, since `type2t` has no attribute map. Funneling every read through `get_sol_contract` is the prerequisite for relocating this metadata to a typed off-IR companion (Phase 3.1) without re-touching call sites.

The one emptiness check (`...as_string().empty()`) becomes `!has_sol_contract(...)`; the `.c_str()`-to-`std::string` read becomes `get_sol_contract(...)` (equivalent — both yield the stored name as a `std::string`).

## Remaining legacy dependencies

- The name is still stored on the legacy `typet` under `#sol_contract`; this PR only centralizes access. Contract identity will move into the `sol_typeinfo` companion alongside `#sol_type` in the upcoming Phase 3.1 step.

## Testing performed

- **Compiles cleanly**: incremental `ninja -C build esbmc` succeeds (Z3 + Bitwuzla, `-DENABLE_SOLIDITY_FRONTEND=On`), no new warnings/errors.
- **Formatting**: added block and edits match project style; `clang-format` shows no diff on changed regions.
- **Equivalence**: each edit is a 1:1 substitution preserving the same key and stored value.
- **Regression verdicts**: as in #4951/#4952, the `esbmc-solidity` suite can't run locally on macOS (empty `sol64` models — `_BitInt(256)` unavailable on Apple aarch64); verdict validation relies on **Linux CI**. This change is a mechanical no-op on the IR.

## Recommended next steps

1. Continue encapsulating the remaining read-bearing attributes: `#sol_data_loc`, `#sol_state_var`, `#sol_name`, `#sol_mapping_array`, `#sol_dynarray_state`, `#member_name` (set-only markers like `#inlined`, `#is_sol_virtual`, `#cpp_type` are lower priority — no read chokepoint needed).
2. Once all read-bearing `#sol_*` are behind accessors, introduce the off-IR `sol_typeinfo` companion and repoint every accessor at it (completing Phase 3.1) — this is what removes the silent-attribute-drop hazard and unblocks migrating Solidity type construction to `type2tc` (Phase 3.3).
