### PR TITLE
[cpp] Address review on the exception OM (program-wide handlers, no infinite loop)

### DIFF
--- a/regression/esbmc-cpp/try_catch/set_terminate_cross_tu/helper.cpp
+++ b/regression/esbmc-cpp/try_catch/set_terminate_cross_tu/helper.cpp
@@ -1,0 +1,12 @@
+#include <exception>
+#include <cstdlib>
+
+static void clean_terminate()
+{
+  std::exit(0); // clean exit; not the default "terminate called" failure
+}
+
+void install_handler()
+{
+  std::set_terminate(clean_terminate);
+}

--- a/regression/esbmc-cpp/try_catch/set_terminate_cross_tu/main.cpp
+++ b/regression/esbmc-cpp/try_catch/set_terminate_cross_tu/main.cpp
@@ -1,0 +1,14 @@
+// Program-wide handler state: a terminate handler installed in one translation
+// unit (helper.cpp) must be seen by std::terminate() called in this one. This
+// only holds if __gnu_cxx::__terminate_handler is a single program-wide object
+// (external linkage), not a per-TU static.
+#include <exception>
+
+void install_handler(); // defined in helper.cpp
+
+int main()
+{
+  install_handler();
+  std::terminate(); // runs the handler installed in the other TU -> exit(0)
+  return 1;         // unreachable if the handler is seen program-wide
+}

--- a/regression/esbmc-cpp/try_catch/set_terminate_cross_tu/test.desc
+++ b/regression/esbmc-cpp/try_catch/set_terminate_cross_tu/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+helper.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/exception
+++ b/src/cpp/library/exception
@@ -62,15 +62,18 @@ void terminate() _ESBMC_NOEXCEPT; // forward decl: __gnu_cxx default uses it
 // variants fall out directly. libstdc++ uses __atomic_{exchange,load}_n for
 // thread safety; a plain access is observationally identical here (BMC is
 // single-threaded and the lowering rejects concurrent programs).
+//
+// The handler variables have external linkage (not static): like the real
+// __gnu_cxx::__terminate_handler they must be ONE program-wide object, so a
+// handler installed in one translation unit is seen by terminate() in another.
+// (A file-local `static` would give each TU its own copy.)
 namespace __gnu_cxx
 {
 // Default terminate handler (models __verbose_terminate_handler): aborts.
 inline void __verbose_terminate_handler()
 {
   __ESBMC_assert(0, "terminate called after throwing an exception");
-  while (1)
-  {
-  }
+  __ESBMC_assume(0); // terminate never returns
 }
 
 inline void __default_unexpected_handler()
@@ -78,9 +81,8 @@ inline void __default_unexpected_handler()
   std::terminate();
 }
 
-static std::terminate_handler __terminate_handler = __verbose_terminate_handler;
-static std::unexpected_handler __unexpected_handler =
-  __default_unexpected_handler;
+std::terminate_handler __terminate_handler = __verbose_terminate_handler;
+std::unexpected_handler __unexpected_handler = __default_unexpected_handler;
 } // namespace __gnu_cxx
 
 namespace std
@@ -104,9 +106,7 @@ inline void terminate() _ESBMC_NOEXCEPT
   // and must not return; if it does, abort.
   (*__gnu_cxx::__terminate_handler)();
   __ESBMC_assert(0, "terminate handler unexpectedly returned");
-  while (1)
-  {
-  }
+  __ESBMC_assume(0); // terminate never returns
 }
 
 inline unexpected_handler set_unexpected(unexpected_handler f) _ESBMC_NOEXCEPT


### PR DESCRIPTION
## Summary

Addresses the two outstanding review comments on the merged #5108, both on the
`<exception>` operational model (`src/cpp/library/exception`).

## Changes

1. **Program-wide handler state**
   ([comment](https://github.com/esbmc/esbmc/pull/5108#discussion_r3361297000)).
   `__gnu_cxx::__terminate_handler` and `__unexpected_handler` were declared
   `static` in the header, so each translation unit got its own copy — a handler
   installed via `set_terminate` in one TU was invisible to `terminate()` called
   in another. Like the real libstdc++ symbols, they must be **one program-wide
   object**, so give them external linkage. ESBMC merges the same-named model
   global across TUs, so there is no multiple-definition issue (verified with a
   two-TU build).

   New regression `set_terminate_cross_tu`: the handler is installed in
   `helper.cpp` and `std::terminate()` is called in `main.cpp` — passes only if
   the handler is program-wide.

2. **Drop the infinite loop**
   ([comment](https://github.com/esbmc/esbmc/pull/5108#discussion_r...)).
   Replace the `while (1) {}` "never returns" spins after the terminate asserts
   with `__ESBMC_assume(0)`, which states the unreachability directly rather than
   modelling no-return as an opaque infinite loop.

## Validation

All `esbmc-cpp/try_catch` tests pass (107), including `set_terminate_handler`,
`set_terminate_default_fail`, and the new `set_terminate_cross_tu`. The broad
`esbmc-cpp/cpp` slice shows only the pre-existing, non-exception failures
(`github_2242_*`, `utility2_fail`).

Refs #5075
