### PR TITLE
[python] Fix cmath.acos/acosh crash on pure-imaginary inputs

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -338,3 +338,49 @@ expectation — not an isolated point fix.
 no new isolated, soundly-fixable point fix is available on current `master` without the §5
 architectural work. The two Python-touching landings (`#5381`, `#5382`) do not intersect the
 open KNOWNBUG set. The §5 priority order stands.
+
+---
+
+## 10. 2026-06-19 re-validation & cmath inverse-trig crash fix
+
+Re-test against current `master` (tip `79c8b93eb0`), after the **17 commits** since §9's tip
+`74da7c0400` (notably `#5403` numpy float/complex literal folding, `#5407` np.copysign/fmax/fmin
+scalar-constant crash, `#5404` calloc zero-size, and the V.3 IREP2 frontend landings
+`#5391/#5392/#5401/#5402/#5406/#5408/#5412`). The §3 KNOWNBUG classification is unchanged —
+none of these commits touches a cmath inverse-trig path, and the cmath fix below lives entirely
+in the `caller == "cmath"` dispatch entry, so it cannot move any non-cmath KNOWNBUG.
+
+### 10a. New isolated, soundly-fixable defect found & fixed
+**`cmath.acos`/`cmath.acosh` crashed on pure-imaginary inputs (PR #5415).**
+
+`cmath.acos(0.5j)` and `cmath.acosh(0.5j)` aborted with
+`ERROR: function call: argument "…models/cmath.py@F@acos@z" type mismatch: got pointer,
+expected struct` (SIGABRT / core dump). The "cmath inverse functions" dispatch entry in
+`function_call/expr.cpp` matched only `asin`/`atan`/`asinh`/`atanh`, and `acos` was likewise
+absent from `python_math::is_unary_dispatch_function`. So `cmath.acos`/`cmath.acosh` matched no
+cmath/math handler and fell through to a generic call path that passed the complex literal as a
+**pointer** to the model function's by-value `struct` parameter — the same `got pointer, expected
+struct` argument-binding fault family seen in §8/§9's `depth_first_search`, but here from a
+missing dispatch case rather than the object/pointer-vs-value model.
+
+`acos`/`acosh` were excluded from the original fast path on purpose: that path returns
+`complex(0, ·)`, and their pure-imaginary result has a **nonzero** real part. But the exclusion
+left no correct route at all.
+
+**Fix:** add `acos`/`acosh` to the dispatch entry with their own closed-form pure-imaginary fast
+path, valid for **all** real `y` (guard is just `z.real == 0`):
+`acos(i*y) = (pi/2, -asinh(y))`, `acosh(i*y) = (asinh(|y|), copysign(pi/2, y))`. Every other
+input still routes to the `cmath.py` model unchanged. The fast path matches CPython bit-for-bit
+and is strictly more accurate than the model on the imaginary axis (the model returns `0`
+instead of `pi/2` for `acosh(0j)` and is 1 ULP off elsewhere). New regression pair
+`regression/python/cmath_inverse_pure_imag{,_fail}`; dual-solver Bitwuzla+Z3 agreement; all 133
+`python/(cmath|complex)` regression tests green; code-reviewed (0 critical/major/minor blocking).
+
+Unlike §6a/§7a, this fix **does** restore a working feature (acos/acosh on the imaginary axis now
+verify with exact values) rather than only converting a crash to a diagnostic — it is the §5-item-5
+robustness category, but with a sound value model rather than an "unsupported feature" stub.
+
+### 10b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
+on current `master` without the §5 architectural work; the §5 priority order stands.

--- a/regression/python/cmath_inverse_pure_imag/main.py
+++ b/regression/python/cmath_inverse_pure_imag/main.py
@@ -1,0 +1,21 @@
+import cmath
+
+# Regression for cmath.acos/cmath.acosh on pure-imaginary inputs, which used
+# to crash (the complex argument was passed as a pointer to the model's struct
+# parameter). On the imaginary axis they have an exact, closed-form result:
+#   acos(i*y)  = (pi/2, -asinh(y))
+#   acosh(i*y) = (asinh(|y|), copysign(pi/2, y))
+
+
+def acos_real() -> float:
+    z = cmath.acos(0.5j)
+    return z.real
+
+
+def acosh_imag() -> float:
+    z = cmath.acosh(0.5j)
+    return z.imag
+
+
+assert acos_real() == cmath.pi / 2.0
+assert acosh_imag() == cmath.pi / 2.0

--- a/regression/python/cmath_inverse_pure_imag/test.desc
+++ b/regression/python/cmath_inverse_pure_imag/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cmath_inverse_pure_imag_fail/main.py
+++ b/regression/python/cmath_inverse_pure_imag_fail/main.py
@@ -1,0 +1,11 @@
+import cmath
+
+# Negative variant: cmath.acos(0.5j).real is pi/2, not 1.0, so this must FAIL.
+
+
+def acos_real() -> float:
+    z = cmath.acos(0.5j)
+    return z.real
+
+
+assert acos_real() == 1.0

--- a/regression/python/cmath_inverse_pure_imag_fail/test.desc
+++ b/regression/python/cmath_inverse_pure_imag_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -2504,8 +2504,10 @@ function_call_expr::get_dispatch_table()
      },
      "cmath log/log10"},
 
-    // cmath inverse functions: use a fast path only on pure-imaginary inputs
-    // and delegate all other cases to the Python cmath model implementation.
+    // cmath inverse functions: on pure-imaginary inputs they have an exact
+    // closed form, so use a fast path there and delegate every other input to
+    // the Python cmath model. asin/atan/asinh/atanh are purely imaginary on
+    // the imaginary axis; acos/acosh keep a nonzero real part.
     {[this]() {
        if (!(call_.contains("func") && call_["func"].contains("_type") &&
              call_["func"]["_type"] == "Attribute"))
@@ -2516,7 +2518,7 @@ function_call_expr::get_dispatch_table()
        const std::string &func_name = function_id_.get_function();
        return (
          func_name == "asin" || func_name == "atan" || func_name == "asinh" ||
-         func_name == "atanh");
+         func_name == "atanh" || func_name == "acos" || func_name == "acosh");
      },
      [this]() -> exprt {
        const std::string &raw_func_name = function_id_.get_function();
@@ -2561,32 +2563,70 @@ function_call_expr::get_dispatch_table()
        model_call.type() = to_code_type(model_symbol->get_type()).return_type();
        model_call.location() = converter_.get_location_from_decl(call_);
 
+       python_math &math = converter_.get_math_handler();
        exprt zr = build_member(z, "real", double_type());
        exprt zi = build_member(z, "imag", double_type());
+       exprt zero = from_double(0.0, double_type());
+       exprt fast_guard = equality_exprt(zr, zero);
 
+       // acos(i*y) and acosh(i*y) have a nonzero real part, but a closed form
+       // valid for every real y, so their fast path covers all pure-imaginary
+       // inputs (zr == 0):
+       //   acos(i*y)  = (pi/2, -asinh(y))
+       //   acosh(i*y) = (asinh(|y|), copysign(pi/2, y))
+       if (func_name == "acos" || func_name == "acosh")
+       {
+         // pi/2 at double precision (CPython's exact value); the fast path is
+         // CPython-faithful and supersedes the model on the imaginary axis.
+         exprt half_pi = from_double(1.5707963267948966, double_type());
+         exprt fast_path;
+         if (func_name == "acos")
+         {
+           exprt asinh_zi = math.handle_asinh(zi, call_);
+           if (is_cpp_throw_expr(asinh_zi))
+             return asinh_zi;
+           exprt neg_asinh("unary-", double_type());
+           neg_asinh.copy_to_operands(asinh_zi);
+           fast_path = make_complex(half_pi, neg_asinh);
+         }
+         else
+         {
+           exprt abs_zi = math.handle_fabs(zi, call_);
+           if (is_cpp_throw_expr(abs_zi))
+             return abs_zi;
+           exprt real_part = math.handle_asinh(abs_zi, call_);
+           if (is_cpp_throw_expr(real_part))
+             return real_part;
+           exprt imag_part = math.handle_copysign(half_pi, zi, call_);
+           if (is_cpp_throw_expr(imag_part))
+             return imag_part;
+           fast_path = make_complex(real_part, imag_part);
+         }
+         return if_exprt(fast_guard, fast_path, model_call);
+       }
+
+       // asin/atan/asinh/atanh map the imaginary axis onto itself, so their
+       // fast path has a zero real part.
        exprt imag_result;
        if (func_name == "asin")
-         imag_result = converter_.get_math_handler().handle_asinh(zi, call_);
+         imag_result = math.handle_asinh(zi, call_);
        else if (func_name == "atan")
-         imag_result = converter_.get_math_handler().handle_atanh(zi, call_);
+         imag_result = math.handle_atanh(zi, call_);
        else if (func_name == "asinh")
-         imag_result = converter_.get_math_handler().handle_asin(zi, call_);
+         imag_result = math.handle_asin(zi, call_);
        else
-         imag_result = converter_.get_math_handler().handle_atan(zi, call_);
+         imag_result = math.handle_atan(zi, call_);
 
        if (is_cpp_throw_expr(imag_result))
          return imag_result;
 
-       exprt fast_path =
-         make_complex(from_double(0.0, double_type()), imag_result);
-       exprt zero = from_double(0.0, double_type());
-       exprt fast_guard = equality_exprt(zr, zero);
+       exprt fast_path = make_complex(zero, imag_result);
 
        // For atan(i*y) and asinh(i*y), the pure-imag shortcut only matches
        // the principal branch safely within the unit interval.
        if (func_name == "atan" || func_name == "asinh")
        {
-         exprt abs_zi = converter_.get_math_handler().handle_fabs(zi, call_);
+         exprt abs_zi = math.handle_fabs(zi, call_);
          if (is_cpp_throw_expr(abs_zi))
            return abs_zi;
 


### PR DESCRIPTION
## Problem

`cmath.acos(0.5j)` and `cmath.acosh(0.5j)` (pure-imaginary inputs) aborted with a core dump:

```
ERROR: function call: argument "...models/cmath.py@F@acos@z" type mismatch: got pointer, expected struct
```

## Root cause

The *cmath inverse functions* dispatch entry in `function_call/expr.cpp` matched only `asin`/`atan`/`asinh`/`atanh`, and `acos` was also absent from `python_math::is_unary_dispatch_function`. As a result `cmath.acos`/`cmath.acosh` matched no cmath/math handler and fell through to a generic call path that passed the complex literal as a *pointer* to the model function's by-value `struct` parameter — a symex argument-binding mismatch that crashes.

`acos`/`acosh` were excluded from the original fast path on purpose, because that path returns `complex(0, ·)` and their pure-imaginary result has a *nonzero* real part. But excluding them left no correct route at all.

## Fix

Add `acos`/`acosh` to the dispatch entry and give them their own closed-form pure-imaginary fast path, valid for **all** real `y` (so the only guard is `z.real == 0`):

```
acos(i*y)  = (pi/2, -asinh(y))
acosh(i*y) = (asinh(|y|), copysign(pi/2, y))
```

Every non-pure-imaginary input still routes to the `cmath.py` operational model via `model_call`, unchanged. The fast path matches CPython bit-for-bit and is strictly more accurate than the model on the imaginary axis (the model returns `0` instead of `pi/2` for `acosh(0j)` and is 1 ULP off elsewhere). The sibling `asin`/`atan`/`asinh`/`atanh` paths are unchanged (only a mechanical `get_math_handler()` alias rename).

## Tests

New regression pair (CORE):
- `regression/python/cmath_inverse_pure_imag` — `acos(0.5j).real == pi/2` and `acosh(0.5j).imag == pi/2` → SUCCESSFUL
- `regression/python/cmath_inverse_pure_imag_fail` — `acos(0.5j).real == 1.0` → FAILED

Dual-solver agreement (Bitwuzla + Z3). All 133 `python/(cmath|complex)` regression tests pass; no sibling regressions.