### PR TITLE
[symex] don't crash __ESBMC_get_object_size on a non-array object

### DIFF
--- a/regression/python/github_4782_object_size/main.py
+++ b/regression/python/github_4782_object_size/main.py
@@ -1,0 +1,30 @@
+# Regression for #4782 / #4804 / #4805: a non-array pointer reaching the
+# __ESBMC_get_object_size intrinsic (here via a set() of user objects in a
+# graph traversal) used to dereference an empty/non-array deref item and crash
+# — SIGSEGV in release, assertion failure in debug. It must now stop with a
+# clean diagnostic instead of crashing.
+class Node:
+    def __init__(self, value=None, successors=[]):
+        self.value = value
+        self.successors = successors
+
+
+def depth_first_search(startnode, goalnode):
+    nodesvisited = set()
+
+    def search_from(node):
+        if node in nodesvisited:
+            return False
+        elif node is goalnode:
+            return True
+        else:
+            nodesvisited.add(node)
+            return any(search_from(nextnode) for nextnode in node.successors)
+
+    return search_from(startnode)
+
+
+a = Node("A")
+b = Node("B")
+a.successors = [b]
+assert depth_first_search(a, b)

--- a/regression/python/github_4782_object_size/test.desc
+++ b/regression/python/github_4782_object_size/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: __ESBMC_get_object_size: cannot determine the size of a non-array object$

--- a/regression/python/github_4782_object_size_ok/main.py
+++ b/regression/python/github_4782_object_size_ok/main.py
@@ -1,0 +1,6 @@
+# Companion to github_4782_object_size: the array success path of the
+# __ESBMC_get_object_size intrinsic must keep verifying. len() on a string
+# lowers to __ESBMC_get_object_size on a char array, which the hardened
+# intrinsic handles exactly as before.
+s = "hello"
+assert len(s) == 5

--- a/regression/python/github_4782_object_size_ok/test.desc
+++ b/regression/python/github_4782_object_size_ok/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions/object_size.cpp
+++ b/src/goto-symex/builtin_functions/object_size.cpp
@@ -5,6 +5,7 @@
 #include <util/c_types.h>
 #include <util/expr_util.h>
 #include <irep2/irep2.h>
+#include <util/message.h>
 #include <util/migrate.h>
 #include <util/std_types.h>
 
@@ -176,9 +177,27 @@ void goto_symext::intrinsic_get_object_size(
   expr2tc deref = dereference2tc(get_empty_type(), ptr);
   dereference(deref, dereferencet::INTERNAL);
 
-  assert(is_array_type(internal_deref_items.front().object->type));
-  expr2tc obj_size =
-    to_array_type(internal_deref_items.front().object->type).array_size;
+  // __ESBMC_get_object_size returns the element count of the array object the
+  // pointer addresses. If the pointer cannot be resolved to a concrete object,
+  // or the resolved object is not an array, that count is undefined: reading
+  // internal_deref_items.front() on an empty container is UB (SIGSEGV in
+  // release) and to_array_type() on a non-array trips an assertion. The Python
+  // set/graph operational models can route such a pointer here (issues #4782,
+  // #4804, #4805). Emit a clean diagnostic instead of crashing. The array path
+  // below is byte-for-byte unchanged, so C/C++ callers — which always pass an
+  // array object — are unaffected.
+  if (
+    internal_deref_items.empty() ||
+    !is_array_type(internal_deref_items.front().object->type))
+  {
+    log_error(
+      "__ESBMC_get_object_size: cannot determine the size of a non-array "
+      "object");
+    abort();
+  }
+
+  const type2tc &obj_type = internal_deref_items.front().object->type;
+  expr2tc obj_size = to_array_type(obj_type).array_size;
 
   expr2tc ret_ref = func_call.ret;
   if (!is_nil_expr(ret_ref))


### PR DESCRIPTION
Fixes #4782. Also resolves the crashes tracked by #4804 and #4805 (same root cause).

## Problem

`goto_symext::intrinsic_get_object_size` (the `__ESBMC_get_object_size` intrinsic) did:

```cpp
dereference(deref, dereferencet::INTERNAL);
assert(is_array_type(internal_deref_items.front().object->type));
expr2tc obj_size = to_array_type(internal_deref_items.front().object->type).array_size;
```

When the pointer resolves to **no object** (`internal_deref_items` empty) or to a **non-array** object, this is undefined behaviour:
- release build → `internal_deref_items.front()` on an empty vector → **SIGSEGV** (#4804, #4805, `topological_ordering`);
- asserts-on build → the `assert` fires (#4782, `depth_first_search`).

The Python `set`/graph operational models route such a pointer here — e.g. `len()` / set membership on a set of user objects during graph traversal — so several quixbugs KNOWNBUGs crashed instead of reporting a clean limitation.

## Fix

Replace the bare `assert` with an explicit guard that emits a clean diagnostic via the established symex idiom (`log_error` + `abort()`, as used in `threads.cpp` / `run_builtin.cpp`):

```cpp
if (internal_deref_items.empty() ||
    !is_array_type(internal_deref_items.front().object->type))
{
  log_error("__ESBMC_get_object_size: cannot determine the size of a non-array object");
  abort();
}
```

## Why this is sound (no impact on C/C++ verification)

- The **array success path is byte-for-byte unchanged**, so any program that passes an array object behaves exactly as before.
- Asserts are enabled in `RelWithDebInfo`, so any C/C++ program that reached the non-array path would *already* have aborted on the old `assert` — none do: **all 50 `object_size` / `__builtin_object_size` / `get_object_size_intrinsic` regression tests pass before and after**.
- The guard tests the exact predicate the old code already required (`to_array_type` needs `is_array_type` directly true), so it narrows nothing that previously worked. It additionally removes a genuine release-build UB.
- The diagnostic is emitted pre-solver, so it is solver-independent (verified identical under Bitwuzla and Z3).

## Validation

- `depth_first_search`, `topological_ordering`, `topological_ordering_fail`: previously SIGSEGV/assert → now a clean `ERROR:` diagnostic, no crash.
- New regression tests: `github_4782_object_size` (failing: pins the clean error) and `github_4782_object_size_ok` (passing companion: `len()` on a string still verifies `SUCCESSFUL` via the array path).
- CPython sanity (`check_python_tests.sh`) passes for both; `len`/`str`/`set`/`list`/`dict` Python regression subsets pass (one unrelated skip needs the boolector solver, not built here).

## Scope note

This converts the crash into an honest diagnostic; it does **not** make these graph programs verify (that needs the object-model / set-modeling work tracked separately). The KNOWNBUG verdicts are unchanged — the tool simply no longer crashes.
