### PR TITLE
[python] V.3: build single-char comparison subtree in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -275,24 +275,31 @@ exprt python_converter::handle_string_comparison(
       return true;
     };
 
-    auto char_at_index = [&](const exprt &expr, int idx) -> exprt {
+    // Build a single-character access as IREP2; the comparison below composes
+    // these and back-migrates once at the return boundary (V.3).
+    auto char_at_index = [&](const exprt &expr, int idx) -> expr2tc {
       exprt index = from_integer(idx, index_type());
+
       if (expr.type().is_array())
       {
-        // V.3: IREP2 index access (exact round-trip of index_exprt).
-        expr2tc a2, i2;
-        migrate_expr(expr, a2);
-        migrate_expr(index, i2);
-        return migrate_expr_back(index2tc(migrate_type(char_type()), a2, i2));
+        // exact round-trip of index_exprt(expr, index, char_type())
+        expr2tc expr2, index2;
+        migrate_expr(expr, expr2);
+        migrate_expr(index, index2);
+        return index2tc(migrate_type(char_type()), expr2, index2);
       }
 
+      // Pointer path: reproduce the legacy dereference node verbatim — its
+      // two-arg constructor takes char_type().subtype() (nil), not char_type(),
+      // as the result type — then migrate it forward for a uniform expr2tc.
       exprt ptr = expr;
       if (!ptr.type().is_pointer())
         ptr = address_of_exprt(expr);
-
       plus_exprt ptr_plus(ptr, index);
       ptr_plus.type() = ptr.type();
-      return dereference_exprt(ptr_plus, char_type());
+      expr2tc deref2;
+      migrate_expr(dereference_exprt(ptr_plus, char_type()), deref2);
+      return deref2;
     };
 
     char literal_char = 0;
@@ -305,31 +312,29 @@ exprt python_converter::handle_string_comparison(
        type_utils::is_string_type(resolved_rhs.type())))
     {
       const exprt &str_expr = lhs_is_char_literal ? resolved_rhs : resolved_lhs;
-      exprt first_char = char_at_index(str_expr, 0);
-      exprt second_char = char_at_index(str_expr, 1);
+      expr2tc first_char = char_at_index(str_expr, 0);
+      expr2tc second_char = char_at_index(str_expr, 1);
 
-      exprt lit =
-        from_integer(static_cast<unsigned char>(literal_char), char_type());
-      exprt zero = from_integer(0, char_type());
+      expr2tc lit, zero;
+      migrate_expr(
+        from_integer(static_cast<unsigned char>(literal_char), char_type()),
+        lit);
+      migrate_expr(from_integer(0, char_type()), zero);
 
-      exprt first_eq("=", bool_type());
-      first_eq.copy_to_operands(first_char, lit);
-      exprt second_eq("=", bool_type());
-      second_eq.copy_to_operands(second_char, zero);
-
-      exprt both_eq("and", bool_type());
-      both_eq.copy_to_operands(first_eq, second_eq);
+      // (str[0] == lit) and (str[1] == '\0'); negated for NotEq.
+      expr2tc both_eq =
+        and2tc(equality2tc(first_char, lit), equality2tc(second_char, zero));
 
       if (op == "NotEq")
       {
-        exprt not_expr("not", bool_type());
-        not_expr.copy_to_operands(both_eq);
+        exprt not_expr = migrate_expr_back(not2tc(both_eq));
         not_expr.location() = get_location_from_decl(element);
         return not_expr;
       }
 
-      both_eq.location() = get_location_from_decl(element);
-      return both_eq;
+      exprt both_eq_expr = migrate_expr_back(both_eq);
+      both_eq_expr.location() = get_location_from_decl(element);
+      return both_eq_expr;
     }
   }
 


### PR DESCRIPTION
Migrate the single-character string fast-path in `handle_string_comparison` (`converter_compare.cpp`) to typed IREP2 factories, continuing Phase V.3 of the IREP2 migration. `char_at_index` now returns `expr2tc` (`index2tc` for the array case), and the `(str[0] == lit) and (str[1] == '\0')` composition (negated for `NotEq`) is built with `equality2tc`/`and2tc`/`not2tc`, back-migrating once at each return boundary. Unblocked by the V.1k assert relaxation (#5061).

The pointer (`char*`) path reproduces the legacy `dereference_exprt(ptr_plus, char_type())` node verbatim before migrating it forward: that two-arg constructor uses `tp.subtype()` (nil) as the result type, so building `dereference2tc(char, ...)` would have changed the emitted node. Reproducing it keeps the emitted legacy IR byte-identical.

Behaviour-preserving: validated on an asserts-enabled (Debug) build with the live `migrate.cpp` cross-check silent. The string/char/comparison/None regression stratum passes 490/490 on Bitwuzla; the directly-affected tests (`single-char1{,_fail}`, `github_3041_2_comparison{,_fail}`) match expected verdicts under Z3 as well.