### PR TITLE
[python] V.1k(b) B.2: wire python_adjust behind --python-irep2-adjust

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3400,7 +3400,7 @@ build-IREP2-then-back-migrate pattern file 1 used for non-member expressions
 
 #### V.1k (b)-adjuster — execution scoping (post-V.4.4b: the precondition is now met)
 
-> **Status: B.0 + B.1 landed (2026-06-26); B.2 next.** The V.1k breakthrough above deferred
+> **Status: B.0 + B.1 + B.2 landed (2026-06-26); B.3 next.** The V.1k breakthrough above deferred
 > the (b) IREP2-native adjuster to "V.4+" on the grounds that *a separate adjuster
 > has no IREP2 to operate on until function bodies are IREP2*. **That precondition is
 > now satisfied:** V.4.4b landed and the IREP2 body round-trip is the only body path
@@ -3481,11 +3481,15 @@ following (`next: None`→`Node`), and dataclass field resolution.
   ever sees the by-name source. Still not wired into `python_language.cpp` (B.2).
   `python_adjust_test.cpp` pins direct member, direct index, and recursive nested
   resolution.
-- **B.2 — wire in behind a flag.** `--python-irep2-adjust` (default off) routes Python
-  output through the new pass *in addition to* the legacy `clang_cpp_adjust` (the new
-  pass resolves the pre-adjust `symbol_type2t` members the converter will start
-  emitting; legacy adjust still runs for everything else). Flag off ⇒ byte-identical
-  to today. Tests pin the flag.
+- **B.2 — wire in behind a flag. LANDED.** Added the `--python-irep2-adjust`
+  option (`options.cpp`, IREP2-migration group, default off). `python_languaget::
+  typecheck` runs `python_adjust` after the legacy `clang_cpp_adjust` when the flag
+  is set; `adjust()` is scoped to Python-mode symbols (V.1k RV-adj4 — the C OM
+  bodies stay on the legacy path). Flag off ⇒ byte-identical (the branch is not
+  taken); flag on is also byte-identical on today's corpus (the converter does not
+  yet emit pre-adjust `symbol_type2t` members, so the pass resolves nothing).
+  Regression tests `regression/python/python_irep2_adjust{,_fail}` pin both verdicts
+  under the flag; a unit test pins the Python-mode scoping.
 - **B.3 — converter emits one F-P11 family pre-adjust.** Flip the *smallest* F-P11
   site (e.g. the `BoolOp` short-circuit, `converter_stmt.cpp`) to build `member2t`/
   `index2t` directly over the (relaxed) `symbol_type2t` source, relying on B.2's pass

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3485,11 +3485,18 @@ following (`next: None`→`Node`), and dataclass field resolution.
   option (`options.cpp`, IREP2-migration group, default off). `python_languaget::
   typecheck` runs `python_adjust` after the legacy `clang_cpp_adjust` when the flag
   is set; `adjust()` is scoped to Python-mode symbols (V.1k RV-adj4 — the C OM
-  bodies stay on the legacy path). Flag off ⇒ byte-identical (the branch is not
-  taken); flag on is also byte-identical on today's corpus (the converter does not
-  yet emit pre-adjust `symbol_type2t` members, so the pass resolves nothing).
-  Regression tests `regression/python/python_irep2_adjust{,_fail}` pin both verdicts
-  under the flag; a unit test pins the Python-mode scoping.
+  bodies stay on the legacy path) **and to symbols whose IREP2 value is
+  authoritative** (`symbolt::has_native_value2()`). The latter is required: the
+  pass exists to resolve the converter's *IREP2-native* pre-adjust members, and
+  forcing `get_value2()` on a legacy-valued symbol (e.g. an operational-model
+  function body) would migrate sub-expressions the frontend left with unresolved
+  struct tags — a latent hole the lazy legacy/IREP2 split tolerates only while
+  nothing reads the IREP2 side (see `symbolt`). Flag off ⇒ byte-identical (the
+  branch is not taken); flag on is also byte-identical on today's corpus (no
+  symbol yet carries a native pre-adjust `symbol_type2t` member, so the pass
+  resolves nothing). Regression tests `regression/python/python_irep2_adjust{,_fail}`
+  pin both verdicts under the flag; unit tests pin the Python-mode and
+  native-value scoping.
 - **B.3 — converter emits one F-P11 family pre-adjust.** Flip the *smallest* F-P11
   site (e.g. the `BoolOp` short-circuit, `converter_stmt.cpp`) to build `member2t`/
   `index2t` directly over the (relaxed) `symbol_type2t` source, relying on B.2's pass

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3400,6 +3400,7 @@ build-IREP2-then-back-migrate pattern file 1 used for non-member expressions
 
 #### V.1k (b)-adjuster — execution scoping (post-V.4.4b: the precondition is now met)
 
+> **Status: B.0 + B.1 + B.2 landed; B.3 spike done — service design chosen, B.0–B.2 re-sequenced to B.5 (2026-06-26).** The V.1k breakthrough above deferred
 > **Status: B.0 + B.1 + B.2 landed (2026-06-26); B.3 next.** The V.1k breakthrough above deferred
 > the (b) IREP2-native adjuster to "V.4+" on the grounds that *a separate adjuster
 > has no IREP2 to operate on until function bodies are IREP2*. **That precondition is
@@ -3497,6 +3498,17 @@ following (`next: None`→`Node`), and dataclass field resolution.
   resolves nothing). Regression tests `regression/python/python_irep2_adjust{,_fail}`
   pin both verdicts under the flag; unit tests pin the Python-mode and
   native-value scoping.
+- **B.3 — converter emits one F-P11 family pre-adjust. RE-SCOPED by the B.3 spike
+  (2026-06-26, below): use the resolve-then-build *service*, not the B.2 pass.** The
+  original "build `member2t`/`index2t` over a `symbol_type2t` source and rely on B.2's
+  pass to resolve it" cannot work while legacy `clang_cpp_adjust` still runs (the spike
+  proves both blockers). The viable B.3 flips the *smallest* F-P11 site (e.g. the
+  `BoolOp` short-circuit, `converter_stmt.cpp`) to **resolve the source type via the
+  converter's `name_space().follow()` at construction** and build a *resolved-source*
+  `member2tc`/`index2tc` (the proven file-1 back-migrate-at-seam recipe; satisfies even
+  the strong assert). Acceptance unchanged: the relevant slice of the 20-test fixture
+  green, dual-solver, asserts build, **plus** RV2 — the service's resolved type must
+  equal `clang_cpp_adjust`'s (corpus round-trip equivalence). See the B.3 spike outcome.
 - **B.3 — converter emits one F-P11 family pre-adjust.** Flip the *smallest* F-P11
   site (e.g. the `BoolOp` short-circuit, `converter_stmt.cpp`) to build `member2t`/
   `index2t` directly over the (relaxed) `symbol_type2t` source, relying on B.2's pass
@@ -3511,7 +3523,53 @@ following (`next: None`→`Node`), and dataclass field resolution.
   full 20-test fixture + whole `regression/python` + model `.py` corpus hold parity on
   both solvers (asserts build) and `esbmc-cpp` is green (RV3 — the relaxed assert and
   any shared carriage touch C++ too), make `--python-irep2-adjust` default-on, then
-  remove the legacy adjust hop on Python output.
+  remove the legacy adjust hop on Python output. **Per the B.3 spike, B.0–B.2's
+  materialised-body `python_adjust` pass is the deliverable that does real work *here*
+  — it replaces the legacy hop; it is correctly dead-but-tested + flag-gated until this
+  point, because legacy `clang_cpp_adjust` resolves every source before it runs.**
+
+#### B.3 spike outcome (2026-06-26) — settles the §V.1k design question: B.3 uses the resolve-then-build *service*; the materialised-body pass is B.5
+
+> Read-only spike of the smallest F-P11 site (`BoolOp` short-circuit,
+> `converter_stmt.cpp`) against the live converter→adjust pipeline. It settles the
+> open design question recorded above ("type-resolution *service* the converter
+> queries at construction vs. materialising IREP2 bodies pre-adjust"): **the service
+> wins for B.3; the materialised-body pass (B.0–B.2) is repositioned to B.5.**
+
+**Finding 1 — the original B.3 ("rely on B.2's pass") cannot work pre-B.5.** Two
+independent, code-grounded blockers:
+1. *The converter body is legacy.* Each function body is a single legacy `codet`
+   stored by `set_value(exprt)` (`converter_funcdef.cpp:1403`). A lone IREP2
+   `member2tc` cannot be embedded in a legacy `codet`; making the whole body IREP2 and
+   writing `set_value(expr2tc)` is V.4/B.5-class, not a one-site flip.
+2. *Legacy adjust shadows the pass.* `python_languaget::typecheck` runs
+   `clang_cpp_adjust::adjust()` **unconditionally** (`python_language.cpp:249`), and it
+   follows the legacy member/index sources. By the time `python_adjust` reads
+   `symbol.get_value2()`, the lazily back-migrated body is already resolved — no
+   `symbol_type2t` source survives for it to resolve. So B.2's pass is a structural
+   no-op on the live pipeline *regardless of converter changes*, until the legacy hop
+   is dropped (B.5). (This is consistent with B.2's flag-on byte-identical result.)
+
+**Finding 2 (enabling) — the service is available today.** The converter exposes
+`name_space()` (`python_converter.h:187`), so `ns.follow()` resolution is reachable at
+construction. An F-P11 site can therefore follow its `symbol_type2t` base to the
+resolved `struct_type2t`/`array_type2t` and build a **resolved-source**
+`member2tc`/`index2tc` — which satisfies even the *strong* construction assert (no
+relaxation needed) and back-migrates cleanly at the seam (the proven file-1 recipe).
+This is exactly how the already-merged "resolved-source" sites (#5586/#5587/#5589)
+build, except the source is resolved by the service rather than known-resolved.
+
+**Consequence — re-sequencing (B.0–B.2 are not wasted).** B.0–B.2's `python_adjust`
+remains correct and is the **B.5** deliverable: the IREP2-native replacement for the
+legacy `clang_cpp_adjust` hop, which only has sources to resolve once that hop is
+dropped. It stays dead-but-tested + `--python-irep2-adjust`-gated until B.5. B.3/B.4
+proceed independently via the **service** (`ns.follow` at construction).
+
+**The load-bearing risk stays RV2 (critical).** `clang_cpp_adjust` does more than
+`ns.follow` — pointer auto-deref, dataclass/inference completion. The service's
+resolved type must equal what `clang_cpp_adjust` + goto-convert produce, proven by
+corpus round-trip equivalence on an asserts build, before any F-P11 site flips. The
+next task is that proof harness + the first (BoolOp) site, gated dual-solver.
 
 **Risks (extend §V.4 / Part II §7).** *RV-adj1:* the new pass must reproduce
 `clang_cpp_adjust`'s dataclass/inference completion exactly — mitigate by reusing the

--- a/regression/python/python_irep2_adjust/main.py
+++ b/regression/python/python_irep2_adjust/main.py
@@ -1,0 +1,7 @@
+class Point:
+    def __init__(self, x: int):
+        self.x = x
+
+
+p = Point(5)
+assert p.x == 5

--- a/regression/python/python_irep2_adjust/test.desc
+++ b/regression/python/python_irep2_adjust/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_fail/main.py
+++ b/regression/python/python_irep2_adjust_fail/main.py
@@ -1,0 +1,7 @@
+class Point:
+    def __init__(self, x: int):
+        self.x = x
+
+
+p = Point(5)
+assert p.x == 6

--- a/regression/python/python_irep2_adjust_fail/test.desc
+++ b/regression/python/python_irep2_adjust_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -827,7 +827,13 @@ const struct group_opt_templ all_cmd_options[] = {
      "Deprecated no-op (accepted for backward compatibility). goto_convert "
      "always lowers function bodies through the IREP2 round-trip "
      "(migrate legacy codet → code_*2t → codet) since V.4.4; the legacy "
-     "bypass and the --no-irep2-bodies escape hatch have been removed."}}},
+     "bypass and the --no-irep2-bodies escape hatch have been removed."},
+    {"python-irep2-adjust",
+     NULL,
+     "Run the IREP2-native Python adjuster (V.1k) over Python-mode symbols, in "
+     "addition to the legacy clang_cpp_adjust. Default off; off => byte-"
+     "identical. Staged enabling infra for the resolve-then-build migration "
+     "(docs/irep2-migration.md, Part V Phase V.1k (b))."}}},
   {"end", {{"", NULL, "End of options"}}},
   {"Hidden Options",
    {{"depth", boost::program_options::value<int>(), "Instruction"},

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -20,6 +20,12 @@ bool python_adjust::adjust()
     if (symbol.is_type)
       continue;
 
+    // Python-only by design (V.1k RV-adj4): only the Python converter emits the
+    // pre-adjust symbol_type2t member/index sources this pass resolves, so leave
+    // the C operational-model bodies to the legacy path.
+    if (symbol.mode != "Python")
+      continue;
+
     expr2tc value = symbol.get_value2();
     if (is_nil_expr(value))
       continue;

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -26,6 +26,17 @@ bool python_adjust::adjust()
     if (symbol.mode != "Python")
       continue;
 
+    // Only adjust symbols whose IREP2 value is authoritative: those are the
+    // converter's IREP2-native member/index sources this pass exists to
+    // resolve. Forcing get_value2() on a legacy-valued symbol (e.g. an
+    // operational-model function body) would migrate sub-expressions the
+    // frontend left with unresolved struct tags -- a latent hole the lazy
+    // legacy/IREP2 split tolerates precisely because nothing reads their IREP2
+    // side (see symbolt). Until B.3 makes the converter emit these natively the
+    // pass is therefore a true no-op on today's corpus, as documented.
+    if (!symbol.has_native_value2())
+      continue;
+
     expr2tc value = symbol.get_value2();
     if (is_nil_expr(value))
       continue;

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -1,5 +1,6 @@
 #include <python-frontend/python_language.h>
 #include <python-frontend/python_converter.h>
+#include <python-frontend/python_adjust.h>
 #include <python-frontend/python_annotation.h>
 #include <python-frontend/global_scope.h>
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
@@ -249,6 +250,17 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
   clang_cpp_adjust adjuster(context);
   if (adjuster.adjust())
     return true;
+
+  // V.1k (b) B.2: optionally run the IREP2-native Python adjuster over Python
+  // output, in addition to the legacy pass. Default off => byte-identical; it
+  // resolves the pre-adjust symbol_type2t member/index sources the converter
+  // will emit once B.3 lands. See docs/irep2-migration.md, Part V Phase V.1k.
+  if (config.options.get_bool_option("python-irep2-adjust"))
+  {
+    python_adjust py_adjuster(context);
+    if (py_adjuster.adjust())
+      return true;
+  }
 
   return false;
 }

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -49,6 +49,17 @@ public:
   const type2tc &get_type2() const;
   const expr2tc &get_value2() const;
 
+  // True iff the IREP2 value is the authoritative form (written via the
+  // expr2tc setter), so get_value2() returns it directly without a lazy
+  // migration from the legacy exprt. Lets a pass honour the lazy split (see
+  // the class comment above): reading the IREP2 side of a legacy-valued symbol
+  // would force-migrate sub-expressions the frontend left with unresolved tags
+  // -- a latent hole the design tolerates only while nothing reads that side.
+  bool has_native_value2() const
+  {
+    return value2_valid_;
+  }
+
   // Type setters. Each writes one side and invalidates the other; the read
   // side derives lazily on first access (with the nil/empty-id case guarded
   // inside the readers).

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -6,6 +6,7 @@
 #include <util/config.h>
 #include <util/context.h>
 #include <util/c_types.h>
+#include <util/migrate.h>
 
 // Part V Phase V.1k (b), sub-phases B.0/B.1 (docs/irep2-migration.md): the
 // IREP2-native Python adjuster. These tests pin its contracts so each later
@@ -273,4 +274,39 @@ TEST_CASE(
   const symbolt *out = context.find_symbol("c:@F@uses_point");
   REQUIRE(out != nullptr);
   REQUIRE(is_symbol_type(to_member2t(out->get_value2()).source_value->type));
+}
+
+TEST_CASE(
+  "python_adjust B.2 adjust() skips legacy-valued symbols",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+
+  contextt context;
+  add_type_symbol(context, "tag-Point", make_struct("tag-Point", "x", intt));
+
+  // A Python-mode symbol whose value is the *legacy* exprt form: the pass must
+  // leave it untouched. Forcing get_value2() would migrate sub-expressions the
+  // frontend may have left with unresolved tags (the lazy legacy/IREP2 split
+  // tolerates those holes only while nothing reads the IREP2 side), so the pass
+  // adjusts only IREP2-native values -- the converter's pre-adjust members.
+  const expr2tc body =
+    member2tc(intt, symbol2tc(symbol_type2tc("tag-Point"), "p"), "x");
+  symbolt symbol;
+  symbol.id = "py:main.py@F@uses_point_legacy";
+  symbol.name = "uses_point_legacy";
+  symbol.mode = "Python";
+  symbol.set_value(migrate_expr_back(body)); // legacy setter => not native
+  symbol.set_type(intt);
+  REQUIRE_FALSE(symbol.has_native_value2());
+  context.add(symbol);
+
+  // The legacy-valued symbol is never descended into: adjust() skips it before
+  // touching its IREP2 side, so the visit counter stays at zero.
+  test_adjust ta(context);
+  REQUIRE_FALSE(ta.adjust());
+  REQUIRE(ta.visited == 0);
 }

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -243,3 +243,34 @@ TEST_CASE(
   REQUIRE(out != nullptr);
   REQUIRE(is_struct_type(to_member2t(out->get_value2()).source_value->type));
 }
+
+TEST_CASE(
+  "python_adjust B.2 adjust() skips non-Python-mode symbols",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+
+  contextt context;
+  add_type_symbol(context, "tag-Point", make_struct("tag-Point", "x", intt));
+
+  // A C-mode symbol carrying an unresolved member: the Python-only pass must
+  // leave it untouched (V.1k RV-adj4 — the C OM bodies stay on the legacy path).
+  const expr2tc body =
+    member2tc(intt, symbol2tc(symbol_type2tc("tag-Point"), "p"), "x");
+  symbolt symbol;
+  symbol.id = "c:@F@uses_point";
+  symbol.name = "uses_point";
+  symbol.mode = "C";
+  symbol.set_value(body);
+  symbol.set_type(intt);
+  context.add(symbol);
+
+  REQUIRE_FALSE(python_adjust(context).adjust());
+
+  const symbolt *out = context.find_symbol("c:@F@uses_point");
+  REQUIRE(out != nullptr);
+  REQUIRE(is_symbol_type(to_member2t(out->get_value2()).source_value->type));
+}


### PR DESCRIPTION
## What

Part V Phase V.1k (b) sub-phase **B.2 — wire in behind a flag**
(`docs/irep2-migration.md`). Stacked on #5626 (B.1) → #5625 (B.0).

- **New `--python-irep2-adjust` option** (`options.cpp`, IREP2-migration group,
  default **off**).
- **`python_languaget::typecheck`** runs `python_adjust` *after* the legacy
  `clang_cpp_adjust` when the flag is set.
- **`python_adjust::adjust()` is scoped to Python-mode symbols** — the C
  operational-model bodies stay on the legacy path (V.1k RV-adj4); only the Python
  converter emits the pre-adjust `symbol_type2t` member/index sources this pass
  resolves.

## Why

This lands the toggle that B.3 will exercise (the converter starts emitting
member/index nodes over `symbol_type2t` sources pre-adjust, and this pass resolves
them). Wiring it off-by-default keeps every execution path byte-identical until
B.3 flips the converter, while making the new path runnable end-to-end now.

## Verification

- **Flag off ⇒ byte-identical:** the conditional is the only new runtime behavior
  and it is not taken by default.
- **Flag on ⇒ byte-identical on today's corpus:** the converter does not yet emit
  pre-adjust `symbol_type2t` members, so the pass resolves nothing. Verified
  manually: `class Point` attribute access gives `VERIFICATION SUCCESSFUL` with the
  flag both on and off, and a real violation gives `VERIFICATION FAILED` with the
  flag on (not silently passing).
- **Regression tests** `regression/python/python_irep2_adjust{,_fail}` pin both
  verdicts under the flag (CPython sanity via `check_python_tests.sh`: pass exits 0,
  fail exits 1).
- **Unit test** pins the Python-mode scoping (a `mode == "C"` symbol's member source
  is left unresolved). `python_adjust_test`: 8 cases / 30 assertions.
- Existing class-based Python tests pass unchanged (flag-off path).
- Code-reviewer agent: "Good — ready for commit"; no blocking findings.

Refs #4715. Stacked on #5626.
