### PR TITLE
[ir-ieee] handle NaN comparisons for negative sqrt

### DIFF
--- a/regression/ir-ra/ra-sqrt-nan-equality-comparisons/main.c
+++ b/regression/ir-ra/ra-sqrt-nan-equality-comparisons/main.c
@@ -1,0 +1,9 @@
+#include <math.h>
+
+int main(void)
+{
+  double s = sqrt(-1.0);
+  __ESBMC_assert(!(s == s), "NaN == NaN is false");
+  __ESBMC_assert(s != s, "NaN != NaN is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-nan-equality-comparisons/test.desc
+++ b/regression/ir-ra/ra-sqrt-nan-equality-comparisons/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-sqrt-nan-ordered-comparisons/main.c
+++ b/regression/ir-ra/ra-sqrt-nan-ordered-comparisons/main.c
@@ -1,0 +1,11 @@
+#include <math.h>
+
+int main(void)
+{
+  double s = sqrt(-1.0);
+  __ESBMC_assert(!(s < 100.0), "NaN < 100.0 is false");
+  __ESBMC_assert(!(s <= 100.0), "NaN <= 100.0 is false");
+  __ESBMC_assert(!(s > -100.0), "NaN > -100.0 is false");
+  __ESBMC_assert(!(s >= -100.0), "NaN >= -100.0 is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-nan-ordered-comparisons/test.desc
+++ b/regression/ir-ra/ra-sqrt-nan-ordered-comparisons/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-sqrt-pos-sanity/main.c
+++ b/regression/ir-ra/ra-sqrt-pos-sanity/main.c
@@ -1,0 +1,9 @@
+#include <math.h>
+
+int main(void)
+{
+  double s = sqrt(4.0);
+  __ESBMC_assert(s == 2.0, "sqrt(4.0) == 2.0");
+  __ESBMC_assert(s == s, "positive sqrt result equals itself");
+  return 0;
+}

--- a/regression/ir-ra/ra-sqrt-pos-sanity/test.desc
+++ b/regression/ir-ra/ra-sqrt-pos-sanity/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -53,6 +53,35 @@ void ir_ieee_convt::store_interval(smt_astt t, smt_astt lo, smt_astt hi)
   ir_ra_interval_map[t] = {lo, hi};
 }
 
+void ir_ieee_convt::store_nan_pred(smt_astt t, smt_astt nan_pred)
+{
+  ir_ieee_nan_map[t] = nan_pred;
+}
+
+smt_astt ir_ieee_convt::get_nan_pred(smt_astt t) const
+{
+  auto it = ir_ieee_nan_map.find(t);
+  return it != ir_ieee_nan_map.end() ? it->second : nullptr;
+}
+
+void ir_ieee_convt::propagate_nan_pred(smt_astt lhs, smt_astt rhs)
+{
+  auto it = ir_ieee_nan_map.find(rhs);
+  if (it != ir_ieee_nan_map.end())
+    ir_ieee_nan_map[lhs] = it->second;
+}
+
+smt_astt
+ir_ieee_convt::apply_nan_cmp(smt_astt cmp, smt_astt a, smt_astt b, bool is_neq)
+{
+  smt_astt na = get_nan_pred(a);
+  smt_astt nb = get_nan_pred(b);
+  if (!na && !nb)
+    return cmp;
+  smt_astt either_nan = (na && nb) ? ctx->mk_or(na, nb) : (na ? na : nb);
+  return ctx->mk_ite(either_nan, ctx->mk_smt_bool(is_neq), cmp);
+}
+
 std::pair<smt_astt, smt_astt> ir_ieee_convt::apply_ieee754_rne_enclosure(
   smt_astt real_result,
   smt_astt lo_r,

--- a/src/solvers/smt/fp/ir_ieee_conv.h
+++ b/src/solvers/smt/fp/ir_ieee_conv.h
@@ -70,6 +70,27 @@ public:
   /** Integer-encoding path for ieee_fma (fused multiply-add). */
   smt_astt encode_ieee_fma(const expr2tc &expr);
 
+  /** Record that the SMT AST t may be NaN; nan_pred is a boolean SMT term
+   *  that is true iff t holds a NaN value (e.g. not(operand >= 0) for
+   *  sqrt with a negative operand). */
+  void store_nan_pred(smt_astt t, smt_astt nan_pred);
+
+  /** Return the stored NaN predicate for t, or nullptr if none is known. */
+  smt_astt get_nan_pred(smt_astt t) const;
+
+  /** Propagate a NaN predicate from rhs to lhs after an SSA assignment.
+   *  Called from smt_solver_baset::convert_assign alongside
+   *  propagate_interval. */
+  void propagate_nan_pred(smt_astt lhs, smt_astt rhs);
+
+  /** Wrap a comparison result with IEEE NaN semantics.
+   *  If either operand has a known NaN predicate, returns
+   *    ite(nan_pred, is_neq, cmp)
+   *  so that ordered comparisons (is_neq=false) evaluate to false when
+   *  either operand is NaN, and != (is_neq=true) evaluates to true.
+   *  Returns cmp unchanged when no NaN predicate is known. */
+  smt_astt apply_nan_cmp(smt_astt cmp, smt_astt a, smt_astt b, bool is_neq);
+
   /** Interval-lifted RNE enclosure helper.
    *  Input: exact real result and pre-computed interval endpoints [lo_r, hi_r].
    *  Returns {ra_lo, ra_hi} for storage in the interval map. */
@@ -114,6 +135,11 @@ private:
    *  Keyed by pointer identity (SSA variables are hash-consed in smt_cache).
    *  Missing entries fall back to the point interval {t, t}. */
   std::unordered_map<const smt_ast *, ra_interval_t> ir_ra_interval_map;
+
+  /** Map from AST pointer to its NaN predicate (a boolean SMT term that is
+   *  true iff the value is NaN).  Only populated for sqrt results where
+   *  the operand may be negative. */
+  std::unordered_map<const smt_ast *, smt_astt> ir_ieee_nan_map;
 
   /** Set of symbol names that have already received integer range assertions,
    *  preventing duplicate constraints for the same SSA variable. */

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -380,6 +380,7 @@ smt_astt smt_solver_baset::convert_assign(const expr2tc &expr)
   // that get_interval() lookups on the LHS variable find the stored interval
   // for compositional lifting.
   ir_ieee_api->propagate_interval(side1, side2);
+  ir_ieee_api->propagate_nan_pred(side1, side2);
 
   return side2;
 }
@@ -854,9 +855,10 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
       // This ensures that for negative operands the enclosure constraints on
       // sqrt_pos do not propagate to the observable result.
       //
-      // Limitation: NaN non-reflexivity (NaN != NaN in IEEE 754) is not
-      // modelled.  Under --ir-ieee, sqrt(x < 0) returns an unconstrained real,
-      // not a NaN sentinel.
+      // Under --ir-ieee, a NaN predicate  not(operand >= 0)  is stored for
+      // the result so that floating-point comparisons involving this value
+      // can apply IEEE 754 NaN comparison semantics (ordered comparisons
+      // return false; != returns true).
       smt_sortt rs = mk_real_sort();
       smt_astt zero = mk_smt_real("0.0");
       smt_astt op_nonneg = mk_le(zero, operand);
@@ -944,6 +946,8 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
           apply_ieee754_semantics(sqrt_pos, fbv_type, nullptr, rounding_mode);
         a = mk_ite(op_nonneg, pos_result, sqrt_nan);
       }
+      if (ir_ieee)
+        ir_ieee_api->store_nan_pred(a, mk_not(op_nonneg));
     }
     else
     {
@@ -1217,6 +1221,10 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
       a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
     else
       a = args[0]->eq(this, args[1]);
+    if (
+      ir_ieee && int_encoding && is_floatbv_type(eq.side_1) &&
+      is_floatbv_type(eq.side_2))
+      a = ir_ieee_api->apply_nan_cmp(a, args[0], args[1], false);
     break;
   }
   case expr2t::notequal_id:
@@ -1233,6 +1241,10 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     else
       a = args[0]->eq(this, args[1]);
     a = mk_not(a);
+    if (
+      ir_ieee && int_encoding && is_floatbv_type(neq.side_1) &&
+      is_floatbv_type(neq.side_2))
+      a = ir_ieee_api->apply_nan_cmp(a, args[0], args[1], true);
     break;
   }
   case expr2t::shl_id:
@@ -1374,6 +1386,8 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     else if (int_encoding)
     {
       a = mk_lt(args[0], args[1]);
+      if (ir_ieee && is_floatbv_type(lt.side_1) && is_floatbv_type(lt.side_2))
+        a = ir_ieee_api->apply_nan_cmp(a, args[0], args[1], false);
     }
     else if (is_floatbv_type(lt.side_1) && is_floatbv_type(lt.side_2))
     {
@@ -1405,6 +1419,8 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     else if (int_encoding)
     {
       a = mk_le(args[0], args[1]);
+      if (ir_ieee && is_floatbv_type(lte.side_1) && is_floatbv_type(lte.side_2))
+        a = ir_ieee_api->apply_nan_cmp(a, args[0], args[1], false);
     }
     else if (is_floatbv_type(lte.side_1) && is_floatbv_type(lte.side_2))
     {
@@ -1436,6 +1452,8 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     else if (int_encoding)
     {
       a = mk_gt(args[0], args[1]);
+      if (ir_ieee && is_floatbv_type(gt.side_1) && is_floatbv_type(gt.side_2))
+        a = ir_ieee_api->apply_nan_cmp(a, args[0], args[1], false);
     }
     else if (is_floatbv_type(gt.side_1) && is_floatbv_type(gt.side_2))
     {
@@ -1467,6 +1485,8 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     else if (int_encoding)
     {
       a = mk_ge(args[0], args[1]);
+      if (ir_ieee && is_floatbv_type(gte.side_1) && is_floatbv_type(gte.side_2))
+        a = ir_ieee_api->apply_nan_cmp(a, args[0], args[1], false);
     }
     else if (is_floatbv_type(gte.side_1) && is_floatbv_type(gte.side_2))
     {


### PR DESCRIPTION
## Summary

This PR adds minimal NaN predicate tracking for negative `sqrt` results in the `--ir-ieee` integer/real SMT encoding path.

When `sqrt` is applied to a negative operand, the existing encoding already avoids eliminating the path by returning an unconstrained real value for that branch. This PR extends that behaviour by recording a NaN predicate for the observable `sqrt` result and using it when encoding floating-point comparisons.

This allows comparisons involving negative `sqrt` results to follow IEEE NaN comparison behaviour:

* ordered comparisons return false
* equality returns false
* inequality returns true

This is intentionally limited to known NaN predicates from negative `sqrt` results.

## Motivation

The current `--ir-ieee` encoding handles negative `sqrt` operands conservatively by avoiding unsatisfiable real constraints. However, the returned unconstrained real value does not model IEEE NaN comparison behaviour.

For example, under IEEE semantics:

```c
double s = sqrt(-1.0);

s < 100.0   // false
s <= 100.0  // false
s > 100.0   // false
s >= 100.0  // false
s == s      // false
s != s      // true
```

Without NaN-aware comparison handling, the unconstrained real fallback can still allow comparisons that should be false for NaN.

## Changes

This PR:

* Adds a small NaN predicate map to `ir_ieee_convt`.
* Records a NaN predicate for `sqrt` results under `--ir-ieee`.

  * The predicate is `!(operand >= 0)`.
  * For non-negative operands, the predicate is false.
  * For negative operands, the result is treated as NaN for comparison purposes.
* Propagates the NaN predicate through SSA assignments.
* Wraps floating-point comparisons in the integer/real encoding path with IEEE NaN comparison semantics:

  * `<`, `<=`, `>`, `>=`, and `==` return false if either operand has a known NaN predicate.
  * `!=` returns true if either operand has a known NaN predicate.
* Preserves the existing comparison behaviour when no NaN predicate is known.

This change only affects the `--ir-ieee` integer/real encoding path.

## Regression Test

Three new regression tests were added under `regression/ir-ra/`:

* `ra-sqrt-nan-ordered-comparisons`

  * Checks that ordered comparisons involving `sqrt(-1.0)` are false.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-sqrt-nan-equality-comparisons`

  * Checks that `s == s` is false and `s != s` is true when `s = sqrt(-1.0)`, exercising IEEE NaN non-reflexivity.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-sqrt-pos-sanity`

  * Checks that positive sqrt behavior remains unchanged.
  * Expected result: `VERIFICATION SUCCESSFUL`.

## Testing

Focused sqrt tests were run:

```bash
ctest -j$(nproc) -R "ra-sqrt" --timeout 60
```

Result:

```text
4/4 passed
```


## Notes

This PR does not implement full NaN support.

NaN-aware comparison behaviour is only applied when a NaN predicate is known for an operand, currently from negative `sqrt` results. This PR does not add full NaN propagation through arithmetic operations.