### PR TITLE
[python] V.3: build "not in" membership negation in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -347,7 +347,12 @@ exprt python_converter::handle_membership_operator(
   {
     python_list list(*this, element);
     exprt contains_expr = list.contains(lhs, rhs);
-    return invert ? not_exprt(contains_expr) : contains_expr;
+    if (!invert)
+      return contains_expr;
+    // V.3: build the "not in" negation in IREP2.
+    expr2tc c2;
+    migrate_expr(contains_expr, c2);
+    return migrate_expr_back(not2tc(c2));
   }
 
   // Get string type identifiers
@@ -362,7 +367,12 @@ exprt python_converter::handle_membership_operator(
   {
     exprt membership_expr =
       string_handler_.handle_string_membership(lhs, rhs, element);
-    return invert ? not_exprt(membership_expr) : membership_expr;
+    if (!invert)
+      return membership_expr;
+    // V.3: build the "not in" negation in IREP2.
+    expr2tc m2;
+    migrate_expr(membership_expr, m2);
+    return migrate_expr_back(not2tc(m2));
   }
 
   throw std::runtime_error(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `converter_binop.cpp` (#5433, #5465). In
`python_converter::handle_membership_operator`, migrate the two `not in`
negations from legacy `not_exprt` to the IREP2 `not2tc` factory,
back-migrated at the legacy return seam.

## What

```
list/set membership: not_exprt(contains_expr)   -> not2tc
string membership:   not_exprt(membership_expr) -> not2tc
```

## Why it is behaviour-preserving

`contains_expr`/`membership_expr` are bool, so `not2t` (fixed bool result,
single operand) is the exact migrate of `not_exprt`; the back-migrated node
is byte-identical modulo the cosmetic `#cpp_type` hint. The plain `in` path
(non-inverted) returns the unwrapped expr unchanged.

## Validation

- Probe `5 not in [1,2,3]` → True, `"x" not in "hello"` → True →
  `VERIFICATION SUCCESSFUL`.
- 32 in/not-in tests + 425 string/membership tests pass on a Debug/asserts
  build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
