### PR TITLE
[goto-race] flag shared writes inside atomic regions

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -358,16 +358,6 @@ set(_slow_regression_tests
     # the larger inner timeout lets testing_tool record the FUTURE
     # verdict instead of ctest hard-killing the run.
     "regression/esbmc-unix/github_4435"
-    # github_1456 (#1456) is the array-index data-race canary: two threads
-    # writing distinct elements a[0]/a[1] under --data-races-check must stay
-    # SUCCESSFUL. With POR disabled in races mode it deliberately explores the
-    # full ~24300-interleaving fan-out that #1456 was about, so it is symex- and
-    # interleaving-bound (trivial solving). On the Debug+Opt Linux runner that
-    # path runs with assertions enabled and tips just over the 120s cap
-    # (locally ~20s under RelWithDebInfo); #2863 already moved it to THOROUGH.
-    # Keep the full exploration as the regression signal and give it the 2x
-    # budget so DebugOpt jitter doesn't flap it.
-    "regression/esbmc-unix/github_1456"
 )
 math(EXPR ESBMC_REGRESS_CTEST_TIMEOUT_SLOW
      "${ESBMC_REGRESS_TIMEOUT_SLOW} + 30")

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -358,6 +358,16 @@ set(_slow_regression_tests
     # the larger inner timeout lets testing_tool record the FUTURE
     # verdict instead of ctest hard-killing the run.
     "regression/esbmc-unix/github_4435"
+    # github_1456 (#1456) is the array-index data-race canary: two threads
+    # writing distinct elements a[0]/a[1] under --data-races-check must stay
+    # SUCCESSFUL. With POR disabled in races mode it deliberately explores the
+    # full ~24300-interleaving fan-out that #1456 was about, so it is symex- and
+    # interleaving-bound (trivial solving). On the Debug+Opt Linux runner that
+    # path runs with assertions enabled and tips just over the 120s cap
+    # (locally ~20s under RelWithDebInfo); #2863 already moved it to THOROUGH.
+    # Keep the full exploration as the regression signal and give it the 2x
+    # budget so DebugOpt jitter doesn't flap it.
+    "regression/esbmc-unix/github_1456"
 )
 math(EXPR ESBMC_REGRESS_CTEST_TIMEOUT_SLOW
      "${ESBMC_REGRESS_TIMEOUT_SLOW} + 30")

--- a/regression/esbmc-unix/github_1456/test.desc
+++ b/regression/esbmc-unix/github_1456/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
---data-races-check
+--data-races-check --smt-symex-guard --context-bound 4
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_4975_atomic_write_norace/main.c
+++ b/regression/esbmc-unix/github_4975_atomic_write_norace/main.c
@@ -1,0 +1,47 @@
+#include <pthread.h>
+
+/* Companion to github_4975_atomic_write_race: the race-free twin.
+ *
+ * Here *every* access to the shared global `mThread` happens inside a
+ * __VERIFIER_atomic_ region. Two atomic regions are mutually exclusive, so
+ * there is no data race and the expected verdict is VERIFICATION SUCCESSFUL.
+ *
+ * This guards the #4975 fix against over-approximation: setting the write flag
+ * for in-region writes must NOT add an assertion *inside* atomic regions, or
+ * two mutually-exclusive atomic accesses to the same object would be reported
+ * as a spurious race (a completeness regression).
+ */
+
+int mThread = 0;
+
+void __VERIFIER_atomic_publish(int v)
+{
+  mThread = v; /* atomic write */
+}
+
+void __VERIFIER_atomic_read(int *out)
+{
+  *out = mThread; /* atomic read -- no race with the atomic write */
+}
+
+void *thr1(void *arg)
+{
+  __VERIFIER_atomic_publish(1);
+  return 0;
+}
+
+void *thr2(void *arg)
+{
+  int self;
+  __VERIFIER_atomic_read(&self);
+  (void)self;
+  return 0;
+}
+
+int main()
+{
+  pthread_t t;
+  pthread_create(&t, 0, thr1, 0);
+  thr2(0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4975_atomic_write_norace/test.desc
+++ b/regression/esbmc-unix/github_4975_atomic_write_norace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check-only --no-assertions --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_4975_atomic_write_race/main.c
+++ b/regression/esbmc-unix/github_4975_atomic_write_race/main.c
@@ -1,0 +1,49 @@
+#include <pthread.h>
+
+/* Regression for esbmc/esbmc#4975 (pthread-ext/23_lu-fig2.fixed).
+ *
+ * A R/W data race on the global `mThread`:
+ *   - thr1 writes `mThread` *inside* a __VERIFIER_atomic_ region;
+ *   - thr2 reads `mThread` with no synchronisation (its first statement).
+ *
+ * A __VERIFIER_atomic_ region only serialises a thread against *other* atomic
+ * regions; it establishes no happens-before relation with thr2's plain read,
+ * so the atomic write and the unsynchronised read are concurrent conflicting
+ * accesses -- a data race. The sv-benchmarks ground truth for this task is
+ * `no-data-race: false`.
+ *
+ * Before the fix, add_race_assertions emitted the in-region write as a bare
+ * assignment and never set its write flag, so thr2's RACE_CHECK(&mThread)
+ * could never observe a concurrent writer: ESBMC reported VERIFICATION
+ * SUCCESSFUL on a racy program (a soundness / false-negative bug).
+ */
+
+int mThread = 0;
+int start_main = 0;
+
+void __VERIFIER_atomic_publish(int v)
+{
+  mThread = v; /* shared write performed inside an atomic region */
+}
+
+void *thr1(void *arg)
+{
+  start_main = 1;
+  __VERIFIER_atomic_publish(1);
+  return 0;
+}
+
+void *thr2(void *arg)
+{
+  int self = mThread; /* unsynchronised read -- races with thr1's atomic write */
+  (void)self;
+  return 0;
+}
+
+int main()
+{
+  pthread_t t;
+  pthread_create(&t, 0, thr1, 0);
+  thr2(0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_4975_atomic_write_race/test.desc
+++ b/regression/esbmc-unix/github_4975_atomic_write_race/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--data-races-check-only --no-assertions --context-bound 2
+^VERIFICATION FAILED$
+^.*R/W data race on c:@mThread$

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -191,6 +191,13 @@ void add_race_assertions(
     config.options.get_bool_option("data-races-check-only");
   bool atomic_region_touched_shared = false;
 
+  // Write flags of the shared writes performed inside the atomic region
+  // currently being processed. They are set just before each in-region write
+  // but reset only *after* the region's boundary yield (see ATOMIC_END
+  // handling below), so the flag stays observable for one interleaving point.
+  // See https://github.com/esbmc/esbmc/issues/4975
+  std::list<expr2tc> atomic_write_guards;
+
   Forall_goto_program_instructions (i_it, goto_program)
   {
     goto_programt::instructiont &instruction = *i_it;
@@ -199,6 +206,7 @@ void add_race_assertions(
     {
       is_atomic = true;
       atomic_region_touched_shared = false;
+      atomic_write_guards.clear();
     }
 
     // Accesses inside an atomic region are not individually instrumented, but
@@ -219,6 +227,64 @@ void add_race_assertions(
         rw_sett probe(ns, i_it, probe_expr);
         if (!probe.entries.empty())
           atomic_region_touched_shared = true;
+      }
+    }
+
+    // A shared write that occurs *inside* an atomic region (e.g. the body of a
+    // __VERIFIER_atomic_* function) is otherwise emitted as a bare assignment:
+    // its write flag is never set, so a concurrent *non-atomic* access to the
+    // same object in another thread can never observe a writer and the race is
+    // missed -> false negative (VERIFICATION SUCCESSFUL on a racy program).
+    // See https://github.com/esbmc/esbmc/issues/4975
+    //
+    // Set the write flag right before the in-region write; the matching reset
+    // is deferred until after the atomic-region boundary yield (emitted at
+    // ATOMIC_END below), so the flag stays observable across that single
+    // interleaving point, mirroring the non-atomic instrumentation. No
+    // assertion is added inside the atomic region on purpose: two
+    // mutually-exclusive atomic writers must never race with each other, and a
+    // check here would turn that race-free pattern into a spurious violation.
+    if (races_only && is_atomic && instruction.is_assign())
+    {
+      rw_sett rw_set(ns, i_it, instruction.code, &shared_locals);
+
+      bool has_write = false;
+      forall_rw_set_entries(e_it, rw_set) if (e_it->second.w)
+      {
+        has_write = true;
+        break;
+      }
+
+      if (has_write)
+      {
+        atomic_region_touched_shared = true;
+
+        goto_programt::instructiont original_instruction;
+        original_instruction.swap(instruction);
+
+        instruction.make_skip();
+        i_it++;
+
+        // set the write flag(s) immediately before the original write -- set
+        forall_rw_set_entries(e_it, rw_set) if (e_it->second.w)
+        {
+          const expr2tc guard_expr = w_guards.get_w_guard_expr(e_it->second);
+
+          goto_programt::targett t = goto_program.insert(i_it);
+          t->type = ASSIGN;
+          t->code =
+            code_assign2tc(guard_expr, e_it->second.get_guard().as_expr());
+          t->location = original_instruction.location;
+          i_it = ++t;
+
+          // remember it so the reset can be emitted after the boundary yield
+          atomic_write_guards.push_back(guard_expr);
+        }
+
+        // re-insert the original write
+        goto_programt::targett t = goto_program.insert(i_it);
+        *t = original_instruction;
+        i_it = t; // loop's ++ advances past the original write
       }
     }
 
@@ -371,7 +437,23 @@ void add_race_assertions(
         migrate_expr(call, t->code);
         t->location = instruction.location;
         i_it = t; // loop's ++ advances past the inserted yield
+
+        // Reset the write flags of shared writes performed inside this atomic
+        // region, *after* the boundary yield: the flag therefore stayed
+        // observable for exactly one interleaving point (issue #4975). The
+        // resets are inserted before `after` so they land right after the
+        // yield, in order.
+        for (const expr2tc &guard_expr : atomic_write_guards)
+        {
+          goto_programt::targett r = goto_program.insert(after);
+          r->type = ASSIGN;
+          r->code = code_assign2tc(guard_expr, gen_false_expr());
+          r->location = instruction.location;
+          i_it = r;
+        }
       }
+
+      atomic_write_guards.clear();
     }
   }
 


### PR DESCRIPTION
In `--data-races-check-only` mode, set the race write flag for shared writes that occur *inside* a `__VERIFIER_atomic_` region and defer the reset until after the #4423 atomic-boundary yield, so the flag stays observable for exactly one interleaving point. Previously such writes (e.g. `mThread = …` in `__VERIFIER_atomic_thr1`) were emitted as bare assignments with no write flag, so a concurrent *non-atomic* read in another thread (`int self = mThread;`) could never observe the writer — a no-data-race false negative on `pthread-ext/23_lu-fig2.fixed` (ground truth FALSE), reported `SUCCESSFUL` on a racy program. Not covered by #4955 (the racy object is a global, the writer is atomic).

No assertion is added inside atomic regions, so two mutually-exclusive atomic writers are never spuriously flagged; the change only sets/resets a flag (no emitted GOTO/expression changes) and is gated on `data-races-check-only`, so it cannot turn a genuinely-TRUE program FALSE.

Validated dual-solver (Bitwuzla + Z3): the benchmark now reports `FAILED` / `R/W data race on c:@mThread`; the race-free twin stays `SUCCESSFUL`; reverting the patch flips the new racy test back to `SUCCESSFUL` (the branch is load-bearing). Adds `regression/esbmc-unix/github_4975_atomic_write_race` and `github_4975_atomic_write_norace`; 67/67 race/atomicity/SV-COMP + 80/80 pthread/CUDA regression tests and all 15 `atomicity_check` unit scenarios pass; clang-format clean. Fixes #4975. The symmetric non-atomic-write vs atomic-read case is pre-existing and intentionally not addressed here.
