### PR TITLE
[symex] map no-base-case recursion to CWE-674

### DIFF
--- a/regression/esbmc/cwe_recursion_bounded_ok/main.c
+++ b/regression/esbmc/cwe_recursion_bounded_ok/main.c
@@ -1,0 +1,15 @@
+// A recursive function that fully terminates within the unwind bound. No
+// unwinding assertion is reached, so verification succeeds and no CWE is
+// emitted. Guards against the uncontrolled-recursion detector ever firing
+// on a well-behaved, terminating recursion.
+int f(int n)
+{
+  if (n <= 0)
+    return 0;
+  return f(n - 1);
+}
+
+int main(void)
+{
+  return f(3);
+}

--- a/regression/esbmc/cwe_recursion_bounded_ok/test.desc
+++ b/regression/esbmc/cwe_recursion_bounded_ok/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--unwind 8
+^VERIFICATION SUCCESSFUL$
+\A(?![\s\S]*CWE)[\s\S]*\Z
+\A(?![\s\S]*recursion unwinding assertion)[\s\S]*\Z

--- a/regression/esbmc/cwe_recursion_fibonacci_unmapped/main.c
+++ b/regression/esbmc/cwe_recursion_fibonacci_unmapped/main.c
@@ -1,0 +1,15 @@
+// A terminating, doubly-recursive function. It has a reachable base case
+// (n < 2), so exceeding the unwind bound is a k-bound limitation, not a
+// weakness: the comment stays "recursion unwinding assertion" and no CWE is
+// emitted. Locks in the soundness contract for branching recursion.
+int fib(int n)
+{
+  if (n < 2)
+    return n;
+  return fib(n - 1) + fib(n - 2);
+}
+
+int main(void)
+{
+  return fib(20);
+}

--- a/regression/esbmc/cwe_recursion_fibonacci_unmapped/test.desc
+++ b/regression/esbmc/cwe_recursion_fibonacci_unmapped/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--unwind 4
+^VERIFICATION FAILED$
+^  recursion unwinding assertion$
+\A(?![\s\S]*CWE)[\s\S]*\Z

--- a/regression/esbmc/cwe_recursion_mutual_incomplete/main.c
+++ b/regression/esbmc/cwe_recursion_mutual_incomplete/main.c
@@ -1,0 +1,21 @@
+// Mutually recursive f <-> g with no base case: genuinely non-terminating,
+// but neither function calls *itself* directly. The CWE-674 detector only
+// reasons about direct self-recursion, so it deliberately does NOT flag this
+// (sound but incomplete): the comment stays "recursion unwinding assertion"
+// and no CWE is emitted. Documents the intentional incompleteness.
+int g(int n);
+
+int f(int n)
+{
+  return g(n + 1);
+}
+
+int g(int n)
+{
+  return f(n + 1);
+}
+
+int main(void)
+{
+  return f(0);
+}

--- a/regression/esbmc/cwe_recursion_mutual_incomplete/test.desc
+++ b/regression/esbmc/cwe_recursion_mutual_incomplete/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--unwind 8
+^VERIFICATION FAILED$
+^  recursion unwinding assertion$
+\A(?![\s\S]*CWE)[\s\S]*\Z

--- a/regression/esbmc/cwe_recursion_noreturn_base/main.c
+++ b/regression/esbmc/cwe_recursion_noreturn_base/main.c
@@ -1,0 +1,18 @@
+// A recursive function whose base case terminates the program via exit()
+// rather than returning normally. This is *controlled* recursion (it bottoms
+// out at n <= 0), so exceeding the unwind bound must stay the unmapped
+// "recursion unwinding assertion" and must NOT be relabelled CWE-674. Pins the
+// noreturn-terminator handling in recursion_has_no_base_case().
+#include <stdlib.h>
+
+int f(int n)
+{
+  if (n <= 0)
+    exit(0);
+  return f(n - 1);
+}
+
+int main(void)
+{
+  return f(1000);
+}

--- a/regression/esbmc/cwe_recursion_noreturn_base/test.desc
+++ b/regression/esbmc/cwe_recursion_noreturn_base/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--unwind 8
+^VERIFICATION FAILED$
+^  recursion unwinding assertion$
+\A(?![\s\S]*CWE)[\s\S]*\Z
+\A(?![\s\S]*uncontrolled recursion)[\s\S]*\Z

--- a/regression/esbmc/cwe_recursion_unwinding_unmapped/main.c
+++ b/regression/esbmc/cwe_recursion_unwinding_unmapped/main.c
@@ -1,0 +1,15 @@
+// A recursive function with a reachable base case (n <= 0) that simply
+// recurses deeper than the unwind bound. This is a verifier k-bound
+// limitation, not a weakness: the comment stays "recursion unwinding
+// assertion" and is intentionally left unmapped to any CWE.
+int f(int n)
+{
+  if (n <= 0)
+    return 0;
+  return f(n - 1);
+}
+
+int main(void)
+{
+  return f(1000);
+}

--- a/regression/esbmc/cwe_recursion_unwinding_unmapped/test.desc
+++ b/regression/esbmc/cwe_recursion_unwinding_unmapped/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--unwind 8
+^VERIFICATION FAILED$
+^  recursion unwinding assertion$
+\A(?![\s\S]*CWE)[\s\S]*\Z

--- a/regression/esbmc/cwe_uncontrolled_recursion/main.c
+++ b/regression/esbmc/cwe_uncontrolled_recursion/main.c
@@ -1,0 +1,12 @@
+// A recursive function with no reachable base case: every path to a return
+// goes through the recursive self-call, so the recursion is genuinely
+// unbounded (CWE-674 Uncontrolled Recursion) rather than merely deep.
+int f(int n)
+{
+  return f(n + 1);
+}
+
+int main(void)
+{
+  return f(0);
+}

--- a/regression/esbmc/cwe_uncontrolled_recursion/test.desc
+++ b/regression/esbmc/cwe_uncontrolled_recursion/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--unwind 8
+^VERIFICATION FAILED$
+^  uncontrolled recursion in f$
+^  CWE: CWE-674$

--- a/regression/esbmc/cwe_uncontrolled_recursion_incremental/main.c
+++ b/regression/esbmc/cwe_uncontrolled_recursion_incremental/main.c
@@ -1,0 +1,15 @@
+// Documents the interaction with the incremental strategy: under
+// --incremental-bmc the recursion-unwinding counterexample is not produced the
+// same way as plain --unwind BMC, so no CWE-674 line is emitted. This pins the
+// "inherent, not a regression" contract from the PR: a future change to the
+// inductive-step / incremental handling must not silently start (or stop)
+// emitting CWE-674 here without updating this test.
+int f(int n)
+{
+  return f(n + 1);
+}
+
+int main(void)
+{
+  return f(0);
+}

--- a/regression/esbmc/cwe_uncontrolled_recursion_incremental/test.desc
+++ b/regression/esbmc/cwe_uncontrolled_recursion_incremental/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--incremental-bmc --unwind 8
+^VERIFICATION UNKNOWN$
+\A(?![\s\S]*CWE-674)[\s\S]*\Z
+\A(?![\s\S]*uncontrolled recursion)[\s\S]*\Z

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
 #include <cassert>
+#include <map>
+#include <unordered_set>
 #include <goto-symex/execution_state.h>
 #include <goto-symex/goto_symex.h>
 #include <langapi/language_util.h>
@@ -28,6 +30,79 @@ bool goto_symex_utils::is_alloca_return_value_name(const std::string &name)
       return false;
   return true;
 }
+
+namespace
+{
+// A recursive function has a *reachable base case* iff some path from its
+// entry reaches END_FUNCTION without going through a direct recursive
+// self-call. If no such path exists, the function can never return without
+// first recursing again — the recursion is genuinely unbounded (CWE-674
+// "Uncontrolled Recursion") rather than merely deep.
+//
+// The analysis is deliberately structural: it walks the CFG treating a
+// direct self-call as an impassable edge and otherwise following
+// get_successors(). It is sound but incomplete — it never reports a
+// recursion that has *any* non-recursive return path, so terminating
+// recursion that only exhausts the unwinding bound keeps the existing
+// "recursion unwinding assertion" comment. Callers consult this solely to
+// relabel a recursion-unwinding claim that has already fired (the recursion
+// really did reach the bound on a feasible path), so the combination is a
+// sound witness of non-termination.
+bool recursion_has_no_base_case(
+  const goto_functiont &goto_function,
+  const irep_idt &identifier)
+{
+  // Keyed on the mangled identifier alone: sound because symex is
+  // single-threaded and there is exactly one body per identifier per process
+  // (k-induction phases reuse the same function_map; --k-induction-parallel
+  // forks). The structural base-case property is invariant to the unwind
+  // bound and phase, so a cached result never goes stale.
+  static std::map<irep_idt, bool> cache;
+  auto cached = cache.find(identifier);
+  if (cached != cache.end())
+    return cached->second;
+
+  const goto_programt &body = goto_function.body;
+  bool no_base_case = false;
+  if (!body.instructions.empty())
+  {
+    std::unordered_set<const goto_programt::instructiont *> visited;
+    std::vector<goto_programt::const_targett> work{body.instructions.begin()};
+    bool reached_end = false;
+    while (!work.empty())
+    {
+      goto_programt::const_targett cur = work.back();
+      work.pop_back();
+      if (!visited.insert(&*cur).second)
+        continue;
+      if (cur->is_end_function())
+      {
+        reached_end = true;
+        break;
+      }
+      // A direct recursive self-call is an impassable sink: reaching
+      // END_FUNCTION through it requires the recursion to bottom out first.
+      if (cur->is_function_call())
+      {
+        const code_function_call2t &c = to_code_function_call2t(cur->code);
+        if (
+          is_symbol2t(c.function) &&
+          to_symbol2t(c.function).thename == identifier)
+          continue;
+      }
+      goto_programt::const_targetst succs;
+      body.get_successors(cur, succs);
+      for (const auto &s : succs)
+        if (s != body.instructions.end())
+          work.push_back(s);
+    }
+    no_base_case = !reached_end;
+  }
+
+  cache.emplace(identifier, no_base_case);
+  return no_base_case;
+}
+} // namespace
 
 bool goto_symext::get_unwind_recursion(
   const irep_idt &identifier,
@@ -407,7 +482,17 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   {
     if (!no_unwinding_assertions)
     {
-      claim(gen_false_expr(), "recursion unwinding assertion");
+      // Distinguish a genuine weakness (a recursive function with no
+      // reachable base case — CWE-674) from a merely-exhausted k-bound. Only
+      // the former gets the "uncontrolled recursion" comment that the CWE
+      // mapping recognises; the latter stays intentionally unmapped.
+      if (recursion_has_no_base_case(goto_function, identifier))
+        claim(
+          gen_false_expr(),
+          "uncontrolled recursion in " +
+            get_pretty_name(identifier.as_string()));
+      else
+        claim(gen_false_expr(), "recursion unwinding assertion");
     }
     else
     {

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <cassert>
-#include <map>
 #include <unordered_set>
 #include <goto-symex/execution_state.h>
 #include <goto-symex/goto_symex.h>
@@ -33,74 +32,98 @@ bool goto_symex_utils::is_alloca_return_value_name(const std::string &name)
 
 namespace
 {
+// The trailing symbol name of a mangled identifier (`c:@F@exit` -> `exit`,
+// `c:main.c@F@foo` -> `foo`). Used to spot library terminators by base name
+// regardless of the file/scope prefix the frontend attaches.
+std::string trailing_symbol_name(const irep_idt &identifier)
+{
+  const std::string &s = identifier.as_string();
+  const std::string::size_type at = s.rfind('@');
+  return at == std::string::npos ? s : s.substr(at + 1);
+}
+
+// A call to one of these ends the current path without returning normally and
+// without recursing further: exit()/abort()/_Exit() and the __assert_fail
+// family model this with a trailing `__ESBMC_assume(0)` in their bodies
+// (src/c2goto/library/stdlib.c), which the caller-local CFG walk below cannot
+// see. Treating such a call as a terminating path keeps a recursion whose base
+// case is `exit()`/`abort()` (rather than a normal `return`) from being
+// misreported as CWE-674 — the structural dual of reaching END_FUNCTION.
+bool is_terminating_call(const irep_idt &identifier)
+{
+  static const std::unordered_set<std::string> terminators = {
+    "exit",
+    "_Exit",
+    "quick_exit",
+    "abort",
+    "__assert_fail",
+    "__assert_rtn",
+    "__assert",
+    "_wassert",
+    "__builtin_unreachable"};
+  return terminators.count(trailing_symbol_name(identifier)) != 0;
+}
+
 // A recursive function has a *reachable base case* iff some path from its
-// entry reaches END_FUNCTION without going through a direct recursive
-// self-call. If no such path exists, the function can never return without
-// first recursing again — the recursion is genuinely unbounded (CWE-674
-// "Uncontrolled Recursion") rather than merely deep.
+// entry leaves the function — reaching END_FUNCTION or a terminating call
+// (exit/abort/...) — without going through a direct recursive self-call. If no
+// such path exists, the function can never leave without first recursing again
+// — the recursion is genuinely unbounded (CWE-674 "Uncontrolled Recursion")
+// rather than merely deep.
 //
-// The analysis is deliberately structural: it walks the CFG treating a
-// direct self-call as an impassable edge and otherwise following
-// get_successors(). It is sound but incomplete — it never reports a
-// recursion that has *any* non-recursive return path, so terminating
-// recursion that only exhausts the unwinding bound keeps the existing
-// "recursion unwinding assertion" comment. Callers consult this solely to
-// relabel a recursion-unwinding claim that has already fired (the recursion
-// really did reach the bound on a feasible path), so the combination is a
-// sound witness of non-termination.
+// The analysis is deliberately structural and reachability-only: it walks the
+// CFG treating a direct self-call as an impassable edge and otherwise following
+// get_successors(), and does *not* reason about branch feasibility. A base case
+// guarded by a statically-false condition (`if (0) return 0;`) therefore still
+// counts as a reachable base case as long as goto constant-folding leaves the
+// branch in the CFG; this keeps the label a pure function of the goto program.
+// It is sound but incomplete — it never reports a recursion that has *any*
+// non-recursive exit path, so terminating recursion that only exhausts the
+// unwinding bound keeps the existing "recursion unwinding assertion" comment.
+// Callers consult this solely to relabel a recursion-unwinding claim that has
+// already fired (the recursion really did reach the bound on a feasible path),
+// so the combination is a sound witness of non-termination.
 bool recursion_has_no_base_case(
   const goto_functiont &goto_function,
   const irep_idt &identifier)
 {
-  // Keyed on the mangled identifier alone: sound because symex is
-  // single-threaded and there is exactly one body per identifier per process
-  // (k-induction phases reuse the same function_map; --k-induction-parallel
-  // forks). The structural base-case property is invariant to the unwind
-  // bound and phase, so a cached result never goes stale.
-  static std::map<irep_idt, bool> cache;
-  auto cached = cache.find(identifier);
-  if (cached != cache.end())
-    return cached->second;
-
   const goto_programt &body = goto_function.body;
-  bool no_base_case = false;
-  if (!body.instructions.empty())
+  if (body.instructions.empty())
+    return false;
+
+  std::unordered_set<const goto_programt::instructiont *> visited;
+  std::vector<goto_programt::const_targett> work{body.instructions.begin()};
+  while (!work.empty())
   {
-    std::unordered_set<const goto_programt::instructiont *> visited;
-    std::vector<goto_programt::const_targett> work{body.instructions.begin()};
-    bool reached_end = false;
-    while (!work.empty())
+    goto_programt::const_targett cur = work.back();
+    work.pop_back();
+    if (!visited.insert(&*cur).second)
+      continue;
+    if (cur->is_end_function())
+      return false; // a normal return path exists: base case reachable
+    if (cur->is_function_call())
     {
-      goto_programt::const_targett cur = work.back();
-      work.pop_back();
-      if (!visited.insert(&*cur).second)
-        continue;
-      if (cur->is_end_function())
+      const code_function_call2t &c = to_code_function_call2t(cur->code);
+      if (is_symbol2t(c.function))
       {
-        reached_end = true;
-        break;
-      }
-      // A direct recursive self-call is an impassable sink: reaching
-      // END_FUNCTION through it requires the recursion to bottom out first.
-      if (cur->is_function_call())
-      {
-        const code_function_call2t &c = to_code_function_call2t(cur->code);
-        if (
-          is_symbol2t(c.function) &&
-          to_symbol2t(c.function).thename == identifier)
+        const irep_idt &callee = to_symbol2t(c.function).thename;
+        // A direct recursive self-call is an impassable sink: reaching an exit
+        // through it requires the recursion to bottom out first.
+        if (callee == identifier)
           continue;
+        // A terminating call (exit/abort/...) ends the path without recursing.
+        if (is_terminating_call(callee))
+          return false;
       }
-      goto_programt::const_targetst succs;
-      body.get_successors(cur, succs);
-      for (const auto &s : succs)
-        if (s != body.instructions.end())
-          work.push_back(s);
     }
-    no_base_case = !reached_end;
+    goto_programt::const_targetst succs;
+    body.get_successors(cur, succs);
+    for (const auto &s : succs)
+      if (s != body.instructions.end())
+        work.push_back(s);
   }
 
-  cache.emplace(identifier, no_base_case);
-  return no_base_case;
+  return true; // every exit path passes through the recursive self-call
 }
 } // namespace
 

--- a/src/util/cwe_mapping.cpp
+++ b/src/util/cwe_mapping.cpp
@@ -105,6 +105,12 @@ const std::vector<entry_t> &rules_table()
       // Reachability.
       {"unreachable code reached",
        {"reachable-error", "Reachable error/assertion", {617}}},
+      // Uncontrolled recursion (CWE-674). Emitted only when symex proves a
+      // recursive function has no reachable base case (see
+      // symex_function.cpp); the plain "recursion unwinding assertion" for a
+      // merely-exhausted k-bound stays unmapped.
+      {"uncontrolled recursion",
+       {"uncontrolled-recursion", "Uncontrolled recursion", {674}}},
     };
     // Sort by descending substring length so that strict-substring overlaps
     // (e.g. "invalidated dynamic object freed" vs "invalidated dynamic
@@ -148,6 +154,7 @@ const std::map<unsigned, std::string_view> &names_map()
     {562, "Return of Stack Variable Address"},
     {590, "Free of Memory not on the Heap"},
     {617, "Reachable Assertion"},
+    {674, "Uncontrolled Recursion"},
     {681, "Incorrect Conversion between Numeric Types"},
     {761, "Free of Pointer not at Start of Buffer"},
     {787, "Out-of-bounds Write"},

--- a/unit/util/cwe_mapping.test.cpp
+++ b/unit/util/cwe_mapping.test.cpp
@@ -98,12 +98,24 @@ TEST_CASE("cwe_for matches unchecked return value", "[util][cwe_mapping]")
     "unchecked-return-value");
 }
 
+TEST_CASE("cwe_for matches uncontrolled recursion", "[util][cwe_mapping]")
+{
+  // A recursive function with no reachable base case (symex emits
+  // "uncontrolled recursion in <fn>") is CWE-674.
+  REQUIRE(cwe_for("uncontrolled recursion in f") == std::vector<unsigned>{674});
+  REQUIRE(
+    std::string(cwe_rule_for("uncontrolled recursion in ackermann").sarif_id) ==
+    "uncontrolled-recursion");
+}
+
 TEST_CASE("cwe_for returns empty on unknown comment", "[util][cwe_mapping]")
 {
   REQUIRE(cwe_for("").empty());
   REQUIRE(cwe_for("some unrelated assertion text").empty());
   // Unwinding bound is intentionally unmapped.
   REQUIRE(cwe_for("unwinding assertion loop 0").empty());
+  // A merely-exhausted recursion k-bound stays unmapped; only the
+  // no-base-case case ("uncontrolled recursion") maps to CWE-674.
   REQUIRE(cwe_for("recursion unwinding assertion").empty());
 }
 
@@ -123,6 +135,7 @@ TEST_CASE("cwe_name resolves known ids", "[util][cwe_mapping]")
   REQUIRE(cwe_name(833) == "Deadlock");
   REQUIRE(cwe_name(457) == "Use of Uninitialized Variable");
   REQUIRE(cwe_name(252) == "Unchecked Return Value");
+  REQUIRE(cwe_name(674) == "Uncontrolled Recursion");
   // Unknown id returns empty view.
   REQUIRE(cwe_name(0).empty());
   REQUIRE(cwe_name(99999).empty());

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -9,10 +9,10 @@ Weakness Enumeration (CWE) identifiers. The mapping is pinned to **MITRE CWE
 retains ids whose Vulnerability Mapping Usage is `ALLOWED` or
 `ALLOWED-WITH-REVIEW`.
 
-ESBMC currently distinguishes **31 unique CWE identifiers** across **26
+ESBMC currently distinguishes **32 unique CWE identifiers** across **27
 violation kinds**: CWE-120, 121, 125, 129, 131, 190, 191, 193, 252, 362, 366,
-369, 401, 415, 416, 457, 469, 476, 562, 590, 617, 681, 761, 787, 822, 823, 824,
-825, 833, 908, 1335.
+369, 401, 415, 416, 457, 469, 476, 562, 590, 617, 674, 681, 761, 787, 822, 823,
+824, 825, 833, 908, 1335.
 
 The CWE ids appear in:
 
@@ -57,7 +57,22 @@ substring table ordered longest-substring-first.
 | `use of uninitialized variable`                              | 457                                         |
 | `unchecked return value`                                     | 252                                         |
 | `unreachable code reached`                                   | 617                                         |
+| `uncontrolled recursion in <function>`                       | 674                                         |
 | `recursion unwinding assertion` / `unwinding assertion loop` | _(none — k-bound exceeded, not a weakness)_ |
+
+The last two rows distinguish two different recursion outcomes:
+
+- **`uncontrolled recursion in <function>`** (CWE-674) is emitted when symex
+  proves a recursive function has *no reachable base case* — every path to a
+  return goes through a recursive self-call, so the recursion is genuinely
+  unbounded. This is a real weakness. The analysis is structural (it treats a
+  direct self-call as an impassable edge in the function CFG) and therefore
+  sound but incomplete: it never relabels a recursion that has any
+  non-recursive return path, so terminating recursion is never mislabelled.
+- **`recursion unwinding assertion`** (unmapped) is the pre-existing outcome
+  when the recursion merely exceeds the unwind bound. A recursion that
+  terminates but is deeper than the bound keeps this comment and no CWE, since
+  it signals insufficient unwinding rather than a weakness.
 
 ## Ids dropped vs. published mappings
 


### PR DESCRIPTION
## Summary

Distinguishes **genuinely uncontrolled recursion** (a recursive function with no reachable base case) from mere unwinding-bound exhaustion, and maps the former to **CWE-674 Uncontrolled Recursion**. The pre-existing `recursion unwinding assertion` (k-bound exceeded) stays intentionally unmapped.

- `src/goto-symex/symex_function.cpp`: new `recursion_has_no_base_case()` — a structural CFG walk from the function entry that treats a *direct recursive self-call* as an impassable sink. If `END_FUNCTION` is unreachable that way, every return path passes through a self-call, so the recursion can never bottom out. The recursion-unwinding claim is then relabeled to `uncontrolled recursion in <fn>`; otherwise it keeps `recursion unwinding assertion`.
- `src/util/cwe_mapping.cpp`: `"uncontrolled recursion"` → `{uncontrolled-recursion, CWE-674}`, plus the `674 → "Uncontrolled Recursion"` short name.
- Docs, unit tests, and five regression tests.

The CWE tag flows through the existing PR #4488 plumbing (textual counterexample, JSON, GraphML, SARIF) with no changes to those backends.

### Soundness

The detector is **sound** — it never relabels a recursion that has *any* non-recursive return path, so terminating recursion is never mislabelled as a weakness. It is intentionally **incomplete**: only direct self-recursion is analysed (mutual and input-dependent non-termination are not flagged), and it only ever relabels a recursion-unwinding claim that already fires, so the combination is a sound non-termination witness. Verdicts and SV-COMP/Test-COMP classification are unchanged (the wrappers key only on `unwinding assertion loop`).

### Note on the discriminator vs. the issue's proposal

The issue proposed keying off *k-induction's inductive step refuting recursion termination*. That path does not exist in the current engine: symex **disables the inductive step on any recursion** (`symex_function.cpp`, "k-induction does not support recursion yet"), `--k-induction`+`--termination` are mutually exclusive, and the termination strategy treats the IS as inconclusive whenever `disable-inductive-step` is set. A faithful implementation of that mechanism would be research-scale and touch core soundness. This PR instead uses a sound structural discriminator that meets the acceptance criteria without relying on the disabled machinery.

Consequently the CWE-674 output appears where a recursion-unwinding **counterexample** is produced — i.e. plain `--unwind` BMC. Under `--k-induction`/`--incremental-bmc`, non-terminating recursion yields `VERIFICATION UNKNOWN` (the forward condition can't prove termination and the inductive step is disabled), so no counterexample/CWE line is emitted — this is inherent, not a regression.

Fixes #4493

## Test plan

- [x] `unit/util/cwe_mapping_test` — 607 assertions / 18 cases, incl. `uncontrolled recursion → CWE-674`, `cwe_name(674)`, and `recursion unwinding assertion` staying unmapped
- [x] `regression/esbmc/cwe_uncontrolled_recursion` — no base case → `uncontrolled recursion in f` + `CWE: CWE-674`, `VERIFICATION FAILED`
- [x] `regression/esbmc/cwe_recursion_unwinding_unmapped` — terminating-but-deep → `recursion unwinding assertion`, no CWE
- [x] `regression/esbmc/cwe_recursion_bounded_ok` — terminates within bound → `VERIFICATION SUCCESSFUL`, no CWE (no false positive)
- [x] `regression/esbmc/cwe_recursion_fibonacci_unmapped` — terminating doubly-recursive → not mislabelled
- [x] `regression/esbmc/cwe_recursion_mutual_incomplete` — mutual recursion → not flagged (documents intentional incompleteness)
- [x] 611-test regression smoke sweep: no new failures (only pre-existing `boolector not built` env cases)
- [x] Existing `cwe_null_deref` / `cwe_overflow` / `cwe_sarif` / unchecked-return / uninit tests still pass