### PR TITLE
[termination] keep bare self-loops under --termination (#4426)

### DIFF
--- a/regression/termination/github_4426_bounded_loop/main.c
+++ b/regression/termination/github_4426_bounded_loop/main.c
@@ -1,0 +1,19 @@
+/* Terminating companion to github_4426_infinite_loop (esbmc/esbmc#4426).
+ *
+ * Same harness shape (main -> ldv_stop -> loop), but the loop is bounded and
+ * therefore terminates. The result must stay VERIFICATION SUCCESSFUL: the
+ * #4426 fix (not rewriting bare self-loops away under --termination) must not
+ * make a genuinely terminating loop report non-termination.
+ */
+void ldv_stop(int n)
+{
+  int i = 0;
+  while (i < n)
+    i++;
+}
+
+int main(void)
+{
+  ldv_stop(3);
+  return 0;
+}

--- a/regression/termination/github_4426_bounded_loop/test.desc
+++ b/regression/termination/github_4426_bounded_loop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--termination --k-step 2 --max-k-step 6 --max-inductive-step 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/termination/github_4426_infinite_loop/main.c
+++ b/regression/termination/github_4426_infinite_loop/main.c
@@ -1,0 +1,24 @@
+/* Regression for esbmc/esbmc#4426
+ * (ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil).
+ *
+ * The LDV harness ends every path in ldv_stop(), which is a bare unconditional
+ * infinite loop. The program therefore never terminates, so the termination
+ * property is FALSE.
+ *
+ * A bare self-loop `A: goto A;` used to be rewritten to assume(false) (in
+ * goto_loopst::find_function_loops and again in symex_goto), which is sound for
+ * reachability but erases the non-termination under --termination, yielding a
+ * spurious VERIFICATION SUCCESSFUL (0 VCCs, "forward condition shows all
+ * executions terminate"). Both rewrites are now skipped under --termination.
+ */
+void ldv_stop(void)
+{
+  ldv_stop_label:;
+  goto ldv_stop_label;
+}
+
+int main(void)
+{
+  ldv_stop();
+  return 0;
+}

--- a/regression/termination/github_4426_infinite_loop/test.desc
+++ b/regression/termination/github_4426_infinite_loop/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--termination --k-step 2 --max-k-step 6 --max-inductive-step 3
+^VERIFICATION FAILED$
+^.*non-terminating execution.*$

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -1,5 +1,6 @@
 #include "irep2/irep2_utils.h"
 #include <goto-programs/goto_loops.h>
+#include <util/config.h>
 #include <util/expr_util.h>
 
 bool check_var_name(const expr2tc &expr)
@@ -58,8 +59,18 @@ void goto_loopst::find_function_loops()
       // Convert it into: assume(!g);
       if (loop_head->location_number == loop_exit->location_number)
       {
-        simplify(loop_head->guard);
-        it->make_assumption(not2tc(loop_head->guard));
+        // For `A: goto A;` (unconditional self-loop) this rewrite produces
+        // assume(false), which erases an infinite empty loop. That is fine for
+        // reachability, but under --termination it masks the very
+        // non-termination the property checks (the loop never exits, so the
+        // program does not terminate). Leave the self-loop in place so the
+        // termination analysis / forward condition can observe it. Mirrors the
+        // identical guard in goto_loop_simplify.cpp. See issue #4426.
+        if (!config.options.get_bool_option("termination"))
+        {
+          simplify(loop_head->guard);
+          it->make_assumption(not2tc(loop_head->guard));
+        }
         continue;
       }
       create_function_loop(loop_head, loop_exit);

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -163,7 +163,17 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   // backwards?
   if (!forward)
   {
-    if (goto_target == cur_state->source.pc)
+    // A bare self-loop `A: IF cond GOTO A` / `A: GOTO A` is normally
+    // shortcut to assume(!cond) (assume(false) for the unconditional case):
+    // the guard's truth value never changes, so the loop either exits
+    // immediately or spins forever, and assuming the exit condition kills the
+    // non-terminating path. That is sound for reachability but masks
+    // non-termination, so under --termination fall through to the normal
+    // backwards-goto unwinding instead, letting loop_bound_exceeded raise the
+    // forward-condition signal that the loop never exits. See issue #4426.
+    if (
+      goto_target == cur_state->source.pc &&
+      !config.options.get_bool_option("termination"))
     {
       assert(
         cur_state->source.pc->location_number == goto_target->location_number);


### PR DESCRIPTION
## Issue

Fixes #4426 — a **termination false negative** (soundness bug). On [`c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil`](https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/main/c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--media--rc--lirc_dev.ko.cil.i) (ground truth **FALSE** / non-terminating), ESBMC reported `VERIFICATION SUCCESSFUL`/TRUE under the `kinduction` `--termination` profile: *"Generated 0 VCC(s) … forward condition shows all executions terminate (k = 1)."*

## Root cause

The LDV harness ends every path in `ldv_stop()`, which is a bare unconditional infinite loop:

```c
void ldv_stop(void) { ldv_stop_label: ; goto ldv_stop_label; }
```

The program therefore never terminates. But ESBMC rewrites a bare self-loop `A: goto A;` to `assume(false)` in **two** places:

1. `goto_loopst::find_function_loops` (`src/goto-programs/goto_loops.cpp`) — `loop_head == loop_exit` ⇒ `assume(!guard)`, i.e. `assume(false)` for the unconditional case.
2. `goto_symext::symex_goto` (`src/goto-symex/symex_goto.cpp`) — the `goto_target == cur_state->source.pc` self-loop shortcut emits `assume(false)`.

`assume(false)` is sound for **reachability** (nothing after an infinite empty loop is reachable). But under `--termination` it makes the symbolic path infeasible, so there is no loop to unwind, **0 VCCs** are generated, and the forward condition trivially "proves" termination — erasing exactly the non-termination the property is testing. (`goto_loop_simplify.cpp` already guards its copy of this rewrite under `--termination`; these two sites did not.)

## Fix

Gate both rewrites on `!config.options.get_bool_option("termination")`, mirroring `goto_loop_simplify.cpp:592`. Under `--termination` the bare self-loop survives to symex's normal backwards-goto unwinding, where the pre-existing `loop_bound_exceeded` (which already has a `--termination` carve-out) raises the forward-condition unwinding assertion `claim(!guard)` = `claim(false)` — the "loop never exits" non-termination signal. The inductive step then reports a non-terminating execution.

## Why it is correct (no overreach)

`abort()` / `exit()` / `__assert_fail` are NORETURN "program end" constructs lowered through `goto_termination`'s abort-marker mechanism (an `ASSERT(false)` marker spliced before the call), **not** as bare `goto` self-loops. So a program that terminates *via* abort/exit is unaffected. Verified directly:

| Program | Verdict |
|---|---|
| `while(1) { abort(); }` | SUCCESSFUL ✓ (ends via abort) |
| `while(1) { exit(0); }` | SUCCESSFUL ✓ |
| `while(x<10) x++;` | SUCCESSFUL ✓ |
| `while(1) {}` | FAILED ✓ (non-terminating) |
| `for(;;);` | FAILED ✓ |
| `ldv_stop()` self-loop | FAILED ✓ |

Both guards are gated on `--termination`, so reachability, k-induction-for-safety, interval, contractor and bmc modes are byte-for-byte unchanged (the self-loop still collapses for them). `config.options` is populated (and the `--k-induction`/`--termination` conflict already resolved) before these passes run.

## Validation

- **Reproduction → fix (dual-solver):** the real lirc_dev benchmark now reports `VERIFICATION FAILED` / *"Inductive step shows a non-terminating execution (k = 3)"* under **both Bitwuzla and Z3** (was `SUCCESSFUL`).
- **Regression-fails-on-unfixed-code:** reverting the patch flips the new `github_4426_infinite_loop` test back to `VERIFICATION SUCCESSFUL` (C-Live obligation discharged — both guard arms reachable, the termination arm load-bearing).
- **New tests** (`regression/termination/`): `github_4426_infinite_loop` (bare self-loop ⇒ FAILED + non-terminating) and `github_4426_bounded_loop` (same harness shape, bounded ⇒ SUCCESSFUL — guards against over-flagging).
- **No regressions:** termination + k-induction suite (224 tests) and the broader esbmc/k-induction/interval/contractor subset (1593 tests) show **0 new failures** vs pristine master.
- clang-format clean.

Local reproduction was on aarch64 macOS (the `.i` file's x86 inline asm in `__get_user`/`__put_user`/`xchg` helpers was neutralized — outputs become nondet, irrelevant to termination); final soundness validation should come from the x86_64 CI benchexec run.
