### PR TITLE
[python] V.3: build void* cls/null-fallback args via IREP2 gen_zero

### DIFF
--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -3843,7 +3843,9 @@ exprt function_call_expr::handle_general_function_call()
             if (inferred_classes_from_fallback)
             {
               locationt location = converter_.get_location_from_decl(call_);
-              exprt zero_fallback = gen_zero(any_type());
+              // V.3: build the void* null fallback via the IREP2 factory.
+              exprt zero_fallback =
+                migrate_expr_back(gen_zero(migrate_type(any_type())));
               zero_fallback.location() = location;
               zero_fallback.location().user_provided(true);
               return zero_fallback;
@@ -4208,8 +4210,9 @@ exprt function_call_expr::handle_general_function_call()
     else
     {
       // Passing a void pointer to the "cls" argument
+      // (V.3: build the void* null via the IREP2 factory).
       typet t = pointer_typet(empty_typet());
-      call.arguments().push_back(gen_zero(t));
+      call.arguments().push_back(migrate_expr_back(gen_zero(migrate_type(t))));
       param_offset = 1;
 
       // All methods for the int class without parameters acts solely on the encapsulated integer value.


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715): route
the two statically-`void*` null builders in `handle_general_function_call`
through the IREP2 `gen_zero(type2tc)` factory, back-migrated at the legacy
seam. Sibling of the recent math/cmath/BoolOp/isnan V.3 commits.

## What

```
gen_zero(t)  ->  migrate_expr_back(gen_zero(migrate_type(t)))
```

- the uncertain-class-inference `void*` fallback return value;
- the `void*` "cls" argument pushed onto an int-class method call.

## Why it is byte-identical

IREP2 `gen_zero(pointer)` builds `symbol2tc(type,"NULL")`, but
`migrate_expr_back` special-cases the `"NULL"` symbol back to a
`constant_exprt` with value `"NULL"` (`migrate.cpp:3047-3052`) — exactly
the legacy `gen_zero(pointer)` node. The types are a fresh
`pointer_typet(empty_typet())`, so `migrate_type` carries no attributes to
drop.

## Deliberately NOT migrated

The sibling `$union_arg$`/`$ptr_arg$` sites build `gen_zero(arg.type())`
where `arg.type()` may be a struct/complex; IREP2 `gen_zero` has no
`complex` arm and `abort()`s on the default case, whereas legacy `gen_zero`
handles `complex`. Those stay legacy.

## Validation

- GOTO shows `bit_length(0, n)` (the `cls` arg is the NULL constant printed
  as `0`).
- `int_bit_length` + `class-methods` + a 96-test class/attr cluster pass on
  a Debug/asserts build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
