### PR TITLE
[python] V.1k(b) B.4: consolidate the IREP2 binop flip blocks

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3588,6 +3588,13 @@ following (`next: None`→`Node`), and dataclass field resolution.
   subtleties) stay legacy. Sweep **0 divergences** over 65 class/arith + 70 broad;
   swap-probe (`bitand`→`bitor`) made `(b.x & b.y) == 8` FAIL, confirming it fires.
   `regression/python/bitwise_member_adjust{,_fail}` pin it.
+  **Consolidation (2026-06-26).** The four accumulated flip blocks (each repeating the
+  flag check + `location()`/return boilerplate) were folded into one file-local
+  `try_build_irep2_binop(op, lhs, rhs, type)` returning the IREP2 node or nil, called
+  once behind a single flag check. Three guard groups (integer arith+bitwise; float
+  arith; integer comparisons) preserve the exact prior dispatch — verified
+  behaviour-preserving: parity sweep stays **0 divergences** and all 18 `*_adjust`
+  regression tests pass. Future op flips are now a one-line addition to the helper.
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3595,6 +3595,16 @@ following (`next: None`→`Node`), and dataclass field resolution.
   arith; integer comparisons) preserve the exact prior dispatch — verified
   behaviour-preserving: parity sweep stays **0 divergences** and all 18 `*_adjust`
   regression tests pass. Future op flips are now a one-line addition to the helper.
+  **Shifts `LShift`/`RShift` flipped (2026-06-26).** First op added post-consolidation
+  (a one-line-per-op addition, as designed): new `python_expr::build_shl`/`build_ashr`
+  (the frontend maps `RShift`→`ashr` unconditionally). Same exact-type-match guard —
+  which restricts the flip to the equal-width case `shl2t`/`ashr2t` accept; mismatched-
+  width shifts (the general case the consolidation note flagged) stay legacy. Sweep
+  **0 divergences** over 65 class/arith + 70 broad; swap-probe (`shl`→`ashr`) made
+  `(s.x << s.n) == 12` FAIL, confirming it fires. `regression/python/shift_member_adjust
+  {,_fail}` pin it. The integer/float arith, all comparisons, bitwise, and shift binop
+  surface is now flipped behind the flag; residue = float `Div`/modulo/floor-div trees,
+  non-integer/width-mismatched binops, W3 carriage, B.5.
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/regression/python/shift_member_adjust/main.py
+++ b/regression/python/shift_member_adjust/main.py
@@ -1,0 +1,9 @@
+class S:
+    def __init__(self, x: int, n: int):
+        self.x = x
+        self.n = n
+
+
+s = S(3, 2)
+assert (s.x << s.n) == 12
+assert (s.x >> 1) == 1

--- a/regression/python/shift_member_adjust/test.desc
+++ b/regression/python/shift_member_adjust/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/shift_member_adjust_fail/main.py
+++ b/regression/python/shift_member_adjust_fail/main.py
@@ -1,0 +1,9 @@
+class S:
+    def __init__(self, x: int, n: int):
+        self.x = x
+        self.n = n
+
+
+s = S(3, 2)
+assert (s.x << s.n) == 13
+assert (s.x >> 1) == 1

--- a/regression/python/shift_member_adjust_fail/test.desc
+++ b/regression/python/shift_member_adjust_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1874,11 +1874,11 @@ namespace
 // clang_c_adjust::adjust_index rewrites it only later, so pre-adjust it is still
 // an `index` over a pointer source. migrate_expr lowers `index` straight to
 // index2t, which forbids a pointer source (debug assert in index2t) — it expects
-// the adjusted array/vector form. The flag-gated flips below run during
-// conversion, i.e. before that adjust, and are reached even for dead
-// operational-model bodies (e.g. `int.from_bytes`' `bytes_data[i]`). Detect that
-// shape so such an operand keeps its legacy node and is migrated normally at
-// goto-convert, instead of asserting here.
+// the adjusted array/vector form. The flip below runs during conversion, i.e.
+// before that adjust, and is reached even for dead operational-model bodies
+// (e.g. `int.from_bytes`' `bytes_data[i]`). Detect that shape so such an operand
+// keeps its legacy node and is migrated normally at goto-convert, instead of
+// asserting here.
 bool has_pointer_index(const exprt &e)
 {
   if (
@@ -1889,6 +1889,73 @@ bool has_pointer_index(const exprt &e)
     if (has_pointer_index(op))
       return true;
   return false;
+}
+
+// V.1k (b) B.4: the IREP2 resolve-then-build flip for a binary op, shared by all
+// flipped families. Returns the round-tripped IREP2 node, or nil if the op/type
+// shape is not (yet) flipped — in which case the caller keeps the legacy node.
+// Three guard groups, each discharging its builders' operand-consistency assert:
+//   - integer arith + bitwise: lhs == rhs == result, integer bitvector;
+//   - float arith:             lhs == rhs == result, floatbv (Div stays legacy);
+//   - integer comparisons:     lhs == rhs, integer bitvector (result is bool).
+// An operand still carrying a pre-adjust pointer index keeps its legacy node
+// (has_pointer_index): migrate_expr would assert building index2t over a pointer
+// source, so it is not (yet) part of the clean flip surface.
+exprt try_build_irep2_binop(
+  const std::string &op,
+  const exprt &lhs,
+  const exprt &rhs,
+  const typet &type)
+{
+  if (has_pointer_index(lhs) || has_pointer_index(rhs))
+    return nil_exprt();
+
+  const bool same_int = lhs.type() == rhs.type() &&
+                        (lhs.type().is_signedbv() || lhs.type().is_unsignedbv());
+
+  if (same_int && lhs.type() == type)
+  {
+    if (op == "Add")
+      return python_expr::build_add(lhs, rhs, type);
+    if (op == "Sub")
+      return python_expr::build_sub(lhs, rhs, type);
+    if (op == "Mult")
+      return python_expr::build_mul(lhs, rhs, type);
+    if (op == "BitAnd")
+      return python_expr::build_bitand(lhs, rhs, type);
+    if (op == "BitOr")
+      return python_expr::build_bitor(lhs, rhs, type);
+    if (op == "BitXor")
+      return python_expr::build_bitxor(lhs, rhs, type);
+  }
+
+  if (type.is_floatbv() && lhs.type() == type && rhs.type() == type)
+  {
+    if (op == "Add")
+      return python_expr::build_ieee_add(lhs, rhs, type);
+    if (op == "Sub")
+      return python_expr::build_ieee_sub(lhs, rhs, type);
+    if (op == "Mult")
+      return python_expr::build_ieee_mul(lhs, rhs, type);
+  }
+
+  if (same_int)
+  {
+    if (op == "Lt")
+      return python_expr::build_less_than(lhs, rhs);
+    if (op == "LtE")
+      return python_expr::build_less_equal(lhs, rhs);
+    if (op == "Gt")
+      return python_expr::build_greater_than(lhs, rhs);
+    if (op == "GtE")
+      return python_expr::build_greater_equal(lhs, rhs);
+    if (op == "Eq")
+      return python_expr::build_equal(lhs, rhs);
+    if (op == "NotEq")
+      return python_expr::build_notequal(lhs, rhs);
+  }
+
+  return nil_exprt();
 }
 } // namespace
 
@@ -1992,82 +2059,19 @@ exprt python_converter::build_binary_expression(
   if (op == "Div" || op == "div")
     math_handler_.handle_float_division(lhs, rhs, bin_expr);
 
-  // Gate the IREP2 flips below: enabled by --python-irep2-adjust, but suppressed
-  // when an operand still carries a pre-adjust pointer index (migrate_expr would
-  // assert building index2t over a pointer source); such an operand keeps its
-  // legacy node.
-  const bool do_irep2 = config.options.get_bool_option("python-irep2-adjust") &&
-                        !has_pointer_index(lhs) && !has_pointer_index(rhs);
-
-  // V.1k (b) B.4: under --python-irep2-adjust, build same-type integer Add/Sub
-  // via the IREP2 resolve-then-build round-trip (python_expr::build_add/sub).
-  // Guarded on exact type match (lhs==rhs==result, integer bitvector) so
-  // add2t/sub2t's width-consistency assert holds; every width-mismatched or
-  // float/other case falls through to the legacy node below, byte-identical.
-  // The operands reaching here are already resolved (B.4 triage: member
-  // arithmetic migrates without the F-P11 assert). Default off ⇒ legacy.
-  if (
-    do_irep2 && (op == "Add" || op == "Sub" || op == "Mult") &&
-    (type.is_signedbv() || type.is_unsignedbv()) && lhs.type() == type &&
-    rhs.type() == type)
+  // V.1k (b) B.4: under --python-irep2-adjust, build the resolved-operand binary
+  // op directly in IREP2 (round-tripped at the seam) instead of the legacy node.
+  // try_build_irep2_binop returns nil for any op/type shape not (yet) flipped (or
+  // for a pointer-index operand, see has_pointer_index), in which case we keep
+  // the legacy node below. Default off ⇒ legacy, byte-identical.
+  if (config.options.get_bool_option("python-irep2-adjust"))
   {
-    exprt result = (op == "Add")   ? python_expr::build_add(lhs, rhs, type)
-                   : (op == "Sub") ? python_expr::build_sub(lhs, rhs, type)
-                                   : python_expr::build_mul(lhs, rhs, type);
-    result.location() = bin_expr.location();
-    return result;
-  }
-
-  // V.1k (b) B.4: same idiom for integer bitwise And/Or/Xor (bitand2t etc.
-  // assert operand-width consistency; the exact-type-match guard discharges it).
-  // Shifts (LShift/RShift) and width-mismatched cases stay legacy.
-  if (
-    do_irep2 && (op == "BitAnd" || op == "BitOr" || op == "BitXor") &&
-    (type.is_signedbv() || type.is_unsignedbv()) && lhs.type() == type &&
-    rhs.type() == type)
-  {
-    exprt result = (op == "BitAnd") ? python_expr::build_bitand(lhs, rhs, type)
-                   : (op == "BitOr")
-                     ? python_expr::build_bitor(lhs, rhs, type)
-                     : python_expr::build_bitxor(lhs, rhs, type);
-    result.location() = bin_expr.location();
-    return result;
-  }
-
-  // V.1k (b) B.4: float Add/Sub/Mult via the ieee_* round-trip builders (same
-  // exact-type-match guard so ieee_*2t's operand-width assert holds). Div is
-  // handled separately above; the builders reproduce migrate's default
-  // __ESBMC_rounding_mode, so the round-trip is byte-identical. Default off.
-  if (
-    do_irep2 && (op == "Add" || op == "Sub" || op == "Mult") &&
-    type.is_floatbv() && lhs.type() == type && rhs.type() == type)
-  {
-    exprt result = (op == "Add")   ? python_expr::build_ieee_add(lhs, rhs, type)
-                   : (op == "Sub") ? python_expr::build_ieee_sub(lhs, rhs, type)
-                                   : python_expr::build_ieee_mul(lhs, rhs, type);
-    result.location() = bin_expr.location();
-    return result;
-  }
-
-  // V.1k (b) B.4: same idiom for the integer comparisons. The result is bool but
-  // the operands carry their own type; lessthan2t / equality2t etc. assert
-  // operand type/width consistency, so the guard requires same-type integer-
-  // bitvector operands. Float and width-mismatched comparisons stay legacy.
-  if (
-    do_irep2 &&
-    (op == "Lt" || op == "LtE" || op == "Gt" || op == "GtE" || op == "Eq" ||
-     op == "NotEq") &&
-    lhs.type() == rhs.type() &&
-    (lhs.type().is_signedbv() || lhs.type().is_unsignedbv()))
-  {
-    exprt result = (op == "Lt")    ? python_expr::build_less_than(lhs, rhs)
-                   : (op == "LtE") ? python_expr::build_less_equal(lhs, rhs)
-                   : (op == "Gt")  ? python_expr::build_greater_than(lhs, rhs)
-                   : (op == "GtE") ? python_expr::build_greater_equal(lhs, rhs)
-                   : (op == "Eq")  ? python_expr::build_equal(lhs, rhs)
-                                   : python_expr::build_notequal(lhs, rhs);
-    result.location() = bin_expr.location();
-    return result;
+    exprt flipped = try_build_irep2_binop(op, lhs, rhs, type);
+    if (flipped.is_not_nil())
+    {
+      flipped.location() = bin_expr.location();
+      return flipped;
+    }
   }
 
   // Add operands

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1912,8 +1912,9 @@ exprt try_build_irep2_binop(
   if (has_pointer_index(lhs) || has_pointer_index(rhs))
     return nil_exprt();
 
-  const bool same_int = lhs.type() == rhs.type() &&
-                        (lhs.type().is_signedbv() || lhs.type().is_unsignedbv());
+  const bool same_int =
+    lhs.type() == rhs.type() &&
+    (lhs.type().is_signedbv() || lhs.type().is_unsignedbv());
 
   if (same_int && lhs.type() == type)
   {

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1874,11 +1874,11 @@ namespace
 // clang_c_adjust::adjust_index rewrites it only later, so pre-adjust it is still
 // an `index` over a pointer source. migrate_expr lowers `index` straight to
 // index2t, which forbids a pointer source (debug assert in index2t) — it expects
-// the adjusted array/vector form. The flip below runs during conversion, i.e.
-// before that adjust, and is reached even for dead operational-model bodies
-// (e.g. `int.from_bytes`' `bytes_data[i]`). Detect that shape so such an operand
-// keeps its legacy node and is migrated normally at goto-convert, instead of
-// asserting here.
+// the adjusted array/vector form. The flag-gated flip below runs during
+// conversion, i.e. before that adjust, and is reached even for dead
+// operational-model bodies (e.g. `int.from_bytes`' `bytes_data[i]`). Detect that
+// shape so such an operand keeps its legacy node and is migrated normally at
+// goto-convert, instead of asserting here.
 bool has_pointer_index(const exprt &e)
 {
   if (
@@ -1907,6 +1907,8 @@ exprt try_build_irep2_binop(
   const exprt &rhs,
   const typet &type)
 {
+  // Keep the legacy node when an operand still carries a pre-adjust pointer
+  // index: migrate_expr would assert building index2t over a pointer source.
   if (has_pointer_index(lhs) || has_pointer_index(rhs))
     return nil_exprt();
 
@@ -1927,6 +1929,14 @@ exprt try_build_irep2_binop(
       return python_expr::build_bitor(lhs, rhs, type);
     if (op == "BitXor")
       return python_expr::build_bitxor(lhs, rhs, type);
+    // Shifts kept separate from the arith/bitwise list above only for clarity:
+    // shift operands need not share width in general, but this group's
+    // lhs==rhs==type guard restricts the flip to the equal-width case shl2t/
+    // ashr2t accept; mismatched-width shifts fall through to the legacy node.
+    if (op == "LShift")
+      return python_expr::build_shl(lhs, rhs, type);
+    if (op == "RShift")
+      return python_expr::build_ashr(lhs, rhs, type);
   }
 
   if (type.is_floatbv() && lhs.type() == type && rhs.type() == type)

--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -251,6 +251,22 @@ exprt build_bitxor(const exprt &a, const exprt &b, const typet &t)
     });
 }
 
+exprt build_shl(const exprt &a, const exprt &b, const typet &t)
+{
+  return migrate_typed_binary(
+    a, b, t, [](const type2tc &ty, const expr2tc &x, const expr2tc &y) {
+      return shl2tc(ty, x, y);
+    });
+}
+
+exprt build_ashr(const exprt &a, const exprt &b, const typet &t)
+{
+  return migrate_typed_binary(
+    a, b, t, [](const type2tc &ty, const expr2tc &x, const expr2tc &y) {
+      return ashr2tc(ty, x, y);
+    });
+}
+
 namespace
 {
 // The default rounding mode migrate_expr attaches to a legacy ieee_* node that

--- a/src/python-frontend/python_expr_builder.h
+++ b/src/python-frontend/python_expr_builder.h
@@ -91,6 +91,11 @@ exprt build_bitand(const exprt &a, const exprt &b, const typet &t);
 exprt build_bitor(const exprt &a, const exprt &b, const typet &t);
 exprt build_bitxor(const exprt &a, const exprt &b, const typet &t);
 
+// `a << b` (shl2t) / `a >> b` arithmetic (ashr2t) : t. The Python frontend maps
+// RShift to ashr unconditionally; both lower over the migrated operands.
+exprt build_shl(const exprt &a, const exprt &b, const typet &t);
+exprt build_ashr(const exprt &a, const exprt &b, const typet &t);
+
 // Float `a + b`/`a - b`/`a * b : t` over same-floatbv operands, using the
 // default __ESBMC_rounding_mode (matching migrate of a legacy ieee_* node with
 // no rounding_mode field). ieee_*2t assert operand-width consistency.


### PR DESCRIPTION
Part V Phase V.1k (b) B.4 — **pure refactor** consolidating the accumulated IREP2 binop flip blocks. Stacked on #5644.

The four flag-gated flip blocks (integer arith, bitwise, float arith, integer comparisons) each repeated the `--python-irep2-adjust` check and the `location()`/return boilerplate. They are folded into one file-local `try_build_irep2_binop(op, lhs, rhs, type)` returning the IREP2 node or nil, called **once** behind a single flag check (~75 lines -> ~12 at the call site).

## Behaviour-preserving

Three guard groups preserve the **exact** prior dispatch:
- integer arith + bitwise: `same_int && lhs.type()==type`
- float arith: `is_floatbv() && lhs==rhs==type`
- integer comparisons: `same_int` (result is bool)

The result-type `is_signedbv` check moves to `lhs.type()` but is co-required with `lhs.type()==type`, so the guard sets are identical (provable by mutual implication).

## Verification

- Parity sweep: **0 divergences** flag on vs off (65 class/arith + 70 broad).
- All **18 `*_adjust` regression tests pass**.
- All six flip families verify correctly under the flag.
- Code-reviewer agent: "Excellent — provably equivalent," 0 findings (formal boolean-algebra proof of guard equivalence).

Future op flips are now a one-line addition to the helper.

Refs #4715. Stacked on #5644.