### PR TITLE
[python] V.3: build list-contains result check in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3935,7 +3935,10 @@ exprt python_list::contains(const exprt &item, const exprt &list)
 
   // Create a temporary variable to store the result
   symbolt &contains_ret = converter_.create_tmp_symbol(
-    list_value_, "contains_tmp", bool_type(), gen_boolean(false));
+    list_value_,
+    "contains_tmp",
+    bool_type(),
+    migrate_expr_back(gen_false_expr())); // V.3
   code_declt contains_ret_decl(build_symbol(contains_ret));
   converter_.add_instruction(contains_ret_decl);
 
@@ -4042,9 +4045,10 @@ exprt python_list::contains(const exprt &item, const exprt &list)
   contains_call.location() = converter_.get_location_from_decl(list_value_);
   converter_.add_instruction(contains_call);
 
-  exprt result("=", bool_type());
-  result.copy_to_operands(build_symbol(contains_ret));
-  result.copy_to_operands(gen_boolean(true));
+  // V.3: build `contains_ret == true` in IREP2.
+  expr2tc cr2;
+  migrate_expr(build_symbol(contains_ret), cr2);
+  exprt result = migrate_expr_back(equality2tc(cr2, gen_true_expr()));
 
   return result;
 }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) —
continues `python_list.cpp` (#5482/#5483 sibling result-checks). In the list
membership (`x in list`) handler, migrate the contains result check from
legacy `exprt` builders to IREP2:

```
contains_tmp init: gen_boolean(false) -> gen_false_expr()
result: exprt("=")[contains_ret, gen_boolean(true)]
        -> equality2tc(contains_ret, gen_true_expr())
```

## Why it is behaviour-preserving

`contains_ret` is bool; `equality2tc` operands bool, result bool;
`gen_true/false_expr` back-migrate to constant `"true"`/`"false"` identical
to `gen_boolean`. Each factory is the exact migrate of its legacy builder,
byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `20 in [10,20,30]` True, `99 in [..]` False → `VERIFICATION
  SUCCESSFUL`.
- 42 list contains/in tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
