### PR TITLE
[python] V.3: build negative slice-bound value in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -120,6 +120,18 @@ exprt build_add(const exprt &a, const exprt &b, const typet &t)
   return migrate_expr_back(add2tc(migrate_type(t), a2, b2));
 }
 
+// `(t)(a - b)` over synthetic same-width operands. migrate lowers a legacy "-"
+// node to sub2tc(migrate_type(t), migrate(a), migrate(b)) (util/migrate.cpp
+// i_sub path) with no coercion, so this is the byte-identical round-trip. The
+// result type and both operands MUST share bit-width (sub2t asserts it).
+exprt build_sub(const exprt &a, const exprt &b, const typet &t)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(sub2tc(migrate_type(t), a2, b2));
+}
+
 // index2t requires an array/vector/symbol source; a pointer source (e.g. the
 // array/pointer iterable branch) and dyn-sized arrays (slice results) fall
 // back to the legacy node. dyn-array types are checked first to avoid
@@ -1525,11 +1537,11 @@ exprt python_list::handle_range_slice(
         if (bound["_type"] == "UnaryOp" && bound["op"]["_type"] == "USub")
         {
           exprt abs_value = converter_.get_expr(bound["operand"]);
-          exprt neg("-", signedbv_typet(64));
-          neg.copy_to_operands(
+          // 0 - (int64)abs_value: both operands are signedbv64 (same width).
+          return build_sub(
             from_integer(0, signedbv_typet(64)),
-            build_typecast(abs_value, signedbv_typet(64)));
-          return neg;
+            build_typecast(abs_value, signedbv_typet(64)),
+            signedbv_typet(64));
         }
         exprt e = converter_.get_expr(bound);
         e = remove_function_calls_recursive(e, slice_node);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715). **Stacked on #5549** (base branch `feat/v3-list-increments-irep2`).

`handle_range_slice` computed a negative slice bound (`0 - abs_value`, e.g. for `xs[:-1]`) with a legacy `exprt("-")` + `copy_to_operands` over two `signedbv64` operands. A new `build_sub` helper now builds it with `sub2tc` and back-migrates once.

### Why it is behaviour-preserving (byte-identical)

- migrate lowers a legacy `-` node to `sub2tc(migrate_type(t), migrate(a), migrate(b))` with no coercion (`util/migrate.cpp`, `i_sub` path).
- Both operands and the result type are `signedbv64` (the `0` literal and the `(int64)`-typecast abs value), satisfying `sub2t`'s width-consistency assert.

### Validation

- Probes: `xs[:-1]`, `xs[-2:]`, `xs[-3:-1]` (negative slice bounds) — correct; a wrong-length variant correctly FAILED.
- **163/164** `regression/python/(slice|list|negative|range)` tests pass on a Debug/asserts build (`-j4 --timeout 150`; live `migrate.cpp` cross-check silent). The one failure, `list_pop11_nondet`, is a pre-existing `--boolector` environment flake identical on `master`.
- Dual-solver parity delegated to CI.
