### PR TITLE
[python] Reject unmodelled list slice assignment (was unsound)

### DIFF
--- a/regression/python/list_index_assign_slice_read/main.py
+++ b/regression/python/list_index_assign_slice_read/main.py
@@ -1,0 +1,10 @@
+a = [1, 2, 3, 4]
+a[1] = 9            # plain index store
+assert a[1] == 9
+
+m = [[1, 2], [3, 4]]
+m[0][1] = 7         # nested index store
+assert m[0][1] == 7
+
+b = a[1:3]          # slice read (rvalue) is fine
+assert b[0] == 9 and b[1] == 3

--- a/regression/python/list_index_assign_slice_read/test.desc
+++ b/regression/python/list_index_assign_slice_read/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_slice_assign_unsupported/main.py
+++ b/regression/python/list_slice_assign_unsupported/main.py
@@ -1,0 +1,7 @@
+# List slice assignment is not modelled. ESBMC must reject it with an explicit
+# error rather than silently ignore the store (which previously left the list
+# unchanged and reported buggy programs as SUCCESSFUL). This program is valid
+# CPython (a becomes [1, 9, 4]).
+a = [1, 2, 3, 4]
+a[1:3] = [9]
+assert a == [1, 9, 4]

--- a/regression/python/list_slice_assign_unsupported/test.desc
+++ b/regression/python/list_slice_assign_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: List slice assignment \(a\[i:j\] = ...\) is not supported$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1600,6 +1600,21 @@ void python_converter::get_var_assign(
       target_block.copy_to_operands(convert_expression_to_code(setitem_call));
       return;
     }
+
+    // List slice assignment (a[i:j] = ...) is not modelled. Falling through to
+    // the generic store evaluates get_expr(a[i:j]) — a *copy* of the slice —
+    // and assigns into that temporary, leaving the original list unchanged. A
+    // later read then sees stale values, so ESBMC would report a buggy program
+    // as SUCCESSFUL (silent unsoundness). Reject it explicitly instead. Object
+    // slice __setitem__ is handled above; tuples raise TypeError above; dict
+    // subscripts are handled by handle_subscript_assignment_check earlier.
+    if (
+      target.contains("slice") && target["slice"].is_object() &&
+      target["slice"].value("_type", "") == "Slice")
+    {
+      throw std::runtime_error(
+        "List slice assignment (a[i:j] = ...) is not supported");
+    }
   }
 
   if (ast_node["_type"] == "AnnAssign")


### PR DESCRIPTION
## Summary (soundness fix)

Python list **slice assignment** `a[i:j] = [...]` was **silently ignored**, producing unsound verdicts:

```python
a = [1, 2, 3, 4]
a[1:3] = [9]          # Python: a becomes [1, 9, 4]
assert a[1] == 2      # False in Python — but ESBMC reported VERIFICATION SUCCESSFUL
```

The Subscript-target store fell through to the generic assignment path, which evaluated `get_expr(a[i:j])` — a **copy** of the slice — and assigned into that temporary, leaving the original list unchanged. Any later read saw stale values, so ESBMC could report a **buggy program as correct** (a false negative). For a verification tool this is the worst failure mode.

## Fix

Detect a Subscript assignment target whose `slice` is a `Slice` AST node and raise an explicit error instead of silently dropping the store:

```
ERROR: List slice assignment (a[i:j] = ...) is not supported
```

Placement matters — the guard sits **after** the existing, correct paths, so they are unaffected:
- dict subscript assignment (`handle_subscript_assignment_check`, returns early),
- tuple immutability (`TypeError`),
- object `__setitem__` (dunder dispatch, including slice/tuple keys as in `github_4539_setitem` / `github_4564_setitem_call`).

Only **list** (and any other unmodelled) slice-*target* stores are rejected.

## Why it is correct / sound

- Converts a silent false-`SUCCESSFUL` into an honest rejection — strictly improves soundness.
- Verified against the CPython 3.10+ AST that the guard catches exactly `Slice` targets (`a[1:3]`, `a[:]`, `a[1:3:1]`) and **not**: plain index `a[i]` (slice = `Name`/`Constant`), nested index `m[0][1]` (`Constant`), or object `__setitem__` slice keys (`Tuple`). Slice **reads** (`b = a[i:j]`) are rvalues and never enter this target path.
- The `nlohmann` accessors are safe (`contains` → `is_object` → `value("_type","")`), so a missing/non-object `slice` cannot misbehave.
- The throw is caught at the top level (`python_language.cpp`) and reported as `ERROR`, not a crash — consistent with other unsupported-feature rejections.

## Validation

- New `regression/python/list_slice_assign_unsupported` — valid CPython (`a` becomes `[1,9,4]`); ESBMC now emits the explicit error instead of a false pass.
- New `regression/python/list_index_assign_slice_read` — plain index store, nested index store, and slice read all still `VERIFICATION SUCCESSFUL` (guards against over-broad rejection).
- 325 Bitwuzla-runnable list/subscript/setitem regression tests: **0 CORE failures**; `__setitem__` tests and slice reads unaffected.
- CPython sanity (`scripts/check_python_tests.sh`) green.

Full modelling of slice assignment (in-place same-length replacement and list resizing) is left as future work; rejecting it is the sound interim behaviour.
