### PR TITLE
[python] fix list.extend() leaving the list size non-deterministic

### DIFF
--- a/regression/python/list_extend_fail/main.py
+++ b/regression/python/list_extend_fail/main.py
@@ -1,0 +1,4 @@
+# After extend the list has 4 elements, not 5; asserting otherwise must fail.
+a = [1, 2]
+a.extend([3, 4])
+assert len(a) == 5

--- a/regression/python/list_extend_fail/test.desc
+++ b/regression/python/list_extend_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/list_extend_inplace/main.py
+++ b/regression/python/list_extend_inplace/main.py
@@ -1,0 +1,29 @@
+# list.extend(other) appends every element of `other` in place. The operational
+# model previously copied each element with an inline alloca+memcpy whose
+# per-byte loop, nested inside the extend loop, left the resulting list size
+# unconstrained in the SMT model -- so even len() after a non-empty extend was
+# non-deterministic and correct assertions failed.
+a = [1, 2]
+a.extend([3, 4])
+assert len(a) == 4
+assert a == [1, 2, 3, 4]
+assert a[2] == 3
+
+# extending by a variable, and chaining
+b = [5]
+c = [6, 7]
+b.extend(c)
+b.extend([8])
+assert b == [5, 6, 7, 8]
+
+# empty extend is a no-op; float elements keep their value
+d = [1.5]
+d.extend([])
+d.extend([2.5, 3.5])
+assert len(d) == 3
+assert d[1] == 2.5 and d[2] == 3.5
+
+# string elements
+e = ["x"]
+e.extend(["y", "z"])
+assert e[2] == "z"

--- a/regression/python/list_extend_inplace/test.desc
+++ b/regression/python/list_extend_inplace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -469,8 +469,13 @@ void __ESBMC_list_extend(PyListObject *l, const PyListObject *other)
   {
     const PyObject *elem = &other->items[i];
 
-    void *copied_value = __ESBMC_alloca(elem->size);
-    memcpy(copied_value, elem->value, elem->size);
+    // Reuse the same value-copy helper as __ESBMC_list_push instead of an
+    // inline alloca+memcpy: memcpy's per-byte loop nested inside this loop
+    // left the resulting list's size unconstrained in the SMT model, so even
+    // len() after extend() became nondeterministic. float elements keep their
+    // original float_idx (copied below), so reads still hit __ESBMC_float_buf.
+    void *copied_value =
+      __ESBMC_copy_value(elem->value, elem->size, elem->type_id, 0, NULL, 0);
 
     l->items[l->size].value = copied_value;
     l->items[l->size].float_idx = elem->float_idx;


### PR DESCRIPTION
## What

Fixes a wrong-verdict bug in `list.extend(other)`: after a **non-empty** extend, even `len(a)` was non-deterministic.

```python
a = [1, 2]
a.extend([3, 4])
assert len(a) == 4      # was VERIFICATION FAILED (size unconstrained)
```

`a.extend([])` worked; `a.append(x)` worked — only multi-element `extend` was broken.

## Root cause

`__ESBMC_list_extend` (operational model) copied each element with an inline
`void *copied = __ESBMC_alloca(elem->size); memcpy(copied, elem->value, elem->size);`.
`memcpy` lowers to a per-byte loop; nested inside the extend `while` loop it left the resulting list's `size` **unconstrained in the SMT model**, so `len()` after a non-empty extend became non-deterministic and correct assertions failed.

`append` was unaffected because it copies through the shared `__ESBMC_copy_value` helper, which has 8/16/24/32-byte fast-path assignments and only falls back to `memcpy` for unusual sizes.

## Fix

Replace the inline `alloca`+`memcpy` in `__ESBMC_list_extend` with the same `__ESBMC_copy_value(elem->value, elem->size, elem->type_id, /*float_type_id=*/0, /*out_float_idx=*/NULL, /*ptr_free=*/0)` call that `__ESBMC_list_push` and the existing list-copy routine use. The per-element field copies and `l->size++` are unchanged; `float_idx` is still carried from the source element so float values keep reading from `__ESBMC_float_buf`. One-function, ~6-line OM change.

## Validation

- New tests: `list_extend_inplace` (SUCCESSFUL — `len`/equality/element after extend, variable + chained extends, empty no-op, **float** elements via `float_idx`, string elements) and `list_extend_fail` (wrong length → FAILED).
- The existing `list_extend` THOROUGH test and `list_extend2/3/4/8` still pass with my fix (no regression); CPython sanity passes; verdicts agree under **Bitwuzla and Z3**.
- list/append/pop/insert sweep: only the pre-existing boolector-not-built environmental failure.
- A `code-reviewer` pass confirmed the copy is semantically equivalent-or-better for every element type (int/bool/float/str/pointer), matching the established `__ESBMC_copy_value` pattern, with 0 critical/major findings.
