### PR TITLE
[symex] Lower noexcept/throw() specifications in --lower-exceptions

### DIFF
--- a/docs/design-symbolic-exceptions.md
+++ b/docs/design-symbolic-exceptions.md
@@ -71,9 +71,11 @@ single-inheritance base-by-value slicing), pointer (`catch (T*)`) and `void*`
 catches, and catch-all; nested try with inner→outer propagation; inter-procedural
 propagation through direct and indirect calls; rethrow; uncaught detection at both
 `main` and `__ESBMC_main` (the latter covers exceptions from global constructors
-during static initialisation). Reaching outside the subset makes the whole program
-fall back to the imperative path. About **39 of 67** `regression/esbmc-cpp/try_catch`
-CORE tests currently lower, at 0 differential divergences.
+during static initialisation); and `noexcept` / `throw()` enforcement (an exception
+escaping a no-throw function → terminate, asserted at its epilogue). Reaching
+outside the subset makes the whole program fall back to the imperative path. About
+**47 of 67** `regression/esbmc-cpp/try_catch` CORE tests currently lower, at 0
+differential divergences.
 
 **Python** lowers too: try/except/raise share the same THROW/CATCH machinery, the
 registry ingests Python exception ancestry from THROW `exception_list`s, and the
@@ -82,8 +84,9 @@ entry/uncaught anchor is `__ESBMC_main` (which wraps `python_user_main`). 26 of 
 divergences (the rest fall back).
 
 Not yet lowered (fall back): parts of the `std` exception surface; destructor
-unwinding; `bad_cast` from `dynamic_cast<T&>`; dynamic exception specifications /
-`noexcept` (a throw inside a `THROW_DECL` spec region forces fallback).
+unwinding; `bad_cast` from `dynamic_cast<T&>`; dynamic exception specifications
+with real types (`throw(T...)`, a C++14-only form the frontend rejects under
+C++17, so it forces fallback only under `--std c++14`).
 
 `std::set_terminate` / `std::set_unexpected` are honoured: the operational model
 (`src/cpp/library/exception`) now stores the installed handler and `terminate()`
@@ -93,11 +96,10 @@ ignored on all paths).
 ## Roadmap to default-on
 
 The imperative path can only be removed once the lowered path reaches parity.
-Remaining work, roughly ordered: throw-spec / `noexcept` (a throw escaping the
-spec'd function should route to terminate rather than force fallback); the broader
-`std` exception surface; destructor unwinding; `bad_cast` from `dynamic_cast<T&>`.
-Then: two green full-suite differential runs (`--lower-exceptions` ON vs OFF)
-before flipping the default and deleting `symex_catch.cpp`.
+Remaining work, roughly ordered: the broader `std` exception surface; destructor
+unwinding; `bad_cast` from `dynamic_cast<T&>`. Then: two green full-suite
+differential runs (`--lower-exceptions` ON vs OFF) before flipping the default and
+deleting `symex_catch.cpp`.
 
 ## Testing
 

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_call_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_call_fail/main.cpp
@@ -1,0 +1,32 @@
+// An exception thrown by a callee propagates into the noexcept caller and
+// escapes its no-throw boundary -> std::terminate.
+struct E
+{
+  int v;
+  E(int a) : v(a)
+  {
+  }
+};
+
+void g()
+{
+  throw E(1);
+}
+
+void f() noexcept
+{
+  g();
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (...)
+  {
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_call_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_call_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--lower-exceptions --std c++11
+
+^VERIFICATION FAILED$
+noexcept specification violated

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_escape_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_escape_fail/main.cpp
@@ -1,0 +1,28 @@
+// An exception thrown directly in a noexcept function escapes the no-throw
+// boundary -> std::terminate ([except.spec]). The lowering asserts that no
+// exception is in flight at the function epilogue.
+struct E
+{
+  int v;
+  E(int a) : v(a)
+  {
+  }
+};
+
+void f() noexcept
+{
+  throw E(5);
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (...)
+  {
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_escape_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_escape_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--lower-exceptions --std c++11
+
+^VERIFICATION FAILED$
+noexcept specification violated

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_false/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_false/main.cpp
@@ -1,0 +1,30 @@
+#include <cassert>
+
+// noexcept(false) explicitly permits exceptions to escape, so a throw is NOT a
+// specification violation: it propagates normally and is caught by the caller.
+struct E
+{
+  int v;
+  E(int a) : v(a)
+  {
+  }
+};
+
+void f() noexcept(false)
+{
+  throw E(5);
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (E &e)
+  {
+    assert(e.v == 5);
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_false/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_false/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--lower-exceptions --std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_local_catch/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_local_catch/main.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+
+// A throw that is caught within the noexcept function does not escape, so it
+// does not violate the specification.
+struct E
+{
+  int v;
+  E(int a) : v(a)
+  {
+  }
+};
+
+void f() noexcept
+{
+  try
+  {
+    throw E(5);
+  }
+  catch (E &e)
+  {
+    assert(e.v == 5);
+  }
+}
+
+int main()
+{
+  f();
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_local_catch/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_local_catch/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--lower-exceptions --std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1863,6 +1863,7 @@ bool clang_cpp_convertert::get_function_body(
     if (fpt->hasExceptionSpec())
     {
       codet decl = codet("throw_decl");
+      bool emit = true;
       if (fpt->hasDynamicExceptionSpec())
       {
         // e.g: void func() throw(int) { throw 1;}
@@ -1879,11 +1880,20 @@ bool clang_cpp_convertert::get_function_body(
       }
       else if (fpt->hasNoexceptExceptionSpec())
       {
-        codet tmp;
-        tmp.type() = typet("noexcept");
-        decl.move_to_operands(tmp);
+        // hasNoexceptExceptionSpec() is also true for noexcept(false), which
+        // permits exceptions to escape — record the no-throw marker only when
+        // the function genuinely cannot throw.
+        if (fpt->canThrow() == clang::CT_Cannot)
+        {
+          codet tmp;
+          tmp.type() = typet("noexcept");
+          decl.move_to_operands(tmp);
+        }
+        else
+          emit = false;
       }
-      body.operands().insert(body.operands().begin(), decl);
+      if (emit)
+        body.operands().insert(body.operands().begin(), decl);
     }
   }
 

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -13,10 +13,32 @@
 namespace
 {
 const irep_idt ellipsis_id = "ellipsis";
+const irep_idt noexcept_id = "noexcept";
 
 bool is_pointer_catch(const irep_idt &type)
 {
   return type.as_string().find("_ptr") != std::string::npos;
+}
+
+/// A THROW_DECL marking a *no-throw* specification (`noexcept` or `throw()`):
+/// its list is empty or names only the "noexcept" marker. A list naming real
+/// types is a dynamic exception specification (throw(T...), C++14-only) which
+/// the lowering does not model.
+bool is_no_throw_decl(const expr2tc &code)
+{
+  for (const irep_idt &t : to_code_cpp_throw_decl2t(code).exception_list)
+    if (t != noexcept_id)
+      return false;
+  return true;
+}
+
+/// True iff the function body carries a no-throw specification.
+bool function_is_noexcept(const goto_programt &body)
+{
+  for (const auto &ins : body.instructions)
+    if (ins.type == THROW_DECL && is_no_throw_decl(ins.code))
+      return true;
+  return false;
 }
 
 /// One catch clause: its static type (or "ellipsis"), the instruction that
@@ -241,13 +263,14 @@ private:
   {
     const auto end = body.instructions.end();
     int depth = 0;
-    bool in_spec = false; // inside a THROW_DECL..THROW_DECL_END region
     for (auto it = body.instructions.begin(); it != end; ++it)
     {
-      if (it->type == THROW_DECL)
-        in_spec = true;
-      else if (it->type == THROW_DECL_END)
-        in_spec = false;
+      // A dynamic exception specification with real types (throw(T...)) routes
+      // a non-listed throw to unexpected/terminate, which is not modelled —
+      // leave such a program to the imperative path. A no-throw spec
+      // (noexcept / throw()) is fine: it is enforced at the function epilogue.
+      if (it->type == THROW_DECL && !is_no_throw_decl(it->code))
+        return false;
       if (it->type == CATCH && !it->targets.empty())
       {
         const code_cpp_catch2t &c = to_code_cpp_catch2t(it->code);
@@ -281,12 +304,6 @@ private:
       }
       else if (it->type == THROW)
       {
-        // A throw under an active exception specification / noexcept may route
-        // to unexpected/terminate, which the lowering does not model yet —
-        // leave such a program to the imperative path. (A THROW_DECL with no
-        // throw inside, as for implicit noexcept special members, is harmless.)
-        if (in_spec)
-          return false;
         const code_cpp_throw2t &t = to_code_cpp_throw2t(it->code);
         if (is_nil_expr(t.operand))
           continue; // rethrow
@@ -373,6 +390,14 @@ private:
     std::vector<regiont> regions;
     std::vector<sitet> throws, calls;
     collect(body, regions, throws, calls);
+
+    // Throw-spec markers are consumed here; once the throws are lowered the
+    // imperative throw-decl machinery has nothing to act on.
+    const bool noexcept_fn = function_is_noexcept(body);
+    for (auto &ins : body.instructions)
+      if (ins.type == THROW_DECL || ins.type == THROW_DECL_END)
+        ins.make_skip();
+
     if (regions.empty() && throws.empty() && calls.empty())
       return;
 
@@ -397,16 +422,21 @@ private:
       r.pop->make_skip();
     }
 
-    // An exception escaping main() is uncaught (std::terminate). It is checked
-    // at both main's epilogue and __ESBMC_main's: the latter also catches
-    // exceptions thrown during static initialisation (global constructors),
-    // which run before main. The id is the mangled "c:@F@main#<params>".
-    if (id2string(fn_id).rfind("c:@F@main#", 0) == 0 || fn_id == "__ESBMC_main")
+    // An exception in flight at the epilogue is a hard failure in two cases:
+    //  - main / __ESBMC_main: it is uncaught (escapes the program → terminate);
+    //    __ESBMC_main also covers static-init throws from global constructors.
+    //  - a noexcept function: the exception escapes the no-throw boundary →
+    //    terminate ([except.spec]). A locally-caught throw clears `thrown`, so
+    //    this fires only on a genuine escape.
+    const bool is_entry =
+      id2string(fn_id).rfind("c:@F@main#", 0) == 0 || fn_id == "__ESBMC_main";
+    if (is_entry || noexcept_fn)
     {
       auto a = body.insert(std::next(epilogue));
       a->make_assertion(equality2tc(thrown, gen_false_expr()));
       a->location.property("exception");
-      a->location.comment("uncaught exception");
+      a->location.comment(
+        is_entry ? "uncaught exception" : "noexcept specification violated");
     }
 
     body.update();


### PR DESCRIPTION
## Summary

Follow-up to #5108: extends the opt-in `--lower-exceptions` pass to lower
`noexcept` / `throw()` specifications, so a no-throw function from which an
exception escapes is modelled as calling `std::terminate` ([except.spec])
instead of forcing the whole program back onto the imperative path.

Still gated on `--lower-exceptions` (default OFF); the imperative path is the
unchanged default.

## What it does

- **Enforcement at the epilogue.** For a no-throw function, the pass asserts at
  the function epilogue that no exception is in flight (`__ESBMC_exc_thrown ==
  false`), reusing the existing uncaught-at-`main` mechanism. A locally-caught
  throw clears the flag, so the assert fires only on a genuine escape — matching
  the standard (the spec is violated when an exception *escapes*, not when one
  is thrown and caught internally).
- `THROW_DECL` / `THROW_DECL_END` markers are rewritten to `SKIP`. Only dynamic
  specifications with real types (`throw(T...)`, a C++14-only form) still force
  fallback.

## Frontend fix (separate commit)

`hasNoexceptExceptionSpec()` is also true for `noexcept(false)`, which *permits*
exceptions to escape. The frontend emitted the same `noexcept` `THROW_DECL`
marker for it as for `noexcept(true)`, which would make the new enforcement
raise a spurious `terminate` on legal code. The marker is now gated on
`canThrow() == CT_Cannot`, so only genuinely non-throwing specifications are
recorded. (Found in review.)

## Results

- Differential `--lower-exceptions` ON vs OFF across CORE `regression/esbmc-cpp/try_catch`:
  **69 same, 0 divergences**, with **47 of 67** now lowering (up from 42).
- New regression tests: `noexcept_escape_fail`, `noexcept_call_fail` (escape →
  FAILED); `noexcept_local_catch`, `noexcept_false` (no violation → SUCCESSFUL).
- Full `esbmc-cpp/try_catch` suite (104) green; type-id unit test green;
  `clang-format-11` clean. The 3 unrelated broad-suite failures
  (`utility2_fail`, `builtin-template[-fail]`) were confirmed pre-existing by
  building without this change.

Like the earlier nested-propagation and static-init fixes, the lowered path is
standard-correct where it diverges from the imperative path (a throw escaping a
`noexcept` function should terminate; the imperative path currently lets it be
caught by a caller).

Refs #5075
