### PR TITLE
[docs] List the SAFE-LD Ladder Diagram frontend in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ESBMC supports:
 - The Soot framework via Jimple as its Java/Kotlin frontend;
 - The CPython 3.10 parser as its [Python frontend](./src/python-frontend/README.md); the first SMT-based bounded model checker for Python programs;
 - Implements the Solidity grammar production rules as its Solidity frontend;
+- The SAFE-LD frontend for verifying IEC 61131-3 [Ladder Diagram](https://esbmc.github.io/docs/ld/) programs for programmable logic controllers (PLCs), enabled at build time with `-DENABLE_LD_FRONTEND=On`;
 - Supports IEEE floating-point arithmetic for various SMT solvers.
 
 ESBMC implements state-of-the-art incremental BMC and *k*-induction proof-rule algorithms based on Satisfiability Modulo Theories (SMT) and Constraint Programming (CP) solvers.


### PR DESCRIPTION
Follow-up to #5798. The IEC 61131-3 Ladder Diagram (SAFE-LD) frontend
(`src/ld-frontend`), matured by #5620 and documented under `docs/ld`, was
missing from the README's list of supported frontends. This adds it, with
the enabling build flag (`-DENABLE_LD_FRONTEND=On`) and a link to the LD
docs.

(The commit was originally part of the #5798 branch but landed after that
PR was squash-merged, so it needs its own PR.)