### PR TITLE
[python] Fix duplicate idx2t/idxnorm2 redefinition in tuple subscript

### DIFF
--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -324,7 +324,8 @@ exprt tuple_handler::handle_tuple_subscript(
 
     // Normalise negative indices: idx_norm = i < 0 ? i + n : i.
     // V.3: built in IREP2 (all operands are idx_type, so the if2t branch
-    // types agree); idx_norm is back-migrated for the legacy select chain.
+    // types agree). idx2t/idxnorm2 are reused by the bounds check and the
+    // select chain below.
     const type2tc idx2t = migrate_type(idx_type);
     expr2tc index2;
     migrate_expr(index_expr, index2);
@@ -332,7 +333,6 @@ exprt tuple_handler::handle_tuple_subscript(
     const expr2tc zero2 = gen_zero(idx2t);
     const expr2tc idxnorm2 = if2tc(
       idx2t, lessthan2tc(index2, zero2), add2tc(idx2t, index2, n2), index2);
-    exprt idx_norm = migrate_expr_back(idxnorm2);
 
     // Bounds: 0 <= idx_norm < n
     exprt in_bounds = migrate_expr_back(
@@ -349,9 +349,6 @@ exprt tuple_handler::handle_tuple_subscript(
     // types normally agree; a defensive exact-type guard keeps any
     // base_type_eq-but-not-identical component on the legacy builder.
     const type2tc ft2 = migrate_type(first_type);
-    const type2tc idx2t = migrate_type(idx_type);
-    expr2tc idxnorm2;
-    migrate_expr(idx_norm, idxnorm2);
     exprt chain = get_tuple_element(array, tuple_type, 0);
     for (size_t k = 1; k < n; ++k)
     {


### PR DESCRIPTION
Master HEAD fails to compile: the V.3 IREP2 migration landed the index-norm block (#5468) and the select-chain block (#5472) each declaring `idx2t` and `idxnorm2` in the same scope of `handle_tuple_subscript`, producing `error: redefinition of 'idx2t'` at `tuple_handler.cpp`. #5472's CI ran before #5468 was in its base, so the clash was not caught and now breaks every open PR's merge build.

The select chain reuses the norm block's `idx2t`/`idxnorm2` (`idx_norm` was only their back-migration), so drop the duplicate declarations and the now-unused `idx_norm`. Behaviour-preserving.

Verified: master + this fix builds clean; tuple-subscript regression tests pass.