### PR TITLE
[goto-programs] don't warn on float zero in interval analysis

### DIFF
--- a/regression/esbmc/github_1037/main.c
+++ b/regression/esbmc/github_1037/main.c
@@ -1,0 +1,11 @@
+// Regression for #1037: the interval domain used to print a bogus
+// "ESBMC fails to convert constant_floatbv ... value 0.000000 ... into double"
+// warning for every zero double constant, because isnormal(0.0) is false.
+// Zero converts to 0.0 correctly, so no warning must be emitted.
+int main()
+{
+  double x = 0.0;
+  double y = x + 1.0;
+  __ESBMC_assert(y > 0.0, "y must be positive");
+  return 0;
+}

--- a/regression/esbmc/github_1037/test.desc
+++ b/regression/esbmc/github_1037/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+\A(?![\s\S]*fails to convert)[\s\S]*VERIFICATION SUCCESSFUL[\s\S]*\Z

--- a/regression/esbmc/github_1037_fail/main.c
+++ b/regression/esbmc/github_1037_fail/main.c
@@ -1,0 +1,9 @@
+// Companion to github_1037: exercises the normal (non-zero) float interval
+// path under --interval-analysis and must still report VERIFICATION FAILED
+// (the assertion is false), with no spurious "fails to convert" warning.
+int main()
+{
+  double x = 3.0;
+  __ESBMC_assert(x < 0.0, "should fail: x is positive");
+  return 0;
+}

--- a/regression/esbmc/github_1037_fail/test.desc
+++ b/regression/esbmc/github_1037_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+\A(?![\s\S]*fails to convert)[\s\S]*VERIFICATION FAILED[\s\S]*\Z

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -138,8 +138,6 @@ interval_domaint::get_interval_from_const(const expr2tc &e) const
   return result;
 }
 
-#include <cmath>
-
 template <>
 interval_domaint::real_intervalt
 interval_domaint::get_interval_from_const(const expr2tc &e) const
@@ -150,15 +148,20 @@ interval_domaint::get_interval_from_const(const expr2tc &e) const
 
   auto real_value = to_constant_floatbv2t(e).value;
 
-  // Health check, is the conversion to double ok? See #1037
-  if (!real_value.is_normal() || real_value.is_zero())
+  // Zero is exactly representable as a double (#1037 was fixed in PR #1038);
+  // the tightest sound interval for a zero constant is [0, 0].
+  if (real_value.is_zero())
   {
-    if (real_value.is_double())
-      log_warning("ESBMC fails to convert {} into double", *e);
-
-    // Give up for top!
+    const double zero = real_value.to_double(); // exactly 0.0
+    result.make_le_than(zero);
+    result.make_ge_than(zero);
     return result;
   }
+
+  // We can only derive a finite real interval from a normal, double-precision
+  // constant. NaN/infinity, subnormals, or non-double specs stay at top.
+  if (!real_value.is_normal())
+    return result;
 
   auto value1 = to_constant_floatbv2t(e).value;
   auto value2 = to_constant_floatbv2t(e).value;

--- a/unit/util/ieee_float.test.cpp
+++ b/unit/util/ieee_float.test.cpp
@@ -30,3 +30,19 @@ TEST_CASE("ieee float can handle 1", "[core][util][ieee_floatt]")
     REQUIRE(std::isnormal(ieee_one.to_double())); // Holds
   }
 }
+
+TEST_CASE("ieee float converts zero to double", "[core][util][ieee_floatt]")
+{
+  // Zero is not "normal" (isnormal(0.0) is false) but it must still convert
+  // back to exactly 0.0 -- see #1037, where the interval domain mistook this
+  // for a conversion failure.
+  ieee_floatt ieee_zero(ieee_float_spect(52, 11));
+  ieee_zero.from_integer(0);
+
+  CAPTURE(
+    ieee_zero.get_exponent(), ieee_zero.get_fraction(), ieee_zero.get_sign());
+
+  REQUIRE(ieee_zero.is_zero());
+  REQUIRE_FALSE(std::isnormal(ieee_zero.to_double()));
+  REQUIRE(ieee_zero.to_double() == 0.0);
+}


### PR DESCRIPTION
The interval domain treated every zero double constant as a conversion failure (isnormal(0.0) is false), flooding output with a bogus "ESBMC fails to convert constant_floatbv ... into double" warning. The underlying to_double() bug was already fixed by PR #1038; zero converts to exactly 0.0. Handle zero as the tight interval [0,0], drop the misleading warning, and keep the conservative top result for the remaining non-normal cases (NaN/infinity/subnormal). Adds a unit test and github_1037{,_fail} regression tests.

Fixes #1037