### PR TITLE
[python] V.3: migrate converter_dunder dispatch calls to IREP2

### DIFF
--- a/src/python-frontend/converter/converter_dunder.cpp
+++ b/src/python-frontend/converter/converter_dunder.cpp
@@ -1,10 +1,62 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/symbol_id.h>
 #include <python-frontend/type_handler.h>
+#include <irep2/irep2_utils.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
+#include <util/migrate.h>
 
 #include <map>
+
+namespace
+{
+// V.3: IREP2 expression-context call `fn(args...)` returning return_type
+// (side_effect_function_call2tc + symbol_expr2tc), back-migrated for the legacy
+// adjust/goto-convert seam; behaviour-preserving. Caller sets .location().
+// Falls back to the legacy node for a dyn-sized-array return/argument type.
+bool contains_dyn_array(const typet &t)
+{
+  if (t.is_array())
+  {
+    const array_typet &at = to_array_type(t);
+    if (at.size().is_nil() || !at.size().is_constant())
+      return true;
+    return contains_dyn_array(at.subtype());
+  }
+  if (t.is_pointer())
+    return contains_dyn_array(t.subtype());
+  return false;
+}
+
+exprt build_call_expr(
+  const symbolt &fn,
+  const typet &return_type,
+  const std::vector<exprt> &args)
+{
+  bool dyn = contains_dyn_array(return_type);
+  for (const exprt &a : args)
+    dyn = dyn || contains_dyn_array(a.type());
+  if (dyn)
+  {
+    side_effect_expr_function_callt call;
+    call.function() = symbol_expr(fn);
+    for (const exprt &a : args)
+      call.arguments().push_back(a);
+    call.type() = return_type;
+    return call;
+  }
+  std::vector<expr2tc> args2;
+  args2.reserve(args.size());
+  for (const exprt &a : args)
+  {
+    expr2tc a2;
+    migrate_expr(a, a2);
+    args2.push_back(std::move(a2));
+  }
+  return migrate_expr_back(side_effect_function_call2tc(
+    migrate_type(return_type), symbol_expr2tc(fn), args2));
+}
+} // namespace
 
 std::string python_converter::op_to_dunder(const std::string &op)
 {
@@ -171,12 +223,11 @@ exprt python_converter::dispatch_dunder_operator(
           const code_typet &method_type = to_code_type(method->get_type());
           if (is_other_param_compatible(method_type, rhs_type, ns))
           {
-            side_effect_expr_function_callt call;
-            call.function() = symbol_expr(*method);
-            call.type() = method_type.return_type();
+            exprt call = build_call_expr(
+              *method,
+              method_type.return_type(),
+              {gen_address_of(lhs), gen_address_of(rhs)});
             call.location() = loc;
-            call.arguments().push_back(gen_address_of(lhs));
-            call.arguments().push_back(gen_address_of(rhs));
             return call;
           }
         }
@@ -202,12 +253,11 @@ exprt python_converter::dispatch_dunder_operator(
           const code_typet &method_type = to_code_type(method->get_type());
           if (is_other_param_compatible(method_type, lhs_type, ns))
           {
-            side_effect_expr_function_callt call;
-            call.function() = symbol_expr(*method);
-            call.type() = method_type.return_type();
+            exprt call = build_call_expr(
+              *method,
+              method_type.return_type(),
+              {gen_address_of(rhs), gen_address_of(lhs)});
             call.location() = loc;
-            call.arguments().push_back(gen_address_of(rhs));
-            call.arguments().push_back(gen_address_of(lhs));
             return call;
           }
         }
@@ -264,10 +314,8 @@ exprt python_converter::dispatch_unary_dunder_operator(
     return nil_exprt();
 
   const code_typet &method_type = to_code_type(method->get_type());
-  side_effect_expr_function_callt call;
-  call.function() = symbol_expr(*method);
-  call.type() = method_type.return_type();
+  exprt call = build_call_expr(
+    *method, method_type.return_type(), {gen_address_of(operand)});
   call.location() = loc;
-  call.arguments().push_back(gen_address_of(operand));
   return call;
 }


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction, #5055) with converter_dunder.cpp (operator-overloading dispatch), 273 LOC.

Migrates the 3 side_effect_expr_function_callt dunder/rdunder/unary-dunder method calls (a.__add__(b), b.__radd__(a), op.__neg__() ...) -> a file-local guarded build_call_expr (side_effect_function_call2tc + symbol_expr2tc), absorbing the 3 symbol_expr callees. Callers set .location(); dyn-array return/arg fallback to legacy.

No typecast here (args are gen_address_of value pointers, not boolean conditions), so no condition-migration hazard. Helper is the proven #5106/#5112 pattern.

## Verification
- Build green (asserts); 217/217 operator/class tests + full python suite 3622/3628.
- The 6 failures are all pre-existing/env, confirmed failing on master: flask github_4149/_fail, boolector list_pop11_nondet, stray Testing dir, a nondet test, and list_copy_7 (the nested-list-copy bug tracked separately in a WIP branch).
- clang-format clean (Clang 11.0.0).