### PR TITLE
[python] Fix dynamic-index read of mixed int/float lists (Fixes #5160)

### DIFF
--- a/regression/humaneval/humaneval_130/test.desc
+++ b/regression/humaneval/humaneval_130/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --bitwuzla --unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/mixed_list_dynamic_index/main.py
+++ b/regression/python/mixed_list_dynamic_index/main.py
@@ -1,0 +1,13 @@
+# A heterogeneous int/float list read with a loop-variable (non-constant)
+# index must read each element with its actual stored type. Reading the float
+# element 2.0 as if it were an int (the type of element 0) produced a false
+# counterexample (esbmc/esbmc#5160).
+def tri(n):
+    my_tri = [1, 3, 2.0]
+    for i in range(3, n + 1):
+        my_tri.append(my_tri[i - 1] + my_tri[i - 2] + (i + 3) / 2)
+    return my_tri
+
+
+if __name__ == "__main__":
+    assert tri(3) == [1, 3, 2.0, 8.0]

--- a/regression/python/mixed_list_dynamic_index/test.desc
+++ b/regression/python/mixed_list_dynamic_index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/mixed_list_dynamic_index_fail/main.py
+++ b/regression/python/mixed_list_dynamic_index_fail/main.py
@@ -1,0 +1,12 @@
+# Negative variant of mixed_list_dynamic_index: the dynamic-index read returns
+# the real computed values (not a constant), so a wrong expected list must be
+# reported as a violated assertion.
+def tri(n):
+    my_tri = [1, 3, 2.0]
+    for i in range(3, n + 1):
+        my_tri.append(my_tri[i - 1] + my_tri[i - 2] + (i + 3) / 2)
+    return my_tri
+
+
+if __name__ == "__main__":
+    assert tri(3) == [1, 3, 2.0, 9.0]

--- a/regression/python/mixed_list_dynamic_index_fail/test.desc
+++ b/regression/python/mixed_list_dynamic_index_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --smt-during-symex --smt-symex-guard
+^VERIFICATION FAILED$

--- a/regression/python/mixed_list_dynamic_index_int/main.py
+++ b/regression/python/mixed_list_dynamic_index_int/main.py
@@ -1,0 +1,14 @@
+# Reading the *integer* elements of a heterogeneous int/float list with a
+# loop-variable index must promote them to float (Python int->float promotion),
+# not read float_buf at the wrong slot. Covers the int branch of the runtime
+# type dispatch added for esbmc/esbmc#5160.
+def total(n):
+    my_tri = [1, 3, 2.0]
+    s = 0.0
+    for i in range(0, n):
+        s = s + my_tri[i]
+    return s
+
+
+if __name__ == "__main__":
+    assert total(3) == 6.0

--- a/regression/python/mixed_list_dynamic_index_int/test.desc
+++ b/regression/python/mixed_list_dynamic_index_int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2591,11 +2591,49 @@ exprt python_list::handle_index_access(
       }
     }
 
+    // A non-constant subscript into a heterogeneous int/float list cannot
+    // resolve a single static element type from the index, so the code above
+    // defaults to element 0's type. That misreads any element of the other
+    // numeric kind (e.g. a float stored at index 2 read as an int, #5160).
+    // Python promotes int to float in numeric expressions, so treat the read
+    // as float and dispatch on the stored type_id at runtime (see
+    // extract_pyobject_value), which yields the correct value for both kinds.
+    const bool constant_index =
+      slice_node["_type"] == "Constant" ||
+      (slice_node["_type"] == "UnaryOp" && slice_node.contains("op") &&
+       slice_node["op"]["_type"] == "USub" && slice_node.contains("operand") &&
+       slice_node["operand"]["_type"] == "Constant");
+    const bool mixed_numeric =
+      !constant_index && array.is_symbol() &&
+      has_mixed_numeric_types(array.identifier().as_string());
+    if (mixed_numeric)
+      elem_type = double_type();
+
     // Build list access and cast result
     exprt list_at_call = build_list_at_call(array, pos_expr, list_value_);
 
+    // The mixed-numeric read dereferences the element three times (type_id,
+    // float_idx, value), so bind the __ESBMC_list_at result to a temp first and
+    // evaluate the access once instead of three times on the hot path.
+    if (mixed_numeric)
+    {
+      const locationt loc = converter_.get_location_from_decl(list_value_);
+      symbolt &elem_obj = converter_.create_tmp_symbol(
+        list_value_,
+        "$list_elem_obj$",
+        pointer_typet(converter_.get_type_handler().get_list_element_type()),
+        exprt());
+      code_declt obj_decl(build_symbol(elem_obj));
+      obj_decl.location() = loc;
+      converter_.add_instruction(obj_decl);
+      code_assignt obj_assign(build_symbol(elem_obj), list_at_call);
+      obj_assign.location() = loc;
+      converter_.add_instruction(obj_assign);
+      list_at_call = build_symbol(elem_obj);
+    }
+
     // Extract and dereference PyObject value
-    return extract_pyobject_value(list_at_call, elem_type);
+    return extract_pyobject_value(list_at_call, elem_type, mixed_numeric);
   }
 
   // Handle static string indexing with IndexError on out-of-bounds
@@ -4255,7 +4293,8 @@ exprt python_list::build_pop_list_call(
 
 exprt python_list::extract_pyobject_value(
   const exprt &pyobject_expr,
-  const typet &elem_type)
+  const typet &elem_type,
+  bool mixed_numeric)
 {
   // For float types, read __ESBMC_float_buf[item->float_idx].
   // This avoids the void*→integer truncation in --ir mode: float_idx is a size_t
@@ -4263,15 +4302,17 @@ exprt python_list::extract_pyobject_value(
   // (real-sorted in --ir mode), so the array read gives the correct real value.
   if (elem_type.is_floatbv())
   {
-    // Build item->float_idx: dereference the PyObject* and access the float_idx field
-    member_exprt float_idx_member(pyobject_expr, "float_idx", size_type());
-    {
-      exprt &base = float_idx_member.struct_op();
+    // Helper: build deref(pyobject_expr)->field for a given field/type.
+    auto member_of =
+      [&](const char *field, const typet &ftype) -> member_exprt {
+      member_exprt m(pyobject_expr, field, ftype);
+      exprt &base = m.struct_op();
       exprt deref("dereference");
       deref.type() = base.type().subtype();
       deref.move_to_operands(base);
       base.swap(deref);
-    }
+      return m;
+    };
 
     // Look up __ESBMC_float_buf global (static in list.c, but still in symbol table)
     const symbolt *fbuf_sym =
@@ -4279,9 +4320,36 @@ exprt python_list::extract_pyobject_value(
     assert(fbuf_sym && "could not find __ESBMC_float_buf symbol");
 
     // Build __ESBMC_float_buf[item->float_idx]
+    member_exprt float_idx_member = member_of("float_idx", size_type());
     exprt float_val =
       build_index(build_symbol(*fbuf_sym), float_idx_member, elem_type);
-    return float_val;
+
+    if (!mixed_numeric)
+      return float_val;
+
+    // Dynamic index into a heterogeneous int/float list: the element may be an
+    // int whose value lives behind item->value (not in float_buf), so reading
+    // float_buf unconditionally would misread it (#5160). Dispatch on the
+    // stored type_id: float elements come from float_buf, int elements are
+    // promoted to double from their 8-byte payload. The float type_id is the
+    // same hash the push path stamps onto float elements (float_type_id).
+    const size_t float_type_id = std::hash<std::string>{}(
+      converter_.get_type_handler().type_to_string(elem_type));
+
+    // (double)*(long long *)item->value
+    member_exprt value_member =
+      member_of("value", pointer_typet(empty_typet()));
+    typecast_exprt as_int_ptr(
+      value_member, pointer_typet(long_long_int_type()));
+    dereference_exprt int_val(long_long_int_type());
+    int_val.op0() = as_int_ptr;
+    typecast_exprt int_as_float(int_val, elem_type);
+
+    // item->type_id == float_type_id ? float_buf[float_idx] : (double)int
+    equality_exprt is_float(
+      member_of("type_id", size_type()),
+      from_integer(float_type_id, size_type()));
+    return if_exprt(is_float, float_val, int_as_float);
   }
 
   // Extract value from PyObject: pyobject_expr->value

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -160,10 +160,17 @@ public:
    * @brief Extract and dereference value from a PyObject* expression
    * @param pyobject_expr Expression representing PyObject* (from list_at or list_pop)
    * @param elem_type The expected element type
+   * @param mixed_numeric When true and elem_type is float, the element may be
+   *        either an int or a float at runtime (a dynamic index into a mixed
+   *        int/float list). The float value is then read by dispatching on the
+   *        stored type_id: float elements come from __ESBMC_float_buf, int
+   *        elements are promoted from their payload to double.
    * @return Dereferenced value expression (for floats: __ESBMC_float_buf[item->float_idx])
    */
-  exprt
-  extract_pyobject_value(const exprt &pyobject_expr, const typet &elem_type);
+  exprt extract_pyobject_value(
+    const exprt &pyobject_expr,
+    const typet &elem_type,
+    bool mixed_numeric = false);
 
   /**
    * @brief Check if all elements in a list have the same type.


### PR DESCRIPTION
A non-constant subscript (e.g. `my_tri[i-1]`) into a heterogeneous int/float list defaulted its element type to element 0's type, so a float element was misread through the integer `void*` path, producing a false counterexample (`humaneval_130`). When the index is non-constant and the list is mixed numeric, read the element as `double` and dispatch on the stored `type_id` at runtime: float elements come from `__ESBMC_float_buf`, int elements are promoted to `double` from their payload.

Flips `humaneval_130` KNOWNBUG → CORE and adds regression tests exercising both arms of the new conditional (float and int element reads), plus a failing variant. Fixes #5160.
