### PR TITLE
[solver] Add a cache fast path to convert_ast

### DIFF
--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -409,6 +409,18 @@ static bool walks_operands(const expr2tc &expr)
 
 smt_astt smt_solver_baset::convert_ast(const expr2tc &expr)
 {
+  // Fast path: a hit returns without building a worklist. convert_ast_node
+  // re-enters convert_ast for every operand/sub-expression it converts, and on
+  // the warmed post-order path those re-entrant calls are guaranteed hits;
+  // checking the cache up front keeps them O(1) instead of paying a worklist
+  // allocation per call.
+  {
+    std::lock_guard lock(smt_cache_mutex);
+    smt_cachet::const_iterator hit = smt_cache.find(expr);
+    if (hit != smt_cache.end())
+      return hit->ast;
+  }
+
   // Warm the cache bottom-up with an explicit-stack post-order walk so that
   // the per-node body (convert_ast_node) never has to recurse through a long
   // chain of operands. This keeps deeply left-nested associative expressions


### PR DESCRIPTION
## What

Adds an entry-level cache check to `smt_solver_baset::convert_ast`, so a cache hit returns before the explicit-stack worklist is allocated.

## Why

`convert_ast` was made iterative (explicit-stack post-order warm-up) to avoid stack overflow on deeply nested expressions. But the cache check only happened *inside* the worklist loop, after the `std::vector` worklist was constructed and the root pushed. Since `convert_ast_node` re-enters `convert_ast` for every operand/sub-expression it lowers — and on the warmed post-order path those re-entrant calls are guaranteed cache hits — each such call was paying a needless worklist allocation.

## How

Check `smt_cache` up front; on a hit, return the cached ast immediately. On a miss, fall through to the existing worklist exactly as before.

This is the first, lowest-risk step of reducing `convert_ast` re-entrancy overhead. It does not change recursion depth or the formula — it only removes per-call overhead on the hot re-entrant conversion paths.

## Verification

- **Formula parity:** `--smt-formula-only` output is byte-identical to master (normalised for node-id numbering) on a byte-update/struct case (`regression/esbmc/github_1210-2-struct`).
- 422 unit tests pass; 179-test solver-heavy regression slice (structs, vectors, arrays, C++ containers, Python list-slice) passes.
- Encoding-phase time on `python/list-slice-assign` improves (~2.5s vs ~3.2s) with no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)