### PR TITLE
[symex] regression pins for busybox bb_verror_msg no-overflow false alarms (#4977, #4979, #5143)

### DIFF
--- a/regression/esbmc/github_4977/main.c
+++ b/regression/esbmc/github_4977/main.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <string.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Regression for GitHub #4977 (SV-COMP busybox sync-2, no-overflow).
+// Same bb_verror_msg overflow shape as #4978, but the sync applet's call is
+//   bb_error_msg("ignoring all arguments")
+// i.e. a *constant format with no conversion specifier*.  vasprintf then
+// returns exactly strlen("ignoring all arguments") == 22, the simplest case of
+// the printf_formatter return-length bound wired up by #5270.  Before that
+// wiring `used` was an unconstrained nondet, so the solver could pick
+// used = INT_MAX and the signed add `applet_len + used + ...` appeared to
+// overflow -- the spurious counterexample originally reported at k = 11 under
+// k-induction.  With the constant-length bound the sum is provably safe.
+//
+// The 10-iteration applet_name loop drives k-induction to the k = 11 step where
+// the original false alarm fired.
+static const char *msg_eol = "\n";
+static char applet_buf[11];
+
+static int verror(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  int used = vasprintf(&msg, s, p);
+  if (used < 0)
+    return 0;
+
+  int applet_len = (int)(strlen(applet_buf) + 2);
+  int strerr_len = (int)(strerr ? strlen(strerr) : 0);
+  int msgeol_len = (int)strlen(msg_eol);
+
+  // Overflow-checked add: must not report a spurious signed overflow.
+  return applet_len + used + strerr_len + msgeol_len + 3;
+}
+
+static void error_msg(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  verror(s, p, (const char *)0);
+  va_end(p);
+}
+
+int main(void)
+{
+  for (int i = 0; i < 10; ++i)
+    applet_buf[i] = (char)__VERIFIER_nondet_int();
+  applet_buf[10] = 0;
+
+  // Constant format, no varargs (the sync applet's "ignoring all arguments").
+  error_msg("ignoring all arguments");
+  return 0;
+}

--- a/regression/esbmc/github_4977/test.desc
+++ b/regression/esbmc/github_4977/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4979/main.c
+++ b/regression/esbmc/github_4979/main.c
@@ -1,0 +1,52 @@
+#include <stdarg.h>
+#include <string.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Regression for GitHub #4979 (SV-COMP busybox whoami-incomplete-2, no-overflow).
+// Identical bb_verror_msg overflow shape as #4978: the whoami applet's call is
+//   bb_error_msg_and_die("unknown uid %u", (unsigned)uid)
+// so `used = vasprintf(&msg, "unknown uid %u", p)` is bounded by
+// printf_formatter to [13,22] once #5270 wired vasprintf into symex_printf.
+// Before that the return was an unconstrained nondet and the signed add
+// `applet_len + used + strerr_len + msgeol_len + 3` appeared to overflow -- the
+// spurious counterexample originally reported at k = 11 under k-induction.
+//
+// This pins the whoami-incomplete-2 variant specifically (the -1 variant is
+// #4978); both exercise the constant "%u" return-length bound.
+static const char *msg_eol = "\n";
+static char applet_buf[11];
+
+static int verror(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  int used = vasprintf(&msg, s, p);
+  if (used < 0)
+    return 0;
+
+  int applet_len = (int)(strlen(applet_buf) + 2);
+  int strerr_len = (int)(strerr ? strlen(strerr) : 0);
+  int msgeol_len = (int)strlen(msg_eol);
+
+  // Overflow-checked add: must not report a spurious signed overflow.
+  return applet_len + used + strerr_len + msgeol_len + 3;
+}
+
+static void error_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  verror(s, p, (const char *)0);
+  va_end(p);
+}
+
+int main(void)
+{
+  for (int i = 0; i < 10; ++i)
+    applet_buf[i] = (char)__VERIFIER_nondet_int();
+  applet_buf[10] = 0;
+
+  error_and_die("unknown uid %u", (unsigned)__VERIFIER_nondet_int());
+  return 0;
+}

--- a/regression/esbmc/github_4979/test.desc
+++ b/regression/esbmc/github_4979/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5143/main.c
+++ b/regression/esbmc/github_5143/main.c
@@ -1,0 +1,58 @@
+#include <stdarg.h>
+#include <string.h>
+
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+extern int __VERIFIER_nondet_int(void);
+
+// Regression for GitHub #5143 (SV-COMP busybox usleep-1, no-overflow).
+// Same bb_verror_msg overflow shape as #4978, but the usleep applet's failing
+// call uses a *non-literal "%s"* format:
+//   bb_error_msg_and_die("invalid number '%s'", numstr)
+// Unlike the constant "%u" case (#4978/#4979) the "%s" argument has no static
+// length, so printf_formatter cannot give a tight bound.  This is the harder
+// path: #5278 caps the modelled return at INT_MAX/2 so it stays a sound
+// over-approximation (R >= true length) while keeping the signed add
+// `applet_len + used + strerr_len + msgeol_len + 3` provably non-overflowing
+// for the small operands here.  Before #5270/#5278 `used` was an unconstrained
+// nondet and the add reported a spurious overflow at k = 11 under k-induction.
+static const char *msg_eol = "\n";
+static char applet_buf[11];
+static char numbuf[8];
+
+static int verror(const char *s, va_list p, const char *strerr)
+{
+  char *msg;
+  int used = vasprintf(&msg, s, p);
+  if (used < 0)
+    return 0;
+
+  int applet_len = (int)(strlen(applet_buf) + 2);
+  int strerr_len = (int)(strerr ? strlen(strerr) : 0);
+  int msgeol_len = (int)strlen(msg_eol);
+
+  // Overflow-checked add: must not report a spurious signed overflow.
+  return applet_len + used + strerr_len + msgeol_len + 3;
+}
+
+static void error_and_die(const char *s, ...)
+{
+  va_list p;
+  va_start(p, s);
+  verror(s, p, (const char *)0);
+  va_end(p);
+}
+
+int main(void)
+{
+  for (int i = 0; i < 10; ++i)
+    applet_buf[i] = (char)__VERIFIER_nondet_int();
+  applet_buf[10] = 0;
+
+  // Bounded, NUL-terminated numeric string passed through a non-literal "%s".
+  for (int i = 0; i < 7; ++i)
+    numbuf[i] = (char)('0' + (__VERIFIER_nondet_int() & 7));
+  numbuf[7] = 0;
+
+  error_and_die("invalid number '%s'", numbuf);
+  return 0;
+}

--- a/regression/esbmc/github_5143/test.desc
+++ b/regression/esbmc/github_5143/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## Summary

Pins the three remaining SV-COMP busybox `no-overflow` false alarms in the `bb_verror_msg` family — **sync-2 (#4977)**, **whoami-incomplete-2 (#4979)** and **usleep-1 (#5143)**. As with the already-merged #4978 (whoami-incomplete-1, PR #5372), **the false alarm is already fixed on `master`** — this PR adds per-issue regression tests so the behaviour cannot silently regress. No source change is needed.

## Root cause and why it is fixed

All three benchmarks fail the same way. `bb_verror_msg` builds an error string and overflow-checks the signed sum

```c
applet_len + used + strerr_len + msgeol_len + 3
```

whose only variable term is `used = vasprintf(&msg, fmt, p)`. Before #5270 wired `vasprintf` into `symex_printf`, the return value was an unconstrained nondet, so the solver could pick `used = INT_MAX` and the signed add appeared to overflow — the spurious counterexample originally reported at **k = 11** under k-induction. #5270 routes `vasprintf` through `printf_formatter`, which soundly bounds the return length; #5278 adds the complementary `INT_MAX/2` cap for unbounded formats.

I confirmed on a current build that each benchmark now reports `VERIFICATION SUCCESSFUL`, and that the bound is genuinely active (probed with an injected `__ESBMC_assert`): a constant no-specifier format yields the exact length 22, and a non-literal `%s` is capped at `INT_MAX/2` (= 1073741823), never `0`.

## Tests

Each reduction faithfully mirrors `bb_verror_msg` (the 4-operand sum, `va_list` passed two call levels, NULL `strerr`) and drives k-induction to **k = 11** via a 10-iteration applet-name loop — the step where the original alarm fired. Each exercises a **distinct** `printf_formatter` return-length path:

| Test | Benchmark | Format | Bound path |
|---|---|---|---|
| `regression/esbmc/github_4977` | sync-2 | `"ignoring all arguments"` | constant, no specifier → exact length |
| `regression/esbmc/github_4979` | whoami-incomplete-2 | `"unknown uid %u"` | constant `%u` → `[13,22]` |
| `regression/esbmc/github_5143` | usleep-1 | `"invalid number '%s'"` | non-literal `%s` → `INT_MAX/2` cap (#5278) |

All three expect `VERIFICATION SUCCESSFUL` and pass via `ctest`; clang-format clean. The existing `github_4978_fail` negative test already guards that bounding the return does **not** suppress a genuine overflow, so no new negative test is added.

## Validation

- `ctest -R "github_4977|github_4979|github_5143"` → 3/3 passed.
- Re-ran the three original `.i` benchmarks (busybox `sync-2`, `whoami-incomplete-2`, `usleep-1`) with the SV-COMP `no-overflow` flags → all `VERIFICATION SUCCESSFUL` (previously `FALSE_OVERFLOW` at k = 11).

Fixes #4977
Fixes #4979
Fixes #5143