### PR TITLE
[python] quixbugs/bitcount_fail: detect non-termination via unwinding assertion

### DIFF
--- a/regression/quixbugs/bitcount_fail/test.desc
+++ b/regression/quixbugs/bitcount_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc
+--unwind 9 --no-standard-checks --smt-during-symex --smt-symex-guard --bitwuzla
 ^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes #4779 (part of #4778).

## Problem

`regression/quixbugs/bitcount_fail` was marked `KNOWNBUG`. The buggy variant uses `n ^= n - 1` (correct is `n &= n - 1`), which leaves `n == 1` forever for inputs like `127` — a genuine infinite loop. Under `--incremental-bmc` the bug never surfaces as an assertion violation (the asserts sit after the non-terminating loop), so ESBMC unwound indefinitely and reported `VERIFICATION UNKNOWN` instead of the expected `VERIFICATION FAILED`.

## Fix

Switch the test from `--incremental-bmc` to a bounded `--unwind 9` run with unwinding assertions enabled (matching the convention used by sibling `_fail` tests such as `gcd_fail`, `pascal_fail`). The unwinding assertion fires on the infinite loop and yields `VERIFICATION FAILED`, faithfully detecting the QuixBugs bug. Promotes the test `KNOWNBUG` → `CORE`. The buggy `main.py` is left untouched — the bug is the point of the test.

## Verification

- `ctest -R "^regression/quixbugs/bitcount_fail$"` → **Passed** (`unwinding assertion loop 146` → `VERIFICATION FAILED`).
- `bitcount` (passing variant) → still **Passed**, no collateral impact.