### PR TITLE
[python] Compare int and float dict values numerically in dict_eq

### DIFF
--- a/regression/python/dict_eq_int_float/main.py
+++ b/regression/python/dict_eq_int_float/main.py
@@ -1,0 +1,29 @@
+# __ESBMC_dict_eq compared int and float dict values by raw type_id + bytes,
+# so Python's numeric equality (1 == 1.0) was rejected as a spurious mismatch
+# whenever one dict's values were floats and the other's were ints -- the same
+# class of bug already fixed for __ESBMC_list_eq (#5207). Mentioned in #5444
+# ("int/float __ESBMC_dict_eq" gap) as one of the blockers for
+# quixbugs/shortest_paths, whose result dict mixes a float('inf') sentinel
+# with int-valued min() results, compared against an int-literal `expected`.
+# Covers both homogeneous dicts (all-float vs all-int) and a heterogeneous
+# dict (mixed float/int values in one dict), which take different storage
+# paths (dict_construction.cpp's all_values_float gate).
+def main() -> None:
+    d1 = {"a": 1.0, "b": 2.0}
+    d2 = {"a": 1, "b": 2}
+    assert d1 == d2
+    assert not (d1 != d2)
+
+    # Heterogeneous dict (mixed float/int values in the same dict), matching
+    # shortest_paths' actual pattern: a float('inf') sentinel alongside
+    # int-valued min() results, compared against an int-literal dict.
+    d3 = {"a": float("inf"), "b": 2}
+    d4 = {"a": 999999, "b": 2}
+    assert d3 != d4
+
+    d5 = {"a": 1, "b": 2.0}
+    d6 = {"a": 1, "b": 2}
+    assert d5 == d6
+
+
+main()

--- a/regression/python/dict_eq_int_float/test.desc
+++ b/regression/python/dict_eq_int_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_eq_int_float_fail/main.py
+++ b/regression/python/dict_eq_int_float_fail/main.py
@@ -1,0 +1,10 @@
+# Negative variant of dict_eq_int_float: a genuinely different float value
+# (1.5 vs 1) must still compare unequal -- the numeric int/float fallback
+# must not paper over real differences.
+def main() -> None:
+    d1 = {"a": 1.5, "b": 2.0}
+    d2 = {"a": 1, "b": 2}
+    assert d1 == d2
+
+
+main()

--- a/regression/python/dict_eq_int_float_fail/test.desc
+++ b/regression/python/dict_eq_int_float_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -846,7 +846,8 @@ bool __ESBMC_dict_eq(
   const PyListObject *lhs_keys,
   const PyListObject *lhs_values,
   const PyListObject *rhs_keys,
-  const PyListObject *rhs_values)
+  const PyListObject *rhs_values,
+  size_t float_type_id)
 {
   if (!lhs_keys || !lhs_values || !rhs_keys || !rhs_values)
     return false;
@@ -899,6 +900,23 @@ bool __ESBMC_dict_eq(
         (rhs_value->size == 0) ? (const PyListObject *)rhs_value->value
                                : *(const PyListObject **)rhs_value->value;
       if (!__ESBMC_list_eq(lhs_list, rhs_list, 0, 0, 0, 0))
+        return false;
+    }
+    else if (
+      float_type_id != 0 && lhs_value->size == 8 && rhs_value->size == 8 &&
+      (lhs_value->type_id == float_type_id) !=
+        (rhs_value->type_id == float_type_id))
+    {
+      // int-vs-float: Python compares numerically (1 == 1.0), but the two
+      // store different bit patterns, so a byte compare would wrongly
+      // differ. Mirrors __ESBMC_list_eq's int/float fallback.
+      const double lv = (lhs_value->type_id == float_type_id)
+                          ? *(const double *)lhs_value->value
+                          : (double)*(const int64_t *)lhs_value->value;
+      const double rv = (rhs_value->type_id == float_type_id)
+                          ? *(const double *)rhs_value->value
+                          : (double)*(const int64_t *)rhs_value->value;
+      if (lv != rv)
         return false;
     }
     else

--- a/src/python-frontend/python-dict/dict_compare.cpp
+++ b/src/python-frontend/python-dict/dict_compare.cpp
@@ -33,7 +33,19 @@ exprt python_dict_handler::compare(
   result_decl.location() = location;
   converter_.add_instruction(result_decl);
 
-  // Call __ESBMC_dict_eq(lhs_keys, lhs_values, rhs_keys, rhs_values)
+  // float_type_id: the runtime type_id Python's `float` is stamped with
+  // everywhere (see get_list_element_info in list_mutation.cpp), so
+  // __ESBMC_dict_eq can numerically compare an int value against a float
+  // value (Python's `1 == 1.0`) instead of rejecting them on a type_id byte
+  // mismatch. This is a single global constant, not per-dict state -- float
+  // always lowers to the same type, unlike list's type map which also has to
+  // distinguish string/int for its own flags.
+  const size_t float_type_id =
+    std::hash<std::string>{}(type_handler_.type_to_string(
+      type_handler_.get_typet(std::string("float"))));
+
+  // Call __ESBMC_dict_eq(lhs_keys, lhs_values, rhs_keys, rhs_values,
+  // float_type_id)
   code_function_callt dict_eq_call;
   dict_eq_call.function() = build_symbol(*dict_eq_func);
   dict_eq_call.lhs() = build_symbol(result_var);
@@ -41,6 +53,7 @@ exprt python_dict_handler::compare(
   dict_eq_call.arguments().push_back(lhs_values);
   dict_eq_call.arguments().push_back(rhs_keys);
   dict_eq_call.arguments().push_back(rhs_values);
+  dict_eq_call.arguments().push_back(from_integer(float_type_id, size_type()));
   dict_eq_call.type() = bool_type();
   dict_eq_call.location() = location;
   converter_.add_instruction(dict_eq_call);


### PR DESCRIPTION
## Summary
- `__ESBMC_dict_eq` compared dict values by raw `type_id` and bytes, so Python's numeric equality (`1 == 1.0`) was spuriously rejected whenever one dict's values were floats and the other's were ints (e.g. `{"a": 1.0} == {"a": 1}` wrongly gave `VERIFICATION FAILED`).
- Mirrors the int/float fallback already shipped for `__ESBMC_list_eq` in PR #5207 (humaneval_130): widen the int side to `double` and compare numerically when exactly one side is float-typed, instead of rejecting on a `type_id` mismatch.
- `float_type_id` is a single global constant computed by the frontend (`dict_compare.cpp`) — Python's `float` always lowers to the same type everywhere, so unlike `list_eq`'s per-list element-type map, no per-dict tracking is needed.
- Noted in #5444 ("int/float `__ESBMC_dict_eq`" gap) as one of several blockers for `quixbugs/shortest_paths` → CORE; this closes that specific sub-item. (The broader umbrella still has other open blockers — param tuple-key type recovery, mixed `min()` — tracked separately in #5444.)

## Test plan
- [x] New regression tests: `regression/python/dict_eq_int_float` (homogeneous all-float vs all-int dicts, a heterogeneous single dict mixing float/int values matching shortest_paths' actual pattern, and `!=` negation) and `dict_eq_int_float_fail` (a genuinely-different float value must still compare unequal)
- [x] Targeted regression sweep: dict1, dict13, dict65_1-4, dict_constructor_comprehension{,_fail}, dict_eq_none_list{,_fail}, dict_eq_runtime, humaneval_130 — all pass, no regressions
- [x] Verified with `esbmc-verifier`: rebuild confirmed (OM actually regenerated, not cached), both new test verdicts independently reproduced, gating condition confirmed to only fire on float/int 8-byte pairs (can't misfire on the None/nested-list branches earlier in the same chain)
- [x] Reviewed with `code-reviewer`: confirmed the `float_type_id` hash matches the stamp used when PyObjects are actually tagged as float elsewhere (`list_mutation.cpp`), and confirmed correctness on the heterogeneous-dict storage path (`dict_construction.cpp`'s `all_values_float` gate) empirically, not just by inspection. Applied both concrete findings (comment line wrapped to the 80-col limit; added the heterogeneous-dict test case). Skipped the two optional/non-blocking follow-ups it suggested (extracting a shared `__ESBMC_numeric_eq` helper between `list_eq`/`dict_eq`, and threading `float_type_id` into the nested `list_eq` call for dict-of-lists) since both are separate, pre-existing gaps outside this fix's scope.
