### PR TITLE
[symex] constant-propagate structs that contain pointer fields

### DIFF
--- a/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
@@ -1,5 +1,5 @@
 THOROUGH
 main.cpp
---unwind 2 --no-unwinding-assertions --error-label ERROR --depth 131 --timeout 900
+--unwind 2 --no-unwinding-assertions --error-label ERROR --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc/struct_ptr_field_recursion_constprop/main.c
+++ b/regression/esbmc/struct_ptr_field_recursion_constprop/main.c
@@ -1,0 +1,36 @@
+// Regression for constant propagation of struct values that contain a pointer
+// field.
+//
+// `f` recurses only while `p->n >= 1`. The concrete structure built in main
+// terminates the recursion at its real depth (2): root has n == 1 and points
+// at leaf, leaf has n == 0 so the guard is false and recursion stops.
+//
+// Before the fix, ESBMC refused to constant-propagate a struct value whose
+// WITH-chain updated a pointer-typed field (here `next`), because the pointer
+// update was not classified as a plain constant. As a result `p->n` never
+// folded, the recursion guard stayed symbolic, and symex explored the
+// recursive branch on every path up to the --unwind bound -- tripping the
+// recursion unwinding assertion at depth 3. With the fix the guard folds and
+// the recursion stops at its real depth (2 < 3), so no unwinding assertion is
+// reached.
+struct node
+{
+  int n;
+  struct node *next;
+};
+
+void f(struct node *p)
+{
+  if (p == 0)
+    return;
+  if (p->n >= 1)
+    f(p->next);
+}
+
+int main(void)
+{
+  struct node leaf = {0, 0};
+  struct node root = {1, &leaf};
+  f(&root);
+  return 0;
+}

--- a/regression/esbmc/struct_ptr_field_recursion_constprop/test.desc
+++ b/regression/esbmc/struct_ptr_field_recursion_constprop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/struct_ptr_field_recursion_constprop_fail/main.c
+++ b/regression/esbmc/struct_ptr_field_recursion_constprop_fail/main.c
@@ -1,0 +1,31 @@
+// Failing companion to struct_ptr_field_recursion_constprop.
+//
+// The same recursion, but the concrete structure is a chain of four nodes that
+// all have n >= 1, so the recursion legitimately runs deeper than the --unwind
+// bound of 2. With the struct-pointer-field constant-propagation fix, ESBMC
+// folds each `p->n` guard (every node's n is 1) and follows the chain exactly,
+// reaching the unwind bound -- so the recursion unwinding assertion fails, which
+// is the sound, expected outcome (VERIFICATION FAILED).
+struct node
+{
+  int n;
+  struct node *next;
+};
+
+void f(struct node *p)
+{
+  if (p == 0)
+    return;
+  if (p->n >= 1)
+    f(p->next);
+}
+
+int main(void)
+{
+  struct node d = {1, 0};
+  struct node c = {1, &d};
+  struct node b = {1, &c};
+  struct node a = {1, &b};
+  f(&a);
+  return 0;
+}

--- a/regression/esbmc/struct_ptr_field_recursion_constprop_fail/test.desc
+++ b/regression/esbmc/struct_ptr_field_recursion_constprop_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -149,14 +149,34 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
     // Handle WITH chains for structs where all updates are constants
     if (is_struct_type(expr->type))
     {
-      // Check if this is a chain of WITHs with all constant updates
+      // Check if this is a chain of WITHs with all constant updates.
+      // Use constant_propagation (not is_constant_expr) for the update values
+      // so a propagatable pointer-typed field update (NULL, &object, a typecast
+      // thereof) does not poison the whole struct: otherwise a struct with any
+      // pointer field is never propagated, its scalar fields never constant-
+      // fold, and data-dependent recursion guards / loop bounds over those
+      // fields stay symbolic, exploding the path space
+      // (try_catch/nec_ex5-recursive).
+      //
+      // Restrict to scalar- and pointer-typed field updates, though. Inlining
+      // an aggregate update value (array / struct / union / nested with) would
+      // store a value whose concrete size can differ from the field's declared
+      // (often symbolic) size, producing a size-mismatched array-to-array
+      // typecast the SMT backend cannot soundly lower without reinterpreting
+      // the array at a different length -- a char-array member of a std::map
+      // node triggered "Typecast for unexpected type". nec_ex5-recursive only
+      // needs int/pointer fields to fold.
       bool all_constant_updates = true;
       expr2tc current = expr;
 
       while (is_with2t(current))
       {
         const with2t &w = to_with2t(current);
-        if (!is_constant_expr(w.update_value))
+        const expr2tc &uv = w.update_value;
+        if (
+          !(is_number_type(uv->type) || is_bool_type(uv->type) ||
+            is_pointer_type(uv->type)) ||
+          !constant_propagation(uv))
         {
           all_constant_updates = false;
           break;


### PR DESCRIPTION
## Problem

A struct `WITH`-chain was only constant-propagated when **every** field update was `is_constant_expr`. A pointer-typed field update (`NULL`, `&object`, a typecast thereof) is never `is_constant_expr`, so a struct containing *any* pointer field was never propagated. Its scalar fields then never constant-folded, leaving data-dependent recursion guards and loop bounds (e.g. `node->n`) symbolic — so symex explored the infeasible recursive/loop branches a concrete pointer would prune, an exponential path blow-up.

Concretely, `regression/esbmc-cpp/try_catch/nec_ex5-recursive` needed an explicit `--depth` bound to terminate at all; without it symex ran for minutes and the solver exhausted memory, even though the program is concrete and runs instantly.

### Root cause (verified)
With `--show-symex-value-sets` / `--show-vcc`: the value-set of the recursive formal is *precise* at feasible depths, but the guard `(struct WITH [n:=v] WITH [ptr:=p]).n` reads a struct **symbol** whose `WITH`-value is never inlined, because `constant_propagation` returns `false` for structs with a pointer field. An all-scalar struct (`{int n; int p;}`) folds; the same struct with a pointer field (`{int n; T* p;}`) does not — that single difference reproduces the blow-up.

## Fix

Use `constant_propagation` for the update values (as the array-`WITH` case directly below already does), but **restrict to scalar- and pointer-typed field updates**: inlining an aggregate update value (array / struct / union / nested `with`) can produce an expression the SMT backend cannot lower — a `char`-array member of a `std::map` node triggered `Typecast for unexpected type`. `nec_ex5-recursive` only needs int/pointer fields to fold.

## Result

- `nec_ex5-recursive` terminates on its own (~0.005s symex, previously OOM at solve); its `--depth` workaround is removed.
- New C regression tests: `struct_ptr_field_recursion_constprop` (guard folds, recursion stops at real depth → SUCCESSFUL) and `_fail` (chain deeper than `--unwind` → FAILED).

## Validation

- Core C `esbmc/` suite: **same 11 pre-existing baseline failures, zero new** (diffed against the unpatched binary).
- Container C++ suites (map/set/list/deque/unordered/string/bitset/…): **640/640 pass** — this is where the struct-with-array risk concentrates; an earlier broader version regressed `map_operator_brackets_2/3`, which the scalar/pointer restriction fixes.
- All three target tests pass via ctest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)