### PR TITLE
[python] V.3: build set-op loop guards/increments in IREP2

### DIFF
--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -69,6 +69,15 @@ exprt build_deref_member(
   expr2tc deref2 = dereference2tc(migrate_type(obj.type().subtype()), obj2);
   return migrate_expr_back(member2tc(migrate_type(field_type), deref2, field));
 }
+
+// Build v + 1 : size_type in IREP2, back-migrated once (V.3).
+exprt build_size_inc(const exprt &v)
+{
+  const type2tc size_t2 = migrate_type(size_type());
+  expr2tc v2;
+  migrate_expr(v, v2);
+  return migrate_expr_back(add2tc(size_t2, v2, gen_one(size_t2)));
+}
 } // namespace
 
 symbolt &python_set::create_set_list()
@@ -589,8 +598,10 @@ exprt python_set::build_set_difference_call(
   push_call.location() = loc;
   then_block.copy_to_operands(converter_.convert_expression_to_code(push_call));
 
-  exprt not_contains("not", bool_type());
-  not_contains.copy_to_operands(build_symbol(contains_result));
+  // V.3: build the "not contained" guard in IREP2.
+  expr2tc cr2;
+  migrate_expr(build_symbol(contains_result), cr2);
+  exprt not_contains = migrate_expr_back(not2tc(cr2));
 
   codet if_stmt;
   if_stmt.set_statement("ifthenelse");
@@ -598,7 +609,7 @@ exprt python_set::build_set_difference_call(
   body.copy_to_operands(if_stmt);
 
   // Increment counter
-  plus_exprt i_inc(build_symbol(i_sym), gen_one(size_type()));
+  exprt i_inc = build_size_inc(build_symbol(i_sym)); // V.3
   code_assignt i_step(build_symbol(i_sym), i_inc);
   body.copy_to_operands(i_step);
 
@@ -721,7 +732,7 @@ exprt python_set::build_set_intersection_call(
   body.copy_to_operands(if_stmt);
 
   // Increment counter
-  plus_exprt i_inc(build_symbol(i_sym), gen_one(size_type()));
+  exprt i_inc = build_size_inc(build_symbol(i_sym)); // V.3
   code_assignt i_step(build_symbol(i_sym), i_inc);
   body.copy_to_operands(i_step);
 
@@ -852,8 +863,10 @@ exprt python_set::build_set_union_call(
   push_call.location() = loc;
   then_block.copy_to_operands(converter_.convert_expression_to_code(push_call));
 
-  exprt not_contains("not", bool_type());
-  not_contains.copy_to_operands(build_symbol(contains_result));
+  // V.3: build the "not contained" guard in IREP2.
+  expr2tc cr2;
+  migrate_expr(build_symbol(contains_result), cr2);
+  exprt not_contains = migrate_expr_back(not2tc(cr2));
 
   codet if_stmt;
   if_stmt.set_statement("ifthenelse");
@@ -861,7 +874,7 @@ exprt python_set::build_set_union_call(
   body.copy_to_operands(if_stmt);
 
   // Increment counter
-  plus_exprt i_inc(build_symbol(i_sym), gen_one(size_type()));
+  exprt i_inc = build_size_inc(build_symbol(i_sym)); // V.3
   code_assignt i_step(build_symbol(i_sym), i_inc);
   body.copy_to_operands(i_step);
 
@@ -983,7 +996,7 @@ void python_set::emit_filtered_extend(
   if_stmt.copy_to_operands(guard, then_block);
   body.copy_to_operands(if_stmt);
 
-  plus_exprt i_inc(build_symbol(i_sym), gen_one(size_type()));
+  exprt i_inc = build_size_inc(build_symbol(i_sym)); // V.3
   body.copy_to_operands(code_assignt(build_symbol(i_sym), i_inc));
 
   codet loop;
@@ -1090,7 +1103,7 @@ exprt python_set::build_set_relation_call(
   if_stmt.copy_to_operands(not_in, then_block);
   body.copy_to_operands(if_stmt);
 
-  plus_exprt i_inc(build_symbol(i_sym), gen_one(size_type()));
+  exprt i_inc = build_size_inc(build_symbol(i_sym)); // V.3
   body.copy_to_operands(code_assignt(build_symbol(i_sym), i_inc));
 
   codet loop;


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues the set operational-model handler work (#5091, #5240, #5442).
Across the five set loop-builders (difference, intersection, union,
`emit_filtered_extend`, `build_set_relation_call`), migrate the remaining
legacy `exprt` builders to IREP2 factories, back-migrated at the legacy seams
(ifthenelse conditions and `code_assignt` RHS).

## What

- loop increment `i = i+1`: `plus_exprt(i, gen_one(size))` → `add2tc`, via a
  new file-local `build_size_inc` helper that folds the five identical sites
  (mirrors the existing `build_symbol`/`build_call_expr` helper family).
- "not contained" guards (difference + union): `exprt("not")[contains]` →
  `not2tc`.

## Why it is behaviour-preserving

Each factory is the exact migrate of its legacy builder (bool / `size_type`,
matching operand order). `gen_one(size)` takes the unsignedbv arm (constant
1) and the back-migrated nodes are byte-identical modulo the cosmetic
`#cpp_type` hint. `add2t` operands/result are all `size_type` (consistency
holds); `not2t`/`add2t` carry no operand assert that can abort here.

## Validation

- Probe `a-b`=2, `a&b`=2, `a|b`=6.
- 18 set oracle tests pass (`set_difference/intersection/union`,
  `set_from_*`, `set-issuperset`, `github_2965_set_unique`) on a Debug/asserts
  build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
