### PR TITLE
[python] V.3: build folded integer math constant in IREP2

### DIFF
--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -440,8 +440,11 @@ exprt python_math::compute_expr(const exprt &expr) const
   else
     throw std::runtime_error("Unsupported math operation: " + expr.id_string());
 
-  // Return the result as a constant expression
-  return constant_exprt(result, lhs.type());
+  // Return the result as a constant expression. V.3: build the folded
+  // integer constant in IREP2 and back-migrate once -- the operands were read
+  // as bitvector integers, so lhs.type() is always integer here and the
+  // constant_int2t round-trips exactly to the same constant_exprt.
+  return migrate_expr_back(constant_int2tc(migrate_type(lhs.type()), result));
 }
 
 exprt python_math::handle_power_symbolic(exprt base, exprt exp)


### PR DESCRIPTION
## What

Migrates the folded-constant result of `python_math::compute_expr` to
IREP2. The function folds a binary `+`/`-`/`*`/`/` over two constant
integer operands and returned a legacy `constant_exprt`; it now builds
`constant_int2tc` over `migrate_type(lhs.type())` and back-migrates once.

## Why

Part of Part V Phase V.3 of the IREP2 migration (`docs/irep2-migration.md`,
tracking #4715) — the single-node value-construction sweep documented in
#5753. `compute_expr` is used by `handle_power` to resolve compound integer
bases/exponents (e.g. `(2+3)**2`) and by `complex_handler`. The operands
are read as bitvector integers via `binary2integer`, so `lhs.type()` is
always an integer type here and the `constant_int2t` round-trips exactly to
the same `constant_exprt`.

## Testing

- `--goto-functions-only` output **byte-identical** (modulo pre-existing
  astgen-tempdir / unpack-temp non-determinism) across 29 power/complex
  tests, verified A/B against a stashed pre-patch rebuild.
- **48/48** `power*` / `complex_pow*` / `arith` consumer regression tests
  pass.
- clang-format clean.

Refs #4715.