### PR TITLE
[python] V.3: migrate OM-handler dict-member/unpack-index sites to IREP2

### DIFF
--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -10,11 +10,13 @@
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_typecast.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_code.h>
 #include <util/string_constant.h>
@@ -367,6 +369,11 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       if (dict_handler_->is_dict_type(obj_expr.type()))
       {
         typet list_type = type_handler_.get_list_type();
+        // V.3: IREP2 member access (exact round-trip of member_exprt);
+        // `obj_expr` is dict-typed (is_dict_type ⇒ struct), so the member2t
+        // source precondition holds.
+        expr2tc dict2;
+        migrate_expr(obj_expr, dict2);
         if (method_name == "items")
         {
           // For-loop uses of items() are rewritten by the preprocessor into
@@ -375,12 +382,12 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           // return the keys member as a placeholder — same size as the dict,
           // so size/emptiness comparisons (e.g. list(d.items()) == []) work.
           // Full (key, value) tuple semantics are not modelled.
-          member_exprt member(obj_expr, "keys", list_type);
-          return member;
+          return migrate_expr_back(
+            member2tc(migrate_type(list_type), dict2, "keys"));
         }
         // Return the keys or values member directly
-        member_exprt member(obj_expr, method_name, list_type);
-        return member;
+        return migrate_expr_back(
+          member2tc(migrate_type(list_type), dict2, method_name));
       }
     }
   }

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -17,6 +17,7 @@
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/base_type.h>
 #include <util/bitvector.h>
@@ -26,6 +27,7 @@
 #include <util/expr_util.h>
 #include <util/irep.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_code.h>
 #include <util/string_constant.h>
@@ -551,9 +553,16 @@ void python_converter::handle_array_unpacking(
       var_symbol = symbol_table_.move_symbol_to_context(new_symbol);
     }
 
-    // Create subscript: rhs[i]
+    // Create subscript: rhs[i]. V.3: IREP2 index access (exact round-trip of
+    // index_exprt); this path runs only when rhs is array-typed (see the
+    // is_array() guard at the call site), so the index2t source precondition
+    // holds.
     exprt index_expr = from_integer(i, size_type());
-    index_exprt subscript(rhs, index_expr, rhs.type().subtype());
+    expr2tc rhs2, idx2;
+    migrate_expr(rhs, rhs2);
+    migrate_expr(index_expr, idx2);
+    exprt subscript = migrate_expr_back(
+      index2tc(migrate_type(rhs.type().subtype()), rhs2, idx2));
 
     code_assignt assign(symbol_expr(*var_symbol), subscript);
     assign.location() = get_location_from_decl(ast_node);
@@ -3294,8 +3303,13 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
         locationt location = get_location_from_decl(element);
         typet list_type = type_handler_.get_list_type();
 
-        // Get dict.keys member
-        member_exprt keys_member(test, "keys", list_type);
+        // Get dict.keys member. V.3: IREP2 member access (exact round-trip of
+        // member_exprt); `test` is dict-typed (is_dict_type ⇒ struct), so the
+        // member2t source precondition holds.
+        expr2tc dict2;
+        migrate_expr(test, dict2);
+        exprt keys_member =
+          migrate_expr_back(member2tc(migrate_type(list_type), dict2, "keys"));
 
         // Find __ESBMC_list_size function
         const symbolt *size_func =

--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -49,8 +49,13 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
     locationt location = get_location_from_decl(element);
     typet list_type = type_handler_.get_list_type();
 
-    // Get dict.keys member
-    member_exprt keys_member(unary_sub, "keys", list_type);
+    // Get dict.keys member. V.3: IREP2 member access (exact round-trip of
+    // member_exprt); `unary_sub` is dict-typed (is_dict_type ⇒ struct), so the
+    // member2t source precondition holds.
+    expr2tc dict2;
+    migrate_expr(unary_sub, dict2);
+    exprt keys_member =
+      migrate_expr_back(member2tc(migrate_type(list_type), dict2, "keys"));
 
     // Find __ESBMC_list_size function
     const symbolt *size_func =


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction in the converter, #5055), following #5069. Migrates the converter sites that #5069 deferred to the OM-handler phase (RP5) to `member2tc`/`index2tc` via the exact-round-trip pattern (behaviour-preserving; existing adjust+goto-convert still resolves downstream):

- `converter_funcall.cpp` — dict `.keys`/`.values`/`.items` member access
- `converter_unop.cpp` / `converter_stmt.cpp` — dict `.keys` member for the `not d` / dict-truthiness emptiness check
- `converter_stmt.cpp` — `rhs[i]` subscript in `handle_array_unpacking`

#5069 flagged these as "potentially pointer-typed sources". On inspection each is guarded so the IREP2 source precondition holds — the dict sites by `is_dict_type` (⇒ `is_struct`), the subscript by the `is_array()` branch at the unpacking call site — so `member2t`/`index2t` never see a pointer source.

Verified on an asserts build: 219/219 dict/unpack/truthiness/items/keys/values python tests green, both solvers exercised.
