### PR TITLE
[docs] V.3: enumerate the remaining tasks to reach 100% IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3544,46 +3544,54 @@ verdict + counterexample parity holds (dual-solver Bitwuzla + Z3). With these,
 the clean V.3 surface is drained; the residual is exactly the two
 permanently-blocked classes above.
 
-#### V.3 residual reclassified (2026-06-24) — the (b) adjuster route is pinned by the closed W1 boundary
+#### V.3 residual → the remaining tasks to reach 100 % IREP2 (2026-06-24)
 
-The notes above repeatedly hand the F-P11 + width-hazard residual to "the
-**V.1k/V.4 IREP2-native adjuster** … at V.4+". A read-only spike against the
-post-V.4 tree shows that escape route is **itself closed**, by the same wall
-that made W1 a `RETAIN_BOUNDARY`. The residual is therefore reclassified from
-*pending (needs the V.4+ adjuster)* to **boundary-pinned**, with the evidence:
+The pre-V.4 clean V.3 surface is drained; the residual is exactly the two
+classes above (F-P11 user-operand sites + width-hazard guards). Both share one
+root cause and therefore one fix, so the path to **100 % IREP2** is a small,
+ordered task list — not an open-ended sweep. A read-only spike pins the
+constraint the keystone task must respect:
 
-1. **Adjust runs on legacy `codet`, before goto-convert.**
-   `python_languaget::final` constructs `clang_cpp_adjust adjuster(context)` and
-   calls `adjuster.adjust()` (`python_language.cpp:249-250`); the entry is
-   `clang_cpp_adjust::adjust_code(codet&)` (`clang_cpp_adjust.h:32`) — a
-   **legacy `codet`** walk over the symbol values. This is where the converter's
-   unresolved `member`/`index` sources get followed (the P2/W2 resolution), and
-   it happens on legacy bodies.
-2. **V.4 retained the legacy body as the source of truth.** The *V.4 outcome*
-   section concluded W1 is a **closed boundary**: bodies round-trip through
-   IREP2 only *transiently inside* `goto_convert` and are restored to legacy
-   because IREP2 value nodes carry **no per-node source location** (W1-loc) and
-   verification-visible fidelity depends on it. So V.4 did **not** deliver
-   symbol-value IREP2 bodies.
-3. **The (b) adjuster's stated precondition is unmet and closed.** The *V.1k
-   breakthrough* deferred the separate IREP2-native adjuster to "V.4+" on the
-   explicit ground that "a separate adjuster … cannot run until function
-   **bodies** are IREP2 — which is V.4." V.4's actual outcome is that bodies
-   stay legacy (point 2). A separate IREP2-native adjuster therefore has **no
-   IREP2 body to operate on** at adjust time, and the converter cannot emit a
-   *whole* IREP2 body pre-adjust both because of the resolved-source
-   chicken-and-egg (the relaxed assert only lets individual nodes round-trip)
-   and the W1-loc value-node location wall.
+- **The resolution lives in a legacy-`codet` adjust pass.** `python_languaget::
+  final` runs `clang_cpp_adjust::adjust()` over the symbol values
+  (`python_language.cpp:249-250`, entry `adjust_code(codet&)`,
+  `clang_cpp_adjust.h:32`); this is where the converter's unresolved
+  `member`/`index` sources get followed (the P2/W2 resolution). The residual
+  aborts because the converter builds those nodes **before** this pass.
+- **The goto-convert body round-trip stays legacy (W1-loc) — and is off this
+  critical path.** V.4 concluded the *body* round-trip is a `RETAIN_BOUNDARY`
+  for source-location fidelity. That governs `goto_convert`'s side-effect
+  hoisting, **not** the converter→adjust type-resolution seam where the residual
+  is built, so it does not block the tasks below.
 
-**Consequence.** Draining the V.3 residual is not a focused phase blocked on one
-keystone; it requires the **same large, rejected initiative** as the deeper W1
-removal — native IREP2 bodies *plus* native value-node location carriage
-through both `clang_cpp_adjust` and `goto_convert`. Until that is taken (its
-own umbrella, well beyond Python), the F-P11 + width-hazard residual is
-**retained by design**, exactly like W1/W3/W4. The converter-side V.3
-construction work is therefore **complete**; the remaining Part V tracks that do
-*not* depend on this boundary are **V.5** (IREP2-native counterexample printer,
-independent — Part II §2.7, own issue) and the eventual **V.6** flip.
+**Tasks to 100 % (ordered; the first is the keystone, RV2 the gate):**
+
+1. **V.1k — resolve-then-build via the design-(b) IREP2-native adjuster.**
+   Stand up the Python-specific IREP2 adjuster that performs `clang_cpp_adjust`'s
+   *complete* resolution (recursive struct-following + auto-deref +
+   dataclass/inference-aware completion) as one IREP2 pass, so the converter can
+   build `member2tc`/`index2tc`/arith with **resolved** operand types and the
+   F-P11 + width-hazard aborts vanish. **Open design question to settle in the
+   first spike:** whether this runs as a type-resolution *service* the converter
+   queries at construction (no materialised IREP2 body needed) or requires
+   materialising IREP2 bodies pre-adjust (the resolved-source chicken-and-egg
+   the relaxed assert only partially lifts). *Accept (RV2, hard gate):* the
+   20-test acceptance fixture (§V.1k design (b)) back to green; the F-P11/
+   width-hazard sites build in-converter with zero `irep2_expr.h` aborts;
+   verdict + text unchanged.
+2. **V.2 — IREP2-native attribute carriage (W3).** Fold `#cpp_type`/
+   `#member_name`/`#cformat` onto the typed IREP2 companion; the (b) adjuster is
+   the natural home, so V.1k and V.2 land together.
+3. **V.5 — IREP2-native counterexample printer (W4).** Independent of the above
+   (Part II §2.7, own issue); can proceed in parallel.
+4. **V.6 — flip & verify.** Switch the symbol-table writes fully to
+   `set_value(expr2tc)`, census → ~0, dual-solver + asserts + `esbmc-cpp`
+   parity. §V.1 bar met.
+
+Converter-side V.3 *construction* is drained as far as the pre-adjust assert
+allows; everything remaining is the V.1k keystone and what it unblocks. The
+deeper W1 body round-trip (V.4) is the one piece retained by design — it is a
+shared goto-convert concern, not part of the Python 100 % target.
 
 ### Phase V.4 — IREP2 structured CF + IREP2-aware `goto_convert` (removes W1)
 Add the missing structured CF code kinds to IREP2 (`code_ifthenelse2t`,

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3544,6 +3544,47 @@ verdict + counterexample parity holds (dual-solver Bitwuzla + Z3). With these,
 the clean V.3 surface is drained; the residual is exactly the two
 permanently-blocked classes above.
 
+#### V.3 residual reclassified (2026-06-24) — the (b) adjuster route is pinned by the closed W1 boundary
+
+The notes above repeatedly hand the F-P11 + width-hazard residual to "the
+**V.1k/V.4 IREP2-native adjuster** … at V.4+". A read-only spike against the
+post-V.4 tree shows that escape route is **itself closed**, by the same wall
+that made W1 a `RETAIN_BOUNDARY`. The residual is therefore reclassified from
+*pending (needs the V.4+ adjuster)* to **boundary-pinned**, with the evidence:
+
+1. **Adjust runs on legacy `codet`, before goto-convert.**
+   `python_languaget::final` constructs `clang_cpp_adjust adjuster(context)` and
+   calls `adjuster.adjust()` (`python_language.cpp:249-250`); the entry is
+   `clang_cpp_adjust::adjust_code(codet&)` (`clang_cpp_adjust.h:32`) — a
+   **legacy `codet`** walk over the symbol values. This is where the converter's
+   unresolved `member`/`index` sources get followed (the P2/W2 resolution), and
+   it happens on legacy bodies.
+2. **V.4 retained the legacy body as the source of truth.** The *V.4 outcome*
+   section concluded W1 is a **closed boundary**: bodies round-trip through
+   IREP2 only *transiently inside* `goto_convert` and are restored to legacy
+   because IREP2 value nodes carry **no per-node source location** (W1-loc) and
+   verification-visible fidelity depends on it. So V.4 did **not** deliver
+   symbol-value IREP2 bodies.
+3. **The (b) adjuster's stated precondition is unmet and closed.** The *V.1k
+   breakthrough* deferred the separate IREP2-native adjuster to "V.4+" on the
+   explicit ground that "a separate adjuster … cannot run until function
+   **bodies** are IREP2 — which is V.4." V.4's actual outcome is that bodies
+   stay legacy (point 2). A separate IREP2-native adjuster therefore has **no
+   IREP2 body to operate on** at adjust time, and the converter cannot emit a
+   *whole* IREP2 body pre-adjust both because of the resolved-source
+   chicken-and-egg (the relaxed assert only lets individual nodes round-trip)
+   and the W1-loc value-node location wall.
+
+**Consequence.** Draining the V.3 residual is not a focused phase blocked on one
+keystone; it requires the **same large, rejected initiative** as the deeper W1
+removal — native IREP2 bodies *plus* native value-node location carriage
+through both `clang_cpp_adjust` and `goto_convert`. Until that is taken (its
+own umbrella, well beyond Python), the F-P11 + width-hazard residual is
+**retained by design**, exactly like W1/W3/W4. The converter-side V.3
+construction work is therefore **complete**; the remaining Part V tracks that do
+*not* depend on this boundary are **V.5** (IREP2-native counterexample printer,
+independent — Part II §2.7, own issue) and the eventual **V.6** flip.
+
 ### Phase V.4 — IREP2 structured CF + IREP2-aware `goto_convert` (removes W1)
 Add the missing structured CF code kinds to IREP2 (`code_ifthenelse2t`,
 `code_while2t`, `code_for2t`, `code_switch2t`, `code_break2t`,


### PR DESCRIPTION
Reframes the V.3 residual as an **ordered task list to reach 100% IREP2 in the frontends**, rather than a boundary-pinned dead end.

The two residual classes (F-P11 user-operand sites + width-hazard guards) share one root cause: their operands are resolved only by the legacy `clang_cpp_adjust` pass that runs *after* the converter builds them (`python_language.cpp:249-250`), so building IREP2 nodes pre-adjust aborts on the `member2t`/`index2t` resolved-source assert. One cause ⇒ one fix, so the path to 100% is a small, ordered task list:

1. **V.1k — resolve-then-build via the design-(b) IREP2-native adjuster** (keystone; RV2 is the hard gate). Open design question flagged for the first spike: type-resolution *service* vs. materialised IREP2 bodies pre-adjust.
2. **V.2 — IREP2-native attribute carriage (W3)** — folds into the (b) adjuster.
3. **V.5 — IREP2-native counterexample printer (W4)** — independent, parallel.
4. **V.6 — flip & verify.**

A read-only spike records the design constraint the keystone must respect — resolution lives in a legacy-`codet` adjust pass, and the W1-loc goto-convert body round-trip stays legacy by design — but that round-trip governs side-effect hoisting, **not** the converter→adjust type-resolution seam, so it is off this critical path. The deeper W1 body removal remains a shared goto-convert concern outside the Python 100% target.

Squeezes the prior verbose reclassification note into this task-focused form.

Stacked on #5600 (base retargets to master once that merges). Refs #4715