### PR TITLE
[python] Infer list return type for list-returning functions

### DIFF
--- a/regression/humaneval/humaneval_62/test.desc
+++ b/regression/humaneval/humaneval_62/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_return_inferred/main.py
+++ b/regression/python/list_return_inferred/main.py
@@ -1,0 +1,9 @@
+# An unannotated function that returns a sliced list comprehension must infer a
+# list return type, not default to scalar double. Defaulting to double retyped
+# the returned list's elements and broke equality against an int list
+# (regression/humaneval/humaneval_62).
+def derivative(xs: list):
+    return [(i * x) for i, x in enumerate(xs)][1:]
+
+
+assert derivative([3, 1, 2]) == [1, 4]

--- a/regression/python/list_return_inferred/test.desc
+++ b/regression/python/list_return_inferred/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_return_inferred_fail/main.py
+++ b/regression/python/list_return_inferred_fail/main.py
@@ -1,0 +1,7 @@
+# Negative: a wrong expected list must yield a real VERIFICATION FAILED, proving
+# the result is genuinely computed (not a vacuous/abort verdict).
+def derivative(xs: list):
+    return [(i * x) for i, x in enumerate(xs)][1:]
+
+
+assert derivative([3, 1, 2]) == [1, 99]

--- a/regression/python/list_return_inferred_fail/test.desc
+++ b/regression/python/list_return_inferred_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -21,6 +21,7 @@
 #include <util/symbolic_types.h>
 
 #include <functional>
+#include <set>
 
 using namespace json_utils;
 
@@ -278,6 +279,120 @@ python_converter::infer_types_from_returns(const nlohmann::json &function_body)
   scan(function_body);
   return flags;
 }
+
+namespace
+{
+bool is_list_literal_value(const nlohmann::json &v)
+{
+  return v.is_object() && v.contains("_type") &&
+         (v["_type"] == "List" || v["_type"] == "ListComp");
+}
+
+// Collect names bound to a list value within 'body': either assigned a list
+// literal / comprehension, or annotated `list`/`List`. The comprehension
+// desugaring runs before return-type inference, so a `return [..][1:]` reaches
+// here as `return ESBMC_listcomp_0[1:]` with `ESBMC_listcomp_0: list = [...]`
+// hoisted above it — the name must be tracked to recognise the list slice.
+void collect_list_bound_names(
+  const nlohmann::json &body,
+  std::set<std::string> &names)
+{
+  if (!body.is_array())
+    return;
+
+  for (const auto &stmt : body)
+  {
+    if (!stmt.is_object())
+      continue;
+
+    const std::string st = stmt.value("_type", std::string());
+    if (
+      st == "Assign" && stmt.contains("value") &&
+      is_list_literal_value(stmt["value"]) && stmt.contains("targets"))
+    {
+      for (const auto &tgt : stmt["targets"])
+        if (tgt.is_object() && tgt.value("_type", std::string()) == "Name")
+          names.insert(tgt.value("id", std::string()));
+    }
+    else if (st == "AnnAssign" && stmt.contains("target"))
+    {
+      const bool list_ann =
+        stmt.contains("annotation") && stmt["annotation"].is_object() &&
+        (stmt["annotation"].value("id", std::string()) == "list" ||
+         stmt["annotation"].value("id", std::string()) == "List");
+      const bool list_val =
+        stmt.contains("value") && is_list_literal_value(stmt["value"]);
+      const auto &tgt = stmt["target"];
+      if (
+        (list_ann || list_val) && tgt.is_object() &&
+        tgt.value("_type", std::string()) == "Name")
+        names.insert(tgt.value("id", std::string()));
+    }
+
+    for (const char *key : {"body", "orelse"})
+      if (stmt.contains(key))
+        collect_list_bound_names(stmt[key], names);
+  }
+}
+
+// Return true if a return expression denotes a list value: a list literal /
+// comprehension, a name bound to one, or a slice of either (a slice of a list
+// is a list, whereas an index t[i] is an element). Used to keep an unannotated,
+// list-returning function from defaulting its return type to scalar double,
+// which would retype the returned list's elements and break list equality
+// (humaneval_62).
+bool return_value_is_list(
+  const nlohmann::json &val,
+  const std::set<std::string> &list_names)
+{
+  if (!val.is_object() || !val.contains("_type"))
+    return false;
+
+  const std::string t = val["_type"].get<std::string>();
+  if (t == "List" || t == "ListComp")
+    return true;
+  if (t == "Name")
+    return list_names.count(val.value("id", std::string())) > 0;
+  if (
+    t == "Subscript" && val.contains("slice") && val["slice"].is_object() &&
+    val["slice"].value("_type", std::string()) == "Slice" &&
+    val.contains("value"))
+    return return_value_is_list(val["value"], list_names);
+
+  return false;
+}
+
+// Return true if any return statement in 'body' returns a list value. Mirrors
+// the body/orelse recursion of infer_types_from_returns so the two agree on the
+// statement set being inspected.
+bool body_returns_list_value(const nlohmann::json &body)
+{
+  std::set<std::string> list_names;
+  collect_list_bound_names(body, list_names);
+
+  std::function<bool(const nlohmann::json &)> check =
+    [&](const nlohmann::json &b) -> bool {
+    if (!b.is_array())
+      return false;
+    for (const auto &stmt : b)
+    {
+      if (!stmt.is_object())
+        continue;
+      if (
+        stmt.value("_type", std::string()) == "Return" &&
+        stmt.contains("value") && !stmt["value"].is_null() &&
+        return_value_is_list(stmt["value"], list_names))
+        return true;
+      for (const char *key : {"body", "orelse"})
+        if (stmt.contains(key) && check(stmt[key]))
+          return true;
+    }
+    return false;
+  };
+
+  return check(body);
+}
+} // namespace
 
 // Return true if 'param_name' has any attribute written (x.attr = ...)
 // anywhere in 'body' (recursive scan over nested blocks).
@@ -957,10 +1072,26 @@ void python_converter::get_function_definition(
     {
       // Infer type from return statements
       TypeFlags flags = infer_types_from_returns(function_node["body"]);
-      type.return_type() = type_utils::select_widest_type(flags, double_type());
 
-      if (!flags.has_float && !flags.has_int && !flags.has_bool)
-        log_warning("Default to double since no type could be inferred");
+      if (
+        !flags.has_float && !flags.has_int && !flags.has_bool &&
+        body_returns_list_value(function_node["body"]))
+      {
+        // No scalar type could be inferred but the body returns a list whose
+        // element type is unknown. Defaulting to scalar double would retype the
+        // returned list's elements and break equality against, e.g., an int
+        // list (humaneval_62). Use a generic list type, as an explicit
+        // `-> list` annotation would.
+        type.return_type() = type_handler_.get_list_type();
+      }
+      else
+      {
+        type.return_type() =
+          type_utils::select_widest_type(flags, double_type());
+
+        if (!flags.has_float && !flags.has_int && !flags.has_bool)
+          log_warning("Default to double since no type could be inferred");
+      }
     }
     else if (return_type == "Union")
     {


### PR DESCRIPTION
## Summary

Fixes `regression/humaneval/humaneval_62` (was `KNOWNBUG`). An unannotated Python function that returns a **list** — e.g.

```python
def derivative(xs: list):
    return [(i * x) for i, x in enumerate(xs)][1:]
assert derivative([3, 1, 2, 4, 5]) == [1, 4, 12, 20]   # CPython: True
```

produced a wrong `VERIFICATION FAILED` (a transitivity-violating verdict: `derivative(xs) == xs[1:]` held and `xs[1:] == [literal]` held, but `derivative(xs) == [literal]` did not).

## Root cause

The function has no return annotation, so an earlier pass rewrites it to `-> Any` and `get_function_definition` infers the return type from the body via `infer_types_from_returns`. That routine only recognises **scalar** returns (it sets `has_int`/`has_float`/`has_bool`); a `List`/`ListComp`/slice return sets no flag. With no flag set, the call site fell to `select_widest_type(flags, double_type())` and typed the return as scalar **`double`**.

That retyped the returned list's elements as `double`. `__ESBMC_list_eq` then bitwise-compared the `double` elements (`1.0` → `0x3FF0…`) against the `int` literal list's elements (`1` → `0x1`) and returned false, even though every element and the length matched (confirmed: element-wise `==` and `len()` both pass). Slicing the parameter directly (`xs[1:]`) keeps the original `int` elements, which is why only the comprehension-derived return failed.

## Fix

In the `return_type == "Any"` branch of `get_function_definition`: when no scalar type is inferred **and** the body returns a list value, set the return type to `type_handler_.get_list_type()` — the same generic `PyListObject*` type an explicit `-> list` annotation produces — instead of defaulting to scalar `double`.

Detecting "returns a list" is done from the AST after comprehension desugaring (`return [..][1:]` arrives as `ESBMC_listcomp_0: list = [...]; return ESBMC_listcomp_0[1:]`), so the new helpers:
- track names bound to a list value (`List`/`ListComp` assignment, or `list`/`List`-annotated `AnnAssign`);
- treat a return as list-valued if it is a `List`/`ListComp`, a name bound to one, or a **slice** (`Subscript` with a `Slice`, not an index) of either.

The detector mirrors the `body`/`orelse` recursion of `infer_types_from_returns` so the two passes agree on the statements inspected.

## Why it is correct / sound

- **Conjunctive gate.** The list type is chosen only when `infer_types_from_returns` found *no* scalar flag. Any scalar return (including a bare `return name`, which sets `has_int`) keeps the previous behaviour, so scalar functions are unaffected.
- **Index vs. slice.** Only `Subscript` with `slice._type == "Slice"` is list-valued; an element index `t[i]` is correctly excluded.
- **Optional/None.** A list-or-`None` function (only `has_none` set) now resolves to the list type rather than `double`; the `None` path was already mistyped under the old `double` default, so this is strictly more correct, not a regression.
- Matches the verified `-> list` path (`get_list_type()`), which already produced the correct verdict for this program.

## Validation

- `humaneval_62` → `VERIFICATION SUCCESSFUL` (flipped `KNOWNBUG` → `CORE`).
- New `regression/python/list_return_inferred` (passing) and `list_return_inferred_fail` (non-vacuous `VERIFICATION FAILED`) guard the fix; CPython sanity passes for both.
- Scalar-returning untyped functions, float-element list returns, and the default-solver `list*`/`*comprehension*` regression tests all still pass (spot-checked). No regressions: the only `ctest` failures in this environment are pre-existing and solver/stub-driven (tests requiring `--z3`/`--boolector`/`--ir` not built into the local binary, or `import flask` missing typeshed stubs — all fail before/independently of this frontend change).
- Reviewed with the code-reviewer agent (0 critical/major findings; one suggested micro-cleanup applied).

## Note

This narrows the *return-type* default for list-returning functions; bare `return mylist` (a non-sliced list variable) is unchanged because `infer_types_from_returns` classifies any bare-name return as `int` — out of scope here.
