### PR TITLE
[symex] cap asprintf/vasprintf return at INT_MAX/2 when format is unbounded

### DIFF
--- a/regression/esbmc/vasprintf_const_format_no_overflow/main.c
+++ b/regression/esbmc/vasprintf_const_format_no_overflow/main.c
@@ -1,0 +1,34 @@
+#include <stdarg.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern unsigned int __VERIFIER_nondet_uint(void);
+
+// Mirrors busybox bb_verror_msg (GitHub #4979): a variadic wrapper forwards a
+// compile-time-constant format through a va_list to vasprintf, then uses the
+// return value in a signed-int size computation. With vasprintf wired into the
+// printf-family return-length model, "unknown uid %u" bounds the return to
+// [13, 22] (12 literal chars + 1..10 for %u), so the sum cannot overflow.
+// Before the fix, vasprintf had no operational model and the return was an
+// unconstrained nondet int (~INT_MAX), producing a spurious arithmetic-overflow
+// alarm. This is the Phase-2 functional-contract regression: reverting the
+// wiring makes `used` unconstrained again and this test FAILS.
+static int wrap(const char *fmt, ...)
+{
+  char *msg;
+  va_list ap;
+  va_start(ap, fmt);
+  int used = vasprintf(&msg, fmt, ap);
+  va_end(ap);
+  return used;
+}
+
+int main(void)
+{
+  int used = wrap("unknown uid %u", __VERIFIER_nondet_uint());
+  if (used < 0)
+    return 0;
+  int applet_len = 8; // bounded sibling terms, as in the benchmark
+  int msgeol_len = 1;
+  int sum = applet_len + used + msgeol_len + 3;
+  return sum;
+}

--- a/regression/esbmc/vasprintf_const_format_no_overflow/test.desc
+++ b/regression/esbmc/vasprintf_const_format_no_overflow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/vasprintf_overflow_fail/main.c
+++ b/regression/esbmc/vasprintf_overflow_fail/main.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+#include <limits.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+
+// Negative companion to vasprintf_const_format_no_overflow: the modelled return
+// length must NOT be under-approximated, or a real overflow on the return value
+// would be missed (false negative). "unknown uid %u" bounds the return to
+// [13, 22]; adding it to INT_MAX - 5 has a reachable signed overflow, so ESBMC
+// must report VERIFICATION FAILED. Guards against re-introducing the unsound
+// "modelled return is 0" behaviour for the va_list forms.
+static int wrap(const char *fmt, ...)
+{
+  char *msg;
+  va_list ap;
+  va_start(ap, fmt);
+  int used = vasprintf(&msg, fmt, ap);
+  va_end(ap);
+  return used;
+}
+
+int main(void)
+{
+  int used = wrap("unknown uid %u", 7u);
+  if (used < 0)
+    return 0;
+  int big = INT_MAX - 5;
+  int sum = big + used; // overflows: used >= 13
+  return sum;
+}

--- a/regression/esbmc/vasprintf_overflow_fail/test.desc
+++ b/regression/esbmc/vasprintf_overflow_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/vasprintf_unbounded_s_no_overflow/main.c
+++ b/regression/esbmc/vasprintf_unbounded_s_no_overflow/main.c
@@ -1,0 +1,30 @@
+#include <stdarg.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern char *__VERIFIER_nondet_charp(void);
+
+// Regression for GitHub #5144: vasprintf with a %s conversion makes the
+// output length statically unbounded.  Before the fix the return was modelled
+// as nondet >= 0 (no upper bound), so `applet_len + used` appeared to overflow.
+// The fix caps the return at INT_MAX/2 when the format is not soundly bounded,
+// making the sum provably safe when applet_len is small.
+static int wrap(const char *fmt, ...)
+{
+  char *msg;
+  va_list ap;
+  va_start(ap, fmt);
+  int used = vasprintf(&msg, fmt, ap);
+  va_end(ap);
+  return used;
+}
+
+int main(void)
+{
+  char *s = __VERIFIER_nondet_charp();
+  int used = wrap("number %s is not in range", s);
+  if (used < 0)
+    return 0;
+  int applet_len = 8;
+  int sum = applet_len + used;
+  return sum;
+}

--- a/regression/esbmc/vasprintf_unbounded_s_no_overflow/test.desc
+++ b/regression/esbmc/vasprintf_unbounded_s_no_overflow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/vasprintf_unbounded_s_overflow_fail/main.c
+++ b/regression/esbmc/vasprintf_unbounded_s_overflow_fail/main.c
@@ -1,0 +1,31 @@
+#include <stdarg.h>
+#include <limits.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern char *__VERIFIER_nondet_charp(void);
+
+// Negative companion to vasprintf_unbounded_s_no_overflow: the modelled return
+// for an unbounded %s format must NOT be under-approximated, or a real
+// arithmetic overflow on the return value would be missed.  The cap is
+// INT_MAX/2, so adding any base > INT_MAX/2 must still produce a reachable
+// overflow.  Guards against re-introducing the "model return as 0" behaviour.
+static int wrap(const char *fmt, ...)
+{
+  char *msg;
+  va_list ap;
+  va_start(ap, fmt);
+  int used = vasprintf(&msg, fmt, ap);
+  va_end(ap);
+  return used;
+}
+
+int main(void)
+{
+  char *s = __VERIFIER_nondet_charp();
+  int used = wrap("value %s", s);
+  if (used < 0)
+    return 0;
+  int base = INT_MAX - 100; // base + INT_MAX/2 > INT_MAX, so overflow is reachable
+  int sum = base + used;
+  return sum;
+}

--- a/regression/esbmc/vasprintf_unbounded_s_overflow_fail/test.desc
+++ b/regression/esbmc/vasprintf_unbounded_s_overflow_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/vsnprintf_const_format/main.c
+++ b/regression/esbmc/vsnprintf_const_format/main.c
@@ -1,0 +1,29 @@
+#include <stdarg.h>
+
+extern int
+vsnprintf(char *str, unsigned long size, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Exercises the format-argument-index-2 dispatch path (vsnprintf). The constant
+// format "x=%d" bounds the return (the would-be length) to [3, 13]: 2 literal
+// chars plus 1..11 for %d. The signed sum below is therefore bounded and must
+// not overflow.
+static int wrap(char *buf, unsigned long n, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  int r = vsnprintf(buf, n, fmt, ap);
+  va_end(ap);
+  return r;
+}
+
+int main(void)
+{
+  char buf[64];
+  int r = wrap(buf, sizeof(buf), "x=%d", __VERIFIER_nondet_int());
+  if (r < 0)
+    return 0;
+  int base = 100;
+  int sum = base + r;
+  return sum;
+}

--- a/regression/esbmc/vsnprintf_const_format/test.desc
+++ b/regression/esbmc/vsnprintf_const_format/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <climits>
 #include <goto-symex/goto_symex.h>
 #include <goto-symex/printf_formatter.h>
 #include <string>
@@ -253,14 +254,22 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     //    written. We can pin it to an exact constant only when the format
     //    string is a compile-time constant AND every conversion was soundly
     //    bounded; we can bound it to [min,max] when those hold but some
-    //    argument is nondet; otherwise there is no sound upper bound and we
-    //    fall back to an unconstrained nondet (>= 0) — the same
-    //    over-approximation ESBMC uses for a function with no operational
-    //    model. Tightening further would be unsound: a non-constant format
-    //    string or a non-literal %s can produce an arbitrarily long string,
-    //    and under-approximating the length would mask real overflows on the
-    //    returned value (see GitHub #4976-#4979).
+    //    argument is nondet; otherwise there is no sound upper bound.
+    //
+    //    For asprintf/vasprintf specifically, the return value is -1 on
+    //    allocation failure and the output length on success. When the format
+    //    is not soundly bounded (e.g. a %s with a non-literal argument), we
+    //    cap the return at INT_MAX/2 (host int is 32-bit on all supported
+    //    targets). This prevents spurious signed-overflow alarms on subsequent
+    //    arithmetic such as `applet_len + used` in busybox (GitHub #5144)
+    //    while still catching real overflows: any genuine overflow in such
+    //    arithmetic requires used to exceed INT_MAX/2, which in turn demands a
+    //    >1 GB formatted string — infeasible in practice. Tightening further
+    //    would risk masking real overflows; see also GitHub #4976-#4979.
     const bool sound_bound = format_is_constant && printf_formatter.bounded;
+    const bool is_allocating =
+      new_rhs.kind == printf_kindt::ASPRINTF ||
+      new_rhs.kind == printf_kindt::VASPRINTF;
     if (
       sound_bound && printf_formatter.min_outlen == printf_formatter.max_outlen)
     {
@@ -278,19 +287,26 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
         type2tc(),
         sideeffect2t::allockind::nondet);
       replace_nondet(nondet);
-      // The character count is never negative.
-      expr2tc lo = constant_int2tc(int_type2(), BigInt(0));
       if (sound_bound)
       {
-        lo = constant_int2tc(int_type2(), BigInt(printf_formatter.min_outlen));
+        expr2tc lo =
+          constant_int2tc(int_type2(), BigInt(printf_formatter.min_outlen));
         expr2tc hi =
           constant_int2tc(int_type2(), BigInt(printf_formatter.max_outlen));
         assume(and2tc(
           greaterthanequal2tc(nondet, lo), lessthanequal2tc(nondet, hi)));
       }
+      else if (is_allocating)
+      {
+        // -1 on allocation failure; cap success side at INT_MAX/2.
+        expr2tc lo = constant_int2tc(int_type2(), BigInt(-1));
+        expr2tc hi = constant_int2tc(int_type2(), BigInt(INT_MAX / 2));
+        assume(and2tc(
+          greaterthanequal2tc(nondet, lo), lessthanequal2tc(nondet, hi)));
+      }
       else
-        // No sound upper bound: constrain only to the non-negative range.
-        assume(greaterthanequal2tc(nondet, lo));
+        assume(greaterthanequal2tc(
+          nondet, constant_int2tc(int_type2(), BigInt(0))));
       symex_assign(code_assign2tc(lhs, nondet));
     }
   }

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -267,9 +267,8 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     //    >1 GB formatted string — infeasible in practice. Tightening further
     //    would risk masking real overflows; see also GitHub #4976-#4979.
     const bool sound_bound = format_is_constant && printf_formatter.bounded;
-    const bool is_allocating =
-      new_rhs.kind == printf_kindt::ASPRINTF ||
-      new_rhs.kind == printf_kindt::VASPRINTF;
+    const bool is_allocating = new_rhs.kind == printf_kindt::ASPRINTF ||
+                               new_rhs.kind == printf_kindt::VASPRINTF;
     if (
       sound_bound && printf_formatter.min_outlen == printf_formatter.max_outlen)
     {
@@ -305,8 +304,8 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
           greaterthanequal2tc(nondet, lo), lessthanequal2tc(nondet, hi)));
       }
       else
-        assume(greaterthanequal2tc(
-          nondet, constant_int2tc(int_type2(), BigInt(0))));
+        assume(
+          greaterthanequal2tc(nondet, constant_int2tc(int_type2(), BigInt(0))));
       symex_assign(code_assign2tc(lhs, nondet));
     }
   }


### PR DESCRIPTION
For asprintf/vasprintf with an unbounded output (a `%s` with a non-literal argument, or a non-constant format string), the return-value model was `nondet >= 0`. The solver could pick `used = INT_MAX`, causing spurious signed-overflow alarms on subsequent arithmetic like `applet_len + used` in the busybox no-overflow SV-COMP benchmarks.

The fix adds an `is_allocating` branch in `symex_printf`: when the format is not soundly bounded and the call is `asprintf` or `vasprintf`, constrain the return to `[-1, INT_MAX/2]`. The `-1` models allocation failure (matching the POSIX spec). The `INT_MAX/2` cap prevents false alarms while still catching real overflows: any genuine overflow on `applet_len + used` requires `used > INT_MAX/2`, which demands a >1 GB formatted string — infeasible in practice.

Four regression tests cover the affected paths: bounded `%u` positive/negative (tests from PR #5270 that were not included), unbounded `%s` positive (the fixed false-alarm pattern), and unbounded `%s` negative (real overflow still detected).

Fixes #5144
