### PR TITLE
[python] V.3: build any()/all() scalar truthiness in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -1627,8 +1627,9 @@ exprt function_call_expr::handle_print() const
 
 exprt function_call_expr::compute_element_truthiness(const exprt &element) const
 {
+  // V.3: build the scalar truthiness predicate in IREP2.
   if (element.type() == none_type())
-    return gen_boolean(false);
+    return migrate_expr_back(gen_false_expr());
 
   if (element.type().is_bool())
     return element;
@@ -1636,13 +1637,18 @@ exprt function_call_expr::compute_element_truthiness(const exprt &element) const
   if (
     element.type().id() == "signedbv" || element.type().id() == "unsignedbv" ||
     element.type().id() == "floatbv" || element.type().is_pointer())
-    return not_exprt(equality_exprt(element, gen_zero(element.type())));
+  {
+    // element != 0
+    expr2tc el2;
+    migrate_expr(element, el2);
+    return migrate_expr_back(not2tc(equality2tc(el2, gen_zero(el2->type))));
+  }
 
   if (is_complex_type(element.type()))
     return complex_to_bool_expr(element);
 
   // For other types, assume truthy (conservative)
-  return gen_boolean(true);
+  return migrate_expr_back(gen_true_expr());
 }
 
 exprt function_call_expr::handle_any_all(ReduceOp op, const char *name)


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `function_call/builtins.cpp`. In
`function_call_expr::compute_element_truthiness` (the per-element predicate
for `any()`/`all()` and numpy reductions), migrate the three scalar-truthiness
return builders from legacy `exprt` to IREP2 factories, back-migrated at the
legacy fold seam.

## What

```
None             -> gen_boolean(false)              -> gen_false_expr()
numeric/pointer  -> not_exprt(equality_exprt(e, 0)) -> not2tc(equality2tc)
other            -> gen_boolean(true)               -> gen_true_expr()
```

The bool branch (`return element`) and complex branch (`complex_to_bool_expr`)
are unchanged, and the type-dispatch order is identical.

## Why it is behaviour-preserving

The numeric branch is guarded to signedbv/unsignedbv/floatbv/pointer, so
`gen_zero` never hits the complex/default abort; the pointer case builds
`symbol2tc("NULL")` which `migrate_expr_back` special-cases back to a constant
`"NULL"` pointer == legacy `gen_zero(pointer)`. Each factory is the exact
migrate of its legacy builder, byte-identical modulo the cosmetic `#cpp_type`
hint.

## Validation

- Probe `all([1,2,3])`=T, `all([1,0,3])`=F, `any([0,0,5])`=T, `any([0,0,0])`=F
  → `VERIFICATION SUCCESSFUL`.
- 26 any/all + 38 numpy/builtin/reduce tests pass on a Debug/asserts build,
  live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
