### PR TITLE
[python] V.3: build list-comprehension filter+increment in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4518,19 +4518,18 @@ exprt python_list::handle_comprehension(const nlohmann::json &element)
   // If we had filter conditions, wrap append in if statement
   if (generator.contains("ifs") && !generator["ifs"].empty())
   {
-    exprt combined_condition = gen_boolean(true);
+    // V.3: build the comprehension filter and-fold in IREP2. The outer guard
+    // guarantees at least one clause, so no `true` sentinel is needed.
+    expr2tc filt_combined;
+    bool filt_first = true;
     for (const auto &if_clause : generator["ifs"])
     {
-      exprt if_expr = converter_.get_expr(if_clause);
-      if (combined_condition.is_true())
-        combined_condition = if_expr;
-      else
-      {
-        exprt and_expr("and", bool_type());
-        and_expr.copy_to_operands(combined_condition, if_expr);
-        combined_condition = and_expr;
-      }
+      expr2tc filt_c;
+      migrate_expr(converter_.get_expr(if_clause), filt_c);
+      filt_combined = filt_first ? filt_c : and2tc(filt_combined, filt_c);
+      filt_first = false;
     }
+    exprt combined_condition = migrate_expr_back(filt_combined);
 
     codet if_stmt;
     if_stmt.set_statement("ifthenelse");
@@ -4539,9 +4538,11 @@ exprt python_list::handle_comprehension(const nlohmann::json &element)
     loop_body.copy_to_operands(if_stmt);
   }
 
-  // 9. Increment index: i = i + 1
-  exprt increment("+", size_type());
-  increment.copy_to_operands(build_symbol(index_var), gen_one(size_type()));
+  // 9. Increment index: i = i + 1 (V.3: built in IREP2).
+  const type2tc inc_t2 = migrate_type(size_type());
+  expr2tc inc_idx;
+  migrate_expr(build_symbol(index_var), inc_idx);
+  exprt increment = migrate_expr_back(add2tc(inc_t2, inc_idx, gen_one(inc_t2)));
   code_assignt index_increment(build_symbol(index_var), increment);
   index_increment.location() = location;
   loop_body.copy_to_operands(index_increment);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp` (#5437/#5439/#5440/#5441/#5477/#5478). In
`handle_comprehension`, migrate the filter and-fold and the loop increment
from legacy `exprt` builders to IREP2, back-migrated at the legacy seams
(`code_ifthenelse` cond, `code_assignt` RHS).

## What

- filter and-fold: `gen_boolean(true)` sentinel + `and_exprt` → first-clause
  then `and2tc` left-fold (sentinel dropped; outer guard ensures ≥1 clause;
  multi-clause is rejected upstream, so the `and2tc` arm yields the same
  single-clause result)
- increment `i=i+1`: `plus_exprt(i, gen_one(size))` → `add2tc`

## Why it is behaviour-preserving

Same idioms as the dict-comprehension #5449/#5450. Each factory is the exact
migrate of its legacy builder (bool / `size_type`, operand order preserved),
byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `[x for x in range(10) if x>2]`=7, `[x*x for x in range(6) if x%2==0]`=3
  → `VERIFICATION SUCCESSFUL`.
- 26 listcomp/comprehension tests pass on a Debug/asserts build, live
  `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
