### PR TITLE
[python] V.3: build any()/all() literal-reduction constants in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -1707,13 +1707,15 @@ exprt function_call_expr::reduce_iterable_literal_truthiness(
   const auto &elts = iterable_arg["elts"];
 
   if (elts.empty())
-    return gen_boolean(op == ReduceOp::All);
+    // V.3: empty reduction -> all()=True, any()=False (built in IREP2).
+    return migrate_expr_back(
+      op == ReduceOp::All ? gen_true_expr() : gen_false_expr());
 
   std::optional<exprt> result;
   for (const auto &elt : elts)
   {
     exprt is_truthy = is_empty_literal(elt)
-                        ? gen_boolean(false)
+                        ? migrate_expr_back(gen_false_expr()) // V.3
                         : compute_element_truthiness(converter_.get_expr(elt));
     result = result ? combine_truthiness(std::move(*result), is_truthy, op)
                     : is_truthy;
@@ -1729,7 +1731,9 @@ exprt function_call_expr::reduce_tuple_expr_truthiness(
   const auto &components = tuple_type.components();
 
   if (components.empty())
-    return gen_boolean(op == ReduceOp::All);
+    // V.3: empty reduction -> all()=True, any()=False (built in IREP2).
+    return migrate_expr_back(
+      op == ReduceOp::All ? gen_true_expr() : gen_false_expr());
 
   std::optional<exprt> result;
   for (const auto &component : components)


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `function_call/builtins.cpp` (#5454, #5458). In the literal/tuple
`any()`/`all()` fast paths (`reduce_iterable_literal_truthiness`,
`reduce_tuple_expr_truthiness`), migrate the remaining constant-bool builders
from `gen_boolean` to `gen_true_expr`/`gen_false_expr`, back-migrated at the
legacy return seam.

## What

```
empty reduction:        gen_boolean(op == ReduceOp::All)
   -> op == ReduceOp::All ? gen_true_expr() : gen_false_expr()
empty-literal element:  gen_boolean(false) -> gen_false_expr()
```

## Why it is behaviour-preserving

These are pure bool constants; `gen_true_expr`/`gen_false_expr` are the
cached true/false constants and back-migrate to constant `"true"`/`"false"`
identical to `gen_boolean` (same idiom as #5432/#5454), byte-identical modulo
the cosmetic `#cpp_type` hint. The `all()`=True / `any()`=False empty
semantics are unchanged.

## Validation

- Probe `all([])`=T, `any([])`=F, `all([[1],[]])`=F (empty list falsy),
  `any([[],[2]])`=T → `VERIFICATION SUCCESSFUL`.
- 32 any/all/numpy/builtin tests pass on a Debug/asserts build, live
  `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
