### PR TITLE
[cpp] model std::isinf/isfinite/signbit in <cmath>

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers/main.cpp
@@ -1,0 +1,48 @@
+/* Regression for https://github.com/Yiannis128/esbmc/issues/5
+ *
+ * std::isinf failed to parse: the C <math.h> classifier macros (e.g. glibc
+ * lowers isinf to __builtin_isinf_sign) leaked into the std:: call, so
+ * std::isinf(d) macro-expanded to std::__builtin_isinf_sign(d), which is not a
+ * member of std. std::isnan already worked; isinf, isfinite and signbit did
+ * not. The fix undefines the macros and provides std:: overloads for all five
+ * classifiers, including the standard integral-argument overload (treated as
+ * double).
+ *
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+#include <cmath>
+#include <cassert>
+
+bool is_inf(double d)
+{
+  return std::isinf(d);
+}
+
+int main()
+{
+  double inf = INFINITY;
+  double fin = 3.5;
+
+  /* double overloads */
+  assert(is_inf(inf));
+  assert(!is_inf(fin));
+  assert(!std::isnan(fin));
+  assert(std::isfinite(fin));
+  assert(!std::isfinite(inf));
+  assert(std::isnormal(fin));
+  assert(std::signbit(-fin));
+  assert(!std::signbit(fin));
+
+  /* float and long double overloads */
+  assert(std::isinf((float)inf));
+  assert(std::isfinite((long double)fin));
+
+  /* integral argument is treated as double */
+  int n = 5, m = -5;
+  assert(!std::isinf(n));
+  assert(std::isfinite(n));
+  assert(std::signbit(m));
+  assert(!std::signbit(n));
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers_fail/main.cpp
@@ -1,0 +1,21 @@
+/* Negative variant of cmath_std_classifiers (issue #5).
+ *
+ * Confirms std::isinf is actually evaluated, not vacuously satisfied: a finite
+ * value is not infinite, so the assertion must fail.
+ *
+ * Expected: VERIFICATION FAILED
+ */
+#include <cmath>
+#include <cassert>
+
+bool is_inf(double d)
+{
+  return std::isinf(d);
+}
+
+int main()
+{
+  double fin = 3.5;
+  assert(is_inf(fin)); /* VIOLATION: 3.5 is finite */
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/cmath_std_classifiers_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -164,8 +164,15 @@ template <typename Integer>
 double modf(Integer num, double *iptr);
  */
 
+/* These classifiers are function-like macros in the C <math.h> (e.g. glibc
+ * lowers isinf to __builtin_isinf_sign). Undefine them so the std:: overloads
+ * below are real functions; otherwise `std::isinf(x)` macro-expands to
+ * `std::__builtin_isinf_sign(x)`, which is not a member of std (issue #5). */
 #undef isnan
+#undef isinf
+#undef isfinite
 #undef isnormal
+#undef signbit
 
 #define CIMPORT3(name)                                                         \
   bool name(float x)                                                           \
@@ -179,10 +186,19 @@ double modf(Integer num, double *iptr);
   bool name(long double x)                                                     \
   {                                                                            \
     return __builtin_##name(x);                                                \
+  }                                                                            \
+  /* [c.math.fpclass]: an integral argument is treated as double. */           \
+  template <typename T>                                                        \
+  typename std::enable_if<std::is_integral<T>::value, bool>::type name(T x)    \
+  {                                                                            \
+    return __builtin_##name((double)x);                                        \
   }
 
 CIMPORT3(isnan);
+CIMPORT3(isinf);
+CIMPORT3(isfinite);
 CIMPORT3(isnormal);
+CIMPORT3(signbit);
 
 #undef trunc
 #undef truncf


### PR DESCRIPTION
## Introduction

`std::isinf` failed to parse, so no verification ran on any C++ file using it.

ESBMC's bundled `<cmath>` includes the system C `<math.h>`, whose classifier
macros leak into the `std::` call. On glibc, `isinf(x)` is the macro
`__builtin_isinf_sign(x)`, so `std::isinf(d)` macro-expands to
`std::__builtin_isinf_sign(d)` — which is not a member of `std`. The bundled
`<cmath>` only `#undef`-ed and re-declared `isnan` and `isnormal`, so `isinf`,
`isfinite` and `signbit` were all broken. `std::isnan` worked, which is why the
problem looked `isinf`-specific.

Resolves https://github.com/Yiannis128/esbmc/issues/5

## Minimal Repro

```cpp
#include <cmath>
bool is_inf(double d) { return std::isinf(d); }
```

```
esbmc isinf.cpp --function is_inf
```

Before:

```
error: no member named '__builtin_isinf_sign' in namespace 'std'
ERROR: PARSING ERROR
```

After: parses and `VERIFICATION SUCCESSFUL`.

## Fix

In `src/cpp/library/cmath`, `#undef` and re-declare all five classifiers
(`isnan`, `isinf`, `isfinite`, `isnormal`, `signbit`) through the existing
`CIMPORT3` macro. Each overload calls the corresponding `__builtin_*`, which the
clang adjuster already lowers to ESBMC's native float predicates.

`CIMPORT3` also gains the standard integral-argument overload (an integer is
treated as `double`), so `std::isinf(n)` with an `int` is no longer ambiguous —
this also fixes the pre-existing integral-argument gap in `isnan`/`isnormal`.

Note: unqualified `isfinite(x)`/`signbit(x)` after `#include <cmath>` now
require `std::` qualification, matching system libstdc++ (which also `#undef`s
these macros).

Two regression tests are added under `regression/esbmc-cpp/bug_fixes/`:

- `cmath_std_classifiers` — all five classifiers across `float`/`double`/
  `long double`/integral arguments with correct semantics, `VERIFICATION SUCCESSFUL`.
- `cmath_std_classifiers_fail` — a false `std::isinf` claim on a finite value,
  `VERIFICATION FAILED` (guards against vacuous satisfaction).
