### PR TITLE
[ir-ieee] add sqrt encoding under --ir-ieee

### DIFF
--- a/regression/ir-ra/ra-sqrt-interval-lift-core/main.c
+++ b/regression/ir-ra/ra-sqrt-interval-lift-core/main.c
@@ -1,0 +1,12 @@
+#include <math.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x >= 1.0 && x <= 4.0);
+  double z = sqrt(x);
+  __ESBMC_assert(z > 100.0, "should be falsifiable");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-interval-lift-core/test.desc
+++ b/regression/ir-ra/ra-sqrt-interval-lift-core/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-sqrt-interval-lift/main.c
+++ b/regression/ir-ra/ra-sqrt-interval-lift/main.c
@@ -1,0 +1,27 @@
+/* Regression: interval lifting for ieee_sqrt under --ir-ieee.
+ *
+ * x is nondet in [1, 4], so sqrt(x) is in roughly [1, 2].
+ * Under --ir-ieee, the integer-encoding path introduces fresh real symbols:
+ *   ra_sqrt::0    -- exact sqrt, pinned by  s * s = x  and  s >= 0
+ *   ra_sqrt_lo::0 -- sqrt of the hull lower bound
+ *   ra_sqrt_hi::0 -- sqrt of the hull upper bound
+ * followed by the RNE enclosure ra_lo::0 / ra_hi::0.
+ *
+ * The assertion z > 100.0 is clearly falsifiable (z <= 2.0 + eps for
+ * x <= 4.0), so VERIFICATION FAILED is expected.
+ * Z3's nlsat finds the witness x=1, z=1 trivially. */
+
+#include <math.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x >= 1.0 && x <= 4.0);
+
+  double z = sqrt(x);
+
+  __ESBMC_assert(z > 100.0, "should be falsifiable");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-interval-lift/test.desc
+++ b/regression/ir-ra/ra-sqrt-interval-lift/test.desc
@@ -1,0 +1,7 @@
+THOROUGH
+main.c
+--ir-ieee --z3 --smt-formula-too
+ra_sqrt::
+ra_sqrt_lo::
+ra_sqrt_hi::
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-sqrt-ir-basic/main.c
+++ b/regression/ir-ra/ra-sqrt-ir-basic/main.c
@@ -1,0 +1,8 @@
+#include <math.h>
+
+int main(void)
+{
+  double s = sqrt(4.0);
+  __ESBMC_assert(s == 2.0, "sqrt(4.0) == 2.0");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-ir-basic/test.desc
+++ b/regression/ir-ra/ra-sqrt-ir-basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-sqrt-nan-comparison/main.c
+++ b/regression/ir-ra/ra-sqrt-nan-comparison/main.c
@@ -1,0 +1,28 @@
+/* Soundness test: sqrt(x < 0) with a comparison that would be trivially
+ * VERIFICATION SUCCESSFUL if the result were pinned near zero.
+ *
+ * IEEE 754: sqrt(x < 0) = NaN.  NaN < 100.0 is false, so the assertion
+ * should fail (VERIFICATION FAILED).
+ *
+ * Under --ir-ieee, the result for negative operands is the unconstrained
+ * fresh real sqrt_nan::.  Without the ITE split introduced in the
+ * ieee_sqrt_id handler, the enclosure constraints (applied to the inner
+ * sqrt_pos:: symbol) would pin the observable result near zero, making
+ * "s >= 100.0" unsatisfiable and yielding a wrong VERIFICATION SUCCESSFUL.
+ *
+ * With the ITE split, the observable result for operand < 0 is sqrt_nan
+ * (unconstrained), so "s >= 100.0" is satisfiable and ESBMC correctly
+ * reports VERIFICATION FAILED. */
+
+#include <math.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x < -1.0); /* operand definitely negative */
+  double s = sqrt(x);
+  __ESBMC_assert(s < 100.0, "NaN < 100.0 is false; must be falsifiable");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-nan-comparison/test.desc
+++ b/regression/ir-ra/ra-sqrt-nan-comparison/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-sqrt-negative-operand-sound/main.c
+++ b/regression/ir-ra/ra-sqrt-negative-operand-sound/main.c
@@ -1,0 +1,31 @@
+/* Soundness test: sqrt with a definitely negative operand must not make
+ * the SMT formula UNSAT.
+ *
+ * The quadratic axiom  s >= 0 ∧ s² = operand  has no real solution when
+ * operand < 0.  If the axiom is asserted unconditionally, the formula
+ * becomes UNSAT for this path, and ESBMC would report VERIFICATION
+ * SUCCESSFUL — incorrectly discarding the counterexample.
+ *
+ * With the guarded axiom  (operand >= 0) → (s >= 0 ∧ s² = operand),
+ * the formula remains SAT when operand < 0.  The observable result is an
+ * unconstrained real fallback, so the path is not eliminated and the
+ * assertion remains falsifiable.  Therefore VERIFICATION FAILED is the
+ * correct result.
+ *
+ * IEEE 754 note: sqrt(x < 0) = NaN.  NaN > 0.0 is false, so the
+ * assertion would indeed fail for this input.  The --ir-ieee encoding
+ * does not model NaN directly; instead, the result is unconstrained
+ * (see comment in smt_conv.cpp ieee_sqrt_id handler). */
+
+#include <math.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x < -1.0); /* operand definitely negative */
+  double s = sqrt(x);
+  __ESBMC_assert(s > 0.0, "falsifiable: NaN is not > 0");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-negative-operand-sound/test.desc
+++ b/regression/ir-ra/ra-sqrt-negative-operand-sound/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-sqrt-rne-basic/main.c
+++ b/regression/ir-ra/ra-sqrt-rne-basic/main.c
@@ -1,0 +1,17 @@
+/* Regression: ieee_sqrt integer-encoding path under --ir-ieee.
+ *
+ * sqrt(4.0) is exactly 2.0 in IEEE 754, so sqrt(4.0) == 2.0 must hold.
+ * Under --ir-ieee, the quadratic axiom  s * s = 4.0 ∧ s >= 0  pins s = 2.0,
+ * and the RNE enclosure adds a bound of ±eps around 2.0, keeping the
+ * assertion reachable only for the value 2.0.
+ *
+ * The assertion s != 2.0 must be unsatisfiable: VERIFICATION SUCCESSFUL. */
+
+#include <math.h>
+
+int main(void)
+{
+  double s = sqrt(4.0);
+  __ESBMC_assert(s == 2.0, "sqrt(4.0) must equal 2.0");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-rne-basic/test.desc
+++ b/regression/ir-ra/ra-sqrt-rne-basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1098,10 +1098,134 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   case expr2t::ieee_sqrt_id:
   {
     assert(is_floatbv_type(expr));
-    // TODO: no integer mode implementation
-    a = fp_api->mk_smt_fpbv_sqrt(
-      convert_ast(to_ieee_sqrt2t(expr).value),
-      convert_rounding_mode(to_ieee_sqrt2t(expr).rounding_mode));
+    if (int_encoding)
+    {
+      smt_astt operand = convert_ast(to_ieee_sqrt2t(expr).value);
+      const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
+      const expr2tc &rounding_mode = to_ieee_sqrt2t(expr).rounding_mode;
+
+      // Two fresh reals are introduced:
+      //
+      //   sqrt_pos  (tagged "ra_sqrt::")   — for operand >= 0.
+      //     Pinned by the guarded quadratic:
+      //       operand >= 0  →  sqrt_pos >= 0  ∧  sqrt_pos² = operand
+      //     The enclosure is applied to this symbol only.
+      //
+      //   sqrt_nan  (tagged "ra_sqrt_nan::")  — for operand < 0.
+      //     Completely unconstrained.  Models the IEEE 754 NaN result
+      //     without making the formula inconsistent.
+      //
+      // The publicly returned result is  ite(operand >= 0, sqrt_pos, sqrt_nan).
+      // This ensures that for negative operands the enclosure constraints on
+      // sqrt_pos do not propagate to the observable result.
+      //
+      // Limitation: NaN non-reflexivity (NaN != NaN in IEEE 754) is not
+      // modelled.  Under --ir-ieee, sqrt(x < 0) returns an unconstrained real,
+      // not a NaN sentinel.
+      smt_sortt rs = mk_real_sort();
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt op_nonneg = mk_le(zero, operand);
+
+      smt_astt sqrt_pos = mk_fresh(rs, "ra_sqrt::", nullptr);
+      // operand >= 0 → sqrt_pos >= 0
+      assert_ast(mk_or(mk_not(op_nonneg), mk_le(zero, sqrt_pos)));
+      // operand >= 0 → sqrt_pos² = operand
+      assert_ast(
+        mk_or(mk_not(op_nonneg), mk_eq(mk_mul(sqrt_pos, sqrt_pos), operand)));
+
+      // Unconstrained result used when operand < 0.
+      smt_astt sqrt_nan = mk_fresh(rs, "ra_sqrt_nan::", nullptr);
+
+      // Interval-lifted enclosure for ieee_sqrt (--ir-ieee only).
+      // sqrt is monotone increasing on [0, ∞), so the exact hull is:
+      //   lo_r = sqrt(iv.lo),  hi_r = sqrt(iv.hi)
+      // Each bound is a fresh real pinned by the same quadratic axiom.
+      // Mode-dispatch follows the same five-case pattern as add/sub/mul/div.
+      bool interval_lifted = false;
+      if (
+        options.get_bool_option("ir-ieee") &&
+        (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_away(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode) ||
+         smt_fp_rounding_utils::is_round_to_zero(rounding_mode)))
+      {
+        const auto double_spec = ieee_float_spect::double_precision();
+        const auto single_spec = ieee_float_spect::single_precision();
+        if (
+          (fbv_type.exponent == double_spec.e &&
+           fbv_type.fraction == double_spec.f) ||
+          (fbv_type.exponent == single_spec.e &&
+           fbv_type.fraction == single_spec.f))
+        {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t {
+            auto it = ir_ra_interval_map.find(t);
+            return it != ir_ra_interval_map.end() ? it->second
+                                                  : ra_interval_t{t, t};
+          };
+          ra_interval_t iv = get_iv(operand);
+
+          // Fresh reals for sqrt of interval bounds.
+          // Clamp bounds to zero: the RNE/RNA enclosures from prior operations
+          // can make iv.lo slightly negative (by eps_abs) even when the float
+          // operand is always non-negative.  sqrt is only defined for x >= 0,
+          // so we tighten to max(0, iv.lo) and max(0, iv.hi).
+          smt_astt iv_lo_pos = mk_ite(mk_lt(iv.lo, zero), zero, iv.lo);
+          smt_astt iv_hi_pos = mk_ite(mk_lt(iv.hi, zero), zero, iv.hi);
+
+          smt_astt lo_r = mk_fresh(rs, "ra_sqrt_lo::", nullptr);
+          smt_astt hi_r = mk_fresh(rs, "ra_sqrt_hi::", nullptr);
+          assert_ast(mk_le(zero, lo_r));
+          assert_ast(mk_eq(mk_mul(lo_r, lo_r), iv_lo_pos));
+          assert_ast(mk_le(zero, hi_r));
+          assert_ast(mk_eq(mk_mul(hi_r, hi_r), iv_hi_pos));
+
+          // Enclosure is applied to sqrt_pos, not to the final ITE result.
+          // The containment assertions (ra_lo <= sqrt_pos <= ra_hi) therefore
+          // do not constrain the result when operand < 0.
+          std::pair<smt_astt, smt_astt> bounds;
+          if (smt_fp_rounding_utils::is_nearest_rounding_mode(rounding_mode))
+            bounds =
+              apply_ieee754_rne_enclosure(sqrt_pos, lo_r, hi_r, fbv_type);
+          else if (smt_fp_rounding_utils::is_round_to_away(rounding_mode))
+            bounds =
+              apply_ieee754_rna_enclosure(sqrt_pos, lo_r, hi_r, fbv_type);
+          else if (smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode))
+            bounds =
+              apply_ieee754_rup_enclosure(sqrt_pos, lo_r, hi_r, fbv_type);
+          else if (smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode))
+            bounds =
+              apply_ieee754_rdn_enclosure(sqrt_pos, lo_r, hi_r, fbv_type);
+          else
+            bounds =
+              apply_ieee754_rtz_enclosure(sqrt_pos, lo_r, hi_r, fbv_type);
+
+          // ITE result: sqrt_pos (enclosure-constrained) for operand >= 0;
+          // sqrt_nan (unconstrained) for operand < 0.
+          smt_astt sqrt_result = mk_ite(op_nonneg, sqrt_pos, sqrt_nan);
+          // ITE interval stored in the map: enclosure bounds for operand >= 0;
+          // point interval {sqrt_result, sqrt_result} for operand < 0, which
+          // degenerates to the single-step behaviour for chained operations.
+          smt_astt map_lo = mk_ite(op_nonneg, bounds.first, sqrt_result);
+          smt_astt map_hi = mk_ite(op_nonneg, bounds.second, sqrt_result);
+          ir_ra_interval_map[sqrt_result] = {map_lo, map_hi};
+          a = sqrt_result;
+          interval_lifted = true;
+        }
+      }
+      if (!interval_lifted)
+      {
+        smt_astt pos_result =
+          apply_ieee754_semantics(sqrt_pos, fbv_type, nullptr, rounding_mode);
+        a = mk_ite(op_nonneg, pos_result, sqrt_nan);
+      }
+    }
+    else
+    {
+      a = fp_api->mk_smt_fpbv_sqrt(
+        convert_ast(to_ieee_sqrt2t(expr).value),
+        convert_rounding_mode(to_ieee_sqrt2t(expr).rounding_mode));
+    }
     break;
   }
   case expr2t::modulus_id:


### PR DESCRIPTION
## Summary

This PR adds `--ir-ieee` support for `ieee_sqrt` in the integer/real SMT encoding path.

Previously, `ieee_sqrt` did not have a dedicated integer/real encoding implementation. This PR adds a guarded real-arithmetic encoding for square root when `--ir-ieee` is enabled, applies the existing IEEE-754 rounding-mode enclosure helpers, and adds interval lifting so sqrt expressions can participate in compositional real-interval propagation.

For negative operands, IEEE-754 returns NaN. Since full NaN semantics are not yet modelled in the `--ir-ieee` integer/real encoding, this PR uses an unconstrained real fallback for the negative-operand case. This avoids making the SMT formula UNSAT while keeping full NaN modelling as future work.

## Motivation

The `--ir-ieee` encoding already has rounding-aware real/interval support for arithmetic operations such as addition, subtraction, multiplication, and division. However, `ieee_sqrt` was still missing a dedicated integer/real encoding path.

A direct real-arithmetic encoding of sqrt would normally use:

`result >= 0` and `result * result == operand`

This is valid only when `operand >= 0`. If asserted unconditionally, the formula becomes UNSAT for paths where `operand < 0`, because no real number satisfies `result * result == operand` for a negative operand. That can incorrectly eliminate feasible program paths and lead to wrong verification results.

This PR guards the quadratic sqrt constraints with `operand >= 0` and keeps the negative-operand path satisfiable.

## Changes

This PR:

* Adds an `int_encoding` implementation for `expr2t::ieee_sqrt_id`.
* Introduces a fresh real symbol for the non-negative sqrt case.
* Guards the exact real sqrt constraints with `operand >= 0`:

  * `operand >= 0 -> sqrt_pos >= 0`
  * `operand >= 0 -> sqrt_pos * sqrt_pos == operand`
* Applies the existing mode-specific IEEE-754 enclosure helpers for:

  * RNE
  * RNA
  * RUP
  * RDN
  * RTZ
* Adds interval lifting for `ieee_sqrt` under `--ir-ieee` for single and double precision.
* Stores sqrt interval bounds in `ir_ra_interval_map` so chained expressions can propagate interval information through sqrt.
* Handles `operand < 0` with an unconstrained real fallback to avoid unsound path elimination.
* Leaves the existing non-integer-encoding floating-point API path unchanged.

For non-negative operands, sqrt is encoded using the guarded quadratic real constraint and rounded using the selected rounding-mode enclosure.

For negative operands, the result is represented by an unconstrained real fallback. This is intentionally not full IEEE NaN modelling.

## Regression Test

Four new regression tests were added under `regression/ir-ra/`:

* `ra-sqrt-rne-basic`

  * Checks the basic `sqrt(4.0) == 2.0` case under `--ir-ieee`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-sqrt-interval-lift`

  * Checks that interval lifting for sqrt introduces the expected real symbols.
  * The test uses `x` in `[1, 4]` and checks a clearly falsifiable assertion on `sqrt(x)`.
  * Expected result: `VERIFICATION FAILED`.

* `ra-sqrt-negative-operand-sound`

  * Checks that a definitely negative sqrt operand does not make the SMT formula UNSAT.
  * Expected result: `VERIFICATION FAILED`.

* `ra-sqrt-nan-comparison`

  * Checks that negative-operand sqrt comparisons are not incorrectly verified due to the result being pinned near zero.
  * Expected result: `VERIFICATION FAILED`.


## Notes

This PR does not implement full IEEE-754 NaN semantics.

In IEEE-754, `sqrt(x < 0)` produces NaN, and NaN has special comparison behaviour. The current `--ir-ieee` integer/real encoding does not yet model NaN non-reflexivity, NaN ordering rules, or full NaN propagation.

For this reason, the negative-operand case is represented using an unconstrained real fallback. This keeps the SMT formula satisfiable and avoids eliminating feasible paths, but full NaN support remains future work.

This PR is focused on adding `ieee_sqrt` support to the `--ir-ieee` integer/real encoding path without changing the existing non-`--ir-ieee` floating-point API path.