### PR TITLE
[python] V.3: build pointer is-None check in IREP2

### DIFF
--- a/src/python-frontend/python_typechecking.cpp
+++ b/src/python-frontend/python_typechecking.cpp
@@ -290,8 +290,14 @@ exprt python_typechecking::build_none_check(const exprt &value_expr) const
       return build_member(deref, "is_none", bool_type());
     }
 
+    // V.3: build the `value == NULL` check in IREP2. Keep the legacy
+    // gen_zero(original_type) so the null-pointer constant is preserved
+    // exactly (round-tripped through migrate), then compare in IREP2.
     exprt null_expr = gen_zero(original_type);
-    return equality_exprt(value_expr, null_expr);
+    expr2tc ve2, null2;
+    migrate_expr(value_expr, ve2);
+    migrate_expr(null_expr, null2);
+    return migrate_expr_back(equality2tc(ve2, null2));
   }
 
   if (resolved_type == none_type())


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `python_typechecking.cpp`. In the `x is None` check for a pointer
type, migrate the `value==NULL` comparison from `equality_exprt` to
`equality2tc`, back-migrated at the legacy seam.

## Why it is behaviour-preserving

The legacy `gen_zero(original_type)` null-pointer constant is kept and
round-tripped through `migrate`, so the exact NULL constant is preserved;
both operands are then compared in IREP2. `equality2t` carries no
operand-type assert, so `pointer==NULL` constructs cleanly; result is bool,
operand order preserved — byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe `n.next is None` (None-initialised reference) → `VERIFICATION
  SUCCESSFUL`.
- 27 none/optional/linked-list tests pass on a Debug/asserts build, live
  `migrate.cpp` cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
