### PR TITLE
[python] infer imported-class attribute types across module boundaries

### DIFF
--- a/regression/python/github_4784_imported_attr/listnode.py
+++ b/regression/python/github_4784_imported_attr/listnode.py
@@ -1,0 +1,4 @@
+class ListNode:
+    def __init__(self, value=0, successor=None):
+        self.value = value
+        self.successor = successor

--- a/regression/python/github_4784_imported_attr/main.py
+++ b/regression/python/github_4784_imported_attr/main.py
@@ -1,0 +1,15 @@
+# Cross-module attribute-type inference (#4784): `ListNode` is defined in
+# listnode.py and only ever constructed in this module. Inside a function the
+# nested read `node.successor.value` must resolve via the inferred field type
+# of an *imported* class. Before the fix the attribute stayed any_type() and
+# this aborted with "Cannot resolve nested attribute".
+from listnode import ListNode
+
+
+def second_value(node):
+    return node.successor.value
+
+
+a = ListNode(1)
+b = ListNode(2, a)
+assert second_value(b) == 1

--- a/regression/python/github_4784_imported_attr/test.desc
+++ b/regression/python/github_4784_imported_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4784_imported_attr_fail/listnode.py
+++ b/regression/python/github_4784_imported_attr_fail/listnode.py
@@ -1,0 +1,4 @@
+class ListNode:
+    def __init__(self, value=0, successor=None):
+        self.value = value
+        self.successor = successor

--- a/regression/python/github_4784_imported_attr_fail/main.py
+++ b/regression/python/github_4784_imported_attr_fail/main.py
@@ -1,0 +1,15 @@
+# Cross-module attribute-type inference (#4784): `ListNode` is defined in
+# listnode.py and only ever constructed in this module. Inside a function the
+# nested read `node.successor.value` must resolve via the inferred field type
+# of an *imported* class. Before the fix the attribute stayed any_type() and
+# this aborted with "Cannot resolve nested attribute".
+from listnode import ListNode
+
+
+def second_value(node):
+    return node.successor.value
+
+
+a = ListNode(1)
+b = ListNode(2, a)
+assert second_value(b) == 99

--- a/regression/python/github_4784_imported_attr_fail/test.desc
+++ b/regression/python/github_4784_imported_attr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -337,11 +337,55 @@ typet python_converter::infer_attr_type_from_usage(
   if (!unset(t))
     return t;
 
+  // Cross-module inference sources. A class and the code that constructs it can
+  // live in different modules: e.g. `Node` is defined in node.py while the calls
+  // `n2 = Node(2, n1)` are in the importing main.py. The struct type is built
+  // while converting the *defining* module, where the call sites are not the
+  // current module_body. Gather every reachable module body — the entry module
+  // (entry_ast_), every imported module (module_ast_pool_), and the current
+  // module — deduplicated by address, so both the class definition and its
+  // constructor call sites are visible regardless of which module is current.
+  // Without this, an imported class's __init__-parameter attributes stay
+  // any_type() and nested reads inside functions abort ("Cannot resolve nested
+  // attribute"), e.g. quixbugs detect_cycle's `node.successor.successor`.
+  std::vector<const nlohmann::json *> module_bodies;
+  auto add_body = [&](const nlohmann::json &mod) {
+    if (!mod.is_object() || !mod.contains("body") || !mod["body"].is_array())
+      return;
+    const nlohmann::json *b = &mod["body"];
+    for (const auto *seen : module_bodies)
+      if (seen == b)
+        return;
+    module_bodies.push_back(b);
+  };
+  add_body(*ast_json);
+  if (entry_ast_)
+    add_body(*entry_ast_);
+  for (const auto &kv : module_ast_pool_)
+    add_body(kv.second);
+
+  // Locate the class definition across all reachable modules. Accept only an
+  // unambiguous single definition; if two modules define the same class name,
+  // don't guess (return null → attribute falls back to any_type()).
+  auto resolve_class_def = [&]() -> nlohmann::json {
+    nlohmann::json found;
+    for (const auto *b : module_bodies)
+    {
+      nlohmann::json c = json_utils::find_class(*b, class_name);
+      if (c.is_null())
+        continue;
+      if (!found.is_null() && found != c)
+        return nlohmann::json(); // defined in 2+ modules — don't guess
+      found = std::move(c);
+    }
+    return found;
+  };
+
   // Fallback: `self.<attr> = <rhs>` inside the class's own methods. Unify
   // across all methods so that two methods assigning different classes to
   // the same attribute fall back to any_type() rather than returning
   // whichever is encountered first.
-  const auto &cls_node = json_utils::find_class(module_body, class_name);
+  const nlohmann::json cls_node = resolve_class_def();
   if (!cls_node.is_null() && cls_node.contains("body"))
   {
     typet unified;
@@ -432,38 +476,48 @@ typet python_converter::infer_attr_type_from_usage(
           }
         }
       }
-      // 4. Scan module-level constructor calls and unify arg-K's type.
+      // 4. Scan top-level constructor calls across every reachable module and
+      // unify arg-K's type. A call's Name arguments (e.g. `n1` in
+      // `Node(2, n1)`) resolve against the var-map of the module the call lives
+      // in, so rebuild var_to_class per body before scanning it.
       if (param_idx >= 0)
       {
         typet ctor_unified;
-        for (const auto &stmt : module_body)
+        for (const auto *b : module_bodies)
         {
-          auto [t, v] = tgt_val(stmt);
-          if (!v || !v->is_object() || v->value("_type", "") != "Call")
-            continue;
-          const auto &f = (*v)["func"];
-          if (
-            !f.is_object() || f.value("_type", "") != "Name" ||
-            f.value("id", "") != class_name)
-            continue;
-          if (!v->contains("args") || !(*v)["args"].is_array())
-            continue;
-          const auto &call_args = (*v)["args"];
-          if (param_idx >= static_cast<int>(call_args.size()))
-            continue;
-          typet arg_t = infer_rhs(call_args[param_idx]);
-          if (unset(arg_t))
-            continue;
-          if (unset(ctor_unified))
-            ctor_unified = arg_t;
-          else if (ctor_unified != arg_t)
-            return typet();
+          populate_var_map(*b);
+          for (const auto &stmt : *b)
+          {
+            auto [t, v] = tgt_val(stmt);
+            if (!v || !v->is_object() || v->value("_type", "") != "Call")
+              continue;
+            const auto &f = (*v)["func"];
+            if (
+              !f.is_object() || f.value("_type", "") != "Name" ||
+              f.value("id", "") != class_name)
+              continue;
+            if (!v->contains("args") || !(*v)["args"].is_array())
+              continue;
+            const auto &call_args = (*v)["args"];
+            if (param_idx >= static_cast<int>(call_args.size()))
+              continue;
+            typet arg_t = infer_rhs(call_args[param_idx]);
+            if (unset(arg_t))
+              continue;
+            if (unset(ctor_unified))
+              ctor_unified = arg_t;
+            else if (ctor_unified != arg_t)
+              return typet();
+          }
         }
         if (!unset(ctor_unified))
           return ctor_unified;
       }
     }
   }
+  // Note: var_to_class now reflects the last body scanned above. The only
+  // remaining consumer (the function-local fallback) re-populates it per
+  // function, so this leftover state is never observed.
 
   // Fallback: `<local>.<attr> = <rhs>` inside an ordinary top-level function,
   // where `<local>` is a function-local instance of class_name (e.g.
@@ -672,6 +726,22 @@ void python_converter::get_attributes_from_self(
             infer_tuple_struct_from_value(stmt["value"], param_annotations);
         if (type.is_nil() || type.is_empty())
           type = type_handler_.get_typet(annotated_type);
+      }
+      else if (annotated_type == "Any")
+      {
+        // An `Any`-typed attribute carries no static shape, so a later nested
+        // read (`obj.attr.field`) cannot resolve. The per-module annotator
+        // assigns `Any` to a `self.x = <param-defaulting-to-None>` attribute of
+        // an *imported* class (the entry module's annotator would have written
+        // `NoneType` and gone through the usage-inference path below). Recover
+        // the same way: if every construction/assignment of this attribute
+        // across all reachable modules agrees on one class, adopt it; on any
+        // conflict infer_attr_type_from_usage returns unset and we keep Any.
+        typet from_usage =
+          infer_attr_type_from_usage(current_class_name_, attr_name);
+        type = (from_usage.id().as_string().empty() || from_usage.is_nil())
+                 ? type_handler_.get_typet(annotated_type)
+                 : from_usage;
       }
       else
       {

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -62,6 +62,7 @@ python_converter::python_converter(
   const global_scope &gs)
   : symbol_table_(_context),
     ast_json(ast),
+    entry_ast_(ast),
     global_scope_(gs),
     type_handler_(*this),
     string_builder_(new string_builder(*this, &string_handler_)),

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1011,6 +1011,11 @@ private:
 
   contextt &symbol_table_;
   const nlohmann::json *ast_json;
+  /// The entry-point module AST, captured at construction. `ast_json` is
+  /// temporarily swapped to imported modules during conversion (see with_ast),
+  /// so this retains a stable handle to the top-level module whose body holds
+  /// the constructor call sites used by cross-module attribute-type inference.
+  const nlohmann::json *entry_ast_;
   const global_scope &global_scope_;
   type_handler type_handler_;
   string_builder *string_builder_;


### PR DESCRIPTION
## What

Makes the Python frontend infer an **imported** class's attribute types across the module boundary, so a nested attribute read on an imported-class instance resolves instead of aborting.

Part of #4784 — the flow-sensitive class-tracking line of work (the core last-write tracking landed in #5015). This increment removes the *attribute-resolution* blocker shared by the `from node import Node` graph benchmarks.

## Problem

```python
# node.py
class Node:
    def __init__(self, value=0, successor=None):
        self.value = value
        self.successor = successor
# main.py
from node import Node
def f(node):
    return node.successor.value      # ERROR: Cannot resolve nested attribute
a = Node(1); b = Node(2, a)
assert f(b) == 1
```

Defining `Node` *inline* in main.py verifies fine; importing it aborts. Root cause (established empirically):

1. `infer_attr_type_from_usage` (`converter_class.cpp`) scanned only the **current** module body. An imported class's struct type is built while converting the *defining* module (node.py), but the constructor call sites (`Node(2, a)`) live in the *importing* module (main.py) — so the call-site / `__init__`-parameter inference saw no calls and the field stayed `any_type()`.
2. The per-module annotator labels such a `None`-defaulted self-attribute of an imported class as `Any` (the entry module's annotator writes `NoneType`), and `get_attributes_from_self` only routed `NoneType` through usage inference — so `Any` fell straight to `any_type()`.

With the field at `any_type()`, a nested read inside a function (where the straight-line `flow_class_map_` from #5015 is cleared) cannot resolve the second `.attr` and aborts at `converter_expr.cpp`.

## Fix

- Retain the entry-module AST in a new member `entry_ast_` (the converter swaps `ast_json` to imported modules via `with_ast` during conversion).
- In `infer_attr_type_from_usage`: gather every reachable module body (current `ast_json`, `entry_ast_`, and each `module_ast_pool_` entry), deduped by address; resolve the class definition across all of them (unambiguous-only); and unify constructor-arg types across all of them, rebuilding the per-body var-map so a call's `Name` args resolve against the right module.
- Route `annotated_type == "Any"` attributes through the same usage inference.

## Why it's sound

The existing **conflict-collapses-to-`any_type()`** discipline is untouched: inference adopts a concrete class only when *every* observed construction/assignment of the attribute agrees on one class; any disagreement returns unset → the attribute keeps `Any`/`any_type()`. So a genuinely polymorphic attribute is never narrowed. The diagnostic/verdict is produced at conversion time, hence solver-independent (confirmed identical under Bitwuzla and Z3).

A `code-reviewer` pass cleared all six soundness questions (polymorphic-narrowing, address dedup, var-map mutation, ambiguous-class guard, lifetimes, perf) with 0 critical/major findings.

## Validation

- New regression pair `github_4784_imported_attr` (SUCCESSFUL) / `_fail` (FAILED) — a two-module program reading an imported class's nested attribute inside a function. CPython sanity passes for both.
- `github_4117` flow-tracking family unchanged (all still SUCCESSFUL).
- **No regressions**: ~1300 tests swept — `class`/`object`/`dict`/`optional`/`none` (538/539), `import`/`module`/multi-module (88/88), `github_3*` (681/682). The only failures are environmental and pre-existing (tests requiring the `--boolector` solver, not built here; and a `flask` astgen import).
- Dual-solver agreement (Bitwuzla + Z3) on the new tests.

## Scope

This removes the attribute-resolution blocker only. The `from node import Node` graph benchmarks (detect_cycle, reverse_linked_list, depth_first_search, topological_ordering, shortest_*) still hit **separate** downstream blockers — object-size on non-array (#4782, fixed in a separate PR), Optional/`None` object comparison (#4796), `heapq`, DictComp tuple targets, and unbounded-loop timeouts — tracked in `docs/python-issues-triage-report-2026-06-02.md`. Those are follow-on increments.
