### PR TITLE
[goto-programs] Map CBMC instruction types to ESBMC kinds

### DIFF
--- a/src/goto-programs/cbmc_adapter.cpp
+++ b/src/goto-programs/cbmc_adapter.cpp
@@ -304,12 +304,6 @@ irept instruction_to_esbmc_irep(
 {
   irept result;
 
-  if (ins.instr_type == 19)
-  {
-    log_error("CBMC adapter: unexpected instruction type 19");
-    abort();
-  }
-
   // ESBMC expects code arguments inside "operands".
   irept code = ins.code;
   irept operands;
@@ -326,7 +320,8 @@ irept instruction_to_esbmc_irep(
 
   result.add("code") = code;
   result.add("location") = ins.source_location;
-  result.add("typeid") = mk(std::to_string(ins.instr_type));
+  result.add("typeid") =
+    mk(std::to_string(map_cbmc_instruction_type(ins.instr_type)));
   result.add("guard") = ins.guard;
 
   if (!ins.targets.empty())
@@ -381,6 +376,78 @@ irept function_to_esbmc_irep(const cbmc_functiont &func)
 }
 
 } // namespace
+
+unsigned map_cbmc_instruction_type(unsigned cbmc_type)
+{
+  // CBMC's goto_program_instruction_typet (CBMC src/goto-programs/goto_program.h),
+  // named here so the CBMC->ESBMC mapping is explicit and auditable. The
+  // numbering matches CBMC's enum exactly.
+  enum cbmc_instruction_typet
+  {
+    CBMC_NO_INSTRUCTION_TYPE = 0,
+    CBMC_GOTO = 1,
+    CBMC_ASSUME = 2,
+    CBMC_ASSERT = 3,
+    CBMC_OTHER = 4,
+    CBMC_SKIP = 5,
+    CBMC_START_THREAD = 6,
+    CBMC_END_THREAD = 7,
+    CBMC_LOCATION = 8,
+    CBMC_END_FUNCTION = 9,
+    CBMC_ATOMIC_BEGIN = 10,
+    CBMC_ATOMIC_END = 11,
+    CBMC_RETURN = 12, // renamed SET_RETURN_VALUE upstream; value unchanged
+    CBMC_ASSIGN = 13,
+    CBMC_DECL = 14,
+    CBMC_DEAD = 15,
+    CBMC_FUNCTION_CALL = 16,
+    CBMC_THROW = 17,
+    CBMC_CATCH = 18,
+    CBMC_INCOMPLETE_GOTO = 19,
+  };
+
+  switch (cbmc_type)
+  {
+  // ESBMC shares these enumerator values (goto_program.h), so the raw CBMC
+  // value already names the right ESBMC kind: map by identity.
+  case CBMC_NO_INSTRUCTION_TYPE:
+  case CBMC_GOTO:
+  case CBMC_ASSUME:
+  case CBMC_ASSERT:
+  case CBMC_OTHER:
+  case CBMC_SKIP:
+  case CBMC_LOCATION:
+  case CBMC_END_FUNCTION:
+  case CBMC_ATOMIC_BEGIN:
+  case CBMC_ATOMIC_END:
+  case CBMC_RETURN:
+  case CBMC_ASSIGN:
+  case CBMC_DECL:
+  case CBMC_DEAD:
+  case CBMC_FUNCTION_CALL:
+  case CBMC_THROW:
+  case CBMC_CATCH:
+    return cbmc_type;
+
+  case CBMC_START_THREAD:
+  case CBMC_END_THREAD:
+    log_error(
+      "CBMC adapter: thread instruction ({}) is not supported; ESBMC models "
+      "concurrency as intrinsic calls, not goto instruction types",
+      cbmc_type == CBMC_START_THREAD ? "START_THREAD" : "END_THREAD");
+    abort();
+
+  case CBMC_INCOMPLETE_GOTO:
+    log_error(
+      "CBMC adapter: INCOMPLETE_GOTO (19) in a finished binary; the goto "
+      "target was never resolved");
+    abort();
+
+  default:
+    log_error("CBMC adapter: unknown CBMC instruction type {}", cbmc_type);
+    abort();
+  }
+}
 
 cbmc_adapted_resultt adapt_cbmc_to_esbmc(cbmc_parse_resultt parsed)
 {

--- a/src/goto-programs/cbmc_adapter.h
+++ b/src/goto-programs/cbmc_adapter.h
@@ -20,3 +20,19 @@ struct cbmc_adapted_resultt
 /// Rewrites CBMC irep conventions into ESBMC's. Faithful port of
 /// goto-transcoder's adapter.rs (ESBMCParseResult::from(CBMCParseResult)).
 cbmc_adapted_resultt adapt_cbmc_to_esbmc(cbmc_parse_resultt parsed);
+
+/// Maps a CBMC goto-program instruction-type value onto the matching ESBMC
+/// goto_program_instruction_typet value.
+///
+/// CBMC and ESBMC share the `goto_program_instruction_typet` numbering for
+/// every kind that reaches a finished straight-line/control-flow binary, so
+/// those map by identity. The kinds that diverge are handled explicitly:
+///   - START_THREAD (6) / END_THREAD (7): CBMC encodes concurrency as
+///     instruction types, whereas ESBMC models it with `__ESBMC_spawn_thread`
+///     intrinsic calls and has no instruction-type counterpart.
+///   - INCOMPLETE_GOTO (19): an unresolved goto that should not survive into a
+///     finished binary; ESBMC reuses 19 as a removed-enumerator gap.
+/// These divergent kinds are rejected with a named diagnostic (the function
+/// aborts) rather than being silently mis-cast in symex. \p cbmc_type is a raw
+/// CBMC instruction-type value; the return value is the ESBMC enumerator.
+unsigned map_cbmc_instruction_type(unsigned cbmc_type);

--- a/unit/goto-programs/read_cbmc_goto_object.test.cpp
+++ b/unit/goto-programs/read_cbmc_goto_object.test.cpp
@@ -11,7 +11,9 @@
 #include <catch2/catch.hpp>
 
 #include <goto-programs/read_cbmc_goto_object.h>
+#include <goto-programs/cbmc_adapter.h>
 #include <goto-programs/goto_functions.h>
+#include <goto-programs/goto_program.h>
 #include <util/context.h>
 #include <util/migrate.h>
 #include <util/namespace.h>
@@ -128,6 +130,33 @@ TEST_CASE("parses a real CBMC v6 goto-binary", "[cbmc-reader]")
 }
 
 TEST_CASE(
+  "CBMC instruction types map to the matching ESBMC kind",
+  "[cbmc-reader]")
+{
+  // CBMC and ESBMC share the goto_program_instruction_typet numbering for every
+  // kind that survives into a finished straight-line/control-flow binary, so the
+  // adapter maps them by identity. Pin each one against the ESBMC enumerator so a
+  // future renumbering on either side is caught here rather than in symex.
+  REQUIRE(map_cbmc_instruction_type(0) == NO_INSTRUCTION_TYPE);
+  REQUIRE(map_cbmc_instruction_type(1) == GOTO);
+  REQUIRE(map_cbmc_instruction_type(2) == ASSUME);
+  REQUIRE(map_cbmc_instruction_type(3) == ASSERT);
+  REQUIRE(map_cbmc_instruction_type(4) == OTHER);
+  REQUIRE(map_cbmc_instruction_type(5) == SKIP);
+  REQUIRE(map_cbmc_instruction_type(8) == LOCATION);
+  REQUIRE(map_cbmc_instruction_type(9) == END_FUNCTION);
+  REQUIRE(map_cbmc_instruction_type(10) == ATOMIC_BEGIN);
+  REQUIRE(map_cbmc_instruction_type(11) == ATOMIC_END);
+  REQUIRE(map_cbmc_instruction_type(12) == RETURN);
+  REQUIRE(map_cbmc_instruction_type(13) == ASSIGN);
+  REQUIRE(map_cbmc_instruction_type(14) == DECL);
+  REQUIRE(map_cbmc_instruction_type(15) == DEAD);
+  REQUIRE(map_cbmc_instruction_type(16) == FUNCTION_CALL);
+  REQUIRE(map_cbmc_instruction_type(17) == THROW);
+  REQUIRE(map_cbmc_instruction_type(18) == CATCH);
+}
+
+TEST_CASE(
   "loads a CBMC binary into a symbol table and goto functions",
   "[cbmc-reader]")
 {
@@ -153,6 +182,15 @@ TEST_CASE(
   REQUIRE(
     goto_functions.function_map.find("__CPROVER__start") !=
     goto_functions.function_map.end());
+
+  // Every instruction in the loaded body carries an ESBMC instruction type that
+  // came through map_cbmc_instruction_type, and a well-formed function ends with
+  // END_FUNCTION. A raw, unmapped CBMC value would surface as an unknown kind.
+  const goto_programt &body = it->second.body;
+  REQUIRE_FALSE(body.instructions.empty());
+  for (const auto &ins : body.instructions)
+    REQUIRE(ins.type <= CATCH); // the mapper only ever returns 0..18
+  REQUIRE(body.instructions.back().type == END_FUNCTION);
 
   migrate_namespace_lookup = nullptr;
 }


### PR DESCRIPTION
Replaces the CBMC goto-binary adapter's raw instruction-type pass-through (and its ad-hoc abort on type 19) with an explicit, auditable `map_cbmc_instruction_type()` table: identity for the kinds CBMC and ESBMC share (0-5, 8-18), and a named diagnostic for the divergent ones — START_THREAD/END_THREAD (ESBMC models concurrency as intrinsic calls) and INCOMPLETE_GOTO.

Implements Phase 1 (§4.1, instruction-type fidelity) of `docs/cprover-support-roadmap.md`. Adds a unit test pinning every shared kind to its ESBMC enumerator and strengthens the load test to confirm mapped types flow end-to-end. Verified with ESBMC (identity + valid-range, dual-solver Bitwuzla/Z3) and clang-format 11 clean.