### PR TITLE
[python] V.3: route list typecast/deref sites through IREP2 helpers

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -149,6 +149,16 @@ exprt build_deref_member(
   expr2tc deref2 = dereference2tc(migrate_type(obj.type().subtype()), obj2);
   return migrate_expr_back(member2tc(migrate_type(field_type), deref2, field));
 }
+
+// Dereference `ptr` to a value of type `t` (exact round-trip of the single-arg
+// dereference_exprt(t) + op0=ptr form, which sets the result type to `t`
+// directly). Back-migrated once (V.3).
+exprt build_dereference(const exprt &ptr, const typet &t)
+{
+  expr2tc ptr2;
+  migrate_expr(ptr, ptr2);
+  return migrate_expr_back(dereference2tc(migrate_type(t), ptr2));
+}
 } // namespace
 
 // Default depth for list comparison if option not set
@@ -635,7 +645,7 @@ exprt python_list::build_push_list_call(
         signedbv_typet(config.ansi_c.long_int_width),
         exprt());
 
-      typecast_exprt bool_cast(
+      exprt bool_cast = build_typecast(
         build_symbol(*elem_info.elem_symbol),
         signedbv_typet(config.ansi_c.long_int_width));
 
@@ -3287,7 +3297,7 @@ exprt python_list::create_vla(
   // Materialise the count (which may be a compound expression such as m + 1)
   // into an int symbol to use as the loop bound.
   exprt bound_value =
-    (count.type() == int_type()) ? count : typecast_exprt(count, int_type());
+    (count.type() == int_type()) ? count : build_typecast(count, int_type());
   symbolt &bound = converter_.create_tmp_symbol(
     element, "$list_rep_count$", int_type(), exprt());
   code_declt bound_decl(build_symbol(bound));
@@ -4376,11 +4386,10 @@ exprt python_list::extract_pyobject_value(
 
     // (double)*(long long *)item->value
     exprt value_member = member_of("value", pointer_typet(empty_typet()));
-    typecast_exprt as_int_ptr(
-      value_member, pointer_typet(long_long_int_type()));
-    dereference_exprt int_val(long_long_int_type());
-    int_val.op0() = as_int_ptr;
-    typecast_exprt int_as_float(int_val, elem_type);
+    exprt as_int_ptr =
+      build_typecast(value_member, pointer_typet(long_long_int_type()));
+    exprt int_val = build_dereference(as_int_ptr, long_long_int_type());
+    exprt int_as_float = build_typecast(int_val, elem_type);
 
     // item->type_id == float_type_id ? float_buf[float_idx] : (double)int
     equality_exprt is_float(


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration in the Python frontend. Route the `#cpp_type`-safe raw `typecast_exprt`/`dereference_exprt` sites in `python_list.cpp` through the file's IREP2 helper convention:

- New `build_dereference(ptr, t)` helper — the IREP2 round-trip of the legacy single-arg `dereference_exprt(t)` + `op0()=ptr` form (result type `t` directly).
- Migrated three `typecast_exprt` sites via the existing `build_typecast`: the bool→long push cast (`signedbv`), the list-repetition count cast (`int_type`), and the mixed-numeric int-payload subtree `(double)*(long long*)item->value` (targets `pointer(long_long)`, `long_long`, and a float `elem_type`).

**Deliberately left legacy:** the `obj_value` typecast cluster (targets built from a possibly-char `elem_type`, which can carry `#cpp_type` — and `build_typecast` does not restore it, unlike `build_index`), and the nil-typed two-arg `dereference_exprt(list_expr, pointee_type)` site (different construction). The code review confirmed none of the migrated targets can carry `#cpp_type`.

Behaviour-preserving. Validation on an asserts-enabled Debug build (live `migrate.cpp` cross-check silent):
- 265/266 list-stratum tests pass via ctest; the one non-pass is `list_pop11_nondet`, which only fails because it hardcodes `--boolector` (not built in this local config) — it verifies SUCCESSFUL under both Bitwuzla and Z3.
- The migrated paths are exercised by `list-repetition`/`-symbolic`/`list-repeat-nonconst-count` (count cast) and `mixed_list_dynamic_index_int` (the `build_dereference` int-payload subtree), all matching expected verdicts under **both Bitwuzla and Z3**.
- Code review: no correctness findings; `build_dereference` reproduces the legacy single-arg node exactly, and the `exprt` retype of the affected locals is safe.

Stacked on #5242 (the `build_deref_member` PR).
