### PR TITLE
[ir-ieee] use NaN predicates for isnan

### DIFF
--- a/regression/ir-ra/ra-isnan-div-zero-zero-fail/main.c
+++ b/regression/ir-ra/ra-isnan-div-zero-zero-fail/main.c
@@ -1,0 +1,17 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+
+  __ESBMC_assert(!isnan(z), "0.0 / 0.0 should not be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-isnan-div-zero-zero-fail/test.desc
+++ b/regression/ir-ra/ra-isnan-div-zero-zero-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-isnan-div-zero-zero/main.c
+++ b/regression/ir-ra/ra-isnan-div-zero-zero/main.c
@@ -1,0 +1,17 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+
+  __ESBMC_assert(isnan(z), "isnan(0.0 / 0.0) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isnan-div-zero-zero/test.desc
+++ b/regression/ir-ra/ra-isnan-div-zero-zero/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-isnan-not-nan/main.c
+++ b/regression/ir-ra/ra-isnan-not-nan/main.c
@@ -1,0 +1,17 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 1.0);
+  __ESBMC_assume(y == 2.0);
+  double z = x / y;
+
+  __ESBMC_assert(!isnan(z), "isnan(1.0 / 2.0) is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-isnan-not-nan/test.desc
+++ b/regression/ir-ra/ra-isnan-not-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-isnan-sqrt-neg/main.c
+++ b/regression/ir-ra/ra-isnan-sqrt-neg/main.c
@@ -1,0 +1,15 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double z = sqrt(x);
+
+  __ESBMC_assert(isnan(z), "isnan(sqrt(-1.0)) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isnan-sqrt-neg/test.desc
+++ b/regression/ir-ra/ra-isnan-sqrt-neg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -1,6 +1,7 @@
 #include "irep2/irep2_expr.h"
 #include <solvers/smt/smt_solver.h>
 #include <solvers/smt/smt_fp_rounding_utils.h>
+#include <solvers/smt/fp/ir_ieee_conv.h>
 #include <util/arith_tools.h>
 #include <util/expr_util.h>
 #include <util/message.h>
@@ -561,8 +562,21 @@ smt_astt smt_solver_baset::convert_is_nan(const expr2tc &expr)
   const isnan2t &isnan = to_isnan2t(expr);
 
   // Anything other than floats will never be NaNs
-  if (!is_floatbv_type(isnan.value) || int_encoding)
+  if (!is_floatbv_type(isnan.value))
     return mk_smt_bool(false);
+
+  if (int_encoding)
+  {
+    // Under --ir-ieee the operand is a known NaN iff its tracked NaN
+    // predicate holds; values with no tracked predicate are assumed
+    // non-NaN. Plain --int-encoding (without --ir-ieee) has no predicate
+    // tracking at all, so it conservatively reports false.
+    if (!ir_ieee)
+      return mk_smt_bool(false);
+    smt_astt operand = convert_ast(isnan.value);
+    smt_astt nan_pred = ir_ieee_api->get_nan_pred(operand);
+    return nan_pred ? nan_pred : mk_smt_bool(false);
+  }
 
   smt_astt operand = convert_ast(isnan.value);
   return fp_api->mk_smt_fpbv_is_nan(operand);


### PR DESCRIPTION
## Summary

This PR wires `isnan()` into the existing `--ir-ieee` NaN predicate infrastructure.

Previously, `convert_is_nan` returned `false` whenever integer/real floating-point encoding was enabled. This meant that even when `--ir-ieee` had already tracked a value as NaN, `isnan()` could not observe that metadata.

After this change, when `--ir-ieee` has a known NaN predicate for the operand, `isnan()` returns that predicate.

## Motivation

Recent `--ir-ieee` work added minimal NaN predicate tracking and propagation. NaN predicates are now produced by cases such as:

```c
double z = x / y;
```

where:

```c
x == 0.0
y == 0.0
```

and by negative `sqrt` results.

Those predicates are already used by NaN-aware comparison handling. However, `isnan()` itself still returned `false` under integer/real encoding, so the following pattern was not handled correctly:

```c
double z = x / y;   // x == 0.0, y == 0.0
__ESBMC_assert(isnan(z), "z should be NaN");
```

This PR makes `isnan()` use the same tracked NaN metadata as the comparison path.

## Changes

This PR updates `smt_solver_baset::convert_is_nan` in:

```text
src/solvers/smt/smt_fp_conv.cpp
```

For the `--ir-ieee` path, `convert_is_nan` now:

* converts the operand to the SMT expression used by the encoding,
* queries `ir_ieee_api->get_nan_pred(...)`,
* returns the tracked NaN predicate when one is known,
* falls back to `false` when no NaN predicate is known.

The non-`int_encoding` bitvector floating-point path is unchanged.

This PR does not add new NaN sources or new NaN propagation rules. It only makes `isnan()` observe already-tracked NaN predicates.

## Regression Test

Four new CORE regression tests were added under `regression/ir-ra/`:

* `ra-isnan-div-zero-zero`

  * Checks that `isnan(0.0 / 0.0)` succeeds when the NaN predicate comes from the zero-divided-by-zero source.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-isnan-div-zero-zero-fail`

  * Failing companion test.
  * Checks that `!isnan(0.0 / 0.0)` does not incorrectly hold.
  * Expected result: `VERIFICATION FAILED`.

* `ra-isnan-sqrt-neg`

  * Checks that `isnan()` also observes the existing negative-`sqrt` NaN source.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-isnan-not-nan`

  * Checks that `isnan()` does not produce a false positive for a non-NaN division case.
  * Expected result: `VERIFICATION SUCCESSFUL`.

The tests use nondeterministic operands constrained with `__ESBMC_assume` instead of literal-only constants. This avoids front-end constant folding and ensures the expressions reach the `--ir-ieee` SMT encoding path.

## Testing

The focused `isnan` regression tests were run:

```bash
ctest --test-dir build -R "ra-isnan" --output-on-failure
```

Result:

```text
4/4 passed
```


## Notes

This PR is intentionally limited to making `isnan()` observe already-known NaN predicates under `--ir-ieee`.

It does not introduce new NaN sources.

It does not add infinity tracking, NaN propagation through unary negation or absolute value, `nan("")`, signed zero, casts, nearbyint, or other IEEE features.

When no NaN predicate is known for the operand, the `--ir-ieee` path conservatively falls back to `false`, matching the previous behaviour for untracked values.