### PR TITLE
[python] Fold as_integer_ratio() on numeric literals at preprocess time

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -3561,3 +3561,45 @@ is orthogonal.
 ### 74b. Everything else: unchanged disposition
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. The §5 priority order stands.
+
+## 79. 2026-07-02 re-validation (sixty-ninth sweep) & as_integer_ratio() literal fold
+
+Re-test against current `master` (tip `e92296d1fe`). KNOWNBUG classification unchanged — §3 holds.
+This sweep took a §78-battery residual: `float.as_integer_ratio()` was undefined, and unpacking its
+result **crashed conversion**. (The battery's other hits resolved themselves: `str.encode()` now
+passes on current master; set-method timeouts are the §3c perf-banned class;
+`str.maketrans`/`translate` needs a dict intermediate — catalogued, not taken.)
+
+### 79a. New isolated, soundly-fixable defect found & fixed
+**`as_integer_ratio()` was undefined — `assert(false)` stub on call, and a conversion crash
+(`Cannot unpack empty`) when the result was tuple-unpacked.**
+
+`(2.5).as_integer_ratio()` hit "Undefined function … replacing with assert(false)" (spurious
+`FAILED` for any caller), and `n, d = v.as_integer_ratio()` aborted the whole conversion with
+`ERROR: Cannot unpack empty - only tuples and arrays can be unpacked`.
+
+**Fix** (`src/python-frontend/preprocessor/core_visitors_mixin.py`): a preprocess-time fold
+`_maybe_fold_as_integer_ratio`, following the Decimal-constructor precedent — the ratio is computed
+by **CPython itself** during preprocessing, so the folded `(numerator, denominator)` tuple matches
+the interpreter bit-for-bit (e.g. `0.1` → `(3602879701896397, 36028797018963968)`). Scope: int and
+float literals, and unary `+`/`-` over one. Declines (unchanged behaviour) on bool receivers,
+non-literals, `inf`/`nan`, and ratios exceeding 2⁶³−1. Tuple contexts (compare, unpack) work
+because the result is an ordinary tuple literal.
+
+This **restores working behaviour** for literal receivers and removes the unpack crash on that
+path. New regression pair `regression/python/as_integer_ratio{,_fail}` (CORE): the positive covers
+dyadic/non-dyadic floats, negatives, ints, zero, and tuple unpacking (the pre-fix crash shape); the
+`_fail` pins a wrong ratio as a real `FAILED`. Code review differentially tested the imported fold
+against CPython over ~9,000 generated cases (uniform floats, 62-bit ints, wide-exponent floats,
+negative zero, boundary 2⁶³±1, must-decline set incl. `True`/`1e300`/`1e400`/`~5`) — bit-for-bit
+exact, decline predicate exact. CPython sanity passes; the
+decimal/from_bytes/gcd/lcm/preprocessor-adjacent subset (36) passes 100%; the `tuple|float` subset
+shows only the two pre-existing `--ir`/`--z3` environmental failures (verified identical on vanilla
+master). Solver-agnostic (a preprocess-time fold).
+
+Variable receivers (`v.as_integer_ratio()`) keep the prior unsupported behaviour (no wrong fold) —
+a runtime model needs frexp-style bit manipulation in the OM, a separate change.
+
+### 79b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. The §5 priority order stands.

--- a/regression/python/as_integer_ratio/main.py
+++ b/regression/python/as_integer_ratio/main.py
@@ -1,0 +1,12 @@
+assert (2.5).as_integer_ratio() == (5, 2)
+assert (0.5).as_integer_ratio() == (1, 2)
+assert (-2.5).as_integer_ratio() == (-5, 2)
+assert (3.0).as_integer_ratio() == (3, 1)
+assert (0.0).as_integer_ratio() == (0, 1)
+assert (5).as_integer_ratio() == (5, 1)
+assert (-7).as_integer_ratio() == (-7, 1)
+# Exact dyadic ratio of a non-representable decimal.
+assert (0.1).as_integer_ratio() == (3602879701896397, 36028797018963968)
+# Tuple unpacking of the folded result.
+n, d = (1.5).as_integer_ratio()
+assert n == 3 and d == 2

--- a/regression/python/as_integer_ratio/test.desc
+++ b/regression/python/as_integer_ratio/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/as_integer_ratio_fail/main.py
+++ b/regression/python/as_integer_ratio_fail/main.py
@@ -1,0 +1,5 @@
+# Pre-fix, as_integer_ratio() was undefined (assert(false) stub) and a
+# tuple unpack of its result crashed conversion ("Cannot unpack empty").
+# Now the literal fold renders the exact ratio, so this wrong claim must
+# be a real FAILED.
+assert (2.5).as_integer_ratio() == (5, 3)

--- a/regression/python/as_integer_ratio_fail/test.desc
+++ b/regression/python/as_integer_ratio_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -798,6 +798,43 @@ class CoreVisitorsMixin:
         return node
 
     @staticmethod
+    def _maybe_fold_as_integer_ratio(node):
+        # (2.5).as_integer_ratio() on a numeric literal folds to its exact
+        # (numerator, denominator) tuple, computed by CPython itself, so the
+        # result matches the interpreter bit-for-bit. Non-literal receivers
+        # are left to the regular dispatch.
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr == "as_integer_ratio"
+                and not node.args and not node.keywords):
+            return None
+        recv = node.func.value
+        value = None
+        if (isinstance(recv, ast.Constant) and isinstance(recv.value, (int, float))
+                and not isinstance(recv.value, bool)):
+            value = recv.value
+        elif (isinstance(recv, ast.UnaryOp) and isinstance(recv.op, (ast.USub, ast.UAdd))
+              and isinstance(recv.operand, ast.Constant)
+              and isinstance(recv.operand.value, (int, float))
+              and not isinstance(recv.operand.value, bool)):
+            value = -recv.operand.value if isinstance(recv.op, ast.USub) else recv.operand.value
+        if value is None:
+            return None
+        try:
+            num, den = value.as_integer_ratio()
+        except (OverflowError, ValueError):  # inf / nan
+            return None
+        # Stay within the frontend's 64-bit integer comfort zone; larger
+        # ratios (huge exponents) fall through unfolded.
+        if abs(num) > 2**63 - 1 or den > 2**63 - 1:
+            return None
+        result = ast.Tuple(
+            elts=[ast.Constant(value=num), ast.Constant(value=den)],
+            ctx=ast.Load(),
+        )
+        ast.copy_location(result, node)
+        ast.fix_missing_locations(result)
+        return result
+
+    @staticmethod
     def _normalize_int_from_bytes_endianness(node):
         if not (isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name)
                 and node.func.value.id == "int" and node.func.attr == "from_bytes"):
@@ -1242,6 +1279,10 @@ class CoreVisitorsMixin:
         rewritten_decimal = self._maybe_rewrite_decimal_call(node)
         if rewritten_decimal is not None:
             return rewritten_decimal
+
+        rewritten_ratio = self._maybe_fold_as_integer_ratio(node)
+        if rewritten_ratio is not None:
+            return rewritten_ratio
 
         self._normalize_int_from_bytes_endianness(node)
         self._normalize_math_gcd_lcm_variadic(node)

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -813,8 +813,8 @@ class CoreVisitorsMixin:
             value = recv.value
         elif (isinstance(recv, ast.UnaryOp) and isinstance(recv.op, (ast.USub, ast.UAdd))
               and isinstance(recv.operand, ast.Constant)
-              and isinstance(recv.operand.value, (int, float))
-              and not isinstance(recv.operand.value, bool)):
+              and isinstance(recv.operand.value,
+                             (int, float)) and not isinstance(recv.operand.value, bool)):
             value = -recv.operand.value if isinstance(recv.op, ast.USub) else recv.operand.value
         if value is None:
             return None


### PR DESCRIPTION
as_integer_ratio() was undefined (assert(false) stub, spurious FAILED for any caller), and tuple-unpacking its result crashed conversion ("Cannot unpack empty"). Fold literal receivers (int/float, unary +/-) to the exact (numerator, denominator) tuple computed by CPython itself during preprocessing, following the Decimal-constructor precedent — bit-for-bit interpreter agreement by construction (0.1 -> (3602879701896397, 36028797018963968)). Bool/non-literal/inf/nan/oversized ratios decline unchanged. Differential-tested against CPython over ~9,000 generated cases with exact agreement; regression pair as_integer_ratio{,_fail} added; adjacent decimal/from_bytes/gcd/lcm subset 36/36 passes.