### PR TITLE
[contracts] model main's implicit return as 0 under contract enforcement

### DIFF
--- a/regression/function_contract/enforce_main_implicit_return_memleak_pass/main.c
+++ b/regression/function_contract/enforce_main_implicit_return_memleak_pass/main.c
@@ -1,0 +1,11 @@
+/* Regression for issue #5187:
+ * C11 §5.1.2.2.3p1 mandates that reaching the } that terminates main returns 0.
+ * A contract ensures(__ESBMC_return_value == 0) on a main with no explicit
+ * return must therefore hold, even when --memory-leak-check is enabled (the
+ * leak-check path used to expose a nondet implicit return value).
+ */
+__ESBMC_contract
+int main(void)
+{
+  __ESBMC_ensures(__ESBMC_return_value == 0);
+}

--- a/regression/function_contract/enforce_main_implicit_return_memleak_pass/test.desc
+++ b/regression/function_contract/enforce_main_implicit_return_memleak_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function main --enforce-contract main --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/enforce_main_implicit_return_wrong_fail/main.c
+++ b/regression/function_contract/enforce_main_implicit_return_wrong_fail/main.c
@@ -1,0 +1,12 @@
+/* Regression for issue #5187 (soundness guard):
+ * main's implicit return is 0 (C11 §5.1.2.2.3p1), so a postcondition claiming a
+ * different value must be reported as violated. Before the fix the per-main
+ * END_FUNCTION special-casing assumed false on the renamed original's exit,
+ * killing the path before the wrapper's ensures assertion — so this false
+ * postcondition passed vacuously (0 VCCs).
+ */
+__ESBMC_contract
+int main(void)
+{
+  __ESBMC_ensures(__ESBMC_return_value == 42);
+}

--- a/regression/function_contract/enforce_main_implicit_return_wrong_fail/test.desc
+++ b/regression/function_contract/enforce_main_implicit_return_wrong_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function main --enforce-contract main
+^VERIFICATION FAILED$
+contract ensures

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -184,7 +184,18 @@ void code_contractst::rename_function(
   // Copy function to new name
   goto_functiont &old_func = it->second;
   goto_functions.function_map[new_id] = old_func;
-  goto_functions.function_map[new_id].update_instructions_function(new_id);
+
+  // Force-retag every instruction to the new function id. The default
+  // update_instructions_function() only sets the field when empty, so it would
+  // leave the renamed body's instructions tagged with the old id. That matters
+  // for the entry point: when main is renamed to its contracts_original copy,
+  // its END_FUNCTION must no longer be seen as main's by symex — otherwise the
+  // per-main END_FUNCTION special-casing (assume(false) to stop exploring
+  // post-main interleavings) fires inside the wrapper-called original and kills
+  // the path before the wrapper's ensures assertion is ever checked.
+  for (auto &instruction :
+       goto_functions.function_map[new_id].body.instructions)
+    instruction.function = new_id;
 
   // Update symbol table
   symbolt *old_sym = context.find_symbol(old_id);

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -185,17 +185,16 @@ void code_contractst::rename_function(
   goto_functiont &old_func = it->second;
   goto_functions.function_map[new_id] = old_func;
 
-  // Force-retag every instruction to the new function id. The default
-  // update_instructions_function() only sets the field when empty, so it would
-  // leave the renamed body's instructions tagged with the old id. That matters
-  // for the entry point: when main is renamed to its contracts_original copy,
-  // its END_FUNCTION must no longer be seen as main's by symex — otherwise the
-  // per-main END_FUNCTION special-casing (assume(false) to stop exploring
-  // post-main interleavings) fires inside the wrapper-called original and kills
-  // the path before the wrapper's ensures assertion is ever checked.
-  for (auto &instruction :
-       goto_functions.function_map[new_id].body.instructions)
-    instruction.function = new_id;
+  // Force-retag every instruction to the new function id (the default only
+  // tags empty members, which would leave the copied body carrying the old id).
+  // This matters for the entry point: when main is renamed to its
+  // contracts_original copy, its END_FUNCTION must no longer be seen as main's
+  // by symex — otherwise the per-main END_FUNCTION special-casing (assume(false)
+  // to stop exploring post-main interleavings) fires inside the wrapper-called
+  // original and kills the path before the wrapper's ensures assertion is ever
+  // checked.
+  goto_functions.function_map[new_id].update_instructions_function(
+    new_id, /*force=*/true);
 
   // Update symbol table
   symbolt *old_sym = context.find_symbol(old_id);

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -52,6 +52,7 @@ bool goto_convert_functionst::hide(const goto_programt &goto_program)
 
 void goto_convert_functionst::add_return(
   goto_functiont &f,
+  const irep_idt &identifier,
   const locationt &location)
 {
   if (!f.body.instructions.empty() && f.body.instructions.back().is_return())
@@ -67,10 +68,22 @@ void goto_convert_functionst::add_return(
   t->make_return();
   t->location = location;
 
+  type2tc ret_type = ns.follow(to_code_type(f.type).ret_type);
+
+  // C11 §5.1.2.2.3p1: reaching the } that terminates main returns 0. Synthesize
+  // the standard-mandated implicit `return 0` instead of a nondet value so that
+  // main's return value is modelled correctly (e.g. when a contract's ensures
+  // clause refers to __ESBMC_return_value).
+  const std::string &id = id2string(identifier);
+  if (id == "c:@F@main" || has_prefix(id, "c:@F@main#"))
+  {
+    t->code = code_return2tc(gen_zero(ret_type));
+    return;
+  }
+
   // Build a nondet side-effect of the function's return type directly on
   // the irep2 side. Followed through symbol-typed aliases as the legacy
   // path did.
-  type2tc ret_type = ns.follow(to_code_type(f.type).ret_type);
   expr2tc nondet = sideeffect2tc(
     ret_type,
     expr2tc(),
@@ -140,7 +153,7 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
 
   // add non-det return value, if needed
   if (targets.has_return_value)
-    add_return(f, end_location);
+    add_return(f, identifier, end_location);
 
   // Wrap the body of functions name __VERIFIER_atomic_* with atomic_begin
   // and atomic_end

--- a/src/goto-programs/goto_convert_functions.h
+++ b/src/goto-programs/goto_convert_functions.h
@@ -51,7 +51,10 @@ protected:
   //
   // function calls
   //
-  void add_return(goto_functiont &f, const locationt &location);
+  void add_return(
+    goto_functiont &f,
+    const irep_idt &identifier,
+    const locationt &location);
 
   void wallop_type_impl(
     irep_idt name,

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -35,9 +35,11 @@ public:
   /// update the function member in each instruction
   /// \param function_id: the `function_id` used for assigning empty function
   ///   members
-  void update_instructions_function(const irep_idt &function_id)
+  /// \param force: when true, overwrite already-set function members too
+  void
+  update_instructions_function(const irep_idt &function_id, bool force = false)
   {
-    body.update_instructions_function(function_id);
+    body.update_instructions_function(function_id, force);
   }
 };
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -660,16 +660,19 @@ public:
     const irep_idt &identifier,
     std::ostream &out) const;
 
-  /// Sets the `function` member of each instruction if not yet set
+  /// Sets the `function` member of each instruction if not yet set, or
+  /// unconditionally when \p force is true (e.g. to re-tag a body copied from
+  /// another function, as contract renaming does).
   /// Note that a goto program need not be a goto function and therefore,
   /// we cannot do this in update(), but only at the level of
   /// of goto_functionst where goto programs are guaranteed to be
   /// named functions.
-  void update_instructions_function(const irep_idt &function_id)
+  void
+  update_instructions_function(const irep_idt &function_id, bool force = false)
   {
     for (auto &instruction : instructions)
     {
-      if (instruction.function.empty())
+      if (force || instruction.function.empty())
       {
         instruction.function = function_id;
       }


### PR DESCRIPTION
## Introduction

C11 §5.1.2.2.3p1 says reaching the `}` that terminates `main` returns 0. A contract `ensures(__ESBMC_return_value == 0)` on a no-return `main` should therefore hold. It did pass without `--memory-leak-check` and failed with it, so the flag looked like it was dropping the implicit return. The truth is the other way around: without the flag the contract was passing *vacuously*, and the flag merely stopped hiding a genuine modelling bug.

## Minimal Reproduction of Bug

```c
__ESBMC_contract
int main(void) {
    __ESBMC_ensures(__ESBMC_return_value == 0);
}
```

```
$ esbmc m.c --function main --enforce-contract main
VERIFICATION SUCCESSFUL          # 0 VCCs — never actually checked

$ esbmc m.c --function main --enforce-contract main --memory-leak-check
VERIFICATION FAILED              # contract ensures: return_value == 0
```

The "success" was vacuous: replacing the postcondition with `__ESBMC_return_value == 42` also passed without the flag, so a clearly false postcondition was being proven.

Two root causes:

1. `add_return` synthesized a **nondet** implicit return for `main` instead of the standard-mandated 0, so the postcondition could not hold once it was really checked.
2. `--enforce-contract main` renames `main` to `__ESBMC_contracts_original_main` via `rename_function`, which uses `update_instructions_function` — and that only tags an instruction's function when the field is empty. The renamed body kept its original `c:@F@main` tag, so symex's per-`main` `END_FUNCTION` special-casing (the `assume(false)` that stops exploring post-`main` interleavings) fired inside the wrapper-called original and killed the path before the wrapper's `ensures` assertion ran. That suppressed the check entirely without the leak flag, which is why any postcondition passed.

## Fix

- `add_return` now emits `return 0` for `main` (matched by `c:@F@main` / `c:@F@main#`), modelling the C standard. Other functions keep their nondet fall-off-the-end return.
- `rename_function` now force-retags every instruction in the renamed body to the new id, so the renamed original is no longer mistaken for the entry `main` and the special-casing only fires on the real wrapper.

With both fixes, `ensures(__ESBMC_return_value == 0)` is proven (with a real VCC) in both modes, and a wrong postcondition like `== 42` correctly fails in both — closing the vacuous-success hole. Two regression tests cover the passing and failing cases.