### PR TITLE
[irep2] Preserve sizeof(T) type on constants under --irep2-bodies

### DIFF
--- a/regression/esbmc/github_4715_irep2_bodies_malloc_01/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_malloc_01/main.c
@@ -1,0 +1,30 @@
+// esbmc/esbmc#4715 (V.4.4 parity): under --irep2-bodies the body round-trip
+// dropped the folded sizeof(T) element type (#c_sizeof_type) from the malloc
+// size constant, so malloc(sizeof(pair)) allocated a `char` blob instead of a
+// `pair`. The subsequent struct copy `q = *p` then lost the field layout and
+// the value assertions failed spuriously. constant_int2t now carries the
+// sizeof type across the round-trip, so the allocated object is typed `pair`.
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct
+{
+  int id;
+  void *value;
+} pair;
+
+int main()
+{
+  pair *p = (pair *)malloc(sizeof(pair));
+  if (!p)
+    return 0;
+  p->id = 10;
+  p->value = (void *)20;
+
+  pair q = *p; // struct copy through the malloc'd object
+  assert(q.id == 10);
+  assert(q.value == (void *)20);
+
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_malloc_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_malloc_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_bodies_malloc_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_malloc_01_fail/main.c
@@ -1,0 +1,29 @@
+// esbmc/esbmc#4715 (V.4.4 parity): negative variant of malloc_01. With the
+// allocated object correctly typed `pair` across the --irep2-bodies round-trip,
+// the struct copy preserves the fields, so the wrong-value assertion below is a
+// genuine violation (q.value is 20, not 21). This guards against the positive
+// test passing vacuously (e.g. if the assert were silently dropped).
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct
+{
+  int id;
+  void *value;
+} pair;
+
+int main()
+{
+  pair *p = (pair *)malloc(sizeof(pair));
+  if (!p)
+    return 0;
+  p->id = 10;
+  p->value = (void *)20;
+
+  pair q = *p; // struct copy through the malloc'd object
+  assert(q.id == 10);
+  assert(q.value == (void *)21); // wrong: q.value == 20
+
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_malloc_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_malloc_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --irep2-bodies
+^VERIFICATION FAILED$

--- a/scripts/irep2-migration/parity_sweep.sh
+++ b/scripts/irep2-migration/parity_sweep.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# V.4.4 verdict-parity sweep: for each regression test, compare the verdict
+# produced with the test's own flags (legacy, --irep2-bodies OFF) against the
+# verdict with --irep2-bodies added. Any divergence or flag-on crash is a
+# V.4.4 parity blocker. Deterministic verdict comparison per Part V §V.5.
+#
+# Usage: parity_sweep.sh <esbmc-binary> <regression-subdir> [max-tests]
+set -u
+
+# Resolve the binary to an absolute path: the sweep cd's into each test dir
+# before invoking it, so a relative path would silently fail there (esbmc never
+# runs, both sides score OTHER, and the test is falsely reported as parity-OK).
+ESBMC="$(command -v "$1" || realpath "$1")"
+if [ ! -x "$ESBMC" ]; then
+  echo "error: esbmc binary not found or not executable: $1" >&2
+  exit 2
+fi
+DIR="$2"
+MAX="${3:-100000}"
+TIMEOUT="${PARITY_TIMEOUT:-30}"
+
+verdict() {
+  # Extract a normalized verdict / crash signal from esbmc output.
+  if grep -q "VERIFICATION SUCCESSFUL" <<<"$1"; then echo "SUCCESSFUL"
+  elif grep -q "VERIFICATION FAILED" <<<"$1"; then echo "FAILED"
+  elif grep -q "VERIFICATION UNKNOWN" <<<"$1"; then echo "UNKNOWN"
+  elif grep -qi "Segmentation fault\|Assertion .* failed\|terminate called\|what():\|Aborted\|signal SIG\|UNREACHABLE\|terminate\b" <<<"$1"; then echo "CRASH"
+  else echo "OTHER"
+  fi
+}
+
+n=0; diverged=0
+while IFS= read -r desc; do
+  [ "$n" -ge "$MAX" ] && break
+  tdir=$(dirname "$desc")
+  # line 1 = CORE/KNOWNBUG/..., line 2 = source, line 3 = flags
+  kind=$(sed -n '1p' "$desc")
+  src=$(sed -n '2p' "$desc")
+  flags=$(sed -n '3p' "$desc")
+  [ "$kind" = "KNOWNBUG" ] && continue
+  [ -z "$src" ] && continue
+  case "$flags" in *--irep2-bodies*) continue;; esac   # skip tests already pinning the flag
+  n=$((n+1))
+  out_off=$(cd "$tdir" && timeout "$TIMEOUT" "$ESBMC" $src $flags 2>&1)
+  rc_off=$?
+  out_on=$(cd "$tdir" && timeout "$TIMEOUT" "$ESBMC" $src $flags --irep2-bodies 2>&1)
+  rc_on=$?
+  v_off=$(verdict "$out_off"); v_on=$(verdict "$out_on")
+  # ignore timeouts (rc 124) on either side — not a parity signal
+  if [ "$rc_off" = 124 ] || [ "$rc_on" = 124 ]; then continue; fi
+  if [ "$v_off" != "$v_on" ]; then
+    diverged=$((diverged+1))
+    echo "DIVERGE  off=$v_off  on=$v_on  rc_on=$rc_on  $tdir"
+  fi
+done < <(find "$DIR" -name test.desc | { [ "${PARITY_SHUF:-0}" = 1 ] && shuf || sort; })
+echo "--- swept $n tests in $DIR; $diverged divergence(s) ---"

--- a/scripts/irep2-migration/parity_sweep.sh
+++ b/scripts/irep2-migration/parity_sweep.sh
@@ -41,9 +41,14 @@ while IFS= read -r desc; do
   [ -z "$src" ] && continue
   case "$flags" in *--irep2-bodies*) continue;; esac   # skip tests already pinning the flag
   n=$((n+1))
-  out_off=$(cd "$tdir" && timeout "$TIMEOUT" "$ESBMC" $src $flags 2>&1)
+  # Split source and flags into words deliberately: $flags is a flag list that
+  # must reach esbmc as separate arguments. Arrays keep that splitting explicit
+  # (and shellcheck-clean) instead of relying on unquoted expansion.
+  read -ra src_arr <<<"$src"
+  read -ra flag_arr <<<"$flags"
+  out_off=$(cd "$tdir" && timeout "$TIMEOUT" "$ESBMC" "${src_arr[@]}" "${flag_arr[@]}" 2>&1)
   rc_off=$?
-  out_on=$(cd "$tdir" && timeout "$TIMEOUT" "$ESBMC" $src $flags --irep2-bodies 2>&1)
+  out_on=$(cd "$tdir" && timeout "$TIMEOUT" "$ESBMC" "${src_arr[@]}" "${flag_arr[@]}" --irep2-bodies 2>&1)
   rc_on=$?
   v_off=$(verdict "$out_off"); v_on=$(verdict "$out_on")
   # ignore timeouts (rc 124) on either side — not a parity signal
@@ -52,5 +57,6 @@ while IFS= read -r desc; do
     diverged=$((diverged+1))
     echo "DIVERGE  off=$v_off  on=$v_on  rc_on=$rc_on  $tdir"
   fi
-done < <(find "$DIR" -name test.desc | { [ "${PARITY_SHUF:-0}" = 1 ] && shuf || sort; })
+done < <(find "$DIR" -name test.desc |
+  { if [ "${PARITY_SHUF:-0}" = 1 ]; then shuf; else sort; fi; })
 echo "--- swept $n tests in $DIR; $diverged divergence(s) ---"

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -280,12 +280,27 @@ class constant_int2t : public expr2t
 public:
   BigInt value;
 
+  /** Element type T of a folded `sizeof(T)` operand (the C `#c_sizeof_type`
+   *  attribute); nil for an ordinary integer constant. Not reflected: it rides
+   *  with the constant so the malloc/alloca allocated type survives the
+   *  --irep2-bodies body round-trip (esbmc/esbmc#4715) — clang folds
+   *  `malloc(sizeof(T))` to a bare size_t constant whose only record of T is
+   *  this attribute, and `get_alloc_type` reads it back to type the dynamic
+   *  object. Excluded from cmp/crc/hash (kept out of `fields`) so plain integer
+   *  constants stay identical and constant sharing is unaffected. */
+  type2tc sizeof_type;
+  static constexpr std::size_t excluded_field_bytes = sizeof(type2tc);
+
   /** Primary constructor.
    *  @param type Type of this integer.
    *  @param input BigInt object containing the integer we're dealing with
+   *  @param sizeof_t Element type of a folded sizeof(T) operand; nil otherwise
    */
-  constant_int2t(const type2tc &type, const BigInt &input)
-    : expr2t(type, constant_int_id), value(input)
+  constant_int2t(
+    const type2tc &type,
+    const BigInt &input,
+    const type2tc &sizeof_t = type2tc())
+    : expr2t(type, constant_int_id), value(input), sizeof_type(sizeof_t)
   {
   }
   constant_int2t(const constant_int2t &ref) = default;

--- a/src/util/c_typecast.cpp
+++ b/src/util/c_typecast.cpp
@@ -919,8 +919,9 @@ void c_typecastt::do_typecast(exprt &dest, const typet &type)
         // CBMC simplify_typecast is retired in Phase 2.2). dest is
         // typecast(const, type); typecast2t::do_simplify applies the cast
         // (int->int with truncation, int->bool, enum casts) identically to the
-        // legacy path. #c_sizeof_type, which migrate does not carry into IREP2,
-        // is restored just below.
+        // legacy path. The fold builds a fresh constant, which drops
+        // #c_sizeof_type (migrate now preserves it on a constant round-trip, but
+        // the simplifier does not), so it is restored just below.
         expr2tc d2;
         migrate_expr(dest, d2);
         simplify(d2);

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -744,7 +744,17 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
     BigInt val = binary2bigint(expr.value(), is_signed);
 
-    new_expr_ref = constant_int2tc(type, val);
+    // Preserve the `#c_sizeof_type` of a folded sizeof(T) constant (clang stores
+    // the element type T here, e.g. for malloc(sizeof(T))). constant_int2t has
+    // no irept named-subs, so without this the type is lost on the
+    // --irep2-bodies round-trip and the allocated object degrades to char
+    // (esbmc/esbmc#4715).
+    type2tc sizeof_type;
+    const irept &szt = expr.c_sizeof_type();
+    if (szt.is_not_nil())
+      sizeof_type = migrate_type(static_cast<const typet &>(szt));
+
+    new_expr_ref = constant_int2tc(type, val, sizeof_type);
     return;
   }
 
@@ -2862,6 +2872,10 @@ exprt migrate_expr_back(const expr2tc &ref)
     constant_exprt theexpr(thetype);
     unsigned int width = atoi(thetype.width().as_string().c_str());
     theexpr.set_value(integer2binary(ref2.value, width));
+    // Restore the folded sizeof(T) element type so malloc/alloca lowering can
+    // recover the allocated object's type (esbmc/esbmc#4715).
+    if (!is_nil_type(ref2.sizeof_type))
+      theexpr.c_sizeof_type(migrate_type_back(ref2.sizeof_type));
     return theexpr;
   }
   case expr2t::constant_fixedbv_id:

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -355,6 +355,35 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "migrate preserves #c_sizeof_type on folded sizeof constants",
+  "[migrate][v4-cf]")
+{
+  // esbmc#4715: clang folds malloc(sizeof(T)) to a bare size_t constant whose
+  // only record of the element type T is the #c_sizeof_type attribute.
+  // constant_int2t carries a non-reflected sizeof_type so T survives the
+  // --irep2-bodies body round-trip; without it get_alloc_type falls back to
+  // char and the allocated object degrades to a byte blob. Equality ignores
+  // sizeof_type, so assert on it explicitly rather than via the round-trip
+  // helper.
+  use_test_ns();
+
+  exprt sz = from_integer(8, size_type());
+  sz.c_sizeof_type(symbol_typet("tag-s"));
+  expr2tc m;
+  migrate_expr(sz, m);
+  REQUIRE(is_constant_int2t(m));
+  REQUIRE(!is_nil_type(to_constant_int2t(m).sizeof_type));
+  exprt back = migrate_expr_back(m);
+  REQUIRE(back.c_sizeof_type().is_not_nil());
+  REQUIRE(back.c_sizeof_type().id() == "symbol");
+
+  // A plain integer constant carries no sizeof type and must not gain one.
+  expr2tc plain = constant_int2tc(get_uint_type(32), BigInt(8));
+  REQUIRE(is_nil_type(to_constant_int2t(plain).sizeof_type));
+  REQUIRE(migrate_expr_back(plain).c_sizeof_type().is_nil());
+}
+
+TEST_CASE(
   "migrate expr round-trips for pointer_capability",
   "[migrate][b2-vtrack]")
 {


### PR DESCRIPTION
## Problem

Under `--irep2-bodies`, `malloc(sizeof(T))` allocated a `char` blob instead of a `struct T`. clang folds `sizeof(T)` to a bare `size_t` constant whose only record of the element type `T` is the `#c_sizeof_type` attribute. `migrate_expr` dropped that attribute on the IREP2 body round-trip, so `get_alloc_type` fell back to `char_type()` and the dynamic object degraded from `struct T` to `char[N]`.

The subsequent struct copy through the mistyped object then either read the wrong fields or tripped a spurious array-bounds violation — a false `VERIFICATION FAILED` that only appears with the flag on. GOTO proof (`--goto-functions-only | grep MALLOC`):

```
OFF: MALLOC(struct pthread_id_value { int id; ... void *value; }, 16)
ON:  MALLOC(signed char, 16)        # before this PR
```

This is a V.4.4 verdict-parity blocker (the misc-C cluster of esbmc/esbmc#4715).

## Fix

`constant_int2t` now carries a non-reflected `type2tc sizeof_type` field (with `excluded_field_bytes`), mirroring the V.4.1/V.4.5 non-reflected `location` pattern. The `fields` tuple is unchanged, so the field is excluded from `cmp`/`crc`/`hash` — plain integer constants stay byte-identical and constant sharing is unaffected. The migrate forward arm reads `#c_sizeof_type` into it; the back arm restores the attribute. A stale comment in `c_typecast.cpp` (whose manual save/restore is still load-bearing for the simplifier path) is clarified.

Off-flag this is a no-op: `migrate_expr` is only on the body path under `--irep2-bodies`, and the new field defaults to nil.

## Result

Fixes 3 misc-C parity divergences (`SUCCESSFUL`→`FAILED` under the flag):
- `regression/esbmc/fam_true_3` — flexible-array-member bounds relaxation lost
- `regression/esbmc-unix2/github_154_success` — struct field layout lost in the byte-array model
- `regression/esbmc/github_4634` — malloc'd-object reachability for the memory-leak walker

## Validation

- migrate unit tests 30/30 (new `sizeof_type`-survival case added)
- `irep2_bodies` regression family 31/31 (C/C++/Solidity/Jimple/Python/coverage)
- cbmc + floats + cstd flag-off 597/597 (no regression from the core irep2 node change)
- `code-reviewer`: 0 critical, 0 major
- New regression tests `github_4715_irep2_bodies_malloc_01{,_fail}` (positive + a negative that guards against vacuous passing)

Independent of #5323 (cluster 1, exceptions) and #5325 (cluster 2, coverage). Refs #4715.