### PR TITLE
[python] V.3: fold enum-member &str[0] into one IREP2 subtree

### DIFF
--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -70,13 +70,13 @@ exprt python_converter::make_enum_member_struct_expr(
   // name component: char* pointer to the first element of the name string
   exprt str_expr = symbol_expr(*str_sym);
   exprt zero_idx = from_integer(0, index_type());
-  // V.3: IREP2 index access (exact round-trip of index_exprt); str_sym is a
-  // static char-array symbol, so the source is array-typed.
+  // V.3: build &str_sym[0] entirely in IREP2, back-migrating once. str_sym is
+  // a static char-array symbol, so the index source is array-typed.
   expr2tc se2, zi2;
   migrate_expr(str_expr, se2);
   migrate_expr(zero_idx, zi2);
-  exprt name_ptr = address_of_exprt(migrate_expr_back(
-    index2tc(migrate_type(str_expr.type().subtype()), se2, zi2)));
+  expr2tc idx2 = index2tc(migrate_type(str_expr.type().subtype()), se2, zi2);
+  exprt name_ptr = migrate_expr_back(address_of2tc(idx2->type, idx2));
   name_ptr.type() = gen_pointer_type(char_type());
   struct_val.operands().push_back(name_ptr);
 


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration. In `make_enum_member_struct_expr` (`converter/converter_class.cpp`), the Enum member name-pointer `&str_sym[0]` already built the index in IREP2 but then wrapped it in a legacy `address_of_exprt` and back-migrated the index alone. Fold the whole address-of-index subtree into IREP2 (`address_of2tc` over `index2tc`) and back-migrate once, removing the legacy/IREP2 boundary crossing.

Byte-equivalent: the address-of pointer type and operand are identical to the legacy form (and the result type is overwritten with `gen_pointer_type(char_type())` in both, as before). This drains the last raw expression-construction site in `converter_class.cpp`.

Validation on an asserts-enabled Debug build (the `index2t`/`address_of2t` construction asserts and the `migrate.cpp` cross-check are live):
- 14/14 `github_3642*` Enum-class tests pass via ctest (the exact enum-member-struct path), including the `_fail` and `_alias` variants.
- Representative tests match expected verdicts under both Bitwuzla and Z3.
- Code review: byte-equivalent, no findings.