### PR TITLE
[python] implement list.count() and list.index()

### DIFF
--- a/regression/python/list_count_index/main.py
+++ b/regression/python/list_count_index/main.py
@@ -1,0 +1,35 @@
+# list.count(x) and list.index(x). Previously these were misrouted to the
+# string handler (__python_str_count) and produced a non-deterministic result,
+# so even a correct assertion failed. They now walk the list comparing elements.
+a = [1, 2, 2, 3]
+assert a.count(2) == 2
+assert a.count(9) == 0
+assert a.count(1) == 1
+
+b = [10, 20, 30]
+assert b.index(20) == 1
+assert b.index(10) == 0
+
+# first match wins; string elements; use in a larger expression
+c = [5, 7, 5]
+assert c.index(5) == 0
+d = ["a", "b", "a"]
+assert d.count("a") == 2
+assert d.count("a") + d.index("b") == 3
+
+
+def via_param(lst: list) -> int:
+    return lst.count(2)
+
+
+assert via_param([2, 2, 2]) == 3
+
+# Dispatch guard: str and tuple count/index must keep routing to their own
+# handlers (the list change defers only list/tuple receivers out of the string
+# handler, never str receivers).
+s = "abcabc"
+assert s.count("a") == 2
+
+t = (1, 2, 2, 3)
+assert t.count(2) == 2
+assert t.index(2) == 1

--- a/regression/python/list_count_index/test.desc
+++ b/regression/python/list_count_index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_count_index_fail/main.py
+++ b/regression/python/list_count_index_fail/main.py
@@ -1,0 +1,3 @@
+# count returns the true number of matches; asserting a wrong value must fail.
+a = [1, 2, 2, 3]
+assert a.count(2) == 3

--- a/regression/python/list_count_index_fail/test.desc
+++ b/regression/python/list_count_index_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/list_index_absent_fail/main.py
+++ b/regression/python/list_index_absent_fail/main.py
@@ -1,0 +1,4 @@
+# list.index(x) raises ValueError when x is absent (modelled as a failing
+# assertion inside the operational model).
+a = [1, 2, 3]
+i = a.index(9)

--- a/regression/python/list_index_absent_fail/test.desc
+++ b/regression/python/list_index_absent_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -457,6 +457,54 @@ bool __ESBMC_list_contains(
   return false;
 }
 
+/* list.count(x) — number of elements equal to x. Mirrors __ESBMC_list_contains'
+ * element comparison (matching type_id, size, then value bytes). */
+size_t __ESBMC_list_count(
+  const PyListObject *l,
+  const void *item,
+  size_t item_type_id,
+  size_t item_size)
+{
+  __ESBMC_assert(l != NULL, "ValueError: list is null");
+
+  size_t cnt = 0;
+  size_t i = 0;
+  while (i < l->size)
+  {
+    const PyObject *elem = &l->items[i];
+    if (
+      elem->type_id == item_type_id && elem->size == item_size &&
+      __ESBMC_values_equal(elem->value, item, item_size))
+      ++cnt;
+    ++i;
+  }
+  return cnt;
+}
+
+/* list.index(x) — position of the first element equal to x. Raises ValueError
+ * (modelled as a failing assertion) when x is absent, matching CPython. */
+size_t __ESBMC_list_index(
+  const PyListObject *l,
+  const void *item,
+  size_t item_type_id,
+  size_t item_size)
+{
+  __ESBMC_assert(l != NULL, "ValueError: list is null");
+
+  size_t i = 0;
+  while (i < l->size)
+  {
+    const PyObject *elem = &l->items[i];
+    if (
+      elem->type_id == item_type_id && elem->size == item_size &&
+      __ESBMC_values_equal(elem->value, item, item_size))
+      return i;
+    ++i;
+  }
+  __ESBMC_assert(0, "ValueError: list.index(x): x not in list");
+  return 0;
+}
+
 /* ---------- extend list ---------- */
 
 void __ESBMC_list_extend(PyListObject *l, const PyListObject *other)

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -1547,6 +1547,40 @@ exprt function_call_expr::handle_list_remove() const
   return result;
 }
 
+exprt function_call_expr::handle_list_count() const
+{
+  const auto &args = call_["args"];
+  if (args.size() != 1)
+    throw std::runtime_error("list.count() takes exactly one argument");
+
+  std::string list_display_name;
+  const symbolt *list_symbol = get_object_list_symbol(list_display_name);
+  materialize_list_symbol(list_symbol);
+  if (!list_symbol)
+    throw std::runtime_error("List variable not found: " + list_display_name);
+
+  exprt value = converter_.get_expr(args[0]);
+  python_list list_helper(converter_, call_);
+  return list_helper.build_count_list_call(*list_symbol, call_, value);
+}
+
+exprt function_call_expr::handle_list_index() const
+{
+  const auto &args = call_["args"];
+  if (args.size() != 1)
+    throw std::runtime_error("list.index() takes exactly one argument");
+
+  std::string list_display_name;
+  const symbolt *list_symbol = get_object_list_symbol(list_display_name);
+  materialize_list_symbol(list_symbol);
+  if (!list_symbol)
+    throw std::runtime_error("List variable not found: " + list_display_name);
+
+  exprt value = converter_.get_expr(args[0]);
+  python_list list_helper(converter_, call_);
+  return list_helper.build_index_list_call(*list_symbol, call_, value);
+}
+
 exprt function_call_expr::handle_list_sort() const
 {
   const auto &args = call_["args"];
@@ -1735,8 +1769,21 @@ bool function_call_expr::is_list_method_call() const
     method_name != "clear" && method_name != "extend" &&
     method_name != "copy" && method_name != "sort" &&
     method_name != "reverse" && method_name != "popleft" &&
-    method_name != "appendleft")
+    method_name != "appendleft" && method_name != "count" &&
+    method_name != "index")
     return false;
+
+  // "count" / "index" are shared with str and tuple. Tuple receivers are
+  // claimed earlier (is_tuple_method_call); claim a list receiver here only
+  // when it resolves to a list symbol, so a str receiver falls through to the
+  // string handler.
+  if (method_name == "count" || method_name == "index")
+  {
+    std::string dummy;
+    const symbolt *sym = get_object_list_symbol(dummy);
+    const typet list_type = type_handler_.get_list_type();
+    return sym != nullptr && sym->get_type() == list_type;
+  }
 
   // "pop" is shared between list and dict. Disambiguate using the actual
   // symbol type: only treat as list.pop() when the receiver resolves to a
@@ -1806,6 +1853,10 @@ exprt function_call_expr::handle_list_method() const
     return handle_list_sort();
   if (method_name == "reverse")
     return handle_list_reverse();
+  if (method_name == "count")
+    return handle_list_count();
+  if (method_name == "index")
+    return handle_list_index();
   // Add other methods as needed
 
   throw std::runtime_error("Unsupported list method: " + method_name);

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -338,6 +338,8 @@ private:
   exprt handle_list_remove() const;
   exprt handle_list_sort() const;
   exprt handle_list_reverse() const;
+  exprt handle_list_count() const;
+  exprt handle_list_index() const;
 
   /*
    * Check if the current function call is to a regular expression module function

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4623,6 +4623,58 @@ exprt python_list::build_remove_list_call(
   return converter_.convert_expression_to_code(remove_call);
 }
 
+// list.count(x) / list.index(x): both pass (list, &value, type_id, size) to a
+// C model that walks the list comparing elements (same plumbing as remove), and
+// return a size_t value. `func_id` selects the model; the only difference is
+// index() asserts the element is present (handled inside the model).
+exprt python_list::build_count_index_list_call(
+  const symbolt &list,
+  const nlohmann::json &op,
+  const exprt &elem,
+  const std::string &func_id)
+{
+  list_elem_info elem_info = get_list_element_info(op, elem);
+
+  const symbolt *func = converter_.symbol_table().find_symbol(func_id);
+  if (!func)
+    throw std::runtime_error(func_id + " function not found in symbol table");
+
+  exprt element_arg;
+  if (
+    elem_info.elem_symbol->get_type().is_pointer() &&
+    elem_info.elem_symbol->get_type().subtype() == char_type())
+    element_arg = symbol_expr(*elem_info.elem_symbol);
+  else
+    element_arg = address_of_exprt(symbol_expr(*elem_info.elem_symbol));
+
+  side_effect_expr_function_callt call;
+  call.function() = symbol_expr(*func);
+  call.arguments().push_back(symbol_expr(list));                  // list
+  call.arguments().push_back(element_arg);                        // &value/ptr
+  call.arguments().push_back(symbol_expr(*elem_info.elem_type_sym)); // type_id
+  call.arguments().push_back(elem_info.elem_size);                // size
+  call.type() = size_type();
+  call.location() = elem_info.location;
+
+  return call;
+}
+
+exprt python_list::build_count_list_call(
+  const symbolt &list,
+  const nlohmann::json &op,
+  const exprt &elem)
+{
+  return build_count_index_list_call(list, op, elem, "c:@F@__ESBMC_list_count");
+}
+
+exprt python_list::build_index_list_call(
+  const symbolt &list,
+  const nlohmann::json &op,
+  const exprt &elem)
+{
+  return build_count_index_list_call(list, op, elem, "c:@F@__ESBMC_list_index");
+}
+
 size_t python_list::get_list_type_map_size(const std::string &list_id)
 {
   auto it = list_type_map.find(list_id);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4647,12 +4647,13 @@ exprt python_list::build_count_index_list_call(
   else
     element_arg = address_of_exprt(symbol_expr(*elem_info.elem_symbol));
 
+  // Args: (list, &value-or-ptr, type_id, size) — same shape as the remove call.
   side_effect_expr_function_callt call;
   call.function() = symbol_expr(*func);
-  call.arguments().push_back(symbol_expr(list));                  // list
-  call.arguments().push_back(element_arg);                        // &value/ptr
-  call.arguments().push_back(symbol_expr(*elem_info.elem_type_sym)); // type_id
-  call.arguments().push_back(elem_info.elem_size);                // size
+  call.arguments().push_back(symbol_expr(list));
+  call.arguments().push_back(element_arg);
+  call.arguments().push_back(symbol_expr(*elem_info.elem_type_sym));
+  call.arguments().push_back(elem_info.elem_size);
   call.type() = size_type();
   call.location() = elem_info.location;
 

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -240,6 +240,33 @@ public:
     const exprt &elem);
 
   /**
+   * @brief Build a list.count(x) call — number of elements equal to x.
+   * Returns a size_t-typed value expression.
+   */
+  exprt build_count_list_call(
+    const symbolt &list,
+    const nlohmann::json &op,
+    const exprt &elem);
+
+  /**
+   * @brief Build a list.index(x) call — position of the first element equal to
+   * x. Raises ValueError (via assertion) if x is not found. Returns a
+   * size_t-typed value expression.
+   */
+  exprt build_index_list_call(
+    const symbolt &list,
+    const nlohmann::json &op,
+    const exprt &elem);
+
+  /// Shared implementation of build_count_list_call / build_index_list_call;
+  /// @p func_id selects the `c:@F@__ESBMC_list_{count,index}` model.
+  exprt build_count_index_list_call(
+    const symbolt &list,
+    const nlohmann::json &op,
+    const exprt &elem,
+    const std::string &func_id);
+
+  /**
    * @brief Emit a call to a set membership-mutating C model function.
    *
    * Used to implement set.add() and set.discard(): both wrap the same C

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1932,13 +1932,17 @@ exprt string_handler::handle_string_attribute_call(
     return *cached_receiver_expr;
   };
 
-  // Tuple receivers reuse method names that overlap with string methods
-  // (count, index). Defer to the regular dispatch table so the tuple-aware
-  // handler runs instead of evaluating those as string methods.
+  // Tuple and list receivers reuse method names that overlap with string
+  // methods (count, index). Defer to the regular dispatch table so the
+  // tuple-/list-aware handlers run instead of evaluating those as str methods.
   if (method_name == "count" || method_name == "index")
   {
     exprt recv = get_receiver_expr();
-    if (converter_.get_tuple_handler().is_tuple_type(recv.type()))
+    const typet list_type = converter_.get_type_handler().get_list_type();
+    if (
+      converter_.get_tuple_handler().is_tuple_type(recv.type()) ||
+      recv.type() == list_type ||
+      (recv.type().is_pointer() && recv.type().subtype() == list_type))
       return nil_exprt();
   }
 


### PR DESCRIPTION
## What

Implements `list.count(x)` and `list.index(x)`, which previously gave **false alarms**.

```python
a = [1, 2, 2, 3]
assert a.count(2) == 2     # was VERIFICATION FAILED (nondeterministic result)
b = [10, 20, 30]
assert b.index(20) == 1    # was VERIFICATION FAILED
```

## Root cause

`list.count`/`list.index` were misrouted to the **string** handler (`__python_str_count`):
- `is_list_method_call` did not claim `count`/`index`; and
- `handle_string_attribute_call` (which runs *before* the method dispatch table, `builder.cpp:607`) deferred `count`/`index` only for **tuple** receivers — not list receivers.

So a list receiver was evaluated as a string method and produced a non-deterministic value, failing even correct assertions.

## Fix

1. **Operational models** (`src/c2goto/library/python/list.c`): `__ESBMC_list_count` and `__ESBMC_list_index` walk the list with the same element-equality predicate as the existing `__ESBMC_list_contains`/`__ESBMC_list_remove` (`type_id` + `size` + `__ESBMC_values_equal`). `index` raises `ValueError` (a failing assertion) when the element is absent, matching CPython. (Auto-registered by `scripts/gen_python_c_models.py`.)
2. **Frontend plumbing** (`python_list.cpp`): `build_count_list_call`/`build_index_list_call` (shared `build_count_index_list_call`) emit a `size_t`-typed side-effect call, reusing `build_remove_list_call`'s argument construction.
3. **Dispatch** (`function_call/expr.cpp`): `is_list_method_call` claims `count`/`index` only when the receiver resolves to a list symbol (the same disambiguation `pop`/`copy` use); `handle_list_method` routes to new `handle_list_count`/`handle_list_index`.
4. **String handler** (`string/string_handler.cpp`): extend the existing tuple deferral so `count`/`index` on a **list** (or pointer-to-list) receiver also fall through to the dispatch table — `str` receivers are untouched.

## Validation

- New tests: `list_count_index` (SUCCESSFUL — duplicates, zero matches, first-match `index`, string elements, compound expression, `list`-typed parameter, **plus `str.count` and `tuple.count`/`index` to lock the dispatch routing**), `list_count_index_fail` (wrong count → FAILED), `list_index_absent_fail` (absent → ValueError/FAILED).
- CPython sanity passes; verdicts agree under **Bitwuzla and Z3**.
- **866/867 list/str/tuple/set/dict tests pass** — the only failure is the pre-existing boolector-not-built environmental test. No regressions.
- A `code-reviewer` pass confirmed the dispatch precedence is correct for all receiver types (str→string, tuple→tuple, list→list) with 0 critical/major findings.

## Known limitation (pre-existing, not a regression)

A list-*literal* receiver (`[1,2,3].count(2)`) is not resolved to a symbol by `get_object_list_symbol`, so it still falls through to the old behaviour. This was already broken before the patch; the variable-receiver case (the common one) is now correct. A follow-up could materialise the literal into a temp list symbol.
