### PR TITLE
[python] V.3: build class/union attribute-cast pointers in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -908,8 +908,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             expr.type().is_pointer() ? expr : address_of_exprt(expr), base2);
           expr2tc size_call = side_effect_function_call2tc(
             migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
-          exprt list_len = migrate_expr_back(
-            typecast2tc(migrate_type(int_type()), size_call));
+          exprt list_len =
+            migrate_expr_back(typecast2tc(migrate_type(int_type()), size_call));
           expr = build_shape_tuple_expr(*this, {list_len});
           break;
         }

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1460,7 +1460,13 @@ static exprt make_slice_struct_expr(
       return side_effect_expr_nondett(field_type);
     exprt value = conv.get_expr(*node);
     if (value.type() != field_type)
-      value = typecast_exprt(value, field_type);
+    {
+      // (field_type)value, built in IREP2 (V.3).
+      expr2tc v2;
+      migrate_expr(value, v2);
+      value = migrate_expr_back(typecast2tc(migrate_type(field_type), v2));
+      value.type() = field_type; // restore #cpp_type that migrate_type drops
+    }
     return value;
   };
 

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -536,15 +536,16 @@ exprt python_converter::get_expr(const nlohmann::json &element)
               throw std::runtime_error(
                 "__ESBMC_list_size not found for list shape access");
 
-            side_effect_expr_function_callt size_call;
-            size_call.function() = symbol_expr(*size_func);
-            size_call.type() = size_type();
-            if (base_expr.type().is_pointer())
-              size_call.arguments().push_back(base_expr);
-            else
-              size_call.arguments().push_back(address_of_exprt(base_expr));
-
-            exprt list_len = typecast_exprt(size_call, int_type());
+            // (int)__ESBMC_list_size(&base_expr), built in IREP2 (V.3).
+            expr2tc base2;
+            migrate_expr(
+              base_expr.type().is_pointer() ? base_expr
+                                            : address_of_exprt(base_expr),
+              base2);
+            expr2tc size_call = side_effect_function_call2tc(
+              migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
+            exprt list_len = migrate_expr_back(
+              typecast2tc(migrate_type(int_type()), size_call));
             return build_shape_tuple_expr(*this, {list_len});
           }
         }
@@ -895,13 +896,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             throw std::runtime_error(
               "__ESBMC_list_size not found for list shape access");
 
-          side_effect_expr_function_callt size_call;
-          size_call.function() = symbol_expr(*size_func);
-          size_call.type() = size_type();
-          size_call.arguments().push_back(
-            expr.type().is_pointer() ? expr : address_of_exprt(expr));
-
-          exprt list_len = typecast_exprt(size_call, int_type());
+          // (int)__ESBMC_list_size(&expr), built in IREP2 (V.3).
+          expr2tc base2;
+          migrate_expr(
+            expr.type().is_pointer() ? expr : address_of_exprt(expr), base2);
+          expr2tc size_call = side_effect_function_call2tc(
+            migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
+          exprt list_len = migrate_expr_back(
+            typecast2tc(migrate_type(int_type()), size_call));
           expr = build_shape_tuple_expr(*this, {list_len});
           break;
         }

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -659,8 +659,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             bp.empty() ? flow_class_map_.end() : flow_class_map_.find(bp);
           if (it != flow_class_map_.end())
           {
-            exprt cast = typecast_exprt(
-              base_expr, gen_pointer_type(symbol_typet("tag-" + it->second)));
+            // (tag-Cls*)base_expr, built in IREP2 (V.3).
+            const typet cast_t =
+              gen_pointer_type(symbol_typet("tag-" + it->second));
+            expr2tc base2;
+            migrate_expr(base_expr, base2);
+            exprt cast =
+              migrate_expr_back(typecast2tc(migrate_type(cast_t), base2));
+            cast.type() = cast_t; // restore #cpp_type that migrate_type drops
             resolved = resolve_member_on_base(cast, attr_name);
           }
         }
@@ -956,10 +962,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             "' on union type: no class with this attribute found");
         }
 
-        // Create a typecast from char* to target_class*
+        // Create a typecast from char* to target_class* in IREP2 (V.3).
         typet target_ptr_type =
           gen_pointer_type(target_class_symbol->get_type());
-        exprt casted_expr = typecast_exprt(expr, target_ptr_type);
+        expr2tc expr2;
+        migrate_expr(expr, expr2);
+        exprt casted_expr =
+          migrate_expr_back(typecast2tc(migrate_type(target_ptr_type), expr2));
+        casted_expr.type() = target_ptr_type;
 
         // Dereference to get the object
         exprt deref_expr("dereference", target_class_symbol->get_type());
@@ -1062,7 +1072,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
 
         if (!(base_type.is_struct() || base_type.is_union() ||
               points_to_struct))
-          base = typecast_exprt(base, gen_pointer_type(class_type));
+        {
+          // (class_type*)base, built in IREP2 (V.3).
+          const typet bt = gen_pointer_type(class_type);
+          expr2tc base2;
+          migrate_expr(base, base2);
+          base = migrate_expr_back(typecast2tc(migrate_type(bt), base2));
+          base.type() = bt; // restore #cpp_type that migrate_type drops
+        }
 
         if (base.type().is_pointer())
         {


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration in the Python frontend. Migrate three class/union attribute-access pointer casts in `python_converter::get_expr` (`converter/converter_expr.cpp`) from legacy `typecast_exprt` to inline IREP2 (the file's convention):

1. the **flow-sensitive** class-member cast `(tag-Cls*)base_expr` (driven by `flow_class_map_`);
2. the **union-attribute** cast `(target_class*)expr`;
3. the **base-type** class-pointer cast `(class_type*)base` for member access.

Each becomes `migrate_expr_back(typecast2tc(migrate_type(T), migrate_expr(src)))` with `result.type() = T` restored — the restore overwrites the whole type with the verbatim legacy target, so it is exact regardless of any round-trip lossiness (and a no-op for these class-pointer targets, which carry no `#cpp_type`). The paired legacy dereferences and the nil-typed two-arg `dereference_exprt` sites stay legacy by design.

Behaviour-preserving. Validation on an asserts-enabled Debug build (live `migrate.cpp` cross-check, with the V.1k relaxed `member2t` assert in effect):
- 236/236 class/attribute/union/dataclass/nested-attr tests pass via ctest; no abort.
- Representative tests across all three sites — `github_4117_*` (flow-sensitive), `union`/`union2`/`union3` (+ `_fail`), `optional_union`, `github_3976_optional_attr_access`, `nested-attr-*`, `dataclass_field_*` — match expected verdicts under **both Bitwuzla and Z3**. These include the exact families the V.1k design-(a) prototype regressed, confirming this approach (no early type-following) is sound.
- Code review: behaviourally equivalent, no findings; the inert `rounding_mode` sub on the back-migrated typecast is unused for pointer casts and consistent with this file's established convention.

Stacked on #5248 (the `.shape` PR).
