### PR TITLE
[python] V.3: build bool-literal constants in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -253,8 +253,10 @@ exprt python_converter::get_literal(const nlohmann::json &element)
     return from_integer(value.get<long long>(), long_long_int_type());
 
   // Handle boolean literals (True/False)
+  // V.3: build the bool constant in IREP2, back-migrated for the legacy seam.
   if (value.is_boolean())
-    return gen_boolean(value.get<bool>());
+    return migrate_expr_back(
+      value.get<bool>() ? gen_true_expr() : gen_false_expr());
 
   // Handle floating-point literals (float)
   if (value.is_number_float())


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `converter/converter_expr.cpp`. In `get_literal`, migrate the Python
bool-literal (`True`/`False`) conversion from `gen_boolean(value)` to
`gen_true_expr()`/`gen_false_expr()`, back-migrated at the legacy seam.

## Why it is behaviour-preserving

Pure bool constant; `gen_true/false_expr` back-migrate to constant
`"true"`/`"false"` identical to `gen_boolean` (same idiom as #5482),
byte-identical modulo the cosmetic `#cpp_type` hint. This is the most
fundamental bool constant in the frontend — every `True`/`False` literal
flows through it.

## Validation

- Probe `True`/`False` in conditions (`t`, `not g`, `t and not g`) →
  `VERIFICATION SUCCESSFUL` (=7).
- 29 bool-exercising tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
