### PR TITLE
[ir-ieee] add fma interval lifting

### DIFF
--- a/regression/ir-ra/ra-fma-basic/main.c
+++ b/regression/ir-ra/ra-fma-basic/main.c
@@ -1,0 +1,15 @@
+/* Regression test: fma(2.0, 3.0, 4.0) == 10.0 under --ir-ieee.
+ *
+ * FMA is fused: the exact real value 2*3+4 = 10 is computed in one step.
+ * Under --ir-ieee the interval for the result is [10 - eps, 10 + eps],
+ * which still contains only 10.0 for double precision.
+ * The assertion must hold: VERIFICATION SUCCESSFUL. */
+
+#include <math.h>
+
+int main(void)
+{
+  double r = fma(2.0, 3.0, 4.0);
+  __ESBMC_assert(r == 10.0, "fma(2,3,4) must equal 10");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-basic/test.desc
+++ b/regression/ir-ra/ra-fma-basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-interval-lift-core/main.c
+++ b/regression/ir-ra/ra-fma-interval-lift-core/main.c
@@ -1,0 +1,31 @@
+/* Regression test: FMA interval-lifted path produces a sound result
+ * under --ir-ieee with nondet bounded inputs (CORE, no formula-shape check).
+ *
+ * x in [1, 2],  y in [3, 4],  z in [5, 6]
+ * Exact FMA range: x*y + z in [8, 14].
+ * After RNE enclosure the interval is [8 - eps, 14 + eps] where
+ * eps ~ 2^-53 * 14 + 2^-1074 << 1, so the lower bound stays well above 7.
+ *
+ * assert(r > 7.0) must hold: VERIFICATION SUCCESSFUL confirms that the
+ * interval-lifted FMA path does not over-approximate into a false alarm
+ * on bounded nondet inputs. */
+
+#include <assert.h>
+#include <math.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  __ESBMC_assume(x >= 1.0 && x <= 2.0);
+  __ESBMC_assume(y >= 3.0 && y <= 4.0);
+  __ESBMC_assume(z >= 5.0 && z <= 6.0);
+
+  double r = fma(x, y, z);
+
+  assert(r > 7.0);
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-interval-lift-core/test.desc
+++ b/regression/ir-ra/ra-fma-interval-lift-core/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-interval-lift-rna/main.c
+++ b/regression/ir-ra/ra-fma-interval-lift-rna/main.c
@@ -1,0 +1,32 @@
+/* Regression test: FMA interval lifting under --ir-ieee (RNA / ROUND_TO_AWAY).
+ *
+ * Verifies that encode_ieee_fma takes the RNA interval-lifted path when
+ * __ESBMC_rounding_mode == 1 (ROUND_TO_AWAY).
+ *
+ * x in [1, 2],  y in [3, 4],  z in [5, 6]
+ * FMA hull [8, 14]; RNA enclosure adds symmetric B_near bounds.
+ * Assertion r > 100 is always false: VERIFICATION FAILED.
+ *
+ * Pattern ra_lo_aw:: / ra_hi_aw:: confirms the RNA tight path was taken.
+ */
+#include <assert.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  __ESBMC_assume(x >= 1.0 && x <= 2.0);
+  __ESBMC_assume(y >= 3.0 && y <= 4.0);
+  __ESBMC_assume(z >= 5.0 && z <= 6.0);
+
+  double r = fma(x, y, z);
+
+  assert(r > 100.0);
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-interval-lift-rna/test.desc
+++ b/regression/ir-ra/ra-fma-interval-lift-rna/test.desc
@@ -1,0 +1,8 @@
+THOROUGH
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+\(\*
+5551115123125783
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fma-interval-lift-rup/main.c
+++ b/regression/ir-ra/ra-fma-interval-lift-rup/main.c
@@ -1,0 +1,33 @@
+/* Regression test: FMA interval lifting under --ir-ieee (RUP / FE_UPWARD).
+ *
+ * Verifies that encode_ieee_fma takes the RUP interval-lifted path when
+ * fesetround(FE_UPWARD) is used.
+ *
+ * x in [1, 2],  y in [3, 4],  z in [5, 6]
+ * FMA hull [8, 14]; RUP enclosure: exact lower bound, upper gets B_dir error.
+ * Assertion r > 100 is always false: VERIFICATION FAILED.
+ *
+ * Pattern ra_lo_up:: / ra_hi_up:: confirms the RUP tight path was taken.
+ * Numerator 22204460492503131 is Z3's rational for eps_up = 2^-52 (double).
+ */
+#include <assert.h>
+#include <fenv.h>
+#include <math.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  fesetround(FE_UPWARD);
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  __ESBMC_assume(x >= 1.0 && x <= 2.0);
+  __ESBMC_assume(y >= 3.0 && y <= 4.0);
+  __ESBMC_assume(z >= 5.0 && z <= 6.0);
+
+  double r = fma(x, y, z);
+
+  assert(r > 100.0);
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-interval-lift-rup/test.desc
+++ b/regression/ir-ra/ra-fma-interval-lift-rup/test.desc
@@ -1,0 +1,8 @@
+THOROUGH
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
+\(\*
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fma-interval-lift/main.c
+++ b/regression/ir-ra/ra-fma-interval-lift/main.c
@@ -1,0 +1,42 @@
+/* Regression test: FMA interval lifting under --ir-ieee (RNE, double).
+ *
+ * PURPOSE
+ * -------
+ * Verifies that encode_ieee_fma takes the interval-lifted path when
+ * --ir-ieee is active and the rounding mode is known (RNE).
+ *
+ * PROOF SHAPE
+ * -----------
+ * x in [1, 2],  y in [3, 4],  z in [5, 6]
+ * Multiplication hull: min/max of {1*3, 1*4, 2*3, 2*4} = [3, 8]
+ * FMA hull: [3+5, 8+6] = [8, 14]
+ * After RNE enclosure: [8 - B(8), 14 + B(14)]  (tight, eps ~ 1e-16)
+ * The assertion r > 100 is always false (r <= ~14), so a counterexample
+ * exists: VERIFICATION FAILED.
+ *
+ * The formula patterns confirm the IR-IEEE interval-lifted path was taken:
+ *   ra_lo::  -- RNE lower enclosure variable declared
+ *   ra_hi::  -- RNE upper enclosure variable declared
+ *   (*       -- multiplication products in hull computation
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double)
+ */
+#include <assert.h>
+#include <math.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  __ESBMC_assume(x >= 1.0 && x <= 2.0);
+  __ESBMC_assume(y >= 3.0 && y <= 4.0);
+  __ESBMC_assume(z >= 5.0 && z <= 6.0);
+
+  double r = fma(x, y, z);
+
+  /* Maximum possible is fma(2,4,6) = 14; assertion is always false. */
+  assert(r > 100.0);
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-interval-lift/test.desc
+++ b/regression/ir-ra/ra-fma-interval-lift/test.desc
@@ -1,0 +1,8 @@
+THOROUGH
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+\(\*
+5551115123125783
+^VERIFICATION FAILED$

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -560,6 +560,53 @@ smt_astt ir_ieee_convt::encode_ieee_fma(const expr2tc &expr)
   smt_astt intermediate = ctx->mk_mul(val1, val2);
   smt_astt real_result = ctx->mk_add(intermediate, val3);
   const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
+  const expr2tc &rounding_mode = to_ieee_fma2t(expr).rounding_mode;
+
+  if (
+    ctx->options.get_bool_option("ir-ieee") &&
+    is_known_rounding_mode(rounding_mode) && is_single_or_double(fbv_type))
+  {
+    ra_interval_t iv1 = get_interval(val1);
+    ra_interval_t iv2 = get_interval(val2);
+    ra_interval_t iv3 = get_interval(val3);
+
+    // Multiplication hull: min/max over the four endpoint products of x and y.
+    smt_astt p1 = ctx->mk_mul(iv1.lo, iv2.lo);
+    smt_astt p2 = ctx->mk_mul(iv1.lo, iv2.hi);
+    smt_astt p3 = ctx->mk_mul(iv1.hi, iv2.lo);
+    smt_astt p4 = ctx->mk_mul(iv1.hi, iv2.hi);
+    smt_astt mul_lo = ctx->mk_ite(
+      ctx->mk_le(p1, p2),
+      ctx->mk_ite(
+        ctx->mk_le(p1, p3),
+        ctx->mk_ite(ctx->mk_le(p1, p4), p1, p4),
+        ctx->mk_ite(ctx->mk_le(p3, p4), p3, p4)),
+      ctx->mk_ite(
+        ctx->mk_le(p2, p3),
+        ctx->mk_ite(ctx->mk_le(p2, p4), p2, p4),
+        ctx->mk_ite(ctx->mk_le(p3, p4), p3, p4)));
+    smt_astt mul_hi = ctx->mk_ite(
+      ctx->mk_le(p2, p1),
+      ctx->mk_ite(
+        ctx->mk_le(p3, p1),
+        ctx->mk_ite(ctx->mk_le(p4, p1), p1, p4),
+        ctx->mk_ite(ctx->mk_le(p4, p3), p3, p4)),
+      ctx->mk_ite(
+        ctx->mk_le(p3, p2),
+        ctx->mk_ite(ctx->mk_le(p4, p2), p2, p4),
+        ctx->mk_ite(ctx->mk_le(p4, p3), p3, p4)));
+
+    // Fused add: extend the multiplication hull by the z interval.
+    // r = x*y + z is a single rounding, so the enclosure is applied once.
+    smt_astt lo_r = ctx->mk_add(mul_lo, iv3.lo);
+    smt_astt hi_r = ctx->mk_add(mul_hi, iv3.hi);
+
+    auto bounds =
+      apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
+    store_interval(real_result, bounds.first, bounds.second);
+    return real_result;
+  }
+
   return ctx->apply_ieee754_semantics(
-    real_result, fbv_type, nullptr, to_ieee_fma2t(expr).rounding_mode);
+    real_result, fbv_type, nullptr, rounding_mode);
 }


### PR DESCRIPTION
## Summary

Adds interval lifting for `ieee_fma` in the `--ir-ieee` integer/real encoding path.

FMA is treated as a single fused operation `fl(x * y + z)`, not as two separately rounded steps. The exact real result is `x * y + z`; a single rounding-mode enclosure is applied to that fused result and stored in the interval map for downstream propagation.

The multiplication hull uses the four products of the `x` and `y` interval endpoints, following the same approach as `encode_ieee_mul`. The `z` interval is then added:

* `lo_r = mul_lo + iv3.lo`
* `hi_r = mul_hi + iv3.hi`

Unsupported formats and unknown rounding modes fall back to `apply_ieee754_semantics`, matching the other `encode_ieee_*` methods.

## Regression tests

Five new regression tests were added under `regression/ir-ra/`:

* `ra-fma-basic`

  * CORE test.
  * Checks `fma(2, 3, 4) == 10`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-fma-interval-lift-core`

  * CORE test.
  * Uses nondeterministic bounded inputs: `x in [1,2]`, `y in [3,4]`, and `z in [5,6]`.
  * Checks `fma(x, y, z) > 7`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-fma-interval-lift`

  * THOROUGH test.
  * Checks the RNE formula-shape path.
  * Expected result: `VERIFICATION FAILED`.

* `ra-fma-interval-lift-rna`

  * THOROUGH test.
  * Checks the RNA formula-shape path.
  * Expected result: `VERIFICATION FAILED`.

* `ra-fma-interval-lift-rup`

  * THOROUGH test.
  * Checks the RUP formula-shape path.
  * Expected result: `VERIFICATION FAILED`.

The CORE interval-lift test ensures the lifted FMA path is exercised on all CI platforms, not only by the THOROUGH formula-shape tests.

## Testing

```bash
ctest -j$(nproc) -R "ir.ra|ir-ra|ir_ra" --timeout 60
```

Result:

```text
ir-ra: 147/147 passed
```
