### PR TITLE
[python] V.3: build tuple membership or-fold in IREP2

### DIFF
--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -614,7 +614,8 @@ exprt tuple_handler::handle_tuple_membership(
   const bool rhs_is_struct_literal =
     rhs.id() == "struct" && rhs.operands().size() == components.size();
 
-  exprt result;
+  // V.3: build the membership or-fold in IREP2, back-migrated at the return.
+  expr2tc result2;
   for (size_t i = 0; i < components.size(); i++)
   {
     std::string member_name = "element_" + std::to_string(i);
@@ -626,7 +627,7 @@ exprt tuple_handler::handle_tuple_membership(
     const bool comp_is_string =
       components[i].type().is_array() || components[i].type().is_pointer();
 
-    exprt equality;
+    expr2tc eq2;
     if (lhs_is_string && comp_is_string)
     {
       // String content equality via the shared comparison machinery, which
@@ -634,28 +635,32 @@ exprt tuple_handler::handle_tuple_membership(
       // (signalled by a nil return — assemble it like the binop caller does).
       exprt l = lhs;
       exprt r = member_access;
-      equality = converter_.handle_string_comparison("Eq", l, r, element);
+      exprt equality = converter_.handle_string_comparison("Eq", l, r, element);
       if (equality.is_nil())
       {
-        equality = exprt("=", bool_type());
-        equality.copy_to_operands(l, r);
+        expr2tc l2, r2;
+        migrate_expr(l, l2);
+        migrate_expr(r, r2);
+        eq2 = equality2tc(l2, r2);
       }
+      else
+        migrate_expr(equality, eq2);
     }
     else if (lhs_is_string != comp_is_string)
     {
       // Cross-type: a string is never == a non-string in Python.
-      equality = false_exprt();
+      eq2 = gen_false_expr();
     }
     else
     {
-      equality = equality_exprt(lhs, member_access);
+      expr2tc l2, m2;
+      migrate_expr(lhs, l2);
+      migrate_expr(member_access, m2);
+      eq2 = equality2tc(l2, m2);
     }
 
-    if (i == 0)
-      result = equality;
-    else
-      result = or_exprt(result, equality);
+    result2 = (i == 0) ? eq2 : or2tc(result2, eq2);
   }
 
-  return invert ? not_exprt(result) : result;
+  return migrate_expr_back(invert ? not2tc(result2) : result2);
 }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `tuple_handler.cpp` (#5468). In `handle_tuple_membership`
(`x in tuple` / `x not in tuple`), migrate the per-element equality or-fold
from legacy `exprt` builders to IREP2 factories, back-migrated once at the
return.

## What

- `equality_exprt(lhs, member)` → `equality2tc`; `exprt("=")[l,r]` (string
  strcmp path) → `equality2tc`; non-nil string-compare result migrated in
- cross-type `false_exprt()` → `gen_false_expr()`
- `or_exprt` fold → `or2tc`; `not_exprt` (`not in`) → `not2tc`

## Why it is behaviour-preserving

`equality2t`/`or2t`/`not2t` are bool-typed with preserved operand order, so
each is the exact migrate of its legacy builder, byte-identical modulo the
cosmetic `#cpp_type` hint. Unlike `if2t`, `equality2t` carries no
operand-type assert, so a mixed-type numeric membership (e.g. `int in a
(int,float) tuple`) constructs without aborting — same as the legacy
`equality_exprt`. The empty-tuple case returns earlier via a pre-existing
guard, so the accumulator is always assigned before the back-migration (no
null `expr2tc`).

## Validation

- Probe `2 in (1,2,3)`, `"bb" in ("a","bb","ccc")`, `5 not in t`,
  `"x" not in st` → `VERIFICATION SUCCESSFUL` (=15).
- 35 tuple tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
