### PR TITLE
[contracts] Fix spurious SAME-OBJECT on return_value in ensures (#5043)

### DIFF
--- a/regression/function_contract/github_5043_retval_same_object_fail/main.c
+++ b/regression/function_contract/github_5043_retval_same_object_fail/main.c
@@ -1,0 +1,12 @@
+// Companion to github_5043_retval_same_object_pass: the ensures relational
+// comparison on __ESBMC_return_value must still be genuinely enforced. Here the
+// function returns p + 4, so (return_value <= p) is false and the contract is
+// violated. This confirms the fix removes only the spurious safety check from
+// the original body and does not weaken real ensures enforcement in the wrapper
+// (return_value is correctly bound to the returned value, p + 4).
+char *f(char *p)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(p, 8));
+  __ESBMC_ensures((char *)__ESBMC_return_value <= (char *)p);
+  return p + 4;
+}

--- a/regression/function_contract/github_5043_retval_same_object_fail/test.desc
+++ b/regression/function_contract/github_5043_retval_same_object_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_5043_retval_same_object_pass/main.c
+++ b/regression/function_contract/github_5043_retval_same_object_pass/main.c
@@ -1,0 +1,12 @@
+// Regression for #5043: a relational comparison on __ESBMC_return_value in an
+// ensures clause must not spuriously fail the auto-generated SAME-OBJECT check.
+// The function returns p, so return_value and p are the same object and
+// (return_value <= p + 8) is well-defined and true. Before the fix, the
+// ensures' SAME-OBJECT safety check was left in the original function body
+// referencing an unbound return_value, producing a spurious violation.
+char *f(char *p)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(p, 8));
+  __ESBMC_ensures((char *)__ESBMC_return_value <= (char *)p + 8);
+  return p;
+}

--- a/regression/function_contract/github_5043_retval_same_object_pass/test.desc
+++ b/regression/function_contract/github_5043_retval_same_object_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -844,6 +844,25 @@ void code_contractst::enforce_contracts(
           if (comment == "contract::ensures" || comment == "contract::requires")
           {
             instructions_to_remove.insert(it);
+
+            // The GOTO pointer/arithmetic-safety pass emits auto-generated
+            // ASSERTs (e.g. SAME-OBJECT for a pointer comparison) from the
+            // clause expression, immediately preceding this ASSUME. They are
+            // ASSERTs, not ASSUMEs, so the comment scan misses them; for an
+            // ensures clause they reference __ESBMC_return_value, which is
+            // unbound in the original body, yielding a spurious violation
+            // (#5043). The wrapper re-checks the clause with return_value
+            // properly bound, so drop the contiguous run of safety asserts
+            // belonging to this clause. Contract clauses precede the function
+            // body, so a real body assertion never sits directly before a
+            // clause ASSUME; walking back over asserts cannot reach body code.
+            for (auto p = it; p != renamed_body.instructions.begin();)
+            {
+              --p;
+              if (!p->is_assert())
+                break;
+              instructions_to_remove.insert(p);
+            }
           }
         }
       }


### PR DESCRIPTION
## Problem

With `--enforce-contract`, an `ensures` clause containing a relational pointer comparison on `__ESBMC_return_value` spuriously reported `VERIFICATION FAILED` with a `SAME-OBJECT` violation, even though the comparison is well-defined:

```c
char *with_retval(char *p) {
    __ESBMC_requires(__ESBMC_is_fresh(p, 8));
    __ESBMC_ensures((char *)__ESBMC_return_value <= (char *)p + 8);
    return p;                       // return_value == p, so SAME-OBJECT holds
}
```

The identical comparison written on the parameter `p` (`with_param`) passed. The same problem affected a pointer comparison written in a `requires` clause.

## Root cause

`enforce_contracts` renames the function body to `__ESBMC_contracts_original_<f>` and strips its contract clauses, but removed only the `contract::ensures` / `contract::requires` **ASSUME** instructions. The GOTO pointer/arithmetic-safety pass had already emitted auto-generated **ASSERTs** (e.g. `SAME-OBJECT` for a pointer comparison) from those clause expressions, and those were left in the original body. For an `ensures` clause the leftover assert references `__ESBMC_return_value`, which is the unbound global `return_value` in the original body (not the actual returned value), so `SAME-OBJECT((char*)return_value, p + 8)` failed spuriously. The wrapper function re-checks the ensures with `return_value` correctly bound to the call result, so the original-body assert is pure noise.

## Fix

When stripping a contract clause from the renamed original body, also drop the contiguous run of safety `ASSERT`s immediately preceding the clause `ASSUME` (the safety checks the GOTO pass generated from the clause expression).

Adjacency — rather than co-location by source location — is used deliberately: contract clauses precede the function body, so a real body assertion never sits directly before a clause `ASSUME`, and the backward walk over asserts cannot reach body code. (A location-based match could mask a genuine body bug when a macro collapses a clause and body statement onto the same source line; the adjacency walk does not. Verified: a division-by-zero on the same source line as a clause is still caught.)

## Tests

New regression pair (CORE):
- `regression/function_contract/github_5043_retval_same_object_pass` — relational comparison on `return_value` in `ensures` → `SUCCESSFUL`.
- `regression/function_contract/github_5043_retval_same_object_fail` — function returns `p + 4` with `ensures return_value <= p` → still `VERIFICATION FAILED`, confirming the wrapper's enforcement is intact and `return_value` is correctly bound.

Validation: dual-solver Bitwuzla + Z3 agreement; the analogous `requires`-clause pointer comparison is fixed too; the full `function_contract` regression suite (262 tests) passes with no regressions.

Fixes #5043