### PR TITLE
[python] V.3: build list ==/!= element compares in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3262,7 +3262,7 @@ exprt python_list::compare(
 
         if (lhs_n == rhs_n && lhs_n <= 64)
         {
-          exprt all_equal = gen_boolean(true);
+          expr2tc all_equal = gen_true_expr(); // V.3: accumulate in IREP2
           bool comparable = true;
 
           for (size_t i = 0; i < lhs_n; ++i)
@@ -3291,20 +3291,18 @@ exprt python_list::compare(
             exprt lhs_val = extract_pyobject_value(lhs_at, lhs_elem_type);
             exprt rhs_val = extract_pyobject_value(rhs_at, rhs_elem_type);
 
-            exprt eq_elem;
-            if (lhs_elem_type == rhs_elem_type && is_numeric(lhs_elem_type))
+            // Same-type numeric/bool compares directly; mixed numeric promotes
+            // both sides to double first. (V.3: built in IREP2.)
+            if (
+              lhs_elem_type == rhs_elem_type &&
+              (is_numeric(lhs_elem_type) || is_bool(lhs_elem_type)))
             {
-              eq_elem = equality_exprt(lhs_val, rhs_val);
-            }
-            else if (lhs_elem_type == rhs_elem_type && is_bool(lhs_elem_type))
-            {
-              eq_elem = equality_exprt(lhs_val, rhs_val);
+              // direct compare
             }
             else if (is_numeric(lhs_elem_type) && is_numeric(rhs_elem_type))
             {
               lhs_val = build_typecast(lhs_val, double_type());
               rhs_val = build_typecast(rhs_val, double_type());
-              eq_elem = equality_exprt(lhs_val, rhs_val);
             }
             else
             {
@@ -3312,16 +3310,17 @@ exprt python_list::compare(
               break;
             }
 
-            exprt and_expr("and", bool_type());
-            and_expr.copy_to_operands(all_equal, eq_elem);
-            all_equal = and_expr;
+            expr2tc lhs_val2, rhs_val2;
+            migrate_expr(lhs_val, lhs_val2);
+            migrate_expr(rhs_val, rhs_val2);
+            all_equal = and2tc(all_equal, equality2tc(lhs_val2, rhs_val2));
           }
 
           if (comparable)
           {
             if (op == "NotEq")
-              return not_exprt(all_equal);
-            return all_equal;
+              return migrate_expr_back(not2tc(all_equal));
+            return migrate_expr_back(all_equal);
           }
         }
       }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). In
`python_list::compare`, migrate the constant-length (`n<=64`) list equality
element-compare loop from legacy `exprt` builders to IREP2 factories,
back-migrated at the legacy return seam. Follows #5437/#5439/#5440 in this
handler.

## What

```
gen_boolean(true)     -> gen_true_expr()    (accumulator)
equality_exprt(a, b)  -> equality2tc(a, b)  (per element)
exprt("and")[acc, eq] -> and2tc(acc, eq)    (left fold)
not_exprt(all_equal)  -> not2tc(all_equal)  (NotEq)
```

The two identical same-type branches (numeric / bool) are folded into one
(`same-type && (numeric || bool)`); the mixed-numeric branch still promotes
both sides to `double` before the common migrate + `equality2tc` tail.

## Why it is behaviour-preserving

Each factory is the exact migrate of its legacy builder (bool results,
matching operand order and left-fold associativity). Operands always share a
type (same-type guard, or both promoted to double), so `equality2tc` is
well-formed. `all_equal` accumulates as `expr2tc` and is back-migrated only
at the two returns. The branch fold is behaviour-equivalent (identical
bodies; the same-type-non-numeric-non-bool case still falls through to break
in both old and new).

## Validation

- Probe `[1,2,3]==[1,2,3]` true, `!=[1,2,4]` true, `==[1.0,2.0,3.0]` true
  (int/float promotion), `!=[1.0,2.0,3.0]` false → `VERIFICATION SUCCESSFUL`.
- 17 list-eq oracle tests pass (`list-eq1..6`, `list-eq-int-float`,
  `humaneval_130`); broad list cluster **249/250** on a Debug/asserts build
  (the one failure is `list_pop11_nondet`, which hard-codes `--boolector`,
  not built in this config — not a regression). Live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
