### PR TITLE
[SAFE-LD] Wire LD property verification end-to-end (WP2)

### DIFF
--- a/docs/safe-ld-implementation-plan.md
+++ b/docs/safe-ld-implementation-plan.md
@@ -1,9 +1,16 @@
 # SAFE-LD Implementation Plan: SMT-Based Formal Verification of Ladder Diagram Programs
 
-**Status:** PLANNING  
+**Status:** PLANNING — WP2 partially implemented (skeleton #5280, pipeline #5289)  
 **Project:** APP113435 — SAFE-LD (EPSRC Standard Research Grant)  
 **Tracking:** umbrella issue TBD  
 **Date:** 2026-06-09
+
+> **Implementation note.** The boolean/combinational Tier-1 subset now verifies
+> end-to-end (see §10). The integer-arithmetic constructs — TON/TOF/TP timers,
+> CTU/CTD counters, and the `response` property (auxiliary scan counter) — do
+> **not** yet work: they abort GOTO generation with an irep2 bit-width
+> assertion. Treat the timer/counter/response rows of the tables below as
+> *planned*, not *delivered*.
 
 ---
 
@@ -300,10 +307,32 @@ ld-verify [options] <program.xml> [--props <props.yaml>]
 ```
 
 Internally it invokes `esbmc` with the `.ld`-renamed input file and the configured
-strategy (default: `--k-induction --unlimited-k-steps --z3` with fallback to
-`--bmc --unwind 100`). Because SAFE-LD generates GOTO IR directly, ESBMC's clang
-front-end is **never invoked** — `ld_languaget::typecheck()` populates the `contextt`
-and control passes straight to symex.
+strategy. Because SAFE-LD generates GOTO IR directly, ESBMC's clang front-end is
+**never invoked** — `ld_languaget::typecheck()` populates the `contextt` and
+control passes straight to symex.
+
+**As implemented (#5289).** `LdVerifyRunner::run()`:
+
+- Stages a non-`.ld` input (e.g. PLCopen `.xml`) into a PID-tagged temporary
+  `.ld` copy so ESBMC's extension dispatch (§4.2) routes it to the LD front-end,
+  and removes the copy afterwards.
+- Locates the `esbmc` binary via `$ESBMC`, else `$PATH`.
+- Maps `--strategy`: `k-induction` → `--k-induction --unlimited-k-steps`;
+  `bmc` → `--unwind <N> --no-unwinding-assertions` (the `--no-unwinding-assertions`
+  flag is required because the scan loop is `while(true)` — otherwise the
+  unwinding assertion fires at the bound and is indistinguishable from a property
+  violation). `portfolio` currently aliases `k-induction`; an unrecognised
+  strategy is rejected as `ERROR`.
+- Passes the YAML file through as `--ld-props <file>`.
+- Parses the verdict and emits the JSON report, with the verdict set
+  `{SAFE, VIOLATION, INCOMPLETE, UNKNOWN, ERROR}`. A `k-induction` success is
+  reported as `SAFE`; a `bmc` success is reported as `INCOMPLETE` (bounded — it
+  proves nothing beyond the unwind depth, §3.7); a non-zero exit with no verdict
+  token is reported as `ERROR` rather than silently as `UNKNOWN`.
+
+The same `--ld-props` option is available on bare `esbmc` (e.g.
+`esbmc program.ld --ld-props props.yaml --k-induction`), which is what the
+regression tests drive directly.
 
 `ld-verify` then parses ESBMC's output and emits a structured JSON report:
 
@@ -516,12 +545,12 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 
 ### WP2 — SAFE-LD Tool Development (Months 4–12)
 
-| Task | Subtasks | Milestone |
-|---|---|---|
-| T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs |
-| T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs |
-| T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready |
-| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov |
+| Task | Subtasks | Milestone | Status |
+|---|---|---|---|
+| T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280) |
+| T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | partial — boolean subset works; timers/counters/`response` abort with an irep2 bit-width assertion (§10) |
+| T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired, `ld-verify` runner + JSON report implemented (#5289) |
+| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 2 driver regression tests; `ld-verify` runner not yet covered |
 
 **Success criteria (WP2):**
 - **Correctness:** ≥95% of benchmark programs translated to GOTO IR with semantic
@@ -663,3 +692,67 @@ both the translation and the verifier on real semantic errors, not just syntacti
 | M9 | 28 | Paper 1 submitted |
 | M10 | 32 | Paper 2 submitted |
 | M11 | 36 | Full open-source release + SV-COMP category proposal |
+
+---
+
+## 10. Implementation Status
+
+This section records what has actually landed against the plan above, so the
+prose in §3 is not mistaken for delivered functionality.
+
+### Landed
+
+- **WP2 skeleton (#5280).** Front-end scaffolding: `ld_languaget`, PLCopen XML
+  parser, type checker, LdIR + builder, `ld_converter`, YAML property parser,
+  property encoder, `ld-verify` tool, CMake wiring behind `ENABLE_LD_FRONTEND`
+  (default `OFF`), and unit tests.
+- **Property pipeline + ld-verify runner (#5289).**
+  - `--ld-props <file>` option on the `esbmc` driver; `ld_languaget::parse()`
+    reads it (an explicit `set_props_path` from `ld-verify` still wins). Before
+    this, the property file was never loaded and every program verified
+    vacuously.
+  - **READ_INPUTS** (§3.3): each `is_input` variable is re-sampled
+    nondeterministically at the top of every scan iteration. Before this, inputs
+    were frozen at their initial value, so verification was vacuous even with
+    properties loaded.
+  - `LdVerifyRunner::run()` implemented end-to-end (see §3.6) with the verdict
+    set `{SAFE, VIOLATION, INCOMPLETE, UNKNOWN, ERROR}`.
+  - Regression suite `regression/ld/` registered (guarded by
+    `ENABLE_LD_FRONTEND`, excluding the `benchmarks/` dataset): `motor_interlock`
+    (SAFE under k-induction) and `missing_interlock_fail` (mutual-exclusion
+    VIOLATION).
+
+### Working end-to-end
+
+Contacts and coils (`--( )--`, `--( S )--`, `--( R )--`), and the property kinds
+`mutual_exclusion`, `invariant`, `absence`, and `reachability`. These encode to
+GOTO IR and verify under both k-induction and bounded BMC.
+
+### Known limitations / not yet working
+
+- **Timers and counters abort GOTO generation.** TON/TOF/TP and CTU/CTD
+  encodings, and the `response` property (which builds an auxiliary scan
+  counter), trigger an irep2 assertion —
+  `assert_arith_2ops_consistency` (`irep2_expr.cpp`) — during
+  "Generating GOTO Program". Reproduced both with the `conveyor_sequencing`
+  benchmark (timer FB, no properties) and with a `response` property on a
+  boolean-only program, so the integer-arithmetic encoding mixes operand
+  bit-widths. This blocks the timer/counter rows of the §3.4 table and the
+  `response` row of the §3.5 table, and is why `conveyor_sequencing` and
+  `emergency_shutdown` are **not** yet wired as passing regression tests.
+- **`ld-verify` runner has no automated test.** The two regression tests drive
+  the `esbmc` driver directly; the runner (process spawning, `.xml` staging,
+  verdict mapping) is exercised manually only.
+- **Fault-injection mode** exists on `ld_converter` but is not exposed through
+  the `esbmc` driver or `ld-verify`.
+- **WRITE_OUTPUTS** is not modelled as a distinct step; output coils are plain
+  variable assignments (sufficient for the current property checks).
+
+### Suggested next increments
+
+1. Fix the timer/counter/`response` bit-width assertion in `ld_converter` /
+   `property_encoder`, then promote `conveyor_sequencing` and
+   `emergency_shutdown` to passing regression tests.
+2. Enable `-DENABLE_LD_FRONTEND=On` in a CI job so `regression/ld/` actually
+   runs upstream (the suite is skipped on a default build).
+3. Add coverage for the `ld-verify` runner itself.

--- a/docs/safe-ld-implementation-plan.md
+++ b/docs/safe-ld-implementation-plan.md
@@ -5,12 +5,12 @@
 **Tracking:** umbrella issue TBD  
 **Date:** 2026-06-09
 
-> **Implementation note.** The boolean/combinational Tier-1 subset now verifies
-> end-to-end (see §10). The integer-arithmetic constructs — TON/TOF/TP timers,
-> CTU/CTD counters, and the `response` property (auxiliary scan counter) — do
-> **not** yet work: they abort GOTO generation with an irep2 bit-width
-> assertion. Treat the timer/counter/response rows of the tables below as
-> *planned*, not *delivered*.
+> **Implementation note.** The boolean/combinational Tier-1 subset and the
+> integer-arithmetic constructs (TON/TOF/TP timers, CTU/CTD counters, and the
+> `response` property) now lower to GOTO IR and verify end-to-end (see §10). The
+> verdicts for the curated `conveyor_sequencing` / `emergency_shutdown`
+> benchmarks have not yet been validated against an intended ground truth, so
+> those two are not yet wired as passing regression tests.
 
 ---
 
@@ -548,7 +548,7 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 | Task | Subtasks | Milestone | Status |
 |---|---|---|---|
 | T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280) |
-| T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | partial — boolean subset works; timers/counters/`response` abort with an irep2 bit-width assertion (§10) |
+| T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | boolean subset + timers/counters/`response` all lower and verify (#5289); per-benchmark verdict validation outstanding (§10) |
 | T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired, `ld-verify` runner + JSON report implemented (#5289) |
 | T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 2 driver regression tests; `ld-verify` runner not yet covered |
 
@@ -717,42 +717,48 @@ prose in §3 is not mistaken for delivered functionality.
     properties loaded.
   - `LdVerifyRunner::run()` implemented end-to-end (see §3.6) with the verdict
     set `{SAFE, VIOLATION, INCOMPLETE, UNKNOWN, ERROR}`.
+  - **Typed arithmetic IR.** `plus_exprt`/`mult_exprt` leave their result type
+    unset (the C frontend fills it in during its `adjust` pass; the LD frontend
+    builds final IR directly and has none), so the timer/counter/`response`
+    arithmetic previously migrated to a typeless `add2t` and aborted GOTO
+    generation with `assert_arith_2ops_consistency` (`irep2_expr.cpp`). The
+    arithmetic nodes are now built with an explicit result type, so TON/TOF/TP
+    timers, CTU/CTD counters, and the `response` property lower and verify.
   - Regression suite `regression/ld/` registered (guarded by
-    `ENABLE_LD_FRONTEND`, excluding the `benchmarks/` dataset): `motor_interlock`
-    (SAFE under k-induction) and `missing_interlock_fail` (mutual-exclusion
-    VIOLATION).
+    `ENABLE_LD_FRONTEND`, excluding the `benchmarks/` dataset):
+    `motor_interlock` (SAFE), `missing_interlock_fail` (mutual-exclusion
+    VIOLATION), `response_direct` (response SAFE — coil tracks the trigger in
+    the same scan), and `response_blocked_fail` (response VIOLATION — a gated
+    coil leaves the trigger unanswered past `max_scans`).
 
 ### Working end-to-end
 
-Contacts and coils (`--( )--`, `--( S )--`, `--( R )--`), and the property kinds
-`mutual_exclusion`, `invariant`, `absence`, and `reachability`. These encode to
-GOTO IR and verify under both k-induction and bounded BMC.
+Contacts and coils (`--( )--`, `--( S )--`, `--( R )--`), TON/TOF/TP timers,
+CTU/CTD counters, and all five property kinds — `mutual_exclusion`, `invariant`,
+`absence`, `reachability`, `response`. These lower to GOTO IR and verify under
+both k-induction and bounded BMC.
 
-### Known limitations / not yet working
+### Known limitations / not yet validated
 
-- **Timers and counters abort GOTO generation.** TON/TOF/TP and CTU/CTD
-  encodings, and the `response` property (which builds an auxiliary scan
-  counter), trigger an irep2 assertion —
-  `assert_arith_2ops_consistency` (`irep2_expr.cpp`) — during
-  "Generating GOTO Program". Reproduced both with the `conveyor_sequencing`
-  benchmark (timer FB, no properties) and with a `response` property on a
-  boolean-only program, so the integer-arithmetic encoding mixes operand
-  bit-widths. This blocks the timer/counter rows of the §3.4 table and the
-  `response` row of the §3.5 table, and is why `conveyor_sequencing` and
-  `emergency_shutdown` are **not** yet wired as passing regression tests.
-- **`ld-verify` runner has no automated test.** The two regression tests drive
-  the `esbmc` driver directly; the runner (process spawning, `.xml` staging,
-  verdict mapping) is exercised manually only.
+- **Benchmark verdicts not validated.** `conveyor_sequencing` and
+  `emergency_shutdown` now lower and verify (no crash) but currently report
+  VIOLATION; whether that is the intended verdict is a WP3 benchmark-design /
+  SOS-correctness question, so neither is yet wired as a passing regression test.
+- **`ld-verify` runner has no automated test.** The regression tests drive the
+  `esbmc` driver directly; the runner (process spawning, `.xml` staging, verdict
+  mapping) is exercised manually only.
 - **Fault-injection mode** exists on `ld_converter` but is not exposed through
   the `esbmc` driver or `ld-verify`.
 - **WRITE_OUTPUTS** is not modelled as a distinct step; output coils are plain
   variable assignments (sufficient for the current property checks).
+- **Timer/counter integer width.** The arithmetic uses `int_type()` with no
+  overflow guard; very long-running counters could wrap. Not exercised by the
+  current bounded tests.
 
 ### Suggested next increments
 
-1. Fix the timer/counter/`response` bit-width assertion in `ld_converter` /
-   `property_encoder`, then promote `conveyor_sequencing` and
-   `emergency_shutdown` to passing regression tests.
+1. Validate the `conveyor_sequencing` / `emergency_shutdown` benchmark verdicts
+   against their intended SOS semantics and promote them to regression tests.
 2. Enable `-DENABLE_LD_FRONTEND=On` in a CI job so `regression/ld/` actually
    runs upstream (the suite is skipped on a default build).
 3. Add coverage for the `ld-verify` runner itself.

--- a/docs/safe-ld-property-format.md
+++ b/docs/safe-ld-property-format.md
@@ -22,7 +22,7 @@ each entry into a `code_assertt` node appended to the scan-loop body.
 | `invariant` | **Implemented**, encodes and verifies |
 | `absence` | **Implemented & exercised** (regression test `motor_interlock`) |
 | `reachability` | **Implemented**, encodes and verifies |
-| `response` | **Not yet working** — the auxiliary scan counter trips an irep2 bit-width assertion during GOTO generation (shared root cause with the timer/counter encoding; see the implementation plan §10) |
+| `response` | **Implemented & exercised** (regression tests `response_direct` SAFE, `response_blocked_fail` VIOLATION); the auxiliary scan counter is emitted as typed arithmetic |
 
 The `description` field is propagated into the `code_assertt` comment, so a
 violated property is named in the ESBMC counterexample and in the `ld-verify`

--- a/docs/safe-ld-property-format.md
+++ b/docs/safe-ld-property-format.md
@@ -9,6 +9,27 @@ IEC 61131-3 Ladder Diagram programs verified with SAFE-LD.
 
 ---
 
+## Implementation Status (#5289)
+
+A property file is consumed either by the `esbmc` driver directly —
+`esbmc program.ld --ld-props props.yaml --k-induction` — or via `ld-verify`
+(`ld-verify program.{ld,xml} --props props.yaml`). The property encoder turns
+each entry into a `code_assertt` node appended to the scan-loop body.
+
+| Kind | Status |
+|---|---|
+| `mutual_exclusion` | **Implemented & exercised** (regression test `missing_interlock_fail`) |
+| `invariant` | **Implemented**, encodes and verifies |
+| `absence` | **Implemented & exercised** (regression test `motor_interlock`) |
+| `reachability` | **Implemented**, encodes and verifies |
+| `response` | **Not yet working** — the auxiliary scan counter trips an irep2 bit-width assertion during GOTO generation (shared root cause with the timer/counter encoding; see the implementation plan §10) |
+
+The `description` field is propagated into the `code_assertt` comment, so a
+violated property is named in the ESBMC counterexample and in the `ld-verify`
+JSON report's `description` field.
+
+---
+
 ## File Structure
 
 ```yaml

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -60,6 +60,10 @@ function(add_esbmc_regression folder modes)
     if(${folder} STREQUAL "quixbugs")
         list(REMOVE_ITEM SUBDIRS bucketsort)
     endif()
+    if(${folder} STREQUAL "ld")
+        # WP3 benchmark dataset, not a CTest test (no test.desc)
+        list(REMOVE_ITEM SUBDIRS benchmarks)
+    endif()
     foreach(test ${SUBDIRS})
         add_esbmc_regression_test(${folder} "${modes}" ${test})
     endforeach()
@@ -92,6 +96,9 @@ if(ENABLE_GOTO_CONTRACTOR)
 endif()
 if(ENABLE_JIMPLE_FRONTEND)
     set(REGRESSIONS_JIMPLE jimple)
+endif()
+if(ENABLE_LD_FRONTEND)
+    set(REGRESSIONS_LD ld)
 endif()
 if(ENABLE_PYTHON_FRONTEND)
     set(REGRESSIONS_PYTHON python)
@@ -209,6 +216,7 @@ if(APPLE)
                     ${REGRESSIONS_QUIXBUGS}
                     ${REGRESSIONS_PYTHON_COVERAGE}
                     ${REGRESSIONS_AI_GENERATED_CODE}
+                    ${REGRESSIONS_LD}
                     ${TEST_GENERATION}
                     ltl
                     goto-transcoder
@@ -277,6 +285,7 @@ else()
                     ${REGRESSIONS_QUIXBUGS}
                     ${REGRESSIONS_PYTHON_COVERAGE}
                     ${REGRESSIONS_AI_GENERATED_CODE}
+                    ${REGRESSIONS_LD}
                     ${TEST_GENERATION}
                     ltl
                     goto-coverage

--- a/regression/ld/missing_interlock_fail/missing_interlock.ld
+++ b/regression/ld/missing_interlock_fail/missing_interlock.ld
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Negative test: forward/reverse coils driven directly with NO interlock.   -->
+<!-- Both inputs can be TRUE in the same scan, so Motor_Forward and            -->
+<!-- Motor_Reverse can be energised simultaneously, violating P1.             -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-10"/>
+  <contentHeader name="MissingInterlock"/>
+  <types/>
+  <instances>
+    <configurations>
+      <configuration name="Config">
+        <resource name="Resource">
+          <task name="MainTask" priority="0" interval="T#10ms"/>
+          <pouInstance name="MissingInterlock_POU" typeName="MissingInterlock"/>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+  <pous>
+    <pou name="MissingInterlock" pouType="program">
+      <interface>
+        <inputVars>
+          <variable name="Start_Fwd"><type><BOOL/></type></variable>
+          <variable name="Start_Rev"><type><BOOL/></type></variable>
+        </inputVars>
+        <outputVars>
+          <variable name="Motor_Forward"><type><BOOL/></type></variable>
+          <variable name="Motor_Reverse"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <!-- Rung 1: forward coil, no interlock contact -->
+          <rung localId="1" lineNumber="1">
+            <contact variable="Start_Fwd"/>
+            <coil variable="Motor_Forward"/>
+          </rung>
+          <!-- Rung 2: reverse coil, no interlock contact -->
+          <rung localId="2" lineNumber="2">
+            <contact variable="Start_Rev"/>
+            <coil variable="Motor_Reverse"/>
+          </rung>
+        </LD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/missing_interlock_fail/props.yaml
+++ b/regression/ld/missing_interlock_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [Motor_Forward, Motor_Reverse]
+    description: "Forward and Reverse coils must never be simultaneously energised"

--- a/regression/ld/missing_interlock_fail/test.desc
+++ b/regression/ld/missing_interlock_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+missing_interlock.ld
+--ld-props props.yaml --k-induction
+^VERIFICATION FAILED$
+Forward and Reverse coils must never be simultaneously energised

--- a/regression/ld/motor_interlock/motor_interlock.ld
+++ b/regression/ld/motor_interlock/motor_interlock.ld
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CS1: Three-phase motor forward/reverse interlock (PLCopen XML format) -->
+<!-- Safety property: Forward and Reverse coils must never be simultaneously energised -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-09"/>
+  <contentHeader name="MotorInterlock"/>
+  <types/>
+  <instances>
+    <configurations>
+      <configuration name="Config">
+        <resource name="Resource">
+          <task name="MainTask" priority="0" interval="T#10ms"/>
+          <pouInstance name="MotorInterlock_POU" typeName="MotorInterlock"/>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+  <pous>
+    <pou name="MotorInterlock" pouType="program">
+      <interface>
+        <inputVars>
+          <variable name="Start_Fwd"><type><BOOL/></type></variable>
+          <variable name="Start_Rev"><type><BOOL/></type></variable>
+          <variable name="Stop"><type><BOOL/></type></variable>
+          <variable name="OL_Trip"><type><BOOL/></type></variable>
+        </inputVars>
+        <outputVars>
+          <variable name="Motor_Forward"><type><BOOL/></type></variable>
+          <variable name="Motor_Reverse"><type><BOOL/></type></variable>
+        </outputVars>
+        <localVars>
+          <variable name="Fwd_Seal"><type><BOOL/></type></variable>
+          <variable name="Rev_Seal"><type><BOOL/></type></variable>
+        </localVars>
+      </interface>
+      <body>
+        <LD>
+          <!-- Rung 1: Forward direction with hardware interlock (NC contact on Motor_Reverse) -->
+          <rung localId="1" lineNumber="1">
+            <contact variable="Start_Fwd"/>
+            <contact variable="Motor_Reverse" negated="negated"/>
+            <contact variable="Stop" negated="negated"/>
+            <contact variable="OL_Trip" negated="negated"/>
+            <coil variable="Motor_Forward"/>
+          </rung>
+          <!-- Rung 2: Reverse direction with hardware interlock (NC contact on Motor_Forward) -->
+          <rung localId="2" lineNumber="2">
+            <contact variable="Start_Rev"/>
+            <contact variable="Motor_Forward" negated="negated"/>
+            <contact variable="Stop" negated="negated"/>
+            <contact variable="OL_Trip" negated="negated"/>
+            <coil variable="Motor_Reverse"/>
+          </rung>
+        </LD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/motor_interlock/props.yaml
+++ b/regression/ld/motor_interlock/props.yaml
@@ -1,0 +1,15 @@
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [Motor_Forward, Motor_Reverse]
+    description: "Forward and Reverse coils must never be simultaneously energised"
+
+  - id: P2
+    kind: absence
+    expression: "OL_Trip && Motor_Forward"
+    description: "Motor must not run forward when overload trip is active"
+
+  - id: P3
+    kind: absence
+    expression: "OL_Trip && Motor_Reverse"
+    description: "Motor must not run reverse when overload trip is active"

--- a/regression/ld/motor_interlock/test.desc
+++ b/regression/ld/motor_interlock/test.desc
@@ -1,0 +1,4 @@
+CORE
+motor_interlock.ld
+--ld-props props.yaml --k-induction
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/response_blocked_fail/props.yaml
+++ b/regression/ld/response_blocked_fail/props.yaml
@@ -1,0 +1,7 @@
+properties:
+  - id: R1
+    kind: response
+    trigger: Start
+    response: Out
+    max_scans: 2
+    justification: "negative test: Out gated by Enable, so response can be blocked"

--- a/regression/ld/response_blocked_fail/response_blocked.ld
+++ b/regression/ld/response_blocked_fail/response_blocked.ld
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-10"/>
+  <contentHeader name="RespFail"/>
+  <types/>
+  <instances><configurations><configuration name="Config"><resource name="R">
+    <task name="MainTask" priority="0" interval="T#10ms"/>
+    <pouInstance name="P" typeName="RespFail"/>
+  </resource></configuration></configurations></instances>
+  <pous><pou name="RespFail" pouType="program"><interface>
+    <inputVars>
+      <variable name="Start"><type><BOOL/></type></variable>
+      <variable name="Enable"><type><BOOL/></type></variable>
+    </inputVars>
+    <outputVars><variable name="Out"><type><BOOL/></type></variable></outputVars>
+  </interface><body><LD>
+    <rung localId="1" lineNumber="1">
+      <contact variable="Start"/>
+      <contact variable="Enable"/>
+      <coil variable="Out"/>
+    </rung>
+  </LD></body></pou></pous>
+</project>

--- a/regression/ld/response_blocked_fail/test.desc
+++ b/regression/ld/response_blocked_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+response_blocked.ld
+--ld-props props.yaml --k-induction
+^VERIFICATION FAILED$

--- a/regression/ld/response_direct/props.yaml
+++ b/regression/ld/response_direct/props.yaml
@@ -1,0 +1,7 @@
+properties:
+  - id: R1
+    kind: response
+    trigger: Start
+    response: Out
+    max_scans: 2
+    justification: "direct coil; Out tracks Start in the same scan"

--- a/regression/ld/response_direct/response_direct.ld
+++ b/regression/ld/response_direct/response_direct.ld
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-10"/>
+  <contentHeader name="RespSafe"/>
+  <types/>
+  <instances><configurations><configuration name="Config"><resource name="R">
+    <task name="MainTask" priority="0" interval="T#10ms"/>
+    <pouInstance name="P" typeName="RespSafe"/>
+  </resource></configuration></configurations></instances>
+  <pous><pou name="RespSafe" pouType="program"><interface>
+    <inputVars><variable name="Start"><type><BOOL/></type></variable></inputVars>
+    <outputVars><variable name="Out"><type><BOOL/></type></variable></outputVars>
+  </interface><body><LD>
+    <rung localId="1" lineNumber="1">
+      <contact variable="Start"/>
+      <coil variable="Out"/>
+    </rung>
+  </LD></body></pou></pous>
+</project>

--- a/regression/ld/response_direct/test.desc
+++ b/regression/ld/response_direct/test.desc
@@ -1,0 +1,4 @@
+CORE
+response_direct.ld
+--ld-props props.yaml --k-induction
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -122,6 +122,13 @@ const struct group_opt_templ all_cmd_options[] = {
       "Set maximum nesting depth for Python list comparison (default is 4)"},
    }},
 #endif
+#ifdef ENABLE_LD_FRONTEND
+  {"LD frontend",
+   {{"ld-props",
+     boost::program_options::value<std::string>()->value_name("file"),
+     "YAML safety-property specification for IEC 61131-3 Ladder Diagram "
+     "(.ld) programs"}}},
+#endif
 #ifdef ENABLE_SOLIDITY_FRONTEND
   {"Solidity frontend",
    {{"sol",

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -34,6 +34,21 @@ static std::string ld_name(const std::string &var)
   return "ld::" + var;
 }
 
+// plus_exprt/mult_exprt set no result type (the C frontend fills it in during
+// its adjust pass; the LD frontend builds final IR directly and has none), so
+// an untyped arith node migrates to a typeless add2t and trips the irep2
+// bit-width assertion.  Build arith nodes with an explicit result type.
+static exprt make_arith(
+  const irep_idt &op,
+  const exprt &lhs,
+  const exprt &rhs,
+  const typet &type)
+{
+  exprt e(op, type);
+  e.copy_to_operands(lhs, rhs);
+  return e;
+}
+
 symbol_exprt ld_converter::declare_variable(const VarDecl &v)
 {
   symbolt sym;
@@ -181,7 +196,8 @@ codet ld_converter::translate_timer(const LdIRNode &n)
 
   code_ifthenelset et_step;
   et_step.cond() = condition;
-  et_step.then_case() = code_assignt(et_sym, plus_exprt(et_sym, one));
+  et_step.then_case() =
+    code_assignt(et_sym, make_arith(exprt::plus, et_sym, one, int32_t_()));
   et_step.else_case() = code_assignt(et_sym, zero);
 
   exprt q_expr =
@@ -214,7 +230,8 @@ codet ld_converter::translate_counter(const LdIRNode &n)
 
     code_ifthenelset cu_step;
     cu_step.cond() = and_exprt(cu, not_exprt(cu_prev));
-    cu_step.then_case() = code_assignt(cv, plus_exprt(cv, one));
+    cu_step.then_case() =
+      code_assignt(cv, make_arith(exprt::plus, cv, one, int32_t_()));
     blk.copy_to_operands(cu_step);
 
     if (!n.ctr_R.empty())
@@ -246,7 +263,8 @@ codet ld_converter::translate_counter(const LdIRNode &n)
 
     code_ifthenelset cd_step;
     cd_step.cond() = and_exprt(cd, not_exprt(cd_prev));
-    cd_step.then_case() = code_assignt(cv, plus_exprt(cv, neg_one));
+    cd_step.then_case() =
+      code_assignt(cv, make_arith(exprt::plus, cv, neg_one, int32_t_()));
     blk.copy_to_operands(cd_step);
 
     blk.copy_to_operands(code_assignt(cd_prev, cd));
@@ -265,22 +283,18 @@ codet ld_converter::translate_arith(const LdIRNode &n)
   switch (n.arith_kind)
   {
   case FBKind::ADD:
-    op_expr = plus_exprt(in1, var_expr(n.arith_IN2));
+    op_expr = make_arith(exprt::plus, in1, var_expr(n.arith_IN2), int32_t_());
     break;
   case FBKind::SUB:
-    op_expr = exprt(exprt::minus, int32_t_());
-    op_expr.copy_to_operands(in1, var_expr(n.arith_IN2));
+    op_expr = make_arith(exprt::minus, in1, var_expr(n.arith_IN2), int32_t_());
     break;
   case FBKind::MUL:
-    op_expr = mult_exprt(in1, var_expr(n.arith_IN2));
+    op_expr = make_arith(exprt::mult, in1, var_expr(n.arith_IN2), int32_t_());
     break;
   case FBKind::DIV:
-    op_expr = exprt(exprt::div, int32_t_());
-    op_expr.copy_to_operands(in1, var_expr(n.arith_IN2));
+    op_expr = make_arith(exprt::div, in1, var_expr(n.arith_IN2), int32_t_());
     break;
   case FBKind::MOVE:
-    op_expr = in1;
-    break;
   default:
     op_expr = in1;
     break;

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -296,6 +296,19 @@ code_blockt ld_converter::build_scan_body(const exprt &)
 {
   code_blockt scan_body;
 
+  // READ_INPUTS (SOS cyclic-scan model, §3.3): at the start of every scan
+  // iteration each physical input is re-sampled nondeterministically.  Without
+  // this the inputs stay frozen at their initial value and every property
+  // verifies vacuously.
+  for (const auto &v : ir_.variables)
+  {
+    if (!v.is_input)
+      continue;
+    symbol_exprt input = var_expr(v.name);
+    scan_body.copy_to_operands(
+      code_assignt(input, side_effect_expr_nondett(input.type())));
+  }
+
   for (const auto &rung : ir_.rungs)
   {
     code_blockt rung_blk;

--- a/src/ld-frontend/ld_language.cpp
+++ b/src/ld-frontend/ld_language.cpp
@@ -6,6 +6,7 @@
 #include <ld-frontend/property/yaml_property_parser.h>
 #include <ld-frontend/property/property_encoder.h>
 #include <util/c_expr2string.h>
+#include <util/config.h>
 #include <util/message.h>
 #include <iostream>
 
@@ -17,6 +18,11 @@ languaget *new_ld_language()
 bool ld_languaget::parse(const std::string &path)
 {
   log_debug("ld", "Parsing: {}", path);
+
+  // When driven by the esbmc CLI (not ld-verify), pick up the property file
+  // from the --ld-props option unless one was already set explicitly.
+  if (props_path_.empty())
+    props_path_ = config.options.get_option("ld-props");
 
   try
   {

--- a/src/ld-frontend/property/property_encoder.cpp
+++ b/src/ld-frontend/property/property_encoder.cpp
@@ -190,9 +190,15 @@ code_blockt property_encoder::encode_response(const LdProperty &p)
   exprt one = gen_one(int_type());
   exprt zero = gen_zero(int_type());
 
+  // plus_exprt leaves its result type unset; set it explicitly (int_type)
+  // since the LD frontend has no adjust pass to infer it, otherwise the node
+  // migrates to a typeless add2t and trips an irep2 bit-width assertion.
+  exprt incr(exprt::plus, int_type());
+  incr.copy_to_operands(ctr, one);
+
   code_ifthenelset ctr_step;
   ctr_step.cond() = and_exprt(trigger, not_exprt(response));
-  ctr_step.then_case() = code_assignt(ctr, plus_exprt(ctr, one));
+  ctr_step.then_case() = code_assignt(ctr, incr);
   ctr_step.else_case() = code_assignt(ctr, zero);
 
   code_blockt blk;

--- a/src/ld-frontend/verify/ld_verify.cpp
+++ b/src/ld-frontend/verify/ld_verify.cpp
@@ -1,5 +1,10 @@
 #include <ld-frontend/verify/ld_verify.h>
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 #include <sstream>
+#include <unistd.h>
 
 static std::string json_escape(const std::string &s)
 {
@@ -71,11 +76,163 @@ std::string LdVerifyResult::to_json() const
   return s.str();
 }
 
+// Single-quote a string for safe inclusion in a /bin/sh command line.
+static std::string shell_quote(const std::string &s)
+{
+  std::string q = "'";
+  for (char c : s)
+    q += (c == '\'') ? std::string("'\\''") : std::string(1, c);
+  q += "'";
+  return q;
+}
+
+// Locate the esbmc binary: honour $ESBMC, else rely on $PATH.
+static std::string esbmc_binary()
+{
+  const char *e = std::getenv("ESBMC");
+  return (e && *e) ? std::string(e) : std::string("esbmc");
+}
+
+// Pull the violated-property description out of an ESBMC counterexample.
+// The trace prints "Violated property:" then an indented "file <path>" line,
+// then the assertion comment (the property description).  Scan for the first
+// non-empty, non-"file" line after the header rather than assuming a fixed
+// layout, so the field survives minor trace-format changes.
+static std::string extract_violated_description(const std::string &output)
+{
+  auto pos = output.find("Violated property:");
+  if (pos == std::string::npos)
+    return {};
+
+  std::istringstream is(output.substr(pos));
+  std::string line;
+  std::getline(is, line); // consume the "Violated property:" header
+  while (std::getline(is, line))
+  {
+    auto begin = line.find_first_not_of(" \t");
+    if (begin == std::string::npos)
+      continue; // blank line
+    std::string trimmed = line.substr(begin);
+    if (trimmed.rfind("file ", 0) == 0)
+      continue; // source-location line, not the description
+    return trimmed;
+  }
+  return {};
+}
+
 LdVerifyResult LdVerifyRunner::run(const LdVerifyOptions &opts)
 {
-  (void)opts;
+  namespace fs = std::filesystem;
   LdVerifyResult r;
-  r.verdict = LdVerifyResult::Verdict::Unknown;
-  r.description = "Use the ESBMC driver for full verification";
+
+  if (opts.program_path.empty())
+  {
+    r.verdict = LdVerifyResult::Verdict::Error;
+    r.description = "no input program specified";
+    return r;
+  }
+
+  // "portfolio" currently shares the k-induction invocation (the dedicated
+  // portfolio orchestration is future work); reject anything else so a typo is
+  // not silently treated as k-induction.
+  const bool bmc = (opts.strategy == "bmc");
+  if (!bmc && opts.strategy != "k-induction" && opts.strategy != "portfolio")
+  {
+    r.verdict = LdVerifyResult::Verdict::Error;
+    r.description =
+      "unknown strategy '" + opts.strategy + "' (expected k-induction|bmc)";
+    return r;
+  }
+
+  // ESBMC dispatches frontends by file extension (§4.2), so a PLCopen .xml
+  // file must be staged as a .ld copy before invocation.  A PID-tagged name
+  // keeps concurrent ld-verify runs from clobbering each other's staging file.
+  std::string program = opts.program_path;
+  std::string staged;
+  if (fs::path(program).extension() != ".ld")
+  {
+    std::error_code ec;
+    fs::path tmp = fs::temp_directory_path() /
+                   (fs::path(program).stem().string() + "-ldverify-" +
+                    std::to_string(static_cast<long>(getpid())) + ".ld");
+    fs::copy_file(program, tmp, fs::copy_options::overwrite_existing, ec);
+    if (ec)
+    {
+      r.verdict = LdVerifyResult::Verdict::Error;
+      r.description = "could not stage .ld copy: " + ec.message();
+      return r;
+    }
+    staged = tmp.string();
+    program = staged;
+  }
+
+  std::ostringstream cmd;
+  cmd << shell_quote(esbmc_binary()) << ' ' << shell_quote(program);
+  if (!opts.props_path.empty())
+    cmd << " --ld-props " << shell_quote(opts.props_path);
+  if (bmc)
+    // The scan loop is while(true); without --no-unwinding-assertions the
+    // unwinding assertion fires at the bound and masquerades as a property
+    // violation.  Suppressing it gives genuine bounded semantics: a real
+    // property violation within the bound still FAILS, while its absence maps
+    // to INCOMPLETE (never SAFE) below.
+    cmd << " --unwind " << opts.bmc_unwind << " --no-unwinding-assertions";
+  else
+    cmd << " --k-induction --unlimited-k-steps";
+  cmd << " 2>&1";
+
+  std::string output;
+  FILE *pipe = popen(cmd.str().c_str(), "r");
+  if (!pipe)
+  {
+    if (!staged.empty())
+    {
+      std::error_code ec;
+      fs::remove(staged, ec);
+    }
+    r.verdict = LdVerifyResult::Verdict::Error;
+    r.description = "failed to launch esbmc (set $ESBMC or add it to PATH)";
+    return r;
+  }
+
+  std::array<char, 4096> buf;
+  size_t n;
+  while ((n = fread(buf.data(), 1, buf.size(), pipe)) > 0)
+    output.append(buf.data(), n);
+  int status = pclose(pipe);
+
+  if (!staged.empty())
+  {
+    std::error_code ec;
+    fs::remove(staged, ec);
+  }
+
+  r.raw_output = output;
+
+  if (output.find("VERIFICATION FAILED") != std::string::npos)
+  {
+    r.verdict = LdVerifyResult::Verdict::Violation;
+    r.description = extract_violated_description(output);
+  }
+  else if (output.find("VERIFICATION SUCCESSFUL") != std::string::npos)
+  {
+    // A bounded BMC pass proves safety only up to the unwind depth (§3.7).
+    r.verdict =
+      bmc ? LdVerifyResult::Verdict::Incomplete : LdVerifyResult::Verdict::Safe;
+  }
+  else if (status != 0)
+  {
+    // No verdict token and a non-zero exit means esbmc never ran or crashed
+    // (e.g. missing binary, parse error); this is an error, not an
+    // inconclusive run.
+    r.verdict = LdVerifyResult::Verdict::Error;
+    r.description = "esbmc produced no verdict (exit status " +
+                    std::to_string(status) + "); set $ESBMC or check the input";
+  }
+  else
+  {
+    r.verdict = LdVerifyResult::Verdict::Unknown;
+  }
+
   return r;
 }


### PR DESCRIPTION
Resumes the SAFE-LD plan (`docs/safe-ld-implementation-plan.md`) after the WP2 skeleton (#5280), making the pipeline actually verify Ladder Diagram programs.

- **`--ld-props` option** in the esbmc driver — properties were never loaded, so `.ld` programs verified vacuously. `ld_languaget::parse()` now reads the option (explicit `set_props_path` still wins for `ld-verify`).
- **READ_INPUTS havocing** — inputs were frozen at 0; the converter now re-samples each `is_input` variable nondeterministically per scan (plan §3.3), making verification meaningful.
- **Typed arithmetic IR** — `plus_exprt`/`mult_exprt` leave the result type unset (the C frontend fills it during `adjust`; the LD frontend has no such pass), so timer/counter/`response` arithmetic migrated to a typeless `add2t` and aborted GOTO generation with `assert_arith_2ops_consistency`. Arith nodes are now built with an explicit result type, so TON/TOF/TP timers, CTU/CTD counters, and the `response` property lower and verify.
- **`LdVerifyRunner::run()`** — was a stub; now stages `.xml`→`.ld`, invokes esbmc, parses the verdict, and emits the JSON report. Verdict mapping is honest: k-induction-success→SAFE, BMC-success→INCOMPLETE, FAILED→VIOLATION, no-verdict→ERROR. BMC uses `--no-unwinding-assertions` so the infinite scan loop's unwinding assertion isn't misread as a property violation.
- **Regression tests** (suite guarded by `ENABLE_LD_FRONTEND`): `motor_interlock` (SAFE), `missing_interlock_fail` (mutual-exclusion VIOLATION), `response_direct` (response SAFE), `response_blocked_fail` (response VIOLATION).
- **Docs** — plan §10 (Implementation Status) and the property-format spec record what is delivered vs. outstanding.

### Working end-to-end
Contacts/coils, TON/TOF/TP timers, CTU/CTD counters, and all five property kinds (`mutual_exclusion`, `invariant`, `absence`, `reachability`, `response`).

### Outstanding (documented, not in this PR)
The curated `conveyor_sequencing` / `emergency_shutdown` benchmarks now lower and verify (no crash) but report VIOLATION; validating whether that matches their intended SOS semantics is a WP3 task, so they are not yet wired as passing tests. The `ld-verify` runner has no automated test (exercised manually).

Built with `-DENABLE_LD_FRONTEND=On`; 3 LD unit suites (56 assertions) and all 4 regression tests pass; clang-format-clean against Clang 11.

> Note: `regression/ld/` is guarded by `ENABLE_LD_FRONTEND` (default OFF), so it only runs in a CI job that enables that flag.