### PR TITLE
[docs] SV-COMP triage Pass 12+13: consolidate parallel Pass-11 merges; verify #4427 fixed by #4484

### DIFF
--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -5,8 +5,11 @@ appended a `## 15` section, colliding the heading and the `Last updated` banner:
 stranded `github_1470_overflow_witness` tests + reconcile the #1470/#1471/#4611 witness closures and the
 #5666 scanf fix already on master) stays **§15**; **#5735** (#5565 CLOSED by #5650; #5530 retired the
 compile-time `ESBMC_SVCOMP` macro for the runtime `--sv-comp` flag; aws-hash scouting) is renumbered to
-**§16**. Canonical remaining-work list and next task (#4427) live in §15.1/§15.2. See §16. Pass 11 in
-§15, Pass 10 in §14, Pass 9 in §13, Pass 8 in §12, Pass 7 in §11)
+**§16**. Canonical remaining-work list lives in §15.1. **Pass 13 (§17)** then executed the §15.2 next task:
+re-ran #4427's exact reproducer on current master and confirmed the `megaraid_mm.ko` false-negative
+**no longer reproduces — #4484's fn-ptr inductive-step guard fixed it** (sound `UNKNOWN`/timeout, no
+unsound TRUE); recommend closing after an x86 CI cross-check. See §16/§17. Pass 11 in §15, Pass 10 in
+§14, Pass 9 in §13, Pass 8 in §12, Pass 7 in §11)
 **Scope:** every open issue carrying the `SV-COMP` label in `esbmc/esbmc`, plus recently-closed
 SV-COMP issues for context and de-duplication.
 **Reference binary:** `build/src/esbmc/esbmc`, ESBMC 8.3.0. Pass 8 on an **x86_64 Linux** host with
@@ -1556,3 +1559,68 @@ concern (GraphML violation path in `goto_trace.cpp:302-362` lacks the system-hea
 symbol dedup the YAML path has at `witnesses.cpp:1292-1308`) is not a live issue and any change to it is
 soundness-gated on a witness validator (CPAchecker/Ultimate) absent here. So item 8 offers no
 loop-scoped verifiable fix either — confirming #4427 as the correct next task over it.
+
+---
+
+## 17. Pass 13 — #4427 megaraid_mm.ko false-negative no longer reproduces (fixed by #4484) (2026-07-01)
+
+Executed the next task selected in §15.2: fetched the benchmark and re-ran #4427's exact reproducer on
+current master. **Result: the false-negative soundness bug does not reproduce — #4484 fixed it.**
+Confirmed on an aarch64/macOS host; an x86 CI cross-check is still advisable before closing (this
+document's standing recommendation for #4427).
+
+**What was run.** Fetched
+`c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-43_2a-drivers--scsi--megaraid--megaraid_mm.ko-entry_point.cil.out.i`
+(5371 lines, read-only from the sv-benchmarks GitLab raw endpoint; contains the `ERROR` label; no
+`__regparm__` to strip on this host) and ran the issue's **exact** underlying ESBMC command
+(`--k-induction --max-inductive-step 3 --k-step 2 --unlimited-k-steps --error-label ERROR
+--enable-unreachability-intrinsic --interval-analysis --floatbv --64 …`) against the local ESBMC 8.3.0
+binary built from a master that includes **#4484** (commit `b49db0942d`,
+`[k-induction] deep-dive batch: … pointer handling …`).
+
+**Root cause of the original false negative (now closed).** The megaraid ioctl path dispatches through
+function pointers (`*adp->issue_uioc`; the issue's own log shows `No target candidate for function call
+*adp->issue_uioc`). On ESBMC 8.2.0 the k-induction **inductive step ran on this fn-ptr program and
+unsoundly concluded `VERIFICATION SUCCESSFUL`** (the reported false negative; ground truth `false`).
+The current binary emits, at `k = 1`:
+
+```
+WARNING: k-induction does not support function pointer calls yet. Disabling inductive step
+```
+
+— i.e. **#4484 detects the function-pointer calls and disables the (unsound-for-fn-ptr) inductive
+step**, removing the path that produced the spurious TRUE.
+
+**Observed behaviour on current master.** With the inductive step disabled, k-induction reduces to
+base-case falsification + forward-condition proof:
+* **Base case** finds *no* bug through `k = 17` (`No bug has been found in the base case` at each step) —
+  sound; the real violation needs deeper unwinding than the run reached.
+* **Forward condition** never proves the property (`The forward condition is unable to prove the
+  property`) because the driver's loops are not fully unwound at these depths.
+* Neither converging, the run **escalates and times out at 280 s** (no `VERIFICATION SUCCESSFUL`
+  anywhere in 4533 log lines) = **sound `UNKNOWN`**, not the previous unsound TRUE.
+
+**Disposition.** #4427's soundness bug (false negative) is **fixed by #4484** — the unsound
+`VERIFICATION SUCCESSFUL` no longer occurs; the tool now safely fails to conclude rather than reporting
+an incorrect TRUE. This confirms the Pass-6 "fixed-on-master by #4484" hypothesis with a concrete local
+run. **Recommend closing #4427 after an x86_64 CI cross-check** (host parity with the original SV-COMP
+26 run). A residual, lower-priority follow-up: the benchmark now yields `UNKNOWN` (timeout) rather than
+the ground-truth `false` — obtaining the actual counterexample would need deeper base-case unwinding or
+a targeted falsification run, but that is a *precision/perf* item, not the *soundness* bug the issue
+filed.
+
+### 17.1 Pass-13 running report
+
+**Analysed.** #4427 — exact-command re-run on current master; root-caused the original false negative to
+the pre-#4484 inductive step running on function-pointer dispatch, and confirmed #4484's fn-ptr guard
+(`Disabling inductive step`) removes the unsound TRUE.
+
+**PRs opened.** This entry extends the Pass-12 consolidation PR (#5739) rather than opening a third
+doc PR against a master that still carries the pre-consolidation `## 15` collision — and, per the
+stranded-PR lesson recorded in §15, is based directly on `master`, not stacked on a branch that could be
+closed unmerged.
+
+**Remaining work.** §15.1 list, with #4427 moved from "selected next task" to **recommend-close pending
+x86 CI**. No remaining item is loop-scoped without infra (x86 host + SV-benchmarks + witness validator):
+the rest are research-grade (#5145 k≥2, #5012, #5400/#5138), overlap in-flight PRs (#4980/#4919), or
+x86-host-gated (#4432, #5142 no-overflow layer, the LDV clusters).

--- a/docs/svcomp-issue-triage.md
+++ b/docs/svcomp-issue-triage.md
@@ -1,15 +1,12 @@
 # SV-COMP Issue Triage & Fix Plan
 
-**Last updated:** 2026-07-01 (Pass 11 — recover regression tests stranded on an orphaned branch and
-reconcile three witness-issue closures (#1470, #1471, #4611) plus the scanf overflow-check fix (#5666)
-that had already landed on master undocumented; see §15. Pass 10 in §14, Pass 9 in §13, Pass 8 in §12,
-Pass 7 in §11)
-**Last updated:** 2026-07-01 (Pass 11 — reconcile the two merged PRs that closed the #5565 residual
-after Pass 9: **#5650** (`fclose` frees only heap streams ⇒ `fclose(stdout)` sound) closed item-8's
-`fclose(stdout)` half and **CLOSED #5565**; **#5530** replaced the compile-time `ESBMC_SVCOMP` build
-macro with the runtime `--sv-comp` flag, obsoleting the `-DESBMC_SVCOMP=On` reproduction recipe; no
-new SV-COMP issues since Pass 9; remaining-work list re-based; see §15. Pass 10 in §14, Pass 9 in §13,
-Pass 8 in §12, Pass 7 in §11)
+**Last updated:** 2026-07-01 (Pass 12 — consolidate two Pass-11 PRs that merged in parallel and both
+appended a `## 15` section, colliding the heading and the `Last updated` banner: **#5730** (recover the
+stranded `github_1470_overflow_witness` tests + reconcile the #1470/#1471/#4611 witness closures and the
+#5666 scanf fix already on master) stays **§15**; **#5735** (#5565 CLOSED by #5650; #5530 retired the
+compile-time `ESBMC_SVCOMP` macro for the runtime `--sv-comp` flag; aws-hash scouting) is renumbered to
+**§16**. Canonical remaining-work list and next task (#4427) live in §15.1/§15.2. See §16. Pass 11 in
+§15, Pass 10 in §14, Pass 9 in §13, Pass 8 in §12, Pass 7 in §11)
 **Scope:** every open issue carrying the `SV-COMP` label in `esbmc/esbmc`, plus recently-closed
 SV-COMP issues for context and de-duplication.
 **Reference binary:** `build/src/esbmc/esbmc`, ESBMC 8.3.0. Pass 8 on an **x86_64 Linux** host with
@@ -1438,17 +1435,22 @@ methodology), run the issue's exact wrapper/ESBMC invocation, and either close t
 resolved it, matching the ground truth `false` now correctly detected) or re-open the RCA (if it still
 reports the unsound `true`, in which case this is a live soundness bug and the highest-severity item in
 the backlog).
-## 15. Pass 11 — reconcile #5565 closure (#5650) + `ESBMC_SVCOMP`→`--sv-comp` migration (#5530) (2026-07-01)
+## 16. Pass 12 — consolidate the two parallel Pass-11 merges (#5730 + #5735); carry the #5565/#5530 reconciliation (2026-07-01)
 
-Pass 9 (2026-06-26, §13) shipped the `getopt_long`/`optarg` fix for #5565 and left item 8 of its
-remaining-work list open: the `ESBMC_SVCOMP`-gated `fclose(stdout)` static-stream free plus the
-`strcmp` argv-string pointer-validity residual. Two PRs merged **after** Pass 9's binary was cut, and
-Pass 10 (2026-07-01, §14) was scoped to the #5142 parse layer only, so neither reconciled them. This
-pass records both, closes item 8, and re-bases the remaining-work list. Verdicts here are **repro**
-against master `91f4acd2b8` (the Pass-10 tip) plus direct GitHub-state inspection; no new code — every
-still-open item remains the research-grade / host-blocked / in-flight class documented in §13.
+**Process finding.** Two independent Pass-11 PRs landed on `master` within minutes of each other and
+both appended a `## 15. Pass 11` section plus a second `**Last updated:**` banner: #5730 (§15 —
+orphaned-branch recovery + witness closures) and #5735 (this block — the #5565/#5530 reconciliation). The
+parallel merge left the document with a duplicate `## 15` heading, duplicate `### 15.1/15.2/15.3`
+subsection numbers, and two banners. This Pass-12 pass repairs the structure: #5730's section keeps
+**§15** (it also owns the canonical, more-current remaining-work list at §15.1 and the selected next
+task #4427 at §15.2); the #5735 content below is renumbered to **§16** and its subsections to 16.x. No
+content is dropped — the #5565/#5530 findings are still accurate and complementary to §15. The one
+reconciliation between the two: §16.3's remaining-work list is **superseded by §15.1** (which adds #4427
+at the top and #4438/#1492/#1447/#1440); it is kept here only as the record of what #5735 saw.
 
-### 15.1 #5565 residual — CLOSED by #5650; `strcmp` half resolved upstream of it
+The #5565/#5530 reconciliation carried forward from PR #5735 follows.
+
+### 16.1 #5565 residual — CLOSED by #5650; `strcmp` half resolved upstream of it
 
 * **`fclose(stdout)` static-stream free — FIXED.** Merged **PR #5650** (`[om] fclose: free only heap
   streams so fclose(stdout) is sound`, 2026-06-27) guards the `free(stream)` in ESBMC's `fclose`
@@ -1467,7 +1469,7 @@ still-open item remains the research-grade / host-blocked / in-flight class docu
 * **Issue state.** **#5565 is CLOSED.** Its two-layer residual is fully discharged (`fclose` by #5650,
   `strcmp` by the Pass-9 `getopt_long` OM). No further ESBMC-side work is owed on #5565.
 
-### 15.2 `ESBMC_SVCOMP` build macro retired → runtime `--sv-comp` flag (#5530)
+### 16.2 `ESBMC_SVCOMP` build macro retired → runtime `--sv-comp` flag (#5530)
 
 Merged **PR #5530** (`[svcomp] Replace ESBMC_SVCOMP build macro with runtime --sv-comp flag`,
 2026-06-25) removed the compile-time `-DESBMC_SVCOMP=On` CMake option that baked `__ESBMC_SVCOMP` into
@@ -1477,10 +1479,10 @@ OMs (`__ESBMC_sv_comp()`). **Consequence for this document:** every reproduction
 gating note) is obsolete — the SV-COMP-mode OM behaviour is now selected per-run with the `--sv-comp`
 flag on a stock binary, no dedicated build required. Those historical pass sections are left intact as
 the record of how the run was done at the time; the corrected instruction is: **reproduce
-`--sv-comp`-gated OM behaviour by passing `--sv-comp` at run time.** #5138 (§15.3 item 2) is the one
+`--sv-comp`-gated OM behaviour by passing `--sv-comp` at run time.** #5138 (§16.3 item 2) is the one
 open issue whose reproduction recipe this simplifies.
 
-### 15.3 Pass-11 running report
+### 16.3 Pass-11 running report (PR #5735)
 
 **Analysed.** #5565 (now CLOSED — #5650 + Pass-9 `getopt_long`) reconciled against current GitHub
 state; the #5530 `ESBMC_SVCOMP`→`--sv-comp` migration and its effect on every "`ESBMC_SVCOMP`-build"
@@ -1495,8 +1497,11 @@ pass is the recurring triage-doc update (established cadence: Pass 4 → #5234, 
 **Duplicated work avoided.** #5565 not re-fixed — CLOSED by #5650 (`fclose`) + the Pass-9 `getopt_long`
 OM (`strcmp`). No re-proposal of a compile-time SV-COMP build — retired by #5530.
 
-**Remaining work (priority order, updated 2026-07-01).** Item 8 (#5565 residual) is dropped — closed.
-The rest is unchanged from §13.3, with #5138's recipe simplified to the runtime `--sv-comp` flag:
+**Remaining work — SUPERSEDED by §15.1.** The list below is what PR #5735 saw; the canonical,
+more-current priority list is **§15.1** (from the sibling Pass-11 PR #5730), which adds #4427 at the top
+plus #4438 and the validation-only items #1492/#1447/#1440. Item 8 here (#5565 residual) is dropped —
+closed. Retained verbatim as the #5735 record, with #5138's recipe simplified to the runtime `--sv-comp`
+flag:
 1. **#5145 / #5393 / #5394** — aws-hash byte-addressed pointer-read-consistency: the general mechanism
    is RCA-closed as **#5369** (fresh, non-deduplicated pointer identity minted per read through an
    unresolvable/byte-reconstructed pointer, in `make_failed_symbol` and `convert_typecast_to_ptr`); a
@@ -1512,7 +1517,7 @@ The rest is unchanged from §13.3, with #5138's recipe simplified to the runtime
 7. **Device-API / LDV-environment model** (`platform_get_drvdata` etc.) — shared #5396–#5399 blocker.
 8. **Close-outs pending CI:** #1470, #4427; witness end-to-end validation for #1471/#1492/#4611.
 
-### 15.4 Next-task scouting — #5145 / #5393 / #5394 (aws-hash) is research-grade, no loop-scoped fix
+### 16.4 Next-task scouting — #5145 / #5393 / #5394 (aws-hash) is research-grade, no loop-scoped fix
 
 Scouted the top remaining-work item to confirm whether a sound localized fix is available before the
 next coding pass commits to it. **Conclusion: not loop-scoped — the tractable half is already shipped
@@ -1540,7 +1545,14 @@ and the open half is research-grade.** Evidence:
   records SV-COMP repro was done on x86_64 Linux — the k≥2 divergence is not reproducible in isolation
   on the aarch64/macOS host available to this pass, so even a candidate fix could not be validated here.
 
-**Disposition.** #5145/#5393/#5394 stays item 1, flagged **research-grade (k≥2 SMT re-versioning)** —
-the same "reproduced, sound over-approximation, no localized fix" class as the LDV-environment cluster.
-The next loop-scoped candidate to scout is item 8 (witness end-to-end validation / close-outs), pending
-a witness-validator tool in the environment.
+**Disposition.** #5145/#5393/#5394 stays flagged **research-grade (k≥2 SMT re-versioning)** — the same
+"reproduced, sound over-approximation, no localized fix" class as the LDV-environment cluster. It is #5735's
+item 1; in the reconciled §15.1 list it is item 2, behind **#4427** (the selected next task, §15.2 —
+a bounded fetch-and-run, not a design effort).
+
+**Item-8 witness scouting (this Pass-12 pass).** Also scouted #5735's item-8 (witness) before adopting
+#4427: #1470/#1471/#4611 are all **CLOSED** (reconciled by §15), so the residual witness *quality*
+concern (GraphML violation path in `goto_trace.cpp:302-362` lacks the system-header file-path filter and
+symbol dedup the YAML path has at `witnesses.cpp:1292-1308`) is not a live issue and any change to it is
+soundness-gated on a witness validator (CPAchecker/Ultimate) absent here. So item 8 offers no
+loop-scoped verifiable fix either — confirming #4427 as the correct next task over it.


### PR DESCRIPTION
## What

Pass 12 of the SV-COMP issue-triage running report — a **structural consolidation** of the two Pass-11 PRs that merged in parallel today (#5730 and #5735).

Both PRs independently appended a `## 15. Pass 11` section and a `**Last updated:**` banner to `docs/svcomp-issue-triage.md`. Merging both left `master` with:
- a **duplicate `## 15. Pass 11` H2 heading**,
- **duplicated `### 15.1 / 15.2 / 15.3` subsection numbers**, and
- **two `**Last updated:**` banners**.

This pass repairs the document:
- Merges the two banners into one Pass-12 banner that records the collision and its resolution.
- Keeps **#5730's section as the canonical §15** — it owns the more-current remaining-work list (§15.1) and the selected next task **#4427** (§15.2).
- Renumbers **#5735's block to §16**, subsections `16.1–16.4`, and marks its remaining-work list as **superseded by §15.1** (kept verbatim as the record of what #5735 saw).
- Fixes the internal cross-references (`§15.3`/`§15.2` → `§16.3`/`§16.2`).
- Folds in this pass's item-8 (witness) scouting: #1470/#1471/#4611 are all **CLOSED**, and the residual witness-quality asymmetry (GraphML violation path in `goto_trace.cpp:302-362` lacks the system-header filter and symbol dedup the YAML path has at `witnesses.cpp:1292-1308`) is soundness-gated on a witness validator absent here — confirming **#4427** as the correct next task.

## Why

Two parallel merges of the same running-report file produced a malformed section structure (duplicate headings and banners). Left as-is, the duplicate numbering makes the doc's cross-references ambiguous. No triage content is dropped; the two Pass-11 contributions are preserved and given non-colliding section numbers, with a single canonical remaining-work list.

Docs-only; no code change.
