### PR TITLE
[python] V.3: build set char* iterable pointer arithmetic in IREP2

### DIFF
--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -341,9 +341,10 @@ exprt python_set::get_from_iterable(
     }
     else
     {
-      // char* case: *(iterable + i)
-      exprt ptr_add("+", iterable.type());
-      ptr_add.copy_to_operands(iterable, build_symbol(idx_sym));
+      // char* case: *(iterable + i). iterable is a resolved char* and idx_sym
+      // a synthetic size_type, so build the pointer arithmetic in IREP2 (V.3).
+      exprt ptr_add =
+        build_add(iterable, build_symbol(idx_sym), iterable.type());
       dereference_exprt deref(char_type());
       deref.op0() = ptr_add;
       elem_expr = deref;


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

In `get_from_iterable`, building a set from a `char*` string iterates the bytes
via `*(iterable + i)`. The pointer arithmetic was a legacy `exprt("+")` +
`copy_to_operands`; it now uses the shared `build_add` helper. The dereference
still wraps it and the whole element expression is migrated wholesale just
below, so the change is byte-identical.

### Why it is behaviour-preserving (byte-identical)

`iterable` is a resolved `char*` (a function parameter / symbol, used directly
elsewhere as a `strlen` / `build_index` operand) and `idx_sym` is a synthetic
`size_type`, so `add2t`'s operands are well-formed. `migrate` lowers a legacy
`+` node to `add2tc(migrate(a), migrate(b))`, reproducing the node goto-convert
would build. `build_add` is already on master (#5568) — no unmerged-helper
dependency.

### Validation

- Build clean; `regression/python/set` suite **16/16 passed**.
- Probe: `set(s)` over a `str` parameter (the char* path) with duplicate
  characters verifies SUCCESSFUL (correct unique-count).
- clang-format (Clang 11) clean.

Refs #4715.
