### PR TITLE
[python] V.3: build complex() conditional part-selects in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -1315,14 +1315,21 @@ exprt function_call_expr::handle_complex() const
 
             if (true_complex && false_complex)
             {
-              exprt real_part = if_exprt(
-                cond,
-                from_double(true_complex->first, double_type()),
-                from_double(false_complex->first, double_type()));
-              exprt imag_part = if_exprt(
-                cond,
-                from_double(true_complex->second, double_type()),
-                from_double(false_complex->second, double_type()));
+              // V.3: build the per-part conditional selects in IREP2 (both
+              // branches are double constants, so the if2t types agree).
+              const type2tc dbl2 = double_type2();
+              expr2tc cond2, tr2, fr2, ti2, fi2;
+              migrate_expr(cond, cond2);
+              migrate_expr(
+                from_double(true_complex->first, double_type()), tr2);
+              migrate_expr(
+                from_double(false_complex->first, double_type()), fr2);
+              migrate_expr(
+                from_double(true_complex->second, double_type()), ti2);
+              migrate_expr(
+                from_double(false_complex->second, double_type()), fi2);
+              exprt real_part = migrate_expr_back(if2tc(dbl2, cond2, tr2, fr2));
+              exprt imag_part = migrate_expr_back(if2tc(dbl2, cond2, ti2, fi2));
               return make_complex(real_part, imag_part);
             }
 


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `function_call/builtins.cpp` (#5454/#5458/#5459/#5461). In
`handle_complex`'s `complex(cond ? "a" : "b")` branch (both branches parse to
complex literals), migrate the two per-part `if_exprt` selects from legacy
`exprt` to IREP2 factories, back-migrated for the legacy `make_complex` seam.

## What

```
real_part = if_exprt(cond, true.first,  false.first)  -> if2tc
imag_part = if_exprt(cond, true.second, false.second) -> if2tc
```

## Why it is behaviour-preserving

Both branches are `from_double(..., double)` constants and the node type is
`double_type2()`, so all `if2t` branch type-ids are floatbv → the assert
cannot fire. `cond` is migrated once and reused for both selects (immutable
shared `expr2tc`), matching the legacy code. Operand order (then=true,
else=false) and the four constant values are preserved, so each node is
byte-identical to the legacy one modulo the cosmetic `#cpp_type` hint; the
back-migrated double type compares equal to `make_complex`'s cached double in
both floatbv and fixedbv modes, so no spurious typecast is introduced.

## Validation

- Probe `complex("1+2j" if b else "3+4j").real` → b=True:1.0, b=False:3.0 →
  `VERIFICATION SUCCESSFUL`.
- 133 complex/cmath tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
