### PR TITLE
[python] Support the builtin format() for int base specs and default

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,61 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 46. 2026-06-28 re-validation (thirty-sixth sweep) & builtin format()
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+This sweep first probed the list-literal-receiver method gap (`[1,2].count(x)`) — the §45b list
+analogue of §42 — but found it is **not** a clean fix: routing the literal to `handle_list_count`
+needs the list-element metadata (`list_type_map`) materialised for the temp symbol, deeper
+list-machinery work (recorded as deferred, §46b). The sweep then took the builtin `format()`.
+
+### 46a. New isolated, soundly-fixable defect found & fixed
+**The builtin `format(value[, spec])` was unmodelled, producing a spurious `Unsupported function`.**
+
+`format(255, "x")` should give `"ff"` (CPython), but the builtin `format` had no handler and reported
+`Unsupported function 'format'` → `FAILED`. (The `str.format()` *method* was already handled.)
+
+**Fix** (`function_call/str_conv.cpp`): add `handle_format()`, dispatched from `get_dispatch_table()`
+when the call is a bare `Name` call to `format` (`_type == "Name"`, so the `str.format()` method —
+an `Attribute` call — is unaffected). It constant-folds a **literal** integer value with a bare
+presentation-type spec — `'d'`/`'x'`/`'X'`/`'o'`/`'b'` or empty/default — to the base string (no
+`0x`/`0o`/`0b` prefix, leading `-` for negatives, magnitude taken in the unsigned domain so
+`LLONG_MIN` is safe), and a constant string with the default spec to itself. Width/alignment/precision
+specs (e.g. `"08x"`), float values, and unsupported arity raise a clean error, never a wrong fold.
+
+A code review surfaced a **soundness hazard** that was fixed before commit: the value is folded only
+from a genuine literal node (`Constant`/`UnaryOp`), never a `Name` — `extract_constant_integer` would
+otherwise resolve a *reassigned* variable (`x = 255; x = 10`) to its stale constant, a potential false
+`SUCCESSFUL`. A variable argument is now left unsupported (a clean error, no worse than the prior
+fully-unsupported state).
+
+Like §39a this **restores a working feature**. New regression pair
+`regression/python/builtin_format{,_fail}` (CORE) covering the five base specs, the default spec,
+negatives, zero, a constant string, `len`/index composition, and the `str.format()` method coexistence;
+the positive test is the liveness witness (`Unsupported`→`FAILED` pre-fix → `SUCCESSFUL` post-fix).
+Verified bit-for-bit against CPython; CPython sanity passes
+(`scripts/check_python_tests.sh builtin_format`); the focused
+`regression/python/(builtin_format|str_format|format|hex|ascii|oct|bin)` ctest subset (77 tests) is
+100% green — `str.format`/`hex`/`oct`/`bin`/`ascii` all unaffected. Code-reviewed (0 critical/major;
+the one soundness hazard — `Name`-resolved stale value — fixed before commit). Solver-agnostic (a
+frontend constant-fold, no SMT encoding).
+
+### 46b. Next candidate & everything else: unchanged disposition
+The builtin `format()` now folds the int base specs and the default. Remaining catalogued candidates:
+the **list-literal-receiver** method gap (`[1,2].count(x)`/`.index(x)` — `handle_list_count`/`index`
+need the literal's element metadata materialised for the `$literal_list$` temp, a list-machinery
+change, newly characterised this sweep); `format()` width/alignment specs (the format mini-language,
+larger); `str.maketrans`/`translate` dict-table; multi-byte (non-ASCII) UTF-8 encode/decode; and the
+§36a bytes-literal-argument lowering (deferred). The separately-tracked inline-`len`/strlen concern
+(§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()` (materialisation via
+`list(zip(...))` — a larger feature), symbolic/user-function `max`/`min(key=)`,
+`list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()` (string-soundness,
+§5-#2). The §3 design-level blockers, §3c timeouts, §3d questionable expectation, and the infeasible
+`hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39 (PR #5661), §40 (PR #5663), §41 (PR #5665), §42 (PR #5668), §43 (PR
+> #5669), §44 (PR #5670), and §45 (PR #5671) are in flight and not yet on `master`; this sweep is
+> appended as §46. When all land, the maintainer orders §39 → … → §46.

--- a/regression/python/builtin_format/main.py
+++ b/regression/python/builtin_format/main.py
@@ -1,0 +1,26 @@
+def main() -> None:
+    # The builtin format(value, spec) was unmodelled. Fold the integer base
+    # specs and the default/empty spec (str(value)) over a constant value.
+    assert format(255, "x") == "ff"
+    assert format(255, "X") == "FF"
+    assert format(8, "o") == "10"
+    assert format(5, "b") == "101"
+    assert format(42, "d") == "42"
+
+    # Default spec is str(value); negatives keep a leading '-'.
+    assert format(42) == "42"
+    assert format(-255, "x") == "-ff"
+    assert format(0, "b") == "0"
+
+    # A constant string formats to itself with the default spec.
+    assert format("hi") == "hi"
+
+    # The result is a str and composes (len / index).
+    s = format(255, "x")
+    assert len(s) == 2 and s[0] == "f"
+
+    # The str.format() method is unaffected by the builtin handler.
+    assert "{} {}".format(1, 2) == "1 2"
+
+
+main()

--- a/regression/python/builtin_format/test.desc
+++ b/regression/python/builtin_format/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/builtin_format_fail/main.py
+++ b/regression/python/builtin_format_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # format(255, "x") == "ff", not "00".
+    assert format(255, "x") == "00"
+
+
+main()

--- a/regression/python/builtin_format_fail/test.desc
+++ b/regression/python/builtin_format_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -3070,6 +3070,15 @@ function_call_expr::get_dispatch_table()
      [this]() { return handle_ascii(); },
      "ascii() builtin"},
 
+    // format() builtin — a bare Name call (not the str.format() method).
+    {[this]() {
+       return function_id_.get_function() == "format" &&
+              function_id_.get_prefix() == "py:" &&
+              call_["func"]["_type"] == "Name";
+     },
+     [this]() { return handle_format(); },
+     "format() builtin"},
+
     // round() builtin function
     {[this]() {
        const std::string &func_name = function_id_.get_function();

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -255,6 +255,14 @@ private:
   exprt handle_ascii() const;
 
   /*
+   * Handles the builtin format(value[, spec]) for a constant value with a bare
+   * presentation-type spec: the integer base specs ('d'/'x'/'X'/'o'/'b') and
+   * the default/empty spec (str(value)). Width/alignment/precision specs and
+   * non-constant values are not folded — they raise a clean error.
+   */
+  exprt handle_format() const;
+
+  /*
    * Handles ord(str) conversions by extracting the Unicode code point
    * (as an integer) from a single-character string expression.
    */

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -756,8 +756,7 @@ exprt function_call_expr::handle_format() const
     spec = args[1]["value"].get<std::string>();
   }
   if (spec.size() > 1)
-    throw std::runtime_error(
-      "format() spec '" + spec + "' is not supported");
+    throw std::runtime_error("format() spec '" + spec + "' is not supported");
   const char type = spec.empty() ? '\0' : spec[0];
 
   // Integer value with a base spec ('d'/''/'x'/'X'/'o'/'b'). A bool is an int
@@ -772,19 +771,20 @@ exprt function_call_expr::handle_format() const
   const bool is_literal_value =
     value_node_type == "Constant" || value_node_type == "UnaryOp";
   long long v = 0;
-  const bool is_int =
-    is_literal_value &&
-    json_utils::extract_constant_integer(
-      args[0], converter_.get_current_func_name(), converter_.get_ast_json(), v);
+  const bool is_int = is_literal_value && json_utils::extract_constant_integer(
+                                            args[0],
+                                            converter_.get_current_func_name(),
+                                            converter_.get_ast_json(),
+                                            v);
   if (
     is_int && (type == '\0' || type == 'd' || type == 'x' || type == 'X' ||
                type == 'o' || type == 'b'))
   {
     const bool negative = v < 0;
     // Magnitude in the unsigned domain so LLONG_MIN does not overflow.
-    unsigned long long mag =
-      negative ? 0ULL - static_cast<unsigned long long>(v)
-               : static_cast<unsigned long long>(v);
+    unsigned long long mag = negative
+                               ? 0ULL - static_cast<unsigned long long>(v)
+                               : static_cast<unsigned long long>(v);
 
     std::string digits;
     if (type == '\0' || type == 'd')
@@ -806,9 +806,7 @@ exprt function_call_expr::handle_format() const
 
   // format(value) / format(value, "") on a constant string is the string
   // itself (the default str.__format__ with an empty spec).
-  if (
-    type == '\0' && args[0].contains("value") &&
-    args[0]["value"].is_string())
+  if (type == '\0' && args[0].contains("value") && args[0]["value"].is_string())
     return converter_.get_string_builder().build_string_literal(
       args[0]["value"].get<std::string>());
 

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -738,6 +738,85 @@ exprt function_call_expr::handle_ascii() const
     "TypeError", "ascii() argument type not supported");
 }
 
+exprt function_call_expr::handle_format() const
+{
+  const auto &args = call_["args"];
+  if (args.empty() || args.size() > 2)
+    throw std::runtime_error("format() takes one or two arguments");
+
+  // The format spec (default "") must be a constant string. Only a bare
+  // presentation-type spec is folded; any width/alignment/precision spec
+  // (e.g. "08x", ">10") is left unsupported rather than mis-folded.
+  std::string spec;
+  if (args.size() == 2)
+  {
+    if (!args[1].contains("value") || !args[1]["value"].is_string())
+      throw std::runtime_error(
+        "format() currently requires a constant string spec");
+    spec = args[1]["value"].get<std::string>();
+  }
+  if (spec.size() > 1)
+    throw std::runtime_error(
+      "format() spec '" + spec + "' is not supported");
+  const char type = spec.empty() ? '\0' : spec[0];
+
+  // Integer value with a base spec ('d'/''/'x'/'X'/'o'/'b'). A bool is an int
+  // subclass in Python, but a JSON bool is not is_number_integer, so True/False
+  // fall through to the unsupported path below (rare for format()).
+  //
+  // Only a genuine literal value is folded — a Constant or a unary +/- over one.
+  // extract_constant_integer would also resolve a Name to its bound constant,
+  // but that value can be stale after a reassignment (`x = 255; x = 10`), which
+  // would mis-fold; a variable argument is left unsupported instead.
+  const std::string value_node_type = args[0].value("_type", std::string());
+  const bool is_literal_value =
+    value_node_type == "Constant" || value_node_type == "UnaryOp";
+  long long v = 0;
+  const bool is_int =
+    is_literal_value &&
+    json_utils::extract_constant_integer(
+      args[0], converter_.get_current_func_name(), converter_.get_ast_json(), v);
+  if (
+    is_int && (type == '\0' || type == 'd' || type == 'x' || type == 'X' ||
+               type == 'o' || type == 'b'))
+  {
+    const bool negative = v < 0;
+    // Magnitude in the unsigned domain so LLONG_MIN does not overflow.
+    unsigned long long mag =
+      negative ? 0ULL - static_cast<unsigned long long>(v)
+               : static_cast<unsigned long long>(v);
+
+    std::string digits;
+    if (type == '\0' || type == 'd')
+      digits = std::to_string(mag);
+    else
+    {
+      const unsigned base = (type == 'o') ? 8 : (type == 'b') ? 2 : 16;
+      const char *alphabet =
+        (type == 'X') ? "0123456789ABCDEF" : "0123456789abcdef";
+      if (mag == 0)
+        digits = "0";
+      for (; mag != 0; mag /= base)
+        digits.insert(digits.begin(), alphabet[mag % base]);
+    }
+    if (negative)
+      digits.insert(digits.begin(), '-');
+    return converter_.get_string_builder().build_string_literal(digits);
+  }
+
+  // format(value) / format(value, "") on a constant string is the string
+  // itself (the default str.__format__ with an empty spec).
+  if (
+    type == '\0' && args[0].contains("value") &&
+    args[0]["value"].is_string())
+    return converter_.get_string_builder().build_string_literal(
+      args[0]["value"].get<std::string>());
+
+  throw std::runtime_error(
+    "format() currently supports a constant int (with a base spec) or a "
+    "constant str");
+}
+
 exprt function_call_expr::handle_bin(nlohmann::json &arg) const
 {
   // The formatter is unused for binary (handled manually in


### PR DESCRIPTION
## What

The builtin `format(value[, spec])` was unmodelled, reporting a spurious `Unsupported function 'format'` → `VERIFICATION FAILED`. (The `str.format()` *method* was already handled.) `format(255, "x")` now folds to `"ff"`.

## How

Add `handle_format()` in `function_call/str_conv.cpp`, dispatched from `get_dispatch_table()` when the call is a bare `Name` call to `format` (`_type == "Name"`, so the `str.format()` method — an `Attribute` call — is unaffected). It constant-folds:

- a **literal** integer value with a bare presentation-type spec — `'d'`/`'x'`/`'X'`/`'o'`/`'b'` or empty/default — to the base string (no `0x`/`0o`/`0b` prefix, leading `-` for negatives, magnitude taken in the unsigned domain so `LLONG_MIN` is safe);
- a constant string with the default spec to itself.

Width/alignment/precision specs (e.g. `"08x"`), float values, and unsupported arity raise a clean error, never a wrong fold.

## Soundness

A code review surfaced (and this PR fixes) a hazard: the value is folded only from a genuine literal node (`Constant`/`UnaryOp`), never a `Name`. `extract_constant_integer` would otherwise resolve a *reassigned* variable (`x = 255; x = 10`) to its stale constant — a potential false `SUCCESSFUL`. A variable argument is now left unsupported (a clean error, no worse than the prior fully-unsupported state).

## Testing

- New CORE regression pair `regression/python/builtin_format{,_fail}` covering the five base specs, the default spec, negatives, zero, a constant string, `len`/index composition, and the `str.format()` method coexistence. The positive test is the liveness witness (Unsupported→FAILED pre-fix → SUCCESSFUL post-fix).
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh builtin_format` passes; the focused `builtin_format`/`str_format`/`hex`/`ascii`/`oct`/`bin` ctest subset (77 tests) is 100% green — those builtins are unaffected.
- Code-reviewed (0 critical/major; the one soundness hazard fixed before commit).
- Solver-agnostic (frontend constant-fold, no SMT encoding).
