### PR TITLE
[python] Fix flaky macOS CI timeout in set_variadic_methods

### DIFF
--- a/regression/python/set_variadic_methods/test.desc
+++ b/regression/python/set_variadic_methods/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc
+--unwind 3
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## What

Change `regression/python/set_variadic_methods` from `--incremental-bmc` to a
fixed `--unwind 3`.

## Why

`--incremental-bmc` re-solves at each increasing unwind bound, so the test runs
~24s locally but ~120s on the GitHub `macos-latest` runner — intermittently
tripping the 120s per-test cap (`ESBMC_REGRESS_TIMEOUT`) and failing macOS CI
on unrelated PRs (e.g. #5709, a docs-only change). The small set-operation
loops here fully unwind at bound 3, so a fixed `--unwind 3` proves the same
`VERIFICATION SUCCESSFUL` property (unwinding assertions pass — a sound, complete
proof) in ~9s, removing the flaky timeout with identical coverage.

## Validation

- `ctest -R set_variadic_methods`: pass in **8.75s** (was ~24s); `--unwind 2`
  fails (loop needs 3), confirming 3 is the minimal sound bound.
- `check_python_tests.sh set_variadic_methods`: CPython sanity green
  (`main.py` unchanged).
