### PR TITLE
[irep2] V.4.0: add structured control-flow code kinds (dead-but-tested)

### DIFF
--- a/src/irep2/README.md
+++ b/src/irep2/README.md
@@ -368,7 +368,18 @@ statement   ::= "code_block"         «empty» "(" { statement } ")"
               | "code_expression"    «empty» "(" expr ")"
               | "code_comma"         «type»  "(" expr "," expr ")"
               | "code_asm"           «type»  string-lit
+              | structured-statement
               | cpp-statement
+structured-statement                                       ; V.4, see note below
+            ::= "code_ifthenelse"  «empty» "(" expr "," statement ","
+                                            statement-or-nil ")"  ; cond, then, else
+              | "code_while"       «empty» "(" expr "," statement ")"  ; cond, body
+              | "code_for"         «empty» "(" expr-or-nil "," expr-or-nil ","
+                                            expr-or-nil "," statement ")" ; init,cond,iter,body
+              | "code_switch"      «empty» "(" expr "," statement ")"  ; value, body
+              | "code_break"       «empty»
+              | "code_continue"    «empty»
+              | "code_label"       «empty» name statement              ; label, body
 cpp-statement ::= "code_cpp_delete"         «empty» "(" expr ")"
                 | "code_cpp_del_array"      «empty» "(" expr ")"
                 | "code_cpp_throw"          «empty» "(" expr "," "[" { name } "]" ")"
@@ -403,6 +414,16 @@ Notes:
   and live inside GOTO programs. Conditional branches are encoded on the
   GOTO *instruction*, not as an expression, so only the unconditional
   `code_goto` appears here.
+- **Structured-statement kinds are dead-but-tested (V.4,
+  esbmc/esbmc#4715).** `code_ifthenelse` / `code_while` / `code_for` /
+  `code_switch` / `code_break` / `code_continue` / `code_label` mirror the
+  legacy structured `codet` statements so a frontend can build IREP2
+  bodies and `goto_convert` can consume them, removing the per-instruction
+  back-migration at the body seam (wall W1). They are **not yet built by
+  any pipeline path** — the converter still emits legacy structured
+  `codet`, which `goto_convert` lowers to flat `code_goto` + instruction
+  guards. Only the migrate round-trip tests exercise them today; they
+  become live in the `goto_convert` wiring phase.
 
 ## Examples
 
@@ -770,6 +791,22 @@ ordinary expression tree. Their type is `empty` unless noted.
 | `code_expression` | A statement consisting of a single expression evaluated for its side effects. |
 | `code_comma` | C comma operator — evaluate left, then right; result is right. |
 | `code_asm` | Inline assembly (the string is preserved; semantics are usually opaque). |
+
+### Structured control-flow statements (V.4, dead-but-tested)
+
+These mirror the legacy structured `codet` statements so a frontend can emit
+IREP2 bodies; they are not yet built by any pipeline path (see the
+*Structured-statement kinds* note above).
+
+| Kind | Description |
+|------|-------------|
+| `code_ifthenelse` | `if (cond) then_case [else else_case]`. `else_case` is nil when absent. |
+| `code_while` | `while (cond) body`. |
+| `code_for` | `for (init; cond; iter) body`. `init`/`cond`/`iter` are each nil when absent. |
+| `code_switch` | `switch (value) body`. |
+| `code_break` | `break;`. |
+| `code_continue` | `continue;`. |
+| `code_label` | A labelled statement: `label: code`. |
 
 ### C++ exception / delete statements
 

--- a/src/irep2/expr_kinds.inc
+++ b/src/irep2/expr_kinds.inc
@@ -126,3 +126,12 @@ IREP2_EXPR(exists,                "exists")
 IREP2_EXPR(isinstance,            "isinstance")
 IREP2_EXPR(hasattr,               "hasattr")
 IREP2_EXPR(isnone,                "isnone")
+// V.4 structured control-flow code kinds (esbmc/esbmc#4715). Appended at the
+// end so existing expr_id enum values are not renumbered.
+IREP2_EXPR(code_ifthenelse,       "code_ifthenelse")
+IREP2_EXPR(code_while,            "code_while")
+IREP2_EXPR(code_for,              "code_for")
+IREP2_EXPR(code_switch,           "code_switch")
+IREP2_EXPR(code_break,            "code_break")
+IREP2_EXPR(code_continue,         "code_continue")
+IREP2_EXPR(code_label,            "code_label")

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -837,6 +837,20 @@ std::string object_descriptor2t::field_names[esbmct::num_type_fields] =
   {"object", "offset", "alignment", "", ""};
 std::string code_function_call2t::field_names[esbmct::num_type_fields] =
   {"return_sym", "function", "operands", "", ""};
+std::string code_ifthenelse2t::field_names[esbmct::num_type_fields] =
+  {"cond", "then_case", "else_case", "", ""};
+std::string code_while2t::field_names[esbmct::num_type_fields] =
+  {"cond", "body", "", "", ""};
+std::string code_for2t::field_names[esbmct::num_type_fields] =
+  {"init", "cond", "iter", "body", ""};
+std::string code_switch2t::field_names[esbmct::num_type_fields] =
+  {"value", "body", "", "", ""};
+std::string code_break2t::field_names[esbmct::num_type_fields] =
+  {"", "", "", "", ""};
+std::string code_continue2t::field_names[esbmct::num_type_fields] =
+  {"", "", "", "", ""};
+std::string code_label2t::field_names[esbmct::num_type_fields] =
+  {"label", "code", "", "", ""};
 std::string code_comma2t::field_names[esbmct::num_type_fields] =
   {"side_1", "side_2", "", "", ""};
 std::string invalid_pointer2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -193,6 +193,13 @@ irep_typedefs(code_free);
 irep_typedefs(code_goto);
 irep_typedefs(object_descriptor);
 irep_typedefs(code_function_call);
+irep_typedefs(code_ifthenelse);
+irep_typedefs(code_while);
+irep_typedefs(code_for);
+irep_typedefs(code_switch);
+irep_typedefs(code_break);
+irep_typedefs(code_continue);
+irep_typedefs(code_label);
 irep_typedefs(code_comma);
 irep_typedefs(invalid_pointer);
 irep_typedefs(code_asm);
@@ -1924,6 +1931,147 @@ public:
     &code_function_call2t::ret,
     &code_function_call2t::function,
     &code_function_call2t::operands);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+// V.4 (esbmc/esbmc#4715): structured control-flow code kinds. IREP2 had only
+// the flat goto-level code kinds; these mirror the legacy structured codet
+// statements (ifthenelse/while/for/switch/break/continue/label) so the
+// frontend can build IREP2 bodies and goto_convert can consume them, removing
+// the per-instruction back-migration at the body seam (wall W1). Shipped
+// dead-but-tested first: nothing builds them until the goto_convert wiring
+// phase, so they are behaviour-inert and only the round-trip unit tests
+// exercise them (the V-track pattern).
+class code_ifthenelse2t : public expr2t
+{
+public:
+  expr2tc cond;
+  expr2tc then_case;
+  expr2tc else_case; // nil when there is no else branch
+
+  code_ifthenelse2t(
+    const expr2tc &c,
+    const expr2tc &t,
+    const expr2tc &e)
+    : expr2t(get_empty_type(), code_ifthenelse_id),
+      cond(c),
+      then_case(t),
+      else_case(e)
+  {
+  }
+  code_ifthenelse2t(const code_ifthenelse2t &ref) = default;
+
+  static constexpr auto fields = std::make_tuple(
+    &expr2t::type,
+    &code_ifthenelse2t::cond,
+    &code_ifthenelse2t::then_case,
+    &code_ifthenelse2t::else_case);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class code_while2t : public expr2t
+{
+public:
+  expr2tc cond;
+  expr2tc body;
+
+  code_while2t(const expr2tc &c, const expr2tc &b)
+    : expr2t(get_empty_type(), code_while_id), cond(c), body(b)
+  {
+  }
+  code_while2t(const code_while2t &ref) = default;
+
+  static constexpr auto fields =
+    std::make_tuple(&expr2t::type, &code_while2t::cond, &code_while2t::body);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class code_for2t : public expr2t
+{
+public:
+  expr2tc init; // nil when absent
+  expr2tc cond; // nil when absent
+  expr2tc iter; // nil when absent
+  expr2tc body;
+
+  code_for2t(
+    const expr2tc &i,
+    const expr2tc &c,
+    const expr2tc &it,
+    const expr2tc &b)
+    : expr2t(get_empty_type(), code_for_id),
+      init(i),
+      cond(c),
+      iter(it),
+      body(b)
+  {
+  }
+  code_for2t(const code_for2t &ref) = default;
+
+  static constexpr auto fields = std::make_tuple(
+    &expr2t::type,
+    &code_for2t::init,
+    &code_for2t::cond,
+    &code_for2t::iter,
+    &code_for2t::body);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class code_switch2t : public expr2t
+{
+public:
+  expr2tc value;
+  expr2tc body;
+
+  code_switch2t(const expr2tc &v, const expr2tc &b)
+    : expr2t(get_empty_type(), code_switch_id), value(v), body(b)
+  {
+  }
+  code_switch2t(const code_switch2t &ref) = default;
+
+  static constexpr auto fields =
+    std::make_tuple(&expr2t::type, &code_switch2t::value, &code_switch2t::body);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class code_break2t : public expr2t
+{
+public:
+  code_break2t() : expr2t(get_empty_type(), code_break_id)
+  {
+  }
+  code_break2t(const code_break2t &ref) = default;
+
+  static constexpr auto fields = std::make_tuple(&expr2t::type);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class code_continue2t : public expr2t
+{
+public:
+  code_continue2t() : expr2t(get_empty_type(), code_continue_id)
+  {
+  }
+  code_continue2t(const code_continue2t &ref) = default;
+
+  static constexpr auto fields = std::make_tuple(&expr2t::type);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class code_label2t : public expr2t
+{
+public:
+  irep_idt label;
+  expr2tc code;
+
+  code_label2t(const irep_idt &l, const expr2tc &c)
+    : expr2t(get_empty_type(), code_label_id), label(l), code(c)
+  {
+  }
+  code_label2t(const code_label2t &ref) = default;
+
+  static constexpr auto fields =
+    std::make_tuple(&expr2t::type, &code_label2t::label, &code_label2t::code);
   static std::string field_names[esbmct::num_type_fields];
 };
 

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1949,10 +1949,7 @@ public:
   expr2tc then_case;
   expr2tc else_case; // nil when there is no else branch
 
-  code_ifthenelse2t(
-    const expr2tc &c,
-    const expr2tc &t,
-    const expr2tc &e)
+  code_ifthenelse2t(const expr2tc &c, const expr2tc &t, const expr2tc &e)
     : expr2t(get_empty_type(), code_ifthenelse_id),
       cond(c),
       then_case(t),
@@ -1999,11 +1996,7 @@ public:
     const expr2tc &c,
     const expr2tc &it,
     const expr2tc &b)
-    : expr2t(get_empty_type(), code_for_id),
-      init(i),
-      cond(c),
-      iter(it),
-      body(b)
+    : expr2t(get_empty_type(), code_for_id), init(i), cond(c), iter(it), body(b)
   {
   }
   code_for2t(const code_for2t &ref) = default;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2155,6 +2155,69 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     return;
   }
 
+  // V.4 structured control-flow code kinds (esbmc/esbmc#4715). Forward arms
+  // for the legacy structured codet statements; nil sub-operands (an absent
+  // else / for-init / for-cond / for-iter) migrate to a null expr2tc and back,
+  // so the round-trip is exact.
+  if (expr.id() == "code" && expr.statement() == "ifthenelse")
+  {
+    expr2tc cond, then_case, else_case;
+    migrate_expr(expr.op0(), cond);
+    migrate_expr(expr.op1(), then_case);
+    migrate_expr(expr.op2(), else_case);
+    new_expr_ref = code_ifthenelse2tc(cond, then_case, else_case);
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "while")
+  {
+    expr2tc cond, body;
+    migrate_expr(expr.op0(), cond);
+    migrate_expr(expr.op1(), body);
+    new_expr_ref = code_while2tc(cond, body);
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "for")
+  {
+    expr2tc init, cond, iter, body;
+    migrate_expr(expr.op0(), init);
+    migrate_expr(expr.op1(), cond);
+    migrate_expr(expr.op2(), iter);
+    migrate_expr(expr.op3(), body);
+    new_expr_ref = code_for2tc(init, cond, iter, body);
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "switch")
+  {
+    expr2tc value, body;
+    migrate_expr(expr.op0(), value);
+    migrate_expr(expr.op1(), body);
+    new_expr_ref = code_switch2tc(value, body);
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "break")
+  {
+    new_expr_ref = code_break2tc();
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "continue")
+  {
+    new_expr_ref = code_continue2tc();
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "label")
+  {
+    expr2tc code;
+    migrate_expr(expr.op0(), code);
+    new_expr_ref = code_label2tc(expr.get("label"), code);
+    return;
+  }
+
   if (expr.id() == "code" && expr.statement() == "cpp-catch")
   {
     std::vector<irep_idt> expr_list;
@@ -3610,6 +3673,73 @@ exprt migrate_expr_back(const expr2tc &ref)
     for (auto const &op : ref2.operands)
       block.copy_to_operands(migrate_expr_back(op));
     return block;
+  }
+  // V.4 structured control-flow code kinds (esbmc/esbmc#4715). Reproduce the
+  // legacy structured codet operand layout (std_code.h) so the forward arm
+  // above reads each sub-part back from the same slot.
+  case expr2t::code_ifthenelse_id:
+  {
+    const code_ifthenelse2t &ref2 = to_code_ifthenelse2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("ifthenelse");
+    codeexpr.operands().resize(3);
+    codeexpr.op0() = migrate_expr_back(ref2.cond);
+    codeexpr.op1() = migrate_expr_back(ref2.then_case);
+    codeexpr.op2() = migrate_expr_back(ref2.else_case);
+    return codeexpr;
+  }
+  case expr2t::code_while_id:
+  {
+    const code_while2t &ref2 = to_code_while2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("while");
+    codeexpr.operands().resize(2);
+    codeexpr.op0() = migrate_expr_back(ref2.cond);
+    codeexpr.op1() = migrate_expr_back(ref2.body);
+    return codeexpr;
+  }
+  case expr2t::code_for_id:
+  {
+    const code_for2t &ref2 = to_code_for2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("for");
+    codeexpr.operands().resize(4);
+    codeexpr.op0() = migrate_expr_back(ref2.init);
+    codeexpr.op1() = migrate_expr_back(ref2.cond);
+    codeexpr.op2() = migrate_expr_back(ref2.iter);
+    codeexpr.op3() = migrate_expr_back(ref2.body);
+    return codeexpr;
+  }
+  case expr2t::code_switch_id:
+  {
+    const code_switch2t &ref2 = to_code_switch2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("switch");
+    codeexpr.operands().resize(2);
+    codeexpr.op0() = migrate_expr_back(ref2.value);
+    codeexpr.op1() = migrate_expr_back(ref2.body);
+    return codeexpr;
+  }
+  case expr2t::code_break_id:
+  {
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("break");
+    return codeexpr;
+  }
+  case expr2t::code_continue_id:
+  {
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("continue");
+    return codeexpr;
+  }
+  case expr2t::code_label_id:
+  {
+    const code_label2t &ref2 = to_code_label2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("label");
+    codeexpr.set("label", ref2.label);
+    codeexpr.copy_to_operands(migrate_expr_back(ref2.code));
+    return codeexpr;
   }
   case expr2t::code_cpp_catch_id:
   {

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -215,6 +215,74 @@ TEST_CASE(
   require_expr_roundtrip(pointer_capability2tc(cap_t, base));
 }
 
+// V.4 of the migration (esbmc/esbmc#4715): structured control-flow code kinds.
+// These are dead-but-tested infrastructure -- nothing in the pipeline builds
+// them yet (the converter emits legacy structured codet, which goto_convert
+// lowers). The round-trip property pinned here is the precondition for the
+// goto_convert wiring phase that lets a frontend emit IREP2 bodies. The
+// nil-operand variants (else-less if, head-less for) exercise the null<->nil
+// mapping that an emitted body would hit.
+
+// A small legacy-shaped IREP2 body used as a sub-statement of the CF kinds.
+static expr2tc cf_block()
+{
+  expr2tc lhs = symbol2tc(get_int_type(32), "x");
+  expr2tc rhs = constant_int2tc(get_int_type(32), BigInt(1));
+  return code_block2tc(std::vector<expr2tc>{code_assign2tc(lhs, rhs)});
+}
+
+TEST_CASE("migrate expr round-trips for code_ifthenelse", "[migrate][v4-cf]")
+{
+  use_test_ns();
+  require_expr_roundtrip(
+    code_ifthenelse2tc(gen_true_expr(), cf_block(), cf_block()));
+  // No else branch: the else_case is a null expr2tc <-> nil exprt.
+  require_expr_roundtrip(
+    code_ifthenelse2tc(gen_true_expr(), cf_block(), expr2tc()));
+}
+
+TEST_CASE("migrate expr round-trips for code_while", "[migrate][v4-cf]")
+{
+  use_test_ns();
+  require_expr_roundtrip(code_while2tc(gen_true_expr(), cf_block()));
+}
+
+TEST_CASE("migrate expr round-trips for code_for", "[migrate][v4-cf]")
+{
+  use_test_ns();
+  expr2tc i = symbol2tc(get_int_type(32), "i");
+  expr2tc init =
+    code_assign2tc(i, constant_int2tc(get_int_type(32), BigInt(0)));
+  expr2tc iter =
+    code_assign2tc(i, constant_int2tc(get_int_type(32), BigInt(1)));
+  require_expr_roundtrip(code_for2tc(init, gen_true_expr(), iter, cf_block()));
+  // Absent init/cond/iter -- the null<->nil corner for every head slot.
+  require_expr_roundtrip(
+    code_for2tc(expr2tc(), expr2tc(), expr2tc(), cf_block()));
+}
+
+TEST_CASE("migrate expr round-trips for code_switch", "[migrate][v4-cf]")
+{
+  use_test_ns();
+  expr2tc value = symbol2tc(get_int_type(32), "x");
+  require_expr_roundtrip(code_switch2tc(value, cf_block()));
+}
+
+TEST_CASE(
+  "migrate expr round-trips for code_break and code_continue",
+  "[migrate][v4-cf]")
+{
+  use_test_ns();
+  require_expr_roundtrip(code_break2tc());
+  require_expr_roundtrip(code_continue2tc());
+}
+
+TEST_CASE("migrate expr round-trips for code_label", "[migrate][v4-cf]")
+{
+  use_test_ns();
+  require_expr_roundtrip(code_label2tc("L1", cf_block()));
+}
+
 // Phase 4.2 construction helpers (util/migrate.h): symbol_expr2tc and
 // side_effect_function_call2tc. The contract is that each is a faithful
 // drop-in for the legacy constructor it replaces -- it produces the same IREP2


### PR DESCRIPTION
Begins **Phase V.4** of the IREP2 migration (esbmc/esbmc#4715). IREP2 had only the flat goto-level code kinds; this adds the missing **structured control-flow** kinds — `code_ifthenelse2t`, `code_while2t`, `code_for2t`, `code_switch2t`, `code_break2t`, `code_continue2t`, `code_label2t` — mirroring the legacy structured `codet` statements (`std_code.h`).

This is the prerequisite for teaching `goto_convert` to consume IREP2 bodies, which is what finally removes the per-instruction back-migration at the body seam (wall W1) — the round-trip that Part IV's converter work could not eliminate by frontend-only changes (see the docs pause record, #5264).

**Dead-but-tested.** No pipeline path builds these yet (the converter still emits legacy structured `codet`, which `goto_convert` lowers); the commit is behaviour-inert. This is the V-track pattern (cf. #4737): ship the kinds + bidirectional `migrate` arms + round-trip unit tests first, so the later `goto_convert` wiring lands with zero coverage-axis risk.

Each kind: `expr_kinds.inc` manifest entry (appended, no enum renumbering) + `irep_typedefs` + a class with its `fields` tuple/`field_names` + forward/back `migrate` arms + a round-trip `TEST_CASE` (IREP2 idempotence, including the nil-operand corners — else-less `if`, head-less `for`). Documented in `src/irep2/README.md`.

Validation (asserts-enabled Debug build): full unit suite **413/413**; the 6 new CF round-trip tests pass; regression spot-check **43/43** across C/C++/Python (the kinds are dead in the pipeline, so behaviour is unchanged).