### PR TITLE
[python] Fix sum() over a tuple by folding members directly

### DIFF
--- a/regression/python/sum_tuple/main.py
+++ b/regression/python/sum_tuple/main.py
@@ -1,0 +1,13 @@
+# sum() over a tuple must fold its members with Python's int->float
+# promotion. The list-typed sum/sum_float models iterate a representation a
+# tuple struct does not have, so they used to return garbage (even
+# sum((1, 2, 3)) != 6). Cover all-int, all-float, mixed, start arg, empty,
+# and a tuple bound to a variable.
+assert sum((1, 2, 3)) == 6
+assert sum((1.0, 2.5)) == 3.5
+assert sum((1, 2.5, 3)) == 6.5
+assert sum((1, 2, 3), 10) == 16
+assert sum(()) == 0
+assert sum((5,)) == 5
+t = (1, 2.5, 3)
+assert sum(t) == 6.5

--- a/regression/python/sum_tuple/test.desc
+++ b/regression/python/sum_tuple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sum_tuple_fail/main.py
+++ b/regression/python/sum_tuple_fail/main.py
@@ -1,0 +1,3 @@
+# sum((1, 2.5, 3)) is 6.5, not 6 (the old truncating behaviour) — the
+# assertion must fail.
+assert sum((1, 2.5, 3)) == 6

--- a/regression/python/sum_tuple_fail/test.desc
+++ b/regression/python/sum_tuple_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 1
+^VERIFICATION FAILED$

--- a/regression/python/sum_tuple_user_shadow/main.py
+++ b/regression/python/sum_tuple_user_shadow/main.py
@@ -1,0 +1,7 @@
+# A user-defined sum() that shadows the builtin must be honoured even when
+# the argument is a tuple — the builtin tuple-fold must not intercept it.
+def sum(t):
+    return 42
+
+
+assert sum((1, 2, 3)) == 42

--- a/regression/python/sum_tuple_user_shadow/test.desc
+++ b/regression/python/sum_tuple_user_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4144,6 +4144,64 @@ std::optional<exprt> function_call_expr::apply_builtin_dispatch(
   // both 1- and 2-arg forms so the typed dispatch picks sum / sum_float
   // consistently. The other builtins below remain 1-arg only.
   const size_t n_args = call_["args"].size();
+
+  // sum() over a tuple: the sum/sum_float models iterate a *list*
+  // representation that a tuple struct does not have, so they return
+  // garbage (e.g. sum((1, 2, 3)) != 6). Fold the tuple's members directly
+  // with '+', promoting to double when any element is float so mixed
+  // int/float tuples keep Python semantics (sum((1, 2.5, 3)) == 6.5).
+  if (
+    func_name == "sum" && !is_user_imported && !is_numpy_model_call &&
+    (n_args == 1 || n_args == 2) &&
+    find_function(converter_.ast()["body"], func_name).empty())
+  {
+    exprt arg = converter_.get_expr(call_["args"][0]);
+    const typet &at = converter_.ns.follow(arg.type());
+    if (
+      at.is_struct() &&
+      to_struct_type(at).tag().as_string().starts_with("tag-tuple"))
+    {
+      const struct_typet::componentst &comps = to_struct_type(at).components();
+      // Only fold numeric tuples; leave non-numeric ones (nested tuples,
+      // strings — a TypeError in CPython anyway) to the existing path so
+      // this change is scoped to the case it fixes.
+      bool any_float = false, all_numeric = true;
+      for (const auto &c : comps)
+      {
+        const typet &ct = converter_.ns.follow(c.type());
+        if (ct.is_floatbv() || ct.is_fixedbv())
+          any_float = true;
+        else if (!ct.is_signedbv() && !ct.is_unsignedbv() && !ct.is_bool())
+          all_numeric = false;
+      }
+      if (all_numeric)
+      {
+        const type2tc rt2 =
+          migrate_type(any_float ? double_type() : long_long_int_type());
+
+        expr2tc acc;
+        if (n_args == 2)
+        {
+          migrate_expr(converter_.get_expr(call_["args"][1]), acc);
+          if (acc->type != rt2)
+            acc = typecast2tc(rt2, acc);
+        }
+        else
+          acc = gen_zero(rt2);
+
+        for (const auto &c : comps)
+        {
+          expr2tc m2;
+          migrate_expr(build_member(arg, c.get_name(), c.type()), m2);
+          if (m2->type != rt2)
+            m2 = typecast2tc(rt2, m2);
+          acc = add2tc(rt2, acc, m2);
+        }
+        return migrate_expr_back(acc);
+      }
+    }
+  }
+
   const bool is_sorted_min_max = func_name == "min" || func_name == "max" ||
                                  func_name == "sorted" ||
                                  func_name == "reversed";


### PR DESCRIPTION
## What

Fixes a wrong-verdict (soundness) bug: `sum()` over a **tuple** returned garbage — even `sum((1, 2, 3))` did not equal `6`.

`sum` is a monomorphic operational model — `sum(iterable: list[int]) -> int` / `sum_float(list[float]) -> float` — that iterates a *list* representation. A tuple is a struct (tag `tag-tuple`), so the model iterated past the element count and produced a garbage result (and, for mixed int/float tuples, additionally truncated the float part). Lists were unaffected because they materialize to a symbol with proper element-type inference.

## Fix

In `function_call_expr::apply_builtin_dispatch`, intercept `sum` with a **numeric tuple** argument and fold its members directly with `+`. The result type is `double` when any component is float (Python's int→float promotion), else `long_long_int_type()` — the frontend's `int` model type, so `==` against integer literals does not diverge. Each member is migrated, typecast to the result type if needed, and accumulated via `add2tc`; the `start` argument (`sum(iter, start)`) seeds the accumulator.

Guards keep the change tightly scoped:
- `!is_user_imported`, `!is_numpy_model_call`, and `find_function(ast.body, "sum").empty()` — so a user-defined or imported `sum`, or `numpy.sum`, is never captured (caught in code review).
- `all_numeric` — non-numeric tuples (nested tuples, strings; a `TypeError` in CPython) fall through to the pre-existing path unchanged, so behavior only changes for the numeric case being fixed.

## Tests

- `regression/python/sum_tuple` (CORE, SUCCESSFUL) — all-int, all-float, mixed, `start` arg, empty `()`, single `(5,)`, and a tuple bound to a variable.
- `regression/python/sum_tuple_fail` (CORE, FAILED) — pins that `sum((1, 2.5, 3)) != 6` (the old truncating result).
- `regression/python/sum_tuple_user_shadow` (CORE, SUCCESSFUL) — a user-defined `def sum` is honored over a tuple (regresses the code-review finding).

All three CPython-sanity green. 141 Python `sum`/`tuple`/`any`/`min_max` regression tests pass unchanged. Code review: the one high-severity finding (user-`sum` shadowing) is fixed here; the low-severity non-numeric note is addressed by the `all_numeric` guard.

Found while resuming the Part V Phase V.3 converter work (`docs/irep2-migration.md`, #4715) by probing retained builtins for mixed-type soundness bugs.
