### PR TITLE
[python] Bind inline list-returning call result in len() argument

### DIFF
--- a/regression/python/github_5464/main.py
+++ b/regression/python/github_5464/main.py
@@ -1,0 +1,12 @@
+# Regression for #5464: an inline list-returning call consumed directly by
+# len() -- e.g. len(sorted(d)) -- must bind the call's return value so the
+# size is read from the actual sorted list, not an uninitialised temporary.
+# Previously these reported a spurious VERIFICATION FAILED (wrong list size).
+def main() -> None:
+    m = {3: 30, 1: 10, 2: 20}
+    assert len(sorted(m)) == 3
+    assert len(sorted(m.keys())) == 3
+    assert len(sorted(list(m.keys()))) == 3
+
+
+main()

--- a/regression/python/github_5464/test.desc
+++ b/regression/python/github_5464/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5464_fail/main.py
+++ b/regression/python/github_5464_fail/main.py
@@ -1,0 +1,8 @@
+# Negative variant of github_5464: the dict has three keys, so len(sorted(m))
+# is 3 and the assertion that it equals 2 must fail.
+def main() -> None:
+    m = {3: 30, 1: 10, 2: 20}
+    assert len(sorted(m)) == 2
+
+
+main()

--- a/regression/python/github_5464_fail/test.desc
+++ b/regression/python/github_5464_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4401,19 +4401,35 @@ exprt function_call_expr::handle_general_function_call()
       }
       else
       {
-        const typet list_type = type_handler_.get_list_type();
-        symbolt &tmp_list = converter_.create_tmp_symbol(
-          call_, "$obj_size_list_arg$", list_type, exprt());
+        // get_expr() may hand back an inline list-returning call -- e.g. the
+        // sorted(m) in len(sorted(m)) -- as a code_function_callt statement
+        // rather than a value. Assigning that statement to a temp discards the
+        // call's return value, leaving the temp at its NONDET decl and giving a
+        // wrong size (#5464). materialize_list_function_call() binds the return
+        // value into a temp and yields that symbol (the same path the
+        // sorted()[i] subscript sibling uses, #4807); non-call args pass
+        // through unchanged.
+        arg = converter_.materialize_list_function_call(
+          arg, call_, *converter_.current_block);
 
-        code_declt tmp_decl(build_symbol(tmp_list));
-        tmp_decl.location() = location;
-        converter_.current_block->copy_to_operands(tmp_decl);
+        if (arg.is_symbol())
+          list_symbol = converter_.find_symbol(arg.identifier().as_string());
+        else
+        {
+          const typet list_type = type_handler_.get_list_type();
+          symbolt &tmp_list = converter_.create_tmp_symbol(
+            call_, "$obj_size_list_arg$", list_type, exprt());
 
-        code_assignt tmp_assign(build_symbol(tmp_list), arg);
-        tmp_assign.location() = location;
-        converter_.current_block->copy_to_operands(tmp_assign);
+          code_declt tmp_decl(build_symbol(tmp_list));
+          tmp_decl.location() = location;
+          converter_.current_block->copy_to_operands(tmp_decl);
 
-        list_symbol = &tmp_list;
+          code_assignt tmp_assign(build_symbol(tmp_list), arg);
+          tmp_assign.location() = location;
+          converter_.current_block->copy_to_operands(tmp_assign);
+
+          list_symbol = &tmp_list;
+        }
       }
 
       assert(list_symbol);


### PR DESCRIPTION
## What

`len()` / `__ESBMC_get_object_size` on an **inline list-returning call** — e.g. `len(sorted(d))` — assigned the call *statement* to a temporary instead of binding its return value. The temp stayed at its `NONDET` declaration, so `__ESBMC_list_size` read a nondeterministic size and ESBMC reported a **spurious `VERIFICATION FAILED`** on a trivially-true assertion (soundness false alarm).

Minimal reproducer:

```python
def main() -> None:
    m = {3: 30, 1: 10, 2: 20}
    assert len(sorted(m)) == 3   # true in CPython; ESBMC reported FAILED


main()
```

## Why / root cause

In `src/python-frontend/function_call/expr.cpp`, the `len`/`strlen`/`__ESBMC_get_object_size` argument handler's `else` branch did `code_assignt(tmp_list, arg)`. When `arg` is a `code_function_callt` *statement* (an inline call), the GOTO converter lowers the call with **no LHS** and discards its return value, leaving `tmp_list` nondet.

`x = sorted(m); len(x)` always worked (the assignment binds the return value); only the inline form was broken. `sorted([3,1,2])` (a literal list) also worked, via the existing frontend fast-path.

## Fix

Route the argument through the existing `materialize_list_function_call` helper (`converter_funcall.cpp`), which binds a list-returning call's return value into a temp and yields that symbol — the same path the `sorted()[i]` subscript sibling (#4807) already uses. Non-call args pass through unchanged and keep the original temp+assign path.

## Testing

- New regression tests `regression/python/github_5464` (SUCCESSFUL) and `github_5464_fail` (FAILED). The positive test is the discriminator: `len(sorted(m)) == 3` was refutable under the nondet size and is now SUCCESSFUL.
- Discriminators all verified: `len(sorted(m))`, `len(sorted(m.keys()))`, `len(sorted(list(m.keys())))` → SUCCESSFUL; negative control `== 2` → still FAILED (checker not suppressed).
- Affected-path regression subset (sorted/len/list/dictcomp/#4807) passes; no non-environmental regressions in the broad python suite.

Fixes #5464.