### PR TITLE
[python] V.3: build while-loop lowering conditions in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -2661,12 +2661,16 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
     exprt overall_cond = cond_tmp;
     if (is_wrapped_in_unary)
     {
-      overall_cond = exprt("not", bool_type());
-      overall_cond.copy_to_operands(cond_tmp);
+      // V.3: build the unary-not condition in IREP2.
+      expr2tc ct2;
+      migrate_expr(cond_tmp, ct2);
+      overall_cond = migrate_expr_back(not2tc(ct2));
     }
 
-    exprt break_cond("not", bool_type());
-    break_cond.copy_to_operands(overall_cond);
+    // V.3: build the break guard !cond in IREP2.
+    expr2tc oc2;
+    migrate_expr(overall_cond, oc2);
+    exprt break_cond = migrate_expr_back(not2tc(oc2));
 
     code_breakt break_stmt;
     break_stmt.location() = location;
@@ -2687,7 +2691,8 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
     codet while_code;
     while_code.set_statement("while");
     while_code.location() = location;
-    while_code.copy_to_operands(gen_boolean(true), loop_body);
+    // V.3: build the `while True` condition in IREP2.
+    while_code.copy_to_operands(migrate_expr_back(gen_true_expr()), loop_body);
 
     transformed.copy_to_operands(while_code);
     current_element_type = t;


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `converter_stmt.cpp`. In `python_converter::get_conditional_stm` (the
`while cond:` → `while True: if !cond: break; body` lowering), migrate the
three condition builders from legacy `exprt` to IREP2 factories,
back-migrated at the legacy seam (`code_ifthenelse` cond, while operand).

## What

```
wrapped-unary cond (while not x:): exprt("not")[cond] -> not2tc
break guard (!cond):               exprt("not")[cond] -> not2tc
`while True` condition:            gen_boolean(true)   -> gen_true_expr()
```

## Why it is behaviour-preserving

`not2t`/`gen_true_expr` have bool results (single operand / constant), and
the non-simplifying `not2tc` constructor does no `not(not(x))` folding, so
the back-migrated nodes are byte-identical to the legacy ones modulo the
cosmetic `#cpp_type` hint. `cond_tmp` is a bool temp; no operand assert; no
new location drop (legacy set none on these nodes either).

## Validation

- Probe `while i<5: s+=i; i+=1` → 10, `while not (x>3)` from 0 → 4 iters →
  `VERIFICATION SUCCESSFUL` (exercises wrapped-unary not + break + while-true).
- 115 while/for/loop/break/continue/range tests pass on a Debug/asserts
  build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
