### PR TITLE
[python] fix mismatched-width crash on None-handle vs object compare

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -415,6 +415,14 @@ set(_slow_regression_tests
     # verdict instead of ctest hard-killing the run.
     "regression/quixbugs/breadth_first_search"
     "regression/quixbugs/breadth_first_search_fail"
+    # reverse_linked_list used to fast-crash with a SIGSEGV when comparing a
+    # None-handle (pointer-width int) against a by-value Node struct via ==.
+    # With the pointer-identity reconciliation fix (PR #5274) the crash is gone
+    # and ESBMC reaches the real linked-list reversal symex (list-equality +
+    # loop scalability wall), which does not converge under --incremental-bmc.
+    # It stays KNOWNBUG; the larger inner timeout lets testing_tool record the
+    # KNOWNBUG verdict instead of ctest hard-killing the run.
+    "regression/quixbugs/reverse_linked_list"
     # github_4435 was a soundness false alarm on the SV-COMP libvsync
     # bounded_mpmc_check_full benchmark; the underlying deref unit
     # mismatch is fixed by PR #4939, but the full benchmark

--- a/regression/python/github_4796_object_handle_eq/main.py
+++ b/regression/python/github_4796_object_handle_eq/main.py
@@ -1,0 +1,40 @@
+# Regression for #4796: a bare `prevnode = None` local is modelled as a
+# pointer-width integer object handle, so reverse_linked_list returns a handle
+# while a freshly constructed Node is stored by value. Comparing the two with
+# `==` fed a struct sort and a scalar to the solver's mk_eq, whose operand-width
+# assert is elided under NDEBUG and crashed release builds with a SIGSEGV. The
+# comparison now reconciles handle vs by-value instance as class-pointer
+# identity, so `==`/`!=`/`is`/`is not` are well-typed and precise.
+from node import Node
+
+
+def reverse(node):
+    prevnode = None
+    while node:
+        nextnode = node.successor
+        node.successor = prevnode
+        prevnode = node
+        node = nextnode
+    return prevnode
+
+
+def test_identity():
+    n = Node(0)
+    r = reverse(n)
+    assert r == n
+    assert r is n
+    assert not (r != n)
+    assert not (r is not n)
+
+
+def test_distinct():
+    a = Node(1)
+    b = Node(2)
+    r = reverse(a)
+    assert r != b
+    assert r is not b
+    assert not (r == b)
+
+
+test_identity()
+test_distinct()

--- a/regression/python/github_4796_object_handle_eq/node.py
+++ b/regression/python/github_4796_object_handle_eq/node.py
@@ -1,0 +1,4 @@
+class Node:
+    def __init__(self, value=None, successor=None):
+        self.value = value
+        self.successor = successor

--- a/regression/python/github_4796_object_handle_eq/test.desc
+++ b/regression/python/github_4796_object_handle_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4796_object_handle_eq_fail/main.py
+++ b/regression/python/github_4796_object_handle_eq_fail/main.py
@@ -1,0 +1,25 @@
+# Negative companion to github_4796_object_handle_eq. The reconciled handle vs
+# by-value comparison must be precise, not vacuously true: reversing the list
+# b -> a yields head `a`, so asserting the head is `b` is genuinely false and
+# ESBMC must report it rather than fold the mismatched-width compare away.
+from node import Node
+
+
+def reverse(node):
+    prevnode = None
+    while node:
+        nextnode = node.successor
+        node.successor = prevnode
+        prevnode = node
+        node = nextnode
+    return prevnode
+
+
+def test_wrong_head():
+    a = Node(1)
+    b = Node(2, a)
+    r = reverse(b)
+    assert r == b
+
+
+test_wrong_head()

--- a/regression/python/github_4796_object_handle_eq_fail/node.py
+++ b/regression/python/github_4796_object_handle_eq_fail/node.py
@@ -1,0 +1,4 @@
+class Node:
+    def __init__(self, value=None, successor=None):
+        self.value = value
+        self.successor = successor

--- a/regression/python/github_4796_object_handle_eq_fail/test.desc
+++ b/regression/python/github_4796_object_handle_eq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -540,6 +540,57 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
       struct_side = gen_address_of(struct_side);
   }
 
+  // Python reference-identity when one operand is a by-value class instance and
+  // the other is a None-able object *handle*. A bare `x = None` local — and any
+  // value flowing from it, including a function's return — is modelled as a
+  // pointer-width unsigned integer handle (value 0 for None; see
+  // type_handler `NoneType`/`Optional`). A freshly constructed instance such as
+  // `Node(0)` is stored by value (tag-Node). Comparing the two fed a struct sort
+  // and a pointer-width scalar to the solver's mk_eq, whose operand-width assert
+  // is elided under NDEBUG -> SIGSEGV in release builds (github #4796). The
+  // tag-matched pointer case above does not fire because the handle carries no
+  // class tag. Reinterpret the struct as its address cast to the handle type so
+  // both sides compare as object references.
+  if (op == "Eq" || op == "NotEq" || op == "Is" || op == "IsNot")
+  {
+    // A None-able object handle: a pointer-width unsigned integer (how
+    // NoneType/Optional are modelled). Python ints are signed, so this excludes
+    // ordinary integer comparisons; it does also match other pointer-width
+    // unsigned values (e.g. a size_t/len() result), but those reach the
+    // numeric-vs-numeric paths above before this block when compared to a
+    // number, and comparing one to a class instance is nonsensical in Python.
+    auto is_object_handle = [](const typet &t) {
+      return t.is_unsignedbv() &&
+             to_unsignedbv_type(t).get_width() == config.ansi_c.pointer_width();
+    };
+    // A by-value user-defined class instance. dict/tuple are also structs and
+    // own the equality paths above; list values are pointer-typed, not structs.
+    auto is_user_class_struct = [&](const typet &t) {
+      typet r = (t.id() == "symbol") ? ns.follow(t) : t;
+      return r.is_struct() && !dict_handler_->is_dict_type(r) &&
+             !tuple_handler_->is_tuple_type(r);
+    };
+
+    const bool lhs_handle = is_object_handle(lhs.type());
+    const bool rhs_handle = is_object_handle(rhs.type());
+    if (lhs_handle != rhs_handle)
+    {
+      exprt &struct_side = lhs_handle ? rhs : lhs;
+      exprt &handle_side = lhs_handle ? lhs : rhs;
+      if (is_user_class_struct(struct_side.type()))
+      {
+        // Compare as pointers, not integers: take the struct's address and
+        // reinterpret the integer handle as a pointer to the same class, so
+        // ESBMC's object/offset pointer model decides identity. Casting both
+        // to the integer handle instead would lose the distinct-object
+        // guarantee and spuriously satisfy `a != b` for distinct instances.
+        typet ptr_t = gen_pointer_type(ns.follow(struct_side.type()));
+        struct_side = typecast_exprt(gen_address_of(struct_side), ptr_t);
+        handle_side = typecast_exprt(handle_side, ptr_t);
+      }
+    }
+  }
+
   // Handle identity comparisons
   if (op == "Is")
     return get_binary_operator_expr_for_is(lhs, rhs);


### PR DESCRIPTION
A bare `x = None` local is modelled as a pointer-width integer object handle (how `NoneType`/`Optional` are typed), so a function returning such a local yields an integer handle while a freshly constructed class instance is stored by value as a struct. Comparing the two with `==`/`!=`/`is`/`is not` fed a struct sort and a pointer-width scalar to the solver's `mk_eq`, whose operand-width `assert` is elided under NDEBUG, so release builds crashed with a SIGSEGV (#4796).

Reconcile a None-able handle against a by-value class instance as class-pointer identity: take the struct's address and reinterpret the handle as a pointer to the same class, so ESBMC's object/offset model decides identity precisely — sound for both equality and disequality.

Refs #4796. The crash and the comparison typing are fixed; the quixbugs `reverse_linked_list` test stays KNOWNBUG because its remaining blocker is a separate list-equality/loop scalability wall, not this typing defect.