### PR TITLE
[python] Support nested tuple-unpacking targets

### DIFF
--- a/regression/python/nested_tuple_unpack/main.py
+++ b/regression/python/nested_tuple_unpack/main.py
@@ -1,0 +1,22 @@
+# Nested tuple unpacking targets, e.g. `(a, b), c`, must be supported wherever
+# the RHS is a runtime value (not just a literal flattened at compile time):
+# for-loop iteration, direct assignment from a subscript, and function returns.
+items = [((1, 2), 3), ((4, 5), 6)]
+total = 0
+for (a, b), c in items:
+    total = total + a + b + c
+assert total == 21
+
+# Two nested tuples in one target.
+data = [((1, 2), (3, 4))]
+s = 0
+for (a, b), (c, d) in data:
+    s = s + a + b + c + d
+assert s == 10
+
+# Nested unpack from a function return value.
+def pair_and_value():
+    return (7, 8), 9
+
+(x, y), z = pair_and_value()
+assert x == 7 and y == 8 and z == 9

--- a/regression/python/nested_tuple_unpack/test.desc
+++ b/regression/python/nested_tuple_unpack/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested_tuple_unpack_fail/main.py
+++ b/regression/python/nested_tuple_unpack_fail/main.py
@@ -1,0 +1,7 @@
+# Negative companion: the nested unpacking is performed correctly, but the
+# asserted sum is wrong, so verification must FAIL.
+items = [((1, 2), 3), ((4, 5), 6)]
+total = 0
+for (a, b), c in items:
+    total = total + a + b + c
+assert total == 99

--- a/regression/python/nested_tuple_unpack_fail/test.desc
+++ b/regression/python/nested_tuple_unpack_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/nested_tuple_unpack_scalar_fail/main.py
+++ b/regression/python/nested_tuple_unpack_scalar_fail/main.py
@@ -1,0 +1,5 @@
+# Unpacking a non-tuple element into a nested pattern is a TypeError in Python
+# (cannot unpack non-iterable int). ESBMC must reject it explicitly rather than
+# cast a non-struct component, which guards the nested-unpacking recursion.
+pair = (5, 3)
+(a, b), c = pair

--- a/regression/python/nested_tuple_unpack_scalar_fail/test.desc
+++ b/regression/python/nested_tuple_unpack_scalar_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: Cannot unpack non-tuple element into nested target$

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -464,11 +464,34 @@ void tuple_handler::handle_tuple_unpacking(
   // Create assignments: x = temp.element_0, y = temp.element_1, ...
   for (size_t i = 0; i < targets.size(); i++)
   {
-    if (targets[i]["_type"] != "Name")
+    const std::string tgt_type = targets[i]["_type"].get<std::string>();
+
+    // Nested tuple/list target, e.g. `(a, b), c = pair_and_value`. Resolve the
+    // element's (possibly symbol-referenced) type to a concrete struct, build
+    // the member access temp.element_i, and recurse so the sub-pattern is
+    // unpacked element-wise.
+    if (tgt_type == "Tuple" || tgt_type == "List")
+    {
+      const typet resolved =
+        converter_.name_space().follow(tuple_type.components()[i].type());
+      // Guard before recursing: unpacking a non-tuple element into a nested
+      // pattern (e.g. `(a, b), c = (5, 3)`) is a TypeError in Python. Reject it
+      // explicitly so the recursive to_struct_type() never casts a non-struct.
+      if (!is_tuple_type(resolved))
+      {
+        throw std::runtime_error(
+          "Cannot unpack non-tuple element into nested target");
+      }
+      std::string member_name = "element_" + std::to_string(i);
+      exprt nested_rhs = build_member(rhs, member_name, resolved);
+      handle_tuple_unpacking(ast_node, targets[i], nested_rhs, target_block);
+      continue;
+    }
+
+    if (tgt_type != "Name")
     {
       throw std::runtime_error(
-        "Tuple unpacking only supports simple names, not " +
-        targets[i]["_type"].get<std::string>());
+        "Tuple unpacking only supports simple names, not " + tgt_type);
     }
 
     std::string var_name = targets[i]["id"].get<std::string>();


### PR DESCRIPTION
## Summary

Nested tuple-unpacking targets were rejected by the Python frontend:

```python
items = [((1, 2), 3), ((4, 5), 6)]
for (a, b), c in items:        # ERROR: Tuple unpacking only supports simple names, not Tuple
    ...

(x, y), z = f()                # same error
```

The literal form `(a, b), c = ((1, 2), 3)` happened to work because it is flattened to scalar assignments at compile time, but any **runtime** right-hand side (a for-loop element, a subscript, a function return) reached `tuple_handler::handle_tuple_unpacking`, which assigned each tuple component to its target but threw on any target element that was not a plain `Name`. This blocks common idioms (e.g. `for (u, v), w in graph.items()`).

## Fix

In `handle_tuple_unpacking`, when a target element is itself a `Tuple`/`List`:

1. Resolve the matching component's (possibly symbol-referenced) type to a concrete struct via `name_space().follow()`.
2. Build the `temp.element_i` member access.
3. Recurse, unpacking the sub-pattern element-wise.

A non-tuple element under a nested pattern (e.g. `(a, b), c = (5, 3)` — a `TypeError` in Python) is rejected **before** the recursive `to_struct_type` cast, so the frontend emits a clear error instead of casting a non-struct type (whose guard is an `assert`, compiled out under `NDEBUG`).

Arbitrary nesting depth and the per-level arity check are handled automatically by the recursion (each level re-enters the same size check).

## Why it is correct

- Each recursion strictly descends one AST level over a finite target list, so it terminates.
- The nested RHS is the exact `temp.element_i` lvalue of the resolved sub-struct, so values map to targets the same way the non-nested path does — no new wrong-verdict path.
- Verified across depth-2/3 nesting, two-nested-tuples-per-target, for-loop / assignment / function-return RHS, and the non-tuple-element error path.

## Validation

- New `regression/python/nested_tuple_unpack` (for-loop nesting + two nested tuples + function-return nesting) → `SUCCESSFUL`.
- New `regression/python/nested_tuple_unpack_fail` (false assertion) → `FAILED`.
- New `regression/python/nested_tuple_unpack_scalar_fail` (scalar into nested pattern) → explicit `ERROR`; CPython raises `TypeError` (sanity-checked).
- 53 Bitwuzla-runnable `tuple`/`unpack` regression tests: **0 CORE failures**.
- CPython sanity (`scripts/check_python_tests.sh`) green; lines within 80 cols, `git clang-format` clean.

Relates to #4778 (unblocks the nested-unpack surface used by several quixbugs tests).
