### PR TITLE
[irep2] Resolve inline struct types in get_destructor under --irep2-bodies

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01/main.cpp
@@ -1,0 +1,35 @@
+#include <cassert>
+
+// Regression for the --irep2-bodies round-trip dropping a temporary object's
+// destructor. IREP2 struct types store only data members, so the body
+// round-trip strips the inline class type's `methods` and component
+// attributes. goto_convert finds a temporary's destructor via get_destructor(),
+// which scans the type's methods() and self-compares the destructor's `this`
+// type, so a degraded inline type lost the destructor call. get_destructor now
+// resolves the inline struct back to its authoritative type symbol via its tag.
+//
+// Uses a multi-field class on purpose: a single-field/fieldless class
+// round-trips to a structurally identical type and would pass even unfixed.
+int dtor_calls = 0;
+
+struct Room
+{
+  int a, b;
+  ~Room() { dtor_calls++; }
+};
+
+struct House
+{
+  Room *rm;
+  House() { rm = new Room(); }
+};
+
+int main()
+{
+  House h;
+  // `new Room()` materialises a temporary that is copied into the heap object
+  // and then destroyed, so the destructor runs exactly once during
+  // construction. Without the fix it was dropped (dtor_calls == 0).
+  assert(dtor_calls == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01/main.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+// __ESBMC_assert is a built-in intrinsic; no include needed.
 
 // Regression for the --irep2-bodies round-trip dropping a temporary object's
 // destructor. IREP2 struct types store only data members, so the body
@@ -30,6 +30,6 @@ int main()
   // `new Room()` materialises a temporary that is copied into the heap object
   // and then destroyed, so the destructor runs exactly once during
   // construction. Without the fix it was dropped (dtor_calls == 0).
-  assert(dtor_calls == 1);
+  __ESBMC_assert(dtor_calls == 1, "dtor count");
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01_fail/main.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+// __ESBMC_assert is a built-in intrinsic; no include needed.
 
 // Failing companion to github_4715_irep2_bodies_temp_dtor_01: with the fix the
 // temporary object's destructor runs (dtor_calls == 1), so the assertion below
@@ -22,6 +22,6 @@ struct House
 int main()
 {
   House h;
-  assert(dtor_calls == 0);
+  __ESBMC_assert(dtor_calls == 0, "dtor count");
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01_fail/main.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+
+// Failing companion to github_4715_irep2_bodies_temp_dtor_01: with the fix the
+// temporary object's destructor runs (dtor_calls == 1), so the assertion below
+// is violated and verification FAILS. Without the fix the destructor was
+// dropped (dtor_calls == 0) and this assertion would spuriously hold -- so the
+// two tests pin the fix from both directions.
+int dtor_calls = 0;
+
+struct Room
+{
+  int a, b;
+  ~Room() { dtor_calls++; }
+};
+
+struct House
+{
+  Room *rm;
+  House() { rm = new Room(); }
+};
+
+int main()
+{
+  House h;
+  assert(dtor_calls == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_02/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_02/main.cpp
@@ -1,0 +1,34 @@
+#include <cassert>
+
+// Inheritance variant of github_4715_irep2_bodies_temp_dtor_01: destroying a
+// derived temporary runs both the derived and the base destructor. Exercises
+// get_destructor() resolving an inline derived class type (whose `methods` and
+// `bases` the --irep2-bodies round-trip strips) back to its type symbol.
+int dtor_calls = 0;
+
+struct Base
+{
+  int x;
+  ~Base() { dtor_calls++; }
+};
+
+struct Room : Base
+{
+  int y;
+  ~Room() { dtor_calls++; }
+};
+
+struct House
+{
+  Room *rm;
+  House() { rm = new Room(); }
+};
+
+int main()
+{
+  House h;
+  // The temporary built for `new Room()` is destroyed after the copy, running
+  // ~Room then ~Base -> dtor_calls == 2. Without the fix both were dropped.
+  assert(dtor_calls == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_02/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_02/main.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+// __ESBMC_assert is a built-in intrinsic; no include needed.
 
 // Inheritance variant of github_4715_irep2_bodies_temp_dtor_01: destroying a
 // derived temporary runs both the derived and the base destructor. Exercises
@@ -29,6 +29,6 @@ int main()
   House h;
   // The temporary built for `new Room()` is destroyed after the copy, running
   // ~Room then ~Base -> dtor_calls == 2. Without the fix both were dropped.
-  assert(dtor_calls == 2);
+  __ESBMC_assert(dtor_calls == 2, "dtor count");
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_02/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_bodies_temp_dtor_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-bodies
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/destructor.cpp
+++ b/src/goto-programs/destructor.cpp
@@ -12,7 +12,23 @@ bool get_destructor(
 
   if (type.id() == "struct")
   {
-    const struct_typet &struct_type = to_struct_type(type);
+    // An inline struct type embedded in a function body can be a degraded copy
+    // of the class type: the --irep2-bodies round-trip strips the C++ `methods`
+    // sub and component attributes, because IREP2 struct types store only data
+    // members. Resolve it back to the authoritative type symbol via its tag so
+    // the scan below sees the full method list and the self-reference
+    // comparison matches. Falls back to the inline type for anonymous structs
+    // and when no symbol is bound (the legacy flag-off type already carries its
+    // methods, so this is a no-op there).
+    const irep_idt &tag = type.get("tag");
+    const symbolt *type_sym =
+      tag.empty() ? nullptr : ns.lookup("tag-" + id2string(tag));
+    const typet &resolved =
+      (type_sym != nullptr && type_sym->get_type().id() == "struct")
+        ? type_sym->get_type()
+        : type;
+
+    const struct_typet &struct_type = to_struct_type(resolved);
 
     const struct_typet::componentst &components = struct_type.methods();
 
@@ -29,7 +45,8 @@ bool get_destructor(
           const typet &arg_type = code_type.arguments().front().type();
 
           if (
-            arg_type.id() == "pointer" && ns.follow(arg_type.subtype()) == type)
+            arg_type.id() == "pointer" &&
+            ns.follow(arg_type.subtype()) == resolved)
           {
             exprt symbol_expr("symbol", component.type());
             symbol_expr.identifier(component.name());


### PR DESCRIPTION
## Problem

IREP2 `struct_type2t` stores only data members — it drops the C++ `methods` sub and per-component attributes. Under `--irep2-bodies` the function body is round-tripped legacy → IREP2 → legacy before `goto_convert`, so an **inline** class type embedded in the body loses its methods.

`goto_convert` runs a temporary object's destructor via `get_destructor()` (`src/goto-programs/destructor.cpp`), which scans `struct_type.methods()` and self-compares the destructor's `this` type (`ns.follow(arg.subtype()) == type`). A degraded inline type yields no match, so the destructor call is **silently dropped** — a missed side effect that flips verdicts under `--irep2-bodies`. When the temporary's destructor throws (its exception ctor reaching an `--error-label`), dropping it makes the label unreachable → spurious `VERIFICATION SUCCESSFUL`.

This is the cluster-1 residual of the V.4.4 parity sweep: `regression/esbmc-cpp/try_catch/nec_ex3-delegation-dtor-throw` and `nec_ex6-std-uncaught-dtor` both flipped `FAILED → SUCCESSFUL` under the flag.

## Fix

In `get_destructor`, resolve a tagged inline struct back to its authoritative type symbol (`tag-<name>`), which is never round-tripped, before scanning for the destructor. Anonymous structs and an unbound namespace fall back to the inline type, so the legacy flag-off path (whose inline type already carries its methods) is byte-identical.

This is the consumer-side fix: it uses the complete namespace type, so it handles fieldless, multi-field, base-class, and array-constructor shapes uniformly. (An earlier attempt to restore `methods`/`bases` in `migrate_type_back` was incomplete — the forward migrate also drops component *attributes*, so the structural `==` still failed for any class with multiple/decorated members; it passed only for single-field classes by coincidence.)

## Validation

- `nec_ex3` and `nec_ex6`: now `OFF == ON` (both `FAILED`) — parity restored.
- New regression tests (CORE, flag-on): `github_4715_irep2_bodies_temp_dtor_01` (multi-field, SUCCESSFUL) + `_01_fail` (FAILED) + `_02` (base class). Discrimination confirmed by reverting the fix (`_01` → FAILED, `_01_fail` → SUCCESSFUL).
- `esbmc-cpp/cpp` flag-off: no new failures (only the pre-existing `ch13_10` THOROUGH `--timeout 900` test exceeding the ctest cap).
- migrate unit tests: 29/29.

Refs #4715.