### PR TITLE
[python] Add torch operational model (mm/matmul/cat/split/allclose)

### DIFF
--- a/regression/python/torch_mm_allclose/main.py
+++ b/regression/python/torch_mm_allclose/main.py
@@ -1,0 +1,9 @@
+# Exercises the torch operational model: torch.mm computes the matrix product
+# and torch.allclose confirms it equals the expected result.
+import torch
+
+X = [[1.0, 2.0], [3.0, 4.0]]
+W = [[5.0, 6.0], [7.0, 8.0]]
+P = torch.mm(X, W)
+expected = [[19.0, 22.0], [43.0, 50.0]]
+assert torch.allclose(P, expected)

--- a/regression/python/torch_mm_allclose/test.desc
+++ b/regression/python/torch_mm_allclose/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -89,6 +89,7 @@ ignored_dirs=(
   "github_4666_2d"
   "github_4666_shape"
   "github_5102_nested_list_copy"
+  "torch_mm_allclose"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/python-frontend/models/torch.py
+++ b/src/python-frontend/models/torch.py
@@ -74,9 +74,7 @@ def cat(tensors: list[list[list[float]]], dim: int) -> list[list[float]]:
     return out
 
 
-def split(
-    tensor: list[list[float]], sizes: list[int], dim: int
-) -> list[list[list[float]]]:
+def split(tensor: list[list[float]], sizes: list[int], dim: int) -> list[list[list[float]]]:
     # Split a 2-D tensor along columns (dim == 1) into chunks of the given widths.
     parts = []
     start = 0

--- a/src/python-frontend/models/torch.py
+++ b/src/python-frontend/models/torch.py
@@ -76,6 +76,11 @@ def cat(tensors: list[list[list[float]]], dim: int) -> list[list[float]]:
 
 def split(tensor: list[list[float]], sizes: list[int], dim: int) -> list[list[list[float]]]:
     # Split a 2-D tensor along columns (dim == 1) into chunks of the given widths.
+    # NOTE: torch.split now dispatches here (it is no longer shadowed by the
+    # builtin str.split handler), but the chunk width comes from a list element
+    # (sizes[si]) whose value is not a concrete loop bound, so the inner
+    # range(width) loop is unwinding-heavy. Prefer manual column indexing for
+    # now; a leaner encoding is tracked as follow-up work.
     parts = []
     start = 0
     si = 0

--- a/src/python-frontend/models/torch.py
+++ b/src/python-frontend/models/torch.py
@@ -1,0 +1,116 @@
+# pylint: disable=undefined-variable,unused-argument,redefined-builtin
+# Operational model for a subset of PyTorch (torch).
+#
+# These pure-Python reference implementations let ESBMC verify programs that use
+# the modelled torch operations. Tensors are modelled as nested Python lists of
+# floats (the default dtype of torch.randn and the common ML case). Element
+# types are annotated as float because the converter does not yet propagate a
+# caller's element type into a model function: without the annotation, indexed
+# tensor elements are `any`-typed and arithmetic over them is over-approximated
+# as nondet, which trips the type system. (Delegating to numpy.matmul does not
+# help — numpy's matmul lowering requires literal-shaped arguments at the call
+# site and so fails through any wrapper.) Argument names are part of the
+# contract matched by the converter.
+#
+# Modelled: mm, matmul, cat, split, allclose, tensor.
+import math
+
+
+def tensor(data: list[list[float]]) -> list[list[float]]:
+    # Tensors are modelled directly as nested Python lists; tensor() is identity.
+    return data
+
+
+def mm(A: list[list[float]], B: list[list[float]]) -> list[list[float]]:
+    # 2-D matrix multiply: A is (n x k), B is (k x m) -> (n x m).
+    n = len(A)
+    k = len(B)
+    m = len(B[0])
+    C = [[0.0 for _ in range(m)] for _ in range(n)]
+    i = 0
+    while i < n:
+        j = 0
+        while j < m:
+            s = 0.0
+            t = 0
+            while t < k:
+                s = s + A[i][t] * B[t][j]
+                t = t + 1
+            C[i][j] = s
+            j = j + 1
+        i = i + 1
+    return C
+
+
+def matmul(A: list[list[float]], B: list[list[float]]) -> list[list[float]]:
+    # 2-D alias of mm (the n-D broadcasting cases are not modelled yet).
+    return mm(A, B)
+
+
+def cat(tensors: list[list[list[float]]], dim: int) -> list[list[float]]:
+    # Concatenate a list of 2-D tensors along columns (dim == 1): the rows stay
+    # aligned and the columns of each tensor are appended. (dim == 0 row-stacking
+    # is not modelled here.) Uses pre-sized index assignment rather than repeated
+    # list concatenation, which would generate expensive per-element memcpy loops.
+    n = len(tensors[0])
+    total = 0
+    ti = 0
+    while ti < len(tensors):
+        total = total + len(tensors[ti][0])
+        ti = ti + 1
+    out = [[0.0 for _ in range(total)] for _ in range(n)]
+    r = 0
+    while r < n:
+        col = 0
+        ti = 0
+        while ti < len(tensors):
+            c = 0
+            while c < len(tensors[ti][r]):
+                out[r][col] = tensors[ti][r][c]
+                col = col + 1
+                c = c + 1
+            ti = ti + 1
+        r = r + 1
+    return out
+
+
+def split(
+    tensor: list[list[float]], sizes: list[int], dim: int
+) -> list[list[list[float]]]:
+    # Split a 2-D tensor along columns (dim == 1) into chunks of the given widths.
+    parts = []
+    start = 0
+    si = 0
+    while si < len(sizes):
+        width = sizes[si]
+        n = len(tensor)
+        chunk = [[0.0 for _ in range(width)] for _ in range(n)]
+        r = 0
+        while r < n:
+            c = 0
+            while c < width:
+                chunk[r][c] = tensor[r][start + c]
+                c = c + 1
+            r = r + 1
+        parts = parts + [chunk]
+        start = start + width
+        si = si + 1
+    return parts
+
+
+def allclose(
+    a: list[list[float]],
+    b: list[list[float]],
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+) -> bool:
+    # Element-wise |a - c| <= atol + rtol*|c| over two 2-D tensors of equal shape.
+    i = 0
+    while i < len(a):
+        j = 0
+        while j < len(a[i]):
+            if math.fabs(a[i][j] - b[i][j]) > atol + rtol * math.fabs(b[i][j]):
+                return False
+            j = j + 1
+        i = i + 1
+    return True

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -113,6 +113,7 @@ def _is_imported_model(module_name: str) -> bool:
         "time",
         "threading",
         "queue",
+        "torch",
     }
     return module_name in models
 

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2188,8 +2188,7 @@ exprt string_handler::handle_string_attribute_call(
   if (
     receiver_json.contains("_type") && receiver_json["_type"] == "Name" &&
     receiver_json.contains("id") && receiver_json["id"].is_string() &&
-    !converter_
-       .get_imported_module_path(receiver_json["id"].get<std::string>())
+    !converter_.get_imported_module_path(receiver_json["id"].get<std::string>())
        .empty())
     return nil_exprt();
 

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2176,6 +2176,15 @@ exprt string_handler::handle_string_attribute_call(
       ? call_json["keywords"]
       : empty_json_array;
 
+  // Calls on an imported module (e.g. torch.split, numpy.split) are not string
+  // methods even though the attribute name overlaps with one (split, count,
+  // ...). Defer to the regular dispatch so the module's operational model runs.
+  if (
+    receiver_json.contains("_type") && receiver_json["_type"] == "Name" &&
+    receiver_json.contains("id") && receiver_json["id"].is_string() &&
+    converter_.is_imported_module(receiver_json["id"].get<std::string>()))
+    return nil_exprt();
+
   std::optional<exprt> cached_receiver_expr;
   auto get_receiver_expr = [&]() -> exprt {
     if (!cached_receiver_expr.has_value())

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2179,10 +2179,18 @@ exprt string_handler::handle_string_attribute_call(
   // Calls on an imported module (e.g. torch.split, numpy.split) are not string
   // methods even though the attribute name overlaps with one (split, count,
   // ...). Defer to the regular dispatch so the module's operational model runs.
+  //
+  // Use get_imported_module_path() (non-empty only for a name actually present
+  // in imported_modules) rather than is_imported_module(), which also returns
+  // true when a model .py file merely exists. The latter would misfire for a
+  // local variable that shares a module's name (e.g. a parameter named
+  // `string`), wrongly diverting `string.lower()` away from the str handler.
   if (
     receiver_json.contains("_type") && receiver_json["_type"] == "Name" &&
     receiver_json.contains("id") && receiver_json["id"].is_string() &&
-    converter_.is_imported_module(receiver_json["id"].get<std::string>()))
+    !converter_
+       .get_imported_module_path(receiver_json["id"].get<std::string>())
+       .empty())
     return nil_exprt();
 
   std::optional<exprt> cached_receiver_expr;


### PR DESCRIPTION
## What

Adds a PyTorch operational model so ESBMC can verify programs that use a subset
of `torch`.

- `src/python-frontend/models/torch.py` — pure-Python reference implementations
  of `mm`, `matmul`, `cat`, `split` and `allclose` over float tensors (modelled
  as nested Python lists).
- `src/python-frontend/parser/import_resolver.py` — registers `torch` as an
  importable model, so `import torch` resolves and `torch.*` calls dispatch to
  the model.
- `regression/python/torch_mm_allclose/` — verifies `torch.mm` against a known
  matrix product via `torch.allclose`.

```python
import torch
X = [[1.0, 2.0], [3.0, 4.0]]
W = [[5.0, 6.0], [7.0, 8.0]]
P = torch.mm(X, W)
assert torch.allclose(P, [[19.0, 22.0], [43.0, 50.0]])   # VERIFICATION SUCCESSFUL
```

## Design notes

- **Float element annotations are required.** Tensor parameters are annotated
  `list[list[float]]`. The converter does not yet propagate a caller's element
  type into a model function, so without the annotation indexed tensor elements
  are `any`-typed and the arithmetic is over-approximated / rejected by the type
  system (`irep2_expr.cpp`). Annotating the element type fixes `torch.mm` type
  inference.
- **Delegating `mm` to `numpy.matmul` does not work**: numpy's matmul lowering
  requires literal-shaped arguments at the call site, so it fails through any
  wrapper function (`Unsupported Numpy call: matmul`). Hence the pure-Python
  implementation.

## Status / limitations

`torch.mm` and `torch.allclose` verify. Known WIP edges, to be addressed in
follow-ups:

- Float dtype only (int tensors not supported through the float-annotated model).
- `cat`/`split` model the `dim == 1` (column) case; `cat` is currently
  unwinding-heavy on larger inputs.
- `torch.split` is shadowed by the builtin `split` handler (the 3-arg form is
  rejected); module-qualified dispatch for `torch.split` needs a frontend fix.

## Dependency

Builds on the nested-list copy fix in #5113 (its two commits are the base of
this branch); the PR is targeted at that branch and should merge after #5113.
The torch model's matmul relies on correct nested-list handling.
