### PR TITLE
[build] make pinned nlohmann-json headers beat any system copy

### DIFF
--- a/scripts/cmake/ExternalDependencies.cmake
+++ b/scripts/cmake/ExternalDependencies.cmake
@@ -15,6 +15,18 @@ if(DOWNLOAD_DEPENDENCIES)
     URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
     URL_HASH SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d)
   fetchcontent_makeavailable(json)
+  # The pinned headers must beat any system copy for every target. Several
+  # targets list ${Boost_INCLUDE_DIRS} (e.g. /opt/homebrew/include, which can
+  # also carry a different nlohmann-json) in their own include list, which
+  # precedes the nlohmann_json::nlohmann_json link-interface include; targets
+  # then silently compile against the system version while the fetched one is
+  # linked elsewhere, and the mixed inline-namespace ABIs
+  # (nlohmann::json_abi_v3_11_3 vs v3_12_0) fail to link across libraries
+  # (seen in unit/python-frontend). Prepending directory-wide enforces the
+  # pin uniformly. Deliberately not SYSTEM: -isystem paths are searched
+  # after every plain -I path, which would hand precedence back to the
+  # system copy.
+  include_directories(BEFORE "${json_SOURCE_DIR}/include")
 
   # yaml-cpp (pinned for reproducible builds; was tracking the default branch)
   fetchcontent_declare(yaml-cpp


### PR DESCRIPTION
## Summary

With `DOWNLOAD_DEPENDENCIES=On`, several targets (`pythonfrontend`, `symex`, `esbmc`, `jimple`) list `${Boost_INCLUDE_DIRS}` — e.g. `/opt/homebrew/include`, which can also carry a **system nlohmann-json** — in their own include lists. Those plain `-I` entries precede the `nlohmann_json::nlohmann_json` link-interface include, so such targets silently compile against the system version (3.12.0 here) while other targets use the FetchContent-pinned **3.11.3**.

nlohmann-json versions live in distinct inline namespaces (`nlohmann::json_abi_v3_11_3` vs `v3_12_0`), so the mismatch surfaces as **undefined symbols at link time** whenever json-typed functions cross a library boundary — concretely, all `unit/python-frontend` test executables fail to link on a machine with Homebrew's nlohmann installed (`python_annotation_utils::has_annotation(nlohmann::json_abi_v3_12_0::basic_json<...>)` defined in `libpythonfrontend.a` vs `v3_11_3` referenced by the test objects).

Fix: after `fetchcontent_makeavailable(json)`, prepend the pinned include directory-wide with `include_directories(BEFORE ...)` so every target resolves `<nlohmann/json.hpp>` to the pinned copy. Deliberately **not** `SYSTEM`: `-isystem` paths are searched after every plain `-I`, which would hand precedence straight back to the system copy.

Non-download builds (`find_package` path for distro packaging) are unchanged — there the system version is the intended one.

## Validation

- Before: 14 unit-test executables fail to link (nlohmann ABI mismatch); after: full build green, include order verified via `compile_commands.json` (`_deps/json-src/include` now first everywhere).
- Unit suite: 474/475 pass (was 461 built / 450 passing). The one failure, `all LD symbols have mode == "LD"`, is a pre-existing ld-frontend bug newly *exposed* by these tests becoming buildable — fixed separately in a follow-up PR.
- Regression smoke: printf/va subset unaffected (build-only change).