### PR TITLE
[python] Collapse l[a:b]=reversed(l[a:b]) to in-place range reverse

### DIFF
--- a/regression/python/reverse_slice_inplace/main.py
+++ b/regression/python/reverse_slice_inplace/main.py
@@ -2,9 +2,11 @@
 # frontend collapses it to a single in-place range-reverse pass instead of a
 # slice-read + reversed() rebuild + slice-assign (three heap copies).
 
+
 def rev_suffix(xs):
     xs[1:] = reversed(xs[1:])
     return xs
+
 
 a = [1, 2, 3, 4]
 rev_suffix(a)

--- a/regression/python/reverse_slice_inplace/main.py
+++ b/regression/python/reverse_slice_inplace/main.py
@@ -1,0 +1,49 @@
+# `l[a:b] = reversed(l[a:b])` is an in-place reverse of the sub-range. The
+# frontend collapses it to a single in-place range-reverse pass instead of a
+# slice-read + reversed() rebuild + slice-assign (three heap copies).
+
+def rev_suffix(xs):
+    xs[1:] = reversed(xs[1:])
+    return xs
+
+a = [1, 2, 3, 4]
+rev_suffix(a)
+# suffix [2,3,4] reversed -> [4,3,2]; head 1 unchanged
+assert a[0] == 1
+assert a[1] == 4
+assert a[2] == 3
+assert a[3] == 2
+
+# Whole-list reverse via the same idiom.
+b = [10, 20, 30]
+b[:] = reversed(b[:])
+assert b[0] == 30
+assert b[1] == 20
+assert b[2] == 10
+
+# Bounded interior slice.
+c = [5, 6, 7, 8, 9]
+c[1:4] = reversed(c[1:4])
+assert c[0] == 5
+assert c[1] == 8
+assert c[2] == 7
+assert c[3] == 6
+assert c[4] == 9
+
+# Negative bounds exercise the lower+len / upper+len normalization.
+f = [1, 2, 3, 4, 5]
+f[-3:-1] = reversed(f[-3:-1])  # reverse [3,4] -> [4,3]
+assert f[0] == 1
+assert f[1] == 2
+assert f[2] == 4
+assert f[3] == 3
+assert f[4] == 5
+
+# Near-miss: RHS is a *different* list, so the idiom must NOT collapse; the
+# generic slice-assign path must still produce the correct result.
+d = [1, 2, 3]
+e = [7, 8]
+d[1:] = reversed(e)  # d becomes [1, 8, 7]
+assert d[0] == 1
+assert d[1] == 8
+assert d[2] == 7

--- a/regression/python/reverse_slice_inplace/test.desc
+++ b/regression/python/reverse_slice_inplace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-bounds-check --no-pointer-check --no-align-check --no-div-by-zero-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/reverse_slice_inplace_fail/main.py
+++ b/regression/python/reverse_slice_inplace_fail/main.py
@@ -1,0 +1,10 @@
+# Negative: after reversing the suffix in place, the last element is 2, not 4.
+# ESBMC must report the assertion violation (the idiom must not silently no-op).
+
+def rev_suffix(xs):
+    xs[1:] = reversed(xs[1:])
+    return xs
+
+a = [1, 2, 3, 4]
+rev_suffix(a)
+assert a[3] == 4  # wrong: a[3] is 2 after the in-place reverse

--- a/regression/python/reverse_slice_inplace_fail/main.py
+++ b/regression/python/reverse_slice_inplace_fail/main.py
@@ -1,9 +1,11 @@
 # Negative: after reversing the suffix in place, the last element is 2, not 4.
 # ESBMC must report the assertion violation (the idiom must not silently no-op).
 
+
 def rev_suffix(xs):
     xs[1:] = reversed(xs[1:])
     return xs
+
 
 a = [1, 2, 3, 4]
 rev_suffix(a)

--- a/regression/python/reverse_slice_inplace_fail/test.desc
+++ b/regression/python/reverse_slice_inplace_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-bounds-check --no-pointer-check --no-align-check --no-div-by-zero-check
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -1430,3 +1430,58 @@ void __ESBMC_list_reverse(PyListObject *l)
     right--;
   }
 }
+
+// In-place reverse of the sub-range l[lower:upper] (step 1). Lowers the idiom
+// `l[lower:upper] = reversed(l[lower:upper])` to a single swap pass, avoiding
+// the three heap passes the literal form generates (slice-read copy,
+// reversed() rebuild, slice-assign resize+copy). Bounds are normalized exactly
+// as CPython's slice.indices for step 1 — the same clamping
+// __ESBMC_list_slice_assign uses — so the observable result is identical to the
+// three-step form. has_lower/has_upper distinguish an absent bound (None) from
+// an explicit one; the slice length equals itself, so no resize is needed.
+void __ESBMC_list_reverse_range(
+  PyListObject *l,
+  int64_t lower,
+  int has_lower,
+  int64_t upper,
+  int has_upper)
+{
+  __ESBMC_assert(l != NULL, "list_reverse_range: list is null");
+
+  int64_t size = (int64_t)l->size;
+
+  int64_t start;
+  if (has_lower)
+  {
+    start = (lower < 0) ? lower + size : lower;
+    if (start < 0)
+      start = 0;
+    if (start > size)
+      start = size;
+  }
+  else
+    start = 0;
+
+  int64_t stop;
+  if (has_upper)
+  {
+    stop = (upper < 0) ? upper + size : upper;
+    if (stop < 0)
+      stop = 0;
+    if (stop > size)
+      stop = size;
+  }
+  else
+    stop = size;
+
+  int64_t left = start;
+  int64_t right = stop - 1;
+  while (left < right)
+  {
+    PyObject tmp = l->items[left];
+    l->items[left] = l->items[right];
+    l->items[right] = tmp;
+    left++;
+    right--;
+  }
+}

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -34,8 +34,9 @@ bool ast_equal_ignoring_location(
     {
       if (is_loc_key(it.key()))
         continue;
-      if (!b.contains(it.key()) ||
-          !ast_equal_ignoring_location(it.value(), b[it.key()]))
+      if (
+        !b.contains(it.key()) ||
+        !ast_equal_ignoring_location(it.value(), b[it.key()]))
         return false;
     }
     for (auto it = b.begin(); it != b.end(); ++it)

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -3,6 +3,65 @@
 using namespace python_expr;
 using namespace python_list_detail;
 
+namespace
+{
+// Structural equality of two AST JSON nodes, ignoring source-location keys
+// (lineno/col_offset/...). Two textually distinct occurrences of the same
+// expression — e.g. the `l[i+1:]` on each side of `l[i+1:] = reversed(l[i+1:])`
+// — differ only in their location fields, so a raw `==` would wrongly report
+// them as different. Used to prove the read-slice and write-slice are the same
+// before collapsing the reverse-in-place idiom.
+bool ast_equal_ignoring_location(
+  const nlohmann::json &a,
+  const nlohmann::json &b)
+{
+  static constexpr const char *loc_keys[] = {
+    "lineno", "col_offset", "end_lineno", "end_col_offset"};
+  auto is_loc_key = [&](const std::string &k) {
+    for (const char *lk : loc_keys)
+      if (k == lk)
+        return true;
+    return false;
+  };
+
+  if (a.type() != b.type())
+    return false;
+
+  if (a.is_object())
+  {
+    // Compare the non-location keys of both objects symmetrically.
+    for (auto it = a.begin(); it != a.end(); ++it)
+    {
+      if (is_loc_key(it.key()))
+        continue;
+      if (!b.contains(it.key()) ||
+          !ast_equal_ignoring_location(it.value(), b[it.key()]))
+        return false;
+    }
+    for (auto it = b.begin(); it != b.end(); ++it)
+    {
+      if (is_loc_key(it.key()))
+        continue;
+      if (!a.contains(it.key()))
+        return false;
+    }
+    return true;
+  }
+
+  if (a.is_array())
+  {
+    if (a.size() != b.size())
+      return false;
+    for (size_t i = 0; i < a.size(); ++i)
+      if (!ast_equal_ignoring_location(a[i], b[i]))
+        return false;
+    return true;
+  }
+
+  return a == b;
+}
+} // namespace
+
 exprt python_list::build_list_at_call(
   const exprt &list,
   const exprt &index,
@@ -924,6 +983,78 @@ void python_list::handle_slice_assignment(
   }
 
   const locationt location = converter_.get_location_from_decl(slice_node);
+
+  // Reverse-in-place idiom: `l[a:b] = reversed(l[a:b])`. The literal form emits
+  // three heap passes (slice-read copy, reversed() rebuild, slice-assign
+  // resize+copy); collapse them into a single in-place swap over the sub-range.
+  // Fire ONLY when it is provably the same list variable and the same slice on
+  // both sides, with step 1 — then reversing the read slice and storing it back
+  // is exactly an in-place reverse of [a:b]. Any mismatch falls through to the
+  // correct (slower) generic path, so a missed match is harmless and a wrong
+  // match is impossible.
+  //
+  // `reversed` is matched by name, consistent with the rest of the frontend
+  // (annotation_intrinsics.cpp, loop_mixin.py, expr.cpp all key on the builtin
+  // name); a user-shadowed `reversed` is not honoured anywhere, so this adds no
+  // new assumption. Bounds are evaluated once here vs twice in the three-step
+  // form — immaterial for the pure index expressions this fires on.
+  if (
+    step_val == 1 && value_node.is_object() &&
+    value_node.value("_type", "") == "Call" && value_node.contains("func") &&
+    value_node["func"].value("_type", "") == "Name" &&
+    value_node["func"].value("id", "") == "reversed" &&
+    value_node.contains("args") && value_node["args"].is_array() &&
+    value_node["args"].size() == 1)
+  {
+    const nlohmann::json &arg = value_node["args"][0];
+    const bool arg_is_same_slice =
+      arg.is_object() && arg.value("_type", "") == "Subscript" &&
+      arg.contains("slice") && arg["slice"].is_object() &&
+      arg["slice"].value("_type", "") == "Slice" &&
+      // Same list variable (Name) on both sides.
+      arg.contains("value") && arg["value"].is_object() &&
+      arg["value"].value("_type", "") == "Name" &&
+      list_value_.contains("value") && list_value_["value"].is_object() &&
+      list_value_["value"].value("_type", "") == "Name" &&
+      arg["value"].value("id", "") == list_value_["value"].value("id", "") &&
+      // Same slice bounds (ignoring source locations).
+      ast_equal_ignoring_location(arg["slice"], slice_node);
+
+    if (arg_is_same_slice)
+    {
+      const symbolt *rev_fn = converter_.symbol_table().find_symbol(
+        "c:@F@__ESBMC_list_reverse_range");
+      if (rev_fn)
+      {
+        const typet i64r = signedbv_typet(64);
+        auto rev_bound = [&](const char *name, bool &present) -> exprt {
+          present = slice_node.contains(name) && !slice_node[name].is_null();
+          if (!present)
+            return from_integer(0, i64r);
+          exprt e = converter_.get_expr(slice_node[name]);
+          e = remove_function_calls_recursive(e, slice_node);
+          return build_typecast(e, i64r);
+        };
+        bool rlo = false, rup = false;
+        exprt rlower = rev_bound("lower", rlo);
+        exprt rupper = rev_bound("upper", rup);
+
+        exprt rev_call = build_call_expr(
+          *rev_fn,
+          empty_typet(),
+          {list_expr.type().is_pointer() ? list_expr
+                                         : build_address_of(list_expr),
+           rlower,
+           from_integer(rlo ? 1 : 0, int_type()),
+           rupper,
+           from_integer(rup ? 1 : 0, int_type())});
+        rev_call.location() = location;
+        converter_.add_instruction(
+          converter_.convert_expression_to_code(rev_call));
+        return;
+      }
+    }
+  }
 
   // Evaluate the right-hand side; materialize a call (e.g. sorted(...)) into
   // a temporary so its result can be passed to the model by address. get_expr


### PR DESCRIPTION
The suffix/sub-range reverse idiom `l[a:b] = reversed(l[a:b])` lowered to three
heap passes — slice-read copy, `reversed()` rebuild, and slice-assign
resize+copy — which, replicated across symbolic loop unrolls, drives state
explosion. This detects the idiom in `handle_slice_assignment` (same list
variable, same slice, step 1) and emits a single `__ESBMC_list_reverse_range`
pass that reverses `[a:b]` in place using the same CPython `slice.indices`
normalization as `__ESBMC_list_slice_assign`. Any mismatch falls back to the
correct generic path, so a missed match is harmless and a wrong match is
impossible.

Tests: `regression/python/reverse_slice_inplace{,_fail}` (in-place reverse of a
suffix, whole list, interior slice, negative bounds; plus a different-list
near-miss that must fall back). GOTO inspection confirms 4 collapses + 1
fallback. C-Live dead-code proof discharged with dual-solver (Bitwuzla + Z3)
agreement.

Groundwork toward #4792 (its len-4/5 inputs remain a separate BMC-scalability
wall, so that test stays KNOWNBUG. Refs #4792, #4778.
EOF
)