### PR TITLE
[python] keep list-comprehension element type in param inference

### DIFF
--- a/regression/python/list_comprehension8_nondet/main.py
+++ b/regression/python/list_comprehension8_nondet/main.py
@@ -1,0 +1,20 @@
+def p(a):
+    return a[0] and a[1]
+
+
+def q(a):
+    return a[0]
+
+
+def main():
+    # Issue #5022: a list built by a comprehension and read through a
+    # function-parameter alias must preserve its element type. A pure function
+    # applied twice to the same unmodified list must return the same value.
+    flags = [nondet_bool() for _ in range(2)]
+    assert p(flags) == p(flags)
+
+    nums = [nondet_int() for _ in range(2)]
+    assert q(nums) == q(nums)
+
+
+main()

--- a/regression/python/list_comprehension8_nondet/test.desc
+++ b/regression/python/list_comprehension8_nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-standard-checks --unwind 9 --smt-during-symex --smt-symex-guard --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_comprehension8_nondet_fail/main.py
+++ b/regression/python/list_comprehension8_nondet_fail/main.py
@@ -1,0 +1,14 @@
+def q(a):
+    return a[0]
+
+
+def main():
+    # Companion to list_comprehension8_nondet: the element-type recovery must
+    # not over-constrain comprehension elements into something trivially true.
+    # A nondet element read through a parameter alias can be any int, so
+    # asserting it equals a fixed constant is genuinely violable.
+    nums = [nondet_int() for _ in range(2)]
+    assert q(nums) == 7
+
+
+main()

--- a/regression/python/list_comprehension8_nondet_fail/test.desc
+++ b/regression/python/list_comprehension8_nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-standard-checks --unwind 9 --smt-during-symex --smt-symex-guard --z3
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -109,6 +109,14 @@ private:
   std::string get_type_from_lhs(const std::string &id, const Json &body);
   std::string get_list_subtype(const Json &list);
   std::string get_list_type_from_literal(const Json &list_arg);
+  // Recover a `list[T]` type for a name bound to an *empty* list literal by
+  // inspecting the first `<var_name>.append(arg)` in the enclosing scope.
+  // Comprehensions lower to `tmp = []; tmp.append(elt)`, so the element type
+  // is lost through the empty literal; without recovery a parameter bound to
+  // the list is typed bare `list` and element reads are mis-modelled as nested
+  // lists (issue #5022). Returns "" when no append is found or the element
+  // type does not resolve concretely (then the caller keeps the bare list).
+  std::string recover_list_type_from_appends(const std::string &var_name);
   std::string get_object_name(const Json &call, const std::string &prefix);
   std::string get_string_method_return_type(const std::string &method) const;
   bool extract_type_info(

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -617,6 +617,20 @@ std::string python_annotation<Json>::get_argument_type(const Json &arg)
       !var_node.empty() && var_node.contains("value") &&
       !var_node["value"].is_null())
     {
+      // A name bound to an *empty* list literal loses its element type. This
+      // is how list comprehensions lower (`tmp = []; tmp.append(elt)`), so
+      // recover `list[T]` from the first append before falling back to the
+      // bare `list` the empty literal would otherwise yield (issue #5022).
+      const Json &value = var_node["value"];
+      if (
+        value.contains("_type") && value["_type"] == "List" &&
+        (!value.contains("elts") || value["elts"].empty()))
+      {
+        std::string recovered = recover_list_type_from_appends(var_name);
+        if (!recovered.empty())
+          return recovered;
+      }
+
       std::string inferred_type = get_argument_type(var_node["value"]);
       if (!inferred_type.empty())
         return inferred_type;
@@ -825,6 +839,36 @@ python_annotation<Json>::get_list_type_from_literal(const Json &list_arg)
 
   // Return the full generic type notation
   return "list[" + element_type + "]";
+}
+
+template <class Json>
+std::string python_annotation<Json>::recover_list_type_from_appends(
+  const std::string &var_name)
+{
+  // Look for `<var_name>.append(arg)` inside the enclosing function. The
+  // comprehension lowering emits the empty-list init and its appends in the
+  // same function body, so prefer that scope; fall back to the module body
+  // for module-level comprehensions (where no current function name is set).
+  const std::string &scope = get_current_func_name();
+  const Json &module_body = ast_["body"];
+  Json func =
+    scope.empty() ? Json() : json_utils::find_function(module_body, scope);
+  const Json &body =
+    (!func.empty() && func.contains("body")) ? func["body"] : module_body;
+
+  Json append_arg = find_first_append_arg(body, var_name);
+  if (append_arg.empty())
+    return "";
+
+  // Only commit to a parameterised list when the element type resolves to a
+  // concrete type. An unresolved ("") or dynamic ("Any") element keeps the
+  // permissive bare `list` so heterogeneous/object lists are unaffected
+  // (mirrors the jpl_1 / #3239 guard in infer_type).
+  std::string elem_type = get_argument_type(append_arg);
+  if (elem_type.empty() || elem_type == "Any")
+    return "";
+
+  return "list[" + elem_type + "]";
 }
 
 template <class Json>


### PR DESCRIPTION
## Problem

ESBMC reported a spurious `VERIFICATION FAILED` (a soundness bug) when a list built by a comprehension is read through a function-parameter alias:

```python
def p(a):
    return a[0] and a[1]

def main():
    ans = [nondet_bool() for _ in range(2)]
    assert p(ans) == p(ans)   # FAILED (wrong) — must be SUCCESSFUL

main()
```

The same program written with a list **literal** (`ans = [nondet_bool(), nondet_bool()]`) verifies SUCCESSFUL. The defect reproduces for `int`/`bool`/`float` elements and for the simpler body `return a[0]`.

## Root cause

The preprocessor lowers a comprehension `[elt for ...]` to `tmp = []; tmp.append(elt); ans = tmp` — an **empty** list literal, so the element type is lost. When the annotation pass infers the type of an *unannotated* parameter from a call site `p(ans)`, `get_argument_type` walks `ans → tmp → []` and `get_list_type_from_literal` returns a bare `list`. A bare-`list` parameter makes `a[i]` reads be modelled as **nested list objects** (routed through `__ESBMC_list_size`), reinterpreting the stored scalar as a `PyListObj*` → nondeterministic garbage → the two calls to `p` can disagree.

## Fix

`get_argument_type` now recovers `list[T]` for a name bound to an empty list literal by inspecting the first `<name>.append(arg)` in the enclosing scope (reusing the existing `find_first_append_arg` helper), committing only when `T` resolves to a concrete type. Unresolved/`Any` elements keep the permissive bare `list`, so heterogeneous/object lists (e.g. the `jpl_1` regression) are unaffected. `nondet_bool()`/`nondet_int()` resolve to `bool`/`int` via the model return annotations, so the element type is recoverable.

The post-fix GOTO for `p` types the elements as `_Bool` (matching the literal case) instead of routing through `__ESBMC_list_size`, confirming the recovery branch fires.

## Tests

- `regression/python/list_comprehension8_nondet` (SUCCESSFUL): the #5022 reproducer plus an `int` variant — a deterministic function applied twice to the same comprehension list must agree. Fails pre-fix, passes post-fix.
- `regression/python/list_comprehension8_nondet_fail` (FAILED): a violable property over a comprehension-derived parameter, guarding against over-constraining elements into something trivially true.

The full `comprehension` ctest subset (17 tests) passes; `jpl_1` (object-list non-regression anchor) stays SUCCESSFUL.

Fixes #5022.