### PR TITLE
[python] V.3: build gen_boolean(false) error asserts in IREP2

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4002,9 +4002,9 @@ exprt function_call_expr::handle_general_function_call()
           nondet_expr.location().user_provided(true);
           nondet_expr.location().comment(
             "Unsupported function '" + func_name + "' called");
-          // Also add an assertion to the current block to flag this as an error
-          exprt false_expr = gen_boolean(false);
-          code_assertt assert_code(false_expr);
+          // Also add an assertion to the current block to flag this as an
+          // error (V.3: build the always-fail condition in IREP2).
+          code_assertt assert_code(migrate_expr_back(gen_false_expr()));
           assert_code.location() = location;
           assert_code.location().user_provided(true);
           assert_code.location().comment(
@@ -5104,7 +5104,8 @@ exprt function_call_expr::generate_attribute_error(
 
   log_warning("{}", error_msg.str());
 
-  code_assertt assert_code(gen_boolean(false));
+  // V.3: build the always-fail assert condition in IREP2.
+  code_assertt assert_code(migrate_expr_back(gen_false_expr()));
   assert_code.location() = location;
   assert_code.location().user_provided(true);
   assert_code.location().comment(error_msg.str());


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flip
the two remaining always-fail error-flag assert conditions in
`function_call_expr` from the legacy `gen_boolean(false)` builder to the
IREP2 `gen_false_expr()` factory, back-migrated at the legacy
`code_assertt` seam. Sibling of the recent math/cmath/tuple V.3 commits.

## What

- `handle_general_function_call`: the "Unsupported function" assert
- `generate_attribute_error`: the AttributeError fallback assert

Both `code_assertt(gen_boolean(false))` -> `code_assertt(migrate_expr_back(gen_false_expr()))`.
This retires `gen_boolean` entirely from the file.

## Why it is behaviour-preserving

`gen_false_expr()` returns the cached bool-false constant;
`migrate_expr_back` reconstructs it as `false_exprt` -- structurally
identical (id `constant`, bool type, value `false`) to `gen_boolean(false)`,
so the assert condition is byte-identical. The cached singleton is read by
const reference and copied into a fresh `exprt`; no reference escapes.

## Validation

- GOTO shows the assert is live: `ASSERT 0 // AttributeError: ...` /
  `... Unsupported function ...`; a probe yields `VERIFICATION FAILED`.
- 21 oracle tests pass on a Debug/asserts build (`forward-declaration6_fail`,
  `github_3001_fail`, `threading_*_unsupported`), live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
