### PR TITLE
[python] V.3: build tuple lexicographic compare in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1227,19 +1227,24 @@ exprt python_converter::handle_tuple_operations(
       migrate_expr(tb, b2);
 
       // Base: a proper prefix is strictly less than the longer tuple.
-      exprt result = gen_boolean(ca.size() < cb.size());
+      // V.3: build the lexicographic compare in IREP2.
+      expr2tc result =
+        ca.size() < cb.size() ? gen_true_expr() : gen_false_expr();
       for (size_t k = m; k-- > 0;)
       {
         exprt ai = memb(a2, ca[k]);
         exprt bi = memb(b2, cb[k]);
 
-        exprt lt, eq;
+        expr2tc lt, eq;
         const bool ai_tuple = tuple_handler_->is_tuple_type(ai.type());
         const bool bi_tuple = tuple_handler_->is_tuple_type(bi.type());
         if (ai_tuple && bi_tuple)
         {
-          lt = lex_lt(ai, bi);
-          eq = equality_exprt(ai, bi); // native struct equality, element-wise
+          expr2tc ai2, bi2;
+          migrate_expr(lex_lt(ai, bi), lt);
+          migrate_expr(ai, ai2);
+          migrate_expr(bi, bi2);
+          eq = equality2tc(ai2, bi2); // native struct equality, element-wise
         }
         else if (is_num(ai.type()) && is_num(bi.type()))
         {
@@ -1249,23 +1254,22 @@ exprt python_converter::handle_tuple_operations(
             ai = typecast_exprt(ai, double_type());
             bi = typecast_exprt(bi, double_type());
           }
-          lt = exprt("<", bool_type());
-          lt.copy_to_operands(ai, bi);
-          eq = equality_exprt(ai, bi);
+          expr2tc ai2, bi2;
+          migrate_expr(ai, ai2);
+          migrate_expr(bi, bi2);
+          lt = lessthan2tc(ai2, bi2);
+          eq = equality2tc(ai2, bi2);
         }
         else
         {
           ok = false; // unsupported / mismatched component kinds
-          return gen_boolean(false);
+          return migrate_expr_back(gen_false_expr());
         }
 
-        exprt tail("and", bool_type());
-        tail.copy_to_operands(eq, result);
-        exprt head("or", bool_type());
-        head.copy_to_operands(lt, tail);
-        result = head;
+        // result = lt || (eq && result)
+        result = or2tc(lt, and2tc(eq, result));
       }
-      return result;
+      return migrate_expr_back(result);
     };
 
     const bool swap = (op == "Gt" || op == "LtE");


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `converter_binop.cpp` (#5433). Migrate the `lex_lt` lambda in
`python_converter::handle_tuple_operations` (recursive tuple lexicographic
less-than powering tuple `<` / `<=` / `>` / `>=`) from legacy `exprt`
builders to IREP2 factories, back-migrated once at the lambda's `exprt`
return boundary.

## What

```
base prefix:  gen_boolean(ca.size()<cb.size())
   -> ca.size()<cb.size() ? gen_true_expr() : gen_false_expr()
equality_exprt -> equality2tc   (native struct eq for nested tuples;
                                 double-promoted operands for mixed int/float)
exprt("<")     -> lessthan2tc
fold: or(lt, and(eq, result)) -> or2tc(lt, and2tc(eq, result))
unsupported:   gen_boolean(false) -> gen_false_expr()
```

## Why it is behaviour-preserving

Each factory is the exact migrate of its legacy builder (bool results,
operand order and the right-to-left fold associativity preserved); the
recursive `lex_lt` call keeps its `exprt` signature and is migrated into
`lt`. `equality2t` carries no operand assert, so native struct equality on
nested tuples does not abort; the numeric branch promotes mixed pairs to
double so both operands share a type. Byte-identical modulo the cosmetic
`#cpp_type` hint.

## Validation

- Probe `(1,2)<(1,3)`=T, `(1,2,3)>(1,2)`=T (prefix), `(1,2.5)<(1,3)`=T
  (mixed), `((1,2),3)<((1,2),4)`=T (nested recursive), `(2,0)<(1,9)`=F →
  `VERIFICATION SUCCESSFUL`.
- 6 `tuple_ordering` + 49 tuple/sorted tests pass on a Debug/asserts build,
  live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
