### PR TITLE
[symex] regression tests for whoami no-overflow false alarm (#4978)

### DIFF
--- a/regression/esbmc/github_4978/main.c
+++ b/regression/esbmc/github_4978/main.c
@@ -1,0 +1,56 @@
+#include <stdarg.h>
+#include <string.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Regression for GitHub #4978 (SV-COMP busybox whoami-incomplete-1, no-overflow).
+// Reduced from bb_verror_msg: the overflow-checked expression is
+//   applet_len + used + strerr_len + msgeol_len + 3
+// where every term is a signed int.  `used` is the vasprintf return value.
+// Before #5270 wired vasprintf into symex_printf, its return was an
+// unconstrained nondet, so the solver could pick used = INT_MAX and the signed
+// add appeared to overflow -- a spurious counterexample (originally reported at
+// k = 11 under k-induction).  With the wiring, the constant "%u" format is
+// soundly bounded by printf_formatter to a small range ([13,22] here), so the
+// sum is provably safe.  (The complementary INT_MAX/2 cap from #5278 covers the
+// harder case of an unbounded format such as "%s"; see vasprintf_unbounded_s_*.)
+//
+// The 10-iteration applet_name loop drives k-induction to the k = 11 step where
+// the original false alarm fired, which the simpler vasprintf_* tests do not.
+static const char *msg_eol = "\n";
+static char applet_buf[11];
+
+static int verror(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  int used = vasprintf(&msg, s, p);
+  if (used < 0)
+    return 0;
+
+  int applet_len = (int)(strlen(applet_buf) + 2);
+  int strerr_len = (int)(strerr ? strlen(strerr) : 0);
+  int msgeol_len = (int)strlen(msg_eol);
+
+  // Overflow-checked add: must not report a spurious signed overflow.
+  return applet_len + used + strerr_len + msgeol_len + 3;
+}
+
+static void error_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  verror(s, p, (const char *)0);
+  va_end(p);
+}
+
+int main(void)
+{
+  // Bounded applet name, matching the harness (10 nondet bytes + NUL).
+  for (int i = 0; i < 10; ++i)
+    applet_buf[i] = (char)__VERIFIER_nondet_int();
+  applet_buf[10] = 0;
+
+  error_and_die("unknown uid %u", (unsigned)__VERIFIER_nondet_int());
+  return 0;
+}

--- a/regression/esbmc/github_4978/test.desc
+++ b/regression/esbmc/github_4978/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4978_fail/main.c
+++ b/regression/esbmc/github_4978_fail/main.c
@@ -1,0 +1,36 @@
+#include <stdarg.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Negative companion to GitHub #4978.  Bounding the vasprintf return (#5270)
+// must not suppress overflow detection in the bb_verror_msg arithmetic shape:
+// when another operand is genuinely unbounded the signed add can still overflow
+// and ESBMC must report it.  Here applet_len is an unbounded nondet value, so
+// `applet_len + used` overflows for real.  (used itself is bounded to [13,22]
+// by the constant "%u" format, so the overflow is necessarily driven by
+// applet_len -- which is exactly the point: the checker stays live.)
+static int verror(const char *s, va_list p, int applet_len)
+{
+  char *msg;
+  int used = vasprintf(&msg, s, p);
+  if (used < 0)
+    return 0;
+
+  // Overflow-checked add with an unbounded applet_len: a real overflow exists.
+  return applet_len + used + 3;
+}
+
+static void error_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  verror(s, p, __VERIFIER_nondet_int());
+  va_end(p);
+}
+
+int main(void)
+{
+  error_and_die("unknown uid %u", (unsigned)__VERIFIER_nondet_int());
+  return 0;
+}

--- a/regression/esbmc/github_4978_fail/test.desc
+++ b/regression/esbmc/github_4978_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION FAILED$
+^Violated property:$
+^.*arithmetic overflow on add$


### PR DESCRIPTION
## Summary

Adds regression tests for the SV-COMP busybox `whoami-incomplete-1` no-overflow false alarm (#4978). **The false alarm is already fixed on `master`** — this PR pins the behaviour so it cannot silently regress; no source change is needed.

## Root cause and fix

In `bb_verror_msg`, the overflow-checked expression `applet_len + used + strerr_len + msgeol_len + 3` has one variable term, `used = vasprintf(&msg, "unknown uid %u", p)`. Before #5270 wired `vasprintf` into `symex_printf`, the return value was an unconstrained nondet, so the solver could pick `used = INT_MAX` and the signed add appeared to overflow — the spurious counterexample originally reported at **k = 11** under k-induction.

#5270 routes `vasprintf` through `printf_formatter`, which soundly bounds the constant `"%u"` format to `[13,22]`, making the sum provably safe. The complementary `INT_MAX/2` cap from #5278 covers the harder unbounded-format case (`%s`, #5144), which this benchmark does not hit.

I verified (via an injected `__ESBMC_assert(used <= 100)`) that both the reduced test and the real benchmark take the bounded `%u` path. The current binary reports `VERIFICATION SUCCESSFUL` and clears the k = 11 base case that previously produced `FALSE_OVERFLOW`.

## Tests

- `regression/esbmc/github_4978/` — positive: faithful reduction of `bb_verror_msg` (constant `%u`, `va_list` passed two call levels, NULL `strerr`, the 4-operand sum) with a 10-iteration loop that drives k-induction to k = 11. Expects `VERIFICATION SUCCESSFUL`.
- `regression/esbmc/github_4978_fail/` — negative companion: an unbounded `applet_len` so a genuine overflow on `applet_len + used` remains, with the overflow property pinned in `test.desc`. Expects `VERIFICATION FAILED`.

Both pass via `ctest`; clang-format clean; existing `vasprintf_*` tests unaffected.

Fixes #4978