### PR TITLE
[python] V.3: route python_math operand float-cast through IREP2

### DIFF
--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -54,6 +54,15 @@ exprt math_member(const exprt &base, const irep_idt &name, const typet &t)
   return migrate_expr_back(member2tc(migrate_type(t), base2, name));
 }
 
+// V.3: IREP2 typecast (exact round-trip of typecast_exprt). The single caller
+// targets float_type, which carries no #cpp_type, so no type-restore is needed.
+exprt math_typecast(const exprt &from, const typet &t)
+{
+  expr2tc from2;
+  migrate_expr(from, from2);
+  return migrate_expr_back(typecast2tc(migrate_type(t), from2));
+}
+
 std::string make_math_dispatch_cache_key(
   const std::string &caller,
   const std::string &func_name)
@@ -790,7 +799,7 @@ void python_math::handle_float_division(exprt &lhs, exprt &rhs, exprt &bin_expr)
     else
     {
       // For non-constant operands (like function parameters), create explicit typecast expression
-      e = typecast_exprt(e, float_type);
+      e = math_typecast(e, float_type);
     }
   };
 


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration. Add a `math_typecast(from, t)` helper in `python_math.cpp` (matching the file's existing `math_member` / `build_c_math_call_expr` convention) and route the lone raw `typecast_exprt` site — the non-constant math operand coercion to `float_type` — through it. The target is `float_type` (no `#cpp_type`), so no type-restore is needed.

Byte-equivalent (same `migrate_expr_back(typecast2tc(...))` shape as the merged `math_member`). Drains the last raw construction site in the file.

Validation on an asserts-enabled Debug build (live `migrate.cpp` cross-check):
- 18/18 floor/ceil/sqrt/hypot/fabs math tests pass via ctest.
- Representative math tests over variable operands (`floor_ceil*`, `complex_cmath_log*`, `complex_math_typeerror*`) match expected verdicts under both Bitwuzla and Z3 (10/10).
