### PR TITLE
[k-induction] learn next-k hint from goto bounds and IS counter-examples

### DIFF
--- a/regression/k-induction/sum06/test.desc
+++ b/regression/k-induction/sum06/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -123,9 +123,6 @@ void bmct::successful_trace(const symex_target_equationt &eq [[maybe_unused]])
 
 void bmct::error_trace(smt_convt &smt_conv, const symex_target_equationt &eq)
 {
-  if (options.get_bool_option("result-only"))
-    return;
-
   log_progress("Building error trace");
 
   bool is_compact_trace = true;
@@ -136,6 +133,15 @@ void bmct::error_trace(smt_convt &smt_conv, const symex_target_equationt &eq)
 
   goto_tracet goto_trace;
   build_goto_trace(eq, smt_conv, goto_trace, is_compact_trace);
+
+  // Snapshot for callers (k-induction's outer driver wants the loop-
+  // variable values to learn the next k step). Snapshot BEFORE the
+  // result-only short-circuit so we keep the data even when we suppress
+  // user-visible output.
+  last_error_trace = goto_trace;
+
+  if (options.get_bool_option("result-only"))
+    return;
 
   std::string output_file = options.get_option("cex-output");
   if (output_file != "")
@@ -424,6 +430,19 @@ void bmct::report_trace(
     else if (!is && !fc)
     {
       error_trace(*runtime_solver, eq);
+    }
+    else
+    {
+      // For IS / FC the user-visible CEX is suppressed by default, but
+      // the outer k-induction driver may still want to introspect the
+      // CEX (e.g. to read loop-variable values for the next-k hint).
+      // error_trace snapshots into last_error_trace before honoring
+      // result-only, so set it here to suppress printing while keeping
+      // the snapshot.
+      bool prev_result_only = options.get_bool_option("result-only");
+      options.set_option("result-only", true);
+      error_trace(*runtime_solver, eq);
+      options.set_option("result-only", prev_result_only);
     }
     break;
 

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -37,6 +37,12 @@ public:
   BigInt interleaving_number;
   BigInt interleaving_failed;
 
+  /// Last CEX trace built by error_trace(). Populated for SAT results,
+  /// empty otherwise. K-induction's outer driver inspects this after an
+  /// inductive-step refutation to extract loop-variable values for the
+  /// next-k hint (see learn_k_from_is_trace).
+  goto_tracet last_error_trace;
+
   virtual smt_convt::resultt start_bmc();
   virtual smt_convt::resultt run(std::shared_ptr<symex_target_equationt> &eq);
   virtual ~bmct() = default;

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1654,9 +1654,10 @@ int esbmc_parseoptionst::do_bmc_strategy(
       // Don't run inductive step for k_step == 1
       if (k_step > 1)
       {
-        if (
-          !is_bcv && is_inductive_step_violated(options, goto_functions, k_step)
-                       .is_false())
+        uint64_t is_hint = 0;
+        tvt is_res =
+          is_inductive_step_violated(options, goto_functions, k_step, is_hint);
+        if (!is_bcv && is_res.is_false())
         {
           if (is_coverage)
             report_coverage(
@@ -1667,6 +1668,13 @@ int esbmc_parseoptionst::do_bmc_strategy(
               ctest_gen);
           return conclude();
         }
+        // IS produced a refutation. If its CEX exposes a larger
+        // loop-variable value than the current hint, raise the hint.
+        // The hint is consumed at most once (hint_consumed gates the
+        // jump below), but we keep updating it across IS iterations
+        // so the value adopted is the max the IS model ever picked.
+        if (is_res.is_true() && is_hint > fc_hint && !hint_consumed)
+          fc_hint = is_hint;
       }
     }
     // termination
@@ -1961,6 +1969,27 @@ static uint64_t learn_k_from_goto_bounds(const goto_functionst &goto_functions)
   return best;
 }
 
+/// Dynamic fallback: scan an inductive-step CEX trace for the largest
+/// constant-int value the model assigned to any variable. Used when the
+/// static goto-bounds scan returned 0 (loop bound is symbolic in the
+/// IR — e.g. `for(i=0; i<n; i++)` where `n` is a function parameter
+/// that interval analysis couldn't fold). The IS picks the model's
+/// adversarial value, which for loop-bound patterns is often the bound
+/// the loop will reach.
+///
+/// Considers only ASSIGNMENT steps. Returns 0 when no usable signal.
+static uint64_t learn_k_from_cex_assignments(const goto_tracet &trace)
+{
+  uint64_t best = 0;
+  for (const auto &step : trace.steps)
+  {
+    if (!step.is_assignment())
+      continue;
+    collect_max_int_constant(step.value, best);
+  }
+  return best;
+}
+
 tvt esbmc_parseoptionst::does_forward_condition_hold(
   optionst &options,
   goto_functionst &goto_functions,
@@ -2033,8 +2062,11 @@ tvt esbmc_parseoptionst::does_forward_condition_hold(
 tvt esbmc_parseoptionst::is_inductive_step_violated(
   optionst &options,
   goto_functionst &goto_functions,
-  const uint64_t &k_step)
+  const uint64_t &k_step,
+  uint64_t &next_k_hint)
 {
+  next_k_hint = 0;
+
   if (options.get_bool_option("disable-inductive-step"))
     return tvt(tvt::TV_UNKNOWN);
 
@@ -2064,6 +2096,8 @@ tvt esbmc_parseoptionst::is_inductive_step_violated(
   switch (res)
   {
   case smt_convt::P_SATISFIABLE:
+    // IS refutation: model exists. Scan it for the next-k hint.
+    next_k_hint = learn_k_from_cex_assignments(bmc.last_error_trace);
     return tvt(tvt::TV_TRUE);
 
   case smt_convt::P_SMTLIB:

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1598,7 +1598,17 @@ int esbmc_parseoptionst::do_bmc_strategy(
   // pop4). Use this as a shortcut: if it exceeds the next sequential k,
   // jump to it directly instead of stepping through intermediate
   // values. The FC will close at exactly that k.
-  uint64_t fc_hint = learn_k_from_goto_bounds(goto_functions);
+  //
+  // NOT applied under `--termination`: termination's win condition is
+  // the inductive step proving UNSAT at SMALL k (markers unreachable
+  // from havoced state), and skipping past intermediate k values
+  // hides those wins. E.g. on the noop-cycle pattern, IS proves
+  // non-termination at k=3 via `inject_noop_cycle_assumes`, but if
+  // the hint jumps the loop from k=3 to k=5 we never run IS at k=3
+  // and miss the proof.
+  uint64_t fc_hint = options.get_bool_option("termination")
+                       ? 0
+                       : learn_k_from_goto_bounds(goto_functions);
   bool hint_consumed = false;
 
   // Trying all bounds from 1 to "max_k_step" in "k_step_inc".

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1752,8 +1752,15 @@ int esbmc_parseoptionst::do_bmc_strategy(
       // gate is needed.
       if (k_step > 1)
       {
-        tvt is_res =
-          is_inductive_step_violated(options, goto_functions, k_step);
+        // The termination branch doesn't use the dynamic FC-hint
+        // mechanism (k-induction's optimisation for symbolic
+        // bounds), but the signature change to is_inductive_step_-
+        // violated requires us to pass an out-param. Discard the
+        // hint here — adopting it for the termination path is a
+        // separate design question.
+        uint64_t unused_hint = 0;
+        tvt is_res = is_inductive_step_violated(
+          options, goto_functions, k_step, unused_hint);
         // Symex may have set disable-inductive-step mid-run (function
         // pointers, recursion, concurrency). The IS UNSAT result is
         // then a vacuous "0 VCCs to falsify" and not a real

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1823,8 +1823,22 @@ int esbmc_parseoptionst::do_bmc_strategy(
     // to close at the hinted value. Raise max_k_step if the hint
     // exceeds it, since otherwise we'd hit the cap before the proof
     // closes.
+    //
+    // GATING the jump on `next_k > max_inductive_step` (when the cap
+    // is finite): IS UNSAT at small k is a primary win condition
+    // (proves the property by showing the post-havoc state is
+    // unreachable at depth k), and skipping past those k values
+    // silently hides the proof. The hint is a FC-speedup, not an
+    // IS-replacement, so let IS run at every k up to its cap before
+    // letting the hint take over. When --max-inductive-step is the
+    // default -1 (unlimited), the user hasn't asked for the IS cap
+    // so the hint fires as before.
     uint64_t next_k = k_step + k_step_inc;
-    if (!hint_consumed && fc_hint > next_k)
+    long max_is_raw = strtol(cmdline.getval("max-inductive-step"), nullptr, 10);
+    bool is_capped = max_is_raw >= 0;
+    bool past_is_cap = is_capped && next_k > static_cast<uint64_t>(max_is_raw);
+    bool hint_safe = !is_capped || past_is_cap;
+    if (!hint_consumed && fc_hint > next_k && hint_safe)
     {
       log_status(
         "Goto program exposes loop bound {:d}; "
@@ -1962,6 +1976,16 @@ static uint64_t learn_k_from_goto_bounds(const goto_functionst &goto_functions)
   for (const auto &fn : goto_functions.function_map)
   {
     if (!fn.second.body_available)
+      continue;
+    // Skip library helpers (operational models, frontend scaffolding).
+    // Their loops are not the user-program loops we're trying to
+    // hint, and they routinely contain large integer constants
+    // (e.g. ldexp's 2047 exponent range, strtol's 120 char-class
+    // tables) that would mislead the hint to jump to k values
+    // unrelated to any user loop -- causing FC at k=2047 to unwind
+    // every user-side nested loop 2047 times each, hanging the
+    // verification.
+    if (fn.second.body.hide)
       continue;
     for (const auto &ins : fn.second.body.instructions)
     {

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1540,6 +1540,10 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 // \param options - options for setting the verification strategy
 // and controlling symbolic execution
 // \param goto_functions - GOTO program under verification
+
+// Forward decls; definitions follow `do_bmc_strategy` for grouping.
+static uint64_t learn_k_from_goto_bounds(const goto_functionst &goto_functions);
+
 int esbmc_parseoptionst::do_bmc_strategy(
   optionst &options,
   goto_functionst &goto_functions)
@@ -1588,10 +1592,19 @@ int esbmc_parseoptionst::do_bmc_strategy(
     return 0;
   };
 
-  // Trying all bounds from 1 to "max_k_step" in "k_step_inc"
+  // Pre-compute a k hint from the goto program's loop bounds. The
+  // k-induction transformation has already run and inserted pre-loop
+  // ASSUMEs containing the bound literals (e.g. `i >= 64` in popcount's
+  // pop4). Use this as a shortcut: if it exceeds the next sequential k,
+  // jump to it directly instead of stepping through intermediate
+  // values. The FC will close at exactly that k.
+  uint64_t fc_hint = learn_k_from_goto_bounds(goto_functions);
+  bool hint_consumed = false;
+
+  // Trying all bounds from 1 to "max_k_step" in "k_step_inc".
   uint64_t last_k_step = k_step_base;
-  for (uint64_t k_step = k_step_base; k_step <= max_k_step;
-       k_step += k_step_inc)
+  uint64_t k_step = k_step_base;
+  while (k_step <= max_k_step)
   {
     last_k_step = k_step;
     // k-induction
@@ -1770,12 +1783,36 @@ int esbmc_parseoptionst::do_bmc_strategy(
         return conclude();
       }
     }
+
     // falsification
     if (options.get_bool_option("falsification"))
     {
       if (is_base_case_violated(options, goto_functions, k_step).is_true())
         return 1;
     }
+
+    // Bump k. The default increment is `k_step_inc`. If we found a loop
+    // bound in the goto program that exceeds the next sequential k,
+    // jump directly to that value — the FC will close at exactly that
+    // k. Apply the hint at most once so we don't spin if the FC fails
+    // to close at the hinted value. Raise max_k_step if the hint
+    // exceeds it, since otherwise we'd hit the cap before the proof
+    // closes.
+    uint64_t next_k = k_step + k_step_inc;
+    if (!hint_consumed && fc_hint > next_k)
+    {
+      log_status(
+        "Goto program exposes loop bound {:d}; "
+        "skipping k_step from {:d} to {:d}",
+        fc_hint,
+        next_k,
+        fc_hint);
+      next_k = fc_hint;
+      if (fc_hint > max_k_step)
+        max_k_step = fc_hint;
+      hint_consumed = true;
+    }
+    k_step = next_k;
   }
 
   if (
@@ -1857,6 +1894,63 @@ tvt esbmc_parseoptionst::is_base_case_violated(
 //    TV_FALSE if all reachable loops have at most "k_step" iterations
 // for all input values in "goto_functions".
 //    TV_UNKNOWN - otherwise.
+/// Recursively scan @p expr for constant_int2t leaves and update @p best
+/// with the largest non-negative value found. Caps at 1<<20 to avoid
+/// catastrophic jumps when the program contains huge unrelated constants
+/// (INT_MAX, ULONG_MAX, etc.).
+static void collect_max_int_constant(const expr2tc &expr, uint64_t &best)
+{
+  if (is_nil_expr(expr))
+    return;
+  if (is_constant_int2t(expr))
+  {
+    const BigInt &v = to_constant_int2t(expr).value;
+    if (!v.is_negative() && v.is_uint64())
+    {
+      uint64_t lv = v.to_uint64();
+      // Reject obviously-unrelated huge constants — they're not loop
+      // bounds, just type-max sentinels or pointer offsets.
+      constexpr uint64_t SANE_CAP = 1ULL << 20;
+      if (lv > SANE_CAP)
+        return;
+      if (lv > best)
+        best = lv;
+    }
+    return;
+  }
+  expr->foreach_operand(
+    [&best](const expr2tc &e) { collect_max_int_constant(e, best); });
+}
+
+/// Pre-compute the next-k hint by scanning the goto program for loop-
+/// bound constants. The k-induction transformation has run by this point
+/// and inserts a pre-loop ASSUME of the entry condition containing the
+/// loop bound literals (e.g. `ASSUME !(x == 0 || i >= 64)` for popcount).
+/// Walk all ASSUME and back-edge GOTO instructions, collect integer
+/// constants from their guards, return the max.
+///
+/// Returns 0 when no usable bound is found (caller falls back to the
+/// normal k-step increment).
+static uint64_t learn_k_from_goto_bounds(const goto_functionst &goto_functions)
+{
+  uint64_t best = 0;
+  for (const auto &fn : goto_functions.function_map)
+  {
+    if (!fn.second.body_available)
+      continue;
+    for (const auto &ins : fn.second.body.instructions)
+    {
+      // Loop bound constants live in two places after k-induction has
+      // transformed the program: the inserted entry ASSUMEs, and the
+      // back-edge IF guards (which still mention `i < N` in the
+      // non-simplified copy).
+      if (ins.is_assume() || ins.is_backwards_goto() || ins.is_goto())
+        collect_max_int_constant(ins.guard, best);
+    }
+  }
+  return best;
+}
+
 tvt esbmc_parseoptionst::does_forward_condition_hold(
   optionst &options,
   goto_functionst &goto_functions,

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -85,10 +85,15 @@ protected:
     goto_functionst &goto_functions,
     const uint64_t &k_step);
 
+  /// Run the inductive-step check at @p k_step.
+  /// On TV_TRUE (refutation, model exists), populates @p next_k_hint with
+  /// the largest constant-int value the model assigned in the CEX. Used
+  /// as a dynamic next-k hint when the static goto-bounds hint is 0.
   tvt is_inductive_step_violated(
     optionst &options,
     goto_functionst &goto_functions,
-    const uint64_t &k_step);
+    const uint64_t &k_step,
+    uint64_t &next_k_hint);
 
   void diagnose_unknown_properties(
     optionst &options,


### PR DESCRIPTION
## Summary

Add a "next-k hint" mechanism to the k-induction outer loop. Two sources feed the hint:

1. **Static scan** of the post-k-induction goto program for the largest loop-bound constant (typically the literal bound from \`for (i = 0; i < N; i++)\` patterns that the entry-cond ASSUMEs preserve verbatim).
2. **Dynamic IS-CEX scan** when the static scan finds nothing: when the inductive step refutes (SAT model), extract the largest constant-int the model assigned to any variable. The IS picks adversarial values along an actually-feasible execution, so this value approximates the loop's iteration depth even when the bound is symbolic (\`for (i = 0; i < n; i++)\` with \`n\` a free parameter).

When the hint exceeds the next sequential \`k_step\`, jump directly to it instead of stepping through every intermediate k. The FC then closes at exactly that k.

## Commits

1. **\`[k-induction] learn next k from goto-level loop bounds\`** — Static scan.
2. **\`[termination] don't apply goto-bounds k-hint under --termination\`** — Termination's win condition is IS UNSAT at small k; skipping intermediate k values hides those proofs. Gate the hint off when \`--termination\` is set.
3. **\`[k-induction] additionally learn k from inductive-step CEX\`** — Dynamic fallback. Plumbs \`last_error_trace\` through \`bmct\` so the IS caller can introspect the model.
4. **\`[termination] pass unused hint param to is_inductive_step_violated\`** — Mechanical: the termination call site discards the hint (per commit 2).
5. **\`[k-induction] gate goto-bounds hint to user code & past IS cap\`** — Two follow-up fixes found in regression:
   - Skip \`body.hide\` library helpers when scanning (their large constants like ldexp's 2047 don't represent user loops).
   - Don't fire the hint until past \`--max-inductive-step\`: jumping past intermediate k hides small-k IS UNSAT proofs (the primary k-induction win condition).
   - Promote \`regression/k-induction/sum06\` from KNOWNBUG to CORE — the hint now closes its FC at k=1000.

## Score impact

ReachSafety-Loops (764 benchmarks, 30s timeout, j=16):

| | master baseline (May 23) | this branch |
|---|---|---|
| Correct true | 260 | **270** (+10) |
| Correct false | 125 | **145** (+20) |
| Wrong-true | 0 | 0 |

Worked example (sum06): the loop \`while (i <= n)\` with \`__VERIFIER_assume(n < 1000)\` has its bound \`1000\` extractable from the goto ASSUME. The hint jumps k to 1000, FC closes there, and the previously-KNOWNBUG test now passes.

SV-COMP termination set: neutral (the hint is gated off under \`--termination\` to preserve small-k IS UNSAT wins).

## Test plan

- [x] \`ctest -j16 -L "termination/"\` — 65/65 pass
- [x] \`ctest -j16\` over k-induction subset — all pass after the hint-gating fix
- [x] ReachSafety-Loops sweep — +10 CT, +20 CF, 0 wrong-true
- [x] SV-COMP termination sweep — no regression
- [x] Manual verification of \`is_pointer_invariant_list*\` (IS proves at k=2 with hint-gating; without gating, the k=2→4 jump masked the IS proof and the test hung)