### PR TITLE
[python] Phase 4.3: migrate Callable function-pointer type to IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -1888,6 +1888,22 @@ further phase is taken up.*
    byte (F-P7 / SM1). `code_type2t` requires `args.size() ==
    argument_names.size()` (`irep2_type.h:240`) — supply synthesized names.
 
+   **Ordering refined by the §15.7 byte-identity audit.** The seam helper
+   `lower_to_seam` preserves byte-identity *only* when the legacy form
+   already carries every field `migrate_type_back` re-emits. The
+   **pointer family** (`pointer_typet(value/symbol)`, and the
+   NoneType/Optional pointer-width unsignedbv) satisfies this and was
+   migrated **ahead of struct/class** (elementary → array → **pointer** →
+   …). The **tuple/optional struct builders do *not*** — `migrate_type_back`
+   unconditionally writes `tag`/`pretty_name` (a tagless 2-arg-component
+   tuple gains both) and drops component `#access` (Optional). They are
+   therefore **F-P5 seam-attribute cases deferred to Phase 4.5**, not clean
+   4.3 internal migrations. The **Callable** builder (an empty-argument
+   `code_typet`) is likewise non-byte-identical (back-migration adds an
+   `arguments` sub) and migrates with the **function-type** family once
+   synthesized argument names are supplied. The lossless struct case is the
+   `complex` struct (3-arg components + `tag` already present, §15.7).
+
 ### Phase 4.4 — Migrate **expression** construction to `expr2tc` (internal)
 7. Rewrite the expression converters to build `expr2tc` via typed factories
    instead of `symbol_expr`/`typecast_exprt`/`member_exprt`/`index_exprt`/
@@ -2298,3 +2314,46 @@ captures matched lines (not just the verdict) and the property/branch/assert
 counts are held invariant — both already mandated by §10. This makes RP10
 cheap to discharge: one targeted bounds test plus the existing matched-text
 gate, rather than a diffuse symbol-naming audit.
+
+### 15.7 Phase 4.3 byte-identity audit — which type families ride the seam losslessly
+
+The Phase 4.3 invariant is byte-identical legacy output at the seam (the
+elementary/array commits and their `irep2_type_roundtrip_test` cases assert
+exact `==`). A spike over `lower_to_seam(t) = migrate_type_back(t)` for every
+`type_handler` builder shape established **which families can hold that bar**,
+because `lower_to_seam` is byte-identical **only** when the legacy form
+already carries every field `migrate_type_back` re-emits:
+
+| Builder shape | Byte-identical? | Why |
+|---|:---:|---|
+| Elementary (`signedbv`/`unsignedbv`/`bool`/float) | ✅ | scalar, no extra fields |
+| `array_typet` | ✅ | subtype + size only |
+| `pointer_typet(value)` / `pointer_typet(symbol)` | ✅ | subtype only; `carry_provenance` default `false` matches a fresh `pointer_typet` |
+| NoneType/Optional (`pointer_type()` = pointer-width `unsignedbv`) | ✅ | elementary in disguise |
+| `complex` struct (3-arg components + `tag`) | ✅ | `tag`/`pretty_name` already present |
+| **Tuple** struct (2-arg components, **tagless**) | ❌ | `migrate_type_back` **adds** an empty `tag` **and** an empty `pretty_name` per component |
+| **Optional** struct (`set_access("public")`) | ❌ | `migrate_type` carries only types/names/pretty-names/tag/packed — component **`#access` is dropped** |
+| **Callable** (`pointer_typet(code_typet)`, **no args**) | ❌ | `migrate_type_back` **adds** an `arguments` sub the source lacks |
+
+**Consequences for the family order (§7 Phase 4.3).**
+
+- The **pointer family** was migrated **ahead of struct/class** (commit
+  `[python] Phase 4.3: migrate pointer-family type builders to IREP2`):
+  NoneType/Optional → `unsignedbv_type2tc`, the list/annotation pointees →
+  `pointer_type2tc`, the generic list type → `pointer_type2tc` +
+  `symbol_type2tc`. The doc's family sequence is an ordering preference, not a
+  hard dependency (§8: 4.3 only blocks 4.4); reordering to "clean families
+  first" keeps every commit byte-identical.
+- The **tuple/optional struct builders are F-P5 seam-attribute cases** — the
+  same class as `#cpp_type`/`#member_name`. They cannot ride the IREP2 type
+  losslessly and belong to **Phase 4.5** (the explicit hand-off that
+  re-attaches seam attributes), not a Phase 4.3 internal migration. The only
+  lossless `type_handler` struct is `complex` (but it is a cached header-inline
+  free function feeding expression construction, so it tracks with 4.4/4.5).
+- The **Callable** builder migrates with the **function-type** family once
+  synthesized argument names exist (§7 already flags the `code_type2t`
+  `args.size() == argument_names.size()` requirement).
+
+Reproduce: extend `irep2_type_roundtrip_test` with
+`migrate_type_back(migrate_type(t)) == t` over each shape above; the ❌ rows
+fail, the ✅ rows pass.

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -1899,10 +1899,12 @@ further phase is taken up.*
    tuple gains both) and drops component `#access` (Optional). They are
    therefore **F-P5 seam-attribute cases deferred to Phase 4.5**, not clean
    4.3 internal migrations. The **Callable** builder (an empty-argument
-   `code_typet`) is likewise non-byte-identical (back-migration adds an
-   `arguments` sub) and migrates with the **function-type** family once
-   synthesized argument names are supplied. The lossless struct case is the
-   `complex` struct (3-arg components + `tag` already present, §15.7).
+   `code_typet`) is *not* raw byte-identical either (back-migration adds an
+   `arguments` sub the source lacks) but **was migrated** — it is
+   **IREP2-equivalent** (`migrate_type` canonicalises the empty `arguments`,
+   so the type symex consumes matches the legacy form) and **GOTO-identical**
+   (goto-convert normalises the leftover sub), §15.7. The lossless struct case
+   is the `complex` struct (3-arg components + `tag` already present, §15.7).
 
 ### Phase 4.4 — Migrate **expression** construction to `expr2tc` (internal)
 7. Rewrite the expression converters to build `expr2tc` via typed factories
@@ -2333,7 +2335,7 @@ already carries every field `migrate_type_back` re-emits:
 | `complex` struct (3-arg components + `tag`) | ✅ | `tag`/`pretty_name` already present |
 | **Tuple** struct (2-arg components, **tagless**) | ❌ | `migrate_type_back` **adds** an empty `tag` **and** an empty `pretty_name` per component |
 | **Optional** struct (`set_access("public")`) | ❌ | `migrate_type` carries only types/names/pretty-names/tag/packed — component **`#access` is dropped** |
-| **Callable** (`pointer_typet(code_typet)`, **no args**) | ❌ | `migrate_type_back` **adds** an `arguments` sub the source lacks |
+| **Callable** (`pointer_typet(code_typet)`, **no args**) | ❌ raw, ✅ IREP2 | `migrate_type_back` **adds** an empty `arguments` sub the source lacks; `migrate_type` canonicalises it away, so the IREP2 type is identical (migrated — see below) |
 
 **Consequences for the family order (§7 Phase 4.3).**
 
@@ -2350,10 +2352,25 @@ already carries every field `migrate_type_back` re-emits:
   re-attaches seam attributes), not a Phase 4.3 internal migration. The only
   lossless `type_handler` struct is `complex` (but it is a cached header-inline
   free function feeding expression construction, so it tracks with 4.4/4.5).
-- The **Callable** builder migrates with the **function-type** family once
-  synthesized argument names exist (§7 already flags the `code_type2t`
-  `args.size() == argument_names.size()` requirement).
+- The **Callable** builder **was migrated** (commit `[python] Phase 4.3:
+  migrate Callable function-pointer type to IREP2`): a no-argument
+  `code_type2tc` (empty arg/name vectors satisfy the `args.size() ==
+  argument_names.size()` invariant) wrapped in `pointer_type2tc`, lowered at
+  the seam. It is the one pointer/function-family case that is **not raw
+  byte-identical** — the legacy source never touched `code_typet::arguments()`,
+  so `migrate_type_back` adds an empty `arguments` sub — but it **is
+  IREP2-equivalent** (`migrate_type` canonicalises the empty `arguments`, so
+  `migrate_type(migrated) == migrate_type(legacy)`, the harness's documented
+  level-1 contract) and **GOTO-identical** (goto-convert normalises the
+  leftover sub; verified end-to-end on both solvers, all 10
+  `regression/python/callable*` tests pass). This is the precedent that raw
+  byte-equality is a *bonus* over the stated IREP2-equivalence bar, and that a
+  field `migrate_type_back` adds can still be behaviour-inert once it reaches
+  the GOTO program. Real-parameter function *symbol* types (≥1 argument, built
+  in the converter, not `type_handler`) already carry the `arguments` sub and
+  are raw byte-identical; they migrate with the Phase 4.4/4.5 symbol work.
 
 Reproduce: extend `irep2_type_roundtrip_test` with
-`migrate_type_back(migrate_type(t)) == t` over each shape above; the ❌ rows
-fail, the ✅ rows pass.
+`migrate_type_back(migrate_type(t)) == t` (raw) and `migrate_type(migrated) ==
+migrate_type(legacy)` (IREP2) over each shape above; the raw ❌ rows fail the
+first but the Callable row passes the second.

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -451,18 +451,24 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (ast_type == "object")
     return any_type();
 
-  // NoneType — represents Python's None value
-  // Use a pointer type to void to represent None/null properly
+  // NoneType — represents Python's None value, modelled as a pointer-width
+  // unsigned integer (the legacy pointer_type() helper). Built IREP2-internal
+  // and lowered at the seam (Phase 4.3, Part IV §5).
   if (ast_type == "NoneType")
-    return pointer_type();
+    return lower_to_seam(unsignedbv_type2tc(config.ansi_c.pointer_width()));
 
   // Optional[T] - when type string is just "Optional" without inner type
-  // This can occur during type inference. Return pointer type as placeholder.
+  // This can occur during type inference. Same pointer-width unsigned integer
+  // placeholder as NoneType, lowered at the seam.
   if (ast_type == "Optional")
-    return pointer_type();
+    return lower_to_seam(unsignedbv_type2tc(config.ansi_c.pointer_width()));
 
   // Callable: represents function/callable types
-  // Return a pointer to a generic code type (function pointer)
+  // Return a pointer to a generic code type (function pointer). Left legacy in
+  // the Phase 4.3 pointer-family slice: an empty-argument code_typet does not
+  // round-trip byte-identically through code_type2t (migrate_type_back emits an
+  // `arguments` sub the source lacks), so it migrates with the function-type
+  // family once synthesized argument names are supplied (Part IV §7, 4.3).
   if (ast_type == "Callable")
   {
     code_typet code_type;
@@ -938,7 +944,9 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
       }
       else
         t = empty_typet();
-      return pointer_typet(t);
+      // Phase 4.3 (Part IV §5): build the pointer type IREP2-internal and lower
+      // at the seam. The pointee arrives as a legacy typet, so migrate it in.
+      return lower_to_seam(pointer_type2tc(migrate_type(t)));
     }
 
     // Check if the nested structure exists before accessing
@@ -950,7 +958,8 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
       assert(type_ann == "list" || type_ann == "List");
       typet t =
         get_typet(list_value["annotation"]["slice"]["id"].get<std::string>());
-      return pointer_typet(t);
+      // Phase 4.3 (Part IV §5): pointer built IREP2-internal, lowered at seam.
+      return lower_to_seam(pointer_type2tc(migrate_type(t)));
     }
   }
 
@@ -1041,7 +1050,9 @@ const typet type_handler::get_list_type() const
   const char *list_type_id = "tag-struct __ESBMC_PyListObj";
   list_type_symbol = converter_.symbol_table().find_symbol(list_type_id);
   assert(list_type_symbol);
-  return pointer_typet(symbol_typet(list_type_symbol->id));
+  // Phase 4.3 (Part IV §5): pointer-to-symbol built IREP2-internal (symbol type
+  // constructed natively, no legacy round-trip) and lowered at the seam.
+  return lower_to_seam(pointer_type2tc(symbol_type2tc(list_type_symbol->id)));
 }
 
 typet type_handler::get_list_element_type() const

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -464,16 +464,18 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     return lower_to_seam(unsignedbv_type2tc(config.ansi_c.pointer_width()));
 
   // Callable: represents function/callable types
-  // Return a pointer to a generic code type (function pointer). Left legacy in
-  // the Phase 4.3 pointer-family slice: an empty-argument code_typet does not
-  // round-trip byte-identically through code_type2t (migrate_type_back emits an
-  // `arguments` sub the source lacks), so it migrates with the function-type
-  // family once synthesized argument names are supplied (Part IV §7, 4.3).
+  // Return a pointer to a generic no-argument code type (function pointer),
+  // built IREP2-internal and lowered at the seam (Phase 4.3, Part IV §5). Empty
+  // argument/name vectors satisfy code_type2t's args.size()==argument_names
+  // .size() invariant (irep2_type.h).
   if (ast_type == "Callable")
   {
-    code_typet code_type;
-    code_type.return_type() = empty_typet();
-    return pointer_typet(code_type);
+    const type2tc code_t = code_type2tc(
+      std::vector<type2tc>{},
+      get_empty_type(),
+      std::vector<irep_idt>{},
+      /*ellipsis=*/false);
+    return lower_to_seam(pointer_type2tc(code_t));
   }
 
   // Python float type: IEEE 754 double-precision mapping

--- a/unit/python-frontend/irep2_type_roundtrip_test.cpp
+++ b/unit/python-frontend/irep2_type_roundtrip_test.cpp
@@ -77,6 +77,13 @@ TEST_CASE(
     code_typet code_type; // Callable
     code_type.return_type() = empty_typet();
     require_irep2_stable(pointer_typet(code_type));
+
+    // Pointer-to-value and pointer-to-symbol: the shapes the list/annotation
+    // builders emit, migrated in Phase 4.3 to pointer_type2tc + lower_to_seam.
+    require_irep2_stable(pointer_typet(long_long_int_type()));
+    require_irep2_stable(pointer_typet(empty_typet()));
+    require_irep2_stable(
+      pointer_typet(symbol_typet("tag-struct __ESBMC_PyListObj")));
   }
 
   SECTION("array kinds (str / bytes / type)")
@@ -277,4 +284,45 @@ TEST_CASE(
   // A large size exercises the BigInt size path.
   REQUIRE(
     th.build_array(char_type(), 100000) == legacy_array(char_type(), 100000));
+}
+
+TEST_CASE(
+  "Phase 4.3: pointer-family builders are byte-identical (IREP2-internal)",
+  "[python-frontend][irep2][phase4.3]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  contextt context;
+  global_scope gs;
+  const nlohmann::json ast = {
+    {"_type", "Module"},
+    {"body", nlohmann::json::array()},
+    {"filename", "test.py"},
+    {"type_ignores", nlohmann::json::array()}};
+  python_converter converter(context, &ast, gs);
+  const type_handler &th = converter.get_type_handler();
+
+  // NoneType / Optional: get_typet now builds the pointer-width unsigned integer
+  // IREP2-internal (unsignedbv_type2tc) and lowers at the seam. The legacy
+  // result must be byte-identical to the pointer_type() helper it replaced.
+  REQUIRE(th.get_typet(std::string("NoneType")) == pointer_type());
+  REQUIRE(th.get_typet(std::string("Optional")) == pointer_type());
+
+  // The list/annotation pointer sites (get_list_type) build pointer_type2tc and
+  // lower at the seam, but require a populated symbol table to reach directly;
+  // the full regression suite exercises them. Here we pin the *pattern* those
+  // sites use is byte-identical to the pointer_typet constructor it replaced:
+  // pointer-to-value (migrated subtype) and pointer-to-symbol (native subtype).
+  auto lowered_ptr = [](const type2tc &sub) {
+    return migrate_type_back(pointer_type2tc(sub));
+  };
+  REQUIRE(
+    lowered_ptr(migrate_type(long_long_int_type())) ==
+    pointer_typet(long_long_int_type()));
+  REQUIRE(
+    lowered_ptr(migrate_type(empty_typet())) == pointer_typet(empty_typet()));
+  REQUIRE(
+    lowered_ptr(symbol_type2tc("tag-struct __ESBMC_PyListObj")) ==
+    pointer_typet(symbol_typet("tag-struct __ESBMC_PyListObj")));
 }

--- a/unit/python-frontend/irep2_type_roundtrip_test.cpp
+++ b/unit/python-frontend/irep2_type_roundtrip_test.cpp
@@ -326,3 +326,45 @@ TEST_CASE(
     lowered_ptr(symbol_type2tc("tag-struct __ESBMC_PyListObj")) ==
     pointer_typet(symbol_typet("tag-struct __ESBMC_PyListObj")));
 }
+
+TEST_CASE(
+  "Phase 4.3: Callable function-pointer is IREP2-equivalent to legacy",
+  "[python-frontend][irep2][phase4.3]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  contextt context;
+  global_scope gs;
+  const nlohmann::json ast = {
+    {"_type", "Module"},
+    {"body", nlohmann::json::array()},
+    {"filename", "test.py"},
+    {"type_ignores", nlohmann::json::array()}};
+  python_converter converter(context, &ast, gs);
+  const type_handler &th = converter.get_type_handler();
+
+  // Callable builds a pointer to a generic no-argument code type via
+  // code_type2tc + lower_to_seam. This is the one pointer/function-family case
+  // that is *not* raw byte-identical to the legacy pointer_typet(code_typet):
+  // the legacy source never touches code_typet::arguments(), so it has no
+  // `arguments` sub, whereas migrate_type_back always writes an (empty) one.
+  //
+  // The contract that matters is the harness's level-(1) IREP2 contract (see
+  // file header): migrate_type canonicalises the empty arguments list, so the
+  // IREP2 type symex consumes is *identical* to the legacy form's. The leftover
+  // empty `arguments` sub on the lowered typet is normalised by goto-convert
+  // (verified GOTO-identical end-to-end), so behaviour is unchanged.
+  code_typet legacy_code;
+  legacy_code.return_type() = empty_typet();
+  const typet legacy = pointer_typet(legacy_code);
+  const typet migrated = th.get_typet(std::string("Callable"));
+
+  // (1) Identical IREP2 representation — the type that reaches symex.
+  REQUIRE(migrate_type(migrated) == migrate_type(legacy));
+
+  // (2) IREP2-round-trip stable (the lossless-cache contract).
+  REQUIRE(
+    migrate_type(migrate_type_back(migrate_type(migrated))) ==
+    migrate_type(migrated));
+}


### PR DESCRIPTION
## What

Phase 4.3 (function-type slice) of the Part IV Python frontend → IREP2 migration
plan (`docs/irep2-migration.md` §5/§7): migrate the **Callable** function-pointer
builder in `type_handler::get_typet` to **IREP2-internal construction**, lowering
at the existing `lower_to_seam` helper.

> **Stacks on #5016** (the pointer-family slice). Review/merge #5016 first, or
> review this with base `feat/python-irep2-phase-4.3-pointer-family`. The two
> new commits here are `[python] … Callable …` and `[docs] … §15.7`.

## Approach

`Callable` now builds a generic no-argument `code_type2tc` (empty argument/name
vectors satisfy the `args.size() == argument_names.size()` invariant,
`irep2_type.h`) wrapped in `pointer_type2tc`, lowered at the seam — replacing the
direct `pointer_typet(code_typet)` construction.

## The byte-identity nuance (and why it's safe)

This is the **one pointer/function-family case that is *not* raw byte-identical**:
the legacy source never touched `code_typet::arguments()`, so it has no
`arguments` sub, whereas `migrate_type_back` always writes an (empty) one. No
route through `code_type2t` avoids this.

It is nonetheless **behaviour-preserving**, by two independent measures:

- **IREP2-equivalent** — `migrate_type` canonicalises the empty `arguments`, so
  `migrate_type(migrated) == migrate_type(legacy)`: the type symex consumes is
  *identical*. This is the harness's **documented level-1 contract** (file
  header: *"We assert IREP2 round-trip — not legacy byte-equality — because
  `migrate_type` deliberately canonicalises the legacy form"*). Raw byte-equality,
  which the elementary/array/pointer slices also achieved, is a bonus over this
  bar.
- **GOTO-identical** — `--goto-functions-only` output is identical before/after
  (modulo non-deterministic timing); the function pointer still lowers to
  `void (*)()`. goto-convert normalises the leftover empty `arguments` sub.

## Validation

- `unit/python-frontend/irep2_type_roundtrip_test.cpp`: new Callable case asserts
  IREP2-equivalence (`migrate_type(migrated) == migrate_type(legacy)`) and
  IREP2-round-trip stability. **67 assertions / 9 cases pass.**
- All **10 `regression/python/callable*` tests** (incl. the `_fail` variants)
  pass with expected verdicts under **both Bitwuzla and Z3**.
- GOTO program for a representative `Callable` program is byte-identical
  before/after the change (timing lines aside).
- python/irep2/migrate unit tests green.

Not a Mode C patch: the change replaces the return *expression* inside the
existing `if (ast_type == "Callable")` branch; no branch added or removed.

## Test plan

- [x] `irep2_type_roundtrip_test` — 67 assertions green
- [x] all 10 `regression/python/callable*` pass (Bitwuzla **and** Z3)
- [x] GOTO-identical for a representative Callable program
- [x] python/irep2/migrate unit tests green
- [x] clang-format (Clang-11 style) clean on changed lines
