### PR TITLE
fix(ir-ieee): constrain narrow integer symbols

### DIFF
--- a/regression/floats/uchar-float-widening-ir-ieee/main.c
+++ b/regression/floats/uchar-float-widening-ir-ieee/main.c
@@ -1,0 +1,30 @@
+/* Regression: unsigned char range must be respected under --ir-ieee.
+ *
+ * An unsigned char x is compared to a nondet float f via f == x, which
+ * implicitly promotes x to float.  Since all unsigned char values [0, 255]
+ * are exactly representable in float32, the float that equals x is exactly x.
+ * Widening that float to double (d = f) is lossless, so d == x must hold
+ * whenever f == x.
+ *
+ * Under --ir-ieee, unsigned char variables were formerly encoded as unbounded
+ * Z3 integers, allowing the solver to pick values outside [0, 255] and
+ * exploit the int-to-float rounding asymmetry to generate a spurious
+ * counterexample.  The fix asserts 0 <= x <= 255 in the SMT formula so that
+ * only valid C values are considered. */
+
+#include <assert.h>
+
+extern float __VERIFIER_nondet_float(void);
+extern unsigned char __VERIFIER_nondet_uchar(void);
+
+int main(void)
+{
+  float f = __VERIFIER_nondet_float();
+  unsigned char x = __VERIFIER_nondet_uchar();
+  double d = f;
+
+  if (f == x)
+    assert(d == x);
+
+  return 0;
+}

--- a/regression/floats/uchar-float-widening-ir-ieee/test.desc
+++ b/regression/floats/uchar-float-widening-ir-ieee/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2113,7 +2113,40 @@ smt_astt smt_convt::convert_terminal(const expr2tc &expr)
       return array_api->mk_array_symbol(name, sort, subtype);
     }
 
-    return mk_smt_symbol(name, sort);
+    smt_astt sym_ast = mk_smt_symbol(name, sort);
+
+    // Under --ir-ieee only: assert the C integer type range for narrow integer
+    // types (width < 32 bits, i.e. char and short). This prevents Z3 from
+    // choosing out-of-range values for variables such as unsigned char, which
+    // can trigger spurious counterexamples when integer-to-float casts are
+    // encoded with round_int_to_fp.
+    //
+    // This fix is intentionally limited to narrow integer types because it is
+    // targeted at the float12 regression and avoids the overhead observed when
+    // adding range constraints to all 32/64-bit integer symbols.
+    //
+    // --ir is intentionally left unchanged; this fix is specific to --ir-ieee.
+    if (
+      ir_ieee && int_encoding &&
+      (is_unsignedbv_type(sym.type) || is_signedbv_type(sym.type)) &&
+      sym.type->get_width() < 32 && ir_ieee_ranged_syms.insert(name).second)
+    {
+      const unsigned w = sym.type->get_width();
+      if (is_unsignedbv_type(sym.type))
+      {
+        // 0 <= sym <= 2^w - 1
+        assert_ast(mk_le(mk_smt_int(BigInt(0)), sym_ast));
+        assert_ast(mk_le(sym_ast, mk_smt_int(BigInt::power2(w) - 1)));
+      }
+      else
+      {
+        // -2^(w-1) <= sym <= 2^(w-1) - 1
+        assert_ast(mk_le(mk_smt_int(-BigInt::power2(w - 1)), sym_ast));
+        assert_ast(mk_le(sym_ast, mk_smt_int(BigInt::power2(w - 1) - 1)));
+      }
+    }
+
+    return sym_ast;
   }
 
   default:

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -7,6 +7,7 @@
 #include <boost/multi_index_container.hpp>
 #include <cstdint>
 #include <mutex>
+#include <unordered_set>
 #include <solvers/prop/literal.h>
 #include <solvers/prop/pointer_logic.h>
 #include <irep2/irep2_utils.h>
@@ -943,6 +944,9 @@ public:
   bool int_encoding;
   /** Whether --ir-ieee mode is active (integer encoding with IEEE float semantics). */
   bool ir_ieee;
+  /** Tracks symbols that have already received ir-ieee integer range assertions,
+   *  preventing duplicate assertions for the same SSA variable. */
+  std::unordered_set<std::string> ir_ieee_ranged_syms;
   /** A namespace containing all the types in the program. Used to resolve the
    *  rare case where we're doing some pointer arithmetic and need to have the
    *  concrete type of a pointer. */


### PR DESCRIPTION
## Summary

This PR fixes an `--ir-ieee`-specific false alarm caused by narrow C integer types being encoded as unbounded Z3 integers in the integer/real SMT encoding path.

In the affected case, an `unsigned char` value was used in a comparison with a `float`. Under `--ir-ieee`, the integer-to-float conversion is encoded with rounding-aware constraints. However, because the `unsigned char` symbol was represented as an unbounded mathematical integer, Z3 could choose values outside the valid C range `[0, 255]`. This allowed a spurious counterexample that is not possible in a valid C execution.

The fix adds range constraints for signed and unsigned integer symbols narrower than 32 bits when `--ir-ieee` is enabled. The existing `--ir` mode is intentionally left unchanged.

## Motivation

The issue was observed on the SV-COMP benchmark `floats-cbmc-regression/float12.c`.

The benchmark checks the following property: a nondeterministic `float` is compared with an `unsigned char`, and if they are equal, widening the float to `double` should preserve the equality. This is safe because all `unsigned char` values are in `[0, 255]`, and all of them are exactly representable in both `float` and `double`.

Before this fix, `--ir-ieee` could report a false alarm because the SMT encoding allowed the `unsigned char` value to take values outside its valid C range.

## Changes

This PR:

- Adds `--ir-ieee`-specific range constraints for narrow signed and unsigned integer symbols.
- Applies the constraint only when `--ir-ieee` is enabled, integer/real encoding is active, the symbol type is `signedbv` or `unsignedbv`, and the type width is less than 32 bits.
- Adds a small regression test for the fixed `float12` pattern.
- Leaves the existing `--ir` mode unchanged.

For unsigned integer symbols of width `w`, the added constraint is `0 <= x <= 2^w - 1`.

For signed integer symbols of width `w`, the added constraint is `-2^(w-1) <= x <= 2^(w-1) - 1`.

The restriction to widths below 32 bits keeps the fix focused on narrow integer types such as `char` and `short`, and avoids the overhead observed when adding bounds to all 32-bit and 64-bit integer symbols.

## Regression Test

A new regression test was added at `regression/floats/uchar-float-widening-ir-ieee/`.

The test checks that an `unsigned char` compared with a nondeterministic `float` does not produce a spurious counterexample under `--ir-ieee`.

Expected result: `VERIFICATION SUCCESSFUL`.

## Testing

Tested the new regression test:

- `regression/floats/uchar-float-widening-ir-ieee`

The test passes and returns `VERIFICATION SUCCESSFUL` under `--ir-ieee`.

The original SV-COMP pattern from `floats-cbmc-regression/float12.c` was also checked manually. After the fix, it returns `VERIFICATION SUCCESSFUL` under:

- `--floatbv`
- `--ir`
- `--ir-ieee`

A targeted 75-benchmark floating-point comparison suite was also run after the fix. The `float12` false alarm was removed, and no additional `--ir-ieee` verdict regression was introduced.

## Notes

This PR does not attempt to fix or change the existing `--ir` integer/real encoding behaviour. The range constraints are intentionally gated to `--ir-ieee`.