### PR TITLE
[goto-symex] Hide internal phi-merge steps from --no-slice trace

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -502,6 +502,15 @@ set(_slow_regression_tests
     # does not touch its code path). Give it the 2x budget so transient
     # runner-speed differences don't flap it.
     "regression/python/str_rsplit"
+    # set_variadic_methods verifies SUCCESSFUL but is heavy: under
+    # --incremental-bmc it climbs k while re-running symex over the set/list
+    # operational models (variadic union/intersection/difference fold to
+    # __ESBMC_list_extend + __memcpy_impl loops), re-encoding ~1400 VCCs and a
+    # fresh Bitwuzla query each step. It lands ~137s locally and timed out at
+    # 120.71s on the DebugOpt Linux runner in #5705 CI -- a run that does not
+    # touch its code path. Give it the 2x budget so transient CI slowness does
+    # not flap it.
+    "regression/python/set_variadic_methods"
 )
 math(EXPR ESBMC_REGRESS_CTEST_TIMEOUT_SLOW
      "${ESBMC_REGRESS_TIMEOUT_SLOW} + 30")

--- a/regression/esbmc/github_5701-nondet/main.cpp
+++ b/regression/esbmc/github_5701-nondet/main.cpp
@@ -1,0 +1,35 @@
+/* Faithful reproducer from esbmc/esbmc discussion #5701. */
+int main()
+{
+  bool short_radar;
+  bool lo_speed;
+  bool rl_mode = 0;
+  bool req_mode;
+
+  int loop_idx = 0;
+  while (true)
+  {
+    req_mode = nondet_bool();
+    if (lo_speed)
+      if (req_mode)
+      {
+        rl_mode = true;
+      }
+      else
+      {
+        rl_mode = false;
+        __ESBMC_assert(rl_mode == false, "rl_mode asn");
+      }
+    else
+      switch (rl_mode)
+      {
+      case false:
+        rl_mode = false;
+        break;
+      default:
+        break;
+      }
+    __ESBMC_assert(!(rl_mode == false) || (lo_speed && short_radar), "park");
+    ++loop_idx;
+  }
+}

--- a/regression/esbmc/github_5701-nondet/test.desc
+++ b/regression/esbmc/github_5701-nondet/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--multi-property --no-slice --unwind 2
+^VERIFICATION FAILED$
+^\s*rl_mode = 0$

--- a/regression/esbmc/github_5701/main.cpp
+++ b/regression/esbmc/github_5701/main.cpp
@@ -1,0 +1,41 @@
+/* Deterministic reproducer for esbmc/esbmc discussion #5701.
+ *
+ * lo_speed is pinned false, so the `if (lo_speed)` body -- including the inner
+ * `else` assignment `rl_mode = false;` -- can never execute.  Yet
+ * under `--no-slice` (which keeps internal/hidden SSA steps) the hidden
+ * phi-merge node for rl_mode used to be printed in the counterexample at that
+ * assignment line, a "surprising state" for a line that never ran.  The
+ * human-readable trace must contain NO state at that line, regardless of the
+ * solver. */
+int main()
+{
+  bool short_radar;
+  bool lo_speed;
+  bool rl_mode = 0;
+  bool req_mode;
+  int loop_idx = 0;
+  while (true)
+  {
+    req_mode = nondet_bool();
+    __ESBMC_assume(!lo_speed);
+    if (lo_speed)
+      if (req_mode)
+        rl_mode = true;
+      else
+      {
+        rl_mode = false;
+        __ESBMC_assert(rl_mode == false, "rl_mode asn");
+      }
+    else
+      switch (rl_mode)
+      {
+      case false:
+        rl_mode = false;
+        break;
+      default:
+        break;
+      }
+    __ESBMC_assert(!(rl_mode == false) || (lo_speed && short_radar), "park");
+    ++loop_idx;
+  }
+}

--- a/regression/esbmc/github_5701/test.desc
+++ b/regression/esbmc/github_5701/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--multi-property --no-slice --unwind 2
+^VERIFICATION FAILED$
+line 33 column 9 function main
+(?s)\A(?!.*line 26 column 9 function main)

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -130,14 +130,8 @@ void bmct::error_trace(smt_convt &smt_conv, const symex_target_equationt &eq)
 
   log_progress("Building error trace");
 
-  bool is_compact_trace = true;
-  if (
-    options.get_bool_option("no-slice") &&
-    !options.get_bool_option("compact-trace"))
-    is_compact_trace = false;
-
   goto_tracet goto_trace;
-  build_goto_trace(eq, smt_conv, goto_trace, is_compact_trace);
+  build_goto_trace(eq, smt_conv, goto_trace);
 
   std::string output_file = options.get_option("cex-output");
   if (output_file != "")
@@ -2078,12 +2072,6 @@ smt_resultt bmct::multi_property_check(
         return;
       }
 
-      bool is_compact_trace = true;
-      if (
-        options.get_bool_option("no-slice") &&
-        !options.get_bool_option("compact-trace"))
-        is_compact_trace = false;
-
       // --all-witnesses: re-solve with blocking clauses on the nondet input
       // tuple to enumerate further violating inputs at the current k.
       // No re-encoding: we only push extra assertions onto the live solver.
@@ -2129,7 +2117,7 @@ smt_resultt bmct::multi_property_check(
       while (enum_result == P_SATISFIABLE)
       {
         witness_recordt w;
-        build_goto_trace(local_eq, *solver_ptr, w.trace, is_compact_trace);
+        build_goto_trace(local_eq, *solver_ptr, w.trace);
         // Collecting nondet values walks every SSA step and queries the
         // solver model per nondet symbol — non-trivial on coverage runs
         // with many claims and large arrays. Skip it when we don't need

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -55,8 +55,7 @@ expr2tc build_rhs(smt_convt &smt_conv, const expr2tc &rhs)
 void build_goto_trace(
   const symex_target_equationt &target,
   smt_convt &smt_conv,
-  goto_tracet &goto_trace,
-  const bool &is_compact_trace)
+  goto_tracet &goto_trace)
 {
   unsigned step_nr = 0;
 
@@ -66,7 +65,12 @@ void build_goto_trace(
   // without any explicit scope management here.
   for (auto const &SSA_step : target.SSA_steps)
   {
-    if (SSA_step.hidden && is_compact_trace)
+    // Hidden steps are internal SSA bookkeeping (e.g. phi-merge nodes at
+    // control-flow joins). They carry a synthesised value and a source
+    // location borrowed from a branch, so surfacing them in the trace yields
+    // contradictory-looking states (see discussion #5701). They are never a
+    // user-visible source assignment, so drop them regardless of slicing.
+    if (SSA_step.hidden)
       continue;
 
     if (SSA_step.ignore || !smt_conv.l_get(SSA_step.guard).is_true())

--- a/src/goto-symex/build_goto_trace.h
+++ b/src/goto-symex/build_goto_trace.h
@@ -8,8 +8,7 @@
 void build_goto_trace(
   const symex_target_equationt &target,
   smt_convt &smt_conv,
-  goto_tracet &goto_trace,
-  const bool &is_compact_trace);
+  goto_tracet &goto_trace);
 
 void build_successful_goto_trace(
   const symex_target_equationt &target,


### PR DESCRIPTION
Under bare `--no-slice`, the human-readable counterexample surfaced hidden SSA phi-merge assignments at real source lines with a synthesised merged value, producing the contradictory back-to-back states reported in discussion #5701.

Following @XLiZHI's review, this filters hidden steps unconditionally in `build_goto_trace` (`if (SSA_step.hidden) continue;`) rather than only under compact tracing, instead of propagating a new `hidden` flag onto `goto_trace_stept`. Because the filtering now happens at trace-build time, every trace consumer — plain text, XML, JSON, HTML, SARIF and witnesses — stays consistent, and the now-redundant `is_compact_trace` plumbing is removed.

Adds two regression tests under `regression/esbmc/github_5701*` (a deterministic guard plus the faithful reproducer). Verdicts are unchanged.
