### PR TITLE
[python] Resolve typing.List/Dict/Set aliases to builtin collection types

### DIFF
--- a/regression/python/github_5162/main.py
+++ b/regression/python/github_5162/main.py
@@ -1,0 +1,39 @@
+# A List[List[float]] parameter annotation used to type the inner element as a
+# bogus "tag-List" struct (typing.List was not mapped to the PyListObject type
+# the lowercase builtin "list" resolves to). len(A[0]) then misrouted to
+# strlen(), aborting BMC with "argument ... strlen ... type mismatch: got
+# struct, expected pointer" (#5162). The element type now resolves correctly,
+# so len() of a nested-list subscript routes to __ESBMC_list_size.
+from typing import List
+
+
+def k(A: List[List[float]]) -> int:
+    w = len(A[0])
+    out = [0.0 for _ in range(w)]
+    return len(out)
+
+
+A = [[1.0], [2.0]]
+assert k(A) == 1
+
+
+# len() of each inner list of differing lengths is computed independently.
+def widths(M: List[List[float]]) -> int:
+    return len(M[0]) + len(M[1])
+
+
+B = [[1.0, 2.0, 3.0], [4.0]]
+assert widths(B) == 4
+
+
+# The capitalised typing alias Set shares the root cause (it was typed as a
+# bogus "tag-Set" struct inside a list); len() of a nested set must work too.
+from typing import Set
+
+
+def sizes(S: List[Set[int]]) -> int:
+    return len(S[0])
+
+
+C = [{1, 2}]
+assert sizes(C) == 2

--- a/regression/python/github_5162/test.desc
+++ b/regression/python/github_5162/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5162_fail/main.py
+++ b/regression/python/github_5162_fail/main.py
@@ -1,0 +1,14 @@
+# Negative variant of github_5162: len(A[0]) on a List[List[float]] parameter
+# now computes the correct inner-list length, so an assertion that contradicts
+# it must be reported as VERIFICATION FAILED rather than silently passing.
+from typing import List
+
+
+def k(A: List[List[float]]) -> int:
+    w = len(A[0])
+    out = [0.0 for _ in range(w)]
+    return len(out)
+
+
+A = [[1.0], [2.0]]
+assert k(A) == 2

--- a/regression/python/github_5162_fail/test.desc
+++ b/regression/python/github_5162_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -605,18 +605,33 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (ast_type == "tuple")
     return empty_typet();
 
+  // The capitalised typing-module aliases (typing.List/Dict/Set) must resolve
+  // to the same builtin collection types as their lowercase forms. Otherwise a
+  // nested annotation like List[List[float]] types its element as a bogus
+  // "tag-List" struct that no list/dict/set machinery recognises — len(A[0])
+  // then misroutes to strlen() and aborts on a struct/pointer mismatch (#5162;
+  // Dict/Set crash identically). A user may legally shadow these names with
+  // their own class (e.g. a hand-rolled `class List`, #3728), and that class
+  // must win. is_class() is unusable as the guard because it also matches the
+  // typing OM's own class definitions, which are imported in exactly the alias
+  // case we want to rewrite — so scan only the user's own module body.
+  auto typing_alias = [&](const char *alias) {
+    return ast_type == alias &&
+           json_utils::find_class(converter_.ast()["body"], alias).is_null();
+  };
+
   // list/range — range objects are stored as lists in ESBMC's model
-  if (ast_type == "list" || ast_type == "range")
+  if (ast_type == "list" || ast_type == "range" || typing_alias("List"))
     return get_list_type();
 
   // dict — handle dict type annotations
   // For generic "dict" without key/value types, return empty type
   // so the actual type is inferred from the dictionary literal
-  if (ast_type == "dict")
+  if (ast_type == "dict" || typing_alias("Dict"))
     return get_dict_type();
 
   // Reuse list infrastructure for simplicity for now
-  if (ast_type == "set")
+  if (ast_type == "set" || typing_alias("Set"))
     return get_list_type();
 
   // Custom user-defined types / classes


### PR DESCRIPTION
The capitalised typing-module aliases (`typing.List`/`Dict`/`Set`) fell through `type_handler::get_typet` to the user-class branch and became bogus `tag-List`/`tag-Dict`/`tag-Set` structs. A nested annotation like `List[List[float]]` then typed its element as that struct, so `len(A[0])` could not recognise a list and misrouted to `strlen()`, aborting BMC with "strlen: got struct, expected pointer" (#5162; `Dict`/`Set` crash identically).

This maps the aliases to the same types as the lowercase builtins, guarded so a user-defined class of that name (e.g. a hand-rolled `class List`, #3728) still wins — scanning only the user's own module body, since `is_class()` also matches the typing OM's own class definitions.

Adds `regression/python/github_5162` (List + Set, SUCCESSFUL) and `github_5162_fail` (FAILED).

Fixes #5162
