### PR TITLE
[python] Reject bytearray with a clean diagnostic instead of SIGABRT

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -384,3 +384,50 @@ robustness category, but with a sound value model rather than an "unsupported fe
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
 on current `master` without the §5 architectural work; the §5 priority order stands.
+
+---
+
+> **Note on numbering.** §11 (PR #5510, bare imaginary-literal complex-argument crash) and §12
+> (PR #5513, `np.round(x, decimals)` crash) are both in flight and not yet on `master`; this
+> section is appended as §13 of the third 2026-06-21 sweep so the three same-day PRs do not
+> collide on the section number. When they land, the maintainer orders §11 → §12 → §13.
+
+## 13. 2026-06-21 re-validation (third sweep) & bytearray crash→diagnostic
+
+Re-test against current `master` (tip `4a5b002c26`, still unchanged — zero new commits since §11;
+PRs #5510 and #5513 OPEN, awaiting review). KNOWNBUG classification identical to §11/§12: zero
+flips, §3 holds. This sweep drained the last isolated crash from §11's idiom-probing battery.
+
+### 13a. New isolated, soundly-fixable defect found & fixed
+**`bytearray` crashed ESBMC with an uncaught C++ exception (SIGABRT).**
+
+`bytearray([1,2,3]); b[0]=9` and `bytearray(3)` aborted with `terminating due to uncaught
+exception type2t::symbolic_type_excp`; `bytearray([1,2,3])` followed by a read returned a bogus
+verdict. `bytes(...)` (the immutable form) was and remains fine.
+
+**Root cause** (`src/python-frontend/type_handler.cpp::get_typet`). `bytes` is modeled (array of
+int8); `bytearray` (its mutable counterpart) is not, so it reached the unsupported-but-defined
+fall-through that merely `log_warning`s and returns `empty_typet()`. That empty type then
+propagated into symex and was migrated to IREP2, where the empty type id raised
+`type2t::symbolic_type_excp` — uncaught → SIGABRT (on `bytearray(n)` / item assignment) or a
+silently wrong verdict (on plain construction+read).
+
+**Fix:** add an explicit `bytearray` case beside the `bytes` handler that throws a clean
+`std::runtime_error` — ESBMC's established mechanism for "unsupported feature," reported as
+`ERROR: bytearray is not supported; use bytes for an immutable byte sequence` (clean exit 254).
+All three crashing/wrong-verdict cases now produce the same deterministic diagnostic; `bytes` is
+untouched. This is §5-item-5 robustness (crash → clean diagnostic) and, like #5042/§6a, **does not
+flip a KNOWNBUG** — it removes a crash on an unsupported feature rather than enabling one.
+
+New regression pair: `regression/python/bytearray_unsupported` (asserts the clean diagnostic) and
+`regression/python/bytes_after_bytearray_fix` (guards that the adjacent `bytes` path still
+verifies). Both green via `ctest`; CPython sanity passes; a broad `regression/python/` sweep shows
+**zero new failures** attributable to the change (the only failures are the pre-existing
+Bitwuzla-only environmental set: `--z3`-pinned and `--ir`-pinned tests, none touching `bytearray`).
+Bitwuzla-only build (`ENABLE_Z3=OFF`); the fix is a frontend type-resolution guard with no SMT
+encoding, so the verdict is solver-agnostic.
+
+### 13b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
+on current `master` without the §5 architectural work; the §5 priority order stands.

--- a/regression/python/bytearray_unsupported/main.py
+++ b/regression/python/bytearray_unsupported/main.py
@@ -1,0 +1,6 @@
+# bytearray is not modeled. Before the fix this fell through to an empty_typet()
+# that later crashed symex with an uncaught type2t::symbolic_type_excp (SIGABRT)
+# on item assignment. It must now produce a clean "not supported" diagnostic.
+b = bytearray([1, 2, 3])
+b[0] = 9
+assert b[0] == 9

--- a/regression/python/bytearray_unsupported/test.desc
+++ b/regression/python/bytearray_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: bytearray is not supported; use bytes for an immutable byte sequence$

--- a/regression/python/bytes_after_bytearray_fix/main.py
+++ b/regression/python/bytes_after_bytearray_fix/main.py
@@ -1,0 +1,5 @@
+# bytes (immutable) remains modeled and must still verify after the bytearray
+# diagnostic was added next to it in type_handler::get_typet.
+b = bytes([65, 66, 67])
+assert b[0] == 65
+assert b[2] == 67

--- a/regression/python/bytes_after_bytearray_fix/test.desc
+++ b/regression/python/bytes_after_bytearray_fix/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -554,6 +554,14 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     return build_array(long_long_int_type(), type_size);
   }
 
+  // bytearray — the mutable counterpart of bytes — is not modeled. Reject it
+  // with a clean diagnostic: the unsupported-type fall-through below returns an
+  // empty_typet() that later crashes symex with an uncaught
+  // type2t::symbolic_type_excp (SIGABRT) on item assignment / bytearray(n).
+  if (ast_type == "bytearray")
+    throw std::runtime_error(
+      "bytearray is not supported; use bytes for an immutable byte sequence");
+
   // divmod() — returns tuple of (quotient, remainder)
   // The return type is determined dynamically based on operands
   // Let handle_divmod create the proper type


### PR DESCRIPTION
## What

`bytearray` crashed ESBMC with an uncaught C++ exception (SIGABRT):

```python
b = bytearray([1, 2, 3])
b[0] = 9        # terminating due to uncaught exception type2t::symbolic_type_excp  (before this PR)
```

`bytearray(3)` aborted the same way, and `bytearray([1,2,3])` + read returned a bogus verdict. `bytes(...)` (the immutable form) was and remains fine.

## Why

In `type_handler::get_typet`, `bytes` is modeled (array of int8) but `bytearray` (its mutable counterpart) is not, so it reached the unsupported-but-defined fall-through that merely `log_warning`s and returns `empty_typet()`. That empty type propagated into symex and was migrated to IREP2, where the empty type id raised `type2t::symbolic_type_excp` — uncaught → SIGABRT (on `bytearray(n)` / item assignment) or a silently wrong verdict (on plain construction + read).

## Fix

Add an explicit `bytearray` case beside the `bytes` handler that throws a clean `std::runtime_error` — ESBMC's established "unsupported feature" mechanism — reported as:

```
ERROR: bytearray is not supported; use bytes for an immutable byte sequence
```

All three crashing / wrong-verdict cases now produce the same deterministic diagnostic (clean exit 254). `bytes` is untouched. This is a crash → clean-diagnostic robustness fix; it does not change any valid behaviour.

## Testing

- New pair: `regression/python/bytearray_unsupported` (asserts the clean diagnostic) and `regression/python/bytes_after_bytearray_fix` (guards that the adjacent `bytes` path still verifies). Both pass via `ctest`; CPython sanity passes.
- Broad `regression/python/` sweep: zero new failures attributable to the change (the only failures are the pre-existing Bitwuzla-only environmental set — `--z3`-pinned and `--ir`-pinned tests, none touching `bytearray`).

Methodology recorded in `docs/python-issues-triage-report-2026-06-02.md` §13.

> Built with `ENABLE_Z3=OFF` (Bitwuzla only); the fix is a frontend type-resolution guard with no SMT encoding, so the verdict is solver-agnostic.
>
> Sibling same-day sweeps are in flight as #5510 (imaginary-literal arg crash) and #5513 (np.round decimals); the three PRs append §11/§12/§13 of the triage report respectively and are independent.
