### PR TITLE
[goto] Lower dynamic_cast<T&> bad_cast in --lower-exceptions

### DIFF
--- a/docs/design-symbolic-exceptions.md
+++ b/docs/design-symbolic-exceptions.md
@@ -83,10 +83,16 @@ entry/uncaught anchor is `__ESBMC_main` (which wraps `python_user_main`). 26 of 
 `regression/python/exception*`/`try_finally*`/`try_else*` tests lower at 0
 divergences (the rest fall back).
 
-Not yet lowered (fall back): parts of the `std` exception surface;
-`bad_cast` from `dynamic_cast<T&>`; dynamic exception specifications with real
-types (`throw(T...)`, a C++14-only form the frontend rejects under C++17, so it
-forces fallback only under `--std c++14`).
+A failing `dynamic_cast<T&>` lowers to a call to the bodyless intrinsic
+`__ESBMC_throw_bad_cast`; the pass rewrites that call into an ordinary `THROW` of
+a synthesized `std::bad_cast` (mirroring `goto_symext::symex_throw_bad_cast`) so
+the rest of the pipeline lowers it like any other throw. If `<typeinfo>`'s
+`std::bad_cast` is not in the symbol table the call is left in place and the
+program falls back to the imperative path.
+
+Not yet lowered (fall back): parts of the `std` exception surface; dynamic
+exception specifications with real types (`throw(T...)`, a C++14-only form the
+frontend rejects under C++17, so it forces fallback only under `--std c++14`).
 
 **Destructor unwinding** is handled at the GOTO frontend (`convert_throw`), not
 in the lowering pass, so it applies on **both** the imperative and lowered
@@ -103,10 +109,9 @@ ignored on all paths).
 ## Roadmap to default-on
 
 The imperative path can only be removed once the lowered path reaches parity.
-Remaining work, roughly ordered: the broader `std` exception surface; `bad_cast`
-from `dynamic_cast<T&>`. Then: two green full-suite differential runs
-(`--lower-exceptions` ON vs OFF) before flipping the default and deleting
-`symex_catch.cpp`.
+Remaining work, roughly ordered: the broader `std` exception surface. Then: two
+green full-suite differential runs (`--lower-exceptions` ON vs OFF) before
+flipping the default and deleting `symex_catch.cpp`.
 
 ## Testing
 

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_caught/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_caught/main.cpp
@@ -1,0 +1,34 @@
+// A failing dynamic_cast<T&> throws std::bad_cast; under --lower-exceptions the
+// __ESBMC_throw_bad_cast intrinsic is turned into a real THROW and lowered like
+// any other, so the catch is reached.
+#include <typeinfo>
+
+struct B
+{
+  virtual ~B()
+  {
+  }
+};
+struct D1 : B
+{
+};
+struct D2 : B
+{
+};
+
+int main()
+{
+  B *b = new D1();
+  int caught = 0;
+  try
+  {
+    D2 &d = dynamic_cast<D2 &>(*b);
+    (void)d;
+  }
+  catch (std::bad_cast &)
+  {
+    caught = 1;
+  }
+  __ESBMC_assert(caught == 1, "bad_cast was caught");
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_caught/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_caught/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--lower-exceptions
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_uncaught_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_uncaught_fail/main.cpp
@@ -1,0 +1,33 @@
+// A failing dynamic_cast<T&> throws std::bad_cast; a handler for an unrelated
+// type does not catch it, so it escapes -> terminate (uncaught).
+#include <typeinfo>
+
+struct B
+{
+  virtual ~B()
+  {
+  }
+};
+struct D1 : B
+{
+};
+struct D2 : B
+{
+};
+struct Other
+{
+};
+
+int main()
+{
+  B *b = new D1();
+  try
+  {
+    D2 &d = dynamic_cast<D2 &>(*b);
+    (void)d;
+  }
+  catch (Other &)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_uncaught_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_cast_uncaught_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--lower-exceptions
+
+^VERIFICATION FAILED$

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -8,6 +8,8 @@
 #include <util/symbol.h>
 #include <util/migrate.h>
 #include <util/expr_util.h>
+#include <util/std_types.h>
+#include <util/std_expr.h>
 #include <irep2/irep2_utils.h>
 
 namespace
@@ -80,6 +82,10 @@ public:
 
   void run(goto_functionst &goto_functions)
   {
+    // Turn dynamic_cast<T&> bad_cast intrinsics into ordinary THROWs first, so
+    // every later step (may-throw, registry, dispatch) treats them uniformly.
+    lower_bad_cast_calls(goto_functions);
+
     may_throw = compute_may_throw(goto_functions);
 
     // Single scan: teach the registry any exception hierarchy that lives only in
@@ -202,6 +208,72 @@ private:
     sym.file_local = false;
     context.move_symbol_to_context(sym);
     return symbol2tc(obj_type, irep_idt(id));
+  }
+
+  // ---- bad_cast lowering -------------------------------------------------
+
+  /// THROW code for a synthesized std::bad_cast (operand + exception_list =
+  /// dynamic type and its bases), or nil if the <typeinfo> model's class is not
+  /// in the symbol table. Mirrors goto_symext::symex_throw_bad_cast; the tag is
+  /// elaborated ("class std::bad_cast") on newer Clang/LLVM, un-elaborated on
+  /// older, so try both. Built once and reused across call sites (a single
+  /// exception is in flight at a time).
+  expr2tc build_bad_cast_throw()
+  {
+    const symbolt *sym = ns.lookup("tag-std::bad_cast");
+    if (!sym)
+      sym = ns.lookup("tag-class std::bad_cast");
+    if (!sym)
+      return expr2tc();
+
+    std::vector<irep_idt> exception_list;
+    const std::string tag = id2string(sym->id);
+    exception_list.emplace_back(tag.substr(4)); // strip "tag-"
+    if (sym->get_type().id() == "struct")
+    {
+      const struct_typet &st = to_struct_type(sym->get_type());
+      const exprt &bases = static_cast<const exprt &>(st.find("bases"));
+      if (bases.is_not_nil())
+        for (const auto &base : bases.get_sub())
+          exception_list.emplace_back(id2string(base.id()).substr(4));
+    }
+
+    // A static slot holds the thrown bad_cast object (its state is irrelevant —
+    // only its type identity and address matter to the handler).
+    expr2tc operand = make_exception_storage(migrate_symbol_type(*sym));
+    return code_cpp_throw2tc(operand, exception_list);
+  }
+
+  /// Replace each __ESBMC_throw_bad_cast() call — the bodyless intrinsic a
+  /// failing dynamic_cast<T&> lowers to — with the equivalent THROW, so the rest
+  /// of the pass lowers it like any other throw. If std::bad_cast is
+  /// unresolvable the calls are left in place and program_supported's bad_cast
+  /// guard makes the program fall back to the imperative path.
+  void lower_bad_cast_calls(goto_functionst &goto_functions)
+  {
+    expr2tc bad_cast_throw = build_bad_cast_throw();
+    if (is_nil_expr(bad_cast_throw))
+      return;
+
+    for (auto &fn : goto_functions.function_map)
+    {
+      if (!fn.second.body_available)
+        continue;
+      for (auto &ins : fn.second.body.instructions)
+      {
+        if (ins.type != FUNCTION_CALL)
+          continue;
+        const code_function_call2t &c = to_code_function_call2t(ins.code);
+        if (
+          is_symbol2t(c.function) &&
+          to_symbol2t(c.function).thename == "c:@F@__ESBMC_throw_bad_cast")
+        {
+          // make_throw() preserves location/function (clear() leaves them).
+          ins.make_throw();
+          ins.code = bad_cast_throw;
+        }
+      }
+    }
   }
 
   // ---- may-throw analysis ------------------------------------------------


### PR DESCRIPTION
## Summary

Lowers `std::bad_cast` from a failing `dynamic_cast<T&>` under
`--lower-exceptions`, turning the conservative fallback added in #5128 into real
symbolic dispatch.

## Approach

A failing `dynamic_cast<T&>` compiles to a call to the bodyless intrinsic
`__ESBMC_throw_bad_cast` (which symex turns into a `std::bad_cast` throw). Rather
than re-implement the bad_cast handling inside the lowering, the pass **rewrites
that call into an ordinary `THROW`** of a synthesized `std::bad_cast` as its very
first step (operand = a static slot; `exception_list` = the type and its bases,
mirroring `goto_symext::symex_throw_bad_cast`). Every later step — may-throw
analysis, registry registration, dispatch, inter-procedural propagation — then
handles it exactly like any other throw.

If `<typeinfo>`'s `std::bad_cast` is not in the symbol table, the call is left in
place and the existing guard keeps the program on the imperative path.

This is **lowering-only**: the whole change lives in `remove_exceptions.cpp`,
which runs only under `--lower-exceptions`, so the default path is untouched.

## Validation

- The intrinsic call becomes `THROW class std::bad_cast` and the surrounding
  catch lowers to a guarded dispatch (verified in the GOTO).
- `lower-exceptions_bad_cast_caught`: failing cast caught as `std::bad_cast`
  → `SUCCESSFUL`; a wrong assertion on the caught flag → `FAILED` (so the catch
  really runs).
- `lower-exceptions_bad_cast_uncaught_fail`: bad_cast not caught → escapes →
  `FAILED` on both paths.
- All 116 `esbmc-cpp/try_catch` pass; clang-format clean.

(A `dynamic_cast` whose enclosing try body `return`s still falls back — that is a
pre-existing structural limitation of the lowering, not specific to bad_cast.)

Refs #5075
