### PR TITLE
[python] V.3: build resolved-source str/tuple stragglers in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -4,6 +4,7 @@
 #include <python-frontend/json_utils.h>
 #include <python-frontend/python_consteval.h>
 #include <python-frontend/python_converter.h>
+#include <python-frontend/python_expr_builder.h>
 #include <python-frontend/python_dict_handler.h>
 #include <python-frontend/python_annotation.h>
 #include <python-frontend/python_exception_handler.h>
@@ -132,7 +133,10 @@ void python_converter::adjust_statement_types(exprt &lhs, exprt &rhs) const
     const typet lhs_follow = ns.follow(lhs_type);
     if (lhs_follow.is_struct() && ns.follow(rhs_type.subtype()) == lhs_follow)
     {
-      rhs = dereference_exprt(rhs, lhs_type);
+      // V.3: build the deref in IREP2 (byte-identical round-trip; the helper
+      // restores the exact result type and falls back to legacy for dyn-array
+      // pointees).
+      rhs = python_expr::build_dereference(rhs, lhs_type);
       return;
     }
   }
@@ -1001,7 +1005,8 @@ bool python_converter::handle_unpacking_assignment(
       pointed_type.id() == "struct" &&
       tuple_handler_->is_tuple_type(pointed_type))
     {
-      exprt tuple_value = dereference_exprt(rhs, pointed_type);
+      // V.3: build the deref in IREP2 (resolved tuple-struct pointee).
+      exprt tuple_value = python_expr::build_dereference(rhs, pointed_type);
       tuple_value.location() = rhs.location();
       tuple_handler_->handle_tuple_unpacking(
         ast_node, target, tuple_value, target_block);

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4307,17 +4307,19 @@ exprt function_call_expr::handle_general_function_call()
         temp_decl.location() = location;
         converter_.current_block->copy_to_operands(temp_decl);
 
-        // Assign the character to the first element
+        // Assign the character to the first element. V.3: build the index in
+        // IREP2 (resolved array-typed symbol source) — the byte-identical
+        // round-trip of index_exprt(temp_array, .., char_type()).
         exprt temp_array = build_symbol(temp_symbol);
         exprt first_element =
-          index_exprt(temp_array, from_integer(0, size_type()));
+          build_index(temp_array, from_integer(0, size_type()));
         code_assignt assign_char(first_element, arg);
         assign_char.location() = location;
         converter_.current_block->copy_to_operands(assign_char);
 
         // Assign null terminator to the second element
         exprt second_element =
-          index_exprt(temp_array, from_integer(1, size_type()));
+          build_index(temp_array, from_integer(1, size_type()));
         code_assignt assign_null(second_element, from_integer(0, char_type()));
         assign_null.location() = location;
         converter_.current_block->copy_to_operands(assign_null);


### PR DESCRIPTION
Completes the resolved-source index/deref drains the #5586/#5587/#5589 series left behind: the `str(char)` 2-element array subscripts (`function_call/expr.cpp`) and the tuple-unpack / struct-pointer-field pointer dereferences (`converter_stmt.cpp`), via `build_index` / `build_dereference`.

Each source is a resolved array/struct, so the helpers emit the byte-identical IREP2 round-trip of the legacy node (exact result-type restoration + dyn-array legacy fallback). Reduces the §V.1 item-1 legacy census. Verified: dual-solver Bitwuzla + Z3 (positive SUCCESSFUL, negative FAILED) and a 388-test python regression subset (100% pass).

Refs #4715