### PR TITLE
[python] Fix ord() of runtime strings crashing goto_check

### DIFF
--- a/regression/python/ord-runtime-str/main.py
+++ b/regression/python/ord-runtime-str/main.py
@@ -1,0 +1,18 @@
+# ord() of a runtime string (variable, method result, or index) returns the
+# code point of its single character without crashing goto_check.
+def first_code(s: str) -> int:
+    return ord(s)
+
+
+def lower_code(s: str) -> int:
+    return ord(s.lower())
+
+
+def index_code(s: str) -> int:
+    return ord(s[0])
+
+
+if __name__ == "__main__":
+    assert first_code("a") == 97
+    assert lower_code("Z") == 122
+    assert index_code("bc") == 98

--- a/regression/python/ord-runtime-str/test.desc
+++ b/regression/python/ord-runtime-str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/ord-runtime-str_fail/main.py
+++ b/regression/python/ord-runtime-str_fail/main.py
@@ -1,0 +1,7 @@
+# ord() of a runtime string returns the code point of its first character.
+def first_code(s: str) -> int:
+    return ord(s)
+
+
+if __name__ == "__main__":
+    assert first_code("a") == 98  # wrong: ord("a") == 97

--- a/regression/python/ord-runtime-str_fail/test.desc
+++ b/regression/python/ord-runtime-str_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/ord-ternary-throw_fail/main.py
+++ b/regression/python/ord-ternary-throw_fail/main.py
@@ -1,0 +1,10 @@
+# ord() of a non-string raises TypeError. Inside a ternary condition the
+# exception must propagate, not crash goto_check with a null if-condition.
+def f(x: int) -> bool:
+    return True if 97 <= ord(x) else False
+
+
+if __name__ == "__main__":
+    # f(5) raises TypeError inside the ternary condition before the assert is
+    # ever evaluated; the verdict is an uncaught exception, not an assert fail.
+    assert f(5) == True

--- a/regression/python/ord-ternary-throw_fail/test.desc
+++ b/regression/python/ord-ternary-throw_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$
+uncaught exception

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -2966,6 +2966,14 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
   // ternary operator
   if (type == "IfExp")
   {
+    // A condition that raised while being evaluated (e.g. ord() of a bad
+    // argument) arrives as a cpp-throw side effect, not a boolean value.
+    // Propagate the exception instead of building an if2t with a non-boolean
+    // condition, which migrates to a null cond and crashes goto_check. Mirrors
+    // the cpp-throw guards in get_binary_operator_expr.
+    if (cond.statement() == "cpp-throw")
+      return cond;
+
     // Normalize branches: code_function_callt must become side_effect_expr so
     // that migration to irep2 preserves the correct return type in if2t.
     then = to_value_expr(then, ns);

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -261,6 +261,12 @@ private:
   exprt handle_ord(nlohmann::json &arg) const;
 
   /*
+   * Rewrites the argument AST node into an integer Constant holding the given
+   * code point and returns the resulting int expression. Helper for handle_ord.
+   */
+  exprt build_ord_constant(nlohmann::json &arg, int code_point) const;
+
+  /*
    * Handles abs() function calls by computing the absolute value of the argument.
    * The argument can be an integer, a floating-point number, or an object implementing
    * the __abs__() method. The function returns an expression representing the absolute value.

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -281,106 +281,67 @@ exprt function_call_expr::handle_chr(nlohmann::json &arg) const
   return converter_.get_string_handler().handle_chr_conversion(var_expr, loc);
 }
 
-exprt function_call_expr::handle_ord(nlohmann::json &arg) const
+// Fold a known code point into an integer expression, rewriting the AST node
+// in place so converter_.get_expr() builds an int constant.
+exprt function_call_expr::build_ord_constant(
+  nlohmann::json &arg,
+  int code_point) const
 {
-  int code_point = 0;
-
-  // Ensure the argument is a string
-  if (is_string_arg(arg))
-  {
-    const std::string &s = arg["value"].get<std::string>();
-    code_point = decode_utf8_codepoint(s);
-  }
-  // Handle ord with symbol
-  else if (arg["_type"] == "Name" && arg.contains("id"))
-  {
-    const symbolt *sym = lookup_python_symbol(arg["id"]);
-    if (!sym)
-    {
-      std::string var_name = arg["id"].get<std::string>();
-      return converter_.get_exception_handler().gen_exception_raise(
-        "NameError", "variable '" + var_name + "' is not defined");
-    }
-
-    typet operand_type = sym->get_value().type();
-    std::string py_type = type_handler_.type_to_string(operand_type);
-
-    if (operand_type != char_type() && py_type != "str")
-    {
-      return converter_.get_exception_handler().gen_exception_raise(
-        "TypeError",
-        "ord() expected string of length 1, but " + py_type + " found");
-    }
-
-    // For runtime variables (mutable), try to extract constant value if available
-    if (sym->lvalue && !sym->get_value().is_nil())
-    {
-      auto value_opt = extract_string_from_symbol(sym);
-      if (value_opt)
-      {
-        // Successfully extracted constant value from lvalue string
-        code_point = decode_utf8_codepoint(*value_opt);
-
-        // Remove Name data
-        arg["_type"] = "Constant";
-        arg.erase("id");
-        arg.erase("ctx");
-
-        // Replace the arg with the integer value
-        arg["value"] = code_point;
-        arg["type"] = "int";
-
-        // Build and return the integer expression
-        exprt expr = converter_.get_expr(arg);
-        expr.type() = type_handler_.get_typet("int", 0);
-        return expr;
-      }
-      // If extraction failed for lvalue, fall through to runtime conversion
-    }
-
-    // Use runtime conversion for variables without constant value or failed extraction
-    if (sym->get_value().is_nil() || sym->lvalue)
-    {
-      exprt var_expr = converter_.get_expr(arg);
-
-      if (
-        var_expr.type() == char_type() || var_expr.type().is_signedbv() ||
-        var_expr.type().is_unsignedbv())
-      {
-        return typecast_exprt(var_expr, int_type());
-      }
-
-      return converter_.get_exception_handler().gen_exception_raise(
-        "ValueError", "ord() requires a character");
-    }
-
-    // Compile-time extraction for constant symbols
-    auto value_opt = extract_string_from_symbol(sym);
-    if (!value_opt)
-    {
-      return converter_.get_exception_handler().gen_exception_raise(
-        "ValueError", "failed to extract string from symbol");
-    }
-
-    code_point = decode_utf8_codepoint(*value_opt);
-
-    // Remove Name data
-    arg["_type"] = "Constant";
-    arg.erase("id");
-    arg.erase("ctx");
-  }
-  else
-    return converter_.get_exception_handler().gen_exception_raise(
-      "TypeError", "ord() argument must be a string");
-
-  // Replace the arg with the integer value
+  arg["_type"] = "Constant";
+  arg.erase("id");
+  arg.erase("ctx");
   arg["value"] = code_point;
   arg["type"] = "int";
 
-  // Build and return the integer expression
   exprt expr = converter_.get_expr(arg);
   expr.type() = type_handler_.get_typet("int", 0);
   return expr;
+}
+
+exprt function_call_expr::handle_ord(nlohmann::json &arg) const
+{
+  // Fast path: constant string literal. Folding also handles multi-byte UTF-8
+  // code points that the byte-level runtime string model cannot reconstruct.
+  if (is_string_arg(arg))
+    return build_ord_constant(
+      arg, decode_utf8_codepoint(arg["value"].get<std::string>()));
+
+  // A Name bound to a constant string: fold from the stored value. Gate on the
+  // value being a string so a non-string variable (e.g. `a: str = 1`) skips
+  // folding and falls through to the runtime tail, which raises TypeError.
+  if (arg["_type"] == "Name" && arg.contains("id"))
+  {
+    const symbolt *sym = lookup_python_symbol(arg["id"]);
+    if (!sym)
+      return converter_.get_exception_handler().gen_exception_raise(
+        "NameError",
+        "variable '" + arg["id"].get<std::string>() + "' is not defined");
+
+    if (type_utils::is_string_type(sym->get_value().type()))
+      if (auto value_opt = extract_string_from_symbol(sym))
+        return build_ord_constant(arg, decode_utf8_codepoint(*value_opt));
+    // Non-constant string variable: fall through to runtime evaluation.
+  }
+
+  // Runtime evaluation for slices, method results, and string variables without
+  // a constant value: ord(s), ord(s[i]), ord(s.lower()).
+  exprt expr = converter_.get_expr(arg);
+
+  // Propagate an exception raised while evaluating the argument.
+  if (expr.statement() == "cpp-throw")
+    return expr;
+
+  // A character from string indexing is an 8-bit int tagged #cpp_type==char.
+  if (type_utils::is_char_type(expr.type()))
+    return typecast_exprt(expr, int_type());
+
+  // A runtime string: return the code point of its first character.
+  if (type_utils::is_string_type(expr.type()))
+    return converter_.get_string_handler().handle_ord_conversion(
+      expr, converter_.get_location_from_decl(call_));
+
+  return converter_.get_exception_handler().gen_exception_raise(
+    "TypeError", "ord() expected string of length 1");
 }
 
 exprt function_call_expr::handle_int_to_str(nlohmann::json &arg) const

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1973,6 +1973,21 @@ exprt string_handler::handle_chr_conversion(
   return chr_call;
 }
 
+exprt string_handler::handle_ord_conversion(
+  const exprt &string_obj,
+  const locationt &location)
+{
+  // Take the base address of the (null-terminated) string.
+  exprt string_copy = string_obj;
+  exprt str_expr = ensure_null_terminated_string(string_copy);
+  exprt str_addr = get_array_base_address(str_expr);
+
+  // Code point of the single character: (int) *str_addr.
+  exprt first_char = dereference_exprt(str_addr, char_type());
+  first_char.location() = location;
+  return build_typecast(first_char, int_type());
+}
+
 exprt string_handler::try_handle_len_string_fast_path(
   const nlohmann::json &call_json,
   const exprt &arg_expr)

--- a/src/python-frontend/string/string_handler.h
+++ b/src/python-frontend/string/string_handler.h
@@ -742,6 +742,19 @@ public:
   exprt
   handle_chr_conversion(const exprt &codepoint_arg, const locationt &location);
 
+  /**
+   * Handle ord() of a runtime string whose value is not known at compile time.
+   * Returns the integer code point of the string's first character,
+   * (int) *base. A length-1 precondition is not enforced because a runtime
+   * guard cannot be short-circuited inside an and/or operand; constant strings
+   * (including multi-byte) are folded by the caller instead.
+   * @param string_obj The runtime string argument
+   * @param location Source location for error reporting
+   * @return Expression representing the integer code point
+   */
+  exprt
+  handle_ord_conversion(const exprt &string_obj, const locationt &location);
+
 private:
   python_converter &converter_;
   contextt &symbol_table_;


### PR DESCRIPTION
`ord()` of a runtime `str`, slice, or method result returned a `cpp-throw`
exception as a value; used as a ternary condition it migrated to an `if2t`
with a null `cond` and segfaulted `goto_check` (HumanEval/134). `handle_ord`
now folds constant strings and returns the `(int)` first-character code point
for runtime strings, while the ternary builder propagates a `cpp-throw`
condition instead of building a malformed `if2t`.