### PR TITLE
[python] V.3: build starred-unpack index subtraction in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -5634,18 +5634,16 @@ void python_list::handle_list_var_unpacking(
     size_call.location() = loc;
     target_block.copy_to_operands(size_call);
 
-    // upper = size - after_star
+    // upper = size - after_star. size_var and the literal are both size_type
+    // (synthetic), so build the subtraction in IREP2 (V.3).
     exprt upper_expr;
     if (after_star > 0)
-    {
-      upper_expr = exprt("-", size_type());
-      upper_expr.copy_to_operands(
-        build_symbol(size_var), from_integer(after_star, size_type()));
-    }
+      upper_expr = build_sub(
+        build_symbol(size_var),
+        from_integer(after_star, size_type()),
+        size_type());
     else
-    {
       upper_expr = build_symbol(size_var);
-    }
 
     // Loop: for loop_idx = before_star; loop_idx < upper; loop_idx++
     symbolt &loop_idx = converter_.create_tmp_symbol(
@@ -5722,10 +5720,12 @@ void python_list::handle_list_var_unpacking(
     for (size_t j = 0; j < after_star; j++)
     {
       size_t target_idx = static_cast<size_t>(star_idx) + 1 + j;
-      // index = size - after_star + j
-      exprt after_idx = exprt("-", size_type());
-      after_idx.copy_to_operands(
-        build_symbol(size_var), from_integer(after_star - j, size_type()));
+      // index = size - (after_star - j). size_var and the literal are both
+      // size_type (synthetic), so build the subtraction in IREP2 (V.3).
+      exprt after_idx = build_sub(
+        build_symbol(size_var),
+        from_integer(after_star - j, size_type()),
+        size_type());
       exprt list_at = build_list_at_call(list_expr, after_idx, list_value_);
       exprt val = extract_pyobject_value(list_at, elem_type);
       assign_to_target(targets[target_idx], val);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

The starred list-unpacking path (`a, *b, c = lst`) in
`handle_list_var_unpacking` had two remaining legacy `exprt("-")` +
`copy_to_operands` nodes:

- the starred-loop upper bound `size - after_star`
- each post-star target index `size - (after_star - j)`

Both now use the shared `build_sub` helper, completing the function's
arithmetic migration (it already builds its `<` loop guard, `+` increment, and
calls via the IREP2 helpers).

### Why it is behaviour-preserving (byte-identical)

Both operands are **synthetic** `size_type` values: the `$unpack_size$` symbol
(an `__ESBMC_list_size` result) and an integer literal. `migrate` lowers a
legacy `-` node to `sub2tc(migrate(a), migrate(b))`, so the round-trip
reproduces the exact node goto-convert would build. No unmerged helper
dependency — `build_sub` is already on master (#5568).

### Validation

- Build clean; starred/multiple-assignment/nested-unpack subset **19/19 passed**
  (`github_3588*`, `github_4525_alias_star`, `multiple-assignment*`,
  `nested_tuple_unpack*`); broad `python/list` sweep otherwise clean (the lone
  `list_pop11_nondet` failure is environmental — it requires `--boolector`,
  not compiled into this build).
- Probe over `a,*b,c` / `x,y,*z` / `*p,q` verifies SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.
