### PR TITLE
[python] V.3: build missing-return assert in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -12,10 +12,12 @@
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
 #include <util/message.h>
+#include <util/migrate.h>
 #include <util/python_types.h>
 #include <util/std_code.h>
 #include <util/symbolic_types.h>
@@ -934,7 +936,8 @@ void python_converter::validate_return_paths(
   locationt loc = get_location_from_decl(function_node);
 
   code_assertt missing_return_assert;
-  missing_return_assert.assertion() = gen_boolean(false);
+  // V.3: build the always-fail assert condition in IREP2.
+  missing_return_assert.assertion() = migrate_expr_back(gen_false_expr());
   missing_return_assert.location() = loc;
   missing_return_assert.location().comment(
     "Missing return statement detected in function '" + current_func_name_ +


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `converter/converter_funcdef.cpp`. Migrate the missing-return
always-fail assert from `gen_boolean(false)` to `gen_false_expr()`,
back-migrated at the legacy `code_assertt` seam; add the
`irep2_utils`/`migrate` includes the file lacked.

## Why it is behaviour-preserving

Pure bool constant; `gen_false_expr` back-migrates to constant `"false"`
identical to `gen_boolean(false)` (same idiom as #5481/#5486/#5488),
byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe a function missing a return on one path → FAILED ("Missing return
  statement detected in function 'f'", the migrated assert fires).
- 15 return/funcdef tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
