### PR TITLE
[om] Add a memchr intrinsic to avoid loop unwinding

### DIFF
--- a/regression/cstd/memchr_intrinsic/main.c
+++ b/regression/cstd/memchr_intrinsic/main.c
@@ -1,0 +1,31 @@
+#include <string.h>
+#include <assert.h>
+
+extern char nondet_char(void);
+
+int main()
+{
+  char a[4] = {10, 20, 30, 40};
+  char c = nondet_char();
+  void *p = memchr(a, c, 4);
+
+  /* If a match is reported, the byte at that address must equal c. */
+  if (p != NULL)
+    assert(*(unsigned char *)p == (unsigned char)c);
+
+  /* If c is none of the stored bytes, the result must be NULL. */
+  if (c != 10 && c != 20 && c != 30 && c != 40)
+    assert(p == NULL);
+
+  /* First match wins. */
+  char b[6] = {9, 9, 7, 9, 7, 0};
+  assert(memchr(b, 7, 6) == &b[2]);
+
+  /* n == 0 returns NULL even when the byte is present. */
+  assert(memchr(a, 10, 0) == NULL);
+
+  /* n == 0 examines no bytes, so buf need not be valid (C11 7.24.5.1). */
+  assert(memchr(NULL, 10, 0) == NULL);
+
+  return 0;
+}

--- a/regression/cstd/memchr_intrinsic/test.desc
+++ b/regression/cstd/memchr_intrinsic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+ -Wno-error=implicit-function-declaration
+^VERIFICATION SUCCESSFUL$

--- a/regression/cstd/memchr_intrinsic_oob/main.c
+++ b/regression/cstd/memchr_intrinsic_oob/main.c
@@ -1,0 +1,12 @@
+#include <string.h>
+
+int main()
+{
+  char a[4] = {1, 2, 3, 4};
+
+  /* Reading 8 bytes from a 4-byte object is out of bounds: the intrinsic must
+   * report a dereference failure rather than silently scanning past the end. */
+  memchr(a, 9, 8);
+
+  return 0;
+}

--- a/regression/cstd/memchr_intrinsic_oob/test.desc
+++ b/regression/cstd/memchr_intrinsic_oob/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+ -Wno-error=implicit-function-declaration
+^VERIFICATION FAILED$
+^.*dereference failure on memchr: reading memory segment of size 4 with 8 bytes.*$

--- a/src/c2goto/library/string.c
+++ b/src/c2goto/library/string.c
@@ -355,7 +355,7 @@ __ESBMC_HIDE:;
   return res;
 }
 
-void *memchr(const void *buf, int ch, size_t n)
+void *__memchr_impl(const void *buf, int ch, size_t n)
 {
 __ESBMC_HIDE:;
   while (n && (*(unsigned char *)buf != (unsigned char)ch))
@@ -365,4 +365,12 @@ __ESBMC_HIDE:;
   }
 
   return (n ? (void *)buf : NULL);
+}
+
+void *memchr(const void *buf, int ch, size_t n)
+{
+__ESBMC_HIDE:;
+  void *hax = &__memchr_impl;
+  (void)hax;
+  return __ESBMC_memchr(buf, ch, n);
 }

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -504,8 +504,9 @@ _Bool __ESBMC_is_little_endian();
 extern int __ESBMC_rounding_mode;
 
 void *__ESBMC_memset(void *, int, __SIZE_TYPE__);
-      void *__ESBMC_memcpy(void *, const void *, __SIZE_TYPE__);
-      
+void *__ESBMC_memcpy(void *, const void *, __SIZE_TYPE__);
+void *__ESBMC_memchr(const void *, int, __SIZE_TYPE__);
+
 /* same semantics as memcpy(tgt, src, size) where size matches the size of the
  * types tgt and src point to. */
 void __ESBMC_bitcast(void * /* tgt */, void * /* src */);

--- a/src/goto-symex/builtin_functions/memory_ops.cpp
+++ b/src/goto-symex/builtin_functions/memory_ops.cpp
@@ -711,6 +711,190 @@ void goto_symext::intrinsic_memcpy(
 }
 
 /**
+ * @brief Intrinsic for C memchr.
+ *
+ * memchr(const void *buf, int ch, size_t n) scans the first n bytes of the
+ * object pointed to by buf for the first byte equal to (unsigned char)ch and
+ * returns a pointer to it, or NULL if no such byte appears in those n bytes.
+ *
+ * Instead of unwinding the operational-model loop (one branch per byte), we
+ * read the n candidate bytes with byte_extract and fold them into a single
+ * nested-ite pointer expression:
+ *
+ *   res = ite(byte[0] == ch, buf + 0,
+ *         ite(byte[1] == ch, buf + 1,
+ *         ...
+ *         ite(byte[n-1] == ch, buf + (n-1), NULL)))
+ *
+ * Building from the last position outward keeps the *first* match as the
+ * outermost selected arm. ch is symbolic-friendly (the comparison is encoded);
+ * only n must be a known constant. If the object/offset cannot be resolved to
+ * constants we bump to the __memchr_impl loop.
+ */
+void goto_symext::intrinsic_memchr(
+  reachability_treet &art,
+  const code_function_call2t &func_call)
+{
+  assert(func_call.operands.size() == 3 && "Wrong memchr signature");
+
+  using namespace std::string_literals;
+  const auto bump_name = "c:@F@__memchr_impl"s;
+
+  if (options.get_bool_option("no-simplify"))
+  {
+    bump_call(func_call, bump_name);
+    return;
+  }
+
+  const execution_statet &ex_state = art.get_cur_state();
+  if (ex_state.cur_state->guard.is_false())
+    return;
+
+  expr2tc buf_arg = func_call.operands[0];
+  expr2tc ch_arg = func_call.operands[1];
+  expr2tc n_arg = func_call.operands[2];
+
+  cur_state->rename(ch_arg);
+  cur_state->rename(n_arg);
+  if (!ch_arg || !n_arg || is_symbol2t(n_arg))
+  {
+    bump_call(func_call, bump_name);
+    return;
+  }
+
+  simplify(n_arg);
+  if (!is_constant_int2t(n_arg))
+  {
+    bump_call(func_call, bump_name);
+    return;
+  }
+
+  const unsigned long number_of_bytes = to_constant_int2t(n_arg).as_ulong();
+
+  // Resolve the object(s) buf points to.
+  internal_deref_items.clear();
+  expr2tc deref = dereference2tc(get_empty_type(), buf_arg);
+  dereference(deref, dereferencet::INTERNAL);
+
+  if (!internal_deref_items.size())
+  {
+    bump_call(func_call, bump_name);
+    return;
+  }
+
+  std::list<dereference_callbackt::internal_item> buf_items;
+  buf_items.splice(buf_items.end(), internal_deref_items);
+
+  const bool is_big_endian =
+    (config.ansi_c.endianess == configt::ansi_ct::IS_BIG_ENDIAN);
+
+  expr2tc ret_ref = func_call.ret;
+  if (is_nil_expr(ret_ref))
+    return;
+
+  const type2tc ret_type = ret_ref->type;
+  const expr2tc null_result = symbol2tc(ret_type, "NULL");
+
+  // Byte value to search for: (unsigned char)ch.
+  const expr2tc ch_byte = typecast2tc(get_uint_type(8), ch_arg);
+
+  for (auto &item : buf_items)
+  {
+    guard2tc guard = ex_state.cur_state->guard;
+    guard.add(item.guard);
+
+    expr2tc item_object = item.object;
+    expr2tc item_offset = item.offset;
+    cur_state->rename(item_object);
+    cur_state->rename(item_offset);
+
+    if (!item_object || !item_offset)
+    {
+      bump_call(func_call, bump_name);
+      return;
+    }
+
+    offset_simplifier(item_offset);
+    if (!is_constant_int2t(item_offset))
+    {
+      bump_call(func_call, bump_name);
+      return;
+    }
+
+    const uint64_t number_of_offset =
+      to_constant_int2t(item_offset).value.to_uint64();
+
+    if (is_code_type(item_object->type))
+    {
+      bump_call(func_call, bump_name);
+      return;
+    }
+
+    uint64_t type_size;
+    try
+    {
+      type_size = type_byte_size(item_object->type).to_uint64();
+    }
+    catch (const array_type2t::dyn_sized_array_excp &)
+    {
+      bump_call(func_call, bump_name);
+      return;
+    }
+    catch (const array_type2t::inf_sized_array_excp &)
+    {
+      bump_call(func_call, bump_name);
+      return;
+    }
+
+    // Reading the first n bytes must stay within the object.
+    const bool is_out_bounds =
+      (number_of_offset > type_size) ||
+      ((type_size - number_of_offset) < number_of_bytes);
+    if (
+      is_out_bounds && !options.get_bool_option("no-pointer-check") &&
+      !options.get_bool_option("no-bounds-check"))
+    {
+      std::string error_msg = fmt::format(
+        "dereference failure on memchr: reading memory segment of size {} with "
+        "{} bytes",
+        type_size - number_of_offset,
+        number_of_bytes);
+      expr2tc check = implies2tc(item.guard, gen_false_expr());
+      claim(check, error_msg);
+      continue;
+    }
+
+    // Fold the n candidate bytes into a nested-ite pointer, from the last
+    // position outward so the first match wins.
+    expr2tc result = null_result;
+    for (unsigned long k = number_of_bytes; k-- > 0;)
+    {
+      expr2tc byte = byte_extract2tc(
+        get_uint_type(8),
+        item_object,
+        gen_ulong(number_of_offset + k),
+        is_big_endian);
+      expr2tc match = equality2tc(byte, ch_byte);
+      expr2tc hit = add2tc(ret_type, buf_arg, gen_ulong(k));
+      result = if2tc(ret_type, match, hit, result);
+    }
+
+    symex_assign(code_assign2tc(ret_ref, result), false, guard);
+  }
+
+  // C11/C17 7.24.5.1: with n == 0 no bytes are examined, so buf is never
+  // dereferenced and need not be valid. The __memchr_impl model agrees
+  // (its loop is `while (n && ...)`). Only claim non-NULL when n > 0.
+  if (number_of_bytes != 0 && !options.get_bool_option("no-pointer-check"))
+  {
+    expr2tc null_sym = symbol2tc(buf_arg->type, "NULL");
+    expr2tc null_check = not2tc(same_object2tc(buf_arg, null_sym));
+    ex_state.cur_state->guard.guard_expr(null_check);
+    claim(null_check, " dereference failure: NULL pointer on memchr");
+  }
+}
+
+/**
  * @brief This function will try to initialize the object pointed by
  * the address in a smarter way, minimizing the number of assignments.
  * This is intend to optimize the behavior of a memset operation:

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -508,6 +508,21 @@ protected:
     reachability_treet &art,
     const code_function_call2t &func_call);
 
+  /**
+   * @brief Intrinsic call for C memchr function call
+   *
+   * This will either invoke our operational model (at string.c)
+   * or build the result pointer directly: it scans the first n bytes of the
+   * object pointed to by buf and returns a pointer to the first byte equal to
+   * the (unsigned char) value ch, or NULL if no such byte is found.
+   *
+   * @param art
+   * @param func_call memchr function call
+   */
+  void intrinsic_memchr(
+    reachability_treet &art,
+    const code_function_call2t &func_call);
+
   // Function to call a symname function, in case where were not able to optimize it
   void
   bump_call(const code_function_call2t &func_call, const std::string &symname);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -694,6 +694,12 @@ void goto_symext::run_intrinsic(
     return;
   }
 
+  if (symname == "c:@F@__ESBMC_memchr")
+  {
+    intrinsic_memchr(art, func_call);
+    return;
+  }
+
   if (symname == "c:@F@__ESBMC_get_object_size")
   {
     intrinsic_get_object_size(func_call, art);


### PR DESCRIPTION
## What

Adds `__ESBMC_memchr`, a symbolic-execution intrinsic for C's `memchr(const void *buf, int ch, size_t n)`, following the existing `__ESBMC_memcpy`/`__ESBMC_memset` pattern. This is the fourth in the mem-operation intrinsic series (after memcmp #5342 and memmove #5343).

## Why

`memchr` was modelled purely by an operational-model byte loop in `string.c`. A call with a constant `n` forced symex to unwind `n` loop iterations — one branch per byte — which is expensive for larger buffers and requires a matching `--unwind` bound.

## How

`intrinsic_memchr` resolves the buffer pointer to its concrete object(s), requires a constant `n`, reads the `n` candidate bytes via `byte_extract`, and folds them into a single nested-ite pointer expression:

```
res = ite(byte[0] == ch, buf + 0,
      ite(byte[1] == ch, buf + 1,
      ...
      ite(byte[n-1] == ch, buf + (n-1), NULL)))
```

Building from the last position outward keeps the **first** match as the outermost selected arm. Only `n` must be constant — the search value `ch` stays symbolic (the per-byte equality is encoded directly). When the preconditions don't hold (symbolic/non-constant `n`, unresolvable object/offset, dynamically-sized arrays, code-typed targets, `--no-simplify`), the call bumps to `__memchr_impl` — the old loop — preserving behaviour.

Soundness:
- An out-of-bounds read (`n` exceeds the remaining object size) raises a `dereference failure on memchr` claim, matching the `memcpy`/`memset` bounds check.
- A NULL `buf` with `n > 0` raises a NULL-pointer dereference failure.
- `n == 0` examines no bytes, so `buf` need not be valid (C11/C17 §7.24.5.1); the NULL claim is suppressed in that case, matching the `__memchr_impl` model (`while (n && ...)`).

## Tests

- `regression/cstd/memchr_intrinsic` (SUCCESSFUL): match-implies-equal with **symbolic** `ch`, no-match-implies-NULL, first-match-wins, `n == 0` returns NULL (including on a NULL pointer).
- `regression/cstd/memchr_intrinsic_oob` (FAILED): reading 8 bytes from a 4-byte object trips the bounds claim.

The full `cstd` suite (138 tests, including the pre-existing `memchr`/`memchr_bug` and C++ `cstring17_memchr`/`ch18_26`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)