### PR TITLE
[python] V.3: build dict subscript/membership predicates in IREP2

### DIFF
--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -948,9 +948,13 @@ exprt python_dict_handler::handle_dict_subscript(
   // If index == SIZE_MAX the key was not found: throw KeyError so that
   // try/except KeyError handlers can catch it (instead of failing the property).
   {
+    // V.3: build the not-found check (index == SIZE_MAX) in IREP2.
     const BigInt size_max_val = power(2, bv_width(size_type())) - 1;
-    constant_exprt size_max(size_max_val, size_type());
-    exprt key_not_found = equality_exprt(build_symbol(index_var), size_max);
+    const constant_exprt size_max(size_max_val, size_type());
+    expr2tc idx2, max2;
+    migrate_expr(build_symbol(index_var), idx2);
+    migrate_expr(size_max, max2);
+    exprt key_not_found = migrate_expr_back(equality2tc(idx2, max2));
 
     std::string keyerror_msg = "KeyError: key not found in dictionary";
     std::string keyerror_type_str = "KeyError";
@@ -1352,7 +1356,12 @@ exprt python_dict_handler::handle_dict_membership(
   exprt contains_result = list_handler.contains(key_expr, keys_member);
 
   if (negated)
-    return not_exprt(contains_result);
+  {
+    // V.3: build the negated-membership result in IREP2.
+    expr2tc cr2;
+    migrate_expr(contains_result, cr2);
+    return migrate_expr_back(not2tc(cr2));
+  }
 
   return contains_result;
 }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues the dict operational-model handler work (#5447–#5450). Migrate two
single-site membership predicates to IREP2 factories, back-migrated at the
legacy seam.

## What

- `handle_dict_subscript` (`d[k]`): the not-found check
  `equality_exprt(index, SIZE_MAX)` → `equality2tc`, feeding the KeyError
  guard.
- `handle_dict_membership` (`k not in d`): `not_exprt(contains_result)` →
  `not2tc`.

## Why it is behaviour-preserving

The SIZE_MAX sentinel is migrated, not rebuilt; `equality2t`/`not2t` have
bool results, preserve operand order, and carry no operand assert, so the
back-migrated nodes are byte-identical to the legacy ones modulo the cosmetic
`#cpp_type` hint. The non-negated membership path (`return contains_result`)
is unchanged.

## Validation

- Probe `1 in d` / `3 not in d` / `2 not in d` / `d[2]` → `SUCCESSFUL`;
  `d[99]` missing → `FAILED` (the migrated not-found check raises KeyError).
- 23 membership/subscript dict tests pass on a Debug/asserts build, live
  `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
