### PR TITLE
[python] V.3: build list </>= and == result checks in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3408,7 +3408,7 @@ exprt python_list::compare(
     const symbolt *b_sym = swap ? lhs_symbol : rhs_symbol;
 
     symbolt &lt_ret = converter_.create_tmp_symbol(
-      list_value_, "lt_tmp", bool_type(), gen_boolean(false));
+      list_value_, "lt_tmp", bool_type(), migrate_expr_back(gen_false_expr()));
     code_declt lt_ret_decl(build_symbol(lt_ret));
     converter_.add_instruction(lt_ret_decl);
 
@@ -3424,14 +3424,12 @@ exprt python_list::compare(
     converter_.add_instruction(lt_call);
 
     // Lt / Gt → lt_ret must be true; LtE / GtE → lt_ret must be false
-    exprt cond("=", bool_type());
-    cond.copy_to_operands(build_symbol(lt_ret));
-    if (op == "Lt" || op == "Gt")
-      cond.copy_to_operands(gen_boolean(true));
-    else
-      cond.copy_to_operands(gen_boolean(false));
-
-    return cond;
+    // V.3: build `lt_ret == (op is Lt/Gt)` in IREP2.
+    expr2tc ltr2;
+    migrate_expr(build_symbol(lt_ret), ltr2);
+    const bool want_true = (op == "Lt" || op == "Gt");
+    return migrate_expr_back(
+      equality2tc(ltr2, want_true ? gen_true_expr() : gen_false_expr()));
   }
 
   // ── Equality operators: Eq, NotEq ─────────────────────────────────────────
@@ -3445,7 +3443,7 @@ exprt python_list::compare(
     std::hash<std::string>{}(list_type_name), config.ansi_c.address_width));
 
   symbolt &eq_ret = converter_.create_tmp_symbol(
-    list_value_, "eq_tmp", bool_type(), gen_boolean(false));
+    list_value_, "eq_tmp", bool_type(), migrate_expr_back(gen_false_expr()));
   code_declt eq_ret_decl(build_symbol(eq_ret));
   converter_.add_instruction(eq_ret_decl);
 
@@ -3514,14 +3512,11 @@ exprt python_list::compare(
   list_eq_func_call.location() = converter_.get_location_from_decl(list_value_);
   converter_.add_instruction(list_eq_func_call);
 
-  exprt cond("=", bool_type());
-  cond.copy_to_operands(build_symbol(eq_ret));
-  if (op == "Eq")
-    cond.copy_to_operands(gen_boolean(true));
-  else
-    cond.copy_to_operands(gen_boolean(false));
-
-  return cond;
+  // V.3: build `eq_ret == (op == "Eq")` in IREP2.
+  expr2tc leqr2;
+  migrate_expr(build_symbol(eq_ret), leqr2);
+  return migrate_expr_back(
+    equality2tc(leqr2, op == "Eq" ? gen_true_expr() : gen_false_expr()));
 }
 
 exprt python_list::create_vla(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp` (#5482 did the set_eq sibling). Migrate the two
remaining "runtime comparison result == expected bool" checks:

- list ordering: `lt_tmp` init `gen_boolean(false)` → `gen_false_expr()`;
  cond `exprt("=")[lt_ret, gen_boolean(op is Lt/Gt)]` →
  `equality2tc(lt_ret, want_true ? gen_true_expr() : gen_false_expr())`
- list equality: `eq_tmp` init + cond likewise via `equality2tc`

## Why it is behaviour-preserving

Both `ret` values are bool; `equality2tc` operands bool, result bool;
`gen_true/false_expr` back-migrate to constant `"true"`/`"false"` identical
to `gen_boolean`. Each factory is the exact migrate of its legacy builder,
byte-identical modulo the cosmetic `#cpp_type` hint; the if/else
`copy_to_operands` collapses into the ternary.

## Validation

- Probe `[1,2,3]<[1,2,4]` True, `[1,2,3]==[1,2,3]` True, `>=` False →
  `VERIFICATION SUCCESSFUL`.
- 22 list-comparison tests pass (list-eq*, list-lt*, nested-list*,
  humaneval_130) on a Debug/asserts build, live `migrate.cpp` cross-check
  silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
