### PR TITLE
feat(ld-frontend): user-defined function-block bodies, REAL/analog types, optional scan-watchdog

### DIFF
--- a/regression/ld/userfb_real_arith_fail/calc.ld
+++ b/regression/ld/userfb_real_arith_fail/calc.ld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-26"/>
+  <contentHeader name="CALC"/>
+  <types/><instances/>
+  <pous>
+    <pou name="CALC" pouType="functionBlock">
+      <interface>
+        <outputVars>
+          <variable name="OUT"><type><BOOL/></type></variable>
+        </outputVars>
+        <localVars>
+          <variable name="x"><type><REAL/></type></variable>
+        </localVars>
+      </interface>
+      <body>
+        <ST><![CDATA[
+x := 1.0 + 2.0 * 3.0;
+OUT := x = 9.0;
+]]></ST>
+      </body>
+    </pou>
+    <pou name="MAIN" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="Safe"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <block localId="10" typeName="CALC" instanceName="c0"/>
+          <outVariable localId="11">
+            <expression>Safe</expression>
+            <connectionPointIn>
+              <connection refLocalId="10" formalParameter="OUT"/>
+            </connectionPointIn>
+          </outVariable>
+        </LD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/userfb_real_arith_fail/props.yaml
+++ b/regression/ld/userfb_real_arith_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "Safe"
+    description: "Precedence: 1.0 + 2.0 * 3.0 == 7.0, never 9.0, so Safe stays false"

--- a/regression/ld/userfb_real_arith_fail/test.desc
+++ b/regression/ld/userfb_real_arith_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+calc.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION FAILED$

--- a/regression/ld/userfb_real_arith_safe/calc.ld
+++ b/regression/ld/userfb_real_arith_safe/calc.ld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-26"/>
+  <contentHeader name="CALC"/>
+  <types/><instances/>
+  <pous>
+    <pou name="CALC" pouType="functionBlock">
+      <interface>
+        <outputVars>
+          <variable name="OUT"><type><BOOL/></type></variable>
+        </outputVars>
+        <localVars>
+          <variable name="x"><type><REAL/></type></variable>
+        </localVars>
+      </interface>
+      <body>
+        <ST><![CDATA[
+x := 1.0 + 2.0 * 3.0;
+OUT := x = 7.0;
+]]></ST>
+      </body>
+    </pou>
+    <pou name="MAIN" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="Safe"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <block localId="10" typeName="CALC" instanceName="c0"/>
+          <outVariable localId="11">
+            <expression>Safe</expression>
+            <connectionPointIn>
+              <connection refLocalId="10" formalParameter="OUT"/>
+            </connectionPointIn>
+          </outVariable>
+        </LD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/userfb_real_arith_safe/props.yaml
+++ b/regression/ld/userfb_real_arith_safe/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "Safe"
+    description: "FB body computes 1.0 + 2.0 * 3.0 == 7.0 (operator precedence, REAL)"

--- a/regression/ld/userfb_real_arith_safe/test.desc
+++ b/regression/ld/userfb_real_arith_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+calc.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/userfb_sound_mode_safe/calc.ld
+++ b/regression/ld/userfb_sound_mode_safe/calc.ld
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-26"/>
+  <contentHeader name="CALC"/>
+  <types/><instances/>
+  <pous>
+    <pou name="CALC" pouType="functionBlock">
+      <interface>
+        <outputVars><variable name="OUT"><type><BOOL/></type></variable></outputVars>
+      </interface>
+      <body><ST><![CDATA[
+OUT := mystery() = 1;
+]]></ST></body>
+    </pou>
+    <pou name="MAIN" pouType="program">
+      <interface><outputVars><variable name="Open"><type><BOOL/></type></variable></outputVars></interface>
+      <body><LD>
+        <block localId="10" typeName="CALC" instanceName="c0"/>
+        <outVariable localId="11"><expression>Open</expression>
+          <connectionPointIn><connection refLocalId="10" formalParameter="OUT"/></connectionPointIn></outVariable>
+      </LD></body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/userfb_sound_mode_safe/props.yaml
+++ b/regression/ld/userfb_sound_mode_safe/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: absence
+    expression: "Open"
+    description: "Under --ld-sound-mode the unsupported FB body is a no-op; Open stays false"

--- a/regression/ld/userfb_sound_mode_safe/test.desc
+++ b/regression/ld/userfb_sound_mode_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+calc.ld
+--ld-props props.yaml --ld-sound-mode --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/userfb_tolerant_default_fail/calc.ld
+++ b/regression/ld/userfb_tolerant_default_fail/calc.ld
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-26"/>
+  <contentHeader name="CALC"/>
+  <types/><instances/>
+  <pous>
+    <pou name="CALC" pouType="functionBlock">
+      <interface>
+        <outputVars><variable name="OUT"><type><BOOL/></type></variable></outputVars>
+      </interface>
+      <body><ST><![CDATA[
+OUT := mystery() = 1;
+]]></ST></body>
+    </pou>
+    <pou name="MAIN" pouType="program">
+      <interface><outputVars><variable name="Open"><type><BOOL/></type></variable></outputVars></interface>
+      <body><LD>
+        <block localId="10" typeName="CALC" instanceName="c0"/>
+        <outVariable localId="11"><expression>Open</expression>
+          <connectionPointIn><connection refLocalId="10" formalParameter="OUT"/></connectionPointIn></outVariable>
+      </LD></body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/userfb_tolerant_default_fail/props.yaml
+++ b/regression/ld/userfb_tolerant_default_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: absence
+    expression: "Open"
+    description: "Under --ld-sound-mode the unsupported FB body is a no-op; Open stays false"

--- a/regression/ld/userfb_tolerant_default_fail/test.desc
+++ b/regression/ld/userfb_tolerant_default_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+calc.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION FAILED$

--- a/regression/ld/userfb_watchdog_fail/loop.ld
+++ b/regression/ld/userfb_watchdog_fail/loop.ld
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-26"/>
+  <contentHeader name="LOOP"/>
+  <types/><instances/>
+  <pous>
+    <pou name="LOOP" pouType="functionBlock">
+      <interface>
+        <outputVars><variable name="OUT"><type><BOOL/></type></variable></outputVars>
+        <localVars><variable name="i"><type><INT/></type></variable></localVars>
+      </interface>
+      <body><ST><![CDATA[
+i := 0;
+WHILE i < 10 DO
+  i := i + 1;
+END_WHILE;
+OUT := i >= 10;
+]]></ST></body>
+    </pou>
+    <pou name="MAIN" pouType="program">
+      <interface><outputVars><variable name="Safe"><type><BOOL/></type></variable></outputVars></interface>
+      <body><LD>
+        <block localId="10" typeName="LOOP" instanceName="c0"/>
+        <outVariable localId="11"><expression>Safe</expression>
+          <connectionPointIn><connection refLocalId="10" formalParameter="OUT"/></connectionPointIn></outVariable>
+      </LD></body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/userfb_watchdog_fail/props.yaml
+++ b/regression/ld/userfb_watchdog_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "Safe"
+    description: "Bounded FB loop terminates (i reaches 10); no watchdog by default"

--- a/regression/ld/userfb_watchdog_fail/test.desc
+++ b/regression/ld/userfb_watchdog_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+loop.ld
+--ld-props props.yaml --ld-scan-watchdog --ld-scan-budget 4 --k-induction --unlimited-k-steps --unwind 11
+^VERIFICATION FAILED$

--- a/regression/ld/userfb_watchdog_safe/loop.ld
+++ b/regression/ld/userfb_watchdog_safe/loop.ld
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-06-26"/>
+  <contentHeader name="LOOP"/>
+  <types/><instances/>
+  <pous>
+    <pou name="LOOP" pouType="functionBlock">
+      <interface>
+        <outputVars><variable name="OUT"><type><BOOL/></type></variable></outputVars>
+        <localVars><variable name="i"><type><INT/></type></variable></localVars>
+      </interface>
+      <body><ST><![CDATA[
+i := 0;
+WHILE i < 10 DO
+  i := i + 1;
+END_WHILE;
+OUT := i >= 10;
+]]></ST></body>
+    </pou>
+    <pou name="MAIN" pouType="program">
+      <interface><outputVars><variable name="Safe"><type><BOOL/></type></variable></outputVars></interface>
+      <body><LD>
+        <block localId="10" typeName="LOOP" instanceName="c0"/>
+        <outVariable localId="11"><expression>Safe</expression>
+          <connectionPointIn><connection refLocalId="10" formalParameter="OUT"/></connectionPointIn></outVariable>
+      </LD></body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/userfb_watchdog_safe/props.yaml
+++ b/regression/ld/userfb_watchdog_safe/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "Safe"
+    description: "Bounded FB loop terminates (i reaches 10); no watchdog by default"

--- a/regression/ld/userfb_watchdog_safe/test.desc
+++ b/regression/ld/userfb_watchdog_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+loop.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps --unwind 11
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -144,7 +144,8 @@ const struct group_opt_templ all_cmd_options[] = {
      "nondeterministic (no over-approximation, zero false positives)"},
     {"ld-scan-watchdog",
      NULL,
-     "Instrument WHILE loops in user function-block bodies with a scan-watchdog "
+     "Instrument WHILE loops in user function-block bodies with a "
+     "scan-watchdog "
      "assertion that fails once a loop exceeds --ld-scan-budget iterations, "
      "modelling a PLC scan overrun (changes the verified model)"},
     {"ld-scan-budget",

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -135,7 +135,22 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "Plant known semantic errors in the Ladder Diagram (negate contact "
      "polarities, degrade Set/Reset coils to plain output coils) to validate "
-     "that the property checks detect them"}}},
+     "that the property checks detect them"},
+    {"ld-sound-mode",
+     NULL,
+     "Translate user function-block ST bodies in sound Boolean/integer mode: "
+     "unsupported constructs (function calls, member access) make the FB body "
+     "fall back to a no-op instead of being over-approximated as "
+     "nondeterministic (no over-approximation, zero false positives)"},
+    {"ld-scan-watchdog",
+     NULL,
+     "Instrument WHILE loops in user function-block bodies with a scan-watchdog "
+     "assertion that fails once a loop exceeds --ld-scan-budget iterations, "
+     "modelling a PLC scan overrun (changes the verified model)"},
+    {"ld-scan-budget",
+     boost::program_options::value<unsigned>()->value_name("N"),
+     "Tolerated iterations before the --ld-scan-watchdog assertion fails "
+     "(default 8); keep <= the BMC --unwind so the assertion is reachable"}}},
 #endif
 #ifdef ENABLE_SOLIDITY_FRONTEND
   {"Solidity frontend",

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -148,7 +148,7 @@ const struct group_opt_templ all_cmd_options[] = {
      "assertion that fails once a loop exceeds --ld-scan-budget iterations, "
      "modelling a PLC scan overrun (changes the verified model)"},
     {"ld-scan-budget",
-     boost::program_options::value<unsigned>()->value_name("N"),
+     boost::program_options::value<int>()->value_name("N"),
      "Tolerated iterations before the --ld-scan-watchdog assertion fails "
      "(default 8); keep <= the BMC --unwind so the assertion is reachable"}}},
 #endif

--- a/src/ld-frontend/CMakeLists.txt
+++ b/src/ld-frontend/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(ldfrontend STATIC
   ir/ld_ir.cpp
   ir/ld_ir_builder.cpp
   ir_gen/ld_converter.cpp
+  ir_gen/st_fb_translator.cpp
   property/yaml_property_parser.cpp
   property/property_encoder.cpp
   verify/ld_verify.cpp

--- a/src/ld-frontend/ir/ld_ir.h
+++ b/src/ld-frontend/ir/ld_ir.h
@@ -79,16 +79,16 @@ struct UserFBExec
   std::vector<FBVarDecl> local_vars; // FB locals (e.g. "i") + types
   std::string output_var;
   VarKind output_kind = VarKind::BOOL;
-  std::string in1_var; // program var feeding IN1 ("" => nondet)
+  std::string in1_var;              // program var feeding IN1 ("" => nondet)
   std::vector<FBOutWire> out_wires; // FB pin -> program variable assignments
-  std::string st_body; // raw Structured Text
+  std::string st_body;              // raw Structured Text
 };
 
 // Top-level IR: variable declarations + the ordered list of rungs.
 struct LdIR
 {
   std::string source_file;
-  std::vector<VarDecl> variables;     // copied from LdAst
-  std::vector<LdIRRung> rungs;        // ordered scan body
-  std::vector<UserFBExec> user_fbs;   // user-defined FB bodies to execute
+  std::vector<VarDecl> variables;   // copied from LdAst
+  std::vector<LdIRRung> rungs;      // ordered scan body
+  std::vector<UserFBExec> user_fbs; // user-defined FB bodies to execute
 };

--- a/src/ld-frontend/ir/ld_ir.h
+++ b/src/ld-frontend/ir/ld_ir.h
@@ -70,10 +70,25 @@ struct LdIRRung
   LdLocation loc;
 };
 
+// A user-defined FB instance to execute once per scan cycle, with its ST body.
+struct UserFBExec
+{
+  std::string type_name;
+  std::string instance_name;
+  std::vector<std::string> input_vars; // formal inputs (IN1, IN2, ...)
+  std::vector<std::string> local_vars; // FB locals (e.g. "i")
+  std::string output_var;
+  bool output_is_bool = true;
+  std::string in1_var; // program var feeding IN1 ("" => nondet)
+  std::vector<FBOutWire> out_wires; // FB pin -> program variable assignments
+  std::string st_body; // raw Structured Text
+};
+
 // Top-level IR: variable declarations + the ordered list of rungs.
 struct LdIR
 {
   std::string source_file;
-  std::vector<VarDecl> variables; // copied from LdAst
-  std::vector<LdIRRung> rungs;    // ordered scan body
+  std::vector<VarDecl> variables;     // copied from LdAst
+  std::vector<LdIRRung> rungs;        // ordered scan body
+  std::vector<UserFBExec> user_fbs;   // user-defined FB bodies to execute
 };

--- a/src/ld-frontend/ir/ld_ir.h
+++ b/src/ld-frontend/ir/ld_ir.h
@@ -75,10 +75,10 @@ struct UserFBExec
 {
   std::string type_name;
   std::string instance_name;
-  std::vector<std::string> input_vars; // formal inputs (IN1, IN2, ...)
-  std::vector<std::string> local_vars; // FB locals (e.g. "i")
+  std::vector<FBVarDecl> input_vars; // formal inputs (IN1, IN2, ...) + types
+  std::vector<FBVarDecl> local_vars; // FB locals (e.g. "i") + types
   std::string output_var;
-  bool output_is_bool = true;
+  VarKind output_kind = VarKind::BOOL;
   std::string in1_var; // program var feeding IN1 ("" => nondet)
   std::vector<FBOutWire> out_wires; // FB pin -> program variable assignments
   std::string st_body; // raw Structured Text

--- a/src/ld-frontend/ir/ld_ir_builder.cpp
+++ b/src/ld-frontend/ir/ld_ir_builder.cpp
@@ -105,5 +105,28 @@ LdIR LdIRBuilder::build(const LdAst &ast)
     for (const auto &rung : net.rungs)
       ir.rungs.push_back(lower_rung(rung));
 
+  // Join user-FB instances with their definitions so the converter can
+  // execute each instance's translated body once per scan cycle.
+  for (const auto &inst : ast.user_fb_instances)
+  {
+    for (const auto &def : ast.user_fb_defs)
+    {
+      if (def.type_name != inst.type_name)
+        continue;
+      UserFBExec ex;
+      ex.type_name = def.type_name;
+      ex.instance_name = inst.instance_name;
+      ex.input_vars = def.input_vars;
+      ex.local_vars = def.local_vars;
+      ex.output_var = def.output_var;
+      ex.output_is_bool = def.output_is_bool;
+      ex.in1_var = inst.in1_var;
+      ex.out_wires = inst.out_wires;
+      ex.st_body = def.st_body;
+      ir.user_fbs.push_back(ex);
+      break;
+    }
+  }
+
   return ir;
 }

--- a/src/ld-frontend/ir/ld_ir_builder.cpp
+++ b/src/ld-frontend/ir/ld_ir_builder.cpp
@@ -119,7 +119,7 @@ LdIR LdIRBuilder::build(const LdAst &ast)
       ex.input_vars = def.input_vars;
       ex.local_vars = def.local_vars;
       ex.output_var = def.output_var;
-      ex.output_is_bool = def.output_is_bool;
+      ex.output_kind = def.output_kind;
       ex.in1_var = inst.in1_var;
       ex.out_wires = inst.out_wires;
       ex.st_body = def.st_body;

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -3,8 +3,9 @@
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
+#include <util/message.h>
 #include <util/symbol.h>
-#include <iostream>
+#include <map>
 #include <stdexcept>
 
 ld_converter::ld_converter(contextt &context, const LdIR &ir)
@@ -24,6 +25,22 @@ typet ld_converter::bool_t() const
 typet ld_converter::int32_t_() const
 {
   return int_type();
+}
+
+typet ld_converter::type_of_kind(VarKind kind) const
+{
+  switch (kind)
+  {
+  case VarKind::BOOL:
+    return bool_t();
+  case VarKind::REAL:
+    return double_type();
+  case VarKind::INT:
+  case VarKind::DINT:
+  case VarKind::TIME:
+    break;
+  }
+  return int32_t_();
 }
 
 exprt ld_converter::int_const(long long value) const
@@ -69,21 +86,19 @@ symbol_exprt ld_converter::declare_variable(const VarDecl &v)
   loc.set_column(v.loc.col);
   sym.location = loc;
 
+  sym.set_type(type_of_kind(v.kind));
   switch (v.kind)
   {
   case VarKind::BOOL:
-    sym.set_type(bool_t());
     sym.set_value(false_exprt());
+    break;
+  case VarKind::REAL:
+    sym.set_value(from_double(0.0, double_type()));
     break;
   case VarKind::INT:
   case VarKind::DINT:
   case VarKind::TIME:
-    sym.set_type(int32_t_());
     sym.set_value(int_const(0));
-    break;
-  case VarKind::REAL:
-    sym.set_type(double_type());
-    sym.set_value(from_double(0.0, double_type()));
     break;
   }
 
@@ -360,18 +375,30 @@ codet ld_converter::translate_user_fb(const UserFBExec &ex)
 {
   const std::string prefix = "ld::" + ex.instance_name + "__";
 
+  // Map every declared FB input/local to its type so the resolver can honour
+  // it: a REAL FB variable must stay double, not be demoted to int.  Anything
+  // not declared (e.g. a temporary introduced by the body) defaults to int.
+  std::map<std::string, VarKind> declared_kinds;
+  for (const auto &v : ex.input_vars)
+    declared_kinds[v.name] = v.kind;
+  for (const auto &v : ex.local_vars)
+    declared_kinds[v.name] = v.kind;
+  declared_kinds[ex.output_var] = ex.output_kind;
+
   st_fb_translator::resolver_t resolve =
-    [this, prefix](const std::string &nm) -> symbol_exprt {
+    [this, prefix, &declared_kinds](const std::string &nm) -> symbol_exprt {
     const symbolt *s = context_.find_symbol(prefix + nm);
     if (s)
       return symbol_exprt(prefix + nm, s->get_type());
-    return declare_scoped(prefix + nm, int32_t_());
+    auto it = declared_kinds.find(nm);
+    const typet t = (it != declared_kinds.end()) ? type_of_kind(it->second)
+                                                 : int32_t_();
+    return declare_scoped(prefix + nm, t);
   };
 
-  // Declare the formal output with its correct type (others default to int via
-  // the resolver during translation).
-  declare_scoped(prefix + ex.output_var,
-                 ex.output_is_bool ? bool_t() : int32_t_());
+  // Declare the formal output with its declared type (REAL outputs stay
+  // double); other locals are declared on demand by the resolver above.
+  declare_scoped(prefix + ex.output_var, type_of_kind(ex.output_kind));
 
   // Translate the body first.  If it uses constructs outside the supported ST
   // subset (nested FB calls, REAL, MOD, library functions), it throws and we
@@ -385,15 +412,17 @@ codet ld_converter::translate_user_fb(const UserFBExec &ex)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "warning: user FB '" << ex.type_name
-              << "' body not translated (" << e.what()
-              << "); over-approximating (no-op).\n";
+    log_warning(
+      "user FB '{}' body not translated ({}); over-approximating (no-op).",
+      ex.type_name,
+      e.what());
     return code_skipt();
   }
   catch (...)
   {
-    std::cerr << "warning: user FB '" << ex.type_name
-              << "' body not translated; over-approximating (no-op).\n";
+    log_warning(
+      "user FB '{}' body not translated; over-approximating (no-op).",
+      ex.type_name);
     return code_skipt();
   }
 
@@ -401,7 +430,7 @@ codet ld_converter::translate_user_fb(const UserFBExec &ex)
   code_blockt blk;
   for (const auto &iv : ex.input_vars)
   {
-    symbol_exprt s = resolve(iv);
+    symbol_exprt s = resolve(iv.name);
     blk.copy_to_operands(
       code_assignt(s, side_effect_expr_nondett(s.type())));
   }

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -631,6 +631,29 @@ void ld_converter::prepend_static_init()
 
 void ld_converter::convert()
 {
+  // REAL function-block arithmetic emits ieee_* operators, which reference
+  // c:@__ESBMC_rounding_mode. The C frontend declares this symbol; the LD
+  // frontend must supply it too, initialised to 0 (round-to-nearest-even).
+  // Otherwise the rounding mode is an unconstrained nondet input: the SMT
+  // backend must reason over every rounding mode, which makes even trivial REAL
+  // arithmetic blow up (and is unsound). prepend_static_init() picks this up
+  // and emits the initialisation at the top of __ESBMC_main.
+  if (!context_.find_symbol("c:@__ESBMC_rounding_mode"))
+  {
+    symbolt rm;
+    rm.id = "c:@__ESBMC_rounding_mode";
+    rm.name = "__ESBMC_rounding_mode";
+    rm.module = "ld";
+    rm.mode = "C";
+    rm.lvalue = true;
+    rm.static_lifetime = true;
+    rm.file_local = false;
+    rm.is_extern = false;
+    rm.set_type(int32_t_());
+    rm.set_value(int_const(0));
+    context_.move_symbol_to_context(rm);
+  }
+
   for (const auto &v : ir_.variables)
     declare_variable(v);
 

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -390,8 +390,8 @@ codet ld_converter::translate_user_fb(const UserFBExec &ex)
     if (s)
       return symbol_exprt(prefix + nm, s->get_type());
     auto it = declared_kinds.find(nm);
-    const typet t = (it != declared_kinds.end()) ? type_of_kind(it->second)
-                                                 : int32_t_();
+    const typet t =
+      (it != declared_kinds.end()) ? type_of_kind(it->second) : int32_t_();
     return declare_scoped(prefix + nm, t);
   };
 
@@ -430,8 +430,7 @@ codet ld_converter::translate_user_fb(const UserFBExec &ex)
   for (const auto &iv : ex.input_vars)
   {
     symbol_exprt s = resolve(iv.name);
-    blk.copy_to_operands(
-      code_assignt(s, side_effect_expr_nondett(s.type())));
+    blk.copy_to_operands(code_assignt(s, side_effect_expr_nondett(s.type())));
   }
   for (const auto &op : body.operands())
     blk.copy_to_operands(static_cast<const codet &>(op));

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -153,8 +153,7 @@ symbol_exprt ld_converter::declare_scoped(const std::string &id, const typet &t)
     sym.file_local = false;
     sym.is_extern = false;
     sym.set_type(t);
-    sym.set_value(t.id() == "bool" ? static_cast<exprt>(false_exprt())
-                                   : int_const(0));
+    sym.set_value(gen_zero(t)); // type-correct zero (REAL gets a float zero)
     locationt loc;
     loc.set_file(ir_.source_file);
     sym.location = loc;

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -1,8 +1,10 @@
 #include <ld-frontend/ir_gen/ld_converter.h>
+#include <ld-frontend/ir_gen/st_fb_translator.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
 #include <util/symbol.h>
+#include <iostream>
 #include <stdexcept>
 
 ld_converter::ld_converter(contextt &context, const LdIR &ir)
@@ -79,6 +81,10 @@ symbol_exprt ld_converter::declare_variable(const VarDecl &v)
     sym.set_type(int32_t_());
     sym.set_value(int_const(0));
     break;
+  case VarKind::REAL:
+    sym.set_type(double_type());
+    sym.set_value(from_double(0.0, double_type()));
+    break;
   }
 
   context_.move_symbol_to_context(sym);
@@ -112,6 +118,36 @@ symbol_exprt ld_converter::declare_bool_shadow(const std::string &id)
   return symbol_exprt(id, bool_t());
 }
 
+// Declare an instance-scoped FB-local symbol (idempotent). Names are prefixed
+// per FB instance (e.g. ld::EQ_00__IN1) so they never collide with program
+// variables. static_lifetime gives them a defined zero/false initial value.
+symbol_exprt ld_converter::declare_scoped(const std::string &id, const typet &t)
+{
+  if (!context_.find_symbol(id))
+  {
+    symbolt sym;
+    static const std::string kPrefix = "ld::";
+    sym.id = id;
+    sym.name = (id.compare(0, kPrefix.size(), kPrefix) == 0)
+                 ? id.substr(kPrefix.size())
+                 : id;
+    sym.module = "ld";
+    sym.mode = "LD";
+    sym.lvalue = true;
+    sym.static_lifetime = true;
+    sym.file_local = false;
+    sym.is_extern = false;
+    sym.set_type(t);
+    sym.set_value(t.id() == "bool" ? static_cast<exprt>(false_exprt())
+                                   : int_const(0));
+    locationt loc;
+    loc.set_file(ir_.source_file);
+    sym.location = loc;
+    context_.move_symbol_to_context(sym);
+  }
+  return symbol_exprt(id, t);
+}
+
 symbol_exprt ld_converter::var_expr(const std::string &name) const
 {
   const symbolt *sym = context_.find_symbol(ld_name(name));
@@ -137,9 +173,14 @@ codet ld_converter::translate_contact(
                  ? ContactKind::NormallyClosed
                  : ContactKind::NormallyOpen;
 
+  // Coerce a numeric (INT/REAL) contact variable to a Boolean test (var != 0).
+  exprt base = (var.type() == bool_t())
+                 ? static_cast<exprt>(var)
+                 : static_cast<exprt>(
+                     not_exprt(equality_exprt(var, gen_zero(var.type()))));
   exprt contact_val = (eff_kind == ContactKind::NormallyClosed)
-                        ? static_cast<exprt>(not_exprt(var))
-                        : static_cast<exprt>(var);
+                        ? static_cast<exprt>(not_exprt(base))
+                        : base;
   pf_out = and_exprt(pf_in, contact_val);
   return code_skipt();
 }
@@ -151,17 +192,23 @@ codet ld_converter::translate_coil(const LdIRNode &n, const exprt &pf)
   if (fault_injection_)
     eff_kind = CoilKind::Output;
 
+  // A numeric (INT/REAL) coil receives the Boolean power-flow cast to its type.
+  const bool num = (var.type() != bool_t());
+  auto as_coil = [&](const exprt &b) -> exprt {
+    return num ? static_cast<exprt>(typecast_exprt(b, var.type())) : b;
+  };
+
   code_blockt blk;
   switch (eff_kind)
   {
   case CoilKind::Output:
-    blk.copy_to_operands(code_assignt(var, pf));
+    blk.copy_to_operands(code_assignt(var, as_coil(pf)));
     break;
   case CoilKind::Set:
   {
     code_ifthenelset ite;
     ite.cond() = pf;
-    ite.then_case() = code_assignt(var, true_exprt());
+    ite.then_case() = code_assignt(var, as_coil(true_exprt()));
     blk.copy_to_operands(ite);
     break;
   }
@@ -169,7 +216,7 @@ codet ld_converter::translate_coil(const LdIRNode &n, const exprt &pf)
   {
     code_ifthenelset ite;
     ite.cond() = pf;
-    ite.then_case() = code_assignt(var, false_exprt());
+    ite.then_case() = code_assignt(var, as_coil(false_exprt()));
     blk.copy_to_operands(ite);
     break;
   }
@@ -302,6 +349,83 @@ codet ld_converter::translate_arith(const LdIRNode &n)
   return code_assignt(out, op_expr);
 }
 
+// Execute a user-defined FB body once per scan.  Inputs are sampled
+// nondeterministically (the open-world sensor model: the dataset's FB inputs
+// are program inputs), FB-local symbols are instance-scoped, and the body is
+// translated to native codet — crucially the WHILE stays a real loop so a
+// non-terminating Ladder Logic Bomb trips ESBMC's unwinding assertion.
+// On any translation failure the body is over-approximated (skipped), matching
+// the pre-existing "unsupported FB" behaviour (no regression).
+codet ld_converter::translate_user_fb(const UserFBExec &ex)
+{
+  const std::string prefix = "ld::" + ex.instance_name + "__";
+
+  st_fb_translator::resolver_t resolve =
+    [this, prefix](const std::string &nm) -> symbol_exprt {
+    const symbolt *s = context_.find_symbol(prefix + nm);
+    if (s)
+      return symbol_exprt(prefix + nm, s->get_type());
+    return declare_scoped(prefix + nm, int32_t_());
+  };
+
+  // Declare the formal output with its correct type (others default to int via
+  // the resolver during translation).
+  declare_scoped(prefix + ex.output_var,
+                 ex.output_is_bool ? bool_t() : int32_t_());
+
+  // Translate the body first.  If it uses constructs outside the supported ST
+  // subset (nested FB calls, REAL, MOD, library functions), it throws and we
+  // emit NOTHING — preserving the pre-existing "unsupported FB" behaviour
+  // exactly (no regression on benchmarks whose FBs we cannot model).
+  code_blockt body;
+  try
+  {
+    st_fb_translator translator(resolve);
+    body = translator.translate(ex.st_body);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "warning: user FB '" << ex.type_name
+              << "' body not translated (" << e.what()
+              << "); over-approximating (no-op).\n";
+    return code_skipt();
+  }
+  catch (...)
+  {
+    std::cerr << "warning: user FB '" << ex.type_name
+              << "' body not translated; over-approximating (no-op).\n";
+    return code_skipt();
+  }
+
+  // Success: sample inputs nondeterministically at scan entry, then run body.
+  code_blockt blk;
+  for (const auto &iv : ex.input_vars)
+  {
+    symbol_exprt s = resolve(iv);
+    blk.copy_to_operands(
+      code_assignt(s, side_effect_expr_nondett(s.type())));
+  }
+  for (const auto &op : body.operands())
+    blk.copy_to_operands(static_cast<const codet &>(op));
+
+  // Wire FB output pins to the program variables that consume them, so a forged
+  // FB output (value/actuator-manipulation bomb) propagates into the program.
+  for (const auto &w : ex.out_wires)
+  {
+    const symbolt *pinsym = context_.find_symbol(prefix + w.pin);
+    const symbolt *pvsym = context_.find_symbol("ld::" + w.prog_var);
+    if (!pinsym || !pvsym)
+      continue;
+    symbol_exprt pin(prefix + w.pin, pinsym->get_type());
+    symbol_exprt pv("ld::" + w.prog_var, pvsym->get_type());
+    exprt rhs = (pin.type() == pv.type())
+                  ? static_cast<exprt>(pin)
+                  : static_cast<exprt>(typecast_exprt(pin, pv.type()));
+    blk.copy_to_operands(code_assignt(pv, rhs));
+  }
+  return blk;
+}
+
 // -----------------------------------------------------------------------
 // Scan body construction
 // -----------------------------------------------------------------------
@@ -369,6 +493,13 @@ code_blockt ld_converter::build_scan_body(const exprt &)
     }
 
     scan_body.move_to_operands(rung_blk);
+  }
+
+  // Execute user-defined FB bodies (carriers of hidden logic / LLBs).
+  for (const auto &ex : ir_.user_fbs)
+  {
+    codet fb = translate_user_fb(ex);
+    scan_body.move_to_operands(fb);
   }
 
   return scan_body;

--- a/src/ld-frontend/ir_gen/ld_converter.h
+++ b/src/ld-frontend/ir_gen/ld_converter.h
@@ -39,6 +39,7 @@ private:
 
   typet bool_t() const;
   typet int32_t_() const;
+  typet type_of_kind(VarKind kind) const; // IEC 61131-3 type -> ESBMC typet
   exprt int_const(long long value) const;
 
   symbol_exprt declare_variable(const VarDecl &v);

--- a/src/ld-frontend/ir_gen/ld_converter.h
+++ b/src/ld-frontend/ir_gen/ld_converter.h
@@ -43,6 +43,7 @@ private:
 
   symbol_exprt declare_variable(const VarDecl &v);
   symbol_exprt declare_bool_shadow(const std::string &id);
+  symbol_exprt declare_scoped(const std::string &id, const typet &t);
   symbol_exprt var_expr(const std::string &name) const;
 
   code_blockt build_scan_body(const exprt &pf_in);
@@ -52,6 +53,7 @@ private:
   codet translate_timer(const LdIRNode &n);
   codet translate_counter(const LdIRNode &n);
   codet translate_arith(const LdIRNode &n);
+  codet translate_user_fb(const UserFBExec &ex);
 
   void emit_scan_function(const code_blockt &scan_body);
   void emit_main_function();

--- a/src/ld-frontend/ir_gen/st_fb_translator.cpp
+++ b/src/ld-frontend/ir_gen/st_fb_translator.cpp
@@ -1,0 +1,405 @@
+#include <ld-frontend/ir_gen/st_fb_translator.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <cctype>
+#include <cstdlib>
+#include <stdexcept>
+
+// Configuration toggle for reproducing the two paper configurations from one binary:
+//   default               -> "analog-extended": over-approximate unsupported ST
+//                            constructs (function calls, member access) as
+//                            nondeterministic, enabling analog programs (SWaT) to be
+//                            modelled at the cost of soundness (RQ6).
+//   env LLB_SOUND_MODE set -> "sound Boolean/integer": such constructs throw, so the
+//                            FB body falls back to a no-op; no over-approximation,
+//                            zero false positives (RQ2, RQ5).
+static bool sound_mode()
+{
+  static const bool s = (std::getenv("LLB_SOUND_MODE") != nullptr);
+  return s;
+}
+static void require_tolerant(const char *what)
+{
+  if (sound_mode())
+    throw std::runtime_error(
+      std::string("st_fb_translator: ") + what +
+      " requires analog-extended mode (LLB_SOUND_MODE unset)");
+}
+
+// -----------------------------------------------------------------------
+// Lexer
+// -----------------------------------------------------------------------
+
+void st_fb_translator::skip_ws()
+{
+  while (pos_ < src_.size())
+  {
+    char c = src_[pos_];
+    if (std::isspace(static_cast<unsigned char>(c)))
+    {
+      ++pos_;
+      continue;
+    }
+    // ST block comment (* ... *)
+    if (c == '(' && pos_ + 1 < src_.size() && src_[pos_ + 1] == '*')
+    {
+      pos_ += 2;
+      while (pos_ + 1 < src_.size() &&
+             !(src_[pos_] == '*' && src_[pos_ + 1] == ')'))
+        ++pos_;
+      pos_ += 2;
+      continue;
+    }
+    break;
+  }
+}
+
+bool st_fb_translator::eof()
+{
+  skip_ws();
+  return pos_ >= src_.size();
+}
+
+static std::string lower(std::string s)
+{
+  for (char &c : s)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  return s;
+}
+
+std::string st_fb_translator::peek_word()
+{
+  size_t save = pos_;
+  std::string w = next_word();
+  pos_ = save;
+  return lower(w);
+}
+
+std::string st_fb_translator::next_word()
+{
+  skip_ws();
+  size_t start = pos_;
+  if (pos_ < src_.size() &&
+      (std::isalpha(static_cast<unsigned char>(src_[pos_])) || src_[pos_] == '_'))
+  {
+    while (pos_ < src_.size() &&
+           (std::isalnum(static_cast<unsigned char>(src_[pos_])) ||
+            src_[pos_] == '_'))
+      ++pos_;
+  }
+  return src_.substr(start, pos_ - start);
+}
+
+bool st_fb_translator::accept_kw(const char *kw)
+{
+  size_t save = pos_;
+  std::string w = lower(next_word());
+  if (w == kw)
+    return true;
+  pos_ = save;
+  return false;
+}
+
+void st_fb_translator::expect_kw(const char *kw)
+{
+  if (!accept_kw(kw))
+    throw std::runtime_error(std::string("st_fb_translator: expected '") + kw +
+                             "'");
+}
+
+bool st_fb_translator::accept_sym(const char *s)
+{
+  skip_ws();
+  size_t len = std::string(s).size();
+  if (src_.compare(pos_, len, s) == 0)
+  {
+    pos_ += len;
+    return true;
+  }
+  return false;
+}
+
+void st_fb_translator::expect_sym(const char *s)
+{
+  if (!accept_sym(s))
+    throw std::runtime_error(std::string("st_fb_translator: expected '") + s +
+                             "'");
+}
+
+// -----------------------------------------------------------------------
+// Parser -> exprt
+// -----------------------------------------------------------------------
+
+exprt st_fb_translator::parse_primary()
+{
+  skip_ws();
+  // integer or REAL literal
+  if (pos_ < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_])))
+  {
+    size_t start = pos_;
+    while (pos_ < src_.size() &&
+           std::isdigit(static_cast<unsigned char>(src_[pos_])))
+      ++pos_;
+    bool is_real = false;
+    if (pos_ + 1 < src_.size() && src_[pos_] == '.' &&
+        std::isdigit(static_cast<unsigned char>(src_[pos_ + 1])))
+    {
+      is_real = true;
+      ++pos_;
+      while (pos_ < src_.size() &&
+             std::isdigit(static_cast<unsigned char>(src_[pos_])))
+        ++pos_;
+    }
+    std::string num = src_.substr(start, pos_ - start);
+    if (is_real)
+      return from_double(std::stod(num), double_type());
+    return from_integer(BigInt(std::stoll(num)), int_type());
+  }
+  // parenthesised
+  if (accept_sym("("))
+  {
+    exprt e = parse_expr();
+    expect_sym(")");
+    return e;
+  }
+  // identifier / boolean literal / function call / member access
+  std::string w = next_word();
+  if (w.empty())
+    throw std::runtime_error("st_fb_translator: expected expression");
+  std::string lw = lower(w);
+  if (lw == "true")
+    return true_exprt();
+  if (lw == "false")
+    return false_exprt();
+  // function call  IDENT(args...) : over-approximate result as nondeterministic
+  if (accept_sym("("))
+  {
+    require_tolerant("function-call result");
+    int depth = 1;
+    while (pos_ < src_.size() && depth > 0)
+    {
+      if (src_[pos_] == '(') ++depth;
+      else if (src_[pos_] == ')') --depth;
+      ++pos_;
+    }
+    return side_effect_expr_nondett(int_type());
+  }
+  // member access  IDENT.FIELD (e.g. timer.Q) : nondeterministic Boolean
+  if (accept_sym("."))
+  {
+    require_tolerant("member access");
+    next_word(); // consume field name
+    return side_effect_expr_nondett(typet("bool"));
+  }
+  return resolve_(w); // typed symbol_exprt
+}
+
+// arithmetic: left-associative + - * / (precedence not modelled; FB bodies are
+// flat single-operator expressions, which is sufficient for the LLB corpus).
+exprt st_fb_translator::parse_expr()
+{
+  exprt lhs = parse_primary();
+  for (;;)
+  {
+    irep_idt op;
+    if (accept_sym("+"))
+      op = exprt::plus;
+    else if (accept_sym("-"))
+      op = exprt::minus;
+    else if (accept_sym("*"))
+      op = exprt::mult;
+    else if (accept_sym("/"))
+      op = exprt::div;
+    else
+      break;
+    exprt rhs = parse_primary();
+    exprt e(op, int_type());
+    e.copy_to_operands(lhs, rhs);
+    lhs = e;
+  }
+  return lhs;
+}
+
+// value possibly followed by a relational operator (=, <>, <, <=, >, >=)
+exprt st_fb_translator::parse_condition()
+{
+  exprt lhs = parse_expr();
+  // multi-char operators first
+  if (accept_sym("<="))
+    return binary_relation_exprt(lhs, "<=", parse_expr());
+  if (accept_sym(">="))
+    return binary_relation_exprt(lhs, ">=", parse_expr());
+  if (accept_sym("<>"))
+    return not_exprt(equality_exprt(lhs, parse_expr()));
+  if (accept_sym("<"))
+    return binary_relation_exprt(lhs, "<", parse_expr());
+  if (accept_sym(">"))
+    return binary_relation_exprt(lhs, ">", parse_expr());
+  if (accept_sym("="))
+    return equality_exprt(lhs, parse_expr());
+  return lhs;
+}
+
+// -----------------------------------------------------------------------
+// Parser -> codet
+// -----------------------------------------------------------------------
+
+codet st_fb_translator::parse_stmt()
+{
+  std::string kw = peek_word();
+
+  if (kw == "if")
+  {
+    expect_kw("if");
+    exprt cond = parse_condition();
+    expect_kw("then");
+    code_blockt then_blk;
+    static const char *const term_if[] = {"end_if", "else", "elsif", nullptr};
+    parse_stmt_list(then_blk, term_if);
+
+    code_ifthenelset ite;
+    ite.cond() = cond;
+    ite.then_case() = then_blk;
+
+    if (accept_kw("else"))
+    {
+      code_blockt else_blk;
+      static const char *const term_else[] = {"end_if", nullptr};
+      parse_stmt_list(else_blk, term_else);
+      ite.else_case() = else_blk;
+    }
+    expect_kw("end_if");
+    accept_sym(";");
+    return ite;
+  }
+
+  if (kw == "while")
+  {
+    expect_kw("while");
+    exprt cond = parse_condition();
+    expect_kw("do");
+    code_blockt body;
+    static const char *const term_w[] = {"end_while", nullptr};
+    parse_stmt_list(body, term_w);
+    expect_kw("end_while");
+    accept_sym(";");
+
+    // Scan-watchdog instrumentation.  A real PLC trips a watchdog timer if a
+    // scan overruns; a non-terminating rung loop is exactly such an overrun.
+    // We prepend a per-loop iteration counter and assert it stays within a
+    // bounded budget, turning a (trigger-gated) non-terminating Ladder Logic
+    // Bomb into a reachable safety violation that incremental BMC detects,
+    // while bounded legitimate loops within budget remain SAFE.
+    symbol_exprt wd = resolve_("__wd" + std::to_string(wd_counter_++));
+    const long long WDOG = 8;
+
+    code_blockt instrumented;
+    exprt inc(exprt::plus, wd.type());
+    inc.copy_to_operands(wd, from_integer(BigInt(1), wd.type()));
+    instrumented.copy_to_operands(code_assignt(wd, inc));
+    instrumented.copy_to_operands(code_assertt(
+      binary_relation_exprt(wd, "<=", from_integer(BigInt(WDOG), wd.type()))));
+    for (const auto &op : body.operands())
+      instrumented.copy_to_operands(static_cast<const codet &>(op));
+
+    code_whilet loop;
+    loop.cond() = cond;
+    loop.body() = instrumented;
+
+    code_blockt out;
+    out.copy_to_operands(code_assignt(wd, from_integer(BigInt(0), wd.type())));
+    out.copy_to_operands(loop);
+    return out;
+  }
+
+  // VAR / VAR_INPUT / ... END_VAR declaration block embedded in the body -> skip
+  if (kw == "var" || kw.rfind("var_", 0) == 0)
+  {
+    require_tolerant("embedded VAR block");
+    next_word();
+    while (!eof())
+    {
+      if (peek_word() == "end_var") { next_word(); break; }
+      if (next_word().empty()) ++pos_; // advance over a symbol/token
+    }
+    accept_sym(";");
+    return code_blockt();
+  }
+
+  // assignment: IDENT := value ;
+  std::string name = next_word();
+  if (name.empty())
+    throw std::runtime_error("st_fb_translator: expected statement");
+  // call statement  IDENT(args...) ;  (e.g. a timer/FB invocation) -> no-op
+  if (accept_sym("("))
+  {
+    require_tolerant("call statement");
+    int depth = 1;
+    while (pos_ < src_.size() && depth > 0)
+    {
+      if (src_[pos_] == '(') ++depth;
+      else if (src_[pos_] == ')') --depth;
+      ++pos_;
+    }
+    accept_sym(";");
+    return code_skipt();
+  }
+  // member-access assignment target  IDENT.FIELD := ... ; -> over-approximate
+  if (accept_sym("."))
+  {
+    require_tolerant("member-access assignment");
+    next_word();
+    if (accept_sym(":="))
+    {
+      parse_condition();
+    }
+    accept_sym(";");
+    return code_skipt();
+  }
+  // not an assignment (e.g. a declaration  IDENT : TYPE [:= v];) -> skip stmt
+  if (!accept_sym(":="))
+  {
+    require_tolerant("non-assignment statement");
+    while (!eof() && !accept_sym(";"))
+      if (next_word().empty()) ++pos_;
+    return code_blockt();
+  }
+  symbol_exprt lhs = resolve_(name);
+  exprt rhs = parse_condition();
+  accept_sym(";");
+  if (rhs.type() != lhs.type())
+    rhs = typecast_exprt(rhs, lhs.type());
+  return code_assignt(lhs, rhs);
+}
+
+void st_fb_translator::parse_stmt_list(
+  code_blockt &out,
+  const char *const *terminators)
+{
+  for (;;)
+  {
+    if (eof())
+      break;
+    std::string w = peek_word();
+    bool is_term = false;
+    for (const char *const *t = terminators; *t; ++t)
+      if (w == *t)
+      {
+        is_term = true;
+        break;
+      }
+    if (is_term)
+      break;
+    out.copy_to_operands(parse_stmt());
+  }
+}
+
+code_blockt st_fb_translator::translate(const std::string &body)
+{
+  src_ = body;
+  pos_ = 0;
+  code_blockt out;
+  static const char *const term_none[] = {nullptr};
+  parse_stmt_list(out, term_none);
+  return out;
+}

--- a/src/ld-frontend/ir_gen/st_fb_translator.cpp
+++ b/src/ld-frontend/ir_gen/st_fb_translator.cpp
@@ -107,8 +107,9 @@ std::string st_fb_translator::next_word()
 {
   skip_ws();
   size_t start = pos_;
-  if (pos_ < src_.size() &&
-      (std::isalpha(static_cast<unsigned char>(src_[pos_])) || src_[pos_] == '_'))
+  if (
+    pos_ < src_.size() &&
+    (std::isalpha(static_cast<unsigned char>(src_[pos_])) || src_[pos_] == '_'))
   {
     while (pos_ < src_.size() &&
            (std::isalnum(static_cast<unsigned char>(src_[pos_])) ||
@@ -131,8 +132,8 @@ bool st_fb_translator::accept_kw(const char *kw)
 void st_fb_translator::expect_kw(const char *kw)
 {
   if (!accept_kw(kw))
-    throw std::runtime_error(std::string("st_fb_translator: expected '") + kw +
-                             "'");
+    throw std::runtime_error(
+      std::string("st_fb_translator: expected '") + kw + "'");
 }
 
 bool st_fb_translator::accept_sym(const char *s)
@@ -150,8 +151,8 @@ bool st_fb_translator::accept_sym(const char *s)
 void st_fb_translator::expect_sym(const char *s)
 {
   if (!accept_sym(s))
-    throw std::runtime_error(std::string("st_fb_translator: expected '") + s +
-                             "'");
+    throw std::runtime_error(
+      std::string("st_fb_translator: expected '") + s + "'");
 }
 
 // -----------------------------------------------------------------------
@@ -162,15 +163,17 @@ exprt st_fb_translator::parse_primary()
 {
   skip_ws();
   // integer or REAL literal
-  if (pos_ < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_])))
+  if (
+    pos_ < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_])))
   {
     size_t start = pos_;
     while (pos_ < src_.size() &&
            std::isdigit(static_cast<unsigned char>(src_[pos_])))
       ++pos_;
     bool is_real = false;
-    if (pos_ + 1 < src_.size() && src_[pos_] == '.' &&
-        std::isdigit(static_cast<unsigned char>(src_[pos_ + 1])))
+    if (
+      pos_ + 1 < src_.size() && src_[pos_] == '.' &&
+      std::isdigit(static_cast<unsigned char>(src_[pos_ + 1])))
     {
       is_real = true;
       ++pos_;
@@ -206,8 +209,10 @@ exprt st_fb_translator::parse_primary()
     int depth = 1;
     while (pos_ < src_.size() && depth > 0)
     {
-      if (src_[pos_] == '(') ++depth;
-      else if (src_[pos_] == ')') --depth;
+      if (src_[pos_] == '(')
+        ++depth;
+      else if (src_[pos_] == ')')
+        --depth;
       ++pos_;
     }
     return side_effect_expr_nondett(int_type());
@@ -435,8 +440,13 @@ codet st_fb_translator::parse_stmt()
     next_word();
     while (!eof())
     {
-      if (peek_word() == "end_var") { next_word(); break; }
-      if (next_word().empty()) ++pos_; // advance over a symbol/token
+      if (peek_word() == "end_var")
+      {
+        next_word();
+        break;
+      }
+      if (next_word().empty())
+        ++pos_; // advance over a symbol/token
     }
     accept_sym(";");
     return code_blockt();
@@ -453,8 +463,10 @@ codet st_fb_translator::parse_stmt()
     int depth = 1;
     while (pos_ < src_.size() && depth > 0)
     {
-      if (src_[pos_] == '(') ++depth;
-      else if (src_[pos_] == ')') --depth;
+      if (src_[pos_] == '(')
+        ++depth;
+      else if (src_[pos_] == ')')
+        --depth;
       ++pos_;
     }
     accept_sym(";");
@@ -477,7 +489,8 @@ codet st_fb_translator::parse_stmt()
   {
     require_tolerant("non-assignment statement");
     while (!eof() && !accept_sym(";"))
-      if (next_word().empty()) ++pos_;
+      if (next_word().empty())
+        ++pos_;
     return code_blockt();
   }
   symbol_exprt lhs = resolve_(name);

--- a/src/ld-frontend/ir_gen/st_fb_translator.cpp
+++ b/src/ld-frontend/ir_gen/st_fb_translator.cpp
@@ -1,22 +1,50 @@
 #include <ld-frontend/ir_gen/st_fb_translator.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <cctype>
-#include <cstdlib>
 #include <stdexcept>
+#include <string>
 
-// Configuration toggle for reproducing the two paper configurations from one binary:
-//   default               -> "analog-extended": over-approximate unsupported ST
-//                            constructs (function calls, member access) as
-//                            nondeterministic, enabling analog programs (SWaT) to be
-//                            modelled at the cost of soundness (RQ6).
-//   env LLB_SOUND_MODE set -> "sound Boolean/integer": such constructs throw, so the
-//                            FB body falls back to a no-op; no over-approximation,
-//                            zero false positives (RQ2, RQ5).
+// Configuration toggle for reproducing the two paper configurations from one
+// binary.  Selected by the --ld-sound-mode CLI flag so the chosen semantics is
+// visible in the verification record (rather than an undiscoverable env var):
+//   default (flag unset) -> "analog-extended": over-approximate unsupported ST
+//                           constructs (function calls, member access) as
+//                           nondeterministic, enabling analog programs (SWaT) to
+//                           be modelled at the cost of soundness (RQ6).
+//   --ld-sound-mode      -> "sound Boolean/integer": such constructs throw, so
+//                           the FB body falls back to a no-op; no over-
+//                           approximation, zero false positives (RQ2, RQ5).
 static bool sound_mode()
 {
-  static const bool s = (std::getenv("LLB_SOUND_MODE") != nullptr);
-  return s;
+  return config.options.get_bool_option("ld-sound-mode");
+}
+
+// Scan-watchdog instrumentation is opt-in: it injects an assertion and thus
+// changes the verified model (see the WHILE handler).  --ld-scan-budget bounds
+// the tolerated loop iterations (default 8).
+static bool watchdog_enabled()
+{
+  return config.options.get_bool_option("ld-scan-watchdog");
+}
+static long long scan_budget()
+{
+  const std::string s = config.options.get_option("ld-scan-budget");
+  if (!s.empty())
+  {
+    try
+    {
+      const long long v = std::stoll(s);
+      if (v > 0)
+        return v;
+    }
+    catch (const std::exception &)
+    {
+      // fall through to the default on a malformed value
+    }
+  }
+  return 8;
 }
 static void require_tolerant(const char *what)
 {
@@ -194,11 +222,34 @@ exprt st_fb_translator::parse_primary()
   return resolve_(w); // typed symbol_exprt
 }
 
-// arithmetic: left-associative + - * / (precedence not modelled; FB bodies are
-// flat single-operator expressions, which is sufficient for the LLB corpus).
+// Build a binary arithmetic node, deriving its result type from the operands:
+// promote to double when either side is floating point (REAL/analog), otherwise
+// stay integer.  Hard-coding int here would silently truncate the analog (SWaT)
+// arithmetic this frontend now supports.
+static bool is_floating(const typet &t)
+{
+  return t.id() == "floatbv" || t.id() == "fixedbv";
+}
+static exprt make_binary_arith(const irep_idt &op, exprt lhs, exprt rhs)
+{
+  const typet result = (is_floating(lhs.type()) || is_floating(rhs.type()))
+                          ? double_type()
+                          : int_type();
+  if (lhs.type() != result)
+    lhs = typecast_exprt(lhs, result);
+  if (rhs.type() != result)
+    rhs = typecast_exprt(rhs, result);
+  exprt e(op, result);
+  e.copy_to_operands(lhs, rhs);
+  return e;
+}
+
+// arithmetic with IEC 61131-3 precedence: '*' and '/' bind tighter than '+' and
+// '-'; both levels are left-associative.  Modelling precedence keeps a mixed-
+// operator guard such as `a + b * c` from mis-parsing as `(a + b) * c`.
 exprt st_fb_translator::parse_expr()
 {
-  exprt lhs = parse_primary();
+  exprt lhs = parse_term();
   for (;;)
   {
     irep_idt op;
@@ -206,16 +257,26 @@ exprt st_fb_translator::parse_expr()
       op = exprt::plus;
     else if (accept_sym("-"))
       op = exprt::minus;
-    else if (accept_sym("*"))
+    else
+      break;
+    lhs = make_binary_arith(op, lhs, parse_term());
+  }
+  return lhs;
+}
+
+exprt st_fb_translator::parse_term()
+{
+  exprt lhs = parse_primary();
+  for (;;)
+  {
+    irep_idt op;
+    if (accept_sym("*"))
       op = exprt::mult;
     else if (accept_sym("/"))
       op = exprt::div;
     else
       break;
-    exprt rhs = parse_primary();
-    exprt e(op, int_type());
-    e.copy_to_operands(lhs, rhs);
-    lhs = e;
+    lhs = make_binary_arith(op, lhs, parse_primary());
   }
   return lhs;
 }
@@ -284,26 +345,40 @@ codet st_fb_translator::parse_stmt()
     expect_kw("end_while");
     accept_sym(";");
 
-    // Scan-watchdog instrumentation.  A real PLC trips a watchdog timer if a
-    // scan overruns; a non-terminating rung loop is exactly such an overrun.
-    // We prepend a per-loop iteration counter and assert it stays within a
-    // bounded budget, turning a (trigger-gated) non-terminating Ladder Logic
-    // Bomb into a reachable safety violation that incremental BMC detects,
-    // while bounded legitimate loops within budget remain SAFE.
+    code_whilet loop;
+    loop.cond() = cond;
+
+    // Without the scan-watchdog, the WHILE stays a plain loop: a non-terminating
+    // Ladder Logic Bomb is then caught by ESBMC's unwinding assertion (--unwind),
+    // and no extra assertion is added to the verified model.
+    if (!watchdog_enabled())
+    {
+      loop.body() = body;
+      return loop;
+    }
+
+    // Scan-watchdog instrumentation (opt-in via --ld-scan-watchdog).  A real PLC
+    // trips a watchdog timer if a scan overruns; a non-terminating rung loop is
+    // exactly such an overrun.  We prepend a per-loop iteration counter and
+    // assert it stays within the scan budget, turning a (trigger-gated)
+    // non-terminating Ladder Logic Bomb into a reachable safety violation that
+    // incremental BMC detects, while bounded legitimate loops within budget
+    // remain SAFE.  This injects an assertion, so it deliberately changes the
+    // verified model and is therefore gated behind the explicit flag.  The
+    // budget (--ld-scan-budget, default 8) bounds tolerated iterations and
+    // should be kept <= the BMC --unwind so the assertion is reachable.
+    const long long budget = scan_budget();
     symbol_exprt wd = resolve_("__wd" + std::to_string(wd_counter_++));
-    const long long WDOG = 8;
 
     code_blockt instrumented;
     exprt inc(exprt::plus, wd.type());
     inc.copy_to_operands(wd, from_integer(BigInt(1), wd.type()));
     instrumented.copy_to_operands(code_assignt(wd, inc));
-    instrumented.copy_to_operands(code_assertt(
-      binary_relation_exprt(wd, "<=", from_integer(BigInt(WDOG), wd.type()))));
+    instrumented.copy_to_operands(code_assertt(binary_relation_exprt(
+      wd, "<=", from_integer(BigInt(budget), wd.type()))));
     for (const auto &op : body.operands())
       instrumented.copy_to_operands(static_cast<const codet &>(op));
 
-    code_whilet loop;
-    loop.cond() = cond;
     loop.body() = instrumented;
 
     code_blockt out;

--- a/src/ld-frontend/ir_gen/st_fb_translator.cpp
+++ b/src/ld-frontend/ir_gen/st_fb_translator.cpp
@@ -51,7 +51,7 @@ static void require_tolerant(const char *what)
   if (sound_mode())
     throw std::runtime_error(
       std::string("st_fb_translator: ") + what +
-      " requires analog-extended mode (LLB_SOUND_MODE unset)");
+      " requires analog-extended mode (do not pass --ld-sound-mode)");
 }
 
 // -----------------------------------------------------------------------
@@ -230,16 +230,33 @@ static bool is_floating(const typet &t)
 {
   return t.id() == "floatbv" || t.id() == "fixedbv";
 }
+// Floating-point arithmetic must use the ieee_* operators: the LD frontend has
+// no adjust pass to rewrite plus/mult on a floatbv operand, and the simplifier
+// asserts on a plain plus/mult node whose type is floatbv.  The irep2 migration
+// defaults the rounding mode.
+static irep_idt arith_id(const irep_idt &op, bool real)
+{
+  if (!real)
+    return op;
+  if (op == exprt::plus)
+    return "ieee_add";
+  if (op == exprt::minus)
+    return "ieee_sub";
+  if (op == exprt::mult)
+    return "ieee_mul";
+  if (op == exprt::div)
+    return "ieee_div";
+  return op;
+}
 static exprt make_binary_arith(const irep_idt &op, exprt lhs, exprt rhs)
 {
-  const typet result = (is_floating(lhs.type()) || is_floating(rhs.type()))
-                          ? double_type()
-                          : int_type();
+  const bool real = is_floating(lhs.type()) || is_floating(rhs.type());
+  const typet result = real ? double_type() : int_type();
   if (lhs.type() != result)
     lhs = typecast_exprt(lhs, result);
   if (rhs.type() != result)
     rhs = typecast_exprt(rhs, result);
-  exprt e(op, result);
+  exprt e(arith_id(op, real), result);
   e.copy_to_operands(lhs, rhs);
   return e;
 }
@@ -281,24 +298,48 @@ exprt st_fb_translator::parse_term()
   return lhs;
 }
 
+// Promote a comparison's operands to a common type: if either side is REAL
+// (floating), cast the other to double so a mixed REAL/INT comparison does not
+// build a relation node with mismatched operand sorts (the LD frontend has no
+// adjust pass to fix it up later).
+static void promote_numeric(exprt &a, exprt &b)
+{
+  if (is_floating(a.type()) && !is_floating(b.type()))
+    b = typecast_exprt(b, double_type());
+  else if (is_floating(b.type()) && !is_floating(a.type()))
+    a = typecast_exprt(a, double_type());
+}
+
 // value possibly followed by a relational operator (=, <>, <, <=, >, >=)
 exprt st_fb_translator::parse_condition()
 {
   exprt lhs = parse_expr();
+  irep_idt relop;
+  bool equality = false, negate = false;
   // multi-char operators first
   if (accept_sym("<="))
-    return binary_relation_exprt(lhs, "<=", parse_expr());
-  if (accept_sym(">="))
-    return binary_relation_exprt(lhs, ">=", parse_expr());
-  if (accept_sym("<>"))
-    return not_exprt(equality_exprt(lhs, parse_expr()));
-  if (accept_sym("<"))
-    return binary_relation_exprt(lhs, "<", parse_expr());
-  if (accept_sym(">"))
-    return binary_relation_exprt(lhs, ">", parse_expr());
-  if (accept_sym("="))
-    return equality_exprt(lhs, parse_expr());
-  return lhs;
+    relop = "<=";
+  else if (accept_sym(">="))
+    relop = ">=";
+  else if (accept_sym("<>"))
+    equality = negate = true;
+  else if (accept_sym("<"))
+    relop = "<";
+  else if (accept_sym(">"))
+    relop = ">";
+  else if (accept_sym("="))
+    equality = true;
+  else
+    return lhs;
+
+  exprt rhs = parse_expr();
+  promote_numeric(lhs, rhs);
+  if (equality)
+  {
+    exprt eq = equality_exprt(lhs, rhs);
+    return negate ? static_cast<exprt>(not_exprt(eq)) : eq;
+  }
+  return binary_relation_exprt(lhs, relop, rhs);
 }
 
 // -----------------------------------------------------------------------

--- a/src/ld-frontend/ir_gen/st_fb_translator.h
+++ b/src/ld-frontend/ir_gen/st_fb_translator.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <util/std_code.h>
+#include <util/std_expr.h>
+#include <functional>
+#include <string>
+
+// -----------------------------------------------------------------------
+// st_fb_translator — minimal IEC 61131-3 Structured Text -> codet translator
+// for user-defined function-block bodies referenced by a Ladder Diagram.
+//
+// Supports the ST subset used by FB bodies in practice:
+//   assignment      IDENT := expr ;
+//   conditional     IF cond THEN stmt* END_IF ;
+//   loop            WHILE cond DO stmt* END_WHILE ;     (kept as a real loop so
+//                                                        ESBMC's unwinding
+//                                                        assertions detect a
+//                                                        non-terminating LLB)
+//   expr            IDENT | INT_LIT | TRUE | FALSE | expr <op> expr
+//   relop           =  <  <=  >  >=  <>
+//   arith           +  -  *  /
+// Keywords are case-insensitive.  This is deliberately small: it is enough to
+// faithfully translate the function-block bodies that carry Ladder Logic Bombs
+// (comparison/arithmetic guards plus a non-termination payload) so that the
+// bomb logic reaches the GOTO IR.  Unsupported constructs throw.
+// -----------------------------------------------------------------------
+
+class st_fb_translator
+{
+public:
+  // resolve(name) returns the typed symbol_exprt for an identifier; the caller
+  // (ld_converter) declares one symbol per FB-local variable and supplies this.
+  using resolver_t = std::function<symbol_exprt(const std::string &)>;
+
+  explicit st_fb_translator(resolver_t resolve) : resolve_(std::move(resolve)) {}
+
+  // Translate a whole FB body into a code_blockt.
+  code_blockt translate(const std::string &body);
+
+private:
+  resolver_t resolve_;
+  std::string src_;
+  size_t pos_ = 0;
+  int wd_counter_ = 0; // unique scan-watchdog counter id per loop
+
+  // lexer
+  void skip_ws();
+  bool eof();
+  std::string peek_word();          // next identifier/keyword (lowercased), no consume
+  std::string next_word();          // consume identifier/keyword (original case)
+  bool accept_kw(const char *kw);   // consume if next word == kw (case-insensitive)
+  void expect_kw(const char *kw);
+  bool accept_sym(const char *s);   // consume punctuation/operator if it matches
+  void expect_sym(const char *s);
+
+  // parser -> codet/exprt
+  void parse_stmt_list(code_blockt &out, const char *const *terminators);
+  codet parse_stmt();
+  exprt parse_condition();
+  exprt parse_expr();   // arithmetic (left-assoc + - * /)
+  exprt parse_primary();
+};

--- a/src/ld-frontend/ir_gen/st_fb_translator.h
+++ b/src/ld-frontend/ir_gen/st_fb_translator.h
@@ -32,7 +32,9 @@ public:
   // (ld_converter) declares one symbol per FB-local variable and supplies this.
   using resolver_t = std::function<symbol_exprt(const std::string &)>;
 
-  explicit st_fb_translator(resolver_t resolve) : resolve_(std::move(resolve)) {}
+  explicit st_fb_translator(resolver_t resolve) : resolve_(std::move(resolve))
+  {
+  }
 
   // Translate a whole FB body into a code_blockt.
   code_blockt translate(const std::string &body);
@@ -46,18 +48,19 @@ private:
   // lexer
   void skip_ws();
   bool eof();
-  std::string peek_word();          // next identifier/keyword (lowercased), no consume
-  std::string next_word();          // consume identifier/keyword (original case)
-  bool accept_kw(const char *kw);   // consume if next word == kw (case-insensitive)
+  std::string peek_word(); // next identifier/keyword (lowercased), no consume
+  std::string next_word(); // consume identifier/keyword (original case)
+  bool
+  accept_kw(const char *kw); // consume if next word == kw (case-insensitive)
   void expect_kw(const char *kw);
-  bool accept_sym(const char *s);   // consume punctuation/operator if it matches
+  bool accept_sym(const char *s); // consume punctuation/operator if it matches
   void expect_sym(const char *s);
 
   // parser -> codet/exprt
   void parse_stmt_list(code_blockt &out, const char *const *terminators);
   codet parse_stmt();
   exprt parse_condition();
-  exprt parse_expr();    // additive  (+ -), left-assoc
-  exprt parse_term();    // multiplicative (* /), binds tighter than + -
+  exprt parse_expr(); // additive  (+ -), left-assoc
+  exprt parse_term(); // multiplicative (* /), binds tighter than + -
   exprt parse_primary();
 };

--- a/src/ld-frontend/ir_gen/st_fb_translator.h
+++ b/src/ld-frontend/ir_gen/st_fb_translator.h
@@ -57,6 +57,7 @@ private:
   void parse_stmt_list(code_blockt &out, const char *const *terminators);
   codet parse_stmt();
   exprt parse_condition();
-  exprt parse_expr();   // arithmetic (left-assoc + - * /)
+  exprt parse_expr();    // additive  (+ -), left-assoc
+  exprt parse_term();    // multiplicative (* /), binds tighter than + -
   exprt parse_primary();
 };

--- a/src/ld-frontend/parser/ld_ast.h
+++ b/src/ld-frontend/parser/ld_ast.h
@@ -191,19 +191,19 @@ struct FBVarDecl
 
 struct UserFBDef
 {
-  std::string type_name;              // e.g. "EQ_0"
-  std::vector<FBVarDecl> input_vars;  // formal inputs (IN1, IN2, ...) + types
-  std::vector<FBVarDecl> local_vars;  // FB-local variables (e.g. "i") + types
-  std::string output_var;             // formal output name (OUT)
+  std::string type_name;               // e.g. "EQ_0"
+  std::vector<FBVarDecl> input_vars;   // formal inputs (IN1, IN2, ...) + types
+  std::vector<FBVarDecl> local_vars;   // FB-local variables (e.g. "i") + types
+  std::string output_var;              // formal output name (OUT)
   VarKind output_kind = VarKind::BOOL; // OUT declared type
-  std::string st_body;                // raw Structured Text body
+  std::string st_body;                 // raw Structured Text body
 };
 
 // Wiring of an FB output pin to a program variable: "prog_var := <inst>__pin".
 struct FBOutWire
 {
   std::string prog_var; // program variable driven by the pin (e.g. MV1)
-  std::string pin;       // FB formal output name (e.g. OUT_MV1)
+  std::string pin;      // FB formal output name (e.g. OUT_MV1)
 };
 
 struct UserFBInstance

--- a/src/ld-frontend/parser/ld_ast.h
+++ b/src/ld-frontend/parser/ld_ast.h
@@ -180,14 +180,23 @@ struct VarDecl
 // executed in the scan cycle so the embedded logic reaches the GOTO IR.
 // -----------------------------------------------------------------------
 
+// A function-block formal/local variable with its declared IEC 61131-3 type.
+// Carrying the type (rather than just the name) keeps REAL/analog FB variables
+// from being silently demoted to int when the body is translated.
+struct FBVarDecl
+{
+  std::string name;
+  VarKind kind = VarKind::INT; // numeric default for an untyped FB variable
+};
+
 struct UserFBDef
 {
-  std::string type_name;               // e.g. "EQ_0"
-  std::vector<std::string> input_vars; // formal input names (IN1, IN2, ...)
-  std::vector<std::string> local_vars; // FB-local names (e.g. "i")
-  std::string output_var;              // formal output name (OUT)
-  bool output_is_bool = true;          // OUT type (BOOL vs INT)
-  std::string st_body;                 // raw Structured Text body
+  std::string type_name;              // e.g. "EQ_0"
+  std::vector<FBVarDecl> input_vars;  // formal inputs (IN1, IN2, ...) + types
+  std::vector<FBVarDecl> local_vars;  // FB-local variables (e.g. "i") + types
+  std::string output_var;             // formal output name (OUT)
+  VarKind output_kind = VarKind::BOOL; // OUT declared type
+  std::string st_body;                // raw Structured Text body
 };
 
 // Wiring of an FB output pin to a program variable: "prog_var := <inst>__pin".

--- a/src/ld-frontend/parser/ld_ast.h
+++ b/src/ld-frontend/parser/ld_ast.h
@@ -162,6 +162,7 @@ enum class VarKind
   INT,
   DINT,
   TIME, // used for timer PT/ET fields
+  REAL, // IEEE floating point (analog process variables)
 };
 
 struct VarDecl
@@ -174,6 +175,39 @@ struct VarDecl
 };
 
 // -----------------------------------------------------------------------
+// User-defined function blocks (e.g. EQ_0/GT_0/SUB_0 wrappers that may carry
+// Ladder Logic Bombs).  Their Structured Text bodies are translated and
+// executed in the scan cycle so the embedded logic reaches the GOTO IR.
+// -----------------------------------------------------------------------
+
+struct UserFBDef
+{
+  std::string type_name;               // e.g. "EQ_0"
+  std::vector<std::string> input_vars; // formal input names (IN1, IN2, ...)
+  std::vector<std::string> local_vars; // FB-local names (e.g. "i")
+  std::string output_var;              // formal output name (OUT)
+  bool output_is_bool = true;          // OUT type (BOOL vs INT)
+  std::string st_body;                 // raw Structured Text body
+};
+
+// Wiring of an FB output pin to a program variable: "prog_var := <inst>__pin".
+struct FBOutWire
+{
+  std::string prog_var; // program variable driven by the pin (e.g. MV1)
+  std::string pin;       // FB formal output name (e.g. OUT_MV1)
+};
+
+struct UserFBInstance
+{
+  std::string type_name;     // references a UserFBDef
+  std::string instance_name; // e.g. "EQ_00"
+  std::string block_id;      // graphical localId of the block
+  std::string in1_var; // program variable feeding IN1 ("" => nondet sample)
+  std::vector<FBOutWire> out_wires; // pins consumed by program outVariables
+  LdLocation loc;
+};
+
+// -----------------------------------------------------------------------
 // Top-level AST
 // -----------------------------------------------------------------------
 
@@ -182,5 +216,7 @@ struct LdAst
   std::string source_file;           // path of the PLCopen XML file
   std::vector<VarDecl> variables;    // all declared variables
   std::vector<NetworkNode> networks; // one per POU (Tier 1: single POU)
-  bool has_interrupt_tasks = false;  // triggers Tier-2 rejection
+  std::vector<UserFBDef> user_fb_defs;
+  std::vector<UserFBInstance> user_fb_instances;
+  bool has_interrupt_tasks = false; // triggers Tier-2 rejection
 };

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -46,7 +46,13 @@ VarKind PlcopenXmlParser::var_kind_from_string(const std::string &s)
     {"BOOL", VarKind::BOOL},
     {"INT", VarKind::INT},
     {"DINT", VarKind::DINT},
+    {"UINT", VarKind::INT},
+    {"SINT", VarKind::INT},
+    {"LINT", VarKind::DINT},
+    {"WORD", VarKind::INT},
     {"TIME", VarKind::TIME},
+    {"REAL", VarKind::REAL},
+    {"LREAL", VarKind::REAL},
   };
   auto it = table.find(s);
   if (it == table.end())
@@ -639,6 +645,98 @@ LdAst PlcopenXmlParser::parse(const std::string &path)
         v.is_input = true;
       else if (coil_vars.count(v.name) && !contact_vars.count(v.name))
         v.is_output = true;
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // User-defined function-block bodies (e.g. EQ_0/GT_0/SUB_0 wrappers that
+  // may carry Ladder Logic Bombs).  Register each functionBlock POU's
+  // Structured Text body, and record every block instance referencing one so
+  // the converter can execute the translated body in the scan cycle.  This
+  // makes logic hidden inside FB bodies reachable to the verifier instead of
+  // being dropped as an unsupported rung element.
+  // -------------------------------------------------------------------
+  std::function<void(const pugi::xml_node &, std::string &)> collect_text =
+    [&](const pugi::xml_node &n, std::string &out) {
+      for (pugi::xml_node c : n)
+      {
+        if (c.type() == pugi::node_pcdata || c.type() == pugi::node_cdata)
+          out += c.value();
+        else
+          collect_text(c, out);
+      }
+    };
+
+  for (auto xp : root.select_nodes("//pou[@pouType='functionBlock']"))
+  {
+    pugi::xml_node pou = xp.node();
+    UserFBDef def;
+    def.type_name = pou.attribute("name").as_string();
+    if (def.type_name.empty())
+      continue;
+    for (auto v : pou.select_nodes(".//interface/inputVars/variable"))
+      def.input_vars.push_back(v.node().attribute("name").as_string());
+    for (auto v : pou.select_nodes(".//interface/localVars/variable"))
+      def.local_vars.push_back(v.node().attribute("name").as_string());
+    if (auto ov = pou.select_node(".//interface/outputVars/variable").node())
+    {
+      def.output_var = ov.attribute("name").as_string();
+      pugi::xml_node tnode = ov.child("type");
+      def.output_is_bool =
+        tnode && tnode.first_child() &&
+        std::string(tnode.first_child().name()) == "BOOL";
+    }
+    pugi::xml_node st = pou.select_node(".//body/ST").node();
+    if (!st)
+      continue; // non-ST body (e.g. graphical FB) — not handled here
+    collect_text(st, def.st_body);
+    if (def.output_var.empty() || def.st_body.empty())
+      continue;
+    ast.user_fb_defs.push_back(std::move(def));
+  }
+
+  if (!ast.user_fb_defs.empty())
+  {
+    for (auto xp : root.select_nodes("//pou[@pouType='program']//block"))
+    {
+      pugi::xml_node blk = xp.node();
+      std::string tn = blk.attribute("typeName").as_string();
+      for (const auto &def : ast.user_fb_defs)
+      {
+        if (def.type_name != tn)
+          continue;
+        UserFBInstance inst;
+        inst.type_name = tn;
+        inst.instance_name = blk.attribute("instanceName").as_string();
+        inst.block_id = blk.attribute("localId").as_string();
+        inst.loc = {source_file_, 0, 0};
+        ast.user_fb_instances.push_back(std::move(inst));
+        break;
+      }
+    }
+
+    // Wire FB output pins to the program variables that consume them: a program
+    // <outVariable> with <connection refLocalId="<block>" formalParameter="<pin>">
+    // means "<prog_var> := <fb_instance>.<pin>".  This propagates a (possibly
+    // forged) FB output into the program so value/actuator-manipulation bombs
+    // become observable, and makes the model faithful instead of vacuous.
+    for (auto xp :
+         root.select_nodes("//pou[@pouType='program']//outVariable"))
+    {
+      pugi::xml_node ov = xp.node();
+      std::string pv = ov.child("expression").child_value();
+      if (pv.empty())
+        pv = ov.child("variable").child_value();
+      pugi::xml_node conn = ov.select_node(".//connection").node();
+      if (!conn || pv.empty())
+        continue;
+      std::string ref = conn.attribute("refLocalId").as_string();
+      std::string pin = conn.attribute("formalParameter").as_string();
+      if (pin.empty())
+        continue;
+      for (auto &inst : ast.user_fb_instances)
+        if (inst.block_id == ref)
+          inst.out_wires.push_back({pv, pin});
     }
   }
 

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -674,17 +674,31 @@ LdAst PlcopenXmlParser::parse(const std::string &path)
     def.type_name = pou.attribute("name").as_string();
     if (def.type_name.empty())
       continue;
+    // Resolve a <variable>'s declared type the same way parse_var_decl does:
+    // <type> holds a single child whose tag is the type name (or "derived"
+    // carrying a name attribute).  Mapping through var_kind_from_string (which
+    // knows REAL) keeps REAL FB variables from collapsing to BOOL/INT.
+    auto fb_var_kind = [this](const pugi::xml_node &v) -> VarKind {
+      pugi::xml_node tnode = v.child("type");
+      pugi::xml_node first = tnode.first_child();
+      if (!first)
+        return VarKind::INT; // numeric default for an untyped FB variable
+      std::string tag = first.name();
+      std::string type_str = (tag == "derived")
+                               ? first.attribute("name").as_string()
+                               : tag;
+      return var_kind_from_string(type_str);
+    };
     for (auto v : pou.select_nodes(".//interface/inputVars/variable"))
-      def.input_vars.push_back(v.node().attribute("name").as_string());
+      def.input_vars.push_back(
+        {v.node().attribute("name").as_string(), fb_var_kind(v.node())});
     for (auto v : pou.select_nodes(".//interface/localVars/variable"))
-      def.local_vars.push_back(v.node().attribute("name").as_string());
+      def.local_vars.push_back(
+        {v.node().attribute("name").as_string(), fb_var_kind(v.node())});
     if (auto ov = pou.select_node(".//interface/outputVars/variable").node())
     {
       def.output_var = ov.attribute("name").as_string();
-      pugi::xml_node tnode = ov.child("type");
-      def.output_is_bool =
-        tnode && tnode.first_child() &&
-        std::string(tnode.first_child().name()) == "BOOL";
+      def.output_kind = fb_var_kind(ov);
     }
     pugi::xml_node st = pou.select_node(".//body/ST").node();
     if (!st)

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -684,9 +684,8 @@ LdAst PlcopenXmlParser::parse(const std::string &path)
       if (!first)
         return VarKind::INT; // numeric default for an untyped FB variable
       std::string tag = first.name();
-      std::string type_str = (tag == "derived")
-                               ? first.attribute("name").as_string()
-                               : tag;
+      std::string type_str =
+        (tag == "derived") ? first.attribute("name").as_string() : tag;
       return var_kind_from_string(type_str);
     };
     for (auto v : pou.select_nodes(".//interface/inputVars/variable"))
@@ -734,8 +733,7 @@ LdAst PlcopenXmlParser::parse(const std::string &path)
     // means "<prog_var> := <fb_instance>.<pin>".  This propagates a (possibly
     // forged) FB output into the program so value/actuator-manipulation bombs
     // become observable, and makes the model faithful instead of vacuous.
-    for (auto xp :
-         root.select_nodes("//pou[@pouType='program']//outVariable"))
+    for (auto xp : root.select_nodes("//pou[@pouType='program']//outVariable"))
     {
       pugi::xml_node ov = xp.node();
       std::string pv = ov.child("expression").child_value();

--- a/src/ld-frontend/semantics/type_checker.cpp
+++ b/src/ld-frontend/semantics/type_checker.cpp
@@ -142,12 +142,15 @@ void TypeChecker::check_rung_element(const RungElement &elem)
     // Non-BOOL contacts/coils occur in analog process control (INT/REAL
     // process variables). They are permitted; the converter coerces a numeric
     // contact to a Boolean test (var != 0) and casts power-flow to a numeric
-    // coil. Only the variable's existence is required here.
+    // coil. Only the variable's existence is enforced here (lookup_type throws
+    // on an undeclared name), so a stray contact cannot slip through as nondet.
+    lookup_type(elem.contact.variable, elem.loc);
     break;
 
   case RungElementKind::Coil:
     if (elem.coil.variable.empty())
       throw TypeCheckError(loc_str(elem.loc) + ": coil has no variable");
+    lookup_type(elem.coil.variable, elem.loc);
     break;
 
   case RungElementKind::TimerFB:

--- a/src/ld-frontend/semantics/type_checker.cpp
+++ b/src/ld-frontend/semantics/type_checker.cpp
@@ -139,19 +139,15 @@ void TypeChecker::check_rung_element(const RungElement &elem)
   case RungElementKind::Contact:
     if (elem.contact.variable.empty())
       throw TypeCheckError(loc_str(elem.loc) + ": contact has no variable");
-    if (lookup_type(elem.contact.variable, elem.loc) != VarKind::BOOL)
-      throw TypeCheckError(
-        loc_str(elem.loc) + ": contact variable '" + elem.contact.variable +
-        "' must be BOOL");
+    // Non-BOOL contacts/coils occur in analog process control (INT/REAL
+    // process variables). They are permitted; the converter coerces a numeric
+    // contact to a Boolean test (var != 0) and casts power-flow to a numeric
+    // coil. Only the variable's existence is required here.
     break;
 
   case RungElementKind::Coil:
     if (elem.coil.variable.empty())
       throw TypeCheckError(loc_str(elem.loc) + ": coil has no variable");
-    if (lookup_type(elem.coil.variable, elem.loc) != VarKind::BOOL)
-      throw TypeCheckError(
-        loc_str(elem.loc) + ": coil variable '" + elem.coil.variable +
-        "' must be BOOL");
     break;
 
   case RungElementKind::TimerFB:


### PR DESCRIPTION
## Summary
Extends the **LD (Ladder Diagram) frontend** so that programs using **user-defined
function blocks** and **analog (REAL / non-Boolean) process variables** can be verified.
Today the frontend instantiates a user-defined FB but drops its body, and it rejects
non-Boolean coils/contacts — so any LD program whose logic lives inside an FB body, or
that drives INT/REAL outputs, is either modelled vacuously or fails to parse.

No change to the verification backend (GOTO/symex/SMT); everything is confined to
`src/ld-frontend/` (plus one unrelated LLVM-compat fix, see *Notes*).

## What it adds
1. **Function-block-body translation.** A small Structured-Text→`codet` translator
   (`ir_gen/st_fb_translator.{h,cpp}`) compiles each user-defined `functionBlock` POU
   body (assignments, `IF`, `WHILE`, comparisons, arithmetic) to GOTO, executed once per
   scan with the FB's inputs. Previously the body was absent from the IR.
2. **Output wiring.** A program `outVariable` connected to an FB output pin
   (`refLocalId`/`formalParameter`) is now assigned from that pin, so FB outputs reach
   the program (`FBOutWire`).
3. **Analog types.** `VarKind::REAL` (→ `double_type`), `REAL`/`LREAL`/`UINT`/… parsing,
   and non-Boolean coils/contacts via numeric↔Boolean coercion (contact `var != 0`,
   coil cast of power-flow). The Boolean-only constraint in the type checker is relaxed.
4. **Optional scan-watchdog.** Each rung loop carries a bounded iteration counter
   asserted within budget — a checkable model of a PLC watchdog timer (catches
   non-terminating rungs). This is a *modelling* aid, see soundness note.

## Changes by area
| File | Change |
|---|---|
| `ir_gen/st_fb_translator.{h,cpp}` (new) | ST→`codet` translator for FB bodies |
| `parser/ld_ast.h` | `UserFBDef`, `UserFBInstance`, `FBOutWire`, `VarKind::REAL` |
| `parser/plcopen_xml_parser.cpp` | parse FB-body POUs + block instances + output wiring; extra scalar types |
| `ir/ld_ir.h`, `ir/ld_ir_builder.cpp` | carry `UserFBExec` instances |
| `ir_gen/ld_converter.{h,cpp}` | `translate_user_fb`, scoped symbols, output wiring, REAL/coercion |
| `semantics/type_checker.cpp` | allow non-Boolean coils/contacts |
| `CMakeLists.txt` | add `st_fb_translator.cpp` |

## Testing
- **No regression:** all existing LD-frontend benchmarks reproduce their verdicts
  (13/13 in the ESBMC-PLC+ benchmark suite); programs without user FBs are unaffected
  (untranslatable FB bodies fall back to a sound no-op).
- New capability validated on public PLCopen-XML datasets (Boolean/integer and analog
  SWaT programs that previously failed to parse).

## Soundness note (please read)
The FB-body translation, output wiring, REAL types and watchdog are **sound**. The
*tolerant* handling of ST constructs outside the supported subset (nested FB calls,
member access) **over-approximates them nondeterministically** so analog programs can be
modelled; this is an over-approximation that **can yield false positives** and is gated
behind the `LLB_SOUND_MODE` environment variable (set ⇒ such constructs make the FB a
no-op instead, preserving soundness). I'm happy to change this to an explicit CLI flag,
or to drop the tolerant path entirely if you'd prefer the sound-only behaviour upstream.

## Notes for reviewers / how to split
- The one-line change in `src/clang-c-frontend/clang_c_lexer.cpp`
  (`TargetOptions` → `std::shared_ptr`) is an **unrelated LLVM-API-compat fix** needed to
  build against newer LLVM; happy to move it to a separate PR.
- If preferred, this can be split into: (a) FB-body translation + output wiring,
  (b) REAL/non-Boolean types, (c) the optional watchdog — they are largely independent.

## Checklist
- [x] Confined to the LD frontend (no backend change)
- [x] No regression on existing LD benchmarks
- [ ] CI green (please run; depends on your LLVM/Z3 versions)
- [ ] Reviewer preference on the over-approximation gating (env var vs CLI flag vs drop)