### PR TITLE
[contracts] Bound array-elem assigns witness by the real is_fresh size

### DIFF
--- a/regression/function_contract/github_5314_is_fresh_arr_elem_fail/main.c
+++ b/regression/function_contract/github_5314_is_fresh_arr_elem_fail/main.c
@@ -1,0 +1,11 @@
+/* github #5314 soundness guard: the witness index still ranges over the whole
+ * is_fresh buffer, so a write to an element NOT in the assigns clause (here a[9],
+ * the last valid element) must still be reported as a frame violation. */
+__ESBMC_contract
+void f(int *a)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(a, 10 * sizeof(int)));
+  __ESBMC_assigns(a[0]);
+  a[0] = 0;
+  a[9] = 5; /* not in assigns clause */
+}

--- a/regression/function_contract/github_5314_is_fresh_arr_elem_fail/test.desc
+++ b/regression/function_contract/github_5314_is_fresh_arr_elem_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_5314_is_fresh_arr_elem_pass/main.c
+++ b/regression/function_contract/github_5314_is_fresh_arr_elem_pass/main.c
@@ -1,0 +1,11 @@
+/* github #5314: under --enforce-contract, naming an array element a[k] as an
+ * assigns target tripped a spurious "array bounds violated" because the Phase-2B
+ * witness index was bounded by ARRAY_ALLOC_ELEMS (100) instead of the real
+ * __ESBMC_is_fresh allocation (10 elements). a[0] / a[2] / *(a+2) all in bounds. */
+__ESBMC_contract
+void f(int *a)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(a, 10 * sizeof(int)));
+  __ESBMC_assigns(a[2]);
+  a[2] = 0;
+}

--- a/regression/function_contract/github_5314_is_fresh_arr_elem_pass/test.desc
+++ b/regression/function_contract/github_5314_is_fresh_arr_elem_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -1,6 +1,8 @@
 #include <cstdlib>
 #include <algorithm>
+#include <map>
 #include <goto-programs/contracts/contracts.h>
+#include <util/type_byte_size.h>
 #include <goto-programs/remove_no_op.h>
 #include <util/base_type.h>
 #include <util/c_types.h>
@@ -1010,6 +1012,11 @@ goto_programt code_contractst::generate_checking_wrapper(
     }
   }
 
+  // Records each is_fresh pointer's byte-size so the Phase 2B array-element
+  // witness index can be bounded by the real allocation rather than the default
+  // ARRAY_ALLOC_ELEMS (which only applies to validity-assumption allocations).
+  std::map<irep_idt, expr2tc> is_fresh_sizes;
+
   for (const auto &info : is_fresh_calls)
   {
     // Strip typecasts (e.g. (void*)(&hdr_len) → &hdr_len) to recover the
@@ -1069,6 +1076,11 @@ goto_programt code_contractst::generate_checking_wrapper(
 
     // Remember the allocation so the wrapper can free it before returning.
     wrapper_heap_ptrs.push_back(ptr_var);
+
+    // Record the allocation size keyed by the pointer symbol so Phase 2B can
+    // bound its array-element witness index by the real allocation.
+    if (is_symbol2t(ptr_var))
+      is_fresh_sizes[to_symbol2t(ptr_var).thename] = info.size_expr;
 
     // Assume the pointer is non-null: __ESBMC_is_fresh guarantees a fresh,
     // valid memory block.  Without this, symex_mem's non-deterministic
@@ -1233,7 +1245,12 @@ goto_programt code_contractst::generate_checking_wrapper(
 
     // 3b-v. Phase 2B: nondet-witness snapshot for array element assigns
     arr_elem_snaps = materialize_arr_elem_snapshots(
-      classified_assigns, assigns_targets, wrapper, location, func_name);
+      classified_assigns,
+      assigns_targets,
+      wrapper,
+      location,
+      func_name,
+      is_fresh_sizes);
     if (!arr_elem_snaps.empty())
     {
       log_debug(
@@ -2478,7 +2495,8 @@ code_contractst::materialize_arr_elem_snapshots(
   const std::vector<expr2tc> &assigns_targets,
   goto_programt &wrapper,
   const locationt &location,
-  const std::string &func_name)
+  const std::string &func_name,
+  const std::map<irep_idt, expr2tc> &is_fresh_sizes)
 {
   std::vector<arr_elem_snapshot_t> result;
 
@@ -2552,11 +2570,27 @@ code_contractst::materialize_arr_elem_snapshots(
     j_assign->location.comment("frame: nondet witness index (Phase 2B)");
 
     // Constrain j to the allocated range so that arr[j] is a valid access.
-    // The allocation in add_pointer_validity_assumptions uses ARRAY_ALLOC_ELEMS
-    // elements, so j must be in [0, ARRAY_ALLOC_ELEMS).
+    // Two allocation sources exist: __ESBMC_is_fresh(p, n) allocates exactly n
+    // bytes (n/sizeof(elem) elements), while add_pointer_validity_assumptions
+    // allocates ARRAY_ALLOC_ELEMS elements for the remaining array params.  Use
+    // the real is_fresh element count when known; otherwise fall back to
+    // ARRAY_ALLOC_ELEMS.  Over-bounding j here makes arr[j] read past the real
+    // allocation and trips a spurious "array bounds violated" (see #5314).
     {
       expr2tc j_lo = gen_zero(j_type);
       expr2tc j_hi = constant_int2tc(j_type, BigInt(ARRAY_ALLOC_ELEMS));
+      auto fresh_it = is_fresh_sizes.find(to_symbol2t(arr_ptr).thename);
+      if (fresh_it != is_fresh_sizes.end())
+      {
+        BigInt elem_sz = type_byte_size(elem_type, &ns);
+        if (elem_sz > 0)
+        {
+          expr2tc size_bytes = typecast2tc(j_type, fresh_it->second);
+          expr2tc elem_sz_e = constant_int2tc(j_type, elem_sz);
+          j_hi = div2tc(j_type, size_bytes, elem_sz_e);
+          simplify(j_hi);
+        }
+      }
       expr2tc in_range = and2tc(
         greaterthanequal2tc(witness_j, j_lo), lessthan2tc(witness_j, j_hi));
       goto_programt::targett range_assume = wrapper.add_instruction(ASSUME);

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -42,6 +42,7 @@
 #include <goto-programs/frame_enforcer.h>
 #include <util/context.h>
 #include <util/namespace.h>
+#include <map>
 #include <set>
 #include <string>
 
@@ -384,13 +385,18 @@ private:
   /// \param wrapper GOTO program to append snapshot instructions to
   /// \param location Source location
   /// \param func_name Function name for unique snapshot naming
+  /// \param is_fresh_sizes Maps each __ESBMC_is_fresh pointer symbol to its
+  ///        byte-size expression, so the array-element witness index is bounded
+  ///        by the real allocation (size/sizeof(elem)) rather than the default
+  ///        ARRAY_ALLOC_ELEMS used for validity-assumption allocations.
   /// \return Vector of snapshot records for use in emit_arr_elem_assertions
   std::vector<arr_elem_snapshot_t> materialize_arr_elem_snapshots(
     const frame_enforcert::classified_assignst &classified,
     const std::vector<expr2tc> &assigns_targets,
     goto_programt &wrapper,
     const locationt &location,
-    const std::string &func_name);
+    const std::string &func_name,
+    const std::map<irep_idt, expr2tc> &is_fresh_sizes);
 
   /// \brief Emit ASSERT instructions for array element assigns compliance.
   /// For each snapshot: asserts (j == declared_idx) || (arr[j] == snapshot).


### PR DESCRIPTION
Fixes #5314 — under `--enforce-contract`, naming an array element as an assigns target (`__ESBMC_assigns(a[k])` / `__ESBMC_assigns(*(a+k))`) reported a spurious `VERIFICATION FAILED: dereference failure: array bounds violated`, even for an in-bounds element. Bare `__ESBMC_assigns(*a)` worked.

**Root cause.** The Phase 2B array-element frame rule (`materialize_arr_elem_snapshots`) builds a nondet witness index `j` to assert that no non-assigned element changed, and constrained `j` to `[0, ARRAY_ALLOC_ELEMS)` with `ARRAY_ALLOC_ELEMS = 100`. That bound matches the allocation made by `add_pointer_validity_assumptions`, but `__ESBMC_is_fresh(a, n)` allocates exactly `n` bytes (`n/sizeof(elem)` elements) and is *skipped* by that pass. So for an is_fresh buffer of 10 ints, `a[j]` with `j` up to 99 reads past the real allocation → spurious bounds violation.

**Fix.** Thread a `pointer-symbol → byte-size` map built in `generate_checking_wrapper`'s is_fresh allocation loop into `materialize_arr_elem_snapshots`, and bound the witness index by the real element count `size/sizeof(elem)` when the array pointer was allocated by `__ESBMC_is_fresh`; otherwise keep `ARRAY_ALLOC_ELEMS`.

**Soundness.** The smaller bound never masks a real frame violation: a write to an in-bounds element outside the assigns clause is still in `[0, real_count)` and caught, while an out-of-bounds write is caught by the ordinary bounds checker. A negative regression test that writes `a[9]` (the last valid element, not in the assigns clause) still reports `VERIFICATION FAILED`.

**Tests.** `regression/function_contract/github_5314_is_fresh_arr_elem_pass` (a[k] target ⇒ SUCCESSFUL) and `github_5314_is_fresh_arr_elem_fail` (out-of-clause write ⇒ FAILED). Validated via the binary (the function_contract suite is ctest-skipped on macOS); no regressions vs. the pre-fix binary.