### PR TITLE
[symex] Don't model non-scalar uninterpreted functions as native UFs

### DIFF
--- a/regression/esbmc/cprover_uninterpreted_pointer_arg/main.c
+++ b/regression/esbmc/cprover_uninterpreted_pointer_arg/main.c
@@ -1,0 +1,19 @@
+// A "__CPROVER_uninterpreted_*" function whose argument is a pointer (here a
+// "const void *", as in CBMC's aws-c-common hash-table harnesses). A pointer
+// lowers to a tuple sort, which the SMT backend cannot use as an uninterpreted-
+// function domain; modelling it as a native uninterpreted function used to
+// abort ESBMC in to_solver_smt_sort (GitHub #5369). The signature is now
+// detected as non-scalar and the result is modelled as a fresh nondet value
+// (sound over-approximation), so encoding completes and an unrelated property
+// is proved without a crash.
+unsigned long __CPROVER_uninterpreted_hasher(const void *key);
+
+int main()
+{
+  int x = 3;
+  const void *p = &x;
+  unsigned long h = __CPROVER_uninterpreted_hasher(p);
+  (void)h;
+  __ESBMC_assert(x == 3, "unrelated property holds; UF call must not crash");
+  return 0;
+}

--- a/regression/esbmc/cprover_uninterpreted_pointer_arg/test.desc
+++ b/regression/esbmc/cprover_uninterpreted_pointer_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cprover_uninterpreted_pointer_arg_fail/main.c
+++ b/regression/esbmc/cprover_uninterpreted_pointer_arg_fail/main.c
@@ -1,0 +1,16 @@
+// Soundness check for the non-scalar uninterpreted-function fallback. A pointer
+// argument makes the signature non-scalar, so the result is modelled as a fresh
+// nondeterministic value (functional congruence is dropped). That value must be
+// genuinely unconstrained: a reachable property that depends on it must still be
+// refutable, so the violation is found rather than masked. Previously this call
+// aborted ESBMC before any verdict (GitHub #5369).
+unsigned long __CPROVER_uninterpreted_hasher(const void *key);
+
+int main()
+{
+  int x;
+  const void *p = &x;
+  unsigned long h = __CPROVER_uninterpreted_hasher(p);
+  __ESBMC_assert(h != 42, "UF result is unconstrained, so h can be 42");
+  return 0;
+}

--- a/regression/esbmc/cprover_uninterpreted_pointer_arg_fail/test.desc
+++ b/regression/esbmc/cprover_uninterpreted_pointer_arg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/esbmc_uninterpreted_pointer_arg/main.c
+++ b/regression/esbmc/esbmc_uninterpreted_pointer_arg/main.c
@@ -1,0 +1,15 @@
+// The native "__ESBMC_uninterpreted_*" prefix (always modelled as an
+// uninterpreted function, no flag) routes through the same handler as the
+// "__CPROVER_uninterpreted_*" alias, so it shares the non-scalar-argument
+// fix for GitHub #5369: a pointer argument must not abort the SMT backend.
+unsigned long __ESBMC_uninterpreted_hasher(const void *key);
+
+int main()
+{
+  int x = 7;
+  const void *p = &x;
+  unsigned long h = __ESBMC_uninterpreted_hasher(p);
+  (void)h;
+  __ESBMC_assert(x == 7, "unrelated property holds; native UF must not crash");
+  return 0;
+}

--- a/regression/esbmc/esbmc_uninterpreted_pointer_arg/test.desc
+++ b/regression/esbmc/esbmc_uninterpreted_pointer_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -316,14 +316,47 @@ bool goto_symext::symex_uninterpreted_function(
     do_simplify(argument);
   }
 
-  // Emit an uninterpreted-function application and assign it to the return.
-  // Functional congruence (equal arguments imply an equal result) is enforced
-  // downstream by the SMT backend's native uninterpreted-function support
-  // (with a generic Ackermannisation fallback for solvers that lack it), so no
-  // congruence history is tracked here. Key the function on the full mangled
-  // identifier so two genuinely distinct symbols that share a C-level name are
-  // never tied together by congruence.
-  expr2tc result = uninterpreted_func2tc(call.ret->type, mangled, arguments);
+  // A native uninterpreted-function symbol can only be declared over scalar
+  // (number/bool) argument and result sorts. A pointer or aggregate operand
+  // lowers to a tuple sort, which mk_smt_uninterpreted_function cannot encode
+  // and which aborts the solver backend (GitHub #5369; the CBMC aws-c-common
+  // harnesses hit this with a `const void *` hasher/equals argument). When any
+  // argument or the result is non-scalar, fall back to a fresh nondeterministic
+  // result. This is a sound over-approximation: it drops only the functional-
+  // congruence constraint (equal arguments need no longer imply an equal
+  // result), never adding behaviour, and the body is still discarded.
+  bool uf_encodable = is_number_type(call.ret->type);
+  for (const expr2tc &argument : arguments)
+    uf_encodable = uf_encodable && is_number_type(argument->type);
+
+  expr2tc result;
+  if (uf_encodable)
+  {
+    // Emit an uninterpreted-function application and assign it to the return.
+    // Functional congruence (equal arguments imply an equal result) is enforced
+    // downstream by the SMT backend's native uninterpreted-function support
+    // (with a generic Ackermannisation fallback for solvers that lack it), so
+    // no congruence history is tracked here. Key the function on the full
+    // mangled identifier so two genuinely distinct symbols that share a C-level
+    // name are never tied together by congruence.
+    result = uninterpreted_func2tc(call.ret->type, mangled, arguments);
+  }
+  else
+  {
+    log_debug(
+      "symex",
+      "uninterpreted function '{}' has a non-scalar signature; modelling its "
+      "result as unconstrained nondet (no functional congruence)",
+      name);
+    result = sideeffect2tc(
+      call.ret->type,
+      expr2tc(),
+      expr2tc(),
+      std::vector<expr2tc>(),
+      type2tc(),
+      sideeffect2t::allockind::nondet);
+    replace_nondet(result);
+  }
 
   symex_assign(code_assign2tc(call.ret, result));
   return true;


### PR DESCRIPTION
## Problem

Calls to `__ESBMC_uninterpreted_*` / `__CPROVER_uninterpreted_*` are modelled as native SMT uninterpreted functions (#5364). A native UF symbol can only be declared over **scalar** sorts. When an argument or the result is a pointer or aggregate — which lowers to a *tuple* sort — `mk_smt_uninterpreted_function` feeds that tuple sort to `to_solver_smt_sort<...>`, whose `dynamic_cast` fails and aborts ESBMC:

```
Assertion failed: (r), function to_solver_smt_sort, file smt_sort.h, line 220.
```

This is reachable from ordinary input: the CBMC `aws-c-common` hash-table harnesses declare a `const void *` hasher/equals, so the SV-COMP `aws_hash_table_create_harness` reproducer (#5145 / #5287) now crashes during encoding instead of returning a verdict.

Minimal reproducer:

```c
unsigned long __CPROVER_uninterpreted_hasher(const void *key);
int main(void) {
  int x; const void *p = &x;
  unsigned long h1 = __CPROVER_uninterpreted_hasher(p);
  unsigned long h2 = __CPROVER_uninterpreted_hasher(p);
  __ESBMC_assert(h1 == h2, "congruence");
  return 0;
}
```

## Root cause

`is_number_type` (bv/fixedbv/floatbv/bool) is exactly the set of types `convert_sort` maps to a flat solver sort. Every other type a UF argument/result can have — pointer, struct, union, array, code — lowers to a tuple or array sort that cannot be a UF domain or range. The model in `symex_uninterpreted_function` emitted a native UF unconditionally, so any non-scalar signature reached the backend and aborted.

## Fix

`goto_symext::symex_uninterpreted_function` now emits a native `uninterpreted_func2tc` only when the result **and every argument** are `is_number_type`; otherwise it models the result as a fresh unconstrained nondet value (the same `sideeffect2tc(..., nondet)` + `replace_nondet` idiom used in `io.cpp`).

This is **sound**: dropping functional congruence only weakens the constraints on the result, so it can never rule out a feasible bug — at worst it admits a spurious counterexample (a precision loss), never a missed one. It also matches the pre-#5364 behaviour for these signatures (a bodyless function returned nondet). Scalar congruence is unchanged.

## Validation

- Minimal `const void *` reproducer: SIGABRT → clean verdict; int-argument control still `VERIFICATION SUCCESSFUL`.
- All 9 uninterpreted-function regression tests pass (6 existing scalar + 3 new).
- Pointer-soundness guards `github_2153{,_2..5}` and the pointer/dereference unit tests pass.
- `clang-format` (Clang 11) clean.

Three regression tests are added:

- `cprover_uninterpreted_pointer_arg` — pointer-argument UF must encode without aborting (SUCCESSFUL on an unrelated property).
- `esbmc_uninterpreted_pointer_arg` — same for the always-on native prefix.
- `cprover_uninterpreted_pointer_arg_fail` — soundness probe: the nondet fallback must stay refutable, so a reachable violation through the UF result is still found (FAILED).

This stops the crash so the harness yields a verdict again; it is not the deeper #5287/#5369 pointer-identity false alarm, which remains a separate memory-model limitation.

Fixes #5369
