### PR TITLE
[python] fix str.split() on join/replace/repeat receivers (Fixes #5096)

### DIFF
--- a/regression/python/string-split-join/main.py
+++ b/regression/python/string-split-join/main.py
@@ -1,0 +1,15 @@
+def main() -> None:
+    # split() on a str.join() receiver built from an inline list
+    parts = ",".join(["a", "b", "c"]).split(",")
+    assert len(parts) == 3
+    assert parts[0] == "a"
+    assert parts[2] == "c"
+
+    # join() over a variable-bound list
+    items = ["x", "y"]
+    s = "-".join(items).split("-")
+    assert len(s) == 2
+    assert s[1] == "y"
+
+
+main()

--- a/regression/python/string-split-join/test.desc
+++ b/regression/python/string-split-join/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-split-nonconcat_fail/main.py
+++ b/regression/python/string-split-nonconcat_fail/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    # Unsoundness from issue #5096: split() of a join() receiver was modeled as
+    # a length-1 list, so this FALSE assertion was wrongly proved SUCCESSFUL.
+    # CPython yields len == 2, so ESBMC must report a counterexample.
+    assert len(",".join(["a", "b"]).split(",")) == 1
+
+
+main()

--- a/regression/python/string-split-nonconcat_fail/test.desc
+++ b/regression/python/string-split-nonconcat_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$

--- a/regression/python/string-split-repeat/main.py
+++ b/regression/python/string-split-repeat/main.py
@@ -1,0 +1,14 @@
+def main() -> None:
+    # split() on a "*"-repeat receiver, str * n
+    parts = ("a." * 2).split(".")
+    assert len(parts) == 3      # ['a', 'a', '']
+    assert parts[0] == "a"
+    assert parts[2] == ""
+
+    # n * str form
+    chunks = (3 * "x,").split(",")
+    assert len(chunks) == 4      # ['x', 'x', 'x', '']
+    assert chunks[0] == "x"
+
+
+main()

--- a/regression/python/string-split-repeat/test.desc
+++ b/regression/python/string-split-repeat/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-split-replace/main.py
+++ b/regression/python/string-split-replace/main.py
@@ -1,0 +1,15 @@
+def main() -> None:
+    # split() on a str.replace() receiver bound through a variable
+    s = "a-b-c".replace("-", ".")
+    parts = s.split(".")
+    assert len(parts) == 3
+    assert parts[0] == "a"
+    assert parts[2] == "c"
+
+    # replace() with a count argument, inline receiver
+    t = "a.a.a".replace(".", "-", 1).split(".")
+    assert len(t) == 2
+    assert t[0] == "a-a"
+
+
+main()

--- a/regression/python/string-split-replace/test.desc
+++ b/regression/python/string-split-replace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -2223,6 +2223,17 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
         }
       }
     }
+
+    // Method call chained on another call's result, e.g.
+    // ",".join([...]).split(",") or "a-b".replace("-", ".").split("."). The
+    // inner receiver is a temporary with no symbol name and no class to
+    // resolve, so report an unknown type instead of throwing.
+    if (
+      call["func"].contains("value") &&
+      call["func"]["value"].contains("_type") &&
+      call["func"]["value"]["_type"] == "Call")
+      return "Any";
+
     throw std::runtime_error("Object \"" + obj + "\" not found.");
   }
 

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1516,8 +1516,9 @@ static bool fold_string_method_call(
   if (method == "join")
   {
     std::string sep;
-    if (args.size() != 1 ||
-        !fold_constant_string(func["value"], converter, sep, depth + 1))
+    if (
+      args.size() != 1 ||
+      !fold_constant_string(func["value"], converter, sep, depth + 1))
       return false;
 
     // Resolve the iterable, following a single Name binding, to a literal
@@ -1566,12 +1567,11 @@ static bool fold_string_method_call(
 
     long long count = -1;
     if (
-      args.size() == 3 &&
-      !json_utils::extract_constant_integer(
-        args[2],
-        converter.get_current_func_name(),
-        converter.get_ast_json(),
-        count))
+      args.size() == 3 && !json_utils::extract_constant_integer(
+                            args[2],
+                            converter.get_current_func_name(),
+                            converter.get_ast_json(),
+                            count))
       return false;
 
     return python_str_replace(subject, old_sub, new_sub, count, out);
@@ -1661,9 +1661,10 @@ static bool fold_constant_string(
       // Bound the materialized string so a large factor cannot exhaust memory;
       // beyond the cap, defer to the runtime model.
       constexpr unsigned long long max_len = 1ull << 16;
-      if (static_cast<unsigned long long>(s.size()) *
-            static_cast<unsigned long long>(n) >
-          max_len)
+      if (
+        static_cast<unsigned long long>(s.size()) *
+          static_cast<unsigned long long>(n) >
+        max_len)
         return false;
       out.clear();
       out.reserve(s.size() * static_cast<std::size_t>(n));

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1453,10 +1453,138 @@ string_handler::find_cached_c_function_symbol(const std::string &symbol_id)
   return find_cached_symbol(symbol_id);
 }
 
+static bool fold_constant_string(
+  const nlohmann::json &node,
+  python_converter &converter,
+  std::string &out,
+  unsigned depth);
+
+// Python str.replace(old, new, count): replace up to `count` non-overlapping
+// occurrences of `old` with `new`, scanning left to right; a negative `count`
+// replaces every occurrence. Returns false for an empty `old` (Python inserts
+// `new` between every character), so the caller defers to the runtime model
+// (which still under-approximates split — see #5096).
+static bool python_str_replace(
+  const std::string &subject,
+  const std::string &old_sub,
+  const std::string &new_sub,
+  long long count,
+  std::string &out)
+{
+  if (old_sub.empty())
+    return false;
+
+  out.clear();
+  std::size_t pos = 0;
+  for (long long done = 0; count < 0 || done < count; ++done)
+  {
+    std::size_t hit = subject.find(old_sub, pos);
+    if (hit == std::string::npos)
+      break;
+    out.append(subject, pos, hit - pos);
+    out += new_sub;
+    pos = hit + old_sub.size();
+  }
+  out.append(subject, pos, std::string::npos);
+  return true;
+}
+
+// Fold a constant string-valued method call: `sep.join([...])` over a literal
+// list/tuple of constant strings, or `subject.replace(old, new[, count])`.
+// Only positional, constant-foldable arguments are handled; anything else
+// returns false so the caller falls back to the runtime string model (which
+// still under-approximates split — see #5096).
+static bool fold_string_method_call(
+  const nlohmann::json &node,
+  python_converter &converter,
+  std::string &out,
+  unsigned depth)
+{
+  const auto &func = node["func"];
+  if (
+    !func.contains("_type") || func["_type"] != "Attribute" ||
+    !func.contains("attr") || !func.contains("value"))
+    return false;
+
+  // Keyword arguments are not folded.
+  if (node.contains("keywords") && !node["keywords"].empty())
+    return false;
+
+  const std::string method = func["attr"].get<std::string>();
+  const nlohmann::json &args = node["args"];
+
+  if (method == "join")
+  {
+    std::string sep;
+    if (args.size() != 1 ||
+        !fold_constant_string(func["value"], converter, sep, depth + 1))
+      return false;
+
+    // Resolve the iterable, following a single Name binding, to a literal
+    // list/tuple of constant strings.
+    nlohmann::json seq = args[0];
+    if (seq.contains("_type") && seq["_type"] == "Name" && seq.contains("id"))
+    {
+      nlohmann::json decl = json_utils::get_var_value(
+        seq["id"].get<std::string>(),
+        converter.get_current_func_name(),
+        converter.get_ast_json());
+      if (decl.empty() || !decl.contains("value"))
+        return false;
+      seq = decl["value"];
+    }
+    if (
+      !seq.contains("_type") ||
+      (seq["_type"] != "List" && seq["_type"] != "Tuple") ||
+      !seq.contains("elts"))
+      return false;
+
+    out.clear();
+    bool first = true;
+    for (const auto &elt : seq["elts"])
+    {
+      std::string piece;
+      if (!fold_constant_string(elt, converter, piece, depth + 1))
+        return false;
+      if (!first)
+        out += sep;
+      out += piece;
+      first = false;
+    }
+    return true;
+  }
+
+  if (method == "replace")
+  {
+    std::string subject, old_sub, new_sub;
+    if (
+      args.size() < 2 || args.size() > 3 ||
+      !fold_constant_string(func["value"], converter, subject, depth + 1) ||
+      !fold_constant_string(args[0], converter, old_sub, depth + 1) ||
+      !fold_constant_string(args[1], converter, new_sub, depth + 1))
+      return false;
+
+    long long count = -1;
+    if (
+      args.size() == 3 &&
+      !json_utils::extract_constant_integer(
+        args[2],
+        converter.get_current_func_name(),
+        converter.get_ast_json(),
+        count))
+      return false;
+
+    return python_str_replace(subject, old_sub, new_sub, count, out);
+  }
+
+  return false;
+}
+
 // Recursively fold an AST node into a constant string: a string literal, a Name
-// bound to such a value, or a Python "+" concatenation of two foldable string
-// operands. Any non-constant operand yields false, so callers fall back to the
-// runtime string model. `depth` bounds the recursion against degenerate ASTs.
+// bound to such a value, a Python "+" concatenation, a "*" repetition, or a
+// constant-foldable join()/replace() method call. Any non-constant operand
+// yields false, so callers fall back to the runtime string model. `depth`
+// bounds the recursion against degenerate ASTs.
 static bool fold_constant_string(
   const nlohmann::json &node,
   python_converter &converter,
@@ -1505,6 +1633,55 @@ static bool fold_constant_string(
       return true;
     }
   }
+
+  // String repetition: "ab" * n  or  n * "ab".
+  if (
+    type == "BinOp" && node.contains("op") && node["op"].contains("_type") &&
+    node["op"]["_type"] == "Mult" && node.contains("left") &&
+    node.contains("right"))
+  {
+    auto fold_repeat = [&](
+                         const nlohmann::json &str_node,
+                         const nlohmann::json &count_node) -> bool {
+      std::string s;
+      long long n = 0;
+      if (
+        !fold_constant_string(str_node, converter, s, depth + 1) ||
+        !json_utils::extract_constant_integer(
+          count_node,
+          converter.get_current_func_name(),
+          converter.get_ast_json(),
+          n))
+        return false;
+      if (n <= 0)
+      {
+        out.clear();
+        return true;
+      }
+      // Bound the materialized string so a large factor cannot exhaust memory;
+      // beyond the cap, defer to the runtime model.
+      constexpr unsigned long long max_len = 1ull << 16;
+      if (static_cast<unsigned long long>(s.size()) *
+            static_cast<unsigned long long>(n) >
+          max_len)
+        return false;
+      out.clear();
+      out.reserve(s.size() * static_cast<std::size_t>(n));
+      for (long long i = 0; i < n; ++i)
+        out += s;
+      return true;
+    };
+    if (
+      fold_repeat(node["left"], node["right"]) ||
+      fold_repeat(node["right"], node["left"]))
+      return true;
+  }
+
+  // Constant-foldable string method call: join()/replace().
+  if (
+    type == "Call" && node.contains("func") && node.contains("args") &&
+    node["args"].is_array())
+    return fold_string_method_call(node, converter, out, depth);
 
   return false;
 }


### PR DESCRIPTION
## Summary

Fixes #5096. ESBMC's Python frontend mis-modeled `str.split(sep)` when the receiver string was produced by `str.join()`, `str.replace()`, or `*` repetition. The constant-split path only folded string literals and `+` concatenation (added in #5090), so these other producers fell through to the runtime stub `__python_str_split`, which returns a hardcoded single-element list. This caused both false alarms and **unsound missed counterexamples**.

| Expression | CPython | ESBMC (before) |
|---|---|---|
| `len(",".join(["a","b"]).split(","))` | 2 | 1 |
| `len("a-b".replace("-",".").split("."))` | 2 | 1 |
| `len(("a." * 2).split("."))` | 3 | 1 |

## Root cause

`string_handler::extract_constant_string` → `fold_constant_string` recognized only `Constant`, `Name`-bound, and `+`/`BinOp.Add` receivers. Any `join`/`replace`/`*` receiver was not folded, so `split()` defaulted to the broken runtime model.

## Fix

Extend `fold_constant_string` (the same strategy as #5090) with three new foldable node shapes:

- **`*` repetition** — `"ab" * n` and `n * "ab"`, with a 64 KB materialization cap so a large factor cannot exhaust memory (beyond the cap it defers to the runtime model).
- **`sep.join([...])`** — over an inline or single-`Name`-bound literal `List`/`Tuple` of constant strings.
- **`subject.replace(old, new[, count])`** — CPython left-to-right, non-overlapping semantics; negative/absent `count` replaces all, `count == 0` replaces none; an empty `old` defers to the runtime model.

Any non-constant operand still returns `false`, preserving the existing runtime fallback for symbolic strings. The annotation pass (`annotation_conversion.inl`) now returns `"Any"` for a method called on another call's result (a chained-call receiver such as `",".join([...]).split(",")`) instead of throwing.

## Verification

- The three issue reproducers now produce CPython-correct verdicts (counterexample found in each).
- Full `string-split*` / `concat*` regression suites pass (98 tests), no regressions.

## Tests

- `regression/python/string-split-join/` — passing: inline and variable-bound `join()` receivers.
- `regression/python/string-split-replace/` — passing: variable-bound and count-arg `replace()` receivers.
- `regression/python/string-split-repeat/` — passing: `str * n` and `n * str` receivers.
- `regression/python/string-split-nonconcat_fail/` — failing: the issue's `join()` unsoundness variant (`len(",".join(["a","b"]).split(",")) == 1`).