### PR TITLE
[symex] treat stack-reachable heap as live in memory-leak check

### DIFF
--- a/regression/esbmc/github_5138/main.c
+++ b/regression/esbmc/github_5138/main.c
@@ -1,0 +1,40 @@
+#include <stdlib.h>
+
+extern char nondet_char(void);
+
+static void cleanup(void)
+{
+}
+
+static void terminate(char **a, int n)
+{
+  (void)a;
+  (void)n;
+  exit(0);
+}
+
+/* Models the SV-COMP entry harness of coreutils/comm_3args_ok: an argv-style
+ * array of char* is stored into a flat malloc'd byte buffer, and the program
+ * exit()s (running the leak check) while the buffer and its elements are still
+ * reachable from main's own local `a`. None of it is a leak -- valid-memtrack
+ * counts stack-reachable memory as tracked. Regresses issue #5138. */
+int main(void)
+{
+  atexit(cleanup); /* registers a handler so exit() runs the leak check */
+  int n = 3;
+  char **a = malloc((n + 1) * 8UL);
+  if (!a)
+    return 0;
+  for (int i = 0; i < n; i++)
+  {
+    a[i] = malloc(8);
+    if (!a[i])
+      return 0;
+    a[i][0] = nondet_char();
+  }
+  terminate(a, n); /* exit() while `a` and every a[i] are still reachable */
+  for (int i = 0; i < n; i++)
+    free(a[i]); /* keeps `a` live across terminate(): not a leak */
+  free(a);
+  return 0;
+}

--- a/regression/esbmc/github_5138/test.desc
+++ b/regression/esbmc/github_5138/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --force-malloc-success --64 --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5138_fail/main.c
+++ b/regression/esbmc/github_5138_fail/main.c
@@ -1,0 +1,39 @@
+#include <stdlib.h>
+
+extern char nondet_char(void);
+
+static void cleanup(void)
+{
+}
+
+static void terminate(char **a, int n)
+{
+  (void)a;
+  (void)n;
+  exit(0);
+}
+
+/* Soundness companion to github_5138: the element pointers are dropped (a[i]=0)
+ * before exit(), so the three malloc(8) blocks are genuinely orphaned and must
+ * still be reported as leaked. The content-based reachability chase reads the
+ * buffer's *current* bytes, which no longer hold the element addresses, so the
+ * leak is not masked. */
+int main(void)
+{
+  atexit(cleanup);
+  int n = 3;
+  char **a = malloc((n + 1) * 8UL);
+  if (!a)
+    return 0;
+  for (int i = 0; i < n; i++)
+  {
+    a[i] = malloc(8);
+    if (!a[i])
+      return 0;
+    a[i][0] = nondet_char();
+    a[i] = 0; /* drop the only reference -> genuine leak of this block */
+  }
+  terminate(a, n);
+  free(a);
+  return 0;
+}

--- a/regression/esbmc/github_5138_fail/test.desc
+++ b/regression/esbmc/github_5138_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --force-malloc-success --64 --unwind 5
+^VERIFICATION FAILED$
+^.*forgotten memory.*$

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -19,6 +19,7 @@
 #include <util/pretty.h>
 #include <util/std_expr.h>
 #include <util/time_stopping.h>
+#include <util/type_byte_size.h>
 #include <util/message.h>
 
 #include <vector>
@@ -1283,6 +1284,220 @@ void goto_symext::add_memory_leak_checks()
      * 'true'). */
     std::vector<std::pair<expr2tc, std::list<value_sett::entryt>>> globals(1);
     va.get_globals(globals[0].second);
+
+    /* A dynamic object reachable only through an in-scope automatic variable of
+     * an active call frame is NOT a leak: when __ESBMC_memory_leak_checks() is
+     * invoked from exit()/abort() (or a __noreturn assert) the call stack is
+     * still live, so SV-COMP valid-memtrack counts stack-reachable memory as
+     * tracked. The static-globals roots above miss these; without them an
+     * `argv` buffer that the entry harness allocates and keeps in main's own
+     * local is wrongly reported as "forgotten memory" (issue #5138).
+     *
+     * We root reachability from the pointer-typed locals of every active frame
+     * and then chase the pointer graph through heap objects, recording each
+     * reachable object (and the condition under which it is reachable) into
+     * globals_point_to alongside the global roots above.
+     *
+     * Heap buffers need a content-based chase rather than the type-based
+     * get_entries_rec() used for globals: the SV-COMP entry harness stores an
+     * array of `char *` arguments into a single `malloc((argc+1)*8)` block,
+     * which ESBMC types as a flat byte array. get_entries_rec() sees no pointer
+     * sub-component there and would stop, leaking the argument strings. Instead,
+     * for each constant-size object we read a pointer at every pointer-aligned
+     * offset and OR same_object() over them: this reads the actual stored bytes
+     * (sound -- a pointer the buffer no longer holds does not match) and, being
+     * fully expanded for a constant size, is negatable in the leak claim's
+     * `not(reachable)` context (the array-index reachability TODO below only
+     * blocks the *symbolic*-size case). */
+    const bool is_big_endian =
+      (config.ansi_c.endianess == configt::ansi_ct::IS_BIG_ENDIAN);
+    const BigInt ptr_bytes(config.ansi_c.pointer_width() / 8);
+    const type2tc void_ptr_type = pointer_type2tc(get_empty_type());
+
+    /* A value-set target is a usable reachability root only if it denotes a
+     * concrete object: drop unknown/invalid descriptors and null/string/code
+     * objects. Returns the root object symbol, or nil to skip. */
+    auto usable_root = [](const expr2tc &descriptor) -> expr2tc {
+      if (is_unknown2t(descriptor) || is_invalid2t(descriptor))
+        return expr2tc();
+      assert(is_object_descriptor2t(descriptor));
+      expr2tc obj = to_object_descriptor2t(descriptor).get_root_object();
+      if (
+        is_null_object2t(obj) || is_constant_string2t(obj) ||
+        is_code_type(obj) || !is_symbol2t(obj))
+        return expr2tc();
+      return obj;
+    };
+
+    /* Worklist of (heap-object symbol, condition under which it is reachable).
+     * `local_reached` bounds work on cyclic heaps and caps total objects. */
+    std::vector<std::pair<expr2tc, expr2tc>> reach_work;
+    std::unordered_set<std::string> local_reached;
+    const size_t max_reached = 4096;
+    const uint64_t max_slots = 1024;
+
+    for (const auto &local_frame : cur_state->call_stack)
+    {
+      for (const auto &lv : local_frame.local_variables)
+      {
+        const symbolt *lsym = ns.lookup(lv.base_name);
+        if (lsym == nullptr || has_prefix(lsym->name, "__ESBMC_"))
+          continue;
+
+        /* Skip compiler-generated temporaries. A function-return temporary
+         * such as `return_value$_malloc$N` keeps holding the pointer it
+         * produced even after the source program has dropped its last
+         * reference (e.g. `p = malloc(); p = NULL;`), so rooting reachability
+         * from it would mask genuine leaks (unsound). Only source-level
+         * automatic variables denote program-visible references; the frontend
+         * names those `<file>@<line>@F@<func>@<var>` (no `$`) and reserves `$`
+         * for synthetic symbols, so a `$` anywhere marks a temporary. Dropping
+         * a real root we fail to recognise only costs precision (a residual
+         * false positive), never soundness. */
+        const std::string &lname = lv.base_name.as_string();
+        if (lname.find('$') != std::string::npos)
+          continue;
+
+        type2tc lsym_type = migrate_symbol_type(*lsym);
+        if (!is_pointer_type(lsym_type))
+          continue;
+
+        expr2tc lptr = symbol2tc(lsym_type, lv.base_name);
+        local_frame.level1.get_ident_name(lptr);
+
+        value_sett::object_mapt lpoints_to;
+        cur_state->value_set.get_value_set_rec(
+          lptr, lpoints_to, "", lptr->type);
+
+        /* The value set is flow-insensitive: lptr's entry still lists every
+         * object it ever pointed at, even ones it no longer holds (e.g. after
+         * `p = NULL`). To keep the leak check sound we must test the pointer's
+         * *current* value, so L2-rename a copy of lptr to its SSA value here.
+         * level1 was already applied via the owning frame above; level2 is
+         * frame-independent, so renaming through the current state is correct. */
+        expr2tc lptr_val = lptr;
+        cur_state->level2.rename(lptr_val);
+
+        for (auto it = lpoints_to.begin(); it != lpoints_to.end(); ++it)
+        {
+          expr2tc root_object = usable_root(cur_state->value_set.to_expr(it));
+          if (is_nil_expr(root_object))
+            continue;
+
+          /* The local is unconditionally live; it points at root_object
+           * exactly when same_object holds. */
+          expr2tc adr = address_of2tc(root_object->type, root_object);
+          reach_work.emplace_back(root_object, same_object2tc(lptr_val, adr));
+        }
+      }
+    }
+
+    while (!reach_work.empty() && local_reached.size() < max_reached)
+    {
+      expr2tc obj = reach_work.back().first;
+      expr2tc cond = reach_work.back().second;
+      reach_work.pop_back();
+
+      /* Record the object as reachable under `cond`. */
+      expr2tc adr = address_of2tc(obj->type, obj);
+      expr2tc &pts = globals_point_to[adr];
+      pts = pts ? or2tc(pts, cond) : cond;
+
+      /* Expand each object's contents once. */
+      if (!local_reached.insert(to_symbol2t(obj).get_symbol_name()).second)
+        continue;
+
+      /* Only constant-size objects can be soundly, fully expanded; a symbolic
+       * size hits the array-index reachability TODO further down and is left
+       * as a (sound) residual false positive. */
+      if (!is_array_type(obj->type))
+        continue;
+      const array_type2t &arr_t = to_array_type(obj->type);
+      if (is_nil_expr(arr_t.array_size) || !is_constant_int2t(arr_t.array_size))
+        continue;
+
+      /* Only scalar elements are read below: a byte (stitched) or a
+       * pointer-width number/pointer (indexed directly). Restricting to these
+       * keeps type_byte_size() off incomplete/unsized types and keeps the
+       * direct-index path off aggregates (bitcast would be ill-formed). Arrays
+       * of structs/arrays are left unexpanded -- a sound residual. */
+      if (!is_number_type(arr_t.subtype) && !is_pointer_type(arr_t.subtype))
+        continue;
+
+      const BigInt elem_bytes = type_byte_size(arr_t.subtype);
+      const BigInt total_bytes =
+        to_constant_int2t(arr_t.array_size).value * elem_bytes;
+      if (
+        ptr_bytes == 0 || elem_bytes == 0 ||
+        total_bytes / ptr_bytes > BigInt(max_slots))
+        continue;
+
+      /* Each pointer occupies a whole number of elements, or each element is a
+       * single byte we stitch together; other element sizes are skipped (a
+       * sound residual). The SMT backend rejects byte_extract on an array, so
+       * read element-by-element via index() and combine. */
+      const uint64_t pb = ptr_bytes.to_uint64();
+      if (elem_bytes != 1 && elem_bytes != ptr_bytes)
+        continue;
+
+      /* The buffer's current content: L2-rename the object symbol. */
+      expr2tc buf_val = obj;
+      cur_state->rename(buf_val);
+
+      /* Read the pointer stored at byte offset `off`. */
+      auto read_slot = [&](const BigInt &off) -> expr2tc {
+        if (elem_bytes == ptr_bytes)
+        {
+          expr2tc el = index2tc(
+            arr_t.subtype, buf_val, gen_ulong((off / elem_bytes).to_uint64()));
+          return is_pointer_type(el) ? typecast2tc(void_ptr_type, el)
+                                     : bitcast2tc(void_ptr_type, el);
+        }
+        /* elem_bytes == 1: stitch `pb` consecutive bytes into a pointer. */
+        std::vector<expr2tc> bytes;
+        bytes.reserve(pb);
+        for (uint64_t b = 0; b < pb; b++)
+          bytes.push_back(typecast2tc(
+            get_uint8_type(),
+            index2tc(
+              arr_t.subtype,
+              buf_val,
+              gen_ulong((off + BigInt(b)).to_uint64()))));
+        expr2tc accuml = is_big_endian ? bytes.front() : bytes.back();
+        if (is_big_endian)
+          for (uint64_t b = 1; b < pb; b++)
+            accuml = concat2tc(
+              get_uint_type(accuml->type->get_width() + 8), accuml, bytes[b]);
+        else
+          for (int b = (int)pb - 2; b >= 0; b--)
+            accuml = concat2tc(
+              get_uint_type(accuml->type->get_width() + 8), accuml, bytes[b]);
+        return bitcast2tc(void_ptr_type, accuml);
+      };
+
+      /* Candidate objects the buffer's elements may point at. */
+      value_sett::object_mapt contents;
+      cur_state->value_set.get_value_set_rec(obj, contents, "[]", obj->type);
+
+      for (auto c_it = contents.begin(); c_it != contents.end(); ++c_it)
+      {
+        expr2tc cobj = usable_root(cur_state->value_set.to_expr(c_it));
+        if (is_nil_expr(cobj))
+          continue;
+
+        /* Reach `cobj` iff some pointer-aligned slot of the buffer currently
+         * holds its address: OR over slots of same_object(slot, &cobj). */
+        expr2tc cadr = address_of2tc(cobj->type, cobj);
+        expr2tc slot_reach;
+        for (BigInt off(0); off + ptr_bytes <= total_bytes; off += ptr_bytes)
+        {
+          expr2tc so = same_object2tc(read_slot(off), cadr);
+          slot_reach = slot_reach ? or2tc(slot_reach, so) : so;
+        }
+        if (slot_reach)
+          reach_work.emplace_back(cobj, and2tc(cond, slot_reach));
+      }
+    }
 
     /* In order to handle every globally reachable symbol just once even in case
      * the user code has constructed circular data structures, maintain a set


### PR DESCRIPTION
Roots the `--no-reachable-memory-leak` reachability scan at the pointer locals of every active call frame (not just static globals) and chases pointers stored in constant-size heap buffers by byte-stitching, so heap still reachable from a live stack local at `exit()`/`abort()` is no longer reported as a forgotten-memory leak. Sound: each pointer is L2-renamed to its current value before `same_object`, and compiler temporaries are excluded. Two regression tests included. Refs #5138 — fixes the memory-leak false-alarm layer; `comm_3args_ok` also needs the unrelated `fclose`/`strcmp` model fixes tracked in #5565.