### PR TITLE
[python] V.3: build complex int->double promotion cast in IREP2

### DIFF
--- a/src/python-frontend/complex_handler.cpp
+++ b/src/python-frontend/complex_handler.cpp
@@ -28,6 +28,17 @@ exprt complex_member(const exprt &base, const irep_idt &name, const typet &t)
   migrate_expr(base, base2);
   return migrate_expr_back(member2tc(migrate_type(t), base2, name));
 }
+
+// V.3: IREP2 typecast (exact round-trip of typecast_exprt). The source is a
+// concrete numeric value (floatbv/signedbv/unsignedbv/bool) and the target is
+// the plain double type, which carries no #cpp_type, so no type-restore is
+// needed -- mirrors python_math's math_typecast.
+exprt complex_typecast(const exprt &from, const typet &t)
+{
+  expr2tc from2;
+  migrate_expr(from, from2);
+  return migrate_expr_back(typecast2tc(migrate_type(t), from2));
+}
 } // namespace
 
 // -----------------------------------------------------------------------
@@ -248,7 +259,7 @@ exprt complex_handler::promote_int_arith_to_double(
   if (!numeric_like)
     return input_expr;
 
-  return typecast_exprt(input_expr, dt);
+  return complex_typecast(input_expr, dt);
 }
 
 exprt complex_handler::normalize_numeric_expr(const exprt &value) const


### PR DESCRIPTION
Continue Phase V.3 of the IREP2 migration. In complex_handler's `promote_int_arith_to_double`, the numeric->double promotion was a legacy `typecast_exprt`. Add a `complex_typecast` helper (exact IREP2 round-trip via `typecast2tc`, mirroring python_math's `math_typecast`) and route that site through it. Behaviour-preserving: the source is concrete-numeric and the double target carries no `#cpp_type`, so no type-restore is needed.

The `depth>64` recursion-limit fallback is left as legacy `typecast_exprt` -- it is a defensive branch no regression test exercises, so migrating it would ship un-gateable construction.

Validated on an asserts-enabled Debug build (live migrate cross-check silent): 129/129 complex+cmath regression tests pass; the migrated site is reachable (fires 11x on `complex_attr_int_promotion`); dual-solver (Bitwuzla + Z3) agreement confirmed on the promotion path.