### PR TITLE
[python] V.4 B.3: record the before-placement negative result

### DIFF
--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -259,9 +259,19 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
   // constant aggregate trips constant_struct2t's (un-relaxed) assert. Post-adjust
   // the types are resolved, so the walk is safe; it currently resolves nothing
   // (clang_cpp_adjust already did) and only writes a symbol back when it changes
-  // the value, so the flag is behaviour-inert. Moving the pass *before*
-  // clang_cpp_adjust to actually replace it (B.5) first requires resolving the
-  // migration-before-resolution problem this ordering documents.
+  // the value, so the flag is behaviour-inert.
+  //
+  // B.3 experiment (2026-06-25, negative result, do not retry as-is): moving the
+  // pass *before* clang_cpp_adjust to exercise resolution was prototyped. It
+  // additionally needs member2t/index2t to tolerate a transient pointer source
+  // (the Python frontend stores instances/containers behind a pointer) plus a
+  // pointer auto-deref in resolve_source. With those, migration no longer aborts,
+  // but the whole 20-test fixture then produced *no verdict* under the flag
+  // (symex crash/hang): running the IREP2 adjuster before clang_cpp_adjust while
+  // clang_cpp_adjust still runs afterwards double-resolves the same nodes — the
+  // "two-places-resolve hazard" the V.1k spike flagged. Conclusion: the
+  // before-placement is only viable once it *replaces* clang_cpp_adjust for
+  // Python (B.5), which is a dedicated effort, not a reorder of this call.
   if (config.options.get_bool_option("python-irep2-adjust"))
   {
     python_adjust py_adjuster(context);


### PR DESCRIPTION
Phase **B.3** investigation outcome, **stacked on the B.2 validation (#5621)**. Comment-only; no behaviour change.

**What was tried.** To actually exercise the adjuster's member/index source resolution (after `clang_cpp_adjust` everything is already resolved, so the B.2 walk is inert), I prototyped running `python_adjust` *before* `clang_cpp_adjust` over the full 20-test acceptance fixture under `--python-irep2-adjust`.

**What happened.**
1. All 69 fixture tests aborted on `index2t`'s construction assert — the Python frontend stores instances/containers behind a pointer, so the migrated member/index source is a pointer, which the V.1k relaxation didn't permit.
2. Relaxing `member2t`/`index2t` to tolerate a transient pointer source + adding a pointer auto-deref to `resolve_source` stopped the aborts — but then the whole fixture produced **no verdict** (symex crash/hang).

**Conclusion.** Running the IREP2 adjuster *before* `clang_cpp_adjust` while `clang_cpp_adjust` still runs afterwards **double-resolves** the same nodes — the "two-places-resolve hazard" the V.1k spike flagged. The before-placement is viable only once it **replaces** `clang_cpp_adjust` for the Python path (B.5), which is a dedicated effort, not a reorder of this call. This PR records that finding at the call site so it isn't re-attempted as-is; the prototype itself is reverted (it breaks).