### PR TITLE
[python] V.3: build complex div-by-zero guard in IREP2

### DIFF
--- a/src/python-frontend/complex_handler.cpp
+++ b/src/python-frontend/complex_handler.cpp
@@ -133,9 +133,13 @@ exprt complex_handler::complex_div(
     ieee_binop("ieee_div", numer_imag, denom));
 
   // Runtime ZeroDivisionError guard — denom==0 iff yr==0 AND yi==0.
-  exprt yr_zero = equality_exprt(yr, zero);
-  exprt yi_zero = equality_exprt(yi, zero);
-  exprt denom_is_zero = and_exprt(yr_zero, yi_zero);
+  // V.3: built in IREP2, back-migrated for the legacy code_ifthenelset guard.
+  expr2tc yr2, yi2, zero2;
+  migrate_expr(yr, yr2);
+  migrate_expr(yi, yi2);
+  migrate_expr(zero, zero2);
+  exprt denom_is_zero =
+    migrate_expr_back(and2tc(equality2tc(yr2, zero2), equality2tc(yi2, zero2)));
 
   exprt raise_zdiv = converter_.get_exception_handler().gen_exception_raise(
     "ZeroDivisionError", "complex division by zero");


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `complex_handler.cpp` (#5475). In `complex_handler::complex_div`,
migrate the ZeroDivisionError guard condition (`denom==0 iff yr==0 && yi==0`)
from legacy `exprt` builders to IREP2 factories, back-migrated for the legacy
`code_ifthenelset` guard.

## What

```
equality_exprt(yr,zero) && equality_exprt(yi,zero)
  -> and2tc(equality2tc(yr,zero), equality2tc(yi,zero))
```

## Why it is behaviour-preserving

`yr`/`yi`/`zero` are double, so `equality2tc` operands are type-matched;
`equality2t`/`and2t` are bool-typed with preserved operand order, so each is
the exact migrate of its legacy builder, byte-identical modulo the cosmetic
`#cpp_type` hint.

## Validation

- Probe `(6+4j)/(1+1j)` real==5.0 → SUCCESSFUL; `(1+2j)/(0+0j)` → FAILED
  (the migrated guard fires ZeroDivisionError).
- 26 complex tests pass (complex_div/arith/equality/attr/constructor/
  isinstance) on a Debug/asserts build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
