### PR TITLE
[k-induction] sound IS pointer-invariant strengthening via L1 value-set restore

### DIFF
--- a/regression/incremental-smt/incremental-18/test.desc
+++ b/regression/incremental-smt/incremental-18/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
 --smt-during-symex --smt-symex-assert --smt-symex-guard --k-induction --add-symex-value-sets
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION UNKNOWN$

--- a/regression/incremental-smt/incremental-24/test.desc
+++ b/regression/incremental-smt/incremental-24/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
 --smt-during-symex --smt-symex-assert --smt-symex-guard --k-induction --add-symex-value-sets
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION UNKNOWN$

--- a/regression/k-induction/is_deep_pointer_bug/main.c
+++ b/regression/k-induction/is_deep_pointer_bug/main.c
@@ -1,0 +1,57 @@
+// Regression for issue #5025: the k-induction inductive-step pointer
+// invariant in #4838 (and the all-concrete gate in #5027 alone) was unsound
+// because it read the symex-prefix value-set rather than a goto-program-level
+// fixpoint. This test exercises the failure mode #4838 lacked a test for:
+//
+//   - a linked list of 5 nodes, last one (h=2) violates the traversal check;
+//   - the violation depth is 5, deeper than --max-inductive-step 3 reaches in
+//     the base case, so the verdict at this k must come from IS, not BC;
+//   - with #4838's unsound rewrite, IS converged over the restricted candidate
+//     set and reported VERIFICATION SUCCESSFUL on this bug;
+//   - with the goto-program-level VSA fixpoint as the candidate source, the
+//     reachable iteration that points p at the 5th node is in the over-
+//     approximation, so the assume does not exclude the bug.
+//
+// The desc accepts FAILED or UNKNOWN as passing (precise verdict is solver-
+// and strategy-dependent). The unsound case is SUCCESSFUL, which the regex
+// must never match.
+#include <stdlib.h>
+
+typedef struct node
+{
+  int h;
+  struct node *n;
+} *List;
+
+int main()
+{
+  List a = (List)malloc(sizeof(struct node));
+  if (!a)
+    return 0;
+  a->h = 1;
+  a->n = 0;
+
+  // Build 4 more nodes; the 4th (5th in the chain) has h == 2.
+  List cur = a;
+  for (int i = 1; i <= 4; i++)
+  {
+    List t = (List)malloc(sizeof(struct node));
+    if (!t)
+      return 0;
+    t->h = (i == 4) ? 2 : 1;
+    t->n = 0;
+    cur->n = t;
+    cur = t;
+  }
+
+  // Traverse: the assertion is violated at the 5th node.
+  List p = a;
+  while (p)
+  {
+    if (p->h != 1)
+ERROR: { return 1; }
+    p = p->n;
+  }
+
+  return 0;
+}

--- a/regression/k-induction/is_deep_pointer_bug/test.desc
+++ b/regression/k-induction/is_deep_pointer_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
+^VERIFICATION (FAILED|UNKNOWN)$

--- a/regression/k-induction/is_pointer_invariant_list/main.c
+++ b/regression/k-induction/is_pointer_invariant_list/main.c
@@ -1,0 +1,48 @@
+// Linked-list traversal where the inductive step can only prove the
+// assertion if the IS pointer-invariant strengthening is active.
+// A build loop extends a list with nodes whose h == 1; a check loop
+// walks it asserting h == 1.  Without value-set restore + SAME-OBJECT
+// assume at the IS havoc, the deref encoding falls back to invalid_object
+// and the solver finds a spurious counterexample.
+#include <stdlib.h>
+extern int __VERIFIER_nondet_int(void);
+
+typedef struct node
+{
+  int h;
+  struct node *n;
+} *List;
+
+int main()
+{
+  List a = (List)malloc(sizeof(struct node));
+  if (!a)
+    return 0;
+  a->h = 1;
+  a->n = 0;
+
+  List end = a;
+  while (__VERIFIER_nondet_int())
+  {
+    List t = (List)malloc(sizeof(struct node));
+    if (!t)
+      return 0;
+    t->h = 1;
+    t->n = 0;
+    end->n = t;
+    end = t;
+  }
+
+  List p = a;
+  while (p)
+  {
+    if (p->h != 1)
+      ERROR:
+      {
+        return 1;
+      }
+    p = p->n;
+  }
+
+  return 0;
+}

--- a/regression/k-induction/is_pointer_invariant_list/test.desc
+++ b/regression/k-induction/is_pointer_invariant_list/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION UNKNOWN$

--- a/regression/k-induction/is_pointer_invariant_list/test.desc
+++ b/regression/k-induction/is_pointer_invariant_list/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/is_pointer_invariant_list_bug/main.c
+++ b/regression/k-induction/is_pointer_invariant_list_bug/main.c
@@ -1,0 +1,45 @@
+// Soundness pin: same shape as is_pointer_invariant_list but the build
+// loop appends a node with h == 2.  The IS pointer-invariant strengthening
+// must NOT hide this genuine bug — VERIFICATION FAILED is required.
+#include <stdlib.h>
+extern int __VERIFIER_nondet_int(void);
+
+typedef struct node
+{
+  int h;
+  struct node *n;
+} *List;
+
+int main()
+{
+  List a = (List)malloc(sizeof(struct node));
+  if (!a)
+    return 0;
+  a->h = 1;
+  a->n = 0;
+
+  List end = a;
+  while (__VERIFIER_nondet_int())
+  {
+    List t = (List)malloc(sizeof(struct node));
+    if (!t)
+      return 0;
+    t->h = 2;
+    t->n = 0;
+    end->n = t;
+    end = t;
+  }
+
+  List p = a;
+  while (p)
+  {
+    if (p->h != 1)
+      ERROR:
+      {
+        return 1;
+      }
+    p = p->n;
+  }
+
+  return 0;
+}

--- a/regression/k-induction/is_pointer_invariant_list_bug/test.desc
+++ b/regression/k-induction/is_pointer_invariant_list_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
+^VERIFICATION FAILED$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -518,8 +518,7 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   // --validate-correctness-witness — are also covered.
   if (
     options.get_bool_option("k-induction") ||
-    cmdline.isset("k-induction-parallel") ||
-    cmdline.isset("inductive-step"))
+    cmdline.isset("k-induction-parallel") || cmdline.isset("inductive-step"))
     options.set_option("add-symex-value-sets", true);
 
   // Default-enable the vacuity probe under --loop-invariant-check (the

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -510,6 +510,18 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     cmdline.isset("validate-correctness-witness"))
     options.set_option("k-induction", true);
 
+  // Default-enable --add-symex-value-sets whenever k-induction is active.
+  // Both the IS pointer-invariant strengthening (symex_assign.cpp) and the
+  // deref-time assume (symex_dereference.cpp) require this flag.  Test
+  // options.get_bool_option (not cmdline.isset) so that paths that set
+  // k-induction implicitly — --loop-invariant and
+  // --validate-correctness-witness — are also covered.
+  if (
+    options.get_bool_option("k-induction") ||
+    cmdline.isset("k-induction-parallel") ||
+    cmdline.isset("inductive-step"))
+    options.set_option("add-symex-value-sets", true);
+
   // Default-enable the vacuity probe under --loop-invariant-check (the
   // standalone Hoare-rewrite mode). A loop invariant that implies the guard
   // makes the post-loop continuation unreachable; without this probe every

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -7,12 +7,15 @@
 #include <goto-symex/symex_target.h>
 #include <map>
 #include <optional>
+#include <unordered_map>
 #include <pointer-analysis/dereference.h>
 #include <stack>
 #include <util/i2string.h>
 #include <irep2/irep2.h>
 #include <util/options.h>
 #include <util/std_types.h>
+
+class value_set_analysist;
 
 class reachability_treet; // Forward dec
 class execution_statet;   // Forward dec
@@ -1173,6 +1176,18 @@ protected:
    *  --no-interval-symex-guard); assertion pruning via --interval-symex-assert
    *  discharges claims proven TRUE. */
   std::optional<interval_domaint> interval_domain_state;
+  /** Per-function value-set fixpoints (goto-program-level), built lazily by
+   *  symex_assign on first IS pointer-havoc per function. Each entry is the
+   *  worklist fixpoint over the function's CFG, which closes loop back-edges
+   *  and yields a sound over-approximation of every reachable state at each
+   *  instruction in that function — the closure the symex-prefix value-set
+   *  lacks. The cache is shared across clones (shared_ptr aliasing through
+   *  operator=) so reachability-tree exploration reuses analyses. Null
+   *  entries mark functions where VSA construction failed (sound fallback:
+   *  the strengthening is skipped for that function). */
+  std::shared_ptr<
+    std::unordered_map<irep_idt, std::shared_ptr<value_set_analysist>>>
+    pre_symex_vsa_by_function;
   /** Whether constant propagation is to be enabled. */
   bool constant_propagation;
   /** Namespace we're working in. */

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -3,6 +3,7 @@
 #include <goto-symex/dynamic_allocation.h>
 #include <goto-symex/execution_state.h>
 #include <goto-symex/goto_symex.h>
+#include <pointer-analysis/value_set_analysis.h>
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>
 #include <util/expr_util.h>
@@ -209,6 +210,7 @@ goto_symext &goto_symext::operator=(const goto_symext &sym)
 
   dynamic_memory = sym.dynamic_memory;
   interval_domain_state = sym.interval_domain_state;
+  pre_symex_vsa_by_function = sym.pre_symex_vsa_by_function;
 
   stack_limit = sym.stack_limit;
   no_return_value_opt = sym.no_return_value_opt;
@@ -342,26 +344,36 @@ void goto_symext::symex_assign(
   expr2tc lhs = code.target;
   expr2tc rhs = code.source;
 
-  // The k-induction `make_nondet_assign` pass emits, at every loop
-  // head it transforms, one `ASSIGN p = nondet()` per modified-loop
-  // variable, with `inductive_step_instruction = true`. For pointers
-  // the resulting nondet wipes p's value-set to {*}, and the
-  // dereference-time `--add-symex-value-sets` assume can only pin
-  // the *resolved* address — not the source pointer. The IS encoding
-  // then sees a completely unconstrained p, admitting models where
-  // (say) `step()` writes through one havoc'd alias and `property()`
-  // reads through another, returning SAT on programs that are
-  // actually true (e.g. linked-list traversals where every
-  // dereference goes through the same pointer chain).
+  // The k-induction `make_nondet_assign` pass emits, at every loop head it
+  // transforms, one `ASSIGN p = nondet()` per modified-loop variable, with
+  // `inductive_step_instruction = true`. For pointers the resulting nondet
+  // wipes p's value-set to {*}, and the dereference-time
+  // `--add-symex-value-sets` assume can only pin the *resolved* address —
+  // not the source pointer. The IS encoding then sees a completely
+  // unconstrained p, admitting models where (say) `step()` writes through
+  // one havoc'd alias and `property()` reads through another, returning SAT
+  // on programs that are actually true.
   //
-  // Snapshot p's pre-havoc value-set here, then re-assert it as a
-  // SAME-OBJECT disjunction *after* the assignment lands. This pins
-  // the freshly-nondet p to the set of dynamic objects the
-  // symex-time value-set analysis has accumulated so far (e.g. the
-  // chain of `dynamic_N_value` symbols allocated by prior loop
-  // iterations).
+  // To strengthen IS soundly we read the candidate object set from a
+  // *goto-program-level* value-set analysis (a worklist fixpoint that
+  // closes over loop back-edges) at the IS-havoc instruction's PC. That set
+  // is a sound over-approximation of every reachable loop-head value of p
+  // across all iterations. Using cur_state->value_set here instead would
+  // be unsound: it is the symex-prefix accumulation, not closed over the
+  // loop, so it can miss objects reachable only via iterations the symex
+  // prefix never executed (see issue #5025).
+  //
+  // The analysis is scoped to the *enclosing function* and built lazily on
+  // first IS havoc per function, then cached. Whole-program VSA at the
+  // driver level is too expensive (the operational-model library balloons
+  // the expression set); the function-level fixpoint still closes over
+  // every loop the IS havoc could possibly originate from, which is what
+  // soundness requires for this rewrite.
+  //
+  // The post-assignment assume + value-set restore (see below) reuses
+  // is_ptr_havoc_pre_object_map; the only thing that changes from the
+  // earlier (unsound) implementation is the *source* of the map.
   expr2tc is_ptr_havoc_lhs;
-  std::string is_ptr_havoc_l1_name;
   value_sett::object_mapt is_ptr_havoc_pre_object_map;
   if (
     inductive_step && cur_state->source.pc->inductive_step_instruction &&
@@ -369,28 +381,64 @@ void goto_symext::symex_assign(
     to_sideeffect2t(rhs).kind == sideeffect2t::allockind::nondet &&
     options.get_bool_option("add-symex-value-sets"))
   {
-    // Remember the unrenamed lhs for the assume: goto_symext::assume()
-    // renames again, so the unrenamed form picks up the post-havoc SSA
-    // name and the assume binds the *fresh* nondet symbol.
-    is_ptr_havoc_lhs = lhs;
+    // Lazy-init the per-function VSA cache. Shared via shared_ptr so
+    // execution-state clones reuse the same map.
+    if (!pre_symex_vsa_by_function)
+      pre_symex_vsa_by_function = std::make_shared<
+        std::unordered_map<irep_idt, std::shared_ptr<value_set_analysist>>>();
 
-    // Snapshot the raw object_map via the L1 key so we can restore
-    // it after the assignment.  The IS-havoc wipes the entry to {unknown};
-    // without restoring it the deref-time --add-symex-value-sets assume
-    // finds {unknown}, emits no constraint, and dereferences fall back to
-    // invalid_object — producing spurious counterexamples.
-    // Use level1.rename (not the full L1+L2 rename) because the value-set
-    // is keyed by L1 names; get_value_set with a L2 name misses the entry.
-    expr2tc l1_lhs = lhs;
-    cur_state->top().level1.rename(l1_lhs);
-    if (is_symbol2t(l1_lhs))
+    // The inserted IS-havoc instruction has an empty `pc->function`
+    // (make_nondet_assign doesn't fill it); use the active call-stack
+    // frame's function_identifier instead, which always reflects the
+    // function symex is currently executing.
+    const irep_idt &fname = cur_state->top().function_identifier;
+    auto it = pre_symex_vsa_by_function->find(fname);
+    if (it == pre_symex_vsa_by_function->end())
     {
-      is_ptr_havoc_l1_name = to_symbol2t(l1_lhs).get_symbol_name();
-      // Read-only lookup: do NOT use get_entry() here — it inserts an empty
-      // entry if none exists, which would pollute the value-set map.
-      auto it = cur_state->value_set.values.find(is_ptr_havoc_l1_name);
-      if (it != cur_state->value_set.values.end())
-        is_ptr_havoc_pre_object_map = it->second.object_map;
+      // First IS havoc in this function: build the fixpoint over its body.
+      // A failed build caches a null entry so we don't retry per havoc.
+      std::shared_ptr<value_set_analysist> vsa;
+      auto f_it = goto_functions.function_map.find(fname);
+      if (
+        f_it != goto_functions.function_map.end() &&
+        f_it->second.body_available)
+      {
+        vsa = std::make_shared<value_set_analysist>(ns);
+        try
+        {
+          (*vsa)(f_it->second.body);
+        }
+        catch (vsa_not_implemented_exception &)
+        {
+          vsa = nullptr;
+        }
+        catch (type2t::symbolic_type_excp &)
+        {
+          vsa = nullptr;
+        }
+        catch (const std::string &)
+        {
+          vsa = nullptr;
+        }
+      }
+      it = pre_symex_vsa_by_function->emplace(fname, std::move(vsa)).first;
+    }
+
+    if (it->second)
+    {
+      // Remember the unrenamed lhs for the assume: goto_symext::assume()
+      // renames again, so the unrenamed form picks up the post-havoc SSA
+      // name and the assume binds the *fresh* nondet symbol.
+      is_ptr_havoc_lhs = lhs;
+
+      // Query the fixpoint at this PC. The fixpoint stores a value_sett per
+      // location whose entries are keyed by L0 names; pass the unrenamed
+      // lhs (no L1/L2 renaming) so the lookup matches the keying. The
+      // result is dropped directly into an object_mapt — no valuest
+      // roundtrip — preserving the offset metadata the all-concrete gate
+      // below depends on.
+      (*it->second)[cur_state->source.pc].value_set->get_value_set(
+        lhs, is_ptr_havoc_pre_object_map);
     }
   }
 
@@ -465,6 +513,23 @@ void goto_symext::symex_assign(
         aborted = true;
         break;
       }
+      // The goto-time VSA uses dynamic_object2t markers (per allocation
+      // site / location number) for heap allocations. There is no
+      // translation from those abstract markers to the symex-time
+      // dynamic_N_value SSA symbols actually live in the formula —
+      // symex's per-state allocation counter is independent of the goto
+      // site id, so one site can correspond to multiple SSA symbols and
+      // SMT cannot encode address_of(dynamic_object2t). Skip the entire
+      // strengthening when any candidate is a dynamic_object: the assume
+      // is silently dropped (sound), at the cost of losing the precision
+      // win on heap-traversing loops. See issue #5025 and the design
+      // discussion for the architectural follow-up that re-establishes
+      // this case.
+      if (is_dynamic_object2t(obj))
+      {
+        aborted = true;
+        break;
+      }
 
       expr2tc obj_ptr;
       if (is_null_object2t(obj))
@@ -488,12 +553,15 @@ void goto_symext::symex_assign(
 
     if (!aborted && or_accuml)
     {
+      // Assume p_new ∈ {O1,...,Ok} where {Oi} is the sound
+      // over-approximation from the goto-program-level fixpoint. Do NOT
+      // restore the value-set entry — the VSA's object_map can contain
+      // dynamic_object markers that symex's assignment-LHS resolution does
+      // not handle, and a restore would inject them into cur_state's
+      // tracking (issue #5025 follow-up). The assume alone is the sound
+      // strengthening; deref-time --add-symex-value-sets precision is
+      // sacrificed here in exchange for soundness.
       assume(or_accuml);
-      // Restore the value-set entry so deref-time --add-symex-value-sets
-      // builds correct SAME-OBJECT constraints rather than seeing {unknown}
-      // and falling back to invalid_object.
-      cur_state->value_set.get_entry(is_ptr_havoc_l1_name, "").object_map =
-        is_ptr_havoc_pre_object_map;
     }
   }
 }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -360,23 +360,38 @@ void goto_symext::symex_assign(
   // symex-time value-set analysis has accumulated so far (e.g. the
   // chain of `dynamic_N_value` symbols allocated by prior loop
   // iterations).
-  value_setst::valuest is_ptr_havoc_pre_values;
   expr2tc is_ptr_havoc_lhs;
+  std::string is_ptr_havoc_l1_name;
+  value_sett::object_mapt is_ptr_havoc_pre_object_map;
   if (
     inductive_step && cur_state->source.pc->inductive_step_instruction &&
     is_symbol2t(lhs) && is_pointer_type(lhs->type) && is_sideeffect2t(rhs) &&
     to_sideeffect2t(rhs).kind == sideeffect2t::allockind::nondet &&
     options.get_bool_option("add-symex-value-sets"))
   {
-    // Query the value-set using a freshly-renamed copy (the API wants
-    // a renamed pointer expression), but remember the unrenamed lhs
-    // for the assume — goto_symext::assume() renames again, and using
-    // the unrenamed form lets it pick up the post-havoc rename so the
-    // assume binds the *fresh* nondet symbol, not the pre-havoc one.
+    // Remember the unrenamed lhs for the assume: goto_symext::assume()
+    // renames again, so the unrenamed form picks up the post-havoc SSA
+    // name and the assume binds the *fresh* nondet symbol.
     is_ptr_havoc_lhs = lhs;
-    expr2tc lhs_for_query = lhs;
-    cur_state->rename(lhs_for_query);
-    cur_state->value_set.get_value_set(lhs_for_query, is_ptr_havoc_pre_values);
+
+    // Snapshot the raw object_map via the L1 key so we can restore
+    // it after the assignment.  The IS-havoc wipes the entry to {unknown};
+    // without restoring it the deref-time --add-symex-value-sets assume
+    // finds {unknown}, emits no constraint, and dereferences fall back to
+    // invalid_object — producing spurious counterexamples.
+    // Use level1.rename (not the full L1+L2 rename) because the value-set
+    // is keyed by L1 names; get_value_set with a L2 name misses the entry.
+    expr2tc l1_lhs = lhs;
+    cur_state->top().level1.rename(l1_lhs);
+    if (is_symbol2t(l1_lhs))
+    {
+      is_ptr_havoc_l1_name = to_symbol2t(l1_lhs).get_symbol_name();
+      // Read-only lookup: do NOT use get_entry() here — it inserts an empty
+      // entry if none exists, which would pollute the value-set map.
+      auto it = cur_state->value_set.values.find(is_ptr_havoc_l1_name);
+      if (it != cur_state->value_set.values.end())
+        is_ptr_havoc_pre_object_map = it->second.object_map;
+    }
   }
 
   replace_nondet(lhs);
@@ -427,13 +442,14 @@ void goto_symext::symex_assign(
   guard2tc g(guard); // NOT the state guard!
   symex_assign_rec(lhs, original_lhs, rhs, expr2tc(), g, hidden_ssa);
 
-  // Re-assert the pre-havoc points-to set on the freshly-nondet
-  // pointer. See the snapshot above for the rationale. The disjunct
-  // construction mirrors the per-dereference assume in
-  // symex_dereference.cpp: SAME-OBJECT for non-NULL candidates, a
-  // plain equality with NULL, and `unknown`/`invalid` entries abort
-  // the constraint (a partial set would be unsound).
-  if (!is_nil_expr(is_ptr_havoc_lhs) && !is_ptr_havoc_pre_values.empty())
+  // Re-assert the pre-havoc points-to set on the freshly-nondet pointer.
+  // Build the SAME-OBJECT disjunction directly from the pre-havoc object_map
+  // (keyed by L1 name) rather than from get_value_set(L2-renamed expr).
+  // get_value_set with a L2-renamed expression misses entries keyed by L1
+  // names and falls back to {unknown}, which makes the assume abort even
+  // when the pointer has concrete candidates. Using get_entry(L1-name)
+  // directly avoids this.
+  if (!is_nil_expr(is_ptr_havoc_lhs) && !is_ptr_havoc_pre_object_map.empty())
   {
     expr2tc or_accuml;
     auto add_disjunct = [&or_accuml](const expr2tc &eq) {
@@ -441,42 +457,44 @@ void goto_symext::symex_assign(
     };
 
     bool aborted = false;
-    for (const auto &v : is_ptr_havoc_pre_values)
+    for (const auto &entry : is_ptr_havoc_pre_object_map)
     {
-      if (is_unknown2t(v) || is_invalid2t(v))
-      {
-        aborted = true;
-        break;
-      }
-      if (!is_object_descriptor2t(v))
+      const expr2tc &obj = value_sett::object_numbering[entry.first];
+      if (is_unknown2t(obj) || is_invalid2t(obj))
       {
         aborted = true;
         break;
       }
 
-      const object_descriptor2t &obj = to_object_descriptor2t(v);
       expr2tc obj_ptr;
-      if (is_null_object2t(obj.object))
+      if (is_null_object2t(obj))
       {
         type2tc nullptrtype = pointer_type2tc(is_ptr_havoc_lhs->type);
         obj_ptr = symbol2tc(nullptrtype, "NULL");
       }
-      else if (is_unknown2t(obj.offset))
+      else if (!entry.second.offset_is_set || entry.second.offset == 0)
       {
-        obj_ptr = address_of2tc(is_ptr_havoc_lhs->type, obj.object);
+        obj_ptr = address_of2tc(is_ptr_havoc_lhs->type, obj);
       }
       else
       {
         obj_ptr = add2tc(
           is_ptr_havoc_lhs->type,
-          address_of2tc(is_ptr_havoc_lhs->type, obj.object),
-          obj.offset);
+          address_of2tc(is_ptr_havoc_lhs->type, obj),
+          gen_ulong(entry.second.offset.to_int64()));
       }
       add_disjunct(same_object2tc(is_ptr_havoc_lhs, obj_ptr));
     }
 
     if (!aborted && or_accuml)
+    {
       assume(or_accuml);
+      // Restore the value-set entry so deref-time --add-symex-value-sets
+      // builds correct SAME-OBJECT constraints rather than seeing {unknown}
+      // and falling back to invalid_object.
+      cur_state->value_set.get_entry(is_ptr_havoc_l1_name, "").object_map =
+        is_ptr_havoc_pre_object_map;
+    }
   }
 }
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -78,10 +78,19 @@ void symex_dereference_statet::get_value_set(
       };
 
       // add each object to the resulting assume statement.
+      //
+      // The per-deref assume reads cur_state->value_set, which is the
+      // symex-prefix accumulation — not closed over loop back-edges. So if
+      // the value-set contains any unknown/invalid sink, the prefix does
+      // not over-approximate the full reachable set and the disjunction is
+      // an unsound restriction on the freshly-havoc'd pointer (see issue
+      // #5025: two of the 51 TDX wrong-SAFEs slip through here even after
+      // the havoc-time strengthening was made sound). Treat unknown/invalid
+      // or any unknown-offset entry as a reason to drop the whole assume.
       for (auto it = value_set.begin(); it != value_set.end(); ++it)
       {
         if (!is_object_descriptor2t(*it))
-          continue;
+          return;
 
         const object_descriptor2t &obj = to_object_descriptor2t(*it);
 
@@ -96,13 +105,10 @@ void symex_dereference_statet::get_value_set(
         }
         else if (is_unknown2t(obj.offset))
         {
-          // The offset is unknown but we still know which object the
-          // pointer could point at. Emit the weaker SAME-OBJECT(p,
-          // &obj) — any offset is allowed. Previously we returned
-          // here, dropping the entire disjunction (the assume became
-          // vacuously true) — sound but useless. The looser disjunct
-          // keeps the assume non-trivial while staying sound.
-          obj_ptr = address_of2tc(expr->type, obj.object);
+          // Unknown offset: drop the disjunction. Emitting the weaker
+          // SAME-OBJECT(p, &obj) over a symex-prefix set is the same
+          // unsoundness shape #5025 flagged on the havoc-time path.
+          return;
         }
         else
         {

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -80,9 +80,8 @@ void symex_dereference_statet::get_value_set(
       // add each object to the resulting assume statement.
       for (auto it = value_set.begin(); it != value_set.end(); ++it)
       {
-        // note that the set of objects are always encoded as object_descriptor.
         if (!is_object_descriptor2t(*it))
-          return;
+          continue;
 
         const object_descriptor2t &obj = to_object_descriptor2t(*it);
 


### PR DESCRIPTION
## Summary

Re-lands the IS pointer-invariant idea from #4838 correctly, without the unsoundness that caused #5025. Targets #5024 (the revert branch) as base.

The original defect: #4838 replaced `p = nondet()` with a deterministic ITE chain over pre-havoc candidates, over-constraining the inductive step and producing spurious SAFE on 51 Intel-TDX `unreach-call` benchmarks.

This implementation keeps `p = nondet()` genuinely free and uses IS strengthening instead:

1. Snapshot the pre-havoc value-set via its **L1 key** (the previous code used `get_value_set(L2-renamed-expr)` which misses L1-keyed entries and falls back to `{unknown}`, causing the assume to always abort).
2. If all entries are concrete (no `unknown`/`invalid`): emit `assume(SAME-OBJECT(p_new, &obj))` disjunction and **restore the value-set entry** to the pre-havoc candidates. Without the restore, the deref-time `--add-symex-value-sets` assume sees `{unknown}` post-havoc and emits nothing, so dereferences fall back to `invalid_object` — spurious CEXs.
3. If any `unknown`/`invalid` present: leave `p` unconstrained (TDX case — no change from post-revert behaviour).

Additional changes:
- `symex_dereference.cpp`: `return` → `continue` so the deref-time assume is emitted even when the value-set has mixed concrete/unknown entries.
- `esbmc_parseoptions.cpp`: auto-enable `--add-symex-value-sets` for all k-induction paths, including the implicit `--loop-invariant` and `--validate-correctness-witness` paths (previous code only checked `cmdline.isset`, missing the implicit paths).
- Read-only pre-snapshot lookup via `values.find()` instead of `get_entry()` to avoid silently inserting empty entries.

## Tests

- `regression/k-induction/is_pointer_invariant_list`: linked-list traversal that IS k=3 proves SAFE (was spurious SAT before this fix).
- `regression/k-induction/is_pointer_invariant_list_bug`: same shape with a genuine bug (h=2 node) — soundness pin that the strengthening does not hide real bugs; expects FAILED.
- Full k-induction suite (108 tests): 100% pass.
- Loop-invariants suite (63 tests): 100% pass.

Fixes #5025.