### PR TITLE
[util] collapse contextt's three symbol maps into one multi_index

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -418,27 +418,22 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
     }
   }
 
-  /* We successfully constructed the type of this symbol; replace the
-   * symbol with the incomplete type by one with the now-complete type
-   * definition.
-   * Do this by erasing and re-inserting because the order of definitions in the
-   * context matters. This type should be defined after any of the types that it
-   * is composed of.
+  /* We successfully constructed the type of this symbol; complete the
+   * incomplete-type symbol with the now-complete type definition, in place.
+   * The order of definitions in the context matters — this type must be
+   * defined after any of the types it is composed of — so move it to the
+   * back of the insertion order afterwards.
    *
-   * Refresh `sym` here: get_struct_union_class_fields() above can recurse
-   * through field types into other records; any of those recursions may
-   * call erase_symbol() on the symbol table, and although unordered_map
-   * doesn't invalidate references on rehash, it *does* invalidate the
-   * specific element that was erased.  In the cross-record recursion case
-   * the same record can be processed twice, and the second pass's erase
-   * makes the outer `sym` dangling.  A fresh find_symbol() by id avoids
-   * the use-after-free. */
+   * Refresh `sym` by id: get_struct_union_class_fields() above can recurse
+   * through field types into other records, and any of those recursions may
+   * reorder/complete the same record, leaving the outer `sym` stale. A fresh
+   * find_symbol() avoids using a stale pointer. (The symbol table is
+   * node-based, so updating in place and relocating no longer dangles or
+   * copies the symbol.) */
   sym = context.find_symbol(id);
   assert(sym && "symbol disappeared from context during field conversion");
-  symbolt symbol = *sym;
-  context.erase_symbol(symbol.id);
-  symbol.set_type(t);
-  sym = context.move_symbol_to_context(symbol);
+  sym->set_type(t);
+  sym = context.reorder_symbol_to_back(id);
 
   {
     typet t = sym->get_type();
@@ -617,19 +612,19 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
     if (vd.isStaticDataMember() && vd.isOutOfLine())
     {
-      // Reorder to respect definition order for static_lifetime_init()
-      // C++ class static members are inserted into ordered_symbols when the
-      // class body is processed (in declaration order), but their out-of-class
-      // definitions appear later in textual order. Both C and C++ require
-      // initialization in definition order
+      // Reorder to respect definition order for static_lifetime_init().
+      // C++ class static members are inserted when the class body is processed
+      // (in declaration order), but their out-of-class definitions appear later
+      // in textual order, and the later definition supplies the complete type
+      // (e.g. an array's real size). Erase the incomplete declaration-order
+      // symbol so move_symbol_to_context below re-adds the complete one at the
+      // end — both replacing its contents and fixing the init order.
       symbolt *s = context.find_symbol(symbol.id);
       if (
         s &&
         vd.getTemplateSpecializationKind() != clang::TSK_ImplicitInstantiation)
-        // In AST, nodes will be generated for the template Instantiation.
-        // We have already initialized it, so skip it
-
-        // Remove the zero initialization symbol and re-arrange the initialization order
+        // In AST, nodes are also generated for the template instantiation,
+        // already initialized — skip those.
         context.erase_symbol(s->id);
     }
 

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -65,8 +65,7 @@ bool clang_c_maint::clang_main()
   // find main symbol
   std::list<irep_idt> matches;
 
-  forall_symbol_base_map (it, context.symbol_base_map, main)
-  {
+  context.foreach_named_symbol_with_base(main, [&](irep_idt id) {
     // if user provided class/contract name
     if (!config.cname.empty() && !config.main.empty())
     {
@@ -80,7 +79,7 @@ bool clang_c_maint::clang_main()
       while (iss >> tgt_cname)
       {
         const std::string fmt = "@" + tgt_cname + "@F@" + main;
-        if (it->second.as_string().find(fmt) != std::string::npos)
+        if (id.as_string().find(fmt) != std::string::npos)
         {
           is_found_sym = true;
           break;
@@ -88,20 +87,21 @@ bool clang_c_maint::clang_main()
       }
       if (is_found_sym)
       {
-        symbolt *s = context.find_symbol(it->second);
+        symbolt *s = context.find_symbol(id);
         if (s != nullptr && s->get_type().is_code())
-          matches.push_back(it->second);
-        break; // prevent ambiguous
+          matches.push_back(id);
+        return false; // first cname match wins; stop scanning
       }
     }
     else
     {
       // look it up
-      symbolt *s = context.find_symbol(it->second);
+      symbolt *s = context.find_symbol(id);
       if (s != nullptr && s->get_type().is_code())
-        matches.push_back(it->second);
+        matches.push_back(id);
     }
-  }
+    return true; // keep scanning
+  });
 
   if (matches.empty())
   {

--- a/src/jimple-frontend/jimple-language.cpp
+++ b/src/jimple-frontend/jimple-language.cpp
@@ -134,17 +134,13 @@ void jimple_languaget::setup_main(contextt &context)
   // find main symbol
   std::list<irep_idt> matches;
 
-  forall_symbol_base_map (it, context.symbol_base_map, main)
-  {
+  context.foreach_named_symbol_with_base(main, [&](irep_idt id) {
     // look it up
-    symbolt *s = context.find_symbol(it->second);
-
-    if (s == nullptr)
-      continue;
-
-    if (s->get_type().is_code())
-      matches.push_back(it->second);
-  }
+    symbolt *s = context.find_symbol(id);
+    if (s != nullptr && s->get_type().is_code())
+      matches.push_back(id);
+    return true; // collect all; ambiguity is reported after the scan
+  });
   if (matches.empty())
     abort();
 

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -2,38 +2,36 @@
 #include <util/message.h>
 #include <util/message/format.h>
 
+using contextt_detail::by_id;
+using contextt_detail::by_order;
+
 bool contextt::add(const symbolt &symbol)
 {
-  std::pair<symbolst::iterator, bool> result =
-    symbols.insert(std::pair<irep_idt, symbolt>(symbol.id, symbol));
-
-  if (!result.second)
-    return true;
-
-  symbol_base_map.insert(std::pair<irep_idt, irep_idt>(symbol.name, symbol.id));
-
-  ordered_symbols.push_back(&result.first->second);
-  return false;
+  // push_back appends to the sequenced (insertion-order) index; the id index
+  // is updated automatically. The bool is false when the id is already present
+  // (hashed_unique rejects the duplicate).
+  return !symbols.get<by_order>().push_back(symbol).second;
 }
 
 bool contextt::move(symbolt &symbol, symbolt *&new_symbol)
 {
-  symbolt tmp;
-  std::pair<symbolst::iterator, bool> result =
-    symbols.insert(std::pair<irep_idt, symbolt>(symbol.id, tmp));
+  auto &by_id_idx = symbols.get<by_id>();
 
-  if (!result.second)
+  // If the id is already present, hand back the existing symbol and leave
+  // `symbol` untouched — callers (e.g. c_linkt::move -> duplicate()) read the
+  // incoming symbol afterwards to merge it. Only move-from `symbol` once we
+  // know the insert will succeed.
+  auto existing = by_id_idx.find(symbol.id);
+  if (existing != by_id_idx.end())
   {
-    new_symbol = &result.first->second;
+    new_symbol = const_cast<symbolt *>(&*existing);
     return true;
   }
 
-  symbol_base_map.insert(std::pair<irep_idt, irep_idt>(symbol.name, symbol.id));
-
-  ordered_symbols.push_back(&result.first->second);
-
-  result.first->second.swap(symbol);
-  new_symbol = &result.first->second;
+  // Insert the symbol with its final keys directly (the old tmp-then-swap
+  // would have mutated the id key after indexing, which multi_index forbids).
+  auto result = symbols.get<by_order>().push_back(std::move(symbol));
+  new_symbol = const_cast<symbolt *>(&*result.first);
   return false;
 }
 
@@ -46,70 +44,88 @@ void contextt::dump() const
 
 symbolt *contextt::find_symbol(irep_idt name)
 {
-  auto it = symbols.find(name);
-  if (it != symbols.end())
-    return &(it->second);
+  // NB: the parameter is a symbol id (the table is keyed by symbolt::id).
+  auto &by_id_idx = symbols.get<by_id>();
+  auto it = by_id_idx.find(name);
+  if (it != by_id_idx.end())
+    return const_cast<symbolt *>(&*it);
   return nullptr;
 }
 
 const symbolt *contextt::find_symbol(irep_idt name) const
 {
-  auto it = symbols.find(name);
-  if (it != symbols.end())
-    return &(it->second);
+  const auto &by_id_idx = symbols.get<by_id>();
+  auto it = by_id_idx.find(name);
+  if (it != by_id_idx.end())
+    return &*it;
   return nullptr;
 }
 
 void contextt::erase_symbol(irep_idt name)
 {
-  symbolst::iterator it = symbols.find(name);
-  if (it == symbols.end())
+  auto &by_id_idx = symbols.get<by_id>();
+  auto it = by_id_idx.find(name);
+  if (it == by_id_idx.end())
   {
     log_error("Couldn't find symbol to erase");
     abort();
   }
 
-  ordered_symbols.erase(
-    std::remove_if(
-      ordered_symbols.begin(),
-      ordered_symbols.end(),
-      [&name](const symbolt *s) { return s->id == name; }),
-    ordered_symbols.end());
-  symbols.erase(it);
+  // O(1): erasing from one index removes the element from all indices.
+  by_id_idx.erase(it);
+}
+
+symbolt *contextt::reorder_symbol_to_back(irep_idt name)
+{
+  auto &by_id_idx = symbols.get<by_id>();
+  auto id_it = by_id_idx.find(name);
+  if (id_it == by_id_idx.end())
+    return nullptr;
+
+  // Move the element to the back of the sequenced (insertion-order) view.
+  // relocate is O(1) and does not touch the id index, so the element and any
+  // held reference stay valid.
+  auto &order = symbols.get<by_order>();
+  auto ord_it = symbols.project<by_order>(id_it);
+  order.relocate(order.end(), ord_it);
+  return const_cast<symbolt *>(&*id_it);
 }
 
 void contextt::foreach_operand_impl_const(const_symbol_delegate &expr) const
 {
-  for (const auto &symbol : symbols)
-  {
-    expr(symbol.second);
-  }
+  // Iterate in insertion order. The old unordered_map made foreach_operand
+  // hash-ordered, which varied between builds and leaked into GOTO output
+  // (global init order, symbol enumeration); the single container lets every
+  // walk be deterministic, so foreach_operand now matches the in-order walk.
+  for (const symbolt &symbol : symbols.get<by_order>())
+    expr(symbol);
 }
 
 void contextt::foreach_operand_impl(symbol_delegate &expr)
 {
-  for (auto &symbol : symbols)
-  {
-    expr(symbol.second);
-  }
+  // Hand out a mutable reference, in insertion order (see the const overload).
+  // Callers must not change the id/name keys (they never do — keys are only
+  // set on fresh symbols before insertion); mutating type/value/flags in place
+  // is safe and leaves the indices intact.
+  auto &order = symbols.get<by_order>();
+  for (auto it = order.begin(); it != order.end(); ++it)
+    expr(const_cast<symbolt &>(*it));
 }
 
 void contextt::foreach_operand_impl_in_order_const(
   const_symbol_delegate &expr) const
 {
-  for (auto ordered_symbol : ordered_symbols)
-  {
-    expr(*ordered_symbol);
-  }
+  for (const symbolt &symbol : symbols.get<by_order>())
+    expr(symbol);
 }
 
 void contextt::foreach_operand_impl_in_order(symbol_delegate &expr)
 {
-  for (auto &ordered_symbol : ordered_symbols)
-  {
-    expr(*ordered_symbol);
-  }
+  auto &order = symbols.get<by_order>();
+  for (auto it = order.begin(); it != order.end(); ++it)
+    expr(const_cast<symbolt &>(*it));
 }
+
 symbolt *contextt::move_symbol_to_context(symbolt &symbol)
 {
   symbolt *s = find_symbol(symbol.id);
@@ -121,24 +137,29 @@ symbolt *contextt::move_symbol_to_context(symbolt &symbol)
         "Couldn't add symbol {} to symbol table\n{}", symbol.name, symbol);
       abort();
     }
+    return s;
   }
-  else
+
+  // A symbol with this id is already present (s was found by symbol.id).
+  // Replace the stored symbol with the incoming one when the latter completes
+  // a forward declaration: a function/type definition supplying the missing
+  // body/type, or an extern variable becoming a real definition. The incoming
+  // symbol shares the id, so the by_id key is unchanged; route the replacement
+  // through multi_index's modify() (the in-place reference is const otherwise).
+  const bool replace =
+    (s->get_type().is_code() && symbol.get_value().is_not_nil() &&
+     !s->get_value().is_not_nil()) ||
+    (s->is_type && symbol.get_type().is_not_nil() &&
+     !s->get_type().is_not_nil()) ||
+    (s->is_extern && !symbol.is_extern);
+
+  if (replace)
   {
-    // types that are code means functions
-    if (s->get_type().is_code())
-    {
-      if (symbol.get_value().is_not_nil() && !s->get_value().is_not_nil())
-        s->swap(symbol);
-    }
-    else if (s->is_type)
-    {
-      if (symbol.get_type().is_not_nil() && !s->get_type().is_not_nil())
-        s->swap(symbol);
-    }
-    else if (s->is_extern && !symbol.is_extern)
-      // Variable symbol already in context. Apply extern→non-extern swap if
-      // needed, then reorder to preserve definition order.
-      s->swap(symbol);
+    auto &by_id_idx = symbols.get<by_id>();
+    auto it = by_id_idx.iterator_to(*s);
+    by_id_idx.modify(
+      it, [&symbol](symbolt &existing) { existing = std::move(symbol); });
+    return const_cast<symbolt *>(&*it);
   }
   return s;
 }

--- a/src/util/context.h
+++ b/src/util/context.h
@@ -3,22 +3,55 @@
 
 #include <functional>
 
-#include <map>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
 #include <util/config.h>
 #include <util/symbol.h>
 #include <util/type.h>
 
-typedef std::unordered_map<irep_idt, symbolt, irep_id_hash> symbolst;
-typedef std::vector<symbolt *> ordered_symbolst;
+/* Symbol table.
+ *
+ * A single boost::multi_index_container of symbolt holds every symbol and
+ * exposes the two views the codebase needs, kept in sync automatically:
+ *
+ *   - by_id:    hashed_unique on symbolt::id    — O(1) lookup by id
+ *   - by_order: sequenced                       — insertion order (init order)
+ *
+ * multi_index is node-based, so element references/pointers stay valid across
+ * insert and erase (only the erased element is invalidated). This replaces the
+ * former hand-synced trio (unordered_map + vector<symbolt*> + multimap), which
+ * leaked base-name entries on erase, did an O(n) scan to erase from the order
+ * vector, and stored raw symbolt* into the map (a documented use-after-free
+ * hazard on erase). Same pattern already used by smt_convt::smt_cache.
+ *
+ * There is no base-name index: the only base-name lookup is the one-shot
+ * entry-point search (find `main`) done once per run, served by a linear scan
+ * (foreach_named_symbol_with_base) — not worth a third index maintained on
+ * every insert/erase.
+ */
 
-typedef std::multimap<irep_idt, irep_idt> symbol_base_mapt;
+namespace contextt_detail
+{
+struct by_id
+{
+};
+struct by_order
+{
+};
 
-#define forall_symbol_base_map(it, expr, base_name)                            \
-  for (symbol_base_mapt::const_iterator                                        \
-         it = (expr).lower_bound(base_name),                                   \
-         it_end = (expr).upper_bound(base_name);                               \
-       it != it_end;                                                           \
-       it++)
+typedef boost::multi_index_container<
+  symbolt,
+  boost::multi_index::indexed_by<
+    boost::multi_index::hashed_unique<
+      boost::multi_index::tag<by_id>,
+      BOOST_MULTI_INDEX_MEMBER(symbolt, irep_idt, id),
+      irep_id_hash>,
+    boost::multi_index::sequenced<boost::multi_index::tag<by_order>>>>
+  symbol_containert;
+} // namespace contextt_detail
 
 class contextt
 {
@@ -26,8 +59,6 @@ class contextt
   typedef std::function<void(symbolt &symbol)> symbol_delegate;
 
 public:
-  typedef ::symbolst symbolst;
-  typedef ::ordered_symbolst ordered_symbolst;
   explicit contextt()
   {
   }
@@ -57,8 +88,6 @@ public:
 
   contextt &operator=(contextt &&) noexcept = default;
 
-  symbol_base_mapt symbol_base_map;
-
   bool add(const symbolt &symbol);
   bool move(symbolt &symbol, symbolt *&new_symbol);
 
@@ -72,8 +101,6 @@ public:
   void clear()
   {
     symbols.clear();
-    symbol_base_map.clear();
-    ordered_symbols.clear();
   }
 
   DUMP_METHOD void dump() const;
@@ -81,8 +108,6 @@ public:
   void swap(contextt &other)
   {
     symbols.swap(other.symbols);
-    symbol_base_map.swap(other.symbol_base_map);
-    ordered_symbols.swap(other.ordered_symbols);
   }
 
   symbolt *find_symbol(const char *name)
@@ -93,6 +118,29 @@ public:
   const symbolt *find_symbol(irep_idt name) const;
 
   void erase_symbol(irep_idt name);
+
+  /// Move the symbol with id @p name to the end of the insertion-order view,
+  /// keeping it in the table. The C/C++ frontends need this when a symbol's
+  /// definition must sort after symbols it now depends on (a completed struct
+  /// after its field types; a static member in definition rather than
+  /// declaration order). O(1); replaces the former erase-and-reinsert, which
+  /// copied the symbol and briefly dangled any held symbolt*. Returns the
+  /// (stable) symbol, or nullptr if no such id exists.
+  symbolt *reorder_symbol_to_back(irep_idt name);
+
+  /// Invoke @p t(id) for every symbol whose base name equals @p base_name, in
+  /// insertion order (the former forall_symbol_base_map). @p t returns a bool:
+  /// false stops the scan early (the lambda equivalent of `break`). Implemented
+  /// as a linear scan: the sole caller is the once-per-run entry-point search,
+  /// so a dedicated base-name index is not worth maintaining on every insert.
+  template <typename T>
+  void foreach_named_symbol_with_base(irep_idt base_name, T &&t) const
+  {
+    for (const symbolt &s : symbols.get<contextt_detail::by_order>())
+      if (s.name == base_name)
+        if (!t(s.id))
+          break;
+  }
 
   template <typename T>
   void foreach_operand_in_order(T &&t) const
@@ -128,8 +176,7 @@ public:
   }
 
 private:
-  symbolst symbols;
-  ordered_symbolst ordered_symbols;
+  contextt_detail::symbol_containert symbols;
 
   void foreach_operand_impl_const(const_symbol_delegate &expr) const;
   void foreach_operand_impl(symbol_delegate &expr);


### PR DESCRIPTION
## What

Collapses `contextt`'s three hand-synchronised symbol containers into a single `boost::multi_index_container<symbolt>` — the same pattern `smt_convt` already uses for `smt_cache`.

Before:
```cpp
std::unordered_map<irep_idt, symbolt, irep_id_hash> symbols;     // id -> symbol
std::vector<symbolt *>                              ordered;      // insertion order
std::multimap<irep_idt, irep_idt>                   symbol_base;  // base name -> id
```
After: one container, two indices — `hashed_unique` on `id` (O(1) lookup) and `sequenced` (insertion / init order).

## Why

The three structures were maintained by hand in `add`/`move`/`clear`/`swap`/`erase_symbol`, which caused several real problems this PR fixes:

- **Use-after-free hazard.** `ordered_symbols` held raw `symbolt*` into the map; `erase_symbol` invalidated the erased element, a UAF the clang frontend explicitly worked around by re-`find`ing the symbol. `multi_index` is node-based, so references stay valid across insert *and* erase — the workaround is removed.
- **`erase_symbol` leaked the base-name entry** (it never cleaned up `symbol_base_map`) and scanned the order vector in **O(n)**. It is now **O(1)** and consistent across indices.
- **Triplicate hand-maintenance** of three containers is gone.

## Notable choices

- **No base-name index.** The only base-name lookup is the once-per-run entry-point (`main`) search; it is now a linear scan (`foreach_named_symbol_with_base`, callback returns `bool` to stop early — the lambda equivalent of the old `break`). Insertion-order iteration is preserved, matching the old `std::multimap`, so the "first `--class`/`--contract` match wins" and the multiple-`main` ambiguity abort are unchanged. A third index maintained on every insert/erase is not worth a single startup query.
- **`move`/`move_symbol_to_context`** drop the old insert-tmp-then-swap in favour of a direct insert / in-place `modify`. `move` checks for an existing id first so a duplicate leaves the incoming symbol intact for `c_linkt::duplicate()` to merge.
- **New `contextt::reorder_symbol_to_back`** (O(1) sequenced `relocate`) replaces the erase-and-reinsert used to fix definition order when a struct's type is completed — eliminating that site's erase and the UAF workaround. The static-data-member site keeps `erase_symbol` because it must *replace* the incomplete symbol's contents (e.g. an array's real size), not merely reorder it.

## Testing

Full C++ regression suite (501) and the core C suite pass unchanged. A mid-development regression in multi-TU C++ linking (`ch8_4` — a class static array shrank to size 1) was caught and traced to over-simplifying the static-member site; reverting that one site to erase-then-readd restored correct behaviour.

Addresses #5050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
