### PR TITLE
[python] Route len() to dict-size handler for dict-typed symbols

### DIFF
--- a/regression/python/dictcomp_len/main.py
+++ b/regression/python/dictcomp_len/main.py
@@ -1,0 +1,9 @@
+# len() of a dict-comprehension result. The comprehension assigns the
+# __python_dict__ struct directly to the variable without recording a "dict"
+# annotation, so len() used to fall through to strlen() and read the struct's
+# bytes as a C string, yielding a wrong size. len() must instead route to the
+# dict-size handler. Regression for #5222 (the len() portion).
+d = {i: i for i in range(2)}
+assert len(d) == 2
+# Read-back still works alongside the corrected len().
+assert d[1] == 1

--- a/regression/python/dictcomp_len/test.desc
+++ b/regression/python/dictcomp_len/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --no-unwinding-assertions --no-standard-checks --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dictcomp_len_fail/main.py
+++ b/regression/python/dictcomp_len_fail/main.py
@@ -1,0 +1,6 @@
+# Soundness guard for the dict-comprehension len() fix (#5222): an assertion
+# that states the wrong size must still FAIL. This rules out a vacuous fix
+# where len() of a dict-comprehension result is treated as a constant that
+# satisfies any equality.
+d = {i: i for i in range(2)}
+assert len(d) == 5

--- a/regression/python/dictcomp_len_fail/test.desc
+++ b/regression/python/dictcomp_len_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --no-unwinding-assertions --no-standard-checks --smt-during-symex --smt-symex-guard
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -483,6 +483,16 @@ symbol_id function_call_builder::build_function_id() const
 
       const bool var_symbol_is_list = symbol_points_to_list(var_symbol);
 
+      // A dict-typed symbol may carry no "dict" frontend annotation: a dict
+      // comprehension ({k: v for ...}) or a dict-returning call assigns the
+      // __python_dict__ struct directly without recording the type in the
+      // annotation map. Detect the struct type on the symbol so len() routes
+      // to the dict-size handler rather than falling through to strlen, which
+      // would read the struct's bytes as a C string and yield a wrong size.
+      const bool var_symbol_is_dict =
+        var_symbol && converter_.get_dict_handler()->is_dict_type(
+                        converter_.ns.follow(var_symbol->get_type()));
+
       auto is_list_slice_assignment = [&]() -> bool {
         nlohmann::json var_value = json_utils::get_var_value(
           var_name,
@@ -546,7 +556,7 @@ symbol_id function_call_builder::build_function_id() const
           }
         }
       }
-      if (var_type == "dict")
+      if (var_type == "dict" || var_symbol_is_dict)
       {
         // Mark this as a dict len() call
         func_name = "__ESBMC_len_dict";


### PR DESCRIPTION
## Summary

`len()` on a Python dict whose variable carries no `"dict"` frontend annotation — the result of a **dict comprehension** (`{k: v for ...}`) or a dict-returning call — was lowered to `strlen()`. `strlen` then read the `__python_dict__` struct's bytes as a C string, so `len()` returned a wrong (and **unsound**) size:

```python
d = {i: i for i in range(2)}
assert len(d) == 2          # was VERIFICATION FAILED, now SUCCESSFUL
```

This is the `len()` portion of #5222.

## Root cause

The `len()` dispatcher in `src/python-frontend/function_call/builder.cpp` routed to `__ESBMC_len_dict` only when the AST annotation string equals `"dict"`, and to the list-size handler only when the symbol's type was a pylist. A dict comprehension assigns the `__python_dict__` struct **directly** to the variable without recording a `"dict"` annotation, so the call fell through to the default `strlen` path. (A dict *literal* with an annotation worked, which is why only non-trivial/comprehension dicts were affected.)

## Fix

Mirror the existing `var_symbol_is_list` detection: recognise the `__python_dict__` struct type directly on the symbol via `python_dict_handler::is_dict_type` on the followed symbol type, and OR it into the dict-routing condition:

```cpp
const bool var_symbol_is_dict =
  var_symbol && converter_.get_dict_handler()->is_dict_type(
                  converter_.ns.follow(var_symbol->get_type()));
...
if (var_type == "dict" || var_symbol_is_dict)
  // route to __ESBMC_len_dict
```

This prefers the resolved symbol type over the (missing) annotation — the same precedent the code already applies for lists.

## Why it is correct / sound

- `is_dict_type` requires an **exact** `"__python_dict__"` struct tag, disjoint from the list (`__ESBMC_PyListObj`) and tuple (`tag-tuple`) tags, so `len()` on lists / tuples / str / set / bytes is unaffected.
- The earlier tuple branch (`var_type == "tuple" || var_type.empty()`) only returns for `tag-tuple` structs; a `__python_dict__` symbol falls through to the new dict route.
- `var_symbol` is null-guarded; `get_dict_handler()` lives for the converter's lifetime.
- The previous `strlen`-over-struct-bytes behaviour was unsound; this strictly narrows mis-dispatch.

## Validation

- `dictcomp_len` (new, CORE): `len()` of a comprehension result equals the correct size, with read-back — **VERIFICATION SUCCESSFUL**.
- `dictcomp_len_fail` (new, CORE): the wrong size (`== 5`) must still **VERIFICATION FAILED** — rules out a vacuous fix.
- CPython sanity (`scripts/check_python_tests.sh`) passes for both new tests.
- A 23-test dict/`len()` regression subset (dictcomp, dict_comprehension_list, dict_basics, builtin1, bytes2, concat3, boolop-len-or, deque_popleft, …) passes with no regressions.
- Code-reviewed: 0 critical/major findings.
- Branch-reachability (C-Live) is discharged behaviourally — the new test reaches the added route; were it dead, `len()` would still go to `strlen` and the test would FAIL.

## Scope / remaining work

This fixes only the `len()` symptom of #5222. The issue's other reproducers have **separate root causes** and remain open:

- **Reproducer 2** — read-back over a *list* iterable (`{i: 0 for i in lst}[5]`) returns the wrong value (key-comparison path; loop variable typed as the generic list pointer for unknown lists).
- **Reproducer 3** — comprehension over a *symbolic* `range(n)` reached through a function parameter (`def f(n): {i: 7 for i in range(n)}; return f(3)`) — the whole call is **constant-folded to a false assertion** before the dict model runs.

These should likely be split into focused follow-up issues.

Refs #5222
