### PR TITLE
[goto-convert] Add IREP2 remove_sideeffects dual-API seam (W1)

### DIFF
--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -57,6 +57,13 @@ protected:
     goto_programt &dest,
     bool result_is_used = true);
 
+  // IREP2 dual-API seam (W1, esbmc/esbmc#4715): delegates to the legacy
+  // exprt overload above; behaviour-identical by construction.
+  void remove_sideeffects(
+    expr2tc &expr,
+    goto_programt &dest,
+    bool result_is_used = true);
+
   void address_of_replace_objects(exprt &expr, goto_programt &dest);
 
   bool rewrite_vla_decl(typet &var_type, goto_programt &dest);

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -5,6 +5,7 @@
 #include <util/i2string.h>
 #include <util/message.h>
 #include <util/message/format.h>
+#include <util/migrate.h>
 #include <util/rename.h>
 #include <util/std_expr.h>
 
@@ -592,6 +593,23 @@ void goto_convertt::remove_sideeffects(
       abort();
     }
   }
+}
+
+// IREP2 dual-API seam (W1, esbmc/esbmc#4715): an expr2tc overload of
+// remove_sideeffects that delegates to the legacy exprt path — migrate to
+// legacy, run the unchanged legacy side-effect removal (which emits the hoisted
+// instructions into dest), then migrate the cleaned result back. Behaviour is
+// identical by construction. This is the dead-but-tested seam the future
+// IREP2-native goto-convert handlers call; the legacy body is ported to native
+// expr2tc in a later phase behind this same signature.
+void goto_convertt::remove_sideeffects(
+  expr2tc &expr,
+  goto_programt &dest,
+  bool result_is_used)
+{
+  exprt legacy = migrate_expr_back(expr);
+  remove_sideeffects(legacy, dest, result_is_used);
+  migrate_expr(legacy, expr);
 }
 
 void goto_convertt::remove_assignment(

--- a/unit/goto-programs/CMakeLists.txt
+++ b/unit/goto-programs/CMakeLists.txt
@@ -8,3 +8,4 @@ new_unit_test(interval-symex-guard-test "interval_symex_guard.test.cpp" "mode_ta
 new_unit_test(k-path-spanning-test "k_path_spanning.test.cpp" "gotoprograms;langapi")
 new_unit_test(rw-set-test "rw_set.test.cpp" "gotoprograms;pointeranalysis;solve")
 new_unit_test(exception-typeid-test "exception_typeid.test.cpp" "test_goto_factory;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(remove-sideeffects-irep2-test "remove_sideeffects_irep2.test.cpp" "test_goto_factory;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-programs/remove_sideeffects_irep2.test.cpp
+++ b/unit/goto-programs/remove_sideeffects_irep2.test.cpp
@@ -21,12 +21,15 @@ namespace
 // Expose the protected remove_sideeffects overloads for testing.
 struct test_convertt : public goto_convertt
 {
-  test_convertt(contextt &c, optionst &o) : goto_convertt(c, o) {}
+  test_convertt(contextt &c, optionst &o) : goto_convertt(c, o)
+  {
+  }
   using goto_convertt::remove_sideeffects;
 };
 
-const char *const SRC = "int f(void) { return 1; }\n"
-                        "int main(void) { return 0; }\n";
+const char *const SRC =
+  "int f(void) { return 1; }\n"
+  "int main(void) { return 0; }\n";
 
 optionst default_options()
 {
@@ -36,12 +39,13 @@ optionst default_options()
 } // namespace
 
 TEST_CASE(
-  "remove_sideeffects expr2tc overload leaves a side-effect-free expr unchanged",
+  "remove_sideeffects expr2tc overload leaves a side-effect-free expr "
+  "unchanged",
   "[goto-convert][irep2]")
 {
   std::string src = SRC;
-  program p = goto_factory::get_goto_functions(
-    src, goto_factory::Architecture::BIT_64);
+  program p =
+    goto_factory::get_goto_functions(src, goto_factory::Architecture::BIT_64);
   optionst opts = default_options();
   test_convertt conv(p.context, opts);
 
@@ -60,8 +64,8 @@ TEST_CASE(
   "[goto-convert][irep2]")
 {
   std::string src = SRC;
-  program p = goto_factory::get_goto_functions(
-    src, goto_factory::Architecture::BIT_64);
+  program p =
+    goto_factory::get_goto_functions(src, goto_factory::Architecture::BIT_64);
   const symbolt *f = p.context.find_symbol("c:@F@f");
   REQUIRE(f != nullptr);
 

--- a/unit/goto-programs/remove_sideeffects_irep2.test.cpp
+++ b/unit/goto-programs/remove_sideeffects_irep2.test.cpp
@@ -1,0 +1,82 @@
+/*******************************************************************
+ Module: goto_convertt::remove_sideeffects IREP2 dual-API seam (W1)
+
+ The expr2tc overload of remove_sideeffects delegates to the legacy
+ exprt path, so it must be behaviour-identical: a side-effect-free
+ expression is returned unchanged with no emitted instructions, and a
+ function-call side effect is hoisted into an instruction with the
+ expression replaced by its result symbol.
+\*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include "../testing-utils/goto_factory.h"
+#include <goto-programs/goto_convert_class.h>
+#include <util/migrate.h>
+#include <util/c_types.h>
+#include <irep2/irep2_utils.h>
+
+namespace
+{
+// Expose the protected remove_sideeffects overloads for testing.
+struct test_convertt : public goto_convertt
+{
+  test_convertt(contextt &c, optionst &o) : goto_convertt(c, o) {}
+  using goto_convertt::remove_sideeffects;
+};
+
+const char *const SRC = "int f(void) { return 1; }\n"
+                        "int main(void) { return 0; }\n";
+
+optionst default_options()
+{
+  cmdlinet cmd = goto_factory::get_default_cmdline("test.c");
+  return goto_factory::get_default_options(cmd);
+}
+} // namespace
+
+TEST_CASE(
+  "remove_sideeffects expr2tc overload leaves a side-effect-free expr unchanged",
+  "[goto-convert][irep2]")
+{
+  std::string src = SRC;
+  program p = goto_factory::get_goto_functions(
+    src, goto_factory::Architecture::BIT_64);
+  optionst opts = default_options();
+  test_convertt conv(p.context, opts);
+
+  expr2tc e = constant_int2tc(migrate_type(int_type()), BigInt(5));
+  const expr2tc original = e;
+
+  goto_programt dest;
+  conv.remove_sideeffects(e, dest);
+
+  REQUIRE(dest.instructions.empty());
+  REQUIRE(e == original);
+}
+
+TEST_CASE(
+  "remove_sideeffects expr2tc overload hoists a function-call side effect",
+  "[goto-convert][irep2]")
+{
+  std::string src = SRC;
+  program p = goto_factory::get_goto_functions(
+    src, goto_factory::Architecture::BIT_64);
+  const symbolt *f = p.context.find_symbol("c:@F@f");
+  REQUIRE(f != nullptr);
+
+  optionst opts = default_options();
+  test_convertt conv(p.context, opts);
+
+  expr2tc call = side_effect_function_call2tc(
+    migrate_type(int_type()), symbol_expr2tc(*f), std::vector<expr2tc>{});
+
+  goto_programt dest;
+  conv.remove_sideeffects(call, dest, /*result_is_used=*/true);
+
+  // The call is hoisted out into an instruction and the expression is replaced
+  // by its result symbol; no side effect remains.
+  REQUIRE_FALSE(dest.instructions.empty());
+  REQUIRE_FALSE(is_sideeffect2t(call));
+  REQUIRE(is_symbol2t(call));
+}


### PR DESCRIPTION
First concrete step of the **W1** phase of the IREP2 migration (esbmc/esbmc#4715) — the deeper `goto_convert` removal that follows the landed V.4 body round-trip.

## Background (scoping result)

After V.4.4b, every function body is round-tripped through IREP2 at `goto_convert` entry (`migrate_expr_back(get_value2())`) and then re-migrated per-instruction inside the `convert_*` handlers. Removing those round trips ("W1") is gated by a finding from scoping this work:

- `goto_convert`'s expression-cleaning / side-effect-hoisting subsystem (`remove_sideeffects`, `clean_expr`, the `remove_*` family, `goto_sideeffects.cpp` — ~1300 lines) is **100% legacy `exprt`**. The handlers migrate precisely to feed it.
- Cleaning must be **total** for the reducible C-expression side effects: `goto_symext::handle_sideeffect` (`symex_assign.cpp`) only handles allocation/nondet allkinds as ASSIGN RHSs and `assert(0)`s on anything else — so `function_call`/`++`/`--`/comma side effects have no symex handler and must be fully hoisted at `goto_convert`, regardless of representation.

So the W1 keystone is an **IREP2-native cleaning subsystem**, with the handler rewrites layered on top. This PR lands the first seam of that subsystem.

## What

A dead-but-tested `expr2tc` overload of `goto_convertt::remove_sideeffects` that delegates to the legacy `exprt` path:

```cpp
void goto_convertt::remove_sideeffects(expr2tc &expr, goto_programt &dest, bool result_is_used)
{
  exprt legacy = migrate_expr_back(expr);
  remove_sideeffects(legacy, dest, result_is_used);   // unchanged legacy path
  migrate_expr(legacy, expr);
}
```

It is **behaviour-identical by construction** and has **no pipeline callers** yet (V-track / dead-but-tested staging, as in V1 #4737 / Phase 4.2 #4997). Future IREP2-native handlers call this signature; the body is ported to native `expr2tc` in a later phase behind it.

## Tests

`unit/goto-programs/remove_sideeffects_irep2.test.cpp` (catch2): (a) a side-effect-free expr is returned unchanged with no emitted instructions; (b) a function-call side effect is hoisted into an instruction and replaced by its result symbol.

## Validation

- New unit test passes (6 assertions). Existing `goto-inline-test` green; core-C regression subset 229/229.
- **ESBMC behaviour-preservation check**: function-call / `++`/`--` / comma / short-circuit / malloc side-effect programs verify with correct verdicts and produce side-effect-free GOTO — i.e. the legacy cleaning path is unperturbed (the overload is dead).
- Build + clang-format clean.
