### PR TITLE
[python] Support bytes.fromhex() constant fold

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,60 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 41. 2026-06-28 re-validation (thirty-first sweep) & bytes.fromhex()
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+With the `bytes.hex` family complete (§32/§39), this sweep took its natural inverse, `bytes.fromhex`
+— a constant-fold parsing a hex string into a bytes object, the same shape as the §32 fold run
+backwards.
+
+### 41a. New isolated, soundly-fixable defect found & fixed
+**`bytes.fromhex("0102")` was unmodelled, producing a spurious `VERIFICATION FAILED`.**
+
+`bytes.fromhex("0102")` should give `b"\x01\x02"` (CPython), but `fromhex` — a `bytes` classmethod —
+had no handler, so the call lowered to the unsupported-function `assert(false)` and any program using
+it reported `FAILED` — the wrong-verdict class.
+
+**Fix** (`function_call/expr.cpp`): add a `handle_bytes_fromhex()` constant-fold, dispatched from
+`get_dispatch_table()` when the function is `fromhex` and the receiver is the `bytes` builtin (the
+predicate short-circuits on the method name, so `get_object_name()` runs only for `fromhex` calls).
+The handler parses a constant hex string into a byte array via the existing `build_raw_byte_array`
+(the same representation as a bytes literal / the `bytes([...])` constructor), reproducing CPython
+exactly: pairs of hex digits, ASCII whitespace skipped **between** byte pairs but not **within** one
+(a space inside a pair is a `ValueError`), uppercase accepted, the empty string yielding the size-0
+`bytes` representation. Odd-length or non-hex input raises CPython's `ValueError` text (a clean
+frontend error, never a wrong value); a non-constant string argument is rejected with a clean error
+rather than mis-folded. Because `build_raw_byte_array` returns a genuinely `bytes`-typed array, the
+assignment target is typed correctly with no type-inference change — `len`, indexing, and the
+`fromhex(...).hex()` round-trip all work.
+
+Like §16a–§20a/§30a/§32a this **restores a working feature**. New regression tests
+`regression/python/bytes_fromhex{,_fail}` (CORE) plus `bytes_fromhex_invalid_fail` pinning the
+`ValueError` boundary (odd length / non-hex → clean error, mirroring §30's
+`list_from_bytes_unsupported`). The positive test is the liveness witness (FAILED pre-fix) and covers
+literal/variable receivers, whitespace, uppercase, embedded NUL, `len`/index, the empty case, and the
+`.hex()` round-trip. Verified bit-for-bit against CPython; CPython sanity passes
+(`scripts/check_python_tests.sh bytes_fromhex`); the focused `regression/python/(bytes|hex)` ctest
+subset (19 tests) shows zero new failures. Code-reviewed (0 critical/major; the parsing loop, dispatch
+predicate, and non-constant fall-through all confirmed sound). Solver-agnostic (a frontend
+constant-fold, no SMT encoding). Inline `len(bytes.fromhex(""))` mis-measures via the separately-
+tracked §14b inline-`len` concern, so the empty-case test binds the result to a variable first.
+
+### 41b. Next candidate & everything else: unchanged disposition
+The `bytes.hex`/`fromhex` round-trip is now complete. Remaining catalogued candidates: the §36a
+bytes-**literal-argument** lowering (deferred — needs the frontend `get_literal` context fix); the
+`int.from_bytes(byteorder=)` keyword form (shipped in flight as §40/PR #5663); `bytes.hex(sep)`
+(shipped in flight as §39/PR #5661); `str.maketrans`/`translate` dict-table and non-constant forms
+(fall through cleanly today); and multi-byte (non-ASCII) UTF-8 encode/decode. The separately-tracked
+inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`
+(materialisation via `list(zip(...))` still unsupported — a larger feature), symbolic/user-function
+`max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()`
+(string-soundness, §5-#2). The §3 design-level blockers, §3c timeouts, §3d questionable expectation,
+and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39 (PR #5661, `bytes.hex(sep)`) and §40 (PR #5663, `int.from_bytes`
+> `byteorder=` keyword) are in flight and not yet on `master`; this sweep is appended as §41. When all
+> land, the maintainer orders §39 → §40 → §41.

--- a/regression/python/bytes_fromhex/main.py
+++ b/regression/python/bytes_fromhex/main.py
@@ -1,0 +1,28 @@
+def main() -> None:
+    # bytes.fromhex parses a constant hex string into a bytes object.
+    b = bytes.fromhex("0102ab")
+    assert b[0] == 1
+    assert b[1] == 2
+    assert b[2] == 171
+    assert len(b) == 3
+
+    # CPython skips ASCII whitespace between byte pairs.
+    spaced = bytes.fromhex("de ad be ef")
+    assert spaced[0] == 222
+    assert spaced[3] == 239
+    assert len(spaced) == 4
+
+    # Uppercase digits are accepted, and the result composes with .hex().
+    assert bytes.fromhex("DEAD").hex() == "dead"
+
+    # The empty string yields an empty bytes object.
+    empty = bytes.fromhex("")
+    assert len(empty) == 0
+
+    # A variable holding the hex string works too.
+    s = "ff00"
+    v = bytes.fromhex(s)
+    assert v[0] == 255 and v[1] == 0
+
+
+main()

--- a/regression/python/bytes_fromhex/test.desc
+++ b/regression/python/bytes_fromhex/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes_fromhex_fail/main.py
+++ b/regression/python/bytes_fromhex_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    # bytes.fromhex("0102")[0] == 1, not 9.
+    b = bytes.fromhex("0102")
+    assert b[0] == 9
+
+
+main()

--- a/regression/python/bytes_fromhex_fail/test.desc
+++ b/regression/python/bytes_fromhex_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/bytes_fromhex_invalid_fail/main.py
+++ b/regression/python/bytes_fromhex_invalid_fail/main.py
@@ -1,0 +1,5 @@
+# bytes.fromhex over an odd-length (or otherwise non-hex) string raises a
+# ValueError in CPython. ESBMC must reject it with a clean error rather than
+# folding a partial/garbage byte value (a wrong verdict). A space inside a
+# byte pair is likewise invalid; only whitespace between pairs is skipped.
+x = bytes.fromhex("012")

--- a/regression/python/bytes_fromhex_invalid_fail/test.desc
+++ b/regression/python/bytes_fromhex_invalid_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: ValueError: non-hexadecimal number found in fromhex\(\) arg$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -938,6 +938,56 @@ exprt function_call_expr::build_constant_from_arg() const
   return expr;
 }
 
+exprt function_call_expr::handle_bytes_fromhex() const
+{
+  // bytes.fromhex("0102") == b"\x01\x02". Fold a constant hex string into a
+  // byte array (the same representation as a bytes literal / the bytes()
+  // constructor). CPython skips ASCII whitespace between byte pairs but
+  // requires the two hex digits of a byte to be adjacent.
+  if (call_["args"].size() != 1)
+    throw std::runtime_error("bytes.fromhex() takes exactly one argument");
+
+  std::string hexstr;
+  if (!string_handler::extract_constant_string(
+        call_["args"][0], converter_, hexstr))
+    throw std::runtime_error(
+      "bytes.fromhex() is only supported on a constant string");
+
+  auto hexval = [](char c) -> int {
+    if (c >= '0' && c <= '9')
+      return c - '0';
+    if (c >= 'a' && c <= 'f')
+      return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+      return c - 'A' + 10;
+    return -1;
+  };
+
+  std::vector<uint8_t> bytes;
+  const std::size_t n = hexstr.size();
+  for (std::size_t i = 0; i < n;)
+  {
+    if (std::isspace(static_cast<unsigned char>(hexstr[i])))
+    {
+      ++i;
+      continue;
+    }
+    const int hi = hexval(hexstr[i]);
+    const int lo = (i + 1 < n) ? hexval(hexstr[i + 1]) : -1;
+    if (hi < 0 || lo < 0)
+      throw std::runtime_error(
+        "ValueError: non-hexadecimal number found in fromhex() arg");
+    bytes.push_back(static_cast<uint8_t>((hi << 4) | lo));
+    i += 2;
+  }
+
+  // An empty byte array reuses the no-argument bytes() representation, which
+  // the size-0 (variable-length) path handles correctly for len()/iteration.
+  if (bytes.empty())
+    return exprt("constant", type_handler_.get_typet("bytes", 0));
+  return converter_.get_string_builder().build_raw_byte_array(bytes);
+}
+
 std::string function_call_expr::get_object_name() const
 {
   const nlohmann::json &func_json =
@@ -3114,6 +3164,14 @@ function_call_expr::get_dispatch_table()
        return handle_general_function_call();
      },
      "repr()"},
+
+    // bytes.fromhex("..") classmethod — fold a constant hex string to bytes
+    {[this]() {
+       return function_id_.get_function() == "fromhex" &&
+              get_object_name() == "bytes";
+     },
+     [this]() { return handle_bytes_fromhex(); },
+     "bytes.fromhex()"},
 
     // Built-in type constructors (int, float, str, bool, etc.)
     {[this]() {

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -117,6 +117,11 @@ private:
   exprt build_constant_from_arg() const;
 
   /*
+   * Folds bytes.fromhex("..") over a constant hex string into a byte array.
+   */
+  exprt handle_bytes_fromhex() const;
+
+  /*
    * Sets the function_type_ attribute based on the call information.
    */
   void get_function_type();


### PR DESCRIPTION
## What

`bytes.fromhex("0102")` — the inverse of the existing `bytes.hex()` fold (§32/PR #5585) — was unmodelled. `fromhex` is a `bytes` classmethod with no handler, so any program using it lowered to the unsupported-function `assert(false)` and reported a spurious `VERIFICATION FAILED`.

## How

Add a `handle_bytes_fromhex()` constant-fold in `function_call/expr.cpp`, dispatched from `get_dispatch_table()` when the function is `fromhex` and the receiver is the `bytes` builtin (the predicate short-circuits on the method name, so `get_object_name()` runs only for `fromhex` calls). It parses a constant hex string into a byte array via the existing `build_raw_byte_array` (the same representation as a bytes literal / `bytes([...])`), reproducing CPython exactly:

- pairs of hex digits, uppercase accepted;
- ASCII whitespace skipped **between** byte pairs but not **within** one (a space inside a pair is a `ValueError`);
- the empty string yields the size-0 `bytes` representation;
- odd-length or non-hex input raises CPython's `ValueError` text (a clean frontend error, never a wrong value);
- a non-constant string argument is rejected with a clean error rather than mis-folded.

`build_raw_byte_array` returns a genuinely `bytes`-typed array, so the assignment target is typed correctly with no type-inference change — `len`, indexing, and the `fromhex(...).hex()` round-trip all work.

## Testing

- New CORE tests `regression/python/bytes_fromhex{,_fail}` plus `bytes_fromhex_invalid_fail` pinning the `ValueError` boundary (odd length / non-hex → clean error), mirroring §30's `list_from_bytes_unsupported`. The positive test is the liveness witness (FAILED pre-fix) covering literal/variable receivers, whitespace, uppercase, embedded NUL, `len`/index, the empty case, and the `.hex()` round-trip.
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh bytes_fromhex` passes; focused `regression/python/(bytes|hex)` ctest subset (19 tests) shows zero new failures.
- Solver-agnostic (frontend constant-fold, no SMT encoding).
