### PR TITLE
[python] V.3: build dict.update loop guard in IREP2

### DIFF
--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -81,6 +81,19 @@ exprt build_address_of(const exprt &obj)
   return migrate_expr_back(address_of2tc(obj2->type, obj2));
 }
 
+// `a < b` over synthetic same-width operands (loop counter / size). migrate
+// lowers a legacy "<" node to lessthan2tc(migrate(a), migrate(b)) with no
+// coercion (util/migrate.cpp i_lt path), so this is the byte-identical
+// round-trip. Operands MUST share bit-width: lessthan2t asserts width
+// consistency, which the legacy "<" node defers to clang_cpp_adjust.
+exprt build_less_than(const exprt &a, const exprt &b)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(lessthan2tc(a2, b2));
+}
+
 // Build "key found" = !(index_var == SIZE_MAX) in IREP2, back-migrated once
 // (V.3). SIZE_MAX is the dict lookup's not-found sentinel.
 exprt build_key_found(const symbolt &index_var)
@@ -3486,8 +3499,9 @@ exprt python_dict_handler::handle_dict_update(
   index_init.location() = location;
   converter_.add_instruction(index_init);
 
-  exprt loop_cond("<", bool_type());
-  loop_cond.copy_to_operands(build_symbol(index_var), build_symbol(size_var));
+  // (both $dict_update_iter$ and $dict_update_size$ are size_type — same width)
+  exprt loop_cond =
+    build_less_than(build_symbol(index_var), build_symbol(size_var));
 
   // Rebuild the current key/value pair from the source lists.
   code_blockt loop_body;


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`handle_dict_update` built its `index < size` loop guard with a legacy `exprt("<")` + `copy_to_operands` over two `size_type` counters (`$dict_update_iter$`, `$dict_update_size$`). A new `build_less_than` helper now builds it with `lessthan2tc` and back-migrates once, mirroring the set (#5538) and list (#5539) loop-guard migrations.

### Why it is behaviour-preserving (byte-identical)

- migrate lowers a legacy `<` node to `lessthan2tc(migrate(a), migrate(b))` with no coercion (`util/migrate.cpp`, `i_lt` path), so the round-trip reproduces the node goto-convert would build.
- Both operands are `size_type` (same width), satisfying `lessthan2t`'s width-consistency assert (`assert_arith_2ops_consistency`).

### Validation

- **201/201** `regression/python/(dict|Dict|defaultdict)` tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent).
- Probe note: a `d.update(other)` overlapping-key probe fails identically on `master` (a pre-existing dict.update modelling limitation, unrelated to this byte-identical change — verified by stash + rebuild).
- Completes the OM loop-guard series (set/list/dict). Dual-solver parity delegated to CI.
