### PR TITLE
[goto-programs] keep overflow2t operand intact in interval analysis

### DIFF
--- a/regression/esbmc/github_5007/main.c
+++ b/regression/esbmc/github_5007/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  const int ARRAY_SIZE = 10;
+  long packet[ARRAY_SIZE];
+  return 0;
+}

--- a/regression/esbmc/github_5007/test.desc
+++ b/regression/esbmc/github_5007/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --interval-analysis
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5007_fail/main.c
+++ b/regression/esbmc/github_5007_fail/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  const int ARRAY_SIZE = 10;
+  long packet[ARRAY_SIZE];
+  packet[20] = 1; // out-of-bounds write
+  return 0;
+}

--- a/regression/esbmc/github_5007_fail/test.desc
+++ b/regression/esbmc/github_5007_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --interval-analysis
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_5007_nondet/main.c
+++ b/regression/esbmc/github_5007_nondet/main.c
@@ -1,0 +1,11 @@
+extern int __VERIFIER_nondet_int(void);
+
+// Non-singleton VLA size: the overflow2t guard's operand must NOT be collapsed
+// to a constant, exercising the leaf-only optimisation path of the fix.
+int main()
+{
+  int n = __VERIFIER_nondet_int();
+  __ESBMC_assume(n > 0 && n < 100);
+  long packet[n];
+  return 0;
+}

--- a/regression/esbmc/github_5007_nondet/test.desc
+++ b/regression/esbmc/github_5007_nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --interval-analysis --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -75,6 +75,18 @@ static void optimize_expression(expr2tc &expr, const interval_domaint &state)
     return;
   }
 
+  // An overflow2t requires its operand to remain a binary arithmetic operation
+  // (add/sub/mul/...). Collapsing a singleton operand into a constant breaks
+  // both backmigration (migrate.cpp) and SMT overflow encoding, which read the
+  // operand's two sub-expressions. Optimise only the arithmetic operands'
+  // leaves; keep the operation node intact. (Mirrors gcse.cpp.)
+  if (is_overflow2t(expr))
+  {
+    to_overflow2t(expr).operand->Foreach_operand(
+      [&state](expr2tc &e) { optimize_expression(e, state); });
+    return;
+  }
+
   if (interval_domaint::enable_wrapped_intervals)
     optimize_expr_interval<wrapped_interval>(expr, state);
   else


### PR DESCRIPTION
Interval analysis collapsed singleton bitvector subexpressions into constants, including the binary arithmetic operand of an overflow2t (e.g., the VLA size guard `!overflow("*", n, 8)`). ESBMC requires that the operand stay an arithmetic node, so the constant operand aborted backmigration and caused a null-deref segfault during SMT overflow encoding.

Guard `overflow2t` in `optimize_expression` so only the operand's leaves are optimised, thereby preserving the operation node (mirrors `gcse.cpp`). 

Fixes #5007.