### PR TITLE
[python] Resolve list[Tuple[...]] element to the concrete tuple struct

### DIFF
--- a/regression/python/list_tuple_elem_annotation/main.py
+++ b/regression/python/list_tuple_elem_annotation/main.py
@@ -1,0 +1,46 @@
+# An element annotated list[Tuple[...]] used to resolve to an opaque 0-member
+# "Tuple" struct (get_typet treated the Tuple[...] Subscript node as a wrapper
+# and unwrapped it to the bare name "Tuple"). Reading such an element through a
+# function parameter or a function return — e.g. `def pop(xs): return xs[0]` —
+# then crashed the backend (value-set member access / SMT cast-to-struct).
+# The annotation now resolves to the concrete tuple struct, matching what a
+# tuple literal produces, so the element carries real components.
+from typing import List, Tuple
+
+
+def first_pair(xs: List[Tuple[int, int]]) -> Tuple[int, int]:
+    return xs[0]
+
+
+def unpack_param(xs: List[Tuple[int, int]]) -> int:
+    a, b = xs[0]
+    return a + b
+
+
+def main() -> None:
+    h: List[Tuple[int, int]] = [(1, 2)]
+
+    # Cross-function tuple return, unpacked at the call site.
+    a, b = first_pair(h)
+    assert a == 1 and b == 2
+
+    # Subscript-and-unpack of a list[Tuple] parameter.
+    assert unpack_param(h) == 3
+
+    # Three-component tuple element.
+    g: List[Tuple[int, int, int]] = [(4, 5, 6)]
+    x, y, z = g[0]
+    assert x == 4 and y == 5 and z == 6
+
+    # Lowercase tuple annotation behaves identically.
+    k: list[tuple[int, int]] = [(7, 8)]
+    p, q = k[0]
+    assert p == 7 and q == 8
+
+    # Single-element tuple annotation (no elts list) resolves to a 1-component
+    # struct, so a direct chained read works.
+    s: List[Tuple[int]] = [(9,)]
+    assert s[0][0] == 9
+
+
+main()

--- a/regression/python/list_tuple_elem_annotation/test.desc
+++ b/regression/python/list_tuple_elem_annotation/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_tuple_elem_annotation_fail/main.py
+++ b/regression/python/list_tuple_elem_annotation_fail/main.py
@@ -1,0 +1,17 @@
+# Negative variant: reading a list[Tuple[...]] element through a function
+# return now yields the real tuple components, so a wrong claim about a
+# component is refuted (rather than crashing or silently passing).
+from typing import List, Tuple
+
+
+def first_pair(xs: List[Tuple[int, int]]) -> Tuple[int, int]:
+    return xs[0]
+
+
+def main() -> None:
+    h: List[Tuple[int, int]] = [(1, 2)]
+    a, b = first_pair(h)
+    assert a == 2
+
+
+main()

--- a/regression/python/list_tuple_elem_annotation_fail/test.desc
+++ b/regression/python/list_tuple_elem_annotation_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -125,7 +125,7 @@ public:
     return string_handler_;
   }
 
-  tuple_handler &get_tuple_handler()
+  tuple_handler &get_tuple_handler() const
   {
     return *tuple_handler_;
   }

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -241,6 +241,17 @@ static typet get_elem_type_from_annotation(
     if (slice.contains("id") && slice["id"].is_string())
       return type_handler_.get_typet(slice["id"].get<std::string>());
 
+    // Tuple element: list[Tuple[A, B]] / list[tuple[A, B]]. Build the concrete
+    // tuple struct (not the opaque 0-member "Tuple") so subscript/unpack of a
+    // W[i] read sees real components; see type_handler::get_typet(json) for why
+    // the opaque form crashes the SMT cast-to-struct path.
+    if (
+      slice.contains("_type") && slice["_type"] == "Subscript" &&
+      slice.contains("value") && slice["value"].is_object() &&
+      slice["value"].contains("id") && slice["value"]["id"].is_string() &&
+      (slice["value"]["id"] == "Tuple" || slice["value"]["id"] == "tuple"))
+      return type_handler_.get_typet(slice);
+
     // Nested container element: list[list[T]], list[dict[K, V]], ...
     // Resolve to the container's own type (list[T] -> __ESBMC_PyListObj*),
     // so the caller treats W[i] as a list and re-routes W[i][j] through

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -558,6 +558,18 @@ typet tuple_handler::get_tuple_type_from_annotation(
       element_types.push_back(elem_type);
     }
   }
+  else
+  {
+    // Single element type: tuple[int]. The slice is the lone element node
+    // (a bare Name or nested subscript), not an elts list. Without this the
+    // tuple would get zero components — the opaque struct the callers of this
+    // function are specifically avoiding.
+    if (slice.contains("id") && slice["id"].is_string())
+      element_types.push_back(
+        type_handler_.get_typet(slice["id"].get<std::string>()));
+    else
+      element_types.push_back(type_handler_.get_typet(slice));
+  }
 
   return create_tuple_struct_type(element_types);
 }

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -2,6 +2,7 @@
 #include <python-frontend/json_utils.h>
 #include <python-frontend/type_utils.h>
 #include <python-frontend/python_converter.h>
+#include <python-frontend/tuple_handler.h>
 #include <python-frontend/python_typechecking.h>
 #include <python-frontend/symbol_id.h>
 #include <util/arith_tools.h>
@@ -769,6 +770,22 @@ typet type_handler::get_typet(const nlohmann::json &elem) const
   // Handle nested value object
   if (elem.is_object())
   {
+    // Tuple annotation subscript: Tuple[int, str] / tuple[int, str]. Build the
+    // concrete tuple struct (matching the tag-tuple_* type a tuple literal
+    // produces) so a list element annotated list[Tuple[...]] resolves to real
+    // components. This must precede the wrapper-node unwrap below: a Subscript
+    // node also carries a "value" key (the subscripted name), so the unwrap
+    // would otherwise recurse into the bare "Tuple" name and resolve it to the
+    // opaque 0-member "Tuple" symbol type — which crashes the SMT
+    // cast-to-struct path when a function returns such an element.
+    if (
+      elem["_type"] == "Subscript" && elem.contains("value") &&
+      elem["value"].is_object() && elem["value"].contains("id") &&
+      elem["value"]["id"].is_string() &&
+      (elem["value"]["id"] == "Tuple" || elem["value"]["id"] == "tuple") &&
+      elem.contains("slice"))
+      return converter_.get_tuple_handler().get_tuple_type_from_annotation(elem);
+
     // Recursive delegation for wrapper node
     if (elem.contains("value"))
       return get_typet(elem["value"]);

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -784,7 +784,8 @@ typet type_handler::get_typet(const nlohmann::json &elem) const
       elem["value"]["id"].is_string() &&
       (elem["value"]["id"] == "Tuple" || elem["value"]["id"] == "tuple") &&
       elem.contains("slice"))
-      return converter_.get_tuple_handler().get_tuple_type_from_annotation(elem);
+      return converter_.get_tuple_handler().get_tuple_type_from_annotation(
+        elem);
 
     // Recursive delegation for wrapper node
     if (elem.contains("value"))


### PR DESCRIPTION
A list element annotated `list[Tuple[A, B]]` resolved to an **opaque 0-member `Tuple` struct**: `type_handler::get_typet(json)` treated the `Tuple[...]` Subscript node as a wrapper and unwrapped it to the bare name `Tuple`. Reading such an element through a function parameter or return — e.g. `def pop(xs): return xs[0]` — then crashed the backend:

- `value_sett::make_member` called `.value()` on an empty `std::optional` (pushing a member access through the `*(Tuple*)pyobj->value` reinterpret cast whose source lacked the component);
- failing that, `smt_convt::convert_typecast_to_struct` read past the end of the 0-member source struct (segfault).

The annotation now resolves to the concrete `tag-tuple_*` struct — the same type a tuple literal produces — so the casts become `tag-tuple → tag-tuple` (compatible) and the crashes vanish. The Tuple-subscript case is matched **before** the wrapper-node unwrap (a Subscript node also carries a `value` key), and the `list`-element path routes to it. Single-element `tuple[X]` annotations (no `elts` list) now build a 1-component struct rather than a 0-member one.

Inline unpack (`a, b = pop(h)`), parameter subscript (`a, b = xs[0]`), and tuple-return reads now verify for all tuple arities. Adds passing and failing regression tests.

**Known limitation (pre-existing, not introduced here):** the intermediate-assignment-then-subscript form `r = container[i]; r[j]` still hits a separate SMT tuple assertion (`Tuple AST mismatch`) for tuples of any arity; the regression tests use inline unpack / direct chained subscript, which converge.
