### PR TITLE
[python] Support str.rindex()

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,55 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 44. 2026-06-28 re-validation (thirty-fourth sweep) & str.rindex()
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+An idiom battery over the str search methods surfaced `str.rindex` as the one unmodelled member — the
+right-side analogue of `str.index`, missing while `find`/`index`/`rfind` were all handled.
+
+### 44a. New isolated, soundly-fixable defect found & fixed
+**`str.rindex()` was unmodelled, producing a spurious `Unsupported function`.**
+
+`"abcabc".rindex("b")` should give `4` (CPython — the last occurrence; like `rfind` but raising
+`ValueError` when absent), but `rindex` had no handler and reported `Unsupported function 'rindex'` →
+`FAILED`.
+
+**Fix** mirrors the existing `index`/`find` relationship onto `rindex`/`rfind`:
+- `string/string_method_handler.cpp`: new `handle_string_rindex()` / `handle_string_rindex_range()`
+  call the existing `handle_string_rfind()` / `handle_string_rfind_range()` then reuse
+  `build_string_index_result()` — the same builder `index` uses, which raises `ValueError` on a `-1`
+  (not-found) result. `rindex` is added to the search-method dispatcher, routed before the `rfind`
+  fall-through so it cannot leak into the non-raising path.
+- `python_consteval.cpp`: `rindex` is added to the constant-fold path — it searches like `rfind`
+  (`window.rfind`) and raises like `index` (returns nullopt on not-found, leaving BMC to raise), so
+  the constant and runtime paths agree.
+
+The underlying `__python_str_rfind`/`__python_str_rfind_range` OMs (which return `-1` on not-found, the
+same sentinel `find` uses) are reused unchanged — no new operational model. Like §24a (`rsplit`) this
+**restores a working feature**. New regression pair `regression/python/str_rindex{,_fail}` (CORE)
+covering last-occurrence, the start/end window, the catchable not-found `ValueError`, int-typed result
+arithmetic, and a variable receiver; the positive test is the liveness witness (`Unsupported`→`FAILED`
+pre-fix → `SUCCESSFUL` post-fix). Verified bit-for-bit against CPython; CPython sanity passes
+(`scripts/check_python_tests.sh str_rindex`); the focused `regression/python/(str_rindex|string-rfind|
+str_index)` ctest subset is green (the 12 failing are the pre-existing `--z3` environmental set on this
+Bitwuzla-only build — confirmed by re-running one without `--z3`). Code-reviewed (0 critical/major;
+soundness, const-eval/runtime consistency, dispatcher ordering, and the `build_string_index_result`
+reuse all confirmed). Solver-agnostic (a frontend constant-fold + existing OM reuse, no SMT change).
+
+### 44b. Next candidate & everything else: unchanged disposition
+The str search family (`find`/`index`/`rfind`/`rindex`) is now complete. Remaining catalogued
+candidates: `str.maketrans`/`translate` dict-table and non-constant forms (fall through cleanly today);
+multi-byte (non-ASCII) UTF-8 encode/decode; `float.as_integer_ratio()` on a literal (returns a tuple —
+larger); and the §36a bytes-literal-argument lowering (deferred). The separately-tracked
+inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`
+(materialisation via `list(zip(...))` — a larger feature), symbolic/user-function `max`/`min(key=)`,
+`list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()` (string-soundness,
+§5-#2). The §3 design-level blockers, §3c timeouts, §3d questionable expectation, and the infeasible
+`hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39 (PR #5661), §40 (PR #5663), §41 (PR #5665), §42 (PR #5668), and §43 (PR
+> #5669) are in flight and not yet on `master`; this sweep is appended as §44. When all land, the
+> maintainer orders §39 → §40 → §41 → §42 → §43 → §44.

--- a/regression/python/str_rindex/main.py
+++ b/regression/python/str_rindex/main.py
@@ -1,0 +1,27 @@
+def main() -> None:
+    # str.rindex is str.rfind that raises ValueError when the substring is not
+    # found (the right-side analogue of str.index). It was unmodelled before.
+    assert "abcabc".rindex("b") == 4
+    assert "abcabc".rindex("c") == 5
+    assert "banana".rindex("a") == 5
+    assert "hello".rindex("h") == 0
+
+    # Optional start/end search window, like rfind.
+    assert "abcabc".rindex("b", 0, 3) == 1
+
+    # The result is an int and composes in arithmetic.
+    assert "abcabc".rindex("c") + 1 == 6
+
+    # A variable receiver works too.
+    s = "abcabc"
+    assert s.rindex("a") == 3
+
+    # Not found raises a catchable ValueError (unlike rfind, which returns -1).
+    try:
+        "abc".rindex("z")
+        assert False
+    except ValueError:
+        pass
+
+
+main()

--- a/regression/python/str_rindex/test.desc
+++ b/regression/python/str_rindex/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_rindex_fail/main.py
+++ b/regression/python/str_rindex_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # "abcabc".rindex("b") == 4 (last occurrence), not 1.
+    assert "abcabc".rindex("b") == 1
+
+
+main()

--- a/regression/python/str_rindex_fail/test.desc
+++ b/regression/python/str_rindex_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1317,7 +1317,7 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
           return PyConstValue::make_int(c);
         }
 
-        if (m == "find" || m == "rfind" || m == "index")
+        if (m == "find" || m == "rfind" || m == "index" || m == "rindex")
         {
           if (args_arr.empty() || args_arr.size() > 3)
             return std::nullopt;
@@ -1337,11 +1337,11 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
           // the original string (offset by `start`).
           const std::string window = s.substr(
             static_cast<size_t>(start), static_cast<size_t>(end - start));
-          size_t pos =
-            (m == "rfind") ? window.rfind(needle) : window.find(needle);
+          size_t pos = (m == "rfind" || m == "rindex") ? window.rfind(needle)
+                                                        : window.find(needle);
           if (pos == std::string::npos)
           {
-            if (m == "index")
+            if (m == "index" || m == "rindex")
               return std::nullopt; // would raise ValueError — leave to BMC
             return PyConstValue::make_int(-1);
           }

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1338,7 +1338,7 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
           const std::string window = s.substr(
             static_cast<size_t>(start), static_cast<size_t>(end - start));
           size_t pos = (m == "rfind" || m == "rindex") ? window.rfind(needle)
-                                                        : window.find(needle);
+                                                       : window.find(needle);
           if (pos == std::string::npos)
           {
             if (m == "index" || m == "rindex")

--- a/src/python-frontend/string/string_handler.h
+++ b/src/python-frontend/string/string_handler.h
@@ -506,6 +506,40 @@ public:
     const locationt &location);
 
   /**
+   * @brief Handle str.rindex() method (rfind that raises on not-found)
+   * @param call Call AST node (for the temp/exception location)
+   * @param string_obj String object
+   * @param find_arg Substring to locate
+   * @param location Source location
+   * @return index of the last occurrence of the substring.
+   * @throws ValueError if substring is not found.
+   */
+  exprt handle_string_rindex(
+    const nlohmann::json &call,
+    const exprt &string_obj,
+    const exprt &find_arg,
+    const locationt &location);
+
+  /**
+   * @brief Handle str.rindex() with start/end
+   * @param call Call AST node (for the temp/exception location)
+   * @param string_obj String object
+   * @param find_arg Substring to locate
+   * @param start_arg Start index
+   * @param end_arg End index (INT_MIN means default)
+   * @param location Source location
+   * @return index of the last occurrence within range.
+   * @throws ValueError if substring is not found.
+   */
+  exprt handle_string_rindex_range(
+    const nlohmann::json &call,
+    const exprt &string_obj,
+    const exprt &find_arg,
+    const exprt &start_arg,
+    const exprt &end_arg,
+    const locationt &location);
+
+  /**
    * @brief Handle str.replace() method
    * @param string_obj String object
    * @param old_arg Substring to replace

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -575,7 +575,9 @@ std::optional<exprt> dispatch_search_string_methods(
   const std::function<locationt()> &get_location,
   python_converter &converter)
 {
-  if (method_name != "find" && method_name != "index" && method_name != "rfind")
+  if (
+    method_name != "find" && method_name != "index" &&
+    method_name != "rfind" && method_name != "rindex")
     return std::nullopt;
 
   exprt obj_expr = get_receiver_expr();
@@ -596,6 +598,20 @@ std::optional<exprt> dispatch_search_string_methods(
       return self.handle_string_index(
         call_json, obj_expr, parsed.needle, get_location());
     return self.handle_string_index_range(
+      call_json,
+      obj_expr,
+      parsed.needle,
+      parsed.start,
+      parsed.end,
+      get_location());
+  }
+
+  if (method_name == "rindex")
+  {
+    if (!parsed.has_range)
+      return self.handle_string_rindex(
+        call_json, obj_expr, parsed.needle, get_location());
+    return self.handle_string_rindex_range(
       call_json,
       obj_expr,
       parsed.needle,
@@ -2049,6 +2065,31 @@ exprt string_handler::handle_string_rfind_range(
   rfind_call.location() = location;
 
   return rfind_call;
+}
+
+exprt string_handler::handle_string_rindex(
+  const nlohmann::json &call,
+  const exprt &string_obj,
+  const exprt &find_arg,
+  const locationt &location)
+{
+  // rindex is rfind that raises ValueError when the substring is not found,
+  // exactly as index relates to find (build_string_index_result raises on -1).
+  exprt rfind_expr = handle_string_rfind(string_obj, find_arg, location);
+  return build_string_index_result(call, rfind_expr, location);
+}
+
+exprt string_handler::handle_string_rindex_range(
+  const nlohmann::json &call,
+  const exprt &string_obj,
+  const exprt &find_arg,
+  const exprt &start_arg,
+  const exprt &end_arg,
+  const locationt &location)
+{
+  exprt rfind_expr = handle_string_rfind_range(
+    string_obj, find_arg, start_arg, end_arg, location);
+  return build_string_index_result(call, rfind_expr, location);
 }
 
 exprt string_handler::handle_string_replace(


### PR DESCRIPTION
## What

`str.rindex()` was unmodelled, reporting a spurious `Unsupported function 'rindex'` → `VERIFICATION FAILED`. `str.rindex(sub)` is `str.rfind(sub)` that raises `ValueError` when the substring is not found — the right-side analogue of `str.index` (which is `str.find` that raises). The other three search methods (`find`/`index`/`rfind`) were already handled.

## How

Mirror the existing `index`/`find` relationship onto `rindex`/`rfind`:

- **`string/string_method_handler.cpp`**: new `handle_string_rindex()` / `handle_string_rindex_range()` call the existing `handle_string_rfind()` / `handle_string_rfind_range()` then reuse `build_string_index_result()` — the same builder `index` uses, which raises `ValueError` on a `-1` (not-found) result. `rindex` is added to the search-method dispatcher, routed **before** the `rfind` fall-through so it cannot leak into the non-raising path.
- **`python_consteval.cpp`**: `rindex` added to the constant-fold path — it searches like `rfind` (`window.rfind`) and raises like `index` (returns `nullopt` on not-found, leaving BMC to raise), so the constant and runtime paths agree.

The underlying `__python_str_rfind` / `__python_str_rfind_range` operational models (which return `-1` on not-found, the same sentinel `find` uses) are reused unchanged — no new OM.

## Testing

- New CORE regression pair `regression/python/str_rindex{,_fail}` covering last-occurrence, the start/end window, the catchable not-found `ValueError`, int-typed result arithmetic, and a variable receiver. The positive test is the liveness witness (Unsupported→FAILED pre-fix → SUCCESSFUL post-fix).
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh str_rindex` passes; the focused `str_rindex`/`string-rfind`/`str_index` ctest subset is green (the failing ones are the pre-existing `--z3` environmental set on this Bitwuzla-only build — confirmed by re-running one without `--z3`).
- Code-reviewed (0 critical/major; soundness, const-eval/runtime consistency, dispatcher ordering, and the `build_string_index_result` reuse all confirmed).
- Solver-agnostic (frontend constant-fold + existing OM reuse, no SMT change).
