### PR TITLE
[python] V.3: build ord() char dereference in IREP2

### DIFF
--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2002,7 +2002,15 @@ exprt string_handler::handle_ord_conversion(
   exprt str_addr = get_array_base_address(str_expr);
 
   // Code point of the single character: (int) *str_addr.
-  exprt first_char = dereference_exprt(str_addr, char_type());
+  // V.3: build the dereference in IREP2, back-migrating once. dereference2t
+  // carries only (type, value) — no offset/guard — so the round-trip is
+  // byte-identical to dereference_exprt(str_addr, char) (mirrors build_index/
+  // build_dereference). Restore the exact element type migrate_type may drop.
+  expr2tc str_addr2;
+  migrate_expr(str_addr, str_addr2);
+  exprt first_char =
+    migrate_expr_back(dereference2tc(migrate_type(char_type()), str_addr2));
+  first_char.type() = char_type();
   first_char.location() = location;
   return build_typecast(first_char, int_type());
 }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`handle_ord_conversion` built the single-character load `*str_addr` (the code-point of `ord(c)`) with a legacy `dereference_exprt`. It now builds it with `dereference2tc` and back-migrates once, mirroring the already-migrated `build_index`/`build_dereference` helpers.

### Why it is behaviour-preserving (byte-identical)

- `dereference2t` carries only `(type, value)` — no offset/guard — so `migrate_expr_back(dereference2tc(migrate_type(char), migrate(str_addr)))` is the exact round-trip of `dereference_exprt(str_addr, char_type())`.
- The element type is restored (`first_char.type() = char_type()` — the `#cpp_type` attribute `migrate_type` may drop), and the location set + `build_typecast` wrapping are unchanged, so the `first_char` node handed downstream is identical.

### Validation

- Probes: `ord('A')==65`, `'a'==97`, `'0'==48`, `ord(s)` over a `str` var — correct; a wrong-value variant correctly FAILED.
- **444/444** `regression/python/(ord|chr|str|char|ascii)` tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent).
- Dual-solver parity delegated to CI.
