### PR TITLE
[python] Fold str % formatting instead of crashing the SMT backend

### DIFF
--- a/regression/python/github_5495/main.py
+++ b/regression/python/github_5495/main.py
@@ -1,0 +1,23 @@
+# Regression for #5495: `str % args` (printf-style formatting) was mis-lowered
+# as numeric modulo on the format string's pointer, crashing the SMT backend
+# (SIGSEGV) when the result was consumed by len()/==. Constant format + constant
+# args are now folded to the correct string literal. The `==` checks validate
+# exact content (and therefore length); len() is exercised via a bound variable.
+def main() -> None:
+    assert "%d" % 5 == "5"
+    assert "%i" % 7 == "7"
+    assert "%d-%d" % (3, 4) == "3-4"
+    assert "%s" % "hi" == "hi"
+    assert "val=%s" % 42 == "val=42"
+    assert "%s" % True == "True"
+    assert "%x" % 255 == "ff"
+    assert "%X" % 255 == "FF"
+    assert "%o" % 8 == "10"
+    assert "%c" % 65 == "A"
+    assert "%d%%" % 50 == "50%"
+    assert "%d" % (-7) == "-7"
+    s = "%d" % 5
+    assert len(s) == 1
+
+
+main()

--- a/regression/python/github_5495/test.desc
+++ b/regression/python/github_5495/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5495_fail/main.py
+++ b/regression/python/github_5495_fail/main.py
@@ -1,0 +1,8 @@
+# Negative variant of github_5495: the formatted string is "3-4", so asserting
+# it equals "3-5" must fail.
+def main() -> None:
+    s = "%d-%d" % (3, 4)
+    assert s == "3-5"
+
+
+main()

--- a/regression/python/github_5495_fail/test.desc
+++ b/regression/python/github_5495_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -25,6 +25,160 @@
 #include <cctype>
 #include <sstream>
 
+namespace
+{
+// Parse a constant integer from a Python AST argument node: a Constant int or
+// bool, or a UnaryOp(USub) over one (the parser emits negative literals that
+// way). Returns false when the node is not a compile-time integer.
+bool py_const_int(const nlohmann::json &a, long long &out)
+{
+  if (!a.is_object())
+    return false;
+  const std::string t = a.value("_type", "");
+  if (t == "Constant" && a.contains("value"))
+  {
+    if (a["value"].is_number_integer())
+    {
+      out = a["value"].get<long long>();
+      return true;
+    }
+    if (a["value"].is_boolean())
+    {
+      out = a["value"].get<bool>() ? 1 : 0;
+      return true;
+    }
+    return false;
+  }
+  if (
+    t == "UnaryOp" && a.contains("operand") &&
+    a.value("op", nlohmann::json::object()).value("_type", "") == "USub")
+  {
+    long long v;
+    if (py_const_int(a["operand"], v))
+    {
+      out = -v;
+      return true;
+    }
+  }
+  return false;
+}
+
+// Constant-fold a printf-style ``str % args`` formatting, matching CPython for
+// the supported conversions. Throws std::runtime_error for any unsupported
+// conversion, flag/width/precision, or non-constant argument, so the caller
+// surfaces a clean diagnostic instead of mis-lowering ``str % x`` to pointer
+// arithmetic (which crashed the SMT backend, #5495).
+std::string py_percent_format(
+  const std::string &fmt,
+  const std::vector<nlohmann::json> &args)
+{
+  std::string out;
+  size_t argi = 0;
+  auto next_arg = [&]() -> const nlohmann::json & {
+    if (argi >= args.size())
+      throw std::runtime_error(
+        "TypeError: not enough arguments for format string");
+    return args[argi++];
+  };
+
+  for (size_t i = 0; i < fmt.size(); ++i)
+  {
+    if (fmt[i] != '%')
+    {
+      out.push_back(fmt[i]);
+      continue;
+    }
+    if (i + 1 >= fmt.size())
+      throw std::runtime_error("ValueError: incomplete format");
+    const char c = fmt[++i];
+    switch (c)
+    {
+    case '%':
+      out.push_back('%');
+      break;
+    case 'd':
+    case 'i':
+    {
+      long long v;
+      if (!py_const_int(next_arg(), v))
+        throw std::runtime_error(
+          "unsupported: non-constant argument in str %% formatting");
+      out += std::to_string(v);
+      break;
+    }
+    case 's':
+    {
+      const nlohmann::json &a = next_arg();
+      long long v;
+      if (
+        a.value("_type", "") == "Constant" && a.contains("value") &&
+        a["value"].is_boolean())
+        // CPython renders bool via str(): "True"/"False", not "1"/"0".
+        out += a["value"].get<bool>() ? "True" : "False";
+      else if (
+        a.value("_type", "") == "Constant" && a.contains("value") &&
+        a["value"].is_string())
+        out += a["value"].get<std::string>();
+      else if (py_const_int(a, v))
+        out += std::to_string(v);
+      else
+        throw std::runtime_error(
+          "unsupported: non-constant argument in str %% formatting");
+      break;
+    }
+    case 'x':
+    case 'X':
+    case 'o':
+    {
+      long long v;
+      if (!py_const_int(next_arg(), v))
+        throw std::runtime_error(
+          "unsupported: non-constant argument in str %% formatting");
+      if (v < 0)
+        throw std::runtime_error(
+          "unsupported: negative argument in str %% %x/%o formatting");
+      std::ostringstream ss;
+      if (c == 'o')
+        ss << std::oct << v;
+      else
+        ss << (c == 'X' ? std::uppercase : std::nouppercase) << std::hex << v;
+      out += ss.str();
+      break;
+    }
+    case 'c':
+    {
+      const nlohmann::json &a = next_arg();
+      long long v;
+      if (py_const_int(a, v))
+      {
+        if (v < 0 || v > 255)
+          throw std::runtime_error(
+            "unsupported: %c code points above 255 (non-ASCII) not modelled");
+        out.push_back(static_cast<char>(v));
+      }
+      else if (
+        a.value("_type", "") == "Constant" && a.contains("value") &&
+        a["value"].is_string() && a["value"].get<std::string>().size() == 1)
+        out += a["value"].get<std::string>();
+      else
+        throw std::runtime_error(
+          "unsupported: %c argument in str %% formatting");
+      break;
+    }
+    default:
+      throw std::runtime_error(
+        std::string("unsupported conversion '%") + c +
+        "' in str %% formatting");
+    }
+  }
+
+  if (argi != args.size())
+    throw std::runtime_error(
+      "TypeError: not all arguments converted during string formatting");
+  return out;
+}
+} // namespace
+
 exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
 {
   // `and`/`or` short-circuit: a later operand may not execute. get_named_expr
@@ -1094,6 +1248,39 @@ exprt python_converter::handle_array_operations(
         msg << " at " << loc.get_file() << ":" << loc.get_line();
       throw std::runtime_error(msg.str());
     }
+  }
+
+  // Python ``str % args`` is string formatting, not numeric modulo. Falling
+  // through to the generic arithmetic path builds ``&"%d"[0] % 5`` (pointer
+  // modulo int), mistypes the result as ``char[0]``, and crashes the SMT
+  // backend on the bogus pointer arithmetic (#5495). Constant-fold the common
+  // printf-style conversions into a string literal; throw a clean diagnostic
+  // for anything not modelled (non-constant format/args, widths, floats).
+  if (op == "Mod" && type_utils::is_string_type(lhs.type()))
+  {
+    // Gate on the string type (char-element array), not the structural 8-bit
+    // test: np.int8/np.uint8 arrays are also 8-bit arrays but use a bv element,
+    // and their `% scalar` must keep flowing through the numeric path.
+    if (
+      left.value("_type", "") != "Constant" || !left.contains("value") ||
+      !left["value"].is_string())
+      throw std::runtime_error(
+        "unsupported: str %% formatting requires a literal format string");
+
+    std::vector<nlohmann::json> args;
+    if (right.is_object() && right.value("_type", "") == "Tuple")
+      for (const auto &e : right["elts"])
+        args.push_back(e);
+    else
+      args.push_back(right);
+
+    // Re-enter conversion through a synthesised Constant node so the folded
+    // string flows through the exact same path as a string literal (e.g.
+    // len("ab")), which materialises it correctly when consumed inline by
+    // len()/==. Building the array directly left it unaddressable inline.
+    nlohmann::json folded = left;
+    folded["value"] = py_percent_format(left["value"].get<std::string>(), args);
+    return get_expr(folded);
   }
 
   // Handle string concatenation -- only valid for char-arrays. Numeric


### PR DESCRIPTION
## What

`str % args` (printf-style string formatting) was mis-lowered as **numeric modulo on the format string's pointer** — `&"%d"[0] % 5` — typing the result `char[0]`. Consuming the formatted string with `len()` or `==` then fed a malformed term to the SMT backend and **crashed ESBMC with a SIGSEGV** (`bitwuzla_mk_term2`).

```python
def main() -> None:
    s = "%d" % 5
    assert len(s) == 1   # Segmentation fault before this PR


main()
```

## Fix

In `handle_array_operations` (`converter/converter_binop.cpp`), intercept `Mod` with a **string** LHS and constant-fold the common printf-style conversions into a string literal, re-entering conversion through a synthesised `Constant` node so the result flows through the identical path as a string literal:

- Supported: `%d %i %s %x %X %o %c %%`, negative literals (`UnaryOp(USub)`), and `%s` of a bool (`True`/`False`, matching CPython `str()`).
- Non-constant format/args, floats, widths/precision/flags → a clean `runtime_error` diagnostic instead of a crash.

The gate is `type_utils::is_string_type(lhs)` (char-element array), **not** the structural 8-bit-array test — so `np.int8`/`np.uint8` array `% scalar` keeps flowing through the numeric path untouched.

## Testing

- New regression tests: `regression/python/github_5495` (CORE, SUCCESSFUL — exercises every supported conversion, bool `%s`, `%%`, negative, and `len()` via a bound variable) and `regression/python/github_5495_fail` (CORE, FAILED — wrong-content assertion).
- All folded results verified against CPython; wrong assertions correctly report `VERIFICATION FAILED`; non-constant args produce a graceful error rather than a crash.
- Broad python regression sweep: no non-environmental regressions (numeric `%` and numpy array `%` paths unchanged).

## Known limitations (out of scope; pre-existing)

- `str` **variable** `% args` (non-literal format string) is not folded.
- Inline `len("%d" % 5)` (no intermediate variable) is a separate pre-existing len-handler limitation for inline non-symbol char-array args.

Fixes #5495.
