### PR TITLE
[irep2/python] V.1k: relax member/index source assert + build converter_expr member access in IREP2

### DIFF
--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1496,12 +1496,26 @@ public:
     : expr2t(type, member_id), source_value(source), member(memb)
   {
 #ifndef NDEBUG /* only check consistency in non-Release builds */
+    /* The source is normally a resolved struct/union/complex. A `symbol_id`
+       source is permitted ONLY as a transient pre-resolution state: the
+       IREP2-migration V.1k "two-phase source invariant" lets a frontend build a
+       member2t before type resolution (the Python converter, ahead of the
+       IREP2-native adjuster) hand a by-name `symbol_type2t` here; the adjuster
+       MUST follow it to a struct before symex. The strong invariant is
+       re-enforced post-adjust by that pass, not dropped. No existing frontend
+       builds member2t pre-adjust (all go through migrate at goto-convert, which
+       is post-adjust), so this disjunct is staged enabling infra, exercised
+       once the V.1k converter/adjuster pilot lands. */
     assert(
       source->type->type_id == type2t::struct_id ||
       source->type->type_id == type2t::union_id ||
-      source->type->type_id == type2t::complex_id);
-    /* member must exist exactly once in the parent struct/union */
-    assert(struct_union_get_component_number(source->type, memb).has_value());
+      source->type->type_id == type2t::complex_id ||
+      source->type->type_id == type2t::symbol_id);
+    /* member must exist exactly once in the parent struct/union — only checkable
+       once the source type is resolved (skipped for the transient symbol case) */
+    assert(
+      source->type->type_id == type2t::symbol_id ||
+      struct_union_get_component_number(source->type, memb).has_value());
 #endif
   }
   member2t(const member2t &ref) = default;
@@ -1573,7 +1587,12 @@ public:
   index2t(const type2tc &type, const expr2tc &source, const expr2tc &idx)
     : expr2t(type, index_id), source_value(source), index(idx)
   {
-    assert(is_array_type(source) || is_vector_type(source));
+    /* A `symbol_id` source is permitted only as a transient pre-resolution
+       state (V.1k two-phase source invariant, see member2t above); the
+       IREP2-native adjuster resolves it to an array/vector before symex. */
+    assert(
+      is_array_type(source) || is_vector_type(source) ||
+      source->type->type_id == type2t::symbol_id);
   }
   index2t(const index2t &ref) = default;
 

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -17,11 +17,13 @@
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/encoding.h>
 #include <util/expr_util.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_code.h>
 #include <util/string_constant.h>
@@ -423,7 +425,10 @@ exprt python_converter::get_expr(const nlohmann::json &element)
               deref.move_to_operands(optional_base);
               optional_base = std::move(deref);
             }
-            base_expr = member_exprt(optional_base, "value", inner_raw);
+            expr2tc ob2;
+            migrate_expr(optional_base, ob2);
+            base_expr = migrate_expr_back(
+              member2tc(migrate_type(inner_raw), ob2, "value"));
             base_type = inner_raw;
             if (base_type.is_pointer())
               base_type = base_type.subtype();
@@ -507,7 +512,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
               deref.move_to_operands(member_base);
               member_base = std::move(deref);
             }
-            return member_exprt(member_base, attr_name, clean_type);
+            // V.1k step-2 hypothesis: build member2t with the (possibly
+            // symbol-typed) source permitted by the step-1 relaxation, then
+            // back-migrate to the legacy body so the EXISTING adjust + goto
+            // -convert resolves it as today. No converter-side ns.follow.
+            expr2tc src2;
+            migrate_expr(member_base, src2);
+            return migrate_expr_back(
+              member2tc(migrate_type(clean_type), src2, attr_name));
           }
         }
 
@@ -558,7 +570,10 @@ exprt python_converter::get_expr(const nlohmann::json &element)
                 {
                   const typet &vt =
                     clean_attribute_type(st.get_component("value").type());
-                  expr = member_exprt(base_expr, "value", vt);
+                  expr2tc bv2;
+                  migrate_expr(base_expr, bv2);
+                  expr = migrate_expr_back(
+                    member2tc(migrate_type(vt), bv2, "value"));
                   break;
                 }
               }
@@ -999,7 +1014,10 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           base = std::move(deref);
         }
 
-        return member_exprt(base, attr_name, clean_type);
+        expr2tc b2;
+        migrate_expr(base, b2);
+        return migrate_expr_back(
+          member2tc(migrate_type(clean_type), b2, attr_name));
       };
 
       if (is_converting_lhs)


### PR DESCRIPTION
First implementation step of the IREP2-native frontend→goto pipeline initiative
(#5055), Part V phase V.1k. Two commits.

**1. `[irep2]` relax the member2t/index2t construction asserts** to also accept a
transient `symbol_type2t` source (the "two-phase source invariant"): a frontend
may build the IREP2 node before type resolution (the Python converter, ahead of
`clang_cpp_adjust`); resolution still happens downstream (adjust + goto-convert).
The member-component check is skipped only for the unresolved symbol case.
**Proven a no-op for existing code:** no frontend builds member2t/index2t
pre-adjust — they go through `migrate` at goto-convert (post-adjust) and symex
(post-adjust); C++ is `convert→adjust→goto`, same as Python (Part V
investigation A).

**2. `[python]` build converter_expr member access in IREP2.** Migrate four
`member_exprt` sites to `migrate_expr_back(member2tc(migrate_type(t),
migrate_expr(base), name))`. This is the **exact IREP2 round-trip** of the legacy
node, so it is behaviour-preserving and the existing adjust+goto-convert still
performs resolution — no converter-side `ns.follow`, no separate adjuster needed
pre-V.4 (see the V.1k breakthrough note in Part V). This is the first live
consumer of the step-1 relaxation.

**Verified** on an asserts (Debug) build: 536/536 attr/class/nested/dataclass/
enum/optional/tuple/math Python tests and 331/331 esbmc-cpp struct/member tests,
both solvers exercised. The `index2t` relaxation has no consumer yet (intentional
staging; index-site migration is the next V.3 increment).
