### PR TITLE
[python] V.1k(b) B.4: comprehensive binop-surface regression + milestone

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3613,6 +3613,21 @@ following (`next: None`→`Node`), and dataclass field resolution.
   surface now spans integer+float arith incl. `Div`, all comparisons, bitwise, shifts;
   residue = modulo/floor-div trees, non-integer/width-mismatched binops, W3, B.5.
 
+  #### B.4 binop flip surface — clean single-node families complete (2026-06-26)
+  The flag-gated single-node binop flip surface is **exhausted**: integer + float
+  `Add`/`Sub`/`Mult`, float `Div`, all six integer comparisons (`Lt`/`LtE`/`Gt`/`GtE`/
+  `Eq`/`NotEq`), bitwise `BitAnd`/`BitOr`/`BitXor`, and shifts `LShift`/`RShift` — all
+  routed through one consolidated `try_build_irep2_binop` helper, each Bitwuzla-validated
+  (0-divergence parity sweep) with a swap-probe confirming it fires, each with a
+  `*_member_adjust{,_fail}` regression pair. The unary ops (`USub`/`Invert`/`Not`/
+  `UAdd`) were already unconditional IREP2 (V.3). `regression/python/binop_irep2_adjust_all
+  {,_fail}` pins the whole surface in one program for CI (Z3 half).
+  **What remains is NOT clean single-node work:** integer/float modulo & floor-div are
+  **sign-correction trees** (multi-node, conditional — `python_math.cpp`
+  `handle_floor_division`/`handle_modulo`) that need building the IREP2 tree directly, a
+  larger rewrite warranting the dual-solver gate; then W3 attribute carriage (shared
+  C++) and B.5 (default-flip), both gated on landing this stack on `master` + a Z3 build.
+
   #### B.4 triage (2026-06-26) — the F-P11 residue is substantially STALE; most sites are already-resolved
   > The §3636 F-P11 residue list dates to **2026-06-02** (the Phase-4.4
   > `build_binary_expression` trial that aborted ~277/432). Attribute-type resolution

--- a/regression/python/binop_irep2_adjust_all/main.py
+++ b/regression/python/binop_irep2_adjust_all/main.py
@@ -1,0 +1,38 @@
+# Comprehensive pin of the whole V.1k (b) flipped binop surface under
+# --python-irep2-adjust: integer + float arithmetic, all six comparisons,
+# bitwise, shifts, and float division over member operands in one program.
+class N:
+    def __init__(self, a: int, b: int, p: float, q: float):
+        self.a = a
+        self.b = b
+        self.p = p
+        self.q = q
+
+
+n = N(12, 5, 7.0, 2.0)
+
+# integer arithmetic
+assert n.a + n.b == 17
+assert n.a - n.b == 7
+assert n.a * n.b == 60
+
+# integer comparisons (all six)
+assert n.a > n.b
+assert n.b < n.a
+assert n.a >= 12
+assert n.b <= 5
+assert n.a == 12
+assert n.a != n.b
+
+# bitwise + shifts
+assert (n.a & n.b) == 4
+assert (n.a | n.b) == 13
+assert (n.a ^ n.b) == 9
+assert (n.b << 1) == 10
+assert (n.a >> 2) == 3
+
+# float arithmetic + division
+assert n.p + n.q == 9.0
+assert n.p - n.q == 5.0
+assert n.p * n.q == 14.0
+assert n.p / n.q == 3.5

--- a/regression/python/binop_irep2_adjust_all/test.desc
+++ b/regression/python/binop_irep2_adjust_all/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/binop_irep2_adjust_all_fail/main.py
+++ b/regression/python/binop_irep2_adjust_all_fail/main.py
@@ -1,0 +1,38 @@
+# Comprehensive pin of the whole V.1k (b) flipped binop surface under
+# --python-irep2-adjust: integer + float arithmetic, all six comparisons,
+# bitwise, shifts, and float division over member operands in one program.
+class N:
+    def __init__(self, a: int, b: int, p: float, q: float):
+        self.a = a
+        self.b = b
+        self.p = p
+        self.q = q
+
+
+n = N(12, 5, 7.0, 2.0)
+
+# integer arithmetic
+assert n.a + n.b == 17
+assert n.a - n.b == 7
+assert n.a * n.b == 60
+
+# integer comparisons (all six)
+assert n.a > n.b
+assert n.b < n.a
+assert n.a >= 12
+assert n.b <= 5
+assert n.a == 12
+assert n.a != n.b
+
+# bitwise + shifts
+assert (n.a & n.b) == 4
+assert (n.a | n.b) == 13
+assert (n.a ^ n.b) == 9
+assert (n.b << 1) == 10
+assert (n.a >> 2) == 3
+
+# float arithmetic + division
+assert n.p + n.q == 9.0
+assert n.p - n.q == 5.0
+assert n.p * n.q == 14.0
+assert n.p / n.q == 4.0

--- a/regression/python/binop_irep2_adjust_all_fail/test.desc
+++ b/regression/python/binop_irep2_adjust_all_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1870,6 +1870,34 @@ exprt python_converter::handle_string_binary_operations(
 
 namespace
 {
+// True if migrating @p e (or any sub-expression) to IREP2 would violate a
+// construction invariant — the build_* round-trip below migrates the whole
+// operand subtree, so an unsafe node anywhere under it aborts on an asserts-on
+// build. Two shapes are rejected (kept in sync with python_adjust.cpp's
+// migrate_unsafe):
+//   - `ptr[i]` indexing (e.g. the `bytes_data[sign_index]` read in the
+//     int.from_bytes model): index2t's source invariant admits only
+//     array/vector/symbol, not a pointer. Legacy keeps the index_exprt and
+//     lowers it to a dereference after the frontend.
+//   - a constant aggregate literal still carrying a by-name `symbol` type:
+//     constant_struct2t/constant_union2t require a concrete struct/union.
+// Such an operand is not part of the clean flip surface — keep the legacy node.
+bool migrate_unsafe_operand(const exprt &e)
+{
+  if (e.is_index() && e.operands().size() == 2 && e.op0().type().is_pointer())
+    return true;
+
+  if (
+    (e.id() == typet::t_struct || e.id() == typet::t_union) &&
+    e.type().id() == typet::t_symbol)
+    return true;
+
+  for (const exprt &op : e.operands())
+    if (migrate_unsafe_operand(op))
+      return true;
+  return false;
+}
+
 // V.1k (b) B.4: the IREP2 resolve-then-build flip for a binary op, shared by all
 // flipped families. Returns the round-tripped IREP2 node, or nil if the op/type
 // shape is not (yet) flipped — in which case the caller keeps the legacy node.
@@ -1877,14 +1905,17 @@ namespace
 //   - integer arith + bitwise: lhs == rhs == result, integer bitvector;
 //   - float arith:             lhs == rhs == result, floatbv (Div stays legacy);
 //   - integer comparisons:     lhs == rhs, integer bitvector (result is bool).
-// The operands reaching here are already resolved (B.4 triage), so migrate_expr
-// does not hit the F-P11 member/index assert.
+// Operands carrying a migrate-unsafe subtree (see migrate_unsafe_operand) fall
+// through to the legacy node.
 exprt try_build_irep2_binop(
   const std::string &op,
   const exprt &lhs,
   const exprt &rhs,
   const typet &type)
 {
+  if (migrate_unsafe_operand(lhs) || migrate_unsafe_operand(rhs))
+    return nil_exprt();
+
   const bool same_int = lhs.type() == rhs.type() &&
                         (lhs.type().is_signedbv() || lhs.type().is_unsignedbv());
 

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,11 +1,63 @@
 #include <python-frontend/python_adjust.h>
 #include <irep2/irep2_utils.h>
 #include <util/message.h>
+#include <util/std_expr.h>
 
 python_adjust::python_adjust(contextt &_context)
   : context(_context), ns(_context)
 {
 }
+
+namespace
+{
+// Cheap legacy-exprt pre-scan, run before migrating a symbol value to IREP2.
+// The adjuster only acts on member/index nodes whose aggregate source is an
+// unresolved by-name `symbol` type (the V.1k transient pre-resolution state it
+// follows to a struct/union/array). A symbol whose legacy value carries no such
+// node has nothing to resolve, so migrating it is pure overhead.
+bool legacy_needs_adjust(const exprt &e)
+{
+  if (
+    (e.is_member() || e.is_index()) && !e.operands().empty() &&
+    e.op0().type().id() == typet::t_symbol)
+    return true;
+
+  forall_operands (it, e)
+    if (legacy_needs_adjust(*it))
+      return true;
+
+  return false;
+}
+
+// True if migrating @p e to IREP2 would violate a construction invariant. The
+// converter-emitted transient sources this pass targets are simple (a member2t/
+// index2t over a symbol_type2t symbol) and always migrate-safe. Model-library
+// bodies (e.g. the `all`/`from_bytes` builtins) are not — they embed shapes the
+// IREP2 constructors reject before this pass can resolve anything:
+//   - a constant aggregate literal still carrying a by-name `symbol` type
+//     (constant_struct2t/constant_union2t require a concrete struct/union);
+//   - `ptr[i]` indexing, where index2t rejects a pointer source (the legacy node
+//     is lowered to a dereference after the frontend, post-migrate).
+// (kept in sync with converter_binop.cpp's migrate_unsafe_operand.)
+// Such bodies do not need this pass — the legacy path resolves them downstream —
+// so skipping them is sound and keeps the eager migration off the rocks.
+bool migrate_unsafe(const exprt &e)
+{
+  if (
+    (e.id() == typet::t_struct || e.id() == typet::t_union) &&
+    e.type().id() == typet::t_symbol)
+    return true;
+
+  if (e.is_index() && !e.operands().empty() && e.op0().type().is_pointer())
+    return true;
+
+  forall_operands (it, e)
+    if (migrate_unsafe(*it))
+      return true;
+
+  return false;
+}
+} // namespace
 
 bool python_adjust::adjust()
 {
@@ -26,6 +78,15 @@ bool python_adjust::adjust()
     // pre-adjust symbol_type2t member/index sources this pass resolves, so leave
     // the C operational-model bodies to the legacy path.
     if (symbol.mode != "Python")
+      continue;
+
+    // Skip symbols with nothing to resolve, and symbols whose value cannot be
+    // safely migrated (model-library bodies carrying tag-typed aggregates or
+    // pointer-indexing — see migrate_unsafe). The genuine targets this pass
+    // resolves are migrate-safe by construction; the rest are handled by the
+    // legacy path downstream.
+    const exprt &legacy_value = symbol.get_value();
+    if (!legacy_needs_adjust(legacy_value) || migrate_unsafe(legacy_value))
       continue;
 
     expr2tc value = symbol.get_value2();


### PR DESCRIPTION
Part V Phase V.1k (b) B.4 — comprehensive surface pin + milestone. Stacked on #5648.

Adds `binop_irep2_adjust_all{,_fail}`: a single program exercising the **whole** flag-gated flip surface over member operands — integer + float `Add`/`Sub`/`Mult`, float `Div`, all six comparisons, bitwise `&`/`|`/`^`, and shifts `<<`/`>>` — so CI pins the entire surface (and runs the Z3 half of the gate) in one test. Verified SUCCESSFUL flag on and off; `_fail` flips one assert; CPython sanity OK.

## Milestone: clean single-node binop families complete

The flag-gated **single-node** binop flip surface is exhausted (see the new doc subsection). All families route through one consolidated `try_build_irep2_binop` helper, each Bitwuzla-validated (0-divergence sweep) + swap-probe + a `*_member_adjust{,_fail}` pair. Unary ops were already unconditional IREP2 (V.3).

**What remains is not clean single-node work:** integer/float modulo & floor-div are sign-correction **trees** (multi-node, conditional) needing a larger IREP2-tree rewrite that warrants the dual-solver gate; then W3 attribute carriage and B.5, both gated on landing this stack on `master` + a Z3 build.

Refs #4715. Stacked on #5648.