### PR TITLE
[python] Add param-attr fixtures to --python-irep2-adjust acceptance set

### DIFF
--- a/regression/python/python_irep2_adjust_param_attr/main.py
+++ b/regression/python/python_irep2_adjust_param_attr/main.py
@@ -1,0 +1,20 @@
+# Attribute read through a function parameter under --python-irep2-adjust.
+# A class instance is passed by pointer, so `p.x` is a member over *p — the
+# dereference member-source arm the IREP2-native adjuster resolves (V.4 B.1).
+# The sibling fixtures only read attributes on main-local instances; this pins
+# flag parity for the pointer-deref source. Verdict must match the default path.
+class Point:
+    def __init__(self, x: int) -> None:
+        self.x: int = x
+
+
+def get_x(p: Point) -> int:
+    return p.x
+
+
+def main() -> None:
+    pt = Point(5)
+    assert get_x(pt) == 5
+
+
+main()

--- a/regression/python/python_irep2_adjust_param_attr/test.desc
+++ b/regression/python/python_irep2_adjust_param_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_param_attr_fail/main.py
+++ b/regression/python/python_irep2_adjust_param_attr_fail/main.py
@@ -1,0 +1,18 @@
+# Negative variant of python_irep2_adjust_param_attr: the assertion contradicts
+# the value read through the parameter, so verification must FAIL under
+# --python-irep2-adjust too (the deref member source resolves to the real field).
+class Point:
+    def __init__(self, x: int) -> None:
+        self.x: int = x
+
+
+def get_x(p: Point) -> int:
+    return p.x
+
+
+def main() -> None:
+    pt = Point(5)
+    assert get_x(pt) == 99
+
+
+main()

--- a/regression/python/python_irep2_adjust_param_attr_fail/test.desc
+++ b/regression/python/python_irep2_adjust_param_attr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 3
+^VERIFICATION FAILED$


### PR DESCRIPTION
## What

Adds a passing/failing regression pair to the `--python-irep2-adjust`
acceptance fixture (V.4 B.2, the IREP2-native Python adjuster gate):

- `regression/python/python_irep2_adjust_param_attr` — `VERIFICATION SUCCESSFUL`
- `regression/python/python_irep2_adjust_param_attr_fail` — `VERIFICATION FAILED`

Both read a class attribute **through a function parameter** (`def get_x(p: Point): return p.x`).

## Why

The five existing flag fixtures (`python_irep2_adjust_{flag,flag_fail,dataclass,inferred_attr,nested_attr}`)
all read attributes on **main-local** instances. The Python frontend passes
class instances by pointer, so `p.x` on a parameter lowers to a member over
`*p` — the **dereference member-source** arm that `python_adjust::resolve_source`
auto-resolves (`src/python-frontend/python_adjust.cpp`). That arm is currently
only unit-tested synthetically; no integration fixture exercises it. This pair
pins flag-on/flag-off verdict parity for the pointer-deref source shape and
extends the acceptance gate the keystone adjuster must satisfy.

## Validation

- ESBMC: pass fixture → `VERIFICATION SUCCESSFUL`, fail fixture → `VERIFICATION FAILED`, identical with and without `--python-irep2-adjust` (parity).
- `ctest -R python_irep2_adjust_param_attr`: 2/2 pass.
- `scripts/check_python_tests.sh param_attr`: CPython sanity green (pass→exit 0, fail→assert→exit 1).
- YAPF/format consistent with the existing fixtures.
