### PR TITLE
[python] Return 64-bit int from __python_int for split→int rebind

### DIFF
--- a/regression/humaneval/humaneval_124/test.desc
+++ b/regression/humaneval/humaneval_124/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 11 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 12 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_from_split_rebind-fail/main.py
+++ b/regression/python/int_from_split_rebind-fail/main.py
@@ -1,0 +1,16 @@
+# Negative companion to int_from_split_rebind (#5159). The rebound int value is
+# parsed correctly, so the membership test is genuinely False here and the
+# assertion that it is True must make verification FAIL — pinning that int() of
+# a split-unpacked, self-rebound variable produces a real value (not nondet or a
+# vacuously-true claim).
+
+
+def first_field_in_months(date: str) -> bool:
+    month, day = date.split('-')
+    month = int(month)
+    return month in [1, 3, 5, 7, 8, 10, 12]
+
+
+if __name__ == "__main__":
+    # 4 is not in the odd-month set, so this is False; asserting True must FAIL.
+    assert first_field_in_months('4-11') == True

--- a/regression/python/int_from_split_rebind-fail/test.desc
+++ b/regression/python/int_from_split_rebind-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/int_from_split_rebind/main.py
+++ b/regression/python/int_from_split_rebind/main.py
@@ -1,0 +1,16 @@
+# Regression for #5159: a string element unpacked from str.split() and rebound
+# to the SAME name via int() must not be truncated. int() now yields a 64-bit
+# Python int, so the string pointer survives the assignment and is parsed
+# correctly (a 32-bit result truncated the pointer, giving a wrong value and an
+# out-of-bounds read in the `month in [...]` membership test).
+
+
+def first_field_in_months(date: str) -> bool:
+    month, day = date.split('-')
+    month = int(month)
+    return month in [1, 3, 5, 7, 8, 10, 12]
+
+
+if __name__ == "__main__":
+    assert first_field_in_months('3-11') == True
+    assert first_field_in_months('4-11') == False

--- a/regression/python/int_from_split_rebind/test.desc
+++ b/regression/python/int_from_split_rebind/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -1104,8 +1104,12 @@ __ESBMC_HIDE:;
   list->size = count;
   return list;
 }
-// Python int() builtin - converts string to integer
-int __python_int(const char *s, int base)
+// Python int() builtin - converts string to integer.
+// Returns a 64-bit value: Python ints are modelled as 64-bit everywhere else
+// in the frontend (type_handler::get_typet("int")), so a 32-bit return here
+// makes the result symbol 32-bit and truncates a string pointer that is later
+// rebound through it (e.g. `a, b = s.split('-'); a = int(a)`). See issue #5159.
+long long __python_int(const char *s, int base)
 {
 __ESBMC_HIDE:;
   if (!s)
@@ -1186,7 +1190,7 @@ __ESBMC_HIDE:;
     return 0;
   }
 
-  int result = 0;
+  long long result = 0;
   _Bool found_digit = 0;
 
   while (*s)
@@ -1231,7 +1235,7 @@ __ESBMC_HIDE:;
 
     found_digit = 1;
 
-    if (result > (INT_MAX / base))
+    if (result > (LLONG_MAX / base))
     {
       __ESBMC_assert(0, "int() conversion overflow");
       return 0;

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1801,9 +1801,12 @@ exprt string_handler::handle_string_to_int(
     throw std::runtime_error("__python_int function not found in symbol table");
   }
 
-  // Call __python_int(str, base)
+  // Call __python_int(str, base). The result is a 64-bit Python int (matching
+  // the model's `long long` return); a 32-bit result type here would make the
+  // assigned-to variable 32-bit and truncate a string pointer rebound through
+  // it, e.g. `a, b = s.split('-'); a = int(a)` (#5159).
   exprt int_call =
-    build_call_expr(*int_symbol, int_type(), {str_addr, base_expr});
+    build_call_expr(*int_symbol, long_long_int_type(), {str_addr, base_expr});
   int_call.location() = location;
 
   return int_call;


### PR DESCRIPTION
int() of a string returned a 32-bit C int, so a variable rebound via a single-target assignment from a runtime string (e.g. `a, b = s.split('-'); a = int(a)`) was typed 32-bit and the split element's 64-bit string pointer was truncated, then read back as a corrupt pointer — an out-of-bounds read in `__ESBMC_list_at` on the `month in [...]` membership test.

`__python_int` now returns `long long` (Python ints are modelled as 64-bit elsewhere) and the single frontend caller's call-result type is widened to match, so the pointer round-trips losslessly. humaneval_124 already passed by luck (its tuple-target unpack widens to long); its test.desc now pins the issue's exact flags, and a focused `int_from_split_rebind` pass/fail pair covers the single-target pattern.

Fixes #5159.