### PR TITLE
[python] Fix duplicate idx2t/idxnorm2 decls breaking master build

### DIFF
--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -349,9 +349,6 @@ exprt tuple_handler::handle_tuple_subscript(
     // types normally agree; a defensive exact-type guard keeps any
     // base_type_eq-but-not-identical component on the legacy builder.
     const type2tc ft2 = migrate_type(first_type);
-    const type2tc idx2t = migrate_type(idx_type);
-    expr2tc idxnorm2;
-    migrate_expr(idx_norm, idxnorm2);
     exprt chain = get_tuple_element(array, tuple_type, 0);
     for (size_t k = 1; k < n; ++k)
     {


### PR DESCRIPTION
## Problem

`origin/master` currently does not compile. `src/python-frontend/tuple_handler.cpp` declares `idx2t` and `idxnorm2` twice in the same scope (the non-constant tuple-index branch of `get_tuple_element`):

```
error: redeclaration of 'const type2tc idx2t'
error: conflicting declaration 'expr2tc idxnorm2'
error: binding reference of type 'expr2tc&' to 'const expr2tc' discards qualifiers
```

This is a semantic conflict between two PRs that each passed CI independently:
- #5468 ("build tuple subscript index-norm + bounds in IREP2") added `idx2t`/`idxnorm2` in the index-norm block.
- #5472 ("build tuple subscript select chain in IREP2") added `idx2t`/`idxnorm2` again in the select-chain block.

Each built against a master without the other; combined on master they collide. Every open PR's CI is failing as a result (e.g. #5503).

## Fix

Drop the three redundant lines in the select-chain block — the earlier index-norm block already provides `idx2t` and `idxnorm2` in the same scope.

## Verification

- `pythonfrontend` and full `esbmc` now build (master did not).
- All 105 tuple regression tests pass (`ctest -R tuple`).
- Manual check: in-bounds nondet index returns the correct element; OOB index correctly trips the "Tuple index out of range" assertion.
- clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)