### PR TITLE
[python] Phase 4.3: migrate pointer-family type builders to IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -1888,6 +1888,22 @@ further phase is taken up.*
    byte (F-P7 / SM1). `code_type2t` requires `args.size() ==
    argument_names.size()` (`irep2_type.h:240`) — supply synthesized names.
 
+   **Ordering refined by the §15.7 byte-identity audit.** The seam helper
+   `lower_to_seam` preserves byte-identity *only* when the legacy form
+   already carries every field `migrate_type_back` re-emits. The
+   **pointer family** (`pointer_typet(value/symbol)`, and the
+   NoneType/Optional pointer-width unsignedbv) satisfies this and was
+   migrated **ahead of struct/class** (elementary → array → **pointer** →
+   …). The **tuple/optional struct builders do *not*** — `migrate_type_back`
+   unconditionally writes `tag`/`pretty_name` (a tagless 2-arg-component
+   tuple gains both) and drops component `#access` (Optional). They are
+   therefore **F-P5 seam-attribute cases deferred to Phase 4.5**, not clean
+   4.3 internal migrations. The **Callable** builder (an empty-argument
+   `code_typet`) is likewise non-byte-identical (back-migration adds an
+   `arguments` sub) and migrates with the **function-type** family once
+   synthesized argument names are supplied. The lossless struct case is the
+   `complex` struct (3-arg components + `tag` already present, §15.7).
+
 ### Phase 4.4 — Migrate **expression** construction to `expr2tc` (internal)
 7. Rewrite the expression converters to build `expr2tc` via typed factories
    instead of `symbol_expr`/`typecast_exprt`/`member_exprt`/`index_exprt`/
@@ -2298,3 +2314,46 @@ captures matched lines (not just the verdict) and the property/branch/assert
 counts are held invariant — both already mandated by §10. This makes RP10
 cheap to discharge: one targeted bounds test plus the existing matched-text
 gate, rather than a diffuse symbol-naming audit.
+
+### 15.7 Phase 4.3 byte-identity audit — which type families ride the seam losslessly
+
+The Phase 4.3 invariant is byte-identical legacy output at the seam (the
+elementary/array commits and their `irep2_type_roundtrip_test` cases assert
+exact `==`). A spike over `lower_to_seam(t) = migrate_type_back(t)` for every
+`type_handler` builder shape established **which families can hold that bar**,
+because `lower_to_seam` is byte-identical **only** when the legacy form
+already carries every field `migrate_type_back` re-emits:
+
+| Builder shape | Byte-identical? | Why |
+|---|:---:|---|
+| Elementary (`signedbv`/`unsignedbv`/`bool`/float) | ✅ | scalar, no extra fields |
+| `array_typet` | ✅ | subtype + size only |
+| `pointer_typet(value)` / `pointer_typet(symbol)` | ✅ | subtype only; `carry_provenance` default `false` matches a fresh `pointer_typet` |
+| NoneType/Optional (`pointer_type()` = pointer-width `unsignedbv`) | ✅ | elementary in disguise |
+| `complex` struct (3-arg components + `tag`) | ✅ | `tag`/`pretty_name` already present |
+| **Tuple** struct (2-arg components, **tagless**) | ❌ | `migrate_type_back` **adds** an empty `tag` **and** an empty `pretty_name` per component |
+| **Optional** struct (`set_access("public")`) | ❌ | `migrate_type` carries only types/names/pretty-names/tag/packed — component **`#access` is dropped** |
+| **Callable** (`pointer_typet(code_typet)`, **no args**) | ❌ | `migrate_type_back` **adds** an `arguments` sub the source lacks |
+
+**Consequences for the family order (§7 Phase 4.3).**
+
+- The **pointer family** was migrated **ahead of struct/class** (commit
+  `[python] Phase 4.3: migrate pointer-family type builders to IREP2`):
+  NoneType/Optional → `unsignedbv_type2tc`, the list/annotation pointees →
+  `pointer_type2tc`, the generic list type → `pointer_type2tc` +
+  `symbol_type2tc`. The doc's family sequence is an ordering preference, not a
+  hard dependency (§8: 4.3 only blocks 4.4); reordering to "clean families
+  first" keeps every commit byte-identical.
+- The **tuple/optional struct builders are F-P5 seam-attribute cases** — the
+  same class as `#cpp_type`/`#member_name`. They cannot ride the IREP2 type
+  losslessly and belong to **Phase 4.5** (the explicit hand-off that
+  re-attaches seam attributes), not a Phase 4.3 internal migration. The only
+  lossless `type_handler` struct is `complex` (but it is a cached header-inline
+  free function feeding expression construction, so it tracks with 4.4/4.5).
+- The **Callable** builder migrates with the **function-type** family once
+  synthesized argument names exist (§7 already flags the `code_type2t`
+  `args.size() == argument_names.size()` requirement).
+
+Reproduce: extend `irep2_type_roundtrip_test` with
+`migrate_type_back(migrate_type(t)) == t` over each shape above; the ❌ rows
+fail, the ✅ rows pass.

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -451,18 +451,24 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (ast_type == "object")
     return any_type();
 
-  // NoneType — represents Python's None value
-  // Use a pointer type to void to represent None/null properly
+  // NoneType — represents Python's None value, modelled as a pointer-width
+  // unsigned integer (the legacy pointer_type() helper). Built IREP2-internal
+  // and lowered at the seam (Phase 4.3, Part IV §5).
   if (ast_type == "NoneType")
-    return pointer_type();
+    return lower_to_seam(unsignedbv_type2tc(config.ansi_c.pointer_width()));
 
   // Optional[T] - when type string is just "Optional" without inner type
-  // This can occur during type inference. Return pointer type as placeholder.
+  // This can occur during type inference. Same pointer-width unsigned integer
+  // placeholder as NoneType, lowered at the seam.
   if (ast_type == "Optional")
-    return pointer_type();
+    return lower_to_seam(unsignedbv_type2tc(config.ansi_c.pointer_width()));
 
   // Callable: represents function/callable types
-  // Return a pointer to a generic code type (function pointer)
+  // Return a pointer to a generic code type (function pointer). Left legacy in
+  // the Phase 4.3 pointer-family slice: an empty-argument code_typet does not
+  // round-trip byte-identically through code_type2t (migrate_type_back emits an
+  // `arguments` sub the source lacks), so it migrates with the function-type
+  // family once synthesized argument names are supplied (Part IV §7, 4.3).
   if (ast_type == "Callable")
   {
     code_typet code_type;
@@ -938,7 +944,9 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
       }
       else
         t = empty_typet();
-      return pointer_typet(t);
+      // Phase 4.3 (Part IV §5): build the pointer type IREP2-internal and lower
+      // at the seam. The pointee arrives as a legacy typet, so migrate it in.
+      return lower_to_seam(pointer_type2tc(migrate_type(t)));
     }
 
     // Check if the nested structure exists before accessing
@@ -950,7 +958,8 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
       assert(type_ann == "list" || type_ann == "List");
       typet t =
         get_typet(list_value["annotation"]["slice"]["id"].get<std::string>());
-      return pointer_typet(t);
+      // Phase 4.3 (Part IV §5): pointer built IREP2-internal, lowered at seam.
+      return lower_to_seam(pointer_type2tc(migrate_type(t)));
     }
   }
 
@@ -1041,7 +1050,9 @@ const typet type_handler::get_list_type() const
   const char *list_type_id = "tag-struct __ESBMC_PyListObj";
   list_type_symbol = converter_.symbol_table().find_symbol(list_type_id);
   assert(list_type_symbol);
-  return pointer_typet(symbol_typet(list_type_symbol->id));
+  // Phase 4.3 (Part IV §5): pointer-to-symbol built IREP2-internal (symbol type
+  // constructed natively, no legacy round-trip) and lowered at the seam.
+  return lower_to_seam(pointer_type2tc(symbol_type2tc(list_type_symbol->id)));
 }
 
 typet type_handler::get_list_element_type() const

--- a/unit/python-frontend/irep2_type_roundtrip_test.cpp
+++ b/unit/python-frontend/irep2_type_roundtrip_test.cpp
@@ -77,6 +77,13 @@ TEST_CASE(
     code_typet code_type; // Callable
     code_type.return_type() = empty_typet();
     require_irep2_stable(pointer_typet(code_type));
+
+    // Pointer-to-value and pointer-to-symbol: the shapes the list/annotation
+    // builders emit, migrated in Phase 4.3 to pointer_type2tc + lower_to_seam.
+    require_irep2_stable(pointer_typet(long_long_int_type()));
+    require_irep2_stable(pointer_typet(empty_typet()));
+    require_irep2_stable(
+      pointer_typet(symbol_typet("tag-struct __ESBMC_PyListObj")));
   }
 
   SECTION("array kinds (str / bytes / type)")
@@ -277,4 +284,45 @@ TEST_CASE(
   // A large size exercises the BigInt size path.
   REQUIRE(
     th.build_array(char_type(), 100000) == legacy_array(char_type(), 100000));
+}
+
+TEST_CASE(
+  "Phase 4.3: pointer-family builders are byte-identical (IREP2-internal)",
+  "[python-frontend][irep2][phase4.3]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  contextt context;
+  global_scope gs;
+  const nlohmann::json ast = {
+    {"_type", "Module"},
+    {"body", nlohmann::json::array()},
+    {"filename", "test.py"},
+    {"type_ignores", nlohmann::json::array()}};
+  python_converter converter(context, &ast, gs);
+  const type_handler &th = converter.get_type_handler();
+
+  // NoneType / Optional: get_typet now builds the pointer-width unsigned integer
+  // IREP2-internal (unsignedbv_type2tc) and lowers at the seam. The legacy
+  // result must be byte-identical to the pointer_type() helper it replaced.
+  REQUIRE(th.get_typet(std::string("NoneType")) == pointer_type());
+  REQUIRE(th.get_typet(std::string("Optional")) == pointer_type());
+
+  // The list/annotation pointer sites (get_list_type) build pointer_type2tc and
+  // lower at the seam, but require a populated symbol table to reach directly;
+  // the full regression suite exercises them. Here we pin the *pattern* those
+  // sites use is byte-identical to the pointer_typet constructor it replaced:
+  // pointer-to-value (migrated subtype) and pointer-to-symbol (native subtype).
+  auto lowered_ptr = [](const type2tc &sub) {
+    return migrate_type_back(pointer_type2tc(sub));
+  };
+  REQUIRE(
+    lowered_ptr(migrate_type(long_long_int_type())) ==
+    pointer_typet(long_long_int_type()));
+  REQUIRE(
+    lowered_ptr(migrate_type(empty_typet())) == pointer_typet(empty_typet()));
+  REQUIRE(
+    lowered_ptr(symbol_type2tc("tag-struct __ESBMC_PyListObj")) ==
+    pointer_typet(symbol_typet("tag-struct __ESBMC_PyListObj")));
 }


### PR DESCRIPTION
## What

Phase 4.3 (pointer slice) of the Part IV Python frontend → IREP2 migration plan
(`docs/irep2-migration.md` §5/§7): migrate the **pointer type family** in
`type_handler` to **IREP2-internal construction**, lowering at the existing
`lower_to_seam` helper.

## Approach — "IREP2-internal, legacy-at-the-seam" (§5)

`get_typet`/`get_list_type` keep their `typet` return signatures. The pointer
branches now build `type2tc` via typed factories and lower to the legacy
`typet` at the single seam helper `lower_to_seam`, so the legacy bytes reaching
`create_symbol` stay **byte-identical** to before and behaviour is unchanged.

Migrated sites in `type_handler.cpp`:

- **NoneType / Optional** (`get_typet`) → `unsignedbv_type2tc(pointer_width())`
  (these route through the `pointer_type()` helper, which is itself a
  pointer-width `unsignedbv`, not a literal pointer).
- **list/annotation pointee** (`get_list_type`, ×2) → `pointer_type2tc(migrate_type(t))`.
- **generic list type** (`get_list_type`) → `pointer_type2tc(symbol_type2tc(id))`
  (the symbol subtype is built IREP2-native, no legacy round-trip).

## Ordering — pointer family before struct/class (§15.7)

A byte-identity spike (recorded in the doc's new §15.7) established which
`type_handler` families ride `lower_to_seam` losslessly. `lower_to_seam` is
byte-identical only when the legacy form already carries every field
`migrate_type_back` re-emits:

- ✅ **Pointer** (`pointer_typet(value/symbol)`, NoneType/Optional unsignedbv) and
  the `complex` struct round-trip exactly.
- ❌ **Tuple/Optional struct builders** do not — `migrate_type_back`
  unconditionally writes `tag`/`pretty_name` (a tagless 2-arg-component tuple
  gains both) and drops component `#access` (Optional). These are **F-P5
  seam-attribute cases reclassified to Phase 4.5**.
- ❌ **Callable** (`pointer_typet(code_typet)` with no args) gains an `arguments`
  sub on back-migration, so it is **left legacy this slice** and migrates with
  the **function-type** family once synthesized argument names exist.

The doc's family sequence is an ordering preference, not a hard dependency
(§8: 4.3 only blocks 4.4); reordering to "clean families first" keeps every
commit byte-identical.

## Validation

- `unit/python-frontend/irep2_type_roundtrip_test.cpp` (extends the Phase 4.0
  harness): NoneType/Optional asserted byte-identical to `pointer_type()` via
  the **real builder**; the `pointer_type2tc + lower_to_seam` pattern used by
  the list/annotation sites pinned byte-identical to the `pointer_typet`
  constructor for pointer-to-value and pointer-to-symbol; new IREP2-stability
  cases for the same shapes. **64 assertions / 8 cases pass.**
- All python/irep2/symbolt unit tests pass (**26/26**).
- Migrated paths verified **end-to-end under both Bitwuzla and Z3** (None,
  `Optional[int]`, `list[int]` annotations, generic list ops): identical
  `VERIFICATION SUCCESSFUL`, and a negative `list[int]` assertion still
  `VERIFICATION FAILED` on both solvers (checker boundary intact).
- Representative `python-intensive` regression tests pass (`tuple3`, `list5`,
  `list-insert`).

Not a Mode C patch: the change touches only the return *expressions* inside
existing `if` branches (single-statement-body changes); no branch is added or
removed.

## Test plan

- [x] `irep2_type_roundtrip_test` — 64 assertions green
- [x] python/irep2/symbolt unit tests — 26/26
- [x] end-to-end migrated paths under Bitwuzla **and** Z3 (incl. negative case)
- [x] representative regression tests pass
- [x] clang-format (Clang-11 style) clean on changed lines
