### PR TITLE
[irep2] Fix exception round-trip under --irep2-bodies

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3495,20 +3495,46 @@ verdict parity, dual-solver, asserts build (§V.5).
    `decl-block`. Fixed a latent UB in `ifthenelse` migration (2-operand
    form from Clang C frontend). Regression tests
    `github_4715_irep2_bodies_01{,_fail}` gate on `--irep2-bodies`.
-4. **V.4.3 — one frontend at a time.** **LANDED (Python + C)**
-   - **Python** (commit `45a024710c`): added `code_dowhile2t`, `code_assert2t`,
-     `code_assume2t` IREP2 kinds; `sideeffect("cpp-throw")` forward/back
-     migration; regression tests `github_4715_irep2_bodies_py_01{,_fail}`.
-   - **C** (commit `8deb03d108`): extended `code_decl2t` with optional `init`
-     field; 2-op `code_decl(sym, init)` preserved directly (was incorrectly
-     split into `code_block` causing premature DEAD); `code("decl-block")`
-     children flattened inline (prevents spurious extra scope boundary);
-     `sideeffect("statement_expression")` (GNU `{ }` / `assert()` macro)
-     added to `sideeffect_allockind` with forward/back arms; regression tests
-     `github_4715_irep2_bodies_c_01{,_fail}`. Remaining: C++/CUDA/Solidity/
-     Jimple, each its own commit.
-5. **V.4.4 — remove the legacy path** once all frontends are flipped and
-   the flag is the only path; delete `to_code(symbol.get_value())` seam.
+4. **V.4.3 — one frontend at a time.** **LANDED (all frontends).**
+   - **Python** (#5281, commit `45a024710c`): added `code_dowhile2t`,
+     `code_assert2t`, `code_assume2t` IREP2 kinds; `sideeffect("cpp-throw")`
+     forward/back migration; tests `github_4715_irep2_bodies_py_01{,_fail}`.
+   - **C** (#5282, commit `8deb03d108`): extended `code_decl2t` with optional
+     `init` field; 2-op `code_decl(sym, init)` preserved directly (was
+     incorrectly split into `code_block` causing premature DEAD);
+     `code("decl-block")` children flattened inline (prevents spurious extra
+     scope boundary); `sideeffect("statement_expression")` (GNU `{ }` /
+     `assert()` macro) added to `sideeffect_allockind` with forward/back arms;
+     tests `github_4715_irep2_bodies_c_01{,_fail}`.
+   - **C++** (#5284) and **Jimple + Solidity** (#5286) followed, each its own
+     commit; CUDA rides the C/clang-c path.
+   - **Exception round-trip fixes (post-flip).** A verdict-parity sweep over
+     the flag found two exception-handling defects that the per-frontend
+     `_01` tests missed — both **flag-only**, the legacy (flag-off) path is
+     unaffected:
+     1. *throw dropped → false `SUCCESSFUL`.* A `side_effect_exprt("cpp-throw")`
+        nested in a `code_expression` round-trips to the code form
+        `codet("cpp-throw")`; `convert_expression`'s `remove_sideeffects`
+        recognizes only the side-effect form, so the throw became an inert
+        `OTHER`. Affected **every** frontend that throws (Python `raise`/builtin
+        TypeErrors, C++ `throw`). Fix: `convert_expression` dispatches a
+        code-valued operand via `convert(to_code(...))` (goto_convert.cpp).
+     2. *try/catch → SIGSEGV.* `code_cpp_catch2t` stored only `exception_list`
+        and **no operand storage**, so the forward migrate dropped the try/
+        handler blocks and `convert_catch` read `op0()` on an empty operand
+        list. Fix: added `std::vector<expr2tc> operands` to the kind; forward/
+        back migration carry the operands and re-attach each handler's
+        `exception_id` from the parallel `exception_list`; the post-goto-convert
+        CATCH marker (no operands) is preserved by disambiguating on
+        `operands.empty()` (irep2_expr.{h,cpp}, migrate.cpp).
+     Gated dual-solver (Z3 + Bitwuzla) with the asserts cross-check live; tests
+     `github_4715_irep2_bodies_{py,cpp}_exc_01{,_fail}`.
+5. **V.4.4 — remove the legacy path** once all frontends are flipped and the
+   flag is the only path; delete `to_code(symbol.get_value())` seam. **Gated
+   on full verdict parity** — the exception fixes above were the first parity
+   blockers found; before flipping the default, run the deterministic
+   verdict-equivalence sweep (§V.5) flag-on across **all** frontends, since
+   the per-frontend `_01` smoke tests do not exercise every body construct.
 
 **Risk/scope:** V.4.0 and V.4.1 are small and safe (infra only). V.4.2+
 touch the shared goto pipeline → gate on `esbmc-cpp` and a

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01/main.cpp
@@ -1,0 +1,20 @@
+// Exercises C++ try/catch under --irep2-bodies (V.4.3, esbmc#4715). The
+// cpp-catch node carries its try block and catch-handler blocks as operands,
+// plus a per-handler exception_id. code_cpp_catch2t historically stored only
+// the catchable-type list, so the body round-trip dropped the operands and
+// convert_catch crashed on an empty catch. With the operands carried, the
+// exception is thrown, caught by the matching handler, and the in-handler
+// assertion holds, so verification must SUCCEED.
+int main()
+{
+  try
+  {
+    throw 42;
+    __ESBMC_assert(0, "unreachable after throw");
+  }
+  catch (int e)
+  {
+    __ESBMC_assert(e == 42, "caught value is 42");
+  }
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies --unwind 5 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01_fail/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01_fail/main.cpp
@@ -1,0 +1,17 @@
+// Negative variant of github_4715_irep2_bodies_cpp_exc_01: the exception is
+// caught by the matching handler, but the in-handler assertion is wrong, so
+// ESBMC must falsify it. This proves the catch-handler body and its
+// exception_id are faithfully reconstructed across the --irep2-bodies body
+// round-trip (a dropped handler would yield a spurious SUCCESSFUL).
+int main()
+{
+  try
+  {
+    throw 42;
+  }
+  catch (int e)
+  {
+    __ESBMC_assert(e == 7, "caught value is (wrongly) 7");
+  }
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies --unwind 5 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_02/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_02/main.cpp
@@ -1,0 +1,23 @@
+// Multi-handler variant of github_4715_irep2_bodies_cpp_exc_01 (V.4.3,
+// esbmc#4715). Two catch clauses force the cpp-catch operand list to carry
+// more than one handler, so the back-migration must re-attach each handler's
+// exception_id from exception_list[i-1] for i > 1 (a single-handler test never
+// exercises that index). A char is thrown, the second handler (catch(char))
+// matches, and its in-handler assertion holds, so verification must SUCCEED.
+int main()
+{
+  try
+  {
+    throw 'c';
+    __ESBMC_assert(0, "unreachable after throw");
+  }
+  catch (int e)
+  {
+    __ESBMC_assert(0, "int handler must not catch a char");
+  }
+  catch (char e)
+  {
+    __ESBMC_assert(e == 'c', "caught value is 'c'");
+  }
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_02/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies --unwind 5 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_bodies_py_exc_01/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_exc_01/main.py
@@ -1,0 +1,9 @@
+# Exercises Python exception handling under --irep2-bodies (V.4.3, esbmc#4715).
+# abs() on a str raises TypeError; the try/except catches it, so verification
+# must SUCCEED. This pins both the cpp-throw round-trip (the raise must not be
+# dropped) and the cpp-catch round-trip (the try/handler operands must survive
+# migrate_expr -> migrate_expr_back).
+try:
+    x = abs("hello")
+except TypeError:
+    pass

--- a/regression/python/github_4715_irep2_bodies_py_exc_01/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_exc_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-unwinding-assertions --irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_bodies_py_exc_01_fail/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_exc_01_fail/main.py
@@ -1,0 +1,6 @@
+# Negative variant: an uncaught exception under --irep2-bodies must be FAILED.
+# abs() on a str raises TypeError with nothing to catch it. Before the throw
+# round-trip fix, the body round-trip lowered the side_effect("cpp-throw") to a
+# code form that convert_expression dropped, yielding a false SUCCESSFUL; this
+# test guards that regression.
+x = abs("hello")

--- a/regression/python/github_4715_irep2_bodies_py_exc_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_exc_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --no-unwinding-assertions --irep2-bodies
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -505,6 +505,19 @@ void goto_convertt::convert_expression(const codet &code, goto_programt &dest)
 
   exprt expr = code.op0();
 
+  // An IREP2 body round-trip (--irep2-bodies, esbmc/esbmc#4715) lowers a
+  // nested side_effect_exprt("cpp-throw") to its code form codet("cpp-throw"):
+  // migrate_expr_back has no way to know the throw sat in expression position
+  // (block statements need is_code(), so the back-arm cannot universally emit
+  // the side-effect form). A code operand here is therefore a statement that
+  // must be converted as such; otherwise remove_sideeffects below does not
+  // recognize it as a side effect and the throw is silently dropped.
+  if (expr.is_code())
+  {
+    convert(to_code(expr), dest);
+    return;
+  }
+
   if (expr.id() == "if")
   {
     const if_exprt &if_expr = to_if_expr(expr);

--- a/src/irep2/README.md
+++ b/src/irep2/README.md
@@ -383,7 +383,7 @@ structured-statement                                       ; V.4, see note below
 cpp-statement ::= "code_cpp_delete"         «empty» "(" expr ")"
                 | "code_cpp_del_array"      «empty» "(" expr ")"
                 | "code_cpp_throw"          «empty» "(" expr "," "[" { name } "]" ")"
-                | "code_cpp_catch"          «empty» "(" "[" { name } "]" ")"
+                | "code_cpp_catch"          «empty» "(" "[" { name } "]" "," "[" { expr } "]" ")"
                 | "code_cpp_throw_decl"     «empty» "(" "[" { name } "]" ")"
                 | "code_cpp_throw_decl_end" «empty» "(" "[" { name } "]" ")"
 ```
@@ -815,7 +815,7 @@ IREP2 bodies; they are not yet built by any pipeline path (see the
 | `code_cpp_delete` | C++ `delete expr;`. |
 | `code_cpp_del_array` | C++ `delete[] expr;`. |
 | `code_cpp_throw` | `throw expr;` with a list of types being thrown. |
-| `code_cpp_catch` | `catch (...)` clause with a list of catchable types. |
+| `code_cpp_catch` | `try`/`catch`: a list of catchable types plus, for the source-level form, the try block and per-type handler blocks as operands (empty on the post-goto-convert CATCH marker). |
 | `code_cpp_throw_decl` | Function-level `throw(...)` declaration (start marker). |
 | `code_cpp_throw_decl_end` | Matching end marker for `code_cpp_throw_decl`. |
 

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -884,7 +884,7 @@ std::string code_cpp_del_array2t::field_names[esbmct::num_type_fields] =
 std::string code_cpp_delete2t::field_names[esbmct::num_type_fields] =
   {"value", "", "", "", ""};
 std::string code_cpp_catch2t::field_names[esbmct::num_type_fields] =
-  {"exception_list", "", "", "", ""};
+  {"exception_list", "operands", "", "", ""};
 std::string code_cpp_throw2t::field_names[esbmct::num_type_fields] =
   {"operand", "exception_list", "", "", ""};
 std::string code_cpp_throw_decl2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -2359,15 +2359,31 @@ class code_cpp_catch2t : public expr2t
 {
 public:
   std::vector<irep_idt> exception_list;
+  // Source-level try/catch operands: operands[0] is the try block, operands
+  // [1..N] the catch-handler blocks (parallel to exception_list). Empty for
+  // the post-goto-convert CATCH-push/pop marker instructions, which carry only
+  // the catchable-type list. Retained so a try/catch body survives the
+  // --irep2-bodies round-trip (esbmc/esbmc#4715); convert_catch reads it back.
+  std::vector<expr2tc> operands;
 
   code_cpp_catch2t(const std::vector<irep_idt> &el)
     : expr2t(get_empty_type(), code_cpp_catch_id), exception_list(el)
   {
   }
+  code_cpp_catch2t(
+    const std::vector<irep_idt> &el,
+    const std::vector<expr2tc> &ops)
+    : expr2t(get_empty_type(), code_cpp_catch_id),
+      exception_list(el),
+      operands(ops)
+  {
+  }
   code_cpp_catch2t(const code_cpp_catch2t &ref) = default;
 
-  static constexpr auto fields =
-    std::make_tuple(&expr2t::type, &code_cpp_catch2t::exception_list);
+  static constexpr auto fields = std::make_tuple(
+    &expr2t::type,
+    &code_cpp_catch2t::exception_list,
+    &code_cpp_catch2t::operands);
   static std::string field_names[esbmct::num_type_fields];
 };
 

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2375,11 +2375,41 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
   if (expr.id() == "code" && expr.statement() == "cpp-catch")
   {
+    // A cpp-catch node is one of two things:
+    //  - the source-level try/catch statement, whose operands[0] is the try
+    //    block and operands[1..N] the catch-handler blocks (each carrying its
+    //    catchable-type id in the "exception_id" attribute set by adjust_catch);
+    //  - the post-goto-convert CATCH-push/pop marker, built directly by
+    //    convert_catch with only a catchable-type list and no operands.
+    // Carry the operands and per-handler ids so the source form survives the
+    // --irep2-bodies round-trip; convert_catch reads them back. The marker form
+    // simply has no operands. The legacy top-level "exception_list" attribute
+    // belongs to the throw-decl family and is not set on a catch, so the id
+    // list is derived from the per-handler "exception_id" attributes.
     std::vector<irep_idt> expr_list;
-    const irept::subt &exceptions = expr.find("exception_list").get_sub();
-    for (const auto &e_it : exceptions)
-      expr_list.push_back(e_it.id());
-    new_expr_ref = code_cpp_catch2tc(expr_list);
+    std::vector<expr2tc> ops;
+    const codet::operandst &operands = expr.operands();
+    if (operands.empty())
+    {
+      // Marker form: the catchable-type list rides the top-level attribute.
+      const irept::subt &exceptions = expr.find("exception_list").get_sub();
+      for (const auto &e_it : exceptions)
+        expr_list.push_back(e_it.id());
+    }
+    else
+    {
+      // Source form: operands[0] is the try block, operands[1..N] the handler
+      // blocks, each carrying its id in the "exception_id" attribute.
+      for (std::size_t i = 0; i < operands.size(); i++)
+      {
+        expr2tc op;
+        migrate_expr(operands[i], op);
+        ops.push_back(op);
+        if (i != 0)
+          expr_list.push_back(operands[i].get("exception_id"));
+      }
+    }
+    new_expr_ref = code_cpp_catch2tc(expr_list, ops);
     return;
   }
 
@@ -4026,6 +4056,24 @@ exprt migrate_expr_back(const expr2tc &ref)
     irept::subt &exceptions = codeexpr.add("exception_list").get_sub();
     for (auto const &it : ref2.exception_list)
       exceptions.emplace_back(it);
+    // Source-level try/catch: restore the try/handler operands and re-attach
+    // each handler's "exception_id" (operands[1..N] parallel exception_list) so
+    // convert_catch can rebuild the CATCH targets. The marker form has no
+    // operands and falls straight through. The forward arm guarantees one id
+    // per handler, i.e. operands == try-block + N handlers == exception_list+1.
+    assert(
+      ref2.operands.empty() ||
+      ref2.operands.size() == ref2.exception_list.size() + 1);
+    for (std::size_t i = 0; i < ref2.operands.size(); i++)
+    {
+      exprt op = migrate_expr_back(ref2.operands[i]);
+      // The assert above is elided under -DNDEBUG (release builds), so this
+      // bounds check is the actual guard against an out-of-range read when the
+      // parallel-array invariant is somehow violated.
+      if (i != 0 && i - 1 < ref2.exception_list.size())
+        op.set("exception_id", ref2.exception_list[i - 1]);
+      codeexpr.copy_to_operands(op);
+    }
     return codeexpr;
   }
   case expr2t::code_cpp_throw_decl_id:

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -190,8 +190,25 @@ TEST_CASE(
 
 TEST_CASE("migrate expr round-trips for code_cpp_catch", "[migrate][b2-vtrack]")
 {
+  // Marker form (post-goto-convert CATCH-push/pop): catchable-type list only.
   std::vector<irep_idt> exceptions{"std::exception", "std::runtime_error"};
   require_expr_roundtrip(code_cpp_catch2tc(exceptions));
+}
+
+TEST_CASE(
+  "migrate expr round-trips for code_cpp_catch with operands",
+  "[migrate][b2-vtrack]")
+{
+  // Source-level try/catch (the --irep2-bodies form): operands[0] is the try
+  // block, operands[1..N] the catch-handler blocks parallel to the id list.
+  // The per-handler ids ride the legacy "exception_id" attribute across the
+  // round-trip, so dropping them would surface here.
+  std::vector<irep_idt> exceptions{"std::runtime_error", "std::logic_error"};
+  std::vector<expr2tc> ops{
+    code_block2tc(std::vector<expr2tc>{}),  // try block
+    code_block2tc(std::vector<expr2tc>{}),  // handler for std::runtime_error
+    code_block2tc(std::vector<expr2tc>{})}; // handler for std::logic_error
+  require_expr_roundtrip(code_cpp_catch2tc(exceptions, ops));
 }
 
 TEST_CASE("migrate expr round-trips for code_cpp_throw", "[migrate][b2-vtrack]")


### PR DESCRIPTION
## What

Fixes two **flag-only** exception-handling defects in the `--irep2-bodies` IREP2 structured-CF round-trip (esbmc#4715). The legacy (flag-off) path is unaffected. Both were surfaced by a verdict-parity sweep (flag ON vs OFF) that the per-frontend `_01` smoke tests missed.

1. **`throw` dropped → false `SUCCESSFUL`.** A `side_effect_exprt("cpp-throw")` nested in a `code_expression` round-trips to its code form `codet("cpp-throw")`. `convert_expression`'s `remove_sideeffects` only recognizes the side-effect form, so the throw became an inert `OTHER` and was silently dropped — yielding a spurious `VERIFICATION SUCCESSFUL`. This affected **every** frontend that throws (Python `raise` / builtin `TypeError`s such as `abs("x")`, C++ `throw`). Fix: `convert_expression` dispatches a code-valued operand via `convert(to_code(...))`.

2. **`try`/`catch` → SIGSEGV.** `code_cpp_catch2t` stored only `exception_list` and had **no operand storage**, so the forward migrate dropped the try/handler blocks and `convert_catch` read `op0()` on an empty operand list. Fix: added a `std::vector<expr2tc> operands` field; forward/back migration carry the try + handler blocks and re-attach each handler's `exception_id` from the parallel `exception_list`, disambiguating the source-level form from the post-goto-convert CATCH marker on `operands.empty()`.

## Tests

- `github_4715_irep2_bodies_py_exc_01{,_fail}` — Python `try/except` over a builtin `TypeError`.
- `github_4715_irep2_bodies_cpp_exc_01{,_fail}` — C++ single-handler `try/catch`.
- `github_4715_irep2_bodies_cpp_exc_02` — C++ multi-handler `try/catch` (exercises the per-handler `exception_id` indexing for more than one handler).
- Round-trip unit tests cover both `code_cpp_catch` forms (marker and operand-carrying).

Verified green: the new exception tests, 29 migrate unit tests, and 155 flag-off `esbmc-cpp/try_catch` regression tests; dual-solver (Z3 + Bitwuzla).

Refs #4715.