### PR TITLE
[python] V.3: build attribute-base dereference in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -538,16 +538,15 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             opt_st.has_component("value") && !opt_st.has_component(attr_name))
           {
             const typet &inner_raw = opt_st.get_component("value").type();
-            exprt optional_base = base_expr;
-            if (optional_base.type().is_pointer())
-            {
-              exprt deref("dereference");
-              deref.type() = optional_base.type().subtype();
-              deref.move_to_operands(optional_base);
-              optional_base = std::move(deref);
-            }
+            // V.3: build the (optional) dereference of the base directly in
+            // IREP2 instead of staging a legacy "dereference" node and
+            // re-migrating it; byte-identical (migrate of the legacy node is
+            // exactly dereference2tc(migrate_type(subtype), migrate(base))).
             expr2tc ob2;
-            migrate_expr(optional_base, ob2);
+            migrate_expr(base_expr, ob2);
+            if (base_expr.type().is_pointer())
+              ob2 =
+                dereference2tc(migrate_type(base_expr.type().subtype()), ob2);
             base_expr = migrate_expr_back(
               member2tc(migrate_type(inner_raw), ob2, "value"));
             base_type = inner_raw;
@@ -625,20 +624,18 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             const typet &attr_type =
               struct_type.get_component(attr_name).type();
             typet clean_type = clean_attribute_type(attr_type);
-            exprt member_base = base_expr;
-            if (member_base.type().is_pointer())
-            {
-              exprt deref("dereference");
-              deref.type() = member_base.type().subtype();
-              deref.move_to_operands(member_base);
-              member_base = std::move(deref);
-            }
             // V.1k step-2 hypothesis: build member2t with the (possibly
             // symbol-typed) source permitted by the step-1 relaxation, then
             // back-migrate to the legacy body so the EXISTING adjust + goto
             // -convert resolves it as today. No converter-side ns.follow.
+            // V.3: the (optional) base dereference is built directly in IREP2
+            // rather than staged as a legacy "dereference" node and re-migrated
+            // (byte-identical to migrate of that node).
             expr2tc src2;
-            migrate_expr(member_base, src2);
+            migrate_expr(base_expr, src2);
+            if (base_expr.type().is_pointer())
+              src2 =
+                dereference2tc(migrate_type(base_expr.type().subtype()), src2);
             return migrate_expr_back(
               member2tc(migrate_type(clean_type), src2, attr_name));
           }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). Two analogous attribute-access sites in `converter_expr.cpp` — the `Optional` struct `.value` unwrap and the struct-component lookup — staged a legacy `dereference` node over the base (`exprt deref("dereference"); deref.type() = base.type().subtype(); deref.move_to_operands(base);`) and then re-migrated it forward. Both now build the optional dereference directly with `dereference2tc`.

## Why it is behaviour-preserving (byte-identical)

`migrate_expr` of the legacy `dereference` node is exactly `dereference2tc(migrate_type(base.type().subtype()), migrate_expr(base))` — and `dereference2t` carries no extra fields beyond type and operand. The non-pointer branch is unchanged (no wrapping), and the result still feeds `member2tc(...)` and is back-migrated once at the legacy seam. The change removes a round-trip and the legacy node construction at both sites.

## Validation

- Optional / linked-node attribute-access probe -> `VERIFICATION SUCCESSFUL`.
- 135 optional / attribute / class regression tests pass on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (edited regions). Dual-solver parity delegated to CI.
