### PR TITLE
[python] Fix min/max truncating mixed int/float tuples; drain to IREP2

### DIFF
--- a/regression/python/min_max_mixed_tuple/main.py
+++ b/regression/python/min_max_mixed_tuple/main.py
@@ -1,0 +1,8 @@
+# min()/max() over a single mixed int/float tuple must keep the wider
+# (float) candidate, not truncate it to the current component's int type.
+# Regresses the bug where the running double accumulator was cast back to
+# int by the select's result type, so min((3, 2.5, 4)) wrongly gave 2.
+assert min((3, 2.5, 4)) == 2.5
+assert max((1, 5.5, 2)) == 5.5
+assert min((10, 2.5, 7, 1)) == 1
+assert max((3, 2.5)) == 3

--- a/regression/python/min_max_mixed_tuple/test.desc
+++ b/regression/python/min_max_mixed_tuple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/min_max_mixed_tuple_fail/main.py
+++ b/regression/python/min_max_mixed_tuple_fail/main.py
@@ -1,0 +1,2 @@
+# min((3, 2.5, 4)) is 2.5, not 3 — the assertion must fail.
+assert min((3, 2.5, 4)) == 3

--- a/regression/python/min_max_mixed_tuple_fail/test.desc
+++ b/regression/python/min_max_mixed_tuple_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 1
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -18,6 +18,7 @@
 #include <python-frontend/python_expr_builder.h>
 #include <util/arith_tools.h>
 #include <util/base_type.h>
+#include <util/c_typecast.h>
 #include <util/expr_util.h>
 #include <util/message.h>
 #include <util/python_types.h>
@@ -1476,28 +1477,37 @@ exprt function_call_expr::handle_min_max(
           exprt elem =
             build_member(arg, components[i].get_name(), components[i].type());
 
-          // result = (elem < result) ? elem : result  (> for max).
-          // V.3: build the select in IREP2 when both branches share the
-          // result type; mixed-type tuple components keep the legacy builder
-          // (if2t asserts type-id equality).
-          const typet &ut = components[i].type();
-          if (elem.type() == ut && result.type() == ut)
+          // result = (elem < result) ? elem : result  (> for max), built in
+          // IREP2. Reconcile mixed-type components to their common arithmetic
+          // type first so the wider candidate survives: the previous legacy
+          // builder set the select's type to the *current* component's type
+          // (ut), truncating a running double accumulator back to int
+          // (min((3, 2.5)) wrongly became 2, not 2.5).
+          // c_implicit_typecast_arithmetic is a no-op when the types already
+          // match, so the same-type case stays byte-identical.
+          exprt elem_r = elem, result_r = result;
+          if (elem_r.type() != result_r.type())
+            c_implicit_typecast_arithmetic(elem_r, result_r, converter_.ns);
+          if (elem_r.type() == result_r.type())
           {
-            const type2tc ut2 = migrate_type(ut);
+            const type2tc rt2 = migrate_type(elem_r.type());
             expr2tc elem2, result2;
-            migrate_expr(elem, elem2);
-            migrate_expr(result, result2);
+            migrate_expr(elem_r, elem2);
+            migrate_expr(result_r, result2);
             expr2tc cond = comparison_op == exprt::i_lt
                              ? lessthan2tc(elem2, result2)
                              : greaterthan2tc(elem2, result2);
-            result = migrate_expr_back(if2tc(ut2, cond, elem2, result2));
+            result = migrate_expr_back(if2tc(rt2, cond, elem2, result2));
           }
           else
           {
+            // Differing non-arithmetic components (an invalid Python min/max,
+            // a TypeError in CPython). Keep the legacy select rather than
+            // tripping if2t's type-id assertion.
             exprt condition(comparison_op, type_handler_.get_typet("bool", 0));
             condition.copy_to_operands(elem, result);
             if_exprt update(condition, elem, result);
-            update.type() = ut;
+            update.type() = components[i].type();
             result = update;
           }
         }


### PR DESCRIPTION
## What

Fixes a wrong-verdict (soundness) bug in `min(iterable)` / `max(iterable)` over a **single mixed int/float tuple**, and drains the last legacy `if_exprt` construction in that path to IREP2.

`min((3, 2.5, 4))` returned **2** instead of **2.5**: the comparison chain set the select's result type to the *current* tuple component's type (`components[i].type()`), so once the running accumulator became a `double`, a later `int` component truncated it back to `int`. ESBMC reported `VERIFICATION SUCCESSFUL` for `min((3, 2.5, 4)) == 2` and `FAILED` for the correct `== 2.5` — a silent wrong answer, the worst failure mode for a verifier.

## Fix

In `function_call_expr::handle_min_max` (single-tuple path), reconcile the two candidates to their common arithmetic type with `c_implicit_typecast_arithmetic` before building the IREP2 `if2tc`. That call is a no-op when the types already match, so the same-type case stays byte-identical. When reconciliation cannot equalize the types (differing non-arithmetic components — an invalid Python `min`/`max`, a `TypeError` in CPython), it falls back to the pre-existing legacy `if_exprt` builder rather than tripping `if2t`'s type-id assertion. This unifies the previously-split same-type (IREP2) and mixed-type (buggy legacy) arms into one correct IREP2 path, completing the V.3 drain of this function.

## Tests

- `regression/python/min_max_mixed_tuple` (CORE, SUCCESSFUL) — `min`/`max` over mixed int/float tuples, including the accumulator-truncation case `min((10, 2.5, 7, 1)) == 1` and `max((3, 2.5)) == 3`.
- `regression/python/min_max_mixed_tuple_fail` (CORE, FAILED) — pins that `min((3, 2.5, 4)) != 3`.

Both verified against CPython (success → exit 0, fail → non-zero). The 30 existing `min`/`max` tests and the 182-test tuple/min/max regression subset pass unchanged (one pre-existing `github_3915` failure locally is environmental — it needs `--z3`, absent from the local Bitwuzla-only build; SUCCESSFUL under Bitwuzla). `scripts/check_python_tests.sh min_max` green.

Part of the Part V Phase V.3 converter drain (`docs/irep2-migration.md`, #4715).
