### PR TITLE
[python] V.4 B.2+B.3: wire python_adjust flag, fixture validation, before-placement finding

### DIFF
--- a/regression/python/python_irep2_adjust_dataclass/main.py
+++ b/regression/python/python_irep2_adjust_dataclass/main.py
@@ -1,0 +1,18 @@
+# Dataclass field access under --python-irep2-adjust: fields are struct
+# components the adjuster resolves like any other member source.
+from dataclasses import dataclass
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 3
+    assert p.y == 4
+
+
+main()

--- a/regression/python/python_irep2_adjust_dataclass/test.desc
+++ b/regression/python/python_irep2_adjust_dataclass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_flag/main.py
+++ b/regression/python/python_irep2_adjust_flag/main.py
@@ -1,0 +1,17 @@
+# Exercises the --python-irep2-adjust flag (V.4 B.2). Class member access is
+# the construct the IREP2-native adjuster will resolve once the converter emits
+# transient symbol_type member sources (B.3); for now the flag is inert and the
+# verdict must match the default path.
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x: int = x
+        self.y: int = y
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 3
+    assert p.y == 4
+
+
+main()

--- a/regression/python/python_irep2_adjust_flag/test.desc
+++ b/regression/python/python_irep2_adjust_flag/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_flag_fail/main.py
+++ b/regression/python/python_irep2_adjust_flag_fail/main.py
@@ -1,0 +1,14 @@
+# Negative variant of python_irep2_adjust_flag: the member read contradicts the
+# constructed value, so verification must fail under --python-irep2-adjust too.
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x: int = x
+        self.y: int = y
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 99
+
+
+main()

--- a/regression/python/python_irep2_adjust_flag_fail/test.desc
+++ b/regression/python/python_irep2_adjust_flag_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION FAILED$

--- a/regression/python/python_irep2_adjust_inferred_attr/main.py
+++ b/regression/python/python_irep2_adjust_inferred_attr/main.py
@@ -1,0 +1,16 @@
+# Flow-inferred attribute type (None -> Node) under --python-irep2-adjust, the
+# github_4117 shape: the adjuster follows the inferred symbol_type tag.
+class Node:
+    def __init__(self, value: int) -> None:
+        self.value: int = value
+        self.next = None
+
+
+def main() -> None:
+    n1 = Node(1)
+    n2 = Node(2)
+    n1.next = n2
+    assert n1.next.value == 2
+
+
+main()

--- a/regression/python/python_irep2_adjust_inferred_attr/test.desc
+++ b/regression/python/python_irep2_adjust_inferred_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_nested_attr/main.py
+++ b/regression/python/python_irep2_adjust_nested_attr/main.py
@@ -1,0 +1,19 @@
+# Nested attribute chain self.b.a under --python-irep2-adjust. This is the
+# recursive-resolution shape the IREP2-native adjuster's member-source follow
+# targets (V.4 B.1); the verdict must match the default path.
+class Inner:
+    def __init__(self, a: int) -> None:
+        self.a: int = a
+
+
+class Outer:
+    def __init__(self, inner: Inner) -> None:
+        self.b: Inner = inner
+
+
+def main() -> None:
+    o = Outer(Inner(7))
+    assert o.b.a == 7
+
+
+main()

--- a/regression/python/python_irep2_adjust_nested_attr/test.desc
+++ b/regression/python/python_irep2_adjust_nested_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -123,6 +123,10 @@ const struct group_opt_templ all_cmd_options[] = {
      {"python-list-compare-depth",
       boost::program_options::value<int>()->default_value(4)->value_name("nr"),
       "Set maximum nesting depth for Python list comparison (default is 4)"},
+     {"python-irep2-adjust",
+      NULL,
+      "Run the IREP2-native Python adjuster alongside the legacy adjust pass "
+      "(V.4 migration; experimental, default off)"},
    }},
 #endif
 #ifdef ENABLE_LD_FRONTEND

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -447,9 +447,19 @@ public:
     // struct view at the SMT boundary (see struct_union_members), and
     // the clang frontend builds complex literals as struct-id exprt
     // with a complex type — accept that shape here.
+    //
+    // A symbol_id type is permitted ONLY as a transient pre-resolution state,
+    // the same V.1k "two-phase source invariant" the member2t/index2t asserts
+    // carry: the Python frontend stores class instances with a by-name
+    // symbol_type and resolves it lazily, so migrating a constant aggregate
+    // before the IREP2-native adjuster has followed the type would otherwise
+    // abort here. The adjuster re-establishes the strong invariant before symex;
+    // no frontend builds a constant_struct2t pre-adjust today, so this disjunct
+    // is staged enabling infra exercised by the --python-irep2-adjust path.
     assert(
       type->type_id == type2t::struct_id ||
-      type->type_id == type2t::complex_id);
+      type->type_id == type2t::complex_id ||
+      type->type_id == type2t::symbol_id);
   }
   constant_struct2t(const constant_struct2t &ref) = default;
 

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -21,12 +21,26 @@ bool python_adjust::adjust()
     if (symbol->is_type)
       continue;
 
+    // Only function bodies carry the member2t/index2t expressions this pass
+    // resolves, and only bodies are what goto-convert later migrates via
+    // get_value2() (V.4.4b). Reading get_value2() on a data symbol whose value
+    // is a by-name-typed constant aggregate would trip constant_struct2t's
+    // (un-relaxed) migration assert, so skip non-code symbols.
+    if (!is_code_type(symbol->get_type2()))
+      continue;
+
     expr2tc value = symbol->get_value2();
     if (is_nil_expr(value))
       continue;
 
+    const expr2tc original = value;
     adjust_expr(value);
-    symbol->set_value(value);
+    // Only write back when resolution actually changed the tree. Leaving an
+    // unchanged symbol untouched keeps its legacy value cache valid, so the
+    // following clang_cpp_adjust pass sees a byte-identical body — the pass is
+    // inert until the converter emits transient symbol_type member sources.
+    if (value != original)
+      symbol->set_value(value);
   }
 
   return false;

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -259,9 +259,19 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
   // constant aggregate trips constant_struct2t's (un-relaxed) assert. Post-adjust
   // the types are resolved, so the walk is safe; it currently resolves nothing
   // (clang_cpp_adjust already did) and only writes a symbol back when it changes
-  // the value, so the flag is behaviour-inert. Moving the pass *before*
-  // clang_cpp_adjust to actually replace it (B.5) first requires resolving the
-  // migration-before-resolution problem this ordering documents.
+  // the value, so the flag is behaviour-inert.
+  //
+  // B.3 experiment (2026-06-25, negative result, do not retry as-is): moving the
+  // pass *before* clang_cpp_adjust to exercise resolution was prototyped. It
+  // additionally needs member2t/index2t to tolerate a transient pointer source
+  // (the Python frontend stores instances/containers behind a pointer) plus a
+  // pointer auto-deref in resolve_source. With those, migration no longer aborts,
+  // but the whole 20-test fixture then produced *no verdict* under the flag
+  // (symex crash/hang): running the IREP2 adjuster before clang_cpp_adjust while
+  // clang_cpp_adjust still runs afterwards double-resolves the same nodes — the
+  // "two-places-resolve hazard" the V.1k spike flagged. Conclusion: the
+  // before-placement is only viable once it *replaces* clang_cpp_adjust for
+  // Python (B.5), which is a dedicated effort, not a reorder of this call.
   if (config.options.get_bool_option("python-irep2-adjust"))
   {
     python_adjust py_adjuster(context);

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -2,6 +2,7 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_annotation.h>
 #include <python-frontend/global_scope.h>
+#include <python-frontend/python_adjust.h>
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
 #include <util/message.h>
 #include <util/filesystem.h>
@@ -249,6 +250,23 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
   clang_cpp_adjust adjuster(context);
   if (adjuster.adjust())
     return true;
+
+  // V.4 B.2: optionally run the IREP2-native Python adjuster. Default off.
+  //
+  // It runs *after* clang_cpp_adjust for now: reading get_value2() migrates each
+  // legacy value to IREP2, which requires its types to already be resolved —
+  // before clang_cpp_adjust they are still by-name symbol_types and migrating a
+  // constant aggregate trips constant_struct2t's (un-relaxed) assert. Post-adjust
+  // the types are resolved, so the walk is safe; it currently resolves nothing
+  // (clang_cpp_adjust already did) and only writes a symbol back when it changes
+  // the value, so the flag is behaviour-inert. Moving the pass *before*
+  // clang_cpp_adjust to actually replace it (B.5) first requires resolving the
+  // migration-before-resolution problem this ordering documents.
+  if (config.options.get_bool_option("python-irep2-adjust"))
+  {
+    python_adjust py_adjuster(context);
+    py_adjuster.adjust();
+  }
 
   return false;
 }


### PR DESCRIPTION
Top of the V.4 IREP2-native Python adjuster ladder. **Stacked on #5616 (B.1)**, which is stacked on #5615 (B.0). Merge bottom-up: **#5615 → #5616 → this**.

Rebuilt cleanly on current master (the earlier out-of-order merges had cross-contaminated the branches). This branch now carries three commits on top of B.1:

- **B.2 — wire `python_adjust` behind `--python-irep2-adjust`** (was #5618, which got merged into a parent branch rather than master). Adds the option + invocation after `clang_cpp_adjust`; default off ⇒ byte-identical. Wiring forced relaxing `constant_struct2t` for a transient `symbol_id` (matching `member2t`/`index2t`). Tests `python_irep2_adjust_flag{,_fail}`.
- **B.2 validation** — flag-on/off parity over the full 20-test fixture (0 divergences); pinned by `python_irep2_adjust_{nested_attr,inferred_attr,dataclass}`.
- **B.3 — before-placement negative finding** (was #5622). Documents at the call site that running the pass before `clang_cpp_adjust` double-resolves nodes (unsound); B.3–B.5 collapse into one milestone (replace `clang_cpp_adjust`).

This supersedes the now-closed #5618 and #5622 (which merged into parent branches, not master). Verified on current master: esbmc builds, `python_adjust_test` 15/15, flag tests give matching verdicts, clang-format-11 clean.