### PR TITLE
[goto-race] exclude pointer-reached atomic elements from race check (#4431)

### DIFF
--- a/regression/esbmc-unix/github_4431_atomic_ptr_norace/main.c
+++ b/regression/esbmc-unix/github_4431_atomic_ptr_norace/main.c
@@ -1,0 +1,39 @@
+// Regression for issue #4431 (SV-COMP no-data-race false alarm on
+// c/weaver/popl20-min-max-inc-dec.wvr).
+//
+// Two threads concurrently update the SAME object through a pointer to
+// _Atomic int. Per C11 §5.1.2.4p4, concurrent accesses to an _Atomic object
+// are not a data race, so this is race-free. ESBMC used to report a spurious
+// W/W race because the rw_set #atomic filter only inspects the root symbol's
+// own type: for `A[i]` with `_Atomic int *A`, neither the (non-atomic) pointer
+// A nor the index i is itself atomic, so the access to the atomic element
+// slipped past the filter. irep2 has no atomic-type node, so the fix recovers
+// the flag from the base symbol's pointee/element type.
+//
+// Expected: VERIFICATION SUCCESSFUL.
+#include <pthread.h>
+
+_Atomic int storage;
+_Atomic int *A;
+
+void *t_inc(void *arg)
+{
+  A[0]++;
+  return 0;
+}
+void *t_dec(void *arg)
+{
+  A[0]--;
+  return 0;
+}
+
+int main(void)
+{
+  A = &storage;
+  pthread_t x, y;
+  pthread_create(&x, 0, t_inc, 0);
+  pthread_create(&y, 0, t_dec, 0);
+  pthread_join(x, 0);
+  pthread_join(y, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4431_atomic_ptr_norace/test.desc
+++ b/regression/esbmc-unix/github_4431_atomic_ptr_norace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_4431_nonatomic_ptr_race/main.c
+++ b/regression/esbmc-unix/github_4431_nonatomic_ptr_race/main.c
@@ -1,0 +1,33 @@
+// Negative companion to github_4431_atomic_ptr_norace: identical structure but
+// the pointer targets a plain (non-atomic) int, so the two unsynchronised
+// updates through the pointer ARE a genuine data race. This confirms that the
+// atomic-element exclusion does NOT over-suppress real races on non-atomic
+// objects reached through a pointer.
+//
+// Expected: VERIFICATION FAILED.
+#include <pthread.h>
+
+int storage;
+int *A;
+
+void *t_inc(void *arg)
+{
+  A[0]++; // RACE!
+  return 0;
+}
+void *t_dec(void *arg)
+{
+  A[0]--; // RACE!
+  return 0;
+}
+
+int main(void)
+{
+  A = &storage;
+  pthread_t x, y;
+  pthread_create(&x, 0, t_inc, 0);
+  pthread_create(&y, 0, t_dec, 0);
+  pthread_join(x, 0);
+  pthread_join(y, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4431_nonatomic_ptr_race/test.desc
+++ b/regression/esbmc-unix/github_4431_nonatomic_ptr_race/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION FAILED$

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -5,6 +5,69 @@
 #include <util/namespace.h>
 #include <util/std_expr.h>
 
+// Follow pointer arithmetic and typecasts down to the root pointer/array/object
+// symbol of an address expression (`A + i` -> A, `(T *)p` -> p), or return null
+// when the base is not a plain symbol.
+static const symbolt *root_object_symbol(const expr2tc &e, const namespacet &ns)
+{
+  expr2tc cur = e;
+  while (!is_nil_expr(cur))
+  {
+    if (is_symbol2t(cur))
+      return ns.lookup(to_symbol2t(cur).thename);
+    if (is_typecast2t(cur))
+      cur = to_typecast2t(cur).from;
+    else if (is_add2t(cur))
+      // pointer +/- integer offset: keep following the pointer-typed operand
+      cur = is_pointer_type(to_add2t(cur).side_1->type) ? to_add2t(cur).side_1
+                                                        : to_add2t(cur).side_2;
+    else if (is_sub2t(cur))
+      cur = to_sub2t(cur).side_1;
+    else
+      break;
+  }
+  return nullptr;
+}
+
+// C11 §5.1.2.4p4: concurrent accesses to _Atomic objects are not data races.
+// irep2 has no atomic-type node (see the FIXME in clang_c_convert's Atomic
+// case), so the `#atomic` flag survives only on the *legacy symbol type*. The
+// per-symbol check in read_write_rec therefore misses an access that reaches an
+// atomic element through a non-atomic pointer/array — e.g. `A[i]` with
+// `_Atomic int *A`, where neither the pointer A nor the index i is itself
+// atomic. Recover the flag from the base symbol's pointee/element type so such
+// accesses are correctly excluded from race checking (issue #4431).
+static bool accesses_atomic_object(const expr2tc &access, const namespacet &ns)
+{
+  if (is_nil_expr(access))
+    return false;
+
+  if (is_symbol2t(access))
+  {
+    const symbolt *s = ns.lookup(to_symbol2t(access).thename);
+    return s && s->get_type().get_bool("#atomic");
+  }
+
+  if (is_dereference2t(access) || is_index2t(access))
+  {
+    const expr2tc &base = is_dereference2t(access)
+                            ? to_dereference2t(access).value
+                            : to_index2t(access).source_value;
+    const symbolt *s = root_object_symbol(base, ns);
+    if (!s)
+      return false;
+    const typet &t = s->get_type();
+    if (t.is_pointer() || t.is_array())
+      return t.subtype().get_bool("#atomic");
+    return t.get_bool("#atomic");
+  }
+
+  if (is_member2t(access))
+    return accesses_atomic_object(to_member2t(access).source_value, ns);
+
+  return false;
+}
+
 void rw_sett::compute(const expr2tc &expr)
 {
   if (is_nil_expr(expr))
@@ -113,6 +176,14 @@ void rw_sett::read_write_rec(
     // C11 _Atomic variables are never involved in data races
     // (§5.1.2.4p4: concurrent accesses to atomic objects are not races).
     if (symbol->get_type().get_bool("#atomic"))
+      return;
+
+    // The check above only sees this symbol's own type. When the access
+    // reaches an atomic element through a non-atomic pointer/array (e.g.
+    // `A[i]` with `_Atomic int *A`), the atomic object is named by
+    // original_expr, not by this symbol; suppress those too (issue #4431).
+    if (
+      !is_nil_expr(original_expr) && accesses_atomic_object(original_expr, ns))
       return;
 
     irep_idt object = id2string(symbol_expr.thename) + suffix;


### PR DESCRIPTION
For `A[i]` with `_Atomic int *A`, the accessed element is `_Atomic`, so
concurrent access is not a data race (C11 §5.1.2.4p4) — but the rw_set `#atomic`
filter only inspected the root symbol's type, and neither the pointer `A` nor
the index `i` is itself atomic, so ESBMC reported a spurious W/W race. Recover
atomicity from the base symbol's pointee/element type and exclude such accesses;
the check stays conservative, so real races on non-atomic objects are still
reported.

Fixes #4431
