### PR TITLE
[python] V.3: build set ==/!= result check in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3140,7 +3140,10 @@ exprt python_list::compare(
 
     locationt loc = converter_.get_location_from_decl(list_value_);
     symbolt &eq_ret = converter_.create_tmp_symbol(
-      list_value_, "set_eq_tmp", bool_type(), gen_boolean(false));
+      list_value_,
+      "set_eq_tmp",
+      bool_type(),
+      migrate_expr_back(gen_false_expr())); // V.3
     code_declt eq_ret_decl(build_symbol(eq_ret));
     converter_.add_instruction(eq_ret_decl);
 
@@ -3159,14 +3162,11 @@ exprt python_list::compare(
     set_eq_call.location() = loc;
     converter_.add_instruction(set_eq_call);
 
-    exprt cond("=", bool_type());
-    cond.copy_to_operands(build_symbol(eq_ret));
-    if (op == "Eq")
-      cond.copy_to_operands(gen_boolean(true));
-    else
-      cond.copy_to_operands(gen_boolean(false));
-
-    return cond;
+    // V.3: build `eq_ret == (op == "Eq")` in IREP2.
+    expr2tc er2;
+    migrate_expr(build_symbol(eq_ret), er2);
+    return migrate_expr_back(
+      equality2tc(er2, op == "Eq" ? gen_true_expr() : gen_false_expr()));
   }
 
   // Fast path for list equality/inequality when we have concrete type-map


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp`. In the set-equality comparison path, migrate
the `eq_ret == (op == "Eq")` result check from legacy `exprt` builders to
IREP2.

## What

- `set_eq_tmp` init: `gen_boolean(false)` → `gen_false_expr()`
- cond: `exprt("=")[eq_ret, gen_boolean(op=="Eq")]`
        → `equality2tc(eq_ret, op=="Eq" ? gen_true_expr() : gen_false_expr())`

This drops the if/else `copy_to_operands` of the bool constant.

## Why it is behaviour-preserving

`eq_ret` is bool; `equality2tc` operands are bool, result bool;
`gen_true/false_expr` back-migrate to constant `"true"`/`"false"` identical
to `gen_boolean`. Each factory is the exact migrate of its legacy builder,
byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `{1,2,3}=={3,2,1}` True, `{1,2,3}!={1,2}` True → `VERIFICATION
  SUCCESSFUL`.
- 11 set tests pass (set_difference/intersection/github_2965, set==) on a
  Debug/asserts build, live `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
