### PR TITLE
[contracts] Widen return_value comparison to fix wide-constant sort mismatch

### DIFF
--- a/regression/function_contract/github_5312_return_value_wide_const/main.c
+++ b/regression/function_contract/github_5312_return_value_wide_const/main.c
@@ -1,0 +1,25 @@
+/* Issue #5312: --enforce-contract aborted with a Z3/Bitwuzla sort mismatch
+ * (BitVec 64 vs BitVec 32) when an __ESBMC_ensures compared the 32-bit
+ * __ESBMC_return_value against a constant that does not fit in int.
+ *
+ * In C such a literal has type long (64-bit), so the comparison is encoded at
+ * 64 bits; the contract machinery stripped the usual-arithmetic-conversion
+ * cast off the return value, leaving a 32-bit operand against the 64-bit
+ * constant. The ensures is genuinely true: an int return value is always
+ * greater than INT_MIN - 1 and always less than INT_MAX + 1.
+ */
+
+int f(int x)
+{
+  __ESBMC_requires(x > 0);
+  __ESBMC_requires(x < 16);
+  __ESBMC_ensures(__ESBMC_return_value > -2147483649); /* INT_MIN - 1 */
+  __ESBMC_ensures(__ESBMC_return_value < 2147483648);  /* INT_MAX + 1 */
+  return x;
+}
+
+int main()
+{
+  int r = f(5);
+  return r;
+}

--- a/regression/function_contract/github_5312_return_value_wide_const/test.desc
+++ b/regression/function_contract/github_5312_return_value_wide_const/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_5312_return_value_wide_const_fail/main.c
+++ b/regression/function_contract/github_5312_return_value_wide_const_fail/main.c
@@ -1,0 +1,19 @@
+/* Issue #5312 negative variant: the same wide-constant comparison path, but the
+ * ensures is genuinely violated. The width fix must still encode the comparison
+ * (no sort-mismatch abort) and the verdict must be FAILED: f returns a small
+ * positive value, which is never greater than INT_MAX + 1.
+ */
+
+int f(int x)
+{
+  __ESBMC_requires(x > 0);
+  __ESBMC_requires(x < 16);
+  __ESBMC_ensures(__ESBMC_return_value > 2147483648); /* INT_MAX + 1 */
+  return x;
+}
+
+int main()
+{
+  int r = f(5);
+  return r;
+}

--- a/regression/function_contract/github_5312_return_value_wide_const_fail/test.desc
+++ b/regression/function_contract/github_5312_return_value_wide_const_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f
+^VERIFICATION FAILED$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -3032,6 +3032,32 @@ expr2tc code_contractst::fix_comparison_types(
             get_type_id(*ret_val->type));
         }
       }
+      // Case 3: return_value is an integer compared with an integer operand of
+      // a different width — e.g. an `int` return value against a `long`
+      // constant that does not fit in `int`. remove_incorrect_casts above
+      // stripped the usual-arithmetic-conversion cast Clang inserted, leaving a
+      // width mismatch the SMT backend rejects (mk_bvsgt requires equal operand
+      // widths). Re-apply the conversion by widening the narrower side to the
+      // wider integer type. Issue #5312.
+      else if (side1_is_retval || side2_is_retval)
+      {
+        auto is_int = [](const type2tc &t) {
+          return is_signedbv_type(t) || is_unsignedbv_type(t);
+        };
+        if (
+          is_int((*side1)->type) && is_int((*side2)->type) &&
+          (*side1)->type->get_width() != (*side2)->type->get_width())
+        {
+          if ((*side1)->type->get_width() < (*side2)->type->get_width())
+            *side1 = typecast2tc((*side2)->type, *side1);
+          else
+            *side2 = typecast2tc((*side1)->type, *side2);
+          log_debug(
+            "contracts",
+            "Fixed integer comparison: widened return_value comparison to "
+            "matching width");
+        }
+      }
     }
 
     return new_expr;


### PR DESCRIPTION
Fixes #5312.

Under `--enforce-contract`, an `__ESBMC_ensures` comparing the 32-bit `__ESBMC_return_value` against a constant that does not fit in `int` — a 64-bit `long` literal such as `-2147483649` (INT_MIN−1) or `2147483648` (INT_MAX+1) — aborted at VC-encoding time with a sort mismatch:

```
Z3 error: Argument (bvneg #x0000000080000001) ... has sort (_ BitVec 64) it does not match
declaration (declare-fun bvsgt ((_ BitVec 32) (_ BitVec 32)) Bool)
```

(ESBMC asserts the same in `mk_bvsgt`: `a->sort->get_data_width() == b->sort->get_data_width()`.)

**Root cause.** In C the out-of-int-range literal has type `long`, so Clang inserts a usual-arithmetic-conversion cast `(long)__ESBMC_return_value`. The contract machinery's `remove_incorrect_casts` strips that cast off the return value, and `fix_comparison_types` only re-equalized types for the pointer-return (NULL) and float-return (cast the constant) cases — never the integer-width case. The comparison was left as a 32-bit operand against a 64-bit constant.

**Fix.** Add the integer case to `fix_comparison_types`: when one comparison side is the return-value symbol and both sides are bitvector integers of differing width, widen the narrower side to the wider integer type — re-applying the conversion that was stripped.

Verified: the repro and the INT_MAX+1 variant now verify SUCCESSFUL (an `int` return is always `> INT_MIN−1` and `< INT_MAX+1`); a genuinely-violated wide-constant ensures verifies FAILED; all 255 CORE `function_contract` regression tests pass. Adds passing and failing regression tests.
