### PR TITLE
[python] Support int.to_bytes() keyword and default arguments

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,58 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 45. 2026-06-28 re-validation (thirty-fifth sweep) & int.to_bytes() keyword/default arguments
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+This sweep took the `int.to_bytes` keyword form — the `to_bytes` analogue of §40's `from_bytes`
+`byteorder=` keyword fix.
+
+### 45a. New isolated, soundly-fixable defect found & fixed
+**`int.to_bytes(2, byteorder="big")` and the no-arg default form errored — only the all-positional
+form was accepted.**
+
+CPython's signature is `int.to_bytes(length=1, byteorder='big', *, signed=False)` — both arguments may
+be passed by keyword and both default since 3.11. But `handle_int_to_bytes` (`function_call/str_conv.cpp`)
+read `length`/`byteorder` purely positionally and required the exact positional count, so
+`x.to_bytes(2, byteorder="big")`, `x.to_bytes(length=2, byteorder="big")`, and `x.to_bytes()` all hit
+`ERROR: int.to_bytes() expects 2 or 3 positional arguments`.
+
+**Fix** (`function_call/str_conv.cpp`): resolve `length` and `byteorder` each from its positional slot,
+else a keyword of that name, else the CPython default (`length=1`, `byteorder='big'`), via two small
+`positional()`/`keyword()` lookups. The `value_offset` shift keeps the unbound type-method form
+`int.to_bytes(x, ...)` correct (the integer value is the leading positional, so the length/byteorder
+slots start one later). The positional slot is consulted before the keyword, so a positional length is
+never shadowed. A code review also surfaced a **pre-existing** latent soundness gap — a *non-constant*
+byteorder silently defaulted to big-endian, mis-folding a little-endian intent into a wrong byte array
+— now closed: an explicit non-constant byteorder raises a clean error (matching the constant-length
+guard), never a wrong fold. `signed=` stays accepted-and-ignored, as the positional form already did.
+
+Like §34a/§40a this **restores a working feature**. New regression pair
+`regression/python/int_to_bytes_kwargs{,_fail}` (CORE) covering byteorder-keyword, both-keyword,
+little-endian keyword, length-only (default byteorder), the no-arg default form, the type-method form
+with keywords, and the unchanged positional form; the positive test is the liveness witness (errored
+pre-fix). Verified bit-for-bit against CPython; CPython sanity passes
+(`scripts/check_python_tests.sh int_to_bytes`); the focused `regression/python/int_(to|from)_bytes*`
+ctest subset (10 tests) is 100% green — the existing `int_to_bytes` positional test still passes.
+Code-reviewed (0 critical/major; the one medium pre-existing non-constant-byteorder gap fixed before
+commit). Solver-agnostic (a frontend value-handler change, no SMT encoding).
+
+### 45b. Next candidate & everything else: unchanged disposition
+The `int.to_bytes`/`from_bytes` keyword/default surface is now complete. Remaining catalogued
+candidates: `str.maketrans`/`translate` dict-table and non-constant forms (fall through cleanly today);
+multi-byte (non-ASCII) UTF-8 encode/decode; `float.as_integer_ratio()` on a literal (returns a tuple —
+larger); the list-literal-receiver method gap (`[1,2].count(x)` — the list analogue of §42, a
+distinct list-dispatch path); and the §36a bytes-literal-argument lowering (deferred). The
+separately-tracked inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other deferred candidates
+stand: `zip()` (materialisation via `list(zip(...))` — a larger feature), symbolic/user-function
+`max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()`
+(string-soundness, §5-#2 — the constant-fold-vs-symbolic interaction makes it unsound, §19a). The §3
+design-level blockers, §3c timeouts, §3d questionable expectation, and the infeasible `hashlib` case
+all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39 (PR #5661), §40 (PR #5663), §41 (PR #5665), §42 (PR #5668), §43 (PR
+> #5669), and §44 (PR #5670) are in flight and not yet on `master`; this sweep is appended as §45.
+> When all land, the maintainer orders §39 → §40 → §41 → §42 → §43 → §44 → §45.

--- a/regression/python/int_to_bytes_kwargs/main.py
+++ b/regression/python/int_to_bytes_kwargs/main.py
@@ -1,0 +1,36 @@
+def main() -> None:
+    # int.to_bytes accepts length and byteorder positionally or by keyword, and
+    # both default (length=1, byteorder='big' since CPython 3.11). The handler
+    # previously required them positionally and rejected the keyword/default forms.
+    x = 258
+
+    # byteorder as a keyword (length still positional).
+    bk = x.to_bytes(2, byteorder="big")
+    assert bk[0] == 1 and bk[1] == 2
+
+    # both length and byteorder as keywords.
+    bb = x.to_bytes(length=2, byteorder="big")
+    assert bb[0] == 1 and bb[1] == 2
+
+    # little-endian keyword.
+    bl = x.to_bytes(2, byteorder="little")
+    assert bl[0] == 2 and bl[1] == 1
+
+    # length only (byteorder defaults to 'big').
+    bp = x.to_bytes(2)
+    assert bp[0] == 1 and bp[1] == 2
+
+    # no arguments (length=1, byteorder='big').
+    bd = (5).to_bytes()
+    assert bd[0] == 5 and len(bd) == 1
+
+    # the unbound type-method form with keywords.
+    bt = int.to_bytes(258, length=2, byteorder="big")
+    assert bt[0] == 1 and bt[1] == 2
+
+    # the positional form is unchanged.
+    bpos = x.to_bytes(2, "big")
+    assert bpos[0] == 1 and bpos[1] == 2
+
+
+main()

--- a/regression/python/int_to_bytes_kwargs/test.desc
+++ b/regression/python/int_to_bytes_kwargs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_to_bytes_kwargs_fail/main.py
+++ b/regression/python/int_to_bytes_kwargs_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    # 258 big-endian is b'\x01\x02', so b[0] == 1, not 2.
+    b = (258).to_bytes(length=2, byteorder="big")
+    assert b[0] == 2
+
+
+main()

--- a/regression/python/int_to_bytes_kwargs_fail/test.desc
+++ b/regression/python/int_to_bytes_kwargs_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -417,8 +417,7 @@ exprt function_call_expr::handle_int_to_bytes() const
       (*byteorder_arg)["value"].is_boolean())
       big_endian = (*byteorder_arg)["value"].get<bool>();
     else if (
-      byteorder_arg->contains("value") &&
-      (*byteorder_arg)["value"].is_string())
+      byteorder_arg->contains("value") && (*byteorder_arg)["value"].is_string())
       big_endian = (*byteorder_arg)["value"].get<std::string>() == "big";
     else
       throw std::runtime_error(

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -366,39 +366,63 @@ exprt function_call_expr::handle_int_to_bytes() const
                                    call_["func"]["value"]["_type"] == "Name" &&
                                    call_["func"]["value"]["id"] == "int";
 
-  // In the type-method form, the integer value is passed explicitly as the
-  // first argument. In the instance-method form, it comes from the receiver.
-  if (
-    args.size() < (is_type_method_call ? 3 : 2) ||
-    args.size() > (is_type_method_call ? 4 : 3))
-  {
-    throw std::runtime_error(
-      is_type_method_call ? "int.to_bytes() expects 3 or 4 positional "
-                            "arguments"
-                          : "int.to_bytes() expects 2 or 3 positional "
-                            "arguments");
-  }
-
+  // CPython signature: int.to_bytes(length=1, byteorder='big', *, signed=False).
+  // length and byteorder may be passed positionally or by keyword, and both
+  // default (since 3.11). Resolve each from its positional slot, then its
+  // keyword, then the default. The type-method form passes the integer value as
+  // the leading positional argument, shifting the length/byteorder slots by one.
+  const std::size_t value_offset = is_type_method_call ? 1 : 0;
   exprt value = is_type_method_call
                   ? converter_.get_expr(args[0])
                   : converter_.get_expr(call_["func"]["value"]);
-  const nlohmann::json &length_arg = args[is_type_method_call ? 1 : 0];
-  const nlohmann::json &byteorder_arg = args[is_type_method_call ? 2 : 1];
 
-  if (
-    !length_arg.contains("value") || !length_arg["value"].is_number_unsigned())
-    throw std::runtime_error(
-      "int.to_bytes() currently expects a constant unsigned length");
+  auto positional = [&](std::size_t i) -> const nlohmann::json * {
+    const std::size_t idx = value_offset + i;
+    return idx < args.size() ? &args[idx] : nullptr;
+  };
+  auto keyword = [&](const char *name) -> const nlohmann::json * {
+    if (call_.contains("keywords"))
+      for (const auto &kw : call_["keywords"])
+        if (kw.contains("arg") && kw["arg"].is_string() && kw["arg"] == name)
+          return &kw["value"];
+    return nullptr;
+  };
 
-  const std::size_t length = length_arg["value"].get<std::size_t>();
-
-  bool big_endian = true;
-  if (byteorder_arg.contains("value"))
+  const nlohmann::json *length_arg = positional(0);
+  if (!length_arg)
+    length_arg = keyword("length");
+  std::size_t length = 1; // CPython default
+  if (length_arg)
   {
-    if (byteorder_arg["value"].is_boolean())
-      big_endian = byteorder_arg["value"].get<bool>();
-    else if (byteorder_arg["value"].is_string())
-      big_endian = byteorder_arg["value"].get<std::string>() == "big";
+    if (
+      !length_arg->contains("value") ||
+      !(*length_arg)["value"].is_number_unsigned())
+      throw std::runtime_error(
+        "int.to_bytes() currently expects a constant unsigned length");
+    length = (*length_arg)["value"].get<std::size_t>();
+  }
+
+  const nlohmann::json *byteorder_arg = positional(1);
+  if (!byteorder_arg)
+    byteorder_arg = keyword("byteorder");
+  bool big_endian = true; // CPython default 'big' when byteorder is omitted
+  if (byteorder_arg)
+  {
+    // An explicit byteorder must be a constant; otherwise default it silently
+    // to big-endian would mis-fold a little-endian intent into a wrong byte
+    // array. Reject the non-constant form with a clean error instead, matching
+    // the constant-length guard above.
+    if (
+      byteorder_arg->contains("value") &&
+      (*byteorder_arg)["value"].is_boolean())
+      big_endian = (*byteorder_arg)["value"].get<bool>();
+    else if (
+      byteorder_arg->contains("value") &&
+      (*byteorder_arg)["value"].is_string())
+      big_endian = (*byteorder_arg)["value"].get<std::string>() == "big";
+    else
+      throw std::runtime_error(
+        "int.to_bytes() currently expects a constant byteorder");
   }
 
   const typet bytes_type = type_handler_.get_typet("bytes", length);


### PR DESCRIPTION
## What

`int.to_bytes(2, byteorder="big")`, `int.to_bytes(length=2, byteorder="big")`, and the no-arg default form `(5).to_bytes()` all errored with `ERROR: int.to_bytes() expects 2 or 3 positional arguments`. CPython's signature is `int.to_bytes(length=1, byteorder='big', *, signed=False)` — both arguments may be passed by keyword and both default (since 3.11) — but the handler read them purely positionally and required an exact positional count. This is the `to_bytes` analogue of PR #5663 (§40), which fixed the `from_bytes` `byteorder=` keyword form.

## How

In `handle_int_to_bytes()` (`function_call/str_conv.cpp`), resolve `length` and `byteorder` each from its positional slot, else a keyword of that name, else the CPython default (`length=1`, `byteorder='big'`), via small `positional()`/`keyword()` lookups. The `value_offset` shift keeps the unbound type-method form `int.to_bytes(x, ...)` correct (the integer value is the leading positional). The positional slot is consulted before the keyword, so a positional length is never shadowed.

A code review also surfaced a **pre-existing** latent soundness gap — a *non-constant* byteorder silently defaulted to big-endian, mis-folding a little-endian intent into a wrong byte array — now closed: an explicit non-constant byteorder raises a clean error (matching the constant-length guard), never a wrong fold. `signed=` stays accepted-and-ignored, as the positional form already did.

## Testing

- New CORE regression pair `regression/python/int_to_bytes_kwargs{,_fail}` covering byteorder-keyword, both-keyword, little-endian keyword, length-only (default byteorder), the no-arg default form, the type-method form with keywords, and the unchanged positional form. The positive test is the liveness witness (errored pre-fix).
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh int_to_bytes` passes; the focused `int_(to|from)_bytes*` ctest subset (10 tests) is 100% green — the existing positional test still passes.
- Code-reviewed (0 critical/major; the one medium pre-existing non-constant-byteorder gap fixed before commit).
- Solver-agnostic (frontend value-handler change, no SMT encoding).
