### PR TITLE
[build] Silence compiler warnings on Clang/macOS builds

### DIFF
--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -390,7 +390,7 @@ bool clang_c_languaget::parse(const std::string &path)
     return true;
 
   if (!AST)
-    AST = move(newAST);
+    AST = std::move(newAST);
   else
     mergeASTs(newAST, AST);
 

--- a/src/util/c_misc.cpp
+++ b/src/util/c_misc.cpp
@@ -60,7 +60,7 @@ void MetaChar(std::string &out, char c, bool inString)
     if ((c < ' ') || (c >= 127))
     {
       char octbuf[8];
-      sprintf(octbuf, "%03o", (unsigned char)c);
+      snprintf(octbuf, sizeof(octbuf), "%03o", (unsigned char)c);
       out += "\\";
       out += octbuf;
     }

--- a/src/util/compiler_defs.h
+++ b/src/util/compiler_defs.h
@@ -14,6 +14,7 @@
 #  define CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()                                   \
     __pragma(message("Disabling diagnostic checks for clang headers"))         \
       CC_DIAGNOSTIC_DISABLE(4146 4244 4267 4291 4624)
+#  define CC_DIAGNOSTIC_IGNORE_DEPRECATED_LITERAL_OPERATOR()
 #else
 #  define CC_DIAGNOSTIC_PUSH() _Pragma("GCC diagnostic push")
 #  define CC_DIAGNOSTIC_POP() _Pragma("GCC diagnostic pop")
@@ -24,7 +25,34 @@
     DO_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")                     \
     DO_PRAGMA(GCC diagnostic ignored "-Wnonnull")                              \
     DO_PRAGMA(GCC diagnostic ignored "-Wdeprecated-declarations")              \
-    DO_PRAGMA(GCC diagnostic ignored "-Wclass-memaccess")
+    CC_DIAGNOSTIC_IGNORE_CLASS_MEMACCESS()
+
+// -Wclass-memaccess is GCC-only; Clang does not recognise it and would emit
+// -Wunknown-warning-option on the pragma itself.
+#  if defined(__GNUC__) && !defined(__clang__)
+#    define CC_DIAGNOSTIC_IGNORE_CLASS_MEMACCESS()                             \
+      DO_PRAGMA(GCC diagnostic ignored "-Wclass-memaccess")
+#  else
+#    define CC_DIAGNOSTIC_IGNORE_CLASS_MEMACCESS()
+#  endif
+
+// -Wdeprecated-literal-operator exists only on Clang >= 17 and GCC >= 15;
+// emitting the pragma on older compilers trips -Wunknown-warning-option
+// (Clang) or -Wpragmas (GCC). Probe with Clang's __has_warning where
+// available, and fall back to a GCC version check otherwise.
+#  if defined(__has_warning)
+#    if __has_warning("-Wdeprecated-literal-operator")
+#      define CC_DIAGNOSTIC_IGNORE_DEPRECATED_LITERAL_OPERATOR()               \
+        DO_PRAGMA(GCC diagnostic ignored "-Wdeprecated-literal-operator")
+#    else
+#      define CC_DIAGNOSTIC_IGNORE_DEPRECATED_LITERAL_OPERATOR()
+#    endif
+#  elif defined(__GNUC__) && __GNUC__ >= 15
+#    define CC_DIAGNOSTIC_IGNORE_DEPRECATED_LITERAL_OPERATOR()                 \
+      DO_PRAGMA(GCC diagnostic ignored "-Wdeprecated-literal-operator")
+#  else
+#    define CC_DIAGNOSTIC_IGNORE_DEPRECATED_LITERAL_OPERATOR()
+#  endif
 #endif
 
 #ifndef GNUC_PREREQ

--- a/src/util/config_file.cpp
+++ b/src/util/config_file.cpp
@@ -6,8 +6,14 @@
 #include <set>
 #include <fmt/core.h>
 #include <util/message.h>
+#include <util/compiler_defs.h>
 
+// toml++ is a vendored third-party header; silence its deprecated literal
+// operators rather than patching the upstream file.
+CC_DIAGNOSTIC_PUSH()
+CC_DIAGNOSTIC_IGNORE_DEPRECATED_LITERAL_OPERATOR()
 #include "lib/toml.hpp"
+CC_DIAGNOSTIC_POP()
 
 static const std::string toml_type_to_string(const toml::node &node)
 {

--- a/src/util/i2string.cpp
+++ b/src/util/i2string.cpp
@@ -13,7 +13,7 @@ std::string i2string(int i)
 {
 #ifdef USE_SPRINTF
   char buffer[100];
-  sprintf(buffer, "%d", i);
+  snprintf(buffer, sizeof(buffer), "%d", i);
   return buffer;
 #else
   std::ostringstream strInt;
@@ -29,7 +29,7 @@ std::string i2string(signed long int i)
 {
 #ifdef USE_SPRINTF
   char buffer[100];
-  sprintf(buffer, "%ld", i);
+  snprintf(buffer, sizeof(buffer), "%ld", i);
   return buffer;
 #else
   std::ostringstream strInt;
@@ -45,7 +45,7 @@ std::string i2string(unsigned i)
 {
 #ifdef USE_SPRINTF
   char buffer[100];
-  sprintf(buffer, "%u", i);
+  snprintf(buffer, sizeof(buffer), "%u", i);
   return buffer;
 #else
   std::ostringstream strInt;
@@ -61,7 +61,7 @@ std::string i2string(unsigned long int i)
 {
 #ifdef USE_SPRINTF
   char buffer[100];
-  sprintf(buffer, "%lu", i);
+  snprintf(buffer, sizeof(buffer), "%lu", i);
   return buffer;
 #else
   std::ostringstream strInt;


### PR DESCRIPTION
Cleans up four classes of compiler warnings seen on Clang/macOS builds, with no behavioural change.

- **`sprintf` → `snprintf`** in `i2string.cpp` (×4) and `c_misc.cpp` (×1): removes the deprecated/unsafe API. Buffers are amply sized (≤22 bytes needed of 100; ≤4 of 8), so output is byte-identical. ESBMC proves the bounds hold for all inputs (Bitwuzla + Z3 agree).
- **`std::move`** qualification in `clang_c_language.cpp` (fixes `-Wunqualified-std-cast-call`).
- **`-Wclass-memaccess`** ignore gated behind `__GNUC__ && !__clang__` (GCC-only flag; Clang emitted `-Wunknown-warning-option` on the pragma itself).
- **toml++ `-Wdeprecated-literal-operator`** suppressed only at its vendored `#include`, leaving the upstream header untouched. The pragma is version-gated (Clang ≥ 17 via `__has_warning`, GCC ≥ 15) so it never trips `-Wpragmas`/`-Wunknown-warning-option` on older compilers.

Verified: clean build (exit 0, all four warnings gone), 451/451 unit tests pass, `config_file_test` passes, counterexample formatting confirmed unchanged, clang-format 11 clean.