### PR TITLE
[solver] diagnose mismatched-width (dis)equality instead of crashing

### DIFF
--- a/regression/python/github_4796_mk_eq_width/main.py
+++ b/regression/python/github_4796_mk_eq_width/main.py
@@ -1,0 +1,39 @@
+# Regression for #4796: reversing a linked list and comparing the result to a
+# node with `==` made the frontend emit an equality between a Node object
+# pointer (64-bit) and a None modelled at width 0. The per-solver mk_eq asserted
+# equal operand widths, but that assert is elided under NDEBUG, so release builds
+# fed mismatched terms to the solver API and crashed with a raw SIGSEGV.
+#
+# The solver backends now route through smt_convt::check_eq_operand_widths,
+# which stops with a clear diagnostic in every build configuration instead of
+# crashing. This test pins that behaviour: ESBMC must emit the bit-width
+# mismatch error (and abort) rather than segfault. The underlying #4796 codegen
+# bug (None typed at a mismatched width) is tracked separately under the
+# object/Optional model rework (#4653/#3067).
+from node import Node
+
+
+def reverse_linked_list(node):
+    prevnode = None
+    while node:
+        nextnode = node.successor
+        node.successor = prevnode
+        prevnode = node
+        node = nextnode
+    return prevnode
+
+
+def test1():
+    node1 = Node(1)
+    node2 = Node(2, node1)
+    result = reverse_linked_list(node2)
+    assert result == node1
+
+
+def test2():
+    node = Node(0)
+    result = reverse_linked_list(node)
+    assert result == node
+
+
+test2()

--- a/regression/python/github_4796_mk_eq_width/node.py
+++ b/regression/python/github_4796_mk_eq_width/node.py
@@ -1,0 +1,4 @@
+class Node:
+    def __init__(self, value=None, successor=None):
+        self.value = value
+        self.successor = successor

--- a/regression/python/github_4796_mk_eq_width/test.desc
+++ b/regression/python/github_4796_mk_eq_width/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: EQUAL: operand bit-width mismatch

--- a/regression/python/github_4796_mk_eq_width_ok/main.py
+++ b/regression/python/github_4796_mk_eq_width_ok/main.py
@@ -1,0 +1,8 @@
+# Companion to github_4796_mk_eq_width: a well-typed equality between operands
+# of the same bit-width must keep verifying. check_eq_operand_widths only fires
+# on a width mismatch, so an ordinary symbolic integer comparison is unaffected.
+def check(x: int) -> None:
+    assert x == x
+
+
+check(5)

--- a/regression/python/github_4796_mk_eq_width_ok/test.desc
+++ b/regression/python/github_4796_mk_eq_width_ok/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -467,7 +467,7 @@ smt_astt bitwuzla_convt::mk_bvsge(smt_astt a, smt_astt b)
 
 smt_astt bitwuzla_convt::mk_eq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "EQUAL");
   return new_ast(
     bitwuzla_mk_term2(
       bitw_term_manager,
@@ -479,7 +479,7 @@ smt_astt bitwuzla_convt::mk_eq(smt_astt a, smt_astt b)
 
 smt_astt bitwuzla_convt::mk_neq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "DISTINCT");
   return new_ast(
     bitwuzla_mk_term2(
       bitw_term_manager,

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -428,7 +428,7 @@ smt_astt boolector_convt::mk_bvsge(smt_astt a, smt_astt b)
 
 smt_astt boolector_convt::mk_eq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "EQUAL");
   return new_ast(
     boolector_eq(
       btor,
@@ -439,7 +439,7 @@ smt_astt boolector_convt::mk_eq(smt_astt a, smt_astt b)
 
 smt_astt boolector_convt::mk_neq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "DISTINCT");
   return new_ast(
     boolector_ne(
       btor,

--- a/src/solvers/cvc5/cvc5_conv.cpp
+++ b/src/solvers/cvc5/cvc5_conv.cpp
@@ -941,7 +941,7 @@ smt_astt cvc5_convt::mk_bvsge(smt_astt a, smt_astt b)
 
 smt_astt cvc5_convt::mk_eq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "EQUAL");
   return new_ast(
     slv.mkTerm(
       cvc5::Kind::EQUAL,
@@ -952,7 +952,7 @@ smt_astt cvc5_convt::mk_eq(smt_astt a, smt_astt b)
 
 smt_astt cvc5_convt::mk_neq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "DISTINCT");
   return new_ast(
     slv.mkTerm(
       cvc5::Kind::DISTINCT,

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -587,7 +587,7 @@ smt_astt mathsat_convt::mk_bvsle(smt_astt a, smt_astt b)
 
 smt_astt mathsat_convt::mk_eq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "EQUAL");
   if (a->sort->id == SMT_SORT_BOOL || a->sort->id == SMT_SORT_STRUCT)
     return new_ast(
       msat_make_iff(

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -4282,6 +4282,23 @@ smt_astt smt_convt::mk_neq(smt_astt a, smt_astt b)
   return mk_not(mk_eq(a, b));
 }
 
+void smt_convt::check_eq_operand_widths(
+  smt_astt a,
+  smt_astt b,
+  const char *kind) const
+{
+  if (a->sort->get_data_width() != b->sort->get_data_width())
+  {
+    log_error(
+      "{}: operand bit-width mismatch ({} vs {}); the comparison operands have "
+      "incompatible types (frontend codegen error)",
+      kind,
+      a->sort->get_data_width(),
+      b->sort->get_data_width());
+    abort();
+  }
+}
+
 smt_astt smt_convt::mk_store(smt_astt a, smt_astt b, smt_astt c)
 {
   (void)a;

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -367,6 +367,18 @@ public:
   virtual smt_astt mk_bvsge(smt_astt a, smt_astt b);
   virtual smt_astt mk_eq(smt_astt a, smt_astt b);
   virtual smt_astt mk_neq(smt_astt a, smt_astt b);
+
+  /** Abort with a clear diagnostic when the two operands of a (dis)equality do
+   *  not share a bit-width. A mismatch is a frontend codegen bug — e.g. #4796,
+   *  a Python object pointer compared against None modelled at a different
+   *  width. The per-solver mk_eq/mk_neq asserts that enforced this are elided
+   *  under NDEBUG, so release builds fed mismatched terms straight to the solver
+   *  API and crashed (SIGSEGV in Bitwuzla). Centralising the check keeps the
+   *  same controlled hard-stop in every build configuration and solver, and
+   *  surfaces the codegen bug rather than masking it. @param kind names the
+   *  operation for the message ("EQUAL" / "DISTINCT"). */
+  void check_eq_operand_widths(smt_astt a, smt_astt b, const char *kind) const;
+
   virtual smt_astt mk_store(smt_astt a, smt_astt b, smt_astt c);
   virtual smt_astt mk_select(smt_astt a, smt_astt b);
   virtual smt_astt mk_real2int(smt_astt a);

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -1388,7 +1388,7 @@ smt_astt smtlib_convt::mk_bvsge(smt_astt a, smt_astt b)
 
 smt_astt smtlib_convt::mk_eq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "EQUAL");
   smtlib_smt_ast *ast = new smtlib_smt_ast(this, boolean_sort, SMT_FUNC_EQ);
   ast->args.push_back(a);
   ast->args.push_back(b);

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -548,7 +548,7 @@ smt_astt yices_convt::mk_bvsge(smt_astt a, smt_astt b)
 
 smt_astt yices_convt::mk_eq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "EQUAL");
   if (a->sort->id == SMT_SORT_BOOL || a->sort->id == SMT_SORT_STRUCT)
     return new_ast(
       yices_eq(
@@ -572,7 +572,7 @@ smt_astt yices_convt::mk_eq(smt_astt a, smt_astt b)
 
 smt_astt yices_convt::mk_neq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "DISTINCT");
   if (a->sort->id == SMT_SORT_BOOL || a->sort->id == SMT_SORT_STRUCT)
     return new_ast(
       yices_neq(

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -720,7 +720,7 @@ smt_astt z3_convt::mk_bvsge(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_eq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "EQUAL");
   auto &za = to_solver_smt_ast<z3_smt_ast>(a)->a;
   auto &zb = to_solver_smt_ast<z3_smt_ast>(b)->a;
   return new_ast(za == zb, boolean_sort);
@@ -728,7 +728,7 @@ smt_astt z3_convt::mk_eq(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_neq(smt_astt a, smt_astt b)
 {
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  check_eq_operand_widths(a, b, "DISTINCT");
   return new_ast(
     (to_solver_smt_ast<z3_smt_ast>(a)->a !=
      to_solver_smt_ast<z3_smt_ast>(b)->a),


### PR DESCRIPTION
Equality over operands of different bit-width (#4796: a Python object pointer vs a None modelled at width 0) was guarded only by an `assert` that NDEBUG elides, so release builds fed mismatched terms to the solver and crashed with a SIGSEGV.

Route every backend's `mk_eq`/`mk_neq` through a new `smt_convt::check_eq_operand_widths` that aborts with a clear diagnostic on mismatch — the controlled hard-stop debug builds already produced. No verdict changes and the bug is surfaced, not masked; the underlying #4796 typing defect stays open (#4653/#3067). Refs #4796.