### PR TITLE
[python] V.3: build raise-expression call in IREP2

### DIFF
--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -368,10 +368,19 @@ void python_exception_handler::get_raise_statement(
     {
       code_function_callt call =
         to_code_function_call(converter_.convert_expression_to_code(raise));
-      side_effect_expr_function_callt tmp;
-      tmp.function() = call.function();
-      tmp.arguments() = call.arguments();
-      tmp.type() = type;
+      // V.3: build the expression-context call in IREP2, back-migrating once.
+      expr2tc fn2;
+      migrate_expr(call.function(), fn2);
+      std::vector<expr2tc> args2;
+      args2.reserve(call.arguments().size());
+      for (const exprt &a : call.arguments())
+      {
+        expr2tc a2;
+        migrate_expr(a, a2);
+        args2.push_back(std::move(a2));
+      }
+      exprt tmp = migrate_expr_back(
+        side_effect_function_call2tc(migrate_type(type), fn2, args2));
       tmp.location() = location;
       raise = tmp;
     }


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration. In the raise handler (`python_exception_handler.cpp`), the function-call form of a raise value (`raise Exc(args)`) hand-built a `side_effect_expr_function_callt` by copying `function`/`arguments`/`type`. Build it with `side_effect_function_call2tc` and back-migrate once, re-setting the outer location exactly as before.

This matches the established merged `build_call` pattern (`function_call/builder.cpp`). The args' expr-level locations are not individually re-attached (they are stripped by `migrate_expr` at goto-convert regardless), and the outer location is preserved — validated by matched-text below.

Validation on an asserts-enabled Debug build (live `migrate.cpp` cross-check):
- 37/37 exception / raise / try tests pass via ctest, including the matched-text checks (exception message / line numbers), confirming no location regression.
- Representative `raise Exc(args)` tests (`exception`, `exception_base_class`, `exception_div_zero`, `exception10`, `any-example`, and `_fail` variants) match expected verdicts under both Bitwuzla and Z3 (10/10).

Drains the last raw expression-construction site in the file.
