### PR TITLE
[witnesses] Add ReachSafety-CorrectnessWitnesses regression suite

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -309,6 +309,7 @@ else()
                     loop-invariants
                     function_contract
                     witnesses_validate/reachsafety-violationwitness
+                    witnesses_validate/reachsafety-correctnesswitness
        )
   else()
     set(REGRESSIONS $ENV{BENCHMARK_TO_RUN}) # run a single user-specified benchmark

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_as2013_hybrid/as2013-hybrid.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_as2013_hybrid/as2013-hybrid.i
@@ -1,0 +1,28 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "as-hybrid.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+int main() {
+  int i = 0;
+  while (1) {
+    i++;
+    int j = 0;
+    while (j < 10) {
+      __VERIFIER_assert(0 <= i);
+      __VERIFIER_assert(i <= 10);
+      j++;
+    }
+    if (i > 9)
+      i = 0;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_as2013_hybrid/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_as2013_hybrid/test.desc
@@ -1,0 +1,5 @@
+CORE
+as2013-hybrid.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_as2013_hybrid/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_as2013_hybrid/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: 71b761c6-4f85-405e-8ee6-9a3a8f743513
+    creation_time: 2022-10-12T11:50:43Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - as2013-hybrid.i
+      input_file_hashes:
+        as2013-hybrid.i: 6f4877babf2234c4d9f84af37e06b0d1c35e333b586df80a0a3a6ac5b1b8e2d2
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: loop_invariant
+      location:
+        file_name: as2013-hybrid.i
+        line: 16
+        column: 3
+        function: main
+      value: 0 <= i && i <= 9
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_bh2017_ex1_poly/bh2017-ex1-poly.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_bh2017_ex1_poly/bh2017-ex1-poly.i
@@ -1,0 +1,33 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "bh-ex1-poly.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+int main() {
+  int i = 0;
+  while (i < 4) {
+    int j = 0;
+    while (j < 3) {
+      i++;
+      j += 2;
+      __VERIFIER_assert(0 <= j);
+      __VERIFIER_assert(j <= 2 * i);
+      __VERIFIER_assert(2 * i <= j + 6);
+      __VERIFIER_assert(j <= 4);
+    }
+    __VERIFIER_assert(0 <= j);
+    __VERIFIER_assert(j <= 2 * i);
+    __VERIFIER_assert(2 * i <= j + 6);
+    __VERIFIER_assert(j <= 4);
+    i = i - j / 2 + 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_bh2017_ex1_poly/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_bh2017_ex1_poly/test.desc
@@ -1,0 +1,5 @@
+CORE
+bh2017-ex1-poly.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_bh2017_ex1_poly/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_bh2017_ex1_poly/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: 6ee08942-60e6-4291-a9fc-ff6f2744ef4b
+    creation_time: 2022-10-12T11:19:46Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - bh2017-ex1-poly.i
+      input_file_hashes:
+        bh2017-ex1-poly.i: d6dbcbf51695ea037a123bcc006ce5f6db095b874a22b169ec869d834ce41de6
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: bh2017-ex1-poly.i
+        line: 17
+        column: 5
+        function: main
+      value: 0 <= i && i <= 3
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex1b/hh2012-ex1b.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex1b/hh2012-ex1b.i
@@ -1,0 +1,28 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "hh-ex1b.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+int main() {
+  int i = 0;
+  while (i < 100) {
+    int j = 0;
+    while (j < 100) {
+      j++;
+      __VERIFIER_assert(j <= 100);
+    }
+    __VERIFIER_assert(j == 100);
+    i++;
+    __VERIFIER_assert(i <= 100);
+  }
+  __VERIFIER_assert(i == 100);
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex1b/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex1b/test.desc
@@ -1,0 +1,5 @@
+CORE
+hh2012-ex1b.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex1b/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex1b/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: 1a354f1e-76e8-40e9-808a-8d5efbe35496
+    creation_time: 2022-10-12T10:45:49Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - hh2012-ex1b.i
+      input_file_hashes:
+        hh2012-ex1b.i: 7ce79fe11836d82ec064e02fff135ad9866417774e7d276b3384b4d4dde863b5
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: loop_invariant
+      location:
+        file_name: hh2012-ex1b.i
+        line: 18
+        column: 5
+        function: main
+      value: 0 <= i && i <= 99
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex3/hh2012-ex3.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex3/hh2012-ex3.i
@@ -1,0 +1,33 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "hh-ex3.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+int main() {
+  int i = 0;
+  while (i < 4) {
+    int j = 0;
+    while (j < 4) {
+      i++;
+      j++;
+      __VERIFIER_assert(0 <= j);
+      __VERIFIER_assert(j <= i);
+      __VERIFIER_assert(i <= j + 3);
+      __VERIFIER_assert(j <= 4);
+    }
+    __VERIFIER_assert(0 <= j);
+    __VERIFIER_assert(j <= i);
+    __VERIFIER_assert(i <= j + 3);
+    __VERIFIER_assert(j <= 4);
+    i = i - j + 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex3/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex3/test.desc
@@ -1,0 +1,5 @@
+CORE
+hh2012-ex3.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex3/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_hh2012_ex3/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: d834761a-d0d7-4fea-bf42-2ff2b9a19143
+    creation_time: 2022-10-12T10:59:25Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - hh2012-ex3.i
+      input_file_hashes:
+        hh2012-ex3.i: 3c7177334f88b94ca4ee99044935e396702561856a6f48616f98f91aafc609bb
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: location_invariant
+      location:
+        file_name: hh2012-ex3.i
+        line: 17
+        column: 5
+        function: main
+      value: 0 <= i && i <= 3
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_1/linear-inequality-inv-a.c
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_1/linear-inequality-inv-a.c
@@ -1,0 +1,33 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2022 Dirk Beyer, Matthias Dangl, Daniel Dietsch, Matthias Heizmann, Thomas Lemberger, and Michael Tautschnig
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "linear-inequality-inv-a.c", 2, "reach_error"); }
+extern unsigned char __VERIFIER_nondet_uchar(void);
+int main() {
+  unsigned char n = __VERIFIER_nondet_uchar();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned char v = 0;
+  unsigned int  s = 0;
+  unsigned int  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_uchar();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 65025) {
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_1/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+linear-inequality-inv-a.c
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION FAILED$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_1/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_1/witness.yml
@@ -1,0 +1,26 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: "8faefbb9-b514-441e-b3a9-9d4a491f2827"
+    creation_time: "2024-09-17T09:35:16+0000"
+    producer:
+      name: "Handcrafted"
+      version: ""
+    task:
+      input_files:
+      - "./linear-inequality-inv-a.c"
+      input_file_hashes:
+        "./linear-inequality-inv-a.c": "d2b9c65bc0d5e6814219e058019ca5895f861b5993bd9ff39cc6b3d5fb3e6a41"
+      specification: "G ! call(reach_error())"
+      data_model: "ILP32"
+      language: "C"
+  content:
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: "linear-inequality-inv-a.c"
+          line: 19
+          column: 3
+          function: main
+        value: "0" # Incorrect, wrong invariant
+        format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_2/linear-inequality-inv-a.c
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_2/linear-inequality-inv-a.c
@@ -1,0 +1,33 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2022 Dirk Beyer, Matthias Dangl, Daniel Dietsch, Matthias Heizmann, Thomas Lemberger, and Michael Tautschnig
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "linear-inequality-inv-a.c", 2, "reach_error"); }
+extern unsigned char __VERIFIER_nondet_uchar(void);
+int main() {
+  unsigned char n = __VERIFIER_nondet_uchar();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned char v = 0;
+  unsigned int  s = 0;
+  unsigned int  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_uchar();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 65025) {
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_2/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_2/test.desc
@@ -1,0 +1,5 @@
+CORE
+linear-inequality-inv-a.c
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_2/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_a_2/witness.yml
@@ -1,0 +1,26 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: "eee0ba85-b96e-4aab-9e30-8105af1fd3f8"
+    creation_time: "2024-09-17T09:35:16+0000"
+    producer:
+      name: "Handcrafted"
+      version: ""
+    task:
+      input_files:
+      - "./linear-inequality-inv-a.c"
+      input_file_hashes:
+        "./linear-inequality-inv-a.c": "d2b9c65bc0d5e6814219e058019ca5895f861b5993bd9ff39cc6b3d5fb3e6a41"
+      specification: "G ! call(reach_error())"
+      data_model: "ILP32"
+      language: "C"
+  content:
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: "linear-inequality-inv-a.c"
+          line: 19
+          column: 3
+          function: main
+        value: "s <= i*255 && 0 <= i && i <= 255 && n <= 255"
+        format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_1/linear-inequality-inv-c.c
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_1/linear-inequality-inv-c.c
@@ -1,0 +1,33 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2022 Dirk Beyer, Matthias Dangl, Daniel Dietsch, Matthias Heizmann, Thomas Lemberger, and Michael Tautschnig
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "linear-inequality-inv-a.c", 2, "reach_error"); }
+extern unsigned short __VERIFIER_nondet_ushort(void);
+int main() {
+  unsigned short n = __VERIFIER_nondet_ushort();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned short v = 0;
+  unsigned int  s = 0;
+  unsigned int  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_ushort();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 4294836225) { // (2**16 - 1)**2
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_1/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+linear-inequality-inv-c.c
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION FAILED$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_1/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_1/witness.yml
@@ -1,0 +1,26 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: "0f8d0035-39bf-459c-8443-283f2a4d34c6"
+    creation_time: "2024-09-17T09:35:16+0000"
+    producer:
+      name: "Handcrafted"
+      version: ""
+    task:
+      input_files:
+      - "./linear-inequality-inv-c.c"
+      input_file_hashes:
+        "./linear-inequality-inv-c.c": "98c9a7161a25877cb0d3946df13d012bfde80051390422e2e164abf2e04cd600"
+      specification: "G ! call(reach_error())"
+      data_model: "ILP32"
+      language: "C"
+  content:
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: "linear-inequality-inv-c.c"
+          line: 19
+          column: 3
+          function: main
+        value: "i < n" # Incorrect, wrong invariant, the last iteration has i == n
+        format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_2/linear-inequality-inv-c.c
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_2/linear-inequality-inv-c.c
@@ -1,0 +1,33 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2022 Dirk Beyer, Matthias Dangl, Daniel Dietsch, Matthias Heizmann, Thomas Lemberger, and Michael Tautschnig
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "linear-inequality-inv-a.c", 2, "reach_error"); }
+extern unsigned short __VERIFIER_nondet_ushort(void);
+int main() {
+  unsigned short n = __VERIFIER_nondet_ushort();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned short v = 0;
+  unsigned int  s = 0;
+  unsigned int  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_ushort();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 4294836225) { // (2**16 - 1)**2
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_2/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_2/test.desc
@@ -1,0 +1,5 @@
+CORE
+linear-inequality-inv-c.c
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_2/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_c_2/witness.yml
@@ -1,0 +1,26 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: "c91293f2-eff2-40df-8010-53b603411a94"
+    creation_time: "2024-09-17T09:35:16+0000"
+    producer:
+      name: "Handcrafted"
+      version: ""
+    task:
+      input_files:
+      - "./linear-inequality-inv-c.c"
+      input_file_hashes:
+        "./linear-inequality-inv-c.c": "98c9a7161a25877cb0d3946df13d012bfde80051390422e2e164abf2e04cd600"
+      specification: "G ! call(reach_error())"
+      data_model: "ILP32"
+      language: "C"
+  content:
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: "linear-inequality-inv-c.c"
+          line: 19
+          column: 3
+          function: main
+        value: "s <= i*65535 && 0 <= i && i <= 65535 && n <= 65535"
+        format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_1/linear-inequality-inv-d.c
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_1/linear-inequality-inv-d.c
@@ -1,0 +1,33 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2022 Dirk Beyer, Matthias Dangl, Daniel Dietsch, Matthias Heizmann, Thomas Lemberger, and Michael Tautschnig
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "linear-inequality-inv-a.c", 2, "reach_error"); }
+extern unsigned int __VERIFIER_nondet_uint(void);
+int main() {
+  unsigned int n = __VERIFIER_nondet_uint();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned int   v = 0;
+  unsigned long  s = 0;
+  unsigned long  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_uint();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 18446744065119617025ULL) { // (2**32 - 1)**2
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_1/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+linear-inequality-inv-d.c
+--64 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION FAILED$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_1/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_1/witness.yml
@@ -1,0 +1,26 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: "34aa480c-df81-4f29-b496-d075e84fe038"
+    creation_time: "2024-09-17T09:35:16+0000"
+    producer:
+      name: "Handcrafted"
+      version: ""
+    task:
+      input_files:
+      - "./linear-inequality-inv-d.c"
+      input_file_hashes:
+        "./linear-inequality-inv-d.c": "87519343d07fb680fe2f0e8c357c18ba883357d08bc5bf0ec4a3dc8f1cac4329"
+      specification: "G ! call(reach_error())"
+      data_model: "LP64"
+      language: "C"
+  content:
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: "linear-inequality-inv-d.c"
+          line: 19
+          column: 3
+          function: main
+        value: "i < 0xfffffffe" # Incorrect invariant, n can be equal to 0xffffffff, and in the last iteration i == n
+        format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_2/linear-inequality-inv-d.c
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_2/linear-inequality-inv-d.c
@@ -1,0 +1,33 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2022 Dirk Beyer, Matthias Dangl, Daniel Dietsch, Matthias Heizmann, Thomas Lemberger, and Michael Tautschnig
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "linear-inequality-inv-a.c", 2, "reach_error"); }
+extern unsigned int __VERIFIER_nondet_uint(void);
+int main() {
+  unsigned int n = __VERIFIER_nondet_uint();
+  if (n == 0) {
+    return 0;
+  }
+  unsigned int   v = 0;
+  unsigned long  s = 0;
+  unsigned long  i = 0;
+  while (i < n) {
+    v = __VERIFIER_nondet_uint();
+    s += v;
+    ++i;
+  }
+  if (s < v) {
+    reach_error();
+    return 1;
+  }
+  if (s > 18446744065119617025ULL) { // (2**32 - 1)**2
+    reach_error();
+    return 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_2/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_2/test.desc
@@ -1,0 +1,5 @@
+CORE
+linear-inequality-inv-d.c
+--64 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_2/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_linear_inequality_inv_d_2/witness.yml
@@ -1,0 +1,26 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: "33ee4552-3990-4e4b-8d09-c371c7edbfba"
+    creation_time: "2024-09-17T09:35:16+0000"
+    producer:
+      name: "Handcrafted"
+      version: ""
+    task:
+      input_files:
+      - "./linear-inequality-inv-d.c"
+      input_file_hashes:
+        "./linear-inequality-inv-d.c": "87519343d07fb680fe2f0e8c357c18ba883357d08bc5bf0ec4a3dc8f1cac4329"
+      specification: "G ! call(reach_error())"
+      data_model: "LP64"
+      language: "C"
+  content:
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: "linear-inequality-inv-d.c"
+          line: 19
+          column: 3
+          function: main
+        value: "s <= i*4294967295 && 0 <= i && i <= 4294967295 && n <= 4294967295"
+        format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_10/mine2017-ex4.10.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_10/mine2017-ex4.10.i
@@ -1,0 +1,24 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mine-tutorial-ex4.10.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+int main() {
+  int v = 1;
+  while (v <= 50) {
+    __VERIFIER_assert(1 <= v);
+    v += 2;
+    __VERIFIER_assert(v <= 52);
+  }
+  __VERIFIER_assert(51 <= v);
+  __VERIFIER_assert(v <= 52);
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_10/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_10/test.desc
@@ -1,0 +1,5 @@
+CORE
+mine2017-ex4.10.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_10/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_10/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: f04fe372-3d6e-4a80-9567-80c64bd7fd03
+    creation_time: 2022-10-07T10:47:08Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - mine2017-ex4.10.i
+      input_file_hashes:
+        mine2017-ex4.10.i: 55b5907667de8828dab419c82ab626d27191191343b82d619fed89d8923b6a77
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: loop_invariant
+      location:
+        file_name: mine2017-ex4.10.i
+        line: 16
+        column: 3
+        function: main
+      value: 1 <= v && v <= 52
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_6/mine2017-ex4.6.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_6/mine2017-ex4.6.i
@@ -1,0 +1,23 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mine-tutorial-ex4.6.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+int main() {
+  int x = 40;
+  while (x != 0) {
+    __VERIFIER_assert(x <= 40);
+    x--;
+    __VERIFIER_assert(x >= 0);
+  }
+  __VERIFIER_assert(x == 0);
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_6/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_6/test.desc
@@ -1,0 +1,5 @@
+CORE
+mine2017-ex4.6.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_6/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_6/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: 0e84a9de-b9f6-44dd-ab8d-ebdeca941482
+    creation_time: 2022-10-07T09:14:31Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - mine2017-ex4.6.i
+      input_file_hashes:
+        mine2017-ex4.6.i: 1fa7c9a8ed8874a508931184bf09b1ee30162cb6ccbf87de6b2ebe54845cfa76
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: loop_invariant
+      location:
+        file_name: mine2017-ex4.6.i
+        line: 16
+        column: 3
+        function: main
+      value: 0 <= x && x <= 40
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_7/mine2017-ex4.7.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_7/mine2017-ex4.7.i
@@ -1,0 +1,27 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mine-tutorial-ex4.7.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+extern _Bool __VERIFIER_nondet_bool();
+int main() {
+  int x = 0;
+  while (__VERIFIER_nondet_bool() == 0) {
+    __VERIFIER_assert(0 <= x);
+    __VERIFIER_assert(x <= 40);
+    if (__VERIFIER_nondet_bool() == 0) {
+      x++;
+      if (x > 40)
+        x = 0;
+    }
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_7/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_7/test.desc
@@ -1,0 +1,5 @@
+CORE
+mine2017-ex4.7.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_7/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_7/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: e17f9860-95af-4213-a767-ab4876ead27e
+    creation_time: 2022-10-07T10:33:01Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - mine2017-ex4.7.i
+      input_file_hashes:
+        mine2017-ex4.7.i: 51cb0ed4f3a380cdd7ae4c472320ddbca58dabad2572a56f851358e7417ed040
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: loop_invariant
+      location:
+        file_name: mine2017-ex4.7.i
+        line: 17
+        column: 3
+        function: main
+      value: 0 <= x && x <= 40
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_8/mine2017-ex4.8.i
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_8/mine2017-ex4.8.i
@@ -1,0 +1,24 @@
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+extern void abort(void);
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mine-tutorial-ex4.8.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int cond) { if(!(cond)) { ERROR: {reach_error();abort();} } }
+extern _Bool __VERIFIER_nondet_bool();
+int main() {
+  int v = 0;
+  while (__VERIFIER_nondet_bool() == 0) {
+    __VERIFIER_assert(0 <= v);
+    __VERIFIER_assert(v <= 1);
+    if (v == 0)
+      v = 1;
+  }
+  return 0;
+}

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_8/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_8/test.desc
@@ -1,0 +1,5 @@
+CORE
+mine2017-ex4.8.i
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_8/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_mine2017_ex4_8/witness.yml
@@ -1,0 +1,33 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2023-2025 Simmo Saan
+#
+# SPDX-License-Identifier: MIT
+
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: 299c2080-fb13-4879-be2b-5d2758465577
+    creation_time: 2022-10-07T10:36:41Z
+    producer:
+      name: Simmo Saan
+      version: n/a
+    task:
+      input_files:
+      - mine2017-ex4.8.i
+      input_file_hashes:
+        mine2017-ex4.8.i: ee63462f1ec886f4aa9c5663162640144e173530e57636655ca95f3d6ab0ae72
+      specification: G ! call(reach_error())
+      data_model: LP64
+      language: C
+  content:
+  - invariant:
+      type: loop_invariant
+      location:
+        file_name: mine2017-ex4.8.i
+        line: 17
+        column: 3
+        function: main
+      value: 0 <= v && v <= 1
+      format: c_expression

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_trex02_2_1/test.desc
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_trex02_2_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+trex02-2.c
+--32 --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --k-induction --max-inductive-step 3 --validate-correctness-witness --witness witness.yml
+
+^VERIFICATION FAILED$

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_trex02_2_1/trex02-2.c
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_trex02_2_1/trex02-2.c
@@ -1,0 +1,32 @@
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "trex02-2.c", 3, "reach_error"); }
+
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: {reach_error();abort();}
+  }
+  return;
+}
+_Bool __VERIFIER_nondet_bool();
+int __VERIFIER_nondet_int();
+
+//x is an input variable
+int x;
+
+void foo() {
+  x--;
+}
+
+int main() {
+  x=__VERIFIER_nondet_int();
+  while (x > 0) {
+    _Bool c = __VERIFIER_nondet_bool();
+    if(c) foo();
+    else foo();
+  }
+  __VERIFIER_assert(x==0);
+}
+
+
+

--- a/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_trex02_2_1/witness.yml
+++ b/regression/witnesses_validate/reachsafety-correctnesswitness/svcomp_trex02_2_1/witness.yml
@@ -1,0 +1,26 @@
+- entry_type: invariant_set
+  metadata:
+    format_version: "2.0"
+    uuid: "8faefbb9-b514-441e-b3a9-9d4a491f2827"
+    creation_time: "2024-09-17T09:35:16+0000"
+    producer:
+      name: "Handcrafted"
+      version: ""
+    task:
+      input_files:
+      - "./trex02-2.c"
+      input_file_hashes:
+        "./trex02-2.c": "813a8ddd546bc7f5130f32994d5f684af23ea3f2882f066aeb97d0e96f57ab55"
+      specification: "G ! call(reach_error())"
+      data_model: "ILP32"
+      language: "C"
+  content:
+    - invariant:
+        type: loop_invariant
+        location:
+          file_name: "./trex02-2.c"
+          line: 23
+          column: 3
+          function: main
+        value: "1" # The invariant is correct, but the program is unsafe
+        format: c_expression


### PR DESCRIPTION
Add 15 regression tests for correctness witness validation (--validate-correctness-witness) covering loop-invariants, loop-invariants64, loop-lit, and loops benchmarks from sv-benchmarks.

Tests use k-induction with --max-inductive-step 3. Expected verdicts are read from the properties.expected_verdict field of each witness-validation.yml task file: 12 tests expect VERIFICATION SUCCESSFUL (valid invariants) and 3 expect VERIFICATION FAILED (invalid witnesses where properties.expected_verdict=false).