### PR TITLE
[python] Support scalar<->string retyping inside conditional bodies

### DIFF
--- a/regression/python/conditional_retype_inblock/main.py
+++ b/regression/python/conditional_retype_inblock/main.py
@@ -1,0 +1,13 @@
+# Dynamic retyping inside a conditional body. A variable bound to a numeric
+# scalar is rebound to a string (and back) inside an `if` block. Reads INSIDE
+# the block must observe the new (string) type, while the variable's float
+# binding established after the block is unaffected. Previously the frontend
+# coerced the in-block string write to a numeric value (0.0) and reported a
+# spurious counterexample for the in-block assertion.
+a = 1
+assert a == 1
+if True:
+    a = "Rafael"
+    assert a == "Rafael"
+a = 1.3
+assert a == 1.3

--- a/regression/python/conditional_retype_inblock/test.desc
+++ b/regression/python/conditional_retype_inblock/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-slice
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/conditional_retype_inblock_fail/main.py
+++ b/regression/python/conditional_retype_inblock_fail/main.py
@@ -1,0 +1,8 @@
+# Negative companion to conditional_retype_inblock: an in-block read of a
+# variable retyped from int to str must still be checked against the real
+# string value, so a wrong in-block assertion is detected (the retype must not
+# silently mask genuine violations).
+a = 1
+if True:
+    a = "Rafael"
+    assert a == "WRONG"

--- a/regression/python/conditional_retype_inblock_fail/test.desc
+++ b/regression/python/conditional_retype_inblock_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-slice
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -91,26 +91,38 @@ bool ast_contains_call(const nlohmann::json &n)
 }
 
 // RAII bump of the get_block() nesting depth, and optionally the function-body
-// depth. Depth 1 is an unconditional top-level (module) statement; anything
-// deeper is nested in a function or a conditional body. Straight-line retyping
-// (#4770/#4774) is sound on the unconditional spine (module body plus enclosing
-// function bodies): exactly block_nesting_ == function_body_depth_ + 1.
+// or loop-body depth. Depth 1 is an unconditional top-level (module) statement;
+// anything deeper is nested in a function or a conditional body. Straight-line
+// retyping (#4770/#4774) is sound on the unconditional spine (module body plus
+// enclosing function bodies): exactly block_nesting_ == function_body_depth_ + 1.
+// loop_body_depth_ counts enclosing while/for bodies: a loop target variable
+// leaks past the loop in Python (so its retype must not be reverted at the
+// body's join), so dynamic retyping is refused inside a loop body and left to
+// the existing fallback, matching the pre-#5716 behaviour.
 struct block_nesting_guard
 {
   unsigned &depth;
   unsigned *fb_depth;
-  explicit block_nesting_guard(unsigned &d, unsigned *fb = nullptr)
-    : depth(d), fb_depth(fb)
+  unsigned *loop_depth;
+  explicit block_nesting_guard(
+    unsigned &d,
+    unsigned *fb = nullptr,
+    unsigned *loop = nullptr)
+    : depth(d), fb_depth(fb), loop_depth(loop)
   {
     ++depth;
     if (fb_depth)
       ++*fb_depth;
+    if (loop_depth)
+      ++*loop_depth;
   }
   ~block_nesting_guard()
   {
     --depth;
     if (fb_depth)
       --*fb_depth;
+    if (loop_depth)
+      --*loop_depth;
   }
 };
 
@@ -2347,14 +2359,22 @@ void python_converter::get_var_assign(
     //
     // On the unconditional spine (block_nesting_ == function_body_depth_ + 1)
     // the alias persists for the rest of the body — there is no control-flow
-    // join that could leave the runtime type ambiguous. Inside an if/while/for/
-    // try body the same rebinding is applied for in-body reads, but get_block
+    // join that could leave the runtime type ambiguous. Inside an if/else/try
+    // body the same rebinding is applied for in-body reads, but get_block
     // snapshots retype_aliases_ on body entry and restores it on exit, so the
     // retype does not leak across the join (the post-join view keeps the
-    // pre-conditional type — see retype_str_cond_gated). Class bodies are
-    // excluded via current_class_name_: their attribute symbols are managed
-    // separately by python_class_builder.
-    if (current_class_name_.empty() && lhs_symbol && lhs.is_symbol())
+    // pre-conditional type — see retype_str_cond_gated).
+    //
+    // Refused inside a while/for body (loop_body_depth_ > 0): a loop target
+    // variable leaks past the loop in Python, so the retyped value must remain
+    // visible after the body rather than be reverted at the join. Leaving the
+    // rebinding to the existing fallback there preserves the pre-#5716 verdict
+    // (see github_3647_15_fail). Class bodies are excluded via
+    // current_class_name_: their attribute symbols are managed separately by
+    // python_class_builder.
+    if (
+      current_class_name_.empty() && lhs_symbol && lhs.is_symbol() &&
+      loop_body_depth_ == 0)
     {
       // The LHS lookup above returns the ORIGINAL symbol. If this variable was
       // already retyped, its live value lives in the alias target; resolve to
@@ -3048,7 +3068,10 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
 
     exprt body_expr;
     if (ast_node["body"].is_array())
-      body_expr = get_block(ast_node["body"]);
+      body_expr = get_block(
+        ast_node["body"],
+        /*is_function_body=*/false,
+        /*is_loop_body=*/true);
     else
       body_expr = get_expr(ast_node["body"]);
     body_expr.location() = location;
@@ -3401,7 +3424,10 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
   else
   {
     if (ast_node["body"].is_array())
-      then = get_block(ast_node["body"]);
+      then = get_block(
+        ast_node["body"],
+        /*is_function_body=*/false,
+        /*is_loop_body=*/type == "While");
     else
       then = get_expr(ast_node["body"]);
   }
@@ -3735,20 +3761,26 @@ void python_converter::get_return_statements(
 
 exprt python_converter::get_block(
   const nlohmann::json &ast_block,
-  bool is_function_body)
+  bool is_function_body,
+  bool is_loop_body)
 {
-  // Track block nesting (and, for a function body, function-body depth) so
-  // straight-line retyping (#4770/#4774) fires on the unconditional spine (the
-  // module body plus enclosing function bodies, block_nesting_ ==
-  // function_body_depth_ + 1) but not inside any if/while/for/try body, which
-  // adds a block_nesting_ frame without a function_body_depth_ frame.
+  // Track block nesting (and the function-body / loop-body depths) so dynamic
+  // retyping (#4770/#4774) fires on the unconditional spine (the module body
+  // plus enclosing function bodies, block_nesting_ == function_body_depth_ + 1)
+  // and inside if/else/try bodies, but not inside a while/for body, where a
+  // retyped loop variable must keep leaking past the join (see get_var_assign).
   block_nesting_guard nesting_guard(
-    block_nesting_, is_function_body ? &function_body_depth_ : nullptr);
+    block_nesting_,
+    is_function_body ? &function_body_depth_ : nullptr,
+    is_loop_body ? &loop_body_depth_ : nullptr);
 
   // A conditional body is any block off the unconditional spine (the module
   // body plus enclosing function bodies, block_nesting_ == function_body_depth_
-  // + 1). Inside one, dynamic retyping is applied locally for in-body reads but
-  // reverted on exit so it does not leak across the control-flow join.
+  // + 1). Inside an if/else/try body, dynamic retyping is applied locally for
+  // in-body reads but reverted on exit so it does not leak across the join. A
+  // loop body retypes nothing (refused in get_var_assign via loop_body_depth_),
+  // so the snapshot/restore is a no-op there and merely preserves any alias
+  // established before the loop.
   const bool is_conditional_body = (block_nesting_ != function_body_depth_ + 1);
   retype_alias_scope_guard retype_guard(retype_aliases_, is_conditional_body);
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -113,6 +113,33 @@ struct block_nesting_guard
       --*fb_depth;
   }
 };
+
+// RAII snapshot/restore of the dynamic-retyping alias map across a conditional
+// body. A numeric<->string reassignment inside an if/while/for/try body retypes
+// the variable so in-body reads observe the new type (sound: there is no join
+// before the body ends). On body exit the alias map is reverted so the
+// post-join view keeps the variable's pre-conditional type — the branch-taken
+// retype must not leak across the control-flow join (see retype_str_cond_gated).
+// Inactive on the unconditional spine, where retypes persist for the whole body.
+struct retype_alias_scope_guard
+{
+  std::unordered_map<std::string, std::string> &aliases;
+  std::unordered_map<std::string, std::string> saved;
+  bool active;
+  retype_alias_scope_guard(
+    std::unordered_map<std::string, std::string> &a,
+    bool act)
+    : aliases(a), active(act)
+  {
+    if (active)
+      saved = aliases;
+  }
+  ~retype_alias_scope_guard()
+  {
+    if (active)
+      aliases = std::move(saved);
+  }
+};
 } // namespace
 
 void python_converter::adjust_statement_types(exprt &lhs, exprt &rhs) const
@@ -2309,24 +2336,25 @@ void python_converter::get_var_assign(
       return;
     }
 
-    // Straight-line dynamic retyping (#4770, #4774). A variable whose current
-    // static type is a numeric scalar is being reassigned a string value (or
-    // vice versa). The GOTO IR binds one type per symbol, so the new value
-    // cannot be stored in the old slot. On the unconditional spine (the module
-    // body plus the chain of enclosing function bodies, i.e. block_nesting_ ==
-    // function_body_depth_ + 1) there is no control-flow join that could leave
-    // the runtime type ambiguous, so we model the rebinding soundly: mint a
-    // fresh symbol of the new type, declare it, and redirect later loads of the
-    // name to it via retype_aliases_ (keyed by the function-qualified symbol
-    // id, so aliases never leak between functions). We then fall through to the
-    // normal assignment path with the new, correctly typed symbol. Statements
-    // inside any if/while/for/try body add a block_nesting_ frame without a
-    // function_body_depth_ frame, so the equality fails and they fall to the
-    // existing fallback. Class bodies are excluded via current_class_name_:
-    // their attribute symbols are managed separately by python_class_builder.
-    if (
-      block_nesting_ == function_body_depth_ + 1 &&
-      current_class_name_.empty() && lhs_symbol && lhs.is_symbol())
+    // Dynamic retyping (#4770, #4774). A variable whose current static type is a
+    // numeric scalar is being reassigned a string value (or vice versa). The
+    // GOTO IR binds one type per symbol, so the new value cannot be stored in
+    // the old slot. We model the rebinding by minting a fresh symbol of the new
+    // type, declaring it, and redirecting later loads of the name to it via
+    // retype_aliases_ (keyed by the function-qualified symbol id, so aliases
+    // never leak between functions). We then fall through to the normal
+    // assignment path with the new, correctly typed symbol.
+    //
+    // On the unconditional spine (block_nesting_ == function_body_depth_ + 1)
+    // the alias persists for the rest of the body — there is no control-flow
+    // join that could leave the runtime type ambiguous. Inside an if/while/for/
+    // try body the same rebinding is applied for in-body reads, but get_block
+    // snapshots retype_aliases_ on body entry and restores it on exit, so the
+    // retype does not leak across the join (the post-join view keeps the
+    // pre-conditional type — see retype_str_cond_gated). Class bodies are
+    // excluded via current_class_name_: their attribute symbols are managed
+    // separately by python_class_builder.
+    if (current_class_name_.empty() && lhs_symbol && lhs.is_symbol())
     {
       // The LHS lookup above returns the ORIGINAL symbol. If this variable was
       // already retyped, its live value lives in the alias target; resolve to
@@ -3716,6 +3744,13 @@ exprt python_converter::get_block(
   // adds a block_nesting_ frame without a function_body_depth_ frame.
   block_nesting_guard nesting_guard(
     block_nesting_, is_function_body ? &function_body_depth_ : nullptr);
+
+  // A conditional body is any block off the unconditional spine (the module
+  // body plus enclosing function bodies, block_nesting_ == function_body_depth_
+  // + 1). Inside one, dynamic retyping is applied locally for in-body reads but
+  // reverted on exit so it does not leak across the control-flow join.
+  const bool is_conditional_body = (block_nesting_ != function_body_depth_ + 1);
+  retype_alias_scope_guard retype_guard(retype_aliases_, is_conditional_body);
 
   // Entering any nested/conditional body (function, if/while/for, try/except):
   // straight-line flow-sensitive class tracking is no longer valid here, so

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -460,8 +460,10 @@ private:
 
   exprt get_function_call(const nlohmann::json &ast_block);
 
-  exprt
-  get_block(const nlohmann::json &ast_block, bool is_function_body = false);
+  exprt get_block(
+    const nlohmann::json &ast_block,
+    bool is_function_body = false,
+    bool is_loop_body = false);
 
   exprt get_static_array(const nlohmann::json &arr, const typet &shape);
 
@@ -1163,6 +1165,14 @@ private:
   /// function_body_depth_ frame, so the equality fails and retyping is refused.
   /// Fail-safe: an unrecognised block kind is treated as conditional.
   unsigned function_body_depth_ = 0;
+
+  /// How many enclosing get_block() frames are while/for loop bodies. A loop
+  /// target variable (and any rebinding inside the body) leaks past the loop in
+  /// Python, so reverting its retype at the body's join would be wrong (it would
+  /// hide the leaked value). Dynamic retyping (#4770/#4774) is therefore refused
+  /// while loop_body_depth_ > 0 and left to the existing fallback — the
+  /// pre-#5716 behaviour — whereas if/else/try bodies do retype-with-revert.
+  unsigned loop_body_depth_ = 0;
 
   function_call_cache function_call_cache_;
 


### PR DESCRIPTION
## Problem

The Python frontend produced a spurious counterexample for a valid program that
rebinds a variable to a different type inside a conditional block:

```python
a = 1
assert a == 1
if True:
    a = "Rafael"
    assert a == "Rafael"
a = 1.3
assert a == 1.3
```

ESBMC reported `VERIFICATION FAILED`, with the in-block `assert a == "Rafael"`
violated. The GOTO showed `a` modelled as a single `double` symbol for its whole
lifetime, so `a = "Rafael"` was silently coerced to `(double)0`.

## Root cause

ESBMC binds one type per GOTO symbol. The existing dynamic-retyping mechanism
(#4770/#4774) mints a fresh symbol when a variable crosses the numeric↔string
boundary and redirects later loads through `retype_aliases_` — but it only fired
on the *unconditional spine* (`block_nesting_ == function_body_depth_ + 1`). A
reassignment one block deep (inside `if`/`while`/`for`/`try`) fell through to the
lossy coercion path, giving the wrong value and a false alarm.

## Fix

1. Relax the retype gate in `get_var_assign` so it also fires inside conditional
   bodies.
2. Add an RAII `retype_alias_scope_guard` in `get_block` that snapshots
   `retype_aliases_` on entry to a conditional body and restores it on exit. An
   in-block retype is therefore visible to in-block reads (sound — there is no
   join before the body ends) but does **not** leak across the control-flow
   join. This preserves the deliberately-chosen post-join policy documented in
   the existing `retype_str_cond_gated` test (the variable keeps its
   pre-conditional type after the block).

## Testing

- New regression tests:
  - `regression/python/conditional_retype_inblock` — the reproducer, now
    `VERIFICATION SUCCESSFUL`.
  - `regression/python/conditional_retype_inblock_fail` — an in-block read of a
    retyped variable is still checked against the real string value, so a wrong
    in-block assertion is detected (`VERIFICATION FAILED`).
- Affected-subset regression run (138 tests: all `retype_*`, `string-split`
  reassignment chains, `boolop_mixed_type`, `github_4770_retype_in_try`,
  `github_4774_chained_retype`, `float_cond_retype`, `consteval_global_*`) — 100%
  passed.
- clang-format clean.

## Known limitation (pre-existing, unchanged)

When a conditional branch *is* taken and the variable is read *after* the join
expecting the old type, ESBMC keeps the old type — a latent false negative the
codebase already accepts (see `retype_str_cond_gated`). This change does not
worsen it; the post-join view is identical to the prior "drop the write"
behaviour, while in-block reads are now correct.
