### PR TITLE
[docs] Add bison to macOS build prerequisites

### DIFF
--- a/website/content/docs/development/building.md
+++ b/website/content/docs/development/building.md
@@ -120,7 +120,7 @@ For a multi-solver build see [Building with all solvers](#building-with-all-solv
 ### Install prerequisites
 
 ```sh
-brew install llvm@21 z3 boost cmake ninja python
+brew install llvm@21 z3 boost cmake ninja python bison
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## What

Add `bison` to the macOS prerequisites in the building guide.

## Why

The macOS `brew install` line omitted `bison`. ESBMC's SMT-LIB parser
requires `find_package(BISON 2.6.1 REQUIRED)`
(`src/solvers/smtlib/CMakeLists.txt`), but macOS ships **bison 2.3** (frozen
at GPLv2), so `cmake` configure fails until the user installs a newer bison
from Homebrew. `CMakeLists.txt` already auto-detects the keg-only Homebrew
bison via `brew --prefix bison`, so installing it is sufficient — no `PATH`
change needed.

Reported in https://github.com/esbmc/esbmc/discussions/5721 (students on
macOS had to add `bison` to make the build configure).

## Why not `flex`

The same CMake also requires `FLEX 2.6.1`, but macOS's Xcode Command Line
Tools ship a new-enough flex, whereas bison is stuck at 2.3 — so only bison
is the gap. This matches `scripts/build-esbmc-mac.sh` (the documented "easiest"
helper), which installs `bison` but deliberately not `flex`.

## Change

```diff
-brew install llvm@21 z3 boost cmake ninja python
+brew install llvm@21 z3 boost cmake ninja python bison
```
