### PR TITLE
[python] V.3: build the isnone comparison node in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -518,10 +518,15 @@ exprt python_converter::handle_none_comparison(
     }
   }
 
-  // Create isnone expression with unwrapped operands
-  exprt isnone_expr("isnone", typet("bool"));
-  isnone_expr.copy_to_operands(lhs);
-  isnone_expr.copy_to_operands(rhs);
+  // Create isnone expression with unwrapped operands.
+  // V.3: build the isnone node in IREP2. isnone2t is a 2-operand custom kind
+  // with forward/back migrate arms (since #3289), so migrating the operands,
+  // building, and back-migrating once is the exact round-trip of the legacy
+  // node. Spike-1 confirmed the operands are already resolved at this site.
+  expr2tc lhs2, rhs2;
+  migrate_expr(lhs, lhs2);
+  migrate_expr(rhs, rhs2);
+  exprt isnone_expr = migrate_expr_back(isnone2tc(lhs2, rhs2));
 
   // If checking inequality, wrap with not
   if (!is_eq)


### PR DESCRIPTION
Migrates the `is None` / `is not None` lowering in `handle_none_comparison`
(`converter_compare.cpp`) from a legacy `exprt("isnone")` to the shared
migrate-forward idiom: migrate the two operands, build `isnone2tc`, and
back-migrate once. `isnone2t` is a 2-operand IREP2 custom kind with
forward/back `migrate_expr` arms (since #3289), so this is the exact
round-trip of the legacy node.

Part of Part V Phase V.3 (`docs/irep2-migration.md`, #4715). Spike-1
(`docs/scope-v1k-adjuster.md` §5.1) confirmed the operands are already
resolved at this site -- no whole-body adjuster needed -- and the drain
fires with zero asserts-on aborts across the is-None regression corpus.

Testing: `--goto-functions-only` byte-identical (0-line diff modulo the
pre-existing astgen-tempdir nondeterminism) on `optional7`, `github_2937_3`,
`none4_fail`, `github_4746`; 34/34 optional/none regression tests pass;
clang-format clean.

Refs #4715.
