### PR TITLE
[goto-programs] Recover from malformed CBMC binaries instead of abort()

### DIFF
--- a/docs/cprover-support-roadmap.md
+++ b/docs/cprover-support-roadmap.md
@@ -248,9 +248,17 @@ The adapter maps a subset of symbol flags (`is_type`, `is_macro`, `is_parameter`
 whole subsystem. ESBMC has its own contracts (`src/goto-programs/contracts/`); the work is
 to bridge CBMC's encoding onto it rather than re-implement.
 
-### 4.7 Versioning & robustness (Phase 5)
-Only CBMC binary **version 6** is accepted. No graceful handling of other versions, and the
-reader `abort()`s on malformed input rather than returning a recoverable error.
+### 4.7 Versioning & robustness (Phase 5) — 🔶 malformed-input recovery landed
+Only CBMC binary **version 6** is accepted (a wrong version, like a non-magic header, is
+already a clean `log_error` + `return true`). The low-level reader no longer `abort()`s on
+malformed input: an over-wide varint (>32 bits), an over-long varint (>64 shift bits), and an
+unterminated irep now set a `cbmc_irep_readert::failed()` flag that short-circuits the rest of
+the parse (subsequent reads no-op, the S/N/C child loops stop) and surfaces through
+`parse_cbmc_goto`'s bool return as a recoverable error rather than crashing the whole process
+(PR #5811). Pinned by unit tests for each malformed shape plus a truncated-binary parse.
+**Still open:** multi-version tolerance (accept/adapt versions other than 6), and bounding the
+symbol/function/instruction counts so a corrupt-but-in-range count can't trigger a huge
+`reserve()` before the first element is read.
 
 ### 4.8 Builtin-call rewrites (malloc, libm, ...) never reach CBMC-sourced GOTO (Phase 2) — 🔶 `malloc`/`sqrtf`/`alloca` landed, family audit still open
 ### 4.8 Builtin-call rewrites (malloc, libm, ...) never reach CBMC-sourced GOTO (Phase 2) — 🔶 `malloc`/`sqrtf`/`free` landed, family audit still open

--- a/src/goto-programs/read_cbmc_goto_object.cpp
+++ b/src/goto-programs/read_cbmc_goto_object.cpp
@@ -20,6 +20,9 @@ bool is_cbmc_goto_magic(const unsigned char header[4])
 
 unsigned cbmc_irep_readert::read_word()
 {
+  if (failed_)
+    return 0;
+
   unsigned shift_distance = 0;
   // Accumulate in 64 bits so that bits shifted past bit 31 stay visible and an
   // over-wide varint is detectable rather than silently truncated.
@@ -30,7 +33,8 @@ unsigned cbmc_irep_readert::read_word()
     if (shift_distance >= 64)
     {
       log_error("CBMC goto-binary: malformed varint (too many bytes)");
-      abort();
+      failed_ = true;
+      return 0;
     }
 
     unsigned byte = static_cast<unsigned char>(in.get());
@@ -40,7 +44,8 @@ unsigned cbmc_irep_readert::read_word()
     if (res > UINT32_MAX)
     {
       log_error("CBMC goto-binary: input number {} exceeds 32 bits", res);
-      abort();
+      failed_ = true;
+      return 0;
     }
 
     if ((byte & 0x80) == 0)
@@ -52,6 +57,9 @@ unsigned cbmc_irep_readert::read_word()
 
 std::string cbmc_irep_readert::read_string()
 {
+  if (failed_)
+    return {};
+
   std::string result;
 
   while (in.good())
@@ -76,6 +84,8 @@ std::string cbmc_irep_readert::read_string()
 irep_idt cbmc_irep_readert::read_string_ref()
 {
   unsigned id = read_word();
+  if (failed_)
+    return irep_idt();
 
   auto it = string_cache.find(id);
   if (it != string_cache.end())
@@ -89,6 +99,8 @@ irep_idt cbmc_irep_readert::read_string_ref()
 void cbmc_irep_readert::read_reference(irept &irep)
 {
   unsigned id = read_word();
+  if (failed_)
+    return;
 
   auto it = irep_cache.find(id);
   if (it != irep_cache.end())
@@ -105,31 +117,36 @@ void cbmc_irep_readert::read_irep(irept &irep)
 {
   irep.id(read_string_ref());
 
-  while (in.peek() == 'S')
+  // Guard each loop on failed_ so a malformed child (which sets the flag deep
+  // in read_reference) stops the walk instead of spinning on garbage bytes.
+  while (!failed_ && in.peek() == 'S')
   {
     in.get();
     irep.get_sub().emplace_back();
     read_reference(irep.get_sub().back());
   }
 
-  while (in.peek() == 'N')
+  while (!failed_ && in.peek() == 'N')
   {
     in.get();
     irep_idt name = read_string_ref();
     read_reference(irep.add(name));
   }
 
-  while (in.peek() == 'C')
+  while (!failed_ && in.peek() == 'C')
   {
     in.get();
     irep_idt name = read_string_ref();
     read_reference(irep.add(name));
   }
+
+  if (failed_)
+    return;
 
   if (in.get() != 0)
   {
     log_error("CBMC goto-binary: irep not terminated");
-    abort();
+    failed_ = true;
   }
 }
 
@@ -164,6 +181,9 @@ bool parse_cbmc_goto(
   result.symbols.reserve(number_of_symbols);
   for (unsigned i = 0; i < number_of_symbols; i++)
   {
+    if (reader.failed())
+      return true;
+
     cbmc_symbolt sym;
     reader.read_reference(sym.stype);
     reader.read_reference(sym.value);
@@ -209,6 +229,9 @@ bool parse_cbmc_goto(
   result.functions.reserve(number_of_functions);
   for (unsigned i = 0; i < number_of_functions; i++)
   {
+    if (reader.failed())
+      return true;
+
     cbmc_functiont function;
     function.name = reader.read_string(); // raw string, not a string ref
     unsigned number_of_instructions = reader.read_word();
@@ -216,6 +239,9 @@ bool parse_cbmc_goto(
 
     for (unsigned j = 0; j < number_of_instructions; j++)
     {
+      if (reader.failed())
+        return true;
+
       cbmc_instructiont instruction;
       reader.read_reference(instruction.code);
       reader.read_reference(instruction.source_location);
@@ -238,6 +264,11 @@ bool parse_cbmc_goto(
 
     result.functions.push_back(std::move(function));
   }
+
+  // A malformed encoding anywhere above leaves the reader in a failed state
+  // with a partial parse; report it as a recoverable error, not a success.
+  if (reader.failed())
+    return true;
 
   return false;
 }

--- a/src/goto-programs/read_cbmc_goto_object.h
+++ b/src/goto-programs/read_cbmc_goto_object.h
@@ -37,10 +37,20 @@ public:
   /// Reads a word-tagged, cached irep reference (with S/N/C children).
   void read_reference(irept &dest);
 
+  /// True once a malformed encoding was hit. The reader then abandons the rest
+  /// of the parse cleanly (subsequent reads no-op) instead of aborting the
+  /// process, so a corrupt CBMC binary is a recoverable error rather than a
+  /// crash (roadmap §4.7). parse_cbmc_goto surfaces this as its bool return.
+  bool failed() const
+  {
+    return failed_;
+  }
+
 private:
   void read_irep(irept &dest);
 
   std::istream &in;
+  bool failed_ = false;
   std::map<unsigned, irept> irep_cache;
   std::map<unsigned, irep_idt> string_cache;
 };

--- a/unit/goto-programs/read_cbmc_goto_object.test.cpp
+++ b/unit/goto-programs/read_cbmc_goto_object.test.cpp
@@ -96,6 +96,70 @@ TEST_CASE("rejects a non-CBMC header", "[cbmc-reader]")
   REQUIRE(parse_cbmc_goto(in, "fake.goto", result) == true);
 }
 
+TEST_CASE(
+  "read_word flags a >32-bit varint instead of aborting",
+  "[cbmc-reader]")
+{
+  // 0x80 0x80 0x80 0x80 0x10 decodes to 0x10 << 28 == 2^32, one past UINT32_MAX.
+  std::istringstream in(
+    std::string("\x80\x80\x80\x80\x10", 5), std::ios::binary);
+  cbmc_irep_readert reader(in);
+
+  reader.read_word();
+  REQUIRE(reader.failed());
+}
+
+TEST_CASE(
+  "read_word flags an over-long varint instead of aborting",
+  "[cbmc-reader]")
+{
+  // Eleven continuation bytes (all value bits zero) push the shift past 64 bits
+  // without ever exceeding UINT32_MAX, so this exercises the length guard.
+  std::istringstream in(std::string(11, '\x80'), std::ios::binary);
+  cbmc_irep_readert reader(in);
+
+  reader.read_word();
+  REQUIRE(reader.failed());
+}
+
+TEST_CASE(
+  "recovers from a truncated binary instead of aborting",
+  "[cbmc-reader]")
+{
+  // Valid magic + version + a symbol count of one, then the stream ends
+  // mid-symbol: the reader must report a recoverable error, not abort().
+  std::string bytes;
+  bytes += '\x7f';
+  bytes += 'G';
+  bytes += 'B';
+  bytes += 'F';
+  bytes += encode_varint(6); // version
+  bytes += encode_varint(1); // one symbol announced...
+  // ...but no symbol body follows.
+
+  std::istringstream in(bytes, std::ios::binary);
+  cbmc_parse_resultt result;
+  REQUIRE(parse_cbmc_goto(in, "truncated.goto", result) == true);
+}
+
+TEST_CASE("reads no-op after the reader has failed", "[cbmc-reader]")
+{
+  // Trip the failure with an over-wide varint, then confirm the higher-level
+  // readers short-circuit cleanly (no consuming, no throw) instead of acting on
+  // the corrupt stream.
+  std::istringstream in(
+    std::string("\x80\x80\x80\x80\x10", 5), std::ios::binary);
+  cbmc_irep_readert reader(in);
+
+  REQUIRE(reader.read_word() == 0);
+  REQUIRE(reader.failed());
+
+  REQUIRE(reader.read_string_ref() == irep_idt());
+  irept dummy;
+  reader.read_reference(dummy);
+  REQUIRE(reader.failed());
+}
+
 TEST_CASE("parses a real CBMC v6 goto-binary", "[cbmc-reader]")
 {
   const std::string path = std::string(CBMC_TEST_DATA_DIR) + "/cbmc_hello.goto";


### PR DESCRIPTION
## What

The CBMC goto-binary reader (`read_cbmc_goto_object.cpp`) `abort()`ed the entire
process on malformed input at three sites:

- an over-wide varint (a word > 32 bits),
- an over-long varint (shift past 64 bits),
- an unterminated irep.

This replaces those `abort()` calls with a `cbmc_irep_readert::failed()` flag
that short-circuits the rest of the parse — subsequent reads no-op and the
`S`/`N`/`C` child loops stop — and surfaces through `parse_cbmc_goto`'s existing
`bool` return as a **recoverable error**, exactly like the already-graceful
bad-magic and wrong-version paths. A corrupt `--binary` input now produces a
clean diagnostic instead of crashing the whole run.

## Why

Roadmap [§4.7 Versioning & robustness](https://github.com/esbmc/esbmc/blob/master/docs/cprover-support-roadmap.md):
_"the reader `abort()`s on malformed input rather than returning a recoverable
error."_ This discharges the abort→recoverable half of that item.

## Tests

New Catch2 cases in `read_cbmc_goto_object.test.cpp`:

- over-wide varint sets `failed()` (no abort),
- over-long varint sets `failed()` (no abort),
- a truncated binary makes `parse_cbmc_goto` return `true` without aborting,
- reads no-op after the reader has failed.

All 12 reader unit tests pass (77 assertions); the full `goto-transcoder`
regression suite (27 tests) stays green — well-formed binaries are unaffected,
since the guards only trip on malformed input.

## Scope

Reader-only (`read_cbmc_goto_object.{h,cpp}` + its unit test, plus a §4.7 doc
note). Does not touch `cbmc_adapter.cpp`, so it is conflict-free with the other
open CBMC builtin-rewrite PRs. Still open (noted in §4.7): multi-version
tolerance, and bounding table counts against a huge `reserve()`.