### PR TITLE
[python] Fold float.is_integer() on a constant literal receiver

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,59 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 43. 2026-06-28 re-validation (thirty-third sweep) & float.is_integer() on a literal receiver
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+This sweep took the float analogue named in §42b — the literal-receiver dispatch gap for
+`float.is_integer()`, the float counterpart of §42's int methods.
+
+### 43a. New isolated, soundly-fixable defect found & fixed
+**`(2.0).is_integer()` (a float method on a *constant literal* receiver) reported a spurious
+`Unsupported function`.**
+
+`x.is_integer()` on a variable verifies (the float operational model `models/float.py` returns
+`x == int(x)`), but the bare-literal forms `(2.0).is_integer()`, `(2.5).is_integer()` reported
+`Unsupported function 'is_integer'` → `FAILED`. A literal receiver is not classified as a float
+instance (only a `Name`/`BinOp` receiver is), so the call never reached the model — the same
+class-resolution gap §34/§42 found for int methods.
+
+**Fix** (`function_call/expr.cpp`): add a `handle_float_is_integer_literal()` constant-fold,
+dispatched from `get_dispatch_table()` (next to the §34 `int.to_bytes` entry) when the method is
+`is_integer` and the receiver is a constant float literal or a unary `+`/`-` over one. It folds to a
+Python bool — `std::isfinite(d) && d == std::trunc(d)`, mirroring the float OM's `x == int(x)` and
+matching CPython for integral / fractional / zero / negative / inf / nan — built via
+`migrate_expr_back(gen_true_expr()/gen_false_expr())`, the same construction Python `True`/`False`
+literals use (so `is True`/`is False` identity comparisons work). The predicate matches only
+`Constant`/`UnaryOp(USub|UAdd)` float receivers, so the working `Name` (variable) path is untouched,
+int literals (`is_number_float()` is false for ints) and `~`/`not` operators are declined, and any
+argument is rejected by the handler's guard — no predicate-admits/handler-throws mismatch (the HIGH
+finding the sibling §42 PR fixed).
+
+Like §31a/§42a this **restores a working feature**. New regression pair
+`regression/python/float_is_integer_literal{,_fail}` (CORE) covering integral/fractional/zero/
+unary-signed literals, boolean context, and the unchanged variable form; the positive test is the
+liveness witness (`Unsupported`→`FAILED` pre-fix → `SUCCESSFUL` post-fix). Verified bit-for-bit
+against CPython; CPython sanity passes (`scripts/check_python_tests.sh float_is_integer_literal`); the
+focused `regression/python/(float_is_integer|is_integer|numeric_tower)` ctest subset (8 tests) is
+100% green — the existing `float_is_integer` variable-form tests still pass. Code-reviewed (0
+critical/major; predicate/handler consistency, bool typing, and the inf/nan guard all confirmed
+sound). Solver-agnostic (a frontend constant-fold, no SMT encoding).
+
+### 43b. Next candidate & everything else: unchanged disposition
+The int/float instance-method families now fold on literal receivers. Remaining catalogued
+candidates: `float.as_integer_ratio()` on a literal (returns a tuple — needs the tuple-construction
+path, larger); `str.maketrans`/`translate` dict-table and non-constant forms (fall through cleanly
+today); multi-byte (non-ASCII) UTF-8 encode/decode; and the §36a bytes-literal-argument lowering
+(deferred). The separately-tracked inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other
+deferred candidates stand: `zip()` (materialisation via `list(zip(...))` — a larger feature),
+symbolic/user-function `max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()` (infeasible),
+and `str.isascii()` (string-soundness, §5-#2). The §3 design-level blockers, §3c timeouts, §3d
+questionable expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39 (PR #5661, `bytes.hex(sep)`), §40 (PR #5663, `int.from_bytes`
+> `byteorder=`), §41 (PR #5665, `bytes.fromhex()`), and §42 (PR #5668, int methods on a literal
+> receiver) are in flight and not yet on `master`; this sweep is appended as §43. When all land, the
+> maintainer orders §39 → §40 → §41 → §42 → §43.

--- a/regression/python/float_is_integer_literal/main.py
+++ b/regression/python/float_is_integer_literal/main.py
@@ -1,0 +1,26 @@
+def main() -> None:
+    # float.is_integer() on a constant literal receiver. A variable receiver
+    # already routes through the float operational model; a bare literal did
+    # not, reporting a spurious "Unsupported function" before this fix.
+    assert (2.0).is_integer() is True
+    assert (2.5).is_integer() is False
+    assert (0.0).is_integer() is True
+
+    # Unary +/- literals work; sign does not affect integrality.
+    assert (-4.0).is_integer() is True
+    assert (-4.5).is_integer() is False
+    assert (+8.0).is_integer() is True
+
+    # The bool result composes in boolean context.
+    if (10.0).is_integer():
+        ok = 1
+    else:
+        ok = 0
+    assert ok == 1
+
+    # The variable receiver still works (unchanged path).
+    x = 3.0
+    assert x.is_integer() is True
+
+
+main()

--- a/regression/python/float_is_integer_literal/test.desc
+++ b/regression/python/float_is_integer_literal/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_is_integer_literal_fail/main.py
+++ b/regression/python/float_is_integer_literal_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # (2.5).is_integer() is False, not True.
+    assert (2.5).is_integer() is True
+
+
+main()

--- a/regression/python/float_is_integer_literal_fail/test.desc
+++ b/regression/python/float_is_integer_literal_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <boost/algorithm/string/predicate.hpp>
 #include <optional>
 #include <regex>
@@ -936,6 +937,31 @@ exprt function_call_expr::build_constant_from_arg() const
     expr.type() = t;
 
   return expr;
+}
+
+exprt function_call_expr::handle_float_is_integer_literal() const
+{
+  if (
+    !call_["args"].empty() ||
+    (call_.contains("keywords") && !call_["keywords"].empty()))
+    throw std::runtime_error("is_integer() takes no arguments");
+
+  // Receiver is a constant float literal, or a unary +/- over one. Read the
+  // operand value and apply the sign.
+  const auto &obj = call_["func"]["value"];
+  const nlohmann::json &lit =
+    obj["_type"] == "UnaryOp" ? obj["operand"] : obj;
+  double d = lit["value"].get<double>();
+  if (
+    obj["_type"] == "UnaryOp" && obj.contains("op") &&
+    ((obj["op"].is_object() && obj["op"].value("_type", "") == "USub") ||
+     (obj["op"].is_string() && obj["op"] == "USub")))
+    d = -d;
+
+  // CPython: float.is_integer() is True iff the value is finite and has no
+  // fractional part (mirrors the float OM's `x == int(x)`).
+  const bool is_int = std::isfinite(d) && d == std::trunc(d);
+  return migrate_expr_back(is_int ? gen_true_expr() : gen_false_expr());
 }
 
 std::string function_call_expr::get_object_name() const
@@ -2347,6 +2373,33 @@ function_call_expr::get_dispatch_table()
      },
      [this]() { return handle_int_to_bytes(); },
      "int.to_bytes()"},
+
+    // float.is_integer() on a constant literal receiver, e.g.
+    // (2.0).is_integer(). A Name receiver routes through the float operational
+    // model; a bare literal is not classified as a float instance, so fold it.
+    {[this]() {
+       if (call_["func"]["_type"] != "Attribute")
+         return false;
+       if (function_id_.get_function() != "is_integer")
+         return false;
+       const auto &obj = call_["func"]["value"];
+       // A constant float literal, or a unary +/- over one (e.g. (-2.0)); a
+       // Name receiver is left to the float operational model.
+       if (
+         obj["_type"] == "Constant" && obj.contains("value") &&
+         obj["value"].is_number_float())
+         return true;
+       return obj["_type"] == "UnaryOp" && obj.contains("op") &&
+              obj.contains("operand") && obj["operand"].contains("value") &&
+              obj["operand"]["value"].is_number_float() &&
+              ((obj["op"].is_object() &&
+                (obj["op"].value("_type", "") == "USub" ||
+                 obj["op"].value("_type", "") == "UAdd")) ||
+               (obj["op"].is_string() &&
+                (obj["op"] == "USub" || obj["op"] == "UAdd")));
+     },
+     [this]() { return handle_float_is_integer_literal(); },
+     "float.is_integer()"},
 
     // Min/Max functions
     {[this]() { return is_min_max_call(); },

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -146,6 +146,14 @@ private:
   exprt handle_int_to_bytes() const;
 
   /*
+   * Folds float.is_integer() on a constant literal receiver
+   * (e.g. (2.0).is_integer()). A Name receiver already routes through the
+   * float operational model; a bare literal is not classified as a float
+   * instance, so fold it here to a Python bool.
+   */
+  exprt handle_float_is_integer_literal() const;
+
+  /*
    * Extracts a string representation from a symbol's constant value.
    * Handles both character arrays (e.g., ['6', '5']) and single-character
    * constants by decoding their binary-encoded bitvector representations.


### PR DESCRIPTION
float.is_integer() on a constant literal receiver such as (2.0).is_integer() reported a spurious Unsupported function and VERIFICATION FAILED because a bare float literal is not classified as a float instance, so the call never reached the float operational model. Add a constant-fold that evaluates is_integer on a constant float literal (or a unary +/- over one) as std::isfinite(d) && d == std::trunc(d), matching CPython and the model; the variable form and non-float receivers are untouched.
