### PR TITLE
[goto-symex] fix false data race from aliasing race-flag index

### DIFF
--- a/regression/esbmc/github_5137/main.c
+++ b/regression/esbmc/github_5137/main.c
@@ -1,0 +1,35 @@
+// Issue #5137: the data-race flag was indexed by a flat hash
+// `pointer_object * 1000 + pointer_offset`, so a write to a large array element
+// (offset >= 1000) spilled into another object's flag band and fabricated a
+// data race. Here `data` is written by exactly one thread and `arr[k]` by
+// another at a solver-chosen offset; the program is race-free and must verify.
+#include <pthread.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int data;
+int arr[4096];
+
+void *write_arr(void *p)
+{
+  unsigned k = __VERIFIER_nondet_uint();
+  if (k < 4096)
+    arr[k] = 1;
+  return 0;
+}
+
+void *write_data(void *p)
+{
+  data = 2;
+  return 0;
+}
+
+int main()
+{
+  pthread_t a, b;
+  pthread_create(&a, 0, write_arr, 0);
+  pthread_create(&b, 0, write_data, 0);
+  pthread_join(a, 0);
+  pthread_join(b, 0);
+  return 0;
+}

--- a/regression/esbmc/github_5137/test.desc
+++ b/regression/esbmc/github_5137/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check --context-bound 2 --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5137_fail/main.c
+++ b/regression/esbmc/github_5137_fail/main.c
@@ -1,0 +1,22 @@
+// Companion to github_5137: a genuine write/write race on a large-offset array
+// element. The packed race-flag index must still detect it (the fix must not
+// mask real races at large offsets).
+#include <pthread.h>
+
+int arr[4096];
+
+void *writer(void *p)
+{
+  arr[3000] = 1;
+  return 0;
+}
+
+int main()
+{
+  pthread_t a, b;
+  pthread_create(&a, 0, writer, 0);
+  pthread_create(&b, 0, writer, 0);
+  pthread_join(a, 0);
+  pthread_join(b, 0);
+  return 0;
+}

--- a/regression/esbmc/github_5137_fail/test.desc
+++ b/regression/esbmc/github_5137_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--data-races-check --context-bound 2 --unwind 2
+^VERIFICATION FAILED$
+^.*W/W data race on c:@arr.*$

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -3,6 +3,7 @@
 #include <goto-programs/rw_set.h>
 #include <pointer-analysis/value_sets.h>
 #include <util/expr_util.h>
+#include <util/migrate.h>
 #include <irep2/irep2_guard.h>
 #include <util/prefix.h>
 #include <util/std_expr.h>
@@ -14,46 +15,6 @@ class w_guardst
 public:
   explicit w_guardst(contextt &_context) : context(_context)
   {
-  }
-
-  std::list<irep_idt> w_guards;
-
-  const symbolt &
-  get_guard_symbol(const irep_idt &object, const exprt &original_expr)
-  {
-    const irep_idt identifier = "tmp_" + id2string(object);
-
-    const symbolt *s = context.find_symbol(identifier);
-    if (s != nullptr)
-      return *s;
-
-    w_guards.push_back(identifier);
-
-    type2tc index = array_type2tc(get_bool_type(), expr2tc(), true);
-
-    symbolt new_symbol;
-    new_symbol.id = identifier;
-    new_symbol.name = identifier;
-    set_symbol_type(
-      new_symbol, original_expr.is_index() ? index : get_bool_type());
-    new_symbol.static_lifetime = true;
-    {
-      exprt v = new_symbol.get_value();
-      v.make_false();
-      new_symbol.set_value(std::move(v));
-    }
-
-    symbolt *symbol_ptr;
-    context.move(new_symbol, symbol_ptr);
-    return *symbol_ptr;
-  }
-
-  expr2tc get_guard_symbol_expr(const expr2tc &original_expr)
-  {
-    // introduce a new expression: RACE_CHECK(&x)
-    // its operand is the address of the variable
-    // which we will replace during symbolic execution.
-    return races_check2tc(address_of2tc(original_expr->type, original_expr));
   }
 
   expr2tc get_w_guard_expr(const rw_sett::entryt &entry)
@@ -70,46 +31,40 @@ public:
 
 protected:
   contextt &context;
+
+  expr2tc get_guard_symbol_expr(const expr2tc &original_expr)
+  {
+    // Introduce a RACE_CHECK(&x) marker whose operand is the address of the
+    // accessed object; goto_symext::replace_races_check lowers it to the
+    // __ESBMC_races_flag slot for that (object, offset) during symbolic
+    // execution.
+    return races_check2tc(address_of2tc(original_expr->type, original_expr));
+  }
 };
 
 void w_guardst::add_initialization(goto_programt &goto_program)
 {
-  goto_programt::targett t = goto_program.instructions.begin();
-  const namespacet ns(context);
+  // __ESBMC_races_flag is an infinite array of booleans indexed by a unique
+  // (pointer object, byte offset) key (see goto_symext::replace_races_check).
+  // Declare it and reset every slot to false at program entry.
+  type2tc flag_type = array_type2tc(get_bool_type(), expr2tc(), true);
+  expr2tc all_false = constant_array_of2tc(flag_type, gen_false_expr());
 
-  // introduce new infinite array: __ESBMC_races_flag[]
-  // initialize it to zero: ARRAY_OF(0)
-  type2tc arrayt = array_type2tc(get_bool_type(), expr2tc(), true);
-  const irep_idt identifier = "c:@F@__ESBMC_races_flag";
-  w_guards.push_back(identifier);
   symbolt new_symbol;
-  new_symbol.id = identifier;
-  new_symbol.name = identifier;
-  set_symbol_type(new_symbol, arrayt);
+  new_symbol.id = "c:@F@__ESBMC_races_flag";
+  new_symbol.name = new_symbol.id;
+  set_symbol_type(new_symbol, flag_type);
   new_symbol.static_lifetime = true;
-  {
-    exprt v = new_symbol.get_value();
-    v.make_false();
-    new_symbol.set_value(std::move(v));
-  }
-  context.move_symbol_to_context(new_symbol);
+  new_symbol.set_value(migrate_expr_back(all_false));
+  const symbolt &flag = *context.move_symbol_to_context(new_symbol);
 
-  for (const auto &w_guard : w_guards)
-  {
-    const symbolt &s = *ns.lookup(w_guard);
-    exprt symbol = symbol_expr(s);
-    expr2tc new_sym;
-    migrate_expr(symbol, new_sym);
+  expr2tc flag_symbol;
+  migrate_expr(symbol_expr(flag), flag_symbol);
 
-    expr2tc falsity = s.get_type().is_array()
-                        ? gen_zero(migrate_symbol_type(s), true)
-                        : gen_false_expr();
-    t = goto_program.insert(t);
-    t->type = ASSIGN;
-    t->code = code_assign2tc(new_sym, falsity);
-
-    t++;
-  }
+  goto_programt::targett t =
+    goto_program.insert(goto_program.instructions.begin());
+  t->type = ASSIGN;
+  t->code = code_assign2tc(flag_symbol, all_false);
 }
 
 // Collect the root symbol of every object whose address is taken in `expr`,

--- a/src/goto-symex/builtin_functions/misc.cpp
+++ b/src/goto-symex/builtin_functions/misc.cpp
@@ -23,33 +23,43 @@ void goto_symext::replace_races_check(expr2tc &expr)
 
   if (is_races_check2t(expr))
   {
-    // replace with __ESBMC_races_flag[index]
+    // Replace RACE_CHECK(&x) with __ESBMC_races_flag[key(&x)].
     const races_check2t &obj = to_races_check2t(expr);
 
     expr2tc flag;
     migrate_expr(symbol_expr(*ns.lookup("c:@F@__ESBMC_races_flag")), flag);
 
-    expr2tc max_offset =
-      constant_int2tc(get_uint_type(config.ansi_c.address_width), 1000);
-    // The reason for not using address directly is that address
-    // is modeled as an nondet value, which depends on the address space constraints.
-    // VCC becomes complex and inefficient in this case.
+    // Index __ESBMC_races_flag by a word-sized key that packs the access's
+    // pointer object into the high half of the word and its (masked) byte offset
+    // into the low half: (object << word_size/2) | (offset & (2^(word_size/2)-1)).
+    // The races_flag array domain is the machine word, so the key must stay
+    // word-sized; placing the object in the high half and masking the offset to
+    // the low half guarantees an offset can never reach another object's bits.
+    // Distinct objects therefore never alias as long as the object number and
+    // the in-object offset each fit in word_size/2 bits -- which they do for the
+    // accesses these checks instrument. The previous encoding flattened the two
+    // into `object * 1000 + offset`, where any offset of 1000 or more (e.g. a
+    // write to arr[i] with a large i) spilled into the next object's band and
+    // fabricated a data race. See issue #5137.
+    //
+    // pointer_object/pointer_offset lower to projections of the pointer tuple,
+    // whose fields are address_width wide regardless of the type carried here;
+    // cast both to key_type so the bitwise ops below see matching widths even on
+    // data models where address_width != word_size (e.g. LP32).
+    unsigned int half = config.ansi_c.word_size / 2;
+    type2tc key_type = get_uint_type(config.ansi_c.word_size);
 
-    // The current method is similar to a two-dimensional array: array[obj][offset]
-    // But we flatten it out: obj * MAX_VALUE + offset
-    // In theory, this should create a unique index for variables.
-    // We need to think carefully about the value of MAX_VALUE
-    // XL: Should we let the user choose this value?
-    expr2tc mul = mul2tc(
-      size_type2(), pointer_object2tc(pointer_type2(), obj.value), max_offset);
-    expr2tc add = add2tc(
-      size_type2(),
-      mul,
-      pointer_offset2tc(get_int_type(config.ansi_c.address_width), obj.value));
+    expr2tc object =
+      typecast2tc(key_type, pointer_object2tc(ptraddr_type2(), obj.value));
+    expr2tc offset =
+      typecast2tc(key_type, pointer_offset2tc(ptraddr_type2(), obj.value));
+    expr2tc index = bitor2tc(
+      key_type,
+      shl2tc(key_type, object, constant_int2tc(key_type, BigInt(half))),
+      bitand2tc(
+        key_type, offset, constant_int2tc(key_type, BigInt::power2m1(half))));
 
-    expr2tc index_expr = index2tc(get_bool_type(), flag, add);
-
-    expr = index_expr;
+    expr = index2tc(get_bool_type(), flag, index);
   }
 }
 

--- a/src/goto-symex/builtin_functions/misc.cpp
+++ b/src/goto-symex/builtin_functions/misc.cpp
@@ -46,13 +46,19 @@ void goto_symext::replace_races_check(expr2tc &expr)
     // whose fields are address_width wide regardless of the type carried here;
     // cast both to key_type so the bitwise ops below see matching widths even on
     // data models where address_width != word_size (e.g. LP32).
+    //
+    // pointer_offset2t models a signed byte difference and asserts a signed
+    // address-width type, so build it with get_int_type, not the unsigned
+    // ptraddr_type2; the cast to the unsigned key_type and the low-half mask
+    // then discard the sign for the always-non-negative in-object offsets.
     unsigned int half = config.ansi_c.word_size / 2;
     type2tc key_type = get_uint_type(config.ansi_c.word_size);
 
     expr2tc object =
       typecast2tc(key_type, pointer_object2tc(ptraddr_type2(), obj.value));
-    expr2tc offset =
-      typecast2tc(key_type, pointer_offset2tc(ptraddr_type2(), obj.value));
+    expr2tc offset = typecast2tc(
+      key_type,
+      pointer_offset2tc(get_int_type(config.ansi_c.address_width), obj.value));
     expr2tc index = bitor2tc(
       key_type,
       shl2tc(key_type, object, constant_int2tc(key_type, BigInt(half))),


### PR DESCRIPTION
Fixes #5137.

ESBMC raised a spurious W/W data race because `__ESBMC_races_flag` was indexed by `object*1000 + offset`, so once a byte offset exceeded 1000 the bands of adjacent objects overlapped and distinct objects shared one in-flight-write flag. Index instead by a word-sized key that packs the pointer object into the high half and the masked offset into the low half, so an offset can never reach into the object bits and distinct objects no longer alias. Also removes the now-dead `get_guard_symbol`/`w_guards` machinery. Adds `github_5137` (race-free, SUCCESSFUL) and `github_5137_fail` (genuine large-offset race, FAILED) regression tests.