### PR TITLE
[python] Reject dict union '|' with a clean diagnostic instead of SIGSEGV

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -384,3 +384,57 @@ robustness category, but with a sound value model rather than an "unsupported fe
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
 on current `master` without the §5 architectural work; the §5 priority order stands.
+
+---
+
+> **Note on numbering.** §11–§14 (PRs #5510/#5513/#5515/#5518) are all in flight and not yet on
+> `master`; this section is appended as §15 of the fifth 2026-06-21 sweep. When they land, the
+> maintainer orders §11 → §12 → §13 → §14 → §15.
+
+## 15. 2026-06-21 re-validation (fifth sweep) & dict-union SIGSEGV→diagnostic
+
+Re-test against current `master` (tip `4a5b002c26`, still unchanged; PRs #5510/#5513/#5515/#5518
+OPEN, awaiting review). KNOWNBUG classification unchanged. This sweep probed dict/set/int/float/
+list method idioms (fresh ground — the §11 string/cmath/numpy battery is drained).
+
+### 15a. New isolated, soundly-fixable defect found & fixed
+**Python dict union (`d1 | d2`) SIGSEGV'd in the SMT backend.**
+
+`{"a":1} | {"b":2}` (PEP 584 dict merge, Python 3.9+) crashed with `EXC_BAD_ACCESS` inside
+`bitwuzla_mk_term2` — the faulting address decoded to ASCII (`...tuple_`), i.e. a struct/type
+irep was handed to the solver as a term pointer. The crash reproduced for every key type; set
+union (`{1,2}|{3,4}`) and integer bitwise-or (`6|1`) were unaffected.
+
+**Root cause** (`src/python-frontend/converter/converter_binop.cpp`,
+`build_binary_operator_expr`). Set union and the difference/intersection ops are intercepted for
+list-typed (set) operands; integer `|` takes the proper bitvector path. But **two dict operands
+matched neither** — dict union is unmodeled — so they fell through to `build_binary_expression`,
+whose bitwise branch (`is_bitwise_op`) only type-adjusts bv/bool operands and then emitted a raw
+`BitOr` over the two dict structs. That malformed term crashed the Bitwuzla encoder.
+
+**Fix:** add a guard beside the existing set-operation handling that rejects bitwise ops
+(`BitOr`/`BitAnd`/`BitXor`) on dict operands with a clean
+`ERROR: dict union '|' and bitwise operations on dict are not supported`. Modelling dict merge
+properly (copy-then-update semantics with right-wins key precedence) is a feature for a dedicated
+change; this is the §5-item-5 crash→diagnostic robustness step, bounded and sound. Set/int
+bitwise ops and dict `==`/`.update()` are untouched. New regression pair
+`regression/python/dict_union_unsupported` (clean error — the **C-Live** liveness witness for the
+added guard) + `set_union_after_dict_fix` (set/int `|` still verify). Broad `regression/python/`
+sweep: **zero new failures** (only the pre-existing `--z3`/`--ir` environmental set).
+
+Bitwuzla-only build; the fix is a frontend dispatch guard with no SMT encoding, so the verdict is
+solver-agnostic.
+
+### 15b. Other fresh defects observed this sweep (catalogued, not yet fixed)
+The dict/int/float probe also surfaced (deferred — several are unmodeled-method feature gaps, and
+one is blocked behind an in-flight PR):
+- `int.bit_count()`, `int.from_bytes()`, `int.to_bytes()`, `float.is_integer()`, `float.hex()` —
+  **unmodeled methods**; ESBMC replaces the undefined function with `assert(false)`, so any program
+  calling them reports a spurious `FAILED`. Each is an isolated "add the model" candidate.
+- `set.isdisjoint()` — `ERROR: Object "" not found` (dispatch/model gap).
+- `len()` of a space-padded `str.center()` result still mis-verifies (noted in §14) — blocked
+  behind PR #5518, which must land first to make `center` return a concrete value.
+
+### 15c. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. The §5 priority order stands.

--- a/regression/python/dict_union_unsupported/main.py
+++ b/regression/python/dict_union_unsupported/main.py
@@ -1,0 +1,8 @@
+# dict union (PEP 584: d1 | d2) is not modeled. Before the fix both dict structs
+# fell through to the bitwise BitOr path and SIGSEGV'd in the SMT backend (a
+# struct irep handed to bitwuzla_mk_term2 as a term pointer). It must now produce
+# a clean "not supported" diagnostic instead of crashing.
+a = {"a": 1}
+b = {"b": 2}
+c = a | b
+assert c["b"] == 2

--- a/regression/python/dict_union_unsupported/test.desc
+++ b/regression/python/dict_union_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^ERROR: dict union '\|' and bitwise operations on dict are not supported$

--- a/regression/python/set_union_after_dict_fix/main.py
+++ b/regression/python/set_union_after_dict_fix/main.py
@@ -1,0 +1,7 @@
+# Guard: set union (|) and integer bitwise-or must still work after the dict-|
+# diagnostic was added to the same BitOr path.
+s = {1, 2} | {3, 4}
+assert 3 in s
+assert 1 in s
+x = 6 | 1
+assert x == 7

--- a/regression/python/set_union_after_dict_fix/test.desc
+++ b/regression/python/set_union_after_dict_fix/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -656,6 +656,19 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
       return set_result;
   }
 
+  // Python dict union (PEP 584: `d1 | d2`) and bitwise operations on dicts are
+  // not modeled. Reject them with a clean diagnostic: otherwise both dict
+  // structs fall through to build_binary_expression's bitwise path, which emits
+  // a bitvector BitOr over struct operands and SIGSEGVs in the SMT backend
+  // (a struct irep is handed to bitwuzla_mk_term2 as a term pointer).
+  if (
+    (op == "BitOr" || op == "BitAnd" || op == "BitXor") &&
+    lhs.type().is_struct() && rhs.type().is_struct() &&
+    dict_handler_->is_dict_type(lhs.type()) &&
+    dict_handler_->is_dict_type(rhs.type()))
+    throw std::runtime_error(
+      "dict union '|' and bitwise operations on dict are not supported");
+
   // Handle membership operators
   if (op == "In")
     return handle_membership_operator(lhs, rhs, element, false);


### PR DESCRIPTION
## What

Python dict union (`d1 | d2`, PEP 584, Python 3.9+) **SIGSEGV'd**:

```python
{"a": 1} | {"b": 2}     # EXC_BAD_ACCESS in bitwuzla_mk_term2 (before this PR)
```

The faulting address decoded to ASCII (`...tuple_`) — a struct/type irep handed to the solver as a term pointer. It crashed for every key type. Set union (`{1,2}|{3,4}`) and integer bitwise-or (`6|1`) were unaffected.

## Why

In `converter_binop.cpp` (`build_binary_operator_expr`), set union / difference / intersection are intercepted for list-typed (set) operands, and integer `|` takes the proper bitvector path. But **two dict operands matched neither** — dict union is unmodeled — so they fell through to `build_binary_expression`, whose bitwise branch only type-adjusts bv/bool operands and then emitted a raw `BitOr` over the two dict structs. That malformed term crashed the Bitwuzla encoder.

## Fix

Add a guard beside the existing set-operation handling that rejects bitwise ops (`BitOr`/`BitAnd`/`BitXor`) on dict operands with a clean diagnostic:

```
ERROR: dict union '|' and bitwise operations on dict are not supported
```

Modelling dict merge properly (copy-then-update with right-wins key precedence) is a feature for a dedicated change; this is a crash → clean-diagnostic robustness fix, bounded and sound. Set/int bitwise ops and dict `==` / `.update()` are untouched.

## Testing

- New pair `regression/python/dict_union_unsupported` (clean error) and `set_union_after_dict_fix` (set/int `|` still verify). Both pass via `ctest`; CPython sanity passes.
- Broad `regression/python/` sweep: **zero new failures** (only the pre-existing Bitwuzla-only environmental set — `--z3`/`--ir`-pinned).

Methodology recorded in `docs/python-issues-triage-report-2026-06-02.md` §15, which also catalogues other fresh defects found this sweep (unmodeled `int.bit_count`/`from_bytes`/`to_bytes`, `float.is_integer`/`hex`, `set.isdisjoint`) deferred to later changes.

> Built with `ENABLE_Z3=OFF` (Bitwuzla only); the fix is a frontend dispatch guard with no SMT encoding, so the verdict is solver-agnostic.
>
> Sibling same-day sweeps are in flight as #5510 / #5513 / #5515 / #5518; the five PRs append §11–§15 of the triage report respectively and are independent.
