### PR TITLE
[python] V.3: build numpy .shape tuple value in IREP2

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3918,6 +3918,22 @@ string/tuple/partition tests green. The membership path is not visible in the go
 marker is read during conversion), so the type re-attach is load-bearing and
 the full suite is the real gate — the #5738 first cut proved this.
 
+**Follow-up (2026-07-02) — the numpy `.shape` tuple, the last `create_tuple_
+struct_type` literal.** `build_shape_tuple_expr` (`converter_expr.cpp`, the
+builder behind `ndarray.shape` / list `.shape`) was the remaining marker-bearing
+tuple literal built via `struct_exprt` rather than the shared idiom. Migrated to
+`constant_struct2tc` over migrated operands with the full `struct_typet`
+re-attached, mirroring `get_tuple_expr` exactly. Cleaner than the sibling sites:
+all four call sites feed `int_type()` dimension exprs (`from_integer(dim,
+int_type())` for C arrays, `(int)__ESBMC_list_size(...)` for lists), so the
+operands already match the tuple's `int_type()` components and no operand surgery
+is needed. Behaviour-preserving: a clean A/B rebuild (stash → baseline → restore)
+shows `--goto-functions-only` byte-identical on `github_4666_shape_2d` (the
+shape tuple prints `ASSIGN s={ .element_0=2, .element_1=2 }` unchanged), the only
+residual diff being the astgen-tempdir hash in `__file__` and GOTO timing; 36
+shape tests green (`tuple-from-list` is a pre-existing 70 s solver test that only
+timed out under `-j4`, not on the `.shape` path).
+
 ### Phase V.4 — IREP2 structured CF + IREP2-aware `goto_convert` (removes W1)
 Add the missing structured CF code kinds to IREP2 (`code_ifthenelse2t`,
 `code_while2t`, `code_for2t`, `code_switch2t`, `code_break2t`,

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -52,8 +52,23 @@ static exprt build_shape_tuple_expr(
   std::vector<typet> element_types(dims.size(), int_type());
   struct_typet tuple_type =
     converter.get_tuple_handler().create_tuple_struct_type(element_types);
-  struct_exprt tuple_expr(tuple_type);
-  tuple_expr.operands() = dims;
+  // V.3: build the tuple value in IREP2, back-migrating once. The operands are
+  // already-built int_type() dimension exprs, so a constant_struct2t over them
+  // round-trips exactly through migrate. Re-attach the full struct type
+  // afterwards: migrate_type drops the frontend-only #python_aggregate_kind
+  // marker that the in/membership dispatch reads (python_aggregate_kind) with no
+  // tag fallback — mirroring tuple_handler::get_tuple_expr.
+  std::vector<expr2tc> members;
+  members.reserve(dims.size());
+  for (const exprt &d : dims)
+  {
+    expr2tc d2;
+    migrate_expr(d, d2);
+    members.push_back(std::move(d2));
+  }
+  exprt tuple_expr =
+    migrate_expr_back(constant_struct2tc(migrate_type(tuple_type), members));
+  tuple_expr.type() = tuple_type;
   return tuple_expr;
 }
 


### PR DESCRIPTION
## What

Migrates the numpy `.shape` tuple construction in the Python frontend to IREP2. `build_shape_tuple_expr` (`converter_expr.cpp`) built the shape tuple `(dim0, dim1, ...)` for `ndarray.shape` / list `.shape` as a legacy `struct_exprt`. It now builds the value via `constant_struct2tc` over the migrated dimension operands and back-migrates once, then restores the full struct type. This drains the last `create_tuple_struct_type` literal still built the legacy way.

## Why

Part of Part V Phase V.3 of the IREP2 migration (`docs/irep2-migration.md`, tracking #4715). Follows the tuple-struct literal drain — `get_tuple_expr` (#5738), `handle_tuple_subscript` slice (#5740), `build_partition_tuple` (#5753) — with the identical seam pattern.

The full-type re-attach (`tuple_expr.type() = tuple_type`) is load-bearing: `migrate_type` drops the frontend-only `#python_aggregate_kind` marker that the `in`/membership/subscript dispatch reads during conversion with no tag-based fallback. Cleaner than the sibling sites — all four call sites feed `int_type()` dimension exprs, so the operands already match the tuple's `int_type()` components and no operand surgery is needed.

## Testing

- `--goto-functions-only` output **byte-identical** (modulo pre-existing astgen-tempdir / GOTO-timing non-determinism) on `github_4666_shape_2d`, verified A/B against a stashed pre-patch rebuild; the shape tuple prints `ASSIGN s={ .element_0=2, .element_1=2 }` unchanged.
- **36/36** shape regression tests pass (`tuple-from-list` is a pre-existing 70 s solver test that timed out only under `-j4`, not on the `.shape` path — passes standalone).
- clang-format clean.

Refs #4715.