### PR TITLE
[symex] sound object-size bound for non-literal %s return length

### DIFF
--- a/docs/design-printf-return-length-om.md
+++ b/docs/design-printf-return-length-om.md
@@ -1,9 +1,26 @@
 # Design Proposal: a sound return-length model for the printf / (v)asprintf family
 
-**Status:** DRAFT PROPOSAL (for discussion — no implementation committed)
-**Tracking:** #4976, #4977, #4978, #4979 (busybox `no-overflow` false alarms); umbrella #2513; related #2797 (missing libc OM bodies)
+**Status:** IMPLEMENTED — Phases 0–2 merged; Phase 3 (G-C) deferred (optional precision)
+**Tracking:** #4976, #4977, #4978, #4979 (busybox `no-overflow` false alarms) — **all CLOSED**; umbrella #2513; related #2797 (missing libc OM bodies); follow-on precision tracked by #5012.
 **Author context:** follow-up to `docs/svcomp-issue-triage.md` §3.1 and the finding that wiring `vasprintf` into the *current* `symex_printf` is unsound (PR #5009).
-**Date:** 2026-05-31
+**Date:** 2026-05-31 (proposal); 2026-06-26 (status update)
+
+> **Implementation status (2026-06-26).** The sound model proposed here shipped across
+> four PRs and closed the four busybox false alarms:
+> - **Phase 1 / G-A** — non-constant format no longer under-approximates: **PR #5017**.
+> - **Phase 1 / G-B** — non-literal `%s` contributes the sound *unbounded* fallback (never 0);
+>   the object-size tightening of §4.2.1 remains an optional precision improvement.
+> - **Phase 2 / G-D** — `vprintf`/`vsprintf`/`vsnprintf`/`asprintf`/`vasprintf` wired into
+>   `symex_printf`: **PR #5270**, with the unbounded-return cap at `INT_MAX/2` (**PR #5278**)
+>   and the `*strp` heap-allocation model (**PR #5279**).
+> - **Phase 3 / G-C** — `va_list` `%s` argument recovery: **deferred** (precision-only;
+>   correctness never depends on it). Tracked under #5012.
+>
+> Regression coverage lives in `regression/esbmc/`: `asprintf_const_format_exact`,
+> `vasprintf_const_format_no_overflow`, `vasprintf_overflow_fail`,
+> `vasprintf_unbounded_s_no_overflow`, `vasprintf_unbounded_s_overflow_fail`, and the
+> reduced reproducers `github_4977`/`github_4978`/`github_4979` (+ `github_4978_fail`).
+> Issues #4976–#4979 were closed on 2026-06-09. See `docs/svcomp-issue-triage.md` §3.1.
 
 ---
 

--- a/docs/design-printf-return-length-om.md
+++ b/docs/design-printf-return-length-om.md
@@ -1,6 +1,6 @@
 # Design Proposal: a sound return-length model for the printf / (v)asprintf family
 
-**Status:** IMPLEMENTED — Phases 0–2 merged; Phase 3 (G-C) deferred (optional precision)
+**Status:** IMPLEMENTED — Phases 0–2 merged; Phase 3 Patch 1 (§4.2.1 object-size `%s` bound) in PR #5628; Phase 3 §4.4 va_list recovery deferred (optional precision)
 **Tracking:** #4976, #4977, #4978, #4979 (busybox `no-overflow` false alarms) — **all CLOSED**; umbrella #2513; related #2797 (missing libc OM bodies); follow-on precision tracked by #5012.
 **Author context:** follow-up to `docs/svcomp-issue-triage.md` §3.1 and the finding that wiring `vasprintf` into the *current* `symex_printf` is unsound (PR #5009).
 **Date:** 2026-05-31 (proposal); 2026-06-26 (status update)
@@ -8,12 +8,15 @@
 > **Implementation status (2026-06-26).** The sound model proposed here shipped across
 > four PRs and closed the four busybox false alarms:
 > - **Phase 1 / G-A** — non-constant format no longer under-approximates: **PR #5017**.
-> - **Phase 1 / G-B** — non-literal `%s` contributes the sound *unbounded* fallback (never 0);
->   the object-size tightening of §4.2.1 remains an optional precision improvement.
+> - **Phase 1 / G-B** — non-literal `%s` contributes the sound *unbounded* fallback (never 0).
 > - **Phase 2 / G-D** — `vprintf`/`vsprintf`/`vsnprintf`/`asprintf`/`vasprintf` wired into
 >   `symex_printf`: **PR #5270**, with the unbounded-return cap at `INT_MAX/2` (**PR #5278**)
 >   and the `*strp` heap-allocation model (**PR #5279**).
-> - **Phase 3 / G-C** — `va_list` `%s` argument recovery: **deferred** (precision-only;
+> - **Phase 3 Patch 1 / §4.2.1** — non-literal `%s` over a finite char array of `N` bytes
+>   contributes the sound object-size bound `N − 1` instead of staying unbounded: **PR #5628**.
+>   The `v*` variants keep the operand unreliable (the `%s` position is the `va_list` pointer),
+>   so `%s` stays unbounded there until va_list recovery.
+> - **Phase 3 §4.4 / G-C** — `va_list` `%s` argument recovery: **deferred** (precision-only;
 >   correctness never depends on it). Tracked under #5012.
 >
 > Regression coverage lives in `regression/esbmc/`: `asprintf_const_format_exact`,
@@ -226,7 +229,9 @@ closes the constant-format cases and never introduces a false negative.
   follows: removes latent false negatives in `sprintf`/`snprintf`. Full §8 soundness gate.
 - **Phase 2 — wire the family (G-D):** constant-format path only; `(v)asprintf` return + consistent
   allocation size. Tests + §8.
-- **Phase 3 — va_list `%s` tightening (G-C):** precision pass; optional.
+- **Phase 3 — `%s` tightening:** precision pass; optional. Patch 1 (§4.2.1 object-size bound for a
+  non-literal `%s` over a finite char array) shipped in PR #5628; Patch 2 (§4.4 va_list recovery,
+  G-C) remains deferred.
 - **Phase 4 — measurement & docs:** SV-COMP overflow run, update `svcomp-issue-triage.md` §3.1 with
   the outcome, close whichever of #4976–#4979 actually flip.
 

--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -41,10 +41,10 @@ The SV-COMP backlog was triaged in two passes:
 
 | # | Benchmark | Property | Disposition | New PR? |
 |---|---|---|---|---|
-| 4976 | busybox `sync-1` | no-overflow | PRECISION LIMITATION — printf-layer fix is unsound; sound fix needs a `va_list`-modeling OM | no (coupled, see below) |
-| 4977 | busybox `sync-2` | no-overflow | PRECISION LIMITATION — same root cause as #4976 | no |
-| 4978 | busybox `whoami-incomplete-1` | no-overflow | PRECISION LIMITATION — same root cause as #4976 | no |
-| 4979 | busybox `whoami-incomplete-2` | no-overflow | PRECISION LIMITATION — same root cause as #4976 | no |
+| 4976 | busybox `sync-1` | no-overflow | RESOLVED — sound return-length model shipped (#5017/#5270/#5278/#5279); CLOSED 06-09. *Pass-2 view below was superseded; see §3.1 banner.* | yes (later) |
+| 4977 | busybox `sync-2` | no-overflow | RESOLVED — same fix; CLOSED 06-09 (§3.1 banner) | yes (later) |
+| 4978 | busybox `whoami-incomplete-1` | no-overflow | RESOLVED — same fix; CLOSED 06-09 (§3.1 banner) | yes (later) |
+| 4979 | busybox `whoami-incomplete-2` | no-overflow | RESOLVED — same fix; CLOSED 06-09 (§3.1 banner) | yes (later) |
 | 4980 | ldv `turbografx.ko` | termination | ALREADY-ADDRESSED — overlaps open PR #4919 | no (avoid duplicate) |
 
 **Why no new PRs for this batch.** In both cases shipping a quick patch would be either *unsound*
@@ -75,10 +75,10 @@ The SV-COMP backlog was triaged in two passes:
 | # | Title (short) | Category | Disposition |
 |---|---|---|---|
 | 4980 | termination false alarm: turbografx.ko | termination/k-induction | overlaps open PR #4919 (§3.2) |
-| 4979 | no-overflow false alarm: whoami-incomplete-2 | overflow/OM | precision limit; printf-layer fix unsound (§3.1) |
-| 4978 | no-overflow false alarm: whoami-incomplete-1 | overflow/OM | precision limit; printf-layer fix unsound (§3.1) |
-| 4977 | no-overflow false alarm: sync-2 | overflow/OM | precision limit; printf-layer fix unsound (§3.1) |
-| 4976 | no-overflow false alarm: sync-1 | overflow/OM | precision limit; printf-layer fix unsound (§3.1) |
+| 4979 | no-overflow false alarm: whoami-incomplete-2 | overflow/OM | RESOLVED — sound model shipped, CLOSED 06-09 (§3.1 banner) |
+| 4978 | no-overflow false alarm: whoami-incomplete-1 | overflow/OM | RESOLVED — sound model shipped, CLOSED 06-09 (§3.1 banner) |
+| 4977 | no-overflow false alarm: sync-2 | overflow/OM | RESOLVED — sound model shipped, CLOSED 06-09 (§3.1 banner) |
+| 4976 | no-overflow false alarm: sync-1 | overflow/OM | RESOLVED — sound model shipped, CLOSED 06-09 (§3.1 banner) |
 | 4611 | Witness GraphML returnFromFunction key + dup nodes | witness | needs witness validator (§4) |
 | 4439 | valid-memsafety false alarm: w83977af_ir.ko | memsafety/concurrency | research-grade LDV driver (§4) |
 | 4438 | unreach-call false alarm: log_6_safe | FP/k-induction | open PR #4480 (§4) |
@@ -115,9 +115,25 @@ ESBMC 8.3.0 commit `911d1790`. Each is a *false alarm* (ground truth `true`, ESB
 
 ### 3.1 #4976 / #4977 / #4978 / #4979 — no-overflow false alarm in busybox `bb_verror_msg`
 
-**Status: tightly coupled (one function, one root cause). One future PR, not four. PRECISION /
-INCOMPLETENESS LIMITATION — the printf-model-layer fix was measured to be unsound; a sound fix
-requires a `va_list`-modeling `(v)asprintf` OM.**
+> **RESOLVED (2026-06-26 reconciliation) — supersedes the Pass-2 conclusion below.** A *sound*
+> return-length model for the printf/(v)asprintf family was designed
+> (`docs/design-printf-return-length-om.md`) and shipped: **PR #5017** (G-A, non-constant format
+> no longer under-approximates), **PR #5270** (G-D, wire `(v)asprintf`/`(v)sprintf`/`vsnprintf`/
+> `vprintf` into `symex_printf`), **PR #5278** (cap the unbounded return at `INT_MAX/2`), and
+> **PR #5279** (model the `*strp` heap allocation). The key realisation that unblocked it: the
+> earlier "unsound" measurement (PR #5009) was of a *naive* routing that clamped a symbolic
+> format to length 0; the shipped model instead caps the return at a sound over-approximation
+> (`INT_MAX/2`), which removes the false overflow *without* masking a genuine one. **All four
+> issues #4976–#4979 were closed on 2026-06-09.** Regression coverage:
+> `regression/esbmc/asprintf_const_format_exact`, `vasprintf_*`, and the reduced reproducers
+> `github_4977`/`github_4978`/`github_4979` (+ `github_4978_fail`) — all green; the reproducers
+> converge to `VERIFICATION SUCCESSFUL` at k=11 and the `_fail` variant still `FAILED`. Only the
+> Phase-3 G-C precision pass (`va_list` `%s` recovery, symbolic-format tightening) remains open,
+> tracked by #5012. The historical Pass-2 analysis is retained below for the record.
+
+**Status (Pass 2, superseded — see banner above): tightly coupled (one function, one root cause).
+One future PR, not four. PRECISION / INCOMPLETENESS LIMITATION — the printf-model-layer fix was
+measured to be unsound; a sound fix requires a `va_list`-modeling `(v)asprintf` OM.**
 
 **Benchmarks.** `c/busybox-1.22.0/{sync-1,sync-2,whoami-incomplete-1,whoami-incomplete-2}.i`.
 Each is run (per the issue) with:

--- a/regression/esbmc/sprintf_objsize_s_no_overflow/main.c
+++ b/regression/esbmc/sprintf_objsize_s_no_overflow/main.c
@@ -1,0 +1,17 @@
+#include <limits.h>
+extern int sprintf(char *restrict s, const char *restrict fmt, ...);
+
+// A non-literal %s whose argument points into a known-size array bounds the
+// formatted length: strlen(src) <= sizeof(src)-1 = 15, so n <= 6 + 15 = 21.
+// Before the object-size bound the return of a runtime-filled array was
+// under-approximated to 0 (and an unknown array to unbounded); now it is a
+// sound, finite over-approximation, so `base + n` is provably safe.
+int main(void)
+{
+  char src[16]; // nondet content: strlen <= 15
+  char dst[128];
+  int n = sprintf(dst, "value=%s", src);
+  int base = INT_MAX - 100;
+  int sum = base + n; // n <= 21, so base + n < INT_MAX: no overflow
+  return sum;
+}

--- a/regression/esbmc/sprintf_objsize_s_no_overflow/test.desc
+++ b/regression/esbmc/sprintf_objsize_s_no_overflow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/sprintf_objsize_s_overflow_fail/main.c
+++ b/regression/esbmc/sprintf_objsize_s_overflow_fail/main.c
@@ -1,0 +1,17 @@
+#include <limits.h>
+extern int sprintf(char *restrict s, const char *restrict fmt, ...);
+
+// Companion to sprintf_objsize_s_no_overflow: the object-size bound must be
+// SOUND, never an under-approximation.  With a 64-byte source the return can
+// be as large as 63, so `base + n` with base = INT_MAX - 10 has a reachable
+// overflow.  Guards against re-introducing the "model an unknown %s as 0"
+// behaviour, which would silently mask this overflow.
+int main(void)
+{
+  char src[64]; // nondet content: strlen can reach 63
+  char dst[128];
+  int n = sprintf(dst, "%s", src);
+  int base = INT_MAX - 10;
+  int sum = base + n; // n up to 63 > 10: overflow reachable
+  return sum;
+}

--- a/regression/esbmc/sprintf_objsize_s_overflow_fail/test.desc
+++ b/regression/esbmc/sprintf_objsize_s_overflow_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -249,6 +249,14 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
           continue;
         }
         const symbolt &s = *ns.lookup(to_symbol2t(base_expr).thename);
+        // Only fold to a string constant when the array has compile-time
+        // content. A nondet / runtime-filled array has no static initializer;
+        // leaving it as an array lets the formatter apply a sound object-size
+        // length bound (strlen <= size-1) instead of under-approximating the
+        // %s contribution to "" (length 0).
+        const exprt &val = s.get_value();
+        if (val.is_nil() || val.operands().empty())
+          continue;
         exprt dest;
         if (array2string(s, dest))
           continue;
@@ -258,6 +266,30 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
 
     // 3 get the number of characters output (return value)
     printf_formattert printf_formatter;
+    // For the v* variants the actual arguments are hidden behind a va_list, so
+    // the operand at a %s position is the va_list pointer, not the string. Mark
+    // the operands unreliable so the formatter does not derive an (unsound)
+    // object-size bound from them; %s stays unbounded until va_list recovery.
+    // Exhaustive over printf_kindt (no default) so a future va_list kind must
+    // be classified here rather than silently inheriting the reliable default.
+    switch (new_rhs.kind)
+    {
+    case printf_kindt::VPRINTF:
+    case printf_kindt::VFPRINTF:
+    case printf_kindt::VSPRINTF:
+    case printf_kindt::VSNPRINTF:
+    case printf_kindt::VASPRINTF:
+      printf_formatter.args_reliable = false;
+      break;
+    case printf_kindt::PRINTF:
+    case printf_kindt::FPRINTF:
+    case printf_kindt::DPRINTF:
+    case printf_kindt::SPRINTF:
+    case printf_kindt::SNPRINTF:
+    case printf_kindt::ASPRINTF:
+      printf_formatter.args_reliable = true;
+      break;
+    }
     printf_formatter(fmt.as_string(), args);
     printf_formatter.as_string(); // populate min_outlen / max_outlen
 

--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -329,11 +329,33 @@ void printf_formattert::process_format(std::ostream &out)
     const expr2tc symbol2 = get_base_object(op);
     exprt char_array = migrate_expr_back(symbol2);
     if (char_array.id() == "string-constant")
+    {
       emit(char_array.value().as_string());
-    else
-      // A non-literal string argument has no statically-known length, so the
-      // total output length cannot be bounded.
-      bounded = false;
+      break;
+    }
+    // A non-literal %s: derive a sound upper bound from the pointed-to
+    // object's size when possible. If the argument points into a constant-size
+    // char array of N bytes, a valid C string there has strlen <= N-1 (the NUL
+    // must fit), and that holds for any starting offset within the array.
+    // Contribute N-1 to the maximum (the string may be empty, so the minimum is
+    // unchanged) and keep the result bounded. The restriction to a finite,
+    // 8-bit-element array keeps the byte size well-defined without a namespace
+    // and matches the C-string narrative; anything else (a bare pointer of
+    // unknown extent, an incomplete/VLA array, a non-char element type) has no
+    // statically-known bound, so the output is treated as unbounded.
+    if (
+      args_reliable && is_array_type(symbol2->type) &&
+      !array_or_vector_size_is_infinite(symbol2->type) &&
+      is_byte_type(to_array_type(symbol2->type).subtype))
+    {
+      const BigInt nbytes = type_byte_size_default(symbol2->type, BigInt(0));
+      if (nbytes > 0)
+      {
+        max_outlen += (nbytes - 1).to_uint64();
+        break;
+      }
+    }
+    bounded = false;
   }
   break;
 

--- a/src/goto-symex/printf_formatter.h
+++ b/src/goto-symex/printf_formatter.h
@@ -25,6 +25,14 @@ public:
    *  a format whose conversions are all constant-bounded. */
   bool bounded = true;
 
+  /** True when `operands` are the call's actual arguments, so a non-literal
+   *  %s operand may be used to derive a sound object-size length bound. For
+   *  the v* variants (vprintf/vsprintf/vsnprintf/vasprintf/vfprintf) the
+   *  arguments are hidden behind a va_list and the operand at a %s position is
+   *  the va_list itself, not the string — deriving a size bound from it would
+   *  be unsound, so callers set this false and %s stays unbounded. */
+  bool args_reliable = true;
+
 protected:
   std::string format;
   std::list<expr2tc> operands;


### PR DESCRIPTION
## Summary

Resumes `docs/design-printf-return-length-om.md`. Two parts:

1. **Phase 3 (G-C), Patch 1 — object-size `%s` bound.** A non-literal `%s` previously left the printf-family return length unbounded, or **under-approximated it to 0** when the array argument had no static initializer (folded to `""` by `array2string`) — a latent **G-B unsoundness** that could mask a real overflow on the return value. When the `%s` argument points into a finite `char` array of N bytes, a valid C string there has `strlen ≤ N-1` for any starting offset, so the model now contributes `N-1` as a **sound** upper bound and keeps the return bounded.

2. **Phase 4 — triage reconciliation (docs).** `docs/svcomp-issue-triage.md` §3.1 still declared the printf return-length fix "unsound" and the busybox issues open, contradicting the merged code (#5017/#5270/#5278/#5279) and the closed issues #4976–#4979. Adds a superseding RESOLVED banner and flips the design-doc status to IMPLEMENTED.

## Soundness

The invariant is `R ≥ true output length` (over-approximation only). The bound is restricted to **finite, 8-bit-element** arrays so the byte size is well-defined without a namespace and matches the C-string narrative. `get_base_object` strips to the root object, so mid-array pointers, struct/union members, and array rows all yield a whole-allocation size ≥ the reachable string length. Infinite/incomplete arrays, VLAs, non-char element types, and bare pointers of unknown extent fall through to the existing unbounded fallback.

The **v\* variants** (`vprintf`/`vfprintf`/`vsprintf`/`vsnprintf`/`vasprintf`) pass arguments through a `va_list`, so the operand at a `%s` position is the va_list pointer (its backing store is itself an array), not the string — deriving an object-size bound from it would be unsound. These are marked `args_reliable=false`, so `%s` stays unbounded there until va_list recovery (G-C Patch 2, follow-up).

## Tests

New regression pair under `regression/esbmc/`:
- `sprintf_objsize_s_no_overflow` — bounded return (`n ≤ 21`) ⇒ `VERIFICATION SUCCESSFUL`.
- `sprintf_objsize_s_overflow_fail` — 64-byte source allows `n = 63`, so `base + n` overflow is reachable ⇒ `VERIFICATION FAILED` (guards against re-introducing the model-`%s`-as-0 under-approximation).

All 37 printf-family regression tests + the full `cstd` label (138) pass; clang-format clean. The bound was confirmed tight (`n ≤ 7` holds, `n ≤ 6` fails for an 8-byte buffer) and the incomplete-array / non-char-array cases confirmed not to abort. A code review (correctness/soundness focus) was applied: it surfaced two reachable abort paths (uncaught `inf_sized_array_excp`; `ns`-less size of a non-char subtype) and a non-exhaustive switch, all fixed here — the exhaustive `switch` then caught a missing `ASPRINTF` case at compile time.