### PR TITLE
[python] Don't abort on forward-referenced function returning a class

### DIFF
--- a/regression/python/forward_func_class_return/main.py
+++ b/regression/python/forward_func_class_return/main.py
@@ -1,0 +1,23 @@
+# A module-level function whose return type is a user-defined class, called
+# from a site that lexically precedes its definition (a forward reference).
+# This is valid Python: `make` is resolved at call time, by which point it is
+# defined. The frontend previously aborted with an assertion in
+# handle_function_call_rhs because the callee symbol was not yet in the symbol
+# table when the call site was converted.
+
+class Widget:
+    def __init__(self):
+        self.x = 0.0
+
+
+def f() -> float:
+    w = make()
+    w.x = 7.0
+    return w.x
+
+
+def make() -> Widget:
+    return Widget()
+
+
+assert f() == 7.0

--- a/regression/python/forward_func_class_return/test.desc
+++ b/regression/python/forward_func_class_return/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/forward_func_class_return_fail/main.py
+++ b/regression/python/forward_func_class_return_fail/main.py
@@ -1,0 +1,20 @@
+# Negative variant of forward_func_class_return: the same forward-referenced
+# function returning a user-defined class, but with an assertion that does not
+# hold. Confirms the fix preserves soundness (the previously-crashing path now
+# yields a real verdict, and a false claim is correctly refuted).
+
+class Widget:
+    def __init__(self):
+        self.x = 0.0
+
+
+def f() -> float:
+    w = make()
+    return w.x
+
+
+def make() -> Widget:
+    return Widget()
+
+
+assert f() == 99.0

--- a/regression/python/forward_func_class_return_fail/test.desc
+++ b/regression/python/forward_func_class_return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1192,12 +1192,20 @@ void python_converter::handle_function_call_rhs(
   }
   else
   {
+    // The callee may not be in the symbol table yet when the called
+    // function is defined later in the module than its call site (a forward
+    // reference, e.g. `def f(): w = make()` with `make` defined afterwards).
+    // The block below only propagates instance-attribute type hints from the
+    // callee's return object to the LHS; it does not affect the GOTO call
+    // itself, which is built from the function identifier elsewhere. When the
+    // callee symbol is not available yet, skip the best-effort copy instead of
+    // aborting.
     symbolt *func_symbol =
       symbol_table_.find_symbol(rhs.op1().identifier().c_str());
-    assert(func_symbol);
-    if (!static_cast<const code_typet &>(func_symbol->get_type())
-           .return_type()
-           .is_empty())
+    if (
+      func_symbol && !static_cast<const code_typet &>(func_symbol->get_type())
+                        .return_type()
+                        .is_empty())
     {
       if (auto ret = get_return_from_func(func_symbol->id.c_str());
           !ret.is_nil())


### PR DESCRIPTION
## Problem

A module-level function whose **return type is a user-defined class**, called from a site that lexically **precedes its definition** (a forward reference), aborted the Python frontend with an assertion. This is valid Python — the callee is resolved at call time, by which point it is defined:

```python
class Widget:
    def __init__(self):
        self.x = 0.0

def f() -> float:
    w = make()        # forward reference: make defined below
    return w.x

def make() -> Widget:
    return Widget()

assert f() == 0.0
```

```
Assertion failed: (func_symbol), function handle_function_call_rhs, file converter_stmt.cpp, line 1197.
```

## Root cause

`python_converter::handle_function_call_rhs` (`converter_stmt.cpp:1197`) did `find_symbol(callee)` then `assert(func_symbol)` before copying instance-attribute **type hints** from the callee's return object to the LHS. For a forward-referenced callee the symbol is not yet in the table, so the assertion fired. Forward references to *classes* were already handled by `process_forward_reference`; the same gap remained for *functions returning a class*. A plain forward-referenced function (e.g. returning `int`) does not reach this block, which is why only class-typed returns crashed.

## Fix

Guard the lookup: when the callee symbol is unavailable (forward reference), skip the best-effort attribute-hint copy instead of aborting. The block only propagates type hints — the GOTO call itself is built from the function identifier elsewhere, so verification semantics are unchanged.

## Why it is correct / sound

Validated on the previously-crashing path:
- forward class-return with a true claim → `VERIFICATION SUCCESSFUL`
- the same path with a false claim → `VERIFICATION FAILED` (no false SUCCESSFUL)
- attribute mutation (`w.x = 7.0`) still tracked correctly
- non-forward control case unchanged

Dead-code (C-Live): the new `func_symbol == null` branch is exercised by the added `forward_func_class_return` test, which previously aborted at exactly this site.

## Validation

- New tests: `regression/python/forward_func_class_return` (CORE, SUCCESSFUL) and `forward_func_class_return_fail` (CORE, FAILED).
- `ctest` over the affected Python subset (`forward_*`, `github_4117_*`, `import-class-*`, `*attr*`, `*class*`): **176/176 passed**, including `github_4117_function_internal` which correctly remains KNOWNBUG (its blocker is object-escape/heap modeling, tracked separately in #4773 / PR #5316).
- CPython sanity (`scripts/check_python_tests.sh`) green for both new tests.

## Scope

Uncovered while reducing the `rover` integration test (#4775). This fixes one independent frontend crash on that path; it does **not** fully close #4775, which additionally needs `from package.module import Class` resolution inside method bodies, typed `Dict[str, T]` attributes, and nested attribute writes.

Refs #4775
