### PR TITLE
[symex] Fix missed memtrack leak in --no-reachable-memory-leak (#5400)

### DIFF
--- a/regression/esbmc/github_5400/main.c
+++ b/regression/esbmc/github_5400/main.c
@@ -1,0 +1,50 @@
+// Regression for issue #5400: under --no-reachable-memory-leak (SV-COMP
+// valid-memtrack), a node inserted into two lists via a reused pointer orphans
+// a previously-linked node. ESBMC used to report VERIFICATION SUCCESSFUL
+// (unsound, missed leak) because the global-reachability fixpoint dropped a
+// target's guard, treating the orphaned node as unconditionally reachable.
+#include <stdlib.h>
+extern int __VERIFIER_nondet_int();
+
+struct s
+{
+  int datum;
+  struct s *next;
+};
+
+struct s *mk(int x)
+{
+  struct s *p = malloc(sizeof(struct s));
+  p->datum = x;
+  p->next = 0;
+  return p;
+}
+
+void list_add(struct s *node, struct s *list)
+{
+  struct s *t = list->next;
+  list->next = node;
+  node->next = t;
+}
+
+struct s *slot[3];
+
+int main()
+{
+  for (int i = 0; i < 3; i++)
+  {
+    slot[i] = mk(1);
+    list_add(mk(2), slot[i]);
+  }
+
+  int j = __VERIFIER_nondet_int(), k = __VERIFIER_nondet_int();
+  if (!(0 <= j && j < 3))
+    return 0;
+  if (!(0 <= k && k < 3))
+    return 0;
+
+  struct s *p = mk(3);
+  list_add(p, slot[j]);
+  list_add(p, slot[k]); // reuse p across two lists -> orphans a node when j != k
+  return 0;
+}

--- a/regression/esbmc/github_5400/test.desc
+++ b/regression/esbmc/github_5400/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --force-malloc-success --unwind 6
+^VERIFICATION FAILED$
+^.*forgotten memory.*$

--- a/regression/esbmc/github_5400_reachable/main.c
+++ b/regression/esbmc/github_5400_reachable/main.c
@@ -1,0 +1,48 @@
+// Companion to github_5400: a node inserted into a single list (chosen by a
+// non-deterministic index) keeps every allocation reachable from the global
+// `slot[]`, so there is no leak. The global-reachability fixpoint must merge
+// the inserted node's incoming path conditions across all candidate list
+// heads; expanding it under only one path made its guard false on the other
+// executions and produced a spurious "forgotten memory" leak. This pins the
+// VERIFICATION SUCCESSFUL verdict (no false positive).
+#include <stdlib.h>
+extern int __VERIFIER_nondet_int();
+
+struct s
+{
+  int datum;
+  struct s *next;
+};
+
+struct s *mk(int x)
+{
+  struct s *p = malloc(sizeof(struct s));
+  p->datum = x;
+  p->next = 0;
+  return p;
+}
+
+void list_add(struct s *node, struct s *list)
+{
+  struct s *t = list->next;
+  list->next = node;
+  node->next = t;
+}
+
+struct s *slot[3];
+
+int main()
+{
+  int j = __VERIFIER_nondet_int();
+  if (!(0 <= j && j < 3))
+    return 0;
+
+  for (int i = 0; i < 3; i++)
+  {
+    slot[i] = mk(1);
+    list_add(mk(2), slot[i]);
+  }
+
+  list_add(mk(3), slot[j]); // fresh node into list j; everything stays reachable
+  return 0;
+}

--- a/regression/esbmc/github_5400_reachable/test.desc
+++ b/regression/esbmc/github_5400_reachable/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --force-malloc-success --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -1346,14 +1346,42 @@ void goto_symext::add_memory_leak_checks()
     for (int i = 0; !globals.empty(); i++)
     {
       std::vector<std::pair<expr2tc, std::list<value_sett::entryt>>> tmp;
+      /* A symbol can be reached at this frontier level through several pointers
+       * with different preconditions (e.g. a node inserted into a list chosen
+       * by a non-deterministic index is, in the value-set, reachable from every
+       * list head). Merge those entries by symbol, OR-ing their path conditions,
+       * before expanding each symbol once. Expanding under only the first
+       * incoming path — as the old per-symbol 'visited' cull did — gives the
+       * symbol's outgoing edges a guard that is false on the executions taking
+       * the other paths, under-approximating reachability and producing spurious
+       * "forgotten memory" leaks (#2335). The single expansion per symbol keeps
+       * termination on circular data structures. */
+      std::unordered_map<std::string, std::pair<expr2tc, value_sett::entryt>>
+        merged;
+      std::vector<std::string> order;
       for (const auto &[path_to_e, g] : globals)
         for (const value_sett::entryt &e : g)
         {
-          /* Skip if already visited
-           *
-           * TODO: this is possibly wrongly culling paths that have different
-           *       preconditions; should take path_to_e into account. */
-          if (!visited.emplace(e.identifier + e.suffix).second)
+          std::string key = e.identifier + e.suffix;
+          auto [mit, ins] = merged.emplace(key, std::make_pair(path_to_e, e));
+          if (ins)
+            order.push_back(std::move(key));
+          else
+          {
+            /* An empty path stands for 'true' and absorbs everything. */
+            expr2tc &p = mit->second.first;
+            if (p)
+              p = path_to_e ? or2tc(p, path_to_e) : path_to_e;
+          }
+        }
+
+      for (const std::string &key : order)
+      {
+        const auto &[path_to_e, e] = merged.at(key);
+        {
+          /* Each globally reachable symbol is expanded only once, even for
+           * circular data structures. */
+          if (!visited.emplace(key).second)
             continue;
 
           /* Unfortunately, we just have the symbol id and a suffix that's only
@@ -1586,6 +1614,7 @@ void goto_symext::add_memory_leak_checks()
             tmp.emplace_back(is_e, std::move(root_points_to));
           }
         }
+      }
       globals = std::move(tmp);
     }
 
@@ -1605,20 +1634,24 @@ void goto_symext::add_memory_leak_checks()
       // Iterate over each (expression, condition) pair in tgts
       for (const auto &[e, g] : tgts)
       {
-        /* XXX: 'obj' is the address of a statically known dynamic object,
-           *      couldn't we just statically check whether the symbol 'e'
-           *      addresses is the same as 'obj' directly?
-           *
-           * Explanation:
-           * - 'g' acts as a guard condition, determining whether 'e' should be considered.
-           * - 'same_object2tc(obj, e)' checks if 'obj' and 'e' refer to the same object.
-           * - If 'g' is an AND condition (is_and2t) or already a same-object check (is_same_object2t),
-           *   then 'g' is combined with 'same_object2tc(obj, e)'.
-           * - Otherwise, we directly use 'same_object2tc(obj, e)'.
-           */
-        expr2tc same = (is_and2t(g) || is_same_object2t(g))
-                         ? and2tc(g, same_object2tc(obj, e))
-                         : same_object2tc(obj, e);
+        /* 'obj' is the address of a statically known dynamic object; 'e' is
+         * the address of an object found reachable from a global, and 'g' is
+         * the condition under which 'e' is actually reachable. The object is
+         * globally reachable here iff some reachable 'e' is the same object as
+         * 'obj', i.e. the contribution of this target is g ∧ same_object(obj,e).
+         *
+         * The guard 'g' must ALWAYS be conjoined. Dropping it (as was done for
+         * guards that are neither an and2t nor a bare same_object2t, e.g. the
+         * or2t built when an object is reachable via more than one path) makes
+         * same_object(obj,e) unconditional. Since 'obj' itself appears among
+         * the targets, same_object(obj,obj) is trivially true, so 'targeted'
+         * collapses to true and the object's leak claim becomes vacuous — a
+         * missed leak (false VERIFICATION SUCCESSFUL) for memory that is in
+         * fact orphaned on some path. See issue #5400.
+         *
+         * 'g' is non-null by construction: every entry recorded in 'tgts' above
+         * carries the non-null reachability condition 'is_e'. */
+        expr2tc same = and2tc(g, same_object2tc(obj, e));
         is_any = is_any ? or2tc(is_any, same) : same;
       }
       return is_any ? is_any : gen_false_expr();


### PR DESCRIPTION
## Problem

ESBMC reported a false `VERIFICATION SUCCESSFUL` (a *missed* memory leak) on the SV-COMP `valid-memtrack` benchmark `c/goblint-regression/09-regions_12-arraycollapse_rc.c`, whose ground truth is `false`. The issue title attributed it to k-induction and concurrency, but **both are red herrings** — the miss is purely in the `--no-reachable-memory-leak` (valid-memtrack) reachability computation and reproduces sequentially under plain BMC.

## Root cause

`goto_symext::add_memory_leak_checks()` computes which dynamic objects are reachable from global symbols and excludes them from the leak check (`when = alloc_guard ∧ ¬targeted`; the claim is `when ⇒ deallocated`). For soundness, `targeted` must **under-approximate** reachability — it may flag a reachable object (a false positive) but must never mark an orphaned object as reachable (a missed leak). Two defects made it over-approximate:

1. **`maybe_global_target` dropped the reachability guard `g`** for any guard that was not an `and2t` or a bare `same_object2t` — notably the `or2t` produced when an object is reachable via more than one path. With `g` dropped, `same_object(obj, e)` becomes unconditional; since the object's own address appears among the targets, `same_object(obj, obj)` is trivially true, so `targeted` collapses to `true` and the leak claim becomes vacuous.

2. **The per-symbol `visited` cull expanded each symbol under only its first incoming path**, discarding the others. A node inserted into a list chosen by a non-deterministic index is, in the value-set, reachable from every list head; expanding it under one head's path gives its outgoing edges a guard that is false on the executions taking the other paths.

Defect 1 caused the #5400 missed leak. Defect 2 surfaced once defect 1 was fixed: it under-approximated reachability and produced a spurious "forgotten memory" false positive on the no-leak sibling `github_2335_1`.

## Fix

- **Always conjoin `g`:** `same = and2tc(g, same_object2tc(obj, e))`. (`g` is non-null by construction.)
- **Merge a frontier level's entries by symbol**, OR-ing their path conditions, before the single expansion.

Both keep `targeted` a sound under-approximation of reachability. The single expansion per symbol (via the unchanged global `visited` set) preserves termination on circular data structures.

## Tests

New regression pair (CORE):
- `regression/esbmc/github_5400` — orphaned-node leak (a node reused across two lists) → `FAILED` with `forgotten memory`.
- `regression/esbmc/github_5400_reachable` — multi-path-reachable node (no leak) → `SUCCESSFUL`, pinning the absence of the false positive.

Validation: the original benchmark now reports `VERIFICATION FAILED`; dual-solver Bitwuzla + Z3 agreement; the full `--no-reachable-memory-leak` + memory-leak regression family (incl. the `09-regions` sibling and `github_2335_1`) passes with no verdict regressions; the change is confined to the `no_reachable_memleak` path (classic leak check untouched).

Fixes #5400