### PR TITLE
[python] Support while-else (lower the else via a did-not-break flag)

### DIFF
--- a/regression/python/while_else/main.py
+++ b/regression/python/while_else/main.py
@@ -1,0 +1,26 @@
+# Python while-else: the else clause runs when the loop condition becomes false
+# (the loop ends without hitting break), and is skipped when the loop exits via
+# break. This previously aborted conversion with "while takes two operands"
+# because the else block was emitted as an invalid third operand of the GOTO
+# while. It is now lowered with a did-not-break flag, the same desugaring used
+# for for-else.
+
+# No break: the else clause runs.
+i = 0
+while i < 3:
+    i += 1
+else:
+    i = 100
+assert i == 100
+
+# break taken: the else clause is skipped.
+found = -1
+j = 0
+while j < 5:
+    if j == 2:
+        found = j
+        break
+    j += 1
+else:
+    found = 100
+assert found == 2

--- a/regression/python/while_else/test.desc
+++ b/regression/python/while_else/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/while_else_fail/main.py
+++ b/regression/python/while_else_fail/main.py
@@ -1,0 +1,13 @@
+# Negative variant of while_else: the loop exits via break, so the else clause
+# must be skipped. Asserting that the else ran must FAIL -- confirms the
+# did-not-break flag correctly suppresses the else after a break (not vacuously
+# accepted).
+
+x = 0
+while True:
+    x = 5
+    break
+else:
+    x = 99
+
+assert x == 99

--- a/regression/python/while_else_fail/test.desc
+++ b/regression/python/while_else_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/expression_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/expression_rewrite_mixin.py
@@ -338,12 +338,20 @@ class ExpressionRewriteMixin:
 
     def visit_While(self, node):
         node = self.generic_visit(node)
+        # Lower `while ... else: <orelse>` (the else runs when the loop ends
+        # without break) into a did-not-break flag, the same desugaring used for
+        # for-else. Without this the while node keeps its orelse, which the
+        # converter emits as an invalid third operand of the GOTO `while`
+        # ("while takes two operands"). _lower_for_else is a no-op when there is
+        # no orelse and clears node.orelse otherwise.
+        while_else_pre, while_else_post = self._lower_for_else(node)
         prefix, new_test, _ = self._lower_listcomp_in_expr(node.test)
         node.test = new_test
         node.test = self._transform_list_truthiness(node.test, node)
-        if prefix:
-            return prefix + [node]
-        return node
+        result = (prefix or []) + [node]
+        if while_else_pre or while_else_post:
+            return while_else_pre + result + while_else_post
+        return result if prefix else node
 
     def _simplify_isinstance(self, node):
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)


### PR DESCRIPTION
## Problem

A `while ... else:` loop aborted conversion:

```python
i = 0
while i < 3:
    i += 1
else:               # ERROR: while takes two operands
    i = 100
```

`for ... else:` worked, but `while ... else:` did not.

## Root cause

The preprocessor lowers **for-else** (the `else` runs when the loop ends without `break`) via `_lower_for_else`, but `visit_While` did not lower **while-else**. The while node kept its `orelse`, which the converter emitted as an invalid *third* operand of the GOTO `while` (goto_convert allows exactly two: condition and body).

## Fix

Lower while-else in `visit_While` by reusing the existing, loop-agnostic `_lower_for_else` helper. It:
1. initialises a did-not-break flag to `True`,
2. rewrites every reachable `break` in the loop body to clear the flag first (not descending into nested loops, whose breaks bind to the inner loop), and
3. guards the `else` block with `if flag:` after the loop.

Plain `while` loops are unaffected — the helper is a no-op when `orelse` is empty.

## Semantics / soundness

- `else` runs on normal completion; **skipped after `break`**; a `break` in a nested loop binds to the inner loop's `else` (verified).
- Wrong claims still **FAIL** (e.g. asserting the `else` ran after a `break`).
- New tests: `regression/python/while_else` (CORE, SUCCESSFUL) and `while_else_fail` (CORE, FAILED). CPython sanity green.
- Loop / while / break / range regression cluster: **136/136 passed**; full `python` label backstop running.
