### PR TITLE
[goto-cov] preserve assertion message in coverage claim text

### DIFF
--- a/regression/goto-coverage/github_5747_1/main.c
+++ b/regression/goto-coverage/github_5747_1/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main()
+{
+  int a = 2;
+  __ESBMC_assert(!(a % 2), "a stays even");
+  assert(a == 2);
+  return 0;
+}

--- a/regression/goto-coverage/github_5747_1/test.desc
+++ b/regression/goto-coverage/github_5747_1/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--assertion-coverage-claims
+FAILED: 'a stays even at file .*main.c line 6
+Reached Assertion Instances: 2
+Assertion Instances Coverage: 100%
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_5747_2/main.c
+++ b/regression/goto-coverage/github_5747_2/main.c
@@ -1,0 +1,14 @@
+int nondet_int();
+
+int main()
+{
+  int a = nondet_int();
+  __ESBMC_assume(a % 2 == 0);
+  if (a % 2)
+  {
+    ++a;
+    __ESBMC_assert(0, "unreachable odd branch");
+  }
+  __ESBMC_assert(a % 2 == 0, "a is even here");
+  return 0;
+}

--- a/regression/goto-coverage/github_5747_2/test.desc
+++ b/regression/goto-coverage/github_5747_2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--assertion-coverage-claims
+PASSED: 'unreachable odd branch at file .*main.c line 10
+FAILED: 'a is even here at file .*main.c line 12
+Reached Assertion Instances: 1
+Assertion Instances Coverage: 50%
+^VERIFICATION FAILED$

--- a/regression/python-coverage/assertion_coverage_message/main.py
+++ b/regression/python-coverage/assertion_coverage_message/main.py
@@ -1,0 +1,7 @@
+def f(n: int) -> int:
+    assert n > 0, "n must be positive"
+    assert n < 100
+    return n
+
+
+f(5)

--- a/regression/python-coverage/assertion_coverage_message/test.desc
+++ b/regression/python-coverage/assertion_coverage_message/test.desc
@@ -1,0 +1,7 @@
+THOROUGH
+main.py
+--assertion-coverage-claims
+FAILED: 'n must be positive at file .*main.py line 2
+FAILED: 'n < 100 at file .*main.py line 3
+Assertion Instances Coverage: 100%
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -76,7 +76,11 @@ void goto_coveraget::replace_assert_to_guard(
     it->location.property("instrumented assertion");
   else
     it->location.property("replaced assertion");
-  it->location.comment(from_expr(ns, "", old_guard));
+  // Keep an existing comment (e.g. the "msg" of __ESBMC_assert(cond, "msg"),
+  // or the modeled "assertion ..." text of C library asserts) as the claim
+  // identifier; asserts lowered without a comment get the stringified guard.
+  if (it->location.comment().empty())
+    it->location.comment(from_expr(ns, "", old_guard));
   it->location.user_provided(true);
 }
 


### PR DESCRIPTION
## Summary

Fixes the problem reported in discussion #5747: under `--assertion-coverage`, claims from `__ESBMC_assert(cond, "msg")` were reported as the stringified guard expression instead of the user-provided message, e.g.

```
✓ PASSED: '!((_Bool)(a % 2)) at file unreach.cpp line 63 ...'
```

instead of

```
✓ PASSED: 'UNREACH a even symb loop then at file unreach.cpp line 63 ...'
```

## Root cause

The frontend stores the `__ESBMC_assert` message in the assert's location comment (`builtin_functions.cpp`). Assertion-coverage instrumentation (`goto_coveraget::replace_assert_to_guard`) then unconditionally overwrote that comment with `from_expr(old_guard)`. Every downstream consumer of the claim identity — the goal set (`get_total_cond_assert`), the reached-claim signature (`claim_msg + "\t" + claim_loc`), the claim slicer, and the `PASSED`/`FAILED` report lines — reads that comment, so the guard text is what got displayed.

## Fix

Keep an existing comment and fall back to the stringified guard only when none is set (message-less asserts lowered via `goto_convertt::convert_assert`, e.g. Python `assert x` without a message). Since the goal set and the reached-claim signatures both read the same comment field after instrumentation, goal/reached matching stays consistent by construction.

## Tests

- `regression/goto-coverage/github_5747_1` — message-bearing `__ESBMC_assert` plus a plain `assert`; regexes the message in the `FAILED` claim line, 100% coverage.
- `regression/goto-coverage/github_5747_2` — an unreached message-bearing assert (`PASSED` with message) plus a reached one (`FAILED` with message), 50% coverage.
- `regression/python-coverage/assertion_coverage_message` — pins both arms of the new branch: message preserved (`n must be positive`) and message-less fallback to the guard text (`n < 100`); verified clean under CPython.

Full goto-coverage suite run locally (macOS): no new failures vs. the unpatched baseline; python-coverage 14/14; unit tests pass. Reachability of both arms of the added branch additionally proved with `__ESBMC_unreachable()` + `--enable-unreachability-intrinsic` under Bitwuzla and Z3 in agreement.

Fixes discussion #5747.
