### PR TITLE
[python] Read mixed int/float list parameters with runtime type dispatch (Fixes #5156)

### DIFF
--- a/regression/humaneval/humaneval_81/test.desc
+++ b/regression/humaneval/humaneval_81/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/mixed_list_param_for_eq/main.py
+++ b/regression/python/mixed_list_param_for_eq/main.py
@@ -1,0 +1,19 @@
+# A heterogeneous int/float list passed as a parameter and iterated with a
+# for-loop must read each element at its true width, so an integral float
+# element compares equal to its float literal and an int element promotes to
+# float. Under the old list[int] fallback the loop variable was int: 4.0
+# truncated to 4 so `gpa == 4.0` was false (esbmc/esbmc#5156).
+def grade(xs):
+    out = []
+    for x in xs:
+        if x == 4.0:
+            out.append("A")
+        elif x > 1.5:
+            out.append("B")
+        else:
+            out.append("C")
+    return out
+
+
+if __name__ == "__main__":
+    assert grade([4.0, 3, 1.7]) == ["A", "B", "B"]

--- a/regression/python/mixed_list_param_for_eq/test.desc
+++ b/regression/python/mixed_list_param_for_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/mixed_list_param_for_fail/main.py
+++ b/regression/python/mixed_list_param_for_fail/main.py
@@ -1,0 +1,17 @@
+# Negative variant of mixed_list_param_for_eq: the heterogeneous list elements
+# are read at their true values, so a wrong expected result must be reported as a
+# violated assertion (esbmc/esbmc#5156).
+def grade(xs):
+    out = []
+    for x in xs:
+        if x == 4.0:
+            out.append("A")
+        elif x > 1.5:
+            out.append("B")
+        else:
+            out.append("C")
+    return out
+
+
+if __name__ == "__main__":
+    assert grade([4.0, 3, 1.7]) == ["A", "B", "C"]

--- a/regression/python/mixed_list_param_for_fail/test.desc
+++ b/regression/python/mixed_list_param_for_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --smt-during-symex --smt-symex-guard
+^VERIFICATION FAILED$

--- a/regression/python/mixed_list_param_for_trunc/main.py
+++ b/regression/python/mixed_list_param_for_trunc/main.py
@@ -1,0 +1,11 @@
+# A non-integral float element of a heterogeneous int/float list parameter must
+# survive iteration. Under the old list[int] fallback the loop variable was int,
+# so 1.7 truncated to 1 and the band check failed (esbmc/esbmc#5156).
+def first_band(xs):
+    for x in xs:
+        return x > 1.3 and x < 1.9
+    return False
+
+
+if __name__ == "__main__":
+    assert first_band([1.7, 2]) == True

--- a/regression/python/mixed_list_param_for_trunc/test.desc
+++ b/regression/python/mixed_list_param_for_trunc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -576,6 +576,18 @@ size_t python_converter::register_function_argument(
         typet elem_type = type_handler_.get_list_type(element).subtype();
         if (!elem_type.is_empty())
           python_list::add_type_info_entry(arg_id, "", elem_type);
+
+        // A parameter that receives a heterogeneous int/float list literal
+        // collapses to a single element annotation, which would make the
+        // element read take the plain (truncating) integer path. Record both
+        // an int and a float element so has_mixed_numeric_types() reports the
+        // parameter as mixed and get_subscript dispatches on the runtime
+        // type_id, reading each element at its true width (esbmc/esbmc#5156).
+        if (element.value("esbmc_mixed_numeric_list", false))
+        {
+          python_list::add_type_info_entry(arg_id, "", long_long_int_type());
+          python_list::add_type_info_entry(arg_id, "", double_type());
+        }
       }
     }
   }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -109,6 +109,10 @@ private:
   std::string get_type_from_lhs(const std::string &id, const Json &body);
   std::string get_list_subtype(const Json &list);
   std::string get_list_type_from_literal(const Json &list_arg);
+  // True when a list literal mixes int and float numeric elements
+  // (esbmc/esbmc#5156); the parameter-inference pass uses this to mark
+  // parameters that must be read with runtime type dispatch.
+  bool is_mixed_numeric_list_literal(const Json &arg);
   // Recover a `list[T]` type for a name bound to an *empty* list literal by
   // inspecting the first `<var_name>.append(arg)` in the enclosing scope.
   // Comprehensions lower to `tmp = []; tmp.append(elt)`, so the element type

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -821,6 +821,27 @@ static Json find_first_append_arg(const Json &node, const std::string &name)
   return Json();
 }
 
+// Return true when a list literal mixes int and float numeric elements
+// (e.g. [4.0, 3, 1.7]). Such a list collapses to a single annotation but must
+// be read element-by-element with runtime type dispatch (esbmc/esbmc#5156).
+template <class Json>
+bool python_annotation<Json>::is_mixed_numeric_list_literal(const Json &arg)
+{
+  if (!arg.contains("_type") || arg["_type"] != "List" || !arg.contains("elts"))
+    return false;
+
+  bool has_int = false, has_float = false;
+  for (const auto &elt : arg["elts"])
+  {
+    const std::string t = get_argument_type(elt);
+    if (t == "int")
+      has_int = true;
+    else if (t == "float")
+      has_float = true;
+  }
+  return has_int && has_float;
+}
+
 // Method to get the full type of a list literal
 template <class Json>
 std::string
@@ -3356,6 +3377,23 @@ void python_annotation<Json>::infer_parameter_types(Json &function_element)
     for (size_t i = 0; i < params.size(); ++i)
     {
       Json &param = params[i];
+
+      // Flag a parameter that receives a heterogeneous int/float list literal
+      // at any call site. The collapsed `list[int]`/`list[float]` annotation
+      // loses this, but the element read must dispatch on the runtime type_id
+      // (see python_list::has_mixed_numeric_types / esbmc/esbmc#5156). The
+      // funcdef seeding consumes this marker to record genuinely-mixed element
+      // types for the parameter symbol.
+      for (const Json &call : function_calls)
+      {
+        if (
+          call.contains("args") && i < call["args"].size() &&
+          is_mixed_numeric_list_literal(call["args"][i]))
+        {
+          param["esbmc_mixed_numeric_list"] = true;
+          break;
+        }
+      }
 
       // Check if parameter needs type inference or refinement
       bool needs_inference = false;


### PR DESCRIPTION
## Problem

`regression/humaneval/humaneval_81` (KNOWNBUG) produced a false counterexample: iterating a mixed int/float list parameter with `for gpa in grades:` and comparing `gpa == 4.0` / `gpa > 3.7` reported VERIFICATION FAILED where SUCCESSFUL was expected.

## Root cause

A function parameter inferred from a heterogeneous int/float list literal (e.g. `numerical_letter_grade([4.0, 3, 1.7, 2, 3.5])`) collapses to `list[int]`. The loop variable then becomes `int`, so float elements truncate (`1.7 → 1`, `3.5 → 3`) and `gpa == 4.0` evaluates false even for an integral `4.0`.

PR #5160 already added the correct read in `python_list::get_subscript`: for a non-constant subscript into a list where `has_mixed_numeric_types(list_id)` is true, it reads each element by dispatching on the stored runtime `type_id` (float → `__ESBMC_float_buf[float_idx]`, int → promoted to double). But for a *parameter* that path never fired: `list_type_map` was seeded with a single element type derived from the collapsed annotation, so `has_mixed_numeric_types` returned false.

## Fix

- `python_annotation/annotation_conversion.inl`: add `is_mixed_numeric_list_literal`, and in `infer_parameter_types` mark a parameter (`esbmc_mixed_numeric_list`) when any call site passes a mixed int/float list literal at that position.
- `converter/converter_funcdef.cpp` (`register_function_argument`): when seeding a marked list parameter's `list_type_map`, also record one int and one float element so `has_mixed_numeric_types` reports it as mixed and the existing #5160 dispatch fires on the parameter read. The loop variable then resolves to `double` automatically via the converter's existing `Any`-annotation RHS-type adoption.

This keeps the list genuinely heterogeneous (per-element `type_id` preserved) and reuses the already-reviewed runtime-dispatch path rather than adding a parallel one. Changing the literal annotation to `list[float]` was rejected: it collapses `list_type_map` to homogeneous-float, disabling the dispatch and misreading int elements.

## Tests

- Flips `humaneval_81` KNOWNBUG → CORE (now VERIFICATION SUCCESSFUL).
- Adds `regression/python/mixed_list_param_for_{eq,trunc,fail}` covering the equality, float-truncation, and negative cases.
- The #5160 trio (`mixed_list_dynamic_index{,_int,_fail}`) still passes; both arms of the new conditionals are exercised (mixed-param tests vs. existing homogeneous/local-list tests).

Fixes #5156.