### PR TITLE
[irep2] Flatten single-decl labeled decl-block under --irep2-bodies

### DIFF
--- a/regression/esbmc/github_4715_irep2_bodies_label_decl_01/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_label_decl_01/main.cpp
@@ -1,0 +1,30 @@
+// esbmc/esbmc#4715 (V.4.4 parity): a labeled declaration with initializer
+// `lbl: char *s = p;` is legacy label(decl-block(decl)). Under --irep2-bodies
+// the decl-block round-tripped to a code("block"), whose scope boundary made
+// convert_block emit a premature DEAD for `s` right after its init -- so every
+// later use read a dead object. This is the pattern at the top of the C++
+// std::string operational-model methods (`__ESBMC_HIDE: char *s = ...;`), which
+// produced wrong string contents under the flag. With the fix the single-decl
+// labeled decl-block round-trips as label(decl) and the DEAD is deferred to the
+// enclosing scope, so `s` stays live and the read is correct.
+#include <cassert>
+
+struct T
+{
+  char *p;
+  char get()
+  {
+  lbl:
+    char *s = p;
+    return s[0];
+  }
+};
+
+int main()
+{
+  char buf[2] = {'h', 0};
+  T t;
+  t.p = buf;
+  assert(t.get() == 'h');
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_label_decl_01/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_label_decl_01/main.cpp
@@ -7,7 +7,13 @@
 // produced wrong string contents under the flag. With the fix the single-decl
 // labeled decl-block round-trips as label(decl) and the DEAD is deferred to the
 // enclosing scope, so `s` stays live and the read is correct.
-#include <cassert>
+//
+// Uses __ESBMC_assert (like the sibling github_4715 cpp tests) rather than the
+// <cassert> macro: standard assert() lowers to a void-typed ternary
+// `cond ? (void)0 : __assert_fail(...)`, whose --irep2-bodies migration is an
+// orthogonal path that trips an if2t type-equality assert under assertion-
+// enabled builds; that is unrelated to the label-decl-block scope behaviour
+// under test here.
 
 struct T
 {
@@ -25,6 +31,6 @@ int main()
   char buf[2] = {'h', 0};
   T t;
   t.p = buf;
-  assert(t.get() == 'h');
+  __ESBMC_assert(t.get() == 'h', "s stays live: t.get() == 'h'");
   return 0;
 }

--- a/regression/esbmc/github_4715_irep2_bodies_label_decl_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_label_decl_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_bodies_label_decl_01_fail/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_label_decl_01_fail/main.cpp
@@ -1,0 +1,27 @@
+// esbmc/esbmc#4715 (V.4.4 parity): negative variant of label_decl_01. With the
+// labeled decl-with-init kept live across the --irep2-bodies round-trip, `s`
+// genuinely points at `p`, so the wrong-value assertion below is a real
+// violation (s[0] is 'h', not 'x'). Guards against the positive test passing
+// vacuously (e.g. if `s` were dead and read an unconstrained value that could
+// also satisfy the assert).
+#include <cassert>
+
+struct T
+{
+  char *p;
+  char get()
+  {
+  lbl:
+    char *s = p;
+    return s[0];
+  }
+};
+
+int main()
+{
+  char buf[2] = {'h', 0};
+  T t;
+  t.p = buf;
+  assert(t.get() == 'x'); // wrong: t.get() == 'h'
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_label_decl_01_fail/main.cpp
+++ b/regression/esbmc/github_4715_irep2_bodies_label_decl_01_fail/main.cpp
@@ -4,7 +4,10 @@
 // violation (s[0] is 'h', not 'x'). Guards against the positive test passing
 // vacuously (e.g. if `s` were dead and read an unconstrained value that could
 // also satisfy the assert).
-#include <cassert>
+//
+// Uses __ESBMC_assert (like the sibling github_4715 cpp tests) rather than the
+// <cassert> macro, whose void-ternary lowering hits an orthogonal --irep2-bodies
+// migration path unrelated to the scope behaviour under test.
 
 struct T
 {
@@ -22,6 +25,6 @@ int main()
   char buf[2] = {'h', 0};
   T t;
   t.p = buf;
-  assert(t.get() == 'x'); // wrong: t.get() == 'h'
+  __ESBMC_assert(t.get() == 'x', "wrong on purpose: t.get() == 'h', not 'x'");
   return 0;
 }

--- a/regression/esbmc/github_4715_irep2_bodies_label_decl_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_label_decl_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies --unwind 2
+^VERIFICATION FAILED$

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2369,8 +2369,26 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
   if (expr.id() == "code" && expr.statement() == "label")
   {
+    // A label whose body is a single-declaration decl-block (e.g. the C++ OM's
+    // `__ESBMC_HIDE: char *s = ...;`) must not gain a scope boundary on the
+    // round-trip. code("decl-block") forward-migrates to code_block2t, which
+    // back-migrates to code("block"); convert_block then unwinds the decl's
+    // destructor at the block end -- a premature DEAD that kills the variable
+    // before its later uses (esbmc/esbmc#4715). convert_decl_block introduces
+    // no such scope, so flatten the single-decl labeled decl-block to the bare
+    // decl: it round-trips as label(decl) and convert_decl defers the DEAD to
+    // the enclosing scope, matching the legacy path. A label labels exactly one
+    // statement, so the only multi-decl shape is `lbl: int x, y;`; that case has
+    // no flat label(decl) form and is left on the standalone decl-block arm
+    // below -- it is not exercised by the operational models this fix targets.
+    const exprt &body = expr.op0();
+    const exprt &labelled =
+      (body.id() == "code" && body.statement() == "decl-block" &&
+       body.operands().size() == 1)
+        ? body.op0()
+        : body;
     expr2tc code;
-    migrate_expr(expr.op0(), code);
+    migrate_expr(labelled, code);
     new_expr_ref = code_label2tc(expr.get("label"), code, expr.location());
     return;
   }

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -164,6 +164,35 @@ TEST_CASE("migrate expr round-trips for code_decl with init", "[migrate]")
   require_expr_roundtrip(code_decl2tc(get_int_type(32), irep_idt("x")));
 }
 
+TEST_CASE(
+  "migrate flattens a single-decl labeled decl-block",
+  "[migrate][v4-cf]")
+{
+  // esbmc#4715: `lbl: char *s = p;` is legacy label(decl-block(decl)). The
+  // decl-block must NOT migrate to a code_block -- code_block back-migrates to
+  // code("block"), whose scope boundary makes convert_block emit a premature
+  // DEAD for the declared variable right after its init (killing it before its
+  // uses). A decl-block introduces no scope (convert_decl_block), so a
+  // single-decl labeled decl-block flattens to the bare decl: the label's body
+  // round-trips as a code_decl, deferring the DEAD to the enclosing scope.
+  use_test_ns();
+  typet ct = migrate_type_back(get_int_type(32));
+
+  codet decl("decl");
+  decl.copy_to_operands(symbol_exprt("x", ct), from_integer(7, ct));
+  codet declblock("decl-block");
+  declblock.copy_to_operands(decl);
+  codet label("label");
+  label.set("label", "lbl");
+  label.copy_to_operands(declblock);
+
+  expr2tc m;
+  migrate_expr(label, m);
+  REQUIRE(is_code_label2t(m));
+  // The labeled body is the bare decl, not a scope-introducing block.
+  REQUIRE(is_code_decl2t(to_code_label2t(m).code));
+}
+
 // V1 of the symbol-table V-track (esbmc/esbmc#4715): five expr2t kinds had
 // gaps in the migration layer (no back-arm, or no forward-arm, or neither).
 // These tests pin the round-trip property -- migrate_expr_back followed by


### PR DESCRIPTION
## What

Under `--irep2-bodies`, a labeled declaration with an initializer
(`lbl: char *s = p;`) is legacy `label(decl-block(decl))`. The forward
migration's decl-block arm wrapped the standalone decl-block in a
`code_block2t`, which back-migrates to `code("block")`. `convert_block`
then unwinds the decl's destructor at block end, emitting a **premature
`DEAD`** that killed the local right after its initialiser — so all later
uses read a dead/unconstrained object.

This is exactly the pattern at the top of every C++ `std::string`
operational-model method (`__ESBMC_HIDE: char *s = ...;`), so the
iterator-range string ops (`append`/`assign` with `begin`/`end`) copied
garbage and produced a wrong result **only** under `--irep2-bodies`.

## Fix

In the forward `label` arm of `migrate_expr` (`src/util/migrate.cpp`): when
the label's body is a decl-block with exactly **one** decl, migrate the bare
decl instead, so it round-trips as `label(decl)`. `convert_decl_block` adds
no scope, deferring the `DEAD` to the enclosing scope exactly as on the
legacy path. Multi-decl `lbl: int x, y;` (rare; no flat `label(decl)` form)
is left on the legacy decl-block arm.

Minimal repro that FAILED under `--irep2-bodies` pre-fix:
`struct T{char*p; char get(){lbl: char *s=p; return s[0];}};`

## Validation

- All 4 previously-diverging string tests now ON=OFF `SUCCESSFUL`
  (string_append_6, string_append_final, string_assign_final,
  string_iterator_propagation).
- migrate unit suite 30/30 (+ new `is_code_decl2t` shape test);
  irep2_bodies regression 29/29.
- flag-off `esbmc-cpp/string` 236/236; `esbmc-cpp/cpp` 500/501
  (ch13_10 is a pre-existing THOROUGH `--timeout 900` hitting the 120s cap,
  not a regression).
- `clang-format`(11) clean; code-reviewer 0 critical / 0 high.

New regression tests: `github_4715_irep2_bodies_label_decl_01{,_fail}`.

This clears cluster 3 (C++ std::string OM) of the V.4.4 `--irep2-bodies`
verdict-parity sweep. Refs #4715.
