### PR TITLE
[symex] model *strp heap allocation for asprintf/vasprintf

### DIFF
--- a/regression/esbmc/asprintf_const_format_exact/main.c
+++ b/regression/esbmc/asprintf_const_format_exact/main.c
@@ -6,9 +6,9 @@
 // return value for a constant format with no conversion specifiers (5 chars).
 // The subsequent addition cannot overflow, so verification must succeed.
 //
-// Note: the symex_printf model does not allocate the output buffer pointed to
-// by *strp — only the return length is modelled.  We avoid dereferencing or
-// freeing the result pointer to stay within the modelled behaviour.
+// The symex_printf model also allocates a 1-byte tracked heap buffer for *strp
+// (GitHub #5139/#5141 fix). We avoid dereferencing with exact-size checks
+// since the buffer is modelled as 1 byte regardless of format length.
 int main(void)
 {
   char *s = NULL;

--- a/regression/esbmc/github_5139/main.c
+++ b/regression/esbmc/github_5139/main.c
@@ -1,0 +1,44 @@
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Regression test for GitHub #5139: with --add-symex-value-sets, an unmodeled
+// *strp from vasprintf caused the resulting nondet pointer to appear in the
+// value-sets of other pointers, producing spurious memsafety false alarms on
+// subsequent pointer operations. The fix models *strp as a fresh tracked heap
+// allocation, eliminating the aliasing.
+static void format_and_use(const char *s, va_list p)
+{
+  char *msg;
+  int used = vasprintf(&msg, s, p);
+  if (used < 0)
+    return;
+
+  // Appending some extra length — mirrors the busybox bb_verror_msg pattern
+  // that triggered the original false alarm.
+  int extra = __VERIFIER_nondet_int();
+  if (extra < 0 || extra > 100)
+    extra = 0;
+  char *buf = (char *)realloc(msg, (size_t)(used + extra + 1));
+  if (buf)
+    free(buf);
+  else
+    free(msg);
+}
+
+void wrapper(const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  format_and_use(fmt, ap);
+  va_end(ap);
+}
+
+int main(void)
+{
+  wrapper("value: %d", __VERIFIER_nondet_int());
+  return 0;
+}

--- a/regression/esbmc/github_5139/test.desc
+++ b/regression/esbmc/github_5139/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --force-malloc-success --force-realloc-success --add-symex-value-sets --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5141/main.c
+++ b/regression/esbmc/github_5141/main.c
@@ -1,0 +1,33 @@
+#include <stdarg.h>
+#include <stdlib.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Regression test for GitHub #5141: after vasprintf the buffer pointer *strp
+// must be a valid tracked heap allocation so that free(*strp) is sound.
+// Before the fix, symex_printf did not model *strp, leaving it as a nondet
+// value; ESBMC then reported a memsafety violation on free(msg) because the
+// pointer was not in the tracked malloc set.
+static void format_msg(const char *s, va_list p)
+{
+  char *msg;
+  int used = vasprintf(&msg, s, p);
+  if (used < 0)
+    return;
+  free(msg);
+}
+
+void wrapper(const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  format_msg(fmt, ap);
+  va_end(ap);
+}
+
+int main(void)
+{
+  wrapper("hello %d", __VERIFIER_nondet_int());
+  return 0;
+}

--- a/regression/esbmc/github_5141/test.desc
+++ b/regression/esbmc/github_5141/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --force-malloc-success --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -196,6 +196,17 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     }
   }
 
+  // For asprintf/vasprintf, save the char **strp argument (operand[0])
+  // before erasing the leading arguments so we can later model the side-effect
+  // on *strp. Without this, *strp keeps its uninitialized nondet value, causing
+  // value-set aliasing and spurious memsafety false alarms (GitHub #5139,
+  // #5140, #5141).
+  const bool is_allocating = new_rhs.kind == printf_kindt::ASPRINTF ||
+                             new_rhs.kind == printf_kindt::VASPRINTF;
+  expr2tc strp;
+  if (is_allocating && !new_rhs.operands.empty())
+    strp = new_rhs.operands[0];
+
   // Now we pop the format
   for (size_t i = 0; i < idx; i++)
     new_rhs.operands.erase(new_rhs.operands.begin());
@@ -293,6 +304,28 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
         assume(greaterthanequal2tc(nondet, lo));
       symex_assign(code_assign2tc(lhs, nondet));
     }
+  }
+
+  // Model *strp for asprintf/vasprintf: assign a fresh tracked heap allocation.
+  // The buffer size is modelled as 1 byte; exact sizing requires va_list
+  // recovery (G-C, not yet implemented). With --no-bounds-check this is
+  // sufficient to eliminate the false alarms while exact size analysis is
+  // deferred. Users running with --bounds-check should be aware of this
+  // limitation.
+  if (is_allocating && !is_nil_expr(strp) && is_pointer_type(strp->type))
+  {
+    // Derive char * from strp's declared type (char **) so the dereference
+    // width matches what the value-set analysis and SMT encoding expect.
+    type2tc char_ptr_type = to_pointer_type(strp->type).subtype;
+    expr2tc deref_strp = dereference2tc(char_ptr_type, strp);
+    expr2tc malloc_se = sideeffect2tc(
+      char_ptr_type,
+      expr2tc(),
+      constant_int2tc(size_type2(), BigInt(1)),
+      std::vector<expr2tc>(),
+      char_type2(),
+      sideeffect2t::allockind::malloc);
+    symex_assign(code_assign2tc(deref_strp, malloc_se));
   }
 
   target->output(


### PR DESCRIPTION
After PR #5270 wired asprintf/vasprintf into symex_printf, the return length
was modelled but the char **strp side-effect was not. The *strp pointer kept
its uninitialised nondet value, causing value-set aliasing and spurious
memsafety false alarms on free(*strp) in busybox bb_verror_msg.

Root cause: symex_printf erased operands[0] (char **strp) before recording
it; downstream pointer operations on the unmodelled *strp produced nondet
aliases visible to --add-symex-value-sets, triggering invalid-pointer and
memory-leak claims.

Fix: save operands[0] as strp before the erase, then assign *strp = malloc(1)
as a fresh tracked heap object after the return-value model. Buffer size is
1 byte (sound underapproximation for --no-bounds-check; exact sizing deferred
to G-C va_list recovery). Added github_5139 and github_5141 regression tests.

Fixes #5139
Fixes #5140
Fixes #5141