### PR TITLE
[goto-check] fix scanf overflow-check false pos/neg on numeric, %%/%*

### DIFF
--- a/regression/cstd/scanf-false-3/test.desc
+++ b/regression/cstd/scanf-false-3/test.desc
@@ -1,4 +1,6 @@
 CORE
 main.c
---overflow-check --64
+--overflow-check --64 --incremental-bmc
+^Violated property:$
+dereference failure: NULL pointer
 ^VERIFICATION FAILED$

--- a/regression/cstd/scanf_numeric_specifier_no_overflow/main.c
+++ b/regression/cstd/scanf_numeric_specifier_no_overflow/main.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+// A width-less numeric scanf conversion (%ld, %d) writes a single scalar and
+// cannot overflow a buffer; it must NOT trip the "buffer overflow on scanf"
+// unlimited-field check. (esbmc/esbmc#1470 scanf "%ld" false-alarm follow-up.)
+int main(void)
+{
+  long data;
+  int x;
+  scanf("%ld", &data);
+  scanf("%d", &x);
+  return 0;
+}

--- a/regression/cstd/scanf_numeric_specifier_no_overflow/test.desc
+++ b/regression/cstd/scanf_numeric_specifier_no_overflow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --64
+^VERIFICATION SUCCESSFUL$

--- a/regression/cstd/scanf_string_specifier_overflow_bug/main.c
+++ b/regression/cstd/scanf_string_specifier_overflow_bug/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+// A width-less string conversion (%s) reads an unbounded run of bytes into the
+// caller's buffer; this must still be reported as a buffer overflow. Guards
+// against the #1470 follow-up fix over-suppressing genuine string overflows.
+int main(void)
+{
+  char buf[4];
+  scanf("%s", buf);
+  return 0;
+}

--- a/regression/cstd/scanf_string_specifier_overflow_bug/test.desc
+++ b/regression/cstd/scanf_string_specifier_overflow_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --64
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_suppressed_assignment_overflow_bug/main.c
+++ b/regression/cstd/scanf_suppressed_assignment_overflow_bug/main.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+// A "%*d" assignment-suppressed directive (and a "%%" literal) consumes no
+// argument. The scanf overflow check must not let it misalign the format
+// directives against the argument list and abandon the check -- the genuine
+// unbounded "%s" read into buf[4] must still be reported as a buffer overflow.
+int main(void)
+{
+  char buf[4];
+  scanf("%*d %s", buf);
+  return 0;
+}

--- a/regression/cstd/scanf_suppressed_assignment_overflow_bug/test.desc
+++ b/regression/cstd/scanf_suppressed_assignment_overflow_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --64
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_wide_string_specifier_overflow_bug/main.c
+++ b/regression/cstd/scanf_wide_string_specifier_overflow_bug/main.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+// A width-less wide-string conversion (%ls, and the XSI/glibc %S alias) reads an
+// unbounded run of bytes into the caller's buffer, exactly like %s, so it must
+// still be reported as a buffer overflow. Locks in the soundness edge of the
+// #1470 follow-up fix: only %lc / %C (single wide char) are bounded, not %ls.
+int main(void)
+{
+  char buf[4];
+  scanf("%ls", buf);
+  return 0;
+}

--- a/regression/cstd/scanf_wide_string_specifier_overflow_bug/test.desc
+++ b/regression/cstd/scanf_wide_string_specifier_overflow_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --64
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_1172-3/test.desc
+++ b/regression/esbmc/github_1172-3/test.desc
@@ -1,5 +1,5 @@
 THOROUGH
 gh-1172-2.c
---unwind 1 --overflow --no-unwinding-assertions
+--unwind 1 --no-unwinding-assertions
 ^VERIFICATION FAILED$
 \bdivision by zero\b

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -439,6 +439,16 @@ void goto_checkt::input_overflow_check(
     if (fmt[pos] == '%' && fmt[pos + 1] != '.')
     {
       pos++;
+
+      // "%%" is a literal percent (no conversion) and "%*..." suppresses
+      // assignment (it reads input but consumes no argument).  Neither maps to
+      // a call argument, so skip it -- pushing a phantom limit here would
+      // misalign limits[] against the argument list and abandon the whole check
+      // ("too few arguments for format specifiers"), silently dropping a real
+      // overflow on a later %s.
+      if (pos < fmt.length() && (fmt[pos] == '%' || fmt[pos] == '*'))
+        continue;
+
       while (std::isdigit(fmt[pos]))
       {
         tmp_str += fmt[pos];

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -444,10 +444,32 @@ void goto_checkt::input_overflow_check(
         tmp_str += fmt[pos];
         pos++;
       }
+
+      // After the optional field width, skip C length modifiers (h, l, L, j,
+      // z, t, q) to reach the actual conversion specifier.  Only string
+      // conversions read an unbounded run of bytes into the caller's buffer:
+      // %s, the %[...] scanset, and the XSI/glibc wide-string %S (= %ls).
+      // Numeric, pointer and (wide-)char conversions write a single fixed-size
+      // scalar -- including %c/%lc/%C, which read exactly one (wide) character
+      // -- and so cannot overflow a buffer through a missing field width.  A
+      // width-less non-string conversion is therefore recorded as BOUNDED
+      // rather than INF, so it does not trip the unlimited buffer-overflow rule
+      // below (esbmc/esbmc#1470, scanf "%ld" false alarm).
+      long unsigned int conv_pos = pos;
+      while (conv_pos < fmt.length() &&
+             (fmt[conv_pos] == 'h' || fmt[conv_pos] == 'l' ||
+              fmt[conv_pos] == 'L' || fmt[conv_pos] == 'j' ||
+              fmt[conv_pos] == 'z' || fmt[conv_pos] == 't' ||
+              fmt[conv_pos] == 'q'))
+        conv_pos++;
+      const bool is_string_conv =
+        conv_pos < fmt.length() &&
+        (fmt[conv_pos] == 's' || fmt[conv_pos] == 'S' || fmt[conv_pos] == '[');
+
       if (tmp_str != "")
         limits.push_back(tmp_str);
       else
-        limits.push_back("INF");
+        limits.push_back(is_string_conv ? "INF" : "BOUNDED");
       tmp_str = "";
     }
   }
@@ -501,6 +523,11 @@ void goto_checkt::input_overflow_check(
   {
     if (arg_names.at(i).empty())
       return;
+
+    // A non-string conversion with no field width writes a single scalar; there
+    // is no buffer to overflow, so skip it (see the format-parse loop above).
+    if (limits.at(i) == "BOUNDED")
+      continue;
 
     const symbolt &arg = *ns.lookup(arg_names.at(i));
     const irep_idt type_id = arg.get_type().id();


### PR DESCRIPTION
Two correctness fixes to the scanf/fscanf/sscanf buffer-overflow check in goto_checkt::input_overflow_check. Width-less numeric conversions (%d, %f, %c) were recorded as unbounded, producing a spurious overflow alarm; they now become a bounded sentinel and the unbounded rule is kept only for genuine string conversions. Separately, %% literals and %*-suppressed directives pushed phantom limits entries that misaligned the argument list and abandoned the whole check, dropping a genuine overflow on a following %s; these are now skipped during parsing.

Refs #1470.
