### PR TITLE
[python] V.3: build not-negations over synthetic bools in IREP2

### DIFF
--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -3550,8 +3550,7 @@ exprt python_dict_handler::compare(
 
   if (op == "NotEq")
   {
-    exprt negated("not", bool_type());
-    negated.move_to_operands(result);
+    exprt negated = build_not(result);
     negated.location() = location;
     return negated;
   }

--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -126,6 +126,16 @@ exprt build_index(const exprt &arr, const exprt &idx)
   return build_index(arr, idx, arr.type().subtype());
 }
 
+// `not op`, `op` a bool-typed value. migrate lowers a legacy "not" node to
+// not2tc(migrate(op)) (util/migrate.cpp i_not path), so this is the
+// byte-identical round-trip.
+exprt build_not(const exprt &op)
+{
+  expr2tc op2;
+  migrate_expr(op, op2);
+  return migrate_expr_back(not2tc(op2));
+}
+
 // `a < b` over synthetic same-width operands. migrate lowers a legacy "<" node
 // to lessthan2tc(migrate(a), migrate(b)) with no coercion (util/migrate.cpp
 // i_lt path), so this is the byte-identical round-trip.

--- a/src/python-frontend/python_expr_builder.h
+++ b/src/python-frontend/python_expr_builder.h
@@ -55,6 +55,10 @@ exprt build_index(const exprt &arr, const exprt &idx, const typet &t);
 // `arr[idx]` with element type taken from the source array's subtype.
 exprt build_index(const exprt &arr, const exprt &idx);
 
+// Boolean negation `not op`, `op` a bool-typed value. migrate lowers a legacy
+// "not" node to not2tc(migrate(op)), so this is the byte-identical round-trip.
+exprt build_not(const exprt &op);
+
 // `a < b` over same-width operands (lessthan2t asserts width consistency).
 exprt build_less_than(const exprt &a, const exprt &b);
 

--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -933,11 +933,7 @@ void python_set::emit_filtered_extend(
 
   exprt guard = build_symbol(contains_result);
   if (!want_in_ref)
-  {
-    exprt neg("not", bool_type());
-    neg.copy_to_operands(guard);
-    guard = neg;
-  }
+    guard = build_not(guard);
 
   code_blockt then_block;
   then_block.copy_to_operands(converter.convert_expression_to_code(push_call));
@@ -1052,10 +1048,7 @@ exprt python_set::build_set_relation_call(
   if (disjoint)
     trigger = build_symbol(in);
   else
-  {
-    trigger = exprt("not", bool_type());
-    trigger.copy_to_operands(build_symbol(in));
-  }
+    trigger = build_not(build_symbol(in));
   code_blockt then_block;
   then_block.copy_to_operands(
     code_assignt(build_symbol(result), gen_boolean(false)));


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

Adds a shared `build_not` helper to the `python_expr` builder module and
redirects the three `not` sites whose operand is a **synthetic boolean** to
the IREP2 round-trip:

- `python_set.cpp` — `emit_filtered_extend` membership guard (`build_symbol(contains_result)`)
- `python_set.cpp` — `build_set_relation_call` disjoint/subset/superset trigger (`build_symbol(in)`)
- `python_dict_handler.cpp` — `compare` NotEq result (`build_symbol(result_var)`)

Each previously built a legacy `exprt("not") + copy_to_operands`; they now call
`build_not`, which is `migrate_expr_back(not2tc(migrate(op)))`.

### Why it is behaviour-preserving (byte-identical)

`migrate` lowers a legacy bool `not` node to `not2tc(migrate(op0))`
(`util/migrate.cpp`, `i_not` path, which also asserts the operand is bool), so
the round-trip reproduces the exact node goto-convert would build. All three
operands are `bool_type()` temporaries.

### What stays legacy (by design)

The four `not` sites whose operand is a general **user** expression — is-none
inequality (`converter_compare.cpp`), the BoolOp short-circuit negation and the
conditional-test wrapper (`converter_stmt.cpp`), and tuple lexicographic
negation (`converter_binop.cpp`) — keep the legacy node. Their operands can
carry an unresolved `member`/`index` that aborts `migrate_expr` (the F-P11
general-operand wall, pending the V.4+ IREP2-native adjuster).

### Validation

- Build clean; full `regression/python/(set|dict)` subset: **215/215 passed**
  (covers `set_intersection`/`set_difference`, `set-isdisjoint`/`set-issuperset`,
  dict comparisons).
- Direct probes: set `not in` and dict `!=` verify SUCCESSFUL with correct verdicts.
- clang-format (Clang 11) clean.

Refs #4715.