### PR TITLE
[python] Reject str-variable % formatting instead of crashing

### DIFF
--- a/regression/python/github_5495/main.py
+++ b/regression/python/github_5495/main.py
@@ -1,0 +1,23 @@
+# Regression for #5495: `str % args` (printf-style formatting) was mis-lowered
+# as numeric modulo on the format string's pointer, crashing the SMT backend
+# (SIGSEGV) when the result was consumed by len()/==. Constant format + constant
+# args are now folded to the correct string literal. The `==` checks validate
+# exact content (and therefore length); len() is exercised via a bound variable.
+def main() -> None:
+    assert "%d" % 5 == "5"
+    assert "%i" % 7 == "7"
+    assert "%d-%d" % (3, 4) == "3-4"
+    assert "%s" % "hi" == "hi"
+    assert "val=%s" % 42 == "val=42"
+    assert "%s" % True == "True"
+    assert "%x" % 255 == "ff"
+    assert "%X" % 255 == "FF"
+    assert "%o" % 8 == "10"
+    assert "%c" % 65 == "A"
+    assert "%d%%" % 50 == "50%"
+    assert "%d" % (-7) == "-7"
+    s = "%d" % 5
+    assert len(s) == 1
+
+
+main()

--- a/regression/python/github_5495/test.desc
+++ b/regression/python/github_5495/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5495_fail/main.py
+++ b/regression/python/github_5495_fail/main.py
@@ -1,0 +1,8 @@
+# Negative variant of github_5495: the formatted string is "3-4", so asserting
+# it equals "3-5" must fail.
+def main() -> None:
+    s = "%d-%d" % (3, 4)
+    assert s == "3-5"
+
+
+main()

--- a/regression/python/github_5495_fail/test.desc
+++ b/regression/python/github_5495_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_5499/main.py
+++ b/regression/python/github_5499/main.py
@@ -1,0 +1,14 @@
+# Regression for #5499 (and the #5495 hoist): str % formatting handling now runs
+# in get_binary_operator_expr before the is_array() gate, so it covers both char
+# arrays (literals) and char pointers (str variables). Literal format + constant
+# args still fold to the correct string here.
+def labelled() -> str:
+    return "item-%d" % 7
+
+
+def main() -> None:
+    assert labelled() == "item-7"
+    assert "%s=%d" % ("x", 5) == "x=5"
+
+
+main()

--- a/regression/python/github_5499/test.desc
+++ b/regression/python/github_5499/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5499_unsupported/main.py
+++ b/regression/python/github_5499_unsupported/main.py
@@ -1,0 +1,14 @@
+# Regression for #5499: a `str` *variable* used as a printf format string was
+# lowered as pointer modulo and crashed the SMT backend (SIGSEGV). It is now
+# rejected with a clean diagnostic instead of crashing. The program itself is
+# valid Python (runs cleanly under CPython); only ESBMC cannot model it.
+def fmt_int(fmt: str, n: int) -> str:
+    return fmt % n
+
+
+def main() -> None:
+    s = fmt_int("%d", 5)
+    assert len(s) >= 0
+
+
+main()

--- a/regression/python/github_5499_unsupported/test.desc
+++ b/regression/python/github_5499_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: unsupported: str % formatting requires a literal format string$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -102,7 +102,7 @@ std::string py_percent_format(
       long long v;
       if (!py_const_int(next_arg(), v))
         throw std::runtime_error(
-          "unsupported: non-constant argument in str %% formatting");
+          "unsupported: non-constant argument in str % formatting");
       out += std::to_string(v);
       break;
     }
@@ -123,7 +123,7 @@ std::string py_percent_format(
         out += std::to_string(v);
       else
         throw std::runtime_error(
-          "unsupported: non-constant argument in str %% formatting");
+          "unsupported: non-constant argument in str % formatting");
       break;
     }
     case 'x':
@@ -133,10 +133,10 @@ std::string py_percent_format(
       long long v;
       if (!py_const_int(next_arg(), v))
         throw std::runtime_error(
-          "unsupported: non-constant argument in str %% formatting");
+          "unsupported: non-constant argument in str % formatting");
       if (v < 0)
         throw std::runtime_error(
-          "unsupported: negative argument in str %% %x/%o formatting");
+          "unsupported: negative argument in str % %x/%o formatting");
       std::ostringstream ss;
       if (c == 'o')
         ss << std::oct << v;
@@ -162,13 +162,13 @@ std::string py_percent_format(
         out += a["value"].get<std::string>();
       else
         throw std::runtime_error(
-          "unsupported: %c argument in str %% formatting");
+          "unsupported: %c argument in str % formatting");
       break;
     }
     default:
       throw std::runtime_error(
         std::string("unsupported conversion '%") + c +
-        "' in str %% formatting");
+        "' in str % formatting");
     }
   }
 
@@ -670,6 +670,40 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   // building, which cannot operate directly on struct operands.
   if (is_complex_type(lhs.type()) || is_complex_type(rhs.type()))
     return complex_handler_.handle_binary_op(op, lhs, rhs, element);
+
+  // Python ``str % args`` is string formatting, not numeric modulo. The generic
+  // arithmetic path builds ``str_ptr % int``, mistypes the result, and crashes
+  // the SMT backend (#5495 for a literal format, #5499 for a str variable). It
+  // runs before the is_array() gate below because a ``str`` parameter is a char
+  // *pointer*, not an array, so it would otherwise miss handle_array_operations
+  // (whose gate requires an array operand). is_string_type covers both char
+  // arrays (literals) and char pointers (str variables),
+  // but not np.int8/np.uint8 arrays, whose ``% scalar`` keeps its numeric path.
+  if (op == "Mod" && type_utils::is_string_type(lhs.type()))
+  {
+    // Only a literal format string is constant-foldable; a variable format
+    // (#5499) is rejected with a clean diagnostic rather than crashing.
+    if (
+      left.value("_type", "") != "Constant" || !left.contains("value") ||
+      !left["value"].is_string())
+      throw std::runtime_error(
+        "unsupported: str % formatting requires a literal format string");
+
+    std::vector<nlohmann::json> args;
+    if (right.is_object() && right.value("_type", "") == "Tuple")
+      for (const auto &e : right["elts"])
+        args.push_back(e);
+    else
+      args.push_back(right);
+
+    // Re-enter conversion through a synthesised Constant node so the folded
+    // string flows through the exact same path as a string literal (e.g.
+    // len("ab")), which materialises it correctly when consumed inline by
+    // len()/==. Building the array directly left it unaddressable inline.
+    nlohmann::json folded = left;
+    folded["value"] = py_percent_format(left["value"].get<std::string>(), args);
+    return get_expr(folded);
+  }
 
   // Handle array/string operations
   if (lhs.type().is_array() || rhs.type().is_array())
@@ -1248,39 +1282,6 @@ exprt python_converter::handle_array_operations(
         msg << " at " << loc.get_file() << ":" << loc.get_line();
       throw std::runtime_error(msg.str());
     }
-  }
-
-  // Python ``str % args`` is string formatting, not numeric modulo. Falling
-  // through to the generic arithmetic path builds ``&"%d"[0] % 5`` (pointer
-  // modulo int), mistypes the result as ``char[0]``, and crashes the SMT
-  // backend on the bogus pointer arithmetic (#5495). Constant-fold the common
-  // printf-style conversions into a string literal; throw a clean diagnostic
-  // for anything not modelled (non-constant format/args, widths, floats).
-  if (op == "Mod" && type_utils::is_string_type(lhs.type()))
-  {
-    // Gate on the string type (char-element array), not the structural 8-bit
-    // test: np.int8/np.uint8 arrays are also 8-bit arrays but use a bv element,
-    // and their `% scalar` must keep flowing through the numeric path.
-    if (
-      left.value("_type", "") != "Constant" || !left.contains("value") ||
-      !left["value"].is_string())
-      throw std::runtime_error(
-        "unsupported: str %% formatting requires a literal format string");
-
-    std::vector<nlohmann::json> args;
-    if (right.is_object() && right.value("_type", "") == "Tuple")
-      for (const auto &e : right["elts"])
-        args.push_back(e);
-    else
-      args.push_back(right);
-
-    // Re-enter conversion through a synthesised Constant node so the folded
-    // string flows through the exact same path as a string literal (e.g.
-    // len("ab")), which materialises it correctly when consumed inline by
-    // len()/==. Building the array directly left it unaddressable inline.
-    nlohmann::json folded = left;
-    folded["value"] = py_percent_format(left["value"].get<std::string>(), args);
-    return get_expr(folded);
   }
 
   // Handle string concatenation -- only valid for char-arrays. Numeric

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -167,8 +167,7 @@ std::string py_percent_format(
     }
     default:
       throw std::runtime_error(
-        std::string("unsupported conversion '%") + c +
-        "' in str % formatting");
+        std::string("unsupported conversion '%") + c + "' in str % formatting");
     }
   }
 

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -25,6 +25,160 @@
 #include <cctype>
 #include <sstream>
 
+namespace
+{
+// Parse a constant integer from a Python AST argument node: a Constant int or
+// bool, or a UnaryOp(USub) over one (the parser emits negative literals that
+// way). Returns false when the node is not a compile-time integer.
+bool py_const_int(const nlohmann::json &a, long long &out)
+{
+  if (!a.is_object())
+    return false;
+  const std::string t = a.value("_type", "");
+  if (t == "Constant" && a.contains("value"))
+  {
+    if (a["value"].is_number_integer())
+    {
+      out = a["value"].get<long long>();
+      return true;
+    }
+    if (a["value"].is_boolean())
+    {
+      out = a["value"].get<bool>() ? 1 : 0;
+      return true;
+    }
+    return false;
+  }
+  if (
+    t == "UnaryOp" && a.contains("operand") &&
+    a.value("op", nlohmann::json::object()).value("_type", "") == "USub")
+  {
+    long long v;
+    if (py_const_int(a["operand"], v))
+    {
+      out = -v;
+      return true;
+    }
+  }
+  return false;
+}
+
+// Constant-fold a printf-style ``str % args`` formatting, matching CPython for
+// the supported conversions. Throws std::runtime_error for any unsupported
+// conversion, flag/width/precision, or non-constant argument, so the caller
+// surfaces a clean diagnostic instead of mis-lowering ``str % x`` to pointer
+// arithmetic (which crashed the SMT backend, #5495).
+std::string py_percent_format(
+  const std::string &fmt,
+  const std::vector<nlohmann::json> &args)
+{
+  std::string out;
+  size_t argi = 0;
+  auto next_arg = [&]() -> const nlohmann::json & {
+    if (argi >= args.size())
+      throw std::runtime_error(
+        "TypeError: not enough arguments for format string");
+    return args[argi++];
+  };
+
+  for (size_t i = 0; i < fmt.size(); ++i)
+  {
+    if (fmt[i] != '%')
+    {
+      out.push_back(fmt[i]);
+      continue;
+    }
+    if (i + 1 >= fmt.size())
+      throw std::runtime_error("ValueError: incomplete format");
+    const char c = fmt[++i];
+    switch (c)
+    {
+    case '%':
+      out.push_back('%');
+      break;
+    case 'd':
+    case 'i':
+    {
+      long long v;
+      if (!py_const_int(next_arg(), v))
+        throw std::runtime_error(
+          "unsupported: non-constant argument in str %% formatting");
+      out += std::to_string(v);
+      break;
+    }
+    case 's':
+    {
+      const nlohmann::json &a = next_arg();
+      long long v;
+      if (
+        a.value("_type", "") == "Constant" && a.contains("value") &&
+        a["value"].is_boolean())
+        // CPython renders bool via str(): "True"/"False", not "1"/"0".
+        out += a["value"].get<bool>() ? "True" : "False";
+      else if (
+        a.value("_type", "") == "Constant" && a.contains("value") &&
+        a["value"].is_string())
+        out += a["value"].get<std::string>();
+      else if (py_const_int(a, v))
+        out += std::to_string(v);
+      else
+        throw std::runtime_error(
+          "unsupported: non-constant argument in str %% formatting");
+      break;
+    }
+    case 'x':
+    case 'X':
+    case 'o':
+    {
+      long long v;
+      if (!py_const_int(next_arg(), v))
+        throw std::runtime_error(
+          "unsupported: non-constant argument in str %% formatting");
+      if (v < 0)
+        throw std::runtime_error(
+          "unsupported: negative argument in str %% %x/%o formatting");
+      std::ostringstream ss;
+      if (c == 'o')
+        ss << std::oct << v;
+      else
+        ss << (c == 'X' ? std::uppercase : std::nouppercase) << std::hex << v;
+      out += ss.str();
+      break;
+    }
+    case 'c':
+    {
+      const nlohmann::json &a = next_arg();
+      long long v;
+      if (py_const_int(a, v))
+      {
+        if (v < 0 || v > 255)
+          throw std::runtime_error(
+            "unsupported: %c code points above 255 (non-ASCII) not modelled");
+        out.push_back(static_cast<char>(v));
+      }
+      else if (
+        a.value("_type", "") == "Constant" && a.contains("value") &&
+        a["value"].is_string() && a["value"].get<std::string>().size() == 1)
+        out += a["value"].get<std::string>();
+      else
+        throw std::runtime_error(
+          "unsupported: %c argument in str %% formatting");
+      break;
+    }
+    default:
+      throw std::runtime_error(
+        std::string("unsupported conversion '%") + c +
+        "' in str %% formatting");
+    }
+  }
+
+  if (argi != args.size())
+    throw std::runtime_error(
+      "TypeError: not all arguments converted during string formatting");
+  return out;
+}
+} // namespace
+
 exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
 {
   // `and`/`or` short-circuit: a later operand may not execute. get_named_expr
@@ -1094,6 +1248,39 @@ exprt python_converter::handle_array_operations(
         msg << " at " << loc.get_file() << ":" << loc.get_line();
       throw std::runtime_error(msg.str());
     }
+  }
+
+  // Python ``str % args`` is string formatting, not numeric modulo. Falling
+  // through to the generic arithmetic path builds ``&"%d"[0] % 5`` (pointer
+  // modulo int), mistypes the result as ``char[0]``, and crashes the SMT
+  // backend on the bogus pointer arithmetic (#5495). Constant-fold the common
+  // printf-style conversions into a string literal; throw a clean diagnostic
+  // for anything not modelled (non-constant format/args, widths, floats).
+  if (op == "Mod" && type_utils::is_string_type(lhs.type()))
+  {
+    // Gate on the string type (char-element array), not the structural 8-bit
+    // test: np.int8/np.uint8 arrays are also 8-bit arrays but use a bv element,
+    // and their `% scalar` must keep flowing through the numeric path.
+    if (
+      left.value("_type", "") != "Constant" || !left.contains("value") ||
+      !left["value"].is_string())
+      throw std::runtime_error(
+        "unsupported: str %% formatting requires a literal format string");
+
+    std::vector<nlohmann::json> args;
+    if (right.is_object() && right.value("_type", "") == "Tuple")
+      for (const auto &e : right["elts"])
+        args.push_back(e);
+    else
+      args.push_back(right);
+
+    // Re-enter conversion through a synthesised Constant node so the folded
+    // string flows through the exact same path as a string literal (e.g.
+    // len("ab")), which materialises it correctly when consumed inline by
+    // len()/==. Building the array directly left it unaddressable inline.
+    nlohmann::json folded = left;
+    folded["value"] = py_percent_format(left["value"].get<std::string>(), args);
+    return get_expr(folded);
   }
 
   // Handle string concatenation -- only valid for char-arrays. Numeric


### PR DESCRIPTION
## What

`str % args` where the **format string is a variable** (e.g. a `str` parameter, `fmt % n`) crashed ESBMC with a **SIGSEGV** in the SMT backend. A `str` variable is a char **pointer**, not an array, so the `str %` handling added in #5497 — which lived inside `handle_array_operations` (gated on an array operand) — was bypassed, and `fmt % n` fell through to the generic numeric-modulo path (`str_ptr % int`), producing a malformed term.

```python
def fmt_int(fmt: str, n: int) -> str:
    return fmt % n        # Segmentation fault before this PR


def main() -> None:
    s = fmt_int("%d", 5)
    assert len(s) >= 0


main()
```

## Fix

Hoist the `op == "Mod" && is_string_type(lhs)` string-format block out of `handle_array_operations` and into `get_binary_operator_expr`, just before the `is_array()` gate. `is_string_type` matches **both** char arrays (literals) and char pointers (str variables) — but not `np.int8`/`np.uint8` arrays, whose `% scalar` keeps its numeric path. Result:

- Literal format + constant args → still constant-folded (unchanged from #5497).
- Variable format (or variable args) → a clean `ERROR` diagnostic instead of a crash, consistent with how this file rejects other unsupported features (e.g. numpy broadcasting).

Also fixes a leaked literal `%%` in the `runtime_error` messages (they are plain `std::string`, not printf formats, so `%%` printed literally).

## Testing

- `regression/python/github_5499` (CORE, SUCCESSFUL) — literal format folds through the hoisted path, including inside a `str`-returning function and a tuple-arg format.
- `regression/python/github_5499_unsupported` (CORE, ERROR diagnostic) — the str-variable case; valid CPython (no `_fail` suffix), so it must be rejected cleanly rather than crash.
- The #5497 literal tests still pass (hoist regression-checked). Broad python sweep: no non-environmental regressions.

## Notes

- **Stacked on #5497** (`fix/python-str-percent-format`). Merge #5497 first; this PR then reduces to the hoist + the str-variable handling.
- Limitation (intentional): folding requires *both* the format string and the args to be compile-time constants; `"%d" % var` is rejected with the same clean diagnostic. Full runtime-format modelling is out of scope.

Fixes #5499.
