### PR TITLE
[irep2] Fix VLA side-effect migrate crash under --irep2-bodies

### DIFF
--- a/regression/esbmc/github_4715_irep2_bodies_vla_01/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_vla_01/main.c
@@ -1,0 +1,27 @@
+// Regression under --irep2-bodies (esbmc#4715, V.4.4 verdict parity);
+// reproducer adapted from regression/esbmc/github_178_unary.
+//
+// A side-effect (here a preincrement) used as a VLA dimension `b[++a]` is part
+// of the array TYPE. Under --irep2-bodies the body — and the types it mentions
+// — are migrated to IREP2 before goto_convert lowers the VLA. The preincrement
+// side-effect therefore reaches migrate_expr, which used to unconditionally
+// read the side-effect's "#size" sub for every non-allocation statement. A
+// preincrement has no "#size", so migrating the empty exprt aborted with
+// "migrate expr failed". The flag-OFF path never hit this (the VLA is lowered
+// before migration), so OFF reported SUCCESSFUL while ON crashed.
+//
+// Expected: VERIFICATION SUCCESSFUL on both paths.
+
+void foo(char **q)
+{
+  q[5]; // unused expression statement: index nested in a code_expression
+}
+
+int main()
+{
+  int a = 5;
+  char *b[++a]; // VLA dimension is a preincrement side-effect
+  __ESBMC_assert(a == 6, "++a increments a to 6");
+  foo(b); // b has 6 elements; q[5] is in bounds
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_vla_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_vla_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_bodies_vla_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_vla_01_fail/main.c
@@ -1,0 +1,22 @@
+// Failing companion to github_4715_irep2_bodies_vla_01.
+//
+// Same VLA-dimension side-effect construct `b[++a]` migrated under
+// --irep2-bodies (exercises the migrate_expr side-effect path that used to
+// abort), but with a property that is violated so the verdict is FAILED.
+// Confirms ON and OFF agree on the FAILED verdict, not just on not crashing.
+//
+// Expected: VERIFICATION FAILED on both paths.
+
+void foo(char **q)
+{
+  q[5];
+}
+
+int main()
+{
+  int a = 5;
+  char *b[++a];                            // a becomes 6
+  __ESBMC_assert(a == 5, "a is 6 after ++a, so this fails");
+  foo(b);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_vla_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_vla_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-bodies
+^VERIFICATION FAILED$

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1881,9 +1881,15 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
       }
     }
     else if (
-      expr.statement() != "nondet" && expr.statement() != "function_call" &&
-      expr.statement() != "cpp-throw" && expr.statement() != "temporary_object")
-      // For everything other than nondet / cpp-throw / temporary_object,
+      expr.statement() == "malloc" || expr.statement() == "realloc" ||
+      expr.statement() == "alloca" || expr.statement() == "va_arg")
+      // Only the allocation side-effects carry a "#size" (cpp_new is handled
+      // above). The other non-allocation forms (increment/decrement,
+      // statement_expression, gcc_conditional, cpp_delete, ...) leave "#size"
+      // empty; reading it would migrate an empty exprt and abort. This surfaces
+      // under --irep2-bodies when a side-effect appears in a type's size
+      // expression (e.g. the VLA dimension `b[++a]`), migrated before
+      // goto_convert lowers it. `thesize` stays nil there, which is correct.
       migrate_expr(static_cast<const exprt &>(expr.cmt_size()), thesize);
 
     type2tc cmt_type =


### PR DESCRIPTION
## What

Under `--irep2-bodies` (IREP2 structured-CF migration, #4715), a side-effect used as a VLA dimension — e.g. the preincrement in `char *b[++a]` — crashed migration with `migrate expr failed` (SIGABRT). Minimal reproducer is the existing `regression/esbmc/github_178_unary`:

```c
void foo(char **q) { q[5]; }
int main() {
  int a;
  __ESBMC_assume(a >= 5 && a <= 20);
  char *b[++a];   // VLA dimension is a preincrement side-effect
  foo(b);
  return 0;
}
```

Flag-OFF reports `VERIFICATION SUCCESSFUL`; flag-ON aborted — a verdict-parity divergence found by the V.4.4 flag-ON vs flag-OFF sweep.

## Why

The VLA dimension is part of the array **type**. `--irep2-bodies` migrates the body and the types it mentions to IREP2 *before* `goto_convert` lowers the VLA, so the raw `preincrement` side-effect reaches `migrate_expr`'s `sideeffect` handler. That handler migrated the side-effect's `#size` (`cmt_size()`) for **every** statement except a small exclusion list. Non-allocation side-effects (increment/decrement, `statement_expression`, `gcc_conditional_expression`, `cpp_delete[]`, `printf2`, …) carry no `#size`, so migrating the empty `exprt` fell through to the `abort()` at the end of `migrate_expr`. The flag-OFF path never hit this because the VLA is lowered before any migration.

## Fix

Replace the exclusion-list guard with an inclusion list: migrate `#size` only for the allocation statements that actually carry one — `malloc` / `realloc` / `alloca` / `va_arg` (`cpp_new` / `cpp_new[]` are handled in a dedicated branch just above). `thesize` stays nil for the rest, which matches the back-migration (`migrate_expr_back` restores `#size` only for the same allocation kinds).

## Tests

- `regression/esbmc/github_4715_irep2_bodies_vla_01` (pass) and `..._vla_01_fail` (fail) — both run with `--irep2-bodies` and assert ON/OFF agree on the verdict, not merely on not crashing.
- Existing `github_178_unary{,_fail}` continue to pass flag-OFF.
- migrate unit suite (31) and all `irep2_bodies` regression tests (23) green; flag-OFF `esbmc/` C suite unaffected.

Part of the V.4.4 verdict-parity sweep toward removing the legacy `to_code(symbol.get_value())` seam. Refs #4715, #178.