### PR TITLE
[k-induction] Disable inductive step on reachable __VERIFIER_nondet_memory

### DIFF
--- a/regression/k-induction/github_5593_nondet_memory_heap/main.c
+++ b/regression/k-induction/github_5593_nondet_memory_heap/main.c
@@ -1,0 +1,26 @@
+// Issue #5593 (recurrence of #5224 / #5230): __VERIFIER_nondet_memory havocs a
+// caller object with fresh nondeterminism through a pointer
+// (`*(p + i) = nondet_uchar()` over memory with no nameable symbol). The
+// inductive step cannot generalise such an input, so a reachable call to it
+// must disable the inductive step — exactly as the per-element user
+// nondet-array builder loops do in the SV-COMP "havoc_object" shape. Unlike
+// those builders, the write lives in a hidden library model whose body is
+// linked into every program, so the gate keys on the *call*, not the loop.
+//
+// This safe program is proven by the forward condition once the inductive step
+// is disabled; the warning confirms the gate fired.
+#include <stdlib.h>
+extern void __VERIFIER_nondet_memory(void *, __SIZE_TYPE__);
+
+int main(void)
+{
+  unsigned char *a = malloc(8);
+  __ESBMC_assume(a != 0);
+  __VERIFIER_nondet_memory(a, 8); // havoc heap memory: disables the inductive step
+
+  unsigned char s = 0;
+  for (int i = 0; i < 8; i++)
+    s |= a[i]; // bounded loop, fully unwound by the forward condition
+
+  return 0;
+}

--- a/regression/k-induction/github_5593_nondet_memory_heap/test.desc
+++ b/regression/k-induction/github_5593_nondet_memory_heap/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--k-induction --max-inductive-step 3 --force-malloc-success --no-bounds-check
+^VERIFICATION SUCCESSFUL$
+does not support loops that write array elements through a pointer

--- a/regression/k-induction/github_5593_nondet_memory_heap_fail/main.c
+++ b/regression/k-induction/github_5593_nondet_memory_heap_fail/main.c
@@ -1,0 +1,21 @@
+// Issue #5593 (recurrence of #5224 / #5230) soundness guard: an UNSAFE program
+// whose nondeterministic input is built with __VERIFIER_nondet_memory. Before
+// the fix the k-induction inductive step proved the Intel-TDX-Module
+// `*_havoc_memory` tasks SAFE because this opaque memory havoc — a write
+// through a pointer with no nameable symbol — was not gated (its loop lives in
+// a hidden library model, unlike the user nondet-array builders of the
+// "havoc_object" shape). Now a reachable call disables the inductive step, so
+// the base case finds the genuinely reachable violation: VERIFICATION FAILED,
+// never a spurious SUCCESSFUL.
+#include <stdlib.h>
+extern void __VERIFIER_nondet_memory(void *, __SIZE_TYPE__);
+
+int main(void)
+{
+  unsigned char *a = malloc(8);
+  __ESBMC_assume(a != 0);
+  __VERIFIER_nondet_memory(a, 8); // havoc heap memory through a pointer
+
+  __ESBMC_assert(a[7] != 0x2A, "a[7] is nondet, so 0x2A is reachable");
+  return 0;
+}

--- a/regression/k-induction/github_5593_nondet_memory_heap_fail/test.desc
+++ b/regression/k-induction/github_5593_nondet_memory_heap_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--k-induction --max-inductive-step 3 --force-malloc-success --no-bounds-check
+^VERIFICATION FAILED$
+does not support loops that write array elements through a pointer

--- a/src/goto-programs/goto_k_induction.cpp
+++ b/src/goto-programs/goto_k_induction.cpp
@@ -498,6 +498,36 @@ bool has_direct_pointer_array_write(const goto_functionst &goto_functions)
   }
   return false;
 }
+
+/// True iff the program contains a reachable call to __VERIFIER_nondet_memory
+/// in user (non-hidden) code. That intrinsic havocs a caller object with fresh
+/// nondeterminism through a pointer (`*(p + i) = nondet_uchar()` over memory
+/// with no nameable symbol) — the opaque "havoc_memory" analogue of the
+/// per-element user nondet-array builder loops the SV-COMP "havoc_object" shape
+/// uses. The inductive step cannot generalise such an input, so a reachable
+/// call makes it unsound: it proves unsafe programs SAFE (the
+/// SoftwareSystems-Intel-TDX-Module-ReachSafety `*_havoc_memory` tasks). The
+/// model body is linked into *every* program, so gate on an actual call, not
+/// on its always-present loop. See #5593 (recurrence of #5224 / #5230).
+bool calls_nondet_memory(const goto_functionst &goto_functions)
+{
+  forall_goto_functions (it, goto_functions)
+  {
+    if (!it->second.body_available || it->second.body.hide)
+      continue;
+    for (const auto &instr : it->second.body.instructions)
+    {
+      if (!instr.is_function_call())
+        continue;
+      const code_function_call2t &call = to_code_function_call2t(instr.code);
+      if (
+        is_symbol2t(call.function) &&
+        to_symbol2t(call.function).thename == "c:@F@__VERIFIER_nondet_memory")
+        return true;
+    }
+  }
+  return false;
+}
 } // namespace
 
 bool goto_k_induction(goto_functionst &goto_functions, const namespacet &ns)
@@ -524,7 +554,10 @@ bool goto_k_induction(goto_functionst &goto_functions, const namespacet &ns)
     }
   }
 
-  bool disable_inductive_step = false;
+  // A reachable __VERIFIER_nondet_memory call havocs a caller object the
+  // inductive step cannot generalise, so its unsoundness is independent of any
+  // loop shape — disable the inductive step up front. See #5593.
+  bool disable_inductive_step = calls_nondet_memory(goto_functions);
   Forall_goto_functions (it, goto_functions)
   {
     if (!it->second.body_available)


### PR DESCRIPTION
## Problem

ESBMC's k-induction inductive step unsoundly returns `VERIFICATION SUCCESSFUL` on 27 unsafe Intel-TDX-Module SV-COMP tasks (`tdh_mr_finalize` / `tdh_phymem_page_reclaim` families, all `*_havoc_memory` shape, `expected_verdict: false`). These are missed bugs — unsafe code proven safe.

## Root cause

The pointer-array havoc gate added in #5228 / #5230 only fires on **user-code** loops that write array elements through a pointer. The `__VERIFIER_nondet_memory` intrinsic havocs a caller object the same way (`*(p + i) = nondet_uchar()` over memory with no nameable symbol), but its write loop lives in a **hidden library model** (`body.hide`). The existing gate excludes hidden bodies, so the call slips through and the inductive step over-approximates the havoc'd input to `true`.

## Fix

Gate on a *reachable call* to `__VERIFIER_nondet_memory` in user code, rather than on the always-present library loop. A reachable call disables the inductive step up front, so the base/forward case finds the genuine violation instead of a spurious proof. This keeps soundness independent of the loop's location.

## Tests

Two regression tests under `regression/k-induction/`:
- `github_5593_nondet_memory_heap` — safe program, proven `SUCCESSFUL` by the forward condition once the gate fires.
- `github_5593_nondet_memory_heap_fail` — unsafe program; the gate ensures `VERIFICATION FAILED`, never a spurious `SUCCESSFUL`.

Full `k-induction` and `k-induction-parallel` regression suites pass with no regressions.

Fixes #5593