### PR TITLE
[python] V.3: build `is`/`is not` identity equality in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -498,37 +498,39 @@ exprt python_converter::handle_none_comparison(
   return isnone_expr;
 }
 
+/// Build the Python 'is' identity equality in IREP2. The operands are the
+/// raw values, or the arrays' base addresses when both sides are arrays.
+expr2tc python_converter::build_is_equality(const exprt &lhs, const exprt &rhs)
+{
+  expr2tc lhs2, rhs2;
+  if (lhs.type().is_array() && rhs.type().is_array())
+  {
+    // Compare base addresses of the arrays
+    migrate_expr(string_handler_.get_array_base_address(lhs), lhs2);
+    migrate_expr(string_handler_.get_array_base_address(rhs), rhs2);
+  }
+  else
+  {
+    // Default identity comparison
+    migrate_expr(lhs, lhs2);
+    migrate_expr(rhs, rhs2);
+  }
+
+  return equality2tc(lhs2, rhs2);
+}
+
 /// Construct the expression for Python 'is' operator
 exprt python_converter::get_binary_operator_expr_for_is(
   const exprt &lhs,
   const exprt &rhs)
 {
-  typet bool_type_result = bool_type();
-  exprt is_expr("=", bool_type_result);
-
-  if (lhs.type().is_array() && rhs.type().is_array())
-  {
-    // Compare base addresses of the arrays
-    is_expr.copy_to_operands(
-      string_handler_.get_array_base_address(lhs),
-      string_handler_.get_array_base_address(rhs));
-  }
-  else
-  {
-    // Default identity comparison
-    is_expr.copy_to_operands(lhs, rhs);
-  }
-
-  return is_expr;
+  return migrate_expr_back(build_is_equality(lhs, rhs));
 }
 
 /// Construct the negation of an 'is' expression, used for 'is not'
 exprt python_converter::get_negated_is_expr(const exprt &lhs, const exprt &rhs)
 {
-  exprt is_expr = get_binary_operator_expr_for_is(lhs, rhs);
-  exprt not_expr("not", bool_type());
-  not_expr.copy_to_operands(is_expr);
-  return not_expr;
+  return migrate_expr_back(not2tc(build_is_equality(lhs, rhs)));
 }
 
 exprt python_converter::handle_string_type_mismatch(

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -337,6 +337,10 @@ private:
 
   bool is_bytes_literal(const nlohmann::json &element);
 
+  // V.3: build the `is` identity equality in IREP2 (shared by the `is` and
+  // `is not` paths); the public wrappers back-migrate once at the legacy seam.
+  expr2tc build_is_equality(const exprt &lhs, const exprt &rhs);
+
   exprt get_binary_operator_expr_for_is(const exprt &lhs, const exprt &rhs);
 
   exprt get_negated_is_expr(const exprt &lhs, const exprt &rhs);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). The Python `is` / `is not` operator construction in `converter_compare.cpp` built an `exprt("=", bool)` via `copy_to_operands` and wrapped it in `exprt("not", bool)`. Add a shared private helper `build_is_equality` that composes the identity equality with `equality2tc` (comparing the arrays' base addresses when both operands are arrays, else the raw values); the two public wrappers back-migrate once at the legacy seam — `get_binary_operator_expr_for_is` returns the equality, `get_negated_is_expr` returns `not2tc` over it.

## Why it is behaviour-preserving

`equality2t` fixes the operand order (lhs, rhs) and a bool result type, matching the legacy `"="` node; `not2t` matches the legacy `"not"`. The array-base-address branch (`github_4773_escape_identity` path) is unchanged. The shared helper also removes the old double-construction in the `is not` path (it previously built the legacy `=` then re-wrapped it).

## Validation

- `is` / `is not` / array-identity / `is None` probe -> `VERIFICATION SUCCESSFUL`.
- 83 comparison / none / identity regression tests pass on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (edited regions). Dual-solver parity delegated to CI.
