### PR TITLE
[python] V.3: build remaining truthiness/membership checks in IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3544,6 +3544,55 @@ verdict + counterexample parity holds (dual-solver Bitwuzla + Z3). With these,
 the clean V.3 surface is drained; the residual is exactly the two
 permanently-blocked classes above.
 
+#### V.3 residual → the remaining tasks to reach 100 % IREP2 (2026-06-24)
+
+The pre-V.4 clean V.3 surface is drained; the residual is exactly the two
+classes above (F-P11 user-operand sites + width-hazard guards). Both share one
+root cause and therefore one fix, so the path to **100 % IREP2** is a small,
+ordered task list — not an open-ended sweep. A read-only spike pins the
+constraint the keystone task must respect:
+
+- **The resolution lives in a legacy-`codet` adjust pass.** `python_languaget::
+  final` runs `clang_cpp_adjust::adjust()` over the symbol values
+  (`python_language.cpp:249-250`, entry `adjust_code(codet&)`,
+  `clang_cpp_adjust.h:32`); this is where the converter's unresolved
+  `member`/`index` sources get followed (the P2/W2 resolution). The residual
+  aborts because the converter builds those nodes **before** this pass.
+- **The goto-convert body round-trip stays legacy (W1-loc) — and is off this
+  critical path.** V.4 concluded the *body* round-trip is a `RETAIN_BOUNDARY`
+  for source-location fidelity. That governs `goto_convert`'s side-effect
+  hoisting, **not** the converter→adjust type-resolution seam where the residual
+  is built, so it does not block the tasks below.
+
+**Tasks to 100 % (ordered; the first is the keystone, RV2 the gate):**
+
+1. **V.1k — resolve-then-build via the design-(b) IREP2-native adjuster.**
+   Stand up the Python-specific IREP2 adjuster that performs `clang_cpp_adjust`'s
+   *complete* resolution (recursive struct-following + auto-deref +
+   dataclass/inference-aware completion) as one IREP2 pass, so the converter can
+   build `member2tc`/`index2tc`/arith with **resolved** operand types and the
+   F-P11 + width-hazard aborts vanish. **Open design question to settle in the
+   first spike:** whether this runs as a type-resolution *service* the converter
+   queries at construction (no materialised IREP2 body needed) or requires
+   materialising IREP2 bodies pre-adjust (the resolved-source chicken-and-egg
+   the relaxed assert only partially lifts). *Accept (RV2, hard gate):* the
+   20-test acceptance fixture (§V.1k design (b)) back to green; the F-P11/
+   width-hazard sites build in-converter with zero `irep2_expr.h` aborts;
+   verdict + text unchanged.
+2. **V.2 — IREP2-native attribute carriage (W3).** Fold `#cpp_type`/
+   `#member_name`/`#cformat` onto the typed IREP2 companion; the (b) adjuster is
+   the natural home, so V.1k and V.2 land together.
+3. **V.5 — IREP2-native counterexample printer (W4).** Independent of the above
+   (Part II §2.7, own issue); can proceed in parallel.
+4. **V.6 — flip & verify.** Switch the symbol-table writes fully to
+   `set_value(expr2tc)`, census → ~0, dual-solver + asserts + `esbmc-cpp`
+   parity. §V.1 bar met.
+
+Converter-side V.3 *construction* is drained as far as the pre-adjust assert
+allows; everything remaining is the V.1k keystone and what it unblocks. The
+deeper W1 body round-trip (V.4) is the one piece retained by design — it is a
+shared goto-convert concern, not part of the Python 100 % target.
+
 ### Phase V.4 — IREP2 structured CF + IREP2-aware `goto_convert` (removes W1)
 Add the missing structured CF code kinds to IREP2 (`code_ifthenelse2t`,
 `code_while2t`, `code_for2t`, `code_switch2t`, `code_break2t`,

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3520,7 +3520,29 @@ pre-V.4:
    subtracting, so a blind migrate is unsound.)
 
 Both classes need the **V.1k/V.4 IREP2-native adjuster** (resolve-then-build),
-not site-by-site migration. Pre-V.4, the clean V.3 surface is **fully drained**.
+not site-by-site migration.
+
+#### V.3 follow-up (2026-06-24) — truthiness/membership stragglers drained
+
+A re-census after the pass above found the "fully drained" claim was slightly
+overstated: five clean synthetic-operand sites — each a *byte-identical
+round-trip* analog of an already-merged migration — were still building legacy
+`exprt("notequal"/…)` nodes. All were drained to the
+`migrate_expr_back(notequal2tc/equality2tc(…))` pattern:
+
+- `converter_stmt.cpp` list-condition `__ESBMC_list_size(xs) != 0` (analog of the
+  already-migrated truthiness path at the same file ~3216);
+- `converter_stmt.cpp` dict-truthiness `$dict_size$ != 0`;
+- `string_handler.cpp` `strchr(...) != NULL` and `strstr(...) != NULL` membership
+  (analog of the merged `strcmp(...) op 0` at `converter_binop.cpp:973`);
+- `python_exception_handler.cpp` non-negated assertion `(int)<bool-temp> == 1`
+  (sibling of the already-migrated `not <temp>` branch).
+
+Operands are all fully-synthetic concrete-typed (OM-call results, `size_type`
+temps, constants), so each is the exact IREP2 round-trip of the legacy node —
+verdict + counterexample parity holds (dual-solver Bitwuzla + Z3). With these,
+the clean V.3 surface is drained; the residual is exactly the two
+permanently-blocked classes above.
 
 ### Phase V.4 — IREP2 structured CF + IREP2-aware `goto_convert` (removes W1)
 Add the missing structured CF code kinds to IREP2 (`code_ifthenelse2t`,

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -2994,9 +2994,16 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
       else
         size_call.arguments().push_back(address_of_exprt(value_expr));
 
-      exprt cond("notequal", bool_type());
-      cond.copy_to_operands(size_call, gen_zero(size_type()));
-      cond.location() = get_location_from_decl(value_node);
+      // V.3: build `__ESBMC_list_size(xs) != 0` in IREP2, back-migrating once
+      // (mirrors the list-condition path at converter_stmt.cpp:3216). The
+      // round-trip drops the call operand's location, so re-attach it.
+      expr2tc size_call2;
+      migrate_expr(size_call, size_call2);
+      exprt cond = migrate_expr_back(
+        notequal2tc(size_call2, gen_zero(migrate_type(size_type()))));
+      const locationt cond_loc = get_location_from_decl(value_node);
+      cond.location() = cond_loc;
+      cond.op0().location() = cond_loc;
       return cond;
     }
 
@@ -3721,9 +3728,12 @@ exprt python_converter::get_block(
         block.copy_to_operands(size_call);
 
         // Replace test with: size != 0 (non-empty dict is truthy)
-        exprt is_not_empty("notequal", bool_type());
-        is_not_empty.copy_to_operands(
-          symbol_expr(size_result), gen_zero(size_type()));
+        // V.3: build `$dict_size$ != 0` in IREP2, back-migrating once
+        // (mirrors the list/string truthiness paths above).
+        expr2tc size2;
+        migrate_expr(symbol_expr(size_result), size2);
+        exprt is_not_empty = migrate_expr_back(
+          notequal2tc(size2, gen_zero(migrate_type(size_type()))));
         is_not_empty.location() = location;
         test = is_not_empty;
       }

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -533,9 +533,14 @@ void python_exception_handler::handle_function_call_assertion(
   }
   else
   {
+    // V.3: build `(int)<temp> == 1` in IREP2 (the temp is a synthetic bool),
+    // mirroring the is_negated `not` branch above.
     exprt cast_expr = build_typecast(temp_var_expr, signedbv_typet(32));
     exprt one_expr = constant_exprt("1", signedbv_typet(32));
-    assertion_expr = equality_exprt(cast_expr, one_expr);
+    expr2tc cast2, one2;
+    migrate_expr(cast_expr, cast2);
+    migrate_expr(one_expr, one2);
+    assertion_expr = migrate_expr_back(equality2tc(cast2, one2));
   }
 
   code_assertt assert_code;

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1296,8 +1296,15 @@ exprt string_handler::handle_string_membership(
     constant_exprt null_ptr(gen_pointer_type(char_type()));
     null_ptr.set_value("NULL");
 
-    exprt not_equal("notequal", bool_type());
-    not_equal.copy_to_operands(strchr_call, null_ptr);
+    // V.3: build `strchr(...) != NULL` in IREP2, back-migrating once (mirrors
+    // the strcmp membership path at converter_binop.cpp:973). The round-trip
+    // drops the call operand's location, so re-attach it.
+    expr2tc strchr_call2;
+    migrate_expr(strchr_call, strchr_call2);
+    expr2tc null2;
+    migrate_expr(null_ptr, null2);
+    exprt not_equal = migrate_expr_back(notequal2tc(strchr_call2, null2));
+    not_equal.op0().location() = strchr_call.location();
 
     return not_equal;
   }
@@ -1441,8 +1448,15 @@ exprt string_handler::handle_string_membership(
   constant_exprt null_ptr(gen_pointer_type(char_type()));
   null_ptr.set_value("NULL");
 
-  exprt not_equal("notequal", bool_type());
-  not_equal.copy_to_operands(strstr_call, null_ptr);
+  // V.3: build `strstr(...) != NULL` in IREP2, back-migrating once (mirrors
+  // the strchr membership path above). The round-trip drops the call operand's
+  // location, so re-attach it.
+  expr2tc strstr_call2;
+  migrate_expr(strstr_call, strstr_call2);
+  expr2tc null2;
+  migrate_expr(null_ptr, null2);
+  exprt not_equal = migrate_expr_back(notequal2tc(strstr_call2, null2));
+  not_equal.op0().location() = strstr_call.location();
 
   return not_equal;
 }


### PR DESCRIPTION
Drains five clean synthetic-operand sites the prior V.3 pass missed, each a byte-identical round-trip analog of an already-merged migration: the list-condition and dict-truthiness `... != 0` checks, the `strchr/strstr(...) != NULL` membership tests, and the non-negated exception assertion `(int)<temp> == 1`.

All operands are fully-synthetic concrete-typed (OM-call results, size_type temps, constants), so each lowers identically via `migrate_expr_back(notequal2tc/equality2tc(...))`. Verdict + counterexample parity verified under Bitwuzla and Z3 (positive SUCCESSFUL, negative FAILED) plus a 133-test python regression subset (100% pass).

Refs #4715