### PR TITLE
[docs] add Python issues triage & improvement plan

### DIFF
--- a/docs/python-issues-triage-plan.md
+++ b/docs/python-issues-triage-plan.md
@@ -1,0 +1,191 @@
+# Python issues — triage & improvement plan
+
+This document is a snapshot triage of the open `python`-labelled issues in the
+ESBMC tracker, with a per-issue disposition (fix shipped / already resolved /
+intentional behavior / design-level / multi-blocker) and a prioritised plan for
+the remaining work. It exists so the next contributor does not have to
+re-reproduce ~60 KNOWNBUG tests to know where the real, *sound* wins are.
+
+- **Snapshot date:** 2026-05-31 (ESBMC 8.3.0, `master` HEAD).
+- **Method:** pulled all 40 open `python` issues + recently-closed ones,
+  reproduced every currently-failing Python KNOWNBUG test, classified by failure
+  mode, and fixed the issues that admit a sound, contained fix.
+- **Guiding constraint:** ESBMC is a formal-verification tool. An unsound or
+  heuristic "fix" is worse than an honest KNOWNBUG, so forcing fixes on
+  multi-blocker or deep-modeling issues was deliberately avoided.
+- **How to refresh:** re-run
+  `grep -lE '^KNOWNBUG' regression/{python,python-intensive,quixbugs,humaneval}/*/test.desc`
+  and `gh issue list --repo esbmc/esbmc --label python --state open`, then
+  re-reproduce. The cluster structure below is the stable part; exact counts
+  drift as fixes land.
+
+---
+
+## 1. Fixes shipped
+
+| Issue | PR | Title | Status |
+|---|---|---|---|
+| [#4984](https://github.com/esbmc/esbmc/issues/4984) | [#4993](https://github.com/esbmc/esbmc/pull/4993) | `[python]` carry referenced module globals through named imports | opened, fully validated |
+
+### #4984 — `from mod import C` drops module globals used by C's methods
+- **Root cause:** `_filter_nodes_for_import` in
+  `src/python-frontend/parser/json_emitter.py` pruned the imported module's AST
+  to the imported name before conversion, keeping referenced sibling
+  **classes/functions** but dropping module **globals** (`AnnAssign`/`Assign`)
+  unless explicitly imported. `get_referenced_names` also never collected bare
+  `Load` reads like `TAG`. So `from modstub import C` emitted `[ClassDef C]` with
+  `TAG: int = 1` dropped → `Variable 'TAG' is not defined`.
+- **Fix:** retain the **transitive closure** of top-level defs/globals referenced
+  by the imported symbols; broaden `get_referenced_names` to all `Load`-context
+  reads. The closure only ever **adds** nodes (never drops) — the safe direction
+  for a verifier — and matches CPython LEGB (a method resolves a module global
+  against its defining module at call time). Also fixes latent gaps: transitive
+  helper deps and async-function retention.
+- **Validation:** 3 new regression tests — `github_4984` (direct global →
+  SUCCESSFUL), `github_4984_fail` (mismatched value → FAILED, guards against a
+  dropped/nondet global), `github_4984_transitive` (`C`→helper→global, exercises
+  the closure). All 94 multi-file Python import regression tests pass (the full
+  at-risk surface; the change is inert for single-file/no-import programs).
+  CPython sanity (`check_python_tests.sh`) ✓, pylint 10/10 ✓, code-review clean.
+
+---
+
+## 2. Already resolved — recommend closing (no work needed)
+
+These open issues' tests already pass / were already re-tagged on `master`:
+
+| Issue | Evidence |
+|---|---|
+| #4774 `mixed-types` | test.desc is now `CORE`, runs `--incremental-bmc`, → **VERIFICATION SUCCESSFUL** locally. No longer KNOWNBUG. |
+| #4770 `cast` (`chr(int(float))`) | no longer in the KNOWNBUG set on `master` (closed-issue list shows #4770 COMPLETED 2026-05-31). |
+| #4777 `python-intensive/problem1_fail` | re-tagged `FUTURE` (acknowledged, excluded from default run). |
+
+---
+
+## 3. Intentional conservative behavior — do NOT "fix" without a redesign
+
+The **github_4117** trio is documented *in the test sources themselves* as a
+deliberate soundness-preserving limitation of the lexical usage-site type
+scanner. Failure mode: `ERROR: Cannot resolve nested attribute: <field>`.
+
+| Issue | Test | Why intentional |
+|---|---|---|
+| #4771 | `github_4117_attr_conflict` | an attribute assigned values of two classes → scanner refuses to commit (returns `any_type()`) rather than unsoundly pick one. |
+| #4772 | `github_4117_attr_shadow` | a variable reassigned to a different class → scanner drops the class mapping rather than mis-attribute later writes. |
+| #4773 | `github_4117_function_internal` | instance-var writes inside function bodies aren't tracked; needs *scope-aware* tracking. The only one without a conflict, but still requires flow-sensitive analysis to fix soundly. |
+
+The same `Cannot resolve nested attribute` signature blocks **quixbugs/detect_cycle**
+(`node.successor.successor`) and is the dominant frontend blocker for the
+linked-list/graph quixbugs. **Required design change:** flow-sensitive
+(per-program-point) class tracking instead of the current lexical scan, plus a
+union-type or diagnostic model for genuine conflicts. High risk; out of scope
+for a safe point fix.
+
+---
+
+## 4. Design-level issues — blockers documented, not point-fixable
+
+| Issue | Summary | Blocker / required design change |
+|---|---|---|
+| #4642 | arbitrary-precision (bignum) int | needs IR-level wide-int support; #4653 is the OM-rework prerequisite. |
+| #4653 | OM rework to unblock `--ir-gated` bignum | depends on #4642 IR work. |
+| #4579 | model CPython GIL-aware thread scheduling | concurrency-semantics design effort. |
+| #4584 | insert interleaving points at module-global accesses in Thread bodies | symex scheduling change; couples with #4579. |
+| #4566 | `concurrency_fail`: needs `threading.Thread` + `queue.Queue` | blocked on the threading/Queue model (#4579/#4584). |
+| #3067 | refactor class handling into a dedicated class | pure refactor, no behavior change. |
+| #2848 | type inference for `typing.Any` at symex level | inference design. |
+| #3541 | math dataset/benchmark suite | infra, not a bug. |
+
+---
+
+## 5. Benchmark KNOWNBUGs — full failure-mode classification
+
+All reproduced on `master` HEAD. None is a clean single-root-cause fix that
+soundly flips a verdict; each is multi-blocker, scalability-bound, an internal
+assertion/segfault needing care, or the intentional limitation above.
+
+### quixbugs (#4778 umbrella, 25 still failing)
+
+- **Cluster 1 — `Cannot unpack <X>` (6, frontend conversion crash):**
+  `minimum_spanning_tree(_fail)` (`signedbv`), `powerset(_fail)` (`pointer`),
+  `shortest_path_length(_fail)` (`empty`). Tuple-unpack target (`u, v = edge`)
+  where the RHS isn't inferred as a tuple/array. *Also* blocked by `heappop`
+  (undefined → assert(false)) and rich dict/set semantics → fixing unpack alone
+  won't flip them.
+- **Cluster 2 — TIMEOUT/scalability (5):** `flatten_fail`, `knapsack(_fail)`,
+  `next_permutation_fail`, `shortest_path_lengths`. Deep recursion / list-OM
+  loops / SMT explosion (5418 VCCs). Not a frontend bug.
+- **Cluster 3 — segfault in `__memcpy_impl` (string.c:278) during unwind (2):**
+  `topological_ordering(_fail)`. Backend robustness bug; deep.
+- **Cluster 4 — `NameError: name 'Queue' is not defined` (2):**
+  `breadth_first_search(_fail)`. `queue.Queue`/FIFO unmodelled.
+- **Singletons:** `detect_cycle` (`Cannot resolve nested attribute` — §3);
+  `depth_first_search` (internal assert `is_array_type` in `object_size.cpp:179`);
+  `reverse_linked_list` (bitwuzla `mk_eq` width-mismatch assert);
+  `shortest_paths(_fail)` (`Only simple targets are supported in DictComp` —
+  tuple target in a dict comprehension; also `float('inf')`+dict semantics);
+  `next_permutation` (`reversed()` on a list unmodelled — only `reversed(range)`
+  is lowered — plus slice-assignment + list `==`);
+  `wrap` (unwinding assertion: `--unwind 200` too low for the string loop);
+  `bitcount_fail` (k-induction UNKNOWN);
+  `rpn_eval`/`rpn_eval_fail` — **`rpn_eval_fail/main.py` is invalid Python**
+  (calls `rpn_eval(3.0, 5.0, '+', …)` — 5 args to a 1-arg function; CPython
+  raises `TypeError`). The intended call passes a list. Both also use
+  `--unwind 1`, too low for the token loop. Needs a test-config fix, not an
+  ESBMC fix; murky verdict, documented for the maintainer.
+
+### humaneval (#4807 umbrella, 30 still failing)
+
+- **C1 — `assertion 0` on computed string/list `== literal` (5):** 62, 103, 119,
+  125, 127. Likely a string/list-equality modeling issue (soundness-relevant),
+  but intertwined with string concat, comprehensions, and per-function logic.
+  Deep solver/model change — not safe to rush.
+- **C2 — `TypeError: str() expects a string argument` (3):** 108, 145, 151.
+  `str(int)` rejected by the str() model. Generally-useful gap, but each test
+  also hits `filter`/`sorted(key=)`/comprehensions → won't flip on its own.
+- **C3 — string-OM unwinding assertions (3):** 1, 1-1, 67. `--unwind` too low for
+  `strlen`/`__python_strnlen_bounded`. Bound/loop-handling.
+- **C4 — `Unsupported reassignment from dict to list` (2):** 93, 126.
+- **C5 — `tuple(...) == tuple(...)` → `NONDET(_Bool)` (2):** 33, 37. Tuple-equality
+  nondet (soundness), but tests also use slice-assignment, `zip`, `extend`,
+  extended slices.
+- **C6 — scalar return mismatches (≈4, distinct causes):** 59, 78, 95, 137 (+86).
+- **Singletons:** 123 (sorted mixed types), 136 (`filter()`), 148 (tuple slice
+  non-const lower), 158 (list-OM empty type), 162 (`hashlib` unmodelled),
+  2-1 (numpy `fmod`), 91 (`split` maxsplit), and three internal C++ asserts —
+  29 (`to_array_type`), 39 (`get_significand_width`), 90 (`member2t`).
+
+### regression/python (#4769 umbrella, 6 still failing)
+`github_4117_attr_conflict/_shadow/_function_internal` (§3 intentional);
+`rover` (`Variable 'Twist' not defined` — named-import-into-function scope +
+`Dict[str,T]` + nested attr writes; multi-feature); `shedskin`
+(`'int' object is not subscriptable` on `d.items()` + broad list/dict/str/set
+smoke test); `concurrency_fail` (#4566, design).
+
+---
+
+## 6. Prioritised plan for the remaining work
+
+Each item below is its own focused, carefully-validated effort — not a rush.
+Ordered by leverage × soundness-confidence.
+
+1. **Flow-sensitive class tracking.** Replace the lexical usage-site scanner with
+   per-program-point class tracking (+ union-type / diagnostic for genuine
+   conflicts). Unblocks #4771/#4772/#4773 + `detect_cycle` + the linked-list /
+   graph quixbugs. Largest leverage, but a real redesign; must preserve the
+   current conservative soundness on true conflicts.
+2. **String/list-equality modeling (humaneval C1).** Soundness-relevant: a
+   computed string/list compared to a literal currently collapses to false.
+   Needs solver-level validation against CPython semantics before trusting any
+   verdict change.
+3. **Tuple-unpack-from-iteration type inference (quixbugs Cluster 1).** Infer the
+   element type of `for u, v in <dict/sequence of tuples>` and `u, v = edge` so
+   the unpack resolves to a tuple/array.
+4. **Generally-useful builtins, each with its own regression pair:** `str(int)`,
+   general `reversed(list)`, `filter`, `queue.Queue` / FIFO.
+
+**Do NOT** machine-fix the scalability/timeout tests (quixbugs Cluster 2,
+humaneval C3) by loosening unwinding — `--no-unwinding-assertions` paired with a
+truncated loop produces false `SUCCESSFUL` and is banned by project policy. Use
+`--k-induction` with required convergence instead, or raise the bound only when
+the loop provably terminates within it.


### PR DESCRIPTION
Adds `docs/python-issues-triage-plan.md` — a snapshot triage (2026-05-31, `master` HEAD) of the open `python`-labelled issues, with per-issue disposition and a prioritised plan for the remaining work.

## What it contains
- **Fixes shipped:** #4984 → PR #4993 (named-import module globals), with root cause and validation.
- **Already resolved → recommend closing:** #4774 (mixed-types now passes), #4770 (cast), #4777 (re-tagged FUTURE).
- **Intentional conservative behavior:** the github_4117 trio (#4771/#4772/#4773) and `detect_cycle` — the lexical type scanner deliberately refuses to commit on class conflicts; needs flow-sensitive tracking to fix soundly.
- **Design-level blockers:** bignum (#4642/#4653), GIL/threading (#4579/#4584/#4566), class refactor (#3067), `Any` inference (#2848), benchmark infra (#3541).
- **Benchmark KNOWNBUGs:** full failure-mode clustering of the 25 quixbugs and 30 humaneval tests (e.g. `Cannot unpack <X>` ×6, `str(int)` ×3, tuple/string equality, scalability timeouts, internal asserts).
- **Prioritised plan** for the remaining sound work, with an explicit warning against loosening unwinding to force false SUCCESSFUL.

## Why
ESBMC is a formal-verification tool, so most benchmark KNOWNBUGs are *not* safe point fixes (multi-blocker, scalability, or intentional conservatism). This doc records the analysis so the next contributor does not have to re-reproduce ~60 KNOWNBUG tests to find the real, sound wins.

Documentation only — no code or behavior change.