### PR TITLE
[symex] Resolve std::bad_cast under elaborated tag name (LLVM 22)

### DIFF
--- a/regression/esbmc-cpp/try_catch/dynamic_cast_bad_cast_caught/main.cpp
+++ b/regression/esbmc-cpp/try_catch/dynamic_cast_bad_cast_caught/main.cpp
@@ -1,0 +1,33 @@
+// A failing dynamic_cast<T&> throws std::bad_cast, which is caught here. This
+// requires symex to resolve the <typeinfo> model's std::bad_cast symbol, whose
+// tag name is elaborated ("class std::bad_cast") on newer Clang/LLVM.
+#include <typeinfo>
+
+struct B
+{
+  virtual ~B()
+  {
+  }
+};
+struct D1 : B
+{
+};
+struct D2 : B
+{
+};
+
+int main()
+{
+  B *b = new D1();
+  try
+  {
+    D2 &d = dynamic_cast<D2 &>(*b); // dynamic type is D1, not D2 -> bad_cast
+    (void)d;
+    return 2; // not reached
+  }
+  catch (std::bad_cast &)
+  {
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/dynamic_cast_bad_cast_caught/test.desc
+++ b/regression/esbmc-cpp/try_catch/dynamic_cast_bad_cast_caught/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -276,7 +276,13 @@ bool goto_symext::symex_throw_bad_cast()
   // Reuse the previously constructed instruction if available.
   if (!bad_cast_throw.code)
   {
+    // Depending on the Clang/LLVM version the <typeinfo> model's class is
+    // recorded either with the un-elaborated name ("tag-std::bad_cast") or with
+    // the elaborated one ("tag-class std::bad_cast"); newer LLVM uses the
+    // latter, which must match the name the catch clause carries. Try both.
     const symbolt *bad_cast_sym = ns.lookup("tag-std::bad_cast");
+    if (!bad_cast_sym)
+      bad_cast_sym = ns.lookup("tag-class std::bad_cast");
     if (!bad_cast_sym)
     {
       // <typeinfo> not included — emit a hard failure directly.


### PR DESCRIPTION
> **Draft — needs CI to confirm the runtime verdict.** See the validation note
> at the bottom.

## Summary

A failing `dynamic_cast<T&>` is supposed to throw `std::bad_cast`. ESBMC
synthesises that throw in `goto_symext::symex_throw_bad_cast`
(`src/goto-symex/symex_catch.cpp`) via `ns.lookup("tag-std::bad_cast")`.

On newer Clang/LLVM (observed on LLVM 22) the `<typeinfo>` model's class is
recorded under the **elaborated** name `tag-class std::bad_cast` — and the
`catch (std::bad_cast&)` clause carries the matching elaborated type
(`CATCH class std::bad_cast` in the GOTO). The un-elaborated lookup therefore
fails, and a `bad_cast` that the program **catches** is reported as a spurious
`VERIFICATION FAILED`:

```
dynamic_cast<T&> failed; include <typeinfo> for std::bad_cast
```

## Fix

Fall back to `ns.lookup("tag-class std::bad_cast")` when the un-elaborated lookup
misses. The rest of `symex_throw_bad_cast` already derives the `exception_list`
from the resolved symbol's own name, so matching the catch type follows
automatically.

## Test

`regression/esbmc-cpp/try_catch/dynamic_cast_bad_cast_caught` — a failing
`dynamic_cast<T&>` caught as `std::bad_cast`, expected `SUCCESSFUL`. There was no
prior coverage for the *throwing* path (`nec_ex9-dynamic-cast` exercises a
*succeeding* cast), which is why this regression went unnoticed.

## Validation note (why this is a draft)

The diagnosis (`CATCH class std::bad_cast` vs `tag-std::bad_cast`) was confirmed
directly from the GOTO, and the change compiles cleanly. The **runtime verdict
could not be confirmed locally**: on the macOS / Homebrew-LLVM-22 build used
here, parsing `<typeinfo>`/`<cassert>` requires pointing at the SDK includes,
which causes the SDK's libc++ headers to **non-deterministically shadow ESBMC's
own `<typeinfo>` model** — the same test flips verdict between identical runs.
So this PR is opened as a draft to let **CI (Linux)** decide the verdict on the
new regression test. If CI is green, it's ready to un-draft.

Refs #5075
