### PR TITLE
[python] V.3: build numpy broadcast index/update in IREP2

### DIFF
--- a/regression/numpy/broadcast_float_scalar/main.py
+++ b/regression/numpy/broadcast_float_scalar/main.py
@@ -1,0 +1,15 @@
+# Float numeric-array +/* scalar broadcast: exercises the IEEE-float element op
+# (ieee_add/ieee_mul) path of handle_array_operations' build_scalar_broadcast,
+# distinct from the integer add/mul path (Part V Phase V.3).
+import numpy as np
+
+a = np.array([1.5, 2.5, 3.0])
+b = a + 0.5
+assert b[0] == 2.0
+assert b[1] == 3.0
+assert b[2] == 3.5
+
+c = a * 2.0
+assert c[0] == 3.0
+assert c[1] == 5.0
+assert c[2] == 6.0

--- a/regression/numpy/broadcast_float_scalar/test.desc
+++ b/regression/numpy/broadcast_float_scalar/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/broadcast_float_scalar_fail/main.py
+++ b/regression/numpy/broadcast_float_scalar_fail/main.py
@@ -1,0 +1,8 @@
+# Fail variant: the float broadcast result is asserted against a wrong value, so
+# verification must fail. Exercises the IEEE-float ieee_add element-op path of
+# build_scalar_broadcast (Part V Phase V.3).
+import numpy as np
+
+a = np.array([1.5, 2.5, 3.0])
+b = a + 0.5
+assert b[0] == 99.0  # actual value is 2.0

--- a/regression/numpy/broadcast_float_scalar_fail/test.desc
+++ b/regression/numpy/broadcast_float_scalar_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -969,24 +969,28 @@ exprt python_converter::handle_array_operations(
                             ? scalar_expr
                             : typecast_exprt(scalar_expr, elem_type);
 
-    exprt result_array = array_expr;
-    // V.3: build the array element access in IREP2 (index2tc), the exact
-    // round-trip of index_exprt (behaviour-preserving). The array and element
-    // type are loop-invariant, so migrate them once.
+    // V.3: build the per-element index in IREP2 and accumulate the array update
+    // with with2tc. The +/* element op stays a legacy node so map_operator +
+    // migrate_expr select the correct integer (add/mul) or IEEE-float
+    // (ieee_add/ieee_mul + rounding mode) form per element type; the array is
+    // back-migrated once at the end.
     expr2tc ar2;
     migrate_expr(array_expr, ar2);
     const type2tc elem_t2 = migrate_type(elem_type);
+    const type2tc index_t2 = migrate_type(size_type());
+
+    expr2tc result2 = ar2;
     for (long long i = 0; i < array_size; ++i)
     {
-      exprt index = from_integer(i, size_type());
-      expr2tc ix2;
-      migrate_expr(index, ix2);
+      expr2tc ix2 = from_integer(BigInt(i), index_t2);
       exprt array_item = migrate_expr_back(index2tc(elem_t2, ar2, ix2));
       exprt bin_elem(python_frontend::map_operator(op, elem_type), elem_type);
       bin_elem.copy_to_operands(array_item, casted_scalar);
-      result_array = with_exprt(result_array, index, bin_elem);
+      expr2tc bin_elem2;
+      migrate_expr(bin_elem, bin_elem2);
+      result2 = with2tc(result2->type, result2, ix2, bin_elem2);
     }
-    return result_array;
+    return migrate_expr_back(result2);
   };
 
   // For direct Python binary operators over arrays, keep behaviour explicit


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

`handle_array_operations`' `build_scalar_broadcast` lowers a numeric-array `+`/`*` scalar (e.g. `np.array([1,2,3]) + 4`) to a per-element `with`-update loop. This converts the per-element index build and the array update to IREP2:

```cpp
// before (per element)
exprt index = from_integer(i, size_type());
expr2tc ix2; migrate_expr(index, ix2);
exprt array_item = migrate_expr_back(index2tc(elem_t2, ar2, ix2));
exprt bin_elem(map_operator(op, elem_type), elem_type);
bin_elem.copy_to_operands(array_item, casted_scalar);
result_array = with_exprt(result_array, index, bin_elem);   // ... return result_array;

// after
expr2tc ix2 = from_integer(BigInt(i), index_t2);
exprt array_item = migrate_expr_back(index2tc(elem_t2, ar2, ix2));
exprt bin_elem(map_operator(op, elem_type), elem_type);
bin_elem.copy_to_operands(array_item, casted_scalar);
expr2tc bin_elem2; migrate_expr(bin_elem, bin_elem2);
result2 = with2tc(result2->type, result2, ix2, bin_elem2);  // ... return migrate_expr_back(result2);
```

`from_integer` and `with_exprt` are now built in IREP2; the array accumulates in `expr2tc` and is back-migrated once.

## Why the `+`/`*` op stays a legacy node (correctness)

`map_operator(op, elem_type)` returns `ieee_add`/`ieee_mul` when `elem_type` is **float** and `add`/`mul` (`+`/`*`) for integers (`converter_internal.h`), and `migrate_expr` lowers `ieee_add` to `ieee_add2tc` **with a rounding-mode operand**. Building `add2tc`/`mul2tc` directly would silently drop IEEE-754 semantics for float arrays. So the element op is kept as a legacy node and migrated — `migrate_expr` selects the correct integer or IEEE-float form per element type. The result is an exact round-trip for both: `migrate_expr_back(result2)` reconstructs the identical chained `with_exprt` the legacy code produced.

## Tests

The float broadcast path (`ieee_add`/`ieee_mul`) had no regression coverage — adds:
- `broadcast_float_scalar` — `np.array([1.5,2.5,3.0]) + 0.5` and `* 2.0`, asserting IEEE results → SUCCESSFUL.
- `broadcast_float_scalar_fail` — same with a wrong expected value → FAILED.

## Validation

- numpy regression suite (331 tests incl. the 73 integer `github_4668_*` broadcast tests and the 2 new float ones): all Bitwuzla-runnable tests pass.
- Build + clang-format clean.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.

A first cut that built `add2tc`/`mul2tc` directly was caught in review as unsound for float arrays; this version delegates the int/float dispatch to `migrate_expr`, and the new float test pins it.
