### PR TITLE
[python] Fix abort subscripting a tuple literal with string elements

### DIFF
--- a/regression/python/github_5185_tuple_literal_subscript/main.py
+++ b/regression/python/github_5185_tuple_literal_subscript/main.py
@@ -1,0 +1,14 @@
+# Issue #5185: subscripting a tuple literal with heterogeneous string elements
+# at a non-zero index aborted SMT encoding ("Unrecognized address_of operand")
+# because the element member of the inline constant struct rvalue is not
+# addressable. Each access here matches the CPython result.
+def main() -> None:
+    assert ("a", ".", "b.c")[0] == "a"
+    assert ("a", ".", "b.c")[1] == "."
+    assert ("a", ".", "b.c")[2] == "b.c"
+    assert ("a", ".", "b.c")[-1] == "b.c"
+    # slice over the literal then index the longer element
+    assert ("a", ".", "b.c")[1:3][1] == "b.c"
+
+
+main()

--- a/regression/python/github_5185_tuple_literal_subscript/test.desc
+++ b/regression/python/github_5185_tuple_literal_subscript/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5185_tuple_literal_subscript_fail/main.py
+++ b/regression/python/github_5185_tuple_literal_subscript_fail/main.py
@@ -1,0 +1,8 @@
+# Issue #5185 (negative variant): the subscript must produce a real verdict, not
+# an internal abort. Here the asserted element is wrong, so verification must
+# FAIL rather than crash with "Unrecognized address_of operand".
+def main() -> None:
+    assert ("a", ".", "b.c")[2] == "wrong"
+
+
+main()

--- a/regression/python/github_5185_tuple_literal_subscript_fail/test.desc
+++ b/regression/python/github_5185_tuple_literal_subscript_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -158,6 +158,28 @@ bool tuple_handler::is_tuple_type(const typet &type) const
   return struct_type.tag().as_string().find("tag-tuple") == 0;
 }
 
+exprt tuple_handler::get_tuple_element(
+  const exprt &array,
+  const struct_typet &tuple_type,
+  size_t idx) const
+{
+  const auto &components = tuple_type.components();
+
+  // An inline tuple literal `(a, b, c)` is a struct_exprt whose operands are
+  // already-materialised, addressable temp symbols (see get_tuple_expr). A
+  // member access into such a constant struct rvalue is not addressable, so a
+  // downstream address_of — e.g. the strcmp set up for a string element —
+  // reaches the unhandled constant_struct branch in smt_memspace.cpp and
+  // aborts (#5185). Return the operand directly; a named tuple variable is a
+  // symbol, for which a member access is a proper lvalue. This mirrors the
+  // identical handling in handle_tuple_membership.
+  if (array.id() == "struct" && array.operands().size() == components.size())
+    return array.operands()[idx];
+
+  return build_member(
+    array, components[idx].get_name(), components[idx].type());
+}
+
 exprt tuple_handler::handle_tuple_subscript(
   const exprt &array,
   const nlohmann::json &slice,
@@ -247,8 +269,7 @@ exprt tuple_handler::handle_tuple_subscript(
 
     struct_exprt result(new_type);
     for (size_t k : kept)
-      result.copy_to_operands(
-        build_member(array, components[k].get_name(), components[k].type()));
+      result.copy_to_operands(get_tuple_element(array, tuple_type, k));
 
     if (element.contains("lineno"))
       result.location() = converter_.get_location_from_decl(element);
@@ -319,11 +340,10 @@ exprt tuple_handler::handle_tuple_subscript(
     converter_.add_instruction(bounds_assert);
 
     // Build chain: i==n-1 ? element_(n-1) : (... ? ... : element_0)
-    exprt chain = build_member(array, components[0].get_name(), first_type);
+    exprt chain = get_tuple_element(array, tuple_type, 0);
     for (size_t k = 1; k < n; ++k)
     {
-      exprt member =
-        build_member(array, components[k].get_name(), components[k].type());
+      exprt member = get_tuple_element(array, tuple_type, k);
       exprt cond =
         binary_relation_exprt(idx_norm, "=", from_integer(BigInt(k), idx_type));
       if_exprt sel(cond, member, chain);
@@ -353,11 +373,9 @@ exprt tuple_handler::handle_tuple_subscript(
       "Tuple index out of range (size: " + std::to_string(tuple_size) + ")");
   }
 
-  // Create member access expression: t[0] -> t.element_0
-  std::string member_name = "element_" + integer2string(index_val);
-  const struct_typet::componentt &comp = tuple_type.components()[idx];
-
-  exprt result = build_member(array, member_name, comp.type());
+  // Create member access expression: t[0] -> t.element_0 (or, for an inline
+  // tuple literal, the addressable operand symbol — see get_tuple_element).
+  exprt result = get_tuple_element(array, tuple_type, idx);
 
   if (element.contains("lineno"))
   {

--- a/src/python-frontend/tuple_handler.h
+++ b/src/python-frontend/tuple_handler.h
@@ -114,6 +114,25 @@ private:
    */
   std::string build_tuple_tag(const std::vector<typet> &element_types) const;
 
+  /**
+   * @brief Obtain an addressable expression for tuple element @p idx
+   *
+   * For an inline tuple literal (a struct_exprt whose operands are
+   * already-materialised temp symbols) a member access into the constant
+   * struct rvalue is not addressable, so any downstream address_of (e.g. a
+   * strcmp on a string element) aborts SMT encoding (#5185). In that case the
+   * operand symbol is returned directly; for a named tuple variable a member
+   * access is a proper lvalue.
+   * @param array The tuple expression (literal or named variable)
+   * @param tuple_type The tuple struct type
+   * @param idx The element index
+   * @return exprt An addressable expression denoting element @p idx
+   */
+  exprt get_tuple_element(
+    const exprt &array,
+    const struct_typet &tuple_type,
+    size_t idx) const;
+
   python_converter &converter_;
   type_handler &type_handler_;
 };


### PR DESCRIPTION
Subscripting a Python tuple literal with string elements — e.g. `("a", ".", "b.c")[2]` — aborted SMT encoding with "Unrecognized address_of operand" instead of producing a verdict. An inline tuple literal is a `struct_exprt` rvalue, so the member access used by the subscript paths was not addressable, and the `strcmp` set up for the string element took `address_of` of a constant-struct member and hit an unhandled branch. Add `tuple_handler::get_tuple_element`, which returns the already-addressable operand symbol for an inline literal and falls back to a member access for named tuple variables, applied across the constant-index, if-chain, and slice paths. 

Fixes #5185.