### PR TITLE
[solidity] encapsulate #sol_data_loc behind a typed setter

### DIFF
--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -170,6 +170,14 @@ public:
     return t.get("#sol_name").as_string();
   }
 
+  // Set the Solidity data location ("memory"/"storage"/"calldata") carried on
+  // a typet via the #sol_data_loc irep attribute. Set-only today (no readers);
+  // wrapped to keep every Solidity type-attribute write behind one seam.
+  static void set_sol_data_loc(typet &t, const irep_idt &loc)
+  {
+    t.set("#sol_data_loc", loc);
+  }
+
   // json nodes that always empty
   // used as the return value for find_constructor_ref when
   // dealing with the implicit constructor call

--- a/src/solidity-frontend/solidity_convert_type.cpp
+++ b/src/solidity-frontend/solidity_convert_type.cpp
@@ -574,11 +574,11 @@ bool solidity_convertert::get_type_description(
 
   // set data location
   if (typeIdentifier.find("_memory_ptr") != std::string::npos)
-    new_type.set("#sol_data_loc", "memory");
+    set_sol_data_loc(new_type, "memory");
   else if (typeIdentifier.find("_storage_ptr") != std::string::npos)
-    new_type.set("#sol_data_loc", "storage");
+    set_sol_data_loc(new_type, "storage");
   else if (typeIdentifier.find("_calldata_ptr") != std::string::npos)
-    new_type.set("#sol_data_loc", "calldata");
+    set_sol_data_loc(new_type, "calldata");
 
   return false;
 }


### PR DESCRIPTION
## Summary

Routes the three `#sol_data_loc` set sites (the Solidity data location — `"memory"` / `"storage"` / `"calldata"` — carried on a `typet`) through a new `set_sol_data_loc` helper on `solidity_convertert`. This completes the attribute-chokepoint pass for the **Solidity-specific** `#sol_*` type attributes.

The attribute is **set-only** today (0 readers anywhere in `src/`), so only a setter is added — no `get_`/`has_`.

> **Stacked on #4958.** Base is `refactor/sol-remaining-attr-accessors`; GitHub retargets to `master` once #4958 merges. Review just this PR's diff (2 files, +11/−3).

## Rationale

Finishes the Phase 3.1 chokepoint groundwork (`docs/irep2-migration.md`, Part III): with this, **every Solidity-specific `#sol_*` type attribute is now written/read through a single typed seam**, which is the prerequisite for later relocating them to an off-IR `sol_typeinfo` companion without re-touching call sites. Although `#sol_data_loc` is currently unread, the data location is semantically important (storage-vs-memory aliasing), so keeping its writes behind one seam is worthwhile groundwork.

## Scope note — why `#member_name` is excluded

I had earlier listed `#member_name` as the other "set-only" attribute, but investigation shows it is **not Solidity-specific**: it is a shared clang-cpp irep convention, **read by `clang_cpp_adjust_code_gen.cpp`** (constructor namespace lookup / name mangling — which runs over Solidity output too) and referenced in the python frontend. Wrapping it as a `solidity_convertert` accessor would mischaracterize it and serve no migration purpose — it cannot be moved off the IR by frontend work, since the shared adjust pass reads it from the IR. It is therefore left untouched, out of scope for the Solidity type-metadata migration.

## Remaining legacy dependencies

- `#sol_data_loc` is still stored on the legacy `typet`; this PR only centralizes the writes. It will move into the `sol_typeinfo` companion at the next phase.

## Testing performed

- **Compiles cleanly**: incremental `ninja -C build esbmc` succeeds (Z3 + Bitwuzla, `-DENABLE_SOLIDITY_FRONTEND=On`), no new warnings/errors.
- **Formatting**: matches project style; `clang-format` shows no diff on changed regions.
- **Equivalence**: each edit is a 1:1 substitution (`new_type.set("#sol_data_loc", X)` → `set_sol_data_loc(new_type, X)`), same key, same value.
- **Regression verdicts**: `esbmc-solidity` can't run locally on macOS (empty `sol64` models — `_BitInt(256)` unavailable on Apple aarch64); verdicts validate on Linux CI. Mechanical no-op on the IR.

## Recommended next step

**Phase 3.1 completion** — introduce the off-IR `sol_typeinfo` companion (keyed by symbol id / threaded for transient types) and repoint **all** `get_/set_sol_*` accessors at it, removing `#sol_*` from the IR. That is the step that eliminates the `migrate_type` silent-drop hazard and unblocks migrating Solidity type construction to `type2tc` (Phase 3.3).
