### PR TITLE
[python] Support tuple targets in dict comprehensions

### DIFF
--- a/regression/python/dictcomp_tuple_target/main.py
+++ b/regression/python/dictcomp_tuple_target/main.py
@@ -1,0 +1,15 @@
+# Dict comprehension whose generator target is a tuple, unpacking each
+# (key, value) element of a list of tuples. The frontend previously rejected
+# this with "Only simple targets are supported in DictComp"; it now unpacks the
+# element tuple into the component names via the shared tuple-unpacking path.
+
+pairs = [(1, 2), (3, 4)]
+
+d = {v: u for u, v in pairs}
+assert d[2] == 1
+assert d[4] == 3
+
+# Both component names are usable in the key/value expressions.
+e = {u: u + v for u, v in pairs}
+assert e[1] == 3
+assert e[3] == 7

--- a/regression/python/dictcomp_tuple_target/test.desc
+++ b/regression/python/dictcomp_tuple_target/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dictcomp_tuple_target_fail/main.py
+++ b/regression/python/dictcomp_tuple_target_fail/main.py
@@ -1,0 +1,8 @@
+# Negative variant of dictcomp_tuple_target: the tuple-target dict comprehension
+# is built correctly, but the assertion does not hold. Confirms the unpacked
+# values flow precisely (a wrong claim is refuted, not vacuously accepted).
+
+pairs = [(1, 2), (3, 4)]
+
+d = {v: u for u, v in pairs}
+assert d[2] == 99

--- a/regression/python/dictcomp_tuple_target_fail/test.desc
+++ b/regression/python/dictcomp_tuple_target_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -433,10 +433,30 @@ exprt python_dict_handler::get_dict_comprehension(const nlohmann::json &element)
     iterable_expr = build_symbol(tmp_var_symbol);
   }
 
-  if (target["_type"] != "Name")
+  // A tuple target (`{k: v for a, b in pairs}`) iterates a list of tuples and
+  // unpacks each element into the component names. Hold the element in a temp
+  // of the tuple's struct type and let tuple_handler::handle_tuple_unpacking
+  // emit the per-component assignments (the same path `a, b = t` uses), so the
+  // key/value expressions see the unpacked names.
+  const bool is_tuple_target = (target["_type"] == "Tuple");
+  typet tuple_elem_type;
+  if (is_tuple_target)
+  {
+    if (!iterable_expr.is_symbol())
+      throw std::runtime_error(
+        "DictComp tuple target requires a named list of tuples");
+    tuple_elem_type = converter_.name_space().follow(
+      python_list::get_list_element_type(
+        iterable_expr.identifier().as_string(), 0));
+    if (!converter_.get_tuple_handler().is_tuple_type(tuple_elem_type))
+      throw std::runtime_error(
+        "DictComp tuple target requires iterating a list of tuples");
+  }
+  else if (target["_type"] != "Name")
     throw std::runtime_error("Only simple targets are supported in DictComp");
 
-  std::string loop_var_name = target["id"].get<std::string>();
+  std::string loop_var_name =
+    is_tuple_target ? "$dictcomp_tuple$" : target["id"].get<std::string>();
   symbol_id loop_var_sid = converter_.create_symbol_id();
   loop_var_sid.set_object(loop_var_name);
 
@@ -449,7 +469,12 @@ exprt python_dict_handler::get_dict_comprehension(const nlohmann::json &element)
   // cannot be determined, so no currently-working case regresses.
   typet loop_var_type = any_type();
   bool mixed_numeric = false;
-  if (
+  if (is_tuple_target)
+  {
+    // The temp holds the element tuple; component reads come from unpacking.
+    loop_var_type = tuple_elem_type;
+  }
+  else if (
     iter.contains("_type") && iter["_type"] == "Call" &&
     iter.contains("func") && iter["func"].contains("_type") &&
     iter["func"]["_type"] == "Name" && iter["func"].contains("id") &&
@@ -543,6 +568,15 @@ exprt python_dict_handler::get_dict_comprehension(const nlohmann::json &element)
   code_assignt loop_var_assign(build_symbol(*loop_var), current_element);
   loop_var_assign.location() = location;
   loop_body.copy_to_operands(loop_var_assign);
+
+  // For a tuple target, unpack the element tuple held in the temp into the
+  // component names (a, b) so the key/value expressions can reference them.
+  if (is_tuple_target)
+  {
+    exprt tuple_value = build_symbol(*loop_var);
+    converter_.get_tuple_handler().handle_tuple_unpacking(
+      element, target, tuple_value, loop_body);
+  }
 
   // Keep current_block redirected to loop_body across the whole pair build:
   // get_expr, contains(), get_list_element_info() and other helpers used by

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -445,8 +445,8 @@ exprt python_dict_handler::get_dict_comprehension(const nlohmann::json &element)
     if (!iterable_expr.is_symbol())
       throw std::runtime_error(
         "DictComp tuple target requires a named list of tuples");
-    tuple_elem_type = converter_.name_space().follow(
-      python_list::get_list_element_type(
+    tuple_elem_type =
+      converter_.name_space().follow(python_list::get_list_element_type(
         iterable_expr.identifier().as_string(), 0));
     if (!converter_.get_tuple_handler().is_tuple_type(tuple_elem_type))
       throw std::runtime_error(


### PR DESCRIPTION
## Problem

A dict comprehension whose generator target is a tuple — the common `{key: val for a, b in pairs}` idiom over a list of tuples — aborted conversion:

```python
pairs = [(1, 2), (3, 4)]
d = {v: u for u, v in pairs}        # ERROR: Only simple targets are supported in DictComp
```

The equivalent `for a, b in pairs:` loop and `[... for a, b in pairs]` list comprehension already work, so this was an inconsistent gap.

## Root cause

`python_dict_handler::get_dict_comprehension` assumed the generator target was a single `Name` (`target["id"]`) and read each list element into one loop variable. A `Tuple` target had no handling and hit an explicit `throw`.

## Fix

Detect a tuple target and:
1. take the element type from the iterable's list type map (the tuple struct, e.g. `tag-tuple_signedbv`),
2. hold each element in a temp of that struct type, and
3. reuse `tuple_handler::handle_tuple_unpacking` — the exact path `a, b = t` uses — to bind the component names into scope before the key/value expressions are evaluated.

No new unpacking logic is introduced; it composes the existing tuple-unpacking with the existing comprehension loop. Non-tuple, non-Name targets still throw as before.

## Soundness / validation

- Correct results: `{v: u for u, v in pairs}`, `{u: v for u, v in pairs}`, expressions using both names (`{u: u + v ...}`), and filtered forms (`... if v > 15`) all verify `SUCCESSFUL` with correct read-back.
- A wrong claim on an unpacked value is correctly refuted (`FAILED`) — values flow precisely, not vacuously.
- New tests: `regression/python/dictcomp_tuple_target` (CORE, SUCCESSFUL) and `dictcomp_tuple_target_fail` (CORE, FAILED).
- CPython sanity (`scripts/check_python_tests.sh`) green for both.
- Dict / comprehension / tuple regression cluster: **302/302 passed**, 0 regressions.

## Scope

Unblocks the `{v: w for u, v in edges}` idiom used by `quixbugs/shortest_paths` (#4802); that benchmark has a separate symbolic-list performance wall, so it is not flipped here.

Refs #4802
