### PR TITLE
[python] V.3: build startswith/endswith result bools in IREP2

### DIFF
--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -881,22 +881,22 @@ exprt string_handler::handle_string_startswith(
     *strncmp_symbol, int_type(), {str_addr, prefix_addr, actual_len});
   strncmp_call.location() = location;
 
-  // Check if result == 0 (strings match)
-  exprt zero = gen_zero(int_type());
-  exprt equal("=", bool_type());
-  equal.copy_to_operands(strncmp_call, zero);
+  // V.3: build `(actual_len == 0) || (strncmp(...) == 0)` in IREP2, back
+  // -migrating once. Python treats the empty string as a prefix of every
+  // string, so s.startswith("") is always True; the empty-prefix guard keeps
+  // the result correct for a symbolic empty prefix and is robust to
+  // strncmp(_,_,0), which the operational model evaluates to a non-zero value.
+  expr2tc strncmp2, zero2;
+  migrate_expr(strncmp_call, strncmp2);
+  migrate_expr(gen_zero(int_type()), zero2);
+  expr2tc equal2 = equality2tc(strncmp2, zero2);
 
-  // Python treats the empty string as a prefix of every string, so
-  // s.startswith("") is always True. Guard this case explicitly: it keeps the
-  // result correct for a symbolic empty prefix and is robust to strncmp(_,_,0),
-  // which the operational model evaluates to a non-zero value.
-  exprt is_empty("=", bool_type());
-  is_empty.copy_to_operands(actual_len, gen_zero(actual_len.type()));
+  expr2tc len2, len_zero2;
+  migrate_expr(actual_len, len2);
+  migrate_expr(gen_zero(actual_len.type()), len_zero2);
+  expr2tc is_empty2 = equality2tc(len2, len_zero2);
 
-  exprt result("or", bool_type());
-  result.copy_to_operands(is_empty, equal);
-
-  return result;
+  return migrate_expr_back(or2tc(is_empty2, equal2));
 }
 
 exprt string_handler::handle_string_endswith(
@@ -963,19 +963,18 @@ exprt string_handler::handle_string_endswith(
     *strncmp_symbol, int_type(), {offset_ptr, suffix_addr, suffix_strlen_call});
   strncmp_call.location() = location;
 
-  // Check if result == 0 (strings match)
-  exprt zero = gen_zero(int_type());
-  exprt strings_equal("=", bool_type());
-  strings_equal.copy_to_operands(strncmp_call, zero);
+  // V.3: build `!(suffix_len > str_len) && (strncmp(...) == 0)` in IREP2,
+  // back-migrating once. Order and operands match the legacy nodes exactly.
+  expr2tc strncmp2, zero2;
+  migrate_expr(strncmp_call, strncmp2);
+  migrate_expr(gen_zero(int_type()), zero2);
+  expr2tc strings_equal2 = equality2tc(strncmp2, zero2);
 
-  // Return: (suffix_len <= str_len) && (strncmp(...) == 0)
-  exprt len_ok("not", bool_type());
-  len_ok.copy_to_operands(len_check);
+  expr2tc len_check2;
+  migrate_expr(len_check, len_check2);
+  expr2tc len_ok2 = not2tc(len_check2);
 
-  exprt result("and", bool_type());
-  result.copy_to_operands(len_ok, strings_equal);
-
-  return result;
+  return migrate_expr_back(and2tc(len_ok2, strings_equal2));
 }
 
 exprt string_handler::handle_string_isdigit(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). `handle_string_startswith` and `handle_string_endswith` built their boolean result with legacy `exprt("or"/"and"/"not"/"=")` + `copy_to_operands`. They now build the result subtrees with IREP2 factories (`equality2tc`, `or2tc`, `and2tc`, `not2tc`) and back-migrate once at the return seam.

## Why it is behaviour-preserving

- **startswith** returns `or2tc(is_empty, equal)` — `is_empty = (actual_len == 0)`, `equal = (strncmp(...) == 0)` — with `is_empty` first, matching the legacy `result.copy_to_operands(is_empty, equal)`.
- **endswith** returns `and2tc(not2tc(len_check), strings_equal)` — `len_check` is the pre-existing `>` node `(suffix_len > str_len)`, migrated forward unchanged, and `strings_equal = (strncmp(...) == 0)` — with `len_ok` first, matching the legacy `result.copy_to_operands(len_ok, strings_equal)`.
- Operand order and bool result types match the legacy nodes; the equality operands keep their `int`/`actual_len` types; the empty-prefix guard semantics are preserved.

## Validation

- startswith/endswith probes including empty-string prefix/suffix (`s.startswith("")`, `s.endswith("")`) -> `VERIFICATION SUCCESSFUL`; negative cases correct.
- 490 string regression tests pass on a Debug/asserts build (15 startswith/endswith-specific); live `migrate.cpp` cross-check silent.
- clang-format clean (edited regions). Dual-solver parity delegated to CI.
