### PR TITLE
[python] V.3: build partition tuple value in IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3903,6 +3903,21 @@ only V.3 residual now is the `isinstance`/`isnone` custom-node retain boundary
 (needs a `migrate_expr` extension, out of scope), plus the V.1k keystone and
 what it unblocks (V.2/V.4/V.5/V.6).
 
+**Follow-up (2026-07-02) — the tuple-struct literal drain, now including the
+string-partition site.** The `struct_exprt` tuple-value construction was drained
+across the tuple family with one shared idiom (`constant_struct2tc` over migrated
+operands, back-migrated once, then the full `struct_typet` re-attached so the
+frontend-only `#python_aggregate_kind` marker — dropped by `migrate_type` and
+read by the `in`/membership/subscript dispatch with no tag-based fallback — is
+preserved): `tuple_handler::get_tuple_expr` (#5738), `handle_tuple_subscript`'s
+slice sub-tuple (#5740), and now `string_handler::build_partition_tuple`'s
+`make_tuple3` (the 3-tuple result of `str.partition()`/`str.rpartition()`). The
+last mirrors the first two exactly. Behaviour-preserving: `--goto-functions-only`
+byte-identical across all 11 partition/rpartition tests; 605/605 matched
+string/tuple/partition tests green. The membership path is not visible in the goto diff (the
+marker is read during conversion), so the type re-attach is load-bearing and
+the full suite is the real gate — the #5738 first cut proved this.
+
 ### Phase V.4 — IREP2 structured CF + IREP2-aware `goto_convert` (removes W1)
 Add the missing structured CF code kinds to IREP2 (`code_ifthenelse2t`,
 `code_while2t`, `code_for2t`, `code_switch2t`, `code_break2t`,

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -3061,8 +3061,21 @@ exprt string_handler::build_partition_tuple(
     tuple_type.tag(tag);
     set_python_aggregate_kind(tuple_type, "tuple");
 
-    struct_exprt tuple_expr(tuple_type);
-    tuple_expr.operands() = {a, b, c};
+    // V.3: build the tuple struct value in IREP2, back-migrating once, then
+    // restore the full type -- migrate_type drops the frontend-only
+    // aggregate-kind marker read by the `in`/membership/subscript dispatch
+    // (see tuple_handler::get_tuple_expr).
+    std::vector<expr2tc> members;
+    members.reserve(elems.size());
+    for (const exprt *e : elems)
+    {
+      expr2tc m2;
+      migrate_expr(*e, m2);
+      members.push_back(std::move(m2));
+    }
+    exprt tuple_expr =
+      migrate_expr_back(constant_struct2tc(migrate_type(tuple_type), members));
+    tuple_expr.type() = tuple_type;
     tuple_expr.location() = location;
     return tuple_expr;
   };


### PR DESCRIPTION
## What

Migrates the last legacy `struct_exprt` tuple-value construction in the
Python frontend to IREP2. `string_handler::build_partition_tuple`'s
`make_tuple3` lambda built the 3-tuple `(before, sep, after)` result of
`str.partition()` / `str.rpartition()` as a legacy `struct_exprt`. It now
builds the value via `constant_struct2tc` over the migrated element
operands and back-migrates once, then **restores the full struct type**.

## Why

Part of Part V Phase V.3 of the IREP2 migration (`docs/irep2-migration.md`,
tracking #4715). Follows the `get_tuple_expr` (#5738) and
`handle_tuple_subscript` slice (#5740) migrations with the identical seam
pattern — this drains the remaining tuple-struct literal site.

The full-type re-attach (`tuple_expr.type() = tuple_type`) is load-bearing:
`migrate_type` drops the frontend-only `#python_aggregate_kind` marker,
which the `in`/membership/subscript dispatch reads during conversion with
no tag-based fallback for tuples. The marker is read at conversion time
(not visible in the GOTO), so it cannot be caught by a goto diff alone —
mirrors the `get_tuple_expr` first-cut lesson in #5738.

## Testing

- `--goto-functions-only` output **byte-identical** (modulo pre-existing
  astgen-tempdir / unpack-temp non-determinism) across all 11
  partition/rpartition tests, verified A/B against a stashed pre-patch
  rebuild.
- **605/605** matched `string`/`tuple`/`partition` regression tests pass,
  including the membership paths (`tuple_str_membership`,
  `github_5185_tuple_literal_subscript`).
- clang-format clean.

Refs #4715.