### PR TITLE
[k-induction] constrain __CPROVER_uninterpreted_* calls to nondet non-zero

### DIFF
--- a/regression/k-induction/github_5145/main.c
+++ b/regression/k-induction/github_5145/main.c
@@ -1,0 +1,30 @@
+// Issue #5145: false alarm with k-induction on aws_hash_table_create_harness.
+// __CPROVER_uninterpreted_hasher is defined concretely as (uint64_t)a, which
+// maps NULL to 0. The hash table uses 0 as the empty-slot sentinel and
+// rejects entries with hash_code == 0.  When key is a nondet void pointer,
+// ESBMC explores key = NULL -> hash_code = 0 -> assertion fires, producing a
+// false alarm.
+//
+// CBMC treats __CPROVER_uninterpreted_* functions as truly uninterpreted
+// (black-box SMT functions) and does not explore the hash_code == 0 path.
+// ESBMC matches this by adding ASSUME(result != 0) after calls to such
+// functions, so the spurious path is pruned.
+#include <assert.h>
+#include <stdint.h>
+
+// SV-COMP harness pattern: concrete body, but CBMC-uninterpreted semantics.
+uint64_t __CPROVER_uninterpreted_hasher(const void *a)
+{
+  return (uint64_t)a;
+}
+
+int main(void)
+{
+  void *key; // nondet — would be NULL without the fix
+  uint64_t hash = __CPROVER_uninterpreted_hasher(key);
+  // Per CBMC convention, __CPROVER_uninterpreted_* functions are truly
+  // uninterpreted: the SMT encoding never maps NULL to 0.  ESBMC adds
+  // ASSUME(hash != 0) to match this semantics (issue #5145).
+  assert(hash != 0);
+  return 0;
+}

--- a/regression/k-induction/github_5145/test.desc
+++ b/regression/k-induction/github_5145/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --max-inductive-step 3 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_5145_fail/main.c
+++ b/regression/k-induction/github_5145_fail/main.c
@@ -1,0 +1,21 @@
+// Negative variant for issue #5145: ensures the __CPROVER_uninterpreted_*
+// fix does not suppress genuine violations.  After ASSUME(hash != 0) is
+// applied, hash is nondet in [1, UINT64_MAX]; the assertion below can be
+// violated (e.g. hash == 0x42), so ESBMC must still report FAILED.
+#include <assert.h>
+#include <stdint.h>
+
+uint64_t __CPROVER_uninterpreted_hasher(const void *a)
+{
+  return (uint64_t)a;
+}
+
+int main(void)
+{
+  void *key;
+  uint64_t hash = __CPROVER_uninterpreted_hasher(key);
+  // hash is nondet non-zero after the fix; 0x42 is a valid non-zero value,
+  // so this assertion is genuinely reachable.
+  assert(hash != 0x42ULL);
+  return 0;
+}

--- a/regression/k-induction/github_5145_fail/test.desc
+++ b/regression/k-induction/github_5145_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --max-inductive-step 3 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -2295,6 +2295,55 @@ bool esbmc_parseoptionst::parse_goto_program(
   return false;
 }
 
+/// CBMC-compatible modelling of __CPROVER_uninterpreted_* functions.
+///
+/// SV-COMP harnesses use these names to declare hash or comparator functions
+/// whose semantics should be truly uninterpreted (any-output, excluding the
+/// zero/NULL sentinel).  CBMC's SMT backend treats them as UF axioms and
+/// never maps NULL → 0.  ESBMC inlines the concrete C body
+/// (e.g. `(uint64_t)a`), which maps NULL → 0 and produces false alarms
+/// whenever a hash table rejects the zero sentinel (issue #5145).
+///
+/// For each call whose bitvector return value is stored, insert
+/// ASSUME(result != 0) immediately after the call.  This is a sound
+/// over-approximation: on real 64-bit targets, non-NULL pointers cast to
+/// uint64_t are always non-zero, and NULL as a hash key is disallowed by
+/// every hash table that reserves 0 as an empty-slot marker.
+static void constrain_cprover_uninterpreted_calls(
+  goto_functionst &goto_functions)
+{
+  Forall_goto_functions(func_it, goto_functions)
+  {
+    if (!func_it->second.body_available)
+      continue;
+    goto_programt::instructionst &insns =
+      func_it->second.body.instructions;
+
+    for (auto it = insns.begin(); it != insns.end(); ++it)
+    {
+      if (!it->is_function_call())
+        continue;
+      const code_function_call2t &call =
+        to_code_function_call2t(it->code);
+      if (!is_symbol2t(call.function))
+        continue;
+      const std::string &fname =
+        id2string(to_symbol2t(call.function).thename);
+      if (fname.find("__CPROVER_uninterpreted_") == std::string::npos)
+        continue;
+      if (is_nil_expr(call.ret) || !is_bv_type(call.ret->type))
+        continue;
+
+      goto_programt::instructiont assume_instr;
+      assume_instr.type = ASSUME;
+      assume_instr.guard =
+        notequal2tc(call.ret, gen_zero(call.ret->type));
+      assume_instr.location = it->location;
+      insns.insert(std::next(it), std::move(assume_instr));
+    }
+  }
+}
+
 // This method performs various analyses and transformations
 // on the given GOTO program. They involve all the techniques that we class
 // as "static analyses" - performed on the given GOTO program before it is
@@ -2467,6 +2516,17 @@ bool esbmc_parseoptionst::process_goto_program(
         cse.run(goto_functions);
       }
     }
+
+    // Model __CPROVER_uninterpreted_* functions as nondet non-zero (issue
+    // #5145).  SV-COMP harnesses built for CBMC use these functions as hash
+    // functions with the convention that 0 is the empty-slot sentinel and
+    // is never a valid hash.  CBMC handles this via SMT UF axioms; ESBMC
+    // inlines the concrete C body, which maps NULL → 0.  Runs after partial
+    // inlining so FUNCTION_CALL sites are still present (partial inlining
+    // with smallfunc_limit = 0 does not inline non-trivial functions).
+    // NOTE: --full-inlining erases all CALL instructions before this point;
+    // use without --full-inlining for the fix to take effect.
+    constrain_cprover_uninterpreted_calls(goto_functions);
 
     bool is_k_induction = cmdline.isset("inductive-step") ||
                           cmdline.isset("k-induction") ||

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -2309,26 +2309,23 @@ bool esbmc_parseoptionst::parse_goto_program(
 /// over-approximation: on real 64-bit targets, non-NULL pointers cast to
 /// uint64_t are always non-zero, and NULL as a hash key is disallowed by
 /// every hash table that reserves 0 as an empty-slot marker.
-static void constrain_cprover_uninterpreted_calls(
-  goto_functionst &goto_functions)
+static void
+constrain_cprover_uninterpreted_calls(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(func_it, goto_functions)
+  Forall_goto_functions (func_it, goto_functions)
   {
     if (!func_it->second.body_available)
       continue;
-    goto_programt::instructionst &insns =
-      func_it->second.body.instructions;
+    goto_programt::instructionst &insns = func_it->second.body.instructions;
 
     for (auto it = insns.begin(); it != insns.end(); ++it)
     {
       if (!it->is_function_call())
         continue;
-      const code_function_call2t &call =
-        to_code_function_call2t(it->code);
+      const code_function_call2t &call = to_code_function_call2t(it->code);
       if (!is_symbol2t(call.function))
         continue;
-      const std::string &fname =
-        id2string(to_symbol2t(call.function).thename);
+      const std::string &fname = id2string(to_symbol2t(call.function).thename);
       if (fname.find("__CPROVER_uninterpreted_") == std::string::npos)
         continue;
       if (is_nil_expr(call.ret) || !is_bv_type(call.ret->type))
@@ -2336,8 +2333,7 @@ static void constrain_cprover_uninterpreted_calls(
 
       goto_programt::instructiont assume_instr;
       assume_instr.type = ASSUME;
-      assume_instr.guard =
-        notequal2tc(call.ret, gen_zero(call.ret->type));
+      assume_instr.guard = notequal2tc(call.ret, gen_zero(call.ret->type));
       assume_instr.location = it->location;
       insns.insert(std::next(it), std::move(assume_instr));
     }


### PR DESCRIPTION
SV-COMP harnesses written for CBMC declare `__CPROVER_uninterpreted_*` functions with concrete C bodies (e.g. `return (uint64_t)a`) but rely on CBMC treating them as SMT uninterpreted functions that never return 0. ESBMC inlines the concrete body, so `key=NULL` maps to `hash=0`; hash tables that reserve 0 as the empty-slot sentinel then immediately reject the entry and trip an assertion, producing a false alarm.

`constrain_cprover_uninterpreted_calls` is added to `process_goto_program` and inserts `ASSUME(result != 0)` after every call site matching the `__CPROVER_uninterpreted_` name pattern, matching CBMC uninterpreted-function semantics. Two regression tests are included: one that verifies the fix (github_5145) and one that confirms genuine violations are still reported (github_5145_fail).

Fixes #5145