### PR TITLE
[python] Support list("abc") and reject list(bytes) cleanly

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1308,3 +1308,57 @@ model" entries. The §3 design-level blockers, §3c policy-banned timeouts, §3d
 expectation, and the infeasible `hashlib` case all stand. No further isolated, soundly-fixable
 point fix beyond those candidates is available on current `master` without the §5 architectural
 work; the §5 priority order stands.
+
+---
+
+> **Note on numbering.** §16–§29 (PRs #5526, #5531, #5532, #5536, #5537, #5540, #5543, #5548,
+> #5554, #5555, #5556, #5558, #5562, #5563) precede this section; this sweep is appended as §30.
+> Its fix is in flight as PR #5577 and not yet on `master`.
+
+## 30. 2026-06-24 re-validation (twentieth sweep) & list(str) constructor
+
+Re-test against current `master` (tip `8567a816e2`). KNOWNBUG classification unchanged — §3 holds.
+This sweep implemented the `list("abc")` candidate named in §29b — the direct sibling of §29's
+`tuple(str)`, on the `list()` constructor path.
+
+### 30a. New isolated, soundly-fixable defect found & fixed
+**`list("abc")` (the `list()` constructor over a constant string) crashed with `migrate expr
+failed`.**
+
+CPython yields `list("ab") == ['a', 'b']`, but ESBMC crashed: the string array fell through the
+`list()` operand dispatch (which handled empty / `range` / list-typed / tuple operands) into the
+generic call builder, which mistyped the `char` array as a `PyListObject` pointer.
+
+**Fix** (`converter/converter_funcall.cpp`): in the `list(...)` handler, fold a constant-string
+operand to a `List` AST of single-character `Constant`s and recurse through the proven `[]`
+list-literal path (reusing `build_char_sequence_node`, hoisted from §29's `tuple(str)` fix in
+`function_call/expr.cpp` into the dependency-free `json_utils.h` as a template — a net
+de-duplication). The fold is gated on a char-element operand (`subtype() == char_type()`), so a
+`bytes` literal — modelled as a 64-bit int array (`type_handler.cpp` `build_array(long_long_int
+_type())`) — is excluded: CPython `list(b"ab") == [97, 98]` (ints), not chars.
+
+**Code review (the same boundary §29 flagged) recommended pinning the bytes case.** `list(b"ab")`
+previously fell through to the generic builder and *crashed* (`migrate expr failed`); it is now
+rejected with a clean `ERROR: list() over a bytes object is not supported; bytes elements are
+integers, not characters` (exit 254) — a §5-item-5 crash→diagnostic that also pins the str-only
+soundness boundary of the fold, mirroring §29's `tuple_from_bytes_unsupported`.
+
+This **restores a working feature** (`list(str)` now verifies with the right elements) and removes
+an adjacent crash. New regression tests `regression/python/list_from_str{,_fail}` (CORE) and
+`list_from_bytes_unsupported`; the positive `list_from_str` test is the **Py-Live** liveness
+witness for both added branches (pre-fix it crashed). Verified bit-for-bit against CPython for
+literal/variable/empty-string and the `list(list)`/`list(tuple)` non-regression; CPython sanity
+passes; the focused `regression/python/{list,tuple,str,string}*` ctest subset (739 tests) shows
+zero new failures (the 50 failing are the pre-existing `--z3`/`--ir`/`--boolector` environmental
+set on this Bitwuzla-only `ENABLE_Z3=OFF` build). Code-reviewed (0 critical/major). Solver-agnostic
+(constant-fold + dispatch guard in the frontend, no SMT-encoding change).
+
+### 30b. Next candidate & everything else: unchanged disposition
+The `list(str)`/`tuple(str)` char-sequence lowering is now complete on both constructor paths. The
+obvious **next candidate** is `str.encode()` / `bytes.decode()` / `bytes.hex()` — the bytes/encoding
+family deferred since §22b–§29b (the now-clean `list(bytes)`/`tuple(bytes)` boundaries make a proper
+bytes-iteration model the natural next step). Other deferred candidates stand: `zip()` (unmodelled),
+symbolic/user-function `max`/`min(key=)`, `list.index()`-in-`try/except`, `int.to_bytes()`,
+`str.maketrans`/`translate`, `float.hex()` (infeasible), `str.isascii()` (string-soundness), and the
+numeric-tower *properties*. The §3 design-level blockers, §3c timeouts, §3d questionable
+expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.

--- a/regression/python/list_from_bytes_unsupported/main.py
+++ b/regression/python/list_from_bytes_unsupported/main.py
@@ -1,0 +1,4 @@
+# list(bytes) would be a list of ints in CPython (list(b"ab") == [97, 98]),
+# which is not modelled. It must be rejected with a clean error rather than
+# silently reusing the list(str) char-string lowering (a wrong verdict).
+x = list(b"ab")

--- a/regression/python/list_from_bytes_unsupported/test.desc
+++ b/regression/python/list_from_bytes_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: list\(\) over a bytes object is not supported; bytes elements are integers, not characters$

--- a/regression/python/list_from_str/main.py
+++ b/regression/python/list_from_str/main.py
@@ -1,0 +1,22 @@
+def main() -> None:
+    # list() over a string yields a list of single-character strings.
+    x = list("abc")
+    assert x[0] == "a" and x[1] == "b" and x[2] == "c" and len(x) == 3
+
+    # A string held in a variable works too.
+    s = "hi"
+    y = list(s)
+    assert y[0] == "h" and y[1] == "i" and len(y) == 2
+
+    # An empty string yields an empty list.
+    e = list("")
+    assert len(e) == 0
+
+    # list() over a list / tuple is unaffected.
+    z = list([1, 2])
+    assert z[0] == 1 and z[1] == 2 and len(z) == 2
+    w = list((3, 4))
+    assert w[0] == 3 and w[1] == 4 and len(w) == 2
+
+
+main()

--- a/regression/python/list_from_str/test.desc
+++ b/regression/python/list_from_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_from_str_fail/main.py
+++ b/regression/python/list_from_str_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    x = list("abc")
+    # x == ['a', 'b', 'c']; x[0] is "a", not "z".
+    assert x[0] == "z"
+
+
+main()

--- a/regression/python/list_from_str_fail/test.desc
+++ b/regression/python/list_from_str_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -345,8 +345,37 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     // mistypes it as a list (wrong elements / out-of-bounds dereference).
     if (get_tuple_handler().is_tuple_type(arg_expr.type()))
       return python_list::build_list_from_tuple(*this, arg_expr, element);
+
+    // list("abc") — a constant string yields a list of single-character
+    // strings (CPython: list("ab") == ['a', 'b']). Lower to a list literal so
+    // it routes through the proven `[]` path. Gate on a genuine string
+    // (char-element) operand: a bytes literal serialises to an identical
+    // Constant JSON, but list(b"ab") is [97, 98] in CPython — its operand type
+    // is an int array (not char), so it correctly falls through to the error.
+    const typet &arg_t = arg_expr.type();
+    const bool is_string_operand = (arg_t.is_array() || arg_t.is_pointer()) &&
+                                   arg_t.subtype() == char_type();
+    std::string str_val;
+    if (
+      is_string_operand &&
+      string_handler::extract_constant_string(list_arg, *this, str_val))
+      return get_expr(build_char_sequence_node("List", str_val, element));
+
+    // list(b"ab") — a bytes literal serialises to the same Constant JSON as a
+    // str, so it also extracts as a constant string, but CPython yields the
+    // int list [97, 98], not a char list. Its operand type is a (non-char) int
+    // array, so it is excluded above; reject it here with a clean diagnostic
+    // rather than letting the byte array reach the generic builder, which
+    // mistypes it as a list pointer (out-of-bounds dereference / migrate
+    // failure). This pins the str-only boundary of the fold above.
+    if (
+      arg_t.is_array() && arg_t.subtype() != char_type() &&
+      string_handler::extract_constant_string(list_arg, *this, str_val))
+      throw std::runtime_error(
+        "list() over a bytes object is not supported; bytes elements are "
+        "integers, not characters");
     // Fall through to the generic function-call builder below for non-list
-    // iterables (e.g. list("abc") or list(42)).
+    // iterables (e.g. list(42) or a non-constant string).
   }
 
   // Handle dict(iterable) constructor:

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -38,40 +38,6 @@ using namespace python_expr;
 
 namespace
 {
-// Build a List/Tuple AST node whose elements are the single-character strings
-// of @p chars. Used to lower list("abc") / tuple("abc") to the proven
-// list/tuple-literal path. Location fields are copied from @p loc_src.
-nlohmann::json build_char_sequence_node(
-  const char *kind,
-  const std::string &chars,
-  const nlohmann::json &loc_src)
-{
-  static constexpr const char *loc_keys[] = {
-    "lineno", "col_offset", "end_lineno", "end_col_offset"};
-  auto copy_loc = [&](nlohmann::json &node) {
-    for (const char *k : loc_keys)
-      if (loc_src.contains(k))
-        node[k] = loc_src[k];
-  };
-
-  nlohmann::json node;
-  node["_type"] = kind;
-  node["elts"] = nlohmann::json::array();
-  for (const char ch : chars)
-  {
-    nlohmann::json elt;
-    elt["_type"] = "Constant";
-    elt["value"] = std::string(1, ch);
-    copy_loc(elt);
-    node["elts"].push_back(elt);
-  }
-  copy_loc(node);
-  return node;
-}
-} // namespace
-
-namespace
-{
 // Constants for UTF-8 encoding
 
 // Constants for symbol parsing

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -687,6 +687,38 @@ inline std::string extract_var_name_from_symbol_id(const std::string &symbol_id)
                                         : symbol_id;
 }
 
+// Build a List/Tuple AST node whose elements are the single-character strings
+// of @p chars. Used to lower list("abc") / tuple("abc") to the proven
+// list/tuple-literal path. Location fields are copied from @p loc_src.
+template <typename JsonType>
+JsonType build_char_sequence_node(
+  const char *kind,
+  const std::string &chars,
+  const JsonType &loc_src)
+{
+  static constexpr const char *loc_keys[] = {
+    "lineno", "col_offset", "end_lineno", "end_col_offset"};
+  auto copy_loc = [&](JsonType &node) {
+    for (const char *k : loc_keys)
+      if (loc_src.contains(k))
+        node[k] = loc_src[k];
+  };
+
+  JsonType node;
+  node["_type"] = kind;
+  node["elts"] = JsonType::array();
+  for (const char ch : chars)
+  {
+    JsonType elt;
+    elt["_type"] = "Constant";
+    elt["value"] = std::string(1, ch);
+    copy_loc(elt);
+    node["elts"].push_back(elt);
+  }
+  copy_loc(node);
+  return node;
+}
+
 template <typename JsonType>
 bool has_overload_decorator(const JsonType &func_node)
 {


### PR DESCRIPTION
Implements `list("abc")` — the `list()` constructor over a constant string yields a list of single-character strings (CPython: `list("ab") == ['a', 'b']`). Mirrors the already-shipped `tuple(str)` fix (#5563) and is the next candidate named in §29b of the Python triage report.

## Problem
`list("abc")` crashed ESBMC with `migrate expr failed`: the string array flowed into the generic call builder, which mistyped it as a `PyListObject` pointer.

## Fix
In `converter_funcall.cpp`'s `list(...)` handler, a constant-string argument is lowered to a `List` literal of single-character `Constant`s and routed through the proven `[]` path. The fold is gated on a char-element operand (`subtype() == char_type()`), so a `bytes` literal — modeled as a 64-bit int array — is correctly excluded (CPython `list(b"ab") == [97, 98]`, not chars). `list(b"ab")` previously crashed on the generic builder; it is now rejected with a clean diagnostic, pinning the str-only soundness boundary of the fold (same boundary the `tuple(str)` review flagged as a critical soundness concern).

The shared char-sequence AST builder `build_char_sequence_node` is hoisted from `function_call/expr.cpp` into the dependency-free `json_utils.h` (as a template), so the `tuple()` and `list()` paths reuse it — a net de-duplication.

## Validation
- New regression tests (CORE): `list_from_str` (positive — the C-Live liveness witness, crashed pre-fix), `list_from_str_fail` (negative), `list_from_bytes_unsupported` (pins the bytes clean-error boundary, mirroring `tuple_from_bytes_unsupported`).
- Verified bit-for-bit against CPython for literal/variable/empty-string and the `list(list)`/`list(tuple)` non-regression; `list(b"ab")` gives the clean error (exit 254), no crash.
- CPython sanity (`scripts/check_python_tests.sh`) passes for all three tests.
- Focused `regression/python/{list,tuple,str,string}*` ctest subset (739 tests): zero new failures (the 50 failing are the pre-existing `--z3`/`--ir`/`--boolector` environmental set on this Bitwuzla-only `ENABLE_Z3=OFF` build).
- Code-reviewed (0 critical/major); the reviewer's sole recommendation — pin the bytes boundary — is addressed by the `list(bytes)` clean-error guard + test.
- Solver-agnostic: a frontend AST constant-fold + dispatch guard with no SMT encoding.