### PR TITLE
[python] V.3: route numpy 2D-result indexing through an IREP2 helper

### DIFF
--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -57,6 +57,16 @@ exprt np_address_of(const exprt &obj)
   migrate_expr(obj, obj2);
   return migrate_expr_back(address_of2tc(obj2->type, obj2));
 }
+
+// index_exprt(arr, idx, t): arr is an array-typed numpy result (the 2D row/
+// element access below), a permitted index2t source.
+exprt np_index(const exprt &arr, const exprt &idx, const typet &t)
+{
+  expr2tc arr2, idx2;
+  migrate_expr(arr, arr2);
+  migrate_expr(idx, idx2);
+  return migrate_expr_back(index2tc(migrate_type(t), arr2, idx2));
+}
 } // namespace
 
 struct numeric_value
@@ -2053,12 +2063,12 @@ exprt numpy_call_expr::create_expr_from_call()
         }
         else
         {
-          exprt row0 = index_exprt(
+          exprt row0 = np_index(
             *converter_.current_lhs,
             from_integer(0, size_type()),
             converter_.current_lhs->type().subtype());
           exprt elem00 =
-            index_exprt(row0, from_integer(0, size_type()), base_type);
+            np_index(row0, from_integer(0, size_type()), base_type);
           result_ptr = np_address_of(elem00);
         }
         args.push_back(np_typecast(result_ptr, flat_ptr_type));


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration in the Python frontend. Add an `np_index(arr, idx, t)` helper in `numpy_call_expr.cpp` (matching the file's existing `np_member`/`np_typecast`/`np_address_of` convention) and route the two remaining raw `index_exprt` sites through it — the 2D numpy matmul/dot result row/element access (`current_lhs[0][0]`).

`np_index` = `migrate_expr_back(index2tc(migrate_type(t), migrate_expr(arr), migrate_expr(idx)))`, the same shape as the merged `np_member`. Both index sources are fixed-size `array_type2tc` results from `build_array`, so `index2t`'s array-source precondition holds on the array leg; the numpy element/row types carry no `#cpp_type`, so no type-restore is needed.

Behaviour-preserving. Validation on an asserts-enabled Debug build (the `index2t` source-precondition assert and the `migrate.cpp` cross-check are live):
- 329/329 `regression/numpy` tests pass via ctest; no abort.
- The 2D matmul/dot tests (`github_5115_matmul_2x2_literal`, `github_5115_dot_2x2_literal`, `github_5115_matmul_1x1_symbolic`, and the `_fail` variants) — the exact 2D-result-indexing path — match expected verdicts under **both Bitwuzla and Z3**.
- Code review: behaviour-preserving, no findings; `np_index` reproduces the legacy `index_exprt` exactly, the precondition holds, and no consumer needs index-specific API.

This completes the raw expression-construction surface in `numpy_call_expr.cpp` (the member/typecast/address-of sites were already migrated to the `np_*` helpers).
