### PR TITLE
[python] V.3: route tuple/complex member access through IREP2 helper

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -83,6 +83,22 @@ exprt build_address_of(const exprt &obj)
   migrate_expr(obj, obj2);
   return migrate_expr_back(address_of2tc(obj2->type, obj2));
 }
+
+// Struct member access base.field : t (V.3). `base` must be a struct/union/
+// complex value (member2t's source precondition); the callers here pass a
+// tuple or complex struct whose component is named `name`.
+exprt build_member(const exprt &base, const irep_idt &name, const typet &t)
+{
+  if (contains_dyn_array(t) || contains_dyn_array(base.type()))
+    return member_exprt(base, name, t);
+  expr2tc base2;
+  migrate_expr(base, base2);
+  exprt result = migrate_expr_back(member2tc(migrate_type(t), base2, name));
+  // migrate_type does not round-trip #cpp_type; restore the exact member type
+  // so legacy member_exprt(base, name, t) is reproduced faithfully.
+  result.type() = t;
+  return result;
+}
 } // namespace
 
 namespace
@@ -1457,7 +1473,7 @@ exprt function_call_expr::handle_tuple_method() const
     exprt total = gen_zero(result_type);
     for (const auto &comp : components)
     {
-      exprt member = member_exprt(receiver, comp.get_name(), comp.type());
+      exprt member = build_member(receiver, comp.get_name(), comp.type());
       exprt eq = equality_exprt(member, elem);
       if_exprt sel(eq, gen_one(result_type), gen_zero(result_type));
       sel.type() = result_type;
@@ -1477,7 +1493,7 @@ exprt function_call_expr::handle_tuple_method() const
   exprt any_match = gen_boolean(false);
   for (const auto &comp : components)
   {
-    exprt member = member_exprt(receiver, comp.get_name(), comp.type());
+    exprt member = build_member(receiver, comp.get_name(), comp.type());
     exprt eq = equality_exprt(member, elem);
     any_match = or_exprt(any_match, eq);
   }
@@ -1493,7 +1509,7 @@ exprt function_call_expr::handle_tuple_method() const
   for (size_t k = n - 1; k-- > 0;)
   {
     exprt member =
-      member_exprt(receiver, components[k].get_name(), components[k].type());
+      build_member(receiver, components[k].get_name(), components[k].type());
     exprt eq = equality_exprt(member, elem);
     if_exprt sel(eq, from_integer(BigInt(k), result_type), result);
     sel.type() = result_type;
@@ -2458,8 +2474,8 @@ function_call_expr::get_dispatch_table()
        model_call.type() = to_code_type(model_symbol->get_type()).return_type();
        model_call.location() = converter_.get_location_from_decl(call_);
 
-       exprt zr = member_exprt(z, "real", double_type());
-       exprt zi = member_exprt(z, "imag", double_type());
+       exprt zr = build_member(z, "real", double_type());
+       exprt zi = build_member(z, "imag", double_type());
 
        exprt imag_result;
        if (func_name == "asin")


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration in the Python frontend. Add a `build_member(base, name, t)` helper in `function_call/expr.cpp` and route the five raw `member_exprt` construction sites through it:

- three tuple-component accesses in `handle_tuple_method` (`.count()` / `.index()` — `receiver` is the tuple struct, iterated over its components);
- two complex accesses `z.real` / `z.imag` in the cmath dispatch (`z` is the complex struct whose components are literally named `real`/`imag`).

The helper follows the file's existing convention (`build_typecast`/`build_address_of`): a dyn-array fallback to legacy `member_exprt`, otherwise `migrate_expr_back(member2tc(migrate_type(t), migrate_expr(base), name))` with `result.type() = t` restored (since `migrate_type` does not round-trip `#cpp_type`). `member2t`'s source + component-existence preconditions hold at every site (struct source, real component name) — confirmed by the code review.

Behaviour-preserving. Validation on an asserts-enabled Debug build (the `member2t` construction asserts and the `migrate.cpp` cross-check are live):
- 164/164 tuple + complex regression tests pass via ctest; no `member2t` assert fired.
- Representative tests (`tuple_index_method`/`_fail`, `complex_attr_real_imag`, `complex_cmath_log*`, `complex_conjugate_handler`, `complex_attr_identities`) and a fresh `tuple.count()` probe match expected verdicts under **both Bitwuzla and Z3**.
- Code review: no correctness findings; all `member2t` preconditions statically guaranteed, the `exprt` retype is safe, and the dyn-array fallback is reachable (a tuple holding a list).
