### PR TITLE
[python] V.3: build complex depth-guard promotion cast in IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3694,6 +3694,23 @@ pre-V.4:
 Both classes need the **V.1k/V.4 IREP2-native adjuster** (resolve-then-build),
 not site-by-site migration.
 
+**Correction (2026-07-01, PR #5727):** the "complex int→double promotion"
+item above was mis-scoped as F-P11 (resolved-source-blocked). The actual
+site — `complex_handler.cpp`'s `promote_int_arith_to_double` (the file moved;
+`numpy_call_expr.cpp:1607` is stale) — is a `depth > 64` defensive
+recursion-limit guard, not an operand-resolution wall. It had been left
+legacy by an earlier commit (#5260) on the belief that the branch was
+"ungateable" (no realistic input reaches it). That belief was checked and
+found false: a 65+-deep nested-arithmetic literal (e.g.
+`complex(((...((1+1)+1)...)+1), 2)`) is ordinary, parseable Python source
+that does reach it. Migrated to the file's own `complex_typecast` helper
+(matching the leaf case two lines below) with a dedicated regression test
+at that depth (`regression/python/complex_deep_int_promotion{,_fail}`).
+Verified byte-identical GOTO on the reproducer and 168/168 complex-number
+regression tests green. Lesson for future sessions: a "no test can exercise
+this" claim is itself a factual claim — verify it before accepting a site as
+permanently blocked.
+
 #### V.3 follow-up (2026-06-24) — truthiness/membership stragglers drained
 
 A re-census after the pass above found the "fully drained" claim was slightly

--- a/regression/python/complex_deep_int_promotion/main.py
+++ b/regression/python/complex_deep_int_promotion/main.py
@@ -1,0 +1,9 @@
+# Exercises complex_handler::promote_int_arith_to_double's depth>64
+# recursion-limit fallback: 65 nested `+` operators push the real-part
+# promotion past its defensive recursion guard.
+z = complex(
+    (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((1+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1),
+    2,
+)
+assert z.real == 66.0
+assert z.imag == 2.0

--- a/regression/python/complex_deep_int_promotion/main.py
+++ b/regression/python/complex_deep_int_promotion/main.py
@@ -1,8 +1,11 @@
 # Exercises complex_handler::promote_int_arith_to_double's depth>64
-# recursion-limit fallback: 65 nested `+` operators push the real-part
-# promotion past its defensive recursion guard.
+# recursion-limit fallback: 65 nested `+` operators (left-associative,
+# no parens needed) push the real-part promotion past its defensive
+# recursion guard.
 z = complex(
-    (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((1+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1),
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     2,
 )
 assert z.real == 66.0

--- a/regression/python/complex_deep_int_promotion/test.desc
+++ b/regression/python/complex_deep_int_promotion/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/complex_deep_int_promotion_fail/main.py
+++ b/regression/python/complex_deep_int_promotion_fail/main.py
@@ -1,0 +1,8 @@
+# Exercises complex_handler::promote_int_arith_to_double's depth>64
+# recursion-limit fallback: 65 nested `+` operators push the real-part
+# promotion past its defensive recursion guard.
+z = complex(
+    (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((1+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1),
+    2,
+)
+assert z.real == 0.0

--- a/regression/python/complex_deep_int_promotion_fail/main.py
+++ b/regression/python/complex_deep_int_promotion_fail/main.py
@@ -1,8 +1,11 @@
 # Exercises complex_handler::promote_int_arith_to_double's depth>64
-# recursion-limit fallback: 65 nested `+` operators push the real-part
-# promotion past its defensive recursion guard.
+# recursion-limit fallback: 65 nested `+` operators (left-associative,
+# no parens needed) push the real-part promotion past its defensive
+# recursion guard.
 z = complex(
-    (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((1+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1)+1),
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
+    1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     2,
 )
 assert z.real == 0.0

--- a/regression/python/complex_deep_int_promotion_fail/test.desc
+++ b/regression/python/complex_deep_int_promotion_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$

--- a/src/python-frontend/complex_handler.cpp
+++ b/src/python-frontend/complex_handler.cpp
@@ -221,7 +221,7 @@ exprt complex_handler::promote_int_arith_to_double(
   std::size_t depth) const
 {
   if (depth > 64)
-    return typecast_exprt(input_expr, cached_double_type());
+    return complex_typecast(input_expr, cached_double_type());
 
   if (input_expr.statement() == "cpp-throw")
     return input_expr;


### PR DESCRIPTION
## What

Completes the residue PR #5260 explicitly deferred. `complex_handler`'s
`promote_int_arith_to_double` (which rewrites integer arithmetic sub-trees
into IEEE-double arithmetic for complex-number code) has a `depth > 64`
recursion-limit guard whose fallback used raw `typecast_exprt`, while the
function's normal leaf case (two lines below) already used the migrated
`complex_typecast` helper. PR #5260's commit message explained why it left
this one site alone:

> The depth>64 recursion-limit fallback is left as legacy typecast_exprt --
> it is a defensive branch no regression test exercises, so migrating it
> would ship un-gateable construction.

That reasoning was sound *at the time*, but the branch turns out to be
gateable: it's reachable via an ordinary (if unusual) 65+-level nested
arithmetic expression, e.g. `complex(((...((1+1)+1)...)+1), 2)`. This PR:

- Routes the fallback through `complex_typecast`, matching the rest of the
  function.
- Adds `regression/python/complex_deep_int_promotion{,_fail}` — a 65-deep
  nested-addition literal that exercises exactly this branch, closing the
  coverage gap #5260 cited.

## Validation

- Confirmed (before touching the code) that `input_expr` at the `depth > 64`
  branch is always numeric by construction: every arithmetic exprt node the
  function recurses through is built by `build_binary_expression`
  (`converter_binop.cpp`), which unifies operand widths/types before
  constructing the node; string/list/tuple `+` are dispatched to entirely
  separate code paths before reaching this function.
- Byte-identical `--goto-functions-only` output before/after on inputs that
  actually reach the `depth > 64` branch (65-deep and 70-deep nested-add
  harnesses), confirmed via A/B rebuild.
- Full complex-number regression subset: 168/168 green (166 pre-existing +
  2 new).
- Dual-solver (Bitwuzla + Z3) agreement on the new tests and two existing
  complex/cmath tests.
- clang-format clean.

## Test plan

- [x] `ctest -R complex_deep_int_promotion`
- [x] `ctest -R complex` (168/168)
- [x] A/B GOTO diff on the depth>64 reproducer
- [x] dual-solver check