### PR TITLE
[python] V.3: build ord() char->int cast in IREP2

### DIFF
--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -332,8 +332,14 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
     return expr;
 
   // A character from string indexing is an 8-bit int tagged #cpp_type==char.
+  // V.3: build the char->int cast in IREP2, back-migrating once (mirrors the
+  // build_typecast helper; typecast2t round-trips byte-identically).
   if (type_utils::is_char_type(expr.type()))
-    return typecast_exprt(expr, int_type());
+  {
+    expr2tc expr2;
+    migrate_expr(expr, expr2);
+    return migrate_expr_back(typecast2tc(migrate_type(int_type()), expr2));
+  }
 
   // A runtime string: return the code point of its first character.
   if (type_utils::is_string_type(expr.type()))


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`handle_ord`'s runtime char path — `ord(s[i])`, where the argument is an 8-bit int tagged `#cpp_type==char` — built the `(int)` cast with a legacy `typecast_exprt`. It now builds it with `typecast2tc` and back-migrates once, mirroring the already-migrated `build_typecast` helper.

### Why it is behaviour-preserving (byte-identical)

- `typecast2t` round-trips byte-identically: `migrate_expr_back(typecast2tc(migrate_type(int), migrate(expr)))` is the exact IREP2 round-trip of `typecast_exprt(expr, int_type())`, which the body round-trip would build at goto-convert anyway.
- Matches the proven `build_typecast` helper shape exactly (no operand retype needed; the result type is `int_type()`).

### Validation

- Probes: `ord(s[0])==65`, `ord(s[1])==66`, `ord(c[0])==122` (char-from-indexing path) — correct; a wrong-value variant correctly FAILED.
- **444/444** `regression/python/(ord|chr|str|char|ascii)` tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent).
- Companion to #5534 (the `ord()` string-dereference migration). Dual-solver parity delegated to CI.
