### PR TITLE
[python] Resolve element type for index>=1 in homogeneous nested lists (Fixes #5129)

### DIFF
--- a/regression/python/nested-list-comprehension-fp-index/main.py
+++ b/regression/python/nested-list-comprehension-fp-index/main.py
@@ -1,0 +1,22 @@
+# A 2-D list comprehension records a single (homogeneous) element-type entry.
+# Reading a constant outer index >= 1 and using the inner float element in FP
+# arithmetic must resolve the float type, not fall through to a non-FP sort
+# (previously crashed the SMT backend: get_exponent_width / Z3 "rm and fp
+# sorts", #5129 — a residual of #5103/#5111 for the index>=1 case).
+
+C = [[0.0 for _ in range(2)] for _ in range(2)]
+i = 0
+while i < 2:
+    j = 0
+    while j < 2:
+        C[i][j] = 2.0 + 3.0
+        j = j + 1
+    i = i + 1
+
+# Constant outer index >= 1 + FP arithmetic on the inner element.
+x = C[1][0]
+assert x - 5.0 == 0.0
+
+# Row-extraction form of the same access.
+r = C[1]
+assert r[1] - 5.0 == 0.0

--- a/regression/python/nested-list-comprehension-fp-index/test.desc
+++ b/regression/python/nested-list-comprehension-fp-index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-list-comprehension-fp-index_fail/main.py
+++ b/regression/python/nested-list-comprehension-fp-index_fail/main.py
@@ -1,0 +1,9 @@
+# Non-vacuity counterpart of nested-list-comprehension-fp-index: the inner float
+# element of a 2-D comprehension is read at a constant outer index >= 1 and used
+# in FP arithmetic.  The read returns the genuine value (0.0), so an assertion on
+# the wrong value must FAIL with a counterexample (proving the read is real, not
+# vacuously passing and not crashing the SMT backend, #5129).
+
+C = [[0.0 for _ in range(2)] for _ in range(2)]
+x = C[1][0]
+assert x - 1.0 == 0.0

--- a/regression/python/nested-list-comprehension-fp-index_fail/test.desc
+++ b/regression/python/nested-list-comprehension-fp-index_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/nested-list-comprehension-oob_fail/main.py
+++ b/regression/python/nested-list-comprehension-oob_fail/main.py
@@ -1,0 +1,9 @@
+# The element-type clamp in handle_index_access (#5129) must not mask a genuine
+# out-of-bounds access: a constant outer index past the end of a comprehension
+# still has its value read at the real index, so the runtime list-bounds check
+# must fire (out-of-bounds read in list) rather than silently passing or
+# crashing the SMT backend.
+
+C = [[0.0 for _ in range(2)] for _ in range(2)]
+x = C[9][0]
+assert x - 0.0 == 0.0

--- a/regression/python/nested-list-comprehension-oob_fail/test.desc
+++ b/regression/python/nested-list-comprehension-oob_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$
+^  out-of-bounds read in list$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2029,10 +2029,24 @@ exprt python_list::handle_index_access(
       auto type_map_it = list_type_map.find(key);
       if (type_map_it != list_type_map.end())
       {
-        if (index < type_map_it->second.size())
+        if (!type_map_it->second.empty())
         {
-          const std::string &elem_id = type_map_it->second.at(index).first;
-          elem_type = type_map_it->second.at(index).second;
+          // Homogeneous lists (e.g. list comprehensions) record a single
+          // element-type entry; ESBMC models lists as homogeneous, so reuse
+          // that entry for any in-structure index.  Without this, a constant
+          // outer index >= 1 into a comprehension-built nested list skips the
+          // nested-element handling below, the inner element type (float) is
+          // lost, and the value reaches the SMT FP encoder as a non-FP sort
+          // (get_exponent_width abort / Z3 "rm and fp sorts", #5129).  Literal
+          // lists record one entry per element, so for an in-bounds index
+          // eff_index == index and behaviour is unchanged.  The runtime value
+          // is still read at pos_expr below, so only the static type is taken
+          // from the homogeneous entry.
+          const size_t eff_index = index < type_map_it->second.size()
+                                     ? index
+                                     : type_map_it->second.size() - 1;
+          const std::string &elem_id = type_map_it->second.at(eff_index).first;
+          elem_type = type_map_it->second.at(eff_index).second;
 
           if (elem_type == converter_.get_type_handler().get_list_type())
           {


### PR DESCRIPTION
## Problem

FP arithmetic over an element of a **nested list comprehension** read at a constant outer index `>= 1` crashes the SMT backend:

```python
C = [[0.0 for _ in range(2)] for _ in range(2)]
x = C[1][0]
assert x - 0.0 == 0.0
```

```
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Assertion failed: (id == SMT_SORT_BVFP || id == SMT_SORT_FPBV), get_exponent_width, smt_sort.h:123
# Z3: ERROR: Z3 error rm and fp sorts expected encountered
```

`C[0][0]` is fine; `==` comparison is fine; the int version is fine — only a constant outer index `>= 1` combined with **FP arithmetic** aborts. This is a residual of #5103/#5102 (fixed by #5111) for the index `>= 1` case, reported as #5129.

## Root cause

A list comprehension records a single **homogeneous** entry in `list_type_map` for the outer list (`elem_id` = inner-comprehension result symbol, type = `list`). In `python_list::handle_index_access`, the nested-list type-resolution block — including the #5111 inner-pointer rebinding that propagates the inner `float`/`int` element type — was gated by:

```cpp
if (index < type_map_it->second.size())
```

For a constant outer index `>= 1`, `1 < 1` is false, so that block is skipped. Execution falls to the dynamic path, the element resolves as `list` rather than `float`, and `C[1][0]` reaches the SMT FP encoder with a non-FP sort → `get_exponent_width` abort. A **literal** `[[..],[..]]` records one entry *per element* (size 2), so all in-bounds indices resolve; a variable/loop index defaults to entry 0 — which is why only the constant `>= 1` case was affected.

## Fix

Frontend-only (`src/python-frontend/python_list.cpp`, `handle_index_access`). Widen the guard to `!empty()` and clamp the **type** lookup to the homogeneous entry; the runtime **value** is still read at the actual index (`build_list_at_call(array, pos_expr, …)` lower in the block), so aliasing, mutation, and bounds semantics are preserved:

```cpp
const size_t eff_index = index < type_map_it->second.size()
                           ? index
                           : type_map_it->second.size() - 1;
```

ESBMC models lists as homogeneous, so reusing the single entry for any index is sound. For an in-bounds literal access `eff_index == index`, so behaviour is unchanged; `size() - 1` cannot underflow (guarded by `!empty()`).

## Tests

- `regression/python/nested-list-comprehension-fp-index` — constant index `>= 1` + FP arithmetic (and row-extraction form) → `VERIFICATION SUCCESSFUL`.
- `regression/python/nested-list-comprehension-fp-index_fail` — wrong-value assertion → `VERIFICATION FAILED` (non-vacuity: the read returns the genuine value, not a vacuous pass).
- `regression/python/nested-list-comprehension-oob_fail` — genuinely out-of-bounds outer index still triggers `out-of-bounds read in list` (the clamp must not mask real errors).

Verified on current `master` (`390fad2129`) + this patch: the #5129 reproducer and minimal cases now verify; index-0 and variable-index paths still work; #5111's `nested-list-return` tests and the list/comprehension/nested-list regression subset pass with no regressions; CPython sanity (`check_python_tests.sh`) green for the new tests.

Fixes #5129
