### PR TITLE
[ir-ieee] mark zero divided by zero as NaN

### DIFF
--- a/regression/ir-ra/ra-div-zero-zero-nan-fail/main.c
+++ b/regression/ir-ra/ra-div-zero-zero-nan-fail/main.c
@@ -1,0 +1,17 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+
+  __ESBMC_assert(z > -100.0, "0.0 / 0.0 > -100.0 should not hold for NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-div-zero-zero-nan-fail/test.desc
+++ b/regression/ir-ra/ra-div-zero-zero-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-div-zero-zero-nan-prop/main.c
+++ b/regression/ir-ra/ra-div-zero-zero-nan-prop/main.c
@@ -1,0 +1,18 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+  double t = z + 1.0;
+
+  __ESBMC_assert(!(t > -100.0), "NaN + 1.0 > -100.0 is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-div-zero-zero-nan-prop/test.desc
+++ b/regression/ir-ra/ra-div-zero-zero-nan-prop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-div-zero-zero-nan/main.c
+++ b/regression/ir-ra/ra-div-zero-zero-nan/main.c
@@ -1,0 +1,17 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+
+  __ESBMC_assert(!(z > -100.0), "0.0 / 0.0 > -100.0 is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-div-zero-zero-nan/test.desc
+++ b/regression/ir-ra/ra-div-zero-zero-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -595,7 +595,13 @@ smt_astt ir_ieee_convt::encode_ieee_div(const expr2tc &expr)
       apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
     smt_astt a = ctx->mk_ite(div_by_zero, inf_result, real_result);
     store_interval(a, bounds.first, bounds.second);
-    store_combined_nan_pred(a, side1, side2);
+    smt_astt zero_div_zero_nan =
+      ctx->mk_and(ctx->mk_eq(side1, zero), div_by_zero);
+    store_nan_pred(
+      a,
+      combine_nan_preds(
+        combine_nan_preds(get_nan_pred(side1), get_nan_pred(side2)),
+        zero_div_zero_nan));
     return a;
   }
 


### PR DESCRIPTION
## Summary

This PR adds a new `--ir-ieee` NaN source for the real/integer floating-point encoding.

It marks the `0.0 / 0.0` division case as NaN by storing a NaN predicate on the division result when both operands are known to be zero.

This builds on the existing NaN predicate infrastructure and the recently merged NaN propagation support.

## Motivation

The previous NaN propagation work preserves already-known NaN predicates through arithmetic operations. However, those predicates still need to be introduced at individual IEEE NaN source points.

One such source is division where both numerator and denominator are zero:

```c
double z = x / y;
```

with:

```c
x == 0.0
y == 0.0
```

Under IEEE semantics, this result is NaN. This PR records that fact in the `--ir-ieee` metadata so comparisons involving the result can use the existing NaN-aware comparison handling.

## Changes

This PR updates the `--ir-ieee` interval-lifted division path in `ir_ieee_convt::encode_ieee_div`.

When both division operands are known to be zero, it creates a NaN predicate for the division result and stores it using the existing NaN predicate infrastructure.

The predicate is stored on the actual result expression returned by the division encoding.

This PR reuses the existing:

* `get_nan_pred`
* `store_nan_pred`
* `combine_nan_preds`

infrastructure.

It does not introduce a new NaN tracking mechanism.

## Regression Test

Three new CORE regression tests were added under `regression/ir-ra/`:

* `ra-div-zero-zero-nan`

  * Checks that `0.0 / 0.0` is treated as NaN-aware in ordered comparisons such as `!(z > -100.0)`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-div-zero-zero-nan-fail`

  * Failing companion test.
  * Checks that an ordered comparison involving the NaN result, such as `z > -100.0`, does not incorrectly hold.
  * Expected result: `VERIFICATION FAILED`.

* `ra-div-zero-zero-nan-prop`

  * Checks that the NaN predicate produced by `0.0 / 0.0` propagates through a later arithmetic operation.
  * Expected result: `VERIFICATION SUCCESSFUL`.

The tests use symbolic nondeterministic operands constrained to zero with `__ESBMC_assume` instead of literal-only `0.0 / 0.0`. This avoids front-end constant folding and ensures the division reaches the `--ir-ieee` SMT encoding path.

## Testing

The new regression tests were run:

```bash
ctest --test-dir build -R "ra-div-zero-zero-nan" --output-on-failure
```

Result:

```text
3/3 passed
```

The failing companion `ra-div-zero-zero-nan-fail` was also run directly to inspect the counterexample. It produced:

```text
x = 0.000000
y = 0.000000
z = +NAN
VERIFICATION FAILED
```

This confirms that the NaN result is produced for the zero-divided-by-zero case and that the ordered comparison fails as expected.

## Notes

This PR is intentionally limited to the `0.0 / 0.0` NaN case.

It does not implement general division-by-zero IEEE behaviour. In particular, it does not add infinity tracking for non-zero values divided by zero.

It also does not add support for `INFINITY - INFINITY`, `0.0 * INFINITY`, `nan("")`, signed zero, casts, nearbyint, or `isnan`.