### PR TITLE
[python] V.3: build dict-comprehension filter and-fold in IREP2

### DIFF
--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -604,19 +604,18 @@ exprt python_dict_handler::get_dict_comprehension(const nlohmann::json &element)
   {
     // Dict comprehensions may include filters such as
     // {k: v for x in xs if cond1 if cond2}
-    exprt combined_condition = gen_boolean(true);
+    // V.3: build the comprehension filter and-fold in IREP2. The outer guard
+    // guarantees at least one clause, so no `true` sentinel is needed.
+    expr2tc combined2;
+    bool first = true;
     for (const auto &if_clause : generator["ifs"])
     {
-      exprt if_expr = converter_.get_expr(if_clause);
-      if (combined_condition.is_true())
-        combined_condition = if_expr;
-      else
-      {
-        exprt and_expr("and", bool_type());
-        and_expr.copy_to_operands(combined_condition, if_expr);
-        combined_condition = and_expr;
-      }
+      expr2tc c2;
+      migrate_expr(converter_.get_expr(if_clause), c2);
+      combined2 = first ? c2 : and2tc(combined2, c2);
+      first = false;
     }
+    exprt combined_condition = migrate_expr_back(combined2);
 
     codet if_stmt;
     if_stmt.set_statement("ifthenelse");
@@ -731,19 +730,18 @@ exprt python_dict_handler::build_range_dict_comprehension(
 
   if (generator.contains("ifs") && !generator["ifs"].empty())
   {
-    exprt combined_condition = gen_boolean(true);
+    // V.3: build the comprehension filter and-fold in IREP2. The outer guard
+    // guarantees at least one clause, so no `true` sentinel is needed.
+    expr2tc combined2;
+    bool first = true;
     for (const auto &if_clause : generator["ifs"])
     {
-      exprt if_expr = converter_.get_expr(if_clause);
-      if (combined_condition.is_true())
-        combined_condition = if_expr;
-      else
-      {
-        exprt and_expr("and", bool_type());
-        and_expr.copy_to_operands(combined_condition, if_expr);
-        combined_condition = and_expr;
-      }
+      expr2tc c2;
+      migrate_expr(converter_.get_expr(if_clause), c2);
+      combined2 = first ? c2 : and2tc(combined2, c2);
+      first = false;
     }
+    exprt combined_condition = migrate_expr_back(combined2);
 
     codet if_stmt;
     if_stmt.set_statement("ifthenelse");


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues the dict operational-model handler work (#5447, #5448). In both
`get_dict_comprehension` and `build_range_dict_comprehension`, migrate the
filter and-fold (`{k:v for ... if c1 if c2}`) from legacy `exprt` builders
to IREP2 factories, back-migrated at the legacy ifthenelse-cond seam.

## What

```
gen_boolean(true) sentinel + and_exprt fold
  -> first-clause c1, then and2tc(combined, c) left-fold
```

The outer guard guarantees a non-empty `ifs`, so the `true` sentinel +
`is_true()` check is replaced by a `first` flag and dropped entirely.

## Why it is behaviour-preserving

The result is byte-identical (1 clause → c1; n → left-folded `and2tc`),
operand order and bool result preserved, modulo the cosmetic `#cpp_type`
hint. Each if-clause flows through `migrate_expr` (V.1k relaxed assert
covers member/index conditions). No empty-`ifs` path reaches the
back-migrate (guarded), so no null-`expr2tc` hazard.

## Validation

- Probe `{k:v for k,v in src.items() if k>1 if v<40}`=2 (multi-clause
  and-fold) and `{i:i*i for i in range(6) if i%2==0}`=3 (range path) →
  `VERIFICATION SUCCESSFUL`.
- 189 dict-cluster tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
