### PR TITLE
[docs] theory: add termination page; document inductive-step strengthening

### DIFF
--- a/website/content/docs/theory/_index.md
+++ b/website/content/docs/theory/_index.md
@@ -10,6 +10,7 @@ for SMT solvers, and the data structures it is built on.
 {{< cards >}}
   {{< card link="/docs/theory/non-determinism" title="Modeling with Non-determinism" subtitle="The primitives ESBMC adds to C for non-deterministic values, assumptions, and atomic blocks." >}}
   {{< card link="/docs/theory/verification-algorithms" title="Verification Algorithms" subtitle="Bounded model checking, falsification, incremental BMC, and k-induction — how ESBMC unwinds loops and proves correctness." >}}
+  {{< card link="/docs/theory/termination" title="Termination and Non-termination" subtitle="Proving loops halt via ranking functions, refuting them via recurrent sets, and the reduction to a k-induction reachability check." >}}
   {{< card link="/docs/theory/memory-model" title="Memory Model and Pointer Safety" subtitle="How ESBMC models pointers as object + offset and derives bounds, NULL, use-after-free, and leak checks." >}}
   {{< card link="/docs/theory/concurrency" title="Concurrency and Context-Bounded MC" subtitle="Thread interleavings, context bounding, partial-order reduction, and data-race / deadlock detection." >}}
   {{< card link="/docs/theory/interval-analysis" title="Interval Analysis" subtitle="Abstract interpretation that infers variable ranges and injects them as assumptions before SMT solving." >}}

--- a/website/content/docs/theory/termination.md
+++ b/website/content/docs/theory/termination.md
@@ -1,0 +1,130 @@
+---
+title: Termination and Non-termination
+weight: 22
+---
+
+Most ESBMC modes prove *safety* — that nothing bad happens within a bound. The
+`--termination` mode proves a *liveness* property instead:
+
+> for every input, every execution of the program eventually halts.
+
+```sh
+esbmc file.c --termination
+```
+
+A `VERIFICATION SUCCESSFUL` here means every loop in the program is guaranteed to
+finish; a `VERIFICATION FAILED` means ESBMC found an input under which some loop
+runs forever, and reports the non-terminating execution as a counterexample.
+Termination is undecidable in general [1], so — like every other ESBMC mode —
+the analysis is sound but incomplete: it answers `TRUE`, `FALSE`, or `UNKNOWN`.
+
+## Reduction to a safety property {#reduction}
+
+ESBMC does not reason about termination directly. It rewrites the question into
+a reachability problem it already knows how to solve. For each natural loop, a
+GOTO-to-GOTO pass inserts an `assert(false)` *marker* on every edge that leaves
+the loop body — the top-test fall-through, every `break`, and every jump to a
+label outside the loop. The marker carries exactly one bit of information:
+*control left the loop.* The same pass applies the
+[k-induction](/docs/theory/verification-algorithms#k-induction) havoc [4] to the
+loop head, so the marker is evaluated from an arbitrary in-loop state rather than
+only the concrete one.
+
+The two k-induction obligations then read directly as termination verdicts:
+
+- **Forward condition unsatisfiable at *k*** — from the concrete initial state,
+  no execution reaches a loop exit within *k* unwindings *because the loop has
+  fully unwound*. Every iteration is dominated by the guard, so the loop always
+  exits. **The program terminates.**
+- **Inductive step unsatisfiable at *k*** — from a havoc'd in-loop state, no
+  execution can leave the loop within *k* iterations. An adversary controlling
+  the inputs can stay inside forever. **A non-terminating execution exists.**
+
+Anything still open at the maximum *k* is reported as `UNKNOWN`.
+
+## The three-pass pipeline {#pipeline}
+
+The marker reduction above is the fallback. Two cheaper structural analyses run
+first, because each settles a large class of loops without paying for full
+symbolic execution. The passes run in order, and ESBMC stops as soon as one
+returns a definite verdict:
+
+1. **Recurrent-set non-termination.** Looks for a cheap witness that a loop can
+   stay live forever: a reachable set of states the loop can re-enter
+   indefinitely under some input. It targets `while (1)` controller loops that
+   read an input, validate it, and dispatch to a state-machine update — if the
+   solver finds an input under which no branch fires, the loop sits at a fixed
+   point and never exits. This pass only ever reports `FALSE` (non-terminating)
+   or abstains.
+
+2. **Ranking-function synthesis.** Tries to *prove* termination by exhibiting a
+   **ranking function** — an integer measure of the loop state that is bounded
+   below and strictly decreases on every iteration [2]. A measure that cannot
+   decrease forever forces the loop to halt. ESBMC derives candidate measures
+   from the loop guard, synthesises the supporting invariants the measure needs
+   to hold [3], and discharges two SMT obligations per candidate: *bounded below*
+   (the measure cannot drop under its floor while the guard holds) and *strict
+   decrease* (every path through the body lowers it). When no single measure
+   works, a lexicographic pair of measures is tried. This pass only ever reports
+   `TRUE` (terminating) or abstains.
+
+3. **k-induction on the markers.** If neither structural pass settles the loop,
+   ESBMC falls back to the marker-and-havoc reduction of the previous section and
+   lets the incremental [k-induction](/docs/theory/verification-algorithms#k-induction)
+   loop discharge it as an ordinary safety property.
+
+The ordering is deliberate: the structural detectors are cheap and each covers a
+distinct shape (live controller loops; loops with an obvious decreasing measure),
+so the expensive symbolic pipeline only runs on what they leave behind.
+
+## Soundness {#soundness}
+
+The non-negotiable constraint is **no wrong `TRUE`**: ESBMC must never claim a
+non-terminating program terminates. Two places need care.
+
+- **Ranking arguments rest on their supporting invariants.** A measure derived
+  from the guard only proves termination relative to facts the synthesiser can
+  establish about the reachable loop-head states; ranking and reachability are
+  proved together, not separately [3]. If the supporting invariant cannot be
+  established, the candidate is rejected rather than trusted.
+- **The havoc must cover the variables termination depends on.** The inductive
+  step is only a valid non-termination witness if the loop-head havoc actually
+  freed every variable the loop's exit condition reads. A loop that exits on the
+  *contents* of a heap buffer, while only the pointer is in the modified set,
+  would otherwise report non-termination spuriously. ESBMC detects these shapes
+  and treats the inductive-step verdict as inconclusive for them, falling back to
+  the forward condition or the recurrent-set witness.
+
+## Command-line flags {#flags}
+
+```sh
+esbmc file.c --termination --max-inductive-step 3 --interval-analysis
+```
+
+- `--termination` — enable the reduction and the three-pass pipeline above. It
+  is mutually exclusive with `--k-induction` (k-induction takes precedence).
+- `--max-inductive-step N` — cap how far the inductive step unwinds. The decisive
+  non-termination proofs typically fire at small *k* (2 or 3), so a small cap is
+  usually enough.
+- `--interval-analysis` — supply the ranking and recurrent-set passes with
+  per-loop numeric bounds (see [Interval Analysis](/docs/theory/interval-analysis));
+  tighter ranges help the supporting-invariant synthesis converge.
+
+## References
+
+[1] Byron Cook, Andreas Podelski, Andrey Rybalchenko: *Proving Program
+Termination.* Communications of the ACM 54(5):88–98, 2011.
+[doi:10.1145/1941487.1941509](https://doi.org/10.1145/1941487.1941509)
+
+[2] Andreas Podelski, Andrey Rybalchenko: *A Complete Method for the Synthesis of
+Linear Ranking Functions.* VMCAI 2004, LNCS 2937: 239–251.
+[doi:10.1007/978-3-540-24622-0_20](https://doi.org/10.1007/978-3-540-24622-0_20)
+
+[3] Aaron R. Bradley, Zohar Manna, Henny B. Sipma: *Linear Ranking with
+Reachability.* CAV 2005, LNCS 3576: 491–504.
+[doi:10.1007/11513988_48](https://doi.org/10.1007/11513988_48)
+
+[4] Mikhail Y. R. Gadelha, Hussama Ibrahim Ismail, Lucas C. Cordeiro: *Handling
+loops in bounded model checking of C programs via k-induction.* Int. J. Softw.
+Tools Technol. Transf. 19(1):97–114, 2017.
+[doi:10.1007/s10009-015-0407-9](https://doi.org/10.1007/s10009-015-0407-9)

--- a/website/content/docs/theory/verification-algorithms.md
+++ b/website/content/docs/theory/verification-algorithms.md
@@ -110,6 +110,44 @@ program until it finds a bug (base case satisfiable), proves correctness (base
 case unsatisfiable and either the forward condition or inductive step
 unsatisfiable), or exhausts the time or memory limit.
 
+For loops whose termination matters as a property in its own right, the same
+machinery is reused to prove (or refute) that loops halt — see
+[Termination and Non-termination](/docs/theory/termination).
+
+### Strengthening the inductive step {#strengthening-is}
+
+The inductive step is where *k*-induction gets its power to prove unbounded
+safety, and also where it is weakest. To model an *arbitrary* loop iteration it
+**havocs** the loop-modified variables — assigns each a fresh non-deterministic
+value — which erases everything symbolic execution had learned about them. The
+havoc is sound, but imprecise: it admits states no real execution can reach, so
+the inductive step often reports a *spurious* counterexample and fails to close
+an otherwise-valid proof.
+
+ESBMC recovers the lost precision without giving up soundness. The key
+observation is that any *sound over-approximation* of the states reachable at the
+loop head may be re-asserted as an inductive hypothesis immediately after the
+havoc: doing so can only prune spurious havoc-induced states, never a real
+inductive counterexample [6]. ESBMC supplies two such hypotheses:
+
+- **Numeric bounds.** After the havoc is in place, the
+  [interval analysis](/docs/theory/interval-analysis) is recomputed on the
+  transformed program and the inferred range for each loop variable is injected
+  as an assumption at the loop head. This re-establishes the variable bounds the
+  havoc discarded, so the inductive step reasons over realistic values.
+- **Pointer points-to sets.** Under value-set (points-to) analysis, a havoc'd
+  pointer would otherwise range over every object. ESBMC pins it to the sound set
+  of candidate objects the analysis already proved it may reference, recovering
+  enough shape information to discharge traversal-style loops over linked
+  structures.
+
+Both hypotheses are tagged so that **only the inductive step sees them** — the
+base case and forward condition are untouched, so bug-finding and the bounded
+proof are unaffected. Each hypothesis is applied only where it provably
+over-approximates the reachable loop-head states; where that cannot be
+guaranteed, the inductive step falls back to the plain havoc (sound, if less
+precise).
+
 ## References
 
 [1] Mikhail Y. R. Gadelha, Felipe R. Monteiro, Jeremy Morse, Lucas C. Cordeiro,
@@ -129,3 +167,7 @@ Using Induction and a SAT-Solver.* FMCAD 2000: 108–125
 [5] Mikhail Y. R. Gadelha, Hussama Ibrahim Ismail, Lucas C. Cordeiro: *Handling
 loops in bounded model checking of C programs via k-induction.* Int. J. Softw.
 Tools Technol. Transf. 19(1):97–114, 2017. [doi:10.1007/s10009-015-0407-9](https://doi.org/10.1007/s10009-015-0407-9)
+
+[6] Martin Brain, Saurabh Joshi, Daniel Kroening, Peter Schrammel: *Safety
+Verification and Refutation by k-Invariants and k-Induction.* SAS 2015, LNCS
+9291: 145–161. [doi:10.1007/978-3-662-48288-9_9](https://doi.org/10.1007/978-3-662-48288-9_9)


### PR DESCRIPTION
## What

Updates the [Theory documentation](https://esbmc.github.io/docs/theory/) to cover two areas that were previously undocumented on the site:

1. **New page — Termination and Non-termination** (`termination.md`). Explains the `--termination` property, its reduction to a safety/reachability problem via per-loop exit markers, and the three-pass pipeline:
   - recurrent-set **non-termination** refutation,
   - **ranking-function** synthesis (bounded-below + strictly-decreasing measure, with supporting invariants),
   - fallback to **k-induction** on the inserted markers (forward-condition ⇒ terminates, inductive-step ⇒ non-terminating).
   - Includes the soundness discussion (no wrong `TRUE`) and the relevant CLI flags.

2. **Verification Algorithms page** — new *"Strengthening the inductive step"* section. Describes, at a conceptual level, how ESBMC recovers precision lost to the inductive-step havoc by re-asserting sound over-approximations of the loop-head state: post-havoc **interval bounds** and **value-set pointer invariants**, both injected as IS-only hypotheses so the base case / forward condition (and hence bug-finding) are unaffected.

3. **Index** — adds a card for the new page, and cross-links the two pages.

## Why

These reflect verification capabilities ESBMC already ships (`--termination`, the ranking/recurrent-set passes, and the interval/value-set inductive-step strengthening) that had no user-facing theory page. Content is written in the existing house style of the theory section (concise, conceptual, CLI examples, numbered references with DOIs).

## Citations

The four newly added references were verified verbatim (title, authors, venue, year, DOI) against DBLP / Springer / ACM before inclusion:

- Podelski & Rybalchenko, *A Complete Method for the Synthesis of Linear Ranking Functions*, VMCAI 2004 — `10.1007/978-3-540-24622-0_20`
- Cook, Podelski & Rybalchenko, *Proving Program Termination*, CACM 2011 — `10.1145/1941487.1941509`
- Bradley, Manna & Sipma, *Linear Ranking with Reachability*, CAV 2005 — `10.1007/11513988_48`
- Brain, Joshi, Kroening & Schrammel, *Safety Verification and Refutation by k-Invariants and k-Induction*, SAS 2015 — `10.1007/978-3-662-48288-9_9`

## Testing

Docs-only change. Rendered locally with Hugo (content + shortcodes consistent with the existing theory pages); the full module build runs in the `pages.yml` CI workflow.