### PR TITLE
[python] V.3: build string-index length subtraction in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2851,9 +2851,10 @@ exprt python_list::handle_index_access(
     exprt array_size = to_array_type(resolved_array_type).size();
     if (array_size.type() != size_type())
       array_size = build_typecast(array_size, size_type());
-    exprt one = from_integer(1, size_type());
-    exprt str_len = exprt("-", size_type());
-    str_len.copy_to_operands(array_size, one);
+    // str_len = array_size - 1. array_size is typecast to size_type above, so
+    // both operands share width; build the subtraction in IREP2 (V.3).
+    exprt str_len =
+      build_sub(array_size, from_integer(1, size_type()), size_type());
 
     // Emit: if (idx >= str_len) throw IndexError("string index out of range")
     // (idx is typecast to size_type above; str_len is a size_type subtraction —


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

The string-subscript bounds check in `handle_index_access` computes the logical
length as `array_size - 1` (excluding the null terminator) before the
`idx >= str_len` IndexError guard. This last legacy `exprt("-")` +
`copy_to_operands` now uses the shared `build_sub` helper; the adjacent `>=`
guard already builds in IREP2 (`build_greater_equal`).

### Why it is behaviour-preserving (byte-identical)

`array_size` is typecast to `size_type` immediately above and the literal is
`size_type`, so both operands share width (`sub2t`'s consistency assert holds).
`migrate` lowers a legacy `-` node to `sub2tc(migrate(a), migrate(b))` — the
byte-identical round-trip. `build_sub` is already on master (#5568), so there is
no unmerged-helper dependency.

### Validation

- Build clean; `regression/python/string-index` subset **38/38 passed**.
- Probes: in-range `s[0]`/`s[4]`/`s[i]` verify SUCCESSFUL; out-of-range `s[5]`
  on a 2-char string correctly VERIFICATION FAILED (IndexError bound fires).
- clang-format (Clang 11) clean.

Note: the two list **loop guards** (`python_list.cpp:4120`, `:4533`) were
evaluated for the same treatment but kept legacy — their `<` operands can carry
an `arr_type.size()` width that differs from the `size_type` index, which
`lessthan2t`'s assert would reject (the legacy `<` tolerates it; `clang_cpp_adjust`
reconciles later). Same hazard as `python_set.cpp:234`.

Refs #4715.
