### PR TITLE
[irep2] Restore side-effect location in convert_expression

### DIFF
--- a/regression/goto-coverage/github_4715_irep2_bodies_cov_01/main.c
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cov_01/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+// Assertion coverage under --irep2-bodies (esbmc#4715). The two asserts back
+// onto a side_effect_exprt("function_call") for __ESBMC_assert; sideeffect2t
+// carries no source location, so the IREP2 body round-trip used to strip the
+// ASSERT instruction's location. --assertion-coverage gates its instrumentation
+// on the source filename, so a location-less assert was silently dropped and
+// the run reported "Total Asserts: 0" / SUCCESSFUL. convert_expression now
+// restores the statement location onto the side effect, so both asserts are
+// counted and reached (FAILED, because assertion coverage negates them).
+void test()
+{
+  int x = 1;
+  for (int i = 0; i < 2; i++)
+    assert(x == 1);
+}
+
+int main()
+{
+  test();
+}

--- a/regression/goto-coverage/github_4715_irep2_bodies_cov_01/test.desc
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cov_01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--assertion-coverage --unwind 3 --no-unwinding-assertions --irep2-bodies
+^Total Asserts: 1$
+^Total Assertion Instances: 2$
+^Reached Assertion Instances: 2$
+^Assertion Instances Coverage: 100%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_4715_irep2_bodies_cov_02/main.c
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cov_02/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+// SUCCESSFUL counterpart to github_4715_irep2_bodies_cov_01: the assert lives in
+// a function that main never calls, so under --assertion-coverage no instance is
+// reachable (Reached: 0, SUCCESSFUL). It still must be COUNTED -- "Total Asserts:
+// 1" -- which only holds if the assert kept its source location across the
+// --irep2-bodies body round-trip. Before the convert_expression fix the
+// location-less assert was filtered out and the run reported "Total Asserts: 0".
+void dead()
+{
+  int x = 0;
+  assert(x == 1);
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/goto-coverage/github_4715_irep2_bodies_cov_02/test.desc
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cov_02/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--assertion-coverage --unwind 1 --no-unwinding-assertions --irep2-bodies
+^Total Asserts: 1$
+^Reached Assertion Instances: 0$
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -477,6 +477,20 @@ void goto_convertt::convert_expression(const codet &code, goto_programt &dest)
 
   exprt expr = code.op0();
 
+  // An IREP2 body round-trip (--irep2-bodies, esbmc/esbmc#4715) strips the
+  // source location from a side_effect_exprt: sideeffect2t carries no location
+  // field, unlike the enclosing code_expression statement (whose location does
+  // survive). remove_function_call copies expr.location() into the lowered call,
+  // so for the function_call side effect that backs the void builtins
+  // (__ESBMC_assert / assert, __ESBMC_assume / __VERIFIER_assume, the
+  // loop-invariant / requires / ensures contracts) this yields a location-less
+  // ASSERT/ASSUME — which in turn makes --assertion-coverage's filename-gated
+  // counter ignore it ("Total Asserts: 0", spurious SUCCESSFUL). Restore the
+  // statement location onto the side effect when the round-trip has dropped it;
+  // a no-op on the legacy path (the side effect keeps its own location there).
+  if (expr.id() == "sideeffect" && expr.location().get_file().empty())
+    expr.location() = code.location();
+
   // An IREP2 body round-trip (--irep2-bodies, esbmc/esbmc#4715) lowers a
   // nested side_effect_exprt("cpp-throw") to its code form codet("cpp-throw"):
   // migrate_expr_back has no way to know the throw sat in expression position

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -352,6 +352,30 @@ TEST_CASE(
   REQUIRE(is_sideeffect_assign2t(mc));
   REQUIRE(to_sideeffect_assign2t(mc).location.get_file() == "contract.sol");
   REQUIRE(migrate_expr_back(mc).location().get_file() == "contract.sol");
+
+  // code_assert: its location becomes the ASSERT instruction location, which
+  // gates --assertion-coverage instrumentation (filename-pooled) and the
+  // coverage assert-count -- a dropped location yields "Total Asserts: 0".
+  codet assert_code("assert");
+  assert_code.copy_to_operands(
+    symbol_exprt("x", migrate_type_back(get_bool_type())));
+  assert_code.location() = loc;
+  expr2tc ma;
+  migrate_expr(assert_code, ma);
+  REQUIRE(is_code_assert2t(ma));
+  REQUIRE(to_code_assert2t(ma).location.get_file() == "contract.sol");
+  REQUIRE(migrate_expr_back(ma).location().get_file() == "contract.sol");
+
+  // code_assume: same, lowers to an ASSUME instruction.
+  codet assume_code("assume");
+  assume_code.copy_to_operands(
+    symbol_exprt("x", migrate_type_back(get_bool_type())));
+  assume_code.location() = loc;
+  expr2tc mu;
+  migrate_expr(assume_code, mu);
+  REQUIRE(is_code_assume2t(mu));
+  REQUIRE(to_code_assume2t(mu).location.get_file() == "contract.sol");
+  REQUIRE(migrate_expr_back(mu).location().get_file() == "contract.sol");
 }
 
 TEST_CASE(


### PR DESCRIPTION
A `--irep2-bodies` verdict-parity sweep (esbmc#4715) found 10 diverging `goto-coverage` tests. This fixes the 8 assertion-coverage divergences; the legacy flag-off path is unaffected.

## Root cause

`__ESBMC_assert` / `assert` / `__ESBMC_assume` are represented in a function body as a `code(expression)` statement wrapping a `side_effect_exprt("function_call")`. Under `--irep2-bodies` the body is migrated legacy → IREP2 → legacy. The code-statement kinds carry a non-reflected `location` field that survives the round-trip, but `sideeffect2t` (a value expression) has **no** location field, so the function-call side effect loses its source location.

`remove_function_call` builds the lowered call with `call.location() = expr.location()` (now empty); the `__ESBMC_assert` handler then stamps that empty location onto the ASSERT instruction. `--assertion-coverage` gates its instrumentation on the source filename (`replace_all_asserts_to_guard`), so a location-less assert is silently skipped — the run reports `Total Asserts: 0` and a spurious `VERIFICATION SUCCESSFUL` (and the coverage-count assertions in the regression `test.desc` no longer match).

## Fix

`convert_expression` restores the surviving `code_expression` statement location onto the side effect when the round-trip has emptied it. The guard (`expr.id() == "sideeffect" && expr.location().get_file().empty()`) is false on the legacy path — the frontend wraps the side effect with the same location it already carries — so it is a no-op off-flag, and it can never substitute a *different* location (the statement and its side-effect operand share the same source location by construction).

## Validation

- 8/10 `goto-coverage` `--irep2-bodies` parity divergences fixed (all assertion-coverage, plus one simple condition-coverage test).
- 116 flag-off `goto-coverage` tests + 58 `esbmc`-core tests pass (the only non-pass, `branch_cov_9`, is a pre-existing THOROUGH test that runs ~126s against a 120s cap, producing correct output — unrelated).
- `migrate` unit test extended to pin `code_assert` / `code_assume` source-location survival across the round-trip.
- New regression tests: `regression/goto-coverage/github_4715_irep2_bodies_cov_01` (assert counted + reached → FAILED) and `..._cov_02` (assert counted but unreachable → SUCCESSFUL — guards against the dropped-location `Total Asserts: 0` masquerading as a false SUCCESSFUL).

## Out of scope

Two `goto-coverage` tests still diverge and are left for a follow-up: `github_1999_7` and `stl_set_cond_cov`. Both use **condition** coverage with short-circuit handling; `stl_set_cond_cov` additionally trips a known `--condition-coverage` + `--irep2-bodies` crash (a residual side effect reaching the SMT backend). Distinct from the assertion-coverage location drop fixed here.

Refs #4715.