### PR TITLE
[python] V.3: migrate string_handler construction to IREP2

### DIFF
--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -11,9 +11,11 @@
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_utils.h>
 #include <python-frontend/symbol_id.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_expr.h>
 #include <util/std_code.h>
@@ -35,6 +37,60 @@
 #include <stdexcept>
 #include <unordered_map>
 #include <vector>
+
+namespace
+{
+// V.3: IREP2 expression-construction helpers (exact round-trip of the legacy
+// constructors; behaviour-preserving -- migrate_expr already lowers the legacy
+// nodes through these same paths downstream). Back-migrated for the legacy
+// adjust/goto-convert seam; the caller sets .location() where it did before.
+exprt build_call_expr(
+  const symbolt &fn,
+  const typet &return_type,
+  const std::vector<exprt> &args)
+{
+  std::vector<expr2tc> args2;
+  args2.reserve(args.size());
+  for (const exprt &a : args)
+  {
+    expr2tc a2;
+    migrate_expr(a, a2);
+    args2.push_back(std::move(a2));
+  }
+  return migrate_expr_back(side_effect_function_call2tc(
+    migrate_type(return_type), symbol_expr2tc(fn), args2));
+}
+
+exprt build_typecast(const exprt &from, const typet &t)
+{
+  expr2tc from2;
+  migrate_expr(from, from2);
+  return migrate_expr_back(typecast2tc(migrate_type(t), from2));
+}
+
+exprt build_symbol(const symbolt &sym)
+{
+  return migrate_expr_back(symbol_expr2tc(sym));
+}
+
+// 2-arg index: element type is the source array's subtype (matches the legacy
+// index_exprt(arr, idx) ctor). Reached only on array sources here.
+exprt build_index(const exprt &arr, const exprt &idx)
+{
+  expr2tc arr2, idx2;
+  migrate_expr(arr, arr2);
+  migrate_expr(idx, idx2);
+  return migrate_expr_back(
+    index2tc(migrate_type(arr.type().subtype()), arr2, idx2));
+}
+
+exprt build_address_of(const exprt &obj)
+{
+  expr2tc obj2;
+  migrate_expr(obj, obj2);
+  return migrate_expr_back(address_of2tc(obj2->type, obj2));
+}
+} // namespace
 
 string_handler::string_handler(
   python_converter &converter,
@@ -852,7 +908,7 @@ exprt string_handler::convert_to_string(const exprt &expr)
   {
     typet char_ptr = gen_pointer_type(char_type());
     if (t != char_ptr)
-      return typecast_exprt(expr, char_ptr);
+      return build_typecast(expr, char_ptr);
     return expr;
   }
 
@@ -1074,8 +1130,10 @@ exprt string_handler::get_array_base_address(const exprt &arr)
 {
   if (arr.type().is_pointer())
     return arr;
-  exprt index = index_exprt(arr, from_integer(0, index_type()));
-  return address_of_exprt(index);
+  // arr is non-pointer (array) here; index2t source ok, address_of of a
+  // non-constant/non-address_of expr is a valid address_of2t source.
+  exprt index = build_index(arr, from_integer(0, index_type()));
+  return build_address_of(index);
 }
 
 exprt string_handler::handle_string_concatenation_with_promotion(
@@ -1107,9 +1165,9 @@ exprt string_handler::handle_string_concatenation_with_promotion(
       {
         symbolt &temp = converter_.create_tmp_symbol(
           nlohmann::json(), "$char_temp$", lhs.type(), gen_zero(lhs.type()));
-        code_assignt assign(symbol_expr(temp), lhs);
+        code_assignt assign(build_symbol(temp), lhs);
         converter_.add_instruction(assign);
-        lhs_value = symbol_expr(temp);
+        lhs_value = build_symbol(temp);
       }
 
       typet string_type = type_handler_.build_array(char_type(), 2);
@@ -1191,14 +1249,12 @@ exprt string_handler::handle_string_membership(
     exprt rhs_addr = get_array_base_address(rhs_str);
 
     // lhs contains the character value (as void*), cast directly to int
-    typecast_exprt char_as_int(lhs, int_type());
+    exprt char_as_int = build_typecast(lhs, int_type());
 
     // Call strchr(string, character)
-    side_effect_expr_function_callt strchr_call;
-    strchr_call.function() = symbol_expr(*strchr_symbol);
-    strchr_call.arguments() = {rhs_addr, char_as_int};
+    exprt strchr_call = build_call_expr(
+      *strchr_symbol, gen_pointer_type(char_type()), {rhs_addr, char_as_int});
     strchr_call.location() = converter_.get_location_from_decl(element);
-    strchr_call.type() = gen_pointer_type(char_type());
 
     // Check if result != NULL (character found)
     constant_exprt null_ptr(gen_pointer_type(char_type()));
@@ -1336,12 +1392,10 @@ exprt string_handler::handle_string_membership(
     throw std::runtime_error("strstr function not found for 'in' operator");
 
   // Call strstr(haystack, needle) - in Python "needle in haystack"
-  side_effect_expr_function_callt strstr_call;
-  strstr_call.function() = symbol_expr(*strstr_symbol);
-  strstr_call.arguments() = {
-    rhs_addr, lhs_addr}; // haystack is rhs, needle is lhs
+  // haystack is rhs, needle is lhs
+  exprt strstr_call = build_call_expr(
+    *strstr_symbol, gen_pointer_type(char_type()), {rhs_addr, lhs_addr});
   strstr_call.location() = converter_.get_location_from_decl(element);
-  strstr_call.type() = gen_pointer_type(char_type());
 
   // Check if result != NULL (substring found)
   constant_exprt null_ptr(gen_pointer_type(char_type()));
@@ -1455,7 +1509,7 @@ exprt string_handler::handle_string_to_int(
   else if (!base_expr.type().is_signedbv() && !base_expr.type().is_unsignedbv())
   {
     // Cast base to int if needed
-    base_expr = typecast_exprt(base_expr, int_type());
+    base_expr = build_typecast(base_expr, int_type());
   }
 
   // Find the __python_int function symbol
@@ -1466,12 +1520,9 @@ exprt string_handler::handle_string_to_int(
   }
 
   // Call __python_int(str, base)
-  side_effect_expr_function_callt int_call;
-  int_call.function() = symbol_expr(*int_symbol);
-  int_call.arguments().push_back(str_addr);
-  int_call.arguments().push_back(base_expr);
+  exprt int_call =
+    build_call_expr(*int_symbol, int_type(), {str_addr, base_expr});
   int_call.location() = location;
-  int_call.type() = int_type();
 
   return int_call;
 }
@@ -1499,7 +1550,7 @@ exprt string_handler::handle_int_conversion(
   // If argument is a float, truncate to integer
   if (arg.type().is_floatbv())
   {
-    return typecast_exprt(arg, int_type());
+    return build_typecast(arg, int_type());
   }
 
   // If argument is a boolean, convert to 0 or 1
@@ -1527,7 +1578,7 @@ exprt string_handler::handle_int_conversion(
   }
 
   // For other types, attempt a typecast
-  return typecast_exprt(arg, int_type());
+  return build_typecast(arg, int_type());
 }
 
 exprt string_handler::handle_int_conversion_with_base(
@@ -1545,7 +1596,7 @@ exprt string_handler::handle_int_conversion_with_base(
   exprt base_expr = base;
   if (!base_expr.type().is_signedbv() && !base_expr.type().is_unsignedbv())
   {
-    base_expr = typecast_exprt(base_expr, int_type());
+    base_expr = build_typecast(base_expr, int_type());
   }
 
   return handle_string_to_int(arg, base_expr, location);
@@ -1567,11 +1618,8 @@ exprt string_handler::handle_string_to_float(
       "__python_str_to_float function not found in symbol table");
 
   // Call __python_str_to_float(str)
-  side_effect_expr_function_callt float_call;
-  float_call.function() = symbol_expr(*float_symbol);
-  float_call.arguments().push_back(str_addr);
+  exprt float_call = build_call_expr(*float_symbol, double_type(), {str_addr});
   float_call.location() = location;
-  float_call.type() = double_type();
 
   return float_call;
 }
@@ -1591,11 +1639,8 @@ exprt string_handler::handle_string_is_float(
       "__python_str_is_float function not found in symbol table");
 
   // Call __python_str_is_float(str)
-  side_effect_expr_function_callt check_call;
-  check_call.function() = symbol_expr(*check_symbol);
-  check_call.arguments().push_back(str_addr);
+  exprt check_call = build_call_expr(*check_symbol, bool_type(), {str_addr});
   check_call.location() = location;
-  check_call.type() = bool_type();
 
   return check_call;
 }
@@ -1612,7 +1657,7 @@ exprt string_handler::handle_chr_conversion(
   {
     // If it's a float, truncate to integer
     if (codepoint_expr.type().is_floatbv())
-      codepoint_expr = typecast_exprt(codepoint_expr, int_type());
+      codepoint_expr = build_typecast(codepoint_expr, int_type());
     // If it's a boolean, convert to 0 or 1
     else if (codepoint_expr.type().is_bool())
     {
@@ -1628,7 +1673,7 @@ exprt string_handler::handle_chr_conversion(
 
   // Cast to int type if it's a different integer width
   if (codepoint_expr.type() != int_type())
-    codepoint_expr = typecast_exprt(codepoint_expr, int_type());
+    codepoint_expr = build_typecast(codepoint_expr, int_type());
 
   // Find the __python_chr function symbol
   symbolt *chr_symbol = find_cached_c_function_symbol("c:@F@__python_chr");
@@ -1636,11 +1681,9 @@ exprt string_handler::handle_chr_conversion(
     throw std::runtime_error("__python_chr function not found in symbol table");
 
   // Call __python_chr(codepoint)
-  side_effect_expr_function_callt chr_call;
-  chr_call.function() = symbol_expr(*chr_symbol);
-  chr_call.arguments().push_back(codepoint_expr);
+  exprt chr_call =
+    build_call_expr(*chr_symbol, pointer_typet(char_type()), {codepoint_expr});
   chr_call.location() = location;
-  chr_call.type() = pointer_typet(char_type());
 
   return chr_call;
 }
@@ -1706,7 +1749,7 @@ exprt string_handler::try_handle_len_string_fast_path(
     {
       const symbolt *len_sym = converter_.find_symbol(it->second);
       if (len_sym)
-        return typecast_exprt(symbol_expr(*len_sym), size_type());
+        return build_typecast(build_symbol(*len_sym), size_type());
     }
   }
 
@@ -2419,13 +2462,13 @@ exprt string_handler::handle_single_char_comparison(
   // Handle mixed cases: dereferenced pointer with valid character value
   if (lhs_to_check.id() == "dereference" && !rhs_char_value.is_nil())
   {
-    exprt lhs_as_int = typecast_exprt(lhs_to_check, rhs_char_value.type());
+    exprt lhs_as_int = build_typecast(lhs_to_check, rhs_char_value.type());
     return create_comparison(lhs_as_int, rhs_char_value);
   }
 
   if (!lhs_char_value.is_nil() && rhs_to_check.id() == "dereference")
   {
-    exprt rhs_as_int = typecast_exprt(rhs_to_check, lhs_char_value.type());
+    exprt rhs_as_int = build_typecast(rhs_to_check, lhs_char_value.type());
     return create_comparison(lhs_char_value, rhs_as_int);
   }
 


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction in the converter, #5055), after #5086. File 11 (the `string/` handlers), part 3 — `string_handler.cpp`.

Adds five file-local exact-round-trip helpers (build the IREP2 node, `migrate_expr_back` at the legacy seam) and rewires ~20 construction sites:

- **`build_call_expr()`** — the 6 `side_effect_expr_function_callt` runtime calls (`strchr`, `strstr`, `__python_int`, `__python_str_to_float`, `__python_str_is_float`, `__python_chr`) → `side_effect_function_call2tc` + `symbol_expr2tc`; callers set `.location()` exactly where they did before.
- **`build_typecast()`** — 11 coercion casts (`char*` / `int` / `size_t` / char-value types, including `floatbv`→`int`, which relies on the default `__ESBMC_rounding_mode` — matching `migrate_expr`'s lowering of a legacy `typecast_exprt`) → `typecast2tc`.
- **`build_symbol()`** — the standalone `symbol_expr(temp)` (×2) and the nested `symbol_expr(*len_sym)` → `symbol_expr2tc`.
- **`build_index()` / `build_address_of()`** — `get_array_base_address`'s `index_exprt` + `address_of_exprt`, reached only after the `is_pointer()` early-return (so `arr` is array-typed and `index` is a valid `address_of2t` source) → `index2tc` (element type = `arr.type().subtype()`, matching the 2-arg `index_exprt` ctor) / `address_of2tc(obj->type, obj)`.

### Notes
- Behaviour-preserving exact round-trip — `migrate_expr` already lowers every legacy node through these same paths downstream at goto-convert.
- `strstr` args stay `{haystack=rhs, needle=lhs}` (not swapped); all return types preserved.
- **String literals stay legacy** (`constant_exprt`) per Q-P4.

### Verification
- Build green.
- 647/647 string + `int`/`float`-conversion python regression tests pass.
- No branch added/removed (pure expression-construction substitution).
