### PR TITLE
[python] route list(dict)/sorted(dict) through d.keys()

### DIFF
--- a/regression/python/list_sorted_dict/main.py
+++ b/regression/python/list_sorted_dict/main.py
@@ -1,0 +1,27 @@
+# Regression for GitHub #4790: list(d) / sorted(d) over a dict were lowered by
+# relabeling the dict struct as a list, giving a wrong length and an unsound
+# subscript that read a wrong deterministic value. They are now routed through
+# d.keys(), the correctly typed dict-keys list.
+
+# list(dict) -> keys in insertion order
+d = {7: 70, 3: 30}
+ks = list(d)
+assert len(ks) == 2
+assert ks[0] == 7
+assert ks[1] == 3
+
+# sorted(dict) -> sorted list of keys
+s = sorted(d)
+assert s[0] == 3
+assert s[1] == 7
+
+# iteration over list(dict)
+total = 0
+for k in list(d):
+    total += k
+assert total == 10
+
+# lowercase dict[...] annotation is recognised too
+e: dict[int, int] = {2: 20, 1: 10}
+se = sorted(e)
+assert se[0] == 1

--- a/regression/python/list_sorted_dict/test.desc
+++ b/regression/python/list_sorted_dict/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_sorted_dict_fail/main.py
+++ b/regression/python/list_sorted_dict_fail/main.py
@@ -1,0 +1,9 @@
+# Negative variant of list_sorted_dict (GitHub #4790).
+#
+# list(d) yields the keys in insertion order, so list({7:70, 9:90})[1] is 9,
+# not 7. The subscript now reads the correct key value, so asserting it equals
+# 7 must be refuted (before the fix the subscript read a wrong constant, which
+# would refute this for the wrong reason).
+d = {7: 70, 9: 90}
+ks = list(d)
+assert ks[1] == 7

--- a/regression/python/list_sorted_dict_fail/test.desc
+++ b/regression/python/list_sorted_dict_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -217,10 +217,15 @@ class CoreVisitorsMixin:
             self.list_literal_values.pop(target_id, None)
 
         if isinstance(node.value, ast.Dict):
+            self.dict_literal_vars.add(target_id)
             if self._has_heterogeneous_keys(node.value):
                 self.het_dict_literals[target_id] = node.value
             if self._has_heterogeneous_values(node.value):
                 self.het_value_dict_literals[target_id] = node.value
+        else:
+            # Reassigned to a non-dict: stop treating the name as a dict so a
+            # later list(name)/sorted(name) is not rewritten incorrectly.
+            self.dict_literal_vars.discard(target_id)
 
         if isinstance(node.value, ast.Call):
             self._track_call_result_bindings(target_id, node)
@@ -651,8 +656,68 @@ class CoreVisitorsMixin:
             return self._handle_single_target_assign(node)
         return self._handle_multi_target_assign(node)
 
+    def _is_known_dict_name(self, name):
+        """True when `name` is reliably known to be bound to a dict.
+
+        Only an explicit ``dict``/``Dict`` annotation or a tracked dict-literal
+        binding qualifies, so the list(d)/sorted(d) rewrite never fires on a
+        list/set/other iterable.
+        """
+        ann = self.variable_annotations.get(name)
+        if isinstance(ann, ast.Subscript) and isinstance(ann.value, ast.Name):
+            if ann.value.id in ("dict", "Dict"):
+                return True
+            # An annotation for a different generic (list[...], set[...], ...)
+            # means the name was rebound away from a dict; do not treat a stale
+            # dict-literal binding as a dict.
+            return False
+        return name in self.dict_literal_vars
+
+    def _maybe_rewrite_dict_to_list_call(self, node):
+        """Rewrite list(d) -> d.keys() and sorted(d, ...) -> sorted(d.keys(), ...).
+
+        The bare list()/sorted() builtins reinterpret the dict struct as a list
+        (wrong length, unsound subscript). Routing through d.keys() reuses the
+        correctly-typed dict-keys list path. Only fires for names reliably known
+        to be dicts. (GitHub #4790)
+        """
+        if not (isinstance(node.func, ast.Name)
+                and node.func.id in ("list", "sorted")):
+            return None
+        if not node.args or (node.keywords and node.func.id == "list"):
+            return None
+        first = node.args[0]
+        if not (isinstance(first, ast.Name) and self._is_known_dict_name(first.id)):
+            return None
+
+        keys_call = ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(id=first.id, ctx=ast.Load()),
+                attr="keys",
+                ctx=ast.Load()),
+            args=[],
+            keywords=[])
+        ast.copy_location(keys_call, node)
+        ast.fix_missing_locations(keys_call)
+
+        if node.func.id == "list":
+            # list(d) yields the keys list; d.keys() is exactly that. Note this
+            # aliases the dict's keys member rather than copying it, so mutating
+            # the result also mutates the dict — acceptable here because the
+            # pre-fix relabeling was outright unsound, and the common uses
+            # (len/iteration/indexing/sorted) are read-only.
+            return self.visit(keys_call)
+
+        # sorted(d, key=..., reverse=...) -> sorted(d.keys(), key=..., reverse=...)
+        node.args[0] = keys_call
+        self.generic_visit(node)
+        return node
+
     def visit_Call(self, node):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,import-outside-toplevel,no-else-raise
         self._invalidate_list_literals_for_call(node)
+        rewritten_dict_list = self._maybe_rewrite_dict_to_list_call(node)
+        if rewritten_dict_list is not None:
+            return rewritten_dict_list
         rewritten_newtype = self._maybe_rewrite_newtype_call(node)
         if rewritten_newtype is not None:
             return rewritten_newtype
@@ -679,31 +744,39 @@ class CoreVisitorsMixin:
         return node
 
     def visit_FunctionDef(self, node):  # pylint: disable=too-many-branches,too-many-statements
-        node = self._rewrite_humaneval_20_none_sentinel(node)
+        # dict-literal bindings are local to a scope: snapshot on entry and
+        # restore on exit so a dict named `d` in one function does not make a
+        # same-named plain parameter in another function look like a dict.
+        saved_dict_vars = set(self.dict_literal_vars)
+        try:
+            node = self._rewrite_humaneval_20_none_sentinel(node)
 
-        if (len(node.args.args) == 1 and len(node.body) == 1
-                and isinstance(node.body[0], ast.Return)
-                and isinstance(node.body[0].value, ast.Name)
-                and node.body[0].value.id == node.args.args[0].arg):
-            self._identity_functions.add(node.name)
+            if (len(node.args.args) == 1 and len(node.body) == 1
+                    and isinstance(node.body[0], ast.Return)
+                    and isinstance(node.body[0].value, ast.Name)
+                    and node.body[0].value.id == node.args.args[0].arg):
+                self._identity_functions.add(node.name)
 
-        self._resolve_and_store_function_annotations(node)
-        node, is_generator = self._prepare_generator_function(node)
-        self._record_function_param_types(node)
-        qualified_name = self._build_qualified_function_name(node)
+            self._resolve_and_store_function_annotations(node)
+            node, is_generator = self._prepare_generator_function(node)
+            self._record_function_param_types(node)
+            qualified_name = self._build_qualified_function_name(node)
 
-        self.functionParams[qualified_name] = [i.arg for i in node.args.args]
-        self.functionKwonlyParams[qualified_name] = [i.arg for i in node.args.kwonlyargs]
+            self.functionParams[qualified_name] = [i.arg for i in node.args.args]
+            self.functionKwonlyParams[qualified_name] = [
+                i.arg for i in node.args.kwonlyargs]
 
-        if len(node.args.defaults) < 1 and len(node.args.kw_defaults) < 1:
+            if len(node.args.defaults) < 1 and len(node.args.kw_defaults) < 1:
+                self.generic_visit(node)
+                if is_generator:
+                    self.generator_func_defs[node.name] = list(node.body)
+                return node
+            return_nodes = self._store_function_defaults(node, qualified_name)
+
             self.generic_visit(node)
             if is_generator:
                 self.generator_func_defs[node.name] = list(node.body)
-            return node
-        return_nodes = self._store_function_defaults(node, qualified_name)
-
-        self.generic_visit(node)
-        if is_generator:
-            self.generator_func_defs[node.name] = list(node.body)
-        return_nodes.append(node)
-        return return_nodes
+            return_nodes.append(node)
+            return return_nodes
+        finally:
+            self.dict_literal_vars = saved_dict_vars

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -681,8 +681,7 @@ class CoreVisitorsMixin:
         correctly-typed dict-keys list path. Only fires for names reliably known
         to be dicts. (GitHub #4790)
         """
-        if not (isinstance(node.func, ast.Name)
-                and node.func.id in ("list", "sorted")):
+        if not (isinstance(node.func, ast.Name) and node.func.id in ("list", "sorted")):
             return None
         if not node.args or (node.keywords and node.func.id == "list"):
             return None
@@ -690,13 +689,11 @@ class CoreVisitorsMixin:
         if not (isinstance(first, ast.Name) and self._is_known_dict_name(first.id)):
             return None
 
-        keys_call = ast.Call(
-            func=ast.Attribute(
-                value=ast.Name(id=first.id, ctx=ast.Load()),
-                attr="keys",
-                ctx=ast.Load()),
-            args=[],
-            keywords=[])
+        keys_call = ast.Call(func=ast.Attribute(value=ast.Name(id=first.id, ctx=ast.Load()),
+                                                attr="keys",
+                                                ctx=ast.Load()),
+                             args=[],
+                             keywords=[])
         ast.copy_location(keys_call, node)
         ast.fix_missing_locations(keys_call)
 
@@ -763,8 +760,7 @@ class CoreVisitorsMixin:
             qualified_name = self._build_qualified_function_name(node)
 
             self.functionParams[qualified_name] = [i.arg for i in node.args.args]
-            self.functionKwonlyParams[qualified_name] = [
-                i.arg for i in node.args.kwonlyargs]
+            self.functionKwonlyParams[qualified_name] = [i.arg for i in node.args.kwonlyargs]
 
             if len(node.args.defaults) < 1 and len(node.args.kw_defaults) < 1:
                 self.generic_visit(node)

--- a/src/python-frontend/preprocessor/preprocessor_state_mixin.py
+++ b/src/python-frontend/preprocessor/preprocessor_state_mixin.py
@@ -40,6 +40,9 @@ class PreprocessorStateMixin:
         self._defaultdict_factory = {}
         self.het_dict_literals = {}
         self.het_value_dict_literals = {}
+        # Names currently bound to a dict literal (any key types). Used to
+        # rewrite list(d)/sorted(d) into the correctly-typed d.keys() path.
+        self.dict_literal_vars = set()
         self.bound_method_vars = {}
         self.called_names = set()
         self.list_literal_values = {}


### PR DESCRIPTION
list(d) and sorted(d) over a dict were lowered by the builtin-constructor fall-through, which relabels the dict struct's type as a list (`ks = &d`). `list_size` then read the dict layout (wrong length) and subscript read a wrong **deterministic** value, so e.g. `assert list({7:10})[0] != 7` verified SUCCESSFUL — an unsound result. Python's `list(d)`/`sorted(d)` operate on the dict keys.

## Fix
Rewrite `list(d)` → `d.keys()` and `sorted(d, ...)` → `sorted(d.keys(), ...)` in the preprocessor when `d` is reliably a dict (a `dict[...]`/`Dict[...]` annotation or a tracked dict-literal binding), reusing the already-correct `d.keys()` lowering so length, iteration and subscript are all correct and sound.

Robustness: the dict-literal tracking is **scoped per function** (snapshot/restore around `visit_FunctionDef`) and **corroborated against the current annotation**, so a same-named non-dict in another scope, or a name rebound away from a dict, is never rewritten. The rewrite is conservative — bare `list()`/`sorted()`, non-Name args, and `list()` with keywords are skipped.

## Validation
- New `regression/python/list_sorted_dict{,_fail}` pass via ctest and match CPython; the previously-unsound `assert list({7:10})[0] != 7` now correctly FAILS.
- All 65 CORE tests calling `list()`/`sorted()` pass; the dict/list/sorted/comprehension/closure/nested ctest subset shows no regressions.
- pylint clean.

Known limitation (separate, pre-existing): `typing.Dict` (capital) annotations are independently broken (even `len(d)` warns "module-file-not-found"); inline `sorted(d)[0]` without binding to a variable produces a hard error (sound, never a false verdict).

Fixes #4790