### PR TITLE
add float support and complex literal folding for numpy runtime ops

### DIFF
--- a/regression/numpy/det_complex_2x2_fail/test.desc
+++ b/regression/numpy/det_complex_2x2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: TypeError: numpy.linalg.det currently supports only constant 2D numeric arrays$
+^ERROR: TypeError: numpy.linalg.det does not support complex-valued matrices$

--- a/regression/numpy/det_edge_complex_imag_only_fail/test.desc
+++ b/regression/numpy/det_edge_complex_imag_only_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: TypeError: numpy.linalg.det currently supports only constant 2D numeric arrays$
+^ERROR: TypeError: numpy.linalg.det does not support complex-valued matrices$

--- a/regression/numpy/github_4668_np_add_bool_array_unsupported/test.desc
+++ b/regression/numpy/github_4668_np_add_bool_array_unsupported/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Unsupported Numpy call: add$
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/github_4668_np_add_call_unsupported/test.desc
+++ b/regression/numpy/github_4668_np_add_call_unsupported/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Unsupported Numpy call: add$
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/github_4668_np_add_scalar_array_unsupported/test.desc
+++ b/regression/numpy/github_4668_np_add_scalar_array_unsupported/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Unsupported Numpy call: add$
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/github_4668_np_multiply_bool_array_unsupported/test.desc
+++ b/regression/numpy/github_4668_np_multiply_bool_array_unsupported/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Unsupported Numpy call: multiply$
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/github_4668_np_multiply_call_unsupported/test.desc
+++ b/regression/numpy/github_4668_np_multiply_call_unsupported/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Unsupported Numpy call: multiply$
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/github_4668_np_multiply_scalar_array_unsupported/test.desc
+++ b/regression/numpy/github_4668_np_multiply_scalar_array_unsupported/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Unsupported Numpy call: multiply$
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_1d_success/main.py
+++ b/regression/numpy/numpy_float_add_1d_success/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+a = np.array([1.5, 2.5])
+b = np.array([3.0, 4.0])
+c = np.add(a, b)
+assert c[0] == 4.5
+assert c[1] == 6.5

--- a/regression/numpy/numpy_float_add_1d_success/test.desc
+++ b/regression/numpy/numpy_float_add_1d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_2d_broadcast_success/main.py
+++ b/regression/numpy/numpy_float_add_2d_broadcast_success/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+a = np.array([[1.0], [2.0]])
+b = np.array([3.0, 4.0])
+c = np.add(a, b)
+assert c[0][0] == 4.0
+assert c[0][1] == 5.0
+assert c[1][0] == 5.0
+assert c[1][1] == 6.0

--- a/regression/numpy/numpy_float_add_2d_broadcast_success/test.desc
+++ b/regression/numpy/numpy_float_add_2d_broadcast_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_2d_wrong_assert_fail/main.py
+++ b/regression/numpy/numpy_float_add_2d_wrong_assert_fail/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.array([[1.0], [2.0]])
+b = np.array([3.0, 4.0])
+c = np.add(a, b)
+assert c[1][1] == 7.0

--- a/regression/numpy/numpy_float_add_2d_wrong_assert_fail/test.desc
+++ b/regression/numpy/numpy_float_add_2d_wrong_assert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/numpy/numpy_float_add_mixed_edge/main.py
+++ b/regression/numpy/numpy_float_add_mixed_edge/main.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 a = np.array([1.5, 2.5])
-b = np.array([1, 2])
+b = 1
 c = np.add(a, b)
 assert c[0] == 2.5
-assert c[1] == 4.5
+assert c[1] == 3.5

--- a/regression/numpy/numpy_float_add_mixed_edge/main.py
+++ b/regression/numpy/numpy_float_add_mixed_edge/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+a = np.array([1.5, 2.5])
+b = np.array([1, 2])
+c = np.add(a, b)
+assert c[0] == 2.5
+assert c[1] == 4.5

--- a/regression/numpy/numpy_float_add_mixed_edge/test.desc
+++ b/regression/numpy/numpy_float_add_mixed_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_mixed_success/main.py
+++ b/regression/numpy/numpy_float_add_mixed_success/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+a = np.array([1.5, 2.5])
+b = np.array([1, 2])
+c = np.add(a, b)
+assert c[0] == 2.5
+assert c[1] == 4.5

--- a/regression/numpy/numpy_float_add_mixed_success/test.desc
+++ b/regression/numpy/numpy_float_add_mixed_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_row_column_edge/main.py
+++ b/regression/numpy/numpy_float_add_row_column_edge/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+a = np.array([[1.0, 2.0, 3.0]])
+b = np.array([[10.0], [20.0]])
+c = np.add(a, b)
+assert c[0][0] == 11.0
+assert c[0][1] == 12.0
+assert c[0][2] == 13.0
+assert c[1][0] == 21.0
+assert c[1][1] == 22.0
+assert c[1][2] == 23.0

--- a/regression/numpy/numpy_float_add_row_column_edge/test.desc
+++ b/regression/numpy/numpy_float_add_row_column_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_single_element_edge/main.py
+++ b/regression/numpy/numpy_float_add_single_element_edge/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.array([1.5])
+b = np.array([2.5])
+c = np.add(a, b)
+assert c[0] == 4.0

--- a/regression/numpy/numpy_float_add_single_element_edge/test.desc
+++ b/regression/numpy/numpy_float_add_single_element_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_singleton_edge/main.py
+++ b/regression/numpy/numpy_float_add_singleton_edge/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+a = np.array([[1.5], [2.5]])
+b = np.array([10.0, 20.0])
+c = np.add(a, b)
+assert c[0][0] == 11.5
+assert c[0][1] == 21.5
+assert c[1][0] == 12.5
+assert c[1][1] == 22.5

--- a/regression/numpy/numpy_float_add_singleton_edge/test.desc
+++ b/regression/numpy/numpy_float_add_singleton_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_add_wrong_assert_fail/main.py
+++ b/regression/numpy/numpy_float_add_wrong_assert_fail/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.array([1.5, 2.5])
+b = np.array([3.0, 4.0])
+c = np.add(a, b)
+assert c[0] == 5.0

--- a/regression/numpy/numpy_float_add_wrong_assert_fail/test.desc
+++ b/regression/numpy/numpy_float_add_wrong_assert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/numpy/numpy_float_broadcast_mismatch_fail/main.py
+++ b/regression/numpy/numpy_float_broadcast_mismatch_fail/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.array([[1.0, 2.0, 3.0]])
+b = np.array([[4.0, 5.0], [6.0, 7.0]])
+c = np.add(a, b)
+assert c[0][0] == 5.0

--- a/regression/numpy/numpy_float_broadcast_mismatch_fail/test.desc
+++ b/regression/numpy/numpy_float_broadcast_mismatch_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: operands could not be broadcast together with shapes \(1, 3\) \(2, 2\)$

--- a/regression/numpy/numpy_float_divide_2d_success/main.py
+++ b/regression/numpy/numpy_float_divide_2d_success/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+a = np.array([[8.0, 6.0], [9.0, 12.0]])
+b = np.array([[2.0, 3.0], [3.0, 4.0]])
+c = np.divide(a, b)
+assert c[0][0] == 4.0
+assert c[0][1] == 2.0
+assert c[1][0] == 3.0
+assert c[1][1] == 3.0

--- a/regression/numpy/numpy_float_divide_2d_success/test.desc
+++ b/regression/numpy/numpy_float_divide_2d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_divide_fractional_success/main.py
+++ b/regression/numpy/numpy_float_divide_fractional_success/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+a = np.array([[1.5, 2.0], [3.0, 4.5]])
+b = np.array([[0.5, 2.0], [1.5, 1.5]])
+c = np.divide(a, b)
+assert c[0][0] == 3.0
+assert c[0][1] == 1.0
+assert c[1][0] == 2.0
+assert c[1][1] == 3.0

--- a/regression/numpy/numpy_float_divide_fractional_success/test.desc
+++ b/regression/numpy/numpy_float_divide_fractional_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/numpy_float_divide_mismatch_fail/main.py
+++ b/regression/numpy/numpy_float_divide_mismatch_fail/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.array([[8.0, 6.0], [9.0, 12.0]])
+b = np.array([[2.0, 3.0], [3.0, 4.0]])
+result = np.divide(a, b)
+assert result[0][0] == 5.0

--- a/regression/numpy/numpy_float_divide_mismatch_fail/test.desc
+++ b/regression/numpy/numpy_float_divide_mismatch_fail/test.desc
@@ -2,5 +2,3 @@ CORE
 main.py
 --incremental-bmc
 ^VERIFICATION FAILED$
-^Violated property:$
-^  division by zero$

--- a/regression/numpy/numpy_float_divide_mismatch_fail/test.desc
+++ b/regression/numpy/numpy_float_divide_mismatch_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$
+^Violated property:$
+^  division by zero$

--- a/regression/numpy/numpy_float_divide_wrong_assert_fail/main.py
+++ b/regression/numpy/numpy_float_divide_wrong_assert_fail/main.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+a = np.array([[8.0, 6.0], [9.0, 12.0]])
+b = np.array([[2.0, 3.0], [3.0, 4.0]])
+c = np.divide(a, b)
+assert c[1][1] == 4.0

--- a/regression/numpy/numpy_float_divide_wrong_assert_fail/test.desc
+++ b/regression/numpy/numpy_float_divide_wrong_assert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/umath.c
+++ b/src/c2goto/library/python/umath.c
@@ -8,8 +8,12 @@ get_value(int64_t *base, int64_t rows, int64_t cols, int64_t row, int64_t col)
   return *(base + effective_row * cols + effective_col);
 }
 
-static double
-get_value_double(double *base, int64_t rows, int64_t cols, int64_t row, int64_t col)
+static double get_value_double(
+  double *base,
+  int64_t rows,
+  int64_t cols,
+  int64_t row,
+  int64_t col)
 {
   int64_t effective_row = rows == 1 ? 0 : row;
   int64_t effective_col = cols == 1 ? 0 : col;
@@ -60,8 +64,8 @@ void add_double(
     int64_t j = 0;
     while (j < cols)
     {
-      *(C + i * cols + j) = get_value_double(
-        A, a_rows, a_cols, i, j) + get_value_double(B, b_rows, b_cols, i, j);
+      *(C + i * cols + j) = get_value_double(A, a_rows, a_cols, i, j) +
+                            get_value_double(B, b_rows, b_cols, i, j);
       j++;
     }
     i++;
@@ -112,8 +116,8 @@ void subtract_double(
     int64_t j = 0;
     while (j < cols)
     {
-      *(C + i * cols + j) = get_value_double(
-        A, a_rows, a_cols, i, j) - get_value_double(B, b_rows, b_cols, i, j);
+      *(C + i * cols + j) = get_value_double(A, a_rows, a_cols, i, j) -
+                            get_value_double(B, b_rows, b_cols, i, j);
       j++;
     }
     i++;
@@ -164,8 +168,8 @@ void multiply_double(
     int64_t j = 0;
     while (j < cols)
     {
-      *(C + i * cols + j) = get_value_double(
-        A, a_rows, a_cols, i, j) * get_value_double(B, b_rows, b_cols, i, j);
+      *(C + i * cols + j) = get_value_double(A, a_rows, a_cols, i, j) *
+                            get_value_double(B, b_rows, b_cols, i, j);
       j++;
     }
     i++;
@@ -216,8 +220,8 @@ void divide_double(
     int64_t j = 0;
     while (j < cols)
     {
-      *(C + i * cols + j) = get_value_double(
-        A, a_rows, a_cols, i, j) / get_value_double(B, b_rows, b_cols, i, j);
+      *(C + i * cols + j) = get_value_double(A, a_rows, a_cols, i, j) /
+                            get_value_double(B, b_rows, b_cols, i, j);
       j++;
     }
     i++;

--- a/src/c2goto/library/python/umath.c
+++ b/src/c2goto/library/python/umath.c
@@ -8,6 +8,14 @@ get_value(int64_t *base, int64_t rows, int64_t cols, int64_t row, int64_t col)
   return *(base + effective_row * cols + effective_col);
 }
 
+static double
+get_value_double(double *base, int64_t rows, int64_t cols, int64_t row, int64_t col)
+{
+  int64_t effective_row = rows == 1 ? 0 : row;
+  int64_t effective_col = cols == 1 ? 0 : col;
+  return *(base + effective_row * cols + effective_col);
+}
+
 void add(
   int64_t *A,
   int64_t *B,
@@ -28,6 +36,32 @@ void add(
     {
       *(C + i * cols + j) =
         get_value(A, a_rows, a_cols, i, j) + get_value(B, b_rows, b_cols, i, j);
+      j++;
+    }
+    i++;
+  }
+}
+
+void add_double(
+  double *A,
+  double *B,
+  double *C,
+  int64_t a_rows,
+  int64_t a_cols,
+  int64_t b_rows,
+  int64_t b_cols)
+{
+  int64_t rows = a_rows > b_rows ? a_rows : b_rows;
+  int64_t cols = a_cols > b_cols ? a_cols : b_cols;
+
+  int64_t i = 0;
+  while (i < rows)
+  {
+    int64_t j = 0;
+    while (j < cols)
+    {
+      *(C + i * cols + j) = get_value_double(
+        A, a_rows, a_cols, i, j) + get_value_double(B, b_rows, b_cols, i, j);
       j++;
     }
     i++;
@@ -60,6 +94,32 @@ void subtract(
   }
 }
 
+void subtract_double(
+  double *A,
+  double *B,
+  double *C,
+  int64_t a_rows,
+  int64_t a_cols,
+  int64_t b_rows,
+  int64_t b_cols)
+{
+  int64_t rows = a_rows > b_rows ? a_rows : b_rows;
+  int64_t cols = a_cols > b_cols ? a_cols : b_cols;
+
+  int64_t i = 0;
+  while (i < rows)
+  {
+    int64_t j = 0;
+    while (j < cols)
+    {
+      *(C + i * cols + j) = get_value_double(
+        A, a_rows, a_cols, i, j) - get_value_double(B, b_rows, b_cols, i, j);
+      j++;
+    }
+    i++;
+  }
+}
+
 void multiply(
   int64_t *A,
   int64_t *B,
@@ -86,6 +146,32 @@ void multiply(
   }
 }
 
+void multiply_double(
+  double *A,
+  double *B,
+  double *C,
+  int64_t a_rows,
+  int64_t a_cols,
+  int64_t b_rows,
+  int64_t b_cols)
+{
+  int64_t rows = a_rows > b_rows ? a_rows : b_rows;
+  int64_t cols = a_cols > b_cols ? a_cols : b_cols;
+
+  int64_t i = 0;
+  while (i < rows)
+  {
+    int64_t j = 0;
+    while (j < cols)
+    {
+      *(C + i * cols + j) = get_value_double(
+        A, a_rows, a_cols, i, j) * get_value_double(B, b_rows, b_cols, i, j);
+      j++;
+    }
+    i++;
+  }
+}
+
 void divide(
   int64_t *A,
   int64_t *B,
@@ -106,6 +192,32 @@ void divide(
     {
       *(C + i * cols + j) =
         get_value(A, a_rows, a_cols, i, j) / get_value(B, b_rows, b_cols, i, j);
+      j++;
+    }
+    i++;
+  }
+}
+
+void divide_double(
+  double *A,
+  double *B,
+  double *C,
+  int64_t a_rows,
+  int64_t a_cols,
+  int64_t b_rows,
+  int64_t b_cols)
+{
+  int64_t rows = a_rows > b_rows ? a_rows : b_rows;
+  int64_t cols = a_cols > b_cols ? a_cols : b_cols;
+
+  int64_t i = 0;
+  while (i < rows)
+  {
+    int64_t j = 0;
+    while (j < cols)
+    {
+      *(C + i * cols + j) = get_value_double(
+        A, a_rows, a_cols, i, j) / get_value_double(B, b_rows, b_cols, i, j);
       j++;
     }
     i++;

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1391,32 +1391,27 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       slice["_type"] == "Tuple")
     {
       if (
-        slice.contains("elts") && slice["elts"].is_array() &&
-        slice["elts"].size() == 2)
-      {
-        const auto &row_idx_raw = slice["elts"][0];
-        const auto &col_idx_raw = slice["elts"][1];
-        const nlohmann::json row_idx = normalize_bool_index_node(row_idx_raw);
-        const nlohmann::json col_idx = normalize_bool_index_node(col_idx_raw);
-        const bool has_slice_dim =
-          (row_idx.contains("_type") && row_idx["_type"] == "Slice") ||
-          (col_idx.contains("_type") && col_idx["_type"] == "Slice");
-        if (has_slice_dim)
-          throw_numpy_multidim_index_error(*this, element);
+        !slice.contains("elts") || !slice["elts"].is_array() ||
+        slice["elts"].empty())
+        throw_numpy_multidim_index_error(*this, element);
 
-        python_list list(*this, element);
-        exprt row = list.index(array, row_idx);
-        if (contains_cpp_throw(row))
+      python_list list(*this, element);
+      exprt current = array;
+      for (const auto &index_node : slice["elts"])
+      {
+        const nlohmann::json normalized_index =
+          normalize_bool_index_node(index_node);
+        current = list.index(current, normalized_index);
+        if (contains_cpp_throw(current))
         {
-          expr = row;
+          expr = current;
           break;
         }
-
-        expr = list.index(row, col_idx);
-        break;
       }
 
-      throw_numpy_multidim_index_error(*this, element);
+      if (expr.is_nil())
+        expr = current;
+      break;
     }
 
     // Handle object subscripting through __getitem__:

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1391,27 +1391,32 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       slice["_type"] == "Tuple")
     {
       if (
-        !slice.contains("elts") || !slice["elts"].is_array() ||
-        slice["elts"].empty())
-        throw_numpy_multidim_index_error(*this, element);
-
-      python_list list(*this, element);
-      exprt current = array;
-      for (const auto &index_node : slice["elts"])
+        slice.contains("elts") && slice["elts"].is_array() &&
+        slice["elts"].size() == 2)
       {
-        const nlohmann::json normalized_index =
-          normalize_bool_index_node(index_node);
-        current = list.index(current, normalized_index);
-        if (contains_cpp_throw(current))
+        const auto &row_idx_raw = slice["elts"][0];
+        const auto &col_idx_raw = slice["elts"][1];
+        const nlohmann::json row_idx = normalize_bool_index_node(row_idx_raw);
+        const nlohmann::json col_idx = normalize_bool_index_node(col_idx_raw);
+        const bool has_slice_dim =
+          (row_idx.contains("_type") && row_idx["_type"] == "Slice") ||
+          (col_idx.contains("_type") && col_idx["_type"] == "Slice");
+        if (has_slice_dim)
+          throw_numpy_multidim_index_error(*this, element);
+
+        python_list list(*this, element);
+        exprt row = list.index(array, row_idx);
+        if (contains_cpp_throw(row))
         {
-          expr = current;
+          expr = row;
           break;
         }
+
+        expr = list.index(row, col_idx);
+        break;
       }
 
-      if (expr.is_nil())
-        expr = current;
-      break;
+      throw_numpy_multidim_index_error(*this, element);
     }
 
     // Handle object subscripting through __getitem__:

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -190,9 +190,8 @@ static scalar_value make_complex_scalar(double real, double imag)
   return out;
 }
 
-static bool try_extract_scalar_binary(
-  const nlohmann::json &node,
-  scalar_value &out)
+static bool
+try_extract_scalar_binary(const nlohmann::json &node, scalar_value &out)
 {
   if (
     !node.is_object() || !node.contains("_type") || node["_type"] != "BinOp" ||
@@ -217,8 +216,8 @@ static bool try_extract_scalar_binary(
   }
 
   out.is_complex = left.is_complex || right.is_complex;
-  out.value = op_type == "Add" ? left.value + right.value
-                                : left.value - right.value;
+  out.value =
+    op_type == "Add" ? left.value + right.value : left.value - right.value;
   return true;
 }
 
@@ -1338,7 +1337,8 @@ T get_constant_value(const nlohmann::json &node)
   // node["value"].get<T>() below would raise an opaque nlohmann type_error.
   // Surface the curated overflow diagnostic instead so the user sees the
   // same message they get from get_literal.
-  auto reject_bigint = [](const nlohmann::json &c) {
+  auto reject_bigint = [](const nlohmann::json &c)
+  {
     if (c.contains("_bigint"))
       throw python_int_overflow_excp(
         "Python int overflow: literal " + c["_bigint"].get<std::string>() +
@@ -1382,7 +1382,8 @@ exprt numpy_call_expr::create_expr_from_call()
   nlohmann::json expr;
 
   // Resolve variables if they are names
-  auto resolve_var = [this](nlohmann::json &var) {
+  auto resolve_var = [this](nlohmann::json &var)
+  {
     if (var["_type"] == "Name")
     {
       var = json_utils::find_var_decl(
@@ -2202,27 +2203,29 @@ exprt numpy_call_expr::create_expr_from_call()
         }
 
         auto as_dim =
-          [](const std::vector<std::size_t> &shape, std::size_t axis) {
-            if (shape.empty())
-              return from_integer(1, int_type());
-            if (shape.size() == 1)
-              return from_integer(
-                axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
+          [](const std::vector<std::size_t> &shape, std::size_t axis)
+        {
+          if (shape.empty())
+            return from_integer(1, int_type());
+          if (shape.size() == 1)
             return from_integer(
-              static_cast<int>(axis < shape.size() ? shape[axis] : 1),
-              int_type());
-          };
+              axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
+          return from_integer(
+            static_cast<int>(axis < shape.size() ? shape[axis] : 1),
+            int_type());
+        };
 
         auto build_array_type =
-          [&](const std::vector<std::size_t> &shape, const typet &elem_type) {
-            if (shape.empty())
-              return elem_type;
+          [&](const std::vector<std::size_t> &shape, const typet &elem_type)
+        {
+          if (shape.empty())
+            return elem_type;
 
-            typet array_type = elem_type;
-            for (auto it = shape.rbegin(); it != shape.rend(); ++it)
-              array_type = type_handler_.build_array(array_type, *it);
-            return array_type;
-          };
+          typet array_type = elem_type;
+          for (auto it = shape.rbegin(); it != shape.rend(); ++it)
+            array_type = type_handler_.build_array(array_type, *it);
+          return array_type;
+        };
 
         typet lhs_scalar_type =
           get_array_scalar_type(type_handler_.get_typet(lhs["elts"]));
@@ -2235,7 +2238,10 @@ exprt numpy_call_expr::create_expr_from_call()
           lhs_shape.size() >= rhs_shape.size() ? lhs : rhs;
         typet t = is_float
                     ? build_array_type(result_shape, double_type())
-                    : converter_.get_static_array(reference, type_handler_.get_typet(reference["elts"])).type();
+                    : converter_
+                        .get_static_array(
+                          reference, type_handler_.get_typet(reference["elts"]))
+                        .type();
         function_id_.set_function(operation + (is_float ? "_double" : ""));
 
         converter_.current_lhs->type() = t;
@@ -2244,7 +2250,7 @@ exprt numpy_call_expr::create_expr_from_call()
         code_function_callt call =
           to_code_function_call(to_code(function_call_expr::get()));
         auto &args = call.arguments();
-        typet flat_ptr_type =
+        const typet flat_ptr_type =
           pointer_typet(is_float ? double_type() : long_long_int_type());
         if (args.size() >= 2)
         {
@@ -2374,7 +2380,8 @@ exprt numpy_call_expr::get()
       // pointer). handle_fmod is scalar-only and would otherwise mis-fold
       // them or crash the FP backend.
       const typet list_type = type_handler_.get_list_type();
-      auto is_container = [&list_type](const exprt &e) {
+      auto is_container = [&list_type](const exprt &e)
+      {
         return e.type().is_array() || e.type() == list_type ||
                (e.type().is_pointer() && e.type().subtype() == list_type);
       };
@@ -2384,7 +2391,8 @@ exprt numpy_call_expr::get()
       return converter_.get_math_handler().handle_fmod(lhs, rhs, call_);
     }
 
-    auto is_scalar_node = [](const nlohmann::json &node) {
+    auto is_scalar_node = [](const nlohmann::json &node)
+    {
       const std::string type = node["_type"];
       return type == "Constant" || type == "UnaryOp";
     };
@@ -2399,7 +2407,8 @@ exprt numpy_call_expr::get()
       auto rhs = extract_value(call_["args"][1]);
 
       auto compute_scalar_result =
-        [&](double left, double right, double &out) -> bool {
+        [&](double left, double right, double &out) -> bool
+      {
         if (function == "add")
         {
           out = left + right;

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -1337,7 +1337,8 @@ T get_constant_value(const nlohmann::json &node)
   // node["value"].get<T>() below would raise an opaque nlohmann type_error.
   // Surface the curated overflow diagnostic instead so the user sees the
   // same message they get from get_literal.
-  auto reject_bigint = [](const nlohmann::json &c) {
+  auto reject_bigint = [](const nlohmann::json &c)
+  {
     if (c.contains("_bigint"))
       throw python_int_overflow_excp(
         "Python int overflow: literal " + c["_bigint"].get<std::string>() +
@@ -1381,7 +1382,8 @@ exprt numpy_call_expr::create_expr_from_call()
   nlohmann::json expr;
 
   // Resolve variables if they are names
-  auto resolve_var = [this](nlohmann::json &var) {
+  auto resolve_var = [this](nlohmann::json &var)
+  {
     if (var["_type"] == "Name")
     {
       var = json_utils::find_var_decl(
@@ -1446,8 +1448,8 @@ exprt numpy_call_expr::create_expr_from_call()
           if (value.is_complex)
           {
             throw std::runtime_error(
-              "TypeError: numpy.linalg.det currently supports only constant "
-              "2D numeric arrays");
+              "TypeError: numpy.linalg.det does not support complex-valued "
+              "matrices");
           }
         }
       }
@@ -1773,6 +1775,9 @@ exprt numpy_call_expr::create_expr_from_call()
           "yet");
       }
 
+      std::vector<std::size_t> lhs_shape;
+      std::vector<std::size_t> rhs_shape;
+
       scalar_value lhs_scalar;
       scalar_value rhs_scalar;
       if (
@@ -1908,15 +1913,97 @@ exprt numpy_call_expr::create_expr_from_call()
         }
         return converter_.get_expr(out);
       }
-
-      if (lhs["_type"] == "List" && rhs["_type"] == "List")
+      if (
+        try_extract_scalar_1d_list(lhs, lhs_1d) &&
+        try_extract_scalar_constant(rhs, rhs_scalar))
       {
-        std::vector<std::size_t> lhs_shape;
-        std::vector<std::size_t> rhs_shape;
+        nlohmann::json out;
+        out["_type"] = "List";
+        out["elts"] = nlohmann::json::array();
+        for (const auto &v : lhs_1d)
+          out["elts"].push_back(
+            to_json_constant(apply_complex_binary(function, v, rhs_scalar)));
+        exprt folded = converter_.get_expr(out);
+        if (converter_.current_lhs)
+        {
+          converter_.current_lhs->type() = folded.type();
+          converter_.update_symbol(*converter_.current_lhs);
+        }
+        return folded;
+      }
+      if (
+        try_extract_scalar_constant(lhs, lhs_scalar) &&
+        try_extract_scalar_1d_list(rhs, rhs_1d))
+      {
+        nlohmann::json out;
+        out["_type"] = "List";
+        out["elts"] = nlohmann::json::array();
+        for (const auto &v : rhs_1d)
+          out["elts"].push_back(
+            to_json_constant(apply_complex_binary(function, lhs_scalar, v)));
+        exprt folded = converter_.get_expr(out);
+        if (converter_.current_lhs)
+        {
+          converter_.current_lhs->type() = folded.type();
+          converter_.update_symbol(*converter_.current_lhs);
+        }
+        return folded;
+      }
+      if (
+        try_extract_scalar_2d_list(lhs, lhs_2d) &&
+        try_extract_scalar_constant(rhs, rhs_scalar))
+      {
+        nlohmann::json out;
+        out["_type"] = "List";
+        out["elts"] = nlohmann::json::array();
+        for (const auto &row_vals : lhs_2d)
+        {
+          nlohmann::json row;
+          row["_type"] = "List";
+          row["elts"] = nlohmann::json::array();
+          for (const auto &v : row_vals)
+            row["elts"].push_back(
+              to_json_constant(apply_complex_binary(function, v, rhs_scalar)));
+          out["elts"].push_back(row);
+        }
+        exprt folded = converter_.get_expr(out);
+        if (converter_.current_lhs)
+        {
+          converter_.current_lhs->type() = folded.type();
+          converter_.update_symbol(*converter_.current_lhs);
+        }
+        return folded;
+      }
+      if (
+        try_extract_scalar_constant(lhs, lhs_scalar) &&
+        try_extract_scalar_2d_list(rhs, rhs_2d))
+      {
+        nlohmann::json out;
+        out["_type"] = "List";
+        out["elts"] = nlohmann::json::array();
+        for (const auto &row_vals : rhs_2d)
+        {
+          nlohmann::json row;
+          row["_type"] = "List";
+          row["elts"] = nlohmann::json::array();
+          for (const auto &v : row_vals)
+            row["elts"].push_back(
+              to_json_constant(apply_complex_binary(function, lhs_scalar, v)));
+          out["elts"].push_back(row);
+        }
+        exprt folded = converter_.get_expr(out);
+        if (converter_.current_lhs)
+        {
+          converter_.current_lhs->type() = folded.type();
+          converter_.update_symbol(*converter_.current_lhs);
+        }
+        return folded;
+      }
+      if (
+        get_literal_shape(lhs, lhs_shape) && get_literal_shape(rhs, rhs_shape))
+      {
         std::vector<std::size_t> result_shape;
         if (
-          get_literal_shape(lhs, lhs_shape) &&
-          get_literal_shape(rhs, rhs_shape) &&
           compute_broadcast_shape(lhs_shape, rhs_shape, result_shape) &&
           result_shape.size() <= 2)
         {
@@ -2176,6 +2263,7 @@ exprt numpy_call_expr::create_expr_from_call()
 
         std::vector<std::size_t> lhs_shape;
         std::vector<std::size_t> rhs_shape;
+
         if (
           !get_literal_shape(lhs, lhs_shape) ||
           !get_literal_shape(rhs, rhs_shape))
@@ -2201,43 +2289,42 @@ exprt numpy_call_expr::create_expr_from_call()
         }
 
         auto as_dim =
-          [](const std::vector<std::size_t> &shape, std::size_t axis) {
-            if (shape.empty())
-              return from_integer(1, int_type());
-            if (shape.size() == 1)
-              return from_integer(
-                axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
+          [](const std::vector<std::size_t> &shape, std::size_t axis)
+        {
+          if (shape.empty())
+            return from_integer(1, int_type());
+          if (shape.size() == 1)
             return from_integer(
-              static_cast<int>(axis < shape.size() ? shape[axis] : 1),
-              int_type());
-          };
+              axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
+          return from_integer(
+            static_cast<int>(axis < shape.size() ? shape[axis] : 1),
+            int_type());
+        };
 
         auto build_array_type =
-          [&](const std::vector<std::size_t> &shape, const typet &elem_type) {
-            if (shape.empty())
-              return elem_type;
+          [&](const std::vector<std::size_t> &shape, const typet &elem_type)
+        {
+          if (shape.empty())
+            return elem_type;
 
-            typet array_type = elem_type;
-            for (auto it = shape.rbegin(); it != shape.rend(); ++it)
-              array_type = type_handler_.build_array(array_type, *it);
-            return array_type;
-          };
+          typet array_type = elem_type;
+          for (auto it = shape.rbegin(); it != shape.rend(); ++it)
+            array_type = type_handler_.build_array(array_type, *it);
+          return array_type;
+        };
 
         typet lhs_scalar_type =
-          get_array_scalar_type(type_handler_.get_typet(lhs["elts"]));
+          get_array_scalar_type(type_handler_.get_typet(lhs));
         typet rhs_scalar_type =
-          get_array_scalar_type(type_handler_.get_typet(rhs["elts"]));
+          get_array_scalar_type(type_handler_.get_typet(rhs));
         const bool is_float =
           lhs_scalar_type.is_floatbv() || rhs_scalar_type.is_floatbv();
 
-        const nlohmann::json &reference =
-          lhs_shape.size() >= rhs_shape.size() ? lhs : rhs;
-        typet t = is_float
-                    ? build_array_type(result_shape, double_type())
-                    : converter_
-                        .get_static_array(
-                          reference, type_handler_.get_typet(reference["elts"]))
-                        .type();
+        typet elem_type =
+          is_float ? double_type()
+          : lhs_scalar_type.is_bool() || rhs_scalar_type.is_bool() ? bool_type()
+                                                                   : int_type();
+        typet t = build_array_type(result_shape, elem_type);
         function_id_.set_function(operation + (is_float ? "_double" : ""));
 
         converter_.current_lhs->type() = t;
@@ -2253,7 +2340,8 @@ exprt numpy_call_expr::create_expr_from_call()
           args[0] = typecast_exprt(args[0], flat_ptr_type);
           args[1] = typecast_exprt(args[1], flat_ptr_type);
         }
-        args.push_back(np_address_of(*converter_.current_lhs));
+        args.push_back(
+          np_typecast(np_address_of(*converter_.current_lhs), flat_ptr_type));
         args.push_back(as_dim(lhs_shape, 0));
         args.push_back(as_dim(lhs_shape, 1));
         args.push_back(as_dim(rhs_shape, 0));
@@ -2376,7 +2464,8 @@ exprt numpy_call_expr::get()
       // pointer). handle_fmod is scalar-only and would otherwise mis-fold
       // them or crash the FP backend.
       const typet list_type = type_handler_.get_list_type();
-      auto is_container = [&list_type](const exprt &e) {
+      auto is_container = [&list_type](const exprt &e)
+      {
         return e.type().is_array() || e.type() == list_type ||
                (e.type().is_pointer() && e.type().subtype() == list_type);
       };
@@ -2386,7 +2475,8 @@ exprt numpy_call_expr::get()
       return converter_.get_math_handler().handle_fmod(lhs, rhs, call_);
     }
 
-    auto is_scalar_node = [](const nlohmann::json &node) {
+    auto is_scalar_node = [](const nlohmann::json &node)
+    {
       const std::string type = node["_type"];
       return type == "Constant" || type == "UnaryOp";
     };
@@ -2401,7 +2491,8 @@ exprt numpy_call_expr::get()
       auto rhs = extract_value(call_["args"][1]);
 
       auto compute_scalar_result =
-        [&](double left, double right, double &out) -> bool {
+        [&](double left, double right, double &out) -> bool
+      {
         if (function == "add")
         {
           out = left + right;

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -1440,6 +1440,19 @@ exprt numpy_call_expr::create_expr_from_call()
           "TypeError: numpy.linalg.det requires a square 2D matrix");
       }
 
+      for (const auto &row : matrix)
+      {
+        for (const auto &value : row)
+        {
+          if (value.is_complex)
+          {
+            throw std::runtime_error(
+              "TypeError: numpy.linalg.det currently supports only constant "
+              "2D numeric arrays");
+          }
+        }
+      }
+
       if (n == 2)
         return converter_.get_expr(to_json_constant(determinant_2x2(matrix)));
       if (n == 3)
@@ -2200,10 +2213,30 @@ exprt numpy_call_expr::create_expr_from_call()
               int_type());
           };
 
+        auto build_array_type =
+          [&](const std::vector<std::size_t> &shape, const typet &elem_type) {
+            if (shape.empty())
+              return elem_type;
+
+            typet array_type = elem_type;
+            for (auto it = shape.rbegin(); it != shape.rend(); ++it)
+              array_type = type_handler_.build_array(array_type, *it);
+            return array_type;
+          };
+
+        typet lhs_scalar_type =
+          get_array_scalar_type(type_handler_.get_typet(lhs["elts"]));
+        typet rhs_scalar_type =
+          get_array_scalar_type(type_handler_.get_typet(rhs["elts"]));
+        const bool is_float =
+          lhs_scalar_type.is_floatbv() || rhs_scalar_type.is_floatbv();
+
         const nlohmann::json &reference =
           lhs_shape.size() >= rhs_shape.size() ? lhs : rhs;
-        typet size = type_handler_.get_typet(reference["elts"]);
-        typet t = converter_.get_static_array(reference, size).type();
+        typet t = is_float
+                    ? build_array_type(result_shape, double_type())
+                    : converter_.get_static_array(reference, type_handler_.get_typet(reference["elts"])).type();
+        function_id_.set_function(operation + (is_float ? "_double" : ""));
 
         converter_.current_lhs->type() = t;
         converter_.update_symbol(*converter_.current_lhs);
@@ -2211,6 +2244,13 @@ exprt numpy_call_expr::create_expr_from_call()
         code_function_callt call =
           to_code_function_call(to_code(function_call_expr::get()));
         auto &args = call.arguments();
+        typet flat_ptr_type =
+          pointer_typet(is_float ? double_type() : long_long_int_type());
+        if (args.size() >= 2)
+        {
+          args[0] = typecast_exprt(args[0], flat_ptr_type);
+          args[1] = typecast_exprt(args[1], flat_ptr_type);
+        }
         args.push_back(np_address_of(*converter_.current_lhs));
         args.push_back(as_dim(lhs_shape, 0));
         args.push_back(as_dim(lhs_shape, 1));

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -1337,8 +1337,7 @@ T get_constant_value(const nlohmann::json &node)
   // node["value"].get<T>() below would raise an opaque nlohmann type_error.
   // Surface the curated overflow diagnostic instead so the user sees the
   // same message they get from get_literal.
-  auto reject_bigint = [](const nlohmann::json &c)
-  {
+  auto reject_bigint = [](const nlohmann::json &c) {
     if (c.contains("_bigint"))
       throw python_int_overflow_excp(
         "Python int overflow: literal " + c["_bigint"].get<std::string>() +
@@ -1382,8 +1381,7 @@ exprt numpy_call_expr::create_expr_from_call()
   nlohmann::json expr;
 
   // Resolve variables if they are names
-  auto resolve_var = [this](nlohmann::json &var)
-  {
+  auto resolve_var = [this](nlohmann::json &var) {
     if (var["_type"] == "Name")
     {
       var = json_utils::find_var_decl(
@@ -2289,29 +2287,27 @@ exprt numpy_call_expr::create_expr_from_call()
         }
 
         auto as_dim =
-          [](const std::vector<std::size_t> &shape, std::size_t axis)
-        {
-          if (shape.empty())
-            return from_integer(1, int_type());
-          if (shape.size() == 1)
+          [](const std::vector<std::size_t> &shape, std::size_t axis) {
+            if (shape.empty())
+              return from_integer(1, int_type());
+            if (shape.size() == 1)
+              return from_integer(
+                axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
             return from_integer(
-              axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
-          return from_integer(
-            static_cast<int>(axis < shape.size() ? shape[axis] : 1),
-            int_type());
-        };
+              static_cast<int>(axis < shape.size() ? shape[axis] : 1),
+              int_type());
+          };
 
         auto build_array_type =
-          [&](const std::vector<std::size_t> &shape, const typet &elem_type)
-        {
-          if (shape.empty())
-            return elem_type;
+          [&](const std::vector<std::size_t> &shape, const typet &elem_type) {
+            if (shape.empty())
+              return elem_type;
 
-          typet array_type = elem_type;
-          for (auto it = shape.rbegin(); it != shape.rend(); ++it)
-            array_type = type_handler_.build_array(array_type, *it);
-          return array_type;
-        };
+            typet array_type = elem_type;
+            for (auto it = shape.rbegin(); it != shape.rend(); ++it)
+              array_type = type_handler_.build_array(array_type, *it);
+            return array_type;
+          };
 
         typet lhs_scalar_type =
           get_array_scalar_type(type_handler_.get_typet(lhs));
@@ -2464,8 +2460,7 @@ exprt numpy_call_expr::get()
       // pointer). handle_fmod is scalar-only and would otherwise mis-fold
       // them or crash the FP backend.
       const typet list_type = type_handler_.get_list_type();
-      auto is_container = [&list_type](const exprt &e)
-      {
+      auto is_container = [&list_type](const exprt &e) {
         return e.type().is_array() || e.type() == list_type ||
                (e.type().is_pointer() && e.type().subtype() == list_type);
       };
@@ -2475,8 +2470,7 @@ exprt numpy_call_expr::get()
       return converter_.get_math_handler().handle_fmod(lhs, rhs, call_);
     }
 
-    auto is_scalar_node = [](const nlohmann::json &node)
-    {
+    auto is_scalar_node = [](const nlohmann::json &node) {
       const std::string type = node["_type"];
       return type == "Constant" || type == "UnaryOp";
     };
@@ -2491,8 +2485,7 @@ exprt numpy_call_expr::get()
       auto rhs = extract_value(call_["args"][1]);
 
       auto compute_scalar_result =
-        [&](double left, double right, double &out) -> bool
-      {
+        [&](double left, double right, double &out) -> bool {
         if (function == "add")
         {
           out = left + right;

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -190,6 +190,38 @@ static scalar_value make_complex_scalar(double real, double imag)
   return out;
 }
 
+static bool try_extract_scalar_binary(
+  const nlohmann::json &node,
+  scalar_value &out)
+{
+  if (
+    !node.is_object() || !node.contains("_type") || node["_type"] != "BinOp" ||
+    !node.contains("op") || !node["op"].is_object() ||
+    !node["op"].contains("_type") || !node.contains("left") ||
+    !node.contains("right"))
+  {
+    return false;
+  }
+
+  const std::string op_type = node["op"]["_type"];
+  if (op_type != "Add" && op_type != "Sub")
+    return false;
+
+  scalar_value left;
+  scalar_value right;
+  if (
+    !try_extract_scalar_constant(node["left"], left) ||
+    !try_extract_scalar_constant(node["right"], right))
+  {
+    return false;
+  }
+
+  out.is_complex = left.is_complex || right.is_complex;
+  out.value = op_type == "Add" ? left.value + right.value
+                                : left.value - right.value;
+  return true;
+}
+
 static bool is_complex_annotated_constant(const nlohmann::json &node)
 {
   if (!node.is_object())
@@ -205,11 +237,16 @@ try_extract_scalar_constant(const nlohmann::json &node, scalar_value &out)
     return false;
 
   const std::string type = node["_type"];
-  if (type != "Constant" && type != "UnaryOp")
+  if (type != "Constant" && type != "UnaryOp" && type != "BinOp")
     return false;
 
   try
   {
+    if (type == "BinOp")
+    {
+      if (try_extract_scalar_binary(node, out))
+        return true;
+    }
     if (type == "UnaryOp")
     {
       if (!node.contains("operand") || !node["operand"].is_object())
@@ -526,6 +563,27 @@ enum class scalar_kind
 
 static scalar_kind get_scalar_kind(const nlohmann::json &node)
 {
+  if (
+    node.contains("_type") && node["_type"] == "BinOp" &&
+    node.contains("left") && node["left"].is_object())
+  {
+    const scalar_kind left_kind = get_scalar_kind(node["left"]);
+    const scalar_kind right_kind =
+      node.contains("right") && node["right"].is_object()
+        ? get_scalar_kind(node["right"])
+        : scalar_kind::int_like;
+
+    if (
+      left_kind == scalar_kind::complex_like ||
+      right_kind == scalar_kind::complex_like)
+      return scalar_kind::complex_like;
+    if (
+      left_kind == scalar_kind::float_like ||
+      right_kind == scalar_kind::float_like)
+      return scalar_kind::float_like;
+    return scalar_kind::int_like;
+  }
+
   if (
     node.contains("_type") && node["_type"] == "UnaryOp" &&
     node.contains("operand") && node["operand"].is_object())
@@ -856,6 +914,14 @@ static nlohmann::json unwrap_list_like_node(const nlohmann::json &node)
   }
 
   return {};
+}
+
+static typet get_array_scalar_type(const typet &array_type)
+{
+  typet scalar_type = array_type;
+  while (scalar_type.is_array())
+    scalar_type = scalar_type.subtype();
+  return scalar_type;
 }
 
 static numeric_value extract_value(const nlohmann::json &arg)

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -1337,8 +1337,7 @@ T get_constant_value(const nlohmann::json &node)
   // node["value"].get<T>() below would raise an opaque nlohmann type_error.
   // Surface the curated overflow diagnostic instead so the user sees the
   // same message they get from get_literal.
-  auto reject_bigint = [](const nlohmann::json &c)
-  {
+  auto reject_bigint = [](const nlohmann::json &c) {
     if (c.contains("_bigint"))
       throw python_int_overflow_excp(
         "Python int overflow: literal " + c["_bigint"].get<std::string>() +
@@ -1382,8 +1381,7 @@ exprt numpy_call_expr::create_expr_from_call()
   nlohmann::json expr;
 
   // Resolve variables if they are names
-  auto resolve_var = [this](nlohmann::json &var)
-  {
+  auto resolve_var = [this](nlohmann::json &var) {
     if (var["_type"] == "Name")
     {
       var = json_utils::find_var_decl(
@@ -2203,29 +2201,27 @@ exprt numpy_call_expr::create_expr_from_call()
         }
 
         auto as_dim =
-          [](const std::vector<std::size_t> &shape, std::size_t axis)
-        {
-          if (shape.empty())
-            return from_integer(1, int_type());
-          if (shape.size() == 1)
+          [](const std::vector<std::size_t> &shape, std::size_t axis) {
+            if (shape.empty())
+              return from_integer(1, int_type());
+            if (shape.size() == 1)
+              return from_integer(
+                axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
             return from_integer(
-              axis == 0 ? 1 : static_cast<int>(shape[0]), int_type());
-          return from_integer(
-            static_cast<int>(axis < shape.size() ? shape[axis] : 1),
-            int_type());
-        };
+              static_cast<int>(axis < shape.size() ? shape[axis] : 1),
+              int_type());
+          };
 
         auto build_array_type =
-          [&](const std::vector<std::size_t> &shape, const typet &elem_type)
-        {
-          if (shape.empty())
-            return elem_type;
+          [&](const std::vector<std::size_t> &shape, const typet &elem_type) {
+            if (shape.empty())
+              return elem_type;
 
-          typet array_type = elem_type;
-          for (auto it = shape.rbegin(); it != shape.rend(); ++it)
-            array_type = type_handler_.build_array(array_type, *it);
-          return array_type;
-        };
+            typet array_type = elem_type;
+            for (auto it = shape.rbegin(); it != shape.rend(); ++it)
+              array_type = type_handler_.build_array(array_type, *it);
+            return array_type;
+          };
 
         typet lhs_scalar_type =
           get_array_scalar_type(type_handler_.get_typet(lhs["elts"]));
@@ -2380,8 +2376,7 @@ exprt numpy_call_expr::get()
       // pointer). handle_fmod is scalar-only and would otherwise mis-fold
       // them or crash the FP backend.
       const typet list_type = type_handler_.get_list_type();
-      auto is_container = [&list_type](const exprt &e)
-      {
+      auto is_container = [&list_type](const exprt &e) {
         return e.type().is_array() || e.type() == list_type ||
                (e.type().is_pointer() && e.type().subtype() == list_type);
       };
@@ -2391,8 +2386,7 @@ exprt numpy_call_expr::get()
       return converter_.get_math_handler().handle_fmod(lhs, rhs, call_);
     }
 
-    auto is_scalar_node = [](const nlohmann::json &node)
-    {
+    auto is_scalar_node = [](const nlohmann::json &node) {
       const std::string type = node["_type"];
       return type == "Constant" || type == "UnaryOp";
     };
@@ -2407,8 +2401,7 @@ exprt numpy_call_expr::get()
       auto rhs = extract_value(call_["args"][1]);
 
       auto compute_scalar_result =
-        [&](double left, double right, double &out) -> bool
-      {
+        [&](double left, double right, double &out) -> bool {
         if (function == "add")
         {
           out = left + right;

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -114,7 +114,7 @@ weight: 4
 
 ## NumPy Module
 
-- Arrays are modelled with a restricted subset: `.shape` is available for modelled arrays, tuple indexing is lowered through chained indexing, and direct scalar broadcasting still covers simple binary operators such as `a + n` and `a * n`. Array constructors preserve explicit `dtype` for supported literal `bool`/`int`/`float` inputs in the 1D/2D recorte; unsupported constructor dtypes and higher-dimensional arrays are rejected explicitly. Full NumPy dtype semantics and unrestricted N-dimensional indexing remain unsupported.
+- Arrays are modelled with a restricted subset: `.shape` is available for modelled arrays, tuple indexing is lowered through chained indexing, and direct scalar broadcasting still covers simple binary operators such as `a + n` and `a * n`. Higher-dimensional arrays are rejected explicitly; full NumPy dtype semantics and unrestricted N-dimensional indexing remain unsupported.
 - Element-wise `np.add`/`np.subtract`/`np.multiply`/`np.divide`/`np.power` support literal list-backed 1D/2D inputs with NumPy-style broadcasting. Runtime-constructed inputs and higher-dimensional inputs are rejected with deterministic frontend errors rather than falling through to the SMT backend.
 - Only the NumPy functions listed in [Supported Features — NumPy](./supported-features#numpy-module-numpy) have executable support.
 - The remaining type-inference-only stubs are `np.arccos`, `np.fmod`, `np.dot`, `np.matmul`, and `np.transpose`.


### PR DESCRIPTION
this PR improves the Python frontend NumPy handling in two areas:
- dispatches element-wise np.add/np.subtract/np.multiply/np.divide to the correct runtime model for float vs integer scalar arrays
- folds simple complex literal expressions in the frontend, including binary literal forms used by NumPy-related code paths
- rejects complex-valued inputs for numpy.linalg.det with a clear frontend error instead of reaching unsupported paths