### PR TITLE
[python] V.3: build slice step-zero assert in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1454,7 +1454,8 @@ exprt python_list::handle_range_slice(
   // already reported by the checker.
   if (literal_zero_step)
   {
-    code_assertt step_assert(gen_boolean(false));
+    // V.3: build the always-fail assert condition in IREP2.
+    code_assertt step_assert(migrate_expr_back(gen_false_expr()));
     step_assert.location() = converter_.get_location_from_decl(slice_node);
     step_assert.location().comment("ValueError: slice step cannot be zero");
     converter_.add_instruction(step_assert);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp`. In `handle_range_slice`'s literal-zero-step
path, migrate the "slice step cannot be zero" ValueError always-fail assert
from `gen_boolean(false)` to `gen_false_expr()`, back-migrated at the legacy
`code_assertt` seam.

## Why it is behaviour-preserving

Pure bool constant; `gen_false_expr` back-migrates to constant `"false"`
identical to `gen_boolean(false)` (same idiom as #5432/#5470), byte-identical
modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `a[::0]` → FAILED ("slice step cannot be zero", the migrated assert
  fires).
- 5 slice-step tests pass (incl. `list-slice-step-zero_fail`) on a
  Debug/asserts build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
