### PR TITLE
[python] Model int.bit_count() to fix spurious FAILED on popcount

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -645,3 +645,50 @@ encoding, so the verdict is solver-agnostic.
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. No further isolated, soundly-fixable point fix is available
 on current `master` without the §5 architectural work; the §5 priority order stands.
+
+---
+
+## 16. 2026-06-22 re-validation (sixth sweep) & int.bit_count() model
+
+Re-test against current `master` (tip `38fd6daaa1`, with §11–§15's PRs now landed:
+`#5518` width string methods, `#5519` chained-comparison fold, `#5520` dict-union diagnostic,
+`#5516` strcmp normalisation, `#5521` startswith/endswith). KNOWNBUG classification unchanged —
+§3 holds. This sweep drained the next entry from the §15b "unmodeled method" backlog.
+
+### 16a. New isolated, soundly-fixable defect found & fixed
+**`int.bit_count()` was unmodeled, producing a spurious `VERIFICATION FAILED`.**
+
+`x = 13; x.bit_count()` (Python 3.10+ population count) reported
+`Unsupported function 'bit_count' is reached → VERIFICATION FAILED` even though `13 == 0b1101`
+has three ones. `bit_count` had no operational model, so ESBMC lowered the call to the
+unsupported-function stub. The no-argument int instance-method dispatch already works
+(`expr.cpp` passes the receiver as the value argument, exactly as for `bit_length`); only the
+model body was missing.
+
+**Fix** (`src/python-frontend/models/int.py`): add a `bit_count` classmethod mirroring the
+existing `bit_length` template — fold negatives to their magnitude (`bit_count` operates on the
+absolute value), then accumulate `n & 1` while right-shifting, bounded by a literal 512-shift
+counter (the `--ir` bignum `IntWide` width) so the unwinder has a termination bound and narrow
+callsites exit at `n == 0` well before it. Modelling `bit_count` as an eager popcount is sound
+in every context (it has no side effects and depends only on the receiver's value), verified
+bit-for-bit against CPython for `0`, `255`, `1024`, a negative (`-3 → 2`), an expression
+receiver (`(4-1) → 2`), and `13 → 3`.
+
+Unlike the §6a/§7a/§13a crash→diagnostic fixes, this **restores a working feature** (any program
+calling `int.bit_count()` now verifies with the exact count) — like §10a/§11a/§12a it adds a
+sound value model. New regression pair `regression/python/int_bit_count{,_fail}` (CORE); the
+positive test is the **Py-Live** liveness witness for the new model branch (it reported the
+unsupported-function `FAILED` pre-fix and `SUCCESSFUL` after). The full `regression/python/`
+suite shows zero new failures (only the pre-existing Bitwuzla-only `--z3`/`--ir` environmental
+set, e.g. `github_1964_bit_length_bignum` which is `--ir`-pinned and needs Z3). The fix is
+FLAIL-mangled into the binary, so the OM rebuild requirement was honoured before testing.
+Bitwuzla-only build (`ENABLE_Z3=OFF`); the model is a frontend lowering with no SMT encoding, so
+the verdict is solver-agnostic.
+
+### 16b. Everything else: unchanged disposition
+The remaining §15b unmodeled-method candidates (`int.from_bytes`/`to_bytes` instance-method
+dispatch, `float.is_integer()`/`float.hex()`, `set.isdisjoint()`) stand as the next "add the
+model" entries. The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable
+expectation, and the infeasible `hashlib` case all stand. No further isolated, soundly-fixable
+point fix beyond those candidates is available on current `master` without the §5 architectural
+work; the §5 priority order stands.

--- a/regression/python/int_bit_count/main.py
+++ b/regression/python/int_bit_count/main.py
@@ -1,0 +1,19 @@
+a = int(0)
+assert a.bit_count() == 0
+
+b = int(255)
+assert b.bit_count() == 8
+
+c = int(1024)
+assert c.bit_count() == 1
+
+# bit_count() operates on the absolute value: abs(-3) == 0b11 has two ones.
+d = int(-3)
+assert d.bit_count() == 2
+
+e = 4
+assert (e - 1).bit_count() == 2  # (4 - 1) == 0b11 has two ones
+
+f = int(13)
+g = f.bit_count()
+assert g == 3

--- a/regression/python/int_bit_count/test.desc
+++ b/regression/python/int_bit_count/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_bit_count_fail/main.py
+++ b/regression/python/int_bit_count_fail/main.py
@@ -1,0 +1,2 @@
+x = int(13)
+assert x.bit_count() == 2 # 13 == 0b1101 has three ones, not two

--- a/regression/python/int_bit_count_fail/test.desc
+++ b/regression/python/int_bit_count_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 6
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -63,3 +63,26 @@ class int:
             n: IntWide = n >> 1
             length = length + 1
         return length
+
+    @classmethod
+    # bit_count() returns the number of ones in the binary representation
+    # of the absolute value of the integer (Python 3.10+). `n` is annotated
+    # `IntWide` for the same bignum reason as bit_length; narrow inputs
+    # sign-extend on entry, so negatives are folded to their magnitude
+    # before counting. The loop is bounded by a literal 512-shift counter
+    # (matching the --ir bignum IntWide width) rather than by the symbolic
+    # input, so the unwinder has a termination bound; narrow callsites exit
+    # at n == 0 well before that. The literal 512 shares bit_length's
+    # soundness contract (>= kPythonBitLengthCap in type_handler.cpp, tied to
+    # kPythonBignumWidth by a static_assert) — bump both together when
+    # widening Python int. Issues #1964 / #4642.
+    def bit_count(cls, n: IntWide) -> int:
+        if n < 0:
+            n: IntWide = -n
+        count: int = 0
+        shifts: int = 0
+        while shifts < 512 and n > 0:
+            count = count + (n & 1)
+            n: IntWide = n >> 1
+            shifts = shifts + 1
+        return count


### PR DESCRIPTION
## Problem

`int.bit_count()` (Python 3.10+ population count) was unmodeled in the Python frontend. ESBMC lowered the call to the unsupported-function stub, so any program calling it reported a spurious `VERIFICATION FAILED`:

```python
x: int = 13
assert x.bit_count() == 3   # 13 == 0b1101 has three ones
```
→ `Unsupported function 'bit_count' is reached → VERIFICATION FAILED`

The no-argument int instance-method dispatch already works (`function_call/expr.cpp` passes the receiver as the value argument, exactly as for the existing `bit_length`); only the model body was missing.

## Fix

Add a `bit_count` classmethod to `src/python-frontend/models/int.py`, mirroring the existing `bit_length` template:
- fold negatives to their magnitude (`bit_count` operates on the absolute value);
- accumulate `n & 1` while right-shifting, bounded by a literal 512-shift counter (the `--ir` bignum `IntWide` width) so the unwinder has a termination bound and narrow callsites exit at `n == 0` well before it.

Modelling `bit_count` as an eager popcount is sound in every context (no side effects, depends only on the receiver's value). This **restores a working feature** rather than converting a crash to a diagnostic — `int.bit_count()` now verifies with the exact count.

## Tests

New regression pair (CORE):
- `regression/python/int_bit_count` → `VERIFICATION SUCCESSFUL` (the Py-Live liveness witness for the new model branch; it reported the unsupported-function `FAILED` pre-fix). Covers `0`, `255`, `1024`, a negative (`-3 → 2`), an expression receiver (`(4-1) → 2`), and `13 → 3`, all CPython-verified.
- `regression/python/int_bit_count_fail` → `VERIFICATION FAILED`.

CPython sanity (`scripts/check_python_tests.sh int_bit_count`) passes; the full `regression/python/` suite shows zero new failures (only the pre-existing Bitwuzla-only `--z3`/`--ir` environmental set). The OM was rebuilt before testing (FLAIL-mangled into the binary).

Drains the next "unmodeled method" entry from §15b of `docs/python-issues-triage-report-2026-06-02.md`; documented as §16.
