### PR TITLE
[python] V.3: drain the last legacy arithmetic constructions to IREP2

### DIFF
--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -2634,7 +2634,17 @@ exprt numpy_call_expr::create_expr_from_call()
         if (function == "imag")
           return imag;
         if (function == "conj" || function == "conjugate")
-          return make_complex(real, minus_exprt(from_double(0.0, dt), imag));
+        {
+          // V.3: build the conjugate's `0.0 - imag` negation in IREP2. migrate
+          // lowers a legacy `minus` (id "-") to sub2t unconditionally (no
+          // rounding mode, even for floatbv), so this sub2tc is the exact
+          // round-trip of the legacy minus_exprt.
+          expr2tc zero2, imag2;
+          migrate_expr(from_double(0.0, dt), zero2);
+          migrate_expr(imag, imag2);
+          return make_complex(
+            real, migrate_expr_back(sub2tc(migrate_type(dt), zero2, imag2)));
+        }
         if (function == "abs")
           return converter_.get_complex_handler().handle_abs(arg_expr);
         if (function == "angle")

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -1121,15 +1121,23 @@ exprt python_list::handle_range_slice(
   // for the common step==1 case.
   const typet signed_t = signed_size_type();
   const typet counter_type = negative_step ? signed_t : size_type();
+  // V.3: build the slice-bound arithmetic natively in IREP2. Every call site
+  // passes operands uniformly at signed_t (size_signed/val_signed via
+  // build_typecast, one_s via from_integer), so add2t/sub2t with an explicit
+  // signed_t2 result is the exact round-trip of the legacy plus/minus whose
+  // result type was overridden to signed_t.
+  const type2tc signed_t2 = migrate_type(signed_t);
   auto signed_add = [&](const exprt &lhs, const exprt &rhs) -> exprt {
-    plus_exprt out(lhs, rhs);
-    out.type() = signed_t;
-    return out;
+    expr2tc lhs2, rhs2;
+    migrate_expr(lhs, lhs2);
+    migrate_expr(rhs, rhs2);
+    return migrate_expr_back(add2tc(signed_t2, lhs2, rhs2));
   };
   auto signed_sub = [&](const exprt &lhs, const exprt &rhs) -> exprt {
-    minus_exprt out(lhs, rhs);
-    out.type() = signed_t;
-    return out;
+    expr2tc lhs2, rhs2;
+    migrate_expr(lhs, lhs2);
+    migrate_expr(rhs, rhs2);
+    return migrate_expr_back(sub2tc(signed_t2, lhs2, rhs2));
   };
 
   // Resolve a slice bound following CPython's slice.indices(len) semantics.
@@ -1140,7 +1148,6 @@ exprt python_list::handle_range_slice(
     const exprt size_signed = build_typecast(build_symbol(size_sym), signed_t);
     const exprt zero_s = from_integer(0, signed_t);
     const exprt one_s = from_integer(1, signed_t);
-    const type2tc signed_t2 = migrate_type(signed_t); // V.3: for IREP2 selects
 
     // Step 1: produce a signed `resolved` value.
     //   - missing bound → step-direction default


### PR DESCRIPTION
Route the slice-bound signed_add/signed_sub (list_access.cpp) and the
numpy conj/conjugate `0.0 - imag` negation (numpy_call_expr.cpp) through
the shared migrate-forward idiom (add2tc/sub2tc) instead of legacy
plus/minus_exprt. Operands are uniform (signed_t / floatbv), and migrate
lowers a legacy `minus` to sub2t unconditionally, so both are exact
round-trips; goto_convert's mandatory IREP2 body round-trip makes the
emitted GOTO byte-identical (A/B verified on the slice and numpy-conj
suites, modulo pre-existing astgen-tempdir nondeterminism).

The char_at_index pointer path (converter_compare.cpp) is left as-is: it
already migrates forward and returns expr2tc, and its dereference
deliberately keeps the pointee's nil subtype as the result type
(documented inline), so native construction there would be un-gateable.

Refs #4715.
