### PR TITLE
[docs] Cross-link contracts theory to how-to Two modes section

### DIFF
--- a/website/content/docs/theory/function-contracts.md
+++ b/website/content/docs/theory/function-contracts.md
@@ -36,6 +36,12 @@ obligations:
   assume the postcondition. This lets a caller be verified against the
   *specification* of its callees, without unrolling their bodies.
 
+The concrete checking harness for each obligation — the exact ordering of
+assume/assert/havoc steps and the flags that drive them
+(`--enforce-contract`, `--replace-call-with-contract`) — is given in the how-to
+guide's [Two modes](/docs/function-contracts#two-modes-enforce-and-replace)
+section.
+
 Enforcing each function once and replacing it everywhere it is called yields a
 proof whose cost does not blow up with call depth — the key scalability win over
 inlining everything into one [bounded model checking](/docs/theory/verification-algorithms#bmc)


### PR DESCRIPTION
## What

Adds an explicit cross-reference from the **theory** page
(`docs/theory/function-contracts.md`) enforce/replace proof-obligation bullets
to the **how-to** guide's [Two modes](https://esbmc.github.io/docs/function-contracts/#two-modes-enforce-and-replace)
section.

## Why

A review of the three contracts-related docs pages — `constructs` (reference),
`function-contracts` (how-to), and `theory/function-contracts` (theory) —
confirmed they are **not** redundant and are already cleanly layered with
intentional cross-links. The only conceptual overlap was that both the theory
page and the how-to describe the enforce/replace duality: the theory page as
abstract proof obligations, the how-to as concrete harness steps and CLI flags.

This change tightens that one spot of overlap by pointing readers who want the
mechanical detail (assume/assert/havoc ordering, `--enforce-contract` /
`--replace-call-with-contract`) directly at the how-to, so the theory page keeps
its conceptual framing without restating the practical steps. No content was
removed and no pages were merged.

Docs-only Markdown change; no code or tests affected.