### PR TITLE
[esbmc] Detect excessive allocation sizes (CWE-789)

### DIFF
--- a/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new/main.cpp
+++ b/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new/main.cpp
@@ -1,0 +1,12 @@
+extern unsigned nondet_uint();
+
+int main()
+{
+  // operator new[n] with attacker-controlled n: the pass scales the element
+  // count by sizeof(int), so the byte request is unbounded above the default
+  // 1 MiB --excessive-alloc-check limit (CWE-789).
+  unsigned n = nondet_uint();
+  int *p = new int[n];
+  delete[] p;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new/main.cpp
+++ b/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new/main.cpp
@@ -2,9 +2,9 @@ extern unsigned nondet_uint();
 
 int main()
 {
-  // operator new[n] with attacker-controlled n: the pass scales the element
-  // count by sizeof(int), so the byte request is unbounded above the default
-  // 1 MiB --excessive-alloc-check limit (CWE-789).
+  // operator new[n] with attacker-controlled n: the Clang frontend pre-scales
+  // the element count by sizeof(int) to a byte request (do_cpp_new), unbounded
+  // above the default 1 MiB --excessive-alloc-check limit (CWE-789).
   unsigned n = nondet_uint();
   int *p = new int[n];
   delete[] p;

--- a/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new/test.desc
+++ b/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION FAILED$
+^  excessive allocation size: operator new\[\]$
+^  CWE: CWE-789$

--- a/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new_pass/main.cpp
+++ b/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new_pass/main.cpp
@@ -1,0 +1,15 @@
+extern unsigned nondet_uint();
+
+int main()
+{
+  // Passing companion to cwe_excessive_alloc_new: operator new[n] with a bounded
+  // n must succeed. n <= 256 => 256 * sizeof(int) = 1024 bytes, under the 1 MiB
+  // default. Guards the new[] byte scaling against over-counting.
+  unsigned n = nondet_uint();
+  if (n <= 256)
+  {
+    int *p = new int[n];
+    delete[] p;
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new_pass/test.desc
+++ b/regression/esbmc-cpp/cpp/cwe_excessive_alloc_new_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_excessive_alloc/main.c
+++ b/regression/esbmc/cwe_excessive_alloc/main.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  // Attacker-controlled, unbounded allocation size (CWE-789): n can be up to
+  // UINT_MAX, well above the default 1 MiB --excessive-alloc-check bound.
+  unsigned n = __VERIFIER_nondet_uint();
+  char *p = malloc(n);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION FAILED$
+^  excessive allocation size: malloc$
+^  CWE: CWE-789$

--- a/regression/esbmc/cwe_excessive_alloc_boundary_fail/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_boundary_fail/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+// A request of 100 bytes against a bound of 99 exceeds K by one byte and must
+// be flagged. Together with cwe_excessive_alloc_boundary_ok this pins the
+// exact `size <= K` boundary against a silent off-by-one regression.
+int main(void)
+{
+  char *p = malloc(100);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_boundary_fail/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_boundary_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--excessive-alloc-check=99 --incremental-bmc
+^VERIFICATION FAILED$
+^  excessive allocation size: malloc$
+^  CWE: CWE-789$

--- a/regression/esbmc/cwe_excessive_alloc_boundary_ok/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_boundary_ok/main.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+// A request of exactly K bytes must pass: the bound is `size <= K`, so K is
+// allowed and only K+1 is flagged. Pins the off-by-one direction of the check.
+int main(void)
+{
+  char *p = malloc(100);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_boundary_ok/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_boundary_ok/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--excessive-alloc-check=100 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_excessive_alloc_calloc/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_calloc/main.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+// calloc has no inline sideeffect lowering; it is a real function whose
+// operational model (src/c2goto/library/stdlib.c) allocates via malloc. The
+// excessive-size pass instruments that model body, so an attacker-controlled
+// calloc size is still flagged CWE-789. The finding is reported at the model's
+// malloc site rather than this call site (documented limitation), so only the
+// message and CWE tag are anchored here, not the location.
+int main(void)
+{
+  unsigned n = __VERIFIER_nondet_uint();
+  char *p = calloc(n, 1);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_calloc/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_calloc/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION FAILED$
+excessive allocation size: malloc
+^  CWE: CWE-789$

--- a/regression/esbmc/cwe_excessive_alloc_invalid/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_invalid/main.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+
+int main(void)
+{
+  char *p = malloc(8);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_invalid/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_invalid/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--excessive-alloc-check=0 --incremental-bmc
+^ERROR: --excessive-alloc-check=K requires K >= 1 \(got 0\)$

--- a/regression/esbmc/cwe_excessive_alloc_pass/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_pass/main.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  // The size is bounded well below the default 1 MiB
+  // --excessive-alloc-check limit, so no path can reach an excessive
+  // allocation: verification succeeds silently.
+  unsigned n = __VERIFIER_nondet_uint();
+  if (n <= 1024)
+  {
+    char *p = malloc(n);
+    free(p);
+  }
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_pass/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_excessive_alloc_realloc/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_realloc/main.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  // --force-malloc-success makes the initial 8-byte allocation non-NULL, so
+  // the frontend's `p == 0 ? malloc(n) : realloc(p, n)` lowering takes the
+  // realloc branch, where the attacker-controlled n is unbounded (CWE-789).
+  char *p = malloc(8);
+  unsigned n = __VERIFIER_nondet_uint();
+  p = realloc(p, n);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_realloc/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_realloc/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--excessive-alloc-check --force-malloc-success --incremental-bmc
+^VERIFICATION FAILED$
+^  excessive allocation size: realloc$
+^  CWE: CWE-789$

--- a/regression/esbmc/cwe_excessive_alloc_sarif/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_sarif/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  unsigned n = __VERIFIER_nondet_uint();
+  char *p = malloc(n);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_sarif/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_sarif/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--excessive-alloc-check --incremental-bmc --sarif-output -
+^VERIFICATION FAILED$
+"ruleId": "excessive-allocation"
+"external/cwe/cwe-789"
+"id": "789"
+"name": "CWE"
+"version": "4.20"

--- a/regression/esbmc/cwe_excessive_alloc_typed/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_typed/main.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+
+// A bare malloc(sizeof(T)) is lowered to element-count 1 with element type T
+// (never a raw byte count), so the excessive-size check must scale by
+// sizeof(T). Here sizeof(struct Huge) is 2 MiB > the default 1 MiB bound, so
+// the allocation must be flagged CWE-789. Pins the typed-size scaling fix:
+// without it the check would compare 1 <= K and pass silently.
+struct Huge
+{
+  char b[2 * 1024 * 1024];
+};
+
+int main(void)
+{
+  struct Huge *p = malloc(sizeof(struct Huge));
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_typed/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_typed/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION FAILED$
+^  excessive allocation size: malloc$
+^  CWE: CWE-789$

--- a/regression/esbmc/cwe_excessive_alloc_typed_pass/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_typed_pass/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+// Passing companion to cwe_excessive_alloc_typed: a typed malloc(sizeof(T))
+// whose real byte size (1000) is under the bound must succeed. Guards the typed
+// size scaling against over-counting: a spurious extra sizeof factor
+// (1000 * 1000) would push the request past the 2000-byte bound and wrongly
+// FAIL. Together with cwe_excessive_alloc_typed this brackets the scaling from
+// both sides, mirroring the vla / vla_pass pair.
+struct Mid
+{
+  char b[1000];
+};
+
+int main(void)
+{
+  struct Mid *p = malloc(sizeof(struct Mid));
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_typed_pass/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_typed_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--excessive-alloc-check=2000 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_excessive_alloc_vla/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_vla/main.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  // sizeof(int[n]) is a VLA type: the frontend records element count 1 with a
+  // dynamically-sized array element type, so type_byte_size throws and the
+  // check must fall back to the symbolic byte size (n * sizeof(int)) rather
+  // than skip the allocation. Unbounded n can exceed the 1 MiB bound (CWE-789).
+  unsigned n = __VERIFIER_nondet_uint();
+  int *p = malloc(sizeof(int[n]));
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_vla/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_vla/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION FAILED$
+^  excessive allocation size: malloc$
+^  CWE: CWE-789$

--- a/regression/esbmc/cwe_excessive_alloc_vla_pass/main.c
+++ b/regression/esbmc/cwe_excessive_alloc_vla_pass/main.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  // Bounded VLA request: n <= 512 => sizeof(int[n]) <= 2048 bytes, well under
+  // the 1 MiB default. This also guards the symbolic scaling against
+  // over-counting: a spurious n*n byte term (16 MiB at n=512) would push the
+  // request past the bound and wrongly FAIL.
+  unsigned n = __VERIFIER_nondet_uint();
+  if (n <= 512)
+  {
+    int *p = malloc(sizeof(int[n]));
+    free(p);
+  }
+  return 0;
+}

--- a/regression/esbmc/cwe_excessive_alloc_vla_pass/test.desc
+++ b/regression/esbmc/cwe_excessive_alloc_vla_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--excessive-alloc-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -712,6 +712,17 @@ const struct group_opt_templ all_cmd_options[] = {
     {"dead-store-check",
      NULL,
      "Emit advisory notes for dead stores / assignments never read (CWE-563)"},
+    {"excessive-alloc-check",
+     // Optional bound: bare flag uses the implicit 1 MiB (1048576-byte)
+     // default; --excessive-alloc-check=K sets the byte bound to K. `int`
+     // (not a wider type) because cmdlinet only stringifies int / string /
+     // vector<int> values; the 2 GiB ceiling is far past any meaningful
+     // "excessive" threshold.
+     boost::program_options::value<int>()->implicit_value(1048576)->value_name(
+       "bytes"),
+     "Enable check for allocations (malloc/calloc/realloc/new[]) whose size "
+     "can exceed K bytes; give the bound attached as --excessive-alloc-check=K "
+     "(default 1 MiB) (CWE-789)"},
     {"volatile-check", NULL, "Enable check for volatile variable"},
     {"stack-limit",
      boost::program_options::value<int>()->default_value(-1)->value_name(

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -721,8 +721,10 @@ const struct group_opt_templ all_cmd_options[] = {
      boost::program_options::value<int>()->implicit_value(1048576)->value_name(
        "bytes"),
      "Enable check for allocations (malloc/calloc/realloc/new[]) whose size "
-     "can exceed K bytes; give the bound attached as --excessive-alloc-check=K "
-     "(default 1 MiB) (CWE-789)"},
+     "can exceed K bytes; attach the bound with '=' as "
+     "--excessive-alloc-check=K "
+     "(a space-separated value is treated as an input file), default 1 MiB "
+     "(CWE-789)"},
     {"volatile-check", NULL, "Enable check for volatile variable"},
     {"stack-limit",
      boost::program_options::value<int>()->default_value(-1)->value_name(

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -185,6 +185,9 @@ int esbmc_parseoptionst::doit()
     // implicit 1 MiB default (see options.cpp).
     if (cmdline.isset("excessive-alloc-check"))
     {
+      // boost's value<int> already validated this as an int at parse time (as
+      // --unwind / --k-path-coverage do), so atoi only reads it back and never
+      // sees the non-numeric input that would make it silently yield 0.
       int k = atoi(cmdline.getval("excessive-alloc-check"));
       if (k <= 0)
       {

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -63,6 +63,7 @@ extern "C"
 #include <goto-programs/loop_unroll.h>
 #include <goto-programs/goto_check_uninit_vars.h>
 #include <goto-programs/goto_check_unchecked_return.h>
+#include <goto-programs/goto_check_excessive_alloc.h>
 #include <goto-programs/dead_store_analysis.h>
 #include <goto-programs/mark_decl_as_non_det.h>
 #include <goto-programs/assign_params_as_non_det.h>
@@ -178,6 +179,21 @@ int esbmc_parseoptionst::doit()
     if (cmdline.isset("unchecked-return-value-check"))
       goto_preprocess_algorithms.emplace_back(
         std::make_unique<goto_check_unchecked_return>(context));
+
+    // Excessive-allocation-size check (CWE-789). The bound K is the byte
+    // limit above which an allocation size is flagged; a bare flag uses the
+    // implicit 1 MiB default (see options.cpp).
+    if (cmdline.isset("excessive-alloc-check"))
+    {
+      int k = atoi(cmdline.getval("excessive-alloc-check"));
+      if (k <= 0)
+      {
+        log_error("--excessive-alloc-check=K requires K >= 1 (got {})", k);
+        return 1;
+      }
+      goto_preprocess_algorithms.emplace_back(
+        std::make_unique<goto_check_excessive_alloc>(context, BigInt(k)));
+    }
 
     // Dead-store advisory (CWE-563). Must also run before mark_decl_as_non_det,
     // which rewrites uninitialised DECLs into `DECL; ASSIGN x = nondet` — that

--- a/src/goto-programs/CMakeLists.txt
+++ b/src/goto-programs/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(gotoprograms goto_convert.cpp goto_function.cpp goto_main.cpp
   loop_numbers.cpp goto_loops.cpp goto_loop_simplify.cpp write_goto_binary.cpp
   goto_k_induction.cpp goto_termination.cpp loopst.cpp goto_coverage.cpp goto_coverage_rm.cpp k_path_spanning.cpp goto_cfg.cpp goto_loop_invariant.cpp
   goto_atomicity_check.cpp frame_enforcer.cpp contracts/contracts.cpp)
-add_library(gotoalgorithms loop_unroll.cpp mark_decl_as_non_det.cpp assign_params_as_non_det.cpp goto_check_uninit_vars.cpp goto_check_unchecked_return.cpp dead_store_analysis.cpp)
+add_library(gotoalgorithms loop_unroll.cpp mark_decl_as_non_det.cpp assign_params_as_non_det.cpp goto_check_uninit_vars.cpp goto_check_unchecked_return.cpp dead_store_analysis.cpp goto_check_excessive_alloc.cpp)
 
 if(ENABLE_GOTO_CONTRACTOR)
     include(SetupIbex)

--- a/src/goto-programs/goto_check_excessive_alloc.cpp
+++ b/src/goto-programs/goto_check_excessive_alloc.cpp
@@ -47,7 +47,7 @@ expr2tc alloc_byte_size(const sideeffect2t &se, const namespacet &ns)
   if (size->type != size_type2())
     size = typecast2tc(size_type2(), size);
 
-  // A char/unknown element type is already a byte count: no scaling needed.
+  // An unknown (nil/empty) element type is already a byte count: no scaling.
   if (is_nil_type(se.alloctype) || is_empty_type(se.alloctype))
     return size;
 
@@ -57,35 +57,14 @@ expr2tc alloc_byte_size(const sideeffect2t &se, const namespacet &ns)
     // uses to model the allocation. A count near 2^64 can wrap the product to
     // a small value and slip under K — a false negative, never a false
     // positive; it mirrors the model rather than contradicting it.
-    BigInt elem_bytes = type_byte_size(se.alloctype, &ns);
-    if (elem_bytes == 1)
-      return size; // sizeof(char)-equivalent: avoid a redundant `* 1`
-    return mul2tc(
-      size_type2(), size, constant_int2tc(size_type2(), elem_bytes));
-  }
-  catch (const array_type2t::dyn_sized_array_excp &)
-  {
-    // A dynamically-sized (VLA) element type, e.g. malloc(sizeof(int[n])):
-    // the frontend records size == 1 with a VLA alloctype, so the byte size
-    // is symbolic but still computable. type_byte_size_expr handles dyn-sized
-    // arrays (unlike the BigInt type_byte_size above, which throws), so scale
-    // by the symbolic element size rather than skipping — otherwise a large
-    // runtime n slips under the bound unchecked.
-    try
-    {
-      expr2tc elem_bytes = type_byte_size_expr(se.alloctype, &ns);
-      if (elem_bytes->type != size_type2())
-        elem_bytes = typecast2tc(size_type2(), elem_bytes);
-      return mul2tc(size_type2(), size, elem_bytes);
-    }
-    catch (const array_type2t::array_size_excp &)
-    {
-      return expr2tc(); // nested element size still unknown — skip
-    }
+    // type_byte_size_expr folds a fixed element type to a constant and returns
+    // a symbolic size for a VLA element (e.g. malloc(sizeof(int[n]))), so this
+    // one path covers both.
+    return mul2tc(size_type2(), size, type_byte_size_expr(se.alloctype, &ns));
   }
   catch (const array_type2t::array_size_excp &)
   {
-    // Element type has no size at all (flexible/incomplete array member).
+    // Element type has no finite size (flexible/incomplete array member).
     return expr2tc();
   }
 }
@@ -130,22 +109,15 @@ void collect_allocs(
   if (is_if2t(e))
   {
     const if2t &i = to_if2t(e);
-    const expr2tc not_cond = not2tc(i.cond);
-    collect_allocs(
-      i.true_value,
-      is_nil_expr(guard) ? i.cond : and2tc(guard, i.cond),
-      ns,
-      out);
-    collect_allocs(
-      i.false_value,
-      is_nil_expr(guard) ? not_cond : and2tc(guard, not_cond),
-      ns,
-      out);
+    auto extend = [&](const expr2tc &c)
+    { return is_nil_expr(guard) ? c : and2tc(guard, c); };
+    collect_allocs(i.true_value, extend(i.cond), ns, out);
+    collect_allocs(i.false_value, extend(not2tc(i.cond)), ns, out);
     return;
   }
 
-  e->foreach_operand(
-    [&](const expr2tc &op) { collect_allocs(op, guard, ns, out); });
+  e->foreach_operand([&](const expr2tc &op)
+                     { collect_allocs(op, guard, ns, out); });
 }
 } // namespace
 
@@ -189,8 +161,10 @@ bool goto_check_excessive_alloc::runOnFunction(
       work.emplace_back(it, std::move(sites));
   }
 
+  if (work.empty())
+    return false;
+
   const expr2tc bound = constant_int2tc(size_type2(), max_alloc_bytes);
-  bool changed = false;
   for (auto &[it, sites] : work)
   {
     // Snapshot before inserting: each insert_swap splices a new ASSERT into
@@ -204,7 +178,7 @@ bool goto_check_excessive_alloc::runOnFunction(
       // conditional so a not-taken branch cannot raise a false witness.
       expr2tc cond = lessthanequal2tc(site.byte_size, bound);
       if (!is_nil_expr(site.guard))
-        cond = or2tc(not2tc(site.guard), cond);
+        cond = implies2tc(site.guard, cond);
 
       goto_programt new_code;
       goto_programt::targett t = new_code.add_instruction(ASSERT);
@@ -215,8 +189,7 @@ bool goto_check_excessive_alloc::runOnFunction(
       t->function = fn;
       body.insert_swap(it, new_code.instructions.front());
     }
-    changed = true;
   }
 
-  return changed;
+  return true;
 }

--- a/src/goto-programs/goto_check_excessive_alloc.cpp
+++ b/src/goto-programs/goto_check_excessive_alloc.cpp
@@ -26,7 +26,8 @@ const char *alloc_fn_name(sideeffect2t::allockind kind)
 }
 
 /// Total requested allocation size in bytes for `se`, or a nil expression
-/// when it cannot be computed (an element type with no static size).
+/// when it cannot be computed (an element type with no size at all, i.e. a
+/// flexible/incomplete array member).
 ///
 /// The allocation model (`goto_symext::symex_mem`, src/goto-symex/
 /// builtin_functions/memory_alloc.cpp) uniformly allocates `se.size` elements
@@ -62,9 +63,29 @@ expr2tc alloc_byte_size(const sideeffect2t &se, const namespacet &ns)
     return mul2tc(
       size_type2(), size, constant_int2tc(size_type2(), elem_bytes));
   }
+  catch (const array_type2t::dyn_sized_array_excp &)
+  {
+    // A dynamically-sized (VLA) element type, e.g. malloc(sizeof(int[n])):
+    // the frontend records size == 1 with a VLA alloctype, so the byte size
+    // is symbolic but still computable. type_byte_size_expr handles dyn-sized
+    // arrays (unlike the BigInt type_byte_size above, which throws), so scale
+    // by the symbolic element size rather than skipping — otherwise a large
+    // runtime n slips under the bound unchecked.
+    try
+    {
+      expr2tc elem_bytes = type_byte_size_expr(se.alloctype, &ns);
+      if (elem_bytes->type != size_type2())
+        elem_bytes = typecast2tc(size_type2(), elem_bytes);
+      return mul2tc(size_type2(), size, elem_bytes);
+    }
+    catch (const array_type2t::array_size_excp &)
+    {
+      return expr2tc(); // nested element size still unknown — skip
+    }
+  }
   catch (const array_type2t::array_size_excp &)
   {
-    // Element type has no static byte size (flexible/infinite array member).
+    // Element type has no size at all (flexible/incomplete array member).
     return expr2tc();
   }
 }

--- a/src/goto-programs/goto_check_excessive_alloc.cpp
+++ b/src/goto-programs/goto_check_excessive_alloc.cpp
@@ -26,10 +26,17 @@ const char *alloc_fn_name(sideeffect2t::allockind kind)
 }
 
 /// Total requested allocation size in bytes for `se`, or a nil expression
-/// when it cannot be computed (a size-one allocation, or an element type with
-/// no static size). `malloc`/`realloc` sizes are already in bytes;
-/// `operator new[]` carries an element count that is scaled by
-/// `sizeof(element)`.
+/// when it cannot be computed (an element type with no static size).
+///
+/// The allocation model (`goto_symext::symex_mem`, src/goto-symex/
+/// builtin_functions/memory_alloc.cpp) uniformly allocates `se.size` elements
+/// of `se.alloctype`, so the requested byte count is `size * sizeof(alloctype)`
+/// for every kind we check. This matters for typed requests: the frontend
+/// lowers a bare `malloc(sizeof(T))` to `size == 1, alloctype == T` (never a
+/// raw byte count), so without the scaling a large `T` would be checked as
+/// `1 <= K` and slip through. A byte-count request such as `malloc(n)` or
+/// `n * sizeof(T)` keeps `alloctype == char` (sizeof 1), so the scaling is the
+/// identity there.
 expr2tc alloc_byte_size(const sideeffect2t &se, const namespacet &ns)
 {
   if (is_nil_expr(se.size))
@@ -39,19 +46,19 @@ expr2tc alloc_byte_size(const sideeffect2t &se, const namespacet &ns)
   if (size->type != size_type2())
     size = typecast2tc(size_type2(), size);
 
-  if (se.kind != sideeffect2t::allockind::cpp_new_arr)
-    return size; // already a byte count
-
+  // A char/unknown element type is already a byte count: no scaling needed.
   if (is_nil_type(se.alloctype) || is_empty_type(se.alloctype))
     return size;
 
   try
   {
-    // count * sizeof(element), in the same modular size_type arithmetic symex
+    // size * sizeof(element), in the same modular size_type arithmetic symex
     // uses to model the allocation. A count near 2^64 can wrap the product to
     // a small value and slip under K — a false negative, never a false
     // positive; it mirrors the model rather than contradicting it.
     BigInt elem_bytes = type_byte_size(se.alloctype, &ns);
+    if (elem_bytes == 1)
+      return size; // sizeof(char)-equivalent: avoid a redundant `* 1`
     return mul2tc(
       size_type2(), size, constant_int2tc(size_type2(), elem_bytes));
   }
@@ -121,6 +128,17 @@ void collect_allocs(
 }
 } // namespace
 
+// This pass instruments *every* function, user code and linked operational
+// models alike. malloc/realloc/operator new[] are frontend intrinsics lowered
+// to inline sideeffects at the user call site, so they are checked there.
+// Model-based allocators (calloc, strdup, kmalloc, ldv_malloc, ...) are real
+// functions whose OM bodies allocate via malloc/realloc; instrumenting those
+// bodies is what gives calloc & co. their CWE-789 coverage. The trade-off is
+// that such a finding is reported at the model's malloc site (e.g.
+// stdlib.c:calloc) rather than the user's call site, and a library routine
+// that allocates an input-sized buffer (e.g. strdup of a symbolic-length
+// string) can surface a genuine — but library-located — CWE-789. Both are
+// documented in website/content/docs/cwe-mapping.md.
 bool goto_check_excessive_alloc::runOnFunction(
   std::pair<const irep_idt, goto_functiont> &F)
 {
@@ -133,7 +151,11 @@ bool goto_check_excessive_alloc::runOnFunction(
   // Collect the target assignments (with their allocation sites) first:
   // inserting an ASSERT before an allocation shifts that allocation to the
   // next slot, so a single forward scan that inserted in place would
-  // re-encounter and re-instrument it.
+  // re-encounter and re-instrument it. Scanning assignment right-hand sides is
+  // sufficient: every allocation that survives to the GOTO program lands on an
+  // assignment (an allocation whose result is discarded, `malloc(n);`, is
+  // elided by the frontend before this pass runs, so there is nothing to
+  // check).
   std::vector<std::pair<goto_programt::targett, std::vector<alloc_site_t>>>
     work;
   for (auto it = body.instructions.begin(); it != body.instructions.end(); ++it)

--- a/src/goto-programs/goto_check_excessive_alloc.cpp
+++ b/src/goto-programs/goto_check_excessive_alloc.cpp
@@ -1,0 +1,179 @@
+#include <goto-programs/goto_check_excessive_alloc.h>
+
+#include <util/lang/c_types.h>
+#include <util/symtab/namespace.h>
+#include <util/expr/type_byte_size.h>
+
+namespace
+{
+/// Human-readable allocator name for an allocation side-effect kind, used in
+/// the property comment. Returns nullptr for kinds this pass does not check
+/// (scalar `new`, `alloca`, and the non-allocation side-effect kinds): a
+/// single object or a stack allocation is not an excessive-heap-size concern.
+const char *alloc_fn_name(sideeffect2t::allockind kind)
+{
+  switch (kind)
+  {
+  case sideeffect2t::allockind::malloc:
+    return "malloc";
+  case sideeffect2t::allockind::realloc:
+    return "realloc";
+  case sideeffect2t::allockind::cpp_new_arr:
+    return "operator new[]";
+  default:
+    return nullptr;
+  }
+}
+
+/// Total requested allocation size in bytes for `se`, or a nil expression
+/// when it cannot be computed (a size-one allocation, or an element type with
+/// no static size). `malloc`/`realloc` sizes are already in bytes;
+/// `operator new[]` carries an element count that is scaled by
+/// `sizeof(element)`.
+expr2tc alloc_byte_size(const sideeffect2t &se, const namespacet &ns)
+{
+  if (is_nil_expr(se.size))
+    return expr2tc();
+
+  expr2tc size = se.size;
+  if (size->type != size_type2())
+    size = typecast2tc(size_type2(), size);
+
+  if (se.kind != sideeffect2t::allockind::cpp_new_arr)
+    return size; // already a byte count
+
+  if (is_nil_type(se.alloctype) || is_empty_type(se.alloctype))
+    return size;
+
+  try
+  {
+    // count * sizeof(element), in the same modular size_type arithmetic symex
+    // uses to model the allocation. A count near 2^64 can wrap the product to
+    // a small value and slip under K — a false negative, never a false
+    // positive; it mirrors the model rather than contradicting it.
+    BigInt elem_bytes = type_byte_size(se.alloctype, &ns);
+    return mul2tc(
+      size_type2(), size, constant_int2tc(size_type2(), elem_bytes));
+  }
+  catch (const array_type2t::array_size_excp &)
+  {
+    // Element type has no static byte size (flexible/infinite array member).
+    return expr2tc();
+  }
+}
+
+/// One allocation reached from an assignment's right-hand side.
+struct alloc_site_t
+{
+  expr2tc byte_size; ///< total request in bytes
+  expr2tc guard;     ///< path condition it is evaluated under (nil == always)
+  const char *fn;    ///< allocator name for the property comment
+};
+
+/// Collect the allocation side-effects reachable from `e`, threading the
+/// branch condition each one is evaluated under. The Clang frontend lowers
+/// `realloc(p, n)` to `p == 0 ? malloc(n) : realloc(p, n)`, so allocations
+/// can sit inside an `if` expression rather than being the bare right-hand
+/// side; guarding each site keeps the reported allocator accurate and avoids
+/// flagging the size of a branch that is not taken.
+void collect_allocs(
+  const expr2tc &e,
+  const expr2tc &guard,
+  const namespacet &ns,
+  std::vector<alloc_site_t> &out)
+{
+  if (is_nil_expr(e))
+    return;
+
+  if (is_sideeffect2t(e))
+  {
+    const sideeffect2t &se = to_sideeffect2t(e);
+    if (const char *fn = alloc_fn_name(se.kind))
+    {
+      expr2tc bytes = alloc_byte_size(se, ns);
+      if (!is_nil_expr(bytes))
+        out.push_back({bytes, guard, fn});
+    }
+    // The size/arguments of an allocation are already flattened temporaries,
+    // never nested allocations, so no further recursion is needed here.
+    return;
+  }
+
+  if (is_if2t(e))
+  {
+    const if2t &i = to_if2t(e);
+    const expr2tc not_cond = not2tc(i.cond);
+    collect_allocs(
+      i.true_value,
+      is_nil_expr(guard) ? i.cond : and2tc(guard, i.cond),
+      ns,
+      out);
+    collect_allocs(
+      i.false_value,
+      is_nil_expr(guard) ? not_cond : and2tc(guard, not_cond),
+      ns,
+      out);
+    return;
+  }
+
+  e->foreach_operand(
+    [&](const expr2tc &op) { collect_allocs(op, guard, ns, out); });
+}
+} // namespace
+
+bool goto_check_excessive_alloc::runOnFunction(
+  std::pair<const irep_idt, goto_functiont> &F)
+{
+  if (!F.second.body_available)
+    return false;
+
+  namespacet ns(context);
+  goto_programt &body = F.second.body;
+
+  // Collect the target assignments (with their allocation sites) first:
+  // inserting an ASSERT before an allocation shifts that allocation to the
+  // next slot, so a single forward scan that inserted in place would
+  // re-encounter and re-instrument it.
+  std::vector<std::pair<goto_programt::targett, std::vector<alloc_site_t>>>
+    work;
+  for (auto it = body.instructions.begin(); it != body.instructions.end(); ++it)
+  {
+    if (!it->is_assign())
+      continue;
+    std::vector<alloc_site_t> sites;
+    collect_allocs(to_code_assign2t(it->code).source, expr2tc(), ns, sites);
+    if (!sites.empty())
+      work.emplace_back(it, std::move(sites));
+  }
+
+  const expr2tc bound = constant_int2tc(size_type2(), max_alloc_bytes);
+  bool changed = false;
+  for (auto &[it, sites] : work)
+  {
+    // Snapshot before inserting: each insert_swap splices a new ASSERT into
+    // the slot `it` names and shifts the allocation one step right, so the
+    // location/function are read from the allocation exactly once.
+    const locationt loc = it->location;
+    const irep_idt fn = it->function;
+    for (const alloc_site_t &site : sites)
+    {
+      // `size <= K`, weakened to `guard => size <= K` when the allocation is
+      // conditional so a not-taken branch cannot raise a false witness.
+      expr2tc cond = lessthanequal2tc(site.byte_size, bound);
+      if (!is_nil_expr(site.guard))
+        cond = or2tc(not2tc(site.guard), cond);
+
+      goto_programt new_code;
+      goto_programt::targett t = new_code.add_instruction(ASSERT);
+      t->guard = cond;
+      t->location = loc;
+      t->location.comment(std::string("excessive allocation size: ") + site.fn);
+      t->location.property("excessive-allocation");
+      t->function = fn;
+      body.insert_swap(it, new_code.instructions.front());
+    }
+    changed = true;
+  }
+
+  return changed;
+}

--- a/src/goto-programs/goto_check_excessive_alloc.cpp
+++ b/src/goto-programs/goto_check_excessive_alloc.cpp
@@ -109,15 +109,16 @@ void collect_allocs(
   if (is_if2t(e))
   {
     const if2t &i = to_if2t(e);
-    auto extend = [&](const expr2tc &c)
-    { return is_nil_expr(guard) ? c : and2tc(guard, c); };
+    auto extend = [&](const expr2tc &c) {
+      return is_nil_expr(guard) ? c : and2tc(guard, c);
+    };
     collect_allocs(i.true_value, extend(i.cond), ns, out);
     collect_allocs(i.false_value, extend(not2tc(i.cond)), ns, out);
     return;
   }
 
-  e->foreach_operand([&](const expr2tc &op)
-                     { collect_allocs(op, guard, ns, out); });
+  e->foreach_operand(
+    [&](const expr2tc &op) { collect_allocs(op, guard, ns, out); });
 }
 } // namespace
 

--- a/src/goto-programs/goto_check_excessive_alloc.h
+++ b/src/goto-programs/goto_check_excessive_alloc.h
@@ -15,8 +15,9 @@
 /// symex finds a model with `byte_size > K`, that is a CWE-789 witness.
 ///
 /// `byte_size` is the total request in bytes: `malloc`/`realloc` already carry
-/// a byte size; `operator new[n]` carries an element count, so the pass scales
-/// it by `sizeof(element)`.
+/// a byte size; `operator new[n]` is pre-scaled to bytes by the Clang frontend
+/// (`do_cpp_new` multiplies the element count by `sizeof(element)` before
+/// setting `cmt_size`), so the pass compares it directly.
 ///
 /// The bound K is a policy choice, not a soundness property: the pass proves
 /// "no path reaches an allocation with size > K", not "no path can exhaust

--- a/src/goto-programs/goto_check_excessive_alloc.h
+++ b/src/goto-programs/goto_check_excessive_alloc.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <util/ssa/algorithms.h>
+#include <util/arith/mp_arith.h>
+#include <irep2/irep2.h>
+
+/// Detect memory allocations whose requested size can exceed a configurable
+/// byte bound K (CWE-789, "Memory Allocation with Excessive Size Value").
+///
+/// For every `ASSIGN lhs = <alloc>` whose right-hand side is a dynamic
+/// allocation side-effect — `malloc`/`calloc` (calloc lowers to malloc in the
+/// operational model), `realloc`, or `operator new[]` — the pass inserts
+/// `ASSERT(byte_size <= K)` immediately before the assignment, with comment
+/// `excessive allocation size: <fn>` and property `excessive-allocation`. If
+/// symex finds a model with `byte_size > K`, that is a CWE-789 witness.
+///
+/// `byte_size` is the total request in bytes: `malloc`/`realloc` already carry
+/// a byte size; `operator new[n]` carries an element count, so the pass scales
+/// it by `sizeof(element)`.
+///
+/// The bound K is a policy choice, not a soundness property: the pass proves
+/// "no path reaches an allocation with size > K", not "no path can exhaust
+/// memory" (the latter is undecidable in general). The check is independent of
+/// `--force-malloc-success`: the assertion precedes the allocation, so an
+/// excessive size is reported whether or not the allocation is forced to
+/// succeed.
+///
+/// Runs as a preprocessing algorithm, mirroring `goto_check_unchecked_return`.
+class goto_check_excessive_alloc : public goto_functions_algorithm
+{
+public:
+  goto_check_excessive_alloc(contextt &context, const BigInt &max_alloc_bytes)
+    : goto_functions_algorithm(true),
+      context(context),
+      max_alloc_bytes(max_alloc_bytes)
+  {
+  }
+
+protected:
+  contextt &context;
+  BigInt max_alloc_bytes;
+
+  bool runOnFunction(std::pair<const irep_idt, goto_functiont> &F) override;
+};

--- a/src/util/base/cwe_mapping.cpp
+++ b/src/util/base/cwe_mapping.cpp
@@ -115,6 +115,13 @@ const std::vector<entry_t> &rules_table()
       // Unchecked return value of fallible call (CWE-252).
       {"unchecked return value",
        {"unchecked-return-value", "Unchecked return value", {252}}},
+      // Attacker-controlled allocation size above the --excessive-alloc-check
+      // bound (CWE-789). CWE-770 is the class entry; 789 is the variant we
+      // map to.
+      {"excessive allocation size",
+       {"excessive-allocation",
+        "Memory allocation with excessive size",
+        {789}}},
       // Reachability.
       {"unreachable code reached",
        {"reachable-error", "Reachable error/assertion", {617}}},
@@ -182,6 +189,7 @@ const std::map<unsigned, std::string_view> &names_map()
     {681, "Incorrect Conversion between Numeric Types"},
     {761, "Free of Pointer not at Start of Buffer"},
     {787, "Out-of-bounds Write"},
+    {789, "Memory Allocation with Excessive Size Value"},
     {822, "Untrusted Pointer Dereference"},
     {823, "Use of Out-of-range Pointer Offset"},
     {824, "Access of Uninitialized Pointer"},

--- a/unit/util/cwe_mapping.test.cpp
+++ b/unit/util/cwe_mapping.test.cpp
@@ -161,6 +161,21 @@ TEST_CASE("cwe_for matches uncontrolled recursion", "[util][cwe_mapping]")
     std::string(cwe_rule_for("uncontrolled recursion in ackermann").sarif_id) ==
     "uncontrolled-recursion");
 }
+TEST_CASE("cwe_for matches excessive allocation size", "[util][cwe_mapping]")
+{
+  REQUIRE(
+    cwe_for("excessive allocation size: malloc") == std::vector<unsigned>{789});
+  REQUIRE(
+    cwe_for("excessive allocation size: operator new[]") ==
+    std::vector<unsigned>{789});
+  REQUIRE(
+    std::string(cwe_rule_for("excessive allocation size: realloc").sarif_id) ==
+    "excessive-allocation");
+  REQUIRE(
+    std::string(
+      cwe_rule_for("excessive allocation size: malloc").short_description) ==
+    "Memory allocation with excessive size");
+}
 
 TEST_CASE("cwe_for returns empty on unknown comment", "[util][cwe_mapping]")
 {
@@ -194,6 +209,7 @@ TEST_CASE("cwe_name resolves known ids", "[util][cwe_mapping]")
   REQUIRE(cwe_name(674) == "Uncontrolled Recursion");
   REQUIRE(
     cwe_name(835) == "Loop with Unreachable Exit Condition ('Infinite Loop')");
+  REQUIRE(cwe_name(789) == "Memory Allocation with Excessive Size Value");
   // Unknown id returns empty view.
   REQUIRE(cwe_name(0).empty());
   REQUIRE(cwe_name(99999).empty());

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -167,6 +167,15 @@ allocation, so an excessive size is still reported under
 `--force-malloc-success`. CWE-770 is the class-level entry for unbounded
 allocation; ESBMC maps to the CWE-789 variant.
 
+A typed request such as `malloc(sizeof(T))` is lowered to an element count of
+one with element type `T`, so the check scales by `sizeof(T)`; a byte-count
+request (`malloc(n)`, `malloc(n * sizeof(T))`) keeps a `char` element type and
+is compared directly. `calloc` and other allocators modelled by an operational
+model (e.g. `strdup`) are covered by instrumenting their model bodies, so a
+violation there is reported at the model's internal `malloc` site rather than
+the user call site, and a library routine that allocates an input-sized buffer
+can raise a genuine but library-located CWE-789.
+
 ## Ids dropped vs. published mappings
 
 The mapping derives from Table 4 of Sousa et al., _"Finding Software

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -9,10 +9,10 @@ Weakness Enumeration (CWE) identifiers. The mapping is pinned to **MITRE CWE
 retains ids whose Vulnerability Mapping Usage is `ALLOWED` or
 `ALLOWED-WITH-REVIEW`.
 
-ESBMC currently distinguishes **35 unique CWE identifiers** across **29
+ESBMC currently distinguishes **36 unique CWE identifiers** across **30
 violation kinds**: CWE-120, 121, 122, 125, 129, 131, 190, 191, 193, 252, 362,
 366, 369, 401, 415, 416, 457, 469, 476, 562, 563, 590, 617, 674, 681, 761, 787,
-822, 823, 824, 825, 833, 835, 908, 1335. One of these — CWE-563 — is an
+789, 822, 823, 824, 825, 833, 835, 908, 1335. One of these — CWE-563 — is an
 *advisory* rather than a property violation; see [Advisories](#advisories)
 below.
 
@@ -61,6 +61,7 @@ substring table ordered longest-substring-first.
 | `Deadlocked state`                                           | 833                                         |
 | `use of uninitialized variable`                              | 457                                         |
 | `unchecked return value`                                     | 252                                         |
+| `excessive allocation size`                                  | 789                                         |
 | `unreachable code reached`                                   | 617                                         |
 | `non-terminating execution`                                  | 835                                         |
 | `dead store` _(advisory; `--dead-store-check`)_              | 563                                         |
@@ -156,6 +157,15 @@ the CFG and a value read only in a `catch` would be misreported. Reporting is
 restricted to user source (system-header and operational-model locations are
 excluded by a best-effort path heuristic). Inter-procedural dead-store
 detection is a future extension.
+The `excessive allocation size` row is produced only by the opt-in
+`--excessive-alloc-check[=K]` flag, which inserts an
+`ASSERT(size <= K)` before every `malloc`/`calloc`/`realloc`/`operator new[]`
+(default `K` = 1 MiB). The bound `K` is a **policy** choice, not a soundness
+property: a violation proves "a path reaches an allocation with size > K", not
+"memory can be exhausted" (undecidable in general). The assertion precedes the
+allocation, so an excessive size is still reported under
+`--force-malloc-success`. CWE-770 is the class-level entry for unbounded
+allocation; ESBMC maps to the CWE-789 variant.
 
 ## Ids dropped vs. published mappings
 

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -117,6 +117,27 @@ witness format has no CWE field, so it is unaffected.) Unwinding-assertion
 failures remain intentionally unmapped — they signal an insufficient k-bound,
 not a weakness.
 
+### Excessive allocation size (CWE-789)
+
+The `excessive allocation size` row is produced only by the opt-in
+`--excessive-alloc-check[=K]` flag, which inserts an
+`ASSERT(size <= K)` before every `malloc`/`calloc`/`realloc`/`operator new[]`
+(default `K` = 1 MiB). The bound `K` is a **policy** choice, not a soundness
+property: a violation proves "a path reaches an allocation with size > K", not
+"memory can be exhausted" (undecidable in general). The assertion precedes the
+allocation, so an excessive size is still reported under
+`--force-malloc-success`. CWE-770 is the class-level entry for unbounded
+allocation; ESBMC maps to the CWE-789 variant.
+
+A typed request such as `malloc(sizeof(T))` is lowered to an element count of
+one with element type `T`, so the check scales by `sizeof(T)`; a byte-count
+request (`malloc(n)`, `malloc(n * sizeof(T))`) keeps a `char` element type and
+is compared directly. `calloc` and other allocators modelled by an operational
+model (e.g. `strdup`) are covered by instrumenting their model bodies, so a
+violation there is reported at the model's internal `malloc` site rather than
+the user call site, and a library routine that allocates an input-sized buffer
+can raise a genuine but library-located CWE-789.
+
 ## Advisories
 
 Some CWEs describe code-quality signals rather than property violations. ESBMC
@@ -157,24 +178,6 @@ the CFG and a value read only in a `catch` would be misreported. Reporting is
 restricted to user source (system-header and operational-model locations are
 excluded by a best-effort path heuristic). Inter-procedural dead-store
 detection is a future extension.
-The `excessive allocation size` row is produced only by the opt-in
-`--excessive-alloc-check[=K]` flag, which inserts an
-`ASSERT(size <= K)` before every `malloc`/`calloc`/`realloc`/`operator new[]`
-(default `K` = 1 MiB). The bound `K` is a **policy** choice, not a soundness
-property: a violation proves "a path reaches an allocation with size > K", not
-"memory can be exhausted" (undecidable in general). The assertion precedes the
-allocation, so an excessive size is still reported under
-`--force-malloc-success`. CWE-770 is the class-level entry for unbounded
-allocation; ESBMC maps to the CWE-789 variant.
-
-A typed request such as `malloc(sizeof(T))` is lowered to an element count of
-one with element type `T`, so the check scales by `sizeof(T)`; a byte-count
-request (`malloc(n)`, `malloc(n * sizeof(T))`) keeps a `char` element type and
-is compared directly. `calloc` and other allocators modelled by an operational
-model (e.g. `strdup`) are covered by instrumenting their model bodies, so a
-violation there is reported at the model's internal `malloc` site rather than
-the user call site, and a library routine that allocates an input-sized buffer
-can raise a genuine but library-located CWE-789.
 
 ## Ids dropped vs. published mappings
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `--excessive-alloc-check[=K]` goto preprocessing pass that inserts `ASSERT(size <= K)` before every `malloc`/`calloc`/`realloc`/`operator new[]` (default `K` = 1 MiB), mapping violations to **CWE-789** (Memory Allocation with Excessive Size Value).
- The pass computes the byte request per allocation kind (`malloc`/`realloc` sizes are already bytes; `operator new[]` scales the element count by `sizeof(element)`) and threads branch guards so the frontend's `realloc` lowering `p==0 ? malloc(n) : realloc(p,n)` reports the allocator actually reached. `calloc` is covered transitively via its operational model.
- The bound `K` is a **policy** choice, not a soundness property, and the assertion precedes the allocation, so an excessive size is still reported under `--force-malloc-success`.
- CWE-789 flows through all existing annotation paths: textual (`CWE: CWE-789`), SARIF (`ruleId: excessive-allocation` + taxon 789), JSON (`assertion.cwe: [789]`), and GraphML (`<data key="cwe">CWE-789</data>`).
- Mirrors the existing `goto_check_unchecked_return` (CWE-252) pass. Off by default, so existing regressions and SV-COMP wrapper output are unaffected.

Implements the extension proposed in the issue (tracks #4488 / #1854).

Fixes #4497

## Test plan

- [x] `ctest` unit suite — `util/cwe_mapping` (18 cases, 609 assertions) passing, incl. new CWE-789 case + `cwe_name(789)`
- [x] New regression tests passing: `cwe_excessive_alloc` (malloc, FAIL), `cwe_excessive_alloc_pass` (guarded, SUCCESSFUL), `cwe_excessive_alloc_realloc`, `cwe_excessive_alloc_sarif`, `cwe_excessive_alloc_new` (C++ `new[]`)
- [x] 77 allocation/memory/CWE regression tests + 23 existing `cwe_*` tests pass — no regressions
- [x] clang-format 11 clean on all changed C++ files
- [x] Verified `--excessive-alloc-check=K` bound is exact; invalid `K<=0` rejected; SARIF/JSON/GraphML/textual all reflect CWE-789