### PR TITLE
[build] Silence unused-parameter/variable compiler warnings

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3482,7 +3482,7 @@ exprt python_list::list_repetition(
   // True when the list operand is a variable (not a literal).
   bool is_variable_list = false;
 
-  auto is_integer_type = [](const typet &type) {
+  [[maybe_unused]] auto is_integer_type = [](const typet &type) {
     return type.is_signedbv() || type.is_unsignedbv();
   };
 

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -333,7 +333,6 @@ protected:
   bool is_sol_builin_symbol(const std::string &cname, const std::string &name);
   nlohmann::json reorder_arguments(
     const nlohmann::json &expr,
-    const nlohmann::json &src_ast_json,
     const nlohmann::json &callee_expr_json);
 
   // handle the non-contract definition, including struct/enum/error/event/abstract/...

--- a/src/solidity-frontend/solidity_convert_contract.cpp
+++ b/src/solidity-frontend/solidity_convert_contract.cpp
@@ -515,7 +515,6 @@ bool solidity_convertert::get_high_level_call_wrapper(
 
 nlohmann::json solidity_convertert::reorder_arguments(
   const nlohmann::json &expr,
-  const nlohmann::json &src_ast_json,
   const nlohmann::json &callee_expr_json)
 {
   // build a map from name to argument

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -1587,8 +1587,7 @@ bool solidity_convertert::get_call_expr(
   auto it = expr.find("names");
   if (it != expr.end() && it->is_array() && !it->empty())
   {
-    nlohmann::json clean_expr =
-      reorder_arguments(expr, src_ast_json, callee_expr_json);
+    nlohmann::json clean_expr = reorder_arguments(expr, callee_expr_json);
     if (get_non_library_function_call(decl_ref, clean_expr, call))
       return true;
 
@@ -2137,7 +2136,7 @@ bool solidity_convertert::get_index_access_expr(
 
 bool solidity_convertert::get_index_range_access_expr(
   const nlohmann::json &expr,
-  const nlohmann::json &literal_type,
+  const nlohmann::json & /*literal_type*/,
   exprt &new_expr)
 {
   // IndexRangeAccess: data[start:end] on calldata arrays/bytes
@@ -2163,7 +2162,7 @@ bool solidity_convertert::get_index_range_access_expr(
 
 bool solidity_convertert::get_new_object_expr(
   const nlohmann::json &expr,
-  const nlohmann::json &literal_type,
+  const nlohmann::json & /*literal_type*/,
   exprt &new_expr)
 {
   locationt location;


### PR DESCRIPTION
## What

Fixes four compiler warnings emitted during a normal build of the Solidity
and Python frontends:

- `solidity_convert_expr.cpp` — `get_index_range_access_expr` and
  `get_new_object_expr` did not use their `literal_type` parameter
  (`-Wunused-parameter`). Since `literal_type` is part of the uniform
  `(expr, literal_type, new_expr)` interface shared by the sibling
  `get_*_expr` helpers, the parameter is kept but left **unnamed** in the
  `.cpp` definition (still named in the header for documentation).
- `reorder_arguments` — removed the unused `src_ast_json` parameter. It
  shadowed the static member `solidity_convertert::src_ast_json` and was
  never read in the body. Dropped from the declaration, definition, and the
  single call site.
- `python_list.cpp` — the `is_integer_type` lambda in `list_repetition` is
  referenced only inside `assert(...)`, so under `NDEBUG` it is unused
  (`-Wunused-but-set-variable`). Marked `[[maybe_unused]]`, preserving the
  debug-build assertions.

## Why

These warnings add noise to clean builds. All three fixes are
behaviour-neutral.

## Verification

- Full build is clean; all four warnings are gone.
- Regression subsets for the affected frontends were run. The only failures
  (`delegate_shadow_3`, `nested_array_deep_1`, `python-intensive/list5`,
  `list_extend15`) reproduce **identically on `master`** without this
  change, confirming they are pre-existing and unrelated.
- `clang-format` clean on all four files.