### PR TITLE
[util] don't abort in ~tmp_path when the path is already removed

### DIFF
--- a/src/util/filesystem.cpp
+++ b/src/util/filesystem.cpp
@@ -37,8 +37,15 @@ tmp_path::~tmp_path()
 {
   if (_keep)
     return;
-  uintmax_t removed [[maybe_unused]] = boost::filesystem::remove_all(_path);
-  assert(removed >= 1 && "expected to remove temp path");
+  // Best-effort cleanup: the path may already be gone. create_tmp_dir() also
+  // hands the path to register_tmp_for_cleanup(), so cleanup_registered_tmps()
+  // — invoked from the signal handler before exit() runs static/RAII
+  // destructors (see signal_catcher.cpp) — can remove it first. remove_all
+  // then returns 0, which is a valid "nothing to remove" outcome, not an
+  // error. Use the non-throwing form and tolerate a missing path; asserting
+  // removed >= 1 here aborted on SIGTERM/SIGINT (e.g. a benchexec timeout).
+  boost::system::error_code ec;
+  boost::filesystem::remove_all(_path, ec);
 }
 
 tmp_path &tmp_path::operator=(tmp_path o)

--- a/unit/util/filesystem.test.cpp
+++ b/unit/util/filesystem.test.cpp
@@ -62,3 +62,27 @@ TEST_CASE("tmp file is file and should be removed", "[core][util][filesystem]")
   }
   REQUIRE(!boost::filesystem::exists(path));
 }
+
+TEST_CASE(
+  "tmp_path destructor tolerates an already-removed path",
+  "[core][util][filesystem]")
+{
+  // create_tmp_dir() also registers the path with register_tmp_for_cleanup(),
+  // so cleanup_registered_tmps() (run from the signal handler before exit()
+  // triggers static/RAII destructors) can remove the directory before the
+  // tmp_path destructor runs. Pre-fix, the destructor asserted removed >= 1
+  // and aborted (SIGABRT) on SIGTERM/SIGINT, e.g. a benchexec timeout. The
+  // destructor must instead tolerate the directory already being gone.
+  const char *format = "esbmc-test-%%%%";
+  std::string path;
+  {
+    auto dir = file_operations::create_tmp_dir(format);
+    path = dir.path();
+    REQUIRE(boost::filesystem::is_directory(path));
+    // Simulate the registered-cleanup / signal-handler removing it first.
+    boost::filesystem::remove_all(path);
+    REQUIRE(!boost::filesystem::exists(path));
+    // dir's destructor runs at end of scope: must not abort.
+  }
+  REQUIRE(!boost::filesystem::exists(path));
+}


### PR DESCRIPTION
## Summary

Fixes a `SIGABRT` in `tmp_path::~tmp_path()` (`src/util/filesystem.cpp`) that fires when ESBMC receives a catchable signal (SIGTERM/SIGINT — e.g. a benchexec timeout) in an assertions-enabled build.

## Root cause

`create_tmp_dir()` sets up **two** independent owners of the same temp directory:

```cpp
tmp_path file_operations::create_tmp_dir(const std::string &format)
{
  std::string dir = with_unique_tmp_path(...);
  register_tmp_for_cleanup(dir);   // (1) cleaned by cleanup_registered_tmps()
  return {std::move(dir)};         // (2) tmp_path(keep=false): destructor also removes
}
```

`signal_catcher()` (`src/util/signal_catcher.cpp`) runs `cleanup_registered_tmps()` and then **`exit(sig)`**. Unlike `_exit`, `exit()` runs static/RAII destructors — including the static `tmp_path` that holds the `esbmc-headers-*` directory (`src/clang-c-frontend/clang_headers.cpp:24`). So on a signal:

1. `cleanup_registered_tmps()` removes the directory (owner 1), then
2. `exit()` runs `~tmp_path` (owner 2), whose `remove_all` now returns `0`, tripping `assert(removed >= 1 && "expected to remove temp path")` → **SIGABRT**.

The `--timeout` handler (`esbmc_parseoptions.cpp`) uses `_exit(1)`, which skips destructors, so it was unaffected — which is why only signal-driven termination crashed.

Release/`NDEBUG` builds don't evaluate the assert, so CI's release binary was unaffected; the crash hit assertion-enabled (Debug/RelWithDebInfo) builds, where a timeout-kill aborts during shutdown.

## Fix

Make the destructor best-effort and idempotent, matching `cleanup_registered_tmps()`'s own idiom:

```cpp
tmp_path::~tmp_path()
{
  if (_keep)
    return;
  boost::system::error_code ec;
  boost::filesystem::remove_all(_path, ec);
}
```

`removed == 0` is a legitimate "nothing to remove" outcome given the by-design double cleanup, not an error. The non-throwing overload also removes a latent **throw-from-`noexcept`-destructor** (the old `remove_all(_path)` throws `filesystem_error` on a genuine failure → `std::terminate`).

## Validation

- New unit test `unit/util/filesystem.test.cpp` reproduces the double-removal (remove the dir, then run the `tmp_path` destructor). **Verified: SIGABRT on unfixed code, passes after the fix.**
- Full `filesystemtest` suite passes (6 cases); util unit tests green.
- clang-format clean; change confined to the `file_operations` utility layer.

Discovered while investigating SV-COMP issues #4427/#4432 (the abort masked the real verdict on signal/timeout). Not tied to a single issue; standalone hardening.
