### PR TITLE
[python] V.3: normalise strcmp char* operands in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -889,22 +889,27 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
       const symbolt *strcmp_symbol = symbol_table_.find_symbol("c:@F@strcmp");
       if (strcmp_symbol)
       {
-        // Normalise each side to char*: cast void*, take base address of arrays.
+        // Normalise each side to char* in IREP2: cast void*, take base address
+        // of arrays. Building the typecast as typecast2tc is byte-identical to
+        // migrating the legacy typecast_exprt, and lets the strcmp call below
+        // be built without a separate forward migration of each side.
         const typet char_ptr = pointer_typet(char_type());
-        auto as_char_ptr = [&](const exprt &e) -> exprt {
-          if (is_void_ptr(e.type()))
-            return typecast_exprt(e, char_ptr);
+        auto as_char_ptr = [&](const exprt &e) -> expr2tc {
+          expr2tc e2;
           if (e.type().is_array())
-            return string_handler_.get_array_base_address(e);
-          return e;
+            migrate_expr(string_handler_.get_array_base_address(e), e2);
+          else
+            migrate_expr(e, e2);
+          if (is_void_ptr(e.type()))
+            return typecast2tc(migrate_type(char_ptr), e2);
+          return e2;
         };
 
         // V.3: build `strcmp(a, b) op 0` (op is Eq/NotEq) in IREP2, back
         // -migrating once. Exact round-trip of the legacy side-effect strcmp
         // call compared against zero via equality/notequal.
-        expr2tc lhs2, rhs2;
-        migrate_expr(as_char_ptr(lhs), lhs2);
-        migrate_expr(as_char_ptr(rhs), rhs2);
+        expr2tc lhs2 = as_char_ptr(lhs);
+        expr2tc rhs2 = as_char_ptr(rhs);
         expr2tc strcmp_call2 = side_effect_function_call2tc(
           migrate_type(int_type()),
           symbol_expr2tc(*strcmp_symbol),


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). In the `void*`/Any-vs-string comparison path (`strcmp(a, b) op 0`) the `as_char_ptr` lambda returned a legacy `exprt` (a `void*` typecast, an array base address, or the operand unchanged) that was then forward-migrated at each call site. The lambda now returns `expr2tc` directly: it migrates the operand (or the array base address) up front and builds the `void*` cast with `typecast2tc`.

## Why it is behaviour-preserving (byte-identical)

- **void\***: `migrate_expr(typecast_exprt(e, char_ptr))` is exactly `typecast2tc(migrate_type(char_ptr), migrate(e))` — the two-arg `typecast2tc` ctor defaults the rounding mode to the same `__ESBMC_rounding_mode` symbol that `migrate` synthesises.
- **array / passthrough**: both paths `migrate_expr` the identical `exprt`.
- `void*` and array types are mutually exclusive (a `void*` is a pointer, not an array), so checking `is_array()` first for the migration source cannot change classification; `is_void_ptr(e.type())` still reads the original operand type.

The downstream `side_effect_function_call2tc` strcmp call and `equality2tc`/`notequal2tc` vs zero are unchanged. The change removes the per-side forward migration.

## Validation

- Any-vs-string `strcmp` comparison probe -> `VERIFICATION SUCCESSFUL`.
- 459 string / comparison regression tests pass on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (Clang 11; the edited lambda matches the file's existing style). Dual-solver parity delegated to CI.
