### PR TITLE
[python] fix nested-list cross-function-return value/type (#5103, #5102)

### DIFF
--- a/regression/python/nested-list-return/main.py
+++ b/regression/python/nested-list-return/main.py
@@ -1,0 +1,33 @@
+# A nested list returned from a function must keep correct element values and
+# element types (int/float) when subscripted in the caller (#5103, #5102).
+# Previously the frontend referenced the callee-frame inner-list symbol, which
+# is nondet in the caller's frame: floats hit a __ESBMC_float_buf OOB crash and
+# ints read a wrong value.
+
+
+def build_float():
+    return [[1.5, 2.5]]
+
+
+def build_int():
+    return [[7, 8]]
+
+
+def build_deep():
+    return [[[9.0]]]
+
+
+Qf = build_float()
+Qi = build_int()
+Qd = build_deep()
+
+assert Qf[0][0] == 1.5
+assert Qf[0][1] == 2.5
+assert Qi[0][0] == 7
+assert Qi[0][1] == 8
+assert Qd[0][0][0] == 9.0
+
+# Variable (non-constant) outer index into a returned nested float list must
+# also read the inner element type/value at runtime.
+k = 0
+assert Qf[k][1] == 2.5

--- a/regression/python/nested-list-return/test.desc
+++ b/regression/python/nested-list-return/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-list-return_fail/main.py
+++ b/regression/python/nested-list-return_fail/main.py
@@ -1,0 +1,11 @@
+# Negative variant of nested-list-return: the float element returned from a
+# function is read at runtime from the caller, so an assertion on the wrong
+# value must FAIL (proves the read is genuine, not vacuous).
+
+
+def build_float():
+    return [[1.5]]
+
+
+Qf = build_float()
+assert Qf[0][0] == 2.5

--- a/regression/python/nested-list-return_fail/test.desc
+++ b/regression/python/nested-list-return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1979,14 +1979,41 @@ exprt python_list::handle_index_access(
 
           if (elem_type == converter_.get_type_handler().get_list_type())
           {
-            // Compile-time symbol resolution is only valid when the entry
-            // records a concrete inner-list symbol (literal case).  For
-            // parameter-annotation-only entries (elem_id is empty), fall
-            // through to the dynamic __ESBMC_list_at path below.
+            // Nested-list element.  The recorded elem_id names the inner-list
+            // symbol, but copy_type_info copies that id verbatim across a
+            // function-return boundary (Q = build()), where it is a *callee*
+            // frame local — returning build_symbol(elem_id) would reference a
+            // symbol that is never assigned in the caller's symex frame, so its
+            // value is nondet (float_buf OOB / wrong value, #5103/#5102).
+            //
+            // Instead, read the inner list pointer at runtime from `array`
+            // (valid in every scope: list_at returns the stored pointer, so
+            // aliasing/mutation semantics are preserved), bind it to a fresh
+            // caller-scope symbol, and copy the inner element-type map onto
+            // that symbol so deeper subscripts (Q[i][j]) still resolve
+            // int/float.  For parameter-annotation-only entries (elem_id
+            // empty) fall through to the dynamic __ESBMC_list_at path below.
             if (!elem_id.empty())
             {
-              if (symbolt *nested_list = converter_.find_symbol(elem_id))
-                return build_symbol(*nested_list);
+              const locationt loc =
+                converter_.get_location_from_decl(list_value_);
+
+              exprt list_at_call =
+                build_list_at_call(array, pos_expr, list_value_);
+              exprt inner_ptr = extract_pyobject_value(list_at_call, elem_type);
+
+              symbolt &inner_sym = converter_.create_tmp_symbol(
+                list_value_, "$nested_list$", elem_type, exprt());
+              code_declt inner_decl(build_symbol(inner_sym));
+              inner_decl.location() = loc;
+              converter_.add_instruction(inner_decl);
+
+              code_assignt inner_assign(build_symbol(inner_sym), inner_ptr);
+              inner_assign.location() = loc;
+              converter_.add_instruction(inner_assign);
+
+              copy_type_info(elem_id, inner_sym.id.as_string());
+              return build_symbol(inner_sym);
             }
           }
         }


### PR DESCRIPTION
## Problem

A nested list returned from a function and then subscripted in the caller crashed or read wrong values:

```python
def build():
    return [[1.5]]
Q = build()
assert Q[0][0] == 1.5   # __ESBMC_float_buf OOB crash (#5103) / wrong value (#5102)
```

- **#5103**: float matmul over nested lists aborted the SMT backend in `mk_smt_fpbv_add` (a list pointer reached the FP encoder).
- **#5102**: int/float nested-list reads returned the wrong value.

## Root cause

The Python frontend records nested-list structure in `list_type_map` by chaining inner-list **symbol ids**. On a list-returning call (`Q = build()`), `copy_type_info` copies the callee's return type-map verbatim into the caller — including inner-list symbol ids that are **local to the callee's frame** (e.g. `py_list$130`). The nested-access early-return in `handle_index_access` then lowered `Q[0]` to `build_symbol(py_list$130)` directly, so `Q[0][0]` became `list_at(py_list$130, 0)`. In the caller's symex frame that symbol is **never assigned → nondet pointer**, so `->float_idx` is havoc (float_buf OOB for floats; wrong value for ints). The inner heap object survives the return; only the *pointer variable* referencing it is out of scope.

## Fix

Frontend-only (`src/python-frontend/python_list.cpp`, `handle_index_access`). For a nested-list element with a recorded inner symbol id, instead of referencing the foreign callee-frame symbol:

1. Read the inner list pointer **at runtime** from the outer list (`build_list_at_call` + `extract_pyobject_value`), which recovers the *stored* `PyListObject*` — so aliasing/mutation semantics are preserved.
2. Bind it to a **fresh caller-scope symbol** (emitted DECL + ASSIGN).
3. `copy_type_info(elem_id → inner_sym)` so deeper subscripts (`Q[i][j]`) still resolve int/float from the (globally valid) static type map.

Value and element type now share one caller-valid key. Parameter-annotation-only entries (empty elem id) are unchanged and still take the dynamic path. No operational-model change.

## Tests

- `regression/python/nested-list-return` — float, int, 3-level, multi-element, and variable-index nested returns → `VERIFICATION SUCCESSFUL`
- `regression/python/nested-list-return_fail` — wrong-value assertion on a returned nested float → `VERIFICATION FAILED` (proves the read is genuine, not vacuous)

The original float matmul reproducer now verifies with the correct result (`C[0][0] == 19.0`), no SMT-backend crash.

Fixes #5103
Fixes #5102
