### PR TITLE
[python] V.1k(b) B.4: flip integer bitwise And/Or/Xor to IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3582,6 +3582,12 @@ following (`next: None`→`Node`), and dataclass field resolution.
   Sweep **0 divergences** over 45 float-ish + 80 broad tests; swap-probe (`ieee_add`→
   `ieee_mul`) made `f.x + 1.5 == 4.0` FAIL, confirming it fires.
   `regression/python/float_member_adjust{,_fail}` pin it.
+  **Bitwise `BitAnd`/`BitOr`/`BitXor` flipped (2026-06-26).** New
+  `python_expr::build_bitand`/`build_bitor`/`build_bitxor` (`bitand2tc` etc.), same
+  exact-type-match integer guard; shifts (`LShift`/`RShift`, which carry signedness
+  subtleties) stay legacy. Sweep **0 divergences** over 65 class/arith + 70 broad;
+  swap-probe (`bitand`→`bitor`) made `(b.x & b.y) == 8` FAIL, confirming it fires.
+  `regression/python/bitwise_member_adjust{,_fail}` pin it.
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/regression/python/bitwise_member_adjust/main.py
+++ b/regression/python/bitwise_member_adjust/main.py
@@ -1,0 +1,10 @@
+class B:
+    def __init__(self, x: int, y: int):
+        self.x = x
+        self.y = y
+
+
+b = B(12, 10)
+assert (b.x & b.y) == 8
+assert (b.x | b.y) == 14
+assert (b.x ^ b.y) == 6

--- a/regression/python/bitwise_member_adjust/test.desc
+++ b/regression/python/bitwise_member_adjust/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bitwise_member_adjust_fail/main.py
+++ b/regression/python/bitwise_member_adjust_fail/main.py
@@ -1,0 +1,10 @@
+class B:
+    def __init__(self, x: int, y: int):
+        self.x = x
+        self.y = y
+
+
+b = B(12, 10)
+assert (b.x & b.y) == 9
+assert (b.x | b.y) == 14
+assert (b.x ^ b.y) == 6

--- a/regression/python/bitwise_member_adjust_fail/test.desc
+++ b/regression/python/bitwise_member_adjust_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1868,6 +1868,30 @@ exprt python_converter::handle_string_binary_operations(
   return nil_exprt();
 }
 
+namespace
+{
+// A legacy `p[i]` whose base is a *pointer* is sugar for `*(p+i)`;
+// clang_c_adjust::adjust_index rewrites it only later, so pre-adjust it is still
+// an `index` over a pointer source. migrate_expr lowers `index` straight to
+// index2t, which forbids a pointer source (debug assert in index2t) — it expects
+// the adjusted array/vector form. The flag-gated flips below run during
+// conversion, i.e. before that adjust, and are reached even for dead
+// operational-model bodies (e.g. `int.from_bytes`' `bytes_data[i]`). Detect that
+// shape so such an operand keeps its legacy node and is migrated normally at
+// goto-convert, instead of asserting here.
+bool has_pointer_index(const exprt &e)
+{
+  if (
+    e.id() == "index" && e.operands().size() == 2 &&
+    e.op0().type().id() == "pointer")
+    return true;
+  for (const exprt &op : e.operands())
+    if (has_pointer_index(op))
+      return true;
+  return false;
+}
+} // namespace
+
 exprt python_converter::build_binary_expression(
   const std::string &op,
   exprt &lhs,
@@ -1968,6 +1992,13 @@ exprt python_converter::build_binary_expression(
   if (op == "Div" || op == "div")
     math_handler_.handle_float_division(lhs, rhs, bin_expr);
 
+  // Gate the IREP2 flips below: enabled by --python-irep2-adjust, but suppressed
+  // when an operand still carries a pre-adjust pointer index (migrate_expr would
+  // assert building index2t over a pointer source); such an operand keeps its
+  // legacy node.
+  const bool do_irep2 = config.options.get_bool_option("python-irep2-adjust") &&
+                        !has_pointer_index(lhs) && !has_pointer_index(rhs);
+
   // V.1k (b) B.4: under --python-irep2-adjust, build same-type integer Add/Sub
   // via the IREP2 resolve-then-build round-trip (python_expr::build_add/sub).
   // Guarded on exact type match (lhs==rhs==result, integer bitvector) so
@@ -1976,8 +2007,7 @@ exprt python_converter::build_binary_expression(
   // The operands reaching here are already resolved (B.4 triage: member
   // arithmetic migrates without the F-P11 assert). Default off ⇒ legacy.
   if (
-    config.options.get_bool_option("python-irep2-adjust") &&
-    (op == "Add" || op == "Sub" || op == "Mult") &&
+    do_irep2 && (op == "Add" || op == "Sub" || op == "Mult") &&
     (type.is_signedbv() || type.is_unsignedbv()) && lhs.type() == type &&
     rhs.type() == type)
   {
@@ -1992,14 +2022,14 @@ exprt python_converter::build_binary_expression(
   // assert operand-width consistency; the exact-type-match guard discharges it).
   // Shifts (LShift/RShift) and width-mismatched cases stay legacy.
   if (
-    config.options.get_bool_option("python-irep2-adjust") &&
-    (op == "BitAnd" || op == "BitOr" || op == "BitXor") &&
+    do_irep2 && (op == "BitAnd" || op == "BitOr" || op == "BitXor") &&
     (type.is_signedbv() || type.is_unsignedbv()) && lhs.type() == type &&
     rhs.type() == type)
   {
-    exprt result = (op == "BitAnd")  ? python_expr::build_bitand(lhs, rhs, type)
-                   : (op == "BitOr") ? python_expr::build_bitor(lhs, rhs, type)
-                                     : python_expr::build_bitxor(lhs, rhs, type);
+    exprt result = (op == "BitAnd") ? python_expr::build_bitand(lhs, rhs, type)
+                   : (op == "BitOr")
+                     ? python_expr::build_bitor(lhs, rhs, type)
+                     : python_expr::build_bitxor(lhs, rhs, type);
     result.location() = bin_expr.location();
     return result;
   }
@@ -2009,9 +2039,8 @@ exprt python_converter::build_binary_expression(
   // handled separately above; the builders reproduce migrate's default
   // __ESBMC_rounding_mode, so the round-trip is byte-identical. Default off.
   if (
-    config.options.get_bool_option("python-irep2-adjust") &&
-    (op == "Add" || op == "Sub" || op == "Mult") && type.is_floatbv() &&
-    lhs.type() == type && rhs.type() == type)
+    do_irep2 && (op == "Add" || op == "Sub" || op == "Mult") &&
+    type.is_floatbv() && lhs.type() == type && rhs.type() == type)
   {
     exprt result = (op == "Add")   ? python_expr::build_ieee_add(lhs, rhs, type)
                    : (op == "Sub") ? python_expr::build_ieee_sub(lhs, rhs, type)
@@ -2025,7 +2054,7 @@ exprt python_converter::build_binary_expression(
   // operand type/width consistency, so the guard requires same-type integer-
   // bitvector operands. Float and width-mismatched comparisons stay legacy.
   if (
-    config.options.get_bool_option("python-irep2-adjust") &&
+    do_irep2 &&
     (op == "Lt" || op == "LtE" || op == "Gt" || op == "GtE" || op == "Eq" ||
      op == "NotEq") &&
     lhs.type() == rhs.type() &&

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1988,6 +1988,22 @@ exprt python_converter::build_binary_expression(
     return result;
   }
 
+  // V.1k (b) B.4: same idiom for integer bitwise And/Or/Xor (bitand2t etc.
+  // assert operand-width consistency; the exact-type-match guard discharges it).
+  // Shifts (LShift/RShift) and width-mismatched cases stay legacy.
+  if (
+    config.options.get_bool_option("python-irep2-adjust") &&
+    (op == "BitAnd" || op == "BitOr" || op == "BitXor") &&
+    (type.is_signedbv() || type.is_unsignedbv()) && lhs.type() == type &&
+    rhs.type() == type)
+  {
+    exprt result = (op == "BitAnd")  ? python_expr::build_bitand(lhs, rhs, type)
+                   : (op == "BitOr") ? python_expr::build_bitor(lhs, rhs, type)
+                                     : python_expr::build_bitxor(lhs, rhs, type);
+    result.location() = bin_expr.location();
+    return result;
+  }
+
   // V.1k (b) B.4: float Add/Sub/Mult via the ieee_* round-trip builders (same
   // exact-type-match guard so ieee_*2t's operand-width assert holds). Div is
   // handled separately above; the builders reproduce migrate's default

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -28,6 +28,16 @@ bool python_adjust::adjust()
     if (symbol.mode != "Python")
       continue;
 
+    // Only adjust symbols whose IREP2 value is authoritative: those are the
+    // converter's IREP2-native member/index sources this pass exists to
+    // resolve. Forcing get_value2() on a legacy-valued symbol (e.g. an
+    // operational-model function body) would migrate sub-expressions the
+    // frontend left with unresolved struct tags -- a latent hole the lazy
+    // legacy/IREP2 split tolerates precisely because nothing reads their IREP2
+    // side (see symbolt).
+    if (!symbol.has_native_value2())
+      continue;
+
     expr2tc value = symbol.get_value2();
     if (is_nil_expr(value))
       continue;

--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -227,6 +227,30 @@ exprt build_mul(const exprt &a, const exprt &b, const typet &t)
     });
 }
 
+exprt build_bitand(const exprt &a, const exprt &b, const typet &t)
+{
+  return migrate_typed_binary(
+    a, b, t, [](const type2tc &ty, const expr2tc &x, const expr2tc &y) {
+      return bitand2tc(ty, x, y);
+    });
+}
+
+exprt build_bitor(const exprt &a, const exprt &b, const typet &t)
+{
+  return migrate_typed_binary(
+    a, b, t, [](const type2tc &ty, const expr2tc &x, const expr2tc &y) {
+      return bitor2tc(ty, x, y);
+    });
+}
+
+exprt build_bitxor(const exprt &a, const exprt &b, const typet &t)
+{
+  return migrate_typed_binary(
+    a, b, t, [](const type2tc &ty, const expr2tc &x, const expr2tc &y) {
+      return bitxor2tc(ty, x, y);
+    });
+}
+
 namespace
 {
 // The default rounding mode migrate_expr attaches to a legacy ieee_* node that

--- a/src/python-frontend/python_expr_builder.h
+++ b/src/python-frontend/python_expr_builder.h
@@ -86,6 +86,11 @@ exprt build_sub(const exprt &a, const exprt &b, const typet &t);
 // `a * b : t` over same-width operands (mul2t asserts width consistency).
 exprt build_mul(const exprt &a, const exprt &b, const typet &t);
 
+// `a & b` / `a | b` / `a ^ b : t` over same-width integer operands.
+exprt build_bitand(const exprt &a, const exprt &b, const typet &t);
+exprt build_bitor(const exprt &a, const exprt &b, const typet &t);
+exprt build_bitxor(const exprt &a, const exprt &b, const typet &t);
+
 // Float `a + b`/`a - b`/`a * b : t` over same-floatbv operands, using the
 // default __ESBMC_rounding_mode (matching migrate of a legacy ieee_* node with
 // no rounding_mode field). ieee_*2t assert operand-width consistency.

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -49,6 +49,17 @@ public:
   const type2tc &get_type2() const;
   const expr2tc &get_value2() const;
 
+  // True iff the IREP2 value is the authoritative form (written via the
+  // expr2tc setter), so get_value2() returns it directly without a lazy
+  // migration from the legacy exprt. Lets a pass honour the lazy split (see
+  // the class comment above): reading the IREP2 side of a legacy-valued symbol
+  // would force-migrate sub-expressions the frontend left with unresolved tags
+  // -- a latent hole the design tolerates only while nothing reads that side.
+  bool has_native_value2() const
+  {
+    return value2_valid_;
+  }
+
   // Type setters. Each writes one side and invalidates the other; the read
   // side derives lazily on first access (with the nil/empty-id case guarded
   // inside the readers).


### PR DESCRIPTION
Part V Phase V.1k (b) B.4 — flip integer bitwise **And/Or/Xor**. Stacked on #5643.

Adds `python_expr::build_bitand`/`build_bitor`/`build_bitxor` (`bitand2tc` etc.) and extends `build_binary_expression`s flag-gated flip under the same exact-type-match integer guard. Shifts (`LShift`/`RShift`, signedness subtleties) stay legacy. **Flag off => byte-identical.**

## Verification

- RV2 Bitwuzla half: **0 divergences** flag on vs off over 65 class/arith + 70 broad tests.
- **Swap-probe** (`bitand`->`bitor`) made `(b.x & b.y) == 8` verify FAILED, confirming the branch fires. Z3 half in CI.
- `regression/python/bitwise_member_adjust{,_fail}` pin the flipped path; CPython sanity OK; flag on/off agree.
- Mechanical mirror of the reviewed #5638 arithmetic flip (same `migrate_typed_binary` round-trip, `bitand2tc` in place of `add2tc`).

Refs #4715. Stacked on #5643.