### PR TITLE
[om] calloc: route zero-size request to malloc(0), not NULL

### DIFF
--- a/regression/esbmc-unix/github_5395_calloc_empty_struct/main.c
+++ b/regression/esbmc-unix/github_5395_calloc_empty_struct/main.c
@@ -1,0 +1,28 @@
+// Regression for github #5395: a zero-sized calloc request must honour
+// --force-malloc-success and return non-null, exactly like malloc(0).
+//
+// Here `struct bus_info` is empty, so sizeof == 0 and kzalloc()/calloc()
+// request zero bytes.  Previously calloc(_, 0) returned NULL
+// unconditionally (ignoring --force-malloc-success), so the NULL-check
+// error path was wrongly reachable and reach_error fired -- a false
+// alarm on the unreach-call property.  The original benchmark is
+// c/ldv-regression/rule57_ebda_blast.i.
+#include <stdlib.h>
+
+struct bus_info {};
+
+void reach_error(void) {}
+
+static void *kzalloc(int size, int flags)
+{
+  (void)flags;
+  return calloc(1, size); // calloc(1, 0) when size == 0
+}
+
+int main(void)
+{
+  struct bus_info *p = (struct bus_info *)kzalloc(sizeof(struct bus_info), 0);
+  if (!p)
+    reach_error(); // unreachable under --force-malloc-success
+  return 0;
+}

--- a/regression/esbmc-unix/github_5395_calloc_empty_struct/test.desc
+++ b/regression/esbmc-unix/github_5395_calloc_empty_struct/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --no-pointer-check --no-bounds-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_5395_calloc_zero_is_null_fail/main.c
+++ b/regression/esbmc-unix/github_5395_calloc_zero_is_null_fail/main.c
@@ -1,0 +1,20 @@
+// Regression for github #5395: calloc of a zero-sized request must track
+// malloc(0) under --malloc-zero-is-null too -- i.e. return NULL.  This
+// pins the option-respecting boundary: asserting the pointer is non-null
+// must FAIL here (the fix routes calloc(_,0) through malloc(0), which
+// returns NULL when --malloc-zero-is-null is set).
+#include <stdlib.h>
+
+void reach_error(void) {}
+static void verifier_assert(int cond)
+{
+  if (!cond)
+    reach_error();
+}
+
+int main(void)
+{
+  void *p = calloc(1, 0);
+  verifier_assert(p != 0); // FAILS: calloc(1,0) is NULL under --malloc-zero-is-null
+  return 0;
+}

--- a/regression/esbmc-unix/github_5395_calloc_zero_is_null_fail/test.desc
+++ b/regression/esbmc-unix/github_5395_calloc_zero_is_null_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null --no-pointer-check --no-bounds-check --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -85,8 +85,15 @@ __ESBMC_HIDE:;
 void *calloc(size_t nmemb, size_t size)
 {
 __ESBMC_HIDE:;
+  // A zero element count or zero element size is a zero-byte request.
+  // Defer to malloc(0) so the result honours --force-malloc-success and
+  // --malloc-zero-is-null, exactly like a direct malloc(0).  Returning
+  // NULL unconditionally here ignored those options and made calloc(n, 0)
+  // inconsistent with malloc(0), producing false alarms when a zero-sized
+  // allocation (e.g. of an empty struct) feeds a NULL-check error path.
+  // Keeping the guard also protects the SIZE_MAX / size division below.
   if (!nmemb || !size)
-    return NULL;
+    return malloc(0);
 
   // Detect size_t multiplication overflow (e.g. nmemb=2^30, size=4 on
   // 32-bit wraps total_size to 0).  Real implementations (glibc, musl)


### PR DESCRIPTION
Fixes #5395 — an SV-COMP `unreach-call` false alarm on `c/ldv-regression/rule57_ebda_blast.i` (ESBMC reports `VERIFICATION FAILED`, ground truth `true`).

**Root cause.** `struct bus_info` is empty (`sizeof == 0`), so `ibmphp_find_same_bus_num()`'s `kzalloc(sizeof(struct bus_info), 0)` lowers to `calloc(1, 0)`. The `calloc` operational model (`src/c2goto/library/stdlib.c`), after #5269 added `if (!nmemb || !size) return NULL;` for overflow handling, returned NULL *unconditionally* for a zero-byte request — ignoring `--force-malloc-success`. A direct `malloc(0)` honours that option, so `calloc(n, 0)` was inconsistent with `malloc(0)`: the trace shows `bus_info_ptr1 = NULL` despite `--force-malloc-success`, driving a NULL-check error path that fires `reach_error`.

**Fix.** Route the zero-byte case to `malloc(0)` instead of returning NULL. The guard condition is unchanged, so the later `__ESBMC_assume(nmemb <= SIZE_MAX / size)` overflow prune from #5269 is still protected from div-by-zero. Zero-size `calloc` now mirrors `malloc(0)`: non-null under `--force-malloc-success`, NULL under `--malloc-zero-is-null` (C17 §7.22.3: `calloc(_, 0)` is implementation-defined NULL-or-unique-pointer, exactly like `malloc(0)`). Note: an unfreed `calloc(1, 0)` now reports a leak under `--memory-leak-check`, matching `malloc(0)`.

**Validation.** #5395 with the issue's exact flags → `VERIFICATION SUCCESSFUL`. The three `github_4433` calloc-overflow regressions (#5269) still pass; all 49 calloc-using regression tests pass. Two new tests: `github_5395_calloc_empty_struct` (zero-size under `--force-malloc-success` ⇒ SUCCESSFUL) and `github_5395_calloc_zero_is_null_fail` (`calloc(1,0)` under `--malloc-zero-is-null` ⇒ NULL ⇒ FAILED, pinning the option boundary).