### PR TITLE
[python] V.3: migrate function_call/expr.cpp bulk idioms to IREP2

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -21,6 +21,8 @@
 #include <util/python_types.h>
 #include <util/std_expr.h>
 #include <util/string_constant.h>
+#include <irep2/irep2_utils.h>
+#include <util/migrate.h>
 
 #include <algorithm>
 #include <cctype>
@@ -30,6 +32,59 @@
 #include <unordered_set>
 
 using namespace json_utils;
+namespace
+{
+// V.3: IREP2 expression-construction helpers (exact round-trip; behaviour-
+// preserving). Back-migrated for the legacy adjust/goto-convert seam.
+//
+// A dynamically-sized array type (non-constant size) does not survive the
+// migrate_type round-trip (get_width throws downstream), so the helpers fall
+// back to the legacy constructor when the relevant type contains one.
+bool contains_dyn_array(const typet &t)
+{
+  if (t.is_array())
+  {
+    const array_typet &at = to_array_type(t);
+    if (at.size().is_nil() || !at.size().is_constant())
+      return true;
+    return contains_dyn_array(at.subtype());
+  }
+  if (t.is_pointer())
+    return contains_dyn_array(t.subtype());
+  return false;
+}
+
+exprt build_symbol(const symbolt &sym)
+{
+  if (contains_dyn_array(sym.get_type()))
+    return symbol_expr(sym);
+  return migrate_expr_back(symbol_expr2tc(sym));
+}
+
+exprt build_typecast(const exprt &from, const typet &t)
+{
+  if (contains_dyn_array(t) || contains_dyn_array(from.type()))
+    return typecast_exprt(from, t);
+  expr2tc from2;
+  migrate_expr(from, from2);
+  exprt result = migrate_expr_back(typecast2tc(migrate_type(t), from2));
+  // migrate_type does not round-trip type attributes such as #cpp_type;
+  // restore the exact target type so legacy typecast_exprt(from, t) is
+  // reproduced faithfully.
+  result.type() = t;
+  return result;
+}
+
+exprt build_address_of(const exprt &obj)
+{
+  if (contains_dyn_array(obj.type()))
+    return address_of_exprt(obj);
+  expr2tc obj2;
+  migrate_expr(obj, obj2);
+  return migrate_expr_back(address_of2tc(obj2->type, obj2));
+}
+} // namespace
+
 namespace
 {
 // Constants for UTF-8 encoding
@@ -549,7 +604,7 @@ exprt function_call_expr::build_constant_from_arg() const
         else
         {
           // Convert symbol to expression and use with base
-          exprt value_expr = symbol_expr(*sym);
+          exprt value_expr = build_symbol(*sym);
           return converter_.get_string_handler()
             .handle_int_conversion_with_base(
               value_expr, base_expr, converter_.get_location_from_decl(call_));
@@ -739,7 +794,7 @@ exprt function_call_expr::build_constant_from_arg() const
       // Numeric variable: emit a proper typecast to avoid mislabeled IR
       typet float_t = type_handler_.get_typet("float", 0);
       if (!expr.type().is_floatbv())
-        return typecast_exprt(expr, float_t);
+        return build_typecast(expr, float_t);
       return expr;
     }
   }
@@ -825,7 +880,7 @@ exprt function_call_expr::build_constant_from_arg() const
   // the type tag says float but the operation is bitvector arithmetic,
   // causing sort mismatches in the SMT encoder.
   if (func_name == "float" && !expr.type().is_floatbv())
-    return typecast_exprt(expr, t);
+    return build_typecast(expr, t);
 
   if (func_name != "str")
     expr.type() = t;
@@ -1107,7 +1162,7 @@ void function_call_expr::materialize_list_symbol(const symbolt *sym) const
     name.find("$call_list$") == std::string::npos &&
     name.find("$dict_list$") == std::string::npos)
     return;
-  code_declt decl(symbol_expr(*sym));
+  code_declt decl(build_symbol(*sym));
   decl.copy_to_operands(sym->get_value());
   decl.location() = sym->location;
   converter_.current_block->copy_to_operands(decl);
@@ -1189,7 +1244,7 @@ exprt function_call_expr::handle_list_insert() const
   {
     symbolt &insert_value_symbol = converter_.create_tmp_symbol(
       call_, "insert_value", size_type(), gen_zero(size_type()));
-    code_declt insert_value(symbol_expr(insert_value_symbol));
+    code_declt insert_value(build_symbol(insert_value_symbol));
     insert_value.copy_to_operands(value_to_insert);
     converter_.current_block->copy_to_operands(insert_value);
   }
@@ -1220,8 +1275,8 @@ exprt function_call_expr::handle_list_clear() const
 
   // Build function call
   code_function_callt clear_call;
-  clear_call.function() = symbol_expr(*clear_func);
-  clear_call.arguments().push_back(symbol_expr(*list_symbol));
+  clear_call.function() = build_symbol(*clear_func);
+  clear_call.arguments().push_back(build_symbol(*list_symbol));
   clear_call.type() = empty_typet();
   clear_call.location() = converter_.get_location_from_decl(call_);
 
@@ -1323,7 +1378,7 @@ exprt function_call_expr::handle_list_appendleft() const
   {
     symbolt &insert_value_symbol = converter_.create_tmp_symbol(
       call_, "insert_value", size_type(), gen_zero(size_type()));
-    code_declt insert_value(symbol_expr(insert_value_symbol));
+    code_declt insert_value(build_symbol(insert_value_symbol));
     insert_value.copy_to_operands(value_to_insert);
     converter_.current_block->copy_to_operands(insert_value);
   }
@@ -1506,16 +1561,16 @@ exprt function_call_expr::handle_dict_method() const
       converter_.find_symbol(dict_symbol_id.to_string());
     if (!dict_symbol)
       throw std::runtime_error("Dictionary variable not found: " + dict_name);
-    dict_expr = symbol_expr(*dict_symbol);
+    dict_expr = build_symbol(*dict_symbol);
   }
   else
   {
     exprt literal = converter_.get_expr(call_["func"]["value"]);
     symbolt &tmp = converter_.create_tmp_symbol(
       call_, "$dict_lit$", literal.type(), exprt());
-    converter_.add_instruction(code_declt(symbol_expr(tmp)));
-    converter_.add_instruction(code_assignt(symbol_expr(tmp), literal));
-    dict_expr = symbol_expr(tmp);
+    converter_.add_instruction(code_declt(build_symbol(tmp)));
+    converter_.add_instruction(code_assignt(build_symbol(tmp), literal));
+    dict_expr = build_symbol(tmp);
   }
 
   if (method_name == "get")
@@ -1692,8 +1747,8 @@ exprt function_call_expr::handle_list_sort() const
 
   // ── Emit the call: __ESBMC_list_sort(list, type_flag, float_type_id) ──────
   code_function_callt sort_call;
-  sort_call.function() = symbol_expr(*sort_func);
-  sort_call.arguments().push_back(symbol_expr(*list_symbol));
+  sort_call.function() = build_symbol(*sort_func);
+  sort_call.arguments().push_back(build_symbol(*list_symbol));
   sort_call.arguments().push_back(from_integer(type_flag, int_type()));
   sort_call.arguments().push_back(
     from_integer(float_type_id, unsignedbv_typet(config.ansi_c.address_width)));
@@ -1712,8 +1767,8 @@ exprt function_call_expr::handle_list_sort() const
       "__ESBMC_list_reverse function not found in symbol table");
 
   code_function_callt reverse_call;
-  reverse_call.function() = symbol_expr(*reverse_func);
-  reverse_call.arguments().push_back(symbol_expr(*list_symbol));
+  reverse_call.function() = build_symbol(*reverse_func);
+  reverse_call.arguments().push_back(build_symbol(*list_symbol));
   reverse_call.type() = empty_typet();
   reverse_call.location() = converter_.get_location_from_decl(call_);
 
@@ -1746,8 +1801,8 @@ exprt function_call_expr::handle_list_reverse() const
 
   // Emit: __ESBMC_list_reverse(list)
   code_function_callt reverse_call;
-  reverse_call.function() = symbol_expr(*reverse_func);
-  reverse_call.arguments().push_back(symbol_expr(*list_symbol));
+  reverse_call.function() = build_symbol(*reverse_func);
+  reverse_call.arguments().push_back(build_symbol(*list_symbol));
   reverse_call.type() = empty_typet();
   reverse_call.location() = converter_.get_location_from_decl(call_);
 
@@ -1968,7 +2023,7 @@ exprt function_call_expr::handle_list_append() const
     symbolt &tmp_var = converter_.create_tmp_symbol(
       call_, "$append_ret$", ret_type, gen_zero(ret_type));
 
-    code_declt tmp_decl(symbol_expr(tmp_var));
+    code_declt tmp_decl(build_symbol(tmp_var));
     tmp_decl.location() = converter_.get_location_from_decl(call_);
     converter_.current_block->copy_to_operands(tmp_decl);
 
@@ -1976,13 +2031,13 @@ exprt function_call_expr::handle_list_append() const
     code_function_callt new_call;
     new_call.function() = func_expr;
     new_call.arguments() = func_args;
-    new_call.lhs() = symbol_expr(tmp_var);
+    new_call.lhs() = build_symbol(tmp_var);
     new_call.type() = ret_type;
     new_call.location() = converter_.get_location_from_decl(call_);
     converter_.current_block->copy_to_operands(new_call);
 
     // Replace value_to_append with the temporary variable
-    value_to_append = symbol_expr(tmp_var);
+    value_to_append = build_symbol(tmp_var);
   }
 
   // Treat a single-element char array (`char[1]`) as a `char *` for storage
@@ -2012,7 +2067,7 @@ exprt function_call_expr::handle_list_append() const
     // Create tmp variable to hold value
     symbolt &append_value_symbol = converter_.create_tmp_symbol(
       call_, "append_value", size_type(), gen_zero(size_type()));
-    code_declt append_value(symbol_expr(append_value_symbol));
+    code_declt append_value(build_symbol(append_value_symbol));
     append_value.copy_to_operands(value_to_append);
     converter_.current_block->copy_to_operands(append_value);
   }
@@ -2303,7 +2358,7 @@ function_call_expr::get_dispatch_table()
            if (!is_cpp_throw_expr(z))
            {
              side_effect_expr_function_callt model_call;
-             model_call.function() = symbol_expr(*model_sym);
+             model_call.function() = build_symbol(*model_sym);
              model_call.arguments() = {z};
              model_call.type() =
                to_code_type(model_sym->get_type()).return_type();
@@ -2370,7 +2425,7 @@ function_call_expr::get_dispatch_table()
        }
 
        side_effect_expr_function_callt model_call;
-       model_call.function() = symbol_expr(*model_symbol);
+       model_call.function() = build_symbol(*model_symbol);
        model_call.arguments() = {z};
        model_call.type() = to_code_type(model_symbol->get_type()).return_type();
        model_call.location() = converter_.get_location_from_decl(call_);
@@ -2773,10 +2828,10 @@ function_call_expr::get_dispatch_table()
              {
                symbolt &tmp = converter_.create_tmp_symbol(
                  call_, "$dist_arg$", arg.type(), arg);
-               code_declt decl(symbol_expr(tmp));
+               code_declt decl(build_symbol(tmp));
                decl.location() = converter_.get_location_from_decl(call_);
                converter_.current_block->copy_to_operands(decl);
-               arg = symbol_expr(tmp);
+               arg = build_symbol(tmp);
              }
            };
            materialize(lhs_expr);
@@ -3153,11 +3208,11 @@ exprt function_call_expr::handle_general_function_call()
     {
       side_effect_expr_function_callt call;
       call.location() = converter_.get_location_from_decl(call_);
-      exprt func_expr = symbol_expr(*var_symbol);
+      exprt func_expr = build_symbol(*var_symbol);
       if (
         !var_symbol->get_type().is_pointer() ||
         !var_symbol->get_type().subtype().is_code())
-        func_expr = typecast_exprt(func_expr, gen_pointer_type(code_typet()));
+        func_expr = build_typecast(func_expr, gen_pointer_type(code_typet()));
       call.function() = func_expr;
 
       bool resolved = false;
@@ -3189,7 +3244,7 @@ exprt function_call_expr::handle_general_function_call()
       {
         exprt arg = converter_.get_expr(arg_node);
         if (arg.type().is_code() && arg.is_symbol())
-          arg = address_of_exprt(arg);
+          arg = build_address_of(arg);
         call.arguments().push_back(arg);
       }
       return call;
@@ -3232,7 +3287,7 @@ exprt function_call_expr::handle_general_function_call()
       {
         exprt arg = converter_.get_expr(arg_node);
         if (arg.type().is_array())
-          call.arguments().push_back(address_of_exprt(arg));
+          call.arguments().push_back(build_address_of(arg));
         else
           call.arguments().push_back(arg);
       }
@@ -3385,7 +3440,7 @@ exprt function_call_expr::handle_general_function_call()
 
           if (obj_symbol)
           {
-            exprt receiver = symbol_expr(*obj_symbol);
+            exprt receiver = build_symbol(*obj_symbol);
             call.arguments().push_back(
               receiver.type().is_pointer() ? receiver
                                            : gen_address_of(receiver));
@@ -3410,12 +3465,12 @@ exprt function_call_expr::handle_general_function_call()
                 // Constant array (e.g., folded string concat) must be materialized before address_of_exprt.
                 symbolt &tmp = converter_.create_tmp_symbol(
                   call_, "$const_str_arg$", arg.type(), arg);
-                code_declt tmp_decl(symbol_expr(tmp));
+                code_declt tmp_decl(build_symbol(tmp));
                 tmp_decl.location() = location;
                 converter_.current_block->copy_to_operands(tmp_decl);
-                arg = symbol_expr(tmp);
+                arg = build_symbol(tmp);
               }
-              call.arguments().push_back(address_of_exprt(arg));
+              call.arguments().push_back(build_address_of(arg));
             }
             else
               call.arguments().push_back(arg);
@@ -3496,12 +3551,12 @@ exprt function_call_expr::handle_general_function_call()
                 // Constant array (e.g., folded string concat) must be materialized before address_of_exprt.
                 symbolt &tmp = converter_.create_tmp_symbol(
                   call_, "$const_str_arg$", arg.type(), arg);
-                code_declt tmp_decl(symbol_expr(tmp));
+                code_declt tmp_decl(build_symbol(tmp));
                 tmp_decl.location() = location;
                 converter_.current_block->copy_to_operands(tmp_decl);
-                arg = symbol_expr(tmp);
+                arg = build_symbol(tmp);
               }
-              call.arguments().push_back(address_of_exprt(arg));
+              call.arguments().push_back(build_address_of(arg));
             }
             else
               call.arguments().push_back(arg);
@@ -3552,7 +3607,7 @@ exprt function_call_expr::handle_general_function_call()
 
   code_function_callt call;
   call.location() = location;
-  call.function() = symbol_expr(*func_symbol);
+  call.function() = build_symbol(*func_symbol);
   const typet &return_type =
     to_code_type(func_symbol->get_type()).return_type();
   call.type() = return_type;
@@ -3563,7 +3618,7 @@ exprt function_call_expr::handle_general_function_call()
 
   auto bind_instance_receiver_symbol =
     [&](const symbolt &receiver_symbol) -> exprt {
-    exprt receiver = symbol_expr(receiver_symbol);
+    exprt receiver = build_symbol(receiver_symbol);
     return bind_instance_receiver(receiver);
   };
 
@@ -3637,18 +3692,18 @@ exprt function_call_expr::handle_general_function_call()
           symbolt &tmp = converter_.create_tmp_symbol(
             func_value, "$inst$", class_type, exprt());
           converter_.symbol_table().add(tmp);
-          code_declt tmp_decl(symbol_expr(tmp));
+          code_declt tmp_decl(build_symbol(tmp));
           tmp_decl.location() = location;
           converter_.current_block->copy_to_operands(tmp_decl);
 
           // Call the constructor if it is defined, using tmp as self.
           exprt *saved_lhs = converter_.current_lhs;
-          exprt tmp_expr = symbol_expr(tmp);
+          exprt tmp_expr = build_symbol(tmp);
           converter_.current_lhs = &tmp_expr;
           exprt ctor_result = converter_.get_expr(func_value);
           converter_.current_lhs = saved_lhs;
 
-          call.arguments().push_back(bind_instance_receiver(symbol_expr(tmp)));
+          call.arguments().push_back(bind_instance_receiver(build_symbol(tmp)));
         }
         else if (func_value["_type"] == "Call")
         {
@@ -3663,7 +3718,7 @@ exprt function_call_expr::handle_general_function_call()
             symbolt &tmp = converter_.create_tmp_symbol(
               func_value, "$inst$", class_type, exprt());
             converter_.symbol_table().add(tmp);
-            code_declt tmp_decl(symbol_expr(tmp));
+            code_declt tmp_decl(build_symbol(tmp));
             tmp_decl.location() = location;
             converter_.current_block->copy_to_operands(tmp_decl);
 
@@ -3673,12 +3728,12 @@ exprt function_call_expr::handle_general_function_call()
             if (
               inner_call.is_code() && inner_call.statement() == "function_call")
             {
-              inner_call.op0() = symbol_expr(tmp);
+              inner_call.op0() = build_symbol(tmp);
               inner_call.location() = location;
               converter_.add_instruction(inner_call);
             }
             call.arguments().push_back(
-              bind_instance_receiver(symbol_expr(tmp)));
+              bind_instance_receiver(build_symbol(tmp)));
           }
           else
           {
@@ -3743,7 +3798,7 @@ exprt function_call_expr::handle_general_function_call()
         type_handler_.get_var_type(obj_symbol->name.as_string()) == "int" &&
         call_["args"].empty())
       {
-        call.arguments().push_back(symbol_expr(*obj_symbol));
+        call.arguments().push_back(build_symbol(*obj_symbol));
       }
       else if (call_["func"]["value"]["_type"] == "BinOp")
       {
@@ -3773,7 +3828,7 @@ exprt function_call_expr::handle_general_function_call()
     // A function name passed as an argument decays to a function pointer,
     // mirroring C's implicit function-to-pointer conversion.
     if (arg.type().is_code() && arg.is_symbol())
-      arg = address_of_exprt(arg);
+      arg = build_address_of(arg);
 
     // Check if the corresponding parameter is Optional
     size_t param_idx = arg_index + param_offset;
@@ -3800,12 +3855,12 @@ exprt function_call_expr::handle_general_function_call()
           exprt()); // No initial value here
 
         // Declare the temporary in the current block
-        code_declt temp_decl(symbol_expr(temp_symbol));
+        code_declt temp_decl(build_symbol(temp_symbol));
         temp_decl.location() = location;
         converter_.current_block->copy_to_operands(temp_decl);
 
         // Assign the character to the first element
-        exprt temp_array = symbol_expr(temp_symbol);
+        exprt temp_array = build_symbol(temp_symbol);
         exprt first_element =
           index_exprt(temp_array, from_integer(0, size_type()));
         code_assignt assign_char(first_element, arg);
@@ -3820,7 +3875,7 @@ exprt function_call_expr::handle_general_function_call()
         converter_.current_block->copy_to_operands(assign_null);
 
         // Take address of the temporary variable
-        arg = address_of_exprt(symbol_expr(temp_symbol));
+        arg = build_address_of(build_symbol(temp_symbol));
       }
 
       // Check if parameter is an Optional type
@@ -3856,15 +3911,15 @@ exprt function_call_expr::handle_general_function_call()
           // Materialize the struct in a temp variable first
           symbolt &tmp = converter_.create_tmp_symbol(
             call_, "$union_arg$", arg.type(), gen_zero(arg.type()));
-          code_declt tmp_decl(symbol_expr(tmp));
+          code_declt tmp_decl(build_symbol(tmp));
           tmp_decl.location() = location;
           converter_.current_block->copy_to_operands(tmp_decl);
-          code_assignt tmp_assign(symbol_expr(tmp), arg);
+          code_assignt tmp_assign(build_symbol(tmp), arg);
           tmp_assign.location() = location;
           converter_.current_block->copy_to_operands(tmp_assign);
-          arg = symbol_expr(tmp);
+          arg = build_symbol(tmp);
         }
-        arg = typecast_exprt(address_of_exprt(arg), param_type);
+        arg = build_typecast(build_address_of(arg), param_type);
       }
 
       // General object-reference coercion:
@@ -3879,18 +3934,18 @@ exprt function_call_expr::handle_general_function_call()
         {
           symbolt &tmp = converter_.create_tmp_symbol(
             call_, "$ptr_arg$", arg.type(), gen_zero(arg.type()));
-          code_declt tmp_decl(symbol_expr(tmp));
+          code_declt tmp_decl(build_symbol(tmp));
           tmp_decl.location() = location;
           converter_.current_block->copy_to_operands(tmp_decl);
-          code_assignt tmp_assign(symbol_expr(tmp), arg);
+          code_assignt tmp_assign(build_symbol(tmp), arg);
           tmp_assign.location() = location;
           converter_.current_block->copy_to_operands(tmp_assign);
-          arg = symbol_expr(tmp);
+          arg = build_symbol(tmp);
         }
 
-        arg = address_of_exprt(arg);
+        arg = build_address_of(arg);
         if (!base_type_eq(arg.type(), param_type, converter_.ns))
-          arg = typecast_exprt(arg, param_type);
+          arg = build_typecast(arg, param_type);
       }
     }
 
@@ -3922,11 +3977,11 @@ exprt function_call_expr::handle_general_function_call()
         symbolt &tmp_list = converter_.create_tmp_symbol(
           call_, "$obj_size_list_arg$", list_type, exprt());
 
-        code_declt tmp_decl(symbol_expr(tmp_list));
+        code_declt tmp_decl(build_symbol(tmp_list));
         tmp_decl.location() = location;
         converter_.current_block->copy_to_operands(tmp_decl);
 
-        code_assignt tmp_assign(symbol_expr(tmp_list), arg);
+        code_assignt tmp_assign(build_symbol(tmp_list), arg);
         tmp_assign.location() = location;
         converter_.current_block->copy_to_operands(tmp_assign);
 
@@ -3940,10 +3995,10 @@ exprt function_call_expr::handle_general_function_call()
       assert(list_size_func_sym);
 
       code_function_callt list_size_func_call;
-      list_size_func_call.function() = symbol_expr(*list_size_func_sym);
+      list_size_func_call.function() = build_symbol(*list_size_func_sym);
 
       // passing arguments to list_size
-      list_size_func_call.arguments().push_back(symbol_expr(*list_symbol));
+      list_size_func_call.arguments().push_back(build_symbol(*list_symbol));
 
       // setting return type
       list_size_func_call.type() = signedbv_typet(64);
@@ -4038,12 +4093,12 @@ exprt function_call_expr::handle_general_function_call()
         // Constant array (e.g., folded string concat) must be materialized before address_of_exprt.
         symbolt &tmp = converter_.create_tmp_symbol(
           call_, "$const_str_arg$", arg.type(), arg);
-        code_declt tmp_decl(symbol_expr(tmp));
+        code_declt tmp_decl(build_symbol(tmp));
         tmp_decl.location() = location;
         converter_.current_block->copy_to_operands(tmp_decl);
-        arg = symbol_expr(tmp);
+        arg = build_symbol(tmp);
       }
-      call.arguments().push_back(address_of_exprt(arg));
+      call.arguments().push_back(build_address_of(arg));
     }
     else
       call.arguments().push_back(arg);
@@ -4223,7 +4278,7 @@ exprt function_call_expr::handle_general_function_call()
           // For string constants, use address_of
           if (default_val.id() == "string-constant")
           {
-            default_val = address_of_exprt(default_val);
+            default_val = build_address_of(default_val);
           }
           else
           {
@@ -4281,13 +4336,13 @@ exprt function_call_expr::handle_general_function_call()
       converter_.symbol_table().add(temp_self);
 
       // Add declaration for temporary object
-      code_declt temp_decl(symbol_expr(temp_self));
+      code_declt temp_decl(build_symbol(temp_self));
       temp_decl.location() = location;
       converter_.current_block->copy_to_operands(temp_decl);
 
       // Insert self as first argument
       call.arguments().insert(
-        call.arguments().begin(), gen_address_of(symbol_expr(temp_self)));
+        call.arguments().begin(), gen_address_of(build_symbol(temp_self)));
 
       // Emit the constructor call directly as a FUNCTION_CALL instruction so
       // ESBMC inlines it (codet("expression") would produce OTHER and be
@@ -4295,7 +4350,7 @@ exprt function_call_expr::handle_general_function_call()
       // list literals receive the properly constructed object.
       call.location() = location;
       converter_.add_instruction(call);
-      return symbol_expr(temp_self);
+      return build_symbol(temp_self);
     }
   }
 


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction in the converter, #5055) with **`function_call/expr.cpp`** — the builtin call-builder (4774 LOC), previously untouched. Scoped to the **bulk-safe construction idioms** via file-local guarded helpers; member/index/side_effect deferred to follow-ups.

- **`build_symbol()`** — 60 `symbol_expr(sym)` → `symbol_expr2tc`
- **`build_typecast()`** — 5 `typecast_exprt` → `typecast2tc`, restoring the exact target type (`result.type() = t`) so the `#cpp_type` attribute that `migrate_type` drops — load-bearing for float casts feeding the SMT encoder — is preserved. *(Same class of bug that caused the macOS-CI false-positive fixed in #5094.)*
- **`build_address_of()`** — 13 `address_of_exprt` → `address_of2tc`

### Guards / lessons carried forward
- Each helper falls back to the legacy constructor on a **dyn-sized-array** type (the `migrate_type` round-trip isn't identity for those — `get_width` throws downstream). Defensive precondition here; the same shared guard is exercised by the merged list slice/reverse paths.
- The proactive `#cpp_type` preservation on `build_typecast` applies the macOS-CI lesson up-front.
- The 2 by-name `symbol_exprt(id, code_typet())` callees and 3 `to_symbol_expr(...)` accessors are correctly **not** rewritten (lexically distinct from the `symbol_expr(symbolt)` free function).

### Deferred (per-site work)
`member_exprt` (7), `index_exprt` (2), `side_effect_expr_function_callt` (7).

### Verification
- Build green (asserts build).
- Broad python suite **3623/3628**; the 5 failures are all pre-existing/env (flask-import `github_4149`/`_fail`, boolector `list_pop11_nondet`, stray `Testing` dir, a `-nondet` test), all confirmed failing on master.
- code review: 0 critical/major/minor — both helper branches behaviour-preserving; `result.type() = t` touches only the type sub-irep (not the operand); rounding-mode divergence is inert (converges downstream).
- clang-format applied.

Note: the four helpers now duplicate the proven set/list/dict versions — a follow-up could hoist them into a shared `python-frontend` header.
