### PR TITLE
[symex] sound printf return-length: don't under-approximate a non-constant format

### DIFF
--- a/regression/esbmc/printf_const_format_exact/main.c
+++ b/regression/esbmc/printf_const_format_exact/main.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+// Precision-preservation control for the printf soundness fix. The format is a
+// compile-time constant with no conversion specifiers, so the sprintf return is
+// pinned to the exact length (5). The subsequent addition cannot overflow, so
+// verification must still succeed — the fix must not over-approximate the
+// fully-determined case.
+int main(void)
+{
+  char buf[64];
+  int n = sprintf(buf, "hello"); // exact length 5
+  int base = 10;
+  int t = base + n; // 15, no overflow
+  return t;
+}

--- a/regression/esbmc/printf_const_format_exact/test.desc
+++ b/regression/esbmc/printf_const_format_exact/test.desc
@@ -2,4 +2,3 @@ CORE
 main.c
 --overflow-check --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-^EXIT=0$

--- a/regression/esbmc/printf_const_format_exact/test.desc
+++ b/regression/esbmc/printf_const_format_exact/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$

--- a/regression/esbmc/printf_nonconst_format_overflow/main.c
+++ b/regression/esbmc/printf_nonconst_format_overflow/main.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+extern int __VERIFIER_nondet_int(void);
+
+// G-A soundness test. The format string is not a compile-time constant, so the
+// formatted-output length (the sprintf return) cannot be bounded. ESBMC must
+// model the return as an unconstrained non-negative int; adding it to a value
+// near INT_MAX then has a reachable signed overflow. Before the printf
+// soundness fix, a non-constant format made the modelled return 0, so this
+// overflow was silently missed (false VERIFICATION SUCCESSFUL).
+int main(void)
+{
+  char buf[64];
+  int x = __VERIFIER_nondet_int();
+  const char *fmt = (x & 1) ? "%d" : "%i"; // non-constant format
+  int n = sprintf(buf, fmt, x);
+  int base = 2147483640; // INT_MAX - 7
+  int t = base + n;      // reachable overflow when n >= 8
+  return t;
+}

--- a/regression/esbmc/printf_nonconst_format_overflow/test.desc
+++ b/regression/esbmc/printf_nonconst_format_overflow/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION FAILED$
+^EXIT=1$

--- a/regression/esbmc/printf_nonconst_format_overflow/test.desc
+++ b/regression/esbmc/printf_nonconst_format_overflow/test.desc
@@ -2,4 +2,3 @@ CORE
 main.c
 --overflow-check --incremental-bmc
 ^VERIFICATION FAILED$
-^EXIT=1$

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -48,7 +48,8 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
   irep_idt fmt;
   size_t idx;
   const expr2tc &base_expr = get_base_object(new_rhs.operands[fmt_idx]);
-  if (is_constant_string2t(base_expr))
+  const bool format_is_constant = is_constant_string2t(base_expr);
+  if (format_is_constant)
   {
     fmt = to_constant_string2t(base_expr).value;
     idx = fmt_idx + 1;
@@ -56,6 +57,8 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
   else
   {
     // e.g.   int x = 1; printf(x); // output ""
+    // The format string is not known at compile time, so the output length
+    // cannot be bounded; the return value is handled as unbounded below.
     fmt = "";
     idx = fmt_idx;
   }
@@ -241,8 +244,21 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     printf_formatter(fmt.as_string(), args);
     printf_formatter.as_string(); // populate min_outlen / max_outlen
 
-    // 4. do assign: constant when fully determined, bounded nondet otherwise
-    if (printf_formatter.min_outlen == printf_formatter.max_outlen)
+    // 4. do assign. The return value is the number of characters that would be
+    //    written. We can pin it to an exact constant only when the format
+    //    string is a compile-time constant AND every conversion was soundly
+    //    bounded; we can bound it to [min,max] when those hold but some
+    //    argument is nondet; otherwise there is no sound upper bound and we
+    //    fall back to an unconstrained nondet (>= 0) — the same
+    //    over-approximation ESBMC uses for a function with no operational
+    //    model. Tightening further would be unsound: a non-constant format
+    //    string or a non-literal %s can produce an arbitrarily long string,
+    //    and under-approximating the length would mask real overflows on the
+    //    returned value (see GitHub #4976-#4979).
+    const bool sound_bound = format_is_constant && printf_formatter.bounded;
+    if (
+      sound_bound &&
+      printf_formatter.min_outlen == printf_formatter.max_outlen)
     {
       symex_assign(code_assign2tc(
         lhs,
@@ -258,12 +274,19 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
         type2tc(),
         sideeffect2t::allockind::nondet);
       replace_nondet(nondet);
-      expr2tc lo =
-        constant_int2tc(int_type2(), BigInt(printf_formatter.min_outlen));
-      expr2tc hi =
-        constant_int2tc(int_type2(), BigInt(printf_formatter.max_outlen));
-      assume(
-        and2tc(greaterthanequal2tc(nondet, lo), lessthanequal2tc(nondet, hi)));
+      // The character count is never negative.
+      expr2tc lo = constant_int2tc(int_type2(), BigInt(0));
+      if (sound_bound)
+      {
+        lo = constant_int2tc(int_type2(), BigInt(printf_formatter.min_outlen));
+        expr2tc hi =
+          constant_int2tc(int_type2(), BigInt(printf_formatter.max_outlen));
+        assume(and2tc(
+          greaterthanequal2tc(nondet, lo), lessthanequal2tc(nondet, hi)));
+      }
+      else
+        // No sound upper bound: constrain only to the non-negative range.
+        assume(greaterthanequal2tc(nondet, lo));
       symex_assign(code_assign2tc(lhs, nondet));
     }
   }

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -257,8 +257,7 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     //    returned value (see GitHub #4976-#4979).
     const bool sound_bound = format_is_constant && printf_formatter.bounded;
     if (
-      sound_bound &&
-      printf_formatter.min_outlen == printf_formatter.max_outlen)
+      sound_bound && printf_formatter.min_outlen == printf_formatter.max_outlen)
     {
       symex_assign(code_assign2tc(
         lhs,

--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -31,6 +31,7 @@ void printf_formattert::print(std::ostream &out)
   next_operand = operands.begin();
   min_outlen = 0;
   max_outlen = 0;
+  bounded = true;
 
   try
   {
@@ -234,7 +235,11 @@ void printf_formattert::process_format(std::ostream &out)
   // record [1, max_digits] as the bound (widened by any explicit min-width).
   auto emit_int = [&](bool is_signed, int base, bool uppercase) {
     if (next_operand == operands.end())
+    {
+      // Expected an integer argument but none is available: cannot bound.
+      bounded = false;
       return;
+    }
     const type2tc target = pick_int_type(is_signed, length_mod);
     const expr2tc casted = make_type(*(next_operand++), target);
     std::string s;
@@ -267,6 +272,27 @@ void printf_formattert::process_format(std::ostream &out)
     max_outlen += max_chars;
   };
 
+  // Emit a floating-point conversion (%e/%f/%g). Only a constant argument has
+  // a statically-known rendering; a non-constant double can format to an
+  // arbitrarily long string (e.g. %f of 1e308), so we cannot bound the output
+  // and mark the whole result unbounded. The operand is still consumed to keep
+  // subsequent arguments aligned.
+  auto emit_float = [&](format_spect::stylet style) {
+    format_constant.style = style;
+    if (next_operand == operands.end())
+    {
+      bounded = false;
+      return;
+    }
+    const expr2tc farg = make_type(*(next_operand++), double_type2());
+    if (
+      is_constant_floatbv2t(farg) || is_constant_fixedbv2t(farg) ||
+      is_constant_int2t(farg))
+      emit(format_constant(farg));
+    else
+      bounded = false;
+  };
+
   switch (ch)
   {
   case '%':
@@ -275,39 +301,39 @@ void printf_formattert::process_format(std::ostream &out)
 
   case 'e':
   case 'E':
-    format_constant.style = format_spect::stylet::SCIENTIFIC;
-    if (next_operand == operands.end())
-      break;
-    emit(format_constant(make_type(*(next_operand++), double_type2())));
+    emit_float(format_spect::stylet::SCIENTIFIC);
     break;
 
   case 'f':
   case 'F':
-    format_constant.style = format_spect::stylet::DECIMAL;
-    if (next_operand == operands.end())
-      break;
-    emit(format_constant(make_type(*(next_operand++), double_type2())));
+    emit_float(format_spect::stylet::DECIMAL);
     break;
 
   case 'g':
   case 'G':
-    format_constant.style = format_spect::stylet::AUTOMATIC;
     if (format_constant.precision == 0)
       format_constant.precision = 1;
-    if (next_operand == operands.end())
-      break;
-    emit(format_constant(make_type(*(next_operand++), double_type2())));
+    emit_float(format_spect::stylet::AUTOMATIC);
     break;
 
   case 's':
   {
     if (next_operand == operands.end())
+    {
+      // A %s with no argument to inspect: length is unknown, so the output
+      // has no sound upper bound.
+      bounded = false;
       break;
+    }
     const expr2tc &op = *(next_operand++);
     const expr2tc symbol2 = get_base_object(op);
     exprt char_array = migrate_expr_back(symbol2);
     if (char_array.id() == "string-constant")
       emit(char_array.value().as_string());
+    else
+      // A non-literal string argument has no statically-known length, so the
+      // total output length cannot be bounded.
+      bounded = false;
   }
   break;
 
@@ -335,10 +361,25 @@ void printf_formattert::process_format(std::ostream &out)
     break;
 
   case 'c':
+  {
     if (next_operand == operands.end())
+    {
+      bounded = false;
       break;
-    emit(format_constant(make_type(*(next_operand++), char_type2())));
+    }
+    const expr2tc carg = make_type(*(next_operand++), char_type2());
+    if (is_constant_int2t(carg))
+      emit(format_constant(carg));
+    else
+    {
+      // %c writes exactly one character regardless of its value (padded to
+      // min_width). The length is value-independent, so this stays bounded.
+      const size_t clen =
+        format_constant.min_width > 1 ? format_constant.min_width : 1;
+      emit(std::string(clen, ' '));
+    }
     break;
+  }
 
   case 'x':
     emit_int(false, 16, false);

--- a/src/goto-symex/printf_formatter.h
+++ b/src/goto-symex/printf_formatter.h
@@ -17,6 +17,13 @@ public:
   size_t min_outlen = 0;
   /** Maximum possible output length for the last print() call. */
   size_t max_outlen = 0;
+  /** False when print() could not compute a sound upper bound on the output
+   *  length: a value-dependent conversion (%s, %e/%f/%g) was given a
+   *  non-constant argument, or an expected argument was missing. When false,
+   *  max_outlen is NOT a valid upper bound and callers must treat the return
+   *  value as unbounded (unconstrained nondet). Always true after a run over
+   *  a format whose conversions are all constant-bounded. */
+  bool bounded = true;
 
 protected:
   std::string format;


### PR DESCRIPTION
## What

`symex_printf` modelled the printf-family return value (the character count) as a **constant 0**
when the format string was not a compile-time constant. That is an *under-approximation*: the true
return is then unknown and can be arbitrarily large, so any overflow/size check on the returned
value was silently discharged — a **false negative** (the worst outcome for a verifier).

A genuine signed overflow on `sprintf(buf, fmt, x) + base` with a non-constant `fmt` reported
`VERIFICATION SUCCESSFUL` on master; with this change it correctly reports `VERIFICATION FAILED`.

## How

`printf_formattert` gains a `bounded` flag, cleared whenever a conversion's contribution to the
output length cannot be soundly upper-bounded. `symex_printf` now:

- pins the return to an exact constant only when the format is a compile-time constant **and** every
  conversion was bounded;
- bounds it to `[min,max]` when those hold but some argument is nondet;
- otherwise falls back to an **unconstrained non-negative nondet** — the same sound
  over-approximation ESBMC already uses for a function with no operational model.

Integer/`%c` conversions stay type/width-bounded, so the precise common case is unchanged. The
`%s` / `%e%f%g` / missing-argument clears are conservative soundness hardening (they can only ever
add false positives, never false negatives).

## Validation

Built master and this branch from source and compared:

| case | master | this PR |
|---|---|---|
| non-constant-format `sprintf` return + near-INT_MAX (real overflow) | `SUCCESSFUL` (false negative) | **`FAILED`** |
| constant-format exact-length case | `SUCCESSFUL` | `SUCCESSFUL` |
| constant `%d` real overflow | `FAILED` | `FAILED` |
| `cstd` printf regression subset | 22/22 | **22/22** |

No master-`FAILED` flips to `SUCCESSFUL` (monotone in the safe direction). Two regression tests
added: `printf_nonconst_format_overflow` (→ FAILED) and `printf_const_format_exact` (→ SUCCESSFUL).

## Scope / merge gate

This is the standalone soundness prerequisite from the printf return-length design
(`docs/design-printf-return-length-om.md`, #5012). It does **not** by itself close the busybox
`no-overflow` false positives #4976–#4979 — those call `vasprintf`, which still has no model;
wiring the `(v)asprintf` family in is the next phase (tracked in #5012).

**Merge gate (not run in PR CI):** per the design, before merge this needs a full SV-COMP
`no-overflow` benchexec run confirming **`wrong-false` (false negatives) stays 0**, plus a
precision-delta report. Requesting that run on this branch.

Refs #4976 #4977 #4978 #4979 #5012
