### PR TITLE
[python] Model str.isascii/isdecimal/isprintable on constants

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -3412,3 +3412,46 @@ case all stand; the §5 priority order stands.
 
 > **Note on numbering.** §42/§43 and §47–§55 (PRs #5668, #5669, #5673–#5681) are in flight and not yet
 > on `master` (§39/§40/§41/§44/§45/§46 merged); this sweep is appended as §56.
+
+---
+
+## 74. 2026-06-30 re-validation (sixty-fourth sweep) & str.isascii/isdecimal/isprintable
+
+Re-test against current `master` (tip `efc3a92b5f`). KNOWNBUG classification unchanged — §3 holds.
+A string-predicate battery found three `is*` methods that reported a spurious verdict for want of a
+model.
+
+### 74a. New isolated, soundly-fixable defect found & fixed
+**`str.isascii()`, `str.isdecimal()`, and `str.isprintable()` on a constant string were unmodelled,
+reporting a spurious `VERIFICATION FAILED` (PR #5720).**
+
+`"abc".isascii()`, `"123".isdecimal()`, and `"abc".isprintable()` each hit the "Unsupported function"
+→ `assert(false)` fallback, so any program calling them reported `FAILED` (a false alarm). The sibling
+predicates `isalpha`/`isdigit`/`isalnum`/`isspace`/`isupper`/`islower` were already constant-folded;
+these three had simply never been added.
+
+**Fix** (`src/python-frontend/python_consteval.cpp`): add three entries to the existing `pred_all`
+constant-fold helper — the same per-character mechanism the sibling predicates use — with the correct
+predicate and empty-string result: `isascii` (char < 128, True on empty), `isdecimal` (`'0'..'9'`,
+False on empty), `isprintable` (`std::isprint`, True on empty). Like the existing predicates this is a
+byte-level model: it matches CPython exactly for ASCII (the constant-fold domain) and shares the
+sibling predicates' known non-ASCII/Unicode limitation. Operands are cast to `unsigned char`, so the
+ctype calls are well-defined.
+
+This **restores working behaviour** (the three predicates now verify with exact values). New
+regression pair `regression/python/str_is_predicates{,_fail}` (CORE): the positive is the liveness
+witness, covering all three predicates across ASCII text, the empty string, tab, DEL (`0x7f`), and a
+high byte (`0x80`); the `_fail` pins `"a\tb".isprintable()` as a real `FAILED`. Verified bit-for-bit
+against CPython; CPython sanity passes (`scripts/check_python_tests.sh str_is_predicates`); the
+focused `str`/`string`/`consteval` ctest subset (457 tests) shows zero non-environmental regression
+(only the pre-existing `--z3`/`--ir`/`--boolector` set on this Bitwuzla-only build). Solver-agnostic
+(a frontend constant fold, no SMT encoding).
+
+`str.istitle()` remains unmodelled — it needs word-boundary (cased-run) tracking rather than a flat
+per-character predicate, so it is a separate change. Variable-string receivers (`s.isascii()` for a
+non-literal `s`) still route to the runtime handler, which models a different subset; extending that
+is orthogonal.
+
+### 74b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. The §5 priority order stands.

--- a/regression/python/str_is_predicates/main.py
+++ b/regression/python/str_is_predicates/main.py
@@ -1,0 +1,22 @@
+def main() -> None:
+    # str.isascii(): every char < 128; True on the empty string.
+    assert "abc".isascii()
+    assert "".isascii()
+    assert "a1 ~\t".isascii()
+    assert not "\x80".isascii()
+
+    # str.isdecimal(): every char a decimal digit; False on the empty string.
+    assert "123".isdecimal()
+    assert not "".isdecimal()
+    assert not "12a".isdecimal()
+    assert not "1 2".isdecimal()
+
+    # str.isprintable(): every char printable (space is, tab/DEL are not);
+    # True on the empty string.
+    assert "abc 123 ~".isprintable()
+    assert "".isprintable()
+    assert not "a\tb".isprintable()
+    assert not "x\x7f".isprintable()
+
+
+main()

--- a/regression/python/str_is_predicates/test.desc
+++ b/regression/python/str_is_predicates/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_is_predicates_fail/main.py
+++ b/regression/python/str_is_predicates_fail/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    # "a\tb" contains a tab, which is not printable: isprintable() is False, so
+    # this assertion must be falsified (it was unsupported -> spurious FAILED
+    # before isprintable was modelled, and is a real FAILED now).
+    assert "a\tb".isprintable()
+
+
+main()

--- a/regression/python/str_is_predicates_fail/test.desc
+++ b/regression/python/str_is_predicates_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1245,6 +1245,18 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
         if (m == "isspace")
           return pred_all(
             [](unsigned char c) { return std::isspace(c) != 0; }, false);
+        // isascii/isprintable return True on the empty string (unlike the
+        // other predicates); isdecimal returns False. Over byte strings the
+        // ASCII range coincides with CPython for isdecimal (the '0'..'9'
+        // digits) and for the printable/ascii classification.
+        if (m == "isascii")
+          return pred_all([](unsigned char c) { return c < 128; }, true);
+        if (m == "isdecimal")
+          return pred_all(
+            [](unsigned char c) { return c >= '0' && c <= '9'; }, false);
+        if (m == "isprintable")
+          return pred_all(
+            [](unsigned char c) { return std::isprint(c) != 0; }, true);
         if (m == "isupper" || m == "islower")
         {
           if (!args_arr.empty())


### PR DESCRIPTION
## Problem

`str.isascii()`, `str.isdecimal()`, and `str.isprintable()` on a constant string were unmodelled. Each hit the "Unsupported function" → `assert(false)` fallback, so any program calling them reported a spurious `VERIFICATION FAILED`:

```python
assert "abc".isascii()       # FAILED (should be SUCCESSFUL)
assert "123".isdecimal()     # FAILED
assert "abc".isprintable()   # FAILED
```

The sibling predicates `isalpha`/`isdigit`/`isalnum`/`isspace`/`isupper`/`islower` were already constant-folded; these three had never been added.

## Fix

Add three entries to the existing `pred_all` constant-fold helper in `src/python-frontend/python_consteval.cpp` — the same per-character mechanism the sibling predicates use — with the correct predicate and empty-string result:

| method | predicate | empty string |
|---|---|---|
| `isascii` | `c < 128` | `True` |
| `isdecimal` | `'0' <= c <= '9'` | `False` |
| `isprintable` | `std::isprint(c)` | `True` |

Like the existing predicates this is a byte-level model: it matches CPython exactly for ASCII (the constant-fold domain) and shares the sibling predicates' known non-ASCII/Unicode limitation. Operands are cast to `unsigned char`, so the ctype calls are well-defined.

`str.istitle()` is intentionally left out — it needs word-boundary (cased-run) tracking rather than a flat per-character predicate.

## Tests

- `regression/python/str_is_predicates` (CORE, positive / liveness witness): all three predicates across ASCII text, the empty string, tab, DEL (`0x7f`), and a high byte (`0x80`).
- `regression/python/str_is_predicates_fail` (CORE): `"a\tb".isprintable()` pinned as a real `FAILED`.

Verified bit-for-bit against CPython; `scripts/check_python_tests.sh str_is_predicates` passes; the focused `str`/`string`/`consteval` ctest subset (457 tests) shows zero non-environmental failures. Solver-agnostic (a frontend constant fold).
