### PR TITLE
[python] V.3: build tuple.index() match/select chain in IREP2

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -1544,16 +1544,18 @@ exprt function_call_expr::handle_tuple_method() const
   if (components.empty())
     throw std::runtime_error("tuple.index() on empty tuple");
 
-  // Build "any matched" guard so we can assert the element is present.
-  typet result_type = int_type();
-  exprt any_match = gen_boolean(false);
+  // Build "any matched" guard so we can assert the element is present (V.3).
+  const type2tc result_type = migrate_type(int_type());
+  expr2tc elem2;
+  migrate_expr(elem, elem2);
+  expr2tc any_match = gen_false_expr();
   for (const auto &comp : components)
   {
-    exprt member = build_member(receiver, comp.get_name(), comp.type());
-    exprt eq = equality_exprt(member, elem);
-    any_match = or_exprt(any_match, eq);
+    expr2tc member2;
+    migrate_expr(build_member(receiver, comp.get_name(), comp.type()), member2);
+    any_match = or2tc(any_match, equality2tc(member2, elem2));
   }
-  code_assertt found_assert(any_match);
+  code_assertt found_assert(migrate_expr_back(any_match));
   found_assert.location() = converter_.get_location_from_decl(call_);
   found_assert.location().comment("ValueError: tuple.index(x): x not in tuple");
   converter_.add_instruction(found_assert);
@@ -1561,17 +1563,20 @@ exprt function_call_expr::handle_tuple_method() const
   // Build chain right-to-left: result_(n-1) is index n-1, falling back to
   // earlier matches as we walk backwards. Net effect: leftmost match wins.
   size_t n = components.size();
-  exprt result = from_integer(BigInt(n - 1), result_type);
+  expr2tc result = from_integer(BigInt(n - 1), result_type);
   for (size_t k = n - 1; k-- > 0;)
   {
-    exprt member =
-      build_member(receiver, components[k].get_name(), components[k].type());
-    exprt eq = equality_exprt(member, elem);
-    if_exprt sel(eq, from_integer(BigInt(k), result_type), result);
-    sel.type() = result_type;
-    result = sel;
+    expr2tc member2;
+    migrate_expr(
+      build_member(receiver, components[k].get_name(), components[k].type()),
+      member2);
+    result = if2tc(
+      result_type,
+      equality2tc(member2, elem2),
+      from_integer(BigInt(k), result_type),
+      result);
   }
-  return result;
+  return migrate_expr_back(result);
 }
 
 bool function_call_expr::is_dict_method_call() const


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flipping Python-frontend converter expression construction from legacy `exprt` builders to typed IREP2 `expr2tc` factories, lowered with `migrate_expr_back` at the seam. Sibling of #5418 (the `count` branch of the same function).

## What

`function_call_expr::handle_tuple_method`'s `index` branch lowers `tuple.index(elem)` to a presence-assert plus a right-to-left `if`-chain selecting the leftmost matching component index. This builds both in IREP2:

- **Presence guard:** `gen_boolean(false)` + `or_exprt`/`equality_exprt` → `gen_false_expr()` + `or2tc`/`equality2tc`. The guard is back-migrated for the `code_assertt` (a statement — stays legacy at the body seam).
- **Index-select chain:** `if_exprt(eq, from_integer(k), result)` + `equality_exprt` → `if2tc(int, equality2tc(...), from_integer(k, int2), result)`.

`elem` is migrated once (loop-invariant); `result_type` is `migrate_type(int_type())`.

## Why it is behaviour-preserving

The index/result type is **int** and the guard is **bool**, so each factory is the exact migrate of the legacy builder:
- `gen_boolean(false)` → `gen_false_expr()` (constant bool false); `or_exprt` (id `or`) → `or2tc`; `equality_exprt` (id `=`) → `equality2tc`.
- `if_exprt` with `.type()=int` → `if2tc(int, …)`; `from_integer(BigInt, typet)` → the `type2tc` overload.
- The right-to-left accumulation (`result = if2tc(eq, k, result)`) and the left-folded `or` chain are preserved; the assert's back-migrated guard equals the legacy one.
- Migrating each member early drops the cosmetic `#cpp_type` hint, but it is unobservable — the member is consumed only as an `equality2tc` operand (same reasoning as #5418, confirmed in that review).

## Validation

- Oracle `github_4348` (`u.index(10)`/`index(20)`/`index(30)` over ints **and** `b.index(False)` over bools) → SUCCESSFUL.
- Python tuple/index/count subset: **180 tests, 100% pass, 0 failures**.
- Build + clang-format clean.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
