### PR TITLE
fix(clang-frontend): guard CreateTargetInfo TargetOptions API by Clang version

### DIFF
--- a/src/clang-c-frontend/clang_c_lexer.cpp
+++ b/src/clang-c-frontend/clang_c_lexer.cpp
@@ -52,9 +52,17 @@ struct clang_c_lexert::LexerContext
   {
     lo.C17 = 1;
     lo.GNUMode = 1;
+    // CreateTargetInfo takes TargetOptions by reference since Clang 21; older
+    // releases (e.g. Clang 18) expect a const std::shared_ptr<TargetOptions>&.
+#if CLANG_VERSION_MAJOR >= 21
     clang::TargetOptions target_opts;
     target_opts.Triple = llvm::sys::getDefaultTargetTriple();
     target_info.reset(clang::TargetInfo::CreateTargetInfo(diags, target_opts));
+#else
+    auto target_opts = std::make_shared<clang::TargetOptions>();
+    target_opts->Triple = llvm::sys::getDefaultTargetTriple();
+    target_info.reset(clang::TargetInfo::CreateTargetInfo(diags, target_opts));
+#endif
   }
 };
 


### PR DESCRIPTION
## What

`clang::TargetInfo::CreateTargetInfo` changed signature in Clang 21:

- **Clang ≥ 21:** `CreateTargetInfo(DiagnosticsEngine &, TargetOptions &)` (by reference)
- **Clang < 21** (e.g. Clang 18): `CreateTargetInfo(DiagnosticsEngine &, const std::shared_ptr<TargetOptions> &)`

The current unconditional by-reference call in `clang_c_lexer.cpp` only compiles on Clang ≥ 21 and fails on older LLVM/Clang. This guards the call on `CLANG_VERSION_MAJOR`, matching the existing `>= 21` guard already used for `DiagnosticOptions` in the same `LexerContext` struct.

## Why a separate PR

Split out of #5620 (LD frontend) at reviewer request — it's an unrelated LLVM-API-compat change in a non-LD file, so the LD work can be reviewed/reverted independently.

## Testing

- `CLANG_VERSION_MAJOR >= 21` path is unchanged from current `master` (already validated by the llvm-22 CI).
- `CLANG_VERSION_MAJOR < 21` (shared_ptr) path builds locally against Clang/LLVM 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)