### PR TITLE
[python] V.3: build non-boolean BoolOp short-circuit select in IREP2

### DIFF
--- a/regression/python/boolop_mixed_type/main.py
+++ b/regression/python/boolop_mixed_type/main.py
@@ -1,0 +1,15 @@
+# Mixed-type BoolOp: the operands have different concrete types, so the
+# result type falls back to Any while each operand stays concrete. Building
+# the short-circuit select must not assert/abort on the type-id mismatch.
+
+
+def and_int_str(a: int) -> object:
+    return a and "x"  # 0 -> 0 (falsy short-circuit), else -> "x"
+
+
+def or_bool_int(a: int, b: int) -> object:
+    return (a > 0) or b  # False -> b, True -> True
+
+
+assert and_int_str(0) == 0
+assert or_bool_int(-1, 9) == 9

--- a/regression/python/boolop_mixed_type/test.desc
+++ b/regression/python/boolop_mixed_type/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/boolop_mixed_type_fail/main.py
+++ b/regression/python/boolop_mixed_type_fail/main.py
@@ -1,0 +1,9 @@
+# Negative variant: the mixed-type BoolOp converts, but the asserted
+# short-circuit value is wrong.
+
+
+def and_int_str(a: int) -> object:
+    return a and "x"  # 0 -> 0 (falsy short-circuit)
+
+
+assert and_int_str(0) == 1

--- a/regression/python/boolop_mixed_type_fail/test.desc
+++ b/regression/python/boolop_mixed_type_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -116,19 +116,40 @@ exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
     // Are we dealing with an actual bool expression?
     if (t.is_bool())
       return logical_expr;
-    // Result expression starts from last operand as default else branch
+    // Result expression starts from last operand as default else branch.
+    const type2tc t2 = migrate_type(t);
     exprt result_expr = logical_expr.operands().back();
     for (int i = logical_expr.operands().size() - 2; i >= 0; i--)
     {
       const exprt &current = logical_expr.operands()[i];
       exprt current_cond = get_truthy_condition(current);
-      exprt if_expr("if", t);
-      if (logical_expr.is_and())
-        if_expr.copy_to_operands(current_cond, result_expr, current);
+      // V.3: build the short-circuit select in IREP2 when both branches
+      // share the result type-id. A mixed-type BoolOp keeps the result type
+      // as any_type() while the operands stay concrete (extract_type_from_
+      // boolean_op's "fall back to Any" path); if2t asserts type-id equality,
+      // so those reconcile post-conversion via the legacy adjuster as before.
+      expr2tc cond2, current2, result2;
+      migrate_expr(current_cond, cond2);
+      migrate_expr(current, current2);
+      migrate_expr(result_expr, result2);
+      if (
+        current2->type->type_id == t2->type_id &&
+        result2->type->type_id == t2->type_id)
+      {
+        // and: cond ? result : current  /  or: cond ? current : result
+        result_expr = migrate_expr_back(
+          logical_expr.is_and() ? if2tc(t2, cond2, result2, current2)
+                                : if2tc(t2, cond2, current2, result2));
+      }
       else
-        if_expr.copy_to_operands(current_cond, current, result_expr);
-
-      result_expr = if_expr;
+      {
+        exprt if_expr("if", t);
+        if (logical_expr.is_and())
+          if_expr.copy_to_operands(current_cond, result_expr, current);
+        else
+          if_expr.copy_to_operands(current_cond, current, result_expr);
+        result_expr = if_expr;
+      }
     }
     return result_expr;
   }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flip
the value-returning `a and b` / `a or b` short-circuit if-chain in
`python_converter::get_logical_operator_expr` from the legacy
`exprt("if", t)` builder to the IREP2 `if2tc` factory, back-migrated at
the seam. Sibling of the recent math/cmath/tuple V.3 commits. (The legacy
list-truthiness condition was already IREP2, #5402.)

## What

```
and: cond ? result : current   ->  if2tc(t, cond, result, current)
or:  cond ? current : result   ->  if2tc(t, cond, current, result)
```

## Mixed-type guard (why this is behaviour-preserving)

When a BoolOp mixes concrete operand types, `extract_type_from_boolean_op`
falls back to `any_type()` for the result while the operands stay
concrete, and `if2t` asserts type-id equality between the node and both
branches. The IREP2 path is therefore taken **only** when both branches
already share the result type-id (the common same-type case); mixed-type
BoolOps keep the legacy `exprt("if", t)` builder and reconcile
post-conversion via the legacy adjuster, exactly as before. The
same-type IREP2 node is byte-identical to the legacy one modulo the
cosmetic `#cpp_type` hint, unobservable in a select.

## Validation

- GOTO confirms `a or b` -> `(_Bool)a ? a : b` and `a and b` ->
  `(_Bool)a ? b : a` (exact legacy operand order).
- 21 oracle tests pass on a Debug/asserts build (`boolop-*`,
  `logical-and/or/not`, `github_4784_isnone_short_circuit`,
  `builtin_all_genexp_short_circuit`, `complex_math_wrapper_and_int_edges`),
  live `migrate.cpp` cross-check silent.
- New `boolop_mixed_type{,_fail}` tests cover the previously-untested
  mixed-type path (`int and str`, `bool or int`) under both ESBMC and
  CPython.
- clang-format 11 clean. Dual-solver parity delegated to CI.
