### PR TITLE
[python] V.3: build list loop-counter increments in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -107,6 +107,19 @@ exprt build_greater_equal(const exprt &a, const exprt &b)
   return migrate_expr_back(greaterthanequal2tc(a2, b2));
 }
 
+// `(t)(a + b)` over synthetic operands of result type `t` (loop-counter
+// increments). migrate lowers a legacy "+" node to add2tc(migrate_type(t),
+// migrate(a), migrate(b)) (util/migrate.cpp i_add path), so this is the
+// byte-identical round-trip. The result type and both operands MUST share
+// bit-width: add2t asserts arithmetic-operand consistency.
+exprt build_add(const exprt &a, const exprt &b, const typet &t)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(add2tc(migrate_type(t), a2, b2));
+}
+
 // index2t requires an array/vector/symbol source; a pointer source (e.g. the
 // array/pointer iterable branch) and dyn-sized arrays (slice results) fall
 // back to the legacy node. dyn-array types are checked first to avoid
@@ -1909,8 +1922,7 @@ exprt python_list::handle_range_slice(
   // counter += step_val. step_val is signed; for positive step it's >0 and
   // converts to size_type cleanly via from_integer.
   exprt step_const = from_integer(step_val, counter_type);
-  exprt increment("+", counter_type);
-  increment.copy_to_operands(build_symbol(counter), step_const);
+  exprt increment = build_add(build_symbol(counter), step_const, counter_type);
   code_assignt counter_update(build_symbol(counter), increment);
   loop_body.copy_to_operands(counter_update);
 
@@ -3034,9 +3046,10 @@ exprt python_list::handle_index_access(
     exprt idx_lt_zero =
       build_less_than(build_symbol(idx_sym), from_integer(0, ll_type));
 
-    exprt idx_plus_len("+", ll_type);
-    idx_plus_len.copy_to_operands(
-      build_symbol(idx_sym), build_typecast(build_symbol(len_sym), ll_type));
+    exprt idx_plus_len = build_add(
+      build_symbol(idx_sym),
+      build_typecast(build_symbol(len_sym), ll_type),
+      ll_type);
 
     code_assignt normalize(build_symbol(idx_sym), idx_plus_len);
     normalize.location() = loc;
@@ -3070,8 +3083,8 @@ exprt python_list::handle_index_access(
     // --- 5. __python_str_slice(array, idx, idx+1, 1) ---
     // idx is now a normalized, in-bounds positive index; the slice helper
     // produces a fresh alloca'd single-char null-terminated string.
-    exprt end_expr("+", ll_type);
-    end_expr.copy_to_operands(build_symbol(idx_sym), from_integer(1, ll_type));
+    exprt end_expr =
+      build_add(build_symbol(idx_sym), from_integer(1, ll_type), ll_type);
 
     exprt slice_call = build_call_expr(
       get_str_slice_sym(),
@@ -3623,9 +3636,8 @@ exprt python_list::create_vla(
   for (const auto &list_elem : list_elems)
     then.copy_to_operands(build_push_list_call(result, element, list_elem));
 
-  exprt incr("+", int_type());
-  incr.copy_to_operands(build_symbol(counter));
-  incr.copy_to_operands(gen_one(int_type()));
+  exprt incr =
+    build_add(build_symbol(counter), gen_one(int_type()), int_type());
   code_assignt update(build_symbol(counter), incr);
   then.copy_to_operands(update);
 
@@ -5750,8 +5762,8 @@ void python_list::handle_list_var_unpacking(
       converter_.convert_expression_to_code(push_call));
 
     // loop_idx++
-    exprt inc("+", size_type());
-    inc.copy_to_operands(build_symbol(loop_idx), gen_one(size_type()));
+    exprt inc =
+      build_add(build_symbol(loop_idx), gen_one(size_type()), size_type());
     code_assignt inc_assign(build_symbol(loop_idx), inc);
     loop_body.copy_to_operands(inc_assign);
 

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -120,6 +120,18 @@ exprt build_add(const exprt &a, const exprt &b, const typet &t)
   return migrate_expr_back(add2tc(migrate_type(t), a2, b2));
 }
 
+// `(t)(a - b)` over synthetic same-width operands. migrate lowers a legacy "-"
+// node to sub2tc(migrate_type(t), migrate(a), migrate(b)) (util/migrate.cpp
+// i_sub path) with no coercion, so this is the byte-identical round-trip. The
+// result type and both operands MUST share bit-width (sub2t asserts it).
+exprt build_sub(const exprt &a, const exprt &b, const typet &t)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(sub2tc(migrate_type(t), a2, b2));
+}
+
 // index2t requires an array/vector/symbol source; a pointer source (e.g. the
 // array/pointer iterable branch) and dyn-sized arrays (slice results) fall
 // back to the legacy node. dyn-array types are checked first to avoid
@@ -1525,11 +1537,11 @@ exprt python_list::handle_range_slice(
         if (bound["_type"] == "UnaryOp" && bound["op"]["_type"] == "USub")
         {
           exprt abs_value = converter_.get_expr(bound["operand"]);
-          exprt neg("-", signedbv_typet(64));
-          neg.copy_to_operands(
+          // 0 - (int64)abs_value: both operands are signedbv64 (same width).
+          return build_sub(
             from_integer(0, signedbv_typet(64)),
-            build_typecast(abs_value, signedbv_typet(64)));
-          return neg;
+            build_typecast(abs_value, signedbv_typet(64)),
+            signedbv_typet(64));
         }
         exprt e = converter_.get_expr(bound);
         e = remove_function_calls_recursive(e, slice_node);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). **Stacked on #5547** (base branch `feat/v3-list-oob-ge-irep2`).

Five same-width `+` increments in the list operational model moved from a legacy `exprt("+")` + `copy_to_operands` to a new `build_add` helper (`add2tc` round-trip):
- range-slice step (`counter += step`, `counter_type`),
- negative-index normalisation (`idx + len`, `ll_type`),
- single-char slice end (`idx + 1`, `ll_type`),
- repetition counter (`counter + 1`, `int_type`),
- starred-unpack counter (`loop_idx + 1`, `size_type`).

### Why it is behaviour-preserving (byte-identical)

- migrate lowers a legacy `+` node to `add2tc(migrate_type(t), migrate(a), migrate(b))` with no coercion (`util/migrate.cpp`, `i_add` path), the same shape as the existing `build_size_inc` helper.
- Each site's result type matches both operand widths, satisfying `add2t`'s arithmetic-operand consistency assert (`assert_arith_2ops_consistency`).

### Validation

- Probes: repetition (`[5]*4`), stepped slice (`xs[1:6:2]`), negative index (`s[-1]`/`s[-2]`), starred unpack (`a, *rest, b`) — correct; a wrong-value variant correctly FAILED.
- **749/750** `regression/python/(list|str|slice|index|star|unpack|range|repeat|char)` tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent). The one failure, `list_pop11_nondet`, is a pre-existing `--boolector` environment flake identical on `master`.
- Dual-solver parity delegated to CI.
