### PR TITLE
[python] V.3: build tuple subscript select chain in IREP2

### DIFF
--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -340,15 +340,33 @@ exprt tuple_handler::handle_tuple_subscript(
     converter_.add_instruction(bounds_assert);
 
     // Build chain: i==n-1 ? element_(n-1) : (... ? ... : element_0)
+    // V.3: build the index select chain in IREP2. This path is gated to
+    // base_type_eq-homogeneous tuples (checked above), so the if2t branch
+    // types normally agree; a defensive exact-type guard keeps any
+    // base_type_eq-but-not-identical component on the legacy builder.
+    const type2tc ft2 = migrate_type(first_type);
+    const type2tc idx2t = migrate_type(idx_type);
+    expr2tc idxnorm2;
+    migrate_expr(idx_norm, idxnorm2);
     exprt chain = get_tuple_element(array, tuple_type, 0);
     for (size_t k = 1; k < n; ++k)
     {
       exprt member = get_tuple_element(array, tuple_type, k);
-      exprt cond =
-        binary_relation_exprt(idx_norm, "=", from_integer(BigInt(k), idx_type));
-      if_exprt sel(cond, member, chain);
-      sel.type() = first_type;
-      chain = sel;
+      const expr2tc cond2 =
+        equality2tc(idxnorm2, from_integer(BigInt(k), idx2t));
+      if (member.type() == first_type && chain.type() == first_type)
+      {
+        expr2tc member2, chain2;
+        migrate_expr(member, member2);
+        migrate_expr(chain, chain2);
+        chain = migrate_expr_back(if2tc(ft2, cond2, member2, chain2));
+      }
+      else
+      {
+        if_exprt sel(migrate_expr_back(cond2), member, chain);
+        sel.type() = first_type;
+        chain = sel;
+      }
     }
 
     if (element.contains("lineno"))


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `handle_tuple_subscript` (#5468 did the index-norm + bounds). In
the dynamic-index path, migrate the `i==k ? element_k : ...` select chain
from legacy `exprt` builders to IREP2 factories, back-migrated at the seam.

## What

```
cond = binary_relation_exprt(idx_norm,"=",k) -> equality2tc(idxnorm2, k2)
sel  = if_exprt(cond, member, chain)         -> if2tc(first_type, ...)
```

## Why it is behaviour-preserving

This path is gated to base_type_eq-homogeneous tuples (a check above throws
otherwise), so the if2t branch types normally agree. A defensive exact-type
guard (`member.type()==first_type && chain.type()==first_type`) keeps any
base_type_eq-but-not-byte-identical component on the legacy `if_exprt`
builder (if2t asserts type-id equality); the fallback is byte-identical to
the original. `idxnorm2` is hoisted (migrated once). `equality2tc`/`if2tc`
preserve operand order and result type, so each is the exact migrate of its
legacy builder modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe int tuple `t[0]`=10/`t[-1]`=30/`t[-3]`=10 and float tuple
  `t[0]`=1.5/`t[-1]`=3.5 (dynamic index) → `VERIFICATION SUCCESSFUL`.
- 35 tuple tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
