### PR TITLE
[python] V.3: build str.endswith length/offset arithmetic in IREP2

### DIFF
--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -1024,17 +1024,15 @@ exprt string_handler::handle_string_endswith(
     build_call_expr(*strlen_symbol, size_type(), {suffix_addr});
   suffix_strlen_call.location() = location;
 
-  // Check if suffix is longer than string
-  exprt len_check(">", bool_type());
-  len_check.copy_to_operands(suffix_strlen_call, str_strlen_call);
+  // Check if suffix is longer than string. Both operands are synthetic
+  // size_type strlen() results, so build the comparison in IREP2 (V.3).
+  exprt len_check = build_greater_than(suffix_strlen_call, str_strlen_call);
 
   // Calculate offset: strlen(str) - strlen(suffix)
-  exprt offset("-", size_type());
-  offset.copy_to_operands(str_strlen_call, suffix_strlen_call);
+  exprt offset = build_sub(str_strlen_call, suffix_strlen_call, size_type());
 
   // Get pointer to the position: str + offset
-  exprt offset_ptr("+", gen_pointer_type(char_type()));
-  offset_ptr.copy_to_operands(str_addr, offset);
+  exprt offset_ptr = build_add(str_addr, offset, gen_pointer_type(char_type()));
 
   // Find strncmp symbol
   symbolt *strncmp_symbol = find_cached_c_function_symbol("c:@F@strncmp");


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`handle_string_endswith` (`string_method_handler.cpp`) still built three
intermediate nodes with legacy `exprt(...)` + `copy_to_operands`:

- the suffix-longer-than-string check `suffix_len > str_len` (`>`)
- the offset `strlen(str) - strlen(suffix)` (`-`)
- the position pointer `str + offset` (`+`)

All three operands are **synthetic** — `strlen` OM-call results of `size_type`
and the resolved string base address — so they now go through the existing
`build_greater_than` / `build_sub` / `build_add` shared helpers (migrate the
operands, build the IREP2 node, back-migrate once).

### Why it is behaviour-preserving (byte-identical)

`migrate` lowers a legacy `>`/`-`/`+` node to `greaterthan2tc`/`sub2tc`/`add2tc`
over the migrated operands with no coercion, so the round-trip reproduces the
exact node goto-convert would build. The widths are consistent (`size_type` for
the relational/subtraction operands; pointer + `size_type`, both 64-bit, for the
position pointer). This mirrors `handle_string_startswith`, which is already
IREP2 on this surface.

### Validation

- Build clean; `string-endswith` (THOROUGH/Linux-only) runs `VERIFICATION
  SUCCESSFUL` directly; `string`/`str_` regression subset **433/433 passed**.
- Probe covering match / no-match / suffix-longer-than-string / empty suffix /
  single-char suffix all verify SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.