### PR TITLE
[irep2] Fix cpp-throw-as-return-value crash under --irep2-bodies

### DIFF
--- a/regression/python/github_4715_irep2_bodies_ord_01/main.py
+++ b/regression/python/github_4715_irep2_bodies_ord_01/main.py
@@ -1,0 +1,6 @@
+def f(s: str) -> bool:
+    return True if 97 <= ord(s) else False
+
+
+if __name__ == "__main__":
+    assert f("a") == True

--- a/regression/python/github_4715_irep2_bodies_ord_01/test.desc
+++ b/regression/python/github_4715_irep2_bodies_ord_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4 --irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_bodies_ord_01_fail/main.py
+++ b/regression/python/github_4715_irep2_bodies_ord_01_fail/main.py
@@ -1,0 +1,6 @@
+def f(x: int) -> bool:
+    return True if 97 <= ord(x) else False
+
+
+if __name__ == "__main__":
+    assert f(5) == True

--- a/regression/python/github_4715_irep2_bodies_ord_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_bodies_ord_01_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 4 --irep2-bodies
+^VERIFICATION FAILED$
+uncaught exception

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1425,6 +1425,19 @@ void goto_convertt::convert_return(
   code_returnt new_code(code);
   if (new_code.has_return_value())
   {
+    // An IREP2 body round-trip (--irep2-bodies, esbmc/esbmc#4715) lowers a
+    // sideeffect_exprt("cpp-throw") that appears as the return value to its
+    // code form codet("cpp-throw"). A throw has void type and cannot be used
+    // as a return value; convert it as a statement and return early (the throw
+    // is unconditional, so no RETURN instruction is needed).
+    // Mirrors the same guard in convert_expression (line ~475).
+    if (
+      new_code.return_value().is_code() &&
+      to_code(new_code.return_value()).get_statement() == "cpp-throw")
+    {
+      convert(to_code(new_code.return_value()), dest);
+      return;
+    }
     goto_programt sideeffects;
     remove_sideeffects(new_code.return_value(), sideeffects);
     dest.destructive_append(sideeffects);


### PR DESCRIPTION
## Summary

- Under `--irep2-bodies`, a `sideeffect_exprt("cpp-throw")` that appears as a function's return value (e.g. `return True if 97 <= ord(x) else False` where `ord(x)` always raises TypeError) forward-migrates to `code_cpp_throw2tc` (empty type) and back-migrates to `codet("cpp-throw")`.
- `convert_return` did not recognise the `codet` form as a side effect, so it stored it as the RETURN instruction's value; symex then called `gen_zero(empty_type)` and aborted with `ERROR: Can't generate zero for type empty`.
- Fix: guard added in `convert_return` mirrors the identical guard already in `convert_expression` (~line 475): when the return value is a `cpp-throw` codet, dispatch it via `convert()` (which calls `convert_throw`) and return early — the throw is unconditional so no RETURN instruction is needed.

## Test plan

- [ ] `regression/python/github_4715_irep2_bodies_ord_01_fail`: `ord(int_arg)` in ternary return with `--irep2-bodies` → `VERIFICATION FAILED` (uncaught exception), no crash.
- [ ] `regression/python/github_4715_irep2_bodies_ord_01`: valid `ord(str_arg)` in ternary return with `--irep2-bodies` → `VERIFICATION SUCCESSFUL`.
- [ ] 156 `esbmc-cpp/try_catch` tests: all pass.
- [ ] 28 migrate unit tests: all pass.
- [ ] 10 `python/ord*` and `python/github_4715_irep2_bodies_py*` tests: all pass.

Refs #4715