### PR TITLE
[solver] fix int/real bitcast-to-fixedbv sort in --ir mode

### DIFF
--- a/regression/esbmc/fixedbv-bitcast-ir/main.c
+++ b/regression/esbmc/fixedbv-bitcast-ir/main.c
@@ -1,0 +1,13 @@
+// Regression for the --ir (integer/real) fixedbv encoding: a fixedbv->int
+// cast forces round_real_to_int, which requires a REAL operand. A
+// bitcast<fixedbv>(bitvector) used to be left int-sorted under --ir, so the
+// operand reached mk_lt with mismatched sorts and aborted
+// (z3_conv.cpp mk_lt: a->sort->id == b->sort->id). The truncation toward
+// zero of a constant float must hold.
+int main()
+{
+  float x = 2.5f;
+  int n = (int)x;
+  __ESBMC_assert(n == 2, "C casts truncate toward zero");
+  return 0;
+}

--- a/regression/esbmc/fixedbv-bitcast-ir/test.desc
+++ b/regression/esbmc/fixedbv-bitcast-ir/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--fixedbv --ir --z3 --unwind 5 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fixedbv-bitcast-ir_fail/main.c
+++ b/regression/esbmc/fixedbv-bitcast-ir_fail/main.c
@@ -1,0 +1,12 @@
+// Failing companion to fixedbv-bitcast-ir: same --ir fixedbv->int cast path,
+// but the value is nondeterministic so the truncation can violate the claim.
+// Exercises the bitcast<fixedbv>(bitvector) -> round_real_to_int path that
+// previously aborted on a sort mismatch in mk_lt under --ir.
+extern float nondet_float(void);
+int main()
+{
+  float x = nondet_float();
+  int n = (int)x;
+  __ESBMC_assert(n >= 0, "truncated value need not be non-negative");
+  return 0;
+}

--- a/regression/esbmc/fixedbv-bitcast-ir_fail/test.desc
+++ b/regression/esbmc/fixedbv-bitcast-ir_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--fixedbv --ir --z3 --unwind 5 --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -161,7 +161,17 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
   else if (is_fixedbv_type(to_type))
   {
     if (is_bv_type(from))
+    {
+      // Under integer encoding, fixedbv values are real-encoded while the
+      // source bitvector is an SMT integer. Returning it unchanged would yield
+      // an int-sorted term with a fixedbv expr-type, tripping later real-only
+      // operations (e.g. round_real_to_int -> mk_lt sort mismatch). Fall back
+      // to a value-based typecast, mirroring the value-based fallbacks in the
+      // bv- and floatbv-target branches.
+      if (int_encoding)
+        return convert_ast(typecast2tc(to_type, from));
       return convert_ast(from);
+    }
   }
   else if (is_bv_type(to_type))
   {


### PR DESCRIPTION
## Problem

Under integer/real encoding (`--ir`), ESBMC represents fixedbv values as SMT reals and integer bitvectors as SMT integers. `convert_bitcast` for a `bitcast<fixedbv>(bitvector)` returned the source bitvector unchanged:

```cpp
else if (is_fixedbv_type(to_type))
{
  if (is_bv_type(from))
    return convert_ast(from);   // int-sorted, but expr-type is fixedbv
}
```

That yields an **int-sorted** SMT term carrying a **fixedbv** expr-type. When a later fixedbv→int cast runs `round_real_to_int`, its first step is `mk_lt(a, mk_smt_real("0"))`; with `a` int-sorted against a real literal, the Z3 backend hits

```
z3_conv.cpp:545: z3_convt::mk_lt: Assertion `a->sort->id == b->sort->id' failed.
```

and aborts (SIGABRT) during encoding. Reproduces on `master` with e.g. `regression/cbmc/01_cbmc_Fixedbv24` under `--fixedbv --incremental-bmc --ir --z3`, and minimally with a single `(int)nondet_float()` cast.

## Fix

Under `int_encoding`, route the bitcast through a value-based typecast so the result is a real (via `mk_int2real`), mirroring the value-based fallbacks already present in the bv-target and floatbv-target branches of the same function. Bit-encoding (`!int_encoding`) behaviour is unchanged — exact bit-pattern reinterpretation is preserved there. Under `--ir` an exact bit-reinterpret of a real is not representable, so the value-based approximation is the consistent choice (the documented `--ir` tradeoff).

## Tests

Two CORE regression tests under `regression/esbmc/fixedbv-bitcast-ir{,_fail}` (`--fixedbv --ir --z3 --unwind 5 --no-unwinding-assertions`), each confirmed to abort with the `mk_lt` assertion on the unfixed binary and produce a clean verdict on the fixed one:

- `fixedbv-bitcast-ir` — `(int)2.5f == 2`, `VERIFICATION SUCCESSFUL`
- `fixedbv-bitcast-ir_fail` — nondet `(int)x >= 0`, `VERIFICATION FAILED`

Full `cbmc` regression suite (307 tests, including the previously-crashing `01_cbmc_Fixedbv24`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
