### PR TITLE
[solidity] encapsulate remaining read-bearing #sol_* attributes

### DIFF
--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -126,6 +126,50 @@ public:
     return !t.get("#sol_contract").empty();
   }
 
+  // Set/get the Solidity "mapping-backed array" flag carried on a typet via
+  // the #sol_mapping_array irep attribute.
+  static void set_sol_mapping_array(typet &t, bool v)
+  {
+    t.set("#sol_mapping_array", v);
+  }
+  static bool get_sol_mapping_array(const typet &t)
+  {
+    return t.get_bool("#sol_mapping_array");
+  }
+
+  // Set/get the Solidity "state-variable dynamic array" flag carried on a
+  // typet via the #sol_dynarray_state irep attribute.
+  static void set_sol_dynarray_state(typet &t, bool v)
+  {
+    t.set("#sol_dynarray_state", v);
+  }
+  static bool get_sol_dynarray_state(const typet &t)
+  {
+    return t.get_bool("#sol_dynarray_state");
+  }
+
+  // Set/get the Solidity "state variable" flag carried on a typet via the
+  // #sol_state_var irep attribute (stored as "1"/"0").
+  static void set_sol_state_var(typet &t, bool v)
+  {
+    t.set("#sol_state_var", v ? "1" : "0");
+  }
+  static bool get_sol_state_var(const typet &t)
+  {
+    return t.get("#sol_state_var") == "1";
+  }
+
+  // Set/get the Solidity builtin name carried on a typet via the #sol_name
+  // irep attribute.
+  static void set_sol_name(typet &t, const irep_idt &name)
+  {
+    t.set("#sol_name", name);
+  }
+  static std::string get_sol_name(const typet &t)
+  {
+    return t.get("#sol_name").as_string();
+  }
+
   // json nodes that always empty
   // used as the return value for find_constructor_ref when
   // dealing with the implicit constructor call

--- a/src/solidity-frontend/solidity_convert_builtin.cpp
+++ b/src/solidity-frontend/solidity_convert_builtin.cpp
@@ -305,7 +305,7 @@ void solidity_convertert::get_builtin_symbol(
   get_default_symbol(sym, "C++", t, name, id, l);
   {
     typet st = sym.get_type();
-    st.set("#sol_state_var", "1");
+    set_sol_state_var(st, true);
     sym.set_type(std::move(st));
   }
   sym.file_local = true;

--- a/src/solidity-frontend/solidity_convert_constructor.cpp
+++ b/src/solidity-frontend/solidity_convert_constructor.cpp
@@ -473,7 +473,7 @@ bool solidity_convertert::move_initializer_to_ctor(
         "\t@@@ initializing symbol {} in the constructor",
         comp.name().as_string());
 
-      bool is_state = comp.type().get("#sol_state_var") == "1";
+      bool is_state = get_sol_state_var(comp.type());
       if (!is_state)
       {
         // auxiliary local variable we created

--- a/src/solidity-frontend/solidity_convert_decl.cpp
+++ b/src/solidity-frontend/solidity_convert_decl.cpp
@@ -195,7 +195,7 @@ bool solidity_convertert::get_var_decl(
     get_sol_type(t) == SolidityGrammar::SolType::CONTRACT ? true : false;
   bool is_mapping =
     get_sol_type(t) == SolidityGrammar::SolType::MAPPING ? true : false;
-  bool is_mapping_array = t.get_bool("#sol_mapping_array");
+  bool is_mapping_array = get_sol_mapping_array(t);
   bool is_new_expr = should_treat_as_new(current_contractName);
   bool is_byte_static = is_bytesN_type(t);
   // Detect state-var dynamic arrays: model as infinite SMT array + length var
@@ -203,7 +203,7 @@ bool solidity_convertert::get_var_decl(
     ast_node.contains("stateVariable") && ast_node["stateVariable"].get<bool>();
   bool is_dynarray_state =
     get_sol_type(t) == SolidityGrammar::SolType::DYNARRAY &&
-    is_state_var_check && !is_new_expr && !t.get_bool("#sol_mapping_array");
+    is_state_var_check && !is_new_expr && !get_sol_mapping_array(t);
 
   // for mapping: populate the element type (recursively for nested mappings)
   if (is_mapping && !is_new_expr)
@@ -269,7 +269,7 @@ bool solidity_convertert::get_var_decl(
     typet elem_type = t.subtype();
     t = array_typet(elem_type, exprt("infinity"));
     set_sol_type(t, SolidityGrammar::SolType::DYNARRAY);
-    t.set("#sol_dynarray_state", true);
+    set_sol_dynarray_state(t, true);
   }
 
   // set const qualifier
@@ -282,7 +282,7 @@ bool solidity_convertert::get_var_decl(
   // this will be used to decide if the var will be converted to this->var
   // when parsing function body.
   bool is_state_var = ast_node["stateVariable"].get<bool>();
-  t.set("#sol_state_var", std::to_string(is_state_var));
+  set_sol_state_var(t, is_state_var);
 
   // For local storage reference variables (e.g. Wrapper storage ref = param),
   // register an alias so that uses of 'ref' resolve to the source symbol.
@@ -1014,11 +1014,11 @@ bool solidity_convertert::get_struct_class_fields(
   }
 
   // mapping(K=>V)[] is also modeled as a 2D infinite array (not a pointer)
-  if (comp.type().get_bool("#sol_mapping_array"))
+  if (get_sol_mapping_array(comp.type()))
     return false;
 
   // dynarray state vars are modeled as global infinite arrays (not struct members)
-  if (comp.type().get_bool("#sol_dynarray_state"))
+  if (get_sol_dynarray_state(comp.type()))
     return false;
 
   comp.id("component");

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -1354,7 +1354,7 @@ bool solidity_convertert::get_call_expr(
     if (new_expr.is_member() && new_expr.component_name() == "length")
       return false;
 
-    std::string sol_name = new_expr.type().get("#sol_name").as_string();
+    std::string sol_name = get_sol_name(new_expr.type());
     if (sol_name == "revert")
     {
       // Special case: revert
@@ -2124,7 +2124,7 @@ bool solidity_convertert::get_index_access_expr(
   // them.  This ensures the result carries the inner mapping's element type
   // so that subsequent m[k] indexing works correctly.
   if (
-    array.type().is_array() && array.type().get_bool("#sol_mapping_array") &&
+    array.type().is_array() && get_sol_mapping_array(array.type()) &&
     array.type().has_subtype())
   {
     new_expr = index_exprt(array, pos, array.type().subtype());
@@ -2713,7 +2713,7 @@ bool solidity_convertert::get_binary_operator_expr(
     else if (
       (rt_sol == SolidityGrammar::SolType::ARRAY ||
        rt_sol == SolidityGrammar::SolType::ARRAY_LITERAL) &&
-      lhs.is_symbol() && lt.get_bool("#sol_dynarray_state"))
+      lhs.is_symbol() && get_sol_dynarray_state(lt))
     {
       // Dynarray state var: element-wise assignment from array literal
       // e.g. items = [1,2,3] → items[0]=1; items[1]=2; items[2]=3; items_len=3
@@ -2791,7 +2791,7 @@ bool solidity_convertert::get_binary_operator_expr(
     }
     else if (
       rt_sol == SolidityGrammar::SolType::DYNARRAY && lhs.is_symbol() &&
-      lt.get_bool("#sol_dynarray_state"))
+      get_sol_dynarray_state(lt))
     {
       // Dynarray state var: skip arrcpy, just note the assignment is handled
       // by the caller's existing mechanism (element-wise via loops would be
@@ -2832,7 +2832,7 @@ bool solidity_convertert::get_binary_operator_expr(
     }
     else if (
       rt_sol == SolidityGrammar::SolType::ARRAY_CALLOC && lhs.is_symbol() &&
-      lt.get_bool("#sol_dynarray_state"))
+      get_sol_dynarray_state(lt))
     {
       // Dynarray state var: `items = new uint[](n)` → just set length = n
       exprt size_expr;

--- a/src/solidity-frontend/solidity_convert_ref.cpp
+++ b/src/solidity-frontend/solidity_convert_ref.cpp
@@ -64,7 +64,7 @@ bool solidity_convertert::get_var_decl_ref(
   bool is_global_static_mapping =
     (get_sol_type(type) == SolidityGrammar::SolType::MAPPING &&
      type.is_array()) ||
-    type.get_bool("#sol_mapping_array") || is_dynarray_state_var;
+    get_sol_mapping_array(type) || is_dynarray_state_var;
 
   if (context.find_symbol(id) != nullptr)
     new_expr = symbol_expr(*context.find_symbol(id));
@@ -307,7 +307,7 @@ bool solidity_convertert::get_esbmc_builtin_ref(
   {
     assert(context.find_symbol(id) != nullptr);
     new_expr = symbol_expr(*context.find_symbol(id));
-    new_expr.type().set("#sol_name", blt_name);
+    set_sol_name(new_expr.type(), blt_name);
   }
   else
   {
@@ -318,7 +318,7 @@ bool solidity_convertert::get_esbmc_builtin_ref(
     return_type = bool_t;
     convert_type.return_type() = return_type;
     type = convert_type;
-    type.set("#sol_name", blt_name);
+    set_sol_name(type, blt_name);
 
     new_expr = exprt("symbol", type);
     new_expr.identifier(id);
@@ -471,7 +471,7 @@ bool solidity_convertert::get_sol_builtin_ref(
           // mapping array: return the auxiliary _length variable
           if (
             solt == SolidityGrammar::SolType::DYNARRAY &&
-            base_t.get_bool("#sol_mapping_array"))
+            get_sol_mapping_array(base_t))
           {
             assert(base.is_symbol());
             std::string len_id =
@@ -483,7 +483,7 @@ bool solidity_convertert::get_sol_builtin_ref(
           // dynarray state var: return the auxiliary _dynarray_len variable
           else if (
             solt == SolidityGrammar::SolType::DYNARRAY && base.is_symbol() &&
-            base.type().get_bool("#sol_dynarray_state"))
+            get_sol_dynarray_state(base.type()))
           {
             assert(base.is_symbol());
             std::string len_id =
@@ -549,7 +549,7 @@ bool solidity_convertert::get_sol_builtin_ref(
 
         if (
           solt == SolidityGrammar::SolType::DYNARRAY &&
-          base_t.get_bool("#sol_mapping_array"))
+          get_sol_mapping_array(base_t))
         {
           // mapping(K=>V)[]: push increments length, pop decrements.
           assert(base.is_symbol());
@@ -581,7 +581,7 @@ bool solidity_convertert::get_sol_builtin_ref(
         }
         else if (
           solt == SolidityGrammar::SolType::DYNARRAY && base.is_symbol() &&
-          base.type().get_bool("#sol_dynarray_state"))
+          get_sol_dynarray_state(base.type()))
         {
           // Dynarray state var: write element at len, then increment len
           assert(base.is_symbol());

--- a/src/solidity-frontend/solidity_convert_type.cpp
+++ b/src/solidity-frontend/solidity_convert_type.cpp
@@ -413,7 +413,7 @@ bool solidity_convertert::get_type_description(
         new_type = array_typet();
         new_type.size(exprt("infinity"));
         new_type.subtype() = sub_type;
-        new_type.set("#sol_mapping_array", true);
+        set_sol_mapping_array(new_type, true);
         set_sol_type(new_type, SolidityGrammar::SolType::DYNARRAY);
       }
       else
@@ -1045,7 +1045,7 @@ bool solidity_convertert::get_array_pointer_type(
     new_type = array_typet();
     new_type.size(exprt("infinity"));
     new_type.subtype() = base_type;
-    new_type.set("#sol_mapping_array", true);
+    set_sol_mapping_array(new_type, true);
     set_sol_type(new_type, SolidityGrammar::SolType::DYNARRAY);
     return false;
   }


### PR DESCRIPTION
## Summary

Encapsulates the **four remaining read-bearing** Solidity type attributes behind typed static accessors on `solidity_convertert`, completing the attribute-chokepoint pass for the read-bearing set:

| Attribute | kind | set / read sites | accessors |
|---|---|---|---|
| `#sol_mapping_array` | bool flag | 2 / 7 | `get_/set_sol_mapping_array` |
| `#sol_dynarray_state` | bool flag | 1 / 6 | `get_/set_sol_dynarray_state` |
| `#sol_state_var` | bool as `"1"`/`"0"` | 2 / 1 | `get_/set_sol_state_var` |
| `#sol_name` | string | 2 / 1 | `get_/set_sol_name` |

After this, **no non-header file pokes these raw irep attributes** — all access goes through one typed seam each (mirroring `#sol_type` / `#sol_array_size` / `#sol_bytesn_size` / `#sol_contract` from #4951–#4953).

Branches cleanly from `master`. Phase 3.1 of the Solidity → irep2 plan (`docs/irep2-migration.md`, Part III).

## Rationale

`migrate_type` silently drops `#sol_*` attributes (`type2t` has no attribute map), so each read-bearing attribute must be funneled through an accessor that can later be repointed at a typed off-IR `sol_typeinfo` companion **without re-touching call sites**. This PR brings the four remaining read-bearing attributes to that standard.

The change is deliberately mechanical — same key, same value semantics:
- bool flags use `get_bool`/`set` exactly as before;
- `#sol_state_var` keeps its `"1"`/`"0"` string form (`std::to_string(bool) == (v ? "1" : "0")`, and the read still tests `== "1"`).

## Remaining legacy dependencies

- The attributes are still stored on the legacy `typet`; this PR only centralizes access. Moving storage off-IR is the next phase (the `sol_typeinfo` companion).
- The two **set-only** attributes `#sol_data_loc` (3 set / 0 read) and `#member_name` (8 set / 0 read) are **not read-bearing** — they have no read chokepoint to migrate, so they're intentionally out of scope here and handled separately at the companion stage.

## Testing performed

- **Compiles cleanly**: incremental `ninja -C build esbmc` succeeds (Z3 + Bitwuzla, `-DENABLE_SOLIDITY_FRONTEND=On`), no new warnings/errors. The build also confirms overload resolution for the bool/`irep_idt` setters.
- **Formatting**: added block and edits match project style; `clang-format` shows no diff on changed regions.
- **Equivalence**: every edit is a 1:1 substitution preserving the same key and value semantics (verified per-site, incl. the `std::to_string(bool)` ⇔ `"1"/"0"` identity for `#sol_state_var`).
- **Regression verdicts**: the `esbmc-solidity` suite can't run locally on macOS (empty `sol64` models — `_BitInt(256)` unavailable on Apple aarch64); verdict validation relies on **Linux CI**. This change is a mechanical no-op on the IR.

## Recommended next steps

1. Optional tiny follow-up: route the two set-only attributes (`#sol_data_loc`, `#member_name`) through `set_` helpers for completeness before the companion stage.
2. **Phase 3.1 completion** — introduce the off-IR `sol_typeinfo` companion (keyed by symbol id / threaded for transient types) and repoint **all** `get_/set_sol_*` accessors at it, removing `#sol_*` from the IR. This is the step that eliminates the `migrate_type` silent-drop hazard and unblocks migrating Solidity type construction to `type2tc` (Phase 3.3).
