### PR TITLE
[python] V.3: build numpy flat-pointer arg casts via np_typecast

### DIFF
--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -3253,8 +3253,10 @@ exprt numpy_call_expr::create_expr_from_call()
           pointer_typet(is_float ? double_type() : long_long_int_type());
         if (args.size() >= 2)
         {
-          args[0] = typecast_exprt(args[0], flat_ptr_type);
-          args[1] = typecast_exprt(args[1], flat_ptr_type);
+          // V.3: build the flat-pointer arg casts in IREP2 via np_typecast,
+          // matching the sibling binary-op branches (e.g. lines 3133-3134).
+          args[0] = np_typecast(args[0], flat_ptr_type);
+          args[1] = np_typecast(args[1], flat_ptr_type);
         }
         args.push_back(
           np_typecast(np_address_of(*converter_.current_lhs), flat_ptr_type));


### PR DESCRIPTION
Continues Part V Phase V.3 of `docs/irep2-migration.md`: draining legacy expression construction from the Python frontend.

The 2D matmul/dot branch in `numpy_call_expr.cpp` cast its two flat-pointer arguments with raw `typecast_exprt`, while every sibling binary-op branch already used the numpy IREP2 helper `np_typecast` (e.g. lines 3133-3134, 2428, 2553). This routes the two remaining raw sites through `np_typecast` for consistency — they were the last raw legacy builders in `numpy_call_expr.cpp`.

`np_typecast` is the byte-identical round-trip `migrate_expr_back(typecast2tc(migrate_type(t), migrate(from)))`; the operand types (numpy array pointers) are exactly those the sibling branches already migrate.

Behaviour-preserving: numpy 2D binary-op, matmul, and dot regression tests verified green on the rebuilt binary (`github_5115_matmul_*`, `dot*`, `github_4668_*_2d_supported`, the unsupported-arithmetic and broadcast-mismatch `ERROR:` cases).