### PR TITLE
[om] model getopt_long/getopt_long_only so optarg is a valid pointer

### DIFF
--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -1,9 +1,9 @@
 # SV-COMP Issue Triage & Fix Plan
 
-**Last updated:** 2026-06-22 (Pass 8 — reconcile #5395/#5400 closures; **x86_64 Linux host removes
-the aarch64 parse blocker** for the ldv-linux-3.14-races drivers: all four #5396–#5399 reproduced and
-root-caused (a shared unmodeled-LDV-kernel-environment pointer/device gap), #5142 re-classified to a
-clang `-Wint-conversion` blocker; see §12. Pass 7 in §11)
+**Last updated:** 2026-06-26 (Pass 9 — reconcile four closures since Pass 8 (#5395/#5399/#5400 and the
+new #5593, an Intel-TDX `havoc_memory` recurrence of #5224 fixed by merged PR #5602); triage the new
+live issue #5565 and **fix its first post-#5564 residual** — an unmodeled `getopt_long` left `optarg` an
+invalid pointer, a sound localized OM fix; see §13. Pass 8 in §12, Pass 7 in §11)
 **Scope:** every open issue carrying the `SV-COMP` label in `esbmc/esbmc`, plus recently-closed
 SV-COMP issues for context and de-duplication.
 **Reference binary:** `build/src/esbmc/esbmc`, ESBMC 8.3.0. Pass 8 on an **x86_64 Linux** host with
@@ -1177,3 +1177,107 @@ under-/over-approx trade-off is the #5145/#5138 project.
    pointers — the shared blocker behind all four #5396–#5399; research-grade, would close the
    ldv-linux-3.14-races overflow/memsafety cluster.
 8. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.
+
+---
+
+## 13. Pass 9 — reconcile closures + comm_3args_ok getopt_long residual (2026-06-26)
+
+Pass 8 closed on 2026-06-22. This pass reconciles the four issues that closed since, triages the one
+new live issue (#5565), and produces **one sound localized OM fix** for it. Verdicts are **repro**
+(locally reproduced this pass with each issue's exact flags) on an **x86_64 Linux** host. The reference
+binary was rebuilt from master `9e79dbe179` — which **includes PR #5564** (`[symex] treat
+stack-reachable heap as live in memory-leak check`, merged 2026-06-26), the fix for the #5138/#5565
+forgotten-memory layer. (An earlier stale binary still carried the pre-#5564 leak and masked the
+residual below — the rebuild was a prerequisite.)
+
+### 13.1 Closed since Pass 8
+
+| # | Property | Closed | Outcome |
+|---|---|---|---|
+| #5395 | unreach-call (`rule57_ebda_blast`) | 2026-06-18 | the Pass-7 fix landed (`calloc(_,0)` → `malloc(0)`); see §11.2. |
+| #5399 | valid-memsafety (`cafe_ccic.ko.cil-2`) | 2026-06-22 | closed-with-RCA (§12.4). Its twin **#5398** (`cil-1`) stays **open** as the tracker — same root cause (no-op `v4l2_device_register` + non-zeroed `pdev` + unguarded `to_cam`); not re-triaged. |
+| #5400 | valid-memtrack (`arraycollapse_rc`) | 2026-06-19 | closed-with-RCA (§12.2); allocation-site value-set imprecision. |
+| #5593 | unreach-call (Intel-TDX `*_havoc_memory`, 27 tasks) | 2026-06-26 | **recurrence of #5224**; fixed by **merged PR #5602** (`[k-induction] disable inductive step on reachable __VERIFIER_nondet_memory`), extending the #5228/#5230 pointer-array havoc gate to the `__VERIFIER_nondet_memory` write idiom that #5268 missed. Two regression tests (`github_5593_nondet_memory_heap{,_fail}`). Sound Phase-1/2 gate extension — **no competing PR**. |
+
+### 13.2 #5565 — `comm_3args_ok` residual after #5564: `getopt_long`/`optarg` false alarm — FIXED
+
+**Status: FIXED. Sound localized OM fix (`getopt_long`/`getopt_long_only`) + two regression tests.
+PR opened.**
+
+#5565 was filed (2026-06-22) as the residual after #5564 resolved the `forgotten memory` leak on
+`coreutils-v8.31/comm_3args_ok`, and *predicted* two residual model gaps: an `fclose(stdout)`
+static-stream free and a `strcmp` invalid-pointer. **Reproduced on a post-#5564 x86_64 build, the
+first-firing residual is neither of those** — it is an **unmodeled `getopt_long`**:
+
+* Both the `--sv-comp` and the plain (`#5138`-command) runs report
+  `dereference failure: invalid pointer` at `k = 11`: the `--sv-comp` run at `comm_3args_ok.c:51622`
+  (`if (*optarg)` in `__main`), the plain run inside `strlen` (`string.c:92`, from
+  `strlen(optarg)` two lines later). Ground truth is `true` ⇒ false alarm.
+* **Root cause (trace + source).** The trace shows `WARNING: no body for function getopt_long` and
+  `optarg = invalid-object`. ESBMC models `getopt` (`src/c2goto/library/getopt.c`: `optarg =
+  argv[result_index]`, `result_index < argc`) but **not** `getopt_long`/`getopt_long_only`, so the
+  global `optarg` is never assigned and stays its uninitialised (invalid/NULL) value; the benchmark
+  then dereferences it. This is the missing-libc-OM class of §4 #2797, here narrowed to one function.
+
+**Fix.** Add `getopt_long` and `getopt_long_only` to `getopt.c`, mirroring `getopt` via a shared
+`__ESBMC_getopt_long(argc, argv)` helper: `__ESBMC_assume(result_index < argc); optarg =
+argv[result_index]; return nondet_int();`. The nondet return (vs `getopt`'s constant `0`) keeps every
+option-handling branch *and* loop termination via `-1` reachable. An incomplete `struct option`
+forward declaration suffices (the long-option table is only forwarded, never read).
+
+**Why it is sound.** `optarg` is bound to a real argv element (`result_index < argc`), exactly what the
+real library does for an option that takes an argument, and exactly what the pre-existing `getopt`
+model already does. It is an over-approximation in the same direction as `getopt`: `optarg` is always a
+valid non-NULL pointer and `optind`/`*longindex` are not advanced (documented in the file comment) — so
+no genuine race/leak/OOB is hidden. The esbmc-verifier agent confirmed the model does **not**
+blanket-suppress pointer/bounds checks (a deref of `optarg` *without* calling `getopt_long` still fires
+`invalid pointer`; an out-of-bounds write past the argv element still fires `array bounds violated`),
+and that the positive test is **not** vacuous (the `optarg` branch is reachable and verified safe).
+
+**Validation.**
+* Minimal repro → `VERIFICATION SUCCESSFUL` (was `invalid pointer`/`NULL pointer` FAILED).
+* Full `comm_3args_ok.c` with the issue's exact flags (`--sv-comp`): the spurious `FALSE` at `k = 11`
+  is **gone** — ESBMC unwinds past it to `k ≥ 12` and times out (UNKNOWN, sound — no false positive),
+  instead of reporting a false counterexample.
+* Two regressions under `regression/esbmc-unix/`: `github_5565_getopt_long_optarg` (exercises both
+  `getopt_long` and `getopt_long_only`; `optarg` deref safe ⇒ SUCCESSFUL) and
+  `github_5565_getopt_long_optarg_oob_fail` (`optarg[100]` past a 4-byte argv element ⇒
+  `array bounds violated` FAILED — pins that `optarg` is a *bounded* real object, not an invented
+  infinite buffer).
+* **Dual-solver z3 + bitwuzla agree** on both tests; esbmc-verifier (Mode A) reports
+  `PATCH VERIFIED — no new errors`. The pre-existing `getopt_long` test
+  (`instrumented_nohup_comb_overflow`) still passes (still finds its target overflow — the nondet
+  return preserves bug-finding). Code-reviewed: no critical/major findings.
+
+**Residual.** The `fclose` static-stream free the issue names is gated by the **compile-time
+`ESBMC_SVCOMP`** build (`#5138` needs `-DESBMC_SVCOMP=On`, §11.6), and the `strcmp` invalid-pointer did
+not surface as the first failure on a standard build — both are either that-build-gated or downstream
+of the `optarg` layer fixed here. Keep #5565 open for those; the `getopt_long`/`optarg` layer is
+closed by this PR.
+
+### 13.3 Pass-9 running report
+
+**Analysed.** The four closures (#5395/#5399/#5400/#5593) reconciled against current GitHub state;
+#5565 reproduced and root-caused on a post-#5564 build.
+
+**PRs opened.** One: `[om] model getopt_long/getopt_long_only so optarg is a valid pointer` — addresses
+**#5565** (the `getopt_long`/`optarg` layer). Sound, dual-solver-validated, esbmc-verifier-confirmed,
+code-reviewed, two regression tests.
+
+**Duplicated work avoided.** #5593 not re-fixed — merged PR #5602 already targets it (sound gate
+extension of #5228/#5230). #5398 not re-triaged — same RCA as its closed twin #5399 (§12.4). The
+#5138/#5565 forgotten-memory layer not re-fixed — closed by #5564.
+
+**Remaining work (priority order, updated 2026-06-26).** Unchanged from §12.6, with #5565 reduced to
+its `fclose`/`strcmp` residual (lower priority, `ESBMC_SVCOMP`-gated):
+1. **#5145 / #5393 / #5394** — aws-hash byte-addressed pointer-read-consistency (closed #5369 RCA).
+2. **#5400 / #5138** — value-set reachability for `valid-memtrack` (sound under-approximation of
+   "reachable"); note #5564 advanced the live-stack-reachability half.
+3. **#5012** — G-C `va_list` argument recovery (symbolic-format printf return length).
+4. **#4980** — termination ranking recogniser for side-effect-only call bodies (full-set validation).
+5. **#4432** — data-race-checker interleaving reduction on `__atomic_*`.
+6. **#5142** — clang `-Wint-conversion` relaxation / integer→pointer initializer fix-up for CIL inputs.
+7. **Device-API / LDV-environment model** (`platform_get_drvdata` etc.) — shared #5396–#5399 blocker.
+8. **#5565 residual** — `ESBMC_SVCOMP`-gated `fclose(stdout)` static-stream free + `strcmp` argv-string
+   pointer-validity; reproduce under a `-DESBMC_SVCOMP=On` build.
+9. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.

--- a/regression/esbmc-unix/github_5565_getopt_long_optarg/main.c
+++ b/regression/esbmc-unix/github_5565_getopt_long_optarg/main.c
@@ -1,0 +1,64 @@
+/* #5565: getopt_long() must leave optarg pointing into argv (a valid object),
+ * mirroring getopt().  Without an operational model getopt_long had no body,
+ * so optarg stayed an unconstrained/NULL pointer and dereferencing it
+ * (if (*optarg) / strlen(optarg)) raised a spurious "invalid pointer" failure
+ * -- the residual comm_3args_ok false alarm after the #5564 memory-leak fix. */
+#include <stdlib.h>
+
+extern char *optarg;
+
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+
+int getopt_long(
+  int argc,
+  char *const argv[],
+  const char *optstring,
+  const struct option *longopts,
+  int *longindex);
+
+int getopt_long_only(
+  int argc,
+  char *const argv[],
+  const char *optstring,
+  const struct option *longopts,
+  int *longindex);
+
+size_t strlen(const char *s);
+
+int main()
+{
+  int argc = 3;
+  char **argv = malloc((argc + 1) * sizeof(char *));
+  argv[argc] = 0;
+  for (int i = 0; i < argc; i++)
+  {
+    argv[i] = malloc(4);
+    argv[i][0] = 'a';
+    argv[i][1] = 0;
+  }
+
+  struct option lo[1] = {{0, 0, 0, 0}};
+  int c = getopt_long(argc, argv, "abc", lo, 0);
+  if (c == -1)
+    c = getopt_long_only(argc, argv, "abc", lo, 0);
+
+  /* getopt_long returns a nondet option char; on any branch that consumes an
+   * argument the program dereferences optarg.  This must be sound. */
+  if (c == 'd')
+    if (*optarg)
+    {
+      size_t n = strlen(optarg);
+      (void)n;
+    }
+
+  for (int i = 0; i < argc; i++)
+    free(argv[i]);
+  free(argv);
+  return 0;
+}

--- a/regression/esbmc-unix/github_5565_getopt_long_optarg/test.desc
+++ b/regression/esbmc-unix/github_5565_getopt_long_optarg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --memory-leak-check --no-reachable-memory-leak --malloc-zero-is-null --incremental-bmc --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_5565_getopt_long_optarg_oob_fail/main.c
+++ b/regression/esbmc-unix/github_5565_getopt_long_optarg_oob_fail/main.c
@@ -1,0 +1,45 @@
+/* #5565 boundary: the getopt_long model points optarg into argv, a *bounded*
+ * real object -- it does not over-approximate optarg to an unbounded buffer.
+ * Reading far past the argv element must therefore still be caught as an
+ * out-of-bounds access (this would spuriously pass if the model invented an
+ * infinite buffer). */
+#include <stdlib.h>
+
+extern char *optarg;
+
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+
+int getopt_long(
+  int argc,
+  char *const argv[],
+  const char *optstring,
+  const struct option *longopts,
+  int *longindex);
+
+int main()
+{
+  int argc = 2;
+  char **argv = malloc((argc + 1) * sizeof(char *));
+  argv[argc] = 0;
+  for (int i = 0; i < argc; i++)
+  {
+    argv[i] = malloc(4); /* 4-byte argv element */
+    argv[i][0] = 0;
+  }
+
+  int c = getopt_long(argc, argv, "a", (struct option *)0, 0);
+  if (c == 'a')
+    optarg[100] =
+      'x'; /* out of bounds for the 4-byte object optarg points to */
+
+  for (int i = 0; i < argc; i++)
+    free(argv[i]);
+  free(argv);
+  return 0;
+}

--- a/regression/esbmc-unix/github_5565_getopt_long_optarg_oob_fail/test.desc
+++ b/regression/esbmc-unix/github_5565_getopt_long_optarg_oob_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null --incremental-bmc --unwind 3
+^VERIFICATION FAILED$

--- a/src/c2goto/library/getopt.c
+++ b/src/c2goto/library/getopt.c
@@ -8,3 +8,50 @@ __ESBMC_HIDE:;
   optarg = argv[result_index];
   return 0;
 }
+
+/* getopt_long()/getopt_long_only() behave like getopt() but also accept a
+ * long-option table.  As with getopt(), when an option takes an argument the
+ * library points optarg into argv, so modelling that keeps optarg a valid
+ * pointer and callers that dereference it (e.g. strlen(optarg)) stay sound.
+ * The long-option arguments are only declared, never read here, so an
+ * incomplete struct option type is sufficient.  The return value is
+ * nondeterministic so every option branch -- and loop termination via -1 --
+ * stays reachable.
+ *
+ * Like the getopt() model above, this over-approximates: optarg is always a
+ * valid non-NULL argv element (the real library leaves it NULL for options
+ * taking no argument), and optind / *longindex are not advanced.  A program
+ * that dereferences optarg for a no-argument option therefore is not flagged
+ * -- the same intentional trade-off getopt() already makes. */
+struct option;
+
+static int __ESBMC_getopt_long(int argc, char *const argv[])
+{
+__ESBMC_HIDE:;
+  unsigned result_index;
+  __ESBMC_assume(result_index < argc);
+  optarg = argv[result_index];
+  return nondet_int();
+}
+
+int getopt_long(
+  int argc,
+  char *const argv[],
+  const char *optstring,
+  const struct option *longopts,
+  int *longindex)
+{
+__ESBMC_HIDE:;
+  return __ESBMC_getopt_long(argc, argv);
+}
+
+int getopt_long_only(
+  int argc,
+  char *const argv[],
+  const char *optstring,
+  const struct option *longopts,
+  int *longindex)
+{
+__ESBMC_HIDE:;
+  return __ESBMC_getopt_long(argc, argv);
+}


### PR DESCRIPTION
## Problem

ESBMC has no operational model for `getopt_long` / `getopt_long_only`, only for `getopt`. With no body, the global `optarg` is never assigned and stays an invalid/NULL pointer. Programs that dereference it — e.g. `if (*optarg)` / `strlen(optarg)`, the standard coreutils idiom — then raise a spurious `dereference failure: invalid pointer`.

This is the first residual false alarm on `coreutils-v8.31/comm_3args_ok` after PR #5564 resolved the `forgotten memory` leak layer (SV-COMP #5565). The trace shows `WARNING: no body for function getopt_long` and `optarg = invalid-object`; the benchmark's `if (*optarg)` (line 51622) / `strlen(optarg)` then fails. Ground truth is `true`, so this is a false alarm.

## Fix

Add `getopt_long` / `getopt_long_only` to `src/c2goto/library/getopt.c`, mirroring the existing `getopt` model via a shared helper:

```c
__ESBMC_assume(result_index < argc);
optarg = argv[result_index];   /* a valid argv element, as the real library does */
return nondet_int();           /* every option branch + loop termination via -1 stay reachable */
```

An incomplete `struct option` forward declaration suffices (the long-option table is only forwarded, never read).

### Soundness

`optarg` is bound to a real argv element (`result_index < argc`) — exactly what the real library does for an option that takes an argument, and exactly what the pre-existing `getopt` model already does. It over-approximates in the same direction as `getopt` (optarg always valid non-NULL; `optind`/`*longindex` not advanced — documented in the file comment), so no genuine race/leak/OOB is hidden. Verified that the model does **not** blanket-suppress checks: a deref of `optarg` without calling `getopt_long` still fires `invalid pointer`, and an out-of-bounds write past the argv element still fires `array bounds violated`.

## Validation

- Minimal repro: `VERIFICATION SUCCESSFUL` (was `invalid pointer` FAILED).
- Full `comm_3args_ok.c` with the issue's exact flags: the spurious `FALSE` at `k = 11` is gone — ESBMC unwinds past it (sound; no false positive).
- Two regression tests under `regression/esbmc-unix/`:
  - `github_5565_getopt_long_optarg` — exercises both `getopt_long` and `getopt_long_only`; `optarg` deref safe ⇒ SUCCESSFUL.
  - `github_5565_getopt_long_optarg_oob_fail` — `optarg[100]` past a 4-byte argv element ⇒ `array bounds violated` FAILED, pinning that `optarg` is a *bounded* real object.
- Dual-solver **Z3 + Bitwuzla** agree on both tests; the pre-existing `getopt_long` test (`instrumented_nohup_comb_overflow`) still passes (still finds its target overflow).

Fixes #5565