### PR TITLE
[goto-race] add interleaving point at atomic-region boundaries (#4423)

### DIFF
--- a/regression/esbmc-unix/github_4423_atomic_norace/main.c
+++ b/regression/esbmc-unix/github_4423_atomic_norace/main.c
@@ -1,0 +1,97 @@
+#include <pthread.h>
+
+extern void __VERIFIER_atomic_begin(void);
+extern void __VERIFIER_atomic_end(void);
+extern void __VERIFIER_assume(int);
+
+/* No-race companion to github_4423_atomic_race (esbmc/esbmc#4423).
+ *
+ * Identical control flow, but the accesses to `stopped` are synchronized
+ * (wrapped in atomic regions). There is therefore no data race, and the result
+ * must stay VERIFICATION SUCCESSFUL. This guards the #4423 fix against the
+ * opposite failure mode: the extra atomic-boundary interleaving points it adds
+ * must not fabricate a spurious race on a correctly synchronized program.
+ */
+
+volatile int stoppingFlag;
+volatile int pendingIo;
+volatile int stoppingEvent;
+volatile int stopped;
+
+int BCSP_IoIncrement(void)
+{
+  int lsf;
+  __VERIFIER_atomic_begin();
+  lsf = stoppingFlag; /* atomic region A: read shared flag */
+  __VERIFIER_atomic_end();
+  if (lsf)
+    return -1;
+  int lp;
+  __VERIFIER_atomic_begin();
+  lp = pendingIo; /* atomic region B: read shared counter */
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  pendingIo = lp + 1; /* atomic region C: write shared counter */
+  __VERIFIER_atomic_end();
+  return 0;
+}
+
+int dec(void)
+{
+  int tmp;
+  __VERIFIER_atomic_begin();
+  pendingIo = pendingIo - 1;
+  tmp = pendingIo;
+  __VERIFIER_atomic_end();
+  return tmp;
+}
+
+void BCSP_IoDecrement(void)
+{
+  if (dec() == 0)
+  {
+    __VERIFIER_atomic_begin();
+    stoppingEvent = 1;
+    __VERIFIER_atomic_end();
+  }
+}
+
+void *BCSP_PnpStop(void *arg)
+{
+  (void)arg;
+  __VERIFIER_atomic_begin();
+  stoppingFlag = 1;
+  __VERIFIER_atomic_end();
+  BCSP_IoDecrement();
+  int lse;
+  __VERIFIER_atomic_begin();
+  lse = stoppingEvent;
+  __VERIFIER_atomic_end();
+  __VERIFIER_assume(lse);
+  __VERIFIER_atomic_begin();
+  stopped = 1; /* synchronized write */
+  __VERIFIER_atomic_end();
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t;
+  pendingIo = 1;
+  stoppingFlag = 0;
+  stoppingEvent = 0;
+  stopped = 0;
+  pthread_create(&t, 0, BCSP_PnpStop, 0);
+
+  if (BCSP_IoIncrement() == 0)
+  {
+    int observed;
+    __VERIFIER_atomic_begin();
+    observed = stopped; /* synchronized read */
+    __VERIFIER_atomic_end();
+    if (observed)
+      pendingIo = pendingIo;
+  }
+  BCSP_IoDecrement();
+  return 0;
+}

--- a/regression/esbmc-unix/github_4423_atomic_norace/test.desc
+++ b/regression/esbmc-unix/github_4423_atomic_norace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check-only --no-assertions --context-bound 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_4423_atomic_race/main.c
+++ b/regression/esbmc-unix/github_4423_atomic_race/main.c
@@ -1,0 +1,97 @@
+#include <pthread.h>
+
+extern void __VERIFIER_atomic_begin(void);
+extern void __VERIFIER_atomic_end(void);
+extern void __VERIFIER_assume(int);
+
+/* Regression for esbmc/esbmc#4423 (pthread-lit/qw2004-2).
+ *
+ * A W/R data race on `stopped` that can only be exposed by interleaving
+ * *between* two atomic regions of the increment path: the reader must observe
+ * stoppingFlag == 0 (atomic region A) and then be suspended before touching
+ * pendingIo (atomic region B/C) while the writer thread runs to completion and
+ * performs the non-atomic write `stopped = 1`.
+ *
+ * In --data-races-check-only mode all interleaving points are derived from the
+ * yield() calls add_race_assertions emits around non-atomic accesses, so before
+ * the fix there was no context-switch point at the A->B atomic-region boundary
+ * and the race was missed (VERIFICATION SUCCESSFUL on a racy program).
+ */
+
+volatile int stoppingFlag;
+volatile int pendingIo;
+volatile int stoppingEvent;
+volatile int stopped;
+
+int BCSP_IoIncrement(void)
+{
+  int lsf;
+  __VERIFIER_atomic_begin();
+  lsf = stoppingFlag; /* atomic region A: read shared flag */
+  __VERIFIER_atomic_end();
+  if (lsf)
+    return -1;
+  int lp;
+  __VERIFIER_atomic_begin();
+  lp = pendingIo; /* atomic region B: read shared counter */
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  pendingIo = lp + 1; /* atomic region C: write shared counter */
+  __VERIFIER_atomic_end();
+  return 0;
+}
+
+int dec(void)
+{
+  int tmp;
+  __VERIFIER_atomic_begin();
+  pendingIo = pendingIo - 1;
+  tmp = pendingIo;
+  __VERIFIER_atomic_end();
+  return tmp;
+}
+
+void BCSP_IoDecrement(void)
+{
+  if (dec() == 0)
+  {
+    __VERIFIER_atomic_begin();
+    stoppingEvent = 1;
+    __VERIFIER_atomic_end();
+  }
+}
+
+void *BCSP_PnpStop(void *arg)
+{
+  (void)arg;
+  __VERIFIER_atomic_begin();
+  stoppingFlag = 1;
+  __VERIFIER_atomic_end();
+  BCSP_IoDecrement();
+  int lse;
+  __VERIFIER_atomic_begin();
+  lse = stoppingEvent;
+  __VERIFIER_atomic_end();
+  __VERIFIER_assume(lse);
+  stopped = 1; /* NON-atomic write -> races with read below */
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t;
+  pendingIo = 1;
+  stoppingFlag = 0;
+  stoppingEvent = 0;
+  stopped = 0;
+  pthread_create(&t, 0, BCSP_PnpStop, 0);
+
+  if (BCSP_IoIncrement() == 0)
+  {
+    int observed = stopped; /* NON-atomic read -> races with write above */
+    if (observed)
+      pendingIo = pendingIo;
+  }
+  BCSP_IoDecrement();
+  return 0;
+}

--- a/regression/esbmc-unix/github_4423_atomic_race/test.desc
+++ b/regression/esbmc-unix/github_4423_atomic_race/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--data-races-check-only --no-assertions --context-bound 3
+^VERIFICATION FAILED$
+^.*R/W data race on c:@stopped$

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -118,12 +118,50 @@ void add_race_assertions(
 
   bool is_atomic = false;
 
+  // In data-races-check-only mode every interleaving point is derived from a
+  // yield() call, and add_race_assertions only emits those around *non-atomic*
+  // shared accesses (the branch below is guarded by !is_atomic). A thread that
+  // executes back-to-back atomic regions therefore has no interleaving point
+  // between them, so a data race that can only be exposed by another thread
+  // interleaving *between* two atomic regions of the same thread is never
+  // explored -> false negative (VERIFICATION SUCCESSFUL on a racy program).
+  // Track whether the current atomic region touched shared state and, if so,
+  // emit a yield() at its boundary (the ATOMIC_END handling below) so those
+  // interleavings are generated. See https://github.com/esbmc/esbmc/issues/4423
+  const bool races_only =
+    config.options.get_bool_option("data-races-check-only");
+  bool atomic_region_touched_shared = false;
+
   Forall_goto_program_instructions (i_it, goto_program)
   {
     goto_programt::instructiont &instruction = *i_it;
 
     if (instruction.is_atomic_begin())
+    {
       is_atomic = true;
+      atomic_region_touched_shared = false;
+    }
+
+    // Accesses inside an atomic region are not individually instrumented, but
+    // we still need to know whether the region touched shared state so a
+    // context-switch point can be created at its boundary (see note above).
+    if (
+      races_only && is_atomic && !atomic_region_touched_shared &&
+      (instruction.is_assign() || instruction.is_other() ||
+       instruction.is_return() || instruction.is_goto() ||
+       instruction.is_assert() || instruction.is_function_call() ||
+       instruction.is_assume()))
+    {
+      const expr2tc &probe_expr =
+        (instruction.is_goto() || instruction.is_assert()) ? instruction.guard
+                                                           : instruction.code;
+      if (!is_nil_expr(probe_expr))
+      {
+        rw_sett probe(ns, i_it, probe_expr);
+        if (!probe.entries.empty())
+          atomic_region_touched_shared = true;
+      }
+    }
 
     if (
       (instruction.is_assign() || instruction.is_other() ||
@@ -213,7 +251,7 @@ void add_race_assertions(
         i_it = ++t;
       }
 
-      if (config.options.get_bool_option("data-races-check-only"))
+      if (races_only)
       {
         goto_programt::targett t = goto_program.insert(i_it);
         t->type = FUNCTION_CALL;
@@ -252,7 +290,30 @@ void add_race_assertions(
     }
 
     if (instruction.is_atomic_end())
+    {
       is_atomic = false;
+
+      // Emit an interleaving point right after an atomic region that accessed
+      // shared state, so other threads may interleave between consecutive
+      // atomic regions. Restricted to regions that touched shared state to
+      // avoid growing the interleaving space for purely thread-local atomics.
+      // See https://github.com/esbmc/esbmc/issues/4423
+      if (races_only && atomic_region_touched_shared)
+      {
+        atomic_region_touched_shared = false;
+
+        goto_programt::targett after = i_it;
+        ++after;
+        goto_programt::targett t = goto_program.insert(after);
+        t->type = FUNCTION_CALL;
+        code_function_callt call;
+        call.function() =
+          symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
+        migrate_expr(call, t->code);
+        t->location = instruction.location;
+        i_it = t; // loop's ++ advances past the inserted yield
+      }
+    }
   }
 
   remove_no_op(goto_program);


### PR DESCRIPTION
## Issue

Fixes #4423 — a **no-data-race false negative** (soundness bug). On the SV-COMP benchmark [`c/pthread-lit/qw2004-2`](https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/main/c/pthread-lit/qw2004-2.i) (ground truth **FALSE** — a real W/R data race on `stopped`), ESBMC reported `VERIFICATION SUCCESSFUL`/TRUE under the `kinduction` SV-COMP profile, silently missing the race.

## Root cause

In `--data-races-check-only` mode, `execution_statet::get_expr_globals` (`src/goto-symex/execution_state.cpp:759`) short-circuits and records **no** global reads/writes. Consequently `has_cswitch_point_occured()` can only fire via `cswitch_forced`, i.e. from the explicit `__ESBMC_yield()` calls that `add_race_assertions` inserts around **non-atomic** shared accesses.

A thread that executes a sequence of `__VERIFIER_atomic_begin/end` regions with only local code between them therefore has **no interleaving point between those regions**. In qw2004-2 the race is only reachable when the increment thread is suspended *between* reading `stoppingFlag` (atomic region A) and incrementing `pendingIo` (atomic region B) while the stop thread runs to completion and performs the non-atomic write `stopped = 1`. With no switch point at the A→B boundary, that schedule is never generated and the race is missed.

Confirmed empirically: the same benchmark under full `--data-races-check` (which does **not** short-circuit `get_expr_globals`) explores 94+ interleavings and correctly reports the race; `--data-races-check-only` explored only 6 and missed it.

## Fix

`src/goto-programs/add_race_assertions.cpp`: in `--data-races-check-only` mode only, track whether an atomic region touched shared state (via a side-effect-free `rw_sett` probe) and, if so, insert a `__ESBMC_yield()` immediately after that region's `ATOMIC_END`. This restores the missing interleaving point exactly at atomic-region boundaries. It is restricted to shared-touching regions to bound interleaving growth (purely thread-local atomics get no extra yield).

## Why it is correct (no soundness regression)

`__ESBMC_yield` → `intrinsic_yield` only calls `force_cswitch()` (`src/goto-symex/builtin_functions/threads.cpp:17`) — it performs no shared access and adds no data dependency. It can only *enlarge* the set of explored schedules; it cannot fabricate an access a real execution would not perform. Race verdicts are still decided solely by the exact `RACE_CHECK` assertions around genuine non-atomic accesses, so no genuinely-TRUE program can be turned FALSE. The change is gated on `data-races-check-only`; full `--data-races-check` is untouched (it already creates these switch points via global-access analysis).

## Validation

- **Reproduction → fix (dual-solver):** the real qw2004-2 benchmark now reports `VERIFICATION FAILED` / `R/W data race on c:@stopped` under **both** Bitwuzla and Z3 (was `SUCCESSFUL`).
- **Regression-fails-on-unfixed-code:** reverting the patch flips the new racy test back to `VERIFICATION SUCCESSFUL`, confirming the added branches are reachable and load-bearing (C-Live dead-code obligation discharged by the reproducer).
- **New tests** (`regression/esbmc-unix/`): `github_4423_atomic_race` (must report FAILED + the race) and `github_4423_atomic_norace` (synchronized twin, must stay SUCCESSFUL — guards against spurious races).
- **No regressions:** 189/189 concurrency/data-race regression tests pass, including the two pre-existing `--data-races-check-only` tests (`github_2661`, `SV_COMP_04`) and the full-mode tests (`github_4715_rwset*`, `github_4634*`).
- clang-format clean.

## Notes

The flat-`bool` `is_atomic` tracking (no nesting depth) is a pre-existing convention this patch follows; the #4423 benchmark and both new tests use non-nested atomic regions. A follow-up could dedup the three near-identical yield-emission blocks into a helper (flagged in review, deliberately left out to keep this soundness fix minimal and bisectable).

Local reproduction was on aarch64 macOS (the x86-only `__regparm__` attribute in the preprocessed `.i` was neutralized, irrelevant to race analysis); final soundness validation should come from the x86_64 CI benchexec run.
