### PR TITLE
[python] Fix explicit base-class __init__ calls (Base.__init__(self, ...))

### DIFF
--- a/regression/python/explicit_base_init/main.py
+++ b/regression/python/explicit_base_init/main.py
@@ -1,0 +1,25 @@
+# A subclass calling its base class's __init__ explicitly via the class name
+# (`Base.__init__(self, ...)`), the pre-super() idiom. This previously aborted
+# with "_init_undefined": the call was classified as object construction, so a
+# throwaway self object was allocated and the base initialiser wrote to it
+# instead of the real instance. It is now treated as a direct invocation of the
+# base constructor with self passed explicitly.
+
+class Base:
+    def __init__(self, name):
+        self.name = name
+
+    def greet(self):
+        return self.name
+
+
+class Child(Base):
+    def __init__(self, name, age):
+        Base.__init__(self, name)
+        self.age = age
+
+
+c = Child("bot", 3)
+assert c.name == "bot"
+assert c.age == 3
+assert c.greet() == "bot"

--- a/regression/python/explicit_base_init/test.desc
+++ b/regression/python/explicit_base_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/explicit_base_init_fail/main.py
+++ b/regression/python/explicit_base_init_fail/main.py
@@ -1,0 +1,17 @@
+# Negative variant of explicit_base_init: the base initialiser runs via the
+# explicit `Base.__init__(self, ...)` call, but the assertion does not hold.
+# Confirms the base initialiser writes to the real instance (so the value is
+# decided), not vacuously accepted.
+
+class Base:
+    def __init__(self, name):
+        self.name = name
+
+
+class Child(Base):
+    def __init__(self, name):
+        Base.__init__(self, name)
+
+
+c = Child("bot")
+assert c.name == "WRONG"

--- a/regression/python/explicit_base_init_fail/test.desc
+++ b/regression/python/explicit_base_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -618,7 +618,19 @@ symbol_id function_call_builder::build_function_id() const
   }
   else if (th.is_constructor_call(call_))
   {
-    class_name = func_name;
+    // An explicit `Base.__init__(self, ...)` call names the receiver class and
+    // passes self explicitly. is_constructor_call() flags any `.__init__`, but
+    // here the constructor is the named class's own, stored under the class
+    // name (@C@Base@F@Base), not the literal "__init__". Resolve both the class
+    // and the (renamed) function to the receiver so the symbol is found; a
+    // direct `Base()` call keeps func_name as the class name already.
+    if (func_name == "__init__" && json_utils::is_class(obj_name, ast))
+    {
+      class_name = obj_name;
+      func_name = obj_name;
+    }
+    else
+      class_name = func_name;
   }
   else if (is_member_function_call)
   {

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -195,13 +195,31 @@ static std::string get_classname_from_symbol_id(const std::string &symbol_id)
 
 void function_call_expr::get_function_type()
 {
-  if (type_handler_.is_constructor_call(call_))
+  const auto &func_node = call_["func"];
+
+  // An explicit `Base.__init__(self, ...)` call invokes the named base class's
+  // constructor with self passed explicitly; it is not an object construction.
+  // Let it fall through to the ClassMethod classification (is_class(caller)
+  // below) so no fresh self object is allocated -- the builder resolves it to
+  // the class's renamed constructor (@C@Base@F@Base) and the explicit self is
+  // the receiver. Without this it would be classified Constructor and the
+  // constructor would write to a throwaway $ctor_self$ temp.
+  const bool is_explicit_class_init =
+    func_node.contains("_type") && func_node["_type"] == "Attribute" &&
+    func_node.contains("attr") && func_node["attr"] == "__init__" &&
+    func_node.contains("value") && func_node["value"].is_object() &&
+    func_node["value"].contains("_type") &&
+    func_node["value"]["_type"] == "Name" &&
+    func_node["value"].contains("id") &&
+    json_utils::is_class(
+      func_node["value"]["id"].get<std::string>(), converter_.ast());
+
+  if (!is_explicit_class_init && type_handler_.is_constructor_call(call_))
   {
     function_type_ = FunctionType::Constructor;
     return;
   }
 
-  const auto &func_node = call_["func"];
   if (
     !func_node.contains("_type") || !func_node["_type"].is_string() ||
     func_node["_type"] != "Attribute")


### PR DESCRIPTION
## Problem

A subclass calling its base class's `__init__` explicitly via the class name — the common pre-`super()` idiom — aborted conversion:

```python
class Base:
    def __init__(self, name):
        self.name = name

class Child(Base):
    def __init__(self, name, age):
        Base.__init__(self, name)     # ERROR: _init_undefined
        self.age = age
```

`super().__init__(...)` worked, but the explicit `Base.__init__(self, ...)` form did not.

## Root cause

`is_constructor_call()` flags *any* `.__init__` call, so `Base.__init__(self)` was classified as object construction. Two things then went wrong:

1. **Symbol id.** `build_function_id` set `class_name = func_name`, i.e. the literal `"__init__"`, producing `@C@__init__@F@__init__`. The lookup failed and the base-class search could not recover it → `_init_undefined`.
2. **Self wiring.** As a constructor, a throwaway `$ctor_self$` object was allocated as the receiver (`Base(&$ctor_self$, self)`), so the base initialiser wrote to the temp rather than the real instance — the explicit `self` was passed as a *second* argument.

## Fix

Treat an explicit `ClassName.__init__(self, ...)` (an `Attribute` call whose receiver `Name` is a class) as a **ClassMethod** invocation, not a constructor:

- `get_function_type` skips the constructor classification for this shape and falls through to the existing `is_class(caller)` → ClassMethod path, so **no fresh self is allocated** and the explicit `self` is the receiver.
- `build_function_id` resolves the class and the renamed function to the receiver class, so the symbol is the base's own constructor `@C@Base@F@Base`.

`super().__init__()` and direct `Base()` construction are untouched.

## Soundness / validation

- Base initialiser writes reach the **real instance**: `c.name`, inherited methods (`c.greet()`), own subclass fields, multi-level explicit-init chains (`A.__init__` ← `B.__init__` ← `C`), and constructor arguments all verify `SUCCESSFUL`.
- A wrong claim on a base-initialised field is correctly refuted (`FAILED`) — the value is decided, not vacuous.
- New tests: `regression/python/explicit_base_init` (CORE, SUCCESSFUL) and `explicit_base_init_fail` (CORE, FAILED). CPython sanity green.
- Class / init / inheritance / method regression cluster: **248/248 passed**, 0 regressions; `super().__init__` and direct construction confirmed unaffected.

## Scope

Unblocks the `ROSComponent.__init__(self, 'motor_controller')` pattern used by `regression/python/rover` (#4775); rover has further unrelated blockers and is not flipped here.

Refs #4775
