### PR TITLE
[python] V.3: build list symbolic-size member store in IREP2

### DIFF
--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -5085,9 +5085,10 @@ void python_list::set_list_symbolic_size(
   {
     if (comp.get_name() == "size")
     {
-      // Create assignment: list->size = n
-      dereference_exprt deref(list_expr, pointee_type);
-      member_exprt size_member(deref, comp.get_name(), comp.type());
+      // Create assignment: list->size = n. pointee_type is a resolved struct
+      // (followed and checked above), so build *(list).size in IREP2 (V.3).
+      exprt deref = build_dereference(list_expr, pointee_type);
+      exprt size_member = build_member(deref, comp.get_name(), comp.type());
       exprt size_value = build_typecast(size_expr, comp.type());
       code_assignt size_assignment(size_member, size_value);
 


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`set_list_symbolic_size` (the `list(range(n))` symbolic-length path) builds the
assignment target `*(list).size` with a legacy `dereference_exprt` +
`member_exprt`. Both now use the shared `build_dereference` / `build_member`
helpers.

### Why it is behaviour-preserving (byte-identical)

`pointee_type` is a **resolved struct** (followed via `ns.follow` and checked
`is_struct` just above) and `list_expr` is a resolved list pointer, so
`build_dereference(list_expr, pointee_type)` and `build_member` over the
resulting struct source reproduce the legacy nodes exactly — `migrate` lowers
them to `dereference2tc` / `member2tc` identically (`build_member` takes its
IREP2 path because the source is a struct). Both helpers are already on master
(#5568).

### Validation

- Build clean; `python/range` suite **67/67 passed**; broad `python/list` sweep
  **255/256** (the lone `list_pop11_nondet` failure is environmental — it
  requires `--boolector`, not compiled into this build).
- Probe: `list(range(n))` over a bounded symbolic `n` with `len(...)` checks
  verifies SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.
