### PR TITLE
[python] carry referenced module globals through named imports (#4984)

### DIFF
--- a/regression/python/github_4984/main.py
+++ b/regression/python/github_4984/main.py
@@ -1,0 +1,6 @@
+from modstub import C
+
+# Named import (not `import *`): only C is bound here, but C.check still
+# resolves the module global TAG against modstub at call time (CPython LEGB).
+obj: C = C(1)
+obj.check()

--- a/regression/python/github_4984/modstub.py
+++ b/regression/python/github_4984/modstub.py
@@ -1,0 +1,9 @@
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def check(self) -> None:
+        assert self.v == TAG      # module global, referenced inside a method
+
+
+TAG: int = 1                      # not named in the import; must travel with C

--- a/regression/python/github_4984/test.desc
+++ b/regression/python/github_4984/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4984_fail/main.py
+++ b/regression/python/github_4984_fail/main.py
@@ -1,0 +1,7 @@
+from modstub import C
+
+# obj.v is 1 but the module global TAG is 2, so check() must fail. This guards
+# against the named-imported global being silently dropped or made nondet: a
+# dropped/nondet TAG would not deterministically refute self.v == TAG.
+obj: C = C(1)
+obj.check()

--- a/regression/python/github_4984_fail/modstub.py
+++ b/regression/python/github_4984_fail/modstub.py
@@ -1,0 +1,9 @@
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def check(self) -> None:
+        assert self.v == TAG      # module global, referenced inside a method
+
+
+TAG: int = 2                      # value != the v below; check() must refute

--- a/regression/python/github_4984_fail/test.desc
+++ b/regression/python/github_4984_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_4984_transitive/main.py
+++ b/regression/python/github_4984_transitive/main.py
@@ -1,0 +1,6 @@
+from modstub import C
+
+# Only C is named, but C.check -> base() -> TAG. The emitter's transitive
+# closure must carry both the sibling helper `base` and the global `TAG`.
+obj: C = C(7)
+obj.check()

--- a/regression/python/github_4984_transitive/modstub.py
+++ b/regression/python/github_4984_transitive/modstub.py
@@ -1,0 +1,13 @@
+def base() -> int:
+    return TAG                    # helper reads the module global
+
+
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def check(self) -> None:
+        assert self.v == base()   # method calls a sibling helper, not TAG directly
+
+
+TAG: int = 7                      # reachable from C only transitively (C -> base -> TAG)

--- a/regression/python/github_4984_transitive/test.desc
+++ b/regression/python/github_4984_transitive/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/parser/json_emitter.py
+++ b/src/python-frontend/parser/json_emitter.py
@@ -48,24 +48,23 @@ class EmitPipelineDeps:
 
 
 def get_referenced_names(node: ast.AST) -> set[str]:
-    """Find function/class names referenced in a function or class definition."""
-    referenced = set()
+    """Collect every name *read* inside a definition (``Load`` context).
 
-    for child in ast.walk(node):
-        if isinstance(child, ast.Call):
-            if isinstance(child.func, ast.Name):
-                referenced.add(child.func.id)
-        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if child.returns and isinstance(child.returns, ast.Name):
-                referenced.add(child.returns.id)
-            for arg in child.args.args:
-                if arg.annotation and isinstance(arg.annotation, ast.Name):
-                    referenced.add(arg.annotation.id)
-        elif isinstance(child, ast.AnnAssign):
-            if isinstance(child.annotation, ast.Name):
-                referenced.add(child.annotation.id)
-
-    return referenced
+    This subsumes call targets (``C()``), type annotations (``-> Node``,
+    ``x: Tile``), and — crucially — bare reads of module-level globals such as
+    a method that reads a module constant. Capturing the last case lets a
+    named import (``from mod import C``) carry along the globals ``C``'s methods
+    reference, instead of dropping them and failing name resolution at the use
+    site (GitHub #4984). Local stores and parameters are in ``Store``/``Param``
+    context and are intentionally excluded; only top-level definitions whose
+    names match are ever retained by ``_filter_nodes_for_import``, so any
+    incidental over-collection is sound (it can only keep a real sibling
+    global, never drop one)."""
+    return {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+    }
 
 
 def _assign_target_names(target: ast.expr) -> Iterable[str]:
@@ -78,29 +77,50 @@ def _assign_target_names(target: ast.expr) -> Iterable[str]:
         yield from _assign_target_names(target.value)
 
 
+def _node_bound_names(node: ast.stmt) -> set[str]:
+    """Top-level binding names introduced by ``node`` (empty for non-bindings)."""
+    if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+        return {node.name}
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return {node.target.id}
+    if isinstance(node, ast.Assign):
+        return {n for tgt in node.targets for n in _assign_target_names(tgt)}
+    return set()
+
+
 def _filter_nodes_for_import(tree: ast.Module, elements_to_import) -> list[ast.stmt]:
-    """Return the subset of ``tree.body`` selected by ``elements_to_import``."""
+    """Return the subset of ``tree.body`` selected by ``elements_to_import``.
+
+    Beyond the explicitly imported names, retain every top-level definition or
+    global *transitively* referenced by them, computed as a fixpoint over
+    ``get_referenced_names``. An imported class whose method reads a module
+    global — or calls a sibling helper that itself reads one — keeps that
+    global in the emitted body, matching CPython's rule that the global resolves
+    against its defining module at call time (GitHub #4984). The closure only
+    ever adds nodes, so it cannot drop anything the previous one-hop scan kept."""
     if not elements_to_import:
         return []
 
-    explicitly_imported = {elem_info.name for elem_info in elements_to_import}
-    referenced_names = set()
-    for node in tree.body:
-        if isinstance(node, (ast.ClassDef, ast.FunctionDef)) and node.name in explicitly_imported:
-            referenced_names.update(get_referenced_names(node))
+    required = {elem_info.name for elem_info in elements_to_import}
+    worklist = list(required)
+    while worklist:
+        name = worklist.pop()
+        for node in tree.body:
+            if name not in _node_bound_names(node):
+                continue
+            for ref in get_referenced_names(node):
+                if ref not in required:
+                    required.add(ref)
+                    worklist.append(ref)
 
     filtered_nodes = []
     for node in tree.body:
-        if isinstance(node, (ast.ClassDef, ast.FunctionDef)):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
             if (node.name in ("ESBMC_range_has_next_", "ESBMC_range_next_")
-                    or node.name in explicitly_imported or node.name in referenced_names):
+                    or node.name in required):
                 filtered_nodes.append(node)
-        elif (isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
-              and node.target.id in explicitly_imported):
-            filtered_nodes.append(node)
-        elif isinstance(node, ast.Assign):
-            bound = {n for tgt in node.targets for n in _assign_target_names(tgt)}
-            if bound & explicitly_imported:
+        elif isinstance(node, (ast.AnnAssign, ast.Assign)):
+            if _node_bound_names(node) & required:
                 filtered_nodes.append(node)
         elif isinstance(node, (ast.Import, ast.ImportFrom)):
             filtered_nodes.append(node)


### PR DESCRIPTION
## Problem

`from mod import C` prunes `mod`'s AST down to the imported name *before* conversion. Module-level globals that `C`'s methods reference (read at call time, not named in the import) were dropped, so name resolution aborted:

```
ERROR: Variable 'TAG' is not defined in function 'check' at line 5.
```

Minimal reproducer (from the issue):

```python
# modstub.py
class C:
    def __init__(self, v: int):
        self.v = v
    def check(self) -> None:
        assert self.v == TAG     # module global read inside a method
TAG: int = 1

# main.py
from modstub import C
obj: C = C(1)
obj.check()
```

`from modstub import *` already worked (#4970/#4983): a star import keeps the full module body, so the forward-reference pre-pass sees `TAG`. The named-import path pruned `TAG` away.

## Root cause

`_filter_nodes_for_import` (`src/python-frontend/parser/json_emitter.py`) kept an imported class's referenced sibling **classes/functions** but kept **globals** (`AnnAssign`/`Assign`) only when their target was *explicitly imported*. And `get_referenced_names` only collected call targets and type annotations — never a bare `Load` of a global like `TAG`. So `from modstub import C` emitted `[ClassDef C]` with `TAG: int = 1` dropped, and neither the #4983 pre-pass nor normal assignment conversion ever registered it.

## Fix

- Rewrite `_filter_nodes_for_import` to retain the **transitive closure** of top-level definitions/globals referenced by the imported symbols (fixpoint over `get_referenced_names`).
- Broaden `get_referenced_names` to collect all `Load`-context name reads (a strict superset of the old call/annotation scan).

The closure only ever *adds* nodes, so it cannot drop anything the prior one-hop scan kept — the safe direction for a verification frontend. This also fixes latent gaps: transitive helper/global dependencies and async-function retention. It matches CPython LEGB, where a method resolves a module global against its defining module at call time.

## Why it's correct

A named import in CPython still executes the whole defining module; only the *binding* into the importing namespace is restricted. Carrying the referenced globals (rather than pruning them) moves the emitted AST closer to that semantics. Over-retention is sound (it can only keep a real sibling global); under-retention — the previous behaviour — was the bug.

## Validation

- New tests: `github_4984` (direct global ref → SUCCESSFUL), `github_4984_fail` (mismatched value → FAILED, guarding against a dropped/nondet global), `github_4984_transitive` (`C` → helper → global, locking in the closure).
- All **94** multi-file Python import regression tests pass (the complete at-risk surface; the change is inert for single-file/no-import programs).
- `scripts/check_python_tests.sh github_4984` passes under CPython; `pylint` 10.00/10 on the modified file.

Fixes #4984.