### PR TITLE
[python] V.3: build dict popitem empty-check + update increment in IREP2

### DIFF
--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -3061,9 +3061,10 @@ exprt python_dict_handler::handle_dict_popitem(
   size_call.location() = location;
   converter_.add_instruction(size_call);
 
-  // Empty dict → raise KeyError
-  exprt is_empty =
-    equality_exprt(build_symbol(size_var), gen_zero(size_type()));
+  // Empty dict → raise KeyError (V.3: build the check in IREP2).
+  expr2tc size2;
+  migrate_expr(build_symbol(size_var), size2);
+  exprt is_empty = migrate_expr_back(equality2tc(size2, gen_zero(size2->type)));
 
   code_blockt empty_block;
   {
@@ -3467,8 +3468,11 @@ exprt python_dict_handler::handle_dict_update(
     dict_expr, key_expr, value_expr, location, call_node, pair_block);
   loop_body.copy_to_operands(pair_block);
 
-  // Advance to the next source entry.
-  exprt next_index = plus_exprt(build_symbol(index_var), gen_one(size_type()));
+  // Advance to the next source entry (V.3: build index + 1 in IREP2).
+  const type2tc size_t2 = migrate_type(size_type());
+  expr2tc idx2;
+  migrate_expr(build_symbol(index_var), idx2);
+  exprt next_index = migrate_expr_back(add2tc(size_t2, idx2, gen_one(size_t2)));
   code_assignt index_update(build_symbol(index_var), next_index);
   index_update.location() = location;
   loop_body.copy_to_operands(index_update);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues the dict operational-model handler work (#5447). Migrate two
single-site builders to IREP2 factories, back-migrated at the legacy seam.

## What

- `handle_dict_popitem` empty-dict check: `equality_exprt(size, 0)` →
  `equality2tc` (feeds the empty → KeyError guard).
- `handle_dict_update` next-index increment: `plus_exprt(index, 1)` →
  `add2tc` (`code_assignt` RHS, `index = index + 1`).

## Why it is behaviour-preserving

`size_var`/`index_var` are `size_type`, so `equality2t`/`add2t` operands
match; `gen_zero`/`gen_one` take the unsignedbv arm (constant 0/1) and the
back-migrated nodes are byte-identical to the legacy ones modulo the
cosmetic `#cpp_type` hint; operand order and bool/`size_type` results
preserved.

## Validation

- `popitem` on `{1:10,2:20}` (unwind 12) → SUCCESSFUL (v=20); `popitem` on
  `{}` → FAILED (the migrated empty-check raises KeyError as expected).
- 187 dict-cluster tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
