### PR TITLE
[python] V.3: build indirect-call function pointer in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -3,6 +3,7 @@
 #include <python-frontend/json_utils.h>
 #include <python-frontend/python_consteval.h>
 #include <python-frontend/python_converter.h>
+#include <python-frontend/python_expr_builder.h>
 #include <python-frontend/python_lambda.h>
 #include <python-frontend/python_list.h>
 #include <python-frontend/string/string_builder.h>
@@ -610,10 +611,12 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // For Any-typed (void*) parameters, cast to a generic function pointer
       // so that the adjuster can dereference it to a code type (it calls
       // to_code_type on the dereferenced subtype, which would fail on void).
-      exprt func_ptr_expr = symbol_expr(*var_symbol);
+      // V.3: build the function-pointer reference (and the generic-pointer
+      // cast the adjuster relies on) in IREP2; both are over a clean symbol.
+      exprt func_ptr_expr = python_expr::build_symbol(*var_symbol);
       if (var_symbol->get_type() == any_type())
-        func_ptr_expr =
-          typecast_exprt(func_ptr_expr, gen_pointer_type(code_typet()));
+        func_ptr_expr = python_expr::build_typecast(
+          func_ptr_expr, gen_pointer_type(code_typet()));
       call.function() = func_ptr_expr;
 
       // Resolve return type from the concrete target function stored in


### PR DESCRIPTION
Continues Part V Phase V.3 of `docs/irep2-migration.md`: draining legacy expression construction from the Python converter.

Routes the function-pointer reference and the generic-pointer cast used for indirect calls through a function-pointer variable (`get_function_call`, `converter_funcall.cpp`) through the `build_symbol` / `build_typecast` helpers.

Both operate over a clean symbol (a function-pointer variable), so each is the byte-identical round-trip of the legacy node. `build_typecast` restores the exact `gen_pointer_type(code_typet())` target type after `migrate_type` — load-bearing here, since the adjuster calls `to_code_type` on the dereferenced subtype for Any-typed (void*) parameters.

Behaviour-preserving: 20 indirect-call regression tests verified green on the rebuilt binary, including the Any-typed dispatch case `github_4827_runtime_model_dispatch` that exercises the cast path, plus the `higher-order*` and `callable*` families.