### PR TITLE
[docs] theory: add memory model, concurrency, intervals, contracts

### DIFF
--- a/website/content/docs/theory/_index.md
+++ b/website/content/docs/theory/_index.md
@@ -10,6 +10,10 @@ for SMT solvers, and the data structures it is built on.
 {{< cards >}}
   {{< card link="/docs/theory/non-determinism" title="Modeling with Non-determinism" subtitle="The primitives ESBMC adds to C for non-deterministic values, assumptions, and atomic blocks." >}}
   {{< card link="/docs/theory/verification-algorithms" title="Verification Algorithms" subtitle="Bounded model checking, falsification, incremental BMC, and k-induction — how ESBMC unwinds loops and proves correctness." >}}
+  {{< card link="/docs/theory/memory-model" title="Memory Model and Pointer Safety" subtitle="How ESBMC models pointers as object + offset and derives bounds, NULL, use-after-free, and leak checks." >}}
+  {{< card link="/docs/theory/concurrency" title="Concurrency and Context-Bounded MC" subtitle="Thread interleavings, context bounding, partial-order reduction, and data-race / deadlock detection." >}}
+  {{< card link="/docs/theory/interval-analysis" title="Interval Analysis" subtitle="Abstract interpretation that infers variable ranges and injects them as assumptions before SMT solving." >}}
+  {{< card link="/docs/theory/function-contracts" title="Function Contracts" subtitle="Modular assume-guarantee verification with requires / ensures / assigns and loop contracts." >}}
   {{< card link="/docs/theory/counterexample-guided-abstract-refinement" title="Counterexample-Guided Abstraction Refinement" subtitle="Integer vs. bit-vector encodings and how ESBMC refines the abstraction." >}}
   {{< card link="/docs/theory/smt-formula-generation" title="SMT Formula Generation" subtitle="How symbolic execution turns a program into SSA and then into an SMT formula." >}}
   {{< card link="/docs/theory/ltl" title="Linear Temporal Logic" subtitle="LTL property checking via Büchi automata over finite prefixes." >}}

--- a/website/content/docs/theory/concurrency.md
+++ b/website/content/docs/theory/concurrency.md
@@ -1,0 +1,86 @@
+---
+title: Concurrency and Context-Bounded Model Checking
+weight: 25
+---
+
+The "CB" in ESBMC stands for **context-bounded**: when verifying multi-threaded
+programs, ESBMC explores thread interleavings up to a bounded number of context
+switches. This page explains how concurrent programs are modelled and which
+properties are checked.
+
+## Interleavings as symbolic schedules
+
+ESBMC models a concurrent program (POSIX threads, and the language frontends
+that lower onto them) as a set of threads whose instructions interleave.
+Verification explores the reachable **schedules** — orderings of the threads'
+visible operations — and for each schedule it builds the usual
+[SSA / SMT encoding](/docs/theory/smt-formula-generation) and checks every
+safety property. A property is violated if *some* interleaving reaches a bad
+state.
+
+The number of interleavings grows combinatorially with the number of threads
+and operations, so ESBMC controls the explosion in three complementary ways.
+
+## Bounding the context switches
+
+```sh
+esbmc file.c --context-bound K
+```
+
+A *context switch* is a point where execution passes from one thread to another.
+`--context-bound K` limits each thread to at most *K* switches, restricting the
+search to schedules with few preemptions. This is the context-bounding idea: in
+practice, many concurrency bugs manifest within a small number of context
+switches, so a small bound finds them cheaply while keeping the formula
+tractable. The default is unbounded (`-1`).
+
+## Partial-order reduction
+
+Many interleavings differ only in the order of operations that do not interact
+(for example, two threads touching disjoint memory) and therefore lead to
+equivalent states. **Partial-order reduction (POR)** prunes such redundant
+schedules, exploring one representative per equivalence class. POR is on by
+default; disable it with `--no-por` (for example, to cross-check that the
+reduction is not hiding a schedule).
+
+## State hashing
+
+```sh
+esbmc file.c --state-hashing
+```
+
+State hashing records a fingerprint of each explored state and skips
+re-exploring states already seen, pruning duplicate work across interleavings.
+
+By default ESBMC stops at the first interleaving that violates a property; pass
+`--all-runs` to keep checking the remaining interleavings even after a bug is
+found.
+
+## Atomic blocks
+
+The modeling primitives `__ESBMC_atomic_begin()` / `__ESBMC_atomic_end()` mark a
+region that executes without interruption from other threads, suppressing
+context switches inside it (see
+[Modeling with Non-determinism](/docs/theory/non-determinism)).
+
+## Concurrency properties
+
+Beyond the usual assertions and memory-safety checks (which apply per
+interleaving), ESBMC offers concurrency-specific checks:
+
+| Check | Flag |
+|---|---|
+| Data races (unsynchronised conflicting accesses to shared state) | `--data-races-check` |
+| Deadlock (global and local, over mutexes) | `--deadlock-check` |
+| Lock-acquisition ordering | `--lock-order-check` |
+| Atomicity at visible assignments | `--atomicity-check` |
+
+`--data-races-check-only` narrows the run to race checks to reduce overhead.
+
+## Soundness note
+
+The bounds above are search-space reductions, not approximations of the
+semantics within the explored schedules: a counterexample ESBMC reports is a
+real interleaving. A clean result, however, is relative to the chosen context
+bound — increasing `--context-bound` (or removing it) explores deeper schedules
+at higher cost.

--- a/website/content/docs/theory/concurrency.md
+++ b/website/content/docs/theory/concurrency.md
@@ -19,7 +19,10 @@ safety property. A property is violated if *some* interleaving reaches a bad
 state.
 
 The number of interleavings grows combinatorially with the number of threads
-and operations, so ESBMC controls the explosion in three complementary ways.
+and operations — for *n* threads performing *k₁, …, kₙ* operations it is the
+multinomial coefficient `(k₁ + … + kₙ)! / (k₁! ⋯ kₙ!)` — so ESBMC controls the
+explosion in three complementary ways: bounding context switches [2],
+partial-order reduction [3], and state hashing.
 
 ## Bounding the context switches
 
@@ -29,8 +32,8 @@ esbmc file.c --context-bound K
 
 A *context switch* is a point where execution passes from one thread to another.
 `--context-bound K` limits each thread to at most *K* switches, restricting the
-search to schedules with few preemptions. This is the context-bounding idea: in
-practice, many concurrency bugs manifest within a small number of context
+search to schedules with few preemptions. This is the context-bounding idea [2]:
+in practice, many concurrency bugs manifest within a small number of context
 switches, so a small bound finds them cheaply while keeping the formula
 tractable. The default is unbounded (`-1`).
 
@@ -38,7 +41,7 @@ tractable. The default is unbounded (`-1`).
 
 Many interleavings differ only in the order of operations that do not interact
 (for example, two threads touching disjoint memory) and therefore lead to
-equivalent states. **Partial-order reduction (POR)** prunes such redundant
+equivalent states. **Partial-order reduction (POR)** [3] prunes such redundant
 schedules, exploring one representative per equivalence class. POR is on by
 default; disable it with `--no-por` (for example, to cross-check that the
 reduction is not hiding a schedule).
@@ -90,3 +93,11 @@ at higher cost.
 [1] Lucas C. Cordeiro, Bernd Fischer: *Verifying multi-threaded software using
 SMT-based context-bounded model checking.* ICSE 2011: 331–340.
 [doi:10.1145/1985793.1985839](https://doi.org/10.1145/1985793.1985839)
+
+[2] Shaz Qadeer, Jakob Rehof: *Context-Bounded Model Checking of Concurrent
+Software.* TACAS 2005, LNCS 3440: 93–107.
+[doi:10.1007/978-3-540-31980-1_7](https://doi.org/10.1007/978-3-540-31980-1_7)
+
+[3] Cormac Flanagan, Patrice Godefroid: *Dynamic partial-order reduction for
+model checking software.* POPL 2005: 110–121.
+[doi:10.1145/1040305.1040315](https://doi.org/10.1145/1040305.1040315)

--- a/website/content/docs/theory/concurrency.md
+++ b/website/content/docs/theory/concurrency.md
@@ -5,7 +5,7 @@ weight: 25
 
 The "CB" in ESBMC stands for **context-bounded**: when verifying multi-threaded
 programs, ESBMC explores thread interleavings up to a bounded number of context
-switches. This page explains how concurrent programs are modelled and which
+switches [1]. This page explains how concurrent programs are modelled and which
 properties are checked.
 
 ## Interleavings as symbolic schedules
@@ -84,3 +84,9 @@ semantics within the explored schedules: a counterexample ESBMC reports is a
 real interleaving. A clean result, however, is relative to the chosen context
 bound — increasing `--context-bound` (or removing it) explores deeper schedules
 at higher cost.
+
+## References
+
+[1] Lucas C. Cordeiro, Bernd Fischer: *Verifying multi-threaded software using
+SMT-based context-bounded model checking.* ICSE 2011: 331–340.
+[doi:10.1145/1985793.1985839](https://doi.org/10.1145/1985793.1985839)

--- a/website/content/docs/theory/function-contracts.md
+++ b/website/content/docs/theory/function-contracts.md
@@ -12,10 +12,20 @@ annotation syntax, command-line flags, worked examples, and limitations, see the
 ## The assume-guarantee principle
 
 A contract states what a function *assumes* of its callers (a precondition) and
-what it *guarantees* in return (a postcondition), together with a frame
-condition naming the locations it may modify. Given such a contract, a function
-is verified **once** against its specification, and every call to it is then
-replaced by that specification rather than re-analysed.
+what it *guarantees* in return (a postcondition), together with a **frame
+condition**. Given such a contract, a function is verified **once** against its
+specification, and every call to it is then replaced by that specification
+rather than re-analysed.
+
+A *frame condition* names the locations an operation is allowed to modify and —
+crucially — asserts that **every other location is left unchanged**. In a
+contract it is the `assigns` (or `modifies`) clause: `__ESBMC_assigns(x)` says
+"this call may change `x` and nothing else." The "nothing else" half is what
+makes contracts useful — it lets a caller keep everything it already knew about
+the rest of the state across the call, and it is exactly what `replace` mode
+relies on when it havocs *only* the listed locations. The need to state this
+explicitly (rather than leaving "what does not change" implicit) is the *frame
+problem* in procedure specifications [1].
 
 This decomposes a single whole-program proof into independent per-function
 obligations:
@@ -44,7 +54,9 @@ The same assume-guarantee idea applies to loops: a **loop invariant** plus a
 loop frame condition lets ESBMC summarise a loop instead of unrolling it,
 turning a bounded check into an inductive one — closely related to
 [k-induction](/docs/theory/verification-algorithms#k-induction) and detailed in
-the [Loop Invariants](/docs/loop-invariants) guide.
+the [Loop Invariants](/docs/loop-invariants) guide. The "everything else is
+unchanged" guarantee a frame condition provides is the contract-level analogue
+of the *frame rule* in separation logic [2].
 
 ## See also
 
@@ -52,3 +64,13 @@ the [Loop Invariants](/docs/loop-invariants) guide.
   `--enforce-contract` / `--replace-call-with-contract`, quantifiers,
   `__ESBMC_is_fresh`, and known limitations.
 - [Loop Invariants](/docs/loop-invariants) — loop contracts and the frame rule.
+
+## References
+
+[1] Alexander Borgida, John Mylopoulos, Raymond Reiter: *On the Frame Problem in
+Procedure Specifications.* IEEE Trans. Software Eng. 21(10):785–798, 1995.
+[doi:10.1109/32.469460](https://doi.org/10.1109/32.469460)
+
+[2] John C. Reynolds: *Separation Logic: A Logic for Shared Mutable Data
+Structures.* LICS 2002: 55–74.
+[doi:10.1109/LICS.2002.1029817](https://doi.org/10.1109/LICS.2002.1029817)

--- a/website/content/docs/theory/function-contracts.md
+++ b/website/content/docs/theory/function-contracts.md
@@ -3,84 +3,52 @@ title: Function Contracts and Modular Verification
 weight: 35
 ---
 
-Contracts let you specify *what* a function guarantees instead of re-verifying
-*how* it is implemented at every call site. ESBMC uses contracts for **modular
-(assume-guarantee) verification**: a function is checked once against its
-contract, and its calls are then replaced by the contract — turning a
-whole-program proof into a set of smaller, independent ones.
+Contracts are the basis of **modular (assume-guarantee) verification** in ESBMC.
+This page explains the underlying principle and how it fits the other
+[verification algorithms](/docs/theory/verification-algorithms); for the full
+annotation syntax, command-line flags, worked examples, and limitations, see the
+[**Function Contracts** how-to guide](/docs/function-contracts).
 
-## Specifying a contract
+## The assume-guarantee principle
 
-A function is marked for contract processing with the `__ESBMC_contract` macro,
-and its clauses are written with intrinsics in the body. These are always
-declared, so an annotated file still compiles in plain BMC mode (where the
-clauses are dropped as no-ops) and only become active under the contract flags
-below:
+A contract states what a function *assumes* of its callers (a precondition) and
+what it *guarantees* in return (a postcondition), together with a frame
+condition naming the locations it may modify. Given such a contract, a function
+is verified **once** against its specification, and every call to it is then
+replaced by that specification rather than re-analysed.
 
-```c
-#include <limits.h>
+This decomposes a single whole-program proof into independent per-function
+obligations:
 
-__ESBMC_contract
-int abs_val(int x)
-{
-  __ESBMC_requires(x > INT_MIN);              // precondition (−INT_MIN overflows)
-  __ESBMC_ensures(__ESBMC_return_value >= 0); // postcondition
-  __ESBMC_assigns();                          // frame: modifies nothing
-  return x < 0 ? -x : x;
-}
-```
+- **Enforce** — assume the precondition, run the body, assert the postcondition
+  and frame. This discharges "the implementation meets its contract."
+- **Replace** — at a call site, assert the precondition, havoc the frame, and
+  assume the postcondition. This lets a caller be verified against the
+  *specification* of its callees, without unrolling their bodies.
 
-The contract vocabulary:
+Enforcing each function once and replacing it everywhere it is called yields a
+proof whose cost does not blow up with call depth — the key scalability win over
+inlining everything into one [bounded model checking](/docs/theory/verification-algorithms#bmc)
+query.
 
-| Intrinsic | Meaning |
-|---|---|
-| `__ESBMC_requires(cond)` | Precondition assumed on entry / asserted at calls |
-| `__ESBMC_ensures(cond)` | Postcondition guaranteed on return |
-| `__ESBMC_return_value` | The function's return value, for use in `ensures` |
-| `__ESBMC_old(x)` | The pre-state value of `x`, for relating output to input |
-| `__ESBMC_assigns(a, b, …)` | Frame condition: the only locations the function may modify |
+## Relationship to the other algorithms
 
-## Two modes
+Function contracts are an *over-approximation*: replacing a call with its
+contract admits any behaviour the postcondition permits, which may be more than
+the concrete body produces. This is sound for proofs but, like any
+abstraction, can yield spurious counterexamples if a contract is too weak —
+tightening the `ensures`/`assigns` clauses recovers precision. (The how-to
+guide's *Replace mode is an over-approximation* note covers this in practice.)
 
-**Enforce** a contract — prove the implementation satisfies it:
+The same assume-guarantee idea applies to loops: a **loop invariant** plus a
+loop frame condition lets ESBMC summarise a loop instead of unrolling it,
+turning a bounded check into an inductive one — closely related to
+[k-induction](/docs/theory/verification-algorithms#k-induction) and detailed in
+the [Loop Invariants](/docs/loop-invariants) guide.
 
-```sh
-esbmc file.c --enforce-contract abs_val
-```
+## See also
 
-ESBMC assumes `requires`, runs the body, and asserts `ensures` and the
-`assigns` frame on every path. `--enforce-all-contracts` enforces every
-annotated function.
-
-**Replace** calls with a contract — use it as a summary at call sites:
-
-```sh
-esbmc file.c --replace-call-with-contract abs_val
-```
-
-Each call to `abs_val` is replaced by: assert its `requires`, havoc the
-locations in its `assigns`, and assume its `ensures`. The callee's body is not
-re-explored, so a caller is verified against the *specification* of its callees.
-Combining the two modes — enforce each function once, replace it everywhere it
-is called — gives a modular proof whose cost does not blow up with call depth.
-
-## Loop contracts
-
-The same idea applies to loops, replacing unbounded unwinding with an inductive
-argument:
-
-```c
-__ESBMC_loop_invariant(i >= 0 && i <= n);
-__ESBMC_loop_assigns(i, sum);
-for (i = 0; i < n; i++) sum += a[i];
-```
-
-`__ESBMC_loop_invariant` states a property preserved by every iteration;
-`__ESBMC_loop_assigns` declares which locations the loop may change, so
-everything else is known unchanged across it. Loop invariants are applied with
-`--loop-invariant` (a combined loop-invariant + k-induction mode), and the
-`assigns` frame rule with `--loop-frame-rule` (which requires
-`--loop-invariant-check`). A valid invariant lets ESBMC summarise the loop
-instead of unrolling it, which — like
-[k-induction](/docs/theory/verification-algorithms#k-induction) — can prove
-programs whose loop bounds are not statically fixed.
+- [Function Contracts how-to guide](/docs/function-contracts) — syntax,
+  `--enforce-contract` / `--replace-call-with-contract`, quantifiers,
+  `__ESBMC_is_fresh`, and known limitations.
+- [Loop Invariants](/docs/loop-invariants) — loop contracts and the frame rule.

--- a/website/content/docs/theory/function-contracts.md
+++ b/website/content/docs/theory/function-contracts.md
@@ -1,0 +1,86 @@
+---
+title: Function Contracts and Modular Verification
+weight: 35
+---
+
+Contracts let you specify *what* a function guarantees instead of re-verifying
+*how* it is implemented at every call site. ESBMC uses contracts for **modular
+(assume-guarantee) verification**: a function is checked once against its
+contract, and its calls are then replaced by the contract — turning a
+whole-program proof into a set of smaller, independent ones.
+
+## Specifying a contract
+
+A function is marked for contract processing with the `__ESBMC_contract` macro,
+and its clauses are written with intrinsics in the body. These are always
+declared, so an annotated file still compiles in plain BMC mode (where the
+clauses are dropped as no-ops) and only become active under the contract flags
+below:
+
+```c
+#include <limits.h>
+
+__ESBMC_contract
+int abs_val(int x)
+{
+  __ESBMC_requires(x > INT_MIN);              // precondition (−INT_MIN overflows)
+  __ESBMC_ensures(__ESBMC_return_value >= 0); // postcondition
+  __ESBMC_assigns();                          // frame: modifies nothing
+  return x < 0 ? -x : x;
+}
+```
+
+The contract vocabulary:
+
+| Intrinsic | Meaning |
+|---|---|
+| `__ESBMC_requires(cond)` | Precondition assumed on entry / asserted at calls |
+| `__ESBMC_ensures(cond)` | Postcondition guaranteed on return |
+| `__ESBMC_return_value` | The function's return value, for use in `ensures` |
+| `__ESBMC_old(x)` | The pre-state value of `x`, for relating output to input |
+| `__ESBMC_assigns(a, b, …)` | Frame condition: the only locations the function may modify |
+
+## Two modes
+
+**Enforce** a contract — prove the implementation satisfies it:
+
+```sh
+esbmc file.c --enforce-contract abs_val
+```
+
+ESBMC assumes `requires`, runs the body, and asserts `ensures` and the
+`assigns` frame on every path. `--enforce-all-contracts` enforces every
+annotated function.
+
+**Replace** calls with a contract — use it as a summary at call sites:
+
+```sh
+esbmc file.c --replace-call-with-contract abs_val
+```
+
+Each call to `abs_val` is replaced by: assert its `requires`, havoc the
+locations in its `assigns`, and assume its `ensures`. The callee's body is not
+re-explored, so a caller is verified against the *specification* of its callees.
+Combining the two modes — enforce each function once, replace it everywhere it
+is called — gives a modular proof whose cost does not blow up with call depth.
+
+## Loop contracts
+
+The same idea applies to loops, replacing unbounded unwinding with an inductive
+argument:
+
+```c
+__ESBMC_loop_invariant(i >= 0 && i <= n);
+__ESBMC_loop_assigns(i, sum);
+for (i = 0; i < n; i++) sum += a[i];
+```
+
+`__ESBMC_loop_invariant` states a property preserved by every iteration;
+`__ESBMC_loop_assigns` declares which locations the loop may change, so
+everything else is known unchanged across it. Loop invariants are applied with
+`--loop-invariant` (a combined loop-invariant + k-induction mode), and the
+`assigns` frame rule with `--loop-frame-rule` (which requires
+`--loop-invariant-check`). A valid invariant lets ESBMC summarise the loop
+instead of unrolling it, which — like
+[k-induction](/docs/theory/verification-algorithms#k-induction) — can prove
+programs whose loop bounds are not statically fixed.

--- a/website/content/docs/theory/interval-analysis.md
+++ b/website/content/docs/theory/interval-analysis.md
@@ -4,7 +4,7 @@ weight: 30
 ---
 
 Interval analysis is an [abstract interpretation](https://en.wikipedia.org/wiki/Abstract_interpretation)
-ESBMC can run *before* SMT solving. It infers a conservative range for each
+ESBMC can run *before* SMT solving [1]. It infers a conservative range for each
 integer and floating-point variable at each program point and injects those
 ranges back into the program as assumptions, shrinking the state space the
 solver has to explore.
@@ -60,3 +60,11 @@ only forward-propagating ranges, it *contracts* variable domains against the
 assertion condition at the GOTO level (using interval contractors), tightening
 the values that could violate a property. It targets the assertions directly,
 whereas `--interval-analysis` strengthens the whole program.
+
+## References
+
+[1] Rafael Sá Menezes, Mohannad Aldughaim, Bruno Farias, Xianzhiyu Li, Edoardo
+Manino, Fedor Shmarov, Kunjian Song, Franz Brauße, Mikhail R. Gadelha, Norbert
+Tihanyi, Konstantin Korovin, Lucas C. Cordeiro: *ESBMC v7.4: Harnessing the
+Power of Intervals (Competition Contribution).* TACAS 2024, LNCS 14572: 376–380.
+[doi:10.1007/978-3-031-57256-2_24](https://doi.org/10.1007/978-3-031-57256-2_24)

--- a/website/content/docs/theory/interval-analysis.md
+++ b/website/content/docs/theory/interval-analysis.md
@@ -1,0 +1,62 @@
+---
+title: Interval Analysis
+weight: 30
+---
+
+Interval analysis is an [abstract interpretation](https://en.wikipedia.org/wiki/Abstract_interpretation)
+ESBMC can run *before* SMT solving. It infers a conservative range for each
+integer and floating-point variable at each program point and injects those
+ranges back into the program as assumptions, shrinking the state space the
+solver has to explore.
+
+## How it works
+
+```sh
+esbmc file.c --interval-analysis
+```
+
+The analysis computes, for every variable, an interval `[lo, hi]` that
+over-approximates the set of values the variable can hold at a given location.
+Because it is an over-approximation, the inferred bounds are always sound: the
+real value is guaranteed to lie within the interval, though the interval may be
+wider than necessary.
+
+ESBMC then adds the discovered facts to the program as `__ESBMC_assume`
+constraints. These assumptions cannot remove real behaviours (they only restate
+what the abstract domain already proved), but they give the SMT backend tighter
+bounds up front — often pruning infeasible paths and resolving some properties
+without a full bit-precise search. Interval analysis composes with the
+[verification algorithms](/docs/theory/verification-algorithms): the assumptions
+it injects are present in the BMC, falsification, incremental-BMC, and
+k-induction encodings alike, and tighter ranges can in particular help
+k-induction's inductive step converge.
+
+## Tuning the domain
+
+The base analysis covers linear behaviour; several flags extend or instrument
+it:
+
+- `--interval-analysis-arithmetic` — track ranges through arithmetic operations
+- `--interval-analysis-bitwise` — reason about bitwise operations
+- `--interval-analysis-modular` — model wrap-around (modular) integer arithmetic
+- `--interval-analysis-wrapped` — use wrapped (modular) interval domains
+- `--interval-analysis-simplify` — simplify the program using inferred intervals
+- `--interval-analysis-extrapolate` / `--interval-analysis-narrowing` — widening
+  and narrowing to make fixpoint computation over loops terminate and then
+  recover precision
+
+Use `--interval-analysis-dump` (or `--interval-analysis-csv-dump`) to print the
+intervals the analysis inferred, which is useful for understanding why a path
+was or was not pruned.
+
+## Related: the goto contractor
+
+```sh
+esbmc file.c --goto-contractor
+```
+
+The goto contractor is a related, constraint-propagation technique: rather than
+only forward-propagating ranges, it *contracts* variable domains against the
+assertion condition at the GOTO level (using interval contractors), tightening
+the values that could violate a property. It targets the assertions directly,
+whereas `--interval-analysis` strengthens the whole program.

--- a/website/content/docs/theory/memory-model.md
+++ b/website/content/docs/theory/memory-model.md
@@ -5,7 +5,7 @@ weight: 15
 
 ESBMC verifies pointer-manipulating programs by giving every pointer a precise
 symbolic meaning and checking each dereference against the state of the memory
-it refers to. This page explains how pointers are modelled and which safety
+it refers to [1]. This page explains how pointers are modelled and which safety
 properties ESBMC derives from that model.
 
 ## Pointers as object + offset
@@ -75,3 +75,10 @@ ESBMC models the lifetimes of all dynamically allocated objects, a large part of
 a generated [SMT formula](/docs/theory/smt-formula-generation) is pointer-safety
 bookkeeping rather than program arithmetic — see *About Formula Size* on the SMT
 page.
+
+## References
+
+[1] Lucas C. Cordeiro, Bernd Fischer, João Marques-Silva: *SMT-Based Bounded
+Model Checking for Embedded ANSI-C Software.* IEEE Trans. Software Eng.
+38(4):957–974, 2012. The paper describes ESBMC's SMT encoding of pointers,
+arrays, structures, and unions. [doi:10.1109/TSE.2011.59](https://doi.org/10.1109/TSE.2011.59)

--- a/website/content/docs/theory/memory-model.md
+++ b/website/content/docs/theory/memory-model.md
@@ -1,0 +1,77 @@
+---
+title: Memory Model and Pointer Safety
+weight: 15
+---
+
+ESBMC verifies pointer-manipulating programs by giving every pointer a precise
+symbolic meaning and checking each dereference against the state of the memory
+it refers to. This page explains how pointers are modelled and which safety
+properties ESBMC derives from that model.
+
+## Pointers as object + offset
+
+ESBMC does not model a pointer as a flat machine address. Instead, each pointer
+value is a pair:
+
+- an **object** — which allocated entity (a variable, an array, a heap block,
+  or the special *invalid* / *NULL* object) the pointer refers to, and
+- an **offset** — the byte displacement into that object.
+
+Two intrinsics expose the two components and are used internally throughout the
+encoding:
+
+```c
+unsigned __ESBMC_POINTER_OBJECT(const void *p);  // which object p points at
+signed   __ESBMC_POINTER_OFFSET(const void *p);  // byte offset into that object
+```
+
+Pointer arithmetic moves the offset while keeping the object fixed, so
+`p + i` and `p` always share an object. This object/offset split is what lets
+ESBMC reason about spatial safety symbolically: a dereference is in bounds iff
+its offset lies within the size of its object.
+
+## Dynamic allocation and lifetimes
+
+Heap allocation (`malloc`, `calloc`, `realloc`, C++ `new`) creates a fresh
+dynamic object. ESBMC tracks each object's allocation state in internal
+bookkeeping (the `__ESBMC_alloc` map and the `__ESBMC_is_dynamic` predicate),
+so it knows at every program point whether an object is live, already freed, or
+never allocated. `free`/`delete` mark the object deallocated; a later access
+through a pointer to it is then a use-after-free.
+
+By default ESBMC also explores the possibility that an allocation *fails*
+(returns `NULL`), so code that dereferences the result without checking is
+flagged. This can be tuned:
+
+- `--force-malloc-success` — assume allocation never fails
+- `--malloc-zero-is-null` — model `malloc(0)` as returning `NULL`
+
+## Properties checked
+
+From the model above, ESBMC derives the standard spatial and temporal
+memory-safety properties. The relevant checks are on by default (the flags below
+*disable* them) except memory-leak detection, which is opt-in:
+
+| Property | Disable with |
+|---|---|
+| Array / buffer bounds | `--no-bounds-check` |
+| Pointer dereference validity (NULL, invalid, out-of-object, use-after-free) | `--no-pointer-check` |
+| Pointer alignment | `--no-align-check` |
+| Relational comparison of pointers into different objects | `--no-pointer-relation-check` |
+
+`free`-specific diagnostics include freeing a pointer with a non-zero offset
+("Operand of free must have zero pointer offset"), freeing an invalid or
+already-freed pointer ("invalid pointer freed", double free), and freeing
+non-dynamic storage.
+
+Memory-leak detection is enabled with `--memory-leak-check`: a dynamic object
+that is still reachable-but-unfreed (or unreachable, "forgotten memory") at the
+end of `main` is reported.
+
+## Why formulas are pointer-heavy
+
+Because every dereference carries an object identity and an offset, and because
+ESBMC models the lifetimes of all dynamically allocated objects, a large part of
+a generated [SMT formula](/docs/theory/smt-formula-generation) is pointer-safety
+bookkeeping rather than program arithmetic — see *About Formula Size* on the SMT
+page.

--- a/website/content/docs/theory/smt-formula-generation.md
+++ b/website/content/docs/theory/smt-formula-generation.md
@@ -6,7 +6,7 @@ weight: 10
 ## Overview
 
 ESBMC works by encoding a program's safety properties as an SMT formula and
-passing it to an SMT solver. By default, solving happens internally and only the
+passing it to an SMT solver [1]. By default, solving happens internally and only the
 verification verdict is reported. You can instead ask ESBMC to write the formula
 to a file, which is useful for:
 
@@ -79,3 +79,9 @@ ESBMC selects the SMT theory based on the program and the active solver backend:
 
 Use `--smtlib` to see exactly which logic declaration (`(set-logic ...)`) ESBMC
 emits for your program.
+
+## References
+
+[1] Lucas C. Cordeiro, Bernd Fischer, João Marques-Silva: *SMT-Based Bounded
+Model Checking for Embedded ANSI-C Software.* IEEE Trans. Software Eng.
+38(4):957–974, 2012. [doi:10.1109/TSE.2011.59](https://doi.org/10.1109/TSE.2011.59)

--- a/website/content/docs/theory/verification-algorithms.md
+++ b/website/content/docs/theory/verification-algorithms.md
@@ -3,7 +3,7 @@ title: Verification Algorithms
 weight: 20
 ---
 
-ESBMC implements several incremental verification strategies on top of its
+ESBMC [1] implements several incremental verification strategies on top of its
 symbolic execution engine. This page explains how each works; for the practical
 flags and when to use them, see the [Usage](/docs/usage) guide.
 
@@ -16,8 +16,8 @@ esbmc file.c --unwind K
 Plain bounded model checking is the foundation the strategies below build on.
 ESBMC symbolically executes the program, unrolling each loop at most *K* times,
 encodes the resulting [SSA program and safety properties as a single SMT
-formula](/docs/theory/smt-formula-generation), and asks the solver whether any
-property can be violated. A satisfiable formula yields a counterexample; an
+formula](/docs/theory/smt-formula-generation) [2], and asks the solver whether
+any property can be violated. A satisfiable formula yields a counterexample; an
 unsatisfiable one means no property is violated *within the bound K*.
 
 Because a fixed bound can cut a loop short, ESBMC adds an **unwinding assertion**
@@ -79,9 +79,10 @@ As with falsification, the increment granularity is configurable via
 esbmc file.c --k-induction
 ```
 
-The original *k*-induction algorithm by Sheeran et al. [1] proved safety
+The original *k*-induction algorithm by Sheeran et al. [3] proved safety
 properties in hardware verification; it was later refined by Donaldson et al.
-[2] for general C programs. ESBMC combines both approaches:
+[4] for general C programs. ESBMC combines both approaches, with an algorithm
+tailored to handling loops in C [5]:
 
 ```
 ¬B(k)         → program contains a bug
@@ -111,8 +112,20 @@ unsatisfiable), or exhausts the time or memory limit.
 
 ## References
 
-[1] Mary Sheeran, Satnam Singh, Gunnar Stålmarck: *Checking Safety Properties
+[1] Mikhail Y. R. Gadelha, Felipe R. Monteiro, Jeremy Morse, Lucas C. Cordeiro,
+Bernd Fischer, Denis A. Nicole: *ESBMC 5.0: an industrial-strength C model
+checker.* ASE 2018: 888–891. [doi:10.1145/3238147.3240481](https://doi.org/10.1145/3238147.3240481)
+
+[2] Lucas C. Cordeiro, Bernd Fischer, João Marques-Silva: *SMT-Based Bounded
+Model Checking for Embedded ANSI-C Software.* IEEE Trans. Software Eng.
+38(4):957–974, 2012. [doi:10.1109/TSE.2011.59](https://doi.org/10.1109/TSE.2011.59)
+
+[3] Mary Sheeran, Satnam Singh, Gunnar Stålmarck: *Checking Safety Properties
 Using Induction and a SAT-Solver.* FMCAD 2000: 108–125
 
-[2] Alastair F. Donaldson, Leopold Haller, Daniel Kroening, Philipp Rümmer:
+[4] Alastair F. Donaldson, Leopold Haller, Daniel Kroening, Philipp Rümmer:
 *Software Verification Using k-Induction.* SAS 2011: 351–368
+
+[5] Mikhail Y. R. Gadelha, Hussama Ibrahim Ismail, Lucas C. Cordeiro: *Handling
+loops in bounded model checking of C programs via k-induction.* Int. J. Softw.
+Tools Technol. Transf. 19(1):97–114, 2017. [doi:10.1007/s10009-015-0407-9](https://doi.org/10.1007/s10009-015-0407-9)


### PR DESCRIPTION
## What

Extends the Theory section with new pages, resolves a contracts-page duplication, and adds citation-verified references to ESBMC's own papers and the foundational literature. Pure Hugo-markdown — no code.

## New pages

| Page | Covers |
|---|---|
| **Memory Model and Pointer Safety** | object+offset pointer model (`__ESBMC_POINTER_OBJECT/OFFSET`), dynamic-allocation lifetimes, and the bounds / pointer / alignment / leak checks with their disable flags |
| **Concurrency and Context-Bounded MC** | thread interleavings, `--context-bound`, partial-order reduction (`--no-por`), `--state-hashing`, atomic blocks, and the `--data-races-check` / `--deadlock-check` / `--lock-order-check` / `--atomicity-check` checks |
| **Interval Analysis** | abstract-interpretation ranges injected as assumes (`--interval-analysis` and its sub-options), plus `--goto-contractor` |
| **Function Contracts** | a short *conceptual* page on the assume-guarantee / modular-verification principle (including a definition of *frame condition*) and how it relates to BMC / k-induction — all syntax, flags, examples, and limitations are delegated to the existing canonical [how-to guide](/docs/function-contracts/) to avoid duplication |

## Citations

Added inline `[n]` markers and per-page `## References` sections. Every entry (title, author list, venue, year, DOI) was verified against DBLP via the `citation-verifier` agent before inclusion; unverifiable candidates were dropped (no dedicated ESBMC memory-model paper exists — that page cites the TSE 2012 paper, which describes the pointer/array/struct/union SMT encoding; a Godefroid 1996 monograph candidate was dropped after the verifier caught a scrambled subtitle).

ESBMC's own papers:

| Paper | Cited on |
|---|---|
| Cordeiro, Fischer, Marques-Silva — *SMT-Based Bounded Model Checking for Embedded ANSI-C Software*, IEEE TSE 38(4), 2012 ([doi:10.1109/TSE.2011.59](https://doi.org/10.1109/TSE.2011.59)) | Verification Algorithms, SMT Formula Generation, Memory Model |
| Gadelha, Ismail, Cordeiro — *Handling loops in bounded model checking of C programs via k-induction*, STTT 19(1), 2017 ([doi:10.1007/s10009-015-0407-9](https://doi.org/10.1007/s10009-015-0407-9)) | Verification Algorithms (k-induction) |
| Cordeiro, Fischer — *Verifying multi-threaded software using SMT-based context-bounded model checking*, ICSE 2011 ([doi:10.1145/1985793.1985839](https://doi.org/10.1145/1985793.1985839)) | Concurrency |
| Gadelha, Monteiro, Morse, Cordeiro, Fischer, Nicole — *ESBMC 5.0: an industrial-strength C model checker*, ASE 2018 ([doi:10.1145/3238147.3240481](https://doi.org/10.1145/3238147.3240481)) | Verification Algorithms (tool reference) |
| Sá Menezes et al. — *ESBMC v7.4: Harnessing the Power of Intervals (Competition Contribution)*, TACAS 2024 ([doi:10.1007/978-3-031-57256-2_24](https://doi.org/10.1007/978-3-031-57256-2_24)) | Interval Analysis |

Foundational literature:

| Paper | Cited on |
|---|---|
| Qadeer, Rehof — *Context-Bounded Model Checking of Concurrent Software*, TACAS 2005 ([doi:10.1007/978-3-540-31980-1_7](https://doi.org/10.1007/978-3-540-31980-1_7)) | Concurrency (context bounding) |
| Flanagan, Godefroid — *Dynamic partial-order reduction for model checking software*, POPL 2005 ([doi:10.1145/1040305.1040315](https://doi.org/10.1145/1040305.1040315)) | Concurrency (partial-order reduction) |
| Borgida, Mylopoulos, Reiter — *On the Frame Problem in Procedure Specifications*, IEEE TSE 21(10), 1995 ([doi:10.1109/32.469460](https://doi.org/10.1109/32.469460)) | Function Contracts (frame condition) |
| Reynolds — *Separation Logic: A Logic for Shared Mutable Data Structures*, LICS 2002 ([doi:10.1109/LICS.2002.1029817](https://doi.org/10.1109/LICS.2002.1029817)) | Function Contracts (frame rule) |

The existing Sheeran/Donaldson k-induction references were renumbered to stay consistent.

## Verification

All flags, intrinsics, and contract syntax were checked against `src/esbmc/options.cpp`, the frontend declarations (`clang_c_language.cpp`), and passing regression tests before writing. The contracts page defers to `/docs/function-contracts/` rather than restating it.