### PR TITLE
[python] V.3: build str.index not-found check in IREP2

### DIFF
--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -1804,8 +1804,11 @@ exprt string_handler::build_string_index_result(
   assign.location() = location;
   converter_.add_instruction(assign);
 
-  exprt not_found =
-    equality_exprt(build_symbol(find_result), from_integer(-1, int_type()));
+  // V.3: build the `find_result == -1` not-found check in IREP2.
+  expr2tc fr2;
+  migrate_expr(build_symbol(find_result), fr2);
+  exprt not_found = migrate_expr_back(
+    equality2tc(fr2, from_integer(BigInt(-1), migrate_type(int_type()))));
   exprt raise = python_exception_utils::make_exception_raise(
     type_handler_, "ValueError", "substring not found", &location);
 


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `string/string_method_handler.cpp`. In the `str.index()` lowering,
migrate the not-found check from legacy `exprt` builders to IREP2,
back-migrated for the legacy `code_ifthenelset` guard.

## What

```
equality_exprt(find_result, from_integer(-1, int_type()))
  -> equality2tc(find_result, from_integer(BigInt(-1), int2tc))
```

## Why it is behaviour-preserving

`find_result` is `int_type`; `equality2tc` operands int, result bool; the
IREP2 `from_integer` overload yields the same `-1` constant. Exact migrate of
the legacy builder, byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `"hello world".index("world")`==6 → SUCCESSFUL; `"hello".index("xyz")`
  → FAILED (the migrated check fires ValueError "substring not found").
- 73 str index/find tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
