### PR TITLE
[python] V.3: build float(str) ValueError guard condition in IREP2

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -857,7 +857,10 @@ exprt function_call_expr::build_constant_from_arg() const
         codet throw_code("expression");
         throw_code.operands().push_back(raise);
         code_ifthenelset guard;
-        guard.cond() = not_exprt(valid);
+        // V.3: build the "not valid" guard condition in IREP2.
+        expr2tc valid2;
+        migrate_expr(valid, valid2);
+        guard.cond() = migrate_expr_back(not2tc(valid2));
         guard.then_case() = throw_code;
         guard.location() = loc;
         converter_.add_instruction(guard);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flip
the `float(<string variable>)` ValueError guard in `build_constant_from_arg`
from the legacy `not_exprt` builder to the IREP2 `not2tc` factory,
back-migrated at the legacy `code_ifthenelset` condition seam. Sibling of
the recent math/cmath/BoolOp V.3 commits.

## What

```
guard.cond() = not_exprt(valid)
  -> guard.cond() = migrate_expr_back(not2tc(migrate(valid)))
```

`valid` is the bool result of `string_handler::handle_string_is_float`.

## Why it is behaviour-preserving

`not2tc` has a fixed bool type and no operand assert, so it is the exact
migrate of `not_exprt`; `migrate.cpp`'s `not` forward/back arms make the
round-trip byte-identical modulo the cosmetic `#cpp_type` hint,
unobservable in a guard condition. Unlike the `if2t` sibling (#5433),
`not2t` has no type-id equality assert, so there is no mixed-type
pre-adjust wall here.

## Validation

- GOTO of `github_4819` shows the guard live:
  `IF !(!return_value$___python_str_is_float$1)` raising ValueError when
  the string is not a valid float.
- 12 tests pass on a Debug/asserts build, including the
  `github_4819{,_fail}` canonical #4819 oracle (valid parses SUCCESSFUL;
  invalid string -> uncaught ValueError FAILED), live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
