### PR TITLE
[docs] Add SAFE-LD Ladder Diagram user documentation

### DIFF
--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -40,6 +40,7 @@ thread interleavings. Each reported violation is annotated with its matching
 {{< card link="/docs/c-cpp" title="C / C++" >}}
 {{< card link="/docs/python" title="Python" >}}
 {{< card link="/docs/solidity" title="Solidity" >}}
+{{< card link="/docs/ld" title="Ladder Diagram" >}}
 {{< card link="/docs/cwe-mapping" title="CWE Mapping" >}}
 {{< card link="/docs/development" title="Development" >}} {{< /cards >}}
 

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -39,8 +39,8 @@ thread interleavings. Each reported violation is annotated with its matching
 {{< card link="/docs/coverage" title="Coverage" >}}
 {{< card link="/docs/c-cpp" title="C / C++" >}}
 {{< card link="/docs/python" title="Python" >}}
-{{< card link="/docs/solidity" title="Solidity" >}}
 {{< card link="/docs/ld" title="Ladder Diagram" >}}
+{{< card link="/docs/solidity" title="Solidity" >}}
 {{< card link="/docs/cwe-mapping" title="CWE Mapping" >}}
 {{< card link="/docs/development" title="Development" >}} {{< /cards >}}
 

--- a/website/content/docs/ld/_index.md
+++ b/website/content/docs/ld/_index.md
@@ -1,0 +1,25 @@
+---
+title: Ladder Diagram
+weight: 130
+---
+
+SAFE-LD is ESBMC's frontend for **IEC 61131-3 Ladder Diagram (LD)** programs —
+the graphical language used to program Programmable Logic Controllers (PLCs).
+It turns a Ladder Diagram, exported as PLCopen XML, into ESBMC's internal
+representation so the engine's bounded model checker and SMT backend can verify
+safety properties of the control logic — or prove their absence.
+
+Properties are not written in the LD program itself; you supply them separately
+in a small YAML file. The frontend models the PLC's cyclic scan (read inputs →
+evaluate rungs → drive outputs, repeated forever) and checks each property on
+every scan iteration.
+
+> The frontend is gated behind the `ENABLE_LD_FRONTEND` build option (off by
+> default). See [Usage](/docs/ld/usage) for how to build and invoke it.
+
+{{< cards >}}
+  {{< card link="/docs/ld/overview" title="Overview" subtitle="The cyclic-scan model and the pipeline from PLCopen XML to SMT formula." >}}
+  {{< card link="/docs/ld/usage" title="Usage" subtitle="Build with the LD frontend, run esbmc on a .ld program, and read the result." >}}
+  {{< card link="/docs/ld/property-format" title="Property Format" subtitle="The YAML specification for the five supported property kinds." >}}
+  {{< card link="/docs/ld/limitations" title="Limitations" subtitle="Supported constructs and current restrictions." >}}
+{{< /cards >}}

--- a/website/content/docs/ld/limitations.md
+++ b/website/content/docs/ld/limitations.md
@@ -11,8 +11,9 @@ supported and the known restrictions.
 
 - **Contacts and coils** — normally-open and normally-closed contacts; output,
   Set, and Reset coils.
-- **Timers** — `TON` (on-delay), `TOF` (off-delay), and `TP` (pulse), with their
-  retained `ET`/`Q` state evaluated per scan.
+- **Timers** — `TON` (on-delay) and `TOF` (off-delay), with their retained
+  `ET`/`Q` state evaluated per scan. `TP` (pulse) blocks are accepted but
+  currently simplified to `TON` semantics — see Restrictions below.
 - **Counters** — `CTU` (count-up) and `CTD` (count-down), edge-triggered on the
   count input, with reset handling.
 - **Arithmetic function blocks** — `ADD`, `SUB`, `MUL`, `DIV`, and `MOVE`.
@@ -25,6 +26,10 @@ supported and the known restrictions.
 
 - **Input format.** Programs must be supplied as PLCopen XML. Other LD
   serialisations are not parsed.
+- **`TP` pulse timers.** `TP` blocks are modelled with `TON` (on-delay)
+  semantics: `Q` rises after `IN` has been held for `PT` ticks, rather than
+  emitting a fixed-width pulse on a rising edge of `IN`. Properties that depend
+  on accurate pulse-timer behaviour are not faithfully checked yet.
 - **Property expression syntax.** Expressions in `invariant` and `absence`
   properties are Boolean-only: variable names combined with `!`, `&&`, `||`, and
   parentheses. Arithmetic relations (for example `Counter >= 5`) are not yet

--- a/website/content/docs/ld/limitations.md
+++ b/website/content/docs/ld/limitations.md
@@ -1,0 +1,43 @@
+---
+title: Limitations
+weight: 4
+---
+
+The Ladder Diagram frontend is under active development and is gated behind the
+`ENABLE_LD_FRONTEND` build option. This page records what is currently
+supported and the known restrictions.
+
+## Supported constructs
+
+- **Contacts and coils** — normally-open and normally-closed contacts; output,
+  Set, and Reset coils.
+- **Timers** — `TON` (on-delay), `TOF` (off-delay), and `TP` (pulse), with their
+  retained `ET`/`Q` state evaluated per scan.
+- **Counters** — `CTU` (count-up) and `CTD` (count-down), edge-triggered on the
+  count input, with reset handling.
+- **Arithmetic function blocks** — `ADD`, `SUB`, `MUL`, `DIV`, and `MOVE`.
+- **Variable types** — `BOOL`, and the integer types `INT`/`DINT`/`TIME`
+  (modelled as 32-bit integers).
+- **Properties** — the five kinds described in
+  [Property Format](/docs/ld/property-format).
+
+## Restrictions
+
+- **Input format.** Programs must be supplied as PLCopen XML. Other LD
+  serialisations are not parsed.
+- **Property expression syntax.** Expressions in `invariant` and `absence`
+  properties are Boolean-only: variable names combined with `!`, `&&`, `||`, and
+  parentheses. Arithmetic relations (for example `Counter >= 5`) are not yet
+  accepted in property expressions.
+- **Bounded results.** `response` properties are complete only up to their
+  justified `max_scans`. Under BMC, `reachability` and all other properties are
+  checked only up to the unwind bound; use `--k-induction` for an unbounded
+  safety proof.
+- **Integer width.** Integer variables are fixed at 32 bits; configurable widths
+  are not modelled.
+
+## Reporting issues
+
+The frontend is evolving. Please report bugs or missing constructs on the
+[GitHub issue tracker](https://github.com/esbmc/esbmc/issues), ideally with the
+PLCopen XML and the property file that reproduce the problem.

--- a/website/content/docs/ld/overview.md
+++ b/website/content/docs/ld/overview.md
@@ -1,0 +1,60 @@
+---
+title: Overview
+weight: 1
+---
+
+SAFE-LD verifies IEC 61131-3 Ladder Diagram programs by modelling the PLC's
+cyclic scan and encoding user-supplied safety properties as assertions checked
+on every scan iteration.
+
+## The cyclic-scan model
+
+A PLC executes its program in an endless loop called the *scan cycle*:
+
+1. **Read inputs** — sample the physical input variables.
+2. **Evaluate rungs** — compute coil and function-block outputs from the current
+   inputs and retained state.
+3. **Write outputs** — drive the physical outputs.
+
+The frontend reproduces this faithfully. Each scan re-samples every input
+variable non-deterministically, so verification explores *all* possible input
+sequences rather than a single fixed trace. The rung logic and the retained
+state of timers and counters are evaluated exactly as a PLC would, and the whole
+body sits inside a `while(true)` scan loop. Properties are appended to the scan
+body, so they are checked once per cycle, for every reachable state.
+
+## Pipeline
+
+```
+PLCopen .xml  ──►  parse  ──►  LD IR  ──►  GOTO program  ──►  SSA  ──►  SMT
+   (.ld)                     (rungs,      (scan loop +
+                              FBs, vars)   assertions)
+```
+
+- **Parse** — the PLCopen XML is read into an internal Ladder Diagram IR of
+  rungs, contacts, coils, and function-block instances.
+- **IR generation** — the IR is lowered to a GOTO program: a scan loop whose
+  body reads inputs, evaluates each rung, and updates timer/counter state.
+- **Property encoding** — each entry in the YAML property file is turned into an
+  assertion (`code_assertt`) spliced into the scan body. The property's
+  `description` is carried into the assertion comment, so a violated property is
+  named in the counterexample.
+- **Backend** — from there it is the standard ESBMC pipeline: symbolic execution
+  to SSA, SMT encoding, and solving.
+
+## Verification strategies
+
+Because the scan loop is unbounded, the strategy you choose determines what a
+result means:
+
+- **k-induction** (`--k-induction --unlimited-k-steps`) — attempts an unbounded
+  proof. A successful run proves the property holds on *every* scan cycle. This
+  is the strategy to use when you want to establish safety.
+- **Bounded model checking** (`--incremental-bmc`) — explores scan cycles up to
+  a bound. It is complete for finding violations within that bound: a reported
+  counterexample is a genuine bug. Absence of a counterexample only means "no
+  violation up to the bound", not a full proof.
+
+See [Usage](/docs/ld/usage) for concrete invocations and
+[Property Format](/docs/ld/property-format) for the soundness and completeness
+guarantees of each property kind.

--- a/website/content/docs/ld/property-format.md
+++ b/website/content/docs/ld/property-format.md
@@ -1,0 +1,133 @@
+---
+title: Property Format
+weight: 3
+---
+
+Safety properties are written in a YAML file passed to ESBMC with `--ld-props`.
+Each property is encoded as an assertion checked on every scan cycle. This page
+specifies the file structure and the five supported property kinds.
+
+## File structure
+
+```yaml
+properties:
+  - id: <string>                  # unique within the file
+    kind: <property-kind>
+    description: <string>         # optional; shown in counterexamples
+    justification: <string>       # required for 'response' and 'reachability'
+    # kind-specific fields (see below)
+```
+
+The `id` names the property. The optional `description` is copied verbatim into
+the assertion comment, so it appears in the ESBMC counterexample and identifies
+which property failed. Variable names in expressions must match the identifiers
+declared in the PLCopen XML `<variable name="...">` elements exactly
+(case-sensitive).
+
+## Property kinds
+
+### `mutual_exclusion`
+
+Two or more BOOL variables are never simultaneously `TRUE`.
+
+```yaml
+- id: P1
+  kind: mutual_exclusion
+  variables: [Motor_Forward, Motor_Reverse]
+  description: "Forward and Reverse coils must never be energised simultaneously"
+```
+
+Sound and complete.
+
+### `invariant`
+
+A Boolean expression over LD variables holds at all times.
+
+```yaml
+- id: P2
+  kind: invariant
+  expression: "ESD_Valve_Closed || !High_Pressure_Alarm"
+  description: "ESD valve must be closed when the high-pressure alarm is active"
+```
+
+Expression syntax: declared variable names, `!` (negation), `&&` (conjunction),
+`||` (disjunction), and `(...)` for grouping. Sound and complete.
+
+### `absence`
+
+A Boolean expression never holds (the dual of `invariant`).
+
+```yaml
+- id: P3
+  kind: absence
+  expression: "OL_Trip && Motor_Forward"
+  description: "Motor must not run forward when the overload trip is active"
+```
+
+Sound and complete.
+
+### `response`
+
+Whenever a `trigger` variable becomes `TRUE`, a `response` variable becomes
+`TRUE` within `max_scans` scan iterations.
+
+```yaml
+- id: P4
+  kind: response
+  trigger: Start_Button
+  response: Conveyor_Running
+  max_scans: 5
+  justification: "TON1_PT is 2 ticks; worst-case 3 scans + 2-scan margin"
+```
+
+Sound, but **bounded** by `max_scans`. The bound must be justified by timing
+analysis (recorded in the required `justification` field).
+
+### `reachability`
+
+A target state is reachable — useful for liveness checks. Under BMC, a
+`VIOLATION` means the target state was reached; `SAFE` under k-induction means it
+was proved unreachable.
+
+```yaml
+- id: P5
+  kind: reachability
+  expression: "Belt_1 && Belt_2 && Conveyor_Running"
+  description: "Full-speed operation state must be reachable"
+  justification: "Liveness check: all three outputs true simultaneously"
+```
+
+Under k-induction the unreachability proof is sound and complete; under BMC only
+unreachability up to the unwind bound is established.
+
+## Soundness and completeness
+
+| Kind               | Sound? | Complete?        | Notes                                            |
+|--------------------|--------|------------------|--------------------------------------------------|
+| `mutual_exclusion` | Yes    | Yes              | Checked every scan; k-induction and BMC agree    |
+| `invariant`        | Yes    | Yes              | As above                                         |
+| `absence`          | Yes    | Yes              | As above                                         |
+| `response`         | Yes    | Bounded          | Requires a justified `max_scans`                 |
+| `reachability`     | Yes    | No (BMC-bounded) | k-induction unreachability proof is complete     |
+
+## Example: motor interlock
+
+```yaml
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [Motor_Forward, Motor_Reverse]
+    description: "Forward and Reverse coils must never be simultaneously energised"
+
+  - id: P2
+    kind: response
+    trigger: Start_Button
+    response: Motor_Forward
+    max_scans: 3
+    justification: "Direct coil; no timer; response in same scan cycle + 2 margin"
+
+  - id: P3
+    kind: invariant
+    expression: "Motor_Forward || !Start_Fwd || Motor_Reverse"
+    description: "Forward start only activates the forward coil (not reverse)"
+```

--- a/website/content/docs/ld/property-format.md
+++ b/website/content/docs/ld/property-format.md
@@ -68,8 +68,13 @@ Sound and complete.
 
 ### `response`
 
-Whenever a `trigger` variable becomes `TRUE`, a `response` variable becomes
-`TRUE` within `max_scans` scan iterations.
+Whenever a `trigger` variable is held `TRUE`, a `response` variable becomes
+`TRUE` within `max_scans` scan iterations. The check is **level-triggered**: an
+auxiliary counter counts consecutive scans in which `trigger` is `TRUE` and
+`response` is not, and resets whenever `trigger` goes `FALSE` or `response`
+becomes `TRUE`. If the trigger is released before the bound is reached, no
+violation is reported — the property constrains sustained trigger conditions,
+not one-shot edges.
 
 ```yaml
 - id: P4
@@ -85,9 +90,12 @@ analysis (recorded in the required `justification` field).
 
 ### `reachability`
 
-A target state is reachable — useful for liveness checks. Under BMC, a
-`VIOLATION` means the target state was reached; `SAFE` under k-induction means it
-was proved unreachable.
+A target state is reachable — useful for liveness checks. The property is
+encoded as an assertion that fails when the target state is reached, so the
+ESBMC verdict reads inverted: `VERIFICATION FAILED` under BMC means the target
+state **was reached** (the liveness goal is attainable), while
+`VERIFICATION SUCCESSFUL` under k-induction means it was **proved
+unreachable**.
 
 ```yaml
 - id: P5

--- a/website/content/docs/ld/usage.md
+++ b/website/content/docs/ld/usage.md
@@ -1,0 +1,78 @@
+---
+title: Usage
+weight: 2
+---
+
+## Building with the LD frontend
+
+The Ladder Diagram frontend is disabled by default. Enable it at configure time
+with `-DENABLE_LD_FRONTEND=On`, alongside at least one SMT solver:
+
+```sh
+cmake -GNinja -Bbuild -S . \
+  -DDOWNLOAD_DEPENDENCIES=On \
+  -DENABLE_LD_FRONTEND=On \
+  -DENABLE_Z3=On \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+ninja -C build
+```
+
+See the [Build Guide](/docs/development/building) for the full dependency list
+and solver options.
+
+## Inputs
+
+You provide two files:
+
+- A **Ladder Diagram program** exported as PLCopen XML, given to ESBMC with the
+  `.ld` extension (the frontend dispatches on the file extension).
+- A **property file** in YAML describing the safety properties to check, passed
+  with `--ld-props`. See [Property Format](/docs/ld/property-format).
+
+## Running ESBMC
+
+Prove a property holds on every scan cycle with k-induction:
+
+```sh
+esbmc motor_interlock.ld --ld-props props.yaml --k-induction --unlimited-k-steps
+```
+
+```
+VERIFICATION SUCCESSFUL
+```
+
+Search for a violation within a bounded number of scan cycles with BMC:
+
+```sh
+esbmc unsafe.ld --ld-props props.yaml --incremental-bmc
+```
+
+```
+VERIFICATION FAILED
+```
+
+When a property is violated, the counterexample names it via the property's
+`description` field:
+
+```
+Violated property:
+  file unsafe.ld ...
+  Coils A and B must never be simultaneously energised
+```
+
+## Reading the result
+
+| ESBMC output | Strategy | Meaning |
+|---|---|---|
+| `VERIFICATION SUCCESSFUL` | k-induction | The property holds on every scan cycle (proved). |
+| `VERIFICATION SUCCESSFUL` | BMC | No violation up to the unwind bound (not a full proof). |
+| `VERIFICATION FAILED` | either | A genuine property violation was found; see the counterexample. |
+
+## The `ld-verify` helper
+
+The repository also ships a small `ld-verify` CLI (built whenever
+`ENABLE_LD_FRONTEND` is on) that wraps the above: it locates the `esbmc` binary,
+accepts a PLCopen `.xml` or `.ld` input, runs the chosen strategy, and prints a
+JSON report. It is convenient for tooling and CI; the `esbmc` invocations above
+remain the canonical interface.

--- a/website/content/docs/ld/usage.md
+++ b/website/content/docs/ld/usage.md
@@ -52,6 +52,11 @@ esbmc unsafe.ld --ld-props props.yaml --incremental-bmc
 VERIFICATION FAILED
 ```
 
+Incremental BMC raises the unwind bound automatically, so no explicit
+`--unwind` is needed for the infinite scan loop, and unwinding assertions are
+disabled during its base case — `VERIFICATION FAILED` therefore always
+indicates a genuine property violation, never an artifact of the bound.
+
 When a property is violated, the counterexample names it via the property's
 `description` field:
 


### PR DESCRIPTION
Adds a `docs/ld/` section to the website documenting the IEC 61131-3 Ladder Diagram (SAFE-LD) frontend, mirroring the existing Python/Solidity sections.

## Pages
- **Overview** — the PLC cyclic-scan model, the PLCopen XML → GOTO → SMT pipeline, and what k-induction vs BMC results mean.
- **Usage** — building with `-DENABLE_LD_FRONTEND=On`, invoking `esbmc program.ld --ld-props props.yaml` under k-induction/BMC, reading the verdict, and a brief note on the `ld-verify` helper.
- **Property Format** — the YAML specification for the five property kinds (`mutual_exclusion`, `invariant`, `absence`, `response`, `reachability`) with a soundness/completeness table and a worked motor-interlock example.
- **Limitations** — supported constructs (contacts/coils, TON/TOF/TP, CTU/CTD, arithmetic FBs) and current restrictions.

Linked from the docs landing page (weight 130, after Python).

## Scope
Documents only behaviour on `master` (verification via `esbmc --ld-props`, the five property kinds, `ENABLE_LD_FRONTEND`). Features still in flight (the `ld-verify` runner internals and `--ld-fault-injection` from #5294) are not documented as shipped.

Content is grounded in `docs/safe-ld-property-format.md` and the LD frontend's actual behaviour. Local Hugo build is blocked by the theme's Go module dependency; CI validates the build.