### PR TITLE
[clang-c-frontend] Scope adjust() to fresh per-TU context, merge via c_link

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/main.cpp
@@ -1,0 +1,13 @@
+// Regression for esbmc/esbmc#5298: a C++ operational model compiled into the
+// embedded clib must be usable from a verified program. Before the fix, merely
+// having a C++ source in the clib corrupted goto_convert ("non-code operand in
+// this block") because the C++ frontend re-adjusted the C library functions.
+extern "C" int __esbmc_probe_sum(int n);
+extern "C" int __esbmc_probe_range();
+
+int main()
+{
+  __ESBMC_assert(__esbmc_probe_sum(3) == 3, "0+1+2 == 3");
+  __ESBMC_assert(__esbmc_probe_range() == 6, "1+2+3 == 6");
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/main.cpp
@@ -1,0 +1,10 @@
+// Negative variant of cpp_clib_om (esbmc/esbmc#5298): proves the C++ clib OM
+// body is actually verified (not silently skipped) by asserting a false
+// property over its result.
+extern "C" int __esbmc_probe_sum(int n);
+
+int main()
+{
+  __ESBMC_assert(__esbmc_probe_sum(3) == 999, "intentionally false");
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cpp_clib_om_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_5298/main.c
+++ b/regression/esbmc/github_5298/main.c
@@ -1,0 +1,13 @@
+// Regression for esbmc/esbmc#5298: with a C++ operational model present in the
+// embedded clib, lowering a C for-loop must still succeed. The bug made
+// goto_convert abort with "non-code operand in this block" because the C++
+// frontend re-adjusted the C library functions, and clang_c_adjust::adjust_for
+// was not idempotent (it re-wrapped the for-loop, leaving a stray nil operand).
+int main()
+{
+  int s = 0;
+  for (int i = 0; i < 3; i++)
+    s += i;
+  __ESBMC_assert(s == 3, "0+1+2 == 3");
+  return 0;
+}

--- a/regression/esbmc/github_5298/test.desc
+++ b/regression/esbmc/github_5298/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(c2goto
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr
     )
 target_link_libraries(c2goto
-  clangcfrontend langapi c2gotoheaders
+  clangcfrontend clangcppfrontend langapi c2gotoheaders
   filesystem ${Boost_LIBRARIES} ${OS_INCLUDE_LIBS})
 set_target_properties(c2goto PROPERTIES
   PRIVATE_HEADER "${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/libc.h;${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/libm.h;${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/headers/libc_hdr.h")
@@ -149,6 +149,11 @@ function(mangle_clib output)
     set(c2goto_solidity_files "")
   endif()
 
+  # Extract C++ operational models (esbmc/esbmc#5298). These are compiled by
+  # the C++ frontend inside c2goto and serialized into the embedded clib.
+  file(GLOB_RECURSE c2goto_cpp_files CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/library/cpp/*.cpp")
+
   # For each config, generate clib*.c and clib*.goto file in the current binary directory
   foreach(in_f ${ARGN})
     set(in_f "${${in_f}}")
@@ -170,6 +175,10 @@ function(mangle_clib output)
       list(APPEND inputs_c ${c2goto_python_files})
     endif()
 
+    # C++ operational models (esbmc/esbmc#5298): compiled by the C++ frontend
+    # registered in c2goto and serialized into the clib alongside the C models.
+    list(APPEND inputs_c ${c2goto_cpp_files})
+
     # Solidity models are built as a separate goto binary (sol64.goto),
     # NOT mixed into clib64, for faster runtime loading.
 
@@ -183,7 +192,7 @@ function(mangle_clib output)
     # Convert a list of C operational models (e.g. *.c) into a single goto binary file (e.g. clib32.goto) at CMake build time
     add_custom_command(OUTPUT ${out_goto}
       COMMAND ${run_c2goto}
-      DEPENDS c2goto ${c2goto_library_files} ${c2goto_libm_files} ${c2goto_header_files} ${c2goto_python_files}
+      DEPENDS c2goto ${c2goto_library_files} ${c2goto_libm_files} ${c2goto_header_files} ${c2goto_python_files} ${c2goto_cpp_files}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Generating libc model ${out_goto}"
       VERBATIM

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -109,4 +109,7 @@ int main(int argc, const char **argv)
   return parseopt.main();
 }
 
-const mode_table_et mode_table[] = {LANGAPI_MODE_CLANG_C, LANGAPI_MODE_END};
+const mode_table_et mode_table[] = {
+  LANGAPI_MODE_CLANG_C,
+  LANGAPI_MODE_CLANG_CPP,
+  LANGAPI_MODE_END};

--- a/src/c2goto/library/cpp/probe.cpp
+++ b/src/c2goto/library/cpp/probe.cpp
@@ -1,0 +1,20 @@
+// Minimal C++ operational-model probe used to exercise compiling C++ sources
+// into the embedded clib (esbmc/esbmc#5298). Bodies are emitted by the C++
+// frontend and must survive serialization + goto_convert re-lowering.
+
+extern "C" int __esbmc_probe_sum(int n)
+{
+  int total = 0;
+  for (int i = 0; i < n; i++)
+    total += i;
+  return total;
+}
+
+extern "C" int __esbmc_probe_range()
+{
+  int a[3] = {1, 2, 3};
+  int total = 0;
+  for (int x : a)
+    total += x;
+  return total;
+}

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -137,6 +137,15 @@ void clang_c_adjust::adjust_for(codet &code)
   //
   //   { a; for(;b;c) d; }
   //
+  // A nil init means there is nothing to hoist, so the wrap is unnecessary.
+  // Skipping it keeps adjust_for idempotent: when more than one language
+  // frontend adjusts the same context (e.g. c2goto registers both the C and
+  // C++ frontends, and language_uit::typecheck runs every module's adjust over
+  // the shared context), a re-run would otherwise move the now-nil init into a
+  // fresh block as a stray non-code operand and break goto_convert with
+  // "non-code operand in this block" (esbmc/esbmc#5298).
+  if (code.op0().is_nil())
+    return;
 
   code_blockt code_block;
   code_block.location() = code.location();

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -144,6 +144,11 @@ void clang_c_adjust::adjust_for(codet &code)
   // the shared context), a re-run would otherwise move the now-nil init into a
   // fresh block as a stray non-code operand and break goto_convert with
   // "non-code operand in this block" (esbmc/esbmc#5298).
+  //
+  // adjust_for is the only structurally-mutating adjust_* method: the siblings
+  // (adjust_while/adjust_switch/adjust_ifthenelse/adjust_assign) merely insert
+  // idempotent typecasts, so re-application is harmless and they need no guard.
+  // This hoist is the sole non-idempotent transform, hence the only one fenced.
   if (code.op0().is_nil())
     return;
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -757,8 +757,22 @@ bool clang_c_convertert::get_function(
   // function-boundary metadata on the type. No-op for C.
   annotate_exception_specification(fd, type);
 
-  added_symbol.set_type(type);
-  new_expr.type() = type;
+  // A bodyless re-declaration must not clobber the type of a function that is
+  // already defined. The definition's argument list carries the parameter
+  // identifiers symex uses to bind call arguments; replacing it with a
+  // prototype's nameless arguments silently breaks parameter passing. This
+  // surfaces when several frontends share one context and each prepends the
+  // same intrinsic prototypes — e.g. c2goto registers both the C and C++
+  // frontends, and clang_cpp re-declares the nameless
+  // __VERIFIER_nondet_memory prototype after the C definition with its named
+  // parameters was already converted (esbmc/esbmc#5298).
+  if (!fd.hasBody() && added_symbol.get_value().is_not_nil())
+    new_expr.type() = added_symbol.get_type();
+  else
+  {
+    added_symbol.set_type(type);
+    new_expr.type() = type;
+  }
 
   // We need: a type, a name, and an optional body.
   // Always call get_function_body so overrides (e.g. the C++ frontend) can

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -403,18 +403,25 @@ void clang_c_languaget::set_language_version()
     config.language.c_std = c_stdt::c89;
 }
 
-bool clang_c_languaget::typecheck(contextt &context, const std::string &)
+bool clang_c_languaget::typecheck(contextt &context, const std::string &module)
 {
   set_language_version();
-  clang_c_convertert converter(context, AST, "C");
+
+  // Convert + adjust this translation unit in an isolated context, then
+  // merge the fully-adjusted symbols into the shared context via c_link.
+  // This keeps each TU's convert/adjust from re-walking and re-adjusting
+  // symbols contributed by other frontends/TUs sharing `context` (#5309).
+  contextt new_context;
+
+  clang_c_convertert converter(new_context, AST, "C");
   if (converter.convert())
     return true;
 
-  clang_c_adjust adjuster(context);
+  clang_c_adjust adjuster(new_context);
   if (adjuster.adjust())
     return true;
 
-  return false;
+  return c_link(context, new_context, module);
 }
 
 void clang_c_languaget::show_parse(std::ostream &)

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -116,18 +116,27 @@ void clang_cpp_languaget::set_language_version()
     config.language.cpp_std = cxx_stdt::cpp98;
 }
 
-bool clang_cpp_languaget::typecheck(contextt &context, const std::string &)
+bool clang_cpp_languaget::typecheck(
+  contextt &context,
+  const std::string &module)
 {
   set_language_version();
-  clang_cpp_convertert converter(context, AST, "C++");
+
+  // Convert + adjust this translation unit in an isolated context, then
+  // merge the fully-adjusted symbols into the shared context via c_link.
+  // This keeps each TU's convert/adjust from re-walking and re-adjusting
+  // symbols contributed by other frontends/TUs sharing `context` (#5309).
+  contextt new_context;
+
+  clang_cpp_convertert converter(new_context, AST, "C++");
   if (converter.convert())
     return true;
 
-  clang_cpp_adjust adjuster(context);
+  clang_cpp_adjust adjuster(new_context);
   if (adjuster.adjust())
     return true;
 
-  return false;
+  return c_link(context, new_context, module);
 }
 
 bool clang_cpp_languaget::final(contextt &context)

--- a/src/util/c_link.cpp
+++ b/src/util/c_link.cpp
@@ -306,31 +306,27 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       }
     }
 
-    if (in_context.is_extern)
+    if (in_context.is_extern && !new_symbol.is_extern)
     {
-      if (new_symbol.is_extern)
-      {
-        // do nothing if both symbols are extern
-      }
-      else
-      {
-        exprt v = in_context.get_value();
-        exprt nv = new_symbol.get_value();
-        v.swap(nv);
-        in_context.set_value(std::move(v));
-        new_symbol.set_value(std::move(nv));
-        in_context.is_extern = false;
-      }
+      // in_context was only a declaration; adopt the incoming definition.
+      exprt v = in_context.get_value();
+      exprt nv = new_symbol.get_value();
+      v.swap(nv);
+      in_context.set_value(std::move(v));
+      new_symbol.set_value(std::move(nv));
+      in_context.is_extern = false;
     }
-    else
-    {
-      log_error(
-        "duplicate_symbol: in_context is not extern, never seen in tests, "
-        "aborting.");
-      in_context.dump();
-      new_symbol.dump();
-      abort();
-    }
+    // Otherwise keep the symbol already in context. Both-extern declarations
+    // add nothing; and once in_context holds a (tentative or full) definition,
+    // a later extern re-declaration or a duplicate/tentative definition from
+    // another translation unit adds nothing either. This mirrors
+    // contextt::move_symbol_to_context, which replaces a stored variable only
+    // when it is extern and the incoming one is not. The non-extern in_context
+    // path is exercised when frontends convert each TU in an isolated context
+    // and merge here (issue #5309): e.g. `int __ESBMC_return_value;` or
+    // `_Bool __ESBMC_alloc[1];` declared in a shared header pulled into many
+    // TUs, where one TU contributes the tentative definition and others only
+    // the extern declaration.
   }
 }
 


### PR DESCRIPTION
Fixes #5309. Stacked on #5303 (base branch `fix/5298-cpp-clib-operational-models`) — review/merge #5303 first.

## Problem
Once `c2goto` registers both the C and C++ frontends (#5303), `language_uit::typecheck()` calls every registered frontend's `typecheck()` on a **shared** context. `clang_c_languaget::typecheck` / `clang_cpp_languaget::typecheck` convert and adjust directly into that shared context, and `clang_c_adjust::adjust()` walks the **entire** context — so symbols already converted and adjusted by an earlier pass get re-adjusted, corrupting them. #5303 patched the symptom (made `adjust_for` idempotent); this is the structural fix.

## Change
Each `typecheck` now converts + adjusts the translation unit in an isolated `contextt new_context`, then merges the finished symbols into the shared context with `c_link(context, new_context, module)` — the same convert-into-fresh-context-then-link pattern `add_cprover_library` / `add_bundled_library_sources` already use. `adjust()` only ever sees freshly-converted symbols.

### Follow-on fix in `c_link`
Isolating per TU routes the libc/libm clib build through `c_link` once per file. Each TU pulls the intrinsics header, so a tentative definition (`_Bool __ESBMC_alloc[1];` in `builtin_libs.c`, `int __ESBMC_return_value;` in the intrinsics header) now meets its `extern` re-declaration at link time. The old `c_linkt::duplicate_symbol` variable path aborted here ("never seen in tests") — **nondeterministically**, depending on unstable hash-table symbol ordering. It is aligned with `contextt::move_symbol_to_context`: adopt the incoming definition only when `in_context` is `extern` and the incoming symbol is not, otherwise keep the symbol already in context; never abort on variables.

## Verification
- Embedded clib build: previously aborted nondeterministically; now builds cleanly and deterministically (25/25 repeated `clib64.goto` generations), full `esbmc` builds.
- Regression (local, Bitwuzla-only build): core C `esbmc/`, C++ `esbmc-cpp/cpp/`, and a Python sample — **zero new failures** vs a rebuilt baseline. The non-solver failures (`--ir` IEEE encoding, host C++ headers via `--no-abstracted-cpp-includes`, `--multi-property`) fail identically without this change and are environmental; CI (with Z3/Boolector) covers the solver-gated cases.
- The removed abort branch was demonstrably reachable (the clib build hit it), which discharges the dead-code obligation for the deletion.
