### PR TITLE
[python] V.3: build type-assertion OR-fold in IREP2

### DIFF
--- a/src/python-frontend/python_typechecking.cpp
+++ b/src/python-frontend/python_typechecking.cpp
@@ -343,16 +343,20 @@ bool python_typechecking::build_type_assertion(
   if (checks.empty())
     return false;
 
-  exprt assertion_expr = checks.front();
+  // V.3: build the OR-fold of the type checks in IREP2, back-migrated once
+  // at the legacy code_assertt seam. Each check is migrated forward and the
+  // disjunction is composed with or2tc; operand order (assertion-so-far on
+  // the left, next check on the right) is preserved from the legacy fold.
+  expr2tc assertion2;
+  migrate_expr(checks.front(), assertion2);
   for (size_t i = 1; i < checks.size(); ++i)
   {
-    exprt or_expr("or", typet("bool"));
-    or_expr.move_to_operands(assertion_expr);
-    or_expr.move_to_operands(checks[i]);
-    assertion_expr = or_expr;
+    expr2tc check2;
+    migrate_expr(checks[i], check2);
+    assertion2 = or2tc(assertion2, check2);
   }
 
-  out_assert = code_assertt(assertion_expr);
+  out_assert = code_assertt(migrate_expr_back(assertion2));
   out_assert.location() = location;
 
   if (!context_name.empty())


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). In `build_type_assertion` (`python_typechecking.cpp`) the disjunction over the collected `isinstance`/`none` checks was assembled with legacy `exprt("or")` + `move_to_operands`; build it with `or2tc` instead, migrating each check forward and back-migrating once at the legacy `code_assertt` seam.

## Why it is behaviour-preserving

`or2t` fixes the operand order (assertion-so-far on the left, next check on the right) and a bool result type, matching the legacy fold's left-associative shape and `typet("bool")`. The single-check case (`checks.size()==1`) reduces to a lossless `migrate` round-trip of the one boolean check, equivalent to the old `assertion_expr = checks.front()`.

## Validation

- `Union[int, str]` probe with a runtime type assertion -> `VERIFICATION SUCCESSFUL`.
- 86 optional/none/union/typecheck/assert regression tests pass on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (edited region). Dual-solver parity delegated to CI.
