### PR TITLE
[build] Don't fail macOS build when 'brew update' fails

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -457,7 +457,11 @@ run_fetch() {
       fetch_gmp_source
       ;;
     Darwin)
-      brew update
+      # 'brew update' refreshes formula definitions but is best-effort: a
+      # transient tap fetch failure ("Error: Failed to download") must not abort
+      # the build under 'set -e'. Subsequent 'brew install' resolves formulae
+      # via the Homebrew API regardless, so a stale tap is harmless here.
+      brew update || log "warning: 'brew update' failed; continuing"
       ;;
     *)
       error "unsupported OS '$OS'"


### PR DESCRIPTION
## Summary

The macOS CI (`arm64 darwin build`) runs `scripts/build.sh` under `set -euo pipefail`. The Darwin fetch step calls `brew update`, which periodically hits a **transient Homebrew tap-fetch failure** and returns non-zero:

```
==> Updating Homebrew...
Error: Failed to download !
...
##[error]Process completed with exit code 1.
```

Because of `set -e`, that non-zero exit aborts the **entire build** at ~2 minutes — before any compilation — even though the failure is purely a metadata-refresh hiccup. This intermittently red-lights unrelated PRs (observed on #5214, whose only change was regression tests).

## Fix

Make `brew update` best-effort:

```sh
brew update || log "warning: 'brew update' failed; continuing"
```

`brew update` only refreshes formula definitions. The subsequent `brew install` of any missing formula resolves it via the Homebrew API regardless of tap freshness, so a stale tap is harmless here. If a *required formula* genuinely can't be downloaded, the later `brew install` step still fails the build — only the metadata refresh is now tolerant.

## Validation

- `bash -n scripts/build.sh` clean.
- Verified on PR #5214 (same change applied to that branch): the previously-failing **Build ESBMC** step went green.
- No behaviour change on Linux (the `brew update` call is macOS-only).
