### PR TITLE
[python] V.3: build cyclic-struct identity address-of in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -554,7 +554,13 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     };
     const irep_idt s_tag = class_tag(struct_side.type());
     if (!s_tag.empty() && s_tag == class_tag(ptr_side.type().subtype()))
-      struct_side = gen_address_of(struct_side);
+    {
+      // V.3: take the struct's address in IREP2 — exact round-trip of the
+      // legacy gen_address_of (a plain address_of of the struct value).
+      expr2tc ss2;
+      migrate_expr(struct_side, ss2);
+      struct_side = migrate_expr_back(address_of2tc(ss2->type, ss2));
+    }
   }
 
   // Python reference-identity when one operand is a by-value class instance and


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

In `get_binary_operator_expr`'s tag-matched reference-identity path — one operand a by-value class instance (`tag-X`), the other a pointer to the same class (`tag-X *`), as in `a.next.next == a` / `is a` on cyclic linked structures (github #4116) — take the struct's address in IREP2:

```cpp
// before
struct_side = gen_address_of(struct_side);
// after
expr2tc ss2;
migrate_expr(struct_side, ss2);
struct_side = migrate_expr_back(address_of2tc(ss2->type, ss2));
```

This is the sibling of the None-handle identity cast migrated in #5412 (same `address_of2tc(ss2->type, ss2)` round-trip pattern, different identity sub-path).

## Why it is behaviour-preserving

`gen_address_of` builds a plain `address_of` of the struct value with no simplification (`expr_util.cpp:254`), so `address_of2tc(ss2->type, ss2)` — which wraps the pointee type in `pointer_type2tc` — reproduces `migrate_expr(gen_address_of(struct_side))` exactly. `struct_side` here is a struct instance (the `class_tag` guard confirms `r.is_struct()`), so the `address_of2t` ctor's anti-double-wrap assert (`ptrobj != address_of/constant_int`) cannot trip. `migrate_expr` reads `struct_side` before its reassignment; single assignment, no aliasing.

## Validation

- Oracle: `github_4116` (`a.next.next == a` and `is a`) → SUCCESSFUL, `github_4116_fail` → FAILED — directly exercises this path.
- Python identity/class/reference subset (191 tests): all Bitwuzla-runnable tests pass (the only failures are a `--z3`-gated test pair and a pre-existing stale empty local dir).
- Build + clang-format clean.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
