### PR TITLE
[python] Fold bytes.find/rfind over literal bytes operands

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,55 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 48. 2026-06-28 re-validation (thirty-eighth sweep) & bytes.find()/rfind()
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+This sweep continued the bytes-affix/search family from §47 with the literal `bytes.find`/`rfind`.
+
+### 48a. New isolated, soundly-fixable defect found & fixed
+**`bytes.find(sub)`/`bytes.rfind(sub)` returned the wrong index for a literal bytes object.**
+
+`bytes([1,2,3]).find(bytes([2,3]))` should be `1` (CPython), but ESBMC computed the wrong value: like
+the §47 affix methods, bytes search is routed through the str `strncmp`/`strlen` machinery, wrong for
+the int-array bytes representation (a NUL byte truncates the length).
+
+**Fix** (`string/string_handler.cpp`): fold `bytes.find`/`bytes.rfind` when the receiver is a literal
+`bytes([…])` constructor and the argument is either a literal `bytes([…])` subsequence or a single
+integer byte (CPython accepts both), computing the first/last occurrence index (or `-1`) directly and
+returning a `long_long_int_type()` constant. As in §47 the match is **purely syntactic** (AST only),
+so no symbolic, branch-merged, or partially-evaluated value can reach the fold — the soundness hazard
+§47's first draft hit is structurally excluded. A str receiver, a variable/expression receiver, a
+`b"…"` literal, and the position-argument (2/3-arg) forms all fall through to the existing dispatch,
+sound and unchanged. The reverse `rfind` scan is `m <= n`-guarded so `n - m + 1` never underflows
+`size_t`, and `matches_at` indexing stays in bounds.
+
+Like §44a (`str.rindex`) this **restores a working feature** for the literal case. New regression pair
+`regression/python/bytes_find{,_fail}` (CORE) covering find/rfind, the not-found `-1`, the single-int
+argument, the empty subsequence (find→0, rfind→len), repeated occurrences, embedded NUL bytes,
+int-result composition, and `str.find`/`rfind` coexistence; the positive test is the liveness witness
+(FAILED pre-fix). Verified bit-for-bit against CPython; CPython sanity passes
+(`scripts/check_python_tests.sh bytes_find`); the focused `regression/python/(bytes_find|string-rfind|
+str_index|bytes)` ctest subset is green (the 12 failing are the pre-existing `--z3` environmental set
+on this Bitwuzla-only build). Code-reviewed: confirmed **sound** (no path admits a non-constant value;
+search math verified against CPython incl. the `size_t` bounds; 0 critical/major). Solver-agnostic (a
+frontend constant-fold, no SMT encoding).
+
+### 48b. Next candidate & everything else: unchanged disposition
+The literal bytes affix/search methods now fold (`startswith`/`endswith` §47, `find`/`rfind` here).
+Remaining catalogued candidates: literal `bytes.index`/`rindex` (raising variants — need the exception
+machinery), `bytes.count`/`replace`/`split`/`join` over literals (same syntactic-fold pattern); the
+**symbolic** bytes affix/search methods (the str `strncmp`/`strlen` path is unsound for the int-array
+representation — a pre-existing gap needing a bytes-specific symbolic model, §47b); the list-literal
+receiver method gap (§46b); `format()` width specs; `str.maketrans`/`translate` dict-table; and
+multi-byte (non-ASCII) UTF-8 encode/decode. The separately-tracked inline-`len`/strlen concern
+(§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`, symbolic/user-function
+`max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()`
+(string-soundness, §5-#2). The §3 design-level blockers, §3c timeouts, §3d questionable expectation,
+and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39–§47 (PRs #5661/#5663/#5665/#5668/#5669/#5670/#5671/#5672/#5673) are in
+> flight and not yet on `master`; this sweep is appended as §48. When all land, the maintainer orders
+> §39 → … → §48.

--- a/regression/python/bytes_find/main.py
+++ b/regression/python/bytes_find/main.py
@@ -1,0 +1,32 @@
+def main() -> None:
+    # bytes.find / bytes.rfind over literal bytes([...]) were routed through the
+    # str strncmp/strlen machinery, wrong for the int-array bytes representation.
+    # Fold the literal case directly: search the receiver's byte vector.
+    assert bytes([1, 2, 3]).find(bytes([2, 3])) == 1
+    assert bytes([1, 2, 3]).find(bytes([9])) == -1
+    assert bytes([1, 2, 3, 2, 3]).find(bytes([2, 3])) == 1
+
+    # The argument may be a single integer byte (CPython accepts both forms).
+    assert bytes([1, 2, 3]).find(2) == 1
+    assert bytes([1, 2, 3]).find(9) == -1
+
+    # An empty subsequence: find at 0, rfind at len.
+    assert bytes([1, 2, 3]).find(bytes([])) == 0
+    assert bytes([1, 2, 3]).rfind(bytes([])) == 3
+
+    # rfind returns the last occurrence.
+    assert bytes([1, 2, 1, 2]).rfind(bytes([1, 2])) == 2
+    assert bytes([1, 2, 1]).rfind(1) == 2
+
+    # The result is an int and composes in arithmetic.
+    assert bytes([1, 2, 3]).find(bytes([3])) + 1 == 3
+
+    # NUL bytes are ordinary data (strlen would have truncated at them).
+    assert bytes([0, 1, 0, 2]).find(bytes([0, 2])) == 2
+
+    # str.find / str.rfind are unaffected (the char-array path).
+    assert "abcabc".find("b") == 1
+    assert "abcabc".rfind("b") == 4
+
+
+main()

--- a/regression/python/bytes_find/test.desc
+++ b/regression/python/bytes_find/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes_find_fail/main.py
+++ b/regression/python/bytes_find_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # bytes([1, 2, 3]).find(bytes([2, 3])) == 1, not 9.
+    assert bytes([1, 2, 3]).find(bytes([2, 3])) == 9
+
+
+main()

--- a/regression/python/bytes_find_fail/test.desc
+++ b/regression/python/bytes_find_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2336,8 +2336,7 @@ exprt string_handler::handle_string_attribute_call(
     auto extract_bytes_literal =
       [](const nlohmann::json &n, std::vector<unsigned> &out) -> bool {
       // bytes([i0, i1, ...]) with constant ints in range(0, 256).
-      if (!(
-            n.is_object() && n.value("_type", std::string()) == "Call" &&
+      if (!(n.is_object() && n.value("_type", std::string()) == "Call" &&
             n.contains("func") &&
             n["func"].value("_type", std::string()) == "Name" &&
             n["func"].value("id", std::string()) == "bytes" &&
@@ -2349,8 +2348,7 @@ exprt string_handler::handle_string_attribute_call(
       out.clear();
       for (const auto &e : n["args"][0]["elts"])
       {
-        if (!(
-              e.is_object() && e.value("_type", std::string()) == "Constant" &&
+        if (!(e.is_object() && e.value("_type", std::string()) == "Constant" &&
               e.contains("value") && e["value"].is_number_unsigned()))
           return false;
         const unsigned long long v = e["value"].get<unsigned long long>();
@@ -2376,7 +2374,8 @@ exprt string_handler::handle_string_attribute_call(
           a.contains("value") && a["value"].is_number_unsigned() &&
           a["value"].get<unsigned long long>() <= 255)
         {
-          sub_bytes.assign(1, static_cast<unsigned>(a["value"].get<unsigned>()));
+          sub_bytes.assign(
+            1, static_cast<unsigned>(a["value"].get<unsigned>()));
           have_sub = true;
         }
       }

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -2321,6 +2321,104 @@ exprt string_handler::handle_string_attribute_call(
     }
   }
 
+  // bytes.find(sub) / bytes.rfind(sub): the index of the first (find) or last
+  // (rfind) occurrence of sub in the receiver, or -1 if absent. Both methods
+  // are otherwise routed through the str strncmp/strlen machinery, which is
+  // wrong for the int-array bytes representation (a NUL byte truncates the
+  // length). Fold over *literal* operands only: the receiver must be a
+  // bytes([...]) constructor, and the argument either a bytes([...]) subsequence
+  // or a single integer byte. The match is purely syntactic (AST only), so no
+  // symbolic, branch-merged, or partially-evaluated value can reach the fold;
+  // a str receiver, a variable/expression receiver, and any other form fall
+  // through to the existing dispatch, sound and unchanged.
+  if ((method_name == "find" || method_name == "rfind") && args.size() == 1)
+  {
+    auto extract_bytes_literal =
+      [](const nlohmann::json &n, std::vector<unsigned> &out) -> bool {
+      // bytes([i0, i1, ...]) with constant ints in range(0, 256).
+      if (!(
+            n.is_object() && n.value("_type", std::string()) == "Call" &&
+            n.contains("func") &&
+            n["func"].value("_type", std::string()) == "Name" &&
+            n["func"].value("id", std::string()) == "bytes" &&
+            n.contains("args") && n["args"].is_array() &&
+            n["args"].size() == 1 &&
+            n["args"][0].value("_type", std::string()) == "List" &&
+            n["args"][0].contains("elts") && n["args"][0]["elts"].is_array()))
+        return false;
+      out.clear();
+      for (const auto &e : n["args"][0]["elts"])
+      {
+        if (!(
+              e.is_object() && e.value("_type", std::string()) == "Constant" &&
+              e.contains("value") && e["value"].is_number_unsigned()))
+          return false;
+        const unsigned long long v = e["value"].get<unsigned long long>();
+        if (v > 255)
+          return false;
+        out.push_back(static_cast<unsigned>(v));
+      }
+      return true;
+    };
+
+    std::vector<unsigned> recv_bytes;
+    if (extract_bytes_literal(receiver_json, recv_bytes))
+    {
+      // The argument is a bytes([...]) subsequence or a single integer byte
+      // (CPython bytes.find accepts both); any other form falls through.
+      std::vector<unsigned> sub_bytes;
+      bool have_sub = extract_bytes_literal(args[0], sub_bytes);
+      if (!have_sub)
+      {
+        const nlohmann::json &a = args[0];
+        if (
+          a.is_object() && a.value("_type", std::string()) == "Constant" &&
+          a.contains("value") && a["value"].is_number_unsigned() &&
+          a["value"].get<unsigned long long>() <= 255)
+        {
+          sub_bytes.assign(1, static_cast<unsigned>(a["value"].get<unsigned>()));
+          have_sub = true;
+        }
+      }
+
+      if (have_sub)
+      {
+        const std::size_t n = recv_bytes.size();
+        const std::size_t m = sub_bytes.size();
+        long long result = -1;
+        auto matches_at = [&](std::size_t pos) {
+          for (std::size_t i = 0; i < m; ++i)
+            if (recv_bytes[pos + i] != sub_bytes[i])
+              return false;
+          return true;
+        };
+        if (m <= n)
+        {
+          // CPython: an empty sub matches at 0 (find) / n (rfind).
+          if (method_name == "find")
+          {
+            for (std::size_t pos = 0; pos + m <= n; ++pos)
+              if (matches_at(pos))
+              {
+                result = static_cast<long long>(pos);
+                break;
+              }
+          }
+          else // rfind, scan from the end
+          {
+            for (std::size_t pos = n - m + 1; pos-- > 0;)
+              if (matches_at(pos))
+              {
+                result = static_cast<long long>(pos);
+                break;
+              }
+          }
+        }
+        return from_integer(result, long_long_int_type());
+      }
+    }
+  }
+
   // str.translate(str.maketrans(x, y[, z])): fold a constant string through a
   // constant translation table. CPython maps each x[i] to y[i] and deletes the
   // characters in z. Only the two/three-string maketrans form over constant


### PR DESCRIPTION
## What

`bytes.find(sub)` / `bytes.rfind(sub)` returned the wrong index for a literal bytes object (`bytes([1,2,3]).find(bytes([2,3]))` gave the wrong result instead of `1`). Like the affix methods (PR #5673, §47), bytes search was routed through the str `strncmp`/`strlen` machinery, which is wrong for the int-array bytes representation (a NUL byte truncates the length).

## How

In `handle_string_attribute_call`, fold `bytes.find`/`bytes.rfind` when the receiver is a literal `bytes([...])` constructor and the argument is either a literal `bytes([...])` subsequence or a single integer byte (CPython accepts both), computing the first/last occurrence index (or `-1`) directly and returning a `long_long_int_type()` constant.

As in §47, the match is **purely syntactic** — it inspects only the AST (`_type == "Call"`, `func.id == "bytes"`, a `List` of `0..255` integer `Constant`s) and never evaluates an expression, symbol, or operand. So no symbolic, branch-merged, or partially-evaluated value can ever reach the fold. A str receiver, a variable/expression receiver, a `b"..."` literal, and the position-argument (2/3-arg) forms all fall through to the existing dispatch, sound and unchanged. The reverse `rfind` scan is `m <= n`-guarded so `n - m + 1` never underflows `size_t`.

## Testing

- New CORE regression pair `regression/python/bytes_find{,_fail}` covering find/rfind, not-found `-1`, the single-int argument, the empty subsequence (find→0, rfind→len), repeated occurrences, embedded NUL bytes, int-result composition, and `str.find`/`rfind` coexistence. The positive test is the liveness witness (FAILED pre-fix).
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh bytes_find` passes; the focused `bytes_find`/`string-rfind`/`bytes` ctest subset is green (the 12 failing are the pre-existing `--z3` environmental set on this Bitwuzla-only build).
- Code-reviewed: confirmed sound (no path admits a non-constant value; search math verified against CPython including the `size_t` bounds).
- Solver-agnostic (frontend constant-fold, no SMT encoding).
