### PR TITLE
[om] Allow C++ operational models in the embedded clib (#5298)

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/main.cpp
@@ -1,0 +1,13 @@
+// Regression for esbmc/esbmc#5298: a C++ operational model compiled into the
+// embedded clib must be usable from a verified program. Before the fix, merely
+// having a C++ source in the clib corrupted goto_convert ("non-code operand in
+// this block") because the C++ frontend re-adjusted the C library functions.
+extern "C" int __esbmc_probe_sum(int n);
+extern "C" int __esbmc_probe_range();
+
+int main()
+{
+  __ESBMC_assert(__esbmc_probe_sum(3) == 3, "0+1+2 == 3");
+  __ESBMC_assert(__esbmc_probe_range() == 6, "1+2+3 == 6");
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/main.cpp
@@ -1,0 +1,10 @@
+// Negative variant of cpp_clib_om (esbmc/esbmc#5298): proves the C++ clib OM
+// body is actually verified (not silently skipped) by asserting a false
+// property over its result.
+extern "C" int __esbmc_probe_sum(int n);
+
+int main()
+{
+  __ESBMC_assert(__esbmc_probe_sum(3) == 999, "intentionally false");
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_5298/main.c
+++ b/regression/esbmc/github_5298/main.c
@@ -1,0 +1,13 @@
+// Regression for esbmc/esbmc#5298: with a C++ operational model present in the
+// embedded clib, lowering a C for-loop must still succeed. The bug made
+// goto_convert abort with "non-code operand in this block" because the C++
+// frontend re-adjusted the C library functions, and clang_c_adjust::adjust_for
+// was not idempotent (it re-wrapped the for-loop, leaving a stray nil operand).
+int main()
+{
+  int s = 0;
+  for (int i = 0; i < 3; i++)
+    s += i;
+  __ESBMC_assert(s == 3, "0+1+2 == 3");
+  return 0;
+}

--- a/regression/esbmc/github_5298/test.desc
+++ b/regression/esbmc/github_5298/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(c2goto
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr
     )
 target_link_libraries(c2goto
-  clangcfrontend langapi c2gotoheaders
+  clangcfrontend clangcppfrontend langapi c2gotoheaders
   filesystem ${Boost_LIBRARIES} ${OS_INCLUDE_LIBS})
 set_target_properties(c2goto PROPERTIES
   PRIVATE_HEADER "${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/libc.h;${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/libm.h;${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/headers/libc_hdr.h")
@@ -149,6 +149,11 @@ function(mangle_clib output)
     set(c2goto_solidity_files "")
   endif()
 
+  # Extract C++ operational models (esbmc/esbmc#5298). These are compiled by
+  # the C++ frontend inside c2goto and serialized into the embedded clib.
+  file(GLOB_RECURSE c2goto_cpp_files CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/library/cpp/*.cpp")
+
   # For each config, generate clib*.c and clib*.goto file in the current binary directory
   foreach(in_f ${ARGN})
     set(in_f "${${in_f}}")
@@ -170,6 +175,10 @@ function(mangle_clib output)
       list(APPEND inputs_c ${c2goto_python_files})
     endif()
 
+    # C++ operational models (esbmc/esbmc#5298): compiled by the C++ frontend
+    # registered in c2goto and serialized into the clib alongside the C models.
+    list(APPEND inputs_c ${c2goto_cpp_files})
+
     # Solidity models are built as a separate goto binary (sol64.goto),
     # NOT mixed into clib64, for faster runtime loading.
 
@@ -183,7 +192,7 @@ function(mangle_clib output)
     # Convert a list of C operational models (e.g. *.c) into a single goto binary file (e.g. clib32.goto) at CMake build time
     add_custom_command(OUTPUT ${out_goto}
       COMMAND ${run_c2goto}
-      DEPENDS c2goto ${c2goto_library_files} ${c2goto_libm_files} ${c2goto_header_files} ${c2goto_python_files}
+      DEPENDS c2goto ${c2goto_library_files} ${c2goto_libm_files} ${c2goto_header_files} ${c2goto_python_files} ${c2goto_cpp_files}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Generating libc model ${out_goto}"
       VERBATIM

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -109,4 +109,7 @@ int main(int argc, const char **argv)
   return parseopt.main();
 }
 
-const mode_table_et mode_table[] = {LANGAPI_MODE_CLANG_C, LANGAPI_MODE_END};
+const mode_table_et mode_table[] = {
+  LANGAPI_MODE_CLANG_C,
+  LANGAPI_MODE_CLANG_CPP,
+  LANGAPI_MODE_END};

--- a/src/c2goto/library/cpp/probe.cpp
+++ b/src/c2goto/library/cpp/probe.cpp
@@ -1,0 +1,20 @@
+// Minimal C++ operational-model probe used to exercise compiling C++ sources
+// into the embedded clib (esbmc/esbmc#5298). Bodies are emitted by the C++
+// frontend and must survive serialization + goto_convert re-lowering.
+
+extern "C" int __esbmc_probe_sum(int n)
+{
+  int total = 0;
+  for (int i = 0; i < n; i++)
+    total += i;
+  return total;
+}
+
+extern "C" int __esbmc_probe_range()
+{
+  int a[3] = {1, 2, 3};
+  int total = 0;
+  for (int x : a)
+    total += x;
+  return total;
+}

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -137,6 +137,15 @@ void clang_c_adjust::adjust_for(codet &code)
   //
   //   { a; for(;b;c) d; }
   //
+  // A nil init means there is nothing to hoist, so the wrap is unnecessary.
+  // Skipping it keeps adjust_for idempotent: when more than one language
+  // frontend adjusts the same context (e.g. c2goto registers both the C and
+  // C++ frontends, and language_uit::typecheck runs every module's adjust over
+  // the shared context), a re-run would otherwise move the now-nil init into a
+  // fresh block as a stray non-code operand and break goto_convert with
+  // "non-code operand in this block" (esbmc/esbmc#5298).
+  if (code.op0().is_nil())
+    return;
 
   code_blockt code_block;
   code_block.location() = code.location();

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -144,6 +144,11 @@ void clang_c_adjust::adjust_for(codet &code)
   // the shared context), a re-run would otherwise move the now-nil init into a
   // fresh block as a stray non-code operand and break goto_convert with
   // "non-code operand in this block" (esbmc/esbmc#5298).
+  //
+  // adjust_for is the only structurally-mutating adjust_* method: the siblings
+  // (adjust_while/adjust_switch/adjust_ifthenelse/adjust_assign) merely insert
+  // idempotent typecasts, so re-application is harmless and they need no guard.
+  // This hoist is the sole non-idempotent transform, hence the only one fenced.
   if (code.op0().is_nil())
     return;
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -757,8 +757,22 @@ bool clang_c_convertert::get_function(
   // function-boundary metadata on the type. No-op for C.
   annotate_exception_specification(fd, type);
 
-  added_symbol.set_type(type);
-  new_expr.type() = type;
+  // A bodyless re-declaration must not clobber the type of a function that is
+  // already defined. The definition's argument list carries the parameter
+  // identifiers symex uses to bind call arguments; replacing it with a
+  // prototype's nameless arguments silently breaks parameter passing. This
+  // surfaces when several frontends share one context and each prepends the
+  // same intrinsic prototypes — e.g. c2goto registers both the C and C++
+  // frontends, and clang_cpp re-declares the nameless
+  // __VERIFIER_nondet_memory prototype after the C definition with its named
+  // parameters was already converted (esbmc/esbmc#5298).
+  if (!fd.hasBody() && added_symbol.get_value().is_not_nil())
+    new_expr.type() = added_symbol.get_type();
+  else
+  {
+    added_symbol.set_type(type);
+    new_expr.type() = type;
+  }
 
   // We need: a type, a name, and an optional body.
   // Always call get_function_body so overrides (e.g. the C++ frontend) can


### PR DESCRIPTION
## Problem

Compiling any C++ source into ESBMC's embedded clib corrupted `goto_convert` with `ERROR: goto_convert: non-code operand in this block`, breaking verification of *every* program — even plain C with no C++ content. This blocked adding C++ operational models (e.g. a C++ exception OM) to the clib. Fixes #5298.

## Root cause

Registering both the C and C++ frontends in `c2goto` causes `language_uit::typecheck` to run `clang_c_adjust::adjust_for` twice over the shared library context. `adjust_for` wraps a `for` loop in an implicit block to hoist the init declaration:

```
for(a;b;c) d;   ->   { a; for(;b;c) d; }
```

After the first pass the loop's init operand (`op0`) is left nil. The second pass re-ran the wrap, moving the now-nil init into a fresh block as a stray non-code operand — which `goto_convert` rejects.

## Fix

- **`clang_c_adjust_code.cpp`** — make `adjust_for` idempotent: skip the implicit-block wrap when the loop init is nil (nothing to hoist). A freshly converted loop never has a nil init, so this fires only on the re-adjustment path and skips no real hoisting.
- **`c2goto.cpp`** — register the C++ frontend (`LANGAPI_MODE_CLANG_CPP`) in c2goto's mode table.
- **`c2goto/CMakeLists.txt`** — glob and compile `library/cpp/*.cpp` into the clib, with `CONFIGURE_DEPENDS` and a build-time `DEPENDS` entry.
- **`library/cpp/probe.cpp`** — minimal C++ OM probe (loop + range-for) to exercise the pipeline.

## Tests

- `regression/esbmc/github_5298` — a plain C for-loop still lowers and verifies with a C++ OM present.
- `regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om` — a C++ OM body in the clib is usable and verified.
- `regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail` — negative variant asserting a false property over the OM result, proving the body is actually verified (not silently skipped).

All three pass. The broad C++ and core C regression suites show no regressions attributable to this change (the only C++ failures require `--bitwuzla`, which isn't built into the local ESBMC).