### PR TITLE
feat(ld): add real-world CONTROLLINO industrial benchmarks

### DIFF
--- a/regression/ld/benchmarks/stairs_light/README.md
+++ b/regression/ld/benchmarks/stairs_light/README.md
@@ -1,0 +1,23 @@
+# Staircase Light Control
+
+**Source:** CONTROLLINO-PLC/OpenPLC_examples (MIT License)
+**Hardware:** CONTROLLINO MAXI Automation PLC
+**Created:** 2024-11-18 | **Modified:** 2024-12-05
+
+## Description
+
+Real-world building automation program for staircase lighting.
+Two push buttons toggle the light. A PIR motion sensor activates
+the light automatically for 20 seconds via a TOF timer.
+
+## Safety Properties
+
+| ID | Kind | Description |
+|---|---|---|
+| P1 | invariant | Light must not be on without PIR or button activation |
+| P2 | invariant | PIR detection must activate the light |
+| P3 | invariant | Simultaneous button presses must not cause undefined state |
+
+## Expected Result
+
+VERIFICATION SUCCESSFUL — k-induction k=2 in ~0.03s

--- a/regression/ld/benchmarks/stairs_light/props.yaml
+++ b/regression/ld/benchmarks/stairs_light/props.yaml
@@ -1,0 +1,22 @@
+properties:
+
+  # P1: Light must not be on when PIR sensor is inactive AND buttons state is off
+  # If no motion and no button active, light should be off
+  - id: P1
+    kind: invariant
+    expression: "!stairs_light || stairs_pir_sensor || lights_buttons_state"
+    description: "Light must not be on without PIR detection or button activation"
+
+  # P2: PIR sensor and light output consistency
+  # When PIR detects motion and buttons are off, TOF timer keeps light on
+  - id: P2
+    kind: invariant
+    expression: "!stairs_pir_sensor || stairs_light || lights_buttons_state"
+    description: "PIR detection must activate the light"
+
+  # P3: Button state toggle consistency — SET and RESET are mutually exclusive
+  # lights_buttons_state cannot be simultaneously set and reset in the same scan
+  - id: P3
+    kind: invariant
+    expression: "!(control_button_up && control_button_down && lights_buttons_state)"
+    description: "Both buttons pressed simultaneously must not cause undefined light state"

--- a/regression/ld/benchmarks/stairs_light/stairs_light.ld
+++ b/regression/ld/benchmarks/stairs_light/stairs_light.ld
@@ -1,0 +1,388 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ns1="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="Desconocido" productName="Sin nombre" productVersion="1" creationDateTime="2024-11-18T12:32:42"/>
+  <contentHeader name="Sin nombre" modificationDateTime="2024-12-05T12:24:50">
+    <coordinateInfo>
+      <fbd>
+        <scaling x="10" y="10"/>
+      </fbd>
+      <ld>
+        <scaling x="10" y="10"/>
+      </ld>
+      <sfc>
+        <scaling x="10" y="10"/>
+      </sfc>
+    </coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="light_control" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="stairs_light" address="%QX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Light switch turns on with true value]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+          <localVars>
+            <variable name="lights_buttons_state">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Variable that indicates the state of lights according the buttons actions]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+          <localVars>
+            <variable name="stairs_pir_sensor" address="%IX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Passive Infrared Sensor detects persons arriving the stairs]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="control_button_down" address="%IX0.1">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Press button located down the stairs]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="control_button_up" address="%IX0.2">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Press button located up the stairs]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+          <localVars>
+            <variable name="TOF0">
+              <type>
+                <derived name="TOF"/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Temporizador que marca el tiempo de encendido de la luz]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+        </interface>
+        <body>
+          <LD>
+            <leftPowerRail localId="1" width="10" height="280">
+              <position x="30" y="200"/>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="20"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="60"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="100"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="140"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="180"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="220"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="260"/>
+              </connectionPointOut>
+            </leftPowerRail>
+            <rightPowerRail localId="2" width="10" height="280">
+              <position x="710" y="200"/>
+              <connectionPointIn>
+                <relPosition x="0" y="20"/>
+                <connection refLocalId="5">
+                  <position x="710" y="220"/>
+                  <position x="640" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="60"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="100"/>
+                <connection refLocalId="6">
+                  <position x="710" y="300"/>
+                  <position x="640" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="140"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="180"/>
+                <connection refLocalId="11">
+                  <position x="710" y="380"/>
+                  <position x="640" y="380"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="220"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="260"/>
+              </connectionPointIn>
+            </rightPowerRail>
+            <contact localId="3" negated="false" edge="rising" width="30" height="20">
+              <position x="110" y="210"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="220"/>
+                  <position x="40" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>control_button_up</variable>
+            </contact>
+            <contact localId="4" negated="false" edge="rising" width="30" height="20">
+              <position x="110" y="290"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="300"/>
+                  <position x="40" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>control_button_down</variable>
+            </contact>
+            <coil localId="5" negated="false" width="30" height="20" storage="set">
+              <position x="610" y="210"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="8">
+                  <position x="610" y="220"/>
+                  <position x="530" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </coil>
+            <coil localId="6" negated="false" width="30" height="20" storage="reset">
+              <position x="610" y="290"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="7">
+                  <position x="610" y="300"/>
+                  <position x="530" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </coil>
+            <contact localId="7" negated="false" width="30" height="20">
+              <position x="500" y="290"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="3">
+                  <position x="500" y="300"/>
+                  <position x="335" y="300"/>
+                  <position x="335" y="220"/>
+                  <position x="140" y="220"/>
+                </connection>
+                <connection refLocalId="4">
+                  <position x="500" y="300"/>
+                  <position x="140" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <contact localId="8" negated="true" width="30" height="20">
+              <position x="500" y="210"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="4">
+                  <position x="500" y="220"/>
+                  <position x="335" y="220"/>
+                  <position x="335" y="300"/>
+                  <position x="140" y="300"/>
+                </connection>
+                <connection refLocalId="3">
+                  <position x="500" y="220"/>
+                  <position x="140" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <contact localId="9" negated="false" edge="rising" width="30" height="20">
+              <position x="110" y="370"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="380"/>
+                  <position x="40" y="380"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>stairs_pir_sensor</variable>
+            </contact>
+            <block localId="10" typeName="TOF" instanceName="TOF0" width="50" height="60">
+              <position x="330" y="350"/>
+              <inputVariables>
+                <variable formalParameter="IN">
+                  <connectionPointIn>
+                    <relPosition x="0" y="30"/>
+                    <connection refLocalId="12">
+                      <position x="330" y="380"/>
+                      <position x="250" y="380"/>
+                    </connection>
+                  </connectionPointIn>
+                </variable>
+                <variable formalParameter="PT">
+                  <connectionPointIn>
+                    <relPosition x="0" y="50"/>
+                    <connection refLocalId="14">
+                      <position x="330" y="400"/>
+                      <position x="310" y="400"/>
+                    </connection>
+                  </connectionPointIn>
+                </variable>
+              </inputVariables>
+              <inOutVariables/>
+              <outputVariables>
+                <variable formalParameter="Q">
+                  <connectionPointOut>
+                    <relPosition x="50" y="30"/>
+                  </connectionPointOut>
+                </variable>
+                <variable formalParameter="ET">
+                  <connectionPointOut>
+                    <relPosition x="50" y="50"/>
+                  </connectionPointOut>
+                </variable>
+              </outputVariables>
+            </block>
+            <coil localId="11" negated="false" width="30" height="20">
+              <position x="610" y="370"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="10" formalParameter="Q">
+                  <position x="610" y="380"/>
+                  <position x="380" y="380"/>
+                </connection>
+                <connection refLocalId="13">
+                  <position x="610" y="380"/>
+                  <position x="550" y="380"/>
+                  <position x="550" y="460"/>
+                  <position x="140" y="460"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>stairs_light</variable>
+            </coil>
+            <contact localId="12" negated="true" width="30" height="20">
+              <position x="220" y="370"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="9">
+                  <position x="220" y="380"/>
+                  <position x="140" y="380"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <contact localId="13" negated="false" width="30" height="20">
+              <position x="110" y="450"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="460"/>
+                  <position x="40" y="460"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <inVariable localId="14" width="40" height="20" negated="false">
+              <position x="270" y="390"/>
+              <connectionPointOut>
+                <relPosition x="40" y="10"/>
+              </connectionPointOut>
+              <expression>T#20s</expression>
+            </inVariable>
+            <comment localId="15" height="160" width="1170">
+              <position x="10" y="10"/>
+              <content>
+                <xhtml:p><![CDATA[OpenPLC HAL for CONTROLLINO MAXI Automation see https://www.controllino.com/wp-content/uploads/2021/03/CONTROLLINO-MAXI-Automation-Pinout.pdf
+
+Digital In:  AI2, AI3, AI4, AI5, AI6, AI7, AI8, AI9     (%IX0.0 - %IX0.7)
+             AI10, AI11, DI0, DI1, DI2, DI3, AI2, AI3   (%IX1.0 - %IX1.7)
+
+Digital Out: DO0, DO1, DO2, DO3, DO4, DO5, DO6, DO7     (%QX0.0 - %QX0.7)
+             R0, R1, R2, R3, R4, R5, R6, R7             (%QX1.0 - %QX1.7)
+             R8, R9                                     (%QX2.0 - %QX2.1)
+
+Analog In:   AI0, AI1, AI13, AI13                       (%IW0 - %IW3)
+
+Analog Out:  AO0, AO1                                   (%QW0 - %QW1)
+]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="16" height="60" width="320">
+              <position x="730" y="230"/>
+              <content>
+                <xhtml:p><![CDATA[When any button is pressed and is detected a rise pulse the light state flag change among true and false, on and off]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="17" height="70" width="310">
+              <position x="730" y="380"/>
+              <content>
+                <xhtml:p><![CDATA[If sensor PIR signal is detected and the light is turned off, light outuput will turn on during preset time, 20 seconds, if state flag is on the light putput will turn on at the same time]]></xhtml:p>
+              </content>
+            </comment>
+          </LD>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances>
+    <configurations>
+      <configuration name="Config0">
+        <resource name="Res0">
+          <task name="task0" priority="0" interval="T#20ms">
+            <pouInstance name="instance0" typeName="light_control"/>
+          </task>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+</project>

--- a/regression/ld/benchmarks/water_control/README.md
+++ b/regression/ld/benchmarks/water_control/README.md
@@ -1,0 +1,23 @@
+# Water Reserve Control
+
+**Source:** CONTROLLINO-PLC/OpenPLC_examples (MIT License)
+**Hardware:** CONTROLLINO MAXI Automation PLC
+**Created:** 2024-11-13 | **Modified:** 2024-12-05
+
+## Description
+
+Real-world industrial program for automatic water pump control.
+A pump fills an elevated tank from a cistern, controlled by
+level sensors and manual Start/Stop buttons.
+
+## Safety Properties
+
+| ID | Kind | Description |
+|---|---|---|
+| P1 | invariant | Pump must not run when pool is empty (cavitation hazard) |
+| P2 | invariant | Pump must not run when tank is full (overflow hazard) |
+| P3 | absence | Stop button must immediately halt the pump |
+
+## Expected Result
+
+VERIFICATION SUCCESSFUL — k-induction k=2 in ~0.03s

--- a/regression/ld/benchmarks/water_control/props.yaml
+++ b/regression/ld/benchmarks/water_control/props.yaml
@@ -1,0 +1,15 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "!Water_Pump || Pool_Low_Level_Sensor"
+    description: "Pump must not run when pool is empty"
+
+  - id: P2
+    kind: invariant
+    expression: "!Water_Pump || !Tank_High_Level_Sensor"
+    description: "Pump must not run when tank is full"
+
+  - id: P3
+    kind: absence
+    expression: "Water_Pump && Stop_Button"
+    description: "Stop button must halt the pump"

--- a/regression/ld/benchmarks/water_control/water_control.ld
+++ b/regression/ld/benchmarks/water_control/water_control.ld
@@ -1,0 +1,383 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ns1="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="Desconocido" productName="Sin nombre" productVersion="1" creationDateTime="2024-11-13T10:20:43"/>
+  <contentHeader name="Water_Reserve_Control" modificationDateTime="2024-12-05T12:40:23">
+    <coordinateInfo>
+      <fbd>
+        <scaling x="10" y="10"/>
+      </fbd>
+      <ld>
+        <scaling x="10" y="10"/>
+      </ld>
+      <sfc>
+        <scaling x="10" y="10"/>
+      </sfc>
+    </coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="Water_Control" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="Pool_Low_Level_Sensor" address="%IX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Pools Level Sensor signal of min level. Zero indicates that level is under the minimun]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Tank_High_Level_Sensor" address="%IX0.1">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Tank Level Sensor of miax level. State "1" indicates maximun level]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Water_Pump" address="%QX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Pump state control output. High value turns on the motor]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Tank_Low_Level_Sensor" address="%IX0.2">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Tank Level Sensor of min level. Zero indicates that level is under the minimun]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Automatic_Manual_Switch" address="%IX0.3">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Automatic/Manual selector. State "0" is Manual mode and "1" Automatic mode]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Stop_Button" address="%IX0.4">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Stop Push Button. If changes its value to "1" indicates stop de pump  ]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Start_Button" address="%IX0.5">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Start Push Button. If changes its value to "1" indicates start de pump  ]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+        </interface>
+        <body>
+          <LD>
+            <leftPowerRail localId="1" width="10" height="360">
+              <position x="20" y="180"/>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="20"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="60"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="100"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="140"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="180"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="220"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="260"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="300"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="340"/>
+              </connectionPointOut>
+            </leftPowerRail>
+            <rightPowerRail localId="2" width="10" height="360">
+              <position x="690" y="180"/>
+              <connectionPointIn>
+                <relPosition x="0" y="20"/>
+                <connection refLocalId="4">
+                  <position x="690" y="200"/>
+                  <position x="640" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="60"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="100"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="140"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="180"/>
+                <connection refLocalId="8">
+                  <position x="690" y="360"/>
+                  <position x="640" y="360"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="220"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="260"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="300"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="340"/>
+              </connectionPointIn>
+            </rightPowerRail>
+            <contact localId="3" negated="false" width="30" height="20">
+              <position x="230" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="9">
+                  <position x="230" y="200"/>
+                  <position x="130" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Pool_Low_Level_Sensor</variable>
+            </contact>
+            <coil localId="4" negated="false" width="30" height="20" storage="set">
+              <position x="610" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="6">
+                  <position x="610" y="200"/>
+                  <position x="500" y="200"/>
+                </connection>
+                <connection refLocalId="12">
+                  <position x="610" y="200"/>
+                  <position x="560" y="200"/>
+                  <position x="560" y="280"/>
+                  <position x="380" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Water_Pump</variable>
+            </coil>
+            <contact localId="5" negated="true" width="30" height="20">
+              <position x="350" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="3">
+                  <position x="350" y="200"/>
+                  <position x="260" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_Low_Level_Sensor</variable>
+            </contact>
+            <contact localId="6" negated="true" width="30" height="20">
+              <position x="470" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="5">
+                  <position x="470" y="200"/>
+                  <position x="380" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_High_Level_Sensor</variable>
+            </contact>
+            <contact localId="7" negated="true" width="30" height="20" executionOrderId="0">
+              <position x="100" y="350"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="360"/>
+                  <position x="30" y="360"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Pool_Low_Level_Sensor</variable>
+            </contact>
+            <coil localId="8" negated="false" width="30" height="20" storage="reset" executionOrderId="0">
+              <position x="610" y="350"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="7">
+                  <position x="610" y="360"/>
+                  <position x="130" y="360"/>
+                </connection>
+                <connection refLocalId="13">
+                  <position x="610" y="360"/>
+                  <position x="560" y="360"/>
+                  <position x="560" y="520"/>
+                  <position x="130" y="520"/>
+                </connection>
+                <connection refLocalId="14">
+                  <position x="610" y="360"/>
+                  <position x="560" y="360"/>
+                  <position x="560" y="440"/>
+                  <position x="130" y="440"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Water_Pump</variable>
+            </coil>
+            <contact localId="9" negated="false" width="30" height="20">
+              <position x="100" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="200"/>
+                  <position x="30" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Automatic_Manual_Switch</variable>
+            </contact>
+            <contact localId="10" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="100" y="270"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="280"/>
+                  <position x="30" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Start_Button</variable>
+            </contact>
+            <contact localId="11" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="230" y="270"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="10">
+                  <position x="230" y="280"/>
+                  <position x="130" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Pool_Low_Level_Sensor</variable>
+            </contact>
+            <contact localId="12" negated="true" width="30" height="20" executionOrderId="0">
+              <position x="350" y="270"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="11">
+                  <position x="350" y="280"/>
+                  <position x="260" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_High_Level_Sensor</variable>
+            </contact>
+            <contact localId="13" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="100" y="510"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="520"/>
+                  <position x="30" y="520"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Stop_Button</variable>
+            </contact>
+            <contact localId="14" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="100" y="430"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="440"/>
+                  <position x="30" y="440"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_High_Level_Sensor</variable>
+            </contact>
+            <comment localId="15" height="160" width="1170">
+              <position x="0" y="0"/>
+              <content>
+                <xhtml:p><![CDATA[OpenPLC HAL for CONTROLLINO MAXI Automation see https://www.controllino.com/wp-content/uploads/2021/03/CONTROLLINO-MAXI-Automation-Pinout.pdf
+
+Digital In:  AI2, AI3, AI4, AI5, AI6, AI7, AI8, AI9     (%IX0.0 - %IX0.7)
+             AI10, AI11, DI0, DI1, DI2, DI3, AI2, AI3   (%IX1.0 - %IX1.7)
+
+Digital Out: DO0, DO1, DO2, DO3, DO4, DO5, DO6, DO7     (%QX0.0 - %QX0.7)
+             R0, R1, R2, R3, R4, R5, R6, R7             (%QX1.0 - %QX1.7)
+             R8, R9                                     (%QX2.0 - %QX2.1)
+
+Analog In:   AI0, AI1, AI13, AI13                       (%IW0 - %IW3)
+
+Analog Out:  AO0, AO1                                   (%QW0 - %QW1)
+]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="16" height="110" width="340">
+              <position x="720" y="190"/>
+              <content>
+                <xhtml:p><![CDATA[Behaviour: The pump starts if the tank level is under de low limit in this case both level sensors into the tank will be zero, negative coil value. The second condition to start de pump is that level of the pool be over the minimum level and the switch be changed to automatic “true”.  The oter condition is that start button be pressed and the level conditions described be acomplished]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="17" height="80" width="310">
+              <position x="720" y="360"/>
+              <content>
+                <xhtml:p><![CDATA[If pump is working and any level condition change to wrong state or stop button is pressed then pump turns off]]></xhtml:p>
+              </content>
+            </comment>
+          </LD>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances>
+    <configurations>
+      <configuration name="Config0">
+        <resource name="Res0">
+          <task name="task0" priority="0" interval="T#20ms">
+            <pouInstance name="instance0" typeName="Water_Control"/>
+          </task>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+</project>

--- a/regression/ld/stairs_light_safe/props.yaml
+++ b/regression/ld/stairs_light_safe/props.yaml
@@ -1,0 +1,22 @@
+properties:
+
+  # P1: Light must not be on when PIR sensor is inactive AND buttons state is off
+  # If no motion and no button active, light should be off
+  - id: P1
+    kind: invariant
+    expression: "!stairs_light || stairs_pir_sensor || lights_buttons_state"
+    description: "Light must not be on without PIR detection or button activation"
+
+  # P2: PIR sensor and light output consistency
+  # When PIR detects motion and buttons are off, TOF timer keeps light on
+  - id: P2
+    kind: invariant
+    expression: "!stairs_pir_sensor || stairs_light || lights_buttons_state"
+    description: "PIR detection must activate the light"
+
+  # P3: Button state toggle consistency — SET and RESET are mutually exclusive
+  # lights_buttons_state cannot be simultaneously set and reset in the same scan
+  - id: P3
+    kind: invariant
+    expression: "!(control_button_up && control_button_down && lights_buttons_state)"
+    description: "Both buttons pressed simultaneously must not cause undefined light state"

--- a/regression/ld/stairs_light_safe/stairs_light.ld
+++ b/regression/ld/stairs_light_safe/stairs_light.ld
@@ -1,0 +1,388 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ns1="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="Desconocido" productName="Sin nombre" productVersion="1" creationDateTime="2024-11-18T12:32:42"/>
+  <contentHeader name="Sin nombre" modificationDateTime="2024-12-05T12:24:50">
+    <coordinateInfo>
+      <fbd>
+        <scaling x="10" y="10"/>
+      </fbd>
+      <ld>
+        <scaling x="10" y="10"/>
+      </ld>
+      <sfc>
+        <scaling x="10" y="10"/>
+      </sfc>
+    </coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="light_control" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="stairs_light" address="%QX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Light switch turns on with true value]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+          <localVars>
+            <variable name="lights_buttons_state">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Variable that indicates the state of lights according the buttons actions]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+          <localVars>
+            <variable name="stairs_pir_sensor" address="%IX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Passive Infrared Sensor detects persons arriving the stairs]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="control_button_down" address="%IX0.1">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Press button located down the stairs]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="control_button_up" address="%IX0.2">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Press button located up the stairs]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+          <localVars>
+            <variable name="TOF0">
+              <type>
+                <derived name="TOF"/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Temporizador que marca el tiempo de encendido de la luz]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+        </interface>
+        <body>
+          <LD>
+            <leftPowerRail localId="1" width="10" height="280">
+              <position x="30" y="200"/>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="20"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="60"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="100"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="140"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="180"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="220"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="260"/>
+              </connectionPointOut>
+            </leftPowerRail>
+            <rightPowerRail localId="2" width="10" height="280">
+              <position x="710" y="200"/>
+              <connectionPointIn>
+                <relPosition x="0" y="20"/>
+                <connection refLocalId="5">
+                  <position x="710" y="220"/>
+                  <position x="640" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="60"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="100"/>
+                <connection refLocalId="6">
+                  <position x="710" y="300"/>
+                  <position x="640" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="140"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="180"/>
+                <connection refLocalId="11">
+                  <position x="710" y="380"/>
+                  <position x="640" y="380"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="220"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="260"/>
+              </connectionPointIn>
+            </rightPowerRail>
+            <contact localId="3" negated="false" edge="rising" width="30" height="20">
+              <position x="110" y="210"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="220"/>
+                  <position x="40" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>control_button_up</variable>
+            </contact>
+            <contact localId="4" negated="false" edge="rising" width="30" height="20">
+              <position x="110" y="290"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="300"/>
+                  <position x="40" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>control_button_down</variable>
+            </contact>
+            <coil localId="5" negated="false" width="30" height="20" storage="set">
+              <position x="610" y="210"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="8">
+                  <position x="610" y="220"/>
+                  <position x="530" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </coil>
+            <coil localId="6" negated="false" width="30" height="20" storage="reset">
+              <position x="610" y="290"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="7">
+                  <position x="610" y="300"/>
+                  <position x="530" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </coil>
+            <contact localId="7" negated="false" width="30" height="20">
+              <position x="500" y="290"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="3">
+                  <position x="500" y="300"/>
+                  <position x="335" y="300"/>
+                  <position x="335" y="220"/>
+                  <position x="140" y="220"/>
+                </connection>
+                <connection refLocalId="4">
+                  <position x="500" y="300"/>
+                  <position x="140" y="300"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <contact localId="8" negated="true" width="30" height="20">
+              <position x="500" y="210"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="4">
+                  <position x="500" y="220"/>
+                  <position x="335" y="220"/>
+                  <position x="335" y="300"/>
+                  <position x="140" y="300"/>
+                </connection>
+                <connection refLocalId="3">
+                  <position x="500" y="220"/>
+                  <position x="140" y="220"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <contact localId="9" negated="false" edge="rising" width="30" height="20">
+              <position x="110" y="370"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="380"/>
+                  <position x="40" y="380"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>stairs_pir_sensor</variable>
+            </contact>
+            <block localId="10" typeName="TOF" instanceName="TOF0" width="50" height="60">
+              <position x="330" y="350"/>
+              <inputVariables>
+                <variable formalParameter="IN">
+                  <connectionPointIn>
+                    <relPosition x="0" y="30"/>
+                    <connection refLocalId="12">
+                      <position x="330" y="380"/>
+                      <position x="250" y="380"/>
+                    </connection>
+                  </connectionPointIn>
+                </variable>
+                <variable formalParameter="PT">
+                  <connectionPointIn>
+                    <relPosition x="0" y="50"/>
+                    <connection refLocalId="14">
+                      <position x="330" y="400"/>
+                      <position x="310" y="400"/>
+                    </connection>
+                  </connectionPointIn>
+                </variable>
+              </inputVariables>
+              <inOutVariables/>
+              <outputVariables>
+                <variable formalParameter="Q">
+                  <connectionPointOut>
+                    <relPosition x="50" y="30"/>
+                  </connectionPointOut>
+                </variable>
+                <variable formalParameter="ET">
+                  <connectionPointOut>
+                    <relPosition x="50" y="50"/>
+                  </connectionPointOut>
+                </variable>
+              </outputVariables>
+            </block>
+            <coil localId="11" negated="false" width="30" height="20">
+              <position x="610" y="370"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="10" formalParameter="Q">
+                  <position x="610" y="380"/>
+                  <position x="380" y="380"/>
+                </connection>
+                <connection refLocalId="13">
+                  <position x="610" y="380"/>
+                  <position x="550" y="380"/>
+                  <position x="550" y="460"/>
+                  <position x="140" y="460"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>stairs_light</variable>
+            </coil>
+            <contact localId="12" negated="true" width="30" height="20">
+              <position x="220" y="370"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="9">
+                  <position x="220" y="380"/>
+                  <position x="140" y="380"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <contact localId="13" negated="false" width="30" height="20">
+              <position x="110" y="450"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="110" y="460"/>
+                  <position x="40" y="460"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>lights_buttons_state</variable>
+            </contact>
+            <inVariable localId="14" width="40" height="20" negated="false">
+              <position x="270" y="390"/>
+              <connectionPointOut>
+                <relPosition x="40" y="10"/>
+              </connectionPointOut>
+              <expression>T#20s</expression>
+            </inVariable>
+            <comment localId="15" height="160" width="1170">
+              <position x="10" y="10"/>
+              <content>
+                <xhtml:p><![CDATA[OpenPLC HAL for CONTROLLINO MAXI Automation see https://www.controllino.com/wp-content/uploads/2021/03/CONTROLLINO-MAXI-Automation-Pinout.pdf
+
+Digital In:  AI2, AI3, AI4, AI5, AI6, AI7, AI8, AI9     (%IX0.0 - %IX0.7)
+             AI10, AI11, DI0, DI1, DI2, DI3, AI2, AI3   (%IX1.0 - %IX1.7)
+
+Digital Out: DO0, DO1, DO2, DO3, DO4, DO5, DO6, DO7     (%QX0.0 - %QX0.7)
+             R0, R1, R2, R3, R4, R5, R6, R7             (%QX1.0 - %QX1.7)
+             R8, R9                                     (%QX2.0 - %QX2.1)
+
+Analog In:   AI0, AI1, AI13, AI13                       (%IW0 - %IW3)
+
+Analog Out:  AO0, AO1                                   (%QW0 - %QW1)
+]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="16" height="60" width="320">
+              <position x="730" y="230"/>
+              <content>
+                <xhtml:p><![CDATA[When any button is pressed and is detected a rise pulse the light state flag change among true and false, on and off]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="17" height="70" width="310">
+              <position x="730" y="380"/>
+              <content>
+                <xhtml:p><![CDATA[If sensor PIR signal is detected and the light is turned off, light outuput will turn on during preset time, 20 seconds, if state flag is on the light putput will turn on at the same time]]></xhtml:p>
+              </content>
+            </comment>
+          </LD>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances>
+    <configurations>
+      <configuration name="Config0">
+        <resource name="Res0">
+          <task name="task0" priority="0" interval="T#20ms">
+            <pouInstance name="instance0" typeName="light_control"/>
+          </task>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+</project>

--- a/regression/ld/stairs_light_safe/test.desc
+++ b/regression/ld/stairs_light_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+stairs_light.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/water_control_safe/props.yaml
+++ b/regression/ld/water_control_safe/props.yaml
@@ -1,0 +1,15 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "!Water_Pump || Pool_Low_Level_Sensor"
+    description: "Pump must not run when pool is empty"
+
+  - id: P2
+    kind: invariant
+    expression: "!Water_Pump || !Tank_High_Level_Sensor"
+    description: "Pump must not run when tank is full"
+
+  - id: P3
+    kind: absence
+    expression: "Water_Pump && Stop_Button"
+    description: "Stop button must halt the pump"

--- a/regression/ld/water_control_safe/test.desc
+++ b/regression/ld/water_control_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+water_control.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/water_control_safe/water_control.ld
+++ b/regression/ld/water_control_safe/water_control.ld
@@ -1,0 +1,383 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ns1="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="Desconocido" productName="Sin nombre" productVersion="1" creationDateTime="2024-11-13T10:20:43"/>
+  <contentHeader name="Water_Reserve_Control" modificationDateTime="2024-12-05T12:40:23">
+    <coordinateInfo>
+      <fbd>
+        <scaling x="10" y="10"/>
+      </fbd>
+      <ld>
+        <scaling x="10" y="10"/>
+      </ld>
+      <sfc>
+        <scaling x="10" y="10"/>
+      </sfc>
+    </coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="Water_Control" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="Pool_Low_Level_Sensor" address="%IX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Pools Level Sensor signal of min level. Zero indicates that level is under the minimun]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Tank_High_Level_Sensor" address="%IX0.1">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Tank Level Sensor of miax level. State "1" indicates maximun level]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Water_Pump" address="%QX0.0">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Pump state control output. High value turns on the motor]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Tank_Low_Level_Sensor" address="%IX0.2">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Tank Level Sensor of min level. Zero indicates that level is under the minimun]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Automatic_Manual_Switch" address="%IX0.3">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Automatic/Manual selector. State "0" is Manual mode and "1" Automatic mode]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Stop_Button" address="%IX0.4">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Stop Push Button. If changes its value to "1" indicates stop de pump  ]]></xhtml:p>
+              </documentation>
+            </variable>
+            <variable name="Start_Button" address="%IX0.5">
+              <type>
+                <BOOL/>
+              </type>
+              <documentation>
+                <xhtml:p><![CDATA[Start Push Button. If changes its value to "1" indicates start de pump  ]]></xhtml:p>
+              </documentation>
+            </variable>
+          </localVars>
+        </interface>
+        <body>
+          <LD>
+            <leftPowerRail localId="1" width="10" height="360">
+              <position x="20" y="180"/>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="20"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="60"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="100"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="140"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="180"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="220"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="260"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="300"/>
+              </connectionPointOut>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="340"/>
+              </connectionPointOut>
+            </leftPowerRail>
+            <rightPowerRail localId="2" width="10" height="360">
+              <position x="690" y="180"/>
+              <connectionPointIn>
+                <relPosition x="0" y="20"/>
+                <connection refLocalId="4">
+                  <position x="690" y="200"/>
+                  <position x="640" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="60"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="100"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="140"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="180"/>
+                <connection refLocalId="8">
+                  <position x="690" y="360"/>
+                  <position x="640" y="360"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="220"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="260"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="300"/>
+              </connectionPointIn>
+              <connectionPointIn>
+                <relPosition x="0" y="340"/>
+              </connectionPointIn>
+            </rightPowerRail>
+            <contact localId="3" negated="false" width="30" height="20">
+              <position x="230" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="9">
+                  <position x="230" y="200"/>
+                  <position x="130" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Pool_Low_Level_Sensor</variable>
+            </contact>
+            <coil localId="4" negated="false" width="30" height="20" storage="set">
+              <position x="610" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="6">
+                  <position x="610" y="200"/>
+                  <position x="500" y="200"/>
+                </connection>
+                <connection refLocalId="12">
+                  <position x="610" y="200"/>
+                  <position x="560" y="200"/>
+                  <position x="560" y="280"/>
+                  <position x="380" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Water_Pump</variable>
+            </coil>
+            <contact localId="5" negated="true" width="30" height="20">
+              <position x="350" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="3">
+                  <position x="350" y="200"/>
+                  <position x="260" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_Low_Level_Sensor</variable>
+            </contact>
+            <contact localId="6" negated="true" width="30" height="20">
+              <position x="470" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="5">
+                  <position x="470" y="200"/>
+                  <position x="380" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_High_Level_Sensor</variable>
+            </contact>
+            <contact localId="7" negated="true" width="30" height="20" executionOrderId="0">
+              <position x="100" y="350"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="360"/>
+                  <position x="30" y="360"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Pool_Low_Level_Sensor</variable>
+            </contact>
+            <coil localId="8" negated="false" width="30" height="20" storage="reset" executionOrderId="0">
+              <position x="610" y="350"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="7">
+                  <position x="610" y="360"/>
+                  <position x="130" y="360"/>
+                </connection>
+                <connection refLocalId="13">
+                  <position x="610" y="360"/>
+                  <position x="560" y="360"/>
+                  <position x="560" y="520"/>
+                  <position x="130" y="520"/>
+                </connection>
+                <connection refLocalId="14">
+                  <position x="610" y="360"/>
+                  <position x="560" y="360"/>
+                  <position x="560" y="440"/>
+                  <position x="130" y="440"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Water_Pump</variable>
+            </coil>
+            <contact localId="9" negated="false" width="30" height="20">
+              <position x="100" y="190"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="200"/>
+                  <position x="30" y="200"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Automatic_Manual_Switch</variable>
+            </contact>
+            <contact localId="10" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="100" y="270"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="280"/>
+                  <position x="30" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Start_Button</variable>
+            </contact>
+            <contact localId="11" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="230" y="270"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="10">
+                  <position x="230" y="280"/>
+                  <position x="130" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Pool_Low_Level_Sensor</variable>
+            </contact>
+            <contact localId="12" negated="true" width="30" height="20" executionOrderId="0">
+              <position x="350" y="270"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="11">
+                  <position x="350" y="280"/>
+                  <position x="260" y="280"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_High_Level_Sensor</variable>
+            </contact>
+            <contact localId="13" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="100" y="510"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="520"/>
+                  <position x="30" y="520"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Stop_Button</variable>
+            </contact>
+            <contact localId="14" negated="false" width="30" height="20" executionOrderId="0">
+              <position x="100" y="430"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1">
+                  <position x="100" y="440"/>
+                  <position x="30" y="440"/>
+                </connection>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="30" y="10"/>
+              </connectionPointOut>
+              <variable>Tank_High_Level_Sensor</variable>
+            </contact>
+            <comment localId="15" height="160" width="1170">
+              <position x="0" y="0"/>
+              <content>
+                <xhtml:p><![CDATA[OpenPLC HAL for CONTROLLINO MAXI Automation see https://www.controllino.com/wp-content/uploads/2021/03/CONTROLLINO-MAXI-Automation-Pinout.pdf
+
+Digital In:  AI2, AI3, AI4, AI5, AI6, AI7, AI8, AI9     (%IX0.0 - %IX0.7)
+             AI10, AI11, DI0, DI1, DI2, DI3, AI2, AI3   (%IX1.0 - %IX1.7)
+
+Digital Out: DO0, DO1, DO2, DO3, DO4, DO5, DO6, DO7     (%QX0.0 - %QX0.7)
+             R0, R1, R2, R3, R4, R5, R6, R7             (%QX1.0 - %QX1.7)
+             R8, R9                                     (%QX2.0 - %QX2.1)
+
+Analog In:   AI0, AI1, AI13, AI13                       (%IW0 - %IW3)
+
+Analog Out:  AO0, AO1                                   (%QW0 - %QW1)
+]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="16" height="110" width="340">
+              <position x="720" y="190"/>
+              <content>
+                <xhtml:p><![CDATA[Behaviour: The pump starts if the tank level is under de low limit in this case both level sensors into the tank will be zero, negative coil value. The second condition to start de pump is that level of the pool be over the minimum level and the switch be changed to automatic “true”.  The oter condition is that start button be pressed and the level conditions described be acomplished]]></xhtml:p>
+              </content>
+            </comment>
+            <comment localId="17" height="80" width="310">
+              <position x="720" y="360"/>
+              <content>
+                <xhtml:p><![CDATA[If pump is working and any level condition change to wrong state or stop button is pressed then pump turns off]]></xhtml:p>
+              </content>
+            </comment>
+          </LD>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances>
+    <configurations>
+      <configuration name="Config0">
+        <resource name="Res0">
+          <task name="task0" priority="0" interval="T#20ms">
+            <pouInstance name="instance0" typeName="Water_Control"/>
+          </task>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+</project>


### PR DESCRIPTION
Add two Ladder Diagram benchmarks from CONTROLLINO-PLC/OpenPLC_examples (MIT License), verified with SAFE-LD on hardware-mapped PLCopen XML programs.

CS10: water_control
- Real pump/tank automation (CONTROLLINO MAXI, created 2024-11-13)
- Hardware I/O: %IX0.0-%IX0.5 sensors/buttons, %QX0.0 pump
- 3 safety properties (cavitation, overflow, stop button)
- VERIFICATION SUCCESSFUL via k-induction (k=2, 0.03s)

CS11: stairs_light
- Real staircase lighting with PIR sensor and TOF timer (2024-11-18)
- Hardware I/O: %IX0.0-%IX0.2 sensor/buttons, %QX0.0 light
- 3 safety properties (light consistency, PIR activation, button toggle)
- VERIFICATION SUCCESSFUL via k-induction (k=2, 0.03s)

Both programs use graphical PLCopen XML (tc6_0201) with coordinate-based connections, demonstrating SAFE-LD parser compatibility with real vendor tool exports without modification.

Source: https://github.com/CONTROLLINO-PLC/OpenPLC_examples (MIT)