### PR TITLE
[python] V.3: build dict key-found check in IREP2

### DIFF
--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -80,6 +80,18 @@ exprt build_address_of(const exprt &obj)
   migrate_expr(obj, obj2);
   return migrate_expr_back(address_of2tc(obj2->type, obj2));
 }
+
+// Build "key found" = !(index_var == SIZE_MAX) in IREP2, back-migrated once
+// (V.3). SIZE_MAX is the dict lookup's not-found sentinel.
+exprt build_key_found(const symbolt &index_var)
+{
+  const BigInt size_max_val = power(2, bv_width(size_type())) - 1;
+  const constant_exprt size_max(size_max_val, size_type());
+  expr2tc idx2, max2;
+  migrate_expr(build_symbol(index_var), idx2);
+  migrate_expr(size_max, max2);
+  return migrate_expr_back(not2tc(equality2tc(idx2, max2)));
+}
 } // namespace
 
 python_dict_handler::python_dict_handler(
@@ -2213,10 +2225,7 @@ exprt python_dict_handler::handle_dict_get(
   converter_.add_instruction(try_find_call);
 
   // Check if key was found (index != SIZE_MAX)
-  const BigInt size_max_val = power(2, bv_width(size_type())) - 1;
-  constant_exprt size_max(size_max_val, size_type());
-  exprt key_found =
-    not_exprt(equality_exprt(build_symbol(index_var), size_max));
+  exprt key_found = build_key_found(index_var); // V.3
 
   // Create result variable
   symbolt &result_var = converter_.create_tmp_symbol(
@@ -2443,10 +2452,7 @@ exprt python_dict_handler::handle_dict_setdefault(
   converter_.add_instruction(try_find_call);
 
   // Check if key was found (index != SIZE_MAX)
-  const BigInt size_max_val = power(2, bv_width(size_type())) - 1;
-  constant_exprt size_max(size_max_val, size_type());
-  exprt key_found =
-    not_exprt(equality_exprt(build_symbol(index_var), size_max));
+  exprt key_found = build_key_found(index_var); // V.3
 
   // Create result variable
   symbolt &result_var = converter_.create_tmp_symbol(
@@ -2809,10 +2815,7 @@ exprt python_dict_handler::handle_dict_pop(
   try_find_call.location() = location;
   converter_.add_instruction(try_find_call);
 
-  const BigInt size_max_val = power(2, bv_width(size_type())) - 1;
-  constant_exprt size_max(size_max_val, size_type());
-  exprt key_found =
-    not_exprt(equality_exprt(build_symbol(index_var), size_max));
+  exprt key_found = build_key_found(index_var); // V.3
 
   // Create result variable
   symbolt &result_var = converter_.create_tmp_symbol(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in the **dict** operational-model handler. Fold the three identical
"key found" check blocks in `handle_dict_get` / `handle_dict_setdefault` /
`handle_dict_pop` into a new file-local `build_key_found` helper that builds
the predicate in IREP2, back-migrated at the legacy seam.

## What

```
not_exprt(equality_exprt(index_var, SIZE_MAX))
  -> migrate_expr_back(not2tc(equality2tc(index_var, SIZE_MAX)))
```

The helper mirrors the existing `build_symbol`/`build_deref`/`build_address_of`
family in that anonymous namespace, collapsing three byte-identical 4-line
blocks into three one-line calls.

## Why it is behaviour-preserving

The SIZE_MAX sentinel (not-found) is **migrated, not rebuilt**, so the
`not2t`/`equality2t` round-trip is byte-identical to the legacy node modulo
the cosmetic `#cpp_type` hint; bool result and operand order are preserved.
Semantics unchanged: `key_found = !(index == SIZE_MAX)`.

## Validation

- Probe `d.get(2,-1)`=20, `d.get(99,-1)`=-1 → `VERIFICATION SUCCESSFUL`.
- 192 dict-cluster tests pass on a Debug/asserts build (get/pop/setdefault +
  general dict + `github_*`), live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
