### PR TITLE
[python] Fix `Class* is None` guards and main-file model misclassification

### DIFF
--- a/regression/python/isnone_class_field/main.py
+++ b/regression/python/isnone_class_field/main.py
@@ -1,0 +1,23 @@
+# `x.field is None` must evaluate as a null-pointer check when the field holds
+# a heap-allocated class instance (Class*), which is NULL exactly when its
+# Python value is None. Regression for the isnone evaluator folding
+# `Class* is None` to a constant False (defeating None guards and causing
+# spurious NULL dereferences, e.g. QuixBugs detect_cycle).
+
+class Node:
+    def __init__(self, value: int, nxt=None):
+        self.value = value
+        self.nxt = nxt
+
+
+def has_next(n: Node) -> int:
+    if n.nxt is None:
+        return 0
+    return 1
+
+
+tail = Node(2)          # nxt defaults to None
+head = Node(1, tail)    # nxt is a real Node -> field typed Node*
+
+assert has_next(head) == 1   # head.nxt is not None
+assert has_next(tail) == 0   # tail.nxt is None

--- a/regression/python/isnone_class_field/test.desc
+++ b/regression/python/isnone_class_field/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isnone_class_field_fail/main.py
+++ b/regression/python/isnone_class_field_fail/main.py
@@ -1,0 +1,21 @@
+# Negative counterpart of isnone_class_field: pins that `tail.nxt is None`
+# genuinely evaluates to True for a None-valued Class* field, so the wrong
+# expectation (has_next(tail) == 1) is a real assertion violation. Before the
+# isnone-on-Class* fix this folded to False and the bug was hidden (spurious
+# VERIFICATION SUCCESSFUL).
+
+class Node:
+    def __init__(self, value: int, nxt=None):
+        self.value = value
+        self.nxt = nxt
+
+
+def has_next(n: Node) -> int:
+    if n.nxt is None:
+        return 0
+    return 1
+
+
+tail = Node(2)          # nxt defaults to None
+
+assert has_next(tail) == 1   # WRONG: tail.nxt is None, so has_next(tail) == 0

--- a/regression/python/isnone_class_field_fail/test.desc
+++ b/regression/python/isnone_class_field_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/quixbugs/detect_cycle/test.desc
+++ b/regression/quixbugs/detect_cycle/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions/python_builtins.cpp
+++ b/src/goto-symex/builtin_functions/python_builtins.cpp
@@ -246,9 +246,21 @@ void goto_symext::simplify_python_builtins(expr2tc &expr)
           if (auto res = optional_is_none_field(val))
             return res;
         }
-        // For void* (any_type) with no Optional in the value set,
-        // fall back to null-pointer check: x is None ↔ x == NULL.
-        if (is_empty_type(to_pointer_type(side->type).subtype))
+        // Fall back to a null-pointer check: `x is None` ↔ `x == NULL`.
+        // This covers void* (any_type, unannotated) and — since class
+        // instances became heap-allocated Class* references — a pointer to a
+        // user-class struct, whose field/variable holds NULL exactly when its
+        // Python value is None. The pointee may still be an unresolved symbol
+        // tag (`tag-<Class>`) rather than an inlined struct, so follow it.
+        // Without this, `Class* is None` folded to a constant False below
+        // ("None is never equal to non-None"), silently defeating guards like
+        // `node is None or node.next is None` and producing spurious NULL
+        // dereferences (QuixBugs detect_cycle).
+        const type2tc &subt = to_pointer_type(side->type).subtype;
+        bool null_is_none = is_empty_type(subt) || is_struct_type(subt);
+        if (!null_is_none && is_symbol_type(subt))
+          null_is_none = ns.follow(migrate_type_back(subt)).id() == "struct";
+        if (null_is_none)
           return equality2tc(side, gen_zero(side->type));
       }
       return std::nullopt;

--- a/src/python-frontend/converter/converter_util.cpp
+++ b/src/python-frontend/converter/converter_util.cpp
@@ -119,6 +119,16 @@ bool python_converter::is_pytest_generation_mode() const
 bool python_converter::is_model_file(const nlohmann::json &node) const
 {
   const std::string file = get_location_from_decl(node).file().as_string();
+  // The file under verification is never a model — not even when it is passed
+  // by a bare relative name (e.g. `main.py`) that the no-directory heuristic
+  // below would otherwise misread as a model. That misclassification disabled
+  // `and`/`or` short-circuit lowering for the main module, so a guard like
+  // `x is None or x.field is None` was emitted as an eager compound operand and
+  // the verdict flipped depending on whether the source was given by relative
+  // or absolute path (QuixBugs detect_cycle).
+  if (file == main_python_file)
+    return false;
+
   if (file.find("/models/") != std::string::npos)
     return true;
 


### PR DESCRIPTION
Fixes two orthogonal root causes that together caused QuixBugs `detect_cycle` to fail (spurious NULL dereference / path-dependent verdict). Reclassifies it KNOWNBUG → CORE.

## 1. `Class* is None` evaluated as a null-pointer check
Since class instances became heap-allocated `Class*` references, a field or variable holds NULL exactly when its Python value is None. The is-None evaluator in `simplify_python_builtins` only special-cased `void*` and folded `Class* is None` to a constant `False`, silently defeating guards like `node.next is None` and producing spurious NULL dereferences. It now falls back to `side == NULL` for struct pointer subtypes, following unresolved `tag-<Class>` symbol types to their struct.

New regression tests `regression/python/isnone_class_field` (CORE) and `isnone_class_field_fail` (fail counterpart) pin this in isolation.

## 2. The file under verification is never a model
When the main module is passed by a bare relative name (e.g. `main.py`), the no-directory heuristic in `is_model_file` misread it as a model, disabling `and`/`or` short-circuit lowering for that module. A guard such as `x is None or x.field is None` was then emitted as an eager compound operand, flipping the verdict depending on whether the source was given by a relative or absolute path. `is_model_file` now returns `false` early when the location matches `main_python_file`.

## Validation
- `isnone_class_field{,_fail}`, `detect_cycle{,_fail}` — pass
- Full QuixBugs suite: **73/73 pass, 0 failures**
- Targeted None/Optional/boolop/short-circuit subset: **62/62 pass, 0 failures**
- clang-format clean on both C++ files