### PR TITLE
[python] Default int.from_bytes signed=False in the OM model

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1311,6 +1311,59 @@ work; the §5 priority order stands.
 
 ---
 
+> **Note on numbering.** §30 (PR #5577, `list(str)`), §31 (PR #5579, numeric-tower properties),
+> §32 (PR #5585, `bytes.hex()`), §33 (PR #5588, `str.encode()`/`bytes.decode()`), and §34 (PR
+> #5592, `int.to_bytes()` receiver forms) are in flight and not yet on `master`; this sweep is
+> appended as §35. Its fix is in flight as PR #5597. When all land, the maintainer orders
+> §30 → §31 → §32 → §33 → §34 → §35.
+
+## 35. 2026-06-24 re-validation (twenty-fifth sweep) & int.from_bytes default signed
+
+Re-test against current `master` (tip `8567a816e2`). KNOWNBUG classification unchanged — §3 holds.
+This sweep took the `int.from_bytes()` defect catalogued in §34b.
+
+### 35a. New isolated, soundly-fixable defect found & fixed
+**`int.from_bytes(b, "big")` (the common 2-argument form) raised an uncaught `TypeError`.**
+
+The counterexample was an uncaught exception, not a wrong value: the `int.py` operational model's
+`from_bytes(cls, bytes_data, big_endian, signed)` had no default for `signed`, so the preprocessor's
+missing-argument check rejected the 2-argument call before the model ran. CPython's signature is
+`int.from_bytes(bytes, byteorder, *, signed=False)`; the model's arithmetic was already correct (the
+*explicit*-signed form `int.from_bytes(b, "big", False)`, exercised by the pre-existing
+`int_from_bytes` regression test, verified).
+
+**Fix** (`models/int.py`): give the model's `signed` parameter the matching `False` default. One
+line; the preprocessor's `functionDefaults` mechanism then supplies it for the 2-argument form. No
+arithmetic change — a trivial literal (default-value) change, so no Mode C is required. The model is
+FLAIL-mangled, so the binary was rebuilt before testing.
+
+New regression pair `regression/python/int_from_bytes_default_signed{,_fail}` (CORE) covering the
+2-argument default form, the `signed=False` keyword, big/little endian, a leading zero, and a single
+byte; the positive test is the liveness witness (uncaught-exception `FAILED` pre-fix). Verified
+bit-for-bit against CPython; the existing `int_from_bytes` (explicit-signed) test still passes;
+pylint clean on the model; the focused `regression/python/(int_|bytes|from_bytes|to_bytes)` ctest
+subset (31 tests) shows zero new failures.
+
+(Methodology note: the V.3 `python_expr` IREP2 expr-builder module was considered for this fix, but
+the defect turned out to be a missing argument default — an uncaught `TypeError` — not an
+expr-construction problem, so no new exprs are built and the builder does not apply here.)
+
+### 35b. Next candidate & everything else: unchanged disposition
+Two `from_bytes` sub-defects surfaced once the exception was removed and are the obvious **next
+candidates**: (1) a bytes **literal passed directly as the argument** — `int.from_bytes(b"\x00\xff",
+"big")` — still fails because the constant byte-array argument is not materialized for the model
+call (the variable form works); this is the constant-array-arg materialization path, where the
+`python_expr` IREP2 builders (`build_symbol`/`build_address_of`) *would* apply. (2) The `signed=True`
+two's-complement negative path and the `byteorder=` keyword form (the model parameter is named
+`big_endian`). Smaller adjacent entries: `bytes.hex(sep)` separator arguments, multi-byte (non-ASCII)
+UTF-8 encode/decode. The separately-tracked inline-`len`/strlen concern (§14b/§32b/§33b) still
+stands. Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=)`,
+`list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
+`str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
+expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
 > **Note on numbering.** §16–§29 (PRs #5526, #5531, #5532, #5536, #5537, #5540, #5543, #5548,
 > #5554, #5555, #5556, #5558, #5562, #5563) precede this section; this sweep is appended as §30.
 > Its fix is in flight as PR #5577 and not yet on `master`.

--- a/regression/python/int_from_bytes_default_signed/main.py
+++ b/regression/python/int_from_bytes_default_signed/main.py
@@ -1,0 +1,18 @@
+def main() -> None:
+    # The 2-argument form defaults signed=False (CPython), so it no longer
+    # raises a missing-argument TypeError.
+    b = b"\x01\x02"
+    assert int.from_bytes(b, "big") == 258
+    assert int.from_bytes(b, "little") == 513
+
+    # signed=False keyword matches the default.
+    assert int.from_bytes(b, "big", signed=False) == 258
+
+    # A leading zero byte and the single-byte case.
+    c = b"\x00\xff"
+    assert int.from_bytes(c, "big") == 255
+    d = b"\x2a"
+    assert int.from_bytes(d, "big") == 42
+
+
+main()

--- a/regression/python/int_from_bytes_default_signed/test.desc
+++ b/regression/python/int_from_bytes_default_signed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_from_bytes_default_signed_fail/main.py
+++ b/regression/python/int_from_bytes_default_signed_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    b = b"\x01\x02"
+    # int.from_bytes(b, "big") == 258, not 999.
+    assert int.from_bytes(b, "big") == 999
+
+
+main()

--- a/regression/python/int_from_bytes_default_signed_fail/test.desc
+++ b/regression/python/int_from_bytes_default_signed_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -9,7 +9,7 @@
 class int:
 
     @classmethod
-    def from_bytes(cls, bytes_data: bytes, big_endian: bool, signed: bool) -> int:
+    def from_bytes(cls, bytes_data: bytes, big_endian: bool, signed: bool = False) -> int:
         result: int = 0
         index: int = 0
         step: int = 1


### PR DESCRIPTION
Fixes `int.from_bytes()` for the common 2-argument form (the `int.from_bytes` candidate from §34b of the Python triage report).

## Problem
`int.from_bytes(b, "big")` raised an **uncaught `TypeError`** (→ `VERIFICATION FAILED`): the operational model's `signed` parameter had no default, so the preprocessor's missing-argument check rejected the call before it ran. CPython's signature is `int.from_bytes(bytes, byteorder, *, signed=False)`. Only the explicit-signed form (`int.from_bytes(b, "big", False)`, exercised by the existing `int_from_bytes` test) worked — the model's arithmetic was already correct.

## Fix
Give the model's `signed` parameter the matching `False` default (`models/int.py`). One line; the preprocessor's `functionDefaults` mechanism then supplies it for the 2-argument form. No arithmetic change.

## Validation
- New regression pair (CORE): `int_from_bytes_default_signed` (2-arg default form, `signed=False` keyword, big/little endian, leading zero, single byte — the liveness witness) and `..._fail` (wrong value → FAILED).
- Verified bit-for-bit against CPython (the test runs clean under CPython); the **existing** `int_from_bytes` test (explicit-signed form) still passes; pylint clean on the model; focused `regression/python/(int_|bytes|from_bytes|to_bytes)` ctest subset (31 tests) shows zero new failures.
- Trivial literal (default-value) change — the model is FLAIL-mangled, so the binary was rebuilt before testing.

## Known limitations (out of scope, catalogued for follow-up)
- A bytes **literal passed directly as the argument** — `int.from_bytes(b"\x00\xff", "big")` — still fails (a constant-bytes-array argument is not materialized for the model call; the variable form `c = b"\x00\xff"; int.from_bytes(c, ...)` works).
- The `signed=True` two's-complement negative path and the `byteorder=` keyword form are separate pre-existing issues.