### PR TITLE
[python] V.1k(b) B.4: flip same-type integer Add/Sub to IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3539,6 +3539,18 @@ following (`next: None`→`Node`), and dataclass field resolution.
   isinstance/Optional tests + a 90-test broad slice (both this and the BoolOp flip
   active together). Flag off ⇒ byte-identical; `regression/python/isinstance_none_adjust
   {,_fail}` pin the flipped path for the CI Z3 half.
+  **Third site flipped — integer `Add`/`Sub` (`build_binary_expression`, 2026-06-26).**
+  The largest F-P11 family. Under the flag, same-type integer `Add`/`Sub` build via
+  `python_expr::build_add`/`build_sub` (the existing `add2tc`/`sub2tc` round-trip
+  helpers). **Width-hazard handled by a guard:** the flip fires only when
+  `lhs.type() == rhs.type() == result` and the type is an integer bitvector, so
+  `add2t`/`sub2t`'s width-consistency assert always holds; every width-mismatched,
+  float, or other case falls through to the legacy node, byte-identical. RV2 Bitwuzla
+  half: **0 divergences** flag on vs off over 65 class/arith tests + a 110-test broad
+  slice (all three flips active together). A swap-probe (build_add↔build_sub) confirmed
+  the flip actually fires (it flipped the verdict). `regression/python/arith_member_adjust
+  {,_fail}` pin the flipped path for CI. The width-mismatch / float arith remain legacy
+  (the genuine width-hazard residue, §3640).
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/regression/python/arith_member_adjust/main.py
+++ b/regression/python/arith_member_adjust/main.py
@@ -1,0 +1,10 @@
+class Acc:
+    def __init__(self, x: int):
+        self.x = x
+
+
+acc = Acc(10)
+r = acc.x + 5
+s = acc.x - 3
+assert r == 15
+assert s == 7

--- a/regression/python/arith_member_adjust/test.desc
+++ b/regression/python/arith_member_adjust/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/arith_member_adjust_fail/main.py
+++ b/regression/python/arith_member_adjust_fail/main.py
@@ -1,0 +1,10 @@
+class Acc:
+    def __init__(self, x: int):
+        self.x = x
+
+
+acc = Acc(10)
+r = acc.x + 5
+s = acc.x - 3
+assert r == 16
+assert s == 7

--- a/regression/python/arith_member_adjust_fail/test.desc
+++ b/regression/python/arith_member_adjust_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -9,8 +9,10 @@
 #include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <python-frontend/python_expr_builder.h>
 #include <irep2/irep2_utils.h>
 #include <util/arith_tools.h>
+#include <util/config.h>
 #include <util/c_typecast.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
@@ -1965,6 +1967,25 @@ exprt python_converter::build_binary_expression(
   // Handle division promotion
   if (op == "Div" || op == "div")
     math_handler_.handle_float_division(lhs, rhs, bin_expr);
+
+  // V.1k (b) B.4: under --python-irep2-adjust, build same-type integer Add/Sub
+  // via the IREP2 resolve-then-build round-trip (python_expr::build_add/sub).
+  // Guarded on exact type match (lhs==rhs==result, integer bitvector) so
+  // add2t/sub2t's width-consistency assert holds; every width-mismatched or
+  // float/other case falls through to the legacy node below, byte-identical.
+  // The operands reaching here are already resolved (B.4 triage: member
+  // arithmetic migrates without the F-P11 assert). Default off ⇒ legacy.
+  if (
+    config.options.get_bool_option("python-irep2-adjust") &&
+    (op == "Add" || op == "Sub") &&
+    (type.is_signedbv() || type.is_unsignedbv()) && lhs.type() == type &&
+    rhs.type() == type)
+  {
+    exprt result = (op == "Add") ? python_expr::build_add(lhs, rhs, type)
+                                 : python_expr::build_sub(lhs, rhs, type);
+    result.location() = bin_expr.location();
+    return result;
+  }
 
   // Add operands
   bin_expr.copy_to_operands(lhs, rhs);


### PR DESCRIPTION
## What

Part V Phase V.1k (b) B.4 — **third F-P11 site flip, the largest family**
(`src/python-frontend/converter/converter_binop.cpp`). Stacked on #5637 → … → #5625.

Under `--python-irep2-adjust`, `build_binary_expression` builds same-type integer
`Add`/`Sub` via `python_expr::build_add`/`build_sub` (the existing `add2tc`/`sub2tc`
round-trip helpers) instead of the legacy `exprt`. **Flag off ⇒ byte-identical** (the
legacy construction is the untouched fall-through).

## Width-hazard handled by a guard

`add2t`/`sub2t` assert width-consistency, so the flip fires **only** when
`lhs.type() == rhs.type() == result` and the type is an integer bitvector. `typet`
equality compares the full irep (width included), so matching types ⇒ matching widths —
the assert cannot trip. Every width-mismatched, float, or other case falls through to
the legacy node. The width-mismatch / float arith stay legacy (the genuine width-hazard
residue, §3640).

## RV2 — Bitwuzla half discharged

`PARITY_FLAG=--python-irep2-adjust` sweep (flag on vs off, verdict parity), with **all
three flips active** (BoolOp, isinstance, this):
- 65 class/arith tests: **0 divergences**
- 110-test broad python slice: **0 divergences**

No width-assert aborts, no verdict drift. The **Z3 half runs in CI** via
`regression/python/arith_member_adjust{,_fail}`, which pin the flipped path.

## Reachability evidence

A **swap-probe** (temporarily `build_add`→`build_sub`, rebuild) made `arith_member_adjust`
(`acc.x + 5`) verify FAILED — proving the new branch actually fires (C-Live reachability),
not silently falling back to legacy. The formal dual-solver Mode C intrinsic runs in CI
(this dev build is Bitwuzla-only).

## Verification

- Flag off byte-identical; flag on validated by the sweeps.
- Flag on/off agree on the new tests; CPython sanity OK; `python_adjust` unit tests
  still pass (10 cases).
- Code-reviewer agent: "Good — ready for commit," 0 correctness defects (width guard
  sound, placement correct, build_add/build_sub equivalence confirmed).
- Safe to land regardless of CI — the change is default-off.

Refs #4715. Stacked on #5637.
