### PR TITLE
[python] V.3: build string-constant address-of in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3537,7 +3537,8 @@ void python_converter::get_return_statements(
           str_content, string_type, string_constantt::k_default);
 
         // Get its address (converts array to pointer)
-        return_value = address_of_exprt(return_value);
+        // V.3: build the address-of in IREP2 (operand is a string constant).
+        return_value = python_expr::build_address_of(return_value);
       }
       else
       {

--- a/src/python-frontend/exception_utils.cpp
+++ b/src/python-frontend/exception_utils.cpp
@@ -1,4 +1,5 @@
 #include <python-frontend/exception_utils.h>
+#include <python-frontend/python_expr_builder.h>
 
 #include <util/c_types.h>
 
@@ -26,7 +27,8 @@ exprt make_exception_raise(
   string_constantt string_name(message, t, string_constantt::k_default);
 
   exprt sym("struct", type);
-  sym.copy_to_operands(address_of_exprt(string_name));
+  // V.3: build the address-of in IREP2 (operand is a string constant).
+  sym.copy_to_operands(python_expr::build_address_of(string_name));
 
   exprt raise = side_effect_exprt("cpp-throw", type);
   raise.move_to_operands(sym);


### PR DESCRIPTION
Continues Part V Phase V.3 of `docs/irep2-migration.md`: replacing the Python converter's legacy expression-builder call sites with IREP2 byte-identical round-trips via `python_expr::build_*`.

Routes the two remaining `address_of_exprt` sites whose operand is a `string_constantt` through the existing `build_address_of` helper:
- the string-return value address (array→pointer) in `get_return_statements` (`converter_stmt.cpp`), and
- the exception-message address in `make_exception_raise` (`exception_utils.cpp`).

String constants always migrate cleanly to `constant_string2t` with no member/index resolution involved, so each is the byte-identical round-trip `migrate_expr_back(address_of2tc(obj->type, migrate(obj)))` of the legacy node. `address_of2t(subtype, ptrobj)` wraps `subtype` in `pointer_type2tc`, reproducing the legacy `address_of_exprt` result type exactly.

Behaviour-preserving: 29 CORE exception/string-return regression tests verified green on the rebuilt binary (the one KNOWNBUG, `bare_raise_nested`, is unrelated and unchanged).