### PR TITLE
[python] Fix inverted constant-int guard breaking width string methods

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -384,3 +384,57 @@ robustness category, but with a sound value model rather than an "unsupported fe
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
 on current `master` without the §5 architectural work; the §5 priority order stands.
+
+---
+
+> **Note on numbering.** §11 (PR #5510), §12 (PR #5513), and §13 (PR #5515) are all in flight and
+> not yet on `master`; this section is appended as §14 of the fourth 2026-06-21 sweep so the
+> four same-day PRs do not collide on the section number. When they land, the maintainer orders
+> §11 → §12 → §13 → §14.
+
+## 14. 2026-06-21 re-validation (fourth sweep) & inverted constant-int soundness fix
+
+Re-test against current `master` (tip `4a5b002c26`, still unchanged; PRs #5510/#5513/#5515 OPEN,
+awaiting review). KNOWNBUG classification unchanged. With the §11 crash backlog drained, this
+sweep probed string-method idioms and found a **soundness** defect (false verdicts), not just a
+crash — the highest-value class.
+
+### 14a. New isolated, soundly-fixable defect found & fixed
+**An inverted constant-int guard silently broke `str.center`/`ljust`/`rjust`/`zfill` and
+`expandtabs`, proving false assertions.**
+
+`"42".zfill(5) == "00042"`, `"hi".center(6,"*") == "**hi**"`, `"hi".ljust(5,".")`,
+`"hi".rjust(5,".")`, and `"a\tb".expandtabs(4)` all gave wrong verdicts: a *correct* assertion on
+the result reported `VERIFICATION FAILED`, and the result's value/length was effectively nondet
+(`expandtabs(4)` silently used the default tabsize 8, giving length 9 instead of 5). `bytes`,
+`upper`, `replace`, and `find` were unaffected.
+
+**Root cause** (`src/python-frontend/string/string_method_handler.cpp`, `get_constant_int`). The
+helper guarded on `if (!to_integer(expr, tmp)) return false;` — but `to_integer()` returns
+**false on success** (CBMC convention). The `!` inverted it: every valid integer constant was
+rejected (treated as non-constant), and non-constants were *accepted* with an unset value. Each
+width/fill method then hit its `get_constant_int(width_arg, …)` check, concluded the width was
+non-constant, and returned `build_nondet_string_fallback()` — so the assignment target became a
+nondet string. `find`/`upper` were spared because they are folded by `python_consteval` and never
+reach this helper; `bytes`/`replace` take string (not int) arguments.
+
+**Fix:** drop the inverted `!` (`if (to_integer(expr, tmp)) return false;`). One token. All five
+methods now compute exact CPython-matching values (verified `"00042"`, `"**hi**"`, `"hi..."`,
+`"...hi"`, `"a   b"`), and a wrong-value assertion now correctly `FAILED`. This is a condition
+correction (literal change), not a structural branch change; the new regression pair
+`regression/python/str_width_methods{,_fail}` pins the corrected value/length contract. A broad
+`regression/python/` sweep shows **zero new failures** — the only failures are the pre-existing
+Bitwuzla-only environmental set (`--z3`/`--ir`-pinned), none touching these methods.
+
+Unlike §13's crash→diagnostic, this is a true **soundness** fix: ESBMC was proving false
+assertions about string-method results, which is worse than a crash. Bitwuzla-only build; the fix
+is a frontend constant-folding guard with no SMT encoding, so the verdict is solver-agnostic.
+
+A separate, narrower issue remains visible but out of scope here: `len()` of a space-padded
+method result (`len("x".center(7))`) still mis-verifies even though the value (`"   x   "`)
+compares equal — a distinct `len`/`strlen` concern on the padded array, tracked for a later sweep.
+
+### 14b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
+on current `master` without the §5 architectural work; the §5 priority order stands.

--- a/regression/python/str_width_methods/main.py
+++ b/regression/python/str_width_methods/main.py
@@ -1,0 +1,11 @@
+# Regression: width/fill string methods (center/ljust/rjust/zfill) and
+# expandtabs route their integer argument through get_constant_int(), whose
+# guard was inverted (`!to_integer` — to_integer returns false on success).
+# Every valid constant width was rejected, so these methods silently fell back
+# to a nondet/default result and proved false assertions on their length/value.
+assert "42".zfill(5) == "00042"
+assert "hi".center(6, "*") == "**hi**"
+assert "hi".ljust(5, ".") == "hi..."
+assert "hi".rjust(5, ".") == "...hi"
+assert "a\tb".expandtabs(4) == "a   b"
+assert "x".center(7) == "   x   "

--- a/regression/python/str_width_methods/test.desc
+++ b/regression/python/str_width_methods/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_width_methods_fail/main.py
+++ b/regression/python/str_width_methods_fail/main.py
@@ -1,0 +1,4 @@
+# Negative: zfill must produce "00042", not "99999". With the inverted guard
+# the receiver became a nondet string and this assertion was satisfiable,
+# masking the bug. After the fix the value is concrete and the assertion fails.
+assert "42".zfill(5) == "99999"

--- a/regression/python/str_width_methods_fail/test.desc
+++ b/regression/python/str_width_methods_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8 --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -95,7 +95,12 @@ static bool get_constant_int(const exprt &expr, long long &out)
   if (expr.is_nil())
     return false;
   BigInt tmp;
-  if (!to_integer(expr, tmp))
+  // to_integer() returns false on success (CBMC convention), so the guard must
+  // bail when it returns true. The earlier `!to_integer(...)` was inverted: it
+  // rejected every valid integer constant (and accepted non-constants with an
+  // unset value), so width/fill string methods — center/ljust/rjust/zfill and
+  // expandtabs's tabsize — silently fell back to a nondet/default result.
+  if (to_integer(expr, tmp))
     return false;
   out = tmp.to_int64();
   return true;


### PR DESCRIPTION
## What

`str.center` / `ljust` / `rjust` / `zfill` and `expandtabs` returned **wrong verdicts** — a *correct* assertion on the result reported `VERIFICATION FAILED`, and the result was effectively nondet:

```python
assert "42".zfill(5) == "00042"        # FAILED before this PR (correct assertion!)
assert "hi".center(6, "*") == "**hi**" # FAILED
assert "a\tb".expandtabs(4) == "a   b" # expandtabs silently used the default tabsize 8
```

`bytes`, `upper`, `replace`, and `find` were unaffected.

## Why

In `string_method_handler.cpp`, `get_constant_int` guarded on `if (!to_integer(expr, tmp)) return false;` — but `to_integer()` returns **false on success** (CBMC convention). The `!` inverted it: every valid integer constant was *rejected* (treated as non-constant), and non-constants were *accepted* with an unset value.

Each width/fill method then concluded its width argument was non-constant and returned `build_nondet_string_fallback()`, so the assignment target became a nondet string and assertions about its value/length were unsound. `find`/`upper` were spared because `python_consteval` folds them before this helper; `bytes`/`replace` take string (not int) arguments.

## Fix

Drop the inverted `!`:

```cpp
if (to_integer(expr, tmp))
  return false;
```

One token. All five methods now compute exact CPython-matching values (`"00042"`, `"**hi**"`, `"hi..."`, `"...hi"`, `"a   b"`), and a wrong-value assertion correctly `FAILED`.

## Testing

- New pair `regression/python/str_width_methods` (exact-value assertions for all five methods) and `str_width_methods_fail` (wrong value must FAIL). Both pass via `ctest`; CPython sanity passes.
- Broad `regression/python/` sweep: **zero new failures** (only the pre-existing Bitwuzla-only environmental set — `--z3`/`--ir`-pinned tests, none touching these methods).

This is a **soundness** fix — ESBMC was proving false assertions about string-method results.

Methodology recorded in `docs/python-issues-triage-report-2026-06-02.md` §14.

> Built with `ENABLE_Z3=OFF` (Bitwuzla only); the fix is a frontend constant-folding guard with no SMT encoding, so the verdict is solver-agnostic. A separate, narrower `len()`-of-padded-result concern is noted in §14 for a later sweep.
>
> Sibling same-day sweeps are in flight as #5510 / #5513 / #5515; the four PRs append §11–§14 of the triage report respectively and are independent.
