### PR TITLE
[python] V.3: build complex ==/!= in IREP2

### DIFF
--- a/src/python-frontend/complex_handler.cpp
+++ b/src/python-frontend/complex_handler.cpp
@@ -522,11 +522,22 @@ exprt complex_handler::handle_binary_op(
     const exprt c = complex_member(rhs_complex, "real", dt);
     const exprt d = complex_member(rhs_complex, "imag", dt);
 
-    if (op == "Eq")
-      return and_exprt(equality_exprt(a, c), equality_exprt(b, d));
-    if (op == "NotEq")
-      return or_exprt(
-        not_exprt(equality_exprt(a, c)), not_exprt(equality_exprt(b, d)));
+    if (op == "Eq" || op == "NotEq")
+    {
+      // V.3: build complex (in)equality in IREP2.
+      // Eq:    (a == c) && (b == d)
+      // NotEq: (a != c) || (b != d)
+      expr2tc lre, lim, rre, rim;
+      migrate_expr(a, lre);
+      migrate_expr(b, lim);
+      migrate_expr(c, rre);
+      migrate_expr(d, rim);
+      const expr2tc re_eq = equality2tc(lre, rre);
+      const expr2tc im_eq = equality2tc(lim, rim);
+      if (op == "Eq")
+        return migrate_expr_back(and2tc(re_eq, im_eq));
+      return migrate_expr_back(or2tc(not2tc(re_eq), not2tc(im_eq)));
+    }
 
     if (op == "Add")
       return make_complex(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `complex_handler.cpp`. In `complex_handler::handle_binary_op`,
migrate the complex equality/inequality lowering from legacy `exprt` builders
to IREP2 factories, back-migrated once at the return.

## What

```
Eq:    and_exprt(equality_exprt(a,c), equality_exprt(b,d))
         -> and2tc(equality2tc(re), equality2tc(im))
NotEq: or_exprt(not_exprt(eq_re), not_exprt(eq_im))
         -> or2tc(not2tc(re_eq), not2tc(im_eq))
```

## Why it is behaviour-preserving

`a/b/c/d` are the real/imag parts (`cached_double_type`), so `equality2tc`
operands are type-matched; `equality2t`/`and2t`/`or2t`/`not2t` are bool-typed
with preserved operand order, so each is the exact migrate of its legacy
builder, byte-identical modulo the cosmetic `#cpp_type` hint. The two legacy
`if` returns merge into one block that returns on both sub-paths (no
fallthrough to the arithmetic chain).

## Validation

- Probe `(1+2j)==(1+2j)` True, `(1+2j)!=(1+3j)` True, negatives →
  `VERIFICATION SUCCESSFUL` (=3).
- 111 complex tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
