### PR TITLE
[regression] add exception-rework test corpus as a baseline

### DIFF
--- a/regression/esbmc-cpp/inheritance/mi_base_subobject_layout/main.cpp
+++ b/regression/esbmc-cpp/inheritance/mi_base_subobject_layout/main.cpp
@@ -1,0 +1,45 @@
+#include <cassert>
+
+struct A
+{
+  int a;
+  A() : a(1)
+  {
+  }
+};
+
+struct P
+{
+  virtual ~P()
+  {
+  }
+
+  int p;
+
+  P() : p(9)
+  {
+  }
+};
+
+struct AP : A, P
+{
+};
+
+struct PA : P, A
+{
+};
+
+int main()
+{
+  AP ap;
+  A &ap_a = ap;
+  P &ap_p = ap;
+  assert(ap_a.a == 1);
+  assert(ap_p.p == 9);
+
+  PA pa;
+  A &pa_a = pa;
+  P &pa_p = pa;
+  assert(pa_a.a == 1);
+  assert(pa_p.p == 9);
+}

--- a/regression/esbmc-cpp/inheritance/mi_base_subobject_layout/test.desc
+++ b/regression/esbmc-cpp/inheritance/mi_base_subobject_layout/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/mi_base_subobject_layout_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance/mi_base_subobject_layout_fail/main.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+
+struct A
+{
+  int a;
+  A() : a(1)
+  {
+  }
+};
+
+struct P
+{
+  virtual ~P()
+  {
+  }
+
+  int p;
+
+  P() : p(9)
+  {
+  }
+};
+
+struct AP : A, P
+{
+};
+
+int main()
+{
+  AP ap;
+  A &as = ap;
+  assert(as.a == 9);
+}

--- a/regression/esbmc-cpp/inheritance/mi_base_subobject_layout_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/mi_base_subobject_layout_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--std c++17
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/mi_dynamic_cast/main.cpp
+++ b/regression/esbmc-cpp/inheritance/mi_dynamic_cast/main.cpp
@@ -1,0 +1,48 @@
+// dynamic_cast across multiple inheritance with non-zero base offsets:
+// a down-cast from a non-first base back to the derived type, and a sibling
+// cross-cast between two bases. Both require the result pointer to be re-offset
+// to the correct sub-object inside the runtime type (result = src - off(S) +
+// off(T)), not a plain reinterpret.
+#include <cassert>
+
+struct B1
+{
+  virtual ~B1()
+  {
+  }
+  int x;
+  B1() : x(1)
+  {
+  }
+};
+struct B2
+{
+  virtual ~B2()
+  {
+  }
+  int y;
+  B2() : y(2)
+  {
+  }
+};
+struct D : B1, B2
+{
+  int z;
+  D() : z(3)
+  {
+  }
+};
+
+int main()
+{
+  D d;
+  B2 *b2 = &d; // upcast to the non-first base (non-zero offset)
+
+  D *dd = dynamic_cast<D *>(b2); // down-cast through the offset
+  assert(dd && dd->x == 1 && dd->y == 2 && dd->z == 3);
+
+  B1 *b1 = dynamic_cast<B1 *>(b2); // sibling cross-cast B2* -> B1*
+  assert(b1 && b1->x == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/mi_dynamic_cast/test.desc
+++ b/regression/esbmc-cpp/inheritance/mi_dynamic_cast/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 2 --no-unwinding-assertions --std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/mi_dynamic_cast_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance/mi_dynamic_cast_fail/main.cpp
@@ -1,0 +1,37 @@
+// Negative companion: after the sibling cross-cast B2* -> B1*, b1 points at the
+// B1 sub-object, so b1->x is 1, not 2. Asserting the wrong value must fail
+// (proves the cross-cast re-offsets rather than aliasing B2's data).
+#include <cassert>
+
+struct B1
+{
+  virtual ~B1()
+  {
+  }
+  int x;
+  B1() : x(1)
+  {
+  }
+};
+struct B2
+{
+  virtual ~B2()
+  {
+  }
+  int y;
+  B2() : y(2)
+  {
+  }
+};
+struct D : B1, B2
+{
+};
+
+int main()
+{
+  D d;
+  B2 *b2 = &d;
+  B1 *b1 = dynamic_cast<B1 *>(b2);
+  assert(b1 && b1->x == 2); // wrong: b1->x is 1
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/mi_dynamic_cast_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/mi_dynamic_cast_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 2 --no-unwinding-assertions --std c++17
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/exception_spec_dynamic_allowed/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_dynamic_allowed/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+// A dynamic exception specification throw(int) is satisfied when an int is
+// thrown. The exception crosses f's boundary without violating the spec and is
+// delivered normally to the handler in main.
+void f() throw(int)
+{
+  throw 5;
+}
+
+int main()
+{
+  int caught = 0;
+  try
+  {
+    f();
+  }
+  catch (int)
+  {
+    caught = 1;
+  }
+  assert(caught == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_dynamic_allowed/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_dynamic_allowed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++03
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/exception_spec_dynamic_violation_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_dynamic_violation_fail/main.cpp
@@ -1,0 +1,19 @@
+// A dynamic exception specification throw(int) is violated by throwing a char.
+// Crossing f's boundary with a disallowed type must invoke std::unexpected,
+// which by default terminates: the verification fails.
+void f() throw(int)
+{
+  throw 'c';
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (...)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_dynamic_violation_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_dynamic_violation_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++03
+^VERIFICATION FAILED$
+exception specification violated

--- a/regression/esbmc-cpp/try_catch/exception_spec_indirect_call_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_indirect_call_fail/main.cpp
@@ -1,0 +1,22 @@
+// For an indirect (function-pointer) call, the specification enforced is that
+// of the resolved callee. Calling f through a pointer still terminates when its
+// noexcept boundary is crossed by an exception.
+void f() noexcept
+{
+  throw 5;
+}
+
+typedef void (*fp)();
+
+int main()
+{
+  fp p = f;
+  try
+  {
+    p();
+  }
+  catch (...)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_indirect_call_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_indirect_call_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++11
+^VERIFICATION FAILED$
+noexcept specification violated

--- a/regression/esbmc-cpp/try_catch/exception_spec_inlining_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_inlining_fail/main.cpp
@@ -1,0 +1,20 @@
+// Even under full inlining, a function with a restrictive exception
+// specification keeps its own frame so the boundary can be enforced. Were f
+// inlined into main, the noexcept boundary would be lost and the escape would
+// go undetected. Run with --full-inlining to exercise that path.
+void f() noexcept
+{
+  throw 5;
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (...)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_inlining_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_inlining_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--full-inlining --unwind 4 --no-unwinding-assertions --std c++11
+^VERIFICATION FAILED$
+noexcept specification violated

--- a/regression/esbmc-cpp/try_catch/exception_spec_internal_catch/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_internal_catch/main.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+
+// A function with a restrictive (empty dynamic) exception specification may
+// throw and catch an otherwise-disallowed exception *internally*: the
+// specification is only violated when handler search exits the function body.
+// Here the int never crosses f's boundary, so there is no violation.
+void f() throw()
+{
+  int caught = 0;
+  try
+  {
+    throw 5;
+  }
+  catch (int)
+  {
+    caught = 1;
+  }
+  assert(caught == 1);
+}
+
+int main()
+{
+  f();
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_internal_catch/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_internal_catch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++03
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/exception_spec_no_try_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_no_try_fail/main.cpp
@@ -1,0 +1,14 @@
+// An exception specification is a function-boundary contract, enforced even
+// when there is no surrounding try/catch region at all. This is the case the
+// old THROW_DECL representation silently ignored, because it attached the
+// specification to the nearest active catch region (here, none).
+void f() noexcept
+{
+  throw 5;
+}
+
+int main()
+{
+  f();
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_no_try_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_no_try_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++11
+^VERIFICATION FAILED$
+noexcept specification violated

--- a/regression/esbmc-cpp/try_catch/exception_spec_noexcept_escape_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_noexcept_escape_fail/main.cpp
@@ -1,0 +1,19 @@
+// An exception that escapes a noexcept function crosses the function boundary
+// and must invoke std::terminate. The surrounding catch(...) in main is never
+// reached, so this verification fails.
+void f() noexcept
+{
+  throw 5;
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (...)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_noexcept_escape_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_noexcept_escape_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++11
+^VERIFICATION FAILED$
+noexcept specification violated

--- a/regression/esbmc-cpp/try_catch/exception_spec_noexcept_false/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_noexcept_false/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+// noexcept(false) declares a *potentially throwing* function: its
+// specification is NOT restrictive, so an exception may escape it and be
+// caught by the caller without invoking std::terminate.
+void f() noexcept(false)
+{
+  throw 1;
+}
+
+int main()
+{
+  int caught = 0;
+  try
+  {
+    f();
+  }
+  catch (int)
+  {
+    caught = 1;
+  }
+  assert(caught == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_noexcept_false/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_noexcept_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/exception_spec_recursion_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/exception_spec_recursion_fail/main.cpp
@@ -1,0 +1,21 @@
+// The specification is enforced per call frame. A recursive noexcept function
+// that throws at the base of the recursion violates its boundary regardless of
+// how deep the throwing frame is; the catch(...) in main is never reached.
+void f(int n) noexcept
+{
+  if (n == 0)
+    throw 5;
+  f(n - 1);
+}
+
+int main()
+{
+  try
+  {
+    f(3);
+  }
+  catch (...)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/exception_spec_recursion_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/exception_spec_recursion_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 6 --no-unwinding-assertions --std c++11
+^VERIFICATION FAILED$
+noexcept specification violated

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_subst/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_subst/main.cpp
@@ -1,0 +1,37 @@
+// std::bad_exception substitution ([except.unexpected]). f's dynamic spec
+// throw(std::bad_exception) is violated by `throw 42` (int). That runs the
+// installed unexpected handler, which throws a double — also not allowed. Since
+// the spec lists std::bad_exception, the in-flight exception is replaced by a
+// std::bad_exception, which the spec permits, so it propagates and is caught by
+// catch(std::bad_exception&). The lowering models this substitution; the
+// imperative path does not (it reports a spurious specification violation), so
+// this is a lowered-path-only test.
+#include <exception>
+
+void my_unexp()
+{
+  throw 3.14; // double: not allowed by f's spec
+}
+
+void f() throw(std::bad_exception)
+{
+  throw 42; // int: not allowed -> std::unexpected
+}
+
+int main()
+{
+  std::set_unexpected(my_unexp);
+  try
+  {
+    f();
+  }
+  catch (std::bad_exception &)
+  {
+    return 0; // the substituted bad_exception lands here
+  }
+  catch (...)
+  {
+    return 2;
+  }
+  return 1;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_subst/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_subst/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++03
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_terminate_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_terminate_fail/main.cpp
@@ -1,0 +1,36 @@
+// Counterpart to lower-exceptions_bad_exception_subst: f's dynamic spec
+// throw(int) does NOT list std::bad_exception. `throw 'c'` (char) violates it
+// and runs the unexpected handler, which throws a double — also not allowed.
+// With no std::bad_exception in the spec there is no substitution, so
+// std::terminate is called ([except.unexpected]); the lowering models this as a
+// verification failure. Lowered-path-only (the imperative path agrees here, but
+// the sibling SUCCESSFUL test only lowers, so keep the pair consistent).
+#include <exception>
+
+void my_unexp()
+{
+  throw 3.14; // double: not allowed
+}
+
+void f() throw(int)
+{
+  throw 'c'; // char: not allowed -> std::unexpected
+}
+
+int main()
+{
+  std::set_unexpected(my_unexp);
+  try
+  {
+    f();
+  }
+  catch (std::bad_exception &)
+  {
+    return 0;
+  }
+  catch (...)
+  {
+    return 2;
+  }
+  return 1;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_terminate_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_terminate_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++03
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_dualuse/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_dualuse/main.cpp
@@ -1,0 +1,39 @@
+#include <pthread.h>
+#include <cassert>
+
+// worker is used BOTH as a pthread start routine and called directly. The
+// lowering enforces a thread's uncaught-escape terminate at the start routine's
+// own epilogue; marking worker an entry is a sound over-approximation (at worst
+// a spurious terminate on an escape the direct caller would catch, never a
+// missed bug). Here each use catches its own exception, so worker never escapes
+// and the verdict is SUCCESSFUL.
+struct E
+{
+  int v;
+  E(int x) : v(x)
+  {
+  }
+};
+
+void *worker(void *arg)
+{
+  int id = *(int *)arg;
+  try
+  {
+    throw E(id);
+  }
+  catch (E &e)
+  {
+    assert(e.v == id);
+  }
+  return 0;
+}
+
+int main()
+{
+  int a = 0;
+  worker(&a); // direct call
+  pthread_t t;
+  pthread_create(&t, 0, worker, &a); // also a thread start routine
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_dualuse/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_dualuse/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--context-bound 2
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_fail/main.cpp
@@ -1,0 +1,38 @@
+#include <pthread.h>
+#include <cassert>
+
+// Negative counterpart to lower-exceptions_concurrent: each worker throws E(id)
+// and the handler reads its own thread's object, but asserts e.v == 0. The
+// thread launched with id 1 catches E(1), so e.v == 0 is false and the property
+// is violated -> VERIFICATION FAILED. Confirms the lowered per-thread dispatch
+// still detects genuine failures (it does not trivially verify everything).
+struct E
+{
+  int v;
+  E(int x) : v(x)
+  {
+  }
+};
+
+void *worker(void *arg)
+{
+  int id = *(int *)arg;
+  try
+  {
+    throw E(id);
+  }
+  catch (E &e)
+  {
+    assert(e.v == 0); // fails for the thread launched with id 1
+  }
+  return 0;
+}
+
+int main()
+{
+  pthread_t t1, t2;
+  int a = 0, b = 1;
+  pthread_create(&t1, 0, worker, &a);
+  pthread_create(&t2, 0, worker, &b);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--context-bound 2
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_uncaught_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_uncaught_fail/main.cpp
@@ -1,0 +1,23 @@
+#include <pthread.h>
+
+// An exception escaping a thread's start routine is uncaught for that thread and
+// calls std::terminate ([except.terminate]). The lowering treats each function
+// passed to pthread_create as a thread entry, so the escape is caught at the
+// worker's own epilogue -> VERIFICATION FAILED. (Confirms removing the
+// concurrency fallback did not drop uncaught-in-thread detection.)
+struct E
+{
+};
+
+void *worker(void *)
+{
+  throw E(); // not caught in the thread -> std::terminate
+  return 0;
+}
+
+int main()
+{
+  pthread_t t;
+  pthread_create(&t, 0, worker, 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_uncaught_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_concurrent_uncaught_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--context-bound 2
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_empty_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_empty_fail/main.cpp
@@ -1,0 +1,9 @@
+// Rethrowing an empty exception_ptr calls std::terminate().
+#include <exception>
+
+int main()
+{
+  std::exception_ptr ep;
+  std::rethrow_exception(ep);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_empty_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_empty_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++17
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_rethrow/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_rethrow/main.cpp
@@ -1,0 +1,40 @@
+// std::current_exception() captures the currently handled exception and
+// std::rethrow_exception() makes it propagate again. The lowered path should
+// preserve the original object across the capture and rethrow.
+#include <exception>
+#include <cassert>
+
+struct X
+{
+  int v;
+  X(int n) : v(n)
+  {
+  }
+};
+
+int main()
+{
+  std::exception_ptr ep;
+
+  try
+  {
+    throw X(7);
+  }
+  catch (...)
+  {
+    ep = std::current_exception();
+    assert((bool)ep);
+  }
+
+  try
+  {
+    std::rethrow_exception(ep);
+    assert(false);
+  }
+  catch (X &x)
+  {
+    assert(x.v == 7);
+  }
+
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_rethrow/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_exception_ptr_rethrow/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 6 --no-unwinding-assertions --std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr/main.cpp
@@ -1,0 +1,33 @@
+// std::make_exception_ptr(e) captures e into an exception_ptr by throwing and
+// catching it (current_exception), and std::rethrow_exception re-raises it. The
+// value carried through the slot must be preserved. Exercises the fix for
+// throwing a by-value operand: the exception object's copy/move constructor is
+// now called with the source bound to its reference parameter (an address),
+// rather than a struct value.
+#include <exception>
+#include <cassert>
+
+struct E
+{
+  int v;
+  E(int x) : v(x)
+  {
+  }
+};
+
+int main()
+{
+  std::exception_ptr p = std::make_exception_ptr(E(42));
+  assert((bool)p);
+  try
+  {
+    std::rethrow_exception(p);
+  }
+  catch (E &e)
+  {
+    assert(e.v == 42);
+    return 0;
+  }
+  assert(0); // must have been caught
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr_fail/main.cpp
@@ -1,0 +1,26 @@
+// Negative companion: the value carried by the exception_ptr must round-trip
+// faithfully. Asserting the wrong value after rethrow must fail.
+#include <exception>
+#include <cassert>
+
+struct E
+{
+  int v;
+  E(int x) : v(x)
+  {
+  }
+};
+
+int main()
+{
+  std::exception_ptr p = std::make_exception_ptr(E(42));
+  try
+  {
+    std::rethrow_exception(p);
+  }
+  catch (E &e)
+  {
+    assert(e.v == 7); // wrong: the captured value is 42
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_make_exception_ptr_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++17
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_nested_rethrow/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_nested_rethrow/main.cpp
@@ -1,0 +1,51 @@
+#include <cassert>
+
+struct A
+{
+  int value;
+  explicit A(int v) : value(v)
+  {
+  }
+};
+
+struct B
+{
+  int value;
+  explicit B(int v) : value(v)
+  {
+  }
+};
+
+int main()
+{
+  try
+  {
+    throw A(1);
+  }
+  catch (A &)
+  {
+    try
+    {
+      throw B(2);
+    }
+    catch (B &)
+    {
+    }
+
+    try
+    {
+      throw;
+    }
+    catch (A &a)
+    {
+      assert(a.value == 1);
+      return 0;
+    }
+    catch (...)
+    {
+      assert(false);
+    }
+  }
+
+  assert(false);
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_nested_rethrow/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_nested_rethrow/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 8 --no-unwinding-assertions --std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_custom_terminate/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_custom_terminate/main.cpp
@@ -1,0 +1,25 @@
+// An exception escaping a noexcept function calls std::terminate, which runs the
+// installed std::set_terminate handler. Here the handler exits cleanly, so a
+// running binary terminates without error — and the lowering, routing the
+// terminate point through the OM std::terminate(), honours the handler and
+// verifies SUCCESSFUL. (With the default handler the escape is reported FAILED;
+// see lower-exceptions_noexcept_escape_fail.)
+#include <exception>
+#include <cstdlib>
+
+void my_terminate()
+{
+  std::exit(0);
+}
+
+void f() noexcept
+{
+  throw 42; // escapes noexcept -> std::terminate -> my_terminate -> exit(0)
+}
+
+int main()
+{
+  std::set_terminate(my_terminate);
+  f();
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_custom_terminate/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_custom_terminate/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_rethrow_no_active_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_rethrow_no_active_fail/main.cpp
@@ -1,0 +1,16 @@
+// A bare `throw;` with no exception currently being handled calls std::terminate
+// ([except.throw]/9). Here nothing has been thrown, so the rethrow has no active
+// exception and the program must verify FAILED. The lowering guards the rethrow
+// on the exception-state typeid (0 == none): typeid 0 routes to terminate rather
+// than re-raising a non-existent exception that catch(...) would swallow.
+int main()
+{
+  try
+  {
+    throw; // no active exception -> std::terminate
+  }
+  catch (...)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_rethrow_no_active_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_rethrow_no_active_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine/main.cpp
@@ -1,0 +1,34 @@
+// Same computed (function-pointer) thread start routine as the _fail companion,
+// but here the routine catches its own exception, so nothing escapes the thread
+// and std::terminate is not called — VERIFICATION SUCCESSFUL. Confirms the
+// over-approximation for unresolved start routines does not spuriously terminate
+// a thread that handles its exception locally.
+#include <pthread.h>
+#include <cassert>
+
+struct E
+{
+};
+
+void *worker(void *)
+{
+  try
+  {
+    throw E();
+  }
+  catch (E &)
+  {
+    return 0;
+  }
+  assert(0);
+  return 0;
+}
+
+int main()
+{
+  pthread_t t;
+  void *(*fp)(void *) = worker;
+  pthread_create(&t, 0, fp, 0);
+  pthread_join(t, 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 2 --no-unwinding-assertions
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine_fail/main.cpp
@@ -1,0 +1,27 @@
+// A pthread_create whose start routine is passed through a function-pointer
+// variable (a computed routine) — collect_thread_entry cannot resolve it to a
+// single function. The lowering over-approximates by treating every address-
+// taken void*(void*) function as a thread entry, so the uncaught-escape check
+// still applies: worker throws E and never catches it, so the exception escapes
+// the thread's initial function and std::terminate is called ([except.terminate])
+// — VERIFICATION FAILED.
+#include <pthread.h>
+
+struct E
+{
+};
+
+void *worker(void *)
+{
+  throw E();
+  return 0;
+}
+
+int main()
+{
+  pthread_t t;
+  void *(*fp)(void *) = worker; // computed: not a direct &worker argument
+  pthread_create(&t, 0, fp, 0);
+  pthread_join(t, 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_thread_computed_routine_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 2 --no-unwinding-assertions
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/main.cpp
@@ -1,0 +1,81 @@
+// std::throw_with_nested(Outer) throws a type deriving from both Outer and
+// std::nested_exception, capturing the in-flight Inner via current_exception.
+// The outer handler catches it as Outer&, then std::rethrow_if_nested recovers
+// and re-raises the captured Inner. Outer is polymorphic (derives from
+// std::exception) so rethrow_if_nested's dynamic_cast to nested_exception is
+// well-formed.
+//
+// KNOWNBUG: MI base-subobject layout, catch-by-base, and dynamic_cast across a
+// non-zero base offset are now all correct, so rethrow_if_nested's cross-cast
+// works. The remaining blocker is a vtable-model defect: ESBMC gives every
+// polymorphic class its own @vtable_pointer component instead of sharing the
+// primary base's slot (the Itanium primary-base rule). So when the combined
+// type's first base (Outer) itself derives from a polymorphic base
+// (std::exception), the flattened struct carries a redundant primary-chain vptr
+// that shifts the second base (nested_exception) one slot past clang's offset.
+// The cast/ctor/access adjustments use clang's offset, so the construction write
+// lands on the redundant vptr instead of the nested_exception subobject. Minimal
+// non-exception repro:
+//   struct E { virtual ~E(){} };
+//   struct Outer : E { int w; };
+//   struct Nested { virtual ~Nested(){} void* p; Nested():p(0){} };
+//   struct Combined : Outer, Nested { };
+//   Combined c; assert(c.p == 0);   // fails
+// The fix is to model primary-base vptr sharing — a coordinated change to the
+// struct layout (add_vptr / get_base_components_methods), constructor vptr-init
+// (clang_cpp_adjust_code_gen), and name-keyed virtual dispatch
+// (get_vft_binding_expr_vtable_ptr). Once that lands this verifies SUCCESSFUL
+// and can move to CORE.
+#include <exception>
+#include <cassert>
+
+struct Inner
+{
+  int v;
+  Inner(int x) : v(x)
+  {
+  }
+};
+struct Outer : std::exception
+{
+  int w;
+  Outer(int x) : w(x)
+  {
+  }
+};
+
+void f()
+{
+  try
+  {
+    throw Inner(1);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(Outer(2));
+  }
+}
+
+int main()
+{
+  try
+  {
+    f();
+  }
+  catch (Outer &o)
+  {
+    assert(o.w == 2);
+    try
+    {
+      std::rethrow_if_nested(o);
+    }
+    catch (Inner &i)
+    {
+      assert(i.v == 1);
+      return 0;
+    }
+    assert(0); // rethrow_if_nested should have re-raised Inner
+  }
+  assert(0);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count/main.cpp
@@ -1,0 +1,31 @@
+// std::uncaught_exceptions() reports the per-thread count of exceptions thrown
+// (or rethrown) but not yet entered into their handler ([except.uncaught]).
+// The GOTO exception lowering maintains the count: +1 at a throw/rethrow, -1
+// when a handler is entered. With no active exception the count is 0; it is 0
+// again once an exception is caught, and a rethrow makes it uncaught anew.
+#include <exception>
+#include <cassert>
+
+int main()
+{
+  assert(std::uncaught_exceptions() == 0);
+  try
+  {
+    assert(std::uncaught_exceptions() == 0);
+    try
+    {
+      throw 1; // one exception now uncaught
+    }
+    catch (int)
+    {
+      assert(std::uncaught_exceptions() == 0); // entered handler -> 0
+      throw;                                   // rethrow -> uncaught again
+    }
+  }
+  catch (int)
+  {
+    assert(std::uncaught_exceptions() == 0); // re-caught -> 0
+  }
+  assert(std::uncaught_exceptions() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/main.cpp
@@ -1,0 +1,41 @@
+// uncaught-count correctness across dynamic-exception-specification recovery.
+// f() has a throw(X) spec but throws A; the violated spec runs the installed
+// std::unexpected handler, which throws X (a permitted type). That replacement
+// throw propagates and is caught. The original A is *replaced* by X, so exactly
+// one exception is uncaught during recovery — the lowering must not double-count
+// it. Once X enters its handler the count is back to 0 ([except.unexpected],
+// [except.uncaught]). Dynamic specs are pre-C++17, so this uses the singular
+// std::uncaught_exception().
+#include <exception>
+#include <cassert>
+
+struct X
+{
+};
+struct A
+{
+};
+
+void my_unexpected()
+{
+  throw X(); // replacement throw, permitted by f's spec
+}
+
+void f() throw(X)
+{
+  throw A(); // violates throw(X): runs unexpected -> my_unexpected throws X
+}
+
+int main()
+{
+  std::set_unexpected(my_unexpected);
+  try
+  {
+    f();
+  }
+  catch (X &)
+  {
+    assert(!std::uncaught_exception()); // X is being handled -> count 0
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec_fail/main.cpp
@@ -1,0 +1,37 @@
+// Negative companion to lower-exceptions_uncaught_count_dynspec: after the
+// std::unexpected replacement throw (X) is caught, the count is 0 — the original
+// A is replaced, not added. Asserting an exception is still uncaught here must
+// fail, which also proves the count is exactly 0 (not an over-count of 1).
+#include <exception>
+#include <cassert>
+
+struct X
+{
+};
+struct A
+{
+};
+
+void my_unexpected()
+{
+  throw X();
+}
+
+void f() throw(X)
+{
+  throw A();
+}
+
+int main()
+{
+  std::set_unexpected(my_unexpected);
+  try
+  {
+    f();
+  }
+  catch (X &)
+  {
+    assert(std::uncaught_exception()); // wrong: the count is 0 here
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++11
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_fail/main.cpp
@@ -1,0 +1,18 @@
+// Negative companion to lower-exceptions_uncaught_count: once an exception has
+// entered its handler it is no longer uncaught, so std::uncaught_exceptions()
+// is 0 inside the catch, not 1. Asserting the wrong count must fail.
+#include <exception>
+#include <cassert>
+
+int main()
+{
+  try
+  {
+    throw 1;
+  }
+  catch (int)
+  {
+    assert(std::uncaught_exceptions() == 1); // wrong: the count is 0 here
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 4 --no-unwinding-assertions --std c++17
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_vector_at_uncaught_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_vector_at_uncaught_fail/main.cpp
@@ -1,0 +1,20 @@
+// vector::at with an out-of-range index throws std::out_of_range. Here only an
+// unrelated handler is present (std::runtime_error is a sibling of
+// std::out_of_range, not a base), so the exception escapes main and calls
+// std::terminate -> VERIFICATION FAILED. Counterpart to try-catch_vector_02_bug,
+// where the same throw is caught (SUCCESSFUL).
+#include <vector>
+#include <stdexcept>
+
+int main()
+{
+  std::vector<int> v(10);
+  try
+  {
+    v.at(20) = 1; // throws std::out_of_range
+  }
+  catch (std::runtime_error &) // does NOT match out_of_range -> uncaught
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_vector_at_uncaught_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_vector_at_uncaught_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 25 --no-unwinding-assertions
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/mi_base_subobject_catch/main.cpp
+++ b/regression/esbmc-cpp/try_catch/mi_base_subobject_catch/main.cpp
@@ -1,0 +1,59 @@
+#include <cassert>
+
+struct A
+{
+  int a;
+  A() : a(1)
+  {
+  }
+};
+
+struct P
+{
+  virtual ~P()
+  {
+  }
+
+  int p;
+
+  P() : p(9)
+  {
+  }
+};
+
+struct AP : A, P
+{
+};
+
+struct PA : P, A
+{
+};
+
+int main()
+{
+  try
+  {
+    throw AP();
+  }
+  catch (A &a)
+  {
+    assert(a.a == 1);
+  }
+  catch (...)
+  {
+    assert(false);
+  }
+
+  try
+  {
+    throw PA();
+  }
+  catch (A &a)
+  {
+    assert(a.a == 1);
+  }
+  catch (...)
+  {
+    assert(false);
+  }
+}

--- a/regression/esbmc-cpp/try_catch/mi_base_subobject_catch/test.desc
+++ b/regression/esbmc-cpp/try_catch/mi_base_subobject_catch/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--std c++17
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bare_raise_nested/main.py
+++ b/regression/python/bare_raise_nested/main.py
@@ -1,0 +1,26 @@
+# A bare `raise` re-raises the exception currently being handled. Here the outer
+# `except ValueError` handler fully handles an inner KeyError in a nested
+# try/except, then `raise` must re-raise the *outer* ValueError (the one this
+# handler is for), not the inner KeyError.
+#
+# KNOWNBUG: Python's exception lowering currently re-raises a bare `raise` from
+# the global exception state (which the completed inner handler overwrote with
+# KeyError), so it wrongly re-raises KeyError. A correct model needs a per-thread
+# handled-exception stack for Python (the C++ handled-stack OM is not linked for
+# Python because it drags the whole std::terminate closure). Once that lands this
+# test verifies SUCCESSFUL and can move to CORE.
+try:
+    try:
+        raise ValueError()
+    except ValueError:
+        try:
+            raise KeyError()
+        except KeyError:
+            pass
+        raise
+except ValueError:
+    result = 1
+except KeyError:
+    result = 2
+
+assert result == 1

--- a/regression/python/bare_raise_nested/test.desc
+++ b/regression/python/bare_raise_nested/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## Summary

Lands the new C++/Python exception-handling regression tests from the exception
rework (#5126) as a **standalone baseline on master**, ahead of the feature
work. This is the first of a stacked split of #5126; it adds **only tests**, no
source changes.

Tests that pass on current master (post-#5244, which removed the legacy
imperative exception path) are marked `CORE`. Tests that depend on
not-yet-merged features are marked `KNOWNBUG` so the suite is green today. Each
follow-up feature PR flips its own tests `KNOWNBUG` → `CORE` as it lands the
behaviour, giving every later PR a ready-made, reviewed acceptance test.

Classification was determined **empirically**: every test was run against a
clean master build; the 12 that pass as authored are `CORE`, the other 23 are
`KNOWNBUG`.

## Classification

**`CORE` (12)** — pass on master today:
- `try_catch/exception_spec_*` — function-level exception-spec enforcement
  (`internal_catch`, `noexcept_escape_fail`, `noexcept_false`, `recursion_fail`,
  `no_try_fail`, `indirect_call_fail`, `inlining_fail`, `dynamic_allowed`,
  `dynamic_violation_fail`)
- `try_catch/lower-exceptions_bad_exception_terminate_fail`,
  `lower-exceptions_uncaught_count_dynspec_fail`,
  `lower-exceptions_vector_at_uncaught_fail`

**`KNOWNBUG` (23)** — depend on features not yet on master:
- **Exception operational model** (`exception_ptr`, `make_exception_ptr`, nested
  rethrow, `uncaught_count`): `lower-exceptions_exception_ptr_*`,
  `make_exception_ptr*`, `nested_rethrow`, `uncaught_count*`,
  `bad_exception_subst`, `noexcept_custom_terminate`, `rethrow_no_active_fail`,
  `throw_with_nested_knownbug`
- **Multiple-inheritance base-offset layout / `dynamic_cast`**:
  `inheritance/mi_base_subobject_layout*`, `mi_dynamic_cast*`,
  `try_catch/mi_base_subobject_catch`
- **Concurrent exception lowering** (#5244 hard-errors on `pthread_create` in
  the lowering): `lower-exceptions_concurrent_*`,
  `lower-exceptions_thread_computed_routine*`
- `python/bare_raise_nested`

## Validation

Built clean from master; ran all 35 tests under their assigned classification:
every `CORE` passes, every `KNOWNBUG` is expected-fail → suite is green.

Part of the #5126 split. Relates to #5125, #5075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
