### PR TITLE
[python] Sound reads + dict-kind inference for unannotated param dicts

### DIFF
--- a/regression/python/param_dict_for_iter/main.py
+++ b/regression/python/param_dict_for_iter/main.py
@@ -1,0 +1,11 @@
+def summarize(g):
+    n = 0
+    for k in g:
+        n += 1
+    s = 0
+    for k, w in g.items():
+        s += w
+    return n + s
+
+
+assert summarize({'a': 3, 'b': 7}) == 12

--- a/regression/python/param_dict_for_iter/test.desc
+++ b/regression/python/param_dict_for_iter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/param_dict_for_iter_fail/main.py
+++ b/regression/python/param_dict_for_iter_fail/main.py
@@ -1,0 +1,11 @@
+def summarize(g):
+    n = 0
+    for k in g:
+        n += 1
+    s = 0
+    for k, w in g.items():
+        s += w
+    return n + s
+
+
+assert summarize({'a': 3, 'b': 7}) == 99

--- a/regression/python/param_dict_for_iter_fail/test.desc
+++ b/regression/python/param_dict_for_iter_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/param_dict_items/main.py
+++ b/regression/python/param_dict_items/main.py
@@ -1,0 +1,8 @@
+def total(g):
+    s = 0
+    for k, w in g.items():
+        s += w
+    return s
+
+
+assert total({'a': 3, 'b': 7}) == 10

--- a/regression/python/param_dict_items/test.desc
+++ b/regression/python/param_dict_items/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/param_dict_items_fail/main.py
+++ b/regression/python/param_dict_items_fail/main.py
@@ -1,0 +1,8 @@
+def total(g):
+    s = 0
+    for k, w in g.items():
+        s += w
+    return s
+
+
+assert total({'a': 3, 'b': 7}) == 99

--- a/regression/python/param_dict_items_fail/test.desc
+++ b/regression/python/param_dict_items_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/param_dict_scope/main.py
+++ b/regression/python/param_dict_scope/main.py
@@ -1,0 +1,16 @@
+def dict_sum(g):
+    s = 0
+    for k, w in g.items():
+        s += w
+    return s
+
+
+def list_sum(g):
+    s = 0
+    for x in g:
+        s += x
+    return s
+
+
+assert dict_sum({'a': 3, 'b': 7}) == 10
+assert list_sum([1, 2, 3]) == 6

--- a/regression/python/param_dict_scope/test.desc
+++ b/regression/python/param_dict_scope/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -890,6 +890,28 @@ class CoreVisitorsMixin:
                 param_type = self._extract_type_from_annotation(arg.annotation)
                 self.known_variable_types[arg.arg] = param_type
                 self.variable_annotations[arg.arg] = arg.annotation
+        self._infer_dict_params_structurally(node)
+
+    def _infer_dict_params_structurally(self, node):
+        """Recover the container *kind* of unannotated parameters.
+
+        An unannotated parameter carries no static type, so a dict passed into
+        it is treated as a list: iterating it (`for k, v in p`) or comprehending
+        over it then fails. Only dicts expose .items()/.keys()/.values(), so a
+        parameter on which any of those is called in the body is a dict. This
+        recovers the kind, not the element type (which would be unsound to
+        guess), and unblocks iteration/comprehension over a parameter dict
+        (#5444).
+        """
+        # Unannotated parameters only; annotated ones are recorded above.
+        all_args = (list(node.args.posonlyargs) + list(node.args.args) + list(node.args.kwonlyargs))
+        candidates = {arg.arg for arg in all_args if arg.annotation is None}
+        dict_methods = {"items", "keys", "values"}
+        for n in ast.walk(node):
+            if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                    and n.func.attr in dict_methods and isinstance(n.func.value, ast.Name)
+                    and n.func.value.id in candidates):
+                self.known_variable_types[n.func.value.id] = "dict"
 
     def _build_qualified_function_name(self, node):
         if hasattr(self, "current_class_name") and self.current_class_name:
@@ -1094,6 +1116,10 @@ class CoreVisitorsMixin:
         # restore on exit so a dict named `d` in one function does not make a
         # same-named plain parameter in another function look like a dict.
         saved_dict_vars = set(self.dict_literal_vars)
+        # Parameter/local variable kinds are scope-local for the same reason:
+        # an unannotated dict parameter recorded in one function must not make a
+        # same-named plain parameter in another function look like a dict (#5444).
+        saved_known_types = dict(self.known_variable_types)
         # Per-function scope for call-origin tracking and the eq-only set.
         saved_call_origins = dict(self._assignment_call_origins)
         self._assignment_call_origins.clear()
@@ -1130,5 +1156,6 @@ class CoreVisitorsMixin:
             return return_nodes
         finally:
             self.dict_literal_vars = saved_dict_vars
+            self.known_variable_types = saved_known_types
             self._assignment_call_origins = saved_call_origins
             self._eq_only_items_view_targets = saved_eq_only

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4690,6 +4690,33 @@ exprt python_list::extract_pyobject_value(
   exprt obj_value =
     build_deref_member(pyobject_expr, "value", pointer_typet(empty_typet()));
 
+  // Element whose static type was erased to any_type() (void*): this happens
+  // when a dict/list crosses into an *unannotated* parameter, where keys()/
+  // values() reads have no compile-time element type (#5444). The generic
+  // "cast void* to T* and dereference" path below overruns a string element: a
+  // str is stored as a short char[] at item->value (e.g. a 2-byte key), so an
+  // 8-byte void* dereference reads past the array (array-bounds violation). The
+  // element's *runtime* type is recorded in item->type_id (stamped at push
+  // time), so when it marks a string, keep the stored pointer (== char*, the
+  // same value the annotated str path returns) with no dereference. Every other
+  // type keeps the proven dereference read, so numeric elements are unaffected.
+  // The dispatch key is the caller-stamped type, not a usage heuristic, so this
+  // stays sound.
+  if (elem_type.is_pointer() && elem_type.subtype().id() == "empty")
+  {
+    const size_t str_type_id = std::hash<std::string>{}(
+      converter_.get_type_handler().type_to_string(pointer_typet(char_type())));
+    exprt type_id_member =
+      build_deref_member(pyobject_expr, "type_id", size_type());
+    // Default: cast void* to void** and dereference (the read that already
+    // works for numeric / pointer-by-value elements).
+    exprt as_default = build_dereference(
+      build_typecast(obj_value, pointer_typet(elem_type)), elem_type);
+    equality_exprt is_str(
+      type_id_member, from_integer(str_type_id, size_type()));
+    return if_exprt(is_str, obj_value, as_default);
+  }
+
   // For array types, return pointer to element type instead of pointer to array
   // The dereference system doesn't support array types as target types
   if (elem_type.is_array())

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2883,8 +2883,11 @@ exprt python_list::handle_index_access(
       list_at_call = build_symbol(elem_obj);
     }
 
-    // Extract and dereference PyObject value
-    return extract_pyobject_value(list_at_call, elem_type, mixed_numeric);
+    // Extract and dereference PyObject value. string_safe: a subscript read is
+    // value-context (assigned to the target), so an any_type string element may
+    // be returned by pointer without overrunning its short char[] storage.
+    return extract_pyobject_value(
+      list_at_call, elem_type, mixed_numeric, /*string_safe=*/true);
   }
 
   // Handle static string indexing with IndexError on out-of-bounds
@@ -4637,7 +4640,8 @@ exprt python_list::build_pop_list_call(
 exprt python_list::extract_pyobject_value(
   const exprt &pyobject_expr,
   const typet &elem_type,
-  bool mixed_numeric)
+  bool mixed_numeric,
+  bool string_safe)
 {
   // For float types, read __ESBMC_float_buf[item->float_idx].
   // This avoids the void*→integer truncation in --ir mode: float_idx is a size_t
@@ -4701,8 +4705,13 @@ exprt python_list::extract_pyobject_value(
   // same value the annotated str path returns) with no dereference. Every other
   // type keeps the proven dereference read, so numeric elements are unaffected.
   // The dispatch key is the caller-stamped type, not a usage heuristic, so this
-  // stays sound.
-  if (elem_type.is_pointer() && elem_type.subtype().id() == "empty")
+  // stays sound. Gated on string_safe because the result is an if-expression
+  // (rvalue): callers that take its address (membership/find on heaps, queues,
+  // sets) need the plain dereference lvalue, so only value-context reads
+  // (subscript) opt in.
+  if (
+    string_safe && elem_type.is_pointer() &&
+    elem_type.subtype().id() == "empty")
   {
     const size_t str_type_id = std::hash<std::string>{}(
       converter_.get_type_handler().type_to_string(pointer_typet(char_type())));

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -195,7 +195,8 @@ public:
   exprt extract_pyobject_value(
     const exprt &pyobject_expr,
     const typet &elem_type,
-    bool mixed_numeric = false);
+    bool mixed_numeric = false,
+    bool string_safe = false);
 
   /**
    * @brief Check if all elements in a list have the same type.


### PR DESCRIPTION
Stacked on #5443 (base = `fix/python-dictcomp-over-dict-4803`); retarget to `master` once #5443 merges.

A sound sub-fix for #5444. A dict passed to an unannotated parameter erased its element types to `void*`, so string keys/values were read with an 8-byte dereference that overran the short `char[]` storage (spurious array-bounds violation), and the parameter was not recognised as a dict for plain iteration/comprehension.

`extract_pyobject_value` now reads a string element by its stored pointer (dispatching on the runtime `type_id`, not a usage heuristic), and the preprocessor records an unannotated parameter as a dict when the body calls `.items()/.keys()/.values()` on it (container kind only, never element type). Adds 5 regression tests.

Out of scope (tracked follow-ups): full `shortest_paths` support (param tuple-key type recovery, int/float `__ESBMC_dict_eq`, mixed `min`) and a pre-existing SMT crash for float values read through a parameter dict. Refs #5444.