### PR TITLE
[docs] Rewrite SMT-solver update guide against current build

### DIFF
--- a/website/content/docs/development/smt/Update-an-SMT-solver-in-ESBMC.md
+++ b/website/content/docs/development/smt/Update-an-SMT-solver-in-ESBMC.md
@@ -1,20 +1,104 @@
 ---
-title: SMT Solver Update
+title: Updating an SMT Solver
 ---
 
+This guide explains how to bump the version of an SMT solver already integrated
+in ESBMC. The worked example bumps **Bitwuzla**, but the steps generalise — the
+**only** thing that changes per solver is *where the version is pinned*, which
+depends on how that solver is obtained.
 
-These instructions provide information on how to update the version of an existing SMT solver in ESBMC.
+> [!NOTE]
+> Anchors below name **files and identifiers** rather than line numbers, which
+> drift. Grep for the identifier if you cannot find it.
 
-1) Open the file `BUILDING.md` and update the SMT solver version. For example, we'll update the bitwuzla version from 0.5.0 to 0.6.0.
+## Where versions are pinned
 
-![image](https://github.com/user-attachments/assets/2c862974-b6a6-4a31-bdb0-d15162aac7a1)
+ESBMC obtains solvers in two ways, and the pin location differs:
 
-![image](https://github.com/user-attachments/assets/3b1718d5-54d7-4ebb-bbd7-4273b1974405)
+| Solver | How obtained | Version pinned in |
+|---|---|---|
+| Bitwuzla, Boolector, Yices, CVC4 | built from source (CPM / git) | `GIT_TAG` in `src/solvers/<solver>/CMakeLists.txt` |
+| Z3, CVC5, MathSAT | prebuilt archive download | `DEFAULT_<S>_URL` / `DEFAULT_<S>_NAME` in `scripts/cmake/Options.cmake` |
 
-2) Open the file `src/solvers/bitwuzla/CMakeLists.txt` and update the SMT solver version (bitwuzla 0.5.0):
+In **both** cases there is also a compatibility floor:
+`set(<Solver>_MIN_VERSION "x.y.z")` at the top of
+`src/solvers/<solver>/CMakeLists.txt`. ESBMC's CMake aborts the build if the
+located library is older than this.
 
-![image](https://github.com/user-attachments/assets/cc4849bb-8788-49f6-ad90-326328d89f0d)
+CI workflows and `scripts/build.sh` do **not** pin solver versions — they build
+with `-DDOWNLOAD_DEPENDENCIES=On` and inherit whatever the CMake files above
+specify. So you usually do not touch `.github/workflows/*` for a version bump.
 
-3) The next step is to check whether the SMT solver has changed their API signature. If they have changed, we must also update the respective interface in the `src/solvers`
+## Procedure
 
+### A. Source-built solver (e.g. Bitwuzla)
 
+1. **Bump the git tag.** In `src/solvers/bitwuzla/CMakeLists.txt`, update the
+   `GIT_TAG` passed to `cpmaddpackage(... GITHUB_REPOSITORY bitwuzla/bitwuzla
+   GIT_TAG <new-tag>)`.
+2. **Raise the compatibility floor** if the new version is now required:
+   `set(Bitwuzla_MIN_VERSION "<new>")`.
+3. **Re-check the build recipe.** Source-built solvers run their own configure
+   step (Bitwuzla: `python3 ./configure.py … && meson install`). If the upstream
+   build system changed flags between versions, update that `execute_process`
+   invocation.
+
+### B. Prebuilt-download solver (e.g. Z3, CVC5, MathSAT)
+
+1. **Bump the URL and extracted-directory name** in `scripts/cmake/Options.cmake`
+   — update the per-OS `DEFAULT_Z3_URL` / `DEFAULT_Z3_NAME` (and the Windows
+   branch) so the new archive is downloaded and found. These feed the cache
+   variables `ESBMC_Z3_URL` / `ESBMC_Z3_NAME` consumed by
+   `src/solvers/z3/CMakeLists.txt`.
+2. **Raise `<Solver>_MIN_VERSION`** in the per-solver `CMakeLists.txt` if needed.
+
+### C. Common to both
+
+3. **Update `BUILDING.md`.** Change the documented version so manual installers
+   match what `DOWNLOAD_DEPENDENCIES` fetches.
+
+4. **Reconcile API changes — the step that actually breaks.** If the solver
+   changed its API between versions, update the backend interface in
+   `src/solvers/<solver>/<solver>_conv.{cpp,h}` (renamed functions, changed
+   signatures, new term/sort constructors). The compile-time probe
+   `src/solvers/<solver>/try_<solver>.c` may also need adjusting if the symbols it
+   references moved.
+
+5. **Watch bundled static dependencies.** Some solvers statically link a SAT core
+   that clashes with another backend — e.g. `src/solvers/bitwuzla/CMakeLists.txt`
+   renames Bitwuzla's bundled CaDiCaL symbols to avoid colliding with cvc5. A new
+   version may bundle a different SAT core or change those symbol names; verify the
+   rename block still matches.
+
+## Validate
+
+```sh
+# force a fresh fetch/build of the bumped solver
+rm -rf build
+cmake -GNinja -Bbuild -S . -DDOWNLOAD_DEPENDENCIES=On -DENABLE_BITWUZLA=On \
+  -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DCMAKE_BUILD_TYPE=RelWithDebInfo
+ninja -C build
+```
+
+- Confirm CMake reports the new version (`message(STATUS "… version: …")`) and
+  does not trip the `MIN_VERSION` floor.
+- Run that solver's regression subset and compare against the previous version /
+  another backend; a new failure usually means an unhandled API or semantic
+  change, not a flaky test:
+  ```sh
+  cd build && ctest -j$(nproc) -L regression --timeout 120
+  rm -rf /tmp/esbmc-headers-*   # clean per-test temp dirs
+  ```
+
+## Notes & pitfalls
+
+- **Don't forget the `MIN_VERSION` floor.** Bumping `GIT_TAG`/URL without it lets
+  an older system-installed library satisfy the build and silently shadow the
+  intended version.
+- **A version bump can be a behaviour change.** Solver upgrades alter heuristics,
+  default options, and occasionally `check-sat` results on hard instances; treat a
+  regression diff as signal, and pin/adjust solver options in the backend rather
+  than working around it in tests.
+- **Keep `BUILDING.md` and the CMake pin in lockstep** — they are the two places a
+  user vs. the automated build read the version from, and drift between them
+  produces "works in CI, fails locally" reports.


### PR DESCRIPTION
## What

Rewrites the "Update an SMT solver in ESBMC" docs page
(`website/content/docs/development/smt/...`) from three screenshot-driven steps
into a concrete text guide.

## Why

The old page was almost entirely embedded images (opaque on the rendered docs
site, un-searchable, and already stale — it shows Bitwuzla 0.5.0→0.6.0 while the
tree is on 0.9.0). It also implied a single pin location, when the version is
actually pinned differently depending on how the solver is obtained.

## What the rewrite adds

- A table mapping each solver to where its version lives: `GIT_TAG` in
  `src/solvers/<solver>/CMakeLists.txt` for source-built solvers
  (Bitwuzla/Boolector/Yices/CVC4) vs `DEFAULT_<S>_URL`/`DEFAULT_<S>_NAME` in
  `scripts/cmake/Options.cmake` for prebuilt downloads (Z3/CVC5/MathSAT), plus
  the `<Solver>_MIN_VERSION` compatibility floor in both.
- Per-path procedures, API reconciliation in `<solver>_conv.{cpp,h}` /
  `try_<solver>.c`, and the bundled-CaDiCaL static-symbol-rename pitfall (Bitwuzla
  vs cvc5).
- Validation steps and the note that CI/`build.sh` inherit versions via
  `DOWNLOAD_DEPENDENCIES` (so workflow files usually need no edit).

Docs-only change. Companion to #5557 and #5559.