### PR TITLE
[python] V.1k(b) B.1-B.2: land IREP2-native Python adjuster resolution + flag in master

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3400,9 +3400,8 @@ build-IREP2-then-back-migrate pattern file 1 used for non-member expressions
 
 #### V.1k (b)-adjuster — execution scoping (post-V.4.4b: the precondition is now met)
 
-> **Status: superseded by "B.0–B.3 implementation outcomes" below (B.0 merged to
-> master via #5615; B.1–B.2 + validation built on `feat/v4-b1-python-adjust-resolve`,
-> not yet merged).** The section below is the live record; this one is retained for
+> **Status: superseded by "B.0–B.3 implementation outcomes" below (B.0–B.2 + validation
+> now in master).** The section below is the live record; this one is retained for
 > the design rationale. The V.1k breakthrough above deferred
 > the (b) IREP2-native adjuster to "V.4+" on the grounds that *a separate adjuster
 > has no IREP2 to operate on until function bodies are IREP2*. **That precondition is
@@ -3513,17 +3512,16 @@ outcome; the C/C++ counterexample printer W4 stays Phase V.5.)
 
 #### B.0–B.3 implementation outcomes (2026-06-25) — infra landed, B.3 is gated on B.5
 
-> **Status: B.0 skeleton merged to master (#5615); B.1–B.2 + validation built and
-> consolidated on `feat/v4-b1-python-adjust-resolve` (#5621), not yet merged to
-> master; B.3 blocked on B.5.** Only the no-op skeleton is in master's tree today;
-> the resolution, flag-wiring and fixture-validation described below live on that
-> branch and reach master when it does. The step that *exercises* resolution in the
-> pipeline (B.3) is, empirically, not separable from B.5. Recorded so the B.5 effort
-> starts from the real state, not the forecast.
+> **Status: B.0–B.2 + validation merged to master (B.0 skeleton via #5615; B.1–B.2
+> resolution, flag-wiring and fixture tests via the V.4 B.1/B.2 merge); B.3 blocked
+> on B.5.** The skeleton, resolution, flag-wiring and fixture-validation are all in
+> master's tree, flag-gated behind `--python-irep2-adjust` (default off ⇒
+> byte-identical). The step that *exercises* resolution in the pipeline (B.3) is,
+> empirically, not separable from B.5. Recorded so the B.5 effort starts from the
+> real state, not the forecast.
 
-**What was built (B.0 in master via #5615; B.1–B.2 on
-`feat/v4-b1-python-adjust-resolve`; all flag-gated behind `--python-irep2-adjust`,
-default off ⇒ byte-identical):**
+**What was built (all in master — B.0 via #5615, B.1–B.2 via the V.4 B.1/B.2 merge;
+all flag-gated behind `--python-irep2-adjust`, default off ⇒ byte-identical):**
 - **B.0** — `src/python-frontend/python_adjust.{h,cpp}`: a pass that walks each code
   symbol's `get_value2()`. Structurally a no-op; unit-tested (`python_adjust_test`).
 - **B.1** — `adjust_expr` resolves a transient `symbol_type2t` member2t/index2t source
@@ -3542,9 +3540,8 @@ default off ⇒ byte-identical):**
   release-inert). `adjust()` writes a symbol back only when resolution changed it and
   walks only code symbols, so the flag is behaviour-inert.
 - **B.2 validation** — flag-on vs flag-off parity over the **entire 20-test acceptance
-  fixture** (69 CORE tests): **0 divergences, 0 aborts**. Pinned by
-  `python_irep2_adjust_{nested_attr,inferred_attr,dataclass}` regression tests (on
-  `feat/v4-b1-python-adjust-resolve`, not yet in master's `regression/python/`).
+  fixture** (69 CORE tests): **0 divergences, 0 aborts**. Pinned by the
+  `python_irep2_adjust_{nested_attr,inferred_attr,dataclass}` regression tests.
 
 **B.3 negative result — the before-placement is unsound while `clang_cpp_adjust` still
 runs.** B.3 (make resolution actually fire) was prototyped by moving `python_adjust`

--- a/regression/python/python_irep2_adjust_dataclass/main.py
+++ b/regression/python/python_irep2_adjust_dataclass/main.py
@@ -1,0 +1,18 @@
+# Dataclass field access under --python-irep2-adjust: fields are struct
+# components the adjuster resolves like any other member source.
+from dataclasses import dataclass
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 3
+    assert p.y == 4
+
+
+main()

--- a/regression/python/python_irep2_adjust_dataclass/test.desc
+++ b/regression/python/python_irep2_adjust_dataclass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_flag/main.py
+++ b/regression/python/python_irep2_adjust_flag/main.py
@@ -1,0 +1,17 @@
+# Exercises the --python-irep2-adjust flag (V.4 B.2). Class member access is
+# the construct the IREP2-native adjuster will resolve once the converter emits
+# transient symbol_type member sources (B.3); for now the flag is inert and the
+# verdict must match the default path.
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x: int = x
+        self.y: int = y
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 3
+    assert p.y == 4
+
+
+main()

--- a/regression/python/python_irep2_adjust_flag/test.desc
+++ b/regression/python/python_irep2_adjust_flag/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_flag_fail/main.py
+++ b/regression/python/python_irep2_adjust_flag_fail/main.py
@@ -1,0 +1,14 @@
+# Negative variant of python_irep2_adjust_flag: the member read contradicts the
+# constructed value, so verification must fail under --python-irep2-adjust too.
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x: int = x
+        self.y: int = y
+
+
+def main() -> None:
+    p = Point(3, 4)
+    assert p.x == 99
+
+
+main()

--- a/regression/python/python_irep2_adjust_flag_fail/test.desc
+++ b/regression/python/python_irep2_adjust_flag_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION FAILED$

--- a/regression/python/python_irep2_adjust_inferred_attr/main.py
+++ b/regression/python/python_irep2_adjust_inferred_attr/main.py
@@ -1,0 +1,16 @@
+# Flow-inferred attribute type (None -> Node) under --python-irep2-adjust, the
+# github_4117 shape: the adjuster follows the inferred symbol_type tag.
+class Node:
+    def __init__(self, value: int) -> None:
+        self.value: int = value
+        self.next = None
+
+
+def main() -> None:
+    n1 = Node(1)
+    n2 = Node(2)
+    n1.next = n2
+    assert n1.next.value == 2
+
+
+main()

--- a/regression/python/python_irep2_adjust_inferred_attr/test.desc
+++ b/regression/python/python_irep2_adjust_inferred_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_nested_attr/main.py
+++ b/regression/python/python_irep2_adjust_nested_attr/main.py
@@ -1,0 +1,19 @@
+# Nested attribute chain self.b.a under --python-irep2-adjust. This is the
+# recursive-resolution shape the IREP2-native adjuster's member-source follow
+# targets (V.4 B.1); the verdict must match the default path.
+class Inner:
+    def __init__(self, a: int) -> None:
+        self.a: int = a
+
+
+class Outer:
+    def __init__(self, inner: Inner) -> None:
+        self.b: Inner = inner
+
+
+def main() -> None:
+    o = Outer(Inner(7))
+    assert o.b.a == 7
+
+
+main()

--- a/regression/python/python_irep2_adjust_nested_attr/test.desc
+++ b/regression/python/python_irep2_adjust_nested_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -123,6 +123,10 @@ const struct group_opt_templ all_cmd_options[] = {
      {"python-list-compare-depth",
       boost::program_options::value<int>()->default_value(4)->value_name("nr"),
       "Set maximum nesting depth for Python list comparison (default is 4)"},
+     {"python-irep2-adjust",
+      NULL,
+      "Run the IREP2-native Python adjuster alongside the legacy adjust pass "
+      "(V.4 migration; experimental, default off)"},
    }},
 #endif
 #ifdef ENABLE_LD_FRONTEND

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -447,9 +447,19 @@ public:
     // struct view at the SMT boundary (see struct_union_members), and
     // the clang frontend builds complex literals as struct-id exprt
     // with a complex type — accept that shape here.
+    //
+    // A symbol_id type is permitted ONLY as a transient pre-resolution state,
+    // the same V.1k "two-phase source invariant" the member2t/index2t asserts
+    // carry: the Python frontend stores class instances with a by-name
+    // symbol_type and resolves it lazily, so migrating a constant aggregate
+    // before the IREP2-native adjuster has followed the type would otherwise
+    // abort here. The adjuster re-establishes the strong invariant before symex;
+    // no frontend builds a constant_struct2t pre-adjust today, so this disjunct
+    // is staged enabling infra exercised by the --python-irep2-adjust path.
     assert(
       type->type_id == type2t::struct_id ||
-      type->type_id == type2t::complex_id);
+      type->type_id == type2t::complex_id ||
+      type->type_id == type2t::symbol_id);
   }
   constant_struct2t(const constant_struct2t &ref) = default;
 

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -21,12 +21,26 @@ bool python_adjust::adjust()
     if (symbol->is_type)
       continue;
 
+    // Only function bodies carry the member2t/index2t expressions this pass
+    // resolves, and only bodies are what goto-convert later migrates via
+    // get_value2() (V.4.4b). Reading get_value2() on a data symbol whose value
+    // is a by-name-typed constant aggregate would trip constant_struct2t's
+    // (un-relaxed) migration assert, so skip non-code symbols.
+    if (!is_code_type(symbol->get_type2()))
+      continue;
+
     expr2tc value = symbol->get_value2();
     if (is_nil_expr(value))
       continue;
 
+    const expr2tc original = value;
     adjust_expr(value);
-    symbol->set_value(value);
+    // Only write back when resolution actually changed the tree. Leaving an
+    // unchanged symbol untouched keeps its legacy value cache valid, so the
+    // following clang_cpp_adjust pass sees a byte-identical body — the pass is
+    // inert until the converter emits transient symbol_type member sources.
+    if (value != original)
+      symbol->set_value(value);
   }
 
   return false;

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -32,13 +32,67 @@ bool python_adjust::adjust()
   return false;
 }
 
+namespace
+{
+// A member2t/index2t source is "resolved" once it is a concrete aggregate the
+// strong construction invariant accepts; until then it may carry a transient
+// symbol_type2t (the relaxed assert permits this, V.1k step 1).
+bool is_resolved_aggregate(const type2tc &t)
+{
+  return is_struct_type(t) || is_union_type(t) || is_array_type(t) ||
+         is_vector_type(t);
+}
+} // namespace
+
 void python_adjust::adjust_expr(expr2tc &expr)
 {
   if (is_nil_expr(expr))
     return;
 
-  // B.0: structural no-op — recurse into every operand and change nothing.
-  // The recursion shape is the durable part; later phases resolve
-  // member2t/index2t sources here before recursing/returning.
+  // Recurse operands first so nested sources resolve inner-to-outer: building
+  // `self.b.a` needs `self.b` already resolved to a struct. Foreach_operand
+  // mutates each operand in place, so an inner member2t rebuilt below updates
+  // the outer member2t's source before we read its type.
   expr->Foreach_operand([this](expr2tc &op) { adjust_expr(op); });
+
+  // Resolve a transient symbol_type2t member/index source to its followed
+  // aggregate, re-establishing the strong source invariant before symex sees
+  // the node (the V.1k two-phase invariant: relax at construction, re-enforce
+  // here). member2t/index2t are immutable, so rebuild with the resolved source.
+  if (is_member2t(expr))
+  {
+    const member2t &m = to_member2t(expr);
+    expr2tc source = m.source_value;
+    if (resolve_source(source))
+      expr = member2tc(m.type, source, m.member);
+  }
+  else if (is_index2t(expr))
+  {
+    const index2t &i = to_index2t(expr);
+    expr2tc source = i.source_value;
+    if (resolve_source(source))
+      expr = index2tc(i.type, source, i.index);
+  }
+}
+
+bool python_adjust::resolve_source(expr2tc &source)
+{
+  // A member2t/index2t cannot be constructed over a pointer source (the
+  // construction assert rejects pointer_id), so the converter always hands a
+  // symbol_type2t-typed source — either a plain symbol2t (the instance) or a
+  // dereference2t of a `pointer→tag-Cls` instance pointer, whose result type is
+  // the symbol_type pointee. Both reach here as a symbol_type2t source; follow
+  // it to the resolved aggregate and retype the node in place (with_type keeps
+  // expr2t::type immutable). This is the IREP2-native equivalent of
+  // clang_c_adjust's symbol-type completion + pointer auto-deref.
+  const type2tc &src_type = source->type;
+  if (!is_symbol_type(src_type))
+    return false;
+
+  type2tc resolved = ns.follow(src_type);
+  if (resolved == src_type || !is_resolved_aggregate(resolved))
+    return false;
+
+  source = source->with_type(resolved);
+  return true;
 }

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -36,9 +36,10 @@ bool python_adjust::adjust()
     const expr2tc original = value;
     adjust_expr(value);
     // Only write back when resolution actually changed the tree. Leaving an
-    // unchanged symbol untouched keeps its legacy value cache valid, so the
-    // following clang_cpp_adjust pass sees a byte-identical body — the pass is
-    // inert until the converter emits transient symbol_type member sources.
+    // unchanged symbol untouched keeps its legacy value cache valid, so
+    // goto-convert later sees a byte-identical body (this pass runs *after*
+    // clang_cpp_adjust) — the pass is inert until the converter emits transient
+    // symbol_type member sources.
     if (value != original)
       symbol->set_value(value);
   }

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -4,25 +4,23 @@
 #include <util/namespace.h>
 #include <irep2/irep2.h>
 
-/// V.1k (b) IREP2-native Python adjuster — Phase B.0 skeleton.
+/// V.1k (b) IREP2-native Python adjuster (phases B.0–B.2).
 ///
-/// This pass exists to replace, for the Python frontend, the legacy
-/// `clang_cpp_adjust` round-trip currently run on Python output
-/// (`python_language.cpp`). It walks each non-type symbol's IREP2 value
-/// (`symbolt::get_value2()`) recursively.
+/// Replaces, for the Python frontend, the legacy `clang_cpp_adjust` round-trip
+/// on Python output (`python_language.cpp`). It walks each code symbol's IREP2
+/// value (`symbolt::get_value2()`) and follows a transient `symbol_type2t`
+/// `member2t`/`index2t` source to its resolved `struct_type2t`/`array_type2t`
+/// (the V.1k "two-phase source invariant": relaxed at construction, re-enforced
+/// here before symex) — covering both a plain instance source and a
+/// dereferenced instance pointer.
 ///
-/// **B.0 is a structural no-op:** it visits every node and leaves the tree
-/// byte-identical. It is deliberately *not* wired into `python_language.cpp`
-/// yet — it is dead-but-tested, mirroring the "add the machinery, prove it
-/// inert, wire it later" pattern used for the V.4.0 structured-CF kinds
-/// (esbmc/esbmc#5265) and the V-track back-migration arms (#4737).
-///
-/// Later phases give `adjust_expr` real behaviour: following a transient
-/// `symbol_type2t` `member2t`/`index2t` source to its resolved
-/// `struct_type2t`/`array_type2t` (the V.1k "two-phase source invariant"),
-/// pointer auto-deref, and `#cpp_type`/`#member_name` carriage — at which
-/// point the legacy `clang_cpp_adjust` hop on Python output is dropped.
-/// See `docs/irep2-migration.md`, section "V.1k (b)-adjuster".
+/// Wired into `python_languaget::typecheck` behind `--python-irep2-adjust`
+/// (default off ⇒ byte-identical): it runs after `clang_cpp_adjust` and, until
+/// the converter emits transient sources pre-adjust, resolves nothing — so the
+/// path is dead-but-tested, mirroring the "add the machinery, prove it inert,
+/// wire it later" pattern (esbmc/esbmc#5265). `#cpp_type`/`#member_name`
+/// carriage and dropping the legacy hop remain later phases (B.4/B.5). See
+/// `docs/irep2-migration.md`, section "V.1k (b)-adjuster".
 class python_adjust
 {
 public:

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -32,11 +32,21 @@ public:
   /// mirroring `clang_c_adjust::adjust()`.
   bool adjust();
 
-  /// Recursively visit `expr` and its sub-expressions. B.0: structural no-op.
-  /// Phase B.1 hooks member2t/index2t source resolution in here.
+  /// Recursively visit `expr` and its sub-expressions, resolving transient
+  /// `symbol_type2t` member2t/index2t sources to their followed aggregate type
+  /// (the V.1k two-phase source invariant). Recurses operands first, so nested
+  /// sources (`self.b.a`) resolve inner-to-outer.
   void adjust_expr(expr2tc &expr);
 
 protected:
   contextt &context;
   namespacet ns;
+
+  /// If `source` is a member2t/index2t source carrying a transient
+  /// `symbol_type2t`, follow it to the resolved struct/union/array and retype
+  /// the node in place (returns true); otherwise leave it (returns false). The
+  /// source is a plain `symbol2t` (the instance) or a `dereference2t` of a
+  /// `pointer→tag-Cls` instance pointer — both arrive as a symbol_type2t source,
+  /// since a member/index cannot be constructed over a raw pointer.
+  bool resolve_source(expr2tc &source);
 };

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -2,6 +2,7 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_annotation.h>
 #include <python-frontend/global_scope.h>
+#include <python-frontend/python_adjust.h>
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
 #include <util/message.h>
 #include <util/filesystem.h>
@@ -249,6 +250,33 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
   clang_cpp_adjust adjuster(context);
   if (adjuster.adjust())
     return true;
+
+  // V.4 B.2: optionally run the IREP2-native Python adjuster. Default off.
+  //
+  // It runs *after* clang_cpp_adjust for now: reading get_value2() migrates each
+  // legacy value to IREP2, which requires its types to already be resolved —
+  // before clang_cpp_adjust they are still by-name symbol_types and migrating a
+  // constant aggregate trips constant_struct2t's (un-relaxed) assert. Post-adjust
+  // the types are resolved, so the walk is safe; it currently resolves nothing
+  // (clang_cpp_adjust already did) and only writes a symbol back when it changes
+  // the value, so the flag is behaviour-inert.
+  //
+  // B.3 experiment (2026-06-25, negative result, do not retry as-is): moving the
+  // pass *before* clang_cpp_adjust to exercise resolution was prototyped. It
+  // additionally needs member2t/index2t to tolerate a transient pointer source
+  // (the Python frontend stores instances/containers behind a pointer) plus a
+  // pointer auto-deref in resolve_source. With those, migration no longer aborts,
+  // but the whole 20-test fixture then produced *no verdict* under the flag
+  // (symex crash/hang): running the IREP2 adjuster before clang_cpp_adjust while
+  // clang_cpp_adjust still runs afterwards double-resolves the same nodes — the
+  // "two-places-resolve hazard" the V.1k spike flagged. Conclusion: the
+  // before-placement is only viable once it *replaces* clang_cpp_adjust for
+  // Python (B.5), which is a dedicated effort, not a reorder of this call.
+  if (config.options.get_bool_option("python-irep2-adjust"))
+  {
+    python_adjust py_adjuster(context);
+    py_adjuster.adjust();
+  }
 
   return false;
 }

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -6,16 +6,20 @@
 #include <util/symbol.h>
 #include <util/c_types.h>
 #include <irep2/irep2_utils.h>
+#include <string>
+#include <vector>
 
-// Phase B.0 dead-but-tested gate for the V.1k (b) IREP2-native Python adjuster
-// (docs/irep2-migration.md, "V.1k (b)-adjuster", phase B.0).
+// Dead-but-tested gate for the V.1k (b) IREP2-native Python adjuster
+// (docs/irep2-migration.md, "V.1k (b)-adjuster", phases B.0/B.1).
 //
-// The B.0 pass is a *structural no-op*: walking an IREP2 expression — and a
-// symbol's IREP2 value through the full adjust() entry point — must leave it
-// byte-identical. This pins the inert baseline that later phases (B.1+, which
-// resolve member2t/index2t sources) validate against, the same
-// "machinery-first, prove-inert, wire-later" gate used for the V.4.0
-// structured-CF kinds (esbmc/esbmc#5265).
+// B.0 pins the inert baseline: a non-member/index expression is byte-identical
+// after a walk. B.1 adds the resolution behaviour: a transient symbol_type2t
+// member2t/index2t source is followed to its struct/array (and a pointer source
+// is auto-dereferenced), re-establishing the strong source invariant the
+// construction assert was relaxed for. The pass is still not wired into
+// python_language.cpp (B.2 adds the flag), so these tests are the only thing
+// exercising it — the "machinery-first, prove-inert, wire-later" gate used for
+// the V.4.0 structured-CF kinds (esbmc/esbmc#5265).
 
 namespace
 {
@@ -26,6 +30,31 @@ expr2tc make_sample_expr()
   const expr2tc x = symbol2tc(int_t, "x");
   const expr2tc sum = add2tc(int_t, x, gen_one(int_t));
   return equality2tc(sum, gen_zero(int_t));
+}
+
+// Register a type symbol `tag-<name>` = struct { <field> : int; } so that
+// ns.follow(symbol_type2t("tag-<name>")) yields the resolved struct.
+type2tc add_struct_type(
+  contextt &ctx,
+  const std::string &name,
+  const std::string &field)
+{
+  const type2tc struct_t = struct_type2tc(
+    std::vector<type2tc>{get_int32_type()},
+    std::vector<irep_idt>{field},
+    std::vector<irep_idt>{field},
+    name,
+    false);
+
+  symbolt type_sym;
+  type_sym.id = "tag-" + name;
+  type_sym.name = "tag-" + name;
+  type_sym.mode = "Python";
+  type_sym.is_type = true;
+  type_sym.set_type(struct_t);
+  ctx.add(type_sym);
+
+  return struct_t;
 }
 } // namespace
 
@@ -80,4 +109,106 @@ TEST_CASE("python_adjust B.0 ignores a nil-valued symbol", "[python-adjust]")
 
   python_adjust adjuster(ctx);
   REQUIRE_FALSE(adjuster.adjust());
+}
+
+TEST_CASE(
+  "python_adjust B.1 follows a direct symbol_type member source to its struct",
+  "[python-adjust]")
+{
+  contextt ctx;
+  const type2tc struct_t = add_struct_type(ctx, "Foo", "x");
+
+  // member2t over a source whose type is the transient symbol_type2t("tag-Foo")
+  // (permitted by the relaxed construction assert).
+  const expr2tc source = symbol2tc(symbol_type2tc("tag-Foo"), "obj");
+  expr2tc member = member2tc(get_int32_type(), source, "x");
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(member);
+
+  REQUIRE(is_member2t(member));
+  REQUIRE(to_member2t(member).source_value->type == struct_t);
+}
+
+TEST_CASE(
+  "python_adjust B.1 follows a symbol_type on a dereference member source",
+  "[python-adjust]")
+{
+  contextt ctx;
+  const type2tc struct_t = add_struct_type(ctx, "Bar", "y");
+
+  // A Python class-instance access `obj.y`: obj is a pointer→symbol_type, so
+  // the member source is *obj — a dereference2t whose result type is the
+  // symbol_type pointee (a member2t cannot be built over the raw pointer).
+  const expr2tc ptr =
+    symbol2tc(pointer_type2tc(symbol_type2tc("tag-Bar")), "obj");
+  const expr2tc deref = dereference2tc(symbol_type2tc("tag-Bar"), ptr);
+  expr2tc member = member2tc(get_int32_type(), deref, "y");
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(member);
+
+  REQUIRE(is_member2t(member));
+  const expr2tc &resolved_source = to_member2t(member).source_value;
+  REQUIRE(is_dereference2t(resolved_source));
+  REQUIRE(resolved_source->type == struct_t);
+}
+
+TEST_CASE(
+  "python_adjust B.1 resolves a nested member chain inner-to-outer",
+  "[python-adjust]")
+{
+  // self.b : B, and B.a : int, with B a registered struct. The outer member
+  // self.b.a has, as its source, the inner member self.b whose own source is a
+  // symbol_type2t("tag-Outer"). Both levels must resolve.
+  contextt ctx;
+  const type2tc b_struct = add_struct_type(ctx, "B", "a");
+  // Outer struct has a member `b` of (symbol) type tag-B.
+  const type2tc outer_struct = struct_type2tc(
+    std::vector<type2tc>{symbol_type2tc("tag-B")},
+    std::vector<irep_idt>{"b"},
+    std::vector<irep_idt>{"b"},
+    "Outer",
+    false);
+  symbolt outer_sym;
+  outer_sym.id = "tag-Outer";
+  outer_sym.name = "tag-Outer";
+  outer_sym.mode = "Python";
+  outer_sym.is_type = true;
+  outer_sym.set_type(outer_struct);
+  ctx.add(outer_sym);
+
+  const expr2tc self = symbol2tc(symbol_type2tc("tag-Outer"), "self");
+  const expr2tc self_b = member2tc(symbol_type2tc("tag-B"), self, "b");
+  expr2tc self_b_a = member2tc(get_int32_type(), self_b, "a");
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(self_b_a);
+
+  // Outer member's source (self.b) resolved to struct B; its inner source
+  // (self) resolved to struct Outer.
+  REQUIRE(is_member2t(self_b_a));
+  const expr2tc &outer_source = to_member2t(self_b_a).source_value;
+  REQUIRE(outer_source->type == b_struct);
+  REQUIRE(is_member2t(outer_source));
+  REQUIRE(to_member2t(outer_source).source_value->type == outer_struct);
+}
+
+TEST_CASE(
+  "python_adjust B.1 leaves an already-resolved struct source untouched",
+  "[python-adjust]")
+{
+  // A member2t whose source is already a resolved struct must be left alone
+  // (idempotence: re-running the adjuster is a no-op on resolved nodes).
+  contextt ctx;
+  const type2tc struct_t = add_struct_type(ctx, "Baz", "z");
+
+  const expr2tc source = symbol2tc(struct_t, "obj");
+  expr2tc member = member2tc(get_int32_type(), source, "z");
+  const expr2tc original = member;
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(member);
+
+  REQUIRE(member == original);
 }

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -132,33 +132,6 @@ TEST_CASE(
 }
 
 TEST_CASE(
-  "python_adjust B.1 follows a symbol_type index source to its array",
-  "[python-adjust]")
-{
-  // The index2t arm of resolve_source: a source typed as a transient
-  // symbol_type2t("tag-Buf") is followed to its registered array type.
-  contextt ctx;
-  const type2tc array_t = array_type2tc(get_int32_type(), gen_ulong(4), false);
-
-  symbolt type_sym;
-  type_sym.id = "tag-Buf";
-  type_sym.name = "tag-Buf";
-  type_sym.mode = "Python";
-  type_sym.is_type = true;
-  type_sym.set_type(array_t);
-  ctx.add(type_sym);
-
-  const expr2tc source = symbol2tc(symbol_type2tc("tag-Buf"), "buf");
-  expr2tc index = index2tc(get_int32_type(), source, gen_ulong(0));
-
-  python_adjust adjuster(ctx);
-  adjuster.adjust_expr(index);
-
-  REQUIRE(is_index2t(index));
-  REQUIRE(to_index2t(index).source_value->type == array_t);
-}
-
-TEST_CASE(
   "python_adjust B.1 follows a symbol_type on a dereference member source",
   "[python-adjust]")
 {

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -132,6 +132,33 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "python_adjust B.1 follows a symbol_type index source to its array",
+  "[python-adjust]")
+{
+  // The index2t arm of resolve_source: a source typed as a transient
+  // symbol_type2t("tag-Buf") is followed to its registered array type.
+  contextt ctx;
+  const type2tc array_t = array_type2tc(get_int32_type(), gen_ulong(4), false);
+
+  symbolt type_sym;
+  type_sym.id = "tag-Buf";
+  type_sym.name = "tag-Buf";
+  type_sym.mode = "Python";
+  type_sym.is_type = true;
+  type_sym.set_type(array_t);
+  ctx.add(type_sym);
+
+  const expr2tc source = symbol2tc(symbol_type2tc("tag-Buf"), "buf");
+  expr2tc index = index2tc(get_int32_type(), source, gen_ulong(0));
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(index);
+
+  REQUIRE(is_index2t(index));
+  REQUIRE(to_index2t(index).source_value->type == array_t);
+}
+
+TEST_CASE(
   "python_adjust B.1 follows a symbol_type on a dereference member source",
   "[python-adjust]")
 {

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -16,10 +16,11 @@
 // after a walk. B.1 adds the resolution behaviour: a transient symbol_type2t
 // member2t/index2t source is followed to its struct/array (and a pointer source
 // is auto-dereferenced), re-establishing the strong source invariant the
-// construction assert was relaxed for. The pass is still not wired into
-// python_language.cpp (B.2 adds the flag), so these tests are the only thing
-// exercising it — the "machinery-first, prove-inert, wire-later" gate used for
-// the V.4.0 structured-CF kinds (esbmc/esbmc#5265).
+// construction assert was relaxed for. B.2 wires the pass into
+// python_languaget::typecheck behind --python-irep2-adjust (default off); these
+// unit tests exercise the behaviour directly — the "machinery-first,
+// prove-inert, wire-later" gate used for the V.4.0 structured-CF kinds
+// (esbmc/esbmc#5265).
 
 namespace
 {


### PR DESCRIPTION
## What

Merges the V.4 B.1/B.2 work (so far consolidated on `feat/v4-b1-python-adjust-resolve`, #5621) into master, making the documented **"B.0–B.2 built"** state true in the tree. Master already has the B.0 no-op skeleton (#5615); this adds:

- **B.1** — `python_adjust::adjust_expr` resolves a transient `symbol_type2t` `member2t`/`index2t` source to its `struct_type2t`/`array_type2t` via `namespacet::follow` + `expr2t::with_type`, recursing operands first.
- **B.2** — the `--python-irep2-adjust` option (default **off**) + invocation in `python_languaget::typecheck`, **after** the legacy `clang_cpp_adjust`. `adjust()` walks only code symbols and writes back only when resolution changed something, so the flag is behaviour-inert.
- Regression tests `python_irep2_adjust_{nested_attr,inferred_attr,dataclass,flag,flag_fail}` pinning flag-on/flag-off parity; expanded `python_adjust_test` unit cases.
- Third commit syncs `docs/irep2-migration.md` (the state #5653 recorded) to **B.0–B.2 now in master**, so docs and code land together.

## Verification

- Cherry-picks cleanly onto current master (validated: a `--no-ff` trial merge also applied with no conflicts).
- CPython sanity (`scripts/check_python_tests.sh python_irep2_adjust`): all 5 new tests behave as expected (success ⇒ exit 0, `*_fail` ⇒ exit 1).
- **Full build + `ctest` regression run via CI** — a local build is not possible in the authoring environment (no LLVM/Clang dev libs, no Bitwuzla), so CI (`build-unix`, `build`, regression) is the authoritative gate here.

## Key review risk (RV3)

`src/irep2/irep2_expr.h` relaxes the **`constant_struct2t`** construction assert to permit a transient `symbol_id` type — a **shared** assert touching all frontends. It is `NDEBUG`-gated (release-inert) and mirrors the V.1k `member2t`/`index2t` relaxation, but `esbmc-cpp` parity is the gate. Please confirm CI's C/C++ regression is green before merge.

## Non-goals

B.3 stays blocked on B.5 (the before-placement finding: running the pass while `clang_cpp_adjust` still resolves sources double-resolves). This PR only lands the dead-but-tested, flag-gated infra. Supersedes the parallel V.1k(b) stack #5625/#5627.