### PR TITLE
[python] V.3: build the slice (PySliceObject) value in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1664,28 +1664,41 @@ static exprt make_slice_struct_expr(
     return node && !node->is_null();
   };
 
-  struct_exprt slice_expr(struct_type);
+  // V.3: build the PySliceObject value in IREP2. Each member is built exactly
+  // as the legacy struct_exprt did -- start/stop/step (a value, nondet, or an
+  // IREP2 typecast from lower_int), the has_* flags, and a zero for the
+  // anonymous trailing padding member -- then migrated; the constant_struct2t
+  // over those members back-migrates to the same struct value. Re-attach the
+  // followed struct type afterwards: migrate_type_back does not reproduce the
+  // component #cpp_type attributes / padding layout of the C model struct.
+  std::vector<expr2tc> members;
+  members.reserve(struct_type.components().size());
   for (const auto &component : struct_type.components())
   {
     const std::string name = component.get_name().as_string();
+    exprt member;
     if (name == "start")
-      slice_expr.operands().push_back(lower_int(lower, component.type()));
+      member = lower_int(lower, component.type());
     else if (name == "stop")
-      slice_expr.operands().push_back(lower_int(upper, component.type()));
+      member = lower_int(upper, component.type());
     else if (name == "step")
-      slice_expr.operands().push_back(lower_int(step, component.type()));
+      member = lower_int(step, component.type());
     else if (name == "has_start")
-      slice_expr.operands().push_back(
-        from_integer(present_flag(lower) ? 1 : 0, component.type()));
+      member = from_integer(present_flag(lower) ? 1 : 0, component.type());
     else if (name == "has_stop")
-      slice_expr.operands().push_back(
-        from_integer(present_flag(upper) ? 1 : 0, component.type()));
+      member = from_integer(present_flag(upper) ? 1 : 0, component.type());
     else if (name == "has_step")
-      slice_expr.operands().push_back(
-        from_integer(present_flag(step) ? 1 : 0, component.type()));
+      member = from_integer(present_flag(step) ? 1 : 0, component.type());
     else
-      slice_expr.operands().push_back(gen_zero(component.type()));
+      member = gen_zero(component.type());
+    expr2tc m2;
+    migrate_expr(member, m2);
+    members.push_back(std::move(m2));
   }
+
+  exprt slice_expr =
+    migrate_expr_back(constant_struct2tc(migrate_type(struct_type), members));
+  slice_expr.type() = struct_type;
 
   if (source_node.contains("lineno"))
     slice_expr.location() = conv.get_location_from_decl(source_node);


### PR DESCRIPTION
## What

Migrates `make_slice_struct_expr` (`converter_expr.cpp`, the shared lowering
behind `a[i:j:k]` slices and `slice(...)` builtin calls) from a legacy
`struct_exprt` to the shared IREP2 seam idiom. Each member is built exactly as
before -- `start`/`stop`/`step` (a value, an IREP2 typecast from `lower_int`,
or a nondet for an unspecified bound), the `has_*` presence flags, and a zero
for the anonymous trailing padding member -- then migrated; a
`constant_struct2t` over those members back-migrates to the same struct value,
after which the followed struct type is re-attached.

## Why

Part of Part V Phase V.3 of the IREP2 migration (`docs/irep2-migration.md`,
tracking #4715). Continues the `struct_exprt` literal drain after the
tuple-struct family (#5738/#5740/#5753/#5768) and the Optional wrapper.

The full-type re-attach (`slice_expr.type() = struct_type`) is load-bearing:
`migrate_type` round-tripping the followed C-model `PySliceObject` struct does
not reproduce the per-component `#cpp_type` attributes / padding layout, and
downstream call-site coercion keys off the exact `struct_typet`. Members are
built as legacy value exprs and migrated, so nondet bounds and padding
round-trip with no operand surgery; the struct source location is set on the
returned expr exactly as before.

## Testing

- `--goto-functions-only` output **byte-identical** (0-line diff) on both a
  constant-bound `slice()` call (`github_4523_slice_call`) and a nondet-bound
  slice (`string-nondet-slice-success`, exercising `s[:2]`), verified A/B
  against a clean pre-patch rebuild.
- **47/47** slice regression tests pass (`*slice*` across python/, numpy/,
  and the solidity/try_catch incidental matches).
- clang-format (11) clean.

Refs #4715.
