### PR TITLE
[python] V.1k(b) B.1: follow symbol_type2t member/index sources

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3400,7 +3400,7 @@ build-IREP2-then-back-migrate pattern file 1 used for non-member expressions
 
 #### V.1k (b)-adjuster — execution scoping (post-V.4.4b: the precondition is now met)
 
-> **Status: B.0 landed (2026-06-26); B.1 next.** The V.1k breakthrough above deferred
+> **Status: B.0 + B.1 landed (2026-06-26); B.2 next.** The V.1k breakthrough above deferred
 > the (b) IREP2-native adjuster to "V.4+" on the grounds that *a separate adjuster
 > has no IREP2 to operate on until function bodies are IREP2*. **That precondition is
 > now satisfied:** V.4.4b landed and the IREP2 body round-trip is the only body path
@@ -3469,11 +3469,18 @@ following (`next: None`→`Node`), and dataclass field resolution.
   contracts — visits-every-node and the `is_type`-skip no-op — are pinned by
   `unit/python-frontend/python_adjust_test.cpp`. Parity is trivially unchanged
   (the pass is on no execution path).
-- **B.1 — member/index source following.** Teach the pass to follow a `symbol_type2t`
-  member/index source to its `struct_type2t`/`array_type2t` via `namespacet::follow`,
-  **recursively** (resolve `X` before building `X.a`), with pointer auto-deref. Still
-  not wired in. Unit round-trip tests asserting a hand-built
-  `member2tc(symbol_type2t-source)` resolves to a struct source.
+- **B.1 — member/index source following. LANDED.** `python_adjust::adjust_expr`
+  is now a mutating post-order walk: it resolves operands first (resolve `X`
+  before `X.a`), then rewrites a `member2t`/`index2t` source whose type is an
+  unresolved `symbol_type2t` to carry the followed `struct_type2t`/`array_type2t`
+  (`namespacet::follow` + `expr2t::with_type`). **Pointer auto-deref is not in the
+  adjuster:** the `member2t`/`index2t` construction assert forbids a pointer
+  source (`irep2_expr.h:1552-1556`/`:1647-1648` permit only struct/union/complex/
+  array/vector/`symbol_id`), so a pointer base is dereferenced — to a
+  `symbol_type2t`-typed source — *before* the node is built; the adjuster only
+  ever sees the by-name source. Still not wired into `python_language.cpp` (B.2).
+  `python_adjust_test.cpp` pins direct member, direct index, and recursive nested
+  resolution.
 - **B.2 — wire in behind a flag.** `--python-irep2-adjust` (default off) routes Python
   output through the new pass *in addition to* the legacy `clang_cpp_adjust` (the new
   pass resolves the pre-adjust `symbol_type2t` members the converter will start

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,4 +1,5 @@
 #include <python-frontend/python_adjust.h>
+#include <irep2/irep2_utils.h>
 
 python_adjust::python_adjust(contextt &_context)
   : context(_context), ns(_context)
@@ -19,18 +20,58 @@ bool python_adjust::adjust()
     if (symbol.is_type)
       continue;
 
-    adjust_expr(symbol.get_value2());
+    expr2tc value = symbol.get_value2();
+    if (is_nil_expr(value))
+      continue;
+
+    adjust_expr(value);
+    symbol.set_value(value);
   }
 
   return false;
 }
 
-void python_adjust::adjust_expr(const expr2tc &expr)
+void python_adjust::adjust_expr(expr2tc &expr)
 {
   if (is_nil_expr(expr))
     return;
 
-  // B.0: no transformation. Descend into every operand so that B.1
-  // (member/index source following) extends a complete traversal.
-  expr->foreach_operand([this](const expr2tc &e) { adjust_expr(e); });
+  // Resolve sub-expressions first: a source must be resolved before the
+  // member/index that reads it (resolve `X` before building `X.a`).
+  expr->Foreach_operand([this](expr2tc &e) { adjust_expr(e); });
+
+  if (is_member2t(expr))
+  {
+    const member2t &m = to_member2t(expr);
+    expr2tc source = m.source_value;
+    if (resolve_aggregate_source(source))
+      expr = member2tc(expr->type, source, m.member);
+  }
+  else if (is_index2t(expr))
+  {
+    const index2t &i = to_index2t(expr);
+    expr2tc source = i.source_value;
+    if (resolve_aggregate_source(source))
+      expr = index2tc(expr->type, source, i.index);
+  }
+}
+
+bool python_adjust::resolve_aggregate_source(expr2tc &source) const
+{
+  // A member2t/index2t source reaches the adjuster as an unresolved by-name
+  // symbol_type2t (the relaxed-assert transient state); follow it to its
+  // struct/union/array. A pointer base never appears here: the member2t/index2t
+  // construction assert forbids a pointer source, so the converter dereferences
+  // it (yielding a symbol_type2t-typed source) before building the node.
+  if (!is_symbol_type(source->type))
+    return false;
+
+  // ns.follow() asserts (debug) / null-derefs (release) on an unregistered tag.
+  // Leave such a source untouched: the post-adjust strong-invariant check (B.4)
+  // is the correct place to flag a tag that never resolved.
+  if (context.find_symbol(to_symbol_type(source->type).symbol_name) == nullptr)
+    return false;
+
+  source = source->with_type(ns.follow(source->type));
+  return true;
 }

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -7,16 +7,22 @@
 
 /**
  * IREP2-native adjuster for the Python frontend (Part V Phase V.1k design (b),
- * docs/irep2-migration.md). This is the resolve-then-build pass that, in later
- * sub-phases, follows `symbol_type2t` member/index sources to their resolved
- * `struct_type2t`/`array_type2t` over the IREP2 body (`symbol.get_value2()`),
- * replacing the legacy `clang_cpp_adjust` round-trip on Python output.
+ * docs/irep2-migration.md). This is the resolve-then-build pass that replaces
+ * the legacy `clang_cpp_adjust` round-trip on Python output: it walks the IREP2
+ * body (`symbol.get_value2()`) and follows `symbol_type2t` member/index sources
+ * to their resolved `struct_type2t`/`array_type2t` so that, post-adjust, every
+ * `member2t`/`index2t` source satisfies the strong resolved-source invariant.
  *
- * This file ships **B.0**: a structural no-op walker. It visits every operand
- * of every function body's IREP2 expression tree and changes nothing. It is not
- * wired into `python_languaget::final` yet, so it is dead-but-tested — the
- * traversal is exercised by `unit/python-frontend/python_adjust_test.cpp` so
- * that B.1 (member/index source following) has a verified walk to extend.
+ * Sub-phase status:
+ *   B.0 — structural no-op walker (shipped).
+ *   B.1 — member/index source following (this file): a `symbol_type2t` source is
+ *         followed via `namespacet::follow` to its struct/array, recursively
+ *         (resolve `X` before `X.a`). A pointer base is dereferenced by the
+ *         converter before the node is built (the construction assert forbids a
+ *         pointer source), so it never reaches the adjuster as a raw source.
+ *         Still **not wired into** `python_languaget::final` (that is B.2), so
+ *         it remains dead-but-tested — `unit/python-frontend/python_adjust_test.cpp`
+ *         pins the traversal and the resolution.
  */
 class python_adjust
 {
@@ -24,19 +30,25 @@ public:
   explicit python_adjust(contextt &_context);
   virtual ~python_adjust() = default;
 
-  /** Walk every non-type symbol's IREP2 body. Returns true on error (none in
-   *  B.0), mirroring `clang_c_adjust::adjust()`. */
+  /** Walk every non-type symbol's IREP2 body and write the resolved form back.
+   *  Returns true on error (none today), mirroring `clang_c_adjust::adjust()`. */
   bool adjust();
 
 protected:
   contextt &context;
   namespacet ns;
 
-  /** Recursively visit an IREP2 expression. B.0: descends into every operand
-   *  and performs no transformation. Virtual so later phases override the
-   *  member/index source-following behaviour and so tests can observe the
-   *  traversal. */
-  virtual void adjust_expr(const expr2tc &expr);
+  /** Recursively resolve an IREP2 expression in place. Operands are resolved
+   *  first (post-order), then a `member2t`/`index2t` source whose type is an
+   *  unresolved `symbol_type2t` (directly or behind a pointer) is followed to
+   *  its aggregate type. Virtual so tests can observe the traversal. */
+  virtual void adjust_expr(expr2tc &expr);
+
+private:
+  /** If @p source carries an unresolved `symbol_type2t`, rewrite it to carry the
+   *  followed aggregate type and return true. Otherwise leave it untouched and
+   *  return false. */
+  bool resolve_aggregate_source(expr2tc &source) const;
 };
 
 #endif /* PYTHON_FRONTEND_PYTHON_ADJUST_H_ */

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -7,29 +7,51 @@
 #include <util/context.h>
 #include <util/c_types.h>
 
-// Part V Phase V.1k (b) sub-phase B.0 (docs/irep2-migration.md): the IREP2-native
-// Python adjuster ships first as a structural no-op walker. These tests pin the
-// two B.0 contracts so B.1 (member/index source following) extends a verified
-// traversal:
-//   (1) adjust_expr visits every node of an IREP2 expression tree exactly once.
-//   (2) adjust() leaves every symbol's IREP2 value byte-identical (no-op).
+// Part V Phase V.1k (b), sub-phases B.0/B.1 (docs/irep2-migration.md): the
+// IREP2-native Python adjuster. These tests pin its contracts so each later
+// sub-phase extends a verified pass:
+//   B.0 — adjust_expr visits every node; adjust() skips is_type symbols and is a
+//         no-op when nothing needs resolving.
+//   B.1 — a member2t/index2t source carrying an unresolved symbol_type2t is
+//         followed to its struct/array, recursively (resolve X before X.a).
 
 namespace
 {
-// Observes the traversal by counting every non-nil node the walker descends
-// into. Relies on adjust_expr being virtual and recursing through itself.
-struct counting_adjust : public python_adjust
+// Exposes the protected recursion and counts every non-nil node descended into.
+struct test_adjust : public python_adjust
 {
   using python_adjust::python_adjust;
   unsigned visited = 0;
 
-  void adjust_expr(const expr2tc &expr) override
+  void adjust_expr(expr2tc &expr) override
   {
     if (!is_nil_expr(expr))
       ++visited;
     python_adjust::adjust_expr(expr);
   }
 };
+
+void add_type_symbol(contextt &ctx, const irep_idt &id, const type2tc &t)
+{
+  symbolt s;
+  s.id = id;
+  s.name = id;
+  s.mode = "Python";
+  s.is_type = true;
+  s.set_type(t);
+  ctx.add(s);
+}
+
+// A one-field struct named `name` with member `memb` of type `mt`.
+type2tc make_struct(const irep_idt &name, const irep_idt &memb, const type2tc &mt)
+{
+  return struct_type2tc(
+    std::vector<type2tc>{mt},
+    std::vector<irep_idt>{memb},
+    std::vector<irep_idt>{memb},
+    name,
+    false);
+}
 } // namespace
 
 TEST_CASE(
@@ -44,7 +66,7 @@ TEST_CASE(
   expr2tc tree = add2tc(t, mul2tc(t, gen_ulong(1), gen_ulong(2)), gen_ulong(3));
 
   contextt context;
-  counting_adjust walker(context);
+  test_adjust walker(context);
   walker.adjust_expr(tree);
 
   REQUIRE(walker.visited == 5);
@@ -90,4 +112,134 @@ TEST_CASE(
   const symbolt *type_out = context.find_symbol("py:test@T@tag-Skipped");
   REQUIRE(type_out != nullptr);
   REQUIRE(type_out->get_value2() == value);
+}
+
+TEST_CASE(
+  "python_adjust B.1 follows a symbol_type2t member source to its struct",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+
+  contextt context;
+  add_type_symbol(context, "tag-Point", make_struct("tag-Point", "x", intt));
+
+  // member( symbol<tag-Point> p, "x" ) — source carries the unresolved by-name
+  // type, the transient state the relaxed construction assert permits.
+  expr2tc src = symbol2tc(symbol_type2tc("tag-Point"), "p");
+  expr2tc member = member2tc(intt, src, "x");
+  REQUIRE(is_symbol_type(to_member2t(member).source_value->type));
+
+  test_adjust(context).adjust_expr(member);
+
+  const type2tc &resolved = to_member2t(member).source_value->type;
+  REQUIRE(is_struct_type(resolved));
+  REQUIRE(to_struct_type(resolved).name == irep_idt("tag-Point"));
+}
+
+TEST_CASE(
+  "python_adjust B.1 follows a symbol_type2t index source to its array",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+  const type2tc arr = array_type2tc(intt, gen_ulong(4), false);
+
+  contextt context;
+  add_type_symbol(context, "tag-IntArr", arr);
+
+  expr2tc src = symbol2tc(symbol_type2tc("tag-IntArr"), "a");
+  expr2tc index = index2tc(intt, src, gen_ulong(0));
+  REQUIRE(is_symbol_type(to_index2t(index).source_value->type));
+
+  test_adjust(context).adjust_expr(index);
+
+  REQUIRE(is_array_type(to_index2t(index).source_value->type));
+}
+
+TEST_CASE(
+  "python_adjust B.1 resolves nested member sources recursively",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+
+  contextt context;
+  // tag-A { inner: <tag-B> };  tag-B { x: int }
+  add_type_symbol(
+    context, "tag-A", make_struct("tag-A", "inner", symbol_type2tc("tag-B")));
+  add_type_symbol(context, "tag-B", make_struct("tag-B", "x", intt));
+
+  // (a.inner).x — both member sources are unresolved by-name types.
+  expr2tc a = symbol2tc(symbol_type2tc("tag-A"), "a");
+  expr2tc inner = member2tc(symbol_type2tc("tag-B"), a, "inner");
+  expr2tc outer = member2tc(intt, inner, "x");
+
+  test_adjust(context).adjust_expr(outer);
+
+  // Outer source (a.inner) is followed to struct tag-B...
+  const expr2tc &outer_src = to_member2t(outer).source_value;
+  REQUIRE(is_struct_type(outer_src->type));
+  REQUIRE(to_struct_type(outer_src->type).name == irep_idt("tag-B"));
+
+  // ...and its own source (a) was resolved first to struct tag-A.
+  const type2tc &inner_src = to_member2t(outer_src).source_value->type;
+  REQUIRE(is_struct_type(inner_src));
+  REQUIRE(to_struct_type(inner_src).name == irep_idt("tag-A"));
+}
+
+TEST_CASE(
+  "python_adjust B.1 leaves an unregistered-tag source untouched",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+
+  // No type symbol registered for tag-Missing: follow would crash, so the pass
+  // must leave the source as-is for the post-adjust verifier (B.4) to flag.
+  contextt context;
+  expr2tc src = symbol2tc(symbol_type2tc("tag-Missing"), "m");
+  expr2tc member = member2tc(intt, src, "x");
+
+  test_adjust(context).adjust_expr(member);
+
+  REQUIRE(is_symbol_type(to_member2t(member).source_value->type));
+}
+
+TEST_CASE(
+  "python_adjust B.1 resolves member sources through adjust()",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+
+  contextt context;
+  add_type_symbol(context, "tag-Point", make_struct("tag-Point", "x", intt));
+
+  // A value symbol whose body is an unresolved member: adjust() must walk the
+  // symbol table, resolve the body, and store the resolved form back.
+  symbolt symbol;
+  symbol.id = "py:test@F@uses_point";
+  symbol.name = "uses_point";
+  symbol.mode = "Python";
+  symbol.set_value(
+    member2tc(intt, symbol2tc(symbol_type2tc("tag-Point"), "p"), "x"));
+  symbol.set_type(intt);
+  context.add(symbol);
+
+  REQUIRE_FALSE(python_adjust(context).adjust());
+
+  const symbolt *out = context.find_symbol("py:test@F@uses_point");
+  REQUIRE(out != nullptr);
+  REQUIRE(is_struct_type(to_member2t(out->get_value2()).source_value->type));
 }


### PR DESCRIPTION
## What

Part V Phase V.1k (b) sub-phase **B.1 — member/index source following**
(`docs/irep2-migration.md`). Stacked on #5625 (B.0 skeleton).

`python_adjust::adjust_expr` becomes a **mutating post-order walk**: it resolves
operands first, then rewrites a `member2t`/`index2t` source whose type is an
unresolved `symbol_type2t` to carry the followed `struct_type2t`/`array_type2t`
(`namespacet::follow` + `expr2t::with_type`). `adjust()` copies each non-type
symbol's `get_value2()`, adjusts, and writes the resolved form back.

- **Recursive:** nested members resolve inner-before-outer (resolve `X` before
  `(X).a` reads `X`'s type).
- **Unregistered-tag guard:** a `symbol_type2t` whose tag is not in the table is
  left untouched (the post-adjust strong-invariant check, B.4, is the right place
  to flag it) rather than null-deref'ing `ns.follow` in a release build.

### No pointer-auto-deref branch (deliberate)

The plan text mentioned "pointer auto-deref," but the `member2t`/`index2t`
construction asserts (`irep2_expr.h:1552-1556` / index2t equivalent) permit only
`struct`/`union`/`complex`/`array`/`vector`/`symbol_id` sources — **a pointer
source aborts at construction.** So a pointer base is dereferenced (to a
`symbol_type2t`-typed source) *before* the node is built; the adjuster never sees
a raw pointer source. A pointer branch would be unreachable, untestable dead
instrumentation, so it is omitted by design.

## Why

B.1 lands the resolution capability that B.3 (converter emits F-P11 members
pre-adjust) relies on. Shipping it dead-but-tested keeps the resolve-then-build
logic off every execution path until it is wired in behind `--python-irep2-adjust`
at B.2.

## Verification

- Not wired into `python_language.cpp` — on **no execution path**, so Python
  verdicts are unchanged by construction.
- Full `esbmc` binary builds clean; Python smoke test SUCCESSFUL; the `dataclass`
  regression family passes.
- `python_adjust_test` passes (7 cases / 26 assertions): direct member, direct
  index, recursion, unregistered-tag guard, and the `adjust()` round-trip.
- Code-reviewer agent: "Good — ready to commit"; both robustness findings
  (the `ns.follow` guard and the round-trip test) applied.

Refs #4715. Stacked on #5625.
