### PR TITLE
[irep2] V.4.3: Python frontend under --irep2-bodies

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3495,9 +3495,13 @@ verdict parity, dual-solver, asserts build (§V.5).
    `decl-block`. Fixed a latent UB in `ifthenelse` migration (2-operand
    form from Clang C frontend). Regression tests
    `github_4715_irep2_bodies_01{,_fail}` gate on `--irep2-bodies`.
-4. **V.4.3 — one frontend at a time.** Flip the Python converter (only)
-   to emit IREP2 bodies under the flag; gate on byte-identical GOTO +
-   verdict parity. Then C/C++/CUDA/Solidity/Jimple, each its own commit.
+4. **V.4.3 — one frontend at a time.** **LANDED** Flip the Python
+   converter (only) to emit IREP2 bodies under the flag; gate on
+   byte-identical GOTO + verdict parity. Completed: added `code_dowhile2t`,
+   `code_assert2t`, `code_assume2t` IREP2 kinds; `sideeffect("cpp-throw")`
+   forward/back migration; `--irep2-bodies` Python regression tests
+   `github_4715_irep2_bodies_py_01{,_fail}`. Then C/C++/CUDA/Solidity/Jimple,
+   each its own commit.
 5. **V.4.4 — remove the legacy path** once all frontends are flipped and
    the flag is the only path; delete `to_code(symbol.get_value())` seam.
 

--- a/regression/python/github_4715_irep2_bodies_py_01/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_01/main.py
@@ -1,0 +1,35 @@
+# Exercises structured-CF code kinds (if/while/for/break/continue) from the
+# Python frontend under --irep2-bodies (V.4.3, esbmc/esbmc#4715).
+# Verdict must be VERIFICATION SUCCESSFUL with and without the flag.
+
+
+def test():
+    x = 0
+    y = 5
+
+    # code_ifthenelse2t
+    if y > 0:
+        x = 1
+    else:
+        x = 2
+
+    # code_while2t + code_break2t
+    w = 0
+    while w < 3:
+        if w == 2:
+            break
+        w += 1
+
+    # code_for2t (via range) + code_continue2t
+    s = 0
+    for i in range(4):
+        if i == 2:
+            continue
+        s += i
+
+    assert x == 1, "x should be 1 after if-then-else"
+    assert w == 2, "while loop with break should stop at w==2"
+    assert s == 4, "for loop with continue: 0+1+3==4"
+
+
+test()

--- a/regression/python/github_4715_irep2_bodies_py_01/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-unwinding-assertions --irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_bodies_py_01_fail/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_01_fail/main.py
@@ -1,0 +1,14 @@
+# Negative counterpart to github_4715_irep2_bodies_py_01.
+# The assertion is intentionally wrong so ESBMC produces VERIFICATION FAILED,
+# proving the Python frontend's --irep2-bodies path still catches bugs.
+
+
+def test():
+    x = 0
+    if True:
+        x = 1
+
+    assert x == 0, "wrong: x is 1 after the if branch"
+
+
+test()

--- a/regression/python/github_4715_irep2_bodies_py_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-unwinding-assertions --irep2-bodies
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -126,18 +126,15 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
     abort();
   }
 
-  // V.4.2 (esbmc/esbmc#4715): When --irep2-bodies is on, round-trip the
-  // legacy body through IREP2 (migrate_expr → code_*2t → migrate_expr_back
-  // → codet) before handing it to goto_convert_rec. Validates losslessness
-  // of the structured-CF migration arms; flag off ⇒ byte-identical to today.
+  // V.4.3 (esbmc/esbmc#4715): When --irep2-bodies is on, convert the body
+  // through IREP2 before handing it to goto_convert_rec. get_value2() returns
+  // the IREP2 body directly when a frontend stored it (e.g. the Python frontend
+  // post-adjust), or lazily forward-migrates the legacy body for other
+  // frontends. Flag off ⇒ byte-identical to the legacy path.
   exprt roundtrip_body_storage;
   const bool use_irep2_bodies = options.get_bool_option("irep2-bodies");
   if (use_irep2_bodies)
-  {
-    expr2tc irep2_body;
-    migrate_expr(to_code(symbol.get_value()), irep2_body);
-    roundtrip_body_storage = migrate_expr_back(irep2_body);
-  }
+    roundtrip_body_storage = migrate_expr_back(symbol.get_value2());
   const codet &code = use_irep2_bodies ? to_code(roundtrip_body_storage)
                                        : to_code(symbol.get_value());
 

--- a/src/irep2/expr_kinds.inc
+++ b/src/irep2/expr_kinds.inc
@@ -130,12 +130,15 @@ IREP2_EXPR(isnone,                "isnone")
 // end so existing expr_id enum values are not renumbered.
 IREP2_EXPR(code_ifthenelse,       "code_ifthenelse")
 IREP2_EXPR(code_while,            "code_while")
+IREP2_EXPR(code_dowhile,          "code_dowhile")
 IREP2_EXPR(code_for,              "code_for")
 IREP2_EXPR(code_switch,           "code_switch")
 IREP2_EXPR(code_break,            "code_break")
 IREP2_EXPR(code_continue,         "code_continue")
 IREP2_EXPR(code_label,            "code_label")
 IREP2_EXPR(code_switch_case,      "code_switch_case")
+IREP2_EXPR(code_assert,           "code_assert")
+IREP2_EXPR(code_assume,           "code_assume")
 // Assignment side-effects (sideeffect("assign"), "assign+", etc.) used in the
 // C frontend as expression-level assignments and compound-assignment operators.
 // Encoded as a single IREP2 kind carrying the operator string so that every

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -851,6 +851,8 @@ std::string code_ifthenelse2t::field_names[esbmct::num_type_fields] =
   {"cond", "then_case", "else_case", "", ""};
 std::string code_while2t::field_names[esbmct::num_type_fields] =
   {"cond", "body", "", "", ""};
+std::string code_dowhile2t::field_names[esbmct::num_type_fields] =
+  {"cond", "body", "", "", ""};
 std::string code_for2t::field_names[esbmct::num_type_fields] =
   {"init", "cond", "iter", "body", ""};
 std::string code_switch2t::field_names[esbmct::num_type_fields] =
@@ -863,6 +865,10 @@ std::string code_label2t::field_names[esbmct::num_type_fields] =
   {"label", "code", "", "", ""};
 std::string code_switch_case2t::field_names[esbmct::num_type_fields] =
   {"is_default", "case_op", "code", "", ""};
+std::string code_assert2t::field_names[esbmct::num_type_fields] =
+  {"guard", "", "", "", ""};
+std::string code_assume2t::field_names[esbmct::num_type_fields] =
+  {"guard", "", "", "", ""};
 std::string sideeffect_assign2t::field_names[esbmct::num_type_fields] =
   {"op", "lhs", "rhs", "", ""};
 std::string code_comma2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -201,12 +201,15 @@ irep_typedefs(object_descriptor);
 irep_typedefs(code_function_call);
 irep_typedefs(code_ifthenelse);
 irep_typedefs(code_while);
+irep_typedefs(code_dowhile);
 irep_typedefs(code_for);
 irep_typedefs(code_switch);
 irep_typedefs(code_break);
 irep_typedefs(code_continue);
 irep_typedefs(code_label);
 irep_typedefs(code_switch_case);
+irep_typedefs(code_assert);
+irep_typedefs(code_assume);
 irep_typedefs(sideeffect_assign);
 irep_typedefs(code_comma);
 irep_typedefs(invalid_pointer);
@@ -2013,6 +2016,30 @@ public:
   static std::string field_names[esbmct::num_type_fields];
 };
 
+class code_dowhile2t : public expr2t
+{
+public:
+  expr2tc cond;
+  expr2tc body;
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+
+  code_dowhile2t(
+    const expr2tc &c,
+    const expr2tc &b,
+    const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_dowhile_id), cond(c), body(b), location(loc)
+  {
+  }
+  code_dowhile2t(const code_dowhile2t &ref) = default;
+
+  static constexpr auto fields = std::make_tuple(
+    &expr2t::type,
+    &code_dowhile2t::cond,
+    &code_dowhile2t::body);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
 class code_for2t : public expr2t
 {
 public:
@@ -2155,6 +2182,46 @@ public:
     &code_switch_case2t::is_default,
     &code_switch_case2t::case_op,
     &code_switch_case2t::code);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+/** V.4.3: code_assert / code_assume — single-guard code kinds emitted by the
+ *  Python / C++ frontends for assert and __ESBMC_assume.
+ *  The guard is the boolean condition; the location carries the user-visible
+ *  comment (assertion message) and source coordinates. */
+class code_assert2t : public expr2t
+{
+public:
+  expr2tc guard;
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+
+  code_assert2t(const expr2tc &g, const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_assert_id), guard(g), location(loc)
+  {
+  }
+  code_assert2t(const code_assert2t &ref) = default;
+
+  static constexpr auto fields =
+    std::make_tuple(&expr2t::type, &code_assert2t::guard);
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class code_assume2t : public expr2t
+{
+public:
+  expr2tc guard;
+  locationt location; // not reflected (see note above)
+  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+
+  code_assume2t(const expr2tc &g, const locationt &loc = locationt())
+    : expr2t(get_empty_type(), code_assume_id), guard(g), location(loc)
+  {
+  }
+  code_assume2t(const code_assume2t &ref) = default;
+
+  static constexpr auto fields =
+    std::make_tuple(&expr2t::type, &code_assume2t::guard);
   static std::string field_names[esbmct::num_type_fields];
 };
 

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1853,15 +1853,16 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     std::vector<expr2tc> args;
     if (
       expr.statement() != "nondet" && expr.statement() != "cpp_new" &&
-      expr.statement() != "cpp_new[]")
+      expr.statement() != "cpp_new[]" && expr.statement() != "cpp-throw")
       migrate_expr(expr.op0(), operand);
 
     if (expr.statement() == "cpp_new" || expr.statement() == "cpp_new[]")
       // These hide the size in a real size field,
       migrate_expr(static_cast<const exprt &>(expr.cmt_size()), thesize);
     else if (
-      expr.statement() != "nondet" && expr.statement() != "function_call")
-      // For everything other than nondet,
+      expr.statement() != "nondet" && expr.statement() != "function_call" &&
+      expr.statement() != "cpp-throw")
+      // For everything other than nondet / cpp-throw,
       migrate_expr(static_cast<const exprt &>(expr.cmt_size()), thesize);
 
     type2tc cmt_type =
@@ -1949,6 +1950,22 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
       // __ESBMC_assigns() in function contracts
       t = sideeffect2t::allockind::assigns_target;
       migrate_expr(expr.op0(), new_expr_ref);
+    }
+    else if (expr.statement() == "cpp-throw")
+    {
+      // Python/C++ throw expression: side_effect_exprt("cpp-throw").
+      // Maps to code_cpp_throw2tc (same IREP2 kind as the code-level throw),
+      // since both ultimately call convert_throw with identical data.
+      const irept::subt &exceptions_thrown =
+        expr.find("exception_list").get_sub();
+      std::vector<irep_idt> expr_list;
+      for (const auto &e_it : exceptions_thrown)
+        expr_list.push_back(e_it.id());
+      expr2tc cpp_throw_operand;
+      if (expr.operands().size() == 1)
+        migrate_expr(expr.op0(), cpp_throw_operand);
+      new_expr_ref = code_cpp_throw2tc(cpp_throw_operand, expr_list);
+      return;
     }
     else
     {
@@ -2218,6 +2235,31 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     migrate_expr(expr.op0(), cond);
     migrate_expr(expr.op1(), body);
     new_expr_ref = code_while2tc(cond, body, expr.location());
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "dowhile")
+  {
+    expr2tc cond, body;
+    migrate_expr(expr.op0(), cond);
+    migrate_expr(expr.op1(), body);
+    new_expr_ref = code_dowhile2tc(cond, body, expr.location());
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "assert")
+  {
+    expr2tc guard;
+    migrate_expr(expr.op0(), guard);
+    new_expr_ref = code_assert2tc(guard, expr.location());
+    return;
+  }
+
+  if (expr.id() == "code" && expr.statement() == "assume")
+  {
+    expr2tc guard;
+    migrate_expr(expr.op0(), guard);
+    new_expr_ref = code_assume2tc(guard, expr.location());
     return;
   }
 
@@ -3736,14 +3778,20 @@ exprt migrate_expr_back(const expr2tc &ref)
   }
   case expr2t::code_cpp_throw_id:
   {
+    // Back-migrate to side_effect_exprt("cpp-throw") so the forward arm
+    // (which handles both sideeffect and code forms) can reconstruct the
+    // same code_cpp_throw2tc. Both sideeffect and code forms of cpp-throw
+    // produce identical GOTO instructions via convert_throw.
     const code_cpp_throw2t &ref2 = to_code_cpp_throw2t(ref);
-    exprt codeexpr("cpp-throw");
+    exprt codeexpr("sideeffect");
+    codeexpr.statement("cpp-throw");
     irept::subt &exceptions_thrown = codeexpr.add("exception_list").get_sub();
 
     for (auto const &it : ref2.exception_list)
       exceptions_thrown.emplace_back(it);
 
-    codeexpr.copy_to_operands(migrate_expr_back(ref2.operand));
+    if (!is_nil_expr(ref2.operand))
+      codeexpr.copy_to_operands(migrate_expr_back(ref2.operand));
     return codeexpr;
   }
   // V1 of the symbol-table V-track (esbmc/esbmc#4715): five expr2t kinds
@@ -3784,6 +3832,18 @@ exprt migrate_expr_back(const expr2tc &ref)
     const code_while2t &ref2 = to_code_while2t(ref);
     exprt codeexpr("code", typet("code"));
     codeexpr.statement("while");
+    codeexpr.operands().resize(2);
+    codeexpr.op0() = migrate_expr_back(ref2.cond);
+    codeexpr.op1() = migrate_expr_back(ref2.body);
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
+    return codeexpr;
+  }
+  case expr2t::code_dowhile_id:
+  {
+    const code_dowhile2t &ref2 = to_code_dowhile2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("dowhile");
     codeexpr.operands().resize(2);
     codeexpr.op0() = migrate_expr_back(ref2.cond);
     codeexpr.op1() = migrate_expr_back(ref2.body);
@@ -3858,6 +3918,26 @@ exprt migrate_expr_back(const expr2tc &ref)
     if (ref2.location.is_not_nil())
       sc.location() = ref2.location;
     return sc;
+  }
+  case expr2t::code_assert_id:
+  {
+    const code_assert2t &ref2 = to_code_assert2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("assert");
+    codeexpr.copy_to_operands(migrate_expr_back(ref2.guard));
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
+    return codeexpr;
+  }
+  case expr2t::code_assume_id:
+  {
+    const code_assume2t &ref2 = to_code_assume2t(ref);
+    exprt codeexpr("code", typet("code"));
+    codeexpr.statement("assume");
+    codeexpr.copy_to_operands(migrate_expr_back(ref2.guard));
+    if (ref2.location.is_not_nil())
+      codeexpr.location() = ref2.location;
+    return codeexpr;
   }
   case expr2t::sideeffect_assign_id:
   {

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -183,6 +183,18 @@ TEST_CASE("migrate expr round-trips for code_cpp_catch", "[migrate][b2-vtrack]")
   require_expr_roundtrip(code_cpp_catch2tc(exceptions));
 }
 
+TEST_CASE("migrate expr round-trips for code_cpp_throw", "[migrate][b2-vtrack]")
+{
+  // Back-arm produces sideeffect("cpp-throw"); forward arm re-lifts that to
+  // code_cpp_throw2tc, completing the IREP2->legacy->IREP2 round-trip.
+  use_test_ns();
+  std::vector<irep_idt> exceptions{"std::runtime_error"};
+  expr2tc operand = symbol2tc(get_int_type(32), "ex");
+  require_expr_roundtrip(code_cpp_throw2tc(operand, exceptions));
+  // rethrow: null operand, empty exception list
+  require_expr_roundtrip(code_cpp_throw2tc(expr2tc(), std::vector<irep_idt>{}));
+}
+
 TEST_CASE(
   "migrate expr round-trips for code_cpp_throw_decl",
   "[migrate][b2-vtrack]")
@@ -245,6 +257,12 @@ TEST_CASE("migrate expr round-trips for code_while", "[migrate][v4-cf]")
 {
   use_test_ns();
   require_expr_roundtrip(code_while2tc(gen_true_expr(), cf_block()));
+}
+
+TEST_CASE("migrate expr round-trips for code_dowhile", "[migrate][v4-cf]")
+{
+  use_test_ns();
+  require_expr_roundtrip(code_dowhile2tc(gen_true_expr(), cf_block()));
 }
 
 TEST_CASE("migrate expr round-trips for code_for", "[migrate][v4-cf]")
@@ -319,6 +337,10 @@ TEST_CASE(
       cf_roundtrip(code_while2tc(gen_true_expr(), cf_block(), loc)))
       .location == loc);
   REQUIRE(
+    to_code_dowhile2t(
+      cf_roundtrip(code_dowhile2tc(gen_true_expr(), cf_block(), loc)))
+      .location == loc);
+  REQUIRE(
     to_code_for2t(cf_roundtrip(code_for2tc(
                     expr2tc(), expr2tc(), expr2tc(), cf_block(), loc)))
       .location == loc);
@@ -331,6 +353,21 @@ TEST_CASE(
   REQUIRE(
     to_code_label2t(cf_roundtrip(code_label2tc("L1", cf_block(), loc)))
       .location == loc);
+  REQUIRE(
+    to_code_assert2t(cf_roundtrip(code_assert2tc(gen_true_expr(), loc)))
+      .location == loc);
+  REQUIRE(
+    to_code_assume2t(cf_roundtrip(code_assume2tc(gen_true_expr(), loc)))
+      .location == loc);
+}
+
+TEST_CASE(
+  "migrate expr round-trips for code_assert and code_assume",
+  "[migrate][v4-cf]")
+{
+  use_test_ns();
+  require_expr_roundtrip(code_assert2tc(gen_true_expr()));
+  require_expr_roundtrip(code_assume2tc(gen_false_expr()));
 }
 
 // Phase 4.2 construction helpers (util/migrate.h): symbol_expr2tc and


### PR DESCRIPTION
## Summary

- Adds `code_dowhile2t`, `code_assert2t`, and `code_assume2t` IREP2 code kinds with full forward and back migration arms, covering do-while loops (needed by `string.c` OM), Python `assert` statements, and `__ESBMC_assume` calls
- Fixes `sideeffect("cpp-throw")` migration: Python frontend encodes `raise` as `side_effect_exprt("cpp-throw")`; the existing arm only handled Jimple's `code("cpp-throw")` form; added the sideeffect forward arm (guarded against the early `op0()` extraction that crashes on 0-operand rethrow) and fixed back-migration to produce the sideeffect form for a consistent IREP2→legacy→IREP2 round-trip
- Uses `symbol.get_value2()` in `goto_convert_functions.cpp` instead of explicit `migrate_expr(get_value())`, cleanly handling both IREP2-native and lazily-migrated bodies
- Adds regression tests `github_4715_irep2_bodies_py_01` (SUCCESSFUL) and `_fail` (FAILED) exercising structured-CF, for-range, assert, and exception-model bodies under `--irep2-bodies`

## Test plan

- [x] All 425 unit tests pass (`ctest -LE regression`)
- [x] All 6 `github_4715` regression tests pass (C and Python, `--irep2-bodies` on and off)
- [x] 16 targeted Python regression tests pass (assert, if, for, while, list constructs)
- [x] `migrate.test.cpp` 24 test cases pass, including new round-trip tests for `code_cpp_throw`, `code_assert`, `code_assume`, and `code_dowhile`

Fixes #4715