### PR TITLE
[irep2] Pin Python list/dict OM parity under --irep2-bodies

### DIFF
--- a/regression/python/github_4715_irep2_bodies_py_om_01/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_om_01/main.py
@@ -1,0 +1,11 @@
+# Pins the Python list operational-model alloca path under --irep2-bodies.
+# The list OM allocates element storage via __ESBMC_alloca(sizeof(struct)),
+# whose allocated type comes from the size constant's #c_sizeof_type. If the
+# body round-trip drops that type (PR #5330), the alloca degrades to a byte
+# array and reading an element's value as a wide int trips an "Incorrect
+# alignment" dereference failure. These reads must stay sound under the flag.
+l = [10, 20, 30, 40, 50]
+l.append(60)
+assert l[0] == 10
+assert l[2] == 30
+assert l[5] == 60

--- a/regression/python/github_4715_irep2_bodies_py_om_01/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_om_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir --irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_bodies_py_om_01_fail/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_om_01_fail/main.py
@@ -1,0 +1,7 @@
+# Negative variant of github_4715_irep2_bodies_py_om_01: a wrong expected value
+# must still produce a counterexample (VERIFICATION FAILED) under --irep2-bodies,
+# proving the element read is genuinely constrained and not masked by an
+# alignment crash.
+l = [10, 20, 30, 40, 50]
+l.append(60)
+assert l[2] == 31

--- a/regression/python/github_4715_irep2_bodies_py_om_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_om_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir --irep2-bodies
+^VERIFICATION FAILED$

--- a/regression/python/github_4715_irep2_bodies_py_om_02/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_om_02/main.py
@@ -1,0 +1,12 @@
+# Pins the Python dict operational-model allocation path under --irep2-bodies.
+# A typed dict stores key/value objects whose storage is alloca'd from a
+# sizeof(struct) constant; dropping #c_sizeof_type on the body round-trip
+# (PR #5330) degraded the allocation to a byte array, producing alignment /
+# NULL-pointer dereference failures on subscript reads. The reads must stay
+# sound and correctly typed under the flag.
+d: dict[int, float] = {1: 1.0}
+d[2] = 3.5
+assert isinstance(d[2], float)
+assert d[2] == 3.5
+assert d[1] == 1.0
+assert not isinstance(d[2], int)

--- a/regression/python/github_4715_irep2_bodies_py_om_02/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_om_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_bodies_py_om_02_fail/main.py
+++ b/regression/python/github_4715_irep2_bodies_py_om_02_fail/main.py
@@ -1,0 +1,6 @@
+# Negative variant of github_4715_irep2_bodies_py_om_02: a wrong expected value
+# must still produce a counterexample (VERIFICATION FAILED) under --irep2-bodies,
+# proving the dict subscript read is genuinely constrained.
+d: dict[int, float] = {1: 1.0}
+d[2] = 3.5
+assert d[2] == 4.0

--- a/regression/python/github_4715_irep2_bodies_py_om_02_fail/test.desc
+++ b/regression/python/github_4715_irep2_bodies_py_om_02_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5 --irep2-bodies
+^VERIFICATION FAILED$


### PR DESCRIPTION
## What

Adds flag-pinned Python regression tests for the list and dict operational
models under `--irep2-bodies`, closing a coverage gap left by #5330.

## Why

The Python list/dict OMs allocate element storage via
`__ESBMC_alloca(sizeof(struct))`, whose allocated type is carried by the size
constant's `#c_sizeof_type`. Before #5330, the `--irep2-bodies` body
round-trip dropped that type, degrading the alloca to a byte array
(`ALLOCA(signed char, N)` instead of `ALLOCA(struct __ESBMC_PyObj, N)`).
Reading an element value as a wide int then tripped an *Incorrect alignment*
/ NULL-pointer dereference failure, flipping list and dict tests to spurious
`VERIFICATION FAILED` **only** under the flag (e.g. `convert-byte-update1`,
`dict_del13/15/16`, `dict_subscript_typed_assign`, `enumerate1`).

#5330 fixed the root cause (`constant_int2t` `sizeof_type` preservation) but
shipped only **C `malloc`** regression tests — the Python `alloca`/dict OM
path that exercises the same constant was left unpinned. A future regression
of that fix would not be caught on the Python side.

## Tests

Four `--irep2-bodies`-pinned Python tests over the OM allocation path:

- `github_4715_irep2_bodies_py_om_01{,_fail}` — list append + indexed read
  (`--unwind 9 --ir --irep2-bodies`).
- `github_4715_irep2_bodies_py_om_02{,_fail}` — typed-dict subscript assign +
  read (`--unwind 5 --irep2-bodies`).

Each `_fail` variant uses a wrong expected value and must still produce a
genuine counterexample (the violated property is the assertion on the
element value, not a crash), proving the read is sound *and* constrained.

No product code changes — regression coverage only. All four pass via ctest.
Refs #4715.
