### PR TITLE
[python] V.3: build tuple.count() sum expression in IREP2

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -1519,19 +1519,24 @@ exprt function_call_expr::handle_tuple_method() const
 
   if (method_name == "count")
   {
-    // sum(t.element_i == elem ? 1 : 0)
-    typet result_type = int_type();
-    exprt total = gen_zero(result_type);
+    // sum(t.element_i == elem ? 1 : 0), built in IREP2 (V.3).
+    const type2tc result_type = migrate_type(int_type());
+    expr2tc elem2;
+    migrate_expr(elem, elem2);
+    expr2tc total = gen_zero(result_type);
     for (const auto &comp : components)
     {
-      exprt member = build_member(receiver, comp.get_name(), comp.type());
-      exprt eq = equality_exprt(member, elem);
-      if_exprt sel(eq, gen_one(result_type), gen_zero(result_type));
-      sel.type() = result_type;
-      total = plus_exprt(total, sel);
-      total.type() = result_type;
+      expr2tc member2;
+      migrate_expr(
+        build_member(receiver, comp.get_name(), comp.type()), member2);
+      expr2tc sel = if2tc(
+        result_type,
+        equality2tc(member2, elem2),
+        gen_one(result_type),
+        gen_zero(result_type));
+      total = add2tc(result_type, total, sel);
     }
-    return total;
+    return migrate_expr_back(total);
   }
 
   // method_name == "index"


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam.

## What

`function_call_expr::handle_tuple_method`'s `count` branch lowers `tuple.count(elem)` to `sum over components of (component == elem ? 1 : 0)`. This builds that subtree in IREP2:

```cpp
// before (per component)
exprt member = build_member(receiver, comp.get_name(), comp.type());
exprt eq = equality_exprt(member, elem);
if_exprt sel(eq, gen_one(result_type), gen_zero(result_type));
sel.type() = result_type;
total = plus_exprt(total, sel);
total.type() = result_type;
// ... return total;

// after
expr2tc member2; migrate_expr(build_member(...), member2);
expr2tc sel = if2tc(result_type, equality2tc(member2, elem2),
                    gen_one(result_type), gen_zero(result_type));
total = add2tc(result_type, total, sel);
// ... return migrate_expr_back(total);
```

`elem` is migrated once (loop-invariant); `result_type` is `migrate_type(int_type())`.

## Why it is behaviour-preserving

The count type is **int** throughout, so each factory is the exact migrate of the legacy builder it replaces:
- `plus_exprt` (id `+`) migrates **unconditionally** to `add2tc` (no `ieee_*` dispatch — that needs the literal `ieee_add` id); operands are int regardless.
- `equality_exprt` (id `=`) → `equality2tc` (bool result, not an arithmetic op).
- `if_exprt` with `.type()=int` → `if2tc(int, …)`; `gen_zero/gen_one(int)` → the `type2tc` siblings.
- Accumulation stays left-associative (`total = add2tc(total, sel)`).

Migrating each `member` immediately drops the cosmetic `#cpp_type` hint earlier than the legacy path, but it is **unobservable**: the member is consumed only as an `equality2tc` operand (bool result), nothing re-walks it before goto-convert (which drops `#cpp_type` for both paths), and the count result is plain int. Confirmed in review.

## Validation

- Oracle `github_4348` (`t.count(1)`/`count(2)`/`count(99)` over ints **and** `b.count(True)` over bools) → SUCCESSFUL.
- Python tuple/count subset: **119 tests, 100% pass, 0 failures**.
- Build + clang-format clean.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
