### PR TITLE
[python] V.3: build generic unary operator nodes in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -187,8 +187,35 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
   // `or` nodes are bool-typed, and consumers that migrate eagerly (e.g.
   // build_typecast) would otherwise abort before the C adjuster normalises it.
   const typet result_type = (op == "Not") ? bool_type() : type;
-  exprt unary_expr(python_frontend::map_operator(op, result_type), result_type);
-  unary_expr.operands().push_back(unary_sub);
+  const std::string op_id = python_frontend::map_operator(op, result_type);
 
-  return unary_expr;
+  // V.3: build the generic unary node directly in IREP2, back-migrating once.
+  // The Python AST has exactly four unary operators and map_operator covers
+  // each: Not→"not", USub→"unary-", Invert→"bitnot", UAdd→"unary+". The
+  // factories below reproduce migrate_expr's lowering of those ids verbatim
+  // (not2t fixes a bool result; neg2t/bitnot2t take the node type; unary plus
+  // is the identity, dropping the wrapper exactly as migrate_expr does at
+  // util/migrate.cpp:1676), so this is behaviour-preserving under the
+  // mandatory --irep2-bodies round-trip.
+  expr2tc operand2;
+  migrate_expr(unary_sub, operand2);
+
+  expr2tc unary2;
+  if (op_id == "not")
+    unary2 = not2tc(operand2);
+  else if (op_id == "unary-")
+    unary2 = neg2tc(migrate_type(result_type), operand2);
+  else if (op_id == "bitnot")
+    unary2 = bitnot2tc(migrate_type(result_type), operand2);
+  else if (op_id == "unary+")
+    unary2 = operand2; // unary plus is the identity
+  else
+  {
+    // Unknown operator: preserve the legacy (malformed-node + warning) path.
+    exprt unary_expr(op_id, result_type);
+    unary_expr.operands().push_back(unary_sub);
+    return unary_expr;
+  }
+
+  return migrate_expr_back(unary2);
 }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`get_unary_operator_expr`'s generic fallthrough built a legacy unary `exprt` via `map_operator` and pushed a single operand. It now builds the node directly with typed IREP2 factories (`not2tc`/`neg2tc`/`bitnot2tc`) and back-migrates once.

### Why it is behaviour-preserving

- The Python AST has exactly four unary operators and `map_operator` covers each: `Not`→`"not"`, `USub`→`"unary-"`, `Invert`→`"bitnot"`, `UAdd`→`"unary+"`.
- The factories reproduce `migrate_expr`'s lowering of those ids verbatim: `not2t` fixes a bool result; `neg2t`/`bitnot2t` take the node type; unary plus is the identity, dropping the wrapper exactly as `migrate_expr` does at `util/migrate.cpp:1676`.
- With `--irep2-bodies` the unconditional default, every converter body is round-tripped before goto-convert anyway, so this only makes the construction explicit rather than relying on downstream normalisation.
- An unknown-operator `else` branch keeps the legacy malformed-node + warning path unchanged.

### Validation

- Probes for `-a`/`+a`/`~a` (int and float) and `not (...)`, both passing and failing — correct verdicts.
- 146 unary/arith/bitwise/boolop/complex-unary/list-truthiness/string-index regression tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent); broad python feature sweep 382/383 (the one failure, `list_pop11_nondet`, is a pre-existing `--boolector` environment flake identical on `master`).
- Dual-solver parity delegated to CI.