### PR TITLE
[python] Read mixed int/float dict values by runtime type_id

### DIFF
--- a/regression/python/dict_mixed_value/main.py
+++ b/regression/python/dict_mixed_value/main.py
@@ -1,0 +1,23 @@
+# A dict with mixed int/float values now reads every value correctly. The
+# subscript read used one static value type (from the first value), so it
+# misread whichever value carried the other type; e.g. {0: 1, 1: 2.5}[1]
+# read 2.5's bits through the int path. Values are read by their runtime
+# type_id instead. Covers int-first, float-first, three values, string
+# keys, and a value assigned via d[k]=v.
+d = {0: 1, 1: 2.5}
+assert d[0] == 1
+assert d[1] == 2.5
+e = {0: 2.5, 1: 1}
+assert e[0] == 2.5
+assert e[1] == 1
+f = {0: 1, 1: 2.5, 2: 3}
+assert f[1] == 2.5 and f[2] == 3
+g = {"a": 1, "b": 2.5}
+assert g["b"] == 2.5
+h = {0: 1}
+h[1] = 2.5
+assert h[1] == 2.5 and h[0] == 1
+# A >32-bit int value must survive the widened read (regresses reading it as
+# a 32-bit long under LLP64/ILP32 instead of int64).
+k = {0: 5000000000, 1: 2.5}
+assert k[0] == 5000000000

--- a/regression/python/dict_mixed_value/test.desc
+++ b/regression/python/dict_mixed_value/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_mixed_value_fail/main.py
+++ b/regression/python/dict_mixed_value_fail/main.py
@@ -1,0 +1,3 @@
+# {0: 1, 1: 2.5}[1] is 2.5, not 2 (the old truncated/misread value).
+d = {0: 1, 1: 2.5}
+assert d[1] == 2

--- a/regression/python/dict_mixed_value_fail/test.desc
+++ b/regression/python/dict_mixed_value_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/python-dict/dict_access.cpp
+++ b/src/python-frontend/python-dict/dict_access.cpp
@@ -271,7 +271,9 @@ exprt python_dict_handler::handle_dict_subscript(
                                   : std::string();
     const std::string vals_id =
       dict_id.empty() ? std::string() : get_internal_list_id(dict_id, false);
-    if (!vals_id.empty() && python_list::has_mixed_numeric_types(vals_id))
+    if (
+      !vals_id.empty() &&
+      python_list::has_mixed_numeric_types(dict_value_types_key(vals_id)))
     {
       const size_t float_type_id =
         std::hash<std::string>{}(type_handler_.type_to_string(
@@ -415,7 +417,8 @@ void python_dict_handler::handle_dict_subscript_assign(
     const std::string vals_id =
       get_internal_list_id(dict_expr.identifier().as_string(), false);
     if (!vals_id.empty())
-      list_handler.add_type_info(vals_id, std::string(), value.type());
+      list_handler.add_type_info(
+        dict_value_types_key(vals_id), std::string(), value.type());
   }
 
   symbolt &index_var = converter_.create_tmp_symbol(

--- a/src/python-frontend/python-dict/dict_access.cpp
+++ b/src/python-frontend/python-dict/dict_access.cpp
@@ -252,6 +252,56 @@ exprt python_dict_handler::handle_dict_subscript(
     return build_symbol(list_result);
   }
 
+  // A heterogeneous int/float dict stores each value inline with its own
+  // type_id and native bit pattern (the float path is disabled for mixed
+  // dicts — see dict_construction.cpp — so there is no float_buf indirection).
+  // A single static resolved_type misreads whichever value carries the other
+  // type: {0: 1, 1: 2.5} resolves to int and reads 2.5's bits through the int
+  // path, and symmetrically {0: 2.5, 1: 1} misreads the int. Read by the
+  // value's runtime type_id instead, yielding a double either way (int values
+  // widen; value equality still holds), mirroring how .values()/dict_eq read a
+  // mixed dict. Only literal-built dicts have a values-list in the map; a dict
+  // parameter returns an empty id and falls through to the static paths below.
+  if (
+    resolved_type.is_signedbv() || resolved_type.is_unsignedbv() ||
+    resolved_type.is_floatbv())
+  {
+    const std::string dict_id = dict_expr.is_symbol()
+                                  ? dict_expr.identifier().as_string()
+                                  : std::string();
+    const std::string vals_id =
+      dict_id.empty() ? std::string() : get_internal_list_id(dict_id, false);
+    if (!vals_id.empty() && python_list::has_mixed_numeric_types(vals_id))
+    {
+      const size_t float_type_id =
+        std::hash<std::string>{}(type_handler_.type_to_string(
+          type_handler_.get_typet(std::string("float"))));
+      // Python int values are stored as long_long (64-bit) and read as int64_t
+      // by the model (list.c), so recover them at that width — not
+      // config.ansi_c.long_int_width, which is 32 under LLP64/ILP32. (Bignum
+      // --int-encoding stores ints wider than 8 bytes and is out of scope here,
+      // matching list.c's own size==8-gated numeric path.)
+      const typet long_t = long_long_int_type();
+
+      exprt tid = build_member(deref_obj, "type_id", size_type());
+      exprt is_float =
+        equality_exprt(tid, from_integer(float_type_id, size_type()));
+
+      exprt as_double = build_dereference(
+        build_typecast(obj_value, pointer_typet(double_type())), double_type());
+      as_double.type() = double_type();
+
+      exprt as_int = build_dereference(
+        build_typecast(obj_value, pointer_typet(long_t)), long_t);
+      as_int.type() = long_t;
+
+      exprt result =
+        if_exprt(is_float, as_double, build_typecast(as_int, double_type()));
+      result.type() = double_type();
+      return result;
+    }
+  }
+
   // Handle float types
   if (resolved_type.is_floatbv())
   {
@@ -355,6 +405,18 @@ void python_dict_handler::handle_dict_subscript_assign(
       "__ESBMC_list_set_at not found - add it to list.c model");
 
   python_list list_handler(converter_, node);
+
+  // Record the assigned value's type so a later subscript read can detect a
+  // heterogeneous int/float dict: a value assigned via d[k]=v reaches the same
+  // misread path as a mixed literal (see handle_dict_subscript). Only
+  // literal-built dicts (including `{}` then assigned) have a values-list id.
+  if (dict_expr.is_symbol())
+  {
+    const std::string vals_id =
+      get_internal_list_id(dict_expr.identifier().as_string(), false);
+    if (!vals_id.empty())
+      list_handler.add_type_info(vals_id, std::string(), value.type());
+  }
 
   symbolt &index_var = converter_.create_tmp_symbol(
     node, "$dict_update_idx$", size_type(), gen_zero(size_type()));

--- a/src/python-frontend/python-dict/dict_construction.cpp
+++ b/src/python-frontend/python-dict/dict_construction.cpp
@@ -609,11 +609,17 @@ exprt python_dict_handler::create_dict_from_literal(
       exprt push_value = list_handler.build_push_list_call(
         values_list, element, value_expr, all_values_float);
       converter_.add_instruction(push_value);
-      // Record the value's type so has_mixed_numeric_types() can detect a
-      // heterogeneous int/float dict at the subscript read site (where a
-      // single static value type otherwise misreads the other type's bits).
+      // Record the value's type under a dedicated key so
+      // has_mixed_numeric_types() can detect a heterogeneous int/float dict at
+      // the subscript read site (where a single static value type otherwise
+      // misreads the other type's bits). It must NOT be recorded under the
+      // values-list's own id: that would flip the .values()/.items() list read
+      // onto the generic mixed-list path, which reads dict value storage
+      // incorrectly (github_3719_4).
       list_handler.add_type_info(
-        values_list.id.as_string(), std::string(), value_expr.type());
+        dict_value_types_key(values_list.id.as_string()),
+        std::string(),
+        value_expr.type());
     }
   }
 

--- a/src/python-frontend/python-dict/dict_construction.cpp
+++ b/src/python-frontend/python-dict/dict_construction.cpp
@@ -609,6 +609,11 @@ exprt python_dict_handler::create_dict_from_literal(
       exprt push_value = list_handler.build_push_list_call(
         values_list, element, value_expr, all_values_float);
       converter_.add_instruction(push_value);
+      // Record the value's type so has_mixed_numeric_types() can detect a
+      // heterogeneous int/float dict at the subscript read site (where a
+      // single static value type otherwise misreads the other type's bits).
+      list_handler.add_type_info(
+        values_list.id.as_string(), std::string(), value_expr.type());
     }
   }
 

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -480,6 +480,18 @@ public:
     return it != m.end() ? it->second : empty;
   }
 
+  /// Key under which a literal dict's per-value element types are recorded in
+  /// the shared list_type_map, for detecting a heterogeneous int/float dict at
+  /// the subscript read site. Deliberately distinct from the values-list's own
+  /// symbol id: recording value types under that id would flip the
+  /// .values()/.items() list read onto the generic mixed-list path, which reads
+  /// dict value storage incorrectly (github_3719_4). The "$dict_value_types$"
+  /// prefix cannot collide with a real list symbol id.
+  static std::string dict_value_types_key(const std::string &vals_id)
+  {
+    return "$dict_value_types$" + vals_id;
+  }
+
   /**
    * @brief Handles dict.update() method calls.
    * Implements Python's dict.update(other) semantics:


### PR DESCRIPTION
## What

Fixes a wrong-verdict (soundness) bug: a dict with **mixed int/float values** misread subscripts. `{0: 1, 1: 2.5}[1]` read the float `2.5`'s bits through the int path (and symmetrically `{0: 2.5, 1: 1}[1]` misread the int). Reading via `.values()` already worked, which is why the bug looked narrow.

## Root cause

`handle_dict_subscript` picks one static `resolved_type` (inferred from the first value) and dereferences every stored value through it. But a heterogeneous dict stores each value **inline with its own `type_id`** and native bit pattern — the float→`float_buf` path is disabled for mixed dicts by construction. `.values()` and `__ESBMC_dict_eq` already read such storage by runtime `type_id`; the subscript read did not.

## Fix

1. **`dict_access.cpp`** — when the dict's values-list is mixed-numeric, read by runtime `type_id`: `(obj->type_id == float_type_id) ? *(double*)obj->value : (double)*(int64*)obj->value`, result typed `double`. `float_type_id` is computed exactly as `dict_compare.cpp` does; the integer branch reads at `long_long` (int64) width to match storage (`list.c` reads the same as `int64_t`).
2. **`dict_construction.cpp`** + the `d[k]=v` assign path — record each value's type in the values-list `list_type_map` (mirroring what already happens for keys), so `has_mixed_numeric_types` can detect a mixed dict at the read site.

Only literal-built dicts (including `{}` then assigned) have a values-list id; a dict parameter, comprehension, or `dict()`/`update` falls through to the unchanged static paths (out of scope — missing coverage, not a regression). Integer use of a mixed-dict element therefore goes through `double` (Python unifies int/float; `1 == 1.0`).

## Tests

- `dict_mixed_value` (CORE) — int-first, float-first, three values, string keys, `d[k]=v` assign, and a >32-bit int value (regresses the int64-vs-int32 read width).
- `dict_mixed_value_fail` (CORE) — pins that `{0: 1, 1: 2.5}[1] != 2`.

All CPython-sane. Dict regression suite passes with zero real regressions (remaining local failures are all `--z3`/`--boolector`/`--ir` environmental — Bitwuzla-only build). Code review: one major finding (int read width) fixed; the int→double widening and bignum `--int-encoding` boundary are documented pre-existing tradeoffs shared with `list.c`.
