### PR TITLE
[docs] Rewrite SMT-theory implementation guide against current backend

### DIFF
--- a/website/content/docs/development/smt/Implement-a-new-SMT-theory-into-ESBMC.md
+++ b/website/content/docs/development/smt/Implement-a-new-SMT-theory-into-ESBMC.md
@@ -1,45 +1,128 @@
 ---
-title: Implementing SMT Theory
+title: Implementing a New SMT Theory
 ---
 
-This guide outlines the steps to integrate a new SMT theory into ESBMC. Throughout the tutorial, we will use the QF_AUFLIRA theory as an example.
+This guide explains how to teach ESBMC's SMT layer a new **theory** — a family of
+sorts and operations that the encoder can emit to the solver. The worked example
+is ESBMC's integer/real arithmetic mode (`QF_AUFLIRA`), which is the theory the
+`--ir` / `--ir-ieee` flags select.
 
-## Steps to Follow
+> [!NOTE]
+> Anchors below name **files, classes, and functions** rather than line numbers,
+> which drift. Grep for the identifier if you cannot find it.
 
-1. **Create a New Option for ESBMC**  
-   Define the new option in the `options.cpp` file:  
-   [Source Link](https://github.com/esbmc/esbmc/blob/master/src/esbmc/options.cpp#L258)
+## Which guide do you actually need?
 
-2. **Add New Logic to BMC**  
-   Add the logic for your new SMT theory in the `bmc.cpp` file:  
-   [Source Link](https://github.com/esbmc/esbmc/blob/master/src/esbmc/bmc.cpp#L159)
+Three different tasks are easy to confuse:
 
-3. **Set the Option in Parser Options**  
-   Configure the option in the parser options at:  
-   [Source Link](https://github.com/esbmc/esbmc/blob/master/src/esbmc/esbmc_parseoptions.cpp#L317)
+| You want to… | Read |
+|---|---|
+| Add a new IR expression (irep2 → SMT) | [Adding New Expressions](../adding-new-expressions/) |
+| Add a whole new solver backend | [Integrating a New SMT Solver](../integrate-a-new-smt-solver-into-the-esbmc-backend/) |
+| Add a new **sort/operation family** the SMT layer can emit | **this page** |
 
-4. **Adjust Pointer Dereference Module**  
-   Review and modify the pointer dereference module if necessary:  
-   [Source Link](https://github.com/esbmc/esbmc/blob/master/src/pointer-analysis/dereference.cpp#L2325)
+A "theory" here means new SMT sorts (e.g. `Int`, `Real`, `String`, `Set`) and the
+operations over them, plus the *mode* that decides when ESBMC emits them instead
+of the default bit-vector encoding.
 
-5. **Adjust SMT Backends**  
-   Update the relevant SMT backends. As examples:
-   - Bitwuzla: [Source Link](https://github.com/esbmc/esbmc/blob/master/src/solvers/bitwuzla/bitwuzla_conv.cpp#L28)
-   - Boolector: [Source Link](https://github.com/esbmc/esbmc/blob/master/src/solvers/boolector/boolector_conv.cpp#L29)
+## Architecture
 
-6. **Add New Encoding Type**  
-   Define the new encoding type (e.g., `real_encoding`) in the SMT converter:  
-   - [Add Encoding](https://github.com/esbmc/esbmc/blob/master/src/solvers/smt/smt_conv.cpp#L69)  
-   - [Set Encoding](https://github.com/esbmc/esbmc/blob/master/src/solvers/smt/smt_conv.cpp#L1908)
+The relevant pieces live under `src/solvers/smt/`:
 
-7. **Add the New Theory**  
-   Implement the new SMT theory in the SMT-LIB converter:  
-   [Source Link](https://github.com/esbmc/esbmc/blob/master/src/solvers/smtlib/smtlib_conv.cpp#L359)
+- **Sorts** — `smt_sort.h` enumerates sort kinds (`SMT_SORT_BV`, `SMT_SORT_INT`,
+  `SMT_SORT_REAL`, `SMT_SORT_FIXEDBV`, …). A new theory usually needs a new
+  `SMT_SORT_*` and a sort-builder.
+- **Operation surface** — `smt_solver_baset` (`smt_solver.h`) declares the
+  virtual term builders (`mk_smt_int`, `mk_smt_real`, `mk_add`, `mk_lt`, … and the
+  bit-vector duals `mk_bvadd`, `mk_bvult`, …). This virtual set **is** the theory
+  contract each backend implements.
+- **Mode flag** — a theory that is an *alternative encoding* of existing types is
+  gated by a flag. Integer/real mode uses `bool int_encoding`, a member of
+  `smt_solver_baset` initialised from the `int-encoding` option in
+  `smt_solver.cpp` (`int_encoding = options.get_bool_option("int-encoding")`).
+  The encoder branches on it throughout `src/solvers/smt/*.cpp` (`smt_casts.cpp`,
+  `smt_byteops.cpp`, `smt_bitcast.cpp`, `smt_fp_conv.cpp`, …) to pick Int/Real
+  builders over bit-vector ones.
+- **Backends** — each solver implements the new virtuals natively, or rejects the
+  theory. Z3 implements `mk_smt_int`/`mk_smt_real`; bit-vector-only backends
+  (Bitwuzla, Boolector) `abort()` with "does not support integer encoding mode".
+- **Capability guard** — `create_solver`/`pick_solver` in `solve.cpp` reject
+  `--ir`/`--ir-ieee` for bit-vector-only solvers with a clean `exit(1)` instead of
+  letting the backend abort at construction.
+- **SMT-LIB output** — `smtlib_conv.cpp` selects the logic string from the mode
+  (`options.get_bool_option("int-encoding") ? "QF_AUFLIRA" : "QF_AUFBV"`) and
+  emits `(set-logic …)`.
 
-8. **Adjust Simplification Logic**  
-   Modify the expression simplification logic as needed:  
-   [Source Link](https://github.com/esbmc/esbmc/blob/master/src/util/simplify_expr.cpp#L2577)
+## Worked example: integer/real arithmetic
 
-9. **Check for Additional Operations**  
-   Verify whether new operations need to be added in the SMT converter:  
-   [Source Link](https://github.com/esbmc/esbmc/blob/master/src/solvers/smt/smt_conv.h#L288)
+Use these touch points as a checklist when adding a comparable theory. Each is
+named by file/identifier; grep to locate the current line.
+
+1. **Define the user-facing option.** `src/esbmc/options.cpp` declares `--ir` and
+   `--ir-ieee`; both set the internal `int-encoding` option.
+
+2. **Plumb the option into the converter.** `smt_solver_baset` reads it once in
+   its constructor: `int_encoding = options.get_bool_option("int-encoding")`
+   (`smt_solver.cpp`). Everything downstream branches on this flag.
+
+3. **Add sorts.** Ensure the sort kinds exist in `smt_sort.h`
+   (`SMT_SORT_INT`, `SMT_SORT_REAL`) and that backends can build them.
+
+4. **Add operations to the virtual surface.** Declare the new builders on
+   `smt_solver_baset` in `smt_solver.h` (e.g. `mk_smt_int`, `mk_smt_real`, and the
+   arithmetic/relational ops). Give them an `abort()`/diagnostic default so a
+   backend that has not implemented them fails loudly rather than silently
+   miscompiling.
+
+5. **Dispatch the encoding.** In the SMT conversion (`smt_conv.cpp` and the
+   per-operation files under `src/solvers/smt/`), branch on `int_encoding` to emit
+   Int/Real builders instead of the bit-vector ones.
+
+6. **Implement per backend.** Native support: `z3_convt::mk_smt_int` /
+   `mk_smt_real` in `z3_conv.cpp`. No support: the BV-only pattern in
+   `bitwuzla_conv.cpp` / `boolector_conv.cpp`, which logs and `abort()`s — and is
+   pre-empted by the `solve.cpp` capability guard (step 7).
+
+7. **Guard incompatible solvers.** Add the new mode to the rejection check in
+   `solve.cpp` (the same place that already refuses `--ir` for Bitwuzla/Boolector),
+   so an unsupported `--mytheory --bitwuzla` exits cleanly with a clear message.
+
+8. **Emit the right SMT-LIB logic.** Extend the logic selection in
+   `smtlib_conv.cpp` so the textual backend declares the correct `(set-logic …)`.
+
+9. **Adjust the pointer/dereference model if addressing is affected.**
+   `src/pointer-analysis/dereference.cpp` assumes a representation of addresses; a
+   theory that changes how integers/pointers are modelled must be reconciled here.
+
+10. **Add simplifications (optional).** Constant-folding or rewrites for the new
+    operations go in `src/util/simplify_expr.cpp`. Optional for correctness, useful
+    for performance.
+
+## Validation
+
+- Build with a backend that supports the theory (e.g. `-DENABLE_Z3=On`) and run a
+  small program with and without the new mode; confirm the verdicts agree on
+  cases where the theory is sound, and that an unsupported-solver combination
+  exits cleanly (not via `abort()`).
+- Add at least two regression tests (one passing `CORE`, one failing) whose
+  `test.desc` flag line exercises the new mode.
+- Differentially compare against the bit-vector encoding on a representative
+  subset; divergence usually signals an over-approximation made unsound or a
+  missed `int_encoding` branch.
+
+## Maintainability & limitations
+
+- **Capability negotiation, not silent fallback.** A backend that cannot express
+  the theory must reject it (`solve.cpp` guard + a loud backend default), never
+  emit wrong semantics. Where a *flattener* can lower the theory onto bit-vectors
+  (as the array/FP/tuple flatteners do), prefer that to per-backend duplication.
+- **Mode flags are viral.** `int_encoding` is read in many `src/solvers/smt/*.cpp`
+  files; a new flag-gated theory will likely touch the same set. Keep the branch
+  logic in the shared `smt/` layer, not copied into each backend.
+- **Over-approximation is a soundness commitment.** Integer/real mode trades
+  bit-precise wraparound for unbounded Int/Real (faster, over-approximating).
+  Document precisely what your theory approximates, and which checks become
+  unsound under it.
+- **Addressing-sensitive theories need the pointer model.** Skipping
+  `dereference.cpp` for a theory that changes integer/pointer representation
+  produces subtle, hard-to-diagnose failures.


### PR DESCRIPTION
## What

Rewrites the "Implement a new SMT theory into ESBMC" docs page
(`website/content/docs/development/smt/...`) from 9 bare line-number links into
a structured, grounded guide.

## Why

The old page was a list of source links — several commit-pinned to `7f41ac1…`
and drifted from `master` — with no explanation of what a "theory" is or how it
differs from adding an expression vs. adding a solver backend. The QF_AUFLIRA
example was never tied to ESBMC's actual integer/real (`--ir`) mode.

## What the rewrite adds

- A "which guide do you need?" table cross-linking the expression-level and
  backend-level guides.
- Architecture: sorts (`smt_sort.h`), the `mk_smt_*` virtual surface on
  `smt_solver_baset` (`smt_solver.h`), the `int_encoding` flag set from the
  `int-encoding` option in `smt_solver.cpp`, per-backend native-vs-abort
  handling, the `solve.cpp` capability guard, and the `smtlib_conv.cpp`
  `set-logic` selection (`QF_AUFLIRA` vs `QF_AUFBV`).
- A 10-step worked example tracing the integer/real theory by file/identifier
  instead of line number.
- Maintainability and soundness notes (capability negotiation over silent
  fallback, mode-flag viral spread, over-approximation as a soundness
  commitment, addressing-sensitive theories needing the pointer model).

Docs-only change. Companion to #5557.