### PR TITLE
[python] V.3: build list slice-bound clamps in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1567,11 +1567,15 @@ exprt python_list::handle_range_slice(
       if (bound["_type"] == "UnaryOp" && bound["op"]["_type"] == "USub")
       {
         exprt abs_value = to_size_expr(converter_.get_expr(bound["operand"]));
-        // Clamp to 0 when abs_value > logical_len (avoids unsigned underflow)
-        exprt overflow(">", bool_type());
-        overflow.copy_to_operands(abs_value, logical_len);
-        exprt converted = size_sub(logical_len, abs_value);
-        return if_exprt(overflow, gen_zero(size_type()), converted);
+        // Clamp to 0 when abs_value > logical_len (avoids unsigned underflow).
+        // (V.3: built in IREP2.)
+        const type2tc size_t2 = migrate_type(size_type());
+        expr2tc abs2, len2, converted2;
+        migrate_expr(abs_value, abs2);
+        migrate_expr(logical_len, len2);
+        migrate_expr(size_sub(logical_len, abs_value), converted2);
+        return migrate_expr_back(if2tc(
+          size_t2, greaterthan2tc(abs2, len2), gen_zero(size_t2), converted2));
       }
 
       exprt e = converter_.get_expr(bound);
@@ -1598,17 +1602,19 @@ exprt python_list::handle_range_slice(
     // Clamp bounds to [0, logical_len] to match Python semantics.
     if (!negative_step)
     {
-      // lower = max(0, min(lower, logical_len))
-      exprt lower_ge_len(">=", bool_type());
-      lower_ge_len.copy_to_operands(lower_expr, logical_len);
-      lower_expr = if_exprt(lower_ge_len, logical_len, lower_expr);
-      lower_expr.type() = size_type();
-
-      // upper = max(0, min(upper, logical_len))
-      exprt upper_ge_len(">=", bool_type());
-      upper_ge_len.copy_to_operands(upper_expr, logical_len);
-      upper_expr = if_exprt(upper_ge_len, logical_len, upper_expr);
-      upper_expr.type() = size_type();
+      // bound = (bound >= logical_len) ? logical_len : bound
+      // (V.3: built in IREP2.)
+      const type2tc size_t2 = migrate_type(size_type());
+      expr2tc len2;
+      migrate_expr(logical_len, len2);
+      auto clamp_to_len = [&](exprt &bound) {
+        expr2tc b2;
+        migrate_expr(bound, b2);
+        bound = migrate_expr_back(
+          if2tc(size_t2, greaterthanequal2tc(b2, len2), len2, b2));
+      };
+      clamp_to_len(lower_expr);
+      clamp_to_len(upper_expr);
     }
 
     // Calculate slice length


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). In
`python_list::handle_range_slice`, migrate the slice-bound clamps from
legacy `exprt` builders to IREP2 factories, back-migrated at the legacy
seam. Follows the first OM-handler flip (#5437).

## What

- the negative-bound overflow clamp (`abs > len ? 0 : len-abs`):
  `exprt(">")` + `if_exprt` → `greaterthan2tc` + `if2tc(size_t, …, gen_zero, …)`
- the lower/upper `>= len` clamps (`bound >= len ? len : bound`), refactored
  from two copy-pasted blocks into one `clamp_to_len` lambda:
  `exprt(">=")` + `if_exprt` → `greaterthanequal2tc` + `if2tc`

## Why it is behaviour-preserving

All operands are `size_type`/`bool`, so each factory is the exact migrate
of its legacy builder, the then/else operand order is preserved, and both
`if2t` branches are `size_type` (type-id equality holds — no mixed-type
wall, cf. #5433). `gen_zero(size_t)` takes the unsignedbv arm (constant 0),
not the complex-abort default.

## Validation

- Probe `a[1:3]`=2, `a[-2:]`=2, `a[10:20]`=0 (lower clamp), `a[:100]`=5
  (upper clamp) → `VERIFICATION SUCCESSFUL`.
- 73/73 slice oracle tests pass on a Debug/asserts build (`.*slice` +
  `github_452x/453x/454x`), live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
