### PR TITLE
[irep2] Restore value-operand locations after the --irep2-bodies round-trip

### DIFF
--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01/main.c
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01/main.c
@@ -1,0 +1,20 @@
+/* Companion to github_4715_irep2_bodies_cond_cov_01_fail: confirms that the
+ * --irep2-bodies value-location back-fill (which runs over every round-tripped
+ * function body) does not perturb the body's semantics. A short-circuit
+ * expression spanning a called function and main still verifies to the same
+ * SUCCESSFUL verdict as the flag-off run. */
+#include <assert.h>
+#include <stdbool.h>
+
+bool both(int a, int b)
+{
+  return (a > 0) && (b > 0);
+}
+
+int main()
+{
+  int a = 2, b = 3;
+  bool r = both(a, b) || (a == b);
+  assert(r);
+  return 0;
+}

--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01/test.desc
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01_fail/main.c
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01_fail/main.c
@@ -1,0 +1,20 @@
+/* Pins --condition-coverage parity under the --irep2-bodies body round-trip.
+ *
+ * `(a > 0) && (b > 0)` is lowered by goto_convert into a tmp/GOTO short-circuit
+ * sequence whose source location is read from the (value-level) operand
+ * expression (goto_sideeffects.cpp). IREP2 value exprs carry no location, so the
+ * legacy->IREP2->legacy body round-trip dropped it; condition_coverage()
+ * (goto_coverage.cpp) then skipped every condition whose file is not the source
+ * file, reporting "Total Conditions: 0" and a spurious VERIFICATION SUCCESSFUL
+ * only under the flag. With the per-statement location re-attached to its value
+ * operands the count matches the flag-off run (6 conditions) and the coverage
+ * goals are reachable (VERIFICATION FAILED). A regression would flip both back
+ * to 0 / SUCCESSFUL. */
+#include <stdbool.h>
+
+int main()
+{
+  int a, b;
+  bool r = (a > 0) && (b > 0);
+  return r ? 0 : 1;
+}

--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01_fail/test.desc
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01_fail/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--condition-coverage --irep2-bodies
+^Reached Conditions:  6
+^Short Circuited Conditions:  0
+^Total Conditions:  6
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/main.cpp
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/main.cpp
@@ -1,6 +1,11 @@
 #include <set>
-#include <cassert>
 
+// __ESBMC_assert (a built-in intrinsic) is used instead of the libc assert
+// macro on purpose: assert lowers to a discarded `cond ? 0 : __assert_fail()`
+// ternary that injects two extra coverage conditions unrelated to this test's
+// subject, inflating the condition counts below. The intrinsic keeps the
+// size check without that noise.
+//
 // Condition coverage over a std::set whose insert() OM contains an internal
 // function-call side effect. Under --irep2-bodies the body round-trip used to
 // leave that side effect unlifted with a nil sub-field; it reached the SMT
@@ -19,6 +24,6 @@ int main()
   if (r2.second)
     s.insert(15);
 
-  assert(s.size() == 2);
+  __ESBMC_assert(s.size() == 2, "set holds two distinct elements");
   return 0;
 }

--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/main.cpp
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/main.cpp
@@ -1,0 +1,24 @@
+#include <set>
+#include <cassert>
+
+// Condition coverage over a std::set whose insert() OM contains an internal
+// function-call side effect. Under --irep2-bodies the body round-trip used to
+// leave that side effect unlifted with a nil sub-field; it reached the SMT
+// backend and crashed in convert_ast (crc() on a nil operand). Restoring the
+// value-operand locations after the round-trip keeps goto_convert's lowering of
+// the if-guards intact, so the side effect is lowered as on the legacy path.
+int main()
+{
+  std::set<int> s;
+
+  std::pair<std::set<int>::iterator, bool> r1 = s.insert(5);
+  if (r1.second)
+    s.insert(10);
+
+  std::pair<std::set<int>::iterator, bool> r2 = s.insert(5);
+  if (r2.second)
+    s.insert(15);
+
+  assert(s.size() == 2);
+  return 0;
+}

--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/test.desc
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.cpp
+--condition-coverage --unwind 4 --no-unwinding-assertions --irep2-bodies
+^Reached Conditions:  4$
+^Short Circuited Conditions:  2$
+^Total Conditions:  6$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/test.desc
+++ b/regression/goto-coverage/github_4715_irep2_bodies_cond_cov_02/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 --condition-coverage --unwind 4 --no-unwinding-assertions --irep2-bodies
-^Reached Conditions:  4$
-^Short Circuited Conditions:  2$
+^Reached Conditions:  6$
+^Short Circuited Conditions:  0$
 ^Total Conditions:  6$
 ^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -94,6 +94,54 @@ void goto_convert_functionst::add_return(
   t->code = code_return2tc(nondet);
 }
 
+// Stamp `loc` onto every value-level sub-expression of `expr` that lacks a
+// source location (used by restore_value_locations below).
+static void stamp_value_locations(exprt &expr, const locationt &loc)
+{
+  // Read this node's OWN location (const overload, non-recursive); the mutable
+  // overload would materialise an empty #location, and find_location() would
+  // descend into operands and report a child's location for this node.
+  const locationt &own = static_cast<const exprt &>(expr).location();
+  if (own.is_nil() || own.get_file().empty())
+    expr.location() = loc;
+
+  Forall_operands (it, expr)
+    stamp_value_locations(*it, loc);
+}
+
+// --irep2-bodies only: IREP2 value-level expressions carry no source location
+// (only the structured-CF code kinds got the V.4.1/V.4.5 non-reflected
+// `location` field). The clang frontends stamp every sub-expression of a
+// statement with that statement's #location, but the legacy->IREP2->legacy body
+// round-trip drops it from the value operands. goto_convert then generates
+// instructions from those operands (e.g. the tmp/GOTO sequence a `&&`/`||`
+// short-circuit lowers to, whose location is read from the operand at
+// goto_sideeffects.cpp:242) with an empty location -- breaking any pass keyed on
+// instruction location, e.g. --condition-coverage skips conditions whose file
+// is not the source file (goto_coverage.cpp:947), reporting 0 conditions and a
+// spurious SUCCESSFUL. Restore the frontend invariant by pushing each
+// statement's location down onto its location-less value operands. Each nested
+// statement governs its own subtree; flag-off uses the legacy body untouched.
+static void restore_value_locations(exprt &code, const locationt &inherited)
+{
+  // This statement's own location (non-recursive const read); falls back to the
+  // enclosing statement's when the round-trip left this node location-less.
+  const locationt &own = static_cast<const exprt &>(code).location();
+  const locationt &here =
+    (own.is_not_nil() && !own.get_file().empty()) ? own : inherited;
+
+  if (here.get_file().empty())
+    return; // no location to propagate yet
+
+  Forall_operands (it, code)
+  {
+    if (it->is_code())
+      restore_value_locations(*it, here);
+    else
+      stamp_value_locations(*it, here);
+  }
+}
+
 void goto_convert_functionst::convert_function(symbolt &symbol)
 {
   irep_idt identifier = symbol.id;
@@ -135,7 +183,12 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   exprt roundtrip_body_storage;
   const bool use_irep2_bodies = options.get_bool_option("irep2-bodies");
   if (use_irep2_bodies)
+  {
     roundtrip_body_storage = migrate_expr_back(symbol.get_value2());
+    // Re-attach the per-statement source locations the round-trip dropped from
+    // value operands, so goto_convert-generated instructions stay located.
+    restore_value_locations(roundtrip_body_storage, locationt());
+  }
   const codet &code = use_irep2_bodies ? to_code(roundtrip_body_storage)
                                        : to_code(symbol.get_value());
 


### PR DESCRIPTION
## What

Restore the per-statement source locations that the `--irep2-bodies` body round-trip drops from value operands, so goto_convert-generated instructions stay located and `--condition-coverage` counts conditions correctly.

## Why

Under `--irep2-bodies`, a function body round-trips legacy `codet` → IREP2 → `codet` before goto_convert runs. IREP2 **value-level** expressions (`and2t`, `equality2t`, …) carry no source location — only the structured-CF *code* kinds got the non-reflected `location` field in V.4.1/V.4.5 — so the `#location` the clang frontends stamp on every sub-expression of a statement is dropped on the round-trip.

goto_convert's short-circuit lowering reads the location of the `tmp`/`GOTO` instructions it emits for `&&`/`||` from the operand sub-expression (`goto_sideeffects.cpp:242`). With an empty operand location, those instructions are unlocated, and `condition_coverage()` (`goto_coverage.cpp:947`) skips every instruction whose filename is not the source file → **Total Conditions 0 → spurious VERIFICATION SUCCESSFUL**, only under `--condition-coverage --irep2-bodies`.

## How

Two file-local static helpers in `goto_convert_functions.cpp` push each code statement's location down onto its location-less value operands, called once right after `migrate_expr_back` — the single `--irep2-bodies` seam. Each nested statement governs its own subtree; only nil/empty-file locations are written, so populated locations are preserved. The pass is flag-gated, so the flag-off legacy path is byte-identical.

Accepted trade-off: lowered sub-instructions inherit the *statement* location (filename + line correct; finer per-operand columns are lost — cosmetic for coverage, minor counterexample-fidelity only).

## Testing

- `github_1999_7` (`--condition-coverage-claims`): ON now reports Total Conditions 10 → FAILED, **identical to flag-off** (was 0 → SUCCESSFUL).
- New `regression/goto-coverage/github_4715_irep2_bodies_cond_cov_01` (functional, `--irep2-bodies`, SUCCESSFUL — guards the back-fill doesn't perturb body semantics) and `_01_fail` (`--condition-coverage --irep2-bodies`, pins Total Conditions 6 + FAILED — a regression flips both back to 0/SUCCESSFUL).
- All 117 `goto-coverage` + 37 `irep2_bodies` tests (C/C++/Python/Solidity/Jimple) and 33 migrate/irep2 unit tests pass; clang-format clean.

Refs #4715.
