### PR TITLE
[ci] Publish canonical release assets on stable v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,14 @@
 name: Upload Release Asset
 on:
   schedule:
-    #      M H - - D => 06:00 of Monday 
+    #      M H - - D => 06:00 of Monday
   - cron: '0 6 * * 1'
+  push:
+    # Stable releases: tag the commit (e.g. v8.4) and this same pipeline
+    # publishes the canonical esbmc-{linux,windows,macos}.zip assets to that
+    # tag as a draft for a maintainer to review and publish.
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -76,11 +82,18 @@ jobs:
       - name: Do the release
         uses: softprops/action-gh-release@v3
         with:
-          name: 'ESBMC Weekly Pre-release'
-          body: 'This is an automated weekly pre-release of ESBMC. Please report any bugs to our [Issues](https://github.com/esbmc/esbmc/issues) tracking page.'
-          tag_name: weekly
+          # On a v* tag this is a stable release named after the tag; otherwise
+          # it is the rolling weekly pre-release. Both publish the same canonical
+          # asset names, so the website's releases/latest/download/esbmc-*.zip
+          # links keep resolving across stable releases.
+          name: ${{ startsWith(github.ref, 'refs/tags/v') && format('ESBMC {0}', github.ref_name) || 'ESBMC Weekly Pre-release' }}
+          body: ${{ startsWith(github.ref, 'refs/tags/v') && format('ESBMC {0} stable release.', github.ref_name) || 'This is an automated weekly pre-release of ESBMC. Please report any bugs to our [Issues](https://github.com/esbmc/esbmc/issues) tracking page.' }}
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'weekly' }}
           target_commitish: ${{ github.sha }}
-          prerelease: true
+          # Stable releases are created as drafts so a maintainer reviews the
+          # notes and assets before publishing; the weekly stays a live pre-release.
+          draft: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
           files: |
             esbmc-linux.zip
             esbmc-windows.zip


### PR DESCRIPTION
## What

Make stable releases publish the **canonical** asset names
`esbmc-linux.zip` / `esbmc-windows.zip` / `esbmc-macos.zip` by triggering the
existing release pipeline (`.github/workflows/release.yml`) on `v*` tags in
addition to the weekly schedule.

## Why

The homepage Download buttons (`website/content/_index.md`) link to:

- `https://github.com/esbmc/esbmc/releases/latest/download/esbmc-linux.zip`
- `https://github.com/esbmc/esbmc/releases/latest/download/esbmc-windows.zip`

`releases/latest/download/<name>` resolves to that asset on the latest
**non-prerelease** release — currently **v8.3** — but v8.3 was published with
raw build-artifact names instead:

| Website expects | v8.3 actually has |
|---|---|
| `esbmc-linux.zip` | `release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip` |
| `esbmc-windows.zip` | `release-windows-latest.zip` |

So both links 404. Only the `weekly` pre-release (which `release.yml` already
produces) used the canonical names, and `latest` never points at a
pre-release. Reported in https://github.com/esbmc/esbmc/discussions/5713.

## Change

`release.yml` now also fires on `push: tags: ['v*']`. The build matrix is
untouched; only the final `softprops/action-gh-release` step branches on the
ref:

- **`v*` tag** → stable release named after the tag, `prerelease: false`,
  created as a **draft** so a maintainer reviews the notes/assets before
  publishing.
- **schedule / dispatch from master** → unchanged weekly pre-release
  (`tag_name: weekly`, `prerelease: true`).

Both paths upload the same `esbmc-{linux,windows,macos}.zip` + `esbmc.info`,
so `releases/latest/download/esbmc-*.zip` keeps resolving release-to-release.

## Not covered here (needs maintainer action)

This fixes future releases. The **already-published v8.3** still lacks the
canonical names; a maintainer with release write access must add them once:

```sh
gh release download v8.3 --repo esbmc/esbmc \
  -p 'release-ubuntu-24.04--*.zip' -p 'release-windows-latest.zip'
cp release-ubuntu-24.04--*.zip esbmc-linux.zip
cp release-windows-latest.zip   esbmc-windows.zip
gh release upload v8.3 --repo esbmc/esbmc esbmc-linux.zip esbmc-windows.zip
```

(v8.3 has no macOS build artifact, so the homepage macOS tab stays "build
from source" until a stable release ships `esbmc-macos.zip` via this pipeline.)

## Testing

- `release.yml` parses (`yaml.safe_load`); all three triggers
  (`schedule`, `push.tags`, `workflow_dispatch`) and both publish branches
  verified by tracing `github.ref` for the weekly vs. tag cases.
- Can be exercised before the next release via a throwaway tag or
  `workflow_dispatch`.
