### PR TITLE
[goto] Lower dynamic exception specifications in --lower-exceptions (#5075)

### DIFF
--- a/docs/design-symbolic-exceptions.md
+++ b/docs/design-symbolic-exceptions.md
@@ -71,11 +71,15 @@ single-inheritance base-by-value slicing), pointer (`catch (T*)`) and `void*`
 catches, and catch-all; nested try with inner→outer propagation; inter-procedural
 propagation through direct and indirect calls; rethrow; uncaught detection at both
 `main` and `__ESBMC_main` (the latter covers exceptions from global constructors
-during static initialisation); and `noexcept` / `throw()` enforcement (an exception
-escaping a no-throw function → terminate, asserted at its epilogue). Reaching
-outside the subset makes the whole program fall back to the imperative path. About
-**47 of 67** `regression/esbmc-cpp/try_catch` CORE tests currently lower, at 0
-differential divergences.
+during static initialisation); `noexcept` / `throw()` enforcement (an exception
+escaping a no-throw function → terminate, asserted at its epilogue); and
+**dynamic exception specifications** (`throw(T...)`): the epilogue check
+generalises the noexcept one — an exception in flight whose type is not in the
+specification's allowed set (`__ESBMC_exc_typeid ∈ { id(U) : U <: some listed T }`)
+is a specification violation. This mirrors the imperative path, which reports an
+out-of-spec escape as "not allowed by declaration" (`std::unexpected` / handler
+dispatch is modelled on neither path). Reaching outside the subset makes the whole
+program fall back to the imperative path.
 
 **Python** lowers too: try/except/raise share the same THROW/CATCH machinery, the
 registry ingests Python exception ancestry from THROW `exception_list`s, and the
@@ -102,9 +106,10 @@ model, so such programs need an `--unwind` bound; and the frontend can omit
 intermediate bases from the flattened chain, so a catch on a mid-hierarchy base
 may not match — a frontend chain-completeness matter, not a lowering one.)
 
-Not yet lowered (fall back): dynamic exception specifications with real types
-(`throw(T...)`, a C++14-only form the frontend rejects under C++17, so it forces
-fallback only under `--std c++14`).
+Not yet lowered (fall back): a residual set including `dynamic_cast<T&>`/`bad_cast`
+(see above) and `std::bad_exception` value-catches. Dynamic exception
+specifications themselves now lower (above); the `try-catch_decl_*` /
+`try-catch_unexpected_*` tests exercise them.
 
 **Destructor unwinding** is handled at the GOTO frontend (`convert_throw`), not
 in the lowering pass, so it applies on **both** the imperative and lowered

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec/main.cpp
@@ -1,0 +1,21 @@
+// A dynamic exception specification throw(char): the function throws a char,
+// which IS permitted, so it escapes legally and is caught by main. The lowering
+// enforces the spec at the function epilogue (typeid in { id(char) }), so an
+// in-spec escape passes the check and propagates normally.
+void f() throw(char)
+{
+  throw 'x';
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (char)
+  {
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--lower-exceptions --std c++03
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec_fail/main.cpp
@@ -1,0 +1,23 @@
+// A dynamic exception specification throw(char): the function throws an int,
+// which is NOT permitted, so the exception escapes the function out-of-spec.
+// The lowering asserts at the epilogue that any in-flight exception's type is
+// in the spec; an int is not, so the specification is violated ([except.spec]).
+// (This mirrors the imperative path, which reports an out-of-spec escape as
+// "not allowed by declaration"; unexpected() dispatch is modelled on neither.)
+void f() throw(char)
+{
+  throw 5;
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (...)
+  {
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_spec_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--lower-exceptions --std c++03
+
+^VERIFICATION FAILED$
+exception specification violated

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -22,18 +22,6 @@ bool is_pointer_catch(const irep_idt &type)
   return type.as_string().find("_ptr") != std::string::npos;
 }
 
-/// A THROW_DECL marking a *no-throw* specification (`noexcept` or `throw()`):
-/// its list is empty or names only the "noexcept" marker. A list naming real
-/// types is a dynamic exception specification (throw(T...), C++14-only) which
-/// the lowering does not model.
-bool is_no_throw_decl(const expr2tc &code)
-{
-  for (const irep_idt &t : to_code_cpp_throw_decl2t(code).exception_list)
-    if (t != noexcept_id)
-      return false;
-  return true;
-}
-
 /// One catch clause: its static type (or "ellipsis"), the instruction that
 /// begins its handler, and — once lowered — the landing instruction the
 /// dispatch branches to (which clears the in-flight flag before the body).
@@ -106,6 +94,15 @@ public:
           const code_cpp_throw2t &t = to_code_cpp_throw2t(ins.code);
           if (!is_nil_expr(t.operand))
             registry.register_chain(t.exception_list);
+        }
+        else if (ins.type == THROW_DECL)
+        {
+          // A dynamic exception specification's allowed types must each have an
+          // id so the epilogue can test the in-flight exception's membership.
+          for (const irep_idt &ty :
+               to_code_cpp_throw_decl2t(ins.code).exception_list)
+            if (ty != noexcept_id)
+              registry.register_chain({ty});
         }
         else if (ins.type == FUNCTION_CALL)
         {
@@ -328,12 +325,9 @@ private:
     int depth = 0;
     for (auto it = body.instructions.begin(); it != end; ++it)
     {
-      // A dynamic exception specification with real types (throw(T...)) routes
-      // a non-listed throw to unexpected/terminate, which is not modelled —
-      // leave such a program to the imperative path. A no-throw spec
-      // (noexcept / throw()) is fine: it is enforced at the function epilogue.
-      if (it->type == THROW_DECL && !is_no_throw_decl(it->code))
-        return false;
+      // Both no-throw specs (noexcept / throw()) and dynamic exception
+      // specifications (throw(T...)) are enforced at the function epilogue
+      // (see lower_ip), so a THROW_DECL never forces fallback.
       if (it->type == CATCH && !it->targets.empty())
       {
         const code_cpp_catch2t &c = to_code_cpp_catch2t(it->code);
@@ -468,15 +462,21 @@ private:
     collect(body, regions, throws, calls);
 
     // Throw-spec markers are consumed here; once the throws are lowered the
-    // imperative throw-decl machinery has nothing to act on. Record whether the
-    // function is no-throw in the same pass.
-    bool noexcept_fn = false;
+    // imperative throw-decl machinery has nothing to act on. Record the
+    // function's exception specification (if any) in the same pass: `has_spec`
+    // is set by any THROW_DECL, and `spec_types` collects its allowed types
+    // (empty for a no-throw spec — noexcept / throw()).
+    bool has_spec = false;
+    std::vector<irep_idt> spec_types;
     for (auto &ins : body.instructions)
     {
       if (ins.type == THROW_DECL)
       {
-        if (is_no_throw_decl(ins.code))
-          noexcept_fn = true;
+        has_spec = true;
+        for (const irep_idt &ty :
+             to_code_cpp_throw_decl2t(ins.code).exception_list)
+          if (ty != noexcept_id)
+            spec_types.push_back(ty);
         ins.make_skip();
       }
       else if (ins.type == THROW_DECL_END)
@@ -510,20 +510,34 @@ private:
     // An exception in flight at the epilogue is a hard failure in two cases:
     //  - main / __ESBMC_main: it is uncaught (escapes the program → terminate);
     //    __ESBMC_main also covers static-init throws from global constructors.
-    //  - a noexcept function: the exception escapes the no-throw boundary →
-    //    terminate ([except.spec]). A locally-caught throw clears `thrown`, so
-    //    this fires only on a genuine escape.
+    //  - an exception specification is violated: the escaping exception's type
+    //    is not permitted by the function's `throw(...)` / noexcept declaration
+    //    ([except.spec]). A no-throw spec permits nothing, so any escape fails;
+    //    a dynamic spec permits its listed types (and their subtypes). This
+    //    mirrors the imperative path, which reports an escaping out-of-spec
+    //    throw as "not allowed by declaration" (unexpected()/handler dispatch is
+    //    not modelled on either path). A locally-caught throw clears `thrown`,
+    //    so the check fires only on a genuine escape.
     const bool is_entry =
       id2string(fn_id).rfind("c:@F@main#", 0) == 0 || fn_id == "__ESBMC_main";
-    if (is_entry || noexcept_fn)
+    if (is_entry || has_spec)
     {
+      // The assertion is `!thrown || in_spec`; for an uncaught (entry) or
+      // no-throw boundary `in_spec` is empty, leaving the original `!thrown`.
+      expr2tc not_thrown = equality2tc(thrown, gen_false_expr());
+      expr2tc in_spec = is_entry ? expr2tc() : spec_guard(spec_types);
       auto a = body.insert(std::next(epilogue));
-      a->make_assertion(equality2tc(thrown, gen_false_expr()));
+      a->make_assertion(
+        is_nil_expr(in_spec) ? not_thrown : or2tc(not_thrown, in_spec));
       a->location = epilogue->location;
       a->function = epilogue->function;
       a->location.property("exception");
+      // A no-throw spec (empty allowed set) keeps the distinct "noexcept"
+      // wording; a dynamic spec reports a specification violation.
       a->location.comment(
-        is_entry ? "uncaught exception" : "noexcept specification violated");
+        is_entry             ? "uncaught exception"
+        : spec_types.empty() ? "noexcept specification violated"
+                             : "exception specification violated");
     }
 
     body.update();
@@ -630,6 +644,23 @@ private:
       disj = is_nil_expr(disj) ? eq : or2tc(disj, eq);
     }
     return is_nil_expr(disj) ? gen_false_expr() : disj;
+  }
+
+  /// `__ESBMC_exc_typeid ∈ { id(T) : T <: some allowed type }` — the in-flight
+  /// exception is permitted by a dynamic exception specification. Nil when the
+  /// specification allows nothing (a no-throw spec), so callers fall back to the
+  /// plain `!thrown` boundary check.
+  expr2tc spec_guard(const std::vector<irep_idt> &spec_types)
+  {
+    expr2tc disj;
+    for (const irep_idt &t : spec_types)
+      for (unsigned id : registry.concrete_subtype_ids(t))
+      {
+        expr2tc eq =
+          equality2tc(type_id, constant_int2tc(type_id->type, BigInt(id)));
+        disj = is_nil_expr(disj) ? eq : or2tc(disj, eq);
+      }
+    return disj;
   }
 
   /// Replace a throw with: arm the globals (or, for a rethrow, just re-raise


### PR DESCRIPTION
Brings C++ **dynamic exception specifications** (`void f() throw(char)`) into the `--lower-exceptions` lowered path — the largest remaining fall-back category on the road to deleting the imperative exception path (issue #5075). Identified via the `--check-firing` survey (PR #5177): these `try-catch_decl_*` / `try-catch_unexpected_*` tests were the dominant set still depending on the imperative path.

## Key observation

ESBMC’s imperative path does **not** model `std::unexpected()` / handler dispatch. It treats an exception *escaping* a function whose type is not in the spec as a hard property violation — "Trying to throw an exception but it’s not allowed by declaration". `set_unexpected` is ignored on that path.

That makes the lowering the **exact generalisation of the existing noexcept epilogue check**:

| spec | epilogue assertion |
|---|---|
| `noexcept` / `throw()` | `!thrown` |
| `throw(T...)` | `!thrown \|\| __ESBMC_exc_typeid ∈ { id(U) : U <: some listed T }` |

A locally-caught throw clears `thrown`, so the check fires only on a genuine escape (e.g. `decl_02` catches its `float` locally and escapes an in-spec `char`).

## Change (`src/goto-programs/remove_exceptions.cpp`)

1. Register each `THROW_DECL` spec type so its id exists (`register_chain({ty})`, single-element so no false base relations).
2. Drop the dynamic-spec bail in `program_supported`.
3. Generalise the epilogue check via a new `spec_guard` helper (mirrors `match_guard`); keep the distinct "noexcept specification violated" wording for the empty allowed-set.

## Validation

- Full `regression/esbmc-cpp` differential (ON vs OFF `--lower-exceptions`): **0 divergences**; C++ firing **57 → 67 (91%)**; every `try-catch_decl_*` / `try-catch_unexpected_*` now lowers and matches the imperative verdict.
- `try_catch` regression suite green; two new tests `lower-exceptions_throw_spec{,_fail}`.
- **Mode C**: C-Live discharged by `lower-exceptions_throw_spec_fail` (new epilogue assertion fires, non-vacuous VCC, FAILED on Bitwuzla); C-Dead implicitly discharged by the pre-existing `try-catch_decl_*` reproducers. Z3 dual-solver agreement to be confirmed by this PR’s Linux CI (no Z3 in the local macOS build).
- `code-reviewer`: no high-confidence issues (subtype direction, nil-guarded assertion, registration ordering all verified).

The `lower-exceptions-differential` workflow will run automatically (this touches `remove_exceptions.cpp`).