### PR TITLE
[regression] reclassify polymorphism_common_error_3 as CORE

### DIFF
--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/main.cpp
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/main.cpp
@@ -1,5 +1,8 @@
-//treat with a base class object like a derived class object
-//it can generate a compilation error
+// `new Shape` is well-formed: Shape's virtual functions are declared but not
+// pure, so Shape is not abstract. Their missing definitions are only a
+// link-time error (missing vtable, ill-formed but no diagnostic required per
+// [basic.def.odr]) and are never reached here, so ESBMC reports VERIFICATION
+// SUCCESSFUL. (ESBMC's legacy C++ frontend wrongly reported CONVERSION ERROR.)
 #include <iostream>
 using namespace std;
 

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
-^CONVERSION ERROR$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_3/main.cpp
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_3/main.cpp
@@ -1,5 +1,8 @@
-//treat with a base class object like a derived class object
-//it can generate a compilation error
+// `new Shape` is well-formed: Shape's virtual functions are declared but not
+// pure, so Shape is not abstract. Their missing definitions are only a
+// link-time error (missing vtable, ill-formed but no diagnostic required per
+// [basic.def.odr]) and are never reached here, so ESBMC reports VERIFICATION
+// SUCCESSFUL. (ESBMC's legacy C++ frontend wrongly reported CONVERSION ERROR.)
 
 class Shape{
   public:

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_3/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_3/test.desc
@@ -1,5 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
-
-^ERROR: CONVERSION ERROR$
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## What

`polymorphism_common_error_3` was marked `KNOWNBUG` expecting `CONVERSION ERROR`. This reclassifies it to `CORE` / `VERIFICATION SUCCESSFUL` to match ESBMC's correct current behavior, and fixes the now-inaccurate source comment. The change is applied to **both** copies of the test (`esbmc-cpp/inheritance/` and `esbmc-cpp/polymorphism_bringup/`).

## Why

The `CONVERSION ERROR` expectation is a leftover from ESBMC's legacy (pre-Clang) C++ frontend. The test program is well-formed at compile time:

```cpp
class Shape {
public:
  virtual int area(void);       // declared, NOT pure, never defined
  virtual void printArea(void); // declared, NOT pure, never defined
};
int main() { Shape *sh = new Shape; return 0; }
```

- `Shape` is **not abstract** (its virtuals are declared, not pure `= 0`), so `new Shape` is valid.
- The undefined virtuals are an ODR issue that only manifests at **link time** (missing vtable) — ill-formed, no diagnostic required per `[basic.def.odr]`.
- They are never called, so there is no reachable error.

Real-toolchain confirmation:
- `clang++ -c main.cpp` → exit 0 (compiles cleanly; no conversion/parse error).
- `clang++ main.cpp` → *link* error only: `Undefined symbols: vtable for Shape`.

So ESBMC reporting `VERIFICATION SUCCESSFUL` is correct. It is also consistent with the sibling tests `polymorphism_common_error_{1,2,4}`, whose mistakes *are* parse-time detectable (`.` on a pointer / instantiating an abstract class) and are therefore expected as `ERROR: PARSING ERROR`.

## Testing

- Both copies pass: `ctest -R polymorphism_common_error_3` → **2/2 passed**.
- No regressions in the affected suites: `esbmc-cpp/inheritance` (67) + `esbmc-cpp/polymorphism_bringup` (45) → **112/112 passed**.

## Note

This is a test-expectation correction with **no ESBMC code change** — it aligns a stale `KNOWNBUG` with existing, already-correct behavior, so no new tests are added.
