### PR TITLE
[python] add queue.Queue/LifoQueue model; fix dict-method shadowing

### DIFF
--- a/regression/python/queue_fifo/main.py
+++ b/regression/python/queue_fifo/main.py
@@ -1,0 +1,39 @@
+# queue.Queue is modelled as a list-backed FIFO and queue.LifoQueue as a
+# list-backed stack. Exercises the qualified `queue.Queue()` form (whose
+# .get() must dispatch to the class method, not dict.get), the direct
+# `from queue import LifoQueue` form, and maxsize/full tracking.
+import queue
+from queue import LifoQueue
+
+# FIFO: items come out in the order they went in
+q = queue.Queue()
+q.put(1)
+q.put(2)
+q.put(3)
+assert q.qsize() == 3
+assert not q.empty()
+assert q.get() == 1
+assert q.get() == 2
+assert q.get() == 3
+assert q.empty()
+
+# bounded queue: full() tracks maxsize
+b = queue.Queue(2)
+b.put(10)
+assert not b.full()
+b.put(20)
+assert b.full()
+
+# LifoQueue is a stack: last in, first out
+s = LifoQueue()
+s.put(7)
+s.put(8)
+assert s.get() == 8
+assert s.get() == 7
+
+# A genuine dict's .get()/.pop() must still route to the dict handler after the
+# receiver-type dispatch guard (regression guard for the queue.Queue.get fix).
+d = {1: 11, 2: 22}
+assert d.get(1) == 11
+assert d.get(3, -1) == -1
+assert d.pop(2) == 22

--- a/regression/python/queue_fifo/test.desc
+++ b/regression/python/queue_fifo/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/queue_fifo_fail/main.py
+++ b/regression/python/queue_fifo_fail/main.py
@@ -1,0 +1,10 @@
+# Negative variant: queue.Queue is FIFO, so the first item out is the first
+# put in (1), not the last (3). The wrong assertion below must be reported as
+# a violation — guarding against a LIFO/nondet mis-model of get().
+import queue
+
+q = queue.Queue()
+q.put(1)
+q.put(2)
+q.put(3)
+assert q.get() == 3

--- a/regression/python/queue_fifo_fail/test.desc
+++ b/regression/python/queue_fifo_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -1321,6 +1321,15 @@ bool function_call_expr::is_dict_method_call() const
     method_name != "update")
     return false;
 
+  // A receiver that resolves to a non-dict object (e.g. a class instance whose
+  // own method shadows the same-named dict method, such as queue.Queue.get())
+  // must defer to instance-method dispatch. Real dicts carry the
+  // "__python_dict__" struct tag; class instances carry "tag-<Class>". An
+  // unresolved or genuinely dict-typed receiver is left to the dict handler, so
+  // existing dict dispatch is unchanged. Mirrors the list guard for pop below.
+  if (receiver_is_non_dict_object())
+    return false;
+
   // For "pop", which exists on both list and dict, treat as dict.pop() when
   // the receiver does not resolve to a list symbol.
   if (method_name == "pop")
@@ -1332,6 +1341,43 @@ bool function_call_expr::is_dict_method_call() const
   }
 
   return true;
+}
+
+bool function_call_expr::receiver_is_non_dict_object() const
+{
+  const auto &recv = call_["func"]["value"];
+  if (recv["_type"] != "Name" || !recv.contains("id"))
+    return false;
+
+  // Resolve the receiver name in function then module scope. This mirrors
+  // lookup_python_symbol but is kept warning-free: is_dict_method_call is a
+  // discriminator, so a miss here must stay silent (a genuine dict whose
+  // receiver does not resolve through these scopes still defers to the dict
+  // handler below — the safe direction).
+  const std::string var_name = recv["id"].get<std::string>();
+  const std::string filename = function_id_.get_filename();
+  const symbolt *sym = converter_.find_symbol(
+    "py:" + filename + "@F@" + converter_.current_function_name() + "@" +
+    var_name);
+  if (!sym)
+    sym = converter_.find_symbol("py:" + filename + "@" + var_name);
+  if (!sym)
+    return false;
+
+  typet t = sym->get_type();
+  if (t.is_pointer())
+    t = t.subtype();
+  if (t.id() == "symbol")
+    t = converter_.ns.follow(t);
+
+  // Only a positively-resolved non-dict struct defers to instance dispatch; an
+  // unresolved or "__python_dict__"-tagged receiver stays with the dict handler.
+  // list/set receivers also resolve to a (non-dict) struct here, but their
+  // dict-overlapping methods (pop/copy/update) are claimed by the list/set
+  // discriminators earlier in the dispatch table, so they never reach this.
+  if (!t.is_struct())
+    return false;
+  return to_struct_type(t).tag().as_string() != "__python_dict__";
 }
 
 exprt function_call_expr::handle_dict_method() const

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -308,6 +308,12 @@ private:
   bool is_dict_method_call() const;
   exprt handle_dict_method() const;
 
+  // True when the Name receiver positively resolves to a non-dict object type
+  // (a class instance, identified by a struct tag other than "__python_dict__").
+  // Used to stop dict-named methods (get/pop/keys/...) from shadowing a class's
+  // own same-named method (e.g. queue.Queue.get()).
+  bool receiver_is_non_dict_object() const;
+
   // Dict class method detection (e.g. dict.fromkeys([1, 2, 3]))
   bool is_dict_class_method_call() const;
 

--- a/src/python-frontend/models/queue.py
+++ b/src/python-frontend/models/queue.py
@@ -1,0 +1,85 @@
+# Operational model for the queue module.
+# pylint: disable=unused-argument
+# Single-threaded verification model: queue.Queue is backed by a plain
+# Python list, which the frontend already supports (append / pop / pop(0) /
+# __len__). The blocking semantics of put()/get() (the `block` and `timeout`
+# arguments) are NOT modelled — there are no threads to block on under
+# sequential symbolic execution. An unguarded get() on an empty queue pops
+# from an empty list, which the list model reports as an "IndexError: pop from
+# empty list" violation (rather than CPython's block-forever / queue.Empty);
+# programs that guard with empty()/qsize() first verify cleanly. task_done() /
+# join() are accepted no-ops. maxsize is tracked by full() but put() does not
+# block on it.
+from typing import Any
+
+
+class Queue:
+    """queue.Queue — list-backed FIFO (first-in, first-out)."""
+
+    def __init__(self, maxsize: int = 0) -> None:
+        self.items: list[Any]
+        self.items = []
+        self.maxsize: int = maxsize
+
+    def put(self, item: Any, block: bool = True, timeout: Any = None) -> None:
+        self.items.append(item)
+
+    def put_nowait(self, item: Any) -> None:
+        self.items.append(item)
+
+    def get(self, block: bool = True, timeout: Any = None) -> Any:
+        return self.items.pop(0)
+
+    def get_nowait(self) -> Any:
+        return self.items.pop(0)
+
+    def qsize(self) -> int:
+        return len(self.items)
+
+    def empty(self) -> bool:
+        return len(self.items) == 0
+
+    def full(self) -> bool:
+        return self.maxsize > 0 and len(self.items) >= self.maxsize
+
+    def task_done(self) -> None:
+        return None
+
+    def join(self) -> None:
+        return None
+
+
+class LifoQueue:
+    """queue.LifoQueue — list-backed LIFO (last-in, first-out / stack)."""
+
+    def __init__(self, maxsize: int = 0) -> None:
+        self.items: list[Any]
+        self.items = []
+        self.maxsize: int = maxsize
+
+    def put(self, item: Any, block: bool = True, timeout: Any = None) -> None:
+        self.items.append(item)
+
+    def put_nowait(self, item: Any) -> None:
+        self.items.append(item)
+
+    def get(self, block: bool = True, timeout: Any = None) -> Any:
+        return self.items.pop()
+
+    def get_nowait(self) -> Any:
+        return self.items.pop()
+
+    def qsize(self) -> int:
+        return len(self.items)
+
+    def empty(self) -> bool:
+        return len(self.items) == 0
+
+    def full(self) -> bool:
+        return self.maxsize > 0 and len(self.items) >= self.maxsize
+
+    def task_done(self) -> None:
+        return None
+
+    def join(self) -> None:
+        return None

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -112,6 +112,7 @@ def _is_imported_model(module_name: str) -> bool:
         "typing",
         "time",
         "threading",
+        "queue",
     }
     return module_name in models
 


### PR DESCRIPTION
## What

Adds an operational model for the `queue` stdlib module and fixes a method-dispatch bug it exposed.

1. **`src/python-frontend/models/queue.py`** — `queue.Queue` modelled as a list-backed FIFO and `queue.LifoQueue` as a list-backed stack: `put`→`append`, `get`→`pop(0)` (FIFO) / `pop()` (LIFO), plus `empty`/`qsize`/`full`/`put_nowait`/`get_nowait`/`task_done`/`join`. Backed by the list model, which already supports `append`/`pop`/`pop(0)`/`len`.
2. **`src/python-frontend/parser/import_resolver.py`** — registers `queue` in the modeled-module allowlist.
3. **`src/python-frontend/function_call/expr.cpp` + `.h`** — the core fix. `is_dict_method_call()` returned true for any value-returning dict method name (`get`/`keys`/`values`/`items`/`setdefault`/`update`/`pop`) on *any* attribute call, without checking the receiver was a dict. So a class instance's own `.get()` (e.g. `queue.Queue().get()`) was hijacked by the dict handler and failed with `get() missing required argument: 'key'`. The new `receiver_is_non_dict_object()` guard defers to instance-method dispatch when the Name receiver positively resolves to a non-dict struct — real dicts carry the `__python_dict__` struct tag, class instances carry `tag-<Class>`. Unresolved or genuinely dict-typed receivers are left to the dict handler (the safe direction). This mirrors the existing `pop`→list guard right below it.

## Why

`queue.Queue` is a common FIFO; it was unmodelled (`Object "queue" not found`). This is plan item §6.4 in `docs/python-issues-triage-plan.md`. The dispatch bug is general — any class with a method named `get`/`keys`/`values`/`items`/`pop`/`setdefault`/`update` was previously shadowed by dict dispatch.

## Soundness

The guard only ever makes `is_dict_method_call()` return `false` more often (defer); it never sends a real dict to the wrong handler. Dicts are represented as a struct tagged `__python_dict__` (`python_dict_handler.cpp:87-95`), so the tag check excludes them. list/set receivers also resolve to a non-dict struct, but their dict-overlapping methods (`pop`/`copy`/`update`) are claimed by the list/set discriminators *earlier* in the dispatch table, so they never reach this guard. The discriminator is kept side-effect-free (warning-free symbol lookup).

An unguarded `get()` on an empty queue pops from an empty list, which the list model reports as `IndexError: pop from empty list` — a deterministic violation, the correct behavior for a verification model (CPython would block / raise `queue.Empty`; the single-threaded simplification is documented in the model).

## Tests

- New `regression/python/queue_fifo` (qualified `queue.Queue()` FIFO via `.get()`, `from queue import LifoQueue`, `full()`/maxsize, **plus a genuine dict `.get()`/`.pop()` to pin that the dispatch guard does not regress dict calls**) and `regression/python/queue_fifo_fail` (wrong FIFO element → VERIFICATION FAILED).
- 499/500 method-dispatch / dict / class / collections / list / set / tuple tests pass; the 1 non-pass is `list_pop11_nondet`, which requires `--boolector` (not built in this environment) — it verifies SUCCESSFUL under the default solver.
- CPython sanity (`scripts/check_python_tests.sh queue_fifo`) ✓; pylint error-clean (10/10); clang-format-clean changed lines.

The queue model is straight-line (no added branches). The new C++ guard is a frontend-dispatch branch (not symbolically executed by ESBMC, so the `__ESBMC_unreachable()` Mode-C primitive does not apply); its liveness is witnessed by `queue_fifo`, where `queue.Queue().get()` takes the branch — without it the call errors.

Refs #4566.
