### PR TITLE
[contracts] Fix unbounded unwinding of recursive --enforce-contract (#5313)

### DIFF
--- a/regression/function_contract/github_5313_recursive_enforce_fail/main.c
+++ b/regression/function_contract/github_5313_recursive_enforce_fail/main.c
@@ -1,0 +1,16 @@
+// Companion to github_5313_recursive_enforce_pass: enforcing a recursive
+// contract must still catch a contract violation. Here the recursive call
+// rec(n + 1) can reach n + 1 == 4, which violates the callee's own
+// precondition (n < 4). Because the self-call is replaced by the contract,
+// its requires becomes a proof obligation at the call site, so verification
+// must report FAILED (and would, before the fix, instead unwind unboundedly).
+int rec(int n)
+{
+  __ESBMC_requires(n >= 0);
+  __ESBMC_requires(n < 4);
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  __ESBMC_assigns();
+  if (n == 0)
+    return 0;
+  return rec(n + 1);
+}

--- a/regression/function_contract/github_5313_recursive_enforce_fail/test.desc
+++ b/regression/function_contract/github_5313_recursive_enforce_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function rec --enforce-contract rec
+^VERIFICATION FAILED$
+^.*contract requires.*$

--- a/regression/function_contract/github_5313_recursive_enforce_pass/main.c
+++ b/regression/function_contract/github_5313_recursive_enforce_pass/main.c
@@ -1,0 +1,15 @@
+// Regression for #5313: enforcing a contract on a recursive function must use
+// the function's own contract for the recursive self-call instead of unwinding
+// the real recursion unboundedly (which previously ran out of memory). The
+// recursion terminates in at most 4 calls, well within any unwind bound, and
+// the contract holds, so verification must terminate with SUCCESSFUL.
+int rec(int n)
+{
+  __ESBMC_requires(n >= 0);
+  __ESBMC_requires(n < 4);
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  __ESBMC_assigns();
+  if (n == 0)
+    return 0;
+  return rec(n - 1);
+}

--- a/regression/function_contract/github_5313_recursive_enforce_pass/test.desc
+++ b/regression/function_contract/github_5313_recursive_enforce_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function rec --enforce-contract rec
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -889,6 +889,34 @@ void code_contractst::enforce_contracts(
       }
     }
 
+    // Recursive self-calls: under enforcement the function body is executed by
+    // the checking wrapper, and a self-call resolves to that same wrapper, so
+    // the real recursion is unwound unboundedly (OOM) instead of using the
+    // function's own contract (#5313). Replace each self-call in the original
+    // body with the contract (assert requires → havoc assigns → assume ensures),
+    // exactly as --replace-call-with-contract does. original_body_copy still
+    // carries the contract clauses (the renamed body has them stripped), so use
+    // it as the contract source.
+    {
+      goto_programt &self_body =
+        goto_functions.function_map[original_name_id].body;
+      std::vector<goto_programt::targett> self_calls;
+      Forall_goto_program_instructions (i_it, self_body)
+      {
+        if (!i_it->is_function_call() || !is_code_function_call2t(i_it->code))
+          continue;
+        const code_function_call2t &call = to_code_function_call2t(i_it->code);
+        if (
+          is_symbol2t(call.function) &&
+          to_symbol2t(call.function).get_symbol_name() ==
+            id2string(original_id))
+          self_calls.push_back(i_it);
+      }
+      for (auto call_it : self_calls)
+        generate_replacement_at_call(
+          *func_sym, original_body_copy, call_it, self_body);
+    }
+
     // Extract is_fresh mappings from function body for ensures clause replacement
     std::vector<code_contractst::is_fresh_mapping_t> is_fresh_mappings =
       extract_is_fresh_mappings_from_body(original_body_copy);


### PR DESCRIPTION
## Problem

`--enforce-contract` on a *recursive* function unwound the real recursion unboundedly and ran out of memory, instead of using the function's own contract:

```c
int rec(int n) {
    __ESBMC_requires(n >= 0);
    __ESBMC_requires(n < 4);          // recursion depth <= 4
    __ESBMC_ensures(__ESBMC_return_value >= 0);
    __ESBMC_assigns();
    if (n == 0) return 0;
    return rec(n - 1);
}
// esbmc rec.c --function rec --enforce-contract rec
//   Unwinding recursion rec iteration 1762 ... ERROR: Out of memory
```

## Root cause

Enforcing a contract renames the body to `__ESBMC_contracts_original_<f>` and builds a checking wrapper `<f>` that does `assume requires; ret = contracts_original_<f>(args); assert ensures`. The original body's recursive self-call still targets `<f>` — the wrapper — so execution recurses `wrapper → original → wrapper → …` without bound. The recursion is resolved by unwinding rather than by the contract.

## Fix

After the original body is renamed and its contract clauses stripped, replace each **direct self-call** in it with the function's contract — `assert requires(actual args) → havoc assigns → assume ensures` — reusing `generate_replacement_at_call`, the same routine `--replace-call-with-contract` uses. The contract clauses are taken from the pre-strip copy of the body (the renamed body has them stripped).

This is sound modular reasoning:
- The self-call's precondition becomes a **proof obligation** — a recursive call passing an out-of-contract argument is still caught.
- The callee's `ensures` is assumed at the call site, which is sound because the function is independently verified by its own checking wrapper.

Only direct self-recursion is handled; mutual recursion (`f → g → f`) still unwinds, which is conservative (no crash, no unsoundness — it just retains the original unwinding behaviour for that case).

## Tests

New regression pair (CORE):
- `github_5313_recursive_enforce_pass` — the terminating, contract-satisfying recursion now verifies `SUCCESSFUL` (previously OOM/unbounded unwind).
- `github_5313_recursive_enforce_fail` — `rec(n + 1)` violates the callee's own precondition (`requires n < 4`), so the self-call's `requires` obligation fails: `VERIFICATION FAILED` on `contract requires`. This pins that the recursive call is genuinely abstracted by the contract (and its precondition checked), not silently assumed.

Validation: dual-solver Bitwuzla + Z3 agreement; full `function_contract` regression suite (260 tests) passes with no regressions.

Fixes #5313