### PR TITLE
[docs] Sync Python NumPy docs with #5381–#5447

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -117,7 +117,7 @@ weight: 4
 - Arrays are modelled with a restricted subset: `.shape` is available for modelled arrays, tuple indexing is lowered through chained indexing, and direct scalar broadcasting still covers simple binary operators such as `a + n` and `a * n`. Higher-dimensional arrays are rejected explicitly; full NumPy dtype semantics and unrestricted N-dimensional indexing remain unsupported.
 - Element-wise `np.add`/`np.subtract`/`np.multiply`/`np.divide`/`np.power` support literal list-backed 1D/2D inputs with NumPy-style broadcasting. Runtime-constructed inputs and higher-dimensional inputs are rejected with deterministic frontend errors rather than falling through to the SMT backend.
 - Only the NumPy functions listed in [Supported Features — NumPy](./supported-features#numpy-module-numpy) have executable support.
-- The remaining type-inference-only stubs are `np.arccos`, `np.fmod`, `np.dot`, `np.matmul`, and `np.transpose`.
+- `np.arccos`, `np.fmod`, `np.transpose`, `np.dot`, and `np.matmul` now lower to executable models (they were previously type-inference-only stubs), each under a stated restriction: `np.arccos` rejects runtime 2D arrays; `np.fmod` rejects `np.array(...)`-wrapped operands (`Unsupported operation: numpy.fmod on array operands`); `np.transpose` is limited to 2D and rejects higher rank; `np.dot`/`np.matmul` cover 1D/2D integer and float inputs.
 - `numpy.linalg.det` supports constant numeric 2x2 and 3x3 matrices. Other `numpy.linalg` operations, complex determinants, runtime-constructed matrices, and larger matrix sizes are not supported.
 
 ## Exception Handling

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -441,8 +441,14 @@ Partial executable support for list-backed arrays, element-wise arithmetic, sele
 
 **Complex elements**: element-wise complex arithmetic (`add`/`subtract`/`multiply`/`divide`) on complex scalars and arrays, plus `np.conjugate(z)` and `.real`/`.imag` on complex results; division by zero is reported. Complex determinants are rejected (see [Limitations](./limitations#numpy-module))
 
-**Math**: `np.ceil(x)`, `np.floor(x)`, `np.fabs(x)`, `np.sqrt(x)`, `np.trunc(x)`, `np.round(x)`, `np.copysign(x, y)`, `np.fmin(x, y)`, `np.fmax(x, y)`, `np.sin(x)`, `np.cos(x)`, `np.arctan(x)`, `np.exp(x)` on scalar or literal list-backed 1D/2D inputs
+**Math**: `np.ceil(x)`, `np.floor(x)`, `np.fabs(x)`, `np.sqrt(x)`, `np.trunc(x)`, `np.round(x)`, `np.copysign(x, y)`, `np.fmin(x, y)`, `np.fmax(x, y)`, `np.sin(x)`, `np.cos(x)`, `np.arctan(x)`, `np.arccos(x)`, `np.exp(x)` on scalar or literal list-backed 1D/2D inputs. `np.arccos` additionally lowers a runtime 1D array through the libm operational model; a runtime 2D `arccos` is still rejected.
 
-**Additional stubs** (return constant placeholder values for type inference only): `np.arccos(x)`, `np.fmod(x)`, `np.dot(a, b)`, `np.matmul(a, b)`, `np.transpose(a, b)`
+**Modulo**: `np.fmod(x, y)` on scalars and on literal list-backed 1D/2D inputs with NumPy-style broadcasting. Operands wrapped in `np.array(...)` are rejected with `Unsupported operation: numpy.fmod on array operands` rather than mis-folded to a scalar.
 
-**Linear algebra** (`numpy.linalg`): `np.linalg.det(a)` for constant numeric 2x2 and 3x3 matrices
+**Element-wise float ufuncs**: `np.add`/`np.subtract`/`np.multiply`/`np.divide` on float arrays dispatch to a typed `*_double` operational model instead of reinterpreting IEEE-754 payloads as `int64`. The `--python-no-fold` flag suppresses the frontend's constant-folding paths and forces SMT encoding (useful for differential testing of the folder against the encoder).
+
+**Linear algebra**:
+
+- `np.dot(a, b)`, `np.matmul(a, b)`: 1D/2D inputs with both integer and float backends (via `linalg.c`), including symbolic elements
+- `np.transpose(a)`: 2D arrays, including runtime array variables (1D is the identity); higher-rank transpose is rejected
+- `np.linalg.det(a)`: constant numeric 2x2 and 3x3 matrices (complex-valued matrices are rejected)

--- a/website/content/docs/python/usage.md
+++ b/website/content/docs/python/usage.md
@@ -32,6 +32,7 @@ esbmc main.py --unwind 10
 | `--incremental-bmc` | Increase the unwind bound incrementally until a bug is found or the bound is reached |
 | `--multi-property` | Continue verification after the first failure, reporting all violated properties |
 | `--strict-types` | Enable strict type checking for function arguments at verification time |
+| `--python-no-fold` | Disable NumPy constant folding in the Python frontend, forcing SMT encoding (useful for differential testing of the folding paths) |
 | `--branch-coverage` | Instrument branch-coverage properties (useful with `--generate-pytest-testcase`) |
 | `--k-path-coverage[=N]` | Instrument k-path coverage with prefix length `N` (see [Coverage](../coverage#k-path-coverage)). Use with `--generate-pytest-testcase` for higher-coverage test discovery. |
 | `--k-path-witness-depth=D` | Cap post-simplification guard depth for k-path witnesses (default 8). |


### PR DESCRIPTION
## What

Sync the public Python documentation (https://esbmc.github.io/docs/python/) with the NumPy-related PRs merged since the last sync (#5349, which covered through #5338).

Most commits in the window are internal IREP2-migration refactors or crash fixes to already-documented features (no contract change). The genuine doc gap was NumPy, where several functions moved from stubs to executable lowering:

- **#5422** — `np.fmod`, `np.arccos`, `np.transpose` gained real (restricted) lowering
- **#5403** — float ufuncs route through a typed `*_double` operational model; `linalg.det` rejects complex matrices
- **#5430** — new `--python-no-fold` CLI flag; exact integer `power`

The public docs still listed `np.arccos`, `np.fmod`, `np.dot`, `np.matmul`, `np.transpose` as "type-inference-only stubs", which was inaccurate (`dot`/`matmul` already had `linalg.c` backends).

## Changes

- **supported-features.md** — add `np.arccos` to Math; new Modulo entry for `np.fmod`; new element-wise-float-ufunc note (`--python-no-fold`); replace the obsolete "Additional stubs" line with a proper Linear-algebra list (`dot`/`matmul`/`transpose`/`det`), each with its real restriction.
- **limitations.md** — replace the stale "remaining stubs" line with accurate per-function restrictions (runtime-2D `arccos` rejected; `np.array(...)` `fmod` operands rejected; `transpose` 2D-only; `dot`/`matmul` 1D/2D int+float).
- **usage.md** — add `--python-no-fold` to the Useful Flags table.

## Verification

Documentation-only change. Every claim was cross-checked against the `regression/numpy/` tests (`fmod_broadcast`, `fmod_array_unsupported`, `arccos_array_success`, `transpose2`, `transpose7`, `dot6`) and the flag string in `src/esbmc/options.cpp`.