### PR TITLE
[python] V.3: build complex truthiness check in IREP2

### DIFF
--- a/src/python-frontend/type_handler.h
+++ b/src/python-frontend/type_handler.h
@@ -4,6 +4,8 @@
 #include <util/arith_tools.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
+#include <util/migrate.h>
+#include <irep2/irep2_utils.h>
 #include <nlohmann/json.hpp>
 
 class python_converter;
@@ -76,12 +78,20 @@ inline exprt promote_to_complex(const exprt &value)
 inline exprt complex_to_bool_expr(const exprt &complex_expr)
 {
   const typet &dt = cached_double_type();
-  exprt real = member_exprt(complex_expr, "real", dt);
-  exprt imag = member_exprt(complex_expr, "imag", dt);
-  exprt zero = from_double(0.0, dt);
-  return or_exprt(
-    not_exprt(equality_exprt(real, zero)),
-    not_exprt(equality_exprt(imag, zero)));
+  // V.3: build `z.real != 0.0 || z.imag != 0.0` in IREP2, back-migrating once.
+  // member2t over a complex source is exactly the node migrate_expr builds for
+  // the legacy member access at goto-convert (util/migrate.cpp:1580), and the
+  // not(equal) shape mirrors the legacy or_exprt(not_exprt(equality_exprt(...)))
+  // verbatim, so the back-migrated tree is byte-identical to the old one.
+  const type2tc dt2 = migrate_type(dt);
+  expr2tc complex2;
+  migrate_expr(complex_expr, complex2);
+  expr2tc zero2;
+  migrate_expr(from_double(0.0, dt), zero2);
+
+  expr2tc real_nz = not2tc(equality2tc(member2tc(dt2, complex2, "real"), zero2));
+  expr2tc imag_nz = not2tc(equality2tc(member2tc(dt2, complex2, "imag"), zero2));
+  return migrate_expr_back(or2tc(real_nz, imag_nz));
 }
 
 class type_handler


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`complex_to_bool_expr` built the Python complex truthiness condition (`z.real != 0.0 || z.imag != 0.0`) with legacy `member_exprt`/`or_exprt`/`not_exprt`/`equality_exprt`. It now builds the subtree with `member2tc`/`or2tc`/`not2tc`/`equality2tc` and back-migrates once.

### Why it is behaviour-preserving (byte-identical)

- `member2t` over a complex source is *exactly* the node `migrate_expr` already builds for the legacy member access at goto-convert (`util/migrate.cpp:1580` — `member` lowers uniformly to `member2tc(type, migrate(op0), name)`, no complex special-casing).
- The `not(equal)` shape mirrors the legacy `or_exprt(not_exprt(equality_exprt(...)))` verbatim (not collapsed to `notequal2t`), so the back-migrated tree is byte-identical to the old one.
- The V.1k construction-assert relaxation (`irep2_expr.h` `member2t`/`index2t` now permit a transient `symbol_type2t` / complex source) is what lets the converter build this directly; the asserts-enabled build does not abort.

### Validation

- Probes: non-zero complex truthy, zero complex falsy, `bool(z)` in both directions — correct verdicts; a zero-complex-taken-as-truthy variant correctly FAILED.
- **111/111** `regression/python/complex*` tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent).
- 788/789 broad python cross-section (complex/bool/cond/if/while/list/dict/str/tuple/class/int/float); the one failure, `list_pop11_nondet`, is a pre-existing `--boolector` environment flake identical on `master`.
- `type_handler.h` gains `<util/migrate.h>` + `<irep2/irep2_utils.h>`; dual-solver parity delegated to CI.
