### PR TITLE
[python] Pin dict equality across the return boundary with a test pair

### DIFF
--- a/regression/python/github_5444_dict_eq_return/main.py
+++ b/regression/python/github_5444_dict_eq_return/main.py
@@ -1,0 +1,25 @@
+# Sound-twin of github_5444_dict_eq_return_fail.
+#
+# Regression pin for the "return across the call boundary" shape flagged as
+# untested by the #5444 umbrella's DoD note ("sound int/float dict equality
+# on returned dicts"): a dict local to a function starts a slot as
+# float('inf'), reassigns it to an int via subscript, and is then returned
+# and compared (via `==`) against an int-literal dict at the call site.
+#
+# The dict-equality model's int/float numeric fallback (list.c, added by
+# #5726) and the dict's key/value payloads must both survive the
+# function-return copy intact -- this is the exact GOTO shape the umbrella
+# worried might alias the returned struct's key/value lists with the RHS
+# literal's, masking a real mismatch. Confirmed sound by exhaustive
+# differential testing against CPython (15 structural variants: key order,
+# comparison direction, negated assert, nondet parameter, min()-based
+# reassignment, float-vs-int RHS literal); this test pins the true
+# (all-equal) case.
+def mk(a: int) -> dict:
+    d = {"a": float("inf"), "b": 0}
+    d["a"] = a
+    return d
+
+
+r = mk(1)
+assert r == {"a": 1, "b": 0}

--- a/regression/python/github_5444_dict_eq_return/test.desc
+++ b/regression/python/github_5444_dict_eq_return/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5444_dict_eq_return_fail/main.py
+++ b/regression/python/github_5444_dict_eq_return_fail/main.py
@@ -1,0 +1,19 @@
+# Negative twin of github_5444_dict_eq_return.
+#
+# Same return-across-call-boundary shape (float('inf')-init slot reassigned
+# to an int, dict returned, compared against an int-literal dict), but the
+# *untouched* slot ("b") now genuinely differs: mk() never changes "b", so
+# the returned dict still holds "b": 0, while the comparison literal claims
+# "b": 1. CPython raises AssertionError (exit 1); ESBMC must report
+# VERIFICATION FAILED. Guards against any future regression that would
+# let a real mismatch on an untouched slot go undetected once a different
+# slot's numeric int/float fallback fires (dict-equality model,
+# list.c:845-939).
+def mk(a: int) -> dict:
+    d = {"a": float("inf"), "b": 0}
+    d["a"] = a
+    return d
+
+
+r = mk(1)
+assert r == {"a": 1, "b": 1}

--- a/regression/python/github_5444_dict_eq_return_fail/test.desc
+++ b/regression/python/github_5444_dict_eq_return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$


### PR DESCRIPTION
## What

Test-only PR. The existing `dict_eq` regression tests compare local dicts; this pair pins the **returned-dict** shape — a `float('inf')`-initialised value slot reassigned to an int inside the callee, compared against a dict literal at the caller — exercising `__ESBMC_dict_eq`'s int/float numeric fallback (#5726) together with struct return-value passing.

- `regression/python/github_5444_dict_eq_return` — CORE, `--incremental-bmc`, VERIFICATION SUCCESSFUL (CPython exit 0)
- `regression/python/github_5444_dict_eq_return_fail` — genuine value mismatch on the untouched slot, VERIFICATION FAILED (CPython exit 1)

## Why

While working #5444's definition-of-done items, this shape was suspected of a soundness gap; a full RCA (15 structural variants — key order, mismatch direction, negation, unannotated/nondet parameters, cross-boundary literal comparisons) found the machinery behaves correctly on every variant, matching CPython exactly. The suspicion traced back to a malformed probe, not ESBMC. These tests keep the previously-uncovered shape pinned so a future regression here is caught immediately.

Refs #5444.
