### PR TITLE
[python] V.3: build union-attr cast/deref/member in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1044,18 +1044,19 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             "' on union type: no class with this attribute found");
         }
 
-        // Create a typecast from char* to target_class* in IREP2 (V.3).
+        // V.3: build the char* -> target_class* cast, the dereference, and
+        // the member access entirely in IREP2, back-migrated once at the
+        // legacy seam. Keeping the typecast and dereference as expr2tc avoids
+        // the back-migrate/re-migrate round-trip the staged legacy form paid.
         typet target_ptr_type =
           gen_pointer_type(target_class_symbol->get_type());
         expr2tc expr2;
         migrate_expr(expr, expr2);
-        exprt casted_expr =
-          migrate_expr_back(typecast2tc(migrate_type(target_ptr_type), expr2));
-        casted_expr.type() = target_ptr_type;
+        expr2tc casted2 = typecast2tc(migrate_type(target_ptr_type), expr2);
 
         // Dereference to get the object
-        exprt deref_expr("dereference", target_class_symbol->get_type());
-        deref_expr.copy_to_operands(casted_expr);
+        expr2tc deref2 = dereference2tc(
+          migrate_type(target_class_symbol->get_type()), casted2);
 
         // Access the member on the object
         const struct_typet &target_struct =
@@ -1063,11 +1064,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         const typet &attr_type = target_struct.get_component(attr_name).type();
         typet clean_type = clean_attribute_type(attr_type);
 
-        // V.3: IREP2 member access (exact round-trip of member_exprt).
-        expr2tc de2;
-        migrate_expr(deref_expr, de2);
         expr = migrate_expr_back(
-          member2tc(migrate_type(clean_type), de2, attr_name));
+          member2tc(migrate_type(clean_type), deref2, attr_name));
         break;
       }
 


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). The Union-typed attribute access in `converter_expr.cpp` reinterprets a `char*` as the target class pointer, dereferences it, and reads the member. It previously staged this as `typecast2tc` → `migrate_expr_back` → reset `.type()` → legacy `dereference` node → `migrate_expr` forward again → `member2tc` → `migrate_expr_back`.

Now the whole `typecast → dereference → member` subtree is built in IREP2 and back-migrated **once** at the legacy seam.

## Why it is behaviour-preserving (byte-identical)

- The `casted_expr.type() = target_ptr_type` reset only compensated for the `#cpp_type` hint dropped by the now-removed back-migrate/re-migrate round-trip; building `typecast2tc(migrate_type(target_ptr_type), expr2)` yields that type directly.
- `dereference2tc(migrate_type(target_class_symbol->get_type()), casted2)` matches exactly what `migrate_expr` produced from the legacy `dereference` node (type, operand, and the default `__ESBMC_rounding_mode` symbol on the typecast).
- The target type is always a class struct, so no `contains_dyn_array` guard is needed — and because the operand's type no longer round-trips through `migrate_type_back`, this removes (rather than adds) dyn-array round-trip exposure.

## Validation

- `Union[Dog, Cat]` attribute-access probe -> `VERIFICATION SUCCESSFUL`.
- 45 union / class-attribute regression tests pass on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (edited region). Dual-solver parity delegated to CI.
