### PR TITLE
[goto] fix scanf overflow check skipped on &arr[i] (#4956)

### DIFF
--- a/regression/cstd/scanf_malloc_inbounds/main.c
+++ b/regression/cstd/scanf_malloc_inbounds/main.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+// Companion to scanf_malloc_bug_3: same malloc'd int buffer, but the scanf
+// field width (%9d) fits a 32-bit int, so the input-overflow check must NOT
+// fire. Exercises the &arr[i] pointer-arithmetic path in
+// goto_checkt::input_overflow_check and guards against over-triggering.
+int main(int argc, char *argv[])
+{
+  int *arr = (int *)malloc(3 * sizeof(int));
+  for(int i = 0; i < 3; i++)
+  {
+    scanf("%9d", &arr[i]);
+  }
+  return 0;
+}

--- a/regression/cstd/scanf_malloc_inbounds/test.desc
+++ b/regression/cstd/scanf_malloc_inbounds/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check -Wno-error=implicit-function-declaration
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -454,30 +454,27 @@ void goto_checkt::input_overflow_check(
   for (long unsigned int i = fmt_idx + 1; i <= number_of_format_args + fmt_idx;
        i++)
   {
-    const expr2tc &base_expr = get_base_object(func_call.operands[i]);
+    expr2tc base_expr = get_base_object(func_call.operands[i]);
     irep_idt arg_name;
-    if (is_symbol2t(base_expr))
-      arg_name = to_symbol2t(base_expr).thename;
 
     // e.g
     // int *arr = (int*) malloc(10 * sizeof(int));
     // scanf("%13d",&arr[0]);  --> overflow
-    if (arg_name.empty())
+    //
+    // `&arr[i]` is lowered to pointer arithmetic `arr + i` (an add2t),
+    // which get_base_object does not peel.  Descend into the pointer-typed
+    // operand to recover the underlying buffer symbol.
+    if ((is_add2t(base_expr) || is_sub2t(base_expr)) &&
+        is_pointer_type(base_expr))
     {
-      expr2tc deref = get_base_object(func_call.operands[i]);
-
-      // not the format we expected
-      if (!is_pointer_type(deref))
-        return;
-
-      // we expect an address_of(symbol) underneath
-      if (!is_address_of2t(deref))
-        return;
-      const expr2tc &target = to_address_of2t(deref).ptr_obj;
-      if (!is_symbol2t(target))
-        return;
-      arg_name = to_symbol2t(target).thename;
+      const expr2tc &lhs = *base_expr->get_sub_expr(0);
+      const expr2tc &rhs = *base_expr->get_sub_expr(1);
+      base_expr = get_base_object(is_pointer_type(lhs) ? lhs : rhs);
     }
+
+    if (is_symbol2t(base_expr))
+      arg_name = to_symbol2t(base_expr).thename;
+
     arg_names.push_back(arg_name);
   }
 

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -464,8 +464,9 @@ void goto_checkt::input_overflow_check(
     // `&arr[i]` is lowered to pointer arithmetic `arr + i` (an add2t),
     // which get_base_object does not peel.  Descend into the pointer-typed
     // operand to recover the underlying buffer symbol.
-    if ((is_add2t(base_expr) || is_sub2t(base_expr)) &&
-        is_pointer_type(base_expr))
+    if (
+      (is_add2t(base_expr) || is_sub2t(base_expr)) &&
+      is_pointer_type(base_expr))
     {
       const expr2tc &lhs = *base_expr->get_sub_expr(0);
       const expr2tc &rhs = *base_expr->get_sub_expr(1);


### PR DESCRIPTION
`get_base_object()` strips `address_of` and `&arr[i]` lowers to pointer arithmetic (an `add2t`), so `input_overflow_check`'s `is_address_of2t` branch (added in #4946) was dead and the scanf buffer-overflow check was silently skipped — flipping `scanf_bigint_2` / `scanf_malloc_bug_3` to SUCCESSFUL. Peel the pointer-typed operand of the add/sub to recover the buffer symbol instead.

Restores deterministic detection under both Bitwuzla and Z3 (the verdict was never solver/LLVM drift). Adds an in-bounds companion test `scanf_malloc_inbounds` (`%9d` → SUCCESSFUL) to guard against over-triggering.

Fixes #4956