### PR TITLE
[python] Support variadic math.gcd()/math.lcm()

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1766,3 +1766,56 @@ Other deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=
 `list.index()`-in-`try/except`, `str.maketrans`/`translate`, `float.hex()` (infeasible), and
 `str.isascii()` (string-soundness). The §3 design-level blockers, §3c timeouts, §3d questionable
 expectation, and the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+---
+
+## 50. 2026-06-28 re-validation (fortieth sweep) & variadic math.gcd()/lcm()
+
+Re-test against current `master` (tip `810d1bc2d5`). KNOWNBUG classification unchanged — §3 holds.
+This sweep stepped out of the bytes family to the `math` module's variadic `gcd`/`lcm`.
+
+### 50a. New isolated, soundly-fixable defect found & fixed
+**`math.gcd`/`math.lcm` returned the wrong result for any argument count other than 2.**
+
+`math.gcd(12, 8, 6)` should be `2` (CPython 3.9+ accepts any number of integer arguments), but ESBMC
+computed the wrong value: the operational model (`models/math.py`) defines `gcd(a, b)`/`lcm(a, b)` as
+**binary**, so the 0-, 1-, and 3-or-more-argument forms (`gcd()`, `gcd(x)`, `gcd(a, b, c, …)`) all
+mis-evaluated. The 2-argument form was correct.
+
+**Fix** (`preprocessor/core_visitors_mixin.py`): a new AST normalizer
+`_normalize_math_gcd_lcm_variadic`, called from `visit_Call` beside `_normalize_int_from_bytes_endianness`,
+rewrites a variadic `math.gcd`/`math.lcm` call into nested **binary** calls that reuse the existing
+model — `f()` → `f(identity, identity)`, `f(x)` → `f(x, identity)`, `f(a, b, c, …)` →
+`f(f(a, b), c, …)` (a left fold). gcd's identity is `0` (`gcd(x, 0) == abs(x)`), lcm's is `1`
+(`lcm(x, 1) == abs(x)`); the model's existing 2-argument handling of `0`/`1` makes these exact. Because
+the rewrite produces nested binary calls, it works on **symbolic** arguments too (the model runs on
+each pair), not just constants. The 2-argument form is left untouched; `*args` splat, keyword
+arguments, and the `from math import gcd` / `import math as m` spellings fall through unchanged (a
+coverage limitation noted in the code — those forms were already unmodelled, so the canonical
+`math.gcd(...)` path this sweep fixes is a strict improvement).
+
+Like §40a (`int.from_bytes`) this **restores a working feature**. New regression pair
+`regression/python/math_gcd_lcm_variadic{,_fail}` (CORE) covering 0/1/3/4-argument gcd and lcm, the
+identities, negative arguments, the unchanged 2-argument form, a symbolic argument, and the wrong-value
+case; the positive test is the liveness witness (FAILED pre-fix). Verified bit-for-bit against CPython;
+CPython sanity passes (`scripts/check_python_tests.sh math_gcd`); the focused `regression/python/math*`
+ctest subset (187 tests) is 100% green — no regression in the 2-argument or other math paths. pylint
+clean on the changed file (the two pre-existing `listcomp_counter` E1101 false-positives are unrelated).
+The preprocessor is FLAIL-mangled, so the binary was rebuilt before testing. Code-reviewed (0
+critical/high; the fold arithmetic, AST synthesis, and signature-defaults interaction all confirmed; the
+one medium finding — aliased/from-import coverage — documented rather than expanded, and a `*args` guard
+added). Solver-agnostic (an AST-normalisation change, no SMT encoding).
+
+### 50b. Next candidate & everything else: unchanged disposition
+Remaining catalogued candidates: the aliased/from-import `gcd`/`lcm` spellings (need module-alias
+tracking threaded into the normalizer); the *bytes-returning* methods (`replace`/`split`/`join` — need
+receiver-aware return-type inference, §49b); the **symbolic** bytes affix/search methods (§47b); the
+list-literal receiver method gap (§46b); `format()` width specs; `str.maketrans`/`translate` dict-table;
+and multi-byte (non-ASCII) UTF-8 encode/decode. The separately-tracked inline-`len`/strlen concern
+(§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`, symbolic/user-function
+`max`/`min(key=)`, `list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()`
+(string-soundness, §5-#2). The §3 design-level blockers, §3c timeouts, §3d questionable expectation, and
+the infeasible `hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39–§49 (PRs #5661–#5675) are in flight and not yet on `master`; this sweep is
+> appended as §50. When all land, the maintainer orders §39 → … → §50.

--- a/regression/python/math_gcd_lcm_variadic/main.py
+++ b/regression/python/math_gcd_lcm_variadic/main.py
@@ -1,0 +1,30 @@
+import math
+
+
+def main() -> None:
+    # math.gcd / math.lcm accept any number of integer arguments (CPython 3.9+),
+    # but the operational model is binary. The preprocessor normalises the
+    # variadic forms to nested 2-argument calls.
+    assert math.gcd(12, 8, 6) == 2
+    assert math.gcd(24, 36, 48, 60) == 12
+    assert math.lcm(4, 6, 8) == 24
+
+    # Zero arguments return the identity (gcd -> 0, lcm -> 1).
+    assert math.gcd() == 0
+    assert math.lcm() == 1
+
+    # One argument returns the absolute value.
+    assert math.gcd(12) == 12
+    assert math.gcd(-15) == 15
+    assert math.lcm(7) == 7
+
+    # The two-argument form is unchanged, and negatives fold correctly.
+    assert math.gcd(12, 8) == 4
+    assert math.gcd(-12, 8, 6) == 2
+
+    # The variadic fold works on symbolic arguments too (the binary model runs).
+    x = 24
+    assert math.gcd(x, 12, 8) == 4
+
+
+main()

--- a/regression/python/math_gcd_lcm_variadic/test.desc
+++ b/regression/python/math_gcd_lcm_variadic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math_gcd_lcm_variadic_fail/main.py
+++ b/regression/python/math_gcd_lcm_variadic_fail/main.py
@@ -1,0 +1,9 @@
+import math
+
+
+def main() -> None:
+    # math.gcd(12, 8, 6) == 2, not 3.
+    assert math.gcd(12, 8, 6) == 3
+
+
+main()

--- a/regression/python/math_gcd_lcm_variadic_fail/test.desc
+++ b/regression/python/math_gcd_lcm_variadic_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -817,10 +817,8 @@ class CoreVisitorsMixin:
         # Only the canonical `math.gcd(...)` / `math.lcm(...)` spelling is
         # normalised; `from math import gcd` and `import math as m` forms (and a
         # user object named `math`) fall through unchanged.
-        if not (isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "math"
-                and node.func.attr in ("gcd", "lcm")):
+        if not (isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "math" and node.func.attr in ("gcd", "lcm")):
             return
         if node.keywords or len(node.args) == 2:
             return  # gcd/lcm take no keywords; the binary form is already modelled
@@ -833,8 +831,7 @@ class CoreVisitorsMixin:
         elif len(args) == 1:
             node.args = [args[0], ast.Constant(value=identity)]
         else:  # >= 3: left-fold into nested binary calls
-            acc = ast.Call(func=copy.deepcopy(node.func), args=[args[0], args[1]],
-                           keywords=[])
+            acc = ast.Call(func=copy.deepcopy(node.func), args=[args[0], args[1]], keywords=[])
             for a in args[2:-1]:
                 acc = ast.Call(func=copy.deepcopy(node.func), args=[acc, a], keywords=[])
             node.args = [acc, args[-1]]

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -807,6 +807,39 @@ class CoreVisitorsMixin:
             else:
                 node.args[1] = ast.Constant(value=False)
 
+    @staticmethod
+    def _normalize_math_gcd_lcm_variadic(node):
+        # math.gcd / math.lcm accept any number of integer arguments in CPython,
+        # but the operational model (models/math.py) is binary. Normalise to
+        # nested 2-argument calls reusing the binary model: f() -> identity,
+        # f(x) -> f(x, identity), f(a, b, c, ...) -> f(f(a, b), c, ...). gcd's
+        # identity is 0 (gcd(x, 0) == abs(x)); lcm's is 1 (lcm(x, 1) == abs(x)).
+        # Only the canonical `math.gcd(...)` / `math.lcm(...)` spelling is
+        # normalised; `from math import gcd` and `import math as m` forms (and a
+        # user object named `math`) fall through unchanged.
+        if not (isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "math"
+                and node.func.attr in ("gcd", "lcm")):
+            return
+        if node.keywords or len(node.args) == 2:
+            return  # gcd/lcm take no keywords; the binary form is already modelled
+        if any(isinstance(a, ast.Starred) for a in node.args):
+            return  # *args splat: argument count is not statically known
+        identity = 0 if node.func.attr == "gcd" else 1
+        args = node.args
+        if len(args) == 0:
+            node.args = [ast.Constant(value=identity), ast.Constant(value=identity)]
+        elif len(args) == 1:
+            node.args = [args[0], ast.Constant(value=identity)]
+        else:  # >= 3: left-fold into nested binary calls
+            acc = ast.Call(func=copy.deepcopy(node.func), args=[args[0], args[1]],
+                           keywords=[])
+            for a in args[2:-1]:
+                acc = ast.Call(func=copy.deepcopy(node.func), args=[acc, a], keywords=[])
+            node.args = [acc, args[-1]]
+        ast.fix_missing_locations(node)
+
     def _fill_missing_args_with_defaults(self, node, function_name, expected_args, keywords):
         missing_args = []
         for i in range(len(node.args), len(expected_args)):
@@ -1198,6 +1231,7 @@ class CoreVisitorsMixin:
             return rewritten_decimal
 
         self._normalize_int_from_bytes_endianness(node)
+        self._normalize_math_gcd_lcm_variadic(node)
 
         if not self._apply_call_signature_defaults(node):
             self.generic_visit(node)


### PR DESCRIPTION
math.gcd and math.lcm accept any number of integer arguments in CPython, but ESBMC's operational model defines them as binary, so every non-2-argument form was wrong. Add an AST normalizer that rewrites a variadic math.gcd/math.lcm call into nested binary calls (using identities 0 for gcd and 1 for lcm), reusing the existing model and working on symbolic arguments too; the 2-argument form is left unchanged.
