### PR TITLE
[python] Fix float() of conditionally-retyped variable folding to 0.0

### DIFF
--- a/regression/humaneval/humaneval_137/test.desc
+++ b/regression/humaneval/humaneval_137/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_cond_retype-fail/main.py
+++ b/regression/python/float_cond_retype-fail/main.py
@@ -1,0 +1,14 @@
+# Negative variant of #5161: pin the checker boundary. larger(1, 2) computes 2,
+# so asserting it equals 1 must report VERIFICATION FAILED. If float() ever
+# regresses to folding to 0.0 (making both branches collapse), this guards it.
+
+
+def larger(a, b):
+    t = a
+    if isinstance(t, str):
+        t = t.replace(',', '.')
+    return a if float(t) > float(b) else b
+
+
+if __name__ == "__main__":
+    assert larger(1, 2) == 1

--- a/regression/python/float_cond_retype-fail/test.desc
+++ b/regression/python/float_cond_retype-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/float_cond_retype/main.py
+++ b/regression/python/float_cond_retype/main.py
@@ -1,0 +1,15 @@
+# Regression for #5161: float() applied to a numeric variable that is only
+# conditionally reassigned a string (e.g. inside `if isinstance(x, str)`) must
+# emit a numeric cast, not fold to 0.0 from the variable's stale string value.
+
+
+def larger(a, b):
+    t = a
+    if isinstance(t, str):
+        t = t.replace(',', '.')
+    return a if float(t) > float(b) else b
+
+
+if __name__ == "__main__":
+    assert larger(1, 2) == 2
+    assert larger(5, 3) == 5

--- a/regression/python/float_cond_retype/test.desc
+++ b/regression/python/float_cond_retype/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -760,8 +760,16 @@ exprt function_call_expr::build_constant_from_arg() const
   else if (func_name == "float" && arg["_type"] == "Name")
   {
     const symbolt *sym = lookup_python_symbol(arg["id"]);
+    // Only take the constant-string fast path when the variable is genuinely
+    // string-typed here. A numeric variable conditionally reassigned a string
+    // (e.g. `if isinstance(x, str): x = x.replace(...)`) leaves a stale string
+    // value on its symbol even on paths where it stays numeric; keying off the
+    // value alone would mis-route float(x) into string parsing and fold it to
+    // 0.0 (#5161). Gate on the declared type so such cases fall through to the
+    // numeric typecast in the else branch.
     if (
       sym && sym->get_value().is_constant() &&
+      type_utils::is_string_type(sym->get_type()) &&
       type_utils::is_string_type(sym->get_value().type()))
       return handle_str_symbol_to_float(sym);
     else


### PR DESCRIPTION
## Summary

Fixes #5161 (part of #4807). `regression/humaneval/humaneval_137` was marked `KNOWNBUG`: ESBMC reported `VERIFICATION FAILED` on `assert compare_one(1, 2) == 2`, which should be `SUCCESSFUL`.

## Root cause

The Python `float()` builtin handler decided whether to perform a **string→float** conversion from the argument symbol's *stored constant value* (`sym->get_value()`), which is **flow-insensitive**. When a variable is conditionally reassigned a string —

```python
temp_a, temp_b = a, b
if isinstance(temp_a, str): temp_a = temp_a.replace(',', '.')
...
if float(temp_a) == float(temp_b): return None
return a if float(temp_a) > float(temp_b) else b
```

— the symbol carries a stale string value even on the path where it stays numeric. `float(temp_a)` then parsed that stale value and folded to literal `0.000000`, so `float(temp_a) == float(temp_b)` became `0.0 == 0.0` (always true) and `compare_one` always returned `None`.

## Fix

In the `float(<Name>)` branch of `src/python-frontend/function_call/expr.cpp`, gate the constant-string fast path on the symbol's **declared type** as well, so numeric variables with a stale string value fall through to the existing `else` branch (which keys off `get_expr(arg).type()` and emits `(double)x`).

The change only *tightens* an existing guard, so it can never make the fast path fire spuriously — it only reroutes type-inconsistent (unsound-to-fold) cases to the flow-aware path. Genuine constant strings (`s = "3.14"`, declared-string) still take the fast path unchanged.

## Tests

- `regression/humaneval/humaneval_137/test.desc`: `KNOWNBUG` → `CORE`.
- New focused pair `regression/python/float_cond_retype` (CORE, SUCCESSFUL) and `float_cond_retype-fail` (CORE, FAILED) isolating the float()-of-conditionally-retyped-variable pattern and pinning the checker boundary.

## Verification

- humaneval_137 with the issue's flags → `VERIFICATION SUCCESSFUL`; both new tests behave as expected.
- All 245 float-related regression tests pass (100%); legitimate `float("3.14")` and `def f(s: str): float(s)` still pass.