### PR TITLE
[python] V.3: build assert-on-call conditions in IREP2

### DIFF
--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -554,7 +554,8 @@ void python_exception_handler::handle_function_call_assertion(
     block.move_to_operands(code_stmt);
 
     code_assertt assert_code;
-    assert_code.assertion() = false_exprt();
+    // V.3: build the always-fail assert condition in IREP2.
+    assert_code.assertion() = migrate_expr_back(gen_false_expr());
     assert_code.location() = location;
     assert_code.location().comment("Assertion on None-returning function");
     attach_assert_message(assert_code);
@@ -573,7 +574,10 @@ void python_exception_handler::handle_function_call_assertion(
   exprt assertion_expr;
   if (is_negated)
   {
-    assertion_expr = not_exprt(temp_var_expr);
+    // V.3: build `not <result>` in IREP2 (the temp is bool-typed).
+    expr2tc tv2;
+    migrate_expr(temp_var_expr, tv2);
+    assertion_expr = migrate_expr_back(not2tc(tv2));
   }
   else
   {


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `python_exception_handler.cpp`. In the assert-on-function-call
lowering, migrate the two clean assert conditions to IREP2, back-migrated at
the legacy `code_assertt` seam:

- None-returning-function assert: `false_exprt()` → `gen_false_expr()`
- negated assert (`assert not f()`): `not_exprt(temp)` → `not2tc` (the temp
  is bool-typed, confirmed at `create_assert_temp_variable`)

## Why it is behaviour-preserving

Both are exact migrates of their legacy builders, byte-identical modulo the
cosmetic `#cpp_type` hint (false idiom as #5481; not idiom as #5466).

**Deliberately NOT migrated:** the non-negated `(int)f() == 1` equality,
whose `constant_exprt("1", int32)` stores a literal `"1"` value string rather
than the 32-bit binary form `gen_one`/`from_integer` would produce — routing
it through `equality2tc` would normalise the constant and break byte-identity.
Left legacy.

## Validation

- Probe `assert g()` + `assert not h()` → SUCCESSFUL (negated path via
  `not2tc`); `assert h()` (False) → FAILED (legacy equality path, untouched,
  still fires).
- 17 assert/None/raise tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
