### PR TITLE
[python] V.3: build string-index OOB guard in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2983,12 +2983,13 @@ exprt python_list::handle_index_access(
     converter_.add_instruction(norm_guard);
 
     // --- 4. OOB check: if (idx < 0 || idx >= (ll)len) raise IndexError ---
-    exprt still_neg("<", bool_type());
-    still_neg.copy_to_operands(build_symbol(idx_sym), from_integer(0, ll_type));
-
-    exprt idx_ge_len(">=", bool_type());
-    idx_ge_len.copy_to_operands(
-      build_symbol(idx_sym), build_typecast(build_symbol(len_sym), ll_type));
+    // V.3: built in IREP2, back-migrated for the legacy code_ifthenelset.
+    const type2tc oob_llt = migrate_type(ll_type);
+    expr2tc oob_idx, oob_len;
+    migrate_expr(build_symbol(idx_sym), oob_idx);
+    migrate_expr(build_typecast(build_symbol(len_sym), ll_type), oob_len);
+    expr2tc still_neg = lessthan2tc(oob_idx, gen_zero(oob_llt));
+    expr2tc idx_ge_len = greaterthanequal2tc(oob_idx, oob_len);
 
     exprt raise = converter_.get_exception_handler().gen_exception_raise(
       "IndexError", "string index out of range");
@@ -2996,7 +2997,7 @@ exprt python_list::handle_index_access(
     throw_code.operands().push_back(raise);
 
     code_ifthenelset oob_guard;
-    oob_guard.cond() = or_exprt(still_neg, idx_ge_len);
+    oob_guard.cond() = migrate_expr_back(or2tc(still_neg, idx_ge_len));
     oob_guard.then_case() = throw_code;
     oob_guard.location() = loc;
     converter_.add_instruction(oob_guard);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp` (#5437/#5439/#5440/#5441/#5477/#5478/#5479). In
`handle_index_access`, migrate the string-index out-of-bounds check from
legacy `exprt` builders to IREP2, back-migrated for the legacy
`code_ifthenelset` guard.

## What

```
still_neg  = exprt("<")[idx, 0]              -> lessthan2tc(idx, gen_zero)
idx_ge_len = exprt(">=")[idx, (ll)len]       -> greaterthanequal2tc(idx, len)
cond       = or_exprt(still_neg, idx_ge_len) -> or2tc
```

## Why it is behaviour-preserving

All operands are `ll_type`/bool, so each factory is the exact migrate of its
legacy builder (operand order preserved, bool result); `gen_zero(ll_type)`
takes the signedbv arm (constant 0). Byte-identical modulo the cosmetic
`#cpp_type` hint. Same comparison-guard shape as the tuple bounds check
(#5468).

## Validation

- Probe `s[0]`="h", `s[-1]`="o" → SUCCESSFUL; `s[9]` → FAILED (the migrated
  guard fires "string index out of range").
- 28 string tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
