### PR TITLE
[python] Fix nested-list element corruption on list copy (#5102)

### DIFF
--- a/regression/python/github_5102_nested_list_copy/main.py
+++ b/regression/python/github_5102_nested_list_copy/main.py
@@ -1,0 +1,28 @@
+# Regression for esbmc/esbmc#5102: copying a list must preserve the values of
+# nested-list elements. The per-element copy used to byte-copy the inner list
+# pointer's pointee, corrupting nested elements on concat / copy() / list() /
+# repeat / variable assignment.
+a = nondet_int()
+__ESBMC_assume(a >= 0)
+__ESBMC_assume(a <= 9)
+
+src = [[a], [7]]
+
+# concatenation
+cat = [[a]] + [[7]]
+assert cat[0][0] == a
+assert cat[1][0] == 7
+
+# list.copy() and list()
+c1 = src.copy()
+c2 = list(src)
+assert c1[0][0] == a
+assert c2[1][0] == 7
+
+# repeat-then-concat
+rep = [[1], [2]] + [[a]]
+assert rep[2][0] == a
+
+# variable assignment aliases the same nested elements
+alias = src
+assert alias[0][0] == a

--- a/regression/python/github_5102_nested_list_copy/main.py
+++ b/regression/python/github_5102_nested_list_copy/main.py
@@ -1,7 +1,8 @@
-# Regression for esbmc/esbmc#5102: copying a list must preserve the values of
-# nested-list elements. The per-element copy used to byte-copy the inner list
-# pointer's pointee, corrupting nested elements on concat / copy() / list() /
-# repeat / variable assignment.
+# Regression for esbmc/esbmc#5102: every list-copy-like operation must preserve
+# the values of nested-list elements. The per-element copy used to byte-copy the
+# inner list pointer's pointee, corrupting nested elements. This exercises each
+# path the fix touches: concatenation, copy()/list(), slicing, repetition, and
+# starred-unpacking assignment.
 a = nondet_int()
 __ESBMC_assume(a >= 0)
 __ESBMC_assume(a <= 9)
@@ -19,9 +20,20 @@ c2 = list(src)
 assert c1[0][0] == a
 assert c2[1][0] == 7
 
-# repeat-then-concat
-rep = [[1], [2]] + [[a]]
+# slicing
+sl = src[:]
+assert sl[0][0] == a
+assert sl[1][0] == 7
+
+# repetition: the three elements share the same inner list object
+rep = [[a]] * 3
+assert rep[0][0] == a
 assert rep[2][0] == a
+
+# starred-unpacking assignment: rest is a fresh list of the trailing elements
+first, *rest = src
+assert first[0] == a
+assert rest[0][0] == 7
 
 # variable assignment aliases the same nested elements
 alias = src

--- a/regression/python/github_5102_nested_list_copy/test.desc
+++ b/regression/python/github_5102_nested_list_copy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -88,6 +88,7 @@ ignored_dirs=(
   "github_4668"
   "github_4666_2d"
   "github_4666_shape"
+  "github_5102_nested_list_copy"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -171,19 +171,25 @@ bool __ESBMC_list_push_object(
 }
 
 // Per-element append for list copy / assignment / slice / concat that handles
-// nested lists correctly (esbmc/esbmc#5102).
+// elements stored by reference correctly (esbmc/esbmc#5102).
 //
-// A nested-list element stores the inner PyListObject* directly in `value`, so
-// the generic byte-copy (__ESBMC_copy_value copies `size` bytes of `*value`)
-// yields a bogus pointer and the copied list reads garbage. For such elements
-// — identified by o->type_id == list_type_id — we copy the PyObject record
-// verbatim, preserving the inner pointer. This matches Python's shallow-copy
-// semantics: nested lists are shared by reference.
+// An element whose payload is a pointer to a shared object must keep that
+// pointer, not have its pointee byte-copied. Two such elements exist:
+//   * nested lists — the inner PyListObject* is stored in `value`
+//     (type_id == list_type_id);
+//   * pointer-only payloads stored with size == 0 — e.g. nested dicts inserted
+//     via __ESBMC_list_push_dict_ptr (value holds the dict*), and None
+//     (value == NULL).
+// For these we copy the PyObject record verbatim, preserving the pointer. The
+// generic byte-copy would run __ESBMC_copy_value with size == 0 (alloca(0) +
+// memcpy of 0 bytes) and drop the stored pointer, so the copied list would read
+// garbage. Sharing the reference also matches Python's shallow-copy semantics:
+// nested containers are shared, not deep-copied.
 //
-// Scalar elements must NOT share their buffer: Python subscript assignment
-// (l[i] = x) writes through the element's value pointer in place, so two lists
-// sharing a scalar buffer would alias. Scalars therefore keep the independent
-// byte-copy via __ESBMC_list_push_object (pass list_type_id=0 to force it).
+// Scalar elements (size > 0) must NOT share their buffer: Python subscript
+// assignment (l[i] = x) writes through the element's value pointer in place, so
+// two lists sharing a scalar buffer would alias. Scalars therefore keep the
+// independent byte-copy via __ESBMC_list_push_object.
 bool __ESBMC_list_push_shallow(
   PyListObject *l,
   PyObject *o,
@@ -191,7 +197,7 @@ bool __ESBMC_list_push_shallow(
 {
   assert(l != NULL);
   assert(o != NULL);
-  if (list_type_id != 0 && o->type_id == list_type_id)
+  if (o->size == 0 || (list_type_id != 0 && o->type_id == list_type_id))
   {
     l->items[l->size] = *o;
     l->size++;

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -170,6 +170,36 @@ bool __ESBMC_list_push_object(
     l, o->value, o->type_id, o->size, float_type_id, ptr_free);
 }
 
+// Per-element append for list copy / assignment / slice / concat that handles
+// nested lists correctly (esbmc/esbmc#5102).
+//
+// A nested-list element stores the inner PyListObject* directly in `value`, so
+// the generic byte-copy (__ESBMC_copy_value copies `size` bytes of `*value`)
+// yields a bogus pointer and the copied list reads garbage. For such elements
+// — identified by o->type_id == list_type_id — we copy the PyObject record
+// verbatim, preserving the inner pointer. This matches Python's shallow-copy
+// semantics: nested lists are shared by reference.
+//
+// Scalar elements must NOT share their buffer: Python subscript assignment
+// (l[i] = x) writes through the element's value pointer in place, so two lists
+// sharing a scalar buffer would alias. Scalars therefore keep the independent
+// byte-copy via __ESBMC_list_push_object (pass list_type_id=0 to force it).
+bool __ESBMC_list_push_shallow(
+  PyListObject *l,
+  PyObject *o,
+  size_t list_type_id)
+{
+  assert(l != NULL);
+  assert(o != NULL);
+  if (list_type_id != 0 && o->type_id == list_type_id)
+  {
+    l->items[l->size] = *o;
+    l->size++;
+    return true;
+  }
+  return __ESBMC_list_push_object(l, o, 0, 0);
+}
+
 // Store a dict pointer directly in the list without byte-copying.
 // Used for nested dicts so that pointer identity is preserved in the SMT model.
 bool __ESBMC_list_push_dict_ptr(PyListObject *l, void *dict_ptr, size_t type_id)

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -725,8 +725,11 @@ void python_list::emit_list_copy(
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
   const symbolt *at_sym =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_at");
+  // Shallow per-element append: preserves element value pointers so nested
+  // lists are shared (Python shallow-copy semantics) rather than corrupted by
+  // a pointee byte-copy (esbmc/esbmc#5102).
   const symbolt *push_obj_sym =
-    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
+    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_shallow");
   assert(size_sym && at_sym && push_obj_sym);
 
   // list_size / list_at take `const List*`
@@ -780,14 +783,18 @@ void python_list::emit_list_copy(
   tmp_obj_decl.copy_to_operands(at_call);
   body.copy_to_operands(tmp_obj_decl);
 
-  // list_push_object(dst_list, tmp_obj). ptr_free=0 (generic source).
+  // list_push_shallow(dst_list, tmp_obj, list_type_id): nested-list elements
+  // (type_id == list_type_id) keep their inner pointer; scalars are byte-copied
+  // independently, so they are not corrupted by a pointee byte-copy (#5102).
+  constant_exprt list_type_id_arg(size_type());
+  list_type_id_arg.set_value(integer2binary(
+    std::hash<std::string>{}(converter_.get_type_handler().type_to_string(
+      converter_.get_type_handler().get_list_type())),
+    config.ansi_c.address_width));
   exprt push_call = build_call_expr(
     *push_obj_sym,
     bool_type(),
-    {build_symbol(dst),
-     build_symbol(tmp_obj),
-     from_integer(BigInt(0), size_type()),
-     from_integer(BigInt(0), int_type())});
+    {build_symbol(dst), build_symbol(tmp_obj), list_type_id_arg});
   push_call.location() = loc;
   body.copy_to_operands(converter_.convert_expression_to_code(push_call));
 
@@ -1765,18 +1772,24 @@ exprt python_list::handle_range_slice(
   at_decl.copy_to_operands(list_at_call);
   loop_body.copy_to_operands(at_decl);
 
+  // Shallow append: preserve element value pointers so nested lists survive the
+  // slice copy uncorrupted (esbmc/esbmc#5102).
   const symbolt *push_func =
-    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
+    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_shallow");
   if (!push_func)
     throw std::runtime_error("Push function symbol not found");
 
+  // Nested-list elements keep their inner pointer; scalars are byte-copied, so
+  // the slice copy does not corrupt nested lists (#5102).
+  constant_exprt slice_list_type_id(size_type());
+  slice_list_type_id.set_value(integer2binary(
+    std::hash<std::string>{}(converter_.get_type_handler().type_to_string(
+      converter_.get_type_handler().get_list_type())),
+    config.ansi_c.address_width));
   exprt push_call = build_call_expr(
     *push_func,
     bool_type(),
-    {build_symbol(sliced_list),
-     build_symbol(at_result),
-     from_integer(BigInt(0), size_type()),
-     from_integer(BigInt(0), int_type())});
+    {build_symbol(sliced_list), build_symbol(at_result), slice_list_type_id});
   push_call.location() = location;
   loop_body.copy_to_operands(converter_.convert_expression_to_code(push_call));
 
@@ -5029,18 +5042,23 @@ void python_list::handle_list_var_unpacking(
     tmp_at_decl.copy_to_operands(at_call);
     loop_body.copy_to_operands(tmp_at_decl);
 
-    // __ESBMC_list_push_object(star_list, tmp_at)
+    // __ESBMC_list_push_shallow(star_list, tmp_at): preserve element value
+    // pointers so nested lists survive the unpack copy uncorrupted (#5102).
     const symbolt *push_obj_func =
-      converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
+      converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_shallow");
     assert(push_obj_func);
 
+    // Nested-list elements keep their inner pointer; scalars are byte-copied,
+    // so the unpack copy does not corrupt nested lists (#5102).
+    constant_exprt star_list_type_id(size_type());
+    star_list_type_id.set_value(integer2binary(
+      std::hash<std::string>{}(converter_.get_type_handler().type_to_string(
+        converter_.get_type_handler().get_list_type())),
+      config.ansi_c.address_width));
     exprt push_call = build_call_expr(
       *push_obj_func,
       bool_type(),
-      {build_symbol(star_list),
-       build_symbol(tmp_at),
-       from_integer(BigInt(0), size_type()),
-       from_integer(BigInt(0), int_type())});
+      {build_symbol(star_list), build_symbol(tmp_at), star_list_type_id});
     push_call.location() = loc;
     loop_body.copy_to_operands(
       converter_.convert_expression_to_code(push_call));

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1806,18 +1806,40 @@ exprt python_list::handle_range_slice(
   while_loop.copy_to_operands(loop_condition, loop_body);
   converter_.add_instruction(while_loop);
 
-  // Update type map for sliced elements (only if both bounds are constant
-  // literals AND step is the default 1 — for step != 1 the slice index
-  // mapping is no longer lower + i, so the per-index type map would be
-  // wrong; skip the refinement in that case).
-  if (
-    step_val == 1 && slice_node.contains("lower") &&
-    slice_node["lower"].is_object() && slice_node["lower"].contains("_type") &&
-    slice_node["lower"]["_type"] == "Constant" &&
-    slice_node["lower"].contains("value") && slice_node.contains("upper") &&
-    slice_node["upper"].is_object() && slice_node["upper"].contains("_type") &&
-    slice_node["upper"]["_type"] == "Constant" &&
-    slice_node["upper"].contains("value"))
+  // Update type map for sliced elements. Element types are taken positionally
+  // from the source list literal. This is valid when step == 1 and each bound
+  // is either absent (defaulting to the full range) or a non-negative constant
+  // literal. Absent bounds cover the idiomatic full copy src[:] and half-open
+  // slices like src[1:] / src[:2], whose nested-list element types would
+  // otherwise be lost — corrupting reads such as sl[0][0] (esbmc/esbmc#5102).
+  // For step != 1 the index mapping is no longer lower + i, and for negative or
+  // non-constant bounds the static range is unknown; both keep the generic
+  // fallback below.
+  bool bounds_usable = true;
+  bool has_lower = false;
+  bool has_upper = false;
+  size_t lower_bound = 0;
+  size_t upper_bound = 0;
+  for (int which = 0; which < 2; ++which)
+  {
+    const char *key = which == 0 ? "lower" : "upper";
+    bool &present = which == 0 ? has_lower : has_upper;
+    size_t &out = which == 0 ? lower_bound : upper_bound;
+
+    present = slice_node.contains(key) && !slice_node[key].is_null();
+    if (!present)
+      continue; // absent / None: defaults to the list bound below
+    const nlohmann::json &b = slice_node[key];
+    if (
+      b.is_object() && b.contains("_type") && b["_type"] == "Constant" &&
+      b.contains("value") && b["value"].is_number_integer() &&
+      b["value"].get<long long>() >= 0)
+      out = b["value"].get<size_t>();
+    else
+      bounds_usable = false; // negative or non-constant: not known statically
+  }
+
+  if (step_val == 1 && bounds_usable)
   {
     nlohmann::json list_node;
     if (
@@ -1831,9 +1853,6 @@ exprt python_list::handle_range_slice(
         converter_.ast());
     }
 
-    const size_t lower_bound = slice_node["lower"]["value"].get<size_t>();
-    const size_t upper_bound = slice_node["upper"]["value"].get<size_t>();
-
     // Only update type map for actual lists (not strings or other types)
     if (
       !list_node.is_null() && list_node.contains("value") &&
@@ -1841,8 +1860,8 @@ exprt python_list::handle_range_slice(
       list_node["value"]["elts"].is_array())
     {
       const size_t elts_size = list_node["value"]["elts"].size();
-      const size_t begin = std::min(lower_bound, elts_size);
-      const size_t end = std::min(upper_bound, elts_size);
+      const size_t begin = has_lower ? std::min(lower_bound, elts_size) : 0;
+      const size_t end = has_upper ? std::min(upper_bound, elts_size) : elts_size;
 
       for (size_t i = begin; i < end; ++i)
       {

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1861,7 +1861,8 @@ exprt python_list::handle_range_slice(
     {
       const size_t elts_size = list_node["value"]["elts"].size();
       const size_t begin = has_lower ? std::min(lower_bound, elts_size) : 0;
-      const size_t end = has_upper ? std::min(upper_bound, elts_size) : elts_size;
+      const size_t end =
+        has_upper ? std::min(upper_bound, elts_size) : elts_size;
 
       for (size_t i = begin; i < end; ++i)
       {


### PR DESCRIPTION
## What

Fixes the **list-copy** half of #5102: copying a Python list corrupted the
values of nested-list elements.

## Root cause

The per-element list copy byte-copies each element's pointee
(`__ESBMC_copy_value(elem->value, elem->size, …)`). That is correct for inline
scalars, but a **nested list stores the inner `PyListObject*` directly in the
element's `value`**, so copying `size` bytes of `*value` produces a bogus
pointer and the copied list reads garbage — e.g. `([[x]] + [[y]])[0][0] != x`.

This affected concat (`+`), repeat (`*`), slicing and star-unpack of nested
lists. (The complementary cross-function-return case was fixed in #5111.)

## Fix

`__ESBMC_list_push_shallow(l, o, list_type_id)` (in
`src/c2goto/library/python/list.c`) dispatches per element:

- **Nested-list elements** (`o->type_id == list_type_id`) copy the `PyObject`
  record verbatim, preserving the inner pointer — Python's shallow-copy
  semantics, where nested lists are shared by reference.
- **Scalar elements** keep the independent byte-copy via
  `__ESBMC_list_push_object`. They must *not* share a buffer, because Python
  subscript assignment (`l[i] = x`) writes through the element's value pointer
  in place — two lists sharing a scalar buffer would alias.

The list-copy sites in `python_list.cpp` (`emit_list_copy`, slice, star-unpack)
pass the list type hash so the C model can distinguish nested lists from
scalars. `__ESBMC_list_copy` is unchanged.

## Tests

`regression/python/github_5102_nested_list_copy/` checks that nested-list
elements survive concat, `copy()`, `list()`, repeat and assignment.

Validated locally: the new test passes; the existing `list_copy_7`
(scalar-`.copy()` independence) still passes; the #5111 `nested-list-return`
tests still pass; no regressions across the list/dict/set regression subset.

Refs #5102.
