### PR TITLE
[python] V.3: build the .shape list-length subtree in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -902,8 +902,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             expr.type().is_pointer() ? expr : address_of_exprt(expr), base2);
           expr2tc size_call = side_effect_function_call2tc(
             migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
-          exprt list_len = migrate_expr_back(
-            typecast2tc(migrate_type(int_type()), size_call));
+          exprt list_len =
+            migrate_expr_back(typecast2tc(migrate_type(int_type()), size_call));
           expr = build_shape_tuple_expr(*this, {list_len});
           break;
         }

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -536,15 +536,16 @@ exprt python_converter::get_expr(const nlohmann::json &element)
               throw std::runtime_error(
                 "__ESBMC_list_size not found for list shape access");
 
-            side_effect_expr_function_callt size_call;
-            size_call.function() = symbol_expr(*size_func);
-            size_call.type() = size_type();
-            if (base_expr.type().is_pointer())
-              size_call.arguments().push_back(base_expr);
-            else
-              size_call.arguments().push_back(address_of_exprt(base_expr));
-
-            exprt list_len = typecast_exprt(size_call, int_type());
+            // (int)__ESBMC_list_size(&base_expr), built in IREP2 (V.3).
+            expr2tc base2;
+            migrate_expr(
+              base_expr.type().is_pointer() ? base_expr
+                                            : address_of_exprt(base_expr),
+              base2);
+            expr2tc size_call = side_effect_function_call2tc(
+              migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
+            exprt list_len = migrate_expr_back(
+              typecast2tc(migrate_type(int_type()), size_call));
             return build_shape_tuple_expr(*this, {list_len});
           }
         }
@@ -895,13 +896,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             throw std::runtime_error(
               "__ESBMC_list_size not found for list shape access");
 
-          side_effect_expr_function_callt size_call;
-          size_call.function() = symbol_expr(*size_func);
-          size_call.type() = size_type();
-          size_call.arguments().push_back(
-            expr.type().is_pointer() ? expr : address_of_exprt(expr));
-
-          exprt list_len = typecast_exprt(size_call, int_type());
+          // (int)__ESBMC_list_size(&expr), built in IREP2 (V.3).
+          expr2tc base2;
+          migrate_expr(
+            expr.type().is_pointer() ? expr : address_of_exprt(expr), base2);
+          expr2tc size_call = side_effect_function_call2tc(
+            migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
+          exprt list_len = migrate_expr_back(
+            typecast2tc(migrate_type(int_type()), size_call));
           expr = build_shape_tuple_expr(*this, {list_len});
           break;
         }


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration in the Python frontend. Migrate the two near-identical numpy `.shape` list-length subtrees in `python_converter::get_expr` (`converter/converter_expr.cpp`) from legacy construction to inline IREP2.

Each subtree builds `(int)__ESBMC_list_size(&base)`: a `side_effect_expr_function_callt` to `__ESBMC_list_size` over `address_of(base)` (or `base` when already a pointer), typecast to `int`. The new code migrates the `address_of` argument forward, builds `side_effect_function_call2tc(size_type(), __ESBMC_list_size, {arg})` + `typecast2tc(int_type(), …)`, and back-migrates once at the `list_len` boundary that feeds `build_shape_tuple_expr`. `int_type()`/`size_type()` carry no `#cpp_type`, so no type-restore is needed.

Behaviour-preserving. Validation on an asserts-enabled Debug build (live `migrate.cpp` cross-check):
- 329/329 `regression/numpy` tests pass via ctest; no abort.
- The 15 `.shape` tests (`github_4666_shape*`) match expected verdicts under **both Bitwuzla and Z3**.
- 174/174 python attribute/list/class tests pass (the `converter_expr.cpp` dispatch hub).
- Code review: behaviour-preserving, no correctness findings. (The back-migrated side-effect node carries an inert `#type`→`{empty}` named sub that function-call lowering never reads — inherent to `side_effect_function_call2tc` and identical to every prior merged V.3 side-effect migration.)

Note: §16 of the migration plan recorded this `.shape` path as "un-gateable" because `regression/python` has no `import numpy` tests — but the dedicated `regression/numpy` suite (330 tests, run via ESBMC's numpy model, no real numpy needed) does gate it. That note is stale.
