### PR TITLE
[python] V.3: build set-operation loop guards in IREP2

### DIFF
--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -29,6 +29,17 @@ exprt build_address_of(const exprt &obj)
   return migrate_expr_back(address_of2tc(obj2->type, obj2));
 }
 
+// `a < b` over synthetic OM operands (loop counters / sizes). migrate lowers a
+// legacy "<" node to lessthan2tc(migrate(a), migrate(b)) (util/migrate.cpp,
+// i_lt path) with no coercion, so this is the byte-identical round-trip.
+exprt build_less_than(const exprt &a, const exprt &b)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(lessthan2tc(a2, b2));
+}
+
 // The one call site indexes an is_array()-guarded char array, so the index2t
 // array-source precondition holds.
 exprt build_index(const exprt &arr, const exprt &idx, const typet &t)
@@ -284,7 +295,10 @@ exprt python_set::get_from_iterable(
   idx_init.location() = loc;
   converter_.add_instruction(idx_init);
 
-  // Loop condition: i < length
+  // Loop condition: i < length. Kept legacy: idx_sym (size_type) and
+  // length_expr can have mismatched bit-widths here (the .lower()/runtime-string
+  // path), which the legacy "<" node tolerates and clang_cpp_adjust reconciles;
+  // lessthan2t asserts width consistency, so building it pre-adjust would abort.
   exprt cond("<", bool_type());
   cond.copy_to_operands(build_symbol(idx_sym), length_expr);
 
@@ -549,8 +563,7 @@ exprt python_set::build_set_difference_call(
   converter_.add_instruction(i_init);
 
   // Loop condition: i < n
-  exprt cond("<", bool_type());
-  cond.copy_to_operands(build_symbol(i_sym), build_symbol(n_sym));
+  exprt cond = build_less_than(build_symbol(i_sym), build_symbol(n_sym));
 
   code_blockt body;
 
@@ -677,8 +690,7 @@ exprt python_set::build_set_intersection_call(
   converter_.add_instruction(i_init);
 
   // Loop condition: i < n
-  exprt cond("<", bool_type());
-  cond.copy_to_operands(build_symbol(i_sym), build_symbol(n_sym));
+  exprt cond = build_less_than(build_symbol(i_sym), build_symbol(n_sym));
 
   code_blockt body;
 
@@ -815,8 +827,7 @@ exprt python_set::build_set_union_call(
   converter_.add_instruction(i_init);
 
   // Loop condition: i < n
-  exprt cond("<", bool_type());
-  cond.copy_to_operands(build_symbol(i_sym), build_symbol(n_sym));
+  exprt cond = build_less_than(build_symbol(i_sym), build_symbol(n_sym));
 
   code_blockt body;
 
@@ -943,8 +954,7 @@ void python_set::emit_filtered_extend(
   converter.add_instruction(
     code_assignt(build_symbol(i_sym), gen_zero(size_type())));
 
-  exprt cond("<", bool_type());
-  cond.copy_to_operands(build_symbol(i_sym), build_symbol(n_sym));
+  exprt cond = build_less_than(build_symbol(i_sym), build_symbol(n_sym));
 
   code_blockt body;
 
@@ -1065,8 +1075,7 @@ exprt python_set::build_set_relation_call(
   converter_.add_instruction(
     code_assignt(build_symbol(i_sym), gen_zero(size_type())));
 
-  exprt cond("<", bool_type());
-  cond.copy_to_operands(build_symbol(i_sym), build_symbol(n_sym));
+  exprt cond = build_less_than(build_symbol(i_sym), build_symbol(n_sym));
 
   code_blockt body;
 


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

The set difference / intersection / union / relation / filtered-extend handlers built their `i < n` loop guards with a legacy `exprt("<")` + `copy_to_operands` over synthetic `size_type` loop counters. A new `build_less_than` helper now builds them with `lessthan2tc` and back-migrates once (5 sites).

### Why it is behaviour-preserving (byte-identical)

- migrate lowers a legacy `<` node to `lessthan2tc(migrate(a), migrate(b))` with no coercion (`util/migrate.cpp`, `i_lt` path), so the round-trip reproduces exactly the node goto-convert would build.
- Both operands are `size_type` loop counters/sizes (same width), satisfying `lessthan2t`'s width-consistency assert.

### One site deliberately kept legacy

`get_from_iterable`'s `i < length` guard, whose operands (`idx_sym` vs a runtime-string `length_expr` from the `.lower()` path) can have **mismatched bit-widths** — which the legacy `<` node tolerates and `clang_cpp_adjust` reconciles, but `lessthan2t` asserts against. Building it pre-adjust aborts (`assert_arith_2ops_consistency`), so it stays legacy with an explanatory comment.

### Validation

- Probes: set membership / `&` / `|` / `-` / `len` correct; failing variant fails.
- **229/229** `set` regression tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent) — including `set_from_string` (the `.lower()` path that surfaced the width-mismatch site).
- Dual-solver parity delegated to CI.
