### PR TITLE
[python] Fix empty-list equality crash from one-value BoolOp

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -98,6 +98,14 @@ exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
   // Restore the original flag state
   is_converting_rhs = old_is_converting_rhs;
 
+  // A BoolOp must have at least two values, but AST rewrites (e.g. lowering
+  // `x == []` to `len(x) == 0`) can produce a degenerate one-value node. A
+  // single-operand `and`/`or` is malformed IR: the C adjuster reads op1() and
+  // runs off the end of the operands vector. Collapse to the lone operand,
+  // which is the correct result for a one-value boolean operation.
+  if (logical_expr.operands().size() == 1)
+    return logical_expr.operands().front();
+
   // Shockingly enough, a BoolOp may not return a boolean.
   if (contains_non_boolean)
   {

--- a/src/python-frontend/preprocessor/generator_mixin.py
+++ b/src/python-frontend/preprocessor/generator_mixin.py
@@ -1500,8 +1500,8 @@ class GeneratorMixin:
         ``sorted(...)`` since list() is identity on a view.
         """
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-                and node.func.id in ("list", "sorted", "set")
-                and len(node.args) == 1 and not getattr(node, "keywords", [])):
+                and node.func.id in ("list", "sorted", "set") and len(node.args) == 1
+                and not getattr(node, "keywords", [])):
             return None, None
         wrapper = node.func.id
         inner = node.args[0]
@@ -1510,9 +1510,8 @@ class GeneratorMixin:
                     and inner.func.id == "list" and len(inner.args) == 1
                     and not getattr(inner, "keywords", [])):
                 inner = inner.args[0]
-        if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)
-                and inner.func.attr == attr and not inner.args
-                and not getattr(inner, "keywords", [])):
+        if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute) and
+                inner.func.attr == attr and not inner.args and not getattr(inner, "keywords", [])):
             return None, None
         base = inner.func.value
         if isinstance(base, ast.Name):
@@ -1528,7 +1527,7 @@ class GeneratorMixin:
         This avoids tuple struct comparison and uses only proven-working primitives.
         Returns the new AST node, or None if the pattern doesn't match.
         """
-        dict_expr, _ = self._get_items_dict_expr(set_side, ("set",))
+        dict_expr, _ = self._get_items_dict_expr(set_side, ("set", ))
         if dict_expr is None:
             return None
         if not isinstance(literal_side, ast.Set) or not literal_side.elts:
@@ -1711,8 +1710,7 @@ class GeneratorMixin:
         - list wrapper: literal must have at most one pair (ESBMC's dict
           model does not preserve insertion order).
         """
-        dict_expr, wrapper = self._get_items_dict_expr(list_side,
-                                                       ("list", "sorted"))
+        dict_expr, wrapper = self._get_items_dict_expr(list_side, ("list", "sorted"))
         if dict_expr is None:
             return None
         if not isinstance(literal_side, ast.List):
@@ -1724,8 +1722,7 @@ class GeneratorMixin:
             pairs.append((elt.elts[0], elt.elts[1]))
         if pairs and not self._all_constants_distinct([k for k, _ in pairs]):
             return None
-        if wrapper == "sorted" and not self._is_sorted_const_list(
-                literal_side.elts, by="first"):
+        if wrapper == "sorted" and not self._is_sorted_const_list(literal_side.elts, by="first"):
             return None
         if wrapper == "list" and len(pairs) > 1:
             return None
@@ -1756,9 +1753,7 @@ class GeneratorMixin:
             )
             if use_get:
                 value_lookup = ast.Call(
-                    func=ast.Attribute(value=copy.deepcopy(dict_expr),
-                                       attr="get",
-                                       ctx=ast.Load()),
+                    func=ast.Attribute(value=copy.deepcopy(dict_expr), attr="get", ctx=ast.Load()),
                     args=[copy.deepcopy(k)],
                     keywords=[],
                 )
@@ -1768,9 +1763,7 @@ class GeneratorMixin:
                     slice=copy.deepcopy(k),
                     ctx=ast.Load(),
                 )
-            val_eq = ast.Compare(left=value_lookup,
-                                 ops=[ast.Eq()],
-                                 comparators=[copy.deepcopy(v)])
+            val_eq = ast.Compare(left=value_lookup, ops=[ast.Eq()], comparators=[copy.deepcopy(v)])
             value_checks.append(key_in_dict)
             value_checks.append(val_eq)
 

--- a/src/python-frontend/preprocessor/generator_mixin.py
+++ b/src/python-frontend/preprocessor/generator_mixin.py
@@ -1822,7 +1822,15 @@ class GeneratorMixin:
                         comparators=[copy.deepcopy(value_node)],
                     ))
 
-        result = ast.BoolOp(op=ast.And(), values=checks)
+        # An empty literal (``x == []``) yields a single ``len(x) == 0`` check.
+        # A one-value ``BoolOp(And)`` is degenerate AST that lowers to a
+        # malformed single-operand ``and`` expr, so collapse it to the lone
+        # check (mirrors the guards in _lower_assert_eq_literal and
+        # _try_lower_expr_tuple_literal_eq).
+        if len(checks) == 1:
+            result = checks[0]
+        else:
+            result = ast.BoolOp(op=ast.And(), values=checks)
         self.ensure_all_locations(result, source_node)
         ast.fix_missing_locations(result)
         return result


### PR DESCRIPTION
## Summary

Fixes the `list_comprehension5{,_fail}` crash half of #5189 — the `std::system_error: "Invalid argument"` → `terminate` during conversion on the `static llvm-22 DebugOpt (ubuntu-24.04)` CI build. (The `humaneval_109` timeout half was already fixed in #5190.)

## Root cause

The issue hypothesised a libstdc++/`-static`/toolchain interaction. It is actually a **heap out-of-bounds read** (ASan-confirmed), not a pthread/toolchain problem:

- The preprocessor rewrite `_try_transform_list_tuple_eq` lowers `x == []` (list vs empty-list literal) to `len(x) == 0`, but wraps that single check in a degenerate **one-value `BoolOp(And)`** — its sibling rewrites already guard this single-element case; this one did not.
- `get_logical_operator_expr` faithfully builds a **single-operand `and` exprt**, which is malformed IR.
- `clang_c_adjust::adjust_expr_binary_boolean` then reads `op1()` and runs one element past the end of the operands vector. On the static glibc build the garbage slot makes the downstream copy-on-write `std::mutex::lock` return `EINVAL`, thrown as an uncaught `std::system_error` → `terminate` (which is why it escaped ESBMC's top-level handler and only reproduced on the static Linux build — pure heap-layout dependence).

## Fix

1. `generator_mixin.py` — guard `_try_transform_list_tuple_eq` to emit the lone check directly when there is only one (mirrors the existing guards in `_lower_assert_eq_literal` / `_try_lower_expr_tuple_literal_eq`).
2. `converter_binop.cpp` — defensively collapse any one-value `BoolOp` to its single operand in `get_logical_operator_expr`, closing the whole class so no degenerate boolean node can reach the adjuster.

## Verification

- `regression/python/list_comprehension5` → `VERIFICATION SUCCESSFUL`, `list_comprehension5_fail` → `VERIFICATION FAILED` on the static build; both pass under ctest.
- A dedicated AddressSanitizer build is **clean** on the repro (no heap-buffer-overflow); previously it reported the OOB read at `irept::detatch` ← `adjust_expr_binary_boolean`.
- 35/35 curated comparison/boolop/assert/list tests pass (incl. chained-comparison and boolop, exercising the multi-value path).
- clang-format clean on the changed lines; pylint unchanged (no new warnings).

The two existing `list_comprehension5{,_fail}` tests are the regression coverage (the exact repro from #5189).

Refs #5189.
