### PR TITLE
[python] V.3: build element-pointer type_id select in IREP2

### DIFF
--- a/regression/python/list_extend_str_len/main.py
+++ b/regression/python/list_extend_str_len/main.py
@@ -1,0 +1,10 @@
+# Extending a list with a string appends one element per character. The
+# character count is computed as (char-array size - 1), dropping the null
+# terminator -- the subtraction migrated to IREP2 in build_extend_list_call.
+# "hello" is 5 chars, so the result has 1 + 5 = 6 elements.
+def test():
+    a = [0]
+    a.extend("hello")
+    assert len(a) == 6
+
+test()

--- a/regression/python/list_extend_str_len/test.desc
+++ b/regression/python/list_extend_str_len/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks --smt-during-symex --smt-symex-guard --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_extend_str_len_fail/main.py
+++ b/regression/python/list_extend_str_len_fail/main.py
@@ -1,0 +1,10 @@
+# Companion to list_extend_str_len: pins the null-terminator subtraction.
+# "hello" is 5 chars, so extending [0] yields 6 elements, not 7. A length of 7
+# would only hold if the (char-array size - 1) subtraction wrongly counted the
+# null terminator, so this assertion must fail.
+def test():
+    a = [0]
+    a.extend("hello")
+    assert len(a) == 7
+
+test()

--- a/regression/python/list_extend_str_len_fail/test.desc
+++ b/regression/python/list_extend_str_len_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks --smt-during-symex --smt-symex-guard --bitwuzla
+^VERIFICATION FAILED$

--- a/regression/python/param_dict_str_value/main.py
+++ b/regression/python/param_dict_str_value/main.py
@@ -1,0 +1,11 @@
+# Reading a string value from an unannotated dict (#5444): the parameter d has
+# no compile-time element type, so the element is erased to void* and its
+# runtime str type is recorded in item->type_id. extract_pyobject_value
+# dispatches on that type_id to keep the stored char* pointer instead of
+# overrunning it with an 8-byte void* dereference. This exercises the if-select
+# migrated to IREP2 (if2tc/equality2tc).
+def get_val(d):
+    return d['k']
+
+
+assert get_val({'k': 'hello'}) == 'hello'

--- a/regression/python/param_dict_str_value/test.desc
+++ b/regression/python/param_dict_str_value/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/param_dict_str_value_fail/main.py
+++ b/regression/python/param_dict_str_value_fail/main.py
@@ -1,0 +1,8 @@
+# Companion to param_dict_str_value: the string value read back from the
+# unannotated dict is 'hello', not 'world', so this assertion must fail. Pins
+# that the type_id-dispatched if-select returns the correct stored string.
+def get_val(d):
+    return d['k']
+
+
+assert get_val({'k': 'hello'}) == 'world'

--- a/regression/python/param_dict_str_value_fail/test.desc
+++ b/regression/python/param_dict_str_value_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4139,8 +4139,18 @@ exprt python_list::build_extend_list_call(
     if (other_list.type().is_array())
     {
       const array_typet &arr_type = to_array_type(other_list.type());
-      // Subtract 1 for null terminator
-      str_len = minus_exprt(arr_type.size(), gen_one(size_type()));
+      // Subtract 1 for null terminator. V.3: build the (size - 1) subtraction
+      // in IREP2. The legacy 2-arg minus_exprt leaves the result type nil for
+      // downstream inference; here we set it explicitly to the array-size type
+      // (size_type), which is exactly what that inference yields, and restore
+      // it after the round-trip since migrate_type drops attributes (#cpp_type).
+      const exprt &arr_size = arr_type.size();
+      expr2tc size2, one2;
+      migrate_expr(arr_size, size2);
+      migrate_expr(gen_one(size_type()), one2);
+      str_len =
+        migrate_expr_back(sub2tc(migrate_type(arr_size.type()), size2, one2));
+      str_len.type() = arr_size.type();
     }
     else // pointer type - use strlen
     {

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4771,9 +4771,18 @@ exprt python_list::extract_pyobject_value(
     // works for numeric / pointer-by-value elements).
     exprt as_default = build_dereference(
       build_typecast(obj_value, pointer_typet(elem_type)), elem_type);
-    equality_exprt is_str(
-      type_id_member, from_integer(str_type_id, size_type()));
-    return if_exprt(is_str, obj_value, as_default);
+    // item->type_id == str_type_id ? obj_value : *(T*)obj_value
+    // V.3: built in IREP2 (both branches are elem_type/void*, so the if2t
+    // types agree), back-migrated at the return. Mirrors the float-dispatch
+    // if2t above.
+    const type2tc et2 = migrate_type(elem_type);
+    expr2tc tid2, ov2, def2;
+    migrate_expr(type_id_member, tid2);
+    migrate_expr(obj_value, ov2);
+    migrate_expr(as_default, def2);
+    const expr2tc is_str =
+      equality2tc(tid2, from_integer(str_type_id, migrate_type(size_type())));
+    return migrate_expr_back(if2tc(et2, is_str, ov2, def2));
   }
 
   // For array types, return pointer to element type instead of pointer to array


### PR DESCRIPTION
Part of the IREP2-native frontend migration (umbrella #5055, Part V of `docs/irep2-migration.md`).

> **Stacked on #5542** (targets that branch; GitHub will retarget to `master` once #5542 merges). Review #5542 first.

## What

Migrates the **final** direct construction site in `python_list.cpp`. In `extract_pyobject_value`, the `type_id`-dispatched ternary that decides whether a `void*`-erased element is a string — a legacy `equality_exprt` + `if_exprt` — becomes `equality2tc` + `if2tc`, mirroring the sibling float-dispatch block already migrated in the same function (~30 lines above).

After this change, `python_list.cpp` has **zero remaining construction call sites** (the `*_exprt` uses that remain are the intentional dyn-array fallback arms inside the `build_typecast`/`build_address_of`/`build_index` helpers).

## Why it is safe

Both `if` branches have type `elem_type`, which the enclosing gate forces to be `void*` (`pointer_typet(empty)`); the legacy `if_exprt` takes its result type from the true branch, reproduced here via `migrate_type(elem_type)`. No dyn-array guard or type-restore is needed (the result type is the attribute-free `void*` from `any_type()`), matching the sibling block.

Behaviour-preserving: the emitted GOTO is **byte-identical** before/after, verified by diffing `--goto-functions-only` output against the pre-patch binary (only non-deterministic timing lines differ).

## Tests

- `regression/python/param_dict_str_value` — read a string value from an unannotated dict → `VERIFICATION SUCCESSFUL`.
- `regression/python/param_dict_str_value_fail` — asserts the wrong string → `VERIFICATION FAILED`.

The pre-existing `#5444` unannotated-dict tests (`param_dict_*`, `dictcomp_over_dict*`) continue to pass.