### PR TITLE
[docs] sync Python website docs with PRs #4881–#5084

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -40,6 +40,12 @@ weight: 4
 - `print()` evaluates each argument expression once (so safety checks and call side effects reach the GOTO program) but produces no actual output during verification.
 - `enumerate()` supports the iterable + `start` keyword forms; nested or unusually-shaped iterables are not exercised by the regression suite and may surface edge cases.
 
+## Walrus Operator
+
+- The walrus operator `:=` is supported only where the target is evaluated exactly once: `if`/`elif` conditions, standalone assignment expressions, and comprehension filters (see [Supported Features](./supported-features#basic-constructs)).
+- Use inside a boolean (`and`/`or`) operand is refused: `ERROR: Walrus operator ':=' in a boolean (and/or) operand is not supported`.
+- Use in a `while`-loop condition is refused: `ERROR: Walrus operator ':=' in a while-loop condition is not supported`.
+
 ## Lambda Expressions
 
 - Return type inference is naive and defaults to `double`.
@@ -84,7 +90,7 @@ weight: 4
 - `defaultdict`: subscript access/assignment and the common type-factory forms are supported — `defaultdict(list)` (with `.append()` on the materialised list), the built-in scalar factories `defaultdict(int)` / `float` / `bool` / `str`, and nullary `lambda` factories whose body is a constant or built-in constructor (e.g. `defaultdict(lambda: float('inf'))`). On an unannotated dict the value type is also inferred from a constant literal subscript assignment (`d[k] = 5`). The `__missing__` hook and other methods are not.
 - `Counter`: only `__getitem__`, `__setitem__`, `values()`, and truthiness are supported. `most_common()` accepts the call but its result is unusable in any subsequent expression — comparisons trip a frontend "Unsupported comparison" error ([#4665](https://github.com/esbmc/esbmc/issues/4665)). `elements()`, `subtract()`, and arithmetic operators are not supported.
 - `Counter.update(...)` / `dict.update(...)` accept only the single-positional-argument form; the keyword-argument form (`c.update(a=1)`) is rejected at parse time even though it is valid CPython.
-- `OrderedDict` and `deque` support construction and basic indexing / append / `__setitem__`. `namedtuple`, `ChainMap`, and other `collections` types are not supported.
+- `OrderedDict` supports construction and basic indexing / append / `__setitem__`. `deque` adds the FIFO-front methods `popleft()` and `appendleft()` on top of construction / indexing / `append` / `__setitem__`; other `deque` methods (`extend`, `rotate`, `maxlen`, etc.) are not supported. `namedtuple`, `ChainMap`, and other `collections` types are not supported.
 
 ## Datetime Module
 
@@ -117,11 +123,12 @@ weight: 4
 ## Exception Handling
 
 - Core built-in exception types are supported, but not all Python standard library exceptions; custom exception hierarchies with complex inheritance patterns may not be fully handled.
+- `try`/`finally` is supported (including bare `try`/`finally`), but two shapes are refused at parse time rather than lowered unsoundly: a non-empty `else` clause on the `try` (a pre-existing gap — `orelse` is silently dropped today), and a `return`/`break`/`continue` that escapes the `try`, an `except` handler, or the `finally` body (it would bypass the appended `finally`).
 
 ## Class Attributes
 
 - Type inference for class attributes requires values with clear, determinable types; complex expressions may require explicit type annotations.
-- Recovering a self-referential attribute's type from constructor arguments (the linked-list / tree pattern, e.g. `self.successor = successor` set via `Node(2, a)`) is scoped to the module currently being processed. When the class is imported from another module (`from node import Node`), the module-level instances in the importing file are not visible while `__init__` is processed, so the type is not recovered.
+- Recovering a self-referential attribute's type from constructor arguments (the linked-list / tree pattern, e.g. `self.successor = successor` set via `Node(2, a)`) works both within a module and across the module boundary for an imported class (`from node import Node`). It relies on unifying against module-level `ClassName(...)` instantiations: if the class is never instantiated at module scope with the relevant positional argument, the attribute type cannot be recovered and an explicit annotation is required.
 
 ## Missing Return Detection
 
@@ -143,7 +150,7 @@ weight: 4
   - `Thread` as a class attribute (`class C: t = Thread(...)`)
   - `target` defined after the caller in source order
   - `from threading import *`
-- **Other `threading` primitives are not supported**: `RLock`, `Semaphore`, `Condition`, `Event`, `Barrier`, `Timer` are refused at parse time. `queue.Queue` is also unsupported and blocks the existing `regression/python/concurrency_fail` example.
+- **Other `threading` primitives are not supported**: `RLock`, `Semaphore`, `Condition`, `Event`, `Barrier`, `Timer` are refused at parse time. The `queue` module now has a single-threaded model (`queue.Queue`/`LifoQueue`; see [Supported Features — Queue](./supported-features#queue-module-queue)), but its blocking `put()`/`get()` semantics are not modelled, so it does not provide thread synchronisation.
 - **The CPython Global Interpreter Lock (GIL) is not modelled** ([#4579](https://github.com/esbmc/esbmc/issues/4579)). Translated programs execute under sequentially-consistent POSIX semantics rather than GIL-serialised bytecode execution, so the analysis over-approximates the set of feasible interleavings compared to actual CPython execution. This preserves safety but may produce spurious concurrency counterexamples.
 
 ## Module System

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -11,7 +11,8 @@ This page is a reference of all Python language constructs, data structures, and
 - **Arithmetic**: `+`, `-`, `*`, `/`, `//`, `%`, `**`
 - **Logical operations**: `and`, `or`, `not`
 - **Identity comparisons**: `is`, `is not` (including `x is None`, `x is not None`)
-- **Tuple-unpacking assignment**: `a, b = b, a` and cross-binding forms like `a, b = b, a % b` evaluate the entire right-hand side before binding any target (Python's parallel-assignment semantics), so swaps and idioms such as the Euclidean-GCD loop `while b: a, b = b, a % b` are lowered correctly. The simple non-cross-binding shape (`x, y = 1, 2`) uses direct assignment.
+- **Tuple-unpacking assignment**: `a, b = b, a` and cross-binding forms like `a, b = b, a % b` evaluate the entire right-hand side before binding any target (Python's parallel-assignment semantics), so swaps and idioms such as the Euclidean-GCD loop `while b: a, b = b, a % b` are lowered correctly. The simple non-cross-binding shape (`x, y = 1, 2`) uses direct assignment. Unpacking targets may be subscripts or attributes (`a[i], b.x = ...`).
+- **Walrus operator** (PEP 572 `:=`): assignment expressions in the contexts where the target is evaluated exactly once — an `if`/`elif` condition (`if (n := len(data)) > 2:`), a standalone assignment expression (`x = (y := 5)`), and a comprehension filter (`[d for v in data if (d := v * 2) > 4]`). The expression evaluates to the bound value. Use inside `and`/`or` operands and `while`-loop conditions is refused with a clear diagnostic (see [Limitations](./limitations#walrus-operator)).
 - **None handling**: Proper type distinction from `int`, `bool`, `str`, etc.; correctly falsy in boolean contexts (`None and True` → `None`, `None or 1` → `1`)
 - **Global variables**: The `global` keyword for accessing and modifying global scope from within functions
 - **Context managers**: `with` and `async with` statements via preprocessor desugaring into explicit `__enter__`/`__exit__` calls:
@@ -41,7 +42,7 @@ This page is a reference of all Python language constructs, data structures, and
 - **PEP 604 attribute annotations**: `self.x: T | None` (and other `T1 | T2` `BinOp` annotations) are recognised and mapped to the same pointer-to-`T` encoding used for `Optional[T]`
 - **Instance variables**: Attributes defined in `__init__`
 - **Object reference semantics**: When an instance attribute is assigned an aliased class-instance reference (e.g. `self.head = head` from a constructor parameter), the field is stored as a reference, so mutating the object through one binding is visible through the attribute (and vice versa). This makes linked-list, queue, and tree patterns that reassign such attributes through chained references (`curr = q.head; curr = curr.nxt; q.head = curr`) verify correctly. A fresh-constructor RHS (`self.a: A = A()`) is still constructed in place by value.
-- **Self-referential instance attributes**: When an attribute set in `__init__` from a `param=None`-defaulted parameter (e.g. `self.successor = successor`) is populated at construction time (`Node(2, a)`), its field type is recovered by unifying the matching positional constructor argument across module-level `ClassName(...)` calls — enabling linked-list / tree patterns and multi-level attribute chains such as `c.successor.successor`. Recovery is limited to the module being processed (see [Limitations — Class Attributes](./limitations#class-attributes)).
+- **Self-referential instance attributes**: When an attribute set in `__init__` from a `param=None`-defaulted parameter (e.g. `self.successor = successor`) is populated at construction time (`Node(2, a)`), its field type is recovered by unifying the matching positional constructor argument across module-level `ClassName(...)` calls — enabling linked-list / tree patterns and multi-level attribute chains such as `c.successor.successor`. This also works when the class is imported from another module (`from node import Node`): the attribute types are inferred across the module boundary, so a nested read like `node.successor.value` on an imported-class instance resolves.
 - **Inheritance**: Single and multi-level inheritance; verification of scenarios involving overridden methods
 - **`super()` calls**: `super().__init__(...)` and other `super().method(...)` calls, enabling verification of polymorphic behavior and parent-constructor side effects
 - **Class-method defaults**: `Name` defaults referencing `ESBMC_default_*` helpers are hoisted past the enclosing `ClassDef` so they remain visible at call sites
@@ -70,6 +71,8 @@ This page is a reference of all Python language constructs, data structures, and
 - `reverse()`: Reverse in place
 - `sort()`: Sort in place (no arguments; key/reverse parameters not supported)
 - `insert(i, x)`: Insert at position; handles index at/beyond end, within bounds, and empty lists
+- `count(x)`: Return the number of occurrences of a value
+- `index(x)`: Return the position of the first occurrence of a value
 - `in` operator: Membership testing (`2 in [1, 2, 3]`)
 - `+` operator: List concatenation (`[1,2] + [3,4]`)
 - **Repetition**: `lst * n` with both literal and variable lists
@@ -164,12 +167,14 @@ This page is a reference of all Python language constructs, data structures, and
 
 Byte sequences and integer class methods:
 
+- **`bytes(...)` constructor** — `bytes(iterable-of-ints)` (e.g. `bytes([1, 2, 3])`) and `bytes(n)` (`n` zero bytes) build a real byte array, like a `b"..."` literal, so `len()` and indexing work; byte literals (`b"abc"`) are also supported
 - **`int.from_bytes(bytes_data, big_endian, signed)`** — converts a byte sequence to an integer; supports big- and little-endian, signed and unsigned
 - **`int.bit_length(n)`** — returns the number of bits required to represent `n` in binary. The operational model bounds the loop length by `512`, which covers narrow 64-bit `IntWide` and 512-bit `--ir` bignum receivers and guarantees termination on symbolic `n` without an explicit `--unwind`.
 
 ## Error Handling
 
 - **`try`/`except`** blocks with multiple handlers and `except ExceptionType as var` binding
+- **`try`/`finally`** blocks: the `finally` body runs on normal completion, after a caught exception, and when an exception propagates uncaught (run `finally`, then re-raise). Bare `try`/`finally` (no `except`) is supported. Shapes that cannot be lowered soundly are refused with a clean diagnostic (see [Limitations](./limitations#exception-handling))
 - **`raise`** statements with exception instantiation and custom messages; bare `raise` re-raises the active exception inside an `except` handler
 - **`assert`** statements for property verification
 - **`__ESBMC_assume`** for constraining non-deterministic inputs
@@ -359,6 +364,19 @@ See also: [Random Operational Model](./random-operational-model)
 
 - **`defaultdict(default_factory)`**: Dict subclass that returns a default value for missing keys; modelled as a plain `dict` with a nondeterministic default. When the dict has no value annotation, the value type is inferred from the factory or from a subscript assignment in the enclosing function: built-in type factories (`defaultdict(int)`, `float`, `bool`, `str`), nullary `lambda` factories whose body is a constant or a built-in constructor call (`defaultdict(lambda: float('inf'))`), and constant literal assignments (`d[k] = 5`, `0.0`, `True`, `"x"`) all map to the matching value type, so `min`/`max`/comparisons over `d[k]` no longer fall back to `char *`
 - **`Counter`**: Mapping of elements to integer counts; supports `__getitem__`, `__setitem__`, `values()`, and boolean truthiness
+- **`deque`**: List-backed double-ended queue; supports construction, indexing, `__setitem__`, `append()`, and the FIFO-front methods `popleft()` (front pop) and `appendleft()` (front insert), enabling FIFO/BFS patterns. Aliased imports such as `from collections import deque as Queue` resolve correctly
+- **`OrderedDict`**: Supports construction and basic indexing / `append` / `__setitem__`
+
+## Queue Module (`queue`)
+
+A single-threaded verification model: `queue.Queue` is backed by a plain list (FIFO) and `queue.LifoQueue` by a list-backed stack (LIFO). Both the qualified form (`queue.Queue()`) and `from queue import LifoQueue` work.
+
+- **`Queue`** (FIFO): `put(item)` → append, `get()` → pop front, in insertion order
+- **`LifoQueue`** (LIFO / stack): `put(item)` → append, `get()` → pop back
+- **Shared methods**: `qsize()`, `empty()`, `full()`, `put_nowait()`, `get_nowait()`; `task_done()` and `join()` are accepted no-ops
+- **`maxsize`**: tracked by `full()` (`Queue(2)`); `put()` does not block on it
+
+The blocking semantics of `put()`/`get()` (the `block`/`timeout` arguments) are not modelled — there is nothing to block on under sequential symbolic execution. An unguarded `get()` on an empty queue pops from an empty list, reported as an `IndexError`; guard with `empty()`/`qsize()` first.
 
 ## Datetime Module (`datetime`)
 
@@ -411,6 +429,8 @@ Partial executable support for list-backed arrays, element-wise arithmetic, sele
 **Array construction**: `np.array(l)`, `np.zeros(shape)`, `np.ones(shape)` for supported 1D/2D shapes
 
 **Element-wise arithmetic**: `np.add(a, b)`, `np.subtract(a, b)`, `np.multiply(a, b)`, `np.divide(a, b)`, `np.power(a, b)` on literal list-backed inputs, with NumPy-style broadcasting for 1D/2D shapes
+
+**Complex elements**: element-wise complex arithmetic (`add`/`subtract`/`multiply`/`divide`) on complex scalars and arrays, plus `np.conjugate(z)` and `.real`/`.imag` on complex results; division by zero is reported. Complex determinants are rejected (see [Limitations](./limitations#numpy-module))
 
 **Math**: `np.ceil(x)`, `np.floor(x)`, `np.fabs(x)`, `np.sqrt(x)`, `np.trunc(x)`, `np.round(x)`, `np.copysign(x, y)`, `np.fmin(x, y)`, `np.fmax(x, y)`, `np.sin(x)`, `np.cos(x)`, `np.arctan(x)`, `np.exp(x)` on scalar or literal list-backed 1D/2D inputs
 


### PR DESCRIPTION
## What

Syncs the website's Python documentation with the feature PRs that landed since the last comprehensive sync (#4924, which covered up to #4880). Internal IREP2/Phase-4 migration PRs and pure bug fixes have no user-facing surface and are intentionally omitted.

## Supported Features (added)

- Walrus operator `:=` — PEP 572 (#5057)
- `list.count()` / `list.index()` (#5063)
- `bytes(iterable)` / `bytes(n)` constructor (#5068)
- `try`/`finally`, including the bare form (#5072)
- `deque.popleft()` / `appendleft()` + aliased imports (#5008)
- New **Queue Module (`queue`)** section — `Queue`/`LifoQueue` single-threaded model (#5006)
- NumPy complex element-wise arithmetic + `conjugate`/`.real`/`.imag` (#5026)
- Cross-module imported-class attribute inference (#5046)

## Limitations (stale entries fixed)

- Dropped "`queue.Queue` is also unsupported"; now points to the new model
- `deque` entry lists `popleft`/`appendleft`
- Class-attribute inference now resolves across module boundaries
- New **Walrus Operator** section (refused contexts + exact diagnostics)
- `try`/`finally` refused shapes (non-empty `else`; escaping `return`/`break`/`continue`)

## Verification

Docs-only (markdown). Each entry was grounded against the PR description, the `models/queue.py` operational model, and the added regression tests (`queue_fifo`, `bytes_constructor`, `walrus_*`, `try_finally_*`, `numpy/complex_*`). All 9 internal anchor links validated programmatically.