### PR TITLE
[irep2] Lower thrown temporary's side effects in convert_throw

### DIFF
--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03/main.cpp
@@ -1,0 +1,30 @@
+// Exercises throwing a CLASS TEMPORARY under --irep2-bodies (V.4.3, esbmc#4715).
+// `throw A(42)` builds a temporary_object side effect whose initializer is the
+// constructor call. convert_throw was only reached via the side_effect_exprt
+// path in remove_sideeffects (which lowers operands first); the --irep2-bodies
+// body round-trip turns the throw into a codet("cpp-throw") dispatched straight
+// to convert_throw, so the temporary_object operand reached the exception
+// machinery un-lowered — the constructor never ran and the handler read an
+// unconstructed object (spurious FAILED on `a.x == 42`). convert_throw now lowers
+// its operand's side effects, so the constructor runs and the assertion holds.
+struct A
+{
+  int x;
+  A(int v) : x(v)
+  {
+  }
+};
+
+int main()
+{
+  try
+  {
+    throw A(42);
+  }
+  catch (A &a)
+  {
+    __ESBMC_assert(a.x == 42, "thrown object was constructed");
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies --unwind 5 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03_fail/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03_fail/main.cpp
@@ -1,0 +1,27 @@
+// Negative variant of github_4715_irep2_bodies_cpp_exc_03: the thrown class
+// temporary is constructed with x == 42 and caught by reference, but the
+// in-handler assertion wrongly expects 7, so ESBMC must falsify it. This proves
+// the constructed value genuinely flows into the handler across the
+// --irep2-bodies body round-trip — a vacuous (unconstructed / havoced) object
+// would let `a.x == 7` hold and yield a spurious SUCCESSFUL.
+struct A
+{
+  int x;
+  A(int v) : x(v)
+  {
+  }
+};
+
+int main()
+{
+  try
+  {
+    throw A(42);
+  }
+  catch (A &a)
+  {
+    __ESBMC_assert(a.x == 7, "caught value is (wrongly) 7");
+    return 1;
+  }
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_cpp_exc_03_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies --unwind 5 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -313,8 +313,20 @@ static irep_idt destructor_entry_symbol(const codet &entry)
   return irep_idt();
 }
 
-void goto_convertt::convert_throw(const exprt &expr, goto_programt &dest)
+void goto_convertt::convert_throw(const exprt &expr_in, goto_programt &dest)
 {
+  // The thrown operand may still carry side effects — most importantly a
+  // `temporary_object` that constructs the thrown value — when convert_throw is
+  // reached through the code-statement path (a codet("cpp-throw"), as produced
+  // by the --irep2-bodies body round-trip) instead of the side_effect_exprt path
+  // in remove_sideeffects, which lowers operands before dispatching here. Lower
+  // them now so the thrown value is a plain symbol, matching the legacy flag-off
+  // GOTO; otherwise the constructor never runs and the handler reads an
+  // unconstructed object. A no-op when the operand is already side-effect-free.
+  exprt expr = expr_in;
+  Forall_operands (it, expr)
+    remove_sideeffects(*it, dest);
+
   // C++ stack unwinding: before the throw, run the destructors of the automatic
   // objects constructed since the nearest enclosing try block, in reverse
   // construction order ([except.ctor]). throw_stack_size is the destructor-stack


### PR DESCRIPTION
A `--irep2-bodies` verdict-parity sweep (esbmc#4715) surfaced 21 diverging `esbmc-cpp/try_catch` tests where the legacy flag-off path is correct and `--irep2-bodies` regresses. This fixes 19 of them; the legacy path is unaffected.

## Root cause

`throw A(42)` builds a `side_effect_exprt("temporary_object")` whose initializer is the constructor call. `goto_convertt::convert_throw` was historically only reached through the `remove_sideeffects` `cpp-throw` arm (`goto_sideeffects.cpp`), which first recurses `Forall_operands → remove_sideeffects` — lowering the temporary to `DECL tmp; ctor(&tmp); symbol` — *before* calling `convert_throw`.

The `--irep2-bodies` body round-trip turns the throw into a `codet("cpp-throw")`, dispatched straight to `convert_throw` via `convert()` (the code-statement path added when the body-form throw was first supported) **without** that pre-lowering. The raw `temporary_object` therefore reached `convert_throw`: `thrown_id` (which expects a plain symbol) came back empty and `migrate_expr` shoved the un-lowered temporary into the THROW instruction. The constructor never ran, so the handler read an unconstructed object:

- `lower-exceptions_*` (catch by reference, assert a field): `a.x` read 0 → spurious **FAILED**.
- `nec_ex*` / `ch13_1` (`--error-label ERROR`, the label sits in the ctor): the constructor’s `goto ERROR` never ran → spurious **SUCCESSFUL**.

## Fix

`convert_throw` now lowers its operand’s side effects at the top, exactly as `convert_assign` and `convert_return` already do. This is a no-op on the legacy path (`remove_sideeffects` early-returns when the operand has no side effect) and performs the missing lowering on the body-form path, producing GOTO identical to flag-off.

## Validation

- 19/21 `esbmc-cpp/try_catch` `--irep2-bodies` parity divergences fixed (all 17 CORE + 2 THOROUGH).
- All 158 flag-off `try_catch` regression tests pass; 27 `irep2_bodies` regression tests + 28 `migrate` unit tests pass.
- New tests: `regression/esbmc/github_4715_irep2_bodies_cpp_exc_03{,_fail}` — throw a class temporary, catch by reference, assert the constructed field (SUCCESSFUL; wrong-value variant FAILED, proving the value genuinely flows).

## Out of scope

Two THOROUGH tests (`nec_ex3-delegation-dtor-throw`, `nec_ex6-std-uncaught-dtor`) still diverge: their destructors call `std::uncaught_exception()` and throw a **nested** exception during stack unwinding, and the exception-object destructors run during unwinding are dropped under `--irep2-bodies`. That is a separate destructor-unwinding issue and will be handled in a follow-up.

Refs #4715.