### PR TITLE
[symex] Filter function-pointer call targets by signature

### DIFF
--- a/regression/esbmc/github_5296/main.c
+++ b/regression/esbmc/github_5296/main.c
@@ -1,0 +1,68 @@
+// #5296: an indirect call through a function pointer read from a
+// symbolic-size heap object gets an over-approximated value-set that lists
+// address-taken functions of unrelated arity. Dispatching the 1-argument hash
+// call to the 2-argument equals function silently models the missing argument
+// as nondet ("missing argument for parameter ...; modelled as nondet").
+//
+// The pointer provably holds uhash, so the program is SUCCESSFUL either way;
+// the bug is the spurious wrong-arity candidate. This test passes only when
+// that candidate is filtered out (no missing-argument warning).
+#include <stdint.h>
+#include <stdlib.h>
+extern void abort(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+
+uint64_t uhash(const void *a) // 1-argument
+{
+  return (uint64_t)a ? (uint64_t)a : 1ull;
+}
+
+_Bool eqnn(const void *a, const void *b) // 2-argument
+{
+  __ESBMC_assert(b != NULL, "b must not be a dropped (nondet) argument");
+  return a == b;
+}
+
+typedef uint64_t (*hfn)(const void *);
+typedef _Bool (*efn)(const void *, const void *);
+struct state
+{
+  hfn hf;
+  efn ef;
+  size_t n;
+};
+struct table
+{
+  struct state *p;
+};
+
+static void alloc_table(struct table *t)
+{
+  size_t n = __VERIFIER_nondet_ulong();
+  if (!(n && n <= 4))
+    abort();
+  struct state *s = malloc(sizeof(struct state) + n * 16); // symbolic-size heap
+  if (!s)
+    abort();
+  s->hf = uhash;
+  s->ef = eqnn;
+  s->n = n;
+  t->p = s;
+}
+
+static uint64_t do_hash(struct table *t, const void *k)
+{
+  return t->p->hf(k); // 1-argument indirect call through a heap-read pointer
+}
+
+int main(void)
+{
+  struct table t;
+  alloc_table(&t);
+  void *k = (void *)(uintptr_t)__VERIFIER_nondet_ulong();
+  if (!k)
+    abort();
+  uint64_t h = do_hash(&t, k);
+  __ESBMC_assert(h != 0, "uhash never returns 0");
+  return 0;
+}

--- a/regression/esbmc/github_5296/test.desc
+++ b/regression/esbmc/github_5296/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--64 --incremental-bmc --no-pointer-check --no-bounds-check --force-malloc-success
+\A(?![\s\S]*missing argument for parameter)[\s\S]*VERIFICATION SUCCESSFUL[\s\S]*\Z

--- a/regression/esbmc/github_5296_fail/main.c
+++ b/regression/esbmc/github_5296_fail/main.c
@@ -1,0 +1,62 @@
+// #5296 companion: the signature filter must keep the *correct* target.
+// Same over-approximated heap function pointer as github_5296, but the
+// legitimately-dispatched 1-argument uhash asserts its argument is non-null and
+// the key may be null. The assertion is reachable only if uhash is still a call
+// target after filtering, so this FAILED result guards against the filter
+// over-pruning and silently skipping the real call.
+#include <stdint.h>
+#include <stdlib.h>
+extern void abort(void);
+extern unsigned long __VERIFIER_nondet_ulong(void);
+
+uint64_t uhash(const void *a) // 1-argument
+{
+  __ESBMC_assert(a != NULL, "uhash argument must be non-null");
+  return (uint64_t)a ? (uint64_t)a : 1ull;
+}
+
+_Bool eqnn(const void *a, const void *b) // 2-argument
+{
+  return a == b;
+}
+
+typedef uint64_t (*hfn)(const void *);
+typedef _Bool (*efn)(const void *, const void *);
+struct state
+{
+  hfn hf;
+  efn ef;
+  size_t n;
+};
+struct table
+{
+  struct state *p;
+};
+
+static void alloc_table(struct table *t)
+{
+  size_t n = __VERIFIER_nondet_ulong();
+  if (!(n && n <= 4))
+    abort();
+  struct state *s = malloc(sizeof(struct state) + n * 16); // symbolic-size heap
+  if (!s)
+    abort();
+  s->hf = uhash;
+  s->ef = eqnn;
+  s->n = n;
+  t->p = s;
+}
+
+static uint64_t do_hash(struct table *t, const void *k)
+{
+  return t->p->hf(k); // 1-argument indirect call through a heap-read pointer
+}
+
+int main(void)
+{
+  struct table t;
+  alloc_table(&t);
+  void *k = (void *)(uintptr_t)__VERIFIER_nondet_ulong(); // may be null
+  uint64_t h = do_hash(&t, k);
+  return 0;
+}

--- a/regression/esbmc/github_5296_fail/test.desc
+++ b/regression/esbmc/github_5296_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--64 --incremental-bmc --no-pointer-check --no-bounds-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -412,6 +412,49 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   cur_state->source.prog = &goto_function.body;
 }
 
+// True if a function of type `candidate` may be called through a function
+// pointer whose declared pointed-to type is `declared_type`. Mirrors CBMC's
+// remove_function_pointers signature check, adapted to ESBMC's representation
+// in which an unprototyped `void (*)()` is indistinguishable from a prototyped
+// `void (*)(void)` (both carry no arguments and no ellipsis). Such pointers are
+// treated as matching any target, preserving ESBMC's permissive K&R dispatch
+// (regression/esbmc/function_deref_{2,3,4}). Return types are intentionally not
+// compared, to avoid pruning the common void*/typed-pointer casts.
+static bool function_is_type_compatible(
+  const code_type2t &declared_type,
+  const code_type2t &candidate,
+  const namespacet &ns)
+{
+  // An unprototyped (`void (*)()`) or variadic pointer does not pin the
+  // argument count, so any target is admissible.
+  if (declared_type.arguments.empty() || declared_type.ellipsis)
+    return true;
+
+  // A variadic or unprototyped target accepts the declared arguments.
+  if (candidate.arguments.empty() || candidate.ellipsis)
+    return true;
+
+  // Both have fixed arity: the counts must match (the #5296 case rejects a
+  // 1-argument pointer against a 2-argument target here).
+  if (candidate.arguments.size() != declared_type.arguments.size())
+    return false;
+
+  // Each declared parameter must match the target's, allowing the same
+  // number<->pointer interchange the call site performs in
+  // argument_assignments.
+  for (std::size_t i = 0; i < declared_type.arguments.size(); ++i)
+  {
+    const type2tc &a = declared_type.arguments[i];
+    const type2tc &b = candidate.arguments[i];
+    if (base_type_eq(a, b, ns))
+      continue;
+    if (!((is_number_type(a) || is_pointer_type(a)) &&
+          (is_number_type(b) || is_pointer_type(b))))
+      return false;
+  }
+  return true;
+}
+
 static std::list<std::pair<guard2tc, expr2tc>>
 get_function_list(const expr2tc &expr)
 {
@@ -509,6 +552,39 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
   }
 
   std::list<std::pair<guard2tc, expr2tc>> l = get_function_list(func_ptr);
+
+  // Drop candidates whose signature is incompatible with the declared
+  // function-pointer type (#5296). An over-approximated value-set can list
+  // address-taken functions of unrelated arity; dispatching a call to such a
+  // wrong-arity target silently nondet-fills the missing arguments
+  // (argument_assignments), which the solver can turn into a spurious
+  // VERIFICATION FAILED. The declared signature is the function operand's type:
+  // a code type for the usual dereferenced-pointer call, or a pointer-to-code
+  // when the operand is the bare pointer. If the filter would remove every
+  // candidate, keep the full list so a frontend type quirk on the real target
+  // can never silently skip the call.
+  const type2tc &func_type = is_pointer_type(call.function->type)
+                               ? to_pointer_type(call.function->type).subtype
+                               : call.function->type;
+  if (is_code_type(func_type))
+  {
+    const code_type2t &declared_type = to_code_type(func_type);
+    std::list<std::pair<guard2tc, expr2tc>> compatible;
+    for (auto &it : l)
+      if (
+        !is_code_type(it.second->type) ||
+        function_is_type_compatible(
+          declared_type, to_code_type(it.second->type), ns))
+        compatible.push_back(it);
+      else
+        log_debug(
+          "function-pointer",
+          "dropping incompatible call target '{}'",
+          to_symbol2t(it.second).thename.as_string());
+
+    if (!compatible.empty())
+      l = std::move(compatible);
+  }
 
   /* Internal check that all symbols are actually of 'code' type (modulo the
    * guard) */


### PR DESCRIPTION
## Problem

An indirect call through a function pointer read from imprecisely-modelled heap memory gets an over-approximated value-set that lists address-taken functions of **unrelated arity**. `symex_function_call_deref` built its candidate target list from that value-set with **no signature filter** (unlike CBMC's `remove_function_pointers`), so a 1-argument call could be dispatched to a 2-argument target. The surplus parameter is silently modelled as nondet (`argument_assignments`), the solver picks NULL/garbage, an assertion inside the wrongly-dispatched callee fires, and ESBMC reports a **spurious `VERIFICATION FAILED`** (`Fixes #5296`).

## Fix

Add a static `function_is_type_compatible(declared_type, candidate, ns)` predicate and filter the candidate list in `symex_function_call_deref`:

- **Prototyped, fixed-arity pointers** drop candidates of mismatched arity or incompatible parameter type (reusing the same number↔pointer interchange the call site already performs).
- **Unprototyped (`void (*)()`) and variadic pointers** still match any target — ESBMC cannot distinguish `void (*)()` from `void (*)(void)`, so these keep the existing permissive K&R dispatch (`function_deref_{2,3,4}`).
- If filtering would remove **every** candidate, the full list is kept, so a frontend type quirk on the real target can never silently skip a call.

Return types are intentionally not compared, to avoid pruning common `void*`/typed-pointer casts. The filter only tightens fully-prototyped pointers; unprototyped indirect calls are unchanged.

## Tests

- `regression/esbmc/github_5296` — heap-read 1-arg pointer whose value-set over-approximates to a 2-arg target; asserts SUCCESSFUL **and** that the `missing argument for parameter` warning is absent (negative-lookahead). Fails on the unfixed binary, passes with the fix.
- `regression/esbmc/github_5296_fail` — same setup but the correctly-dispatched 1-arg target asserts on a possibly-null key; FAILED is reachable only if the filter keeps the real target — guards against over-pruning.

Validated: both new tests, `function_deref_{0..4}`, 180 C++ virtual-dispatch tests, and ~30 other function-pointer tests all pass; no regressions.
