### PR TITLE
[docs] Triage §36: int.from_bytes literal-arg two-layer root cause

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1311,6 +1311,62 @@ work; the §5 priority order stands.
 
 ---
 
+> **Note on numbering.** §30–§35 (PRs #5577/#5579/#5585/#5588/#5592/#5597) are in flight and not yet
+> on `master`; this finding is appended as §36.
+
+## 36. 2026-06-24 (twenty-sixth sweep) — int.from_bytes literal-arg root cause (characterized, deferred)
+
+Re-test against current `master` (tip `6d79c6204c`). KNOWNBUG classification unchanged — §3 holds.
+This sweep investigated the §35b next candidate — a bytes **literal passed directly as the
+`int.from_bytes` argument** — and root-caused it, but it is **not** the isolated one-liner the
+catalogue implied: it is a two-layer frontend bytes-literal-argument lowering bug. No fix is shipped;
+the precise diagnosis is recorded here for a future focused effort, and the partial patch was reverted
+(it converted a detected out-of-bounds into a silent wrong value — strictly worse).
+
+### 36a. Root cause (GOTO evidence)
+`int.from_bytes(b"\x01\x02", "big")` reports `dereference failure: array bounds violated` at the
+model's `bytes_data[index]`. The **variable** form `c = b"\x01\x02"; int.from_bytes(c, ...)` verifies.
+The GOTO shows why:
+
+- **Variable form:** `c = { 1, 2 }` — a 2-element array of 64-bit ints (`build_raw_byte_array`,
+  element type `long_long_int`) — passed as `from_bytes(0, &c[0], 1, 0)`. The model's
+  `len(bytes_data)`/indexing are correct.
+- **Literal form:** `from_bytes(0, (signed long int *)(&"\001\002"[0]), 1, 0)` — the bytes literal
+  is lowered as a **char-array string constant** `"\001\002"` (1 byte/element, null-terminated) and
+  its address is cast to the model's 64-bit-element bytes pointer. The model reads 8 bytes per
+  element over a 3-byte buffer → out of bounds.
+
+Two layers conspire:
+1. **`get_literal`/`is_bytes_literal` (`converter/converter_expr.cpp`):** a bare bytes-literal
+   *argument* — with no bytes-typed LHS/annotation context — is not recognised as bytes
+   (`current_element_type` is not `"bytes"`, and the node reaches `get_literal` without the
+   `encoded_bytes` marker that fires `is_bytes_literal`), so it falls through to the string path and
+   is built as a char array. The assignment-RHS context works only because the inferred `bytes` LHS
+   sets `current_element_type`.
+2. **Argument clobber (`function_call/expr.cpp`, ~L4410):** the model-call arg path then rebuilds any
+   `Constant` whose JSON `value` is a string into a `string_literal` — the same clobber the adjacent
+   complex-literal guard already prevents. Guarding bytes there (mirroring the complex guard, on a
+   non-char array subtype) removes the size-mismatch cast but **not** the wrong value, because
+   layer 1 already produced a char array.
+
+The complete fix must make layer 1 lower a bare bytes-literal argument as a byte array (preserve/honour
+`encoded_bytes` independent of LHS context), after which the layer-2 guard keeps the arg from being
+re-clobbered. That is a frontend bytes-literal-lowering change touching `get_literal`'s context
+handling — a focused but non-trivial change, deferred. **Sound workaround:** bind the literal to a
+variable first (`c = b"\x01\x02"; int.from_bytes(c, ...)`), which verifies today.
+
+### 36b. Next candidate & everything else: unchanged disposition
+A **cleaner next candidate** (avoiding the layer-1 lowering work) is the `signed=True` two's-complement
+negative path of `int.from_bytes` (a model-logic case), or `bytes.hex(sep)` separator arguments
+(extends §32's `bytes.hex`). The bytes-literal-arg lowering (§36a) and the `byteorder=` keyword form
+(model parameter named `big_endian`) remain catalogued. The separately-tracked inline-`len`/strlen
+concern (§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`, symbolic/user-function
+`max`/`min(key=)`, `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()`
+(infeasible), and `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d
+questionable expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
 > **Note on numbering.** §16–§29 (PRs #5526, #5531, #5532, #5536, #5537, #5540, #5543, #5548,
 > #5554, #5555, #5556, #5558, #5562, #5563) precede this section; this sweep is appended as §30.
 > Its fix is in flight as PR #5577 and not yet on `master`.


### PR DESCRIPTION
A **triage finding (not a code fix)** for the Python issues sweep. Investigating the §35b candidate — a bytes literal passed directly as `int.from_bytes`'s argument — root-caused it as a two-layer frontend lowering bug rather than the isolated one-liner the catalogue implied, so it is documented for a future focused effort.

## Root cause (GOTO evidence)
`int.from_bytes(b"\x01\x02", "big")` → `dereference failure: array bounds violated`; the variable form `c = b"\x01\x02"; int.from_bytes(c, ...)` verifies. The GOTO shows:
- **Variable:** `c = { 1, 2 }` (64-bit-element byte array) → `from_bytes(0, &c[0], 1, 0)` — correct.
- **Literal:** `from_bytes(0, (signed long int *)(&"\001\002"[0]), 1, 0)` — the literal is lowered as a **char-array string constant** (1 byte/element) and its address cast to the 64-bit-element bytes pointer → reads 8 bytes/element over a 3-byte buffer → OOB.

Two layers: (1) `get_literal`/`is_bytes_literal` does not recognise a bare bytes-literal *argument* without a bytes-typed LHS context (so it builds a char array); (2) the model-call arg path then re-clobbers any string-valued `Constant` into a `string_literal` (the same clobber the adjacent complex-literal guard prevents). A guard at layer 2 removes the size-mismatch cast but not the wrong value, because layer 1 already produced a char array — so the partial patch was reverted (it traded a detected OOB for a silent wrong value).

## Disposition
Deferred — the complete fix is a frontend bytes-literal-argument lowering change in `get_literal`'s context handling. **Sound workaround:** bind the literal to a variable first. Cleaner next candidates named: `int.from_bytes(signed=True)` two's-complement negative path, and `bytes.hex(sep)`.

No code change; documentation only.