### PR TITLE
[python] V.3: build list.remove not-found guard in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -5315,7 +5315,7 @@ exprt python_list::build_remove_list_call(
 
   // Raise ValueError from the frontend so Python try/except can catch it.
   symbolt &remove_ret = converter_.create_tmp_symbol(
-    op, "remove_ret", bool_type(), gen_boolean(false));
+    op, "remove_ret", bool_type(), migrate_expr_back(gen_false_expr())); // V.3
   code_declt remove_ret_decl(build_symbol(remove_ret));
   converter_.add_instruction(remove_ret_decl);
 
@@ -5337,7 +5337,10 @@ exprt python_list::build_remove_list_call(
   throw_code.operands().push_back(raise);
 
   code_ifthenelset guard;
-  guard.cond() = not_exprt(build_symbol(remove_ret));
+  // V.3: build the "not removed" guard (x not in list) in IREP2.
+  expr2tc rr2;
+  migrate_expr(build_symbol(remove_ret), rr2);
+  guard.cond() = migrate_expr_back(not2tc(rr2));
   guard.then_case() = throw_code;
   guard.location() = elem_info.location;
   return guard;


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp` (#5437/#5439/#5440/#5441). In
`build_remove_list_call`, migrate the `list.remove(x)` "x not in list"
ValueError guard from legacy `exprt` builders to IREP2.

## What

- `remove_ret` tmp init: `gen_boolean(false)` → `gen_false_expr()`
- guard: `not_exprt(remove_ret)` → `not2tc`, back-migrated for the legacy
  `code_ifthenelset`

## Why it is behaviour-preserving

`remove_ret` is bool; `gen_false_expr`/`not2t` are the exact migrates of
`gen_boolean(false)`/`not_exprt` (bool result, single operand),
byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `[1,2,3].remove(2)` → SUCCESSFUL (len 2); `.remove(99)` → FAILED
  (the migrated guard fires ValueError "x not in list").
- 13 list_remove tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
