### PR TITLE
[python] preregister imported-module globals for LEGB forward refs

### DIFF
--- a/regression/python/github_4970/main.py
+++ b/regression/python/github_4970/main.py
@@ -1,0 +1,4 @@
+from modstub import *
+
+obj: C = C(1)
+obj.check()

--- a/regression/python/github_4970/modstub.py
+++ b/regression/python/github_4970/modstub.py
@@ -1,0 +1,9 @@
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def check(self) -> None:
+        assert self.v == TAG      # module global, referenced inside a method
+
+
+TAG: int = 1                      # ...defined AFTER the class

--- a/regression/python/github_4970/test.desc
+++ b/regression/python/github_4970/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4970_fail/main.py
+++ b/regression/python/github_4970_fail/main.py
@@ -1,0 +1,7 @@
+from modstub import *
+
+# obj.v is 1 but the module global TAG is 2, so check() must fail.
+# This guards against the global being silently dropped or made nondet:
+# a dropped/nondet TAG would not deterministically refute self.v == TAG.
+obj: C = C(1)
+obj.check()

--- a/regression/python/github_4970_fail/modstub.py
+++ b/regression/python/github_4970_fail/modstub.py
@@ -1,0 +1,9 @@
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def check(self) -> None:
+        assert self.v == TAG      # module global, referenced inside a method
+
+
+TAG: int = 2                      # defined AFTER the class; value != the v below

--- a/regression/python/github_4970_fail/test.desc
+++ b/regression/python/github_4970_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -268,6 +268,13 @@ bool python_converter::import_module_into_block(
   imported_annotator.add_type_annotation();
 
   exprt imported_code = with_ast(&nested_module_json, [&]() {
+    // Pre-register this module's annotated globals before converting its body
+    // so that its methods can reference module globals declared textually
+    // after the class that uses them (Python LEGB forward reference). The main
+    // module already gets this treatment in convert(); imported modules need
+    // it here, otherwise a `from mod import *` whose method reads a global
+    // defined later in mod fails name resolution (GitHub #4970).
+    preregister_global_variables(nested_module_json["body"]);
     return get_block(nested_module_json["body"]);
   });
 


### PR DESCRIPTION
Run `preregister_global_variables` on each imported module's body (inside its `with_ast` scope, immediately before conversion), not just on the main file. A method of a star-imported class can now forward-reference a module-level global defined textually *after* the class — Python's LEGB rule — instead of aborting with `Variable '<X>' is not defined`.

The pre-pass is idempotent and builds module-scoped symbol IDs from `current_python_file`, so it cannot shadow or double-register a same-named main-file global, and the later real assignment reuses the pre-registered symbol. Adds `regression/python/github_4970` (resolves to the real value → SUCCESSFUL) and `github_4970_fail` (mismatching value → FAILED, guarding against the global being dropped/nondet).

Fixes #4970. The named-import form (`from mod import C`) is a separate, pre-existing route (related to #4744) and is intentionally not addressed here.
