### PR TITLE
[python] V.3: build __ESBMC_isnan/isinf nodes in IREP2

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -2438,9 +2438,10 @@ function_call_expr::get_dispatch_table()
            return arg_expr;
          if (is_complex_type(arg_expr.type()))
            return complex_utils::raise_math_real_type_error_expr(converter_);
-         exprt isnan_expr("isnan", bool_typet());
-         isnan_expr.copy_to_operands(arg_expr);
-         return isnan_expr;
+         // V.3: build isnan in IREP2.
+         expr2tc arg2;
+         migrate_expr(arg_expr, arg2);
+         return migrate_expr_back(isnan2tc(arg2));
        }
        else // __ESBMC_isinf
        {
@@ -2452,9 +2453,10 @@ function_call_expr::get_dispatch_table()
            return arg_expr;
          if (is_complex_type(arg_expr.type()))
            return complex_utils::raise_math_real_type_error_expr(converter_);
-         exprt isinf_expr("isinf", bool_typet());
-         isinf_expr.copy_to_operands(arg_expr);
-         return isinf_expr;
+         // V.3: build isinf in IREP2.
+         expr2tc arg2;
+         migrate_expr(arg_expr, arg2);
+         return migrate_expr_back(isinf2tc(arg2));
        }
      },
      "isnan/isinf"},


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): flip
the `__ESBMC_isnan` / `__ESBMC_isinf` intrinsic handlers in
`function_call_expr`'s dispatch table from the legacy
`exprt("isnan"/"isinf", bool)` + `copy_to_operands` builders to the IREP2
`isnan2tc`/`isinf2tc` factories, back-migrated at the return seam. Sibling
of the recent math/cmath/BoolOp V.3 commits.

## What

```
exprt("isnan", bool); copy_to_operands(arg)
  -> migrate_expr_back(isnan2tc(migrate(arg)))   (isinf symmetric)
```

## Why it is behaviour-preserving

`isnan2t`/`isinf2t` are single-operand, fixed-bool-typed nodes
(`ESBMC_DEFINE_FP_PREDICATE_1OP`) with no operand-type assert, and
`migrate.cpp`'s isnan/isinf forward/back arms make the round-trip
byte-identical modulo the cosmetic `#cpp_type` hint (unobservable in a
bool predicate). The `is_cpp_throw_expr` and `is_complex_type`
early-return guards are preserved ahead of the node build.

## Validation

- `math.isnan/isinf/isfinite` route through `models/math.py`, which calls
  `__ESBMC_isnan/isinf` (this branch); the node lowers to
  `__inline_isnanf/d/l` at goto-convert.
- 7 oracle tests pass on a Debug/asserts build
  (`math_edge_isnan/isinf/isfinite_{success,fail}`), live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
