### PR TITLE
[python] V.3: migrate remaining converter-core member/index sites to IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1024,10 +1024,16 @@ exprt python_converter::handle_tuple_operations(
       tuple_handler_->create_tuple_struct_type(element_types);
 
     struct_exprt result(new_type);
+    // V.3: IREP2 tuple-component access (exact round-trip of member_exprt).
+    expr2tc lhs2, rhs2;
+    migrate_expr(lhs, lhs2);
+    migrate_expr(rhs, rhs2);
     for (const auto &c : lhs_components)
-      result.copy_to_operands(member_exprt(lhs, c.get_name(), c.type()));
+      result.copy_to_operands(migrate_expr_back(
+        member2tc(migrate_type(c.type()), lhs2, c.get_name())));
     for (const auto &c : rhs_components)
-      result.copy_to_operands(member_exprt(rhs, c.get_name(), c.type()));
+      result.copy_to_operands(migrate_expr_back(
+        member2tc(migrate_type(c.type()), rhs2, c.get_name())));
 
     if (element.contains("lineno"))
       result.location() = get_location_from_decl(element);
@@ -1064,9 +1070,13 @@ exprt python_converter::handle_tuple_operations(
       tuple_handler_->create_tuple_struct_type(element_types);
 
     struct_exprt result(new_type);
+    // V.3: IREP2 tuple-component access (exact round-trip of member_exprt).
+    expr2tc tuple2;
+    migrate_expr(tuple, tuple2);
     for (size_t i = 0; i < n; ++i)
       for (const auto &c : components)
-        result.copy_to_operands(member_exprt(tuple, c.get_name(), c.type()));
+        result.copy_to_operands(migrate_expr_back(
+          member2tc(migrate_type(c.type()), tuple2, c.get_name())));
 
     if (element.contains("lineno"))
       result.location() = get_location_from_decl(element);

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -6,9 +6,11 @@
 #include <python-frontend/symbol_id.h>
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_code.h>
 
@@ -68,7 +70,13 @@ exprt python_converter::make_enum_member_struct_expr(
   // name component: char* pointer to the first element of the name string
   exprt str_expr = symbol_expr(*str_sym);
   exprt zero_idx = from_integer(0, index_type());
-  exprt name_ptr = address_of_exprt(index_exprt(str_expr, zero_idx));
+  // V.3: IREP2 index access (exact round-trip of index_exprt); str_sym is a
+  // static char-array symbol, so the source is array-typed.
+  expr2tc se2, zi2;
+  migrate_expr(str_expr, se2);
+  migrate_expr(zero_idx, zi2);
+  exprt name_ptr = address_of_exprt(migrate_expr_back(
+    index2tc(migrate_type(str_expr.type().subtype()), se2, zi2)));
   name_ptr.type() = gen_pointer_type(char_type());
   struct_val.operands().push_back(name_ptr);
 
@@ -119,8 +127,11 @@ exprt python_converter::create_member_expression(
   if (!source_type.is_struct() && !source_type.is_union())
     return gen_zero(clean_type);
 
-  member_exprt member_expr(source, attr_name, clean_type);
-  return member_expr;
+  // V.3: IREP2 member access (exact round-trip of member_exprt). `source` is
+  // struct/union (checked above) or a by-name symbol; both are valid sources.
+  expr2tc s2;
+  migrate_expr(source, s2);
+  return migrate_expr_back(member2tc(migrate_type(clean_type), s2, attr_name));
 }
 
 // Register instance attribute in maps

--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -409,7 +409,11 @@ exprt python_converter::try_lower_slice_member_is_none(
     return nil_exprt();
   const typet flag_type = slice_struct.get_component(flag_name).type();
 
-  member_exprt flag_access(member_side->op0(), flag_name, flag_type);
+  // V.3: IREP2 member access (exact round-trip of member_exprt).
+  expr2tc fb2;
+  migrate_expr(member_side->op0(), fb2);
+  exprt flag_access =
+    migrate_expr_back(member2tc(migrate_type(flag_type), fb2, flag_name));
   // `sl.start is None` ⇔ flag is zero (bound was absent).
   // `sl.start is not None` ⇔ flag is non-zero (bound was supplied).
   equality_exprt eq(flag_access, gen_zero(flag_type));

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -969,8 +969,11 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         const typet &attr_type = target_struct.get_component(attr_name).type();
         typet clean_type = clean_attribute_type(attr_type);
 
-        member_exprt member_expr(deref_expr, attr_name, clean_type);
-        expr = member_expr;
+        // V.3: IREP2 member access (exact round-trip of member_exprt).
+        expr2tc de2;
+        migrate_expr(deref_expr, de2);
+        expr = migrate_expr_back(
+          member2tc(migrate_type(clean_type), de2, attr_name));
         break;
       }
 

--- a/src/python-frontend/converter/converter_types.cpp
+++ b/src/python-frontend/converter/converter_types.cpp
@@ -55,8 +55,8 @@ exprt python_converter::unwrap_optional_if_needed(
     // Extract the value field. V.3: IREP2 member access (round-trip).
     expr2tc b2;
     migrate_expr(base, b2);
-    return migrate_expr_back(member2tc(
-      migrate_type(struct_type.components()[1].type()), b2, "value"));
+    return migrate_expr_back(
+      member2tc(migrate_type(struct_type.components()[1].type()), b2, "value"));
   }
 
   return expr;

--- a/src/python-frontend/converter/converter_types.cpp
+++ b/src/python-frontend/converter/converter_types.cpp
@@ -3,8 +3,10 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/c_types.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 
 #include <algorithm>
@@ -50,9 +52,11 @@ exprt python_converter::unwrap_optional_if_needed(
       base = symbol_expr(tmp);
     }
 
-    // Extract the value field
-    member_exprt value_field(base, "value", struct_type.components()[1].type());
-    return value_field;
+    // Extract the value field. V.3: IREP2 member access (round-trip).
+    expr2tc b2;
+    migrate_expr(base, b2);
+    return migrate_expr_back(member2tc(
+      migrate_type(struct_type.components()[1].type()), b2, "value"));
   }
 
   return expr;


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction in the converter) for the
IREP2-native frontend→goto pipeline initiative (#5055), migrating the remaining
**converter-core** member/index sites whose source is provably non-pointer.

Eight `member_exprt`/`index_exprt` sites → `member2tc`/`index2tc` via the
exact-round-trip pattern (behaviour-preserving; existing adjust+goto-convert
still resolves downstream):
- `converter_expr.cpp` — member over a dereferenced struct base
- `converter_binop.cpp` — tuple-component access (3 sites; tuple structs)
- `converter_compare.cpp` — slice `has_<bound>` flag member (slice struct)
- `converter_class.cpp` — enum-name char index (static char-array symbol) and
  `create_member_expression` (struct/union-guarded or by-name symbol)
- `converter_types.cpp` — optional/complex `.value` field (struct base)

The load-bearing check (a pointer source would abort `member2t`/`index2t`): each
migrated source is array/struct/union/symbol-typed — verified per-site and
independently confirmed in review. Verified on an asserts build: 853/853
attr/class/nested/tuple/slice/enum/optional/complex/dataclass/string/compare
tests green, both solvers exercised; the existing suite is the contract
regression.

Deferred with reasons: the dict-`.keys` member sites (converter_unop/funcall/
stmt) and the `converter_stmt` subscript site have potentially pointer-typed
sources and belong with the OM-handler phase (RP5).
