### PR TITLE
[python] Return user-class instances by reference (#3067)

### DIFF
--- a/regression/python/github_3067_return_reference/main.py
+++ b/regression/python/github_3067_return_reference/main.py
@@ -1,0 +1,34 @@
+# A function returning a user-defined class instance returns a *reference*
+# (pointer) to a heap object, matching CPython. The returned object outlives
+# the callee frame and preserves identity/aliasing across the call boundary.
+class Node:
+    def __init__(self, value: int) -> None:
+        self.value = value
+        self.next = None
+
+
+def make(v: int) -> Node:
+    # Constructor used directly as a return value: must escape to the heap.
+    return Node(v)
+
+
+def identity(n: Node) -> Node:
+    # Returning a parameter must return the same object, not a copy.
+    return n
+
+
+a = make(7)
+b = a                 # aliasing: two names, one object
+b.value = 100
+assert a.value == 100  # mutation through b is visible through a
+assert a is b
+
+c = identity(a)
+c.value = 55
+assert a.value == 55   # c aliases a
+assert c is a
+
+# A returned object can link to another returned object and survive the frame.
+head = make(1)
+head.next = make(2)
+assert head.next.value == 2

--- a/regression/python/github_3067_return_reference/test.desc
+++ b/regression/python/github_3067_return_reference/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3067_return_reference_fail/main.py
+++ b/regression/python/github_3067_return_reference_fail/main.py
@@ -1,0 +1,16 @@
+# Negative variant of github_3067_return_reference: the returned object is a
+# reference, so mutating it through one alias is observed through the other.
+# The assertion below contradicts that and must be detected as a violation.
+class Node:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+
+def make(v: int) -> Node:
+    return Node(v)
+
+
+a = make(7)
+b = a
+b.value = 100
+assert a.value == 7  # wrong: a aliases b, so a.value is 100

--- a/regression/python/github_3067_return_reference_fail/test.desc
+++ b/regression/python/github_3067_return_reference_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 2
+^\s*assertion a->value == 7$
+^VERIFICATION FAILED$

--- a/regression/python/github_3067_return_reference_forward/main.py
+++ b/regression/python/github_3067_return_reference_forward/main.py
@@ -1,0 +1,28 @@
+# Forward-reference variant of github_3067_return_reference: a function that
+# returns a user-defined class instance is *defined after* its caller, so the
+# call resolves through the forward-reference path. The callee's class return
+# must still be migrated to a reference (Cls*); resolving it by value crashed
+# the backend with a struct-vs-pointer irep2_cast_error on `return f(...)`.
+class Node:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+
+def wrap(v: int) -> Node:
+    # `make` is defined later in the module: forward reference in return pos.
+    return make(v)
+
+
+def make(v: int) -> Node:
+    return Node(v)
+
+
+a = wrap(7)
+b = a                 # aliasing: two names, one object
+b.value = 100
+assert a.value == 100  # mutation through b is visible through a
+assert a is b
+
+# Forward reference in assignment position resolves to the same reference.
+c = wrap(3)
+assert c.value == 3

--- a/regression/python/github_3067_return_reference_forward/test.desc
+++ b/regression/python/github_3067_return_reference_forward/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3067_return_reference_none/main.py
+++ b/regression/python/github_3067_return_reference_none/main.py
@@ -1,0 +1,21 @@
+# A `-> Cls` function that also returns None on some path: because instances
+# are now Cls* references and None is the NULL pointer, such a return is already
+# nullable and must NOT be re-wrapped in Optional. The returned reference is
+# either a live object or None, distinguishable with `is None`.
+class Node:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+
+def maybe(v: int) -> Node:
+    if v > 0:
+        return Node(v)
+    return None
+
+
+a = maybe(5)
+assert a is not None
+assert a.value == 5
+
+b = maybe(-1)
+assert b is None

--- a/regression/python/github_3067_return_reference_none/test.desc
+++ b/regression/python/github_3067_return_reference_none/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -1229,14 +1229,20 @@ void python_converter::get_function_definition(
   // the alternatives and overrides that call-site resolution (e.g. a
   // `Literal["bar"] -> Bar` overload would be mis-typed as `Foo*`, #3057). The
   // real implementation (a union return) is typed `void*` and never reaches
-  // this branch.
-  if (
-    is_user_class_struct_type(type.return_type()) &&
-    !json_utils::has_overload_decorator(function_node))
-  {
-    type.return_type() = gen_pointer_type(type.return_type());
+  // this branch. The same migration is applied below to a return type recovered
+  // by post-annotation inference (e.g. `return self`).
+  auto migrate_user_class_return = [&](typet &t) -> bool {
+    if (
+      is_user_class_struct_type(t) &&
+      !json_utils::has_overload_decorator(function_node))
+    {
+      t = gen_pointer_type(t);
+      return true;
+    }
+    return false;
+  };
+  if (migrate_user_class_return(type.return_type()))
     current_element_type = type.return_type();
-  }
 
   // Create and register function symbol
   symbolt symbol = create_symbol(
@@ -1319,6 +1325,15 @@ void python_converter::get_function_definition(
   if (type.return_type().is_empty())
   {
     typet inferred_type = infer_return_type_from_body(function_node["body"]);
+    // Stage 1 object-model migration (#3067): an unannotated function whose
+    // body returns a user class instance (e.g. `return self` in __getitem__,
+    // #4514) is inferred to the value struct here — apply the same Cls* ->
+    // reference migration as the annotated path, so the declared return type
+    // matches the pointer the body actually returns. Without this, the callee
+    // returns a `Cls*` (self/param) while its declared return type is the value
+    // struct, and the assignment binds a pointer into a struct slot, tripping
+    // value-set's make_member assertion at the field read.
+    migrate_user_class_return(inferred_type);
     if (!inferred_type.is_empty())
     {
       type.return_type() = inferred_type;

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -1213,6 +1213,31 @@ void python_converter::get_function_definition(
   // Process function arguments
   process_function_arguments(function_node, type, id, location);
 
+  // Stage 1 object-model migration (#3067): a function returning a user-defined
+  // class instance returns a *reference* (pointer) to the heap object, matching
+  // CPython and the pointer representation already used for locals, parameters
+  // and `self`. Returning by value copied the struct out of the callee frame,
+  // which (a) breaks identity/aliasing across the call (`y = f(x); y.v = 1`
+  // would not be observed through `x`) and (b) forces a pointer->value
+  // dereference on `return self`/`return param` that crashes the SMT backend
+  // with a sort mismatch. None is encoded as a NULL pointer, so such a return
+  // is already nullable and must not be re-wrapped in Optional below.
+  //
+  // Skip @overload stubs: each carries a single-class annotation (`-> Foo`),
+  // but the overload set is polymorphic — the effective return type is resolved
+  // per call site from the argument types. Migrating a stub to one Class* loses
+  // the alternatives and overrides that call-site resolution (e.g. a
+  // `Literal["bar"] -> Bar` overload would be mis-typed as `Foo*`, #3057). The
+  // real implementation (a union return) is typed `void*` and never reaches
+  // this branch.
+  if (
+    is_user_class_struct_type(type.return_type()) &&
+    !json_utils::has_overload_decorator(function_node))
+  {
+    type.return_type() = gen_pointer_type(type.return_type());
+    current_element_type = type.return_type();
+  }
+
   // Create and register function symbol
   symbolt symbol = create_symbol(
     module_name, current_func_name_, id.to_string(), location, type);
@@ -1254,7 +1279,7 @@ void python_converter::get_function_definition(
   };
 
   bool already_optional =
-    annotation_is_optional ||
+    annotation_is_optional || is_user_class_pointer(type.return_type()) ||
     (type.return_type().is_struct() && to_struct_type(type.return_type())
                                          .tag()
                                          .as_string()

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1657,6 +1657,47 @@ std::string python_converter::flow_rhs_class(const nlohmann::json &rhs) const
   return "";
 }
 
+std::string python_converter::call_return_class(const nlohmann::json &rhs) const
+{
+  if (
+    !rhs.is_object() || rhs.value("_type", "") != "Call" ||
+    !rhs.contains("func") || !rhs["func"].is_object() ||
+    rhs["func"].value("_type", "") != "Name" || !rhs["func"].contains("id") ||
+    !rhs["func"]["id"].is_string())
+    return "";
+
+  // Constructor calls (`Cls(...)`) are handled by the dedicated path above.
+  const std::string fname = rhs["func"]["id"].get<std::string>();
+  if (json_utils::is_class(fname, *ast_json))
+    return "";
+
+  const auto &fn = json_utils::find_function((*ast_json)["body"], fname);
+  if (fn.empty() || !fn.contains("returns") || fn["returns"].is_null())
+    return "";
+
+  // An @overload stub carries a single-class annotation (`-> Foo`) but the
+  // overload set is polymorphic — the real return type is resolved per call
+  // site from the argument types. find_function returns the first stub, so
+  // trusting its annotation would mis-type, e.g., a `Literal["bar"] -> Bar`
+  // result as `Foo*` (#3057). Leave such results to the existing call-site
+  // overload resolution rather than forcing a single Class* here.
+  if (json_utils::has_overload_decorator(fn))
+    return "";
+
+  // The return annotation may be a bare Name (`-> Cls`) or a forward-reference
+  // string (`-> "Cls"`).
+  const auto &ret = fn["returns"];
+  std::string cls;
+  if (ret.value("_type", "") == "Name" && ret.contains("id"))
+    cls = ret["id"].get<std::string>();
+  else if (
+    ret.value("_type", "") == "Constant" && ret.contains("value") &&
+    ret["value"].is_string())
+    cls = ret["value"].get<std::string>();
+
+  return json_utils::is_class(cls, *ast_json) ? cls : std::string();
+}
+
 void python_converter::get_var_assign(
   const nlohmann::json &ast_node,
   codet &target_block)
@@ -1707,6 +1748,17 @@ void python_converter::get_var_assign(
       cls = ast_node["value"]["func"]["id"].get<std::string>();
     else
       cls = flow_rhs_class(ast_node["value"]); // aliasing: `b = a`
+    // `y = f(...)` where f returns a class: type y as `Cls*` so the returned
+    // reference is bound (not value-copied into a struct local).
+    if (cls.empty())
+      cls = call_return_class(ast_node["value"]);
+    // A target explicitly annotated as a user class (`v: Cls = ...`) is an
+    // instance reference too. This covers RHS shapes the cases above miss —
+    // notably method calls `v: Cls = obj.method()` returning a class — so the
+    // result binds as a `Cls*` pointer instead of being value-copied into a
+    // struct slot (which mismatches the pointer the callee now returns).
+    if (cls.empty() && json_utils::is_class(lhs_type, *ast_json))
+      cls = lhs_type;
     if (!cls.empty())
     {
       typet st = type_handler_.get_typet(cls);
@@ -1773,7 +1825,10 @@ void python_converter::get_var_assign(
             ++it;
         }
       }
-      const std::string cls = flow_rhs_class(ast_node["value"]);
+      std::string cls = flow_rhs_class(ast_node["value"]);
+      if (cls.empty())
+        cls =
+          call_return_class(ast_node["value"]); // `v = f()` returning a class
       if (!cls.empty())
         flow_class_map_[path] = cls;
       else
@@ -3547,30 +3602,43 @@ void python_converter::get_return_statements(
       }
     }
 
-    // When returning a class-typed parameter (internally A*), dereference it
-    // so the return type matches the annotation (A).  This is needed because
-    // user-defined class parameters are modelled as pointers internally for
-    // Python object reference semantics, but callers expect a value return.
-    if (return_value.type().is_pointer())
+    // `return ClassName(...)` lowers to a stack-local `$ctor_self$` *value*
+    // struct (function_call_expr's no-LHS constructor path), but the function
+    // now returns a class *reference* (Cls*). Box the constructed value onto a
+    // fresh non-expiring heap object and return the pointer, so the result
+    // survives the callee frame with reference identity (#3067) — the same
+    // model as `o = ClassName(...)`. Returning `&$ctor_self$` would instead
+    // hand back a dangling stack address.
+    if (
+      is_user_class_pointer(current_func_return_type_) &&
+      is_user_class_struct_type(return_value.type()))
     {
-      typet ret_sub = return_value.type().subtype();
-      typet expected = current_func_return_type_;
-      if (ret_sub.id() == "symbol")
-        ret_sub = ns.follow(ret_sub);
-      if (expected.id() == "symbol")
-        expected = ns.follow(expected);
-      if (ret_sub.is_struct() && expected.is_struct())
-      {
-        const struct_typet &rs = to_struct_type(ret_sub);
-        const struct_typet &es = to_struct_type(expected);
-        if (rs.tag() == es.tag())
-        {
-          exprt deref("dereference");
-          deref.type() = return_value.type().subtype();
-          deref.copy_to_operands(return_value);
-          return_value = deref;
-        }
-      }
+      const symbolt *new_obj_sym =
+        symbol_table_.find_symbol("c:@F@__ESBMC_new_object");
+      assert(new_obj_sym && "__ESBMC_new_object model required");
+
+      symbolt heap_symbol = create_return_temp_variable(
+        current_func_return_type_, location, "ctor_box");
+      symbol_table_.add(heap_symbol);
+      exprt heap_ptr = symbol_expr(heap_symbol);
+
+      code_declt heap_decl(heap_ptr);
+      heap_decl.location() = location;
+      target_block.copy_to_operands(heap_decl);
+
+      code_function_callt alloc_call;
+      alloc_call.lhs() = heap_ptr;
+      alloc_call.function() = symbol_expr(*new_obj_sym);
+      alloc_call.location() = location;
+      target_block.copy_to_operands(alloc_call);
+
+      exprt deref("dereference", current_func_return_type_.subtype());
+      deref.copy_to_operands(heap_ptr);
+      code_assignt store(deref, return_value);
+      store.location() = location;
+      target_block.copy_to_operands(store);
+
+      return_value = heap_ptr;
     }
 
     // Wrap return value in Optional if the function returns Optional

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1298,6 +1298,28 @@ void python_converter::handle_function_call_rhs(
     }
   }
 
+  // Stage 1 object-model migration (#3067): the callee now returns a class
+  // *reference* (`Cls*`), but the assignment target may still have been typed
+  // as the value struct `Cls` — the annotator infers a value-struct type for an
+  // RHS it cannot see through (an imported function, or a subscript dispatching
+  // to `__getitem__` that returns `self`). Binding `rhs.op0() = lhs` then stores
+  // a pointer into a struct slot, and the later `lhs.field` read trips
+  // value-set's make_member assertion (#4513/#4514, transitive-imports). Retype
+  // the target to the returned `Cls*` so the reference is bound directly and the
+  // field read auto-dereferences, matching the other migrated assignment paths.
+  // Restricted to a plain symbol target (`x = ...`): for a subscript/attribute
+  // target `lhs_symbol` is the *container/base* symbol while `lhs` is the
+  // element/member expression, so retyping `lhs_symbol` would corrupt the whole
+  // container — the sibling migrations guard on a Name target for the same
+  // reason.
+  if (
+    !is_ctor_call && lhs_symbol && lhs.is_symbol() &&
+    is_user_class_pointer(rhs.type()) && is_user_class_struct_type(lhs.type()))
+  {
+    lhs.type() = rhs.type();
+    lhs_symbol->set_type(rhs.type());
+  }
+
   // Set return destination
   if (rhs.type().is_pointer() && !is_ctor_call)
   {
@@ -3453,8 +3475,8 @@ exprt python_converter::box_value_on_heap(
     symbol_table_.find_symbol("c:@F@__ESBMC_new_object");
   assert(new_obj_sym && "__ESBMC_new_object model required");
 
-  symbolt heap_symbol =
-    create_return_temp_variable(current_func_return_type_, location, "ctor_box");
+  symbolt heap_symbol = create_return_temp_variable(
+    current_func_return_type_, location, "ctor_box");
   symbol_table_.add(heap_symbol);
   exprt heap_ptr = symbol_expr(heap_symbol);
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1752,12 +1752,28 @@ void python_converter::get_var_assign(
     // reference is bound (not value-copied into a struct local).
     if (cls.empty())
       cls = call_return_class(ast_node["value"]);
-    // A target explicitly annotated as a user class (`v: Cls = ...`) is an
-    // instance reference too. This covers RHS shapes the cases above miss —
-    // notably method calls `v: Cls = obj.method()` returning a class — so the
-    // result binds as a `Cls*` pointer instead of being value-copied into a
-    // struct slot (which mismatches the pointer the callee now returns).
-    if (cls.empty() && json_utils::is_class(lhs_type, *ast_json))
+    // A target *explicitly annotated* as a user class (`v: Cls = obj.method()`)
+    // is an instance reference too: bind it as `Cls*` so a migrated class
+    // return is not value-copied into a struct slot (which mismatches the
+    // pointer the callee now returns and trips value-set's make_member
+    // assertion). This is the only path covering an annotated *method*-call
+    // return — call_return_class above handles only plain `Name` function calls.
+    //
+    // Gate on the *resolved* annotation type via is_user_class_struct_type — the
+    // same predicate the funcdef return migration uses — not on the annotation
+    // *name* through json_utils::is_class: the latter also matches the built-in
+    // model classes `Tuple`/`List`/`int`, so `coord: Coordinate`
+    // (= `Tuple[int, int]`) would be mistyped as a pointer-to-tuple and fault on
+    // read. And require a *user-written* annotation: the annotator injects an
+    // inferred `annotation` on plain assignments, naming a class for an RHS that
+    // yields no instance — `_ = B() + B()` infers `B` though `__add__` returns
+    // an int, `b = create("bar")` infers an overload's `Bar` though the callee
+    // returns a value (#3057/#3091/#3286/#3921).
+    if (
+      cls.empty() && ast_node.contains("annotation") &&
+      !ast_node["annotation"].is_null() &&
+      !ast_node.value("_inferred_annotation", false) &&
+      is_user_class_struct_type(current_element_type))
       cls = lhs_type;
     if (!cls.empty())
     {
@@ -3428,6 +3444,39 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
 
   return code;
 }
+exprt python_converter::box_value_on_heap(
+  const exprt &value,
+  const locationt &location,
+  codet &target_block)
+{
+  const symbolt *new_obj_sym =
+    symbol_table_.find_symbol("c:@F@__ESBMC_new_object");
+  assert(new_obj_sym && "__ESBMC_new_object model required");
+
+  symbolt heap_symbol =
+    create_return_temp_variable(current_func_return_type_, location, "ctor_box");
+  symbol_table_.add(heap_symbol);
+  exprt heap_ptr = symbol_expr(heap_symbol);
+
+  code_declt heap_decl(heap_ptr);
+  heap_decl.location() = location;
+  target_block.copy_to_operands(heap_decl);
+
+  code_function_callt alloc_call;
+  alloc_call.lhs() = heap_ptr;
+  alloc_call.function() = symbol_expr(*new_obj_sym);
+  alloc_call.location() = location;
+  target_block.copy_to_operands(alloc_call);
+
+  exprt deref("dereference", current_func_return_type_.subtype());
+  deref.copy_to_operands(heap_ptr);
+  code_assignt store(deref, value);
+  store.location() = location;
+  target_block.copy_to_operands(store);
+
+  return heap_ptr;
+}
+
 void python_converter::get_return_statements(
   const nlohmann::json &ast_node,
   codet &target_block)
@@ -3546,9 +3595,18 @@ void python_converter::get_return_statements(
     // Add the function call statement to the block
     target_block.copy_to_operands(return_value);
 
-    // Wrap in Optional if the function returns Optional
     exprt ret_expr = temp_var_expr;
-    if (current_func_return_type_.is_struct())
+    // `return ClassName(...)` constructs into the stack-local value temp above;
+    // when the function returns a migrated class reference (Cls*, #3067), box
+    // that value onto a non-expiring heap object and return the pointer so the
+    // instance survives the frame (returning &temp would dangle). Mirrors the
+    // member/parameter return path's boxing in the else branch below.
+    if (
+      is_constructor && is_user_class_pointer(current_func_return_type_) &&
+      is_user_class_struct_type(temp_var_expr.type()))
+      ret_expr = box_value_on_heap(temp_var_expr, location, target_block);
+    // Wrap in Optional if the function returns Optional
+    else if (current_func_return_type_.is_struct())
     {
       const struct_typet &st = to_struct_type(current_func_return_type_);
       if (st.tag().as_string().starts_with("tag-Optional_"))
@@ -3612,34 +3670,7 @@ void python_converter::get_return_statements(
     if (
       is_user_class_pointer(current_func_return_type_) &&
       is_user_class_struct_type(return_value.type()))
-    {
-      const symbolt *new_obj_sym =
-        symbol_table_.find_symbol("c:@F@__ESBMC_new_object");
-      assert(new_obj_sym && "__ESBMC_new_object model required");
-
-      symbolt heap_symbol = create_return_temp_variable(
-        current_func_return_type_, location, "ctor_box");
-      symbol_table_.add(heap_symbol);
-      exprt heap_ptr = symbol_expr(heap_symbol);
-
-      code_declt heap_decl(heap_ptr);
-      heap_decl.location() = location;
-      target_block.copy_to_operands(heap_decl);
-
-      code_function_callt alloc_call;
-      alloc_call.lhs() = heap_ptr;
-      alloc_call.function() = symbol_expr(*new_obj_sym);
-      alloc_call.location() = location;
-      target_block.copy_to_operands(alloc_call);
-
-      exprt deref("dereference", current_func_return_type_.subtype());
-      deref.copy_to_operands(heap_ptr);
-      code_assignt store(deref, return_value);
-      store.location() = location;
-      target_block.copy_to_operands(store);
-
-      return_value = heap_ptr;
-    }
+      return_value = box_value_on_heap(return_value, location, target_block);
 
     // Wrap return value in Optional if the function returns Optional
     if (current_func_return_type_.is_struct())

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -3934,8 +3934,20 @@ exprt function_call_expr::handle_general_function_call()
               const auto &returns = func_node["returns"];
               if (returns.contains("id"))
               {
-                return_type =
-                  type_handler_.get_typet(returns["id"].get<std::string>());
+                const std::string ret_cls = returns["id"].get<std::string>();
+                return_type = type_handler_.get_typet(ret_cls);
+                // Stage 1 object-model migration (#3067): mirror the funcdef
+                // migration — a forward-referenced function returning a
+                // user-defined class returns a Cls* reference, not the value
+                // struct. Resolving it by value here leaves the call typed as a
+                // struct while the callee actually returns a pointer, which
+                // crashes on `return f(...)` with a struct-vs-pointer
+                // irep2_cast_error. @overload stubs resolve per call site, so
+                // leave them by value (consistent with call_return_class).
+                if (
+                  json_utils::is_class(ret_cls, converter_.ast()) &&
+                  !json_utils::has_overload_decorator(func_node))
+                  return_type = gen_pointer_type(return_type);
               }
             }
             exprt body = converter_.get_block(func_node["body"]);

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4174,38 +4174,36 @@ exprt function_call_expr::handle_general_function_call()
         else if (func_value["_type"] == "Call")
         {
           // Chained method call (e.g., B().g().f()): the receiver is the return
-          // value of an inner method call. Create a temp to hold it and use
-          // &temp as self so that self is addressable in the GOTO IR.
-          std::string receiver_type =
-            type_handler_.get_operand_type(func_value);
-          if (!receiver_type.empty())
+          // value of an inner method call. Create a temp to hold it and use it
+          // as self so that self is addressable in the GOTO IR.
+          //
+          // Type the temp from the inner call's *actual* return type, not from
+          // get_operand_type's value-struct name: a method whose return was
+          // migrated to a class reference (#3067) returns `Cls*`, so a value
+          // `Cls` temp would receive a pointer (a struct-vs-pointer mismatch
+          // that trips value-set's make_member assertion). bind_instance_-
+          // receiver then forwards the pointer temp directly, or takes the
+          // address of a value temp — matching either representation.
+          exprt inner_call = converter_.get_expr(func_value);
+          if (inner_call.is_code() && inner_call.statement() == "function_call")
           {
-            typet class_type = type_handler_.get_typet(receiver_type);
             symbolt &tmp = converter_.create_tmp_symbol(
-              func_value, "$inst$", class_type, exprt());
+              func_value, "$inst$", inner_call.type(), exprt());
             converter_.symbol_table().add(tmp);
             code_declt tmp_decl(build_symbol(tmp));
             tmp_decl.location() = location;
             converter_.current_block->copy_to_operands(tmp_decl);
 
-            // Process the inner call; set its LHS to tmp so the return value
-            // is stored there (emits: FUNCTION_CALL: tmp = inner_call(...)).
-            exprt inner_call = converter_.get_expr(func_value);
-            if (
-              inner_call.is_code() && inner_call.statement() == "function_call")
-            {
-              inner_call.op0() = build_symbol(tmp);
-              inner_call.location() = location;
-              converter_.add_instruction(inner_call);
-            }
+            // Store the inner call's return value in tmp
+            // (emits: FUNCTION_CALL: tmp = inner_call(...)).
+            inner_call.op0() = build_symbol(tmp);
+            inner_call.location() = location;
+            converter_.add_instruction(inner_call);
             call.arguments().push_back(
               bind_instance_receiver(build_symbol(tmp)));
           }
           else
-          {
-            exprt obj_expr = converter_.get_expr(func_value);
-            call.arguments().push_back(bind_instance_receiver(obj_expr));
-          }
+            call.arguments().push_back(bind_instance_receiver(inner_call));
         }
         else
         {

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -376,6 +376,16 @@ private:
     const locationt &location,
     const std::string &func_name);
 
+  // Stage 1 object-model migration (#3067): copy a constructed class *value*
+  // onto a fresh non-expiring `__ESBMC_new_object` heap object and return the
+  // pointer to it, so a `-> Cls` function can hand back a `Cls*` reference that
+  // survives its frame. `current_func_return_type_` must be the migrated
+  // pointer type. Used by both return paths in get_return_statements.
+  exprt box_value_on_heap(
+    const exprt &value,
+    const locationt &location,
+    codet &target_block);
+
   void register_instance_attribute(
     const std::string &symbol_id,
     const std::string &attr_name,

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1127,6 +1127,16 @@ private:
   /// known class, or a Name already tracked in flow_class_map_. Else "".
   std::string flow_rhs_class(const nlohmann::json &rhs) const;
 
+  /// User-class name returned by a non-constructor call RHS (`y = f(...)` where
+  /// `f` is annotated `-> Cls`), so the LHS can be typed as a `Cls*` reference.
+  /// Returns "" for constructor calls, unannotated returns, or non-class types.
+  /// Scope: only a direct `Name` call to a module-level function with a `Name`
+  /// or forward-reference-string return annotation. Method calls
+  /// (`obj.method()`), `Attribute` annotations (`-> mod.Cls`), and nested or
+  /// imported callees are not resolved here — those reach `Cls*` typing via the
+  /// explicit-annotation fallback in get_var_assign instead.
+  std::string call_return_class(const nlohmann::json &rhs) const;
+
   /// Nesting depth of get_block() invocations. The module/imported-module body
   /// is depth 1; every nested body (function, if/while/for, try/except) is
   /// deeper because those bodies are converted through get_block() too.


### PR DESCRIPTION
## What

Stage 1 of the #3067 object-model migration, extended to the **return path**. Master already heap-allocates class instances at construction (`o = ClassName(...)` yields a pointer to a non-expiring `__ESBMC_new_object`). This PR makes a function whose return annotation resolves to a user-defined class return a **`Cls*` reference** to that heap object instead of a value copy.

The effect: a returned object survives the callee frame and preserves identity/aliasing across the call boundary, matching CPython (and the pointer representation already used for locals, parameters and `self`).

## Why

Returning by value copied the struct out of the callee frame, which:
- breaks identity/aliasing (`y = f(x); y.v = 1` would not be observed through `x`), and
- forces a pointer→value dereference on `return self` / `return param` that crashed the SMT backend with a sort mismatch.

## Changes

- **`converter_funcdef.cpp`** — a function returning a user-class struct now returns `gen_pointer_type(...)`; `@overload` stubs are skipped (their return type is resolved per call site). The `Cls*` return is also treated as "already optional" (None == NULL pointer, so no Optional re-wrap).
- **`converter_stmt.cpp`** — new `call_return_class()` helper types the LHS of `y = f(...)` as `Cls*`; `return ClassName(...)` is boxed onto a fresh `__ESBMC_new_object` heap object and the pointer returned (replacing the old dereference-to-value block).
- **`function_call/expr.cpp`** — the forward-reference return-type resolver now mirrors the funcdef migration, fixing a struct-vs-pointer `irep2_cast_error` crash on `return f(...)` when `f` is defined *after* its caller.
- **`python_converter.h`** — declaration + scope docs for `call_return_class`.

## Tests

Four regression tests under `regression/python/`:
- `github_3067_return_reference` — aliasing, identity (`is`), and chained returns survive the frame.
- `github_3067_return_reference_fail` — negative; asserts the violated property `a->value == 7`.
- `github_3067_return_reference_forward` — the forward-reference crash regression.
- `github_3067_return_reference_none` — `return None` from a `-> Cls` function (NULL pointer, `is None`).

All four pass; the class/object/dataclass/inheritance/annotation regression surface stays green (Z3 backend; `--bitwuzla`-only tests not run in this local build but unaffected by the change). `clang-format` clean.

## Known follow-up (not a blocker)

A polymorphic factory `def make() -> Base: return Derived()` boxes by the declared `Base` type (slices `Derived`-only state). It verifies SUCCESSFUL — sound for the declared interface — but a lossless fix (box by the constructed type) is left for a follow-up.