### PR TITLE
[build] patch stale DIA SDK path for VS 2025 Windows runner

### DIFF
--- a/scripts/cmake/SetupLocalLLVM.cmake
+++ b/scripts/cmake/SetupLocalLLVM.cmake
@@ -48,6 +48,50 @@ elseif(DEFINED ESBMC_CHERI AND NOT ESBMC_CHERI AND ESBMC_CHERI_CLANG)
   unset(ESBMC_CHERI_CLANG_MORELLO)
 endif()
 
+# Patch stale DIA SDK path embedded by LLVM prebuilt binaries on Windows.
+if(WIN32)
+  find_library(DIAGUIDS_LIB diaguids
+    PATHS
+      "$ENV{VSINSTALLDIR}/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/18/Enterprise/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/18/Professional/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/18/Community/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2025/Enterprise/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2025/Professional/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2025/Community/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2022/Professional/DIA SDK/lib/amd64"
+      "C:/Program Files/Microsoft Visual Studio/2022/Community/DIA SDK/lib/amd64"
+    NO_DEFAULT_PATH
+  )
+  if(DIAGUIDS_LIB)
+    message(STATUS "DIA SDK found: ${DIAGUIDS_LIB}")
+    foreach(_dia_tgt IN LISTS LLVM_AVAILABLE_LIBS CLANG_EXPORTED_TARGETS)
+      if(NOT TARGET ${_dia_tgt})
+        continue()
+      endif()
+      get_target_property(_dia_iface ${_dia_tgt} INTERFACE_LINK_LIBRARIES)
+      if(NOT _dia_iface)
+        continue()
+      endif()
+      set(_dia_fixed)
+      set(_dia_changed FALSE)
+      foreach(_dia_lib IN LISTS _dia_iface)
+        if("${_dia_lib}" MATCHES "diaguids\\.lib$" AND NOT EXISTS "${_dia_lib}")
+          list(APPEND _dia_fixed "${DIAGUIDS_LIB}")
+          set(_dia_changed TRUE)
+        else()
+          list(APPEND _dia_fixed "${_dia_lib}")
+        endif()
+      endforeach()
+      if(_dia_changed)
+        set_target_properties(${_dia_tgt} PROPERTIES
+          INTERFACE_LINK_LIBRARIES "${_dia_fixed}")
+      endif()
+    endforeach()
+  endif()
+endif()
+
 if(${LLVM_VERSION_MAJOR} GREATER ${MAX_SUPPORTED_LLVM_VERSION_MAJOR})
   message(WARNING "LLVM version ${LLVM_VERSION_MAJOR} is greater than maximum "
                   "supported (${MAX_SUPPORTED_LLVM_VERSION_MAJOR})")


### PR DESCRIPTION
## Problem

`windows-latest` now maps to VS 2025 (version 18). LLVM prebuilt Windows
binaries embed the VS DIA SDK path they were compiled against (e.g. VS 2022),
so the link step fails with:

```
LINK : fatal error LNK1104: cannot open file
'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\DIA SDK\lib\amd64\diaguids.lib'
```

## Fix

After `find_package(LLVM/Clang)`, scan all imported targets for any
`diaguids.lib` reference pointing to a non-existent path and replace it
with the one found via `find_library`, searching VS 18/2025/2022 editions
and `$ENV{VSINSTALLDIR}`.

## Tested

Manually triggered `Build ESBMC` workflow on `fix/windows-dia-sdk-vs2025`
branch with `windows-latest` / `DebugOpt` — **Success** (build #6566).
https://github.com/esbmc/esbmc/actions/runs/27205823383

Note: GitHub now redirects `windows-latest` to `windows-2025-vs2026`
(effective June 15 2026), so this fix will remain relevant going forward.