### PR TITLE
[python] V.3: build the isinstance node in IREP2

### DIFF
--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -441,10 +441,12 @@ exprt function_call_expr::handle_isinstance() const
     else
       t = gen_zero(expected_type);
 
-    exprt isinstance("isinstance", typet("bool"));
-    isinstance.copy_to_operands(obj_expr);
-    isinstance.move_to_operands(t);
-    return isinstance;
+    // V.3: build the isinstance node in IREP2 (isinstance2t is a 2-operand
+    // custom kind with forward/back migrate arms since #3289).
+    expr2tc obj2, t2;
+    migrate_expr(obj_expr, obj2);
+    migrate_expr(t, t2);
+    return migrate_expr_back(isinstance2tc(obj2, t2));
   };
 
   // Handle tuple of types: isinstance(v, (int, str, type(None)))

--- a/src/python-frontend/python_typechecking.cpp
+++ b/src/python-frontend/python_typechecking.cpp
@@ -198,10 +198,13 @@ exprt python_typechecking::build_isinstance_check(
   else
     type_operand = gen_zero(effective_type);
 
-  exprt isinstance_expr("isinstance", typet("bool"));
-  isinstance_expr.copy_to_operands(value_expr);
-  isinstance_expr.move_to_operands(type_operand);
-  return isinstance_expr;
+  // V.3: build the isinstance node in IREP2. isinstance2t is a 2-operand
+  // custom kind with forward/back migrate arms (since #3289), so this is the
+  // exact round-trip of the legacy node.
+  expr2tc value2, type2;
+  migrate_expr(value_expr, value2);
+  migrate_expr(type_operand, type2);
+  return migrate_expr_back(isinstance2tc(value2, type2));
 }
 
 exprt python_typechecking::build_none_check(const exprt &value_expr) const


### PR DESCRIPTION
Route both isinstance construction sites (handle_isinstance,
build_isinstance_check) through isinstance2tc via the standard
migrate-forward/back recipe instead of the legacy stringly-typed
exprt. Byte-identical GOTO; part of the #5055 V.3 converter drain.
