### PR TITLE
[python] Fold list.count()/index() on a literal receiver

### DIFF
--- a/regression/python/list_count_index_literal/main.py
+++ b/regression/python/list_count_index_literal/main.py
@@ -1,0 +1,11 @@
+# list.count()/index() on a literal receiver folds at conversion time. The
+# OM value-matching path returned a wrong result for a literal (count of a
+# present element was 0, index was misresolved), while tuples already worked.
+assert [1, 2, 2, 3].count(2) == 2
+assert [1, 2, 2, 3].index(2) == 1
+assert [1, 2, 3].count(9) == 0
+assert ["a", "b", "a"].count("a") == 2
+assert ["a", "b", "a"].index("b") == 1
+# Tuples and the string form must remain correct too.
+assert (1, 2, 2, 3).count(2) == 2
+assert "aXbXc".count("X") == 2

--- a/regression/python/list_count_index_literal/test.desc
+++ b/regression/python/list_count_index_literal/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_count_index_literal_fail/main.py
+++ b/regression/python/list_count_index_literal_fail/main.py
@@ -1,0 +1,2 @@
+# [1, 2, 2, 3].count(2) is 2, not 3 — the assertion must fail.
+assert [1, 2, 2, 3].count(2) == 3

--- a/regression/python/list_count_index_literal_fail/test.desc
+++ b/regression/python/list_count_index_literal_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 1
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1118,8 +1118,15 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
       node["func"]["attr"] == "index" && node["func"].contains("value"))
     {
       auto recv = eval_expr(node["func"]["value"], env);
+      // Both LIST and TUPLE store their elements in tuple_val; a list literal
+      // receiver folds the same way a tuple one does. Without covering LIST,
+      // `[...].index(x)` fell through to the OM, whose value matching returns
+      // a wrong index for a literal receiver.
       if (
-        !recv || recv->kind != PyConstValue::TUPLE || node["args"].size() != 1)
+        !recv ||
+        (recv->kind != PyConstValue::TUPLE &&
+         recv->kind != PyConstValue::LIST) ||
+        node["args"].size() != 1)
         return std::nullopt;
 
       auto needle = eval_expr(node["args"][0], env);
@@ -1132,6 +1139,34 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
           return PyConstValue::make_int(static_cast<long long>(i));
       }
       return std::nullopt;
+    }
+
+    // list/tuple .count(x) on a constant receiver folds at conversion time.
+    // The literal-receiver OM path returns 0 for a present element, so fold
+    // it here. String .count is handled by the string-method block below, so
+    // only act on a LIST/TUPLE receiver and otherwise fall through.
+    if (
+      node["func"]["_type"] == "Attribute" &&
+      node["func"].value("attr", std::string()) == "count" &&
+      node["func"].contains("value"))
+    {
+      auto recv = eval_expr(node["func"]["value"], env);
+      if (
+        recv &&
+        (recv->kind == PyConstValue::TUPLE ||
+         recv->kind == PyConstValue::LIST) &&
+        node["args"].size() == 1)
+      {
+        auto needle = eval_expr(node["args"][0], env);
+        if (needle)
+        {
+          long long c = 0;
+          for (const auto &e : recv->tuple_val)
+            if (pyconst_equal(e, *needle))
+              ++c;
+          return PyConstValue::make_int(c);
+        }
+      }
     }
 
     // String methods on a STRING receiver: fold pure, ASCII-only operations


### PR DESCRIPTION
## What

Fixes a wrong-verdict (soundness) bug: `list.count(x)` and `list.index(x)` on a **literal receiver** returned wrong results.

- `[1, 2, 2, 3].count(2)` returned **0** (should be 2) — `count` of a *present* element was always 0 for a literal.
- `[1, 2, 3].index(2)` was misresolved.

Tuples already folded correctly at conversion time in the constant evaluator (`python_consteval`); lists did not, so a literal-list `count`/`index` fell through to the operational model, whose value matching (`type_id`/`size`/`values_equal`) does not line up for a materialized literal receiver and returns a wrong result. Variable-receiver `count`/`index` were unaffected (they already worked).

## Fix

In `python_consteval.cpp` (the `Call` handling of `eval_expr`):
1. Broadened the existing `.index()` fold to accept a `PyConstValue::LIST` receiver in addition to `TUPLE` — both store their elements in `tuple_val`, so a list literal folds exactly as a tuple literal does.
2. Added a `.count()` fold for LIST/TUPLE receivers, counting `pyconst_equal` matches over `tuple_val`.

Both fire only when the receiver and argument are constant-evaluable; otherwise control falls through to the normal codegen path (the variable-receiver OM path). The `count` block acts only on a LIST/TUPLE receiver, so a STRING receiver still reaches the existing string-`.count` fold below.

## Tests

- `regression/python/list_count_index_literal` (CORE, SUCCESSFUL) — list `count`/`index` on literals (int and str elements), `count` of an absent element (0), plus tuple `.count` and string `.count` to guard the unchanged paths.
- `regression/python/list_count_index_literal_fail` (CORE, FAILED) — pins that `[1, 2, 2, 3].count(2) != 3`.

Both CPython-sanity green. 28 count/index/tuple/list regression tests pass unchanged; tuple/string/variable-list `count`/`index` still correct.

Found while resuming the Part V Phase V.3 work (`docs/irep2-migration.md`, #4715) by probing builtins for mixed-type/container soundness bugs.
