### PR TITLE
[python] Support str.translate(str.maketrans(...)) constant fold

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1311,6 +1311,55 @@ work; the §5 priority order stands.
 
 ---
 
+> **Note on numbering.** §30–§37 (PRs #5577/#5579/#5585/#5588/#5592/#5597/#5601 and the #5599 triage
+> finding) are in flight and not yet on `master`; this sweep is appended as §38. Its fix is in
+> flight as PR #5604.
+
+## 38. 2026-06-24 (twenty-eighth sweep) & str.translate(str.maketrans(...))
+
+Re-test against current `master` (tip `6d79c6204c`). KNOWNBUG classification unchanged — §3 holds.
+An idiom battery confirmed `swapcase`/`title`/`zfill`/`removeprefix`/`removesuffix` already verify;
+`str.translate` (and `str.isascii`, withdrawn as unsound in §19a) were the unmodelled ones. This sweep
+took `str.translate` — an independent candidate on `master` (no PR stacking, unlike `bytes.hex(sep)`).
+
+### 38a. New isolated, soundly-fixable defect found & fixed
+**`str.translate` was unmodelled, producing a spurious `VERIFICATION FAILED`.**
+
+`"hello".translate(str.maketrans("el", "ip"))` (CPython `"hippo"`) reported `Unsupported function
+'translate'` → `FAILED`.
+
+**Fix** (`string/string_handler.cpp`): in `handle_string_attribute_call`, constant-fold the common
+idiom `s.translate(str.maketrans(x, y[, z]))` over constant operands — pattern-match the inline
+`str.maketrans(...)` call, extract the constant strings, then map each receiver char `x[i] → y[i]`,
+delete the characters in `z`, and keep the rest (delete takes precedence, matching CPython); the
+`len(x) != len(y)` case raises the CPython `ValueError`. The byte-wise fold is **gated on ASCII
+operands** so a multi-byte UTF-8 sequence cannot be remapped/deleted one byte at a time (which would
+corrupt the string — a soundness concern caught in code review); non-ASCII operands, a dict table, and
+non-constant operands fall through to the existing (unsupported) dispatch — sound, never a wrong
+verdict. `translate` already infers a `str` return type, so no type-inference change is needed.
+
+Like §16a–§20a/§32a this **restores a working feature**. New regression pair
+`regression/python/str_translate{,_fail}` (CORE) covering the 2-arg map, 3-arg delete, a variable
+receiver, absent-char passthrough, and `len`/index on the result; the positive test is the liveness
+witness. Verified bit-for-bit against CPython; CPython sanity passes; the focused
+`regression/python/(str|string)` ctest subset (444 tests) shows zero new failures (12 solver-pinned
+`--z3`/`--ir`/`--boolector` excepted); the ASCII gate confirmed (non-ASCII `translate` falls through).
+Code-reviewed (0 critical/major; the one medium finding — non-ASCII byte corruption — closed by the
+ASCII gate). Solver-agnostic (frontend constant-fold, no SMT encoding).
+
+### 38b. Next candidate & everything else: unchanged disposition
+Remaining catalogued candidates: `bytes.hex(sep)` separator arguments (extends §32, stacks on
+PR #5585); the §36a bytes-**literal-argument** lowering (deferred — needs the frontend `get_literal`
+context fix); the `int.from_bytes(byteorder=)` keyword form (model parameter named `big_endian`); and
+the `str.maketrans`/`translate` dict-table and non-constant forms (fall through cleanly today). The
+separately-tracked inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other deferred candidates
+stand: `zip()`, symbolic/user-function `max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()`
+(infeasible), and `str.isascii()` (string-soundness, §5-#2). The §3 design-level blockers, §3c
+timeouts, §3d questionable expectation, and the infeasible `hashlib` case all stand; the §5 priority
+order stands.
+
+---
+
 > **Note on numbering.** §16–§29 (PRs #5526, #5531, #5532, #5536, #5537, #5540, #5543, #5548,
 > #5554, #5555, #5556, #5558, #5562, #5563) precede this section; this sweep is appended as §30.
 > Its fix is in flight as PR #5577 and not yet on `master`.

--- a/regression/python/str_translate/main.py
+++ b/regression/python/str_translate/main.py
@@ -1,0 +1,17 @@
+def main() -> None:
+    # Two-string maketrans: map each x[i] to y[i].
+    s = "hello".translate(str.maketrans("el", "ip"))
+    assert s == "hippo"
+    assert len(s) == 5 and s[1] == "i"
+
+    # Three-string maketrans: the third argument's characters are deleted.
+    d = "hello world".translate(str.maketrans("", "", "lo"))
+    assert d == "he wrd"
+
+    # A variable receiver works, and characters absent from the table are kept.
+    x = "abcabc"
+    assert x.translate(str.maketrans("abc", "xyz")) == "xyzxyz"
+    assert "keep".translate(str.maketrans("Q", "Z")) == "keep"
+
+
+main()

--- a/regression/python/str_translate/test.desc
+++ b/regression/python/str_translate/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_translate_fail/main.py
+++ b/regression/python/str_translate_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # "hello" with e->i, l->p is "hippo", not "hello".
+    assert "hello".translate(str.maketrans("el", "ip")) == "hello"
+
+
+main()

--- a/regression/python/str_translate_fail/test.desc
+++ b/regression/python/str_translate_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2279,6 +2279,63 @@ exprt string_handler::handle_string_attribute_call(
       return nil_exprt();
   }
 
+  // str.translate(str.maketrans(x, y[, z])): fold a constant string through a
+  // constant translation table. CPython maps each x[i] to y[i] and deletes the
+  // characters in z. Only the two/three-string maketrans form over constant
+  // operands is modelled; a dict table or a non-constant operand falls through
+  // to the regular (unsupported) dispatch.
+  if (method_name == "translate" && args.size() == 1)
+  {
+    const nlohmann::json &mk = args[0];
+    if (
+      mk.is_object() && mk.value("_type", std::string()) == "Call" &&
+      mk.contains("func") &&
+      mk["func"].value("_type", std::string()) == "Attribute" &&
+      mk["func"].value("attr", std::string()) == "maketrans" &&
+      mk["func"].contains("value") &&
+      mk["func"]["value"].value("_type", std::string()) == "Name" &&
+      mk["func"]["value"].value("id", std::string()) == "str" &&
+      mk.contains("args") && mk["args"].is_array())
+    {
+      const nlohmann::json &mkargs = mk["args"];
+      std::string from_chars, to_chars, del_chars, recv;
+      auto all_ascii = [](const std::string &s) {
+        for (unsigned char ch : s)
+          if (ch >= 0x80)
+            return false;
+        return true;
+      };
+      if (
+        (mkargs.size() == 2 || mkargs.size() == 3) &&
+        extract_constant_string(mkargs[0], converter_, from_chars) &&
+        extract_constant_string(mkargs[1], converter_, to_chars) &&
+        (mkargs.size() == 2 ||
+         extract_constant_string(mkargs[2], converter_, del_chars)) &&
+        extract_constant_string(receiver_json, converter_, recv) &&
+        // The fold is byte-wise; restrict it to ASCII so a multi-byte UTF-8
+        // sequence cannot be remapped/deleted one byte at a time (which would
+        // corrupt the string). Non-ASCII operands fall through to the regular
+        // (unsupported) dispatch — sound, never a wrong verdict.
+        all_ascii(from_chars) && all_ascii(to_chars) && all_ascii(del_chars) &&
+        all_ascii(recv))
+      {
+        if (from_chars.size() != to_chars.size())
+          throw std::runtime_error(
+            "str.maketrans() arguments must have equal length");
+        std::string result;
+        result.reserve(recv.size());
+        for (char c : recv)
+        {
+          if (del_chars.find(c) != std::string::npos)
+            continue;
+          const std::size_t pos = from_chars.find(c);
+          result.push_back(pos == std::string::npos ? c : to_chars[pos]);
+        }
+        return string_builder_->build_string_literal(result);
+      }
+    }
+  }
+
   std::optional<locationt> cached_location;
   auto get_location = [&]() -> locationt {
     if (!cached_location.has_value())


### PR DESCRIPTION
Implements `str.translate` for the common `str.maketrans` idiom (a deferred Python triage candidate).

## Problem
`str.translate` was unmodelled, so any program calling it reported a spurious `VERIFICATION FAILED` (the call lowered to `assert(false)`).

## Fix
In `handle_string_attribute_call`, constant-fold `s.translate(str.maketrans(x, y[, z]))` over constant operands: pattern-match the inline `str.maketrans(...)` call, extract the constant strings, then map each receiver char `x[i]→y[i]`, delete the characters in `z`, and keep the rest (delete takes precedence, matching CPython). The equal-length check on `x`/`y` raises the CPython `ValueError`.

The byte-wise fold is **gated on ASCII operands** so a multi-byte UTF-8 sequence cannot be remapped/deleted one byte at a time (which would corrupt the string); non-ASCII operands, a dict table, and non-constant operands all fall through to the existing (unsupported) dispatch — sound, never a wrong verdict. `translate` already infers a `str` return type, so no type-inference change is needed.

## Validation
- New regression pair (CORE): `str_translate` (2-arg map, 3-arg delete, variable receiver, absent-char passthrough, `len`/index on the result — the liveness witness) and `str_translate_fail` (wrong result → FAILED).
- Verified bit-for-bit against CPython; CPython sanity passes; focused `regression/python/(str|string)` ctest subset (444 tests) shows zero new failures (12 solver-pinned `--z3`/`--ir`/`--boolector` excepted); the ASCII gate confirmed (non-ASCII `translate` falls through, no wrong fold).
- Code-reviewed (0 critical/major; the one medium finding — non-ASCII byte-level corruption — is closed by the ASCII gate); clang-format clean; solver-agnostic (frontend constant-fold, no SMT encoding).

Independent on `master` (no dependency on the in-flight Python PRs).