### PR TITLE
[python] Fix divmod() tuple-sort crash on store-then-compare

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -1874,3 +1874,58 @@ questionable expectation, and the infeasible `hashlib` case all stand; the §5 p
 
 > **Note on numbering.** §39 (PR #5661, `bytes.hex(sep[, bytes_per_sep])`) is in flight and not yet on
 > `master`; this sweep is appended as §40. When both land, the maintainer orders §39 → §40.
+
+---
+
+## 53. 2026-06-28 re-validation (forty-third sweep) & divmod() tuple-sort crash
+
+Re-test against current `master` (tip `ff63b29e57`). KNOWNBUG classification unchanged — §3 holds. This
+sweep took the `divmod`-to-variable tuple-sort crash characterised in §52b.
+
+### 53a. New isolated, soundly-fixable defect found & fixed
+**`x = divmod(a, b); x == (q, r)` crashed ESBMC with a tuple-sort assertion.**
+
+`divmod` returns a 2-tuple; storing it in a variable and comparing to a tuple literal aborted with
+`Assertion failed: sort->get_tuple_type() == other->sort->get_tuple_type()`
+(`smt_tuple_node_ast.cpp`). Root cause: `handle_divmod` built its result tuple struct with a
+**hard-coded** tag `"tag-tuple_divmod"`, whereas a tuple literal `(q, r)` gets a **content-based** tag
+from `tuple_handler::build_tuple_tag` (`"tag-tuple_<elemtype>_<elemtype>"`). The two tuples therefore
+had different SMT sorts, and the equality comparison tripped the sort assertion. (The inline form
+`divmod(a, b) == (q, r)` and the unpack form `q, r = divmod(...)` did not crash — only the
+store-then-compare path reached the cross-sort tuple EQ.)
+
+**Fix** (`python_math.cpp`): replace all three manual tuple-struct constructions in `handle_divmod`
+(the float-constant, int-constant, and symbolic paths) with
+`converter.get_tuple_handler().create_tuple_struct_type({result_type, result_type})` — the same shared
+builder a tuple literal uses, which sets the content-based tag, the `element_0`/`element_1` components,
+and the python-aggregate-kind. The divmod result is now sort-compatible with a literal of the same
+element types (the elements already used `result_type`, which for the int path is the dividend's int
+type — the same type an int literal gets), so the comparison no longer mismatches sorts. A net
+de-duplication (−25 lines).
+
+This is a **crash→correct-result** fix (§5-item-5 class, resolved). New regression pair
+`regression/python/divmod_tuple_eq{,_fail}` (CORE) covering store-then-compare, negative and float
+divmod, and the unchanged index / unpack / inline forms; the positive test is the liveness witness —
+confirmed to **abort with the tuple-sort assertion pre-fix** and verify SUCCESSFUL post-fix (the durable
+crash regression). Verified bit-for-bit against CPython; CPython sanity passes
+(`scripts/check_python_tests.sh divmod`); the `regression/python/divmod` (17) and
+`regression/python/tuple` (38) ctest subsets are 100% green — `divmod` indexing/unpacking and all tuple
+behaviour unchanged. Code-review was started; the change is a minimal drop-in (only the struct tag
+changes, to the content-based one the literal uses; `create_tuple_struct_type` sets the identical
+components/kind), empirically confirmed across the float/int/symbolic paths. Solver-agnostic (a frontend
+struct-type change, no SMT-encoding change beyond removing the malformed sort).
+
+### 53b. Next candidate & everything else: unchanged disposition
+Remaining catalogued candidates: `list.index(x, start[, end])` position arguments (unsupported, §52b);
+the set/list-literal-receiver method gap (§46b/§51a); `frozenset` (unsupported AST type); `dict |` PEP
+584 union (explicitly unsupported); variadic `math.hypot` (float-precision, §51b); the bytes-returning
+methods (receiver-aware return-type inference, §49b); the symbolic bytes affix/search methods (§47b);
+`format()`/f-string width specs; `str.maketrans`/`translate` dict-table; and multi-byte UTF-8
+encode/decode. The separately-tracked inline-`len`/strlen concern (§14b/§32b/§33b) still stands. Other
+deferred candidates stand: `zip()`, symbolic/user-function `max`/`min(key=)`,
+`list.index()`-in-`try/except`, `float.hex()` (infeasible), and `str.isascii()` (string-soundness,
+§5-#2). The §3 design-level blockers, §3c timeouts, §3d questionable expectation, and the infeasible
+`hashlib` case all stand; the §5 priority order stands.
+
+> **Note on numbering.** §39 and §42–§52 (PRs #5661, #5668–#5678) are in flight and not yet on `master`
+> (§40/§41 merged); this sweep is appended as §53.

--- a/regression/python/divmod_tuple_eq/main.py
+++ b/regression/python/divmod_tuple_eq/main.py
@@ -1,0 +1,19 @@
+def main() -> None:
+    # divmod() returns a tuple. Storing it in a variable and comparing to a
+    # tuple literal previously crashed: the divmod result used a hard-coded
+    # "tag-tuple_divmod" struct tag, mismatching the content-based tag of the
+    # literal, which tripped a solver tuple-sort assertion. The result now uses
+    # the shared tuple struct type, so the sorts match.
+    x = divmod(17, 5)
+    assert x == (3, 2)
+
+    # Negative and float divmod, and the unchanged index / unpack / inline forms.
+    assert divmod(-7, 3) == (-3, 2)
+    f = divmod(7.5, 2.0)
+    assert f == (3.0, 1.5)
+    assert x[0] == 3 and x[1] == 2
+    q, r = divmod(17, 5)
+    assert q == 3 and r == 2
+
+
+main()

--- a/regression/python/divmod_tuple_eq/test.desc
+++ b/regression/python/divmod_tuple_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_tuple_eq_fail/main.py
+++ b/regression/python/divmod_tuple_eq_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    # divmod(17, 5) == (3, 2), not (9, 9).
+    x = divmod(17, 5)
+    assert x == (9, 9)
+
+
+main()

--- a/regression/python/divmod_tuple_eq_fail/test.desc
+++ b/regression/python/divmod_tuple_eq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -1,5 +1,6 @@
 #include <python-frontend/python_math.h>
 #include <python-frontend/python_converter.h>
+#include <python-frontend/tuple_handler.h>
 #include <python-frontend/python_int_overflow.h>
 #include <python-frontend/type_utils.h>
 #include <python-frontend/math_guard_utils.h>
@@ -893,19 +894,13 @@ exprt python_math::handle_divmod(
       const double q = std::floor(*lhs_const / *rhs_const);
       const double r = *lhs_const - (q * *rhs_const);
 
-      struct_typet tuple_type;
-      tuple_type.tag("tag-tuple_divmod");
-      set_python_aggregate_kind(tuple_type, "tuple");
-
-      struct_typet::componentt comp0;
-      comp0.name("element_0");
-      comp0.type() = result_type;
-      tuple_type.components().push_back(comp0);
-
-      struct_typet::componentt comp1;
-      comp1.name("element_1");
-      comp1.type() = result_type;
-      tuple_type.components().push_back(comp1);
+      // Use the shared tuple struct type (content-based tag) so a divmod
+      // result is sort-compatible with a tuple literal of the same element
+      // types: a hard-coded "tag-tuple_divmod" tag made `x = divmod(a, b);
+      // x == (q, r)` crash on the SMT tuple-sort mismatch.
+      struct_typet tuple_type =
+        converter.get_tuple_handler().create_tuple_struct_type(
+          {result_type, result_type});
 
       exprt tuple_expr("struct", tuple_type);
       tuple_expr.copy_to_operands(
@@ -941,19 +936,9 @@ exprt python_math::handle_divmod(
           r += rhs_val;
         }
 
-        struct_typet tuple_type;
-        tuple_type.tag("tag-tuple_divmod");
-        set_python_aggregate_kind(tuple_type, "tuple");
-
-        struct_typet::componentt comp0;
-        comp0.name("element_0");
-        comp0.type() = result_type;
-        tuple_type.components().push_back(comp0);
-
-        struct_typet::componentt comp1;
-        comp1.name("element_1");
-        comp1.type() = result_type;
-        tuple_type.components().push_back(comp1);
+        struct_typet tuple_type =
+          converter.get_tuple_handler().create_tuple_struct_type(
+            {result_type, result_type});
 
         exprt tuple_expr("struct", tuple_type);
         tuple_expr.copy_to_operands(
@@ -1004,19 +989,9 @@ exprt python_math::handle_divmod(
   }
 
   // Create a tuple struct to hold both values
-  struct_typet tuple_type;
-  tuple_type.tag("tag-tuple_divmod");
-  set_python_aggregate_kind(tuple_type, "tuple");
-
-  struct_typet::componentt comp0;
-  comp0.name("element_0");
-  comp0.type() = result_type;
-  tuple_type.components().push_back(comp0);
-
-  struct_typet::componentt comp1;
-  comp1.name("element_1");
-  comp1.type() = result_type;
-  tuple_type.components().push_back(comp1);
+  struct_typet tuple_type =
+    converter.get_tuple_handler().create_tuple_struct_type(
+      {result_type, result_type});
 
   // Build the tuple expression
   exprt tuple_expr("struct", tuple_type);


### PR DESCRIPTION
## What

`x = divmod(a, b); x == (q, r)` **crashed** ESBMC with a tuple-sort assertion (`Assertion failed: sort->get_tuple_type() == other->sort->get_tuple_type()`, `smt_tuple_node_ast.cpp`).

`divmod` returns a 2-tuple. `handle_divmod` built its result tuple struct with a **hard-coded** tag `"tag-tuple_divmod"`, whereas a tuple literal `(q, r)` gets a **content-based** tag from `tuple_handler::build_tuple_tag` (`"tag-tuple_<elemtype>_<elemtype>"`). The two tuples therefore had different SMT sorts, and the equality comparison tripped the sort assertion. (The inline `divmod(a, b) == (q, r)` and unpack `q, r = divmod(...)` forms did not crash — only the store-then-compare path reached the cross-sort tuple EQ.)

## How

Replace all three manual tuple-struct constructions in `handle_divmod` (the float-constant, int-constant, and symbolic paths) with `converter.get_tuple_handler().create_tuple_struct_type({result_type, result_type})` — the same shared builder a tuple literal uses, which sets the content-based tag, the `element_0`/`element_1` components, and the python-aggregate-kind. The divmod result is now sort-compatible with a literal of the same element types (the elements already used `result_type`, which for the int path is the dividend's int type — the same type an int literal gets). A net de-duplication (−25 lines).

## Testing

- New CORE regression pair `regression/python/divmod_tuple_eq{,_fail}` covering store-then-compare, negative and float divmod, and the unchanged index / unpack / inline forms. The positive test was confirmed to **abort with the tuple-sort assertion pre-fix** and verify SUCCESSFUL post-fix (a durable crash regression).
- Verified bit-for-bit against CPython; `scripts/check_python_tests.sh divmod` passes; the `regression/python/divmod` (17) and `regression/python/tuple` (38) ctest subsets are 100% green — divmod indexing/unpacking and all tuple behaviour unchanged.
- Solver-agnostic (a frontend struct-type change; removes the malformed sort).
