### PR TITLE
[python] V.3: build list-truthiness len()!=0 condition in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -50,18 +50,20 @@ exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
         throw std::runtime_error(
           "__ESBMC_list_size not found for list condition check");
 
-      side_effect_expr_function_callt size_call;
-      size_call.function() = symbol_expr(*size_func);
-      size_call.type() = size_type();
-      size_call.location() = get_location_from_decl(element);
+      // Build len(x) != 0 in IREP2, back-migrating once (V.3).
+      expr2tc arg2, zero2;
       if (value_expr.type().is_pointer())
-        size_call.arguments().push_back(value_expr);
+        migrate_expr(value_expr, arg2);
       else
-        size_call.arguments().push_back(address_of_exprt(value_expr));
+        migrate_expr(address_of_exprt(value_expr), arg2);
+      migrate_expr(gen_zero(size_type()), zero2);
 
-      exprt cond("notequal", bool_type());
-      cond.copy_to_operands(size_call, gen_zero(size_type()));
-      cond.location() = get_location_from_decl(element);
+      expr2tc size_call2 = side_effect_function_call2tc(
+        migrate_type(size_type()), symbol_expr2tc(*size_func), {arg2});
+      exprt cond = migrate_expr_back(notequal2tc(size_call2, zero2));
+      const locationt loc = get_location_from_decl(element);
+      cond.location() = loc;
+      cond.op0().location() = loc; // re-attach the size_call location
       return cond;
     }
 


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration in the Python frontend. Migrate the `get_truthy_condition` subtree in `get_logical_operator_expr` (`converter_binop.cpp`) — the list-truthiness `len(x) != 0` check used when a list value appears in an `and`/`or` boolean context — from legacy `exprt`/`copy_to_operands` to typed IREP2 factories (`side_effect_function_call2tc`, `notequal2tc`), back-migrating once at the return boundary.

Because `expr2t` carries no source location, the locations the original set (on the `notequal` node and on its inner `size_call` operand) are re-attached after `migrate_expr_back`, preserving counterexample text.

Scope note: only this self-contained synthetic subtree is migrated. The file's arithmetic builder (`build_binary_expression`, dynamic `map_operator` id + the `assert_arith_2ops_consistency` gate) and the chained-comparison builder remain legacy by design — they are the resolved-type/arith-consistency risk class flagged in the migration plan and need more than a like-for-like swap.

Behaviour-preserving, validated on an asserts-enabled (Debug) build with the live `migrate.cpp` cross-check silent: 15/15 boolop/list-truthiness tests pass via ctest (verdict + matched-text), and the list-in-`and`/`or` tests (`boolop-len-or`, `github_2947_2`, `github_3288_2`, `dict7`, …) match expected verdicts under both Bitwuzla and Z3.
