### PR TITLE
[python] Fold bytes.startswith/endswith over literal bytes operands

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,62 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 47. 2026-06-28 re-validation (thirty-seventh sweep) & bytes.endswith()
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+An idiom battery over the bytes search/affix methods surfaced `bytes.endswith` as silently wrong while
+its sibling `bytes.startswith` worked.
+
+### 47a. New isolated, soundly-fixable defect found & fixed
+**`bytes.endswith(suffix)` returned the wrong value for a literal bytes object.**
+
+`bytes([1,2,3]).endswith(bytes([2,3]))` should be `True` (CPython), but ESBMC computed `False`. Bytes
+are modelled as an int array (64-bit elements), not a null-terminated char array, and both affix
+methods were routed through the str `strncmp`/`strlen` machinery. `startswith` happened to work (it
+uses the prefix array's static size), but `endswith` uses `strlen()` to compute the from-the-end
+offset — wrong for the int-array representation (a NUL byte truncates it) — so it mis-located the
+suffix.
+
+**Fix** (`string/string_handler.cpp`): in `handle_string_attribute_call` (beside the §32 `bytes.hex`
+block), fold `bytes.startswith`/`bytes.endswith` when the receiver **and** the single argument are
+literal `bytes([const, …])` constructor nodes, comparing the byte vectors directly (startswith at
+offset 0, endswith at offset `len - suffixlen`) and returning a Python bool. A first expr-based draft
+folded the receiver *value*, which a code review showed to be **unsound** — a symbolic or
+branch-merged bytes value reaches the fold as an operand-less array (a bare symbol, or a const-eval
+artifact whose array type collapses to size 0) and folded to a wrong constant, a false `SUCCESSFUL`.
+The fix was rewritten to inspect **only the AST syntax** (`_type == "Call"`, `func.id == "bytes"`, a
+single `List` of `0..255` integer `Constant`s): no symbolic, branch-merged, or partially-evaluated
+value can ever reach it. A str receiver, a *variable*/expression receiver, a `b"..."` literal, a tuple
+argument, and the position-argument (2/3-arg) form all fall through to the existing dispatch, sound and
+unchanged (the variable/symbolic bytes affix case remains on the pre-existing `strncmp` path, an
+out-of-scope incompleteness, not a wrong-`SUCCESSFUL`).
+
+Like §16a–§20a this **restores a working feature** for the literal case. New regression pair
+`regression/python/bytes_endswith{,_fail}` (CORE) covering true/false/full-match/longer suffixes,
+embedded NUL bytes (which `strlen` would truncate at), the unchanged `startswith`, and `str.endswith`
+coexistence; the positive test is the liveness witness (FAILED pre-fix). Verified bit-for-bit against
+CPython; CPython sanity passes (`scripts/check_python_tests.sh bytes_endswith`); the focused
+`regression/python/(endswith|startswith|bytes)` ctest subset (41 tests) is 100% green — `str`
+startswith/endswith unaffected. Code-reviewed across three rounds: a critical symbolic-receiver fold
+was caught and the handler rewritten to the AST-syntactic form, which a final review confirmed
+**sound** (no path admits a non-constant value; 0 critical/major). Solver-agnostic (a frontend
+constant-fold, no SMT encoding).
+
+### 47b. Next candidate & everything else: unchanged disposition
+The constant `bytes.startswith`/`endswith` are now correct. Remaining catalogued candidates: the
+**symbolic** bytes affix/search methods (the str `strncmp`/`strlen` path is unsound for the int-array
+bytes representation — a pre-existing gap needing a bytes-specific symbolic model, newly characterised
+this sweep); the bytes tuple-of-affixes and position-argument forms (same root); the list-literal
+receiver method gap (§46b); `format()` width specs; `str.maketrans`/`translate` dict-table; and
+multi-byte (non-ASCII) UTF-8 encode/decode. The separately-tracked inline-`len`/strlen concern
+(§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`, symbolic/user-function
+`max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()`
+(string-soundness, §5-#2). The §3 design-level blockers, §3c timeouts, §3d questionable expectation,
+and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39–§46 (PRs #5661/#5663/#5665/#5668/#5669/#5670/#5671/#5672) are in flight
+> and not yet on `master`; this sweep is appended as §47. When all land, the maintainer orders
+> §39 → … → §47.

--- a/regression/python/bytes_endswith/main.py
+++ b/regression/python/bytes_endswith/main.py
@@ -1,0 +1,28 @@
+def main() -> None:
+    # bytes.endswith over a literal bytes([...]) was routed through the str
+    # strncmp/strlen machinery, which is wrong for the int-array bytes
+    # representation, so it silently mis-computed its from-the-end offset.
+    # The fold compares the byte vectors of the literal operands directly.
+    assert bytes([1, 2, 3]).endswith(bytes([2, 3])) is True
+    assert bytes([1, 2, 3]).endswith(bytes([1, 2])) is False
+    assert bytes([1, 2, 3]).endswith(bytes([1, 2, 3])) is True
+    assert bytes([1, 2, 3]).endswith(bytes([3])) is True
+
+    # A suffix longer than the receiver does not match.
+    assert bytes([1, 2]).endswith(bytes([0, 1, 2])) is False
+
+    # NUL bytes are ordinary data here (strlen would have truncated at them).
+    assert bytes([0, 1, 0]).endswith(bytes([1, 0])) is True
+    assert bytes([1, 0, 2]).endswith(bytes([0, 2])) is True
+
+    # startswith over literals is folded the same way (it was already correct
+    # via strncmp; the fold keeps it correct and consistent).
+    assert bytes([1, 2, 3]).startswith(bytes([1, 2])) is True
+    assert bytes([1, 2, 3]).startswith(bytes([2, 3])) is False
+
+    # str.endswith is unaffected (the char-array path).
+    assert "hello".endswith("lo") is True
+    assert "hello".endswith("he") is False
+
+
+main()

--- a/regression/python/bytes_endswith/test.desc
+++ b/regression/python/bytes_endswith/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes_endswith_fail/main.py
+++ b/regression/python/bytes_endswith_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # bytes([1, 2, 3]) ends with bytes([2, 3]), so endswith is True, not False.
+    assert bytes([1, 2, 3]).endswith(bytes([2, 3])) is False
+
+
+main()

--- a/regression/python/bytes_endswith_fail/test.desc
+++ b/regression/python/bytes_endswith_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2338,8 +2338,7 @@ exprt string_handler::handle_string_attribute_call(
     auto extract_bytes_literal =
       [](const nlohmann::json &n, std::vector<unsigned> &out) -> bool {
       // bytes([i0, i1, ...]) with constant ints in range(0, 256).
-      if (!(
-            n.is_object() && n.value("_type", std::string()) == "Call" &&
+      if (!(n.is_object() && n.value("_type", std::string()) == "Call" &&
             n.contains("func") &&
             n["func"].value("_type", std::string()) == "Name" &&
             n["func"].value("id", std::string()) == "bytes" &&
@@ -2351,8 +2350,7 @@ exprt string_handler::handle_string_attribute_call(
       out.clear();
       for (const auto &e : n["args"][0]["elts"])
       {
-        if (!(
-              e.is_object() && e.value("_type", std::string()) == "Constant" &&
+        if (!(e.is_object() && e.value("_type", std::string()) == "Constant" &&
               e.contains("value") && e["value"].is_number_unsigned()))
           return false;
         const unsigned long long v = e["value"].get<unsigned long long>();

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2321,6 +2321,71 @@ exprt string_handler::handle_string_attribute_call(
     }
   }
 
+  // bytes.startswith(prefix) / bytes.endswith(suffix) over *literal* bytes
+  // constructors `bytes([...])`. Both methods are otherwise routed through the
+  // str strncmp/strlen machinery, which is wrong for the int-array bytes
+  // representation (not null-terminated): endswith mis-computes its
+  // from-the-end offset and a NUL byte truncates the length. The fold inspects
+  // only the `bytes([const, ...])` AST syntax — so no symbolic, branch-merged,
+  // or partially-evaluated value can ever reach it — and compares the byte
+  // vectors directly. A str receiver, a variable/expression receiver, a tuple
+  // or position argument, and `b"..."` literals all fall through to the
+  // existing dispatch, sound and unchanged.
+  if (
+    (method_name == "startswith" || method_name == "endswith") &&
+    args.size() == 1)
+  {
+    auto extract_bytes_literal =
+      [](const nlohmann::json &n, std::vector<unsigned> &out) -> bool {
+      // bytes([i0, i1, ...]) with constant ints in range(0, 256).
+      if (!(
+            n.is_object() && n.value("_type", std::string()) == "Call" &&
+            n.contains("func") &&
+            n["func"].value("_type", std::string()) == "Name" &&
+            n["func"].value("id", std::string()) == "bytes" &&
+            n.contains("args") && n["args"].is_array() &&
+            n["args"].size() == 1 &&
+            n["args"][0].value("_type", std::string()) == "List" &&
+            n["args"][0].contains("elts") && n["args"][0]["elts"].is_array()))
+        return false;
+      out.clear();
+      for (const auto &e : n["args"][0]["elts"])
+      {
+        if (!(
+              e.is_object() && e.value("_type", std::string()) == "Constant" &&
+              e.contains("value") && e["value"].is_number_unsigned()))
+          return false;
+        const unsigned long long v = e["value"].get<unsigned long long>();
+        if (v > 255)
+          return false; // out of range(0, 256): CPython raises ValueError
+        out.push_back(static_cast<unsigned>(v));
+      }
+      return true;
+    };
+
+    std::vector<unsigned> recv_bytes;
+    std::vector<unsigned> arg_bytes;
+    if (
+      extract_bytes_literal(receiver_json, recv_bytes) &&
+      extract_bytes_literal(args[0], arg_bytes))
+    {
+      bool result = arg_bytes.size() <= recv_bytes.size();
+      if (result)
+      {
+        const std::size_t off = (method_name == "endswith")
+                                  ? recv_bytes.size() - arg_bytes.size()
+                                  : 0;
+        for (std::size_t i = 0; i < arg_bytes.size(); ++i)
+          if (recv_bytes[off + i] != arg_bytes[i])
+          {
+            result = false;
+            break;
+          }
+      }
+      return migrate_expr_back(result ? gen_true_expr() : gen_false_expr());
+    }
+  }
+
   // str.translate(str.maketrans(x, y[, z])): fold a constant string through a
   // constant translation table. CPython maps each x[i] to y[i] and deletes the
   // characters in z. Only the two/three-string maketrans form over constant


### PR DESCRIPTION
## What

`bytes.endswith(suffix)` returned the wrong value for a literal bytes object: `bytes([1,2,3]).endswith(bytes([2,3]))` computed `False` instead of `True`. Bytes are modelled as an int array (64-bit elements), not a null-terminated char array, and both affix methods were routed through the str `strncmp`/`strlen` machinery. `startswith` happened to work (it uses the prefix array's static size), but `endswith` uses `strlen()` to compute the from-the-end offset — wrong for the int-array representation (a NUL byte truncates it).

## How

In `handle_string_attribute_call` (beside the `bytes.hex` fold), fold `bytes.startswith`/`bytes.endswith` when the receiver **and** the single argument are literal `bytes([const, …])` constructor nodes, comparing the byte vectors directly (startswith at offset 0, endswith at offset `len - suffixlen`).

The match is **purely syntactic** — it inspects only the AST (`_type == "Call"`, `func.id == "bytes"`, a single `List` of `0..255` integer `Constant`s) and never evaluates an expression, symbol, or operand. So no symbolic, branch-merged, or partially-evaluated value can ever reach the fold. A str receiver, a variable/expression receiver, a `b"..."` literal, a tuple argument, and the position-argument (2/3-arg) form all fall through to the existing dispatch, sound and unchanged.

(An earlier expr-based draft folded the receiver *value*; code review showed that a symbolic/branch-merged bytes value reached it as an operand-less array and folded to a wrong constant — a false `SUCCESSFUL`. The rewrite to the AST-syntactic form closes that hole, confirmed sound in a final review.)

## Testing

- New CORE regression pair `regression/python/bytes_endswith{,_fail}` covering true/false/full-match/longer suffixes, embedded NUL bytes (which `strlen` would truncate at), the unchanged `startswith`, and `str.endswith` coexistence. The positive test is the liveness witness (FAILED pre-fix).
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh bytes_endswith` passes; the focused `endswith`/`startswith`/`bytes` ctest subset (41 tests) is 100% green — `str` startswith/endswith unaffected.
- Code-reviewed across three rounds; the final AST-syntactic form is confirmed sound (no path admits a non-constant value).
- Solver-agnostic (frontend constant-fold, no SMT encoding).
