### PR TITLE
[python] V.3: build folded-bool call result in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -807,7 +807,9 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           if (result->kind == PyConstValue::INT)
             return from_integer(result->int_val, long_long_int_type());
           if (result->kind == PyConstValue::BOOL)
-            return gen_boolean(result->bool_val);
+            // V.3: build the folded bool constant in IREP2.
+            return migrate_expr_back(
+              result->bool_val ? gen_true_expr() : gen_false_expr());
           // NONE and FLOAT fall through to normal call
         }
       }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715) — first
flip in `converter/converter_funcall.cpp`. When `python_consteval` folds a
call to a constant bool, migrate the result from `gen_boolean(result->bool_val)`
to `gen_true_expr()`/`gen_false_expr()`, back-migrated at the legacy seam.

## Why it is behaviour-preserving

Pure bool constant; `gen_true/false_expr` back-migrate to constant
`"true"`/`"false"` identical to `gen_boolean` (same idiom as #5482/#5488),
byte-identical modulo the cosmetic `#cpp_type` hint.

## Validation

- Probe a const-evaluable bool-returning function `is_pos(5)`/`is_pos(-2)`
  folded into conditions → `VERIFICATION SUCCESSFUL` (=3).
- Bisect confirms behaviour-preservation: an unrelated `bool()` probe FAILS
  identically with and without the change.
- 6 consteval tests pass on a Debug/asserts build, live `migrate.cpp`
  cross-check silent.
- clang-format 11 clean. Dual-solver parity delegated to CI.
