### PR TITLE
[python] V.3: build string-membership bool binops in IREP2

### DIFF
--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -190,7 +190,18 @@ static std::optional<BigInt> get_constant_array_extent(const exprt &array_expr)
 static exprt
 make_binary_bool_expr(const irep_idt &id, const exprt &lhs, const exprt &rhs)
 {
-  exprt out(id, bool_type());
+  // V.3: build the boolean binop in IREP2 (the only ids used are =/and/or),
+  // back-migrated for the legacy callers.
+  expr2tc l2, r2;
+  migrate_expr(lhs, l2);
+  migrate_expr(rhs, r2);
+  if (id == "=")
+    return migrate_expr_back(equality2tc(l2, r2));
+  if (id == "and")
+    return migrate_expr_back(and2tc(l2, r2));
+  if (id == "or")
+    return migrate_expr_back(or2tc(l2, r2));
+  exprt out(id, bool_type()); // fallback for any other id
   out.copy_to_operands(lhs, rhs);
   return out;
 }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `string/string_handler.cpp`. Migrate the `make_binary_bool_expr`
helper (used by `build_symbolic_membership_from_array` for `substr in str`
over a concrete-extent char array) from the legacy `exprt(id, bool)` builder
to IREP2 factories, back-migrated for the legacy callers. This converts all
four call sites (prefix `=`, element `=`, `and` fold, `or` fold) at once.

## What

```
exprt(id, bool)[lhs, rhs]  ->  id=="="  ? equality2tc
                               id=="and"? and2tc
                               id=="or" ? or2tc   (else legacy fallback)
```

## Why it is behaviour-preserving

`equality2t`/`and2t`/`or2t` have bool results and preserve operand order, so
each is the exact migrate of its legacy builder; byte-identical modulo the
cosmetic `#cpp_type` hint. The `=` operands are char-array index reads over a
constant-extent haystack (array source → `index2t` source assert holds) and
char constants; the and/or operands are bool. A legacy fallback is kept for
any other id (unreachable for current callers).

## Validation

- Probe `"world"`/`"ello"`/`"lo w" in "hello world"` → `VERIFICATION
  SUCCESSFUL` (=7; exercises prefix-=, element-=, and-fold, or-fold).
- 6 tuple_str_membership/string-slice tests pass on a Debug/asserts build,
  live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
