### PR TITLE
[python] Fix int.from_bytes signed=True sign-byte handling

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1311,6 +1311,52 @@ work; the §5 priority order stands.
 
 ---
 
+> **Note on numbering.** §30–§36 (PRs #5577/#5579/#5585/#5588/#5592/#5597 and the #5599 triage
+> finding) are in flight and not yet on `master`; this sweep is appended as §37. Its fix is in
+> flight as PR #5601.
+
+## 37. 2026-06-24 (twenty-seventh sweep) & int.from_bytes signed=True sign-byte fix
+
+Re-test against current `master` (tip `6d79c6204c`). KNOWNBUG classification unchanged — §3 holds.
+This sweep took the cleaner `signed=True` candidate named in §36b (avoiding the §36a literal-arg
+lowering work by using variable receivers).
+
+### 37a. New isolated, soundly-fixable defect found & fixed
+**`int.from_bytes(b, "big", signed=True)` crashed and was logically wrong for big-endian.**
+
+The two's-complement path reported `dereference failure: array bounds violated`, and even the cases
+that did not crash were wrong for big-endian. The model located the sign bit with `bytes_data[-1]`:
+(1) Python **negative indexing** is not supported by the OM — `bytes_data[-1]` read out of bounds
+(the crash); (2) the most-significant byte, which carries the sign, is **byte 0** for big-endian, not
+the last byte, so `bytes([255, 0])` big-endian (CPython `-256`) was mis-evaluated independently of the
+crash.
+
+**Fix** (`models/int.py`): index the sign byte directly — `0` for big-endian, `bytes_len - 1` for
+little-endian — via a ternary (no new branch, so Mode C is not engaged), and reuse the already-computed
+`bytes_len`. This **restores a working feature** (signed `from_bytes` now matches CPython) and removes
+the crash. New regression pair `regression/python/int_from_bytes_signed{,_fail}` (CORE) covering
+big/little endian, positive/negative, single/multi-byte, the big-endian sign-in-first-byte case, and
+the unaffected `signed=False` path; the positive test is the liveness witness. Verified bit-for-bit
+against CPython for all seven cases; CPython sanity passes; pylint clean on the model; the focused
+`regression/python/(int_|from_bytes|bytes)` ctest subset (30 tests) shows zero new failures, and the
+existing `int_from_bytes` (signed=False) test still passes. Independent of the in-flight `from_bytes`
+PRs (#5597 default-signed, #5599 literal-arg triage): the tests use the explicit `signed=` keyword and
+variable receivers, so it verifies on `master` as-is.
+
+### 37b. Next candidate & everything else: unchanged disposition
+With `to_bytes` (§34), the `signed` default (§35) and now signed `from_bytes` (§37) done, the
+remaining `from_bytes` work is the §36a bytes-**literal-argument** lowering (deferred; needs the
+frontend `get_literal` context fix) and the `byteorder=` keyword form (model parameter named
+`big_endian`). A cleaner adjacent candidate is **`bytes.hex(sep)`** (the optional separator /
+`bytes_per_sep` arguments, extending §32's `bytes.hex`, stacked on PR #5585). The separately-tracked
+inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`,
+symbolic/user-function `max`/`min(key=)`, `list.index()`-in-`try/except`, `str.maketrans`/`translate`,
+`float.hex()` (infeasible), and `str.isascii()` (string-soundness). The §3 design-level blockers, §3c
+timeouts, §3d questionable expectation, and the infeasible `hashlib` case all stand; the §5 priority
+order stands.
+
+---
+
 > **Note on numbering.** §16–§29 (PRs #5526, #5531, #5532, #5536, #5537, #5540, #5543, #5548,
 > #5554, #5555, #5556, #5558, #5562, #5563) precede this section; this sweep is appended as §30.
 > Its fix is in flight as PR #5577 and not yet on `master`.

--- a/regression/python/int_from_bytes_signed/main.py
+++ b/regression/python/int_from_bytes_signed/main.py
@@ -1,0 +1,25 @@
+def main() -> None:
+    # signed=True interprets the most-significant byte's MSB as the sign:
+    # byte 0 for big-endian, the last byte for little-endian.
+    a = bytes([255, 255])
+    assert int.from_bytes(a, "big", signed=True) == -1
+
+    # The sign byte is byte 0 for big-endian (here 0xFF -> negative).
+    b = bytes([255, 0])
+    assert int.from_bytes(b, "big", signed=True) == -256
+
+    # Little-endian: the last byte carries the sign.
+    c = bytes([0, 255])
+    assert int.from_bytes(c, "little", signed=True) == -256
+
+    # Single byte, and the positive signed cases.
+    d = bytes([128])
+    assert int.from_bytes(d, "big", signed=True) == -128
+    e = bytes([1, 2])
+    assert int.from_bytes(e, "big", signed=True) == 258
+
+    # signed=False is unaffected.
+    assert int.from_bytes(e, "big", signed=False) == 258
+
+
+main()

--- a/regression/python/int_from_bytes_signed/test.desc
+++ b/regression/python/int_from_bytes_signed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_from_bytes_signed_fail/main.py
+++ b/regression/python/int_from_bytes_signed_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    a = bytes([255, 255])
+    # Two's-complement 0xFFFF signed is -1, not 65535.
+    assert int.from_bytes(a, "big", signed=True) == 65535
+
+
+main()

--- a/regression/python/int_from_bytes_signed_fail/test.desc
+++ b/regression/python/int_from_bytes_signed_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -28,11 +28,16 @@ class int:
             result: int = (result << 8) + byte
             index: int = index + step
 
-        if signed and bytes_data[-1] & 128 == 128:  # Check MSB of last byte
+        # The sign lives in the most-significant byte: index 0 for big-endian,
+        # the last byte for little-endian. Index it directly — the model does
+        # not support Python negative indexing (bytes_data[-1] read out of
+        # bounds), and bytes_data[-1] was also the wrong byte for big-endian.
+        sign_index: int = 0 if big_endian else bytes_len - 1
+        if signed and bytes_data[sign_index] & 128 == 128:  # MSB of sign byte
             is_negative: bool = True
 
         if signed and is_negative:
-            result: int = result - (1 << (8 * len(bytes_data)))
+            result: int = result - (1 << (8 * bytes_len))
 
         return result
 


### PR DESCRIPTION
Fixes the `signed=True` two's-complement path of `int.from_bytes()` (the §36b candidate from the Python triage report).

## Problem
`int.from_bytes(b, "big", signed=True)` crashed with `dereference failure: array bounds violated`, and was logically wrong for big-endian. The model located the sign bit with `bytes_data[-1]`:
- Python **negative indexing** is not supported by the operational model — `bytes_data[-1]` read out of bounds (the crash).
- The most-significant byte (which carries the sign) is **byte 0** for big-endian, not the last byte — so even without the crash the verdict would be wrong for big-endian (e.g. `bytes([255, 0])`).

## Fix
Index the sign byte directly — `0` for big-endian, `bytes_len - 1` for little-endian — via a ternary (`models/int.py`). No new branch is added (Mode-C exempt). Also reuse the already-computed `bytes_len` instead of a second `len()` call.

## Validation
- New regression pair (CORE): `int_from_bytes_signed` (big/little endian, positive/negative, single/multi-byte, big-endian sign-in-first-byte `bytes([255,0]) == -256`, and the unaffected `signed=False` case — the liveness witness) and `..._fail` (0xFFFF signed is -1, not 65535 → FAILED).
- Verified **bit-for-bit against CPython** for all seven cases.
- CPython sanity passes; pylint clean on the model; the focused `regression/python/(int_|from_bytes|bytes)` ctest subset (30 tests) shows zero new failures; the existing `int_from_bytes` (signed=False) test still passes.
- The model is FLAIL-mangled, so the binary was rebuilt before testing.

## Note
Independent of the in-flight `int.from_bytes` PRs (#5597 default-signed, #5599 literal-arg triage): tests use the explicit `signed=` keyword and variable receivers, so this verifies on `master` as-is.