### PR TITLE
[python] Support @property: invoke the getter on attribute read

### DIFF
--- a/regression/python/property_getter/main.py
+++ b/regression/python/property_getter/main.py
@@ -1,0 +1,32 @@
+# Reading a @property attribute invokes the decorated getter method. Previously
+# `obj.prop` raised "Attribute 'prop' not found" because the property method was
+# not a struct field. Accessing it now rewrites to the getter call obj.prop().
+
+class Circle:
+    def __init__(self, r):
+        self._r = r
+
+    @property
+    def radius(self):
+        return self._r
+
+    @property
+    def area(self):
+        return self._r * self._r
+
+
+c = Circle(3.0)
+# External access, and a property whose getter computes a value.
+assert c.radius == 3.0
+assert c.area == 9.0
+# Property used in arithmetic.
+assert c.area + 1.0 == 10.0
+
+
+class Sub(Circle):
+    pass
+
+
+# Property inherited from the base class.
+s = Sub(4.0)
+assert s.radius == 4.0

--- a/regression/python/property_getter/test.desc
+++ b/regression/python/property_getter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/property_getter_fail/main.py
+++ b/regression/python/property_getter_fail/main.py
@@ -1,0 +1,15 @@
+# Negative variant of property_getter: the getter runs and returns the real
+# computed value, but the assertion does not hold. Confirms the property value
+# flows precisely (a wrong claim is refuted, not vacuously accepted).
+
+class Circle:
+    def __init__(self, r):
+        self._r = r
+
+    @property
+    def area(self):
+        return self._r * self._r
+
+
+c = Circle(3.0)
+assert c.area == 99.0

--- a/regression/python/property_getter_fail/test.desc
+++ b/regression/python/property_getter_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -82,6 +82,45 @@ static void throw_numpy_multidim_index_error(
   throw std::runtime_error(msg.str());
 }
 
+// True when `method_name` is a method decorated with @property in `class_name`
+// or one of its (transitive) base classes. Reading `obj.prop` then invokes the
+// getter. A same-named non-property method in a derived class shadows a base
+// property (Python MRO), so a match that is not @property stops the search.
+static bool is_property_method(
+  const nlohmann::json &ast_body,
+  const std::string &class_name,
+  const std::string &method_name)
+{
+  const nlohmann::json cls = json_utils::find_class(ast_body, class_name);
+  if (cls.empty() || !cls.contains("body"))
+    return false;
+
+  for (const auto &stmt : cls["body"])
+  {
+    if (
+      stmt.value("_type", std::string()) != "FunctionDef" ||
+      stmt.value("name", std::string()) != method_name)
+      continue;
+    if (stmt.contains("decorator_list"))
+      for (const auto &dec : stmt["decorator_list"])
+        if (
+          dec.value("_type", std::string()) == "Name" &&
+          dec.value("id", std::string()) == "property")
+          return true;
+    return false; // method exists but is not a property: shadows any base
+  }
+
+  if (cls.contains("bases"))
+    for (const auto &base : cls["bases"])
+      if (
+        base.contains("id") &&
+        is_property_method(
+          ast_body, base["id"].template get<std::string>(), method_name))
+        return true;
+
+  return false;
+}
+
 static ExpressionType get_expression_type(const nlohmann::json &element)
 {
   // Return UNKNOWN if the expected "_type" field is missing
@@ -1202,6 +1241,23 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           {
             const typet &attr_type = class_type.get_component(attr_name).type();
             expr = build_member_expr_from_class(attr_type);
+          }
+          else if (is_property_method(
+                     (*ast_json)["body"],
+                     extract_class_name_from_tag(obj_type_name),
+                     attr_name))
+          {
+            // Reading a @property: invoke its getter. Rewrite `obj.attr` to a
+            // call `obj.attr()` and convert that, reusing the method-call
+            // machinery (the @property decorator is otherwise ignored, so the
+            // getter is a plain self-method returning the value).
+            nlohmann::json call_node;
+            call_node["_type"] = "Call";
+            call_node["func"] = element;
+            call_node["args"] = nlohmann::json::array();
+            call_node["keywords"] = nlohmann::json::array();
+            copy_location_fields_from_decl(element, call_node);
+            expr = get_expr(call_node);
           }
           else
           {


### PR DESCRIPTION
## Problem

Reading a `@property` attribute aborted conversion:

```python
class Circle:
    def __init__(self, r):
        self._r = r
    @property
    def area(self):
        return self._r * self._r

c = Circle(3.0)
assert c.area == 9.0        # ERROR: Attribute "area" not found
```

`@property` is a very common idiom, but the property method is not a struct field and decorators were ignored, so the getter was never invoked.

## Fix

When an attribute is not found as a field or class symbol, check whether the class — or a base, following the MRO — defines a method of that name decorated with `@property`. If so, rewrite the read `obj.attr` to a call `obj.attr()` and convert that, reusing the existing method-call machinery (the getter is a plain self-method returning the value; the `@property` decorator is otherwise a no-op). The check is added only on the path that previously raised "not found".

Edge cases:
- A same-named **non-property** method in a derived class shadows a base property and stops the search (Python MRO).
- Non-property methods accessed as bare attributes (`obj.m` without `()`) still error — bound methods are not modelled.
- Regular fields are unaffected.

## Soundness / validation

- Getter values flow precisely: external `c.area`, internal `self.area`, inherited properties (base class), arithmetic on a property, and multiple properties all verify `SUCCESSFUL` with correct values.
- A wrong claim on a property is correctly refuted (`FAILED`).
- New tests: `regression/python/property_getter` (CORE, SUCCESSFUL) and `property_getter_fail` (CORE, FAILED). CPython sanity green.
- Class / init / inheritance / method / property / dunder / dataclass cluster: **215/215 passed**; full `python` backstop running.
