### PR TITLE
[python] V.3: route builder.cpp typecasts through IREP2 helper

### DIFF
--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -181,7 +181,13 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
   if (is_complex_type(unary_sub.type()) && (op == "USub" || op == "UAdd"))
     return complex_handler_.handle_unary_op(op, unary_sub);
 
-  exprt unary_expr(python_frontend::map_operator(op, type), type);
+  // Python's `not` always yields a bool, regardless of its operand's type.
+  // Type the node accordingly (matching every other `not` site in the
+  // frontend) so it is well-formed IR: migrate_expr asserts that `not`/`and`/
+  // `or` nodes are bool-typed, and consumers that migrate eagerly (e.g.
+  // build_typecast) would otherwise abort before the C adjuster normalises it.
+  const typet result_type = (op == "Not") ? bool_type() : type;
+  exprt unary_expr(python_frontend::map_operator(op, result_type), result_type);
   unary_expr.operands().push_back(unary_sub);
 
   return unary_expr;

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -63,6 +63,19 @@ exprt build_member(const exprt &base, const irep_idt &name, const typet &t)
   return member_exprt(base, name, t);
 }
 
+exprt build_typecast(const exprt &from, const typet &t)
+{
+  if (contains_dyn_array(t) || contains_dyn_array(from.type()))
+    return typecast_exprt(from, t);
+  expr2tc from2;
+  migrate_expr(from, from2);
+  exprt result = migrate_expr_back(typecast2tc(migrate_type(t), from2));
+  // migrate_type does not round-trip #cpp_type; restore the exact target type
+  // so legacy typecast_exprt(from, t) is reproduced faithfully.
+  result.type() = t;
+  return result;
+}
+
 // Expression-context call `callee(args...)` returning return_type, where the
 // callee is an already-built function expression (here a by-name symbol_exprt
 // carrying a code_typet). Falls back to the legacy node for a dyn-sized-array
@@ -826,7 +839,7 @@ exprt function_call_builder::build() const
 
     exprt condition = converter_.get_expr(call_["args"][0]);
     if (!condition.type().is_bool())
-      condition = typecast_exprt(condition, bool_type());
+      condition = build_typecast(condition, bool_type());
 
     // Create code_assume statement
     codet assume_code("assume");
@@ -847,7 +860,7 @@ exprt function_call_builder::build() const
 
     exprt condition = converter_.get_expr(args[0]);
     if (!condition.type().is_bool())
-      condition = typecast_exprt(condition, bool_type());
+      condition = build_typecast(condition, bool_type());
 
     code_assertt assert_code(condition);
     assert_code.location() = converter_.get_location_from_decl(call_);
@@ -983,7 +996,7 @@ exprt function_call_builder::build() const
       if (arg.type().is_code())
         arg = build_address_of(arg);
       if (arg.type() != param_type)
-        arg = typecast_exprt(arg, param_type);
+        arg = build_typecast(arg, param_type);
 
       code_function_callt call;
       call.function() = symbol_exprt(symbol_id, fn_type);
@@ -1037,7 +1050,7 @@ exprt function_call_builder::build() const
           throw std::runtime_error(func_name + " takes exactly one argument");
         exprt arg = converter_.get_expr(call_["args"][0]);
         if (arg.type() != uint_type())
-          arg = typecast_exprt(arg, uint_type());
+          arg = build_typecast(arg, uint_type());
         call.arguments().push_back(arg);
       }
       else if (!call_["args"].empty())


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration in the Python frontend. Add a `build_typecast(from, t)` helper in `function_call/builder.cpp` (matching the file's existing `build_member`/`build_address_of` convention and the already-merged helper in `function_call/expr.cpp`: dyn-array fallback to legacy `typecast_exprt`, otherwise `migrate_expr_back(typecast2tc(migrate_type(t), migrate_expr(from)))` with `result.type() = t` restored, since `migrate_type` drops `#cpp_type`).

Route the four raw `typecast_exprt` sites through it:
- the `__ESBMC_assume` / `__VERIFIER_assume` and `__ESBMC_assert` bool-condition casts;
- the function-call argument coercion to the parameter type (`#cpp_type`-safe via the restore);
- a `uint`-typed builtin argument cast.

The `symbol_exprt(symbol_id, code_typet)` callee constructions are deliberately left legacy — migrating a `code_typet` through `migrate_type` risks the `code_type2t` args/names arity assert, and the legacy node never migrates that type.

Behaviour-preserving. Validation on an asserts-enabled Debug build (the `migrate.cpp` cross-check is live):
- 106/106 assume/assert/builtin regression tests pass via ctest; no abort.
- Representative tests across all four sites — `esbmc-assume`/`verifier-assume` (+ `_fail`), `assert-arith`, `casting-chr-func`/`-multibyte` (uint arg), `ascii_builtin` — match expected verdicts under **both Bitwuzla and Z3**.
- Code review: no corrective findings; `build_typecast` is byte-identical to the reviewed reference, no consumer needs `typecast_exprt`-specific API, and leaving the `code_typet` callee sites legacy is correct.
