### PR TITLE
[python] Elide dead duplicate build of List/ListComp RHS literals

### DIFF
--- a/regression/python/nested-list-build-dedup/main.py
+++ b/regression/python/nested-list-build-dedup/main.py
@@ -1,0 +1,13 @@
+# In-function (@F scope) 2D list literal: the converter used to build the
+# literal twice (once as a discarded type probe). Reads must still see the
+# correct values after that dead duplicate is elided (#5121).
+def main():
+    a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    b = [[9, 8, 7], [6, 5, 4], [3, 2, 1]]
+    s = 0
+    for i in range(3):
+        for j in range(3):
+            s = s + a[i][j] * b[i][j]
+    assert s == 165
+
+main()

--- a/regression/python/nested-list-build-dedup/test.desc
+++ b/regression/python/nested-list-build-dedup/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+ --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-list-build-dedup_fail/main.py
+++ b/regression/python/nested-list-build-dedup_fail/main.py
@@ -1,0 +1,12 @@
+# Negative variant: the same construction-heavy 2D workload with a wrong
+# expected sum must still be caught (verdict unchanged by the dedup, #5121).
+def main():
+    a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    b = [[9, 8, 7], [6, 5, 4], [3, 2, 1]]
+    s = 0
+    for i in range(3):
+        for j in range(3):
+            s = s + a[i][j] * b[i][j]
+    assert s == 164
+
+main()

--- a/regression/python/nested-list-build-dedup_fail/test.desc
+++ b/regression/python/nested-list-build-dedup_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+ --unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1700,8 +1700,20 @@ void python_converter::get_var_assign(
       is_right = true;
       if (!ast_node["value"].is_null())
       {
-        // Skip getting expr for dict literals - handle specially later
-        if (!dict_handler_->is_dict_literal(ast_node["value"]))
+        // This RHS build only exists to probe rhs.type() for the Any/char*
+        // string adjustment below; the value is discarded and the real RHS is
+        // built again later. Skip it for kinds whose type is statically known
+        // and never a char* string, otherwise get_expr emits the whole
+        // construction a second time as dead code. Dict literals were already
+        // skipped (handled specially later); list literals and comprehensions
+        // matter most — eliding their dead duplicate roughly halves
+        // list-construction cost on construction-heavy programs (#5121).
+        const std::string rhs_kind =
+          ast_node["value"].value("_type", std::string());
+        const bool rhs_kind_skips_type_probe =
+          dict_handler_->is_dict_literal(ast_node["value"]) ||
+          rhs_kind == "List" || rhs_kind == "ListComp";
+        if (!rhs_kind_skips_type_probe)
         {
           if (ast_node["_type"] != "Call")
           {


### PR DESCRIPTION
## What

`get_var_assign` built the RHS expression once only to probe `rhs.type()` for the `Any`/`char*` string adjustment, then discarded it and built the real RHS again later. For `List`/`ListComp` literals the type is statically known and never a `char*` string, so this probe emitted the entire construction a second time as dead code, roughly doubling list-construction VCCs on construction-heavy programs.

This skips the type probe for `List`/`ListComp` kinds (dict literals were already skipped). On a 2D nested-list workload this roughly halves construction cost (#5121: `nl_int` 2D 4084→3260 VCCs, −20% overall).

## Why

Pure dead-code elision — the probe's result is discarded for these kinds and their type is statically known, so the second build never changes the lowered program or the verdict.

## Tests

- `regression/python/nested-list-build-dedup` — construction-heavy 2D literal workload, reads must still see correct values (`VERIFICATION SUCCESSFUL`).
- `regression/python/nested-list-build-dedup_fail` — same workload with a wrong expected sum, verdict unchanged by the dedup (`VERIFICATION FAILED`).

Fixes #5121.