### PR TITLE
[docs] theory: accuracy pass + bounded model checking section

### DIFF
--- a/website/content/docs/theory/_index.md
+++ b/website/content/docs/theory/_index.md
@@ -9,7 +9,7 @@ for SMT solvers, and the data structures it is built on.
 
 {{< cards >}}
   {{< card link="/docs/theory/non-determinism" title="Modeling with Non-determinism" subtitle="The primitives ESBMC adds to C for non-deterministic values, assumptions, and atomic blocks." >}}
-  {{< card link="/docs/theory/verification-algorithms" title="Verification Algorithms" subtitle="Falsification, incremental BMC, and k-induction — how ESBMC unwinds loops and proves correctness." >}}
+  {{< card link="/docs/theory/verification-algorithms" title="Verification Algorithms" subtitle="Bounded model checking, falsification, incremental BMC, and k-induction — how ESBMC unwinds loops and proves correctness." >}}
   {{< card link="/docs/theory/counterexample-guided-abstract-refinement" title="Counterexample-Guided Abstraction Refinement" subtitle="Integer vs. bit-vector encodings and how ESBMC refines the abstraction." >}}
   {{< card link="/docs/theory/smt-formula-generation" title="SMT Formula Generation" subtitle="How symbolic execution turns a program into SSA and then into an SMT formula." >}}
   {{< card link="/docs/theory/ltl" title="Linear Temporal Logic" subtitle="LTL property checking via Büchi automata over finite prefixes." >}}

--- a/website/content/docs/theory/non-determinism.md
+++ b/website/content/docs/theory/non-determinism.md
@@ -8,26 +8,33 @@ non-determinism and constraining the explored state space.
 
 ## Modeling primitives
 
-`__ESBMC_assert(e, msg)` aborts execution when `e` is false:
+`__ESBMC_assert(cond, msg)` reports a property violation when `cond` is false:
 
 ```c
-void __ESBMC_assert(e, "some message here");
+void __ESBMC_assert(_Bool cond, const char *msg);
+
+__ESBMC_assert(x > 0, "x must be positive");
 ```
 
-`nondet_X()` returns a non-deterministic value of type `X`, where `X` is one of
-`bool`, `char`, `int`, `float`, `double`, `loff_t`, `long`, `pchar`,
-`pthread_t`, `sector_t`, `short`, `size_t`, `u32`, `uchar`, `uint`, `ulong`,
-`unsigned`, `ushort` (no side effects). ESBMC assumes these are implemented as:
+`nondet_X()` returns a non-deterministic, side-effect-free value of type `X`.
+ESBMC forward-declares a convenience set where `X` is one of `bool`, `char`,
+`schar`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`,
+`double`, conceptually defined as:
 
 ```c
 X nondet_X() { X val; return val; }
 ```
 
+The same functions are also available under the SV-COMP `__VERIFIER_nondet_X`
+spelling. More generally, **any function whose body is unavailable returns a
+fresh non-deterministic value of its return type**, so an external function that
+is declared but not defined behaves like a `nondet_` call.
+
 `__ESBMC_assume(e)` ignores the current execution when `e` is false, and is a
-no-op otherwise:
+no-op otherwise (also available as `__VERIFIER_assume`):
 
 ```c
-void __ESBMC_assume(e);
+void __ESBMC_assume(_Bool e);
 ```
 
 `__ESBMC_atomic_begin()` / `__ESBMC_atomic_end()` model the atomic execution of

--- a/website/content/docs/theory/smt-formula-generation.md
+++ b/website/content/docs/theory/smt-formula-generation.md
@@ -52,12 +52,12 @@ esbmc file.c --z3 --smt-formula-only --output formula.smt2
 # Bitwuzla native format
 esbmc file.c --bitwuzla --smt-formula-only --output formula.smt2
 
-# Similarly: --boolector, --yices, --mathsat, --cvc4
+# Similarly: --boolector, --yices, --mathsat, --cvc4, --cvc5
 ```
 
 The `--smtlib` output is the most portable option — it follows the SMT-LIB v2
-standard and is accepted by all compliant solvers, including CVC5, even though
-ESBMC does not yet have a built-in CVC5 backend.
+standard and is accepted by any compliant solver, including external tools for
+which ESBMC has no built-in backend.
 
 ## About Formula Size
 

--- a/website/content/docs/theory/verification-algorithms.md
+++ b/website/content/docs/theory/verification-algorithms.md
@@ -7,6 +7,28 @@ ESBMC implements several incremental verification strategies on top of its
 symbolic execution engine. This page explains how each works; for the practical
 flags and when to use them, see the [Usage](/docs/usage) guide.
 
+## Bounded Model Checking {#bmc}
+
+```sh
+esbmc file.c --unwind K
+```
+
+Plain bounded model checking is the foundation the strategies below build on.
+ESBMC symbolically executes the program, unrolling each loop at most *K* times,
+encodes the resulting [SSA program and safety properties as a single SMT
+formula](/docs/theory/smt-formula-generation), and asks the solver whether any
+property can be violated. A satisfiable formula yields a counterexample; an
+unsatisfiable one means no property is violated *within the bound K*.
+
+Because a fixed bound can cut a loop short, ESBMC adds an **unwinding assertion**
+after each loop that fails if the loop needed more than *K* iterations — so an
+incompletely unrolled loop is reported rather than silently assumed safe. This
+makes a `VERIFICATION SUCCESSFUL` under `--unwind K` a *bounded* proof. The
+checks can be relaxed with `--no-unwinding-assertions` (turn unwinding
+assertions into assumptions) or `--partial-loops` (permit partial loop paths),
+and per-loop bounds can be set with `--unwindset L:nr`. The strategies below
+remove the need to pick *K* by hand by iterating the bound automatically.
+
 ## Falsification {#falsification}
 
 ```sh
@@ -15,7 +37,8 @@ esbmc file.c --falsification
 
 The falsification approach uses an iterative technique and verifies the program
 for each unwind bound up to a maximum default value of 50 (changeable via
-`--max-k-step N`), or indefinitely (until it exhausts the time or memory limit).
+`--max-k-step N`, or `--unlimited-k-steps` to run until it exhausts the time or
+memory limit).
 The goal is to find a counterexample with up to *k* loop unwindings; the
 symbolic execution engine increasingly unwinds the loop after each iteration.
 
@@ -36,8 +59,9 @@ esbmc file.c --incremental-bmc
 ```
 
 Incremental BMC also iterates over unwind bounds (default max 50, via
-`--max-k-step N`, or indefinitely). It either finds a counterexample within *k*
-unwindings or fully unwinds all loops to provide a correctness result.
+`--max-k-step N`, or `--unlimited-k-steps`). It either finds a counterexample
+within *k* unwindings or fully unwinds all loops to provide a correctness
+result.
 
 The approach has two steps. When searching for a property violation it replaces
 unwinding assertions with assumptions (reporting an unwinding-assertion failure


### PR DESCRIPTION
## What

Accuracy pass over the Theory section plus a small expansion, all verified against the current source. Pure Hugo-markdown changes — no code.

## Accuracy fixes

- **SMT formula generation** — ESBMC now has a CVC5 backend (`src/solvers/cvc5/`, `--cvc5`); removed the stale "no built-in CVC5 backend" claim and added `--cvc5` to the solver-format list.
- **Non-determinism**:
  - Corrected the malformed `__ESBMC_assert` prototype to the real signature `void __ESBMC_assert(_Bool, const char *)` with a usage example.
  - Replaced the stale `nondet_X` type list (`loff_t`, `pchar`, `sector_t`, `u32`, …) with the set ESBMC actually forward-declares (`clang_c_language.cpp`).
  - Noted the SV-COMP `__VERIFIER_nondet_X` / `__VERIFIER_assume` aliases and the general rule that any body-less function returns a fresh nondet value (`symex_function.cpp`).

## Light expansion

- **Verification Algorithms** — added a foundational **Bounded Model Checking** section (`--unwind`, unwinding assertions, `--no-unwinding-assertions`, `--partial-loops`, `--unwindset`) that the falsification / incremental-BMC / k-induction strategies build on; documented `--unlimited-k-steps`; updated the index card subtitle.

All referenced flags and primitives were checked against `src/esbmc/options.cpp` and the frontend before writing.