### PR TITLE
[python] V.3: build dict-comprehension loop step/cond in IREP2

### DIFF
--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -629,14 +629,17 @@ exprt python_dict_handler::get_dict_comprehension(const nlohmann::json &element)
     loop_body.copy_to_operands(pair_block);
   }
 
-  exprt increment("+", size_type());
-  increment.copy_to_operands(build_symbol(index_var), gen_one(size_type()));
+  // V.3: build index + 1 and index < length in IREP2.
+  const type2tc size_t2 = migrate_type(size_type());
+  expr2tc idx2, len2;
+  migrate_expr(build_symbol(index_var), idx2);
+  migrate_expr(length_expr, len2);
+  exprt increment = migrate_expr_back(add2tc(size_t2, idx2, gen_one(size_t2)));
   code_assignt index_increment(build_symbol(index_var), increment);
   index_increment.location() = location;
   loop_body.copy_to_operands(index_increment);
 
-  exprt loop_condition("<", bool_type());
-  loop_condition.copy_to_operands(build_symbol(index_var), length_expr);
+  exprt loop_condition = migrate_expr_back(lessthan2tc(idx2, len2));
 
   codet while_stmt;
   while_stmt.set_statement("while");
@@ -757,16 +760,18 @@ exprt python_dict_handler::build_range_dict_comprehension(
   }
 
   // loop_var = loop_var + 1
-  exprt increment("+", idx_type);
-  increment.copy_to_operands(build_symbol(*loop_var), gen_one(idx_type));
+  // V.3: build loop_var + 1 and loop_var < stop in IREP2.
+  const type2tc idx_t2 = migrate_type(idx_type);
+  expr2tc lv2, stop2;
+  migrate_expr(build_symbol(*loop_var), lv2);
+  migrate_expr(build_symbol(stop_var), stop2);
+  exprt increment = migrate_expr_back(add2tc(idx_t2, lv2, gen_one(idx_t2)));
   code_assignt loop_inc(build_symbol(*loop_var), increment);
   loop_inc.location() = location;
   loop_body.copy_to_operands(loop_inc);
 
   // while (loop_var < stop)
-  exprt loop_condition("<", bool_type());
-  loop_condition.copy_to_operands(
-    build_symbol(*loop_var), build_symbol(stop_var));
+  exprt loop_condition = migrate_expr_back(lessthan2tc(lv2, stop2));
 
   codet while_stmt;
   while_stmt.set_statement("while");


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues the dict operational-model handler work (#5447, #5448, #5449). In
`get_dict_comprehension` and `build_range_dict_comprehension`, migrate the
while-loop increment and condition from legacy `exprt` builders to IREP2
factories, back-migrated at the legacy seams (`code_assignt` RHS, while cond).

## What

```
exprt("+", T)[i, gen_one(T)]  -> add2tc(T, i, gen_one(T))
exprt("<", bool)[i, bound]    -> lessthan2tc(i, bound)
```

## Why it is behaviour-preserving

`get_dict_comprehension`'s counter is `size_type`; `build_range_dict_comprehension`'s
is `long_long` (`idx_type`), so `gen_one` takes the unsignedbv/signedbv arm
(constant 1, never the complex-abort default) and `add2t` arith consistency
holds. The migrated index value is reused for both the step and the condition
(matching the legacy two `build_symbol` calls). Operand order, the index/bound
types and the bool result are preserved, byte-identical modulo `#cpp_type`.

## Validation

- Probe `{k:v for k,v in src.items() if k>1 if v<40}`=2,
  `{i:i*i for i in range(6) if i%2==0}`=3, `{i:i for i in range(5)}`=5 →
  `VERIFICATION SUCCESSFUL` (exercises both loops).
- 189 dict-cluster tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
