### PR TITLE
[python] Support int.from_bytes(byteorder=) keyword form

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,57 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 40. 2026-06-28 re-validation (thirtieth sweep) & int.from_bytes(byteorder=) keyword form
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+This sweep took the `int.from_bytes(byteorder=)` keyword form catalogued in §37b/§38b/§39b — the last
+small adjacent entry in the `from_bytes` family before the deferred §36a literal-argument lowering.
+
+### 40a. New isolated, soundly-fixable defect found & fixed
+**`int.from_bytes(b, byteorder="big")` (the keyword endianness form) raised a spurious `TypeError`.**
+
+The positional form `int.from_bytes(b, "big")` verifies (§35/§37), but the keyword form reported
+`FAILED` (uncaught `TypeError: from_bytes() missing 1 required positional argument: 'big_endian'`).
+Two layers conspired: the AST normalizer `_normalize_int_from_bytes_endianness`
+(`preprocessor/core_visitors_mixin.py`) folded the `"big"`/`"little"` string to a bool only for the
+**positional** argument (`node.args[1]`, guarded on `len(node.args) > 1`); and the operational model
+(`models/int.py`) names the endianness parameter `big_endian`, whereas CPython's keyword is
+`byteorder` — so a `byteorder=` keyword matched no model parameter and was reported as a missing
+positional argument by `_fill_missing_args_with_defaults`.
+
+**Fix** (`preprocessor/core_visitors_mixin.py`): extend `_normalize_int_from_bytes_endianness` to also
+walk `node.keywords` — when a `byteorder` keyword is present, **rename** it to the model's `big_endian`
+parameter and **fold** its constant string value to the bool the model expects (`"big" → True`,
+otherwise `False`, the same rule the positional path uses). The positional branch is refactored to the
+same `is_big` form (behaviour-identical: `True` only for the constant `"big"`, else `False`). The
+keyword-only `signed` argument already matches the model parameter name, so it is untouched and
+continues to work (`signed=True` two's-complement verified). A non-constant `byteorder` keyword folds
+to little-endian — the same pre-existing limitation as the positional path, not a new regression.
+
+Like §35a/§37a this **restores a working feature**. New regression pair
+`regression/python/int_from_bytes_byteorder_kw{,_fail}` (CORE) covering keyword big/little, the
+`signed=True`/`signed=False` keyword composition, the unchanged positional form, and a single byte;
+the positive test is the liveness witness (uncaught-`TypeError` `FAILED` pre-fix → `SUCCESSFUL`
+post-fix). All receivers are bytes **variables** because a bytes literal passed directly as the
+argument is the separate, deferred §36a lowering issue. Verified bit-for-bit against CPython; CPython
+sanity passes (`scripts/check_python_tests.sh from_bytes`); pylint clean on the changed file (the two
+pre-existing `listcomp_counter` E1101 false-positives are unrelated); the focused
+`regression/python/int_from_bytes*` ctest subset (8 tests) is 100% green. The preprocessor is
+FLAIL-mangled into the binary, so it was rebuilt before testing. Solver-agnostic (an AST-normalisation
+change, no SMT encoding).
+
+### 40b. Next candidate & everything else: unchanged disposition
+The `from_bytes` family is now complete except the deferred §36a bytes-**literal-argument** lowering
+(needs the frontend `get_literal` context fix). Remaining catalogued candidates: `str.maketrans`/
+`translate` dict-table and non-constant forms (fall through cleanly today); multi-byte (non-ASCII)
+UTF-8 encode/decode; and `bytes.hex(sep)` (shipped in flight as §39/PR #5661). The separately-tracked
+inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`,
+symbolic/user-function `max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()` (infeasible),
+and `str.isascii()` (string-soundness, §5-#2). The §3 design-level blockers, §3c timeouts, §3d
+questionable expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39 (PR #5661, `bytes.hex(sep[, bytes_per_sep])`) is in flight and not yet on
+> `master`; this sweep is appended as §40. When both land, the maintainer orders §39 → §40.

--- a/regression/python/int_from_bytes_byteorder_kw/main.py
+++ b/regression/python/int_from_bytes_byteorder_kw/main.py
@@ -1,0 +1,23 @@
+def main() -> None:
+    # int.from_bytes accepts byteorder as a keyword (CPython's parameter name),
+    # even though the operational model names the parameter big_endian. A bytes
+    # variable receiver is used throughout (a bytes literal passed directly as
+    # the argument is a separate, deferred lowering issue).
+    b = bytes([1, 2])
+    assert int.from_bytes(b, byteorder="big") == 258
+    assert int.from_bytes(b, byteorder="little") == 513
+
+    # The keyword form composes with the keyword-only signed argument.
+    neg = bytes([255, 0])
+    assert int.from_bytes(neg, byteorder="big", signed=True) == -256
+    assert int.from_bytes(neg, byteorder="big", signed=False) == 65280
+
+    # The positional form is unchanged.
+    assert int.from_bytes(b, "little") == 513
+
+    # A single byte is endianness-independent.
+    one = bytes([7])
+    assert int.from_bytes(one, byteorder="little") == 7
+
+
+main()

--- a/regression/python/int_from_bytes_byteorder_kw/test.desc
+++ b/regression/python/int_from_bytes_byteorder_kw/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_from_bytes_byteorder_kw_fail/main.py
+++ b/regression/python/int_from_bytes_byteorder_kw_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    # int.from_bytes(b, byteorder="big") == 258 for b == bytes([1, 2]), not 257.
+    b = bytes([1, 2])
+    assert int.from_bytes(b, byteorder="big") == 257
+
+
+main()

--- a/regression/python/int_from_bytes_byteorder_kw_fail/test.desc
+++ b/regression/python/int_from_bytes_byteorder_kw_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -799,13 +799,22 @@ class CoreVisitorsMixin:
 
     @staticmethod
     def _normalize_int_from_bytes_endianness(node):
-        if (isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "int" and node.func.attr == "from_bytes"
-                and len(node.args) > 1):
-            if isinstance(node.args[1], ast.Constant) and node.args[1].value == "big":
-                node.args[1] = ast.Constant(value=True)
-            else:
-                node.args[1] = ast.Constant(value=False)
+        if not (isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "int" and node.func.attr == "from_bytes"):
+            return
+        # Positional byteorder: int.from_bytes(b, "big" | "little").
+        if len(node.args) > 1:
+            is_big = isinstance(node.args[1], ast.Constant) and node.args[1].value == "big"
+            node.args[1] = ast.Constant(value=is_big)
+        # Keyword byteorder=: CPython names the parameter "byteorder"; the OM
+        # model names it "big_endian". Rename the keyword to the model's
+        # parameter and fold its string value to the bool the model expects.
+        for kw in node.keywords:
+            if kw.arg == "byteorder":
+                is_big = isinstance(kw.value, ast.Constant) and kw.value.value == "big"
+                kw.arg = "big_endian"
+                kw.value = ast.Constant(value=is_big)
+        ast.fix_missing_locations(node)
 
     def _fill_missing_args_with_defaults(self, node, function_name, expected_args, keywords):
         missing_args = []


### PR DESCRIPTION
## What

`int.from_bytes(b, byteorder="big")` — the keyword endianness form — raised a spurious `TypeError` and reported `VERIFICATION FAILED`, even though the positional form `int.from_bytes(b, "big")` verifies. This is the `int.from_bytes(byteorder=)` candidate catalogued in §37b/§38b/§39b of the Python triage report.

## Why

Two layers conspired:

- The AST normalizer `_normalize_int_from_bytes_endianness` folded the `"big"`/`"little"` string to a bool only for the **positional** argument (`node.args[1]`).
- The operational model (`models/int.py`) names the endianness parameter `big_endian`, while CPython's keyword is `byteorder`. So a `byteorder=` keyword matched no model parameter and was reported as a missing positional argument (`TypeError: from_bytes() missing 1 required positional argument: 'big_endian'`).

## How

Extend `_normalize_int_from_bytes_endianness` (`preprocessor/core_visitors_mixin.py`) to also walk `node.keywords`: when a `byteorder` keyword is present, rename it to the model's `big_endian` parameter and fold its constant string value to the bool the model expects (`"big" → True`, else `False` — the same rule the positional path uses). The positional branch is refactored to the same `is_big` form (behavior-identical). The keyword-only `signed` argument already matches the model parameter name and is untouched.

## Testing

- New CORE regression pair `regression/python/int_from_bytes_byteorder_kw{,_fail}` covering keyword big/little, `signed=True`/`signed=False` composition, the unchanged positional form, and a single byte. The positive test is the liveness witness (uncaught-`TypeError` FAILED pre-fix → SUCCESSFUL post-fix). All receivers are bytes variables (a bytes literal passed directly as the argument is the separate, deferred §36a lowering issue).
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh from_bytes` passes; pylint clean on the changed file; focused `regression/python/int_from_bytes*` ctest subset (8 tests) is 100% green.
- The preprocessor is FLAIL-mangled into the binary, so it was rebuilt before testing. Solver-agnostic (AST-normalisation, no SMT encoding).
