### PR TITLE
[python] V.4 B.2: wire python_adjust behind --python-irep2-adjust

### DIFF
--- a/regression/python/python_irep2_adjust_flag/main.py
+++ b/regression/python/python_irep2_adjust_flag/main.py
@@ -1,0 +1,17 @@
+# Exercises the --python-irep2-adjust flag (V.4 B.2). Class member access is
+# the construct the IREP2-native adjuster will resolve once the converter emits
+# transient symbol_type member sources (B.3); for now the flag is inert and the
+# verdict must match the default path.
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x: int = x
+        self.y: int = y
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 3
+    assert p.y == 4
+
+
+main()

--- a/regression/python/python_irep2_adjust_flag/test.desc
+++ b/regression/python/python_irep2_adjust_flag/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_flag_fail/main.py
+++ b/regression/python/python_irep2_adjust_flag_fail/main.py
@@ -1,0 +1,14 @@
+# Negative variant of python_irep2_adjust_flag: the member read contradicts the
+# constructed value, so verification must fail under --python-irep2-adjust too.
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x: int = x
+        self.y: int = y
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 99
+
+
+main()

--- a/regression/python/python_irep2_adjust_flag_fail/test.desc
+++ b/regression/python/python_irep2_adjust_flag_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -123,6 +123,10 @@ const struct group_opt_templ all_cmd_options[] = {
      {"python-list-compare-depth",
       boost::program_options::value<int>()->default_value(4)->value_name("nr"),
       "Set maximum nesting depth for Python list comparison (default is 4)"},
+     {"python-irep2-adjust",
+      NULL,
+      "Run the IREP2-native Python adjuster alongside the legacy adjust pass "
+      "(V.4 migration; experimental, default off)"},
    }},
 #endif
 #ifdef ENABLE_LD_FRONTEND

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -447,9 +447,19 @@ public:
     // struct view at the SMT boundary (see struct_union_members), and
     // the clang frontend builds complex literals as struct-id exprt
     // with a complex type — accept that shape here.
+    //
+    // A symbol_id type is permitted ONLY as a transient pre-resolution state,
+    // the same V.1k "two-phase source invariant" the member2t/index2t asserts
+    // carry: the Python frontend stores class instances with a by-name
+    // symbol_type and resolves it lazily, so migrating a constant aggregate
+    // before the IREP2-native adjuster has followed the type would otherwise
+    // abort here. The adjuster re-establishes the strong invariant before symex;
+    // no frontend builds a constant_struct2t pre-adjust today, so this disjunct
+    // is staged enabling infra exercised by the --python-irep2-adjust path.
     assert(
       type->type_id == type2t::struct_id ||
-      type->type_id == type2t::complex_id);
+      type->type_id == type2t::complex_id ||
+      type->type_id == type2t::symbol_id);
   }
   constant_struct2t(const constant_struct2t &ref) = default;
 

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -21,12 +21,26 @@ bool python_adjust::adjust()
     if (symbol->is_type)
       continue;
 
+    // Only function bodies carry the member2t/index2t expressions this pass
+    // resolves, and only bodies are what goto-convert later migrates via
+    // get_value2() (V.4.4b). Reading get_value2() on a data symbol whose value
+    // is a by-name-typed constant aggregate would trip constant_struct2t's
+    // (un-relaxed) migration assert, so skip non-code symbols.
+    if (!is_code_type(symbol->get_type2()))
+      continue;
+
     expr2tc value = symbol->get_value2();
     if (is_nil_expr(value))
       continue;
 
+    const expr2tc original = value;
     adjust_expr(value);
-    symbol->set_value(value);
+    // Only write back when resolution actually changed the tree. Leaving an
+    // unchanged symbol untouched keeps its legacy value cache valid, so the
+    // following clang_cpp_adjust pass sees a byte-identical body — the pass is
+    // inert until the converter emits transient symbol_type member sources.
+    if (value != original)
+      symbol->set_value(value);
   }
 
   return false;

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -2,6 +2,7 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_annotation.h>
 #include <python-frontend/global_scope.h>
+#include <python-frontend/python_adjust.h>
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
 #include <util/message.h>
 #include <util/filesystem.h>
@@ -249,6 +250,23 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
   clang_cpp_adjust adjuster(context);
   if (adjuster.adjust())
     return true;
+
+  // V.4 B.2: optionally run the IREP2-native Python adjuster. Default off.
+  //
+  // It runs *after* clang_cpp_adjust for now: reading get_value2() migrates each
+  // legacy value to IREP2, which requires its types to already be resolved —
+  // before clang_cpp_adjust they are still by-name symbol_types and migrating a
+  // constant aggregate trips constant_struct2t's (un-relaxed) assert. Post-adjust
+  // the types are resolved, so the walk is safe; it currently resolves nothing
+  // (clang_cpp_adjust already did) and only writes a symbol back when it changes
+  // the value, so the flag is behaviour-inert. Moving the pass *before*
+  // clang_cpp_adjust to actually replace it (B.5) first requires resolving the
+  // migration-before-resolution problem this ordering documents.
+  if (config.options.get_bool_option("python-irep2-adjust"))
+  {
+    python_adjust py_adjuster(context);
+    py_adjuster.adjust();
+  }
 
   return false;
 }


### PR DESCRIPTION
Phase **B.2** of the V.1k (b) IREP2-native Python adjuster (`docs/irep2-migration.md`). **Stacked on #5616 (B.1)** — its base auto-retargets to master as the stack lands.

Adds the `--python-irep2-adjust` option (`options.cpp`) and invokes `python_adjust` from `python_languaget::convert` after `clang_cpp_adjust`. **Default off ⇒ the pass is never invoked, byte-identical to today.**

**Finding — the migration-before-resolution wall (concrete).** Wiring the walk surfaced what the V.1k scoping anticipated abstractly: reading a function body's `get_value2()` migrates it to IREP2, and a by-name `symbol_type` constant aggregate then trips `constant_struct2t`'s assert. V.1k relaxed `member2t`/`index2t` but not `constant_struct2t`. This relaxes it the same way — permit a transient `symbol_id` type — so the body migrates; the adjuster re-establishes the strong invariant before symex. No frontend builds `constant_struct2t` pre-adjust, so it is staged enabling infra, and release-inert (the assert is `NDEBUG`-only).

**Inert by construction.** `adjust()` now (i) walks only code symbols and (ii) writes a symbol back only when resolution actually changed it — so with the flag on but no transient sources yet (pre-B.3), `get_value2()` is a faithful migration and nothing is rewritten. The pass runs *after* `clang_cpp_adjust` for now; moving it *before* to replace it (B.5) requires resolving this same wall for the remaining aggregate constructors.

**Tests.** `python_irep2_adjust_flag{,_fail}` pin the flag (CORE). Validated: flag-on and flag-off give identical verdicts (SUCCESSFUL/SUCCESSFUL, FAILED/FAILED); `python_adjust_test` 15/15; a Python class smoke (10) and an esbmc-cpp smoke (RV3 — `constant_struct2t` touches C++) are unaffected; CPython sanity passes.