### PR TITLE
[python] V.3: build set get_from_iterable guards/increment in IREP2

### DIFF
--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -394,9 +394,11 @@ exprt python_set::get_from_iterable(
       elem_expr = deref;
       list_helper.add_type_info(set_id, std::string(), elem_expr.type());
 
-      // Break if we hit the null terminator
-      exprt is_zero("=", bool_type());
-      is_zero.copy_to_operands(elem_expr, gen_zero(char_type()));
+      // Break if we hit the null terminator (V.3: built in IREP2).
+      expr2tc elem2;
+      migrate_expr(elem_expr, elem2);
+      exprt is_zero = migrate_expr_back(
+        equality2tc(elem2, gen_zero(migrate_type(char_type()))));
       code_breakt brk;
       code_ifthenelset break_if;
       break_if.cond() = is_zero;
@@ -432,7 +434,10 @@ exprt python_set::get_from_iterable(
       contains_call.location() = loc;
       loop_body.copy_to_operands(contains_call);
 
-      not_exprt not_contains(build_symbol(contains_result));
+      // V.3: build the "not contained" guard in IREP2.
+      expr2tc cr2;
+      migrate_expr(build_symbol(contains_result), cr2);
+      exprt not_contains = migrate_expr_back(not2tc(cr2));
 
       code_blockt push_block;
       exprt push_call = build_call_expr(
@@ -457,7 +462,10 @@ exprt python_set::get_from_iterable(
     {
       exprt contains_expr =
         list_helper.contains(elem_expr, build_symbol(set_symbol));
-      not_exprt not_contains(contains_expr);
+      // V.3: build the "not contained" guard in IREP2.
+      expr2tc ce2;
+      migrate_expr(contains_expr, ce2);
+      exprt not_contains = migrate_expr_back(not2tc(ce2));
 
       code_blockt push_block;
       exprt push_call =
@@ -470,8 +478,11 @@ exprt python_set::get_from_iterable(
       loop_body.copy_to_operands(push_if);
     }
 
-    // Increment index: i++
-    plus_exprt idx_inc(build_symbol(idx_sym), gen_one(size_type()));
+    // Increment index: i = i + 1 (V.3: built in IREP2).
+    const type2tc size_t2 = migrate_type(size_type());
+    expr2tc idx2;
+    migrate_expr(build_symbol(idx_sym), idx2);
+    exprt idx_inc = migrate_expr_back(add2tc(size_t2, idx2, gen_one(size_t2)));
     code_assignt idx_update(build_symbol(idx_sym), idx_inc);
     loop_body.copy_to_operands(idx_update);
   }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues the set operational-model handler V.3 work (#5091, #5240). In
`python_set::get_from_iterable` (builds a set from a list/string,
deduplicating), migrate four remaining builders from legacy `exprt` to IREP2
factories, back-migrated at the legacy seams (`code_ifthenelset` conditions
and a `code_assignt` RHS).

## What

- null-terminator break: `exprt("=")[elem, gen_zero(char)]` → `equality2tc`
- dedup push guard (pyobject branch): `not_exprt(contains)` → `not2tc`
- dedup push guard (else branch): `not_exprt(contains)` → `not2tc`
- loop increment `i = i+1`: `plus_exprt(i, gen_one(size))` → `add2tc`

## Why it is behaviour-preserving

Each factory is the exact migrate of its legacy builder (bool/`size_type`,
matching operand order). `gen_zero(char)`/`gen_one(size)` take the bv arm
(constant 0/1, not the complex-abort default) and the back-migrated
constants render to the same width-padded bit-string, so the nodes are
byte-identical modulo the cosmetic `#cpp_type` hint. `equality2t`/`not2t`
have no operand-type assert and `add2t`'s operands are both `size_type`, so
none can abort.

## Validation

- Probe `set([1,2,2,3,3,3])`=3 (dedup) and `set("hello")`=4 (string
  null-term + dedup) → `VERIFICATION SUCCESSFUL`.
- 18 set oracle tests pass (`set_from_list/string/param`,
  `github_2965_set_unique`, `set_difference/intersection`, `set-issuperset`)
  on a Debug/asserts build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
