### PR TITLE
[python] Model a class used as a first-class value; flip rover to CORE

### DIFF
--- a/regression/python/class_as_value/main.py
+++ b/regression/python/class_as_value/main.py
@@ -1,0 +1,30 @@
+# A class name used as a first-class value: passed as a bare argument (the class
+# object itself, not an instance). Python classes are objects, so `register(A)`
+# forwards the class. The frontend previously aborted with "Variable 'A' is not
+# defined" because a class Name was neither a variable nor a function. It is now
+# modelled as an opaque placeholder for inert uses, so constructing instances
+# normally still works.
+
+class A:
+    def __init__(self):
+        self.x = 7
+
+
+class B:
+    def __init__(self):
+        self.y = 9
+
+
+def register(cls):
+    # The class object is stored/forwarded but not constructed here.
+    return 0
+
+
+register(A)
+register(B)
+
+# Real construction through the class name is unaffected.
+a = A()
+b = B()
+assert a.x == 7
+assert b.y == 9

--- a/regression/python/class_as_value/test.desc
+++ b/regression/python/class_as_value/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/class_as_value_fail/main.py
+++ b/regression/python/class_as_value_fail/main.py
@@ -1,0 +1,18 @@
+# Negative variant of class_as_value: passing the class object as a bare
+# argument converts, but the assertion on a real instance does not hold.
+# Confirms modelling the class-as-value as a placeholder does not vacuously
+# accept claims about instances built from the same class.
+
+class A:
+    def __init__(self):
+        self.x = 7
+
+
+def register(cls):
+    return 0
+
+
+register(A)
+
+a = A()
+assert a.x == 99

--- a/regression/python/class_as_value_fail/test.desc
+++ b/regression/python/class_as_value_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/explicit_base_init/main.py
+++ b/regression/python/explicit_base_init/main.py
@@ -1,0 +1,25 @@
+# A subclass calling its base class's __init__ explicitly via the class name
+# (`Base.__init__(self, ...)`), the pre-super() idiom. This previously aborted
+# with "_init_undefined": the call was classified as object construction, so a
+# throwaway self object was allocated and the base initialiser wrote to it
+# instead of the real instance. It is now treated as a direct invocation of the
+# base constructor with self passed explicitly.
+
+class Base:
+    def __init__(self, name):
+        self.name = name
+
+    def greet(self):
+        return self.name
+
+
+class Child(Base):
+    def __init__(self, name, age):
+        Base.__init__(self, name)
+        self.age = age
+
+
+c = Child("bot", 3)
+assert c.name == "bot"
+assert c.age == 3
+assert c.greet() == "bot"

--- a/regression/python/explicit_base_init/test.desc
+++ b/regression/python/explicit_base_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/explicit_base_init_fail/main.py
+++ b/regression/python/explicit_base_init_fail/main.py
@@ -1,0 +1,17 @@
+# Negative variant of explicit_base_init: the base initialiser runs via the
+# explicit `Base.__init__(self, ...)` call, but the assertion does not hold.
+# Confirms the base initialiser writes to the real instance (so the value is
+# decided), not vacuously accepted.
+
+class Base:
+    def __init__(self, name):
+        self.name = name
+
+
+class Child(Base):
+    def __init__(self, name):
+        Base.__init__(self, name)
+
+
+c = Child("bot")
+assert c.name == "WRONG"

--- a/regression/python/explicit_base_init_fail/test.desc
+++ b/regression/python/explicit_base_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/rover/test.desc
+++ b/regression/python/rover/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -808,6 +808,20 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             expr = symbol_expr(*func_symbol);
             break;
           }
+
+          // A bare class name used as a value, e.g. `register(SomeClass)` or
+          // `create_publisher(topic, Twist)` -- passing the class object itself
+          // as an argument. Python classes are first-class objects, but ESBMC
+          // has no first-class type value, so model it as an opaque nondet
+          // placeholder. Inert uses (storing or forwarding the class) then
+          // convert instead of aborting; constructing through such a forwarded
+          // value is not modelled.
+          if (is_class(var_name, *ast_json))
+          {
+            expr = side_effect_expr_nondett(any_type());
+            expr.location() = get_location_from_decl(element);
+            break;
+          }
         }
         locationt location = get_location_from_decl(element);
         std::ostringstream error_msg;

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -618,7 +618,19 @@ symbol_id function_call_builder::build_function_id() const
   }
   else if (th.is_constructor_call(call_))
   {
-    class_name = func_name;
+    // An explicit `Base.__init__(self, ...)` call names the receiver class and
+    // passes self explicitly. is_constructor_call() flags any `.__init__`, but
+    // here the constructor is the named class's own, stored under the class
+    // name (@C@Base@F@Base), not the literal "__init__". Resolve both the class
+    // and the (renamed) function to the receiver so the symbol is found; a
+    // direct `Base()` call keeps func_name as the class name already.
+    if (func_name == "__init__" && json_utils::is_class(obj_name, ast))
+    {
+      class_name = obj_name;
+      func_name = obj_name;
+    }
+    else
+      class_name = func_name;
   }
   else if (is_member_function_call)
   {

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -195,13 +195,31 @@ static std::string get_classname_from_symbol_id(const std::string &symbol_id)
 
 void function_call_expr::get_function_type()
 {
-  if (type_handler_.is_constructor_call(call_))
+  const auto &func_node = call_["func"];
+
+  // An explicit `Base.__init__(self, ...)` call invokes the named base class's
+  // constructor with self passed explicitly; it is not an object construction.
+  // Let it fall through to the ClassMethod classification (is_class(caller)
+  // below) so no fresh self object is allocated -- the builder resolves it to
+  // the class's renamed constructor (@C@Base@F@Base) and the explicit self is
+  // the receiver. Without this it would be classified Constructor and the
+  // constructor would write to a throwaway $ctor_self$ temp.
+  const bool is_explicit_class_init =
+    func_node.contains("_type") && func_node["_type"] == "Attribute" &&
+    func_node.contains("attr") && func_node["attr"] == "__init__" &&
+    func_node.contains("value") && func_node["value"].is_object() &&
+    func_node["value"].contains("_type") &&
+    func_node["value"]["_type"] == "Name" &&
+    func_node["value"].contains("id") &&
+    json_utils::is_class(
+      func_node["value"]["id"].get<std::string>(), converter_.ast());
+
+  if (!is_explicit_class_init && type_handler_.is_constructor_call(call_))
   {
     function_type_ = FunctionType::Constructor;
     return;
   }
 
-  const auto &func_node = call_["func"];
   if (
     !func_node.contains("_type") || !func_node["_type"].is_string() ||
     func_node["_type"] != "Attribute")


### PR DESCRIPTION
> **Stacked on #5328** (explicit base-class `__init__` calls). Both fixes are needed to flip `rover`; this PR's base is the #5328 branch. Retarget to `master` once #5328 merges.

## Problem

Passing a class object as a bare value aborted conversion:

```python
def register(cls):       # the class is stored/forwarded, not constructed
    return 0
register(SomeClass)      # ERROR: Variable 'SomeClass' is not defined
```

This is rover's blocker too: `self.create_publisher('/cmd_vel', Twist)` passes the `Twist` class as an argument.

## Root cause

The Name resolver (`converter_expr.cpp`) tried, in order: a variable symbol, a global, a nested function, a module-level function — then errored. A bare **class name used as a value** matched none of these, so any such reference (local or imported) failed.

## Fix

Python classes are first-class objects, but ESBMC has no first-class type value. Model a bare class-name value as an **opaque nondet placeholder**, added only on the path that previously errored. Inert uses — storing or forwarding the class object — now convert; real construction through the class name (`SomeClass()`) is unchanged because that goes through the constructor path, not this one.

## Soundness / validation

- A wrong claim about an instance built from the same class still **FAILS** — the placeholder does not vacuously accept anything; `SomeClass()` construction is independent of the placeholder.
- The change is additive on a previously-erroring branch, so no passing program reaches it.
- New tests: `regression/python/class_as_value` (CORE, SUCCESSFUL) and `class_as_value_fail` (CORE, FAILED). CPython sanity green.
- Class / import / name / attr / method / init regression cluster: **381/381 passed**; full `python` label backstop running.

## rover → CORE

Combined with the explicit base-`__init__` fix (#5328), `regression/python/rover` — a ROS/F-Prime-style simulation using typed `Dict[str, T]` attributes, cross-module stub imports, inheritance with explicit base init, and a class passed as an argument — now verifies `SUCCESSFUL` and is flipped **KNOWNBUG → CORE**.

Fixes #4775
