### PR TITLE
[python] V.3: build make_complex struct literal in IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3889,6 +3889,20 @@ except the numpy complex int→double site (`numpy_call_expr.cpp`, ieee +
 rounding mode) and the `isinstance`/`isnone` custom-node retain boundary
 above.
 
+**Follow-up (2026-07-01) — the numpy complex int→double site is now drained.**
+`make_complex` (`type_handler.h`), the shared builder behind every complex
+struct literal in the numpy/complex paths, built a `struct_exprt` over two
+legacy `typecast_exprt(x, double)` int/bool/float→double conversions (the ieee
+cast, rounding mode implicit). It is now `constant_struct2tc` over `typecast2tc`
+operands, back-migrated once — the same idiom as `complex_typecast` and the
+`complex_to_bool_expr` exemplar in the same header. Behaviour-preserving:
+`--goto-functions-only` output byte-identical (modulo pre-existing
+astgen-tempdir / unpack-temp non-determinism) across 9 representative
+numpy+python complex tests; 164 complex + 415/415 `regression/numpy` green. The
+only V.3 residual now is the `isinstance`/`isnone` custom-node retain boundary
+(needs a `migrate_expr` extension, out of scope), plus the V.1k keystone and
+what it unblocks (V.2/V.4/V.5/V.6).
+
 ### Phase V.4 — IREP2 structured CF + IREP2-aware `goto_convert` (removes W1)
 Add the missing structured CF code kinds to IREP2 (`code_ifthenelse2t`,
 `code_while2t`, `code_for2t`, `code_switch2t`, `code_break2t`,

--- a/src/python-frontend/type_handler.h
+++ b/src/python-frontend/type_handler.h
@@ -49,13 +49,23 @@ inline bool is_complex_type(const typet &type)
 
 inline exprt make_complex(const exprt &real, const exprt &imag)
 {
-  struct_exprt complex_expr(get_complex_struct_type());
+  // V.3: build the complex struct literal in IREP2, back-migrating once. Each
+  // non-double operand's int/bool/float -> double conversion is exactly the
+  // typecast2t migrate_expr builds for the legacy typecast_exprt (ieee cast,
+  // rounding mode implicit), so the back-migrated struct is byte-identical to
+  // the old struct_exprt. Mirrors complex_typecast / complex_to_bool_expr.
   const typet &dt = cached_double_type();
-  complex_expr.operands().push_back(
-    real.type() == dt ? real : typecast_exprt(real, dt));
-  complex_expr.operands().push_back(
-    imag.type() == dt ? imag : typecast_exprt(imag, dt));
-  return complex_expr;
+  const type2tc dt2 = migrate_type(dt);
+
+  auto to_double2 = [&](const exprt &v) -> expr2tc {
+    expr2tc v2;
+    migrate_expr(v, v2);
+    return v.type() == dt ? v2 : typecast2tc(dt2, v2);
+  };
+
+  std::vector<expr2tc> members{to_double2(real), to_double2(imag)};
+  return migrate_expr_back(
+    constant_struct2tc(migrate_type(get_complex_struct_type()), members));
 }
 
 inline exprt promote_to_complex(const exprt &value)


### PR DESCRIPTION
Migrates `make_complex` (`type_handler.h`) — the last documented V.3 residual in the numpy complex path — to build its struct literal in IREP2. It previously built a `struct_exprt` over two legacy `typecast_exprt(x, double)` int/bool/float→double conversions (the ieee cast, rounding mode implicit); it now builds `constant_struct2tc` over `typecast2tc` operands, back-migrated once, mirroring the `complex_typecast` / `complex_to_bool_expr` idiom already in the same header.

Behaviour-preserving: `--goto-functions-only` output is byte-identical (modulo pre-existing astgen-tempdir / unpack-temp non-determinism) across 9 representative numpy+python complex tests; 164 complex + 415/415 `regression/numpy` regression tests pass.

Refs #4715.