### PR TITLE
[goto-symex] fix segfault on assertion in a catch-all handler

### DIFF
--- a/regression/esbmc-cpp/try_catch/try-catch-ellipsis-assert/main.cpp
+++ b/regression/esbmc-cpp/try_catch/try-catch-ellipsis-assert/main.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+
+// Regression for a symex segfault: an assert as the *first* instruction of a
+// catch(...) handler that catches a thrown object. The catch-all target points
+// straight at the ASSERT goto instruction (nil `code` field); the pre-fix
+// throw-dispatch dereferenced it and crashed. The assertion holds here.
+int main()
+{
+  int x = 0;
+  try
+  {
+    throw 42;
+  }
+  catch (...)
+  {
+    assert(x == 0);
+  }
+  assert(x == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/try-catch-ellipsis-assert/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch-ellipsis-assert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_except_catchall_assert/main.py
+++ b/regression/python/try_except_catchall_assert/main.py
@@ -1,0 +1,12 @@
+# Regression for a symex segfault: an assertion as the *first* instruction of a
+# catch-all `except:` handler that catches a live thrown exception. The catch-all
+# binds no exception variable, so its target points straight at the ASSERT goto
+# instruction, whose `code` field is nil; the pre-fix throw-dispatch dereferenced
+# it and crashed. The assertion here holds, so verification must succeed.
+state = 0
+try:
+    raise ValueError("boom")
+except:
+    assert state == 0
+
+assert state == 0

--- a/regression/python/try_except_catchall_assert/test.desc
+++ b/regression/python/try_except_catchall_assert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_except_catchall_assert_fail/main.py
+++ b/regression/python/try_except_catchall_assert_fail/main.py
@@ -1,0 +1,9 @@
+# The catch-all handler runs and its assertion fails: ESBMC must report the
+# violation rather than crash.
+state = 0
+try:
+    raise ValueError("boom")
+except:
+    assert state == 1
+
+assert False

--- a/regression/python/try_except_catchall_assert_fail/test.desc
+++ b/regression/python/try_except_catchall_assert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -406,15 +406,20 @@ void goto_symext::update_throw_target(
   expr2tc operand = throw_insn.operand;
   symex_assign(code_assign2tc(thrown_obj, operand));
 
-  // Now record that value for future reference.
-  if (!is_pointer_type(target->code->type))
-    cur_state->rename(thrown_obj);
-
   // Target is, as far as I can tell, always a declaration of the variable
   // that the thrown obj ends up in, and is followed by a (blank) assignment
   // to it. So point at the next insn.
+  //
+  // An ellipsis (catch-all) handler binds no exception variable: its target
+  // points straight at the first instruction of the handler body, which may be
+  // an ASSERT/ASSUME/GOTO whose `code` field is nil. Only inspect target->code
+  // (and record the thrown object for the bound variable) when one exists.
   if (!is_ellipsis)
   {
+    // Now record that value for future reference.
+    if (!is_pointer_type(target->code->type))
+      cur_state->rename(thrown_obj);
+
     assert(is_code_decl2t(target->code));
     target++;
     assert(is_code_assign2t(target->code));


### PR DESCRIPTION
## Problem

ESBMC segfaults whenever an **assertion (or any nil-`code` instruction) is the first statement of a catch-all handler** that catches a live thrown exception. This affects both frontends:

```python
try:
    raise ValueError()
except:            # catch-all (ellipsis) handler
    assert True    # <-- segfault
```

```cpp
int main() {
  int x = 0;
  try { throw 42; }
  catch (...) { assert(x == 0); }   // <-- segfault
}
```

Typed handlers (`except ValueError:`, `catch(int)`) and catch-all handlers whose first statement happens to be an assignment are unaffected — which is why the crash went unnoticed.

## Root cause

In `goto_symext::update_throw_target` (`src/goto-symex/symex_catch.cpp`), the throw-dispatch logic unconditionally evaluated `target->code->type` to decide whether to rename the thrown object:

```cpp
if (!is_pointer_type(target->code->type))
  cur_state->rename(thrown_obj);
```

For a **typed/bound** catch, `target` is the DECL of the exception variable, so `target->code` is non-nil. For an **ellipsis** catch-all there is no bound variable: `target` points straight at the first instruction of the handler body. When that instruction is an `ASSERT`/`ASSUME`/`GOTO`, its `code` field is nil (the condition lives in `guard`), so `target->code->type` dereferences a null pointer.

The GOTO for the crashing case makes this explicit:

```
CATCH ellipsis->1
THROW ValueError, ...
CATCH
GOTO 2
1: ASSERT 1          // <-- catch target; nil `code`
2: END_FUNCTION
```

## Fix

Move the `target->code->type` inspection and the associated `cur_state->rename(thrown_obj)` inside the existing `if (!is_ellipsis)` block. The renamed thrown object is consumed only through `thrown_obj_map`, which is populated solely in that block, so for catch-all handlers the rename was already a no-op — there is no bound variable to receive the value. No verification verdict changes for any typed or catch-all case; the only effect is that the nil dereference no longer happens.

## Validation

- **Pre-fix vs post-fix:** the new passing and failing Python tests and the new C++ test all **segfault on the pre-fix binary** and produce the correct verdict (SUCCESSFUL / FAILED) after the fix.
- **Dual-solver agreement:** Bitwuzla and Z3 agree on all new tests.
- **No regressions:** `regression/esbmc-cpp/try_catch` (83), `esbmc-cpp` exception tests (89), and `regression/python/exception*` (18) all pass.
- **CPython sanity:** `scripts/check_python_tests.sh` passes for the new Python tests.

## Tests

- `regression/python/try_except_catchall_assert` — catch-all handler with a holding assertion → SUCCESSFUL (segfaults pre-fix).
- `regression/python/try_except_catchall_assert_fail` — catch-all handler with a violated assertion → FAILED (segfaults pre-fix).
- `regression/esbmc-cpp/try_catch/try-catch-ellipsis-assert` — C++ `catch(...)` with an assertion → SUCCESSFUL (segfaults pre-fix).