### PR TITLE
[python] V.3: migrate string char_utils + string_builder to IREP2

### DIFF
--- a/src/python-frontend/string/char_utils.cpp
+++ b/src/python-frontend/string/char_utils.cpp
@@ -1,7 +1,9 @@
 #include "char_utils.h"
 
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/migrate.h>
 #include <util/std_types.h>
 #include <util/std_expr.h>
 
@@ -9,6 +11,30 @@ namespace python_char_utils
 {
 namespace
 {
+// V.3: IREP2 expression-construction helpers (exact round-trip of the legacy
+// constructors; behaviour-preserving). Back-migrated for the legacy seam.
+exprt build_index(const exprt &arr, const exprt &idx, const typet &t)
+{
+  expr2tc arr2, idx2;
+  migrate_expr(arr, arr2);
+  migrate_expr(idx, idx2);
+  return migrate_expr_back(index2tc(migrate_type(t), arr2, idx2));
+}
+
+exprt build_typecast(const exprt &from, const typet &t)
+{
+  expr2tc from2;
+  migrate_expr(from, from2);
+  return migrate_expr_back(typecast2tc(migrate_type(t), from2));
+}
+
+exprt build_dereference(const exprt &ptr, const typet &t)
+{
+  expr2tc ptr2;
+  migrate_expr(ptr, ptr2);
+  return migrate_expr_back(dereference2tc(migrate_type(t), ptr2));
+}
+
 bool is_char_array_of_length(const typet &type, std::size_t expected_length)
 {
   if (!type.is_array())
@@ -42,8 +68,9 @@ bool try_get_single_char_expr(
 
   if (is_char_array_of_length(expr.type(), 2))
   {
+    // Source is a 2-char array (checked above) -> index2t source ok.
     exprt zero_index = from_integer(0, index_type());
-    char_expr = index_exprt(expr, zero_index, char_type());
+    char_expr = build_index(expr, zero_index, char_type());
     return true;
   }
 
@@ -51,8 +78,8 @@ bool try_get_single_char_expr(
     allow_void_pointer && expr.type().is_pointer() &&
     (expr.type().subtype().is_nil() || expr.type().subtype().id() == "empty"))
   {
-    exprt char_ptr = typecast_exprt(expr, pointer_typet(char_type()));
-    char_expr = dereference_exprt(char_ptr, char_type());
+    exprt char_ptr = build_typecast(expr, pointer_typet(char_type()));
+    char_expr = build_dereference(char_ptr, char_type());
     return true;
   }
 
@@ -65,7 +92,7 @@ exprt get_char_value_as_int(const exprt &expr, bool allow_void_pointer)
   if (!try_get_single_char_expr(expr, char_expr, allow_void_pointer))
     return nil_exprt();
 
-  return typecast_exprt(char_expr, signedbv_typet(8));
+  return build_typecast(char_expr, signedbv_typet(8));
 }
 
 } // namespace python_char_utils

--- a/src/python-frontend/string/string_builder.cpp
+++ b/src/python-frontend/string/string_builder.cpp
@@ -1,13 +1,53 @@
 #include "string_builder.h"
 #include "python_converter.h"
 #include "type_handler.h"
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
+#include <util/migrate.h>
 #include <util/std_code.h>
 #include <util/expr_util.h>
 #include <python-frontend/python_frontend_limits.h>
 #include <optional>
 #include <stdexcept>
 #include <limits>
+
+namespace
+{
+// V.3: IREP2 expression-construction helpers (exact round-trip of the legacy
+// constructors; behaviour-preserving -- migrate_expr already lowers the legacy
+// nodes through these same paths downstream). Back-migrated for the legacy
+// adjust/goto-convert seam; the caller sets .location() where it did before.
+exprt build_call_expr(
+  const symbolt &fn,
+  const typet &return_type,
+  const std::vector<exprt> &args)
+{
+  std::vector<expr2tc> args2;
+  args2.reserve(args.size());
+  for (const exprt &a : args)
+  {
+    expr2tc a2;
+    migrate_expr(a, a2);
+    args2.push_back(std::move(a2));
+  }
+  return migrate_expr_back(side_effect_function_call2tc(
+    migrate_type(return_type), symbol_expr2tc(fn), args2));
+}
+
+exprt build_typecast(const exprt &from, const typet &t)
+{
+  expr2tc from2;
+  migrate_expr(from, from2);
+  return migrate_expr_back(typecast2tc(migrate_type(t), from2));
+}
+
+exprt build_address_of(const exprt &obj)
+{
+  expr2tc obj2;
+  migrate_expr(obj, obj2);
+  return migrate_expr_back(address_of2tc(obj2->type, obj2));
+}
+} // namespace
 
 string_builder::string_builder(python_converter &conv, string_handler *handler)
   : converter_(conv), str_handler_(handler)
@@ -397,12 +437,8 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
       repeat_symbol = get_symbol_table().find_symbol(func_symbol_id);
     }
 
-    side_effect_expr_function_callt repeat_call;
-    repeat_call.function() = symbol_expr(*repeat_symbol);
-    repeat_call.arguments().push_back(str_addr);
-    repeat_call.arguments().push_back(count);
-    repeat_call.type() = gen_pointer_type(char_type());
-    return repeat_call;
+    return build_call_expr(
+      *repeat_symbol, gen_pointer_type(char_type()), {str_addr, count});
   };
 
   // Get size (e.g.: "a" * 3)
@@ -553,12 +589,9 @@ exprt string_builder::concatenate_strings_via_c_function(
   }
 
   // Create the function call: __python_str_concat(lhs, rhs)
-  side_effect_expr_function_callt concat_call;
-  concat_call.function() = symbol_expr(*concat_symbol);
-  concat_call.arguments().push_back(lhs_addr);
-  concat_call.arguments().push_back(rhs_addr);
+  exprt concat_call = build_call_expr(
+    *concat_symbol, gen_pointer_type(char_type()), {lhs_addr, rhs_addr});
   concat_call.location() = location;
-  concat_call.type() = gen_pointer_type(char_type());
 
   return concat_call;
 }
@@ -589,14 +622,9 @@ exprt string_builder::build_runtime_str_conversion_call(
 
   exprt arg_expr = arg;
   if (arg_expr.type() != arg_type)
-    arg_expr = typecast_exprt(arg_expr, arg_type);
+    arg_expr = build_typecast(arg_expr, arg_type);
 
-  side_effect_expr_function_callt call;
-  call.function() = symbol_expr(*fn_symbol);
-  call.arguments().push_back(arg_expr);
-  call.type() = gen_pointer_type(char_type());
-
-  return call;
+  return build_call_expr(*fn_symbol, gen_pointer_type(char_type()), {arg_expr});
 }
 
 exprt string_builder::build_runtime_str_join_call(
@@ -630,15 +658,9 @@ exprt string_builder::build_runtime_str_join_call(
   exprt sep_arg = str_handler_->get_array_base_address(separator);
 
   exprt list_arg =
-    list_expr.type().is_pointer() ? list_expr : address_of_exprt(list_expr);
+    list_expr.type().is_pointer() ? list_expr : build_address_of(list_expr);
   if (list_arg.type() != list_ptr)
-    list_arg = typecast_exprt(list_arg, list_ptr);
+    list_arg = build_typecast(list_arg, list_ptr);
 
-  side_effect_expr_function_callt call;
-  call.function() = symbol_expr(*fn_symbol);
-  call.arguments().push_back(sep_arg);
-  call.arguments().push_back(list_arg);
-  call.type() = char_ptr;
-
-  return call;
+  return build_call_expr(*fn_symbol, char_ptr, {sep_arg, list_arg});
 }


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction in the converter, #5055), after #5084. This **starts file 11 — the `string/` handlers** (the densest specialist), beginning with the two smaller files. `string_handler.cpp` and `string_method_handler.cpp` will follow as separate PRs.

Two per-file commits, each adding file-local exact-round-trip helpers (build the IREP2 node, `migrate_expr_back` at the legacy seam) and rewiring construction sites:

**`char_utils.cpp`** (4 sites)
- `build_index()` — single-char access on a 2-char array (`is_char_array_of_length` ⇒ `is_array()`) → `index2tc`.
- `build_typecast()` — `void*`→`char*` and `char`→`signedbv(8)` casts → `typecast2tc`.
- `build_dereference()` — deref of the freshly-built `char*` (pointer-typed) → `dereference2tc`.

**`string_builder.cpp`** (7 sites)
- `build_call_expr()` — the 4 hand-built `side_effect_expr_function_callt` runtime string calls (`__python_str_repeat`/`concat`/conversion/`join`) → `side_effect_function_call2tc` + `symbol_expr2tc`; callers set `.location()` exactly where they did before.
- `build_typecast()` — 2 argument-coercion casts → `typecast2tc`.
- `build_address_of()` — the list-argument address-of (non-pointer-guarded) → `address_of2tc(obj->type, obj)`.

### Notes
- Behaviour-preserving exact round-trip — `migrate_expr` already lowers every legacy `member`/`index`/`typecast`/`address_of`/`dereference`/`side_effect` node through these same paths downstream at goto-convert.
- **String literals stay legacy** (`constant_exprt`) per Q-P4 — not ported.
- The two identically-named `build_typecast` helpers live in separate anonymous namespaces (internal linkage per TU) — no ODR concern.

### Verification
- Build green.
- 588/588 string-related python regression tests pass.
- No branch added/removed (pure expression-construction substitution).
