### PR TITLE
[clang-c-frontend] import LinkageSpecDecl children when merging C++ ASTs

### DIFF
--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c/first.cpp
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c/first.cpp
@@ -1,0 +1,6 @@
+// First C++ translation unit. Its function is defined inside an extern "C"
+// block, so it lives under a LinkageSpecDecl in the AST.
+extern "C" int multi_tu_first()
+{
+  return 1;
+}

--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c/main.cpp
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c/main.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+
+extern "C" int multi_tu_first();
+extern "C" int multi_tu_second();
+
+int main()
+{
+  // Both functions come from separate C++ translation units merged via
+  // mergeASTs. The second TU's body must survive the merge.
+  assert(multi_tu_first() == 1);
+  assert(multi_tu_second() == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c/second.cpp
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c/second.cpp
@@ -1,0 +1,8 @@
+// Second C++ translation unit. Before the ASTImporter fix, merging this TU on
+// top of the first dropped every decl inside its extern "C" block, so
+// multi_tu_second() resolved to a nondeterministic body and the assertion in
+// main.cpp could fail.
+extern "C" int multi_tu_second()
+{
+  return 2;
+}

--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c/test.desc
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+first.cpp second.cpp
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/first.cpp
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/first.cpp
@@ -1,0 +1,5 @@
+// First C++ translation unit (extern "C" -> LinkageSpecDecl).
+extern "C" int multi_tu_first()
+{
+  return 1;
+}

--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+
+extern "C" int multi_tu_first();
+extern "C" int multi_tu_second();
+
+int main()
+{
+  // The second TU's body is now correctly merged, so multi_tu_second()
+  // returns exactly 2. Asserting it equals 3 must therefore fail with a
+  // concrete counterexample (rather than passing vacuously on a nondet body).
+  assert(multi_tu_first() == 1);
+  assert(multi_tu_second() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/second.cpp
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/second.cpp
@@ -1,0 +1,6 @@
+// Second C++ translation unit. Its body must survive the mergeASTs import so
+// that multi_tu_second() deterministically returns 2 (not a nondet value).
+extern "C" int multi_tu_second()
+{
+  return 2;
+}

--- a/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/multi_tu_extern_c_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+first.cpp second.cpp
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/AST/build_ast.cpp
+++ b/src/clang-c-frontend/AST/build_ast.cpp
@@ -176,6 +176,45 @@ std::unique_ptr<clang::ASTUnit> buildASTs(
   return unit;
 }
 
+/// Import one decl from the source context into \p Importer's destination.
+/// Returns the imported decl, or nullptr if the import failed (the error is
+/// logged and consumed so the rest of the merge can proceed).
+///
+/// clang::ASTImporter::Import() imports the decl node itself but does NOT
+/// recurse into the children of a DeclContext such as a LinkageSpecDecl
+/// (`extern "C" { ... }`). Importing the wrapper alone yields an empty
+/// linkage-spec, so the functions inside it silently vanish from the merged
+/// AST. Every function in ESBMC's C++ operational models is declared inside an
+/// `extern "C"` block, which is why merging a second C++ translation unit
+/// dropped all of its symbols. C functions are direct children of the
+/// translation unit, so they import individually and were unaffected.
+///
+/// We therefore import each child of a LinkageSpecDecl explicitly and attach it
+/// to the imported wrapper's context.
+static clang::Decl *
+importDecl(clang::ASTImporter &Importer, clang::Decl *FromDecl)
+{
+  llvm::Expected<clang::Decl *> ImportedOrErr = Importer.Import(FromDecl);
+  if (!ImportedOrErr)
+  {
+    llvm::Error Err = ImportedOrErr.takeError();
+    llvm::errs() << "Error: " << Err << "\n";
+    consumeError(std::move(Err));
+    return nullptr;
+  }
+  clang::Decl *Imported = *ImportedOrErr;
+
+  auto *FromLS = llvm::dyn_cast<clang::LinkageSpecDecl>(FromDecl);
+  auto *ToLS = llvm::dyn_cast_or_null<clang::LinkageSpecDecl>(Imported);
+  if (FromLS && ToLS)
+    for (clang::Decl *Child : FromLS->decls())
+      if (clang::Decl *ImportedChild = importDecl(Importer, Child))
+        if (ImportedChild->getLexicalDeclContext() != ToLS)
+          ToLS->addDecl(ImportedChild);
+
+  return Imported;
+}
+
 void mergeASTs(
   const std::unique_ptr<clang::ASTUnit> &FromUnit,
   std::unique_ptr<clang::ASTUnit> &ToUnit)
@@ -195,13 +234,5 @@ void mergeASTs(
   Importer.setODRHandling(clang::ASTImporter::ODRHandlingType::Liberal);
 
   for (auto decl : FromUnit->getASTContext().getTranslationUnitDecl()->decls())
-  {
-    llvm::Expected<clang::Decl *> ImportedOrErr = Importer.Import(decl);
-    if (!ImportedOrErr)
-    {
-      llvm::Error Err = ImportedOrErr.takeError();
-      llvm::errs() << "Error: " << Err << "\n";
-      consumeError(std::move(Err));
-    }
-  }
+    importDecl(Importer, decl);
 }


### PR DESCRIPTION
## Problem

`mergeASTs` (`src/clang-c-frontend/AST/build_ast.cpp`) merges multiple translation units into one AST by importing each top-level decl of the source TU with `clang::ASTImporter::Import()`. But `Import()` imports a decl *node* without recursing into the children of a `DeclContext` such as a `LinkageSpecDecl` — i.e. an `extern "C" { ... }` block.

Every function in a C++ TU is wrapped in such a block, so merging a **second** C++ translation unit copied an *empty* linkage-spec and silently dropped every function inside it. C was unaffected because C functions are direct children of the translation unit and import individually.

This breaks compiling more than one C++ source into the embedded clib (e.g. the C++ operational models), where the second-parsed file's symbols vanish.

### Root cause, confirmed

Instrumenting the merge showed the source `LinkageSpecDecl`s had 67 and 1 children, while the imported ones had **0** — the wrapper imported, the contents did not.

## Fix

In `mergeASTs`, when the imported decl is a `LinkageSpecDecl`, import each child of the source linkage-spec explicitly and attach it to the imported wrapper (recursive, with a guard against double-adding if the importer already attached it).

## Tests

Two regression tests under `regression/esbmc-cpp/cpp/` link two `extern "C"` C++ TUs (`first.cpp`, `second.cpp`) plus a `main.cpp` caller:

- `multi_tu_extern_c` — both bodies survive the merge → `VERIFICATION SUCCESSFUL`.
- `multi_tu_extern_c_fail` — same setup, asserts the wrong value → `VERIFICATION FAILED` (confirms the merged body is a real `2`, not a nondet value).

Verified the passing test **fails without** the fix (dropped body → nondet → `VERIFICATION FAILED`) and **passes with** it. Existing multi-file C++ tests (`ch10_2/3/4`, `ch11_*`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)