### PR TITLE
[python] scope return-type inference to the enclosing function (#4807)

### DIFF
--- a/regression/humaneval/humaneval_127/test.desc
+++ b/regression/humaneval/humaneval_127/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested_fn_return_scope/main.py
+++ b/regression/python/nested_fn_return_scope/main.py
@@ -1,0 +1,20 @@
+# A function's return type must be inferred from *its own* return statements,
+# not from a nested helper's. Here `classify` returns a str, while the nested
+# `has_open` returns bool. If the nested bool returns leak into classify's
+# inferred type, classify is mis-typed as bool and the str `==` comparison
+# below is wrongly folded to a constant (cross-type fold) instead of running.
+# Regression guard for GitHub #4807 (humaneval_119 / humaneval_127 family).
+
+
+def classify(s):
+    def has_open(t):
+        for c in t:
+            if c == '(':
+                return True
+        return False
+
+    return 'open' if has_open(s) else 'none'
+
+
+assert classify('(x)') == 'open'
+assert classify('xyz') == 'none'

--- a/regression/python/nested_fn_return_scope/test.desc
+++ b/regression/python/nested_fn_return_scope/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested_fn_return_scope_fail/main.py
+++ b/regression/python/nested_fn_return_scope_fail/main.py
@@ -1,0 +1,22 @@
+# Soundness guard for GitHub #4807. `classify` returns 'open' for this input,
+# so `!= 'open'` is False and the assertion MUST fail (VERIFICATION FAILED).
+#
+# Before the fix, the nested bool-returning `has_open` leaked into classify's
+# inferred return type, so classify was typed bool. The str-vs-bool `!=` then
+# folded to a *constant True* (cross-type fold), turning a genuinely false
+# assertion into VERIFICATION SUCCESSFUL — i.e. the bug masked a real bug.
+# This test would have reported SUCCESSFUL under the old behaviour and so pins
+# the soundness regression.
+
+
+def classify(s):
+    def has_open(t):
+        for c in t:
+            if c == '(':
+                return True
+        return False
+
+    return 'open' if has_open(s) else 'none'
+
+
+assert classify('(x)') != 'open'

--- a/regression/python/nested_fn_return_scope_fail/test.desc
+++ b/regression/python/nested_fn_return_scope_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -2631,6 +2631,19 @@ std::string python_annotation<Json>::infer_from_return_statements(
 {
   for (const Json &stmt : body)
   {
+    // A nested function or class owns its own `return` statements: Python
+    // scopes them to the nested definition, so they must not leak into the
+    // enclosing function's inferred return type. Without this guard, an
+    // unannotated function whose body declares a nested helper that returns a
+    // different type (e.g. a `check()` returning bool) would wrongly inherit
+    // that type, mis-categorising the enclosing return and breaking downstream
+    // type-dependent logic such as the cross-type `==` fold (GitHub #4807).
+    const std::string &stmt_type = stmt["_type"];
+    if (
+      stmt_type == "FunctionDef" || stmt_type == "AsyncFunctionDef" ||
+      stmt_type == "ClassDef")
+      continue;
+
     // Found a return statement
     if (stmt["_type"] == "Return" && !stmt["value"].is_null())
     {


### PR DESCRIPTION
## Problem

An unannotated function whose body declares a **nested helper** got the helper's return type instead of its own. Minimal reproducer:

```python
def f(s):
    def check(t):
        for c in t:
            if c == '(':
                return True
        return False
    return 'Yes' if check(s) else 'No'

assert f('(x)') == 'Yes'   # wrongly reported VERIFICATION FAILED
```

`f` was inferred to return **bool** (inherited from `check`'s `return True/False`) rather than **str**. The downstream cross-type `==` fold then saw `bool == str`, collapsed it to constant `False`, and produced `ASSERT 0` — a spurious `VERIFICATION FAILED` on correct code. This is also a **latent soundness hole**: the same fold turns a genuinely-false `!=` into a constant `True`, i.e. it can hide a real bug (see the `_fail` regression test).

## Root cause

`infer_from_return_statements` (`annotation_conversion.inl`) scans a function body for `return` statements and recurses into nested blocks via `stmt["body"]`/`stmt["orelse"]`. Nested `FunctionDef`/`AsyncFunctionDef`/`ClassDef` nodes *also* have a `body` array, so the scan descended into them and harvested their returns as if they belonged to the enclosing function.

## Fix

Skip nested function/class definitions while scanning — Python scopes a `return` to its lexically enclosing `def`. A legitimate `return helper()` is a `Return` node (resolved separately via `get_function_return_type`/`find_function_recursive`), **not** a `FunctionDef` node, so it is unaffected. The change only ever *prevents* mis-attribution; it never drops a return that belongs to the scanned function.

## Why it's correct

Reviewed against Python scoping and all 9 call sites (function/method/class bodies): none relied on the leak. Edge cases checked: function with only a nested def -> infers None; decorated nested defs; nested classes; async; comprehensions (which appear as expression `_type`s inside a `Return`, not as `FunctionDef` statements, so they neither match nor need to).

## Validation

- New regression tests: `nested_fn_return_scope` (-> `VERIFICATION SUCCESSFUL`) and `nested_fn_return_scope_fail` (-> `VERIFICATION FAILED`; soundness guard — it would have reported SUCCESSFUL under the bug).
- **humaneval_127** flips `KNOWNBUG` -> `CORE` (its `intersection` has a nested `is_prime` returning bool; now verifies).
- All **23** `regression/python` tests containing nested defs pass; the CORE humaneval suite shows no new failures.
- clang-format (Clang 11) clean; `scripts/check_python_tests.sh nested_fn_return_scope` passes under CPython.

## Note on humaneval_119

humaneval_119 (`match_parens`) shares this exact root cause and verifies **SUCCESSFUL** once typed correctly — but the resulting runtime `strcmp` under `--unwind 20` then trips a **separate, path-dependent segfault in bitwuzla encoding** (reproducible: same input verifies via a relative source path, segfaults via an absolute one). That is an independent backend bug, so 119 stays `KNOWNBUG` here rather than masking the crash.

Refs #4807.
