### PR TITLE
[python] V.3: build type-violation asserts in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -2168,7 +2168,8 @@ void python_converter::get_var_assign(
           !expected_base.empty() && !ctor_name.empty() &&
           !get_typechecker().class_derives_from(ctor_name, expected_base))
         {
-          code_assertt ctor_assert(gen_boolean(false));
+          // V.3: build the always-fail assert condition in IREP2.
+          code_assertt ctor_assert(migrate_expr_back(gen_false_expr()));
           ctor_assert.location() = location_begin;
           ctor_assert.location().comment(
             "Constructor '" + ctor_name +
@@ -2207,7 +2208,8 @@ void python_converter::get_var_assign(
       rhs.type().is_array() && !lhs.type().is_array() &&
       !lhs.type().is_pointer())
     {
-      code_assertt type_assert(gen_boolean(false));
+      // V.3: build the always-fail assert condition in IREP2.
+      code_assertt type_assert(migrate_expr_back(gen_false_expr()));
       type_assert.location() = location_begin;
       type_assert.location().comment(
         "Type violation: incompatible types in assignment");


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `converter_stmt.cpp` (#5452). In `python_converter::get_var_assign`,
migrate the two `--is-instance-check`-gated always-fail type-violation
asserts from `gen_boolean(false)` to `gen_false_expr()`, back-migrated at the
legacy `code_assertt` seam:

- `ctor_assert`: constructor incompatible with the annotated base type
- `type_assert`: scalar variable assigned an array value

## Why it is behaviour-preserving

Same idiom as #5432. `gen_false_expr()` is the cached bool-false constant;
`migrate_expr_back` reconstructs `false_exprt` — structurally identical
(id `constant`, bool, value `false`) to `gen_boolean(false)`. The cached
singleton is read by const reference and copied into a fresh `exprt`; no
reference escapes. Location/comment and target-block wiring unchanged.

## Validation

- Probe `x: int = 5; x = "hello"` `--is-instance-check` → FAILED
  (`type_assert`); `a: Animal = Car()` → FAILED "Constructor 'Car' is
  incompatible..." (`ctor_assert`).
- 66 type-annotation/isinstance tests pass on a Debug/asserts build, live
  `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
