### PR TITLE
[python] V.3: fold chained-comparison conjunction in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -435,14 +435,18 @@ exprt python_converter::handle_chained_comparisons_logic(
   const nlohmann::json &element,
   exprt &bin_expr)
 {
-  exprt cond("and", bool_type());
-  cond.move_to_operands(bin_expr); // bin_expr compares left and comparators[0]
+  // Collect the per-pair comparisons (bin_expr is the first), then fold the
+  // conjunction in IREP2 and back-migrate once. V.3: the legacy n-ary "and"
+  // is spliced by migrate into exactly this left-nested and2t chain (and the
+  // mandatory --irep2-bodies round-trip normalises both forms identically),
+  // so building it directly is behaviour-preserving. The callers guarantee
+  // comparators.size() > 1, so there are always at least two conjuncts.
+  std::vector<exprt> conjuncts;
+  conjuncts.push_back(bin_expr); // bin_expr compares left and comparators[0]
 
   for (size_t i = 0; i + 1 < element["comparators"].size(); ++i)
   {
     std::string op(element["ops"][i + 1]["_type"].get<std::string>());
-    exprt logical_expr(
-      python_frontend::map_operator(op, bool_type()), bool_type());
     exprt op1 = get_expr(element["comparators"][i]);
     exprt op2 = get_expr(element["comparators"][i + 1]);
 
@@ -458,21 +462,31 @@ exprt python_converter::handle_chained_comparisons_logic(
       {
         exprt expr(python_frontend::map_operator(op, bool_type()), bool_type());
         expr.copy_to_operands(op1, op2);
-        cond.move_to_operands(expr);
+        conjuncts.push_back(expr);
       }
       else
       {
-        cond.move_to_operands(string_expr);
+        conjuncts.push_back(string_expr);
       }
     }
     else
     {
-      logical_expr.copy_to_operands(op1);
-      logical_expr.copy_to_operands(op2);
-      cond.move_to_operands(logical_expr);
+      exprt logical_expr(
+        python_frontend::map_operator(op, bool_type()), bool_type());
+      logical_expr.copy_to_operands(op1, op2);
+      conjuncts.push_back(logical_expr);
     }
   }
-  return cond;
+
+  expr2tc acc;
+  migrate_expr(conjuncts.front(), acc);
+  for (size_t i = 1; i < conjuncts.size(); ++i)
+  {
+    expr2tc c2;
+    migrate_expr(conjuncts[i], c2);
+    acc = and2tc(acc, c2);
+  }
+  return migrate_expr_back(acc);
 }
 
 exprt python_converter::handle_membership_operator(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). `handle_chained_comparisons_logic` (Python chained comparisons like `a < b < c`) built a flat n-ary legacy `cond("and", bool_type())` and accumulated each per-pair comparison via `cond.move_to_operands(...)`. It now collects the conjuncts into a `std::vector<exprt>` and folds them left-associatively with `and2tc`, back-migrating once.

## Why it is behaviour-preserving

- `migrate`'s `splice_expr` lowers a flat n-ary `"and"` `[c0,c1,c2]` to exactly the left-nested `and2t(and2t(c0,c1),c2)` this fold builds; `and2t` fixes a bool result matching the legacy node.
- Both callers guard `comparators.size() > 1`, so the loop runs at least once and there are always ≥ 2 conjuncts — the old code likewise always produced an `"and"` with ≥ 2 operands (never a malformed 1-operand `"and"`).
- The per-pair comparison construction (str-vs-str via `handle_string_comparison`, numeric `logical_expr`) and operand order (`op1` then `op2`, `bin_expr` first) are unchanged.
- With `--irep2-bodies` now the unconditional default, every converter body is round-tripped (n-ary `"and"` → nested `and2t`) before goto-convert regardless, so this only makes the construction explicit rather than relying on the downstream normalisation.

## Validation

- Numeric and string chained-comparison probes, both passing (`1 < a < 10`, `1 < b < a < 10`, `"a" < x < "z"`) and failing (`1 < 50 < 10`) -> correct verdicts.
- 50 chained/comparison regression tests pass plus the broader string/assert stratum on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (edited region). Dual-solver parity delegated to CI.
