### PR TITLE
[python] fix return-type inference scope for functions returning a local

### DIFF
--- a/regression/python/github_5104/main.py
+++ b/regression/python/github_5104/main.py
@@ -1,0 +1,18 @@
+# GitHub #5104: a user function returning a float (via a ternary) whose
+# argument is itself another user function's return value crashed the SMT
+# backend in an FP comparison. The crash came from the parameter and return
+# being typed as a pointer because b()'s return type could not be inferred:
+# its `return v` local was resolved in the wrong scope.
+def myabs(x):
+    return x if x >= 0.0 else -x
+
+
+def b():
+    v = nondet_float()
+    __ESBMC_assume(v >= -10.0)
+    __ESBMC_assume(v <= 10.0)
+    return v
+
+
+a = b()
+assert myabs(a) <= 100.0

--- a/regression/python/github_5104/test.desc
+++ b/regression/python/github_5104/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5104_fail/main.py
+++ b/regression/python/github_5104_fail/main.py
@@ -1,0 +1,16 @@
+# GitHub #5104 (negative): with the parameter/return now correctly typed as
+# float, a genuinely violated FP bound must still be reported FAILED — the fix
+# must not mask real violations. |a| can reach 10.0, which exceeds 5.0.
+def myabs(x):
+    return x if x >= 0.0 else -x
+
+
+def b():
+    v = nondet_float()
+    __ESBMC_assume(v >= -10.0)
+    __ESBMC_assume(v <= 10.0)
+    return v
+
+
+a = b()
+assert myabs(a) <= 5.0

--- a/regression/python/github_5104_fail/test.desc
+++ b/regression/python/github_5104_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_5105/main.py
+++ b/regression/python/github_5105/main.py
@@ -1,0 +1,24 @@
+# GitHub #5105: a user function returning a float comparison (a bool) yielded a
+# wrong verdict (FAILED) instead of SUCCESSFUL. Same root cause as #5104 — the
+# helper's parameters defaulted to a pointer type because b()'s return type
+# could not be inferred from its local `return v`. Since a and c are the same
+# expression, math.fabs(a - c) == 0.0 <= 1e-08 + 1e-05 * math.fabs(c).
+import math
+
+
+def allclose1(a, c):
+    return math.fabs(a - c) <= 1e-08 + 1e-05 * math.fabs(c)
+
+
+def b():
+    v = nondet_float()
+    __ESBMC_assume(v >= -10.0)
+    __ESBMC_assume(v <= 10.0)
+    return v
+
+
+p = b()
+q = b()
+a = p * q
+c = p * q
+assert allclose1(a, c)

--- a/regression/python/github_5105/test.desc
+++ b/regression/python/github_5105/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -181,6 +181,16 @@ for dir in */; do
     matched_tests=$((matched_tests + 1))
   fi
 
+  # Skip tests that use ESBMC verification intrinsics. Names like __ESBMC_*,
+  # __VERIFIER_* and nondet_* are not defined in CPython, so the test raises
+  # NameError under direct execution and can only be validated via ESBMC.
+  # Detecting them by content means an intrinsic-using test no longer needs a
+  # manual ignore-list entry (e.g. github_5104, github_5105).
+  if grep -qE '__ESBMC|__VERIFIER_|nondet_' "$dir/main.py"; then
+    echo "🚫 IGNORED: $dir (uses ESBMC intrinsics, not runnable under CPython)"
+    continue
+  fi
+
   # Always keep legacy ignore behavior, with or without query mode.
   if echo "$dir" | grep -iq 'nondet'; then
     echo "🚫 IGNORED: $dir (contains 'nondet')"

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -1114,9 +1114,14 @@ std::string python_annotation<Json>::get_function_return_type(
           return elem["returns"]["id"];
         }
 
-        // Try to infer from return statements (excluding recursive calls)
+        // Try to infer from return statements (excluding recursive calls).
+        // Resolve names in func_name's own scope (see the non-recursive path
+        // below; GitHub #5104, #5105).
+        std::string saved_rec_ctx = current_func_name_context_;
+        current_func_name_context_ = func_name;
         std::string inferred =
           infer_from_return_statements(elem["body"], func_name);
+        current_func_name_context_ = saved_rec_ctx;
         if (!inferred.empty())
         {
           functions_in_analysis_.erase(func_name);
@@ -1245,9 +1250,18 @@ std::string python_annotation<Json>::get_function_return_type(
     }
 
     // Try to infer return type from actual return statements
-    // Use recursive inference to find return types in all blocks
+    // Use recursive inference to find return types in all blocks.
+    // Names in a return expression resolve in THIS function's scope, not the
+    // caller's. Switch the inference context to func_name so a local variable
+    // referenced by a return statement (e.g. `return v` where
+    // `v = nondet_float()`) is found; otherwise the type cannot be inferred
+    // and the parameter/return default to a pointer, crashing the FP backend
+    // (GitHub #5104, #5105).
+    std::string saved_return_ctx = current_func_name_context_;
+    current_func_name_context_ = func_name;
     std::string inferred_type =
       infer_from_return_statements(func_elem["body"], func_name);
+    current_func_name_context_ = saved_return_ctx;
 
     if (!inferred_type.empty() && inferred_type != "NoneType")
     {
@@ -1267,6 +1281,8 @@ std::string python_annotation<Json>::get_function_return_type(
     if (!return_node.empty())
     {
       std::string fallback_type;
+      std::string saved_fallback_ctx = current_func_name_context_;
+      current_func_name_context_ = func_name;
       try
       {
         infer_type(return_node, func_elem, fallback_type);
@@ -1276,6 +1292,7 @@ std::string python_annotation<Json>::get_function_return_type(
         // Return value type could not be inferred (e.g. call through a
         // function-pointer parameter); leave fallback_type empty.
       }
+      current_func_name_context_ = saved_fallback_ctx;
       functions_in_analysis_.erase(func_name);
       return fallback_type;
     }


### PR DESCRIPTION
## Problem

A user-defined function that returns a `float` whose argument is itself another user function's return value crashed the SMT backend in a floating-point comparison (#5104), and the `bool`-returning variant produced a wrong verdict (#5105):

```python
def myabs(x):
    return x if x >= 0.0 else -x

def b():
    v = nondet_float()
    __ESBMC_assume(v >= -10.0)
    __ESBMC_assume(v <= 10.0)
    return v

a = b()
assert myabs(a) <= 100.0   # crashed: smt_ast.h:111 / z3++.h:1855
```

## Root cause

`get_function_return_type` infers an un-annotated function's return type by walking its body, but it did **not** switch the name-resolution scope (`current_func_name_context_`) to the function being analysed. So when `b`'s `return v` was inspected, the local `v` (`= nondet_float()`) was resolved in the **caller's** scope, was not found, and `b`'s return type came back empty.

The empty return type cascaded: `a = b()` lost its type, and the parameter `x` of `myabs(a)` — inferred from that call site — defaulted to a **pointer** (`void *`). The float comparison then lowered to a pointer comparison:

```
ASSERT SAME-OBJECT(x, (void *)((unsigned long int)0.000000))
RETURN: x >= (void *)((unsigned long int)0.000000) ? x : -x
```

Feeding a pointer-typed operand to the FP encoder trips the `dynamic_cast` assertion at `smt_ast.h:111` (Bitwuzla) / `z3++.h:1855` (Z3). When the helper returned a `bool` instead (#5105), the same mistyping silently flipped the verdict.

This matches every workaround noted in the issues: `return nondet_float()` directly, inlining the helper, or using `math.fabs` all sidestep the broken local-name resolution.

## Fix

Resolve names in the analysed function's own scope by setting `current_func_name_context_ = func_name` around the three return-statement inference call sites in `get_function_return_type` (recursion-guard `infer_from_return_statements`, main `infer_from_return_statements`, and the fallback `infer_type`), restoring the previous value afterward. This is semantically correct — a name in a function's return expression resolves in that function's scope — and only improves cases that previously failed to resolve.

## Tests

- `regression/python/github_5104/` — reproducer → `VERIFICATION SUCCESSFUL`
- `regression/python/github_5104_fail/` — tightened bound → `VERIFICATION FAILED` (proves the fix does not mask real violations)
- `regression/python/github_5105/` — `allclose`-style reproducer → `VERIFICATION SUCCESSFUL`

All three pass; a curated subset of return-type / parameter-inference / nested-function / optional / lambda regression tests passes with no regressions.

## Known limitation (follow-up)

A *nested* helper that returns one of its own locals is still not resolved (the fix uses the bare `func_name` as the scope, which `find_var_decl` matches only against top-level functions). This is the same crash class, much rarer, and pre-existing; worth a separate follow-up that threads the qualified `outer@F@inner` path into the context.

Fixes #5104
Fixes #5105
