### PR TITLE
[python] V.1k(b) B.4: post-adjust strong-invariant exit check

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3520,6 +3520,16 @@ following (`next: None`→`Node`), and dataclass field resolution.
   (`#cpp_type`/`#member_name` IREP2-native carriage), retiring the legacy attribute
   reads at `clang_cpp_adjust_expr.cpp:464`, `cpp_expr2string.cpp:138-140`,
   `goto2c/expr2c.cpp:169-174`.
+  **Exit assertion LANDED (2026-06-26).** `python_adjust::adjust()` now re-enforces
+  the strong invariant: after resolving each body it walks the result and, if any
+  `member2t`/`index2t` source is still a `symbol_type2t` (a survivor the pass could not
+  follow — e.g. an unregistered tag, left untouched by the guard), it `log_error`s
+  naming the symbol and returns true (error). This is the post-relaxation re-enforcement
+  the relaxed construction assert deferred. It is a pure safety net on the live pipeline
+  — `clang_cpp_adjust` resolves every source before the flag-on pass runs, so the
+  fixture + broad parity sweep stays **0 divergences** with the check active — and it
+  catches a B.5-era resolution bug deterministically. Unit-tested both ways (resolved
+  body ⇒ false; unregistered-tag survivor ⇒ true).
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,5 +1,6 @@
 #include <python-frontend/python_adjust.h>
 #include <irep2/irep2_utils.h>
+#include <util/message.h>
 
 python_adjust::python_adjust(contextt &_context)
   : context(_context), ns(_context)
@@ -14,6 +15,7 @@ bool python_adjust::adjust()
   context.Foreach_operand_in_order(
     [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
 
+  bool error = false;
   Forall_symbol_list(it, symbol_list)
   {
     symbolt &symbol = **it;
@@ -32,9 +34,22 @@ bool python_adjust::adjust()
 
     adjust_expr(value);
     symbol.set_value(value);
+
+    // Post-adjust strong invariant (V.1k B.4): re-enforce that no member/index
+    // source survived as an unresolved symbol_type2t. The construction asserts
+    // permit that source only as the transient pre-resolution state this pass
+    // discharges; a survivor (e.g. an unregistered tag) is an internal error.
+    if (has_unresolved_source(value))
+    {
+      log_error(
+        "python_adjust: symbol `{}' retains an unresolved member/index source "
+        "after adjust (V.1k post-adjust invariant violated)",
+        symbol.id.as_string());
+      error = true;
+    }
   }
 
-  return false;
+  return error;
 }
 
 void python_adjust::adjust_expr(expr2tc &expr)
@@ -80,4 +95,22 @@ bool python_adjust::resolve_aggregate_source(expr2tc &source) const
 
   source = source->with_type(ns.follow(source->type));
   return true;
+}
+
+bool python_adjust::has_unresolved_source(const expr2tc &expr) const
+{
+  if (is_nil_expr(expr))
+    return false;
+
+  if (is_member2t(expr) && is_symbol_type(to_member2t(expr).source_value->type))
+    return true;
+  if (is_index2t(expr) && is_symbol_type(to_index2t(expr).source_value->type))
+    return true;
+
+  bool found = false;
+  expr->foreach_operand([this, &found](const expr2tc &e) {
+    if (has_unresolved_source(e))
+      found = true;
+  });
+  return found;
 }

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -31,7 +31,9 @@ public:
   virtual ~python_adjust() = default;
 
   /** Walk every non-type symbol's IREP2 body and write the resolved form back.
-   *  Returns true on error (none today), mirroring `clang_c_adjust::adjust()`. */
+   *  Returns true on error — specifically if the post-adjust strong invariant is
+   *  violated (a member/index source still carries an unresolved `symbol_type2t`
+   *  after resolution), mirroring `clang_c_adjust::adjust()`'s bool contract. */
   bool adjust();
 
 protected:
@@ -49,6 +51,11 @@ private:
    *  followed aggregate type and return true. Otherwise leave it untouched and
    *  return false. */
   bool resolve_aggregate_source(expr2tc &source) const;
+
+  /** Post-adjust strong-invariant check (V.1k B.4): true if any `member2t` or
+   *  `index2t` in @p expr still has a `symbol_type2t` source — i.e. a source the
+   *  pass could not resolve (e.g. an unregistered tag). Recursive. */
+  bool has_unresolved_source(const expr2tc &expr) const;
 };
 
 #endif /* PYTHON_FRONTEND_PYTHON_ADJUST_H_ */

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -278,6 +278,32 @@ TEST_CASE(
   REQUIRE(is_symbol_type(to_member2t(out->get_value2()).source_value->type));
 }
 
+TEST_CASE(
+  "python_adjust B.4 adjust() flags an unresolved member source post-adjust",
+  "[python-frontend][irep2][python-adjust]")
+{
+  cmdlinet cmdline;
+  REQUIRE_FALSE(config.set(cmdline));
+
+  const type2tc intt = get_int_type(config.ansi_c.int_width);
+
+  // A Python symbol whose body reads a member of an UNREGISTERED tag: the pass
+  // cannot follow it (the unregistered-tag guard leaves it untouched), so the
+  // post-adjust strong-invariant check must catch the survivor and adjust()
+  // must return true (error).
+  contextt context;
+  symbolt symbol;
+  symbol.id = "py:test@F@unresolved";
+  symbol.name = "unresolved";
+  symbol.mode = "Python";
+  symbol.set_value(
+    member2tc(intt, symbol2tc(symbol_type2tc("tag-Missing"), "m"), "x"));
+  symbol.set_type(intt);
+  context.add(symbol);
+
+  REQUIRE(python_adjust(context).adjust());
+}
+
 // --- RV2 foundation: type-following equivalence ---------------------------
 //
 // B.3 resolves member/index sources via the converter's `name_space().follow()`


### PR DESCRIPTION
## What

Part V Phase V.1k (b) sub-phase **B.4 — post-adjust exit assertion**
(`src/python-frontend/python_adjust.{h,cpp}`). Stacked on #5634 → … → #5625.

`python_adjust::adjust()` now re-enforces the **strong invariant** the relaxed
`member2t`/`index2t` construction assert deferred. After resolving each body it walks
the result via a new `has_unresolved_source(const expr2tc&)`; if any member/index
source is still a `symbol_type2t` (a survivor the pass could not follow — e.g. an
unregistered tag, which `resolve_aggregate_source` deliberately leaves untouched), it
`log_error`s naming the symbol and returns `true` (error). Previously `adjust()` always
returned `false`.

This is the post-relaxation re-enforcement the design called for: the relaxed assert
permits a `symbol_type2t` source only as the transient pre-resolution state this pass
discharges; a survivor is an internal error and must be flagged deterministically.

## Why it's safe

Pure safety net on the live pipeline: under the default-off flag, `python_adjust` runs
*after* `clang_cpp_adjust`, which has already resolved every legacy source — so
`get_value2()` bodies contain no `symbol_type2t` member/index sources, the check is a
no-op, and it cannot fire on a valid program. It only ever fires on a genuine
internal-error survivor (e.g. a B.5-era resolution bug).

## Verification

- **Parity sweep with the check active: 0 divergences** flag-on vs flag-off over the
  20-test fixture (71) and a 60-test broad slice — the check does not spuriously trip.
- `python_adjust_test`: **10 cases pass**, including the new B.4 test both ways —
  resolved body ⇒ `adjust()` false; unregistered-tag survivor ⇒ `adjust()` true (this
  also discharges C-Live: the new error branch is reachable, proven by the harness).
- Flag-off byte-identical (the pass does not run).
- Code-reviewer agent: "Good — ready to commit," 0 critical/major.

Refs #4715. Stacked on #5634.
