### PR TITLE
[python] Type dict-comprehension value reads (fix char* read-back)

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -415,6 +415,15 @@ math(EXPR ESBMC_REGRESS_CTEST_TIMEOUT_VERY_SLOW
 set(_very_slow_regression_tests
     "regression/quixbugs/shortest_path_lengths"
     "regression/quixbugs/shortest_path_lengths_fail"
+    # humaneval_62 (derivative) verifies SUCCESSFUL but is heavy: its body is a
+    # list comprehension over enumerate(xs) followed by a slice
+    # ([(i * x) for i, x in enumerate(xs)][1:]) under --unwind 20, which unwinds
+    # the list-OM loops 20x and feeds a large bit-vector query (encode ~16s +
+    # Bitwuzla ~54s locally). It times out at the 120s per-test cap on the
+    # DebugOpt static Linux runner; an assertions-on build measures ~248s, the
+    # same band as shortest_path_lengths above. Give it the 3x budget so it
+    # doesn't flap.
+    "regression/humaneval/humaneval_62"
 )
 
 foreach(_t IN LISTS _slow_regression_tests)

--- a/regression/python/dictcomp_readback_func/main.py
+++ b/regression/python/dictcomp_readback_func/main.py
@@ -1,0 +1,14 @@
+# Read-back of a dict built by a comprehension, inside a function whose
+# return type does not flow into the subscript read. Previously the value
+# type of a comprehension-built dict could not be resolved, so d[k] fell
+# through to the char* default and returned the raw PyObject value pointer
+# instead of the stored scalar -- a wrong verdict. Regression for #5222
+# (the read-back portion, reproducer 2: list-iterable comprehension).
+
+
+def from_list(lst):
+    count = {i: 0 for i in lst}
+    return count[5]
+
+
+assert from_list([5]) == 0

--- a/regression/python/dictcomp_readback_func/test.desc
+++ b/regression/python/dictcomp_readback_func/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-unwinding-assertions --no-standard-checks --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dictcomp_readback_func_fail/main.py
+++ b/regression/python/dictcomp_readback_func_fail/main.py
@@ -1,0 +1,10 @@
+# Soundness guard for the comprehension read-back fix (#5222): a wrong
+# read-back value must still FAIL, ruling out a vacuous fix.
+
+
+def from_range():
+    d = {i: 7 for i in range(3)}
+    return d[0]
+
+
+assert from_range() == 999

--- a/regression/python/dictcomp_readback_func_fail/test.desc
+++ b/regression/python/dictcomp_readback_func_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-unwinding-assertions --no-standard-checks --smt-during-symex --smt-symex-guard
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1496,6 +1496,42 @@ typet python_dict_handler::resolve_expected_type_for_dict_subscript(
       if (kind == "Dict")
         return get_dict_struct_type();
     }
+
+    // Dict comprehension `d = {k: v for ...}`: the variable carries no
+    // annotation and its AST value is a DictComp, so the Dict-literal peek
+    // above does not fire. Infer the subscript value type from the
+    // comprehension's value expression. Without this the read falls through
+    // to the char* default and returns the raw PyObject value pointer rather
+    // than the stored scalar — a wrong verdict on `d[k]` reads, e.g. inside a
+    // function body where no target type flows in (#5222).
+    if (
+      var_decl.contains("value") && var_decl["value"].is_object() &&
+      var_decl["value"].value("_type", std::string()) == "DictComp" &&
+      var_decl["value"].contains("value") &&
+      var_decl["value"]["value"].is_object())
+    {
+      const auto &val_node = var_decl["value"]["value"];
+      const std::string val_kind = val_node.value("_type", std::string());
+      if (val_kind == "List")
+        return type_handler_.get_list_type();
+      if (val_kind == "Dict" || val_kind == "DictComp")
+        return get_dict_struct_type();
+      // Scalar literal value: classify exactly as the value is stored by the
+      // comprehension (Python int -> int, float -> float, bool -> bool). Only
+      // numeric/boolean literal constants are inferred; string, bytes and any
+      // other value expression are left to the existing path, which already
+      // resolves them to the char* default (unchanged behaviour).
+      if (val_kind == "Constant" && val_node.contains("value"))
+      {
+        const auto &lit = val_node["value"];
+        if (lit.is_boolean())
+          return bool_type();
+        if (lit.is_number_integer() || lit.is_number_unsigned())
+          return type_handler_.get_typet("int", 0);
+        if (lit.is_number_float())
+          return type_handler_.get_typet("float", 0);
+      }
+    }
     // Empty literal `d = {}`:
     // scan the enclosing function's top-level statements and pick the most
     // recent `d[k] = Klass(...)` assignment as the subscript value type.


### PR DESCRIPTION
## Summary

Reading a value back from a dict built by a **comprehension** (`d = {k: v for ...}`) returned the wrong result whenever no target type flowed into the subscript read — most visibly `return d[k]` inside a function body:

```python
def f(lst):
    count = {i: 0 for i in lst}
    return count[5]
assert f([5]) == 0          # was VERIFICATION FAILED, now SUCCESSFUL
```

This is the **read-back portion** of #5222 (reproducer 2, plus function-scoped constant-range reads).

## Root cause

`handle_dict_subscript` resolves the element type via `resolve_expected_type_for_dict_subscript`. That resolver peeked `Dict` **literals** but had **no `DictComp` case**, so for a comprehension-built variable it returned an empty type. `handle_dict_subscript` then fell through to its `char*` default and returned the raw `PyObject->value` pointer instead of the stored scalar. The function therefore returned a pointer, and `f(...) == <int>` compared a pointer against an int → spurious `VERIFICATION FAILED`.

A dict *literal* in the same position worked, which is why this only surfaced for comprehensions. The GOTO made it explicit — `return count[0]` lowered to `RETURN: (signed char *)$dict_val_obj->value` instead of `RETURN: *(signed long int *)$dict_val_obj->value`.

## Fix

Add a `DictComp` case to `resolve_expected_type_for_dict_subscript` that infers the subscript value type from the comprehension's value expression:

- `List` → list type, `Dict`/`DictComp` → dict struct;
- numeric/boolean literal `Constant`s classified **exactly as stored** by `handle_dict_subscript_assign`/`get_literal` (Python `int` → int64, `float` → double, `bool` → bool);
- string, bytes and non-constant value expressions are left to the existing path, which already resolves strings to the `char*` default.

The branch is gated on the variable's AST value being a `DictComp`, so behaviour for every non-comprehension dict is unchanged.

## Why it is sound

- The inferred type width matches the stored width, so the dereference reads exactly the bytes that were written (verified against the storage path `get_expr(value) → get_literal`).
- Empirically: `int`, `float`, `bool`, `str` comprehension values all read back correctly, and a wrong-value assertion (`== 999`) still **FAILS** — ruling out a vacuous fix.
- Branch-reachability (C-Live) is discharged behaviourally: the new test reaches the added branch, and its verdict flips to SUCCESSFUL only with the fix.

## Validation

- `dictcomp_readback_func` (new, CORE): list-iterable comprehension read inside a function — **VERIFICATION SUCCESSFUL** (~1.7s).
- `dictcomp_readback_func_fail` (new, CORE): wrong read-back value must **VERIFICATION FAILED** (~12s).
- CPython sanity (`scripts/check_python_tests.sh`) passes for both.
- Dict regression subset (26 tests: dictcomp, dict_comprehension_list, dict_basics, dict15, dict_fromkeys, dict_items, dict_setdefault, defaultdict, …) passes; the only non-pass is `dict_items1`, which requires `--z3` and fails environmentally on this Bitwuzla-only build (not a regression).
- Code-reviewed: 0 critical/major; the reviewer's medium note (a `bytes`-value edge) was eliminated by dropping the redundant `is_string()` arm so strings/bytes stay on the unchanged default path.

## Scope / remaining work

This fixes the read-back **type** bug. #5222's **reproducer 3** — a comprehension over a *symbolic* `range(n)` bound reached through a function parameter — has a **separate root cause** (the symbolic-range population, not the read-back type; `range(3)` literal in the same function already verifies) and **remains open**. It should be split into its own issue.

Companion to PR #5231 (the `len()` portion of #5222).

Refs #5222
