### PR TITLE
[python] V.3: migrate python_typechecking construction to IREP2

### DIFF
--- a/src/python-frontend/python_typechecking.cpp
+++ b/src/python-frontend/python_typechecking.cpp
@@ -6,8 +6,68 @@
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
 #include <unordered_set>
+#include <irep2/irep2_utils.h>
+#include <util/migrate.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
+
+namespace
+{
+// V.3: IREP2 expression-construction helpers (exact round-trip; behaviour-
+// preserving). Back-migrated for the legacy adjust/goto-convert seam. The
+// member/dereference variants guard the dyn-sized-array round-trip hazard and
+// restore the exact result type (#cpp_type that migrate_type drops).
+bool contains_dyn_array(const typet &t)
+{
+  if (t.is_array())
+  {
+    const array_typet &at = to_array_type(t);
+    if (at.size().is_nil() || !at.size().is_constant())
+      return true;
+    return contains_dyn_array(at.subtype());
+  }
+  if (t.is_pointer())
+    return contains_dyn_array(t.subtype());
+  return false;
+}
+
+exprt build_symbol(const symbolt &sym)
+{
+  if (contains_dyn_array(sym.get_type()))
+    return symbol_expr(sym);
+  return migrate_expr_back(symbol_expr2tc(sym));
+}
+
+exprt build_dereference(const exprt &ptr, const typet &t)
+{
+  if (contains_dyn_array(t))
+    return dereference_exprt(ptr, t);
+  expr2tc ptr2;
+  migrate_expr(ptr, ptr2);
+  exprt result = migrate_expr_back(dereference2tc(migrate_type(t), ptr2));
+  result.type() = t;
+  return result;
+}
+
+// member2t needs a struct/union/symbol source (the is_none access here is over
+// an Optional struct or a dereference of one). Falls back to legacy otherwise.
+exprt build_member(const exprt &base, const irep_idt &name, const typet &t)
+{
+  if (contains_dyn_array(t))
+    return member_exprt(base, name, t);
+  expr2tc base2;
+  migrate_expr(base, base2);
+  if (
+    is_struct_type(base2->type) || is_union_type(base2->type) ||
+    is_symbol_type(base2->type))
+  {
+    exprt result = migrate_expr_back(member2tc(migrate_type(t), base2, name));
+    result.type() = t;
+    return result;
+  }
+  return member_exprt(base, name, t);
+}
+} // namespace
 
 python_typechecking::python_typechecking(python_converter &converter)
   : converter_(converter)
@@ -192,7 +252,7 @@ exprt python_typechecking::build_isinstance_check(
     const symbolt *symbol = ns.lookup(effective_type);
     if (symbol == nullptr)
       return nil_exprt();
-    type_operand = symbol_expr(*symbol);
+    type_operand = build_symbol(*symbol);
   }
   else
     type_operand = gen_zero(effective_type);
@@ -219,15 +279,15 @@ exprt python_typechecking::build_none_check(const exprt &value_expr) const
   };
 
   if (is_optional_struct(resolved_type))
-    return member_exprt(value_expr, "is_none", bool_type());
+    return build_member(value_expr, "is_none", bool_type());
 
   if (resolved_type.is_pointer())
   {
     typet subtype = ns.follow(resolved_type.subtype());
     if (is_optional_struct(subtype))
     {
-      dereference_exprt deref(value_expr, subtype);
-      return member_exprt(deref, "is_none", bool_type());
+      exprt deref = build_dereference(value_expr, subtype);
+      return build_member(deref, "is_none", bool_type());
     }
 
     exprt null_expr = gen_zero(original_type);


### PR DESCRIPTION
Continues V.3 (IREP2 expression construction, #5055) with python_typechecking.cpp (is None / Optional / isinstance checks), 4 sites.

- build_member() (2) the is_none accesses over an Optional struct and a dereference of one -> member2tc (struct/union/symbol source guard + result.type()=t)
- build_dereference() (1) the Optional-pointer deref -> dereference2tc
- build_symbol() (1) -> symbol_expr2tc
All with dyn-array fallback. No typecast (no condition-migration hazard).

## Verification
- Build green (asserts); 158/158 isinstance/optional/none/type tests + full python suite 3622/3628.
- The 6 failures are all pre-existing/env, confirmed on master: flask github_4149/_fail, boolector list_pop11_nondet, stray Testing dir, a nondet test, and list_copy_7 (the nested-list-copy bug tracked in a WIP branch).
- clang-format clean (Clang 11.0.0).