### PR TITLE
[irep2] V.4.1: carry source location on structured-CF code kinds

### DIFF
--- a/scripts/cmake/SetupLocalLLVM.cmake
+++ b/scripts/cmake/SetupLocalLLVM.cmake
@@ -48,6 +48,50 @@ elseif(DEFINED ESBMC_CHERI AND NOT ESBMC_CHERI AND ESBMC_CHERI_CLANG)
   unset(ESBMC_CHERI_CLANG_MORELLO)
 endif()
 
+# Patch stale DIA SDK path embedded by LLVM prebuilt binaries on Windows.
+if(WIN32)
+  find_library(DIAGUIDS_LIB diaguids
+    PATHS
+      "$ENV{VSINSTALLDIR}/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/18/Enterprise/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/18/Professional/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/18/Community/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2025/Enterprise/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2025/Professional/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2025/Community/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2022/Professional/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2022/Community/DIA SDK/lib/amd64"
+    NO_DEFAULT_PATH
+  )
+  if(DIAGUIDS_LIB)
+    message(STATUS "DIA SDK found: ${DIAGUIDS_LIB}")
+    foreach(_dia_tgt IN LISTS LLVM_AVAILABLE_LIBS CLANG_EXPORTED_TARGETS)
+      if(NOT TARGET ${_dia_tgt})
+        continue()
+      endif()
+      get_target_property(_dia_iface ${_dia_tgt} INTERFACE_LINK_LIBRARIES)
+      if(NOT _dia_iface)
+        continue()
+      endif()
+      set(_dia_fixed)
+      set(_dia_changed FALSE)
+      foreach(_dia_lib IN LISTS _dia_iface)
+        if("${_dia_lib}" MATCHES "diaguids\\.lib$" AND NOT EXISTS "${_dia_lib}")
+          list(APPEND _dia_fixed "${DIAGUIDS_LIB}")
+          set(_dia_changed TRUE)
+        else()
+          list(APPEND _dia_fixed "${_dia_lib}")
+        endif()
+      endforeach()
+      if(_dia_changed)
+        set_target_properties(${_dia_tgt} PROPERTIES
+          INTERFACE_LINK_LIBRARIES "${_dia_fixed}")
+      endif()
+    endforeach()
+  endif()
+endif()
+
 if(${LLVM_VERSION_MAJOR} GREATER ${MAX_SUPPORTED_LLVM_VERSION_MAJOR})
   message(WARNING "LLVM version ${LLVM_VERSION_MAJOR} is greater than maximum "
                   "supported (${MAX_SUPPORTED_LLVM_VERSION_MAJOR})")

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -1075,18 +1075,42 @@ constexpr std::size_t count_derived_field_entries(std::index_sequence<Is...>)
     ... + std::size_t{0});
 }
 
+// A kind may *intentionally* hold a member that is excluded from
+// cmp/crc/hash/tostring — i.e. deliberately not listed in `fields`. Such a
+// kind declares `static constexpr std::size_t excluded_field_bytes = ...;`
+// giving the byte size of those excluded members, so `fields_cover_class`
+// stops counting them as "missed". The only current use is the non-reflected
+// `locationt location` on the V.4 structured-CF code kinds (esbmc/esbmc#4715):
+// source location must travel with the statement for goto_convert, but must
+// not enter value identity (matching how a goto instructiont stores its
+// locationt separately from its IREP2 code). Kinds without the member get 0.
+template <class K, class = void>
+struct kind_excluded_field_bytes
+{
+  static constexpr std::size_t value = 0;
+};
+template <class K>
+struct kind_excluded_field_bytes<
+  K,
+  std::void_t<decltype(K::excluded_field_bytes)>>
+{
+  static constexpr std::size_t value = K::excluded_field_bytes;
+};
+
 // `fields_cover_class<K>()` — the sum of derived-class field sizes in
-// K::fields must equal `sizeof(K) - sizeof(base)`, modulo at most
-// `alignof(K) - 1` bytes of trailing padding. Catches missed-member-in-tuple
-// at compile time for any kind where the missed member is at least one byte
-// larger than the existing trailing padding (which covers every realistic
-// case — irep2 nodes use pointer-sized fields almost exclusively).
+// K::fields must equal `sizeof(K) - sizeof(base)` (minus any declared
+// `excluded_field_bytes`), modulo at most `alignof(K) - 1` bytes of trailing
+// padding. Catches missed-member-in-tuple at compile time for any kind where
+// the missed member is at least one byte larger than the existing trailing
+// padding (which covers every realistic case — irep2 nodes use pointer-sized
+// fields almost exclusively).
 template <class K>
 constexpr bool fields_cover_class()
 {
   using fields_t = std::remove_cv_t<decltype(K::fields)>;
-  constexpr std::size_t derived_storage =
-    sizeof(K) - sizeof(typename K::base_type);
+  constexpr std::size_t derived_storage = sizeof(K) -
+                                          sizeof(typename K::base_type) -
+                                          kind_excluded_field_bytes<K>::value;
   constexpr std::size_t covered = sum_derived_field_sizes<K>(
     std::make_index_sequence<std::tuple_size_v<fields_t>>{});
   return derived_storage - covered < alignof(K);

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -5,6 +5,7 @@
 #include <util/c_types.h>
 #include <util/fixedbv.h>
 #include <util/ieee_float.h>
+#include <util/location.h>
 #include <irep2/irep2_type.h>
 
 // So - make some type definitions for the different types we're going to be
@@ -1942,18 +1943,35 @@ public:
 // dead-but-tested first: nothing builds them until the goto_convert wiring
 // phase, so they are behaviour-inert and only the round-trip unit tests
 // exercise them (the V-track pattern).
+//
+// V.4.1: each kind carries a `locationt location` so a future IREP2-native
+// goto_convert can stamp each instruction's source location -- the legacy
+// codet carries it on the node, but expr2t/migrate do not, so an IREP2 body
+// would otherwise lose all counterexample line numbers. The field is
+// deliberately NOT part of the `fields` tuple, so it does not enter the IREP2
+// hash/equality (matching how a goto instructiont stores its locationt
+// separately); it is preserved through clone() by the defaulted copy ctor and
+// threaded by hand in migrate (forward copies code.location(), back restores
+// it).
 class code_ifthenelse2t : public expr2t
 {
 public:
   expr2tc cond;
   expr2tc then_case;
   expr2tc else_case; // nil when there is no else branch
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
 
-  code_ifthenelse2t(const expr2tc &c, const expr2tc &t, const expr2tc &e)
+  code_ifthenelse2t(
+    const expr2tc &c,
+    const expr2tc &t,
+    const expr2tc &e,
+    const locationt &loc = locationt())
     : expr2t(get_empty_type(), code_ifthenelse_id),
       cond(c),
       then_case(t),
-      else_case(e)
+      else_case(e),
+      location(loc)
   {
   }
   code_ifthenelse2t(const code_ifthenelse2t &ref) = default;
@@ -1971,9 +1989,14 @@ class code_while2t : public expr2t
 public:
   expr2tc cond;
   expr2tc body;
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
 
-  code_while2t(const expr2tc &c, const expr2tc &b)
-    : expr2t(get_empty_type(), code_while_id), cond(c), body(b)
+  code_while2t(
+    const expr2tc &c,
+    const expr2tc &b,
+    const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_while_id), cond(c), body(b), location(loc)
   {
   }
   code_while2t(const code_while2t &ref) = default;
@@ -1990,13 +2013,21 @@ public:
   expr2tc cond; // nil when absent
   expr2tc iter; // nil when absent
   expr2tc body;
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
 
   code_for2t(
     const expr2tc &i,
     const expr2tc &c,
     const expr2tc &it,
-    const expr2tc &b)
-    : expr2t(get_empty_type(), code_for_id), init(i), cond(c), iter(it), body(b)
+    const expr2tc &b,
+    const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_for_id),
+      init(i),
+      cond(c),
+      iter(it),
+      body(b),
+      location(loc)
   {
   }
   code_for2t(const code_for2t &ref) = default;
@@ -2015,9 +2046,14 @@ class code_switch2t : public expr2t
 public:
   expr2tc value;
   expr2tc body;
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
 
-  code_switch2t(const expr2tc &v, const expr2tc &b)
-    : expr2t(get_empty_type(), code_switch_id), value(v), body(b)
+  code_switch2t(
+    const expr2tc &v,
+    const expr2tc &b,
+    const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_switch_id), value(v), body(b), location(loc)
   {
   }
   code_switch2t(const code_switch2t &ref) = default;
@@ -2030,7 +2066,11 @@ public:
 class code_break2t : public expr2t
 {
 public:
-  code_break2t() : expr2t(get_empty_type(), code_break_id)
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+
+  code_break2t(const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_break_id), location(loc)
   {
   }
   code_break2t(const code_break2t &ref) = default;
@@ -2042,7 +2082,11 @@ public:
 class code_continue2t : public expr2t
 {
 public:
-  code_continue2t() : expr2t(get_empty_type(), code_continue_id)
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+
+  code_continue2t(const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_continue_id), location(loc)
   {
   }
   code_continue2t(const code_continue2t &ref) = default;
@@ -2056,9 +2100,14 @@ class code_label2t : public expr2t
 public:
   irep_idt label;
   expr2tc code;
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
 
-  code_label2t(const irep_idt &l, const expr2tc &c)
-    : expr2t(get_empty_type(), code_label_id), label(l), code(c)
+  code_label2t(
+    const irep_idt &l,
+    const expr2tc &c,
+    const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_label_id), label(l), code(c), location(loc)
   {
   }
   code_label2t(const code_label2t &ref) = default;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2158,14 +2158,17 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
   // V.4 structured control-flow code kinds (esbmc/esbmc#4715). Forward arms
   // for the legacy structured codet statements; nil sub-operands (an absent
   // else / for-init / for-cond / for-iter) migrate to a null expr2tc and back,
-  // so the round-trip is exact.
+  // so the round-trip is exact. V.4.1: the legacy node's source location is
+  // carried into the (non-reflected) code_*2t::location field and restored on
+  // the way back, so a future IREP2-native goto_convert can stamp instructions.
   if (expr.id() == "code" && expr.statement() == "ifthenelse")
   {
     expr2tc cond, then_case, else_case;
     migrate_expr(expr.op0(), cond);
     migrate_expr(expr.op1(), then_case);
     migrate_expr(expr.op2(), else_case);
-    new_expr_ref = code_ifthenelse2tc(cond, then_case, else_case);
+    new_expr_ref =
+      code_ifthenelse2tc(cond, then_case, else_case, expr.location());
     return;
   }
 
@@ -2174,7 +2177,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     expr2tc cond, body;
     migrate_expr(expr.op0(), cond);
     migrate_expr(expr.op1(), body);
-    new_expr_ref = code_while2tc(cond, body);
+    new_expr_ref = code_while2tc(cond, body, expr.location());
     return;
   }
 
@@ -2185,7 +2188,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     migrate_expr(expr.op1(), cond);
     migrate_expr(expr.op2(), iter);
     migrate_expr(expr.op3(), body);
-    new_expr_ref = code_for2tc(init, cond, iter, body);
+    new_expr_ref = code_for2tc(init, cond, iter, body, expr.location());
     return;
   }
 
@@ -2194,19 +2197,19 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     expr2tc value, body;
     migrate_expr(expr.op0(), value);
     migrate_expr(expr.op1(), body);
-    new_expr_ref = code_switch2tc(value, body);
+    new_expr_ref = code_switch2tc(value, body, expr.location());
     return;
   }
 
   if (expr.id() == "code" && expr.statement() == "break")
   {
-    new_expr_ref = code_break2tc();
+    new_expr_ref = code_break2tc(expr.location());
     return;
   }
 
   if (expr.id() == "code" && expr.statement() == "continue")
   {
-    new_expr_ref = code_continue2tc();
+    new_expr_ref = code_continue2tc(expr.location());
     return;
   }
 
@@ -2214,7 +2217,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
   {
     expr2tc code;
     migrate_expr(expr.op0(), code);
-    new_expr_ref = code_label2tc(expr.get("label"), code);
+    new_expr_ref = code_label2tc(expr.get("label"), code, expr.location());
     return;
   }
 
@@ -3686,6 +3689,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.op0() = migrate_expr_back(ref2.cond);
     codeexpr.op1() = migrate_expr_back(ref2.then_case);
     codeexpr.op2() = migrate_expr_back(ref2.else_case);
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
     return codeexpr;
   }
   case expr2t::code_while_id:
@@ -3696,6 +3701,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.operands().resize(2);
     codeexpr.op0() = migrate_expr_back(ref2.cond);
     codeexpr.op1() = migrate_expr_back(ref2.body);
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
     return codeexpr;
   }
   case expr2t::code_for_id:
@@ -3708,6 +3715,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.op1() = migrate_expr_back(ref2.cond);
     codeexpr.op2() = migrate_expr_back(ref2.iter);
     codeexpr.op3() = migrate_expr_back(ref2.body);
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
     return codeexpr;
   }
   case expr2t::code_switch_id:
@@ -3718,18 +3727,26 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.operands().resize(2);
     codeexpr.op0() = migrate_expr_back(ref2.value);
     codeexpr.op1() = migrate_expr_back(ref2.body);
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
     return codeexpr;
   }
   case expr2t::code_break_id:
   {
+    const code_break2t &ref2 = to_code_break2t(ref);
     exprt codeexpr("code", typet("code"));
     codeexpr.statement("break");
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
     return codeexpr;
   }
   case expr2t::code_continue_id:
   {
+    const code_continue2t &ref2 = to_code_continue2t(ref);
     exprt codeexpr("code", typet("code"));
     codeexpr.statement("continue");
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
     return codeexpr;
   }
   case expr2t::code_label_id:
@@ -3739,6 +3756,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.statement("label");
     codeexpr.set("label", ref2.label);
     codeexpr.copy_to_operands(migrate_expr_back(ref2.code));
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
     return codeexpr;
   }
   case expr2t::code_cpp_catch_id:

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -283,6 +283,56 @@ TEST_CASE("migrate expr round-trips for code_label", "[migrate][v4-cf]")
   require_expr_roundtrip(code_label2tc("L1", cf_block()));
 }
 
+// V.4.1: each CF kind carries a source location through migrate in both
+// directions. The location field is intentionally NOT in the fields tuple, so
+// it does not enter operator== -- require_expr_roundtrip would pass even if it
+// were dropped. Assert it survives explicitly via the typed accessor.
+static locationt cf_loc()
+{
+  locationt l;
+  l.set_file("cf.c");
+  l.set_line(42u);
+  return l;
+}
+
+static expr2tc cf_roundtrip(const expr2tc &e2)
+{
+  expr2tc back;
+  migrate_expr(migrate_expr_back(e2), back);
+  return back;
+}
+
+TEST_CASE(
+  "migrate carries source location on CF code kinds",
+  "[migrate][v4-cf]")
+{
+  use_test_ns();
+  const locationt loc = cf_loc();
+  expr2tc value = symbol2tc(get_int_type(32), "x");
+
+  REQUIRE(
+    to_code_ifthenelse2t(cf_roundtrip(code_ifthenelse2tc(
+                           gen_true_expr(), cf_block(), expr2tc(), loc)))
+      .location == loc);
+  REQUIRE(
+    to_code_while2t(
+      cf_roundtrip(code_while2tc(gen_true_expr(), cf_block(), loc)))
+      .location == loc);
+  REQUIRE(
+    to_code_for2t(cf_roundtrip(code_for2tc(
+                    expr2tc(), expr2tc(), expr2tc(), cf_block(), loc)))
+      .location == loc);
+  REQUIRE(
+    to_code_switch2t(cf_roundtrip(code_switch2tc(value, cf_block(), loc)))
+      .location == loc);
+  REQUIRE(to_code_break2t(cf_roundtrip(code_break2tc(loc))).location == loc);
+  REQUIRE(
+    to_code_continue2t(cf_roundtrip(code_continue2tc(loc))).location == loc);
+  REQUIRE(
+    to_code_label2t(cf_roundtrip(code_label2tc("L1", cf_block(), loc)))
+      .location == loc);
+}
+
 // Phase 4.2 construction helpers (util/migrate.h): symbol_expr2tc and
 // side_effect_function_call2tc. The contract is that each is a faithful
 // drop-in for the legacy constructor it replaces -- it produces the same IREP2


### PR DESCRIPTION
Continues **Phase V.4** of the IREP2 migration (esbmc/esbmc#4715), building on V.4.0 (#5265).

**Problem.** `goto_convert` stamps each goto instruction's source location by reading `code.location()` off the legacy `codet` body (~15 sites). IREP2 nodes carry no location and `migrate_expr` drops it — so once a frontend emits IREP2 bodies, every instruction would lose its source location, breaking counterexample line numbers (and the byte-identical-GOTO gate). This is the real prerequisite for the `goto_convert` wiring phase, not a flag.

**Change.** Give the V.4.0 structured-CF kinds (`code_ifthenelse2t`/`while2t`/`for2t`/`switch2t`/`break2t`/`continue2t`/`label2t`) a `locationt location` member, threaded through `migrate` (forward copies `code.location()`, back restores it). The field is **deliberately not in the `fields` tuple** — it stays out of cmp/crc/hash, mirroring how a goto `instructiont` stores its `locationt` separately from its IREP2 code — and is preserved through `clone()` by the defaulted copy ctor. To permit a documented non-reflected member, `fields_cover_class` now subtracts an opt-in `K::excluded_field_bytes` (0 for every other kind via a detector trait), which is exactly the escape hatch the invariant's own static_assert message anticipated.

**Still dead-but-tested** — nothing builds these yet, so behaviour-inert. Adds a round-trip test asserting the location survives via the typed accessor (it is outside `operator==`, so the existing `==` round-trip cannot catch a drop).

Validation (asserts-enabled build): full unit suite **414/414**; new location-survival test passes; regression spot-check **42/42** across C/C++/Python. code-reviewer confirmed the `fields_cover_class` weakening is sound (a future missed pointer-sized member still trips the assert), the round-trip is correct, and `clone`/`with_type` don't silently drop the member.