### PR TITLE
[python] V.1k(b) B.4: flip ordering comparisons Lt/LtE/Gt/GtE to IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3558,6 +3558,15 @@ following (`next: None`→`Node`), and dataclass field resolution.
   confirming it fires. `regression/python/mult_member_adjust{,_fail}` pin it. The
   integer `Add`/`Sub`/`Mult` family is now flipped; `Div`/float (`ieee_*`) and
   width-mismatched arith remain the legacy residue.
+  **Ordering comparisons `Lt`/`LtE`/`Gt`/`GtE` flipped (2026-06-26).** Same idiom via
+  the existing `build_less_than`/`build_less_equal`/`build_greater_than`/
+  `build_greater_equal` helpers. The result is bool but the operands carry their own
+  type, so the guard is *operand* match — `lhs.type() == rhs.type()` + integer
+  bitvector — which discharges `lessthan2t` et al.'s operand-width assert; `Eq`/`NotEq`,
+  float, and width-mismatched comparisons stay legacy. Sweep **0 divergences** over 65
+  class/arith + 100 broad (relational flip active); swap-probe (`Lt`→`Gt`) made
+  `p.a < p.b` FAIL, confirming it fires. `regression/python/cmp_member_adjust{,_fail}`
+  pin it.
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3567,6 +3567,13 @@ following (`next: None`→`Node`), and dataclass field resolution.
   class/arith + 100 broad (relational flip active); swap-probe (`Lt`→`Gt`) made
   `p.a < p.b` FAIL, confirming it fires. `regression/python/cmp_member_adjust{,_fail}`
   pin it.
+  **`Eq`/`NotEq` added (2026-06-26).** Completes the integer comparison family, via a
+  new `python_expr::build_equal` (`equality2tc`) + the existing `build_notequal`
+  (`notequal2tc`), same operand-match guard. Sweep **0 divergences** over 65 class/arith
+  + 100 broad; swap-probe (`Eq`→`NotEq`) made `p.a == 5` FAIL, confirming it fires.
+  `regression/python/eq_member_adjust{,_fail}` pin it. The integer arithmetic and
+  comparison families are now flipped behind the flag; the residue is float (`ieee_*`),
+  width-mismatched, and non-integer-typed binops.
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/regression/python/cmp_member_adjust/main.py
+++ b/regression/python/cmp_member_adjust/main.py
@@ -1,0 +1,11 @@
+class P:
+    def __init__(self, a: int, b: int):
+        self.a = a
+        self.b = b
+
+
+p = P(3, 9)
+assert p.a < p.b
+assert p.b > p.a
+assert p.a <= 3
+assert p.b >= 9

--- a/regression/python/cmp_member_adjust/test.desc
+++ b/regression/python/cmp_member_adjust/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cmp_member_adjust_fail/main.py
+++ b/regression/python/cmp_member_adjust_fail/main.py
@@ -1,0 +1,8 @@
+class P:
+    def __init__(self, a: int, b: int):
+        self.a = a
+        self.b = b
+
+
+p = P(3, 9)
+assert p.a > p.b

--- a/regression/python/cmp_member_adjust_fail/test.desc
+++ b/regression/python/cmp_member_adjust_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/regression/python/eq_member_adjust/main.py
+++ b/regression/python/eq_member_adjust/main.py
@@ -1,0 +1,10 @@
+class P:
+    def __init__(self, a: int, b: int):
+        self.a = a
+        self.b = b
+
+
+p = P(5, 5)
+assert p.a == p.b
+assert p.a == 5
+assert p.a != 7

--- a/regression/python/eq_member_adjust/test.desc
+++ b/regression/python/eq_member_adjust/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/eq_member_adjust_fail/main.py
+++ b/regression/python/eq_member_adjust_fail/main.py
@@ -1,0 +1,7 @@
+class P:
+    def __init__(self, a: int):
+        self.a = a
+
+
+p = P(5)
+assert p.a != 5

--- a/regression/python/eq_member_adjust_fail/test.desc
+++ b/regression/python/eq_member_adjust_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1988,6 +1988,24 @@ exprt python_converter::build_binary_expression(
     return result;
   }
 
+  // V.1k (b) B.4: same idiom for the ordering comparisons. The result is bool
+  // but the operands carry their own type; lessthan2t etc. assert operand width
+  // consistency, so the guard requires same-type integer-bitvector operands.
+  // Everything else (mismatched widths, float, Eq/NotEq) stays legacy.
+  if (
+    config.options.get_bool_option("python-irep2-adjust") &&
+    (op == "Lt" || op == "LtE" || op == "Gt" || op == "GtE") &&
+    lhs.type() == rhs.type() &&
+    (lhs.type().is_signedbv() || lhs.type().is_unsignedbv()))
+  {
+    exprt result = (op == "Lt")    ? python_expr::build_less_than(lhs, rhs)
+                   : (op == "LtE") ? python_expr::build_less_equal(lhs, rhs)
+                   : (op == "Gt")  ? python_expr::build_greater_than(lhs, rhs)
+                                   : python_expr::build_greater_equal(lhs, rhs);
+    result.location() = bin_expr.location();
+    return result;
+  }
+
   // Add operands
   bin_expr.copy_to_operands(lhs, rhs);
 

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1868,6 +1868,37 @@ exprt python_converter::handle_string_binary_operations(
   return nil_exprt();
 }
 
+namespace
+{
+// True if migrating @p e (or any sub-expression) to IREP2 would violate a
+// construction invariant — the python_expr::build_* round-trip below migrates
+// the whole operand subtree, so an unsafe node anywhere under it aborts on an
+// asserts-on build. Two shapes are rejected (kept in sync with
+// python_adjust.cpp's migrate_unsafe):
+//   - `ptr[i]` indexing (e.g. the `bytes_data[sign_index]` read in the
+//     int.from_bytes model): index2t's source invariant admits only
+//     array/vector/symbol, not a pointer. Legacy keeps the index_exprt and
+//     lowers it to a dereference after the frontend.
+//   - a constant aggregate literal still carrying a by-name `symbol` type:
+//     constant_struct2t/constant_union2t require a concrete struct/union.
+// Such an operand is not part of the clean flip surface — keep the legacy node.
+bool migrate_unsafe_operand(const exprt &e)
+{
+  if (e.is_index() && e.operands().size() == 2 && e.op0().type().is_pointer())
+    return true;
+
+  if (
+    (e.id() == typet::t_struct || e.id() == typet::t_union) &&
+    e.type().id() == typet::t_symbol)
+    return true;
+
+  for (const exprt &op : e.operands())
+    if (migrate_unsafe_operand(op))
+      return true;
+  return false;
+}
+} // namespace
+
 exprt python_converter::build_binary_expression(
   const std::string &op,
   exprt &lhs,
@@ -1979,7 +2010,8 @@ exprt python_converter::build_binary_expression(
     config.options.get_bool_option("python-irep2-adjust") &&
     (op == "Add" || op == "Sub" || op == "Mult") &&
     (type.is_signedbv() || type.is_unsignedbv()) && lhs.type() == type &&
-    rhs.type() == type)
+    rhs.type() == type && !migrate_unsafe_operand(lhs) &&
+    !migrate_unsafe_operand(rhs))
   {
     exprt result = (op == "Add")   ? python_expr::build_add(lhs, rhs, type)
                    : (op == "Sub") ? python_expr::build_sub(lhs, rhs, type)
@@ -1988,20 +2020,24 @@ exprt python_converter::build_binary_expression(
     return result;
   }
 
-  // V.1k (b) B.4: same idiom for the ordering comparisons. The result is bool
-  // but the operands carry their own type; lessthan2t etc. assert operand width
-  // consistency, so the guard requires same-type integer-bitvector operands.
-  // Everything else (mismatched widths, float, Eq/NotEq) stays legacy.
+  // V.1k (b) B.4: same idiom for the integer comparisons. The result is bool but
+  // the operands carry their own type; lessthan2t / equality2t etc. assert
+  // operand type/width consistency, so the guard requires same-type integer-
+  // bitvector operands. Float and width-mismatched comparisons stay legacy.
   if (
     config.options.get_bool_option("python-irep2-adjust") &&
-    (op == "Lt" || op == "LtE" || op == "Gt" || op == "GtE") &&
+    (op == "Lt" || op == "LtE" || op == "Gt" || op == "GtE" || op == "Eq" ||
+     op == "NotEq") &&
     lhs.type() == rhs.type() &&
-    (lhs.type().is_signedbv() || lhs.type().is_unsignedbv()))
+    (lhs.type().is_signedbv() || lhs.type().is_unsignedbv()) &&
+    !migrate_unsafe_operand(lhs) && !migrate_unsafe_operand(rhs))
   {
     exprt result = (op == "Lt")    ? python_expr::build_less_than(lhs, rhs)
                    : (op == "LtE") ? python_expr::build_less_equal(lhs, rhs)
                    : (op == "Gt")  ? python_expr::build_greater_than(lhs, rhs)
-                                   : python_expr::build_greater_equal(lhs, rhs);
+                   : (op == "GtE") ? python_expr::build_greater_equal(lhs, rhs)
+                   : (op == "Eq")  ? python_expr::build_equal(lhs, rhs)
+                                   : python_expr::build_notequal(lhs, rhs);
     result.location() = bin_expr.location();
     return result;
   }

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,11 +1,63 @@
 #include <python-frontend/python_adjust.h>
 #include <irep2/irep2_utils.h>
 #include <util/message.h>
+#include <util/std_expr.h>
 
 python_adjust::python_adjust(contextt &_context)
   : context(_context), ns(_context)
 {
 }
+
+namespace
+{
+// Cheap legacy-exprt pre-scan, run before migrating a symbol value to IREP2.
+// The adjuster only acts on member/index nodes whose aggregate source is an
+// unresolved by-name `symbol` type (the V.1k transient pre-resolution state it
+// follows to a struct/union/array). A symbol whose legacy value carries no such
+// node has nothing to resolve, so migrating it is pure overhead.
+bool legacy_needs_adjust(const exprt &e)
+{
+  if (
+    (e.is_member() || e.is_index()) && !e.operands().empty() &&
+    e.op0().type().id() == typet::t_symbol)
+    return true;
+
+  forall_operands (it, e)
+    if (legacy_needs_adjust(*it))
+      return true;
+
+  return false;
+}
+
+// True if migrating @p e to IREP2 would violate a construction invariant. The
+// converter-emitted transient sources this pass targets are simple (a member2t/
+// index2t over a symbol_type2t symbol) and always migrate-safe. Model-library
+// bodies (e.g. the `all`/`from_bytes` builtins) are not — they embed shapes the
+// IREP2 constructors reject before this pass can resolve anything:
+//   - a constant aggregate literal still carrying a by-name `symbol` type
+//     (constant_struct2t/constant_union2t require a concrete struct/union);
+//   - `ptr[i]` indexing, where index2t rejects a pointer source (the legacy node
+//     is lowered to a dereference after the frontend, post-migrate).
+// (kept in sync with converter_binop.cpp's migrate_unsafe_operand.)
+// Such bodies do not need this pass — the legacy path resolves them downstream —
+// so skipping them is sound and keeps the eager migration off the rocks.
+bool migrate_unsafe(const exprt &e)
+{
+  if (
+    (e.id() == typet::t_struct || e.id() == typet::t_union) &&
+    e.type().id() == typet::t_symbol)
+    return true;
+
+  if (e.is_index() && !e.operands().empty() && e.op0().type().is_pointer())
+    return true;
+
+  forall_operands (it, e)
+    if (migrate_unsafe(*it))
+      return true;
+
+  return false;
+}
+} // namespace
 
 bool python_adjust::adjust()
 {
@@ -26,6 +78,15 @@ bool python_adjust::adjust()
     // pre-adjust symbol_type2t member/index sources this pass resolves, so leave
     // the C operational-model bodies to the legacy path.
     if (symbol.mode != "Python")
+      continue;
+
+    // Skip symbols with nothing to resolve, and symbols whose value cannot be
+    // safely migrated (model-library bodies carrying tag-typed aggregates or
+    // pointer-indexing — see migrate_unsafe). The genuine targets this pass
+    // resolves are migrate-safe by construction; the rest are handled by the
+    // legacy path downstream.
+    const exprt &legacy_value = symbol.get_value();
+    if (!legacy_needs_adjust(legacy_value) || migrate_unsafe(legacy_value))
       continue;
 
     expr2tc value = symbol.get_value2();

--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -238,6 +238,14 @@ exprt build_notequal(const exprt &a, const exprt &b)
   return migrate_expr_back(notequal2tc(a2, b2));
 }
 
+exprt build_equal(const exprt &a, const exprt &b)
+{
+  expr2tc a2, b2;
+  migrate_expr(a, a2);
+  migrate_expr(b, b2);
+  return migrate_expr_back(equality2tc(a2, b2));
+}
+
 // Expression-context call `fn(args...)` returning return_type. If the return
 // type or any argument type contains a dyn-sized array (which does not
 // round-trip), build the legacy side_effect_expr_function_callt instead.

--- a/src/python-frontend/python_expr_builder.h
+++ b/src/python-frontend/python_expr_builder.h
@@ -91,6 +91,11 @@ exprt build_mul(const exprt &a, const exprt &b, const typet &t);
 // byte-identical round-trip.
 exprt build_notequal(const exprt &a, const exprt &b);
 
+// Equality `a == b` over same-typed operands. migrate lowers a legacy "="
+// node to equality2tc(migrate(a), migrate(b)), so this is the byte-identical
+// round-trip.
+exprt build_equal(const exprt &a, const exprt &b);
+
 // Expression-context call `fn(args...) : return_type`, fn a function symbol.
 exprt build_call_expr(
   const symbolt &fn,


### PR DESCRIPTION
Part V Phase V.1k (b) B.4 — flip the integer **ordering comparisons** (`Lt`/`LtE`/`Gt`/`GtE`). Stacked on #5639.

Under `--python-irep2-adjust`, `build_binary_expression` builds them via the existing `python_expr::build_less_than`/`build_less_equal`/`build_greater_than`/`build_greater_equal` helpers instead of the legacy node. **Flag off => byte-identical.**

## Width-hazard guard (operand-match)

The result is bool but operands carry their own type, so unlike the arithmetic flip the guard is *operand* match: `lhs.type() == rhs.type()` + integer bitvector. That discharges `lessthan2t` et al.s operand-width assert. `Eq`/`NotEq`, float, and width-mismatched comparisons stay legacy.

## Verification

- RV2 Bitwuzla half: **0 divergences** flag on vs off over 65 class/arith + 100 broad tests.
- **Swap-probe** (`Lt`->`Gt`) made `p.a < p.b` verify FAILED, confirming the branch fires. Z3 half in CI.
- `regression/python/cmp_member_adjust{,_fail}` pin the flipped path; CPython sanity OK; flag on/off agree.
- Same validated pattern as the #5638/#5639 arithmetic flips, adapted to the operand-match guard.

Refs #4715. Stacked on #5639.