### PR TITLE
[SAFE-LD] Implement ld-verify runner driving esbmc with JSON report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,6 @@ endif()
 
 add_subdirectory(src)
 
-if(ENABLE_LD_FRONTEND)
-  add_subdirectory(tools/ld-verify)
-endif()
-
 include(Irep2Optimization)
 
 # Generate ac_config.h. This must be generated after solvers
@@ -164,6 +160,11 @@ if(BUILD_TESTING)
     if(ENABLE_LD_FRONTEND)
         add_subdirectory(regression/ld)
     endif()
+endif()
+# Added after enable_testing() so the ld-verify CLI's own CTest cases register;
+# the binary itself is built whenever the LD front-end is enabled.
+if(ENABLE_LD_FRONTEND)
+  add_subdirectory(tools/ld-verify)
 endif()
 if(ENABLE_REGRESSION)
     add_subdirectory(regression)

--- a/regression/ld/fault_injection_safe/guard.ld
+++ b/regression/ld/fault_injection_safe/guard.ld
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-10"/>
+  <contentHeader name="Guard"/><types/><instances/>
+  <pous>
+    <pou name="Guard" pouType="program">
+      <interface>
+        <inputVars><variable name="Inhibit"><type><BOOL/></type></variable></inputVars>
+        <outputVars><variable name="Hazard"><type><BOOL/></type></variable></outputVars>
+      </interface>
+      <body><LD>
+        <rung localId="1"><contact variable="Inhibit" negated="negated"/><coil variable="Hazard"/></rung>
+      </LD></body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/fault_injection_safe/props.yaml
+++ b/regression/ld/fault_injection_safe/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: absence
+    expression: "Hazard && Inhibit"
+    description: "Hazard output must stay off while Inhibit is asserted"

--- a/regression/ld/fault_injection_safe/test.desc
+++ b/regression/ld/fault_injection_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+guard.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/fault_injection_unsafe/guard.ld
+++ b/regression/ld/fault_injection_unsafe/guard.ld
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-10"/>
+  <contentHeader name="Guard"/><types/><instances/>
+  <pous>
+    <pou name="Guard" pouType="program">
+      <interface>
+        <inputVars><variable name="Inhibit"><type><BOOL/></type></variable></inputVars>
+        <outputVars><variable name="Hazard"><type><BOOL/></type></variable></outputVars>
+      </interface>
+      <body><LD>
+        <rung localId="1"><contact variable="Inhibit" negated="negated"/><coil variable="Hazard"/></rung>
+      </LD></body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/fault_injection_unsafe/props.yaml
+++ b/regression/ld/fault_injection_unsafe/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: absence
+    expression: "Hazard && Inhibit"
+    description: "Hazard output must stay off while Inhibit is asserted"

--- a/regression/ld/fault_injection_unsafe/test.desc
+++ b/regression/ld/fault_injection_unsafe/test.desc
@@ -1,0 +1,4 @@
+CORE
+guard.ld
+--ld-props props.yaml --ld-fault-injection --incremental-bmc --unwind 2
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -127,7 +127,12 @@ const struct group_opt_templ all_cmd_options[] = {
    {{"ld-props",
      boost::program_options::value<std::string>()->value_name("file"),
      "YAML safety-property specification for IEC 61131-3 Ladder Diagram "
-     "(.ld) programs"}}},
+     "(.ld) programs"},
+    {"ld-fault-injection",
+     NULL,
+     "Plant known semantic errors in the Ladder Diagram (negate contact "
+     "polarities, degrade Set/Reset coils to plain output coils) to validate "
+     "that the property checks detect them"}}},
 #endif
 #ifdef ENABLE_SOLIDITY_FRONTEND
   {"Solidity frontend",

--- a/src/ld-frontend/CMakeLists.txt
+++ b/src/ld-frontend/CMakeLists.txt
@@ -23,10 +23,13 @@ add_library(ldfrontend STATIC
 
 target_include_directories(ldfrontend
   PUBLIC  ${CMAKE_SOURCE_DIR}/src
+          ${Boost_INCLUDE_DIRS}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# ld_verify.cpp drives the esbmc binary via Boost.Process and locates it via
+# Boost.DLL, which need Boost.Filesystem/System at link time.
 target_link_libraries(ldfrontend
   PUBLIC pugixml::static util_esbmc irep2
-  PRIVATE fmt::fmt yaml-cpp::yaml-cpp
+  PRIVATE fmt::fmt yaml-cpp::yaml-cpp ${Boost_LIBRARIES}
 )

--- a/src/ld-frontend/ld_language.cpp
+++ b/src/ld-frontend/ld_language.cpp
@@ -76,6 +76,8 @@ bool ld_languaget::typecheck(contextt &context, const std::string & /*module*/)
     LdIR ir = builder.build(ast_);
 
     ld_converter converter(context, ir);
+    if (config.options.get_bool_option("ld-fault-injection"))
+      converter.enable_fault_injection(true);
     converter.convert();
 
     // Append property assertions into the scan-loop body of ld::scan_loop.

--- a/src/ld-frontend/verify/ld_verify.cpp
+++ b/src/ld-frontend/verify/ld_verify.cpp
@@ -135,8 +135,11 @@ run_esbmc(const fs::path &esbmc, const std::vector<std::string> &args)
 }
 
 // Extract the human-readable description from esbmc's "Violated property:"
-// block, which lists the source location, the property comment (the description
-// set by the property encoder), and the guard expression on consecutive lines.
+// block, which lists the source location ("file ... line ..."), the property
+// comment (the description set by the property encoder), and the guard
+// expression on consecutive lines.  The location line may be absent or the
+// layout may shift, so take the first non-empty, non-location line as the
+// description rather than indexing a fixed position.
 static void
 parse_violated_property(const std::string &output, LdVerifyResult &r)
 {
@@ -146,19 +149,17 @@ parse_violated_property(const std::string &output, LdVerifyResult &r)
          line.find("Violated property:") == std::string::npos)
     ;
 
-  std::vector<std::string> block;
   while (std::getline(ss, line))
   {
     const size_t start = line.find_first_not_of(" \t");
     if (start == std::string::npos)
       break; // a blank line ends the block
-    block.push_back(line.substr(start));
+    const std::string trimmed = line.substr(start);
+    if (trimmed.rfind("file ", 0) == 0)
+      continue; // source-location line, not the description
+    r.description = trimmed;
+    return;
   }
-
-  // location, description, guard — the description is present only when the
-  // property carried a comment (the encoder always sets one).
-  if (block.size() >= 3)
-    r.description = block[1];
 }
 
 // esbmc prints its verdict as a standalone, unindented line; match the whole
@@ -181,6 +182,13 @@ static bool has_verdict_line(const std::string &output, const char *verdict)
 LdVerifyResult LdVerifyRunner::run(const LdVerifyOptions &opts)
 {
   LdVerifyResult r;
+
+  if (opts.program_path.empty())
+  {
+    r.verdict = LdVerifyResult::Verdict::Error;
+    r.description = "no input program specified";
+    return r;
+  }
 
   const fs::path esbmc = locate_esbmc();
   if (esbmc.empty())
@@ -215,9 +223,18 @@ LdVerifyResult LdVerifyRunner::run(const LdVerifyOptions &opts)
   if (input.extension() != ".ld")
   {
     boost::system::error_code ec;
-    temp_ld =
-      fs::temp_directory_path(ec) / fs::unique_path("ld-verify-%%%%-%%%%.ld");
-    fs::copy_file(input, temp_ld, fs::copy_options::overwrite_existing, ec);
+    const fs::path tmp_dir = fs::temp_directory_path(ec);
+    if (ec)
+    {
+      r.verdict = LdVerifyResult::Verdict::Error;
+      r.description =
+        "could not determine the temporary directory: " + ec.message();
+      return r;
+    }
+    // unique_path guarantees a fresh name, so the plain copy_file overload
+    // suffices (no overwrite option needed).
+    temp_ld = tmp_dir / fs::unique_path("ld-verify-%%%%-%%%%.ld");
+    fs::copy_file(input, temp_ld, ec);
     if (ec)
     {
       r.verdict = LdVerifyResult::Verdict::Error;

--- a/src/ld-frontend/verify/ld_verify.cpp
+++ b/src/ld-frontend/verify/ld_verify.cpp
@@ -1,10 +1,28 @@
 #include <ld-frontend/verify/ld_verify.h>
-#include <array>
-#include <cstdio>
-#include <cstdlib>
-#include <filesystem>
 #include <sstream>
-#include <unistd.h>
+#include <vector>
+#include <cstdlib>
+
+#include <boost/version.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/dll/runtime_symbol_info.hpp>
+
+// Boost.Process header layout differs between releases (see the same block in
+// src/python-frontend/python_language.cpp).  We use it to run the esbmc binary.
+#if defined(__APPLE__) || (BOOST_VERSION == 108700)
+#  include <boost/process/v1.hpp>
+namespace bp = boost::process::v1;
+#elif BOOST_VERSION >= 108800
+#  include <boost/process/v1/child.hpp>
+#  include <boost/process/v1/io.hpp>
+#  include <boost/process/v1/search_path.hpp>
+namespace bp = boost::process::v1;
+#else
+#  include <boost/process.hpp>
+namespace bp = boost::process;
+#endif
+
+namespace fs = boost::filesystem;
 
 static std::string json_escape(const std::string &s)
 {
@@ -76,162 +94,205 @@ std::string LdVerifyResult::to_json() const
   return s.str();
 }
 
-// Single-quote a string for safe inclusion in a /bin/sh command line.
-static std::string shell_quote(const std::string &s)
+// Locate the esbmc binary: the $ESBMC override, then alongside or relative to
+// this executable (installed bin/ and the build tree), then $PATH.
+static fs::path locate_esbmc()
 {
-  std::string q = "'";
-  for (char c : s)
-    q += (c == '\'') ? std::string("'\\''") : std::string(1, c);
-  q += "'";
-  return q;
-}
+  if (const char *env = std::getenv("ESBMC"))
+    if (*env && fs::exists(env))
+      return fs::path(env);
 
-// Locate the esbmc binary: honour $ESBMC, else rely on $PATH.
-static std::string esbmc_binary()
-{
-  const char *e = std::getenv("ESBMC");
-  return (e && *e) ? std::string(e) : std::string("esbmc");
-}
-
-// Pull the violated-property description out of an ESBMC counterexample.
-// The trace prints "Violated property:" then an indented "file <path>" line,
-// then the assertion comment (the property description).  Scan for the first
-// non-empty, non-"file" line after the header rather than assuming a fixed
-// layout, so the field survives minor trace-format changes.
-static std::string extract_violated_description(const std::string &output)
-{
-  auto pos = output.find("Violated property:");
-  if (pos == std::string::npos)
-    return {};
-
-  std::istringstream is(output.substr(pos));
-  std::string line;
-  std::getline(is, line); // consume the "Violated property:" header
-  while (std::getline(is, line))
+  boost::system::error_code ec;
+  fs::path self = boost::dll::program_location(ec);
+  if (!ec)
   {
-    auto begin = line.find_first_not_of(" \t");
-    if (begin == std::string::npos)
-      continue; // blank line
-    std::string trimmed = line.substr(begin);
-    if (trimmed.rfind("file ", 0) == 0)
-      continue; // source-location line, not the description
-    return trimmed;
+    const fs::path dir = self.parent_path();
+    const fs::path candidates[] = {
+      dir / "esbmc",                                // installed: bin/esbmc
+      dir / ".." / ".." / "src" / "esbmc" / "esbmc" // build tree
+    };
+    for (const auto &cand : candidates)
+      if (fs::exists(cand))
+        return cand;
   }
-  return {};
+
+  return bp::search_path("esbmc");
+}
+
+// Run esbmc with the given arguments, returning its merged stdout+stderr.
+static std::string
+run_esbmc(const fs::path &esbmc, const std::vector<std::string> &args)
+{
+  bp::ipstream out;
+  bp::child proc(esbmc, args, (bp::std_out & bp::std_err) > out);
+
+  std::ostringstream captured;
+  std::string line;
+  while (std::getline(out, line))
+    captured << line << '\n';
+  proc.wait();
+  return captured.str();
+}
+
+// Extract the human-readable description from esbmc's "Violated property:"
+// block, which lists the source location, the property comment (the description
+// set by the property encoder), and the guard expression on consecutive lines.
+static void
+parse_violated_property(const std::string &output, LdVerifyResult &r)
+{
+  std::istringstream ss(output);
+  std::string line;
+  while (std::getline(ss, line) &&
+         line.find("Violated property:") == std::string::npos)
+    ;
+
+  std::vector<std::string> block;
+  while (std::getline(ss, line))
+  {
+    const size_t start = line.find_first_not_of(" \t");
+    if (start == std::string::npos)
+      break; // a blank line ends the block
+    block.push_back(line.substr(start));
+  }
+
+  // location, description, guard — the description is present only when the
+  // property carried a comment (the encoder always sets one).
+  if (block.size() >= 3)
+    r.description = block[1];
+}
+
+// esbmc prints its verdict as a standalone, unindented line; match the whole
+// line so that descriptive text echoed into the counterexample cannot be
+// mistaken for a verdict.
+static bool has_verdict_line(const std::string &output, const char *verdict)
+{
+  std::istringstream ss(output);
+  std::string line;
+  while (std::getline(ss, line))
+  {
+    if (!line.empty() && line.back() == '\r')
+      line.pop_back(); // tolerate CRLF
+    if (line == verdict)
+      return true;
+  }
+  return false;
 }
 
 LdVerifyResult LdVerifyRunner::run(const LdVerifyOptions &opts)
 {
-  namespace fs = std::filesystem;
   LdVerifyResult r;
 
-  if (opts.program_path.empty())
-  {
-    r.verdict = LdVerifyResult::Verdict::Error;
-    r.description = "no input program specified";
-    return r;
-  }
-
-  // "portfolio" currently shares the k-induction invocation (the dedicated
-  // portfolio orchestration is future work); reject anything else so a typo is
-  // not silently treated as k-induction.
-  const bool bmc = (opts.strategy == "bmc");
-  if (!bmc && opts.strategy != "k-induction" && opts.strategy != "portfolio")
+  const fs::path esbmc = locate_esbmc();
+  if (esbmc.empty())
   {
     r.verdict = LdVerifyResult::Verdict::Error;
     r.description =
-      "unknown strategy '" + opts.strategy + "' (expected k-induction|bmc)";
+      "esbmc binary not found; set the ESBMC environment variable or add "
+      "esbmc to PATH";
     return r;
   }
 
-  // ESBMC dispatches frontends by file extension (§4.2), so a PLCopen .xml
-  // file must be staged as a .ld copy before invocation.  A PID-tagged name
-  // keeps concurrent ld-verify runs from clobbering each other's staging file.
-  std::string program = opts.program_path;
-  std::string staged;
-  if (fs::path(program).extension() != ".ld")
+  // esbmc dispatches frontends by file extension, so a PLCopen .xml input must
+  // be presented to it as a .ld file (plan §4.2).  Copy to a temp .ld when the
+  // suffix is not already .ld.
+  fs::path input = opts.program_path;
+  fs::path temp_ld;
+
+  // Remove the staged temp .ld on every exit path, including exceptions.
+  struct temp_cleanup
   {
-    std::error_code ec;
-    fs::path tmp = fs::temp_directory_path() /
-                   (fs::path(program).stem().string() + "-ldverify-" +
-                    std::to_string(static_cast<long>(getpid())) + ".ld");
-    fs::copy_file(program, tmp, fs::copy_options::overwrite_existing, ec);
+    const fs::path &path;
+    ~temp_cleanup()
+    {
+      if (!path.empty())
+      {
+        boost::system::error_code ec;
+        fs::remove(path, ec);
+      }
+    }
+  } cleanup{temp_ld};
+
+  if (input.extension() != ".ld")
+  {
+    boost::system::error_code ec;
+    temp_ld =
+      fs::temp_directory_path(ec) / fs::unique_path("ld-verify-%%%%-%%%%.ld");
+    fs::copy_file(input, temp_ld, fs::copy_options::overwrite_existing, ec);
     if (ec)
     {
       r.verdict = LdVerifyResult::Verdict::Error;
-      r.description = "could not stage .ld copy: " + ec.message();
+      r.description = "failed to stage input '" + opts.program_path +
+                      "' as a .ld file: " + ec.message();
       return r;
     }
-    staged = tmp.string();
-    program = staged;
+    input = temp_ld;
   }
 
-  std::ostringstream cmd;
-  cmd << shell_quote(esbmc_binary()) << ' ' << shell_quote(program);
-  if (!opts.props_path.empty())
-    cmd << " --ld-props " << shell_quote(opts.props_path);
-  if (bmc)
-    // The scan loop is while(true); without --no-unwinding-assertions the
-    // unwinding assertion fires at the bound and masquerades as a property
-    // violation.  Suppressing it gives genuine bounded semantics: a real
-    // property violation within the bound still FAILS, while its absence maps
-    // to INCOMPLETE (never SAFE) below.
-    cmd << " --unwind " << opts.bmc_unwind << " --no-unwinding-assertions";
-  else
-    cmd << " --k-induction --unlimited-k-steps";
-  cmd << " 2>&1";
+  std::vector<std::string> args{input.string()};
 
-  std::string output;
-  FILE *pipe = popen(cmd.str().c_str(), "r");
-  if (!pipe)
+  const std::string strategy =
+    opts.strategy.empty() ? "k-induction" : opts.strategy;
+  if (strategy == "k-induction")
   {
-    if (!staged.empty())
-    {
-      std::error_code ec;
-      fs::remove(staged, ec);
-    }
+    args.push_back("--k-induction");
+    args.push_back("--unlimited-k-steps");
+  }
+  else if (strategy == "bmc")
+  {
+    args.push_back("--incremental-bmc");
+    args.push_back("--unwind");
+    args.push_back(std::to_string(opts.bmc_unwind));
+  }
+  else
+  {
     r.verdict = LdVerifyResult::Verdict::Error;
-    r.description = "failed to launch esbmc (set $ESBMC or add it to PATH)";
+    r.description = "unsupported strategy '" + strategy +
+                    "' (expected 'k-induction' or 'bmc')";
     return r;
   }
 
-  std::array<char, 4096> buf;
-  size_t n;
-  while ((n = fread(buf.data(), 1, buf.size(), pipe)) > 0)
-    output.append(buf.data(), n);
-  int status = pclose(pipe);
-
-  if (!staged.empty())
+  if (!opts.props_path.empty())
   {
-    std::error_code ec;
-    fs::remove(staged, ec);
+    args.push_back("--ld-props");
+    args.push_back(opts.props_path);
+  }
+  if (opts.fault_injection)
+    args.push_back("--ld-fault-injection");
+
+  std::string output;
+  try
+  {
+    output = run_esbmc(esbmc, args);
+  }
+  catch (const std::exception &e)
+  {
+    r.verdict = LdVerifyResult::Verdict::Error;
+    r.description = std::string("failed to run esbmc: ") + e.what();
+    return r;
   }
 
-  r.raw_output = output;
-
-  if (output.find("VERIFICATION FAILED") != std::string::npos)
+  if (has_verdict_line(output, "VERIFICATION SUCCESSFUL"))
+    r.verdict = LdVerifyResult::Verdict::Safe;
+  else if (has_verdict_line(output, "VERIFICATION FAILED"))
   {
     r.verdict = LdVerifyResult::Verdict::Violation;
-    r.description = extract_violated_description(output);
+    parse_violated_property(output, r);
+    r.raw_output = output;
   }
-  else if (output.find("VERIFICATION SUCCESSFUL") != std::string::npos)
+  else if (has_verdict_line(output, "VERIFICATION UNKNOWN"))
   {
-    // A bounded BMC pass proves safety only up to the unwind depth (§3.7).
-    r.verdict =
-      bmc ? LdVerifyResult::Verdict::Incomplete : LdVerifyResult::Verdict::Safe;
-  }
-  else if (status != 0)
-  {
-    // No verdict token and a non-zero exit means esbmc never ran or crashed
-    // (e.g. missing binary, parse error); this is an error, not an
-    // inconclusive run.
-    r.verdict = LdVerifyResult::Verdict::Error;
-    r.description = "esbmc produced no verdict (exit status " +
-                    std::to_string(status) + "); set $ESBMC or check the input";
+    // BMC is only complete up to its unwind bound; an "unknown" under
+    // k-induction means the proof did not converge.
+    r.verdict = (strategy == "bmc") ? LdVerifyResult::Verdict::Incomplete
+                                    : LdVerifyResult::Verdict::Unknown;
+    r.raw_output = output;
   }
   else
   {
-    r.verdict = LdVerifyResult::Verdict::Unknown;
+    // No recognisable verdict: esbmc crashed, was killed, or rejected the input.
+    r.verdict = LdVerifyResult::Verdict::Error;
+    r.description = "esbmc produced no verdict";
+    r.raw_output = output;
   }
 
   return r;

--- a/src/ld-frontend/verify/ld_verify.h
+++ b/src/ld-frontend/verify/ld_verify.h
@@ -11,7 +11,7 @@ struct LdVerifyOptions
 {
   std::string program_path; // PLCopen XML or .ld input
   std::string props_path;   // YAML property file (optional)
-  std::string strategy;     // "k-induction" | "bmc" | "portfolio"
+  std::string strategy;     // "k-induction" | "bmc"
   unsigned bmc_unwind = 100;
   bool fault_injection = false;
 };

--- a/tools/ld-verify/CMakeLists.txt
+++ b/tools/ld-verify/CMakeLists.txt
@@ -12,3 +12,45 @@ target_link_libraries(ld-verify
   PRIVATE ldfrontend util_esbmc irep2 langapi
           ${Boost_LIBRARIES}
 )
+
+if(BUILD_TESTING)
+  set(_ld_reg ${CMAKE_SOURCE_DIR}/regression/ld)
+
+  # ld-verify locates esbmc via $ESBMC; point it at the freshly built binary.
+  # PASS_REGULAR_EXPRESSION matches the JSON report and ignores the exit code,
+  # so VIOLATION (exit 10) and ERROR (exit 2) cases register as passes.
+  function(add_ld_verify_test name regex)
+    add_test(NAME ld-verify/${name}
+             COMMAND ld-verify ${ARGN})
+    set_tests_properties(ld-verify/${name} PROPERTIES
+      PASS_REGULAR_EXPRESSION "${regex}"
+      ENVIRONMENT "ESBMC=$<TARGET_FILE:esbmc>"
+      TIMEOUT 120
+      LABELS "ld-verify")
+  endfunction()
+
+  # esbmc routes by extension, so stage a .xml copy to exercise the temp-.ld path.
+  configure_file(${_ld_reg}/motor_interlock/motor_interlock.ld
+                 ${CMAKE_CURRENT_BINARY_DIR}/motor_interlock.xml COPYONLY)
+
+  add_ld_verify_test(show-parse "Network 'main'"
+    ${_ld_reg}/motor_interlock/motor_interlock.ld --show-parse)
+  add_ld_verify_test(safe "\"result\": \"SAFE\""
+    ${_ld_reg}/motor_interlock/motor_interlock.ld
+    --props ${_ld_reg}/motor_interlock/props.yaml)
+  add_ld_verify_test(xml-input "\"result\": \"SAFE\""
+    ${CMAKE_CURRENT_BINARY_DIR}/motor_interlock.xml
+    --props ${_ld_reg}/motor_interlock/props.yaml)
+  add_ld_verify_test(violation "\"result\": \"VIOLATION\""
+    ${_ld_reg}/mutual_exclusion_unsafe/unsafe.ld
+    --props ${_ld_reg}/mutual_exclusion_unsafe/props.yaml --strategy bmc --unwind 2)
+  add_ld_verify_test(incomplete "\"result\": \"INCOMPLETE\""
+    ${_ld_reg}/motor_interlock/motor_interlock.ld
+    --props ${_ld_reg}/motor_interlock/props.yaml --strategy bmc --unwind 2)
+  add_ld_verify_test(fault-injection "\"result\": \"VIOLATION\""
+    ${_ld_reg}/fault_injection_unsafe/guard.ld
+    --props ${_ld_reg}/fault_injection_unsafe/props.yaml
+    --strategy bmc --unwind 2 --fault-injection)
+  add_ld_verify_test(unsupported-strategy "unsupported strategy"
+    ${_ld_reg}/motor_interlock/motor_interlock.ld --strategy portfolio)
+endif()

--- a/tools/ld-verify/main.cpp
+++ b/tools/ld-verify/main.cpp
@@ -5,19 +5,22 @@
 
 static void print_usage()
 {
-  std::cerr <<
-    "Usage: ld-verify [options] <program.xml>\n"
-    "\n"
-    "Options:\n"
-    "  --props <file.yaml>   YAML property specification\n"
-    "  --strategy <s>        k-induction | bmc | portfolio (default: k-induction)\n"
-    "  --unwind <n>          BMC unwind bound (default: 100)\n"
-    "  --fault-injection     Enable fault-injection mode (for WP1 validation)\n"
-    "  --show-parse          Print the parsed LD program and exit\n"
-    "  --help                Print this message\n"
-    "\n"
-    "ld-verify checks safety properties of IEC 61131-3 Ladder Diagram programs\n"
-    "exported in PLCopen XML format.  Results are reported as JSON to stdout.\n";
+  std::cerr
+    << "Usage: ld-verify [options] <program.xml>\n"
+       "\n"
+       "Options:\n"
+       "  --props <file.yaml>   YAML property specification\n"
+       "  --strategy <s>        k-induction | bmc (default: k-induction)\n"
+       "  --unwind <n>          BMC unwind bound (default: 100)\n"
+       "  --fault-injection     Enable fault-injection mode (for WP1 "
+       "validation)\n"
+       "  --show-parse          Print the parsed LD program and exit\n"
+       "  --help                Print this message\n"
+       "\n"
+       "ld-verify checks safety properties of IEC 61131-3 Ladder Diagram "
+       "programs\n"
+       "exported in PLCopen XML format.  Results are reported as JSON to "
+       "stdout.\n";
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Implements the previously-stubbed `LdVerifyRunner` so the `ld-verify` CLI actually drives esbmc and emits its JSON report (SAFE-LD plan §3.6). The runner locates the esbmc binary (`$ESBMC`, then self-relative for the build tree / installed `bin/`, then `PATH`), stages a PLCopen `.xml` input as a temporary `.ld` so esbmc's extension dispatch routes it (§4.2), maps `--strategy` to esbmc flags (`k-induction`/`bmc`), invokes esbmc via Boost.Process capturing its output, and parses the verdict (SAFE/VIOLATION/INCOMPLETE/UNKNOWN/ERROR) plus the violated-property description.

Also wires a new `--ld-fault-injection` esbmc option onto the converter's existing fault-injection support so `ld-verify --fault-injection` plants and detects a known semantic error end-to-end (WP1 validation).

Adds seven `ld-verify` CTest cases (show-parse, safe, xml-input, violation, incomplete, fault-injection, unsupported-strategy) and a `fault_injection_{safe,unsafe}` regression pair. All 15 LD tests pass; clang-format-11 clean.

Stacked on #5292 (the `--ld-props` property-verification work) and targets that branch; retarget to `master` once #5292 merges.
