### PR TITLE
[SAFE-LD] tag the rounding-mode shim as a C symbol, not an LD one

### DIFF
--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -642,7 +642,11 @@ void ld_converter::convert()
     symbolt rm;
     rm.id = "c:@__ESBMC_rounding_mode";
     rm.name = "__ESBMC_rounding_mode";
-    rm.module = "ld";
+    // This mirrors the C frontend's intrinsic (C-mangled id, C mode), so it
+    // is not an LD-language symbol: tagging it module "ld" would break the
+    // invariant that every LD-module symbol has mode "LD"
+    // (unit/ld-frontend/test_ir_gen.cpp).
+    rm.module = "C";
     rm.mode = "C";
     rm.lvalue = true;
     rm.static_lifetime = true;


### PR DESCRIPTION
## Summary

`ld_converter::convert()` synthesizes the `__ESBMC_rounding_mode` intrinsic to mirror the C frontend's (C-mangled id `c:@__ESBMC_rounding_mode`, mode `C`), but tagged it `module = "ld"`. That breaks the invariant asserted by `unit/ld-frontend/test_ir_gen.cpp` — *every LD-module symbol has mode "LD"* — making the `all LD symbols have mode == "LD"` unit test fail. Tag the shim `module = "C"` to match its mode; nothing in the codebase consumes `module == "ld"` in logic (assignments and this test only).

Surfaced when the python/ld unit-test executables became locally buildable via the nlohmann include-order fix (#5759); the test itself was added with the SAFE-LD skeleton (#5280).

## Validation

- `all LD symbols have mode == "LD"` unit test: fails on master, passes with this change.
- Full unit suite: **475/475** (with #5759's build fix applied locally so the executables link).
- `regression/ld/` suite: 18/19, the one failure (`stairs_light_safe`) reproduced identically on pristine master in an A/B run — pre-existing, unrelated.

## Test plan

- [x] Unit test flips red→green; no regression in the ld suite
- [ ] CI matrix