### PR TITLE
[python] V.1k(b) B.4: flip integer shifts LShift/RShift to IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3595,6 +3595,16 @@ following (`next: None`→`Node`), and dataclass field resolution.
   arith; integer comparisons) preserve the exact prior dispatch — verified
   behaviour-preserving: parity sweep stays **0 divergences** and all 18 `*_adjust`
   regression tests pass. Future op flips are now a one-line addition to the helper.
+  **Shifts `LShift`/`RShift` flipped (2026-06-26).** First op added post-consolidation
+  (a one-line-per-op addition, as designed): new `python_expr::build_shl`/`build_ashr`
+  (the frontend maps `RShift`→`ashr` unconditionally). Same exact-type-match guard —
+  which restricts the flip to the equal-width case `shl2t`/`ashr2t` accept; mismatched-
+  width shifts (the general case the consolidation note flagged) stay legacy. Sweep
+  **0 divergences** over 65 class/arith + 70 broad; swap-probe (`shl`→`ashr`) made
+  `(s.x << s.n) == 12` FAIL, confirming it fires. `regression/python/shift_member_adjust
+  {,_fail}` pin it. The integer/float arith, all comparisons, bitwise, and shift binop
+  surface is now flipped behind the flag; residue = float `Div`/modulo/floor-div trees,
+  non-integer/width-mismatched binops, W3 carriage, B.5.
 
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4

--- a/regression/python/shift_member_adjust/main.py
+++ b/regression/python/shift_member_adjust/main.py
@@ -1,0 +1,9 @@
+class S:
+    def __init__(self, x: int, n: int):
+        self.x = x
+        self.n = n
+
+
+s = S(3, 2)
+assert (s.x << s.n) == 12
+assert (s.x >> 1) == 1

--- a/regression/python/shift_member_adjust/test.desc
+++ b/regression/python/shift_member_adjust/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/shift_member_adjust_fail/main.py
+++ b/regression/python/shift_member_adjust_fail/main.py
@@ -1,0 +1,9 @@
+class S:
+    def __init__(self, x: int, n: int):
+        self.x = x
+        self.n = n
+
+
+s = S(3, 2)
+assert (s.x << s.n) == 13
+assert (s.x >> 1) == 1

--- a/regression/python/shift_member_adjust_fail/test.desc
+++ b/regression/python/shift_member_adjust_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1902,6 +1902,14 @@ exprt try_build_irep2_binop(
       return python_expr::build_bitor(lhs, rhs, type);
     if (op == "BitXor")
       return python_expr::build_bitxor(lhs, rhs, type);
+    // Shifts kept separate from the arith/bitwise list above only for clarity:
+    // shift operands need not share width in general, but this group's
+    // lhs==rhs==type guard restricts the flip to the equal-width case shl2t/
+    // ashr2t accept; mismatched-width shifts fall through to the legacy node.
+    if (op == "LShift")
+      return python_expr::build_shl(lhs, rhs, type);
+    if (op == "RShift")
+      return python_expr::build_ashr(lhs, rhs, type);
   }
 
   if (type.is_floatbv() && lhs.type() == type && rhs.type() == type)

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1870,6 +1870,27 @@ exprt python_converter::handle_string_binary_operations(
 
 namespace
 {
+// A legacy `p[i]` whose base is a *pointer* is sugar for `*(p+i)`;
+// clang_c_adjust::adjust_index rewrites it only later, so pre-adjust it is still
+// an `index` over a pointer source. migrate_expr lowers `index` straight to
+// index2t, which forbids a pointer source (debug assert in index2t) — it expects
+// the adjusted array/vector form. The flag-gated flip below runs during
+// conversion, i.e. before that adjust, and is reached even for dead
+// operational-model bodies (e.g. `int.from_bytes`' `bytes_data[i]`). Detect that
+// shape so such an operand keeps its legacy node and is migrated normally at
+// goto-convert, instead of asserting here.
+bool has_pointer_index(const exprt &e)
+{
+  if (
+    e.id() == "index" && e.operands().size() == 2 &&
+    e.op0().type().id() == "pointer")
+    return true;
+  for (const exprt &op : e.operands())
+    if (has_pointer_index(op))
+      return true;
+  return false;
+}
+
 // V.1k (b) B.4: the IREP2 resolve-then-build flip for a binary op, shared by all
 // flipped families. Returns the round-tripped IREP2 node, or nil if the op/type
 // shape is not (yet) flipped — in which case the caller keeps the legacy node.
@@ -1885,6 +1906,11 @@ exprt try_build_irep2_binop(
   const exprt &rhs,
   const typet &type)
 {
+  // Keep the legacy node when an operand still carries a pre-adjust pointer
+  // index: migrate_expr would assert building index2t over a pointer source.
+  if (has_pointer_index(lhs) || has_pointer_index(rhs))
+    return nil_exprt();
+
   const bool same_int = lhs.type() == rhs.type() &&
                         (lhs.type().is_signedbv() || lhs.type().is_unsignedbv());
 

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -28,6 +28,16 @@ bool python_adjust::adjust()
     if (symbol.mode != "Python")
       continue;
 
+    // Only adjust symbols whose IREP2 value is authoritative: those are the
+    // converter's IREP2-native member/index sources this pass exists to
+    // resolve. Forcing get_value2() on a legacy-valued symbol (e.g. an
+    // operational-model function body) would migrate sub-expressions the
+    // frontend left with unresolved struct tags -- a latent hole the lazy
+    // legacy/IREP2 split tolerates precisely because nothing reads their IREP2
+    // side (see symbolt).
+    if (!symbol.has_native_value2())
+      continue;
+
     expr2tc value = symbol.get_value2();
     if (is_nil_expr(value))
       continue;

--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -251,6 +251,22 @@ exprt build_bitxor(const exprt &a, const exprt &b, const typet &t)
     });
 }
 
+exprt build_shl(const exprt &a, const exprt &b, const typet &t)
+{
+  return migrate_typed_binary(
+    a, b, t, [](const type2tc &ty, const expr2tc &x, const expr2tc &y) {
+      return shl2tc(ty, x, y);
+    });
+}
+
+exprt build_ashr(const exprt &a, const exprt &b, const typet &t)
+{
+  return migrate_typed_binary(
+    a, b, t, [](const type2tc &ty, const expr2tc &x, const expr2tc &y) {
+      return ashr2tc(ty, x, y);
+    });
+}
+
 namespace
 {
 // The default rounding mode migrate_expr attaches to a legacy ieee_* node that

--- a/src/python-frontend/python_expr_builder.h
+++ b/src/python-frontend/python_expr_builder.h
@@ -91,6 +91,11 @@ exprt build_bitand(const exprt &a, const exprt &b, const typet &t);
 exprt build_bitor(const exprt &a, const exprt &b, const typet &t);
 exprt build_bitxor(const exprt &a, const exprt &b, const typet &t);
 
+// `a << b` (shl2t) / `a >> b` arithmetic (ashr2t) : t. The Python frontend maps
+// RShift to ashr unconditionally; both lower over the migrated operands.
+exprt build_shl(const exprt &a, const exprt &b, const typet &t);
+exprt build_ashr(const exprt &a, const exprt &b, const typet &t);
+
 // Float `a + b`/`a - b`/`a * b : t` over same-floatbv operands, using the
 // default __ESBMC_rounding_mode (matching migrate of a legacy ieee_* node with
 // no rounding_mode field). ieee_*2t assert operand-width consistency.

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -49,6 +49,17 @@ public:
   const type2tc &get_type2() const;
   const expr2tc &get_value2() const;
 
+  // True iff the IREP2 value is the authoritative form (written via the
+  // expr2tc setter), so get_value2() returns it directly without a lazy
+  // migration from the legacy exprt. Lets a pass honour the lazy split (see
+  // the class comment above): reading the IREP2 side of a legacy-valued symbol
+  // would force-migrate sub-expressions the frontend left with unresolved tags
+  // -- a latent hole the design tolerates only while nothing reads that side.
+  bool has_native_value2() const
+  {
+    return value2_valid_;
+  }
+
   // Type setters. Each writes one side and invalidates the other; the read
   // side derives lazily on first access (with the nil/empty-id case guarded
   // inside the readers).


### PR DESCRIPTION
Part V Phase V.1k (b) B.4 — flip integer **shifts** (LShift/RShift). Stacked on #5645.

First op family added after the #5645 consolidation — a one-line-per-op addition to the helper, as designed. New `python_expr::build_shl`/`build_ashr` (the frontend maps `RShift`->`ashr` unconditionally). **Flag off => byte-identical.**

## Width handling

Same exact-type-match guard, which restricts the flip to the **equal-width** case `shl2t`/`ashr2t` accept; mismatched-width shifts (the general case the consolidation note flagged) fall through to the legacy node.

## Verification

- RV2 Bitwuzla half: **0 divergences** flag on vs off over 65 class/arith + 70 broad tests.
- **Swap-probe** (`shl`->`ashr`) made `(s.x << s.n) == 12` verify FAILED, confirming the branch fires. Z3 half in CI.
- `regression/python/shift_member_adjust{,_fail}` pin the flipped path; CPython sanity OK; flag on/off agree.

The integer/float arith, all comparisons, bitwise, and shift binop surface is now flipped behind the flag.

Refs #4715. Stacked on #5645.