### PR TITLE
[python] V.3: build startswith prefix-length subtraction in IREP2

### DIFF
--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -933,10 +933,10 @@ exprt string_handler::handle_string_startswith(
     const array_typet &prefix_type = to_array_type(prefix_expr.type());
     exprt prefix_len = prefix_type.size();
 
-    // Subtract 1 for null terminator
-    exprt one = from_integer(1, prefix_len.type());
-    actual_len = exprt("-", prefix_len.type());
-    actual_len.copy_to_operands(prefix_len, one);
+    // Subtract 1 for null terminator. prefix_len (the array dimension) and the
+    // literal share prefix_len.type(), so build it in IREP2 (V.3).
+    actual_len = build_sub(
+      prefix_len, from_integer(1, prefix_len.type()), prefix_len.type());
   }
   else
   {


### PR DESCRIPTION
Part of the IREP2 migration **Part V Phase V.3** (esbmc/esbmc#4715).

In `handle_string_startswith`, the array (string-literal) branch computes the
prefix length excluding the null terminator as `prefix_len - 1` via a legacy
`exprt("-")` + `copy_to_operands`. It now uses the shared `build_sub` helper,
mirroring the endswith offset migration (#5574).

### Why it is behaviour-preserving (byte-identical)

Both operands share `prefix_len.type()`: `prefix_len` is the array dimension and
the literal `1` is built with that same type, so `sub2t`'s width-consistency
assert holds. `migrate` lowers a legacy `-` node to `sub2tc(migrate(a), migrate(b))`,
the byte-identical round-trip. `build_sub` is already on master (#5568).

### Validation

- Build clean; `string-startswith` / `str_startswith` subset **7/7 passed**.
- Probe over match / no-match / single-char / empty / longer-than-string prefix
  verifies SUCCESSFUL.
- clang-format (Clang 11) clean.

Refs #4715.
