### PR TITLE
[python] Fix duplicate idx2t/idxnorm2 in tuple subscript (build break)

### DIFF
--- a/regression/python/tuple_dynamic_index/main.py
+++ b/regression/python/tuple_dynamic_index/main.py
@@ -1,0 +1,11 @@
+# Dynamic (non-constant) tuple subscript: exercises the if-chain select path in
+# tuple_handler::handle_tuple_subscript, including negative-index normalisation.
+def main() -> None:
+    t = (10, 20, 30)
+    i = 1
+    assert t[i] == 20
+    assert t[-1] == 30
+    assert t[i - 1] == 10
+
+
+main()

--- a/regression/python/tuple_dynamic_index/test.desc
+++ b/regression/python/tuple_dynamic_index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple_dynamic_index_fail/main.py
+++ b/regression/python/tuple_dynamic_index_fail/main.py
@@ -1,0 +1,9 @@
+# Out-of-range dynamic tuple index must trip the bounds assertion built in
+# handle_tuple_subscript (0 <= idx_norm < n).
+def main() -> None:
+    t = (10, 20, 30)
+    i = 5
+    assert t[i] == 30
+
+
+main()

--- a/regression/python/tuple_dynamic_index_fail/test.desc
+++ b/regression/python/tuple_dynamic_index_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -324,7 +324,7 @@ exprt tuple_handler::handle_tuple_subscript(
 
     // Normalise negative indices: idx_norm = i < 0 ? i + n : i.
     // V.3: built in IREP2 (all operands are idx_type, so the if2t branch
-    // types agree); idx_norm is back-migrated for the legacy select chain.
+    // types agree); idxnorm2 is reused by the bounds check and select chain.
     const type2tc idx2t = migrate_type(idx_type);
     expr2tc index2;
     migrate_expr(index_expr, index2);
@@ -332,7 +332,6 @@ exprt tuple_handler::handle_tuple_subscript(
     const expr2tc zero2 = gen_zero(idx2t);
     const expr2tc idxnorm2 = if2tc(
       idx2t, lessthan2tc(index2, zero2), add2tc(idx2t, index2, n2), index2);
-    exprt idx_norm = migrate_expr_back(idxnorm2);
 
     // Bounds: 0 <= idx_norm < n
     exprt in_bounds = migrate_expr_back(
@@ -349,9 +348,7 @@ exprt tuple_handler::handle_tuple_subscript(
     // types normally agree; a defensive exact-type guard keeps any
     // base_type_eq-but-not-identical component on the legacy builder.
     const type2tc ft2 = migrate_type(first_type);
-    const type2tc idx2t = migrate_type(idx_type);
-    expr2tc idxnorm2;
-    migrate_expr(idx_norm, idxnorm2);
+    // idx2t and idxnorm2 are already in scope from the index-norm block above.
     exprt chain = get_tuple_element(array, tuple_type, 0);
     for (size_t k = 1; k < n; ++k)
     {


### PR DESCRIPTION
## Problem

`master` HEAD currently does not compile. Commit 632a243c74 (#5472, "build tuple subscript select chain in IREP2") added the IREP2 select chain to the dynamic-index path of `tuple_handler::handle_tuple_subscript`, but it redeclared `idx2t` and `idxnorm2` — both already declared in the index-normalisation block just above (added by #5468). Under `-Werror` this is a hard error:

```
tuple_handler.cpp:352:19: error: redeclaration of 'const type2tc idx2t'
tuple_handler.cpp:353:13: error: conflicting declaration 'expr2tc idxnorm2'
tuple_handler.cpp:354:28: error: binding reference of type 'expr2tc&' to 'const expr2tc' discards qualifiers
```

## Fix

Reuse the in-scope `idx2t`/`idxnorm2` from the index-norm block, and drop the now-unused legacy `idx_norm` back-migration. Behaviour is unchanged — the select chain already consumed exactly those values.

## Tests

Adds dynamic (non-constant) tuple-subscript regression tests, which exercise the affected if-chain select path (existing tuple tests mostly use constant indices):
- `tuple_dynamic_index` — variable + negative index → `VERIFICATION SUCCESSFUL`
- `tuple_dynamic_index_fail` — out-of-range dynamic index trips the bounds assertion → `VERIFICATION FAILED`

Local build clean under `-Werror`; new tests plus the existing tuple suite pass.