### PR TITLE
[python] V.3: build list loop-index increments in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -157,8 +157,9 @@ exprt function_call_expr::handle_input() const
   len_assign.location() = converter_.get_location_from_decl(call_);
   converter_.add_instruction(len_assign);
 
-  exprt len_bound("<", bool_type());
-  len_bound.copy_to_operands(
+  // len_sym and the literal are both size_type (synthetic), so build the
+  // length-bound comparison in IREP2 (V.3).
+  exprt len_bound = build_less_than(
     build_symbol(len_sym), from_integer(max_str_length, size_type()));
   codet assume_len("assume");
   assume_len.copy_to_operands(len_bound);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -689,8 +689,9 @@ void python_list::emit_list_copy(
   push_call.location() = loc;
   body.copy_to_operands(converter_.convert_expression_to_code(push_call));
 
-  // i = i + 1
-  plus_exprt i_inc(build_symbol(i_sym), gen_one(size_type()));
+  // i = i + 1 (V.3: synthetic size_type increment, built in IREP2)
+  exprt i_inc =
+    build_add(build_symbol(i_sym), gen_one(size_type()), size_type());
   body.copy_to_operands(code_assignt(build_symbol(i_sym), i_inc));
 
   // while (i < n) { ... }
@@ -1626,8 +1627,9 @@ exprt python_list::handle_range_slice(
     code_assignt assign(dst, src);
     body.copy_to_operands(assign);
 
-    // i++
-    plus_exprt incr(build_symbol(idx), gen_one(size_type()));
+    // i++ (V.3: synthetic size_type increment, built in IREP2)
+    exprt incr =
+      build_add(build_symbol(idx), gen_one(size_type()), size_type());
     code_assignt update(build_symbol(idx), incr);
     body.copy_to_operands(update);
 
@@ -4161,8 +4163,9 @@ exprt python_list::build_extend_list_call(
     push_call.location() = location;
     loop_body.copy_to_operands(push_call);
 
-    // Increment index: idx++
-    plus_exprt idx_inc(build_symbol(idx), gen_one(size_type()));
+    // Increment index: idx++ (V.3: synthetic size_type increment in IREP2)
+    exprt idx_inc =
+      build_add(build_symbol(idx), gen_one(size_type()), size_type());
     code_assignt idx_update(build_symbol(idx), idx_inc);
     loop_body.copy_to_operands(idx_update);
 


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

Three list-iteration loops — `emit_list_copy`, `handle_range_slice`, and
`build_extend_list_call` — advanced their counter with a legacy
`plus_exprt(build_symbol(idx), gen_one(size_type()))`. Each now uses the shared
`build_add` helper.

### Why it is behaviour-preserving (byte-identical)

The operands are **synthetic** `size_type` values (a loop-counter symbol and the
literal `1`), and `plus_exprt` infers its result type from the lhs (`size_type`),
so `build_add(..., size_type())` reproduces the same node: `migrate` lowers a
legacy `+` to `add2tc(migrate(a), migrate(b))`. `build_add` is already on master
(#5568) — no unmerged-helper dependency.

### Validation

- Build clean; `python/list` sweep **255/256 passed** (the lone
  `list_pop11_nondet` failure is environmental — it requires `--boolector`,
  not compiled into this build — and is unrelated).
- Probe over `for`-loop accumulation and a list comprehension verifies
  SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.
