### PR TITLE
[python] Phase 4.4: migrate dict/list not-truthiness to IREP2

### DIFF
--- a/regression/python/list_not_truthiness/main.py
+++ b/regression/python/list_not_truthiness/main.py
@@ -1,0 +1,9 @@
+# Pins the `not <list>` truthiness contract migrated to IREP2 in Phase 4.4
+# (converter_unop.cpp): an empty list is falsy, so `not []` is True; a non-empty
+# list is truthy, so `not xs` is False. Lowered to __ESBMC_list_size(xs) == 0.
+empty: list = []
+assert not empty
+
+nonempty = [1, 2, 3]
+if not nonempty:
+    assert False  # unreachable: a non-empty list is truthy

--- a/regression/python/list_not_truthiness/test.desc
+++ b/regression/python/list_not_truthiness/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_not_truthiness_fail/main.py
+++ b/regression/python/list_not_truthiness_fail/main.py
@@ -1,0 +1,5 @@
+# Negative variant of list_not_truthiness: `not [1, 2, 3]` is False (a non-empty
+# list is truthy), so asserting it must make verification FAIL. Guards against
+# the IREP2 emptiness-comparison lowering collapsing to a constant.
+xs = [1, 2, 3]
+assert not xs

--- a/regression/python/list_not_truthiness_fail/test.desc
+++ b/regression/python/list_not_truthiness_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -75,11 +75,14 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
     size_call.location() = location;
     current_block->copy_to_operands(size_call);
 
-    // Return comparison: size == 0 (empty dict is truthy for 'not')
-    exprt is_empty("=", bool_type());
-    is_empty.copy_to_operands(symbol_expr(size_result), gen_zero(size_type()));
+    // Return comparison: size == 0 (empty dict is truthy for 'not'). Phase 4.4:
+    // build the returned comparison in IREP2 and lower once at the return. The
+    // size_decl/size_call statements above stay legacy — their operands feed
+    // legacy code_*t shells, so moving them in isolation buys nothing (P1).
+    expr2tc is_empty2 = equality2tc(
+      symbol_expr2tc(size_result), gen_zero(migrate_type(size_type())));
+    exprt is_empty = migrate_expr_back(is_empty2);
     is_empty.location() = location;
-
     return is_empty;
   }
 
@@ -152,11 +155,13 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
     size_call.location() = location;
     current_block->copy_to_operands(size_call);
 
-    // Return comparison: size == 0 (empty list is falsy, so 'not list' is true when empty)
-    exprt is_empty =
-      equality_exprt(symbol_expr(size_result), gen_zero(size_type()));
+    // Return comparison: size == 0 (empty list is falsy, so 'not list' is true
+    // when empty). Phase 4.4: build in IREP2, lower once at the return; the
+    // size_decl/size_call statements above stay legacy (P1).
+    expr2tc is_empty2 = equality2tc(
+      symbol_expr2tc(size_result), gen_zero(migrate_type(size_type())));
+    exprt is_empty = migrate_expr_back(is_empty2);
     is_empty.location() = location;
-
     return is_empty;
   }
 


### PR DESCRIPTION
Completes the IREP2 migration of `converter_unop.cpp` (Part IV file 1, after
#5041's `not`-on-string case). The dict and list `not`-truthiness branches of
`get_unary_operator_expr` now build their returned emptiness comparison
`size == 0` in IREP2 — `equality2tc` over `symbol_expr2tc` and
`gen_zero(type2tc)` — lowered once via `migrate_expr_back` at the return. The
dict case removes a `copy_to_operands` operand-surgery site (RP13).

Behaviour-preserving (same-branch construction refactor, no branch changed):
identical verdicts under both Bitwuzla and Z3 with the asserts-build migrate
cross-check silent. The `size_decl`/`size_call` statements pushed into
`current_block` stay legacy by design (subtree-not-site rule, P1). Dict path
covered by `dict40`/`dict43`; adds `list_not_truthiness{,_fail}` for the list
path (module-level lists, since the `is_empty([])` literal-argument path has a
pre-existing unrelated limitation).
