### PR TITLE
[python] V.3: build affix-tuple disjunction in IREP2

### DIFF
--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -161,6 +161,17 @@ exprt build_greater_equal(const exprt &a, const exprt &b)
   return migrate_expr_back(greaterthanequal2tc(a2, b2));
 }
 
+// `a || b`, both operands bool-typed. migrate lowers a legacy binary "or" node
+// to or2tc(migrate(a), migrate(b)) (util/migrate.cpp i_or path), so this is the
+// byte-identical round-trip.
+exprt build_or(const exprt &a, const exprt &b)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(or2tc(a2, b2));
+}
+
 exprt build_add(const exprt &a, const exprt &b, const typet &t)
 {
   expr2tc a2, b2;

--- a/src/python-frontend/python_expr_builder.h
+++ b/src/python-frontend/python_expr_builder.h
@@ -68,6 +68,11 @@ exprt build_greater_than(const exprt &a, const exprt &b);
 // consistency).
 exprt build_greater_equal(const exprt &a, const exprt &b);
 
+// Boolean disjunction `a || b`, both operands bool-typed. migrate lowers a
+// legacy binary "or" node to or2tc(migrate(a), migrate(b)), so this is the
+// byte-identical round-trip.
+exprt build_or(const exprt &a, const exprt &b);
+
 // `a + b : t` over same-width operands (add2t asserts width consistency).
 exprt build_add(const exprt &a, const exprt &b, const typet &t);
 

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -896,9 +896,9 @@ exprt string_handler::build_affix_tuple_match(
     exprt one = is_suffix
                   ? handle_string_endswith(string_obj, elem, location)
                   : handle_string_startswith(string_obj, elem, location);
-    exprt disjunction("or", bool_type());
-    disjunction.copy_to_operands(result, one);
-    result = disjunction;
+    // result and one are synthetic bools (constant / startswith-endswith
+    // results), so build the disjunction in IREP2 (V.3).
+    result = build_or(result, one);
   }
   return result;
 }


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

Adds a shared `build_or` helper to the `python_expr` builder module and uses it
for the OR-chain in `build_affix_tuple_match` — the `s.startswith((...))` /
`s.endswith((...))` tuple-of-affixes match, which is True iff any element
matches. Each iteration previously built a legacy binary `exprt("or")` +
`copy_to_operands`.

### Why it is behaviour-preserving (byte-identical)

Both operands are **synthetic booleans**: the running `result` (a bool constant,
then prior OR-results) and the per-element `handle_string_startswith` /
`handle_string_endswith` match — itself a back-migrated `or2tc` / `and2tc`.
`migrate` lowers a legacy binary `or` node to `or2tc(migrate(a), migrate(b))`
(`util/migrate.cpp`, `i_or` path, which also asserts bool operands), so the
round-trip reproduces the exact node goto-convert would build.

### Validation

- Build clean; `python/str` regression sweep **442/442 passed**.
- `str_startswith_tuple` (exercises both `startswith((...))` and
  `endswith((...))`) passes.
- Probe over startswith/endswith tuple match (any-match true, none-match false)
  verifies SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.