### PR TITLE
[python] fix segfault returning a tuple literal of function calls

### DIFF
--- a/regression/python/github_5036/main.py
+++ b/regression/python/github_5036/main.py
@@ -1,0 +1,18 @@
+def g(x: int) -> int:
+    return x + 1
+
+
+def outer(a: int) -> tuple[int, int]:
+    # Tuple literal in return position whose elements are non-constant
+    # function calls. Previously this embedded a code_function_call into the
+    # GOTO RETURN struct and crashed with a SIGSEGV (issue #5036).
+    return (g(a), g(a))
+
+
+def main() -> None:
+    x, y = outer(5)
+    assert x == 6
+    assert y == 6
+
+
+main()

--- a/regression/python/github_5036/test.desc
+++ b/regression/python/github_5036/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5036_fail/main.py
+++ b/regression/python/github_5036_fail/main.py
@@ -1,0 +1,18 @@
+def g(x: int) -> int:
+    return x + 1
+
+
+def outer(a: int) -> tuple[int, int]:
+    # Tuple literal in return position whose elements are non-constant
+    # function calls. Previously this embedded a code_function_call into the
+    # GOTO RETURN struct and crashed with a SIGSEGV (issue #5036).
+    return (g(a), g(a))
+
+
+def main() -> None:
+    x, y = outer(5)
+    assert x == 7
+    assert y == 6
+
+
+main()

--- a/regression/python/github_5036_fail/test.desc
+++ b/regression/python/github_5036_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -2,6 +2,7 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/symbol_id.h>
+#include <python-frontend/function_call/expr.h>
 #include <util/arith_tools.h>
 #include <util/base_type.h>
 #include <util/c_types.h>
@@ -58,12 +59,46 @@ exprt tuple_handler::get_tuple_expr(const nlohmann::json &element)
   element_exprs.reserve(elts.size());
   element_types.reserve(elts.size());
 
+  locationt elem_loc = converter_.get_location_from_decl(element);
+
+  // A tuple element that is itself a function call (e.g. ``(g(a), g(a))``)
+  // comes back from get_expr as a code_function_callt (a code statement).
+  // Embedding that directly as a struct operand leaks a call statement into
+  // the GOTO RETURN and crashes on a null operand (issue #5036). Normalise it
+  // to a value expression and spill it into a temporary, exactly as the list
+  // literal path does in python_list::get() for issue #4699.
+  auto materialize_tuple_elem = [&](const exprt &elem) -> exprt {
+    if (elem.is_symbol())
+      return elem;
+
+    const exprt value_elem = to_value_expr(elem, converter_.name_space());
+
+    symbolt &tmp = converter_.create_tmp_symbol(
+      element, "$tuple_elem$", value_elem.type(), value_elem);
+    code_declt decl(symbol_expr(tmp));
+    decl.location() = elem_loc;
+    converter_.add_instruction(decl);
+
+    code_assignt assign(symbol_expr(tmp), value_elem);
+    assign.location() = elem_loc;
+    converter_.add_instruction(assign);
+    return symbol_expr(tmp);
+  };
+
   // First pass: get all expressions to determine types
   for (size_t i = 0; i < elts.size(); i++)
   {
+    // Clear current_lhs so that constructor calls inside tuple elements
+    // (e.g. (A(), B())) create their own self temp variable instead of
+    // inheriting the outer assignment target as self.
+    exprt *saved_lhs = converter_.current_lhs;
+    converter_.current_lhs = nullptr;
     exprt elem_expr = converter_.get_expr(elts[i]);
-    element_exprs.push_back(elem_expr);
+    converter_.current_lhs = saved_lhs;
+
+    elem_expr = materialize_tuple_elem(elem_expr);
     element_types.push_back(elem_expr.type());
+    element_exprs.push_back(elem_expr);
   }
 
   // Create struct type for the tuple


### PR DESCRIPTION
Fixes #5036.

## Problem

The Python frontend segfaults (exit 139, `EXC_BAD_ACCESS`) during GOTO conversion when a `return` statement contains a tuple literal whose elements are function calls:

```python
def g(x):
    return x + 1

def outer(a):
    return (g(a), g(a))   # segfault

x, y = outer(5)
assert x == 6
```

Lists work fine; assigning each call to a local first works fine. The crash is pre-solving, so it is solver-independent.

## Root cause

A Python function call lowers to a `code_function_callt` — a *code statement*, not a value expression. `tuple_handler::get_tuple_expr` built the tuple struct literal by dropping each `get_expr()` result straight into the `struct_exprt` operands. When an element is a call, that call-code gets embedded as a struct operand, flows into the GOTO `RETURN`, and is dereferenced on a null operand.

This is the same bug class already fixed for **list** literals in `python_list::get()` (#4699, the `materialize_list_elem` lambda). The tuple path never received the equivalent treatment.

## Fix

In `get_tuple_expr`, materialise each non-symbol element into a `$tuple_elem$` temporary (`DECL` + `ASSIGN`, emitted via `converter_.add_instruction`) before embedding it — normalising an embedded `code_function_callt` to a value via `to_value_expr`, exactly as the list path does. The `current_lhs` save/restore mirrors the list precedent so constructor-valued elements create their own `self` temp instead of inheriting the outer assignment target.

The change lives in the shared tuple-literal builder, so it fixes the bug in all contexts (return, assignment, nested), not just `return`.

After the fix the GOTO for `outer` materialises each call into a temp ahead of the RETURN:

```
DECL double $tuple_elem$129;
FUNCTION_CALL: $tuple_elem$129 = g((void *)a)
DECL double $tuple_elem$130;
FUNCTION_CALL: $tuple_elem$130 = g((void *)a)
RETURN: { .element_0=$tuple_elem$129, .element_1=$tuple_elem$130 }
```

## Testing

- New regression pair `regression/python/github_5036` (SUCCESSFUL) and `github_5036_fail` (FAILED).
- Dual-solver agreement: Z3 and Bitwuzla both agree on both verdicts.
- CPython sanity (`scripts/check_python_tests.sh github_5036`) passes.
- All existing Python `*tuple*`/`*unpack*` regression tests still pass — no regressions.