### PR TITLE
[python] V.3: build Optional is_none flags in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_types.cpp
+++ b/src/python-frontend/converter/converter_types.cpp
@@ -76,7 +76,7 @@ exprt python_converter::wrap_in_optional(
   exprt is_none_value;
   if (value.type() == none_type())
   {
-    is_none_value = gen_boolean(true);
+    is_none_value = migrate_expr_back(gen_true_expr()); // V.3
     // Set value field to zero for None case
     optional_value.operands().push_back(is_none_value);
     optional_value.operands().push_back(
@@ -84,7 +84,7 @@ exprt python_converter::wrap_in_optional(
   }
   else
   {
-    is_none_value = gen_boolean(false);
+    is_none_value = migrate_expr_back(gen_false_expr()); // V.3
     optional_value.operands().push_back(is_none_value);
     optional_value.operands().push_back(value);
   }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `converter/converter_types.cpp`. In the `Optional[T]` struct
construction, migrate the `is_none` field constants from `gen_boolean` to
IREP2:

- None case:  `gen_boolean(true)`  → `gen_true_expr()`
- value case: `gen_boolean(false)` → `gen_false_expr()`

## Why it is behaviour-preserving

Pure bool constants; `gen_true/false_expr` back-migrate to constant
`"true"`/`"false"` identical to `gen_boolean` (same idiom as #5482),
byte-identical modulo the cosmetic `#cpp_type` hint. The sibling value-field
`gen_zero(component.type())` is left legacy: that component type may be a
struct/complex on which `gen_zero(type2tc)` aborts.

## Validation

- Probe `Optional[int]` `f(5) is not None`, `f(-1) is None` → `VERIFICATION
  SUCCESSFUL`.
- 32 optional/none tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
