### PR TITLE
[contracts] fix bool-return ensures Bool-vs-BitVector sort crash

### DIFF
--- a/regression/function_contract/cpp_ensures_bool_return_fail/main.cpp
+++ b/regression/function_contract/cpp_ensures_bool_return_fail/main.cpp
@@ -1,0 +1,18 @@
+/* cpp_ensures_bool_return_fail:
+ * Negative variant of cpp_ensures_bool_return_pass. Same bool-returning
+ * contract shape (which previously crashed Z3 with a Bool vs (_ BitVec 32)
+ * sort error), but the body returns `c >= 0`, which disagrees with the
+ * postcondition `__ESBMC_return_value == (c > 0)` when c == 0.
+ *
+ * This confirms the sort fix does not mask a genuine contract violation.
+ *
+ * Regression for: https://github.com/Yiannis128/esbmc/issues/4
+ *
+ * Expected: VERIFICATION FAILED
+ */
+
+bool is_pos(int c)
+{
+  __ESBMC_ensures(__ESBMC_return_value == (c > 0));
+  return c >= 0; /* VIOLATION: differs from (c > 0) at c == 0 */
+}

--- a/regression/function_contract/cpp_ensures_bool_return_fail/test.desc
+++ b/regression/function_contract/cpp_ensures_bool_return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--enforce-contract is_pos --function is_pos
+^VERIFICATION FAILED$

--- a/regression/function_contract/cpp_ensures_bool_return_nonbool_operand_fail/main.cpp
+++ b/regression/function_contract/cpp_ensures_bool_return_nonbool_operand_fail/main.cpp
@@ -1,0 +1,23 @@
+/* cpp_ensures_bool_return_nonbool_operand_fail:
+ * Guards the *direction* of the bool/bitvector fix for issue #4.
+ *
+ * The ensures compares the bool return value against `x & 3`, which can be 2
+ * or 3 — values outside {0,1}. The body returns `x & 3`, but the bool return
+ * type collapses it to {0,1}, so the postcondition is violated whenever
+ * x & 3 >= 2.
+ *
+ * The sort fix must *promote* the boolean operand to int (C usual arithmetic
+ * conversions), not demote `x & 3` to bool. Demoting would collapse the
+ * operand to {0,1} and wrongly report VERIFICATION SUCCESSFUL, masking this
+ * real violation.
+ *
+ * Regression for: https://github.com/Yiannis128/esbmc/issues/4
+ *
+ * Expected: VERIFICATION FAILED
+ */
+
+bool f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value == (x & 3));
+  return x & 3; /* VIOLATION: bool return collapses 2,3 to 1 */
+}

--- a/regression/function_contract/cpp_ensures_bool_return_nonbool_operand_fail/test.desc
+++ b/regression/function_contract/cpp_ensures_bool_return_nonbool_operand_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--enforce-contract f --function f
+^VERIFICATION FAILED$

--- a/regression/function_contract/cpp_ensures_bool_return_pass/main.cpp
+++ b/regression/function_contract/cpp_ensures_bool_return_pass/main.cpp
@@ -1,0 +1,22 @@
+/* cpp_ensures_bool_return_pass:
+ * --enforce-contract on a bool-returning function whose ensures compares
+ * __ESBMC_return_value against a boolean-typed expression.
+ *
+ * The global __ESBMC_return_value is declared `int`, so Clang promotes the
+ * boolean operand of the equality to `int`. Once the symbol's type is
+ * corrected to the function's real `bool` return type, the comparison was left
+ * with one side Bool and the other a (_ BitVec 32), which crashed Z3 with
+ * "Sorts Bool and (_ BitVec 32) are incompatible" and a core dump.
+ *
+ * The body returns exactly that boolean, so the postcondition holds.
+ *
+ * Regression for: https://github.com/Yiannis128/esbmc/issues/4
+ *
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+
+bool is_pos(int c)
+{
+  __ESBMC_ensures(__ESBMC_return_value == (c > 0));
+  return c > 0;
+}

--- a/regression/function_contract/cpp_ensures_bool_return_pass/test.desc
+++ b/regression/function_contract/cpp_ensures_bool_return_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--enforce-contract is_pos --function is_pos
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -3214,26 +3214,54 @@ expr2tc code_contractst::fix_comparison_types(
             get_type_id(*ret_val->type));
         }
       }
-      // Case 3: return_value is an integer compared with an integer operand of
-      // a different width — e.g. an `int` return value against a `long`
-      // constant that does not fit in `int`. remove_incorrect_casts above
-      // stripped the usual-arithmetic-conversion cast Clang inserted, leaving a
-      // width mismatch the SMT backend rejects (mk_bvsgt requires equal operand
-      // widths). Re-apply the conversion by widening the narrower side to the
-      // wider integer type. Issue #5312.
+      // Cases 3 & 4: a comparison where one side is the return_value symbol.
+      // Two SMT-level sort mismatches can survive Clang's typing once
+      // get_decl_ref has corrected the symbol to the function's real return
+      // type, both because the global __ESBMC_return_value is declared `int`:
+      //
+      //   * Bool vs BitVector (issue #4): `__ESBMC_return_value == (c > 0)`
+      //     promotes the boolean operand to int. For a bool-returning function
+      //     the symbol is bool, leaving one side Bool and the other
+      //     (_ BitVec 32) — which Z3 rejects with "Sorts Bool and
+      //     (_ BitVec 32) are incompatible" (and core-dumps).
+      //
+      //   * Integer width (issue #5312): an `int` return value compared with a
+      //     wider integer operand after remove_incorrect_casts stripped the
+      //     usual-arithmetic-conversion cast (mk_bvsgt requires equal widths).
       else if (side1_is_retval || side2_is_retval)
       {
+        expr2tc *rv = side1_is_retval ? side1 : side2;
+        expr2tc *other = side1_is_retval ? side2 : side1;
+
         auto is_int = [](const type2tc &t) {
           return is_signedbv_type(t) || is_unsignedbv_type(t);
         };
-        if (
-          is_int((*side1)->type) && is_int((*side2)->type) &&
-          (*side1)->type->get_width() != (*side2)->type->get_width())
+
+        if (is_bool_type((*rv)->type) != is_bool_type((*other)->type))
         {
-          if ((*side1)->type->get_width() < (*side2)->type->get_width())
-            *side1 = typecast2tc((*side2)->type, *side1);
+          // Bool vs BitVector sort mismatch: promote the boolean side to the
+          // other operand's type, matching C's usual arithmetic conversions
+          // (a bool is widened to int, never the reverse). Casting the boolean
+          // up is value-preserving ({0,1} fits any wider type); demoting the
+          // other side to bool would collapse values >1 and silently satisfy
+          // postconditions such as `__ESBMC_return_value == (x & 3)`.
+          expr2tc *boolean = is_bool_type((*rv)->type) ? rv : other;
+          expr2tc *wider = (boolean == rv) ? other : rv;
+          *boolean = typecast2tc((*wider)->type, *boolean);
+          log_debug(
+            "contracts",
+            "Fixed bool/bitvector comparison: promoted boolean operand to {}",
+            get_type_id(*(*wider)->type));
+        }
+        else if (
+          is_int((*rv)->type) && is_int((*other)->type) &&
+          (*rv)->type->get_width() != (*other)->type->get_width())
+        {
+          // Integer width mismatch: widen the narrower side.
+          if ((*rv)->type->get_width() < (*other)->type->get_width())
+            *rv = typecast2tc((*other)->type, *rv);
           else
-            *side2 = typecast2tc((*side1)->type, *side2);
+            *other = typecast2tc((*rv)->type, *other);
           log_debug(
             "contracts",
             "Fixed integer comparison: widened return_value comparison to "


### PR DESCRIPTION
## Introduction

Enforcing a contract on a `bool`-returning function whose `__ESBMC_ensures`
compares `__ESBMC_return_value` against a boolean-typed expression crashed Z3
with `Sorts Bool and (_ BitVec 32) are incompatible` and a core dump.

The global `__ESBMC_return_value` is declared `int`, so Clang promotes the
boolean operand of the equality to `int`. `get_decl_ref` then corrects the
symbol's type to the function's real `bool` return type, leaving the equality
with one `Bool` side and one `(_ BitVec 32)` side — a sort mismatch the SMT
backend rejects.

Resolves https://github.com/Yiannis128/esbmc/issues/4

## Minimal Repro

```cpp
bool is_pos(int c) {
    __ESBMC_ensures(__ESBMC_return_value == (c > 0));
    return c > 0;
}
```

```
esbmc minimal.cpp --function is_pos --enforce-contract is_pos --z3
```

Before:

```
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
ERROR: Z3 error Sorts Bool and (_ BitVec 32) are incompatible encountered
<the monitored command dumped core>
```

After: `VERIFICATION SUCCESSFUL`.

## Fix

`fix_comparison_types` now detects the `Bool`-vs-`BitVector` mismatch in a
return-value comparison and **promotes the boolean operand up** to the other
side's type, matching C's usual arithmetic conversions (a `bool` widens to
`int`, never the reverse).

Promoting is value-preserving (`{0,1}` fits any wider type). Demoting the other
side to `bool` would also fix the sort error but is unsound: it collapses values
`> 1` and would silently satisfy postconditions such as
`__ESBMC_return_value == (x & 3)`, masking a real violation.

Three regression tests are added under `regression/function_contract/`:

- `cpp_ensures_bool_return_pass` — the repro, `VERIFICATION SUCCESSFUL`.
- `cpp_ensures_bool_return_fail` — a violated bool ensures, `VERIFICATION FAILED`.
- `cpp_ensures_bool_return_nonbool_operand_fail` — guards the cast direction:
  `__ESBMC_return_value == (x & 3)` must be `VERIFICATION FAILED`, not masked.
