### PR TITLE
[python] fix str.startswith() crash on a symbolic prefix

### DIFF
--- a/regression/humaneval/humaneval_29/test.desc
+++ b/regression/humaneval/humaneval_29/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-startswith-param/main.py
+++ b/regression/python/string-startswith-param/main.py
@@ -1,0 +1,31 @@
+# A symbolic (parameter) prefix is lowered to char*, not a char array.
+# str.startswith() must handle that without aborting (regression for the
+# to_array_type assertion crash; see humaneval/29).
+
+
+def has_prefix(s: str, prefix: str) -> bool:
+    return s.startswith(prefix)
+
+
+assert has_prefix("hello", "he")
+assert not has_prefix("hello", "xy")
+assert has_prefix("hello", "")        # the empty string is a prefix of anything
+assert not has_prefix("hi", "hello")  # a longer prefix cannot match
+
+
+# A genuinely symbolic, possibly-empty prefix must still be sound: s[:n] is a
+# prefix of s for every n >= 0, including the empty slice s[:0].
+def slice_is_prefix(s: str, n: int) -> bool:
+    return s.startswith(s[:n])
+
+
+assert slice_is_prefix("abc", 0)
+
+
+# The original humaneval/29 trigger: a string method applied to the loop
+# variable of a comprehension, with a symbolic predicate argument.
+def filter_by_prefix(strings, prefix: str):
+    return [x for x in strings if x.startswith(prefix)]
+
+
+assert filter_by_prefix([], "john") == []

--- a/regression/python/string-startswith-param/test.desc
+++ b/regression/python/string-startswith-param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8 --no-bounds-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-startswith-param_fail/main.py
+++ b/regression/python/string-startswith-param_fail/main.py
@@ -1,0 +1,9 @@
+# Negative variant: a symbolic prefix that is not actually a prefix must make
+# startswith() return False, so the assertion fails (no spurious SUCCESSFUL).
+
+
+def has_prefix(s: str, prefix: str) -> bool:
+    return s.startswith(prefix)
+
+
+assert has_prefix("hello", "xy")

--- a/regression/python/string-startswith-param_fail/test.desc
+++ b/regression/python/string-startswith-param_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --no-bounds-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -787,14 +787,35 @@ exprt string_handler::handle_string_startswith(
   exprt str_addr = get_array_base_address(str_expr);
   exprt prefix_addr = get_array_base_address(prefix_expr);
 
-  // Calculate prefix length: len(prefix_expr) - 1 (exclude null terminator)
-  const array_typet &prefix_type = to_array_type(prefix_expr.type());
-  exprt prefix_len = prefix_type.size();
+  // Calculate the prefix length (excluding the null terminator).
+  // A string literal is lowered to a char array carrying a static size, but a
+  // symbolic str (e.g. a function parameter) is a char* with no static size,
+  // so to_array_type() would abort on it. Use strlen() for the pointer case,
+  // mirroring handle_string_endswith().
+  exprt actual_len;
+  if (prefix_expr.type().is_array())
+  {
+    const array_typet &prefix_type = to_array_type(prefix_expr.type());
+    exprt prefix_len = prefix_type.size();
 
-  // Subtract 1 for null terminator
-  exprt one = from_integer(1, prefix_len.type());
-  exprt actual_len("-", prefix_len.type());
-  actual_len.copy_to_operands(prefix_len, one);
+    // Subtract 1 for null terminator
+    exprt one = from_integer(1, prefix_len.type());
+    actual_len = exprt("-", prefix_len.type());
+    actual_len.copy_to_operands(prefix_len, one);
+  }
+  else
+  {
+    symbolt *strlen_symbol = find_cached_c_function_symbol("c:@F@strlen");
+    if (!strlen_symbol)
+      throw std::runtime_error("strlen function not found for startswith()");
+
+    side_effect_expr_function_callt prefix_strlen_call;
+    prefix_strlen_call.function() = symbol_expr(*strlen_symbol);
+    prefix_strlen_call.arguments() = {prefix_addr};
+    prefix_strlen_call.location() = location;
+    prefix_strlen_call.type() = size_type();
+    actual_len = prefix_strlen_call;
+  }
 
   // Find strncmp symbol
   symbolt *strncmp_symbol = find_cached_c_function_symbol("c:@F@strncmp");
@@ -813,7 +834,17 @@ exprt string_handler::handle_string_startswith(
   exprt equal("=", bool_type());
   equal.copy_to_operands(strncmp_call, zero);
 
-  return equal;
+  // Python treats the empty string as a prefix of every string, so
+  // s.startswith("") is always True. Guard this case explicitly: it keeps the
+  // result correct for a symbolic empty prefix and is robust to strncmp(_,_,0),
+  // which the operational model evaluates to a non-zero value.
+  exprt is_empty("=", bool_type());
+  is_empty.copy_to_operands(actual_len, gen_zero(actual_len.type()));
+
+  exprt result("or", bool_type());
+  result.copy_to_operands(is_empty, equal);
+
+  return result;
 }
 
 exprt string_handler::handle_string_endswith(


### PR DESCRIPTION
## Problem

ESBMC's Python frontend **aborts** when `str.startswith(prefix)` is called with a *symbolic* (non-literal) prefix:

```
Assertion failed: (type.id() == typet::t_array), function to_array_type, file std_types.h, line 433.
```

Minimal reproducer:

```python
def f(p: str) -> bool:
    return 'hello'.startswith(p)   # crash: p is a char*, not a char array
```

This is the root cause of the `humaneval/29` KNOWNBUG (`filter_by_prefix(strings, prefix)` uses `x.startswith(prefix)` with a parameter prefix).

## Root cause

`string_handler::handle_string_startswith` computed the prefix length with:

```cpp
const array_typet &prefix_type = to_array_type(prefix_expr.type());
exprt prefix_len = prefix_type.size();
```

A string literal is lowered to a `char` array carrying a static size, but a **symbolic** `str` (e.g. a function parameter) is lowered to a `char*` with no static size. `to_array_type()` asserts on the pointer type and aborts. The sibling `handle_string_endswith` already handles both array and pointer operands via `strlen`; `startswith` did not.

## Fix

- Keep the static `size - 1` fast path for the **array** (literal) case.
- For the **pointer** (symbolic) case, compute the length via `strlen(prefix_addr)`, mirroring `handle_string_endswith`.
- Add an explicit **empty-prefix guard**: Python treats `""` as a prefix of every string, so `s.startswith("")` is always `True`. The disjunct `len(prefix) == 0 ∨ strncmp(s, prefix, len(prefix)) == 0` keeps the result correct for a *symbolic* empty prefix.

### Why the empty-prefix guard is required (soundness)

While fixing this I found that ESBMC's `strncmp` operational model (`src/c2goto/library/string.c`) is **unsound for `n == 0`**: its `do { … } while (… && i < n)` compares `s1[0]`/`s2[0]` *before* checking `i < n`, so it returns a non-zero value where C mandates `0`. Verified:

```c
assert(strncmp("hello", "", 0) == 0);   // holds natively; VERIFICATION FAILED in ESBMC
```

Without the guard, a symbolic empty prefix would make `startswith` return `False` (unsound). The guard makes `startswith` correct independently of the `strncmp` model. The underlying model bug is tracked separately for a follow-up.

## Validation

- New regression pair `regression/python/string-startswith-param{,_fail}` covering: symbolic prefix (true/false), empty prefix, prefix longer than the string, a genuinely symbolic empty prefix (`s[:0]`), and the comprehension trigger from humaneval/29.
- `regression/humaneval/humaneval_29` retagged `KNOWNBUG → CORE` (the original crash reproducer now serves as a contract regression).
- **432/432** `regression/python` string tests pass; comprehension/list subset unaffected (the only failure was a pre-existing `--boolector` config skip).
- CPython parity confirmed for all asserted cases; `scripts/check_python_tests.sh` green.
- `code-reviewer`: APPROVE (0 critical/major findings).

Partially addresses #4807.