### PR TITLE
[python] Join generator/comprehension iterables via runtime model (Fixes #5123)

### DIFF
--- a/regression/humaneval/humaneval_11/test.desc
+++ b/regression/humaneval/humaneval_11/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
---unwind 1 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/join-generator-expr/main.py
+++ b/regression/python/join-generator-expr/main.py
@@ -1,0 +1,18 @@
+# str.join() of a generator expression / comprehension must join the runtime
+# elements, not fall back to a nondet string. Regression for issue #5123
+# (''.join(xor(x, y) for x, y in zip(a, b))).
+def combine(a: str, b: str, sep: str) -> str:
+    def pick(i: str, j: str) -> str:
+        if i == j:
+            return 'S'
+        else:
+            return 'D'
+    return sep.join(pick(x, y) for x, y in zip(a, b))
+
+
+def main() -> None:
+    assert combine('abc', 'axc', '') == 'SDS'
+    assert combine('abc', 'axc', '-') == 'S-D-S'
+
+
+main()

--- a/regression/python/join-generator-expr/test.desc
+++ b/regression/python/join-generator-expr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/join-generator-expr_fail/main.py
+++ b/regression/python/join-generator-expr_fail/main.py
@@ -1,0 +1,17 @@
+# Negative variant: a wrong expected join result must not verify (guards against
+# the old nondet-string fallback silently "passing").
+def combine(a: str, b: str) -> str:
+    def pick(i: str, j: str) -> str:
+        if i == j:
+            return 'S'
+        else:
+            return 'D'
+    return ''.join(pick(x, y) for x, y in zip(a, b))
+
+
+def main() -> None:
+    # combine('abc', 'axc') == 'SDS'; asserting otherwise must fail.
+    assert combine('abc', 'axc') == 'SSS'
+
+
+main()

--- a/regression/python/join-generator-expr_fail/test.desc
+++ b/regression/python/join-generator-expr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/recursive_join_genexp/test.desc
+++ b/regression/python/recursive_join_genexp/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3
+--unwind 8
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2572,9 +2572,24 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
   // Get the list elements from the AST
   const auto &elements = (*list_node)["elts"];
 
-  // Edge case: empty list returns empty string
+  // Edge case: empty list literal
   if (elements.empty())
   {
+    // A Name variable whose declared initialiser is an empty list may still be
+    // populated at runtime. The preprocessor lowers ''.join(<generator>) and
+    // ''.join(<comprehension>) to `tmp = []` followed by appends, so folding
+    // the empty initialiser here would wrongly yield "". Dispatch to the
+    // runtime __python_str_join model, which reads the list's runtime contents
+    // (and still returns "" for a genuinely empty list).
+    if (list_arg.contains("_type") && list_arg["_type"] == "Name")
+    {
+      log_debug(
+        "python-string",
+        "join() iterable is a runtime-built list: runtime dispatch");
+      exprt list_expr = converter_.get_expr(list_arg);
+      return string_builder_->build_runtime_str_join_call(separator, list_expr);
+    }
+
     typet empty_string_type = type_handler_.build_array(char_type(), 1);
     exprt empty_str = gen_zero(empty_string_type);
     empty_str.operands().at(0) = from_integer(0, char_type());


### PR DESCRIPTION
## What

Fixes #5123 (`regression/humaneval/humaneval_11` KNOWNBUG/FUTURE). `string_xor` does `''.join(xor(x, y) for x, y in zip(a, b))` and returned the wrong result.

The preprocessor lowers `''.join(<generator>)` / `''.join(<comprehension>)` to a temp `ESBMC_listcomp_0 = []` (empty list literal) followed by runtime `append`s, then `''.join(ESBMC_listcomp_0)`. `handle_str_join` matched the empty list initialiser and folded the join to `""` (its `elements.empty()` branch), **ignoring the appended elements** — so the join silently produced an empty (and, on other paths, nondet) string.

## Fix

In `handle_str_join`'s empty-list branch, when the join argument is a `Name` variable (which may be populated at runtime), dispatch to the runtime `__python_str_join` operational model via `get_expr(list_arg)` + `build_runtime_str_join_call(...)`, instead of folding to `""`. This mirrors the existing runtime-dispatch path used for opaque variables. A genuinely empty list still yields `""` (the OM short-circuits on `size == 0`).

## Testing

- `humaneval_11` flipped FUTURE → CORE; verifies SUCCESSFUL with the issue's exact flags (`--unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard`).
- New regression tests (positive + `_fail`) for `sep.join(<genexp over zip>)`, CPython-cross-checked.
- All 56 tests whose source uses `.join(` pass; the empty-list invariant `github_3000_3` (`" ".join([]) == ""`) stays SUCCESSFUL.
- `recursive_join_genexp` bumped `--unwind 3` → `8`: it now genuinely runs the join loop (previously it relied on the no-loop fallback). The runtime model is sound; the larger unwind covers its 7-char elements.

## Notes

Pre-existing, separate bugs remain for some comprehension shapes (e.g. `''.join(c for c in <string>)` char iteration, and comprehensions whose element is a ternary-returning function call, which crash during comprehension lowering independent of `join`). These are not caused by this change and are out of scope for #5123.
