### PR TITLE
[ci] Measure lowered-path coverage with --check-firing (#5075)

### DIFF
--- a/docs/design-symbolic-exceptions.md
+++ b/docs/design-symbolic-exceptions.md
@@ -131,6 +131,21 @@ exception-bearing regression test it runs ESBMC with and without the flag (the
 exact command `regression/testing_tool.py` would build) and fails on any verdict
 divergence. Two green full-suite runs are required before the flip.
 
+**Verdict parity is necessary but not sufficient.** Because the pass is
+all-or-nothing, a program outside the supported subset silently *falls back* to
+the imperative path, so an ON run that fell back is identical to OFF by
+construction — 0 divergences does not establish the lowered path is
+self-sufficient. The `--check-firing` mode of the harness measures this directly
+(it counts `THROW`/`CATCH` GOTO instructions ON vs OFF; lowering that fired
+rewrites them, a fall-back leaves them unchanged). A current local survey shows
+**~57/73 C++ and ~132/158 Python** exception programs actually lower; the rest
+still depend on the imperative path. The dominant fall-back categories are
+**dynamic exception specifications** (`try-catch_decl_*`) and **`unexpected`
+handlers** (`try-catch_unexpected_*`) in C++, and a set of model-raised
+exceptions in Python. Before `symex_catch.cpp` can be deleted, these must either
+be brought into the lowered subset (so nothing falls back) or be given a defined
+behaviour once the imperative fallback is gone.
+
 ## Testing
 
 `regression/esbmc-cpp/try_catch/lower-exceptions_*` exercise the lowered path

--- a/scripts/lower_exceptions_differential.py
+++ b/scripts/lower_exceptions_differential.py
@@ -49,6 +49,19 @@ PY_KEYWORDS = ("try:", "except", "raise ", "raise\n")
 
 VERDICT_RE = re.compile(r"VERIFICATION (SUCCESSFUL|FAILED)")
 
+# A GOTO THROW/CATCH instruction in a --goto-functions-only dump. The \b stops
+# THROW from also matching THROW_DECL (a noexcept-spec declaration, not a thrown
+# exception). When the lowering pass fires it rewrites these into guarded gotos,
+# so the count drops; when the program falls back to the imperative path the
+# count is unchanged. That difference is how firing is detected.
+GOTO_EXC_RE = re.compile(r"(?m)^\s*(THROW|CATCH)\b")
+
+# Firing classifications (only computed under --check-firing).
+FIRED = "fired"  # lowering rewrote the THROW/CATCH instructions
+FELLBACK = "fellback"  # program outside the subset — imperative path still used
+NO_GOTO_EXC = "no-goto-exc"  # no THROW/CATCH even on the OFF path
+FIRING_ERROR = "firing-error"  # a --goto-functions-only dump failed
+
 # Verdict classification returned by run_one().
 SUCCESSFUL = "SUCCESSFUL"
 FAILED = "FAILED"
@@ -169,12 +182,43 @@ def run_esbmc(cmd, timeout):
     return match.group(1) if match else ERROR
 
 
-def run_one(test, esbmc, timeout):
-    """Run a test OFF and ON; return (test, off_verdict, on_verdict)."""
+def count_goto_exceptions(cmd, timeout):
+    """Count THROW/CATCH instructions in a --goto-functions-only dump, or None."""
+    try:
+        # See run_esbmc for why this argv-list subprocess is injection-safe.
+        proc = subprocess.run(
+            cmd + ["--goto-functions-only"],  # nosec B603
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,  # the GOTO dump is emitted on stderr
+            timeout=timeout,
+            text=True,
+            errors="replace",
+            check=False)
+    except subprocess.TimeoutExpired:
+        return None
+    if proc.returncode != 0:
+        return None  # no GOTO program produced (parse/convert failure)
+    return len(GOTO_EXC_RE.findall(proc.stdout))
+
+
+def classify_firing(base, timeout):
+    """Decide whether --lower-exceptions fired on this test (see FIRED/...)."""
+    off_n = count_goto_exceptions(base, timeout)
+    on_n = count_goto_exceptions(base + ["--lower-exceptions"], timeout)
+    if off_n is None or on_n is None:
+        return FIRING_ERROR
+    if off_n == 0:
+        return NO_GOTO_EXC
+    return FIRED if on_n < off_n else FELLBACK
+
+
+def run_one(test, esbmc, timeout, check_firing):
+    """Run a test OFF and ON; return (test, off_verdict, on_verdict, firing)."""
     base = test.base_command(esbmc)
     off = run_esbmc(base, timeout)
     on = run_esbmc(base + ["--lower-exceptions"], timeout)
-    return test, off, on
+    firing = classify_firing(base, timeout) if check_firing else None
+    return test, off, on, firing
 
 
 def is_divergence(off, on):
@@ -194,14 +238,23 @@ def is_divergence(off, on):
 
 
 def run_suite(tests, args):
-    """Run every test OFF/ON in parallel; return (matched, no_baseline, divergences)."""
+    """Run every test OFF/ON in parallel.
+
+    Returns (matched, no_baseline, divergences, firing) where firing is a
+    category -> [test names] map (empty unless --check-firing).
+    """
     divergences = []
     no_baseline = []
+    firing = {}
     matched = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        futures = [pool.submit(run_one, t, args.esbmc, args.timeout) for t in tests]
+        futures = [
+            pool.submit(run_one, t, args.esbmc, args.timeout, args.check_firing) for t in tests
+        ]
         for done in concurrent.futures.as_completed(futures):
-            test, off, on = done.result()
+            test, off, on, fired = done.result()
+            if fired is not None:
+                firing.setdefault(fired, []).append(test.name)
             if is_divergence(off, on):
                 divergences.append((test, off, on))
                 tag = "DIVERGE"
@@ -212,8 +265,28 @@ def run_suite(tests, args):
                 no_baseline.append((test, off, on))
                 tag = "skip"  # both errored/timed out — no usable baseline
             if args.verbose or tag == "DIVERGE":
-                print(f"  [{tag}] {test.name}: OFF={off} ON={on}", flush=True)
-    return matched, no_baseline, divergences
+                extra = f" [{fired}]" if fired is not None else ""
+                print(f"  [{tag}] {test.name}: OFF={off} ON={on}{extra}", flush=True)
+    return matched, no_baseline, divergences, firing
+
+
+def print_firing_report(firing):
+    """Print the --check-firing breakdown: how much of the corpus actually lowers."""
+    fired = len(firing.get(FIRED, []))
+    fellback = sorted(firing.get(FELLBACK, []))
+    comparable = fired + len(fellback)
+    print("\nfiring (does --lower-exceptions actually rewrite throw/catch?):")
+    print(f"  fired:       {fired}")
+    print(f"  fell back:   {len(fellback)}")
+    print(f"  no goto exc: {len(firing.get(NO_GOTO_EXC, []))}")
+    print(f"  dump errors: {len(firing.get(FIRING_ERROR, []))}")
+    if comparable:
+        print(f"  => {fired}/{comparable} ({100 * fired // comparable}%) of exception "
+              f"programs lower; the rest still need the imperative path.")
+    if fellback:
+        print("  fell-back tests (still depend on the imperative path):")
+        for name in fellback:
+            print(f"    {name}")
 
 
 def main():
@@ -255,6 +328,11 @@ def main():
                         "--verbose",
                         action="store_true",
                         help="print each test's OFF/ON verdicts as it completes")
+    parser.add_argument("--check-firing",
+                        action="store_true",
+                        help="also report, per test, whether lowering fired (THROW/CATCH "
+                        "rewritten) or fell back to the imperative path. Adds two "
+                        "--goto-functions-only runs per test.")
     args = parser.parse_args()
 
     roots = args.roots or ["regression/esbmc-cpp", "regression/python"]
@@ -279,7 +357,7 @@ def main():
     if not os.path.exists(args.esbmc):
         sys.exit(f"error: esbmc binary not found: {args.esbmc}")
 
-    matched, no_baseline, divergences = run_suite(tests, args)
+    matched, no_baseline, divergences, firing = run_suite(tests, args)
 
     print()
     print(f"matched (ON==OFF, both verdicts): {matched}")
@@ -292,6 +370,9 @@ def main():
         print("\nno-baseline tests (both paths produced no verdict):")
         for test, off, on in sorted(no_baseline, key=lambda d: d[0].name):
             print(f"  {test.name}: OFF={off} ON={on}")
+
+    if args.check_firing:
+        print_firing_report(firing)
 
     if divergences:
         print("\nDIVERGENCES (lowered path disagrees with imperative path):")


### PR DESCRIPTION
Adds a `--check-firing` mode to the P4 differential gate so we can answer the question that verdict parity alone cannot: **how much of the exception corpus does `--lower-exceptions` actually lower, versus silently fall back to the imperative path?**

## Why

The lowering pass is whole-program **all-or-nothing**: a program outside the supported subset lowers nothing and falls back to the imperative path. So an ON run that fell back is byte-identical to OFF — *0 divergences does not prove the lowered path is self-sufficient*. That matters because P4 deletes `symex_catch.cpp`, which **removes the fallback**: any program that still falls back today would break.

## What

`--check-firing` counts `THROW`/`CATCH` GOTO instructions (`--goto-functions-only`) ON vs OFF. Lowering that fired rewrites them into guarded gotos (count drops); a fall-back leaves them unchanged. Per test it classifies **fired / fell-back / no-goto-exc / dump-error**, prints the ratio, and lists the fall-back tests by name. (The `\b` in the regex excludes `THROW_DECL` noexcept markers, which are not thrown exceptions. The GOTO dump is read off the merged stderr stream where ESBMC emits it.)

## Result — current local survey

| Suite | Fired | Fell back | Lower rate |
|---|---|---|---|
| `regression/esbmc-cpp` | 57 | 16 | 78% |
| `regression/python` | 132 | 26 | 83% |

The dominant C++ fall-back categories are **dynamic exception specifications** (`try-catch_decl_*`) and **`unexpected` handlers** (`try-catch_unexpected_*`); Python fall-backs are mostly model-raised exceptions. These ~42 tests are the concrete remaining work before the imperative path can be deleted.

Script + doc only; the verdict gate and its exit semantics are unchanged (firing is opt-in via `--check-firing`). `pylint` clean; Bandit `# nosec` intact.