### PR TITLE
[python] Sound parameter-dict tuple/scalar-key iteration (#5444)

### DIFF
--- a/regression/python/param_dict_tuple_comp/main.py
+++ b/regression/python/param_dict_tuple_comp/main.py
@@ -1,0 +1,11 @@
+def f(edges):
+    # dict comprehension unpacking the tuple keys of a parameter dict
+    nodes = {v: 0 for u, v in edges}
+    # nested-tuple target over the same parameter dict's items
+    total = 0
+    for (u, v), w in edges.items():
+        total += u + v + w
+    return len(nodes) + total
+
+
+assert f({(0, 1): 10, (1, 2): 20}) == 36

--- a/regression/python/param_dict_tuple_comp/test.desc
+++ b/regression/python/param_dict_tuple_comp/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/param_dict_tuple_comp_fail/main.py
+++ b/regression/python/param_dict_tuple_comp_fail/main.py
@@ -1,0 +1,9 @@
+def f(edges):
+    nodes = {v: 0 for u, v in edges}
+    total = 0
+    for (u, v), w in edges.items():
+        total += u + v + w
+    return len(nodes) + total
+
+
+assert f({(0, 1): 10, (1, 2): 20}) == 37

--- a/regression/python/param_dict_tuple_comp_fail/test.desc
+++ b/regression/python/param_dict_tuple_comp_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/param_dict_tuple_iter/main.py
+++ b/regression/python/param_dict_tuple_iter/main.py
@@ -1,0 +1,9 @@
+def f(edges):
+    s = 0
+    for u, v in edges:
+        s += u * 10 + v
+    _ = edges.items()  # structural marker: edges is a dict
+    return s
+
+
+assert f({(1, 2): 0, (3, 4): 0}) == 46

--- a/regression/python/param_dict_tuple_iter/test.desc
+++ b/regression/python/param_dict_tuple_iter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/param_dict_tuple_iter_fail/main.py
+++ b/regression/python/param_dict_tuple_iter_fail/main.py
@@ -1,0 +1,9 @@
+def f(edges):
+    s = 0
+    for u, v in edges:
+        s += u * 10 + v
+    _ = edges.items()
+    return s
+
+
+assert f({(1, 2): 0, (3, 4): 0}) == 45

--- a/regression/python/param_dict_tuple_iter_fail/test.desc
+++ b/regression/python/param_dict_tuple_iter_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -913,6 +913,87 @@ class CoreVisitorsMixin:
                     and n.func.value.id in candidates):
                 self.known_variable_types[n.func.value.id] = "dict"
 
+        # Recover the concrete key/value types of each structurally-inferred
+        # parameter dict from its call sites, so iteration/comprehension over it
+        # resolves tuple/scalar element types instead of erasing them (#5444).
+        positional = list(node.args.posonlyargs) + list(node.args.args)
+        for idx, arg in enumerate(positional):
+            name = arg.arg
+            if (arg.annotation is None and name not in self.variable_annotations
+                    and self.known_variable_types.get(name) == "dict"):
+                recovered = self._recover_param_dict_annotation(node.name, idx)
+                if recovered is not None:
+                    self.variable_annotations[name] = recovered
+
+    def _recover_param_dict_annotation(self, func_name, param_index):
+        """Recover a parameter dict's dict[K, V] annotation from its call sites.
+
+        Returns the inferred annotation node only when every direct call to
+        ``func_name`` passes, at ``param_index``, a dict literal or a name bound
+        to a dict literal whose inferred dict[K, V] type is identical. If any
+        call site is unknown or the shapes disagree, returns None so the
+        parameter stays untyped (a sound refusal rather than a wrong guess).
+        """
+        calls = self._dict_param_call_shapes.get(func_name, [])
+        candidates = []
+        for shapes in calls:
+            # A call that does not supply this parameter positionally (keyword
+            # arg, splat, too few args) leaves its shape unknown, which forces a
+            # refusal rather than silently trusting the remaining call sites.
+            candidates.append(shapes[param_index] if param_index < len(shapes) else None)
+        if not candidates or any(c is None for c in candidates):
+            return None
+        dumps = {ast.dump(c) for c in candidates}
+        return candidates[0] if len(dumps) == 1 else None
+
+    def _build_dict_annotation_from_literal(self, dict_node):
+        """Build a concrete dict[K, V] annotation node from a dict literal.
+
+        Returns None when either the key or value type cannot be inferred from
+        the literal's first entry, so callers treat the shape as unknown.
+        """
+        if not dict_node.keys or not dict_node.values or dict_node.keys[0] is None:
+            return None
+        key_ann = self._infer_dict_key_annotation(dict_node.keys[0])
+        val_ann = self._infer_dict_value_annotation(dict_node.values[0])
+        if key_ann is None or val_ann is None:
+            return None
+        return ast.Subscript(
+            value=ast.Name(id="dict", ctx=ast.Load()),
+            slice=ast.Tuple(elts=[key_ann, val_ann], ctx=ast.Load()),
+            ctx=ast.Load(),
+        )
+
+    def _infer_dict_key_annotation(self, key_node):
+        """Build a full key-type annotation node (preserving tuple element types).
+
+        Unlike _infer_dict_key_type, a tuple key yields the nested
+        tuple[A, B, ...] annotation rather than the bare name 'tuple', so the
+        recovered parameter dict carries the concrete struct shape. Returns None
+        for anything not statically known.
+        """
+        if isinstance(key_node, ast.Constant):
+            value = key_node.value
+            if isinstance(value, bool):
+                return ast.Name(id="bool", ctx=ast.Load())
+            if isinstance(value, float):
+                return ast.Name(id="float", ctx=ast.Load())
+            if isinstance(value, int):
+                return ast.Name(id="int", ctx=ast.Load())
+            if isinstance(value, str):
+                return ast.Name(id="str", ctx=ast.Load())
+            return None
+        if isinstance(key_node, ast.Tuple):
+            elt_anns = [self._infer_dict_key_annotation(e) for e in key_node.elts]
+            if not elt_anns or any(e is None for e in elt_anns):
+                return None
+            return ast.Subscript(
+                value=ast.Name(id="tuple", ctx=ast.Load()),
+                slice=ast.Tuple(elts=elt_anns, ctx=ast.Load()),
+                ctx=ast.Load(),
+            )
+        return None
+
     def _build_qualified_function_name(self, node):
         if hasattr(self, "current_class_name") and self.current_class_name:
             return f"{self.current_class_name}.{node.name}"
@@ -1042,7 +1123,15 @@ class CoreVisitorsMixin:
             # means the name was rebound away from a dict; do not treat a stale
             # dict-literal binding as a dict.
             return False
-        return name in self.dict_literal_vars
+        if name in self.dict_literal_vars:
+            return True
+        # An unannotated parameter recovered as a dict by structural inference
+        # (a .items()/.keys()/.values() call on it in the body — see
+        # _infer_dict_params_structurally) is a reliable dict too, so dict-view
+        # comprehensions and bare-dict iteration over a parameter dict desugar
+        # through the for-loop key-iteration path instead of reaching the C++
+        # dict-comp handler, which cannot consume a dict struct (#5444).
+        return self.known_variable_types.get(name) == "dict"
 
     def _maybe_rewrite_dict_to_list_call(self, node):
         """Rewrite list(d) -> d.keys() and sorted(d, ...) -> sorted(d.keys(), ...).
@@ -1120,6 +1209,10 @@ class CoreVisitorsMixin:
         # an unannotated dict parameter recorded in one function must not make a
         # same-named plain parameter in another function look like a dict (#5444).
         saved_known_types = dict(self.known_variable_types)
+        # Recovered parameter-dict annotations (#5444) are scope-local too: a
+        # synthesized dict[K, V] for a parameter in one function must not leak
+        # onto a same-named parameter elsewhere.
+        saved_var_anns = dict(self.variable_annotations)
         # Per-function scope for call-origin tracking and the eq-only set.
         saved_call_origins = dict(self._assignment_call_origins)
         self._assignment_call_origins.clear()
@@ -1157,5 +1250,6 @@ class CoreVisitorsMixin:
         finally:
             self.dict_literal_vars = saved_dict_vars
             self.known_variable_types = saved_known_types
+            self.variable_annotations = saved_var_anns
             self._assignment_call_origins = saved_call_origins
             self._eq_only_items_view_targets = saved_eq_only

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1481,8 +1481,8 @@ class LoopMixin:
         tmp_name = f"ESBMC_items_elt_{list_var}"
         # Keep the full tuple annotation (tuple[A, B]) for the temp when known,
         # so the key/value struct type is concrete instead of erased (#5444).
-        tuple_ann = (elem_ann if self._is_concrete_tuple_ann(elem_ann)
-                     else ast.Name(id="tuple", ctx=ast.Load()))
+        tuple_ann = (elem_ann if self._is_concrete_tuple_ann(elem_ann) else ast.Name(
+            id="tuple", ctx=ast.Load()))
         body.append(
             self._create_var_subscript_assign(node, tmp_name, list_var, index_var, tuple_ann))
         unpack = ast.Assign(
@@ -1790,20 +1790,20 @@ class LoopMixin:
         # crashing on the unpack (#5444). Scoped to dicts whose key annotation
         # is concrete; a bare/unknown key type falls through to the existing
         # scalar-key handling below.
-        if (annotation_id in ["dict", "Dict"]
-                and isinstance(node.target, (ast.Tuple, ast.List))
+        if (annotation_id in ["dict", "Dict"] and isinstance(node.target, (ast.Tuple, ast.List))
                 and isinstance(node.iter, ast.Name)):
             key_ann, _ = self._get_dict_kv_types(node.iter.id)
             if self._get_base_type_name(key_ann) not in ("Any", None):
                 keys_var = f"ESBMC_keys_{loop_id}"
                 list_ann = ast.Subscript(value=ast.Name(id="list", ctx=ast.Load()),
-                                         slice=key_ann, ctx=ast.Load())
+                                         slice=key_ann,
+                                         ctx=ast.Load())
                 keys_assign = ast.AnnAssign(
                     target=ast.Name(id=keys_var, ctx=ast.Store()),
                     annotation=list_ann,
-                    value=ast.Call(
-                        func=ast.Attribute(value=node.iter, attr="keys", ctx=ast.Load()),
-                        args=[], keywords=[]),
+                    value=ast.Call(func=ast.Attribute(value=node.iter, attr="keys", ctx=ast.Load()),
+                                   args=[],
+                                   keywords=[]),
                     simple=1,
                 )
                 self.ensure_all_locations(keys_assign, node)

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1326,6 +1326,14 @@ class LoopMixin:
             return annotation.slice.elts[0], annotation.slice.elts[1]
         return self._any_ann(), self._any_ann()
 
+    def _is_concrete_tuple_ann(self, ann_node):
+        """True for a full tuple[A, B, ...] annotation node (not the bare name
+        'tuple'). Such annotations must be preserved end-to-end so the C++ list
+        subscript read rebuilds the concrete tuple struct instead of erasing it
+        to void* (#5444)."""
+        return (isinstance(ann_node, ast.Subscript)
+                and self._get_base_type_name(ann_node) in ("tuple", "Tuple"))
+
     def _get_base_type_name(self, ann_node):
         """Return the base type name string from an annotation node.
 
@@ -1397,10 +1405,19 @@ class LoopMixin:
         (produced by _create_var_subscript_assign).
         """
         base_name = self._get_base_type_name(elem_ann)
-        actual_base = base_name if base_name and base_name != "Any" else "Any"
+        # Tuple element types must keep their FULL annotation (list[tuple[A, B]]),
+        # not flatten to the base name 'tuple', so the C++ list subscript read
+        # rebuilds the concrete tuple struct instead of erasing it to void* and
+        # crashing on the unpack (#5444). Other element types (dict, scalars)
+        # keep the base-name form so get_typet(base) resolves correctly.
+        if self._is_concrete_tuple_ann(elem_ann):
+            slice_node = elem_ann
+        else:
+            actual_base = base_name if base_name and base_name != "Any" else "Any"
+            slice_node = ast.Name(id=actual_base, ctx=ast.Load())
         annotation = ast.Subscript(
             value=ast.Name(id="list", ctx=ast.Load()),
-            slice=ast.Name(id=actual_base, ctx=ast.Load()),
+            slice=slice_node,
             ctx=ast.Load(),
         )
         method_call = ast.Call(
@@ -1462,7 +1479,10 @@ class LoopMixin:
             return
 
         tmp_name = f"ESBMC_items_elt_{list_var}"
-        tuple_ann = ast.Name(id="tuple", ctx=ast.Load())
+        # Keep the full tuple annotation (tuple[A, B]) for the temp when known,
+        # so the key/value struct type is concrete instead of erased (#5444).
+        tuple_ann = (elem_ann if self._is_concrete_tuple_ann(elem_ann)
+                     else ast.Name(id="tuple", ctx=ast.Load()))
         body.append(
             self._create_var_subscript_assign(node, tmp_name, list_var, index_var, tuple_ann))
         unpack = ast.Assign(
@@ -1761,6 +1781,40 @@ class LoopMixin:
 
         # Get element type for proper annotation
         element_type = self._get_element_type_from_container(annotation_id, node.iter)
+
+        # Tuple-unpacking iteration over a dict's keys (for u, v in d): the keys
+        # are tuples, so materialize d.keys() into an annotated
+        # list[<key_ann>] intermediate first. That lets the C++ list subscript
+        # read recover the concrete tuple element type from the list annotation
+        # (the working list-of-tuples path) instead of erasing it to void* and
+        # crashing on the unpack (#5444). Scoped to dicts whose key annotation
+        # is concrete; a bare/unknown key type falls through to the existing
+        # scalar-key handling below.
+        if (annotation_id in ["dict", "Dict"]
+                and isinstance(node.target, (ast.Tuple, ast.List))
+                and isinstance(node.iter, ast.Name)):
+            key_ann, _ = self._get_dict_kv_types(node.iter.id)
+            if self._get_base_type_name(key_ann) not in ("Any", None):
+                keys_var = f"ESBMC_keys_{loop_id}"
+                list_ann = ast.Subscript(value=ast.Name(id="list", ctx=ast.Load()),
+                                         slice=key_ann, ctx=ast.Load())
+                keys_assign = ast.AnnAssign(
+                    target=ast.Name(id=keys_var, ctx=ast.Store()),
+                    annotation=list_ann,
+                    value=ast.Call(
+                        func=ast.Attribute(value=node.iter, attr="keys", ctx=ast.Load()),
+                        args=[], keywords=[]),
+                    simple=1,
+                )
+                self.ensure_all_locations(keys_assign, node)
+                ast.fix_missing_locations(keys_assign)
+                self.variable_annotations[keys_var] = list_ann
+                node.iter = ast.Name(id=keys_var, ctx=ast.Load())
+                self.ensure_all_locations(node.iter, node)
+                inner = self._transform_iterable_for(node)
+                if not isinstance(inner, list):
+                    inner = [inner]
+                return [keys_assign] + inner
 
         # Handle dict iteration
         if annotation_id in ["dict", "Dict"]:

--- a/src/python-frontend/preprocessor/module_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/module_rewrite_mixin.py
@@ -311,6 +311,90 @@ class ModuleRewriteMixin:
             elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
                 self.variable_annotations[stmt.target.id] = stmt.annotation
 
+        self._scan_dict_literal_bindings_and_calls(node)
         self.attr_list_element_classes = self._scan_attr_list_element_classes(node)
         self.module_dunder_all = self._capture_dunder_all(node)
         self.apply_range_rewrites(node, alias_seed=alias_seed, wrapper_seed=wrapper_seed)
+
+    def _scan_dict_literal_bindings_and_calls(self, node):
+        """Collect evidence for parameter-dict element recovery (#5444).
+
+        For each scope (the module body and every function body, independently)
+        records its dict-literal name bindings, then resolves each direct
+        ``name(...)`` call's positional arguments against that scope's bindings
+        (falling back to the module scope for free names). The result maps a
+        function name to its per-call list of argument dict[K, V] shapes, which
+        _recover_param_dict_annotation collapses only when every call agrees —
+        keeping the inference sound and scope-correct (a function-local dict
+        never poisons a same-named module global).
+        """
+        self._dict_param_call_shapes = {}
+        module_binds, module_locals = self._collect_scope_dict_binds(node.body)
+        self._record_scope_calls(node.body, module_binds, module_locals, module_binds)
+        for n in ast.walk(node):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                local_binds, local_names = self._collect_scope_dict_binds(n.body)
+                self._record_scope_calls(n.body, local_binds, local_names, module_binds)
+
+    @staticmethod
+    def _walk_scope(stmts):
+        """Yield AST nodes within ``stmts`` without crossing into a nested
+        function/class/lambda scope (which binds its own names)."""
+        stack = list(stmts)
+        while stack:
+            n = stack.pop()
+            yield n
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda,
+                              ast.ClassDef)):
+                continue
+            stack.extend(ast.iter_child_nodes(n))
+
+    def _collect_scope_dict_binds(self, stmts):
+        """Map names bound to a dict literal in this scope to their dict[K, V]
+        annotation. A name reassigned to a conflicting shape or to a non-dict is
+        poisoned (dropped) so it is never used as recovery evidence. Returns
+        (bindings, all-assigned-names)."""
+        binds = {}
+        poisoned = set()
+        assigned = set()
+        for n in self._walk_scope(stmts):
+            if isinstance(n, ast.Assign):
+                names = [t.id for t in n.targets if isinstance(t, ast.Name)]
+                value = n.value
+            elif isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name):
+                names = [n.target.id]
+                value = n.value
+            else:
+                continue
+            ann = (self._build_dict_annotation_from_literal(value)
+                   if isinstance(value, ast.Dict) else None)
+            for name in names:
+                assigned.add(name)
+                if name in poisoned:
+                    continue
+                if ann is None or (name in binds and ast.dump(binds[name]) != ast.dump(ann)):
+                    poisoned.add(name)
+                    binds.pop(name, None)
+                else:
+                    binds[name] = ann
+        return binds, assigned
+
+    def _record_scope_calls(self, stmts, local_binds, local_names, module_binds):
+        """Record the per-call positional dict shapes for every direct call in
+        this scope, resolving Name arguments against the local bindings (or the
+        module bindings for free names)."""
+        for n in self._walk_scope(stmts):
+            if not (isinstance(n, ast.Call) and isinstance(n.func, ast.Name)):
+                continue
+            shapes = []
+            for arg in n.args:
+                if isinstance(arg, ast.Dict):
+                    shapes.append(self._build_dict_annotation_from_literal(arg))
+                elif isinstance(arg, ast.Name):
+                    if arg.id in local_names:
+                        shapes.append(local_binds.get(arg.id))
+                    else:
+                        shapes.append(module_binds.get(arg.id))
+                else:
+                    shapes.append(None)
+            self._dict_param_call_shapes.setdefault(n.func.id, []).append(shapes)

--- a/src/python-frontend/preprocessor/module_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/module_rewrite_mixin.py
@@ -344,8 +344,7 @@ class ModuleRewriteMixin:
         while stack:
             n = stack.pop()
             yield n
-            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda,
-                              ast.ClassDef)):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
                 continue
             stack.extend(ast.iter_child_nodes(n))
 

--- a/src/python-frontend/preprocessor/preprocessor_state_mixin.py
+++ b/src/python-frontend/preprocessor/preprocessor_state_mixin.py
@@ -45,6 +45,14 @@ class PreprocessorStateMixin:
         # Names currently bound to a dict literal (any key types). Used to
         # rewrite list(d)/sorted(d) into the correctly-typed d.keys() path.
         self.dict_literal_vars = set()
+        # Pre-pass results for unannotated parameter-dict element recovery
+        # (#5444): function name -> list of per-call positional shape lists,
+        # where each entry is the inferred dict[K, V] annotation of that
+        # argument (or None when unknown). Argument names are resolved within
+        # the scope of their call site so a function-local dict never poisons a
+        # same-named module global. Recovery succeeds only when every call site
+        # agrees (see _recover_param_dict_annotation).
+        self._dict_param_call_shapes = {}
         self.bound_method_vars = {}
         self.called_names = set()
         self.list_literal_values = {}


### PR DESCRIPTION
## What

Makes iteration, comprehension, and `.items()` unpacking over an **unannotated parameter dict with tuple or scalar keys** sound. Previously a tuple-keyed dict passed into an unannotated parameter lost its key element types across the call boundary, so:

```python
def shortest_paths(source, weight_by_edge):
    wbn = {v: 100 for u, v in weight_by_edge}          # dict-comp, tuple-key unpack
    for (u, v), weight in weight_by_edge.items():      # nested .items() unpack
        ...
```

crashed (`symbolic_type_excp` / "Cannot unpack pointer") or produced wrong verdicts.

## How (preprocessor-only, two phases)

1. **Routing** — tuple-key dict iteration / comprehension / nested `.items()` now go through the already-working *annotated list-of-tuples* for-loop path instead of the C++ dict-comp handler that erases tuple key types. `d.keys()` is materialized into an annotated `list[<key>]` intermediate, and the full `tuple[A,B]` annotation is preserved end-to-end.
2. **Recovery** — an unannotated parameter dict's concrete `dict[K,V]` is recovered from its call sites. Resolution is **scope-aware** (a `Name` argument is resolved within its own scope, so a function-local dict never poisons a same-named module global) and **sound**: recovery succeeds only when every call site agrees; ambiguous or unknown shapes stay a clean ERROR rather than a wrong guess.

This follows the issue's own guidance (use runtime-type-driven reads / reuse the for-loop path, never guess element types statically).

## Scope

Fixes **scalar-key** and **int-tuple-key** parameter dicts. The string-keyed `quixbugs/shortest_paths` headline stays `KNOWNBUG`, blocked by an **orthogonal** bug — annotation-built tuple structs mis-type `str` members as `char[0]` (affects any annotated `tuple[str, ...]`, not just dicts) — filed as #5571.

## Testing

- 4 new CORE tests: `param_dict_tuple_{comp,iter}{,_fail}`.
- 218 relevant regression tests (dict, loop/list, tuple/str subsets) pass; no regressions.
- Code review found 0 verification-soundness issues; the one robustness finding (cross-scope poisoning) is fixed by the scope-aware resolution above.

Fixes part of #5444.
