### PR TITLE
[python] encapsulate frontend irep attribute access (IREP2 Phase 4.1)

### DIFF
--- a/src/python-frontend/convert_float_literal.cpp
+++ b/src/python-frontend/convert_float_literal.cpp
@@ -1,5 +1,6 @@
 #include <python-frontend/convert_float_literal.h>
 #include <python-frontend/parse_float.h>
+#include <python-frontend/type_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
@@ -22,17 +23,17 @@ void convert_float_literal(const std::string &src, exprt &dest)
   if (is_float)
   {
     dest.type() = float_type();
-    dest.type().set("#cpp_type", "float");
+    type_utils::set_cpp_type(dest.type(), "float");
   }
   else if (is_long)
   {
     dest.type() = long_double_type();
-    dest.type().set("#cpp_type", "long_double");
+    type_utils::set_cpp_type(dest.type(), "long_double");
   }
   else
   {
     dest.type() = double_type();
-    dest.type().set("#cpp_type", "double");
+    type_utils::set_cpp_type(dest.type(), "double");
   }
 
   if (config.ansi_c.use_fixed_for_float)

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -93,7 +93,7 @@ python_converter::create_normalized_self_key(const std::string &class_tag)
 typet python_converter::clean_attribute_type(const typet &attr_type)
 {
   typet clean_type = attr_type;
-  clean_type.remove("#member_name");
+  type_utils::remove_member_name(clean_type);
   clean_type.remove("#location");
   clean_type.remove("#identifier");
   return clean_type;

--- a/src/python-frontend/converter/converter_internal.h
+++ b/src/python-frontend/converter/converter_internal.h
@@ -114,7 +114,7 @@ inline struct_typet::componentt build_component(
   // Add metadata used internally by ESBMC for member-to-class tagging.
   // The key "#member_name" is used by the type system; the value
   // "tag-<class_name>" helps associate this member with its parent class.
-  component.type().set("#member_name", "tag-" + class_name);
+  type_utils::set_member_name(component.type(), "tag-" + class_name);
 
   // Set the member visibility to public by default.
   component.set_access("public");

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -948,20 +948,20 @@ exprt numpy_call_expr::get()
             if (is_unsigned)
             {
               exprt folded = from_integer(BigInt(wrapped_bits), t);
-              folded.set("#cformat", std::to_string(wrapped_bits));
+              folded.cformat(std::to_string(wrapped_bits));
               return folded;
             }
             else
             {
               exprt folded = from_integer(BigInt(wrapped_signed), t);
-              folded.set("#cformat", std::to_string(wrapped_signed));
+              folded.cformat(std::to_string(wrapped_signed));
               return folded;
             }
           }
           else
           {
             exprt folded = from_double(final_value, t);
-            folded.set("#cformat", std::to_string(final_value));
+            folded.cformat(std::to_string(final_value));
             return folded;
           }
         }
@@ -1010,8 +1010,7 @@ exprt numpy_call_expr::get()
           auto length = value_str.length();
           expr.value(value_str.substr(length - dtype_size));
           value_str = expr.value().as_string();
-          expr.set(
-            "#cformat", std::to_string(std::stoll(value_str, nullptr, 2)));
+          expr.cformat(std::to_string(std::stoll(value_str, nullptr, 2)));
         }
       }
     }

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -7,6 +7,7 @@
 #include <python-frontend/json_utils.h>
 #include <python-frontend/symbol_id.h>
 #include <python-frontend/string/string_builder.h>
+#include <python-frontend/type_utils.h>
 #include <util/expr.h>
 #include <util/type.h>
 #include <util/symbol.h>
@@ -2452,7 +2453,7 @@ exprt python_list::handle_index_access(
     // string element from an arbitrary 8-bit int (e.g. dtype=np.int8) without
     // resorting to a fragile width-only heuristic.
     typet char_t = char_type();
-    char_t.set("#cpp_type", "char");
+    type_utils::set_cpp_type(char_t, "char");
     return index_exprt(array, idx, char_t);
   }
 

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -560,8 +560,8 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   {
     if (type_size == 1)
     {
-      typet type = char_type();      // 8-bit char
-      type.set("#cpp_type", "char"); // For C backend compatibility
+      typet type = char_type(); // 8-bit char
+      type_utils::set_cpp_type(type, "char"); // For C backend compatibility
       return type;
     }
     return build_array(char_type(), type_size); // Array of characters

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -560,7 +560,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   {
     if (type_size == 1)
     {
-      typet type = char_type(); // 8-bit char
+      typet type = char_type();               // 8-bit char
       type_utils::set_cpp_type(type, "char"); // For C backend compatibility
       return type;
     }

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -162,10 +162,38 @@ public:
       op == "GtE" || op == "And" || op == "Or");
   }
 
+  // Encapsulated accessors for the irep string attributes the Python
+  // frontend attaches to legacy typet nodes. These attributes are read by
+  // shared/downstream passes — "#cpp_type" by clang_cpp_adjust, the C/C++
+  // pretty-printers and goto2c; "#member_name" by the shared clang-cpp pass
+  // — so they must stay on the legacy node at the migrate seam. Funnelling
+  // every raw .set/.get("#…") through one seam each is the Phase 4.1
+  // hardening step of the IREP2 migration (docs/irep2-migration.md Part IV,
+  // F-P5 / §15). Keep the keys and values byte-identical: this is a
+  // behaviour-preserving relocation, not a semantic change.
+  static void set_cpp_type(typet &t, const irep_idt &value)
+  {
+    t.set("#cpp_type", value);
+  }
+
+  static irep_idt get_cpp_type(const typet &t)
+  {
+    return t.get("#cpp_type");
+  }
+
+  static void set_member_name(typet &t, const irep_idt &value)
+  {
+    t.set("#member_name", value);
+  }
+
+  static void remove_member_name(typet &t)
+  {
+    t.remove("#member_name");
+  }
+
   static bool is_char_type(const typet &t)
   {
-    return (t.is_signedbv() || t.is_unsignedbv()) &&
-           t.get("#cpp_type") == "char";
+    return (t.is_signedbv() || t.is_unsignedbv()) && get_cpp_type(t) == "char";
   }
 
   static bool is_float_vs_char(const exprt &a, const exprt &b)


### PR DESCRIPTION
Funnel every raw .set/.get/.remove("#cpp_type"|"#cformat"|"#member_name") in the Python frontend through one typed seam each, the attribute-access encapsulation milestone of the Part IV IREP2 migration plan (docs/irep2-migration.md). Behaviour-preserving: identical keys, values and storage — only the access path is centralized.

- type_utils gains set_cpp_type/get_cpp_type and set_member_name/ remove_member_name; is_char_type now reads through get_cpp_type.
- #cformat routes through the existing standard irept::cformat() accessor.

These three attributes are read by shared/downstream passes (clang_cpp_adjust, the C/C++ pretty-printers, goto2c), so they must stay on the legacy node at the migrate seam; the comment on the accessors and the plan's F-P5/§15 document why. Centralizing them gives a single repoint point per attribute for any future migration step.

Validated: pythonfrontend + esbmc build clean; 8/8 python-frontend unit tests pass; 993/1002 stratified python regression subset pass (the 9 non-passing are pre-existing python-intensive timeouts hitting the fixed 120s per-test cap, unrelated to this no-op change).