### PR TITLE
[python] warn on missing str runtime-model dispatch, not log_debug

### DIFF
--- a/regression/python/github_4827_runtime_model_dispatch/main.py
+++ b/regression/python/github_4827_runtime_model_dispatch/main.py
@@ -1,0 +1,42 @@
+# Integration guard for the str runtime-model dispatch paths whose silent
+# nondet fallback #4827 makes observable (capitalize / title / swapcase /
+# count / isalnum / isupper). Each receiver is passed through a wrapper so it
+# is NON-constant at conversion time -- this forces the handler to dispatch to
+# the __python_str_* operational model (rather than consteval-folding the
+# literal), which is exactly the path #4827 guards. The exact-value assertions
+# only hold if the runtime models actually compute the result.
+
+
+def f_capitalize(s: str) -> str:
+    return s.capitalize()
+
+
+def f_title(s: str) -> str:
+    return s.title()
+
+
+def f_swapcase(s: str) -> str:
+    return s.swapcase()
+
+
+def f_count(s: str, c: str) -> int:
+    return s.count(c)
+
+
+def f_isalnum(s: str) -> bool:
+    return s.isalnum()
+
+
+def f_isupper(s: str) -> bool:
+    return s.isupper()
+
+
+if __name__ == "__main__":
+    assert f_capitalize("hELLO") == "Hello"
+    assert f_title("hello world") == "Hello World"
+    assert f_swapcase("Hello") == "hELLO"
+    assert f_count("aabba", "a") == 3
+    assert f_isalnum("abc123") == True
+    assert f_isalnum("ab c") == False
+    assert f_isupper("ABC") == True
+    assert f_isupper("aBC") == False

--- a/regression/python/github_4827_runtime_model_dispatch/test.desc
+++ b/regression/python/github_4827_runtime_model_dispatch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 30 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4827_runtime_model_dispatch_fail/main.py
+++ b/regression/python/github_4827_runtime_model_dispatch_fail/main.py
@@ -1,0 +1,17 @@
+# Negative variant of github_4827_runtime_model_dispatch: one assertion is
+# deliberately wrong, so the runtime-model dispatch must produce the real value
+# and refute it. Guards against the dispatch silently returning nondet (which
+# would not deterministically fail) -- the soundness check behind #4827.
+
+
+def f_swapcase(s: str) -> str:
+    return s.swapcase()
+
+
+def f_count(s: str, c: str) -> int:
+    return s.count(c)
+
+
+if __name__ == "__main__":
+    assert f_swapcase("Hello") == "hELLO"
+    assert f_count("aabba", "a") == 99   # wrong: real count is 3

--- a/regression/python/github_4827_runtime_model_dispatch_fail/test.desc
+++ b/regression/python/github_4827_runtime_model_dispatch_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 30 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -2010,9 +2010,10 @@ exprt string_handler::handle_string_capitalize(
       call.type() = gen_pointer_type(char_type());
       return call;
     }
-    log_debug(
-      "python-string",
-      "capitalize() on non-constant receiver: nondet fallback");
+    log_warning(
+      "str.capitalize(): runtime model __python_str_capitalize not in the "
+      "symbol table -- falling back to nondet. Define it under "
+      "src/c2goto/library/python/ and rebuild (Python frontend must be on).");
     return build_nondet_string_fallback(location);
   }
 
@@ -2057,8 +2058,10 @@ exprt string_handler::handle_string_title(
       call.type() = gen_pointer_type(char_type());
       return call;
     }
-    log_debug(
-      "python-string", "title() on non-constant receiver: nondet fallback");
+    log_warning(
+      "str.title(): runtime model __python_str_title not in the symbol "
+      "table -- falling back to nondet. Define it under "
+      "src/c2goto/library/python/ and rebuild (Python frontend must be on).");
     return build_nondet_string_fallback(location);
   }
 
@@ -2110,8 +2113,10 @@ exprt string_handler::handle_string_swapcase(
       call.type() = gen_pointer_type(char_type());
       return call;
     }
-    log_debug(
-      "python-string", "swapcase() on non-constant receiver: nondet fallback");
+    log_warning(
+      "str.swapcase(): runtime model __python_str_swapcase not in the symbol "
+      "table -- falling back to nondet. Define it under "
+      "src/c2goto/library/python/ and rebuild (Python frontend must be on).");
     return build_nondet_string_fallback(location);
   }
 
@@ -2196,6 +2201,16 @@ exprt string_handler::handle_string_count(
         call.type() = size_type();
         return call;
       }
+      // The default-range path tried the named model and missed: a silent
+      // degradation worth surfacing (#4827). __python_str_count is normally
+      // auto-registered from library/python/string.c by gen_python_c_models.py,
+      // so a miss means the model is absent or the build lacked the Python
+      // frontend. The outer log_debug still covers the start/end path, where
+      // no model is attempted.
+      log_warning(
+        "str.count(): runtime model __python_str_count not in the symbol "
+        "table -- falling back to nondet. Define it under "
+        "src/c2goto/library/python/ and rebuild (Python frontend must be on).");
     }
     log_debug(
       "python-string", "count() on non-constant receiver/needle: nondet int");
@@ -2619,8 +2634,10 @@ exprt string_handler::handle_string_isalnum(
       call.type() = bool_type();
       return call;
     }
-    log_debug(
-      "python-string", "isalnum() on non-constant receiver: nondet bool");
+    log_warning(
+      "str.isalnum(): runtime model __python_str_isalnum not in the symbol "
+      "table -- falling back to nondet. Define it under "
+      "src/c2goto/library/python/ and rebuild (Python frontend must be on).");
     side_effect_expr_nondett nondet(bool_type());
     nondet.location() = location;
     return nondet;
@@ -2662,8 +2679,10 @@ exprt string_handler::handle_string_isupper(
       call.type() = bool_type();
       return call;
     }
-    log_debug(
-      "python-string", "isupper() on non-constant receiver: nondet bool");
+    log_warning(
+      "str.isupper(): runtime model __python_str_isupper not in the symbol "
+      "table -- falling back to nondet. Define it under "
+      "src/c2goto/library/python/ and rebuild (Python frontend must be on).");
     side_effect_expr_nondett nondet(bool_type());
     nondet.location() = location;
     return nondet;


### PR DESCRIPTION
Promote the `log_debug` to `log_warning` at the six `str.X()` handlers that dispatch to a named `__python_str_X` runtime model and silently fall back to nondet when that symbol is missing (`capitalize`, `title`, `swapcase`, `count`, `isalnum`, `isupper`). `log_debug` is suppressed at default verbosity and the slicer drops the resulting compare-against-nondet VCC as trivial, so the degradation shipped unnoticed across the runtime-model series (#4818/#4821/#4822/#4823/#4824) until #4826 surfaced it.

The change is logging-severity-only: no emitted GOTO/expression changes on any path and no soundness impact — the warning fires only when a model the handler *tried* to use is genuinely absent (a build/setup problem). Handlers that already `throw` on a miss, or attempt no named model, are deliberately left as-is; `count()`'s warning is placed inside the default-range model-attempt block so it fires only on a real miss. The message names the missing symbol and the real remedy (define it under `src/c2goto/library/python/` and rebuild).

Adds `regression/python/github_4827_runtime_model_dispatch` (all six exercised via non-constant receivers → SUCCESSFUL) and `github_4827_runtime_model_dispatch_fail` (wrong assertion → FAILED, proving the real value is dispatched, not nondet). Fixes #4827.
