### PR TITLE
[python] V.3: build list non-empty assertion in IREP2

### DIFF
--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -63,6 +63,18 @@ exprt build_address_of(const exprt &obj)
   migrate_expr(obj, obj2);
   return migrate_expr_back(address_of2tc(obj2->type, obj2));
 }
+
+// `a > b` over synthetic same-width operands. migrate lowers a legacy ">" node
+// to greaterthan2tc(migrate(a), migrate(b)) (util/migrate.cpp i_gt path) with
+// no coercion, so this is the byte-identical round-trip; operands must share
+// bit-width (greaterthan2t asserts it).
+exprt build_greater_than(const exprt &a, const exprt &b)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(greaterthan2tc(a2, b2));
+}
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -525,9 +537,9 @@ void python_exception_handler::handle_list_assertion(
   size_func_call.location() = location;
   block.move_to_operands(size_func_call);
 
-  // Assert size > 0
-  exprt assertion(">", bool_type());
-  assertion.copy_to_operands(build_symbol(size_result), gen_zero(size_type()));
+  // Assert size > 0 (size_result and the 0 literal are both size_type).
+  exprt assertion =
+    build_greater_than(build_symbol(size_result), gen_zero(size_type()));
 
   code_assertt assert_code;
   assert_code.assertion() = assertion;


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`handle_list_assertion` built the `size > 0` precondition (asserting a list/dict is non-empty before `pop`/`popitem`) with a legacy `exprt(">")` + `copy_to_operands` over two `size_type` operands. A new `build_greater_than` helper now builds it with `greaterthan2tc` and back-migrates once.

### Why it is behaviour-preserving (byte-identical)

- migrate lowers a legacy `>` node to `greaterthan2tc(migrate(a), migrate(b))` with no coercion (`util/migrate.cpp`, `i_gt` path).
- Both operands are `size_type` (`size_result` and the `0` literal), satisfying `greaterthan2t`'s width-consistency assert.
- The comparison feeds a `code_assertt` condition — a real expression seam.

### Validation

- Probes: `xs.pop()` on a non-empty list returns the last element and shrinks `len` (correct); `[].pop()` correctly trips the `size > 0` guard (VERIFICATION FAILED).
- **131/132** `regression/python/(pop|empty|exception|list)` tests pass on a Debug/asserts build (live `migrate.cpp` cross-check silent). The one failure, `list_pop11_nondet`, is a pre-existing `--boolector` environment flake identical on `master`.
- Independent (not stacked); branches from `master`. Dual-solver parity delegated to CI.
