### PR TITLE
[witness] drop aggregate-initialiser assumptions from GraphML witnesses

### DIFF
--- a/regression/esbmc/github_1520_witness_no_aggregate/main.c
+++ b/regression/esbmc/github_1520_witness_no_aggregate/main.c
@@ -1,0 +1,16 @@
+/* Regression for #1520 (and #1471): an aggregate value (array / nested array /
+ * struct, or any ESBMC-internal placeholder such as nondet_symbol / ARRAY_OF)
+ * must never appear inside a GraphML witness assumption, because the SV-COMP
+ * witness validators (CPAchecker, cpa-witness2test) cannot parse a brace
+ * initialiser and reject the whole automaton.
+ *
+ * Here `status` is a zero-initialised global nested array. The violating step
+ * reads a single scalar element, so the witness should keep the scalar
+ * assumption (x == 0) and drop the unparseable `status == { { 0, ... } }`. */
+unsigned char status[2][3];
+
+int main()
+{
+  unsigned char x = status[1][2];
+  assert(x);
+}

--- a/regression/esbmc/github_1520_witness_no_aggregate/test.desc
+++ b/regression/esbmc/github_1520_witness_no_aggregate/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--witness-output-graphml - -Wno-error=implicit-function-declaration
+^VERIFICATION FAILED$
+key="assumption">x == 0;
+(?s)\A(?!.*key="assumption">[^<]*[{}])

--- a/regression/esbmc/github_1520_witness_scalar_kept/main.c
+++ b/regression/esbmc/github_1520_witness_scalar_kept/main.c
@@ -1,0 +1,9 @@
+/* Companion to github_1520_witness_no_aggregate: confirms the aggregate filter
+ * does not over-prune. A plain scalar input assumption must still be emitted in
+ * the GraphML witness so validators can replay the violating value. */
+int main()
+{
+  int x;
+  if (x == 5)
+    assert(0);
+}

--- a/regression/esbmc/github_1520_witness_scalar_kept/test.desc
+++ b/regression/esbmc/github_1520_witness_scalar_kept/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--witness-output-graphml - -Wno-error=implicit-function-declaration
+^VERIFICATION FAILED$
+key="assumption">x == 5;

--- a/regression/esbmc/output-format-array_of-double/test.desc
+++ b/regression/esbmc/output-format-array_of-double/test.desc
@@ -3,4 +3,4 @@ main.c
 --witness-output-graphml - --compact-trace -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$
 \bA = \{ 0\.000000 \}
->A\b.*\b0\.0000000000000000\b
+(?s)\A(?!.*key="assumption">[^<]*[{}])

--- a/regression/esbmc/output-format-array_of-float/test.desc
+++ b/regression/esbmc/output-format-array_of-float/test.desc
@@ -3,4 +3,4 @@ main.c
 --witness-output-graphml - --compact-trace -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$
 \bA = \{ 0\.000000f \}
->A == \{ 0\.0000000f, 0\.0000000f \};</data>
+(?s)\A(?!.*key="assumption">[^<]*[{}])

--- a/regression/esbmc/output-format-array_of-struct-int/test.desc
+++ b/regression/esbmc/output-format-array_of-struct-int/test.desc
@@ -3,4 +3,4 @@ main.c
 --witness-output-graphml - --compact-trace -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$
 \bA = \{ \{ \.x\s*=\s*0 \} \}
->A == \{ \{ \.x=0, \.y=0 \}, \{ \.x=0, \.y=0 \} \};</data>
+(?s)\A(?!.*key="assumption">[^<]*[{}])

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -873,52 +873,6 @@ void create_violation_yaml_emitter(
   _create_yaml_metadata_emitter(verifiedfile, options, root);
 }
 
-static const std::regex
-  regex_array("[a-zA-Z0-9_]+ = \\{ ?(-?[0-9]+(.[0-9]+)?,? ?)+ ?\\};");
-
-void reformat_assignment_array(
-  const namespacet &ns,
-  const goto_trace_stept &step,
-  std::string &assignment)
-{
-  std::regex re{R"(((-?[0-9]+(.[0-9]+)?)))"};
-  using reg_itr = std::regex_token_iterator<std::string::iterator>;
-  BigInt pos = 0;
-  std::string lhs = from_expr(ns, "", step.lhs, presentationt::WITNESS);
-  std::string assignment_array = "";
-  for (reg_itr it{assignment.begin(), assignment.end(), re, 1}, end{};
-       it != end;)
-  {
-    std::string value = *it++;
-    assignment_array += lhs + "[" + integer2string(pos) + "] = " + value + "; ";
-    ++pos;
-  }
-  assignment_array.pop_back();
-  assignment = assignment_array;
-}
-
-static const std::regex regex_structs(
-  "[a-zA-Z0-9_]+ = \\{ ?(\\.([a-zA-Z0-9_]+)=(-?[0-9]+(.[0-9]+)?),? ?)+\\};");
-
-void reformat_assignment_structs(
-  const namespacet &ns,
-  const goto_trace_stept &step,
-  std::string &assignment)
-{
-  std::regex re{R"((((.([a-zA-Z0-9_]+)=(-?[0-9]+(.[0-9]+)?))+)))"};
-  using reg_itr = std::regex_token_iterator<std::string::iterator>;
-  std::string lhs = from_expr(ns, "", step.lhs, presentationt::WITNESS);
-  std::string assignment_struct = "";
-  for (reg_itr it{assignment.begin(), assignment.end(), re, 1}, end{};
-       it != end;)
-  {
-    std::string a = *it++;
-    assignment_struct += lhs + a + "; ";
-  }
-  assignment_struct.pop_back();
-  assignment = assignment_struct;
-}
-
 void check_replace_invalid_assignment(std::string &assignment)
 {
   /* replace: SAME-OBJECT(&var1, &var2) into &var1 == &var2 (XXX check if should stay) */
@@ -938,7 +892,13 @@ void check_replace_invalid_assignment(std::string &assignment)
     std::regex_search(assignment, m, std::regex("CONCAT")) ||
     std::regex_search(assignment, m, std::regex("BITCAST:")) ||
     std::regex_search(assignment, m, std::regex("byte_extract")) ||
-    std::regex_search(assignment, m, std::regex("byte_update")))
+    std::regex_search(assignment, m, std::regex("byte_update")) ||
+    /* Aggregate initialisers ({ ... }, including nested and array-of forms)
+     * are not valid C scalar expressions, so the SV-COMP witness validators
+     * (CPAchecker, cpa-witness2test) reject the whole automaton when one
+     * appears in an assumption. Dropping the assumption only loses replay
+     * precision; it never changes the verdict. See #1520 (nested array). */
+    std::regex_search(assignment, m, std::regex("[{}]")))
     assignment.clear();
 }
 
@@ -960,10 +920,6 @@ std::string get_formated_assignment(
       assignment += ";";
 
     std::replace(assignment.begin(), assignment.end(), '$', '_');
-    if (std::regex_match(assignment, regex_array))
-      reformat_assignment_array(ns, step, assignment);
-    else if (std::regex_match(assignment, regex_structs))
-      reformat_assignment_structs(ns, step, assignment);
     check_replace_invalid_assignment(assignment);
   }
   return assignment;


### PR DESCRIPTION
## Root cause
Violation witnesses emitted array/struct brace initialisers inside `<data key="assumption">` edges — e.g. `A == { 0, 0 };` and nested `status == { { 0, 0, 0 }, ... };`. CPAchecker / cpa-witness2test cannot parse a brace initialiser as a C scalar expression and **reject the entire witness automaton** (issue #1520; the array/struct-value half of #1471).

`get_formated_assignment` already excluded `constant_array2t`/`constant_struct2t`/`constant_union2t`, but `constant_array_of` values still rendered as braces and slipped through. A latent helper (`reformat_assignment_array`/`structs`) was meant to rewrite these into parseable element-wise form, but it was **dead**: the assumption string is built with `==`, while its trigger regexes match a single `=`, so it never fired — arrays leaked out as raw braces.

## Fix
- Clear any witness assumption whose rendered value contains a brace (`[{}]`) in `check_replace_invalid_assignment`. Witnesses are advisory **output** artifacts that never feed back into the verdict, so dropping an assumption cannot introduce a false positive/negative; scalar assumptions still survive for replay.
- Remove the dead `reformat_assignment_array`/`reformat_assignment_structs` functions, their regexes, and the two unreachable call sites.

## Soundness
No verification-logic change. A violation witness with the unparseable aggregate removed goes from *rejected outright* to *parseable but slightly more general* — strictly an improvement for SV-COMP witness validation. Scalar branch assumptions (the ones that actually drive replay to the error) are untouched (verified `x == 5;`, `x == 0;` still emitted).

## Tests
- `github_1520_witness_no_aggregate` — reproducer: a zero-init nested array read into a scalar; the witness drops the unparseable `status` aggregate and keeps the surviving `x == 0` (non-vacuous: positive + negative-lookahead assertions together).
- `github_1520_witness_scalar_kept` — anti-over-prune guard: a plain scalar input assumption must still appear.
- `output-format-array_of-{double,float,struct-int}` — these had locked in the unparseable brace witness; updated to assert the witness is now brace-free while preserving each test's human-readable counterexample-trace assertion.

All 75 witness/trace-touching regression tests pass locally.

## Limitations
End-to-end confirmation with CPAchecker / cpa-witness2test was not run (validator unavailable in the dev environment); the change is validated structurally (no brace ever reaches an assumption edge) and against the regression harness. The full struct-rendering case of #1471 (`nondet_symbol`, `ARRAY_OF` tokens) only reaches a top-level assumption inside an aggregate, which the existing struct guard plus this brace filter already drop; bare-token scalar forms are unreachable here because the path is gated by `is_constant_expr`.

Fixes #1520
