### PR TITLE
[ci] Give humaneval_109 the slow-test timeout tier (#5189)

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -323,6 +323,12 @@ set(_slow_regression_tests
     "regression/humaneval/humaneval_129"
     "regression/humaneval/humaneval_153"
     "regression/humaneval/humaneval_161"
+    # humaneval_109 (move_one_ball) verifies SUCCESSFUL but is slow: ~32s on a
+    # fast local build, and it exceeds the 120s per-test cap on the DebugOpt
+    # static Linux runner (sorted()/min()/index()/slice+concat over a list under
+    # --smt-during-symex --smt-symex-guard --bitwuzla). Give it the 2x budget so
+    # transient CI slowness doesn't time it out (#5189).
+    "regression/humaneval/humaneval_109"
     # humaneval_90 used to fast-crash with the member2t assertion
     # ("source->type->type_id == struct_id ...") when next_smallest()'s
     # inline optional comparison (None | int == 2) was lowered. With the


### PR DESCRIPTION
## Summary

Addresses the `humaneval_109` timeout half of #5189.

`regression/humaneval/humaneval_109` (`move_one_ball`) verifies `VERIFICATION SUCCESSFUL`, but it is slow (~32 s on a fast local build) and exceeds the 120 s per-test cap on the `static llvm-22 DebugOpt (ubuntu-24.04)` CI runner, where it is reported as a **Timeout**. It runs `sorted()`/`min()`/`index()`/slice+concat over a list under `--smt-during-symex --smt-symex-guard --bitwuzla --unwind 9`.

## Fix

Add it to the existing `_slow_regression_tests` tier in `regression/CMakeLists.txt` (2× inner/outer timeout budget), exactly the mechanism already used for the other humaneval tests that legitimately run close to the cap. No source or test-logic change.

## Verification

- `cmake` reconfigures cleanly; `ctest --show-only` confirms `humaneval_109` now carries the slow-tier `TIMEOUT` (2430 s locally vs 1200 s for normal tests), matching `humaneval_34`. On CI (base 120 s) that becomes 270 s.
- The verdict is unchanged (`VERIFICATION SUCCESSFUL`); only the timeout budget changes.

## Scope

This fixes one of the two pre-existing ubuntu-static CI failures tracked in #5189. The other — the `list_comprehension5` `std::system_error: "Invalid argument"` crash during conversion on the static build — is environmental (does not reproduce on macOS/Windows; `-pthread` is already linked) and needs Linux reproduction; it is left for a separate fix and documented in #5189.

Refs #5189.
