### PR TITLE
[python] Size len() of an inline str.encode() by element count

### DIFF
--- a/regression/python/len_str_encode/main.py
+++ b/regression/python/len_str_encode/main.py
@@ -1,0 +1,9 @@
+# len(s.encode()) on an inline call now sizes the bytes by element count.
+# The encoded bytes are a wide-int array whose zero high bytes made strlen
+# stop early, so the inline form (unlike a materialised variable) returned a
+# wrong length.
+assert len("abc".encode()) == 3
+assert len("".encode()) == 0
+assert len("hello world".encode()) == 11
+b = "abcde".encode()
+assert len(b) == 5

--- a/regression/python/len_str_encode/test.desc
+++ b/regression/python/len_str_encode/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/len_str_encode_fail/main.py
+++ b/regression/python/len_str_encode_fail/main.py
@@ -1,0 +1,2 @@
+# len("abc".encode()) is 3, not 5.
+assert len("abc".encode()) == 5

--- a/regression/python/len_str_encode_fail/test.desc
+++ b/regression/python/len_str_encode_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -403,6 +403,14 @@ symbol_id function_call_builder::build_function_id() const
         function_id.set_function(func_name);
         return function_id;
       }
+      else if (
+        arg.contains("func") && arg["func"].is_object() &&
+        arg["func"].value("_type", "") == "Attribute" &&
+        arg["func"].value("attr", "") == "encode")
+        // len(s.encode()): the encoded bytes are a wide-int array whose zero
+        // high bytes make strlen stop at the first element, so size by element
+        // count instead (matches the bytes variable and bytes-slice paths).
+        func_name = kGetObjectSize;
     }
     else if (arg["_type"] == "List")
       func_name = kGetObjectSize;


### PR DESCRIPTION
## What

Fixes a wrong-verdict (soundness) bug: `len("abc".encode())` — `len()` of an **inline** `str.encode()` call — returned a wrong length.

## Root cause

`encode()` returns Python bytes, which ESBMC models as a wide-int array whose elements carry zero high bytes. The default `len` path uses `strlen`, which stops at the first element's zero high byte → wrong length (even for pure-ASCII strings). A bytes *variable* (`b = "abc".encode(); len(b)`) already worked, because the `len` handler's Name branch routes a bytes-typed variable to `__ESBMC_get_object_size` (element count). But the inline-Call branch only special-cased `range`/`set`/`dict` by `func["id"]`, so an `encode()` — an Attribute call — fell through to `strlen`.

## Fix

One `else if` in the inline-Call branch of the `len` dispatch (`builder.cpp`): when the argument is an Attribute call with `attr == "encode"`, route `len` to `__ESBMC_get_object_size` (count elements), mirroring the existing bytes-variable and bytes-slice paths.

## Tests

- `len_str_encode` (CORE) — inline `len(s.encode())` for several strings incl. empty, plus the variable form.
- `len_str_encode_fail` (CORE) — pins that `len("abc".encode()) != 5`.

Both CPython-sane. Guards unchanged: `len("abc")`, `len("ab".upper())`, `len([1,2,3])`, `len(b"abcd")`, and a user-defined `.encode()` returning a list all still size correctly.

Out of scope (separate pre-existing limitations, verified to fail via the variable form too, i.e. not touched by this change): the `bytes(str, encoding)` constructor's length, and `.encode("ascii")` / non-ASCII multibyte encodings.
