### PR TITLE
[goto] Warn instead of silently falling back in --lower-exceptions (#5075)

### DIFF
--- a/docs/design-symbolic-exceptions.md
+++ b/docs/design-symbolic-exceptions.md
@@ -119,10 +119,19 @@ model, so such programs need an `--unwind` bound; and the frontend can omit
 intermediate bases from the flattened chain, so a catch on a mid-hierarchy base
 may not match — a frontend chain-completeness matter, not a lowering one.)
 
-Not yet lowered (fall back): a residual set including `dynamic_cast<T&>`/`bad_cast`
-(see above) and `std::bad_exception` value-catches. Dynamic exception
+Not yet lowered (fall back): a small residual set — `std::bad_exception`
+value-catches and a few unusual try-block layouts (function-try-blocks, an empty
+trailing handler whose skip-GOTO `remove_unreachable` prunes). Dynamic exception
 specifications themselves now lower (above); the `try-catch_decl_*` /
 `try-catch_unexpected_*` tests exercise them.
+
+When the pass declines to lower a program that *uses* exceptions, it emits a
+`--lower-exceptions: cannot lower <construct>; falling back to the imperative
+exception path` warning naming the construct, rather than falling back silently
+(`report_fallback`). This is the prerequisite for removing the imperative path
+(see roadmap): once that path is gone, the same site becomes an error, so an
+unsupported program is reported rather than miscompiled. Exception-free programs
+stay silent (the pass is a no-op for them).
 
 **Destructor unwinding** is handled at the GOTO frontend (`convert_throw`), not
 in the lowering pass, so it applies on **both** the imperative and lowered

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns/main.cpp
@@ -1,0 +1,16 @@
+// An empty trailing catch-all leaves the try with no skip-GOTO after the pop
+// (remove_unreachable prunes it), an "unsupported try-block layout" the lowering
+// declines. The P4-prerequisite diagnostic reports the fallback instead of
+// lowering silently; the imperative path still catches the throw, so this
+// verifies SUCCESSFUL (#5075).
+int main()
+{
+  try
+  {
+    throw 1;
+  }
+  catch (...)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--lower-exceptions
+
+^VERIFICATION SUCCESSFUL$
+--lower-exceptions: cannot lower an unsupported try-block layout

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns_fail/main.cpp
@@ -1,0 +1,17 @@
+// Same unsupported empty-catch-all layout as lower-exceptions_unsupported_warns,
+// but an assertion fails after the handler, so the (imperative-fallback) verdict
+// is FAILED. The lowering still reports the fallback diagnostic rather than
+// lowering silently (#5075, P4 prerequisite).
+#include <cassert>
+
+int main()
+{
+  try
+  {
+    throw 1;
+  }
+  catch (...)
+  {
+  }
+  assert(0);
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_unsupported_warns_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--lower-exceptions
+
+^VERIFICATION FAILED$
+--lower-exceptions: cannot lower an unsupported try-block layout

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -10,6 +10,7 @@
 #include <util/expr_util.h>
 #include <util/std_types.h>
 #include <util/std_expr.h>
+#include <util/message.h>
 #include <irep2/irep2_utils.h>
 
 namespace
@@ -111,7 +112,9 @@ public:
             is_symbol2t(c.function) &&
             id2string(to_symbol2t(c.function).thename).find("pthread_create") !=
               std::string::npos)
-            return; // concurrent program — not yet modelled
+            // concurrent program — not yet modelled
+            return report_fallback(
+              goto_functions, "a concurrent program (pthread_create)");
         }
       }
     }
@@ -121,7 +124,7 @@ public:
     // the supported subset we leave the entire program to symex.
     for (auto &fn : goto_functions.function_map)
       if (fn.second.body_available && !program_supported(fn.second.body))
-        return;
+        return report_fallback(goto_functions, unsupported_reason_, fn.first);
 
     // The uncaught-exception check is anchored at the program entry's epilogue.
     // __ESBMC_main is the universal whole-program entry (it runs static init,
@@ -133,7 +136,8 @@ public:
       if (fn.first == "__ESBMC_main")
         has_entry = true;
     if (!has_entry)
-      return;
+      return report_fallback(
+        goto_functions, "no whole-program entry (--function verification)");
 
     for (auto &fn : goto_functions.function_map)
       if (fn.second.body_available)
@@ -147,6 +151,43 @@ public:
       entry != goto_functions.function_map.end() &&
       entry->second.body_available)
       init_globals(entry->second.body);
+  }
+
+  /// True if any function still has an exception construct to lower.
+  static bool program_uses_exceptions(const goto_functionst &gf)
+  {
+    for (const auto &fn : gf.function_map)
+      if (fn.second.body_available)
+        for (const auto &ins : fn.second.body.instructions)
+          if (ins.type == THROW || ins.type == CATCH || ins.type == THROW_DECL)
+            return true;
+    return false;
+  }
+
+  /// Report that the pass declined to lower a program that uses exceptions, so
+  /// the residual dependence on the imperative path is visible rather than
+  /// silent. Today the imperative path takes over; once it is removed (P4) this
+  /// diagnostic is what keeps that deletion non-breaking — an unsupported
+  /// program is reported, not miscompiled. Programs with no exception construct
+  /// are silent (the pass is a no-op for them).
+  void report_fallback(
+    const goto_functionst &gf,
+    const std::string &why,
+    const irep_idt &fn = irep_idt())
+  {
+    if (!program_uses_exceptions(gf))
+      return;
+    if (fn.empty())
+      log_warning(
+        "--lower-exceptions: cannot lower {}; falling back to the imperative "
+        "exception path",
+        why);
+    else
+      log_warning(
+        "--lower-exceptions: cannot lower {} in '{}'; falling back to the "
+        "imperative exception path",
+        why,
+        id2string(fn));
   }
 
   void init_globals(goto_programt &body)
@@ -319,6 +360,16 @@ private:
   /// the supported subset (reference catches of registered class types, throws
   /// of registered objects or rethrows, regions whose pop is followed by the
   /// skip-handlers GOTO)? Read-only.
+  /// Set when program_supported declines, naming the construct for the
+  /// fallback diagnostic (report_fallback).
+  std::string unsupported_reason_;
+
+  bool unsupported(const char *why)
+  {
+    unsupported_reason_ = why;
+    return false;
+  }
+
   bool program_supported(goto_programt &body)
   {
     const auto end = body.instructions.end();
@@ -332,7 +383,7 @@ private:
       {
         const code_cpp_catch2t &c = to_code_cpp_catch2t(it->code);
         if (c.exception_list.size() != it->targets.size())
-          return false;
+          return unsupported("a malformed catch clause");
         auto type_it = c.exception_list.begin();
         for (auto tgt : it->targets)
         {
@@ -344,10 +395,12 @@ private:
           // catch type need not be registered: an unregistered type is one no
           // throw can match, so its guard is simply false (a dead handler).
           if (!is_code_decl2t(tgt->code))
-            return false;
+            return unsupported("an unsupported handler shape");
           auto bind = std::next(tgt);
           if (bind == end || !is_code_assign2t(bind->code))
-            return false;
+            return unsupported(
+              "a value catch without a copy binding (e.g. catching "
+              "std::bad_exception by value)");
         }
         ++depth;
       }
@@ -356,7 +409,9 @@ private:
         // pop: needs the skip-handlers GOTO after it for dispatch placement.
         auto nx = std::next(it);
         if (depth == 0 || nx == end || nx->type != GOTO)
-          return false;
+          return unsupported(
+            "an unsupported try-block layout (e.g. a function-try-block or an "
+            "empty trailing handler)");
         --depth;
       }
       else if (it->type == THROW)
@@ -367,7 +422,7 @@ private:
         if (
           t.exception_list.empty() ||
           !registry.is_registered(t.exception_list.front()))
-          return false;
+          return unsupported("a throw of an unsupported type");
       }
       else if (it->type == FUNCTION_CALL)
       {
@@ -380,7 +435,8 @@ private:
         if (
           is_symbol2t(c.function) &&
           to_symbol2t(c.function).thename == "c:@F@__ESBMC_throw_bad_cast")
-          return false;
+          return unsupported(
+            "a failing dynamic_cast<T&> whose std::bad_cast is unavailable");
       }
     }
     // depth > 0 means some try's empty-CATCH pop was pruned by remove_unreachable


### PR DESCRIPTION
First step of **P4** (the safe prerequisite that makes deleting the imperative exception path non-breaking).

## Why

The `--lower-exceptions` pass is whole-program **all-or-nothing**: when a program uses an exception construct it cannot lower, it returns early and falls back to the imperative path (`symex_catch.cpp`) — **silently**. P4 deletes that imperative path, at which point a silent fallback would become a silent **miscompilation** (an unhandled `THROW` reaching symex). Before the deletion can happen safely, an unsupported program must be *reported*, not silently mishandled.

## Change

- `program_supported` records a descriptive `unsupported_reason_` at each decline (via an `unsupported(const char*)` helper).
- New `report_fallback(gf, why, fn)` emits `--lower-exceptions: cannot lower <construct>; falling back to the imperative exception path` — but **only when the program actually uses exceptions** (`program_uses_exceptions`), so exception-free programs stay silent.
- `run()`’s three decline points (concurrency, unsupported construct, no whole-program entry) route through it.

It is **non-fatal for now**: the imperative path still takes over and the verdict is unchanged. At the flip, this same site becomes a hard error and the imperative path is removed — so the diagnostic is exactly what keeps that deletion non-breaking.

## Validation

- **Diagnostic-only — no verdict changes**: full `regression/esbmc-cpp` + `regression/python` differential (ON vs OFF) still **0 divergences**.
- The warning fires on unsupported constructs (empty trailing catch-all, function-try-block) and stays silent on supported and exception-free programs.
- New tests `lower-exceptions_unsupported_warns{,_fail}` assert the warning text *and* the correct imperative-fallback verdict (SUCCESSFUL / FAILED). All 28 `lower-exceptions_*` + 3 Python `lower_exceptions_*` tests pass.
- **code-reviewer**: no high-confidence issues (verified no false positives, `unsupported_reason_` always set before read, no verdict change, valid control flow). Applied its suggestion to add a direct `#include <util/message.h>`.

Branch-soundness: the new branch is diagnostic-only (no VCC/verdict impact, proven by 0 divergences); C-Live is discharged by the two new tests that exercise the `report_fallback` path.

Next P4 steps (separate PRs): flip `--lower-exceptions` default ON; turn this warning into an error; delete `symex_catch.cpp` and dead symex state with a C-Dead Mode-C proof.