### PR TITLE
Prefer prefix ++/-- for iterators flagged by Codacy

### DIFF
--- a/src/esbmc/document_subgoals.cpp
+++ b/src/esbmc/document_subgoals.cpp
@@ -15,7 +15,7 @@ void strip_space(std::list<linet> &lines)
   unsigned strip = 50;
 
   for (std::list<linet>::const_iterator it = lines.begin(); it != lines.end();
-       it++)
+       ++it)
   {
     for (unsigned j = 0; j < strip && j < it->text.size(); j++)
       if (it->text[j] != ' ')
@@ -159,7 +159,7 @@ void get_code(const irept &location, std::string &dest)
 
   for (std::list<linet>::iterator it = lines.end(); it != lines.begin();)
   {
-    it--;
+    --it;
 
     if (is_empty_str(it->text))
       it = lines.erase(it);
@@ -213,7 +213,7 @@ void document_subgoals(
     }
 
   for (claim_sett::const_iterator it = claim_set.begin(); it != claim_set.end();
-       it++)
+       ++it)
   {
     std::string code;
     const irept &location = it->first;

--- a/src/esbmc/show_vcc.cpp
+++ b/src/esbmc/show_vcc.cpp
@@ -16,7 +16,7 @@ void bmct::show_vcc(std::ostream &out, const symex_target_equationt &eq)
   for (symex_target_equationt::SSA_stepst::const_iterator it =
          eq.SSA_steps.begin();
        it != eq.SSA_steps.end();
-       it++)
+       ++it)
   {
     if (!it->is_assert() || it->ignore)
       continue;
@@ -30,7 +30,7 @@ void bmct::show_vcc(std::ostream &out, const symex_target_equationt &eq)
     symex_target_equationt::SSA_stepst::const_iterator p_it =
       eq.SSA_steps.begin();
 
-    for (unsigned count = 1; p_it != it; p_it++)
+    for (unsigned count = 1; p_it != it; ++p_it)
       if (p_it->is_assume() || p_it->is_assignment())
         if (!p_it->ignore)
         {

--- a/src/goto-programs/format_strings.cpp
+++ b/src/goto-programs/format_strings.cpp
@@ -25,7 +25,7 @@ void parse_flags(std::string::const_iterator &it, format_tokent &curtok)
     default:
       throw 0;
     }
-    it++;
+    ++it;
   }
 }
 
@@ -34,11 +34,11 @@ void parse_field_width(std::string::const_iterator &it, format_tokent &curtok)
   if (*it == '*')
   {
     curtok.flags.push_back(format_tokent::ASTERISK);
-    it++;
+    ++it;
   }
 
   std::string tmp;
-  for (; isdigit(*it); it++)
+  for (; isdigit(*it); ++it)
     tmp += *it;
   curtok.field_width = string2integer(tmp);
 }
@@ -47,17 +47,17 @@ void parse_precision(std::string::const_iterator &it, format_tokent &curtok)
 {
   if (*it == '.')
   {
-    it++;
+    ++it;
 
     if (*it == '*')
     {
       curtok.flags.push_back(format_tokent::ASTERISK);
-      it++;
+      ++it;
     }
     else
     {
       std::string tmp;
-      for (; isdigit(*it); it++)
+      for (; isdigit(*it); ++it)
         tmp += *it;
       curtok.precision = string2integer(tmp);
     }
@@ -70,31 +70,31 @@ void parse_length_modifier(
 {
   if (*it == 'h')
   {
-    it++;
+    ++it;
     if (*it == 'h')
-      it++;
+      ++it;
     curtok.length_modifier = format_tokent::LEN_h;
   }
   else if (*it == 'l')
   {
-    it++;
+    ++it;
     if (*it == 'l')
-      it++;
+      ++it;
     curtok.length_modifier = format_tokent::LEN_l;
   }
   else if (*it == 'L')
   {
-    it++;
+    ++it;
     curtok.length_modifier = format_tokent::LEN_L;
   }
   else if (*it == 'j')
   {
-    it++;
+    ++it;
     curtok.length_modifier = format_tokent::LEN_j;
   }
   else if (*it == 't')
   {
-    it++;
+    ++it;
     curtok.length_modifier = format_tokent::LEN_L;
   }
 }
@@ -151,15 +151,15 @@ void parse_conversion_specifier(
   case '[': // pattern matching in, e.g., fscanf.
   {
     std::string tmp;
-    it++;
+    ++it;
     if (*it == '^') // if it's there, it must be first
     {
       tmp += '^';
-      it++;
+      ++it;
       if (*it == ']') // if it's there, it must be here
       {
         tmp += ']';
-        it++;
+        ++it;
       }
     }
 
@@ -172,7 +172,7 @@ void parse_conversion_specifier(
   default:
     throw std::string("unsupported format conversion specifier: `") + *it + "'";
   }
-  it++;
+  ++it;
 }
 
 bool parse_format_string(
@@ -193,7 +193,7 @@ bool parse_format_string(
       {
         token_list.push_back(format_tokent());
         format_tokent &curtok = token_list.back();
-        it++;
+        ++it;
 
         parse_flags(it, curtok);
         parse_field_width(it, curtok);
@@ -207,7 +207,7 @@ bool parse_format_string(
           token_list.push_back(format_tokent(format_tokent::TEXT));
 
         std::string tmp;
-        for (; it != arg_string.end() && *it != '%'; it++)
+        for (; it != arg_string.end() && *it != '%'; ++it)
           tmp += *it;
 
         token_list.back().value = tmp;

--- a/src/goto-programs/goto_program_irep.cpp
+++ b/src/goto-programs/goto_program_irep.cpp
@@ -98,12 +98,12 @@ void convert(const irept &irep, goto_programt &program)
   for (goto_programt::instructionst::iterator lit =
          program.instructions.begin();
        lit != program.instructions.end() && nit != number_targets_list.end();
-       lit++, nit++)
+       ++lit, ++nit)
   {
     for (unsigned int &tit : *nit)
     {
       goto_programt::targett fit = program.instructions.begin();
-      for (; fit != program.instructions.end(); fit++)
+      for (; fit != program.instructions.end(); ++fit)
       {
         if (fit->location_number == tit)
         {

--- a/src/goto-programs/remove_unreachable.cpp
+++ b/src/goto-programs/remove_unreachable.cpp
@@ -48,7 +48,7 @@ void remove_unreachable(goto_programt &goto_program)
       for (goto_programt::const_targetst::const_iterator s_it =
              successors.begin();
            s_it != successors.end();
-           s_it++)
+           ++s_it)
         working.push(*s_it);
     }
   }

--- a/src/solvers/sat/bitblast_conv.cpp
+++ b/src/solvers/sat/bitblast_conv.cpp
@@ -500,7 +500,7 @@ bool bitblast_convt::process_clause(const bvt &bv, bvt &dest)
 
   dest.reserve(bv.size());
 
-  for (bvt::const_iterator it = bv.begin(); it != bv.end(); it++)
+  for (bvt::const_iterator it = bv.begin(); it != bv.end(); ++it)
   {
     literalt l = *it;
 
@@ -527,7 +527,7 @@ void bitblast_convt::eliminate_duplicates(const bvt &bv, bvt &dest)
 
   dest.reserve(bv.size());
 
-  for (bvt::const_iterator it = bv.begin(); it != bv.end(); it++)
+  for (bvt::const_iterator it = bv.begin(); it != bv.end(); ++it)
   {
     if (s.insert(*it).second)
       dest.push_back(*it);

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -81,7 +81,7 @@ bool struct_typet::is_prefix_of(const struct_typet &other) const
       return false; // they just don't match
     }
 
-    ot_it++;
+    ++ot_it;
   }
 
   return true; // ok, *this is a prefix of ot

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -117,7 +117,7 @@ void xmlt::do_indent(std::ostream &out, unsigned indent)
 xmlt::elementst::const_iterator xmlt::find(const std::string &name) const
 {
   for (elementst::const_iterator it = elements.begin(); it != elements.end();
-       it++)
+       ++it)
     if (it->name == name)
       return it;
 
@@ -126,7 +126,7 @@ xmlt::elementst::const_iterator xmlt::find(const std::string &name) const
 
 xmlt::elementst::iterator xmlt::find(const std::string &name)
 {
-  for (elementst::iterator it = elements.begin(); it != elements.end(); it++)
+  for (elementst::iterator it = elements.begin(); it != elements.end(); ++it)
     if (it->name == name)
       return it;
 
@@ -158,12 +158,12 @@ std::string xmlt::unescape(const std::string &str)
 
   result.reserve(str.size());
 
-  for (std::string::const_iterator it = str.begin(); it != str.end(); it++)
+  for (std::string::const_iterator it = str.begin(); it != str.end(); ++it)
   {
     if (*it == '&')
     {
       std::string tmp;
-      it++;
+      ++it;
 
       while (it != str.end() && *it != ';')
         tmp += *it++;

--- a/src/util/xml_irep.cpp
+++ b/src/util/xml_irep.cpp
@@ -30,7 +30,7 @@ void convert(const xmlt &xml, irept &irep)
 {
   irep.id("nil");
   xmlt::elementst::const_iterator it = xml.elements.begin();
-  for (; it != xml.elements.end(); it++)
+  for (; it != xml.elements.end(); ++it)
   {
     if (it->name == "id")
     {


### PR DESCRIPTION
Convert discarded-value post-increment/decrement on STL iterators to the prefix form across nine files, resolving the Codacy "prefer prefix ++/-- for non-primitive types" performance findings. Every site is a for-loop increment clause or standalone statement, so the change is semantics-preserving; the one value-used post-increment (xml.cpp's `tmp += *it++;`) is left untouched.