### PR TITLE
[goto-convert] Native fast path for IREP2 remove_sideeffects (W1)

### DIFF
--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -74,6 +74,9 @@ protected:
     goto_programt &dest);
 
   bool has_sideeffect(const exprt &expr);
+  // IREP2 overload (W1, esbmc/esbmc#4715): native recursive scan for a
+  // sideeffect2t node, mirroring the legacy exprt overload above.
+  bool has_sideeffect(const expr2tc &expr);
 
   // Used by remove_sideeffects() to process a quantifier body expression.
   // Recursively walks || and && sub-expressions without converting them to

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -150,6 +150,25 @@ bool goto_convertt::has_sideeffect(const exprt &expr)
   return false;
 }
 
+bool goto_convertt::has_sideeffect(const expr2tc &expr)
+{
+  if (is_nil_expr(expr))
+    return false;
+
+  // A legacy "sideeffect" exprt migrates to sideeffect2t (function_call, malloc,
+  // ++/--, …) OR sideeffect_assign2t (assignment / compound-assignment used as
+  // an expression); the legacy has_sideeffect treats both as side effects.
+  if (is_sideeffect2t(expr) || is_sideeffect_assign2t(expr))
+    return true;
+
+  bool found = false;
+  expr->foreach_operand([this, &found](const expr2tc &op) {
+    if (!found && has_sideeffect(op))
+      found = true;
+  });
+  return found;
+}
+
 void goto_convertt::remove_sideeffects(
   exprt &expr,
   goto_programt &dest,
@@ -596,17 +615,23 @@ void goto_convertt::remove_sideeffects(
 }
 
 // IREP2 dual-API seam (W1, esbmc/esbmc#4715): an expr2tc overload of
-// remove_sideeffects that delegates to the legacy exprt path — migrate to
-// legacy, run the unchanged legacy side-effect removal (which emits the hoisted
-// instructions into dest), then migrate the cleaned result back. Behaviour is
-// identical by construction. This is the dead-but-tested seam the future
-// IREP2-native goto-convert handlers call; the legacy body is ported to native
-// expr2tc in a later phase behind this same signature.
+// remove_sideeffects. The side-effect-free common case is handled natively (no
+// migration round-trip — mirroring the first line of the legacy overload). A
+// side-effect-bearing or ternary expression is delegated to the legacy exprt
+// path for now (migrate out, run the unchanged legacy removal, migrate back),
+// which is behaviour-identical by construction; the per-kind hoisting is ported
+// to native expr2tc in a later phase behind this same signature.
 void goto_convertt::remove_sideeffects(
   expr2tc &expr,
   goto_programt &dest,
   bool result_is_used)
 {
+  // Native fast path: nil, or a side-effect-free non-ternary expression, needs
+  // no hoisting. The legacy overload always enters for a ternary (if2t) so that
+  // --validate-violation-witness can lower it; preserve that by delegating.
+  if (is_nil_expr(expr) || (!has_sideeffect(expr) && !is_if2t(expr)))
+    return;
+
   exprt legacy = migrate_expr_back(expr);
   remove_sideeffects(legacy, dest, result_is_used);
   migrate_expr(legacy, expr);

--- a/unit/goto-programs/remove_sideeffects_irep2.test.cpp
+++ b/unit/goto-programs/remove_sideeffects_irep2.test.cpp
@@ -103,8 +103,8 @@ TEST_CASE(
   // 1 + f(): the side effect is nested under an add, so the native
   // has_sideeffect scan must recurse into the operand to find it.
   type2tc int_t = migrate_type(int_type());
-  expr2tc call =
-    side_effect_function_call2tc(int_t, symbol_expr2tc(*f), std::vector<expr2tc>{});
+  expr2tc call = side_effect_function_call2tc(
+    int_t, symbol_expr2tc(*f), std::vector<expr2tc>{});
   expr2tc nested = add2tc(int_t, constant_int2tc(int_t, BigInt(1)), call);
 
   goto_programt dest;
@@ -140,6 +140,6 @@ TEST_CASE(
     locationt());
 
   REQUIRE(conv.has_sideeffect(assign));
-  REQUIRE(
-    conv.has_sideeffect(add2tc(int_t, constant_int2tc(int_t, BigInt(2)), assign)));
+  REQUIRE(conv.has_sideeffect(
+    add2tc(int_t, constant_int2tc(int_t, BigInt(2)), assign)));
 }

--- a/unit/goto-programs/remove_sideeffects_irep2.test.cpp
+++ b/unit/goto-programs/remove_sideeffects_irep2.test.cpp
@@ -24,6 +24,7 @@ struct test_convertt : public goto_convertt
   test_convertt(contextt &c, optionst &o) : goto_convertt(c, o)
   {
   }
+  using goto_convertt::has_sideeffect;
   using goto_convertt::remove_sideeffects;
 };
 
@@ -83,4 +84,62 @@ TEST_CASE(
   REQUIRE_FALSE(dest.instructions.empty());
   REQUIRE_FALSE(is_sideeffect2t(call));
   REQUIRE(is_symbol2t(call));
+}
+
+TEST_CASE(
+  "remove_sideeffects expr2tc overload hoists a side effect nested in an "
+  "expression",
+  "[goto-convert][irep2]")
+{
+  std::string src = SRC;
+  program p =
+    goto_factory::get_goto_functions(src, goto_factory::Architecture::BIT_64);
+  const symbolt *f = p.context.find_symbol("c:@F@f");
+  REQUIRE(f != nullptr);
+
+  optionst opts = default_options();
+  test_convertt conv(p.context, opts);
+
+  // 1 + f(): the side effect is nested under an add, so the native
+  // has_sideeffect scan must recurse into the operand to find it.
+  type2tc int_t = migrate_type(int_type());
+  expr2tc call =
+    side_effect_function_call2tc(int_t, symbol_expr2tc(*f), std::vector<expr2tc>{});
+  expr2tc nested = add2tc(int_t, constant_int2tc(int_t, BigInt(1)), call);
+
+  goto_programt dest;
+  conv.remove_sideeffects(nested, dest, /*result_is_used=*/true);
+
+  // The nested call is hoisted; the add survives with its second operand
+  // replaced by the result symbol, leaving no side effect.
+  REQUIRE_FALSE(dest.instructions.empty());
+  REQUIRE(is_add2t(nested));
+  REQUIRE_FALSE(is_sideeffect2t(to_add2t(nested).side_2));
+  REQUIRE(is_symbol2t(to_add2t(nested).side_2));
+}
+
+TEST_CASE(
+  "has_sideeffect detects a sideeffect_assign2t (assignment side effect)",
+  "[goto-convert][irep2]")
+{
+  std::string src = SRC;
+  program p =
+    goto_factory::get_goto_functions(src, goto_factory::Architecture::BIT_64);
+  optionst opts = default_options();
+  test_convertt conv(p.context, opts);
+
+  // A legacy "assign" sideeffect migrates to sideeffect_assign2t, a distinct
+  // kind from sideeffect2t; has_sideeffect must treat it as a side effect both
+  // at the top level and nested under another expression.
+  type2tc int_t = migrate_type(int_type());
+  expr2tc assign = sideeffect_assign2tc(
+    int_t,
+    irep_idt("assign"),
+    symbol2tc(int_t, "x"),
+    constant_int2tc(int_t, BigInt(1)),
+    locationt());
+
+  REQUIRE(conv.has_sideeffect(assign));
+  REQUIRE(
+    conv.has_sideeffect(add2tc(int_t, constant_int2tc(int_t, BigInt(2)), assign)));
 }


### PR DESCRIPTION
**Stacked on #5414** (the W1.1 dual-API seam) — base is `feat/irep2-w1-remove-sideeffects-seam`, so this diff shows only the W1.2 delta. When #5414 merges, GitHub retargets this to `master`.

Second step of the **W1** phase of the IREP2 migration (esbmc/esbmc#4715): the first *native* logic of the IREP2 cleaning port.

## What

1. A native `bool goto_convertt::has_sideeffect(const expr2tc &expr)` — a recursive scan mirroring the legacy `has_sideeffect(const exprt&)`. It treats both IREP2 kinds a legacy `"sideeffect"` node migrates to as side effects: `sideeffect2t` (function call, malloc, `++`/`--`, …) **and** `sideeffect_assign2t` (assignment / compound-assignment used as an expression).
2. `remove_sideeffects(expr2tc&)` gains a native fast path: a nil or side-effect-free non-ternary expression returns immediately, **without** the `migrate_expr_back` → legacy → `migrate_expr` round-trip. Side-effect-bearing or ternary expressions still delegate to the unchanged legacy path (the ternary always delegates, preserving the `--validate-violation-witness` lowering).

The overload remains **dead** (no pipeline callers); the legacy `has_sideeffect`/`remove_sideeffects` paths are untouched, so the pipeline is unaffected. This is staged so the eventual W1.3 wiring is low-risk.

## Why correct

- `has_sideeffect(expr2tc)` mirrors the legacy node-id-or-any-operand scan, using `foreach_operand` (which visits all sub-`expr2tc` fields). The fast-path condition `is_nil_expr(expr) || (!has_sideeffect(expr) && !is_if2t(expr))` is the De Morgan equivalent of the legacy `if (!has_sideeffect(expr) && expr.id() != "if") return;` plus nil handling.
- The `sideeffect_assign2t` arm was added after code review flagged that the legacy mapping (`migrate.cpp`: `"assign"`/`"assign+"`/… → `sideeffect_assign2t`) is a distinct kind from `sideeffect2t` — without it the native scan would under-report assignment side effects once wired.

## Tests

Two new cases added (4 total): a side effect nested under an `add` (exercises the recursion) and direct `has_sideeffect` detection of a top-level and nested `sideeffect_assign2t` (pins the review fix — fails without it).

## Validation

- Unit test: 13 assertions, 4 cases, all pass. `goto-inline-test` green.
- ESBMC smoke: side-effect program (`f()+g()`, `(x++)+(++x)`) verifies SUCCESSFUL with side-effect-free GOTO — the legacy path is unperturbed.
- Build + clang-format clean. Code-reviewed (the one Major finding — the `sideeffect_assign2t` gap — is fixed here).
