### PR TITLE
[python] Fix `x in tuple_of_strings` membership (Fixes #5150)

### DIFF
--- a/regression/humaneval/humaneval_78/test.desc
+++ b/regression/humaneval/humaneval_78/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple_str_membership/main.py
+++ b/regression/python/tuple_str_membership/main.py
@@ -1,0 +1,21 @@
+# Membership over a *named* tuple of strings must use element-wise string
+# equality, not a substring search over the tuple's raw bytes (issue #5150).
+def hex_key(num):
+    primes = ('2', '3', '5', '7', 'B', 'D')
+    total = 0
+    for i in range(0, len(num)):
+        if num[i] in primes:
+            total += 1
+    return total
+
+
+def main():
+    primes = ('2', '3', '5', '7', 'B', 'D')
+    assert 'B' in primes
+    assert 'D' in primes
+    assert 'A' not in primes
+    assert 'C' not in primes
+    assert hex_key("AB") == 1
+
+
+main()

--- a/regression/python/tuple_str_membership/test.desc
+++ b/regression/python/tuple_str_membership/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple_str_membership_fail/main.py
+++ b/regression/python/tuple_str_membership_fail/main.py
@@ -1,0 +1,8 @@
+# Negative companion to tuple_str_membership: 'A' is not a prime hex digit, so
+# `'A' in primes` is False and the assertion must fail (issue #5150).
+def main():
+    primes = ('2', '3', '5', '7', 'B', 'D')
+    assert 'A' in primes
+
+
+main()

--- a/regression/python/tuple_str_membership_fail/test.desc
+++ b/regression/python/tuple_str_membership_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -322,28 +322,9 @@ exprt python_converter::handle_membership_operator(
 
     if (tag.starts_with("tag-tuple"))
     {
-      // Check if this is a tuple of strings: if so, delegate to string handler
-      const struct_typet &struct_type = to_struct_type(rhs_resolved_type);
-      bool is_string_tuple = true;
-
-      for (const auto &comp : struct_type.components())
-      {
-        if (!comp.type().is_array() && !comp.type().is_pointer())
-        {
-          is_string_tuple = false;
-          break;
-        }
-      }
-
-      // If tuple contains strings and lhs is a string, use string handler
-      if (is_string_tuple && (lhs.type().is_pointer() || lhs.type().is_array()))
-      {
-        exprt membership_expr =
-          string_handler_.handle_string_membership(lhs, rhs, element);
-        return invert ? not_exprt(membership_expr) : membership_expr;
-      }
-
-      return tuple_handler_->handle_tuple_membership(lhs, rhs, invert);
+      // `x in (a, b, c)` is element-wise equality, with string elements
+      // compared by content. handle_tuple_membership builds the OR chain.
+      return tuple_handler_->handle_tuple_membership(lhs, rhs, invert, element);
     }
   }
 

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -524,7 +524,8 @@ typet tuple_handler::get_tuple_type_from_annotation(
 exprt tuple_handler::handle_tuple_membership(
   const exprt &lhs,
   const exprt &rhs,
-  bool invert) const
+  bool invert,
+  const nlohmann::json &element)
 {
   assert(rhs.type().is_struct());
   const struct_typet &tuple_type = to_struct_type(rhs.type());
@@ -547,14 +548,55 @@ exprt tuple_handler::handle_tuple_membership(
       return false_exprt();
   }
 
-  // Build OR chain: lhs == tuple.element_0 || lhs == tuple.element_1 || ...
+  // Python's `x in (a, b, c)` is element-wise equality: x == a or x == b or ...
+  // Strings are compared by content (strcmp), not by pointer/array identity, so
+  // each string element needs handle_string_comparison rather than equality_exprt.
+  const bool lhs_is_string = lhs.type().is_array() || lhs.type().is_pointer();
+
+  // An inline tuple literal `(a, b, c)` is a struct_exprt whose operands are
+  // already-materialised, addressable element symbols. A member access into
+  // such a constant struct is not addressable, so taking the base address for
+  // strcmp would crash; use the operand directly. A named tuple variable is a
+  // symbol, for which a member access is a proper lvalue.
+  const bool rhs_is_struct_literal =
+    rhs.id() == "struct" && rhs.operands().size() == components.size();
+
   exprt result;
   for (size_t i = 0; i < components.size(); i++)
   {
     std::string member_name = "element_" + std::to_string(i);
-    exprt member_access = build_member(rhs, member_name, components[i].type());
+    exprt member_access =
+      rhs_is_struct_literal
+        ? rhs.operands()[i]
+        : build_member(rhs, member_name, components[i].type());
 
-    exprt equality = equality_exprt(lhs, member_access);
+    const bool comp_is_string =
+      components[i].type().is_array() || components[i].type().is_pointer();
+
+    exprt equality;
+    if (lhs_is_string && comp_is_string)
+    {
+      // String content equality via the shared comparison machinery, which
+      // either folds to a boolean or sets up a strcmp(...) == 0 expression
+      // (signalled by a nil return — assemble it like the binop caller does).
+      exprt l = lhs;
+      exprt r = member_access;
+      equality = converter_.handle_string_comparison("Eq", l, r, element);
+      if (equality.is_nil())
+      {
+        equality = exprt("=", bool_type());
+        equality.copy_to_operands(l, r);
+      }
+    }
+    else if (lhs_is_string != comp_is_string)
+    {
+      // Cross-type: a string is never == a non-string in Python.
+      equality = false_exprt();
+    }
+    else
+    {
+      equality = equality_exprt(lhs, member_access);
+    }
 
     if (i == 0)
       result = equality;

--- a/src/python-frontend/tuple_handler.h
+++ b/src/python-frontend/tuple_handler.h
@@ -89,10 +89,14 @@ public:
    * @param lhs The element to search for
    * @param rhs The tuple to search in
    * @param invert Whether this is "not in" operation
+   * @param element The original AST node (for location and string comparison)
    * @return exprt Boolean expression representing membership test
    */
-  exprt handle_tuple_membership(const exprt &lhs, const exprt &rhs, bool invert)
-    const;
+  exprt handle_tuple_membership(
+    const exprt &lhs,
+    const exprt &rhs,
+    bool invert,
+    const nlohmann::json &element);
 
   /**
    * @brief Create a tuple struct type from element types


### PR DESCRIPTION
## What

Fixes #5150. Python `x in tuple_of_strings` was lowered to a C `strstr` over
the tuple struct treated as a flat byte buffer, which is the wrong semantics:
`x in (a, b, c)` is element-wise equality. For a **named** tuple variable this
produced a malformed haystack address and the wrong answer — e.g.

```python
primes = ('2', '3', '5', '7', 'B', 'D')
'B' in primes      # returned False
```

Inline tuple literals only happened to work via a constant-folding path.
`regression/humaneval/humaneval_78` (`hex_key`) was `KNOWNBUG` because of this.

## How

`tuple_handler::handle_tuple_membership` now builds an OR-chain of per-element
comparisons instead of delegating to `strstr`:

- **string** elements are compared by content via the canonical
  `python_converter::handle_string_comparison` (honouring its nil-return
  contract: assemble `strcmp(...) == 0` from the mutated operands, exactly as
  the existing binop caller does);
- **non-string** elements use `equality_exprt`;
- a **string vs non-string** slot yields `false_exprt()` (different Python types
  are never `==`).

All tuples now route through this one function; the `is_string_tuple`/`strstr`
special-case in `handle_membership_operator` is removed. An inline tuple literal
(`struct_exprt`) uses its already-materialised, addressable element operands
directly, because a member access into a constant struct is not addressable and
taking its base address for `strcmp` crashes the SMT backend. The `const`
qualifier on `handle_tuple_membership` is dropped because the string path
registers `strcmp` in the symbol table.

## Tests

- `regression/humaneval/humaneval_78`: `KNOWNBUG` → `CORE` (now SUCCESSFUL).
- New `regression/python/tuple_str_membership` (passing) and
  `tuple_str_membership_fail` (failing) cover named tuples of strings, both
  `in`/`not in`, and the `hex_key` count.
- Verified no regressions across the tuple/membership/string/set Python suites
  (incl. `github_3137`, `github_3594`, `all6`, `notin*`, `set_*`,
  `cross_type_eq_tuple_str`).

## Known limitation (out of scope)

Membership over a **tuple-typed function parameter** still fails due to a
pre-existing parameter-typing defect (a tuple parameter is mistyped on call);
this is orthogonal to #5150 and affected the old path equally.
