### PR TITLE
[docs] Retitle theory page to "Integer vs. Bit-Vector Encoding"

### DIFF
--- a/website/content/docs/theory/_index.md
+++ b/website/content/docs/theory/_index.md
@@ -14,7 +14,7 @@ for SMT solvers, and the data structures it is built on.
   {{< card link="/docs/theory/concurrency" title="Concurrency and Context-Bounded MC" subtitle="Thread interleavings, context bounding, partial-order reduction, and data-race / deadlock detection." >}}
   {{< card link="/docs/theory/interval-analysis" title="Interval Analysis" subtitle="Abstract interpretation that infers variable ranges and injects them as assumptions before SMT solving." >}}
   {{< card link="/docs/theory/function-contracts" title="Function Contracts" subtitle="Modular assume-guarantee verification with requires / ensures / assigns and loop contracts." >}}
-  {{< card link="/docs/theory/counterexample-guided-abstract-refinement" title="Counterexample-Guided Abstraction Refinement" subtitle="Integer vs. bit-vector encodings and how ESBMC refines the abstraction." >}}
+  {{< card link="/docs/theory/counterexample-guided-abstract-refinement" title="Integer vs. Bit-Vector Encoding" subtitle="The --ir integer encoding versus default bit-vectors, and a manual refinement workflow." >}}
   {{< card link="/docs/theory/smt-formula-generation" title="SMT Formula Generation" subtitle="How symbolic execution turns a program into SSA and then into an SMT formula." >}}
   {{< card link="/docs/theory/ltl" title="Linear Temporal Logic" subtitle="LTL property checking via Büchi automata over finite prefixes." >}}
   {{< card link="/docs/theory/irep2" title="IRep2" subtitle="ESBMC's typed, reference-counted, copy-on-write internal representation." >}}

--- a/website/content/docs/theory/counterexample-guided-abstract-refinement.md
+++ b/website/content/docs/theory/counterexample-guided-abstract-refinement.md
@@ -1,7 +1,13 @@
 ---
-title:
-  "Counterexample Guided Abstract Refinement: Integer vs. Bit-Vector Encoding"
+title: "Integer vs. Bit-Vector Encoding"
 ---
+
+ESBMC encodes arithmetic as bit-precise bit-vectors by default. The `--ir`
+option switches to an integer/real (`Int`/`Real` sort) encoding instead. The two
+encodings expose a tradeoff: integer encoding can refute some assertions far
+faster, while bit-vector encoding is the only one that captures fixed-width
+overflow. The examples below illustrate both sides of that tradeoff and a manual
+workflow for combining them.
 
 ## Example 1: Checking the Pythagorean Theorem
 
@@ -201,10 +207,14 @@ Aborted (core dumped)
 - The integer encoding efficiently verifies the correctness of the program once
   overflow checks are introduced, ensuring safe behavior.
 
-## Pseudocode for Counterexample-Guided Abstraction Refinement
+## A Manual Refinement Workflow
 
-The following pseudocode outlines the steps involved in counterexample-guided
-abstraction refinement:
+ESBMC does not perform predicate-abstraction CEGAR internally; integer encoding
+(`--ir`) and bit-vector encoding are simply two solver back-ends you select. The
+pseudocode below sketches a *manual* loop that combines them: add overflow
+checks, verify under integer encoding, validate each counterexample against a
+compiled test case, and discard spurious ones with an `assume` before
+re-running.
 
 ```
 Function VerifyProgram(c_program):


### PR DESCRIPTION
The theory page documented the `--ir` integer encoding vs default bit-vector tradeoff but was titled "Counterexample-Guided Abstraction Refinement", implying ESBMC runs predicate-abstraction CEGAR internally, which it does not.

Retitle to match the content, add an intro framing `--ir` and bit-vectors as two solver back-ends, and reframe the closing pseudocode as a manual refinement workflow. The URL slug is left unchanged to preserve the existing published link. The matching card in `_index.md` is updated too.