### PR TITLE
[python] V.3: build the Optional wrapper value in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_types.cpp
+++ b/src/python-frontend/converter/converter_types.cpp
@@ -68,27 +68,26 @@ exprt python_converter::wrap_in_optional(
 {
   assert(optional_type.is_struct());
   const struct_typet &struct_type = to_struct_type(optional_type);
+  const bool is_none = value.type() == none_type();
 
-  // Create struct expression
-  struct_exprt optional_value(struct_type);
+  // V.3: build the optional value { is_none, value } in IREP2, back-migrating
+  // once. Both members are already-built value exprs (a bool literal and either
+  // the wrapped value or a zero of the field type), so a constant_struct2t over
+  // the migrated operands round-trips exactly through migrate. Re-attach the
+  // full struct type afterwards: migrate_type drops the frontend-only
+  // #python_aggregate_kind="optional" marker that later dispatch reads with no
+  // tag fallback -- mirroring build_shape_tuple_expr / get_tuple_expr.
+  expr2tc value_member;
+  migrate_expr(
+    is_none ? gen_zero(struct_type.components()[1].type()) : value,
+    value_member);
 
-  // Set is_none field based on whether value is None
-  exprt is_none_value;
-  if (value.type() == none_type())
-  {
-    is_none_value = migrate_expr_back(gen_true_expr()); // V.3
-    // Set value field to zero for None case
-    optional_value.operands().push_back(is_none_value);
-    optional_value.operands().push_back(
-      gen_zero(struct_type.components()[1].type()));
-  }
-  else
-  {
-    is_none_value = migrate_expr_back(gen_false_expr()); // V.3
-    optional_value.operands().push_back(is_none_value);
-    optional_value.operands().push_back(value);
-  }
+  std::vector<expr2tc> members{
+    is_none ? gen_true_expr() : gen_false_expr(), std::move(value_member)};
 
+  exprt optional_value =
+    migrate_expr_back(constant_struct2tc(migrate_type(struct_type), members));
+  optional_value.type() = struct_type;
   return optional_value;
 }
 


### PR DESCRIPTION
## What

Migrates `wrap_in_optional` (`converter_types.cpp`) to the shared IREP2
seam idiom. It built the `Optional[T]` struct `{ is_none, value }` for
Optional returns, `= None` parameter defaults and `dict.get()` as a legacy
`struct_exprt`. It now assembles the value via `constant_struct2tc` over the
migrated member operands, back-migrates once, then restores the full struct
type -- mirroring `build_shape_tuple_expr` / `tuple_handler::get_tuple_expr`.

## Why

Part of Part V Phase V.3 of the IREP2 migration
(`docs/irep2-migration.md`, tracking #4715). Drains the next clean,
marker-bearing `struct_exprt` literal after the tuple-struct family
(#5738/#5740/#5753/#5768).

The full-type re-attach (`optional_value.type() = struct_type`) is
load-bearing: `migrate_type` drops the frontend-only
`#python_aggregate_kind="optional"` marker (set in `build_optional_type`)
that later membership/subscript dispatch reads, with no tag fallback. Both
members are already-built value exprs (a bool literal and either the wrapped
value or a zero of the field type), so migrating them round-trips exactly --
no operand surgery is needed.

## Testing

- `--goto-functions-only` output **byte-identical** (0-line diff) on the
  `optional` test, verified A/B against a clean pre-patch rebuild (stash ->
  baseline -> restore).
- **21/21** Optional regression tests pass (`optional*`, `function-option*`,
  `github_3976_optional_attr_access`, `github_4807_optional_call_is_none*`,
  `optional_union`, `dataclass-conformance-hardening_typing_union_optional`).
- clang-format (11) clean.

Refs #4715.
