### PR TITLE
[irep2] Carry code_block end_location through the body round-trip (W1)

### DIFF
--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -187,21 +187,16 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   restore_value_locations(roundtrip_body_storage, locationt());
   const codet &code = to_code(roundtrip_body_storage);
 
-  // code_block2t carries only #location, not #end_location, so the round-trip
-  // drops the closing-brace location the frontend stamped onto the block (see
-  // clang_c_convert.cpp). That location is the END_FUNCTION instruction's
-  // location; for an empty function body it is the *only* located instruction,
-  // so losing it leaves the whole function unlocated and passes keyed on
-  // instruction location skip it (e.g. --branch-function-coverage stops
-  // counting the function entry point). Recover it from the still-authoritative
-  // legacy value, which retains the #end_location IREP2 cannot represent.
+  // The closing-brace location is the END_FUNCTION instruction's location; for
+  // an empty function body it is the *only* located instruction, so losing it
+  // leaves the whole function unlocated and passes keyed on instruction
+  // location skip it (e.g. --branch-function-coverage stops counting the
+  // function entry point). code_block2t now carries #end_location through the
+  // round-trip (W1, esbmc/esbmc#4715), so read it straight off the body block.
   locationt end_location;
-  // legacy_body is guaranteed to be code (the early check above aborts
-  // otherwise); a nil body is already handled before this point.
-  const codet &legacy_body = to_code(symbol.get_value());
-  if (legacy_body.get_statement() == "block")
+  if (code.get_statement() == "block")
     end_location =
-      static_cast<const locationt &>(to_code_block(legacy_body).end_location());
+      static_cast<const locationt &>(to_code_block(code).end_location());
   else
     end_location.make_nil();
 

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -1080,10 +1080,12 @@ constexpr std::size_t count_derived_field_entries(std::index_sequence<Is...>)
 // kind declares `static constexpr std::size_t excluded_field_bytes = ...;`
 // giving the byte size of those excluded members, so `fields_cover_class`
 // stops counting them as "missed". The only current use is the non-reflected
-// `locationt location` on the V.4 structured-CF code kinds (esbmc/esbmc#4715):
-// source location must travel with the statement for goto_convert, but must
-// not enter value identity (matching how a goto instructiont stores its
-// locationt separately from its IREP2 code). Kinds without the member get 0.
+// Non-reflected `locationt` members on code kinds (esbmc/esbmc#4715): the V.4
+// structured-CF kinds carry a `location`, and code_block2t also carries an
+// `end_location`. Source locations must travel with the statement for
+// goto_convert, but must not enter value identity (matching how a goto
+// instructiont stores its locationt separately from its IREP2 code). Kinds
+// without such members get 0.
 template <class K, class = void>
 struct kind_excluded_field_bytes
 {

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1836,12 +1836,20 @@ class code_block2t : public expr2t
 public:
   std::vector<expr2tc> operands;
   locationt location; // not reflected: source loc travels with the stmt
-  static constexpr std::size_t excluded_field_bytes = sizeof(locationt);
+  // not reflected: the closing-brace location travels with the block too, so a
+  // code_block2t consumed natively by goto_convert (W1, esbmc/esbmc#4715) keeps
+  // the end location convert_block needs for destructor placement.
+  locationt end_location;
+  static constexpr std::size_t excluded_field_bytes = 2 * sizeof(locationt);
 
   code_block2t(
     const std::vector<expr2tc> &ops,
-    const locationt &loc = locationt())
-    : expr2t(get_empty_type(), code_block_id), operands(ops), location(loc)
+    const locationt &loc = locationt(),
+    const locationt &end_loc = locationt())
+    : expr2t(get_empty_type(), code_block_id),
+      operands(ops),
+      location(loc),
+      end_location(end_loc)
   {
   }
   code_block2t(const code_block2t &ref) = default;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2322,7 +2322,10 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
         ops.push_back(o);
       }
     }
-    new_expr_ref = code_block2tc(ops, expr.location());
+    new_expr_ref = code_block2tc(
+      ops,
+      expr.location(),
+      static_cast<const locationt &>(expr.end_location()));
     return;
   }
 
@@ -4085,6 +4088,8 @@ exprt migrate_expr_back(const expr2tc &ref)
       block.copy_to_operands(migrate_expr_back(op));
     if (ref2.location.is_not_nil())
       block.location() = ref2.location;
+    if (ref2.end_location.is_not_nil())
+      block.end_location(ref2.end_location);
     return block;
   }
   // V.4 structured control-flow code kinds (esbmc/esbmc#4715). Reproduce the

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -438,9 +438,7 @@ TEST_CASE(
   REQUIRE(migrate_expr_back(mu).location().get_file() == "contract.sol");
 }
 
-TEST_CASE(
-  "migrate preserves code_block end_location",
-  "[migrate][v4-cf]")
+TEST_CASE("migrate preserves code_block end_location", "[migrate][v4-cf]")
 {
   // W1 (esbmc#4715): code_block2t carries a non-reflected end_location (the
   // closing-brace location) so it survives the --irep2-bodies round-trip.

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -439,6 +439,38 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "migrate preserves code_block end_location",
+  "[migrate][v4-cf]")
+{
+  // W1 (esbmc#4715): code_block2t carries a non-reflected end_location (the
+  // closing-brace location) so it survives the --irep2-bodies round-trip.
+  // convert_block stamps it onto the destructor-unwind instructions at scope
+  // exit; without it those instructions are unlocated. Equality ignores it, so
+  // assert on it explicitly.
+  use_test_ns();
+  locationt loc, end_loc;
+  loc.set_file("contract.sol");
+  loc.set_line(3);
+  end_loc.set_file("contract.sol");
+  end_loc.set_line(9);
+
+  codet block("code");
+  block.statement("block");
+  block.location() = loc;
+  block.end_location(end_loc);
+
+  expr2tc m;
+  migrate_expr(block, m);
+  REQUIRE(is_code_block2t(m));
+  REQUIRE(to_code_block2t(m).end_location.get_line() == "9");
+
+  exprt back = migrate_expr_back(m);
+  REQUIRE(back.location().get_line() == "3");
+  REQUIRE(
+    static_cast<const locationt &>(back.end_location()).get_line() == "9");
+}
+
+TEST_CASE(
   "migrate round-trips sizeof(T) carrying the measured type",
   "[migrate][v4-cf]")
 {


### PR DESCRIPTION
First step of the deeper **W1** removal (esbmc/esbmc#4715) — making `goto_convert` able to consume IREP2 bodies natively. It also fixes a latent location regression introduced by the V.4.4b body round-trip.

## Background

After V.4.4b every function body is round-tripped legacy→IREP2→legacy at `goto_convert` entry. `code_block2t` carried only `location`, **not** `#end_location` (the closing-brace location). `convert_block` uses a block's `end_location` as the source location of the destructor-unwind instructions it emits at scope exit. So on master the round-trip **drops nested-block end locations**, and nested-scope destructor instructions come out **unlocated**:

```
// master, for `{ S b; b.x = 1; }`
// no location
FUNCTION_CALL:  ~S(&b)
// no location
DEAD b
```

This is a regression vs the pre-V.4.4b non-round-tripped legacy path, which produced the correct location.

## What

- `code_block2t` gains a non-reflected `locationt end_location` member (alongside `location`); `excluded_field_bytes` is `2 * sizeof(locationt)` so neither location enters value identity.
- `migrate` forward carries `expr.end_location()` into the field; back restores it (nil-guarded, mirroring `location`).
- Result: nested-block destructor instructions are located correctly again:

```
// with this change
// file … line 4 column 19 function main
FUNCTION_CALL:  ~S(&b)
```

- **Simplification:** the END_FUNCTION-location recovery in `convert_function` previously re-read `symbol.get_value()` (the legacy value) precisely *because* `end_location` wasn't carried. It now reads the carried `end_location` straight off the round-tripped body block, dropping the redundant legacy re-read.

## Why it is safe

- The carriage is the IREP2 mirror of how `location` is already handled; `end_location` is excluded from cmp/crc/hash (not in the `fields` tuple), so a block with/without it still compares equal.
- The END_FUNCTION simplification is equivalent: `get_value2()` lazily forward-migrates the same legacy body, so `to_code_block(code).end_location()` equals the old `to_code_block(symbol.get_value()).end_location()`. The empty-body case (END_FUNCTION is the only located instruction) is preserved.
- The location-text change is *restorative* (unlocated → correct location); no `test.desc` asserts these instructions are unlocated.

## Validation

- New migrate round-trip unit test asserting `end_location` survives migrate→migrate_back (it is excluded from `==`, so asserted explicitly — mirrors the V.4.1 `location` test). `migratetest`: 101 assertions, 33 cases.
- C regression subset (incl. coverage-sensitive): **292/292**.
- `esbmc-cpp/cpp` (destructors — the affected path): **503/506**; the 3 failures are pre-existing on master (confirmed by re-running there — known macOS-environment failures), unrelated to this change.
- Empty-body function still gets a located END_FUNCTION; verdicts unchanged.
- Build + clang-format clean.
- Dual-solver (Bitwuzla + Z3) parity is delegated to CI.
