### PR TITLE
[python] V.3: build char.isspace() bool result in IREP2

### DIFF
--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -1098,12 +1098,13 @@ exprt string_handler::handle_char_isspace(
   exprt call = build_call_expr(func_symbol_id, int_type(), {char_as_int});
   call.location() = location;
 
-  // Convert result to boolean (isspace returns non-zero for whitespace)
-  exprt result("notequal", bool_type());
-  result.copy_to_operands(call);
-  result.copy_to_operands(from_integer(0, int_type()));
-
-  return result;
+  // V.3: convert the C isspace() result to a boolean in IREP2 (isspace
+  // returns non-zero for whitespace), back-migrating once. Operand order
+  // (call != 0) and the bool result type match the legacy node.
+  expr2tc call2, zero2;
+  migrate_expr(call, call2);
+  migrate_expr(from_integer(0, int_type()), zero2);
+  return migrate_expr_back(notequal2tc(call2, zero2));
 }
 
 exprt string_handler::handle_string_lstrip(


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). `handle_char_isspace` converted the C `isspace()` int result to a Python bool with a legacy `exprt("notequal", bool_type())` + `copy_to_operands`. It now builds the `call != 0` check with `notequal2tc` and back-migrates once at the return seam.

## Why it is behaviour-preserving

`notequal2t` fixes the operand order (`call`, `0`) and a bool result type matching the legacy node; `call` (the `build_call_expr` int result) and the int zero are migrated forward unchanged, so the `isspace` non-zero-means-true convention is preserved.

## Validation

- `char.isspace()` probe (whitespace true, non-whitespace false) -> `VERIFICATION SUCCESSFUL`.
- 32 string-predicate regression tests pass on a Debug/asserts build; live `migrate.cpp` cross-check silent.
- clang-format clean (edited region). Dual-solver parity delegated to CI.
