### PR TITLE
[om] add operational model for fseeko

### DIFF
--- a/regression/esbmc/github_2797_fseeko/main.c
+++ b/regression/esbmc/github_2797_fseeko/main.c
@@ -1,0 +1,17 @@
+/* #2797: ESBMC had no operational model for fseeko (only the other coreutils
+ * libc functions were modelled by #2798), so calls emitted
+ * "WARNING: no body for function fseeko". This test confirms the model is now
+ * present (no warning) and that the reachable success outcome verifies. */
+#include <stdio.h>
+
+int main(void)
+{
+  FILE *f = fopen("file", "w");
+  if (!f)
+    return 0;
+  int r = fseeko(f, 0, SEEK_SET);
+  __ESBMC_assume(r == 0); /* the success outcome is reachable */
+  assert(r == 0);
+  fclose(f);
+  return 0;
+}

--- a/regression/esbmc/github_2797_fseeko/test.desc
+++ b/regression/esbmc/github_2797_fseeko/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--incremental-bmc -Wno-error=implicit-function-declaration
+^VERIFICATION SUCCESSFUL$
+(?s)\A(?!.*no body for function fseeko)

--- a/regression/esbmc/github_2797_fseeko_fail/main.c
+++ b/regression/esbmc/github_2797_fseeko_fail/main.c
@@ -1,0 +1,17 @@
+/* #2797: soundness guard for the fseeko operational model. fseeko must be a
+ * nondet over-approximation that can fail (-1), not an unsound "always succeeds"
+ * stub. If it were modelled as `return 0`, this assertion would wrongly hold and
+ * ESBMC would miss bugs in callers' seek-error-handling paths. The nondet model
+ * means r can be nonzero, so the assertion fails as expected. */
+#include <stdio.h>
+
+int main(void)
+{
+  FILE *f = fopen("file", "w");
+  if (!f)
+    return 0;
+  int r = fseeko(f, 0, SEEK_SET);
+  assert(r == 0); /* nondet return may be nonzero: fseeko can fail */
+  fclose(f);
+  return 0;
+}

--- a/regression/esbmc/github_2797_fseeko_fail/test.desc
+++ b/regression/esbmc/github_2797_fseeko_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc -Wno-error=implicit-function-declaration
+^VERIFICATION FAILED$

--- a/src/c2goto/library/io.c
+++ b/src/c2goto/library/io.c
@@ -315,6 +315,15 @@ __ESBMC_HIDE:;
   return nondet_int();
 }
 
+int fseeko(FILE *stream, off_t offset, int whence)
+{
+__ESBMC_HIDE:;
+  // Sound over-approximation: fseeko may succeed (0) or fail (-1), matching
+  // the fseek model. A nondet return constrains neither outcome, so it cannot
+  // hide a real bug or introduce a false alarm. See #2797.
+  return nondet_int();
+}
+
 long ftell(FILE *stream)
 {
 __ESBMC_HIDE:;

--- a/src/c2goto/library/io.c
+++ b/src/c2goto/library/io.c
@@ -318,10 +318,7 @@ __ESBMC_HIDE:;
 int fseeko(FILE *stream, off_t offset, int whence)
 {
 __ESBMC_HIDE:;
-  // Sound over-approximation: fseeko may succeed (0) or fail (-1), matching
-  // the fseek model. A nondet return constrains neither outcome, so it cannot
-  // hide a real bug or introduce a false alarm. See #2797.
-  return nondet_int();
+  return nondet_bool() ? 0 : -1;
 }
 
 long ftell(FILE *stream)


### PR DESCRIPTION
## Root cause
The 2023 report (#2797) listed several coreutils libc functions emitting `WARNING: no body for function …` (`fputs_unlocked`, `__fpending`, `ferror_unlocked`, `__freading`, `lseek`, `fseeko`, `__errno_location`, `error`, `_exit`). Re-checking on current `master`, **all of these are now modelled except `fseeko`** — the rest were added by #2798 (commit `77171a75d7`). `fseeko` alone still had no operational model.

## Fix
Add a `fseeko` model to `src/c2goto/library/io.c`, alongside the existing `fseek` model:

```c
int fseeko(FILE *stream, off_t offset, int whence)
{
__ESBMC_HIDE:;
  return nondet_bool() ? 0 : -1;
}
```

`fseeko` returns `0` on success or `-1` on failure; `nondet_bool() ? 0 : -1` lets it take either outcome nondeterministically, so it is a **sound over-approximation** of the real behaviour — it cannot hide a real bug or introduce a false alarm. Restricting the return to exactly `{0, -1}` (rather than an unconstrained `nondet_int()`) keeps the model faithful to the function's real return values and lets the solver branch on a single Boolean instead of a 32-bit variable constrained by a disjunction (per @mikhailramalho / @XLiZHI review — see the SMT comparison in the review thread). `off_t` is already in use in this file (by `lseek`).

## Soundness
The model returns exactly `{0, -1}` — `fseeko`'s real success/failure values — with no side effects, so it is sound with respect to the C library semantics. Both outcomes stay reachable, so no caller's error-handling path is dropped; the existing regression tests that call `fseeko` (esbmc-unix / esbmc-unix2 / k-induction suites) show no change in verdict, and the only observable difference is that the `no body for function fseeko` warning is gone.

The key soundness risk for a stub like this is modelling it as `return 0` (unconditional success), which would suppress bugs in callers' seek-error-handling paths. The `_fail` regression test guards against exactly that regression.

## Tests
- `github_2797_fseeko` — CORE: the reachable success outcome verifies, and asserts (via negative-lookahead) that no `no body for function fseeko` warning is emitted.
- `github_2797_fseeko_fail` — CORE: asserts `fseeko(...) == 0`, which must produce `VERIFICATION FAILED` because the nondet return may be `-1`. If `fseeko` were ever modelled as unconditional success, this test would start passing and flag the unsoundness.

All new and related tests pass locally; `io.c` is clang-format clean.

Fixes #2797