### PR TITLE
[docs] Sync C++ exception OM (#5326) and contracts array-assigns bound (#5409)

### DIFF
--- a/website/content/docs/c-cpp/ESBMC-Cpp-Support.md
+++ b/website/content/docs/c-cpp/ESBMC-Cpp-Support.md
@@ -65,6 +65,10 @@ The standard given is the one the test exercises (`--std`).
 - `noexcept` / `throw()` exception specifications are lowered under `--lower-exceptions` (`regression/esbmc-cpp/try_catch/lower-exceptions_noexcept_*`, `exception_spec_noexcept_*`)
 - `dynamic_cast<T&>` throws `std::bad_cast` on a failed reference cast
 - Virtual base destructor and member/base destructor-chain synthesis fixes
+- `<exception>` operational model: `std::exception_ptr` with `current_exception` / `rethrow_exception` / `make_exception_ptr`, and nested exceptions (`throw_with_nested` / `rethrow_if_nested`). The per-thread handled-exception stack and uncaught counter are instrumented pay-per-use — only when the program touches them (`lower-exceptions_make_exception_ptr`, `lower-exceptions_exception_ptr_rethrow`, `lower-exceptions_nested_rethrow`)
+- `std::uncaught_exception` / `std::uncaught_exceptions` via a lowered per-thread count (`lower-exceptions_uncaught_count`)
+- `std::vector::at` throws `std::out_of_range` instead of asserting (`try-catch_vector_02_bug`); `std::bad_cast` / `std::bad_typeid` derive from `std::exception` with a virtual `what()`
+- Concurrent exceptions: the exception-state globals are thread-local, so each thread raises, catches, and clears its own in-flight exception independently — concurrently-throwing programs are lowered directly rather than rejected (`lower-exceptions_concurrent`). A pthread start routine reached through a computed pointer (or also called directly) cannot get a sound per-function uncaught-escape check and is declined as unsupported; declining is sound — it never validates a buggy program (`lower-exceptions_concurrent_dualuse`)
 
 # Features WIP:
 - Fixing our OMs for STL libraries

--- a/website/content/docs/function-contracts.md
+++ b/website/content/docs/function-contracts.md
@@ -452,8 +452,12 @@ document each one explicitly.
 
 **Array assigns is bounded to 100 elements.** The nondet-witness approach used
 for `__ESBMC_assigns(arr[i])` ranges over indices 0 to 99
-(`ARRAY_ALLOC_ELEMS = 100`). If `i` can exceed 99, assigns compliance for
-out-of-range writes will not be detected.
+(`ARRAY_ALLOC_ELEMS = 100`) for arrays allocated by the validity-assumption
+pass. If `i` can exceed 99, assigns compliance for out-of-range writes will not
+be detected. When the array pointer was allocated by `__ESBMC_is_fresh(a, n)`,
+the witness index is instead bounded by the real element count (`n /
+sizeof(elem)`), so an in-bounds element of a buffer smaller than 100 no longer
+reports a spurious bounds violation.
 
 **Global array element assigns is unsupported.** `__ESBMC_assigns(global[i])`
 does not work correctly for global arrays. Use `__ESBMC_assigns(global)` (the


### PR DESCRIPTION
## What

Follow-up to #5455 (Python docs). I audited the rest of the docs site against PRs merged since the last doc refresh (~June 13). Two non-Python sections were out of date:

### C++ support — `<exception>` operational model (#5326)
`ESBMC-Cpp-Support.md` was last touched the day before #5326 merged, so its "Exceptions and destructors" section omits the new exception OM. Added bullets (each citing its regression test under `regression/esbmc-cpp/try_catch/`):
- `std::exception_ptr` + `current_exception`/`rethrow_exception`/`make_exception_ptr`, nested exceptions (`throw_with_nested`/`rethrow_if_nested`), pay-per-use instrumentation
- `std::uncaught_exception(s)` via a lowered per-thread count
- `std::vector::at` → `std::out_of_range`; `std::bad_cast`/`std::bad_typeid` derive from `std::exception`
- Concurrent (thread-local) exception lowering; computed-pointer/dual-use pthread start routines declined as unsupported (sound)

### Function contracts — is_fresh array-assigns bound (#5409)
Refined the "Array assigns is bounded to 100 elements" known-limitation to note that `__ESBMC_is_fresh(a, n)` buffers are now bounded by their real element count (`n / sizeof(elem)`), so an in-bounds element of a sub-100 buffer no longer reports a spurious bounds violation.

## Other PRs reviewed — no doc change needed
- POSIX socket/select/poll OM (#5388), calloc zero-size (#5404), memchr (#5345): no doc catalogs C library functions, so there is no home for them.
- Contracts bug fixes #5043 (spurious SAME-OBJECT), #5313 (recursive `--enforce-contract` unwinding): correctness fixes with no documented behavior to change.
- `--no-reachable-memory-leak` memtrack leak (#5419), witness column (#5421), IEEE NaN predicates (#5416): internal correctness fixes.

## Verification
Documentation-only. All cited C++ tests exist under `regression/esbmc-cpp/try_catch/`; the is_fresh bound was confirmed against `src/goto-programs/contracts/contracts.cpp` and `#5314`.