### PR TITLE
[python] V.3: build string-membership constant results in IREP2

### DIFF
--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -208,15 +208,17 @@ static std::optional<exprt> build_symbolic_membership_from_array(
     return std::nullopt;
 
   const BigInt extent = *extent_opt;
+  // V.3: membership constant results built in IREP2.
   if (extent <= 0)
-    return gen_boolean(needle_values.empty());
+    return migrate_expr_back(
+      needle_values.empty() ? gen_true_expr() : gen_false_expr());
 
   const BigInt haystack_content_len = extent - 1;
   const BigInt needle_len = static_cast<unsigned long>(needle_values.size());
   if (needle_len == 0)
-    return gen_boolean(true);
+    return migrate_expr_back(gen_true_expr());
   if (needle_len > haystack_content_len)
-    return gen_boolean(false);
+    return migrate_expr_back(gen_false_expr());
 
   // Keep this bounded to avoid path explosion in symbolic membership.
   if (
@@ -225,7 +227,7 @@ static std::optional<exprt> build_symbolic_membership_from_array(
     return std::nullopt;
 
   const long long max_start = (haystack_content_len - needle_len).to_int64();
-  exprt disjunction = gen_boolean(false);
+  exprt disjunction = migrate_expr_back(gen_false_expr()); // V.3
 
   for (long long start = 0; start <= max_start; ++start)
   {
@@ -1422,7 +1424,11 @@ exprt string_handler::handle_string_membership(
 
   if (needle_values.has_value() && haystack_values.has_value())
   {
-    return gen_boolean(contains_subsequence(*haystack_values, *needle_values));
+    // V.3: concrete-fold membership result built in IREP2.
+    return migrate_expr_back(
+      contains_subsequence(*haystack_values, *needle_values)
+        ? gen_true_expr()
+        : gen_false_expr());
   }
 
   // C strstr() is not null-aware for embedded '\0'. When one operand is


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `string/string_handler.cpp` (#5469), retiring `gen_boolean` from
the file. Migrate the remaining constant-bool results in the substring `in`
membership paths to `gen_true_expr`/`gen_false_expr`, back-migrated at the
seam.

## What

- `build_symbolic_membership_from_array`: empty-haystack result
  (`gen_boolean(needle.empty())`), empty-needle True, needle-longer False,
  and the `disjunction` or-fold base.
- `handle_string_membership`: the concrete-fold result
  `gen_boolean(contains_subsequence(...))`.

## Why it is behaviour-preserving

These are pure bool constants; `gen_true_expr`/`gen_false_expr` back-migrate
to constant `"true"`/`"false"` identical to `gen_boolean` (same idiom as
#5459), byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `"" in "abc"` (empty needle), `"abcd" in "ab"` (longer),
  `"ab" in "abxyz"` (concrete) → `VERIFICATION SUCCESSFUL`.
- 12 tuple_str_membership/string-slice/fstring tests pass on a Debug/asserts
  build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
