### PR TITLE
[python] V.3: build constructor default-attr store in IREP2

### DIFF
--- a/src/python-frontend/python_class_builder.cpp
+++ b/src/python-frontend/python_class_builder.cpp
@@ -3,6 +3,7 @@
 #include <json_utils.h>
 #include <python_class_builder.h>
 #include <python-frontend/converter/converter_internal.h>
+#include <python-frontend/python_expr_builder.h>
 #include <type_utils.h>
 #include <util/std_expr.h>
 #include <util/expr_util.h>
@@ -10,6 +11,8 @@
 #include <util/python_types.h>
 #include <util/std_code.h>
 #include <util/symbol.h>
+
+using namespace python_expr;
 
 // Extracts the last identifier in a dotted name, e.g. "pkg.sub.Base" → "Base"
 std::string python_class_builder::leaf(const std::string &dotted)
@@ -269,8 +272,10 @@ void python_class_builder::gen_ctor(bool has_ud_base, struct_typet &st)
       continue;
 
     const typet &comp_type = st.get_component(attr).type();
-    dereference_exprt deref(symbol_expr(self_sym), st);
-    member_exprt member(deref, attr, comp_type);
+    // st is a resolved struct (the class type), so build *(self).attr in
+    // IREP2 (V.3).
+    exprt deref = build_dereference(symbol_expr(self_sym), st);
+    exprt member = build_member(deref, attr, comp_type);
 
     exprt value = conv_.get_expr(n["value"]);
     if (value.type() != comp_type)


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

`gen_ctor` default-initialises each annotated class variable carrying a value
via `self->attr = default` (e.g. `self->value = 0` for `class C: value: int = 0`).
The assignment target `*(self).attr` was a legacy `dereference_exprt` +
`member_exprt`; both now use the shared `build_dereference` / `build_member`
helpers.

### Why it is behaviour-preserving (byte-identical)

`st` is the **resolved** class struct (a `struct_typet&`, queried with
`has_component` / `get_component` just above) and `self_sym` is the resolved
`self` pointer, so the helpers reproduce the legacy nodes exactly — `migrate`
lowers them to `dereference2tc` / `member2tc` identically (`build_member` takes
its IREP2 path because the source is a struct). Both helpers are already on
master (#5568); the translation unit gains the `python_expr` include + using.

### Validation

- Build clean; `class` / `dataclass` / `attr` / `inheritance` sweep **101/101
  passed**; `python/class` subset **40/40**.
- Probe: default-valued class attributes (`int` and `bool`) read back correctly,
  both via direct construction and through a function — verifies SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.
