### PR TITLE
[python] V.3: build binop constant-fold results in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -456,7 +456,9 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
         nondet.location() = get_location_from_decl(element);
         return nondet;
       }
-      return gen_boolean(op == "NotEq");
+      // V.3: constant fold built in IREP2.
+      return migrate_expr_back(
+        op == "NotEq" ? gen_true_expr() : gen_false_expr());
     }
   }
 
@@ -517,7 +519,11 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     // --incremental-bmc, where each k iteration would otherwise re-symbolise
     // the comparison from scratch (issue #4623).
     if (auto folded = dict_handler_->try_constant_fold_eq(left, right))
-      return gen_boolean(op == "NotEq" ? !*folded : *folded);
+    {
+      // V.3: constant fold built in IREP2.
+      const bool val = op == "NotEq" ? !*folded : *folded;
+      return migrate_expr_back(val ? gen_true_expr() : gen_false_expr());
+    }
     return dict_handler_->compare(lhs, rhs, op);
   }
 
@@ -933,7 +939,8 @@ exprt python_converter::handle_array_operations(
     string_handler_.is_zero_length_array(lhs) &&
     string_handler_.is_zero_length_array(rhs) && (op == "Eq" || op == "NotEq"))
   {
-    return gen_boolean(op == "Eq");
+    // V.3: constant fold built in IREP2.
+    return migrate_expr_back(op == "Eq" ? gen_true_expr() : gen_false_expr());
   }
 
   auto is_numeric_type = [](const typet &t) {


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `converter_binop.cpp` (#5433, #5465, #5466). Migrate the three
`gen_boolean` constant-fold return sites in `get_binary_operator_expr` /
`handle_array_operations` to `gen_true_expr`/`gen_false_expr`, back-migrated
at the legacy return seam.

## What

```
None/identity Eq/NotEq fold:  gen_boolean(op == "NotEq")
dict literal-vs-literal eq:   gen_boolean(op == "NotEq" ? !folded : folded)
zero-length array Eq/NotEq:   gen_boolean(op == "Eq")
```

## Why it is behaviour-preserving

These are pure bool constants; `gen_true_expr`/`gen_false_expr` are the
cached true/false constants and back-migrate to constant `"true"`/`"false"`
identical to `gen_boolean` (same idiom as #5459), byte-identical modulo the
cosmetic `#cpp_type` hint. The folded values and op dispatch are unchanged.

## Validation

- Probe `{1:2}=={1:2}`, `{1:2}!={3:4}`, `""==""`, None identity →
  `VERIFICATION SUCCESSFUL`.
- 11 dict_eq/cross_type_eq/humaneval_130/complex_equality tests pass on a
  Debug/asserts build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
