### PR TITLE
[build] Fix -Werror failures under NDEBUG (RelWithDebInfo)

### DIFF
--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -28,7 +28,8 @@ void clang_cpp_adjust::gen_implicit_union_copy_move_constructor(symbolt &symbol)
   if (symbol.get_value().is_not_nil())
   {
     value = symbol.get_value();
-    const code_blockt &existing_body = to_code_block(to_code(value));
+    [[maybe_unused]] const code_blockt &existing_body =
+      to_code_block(to_code(value));
     assert(
       existing_body.operands().size() == 1 &&
       existing_body.op0().statement() ==

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -1227,7 +1227,8 @@ static expr2tc zero_fill_aggregate(
       // arrays) cannot be checked here.
       if (is_constant_int2t(at.array_size))
       {
-        const BigInt &n = to_constant_int2t(at.array_size).value;
+        [[maybe_unused]] const BigInt &n =
+          to_constant_int2t(at.array_size).value;
         assert(
           n == BigInt(ca.datatype_members.size()) &&
           "constant_array2t element count != array_type2t::array_size");

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -135,7 +135,7 @@ static void add_global_static_variable(
     symbol.set_value(std::move(v));
   }
 
-  symbolt *added_symbol = ctx.move_symbol_to_context(symbol);
+  [[maybe_unused]] symbolt *added_symbol = ctx.move_symbol_to_context(symbol);
   assert(added_symbol);
 }
 

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -972,7 +972,8 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
       list_value["annotation"].contains("value") &&
       list_value["annotation"]["value"].contains("id"))
     {
-      const nlohmann::json &type_ann = list_value["annotation"]["value"]["id"];
+      [[maybe_unused]] const nlohmann::json &type_ann =
+        list_value["annotation"]["value"]["id"];
       assert(type_ann == "list" || type_ann == "List");
       typet t =
         get_typet(list_value["annotation"]["slice"]["id"].get<std::string>());

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -51,6 +51,7 @@ std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rne_enclosure(
   else
   {
     assert(!"apply_ieee754_rne_enclosure: unsupported FP format");
+    abort();
   }
 
   smt_sortt rs = mk_real_sort();
@@ -113,6 +114,7 @@ std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rna_enclosure(
   else
   {
     assert(!"apply_ieee754_rna_enclosure: unsupported FP format");
+    abort();
   }
 
   smt_sortt rs = mk_real_sort();
@@ -177,6 +179,7 @@ std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rup_enclosure(
   else
   {
     assert(!"apply_ieee754_rup_enclosure: unsupported FP format");
+    abort();
   }
 
   smt_sortt rs = mk_real_sort();
@@ -237,6 +240,7 @@ std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rdn_enclosure(
   else
   {
     assert(!"apply_ieee754_rdn_enclosure: unsupported FP format");
+    abort();
   }
 
   smt_sortt rs = mk_real_sort();
@@ -308,6 +312,7 @@ std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rtz_enclosure(
   else
   {
     assert(!"apply_ieee754_rtz_enclosure: unsupported FP format");
+    abort();
   }
 
   smt_sortt rs = mk_real_sort();

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -114,7 +114,8 @@ struct switch_locale
 
   ~switch_locale() noexcept
   {
-    const char *n = setlocale(cat, orig.c_str()); // restore locale
+    [[maybe_unused]] const char *n =
+      setlocale(cat, orig.c_str()); // restore locale
     assert(n);
     assert(n == orig);
   }


### PR DESCRIPTION
## What

The repo failed to compile under `-Werror` in a `RelWithDebInfo` build.

`RelWithDebInfo` defines `NDEBUG`, which makes `assert()` a no-op. Two consequences tripped `-Werror`:

1. **`-Werror=unused-variable`** — five variables are read *only* inside an `assert()`, so they became unused once asserts were stripped.
2. **`-Werror=maybe-uninitialized`** — in the five `apply_ieee754_*_enclosure` functions in `smt_fp_conv.cpp`, the unsupported-format `else` branch contained only `assert(!"...")`. With the assert stripped, `eps_rel`/`eps_abs` were read uninitialized (genuine latent UB on that path).

## Fix

- Mark the assert-only locals `[[maybe_unused]]` (`string_constant.cpp`, `python_converter.cpp`, `clang_cpp_adjust_expr.cpp`, `witnesses.cpp`, `type_handler.cpp`). Pure compile-time markers, no runtime change.
- Add `abort();` after the `assert(!"... unsupported FP format")` in the five enclosure functions so the failure path terminates cleanly instead of reading uninitialized values. `abort()` is `[[noreturn]]`, which also discharges the warning.

## Verification

- Full build completes cleanly.
- ESBMC floating-point regression suites pass (154/154), exercising the `--floatbv`, `--ir`, and `--ir-ieee` IEEE754 enclosure paths; core C, Python, and C++ suites show no regressions.
- The `abort()` branches are unreachable for supported single/double formats — every caller guards precision before invoking the enclosure functions.