### PR TITLE
[python] Emit det TypeError on non-numeric arrays (#5206)

### DIFF
--- a/regression/numpy/det_negative_float_success/main.py
+++ b/regression/numpy/det_negative_float_success/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# Unary-negated float matrix elements exercise the UnaryOp branch of the
+# numeric pre-check in try_extract_numeric_constant (issue #5206). Verify a
+# negative-float matrix is still accepted and the determinant is correct:
+# det([[-2.0, 1.0], [4.0, -3.0]]) = (-2.0)(-3.0) - (1.0)(4.0) = 2.0
+m = np.array([[-2.0, 1.0], [4.0, -3.0]])
+x = np.linalg.det(m)
+assert x == 2.0

--- a/regression/numpy/det_negative_float_success/test.desc
+++ b/regression/numpy/det_negative_float_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -127,18 +127,41 @@ try_extract_numeric_constant(const nlohmann::json &node, numeric_value &out)
     return false;
 
   const std::string type = node["_type"];
-  if (type != "Constant" && type != "UnaryOp")
+
+  // The boolean try_extract_* helpers must not depend on catching an exception
+  // for control flow: extract_value() raises std::runtime_error on non-numeric
+  // input, and relying on that as a flow-control signal is fragile. Pre-check
+  // that the payload is numeric and only call extract_value() when it is
+  // guaranteed to succeed, so a non-numeric literal (e.g. a str element in
+  // numpy.linalg.det's matrix) makes this helper return false cleanly instead
+  // of letting the internal "Unknown numeric type" error escape to the user
+  // (issue #5206).
+  if (type == "UnaryOp")
+  {
+    if (
+      !node.contains("operand") || !node["operand"].is_object() ||
+      !node["operand"].contains("value"))
+      return false;
+    // extract_value() only negates integer/float operands.
+    const auto &operand = node["operand"]["value"];
+    if (!operand.is_number_integer() && !operand.is_number_float())
+      return false;
+  }
+  else if (type == "Constant")
+  {
+    if (!node.contains("value"))
+      return false;
+    const auto &value = node["value"];
+    if (
+      !value.is_boolean() && !value.is_number_integer() &&
+      !value.is_number_float())
+      return false;
+  }
+  else
     return false;
 
-  try
-  {
-    out = extract_value(node);
-    return true;
-  }
-  catch (const std::exception &)
-  {
-    return false;
-  }
+  out = extract_value(node);
+  return true;
 }
 
 static scalar_value make_real_scalar(double value)


### PR DESCRIPTION
`numpy.linalg.det` on a non-numeric array surfaced the internal "Unknown numeric type in JSON" error instead of the intended `TypeError`, because the boolean helper `try_extract_numeric_constant` relied on catching `extract_value()`'s exception for control flow. Pre-check the JSON payload kind (UnaryOp operand int/float; Constant value bool/int/float) so non-numeric input returns false cleanly and the `det` handler emits its own `TypeError`; the acceptance set mirrors `extract_value()` exactly, so numeric matrices are unaffected. Validated by `regression/numpy/det_non_numeric_fail` (previously failing, now passing) plus a new `det_negative_float_success` guard for the UnaryOp-float branch; full `regression/numpy` suite passes.

Fixes #5206
