### PR TITLE
[python] compare int/float list elements numerically in list_eq

### DIFF
--- a/regression/humaneval/humaneval_130/test.desc
+++ b/regression/humaneval/humaneval_130/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --bitwuzla --unwind 9 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-eq-int-float/main.py
+++ b/regression/python/list-eq-int-float/main.py
@@ -1,0 +1,5 @@
+# Mixed int/float list equality follows Python numeric semantics: 1 == 1.0.
+assert [1, 2] == [1.0, 2.0]
+assert [1.0, 2.0] == [1, 2]
+assert [1] != [1.5]
+assert ([1] == [1.5]) == False

--- a/regression/python/list-eq-int-float/test.desc
+++ b/regression/python/list-eq-int-float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-eq-int-float_fail/main.py
+++ b/regression/python/list-eq-int-float_fail/main.py
@@ -1,0 +1,2 @@
+# [1] == [1.5] is False in Python (1 != 1.5), so this assertion must fail.
+assert [1] == [1.5]

--- a/regression/python/list-eq-int-float_fail/test.desc
+++ b/regression/python/list-eq-int-float_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --smt-during-symex --smt-symex-guard
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -223,7 +223,8 @@ bool __ESBMC_list_eq(
   const PyListObject *l1,
   const PyListObject *l2,
   size_t list_type_id,
-  size_t max_depth)
+  size_t max_depth,
+  size_t float_type_id)
 {
   // Quick checks
   if (!l1 || !l2)
@@ -289,7 +290,32 @@ bool __ESBMC_list_eq(
     {
       // size == 0 means a dict pointer or None element — stored by pointer
       // identity, not byte content, so cross-type-id comparison is unsound.
-      if (a->size == 0 || !__ESBMC_values_equal(a->value, b->value, a->size))
+      if (a->size == 0)
+        return false;
+
+      // int-vs-float: Python compares numerically (1 == 1.0), but the two
+      // store different bit patterns, so a byte compare would wrongly differ.
+      // Triggered when exactly one side is a float (sizes already match here,
+      // and float/int elements are both 8 bytes). float_type_id is derived by
+      // the frontend from top-level element types only, so this numeric path
+      // does not reach nested mixed int/float lists; like list_lt, the int side
+      // is widened to double, so |int| > 2^53 loses precision vs CPython.
+      if (
+        float_type_id != 0 && a->size == 8 &&
+        (a->type_id == float_type_id) != (b->type_id == float_type_id))
+      {
+        double av = (a->type_id == float_type_id)
+                      ? *(const double *)a->value
+                      : (double)*(const int64_t *)a->value;
+        double bv = (b->type_id == float_type_id)
+                      ? *(const double *)b->value
+                      : (double)*(const int64_t *)b->value;
+        if (av != bv)
+          return false;
+        continue;
+      }
+
+      if (!__ESBMC_values_equal(a->value, b->value, a->size))
         return false;
       continue;
     }
@@ -767,7 +793,7 @@ bool __ESBMC_dict_eq(
       const PyListObject *rhs_list =
         (rhs_value->size == 0) ? (const PyListObject *)rhs_value->value
                                : *(const PyListObject **)rhs_value->value;
-      if (!__ESBMC_list_eq(lhs_list, rhs_list, 0, 0))
+      if (!__ESBMC_list_eq(lhs_list, rhs_list, 0, 0, 0))
         return false;
     }
     else

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3231,6 +3231,23 @@ exprt python_list::compare(
   max_depth_expr.set_value(
     integer2binary(max_depth, config.ansi_c.address_width));
 
+  // Merge the float element type_id from both operands so that mixed int/float
+  // elements compare numerically (Python's 1 == 1.0), as list_lt already does.
+  int type_flag_lhs = 0, type_flag_rhs = 0;
+  size_t float_type_id_lhs = 0, float_type_id_rhs = 0;
+  get_list_type_flags(
+    lhs_symbol->id.as_string(),
+    converter_.get_type_handler(),
+    type_flag_lhs,
+    float_type_id_lhs);
+  get_list_type_flags(
+    rhs_symbol->id.as_string(),
+    converter_.get_type_handler(),
+    type_flag_rhs,
+    float_type_id_rhs);
+  const size_t float_type_id =
+    float_type_id_lhs ? float_type_id_lhs : float_type_id_rhs;
+
   code_function_callt list_eq_func_call;
   list_eq_func_call.function() = build_symbol(*list_eq_func_sym);
   list_eq_func_call.lhs() = build_symbol(eq_ret);
@@ -3239,6 +3256,8 @@ exprt python_list::compare(
   list_eq_func_call.arguments().push_back(build_symbol(*rhs_symbol)); // l2
   list_eq_func_call.arguments().push_back(list_type_id);   // list_type_id
   list_eq_func_call.arguments().push_back(max_depth_expr); // max_depth
+  list_eq_func_call.arguments().push_back(
+    from_integer(float_type_id, size_type())); // float_type_id
   list_eq_func_call.type() = bool_type();
   list_eq_func_call.location() = converter_.get_location_from_decl(list_value_);
   converter_.add_instruction(list_eq_func_call);


### PR DESCRIPTION
Python list equality compares elements with `==`, so `1 == 1.0` holds and `tri(3) == [1, 3, 2.0, 8.0]` is True even when one list stores `1`/`3` as ints and the other as floats. `__ESBMC_list_eq` fell back to a raw byte comparison when element type_ids differed, so int `1` (`0x..01`) and float `1.0` (`0x3FF0..`) wrongly compared unequal and humaneval_130 reported VERIFICATION FAILED.

This passes the float type_id into `__ESBMC_list_eq` (mirroring `__ESBMC_list_lt`) and adds a numeric int-vs-float comparison path. Flips humaneval_130 KNOWNBUG → CORE and adds `list-eq-int-float{,_fail}` regression tests for the equal and unequal mixed-type cases.