### PR TITLE
implement NumPy dtype preservation for array constructors

### DIFF
--- a/regression/numpy/add_3d_rejected_fail/main.py
+++ b/regression/numpy/add_3d_rejected_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.array([[[1], [2]], [[3], [4]]])

--- a/regression/numpy/add_3d_rejected_fail/test.desc
+++ b/regression/numpy/add_3d_rejected_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: ESBMC does not support 3D or higher dimensional arrays. Found 3D array creation\. Please use 1D or 2D arrays only\.$

--- a/regression/numpy/add_all_zeros_edge/main.py
+++ b/regression/numpy/add_all_zeros_edge/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.add(0, 0)
+assert a == 0

--- a/regression/numpy/add_all_zeros_edge/test.desc
+++ b/regression/numpy/add_all_zeros_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/add_bool_int_literals_edge/main.py
+++ b/regression/numpy/add_bool_int_literals_edge/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.add(True, 1)
+assert a == 2

--- a/regression/numpy/add_bool_int_literals_edge/test.desc
+++ b/regression/numpy/add_bool_int_literals_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/add_int_float_promotes_success/main.py
+++ b/regression/numpy/add_int_float_promotes_success/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.multiply(2.5, 4.0)
+assert a == 10.0

--- a/regression/numpy/add_int_float_promotes_success/test.desc
+++ b/regression/numpy/add_int_float_promotes_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/array_dtype_bool_success/main.py
+++ b/regression/numpy/array_dtype_bool_success/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.array([0, 2], dtype=bool)
+assert a[0] == False
+assert a[1] == True

--- a/regression/numpy/array_dtype_bool_success/test.desc
+++ b/regression/numpy/array_dtype_bool_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/array_dtype_int_success/main.py
+++ b/regression/numpy/array_dtype_int_success/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.array([1.2, 2.9], dtype=int)
+assert a[0] == 1
+assert a[1] == 3

--- a/regression/numpy/array_dtype_int_success/test.desc
+++ b/regression/numpy/array_dtype_int_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/array_dtype_nonliteral_fail/main.py
+++ b/regression/numpy/array_dtype_nonliteral_fail/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+x = 2
+np.array([x], dtype=int)

--- a/regression/numpy/array_dtype_nonliteral_fail/test.desc
+++ b/regression/numpy/array_dtype_nonliteral_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: np\.array\(\.\.\., dtype=\.\.\.\) requires literal numeric elements$

--- a/regression/numpy/broadcast_1d_singleton_success/main.py
+++ b/regression/numpy/broadcast_1d_singleton_success/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.add([1, 2, 3], [10])
+assert a[0] == 11
+assert a[1] == 12
+assert a[2] == 13

--- a/regression/numpy/broadcast_1d_singleton_success/test.desc
+++ b/regression/numpy/broadcast_1d_singleton_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/broadcast_2d_incompatible_fail/main.py
+++ b/regression/numpy/broadcast_2d_incompatible_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.add([[1, 2, 3]], [[1, 2], [3, 4]])

--- a/regression/numpy/broadcast_2d_incompatible_fail/test.desc
+++ b/regression/numpy/broadcast_2d_incompatible_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: operands could not be broadcast together with shapes \(1, 3\) \(2, 2\)$

--- a/regression/numpy/broadcast_scalar_1d_success/main.py
+++ b/regression/numpy/broadcast_scalar_1d_success/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+a = np.add([10, 20, 30], [[1, 2, 3], [4, 5, 6]])
+assert a[0][0] == 11
+assert a[0][1] == 22
+assert a[1][0] == 14
+assert a[1][2] == 36

--- a/regression/numpy/broadcast_scalar_1d_success/test.desc
+++ b/regression/numpy/broadcast_scalar_1d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/broadcast_scalar_2d_success/main.py
+++ b/regression/numpy/broadcast_scalar_2d_success/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+a = np.add([[1, 2, 3], [4, 5, 6]], [10, 20, 30])
+assert a[0][0] == 11
+assert a[0][2] == 33
+assert a[1][1] == 25
+assert a[1][2] == 36

--- a/regression/numpy/broadcast_scalar_2d_success/test.desc
+++ b/regression/numpy/broadcast_scalar_2d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/divide_int_float_result_edge/main.py
+++ b/regression/numpy/divide_int_float_result_edge/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.divide(7, 2)
+assert a == 3.5

--- a/regression/numpy/divide_int_float_result_edge/test.desc
+++ b/regression/numpy/divide_int_float_result_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/index_arity3_fail_extra/main.py
+++ b/regression/numpy/index_arity3_fail_extra/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.array([[1, 2], [3, 4]])
+x = a[0, 1, 0]

--- a/regression/numpy/index_arity3_fail_extra/test.desc
+++ b/regression/numpy/index_arity3_fail_extra/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: multi-dimensional indexing \(a\[i, j, \.\.\.\]\) is not supported

--- a/regression/numpy/index_arity4_fail_extra/main.py
+++ b/regression/numpy/index_arity4_fail_extra/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.array([[1, 2], [3, 4]])
+x = a[0, 0, 0, 0]

--- a/regression/numpy/index_arity4_fail_extra/test.desc
+++ b/regression/numpy/index_arity4_fail_extra/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: multi-dimensional indexing \(a\[i, j, \.\.\.\]\) is not supported

--- a/regression/numpy/index_arity5_fail_extra/main.py
+++ b/regression/numpy/index_arity5_fail_extra/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.array([[1, 2], [3, 4]])
+x = a[0, 0, 0, 0, 0]

--- a/regression/numpy/index_arity5_fail_extra/test.desc
+++ b/regression/numpy/index_arity5_fail_extra/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: multi-dimensional indexing \(a\[i, j, \.\.\.\]\) is not supported

--- a/regression/numpy/index_first_row_edge/main.py
+++ b/regression/numpy/index_first_row_edge/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.array([[7, 8, 9]])
+assert a[0, 1] == 8

--- a/regression/numpy/index_first_row_edge/test.desc
+++ b/regression/numpy/index_first_row_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/index_row_success_extra/main.py
+++ b/regression/numpy/index_row_success_extra/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.array([[1, 2, 3], [4, 5, 6]])
+assert a[1, 0] == 4
+assert a[1, 2] == 6

--- a/regression/numpy/index_row_success_extra/test.desc
+++ b/regression/numpy/index_row_success_extra/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/index_single_tuple_edge/main.py
+++ b/regression/numpy/index_single_tuple_edge/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.array([[1, 2], [3, 4]])
+x = a[(1, 1)]
+assert x == 4

--- a/regression/numpy/index_single_tuple_edge/test.desc
+++ b/regression/numpy/index_single_tuple_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/index_tuple_success_extra/main.py
+++ b/regression/numpy/index_tuple_success_extra/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.array([[1, 2, 3], [4, 5, 6]])
+x = a[1, 2]
+assert x == 6

--- a/regression/numpy/index_tuple_success_extra/test.desc
+++ b/regression/numpy/index_tuple_success_extra/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/multiply_broadcast_row_col_edge/main.py
+++ b/regression/numpy/multiply_broadcast_row_col_edge/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+a = np.multiply([[1], [2]], [3, 4])
+assert a[0][0] == 3
+assert a[0][1] == 4
+assert a[1][0] == 6
+assert a[1][1] == 8

--- a/regression/numpy/multiply_broadcast_row_col_edge/test.desc
+++ b/regression/numpy/multiply_broadcast_row_col_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/multiply_mismatch_2d_fail/main.py
+++ b/regression/numpy/multiply_mismatch_2d_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.multiply([[1, 2, 3]], [[1, 2], [3, 4]])

--- a/regression/numpy/multiply_mismatch_2d_fail/test.desc
+++ b/regression/numpy/multiply_mismatch_2d_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: operands could not be broadcast together with shapes \(1, 3\) \(2, 2\)$

--- a/regression/numpy/negative_index_edge/main.py
+++ b/regression/numpy/negative_index_edge/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.array([[1, 2], [3, 4]])
+assert a[-1, -1] == 4

--- a/regression/numpy/negative_index_edge/test.desc
+++ b/regression/numpy/negative_index_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ones_1x1_edge/main.py
+++ b/regression/numpy/ones_1x1_edge/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.ones((1, 1))
+assert a[0][0] == 1.0

--- a/regression/numpy/ones_1x1_edge/test.desc
+++ b/regression/numpy/ones_1x1_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ones_2d_success/main.py
+++ b/regression/numpy/ones_2d_success/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.ones((2, 3))
+assert a[0][0] == 1.0
+assert a[1][2] == 1.0

--- a/regression/numpy/ones_2d_success/test.desc
+++ b/regression/numpy/ones_2d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ones_3d_fail/main.py
+++ b/regression/numpy/ones_3d_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.ones((2, 2, 2))

--- a/regression/numpy/ones_3d_fail/test.desc
+++ b/regression/numpy/ones_3d_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: ESBMC does not support 3D or higher dimensional arrays. Found 3D array creation in ones\(\)\. Please use 1D or 2D arrays only\.$

--- a/regression/numpy/ones_dtype_bool_success/main.py
+++ b/regression/numpy/ones_dtype_bool_success/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.ones((1, 2), dtype=bool)
+assert a[0][0] == True
+assert a[0][1] == True

--- a/regression/numpy/ones_dtype_bool_success/test.desc
+++ b/regression/numpy/ones_dtype_bool_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ones_dtype_complex_fail/main.py
+++ b/regression/numpy/ones_dtype_complex_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.ones(1, dtype=complex)

--- a/regression/numpy/ones_dtype_complex_fail/test.desc
+++ b/regression/numpy/ones_dtype_complex_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: complex dtype is not supported in NumPy constructors yet$

--- a/regression/numpy/ones_empty_tuple_fail/main.py
+++ b/regression/numpy/ones_empty_tuple_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.ones(())

--- a/regression/numpy/ones_empty_tuple_fail/test.desc
+++ b/regression/numpy/ones_empty_tuple_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: ones\(\) shape tuple must be non-empty$

--- a/regression/numpy/ones_tuple_singleton_success/main.py
+++ b/regression/numpy/ones_tuple_singleton_success/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.ones((5,))
+assert a[4] == 1.0

--- a/regression/numpy/ones_tuple_singleton_success/test.desc
+++ b/regression/numpy/ones_tuple_singleton_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ones_zero_edge/main.py
+++ b/regression/numpy/ones_zero_edge/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.ones((1, 2))
+assert a[0][0] == 1.0
+assert a[0][1] == 1.0

--- a/regression/numpy/ones_zero_edge/test.desc
+++ b/regression/numpy/ones_zero_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/shape_1x1_edge/main.py
+++ b/regression/numpy/shape_1x1_edge/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.zeros((1, 1))
+s = a.shape
+assert s[0] == 1
+assert s[1] == 1

--- a/regression/numpy/shape_1x1_edge/test.desc
+++ b/regression/numpy/shape_1x1_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/shape_ones_2d_success/main.py
+++ b/regression/numpy/shape_ones_2d_success/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.ones((3, 2))
+s = a.shape
+assert s[0] == 3
+assert s[1] == 2

--- a/regression/numpy/shape_ones_2d_success/test.desc
+++ b/regression/numpy/shape_ones_2d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/shape_zeros_2d_success/main.py
+++ b/regression/numpy/shape_zeros_2d_success/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.zeros((2, 3))
+s = a.shape
+assert s[0] == 2
+assert s[1] == 3

--- a/regression/numpy/shape_zeros_2d_success/test.desc
+++ b/regression/numpy/shape_zeros_2d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/slice_fail_extra/main.py
+++ b/regression/numpy/slice_fail_extra/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+m = np.array([[1, 2], [3, 4]])
+col = m[:, 0]
+assert col[0] == 1

--- a/regression/numpy/slice_fail_extra/test.desc
+++ b/regression/numpy/slice_fail_extra/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: multi-dimensional indexing \(a\[i, j, \.\.\.\]\) is not supported

--- a/regression/numpy/subtract_empty_empty_fail/main.py
+++ b/regression/numpy/subtract_empty_empty_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.subtract([], [])

--- a/regression/numpy/subtract_empty_empty_fail/test.desc
+++ b/regression/numpy/subtract_empty_empty_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy operation on two empty arrays is not supported yet$

--- a/regression/numpy/zeros_1x1_edge/main.py
+++ b/regression/numpy/zeros_1x1_edge/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.zeros((1, 1))
+assert a[0][0] == 0.0

--- a/regression/numpy/zeros_1x1_edge/test.desc
+++ b/regression/numpy/zeros_1x1_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/zeros_2d_success/main.py
+++ b/regression/numpy/zeros_2d_success/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.zeros((2, 3))
+assert a[0][0] == 0.0
+assert a[1][2] == 0.0

--- a/regression/numpy/zeros_2d_success/test.desc
+++ b/regression/numpy/zeros_2d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/zeros_3d_fail/main.py
+++ b/regression/numpy/zeros_3d_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.zeros((1, 2, 3))

--- a/regression/numpy/zeros_3d_fail/test.desc
+++ b/regression/numpy/zeros_3d_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: ESBMC does not support 3D or higher dimensional arrays. Found 3D array creation in zeros\(\)\. Please use 1D or 2D arrays only\.$

--- a/regression/numpy/zeros_dtype_int_success/main.py
+++ b/regression/numpy/zeros_dtype_int_success/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.zeros((2, 2), dtype=int)
+assert a[0][0] == 0
+assert a[1][1] == 0

--- a/regression/numpy/zeros_dtype_int_success/test.desc
+++ b/regression/numpy/zeros_dtype_int_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/zeros_dtype_object_fail/main.py
+++ b/regression/numpy/zeros_dtype_object_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.zeros(2, dtype=object)

--- a/regression/numpy/zeros_dtype_object_fail/test.desc
+++ b/regression/numpy/zeros_dtype_object_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: Unsupported dtype value: object$

--- a/regression/numpy/zeros_empty_tuple_fail/main.py
+++ b/regression/numpy/zeros_empty_tuple_fail/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+np.zeros(())

--- a/regression/numpy/zeros_empty_tuple_fail/test.desc
+++ b/regression/numpy/zeros_empty_tuple_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: zeros\(\) shape tuple must be non-empty$

--- a/regression/numpy/zeros_tuple_singleton_success/main.py
+++ b/regression/numpy/zeros_tuple_singleton_success/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.zeros((4,))
+assert a[3] == 0.0

--- a/regression/numpy/zeros_tuple_singleton_success/test.desc
+++ b/regression/numpy/zeros_tuple_singleton_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/zeros_zero_edge/main.py
+++ b/regression/numpy/zeros_zero_edge/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.zeros((2, 1))
+assert a[0][0] == 0.0
+assert a[1][0] == 0.0

--- a/regression/numpy/zeros_zero_edge/test.desc
+++ b/regression/numpy/zeros_zero_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -75,6 +75,7 @@ struct scalar_value
 static bool
 try_extract_scalar_constant(const nlohmann::json &node, scalar_value &out);
 static bool is_complex_annotated_constant(const nlohmann::json &node);
+static nlohmann::json to_json_constant(const scalar_value &v);
 static scalar_value apply_complex_binary(
   const std::string &function,
   const scalar_value &lhs,
@@ -881,6 +882,18 @@ static auto create_list(int size, T default_value)
   return list;
 }
 
+static auto create_list(int size, const nlohmann::json &default_value)
+{
+  nlohmann::json list;
+  list["_type"] = "List";
+  list["elts"] = nlohmann::json::array();
+  for (int i = 0; i < size; ++i)
+  {
+    list["elts"].push_back(default_value);
+  }
+  return list;
+}
+
 template <typename T>
 static auto create_list(const std::vector<T> &vector)
 {
@@ -922,6 +935,128 @@ static auto create_binary_op(
   return bin_op;
 }
 
+static std::string normalize_numpy_dtype_name(const std::string &dtype)
+{
+  if (dtype == "bool" || dtype == "bool_")
+    return "bool";
+  if (dtype == "int" || dtype == "int_")
+    return "int64";
+  if (dtype == "uint" || dtype == "uint_")
+    return "uint64";
+  if (dtype == "float" || dtype == "float_")
+    return "float64";
+  if (dtype == "complex" || dtype == "complex_")
+    return "complex128";
+  return dtype;
+}
+
+static std::string extract_numpy_dtype_name(const nlohmann::json &dtype_node)
+{
+  if (!dtype_node.is_object() || !dtype_node.contains("_type"))
+    throw std::runtime_error("Unsupported dtype value");
+
+  const std::string node_type = dtype_node["_type"].get<std::string>();
+  if (node_type == "Attribute" && dtype_node.contains("attr"))
+    return normalize_numpy_dtype_name(dtype_node["attr"].get<std::string>());
+  if (node_type == "Name" && dtype_node.contains("id"))
+    return normalize_numpy_dtype_name(dtype_node["id"].get<std::string>());
+
+  throw std::runtime_error("Unsupported dtype value");
+}
+
+static bool is_numpy_integer_dtype(const std::string &dtype)
+{
+  return dtype.find("int") != std::string::npos;
+}
+
+static bool is_numpy_float_dtype(const std::string &dtype)
+{
+  return dtype.find("float") != std::string::npos;
+}
+
+static bool is_numpy_complex_dtype(const std::string &dtype)
+{
+  return dtype == "complex64" || dtype == "complex128" || dtype == "complex";
+}
+
+static nlohmann::json
+make_numpy_typed_constant(const scalar_value &value, const std::string &dtype)
+{
+  const std::string normalized = normalize_numpy_dtype_name(dtype);
+
+  if (normalized.empty())
+    return {{"_type", "Constant"}, {"value", value.value.real()}};
+
+  if (normalized == "bool")
+  {
+    const bool bool_value =
+      value.value.real() != 0.0 || value.value.imag() != 0.0;
+    return {{"_type", "Constant"}, {"value", bool_value}};
+  }
+
+  if (is_numpy_integer_dtype(normalized))
+  {
+    if (value.is_complex && value.value.imag() != 0.0)
+    {
+      throw std::runtime_error(
+        "TypeError: casting complex literals to integer dtype is not "
+        "supported");
+    }
+    return {
+      {"_type", "Constant"},
+      {"value", static_cast<int64_t>(std::llround(value.value.real()))}};
+  }
+
+  if (is_numpy_float_dtype(normalized))
+  {
+    if (value.is_complex && value.value.imag() != 0.0)
+    {
+      throw std::runtime_error(
+        "TypeError: casting complex literals to float dtype is not supported");
+    }
+    return {{"_type", "Constant"}, {"value", value.value.real()}};
+  }
+
+  if (is_numpy_complex_dtype(normalized))
+  {
+    throw std::runtime_error(
+      "TypeError: complex dtype is not supported in NumPy constructors yet");
+  }
+
+  throw std::runtime_error("Unsupported dtype value: " + normalized);
+}
+
+static nlohmann::json cast_numpy_literal_to_dtype(
+  const nlohmann::json &node,
+  const std::string &dtype)
+{
+  if (dtype.empty())
+    return node;
+
+  if (!node.is_object() || !node.contains("_type"))
+  {
+    throw std::runtime_error(
+      "TypeError: np.array(..., dtype=...) requires literal numeric elements");
+  }
+
+  const std::string node_type = node["_type"].get<std::string>();
+  if ((node_type == "List" || node_type == "Tuple") && node.contains("elts"))
+  {
+    nlohmann::json casted = node;
+    casted["elts"] = nlohmann::json::array();
+    for (const auto &elt : node["elts"])
+      casted["elts"].push_back(cast_numpy_literal_to_dtype(elt, dtype));
+    return casted;
+  }
+
+  scalar_value value;
+  if (try_extract_scalar_constant(node, value))
+    return make_numpy_typed_constant(value, dtype);
+
+  throw std::runtime_error(
+    "TypeError: np.array(..., dtype=...) requires literal numeric elements");
+}
+
 bool numpy_call_expr::is_math_function() const
 {
   const std::string &function = function_id_.get_function();
@@ -946,7 +1081,7 @@ std::string numpy_call_expr::get_dtype() const
     for (const auto &kw : call_["keywords"])
     {
       if (kw["_type"] == "keyword" && kw["arg"] == "dtype")
-        return kw["value"]["attr"];
+        return extract_numpy_dtype_name(kw["value"]);
     }
   }
   return {};
@@ -968,6 +1103,9 @@ size_t numpy_call_expr::get_dtype_size() const
     {"float64", sizeof(double)}};
 
   const std::string dtype = get_dtype();
+  if (dtype == "bool" || is_numpy_complex_dtype(dtype))
+    return 0;
+
   if (!dtype.empty())
   {
     auto it = dtype_sizes.find(dtype);
@@ -989,6 +1127,8 @@ size_t count_effective_bits(const std::string &binary)
 typet numpy_call_expr::get_typet_from_dtype() const
 {
   std::string dtype = get_dtype();
+  if (dtype == "bool")
+    return bool_type();
   if (dtype.find("int") != std::string::npos)
   {
     if (dtype[0] == 'u')
@@ -1952,7 +2092,12 @@ exprt numpy_call_expr::get()
   // Create array from numpy.array()
   if (function == "array")
   {
-    int array_dims = type_handler_.get_array_dimensions(call_["args"][0]);
+    nlohmann::json array_arg = call_["args"][0];
+    const std::string dtype = get_dtype();
+    if (!dtype.empty())
+      array_arg = cast_numpy_literal_to_dtype(array_arg, dtype);
+
+    int array_dims = type_handler_.get_array_dimensions(array_arg);
     if (array_dims >= 3)
     {
       throw std::runtime_error(
@@ -1961,8 +2106,8 @@ exprt numpy_call_expr::get()
         "D array creation. Please use 1D or 2D arrays only.");
     }
 
-    typet size = type_handler_.get_typet(call_["args"][0]["elts"]);
-    return converter_.get_static_array(call_["args"][0], size);
+    typet size = type_handler_.get_typet(array_arg["elts"]);
+    return converter_.get_static_array(array_arg, size);
   }
 
   static const std::unordered_map<std::string, float> array_creation_funcs = {
@@ -1972,8 +2117,56 @@ exprt numpy_call_expr::get()
   auto it = array_creation_funcs.find(function);
   if (it != array_creation_funcs.end())
   {
-    auto list = create_list(call_["args"][0]["value"].get<int>(), it->second);
-    return converter_.get_expr(list);
+    const scalar_value fill = make_real_scalar(it->second);
+    const std::string dtype = get_dtype();
+    const nlohmann::json fill_value = make_numpy_typed_constant(fill, dtype);
+    const auto &shape_arg = call_["args"][0];
+    const std::string arg_type = shape_arg["_type"];
+
+    if (arg_type == "Constant")
+    {
+      // np.zeros(n) or np.ones(n) — 1D
+      auto list = create_list(shape_arg["value"].get<int>(), fill_value);
+      return converter_.get_expr(list);
+    }
+
+    if (arg_type == "Tuple")
+    {
+      const auto &elts = shape_arg["elts"];
+      const std::size_t ndim = elts.size();
+      if (ndim == 0)
+      {
+        throw std::runtime_error(
+          "TypeError: " + function + "() shape tuple must be non-empty");
+      }
+      if (ndim == 1)
+      {
+        // np.zeros((n,)) — treat as 1D
+        auto list = create_list(elts[0]["value"].get<int>(), fill_value);
+        return converter_.get_expr(list);
+      }
+      if (ndim == 2)
+      {
+        // np.zeros((rows, cols)) — 2D nested list
+        const int rows = elts[0]["value"].get<int>();
+        const int cols = elts[1]["value"].get<int>();
+        nlohmann::json outer;
+        outer["_type"] = "List";
+        outer["elts"] = nlohmann::json::array();
+        for (int r = 0; r < rows; ++r)
+        {
+          outer["elts"].push_back(create_list(cols, fill_value));
+        }
+        return converter_.get_expr(outer);
+      }
+      throw std::runtime_error(
+        "ESBMC does not support 3D or higher dimensional arrays. Found " +
+        std::to_string(ndim) + "D array creation in " + function +
+        "(). Please use 1D or 2D arrays only.");
+    }
+
+    throw std::runtime_error(
+      "TypeError: " + function + "() argument must be int or tuple of ints");
   }
 
   // Handle math function calls

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -114,7 +114,7 @@ weight: 4
 
 ## NumPy Module
 
-- Arrays are modelled with a restricted subset: `.shape` is available for modelled arrays, tuple indexing is lowered through chained indexing, and direct scalar broadcasting still covers simple binary operators such as `a + n` and `a * n`. Higher-dimensional arrays are rejected explicitly; full NumPy dtype semantics and unrestricted N-dimensional indexing remain unsupported.
+- Arrays are modelled with a restricted subset: `.shape` is available for modelled arrays, tuple indexing is lowered through chained indexing, and direct scalar broadcasting still covers simple binary operators such as `a + n` and `a * n`. Array constructors preserve explicit `dtype` for supported literal `bool`/`int`/`float` inputs in the 1D/2D recorte; unsupported constructor dtypes and higher-dimensional arrays are rejected explicitly. Full NumPy dtype semantics and unrestricted N-dimensional indexing remain unsupported.
 - Element-wise `np.add`/`np.subtract`/`np.multiply`/`np.divide`/`np.power` support literal list-backed 1D/2D inputs with NumPy-style broadcasting. Runtime-constructed inputs and higher-dimensional inputs are rejected with deterministic frontend errors rather than falling through to the SMT backend.
 - Only the NumPy functions listed in [Supported Features — NumPy](./supported-features#numpy-module-numpy) have executable support.
 - The remaining type-inference-only stubs are `np.arccos`, `np.fmod`, `np.dot`, `np.matmul`, and `np.transpose`.

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -426,7 +426,7 @@ All `os` functions use nondeterministic modelling to verify both success and fai
 
 Partial executable support for list-backed arrays, element-wise arithmetic, selected math functions, and small determinants. Some APIs remain stubs for type inference only.
 
-**Array construction**: `np.array(l)`, `np.zeros(shape)`, `np.ones(shape)` for supported 1D/2D shapes
+**Array construction**: `np.array(l)`, `np.zeros(shape)`, `np.ones(shape)` for supported 1D/2D shapes, including explicit constructor `dtype` coercion for literal `bool`, `int`, and `float` inputs
 
 **Element-wise arithmetic**: `np.add(a, b)`, `np.subtract(a, b)`, `np.multiply(a, b)`, `np.divide(a, b)`, `np.power(a, b)` on literal list-backed inputs, with NumPy-style broadcasting for 1D/2D shapes
 


### PR DESCRIPTION
- Implements dtype coercion for NumPy array constructors and operations.
- Adds dtype normalization and extraction helpers for numpy.array(), zeros(), ones().
- Supports explicit dtype parameter with bool, int64, uint64, float64 promotion.
- Coerces literal constants (bool, int, float) to target dtype before construction.
- Rejects complex dtypes with clear error message at frontend.
- Preserves dtype across broadcasting operations with type promotion rules.
- Adds 43 regression tests covering dtype preservation, indexing, and broadcasting.