### PR TITLE
[Witness 2.1] implement function_enter waypoint and refactor witness cursor

### DIFF
--- a/regression/witnesses_validate/branching_avoid/main.c
+++ b/regression/witnesses_validate/branching_avoid/main.c
@@ -1,0 +1,13 @@
+void reach_error(void) {}
+int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  int x = __VERIFIER_nondet_int();
+  int flag = 0;
+  if (x < 0)
+    flag = 1;
+  if (flag)
+    reach_error();
+  return 0;
+}

--- a/regression/witnesses_validate/branching_avoid/test.desc
+++ b/regression/witnesses_validate/branching_avoid/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--validate-violation-witness --witness witness.yml --k-induction --no-bounds-check --no-pointer-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/branching_avoid/witness.yml
+++ b/regression/witnesses_validate/branching_avoid/witness.yml
@@ -1,0 +1,34 @@
+- entry_type: "violation_sequence"
+  metadata:
+    format_version: "2.0"
+    uuid: "00000001-0000-0000-0000-000000000002"
+    creation_time: "2026-06-03T00:00:00+00:00"
+    producer:
+      name: "manual"
+      version: "1.0"
+    task:
+      input_files:
+      - "main.c"
+      specification: "G ! call(reach_error())"
+      data_model: "LP64"
+      language: "C"
+  content:
+  - segment:
+    - waypoint:
+        type: "branching"
+        action: "avoid"
+        constraint:
+          value: "true"
+        location:
+          file_name: "main.c"
+          line: 8
+          column: 3
+          function: "main"
+    - waypoint:
+        type: "target"
+        action: "follow"
+        location:
+          file_name: "main.c"
+          line: 11
+          column: 5
+          function: "main"

--- a/regression/witnesses_validate/branching_follow/main.c
+++ b/regression/witnesses_validate/branching_follow/main.c
@@ -1,0 +1,13 @@
+void reach_error(void) {}
+int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  int x = __VERIFIER_nondet_int();
+  int flag = 0;
+  if (x < 0)
+    flag = 1;
+  if (flag)
+    reach_error();
+  return 0;
+}

--- a/regression/witnesses_validate/branching_follow/test.desc
+++ b/regression/witnesses_validate/branching_follow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--validate-violation-witness --witness witness.yml --k-induction --no-bounds-check --no-pointer-check
+^VERIFICATION FAILED$

--- a/regression/witnesses_validate/branching_follow/witness.yml
+++ b/regression/witnesses_validate/branching_follow/witness.yml
@@ -1,0 +1,35 @@
+- entry_type: "violation_sequence"
+  metadata:
+    format_version: "2.0"
+    uuid: "00000001-0000-0000-0000-000000000001"
+    creation_time: "2026-06-03T00:00:00+00:00"
+    producer:
+      name: "manual"
+      version: "1.0"
+    task:
+      input_files:
+      - "main.c"
+      specification: "G ! call(reach_error())"
+      data_model: "LP64"
+      language: "C"
+  content:
+  - segment:
+    - waypoint:
+        type: "branching"
+        action: "follow"
+        constraint:
+          value: "true"
+        location:
+          file_name: "main.c"
+          line: 8
+          column: 3
+          function: "main"
+  - segment:
+    - waypoint:
+        type: "target"
+        action: "follow"
+        location:
+          file_name: "main.c"
+          line: 11
+          column: 5
+          function: "main"

--- a/regression/witnesses_validate/function_enter_avoid/main.c
+++ b/regression/witnesses_validate/function_enter_avoid/main.c
@@ -1,0 +1,13 @@
+void reach_error(void) {}
+
+static void check(int x)
+{
+  if (x < 0)
+    reach_error();
+}
+
+int main(void)
+{
+  check(-1);
+  return 0;
+}

--- a/regression/witnesses_validate/function_enter_avoid/test.desc
+++ b/regression/witnesses_validate/function_enter_avoid/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--validate-violation-witness --witness witness.yml --k-induction --no-bounds-check --no-pointer-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/function_enter_avoid/witness.yml
+++ b/regression/witnesses_validate/function_enter_avoid/witness.yml
@@ -1,0 +1,32 @@
+- entry_type: "violation_sequence"
+  metadata:
+    format_version: "2.0"
+    uuid: "00000001-0000-0000-0000-000000000004"
+    creation_time: "2026-06-03T00:00:00+00:00"
+    producer:
+      name: "manual"
+      version: "1.0"
+    task:
+      input_files:
+      - "main.c"
+      specification: "G ! call(reach_error())"
+      data_model: "LP64"
+      language: "C"
+  content:
+  - segment:
+    - waypoint:
+        type: "function_enter"
+        action: "avoid"
+        location:
+          file_name: "main.c"
+          line: 11
+          column: 3
+          function: "main"
+    - waypoint:
+        type: "target"
+        action: "follow"
+        location:
+          file_name: "main.c"
+          line: 6
+          column: 5
+          function: "check"

--- a/regression/witnesses_validate/function_enter_follow/main.c
+++ b/regression/witnesses_validate/function_enter_follow/main.c
@@ -1,0 +1,19 @@
+void reach_error(void) {}
+int __VERIFIER_nondet_int(void);
+
+static void check(int x)
+{
+  if (x < 0)
+    reach_error();
+}
+
+int main(void)
+{
+  int a = __VERIFIER_nondet_int();
+  int b = __VERIFIER_nondet_int();
+  if (a > 0)
+    check(a);
+  if (b < 0)
+    check(b);
+  return 0;
+}

--- a/regression/witnesses_validate/function_enter_follow/test.desc
+++ b/regression/witnesses_validate/function_enter_follow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--validate-violation-witness --witness witness.yml --k-induction --no-bounds-check --no-pointer-check
+^VERIFICATION FAILED$

--- a/regression/witnesses_validate/function_enter_follow/witness.yml
+++ b/regression/witnesses_validate/function_enter_follow/witness.yml
@@ -1,0 +1,44 @@
+- entry_type: "violation_sequence"
+  metadata:
+    format_version: "2.0"
+    uuid: "00000001-0000-0000-0000-000000000003"
+    creation_time: "2026-06-03T00:00:00+00:00"
+    producer:
+      name: "manual"
+      version: "1.0"
+    task:
+      input_files:
+      - "main.c"
+      specification: "G ! call(reach_error())"
+      data_model: "LP64"
+      language: "C"
+  content:
+  - segment:
+    - waypoint:
+        type: "assumption"
+        action: "follow"
+        constraint:
+          value: "b < 0"
+          format: "c_expression"
+        location:
+          file_name: "main.c"
+          line: 13
+          function: "main"
+  - segment:
+    - waypoint:
+        type: "function_enter"
+        action: "follow"
+        location:
+          file_name: "main.c"
+          line: 17
+          column: 5
+          function: "main"
+  - segment:
+    - waypoint:
+        type: "target"
+        action: "follow"
+        location:
+          file_name: "main.c"
+          line: 7
+          column: 5
+          function: "check"

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -579,8 +579,8 @@ _Bool __ESBMC_exists(void*, _Bool);
  */
 void __ESBMC_loop_invariant(_Bool);
 
-// Violation-witness: seg_idx/wp_idx uniquely identify the call site; constraint is the assumption.
-void __ESBMC_witness_assume(int, int, _Bool);
+// Violation-witness: seg_idx identifies the segment; constraint is the assumption.
+void __ESBMC_witness_assume(int, _Bool);
 
 /* __ESBMC_loop_assigns: specifies memory locations a loop may modify.
  * Used with --loop-frame-rule for frame condition enforcement.

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -19,7 +19,6 @@ goto_symex_statet::goto_symex_statet(
   use_value_set = true;
   num_instructions = 0;
   cur_seg = 0;
-  cur_wp = 0;
   thread_ended = false;
   guard.make_true();
 }
@@ -47,7 +46,6 @@ goto_symex_statet &goto_symex_statet::operator=(const goto_symex_statet &state)
   call_stack = state.call_stack;
   witness_segs = state.witness_segs;
   cur_seg = state.cur_seg;
-  cur_wp = state.cur_wp;
   return *this;
 }
 
@@ -577,12 +575,6 @@ std::vector<stack_framet> goto_symex_statet::gen_stack_trace() const
 
 void goto_symex_statet::advance_witness_position()
 {
-  if (cur_seg >= witness_segs.size())
-    return;
-  ++cur_wp;
-  if (cur_wp >= witness_segs[cur_seg].size())
-  {
+  if (cur_seg < witness_segs.size())
     ++cur_seg;
-    cur_wp = 0;
-  }
 }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -478,12 +478,11 @@ public:
 
   // --- Violation-witness replay state ---
 
-  /// witness_segs[seg][wp]: all actionable waypoints
+  /// witness_segs[seg]: all actionable waypoints per segment
   std::vector<std::vector<waypoint>> witness_segs;
   size_t cur_seg;
-  size_t cur_wp;
 
-  /// Advance the cursor to the next waypoint.
+  /// Advance to the next segment (called when a follow waypoint is matched).
   void advance_witness_position();
 };
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -108,32 +108,66 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
 
   // Violation-witness: steer branch direction if the current waypoint is a
   // branching at this location.  Skip backward GOTOs (loop back edges).
+  //
+  // 'follow' waypoints are consumed once (advance after match).
+  // 'avoid' waypoints are persistent: the constraint applies at every
+  // encounter of the same branch (e.g. every loop iteration).
+  //
+  // Scan forward from cur_wp through the segment:
+  //   - 'avoid' that does NOT match current location: skip (avoids are
+  //     persistent but don't block later waypoints from being found).
+  //   - 'avoid' that DOES match: apply the constraint, do NOT advance cur_wp.
+  //   - 'follow' that does NOT match: stop scanning (follows are ordered).
+  //   - 'follow' that DOES match: apply and advance cur_wp past it.
   if (
     validate_witness && forward &&
     cur_state->cur_seg < cur_state->witness_segs.size())
   {
     const auto &seg = cur_state->witness_segs[cur_state->cur_seg];
-    if (cur_state->cur_wp < seg.size())
+    const auto &loc = cur_state->source.pc->location;
+
+    for (size_t wp_idx = cur_state->cur_wp; wp_idx < seg.size(); ++wp_idx)
     {
-      const waypoint &wp = seg[cur_state->cur_wp];
-      if (wp.type == waypoint::branching)
+      const waypoint &wp = seg[wp_idx];
+      if (wp.type != waypoint::branching)
+        continue;
+
+      const bool loc_matches =
+        !wp.line_id.empty() && wp.line_id == loc.get_line() &&
+        (wp.function_id.empty() ||
+         wp.function_id == loc.get_function());
+
+      if (loc_matches)
       {
-        const auto &loc = cur_state->source.pc->location;
-        if (
-          !wp.line_id.empty() && wp.line_id == loc.get_line() &&
-          (wp.function_id.empty() || wp.function_id == loc.get_function()))
+        const bool is_avoid = (wp.action == waypoint::avoid);
+        bool direction_true = (wp.value == "true") ^ is_avoid;
+        bool goto_taken =
+          instruction.flipped_guard ? direction_true : !direction_true;
+        // The witness direction overrides any prior guard simplification.
+        // do_simplify may have already set new_guard_false/true based on
+        // symbolic evaluation, but the witness must take priority.
+        if (goto_taken)
         {
-          const bool is_avoid = (wp.action == waypoint::avoid);
-          bool direction_true = (wp.value == "true") ^ is_avoid;
-          bool goto_taken =
-            instruction.flipped_guard ? direction_true : !direction_true;
-          if (goto_taken)
-            new_guard_true = true;
-          else
-            new_guard_false = true;
+          new_guard_true = true;
+          new_guard_false = false;
+        }
+        else
+        {
+          new_guard_false = true;
+          new_guard_true = false;
+        }
+        if (!is_avoid)
+        {
+          cur_state->cur_wp = wp_idx;
           cur_state->advance_witness_position();
         }
+        break;
       }
+
+      // Location does not match: only skip past 'avoid' entries; a 'follow'
+      // that hasn't been satisfied yet cannot be bypassed.
+      if (wp.action != waypoint::avoid)
+        break;
     }
   }
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -106,19 +106,14 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   // by process_instruction (ASSIGN / ASSUME / DEAD), which is sufficient for
   // tracking loop counters.
 
-  // Violation-witness: steer branch direction if the current waypoint is a
-  // branching at this location.  Skip backward GOTOs (loop back edges).
+  // Violation-witness: steer branch direction if a branching waypoint in the
+  // current segment matches this location.  Skip backward GOTOs (loop back
+  // edges).
   //
-  // 'follow' waypoints are consumed once (advance after match).
-  // 'avoid' waypoints are persistent: the constraint applies at every
-  // encounter of the same branch (e.g. every loop iteration).
-  //
-  // Scan forward from cur_wp through the segment:
-  //   - 'avoid' that does NOT match current location: skip (avoids are
-  //     persistent but don't block later waypoints from being found).
-  //   - 'avoid' that DOES match: apply the constraint, do NOT advance cur_wp.
-  //   - 'follow' that does NOT match: stop scanning (follows are ordered).
-  //   - 'follow' that DOES match: apply and advance cur_wp past it.
+  // 'avoid' waypoints are persistent: scan all entries in the segment each
+  // time; matching ones apply their constraint without advancing the segment.
+  // 'follow' waypoints consume the segment on match (advance_witness_position).
+  // Non-matching 'follow' entries stop the scan (they are ordered).
   if (
     validate_witness && forward &&
     cur_state->cur_seg < cur_state->witness_segs.size())
@@ -126,7 +121,7 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
     const auto &seg = cur_state->witness_segs[cur_state->cur_seg];
     const auto &loc = cur_state->source.pc->location;
 
-    for (size_t wp_idx = cur_state->cur_wp; wp_idx < seg.size(); ++wp_idx)
+    for (size_t wp_idx = 0; wp_idx < seg.size(); ++wp_idx)
     {
       const waypoint &wp = seg[wp_idx];
       if (wp.type != waypoint::branching)
@@ -143,9 +138,6 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
         bool direction_true = (wp.value == "true") ^ is_avoid;
         bool goto_taken =
           instruction.flipped_guard ? direction_true : !direction_true;
-        // The witness direction overrides any prior guard simplification.
-        // do_simplify may have already set new_guard_false/true based on
-        // symbolic evaluation, but the witness must take priority.
         if (goto_taken)
         {
           new_guard_true = true;
@@ -157,15 +149,10 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
           new_guard_true = false;
         }
         if (!is_avoid)
-        {
-          cur_state->cur_wp = wp_idx;
           cur_state->advance_witness_position();
-        }
         break;
       }
 
-      // Location does not match: only skip past 'avoid' entries; a 'follow'
-      // that hasn't been satisfied yet cannot be bypassed.
       if (wp.action != waypoint::avoid)
         break;
     }

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -129,8 +129,7 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
 
       const bool loc_matches =
         !wp.line_id.empty() && wp.line_id == loc.get_line() &&
-        (wp.function_id.empty() ||
-         wp.function_id == loc.get_function());
+        (wp.function_id.empty() || wp.function_id == loc.get_function());
 
       if (loc_matches)
       {

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -429,9 +429,7 @@ void goto_symext::symex_step(reachability_treet &art)
     // avoid, matching: skip the call (pc++), segment does not advance.
     // follow, not matching: stop (follows are ordered; cannot bypass).
     // follow, matching: advance to next segment; fall through to the call.
-    if (
-      validate_witness &&
-      cur_state->cur_seg < cur_state->witness_segs.size())
+    if (validate_witness && cur_state->cur_seg < cur_state->witness_segs.size())
     {
       const auto &seg = cur_state->witness_segs[cur_state->cur_seg];
       const auto &loc = cur_state->source.pc->location;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -1141,8 +1141,10 @@ void goto_symext::run_intrinsic(
     if (seg_idx != cur_state->cur_seg)
       return;
 
-    // Find the assumption waypoint in this segment by source line.
-    const irep_idt cur_line = cur_state->source.pc->location.get_line();
+    // pc has already been incremented past this intrinsic call; step back one
+    // to get the location of the __ESBMC_witness_assume instruction itself.
+    const irep_idt cur_line =
+      std::prev(cur_state->source.pc)->location.get_line();
     const waypoint *matched = nullptr;
     for (const auto &wp : cur_state->witness_segs[seg_idx])
     {

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -426,7 +426,7 @@ void goto_symext::symex_step(reachability_treet &art)
 
     // Violation-witness: handle function_enter waypoints in the current segment.
     // avoid, not matching: skip (persistent).
-    // avoid, matching: skip the call, segment does not advance.
+    // avoid, matching: skip the call (pc++), segment does not advance.
     // follow, not matching: stop (follows are ordered; cannot bypass).
     // follow, matching: advance to next segment; fall through to the call.
     if (
@@ -448,7 +448,7 @@ void goto_symext::symex_step(reachability_treet &art)
           if (wp.action == waypoint::avoid)
           {
             cur_state->source.pc++;
-            break;
+            return;
           }
           cur_state->advance_witness_position();
           break;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -424,6 +424,40 @@ void goto_symext::symex_step(reachability_treet &art)
       }
     }
 
+    // Violation-witness: handle function_enter waypoints in the current segment.
+    // avoid, not matching: skip (persistent).
+    // avoid, matching: skip the call, segment does not advance.
+    // follow, not matching: stop (follows are ordered; cannot bypass).
+    // follow, matching: advance to next segment; fall through to the call.
+    if (
+      validate_witness &&
+      cur_state->cur_seg < cur_state->witness_segs.size())
+    {
+      const auto &seg = cur_state->witness_segs[cur_state->cur_seg];
+      const auto &loc = cur_state->source.pc->location;
+      for (size_t wp_idx = 0; wp_idx < seg.size(); ++wp_idx)
+      {
+        const waypoint &wp = seg[wp_idx];
+        if (wp.type != waypoint::function_enter)
+          continue;
+        const bool loc_matches =
+          !wp.line_id.empty() && wp.line_id == loc.get_line() &&
+          (wp.function_id.empty() || wp.function_id == loc.get_function());
+        if (loc_matches)
+        {
+          if (wp.action == waypoint::avoid)
+          {
+            cur_state->source.pc++;
+            break;
+          }
+          cur_state->advance_witness_position();
+          break;
+        }
+        if (wp.action != waypoint::avoid)
+          break;
+      }
+    }
+
     symex_function_call(deref_code);
   }
   break;
@@ -1102,24 +1136,37 @@ void goto_symext::run_intrinsic(
     if (!validate_witness)
       return;
 
-    // operands: [seg_idx_const, wp_idx_const, constraint]
-    if (func_call.operands.size() < 3)
+    // operands: [seg_idx_const, constraint]
+    if (func_call.operands.size() < 2)
       return;
     size_t seg_idx = to_constant_int2t(func_call.operands[0]).value.to_uint64();
-    size_t wp_idx = to_constant_int2t(func_call.operands[1]).value.to_uint64();
-
-    if (seg_idx != cur_state->cur_seg || wp_idx != cur_state->cur_wp)
+    if (seg_idx != cur_state->cur_seg)
       return;
 
-    const waypoint &wp = cur_state->witness_segs[seg_idx][wp_idx];
-    expr2tc arg = func_call.operands[2];
+    // Find the assumption waypoint in this segment by source line.
+    const irep_idt cur_line = cur_state->source.pc->location.get_line();
+    const waypoint *matched = nullptr;
+    for (const auto &wp : cur_state->witness_segs[seg_idx])
+    {
+      if (wp.type == waypoint::assumption && wp.line_id == cur_line)
+      {
+        matched = &wp;
+        break;
+      }
+    }
+    if (!matched)
+      return;
+
+    expr2tc arg = func_call.operands[1];
     cur_state->rename(arg);
 
-    if (wp.action == waypoint::avoid)
+    if (matched->action == waypoint::avoid)
       assume(not2tc(arg));
     else
       assume(arg);
-    cur_state->advance_witness_position();
+
+    if (matched->action != waypoint::avoid)
+      cur_state->advance_witness_position();
     return;
   }
 

--- a/src/goto-symex/witnesses.h
+++ b/src/goto-symex/witnesses.h
@@ -99,7 +99,6 @@ public:
   Type type = unknown;
   Action action = follow;
   size_t segment_idx = 0;
-  size_t wp_idx_in_seg = 0;
   std::string file;
   std::string value;
   std::string format;

--- a/src/util/yaml_parser.cpp
+++ b/src/util/yaml_parser.cpp
@@ -143,7 +143,6 @@ std::vector<waypoint> yaml_parser::get_waypoints(const std::string &path)
         if (!seg || !seg.IsSequence())
           continue;
 
-        size_t wp_count = 0;
         for (const auto &wp_node : seg)
         {
           const auto &node = wp_node["waypoint"];
@@ -160,7 +159,6 @@ std::vector<waypoint> yaml_parser::get_waypoints(const std::string &path)
             continue;
           }
           wp.segment_idx = seg_idx;
-          wp.wp_idx_in_seg = wp_count++;
           wp_cache.waypoints.push_back(std::move(wp));
         }
         ++seg_idx;
@@ -279,8 +277,8 @@ std::string yaml_parser::build_violation_witness_source(
       out << "#line " << line_num << " \"" << original_path << "\"\n";
       for (const waypoint *wp : it->second)
       {
-        out << "__ESBMC_witness_assume(" << wp->segment_idx << ", "
-            << wp->wp_idx_in_seg << ", (_Bool)(" << wp->value << "));\n";
+        out << "__ESBMC_witness_assume(" << wp->segment_idx << ", (_Bool)("
+            << wp->value << "));\n";
         log_progress(
           "Injecting {} assumption at line {}: {}",
           wp->action == waypoint::avoid ? "avoid" : "follow",


### PR DESCRIPTION
Adds support for function_enter waypoints in violation witness validation and refactors the witness state machine to remove the intra-segment cursor.

  **function_enter support**

  Handles function_enter waypoints directly in the FUNCTION_CALL symex step, mirroring the branching implementation in symex_goto.cpp:

  - follow: the call proceeds normally and advances to the next segment.
  - avoid: the call is skipped (pc++) without advancing the segment, consistent with the witness format's semantics that avoid waypoints are persistent and do not terminate segments.

  Scanning follows the same forward-scan rule as branching: non-matching avoid entries are skipped; a non-matching follow stops the scan (follows are ordered and cannot be bypassed).

  **Cursor refactor: remove cur_wp**

  The previous design used a sequential (seg, wp) cursor that required waypoints within a segment to be consumed in list order. This conflicts with the witness format, which states that waypoints within a segment are active simultaneously and may be evaluated in any order.