### PR TITLE
[python] Add asserting regression tests for symbolic str.split() (#5110)

### DIFF
--- a/regression/python/github_5110_symbolic_split/main.py
+++ b/regression/python/github_5110_symbolic_split/main.py
@@ -1,0 +1,15 @@
+# Issue #5110: str.split(sep) must be sound on a symbolic / runtime string
+# receiver, not just compile-time constants. Here the receiver is selected by a
+# nondet index, so it cannot be constant-folded; split() must still return the
+# correct number of parts and the correct elements (verified against CPython).
+def main() -> None:
+    i = nondet_int()
+    __ESBMC_assume(0 <= i <= 1)
+    s = ["a.b", "c.d"][i]
+    parts = s.split(".")
+    assert len(parts) == 2
+    assert parts[0] == "a" or parts[0] == "c"
+    assert parts[1] == "b" or parts[1] == "d"
+
+
+main()

--- a/regression/python/github_5110_symbolic_split/test.desc
+++ b/regression/python/github_5110_symbolic_split/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5110_symbolic_split_concat_fail/main.py
+++ b/regression/python/github_5110_symbolic_split_concat_fail/main.py
@@ -1,0 +1,12 @@
+# Issue #5110: a concatenation with a symbolic operand is not constant-foldable,
+# so it exercises the runtime split model. "brand." + <uk|com> contains exactly
+# one ".", so split(".") has length 2; asserting length 1 must FAIL.
+def main() -> None:
+    i = nondet_int()
+    __ESBMC_assume(0 <= i <= 1)
+    tlds = ["uk", "com"]
+    s = "brand." + tlds[i]
+    assert len(s.split(".")) == 1
+
+
+main()

--- a/regression/python/github_5110_symbolic_split_concat_fail/test.desc
+++ b/regression/python/github_5110_symbolic_split_concat_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_5110_symbolic_split_fail/main.py
+++ b/regression/python/github_5110_symbolic_split_fail/main.py
@@ -1,0 +1,11 @@
+# Issue #5110: split() on a symbolic receiver used to return a 1-element list,
+# making this false assertion provable (unsound). Both possible receivers split
+# into two parts, so the real length is 2 and the expected verdict is FAILED.
+def main() -> None:
+    i = nondet_int()
+    __ESBMC_assume(0 <= i <= 1)
+    s = ["a.b", "c.d"][i]
+    assert len(s.split(".")) == 1
+
+
+main()

--- a/regression/python/github_5110_symbolic_split_fail/test.desc
+++ b/regression/python/github_5110_symbolic_split_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$


### PR DESCRIPTION
## Context

Issue #5110 reports that `str.split(sep)` was unsound on a **symbolic / runtime** string receiver — it returned a 1-element list regardless of the separator, so ESBMC proved false assertions over any split-based parsing of runtime input.

The underlying runtime `__python_str_split` model was implemented in **#5147** (`Fixes #5124`), which splits non-constant receivers correctly. Verifying against current `master`, all of the issue's reproducers now produce the correct verdict:

```python
i = nondet_int(); __ESBMC_assume(0 <= i <= 1)
s = ["a.b", "c.d"][i]
assert len(s.split(".")) == 1   # now VERIFICATION FAILED (real len is 2)  ✓
assert len(s.split(".")) == 2   # now VERIFICATION SUCCESSFUL              ✓
```

## What this PR does

The fix is already in place, but the **only** symbolic-split regression test (`string-split-symbolic_fail`) calls split with *no assertion on the result*:

```python
def main() -> None:
    nondet_str().split("-", 1)   # never checks the result
```

— which is exactly the coverage gap #5110 calls out. This PR adds three tests that **assert on the split result of a non-constant receiver**, locking in the existing fix:

- `github_5110_symbolic_split` (SUCCESSFUL) — nondet-indexed receiver; asserts `len == 2` and that both elements are correct.
- `github_5110_symbolic_split_fail` (FAILED) — the issue's false `len == 1` assertion via a nondet index.
- `github_5110_symbolic_split_concat_fail` (FAILED) — same, via concatenation with a symbolic operand (`"brand." + tlds[i]`), the not-constant-foldable shape from the issue.

**No source change.**

## Validation

- `ctest -R "github_5110|string-split"`: **76 passed, 0 failed** (3 new + all existing split tests).
- The passing test uses `nondet_int`/`__ESBMC_assume`; `scripts/check_python_tests.sh` auto-skips intrinsic-using tests from the CPython sanity check (verified).

Closes #5110.
