### PR TITLE
[python] V.3: build class-attr deref+member access in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1134,16 +1134,12 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           base.type() = bt; // restore #cpp_type that migrate_type drops
         }
 
-        if (base.type().is_pointer())
-        {
-          exprt deref("dereference");
-          deref.type() = base.type().subtype();
-          deref.move_to_operands(base);
-          base = std::move(deref);
-        }
-
+        // V.3: dereference (when base is a pointer) and member access built in
+        // IREP2; exact round-trip of the legacy dereference + member_exprt.
         expr2tc b2;
         migrate_expr(base, b2);
+        if (base.type().is_pointer())
+          b2 = dereference2tc(migrate_type(base.type().subtype()), b2);
         return migrate_expr_back(
           member2tc(migrate_type(clean_type), b2, attr_name));
       };


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

In `build_member_expr_from_class`, replaces the hand-built legacy `"dereference"` irep node with the IREP2 `dereference2tc` idiom already used in `python_set.cpp:69` / `python_list.cpp:154`.

```cpp
// before
if (base.type().is_pointer())
{
  exprt deref("dereference");
  deref.type() = base.type().subtype();
  deref.move_to_operands(base);
  base = std::move(deref);
}
expr2tc b2;
migrate_expr(base, b2);
return migrate_expr_back(member2tc(migrate_type(clean_type), b2, attr_name));

// after
expr2tc b2;
migrate_expr(base, b2);
if (base.type().is_pointer())
  b2 = dereference2tc(migrate_type(base.type().subtype()), b2);
return migrate_expr_back(member2tc(migrate_type(clean_type), b2, attr_name));
```

This removes raw irep surgery (`exprt("dereference")` + `move_to_operands`).

## Why it is behaviour-preserving

`migrate_expr` takes `base` by const reference, so `base` is intact after the call — the pointer check and `subtype()` read are valid (the old code `std::move`'d `base` into the deref node; that move is no longer needed). The result is an exact round-trip:

- A legacy `"dereference"` node (`type = base.type().subtype()`, operand `base`) migrates to `dereference2tc(migrate_type(base.type().subtype()), migrate_expr(base))` — identical to what the new code builds.
- `member2tc(...)` is unchanged, and the upstream guard still guarantees a struct/union pointee when the deref applies, upholding `member2t`'s source precondition.

## Validation

- Python attr/class/nested/dataclass/self_ref/github_4117/object/inherit subset: **236 runnable tests pass** (the only 3 failures require `--z3`/`--boolector`, not built into the local Bitwuzla-only binary — pre-existing/environmental). Includes the recursive-attribute and object-size cases that exercise this exact path.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
