### PR TITLE
[python] Model reversed() builtin as a list-returning OM

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -185,3 +185,45 @@ humaneval_33; tuple-unpack for minimum_spanning_tree / powerset / shortest_path_
 DictComp tuple targets for shortest_paths; mixed-type `sorted()` / non-const tuple slice for
 humaneval — §3b feature gaps); and wrong-verdict soundness clusters (§3b). Each remains a
 design-level blocker or a substantial sound feature, not an isolated point fix.
+
+---
+
+## 7. 2026-06-11 re-validation & reversed() fix
+
+Independent re-run of **all 47 KNOWNBUG python/quixbugs/humaneval tests** against `master`
+(commit `71d0d97983`, ESBMC 8.3.0, Bitwuzla), each with its own `test.desc` flags, after the
+merges that landed since §6 (`#5302` list slice-assign, `#5307` tuple-as-shallow-copy, `#5268`
+k-induction phase 2). **Zero KNOWNBUG→CORE flips** — the §3 classification still holds. Every
+crash/error reproduced is already documented: the `__ESBMC_get_object_size` diagnostic
+(`depth_first_search`, by design since #5042), `rover`'s `Variable 'Twist' is not defined`
+(#4775 class/import resolution), and `wrap` (its `--z3` pin is a local Bitwuzla-only artefact;
+under Bitwuzla it is the §3b wrong-verdict, not a crash).
+
+### 7a. New isolated, soundly-fixable defect found & fixed
+**`reversed()` was unmodelled, blocking list-slice-assignment RHS.** `#5302` advanced
+QuixBugs `next_permutation` from a slice-assign feature gap to a fresh narrow error,
+`List slice assignment requires a list right-hand side`, on
+`next_perm[i+1:] = reversed(next_perm[i+1:])`: `reversed()` had no operational model and its
+`builtin_functions()` entry mapped to the invalid type tag `"reversed"` (vs `sorted` →
+`"list"`), so even a bare `r = reversed(xs)` assignment raised
+`NameError: name 'reversed' is not defined` during the annotation pass.
+
+**Fix** (commit `8504e4f64d`): add `reversed`/`reversed_float`/`reversed_str` operational
+models returning a freshly reversed list (mirroring `sorted`); wire `reversed` into the
+element-type monomorph dispatch in `function_call/expr.cpp`; correct the `builtin_functions()`
+tag to `"list"` and drop `reversed` from the `iterable_builtins` self-mapping set. Modelling
+`reversed()` as an eager list is sound in every context ESBMC routes through the model (slice
+assignment, `list(reversed(...))`); `for`/`range` iteration is rewritten earlier in the
+preprocessor and is unaffected (existing `reversed1`/`reversed_loop` unchanged). New regression
+pair `regression/python/reversed_builtin{,_fail}`; CPython sanity + 53 sibling
+reversed/sorted/slice/list tests green; code-reviewed (0 critical/major).
+
+Like #5042/#4796/§6a, this **does not flip a KNOWNBUG verdict**: with `reversed()` modelled,
+`next_permutation` now does genuine BMC and hits the unwinding wall (policy-banned timeout,
+§3c) instead of erroring — an honest perf bound, not a feature gap. The fix is independently
+useful for any program using `reversed()` in a value context.
+
+### 7b. Everything else: unchanged disposition
+No further isolated, sound point fix is available on current master without the §5
+architectural work (flow-sensitive class tracking, tuple-unpack inference, any-typing,
+string/tuple-equality soundness). The §5 priority order stands.

--- a/regression/python/reversed_builtin/main.py
+++ b/regression/python/reversed_builtin/main.py
@@ -1,0 +1,25 @@
+# reversed() over a list, exercised through CPython-valid patterns that ESBMC
+# models: slice assignment, for-loop consumption, and list(reversed(...)).
+
+# 1. Slice-assignment RHS (the next_permutation pattern): reverse a tail.
+xs = [10, 20, 30, 40, 50]
+xs[1:] = reversed(xs[1:])
+assert xs == [10, 50, 40, 30, 20]
+
+# 2. Materialise via list(reversed(...)).
+ints = [1, 2, 3, 4]
+assert list(reversed(ints)) == [4, 3, 2, 1]
+
+# 3. for-loop consumption preserves reverse order.
+acc = 0
+weight = 1
+for e in reversed([1, 2, 3]):
+    acc = acc + e * weight
+    weight = weight * 10
+assert acc == 123  # 3*1 + 2*10 + 1*100
+
+# 4. Float and string element types.
+floats = [1.5, 2.5, 3.5]
+assert list(reversed(floats)) == [3.5, 2.5, 1.5]
+chars = ["a", "b", "c"]
+assert list(reversed(chars)) == ["c", "b", "a"]

--- a/regression/python/reversed_builtin/test.desc
+++ b/regression/python/reversed_builtin/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-pointer-check --no-bounds-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/reversed_builtin_fail/main.py
+++ b/regression/python/reversed_builtin_fail/main.py
@@ -1,0 +1,4 @@
+# reversed() must reverse order; asserting the original order is wrong and must
+# fail under both CPython (AssertionError) and ESBMC (VERIFICATION FAILED).
+xs = [1, 2, 3]
+assert list(reversed(xs)) == [1, 2, 3]

--- a/regression/python/reversed_builtin_fail/test.desc
+++ b/regression/python/reversed_builtin_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-pointer-check --no-bounds-check
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -3201,8 +3201,9 @@ exprt function_call_expr::handle_general_function_call()
   // both 1- and 2-arg forms so the typed dispatch picks sum / sum_float
   // consistently. The other builtins below remain 1-arg only.
   const size_t n_args = call_["args"].size();
-  const bool is_sorted_min_max =
-    func_name == "min" || func_name == "max" || func_name == "sorted";
+  const bool is_sorted_min_max = func_name == "min" || func_name == "max" ||
+                                 func_name == "sorted" ||
+                                 func_name == "reversed";
 
   // min(iter, default=...) / max(iter, default=...) route to *_default
   // variants that fall back to the supplied default when iter is empty

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -391,3 +391,38 @@ def sorted_str(iterable: list[str], reverse: bool = False) -> list[str]:
             i = i + 1
 
     return result
+
+
+def reversed(iterable: list[int]) -> list[int]:
+    """Return a new list with the items of iterable in reverse order.
+
+    CPython's reversed() yields a reverse iterator; modelling it as a freshly
+    built list is sound in every list-consuming context ESBMC handles (slice
+    assignment, list(), iteration), mirroring how sorted() returns a list.
+    """
+    result: list[int] = []
+    i: int = len(iterable) - 1
+    while i >= 0:
+        result.append(iterable[i])
+        i = i - 1
+    return result
+
+
+def reversed_float(iterable: list[float]) -> list[float]:
+    """Return a new list with the items of iterable in reverse order."""
+    result: list[float] = []
+    i: int = len(iterable) - 1
+    while i >= 0:
+        result.append(iterable[i])
+        i = i - 1
+    return result
+
+
+def reversed_str(iterable: list[str]) -> list[str]:
+    """Return a new list with the items of iterable in reverse order."""
+    result: list[str] = []
+    i: int = len(iterable) - 1
+    while i >= 0:
+        result.append(iterable[i])
+        i = i - 1
+    return result

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -1551,14 +1551,16 @@ std::string python_annotation<Json>::get_type_from_rhs_variable(
     // Defensive fallback: when the RHS names a Python iterable-producing
     // builtin (e.g. `alias = range`), there is no AST declaration to find.
     // Return the builtin's mapped type so a bare RHS does not abort type
-    // inference. The four entries below are safe because `builtin_functions`
-    // maps each of them to its own name as the call-result type tag
+    // inference. Each entry below is safe because `builtin_functions`
+    // maps it to its own name as the call-result type tag
     // ("range" -> "range", ...), which is also a workable placeholder for
     // the callable. Do NOT extend this set without verifying the same
     // property -- adding e.g. "iter" would return "iterator" as the type
-    // of the callable itself, which is wrong.
+    // of the callable itself, which is wrong. ("reversed" is intentionally
+    // absent: it maps to "list" -- its call-result type, like "sorted" --
+    // not to a self-named callable placeholder.)
     static const std::unordered_set<std::string> iterable_builtins = {
-      "range", "enumerate", "zip", "reversed"};
+      "range", "enumerate", "zip"};
     if (iterable_builtins.count(rhs_var_name))
       return builtin_functions().at(rhs_var_name);
 

--- a/src/python-frontend/python_annotation/annotation_intrinsics.cpp
+++ b/src/python-frontend/python_annotation/annotation_intrinsics.cpp
@@ -31,7 +31,7 @@ const std::map<std::string, std::string> &builtin_functions()
     {"range", "range"},
     {"enumerate", "enumerate"},
     {"zip", "zip"},
-    {"reversed", "reversed"},
+    {"reversed", "list"},
     {"sorted", "list"},
 
     // I/O functions


### PR DESCRIPTION
## What

Adds Python `reversed()` support to the frontend by modelling it as a list-returning operational model, mirroring the existing `sorted()` family.

- `models/builtins.py`: new `reversed` / `reversed_float` / `reversed_str` OMs that return a freshly reversed list.
- `function_call/expr.cpp`: `reversed` joins the element-type monomorph dispatch (`reversed` / `reversed_float` / `reversed_str`), exactly like `sorted`/`min`/`max`.
- `annotation_intrinsics.cpp`: corrects the `builtin_functions()` return-type tag for `reversed` from the invalid `"reversed"` to `"list"` (matching `sorted`). The old self-mapping flowed into `get_typet("reversed")` and raised `NameError` on `r = reversed(xs)` assignments.
- `annotation_conversion.inl`: drops `reversed` from the `iterable_builtins` self-mapping set (its members must map to their own name; `reversed` now maps to `"list"`, like `sorted`).

## Why

On current `master`, #5302 (list slice-assignment) advanced QuixBugs `next_permutation` to a fresh narrow error — `List slice assignment requires a list right-hand side` — on:

```python
next_perm[i + 1:] = reversed(next_perm[i + 1:])
```

because `reversed()` had no model at all, and even a bare `r = reversed(xs)` raised `NameError: name 'reversed' is not defined` during the annotation pass.

## Soundness

Modelling `reversed()` as an eager list (rather than CPython's lazy reverse-iterator) is sound in every context ESBMC routes through the model — slice-assignment RHS, `list(reversed(...))`. The `for`/`range` iteration forms (`for i in reversed(range(n))`, `for x in reversed(seq)`) are rewritten earlier in `preprocessor/loop_mixin.py` and never reach the model, so existing `reversed1` / `reversed_loop` behaviour is unchanged.

This does **not** flip the `next_permutation` KNOWNBUG verdict: with `reversed()` modelled it now does genuine BMC and hits the unwinding wall (an honest perf bound) instead of erroring. The fix is independently useful for any program using `reversed()` in a value context.

## Tests

- New regression pair `regression/python/reversed_builtin{,_fail}` (one passing, one failing), written with CPython-valid patterns so `check_python_tests.sh` passes.
- 53 sibling `reversed`/`sorted`/`slice`/`list` tests pass; CPython sanity green.

Context: continues the sweep in `docs/python-issues-triage-report-2026-06-02.md` (§7).
