### PR TITLE
[goto-cov] list unreached assertions in assertion-coverage output

### DIFF
--- a/regression/goto-coverage/discussion_5745_all_reached/main.c
+++ b/regression/goto-coverage/discussion_5745_all_reached/main.c
@@ -1,0 +1,11 @@
+int nondet_int();
+
+int main()
+{
+  int a = nondet_int();
+  __ESBMC_assert(a == a, "a equals itself");
+  if (a > 0)
+    __ESBMC_assert(a > 0, "positive branch");
+  else
+    __ESBMC_assert(a <= 0, "non-positive branch");
+}

--- a/regression/goto-coverage/discussion_5745_all_reached/test.desc
+++ b/regression/goto-coverage/discussion_5745_all_reached/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--assertion-coverage-claims
+Reached Assertion Instances: 3
+Unreached Asserts: 0
+Assertion Instances Coverage: 100%
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/discussion_5745_unreached/main.c
+++ b/regression/goto-coverage/discussion_5745_unreached/main.c
@@ -1,0 +1,33 @@
+int nondet_int();
+
+/* Branches hold two assertions each so goto_convert's guarded-assertion
+   folding (which only fires on a single assert(false) branch body) does not
+   apply: the asserts must stay behind the branch for the unreached-claims
+   listing to observe their reachability. */
+int main()
+{
+  if (3 > 0)
+  {
+    __ESBMC_assert(1, "reachable concrete then");
+  }
+  else
+  {
+    __ESBMC_assert(0, "dead concrete else A");
+    __ESBMC_assert(1, "dead concrete else B");
+  }
+
+  int a = nondet_int();
+  if (a % 2)
+    ++a;
+  __ESBMC_assert(a % 2 == 0, "a is even");
+
+  if (a % 2)
+  {
+    __ESBMC_assert(0, "dead symbolic then A");
+    __ESBMC_assert(1, "dead symbolic then B");
+  }
+  else
+  {
+    __ESBMC_assert(1, "reachable symbolic else");
+  }
+}

--- a/regression/goto-coverage/discussion_5745_unreached/test.desc
+++ b/regression/goto-coverage/discussion_5745_unreached/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--assertion-coverage-claims
+Reached Assertion Instances: 3
+Unreached Asserts: 4
+dead concrete else A.*main.c line 15.* : UNREACHED
+dead concrete else B.*main.c line 16.* : UNREACHED
+dead symbolic then A.*main.c line 26.* : UNREACHED
+dead symbolic then B.*main.c line 27.* : UNREACHED
+Assertion Instances Coverage: 42.8
+^VERIFICATION FAILED$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -40,6 +40,7 @@
 #include <util/time_stopping.h>
 #include <util/cache.h>
 #include <atomic>
+#include <vector>
 #include <nlohmann/json.hpp>
 
 std::unordered_set<std::string> goto_functionst::reached_claims;
@@ -768,9 +769,23 @@ void report_coverage(
     const int tracked_instance = reached_mul_claims.size();
     const int total_instance = goto_coveraget::total_assert_ins;
 
+    // Assertions never observed during symbolic execution: either their
+    // branch was pruned by a constant guard, or their path guard is
+    // unsatisfiable so the claim is vacuously valid (discussion #5745).
+    std::vector<std::string> unreached_claims;
+    for (const auto &[claim_msg, claim_loc] : goto_coveraget::all_claims)
+    {
+      const std::string claim_sig = claim_msg + "\t" + claim_loc;
+      if (reached_mul_claims.count(claim_sig) == 0)
+        unreached_claims.push_back(claim_sig);
+    }
+
     log_success("\n[Coverage]\n");
     // The total assertion instances include the assert inside the source file, the unwinding asserts, the claims inserted during the goto-check and so on.
+    // "Total/Unreached Asserts" count static claims; the "Instances" lines
+    // count their goto-unwound copies.
     log_result("Total Asserts: {}", total);
+    log_result("Unreached Asserts: {}", unreached_claims.size());
     if (total_instance >= tracked_instance)
       log_result("Total Assertion Instances: {}", total_instance);
     else
@@ -786,7 +801,12 @@ void report_coverage(
       // reached claims:
       for (const auto &claim : reached_mul_claims)
       {
-        log_status("  {}", prettify_solidity_expr(claim));
+        log_status("  {} : REACHED", prettify_solidity_expr(claim));
+      }
+      // unreached claims:
+      for (const auto &claim : unreached_claims)
+      {
+        log_status("  {} : UNREACHED", prettify_solidity_expr(claim));
       }
     }
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -734,7 +734,8 @@ const struct group_opt_templ all_cmd_options[] = {
      {"assertion-coverage", NULL, "Show the coverage of assertion statements"},
      {"assertion-coverage-claims",
       NULL,
-      "Enable assertion-coverage and shows all reached claims"},
+      "Enable assertion-coverage and show all claims, "
+      "both reached and unreached"},
      {"condition-coverage",
       NULL,
       "This activates --multi-property, "


### PR DESCRIPTION
--assertion-coverage-claims previously printed only reached claims, so
assertions in dead code (constant-guard-pruned or unsatisfiable-guard
branches) vanished silently. report_coverage now diffs the static claim
set against the reached multiset, prints an "Unreached Asserts" summary
line, and tags each listed claim REACHED/UNREACHED. Adds a regression
pair covering both sides. Addresses discussion #5745.
