### PR TITLE
[python] V.3: build slice is-None flag check in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -414,17 +414,15 @@ exprt python_converter::try_lower_slice_member_is_none(
     return nil_exprt();
   const typet flag_type = slice_struct.get_component(flag_name).type();
 
-  // V.3: IREP2 member access (exact round-trip of member_exprt).
+  // V.3: build the flag member access and the is/is-not-None check in IREP2,
+  // back-migrated once at the return.
   expr2tc fb2;
   migrate_expr(member_side->op0(), fb2);
-  exprt flag_access =
-    migrate_expr_back(member2tc(migrate_type(flag_type), fb2, flag_name));
+  const expr2tc flag2 = member2tc(migrate_type(flag_type), fb2, flag_name);
   // `sl.start is None` ⇔ flag is zero (bound was absent).
   // `sl.start is not None` ⇔ flag is non-zero (bound was supplied).
-  equality_exprt eq(flag_access, gen_zero(flag_type));
-  if (op == "Is")
-    return eq;
-  return not_exprt(eq);
+  const expr2tc eq2 = equality2tc(flag2, gen_zero(flag2->type));
+  return migrate_expr_back(op == "Is" ? eq2 : not2tc(eq2));
 }
 
 exprt python_converter::handle_none_comparison(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `converter_compare.cpp` (#5473). In `try_lower_slice_member_is_none`
(lowering `slice.start is None` / `is not None`), consolidate the flag member
access and the is/is-not-None equality fully into IREP2, back-migrated once
at the return.

## What

```
member2tc(flag) [kept expr2tc] ; equality2tc(flag, gen_zero) ;
op=="Is" ? eq : not2tc(eq)
```

This drops the intermediate `exprt flag_access` (an eager back-migration of
the member sub-tree).

## Why it is behaviour-preserving

`equality2t`/`not2t` preserve operand order and bool result; the flag is an
integer (bv) component, so `gen_zero` takes the bv arm (constant 0) and
back-migrates to the same width-many-zeros constant as the legacy
`gen_zero(typet)` — byte-identical modulo the cosmetic `#cpp_type` hint. The
`member2t` source (migrated slice struct) is the same one the prior code
already built, so no new assert risk.

## Validation

- Probe `b[2:]` (start present, stop absent) → len 2 → `VERIFICATION
  SUCCESSFUL`.
- 28 slice tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
