### PR TITLE
[python] V.3: build numpy overflow assert in IREP2

### DIFF
--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -121,7 +121,8 @@ static void emit_numpy_overflow_assertion(
   if (!overflow_checks_enabled())
     return;
 
-  code_assertt overflow_assert(gen_boolean(false));
+  // V.3: build the always-fail overflow assert condition in IREP2.
+  code_assertt overflow_assert(migrate_expr_back(gen_false_expr()));
   overflow_assert.location() = converter.get_location_from_decl(call);
   overflow_assert.location().comment(
     "Integer overflow detected in " + function_id.get_function() + "() call");


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `numpy_call_expr.cpp`. In `emit_numpy_overflow_assertion`, migrate
the compile-time integer-overflow always-fail assert from `gen_boolean(false)`
to `gen_false_expr()`, back-migrated at the legacy `code_assertt` seam.

## Why it is behaviour-preserving

Pure bool constant; `gen_false_expr` back-migrates to constant `"false"`
identical to `gen_boolean(false)` (same idiom as #5432/#5470/#5481),
byte-identical modulo the cosmetic `#cpp_type` hint. The construction
`code_assertt(migrate_expr_back(gen_false_expr()))` is the exact one
probe-validated in #5481 (slice step-zero), differing only in call site.

## Validation

- Builds clean; clang-format 11 clean; smoke subset passes on a
  Debug/asserts build, live `migrate.cpp` cross-check silent.
- **Note on coverage:** the numpy overflow path has no regression coverage —
  no `regression/python` test exercises `emit_numpy_overflow_assertion`, and
  the numpy frontend is too limited to trigger it from a probe. Validation
  therefore rests on the build, the established `gen_false_expr` equivalence,
  and the identical probe-validated construction in #5481, not a direct numpy
  probe.
- Dual-solver parity delegated to CI.
