### PR TITLE
[python] fix member2t abort on inline optional comparison

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -323,6 +323,14 @@ set(_slow_regression_tests
     "regression/humaneval/humaneval_129"
     "regression/humaneval/humaneval_153"
     "regression/humaneval/humaneval_161"
+    # humaneval_90 used to fast-crash with the member2t assertion
+    # ("source->type->type_id == struct_id ...") when next_smallest()'s
+    # inline optional comparison (None | int == 2) was lowered. With the
+    # materialise-before-member fix the crash is gone and ESBMC reaches the
+    # real sorted(set(lst)) symex, which does not converge under the default
+    # budget. It stays KNOWNBUG; the larger inner timeout lets testing_tool
+    # record the KNOWNBUG verdict instead of ctest hard-killing the run.
+    "regression/humaneval/humaneval_90"
     "regression/quixbugs/flatten_fail"
     "regression/quixbugs/next_palindrome"
     "regression/quixbugs/pascal"

--- a/regression/python/optional-inline-compare/main.py
+++ b/regression/python/optional-inline-compare/main.py
@@ -1,0 +1,18 @@
+# Comparing the result of an inline call that returns an optional (None | T)
+# directly against a value must not abort the frontend. The call result is a
+# code_function_callt; taking its ".value" member without materialising it
+# first aborted goto generation (member2t requires a struct source). See the
+# member2t crash behind humaneval/90 (#4807).
+
+
+def second_or_none(lst):
+    return None if len(lst) < 2 else lst[1]
+
+
+# Inline form (the crashing one): the call is not bound to a variable first.
+assert second_or_none([1, 2, 3]) == 2
+assert second_or_none([10, 20]) == 20
+
+# Bound form (already worked) must still agree.
+r = second_or_none([7, 8, 9])
+assert r == 8

--- a/regression/python/optional-inline-compare/test.desc
+++ b/regression/python/optional-inline-compare/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-bounds-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional-inline-compare_fail/main.py
+++ b/regression/python/optional-inline-compare_fail/main.py
@@ -1,0 +1,9 @@
+# Negative variant: the inline optional comparison must still be able to fail
+# (no spurious SUCCESSFUL). second_or_none([1,2,3]) is 2, not 99.
+
+
+def second_or_none(lst):
+    return None if len(lst) < 2 else lst[1]
+
+
+assert second_or_none([1, 2, 3]) == 99

--- a/regression/python/optional-inline-compare_fail/test.desc
+++ b/regression/python/optional-inline-compare_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-bounds-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -406,8 +406,8 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   bool is_none_check = handle_none_check_setup(op, lhs, rhs);
   if (!is_none_check)
   {
-    lhs = unwrap_optional_if_needed(lhs);
-    rhs = unwrap_optional_if_needed(rhs);
+    lhs = unwrap_optional_if_needed(lhs, element);
+    rhs = unwrap_optional_if_needed(rhs, element);
   }
 
   if (lhs.type() == none_type() || rhs.type() == none_type())

--- a/src/python-frontend/converter/converter_types.cpp
+++ b/src/python-frontend/converter/converter_types.cpp
@@ -1,3 +1,4 @@
+#include <python-frontend/function_call/expr.h>
 #include <python-frontend/json_utils.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/tuple_handler.h>
@@ -11,7 +12,9 @@
 #include <functional>
 #include <set>
 
-exprt python_converter::unwrap_optional_if_needed(const exprt &expr)
+exprt python_converter::unwrap_optional_if_needed(
+  const exprt &expr,
+  const nlohmann::json &element)
 {
   if (!expr.type().is_struct())
     return expr;
@@ -21,8 +24,34 @@ exprt python_converter::unwrap_optional_if_needed(const exprt &expr)
 
   if (tag.starts_with("tag-Optional_"))
   {
+    // A member can only be taken of an addressable value. When the optional is
+    // produced by a call used directly in a comparison -- e.g. f(...) == 2 --
+    // the operand is the call itself (a code_function_callt statement, or a
+    // side-effect call expression), and member_exprt(<call>, "value") is
+    // malformed: it aborts during goto migration (member2t requires a
+    // struct/union/complex source). Materialise the call result into a
+    // temporary first, mirroring the already-working assigned path
+    // (r = f(...); r.value == 2). See #4807.
+    exprt base = expr;
+    if (base.is_code() && base.is_function_call())
+      base = to_value_expr(base, name_space());
+
+    if (base.id() == "sideeffect")
+    {
+      symbolt &tmp =
+        create_tmp_symbol(element, "$optional_tmp$", base.type(), exprt());
+      code_declt decl(symbol_expr(tmp));
+      decl.location() = base.location();
+      add_instruction(decl);
+
+      code_assignt assign(symbol_expr(tmp), base);
+      assign.location() = base.location();
+      add_instruction(assign);
+      base = symbol_expr(tmp);
+    }
+
     // Extract the value field
-    member_exprt value_field(expr, "value", struct_type.components()[1].type());
+    member_exprt value_field(base, "value", struct_type.components()[1].type());
     return value_field;
   }
 

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -979,7 +979,9 @@ private:
     const std::string &member_name);
 
   /// Handle Optional value access
-  exprt unwrap_optional_if_needed(const exprt &expr);
+  exprt unwrap_optional_if_needed(
+    const exprt &expr,
+    const nlohmann::json &element = nlohmann::json());
 
   // =========================================================================
   // Dunder method dispatch for user-defined struct types


### PR DESCRIPTION
## Problem

ESBMC's Python frontend **aborts** during GOTO generation when the result of an inline call that returns an optional (`None | T`) is compared directly against a value:

```
Assertion failed: (source->type->type_id == type2t::struct_id ||
  source->type->type_id == type2t::union_id ||
  source->type->type_id == type2t::complex_id),
  function member2t, file irep2_expr.h, line 1502.
```

Minimal reproducer:

```python
def second_or_none(lst):
    return None if len(lst) < 2 else lst[1]

assert second_or_none([1, 2, 3]) == 2   # abort
```

This is the `member2t` crash behind `humaneval/90` (`next_smallest`, which does `lst = sorted(set(lst)); return None if len(lst) < 2 else lst[1]`).

## Root cause

A function returning `None | T` is lowered to an `Optional` struct (`tag-Optional_*`, fields `is_none`/`value`). To compare it with a primitive, `unwrap_optional_if_needed` extracts the value field:

```cpp
member_exprt value_field(expr, "value", struct_type.components()[1].type());
```

When the optional is **bound first** (`r = f(...); r.value == 2`) this works, because `r` is an addressable struct symbol. But when the call is used **inline** (`f(...) == 2`), the operand comes back as a `code_function_callt` *statement* (`id == "code"`). A `member` of a call statement is malformed and trips the `member2t` source-type assertion on irep2 migration.

## Fix

In `unwrap_optional_if_needed`, before taking the `.value` member:
- normalise a `code`/function-call operand to a side-effect call via the existing `to_value_expr` helper, then
- materialise it into a temporary (`decl` + `assign`) and take the member of the temp.

This mirrors the already-working assigned path exactly; no behavioural change for non-call operands.

## Validation

- New regression pair `regression/python/optional-inline-compare{,_fail}` (inline true/false comparisons, the bound form, and a negative case so no spurious SUCCESSFUL).
- 214/214 `python`-labelled optional/None/return/compare/tuple/attr tests pass; CPython parity confirmed; `scripts/check_python_tests.sh` green.
- `code-reviewer`: APPROVE (0 critical/major; instruction ordering, no double-evaluation, and temp typing all confirmed sound).

The crash behind `humaneval/90` is removed; the test itself stays KNOWNBUG because it still exceeds the solver time budget (separate, performance issue).

Partially addresses #4807.
