### PR TITLE
[python] Preserve element class in comprehensions over instances

### DIFF
--- a/regression/python/github_4805_comprehension_conflict/main.py
+++ b/regression/python/github_4805_comprehension_conflict/main.py
@@ -1,0 +1,25 @@
+# Reusing a list-variable name across comprehensions whose sources hold
+# different classes must not hang the frontend. The module-wide element-class
+# fixpoint previously spun forever once such a name resolved to a conflict
+# (#4805 review finding).
+
+
+class A:
+    def __init__(self):
+        self.x = 1
+
+
+class B:
+    def __init__(self):
+        self.x = 2
+
+
+def run():
+    s1 = [A(), A()]
+    s2 = [B(), B()]
+    v = [p for p in s1]
+    v = [q for q in s2]
+    return len(v)
+
+
+assert run() == 2

--- a/regression/python/github_4805_comprehension_conflict/test.desc
+++ b/regression/python/github_4805_comprehension_conflict/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4805_comprehension_obj/main.py
+++ b/regression/python/github_4805_comprehension_obj/main.py
@@ -1,0 +1,32 @@
+# A list comprehension over a list of class instances must preserve each
+# element's class. Before the #4805 fix the comprehension stored elements with
+# a zero type-id, so iterating the result and reading an attribute
+# (`for x in node.outs`) dereferenced an invalid pointer. The same computation
+# must now verify cleanly.
+
+
+class Node:
+    def __init__(self, value=0, outs=[]):
+        self.value = value
+        self.outs = outs
+
+
+def total_out_values(nodes):
+    selected = [n for n in nodes if n.value > 0]
+    total = 0
+    for node in selected:
+        for x in node.outs:
+            total = total + x.value
+    return total
+
+
+def test():
+    a = Node(5)
+    b = Node(7)
+    c = Node(9)
+    a.outs = [b, c]
+    # b and c have no outgoing nodes, so only a contributes: 7 + 9 = 16.
+    assert total_out_values([a, b, c]) == 16
+
+
+test()

--- a/regression/python/github_4805_comprehension_obj/test.desc
+++ b/regression/python/github_4805_comprehension_obj/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4805_comprehension_obj_fail/main.py
+++ b/regression/python/github_4805_comprehension_obj_fail/main.py
@@ -1,0 +1,32 @@
+# A list comprehension over a list of class instances must preserve each
+# element's class. Before the #4805 fix the comprehension stored elements with
+# a zero type-id, so iterating the result and reading an attribute
+# (`for x in node.outs`) dereferenced an invalid pointer. The same computation
+# must now verify cleanly.
+
+
+class Node:
+    def __init__(self, value=0, outs=[]):
+        self.value = value
+        self.outs = outs
+
+
+def total_out_values(nodes):
+    selected = [n for n in nodes if n.value > 0]
+    total = 0
+    for node in selected:
+        for x in node.outs:
+            total = total + x.value
+    return total
+
+
+def test():
+    a = Node(5)
+    b = Node(7)
+    c = Node(9)
+    a.outs = [b, c]
+    # b and c have no outgoing nodes, so only a contributes: 7 + 9 = 16, so 17 is wrong.
+    assert total_out_values([a, b, c]) == 17
+
+
+test()

--- a/regression/python/github_4805_comprehension_obj_fail/test.desc
+++ b/regression/python/github_4805_comprehension_obj_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_4805_comprehension_scope/main.py
+++ b/regression/python/github_4805_comprehension_scope/main.py
@@ -1,0 +1,27 @@
+# The element-class map is keyed by bare variable name across the whole module,
+# so it must be conservative: a name that is a class instance in one scope and a
+# plain value in another must not be force-typed as the class (which would
+# mis-store the loop element). Here `a` is an A() in f() but an int in g();
+# g()'s loop must keep it an int (#4805 review finding).
+
+
+class A:
+    def __init__(self):
+        self.x = 7
+
+
+def f():
+    a = A()
+    return a.x
+
+
+def g():
+    a = 3
+    total = 0
+    for v in [a]:
+        total = total + v
+    return total
+
+
+assert f() == 7
+assert g() == 3

--- a/regression/python/github_4805_comprehension_scope/test.desc
+++ b/regression/python/github_4805_comprehension_scope/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/topological_ordering_fail/main.py
+++ b/regression/quixbugs/topological_ordering_fail/main.py
@@ -1,3 +1,23 @@
+# KNOWNBUG (#4805). The QuixBugs `topological_ordering` bug is that the guard
+# reads `nextnode.outgoing_nodes` where it should read `nextnode.incoming_nodes`.
+# ESBMC cannot genuinely detect it within a practical BMC budget: the algorithm
+# builds a list of graph nodes by comprehension and then repeatedly evaluates
+# `set(ordered_nodes).issuperset(...)`, `nextnode not in ordered_nodes`, and
+# `ordered_nodes.append(...)` over a symbolic-size list of heap objects. That
+# membership/append machinery is combinatorially hard for the SMT backend -- it
+# does not converge even on a 3-node graph (decision procedure ~50s at one
+# unwind; full graphs time out). This is the #5121 symbolic-lists-of-objects
+# scalability wall, the same wall as the sibling `github_4782_object_size`.
+# The object-handling correctness fixes that #4805 surfaced have all merged
+# (issuperset lowering / object_size abort / OM copy in PR #5306; Class*-pointer
+# reads in PR #5339; `obj in [obj]` membership in PR #5569; list-comprehension
+# element type-id preservation, with `github_4805_comprehension_obj`). What
+# remains is pure solver scalability, so the test stays KNOWNBUG. The earlier
+# `VERIFICATION FAILED` here was vacuous -- it came from a truncated-loop
+# unwinding assertion, not from detecting the algorithmic bug (adding
+# `--no-unwinding-assertions` makes ESBMC report SUCCESSFUL). The KNOWNBUG flags
+# keep `--no-unwinding-assertions` so the recorded result honestly reflects that
+# ESBMC cannot detect the bug, mirroring the sibling `topological_ordering`.
 class Node:
     def __init__(
         self,

--- a/regression/quixbugs/topological_ordering_fail/test.desc
+++ b/regression/quixbugs/topological_ordering_fail/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
---unwind 1 --no-standard-checks
+--unwind 1 --no-standard-checks --no-unwinding-assertions
 ^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -506,10 +506,25 @@ class LoopMixin:
             if target_is_name:
                 rhs = ast.Name(id=temp_names[idx], ctx=ast.Load())
                 self.ensure_all_locations(rhs, node)
-                target_assign = ast.Assign(
-                    targets=[ast.Name(id=node.target.id, ctx=ast.Store())],
-                    value=rhs,
-                )
+                # Annotate the binding with the element's class when known, so a
+                # user-class element keeps its type even if the body never
+                # touches its attributes. Without this, the loop variable falls
+                # back to Any (void*), and appending it to a list stores a
+                # zero type-id, so a later attribute access on a read-back
+                # element dereferences an invalid pointer (#4805).
+                elem_class = self._element_instance_class(elt)
+                if elem_class:
+                    target_assign = ast.AnnAssign(
+                        target=ast.Name(id=node.target.id, ctx=ast.Store()),
+                        annotation=ast.Name(id=elem_class, ctx=ast.Load()),
+                        value=rhs,
+                        simple=1,
+                    )
+                else:
+                    target_assign = ast.Assign(
+                        targets=[ast.Name(id=node.target.id, ctx=ast.Store())],
+                        value=rhs,
+                    )
             else:
                 # Tuple/list unpacking: keep the RHS as the original literal so
                 # the converter's tuple-unpacking path can still extract elts.

--- a/src/python-frontend/preprocessor/module_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/module_rewrite_mixin.py
@@ -312,7 +312,10 @@ class ModuleRewriteMixin:
                 self.variable_annotations[stmt.target.id] = stmt.annotation
 
         self._scan_dict_literal_bindings_and_calls(node)
+        self.module_class_names, self.instance_var_classes = \
+            self._build_var_class_map(node)
         self.attr_list_element_classes = self._scan_attr_list_element_classes(node)
+        self.list_var_element_classes = self._scan_list_var_element_classes(node)
         self.module_dunder_all = self._capture_dunder_all(node)
         self.apply_range_rewrites(node, alias_seed=alias_seed, wrapper_seed=wrapper_seed)
 

--- a/src/python-frontend/preprocessor/type_inference_mixin.py
+++ b/src/python-frontend/preprocessor/type_inference_mixin.py
@@ -59,6 +59,137 @@ class TypeInferenceMixin:
             return element_annotation.value.id
         return None
 
+    def _build_var_class_map(self, module):
+        """Return (class_names, var_classes) where var_classes maps a variable
+        name to the class of `v = ClassName(...)`. Shared by the attribute-list
+        and list-variable element-class scans.
+
+        The map is keyed by bare name across the whole module (no scope), so it
+        is built conservatively: a name is recorded only when *every* plain
+        assignment to it (in any scope) constructs the same class. A name
+        rebound to a different class, or to any non-constructor value anywhere
+        (e.g. the same local name reused for a non-class value in another
+        function), is dropped -- otherwise a forced loop-target annotation
+        could mis-type it (a soundness hazard, the inverse of #4805)."""
+        class_names = {n.name for n in ast.walk(module) if isinstance(n, ast.ClassDef)}
+        var_classes = {}
+        poisoned = set()
+        # A name bound as a function parameter anywhere is not a fixed class
+        # instance -- drop it so a same-named class local in another scope can
+        # never force a wrong annotation onto the parameter.
+        for n in ast.walk(module):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                a = n.args
+                for arg in (a.posonlyargs + a.args + a.kwonlyargs
+                            + ([a.vararg] if a.vararg else [])
+                            + ([a.kwarg] if a.kwarg else [])):
+                    poisoned.add(arg.arg)
+        for n in ast.walk(module):
+            if not (isinstance(n, ast.Assign) and len(n.targets) == 1
+                    and isinstance(n.targets[0], ast.Name)):
+                continue
+            name = n.targets[0].id
+            func = n.value.func if isinstance(n.value, ast.Call) else None
+            cls = func.id if isinstance(func, ast.Name) and func.id in class_names \
+                else None
+            if cls is None or var_classes.get(name, cls) != cls:
+                poisoned.add(name)
+            else:
+                var_classes[name] = cls
+        for name in poisoned:
+            var_classes.pop(name, None)
+        return class_names, var_classes
+
+    def _element_instance_class(self, elt):
+        """Return the user-class name of a list element when it is a class
+        instance — a constructor call ``ClassName(...)`` or a variable bound to
+        one — else None. Order-independent (resolved from the module-wide
+        ``instance_var_classes`` map), so it works during module rewrite before
+        the main visit pass populates ``known_variable_types``."""
+        class_names = getattr(self, "module_class_names", set())
+        if (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)
+                and elt.func.id in class_names):
+            return elt.func.id
+        if isinstance(elt, ast.Name):
+            return getattr(self, "instance_var_classes", {}).get(elt.id)
+        return None
+
+    def _scan_list_var_element_classes(self, module):
+        """Map a list-variable name -> the single class its elements hold, for
+        `v = [a, b]` (instances of one class) and identity comprehensions
+        `v = [x for x in src ...]` over such a list. Used to type a
+        `for e in v` / comprehension loop target when v carries no element
+        annotation; without it the target falls back to ``Any`` (void*), the
+        element is stored with a zero type-id, and a later attribute access
+        dereferences an invalid pointer (#4805 comprehension type-id loss).
+        """
+        class_names, var_classes = self._build_var_class_map(module)
+
+        def element_class(elt):
+            if (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)
+                    and elt.func.id in class_names):
+                return elt.func.id
+            if isinstance(elt, ast.Name):
+                return var_classes.get(elt.id)
+            return None
+
+        def record(mapping, name, cls):
+            mapping[name] = cls if mapping.get(name, cls) == cls else None
+
+        list_classes = {}
+        # Pass 1: `v = [instances of one class]`.
+        for n in ast.walk(module):
+            if not (isinstance(n, ast.Assign) and isinstance(n.value, ast.List)
+                    and n.value.elts):
+                continue
+            cls = None
+            ok = True
+            for elt in n.value.elts:
+                c = element_class(elt)
+                if c is None or (cls is not None and c != cls):
+                    ok = False
+                    break
+                cls = c
+            if not (ok and cls):
+                continue
+            for t in n.targets:
+                if isinstance(t, ast.Name):
+                    record(list_classes, t.id, cls)
+
+        # Pass 2 (fixpoint): identity comprehension `v = [x for x in src ...]`
+        # inherits src's element class. Iterated so chained comprehensions
+        # resolve regardless of source order.
+        changed = True
+        while changed:
+            changed = False
+            for n in ast.walk(module):
+                if not (isinstance(n, ast.Assign) and isinstance(n.value, ast.ListComp)
+                        and len(n.value.generators) == 1):
+                    continue
+                comp = n.value
+                gen = comp.generators[0]
+                if not (isinstance(comp.elt, ast.Name) and isinstance(gen.target, ast.Name)
+                        and comp.elt.id == gen.target.id and isinstance(gen.iter, ast.Name)):
+                    continue
+                src_cls = list_classes.get(gen.iter.id)
+                if src_cls is None:
+                    continue
+                for t in n.targets:
+                    if not isinstance(t, ast.Name):
+                        continue
+                    # Flag progress only on an actual transition: absent->class
+                    # and class->None (conflict) each fire once, then converge.
+                    # A target already finalized to None must NOT re-flag, or the
+                    # fixpoint never terminates on conflicting comprehension
+                    # sources (e.g. `v=[A...]; v=[B...]`).
+                    sentinel = object()
+                    before = list_classes.get(t.id, sentinel)
+                    record(list_classes, t.id, src_cls)
+                    if list_classes.get(t.id, sentinel) != before:
+                        changed = True
+
+        return {name: cls for name, cls in list_classes.items() if cls}
+
     def _scan_attr_list_element_classes(self, module):
         """Map attribute name -> the single class that every list assigned to
         that attribute anywhere in the module holds (`x.attr = [a, b]` with all
@@ -66,22 +197,7 @@ class TypeInferenceMixin:
         ambiguous or not class instances are dropped. Used to type the target
         of a loop over `obj.attr` when obj's class cannot be resolved (#4805).
         """
-        class_names = {n.name for n in ast.walk(module) if isinstance(n, ast.ClassDef)}
-
-        # name -> class for `v = ClassName(...)`; None when rebound to
-        # different classes.
-        var_classes = {}
-        for n in ast.walk(module):
-            if not (isinstance(n, ast.Assign) and len(n.targets) == 1
-                    and isinstance(n.value, ast.Call)):
-                continue
-            target, func = n.targets[0], n.value.func
-            if not (isinstance(target, ast.Name) and isinstance(func, ast.Name)
-                    and func.id in class_names):
-                continue
-            name = target.id
-            cls = func.id
-            var_classes[name] = cls if var_classes.get(name, cls) == cls else None
+        class_names, var_classes = self._build_var_class_map(module)
 
         def element_class(elt):
             if (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)
@@ -175,10 +291,21 @@ class TypeInferenceMixin:
             attr_class = self.attr_list_element_classes.get(iterable_node.attr)
             if attr_class:
                 return attr_class
+        if isinstance(iterable_node, ast.Name):
+            list_var_class = getattr(self, "list_var_element_classes", {}).get(
+                iterable_node.id)
+            if list_var_class:
+                return list_var_class
         if isinstance(iterable_node, ast.List) and iterable_node.elts:
             first_elem = iterable_node.elts[0]
             if isinstance(first_elem, ast.Constant):
                 return type(first_elem.value).__name__
+            elem_class = self._element_instance_class(first_elem)
+            if elem_class:
+                return elem_class
+            inferred = self._infer_type_from_value(first_elem)
+            if inferred and inferred != "Any":
+                return inferred
         if container_type.lower() in ["list", "tuple"]:
             annotation_element_type = self._extract_list_tuple_annotation_element_type(
                 iterable_node)

--- a/src/python-frontend/preprocessor/type_inference_mixin.py
+++ b/src/python-frontend/preprocessor/type_inference_mixin.py
@@ -114,38 +114,31 @@ class TypeInferenceMixin:
             return getattr(self, "instance_var_classes", {}).get(elt.id)
         return None
 
-    def _scan_list_var_element_classes(self, module):
-        """Map a list-variable name -> the single class its elements hold, for
-        `v = [a, b]` (instances of one class) and identity comprehensions
-        `v = [x for x in src ...]` over such a list. Used to type a
-        `for e in v` / comprehension loop target when v carries no element
-        annotation; without it the target falls back to ``Any`` (void*), the
-        element is stored with a zero type-id, and a later attribute access
-        dereferences an invalid pointer (#4805 comprehension type-id loss).
-        """
-        class_names, var_classes = self._build_var_class_map(module)
+    @staticmethod
+    def _list_element_class(elt, class_names, var_classes):
+        """Class an element expression evaluates to: a `Cls(...)` constructor
+        call or a name already known to hold an instance; otherwise None."""
+        if (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)
+                and elt.func.id in class_names):
+            return elt.func.id
+        if isinstance(elt, ast.Name):
+            return var_classes.get(elt.id)
+        return None
 
-        def element_class(elt):
-            if (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)
-                    and elt.func.id in class_names):
-                return elt.func.id
-            if isinstance(elt, ast.Name):
-                return var_classes.get(elt.id)
-            return None
+    @staticmethod
+    def _record_single_class(mapping, name, cls):
+        """Merge cls into mapping[name], collapsing to None on any conflict."""
+        mapping[name] = cls if mapping.get(name, cls) == cls else None
 
-        def record(mapping, name, cls):
-            mapping[name] = cls if mapping.get(name, cls) == cls else None
-
-        list_classes = {}
-        # Pass 1: `v = [instances of one class]`.
+    def _collect_list_literal_classes(self, module, class_names, var_classes, list_classes):
+        """Pass 1: `v = [instances of one class]` -> list_classes[v] = class."""
         for n in ast.walk(module):
-            if not (isinstance(n, ast.Assign) and isinstance(n.value, ast.List)
-                    and n.value.elts):
+            if not (isinstance(n, ast.Assign) and isinstance(n.value, ast.List) and n.value.elts):
                 continue
             cls = None
             ok = True
             for elt in n.value.elts:
-                c = element_class(elt)
+                c = self._list_element_class(elt, class_names, var_classes)
                 if c is None or (cls is not None and c != cls):
                     ok = False
                     break
@@ -154,11 +147,12 @@ class TypeInferenceMixin:
                 continue
             for t in n.targets:
                 if isinstance(t, ast.Name):
-                    record(list_classes, t.id, cls)
+                    self._record_single_class(list_classes, t.id, cls)
 
-        # Pass 2 (fixpoint): identity comprehension `v = [x for x in src ...]`
-        # inherits src's element class. Iterated so chained comprehensions
-        # resolve regardless of source order.
+    def _propagate_comprehension_classes(self, module, list_classes):
+        """Pass 2 (fixpoint): identity comprehension `v = [x for x in src ...]`
+        inherits src's element class. Iterated so chained comprehensions
+        resolve regardless of source order."""
         changed = True
         while changed:
             changed = False
@@ -184,10 +178,23 @@ class TypeInferenceMixin:
                     # sources (e.g. `v=[A...]; v=[B...]`).
                     sentinel = object()
                     before = list_classes.get(t.id, sentinel)
-                    record(list_classes, t.id, src_cls)
+                    self._record_single_class(list_classes, t.id, src_cls)
                     if list_classes.get(t.id, sentinel) != before:
                         changed = True
 
+    def _scan_list_var_element_classes(self, module):
+        """Map a list-variable name -> the single class its elements hold, for
+        `v = [a, b]` (instances of one class) and identity comprehensions
+        `v = [x for x in src ...]` over such a list. Used to type a
+        `for e in v` / comprehension loop target when v carries no element
+        annotation; without it the target falls back to ``Any`` (void*), the
+        element is stored with a zero type-id, and a later attribute access
+        dereferences an invalid pointer (#4805 comprehension type-id loss).
+        """
+        class_names, var_classes = self._build_var_class_map(module)
+        list_classes = {}
+        self._collect_list_literal_classes(module, class_names, var_classes, list_classes)
+        self._propagate_comprehension_classes(module, list_classes)
         return {name: cls for name, cls in list_classes.items() if cls}
 
     def _scan_attr_list_element_classes(self, module):
@@ -199,14 +206,6 @@ class TypeInferenceMixin:
         """
         class_names, var_classes = self._build_var_class_map(module)
 
-        def element_class(elt):
-            if (isinstance(elt, ast.Call) and isinstance(elt.func, ast.Name)
-                    and elt.func.id in class_names):
-                return elt.func.id
-            if isinstance(elt, ast.Name):
-                return var_classes.get(elt.id)
-            return None
-
         attr_classes = {}
         for n in ast.walk(module):
             if not (isinstance(n, ast.Assign) and len(n.targets) == 1
@@ -214,7 +213,7 @@ class TypeInferenceMixin:
                 continue
             attr = n.targets[0].attr
             for elt in n.value.elts:
-                cls = element_class(elt)
+                cls = self._list_element_class(elt, class_names, var_classes)
                 if cls is None or attr_classes.get(attr, cls) != cls:
                     attr_classes[attr] = None
                 else:

--- a/src/python-frontend/preprocessor/type_inference_mixin.py
+++ b/src/python-frontend/preprocessor/type_inference_mixin.py
@@ -80,9 +80,8 @@ class TypeInferenceMixin:
         for n in ast.walk(module):
             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
                 a = n.args
-                for arg in (a.posonlyargs + a.args + a.kwonlyargs
-                            + ([a.vararg] if a.vararg else [])
-                            + ([a.kwarg] if a.kwarg else [])):
+                for arg in (a.posonlyargs + a.args + a.kwonlyargs +
+                            ([a.vararg] if a.vararg else []) + ([a.kwarg] if a.kwarg else [])):
                     poisoned.add(arg.arg)
         for n in ast.walk(module):
             if not (isinstance(n, ast.Assign) and len(n.targets) == 1
@@ -291,8 +290,7 @@ class TypeInferenceMixin:
             if attr_class:
                 return attr_class
         if isinstance(iterable_node, ast.Name):
-            list_var_class = getattr(self, "list_var_element_classes", {}).get(
-                iterable_node.id)
+            list_var_class = getattr(self, "list_var_element_classes", {}).get(iterable_node.id)
             if list_var_class:
                 return list_var_class
         if isinstance(iterable_node, ast.List) and iterable_node.elts:


### PR DESCRIPTION
A list comprehension over a list of class instances lost each element's class
during preprocessing, so the loop variable fell back to Any (void*), the
comprehension stored elements with a zero type-id, and a later attribute access
on a read-back element dereferenced an invalid pointer. Add a module-wide
list-variable element-class scan and annotate the unrolled loop-target binding;
the class map is built conservatively (a name reused for a non-class value or as
a parameter is dropped) so a loop variable is never mis-typed.

Also re-pin regression/quixbugs/topological_ordering_fail as KNOWNBUG: its CORE
green was a vacuous truncated-loop unwinding assertion, and genuine detection is
blocked by the #5121 symbolic-lists-of-objects scalability wall.

Refs #4805.
