### PR TITLE
[python] V.3: build slice.indices() bound resolution in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1765,6 +1765,7 @@ exprt python_list::handle_range_slice(
     const exprt size_signed = build_typecast(build_symbol(size_sym), signed_t);
     const exprt zero_s = from_integer(0, signed_t);
     const exprt one_s = from_integer(1, signed_t);
+    const type2tc signed_t2 = migrate_type(signed_t); // V.3: for IREP2 selects
 
     // Step 1: produce a signed `resolved` value.
     //   - missing bound → step-direction default
@@ -1784,10 +1785,12 @@ exprt python_list::handle_range_slice(
       exprt val_signed =
         build_typecast(converter_.get_expr(slice_node[name]), signed_t);
       exprt size_plus_val = signed_add(size_signed, val_signed);
-      exprt is_neg("<", bool_type());
-      is_neg.copy_to_operands(val_signed, zero_s);
-      resolved = if_exprt(is_neg, size_plus_val, val_signed);
-      resolved.type() = signed_t;
+      // val < 0 ? size + val : val  (V.3: built in IREP2).
+      expr2tc val2, spv2;
+      migrate_expr(val_signed, val2);
+      migrate_expr(size_plus_val, spv2);
+      resolved = migrate_expr_back(
+        if2tc(signed_t2, lessthan2tc(val2, gen_zero(signed_t2)), spv2, val2));
     }
 
     // Step 2: clamp to the CPython-defined window for this step direction.
@@ -1800,17 +1803,17 @@ exprt python_list::handle_range_slice(
     const exprt over =
       negative_step ? signed_sub(size_signed, one_s) : size_signed;
 
-    exprt is_under("<", bool_type());
-    is_under.copy_to_operands(resolved, under);
-    exprt c1 = if_exprt(is_under, under, resolved);
-    c1.type() = signed_t;
+    // c1 = max(resolved, under); c2 = min(c1, over)  (V.3: built in IREP2).
+    expr2tc resolved2, under2, over2;
+    migrate_expr(resolved, resolved2);
+    migrate_expr(under, under2);
+    migrate_expr(over, over2);
+    expr2tc c1 =
+      if2tc(signed_t2, lessthan2tc(resolved2, under2), under2, resolved2);
+    expr2tc c2 = if2tc(signed_t2, greaterthan2tc(c1, over2), over2, c1);
+    exprt c2_legacy = migrate_expr_back(c2);
 
-    exprt is_over(">", bool_type());
-    is_over.copy_to_operands(c1, over);
-    exprt c2 = if_exprt(is_over, over, c1);
-    c2.type() = signed_t;
-
-    return negative_step ? c2 : build_typecast(c2, size_type());
+    return negative_step ? c2_legacy : build_typecast(c2_legacy, size_type());
   };
 
   exprt lower_expr = resolve_bound("lower", false);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). In the
`resolve_bound` lambda of `python_list::handle_range_slice` (the CPython
`slice.indices(len)` path for stepped/symbolic slices), migrate the three
signed `if`-selects from legacy `exprt` builders to IREP2 factories,
back-migrated at the legacy seam. Follows #5437 (neg-index) and #5439
(slice clamps) in the same handler.

## What

```
negative-adjust: val < 0 ? size+val : val
under-clamp:     resolved < under ? under : resolved
over-clamp:      c1 > over ? over : c1
```
`exprt("<"/">")` + `if_exprt` → `lessthan2tc`/`greaterthan2tc` + `if2tc`.

## Why it is behaviour-preserving

All operands are `signed_t`/`bool`: each factory is the exact migrate of its
legacy builder, the then/else order is preserved, and every `if2t` branch is
`signed_t` (type-id equality holds — no mixed-type wall, cf. #5433).
`gen_zero(signed_t)` replaces `from_integer(0, signed_t)` (identical signedbv
constant 0). `c1` stays an IREP2 node reused by the over-clamp; only the final
`c2` is back-migrated for the legacy return.

## Validation

- Probe `a[::-1]`=6, `a[5:1:-1]`=4, `a[1:100:2]`=3, `a[-3:-1]`=2 →
  `VERIFICATION SUCCESSFUL` (exercises all three selects).
- Step-slice oracle suite **14/14** and broad slice cluster **73/73** pass on
  a Debug/asserts build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
