### PR TITLE
[python] Fix obj in [obj] returning False for class instances

### DIFF
--- a/regression/python/github_4805_obj_membership/main.py
+++ b/regression/python/github_4805_obj_membership/main.py
@@ -1,0 +1,40 @@
+# Membership of a user-class instance in a list of instances must follow
+# CPython's identity/value semantics: an object is in a list that contains it,
+# and a distinct object is not. ESBMC stored each instance as a `Class*` slot
+# but the `in` model dereferenced the queried pointer one level too far, so
+# `obj in [obj]` wrongly evaluated to False (#4805).
+
+
+class Node:
+    def __init__(self, value=0, incoming_nodes=[], outgoing_nodes=[]):
+        self.value = value
+        self.incoming_nodes = incoming_nodes
+        self.outgoing_nodes = outgoing_nodes
+
+
+def test():
+    a = Node(1)
+    b = Node(2)
+    c = Node(3)
+    a.outgoing_nodes = [b]
+    b.incoming_nodes = [a]
+    lst = [a]
+    assert (a in lst) == True
+    assert (b not in lst) == True
+    # The same identity check used by topological_ordering's `nextnode not in
+    # ordered_nodes` guard.
+    assert (b in lst) == False
+
+    # Multi-element object list exercises the model's non-first-slot compare.
+    lst2 = [a, b]
+    assert (b in lst2) == True
+    assert (c not in lst2) == True
+
+    # A None element in an object list must keep the by-value pointer path
+    # (None is a _Bool*); the user-class items still take the by-address path.
+    lst3 = [a, None]
+    assert (a in lst3) == True
+    assert (None in lst3) == True
+
+
+test()

--- a/regression/python/github_4805_obj_membership/test.desc
+++ b/regression/python/github_4805_obj_membership/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4805_obj_membership_fail/main.py
+++ b/regression/python/github_4805_obj_membership_fail/main.py
@@ -1,0 +1,22 @@
+# Negative variant of github_4805_obj_membership: asserting that an object is
+# NOT in a list that contains it must fail. Before the #4805 fix this wrongly
+# verified SUCCESSFUL (the `in` model returned False for `a in [a]`).
+
+
+class Node:
+    def __init__(self, value=0, incoming_nodes=[], outgoing_nodes=[]):
+        self.value = value
+        self.incoming_nodes = incoming_nodes
+        self.outgoing_nodes = outgoing_nodes
+
+
+def test():
+    a = Node(1)
+    b = Node(2)
+    a.outgoing_nodes = [b]
+    lst = [a]
+    # a IS in lst, so this assertion must fail.
+    assert (a in lst) == False
+
+
+test()

--- a/regression/python/github_4805_obj_membership_fail/test.desc
+++ b/regression/python/github_4805_obj_membership_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-standard-checks
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -4066,17 +4066,25 @@ exprt python_list::contains(const exprt &item, const exprt &list)
   // Pass the list directly
   contains_call.arguments().push_back(list);
 
-  // For pointer types (e.g., string parameters), use the pointer directly
-  // For value types, take the address
+  // The model (__ESBMC_list_contains) compares *item against *elem->value, i.e.
+  // it expects `item` to *point to* the search value. A string/None element is
+  // stored as the pointer value itself in elem->value, so a char*/_Bool* item
+  // is passed by value to match. But a user-class instance is stored as a
+  // `Class*` slot (8 bytes), so the search value IS that pointer: passing the
+  // `Class*` by value would make the model dereference it and compare the
+  // pointee struct's first word instead, so `obj in [obj]` wrongly returns
+  // False (#4805). Pass its address, like the value-type path, so *item
+  // recovers the stored `Class*`.
+  const typet &item_type = item_info.elem_symbol->get_type();
   exprt item_arg;
-  if (item_info.elem_symbol->get_type().is_pointer())
+  if (item_type.is_pointer() && !converter_.is_user_class_pointer(item_type))
   {
-    // String parameters are pointers - use the pointer value directly
+    // String/None and other non-class pointers: pass the pointer value direct.
     item_arg = build_symbol(*item_info.elem_symbol);
   }
   else
   {
-    // For arrays or other value types, take the address
+    // Value types and user-class references: take the address.
     item_arg = build_address_of(build_symbol(*item_info.elem_symbol));
   }
 


### PR DESCRIPTION
Membership of a user-class instance in a list of instances always evaluated to False — `obj in [obj]` returned False, and ESBMC would even "prove" `obj not in [obj]`.

`python_list::contains` passed the `Class*` item by value, but the `__ESBMC_list_contains` model compares `*item` against `*elem->value` (it expects `item` to point to the search value). Since an instance is stored as a `Class*` slot, dereferencing the queried pointer compared the pointee struct's first word against the stored pointer, never matching. The fix passes the item's address for user-class pointers, like value types; strings, `None`, and other non-class pointers stay by-value.

Adds `regression/python/github_4805_obj_membership{,_fail}` (true/false membership, multi-element lists, and a `None` element). Verified `obj in [obj]` is now correct, `issuperset`/set-membership over objects works, and 64/64 python class/list/set/dataclass tests pass with no regressions.

Refs #4805 — this fixes one root sub-bug (object membership). Full genuine detection of the topological-ordering bug remains blocked by further object-handling imprecision (attribute-list access on loop-read objects) and the #5121 symbolic-list scalability wall, so #4805 stays open.