### PR TITLE
[irep2] Preserve #pragma unroll count across the --irep2-bodies round-trip

### DIFF
--- a/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01/main.c
@@ -1,0 +1,20 @@
+/* Pins that the --irep2-bodies body round-trip preserves a loop's
+ * `#pragma unroll N` count. The pragma truncates this loop to 3 iterations,
+ * so only a[0..2] are written -- all in bounds. If the count were dropped on
+ * the round-trip the loop would run to its natural bound of 8, writing a[3..7]
+ * out of the 3-element array: a spurious array-bounds violation seen only
+ * under the flag. (An unsound unroll assumes loop exit after N iterations, so
+ * a post-loop assertion would be vacuous; the in-loop bounds checks are the
+ * discriminator.) */
+#include <stdint.h>
+
+int main()
+{
+  int a[3] = {0};
+
+  #pragma unroll 3
+  for (uint32_t j = 0; j < 8; j++)
+    a[j] = (int)(j + 1);
+
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-unwinding-assertions --irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01_fail/main.c
@@ -1,0 +1,18 @@
+/* Negative variant of github_4715_irep2_bodies_pragma_unroll_01: the array is
+ * one element too small, so the third unrolled iteration writes a[2] out of
+ * the 2-element array. This in-loop array-bounds violation is reachable and
+ * must still produce a counterexample (VERIFICATION FAILED) under
+ * --irep2-bodies, confirming the bounds checker runs over the round-tripped
+ * loop body. */
+#include <stdint.h>
+
+int main()
+{
+  int a[2] = {0};
+
+  #pragma unroll 3
+  for (uint32_t j = 0; j < 8; j++)
+    a[j] = (int)(j + 1);
+
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-unwinding-assertions --irep2-bodies
+^VERIFICATION FAILED$

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -2077,13 +2077,24 @@ public:
   expr2tc cond;
   expr2tc body;
   locationt location; // not reflected (see note above)
-  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+  // `#pragma unroll N` count: travels with the loop statement so the
+  // --irep2-bodies round-trip preserves the per-loop unwind bound that
+  // goto_convert later stamps onto the loop's GOTO instruction. Not
+  // reflected, so it stays out of value identity (like `location`).
+  unsigned pragma_unroll_count;
+  static constexpr std::size_t excluded_field_bytes =
+    sizeof(locationt) + sizeof(unsigned);
 
   code_while2t(
     const expr2tc &c,
     const expr2tc &b,
-    const locationt &loc = locationt())
-    : expr2t(get_empty_type(), code_while_id), cond(c), body(b), location(loc)
+    const locationt &loc = locationt(),
+    unsigned pragma = 0)
+    : expr2t(get_empty_type(), code_while_id),
+      cond(c),
+      body(b),
+      location(loc),
+      pragma_unroll_count(pragma)
   {
   }
   code_while2t(const code_while2t &ref) = default;
@@ -2099,13 +2110,21 @@ public:
   expr2tc cond;
   expr2tc body;
   locationt location; // not reflected (see note above)
-  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+  // `#pragma unroll N` count (see code_while2t).
+  unsigned pragma_unroll_count;
+  static constexpr std::size_t excluded_field_bytes =
+    sizeof(locationt) + sizeof(unsigned);
 
   code_dowhile2t(
     const expr2tc &c,
     const expr2tc &b,
-    const locationt &loc = locationt())
-    : expr2t(get_empty_type(), code_dowhile_id), cond(c), body(b), location(loc)
+    const locationt &loc = locationt(),
+    unsigned pragma = 0)
+    : expr2t(get_empty_type(), code_dowhile_id),
+      cond(c),
+      body(b),
+      location(loc),
+      pragma_unroll_count(pragma)
   {
   }
   code_dowhile2t(const code_dowhile2t &ref) = default;
@@ -2125,20 +2144,25 @@ public:
   expr2tc iter; // nil when absent
   expr2tc body;
   locationt location; // not reflected (see note above)
-  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+  // `#pragma unroll N` count (see code_while2t).
+  unsigned pragma_unroll_count;
+  static constexpr std::size_t excluded_field_bytes =
+    sizeof(locationt) + sizeof(unsigned);
 
   code_for2t(
     const expr2tc &i,
     const expr2tc &c,
     const expr2tc &it,
     const expr2tc &b,
-    const locationt &loc = locationt())
+    const locationt &loc = locationt(),
+    unsigned pragma = 0)
     : expr2t(get_empty_type(), code_for_id),
       init(i),
       cond(c),
       iter(it),
       body(b),
-      location(loc)
+      location(loc),
+      pragma_unroll_count(pragma)
   {
   }
   code_for2t(const code_for2t &ref) = default;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -98,6 +98,17 @@ static expr2tc fixup_containerof_in_sizeof(const expr2tc &_expr)
   return compute_pointer_offset(addrof.ptr_obj);
 }
 
+// Read the `#pragma unroll N` count off a loop codet. The clang C frontend
+// stores it as a string irep attribute; goto_convert later turns it into the
+// loop instruction's pragma_unroll_count. Migrating it onto the IREP2 loop
+// kind lets the --irep2-bodies round-trip preserve the per-loop unwind bound
+// (0 = no pragma).
+static unsigned get_pragma_unroll(const exprt &expr)
+{
+  const irep_idt &p = expr.get("#pragma_unroll");
+  return p.empty() ? 0 : std::stoul(p.as_string());
+}
+
 static type2tc migrate_type0(const typet &type)
 {
   if (type.id() == typet::t_bool)
@@ -2316,7 +2327,8 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     expr2tc cond, body;
     migrate_expr(expr.op0(), cond);
     migrate_expr(expr.op1(), body);
-    new_expr_ref = code_while2tc(cond, body, expr.location());
+    new_expr_ref =
+      code_while2tc(cond, body, expr.location(), get_pragma_unroll(expr));
     return;
   }
 
@@ -2325,7 +2337,8 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     expr2tc cond, body;
     migrate_expr(expr.op0(), cond);
     migrate_expr(expr.op1(), body);
-    new_expr_ref = code_dowhile2tc(cond, body, expr.location());
+    new_expr_ref =
+      code_dowhile2tc(cond, body, expr.location(), get_pragma_unroll(expr));
     return;
   }
 
@@ -2352,7 +2365,8 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     migrate_expr(expr.op1(), cond);
     migrate_expr(expr.op2(), iter);
     migrate_expr(expr.op3(), body);
-    new_expr_ref = code_for2tc(init, cond, iter, body, expr.location());
+    new_expr_ref = code_for2tc(
+      init, cond, iter, body, expr.location(), get_pragma_unroll(expr));
     return;
   }
 
@@ -4051,6 +4065,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.op1() = migrate_expr_back(ref2.body);
     if (ref2.location.is_not_nil())
       codeexpr.location() = ref2.location;
+    if (ref2.pragma_unroll_count > 0)
+      codeexpr.set("#pragma_unroll", std::to_string(ref2.pragma_unroll_count));
     return codeexpr;
   }
   case expr2t::code_dowhile_id:
@@ -4063,6 +4079,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.op1() = migrate_expr_back(ref2.body);
     if (ref2.location.is_not_nil())
       codeexpr.location() = ref2.location;
+    if (ref2.pragma_unroll_count > 0)
+      codeexpr.set("#pragma_unroll", std::to_string(ref2.pragma_unroll_count));
     return codeexpr;
   }
   case expr2t::code_for_id:
@@ -4077,6 +4095,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     codeexpr.op3() = migrate_expr_back(ref2.body);
     if (ref2.location.is_not_nil())
       codeexpr.location() = ref2.location;
+    if (ref2.pragma_unroll_count > 0)
+      codeexpr.set("#pragma_unroll", std::to_string(ref2.pragma_unroll_count));
     return codeexpr;
   }
   case expr2t::code_switch_id:


### PR DESCRIPTION
## What

Preserve a loop's `#pragma unroll N` count across the `--irep2-bodies` legacy-codet → IREP2 → codet round-trip.

## Why

Under `--irep2-bodies`, a loop body round-trips `codet -> IREP2 -> codet` before `goto_convert` runs. The clang C frontend stores `#pragma unroll N` as a string irep attribute on the loop codet, which `goto_convert` reads to stamp the loop instruction's `pragma_unroll_count`. The IREP2 loop kinds carried no unroll count, so the pragma was dropped on the round-trip: the loop then ran to its natural bound and a pragma-bounded array access went out of bounds, flipping `pragma_unroll_nested_dowhile_true` to a spurious array-bounds `FAILED` only under the flag.

## How

Mirror the V.4.1 non-reflected `locationt location` pattern: add a non-reflected `unsigned pragma_unroll_count` to `code_while2t`/`code_dowhile2t`/`code_for2t` (excluded from the fields tuple, so out of hash/equality; `excluded_field_bytes` bumped and compile-enforced by `fields_cover_class`), thread it forward in `migrate_expr` and restore the attribute in `migrate_expr_back`. The flag-OFF path is unaffected: an absent pragma migrates to 0 and the back arm's guard re-emits nothing, leaving the codet byte-identical.

## Testing

- New `regression/esbmc/github_4715_irep2_bodies_pragma_unroll_01` (positive, `VERIFICATION SUCCESSFUL`) and `_fail` (negative, `VERIFICATION FAILED`) pin the round-trip both ways under `--irep2-bodies`; the negative variant's in-loop bounds check is the discriminator proving the checker runs over the round-tripped body.
- `pragma_unroll_nested_dowhile_true` — the originally-regressed test — passes again under the flag.
- Full irep2-bodies/pragma sweep (47 tests across C, Python, Solidity, Jimple): 100% pass.

Refs #4715.
