### PR TITLE
[python] V.3: build object-identity pointer casts in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -601,9 +601,18 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
         // ESBMC's object/offset pointer model decides identity. Casting both
         // to the integer handle instead would lose the distinct-object
         // guarantee and spuriously satisfy `a != b` for distinct instances.
+        // V.3: built in IREP2 — exact round-trip of the legacy
+        // gen_address_of + typecast_exprt (migrate's typecast defaults the
+        // same rounding-mode symbol the 2-arg typecast2tc uses).
         typet ptr_t = gen_pointer_type(ns.follow(struct_side.type()));
-        struct_side = typecast_exprt(gen_address_of(struct_side), ptr_t);
-        handle_side = typecast_exprt(handle_side, ptr_t);
+        const type2tc ptr_t2 = migrate_type(ptr_t);
+        expr2tc ss2;
+        migrate_expr(struct_side, ss2);
+        struct_side =
+          migrate_expr_back(typecast2tc(ptr_t2, address_of2tc(ss2->type, ss2)));
+        expr2tc hs2;
+        migrate_expr(handle_side, hs2);
+        handle_side = migrate_expr_back(typecast2tc(ptr_t2, hs2));
       }
     }
   }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

In `get_binary_operator_expr`'s object-identity path (None-able object *handle* vs by-value class instance, github #4796), build the two coercion casts in IREP2:

```cpp
// before
typet ptr_t = gen_pointer_type(ns.follow(struct_side.type()));
struct_side = typecast_exprt(gen_address_of(struct_side), ptr_t);
handle_side = typecast_exprt(handle_side, ptr_t);

// after
typet ptr_t = gen_pointer_type(ns.follow(struct_side.type()));
const type2tc ptr_t2 = migrate_type(ptr_t);
expr2tc ss2; migrate_expr(struct_side, ss2);
struct_side = migrate_expr_back(typecast2tc(ptr_t2, address_of2tc(ss2->type, ss2)));
expr2tc hs2; migrate_expr(handle_side, hs2);
handle_side = migrate_expr_back(typecast2tc(ptr_t2, hs2));
```

## Why it is behaviour-preserving

- `gen_address_of` is a plain `address_of` exprt with no simplification (`expr_util.cpp:254`), so `address_of2tc(ss2->type, ss2)` (which wraps the pointee type in `pointer_type2tc`) reproduces `migrate_expr(gen_address_of(struct_side))` exactly.
- `migrate`'s typecast handler defaults the rounding mode to `symbol2tc(get_int32_type(), "c:@__ESBMC_rounding_mode")` (`migrate.cpp:833-851`), and the 2-arg `typecast2tc` defaults the **same** symbol — and a plain `typecast_exprt` carries no rounding-mode sub-irep, so they match (the rounding mode is irrelevant for a pointer target anyway).
- `struct_side`/`handle_side` alias **different** of `lhs`/`rhs` (the block runs only when `lhs_handle != rhs_handle`), so reassigning one cannot disturb the other's migrate; each `migrate_expr` reads the operand before its reassignment.

The object/offset pointer-model identity the path relies on is structurally unchanged.

## Validation

- Precise oracle: `github_4796_object_handle_eq` → SUCCESSFUL, `github_4796_object_handle_eq_fail` → FAILED, `github_4116` (cyclic linked struct identity) → SUCCESSFUL.
- Python None/identity/object/class subset: all Bitwuzla-runnable tests pass (the only failures are a `--z3`-gated test pair and a pre-existing stale empty local dir).
- Build + clang-format clean.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
