### PR TITLE
[CI] add concurrency limit to push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     name: Build and upload coverage to Codecov


### PR DESCRIPTION
Cancel in-progress coverage runs when a new push to master arrives, so only the latest coverage is uploaded to Codecov.

same as #4734 