### PR TITLE
[python] support try/finally in the Python frontend

### DIFF
--- a/regression/python/try_else_no_finally/main.py
+++ b/regression/python/try_else_no_finally/main.py
@@ -1,0 +1,13 @@
+# `try/except/else` WITHOUT a finally must NOT be refused (the else-clause
+# refusal is scoped to try/finally). Here the exception is raised and caught, so
+# the else branch is not taken and the program completes normally. Guards
+# against re-introducing an over-aggressive else refusal (cf. github_3090).
+x = 0
+try:
+    raise ValueError()
+except ValueError:
+    x = 1
+else:
+    x = 2
+
+assert x == 1

--- a/regression/python/try_else_no_finally/test.desc
+++ b/regression/python/try_else_no_finally/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_finally/main.py
+++ b/regression/python/try_finally/main.py
@@ -1,0 +1,20 @@
+# `finally` must run on both the normal-completion path and after a caught
+# exception. Each block records a distinct contribution so the final assert
+# fails if any finally (or handler) were skipped or run twice.
+log = 0
+
+# Normal completion: try body then finally.
+try:
+    log = log + 1
+finally:
+    log = log + 10
+
+# Caught exception: handler then finally.
+try:
+    raise ValueError("e")
+except ValueError:
+    log = log + 100
+finally:
+    log = log + 1000
+
+assert log == 1111

--- a/regression/python/try_finally/test.desc
+++ b/regression/python/try_finally/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_finally_bare_except/main.py
+++ b/regression/python/try_finally_bare_except/main.py
@@ -1,0 +1,13 @@
+# A bare `except:` catches every exception, so the program completes normally
+# and the finally runs after the handler. Regression for a catch_map collision:
+# the synthetic finally-rethrow handler must not overwrite the user's bare
+# `except:` (both lower to the "ellipsis" exception id).
+x = 0
+try:
+    raise ValueError()
+except:
+    x = 1
+finally:
+    x = x + 10
+
+assert x == 11

--- a/regression/python/try_finally_bare_except/test.desc
+++ b/regression/python/try_finally_bare_except/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_finally_else/main.py
+++ b/regression/python/try_finally_else/main.py
@@ -1,0 +1,15 @@
+# The `else` clause of a try runs only when the body completes without an
+# exception, and its own exceptions are not caught by this try's handlers.
+# ESBMC's lowering does not model that, so a non-empty `else` is refused
+# rather than silently dropped. (Valid Python; runs cleanly under CPython.)
+x = 0
+try:
+    x = 1
+except ValueError:
+    x = 2
+else:
+    x = 3
+finally:
+    x = 4
+
+print(x)

--- a/regression/python/try_finally_else/test.desc
+++ b/regression/python/try_finally_else/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --unwind 1
-^ERROR: try with a non-empty else clause is not supported$
+^ERROR: try/finally with a non-empty else clause is not supported$

--- a/regression/python/try_finally_else/test.desc
+++ b/regression/python/try_finally_else/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^ERROR: try with a non-empty else clause is not supported$

--- a/regression/python/try_finally_nested_loop_break/main.py
+++ b/regression/python/try_finally_nested_loop_break/main.py
@@ -1,0 +1,13 @@
+# A break that targets a loop *nested inside* the try does not escape the try,
+# so it must NOT be refused: the loop captures the break and the finally still
+# runs on the fall-through path. Pins the in-loop boundary of the escape check.
+x = 0
+try:
+    for i in range(3):
+        if i == 1:
+            break
+    x = 1
+finally:
+    x = x + 10
+
+assert x == 11

--- a/regression/python/try_finally_nested_loop_break/test.desc
+++ b/regression/python/try_finally_nested_loop_break/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_finally_no_except/main.py
+++ b/regression/python/try_finally_no_except/main.py
@@ -1,0 +1,10 @@
+# Bare `try`/`finally` with no `except`. This used to abort during conversion
+# (a cpp-catch needs >= 2 operands); the finally-rethrow catch-all now supplies
+# the second operand, and finally runs on the normal-completion path.
+x = 0
+try:
+    x = 1
+finally:
+    x = x + 10
+
+assert x == 11

--- a/regression/python/try_finally_no_except/test.desc
+++ b/regression/python/try_finally_no_except/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_finally_return/main.py
+++ b/regression/python/try_finally_return/main.py
@@ -1,0 +1,12 @@
+# A return/break/continue that escapes a try with a finally is rejected: the
+# current lowering appends the finally on the fall-through path, which such a
+# jump would bypass. ESBMC refuses it rather than return an unsound verdict.
+# (This is valid Python, so it runs cleanly under CPython.)
+def h() -> int:
+    try:
+        return 1
+    finally:
+        pass
+
+
+print(h())

--- a/regression/python/try_finally_return/test.desc
+++ b/regression/python/try_finally_return/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^ERROR: try/finally with return/break/continue in the try, except, or finally body is not supported$

--- a/regression/python/try_finally_return_in_handler/main.py
+++ b/regression/python/try_finally_return_in_handler/main.py
@@ -1,0 +1,14 @@
+# A return inside an except handler escapes the try; the appended finally on
+# the fall-through path would be bypassed, so this shape is refused rather than
+# verified unsoundly. (Valid Python -- finally runs before the return under
+# CPython, so it executes cleanly and exits 0 here.)
+def f() -> int:
+    try:
+        raise ValueError()
+    except ValueError:
+        return 1
+    finally:
+        pass
+
+
+print(f())

--- a/regression/python/try_finally_return_in_handler/test.desc
+++ b/regression/python/try_finally_return_in_handler/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^ERROR: try/finally with return/break/continue in the try, except, or finally body is not supported$

--- a/regression/python/try_finally_uncaught_fail/main.py
+++ b/regression/python/try_finally_uncaught_fail/main.py
@@ -1,0 +1,10 @@
+# `finally` must run even when the exception is not caught by any handler:
+# the handler does not match, so control reaches finally, runs it, and then
+# the exception re-propagates. The `assert False` inside finally is reachable
+# only if finally executes on this uncaught path -- it pins that behaviour.
+try:
+    raise ValueError("e")
+except KeyError:
+    pass
+finally:
+    assert False

--- a/regression/python/try_finally_uncaught_fail/test.desc
+++ b/regression/python/try_finally_uncaught_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$
+^Violated property:$
+main.py line 10

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -65,15 +65,137 @@ void python_exception_handler::get_try_statement(
     return;
   }
 
-  exprt new_expr = codet("cpp-catch");
+  // ESBMC's try lowering does not model the `else` clause: its body runs only
+  // when the try block completes without an exception, and (unlike the try
+  // body) exceptions it raises are not caught by this try's handlers. The
+  // current lowering would silently drop it, so refuse a non-empty `else`
+  // rather than return an unsound verdict.
+  if (element.contains("orelse") && !element["orelse"].empty())
+    throw std::runtime_error(
+      "try with a non-empty else clause is not supported");
+
+  const bool has_finally =
+    element.contains("finalbody") && !element["finalbody"].empty();
+
+  // Python's `finally` runs on every exit path: normal completion, a caught
+  // exception, an *uncaught* exception (run finally, then re-raise), and a
+  // return/break/continue that leaves the try. We model the first three by
+  // duplicating the finally body on the normal path (after the try/catch) and
+  // inside a catch-all handler that re-raises. A return/break/continue inside
+  // the try body, an except handler, or the finally body would bypass that
+  // appended finally and silently change the result, so refuse those with a
+  // clean diagnostic rather than return an unsound verdict.
+  if (has_finally)
+  {
+    bool escapes = body_has_escaping_control_flow(element["body"], false) ||
+                   body_has_escaping_control_flow(element["finalbody"], false);
+    for (const auto &h : element["handlers"])
+      if (h.contains("body"))
+        escapes = escapes || body_has_escaping_control_flow(h["body"], false);
+    if (escapes)
+      throw std::runtime_error(
+        "try/finally with return/break/continue in the try, except, or finally "
+        "body is not supported");
+  }
+
   exprt try_block = converter_.get_block(element["body"]);
   exprt handler = converter_.get_block(element["handlers"]);
+
+  // A bare `except:` already catches every exception, so the fall-through
+  // finally below runs after it on the exception path too. Appending a second
+  // catch-all here would collide with the user's one in symex's catch_map
+  // (both lower to the "ellipsis" exception id, and the later entry wins),
+  // dropping the user's handler. So synthesise the finally-rethrow catch-all
+  // only when no bare `except:` is present.
+  bool has_catch_all = false;
+  for (const auto &h : element["handlers"])
+    if (h["type"].is_null())
+      has_catch_all = true;
+
+  // Build a catch-all handler `{ finally; re-raise; }` so the finally runs on
+  // the exception-propagation path. Appended after any specific handlers, it
+  // only fires for exceptions none of them caught.
+  std::vector<exprt> handler_ops(
+    handler.operands().begin(), handler.operands().end());
+  if (has_finally && !has_catch_all)
+  {
+    exprt finally_handler = converter_.get_block(element["finalbody"]);
+    finally_handler.type().set("ellipsis", true); // catch-all
+    side_effect_exprt rethrow("cpp-throw", empty_typet());
+    rethrow.location() = converter_.get_location_from_decl(element);
+    codet rethrow_code("expression");
+    rethrow_code.operands().push_back(rethrow);
+    finally_handler.copy_to_operands(rethrow_code);
+    handler_ops.push_back(finally_handler);
+  }
+
+  // A valid Python `try` always has at least one handler or a finally, so
+  // handler_ops is non-empty and the cpp-catch has the >= 2 operands it needs
+  // (the try block plus at least one handler).
+  exprt new_expr = codet("cpp-catch");
   new_expr.move_to_operands(try_block);
-
-  for (const auto &op : handler.operands())
+  for (const auto &op : handler_ops)
     new_expr.copy_to_operands(op);
-
   block.move_to_operands(new_expr);
+
+  // finally on the normal-completion path (and after a caught exception).
+  if (has_finally)
+  {
+    exprt final_block = converter_.get_block(element["finalbody"]);
+    for (const auto &op : final_block.operands())
+      block.copy_to_operands(op);
+  }
+}
+
+// True if `node` contains a return/break/continue that transfers control out of
+// the enclosing try. `return` always escapes (we never descend into a nested
+// function/lambda, which would capture it); `break`/`continue` escape only when
+// not inside a nested loop (`in_loop`). Used to refuse try/finally shapes whose
+// appended finally this lowering would skip.
+bool python_exception_handler::body_has_escaping_control_flow(
+  const nlohmann::json &node,
+  bool in_loop)
+{
+  if (node.is_array())
+  {
+    for (const auto &stmt : node)
+      if (body_has_escaping_control_flow(stmt, in_loop))
+        return true;
+    return false;
+  }
+  if (!node.is_object())
+    return false;
+
+  const std::string t = node.value("_type", "");
+  if (t == "Return")
+    return true;
+  if (t == "Break" || t == "Continue")
+    return !in_loop;
+  // Nested functions/lambdas capture every return/break/continue within them.
+  if (t == "FunctionDef" || t == "AsyncFunctionDef" || t == "Lambda")
+    return false;
+
+  // A loop captures break/continue in its own body/orelse.
+  const bool child_in_loop =
+    in_loop || t == "For" || t == "AsyncFor" || t == "While";
+
+  for (const char *key : {"body", "orelse", "finalbody"})
+    if (
+      node.contains(key) &&
+      body_has_escaping_control_flow(node[key], child_in_loop))
+      return true;
+  if (node.contains("handlers") && node["handlers"].is_array())
+    for (const auto &h : node["handlers"])
+      if (
+        h.is_object() && h.contains("body") &&
+        body_has_escaping_control_flow(h["body"], child_in_loop))
+        return true;
+  // NOTE: `match` arms (cases[*].body) are not traversed because `match` is not
+  // yet supported by the frontend (a try containing one already errors during
+  // conversion). When match support lands, this predicate must recurse into the
+  // case bodies, or a return inside a match arm under a try/finally would
+  // silently escape the appended finally.
+  return false;
 }
 
 void python_exception_handler::get_raise_statement(

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -65,17 +65,20 @@ void python_exception_handler::get_try_statement(
     return;
   }
 
-  // ESBMC's try lowering does not model the `else` clause: its body runs only
-  // when the try block completes without an exception, and (unlike the try
-  // body) exceptions it raises are not caught by this try's handlers. The
-  // current lowering would silently drop it, so refuse a non-empty `else`
-  // rather than return an unsound verdict.
-  if (element.contains("orelse") && !element["orelse"].empty())
-    throw std::runtime_error(
-      "try with a non-empty else clause is not supported");
-
   const bool has_finally =
     element.contains("finalbody") && !element["finalbody"].empty();
+
+  // The `else` clause runs only when the try body completes without an
+  // exception. ESBMC's try lowering does not model it (it is silently dropped) —
+  // a pre-existing limitation independent of this change. Combined with the
+  // finally lowering below, which duplicates the finally body on the normal and
+  // exception paths, a dropped `else` would also be skipped on the path where
+  // finally runs, compounding the unsoundness. So refuse a non-empty `else`
+  // only when a finally is present; plain try/except/else keeps its existing
+  // behaviour.
+  if (has_finally && element.contains("orelse") && !element["orelse"].empty())
+    throw std::runtime_error(
+      "try/finally with a non-empty else clause is not supported");
 
   // Python's `finally` runs on every exit path: normal completion, a caught
   // exception, an *uncaught* exception (run finally, then re-raise), and a

--- a/src/python-frontend/python_exception_handler.h
+++ b/src/python-frontend/python_exception_handler.h
@@ -44,6 +44,13 @@ public:
    */
   void get_try_statement(const nlohmann::json &element, codet &block);
 
+  /// True if `node` contains a return/break/continue that would transfer
+  /// control out of an enclosing try (used to refuse try/finally shapes whose
+  /// appended finally would be skipped). `in_loop` tracks loop nesting so that
+  /// break/continue captured by a nested loop are not counted.
+  static bool
+  body_has_escaping_control_flow(const nlohmann::json &node, bool in_loop);
+
   /**
    * Convert a Python raise statement.
    *


### PR DESCRIPTION
## What

Adds Python `try`/`finally` support to the Python frontend. `get_try_statement` emits `finalbody` on both exit paths:

- inside a synthetic catch-all `{finally; re-raise}` handler, so `finally` runs when an exception propagates uncaught (run `finally`, then re-raise);
- on the fall-through path after the `cpp-catch`, so `finally` runs on normal completion and after a caught exception.

Bare `try`/`finally` (no `except`) — which previously aborted because a `cpp-catch` needs ≥2 operands — now works: the synthetic catch-all supplies the second operand.

## Soundness guards

Shapes the lowering cannot model soundly are **refused with a clean diagnostic** rather than verified unsoundly:

- A **non-empty `else` clause** (ESBMC silently drops `orelse` today — a pre-existing gap, independent of `finally`).
- A **`return`/`break`/`continue` that escapes the try**, an `except` handler, or the `finally` body (it would bypass the appended `finally`). `break`/`continue` captured by a loop nested inside the try is *not* refused.

## Correctness notes (caught in review)

- When a bare `except:` is present, the synthetic catch-all is **suppressed** — otherwise two handlers with the `"ellipsis"` exception id collide in symex's `catch_map` (the later entry wins) and the user's `except:` body is dropped, giving a spurious `VERIFICATION FAILED`. The bare `except:` already covers the exception path via the fall-through `finally`.

## Known limitation

An exception **raised inside an `except` handler** skips `finally` (C++ sibling-handler semantics). Documented in code; not currently guarded. Follow-up: when `match` support lands, the escape predicate must traverse `cases[*].body`.

## Tests

Eight regression tests under `regression/python/try_finally*` (seven pass-shape, one `_fail`): normal/caught/uncaught paths, pure `try/finally`, bare `except:` + finally, nested-loop `break` (allowed), and the `else` / `return` / return-in-handler refusals. All pass under `ctest` and the CPython sanity script; Z3 and Bitwuzla agree on representative cases.

## Dependency

Stacked on #5070 (catch-all-assert segfault fix) — the exception-path `finally` would otherwise trigger that segfault. This PR is based on the #5070 branch and will retarget to `master` once #5070 merges.