### PR TITLE
[python] Model NumPy ndarray % scalar instead of crashing

### DIFF
--- a/regression/numpy/github_5498/main.py
+++ b/regression/numpy/github_5498/main.py
@@ -1,0 +1,16 @@
+# #5498: ndarray % scalar previously crashed the SMT backend (pointer modulo on
+# the array). It is now modelled element-wise with Python/NumPy floored modulo
+# (the result takes the sign of the divisor).
+import numpy as np
+
+a = np.array([4, 5, 6])
+b = a % 3
+assert b[0] == 1
+assert b[1] == 2
+assert b[2] == 0
+
+c = np.array([-7, -1, 7])
+d = c % 3
+assert d[0] == 2
+assert d[1] == 2
+assert d[2] == 1

--- a/regression/numpy/github_5498/test.desc
+++ b/regression/numpy/github_5498/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/github_5498_fail/main.py
+++ b/regression/numpy/github_5498_fail/main.py
@@ -1,0 +1,7 @@
+# Negative variant of github_5498: a % 3 is [1, 2, 0], so asserting b[0] == 2
+# must fail.
+import numpy as np
+
+a = np.array([4, 5, 6])
+b = a % 3
+assert b[0] == 2

--- a/regression/numpy/github_5498_fail/test.desc
+++ b/regression/numpy/github_5498_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/numpy/github_5498_scalar_array_fail/main.py
+++ b/regression/numpy/github_5498_scalar_array_fail/main.py
@@ -1,0 +1,7 @@
+# scalar % ndarray broadcasting is not modelled; ESBMC must reject it with a
+# clean diagnostic rather than crashing (#5498).
+import numpy as np
+
+a = np.array([4, 5, 6])
+b = 10 % a
+assert b[0] == 2

--- a/regression/numpy/github_5498_scalar_array_fail/test.desc
+++ b/regression/numpy/github_5498_scalar_array_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: NumPy array modulo broadcasting is not modelled.*$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -986,6 +986,13 @@ exprt python_converter::handle_array_operations(
     if (!is_numeric_type(elem_type) || !is_numeric_type(scalar_expr.type()))
       return nil_exprt();
 
+    // Element-wise modulo is only modelled for integer elements; float-array %
+    // would need fmod-style lowering, so let it fall through to a clean reject.
+    if (
+      op == "Mod" &&
+      !(elem_type.is_signedbv() || elem_type.is_unsignedbv()))
+      return nil_exprt();
+
     const exprt &size_expr = to_array_type(array_type).size();
     if (!size_expr.is_constant())
       return nil_exprt();
@@ -1020,6 +1027,12 @@ exprt python_converter::handle_array_operations(
       exprt array_item = migrate_expr_back(index2tc(elem_t2, ar2, ix2));
       exprt bin_elem(python_frontend::map_operator(op, elem_type), elem_type);
       bin_elem.copy_to_operands(array_item, casted_scalar);
+      // Python/NumPy integer % is floored (sign of the divisor), unlike C's
+      // truncated remainder; correct each element the same way the scalar path
+      // does (#5498). bin_elem currently holds the raw C remainder.
+      if (op == "Mod")
+        bin_elem =
+          math_handler_.handle_int_modulo(array_item, casted_scalar, bin_elem);
       expr2tc bin_elem2;
       migrate_expr(bin_elem, bin_elem2);
       result2 = with2tc(result2->type, result2, ix2, bin_elem2);
@@ -1089,6 +1102,38 @@ exprt python_converter::handle_array_operations(
       std::ostringstream msg;
       msg << "TypeError: arithmetic on numeric arrays is not supported "
              "(numpy broadcasting is not modelled)";
+      const locationt loc = get_location_from_decl(element);
+      if (!loc.is_nil())
+        msg << " at " << loc.get_file() << ":" << loc.get_line();
+      throw std::runtime_error(msg.str());
+    }
+  }
+
+  // NumPy element-wise integer modulo. `ndarray % scalar` previously fell
+  // through to generic arithmetic (pointer-modulo on the array) and crashed the
+  // SMT backend (#5498). Model `numeric_array % scalar` with per-element
+  // floored modulo; reject the broadcasting forms that are not modelled
+  // (scalar % array, array % array, non-constant-size or float arrays) cleanly.
+  if (op == "Mod")
+  {
+    const bool lhs_numeric_array = lhs.type().is_array() &&
+                                   is_numeric_type(lhs.type().subtype()) &&
+                                   !is_char_array(lhs.type());
+    const bool rhs_numeric_array = rhs.type().is_array() &&
+                                   is_numeric_type(rhs.type().subtype()) &&
+                                   !is_char_array(rhs.type());
+
+    if (lhs_numeric_array && !rhs.type().is_array())
+    {
+      exprt lowered = build_scalar_broadcast(lhs, rhs);
+      if (!lowered.is_nil())
+        return lowered;
+    }
+
+    if (lhs_numeric_array || rhs_numeric_array)
+    {
+      std::ostringstream msg;
+      msg << "TypeError: NumPy array modulo broadcasting is not modelled";
       const locationt loc = get_location_from_decl(element);
       if (!loc.is_nil())
         msg << " at " << loc.get_file() << ":" << loc.get_line();

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -988,9 +988,7 @@ exprt python_converter::handle_array_operations(
 
     // Element-wise modulo is only modelled for integer elements; float-array %
     // would need fmod-style lowering, so let it fall through to a clean reject.
-    if (
-      op == "Mod" &&
-      !(elem_type.is_signedbv() || elem_type.is_unsignedbv()))
+    if (op == "Mod" && !(elem_type.is_signedbv() || elem_type.is_unsignedbv()))
       return nil_exprt();
 
     const exprt &size_expr = to_array_type(array_type).size();


### PR DESCRIPTION
## What

`np.array(...) % scalar` (element-wise modulo on a numeric array) crashed ESBMC with a **SIGSEGV** in the SMT backend. `handle_array_operations` modelled scalar broadcast only for `Add`/`Mult`; `Mod` fell through to the generic arithmetic path, which built pointer-modulo on the array and produced a malformed term.

```python
import numpy as np

a = np.array([4, 5, 6])
b = a % 3          # Segmentation fault before this PR
assert b[0] == 1
```

## Fix

In `handle_array_operations` (`converter/converter_binop.cpp`):

1. Extend the `build_scalar_broadcast` lambda to `Mod`. The per-element op is built as the raw C remainder (`map_operator("Mod")`) and then corrected to **Python/NumPy floored modulo** via `math_handler_.handle_int_modulo(...)` — the same correction the scalar `%` path uses, since `%` takes the sign of the divisor (`-7 % 3 == 2`), unlike C's truncated remainder. Float-element arrays are excluded (would need fmod-style lowering).
2. Add a `Mod` dispatch block that models `numeric_array % scalar` and rejects the unmodelled broadcasting forms (scalar % array, array % array, non-constant-size, float arrays) with a clean `TypeError: NumPy array modulo broadcasting is not modelled` diagnostic instead of crashing.

The change is gated on `is_numeric_type && !is_char_array`, so string `%` formatting and numeric scalar `%` are untouched.

## Testing

New tests under `regression/numpy/`:
- `github_5498` (CORE, SUCCESSFUL) — `a % 3` including negative elements (`[-7,-1,7] % 3 == [2,2,1]`, verifying floored semantics).
- `github_5498_fail` (CORE, FAILED) — wrong expectation.
- `github_5498_scalar_array_fail` (CORE, ERROR diagnostic) — `scalar % array`, the graceful-reject path.

The full `regression/numpy` suite (369 tests) passes; scalar integer `%` (including negatives) is unaffected.

Fixes #5498.
