### PR TITLE
[python] V.3: build input() length-bound assume in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -157,8 +157,9 @@ exprt function_call_expr::handle_input() const
   len_assign.location() = converter_.get_location_from_decl(call_);
   converter_.add_instruction(len_assign);
 
-  exprt len_bound("<", bool_type());
-  len_bound.copy_to_operands(
+  // len_sym and the literal are both size_type (synthetic), so build the
+  // length-bound comparison in IREP2 (V.3).
+  exprt len_bound = build_less_than(
     build_symbol(len_sym), from_integer(max_str_length, size_type()));
   codet assume_len("assume");
   assume_len.copy_to_operands(len_bound);


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

The `input()` builtin (`handle_input`) models a bounded nondet C-string and
assumes `len < max_str_length` to bound its length. That comparison was a legacy
`exprt("<")` + `copy_to_operands`; it now uses the shared `build_less_than`
helper.

### Why it is behaviour-preserving (byte-identical)

Both operands are **synthetic** `size_type` values: the `$input_len$` symbol and
an integer literal, so `lessthan2t`'s width-consistency assert holds. `migrate`
lowers a legacy `<` node to `lessthan2tc(migrate(a), migrate(b))`, the
byte-identical round-trip. `build_less_than` is already on master (#5568) — no
unmerged-helper dependency.

### Validation

- Build clean; `regression/python/input` suite **8/8 passed**.
- Probe: `s = input(); n = len(s); assert n >= 0` verifies SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.
