### PR TITLE
[python] V.3: build .shape list-length address-of in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -577,10 +577,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
 
             // (int)__ESBMC_list_size(&base_expr), built in IREP2 (V.3).
             expr2tc base2;
-            migrate_expr(
-              base_expr.type().is_pointer() ? base_expr
-                                            : address_of_exprt(base_expr),
-              base2);
+            migrate_expr(base_expr, base2);
+            if (!is_pointer_type(base2->type))
+              base2 = address_of2tc(base2->type, base2);
             expr2tc size_call = side_effect_function_call2tc(
               migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
             exprt list_len = migrate_expr_back(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

Converts the last legacy `address_of_exprt` in the `.shape`-on-list subtree (`converter_expr.cpp`, completing #5248) to the established IREP2 `address_of2tc(obj->type, obj)` idiom.

```cpp
// before
migrate_expr(
  base_expr.type().is_pointer() ? base_expr : address_of_exprt(base_expr),
  base2);
// after
migrate_expr(base_expr, base2);
if (!is_pointer_type(base2->type))
  base2 = address_of2tc(base2->type, base2);
```

## Why it is behaviour-preserving

`base_expr` is already migrated on this path, so the change is an exact round-trip of the legacy node:

- `is_pointer_type(base2->type)` is true iff the legacy `base_expr.type().is_pointer()` is true (`migrate_type` lowers `t_pointer` → `pointer_type2tc`).
- `address_of2tc(base2->type, base2)` reproduces `migrate_expr(address_of_exprt(base_expr))`: the `address_of2t` constructor wraps the pointee type in `pointer_type2tc` itself, and the migrated `address_of_exprt` uses `migrate_type(base_expr.type())` as its subtype.

No branch is added or removed — the ternary becomes an equivalent `if` with identical reachability on both arms.

## Validation

- numpy `.shape` oracle suite (the exact path exercised): **329/329, Bitwuzla**.
- Python attr/list/shape/tuple/class/nested subset: all Bitwuzla-runnable tests pass.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI (local build is Bitwuzla-only).
