### PR TITLE
[python] V.3: build strcmp(a,b) op 0 comparison in IREP2

### DIFF
--- a/regression/python/strcmp_attr_eq/main.py
+++ b/regression/python/strcmp_attr_eq/main.py
@@ -1,0 +1,13 @@
+# An unannotated parameter is modelled as void*; comparing it against a string
+# literal lowers to `strcmp(a, b) == 0` (converter_binop.cpp). Exercises the
+# IREP2 equality2tc strcmp comparison (Part V Phase V.3).
+class Box:
+    def __init__(self):
+        self.label = "hi"
+
+
+def check(b) -> bool:
+    return b.label == "hi"
+
+
+assert check(Box()) == True

--- a/regression/python/strcmp_attr_eq/test.desc
+++ b/regression/python/strcmp_attr_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/strcmp_attr_neq_fail/main.py
+++ b/regression/python/strcmp_attr_neq_fail/main.py
@@ -1,0 +1,13 @@
+# NotEq variant of the void*-vs-string strcmp path: `b.label != "hi"` lowers to
+# `strcmp(a, b) != 0` (IREP2 notequal2tc). The label equals "hi", so the
+# comparison is False and the assertion is violated (Part V Phase V.3).
+class Box:
+    def __init__(self):
+        self.label = "hi"
+
+
+def check(b) -> bool:
+    return b.label != "hi"
+
+
+assert check(Box()) == True

--- a/regression/python/strcmp_attr_neq_fail/test.desc
+++ b/regression/python/strcmp_attr_neq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -670,7 +670,9 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
         migrate_expr(as_char_ptr(lhs), lhs2);
         migrate_expr(as_char_ptr(rhs), rhs2);
         expr2tc strcmp_call2 = side_effect_function_call2tc(
-          migrate_type(int_type()), symbol_expr2tc(*strcmp_symbol), {lhs2, rhs2});
+          migrate_type(int_type()),
+          symbol_expr2tc(*strcmp_symbol),
+          {lhs2, rhs2});
         expr2tc zero2 = gen_zero(migrate_type(int_type()));
         expr2tc cmp2 = (op == "Eq") ? equality2tc(strcmp_call2, zero2)
                                     : notequal2tc(strcmp_call2, zero2);

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -663,16 +663,22 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
           return e;
         };
 
-        side_effect_expr_function_callt strcmp_call;
-        strcmp_call.function() = symbol_expr(*strcmp_symbol);
-        strcmp_call.arguments() = {as_char_ptr(lhs), as_char_ptr(rhs)};
-        strcmp_call.location() = get_location_from_decl(element);
-        strcmp_call.type() = int_type();
+        // V.3: build `strcmp(a, b) op 0` (op is Eq/NotEq) in IREP2, back
+        // -migrating once. Exact round-trip of the legacy side-effect strcmp
+        // call compared against zero via equality/notequal.
+        expr2tc lhs2, rhs2;
+        migrate_expr(as_char_ptr(lhs), lhs2);
+        migrate_expr(as_char_ptr(rhs), rhs2);
+        expr2tc strcmp_call2 = side_effect_function_call2tc(
+          migrate_type(int_type()), symbol_expr2tc(*strcmp_symbol), {lhs2, rhs2});
+        expr2tc zero2 = gen_zero(migrate_type(int_type()));
+        expr2tc cmp2 = (op == "Eq") ? equality2tc(strcmp_call2, zero2)
+                                    : notequal2tc(strcmp_call2, zero2);
 
-        exprt result(
-          python_frontend::map_operator(op, bool_type()), bool_type());
-        result.copy_to_operands(strcmp_call, gen_zero(int_type()));
-        result.location() = get_location_from_decl(element);
+        exprt result = migrate_expr_back(cmp2);
+        const locationt loc = get_location_from_decl(element);
+        result.location() = loc;
+        result.op0().location() = loc; // re-attach the strcmp call location
         return result;
       }
     }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

In `get_binary_operator_expr`, the void*-vs-string comparison path lowers `a == b` / `a != b` (one side unannotated `void*`, the other string-like) to `strcmp(a, b) op 0`. This converts that subtree to IREP2:

```cpp
// before
side_effect_expr_function_callt strcmp_call;
strcmp_call.function() = symbol_expr(*strcmp_symbol);
strcmp_call.arguments() = {as_char_ptr(lhs), as_char_ptr(rhs)};
strcmp_call.location() = get_location_from_decl(element);
strcmp_call.type() = int_type();
exprt result(map_operator(op, bool_type()), bool_type());
result.copy_to_operands(strcmp_call, gen_zero(int_type()));
result.location() = get_location_from_decl(element);

// after
expr2tc lhs2, rhs2;
migrate_expr(as_char_ptr(lhs), lhs2);
migrate_expr(as_char_ptr(rhs), rhs2);
expr2tc strcmp_call2 = side_effect_function_call2tc(
  migrate_type(int_type()), symbol_expr2tc(*strcmp_symbol), {lhs2, rhs2});
expr2tc zero2 = gen_zero(migrate_type(int_type()));
expr2tc cmp2 = (op == "Eq") ? equality2tc(strcmp_call2, zero2)
                            : notequal2tc(strcmp_call2, zero2);
exprt result = migrate_expr_back(cmp2);
const locationt loc = get_location_from_decl(element);
result.location() = loc;
result.op0().location() = loc; // re-attach the strcmp call location
```

Removes four legacy builders (`side_effect_expr_function_callt`, `symbol_expr`, `gen_zero`, `copy_to_operands`).

## Why it is behaviour-preserving

The enclosing guard is `op == "Eq" || op == "NotEq"`, and `map_operator` maps `eq`→`=` and `noteq`→`notequal` (`converter_internal.h`), so:

- `equality2tc(strcmp_call2, zero2)` / `notequal2tc(...)` back-migrate to exactly `equality_exprt` / `notequal_exprt` with the side-effect strcmp call as `op0` and `0` as `op1` — the legacy `result`.
- `gen_zero(migrate_type(int_type()))` returns `constant_int2tc(int, 0)` = `migrate_expr(gen_zero(int_type()))`.
- Locations are re-attached to match the legacy node (which set both the comparison and the strcmp call locations).

No float/int dispatch hazard (the op is always `=`/`notequal`).

## Tests

Adds two regression tests exercising the path (no existing test covered it):

- `strcmp_attr_eq` — `b.label == "hi"` → `strcmp == 0` (`equality2tc`) → SUCCESSFUL.
- `strcmp_attr_neq_fail` — `b.label != "hi"` → `strcmp != 0` (`notequal2tc`), assertion violated → FAILED.

Both confirmed valid CPython references via `scripts/check_python_tests.sh`.

## Validation

- New tests pass; build + clang-format clean.
- Python string/compare/class/attr/any subset: all Bitwuzla-runnable tests pass (failures are `--z3`/`--ir`-gated, environmental on the local Bitwuzla-only build).
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
