### PR TITLE
[clang-frontend] apply -Wno-int-conversion universally

### DIFF
--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -1385,3 +1385,71 @@ no-overflow precision layer:
 8. **#5565 residual** — `ESBMC_SVCOMP`-gated `fclose(stdout)` static-stream free + `strcmp` argv-string
    pointer-validity; reproduce under a `-DESBMC_SVCOMP=On` build.
 9. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.
+
+---
+
+## 15. Pass 11 — reconcile + confirm the actionable backlog is at its research-grade floor (2026-06-28)
+
+This pass re-swept GitHub immediately after Pass 10 and produced **no new code fix**, because the
+re-sweep found no new issue and confirmed that every concretely-localizable item already has a fix in
+mainline or in flight. It records the verifications that establish this, so a later pass does not
+re-investigate the same residuals. Host: aarch64 macOS, ESBMC 8.3.0, master `f343663bde`.
+
+### 15.1 Re-sweep result — no new work surfaced
+
+* **No new SV-COMP issue** since 2026-06-17 (the four ldv-linux-3.14-races drivers + aws-hash pair);
+  all are already triaged (§12, §13).
+* **Nothing newly closed** since the Pass-9 reconciliation (#5565/#5593 closed 2026-06-26 are already
+  in §13.1/§14.1).
+* **Pass-10 PR (#5142 parse layer) in flight** as **#5660**
+  (`[clang-frontend] apply -Wno-int-conversion universally, not only under --sv-comp`); awaiting review.
+
+### 15.2 Residuals re-checked — already addressed in mainline
+
+* **#5565 / #5138 `fclose(stdout)` static-stream free.** Re-verified this pass: a minimal
+  `fclose(stdout)` under `--memory-leak-check` reports `VERIFICATION SUCCESSFUL`, not the issue's
+  "invalid pointer freed". The guard already lives in `src/c2goto/library/io.c` `fclose`
+  (`if (!__ESBMC_sv_comp() && __ESBMC_is_dynamic[__ESBMC_POINTER_OBJECT(stream)]) free(stream);`),
+  which frees only heap streams from `fopen`/`fdopen` and leaves the static standard streams alone,
+  while still catching a genuine double-`fclose` of an `fopen`'d stream. The remaining `strcmp`
+  argv-string layer "did not surface as the first failure on a standard build" (§13.2) and is not
+  independently reproducible here. The `fclose` residual of item 8 is therefore **discharged**; item 8
+  reduces to the `strcmp`/argv layer only.
+
+### 15.3 #4438 — log_6_safe.c-amalgamation (neural-network unreach-call false alarm): triaged research-grade
+
+Not previously detailed in the priority list. `c/neural-networks/log_6_safe.c-amalgamation` is a TRUE
+`unreach-call` task on which ESBMC reports `false(unreach-call)` under `kinduction` (SV-COMP 26 run,
+ESBMC 8.2.0). It is a large floating-point neural-network amalgamation: the spurious counterexample is
+a k-induction / float-precision interaction, not a localized frontend or OM gap, and is not
+reproducible in isolation without the (large) benchmark and a full-set k-induction validation. Same
+research-grade class as #4980 (k-induction) — added to the backlog rather than patched.
+
+### 15.4 Pass-11 running report
+
+**Analysed.** GitHub re-sweep (no new/newly-closed issues); #5565/#5138 `fclose` residual re-verified
+discharged; #4438 triaged.
+
+**PRs opened.** None code — the actionable, isolation-verifiable backlog is exhausted; every remaining
+item is research-grade or full-benchmark-gated (consistent with the Pass-8 doc-only cadence and the
+correctness-first mandate: no heuristic shipped for a soundness-sensitive subsystem that cannot be
+validated against the full SV-COMP set in this environment). This pass is the recurring triage-doc
+reconciliation, stacked on the #5660 (Pass-10) doc update.
+
+**Duplicated work avoided.** #5565/#5138 `fclose` layer not re-fixed — already guarded in `io.c`
+(re-verified §15.2). #4438 not patched — research-grade k-induction/float class. The #5142 parse layer
+not re-touched — in flight as #5660.
+
+**Remaining work (priority order, updated 2026-06-28, Pass 11).** As §14.3, with #4438 added and the
+#5565 `fclose` half discharged:
+1. **#5145 / #5393 / #5394** — aws-hash byte-addressed pointer-read-consistency (closed #5369 RCA).
+2. **#5400 / #5138** — value-set reachability for `valid-memtrack` (sound under-approximation).
+3. **#5012** — G-C `va_list` argument recovery (symbolic-format printf return length).
+4. **#4980 / #4438** — k-induction precision: termination ranking recogniser (#4980) and the
+   neural-network float counterexample (#4438); both need full-set validation.
+5. **#4432** — data-race-checker interleaving reduction on `__atomic_*`.
+6. **#5142 residual** — no-overflow precision layer once parsed (x86 + full-benchmark-gated).
+7. **Device-API / LDV-environment model** (`platform_get_drvdata` etc.) — shared #5396–#5399 blocker.
+8. **#5565 residual** — `strcmp` argv-string pointer-validity only (the `fclose` half is discharged,
+   §15.2); `ESBMC_SVCOMP`/`--sv-comp`-gated.
+9. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.

--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -1453,3 +1453,86 @@ not re-touched — in flight as #5660.
 8. **#5565 residual** — `strcmp` argv-string pointer-validity only (the `fclose` half is discharged,
    §15.2); `ESBMC_SVCOMP`/`--sv-comp`-gated.
 9. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.
+
+---
+
+## 16. Pass 12 — #1470 overflow-witness assignment verified emitted + pinned (2026-06-28)
+
+This pass picks the most concretely-verifiable close-out from §15's item 9 — **#1470** (*overflow
+witness contains no assignment*) — reproduces it in isolation, confirms the defect is resolved in
+mainline, and **pins the fixed behaviour with two regression tests**. The missing-assignment defect is
+directly observable by inspecting the emitted GraphML (an external validator is needed only for
+end-to-end replay, not to see whether the assignment node is present), so #1470 is verifiable here even
+though full UAutomizer/CPAchecker validation is not. Host: aarch64 macOS, ESBMC 8.3.0.
+
+### 16.1 #1470 — overflow witness now records the overflowing variable — VERIFIED FIXED
+
+**Status: defect resolved in mainline; pinned by two regression tests. Recommend closing #1470.**
+
+#1470 (`CWE190_..._int64_t_fscanf_add_08_bad`) reported that ESBMC found the `data + 1` arithmetic
+overflow but emitted a GraphML witness with **no assignment to `data`**, so UAutomizer/CPAchecker
+could not replay it. Reproduced in isolation with the issue's overflow shape (nondet `int64_t data;
+result = data + 1;`) under `--overflow-check --witness-output-graphml -`: the witness now contains
+
+```xml
+<edge ...>
+  <data key="startline">5</data>
+  <data key="assumption">data == 9223372036854775807;</data>
+</edge>
+```
+
+on the assignment edge — `data` is pinned to `INT64_MAX` (the unique value that overflows signed
+`+ 1`), exactly the assignment the issue said was missing. The missing-assignment defect is gone
+(addressed by the intervening witness work, e.g. #5038 / the #4611 GraphML cleanup).
+
+**Regression tests** (`regression/esbmc/`):
+* `github_1470_overflow_witness_fail` — nondet `int64_t` add ⇒ `VERIFICATION FAILED`, and the stdout
+  GraphML must contain `data == 9223372036854775807` (pins the assignment is emitted; the value is
+  deterministic so the regex is stable across solvers/architectures).
+* `github_1470_overflow_witness` — same shape but `__ESBMC_assume(data < INT64_MAX)` ⇒ `VERIFICATION
+  SUCCESSFUL` (pins the overflow check is value-sensitive, not a blanket alarm on nondet operands).
+
+Both pass.
+
+### 16.2 Residual noted — scanf numeric-specifier buffer-overflow check (separate from #1470)
+
+While reproducing, the literal `fscanf("%ld", &data)` form trips a **`buffer overflow on fscanf`**
+before the arithmetic overflow: the scanf format parser in `src/goto-programs/goto_check.cpp`
+(`fmt_idx`/`limits` loop, ~line 437) records every conversion whose `%` is not followed by a width
+digit as `"INF"` length — including numeric conversions like `%ld`/`%d`/`%lld`, which write a single
+scalar and cannot overflow a character buffer. Only `%s`/`%[...]` (string conversions) can. This is a
+**separate scanf-format-parsing precision matter**, not #1470's witness defect; flagged here for a
+future pass (a fix would restrict the INF-length treatment to string conversions, guarded so genuine
+unbounded `%s` reads still alarm). The #1470 witness behaviour is correctly exercised via a clean
+nondet input, which is the standard SV-COMP way to model `fscanf` input anyway.
+
+### 16.3 Pass-12 running report
+
+**Analysed.** #1470 reproduced, confirmed fixed, and pinned; scanf numeric-specifier INF-length
+residual noted.
+
+**PRs opened.** One: `[witness] regression-pin #1470 overflow-witness variable assignment` — two
+regression tests pinning that an arithmetic-overflow GraphML witness records the overflowing
+variable's assignment. No code change (the defect is already resolved); the tests guard against
+regression in the actively-changing witness emitter. Stacked on the #5660/#5662 (Pass-10/11) doc
+chain.
+
+**Duplicated work avoided.** #1470 not re-fixed — already resolved; this pass pins and recommends
+closure rather than re-patching. The scanf INF-length item is recorded, not speculatively patched
+(soundness-sensitive: must not weaken genuine `%s` overflow detection).
+
+**Remaining work (priority order, updated 2026-06-28, Pass 12).** As §15.4, with #1470 moved to
+"verified fixed, pending closure" and the scanf numeric-specifier residual added:
+1. **#5145 / #5393 / #5394** — aws-hash byte-addressed pointer-read-consistency (closed #5369 RCA).
+2. **#5400 / #5138** — value-set reachability for `valid-memtrack` (sound under-approximation).
+3. **#5012** — G-C `va_list` argument recovery (symbolic-format printf return length).
+4. **#4980 / #4438** — k-induction precision (termination recogniser + neural-network float CE);
+   full-set validation.
+5. **#4432** — data-race-checker interleaving reduction on `__atomic_*`.
+6. **scanf numeric-specifier INF-length** — restrict scanf overflow-check INF length to string
+   conversions only (§16.2); isolation-verifiable, soundness-sensitive.
+7. **#5142 residual** — no-overflow precision layer once parsed (x86 + full-benchmark-gated).
+8. **Device-API / LDV-environment model** (`platform_get_drvdata` etc.) — shared #5396–#5399 blocker.
+9. **#5565 residual** — `strcmp` argv-string pointer-validity (`fclose` half discharged, §15.2).
+10. **Close-outs:** #1470 (verified fixed §16.1, recommend closing), #4427; witness end-to-end
+    validation for #1471/#1492/#4611.

--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -1536,3 +1536,136 @@ closure rather than re-patching. The scanf INF-length item is recorded, not spec
 9. **#5565 residual** — `strcmp` argv-string pointer-validity (`fclose` half discharged, §15.2).
 10. **Close-outs:** #1470 (verified fixed §16.1, recommend closing), #4427; witness end-to-end
     validation for #1471/#1492/#4611.
+
+---
+
+## 17. Pass 13 — scanf numeric-specifier fix shipped + #4611 witness items verified resolved (2026-06-28)
+
+This pass converts the §16.2 scanf residual into a shipped fix, and discharges the concrete,
+isolation-verifiable half of the #4611 witness close-out. Host: aarch64 macOS, ESBMC 8.3.0.
+
+### 17.1 scanf numeric-specifier INF-length (§16.2 item 6) — FIXED
+
+`goto_checkt::input_overflow_check` (`src/goto-programs/goto_check.cpp`) treated *every* width-less
+scanf conversion as `INF` → unconditional `buffer overflow on scanf`, including numeric/char/pointer
+conversions (`%d`, `%ld`, `%f`, `%c`) that write a single fixed-size scalar and cannot overflow a
+buffer. The spurious overflow preceded and masked the intended property (the #1470 CWE190 `data + 1`
+overflow). **Fix:** restrict the `INF` rule to genuine unbounded string conversions — `%s`, the
+`%[...]` scanset, and the wide-string `%S`/`%ls` — by skipping C length modifiers to reach the
+conversion specifier; width-less non-string conversions become a `BOUNDED` sentinel that is skipped.
+Sound (diagnostic-precision only; GCC/glibc semantics unchanged), code-reviewed (two findings applied:
+the `%S` wide-string soundness edge, and pinning `scanf-false-3`'s genuine NULL-deref property after it
+had relied on the removed false positive). Three new regression tests + one repaired. **PR #5666** (off
+master, independent of the doc chain).
+
+### 17.2 #4611 — witness GraphML concrete items verified already-resolved
+
+#4611 lists four GraphML witness tweaks from the defunct `adjust_type` branch. Audited the current
+emitter (`src/goto-symex/witnesses.cpp`) by inspecting `--witness-output-graphml -` output on a failing
+assert (heap write) and a function-return counterexample:
+
+* **Key naming (item 1).** Current output already emits the modern-spec `enterFunction` /
+  `returnFromFunction` keys (the 2020-onwards format the issue identifies as conformant). No change
+  needed.
+* **No duplicate nodes (item 2).** Node/edge counts are minimal and consistent (4 nodes/3 edges for the
+  heap-assert trace, 5/4 for the function-return trace); no repeated initial edge.
+* **No out-of-file trace steps (item 3).** Despite `<assert.h>`/`<stdlib.h>` on the path, every emitted
+  edge carries only user-file `startline`s — no system-header pollution.
+
+So #4611's concrete, isolation-verifiable items are **already satisfied** in mainline; the only residual
+is the external-validator audit (run a witness through CPAchecker/Ultimate to confirm key acceptance),
+not reproducible in this environment (no validators). #4611 reduces to that validation-only residual,
+the same class as #1471/#1492.
+
+### 17.3 Pass-13 running report
+
+**Analysed.** §16.2 scanf residual fixed (#5666); #4611 concrete items verified resolved; in-flight PR
+states reconciled.
+
+**PRs opened.** This doc reconciliation (stacked on the #5664 doc chain). The code deliverable of the
+pass is **#5666** (scanf). In flight from earlier passes: **#5660** (#5142 parse layer), **#5664**
+(#1470 witness-assignment regression tests).
+
+**Duplicated work avoided.** #4611 not patched — concrete items already in mainline (§17.2). The
+research-grade backlog (value-set #5145/#5393/#5394, reachability #5400/#5138, va_list #5012,
+k-induction #4980/#4438, atomics #4432, device-API) is unchanged — none is isolation-verifiable here,
+so none was patched with a heuristic.
+
+**Remaining work (priority order, updated 2026-06-28, Pass 13).** Item 6 (scanf) closed; #4611 moved to
+the validation-only residual:
+1. **#5145 / #5393 / #5394** — aws-hash byte-addressed pointer-read-consistency (closed #5369 RCA).
+2. **#5400 / #5138** — value-set reachability for `valid-memtrack` (sound under-approximation).
+3. **#5012** — G-C `va_list` argument recovery (symbolic-format printf return length).
+4. **#4980 / #4438** — k-induction precision (termination recogniser + neural-network float CE);
+   full-set validation.
+5. **#4432** — data-race-checker interleaving reduction on `__atomic_*`.
+6. **#5142 residual** — no-overflow precision layer once parsed (x86 + full-benchmark-gated).
+7. **Device-API / LDV-environment model** (`platform_get_drvdata` etc.) — shared #5396–#5399 blocker.
+8. **#5565 residual** — `strcmp` argv-string pointer-validity (`fclose` half discharged, §15.2).
+9. **Validation-only close-outs (need CPAchecker/Ultimate):** witness end-to-end validation for
+   #1471 / #1492 / #4611 (concrete items resolved §17.2); #4427 false-negative; #1470 (verified fixed
+   §16.1, recommend closing).
+
+---
+
+## 18. Pass 14 — close the verified-fixed witness issues + scanf parser false-negative (2026-06-28)
+
+This pass reconciles two concrete state changes since Pass 13: three witness issues were verified fixed
+and **closed**, and the scanf overflow-check PR (#5666) was extended with a second, independent
+correctness fix. No new SV-COMP issue has been filed (newest still 2026-06-17). Host: aarch64 macOS.
+
+### 18.1 Issues closed (3)
+
+A full validity re-audit of the 20 open SV-COMP issues confirmed three are effectively fixed in
+mainline; they were closed with evidence-bearing comments:
+
+| # | Property | Why closed |
+|---|---|---|
+| #1470 | overflow witness assignment | Witness now emits `data == INT64_MAX` on the assignment edge (§16.1); regression tests in #5664. |
+| #4611 | witness GraphML keys / dup nodes | Concrete items already in mainline — modern `enterFunction`/`returnFromFunction` keys, no duplicate nodes, no system-header trace pollution (§17.2). Residual is validator-audit only. |
+| #1471 | struct constant in witness not parseable | Struct constants are no longer emitted as unparseable brace literals (omitted instead, per #5038); the parse failure is gone. |
+
+Open SV-COMP count: 20 → **17**.
+
+### 18.2 scanf overflow-check — second fix: `%%`/`%*` false negative (extends #5666)
+
+The §16.2 scanf work (PR #5666) initially fixed the *false positive* on width-less numeric
+conversions (§17.1). Reviewing that change surfaced an independent *false negative* in the same parser:
+a `%%` literal and a `%*...` assignment-suppressed directive consume **no** argument, but the format
+parser pushed a phantom `limits[]` entry for each. That misaligned `limits[]` against the argument list
+and tripped `too few arguments for format specifiers`, which **abandons the entire scanf overflow
+check** — silently dropping a genuine overflow on a following `%s`. Reproduced: `scanf("%*d %s", buf)`
+and `scanf("100%% %s", buf)` into `char[4]` were reported SUCCESSFUL. **Fix:** skip `%%`/`%*` during
+parsing so real conversions line up with their arguments. Now correctly FAILED; no new false positive;
+full `cstd` suite green. Added `scanf_suppressed_assignment_overflow_bug`. PR #5666 now bundles both the
+false-positive and false-negative parser fixes.
+
+### 18.3 Pass-14 running report
+
+**Analysed.** Validity re-audit of all 20 open SV-COMP issues; three closed (§18.1); scanf parser
+false-negative fixed and folded into #5666 (§18.2); in-flight PR states reconciled (no CI failures).
+
+**PRs.** Code: **#5666** (scanf parser — both directions). In flight: **#5660** (#5142 parse layer),
+**#5664** (#1470 regression tests). This doc update continues the #5667 reconciliation chain (Pass 13 +
+14) rather than opening a fourth stacked doc PR.
+
+**Duplicated work avoided.** The closed issues (#1470/#4611/#1471) are not re-touched. The research-grade
+backlog is unchanged — none isolation-verifiable here, so none patched with a heuristic.
+
+**Remaining work (priority order, updated 2026-06-28, Pass 14).** The witness close-outs #1470/#4611/
+#1471 are gone (closed); the scanf parser is complete:
+1. **#5145 / #5393 / #5394** — aws-hash byte-addressed pointer-read-consistency (closed #5369 RCA).
+2. **#5400 / #5138** — value-set reachability for `valid-memtrack`; #5138 narrowed to the `strcmp`
+   argv-string residual (other layers fixed by #5564/#5624 + the `fclose` guard).
+3. **#5012** — G-C `va_list` argument recovery (symbolic-format printf return length).
+4. **#4980 / #4438** — k-induction precision (termination recogniser + neural-network float CE);
+   full-set validation.
+5. **#4432** — data-race-checker interleaving reduction on `__atomic_*` (libvsync mcslock; large
+   benchmark + concurrency k-induction, not isolation-reproducible here).
+6. **#5142 residual** — no-overflow precision layer once parsed (x86 + full-benchmark-gated).
+7. **Device-API / LDV-environment model** (`platform_get_drvdata` etc.) — shared #5396–#5399/#4439
+   blocker.
+8. **#4427** — false-negative on unreach-call (missed bug; hardest class).
+9. **Validation-only (need CPAchecker/Ultimate):** #1492 FP witness validation; #1447 benchmark
+   incorrect-verdicts umbrella; #1440 wrapper-script sub-property handling (speculative, no property
+   file yet).

--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -1297,3 +1297,91 @@ its `fclose`/`strcmp` residual (lower priority, `ESBMC_SVCOMP`-gated):
 8. **#5565 residual** — `ESBMC_SVCOMP`-gated `fclose(stdout)` static-stream free + `strcmp` argv-string
    pointer-validity; reproduce under a `-DESBMC_SVCOMP=On` build.
 9. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.
+
+---
+
+## 14. Pass 10 — reconcile #5624 + universalise the #5142 int-conversion relaxation (2026-06-28)
+
+Pass 9 closed on 2026-06-26. This pass reconciles the Pass-9 PR (now merged) and produces **one sound
+localized frontend fix** for the most feasible remaining item, **#5142**. No new SV-COMP issues have
+been filed since 2026-06-17 (all already triaged), so the priority list is otherwise unchanged. Host:
+**x86_64-independent** — the fix and its tests are architecture-neutral and were validated on aarch64
+macOS (ESBMC 8.3.0, master `f343663bde`).
+
+### 14.1 Closed since Pass 9
+
+| # | Property | Closed | Outcome |
+|---|---|---|---|
+| #5565 | valid-memsafety (`comm_3args_ok`, `getopt_long`/`optarg` layer) | merged | Pass-9 PR landed as **#5624** (`[om] model getopt_long/getopt_long_only so optarg is a valid pointer`). The `fclose`/`strcmp` residual (§13.2) stays open, `ESBMC_SVCOMP`-gated. |
+
+### 14.2 #5142 — `m0_drivers-media-rc-imon`: int-conversion relaxation made universal — FIXED (parse layer)
+
+**Status: FIXED (parse-blocker layer). Sound localized frontend change + two regression tests
+(repurposed from #5530). PR opened.**
+
+Pass 8 (§12.5) re-classified #5142 as a clang-strictness parse blocker: clang 15+ promotes
+`-Wint-conversion` to a hard error, rejecting the CIL-emitted sentinel initialiser
+`static struct mutex driver_lock = { …, 0xffffffffffffffffUL, … }`. ESBMC already carried
+`-Wno-int-conversion`, **but only inside the `--sv-comp` block** of
+`clang_c_languaget::build_compiler_args` (`src/clang-c-frontend/clang_c_language.cpp`). Immediately
+below it, the sibling relaxation `-Wno-incompatible-pointer-types` is applied **universally** (same
+class — "became a hard error … trips across all platforms"). The asymmetry meant a plain
+`esbmc foo.c` on clang 15+ still hard-errored on GCC-acceptable implicit int↔pointer conversions that
+ESBMC fully models.
+
+**Fix.** Move `-Wno-int-conversion` out of the `--sv-comp` block to the universal section, beside
+`-Wno-incompatible-pointer-types`. Reproduced and verified directly:
+
+* `void *p = 0xdeadbeefUL;` (no cast) → plain run was `ERROR: PARSING ERROR`; now `VERIFICATION
+  SUCCESSFUL`. `--sv-comp` already accepted it (proving the relaxation, not a semantics change, is the
+  fix).
+* The conversion is still **modeled, not rubber-stamped**: the same code with a wrong round-trip
+  assertion reports `VERIFICATION FAILED` (value preserved through int→ptr→int).
+
+**Why it is sound.** Purely a diagnostic-level change — it affects only whether clang refuses to
+parse, not the AST/GOTO semantics. GCC (the compiler ESBMC targets) only *warns* on this construct, so
+matching GCC is the correct behaviour; there is no program GCC rejects that ESBMC now silently accepts.
+Inherited unchanged by `clang_cpp_languaget`, where the flag is a no-op (C++ int↔pointer is a genuine
+type error not governed by `-Wint-conversion`), so C++ checking is not weakened. Code-reviewed: 0
+critical/major/minor findings.
+
+**Validation.** Two regressions under `regression/esbmc/`, repurposed from #5530 by dropping their
+`--sv-comp` flag so they now pin the *universal* path: `github_5142_int_conversion` (implicit int→ptr
+round-trip ⇒ SUCCESSFUL) and `github_5142_int_conversion_fail` (wrong round-trip value ⇒ FAILED, with
+the violated-property message). Both pass; a 52-test conversion/cast regression sample
+(`to_union*`, `*nondet_int_ptr*`, `github_382*`, `github_270*`, …) is green — no test depends on
+int-conversion being a hard error.
+
+**Residual.** This closes only the *parse-blocker* layer of #5142. The downstream no-overflow precision
+layer (whether the benchmark verdict is correct once it parses) is x86 + full-benchmark-gated and not
+reproducible in isolation here — it stays in the research-grade LDV-environment class. Keep #5142 open
+for that layer.
+
+### 14.3 Pass-10 running report
+
+**Analysed.** Pass-9 closure (#5624) reconciled; GitHub SV-COMP issue list re-swept (no new issues
+since 2026-06-17); #5142 parse layer reproduced and fixed.
+
+**PRs opened.** One: `[clang-frontend] apply -Wno-int-conversion universally, not only under --sv-comp`
+— addresses **#5142** (parse-blocker layer). Sound diagnostic-level change, code-reviewed, two
+regression tests.
+
+**Duplicated work avoided.** #5565 not re-fixed — its primary layer merged as #5624. The remaining
+research-grade items (#5145/#5393/#5394 value-set, #5400/#5138 reachability, #5012 va_list, #4980
+termination, #4432 atomics, device-API modelling) are unchanged — each requires a subsystem change
+that cannot be validated against the full SV-COMP set in this environment, so none was patched with a
+heuristic.
+
+**Remaining work (priority order, updated 2026-06-28).** As §13.3, with #5142 reduced to its
+no-overflow precision layer:
+1. **#5145 / #5393 / #5394** — aws-hash byte-addressed pointer-read-consistency (closed #5369 RCA).
+2. **#5400 / #5138** — value-set reachability for `valid-memtrack` (sound under-approximation).
+3. **#5012** — G-C `va_list` argument recovery (symbolic-format printf return length).
+4. **#4980** — termination ranking recogniser for side-effect-only call bodies (full-set validation).
+5. **#4432** — data-race-checker interleaving reduction on `__atomic_*`.
+6. **#5142 residual** — no-overflow precision layer once parsed (x86 + full-benchmark-gated;
+   research-grade LDV-environment class).
+7. **Device-API / LDV-environment model** (`platform_get_drvdata` etc.) — shared #5396–#5399 blocker.
+8. **#5565 residual** — `ESBMC_SVCOMP`-gated `fclose(stdout)` static-stream free + `strcmp` argv-string
+   pointer-validity; reproduce under a `-DESBMC_SVCOMP=On` build.
+9. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.

--- a/regression/esbmc/github_1470_overflow_witness/main.c
+++ b/regression/esbmc/github_1470_overflow_witness/main.c
@@ -1,0 +1,15 @@
+// Companion to github_1470_overflow_witness_fail: when the input is constrained
+// so that `data + 1` cannot overflow, ESBMC must report no overflow (no spurious
+// violation witness). Pins that the overflow check is value-sensitive, not a
+// blanket alarm on nondet operands.
+#include <stdint.h>
+
+extern int64_t nondet_int64(void);
+
+int main(void)
+{
+  int64_t data = nondet_int64();
+  __ESBMC_assume(data < 9223372036854775807LL);
+  int64_t result = data + 1; // cannot overflow: data <= INT64_MAX - 1
+  return result == 0;
+}

--- a/regression/esbmc/github_1470_overflow_witness/test.desc
+++ b/regression/esbmc/github_1470_overflow_witness/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_1470_overflow_witness_fail/main.c
+++ b/regression/esbmc/github_1470_overflow_witness_fail/main.c
@@ -1,0 +1,15 @@
+// Regression for github #1470: the GraphML violation witness for an arithmetic
+// overflow must record the assignment to the overflowing variable, otherwise
+// external validators (UAutomizer/CPAchecker) cannot replay the counterexample.
+// Signed `data + 1` overflows iff data == INT64_MAX, so the witness must emit
+// the assumption `data == 9223372036854775807` on the assignment edge.
+#include <stdint.h>
+
+extern int64_t nondet_int64(void);
+
+int main(void)
+{
+  int64_t data = nondet_int64();
+  int64_t result = data + 1; // overflow when data == INT64_MAX
+  return result == 0;
+}

--- a/regression/esbmc/github_1470_overflow_witness_fail/test.desc
+++ b/regression/esbmc/github_1470_overflow_witness_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--overflow-check --witness-output-graphml -
+data == 9223372036854775807
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_5142_int_conversion/main.c
+++ b/regression/esbmc/github_5142_int_conversion/main.c
@@ -1,8 +1,8 @@
 // Implicit unsigned-long -> void* conversion. clang 15+ treats -Wint-conversion
-// as a hard error by default and rejects this at parse time unless ESBMC passes
-// -Wno-int-conversion, which it does under SV-COMP mode (--sv-comp). Mirrors the
-// `struct mutex` sentinel initializer in the SV-COMP imon benchmark (#5142),
-// which CIL emits as (void *)0xffffffffffffffffUL.
+// as a hard error by default and rejects this at parse time; ESBMC passes
+// -Wno-int-conversion universally (GCC only warns), so this parses with no
+// special flags. Mirrors the `struct mutex` sentinel initializer in the
+// SV-COMP imon benchmark (#5142), which CIL emits as (void *)0xffffffffffffffffUL.
 int main(void)
 {
   void *p = 0xdeadUL; // implicit int -> pointer

--- a/regression/esbmc/github_5142_int_conversion/test.desc
+++ b/regression/esbmc/github_5142_int_conversion/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---sv-comp
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5142_int_conversion_fail/test.desc
+++ b/regression/esbmc/github_5142_int_conversion_fail/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---sv-comp
+
 ^Violated property:$
 ^\s*v is 0xdead, not 0 -- must fail$
 ^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -253,12 +253,6 @@ void clang_c_languaget::build_compiler_args(
     // No longer show compiler warnings for SV-COMP
     compiler_args.push_back("-w");
     compiler_args.push_back("-Wno-incompatible-function-pointer-types");
-    // clang 15+ promotes -Wint-conversion to a hard error by default, which
-    // rejects GCC-acceptable implicit int<->pointer conversions common in
-    // preprocessed kernel/CIL inputs (e.g. the sentinel pointers CIL emits as
-    // (void *)0xffffffffffffffffUL). ESBMC models the conversion in its
-    // typecast logic, so downgrading the diagnostic does not affect semantics.
-    compiler_args.push_back("-Wno-int-conversion");
   }
 
   // Increase maximum bracket depth
@@ -271,6 +265,14 @@ void clang_c_languaget::build_compiler_args(
   // Suppress incompatible-pointer-types universally; became a hard error in
   // LLVM 22 and trips on system headers across all platforms.
   compiler_args.emplace_back("-Wno-incompatible-pointer-types");
+
+  // clang 15+ promotes -Wint-conversion to a hard error by default, which
+  // rejects GCC-acceptable implicit int<->pointer conversions common in
+  // preprocessed kernel/CIL inputs (e.g. the sentinel pointers CIL emits as
+  // (void *)0xffffffffffffffffUL) and ordinary embedded/legacy C. GCC only
+  // warns; ESBMC models the conversion in its typecast logic, so downgrading
+  // the diagnostic preserves GCC compatibility without affecting semantics.
+  compiler_args.emplace_back("-Wno-int-conversion");
 
   /* put custom options at the end of the cmdline such that they can override
    * whatever defaults we put in before. */


### PR DESCRIPTION
clang 15+ promotes -Wint-conversion to a hard error by default, rejecting GCC-acceptable implicit int-to-pointer conversions, but ESBMC carried -Wno-int-conversion only inside the --sv-comp block of build_compiler_args, so a plain esbmc run still hard-errored at parse time. Move -Wno-int-conversion to the universal section beside -Wno-incompatible-pointer-types; this is a diagnostic-level change only, matching GCC, with conversion semantics unchanged.

Refs #5142.
