### PR TITLE
[python] V.3: build converter array/char index access in IREP2 (index2tc)

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -9,11 +9,13 @@
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_typecast.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
@@ -881,10 +883,18 @@ exprt python_converter::handle_array_operations(
                             : typecast_exprt(scalar_expr, elem_type);
 
     exprt result_array = array_expr;
+    // V.3: build the array element access in IREP2 (index2tc), the exact
+    // round-trip of index_exprt (behaviour-preserving). The array and element
+    // type are loop-invariant, so migrate them once.
+    expr2tc ar2;
+    migrate_expr(array_expr, ar2);
+    const type2tc elem_t2 = migrate_type(elem_type);
     for (long long i = 0; i < array_size; ++i)
     {
       exprt index = from_integer(i, size_type());
-      index_exprt array_item(array_expr, index, elem_type);
+      expr2tc ix2;
+      migrate_expr(index, ix2);
+      exprt array_item = migrate_expr_back(index2tc(elem_t2, ar2, ix2));
       exprt bin_elem(python_frontend::map_operator(op, elem_type), elem_type);
       bin_elem.copy_to_operands(array_item, casted_scalar);
       result_array = with_exprt(result_array, index, bin_elem);

--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -2,8 +2,10 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/string/string_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 
 std::pair<exprt, exprt> python_converter::resolve_comparison_operands_internal(
@@ -276,7 +278,13 @@ exprt python_converter::handle_string_comparison(
     auto char_at_index = [&](const exprt &expr, int idx) -> exprt {
       exprt index = from_integer(idx, index_type());
       if (expr.type().is_array())
-        return index_exprt(expr, index, char_type());
+      {
+        // V.3: IREP2 index access (exact round-trip of index_exprt).
+        expr2tc a2, i2;
+        migrate_expr(expr, a2);
+        migrate_expr(index, i2);
+        return migrate_expr_back(index2tc(migrate_type(char_type()), a2, i2));
+      }
 
       exprt ptr = expr;
       if (!ptr.type().is_pointer())


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction in the converter) for the
IREP2-native frontend→goto pipeline initiative (#5055), giving the step-1
`index2t` assert relaxation (#5061) its first live consumers.

Migrates two **array-sourced** `index_exprt` sites to `index2tc` via the
exact-round-trip pattern (`migrate_expr_back(index2tc(migrate_type(t),
migrate(arr), migrate(idx))) == index_exprt(arr, idx, t)`):
- `converter_binop.cpp` — numpy element-wise array-op element access (the array
  and element type are loop-invariant, migrated once).
- `converter_compare.cpp` — string char-at, inside `if (expr.type().is_array())`.

Both sources are provably array-typed (the compare site is guarded; the binop
site is double-guarded — `lhs.type().is_array()` at the call site and a re-check
inside the lambda), so `index2t`'s array/vector/symbol precondition holds and no
pointer-source abort is possible. Behaviour-preserving; the existing
adjust+goto-convert still resolves downstream.

Verified on an asserts build: 774/774 relevant string/compare/numpy/array/index/
list tests green (1 boolector-only env failure, baseline-identical), both solvers
exercised; code-reviewer confirmed source-type safety and round-trip exactness.
The OM-handler index sites (`python_list` etc., RP5) and the pointer-ambiguous
`converter_stmt` site are left for careful follow-ups.
