### PR TITLE
[ci] Give str_rsplit the slow-test timeout tier

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -493,6 +493,15 @@ set(_slow_regression_tests
     # the overhead.
     "regression/esbmc/math_log-rec1"
     "regression/esbmc/multi_dimensional_array_1-success"
+    # str_rsplit verifies SUCCESSFUL but is heavy: under --incremental-bmc it
+    # climbs to k=5 before the forward condition converges, re-running symex and
+    # a fresh Bitwuzla query at each step over the str/list operational models
+    # (rsplit + list-equality + __memcmp_impl). It lands at ~106s on the DebugOpt
+    # Linux runner -- right at the 120s cap with no headroom -- so the slower
+    # macOS arm64 runner tips it over (timed out at 120s in #5579 CI, a run that
+    # does not touch its code path). Give it the 2x budget so transient
+    # runner-speed differences don't flap it.
+    "regression/python/str_rsplit"
 )
 math(EXPR ESBMC_REGRESS_CTEST_TIMEOUT_SLOW
      "${ESBMC_REGRESS_TIMEOUT_SLOW} + 30")


### PR DESCRIPTION
## Problem

`regression/python/str_rsplit` (a CORE `--incremental-bmc` test added in #5554) verifies `VERIFICATION SUCCESSFUL` but is heavy: it climbs to k=5 before the forward condition converges, re-running symex and a fresh Bitwuzla query at each step over the str/list operational models (rsplit + list-equality + `__memcmp_impl`).

It lands at **~106s** on the DebugOpt Linux runner — right at the 120s per-test cap with no headroom — so the slower **macOS arm64** runner tips it over and times out at 120s. This reddens the macOS job on **every** open PR regardless of what the PR touches (observed on #5576 and #5579, neither of which goes near this code path).

## Fix

Add `regression/python/str_rsplit` to the existing `_slow_regression_tests` list, granting it the **2x budget** (240s inner / 270s outer at the CI cap). This is the established repo pattern for borderline tests that legitimately run near the cap (cf. `[ci] Give humaneval_109 the slow-test timeout tier`, #5190).

2x is the correct tier (not 3x): Linux passes under 120s, so macOS would need to be >2.3x slower than Linux to exceed 240s — implausible for Apple Silicon.

## Validation

- Confirmed the test converges to `VERIFICATION SUCCESSFUL` at k=5 (rebuilt binary).
- Reconfigured at the CI cap (`ESBMC_REGRESS_TIMEOUT=120`): `str_rsplit` now gets `TIMEOUT=270` / `ESBMC_REGRESS_TIMEOUT=240`.
- `cmakelint --config=.cmakelintrc` passes (0 errors).
- CMake-only change; no solver/encoding impact.