### PR TITLE
[om] fclose: free only heap streams so fclose(stdout) is sound

### DIFF
--- a/regression/esbmc/github_5565_fclose_double_free_fail/main.c
+++ b/regression/esbmc/github_5565_fclose_double_free_fail/main.c
@@ -1,0 +1,16 @@
+/* #5565 boundary: skipping free() for non-heap streams must not weaken
+ * double-free detection.  An fopen'd stream is heap memory, so closing it
+ * twice must still be caught -- the __ESBMC_is_dynamic guard suppresses the
+ * free only for streams ESBMC never allocated, not for fopen'd ones. */
+#include <stdio.h>
+
+int main(void)
+{
+  FILE *f = fopen("x", "r");
+  if (f)
+  {
+    fclose(f);
+    fclose(f); /* double close of a heap stream -> double free */
+  }
+  return 0;
+}

--- a/regression/esbmc/github_5565_fclose_double_free_fail/test.desc
+++ b/regression/esbmc/github_5565_fclose_double_free_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success
+^VERIFICATION FAILED$
+\bdereference failure: invalidated dynamic object freed\b

--- a/regression/esbmc/github_5565_fclose_stdout/main.c
+++ b/regression/esbmc/github_5565_fclose_stdout/main.c
@@ -1,0 +1,13 @@
+/* #5565: fclose() on a standard stream must not report "invalid pointer
+ * freed".  stdin/stdout/stderr are not heap objects, but the fclose model
+ * called free(stream) unconditionally (outside SV-COMP), so closing stdout --
+ * exactly what coreutils' close_stdout atexit handler does -- raised a
+ * spurious "invalid pointer freed".  fclose(stdout) is well-defined C. */
+#include <stdio.h>
+
+int main(void)
+{
+  fclose(stdout);
+  fclose(stderr);
+  return 0;
+}

--- a/regression/esbmc/github_5565_fclose_stdout/test.desc
+++ b/regression/esbmc/github_5565_fclose_stdout/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/io.c
+++ b/src/c2goto/library/io.c
@@ -112,7 +112,13 @@ int fclose(FILE *stream)
 __ESBMC_HIDE:;
   // Don't clear pending state here - let it remain for verification.
   // Mirror fopen: in SV-COMP mode the stream is a sentinel, not heap memory.
-  if (!__ESBMC_sv_comp())
+  // Outside SV-COMP, only release storage we actually allocated on the heap
+  // (fopen/fdopen).  The standard streams stdin/stdout/stderr are not heap
+  // objects, so free()ing them would spuriously report "invalid pointer
+  // freed" even though fclose(stdout) is well-defined.  Guarding on
+  // __ESBMC_is_dynamic keeps a genuine double-fclose of an fopen'd stream
+  // detectable as a double free (the flag stays set after free()).
+  if (!__ESBMC_sv_comp() && __ESBMC_is_dynamic[__ESBMC_POINTER_OBJECT(stream)])
     free(stream);
   return nondet_int();
 }


### PR DESCRIPTION
## What

Guard the `free(stream)` in ESBMC's `fclose` operational model so it only releases streams ESBMC actually allocated on the heap (`fopen`/`fdopen`):

```c
if (!__ESBMC_sv_comp() && __ESBMC_is_dynamic[__ESBMC_POINTER_OBJECT(stream)])
  free(stream);
```

## Why

Outside SV-COMP mode `fclose` called `free(stream)` unconditionally. The standard streams `stdin`/`stdout`/`stderr` are not heap objects (`stdout` resolves to `invalid-object`), so closing one — exactly what coreutils' `close_stdout` `atexit` handler does — raised a spurious `dereference failure: invalid pointer freed`. `fclose(stdout)` is well-defined C.

This is the residual that surfaces on `coreutils-v8.31/comm_3args_ok` (valid-memsafety, #5565/#5138) after the upstream layers are cleared: the plain (non-`--sv-comp`) run fails at `k = 11` via `close_stream → fclose` (`io.c:116`).

## Why it is sound

- Only `fopen`/`fdopen`'d streams (which set `__ESBMC_is_dynamic` at allocation) are freed; non-heap streams are skipped.
- A genuine **double-`fclose`** of a heap stream is still caught: `__ESBMC_is_dynamic` stays set after `free` (only the *valid* bit is cleared), so the second `fclose` re-runs `free` → `invalidated dynamic object freed`.
- `__ESBMC_is_dynamic` is infinite-size, so indexing by any object number (incl. NULL/static) is in-bounds and returns `false` for non-heap pointers.

## Validation

- `fclose(stdout)` / `fclose(stderr)`: `invalid pointer freed` FAILED → **SUCCESSFUL**.
- `fopen` + `fclose` heap stream under `--memory-leak-check`: SUCCESSFUL (stream is freed, no leak).
- double-`fclose` of an `fopen`'d stream: **FAILED** (`invalidated dynamic object freed`).
- Dual-solver **z3 + bitwuzla agree** on both new tests; **0 regressions** across 27 existing `fclose`/`fopen` tests.

## Tests

- `regression/esbmc/github_5565_fclose_stdout` — `fclose(stdout)`/`fclose(stderr)` safe ⇒ SUCCESSFUL (the fixed false positive).
- `regression/esbmc/github_5565_fclose_double_free_fail` — double-close of an `fopen`'d stream ⇒ FAILED (pins that the guard does not weaken double-free detection).

## Scope — the `strcmp` residual is *not* fixed here

#5565 names two residuals. This PR fixes the `fclose` one. The `strcmp` invalid-pointer residual does **not** independently reproduce on the benchmark after this fix (the `--sv-comp` run times out *soundly*, no violation). Root cause is a **general argv-model under-approximation** in `clang_c_main.cpp`: only `--argv-max-args` (default **2**) argv strings are materialised as valid, while `argc` ranges up to ~`MAX-1`, leaving `argv[max_args..argc-1]` invalid — so `strcmp(argv[i], …)` for `i ≥ max_args` can false-positive.

The obvious fix `assume(argc <= max_args)` was implemented and tested, and is **unsound**: it makes any `argc > max_args` path vacuous (UNSAT ⇒ vacuous SUCCESSFUL). It broke `github_2312_4` (`__ESBMC_assume(argc == 10)`) and `25_git-remote-gitkrb5` (bug needs `argc == 3`), and would make `comm_3args_ok`'s own proof vacuous (it needs `argc ≈ 4`). It was reverted. A sound fix is research-grade (quantifier- or solver-aware argv materialisation; quantifiers are deliberately avoided in the model for Boolector compatibility), so **#5565 stays open** for that layer.

Refs #5565.
