### PR TITLE
[python] Phase 4.3: migrate elementary type builders to IREP2-internal

### DIFF
--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -9,7 +9,9 @@
 #include <util/context.h>
 #include <util/c_types.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
+#include <irep2/irep2_utils.h>
 
 #include <regex>
 
@@ -35,6 +37,19 @@ constexpr unsigned kPythonBitLengthCap = 512;
 static_assert(
   kPythonBignumWidth <= kPythonBitLengthCap,
   "bit_length OM cap (models/int.py) must cover the full Python int width");
+
+// Phase 4.3 seam (Part IV §5/§6): lower an internally-built IREP2 type to the
+// legacy `typet` the symbol table and shared downstream passes consume,
+// re-attaching the `#cpp_type` hint IREP2 cannot carry (F-P5). The elementary
+// builders construct `type2tc` via typed factories and pass through here, so
+// the legacy bytes reaching `create_symbol` stay byte-identical to before.
+typet lower_to_seam(const type2tc &t, const irep_idt &cpp_type = irep_idt())
+{
+  typet legacy = migrate_type_back(t);
+  if (!cpp_type.empty())
+    type_utils::set_cpp_type(legacy, cpp_type);
+  return legacy;
+}
 } // namespace
 
 unsigned type_handler::python_int_width()
@@ -468,7 +483,8 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   // int — arbitrarily large integers
   // We approximate using 64-bit signed integer here.
   if (ast_type == "int" || ast_type == "GeneralizedIndex")
-    return long_long_int_type(); // FIXME: Support bignum for true Python semantics
+    // FIXME: Support bignum for true Python semantics
+    return lower_to_seam(signedbv_type2tc(config.ansi_c.long_long_int_width));
 
   // Internal alias for operational models that need a width-polymorphic
   // signed integer parameter — accepts both narrow and wide Python int
@@ -484,11 +500,11 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (
     ast_type == "uint" || ast_type == "uint64" || ast_type == "Epoch" ||
     ast_type == "Slot")
-    return long_long_uint_type();
+    return lower_to_seam(unsignedbv_type2tc(config.ansi_c.long_long_int_width));
 
   // bool — represents True/False
   if (ast_type == "bool")
-    return bool_type();
+    return lower_to_seam(get_bool_type());
 
   // slice — Python's slice() builtin, modelled as __ESBMC_PySliceObj.
   // Only resolve to the slice struct if the operational model is loaded;
@@ -522,7 +538,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
 
   // Custom large unsigned integer types (used in Ethereum, BLS, etc.)
   if (ast_type == "uint256" || ast_type == "BLSFieldElement")
-    return uint256_type();
+    return lower_to_seam(unsignedbv_type2tc(256));
 
   // bytes — immutable sequences of bytes
   // Here modeled as array of signed integers (8-bit).
@@ -560,9 +576,12 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   {
     if (type_size == 1)
     {
-      typet type = char_type();               // 8-bit char
-      type_utils::set_cpp_type(type, "char"); // For C backend compatibility
-      return type;
+      // 8-bit char built IREP2-internal; #cpp_type "char" is re-attached at the
+      // seam for C-backend compatibility (F-P5 — IREP2 cannot carry it).
+      const type2tc char_t = config.ansi_c.char_is_unsigned
+                               ? unsignedbv_type2tc(config.ansi_c.char_width)
+                               : signedbv_type2tc(config.ansi_c.char_width);
+      return lower_to_seam(char_t, "char");
     }
     return build_array(char_type(), type_size); // Array of characters
   }

--- a/unit/python-frontend/irep2_type_roundtrip_test.cpp
+++ b/unit/python-frontend/irep2_type_roundtrip_test.cpp
@@ -3,7 +3,10 @@
 
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <python-frontend/python_converter.h>
+#include <python-frontend/global_scope.h>
 #include <util/config.h>
+#include <util/context.h>
 #include <util/migrate.h>
 #include <util/c_types.h>
 #include <util/python_types.h>
@@ -173,4 +176,44 @@ TEST_CASE(
   REQUIRE(type_utils::get_cpp_type(back).empty());
   REQUIRE(
     type_utils::get_cpp_type(tagged) == "char"); // unchanged on the seam node
+}
+
+TEST_CASE(
+  "Phase 4.3: elementary get_typet outputs are byte-identical (IREP2-internal)",
+  "[python-frontend][irep2][phase4.3]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  contextt context;
+  global_scope gs;
+  const nlohmann::json ast = {
+    {"_type", "Module"},
+    {"body", nlohmann::json::array()},
+    {"filename", "test.py"},
+    {"type_ignores", nlohmann::json::array()}};
+  python_converter converter(context, &ast, gs);
+  const type_handler &th = converter.get_type_handler();
+
+  // The elementary family now builds type2tc internally and lowers at the
+  // seam; the legacy typet reaching create_symbol must be byte-identical to the
+  // direct legacy builder it replaced.
+  REQUIRE(th.get_typet(std::string("int")) == long_long_int_type());
+  REQUIRE(
+    th.get_typet(std::string("GeneralizedIndex")) == long_long_int_type());
+  REQUIRE(th.get_typet(std::string("uint")) == long_long_uint_type());
+  REQUIRE(th.get_typet(std::string("uint64")) == long_long_uint_type());
+  REQUIRE(th.get_typet(std::string("Epoch")) == long_long_uint_type());
+  REQUIRE(th.get_typet(std::string("bool")) == bool_type());
+  REQUIRE(th.get_typet(std::string("uint256")) == uint256_type());
+  REQUIRE(th.get_typet(std::string("BLSFieldElement")) == uint256_type());
+
+  // str/size==1: an 8-bit char carrying #cpp_type "char", re-attached at the
+  // seam (F-P5) since IREP2 cannot carry it. Both the bit-vector and the
+  // re-attached hint must match the legacy builder byte-for-byte.
+  typet expected_char = char_type();
+  type_utils::set_cpp_type(expected_char, "char");
+  const typet got_char = th.get_typet(std::string("str"), 1);
+  REQUIRE(got_char == expected_char);
+  REQUIRE(type_utils::get_cpp_type(got_char) == "char");
 }


### PR DESCRIPTION
First slice of Part IV Phase 4.3 (§5/§7): the elementary branches of type_handler::get_typet now construct type2tc via typed factories (signedbv_type2tc/unsignedbv_type2tc/get_bool_type) and lower to legacy typet at a single seam helper (lower_to_seam), which back-migrates and re-attaches the #cpp_type hint IREP2 cannot carry (F-P5). get_typet keeps its typet return (129 callers across 20 files), so the legacy bytes reaching create_symbol stay byte-identical and behaviour is unchanged.

Migrated: int/GeneralizedIndex, uint/uint64/Epoch/Slot, bool, uint256/BLSFieldElement, and str/size-1 char (the #cpp_type seam case). Deferred to the next 4.3 commit: float/double (build_float_type is config-branched floatbv-vs-fixedbv); python_int_typet untouched (F-P7 pin); array/struct/pointer families follow.

Validation: irep2_type_roundtrip_test extends the Phase 4.0 harness to assert the migrated get_typet outputs are byte-identical to the legacy builders via the real entry point (48 assertions, 5 cases). The pre-existing python-intensive/cmath_intermediate_core THOROUGH failure (an FP-sort assertion in smt_sort.h) reproduces identically on master with identical VCC counts, confirming this change is behaviour-preserving.