### PR TITLE
[python] Dispatch len() to a user-defined __len__

### DIFF
--- a/regression/python/len_dunder/main.py
+++ b/regression/python/len_dunder/main.py
@@ -1,0 +1,17 @@
+# len(obj) now dispatches to a user-defined __len__. The builtin len path
+# only recognises the model container types, so len over a user class used
+# to fall through to strlen on the struct and return a wrong length.
+# (An inline instance like len(Box(3)) is a separate, pre-existing gap: the
+# class of an unnamed instance is not resolved, so it is not covered here.)
+class Box:
+    def __init__(self, n):
+        self.n = n
+
+    def __len__(self):
+        return self.n
+
+
+b = Box(7)
+assert len(b) == 7
+e = Box(0)
+assert len(e) == 0

--- a/regression/python/len_dunder/test.desc
+++ b/regression/python/len_dunder/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/len_dunder_fail/main.py
+++ b/regression/python/len_dunder_fail/main.py
@@ -1,0 +1,8 @@
+# __len__ returns 4, so len(c) is 4, not 5.
+class C:
+    def __len__(self):
+        return 4
+
+
+c = C()
+assert len(c) == 5

--- a/regression/python/len_dunder_fail/test.desc
+++ b/regression/python/len_dunder_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -864,6 +864,21 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
   }
 
+  // len(obj) where obj's class defines __len__: dispatch to obj.__len__().
+  // The builtin len path only recognises the model container types (list,
+  // tuple, dict, str/bytes), so a user-defined __len__ is otherwise ignored
+  // and len falls through to strlen over the struct — a wrong length.
+  if (
+    element.contains("func") && element["func"].is_object() &&
+    element["func"].value("_type", "") == "Name" &&
+    element["func"].value("id", "") == "len" && element.contains("args") &&
+    element["args"].is_array() && element["args"].size() == 1 &&
+    has_dunder_method(element["args"][0], "__len__"))
+  {
+    return get_expr(build_dunder_call(
+      element["args"][0], "__len__", nlohmann::json::array(), element));
+  }
+
   function_call_builder call_builder(*this, element);
   exprt call_expr = call_builder.build();
 


### PR DESCRIPTION
## What

Fixes a wrong-verdict (soundness) bug: `len(obj)` where `obj` is a user-defined class instance with a `__len__` method returned a wrong length.

## Root cause

The builtin `len` dispatch only recognises the model container types (list, tuple, dict, str/bytes, range, set). A user-defined `__len__` was never consulted, so `len(user_obj)` fell through to `strlen` over the instance struct and returned a wrong length.

## Fix

An early hook in `python_converter::get_function_call`, before the `function_call_builder` dispatch: when the call is `len(x)` (a Name-func call with exactly one argument) and `has_dunder_method(x, "__len__")` holds, convert `build_dunder_call(x, "__len__", [], element)` instead — i.e. rewrite `len(x)` to `x.__len__()`. This reuses the exact dunder machinery already used for `__getitem__`/`__setitem__` dispatch, and only fires for a class that actually defines `__len__`, so every builtin-container `len` path is untouched.

## Tests

- `len_dunder` (CORE) — `len(obj)` for a user class defining `__len__` (constant and `self.n`-based).
- `len_dunder_fail` (CORE) — pins that a wrong expected length fails.

Both CPython-sane. Guards verified unchanged: `len` of list / str / tuple / dict-variable / range / set, a class without `__len__`, and `len(c.attr_list)`. Nested `len` inside `__len__` (`return len(self.items)`) works with no recursion (the rewritten call is an Attribute call, not `len(...)`).

Out of scope (separate pre-existing gaps, not regressions): an **inline** instance `len(Box(3))` (the class of an unnamed instance is not resolved by `has_dunder_method`), and an **inherited** `__len__` (`class B(A)` — the dunder lookup checks the direct class only, as the existing `__getitem__`/`__eq__` dispatch does).
