### PR TITLE
[goto-race] detect races on shared function-pointer call targets

### DIFF
--- a/regression/esbmc-unix/github_4425_funptr_norace/main.c
+++ b/regression/esbmc-unix/github_4425_funptr_norace/main.c
@@ -1,0 +1,43 @@
+#include <pthread.h>
+
+/* No-race companion to github_4425_funptr_race (esbmc/esbmc#4425).
+ *
+ * Identical to the racy version except that the write to `fp` and the indirect
+ * call that reads `fp` are protected by the SAME mutex, so the accesses are
+ * synchronized and there is no data race. The result must stay VERIFICATION
+ * SUCCESSFUL: instrumenting the read of an indirect-call target must not
+ * fabricate a spurious race on a correctly locked function pointer.
+ */
+
+int f1(void)
+{
+  return 4;
+}
+int f2(void)
+{
+  return 5;
+}
+
+int (*fp)(void) = f1;
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg)
+{
+  (void)arg;
+  pthread_mutex_lock(&mutex);
+  fp = f2; /* write under mutex */
+  pthread_mutex_unlock(&mutex);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t id;
+  pthread_create(&id, 0, t_fun, 0);
+  pthread_mutex_lock(&mutex);
+  fp(); /* read of fp under the SAME mutex -> synchronized, no race */
+  pthread_mutex_unlock(&mutex);
+  pthread_join(id, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4425_funptr_norace/test.desc
+++ b/regression/esbmc-unix/github_4425_funptr_norace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check-only --no-assertions --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_4425_funptr_race/main.c
+++ b/regression/esbmc-unix/github_4425_funptr_race/main.c
@@ -1,0 +1,47 @@
+#include <pthread.h>
+
+/* Regression for esbmc/esbmc#4425 (goblint-regression/04-mutex_50-funptr_rc).
+ *
+ * The global function pointer `fp` is written by t_fun under mutex1 and read by
+ * main (via the indirect call `fp()`) under mutex2. Because the two accesses use
+ * different locks they are unsynchronized -> a W/R data race on `fp`.
+ *
+ * The read of `fp` happens through the indirect call target `*fp`. rw_sett did
+ * not record reads of an indirect-call target, so only the write was
+ * instrumented (seen as a W/W access) and the race was missed (VERIFICATION
+ * SUCCESSFUL on a racy program).
+ */
+
+int f1(void)
+{
+  return 4;
+}
+int f2(void)
+{
+  return 5;
+}
+
+int (*fp)(void) = f1;
+
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg)
+{
+  (void)arg;
+  pthread_mutex_lock(&mutex1);
+  fp = f2; /* RACE: write under mutex1 */
+  pthread_mutex_unlock(&mutex1);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t id;
+  pthread_create(&id, 0, t_fun, 0);
+  pthread_mutex_lock(&mutex2);
+  fp(); /* RACE: read of fp under a different lock (mutex2) */
+  pthread_mutex_unlock(&mutex2);
+  pthread_join(id, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4425_funptr_race/test.desc
+++ b/regression/esbmc-unix/github_4425_funptr_race/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--data-races-check-only --no-assertions --context-bound 2
+^VERIFICATION FAILED$
+^.*R/W data race on c:@fp$

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -93,19 +93,34 @@ void rw_sett::compute(const expr2tc &expr)
   {
     const code_function_call2t &code = to_code_function_call2t(expr);
     read_write_rec(code.ret, false, true, "", guard2tc(), expr2tc());
-    // An indirect call resolves its target by reading a function pointer (the
-    // call target is a dereference such as `*fp`, not a function symbol). If
-    // that pointer is shared, the read can race with a concurrent write, e.g.
-    // `fp = f2` under a different lock (issue #4425). A direct call instead
-    // names a function symbol (code, not data) and is handled below.
+    // An indirect call through a global function pointer reads that pointer to
+    // resolve its target (the call target is `*fp`, not a function symbol). If
+    // the pointer is shared, the read can race with a concurrent write, e.g.
+    // `fp = f2` under a different lock (issue #4425). Record that read, keyed
+    // on the pointer object itself (&fp) so it aliases the write `fp = ...` --
+    // reading the dereference would key on the pointee `&(*fp)` and miss it.
+    //
+    // Restrict this to a plain pointer *variable* (`*fp`, or a cast of one such
+    // as `*(fn_t)fp`, where fp is a symbol). Function pointers reached through
+    // an aggregate (`*s.fp`, `*tbl[i]`) are in practice internal dispatch
+    // tables -- e.g. the CUDA kernel-launch structs `dev_*.func` in
+    // call_kernel.h, or the pthread cleanup stack -- written before the threads
+    // that read them are even spawned, so they never race. Recording those
+    // reads only inserts spurious yield() interleaving points that dilute
+    // context-bounded search and hide real races; this mirrors the restriction
+    // collect_thread_escaped_locals applies to address-taken locals for the
+    // same reason. A direct call names a function symbol (code, not data) and
+    // is left to the body-less-call branch below.
     if (is_dereference2t(code.function))
-      // Read the pointer VALUE that selects the target, keyed on the pointer
-      // object itself (&fp) so it aliases a concurrent write `fp = ...`.
-      // Reading the dereference would key on the pointee `&(*fp)` and miss it.
-      // For `(*tbl[i])()` this keys on the array object `tbl`.
-      read_rec(to_dereference2t(code.function).value);
-    else if (!is_symbol2t(code.function))
-      read_rec(code.function);
+    {
+      // Peel casts so a cast-wrapped pointer variable is still recognised, but
+      // stop at the first aggregate/computed node so dispatch tables stay out.
+      expr2tc target = to_dereference2t(code.function).value;
+      while (is_typecast2t(target))
+        target = to_typecast2t(target).from;
+      if (is_symbol2t(target))
+        read_rec(target);
+    }
     // For function calls, we first check to see if the function has a body
     // available, and if so, we skip it because we also check inside the
     // function. If not, we need to check these args.

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -93,6 +93,19 @@ void rw_sett::compute(const expr2tc &expr)
   {
     const code_function_call2t &code = to_code_function_call2t(expr);
     read_write_rec(code.ret, false, true, "", guard2tc(), expr2tc());
+    // An indirect call resolves its target by reading a function pointer (the
+    // call target is a dereference such as `*fp`, not a function symbol). If
+    // that pointer is shared, the read can race with a concurrent write, e.g.
+    // `fp = f2` under a different lock (issue #4425). A direct call instead
+    // names a function symbol (code, not data) and is handled below.
+    if (is_dereference2t(code.function))
+      // Read the pointer VALUE that selects the target, keyed on the pointer
+      // object itself (&fp) so it aliases a concurrent write `fp = ...`.
+      // Reading the dereference would key on the pointee `&(*fp)` and miss it.
+      // For `(*tbl[i])()` this keys on the array object `tbl`.
+      read_rec(to_dereference2t(code.function).value);
+    else if (!is_symbol2t(code.function))
+      read_rec(code.function);
     // For function calls, we first check to see if the function has a body
     // available, and if so, we skip it because we also check inside the
     // function. If not, we need to check these args.

--- a/unit/goto-programs/rw_set.test.cpp
+++ b/unit/goto-programs/rw_set.test.cpp
@@ -10,9 +10,13 @@
 //                       respective true/false guards)
 //   - is_address_of2t : taking an address does NOT register an access
 //   - is_code_assign2t: rhs read + lhs write via compute()
+//   - indirect call    : *fp() records a read of the plain pointer fp
+//                        (issue #4425) but *s.func() through an aggregate
+//                        records nothing (CUDA/pthread dispatch dilution guard)
 // Companion regression in regression/esbmc/github_4715_rwset[_fail]/
 // covers the end-to-end behaviour via --data-races-check on the
-// index/member/if paths.
+// index/member/if paths; regression/esbmc-unix/github_4425_funptr_*
+// covers the indirect-call path.
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
@@ -56,12 +60,22 @@ contextt &rwset_test_context()
       std::vector<irep_idt>{"x", "y"},
       std::vector<irep_idt>{"x", "y"},
       "s");
+    // A function-pointer global `fp` and a struct `s_fp` holding a
+    // function-pointer member `func`, for the indirect-call tests below.
+    type2tc fptr_t = pointer_type2tc(int32);
+    type2tc fpstruct_t = struct_type2tc(
+      std::vector<type2tc>{fptr_t},
+      std::vector<irep_idt>{"func"},
+      std::vector<irep_idt>{"func"},
+      "s_fp");
 
     add_global(ctx, "x", int32);
     add_global(ctx, "y", int32);
     add_global(ctx, "arr", arr_t);
     add_global(ctx, "g_struct", struct_t);
     add_global(ctx, "cond", get_bool_type());
+    add_global(ctx, "fp", fptr_t);
+    add_global(ctx, "s_fp", fpstruct_t);
 
     initialised = true;
   }
@@ -226,4 +240,72 @@ TEST_CASE(
   REQUIRE_FALSE(rw.entries["y"].w);
   REQUIRE(rw.entries["x"].w);
   REQUIRE_FALSE(rw.entries["x"].r);
+}
+
+TEST_CASE(
+  "rw_set: indirect call through a plain function-pointer symbol records the "
+  "pointer read",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // *fp(): the call target is dereference(fp). compute() records a read of the
+  // pointer fp itself (keyed on &fp, not the pointee) so it can race with a
+  // concurrent `fp = ...` under a different lock (issue #4425).
+  expr2tc deref = dereference2tc(get_int_type(32), sym("fp"));
+  expr2tc call =
+    code_function_call2tc(expr2tc(), deref, std::vector<expr2tc>{});
+
+  rw_sett rw = make_rw_set();
+  rw.compute(call);
+
+  REQUIRE(rw.entries.size() == 1);
+  auto it = rw.entries.find("fp");
+  REQUIRE(it != rw.entries.end());
+  REQUIRE(it->second.r);
+  REQUIRE_FALSE(it->second.w);
+}
+
+TEST_CASE(
+  "rw_set: indirect call through a cast of a function-pointer symbol still "
+  "records the pointer read",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // *(T)fp(): the call target is dereference(typecast(fp)). compute() peels the
+  // cast and still records the read of the underlying pointer symbol fp.
+  expr2tc cast = typecast2tc(pointer_type2tc(get_int_type(32)), sym("fp"));
+  expr2tc deref = dereference2tc(get_int_type(32), cast);
+  expr2tc call =
+    code_function_call2tc(expr2tc(), deref, std::vector<expr2tc>{});
+
+  rw_sett rw = make_rw_set();
+  rw.compute(call);
+
+  REQUIRE(rw.entries.size() == 1);
+  auto it = rw.entries.find("fp");
+  REQUIRE(it != rw.entries.end());
+  REQUIRE(it->second.r);
+  REQUIRE_FALSE(it->second.w);
+}
+
+TEST_CASE(
+  "rw_set: indirect call through an aggregate function pointer records nothing",
+  "[core][goto-programs][rw_set][b5-phase2]")
+{
+  // *s_fp.func(): the call target reaches the function pointer through a struct
+  // member. The indirect-call read is restricted to a plain pointer variable,
+  // so this records NOTHING. Recording it would flood CUDA kernel-dispatch
+  // structs (dev_*.func in call_kernel.h) and the pthread cleanup stack with
+  // spurious yield() interleaving points, diluting context-bounded search and
+  // hiding real races (the 8 CUDA THOROUGH benchmarks regressed exactly this
+  // way on x86_64). The body-less-call arg walk does not fire either, since the
+  // target is a dereference, not a function symbol.
+  expr2tc func_ptr =
+    member2tc(pointer_type2tc(get_int_type(32)), sym("s_fp"), irep_idt("func"));
+  expr2tc deref = dereference2tc(get_int_type(32), func_ptr);
+  expr2tc call =
+    code_function_call2tc(expr2tc(), deref, std::vector<expr2tc>{});
+
+  rw_sett rw = make_rw_set();
+  rw.compute(call);
+
+  REQUIRE(rw.entries.empty());
 }


### PR DESCRIPTION
An indirect call `fp()` reads the function pointer `fp` to resolve its target, but `rw_sett::compute` never recorded that read — so a W/R data race on a shared `fp` written under a different lock was missed and ESBMC reported a false `VERIFICATION SUCCESSFUL` (issue #4425, goblint `04-mutex_50-funptr_rc`).

Record the call-target pointer read, keyed on the pointer object `&fp` so it aliases the concurrent write `fp = ...`. Restrict it to a plain pointer variable (or a cast of one): function pointers reached through an aggregate (`s.fp`, `tbl[i]`) are internal dispatch tables — CUDA kernel-launch structs and the pthread cleanup stack — written before their reader threads are spawned, so recording them only floods the context-bounded search with spurious interleaving points and hides real races.

Validated: `github_4425_funptr_race` reports `R/W data race on c:@fp`, the same-mutex twin stays SUCCESSFUL, and the data-race + CUDA regression claim sets are unchanged from master. New `rw_set` unit tests pin the symbol/cast/aggregate boundary.

Fixes #4425