### PR TITLE
[python] Model str.partition() as a 3-tuple (Fixes #5114)

### DIFF
--- a/regression/python/github_5114_partition/main.py
+++ b/regression/python/github_5114_partition/main.py
@@ -1,0 +1,25 @@
+# Issue #5114: str.partition(sep) must return the (before, sep, after) 3-tuple,
+# not a mistyped 1-element scalar. Verify the tuple shape, contents (separator
+# found and not found), len(), indexing and unpacking all match CPython.
+def main() -> None:
+    t = "a.b.c".partition(".")
+    assert len(t) == 3
+    assert t[0] == "a"
+    assert t[1] == "."
+    assert t[2] == "b.c"
+
+    # Separator not found: (whole, "", "")
+    u = "a-b-c".partition(".")
+    assert len(u) == 3
+    assert u[0] == "a-b-c"
+    assert u[1] == ""
+    assert u[2] == ""
+
+    # Tuple unpacking
+    before, sep, after = "key=value".partition("=")
+    assert before == "key"
+    assert sep == "="
+    assert after == "value"
+
+
+main()

--- a/regression/python/github_5114_partition/test.desc
+++ b/regression/python/github_5114_partition/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5114_partition_fail/main.py
+++ b/regression/python/github_5114_partition_fail/main.py
@@ -1,0 +1,8 @@
+# Issue #5114: ESBMC used to model str.partition() as a 1-element result, which
+# made this false assertion provable (unsound). The real length is 3, so the
+# expected verdict is VERIFICATION FAILED.
+def main() -> None:
+    assert len("a.b.c".partition(".")) == 1
+
+
+main()

--- a/regression/python/github_5114_partition_fail/test.desc
+++ b/regression/python/github_5114_partition_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -733,6 +733,17 @@ exprt function_call_builder::build() const
     if (arg_expr.type().is_signedbv() || arg_expr.type().is_unsignedbv())
       return from_integer(1, long_long_int_type());
 
+    // len() of a tuple-typed expression (e.g. an inline str.partition() result
+    // that is not bound to a Name, so the __ESBMC_len_tuple routing above never
+    // fires) is the number of components. Without this the call falls through to
+    // strlen() and reports the wrong length (#5114).
+    if (arg_expr.type().id() == "struct")
+    {
+      const struct_typet &struct_type = to_struct_type(arg_expr.type());
+      if (struct_type.tag().as_string().find("tag-tuple") == 0)
+        return from_integer(struct_type.components().size(), size_type());
+    }
+
     exprt len_string_fast_path =
       converter_.get_string_handler().try_handle_len_string_fast_path(
         call_, arg_expr);

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -358,6 +358,15 @@ std::string python_annotation<Json>::get_string_method_return_type(
   if (method == "split")
     return "list";
 
+  // partition() returns a 3-tuple (before, sep, after). Map it to "tuple",
+  // which resolves to an empty type so the concrete struct type of the 3-tuple
+  // produced by handle_string_partition is copied onto the target symbol.
+  // Mapping it to the default "str" mistypes the target as a scalar char, which
+  // makes len()/subscript on the result wrong (unsound — proves false
+  // assertions, #5114).
+  if (method == "partition")
+    return "tuple";
+
   // Keep previous behavior for unmapped string methods.
   return "str";
 }

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -2546,6 +2546,32 @@ exprt string_handler::handle_string_partition(
   const exprt &sep_arg,
   const locationt &location)
 {
+  // Build a 3-tuple (before, sep, after) as a struct tagged like a regular
+  // Python tuple ("tag-tuple_..."). The tag is what lets the assignment target
+  // fixup, len(), and subscript recognise the result as a tuple rather than a
+  // string; without it the result is mistyped as a scalar char and len()/index
+  // give wrong answers (unsound, #5114). The tag/component layout mirrors
+  // tuple_handler::create_tuple_struct_type.
+  auto make_tuple3 =
+    [&](const exprt &a, const exprt &b, const exprt &c) -> exprt {
+    struct_typet tuple_type;
+    const std::array<const exprt *, 3> elems = {&a, &b, &c};
+    std::string tag = "tag-tuple";
+    for (size_t i = 0; i < elems.size(); ++i)
+    {
+      const std::string comp_name = "element_" + std::to_string(i);
+      tuple_type.components().push_back(
+        struct_typet::componentt(comp_name, comp_name, elems[i]->type()));
+      tag += "_" + elems[i]->type().to_string();
+    }
+    tuple_type.tag(tag);
+
+    struct_exprt tuple_expr(tuple_type);
+    tuple_expr.operands() = {a, b, c};
+    tuple_expr.location() = location;
+    return tuple_expr;
+  };
+
   std::string input;
   std::string sep;
   if (
@@ -2567,17 +2593,7 @@ exprt string_handler::handle_string_partition(
     exprt empty_a = string_builder_->build_string_literal("");
     exprt empty_b = string_builder_->build_string_literal("");
     exprt empty_c = string_builder_->build_string_literal("");
-    struct_typet tuple_type;
-    tuple_type.components().push_back(
-      struct_typet::componentt("element_0", empty_a.type()));
-    tuple_type.components().push_back(
-      struct_typet::componentt("element_1", empty_b.type()));
-    tuple_type.components().push_back(
-      struct_typet::componentt("element_2", empty_c.type()));
-    struct_exprt tuple_expr(tuple_type);
-    tuple_expr.operands() = {empty_a, empty_b, empty_c};
-    tuple_expr.location() = location;
-    return tuple_expr;
+    return make_tuple3(empty_a, empty_b, empty_c);
   }
   if (sep.empty())
     throw std::runtime_error("partition() separator cannot be empty");
@@ -2606,18 +2622,7 @@ exprt string_handler::handle_string_partition(
   exprt mid_expr = string_builder_->build_string_literal(mid);
   exprt after_expr = string_builder_->build_string_literal(after);
 
-  struct_typet tuple_type;
-  tuple_type.components().push_back(
-    struct_typet::componentt("element_0", before_expr.type()));
-  tuple_type.components().push_back(
-    struct_typet::componentt("element_1", mid_expr.type()));
-  tuple_type.components().push_back(
-    struct_typet::componentt("element_2", after_expr.type()));
-
-  struct_exprt tuple_expr(tuple_type);
-  tuple_expr.operands() = {before_expr, mid_expr, after_expr};
-  tuple_expr.location() = location;
-  return tuple_expr;
+  return make_tuple3(before_expr, mid_expr, after_expr);
 }
 
 exprt string_handler::handle_string_isalnum(


### PR DESCRIPTION
## Problem

ESBMC's Python frontend mis-modeled `str.partition(sep)`. Instead of the `(before, sep, after)` 3-tuple, the result was typed as `str`, so the assignment target became a scalar `char` and `len()`/indexing on it produced wrong answers. As a result ESBMC **proved false assertions** — an unsoundness (missed counterexample), even for a constant-literal receiver:

```python
def main() -> None:
    assert len("a.b.c".partition(".")) == 1   # FALSE in CPython (len is 3)
main()
# before: VERIFICATION SUCCESSFUL  (wrong)
```

## Root cause

The defect was split across three spots:

1. `get_string_method_return_type()` mapped `partition` to the default `"str"`, mistyping the target symbol as a scalar char.
2. `handle_string_partition()` built its 3-tuple `struct_exprt` **without the `tag-tuple` tag**. The assignment-target fixup (`converter_stmt.cpp`), `len()`, and subscript all key off that tag to recognize a value as a tuple, so an untagged struct was treated as a string.
3. `len()` of an **inline** (unbound) `partition()` result fell through to `strlen`, because the tuple-`len` routing only fires for a `Name` argument.

## Fix

1. Map `partition` to `"tuple"` (resolves to an empty type, so the concrete struct type is copied onto the target by the existing tuple fixup).
2. Tag the 3-tuple struct like a regular Python tuple, mirroring `tuple_handler::create_tuple_struct_type` (shared `make_tuple3` lambda for both the constant and separator-not-found paths).
3. In the `len()` builder, return the component count for a tuple-typed (`tag-tuple`) argument expression.

## Why it is correct

The fix makes `partition()` produce exactly the same tagged tuple representation as a literal `(a, b, c)` tuple, so `len()`, indexing, and unpacking all follow the existing, tested tuple paths. Matches CPython semantics for both the separator-found and separator-not-found cases:

```
>>> "a.b.c".partition(".")   -> ('a', '.', 'b.c'),  len 3
>>> "a-b-c".partition(".")   -> ('a-b-c', '', ''),  len 3
```

## Validation

- New regression tests: `regression/python/github_5114_partition` (SUCCESSFUL — checks contents, `len`, indexing, unpacking, separator-not-found) and `github_5114_partition_fail` (FAILED — the issue's false assertion).
- `ctest` over all `string`, `tuple`, `unpack`, and `split` Python tests: **835 passed, 0 failed**.
- CPython sanity (`scripts/check_python_tests.sh github_5114`): both tests behave as expected.
- clang-format (Clang 11) clean.

## Known limitation (separate, pre-existing)

Inline subscript of a **heterogeneous string-element tuple literal** at a non-zero index — e.g. `("a", ".", "b.c")[2]` and `"a.b.c".partition(".")[2]` — hits a pre-existing `Unrecognized address_of operand` error in the SMT backend (reproducible with a plain tuple literal, independent of this change). After this fix that case errors instead of silently returning a wrong verdict, so it is no longer unsound. The common forms (assign-then-index, unpacking, inline `[0]`/`[1]`, `len`) are all fixed here.

Fixes #5114
