### PR TITLE
[python] Fix str.center() odd-padding split in constant fold

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -3561,3 +3561,42 @@ is orthogonal.
 ### 74b. Everything else: unchanged disposition
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. The §5 priority order stands.
+
+## 77. 2026-07-02 re-validation (sixty-seventh sweep) & str.center() odd-padding split
+
+Re-test against current `master` (tip `af8495a058`). KNOWNBUG classification unchanged — §3 holds.
+A 15-idiom battery (padding/formatting/numeric-base/dict-mutation idioms) found one CPython
+divergence: `str.center()` split odd padding on the wrong side — a **wrong-value/soundness** defect
+(the battery's deliberately-wrong oracle verified `SUCCESSFUL`).
+
+### 77a. New isolated, soundly-fixable defect found & fixed
+**`str.center()` put the extra fill char on the right for odd margins, so
+`assert "ab".center(7, "-") == "--ab---"` verified `SUCCESSFUL` (CPython: `"---ab--"`).**
+
+CPython (`Objects/unicodeobject.c` `unicode_center_impl`) computes
+`left = marg/2 + (marg & width & 1)` — the extra fill char goes on the **left** exactly when both
+the margin and the width are odd (`"ab".center(7)` → left 3/right 2; but `"a".center(4)` → left
+1/right 2, since the width is even). `handle_string_center`
+(`string_method_handler.cpp`) used the naive `left = pad / 2`, so every odd-margin/odd-width call
+folded to the mirror-image string: the valid assertion reported a spurious `FAILED` and the false
+one verified `SUCCESSFUL`. Single site — neither `python_consteval.cpp` nor the runtime OM models
+`center` (non-constant receivers/widths take the nondet fallback), and `ljust`/`rjust`/`zfill`
+(one-sided pads) are unaffected (battery-confirmed).
+
+This is a **wrong-value/soundness fix**. New regression pair
+`regression/python/str_center_odd_padding{,_fail}` (CORE): the positive is the liveness witness
+(odd margin+width with custom and default fill, odd margin+even width, even splits, degenerate
+`width <= len`, empty receiver); the `_fail` pins the previously-false-SUCCESSFUL mirror-image
+claim, now correctly `FAILED`. Code review differential-tested the patched fold against real
+CPython `str.center` over 448 (length, width, fill) combinations — zero mismatches. CPython sanity
+passes (`scripts/check_python_tests.sh str_center`); the `center`/`width` ctest subset (11 tests)
+and the focused `str`/`string`/`consteval` subset (1194 tests) pass 100% (existing center tests use
+even margins and are unaffected). Solver-agnostic (a frontend constant fold, no SMT encoding).
+
+The rest of the battery (`ljust`/`rjust`/`zfill`/`expandtabs`/`bit_length`/3-arg `pow`/
+`setdefault`/`popitem`/`enumerate(start=)`/str-mult/slice-step/`bin`/`oct`/`hex`/format-specs/
+`removeprefix`/`int(s, base)`) matches CPython — no further divergence found this sweep.
+
+### 77b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. The §5 priority order stands.

--- a/regression/python/str_center_odd_padding/main.py
+++ b/regression/python/str_center_odd_padding/main.py
@@ -1,0 +1,16 @@
+def main() -> None:
+    # CPython puts the extra fill char on the LEFT when both the margin
+    # and the width are odd: left = marg//2 + (marg & width & 1).
+    assert "ab".center(7, "-") == "---ab--"
+    assert "ab".center(5) == "  ab "
+    assert "a".center(4) == " a  "
+    assert "abc".center(6, "*") == "*abc**"
+    # Even split and degenerate widths unchanged.
+    assert "ab".center(6) == "  ab  "
+    assert "a".center(5) == "  a  "
+    assert "ab".center(2) == "ab"
+    assert "ab".center(1) == "ab"
+    assert "".center(3, "x") == "xxx"
+
+
+main()

--- a/regression/python/str_center_odd_padding/test.desc
+++ b/regression/python/str_center_odd_padding/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_center_odd_padding_fail/main.py
+++ b/regression/python/str_center_odd_padding_fail/main.py
@@ -1,0 +1,9 @@
+def main() -> None:
+    # Pre-fix, center() split the padding as left = pad//2 (extra on the
+    # right), folding "ab".center(7, "-") to "--ab---" and verifying this
+    # false assertion as SUCCESSFUL. CPython gives "---ab--", so this
+    # must be a real FAILED.
+    assert "ab".center(7, "-") == "--ab---"
+
+
+main()

--- a/regression/python/str_center_odd_padding_fail/test.desc
+++ b/regression/python/str_center_odd_padding_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -3312,8 +3312,11 @@ exprt string_handler::handle_string_center(
   if (width <= static_cast<long long>(input.size()))
     return string_builder_->build_string_literal(input);
 
+  // CPython puts the extra fill char on the LEFT when both the margin and
+  // the width are odd (Objects/unicodeobject.c unicode_center_impl:
+  // left = marg/2 + (marg & width & 1)), e.g. "ab".center(7) == "---ab--".
   long long pad = width - static_cast<long long>(input.size());
-  long long left = pad / 2;
+  long long left = pad / 2 + (pad & width & 1);
   long long right = pad - left;
   std::string result(static_cast<size_t>(left), fill);
   result += input;


### PR DESCRIPTION
handle_string_center used left = pad/2, putting the extra fill char on the right for odd margins, so "ab".center(7, "-") folded to "--ab---" instead of CPython's "---ab--" and a false assertion could verify SUCCESSFUL — a wrong-value/soundness bug. Use CPython's rule (left = marg/2 + (marg & width & 1), Objects/unicodeobject.c unicode_center_impl). Differential-tested against CPython over 448 (length, width, fill) combinations with zero mismatches; regression pair str_center_odd_padding{,_fail} added; center/width subset 11/11 and str/string/consteval subset 1194/1194 pass.