### PR TITLE
[python] V.3: build list string-element +1 size in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -377,11 +377,12 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
     strlen_call.location() = location;
     converter_.add_instruction(strlen_call);
 
-    // Add 1 for null terminator: size = strlen(s) + 1
-    // Use strlen_result.type to ensure exact type match
-    exprt one_const = from_integer(1, strlen_result.get_type());
-    elem_size = exprt("+", strlen_result.get_type());
-    elem_size.copy_to_operands(build_symbol(strlen_result), one_const);
+    // Add 1 for null terminator: size = strlen(s) + 1. strlen_result is a
+    // synthetic size_type symbol, so build the addition in IREP2 (V.3).
+    elem_size = build_add(
+      build_symbol(strlen_result),
+      from_integer(1, strlen_result.get_type()),
+      strlen_result.get_type());
   }
   else
   {
@@ -3984,10 +3985,12 @@ exprt python_list::contains(const exprt &item, const exprt &list)
             strlen_call.location() = item_info.location;
             converter_.add_instruction(strlen_call);
 
-            // Add 1 for null terminator: size = strlen(s) + 1
-            exprt one_const = from_integer(1, strlen_result.get_type());
-            elem_size = exprt("+", strlen_result.get_type());
-            elem_size.copy_to_operands(build_symbol(strlen_result), one_const);
+            // Add 1 for null terminator: size = strlen(s) + 1. strlen_result
+            // is a synthetic size_type symbol, so build it in IREP2 (V.3).
+            elem_size = build_add(
+              build_symbol(strlen_result),
+              from_integer(1, strlen_result.get_type()),
+              strlen_result.get_type());
           }
 
           break; // Found string array type, use it


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

When a list element is a string, its slot size is computed as `strlen(s) + 1`
(for the null terminator). Two sites — `get_list_element_info` and the
string-array branch of `contains()` — built this with a legacy `exprt("+")` +
`copy_to_operands`; both now use the shared `build_add` helper.

### Why it is behaviour-preserving (byte-identical)

Both operands are **synthetic** `size_type` values: the strlen-result symbol
(lhs of an emitted `strlen` call) and an integer literal. `migrate` lowers a
legacy `+` node to `add2tc(migrate(a), migrate(b))`, so the round-trip
reproduces the exact node goto-convert would build. `build_add` is already on
master (#5568) — no unmerged-helper dependency.

### Validation

- Build clean; list-of-string subset **26/26 passed** (`github_2999*`,
  `github_3000*`, `list_extend_str_len*`, `str_untyped_list_element*`).
- Probe over building / indexing / appending / `len` of a string list verifies
  SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.
