### PR TITLE
[goto] Lower try blocks with a pruned CATCH pop in --lower-exceptions (#5075)

### DIFF
--- a/docs/design-symbolic-exceptions.md
+++ b/docs/design-symbolic-exceptions.md
@@ -64,6 +64,16 @@ interoperate across a call, so unless every function is in the supported subset
 - `throw;` (rethrow) re-raises from the globals;
 - asserts *uncaught* at `main`'s epilogue.
 
+**Unclosed-region rebalancing.** `remove_unreachable` runs before this pass and
+prunes the empty `CATCH` pop + skip-GOTO of a try whose body cannot complete
+normally — the common `try: <op that raises>; assert False; except E:` idiom,
+where a model- or user-raised throw makes the fall-through dead. That leaves the
+`CATCH` push unbalanced, which the positional region recovery cannot pair.
+`rebalance_removed_pops` re-inserts a synthetic pop + skip-GOTO before each
+unclosed push's first handler, restoring the balanced shape. Because a push only
+goes unclosed when its normal-completion path is unreachable, the synthetic
+skip-GOTO sits on a dead path and its target is immaterial.
+
 ## Supported subset (current)
 
 Lowered: C++ class **and primitive** throws (`throw 1`); reference, value (incl.
@@ -79,9 +89,12 @@ differential divergences.
 
 **Python** lowers too: try/except/raise share the same THROW/CATCH machinery, the
 registry ingests Python exception ancestry from THROW `exception_list`s, and the
-entry/uncaught anchor is `__ESBMC_main` (which wraps `python_user_main`). 26 of 29
-`regression/python/exception*`/`try_finally*`/`try_else*` tests lower at 0
-divergences (the rest fall back).
+entry/uncaught anchor is `__ESBMC_main` (which wraps `python_user_main`). All
+comparable `regression/python` exception tests lower at 0 divergences (including
+model-raised exceptions — a `KeyError` from `del d[k]`, a `TypeError` from
+mutating a tuple, a `ValueError` from `math.factorial(-1)` — and the common
+`try: <raises>; assert False; except E:` idiom; see *unclosed-region rebalancing*
+below).
 
 A failing `dynamic_cast<T&>` lowers to a call to the bodyless intrinsic
 `__ESBMC_throw_bad_cast`; the pass rewrites that call into an ordinary `THROW` of

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_dead_after_throw/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_dead_after_throw/main.cpp
@@ -1,0 +1,21 @@
+// Dead code after an unconditional throw makes the try's normal-completion path
+// unreachable, so remove_unreachable prunes the try's empty-CATCH pop, leaving
+// the region unbalanced. The lowering rebalances the unclosed region before
+// recovering it (#5075). The throw is caught, so this verifies SUCCESSFUL.
+#include <cassert>
+
+int main()
+{
+  int x = 0;
+  try
+  {
+    throw 1;
+    x = 5; // unreachable: the throw always fires
+  }
+  catch (int)
+  {
+    x = 7;
+  }
+  assert(x == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_dead_after_throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_dead_after_throw/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--lower-exceptions
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/lower_exceptions_raise_assert/main.py
+++ b/regression/python/lower_exceptions_raise_assert/main.py
@@ -1,0 +1,9 @@
+# The "assert it raised" idiom: an unconditional raise inside a try makes the
+# normal-completion path dead, so remove_unreachable prunes the try's empty
+# CATCH pop, leaving the region unbalanced. The lowering rebalances the unclosed
+# region before recovering it (#5075). Here ValueError is caught, so SUCCESSFUL.
+try:
+    raise ValueError("boom")
+    assert False  # unreachable: the raise always fires
+except ValueError:
+    pass

--- a/regression/python/lower_exceptions_raise_assert/test.desc
+++ b/regression/python/lower_exceptions_raise_assert/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 1 --lower-exceptions
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/lower_exceptions_raise_assert_fail/main.py
+++ b/regression/python/lower_exceptions_raise_assert_fail/main.py
@@ -1,0 +1,8 @@
+# Same "assert it raised" idiom as lower_exceptions_raise_assert, but the raised
+# ValueError is not caught by the TypeError handler, so it escapes uncaught and
+# the lowering's uncaught-exception assertion fires at __ESBMC_main -> FAILED.
+try:
+    raise ValueError("boom")
+    assert False  # unreachable: the raise always fires
+except TypeError:
+    pass

--- a/regression/python/lower_exceptions_raise_assert_fail/test.desc
+++ b/regression/python/lower_exceptions_raise_assert_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 1 --lower-exceptions
+
+^VERIFICATION FAILED$

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -389,7 +389,66 @@ private:
           return false;
       }
     }
-    return depth == 0;
+    // depth > 0 means some try's empty-CATCH pop was pruned by remove_unreachable
+    // (its body cannot complete normally). Such unclosed pushes are accepted:
+    // lower_ip's rebalance_removed_pops re-inserts the synthetic pop before
+    // lowering. depth < 0 (an unmatched pop) is already rejected above.
+    return depth >= 0;
+  }
+
+  /// `remove_unreachable` runs before this pass and prunes the empty CATCH pop
+  /// and skip-GOTO of a try whose body cannot complete normally — the common
+  /// Python idiom `try: <raises>; assert False; except E: ...`, where the model-
+  /// or user-raised throw makes the fall-through dead. That leaves the CATCH
+  /// push unbalanced, which the region recovery cannot pair. Re-insert a
+  /// synthetic pop + skip-GOTO immediately before each unclosed push's first
+  /// handler, restoring the balanced shape collect()/build_dispatch expect. The
+  /// skip-GOTO sits on the (now infeasible, hence pruned) normal-completion
+  /// path, so its target is immaterial; the function's END_FUNCTION is a valid
+  /// choice. Called only when the whole program is supported, so it never
+  /// perturbs a body that falls back to the imperative path.
+  void rebalance_removed_pops(goto_programt &body)
+  {
+    const auto end = body.instructions.end();
+    std::vector<goto_programt::targett> open;
+    for (auto it = body.instructions.begin(); it != end; ++it)
+    {
+      if (it->type != CATCH)
+        continue;
+      if (!it->targets.empty())
+        open.push_back(it);
+      else if (!open.empty())
+        open.pop_back();
+    }
+    if (open.empty())
+      return;
+
+    auto end_fn = std::prev(end); // END_FUNCTION
+    for (auto push : open)
+    {
+      // The try body ends at the first handler in program order; that is where
+      // the removed pop belonged.
+      goto_programt::targett first = end;
+      for (auto it = std::next(push); it != end; ++it)
+        if (
+          std::find(push->targets.begin(), push->targets.end(), it) !=
+          push->targets.end())
+        {
+          first = it;
+          break;
+        }
+      assert(first != end && "CATCH push with no reachable handler");
+
+      auto pop = body.insert(first); // synthetic empty-CATCH pop
+      pop->type = CATCH;
+      pop->location = push->location;
+      pop->function = push->function;
+      auto skip = body.insert(first); // skip-handlers GOTO (dead path)
+      skip->make_goto(end_fn);
+      skip->location = push->location;
+      skip->function = push->function;
+    }
+    body.update();
   }
 
   /// Recover the region tree, throw sites, and may-throw call sites (each with
@@ -463,6 +522,8 @@ private:
 
   void lower_ip(goto_programt &body, const irep_idt &fn_id)
   {
+    rebalance_removed_pops(body);
+
     std::vector<regiont> regions;
     std::vector<sitet> throws, calls;
     collect(body, regions, throws, calls);


### PR DESCRIPTION
Brings the **Python model-raised exceptions** — the largest remaining fall-back category (issue #5075) — into the `--lower-exceptions` lowered path, taking `regression/python` to **100% of comparable tests lowering at 0 divergences**.

## Root cause

`remove_unreachable` runs *before* the lowering pass and prunes the empty `CATCH` pop + skip-GOTO of a try whose body cannot complete normally. This is the ubiquitous Python **"assert it raised" idiom**:

```python
try:
    del d["x"]          # KeyError, or x[5] -> IndexError, math.factorial(-1) -> ValueError, raise ...
    assert False        # dead: the throw above always fires
except KeyError:
    ...
```

The throw makes the fall-through dead, so `remove_unreachable` deletes the trys closing `CATCH` pop, leaving the push **unbalanced**. The positional region recovery (`collect`) pairs push/pop, so it could not handle this and the whole program fell back to the imperative path. (Confirmed minimal: `try: raise E()` as the *last* statement stays balanced and lowers; adding `assert False` after it unbalances it.)

## Fix

`rebalance_removed_pops`, called at the start of `lower_ip` (which runs only when the *whole program* is supported, so it never perturbs a fallback body): for each unclosed `CATCH` push it re-inserts a synthetic empty-`CATCH` pop + skip-GOTO immediately before the pushs first handler, restoring the shape `collect`/`build_dispatch` expect. A push only goes unclosed when its normal-completion path is unreachable (thats *why* the pop was pruned), so the synthetic skip-GOTO is dead and its target (`END_FUNCTION`) is immaterial. `program_supported` accepts `depth >= 0` (an unmatched pop, `depth < 0`, is still rejected).

## Validation

- Full `regression/python` differential (ON vs OFF): **158/158 comparable tests lower, 0 divergences** (was 132/158).
- Full `regression/esbmc-cpp` differential: **0 divergences**, firing 57 → 61 (the idiom appears in C++ too).
- New tests: `lower_exceptions_raise_assert{,_fail}` (Python) + `lower-exceptions_dead_after_throw` (C++); existing `lower-exceptions_*` suite green; CPython sanity passes.
- **code-reviewer**: no high-confidence issues (verified first-handler selection, iterator stability, the unclosed-push ⟺ infeasible-normal-completion invariant, nested pushes, imperative-path isolation).
- **Mode C**: C-Live discharged by the three reproducers (rebalancing path fires, lowered GOTO has no residual THROW/CATCH, caught/uncaught verdicts correct); formerly-fallback `dict_del9`/`tuple1`/`math-factorial` agree ON vs OFF. Z3 dual-solver agreement pending this PRs Linux CI (Bitwuzla-only local build).

The `lower-exceptions-differential` workflow runs automatically (touches `remove_exceptions.cpp`).