### PR TITLE
[python] V.3: build list.extend(str) length subtraction in IREP2

### DIFF
--- a/regression/python/list_extend_str_len/main.py
+++ b/regression/python/list_extend_str_len/main.py
@@ -1,0 +1,10 @@
+# Extending a list with a string appends one element per character. The
+# character count is computed as (char-array size - 1), dropping the null
+# terminator -- the subtraction migrated to IREP2 in build_extend_list_call.
+# "hello" is 5 chars, so the result has 1 + 5 = 6 elements.
+def test():
+    a = [0]
+    a.extend("hello")
+    assert len(a) == 6
+
+test()

--- a/regression/python/list_extend_str_len/test.desc
+++ b/regression/python/list_extend_str_len/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks --smt-during-symex --smt-symex-guard --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_extend_str_len_fail/main.py
+++ b/regression/python/list_extend_str_len_fail/main.py
@@ -1,0 +1,10 @@
+# Companion to list_extend_str_len: pins the null-terminator subtraction.
+# "hello" is 5 chars, so extending [0] yields 6 elements, not 7. A length of 7
+# would only hold if the (char-array size - 1) subtraction wrongly counted the
+# null terminator, so this assertion must fail.
+def test():
+    a = [0]
+    a.extend("hello")
+    assert len(a) == 7
+
+test()

--- a/regression/python/list_extend_str_len_fail/test.desc
+++ b/regression/python/list_extend_str_len_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks --smt-during-symex --smt-symex-guard --bitwuzla
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4139,8 +4139,18 @@ exprt python_list::build_extend_list_call(
     if (other_list.type().is_array())
     {
       const array_typet &arr_type = to_array_type(other_list.type());
-      // Subtract 1 for null terminator
-      str_len = minus_exprt(arr_type.size(), gen_one(size_type()));
+      // Subtract 1 for null terminator. V.3: build the (size - 1) subtraction
+      // in IREP2. The legacy 2-arg minus_exprt leaves the result type nil for
+      // downstream inference; here we set it explicitly to the array-size type
+      // (size_type), which is exactly what that inference yields, and restore
+      // it after the round-trip since migrate_type drops attributes (#cpp_type).
+      const exprt &arr_size = arr_type.size();
+      expr2tc size2, one2;
+      migrate_expr(arr_size, size2);
+      migrate_expr(gen_one(size_type()), one2);
+      str_len =
+        migrate_expr_back(sub2tc(migrate_type(arr_size.type()), size2, one2));
+      str_len.type() = arr_size.type();
     }
     else // pointer type - use strlen
     {


### PR DESCRIPTION
Part of the IREP2-native frontend migration (umbrella #5055, Part V of `docs/irep2-migration.md`).

## What

Migrates the `(char-array size - 1)` string-length computation in `python_list::build_extend_list_call` (the `list.extend("string")` path) from a legacy `minus_exprt` to an IREP2-native `sub2tc`.

The legacy 2-arg `minus_exprt(lhs, rhs)` leaves its result type nil for downstream inference. The migration sets the type explicitly to the array-size type (`size_type`) — exactly what that inference yields — and restores it after the round-trip, since `migrate_type` does not round-trip type attributes like `#cpp_type`. This follows the established V.3 helper convention already used throughout this file (`build_typecast`, `build_index`, …).

## Why it is safe

Behaviour-preserving: the emitted GOTO is byte-identical (`6 - 1`) before and after, confirmed by dumping the GOTO for both the legacy and migrated sources. Resolution is left to the existing downstream adjust/goto_convert seam.

## Tests

- `regression/python/list_extend_str_len` — `[0].extend("hello")` yields 6 elements → `VERIFICATION SUCCESSFUL`.
- `regression/python/list_extend_str_len_fail` — asserts 7 elements, which only holds if the null-terminator subtraction were dropped → `VERIFICATION FAILED`.

The existing `list_extend5`–`list_extend9` string-extend tests continue to pass.