### PR TITLE
[build] Fix master build: duplicate idx2t + dangling reference

### DIFF
--- a/regression/python/tuple_subscript_var_index/main.py
+++ b/regression/python/tuple_subscript_var_index/main.py
@@ -1,0 +1,15 @@
+# Exercises the non-constant tuple-index select-chain path in tuple_handler,
+# where #5468 and #5472 each declared idx2t/idxnorm2 in the same scope (a
+# redefinition that broke the build). With the duplicate removed, a tuple
+# subscript by a runtime index resolves correctly.
+def get(t: tuple[int, int, int], i: int) -> int:
+    return t[i]
+
+
+def main() -> None:
+    t = (10, 20, 30)
+    assert get(t, 1) == 20
+    assert get(t, 2) == 30
+
+
+main()

--- a/regression/python/tuple_subscript_var_index/test.desc
+++ b/regression/python/tuple_subscript_var_index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple_subscript_var_index_fail/main.py
+++ b/regression/python/tuple_subscript_var_index_fail/main.py
@@ -1,0 +1,11 @@
+# Negative variant: t[0] is 10, so asserting it equals 99 must fail.
+def get(t: tuple[int, int, int], i: int) -> int:
+    return t[i]
+
+
+def main() -> None:
+    t = (10, 20, 30)
+    assert get(t, 0) == 99
+
+
+main()

--- a/regression/python/tuple_subscript_var_index_fail/test.desc
+++ b/regression/python/tuple_subscript_var_index_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -2272,8 +2272,10 @@ void python_converter::get_var_assign(
       !rhs.type().is_code())
     {
 #ifndef NDEBUG
-      const array_typet &thetype = lhs.type();
-      thetype.size().is_constant();
+      // to_array_type returns a reference into lhs.type(); binding the base
+      // typet& directly would construct a temporary array_typet and leave
+      // thetype dangling (GCC -Wdangling-reference under -Werror).
+      const array_typet &thetype = to_array_type(lhs.type());
       assert(thetype.size().is_nil());
 #endif
       lhs_symbol->set_type(rhs.type());

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -349,9 +349,9 @@ exprt tuple_handler::handle_tuple_subscript(
     // types normally agree; a defensive exact-type guard keeps any
     // base_type_eq-but-not-identical component on the legacy builder.
     const type2tc ft2 = migrate_type(first_type);
-    const type2tc idx2t = migrate_type(idx_type);
-    expr2tc idxnorm2;
-    migrate_expr(idx_norm, idxnorm2);
+    // idx2t and idxnorm2 are already in scope from the index-normalisation
+    // block above (#5468); #5472 re-declared them here, which is a redefinition
+    // in the same scope and breaks the build. Reuse the existing ones.
     exprt chain = get_tuple_element(array, tuple_type, 0);
     for (size_t k = 1; k < n; ++k)
     {


### PR DESCRIPTION
## What

`master` currently does not build. This PR fixes two regressions that block it:

### 1. Duplicate `idx2t`/`idxnorm2` (breaks **all** builds — clang & GCC)

The non-constant tuple-subscript path in `tuple_handler.cpp` declares `idx2t` and `idxnorm2` **twice in the same scope**:
- the index-normalisation block added by #5468, and
- the select-chain block added by #5472.

After both V.3 IREP2 PRs merged, the result is a redefinition:
```
tuple_handler.cpp:352:19: error: redefinition of 'idx2t'
tuple_handler.cpp:353:13: error: redefinition of 'idxnorm2' with a different type
```
Fix: drop the redundant re-declarations in the select-chain block and reuse the ones already in scope (they computed the same values). No behavioural change.

### 2. `-Wdangling-reference` in `converter_stmt.cpp` (breaks the asserts-on DebugOpt `-Werror` build)

```cpp
const array_typet &thetype = lhs.type();   // binds a ref to a temporary array_typet
```
`lhs.type()` returns a base `typet&`; binding it to `const array_typet&` constructs a temporary, leaving `thetype` dangling. Fix: use `to_array_type()` (a reference into the existing object) and drop the adjacent no-op `thetype.size().is_constant();`. Only compiled when asserts are on (`#ifndef NDEBUG`), which is why it surfaces solely on the DebugOpt CI.

## Testing

- `master` + this PR compiles cleanly with **both clang and g++-15** (the dangling check verified asserts-on).
- All 37 existing `tuple*` regression tests pass.
- Adds `regression/python/tuple_subscript_var_index{,_fail}` exercising the runtime-index select-chain path (`t[i]` with non-constant `i`).
