### PR TITLE
[python] Fix list repetition with non-constant count (Fixes #5146)

### DIFF
--- a/regression/humaneval/humaneval_69/test.desc
+++ b/regression/humaneval/humaneval_69/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
---unwind 1 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 9 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-repeat-multielem-nonconst/main.py
+++ b/regression/python/list-repeat-multielem-nonconst/main.py
@@ -1,0 +1,11 @@
+# Known limitation (FUTURE): repeating a MULTI-element source by a runtime count
+# currently repeats only the first element. CPython: [1, 2] * 3 == [1,2,1,2,1,2].
+# Single-element runtime-count repetition (the issue #5146 case) is fixed; this
+# multi-element variant is a pre-existing gap tracked here.
+def f(n: int) -> int:
+    a = [1, 2] * n
+    return len(a)
+
+
+if __name__ == "__main__":
+    assert f(3) == 6

--- a/regression/python/list-repeat-multielem-nonconst/test.desc
+++ b/regression/python/list-repeat-multielem-nonconst/test.desc
@@ -1,0 +1,4 @@
+FUTURE
+main.py
+--unwind 12 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-repeat-nonconst-count/main.py
+++ b/regression/python/list-repeat-nonconst-count/main.py
@@ -1,0 +1,36 @@
+# List repetition [x] * n must produce n elements when the count is a runtime
+# value -- a bare symbol, a compound expression (m + 1), or the count on the
+# left (n * [x]). Regression for issue #5146 (frq = [0] * (max(lst) + 1)).
+from typing import List
+
+
+def repeat_sym(n: int) -> List[int]:
+    return [0] * n
+
+
+def repeat_expr(m: int) -> int:
+    a = [0] * (m + 1)
+    return len(a)
+
+
+def repeat_left(n: int) -> List[int]:
+    return n * [7]
+
+
+def main() -> None:
+    a = repeat_sym(6)
+    assert len(a) == 6
+    assert a[0] == 0
+    assert a[5] == 0
+
+    assert repeat_expr(5) == 6
+
+    b = repeat_left(4)
+    assert len(b) == 4
+    s = 0
+    for x in b:
+        s += x
+    assert s == 28
+
+
+main()

--- a/regression/python/list-repeat-nonconst-count/test.desc
+++ b/regression/python/list-repeat-nonconst-count/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-repeat-nonconst-count_fail/main.py
+++ b/regression/python/list-repeat-nonconst-count_fail/main.py
@@ -1,0 +1,9 @@
+# Negative variant: a wrong size for a runtime-count repeat must not verify.
+def f(n: int) -> int:
+    a = [0] * (n + 1)
+    return len(a)
+
+
+if __name__ == "__main__":
+    # f(5) builds 6 elements; asserting 1 (the old buggy size) must fail.
+    assert f(5) == 1

--- a/regression/python/list-repeat-nonconst-count_fail/test.desc
+++ b/regression/python/list-repeat-nonconst-count_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/list-repetition-rhs/test.desc
+++ b/regression/python/list-repetition-rhs/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 1
+--unwind 2
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3192,41 +3192,59 @@ exprt python_list::compare(
 
 exprt python_list::create_vla(
   const nlohmann::json &element,
-  const symbolt *list,
-  symbolt *size_var,
+  const exprt &count,
   const exprt &list_elem)
 {
-  // Add counter for while loop
+  locationt location = converter_.get_location_from_decl(element);
+
+  // Fresh result list: a literal source (e.g. [0]) already holds its initial
+  // element, so pushing onto it would yield count + 1 elements.
+  symbolt &result = create_list();
+
+  // Materialise the count (which may be a compound expression such as m + 1)
+  // into an int symbol to use as the loop bound.
+  exprt bound_value =
+    (count.type() == int_type()) ? count : typecast_exprt(count, int_type());
+  symbolt &bound = converter_.create_tmp_symbol(
+    element, "$list_rep_count$", int_type(), exprt());
+  code_declt bound_decl(build_symbol(bound));
+  bound_decl.location() = location;
+  converter_.add_instruction(bound_decl);
+  code_assignt bound_assign(build_symbol(bound), bound_value);
+  bound_assign.location() = location;
+  converter_.add_instruction(bound_assign);
+
+  // counter = 0
   symbolt &counter = converter_.create_tmp_symbol(
     element, "counter", int_type(), gen_zero(int_type()));
-
   code_assignt counter_code(build_symbol(counter), gen_zero(int_type()));
+  counter_code.location() = location;
   converter_.add_instruction(counter_code);
 
-  // Build conditional for while loop (counter < len(arr))
+  // while (counter < bound) { result.push(list_elem); counter += 1; }
   exprt cond("<", bool_type());
   cond.operands().push_back(build_symbol(counter));
-  cond.operands().push_back(build_symbol(*size_var));
+  cond.operands().push_back(build_symbol(bound));
 
-  // Build block with lish_push() calls and counter increment
   code_blockt then;
-  exprt list_push_call = build_push_list_call(*list, element, list_elem);
-  then.copy_to_operands(list_push_call);
+  then.copy_to_operands(build_push_list_call(result, element, list_elem));
 
-  // increment counter
-  exprt incr("+");
+  exprt incr("+", int_type());
   incr.copy_to_operands(build_symbol(counter));
   incr.copy_to_operands(gen_one(int_type()));
   code_assignt update(build_symbol(counter), incr);
   then.copy_to_operands(update);
 
-  // add while block for list_push() calls
   codet while_cod;
   while_cod.set_statement("while");
   while_cod.copy_to_operands(cond, then);
   converter_.add_instruction(while_cod);
 
-  return build_symbol(*list);
+  // Record the element type so downstream indexing resolves it.
+  list_type_map[result.id.as_string()].push_back(
+    std::make_pair(std::string(), list_elem.type()));
+
+  return build_symbol(result);
 }
 
 exprt python_list::list_repetition(
@@ -3394,27 +3412,9 @@ exprt python_list::list_repetition(
     return build_symbol(*elem_sym);
   };
 
-  // Get list size from lhs (e.g.: 3 * [1] or 3 * lst)
+  // Count on the lhs (e.g.: 3 * [1] or n * lst). The list operand is the rhs.
   if (lhs.type() != list_type)
   {
-    if (lhs.is_symbol())
-    {
-      symbolt *size_var = converter_.find_symbol(
-        to_symbol_expr(lhs).get_identifier().as_string());
-      assert(size_var);
-
-      list_symbol = converter_.find_symbol(rhs.identifier().as_string());
-      assert(list_symbol);
-
-      if (!parse_size_from_symbol(size_var, list_size))
-        return create_vla(list_value_, list_symbol, size_var, list_elem);
-    }
-    else if (lhs.is_constant())
-    {
-      assert(is_integer_type(lhs.type()));
-      list_size = binary2integer(lhs.value().c_str(), true);
-    }
-
     // List element comes from the rhs operand
     if (right_node.contains("elts"))
       list_elem = converter_.get_expr(right_node["elts"][0]);
@@ -3426,9 +3426,20 @@ exprt python_list::list_repetition(
         return build_symbol(create_list());
       is_variable_list = true;
     }
+
+    if (lhs.is_constant())
+    {
+      assert(is_integer_type(lhs.type()));
+      list_size = binary2integer(lhs.value().c_str(), true);
+    }
+    else
+    {
+      // Non-constant count (symbol `n` or compound `m + 1`): repeat at runtime.
+      return create_vla(list_value_, lhs, list_elem);
+    }
   }
 
-  // Get list size from rhs (e.g.: [1] * 3 or lst * 3)
+  // Count on the rhs (e.g.: [1] * 3 or lst * n). The list operand is the lhs.
   if (rhs.type() != list_type)
   {
     // List element comes from the lhs operand
@@ -3443,22 +3454,15 @@ exprt python_list::list_repetition(
       is_variable_list = true;
     }
 
-    if (rhs.is_symbol()) // (e.g.: [1] * n or lst * n)
-    {
-      symbolt *size_var = converter_.find_symbol(
-        to_symbol_expr(rhs).get_identifier().as_string());
-      assert(size_var);
-
-      list_symbol = converter_.find_symbol(lhs.identifier().as_string());
-      assert(list_symbol);
-
-      if (!parse_size_from_symbol(size_var, list_size))
-        return create_vla(list_value_, list_symbol, size_var, list_elem);
-    }
-    else if (rhs.is_constant())
+    if (rhs.is_constant())
     {
       assert(is_integer_type(rhs.type()));
       list_size = binary2integer(rhs.value().c_str(), true);
+    }
+    else
+    {
+      // Non-constant count (symbol `n` or compound `m + 1`): repeat at runtime.
+      return create_vla(list_value_, rhs, list_elem);
     }
   }
 

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -342,10 +342,13 @@ public:
 private:
   friend class python_dict_handler;
 
+  // Repeat `list_elem` a runtime number of times (`count` may be any integer
+  // expression: a constant, a symbol like `n`, or a compound like `m + 1`).
+  // Builds a fresh list, so a literal source's pre-populated element is not
+  // reused (avoids an off-by-one).
   exprt create_vla(
     const nlohmann::json &element,
-    const symbolt *list,
-    symbolt *size_var,
+    const exprt &count,
     const exprt &list_elem);
 
   exprt build_list_at_call(


### PR DESCRIPTION
## What

Fixes #5146 (`regression/humaneval/humaneval_69` KNOWNBUG/FUTURE). `search` does `frq = [0] * (max(lst) + 1)`; when `lst` is a function parameter, `max(lst)` is a runtime value, so the repeat count is non-constant and the resulting list had the wrong size, making `frq[i]` read out of bounds.

List repetition `[x] * n` / `n * [x]` only handled compile-time-constant counts:

- A **compound** count like `[0] * (m + 1)` matched neither the symbol nor the constant branch, so the size defaulted to 0 and the list collapsed to size 1.
- A **bare-symbol** count `[0] * n` went through `create_vla`, which pushed `n` copies onto the literal's already-populated symbol → off-by-one (`n + 1`).

## Fix

`src/python-frontend/python_list.cpp`:

1. Rewrote `create_vla` to take the count as an `exprt` (constant, symbol, or compound like `m + 1`), build a **fresh** list (`create_list()`), materialise the count into an `int` temp, and emit a runtime `while (counter < bound) { result.push(elem); counter++ }` loop. The fresh list removes the off-by-one; a zero/negative count naturally yields an empty list.
2. Rewrote the two count blocks in `list_repetition` to extract the element first, then route **any** non-constant count (symbol or compound) to `create_vla`. The constant fast path is unchanged.

## Testing

- `humaneval_69` flipped FUTURE → CORE; verifies SUCCESSFUL with the issue's flags (`--unwind 9 --no-bounds-check --no-pointer-check --no-align-check`).
- New regression tests (positive + `_fail`), CPython-cross-checked, covering bare-symbol, compound, and left-count repetition.
- `list-repetition-rhs` bumped `--unwind 1` → `2`: its `(len(digits) - 1) * [0]` count is genuinely runtime now and loops once (it previously passed only because the old size-1 bug happened to match the expected size).
- All directly-affected list-repeat tests pass (constant, variable-source, symbolic).

## Known limitation

Repeating a **multi-element** source by a **runtime** count (e.g. `[1, 2] * n`) currently repeats only the first element — a pre-existing gap (the old `create_vla` did the same; this PR strictly improves it). Tracked as a FUTURE test (`regression/python/list-repeat-multielem-nonconst`).
