### PR TITLE
[python] V.3: build symbol-attr .shape address-of in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -957,8 +957,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
 
           // (int)__ESBMC_list_size(&expr), built in IREP2 (V.3).
           expr2tc base2;
-          migrate_expr(
-            expr.type().is_pointer() ? expr : address_of_exprt(expr), base2);
+          migrate_expr(expr, base2);
+          if (!is_pointer_type(base2->type))
+            base2 = address_of2tc(base2->type, base2);
           expr2tc size_call = side_effect_function_call2tc(
             migrate_type(size_type()), symbol_expr2tc(*size_func), {base2});
           exprt list_len =


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

Converts the legacy `address_of_exprt` in the **symbol-attribute** `.shape` list-size path (`converter_expr.cpp`) to the IREP2 `address_of2tc` idiom. This is the symbol-attribute sibling of #5391 (which handled the general-attribute path); same transformation, independent site.

```cpp
// before
migrate_expr(
  expr.type().is_pointer() ? expr : address_of_exprt(expr), base2);
// after
migrate_expr(expr, base2);
if (!is_pointer_type(base2->type))
  base2 = address_of2tc(base2->type, base2);
```

## Why it is behaviour-preserving

`expr` is already migrated on this path, so the change is an exact round-trip of the legacy node:

- `is_pointer_type(base2->type)` is true iff the legacy `expr.type().is_pointer()` is true (`migrate_type` lowers `t_pointer` → `pointer_type2tc`).
- `address_of2tc(base2->type, base2)` reproduces `migrate_expr(address_of_exprt(expr))`: the `address_of2t` constructor wraps the pointee type in `pointer_type2tc` itself, and the migrated `address_of_exprt` uses `migrate_type(expr.type())` as its subtype.

No branch is added or removed — the ternary becomes an equivalent `if` with identical reachability on both arms.

## Validation

- numpy `.shape` oracle suite: **329/329, Bitwuzla** (the exact path exercised).
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI (local build is Bitwuzla-only).
