### PR TITLE
[goto-symex] Lower Python predicates before deref in GOTO guard

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -130,3 +130,58 @@ a design-level blocker, a policy-banned timeout, a questionable test expectation
 #4796 — a crash whose only sound fix is the architectural work in §5 (masking it in shared
 backend code would degrade ESBMC's bug-detection for all frontends). No further isolated,
 sound PR is available without that architectural work.
+
+---
+
+## 6. 2026-06-10 re-validation & fix
+
+Independent re-run of **all 47 KNOWNBUG python/quixbugs/humaneval/python-intensive tests**
+against `master` as of commit `9d13245e4e` (ESBMC 8.3.0, Z3 + Bitwuzla), with each test's
+own `test.desc` flags. **None now produce their expected verdict** — no zero-risk
+KNOWNBUG→CORE flip is available; the design-level classifications in §3 still hold after the
+8 days of fixes that closed the *separately-tracked* issues (#5085/#5096/#5110/#5114 string
+soundness, #5102–#5129 matmul/FP, #5015 flow-sensitive class tracking, #5274 None-handle
+width, …).
+
+### 6a. New isolated, soundly-fixable defect found & fixed
+**SMT-backend abort on a short-circuited `is None` before an attribute dereference.**
+
+A guard such as `a is None or a.b is None` (QuixBugs `detect_cycle`, `depth_first_search`,
+`topological_ordering`; and `reverse_linked_list`) dereferences `a.b` under the short-circuit
+guard `not isnone(a)`. The short-circuit lowers to a GOTO branch
+`IF !(ISNONE(cur, 0) || ISNONE(cur->nxt, 0))`, so the attribute deref lives **inside the GOTO
+guard**. In the GOTO case of `symex_step` (`symex_main.cpp`), `dereference()` ran **before**
+`simplify_python_builtins()`, so the NULL-pointer dereference-safety assertion was recorded —
+guarded by the short-circuit `not isnone(cur)` — with the still-live `isnone` in its
+condition. That `isnone` then reached `smt_convt::convert_ast`, which has no rule for it, and
+`abort()`ed (`ERROR: Couldn't convert expression in unrecognised format`; SIGABRT / core
+dump).
+
+**Fix:** in the GOTO case, lower Python predicates *before* dereferencing the guard.
+`simplify_python_builtins` is a pure no-op on non-Python expressions (no
+`isnone`/`isinstance`/`hasattr` exist in C/C++ IR), and `dereference` never introduces an
+`isnone`, so the reorder is strictly safe and has **zero effect on non-Python frontends**.
+New regression pair `github_4784_isnone_short_circuit{,_fail}`.
+
+The other two symex sites that interleave `dereference()` with `simplify_python_builtins()` —
+the ASSERT case (`symex_main.cpp`, via `claim`) and assignment RHS (`symex_assign.cpp`) — host
+the *same* `ISNONE(p, 0) || ISNONE(p->attr, 0)` pattern when the short-circuit appears in an
+`assert`/assignment over a pointer owner. They were re-tested with the unchanged ordering and
+do **not** hit the SMT-convert abort (they reach `Converting` and yield a real verdict), so the
+fix is confined to the GOTO site that actually leaks the predicate — no speculative reorder is
+added where it changes nothing.
+
+This **removes the crash** but, like #5042/#4796, **does not flip the KNOWNBUG verdicts**: the
+affected tests still hit the *pre-existing* unsound `isnone(<struct-ptr>, None) → false`
+lowering ("a `Node` pointer is never `None`"), which now surfaces as a spurious NULL-deref
+(`VERIFICATION FAILED`) instead of an abort. Closing those tests still needs the §5 object /
+Optional-model rework (#4653/#3067). This is the §5-item-5 robustness work, shipped.
+
+### 6b. Everything else: unchanged disposition
+Re-confirmed failure modes (today's master): perf/timeout (breadth_first_search, knapsack,
+flatten_fail, reverse_linked_list, shortest_path_lengths, humaneval_39/90/93/158 — §3c,
+policy-banned); clean "unsupported feature" errors (list-slice-assign for next_permutation /
+humaneval_33; tuple-unpack for minimum_spanning_tree / powerset / shortest_path_length;
+DictComp tuple targets for shortest_paths; mixed-type `sorted()` / non-const tuple slice for
+humaneval — §3b feature gaps); and wrong-verdict soundness clusters (§3b). Each remains a
+design-level blocker or a substantial sound feature, not an isolated point fix.

--- a/regression/python/github_4784_isnone_short_circuit/main.py
+++ b/regression/python/github_4784_isnone_short_circuit/main.py
@@ -1,0 +1,28 @@
+# Regression for an SMT-backend abort ("Couldn't convert expression in
+# unrecognised format") on a short-circuited `x is None or x.attr is None`
+# guard inside a loop (QuixBugs detect_cycle / depth_first_search family).
+#
+# `cur.nxt` is only dereferenced when `cur is None` is false, so symex
+# dereferences `cur.nxt` under the guard `not isnone(cur)`. dereference ran
+# before the Python-predicate lowering, so the still-live `isnone(cur)` leaked
+# into the recorded NULL-pointer dereference-safety assertion and reached the
+# SMT backend, which has no conversion rule for `isnone`, aborting. Lowering
+# Python predicates in the GOTO-guard before dereference fixes it.
+class Node:
+    def __init__(self, value, nxt=None):
+        self.value = value
+        self.nxt = nxt
+
+
+def reaches_end(head):
+    cur = head
+    while True:
+        if cur is None or cur.nxt is None:
+            return True
+        cur = cur.nxt.nxt
+    return False
+
+
+a = Node(1)
+b = Node(2, a)  # b -> a -> None
+assert reaches_end(b) == True

--- a/regression/python/github_4784_isnone_short_circuit/test.desc
+++ b/regression/python/github_4784_isnone_short_circuit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4784_isnone_short_circuit_fail/main.py
+++ b/regression/python/github_4784_isnone_short_circuit_fail/main.py
@@ -1,0 +1,23 @@
+# Failing companion to github_4784_isnone_short_circuit: same looping
+# short-circuit `x is None or x.attr is None` guard (which previously aborted
+# the SMT backend), but with a wrong assertion so the expected verdict is
+# FAILED. Pins that the fix yields a real verdict instead of crashing and that
+# the verdict is sense-preserving.
+class Node:
+    def __init__(self, value, nxt=None):
+        self.value = value
+        self.nxt = nxt
+
+
+def reaches_end(head):
+    cur = head
+    while True:
+        if cur is None or cur.nxt is None:
+            return True
+        cur = cur.nxt.nxt
+    return False
+
+
+a = Node(1)
+b = Node(2, a)  # b -> a -> None, so reaches_end(b) is True
+assert reaches_end(b) == False

--- a/regression/python/github_4784_isnone_short_circuit_fail/test.desc
+++ b/regression/python/github_4784_isnone_short_circuit_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -266,9 +266,16 @@ void goto_symext::symex_step(reachability_treet &art)
     replace_nondet(tmp);
     volatile_check(tmp);
 
+    // Lower Python predicates (isnone/isinstance/hasattr) *before* dereference:
+    // a short-circuited `a is None or a.b is None` dereferences `a.b` under the
+    // guard `not isnone(a)`, and dereference records the NULL-pointer safety
+    // assertion immediately. If the isnone is still live it leaks into that
+    // assertion's condition and reaches the SMT backend unlowered (no convert
+    // rule for isnone), aborting. dereference never introduces any of these
+    // predicates, so lowering first is strictly safe.
+    simplify_python_builtins(tmp);
     dereference(tmp, dereferencet::READ);
     replace_dynamic_allocation(tmp);
-    simplify_python_builtins(tmp);
 
     symex_goto(tmp);
   }


### PR DESCRIPTION
## Problem

A short-circuited Python guard such as `a is None or a.b is None` (QuixBugs
`detect_cycle`, `depth_first_search`, `reverse_linked_list`, …) lowers to a GOTO
branch:

```
IF !(ISNONE(cur, 0) || ISNONE(cur->nxt, 0)) THEN GOTO ...
```

so the attribute dereference `cur->nxt` lives **inside the GOTO guard**, under the
short-circuit condition `not isnone(cur)`. In the GOTO case of
`goto_symext::symex_step`, `dereference()` ran **before**
`simplify_python_builtins()`, so the NULL-pointer dereference-safety assertion was
recorded with the still-live `isnone` in its guard. That `isnone` then reached
`smt_convt::convert_ast`, which has no conversion rule for it, and `abort()`ed:

```
ERROR: Couldn't convert expression in unrecognised format
```

(SIGABRT / core dump).

## Fix

In the GOTO case, lower Python predicates **before** dereferencing the guard.
`simplify_python_builtins` is a structural no-op on non-Python IR (no
`isnone`/`isinstance`/`hasattr` nodes exist in C/C++ IR), and `dereference` never
introduces these predicates, so the reorder is sound and has **zero effect on
non-Python frontends**. The `cur->nxt` member-deref still flows into `dereference`
unchanged, so no real NULL-deref check is dropped — only the resolved `isnone` no
longer rides along in the safety assertion's guard.

The ASSERT site (`symex_main.cpp` via `claim`) and assignment RHS
(`symex_assign.cpp`) host the same `ISNONE(p,0) || ISNONE(p->attr,0)` pattern, but
were verified (via `--goto-functions-only` + execution) **not** to trigger the
abort, so they are intentionally left unchanged — the fix is confined to the site
that actually leaks the predicate.

## Tests

New passing/failing regression pair:
- `regression/python/github_4784_isnone_short_circuit` → `VERIFICATION SUCCESSFUL`
- `regression/python/github_4784_isnone_short_circuit_fail` → `VERIFICATION FAILED`

All 263 Python regression tests that exercise `is None` / `isinstance` / `hasattr`
pass (100%). clang-format clean.

## Scope

This removes the crash; it does **not** flip the `detect_cycle` KNOWNBUG (#4784),
which still hits the separately-tracked unsound `isnone(<struct-ptr>, None) → false`
lowering. Refs #4784.