### PR TITLE
[irep2] Avoid recursive CRC traversal

### DIFF
--- a/src/irep2/CMakeLists.txt
+++ b/src/irep2/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(irep2
   irep2_type.cpp
   irep2_expr.cpp
+  irep2_crc.cpp
   irep2_utils.cpp
   irep2_guard.cpp
 )
@@ -10,4 +11,3 @@ add_library(irep2
 # transitively from the (now-removed) crypto_hash target; declare it directly.
 target_include_directories(irep2 PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(irep2 PUBLIC fmt::fmt bigint immer)
-

--- a/src/irep2/README.md
+++ b/src/irep2/README.md
@@ -57,7 +57,8 @@ conversions live in `util/migrate.{h,cpp}`.
 | `irep2_type.h` / `irep2_type.cpp` | Concrete type classes (`bool_type2t`, `signedbv_type2t`, `array_type2t`, `pointer_type2t`, `struct_type2t`, ...). Each kind inherits directly from `type2t` and owns its fields. Free family helpers in the same header (`struct_union_members`, `array_or_vector_subtype`, ...) provide uniform field access when the caller doesn't care which specific kind it is. |
 | `irep2_expr.h` / `irep2_expr.cpp` | Concrete expression classes (`constant_int2t`, `symbol2t`, `add2t`, `if2t`, `code_assign2t`, ...). Each kind inherits directly from `expr2t`. |
 | `irep2_utils.h` | Inline predicates and helpers (`is_bv_type`, `is_number_type`, `is_scalar_type`, simplification helpers). |
-| `irep2_dispatch.h` | Generic `generic_*<K>` helpers that walk a kind's `K::fields` tuple via `std::apply` to implement cmp/lt/crc/tostring/clone/get_sub_expr/foreach_operand uniformly, plus the per-field-type overloads they invoke (`do_type_cmp`, `do_type_lt`, `do_type_crc`, `type_to_string`, `do_get_sub_expr`, `call_*_delegate`). Switch dispatchers on `expr2t`/`type2t` route to these. |
+| `irep2_dispatch.h` | Generic `generic_*<K>` helpers that walk a kind's `K::fields` tuple via `std::apply` to implement cmp/lt/tostring/clone/get_sub_expr/foreach_operand uniformly, plus the per-field-type overloads they invoke. Switch dispatchers on `expr2t`/`type2t` route to these. |
+| `irep2_crc.cpp` | Iterative postorder CRC traversal and per-field CRC operations. Kept in one translation unit with internal linkage so the compiler sees and optimises the complete CRC path. |
 | `irep2_utils.cpp` | Definitions for the predicates and dispatch-catalogue overloads declared in `irep2_utils.h` and `irep2_dispatch.h`. |
 | `CMakeLists.txt` | Builds the `irep2` static library; depends on `bigint` and `fmt`. No Boost. |
 

--- a/src/irep2/irep2_crc.cpp
+++ b/src/irep2/irep2_crc.cpp
@@ -1,0 +1,298 @@
+#include <array>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+#include <irep2/irep2_dispatch.h>
+
+namespace
+{
+struct irep2_node_ref
+{
+  const expr2t *expr;
+  const type2t *type;
+};
+
+struct irep2_traversal_frame
+{
+  irep2_node_ref node;
+  bool expanded;
+};
+
+template <class T>
+size_t do_type_crc(const T &field)
+{
+  if constexpr (std::is_enum_v<T>)
+    return std::hash<uint8_t>{}(static_cast<uint8_t>(field));
+  else
+    return std::hash<T>{}(field);
+}
+
+template <typename Sink>
+void feed_bigint(const BigInt &value, Sink &&sink)
+{
+  const uint8_t sign = value.is_positive() ? 1 : 0;
+  sink(&sign, sizeof(sign));
+
+  if (value.is_zero())
+    return;
+
+  std::array<unsigned char, 256> stack_buf;
+  if (value.dump(stack_buf.data(), stack_buf.size()))
+  {
+    sink(stack_buf.data(), stack_buf.size());
+    return;
+  }
+
+  std::vector<unsigned char> heap_buf(stack_buf.size() * 2);
+  while (!value.dump(heap_buf.data(), heap_buf.size()))
+    heap_buf.resize(heap_buf.size() * 2);
+  sink(heap_buf.data(), heap_buf.size());
+}
+
+size_t do_type_crc(const BigInt &value)
+{
+  size_t crc = 0;
+  feed_bigint(value, [&](const unsigned char *data, size_t len) {
+    for (size_t i = 0; i < len; ++i)
+      esbmct::hash_combine(crc, data[i]);
+  });
+  return crc;
+}
+
+size_t do_type_crc(const fixedbvt &value)
+{
+  return do_type_crc(BigInt(value.to_ansi_c_string().c_str()));
+}
+
+size_t do_type_crc(const ieee_floatt &value)
+{
+  return do_type_crc(value.pack());
+}
+
+size_t do_type_crc(const std::vector<irep_idt> &values)
+{
+  size_t crc = 0;
+  for (const irep_idt &value : values)
+    esbmct::hash_combine(crc, value.hash());
+  return crc;
+}
+
+size_t do_type_crc(const irep_idt &value)
+{
+  return value.hash();
+}
+
+template <typename F>
+void enumerate_irep2_children(const expr2tc &child, F &f)
+{
+  if (const expr2t *ptr = child.get())
+    f(irep2_node_ref{ptr, nullptr});
+}
+
+template <typename F>
+void enumerate_irep2_children(const type2tc &child, F &f)
+{
+  if (const type2t *ptr = child.get())
+    f(irep2_node_ref{nullptr, ptr});
+}
+
+template <typename F>
+void enumerate_irep2_children(const std::vector<expr2tc> &children, F &f)
+{
+  for (const expr2tc &child : children)
+    enumerate_irep2_children(child, f);
+}
+
+template <typename F>
+void enumerate_irep2_children(const std::vector<type2tc> &children, F &f)
+{
+  for (const type2tc &child : children)
+    enumerate_irep2_children(child, f);
+}
+
+template <typename T, typename F>
+void enumerate_irep2_children(const T &, F &)
+{
+}
+
+template <class K, typename F>
+void enumerate_node_children(const K &node, F &f)
+{
+  std::apply(
+    [&](auto... mp) { (enumerate_irep2_children(node.*mp, f), ...); },
+    K::fields);
+}
+
+size_t cached_crc(const irep2_node_ref &node)
+{
+  if (node.expr != nullptr)
+    return node.expr->crc_val.load(std::memory_order_acquire);
+  return node.type->crc_val.load(std::memory_order_acquire);
+}
+
+template <class T>
+size_t do_cached_child_crc(const T &field)
+{
+  return do_type_crc(field);
+}
+
+size_t do_cached_child_crc(const expr2tc &field)
+{
+  if (const expr2t *ptr = field.get())
+    return ptr->crc_val.load(std::memory_order_acquire);
+  return std::hash<uint8_t>{}(0);
+}
+
+size_t do_cached_child_crc(const type2tc &field)
+{
+  if (const type2t *ptr = field.get())
+    return ptr->crc_val.load(std::memory_order_acquire);
+  return std::hash<uint8_t>{}(0);
+}
+
+size_t do_cached_child_crc(const std::vector<expr2tc> &field)
+{
+  size_t crc = 0;
+  for (const expr2tc &child : field)
+    esbmct::hash_combine(crc, do_cached_child_crc(child));
+  return crc;
+}
+
+size_t do_cached_child_crc(const std::vector<type2tc> &field)
+{
+  size_t crc = 0;
+  for (const type2tc &child : field)
+    esbmct::hash_combine(crc, do_cached_child_crc(child));
+  return crc;
+}
+
+template <class K>
+size_t compute_crc_from_cached_children(const K &node)
+{
+  if (size_t cached = node.crc_val.load(std::memory_order_acquire); cached != 0)
+    return cached;
+
+  size_t crc = 0;
+  if constexpr (std::is_base_of_v<expr2t, K>)
+    esbmct::hash_combine(crc, do_type_crc(node.expr_id));
+  else
+    esbmct::hash_combine(crc, do_type_crc(node.type_id));
+
+  std::apply(
+    [&](auto... mp) {
+      (esbmct::hash_combine(crc, do_cached_child_crc(node.*mp)), ...);
+    },
+    K::fields);
+  node.crc_val.store(crc, std::memory_order_release);
+  return crc;
+}
+
+template <typename F>
+void foreach_irep2_child(const irep2_node_ref &node, F &f)
+{
+  if (node.expr != nullptr)
+  {
+    switch (node.expr->expr_id)
+    {
+#define IREP2_EXPR(kind, _)                                                    \
+  case expr2t::kind##_id:                                                      \
+    enumerate_node_children(static_cast<const kind##2t &>(*node.expr), f);     \
+    return;
+#include <irep2/expr_kinds.inc>
+#undef IREP2_EXPR
+    case expr2t::end_expr_id:
+      break;
+    }
+    std::unreachable();
+  }
+
+  switch (node.type->type_id)
+  {
+#define IREP2_TYPE(kind, _)                                                    \
+  case type2t::kind##_id:                                                      \
+    enumerate_node_children(                                                   \
+      static_cast<const kind##_type2t &>(*node.type), f);                      \
+    return;
+#include <irep2/type_kinds.inc>
+#undef IREP2_TYPE
+  case type2t::end_type_id:
+    break;
+  }
+  std::unreachable();
+}
+
+void compute_crc_from_cached_children(const irep2_node_ref &node)
+{
+  if (node.expr != nullptr)
+  {
+    switch (node.expr->expr_id)
+    {
+#define IREP2_EXPR(kind, _)                                                    \
+  case expr2t::kind##_id:                                                      \
+    compute_crc_from_cached_children(                                          \
+      static_cast<const kind##2t &>(*node.expr));                              \
+    return;
+#include <irep2/expr_kinds.inc>
+#undef IREP2_EXPR
+    case expr2t::end_expr_id:
+      break;
+    }
+    std::unreachable();
+  }
+
+  switch (node.type->type_id)
+  {
+#define IREP2_TYPE(kind, _)                                                    \
+  case type2t::kind##_id:                                                      \
+    compute_crc_from_cached_children(                                          \
+      static_cast<const kind##_type2t &>(*node.type));                         \
+    return;
+#include <irep2/type_kinds.inc>
+#undef IREP2_TYPE
+  case type2t::end_type_id:
+    break;
+  }
+  std::unreachable();
+}
+
+size_t iterative_crc(const irep2_node_ref &root)
+{
+  if (size_t cached = cached_crc(root); cached != 0)
+    return cached;
+
+  std::vector<irep2_traversal_frame> stack{{root, false}};
+  while (!stack.empty())
+  {
+    const irep2_traversal_frame frame = stack.back();
+    stack.pop_back();
+
+    if (cached_crc(frame.node) != 0)
+      continue;
+
+    if (frame.expanded)
+    {
+      compute_crc_from_cached_children(frame.node);
+      continue;
+    }
+
+    stack.push_back({frame.node, true});
+    auto push_uncached_child = [&](const irep2_node_ref &child) {
+      if (cached_crc(child) == 0)
+        stack.push_back({child, false});
+    };
+    foreach_irep2_child(frame.node, push_uncached_child);
+  }
+
+  return cached_crc(root);
+}
+} // namespace
+
+size_t expr2t::crc() const
+{
+  return iterative_crc(irep2_node_ref{this, nullptr});
+}
+
+size_t type2t::crc() const
+{
+  return iterative_crc(irep2_node_ref{nullptr, this});
+}

--- a/src/irep2/irep2_dispatch.h
+++ b/src/irep2/irep2_dispatch.h
@@ -8,8 +8,8 @@
 // Each concrete kind exposes a `static constexpr auto fields` tuple of
 // member pointers covering its user-visible fields, plus a static
 // `field_names` array naming them in tuple order. The generic_*<K>
-// helpers below walk that tuple via std::apply to implement cmp/lt/crc/
-// hash/tostring/clone/get_sub_expr/foreach_operand uniformly. The
+// helpers below walk that tuple via std::apply to implement cmp/lt/hash/
+// tostring/clone/get_sub_expr/foreach_operand uniformly. The
 // switch-on-id dispatchers on expr2t / type2t pick the right helper
 // per kind from the X-macro manifests (`expr_kinds.inc`,
 // `type_kinds.inc`).
@@ -26,12 +26,10 @@
 
 // ============================================================================
 // Per-field operations the generic dispatchers invoke on every K::fields
-// entry: pretty-printing, structural cmp/lt, CRC, SHA-1 ingestion, and
-// sub-expression / delegate iteration. Primary templates cover trivially-
-// comparable / hashable field types; explicit overloads handle BigInt
-// sign-aware hashing, std::vector<...>, null-safe expr2tc/type2tc dispatch,
-// irep_idt's interned-index hashing, and the *_ids dummies that mix the
-// kind id into the CRC.
+// entry: pretty-printing, structural cmp/lt, SHA-1 ingestion, and
+// sub-expression / delegate iteration. Primary templates cover trivially
+// comparable field types; explicit overloads handle BigInt,
+// std::vector<...>, and null-safe expr2tc/type2tc dispatch.
 // ============================================================================
 
 std::string type_to_string(const bool &thebool, int);
@@ -68,18 +66,6 @@ inline int do_type_lt(const T &side1, const T &side2)
   return 0;
 }
 
-// std::hash<T> for the non-enum case. For enums, hash through uint8_t
-// so the value matches the byte the CRC mix actually folds into the
-// state — on-disk caches and state hashes depend on this width.
-template <class T>
-inline size_t do_type_crc(const T &theval)
-{
-  if constexpr (std::is_enum_v<T>)
-    return std::hash<uint8_t>{}(static_cast<uint8_t>(theval));
-  else
-    return std::hash<T>{}(theval);
-}
-
 // Explicit overloads for the field types whose semantics differ.
 
 int do_type_lt(const BigInt &side1, const BigInt &side2);
@@ -91,18 +77,6 @@ int do_type_lt(
   const std::vector<type2tc> &side2);
 int do_type_lt(const expr2tc &side1, const expr2tc &side2);
 int do_type_lt(const type2tc &side1, const type2tc &side2);
-
-size_t do_type_crc(const BigInt &theint);
-size_t do_type_crc(const fixedbvt &theval);
-size_t do_type_crc(const ieee_floatt &theval);
-size_t do_type_crc(const std::vector<expr2tc> &theval);
-size_t do_type_crc(const std::vector<type2tc> &theval);
-size_t do_type_crc(const std::vector<irep_idt> &theval);
-size_t do_type_crc(const expr2tc &theval);
-size_t do_type_crc(const type2tc &theval);
-size_t do_type_crc(const irep_idt &theval);
-size_t do_type_crc(const type2t::type_ids &i);
-size_t do_type_crc(const expr2t::expr_ids &i);
 
 template <typename T>
 void do_type2string(
@@ -248,24 +222,6 @@ int generic_lt(const K &a, const expr2t &o)
 }
 
 // --------------------------------------------------------------------------
-// generic_do_crc: mix expr_id then each field in K::fields. Notype kinds
-// (e.g. not2t) have no type slot in K::fields; kinds with dynamic type
-// list &expr2t::type first so the CRC includes it.
-// --------------------------------------------------------------------------
-template <class K>
-size_t generic_do_crc(const K &a)
-{
-  if (size_t cached = a.crc_val.load(std::memory_order_acquire); cached != 0)
-    return cached;
-  size_t v = 0;
-  hash_combine(v, do_type_crc(a.expr_id));
-  std::apply(
-    [&](auto... mp) { (hash_combine(v, do_type_crc(a.*mp)), ...); }, K::fields);
-  a.crc_val.store(v, std::memory_order_release);
-  return v;
-}
-
-// --------------------------------------------------------------------------
 // generic_tostring: build the pretty-print member list from K::fields.
 // K::field_names[i] names the i-th user field (0-based). When K is an expr
 // kind, any type2tc slot in K::fields is skipped — the type is shown by
@@ -375,19 +331,6 @@ int generic_lt_type(const K &a, const type2t &o)
     },
     K::fields);
   return r;
-}
-
-template <class K>
-size_t generic_do_crc_type(const K &a)
-{
-  if (size_t cached = a.crc_val.load(std::memory_order_acquire); cached != 0)
-    return cached;
-  size_t v = 0;
-  hash_combine(v, do_type_crc(a.type_id));
-  std::apply(
-    [&](auto... mp) { (hash_combine(v, do_type_crc(a.*mp)), ...); }, K::fields);
-  a.crc_val.store(v, std::memory_order_release);
-  return v;
 }
 
 template <class K>

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -557,21 +557,6 @@ expr2tc expr2t::with_type(const type2tc &new_type) const
   std::unreachable();
 }
 
-size_t expr2t::crc() const
-{
-  switch (expr_id)
-  {
-#define IREP2_EXPR(kind, _)                                                    \
-  case kind##_id:                                                              \
-    return esbmct::generic_do_crc(static_cast<const kind##2t &>(*this));
-#include <irep2/expr_kinds.inc>
-#undef IREP2_EXPR
-  case end_expr_id:
-    break;
-  }
-  std::unreachable();
-}
-
 list_of_memberst expr2t::tostring(unsigned int indent) const
 {
   switch (expr_id)

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -280,22 +280,6 @@ type2tc type2t::clone() const
   std::unreachable();
 }
 
-size_t type2t::crc() const
-{
-  switch (type_id)
-  {
-#define IREP2_TYPE(kind, _)                                                    \
-  case kind##_id:                                                              \
-    return esbmct::generic_do_crc_type(                                        \
-      static_cast<const kind##_type2t &>(*this));
-#include <irep2/type_kinds.inc>
-#undef IREP2_TYPE
-  case end_type_id:
-    break;
-  }
-  std::unreachable();
-}
-
 list_of_memberst type2t::tostring(unsigned int indent) const
 {
   switch (type_id)

--- a/src/irep2/irep2_utils.cpp
+++ b/src/irep2/irep2_utils.cpp
@@ -306,7 +306,7 @@ void get_symbols(
 }
 
 // Field-overload catalogue for the generic switch dispatchers in
-// irep2_dispatch.h: pretty-printing, cmp/lt, CRC, SHA-1 ingestion,
+// irep2_dispatch.h: pretty-printing, cmp/lt, SHA-1 ingestion,
 // sub-expression iteration, and delegate calling, specialised for each
 // field type that needs non-default behaviour. Primary templates live in
 // irep2_dispatch.h alongside the dispatchers themselves.
@@ -679,117 +679,4 @@ int do_type_lt(const type2tc &side1, const type2tc &side2)
     return 1;
   else
     return side1->lt(*side2.get());
-}
-
-// do_type_crc overloads. Trivial cases (bool, unsigned
-// int, small enums) use the primary templates in irep2_dispatch.h.
-
-// BigInt::dump writes only the magnitude (most-significant-byte first,
-// left-padded with zeros) and reports false on buffer-too-small. Try a
-// stack buffer; on overflow, double a heap buffer until it succeeds.
-// The sign byte is fed first so +x and -x do not collide.
-namespace
-{
-template <typename Sink>
-void feed_bigint(const BigInt &theint, Sink &&sink)
-{
-  // Always include the sign so +x and -x do not collide.
-  const uint8_t sign = theint.is_positive() ? 1 : 0;
-  sink(&sign, sizeof(sign));
-
-  if (theint.is_zero())
-    return;
-
-  std::array<unsigned char, 256> stack_buf;
-  if (theint.dump(stack_buf.data(), stack_buf.size()))
-  {
-    sink(stack_buf.data(), stack_buf.size());
-    return;
-  }
-
-  std::vector<unsigned char> heap_buf(stack_buf.size() * 2);
-  while (!theint.dump(heap_buf.data(), heap_buf.size()))
-    heap_buf.resize(heap_buf.size() * 2);
-  sink(heap_buf.data(), heap_buf.size());
-}
-} // namespace
-
-size_t do_type_crc(const BigInt &theint)
-{
-  size_t crc = 0;
-  feed_bigint(theint, [&](const unsigned char *data, size_t len) {
-    for (size_t i = 0; i < len; ++i)
-      esbmct::hash_combine(crc, data[i]);
-  });
-  return crc;
-}
-
-size_t do_type_crc(const fixedbvt &theval)
-{
-  return do_type_crc(BigInt(theval.to_ansi_c_string().c_str()));
-}
-
-size_t do_type_crc(const ieee_floatt &theval)
-{
-  return do_type_crc(theval.pack());
-}
-
-size_t do_type_crc(const std::vector<expr2tc> &theval)
-{
-  size_t crc = 0;
-  for (auto const &it : theval)
-    esbmct::hash_combine(crc, it->crc());
-
-  return crc;
-}
-
-size_t do_type_crc(const std::vector<type2tc> &theval)
-{
-  size_t crc = 0;
-  for (auto const &it : theval)
-    esbmct::hash_combine(crc, it->crc());
-
-  return crc;
-}
-
-size_t do_type_crc(const std::vector<irep_idt> &theval)
-{
-  // irep_idt is an interned dstring: its hash() returns the stable
-  // table index, unique per string identity within the process. Mix
-  // that directly instead of looking up the std::string and hashing
-  // its char array per element.
-  size_t crc = 0;
-  for (auto const &it : theval)
-    esbmct::hash_combine(crc, it.hash());
-
-  return crc;
-}
-
-size_t do_type_crc(const expr2tc &theval)
-{
-  if (theval.get() != nullptr)
-    return theval->crc();
-  return std::hash<uint8_t>{}(0);
-}
-
-size_t do_type_crc(const type2tc &theval)
-{
-  if (theval.get() != nullptr)
-    return theval->crc();
-  return std::hash<uint8_t>{}(0);
-}
-
-size_t do_type_crc(const irep_idt &theval)
-{
-  return theval.hash();
-}
-
-size_t do_type_crc(const type2t::type_ids &i)
-{
-  return std::hash<uint8_t>{}(i);
-}
-
-size_t do_type_crc(const expr2t::expr_ids &i)
-{
-  return std::hash<uint8_t>{}(i);
 }

--- a/unit/irep2/irep2.test.cpp
+++ b/unit/irep2/irep2.test.cpp
@@ -47,6 +47,15 @@ expr2tc gen_testing_array(unsigned int count)
   return constant_array2tc(array_ty, members);
 }
 
+expr2tc gen_deep_add_chain(unsigned int depth)
+{
+  type2tc word_type = get_uint_type(config.ansi_c.word_size);
+  expr2tc acc = constant_int2tc(word_type, BigInt(0));
+  for (unsigned int i = 1; i <= depth; ++i)
+    acc = add2tc(word_type, acc, constant_int2tc(word_type, BigInt(i)));
+  return acc;
+}
+
 void test_constructed_equally(const expr2tc e1, const expr2tc e2)
 {
   // "The == operator should return true"
@@ -99,6 +108,21 @@ SCENARIO("irep2 hashing", "[core][irep2]")
     {
       for (auto &e : expressions)
         test_constructed_differently(e.first, e.second);
+    }
+  }
+}
+
+SCENARIO("CRC handles deep irep2 expression trees iteratively", "[core][irep2]")
+{
+  GIVEN("A deep left-leaning add expression")
+  {
+    config.ansi_c.word_size = 32;
+    expr2tc chain = gen_deep_add_chain(50000);
+
+    THEN("cold and warm CRC calls complete and agree")
+    {
+      const size_t cold_crc = chain->crc();
+      REQUIRE(chain->crc() == cold_crc);
     }
   }
 }


### PR DESCRIPTION
Compute expression and type CRCs with an iterative postorder walk.

This keeps the CRC implementation internal to a dedicated translation unit, removes the recursive traversal from the dispatch layer, and adds a deep-expression regression test.