### PR TITLE
[python] V.3: build any()/all() reduction fold in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -215,9 +215,12 @@ bool is_empty_literal(const nlohmann::json &node)
 
 exprt function_call_expr::combine_truthiness(exprt acc, exprt next, ReduceOp op)
 {
-  return (op == ReduceOp::Any)
-           ? exprt(or_exprt(std::move(acc), std::move(next)))
-           : exprt(and_exprt(std::move(acc), std::move(next)));
+  // V.3: build the any/all reduction fold in IREP2.
+  expr2tc a2, n2;
+  migrate_expr(acc, a2);
+  migrate_expr(next, n2);
+  return migrate_expr_back(
+    op == ReduceOp::Any ? or2tc(a2, n2) : and2tc(a2, n2));
 }
 
 exprt function_call_expr::handle_input() const


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `function_call/builtins.cpp` (#5454, which migrated the per-element
`compute_element_truthiness`). Migrate `function_call_expr::combine_truthiness`
(the fold combining element truthiness across an `any()`/`all()` reduction)
from legacy `exprt` builders to IREP2 factories, back-migrated at the legacy
fold-loop seam.

## What

```
Any -> or_exprt(acc, next)   -> or2tc(acc, next)
All -> and_exprt(acc, next)  -> and2tc(acc, next)
```

## Why it is behaviour-preserving

`acc`/`next` are bool truthiness values, so `or2t`/`and2t` (result fixed
bool, operand order preserved) are the exact migrate of `or_exprt`/`and_exprt`;
the back-migrated node is byte-identical modulo the cosmetic `#cpp_type` hint.
The ReduceOp dispatch is unchanged and the helper keeps its legacy `exprt`
signature so the fold-loop consumer needs no change.

## Validation

- Probe `all([1,2,3])`=T, `all([1,0,3])`=F, `any([0,0,5])`=T, `any([0,0,0])`=F
  → `VERIFICATION SUCCESSFUL`.
- 32 any/all/numpy/builtin tests pass on a Debug/asserts build, live
  `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
