### PR TITLE
[python] Support keyword arguments in dict.update()

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -2176,3 +2176,62 @@ questionable expectation, and the infeasible `hashlib` case all stand; the §5 p
 
 > **Note on numbering.** §39 (PR #5661, `bytes.hex(sep[, bytes_per_sep])`) is in flight and not yet on
 > `master`; this sweep is appended as §40. When both land, the maintainer orders §39 → §40.
+
+---
+
+## 72. 2026-06-29 re-validation (sixty-second sweep) & dict.update keyword arguments
+
+Re-test against current `master` (tip `c11d07e970`). KNOWNBUG classification unchanged — §3 holds. The
+§71b list-read follow-up (`pop`) was attempted but **withdrawn**: a side-effecting `__ESBMC_list_pop` bound
+to a temp via `add_instruction` double-emits (the expression builder runs across type-inference and
+codegen passes), popping twice — a regression, reverted before committing. §71's subscript fix already
+covers for-loops, comprehensions, `sum`/`min`/`max` over a `list[float]` of ints (they route through the
+subscript read); only `pop` remains, and it needs a single-evaluation mechanism — recorded as a follow-up.
+This sweep took an independent clean candidate instead.
+
+### 72a. New isolated, soundly-fixable defect found & fixed
+**`dict.update()` rejected keyword arguments, a no-argument call, and mixed positional+keyword forms.**
+
+`d.update(a=1, b=2)`, `d.update()`, and `d.update({...}, b=2)` all errored "update() takes exactly one
+argument" — the handler (`python-dict/dict_methods.cpp`) accepted only a single positional dict.
+
+**Fix**: relax the guard to "at most one positional argument" and add an `apply_keywords` step that
+inserts each `call_node["keywords"]` entry as a string-keyed assignment (synthesising a Constant string key
+node and reusing the existing `handle_dict_subscript_assign` primitive). Keywords are applied *after* any
+positional source, matching CPython's keyword-wins-on-conflict semantics; a no-positional call routes
+straight to `apply_keywords` (a no-op when empty); a `**mapping` keyword (null arg) is rejected with a
+clean diagnostic rather than silently dropped.
+
+This is a **crash/unsupported→correct-result fix**. New regression pair `dict_update_kwargs{,_fail}`
+(CORE) covering keyword-only, no-arg, mixed positional+keyword, keyword-wins-on-conflict, and the
+unchanged positional forms; the positive is the liveness witness (it errored pre-fix). Verified bit-for-bit
+against CPython; CPython sanity passes (`scripts/check_python_tests.sh dict_update_kwargs`); the dict/update
+ctest subset shows no new failures (9 pre-existing `--z3`/`--ir` environmental). Code-reviewed: ready for
+commit, 0 critical/major/minor — the synthesised string key processes identically to a dict-literal key,
+the positional paths are byte-for-byte unchanged but for the trailing no-op `apply_keywords()`, and the
+`**mapping`/`>1`-positional rejections were confirmed safe. C-Live for the new keyword/no-arg branches is
+discharged by the positive regression (it exercises them; pre-fix they errored). Solver-agnostic.
+
+**Pre-existing latent bug noted** (not introduced here): `d.update(other_dict)` where `other_dict` is a
+*variable* with two or more keys does not copy all entries (fails on master too) — a separate dict-var
+update-loop defect, recorded as a follow-up.
+
+### 72b. Next candidates & everything else: unchanged disposition
+Priority follow-ups: (i) `list[float].pop()` of an int element (needs a single-evaluation bind — §72
+above); (ii) `dict.update(other_dict_var)` multi-key copy (above); (iii) extend the `type_id` dispatch to
+the other `extract_pyobject_value` read paths for fixed-`list[float]`-signature models that iterate
+(§71b); (iv) `format()` builtin width/precision (the §70 `apply_format_spec` is reusable); (v) char-`join`
+— `"".join(c for c in s)` (§67b); (vi) nested-function closures; (vii) `dict |`/`|=` PEP 584 union.
+
+Remaining catalogued candidates: the set/list-literal-receiver method gap (§46b/§51a); `frozenset`
+(unsupported AST type); variadic `math.hypot` (float-precision, §51b); the bytes-returning methods (§49b);
+the symbolic bytes affix/search methods (§47b); `str.maketrans`/`translate` dict-table; `sorted(dict.items())`
+tuple drop (known multi-layer); strided list-slice delete `del a[::k]` (§66b); `round(int, n)` returns
+float (§63b); and multi-byte UTF-8 encode/decode. The separately-tracked inline-`len`/strlen concern
+(§14b/§32b/§33b) still stands. Other deferred candidates stand: `zip()`, `list.index()`-in-`try/except`
+(ValueError not catchable), `float.hex()` (infeasible), and `str.isascii()` (string-soundness, §5-#2). The
+§3 design-level blockers, §3c timeouts, §3d questionable expectation, and the infeasible `hashlib` case all
+stand; the §5 priority order stands.
+
+> **Note on numbering.** §42/§43 and §49–§71 (PRs #5668, #5669, #5675–#5687, #5689–#5698) are in flight
+> and not yet on `master`; this sweep is appended as §72.

--- a/regression/python/dict_update_kwargs/main.py
+++ b/regression/python/dict_update_kwargs/main.py
@@ -1,0 +1,28 @@
+def main() -> None:
+    # dict.update() previously accepted only a single positional dict and
+    # rejected keyword arguments ("update() takes exactly one argument").
+    # update(a=1, b=2) now inserts each keyword as a string-keyed entry.
+    d = {"a": 1}
+    d.update(a=10, b=2)
+    assert d["a"] == 10 and d["b"] == 2
+
+    # No-argument update() is a no-op.
+    e = {"x": 1}
+    e.update()
+    assert e["x"] == 1
+
+    # A positional source plus keywords; keywords win on a key conflict.
+    f = {}
+    f.update({"a": 1}, b=2)
+    assert f["a"] == 1 and f["b"] == 2
+    g = {}
+    g.update({"k": 1}, k=9)
+    assert g["k"] == 9
+
+    # Positional-only forms are unchanged.
+    h = {"a": 1}
+    h.update({"b": 2})
+    assert h["a"] == 1 and h["b"] == 2
+
+
+main()

--- a/regression/python/dict_update_kwargs/test.desc
+++ b/regression/python/dict_update_kwargs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_update_kwargs_fail/main.py
+++ b/regression/python/dict_update_kwargs_fail/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    # update(a=10) sets d["a"] to 10, not 1.
+    d = {"a": 1}
+    d.update(a=10)
+    assert d["a"] == 1
+
+
+main()

--- a/regression/python/dict_update_kwargs_fail/test.desc
+++ b/regression/python/dict_update_kwargs_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python-dict/dict_methods.cpp
+++ b/src/python-frontend/python-dict/dict_methods.cpp
@@ -1287,8 +1287,42 @@ exprt python_dict_handler::handle_dict_update(
 {
   const auto &args = call_node["args"];
 
-  if (args.size() != 1)
-    throw std::runtime_error("update() takes exactly one argument");
+  if (args.size() > 1)
+    throw std::runtime_error("update() expected at most 1 positional argument");
+
+  // update(a=1, b=2) inserts each keyword as a string-keyed entry. Applied
+  // after any positional source, matching CPython (keywords win on conflict).
+  auto apply_keywords = [&]() {
+    if (!call_node.contains("keywords"))
+      return;
+    for (const auto &kw : call_node["keywords"])
+    {
+      if (!kw.contains("arg") || kw["arg"].is_null())
+        throw std::runtime_error(
+          "update() with **mapping is not supported in ESBMC model");
+      nlohmann::json key_node;
+      key_node["_type"] = "Constant";
+      key_node["value"] = kw["arg"];
+      converter_.copy_location_fields_from_decl(call_node, key_node);
+      exprt value_expr = converter_.get_expr(kw["value"]);
+      code_blockt pair_block;
+      handle_dict_subscript_assign(
+        dict_expr,
+        get_key_expr(key_node),
+        value_expr,
+        converter_.get_location_from_decl(call_node),
+        key_node,
+        pair_block);
+      converter_.add_instruction(pair_block);
+    }
+  };
+
+  // update() / update(**kwargs): no positional source.
+  if (args.empty())
+  {
+    apply_keywords();
+    return nil_exprt();
+  }
 
   const nlohmann::json &arg = args[0];
 
@@ -1312,6 +1346,7 @@ exprt python_dict_handler::handle_dict_update(
       converter_.add_instruction(pair_block);
     }
 
+    apply_keywords();
     return nil_exprt();
   }
 
@@ -1398,5 +1433,6 @@ exprt python_dict_handler::handle_dict_update(
   while_loop.location() = location;
   converter_.add_instruction(while_loop);
 
+  apply_keywords();
   return nil_exprt();
 }


### PR DESCRIPTION
dict.update() rejected keyword arguments, a no-argument call, and mixed positional-plus-keyword forms, accepting only a single positional dict. Relax the guard to allow at most one positional argument and add a keyword-application step that inserts each keyword as a string-keyed assignment, applied after any positional source to match CPython's keyword-wins-on-conflict semantics. A `**mapping` unpacking argument is still rejected with a clean diagnostic.
