### PR TITLE
[python] V.3: build mixed-list float-select in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4678,10 +4678,16 @@ exprt python_list::extract_pyobject_value(
     exprt int_as_float = build_typecast(int_val, elem_type);
 
     // item->type_id == float_type_id ? float_buf[float_idx] : (double)int
-    equality_exprt is_float(
-      member_of("type_id", size_type()),
-      from_integer(float_type_id, size_type()));
-    return if_exprt(is_float, float_val, int_as_float);
+    // V.3: built in IREP2 (both branches are elem_type, so the if2t types
+    // agree), back-migrated at the return.
+    const type2tc et2 = migrate_type(elem_type);
+    expr2tc tid2, fv2, iaf2;
+    migrate_expr(member_of("type_id", size_type()), tid2);
+    migrate_expr(float_val, fv2);
+    migrate_expr(int_as_float, iaf2);
+    const expr2tc is_float =
+      equality2tc(tid2, from_integer(float_type_id, migrate_type(size_type())));
+    return migrate_expr_back(if2tc(et2, is_float, fv2, iaf2));
   }
 
   // Extract value from PyObject: (*pyobject_expr).value


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp` (#5437/#5439/#5440/#5441/#5477). In
`extract_pyobject_value`, migrate the mixed int/float dynamic-index
type_id-dispatch select (issue #5160) from legacy `exprt` builders to IREP2,
back-migrated at the return.

## What

```
is_float = equality_exprt(type_id, float_type_id)  -> equality2tc
type_id==float_id ? float_buf[idx] : (elem)int     -> if2tc
```

## Why it is behaviour-preserving

Both branches are `elem_type` (`float_val` from `build_index(...,elem_type)`,
`int_as_float` from `build_typecast(...,elem_type)`), so the if2t branch
type-ids agree and the assert holds — strictly type-safer than the legacy
`if_exprt`, which silently took the true-operand type and never checked the
false branch. `equality2tc` operands are both `size_type`; operand order and
result type preserved, byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `[1,2.5,3,4.5][1]`==2.5 (float elem) and `[..][0]`==1.0 (int elem
  promoted) → `VERIFICATION SUCCESSFUL`.
- 5 mixed_list tests pass (mixed_list_dynamic_index{,_fail,_int},
  mixed_list_scalar_return{,_fail}) on a Debug/asserts build, live
  `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
