### PR TITLE
[k-induction] Disable inductive step on pointer-array writes

### DIFF
--- a/regression/k-induction/github_5224_pointer_write/main.c
+++ b/regression/k-induction/github_5224_pointer_write/main.c
@@ -1,0 +1,20 @@
+// Issue #5224: a loop that writes array elements through a pointer (here a
+// pointer-to-array, the same shape SV-COMP's Intel-TDX-Module harnesses use
+// via __VERIFIER_nondet_array_1D_*) cannot be soundly havoc'd by the
+// k-induction inductive step, which havocs only named symbols. Before the
+// fix the inductive step proved this unsafe program "true"; the fix disables
+// the inductive step for such loops, so the base case finds the genuinely
+// reachable violation instead.
+extern unsigned char nondet_uchar(void);
+
+int main(void)
+{
+  unsigned char a[8];
+  unsigned char (*dest)[8] = &a;
+
+  for (int i = 0; i < 8; i++)
+    (*dest)[i] = nondet_uchar(); // array element written through a pointer
+
+  __ESBMC_assert(a[7] != 0x2A, "a[7] is nondet, so 0x2A is reachable");
+  return 0;
+}

--- a/regression/k-induction/github_5224_pointer_write/test.desc
+++ b/regression/k-induction/github_5224_pointer_write/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--k-induction --max-inductive-step 3
+does not support loops that write array elements through a pointer
+^VERIFICATION FAILED$

--- a/regression/k-induction/github_5224_pointer_write_helper/main.c
+++ b/regression/k-induction/github_5224_pointer_write_helper/main.c
@@ -1,0 +1,22 @@
+// Issue #5224: the array-element write through a pointer happens inside a
+// helper called from the loop, so the un-havocable write is discovered via
+// the function-summary path (collect_lhs_symbols), not the direct
+// assignment path. The inductive step must still be disabled. This program
+// is safe and is proven by the forward condition once the IS is off.
+extern unsigned char nondet_uchar(void);
+
+static void setelem(unsigned char (*dest)[8], int i)
+{
+  (*dest)[i] = nondet_uchar() & 1u; // array element written through a pointer
+}
+
+int main(void)
+{
+  unsigned char a[8];
+
+  for (int i = 0; i < 8; i++)
+    setelem(&a, i);
+
+  __ESBMC_assert(a[3] <= 1, "each element was set to 0 or 1");
+  return 0;
+}

--- a/regression/k-induction/github_5224_pointer_write_helper/test.desc
+++ b/regression/k-induction/github_5224_pointer_write_helper/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--k-induction --max-inductive-step 3
+does not support loops that write array elements through a pointer
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_5224_scalar_inductive/main.c
+++ b/regression/k-induction/github_5224_scalar_inductive/main.c
@@ -1,0 +1,19 @@
+// Issue #5224 negative control: a loop that modifies only a scalar (no
+// pointer write) must NOT trip the pointer-write gate, so the inductive
+// step stays enabled and proves this unbounded-in-the-base-case program.
+// Matching "Solution found by the inductive step" confirms the gate did
+// not fire (a spurious gate would force VERIFICATION UNKNOWN instead).
+extern int nondet_int(void);
+
+int main(void)
+{
+  int n = nondet_int();
+  __ESBMC_assume(n > 0);
+
+  int x = 0;
+  for (int i = 0; i < n; i++)
+    x = 0;
+
+  __ESBMC_assert(x == 0, "x stays zero across all iterations");
+  return 0;
+}

--- a/regression/k-induction/github_5224_scalar_inductive/test.desc
+++ b/regression/k-induction/github_5224_scalar_inductive/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--k-induction --max-inductive-step 5
+^VERIFICATION SUCCESSFUL$
+Solution found by the inductive step

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -2506,13 +2506,27 @@ bool esbmc_parseoptionst::process_goto_program(
       goto_loop_invariant_combined(goto_functions);
     }
 
+    // goto_k_induction returns true when a loop writes an array element
+    // through a pointer, which the inductive-step havoc cannot soundly
+    // generalise. Disable the inductive step in that case so its UNSAT is
+    // not reported as proof (#5224); base case and forward condition run.
+    auto disable_is_if_unsound = [&](bool unsound) {
+      if (unsound)
+      {
+        log_warning(
+          "k-induction does not support loops that write array elements "
+          "through a pointer yet. Disabling inductive step");
+        options.set_option("disable-inductive-step", true);
+      }
+    };
+
     if (cmdline.isset("loop-invariant"))
     {
       // Combined mode: Branch 1 (invariant inductivity check) +
       // ASSUME(INV) injected at end of loop body + k-induction (Branch 2).
       remove_no_op(goto_functions);
       goto_loop_invariant_combined(goto_functions);
-      goto_k_induction(goto_functions);
+      disable_is_if_unsound(goto_k_induction(goto_functions));
     }
     else
     {
@@ -2522,7 +2536,7 @@ bool esbmc_parseoptionst::process_goto_program(
         remove_no_op(goto_functions);
 
       if (is_k_induction)
-        goto_k_induction(goto_functions);
+        disable_is_if_unsound(goto_k_induction(goto_functions));
 
       if (cmdline.isset("loop-invariant-check"))
       {

--- a/src/goto-programs/goto_k_induction.cpp
+++ b/src/goto-programs/goto_k_induction.cpp
@@ -403,19 +403,36 @@ void transform_loop(goto_functiont &goto_function, loopst &loop)
 }
 } // namespace
 
-void goto_k_induction(goto_functionst &goto_functions)
+bool goto_k_induction(goto_functionst &goto_functions)
 {
+  bool disable_inductive_step = false;
   Forall_goto_functions (it, goto_functions)
   {
     if (!it->second.body_available)
       continue;
+    // Library helpers (body.hide) write through pointers in nearly every
+    // model (memcpy, string ops, ...). Letting them set the gate would
+    // disable the inductive step for essentially every program. Their loops
+    // are never the user property's witness, so exclude them from the
+    // decision — mirrors the body.hide guard in goto_termination.
+    const bool user_function = !it->second.body.hide;
     goto_loopst loops(it->first, goto_functions, it->second);
     for (auto &loop : loops.get_loops())
     {
+      // A loop that writes an array element through a pointer cannot be
+      // soundly havoc'd by the inductive step (the pointer-reached storage
+      // is not a named symbol), so the IS hypothesis is under-generalised.
+      // Report it so the strategy layer disables the inductive step.
+      // Checked before the empty-modified-set skip below, since such a loop
+      // may have no named modified vars yet is still unsound. See #5224.
+      if (user_function && loop.modifies_pointer_array())
+        disable_inductive_step = true;
+
       if (loop.get_modified_loop_vars().empty())
         continue;
       transform_loop(it->second, loop);
     }
   }
   goto_functions.update();
+  return disable_inductive_step;
 }

--- a/src/goto-programs/goto_k_induction.h
+++ b/src/goto-programs/goto_k_induction.h
@@ -8,6 +8,10 @@
 /// before the loop head. Applied to every function with a body
 /// (including __ESBMC_main, which is loop-free and therefore
 /// untouched, and library helpers).
-void goto_k_induction(goto_functionst &goto_functions);
+///
+/// Returns true when at least one loop writes an array element through a
+/// pointer, which the inductive step cannot soundly havoc; the caller must
+/// then disable the inductive step (see issue #5224).
+bool goto_k_induction(goto_functionst &goto_functions);
 
 #endif /* GOTO_PROGRAMS_GOTO_K_INDUCTION_H_ */

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -3,6 +3,30 @@
 #include <util/config.h>
 #include <util/expr_util.h>
 
+// True iff `expr` denotes storage reached through a pointer: a dereference,
+// or an index/member off pointer-reached storage, or a pointer-typed
+// symbol being indexed. Used to fire the inductive-step gate only for
+// array-element writes into pointer-reached memory (e.g. `p[i]`,
+// `(*p)[i]`, `p->arr[i]`), which the inductive step cannot havoc (#5224).
+// A named stack array (array-typed symbol) returns false: the inductive
+// step havocs it as a whole symbol, which is sound.
+static bool indexes_through_pointer(const expr2tc &expr)
+{
+  if (is_dereference2t(expr))
+    return true;
+  if (is_index2t(expr))
+    return indexes_through_pointer(to_index2t(expr).source_value);
+  if (is_member2t(expr))
+    return indexes_through_pointer(to_member2t(expr).source_value);
+  // A cast base (e.g. `((unsigned char (*)[8])q)[i]`) keeps the underlying
+  // pointer/array reach; look through it so the gate is not bypassed.
+  if (is_typecast2t(expr))
+    return indexes_through_pointer(to_typecast2t(expr).from);
+  if (is_symbol2t(expr))
+    return is_pointer_type(expr->type);
+  return false;
+}
+
 bool check_var_name(const expr2tc &expr)
 {
   if (!is_symbol2t(expr))
@@ -132,7 +156,8 @@ void goto_loopst::collect_loop_symbols(
 void goto_loopst::collect_lhs_symbols(
   const expr2tc &expr,
   loopst::loop_varst &modified,
-  loopst::loop_varst &unmodified) const
+  loopst::loop_varst &unmodified,
+  bool &modifies_pointer_array) const
 {
   if (is_nil_expr(expr))
     return;
@@ -145,14 +170,20 @@ void goto_loopst::collect_lhs_symbols(
   if (is_index2t(expr))
   {
     const index2t &idx = to_index2t(expr);
-    collect_lhs_symbols(idx.source_value, modified, unmodified);
+    // An array-element write into pointer-reached memory cannot be havoc'd
+    // by the inductive step, making its hypothesis unsound (#5224).
+    if (indexes_through_pointer(idx.source_value))
+      modifies_pointer_array = true;
+    collect_lhs_symbols(
+      idx.source_value, modified, unmodified, modifies_pointer_array);
     collect_loop_symbols(idx.index, unmodified);
     return;
   }
 
-  expr->foreach_operand([this, &modified, &unmodified](const expr2tc &e) {
-    collect_lhs_symbols(e, modified, unmodified);
-  });
+  expr->foreach_operand(
+    [this, &modified, &unmodified, &modifies_pointer_array](const expr2tc &e) {
+      collect_lhs_symbols(e, modified, unmodified, modifies_pointer_array);
+    });
 
   if (is_symbol2t(expr) && check_var_name(expr))
     modified.insert(expr);
@@ -171,6 +202,7 @@ bool goto_loopst::compute_function_summary(
       cached->second.modified.begin(), cached->second.modified.end());
     out.unmodified.insert(
       cached->second.unmodified.begin(), cached->second.unmodified.end());
+    out.modifies_pointer_array |= cached->second.modifies_pointer_array;
     return true;
   }
 
@@ -195,7 +227,10 @@ bool goto_loopst::compute_function_summary(
     if (instr.is_assign())
     {
       collect_lhs_symbols(
-        to_code_assign2t(instr.code).target, local.modified, local.unmodified);
+        to_code_assign2t(instr.code).target,
+        local.modified,
+        local.unmodified,
+        local.modifies_pointer_array);
     }
     else if (instr.is_function_call())
     {
@@ -231,6 +266,7 @@ bool goto_loopst::compute_function_summary(
   // Fold local into out regardless of completeness.
   out.modified.insert(local.modified.begin(), local.modified.end());
   out.unmodified.insert(local.unmodified.begin(), local.unmodified.end());
+  out.modifies_pointer_array |= local.modifies_pointer_array;
 
   if (complete)
     function_summary_cache[fname] = std::move(local);
@@ -276,6 +312,8 @@ void goto_loopst::get_modified_variables(
       loop->add_modified_var_to_loop(v);
     for (const auto &v : summary.unmodified)
       loop->add_unmodified_var_to_loop(v);
+    if (summary.modifies_pointer_array)
+      loop->set_modifies_pointer_array();
   }
   else if (
     instruction->is_goto() || instruction->is_assert() ||
@@ -309,6 +347,13 @@ void goto_loopst::add_loop_var(
   if (is_modified && is_index2t(expr))
   {
     const index2t &idx = to_index2t(expr);
+    // An array-element write into pointer-reached memory (e.g. `p[i]`,
+    // `(*p)[i]`) cannot be havoc'd by the inductive step, making its
+    // hypothesis unsound. Flag the loop so the strategy disables the
+    // inductive step (#5224). A stack array (array-typed symbol source)
+    // is havoc'd as a whole symbol and stays sound.
+    if (indexes_through_pointer(idx.source_value))
+      loop.set_modifies_pointer_array();
     add_loop_var(loop, idx.source_value, true);
     add_loop_var(loop, idx.index, false);
     return;

--- a/src/goto-programs/goto_loops.h
+++ b/src/goto-programs/goto_loops.h
@@ -30,6 +30,10 @@ protected:
   {
     loopst::loop_varst modified;
     loopst::loop_varst unmodified;
+    /// True iff the callee writes an array element through a pointer.
+    /// Propagated to the calling loop so the inductive step is disabled
+    /// (see loopst::set_modifies_pointer_array and issue #5224).
+    bool modifies_pointer_array = false;
   };
   std::unordered_map<irep_idt, function_summaryt, irep_id_hash>
     function_summary_cache;
@@ -59,11 +63,13 @@ protected:
   /// Walk an assignment LHS, classifying each leaf symbol: storage that
   /// is actually written goes to `modified`, sub-expressions used to
   /// locate that storage (pointer in `*p`, index in `arr[i]`) go to
-  /// `unmodified`.
+  /// `unmodified`. Sets `modifies_pointer_array` when the write is to an
+  /// array element reached through a pointer (issue #5224).
   void collect_lhs_symbols(
     const expr2tc &expr,
     loopst::loop_varst &modified,
-    loopst::loop_varst &unmodified) const;
+    loopst::loop_varst &unmodified,
+    bool &modifies_pointer_array) const;
 
   void add_modified_var(loopst &loop, const expr2tc &expr);
   void add_unmodified_var(loopst &loop, const expr2tc &expr);

--- a/src/goto-programs/loopst.h
+++ b/src/goto-programs/loopst.h
@@ -45,6 +45,26 @@ public:
   void add_modified_var_to_loop(const expr2tc &expr);
   void add_unmodified_var_to_loop(const expr2tc &expr);
 
+  /// Record that the loop writes an array element through a pointer
+  /// (e.g. `p[i] = ...`, `(*p)[i] = ...`, `p->arr[i] = ...`). The
+  /// k-induction inductive step havocs only named symbols (see
+  /// make_nondet_assign); it cannot havoc such pointer-reached array
+  /// storage, so the inductive hypothesis is under-generalised and the
+  /// inductive step becomes unsound. The strategy layer disables the
+  /// inductive step when any loop reports this. Stack arrays (havoc'd as
+  /// whole symbols) and single pointer/field writes (constrained by the
+  /// value-set assume) are sound and therefore excluded. See issue #5224.
+  void set_modifies_pointer_array()
+  {
+    modifies_pointer_array_ = true;
+  }
+
+  /// True iff the loop writes an array element through a pointer.
+  bool modifies_pointer_array() const
+  {
+    return modifies_pointer_array_;
+  }
+
   void dump() const;
   void dump_loop_vars() const;
   void output_to(std::ostream &oss) const;
@@ -63,6 +83,7 @@ protected:
   goto_programt::targett original_loop_exit;
 
   std::size_t size;
+  bool modifies_pointer_array_ = false;
 };
 
 #endif /* GOTO_PROGRAMS_LOOPST_H_ */


### PR DESCRIPTION
The k-induction inductive step havocs only named symbols, so a loop that writes an array element through a pointer (e.g. `(*dest)[i]`, as in SV-COMP's Intel-TDX-Module nondet-array builders) is left under-generalised and can report an unsound VERIFICATION SUCCESSFUL on an unsafe program — the cause of 54 incorrect "true" verdicts.

Detect such writes and disable the inductive step for the program; the base case and forward condition still run. Stack arrays, single pointer/field writes, and library helpers are left untouched, preserving existing inductive proofs (e.g. is_pointer_invariant_list).

Fixes #5224.