### PR TITLE
[python] V.3: IREP2 address-of/zero in boolop list-truthiness

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -53,12 +53,11 @@ exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
           "__ESBMC_list_size not found for list condition check");
 
       // Build len(x) != 0 in IREP2, back-migrating once (V.3).
-      expr2tc arg2, zero2;
-      if (value_expr.type().is_pointer())
-        migrate_expr(value_expr, arg2);
-      else
-        migrate_expr(address_of_exprt(value_expr), arg2);
-      migrate_expr(gen_zero(size_type()), zero2);
+      expr2tc arg2;
+      migrate_expr(value_expr, arg2);
+      if (!is_pointer_type(arg2->type))
+        arg2 = address_of2tc(arg2->type, arg2);
+      expr2tc zero2 = gen_zero(migrate_type(size_type()));
 
       expr2tc size_call2 = side_effect_function_call2tc(
         migrate_type(size_type()), symbol_expr2tc(*size_func), {arg2});


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam. First increment in `converter_binop.cpp`.

## What

In `get_logical_operator_expr`'s `get_truthy_condition` (the `len(x) != 0` test used when a list appears as a boolean-operation operand), converts the last two legacy builders to IREP2:

```cpp
// before
expr2tc arg2, zero2;
if (value_expr.type().is_pointer())
  migrate_expr(value_expr, arg2);
else
  migrate_expr(address_of_exprt(value_expr), arg2);
migrate_expr(gen_zero(size_type()), zero2);

// after
expr2tc arg2;
migrate_expr(value_expr, arg2);
if (!is_pointer_type(arg2->type))
  arg2 = address_of2tc(arg2->type, arg2);
expr2tc zero2 = gen_zero(migrate_type(size_type()));
```

## Why it is behaviour-preserving

`value_expr` is already migrated on this path, so both replacements are exact round-trips:

- `address_of2tc(arg2->type, arg2)` reproduces `migrate_expr(address_of_exprt(value_expr))`, and `is_pointer_type(arg2->type)` matches the legacy `value_expr.type().is_pointer()` check (`migrate_type` lowers `t_pointer` → `pointer_type2tc`).
- `gen_zero(migrate_type(size_type()))` returns `constant_int2tc(size_type2, 0)` for the `unsignedbv` size type — identical to `migrate_expr(gen_zero(size_type()))`. (`irep2_utils.cpp` `gen_zero`.)

The `notequal2tc(size_call2, zero2)` and its `migrate_expr_back` are unchanged.

## Validation

- Python boolop/logical/truthiness/list/dict subset: all Bitwuzla-runnable tests pass; the only failures require `--z3` or `--ir` (integer/real mode, Z3-only) — both unavailable in the local Bitwuzla-only build, failing identically on `master`.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
