### PR TITLE
[irep2] Coerce mismatched ternary branch types under --irep2-bodies

### DIFF
--- a/regression/esbmc/github_4715_irep2_bodies_assert_01/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_assert_01/main.c
@@ -1,0 +1,16 @@
+// esbmc/esbmc#4715 (V.4.4 parity): the C `assert` macro lowers to a discarded
+// statement-level ternary `cond ? 0 : __assert_fail()` whose result type is
+// void (empty) while its branches are int and void. Under --irep2-bodies the
+// whole body is forward-migrated before goto_convert lowers the ternary, so it
+// reaches migrate_expr's if-arm directly; the if2t type invariant
+// (result/branch type ids must agree) then aborted GOTO generation for every
+// C/C++ program containing a libc assert. The migrate arm now coerces the
+// divergent branch to the result type, so the assert lowers cleanly.
+#include <assert.h>
+
+int main()
+{
+  int x = 5;
+  assert(x == 5);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_assert_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_assert_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-bodies --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_bodies_assert_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_bodies_assert_01_fail/main.c
@@ -1,0 +1,13 @@
+// esbmc/esbmc#4715 (V.4.4 parity): negative variant of assert_01. The libc
+// `assert` ternary still lowers under --irep2-bodies after the migrate if-arm
+// coerces its mismatched (void/int) branches, and -- crucially -- still catches
+// a genuine violation. The assertion below is false, so ESBMC must report
+// VERIFICATION FAILED rather than aborting or passing vacuously.
+#include <assert.h>
+
+int main()
+{
+  int x = 5;
+  assert(x == 6);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_bodies_assert_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_bodies_assert_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-bodies --unwind 2
+^VERIFICATION FAILED$

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -973,6 +973,20 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     migrate_expr(expr.op1(), true_val);
     migrate_expr(expr.op2(), false_val);
 
+    // A legacy ternary used as a discarded statement -- notably the C `assert`
+    // idiom `cond ? 0 : __assert_fail()` -- carries a void (empty) result type
+    // with branch types that differ from it and from each other. if2t requires
+    // both branches to share the result type's kind, so coerce any branch whose
+    // type id diverges. The conditional's value is discarded, so the cast is
+    // semantics-preserving and the round-trip stays equivalent. Well-typed
+    // ternaries already have matching branch types, so no cast is added on the
+    // common path. Matching on type_id (not full structural type) keeps this to
+    // exactly the cases the if2t invariant rejects.
+    if (true_val->type->type_id != type->type_id)
+      true_val = typecast2tc(type, true_val);
+    if (false_val->type->type_id != type->type_id)
+      false_val = typecast2tc(type, false_val);
+
     new_expr_ref = if2tc(type, cond, true_val, false_val);
     return;
   }

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -164,6 +164,37 @@ TEST_CASE("migrate expr round-trips for code_decl with init", "[migrate]")
   require_expr_roundtrip(code_decl2tc(get_int_type(32), irep_idt("x")));
 }
 
+TEST_CASE(
+  "migrate coerces mismatched ternary branches to the result type",
+  "[migrate][v4-cf]")
+{
+  // esbmc#4715: the C `assert` macro lowers to a discarded statement-level
+  // ternary `cond ? 0 : __assert_fail()` whose result type is void (empty) and
+  // whose branch types differ from it (int and void). if2t requires both
+  // branches to share the result type, so the forward migration must coerce the
+  // divergent branch -- otherwise the if2t constructor's type invariant trips.
+  // Under --irep2-bodies the whole body is migrated before goto_convert lowers
+  // the ternary, so this shape reaches migrate_expr directly.
+  use_test_ns();
+  typet voidt = migrate_type_back(get_empty_type());
+  typet boolt = migrate_type_back(get_bool_type());
+  typet intt = migrate_type_back(get_int_type(32));
+
+  exprt tern("if", voidt);
+  tern.copy_to_operands(
+    from_integer(1, boolt), // cond
+    from_integer(0, intt),  // true: int, differs from the void result type
+    from_integer(0, intt)); // false: int, differs from the void result type
+
+  expr2tc m;
+  migrate_expr(tern, m);
+  REQUIRE(is_if2t(m));
+  // The if2t and both arms share the (void) result type id.
+  const if2t &i = to_if2t(m);
+  REQUIRE(i.type->type_id == i.true_value->type->type_id);
+  REQUIRE(i.type->type_id == i.false_value->type->type_id);
+}
+
 // V1 of the symbol-table V-track (esbmc/esbmc#4715): five expr2t kinds had
 // gaps in the migration layer (no back-arm, or no forward-arm, or neither).
 // These tests pin the round-trip property -- migrate_expr_back followed by


### PR DESCRIPTION
## What

Under `--irep2-bodies`, every function body is forward-migrated through `migrate_expr` *before* goto_convert lowers it. The C/C++ `assert(...)` macro lowers to a discarded statement-level ternary `cond ? 0 : __assert_fail()` whose declared result type is **void (empty)** while its branches are **int** (the `0`) and **void** (the `__assert_fail()` call). The `if2t` constructor asserts `type->type_id == true_value->type->type_id` (and likewise for the false value), so migrating this ternary **aborts GOTO generation for any C/C++ program containing a libc `assert()`** on an assertions-enabled build (CI's DebugOpt). RelWithDebInfo builds (assertions compiled out) silently build a malformed `if2t` instead.

The flag-off path is unaffected: goto_convert lowers such statement-ternaries into control flow before any `if2t` is ever constructed, so this shape only reaches `migrate_expr` under `--irep2-bodies`.

## Fix

In the `exprt::i_if` arm of `migrate_expr` (`src/util/migrate.cpp`): after migrating the branches, coerce any branch whose `type_id` diverges from the migrated result type via `typecast2tc(type, branch)`, so the `if2t` invariant holds. The conditional's value is discarded, so the cast is semantics-preserving and the round-trip stays equivalent. Matching on `type_id` (not full structural type) keeps the change to exactly the cases the `if2t` invariant rejects — well-typed ternaries already have matching branch types, so no cast is added on the common (shared) path.

## Validation

- New migrate unit test pinning the coercion (`migrate.test.cpp`); full migrate suite 31/31.
- New passing/failing libc-`assert` regression tests under `--irep2-bodies` (`github_4715_irep2_bodies_assert_01{,_fail}`).
- No regressions: `esbmc-cpp/cpp` 501/501 and a C-core sample, all on the assertions-enabled DebugOpt build.
- `clang-format` (11) clean.

Refs #4715.