### PR TITLE
[python] Lexicographic ordering comparison for tuples

### DIFF
--- a/regression/python/tuple_ordering/main.py
+++ b/regression/python/tuple_ordering/main.py
@@ -1,0 +1,28 @@
+# Lexicographic ordering comparison of tuples (<, <=, >, >=). Tuples are modelled
+# as structs, and the SMT backend has no struct ordering, so a tuple `>` tripped
+# an is_signedbv assertion. The frontend now lowers tuple ordering to element-wise
+# comparisons: (a0,a1,..) < (b0,b1,..) == a0<b0 or (a0==b0 and (a1<b1 or ...)).
+
+# First element decides.
+assert (1, 2) < (3, 4)
+assert (3, 4) > (1, 2)
+
+# Equal first element: the second decides (lexicographic).
+assert (1, 2) < (1, 5)
+assert (2, 9) > (2, 1)
+
+# <= / >= including equality.
+assert (2, 3) <= (2, 3)
+assert (2, 3) >= (2, 3)
+assert (1, 0) <= (1, 1)
+
+# Three elements, and signed comparison.
+assert (1, 2, 3) < (1, 2, 4)
+assert (-1, 5) < (0, 0)
+
+# The practical use: a manual sort driven by tuple comparison.
+pairs = [(3, 1), (1, 2)]
+if pairs[0] > pairs[1]:
+    pairs[0], pairs[1] = pairs[1], pairs[0]
+assert pairs[0][0] == 1
+assert pairs[1][0] == 3

--- a/regression/python/tuple_ordering/main.py
+++ b/regression/python/tuple_ordering/main.py
@@ -20,6 +20,19 @@ assert (1, 0) <= (1, 1)
 assert (1, 2, 3) < (1, 2, 4)
 assert (-1, 5) < (0, 0)
 
+# Float components, and a mixed int/float pair (Python promotes int->float).
+assert (1.0, 2.0) < (1.0, 9.0)
+assert (1, 2.0) < (1, 3.0)
+assert (1.0, 2) < (2, 1)
+
+# Nested-tuple components compare recursively.
+assert ((1, 2), 3) < ((1, 2), 4)
+assert ((1, 3), 0) > ((1, 2), 9)
+
+# Tuples of different arity: a proper prefix is the smaller tuple.
+assert (1, 2) < (1, 2, 0)
+assert (1, 2, 3) > (1, 2)
+
 # The practical use: a manual sort driven by tuple comparison.
 pairs = [(3, 1), (1, 2)]
 if pairs[0] > pairs[1]:

--- a/regression/python/tuple_ordering/test.desc
+++ b/regression/python/tuple_ordering/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple_ordering_fail/main.py
+++ b/regression/python/tuple_ordering_fail/main.py
@@ -1,0 +1,5 @@
+# Negative variant of tuple_ordering: a lexicographic comparison that does not
+# hold. Confirms the element-wise lowering decides the comparison precisely
+# (a false claim is refuted, not vacuously accepted).
+
+assert (3, 4) < (1, 2)

--- a/regression/python/tuple_ordering_fail/test.desc
+++ b/regression/python/tuple_ordering_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -18,6 +18,8 @@
 #include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_code.h>
+
+#include <functional>
 #include <util/std_expr.h>
 #include <algorithm>
 #include <cctype>
@@ -1161,56 +1163,94 @@ exprt python_converter::handle_tuple_operations(
     return result;
   }
 
-  // Lexicographic ordering for tuples with scalar (integer/bool) components:
+  // Lexicographic ordering for tuples, lowered to element-wise comparisons
+  // (the SMT backend has no struct ordering -- a raw `>` on a tuple struct trips
+  // an is_signedbv assertion):
   //   (a0,a1,..) < (b0,b1,..)
   //     == a0<b0 or (a0==b0 and (a1<b1 or (a1==b1 and ...)))
-  // Lowered to element-wise comparisons; the SMT backend has no struct
-  // ordering (a raw `>` on the tuple struct trips an is_signedbv assertion).
-  // Gt/LtE compare the swapped operands; LtE/GtE negate the strict result.
+  // Components may be integer/bool/float scalars (mixed int/float promote to
+  // double, matching Python's numeric tower) or nested tuples (compared
+  // recursively). Tuples of differing arity compare on the common prefix, with
+  // the shorter tuple ordered first if the prefix is equal. Gt/LtE compare the
+  // swapped operands; LtE/GtE negate the strict result. Any other component
+  // kind (string/list/...) makes the whole comparison fall through unchanged.
   if (
     lhs_is_tuple && rhs_is_tuple &&
     (op == "Lt" || op == "LtE" || op == "Gt" || op == "GtE"))
   {
-    const auto &lc = to_struct_type(lhs.type()).components();
-    const auto &rc = to_struct_type(rhs.type()).components();
-
-    auto is_scalar = [](const typet &t) {
-      return t.is_signedbv() || t.is_unsignedbv() || t == bool_type();
+    bool ok = true;
+    auto is_num = [](const typet &t) {
+      return t.is_signedbv() || t.is_unsignedbv() || t.is_floatbv() ||
+             t == bool_type();
     };
-    bool ok = !lc.empty() && lc.size() == rc.size();
-    for (size_t i = 0; ok && i < lc.size(); ++i)
-      ok = is_scalar(lc[i].type()) && is_scalar(rc[i].type());
-    if (!ok)
-      return nil_exprt(); // floats / nested tuples / different arity: unhandled
+
+    auto memb = [&](const expr2tc &s, const struct_typet::componentt &c) {
+      return migrate_expr_back(
+        member2tc(migrate_type(c.type()), s, c.get_name()));
+    };
+
+    // Strict lexicographic less-than for two tuple-typed expressions.
+    std::function<exprt(const exprt &, const exprt &)> lex_lt =
+      [&](const exprt &ta, const exprt &tb) -> exprt {
+      const auto &ca = to_struct_type(ta.type()).components();
+      const auto &cb = to_struct_type(tb.type()).components();
+      const size_t m = std::min(ca.size(), cb.size());
+
+      expr2tc a2, b2;
+      migrate_expr(ta, a2);
+      migrate_expr(tb, b2);
+
+      // Base: a proper prefix is strictly less than the longer tuple.
+      exprt result = gen_boolean(ca.size() < cb.size());
+      for (size_t k = m; k-- > 0;)
+      {
+        exprt ai = memb(a2, ca[k]);
+        exprt bi = memb(b2, cb[k]);
+
+        exprt lt, eq;
+        const bool ai_tuple = tuple_handler_->is_tuple_type(ai.type());
+        const bool bi_tuple = tuple_handler_->is_tuple_type(bi.type());
+        if (ai_tuple && bi_tuple)
+        {
+          lt = lex_lt(ai, bi);
+          eq = equality_exprt(ai, bi); // native struct equality, element-wise
+        }
+        else if (is_num(ai.type()) && is_num(bi.type()))
+        {
+          // Promote a mixed int/float pair to double (Python int->float).
+          if (ai.type() != bi.type())
+          {
+            ai = typecast_exprt(ai, double_type());
+            bi = typecast_exprt(bi, double_type());
+          }
+          lt = exprt("<", bool_type());
+          lt.copy_to_operands(ai, bi);
+          eq = equality_exprt(ai, bi);
+        }
+        else
+        {
+          ok = false; // unsupported / mismatched component kinds
+          return gen_boolean(false);
+        }
+
+        exprt tail("and", bool_type());
+        tail.copy_to_operands(eq, result);
+        exprt head("or", bool_type());
+        head.copy_to_operands(lt, tail);
+        result = head;
+      }
+      return result;
+    };
 
     const bool swap = (op == "Gt" || op == "LtE");
     const bool negate = (op == "LtE" || op == "GtE");
     exprt &a = swap ? rhs : lhs;
     exprt &b = swap ? lhs : rhs;
 
-    expr2tc a2, b2;
-    migrate_expr(a, a2);
-    migrate_expr(b, b2);
-    auto memb = [&](const expr2tc &s, const struct_typet::componentt &c) {
-      return migrate_expr_back(
-        member2tc(migrate_type(c.type()), s, c.get_name()));
-    };
+    exprt result = lex_lt(a, b);
+    if (!ok)
+      return nil_exprt(); // a non-orderable component: leave unchanged
 
-    // Build the nested or/and chain from the last component back to the first.
-    exprt result = gen_boolean(false);
-    for (size_t k = lc.size(); k-- > 0;)
-    {
-      exprt ai = memb(a2, lc[k]);
-      exprt bi = memb(b2, rc[k]);
-      exprt lt("<", bool_type());
-      lt.copy_to_operands(ai, bi);
-      exprt eq = equality_exprt(ai, bi);
-      exprt tail("and", bool_type());
-      tail.copy_to_operands(eq, result);
-      exprt head("or", bool_type());
-      head.copy_to_operands(lt, tail);
-      result = head;
-    }
     if (negate)
     {
       exprt n("not", bool_type());

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1161,6 +1161,66 @@ exprt python_converter::handle_tuple_operations(
     return result;
   }
 
+  // Lexicographic ordering for tuples with scalar (integer/bool) components:
+  //   (a0,a1,..) < (b0,b1,..)
+  //     == a0<b0 or (a0==b0 and (a1<b1 or (a1==b1 and ...)))
+  // Lowered to element-wise comparisons; the SMT backend has no struct
+  // ordering (a raw `>` on the tuple struct trips an is_signedbv assertion).
+  // Gt/LtE compare the swapped operands; LtE/GtE negate the strict result.
+  if (
+    lhs_is_tuple && rhs_is_tuple &&
+    (op == "Lt" || op == "LtE" || op == "Gt" || op == "GtE"))
+  {
+    const auto &lc = to_struct_type(lhs.type()).components();
+    const auto &rc = to_struct_type(rhs.type()).components();
+
+    auto is_scalar = [](const typet &t) {
+      return t.is_signedbv() || t.is_unsignedbv() || t == bool_type();
+    };
+    bool ok = !lc.empty() && lc.size() == rc.size();
+    for (size_t i = 0; ok && i < lc.size(); ++i)
+      ok = is_scalar(lc[i].type()) && is_scalar(rc[i].type());
+    if (!ok)
+      return nil_exprt(); // floats / nested tuples / different arity: unhandled
+
+    const bool swap = (op == "Gt" || op == "LtE");
+    const bool negate = (op == "LtE" || op == "GtE");
+    exprt &a = swap ? rhs : lhs;
+    exprt &b = swap ? lhs : rhs;
+
+    expr2tc a2, b2;
+    migrate_expr(a, a2);
+    migrate_expr(b, b2);
+    auto memb = [&](const expr2tc &s, const struct_typet::componentt &c) {
+      return migrate_expr_back(
+        member2tc(migrate_type(c.type()), s, c.get_name()));
+    };
+
+    // Build the nested or/and chain from the last component back to the first.
+    exprt result = gen_boolean(false);
+    for (size_t k = lc.size(); k-- > 0;)
+    {
+      exprt ai = memb(a2, lc[k]);
+      exprt bi = memb(b2, rc[k]);
+      exprt lt("<", bool_type());
+      lt.copy_to_operands(ai, bi);
+      exprt eq = equality_exprt(ai, bi);
+      exprt tail("and", bool_type());
+      tail.copy_to_operands(eq, result);
+      exprt head("or", bool_type());
+      head.copy_to_operands(lt, tail);
+      result = head;
+    }
+    if (negate)
+    {
+      exprt n("not", bool_type());
+      n.copy_to_operands(result);
+      result = n;
+    }
+    result.location() = get_location_from_decl(element);
+    return result;
+  }
+
   return nil_exprt();
 }
 


### PR DESCRIPTION
## Problem

Comparing tuples with an ordering operator crashed the SMT backend:

```python
assert (1, 2) < (3, 4)     # Assertion failed: is_signedbv_type(...), smt_conv.cpp
```

Tuples are modelled as structs, and a raw struct `>`/`<` has no SMT encoding. Only `==`/`!=` worked (native struct equality).

## Fix

Lower tuple ordering in `handle_tuple_operations` to **element-wise lexicographic** comparison, built by a recursive helper:

```
(a0, a1, ..) < (b0, b1, ..)
   == a0 < b0  or  (a0 == b0 and (a1 < b1 or (a1 == b1 and ...)))
```

Component support:
- **integer / bool** scalars;
- **float**, and **mixed int/float** pairs (promoted to double, matching Python's numeric tower);
- **nested tuples** (compared recursively; element equality stays native struct equality);
- **differing arity** — compare the common prefix; the shorter tuple orders first when the prefix is equal.

`Gt`/`LtE` compare the swapped operands; `LtE`/`GtE` negate the strict result. Any non-orderable component (string/list/…) leaves the comparison unchanged (falls through), so nothing regresses.

## Soundness / validation

- Lexicographic order decided precisely across first-element, equal-prefix, `<=`/`>=` equality, 3-element, signed/negative, float, mixed int/float, nested, and mixed-arity cases — all verify `SUCCESSFUL`.
- False comparisons are correctly refuted (`FAILED`).
- Enables the practical pattern: a manual sort driven by tuple comparison (`if a > b: a, b = b, a`).
- New tests: `regression/python/tuple_ordering` (CORE, SUCCESSFUL, covering all component kinds) and `tuple_ordering_fail` (CORE, FAILED). CPython sanity green.
- Tuple / comparison / sort / dunder regression cluster clean; full `python` backstop run clean (only the pre-existing Boolector/flask env failures).

## Scope

This makes tuple **comparison** complete. **`sorted()` over a list of tuples is still unsupported** — it needs a frontend sort lowering (a tuple-aware operational model routes through `python_list::compare` and crashes), and the list-of-tuples sort is a separate performance concern. Those are scoped follow-ups (see PYTHON_DESIGN_PLAN.md, efforts P and S); this PR unblocks manual sorts and tuple-keyed conditionals.
