### PR TITLE
[python] V.3: build conditional truthiness checks in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3016,9 +3016,15 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
         size_call.type() = size_type();
         size_call.location() = location;
 
-        cond = exprt("notequal", bool_type());
-        cond.copy_to_operands(size_call, gen_zero(size_type()));
+        // V.3: build `__ESBMC_list_size(xs) != 0` in IREP2, back-migrating
+        // once (mirrors the list-condition path at converter_binop.cpp:208).
+        // The round-trip drops the call operand's location, so re-attach it.
+        expr2tc size_call2;
+        migrate_expr(size_call, size_call2);
+        cond = migrate_expr_back(
+          notequal2tc(size_call2, gen_zero(migrate_type(size_type()))));
         cond.location() = location;
+        cond.op0().location() = location;
       }
 
       // Python treats strings in conditions by their length: "" is falsy.
@@ -3036,9 +3042,15 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
         strlen_call.type() = size_type();
         strlen_call.location() = location;
 
-        cond = exprt("notequal", bool_type());
-        cond.copy_to_operands(strlen_call, gen_zero(size_type()));
+        // V.3: build `strlen(s) != 0` in IREP2, back-migrating once (mirrors
+        // the string-truthiness path at converter_unop.cpp). Re-attach the
+        // call operand's location that the round-trip drops.
+        expr2tc strlen_call2;
+        migrate_expr(strlen_call, strlen_call2);
+        cond = migrate_expr_back(
+          notequal2tc(strlen_call2, gen_zero(migrate_type(size_type()))));
         cond.location() = location;
+        cond.op0().location() = location;
       }
     }
   }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`get_conditional_stm` built the list/string truthiness conditions (`__ESBMC_list_size(xs) != 0` and `strlen(s) != 0`) with legacy `exprt("notequal", bool_type())` + `copy_to_operands`. Both now build the comparison with `notequal2tc` over the migrated call operand and back-migrate once at the `cond` assignment seam.

### Why it is behaviour-preserving

- Mirrors the already-merged list-condition path at `converter_binop.cpp:208` (`migrate_expr_back(notequal2tc(size_call2, zero2))`).
- The body round-trip drops the call operand's source location, so it is re-attached via `cond.op0().location()`, exactly as that site does.
- With `--irep2-bodies` the unconditional default, the legacy flat `notequal` node was already migrated downstream; this only makes the construction explicit.

### Validation

- Probes for `while xs:` / `if s:` on non-empty and empty list/string — correct verdicts (SUCCESSFUL), and a non-empty-string `if s: assert False` correctly FAILED.
- 581/582 truthiness/while/if/list/str/boolop regression tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent). The one failure, `list_pop11_nondet`, is a pre-existing `--boolector` environment flake identical on `master`.
- Dual-solver parity delegated to CI.
