### PR TITLE
[python] Infer complex for <real> + <imaginary> binary expressions

### DIFF
--- a/regression/python/complex_binop_infer/main.py
+++ b/regression/python/complex_binop_infer/main.py
@@ -1,0 +1,19 @@
+# An unannotated complex value formed by `<real> + <imaginary>j`. The type
+# inference for a binary expression was driven by the left operand only, so
+# `3 + 4j` was typed int (from the `3`) and `.real`/`.imag` access then raised
+# AttributeError. `4j + 3` happened to work because the complex operand was on
+# the left. Python's numeric tower promotes to complex when either operand is
+# complex; the inference now reflects that.
+
+z = 3 + 4j
+assert z.real == 3.0
+assert z.imag == 4.0
+
+# Complex on the left still works, and arithmetic stays complex.
+w = 4j + 3
+assert w.real == 3.0
+
+p = 5 + 2j
+q = p * 2
+assert q.real == 10.0
+assert q.imag == 4.0

--- a/regression/python/complex_binop_infer/test.desc
+++ b/regression/python/complex_binop_infer/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/complex_binop_infer_fail/main.py
+++ b/regression/python/complex_binop_infer_fail/main.py
@@ -1,0 +1,6 @@
+# Negative variant of complex_binop_infer: `3 + 4j` is correctly typed complex,
+# but the assertion on its real part does not hold. Confirms the inferred
+# complex value flows precisely (a wrong claim is refuted, not vacuous).
+
+z = 3 + 4j
+assert z.real == 99.0

--- a/regression/python/complex_binop_infer_fail/test.desc
+++ b/regression/python/complex_binop_infer_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -962,6 +962,29 @@ std::string python_annotation<Json>::get_type_from_binary_expr(
       return "float";
   }
 
+  // Python numeric-tower promotion: an arithmetic operation with a complex
+  // operand yields complex (e.g. `3 + 4j`). The LHS-driven inference below only
+  // detects a complex LHS (so `4j + 3` already works); a complex RHS would
+  // otherwise be ignored and the result mis-typed as the LHS's int/float,
+  // breaking later `.real`/`.imag` access on the assigned variable.
+  {
+    const Json &rhs =
+      stmt.contains("value") ? stmt["value"]["right"] : stmt["right"];
+    auto operand_is_complex = [&](const Json &n) -> bool {
+      if (!n.is_object() || !n.contains("_type"))
+        return false;
+      if (n["_type"] == "Constant")
+        return get_type_from_constant(n) == "complex";
+      // complex(...) constructor call
+      return n["_type"] == "Call" && n.contains("func") &&
+             n["func"].is_object() && n["func"].contains("_type") &&
+             n["func"]["_type"] == "Name" && n["func"].contains("id") &&
+             n["func"]["id"] == "complex";
+    };
+    if (operand_is_complex(lhs) || operand_is_complex(rhs))
+      return "complex";
+  }
+
   if (lhs["_type"] == "BinOp")
     type = get_type_from_binary_expr(lhs, body);
   else if (lhs["_type"] == "List")


### PR DESCRIPTION
## Problem

An unannotated complex value written as `<real> + <imaginary>j` was mis-typed:

```python
z = 3 + 4j
assert z.real == 3.0     # ERROR: AttributeError: 'z' has no attribute 'real'
```

Curiously, `z = 4j + 3` (imaginary operand on the left) worked — an operand-order asymmetry.

## Root cause

`get_type_from_binary_expr` (annotation pass) infers a binary expression's result type from the **left** operand. It detects a complex LHS (`4j + 3` → complex) but ignores a complex RHS, so `3 + 4j` was typed `int` (from the `3`), and `.real`/`.imag` on `z` then failed. The convert-time binop already routes correctly to the complex handler; only the annotation-pass type inference was wrong.

## Fix

Python's numeric tower promotes an arithmetic operation to complex when **either** operand is complex. Add that check before the LHS-driven inference: if either side is an imaginary-literal constant or a `complex(...)` call, the result type is `complex`. Plain int/float arithmetic is untouched.

## Soundness / validation

- `3 + 4j`, `0 + 4j`, `5 + 2j` (and arithmetic on the result, e.g. `* 2`) all verify `SUCCESSFUL` with correct `.real`/`.imag`; `4j + 3` still works.
- A wrong claim on `.real` is correctly refuted (`FAILED`).
- Plain `3 + 4` / `3.0 + 4` binops are unaffected.
- New tests: `regression/python/complex_binop_infer` (CORE, SUCCESSFUL) and `complex_binop_infer_fail` (CORE, FAILED). CPython sanity green.
- Complex / binop / float / arith regression cluster: **153/153 passed**; full `python` backstop running.
