### PR TITLE
[python] Fix bare imaginary-literal crash when passed as a complex argument

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -384,3 +384,74 @@ robustness category, but with a sound value model rather than an "unsupported fe
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
 on current `master` without the §5 architectural work; the §5 priority order stands.
+
+---
+
+## 11. 2026-06-21 re-validation & bare-imaginary-literal argument crash fix
+
+Re-test against current `master` (tip `4a5b002c26`), after the **83 commits** since §10's tip
+`79c8b93eb0` — predominantly the V.3 IREP2 frontend rebuild (`#5454`/`#5459`/`#5472`–`#5493`
+build comparison constant-folds, list/tuple/set/slice/string-index guards, any()/all()
+reductions, complex div-by-zero and numpy-overflow asserts, pointer is-None checks, etc.) plus
+`#5502` (reject str-variable `%` formatting instead of crashing). A `ctest` flip-check over the
+39 KNOWNBUG `humaneval`/`quixbugs` tests reproduced **zero KNOWNBUG→CORE flips** — every test
+that completed (including the design-cluster cases `depth_first_search`, `detect_cycle`,
+`minimum_spanning_tree(_fail)`, and the perf-timeout cases `humaneval_33`/`37`/`39`/`93`/`158`,
+which genuinely ran 120–240 s against their own TIMEOUT property) still misses its expected
+verdict; the §3 classification holds. None of the 83 commits touches the bare-imaginary-literal
+argument path, and the fix below lives entirely in the general call-argument lowering in
+`function_call/expr.cpp`, so it cannot move any KNOWNBUG verdict.
+
+### 11a. New isolated, soundly-fixable defect found & fixed
+**A bare pure-imaginary literal passed directly as a by-value `complex` argument crashed
+(SIGABRT, "got pointer, expected struct").**
+
+`f(0.5j)` — where `f` takes a `complex` parameter — aborted with
+
+```
+ERROR: function call: argument "…@F@f@z" type mismatch: got pointer, expected struct
+```
+
+This is the **root** of the `got pointer, expected struct` argument-binding family the prior
+sweeps repeatedly hit (§8/§9 `depth_first_search`, §10 `cmath.acos`/`acosh`): §10 (PR #5415)
+only *worked around* it for `acos`/`acosh` via a pure-imaginary fast path that bypasses the
+model call. Probing the rest of the surface showed it is **general** — every cmath model
+function crashes on a bare imaginary literal (`cmath.exp(0.5j)`, `sqrt`, `sin`, `cos`, `tan`,
+`sinh`, `cosh`, `tanh`, `phase`, `polar`), and so does any plain user function
+`def f(z: complex)`. The crash fires **only** for a bare imaginary `ast.Constant` used
+*directly* as an argument; every other form already worked: `f(1+1j)`, `f(0+0.5j)` (BinOp),
+`w = 0.5j; f(w)` (variable), `f(complex(0, 0.5))` (ctor) — none crashed.
+
+**Root cause** (`src/python-frontend/function_call/expr.cpp`,
+`function_call_expr::handle_general_function_call`). `ast2json` serialises a Python complex
+value as its `str()` representation (`"0.5j"`), so a complex `Constant`'s JSON `value` field is
+a **string**. `get_literal` correctly reads the `esbmc_type_annotation == "complex"` /
+`real_value` / `imag_value` fields and returns a proper `complex` struct. But a post-`get_expr`
+override unconditionally replaced *any* `Constant` whose JSON `value` is a string with a string
+literal — clobbering the complex struct, which then fell into `build_address_of`, yielding
+`&"0.5j"` (a `pointer`) bound to the by-value `complex` (`struct`) parameter → the symex abort.
+A BinOp/Name/Call argument has a different `_type`, so the override never fired — hence those
+forms worked.
+
+**Fix:** guard the string-literal override to skip complex-annotated constants
+(`!arg_is_complex_literal && _type == "Constant" && value.is_string()`). Minimal, general (no
+per-function workaround), and confined to the Python frontend — it only narrows a frontend
+override that was already wrong for complex constants. New regression pair
+`regression/python/imag_literal_arg{,_fail}` (`imag_literal_arg` is the **C-Live** liveness
+witness for the added guard: without the fix its `f(0.5j)` call took the clobbering path and
+SIGABRT'd; with the fix it takes the new guarded path and verifies). After the fix, the full
+user-function + cmath repro set returns `VERIFICATION SUCCESSFUL`; the six already-working forms
+are unchanged; the cmath/complex regression subset (174 tests) is 100% green; CPython sanity
+(`check_python_tests.sh imag_literal_arg`) passes.
+
+Unlike §6a/§7a, and like §10a, this fix **restores working behaviour** (every cmath function and
+every user function now accepts a bare imaginary literal) rather than only converting a crash to
+a diagnostic — §5-item-5 robustness, but with a sound value model. This sweep ran a
+Bitwuzla-only `esbmc` (this build has `ENABLE_Z3=OFF`, as the §7/§8 sweeps also ran
+single-solver); the fix is a purely syntactic JSON-field guard with no SMT encoding, so the
+verdict is solver-agnostic.
+
+### 11b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
+on current `master` without the §5 architectural work; the §5 priority order stands.

--- a/regression/python/imag_literal_arg/main.py
+++ b/regression/python/imag_literal_arg/main.py
@@ -1,0 +1,26 @@
+import cmath
+
+# Regression test for bare pure-imaginary literal passed directly as a
+# by-value complex argument.  Before the fix, `0.5j` was lowered to a
+# string literal "0.5j" (because the JSON `value` field holds the Python
+# str representation) and then wrapped in address_of(), producing a
+# "got pointer, expected struct" SIGABRT on entry to the callee.
+
+# Plain user function: the general argument-binding path
+def get_imag(z: complex) -> float:
+    return z.imag
+
+def get_real(z: complex) -> float:
+    return z.real
+
+# Bare imaginary literals passed directly as call arguments
+assert get_imag(0.5j) == 0.5
+assert get_real(0.5j) == 0.0
+assert get_imag(1j) == 1.0
+assert get_real(1j) == 0.0
+
+# cmath functions with bare imaginary literals (all were crashing before)
+r1 = cmath.exp(0.5j)
+r2 = cmath.sqrt(0.5j)
+r3 = cmath.sin(0.5j)
+r4 = cmath.phase(0.5j)

--- a/regression/python/imag_literal_arg/main.py
+++ b/regression/python/imag_literal_arg/main.py
@@ -19,8 +19,9 @@ assert get_real(0.5j) == 0.0
 assert get_imag(1j) == 1.0
 assert get_real(1j) == 0.0
 
-# cmath functions with bare imaginary literals (all were crashing before)
-r1 = cmath.exp(0.5j)
-r2 = cmath.sqrt(0.5j)
-r3 = cmath.sin(0.5j)
-r4 = cmath.phase(0.5j)
+# cmath function with a bare imaginary literal (was crashing before): the
+# crash was at argument binding, before the callee runs, so one cheap call
+# (phase -> atan2) is enough to pin the cmath dispatch path without dragging
+# in the heavy libm series loops of exp/sqrt/sin.
+angle = cmath.phase(0.5j)
+assert angle > 0.0

--- a/regression/python/imag_literal_arg/test.desc
+++ b/regression/python/imag_literal_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/imag_literal_arg/test.desc
+++ b/regression/python/imag_literal_arg/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--unwind 6 --no-unwinding-assertions
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/imag_literal_arg_fail/main.py
+++ b/regression/python/imag_literal_arg_fail/main.py
@@ -1,0 +1,8 @@
+# Negative test: asserts a wrong value for the imaginary part of 0.5j.
+# ESBMC must detect the violated assertion.
+
+def get_imag(z: complex) -> float:
+    return z.imag
+
+# 0.5j has imag == 0.5, not 99.0
+assert get_imag(0.5j) == 99.0

--- a/regression/python/imag_literal_arg_fail/test.desc
+++ b/regression/python/imag_literal_arg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4378,8 +4378,18 @@ exprt function_call_expr::handle_general_function_call()
     }
 
     // Handle string literal constants
-    // Ensure they are proper null-terminated arrays
-    if (arg_node["_type"] == "Constant" && arg_node["value"].is_string())
+    // Ensure they are proper null-terminated arrays.
+    // Guard: skip complex literals whose JSON "value" field is a string
+    // representation of the complex number (e.g. "0.5j") — get_expr already
+    // returned the correct complex struct via get_literal's annotation check.
+    // Overwriting it with a string literal here would produce an
+    // address-of-string argument ("got pointer, expected struct" crash).
+    const bool arg_is_complex_literal =
+      arg_node["_type"] == "Constant" &&
+      arg_node.value("esbmc_type_annotation", std::string()) == "complex";
+    if (
+      !arg_is_complex_literal && arg_node["_type"] == "Constant" &&
+      arg_node["value"].is_string())
     {
       std::string str_value = arg_node["value"].get<std::string>();
       arg = converter_.get_string_builder().build_string_literal(str_value);


### PR DESCRIPTION
## What

A bare pure-imaginary literal passed **directly** as a call argument to a by-value `complex` parameter crashed ESBMC with a SIGABRT:

```
ERROR: function call: argument "...@F@f@z" type mismatch: got pointer, expected struct
```

```python
def f(z: complex) -> float:
    return z.imag
r = f(0.5j)          # SIGABRT before this PR
```

This is the **root** of the `got pointer, expected struct` argument-binding family seen across the Python triage sweeps (`depth_first_search`, and `cmath.acos`/`acosh`, which PR #5415 only *worked around* via a pure-imaginary fast path). Probing the full surface showed it is general: every `cmath` model function crashed on a bare imaginary literal (`cmath.exp(0.5j)`, `sqrt`, `sin`, `cos`, `tan`, `sinh`, `cosh`, `tanh`, `phase`, `polar`), and so did any user function taking a `complex`. The crash fired **only** for a bare imaginary `Constant` used directly as an argument — `f(1+1j)`, `f(0+0.5j)` (BinOp), `w = 0.5j; f(w)` (variable), and `f(complex(0, 0.5))` (ctor) all already worked.

## Why

`ast2json` serialises a Python complex value as its `str()` representation (`"0.5j"`), so a complex `Constant`'s JSON `value` field is a **string**. `get_literal` correctly reads the `esbmc_type_annotation == "complex"` / `real_value` / `imag_value` fields and returns a proper `complex` struct. But a post-`get_expr` override in `function_call_expr::handle_general_function_call` unconditionally replaced **any** `Constant` whose JSON `value` is a string with a string literal — clobbering the complex struct, which then fell into `build_address_of`, yielding `&"0.5j"` (a `pointer`) bound to the by-value `complex` (`struct`) parameter, producing the symex abort. A BinOp/Name/Call argument has a different `_type`, so the override never fired.

## Fix

Guard the string-literal override to skip complex-annotated constants. Minimal, general (no per-function workaround), confined to the Python frontend — it only narrows a frontend override that was already wrong for complex constants.

## Testing

- New regression pair `regression/python/imag_literal_arg` and `imag_literal_arg_fail` (CORE). The positive test is the **C-Live** liveness witness for the added guard: without the fix its `f(0.5j)` call took the clobbering path and SIGABRT'd; with the fix it takes the new guarded path and verifies.
- After the fix, the full user-function + `cmath` repro set returns `VERIFICATION SUCCESSFUL`; the six already-working forms are unchanged.
- `python/(cmath|complex|imag)` regression subset: **174/174 green**.
- CPython sanity: `scripts/check_python_tests.sh imag_literal_arg` passes.
- KNOWNBUG flip-check over the 39 `humaneval`/`quixbugs` KNOWNBUG tests: **zero KNOWNBUG to CORE flips**.

Methodology recorded in `docs/python-issues-triage-report-2026-06-02.md` section 11.

> Built with `ENABLE_Z3=OFF`, so verification used Bitwuzla only; the fix is a purely syntactic JSON-field guard with no SMT encoding, so the verdict is solver-agnostic.
