### PR TITLE
[python] V.3: build member-expression dereference in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -114,23 +114,24 @@ exprt python_converter::create_member_expression(
 {
   typet clean_type = clean_attribute_type(attr_type);
   exprt source = symbol_exprt(symbol.id, symbol.get_type());
-  if (source.type().is_pointer())
-  {
-    exprt deref("dereference");
-    deref.type() = source.type().subtype();
-    deref.move_to_operands(source);
-    source = std::move(deref);
-  }
+
+  // V.3: build the (optional) pointer dereference and the member access in
+  // IREP2, back-migrated once at the legacy seam. Building dereference2tc
+  // directly is byte-identical to migrating a staged legacy "dereference"
+  // node, and avoids the extra round-trip.
+  expr2tc s2;
+  migrate_expr(source, s2);
   typet source_type = source.type();
+  if (source_type.is_pointer())
+  {
+    source_type = source_type.subtype();
+    s2 = dereference2tc(migrate_type(source_type), s2);
+  }
   if (source_type.id() == "symbol")
     source_type = ns.follow(source_type);
   if (!source_type.is_struct() && !source_type.is_union())
     return gen_zero(clean_type);
 
-  // V.3: IREP2 member access (exact round-trip of member_exprt). `source` is
-  // struct/union (checked above) or a by-name symbol; both are valid sources.
-  expr2tc s2;
-  migrate_expr(source, s2);
   return migrate_expr_back(member2tc(migrate_type(clean_type), s2, attr_name));
 }
 


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). `create_member_expression` in `converter_class.cpp` staged a legacy `dereference` node over the source symbol (when pointer-typed) and then re-migrated it forward before building the `member2t`. It now migrates the source once up front and builds the optional dereference directly with `dereference2tc`.

## Why it is behaviour-preserving (byte-identical)

- `migrate_expr` of the legacy `dereference` node is exactly `dereference2tc(migrate_type(subtype), migrate(source))`, and `dereference2t` carries only `(type, value)` — no extra fields.
- `source_type` tracks the same value as before (pointer subtype when the source was a pointer, else the original symbol type), so the `source_type.id()=="symbol"` follow, the `!is_struct() && !is_union()` guard, and the `gen_zero(clean_type)` early-return all fire under the identical condition. The eager `s2` migration is simply discarded on the `gen_zero` path (no shared state touched).

The change removes a round-trip and the legacy node construction.

## Validation

- Class member-access probe (`p.x`, `self.x + self.y`) -> `VERIFICATION SUCCESSFUL`.
- 200 class / member / inheritance / dataclass regression tests pass on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (edited region). Dual-solver parity delegated to CI.
