### PR TITLE
[python] fix int() of constant numeric variable folding to 0

### DIFF
--- a/regression/python/int_const_numeric/main.py
+++ b/regression/python/int_const_numeric/main.py
@@ -1,0 +1,23 @@
+# Regression test for GitHub #4770.
+#
+# int() applied to a *constant* numeric variable was mis-routed through the
+# string parser (handle_str_symbol_to_int): an int symbol decoded to a single
+# character (rejected as non-digit) and a float symbol decoded to nothing, so
+# int(x) folded to 0 regardless of x. Numeric symbols must use the numeric
+# conversion path instead, which truncates floats toward zero and treats ints
+# as identity. Constant strings must keep parsing as before.
+
+f: float = 65.0
+assert int(f) == 65
+
+g: float = 65.7
+assert int(g) == 65  # truncates toward zero
+
+h: float = -3.9
+assert int(h) == -3  # truncation toward zero, not floor
+
+i: int = 42
+assert int(i) == 42  # identity on int
+
+s: str = "123"
+assert int(s) == 123  # constant string still parses

--- a/regression/python/int_const_numeric/test.desc
+++ b/regression/python/int_const_numeric/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_const_numeric_fail/main.py
+++ b/regression/python/int_const_numeric_fail/main.py
@@ -1,0 +1,9 @@
+# Negative variant of int_const_numeric (GitHub #4770).
+#
+# int(65.7) truncates toward zero to 65, so asserting it equals 66 must be
+# refuted. Before the fix int(f) folded to 0 for any numeric symbol, which
+# would also have refuted this assertion but for the wrong reason; the point
+# here is that the conversion now produces the *correct* value 65, not 66.
+
+g: float = 65.7
+assert int(g) == 66

--- a/regression/python/int_const_numeric_fail/test.desc
+++ b/regression/python/int_const_numeric_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -482,7 +482,16 @@ exprt function_call_expr::build_constant_from_arg() const
     if (first_arg["_type"] == "Name")
     {
       const symbolt *sym = lookup_python_symbol(first_arg["id"]);
-      if (sym && sym->get_value().is_constant())
+      // The compile-time fast path below decodes the symbol's stored value as
+      // a string; it is only valid for constant *string* symbols. For numeric
+      // symbols (int/float/bool) extract_string_from_symbol misreads the value
+      // — an int 65 decodes to the character 'A' (rejected as non-digit) and a
+      // float yields no string at all — so int(x) wrongly folds to 0. Route
+      // numeric symbols through the general numeric conversion instead, which
+      // truncates floats toward zero and treats ints as identity. (GitHub #4770)
+      if (
+        sym && sym->get_value().is_constant() &&
+        type_utils::is_string_type(sym->get_type()))
       {
         if (base_expr.is_nil())
         {


### PR DESCRIPTION
int(x) where x is a constant numeric variable (e.g. `f = 65.0; int(f)`) was unconditionally routed through `handle_str_symbol_to_int`, which decodes the symbol's value as a string: a signedbv int 65 decoded to the char 'A' (rejected as non-digit) and a floatbv yielded no string at all, so int(x) folded to the literal 0 in the GOTO program — an unsound constant fold affecting both int(const_int) and int(const_float).

Gate the compile-time string fast path on `type_utils::is_string_type` so only genuine constant string symbols take it; numeric symbols fall through to `handle_int_conversion`, which is identity on int, truncates floats toward zero (matching Python int()) and converts bool to 0/1. Constant strings keep their existing compile-time parse.

Adds positive/negative regression tests; all 50 CORE int() tests still pass and CPython parity is confirmed. Partially addresses #4770 (the chr(int(float)) case); the cast test itself stays KNOWNBUG pending variable retyping (#4774).