### PR TITLE
[python] V.3: build slice-field int cast in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1460,7 +1460,13 @@ static exprt make_slice_struct_expr(
       return side_effect_expr_nondett(field_type);
     exprt value = conv.get_expr(*node);
     if (value.type() != field_type)
-      value = typecast_exprt(value, field_type);
+    {
+      // (field_type)value, built in IREP2 (V.3).
+      expr2tc v2;
+      migrate_expr(value, v2);
+      value = migrate_expr_back(typecast2tc(migrate_type(field_type), v2));
+      value.type() = field_type; // restore #cpp_type that migrate_type drops
+    }
     return value;
   };
 


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration. In the `lower_int` lambda (slice `start`/`stop`/`step` field lowering, github #4543), build the `(field_type)value` coercion in IREP2 (`typecast2tc`, back-migrated once with `result.type() = field_type` restored) instead of a legacy `typecast_exprt`. Same inline pattern as the reviewed class/union attribute casts in this file.

Byte-equivalent. Drains the last typecast site in this lambda.

Validation on an asserts-enabled Debug build (live `migrate.cpp` cross-check):
- 32/32 slice tests pass via ctest (verdict + matched-text).
- Non-slice-struct slice tests (`github_4523_*`, `github_4537_*`) match expected verdicts under both Bitwuzla and Z3.

Note: a few `github_4543_*`/`github_4539_*` slice tests error under `--z3` with a pre-existing `__ESBMC_PySliceObj` struct-incompatibility (same error reproduces on clean master, e.g. `github_4543_is_none`) — unrelated to this frontend typecast change; they pass on the default Bitwuzla solver.

Stacked on #5250.
