### PR TITLE
[python] V.3: build min()/max() selection chains in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -1522,14 +1522,30 @@ exprt function_call_expr::handle_min_max(
           exprt elem =
             build_member(arg, components[i].get_name(), components[i].type());
 
-          // Create comparison: elem < result (for min) or elem > result (for max)
-          exprt condition(comparison_op, type_handler_.get_typet("bool", 0));
-          condition.copy_to_operands(elem, result);
-
-          // result = (elem < result) ? elem : result
-          if_exprt update(condition, elem, result);
-          update.type() = components[i].type();
-          result = update;
+          // result = (elem < result) ? elem : result  (> for max).
+          // V.3: build the select in IREP2 when both branches share the
+          // result type; mixed-type tuple components keep the legacy builder
+          // (if2t asserts type-id equality).
+          const typet &ut = components[i].type();
+          if (elem.type() == ut && result.type() == ut)
+          {
+            const type2tc ut2 = migrate_type(ut);
+            expr2tc elem2, result2;
+            migrate_expr(elem, elem2);
+            migrate_expr(result, result2);
+            expr2tc cond = comparison_op == exprt::i_lt
+                             ? lessthan2tc(elem2, result2)
+                             : greaterthan2tc(elem2, result2);
+            result = migrate_expr_back(if2tc(ut2, cond, elem2, result2));
+          }
+          else
+          {
+            exprt condition(comparison_op, type_handler_.get_typet("bool", 0));
+            condition.copy_to_operands(elem, result);
+            if_exprt update(condition, elem, result);
+            update.type() = ut;
+            result = update;
+          }
         }
 
         return result;
@@ -1577,17 +1593,21 @@ exprt function_call_expr::handle_min_max(
       e = build_typecast(e, result_type);
 
   // Fold: result = exprs[0]; for each subsequent arg update via if-expr.
-  exprt result = exprs[0];
+  // V.3: build the min/max selection chain in IREP2. All args are already
+  // promoted to result_type, so the if2t branch types agree.
+  const type2tc rt2 = migrate_type(result_type);
+  expr2tc result2;
+  migrate_expr(exprs[0], result2);
   for (size_t i = 1; i < exprs.size(); ++i)
   {
-    exprt condition(comparison_op, type_handler_.get_typet("bool", 0));
-    condition.copy_to_operands(exprs[i], result);
-    if_exprt update(condition, exprs[i], result);
-    update.type() = result_type;
-    result = update;
+    expr2tc e2;
+    migrate_expr(exprs[i], e2);
+    expr2tc cond = comparison_op == exprt::i_lt ? lessthan2tc(e2, result2)
+                                                : greaterthan2tc(e2, result2);
+    result2 = if2tc(rt2, cond, e2, result2);
   }
 
-  return result;
+  return migrate_expr_back(result2);
 }
 
 exprt function_call_expr::handle_print() const


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `function_call/builtins.cpp` (#5454/#5458/#5459). In
`function_call_expr::handle_min_max`, migrate both `min`/`max` selection
chains from legacy `exprt` builders to IREP2 factories. `comparison_op`
(`i_lt` for min, `i_gt` for max) dispatches to `lessthan2tc`/`greaterthan2tc`;
the select becomes `if2tc(T, cond, elem, result)`.

## What

- **N-arg chain** (`min(a,b,c,...)`): all args are pre-promoted to
  `result_type`, so the if2t branch type-ids agree → built unconditionally
  in IREP2, accumulated and back-migrated once at the return.
- **Tuple chain** (`min((a,b,c))`): components may differ in type. Guarded
  by full-type equality (`elem.type()==ut && result.type()==ut`); mixed-type
  components fall back to the byte-identical legacy `if_exprt` builder, since
  `if2t` asserts type-id equality (cf. #5433).

## Why it is behaviour-preserving

Operand order (elem first, result second; then=elem, else=result) and the
left-fold associativity are preserved, so each migrated node is byte-identical
to the legacy one modulo the cosmetic `#cpp_type` hint. The full-type guard is
conservatively stronger than `if2t`'s type-id-only assert.

## Validation

- Probe `min(5,2,8,1)`=1, `max`=8, `min((7,3,9,4))`=3, `max`=9,
  `max(1,2.5,2)`=2.5 (mixed N-arg promote) → SUCCESSFUL; `min((1,2.5,2))`=1.0
  (mixed tuple → legacy fallback) → SUCCESSFUL, no abort.
- 17 min/max tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
