### PR TITLE
[python] Resolve attribute access on an inline class instance

### DIFF
--- a/regression/python/inline_instance_attr/main.py
+++ b/regression/python/inline_instance_attr/main.py
@@ -1,0 +1,23 @@
+# Attribute access on an inline (unnamed) instance now works: C().attr used
+# to abort with "Unsupported Attribute value type: Call". A named instance
+# (c = C(); c.x) already worked; this covers the inline case, including
+# dataclasses and use inside a larger expression.
+class C:
+    def __init__(self, v):
+        self.x = v
+
+
+assert C(5).x == 5
+assert C(3).x + C(4).x == 7
+
+from dataclasses import dataclass
+
+
+@dataclass
+class P:
+    x: int
+    y: int
+
+
+assert P(1, 2).x == 1
+assert P(1, 2).y == 2

--- a/regression/python/inline_instance_attr/test.desc
+++ b/regression/python/inline_instance_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/inline_instance_attr_fail/main.py
+++ b/regression/python/inline_instance_attr_fail/main.py
@@ -1,0 +1,7 @@
+class C:
+    def __init__(self, v):
+        self.x = v
+
+
+# C(5).x is 5, not 6.
+assert C(5).x == 6

--- a/regression/python/inline_instance_attr_fail/test.desc
+++ b/regression/python/inline_instance_attr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -810,6 +810,25 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           "Cannot resolve attribute '{}' on subscript result", attr_name);
         abort();
       }
+      else if (element["value"]["_type"] == "Call")
+      {
+        // Attribute access on an inline call result, e.g. `C().attr`. Convert
+        // the call to its (materialised) instance and resolve the member on
+        // it, the same way `d[k].attr` is handled above. A named instance
+        // (`c = C(); c.attr`) already works; this covers the unnamed case.
+        exprt base_expr = get_expr(element["value"]);
+        const std::string &attr_name = element["attr"].get<std::string>();
+
+        exprt resolved = resolve_member_on_base(base_expr, attr_name);
+        if (!resolved.is_nil())
+        {
+          expr = resolved;
+          break;
+        }
+
+        log_error("Cannot resolve attribute '{}' on call result", attr_name);
+        abort();
+      }
       else
       {
         log_error(


### PR DESCRIPTION
## What

Fixes attribute access on an **inline (unnamed) class instance** — `C().x`, `C(9).x`, and dataclass `P(1, 2).x` — which aborted with `ERROR: Unsupported Attribute value type: Call`.

## Root cause

In the Attribute-conversion switch in `get_expr` (`converter_expr.cpp`), `element["value"]["_type"]` had cases for a nested `Attribute` (chains), a `Name` (a variable), and a `Subscript` (`d[k].attr`), then an `else` that aborts with "Unsupported Attribute value type". A `Call` value — the inline-instance case `C().attr` — fell into that `else`. A named instance (`c = C(); c.x`) and an inline *method* call (`C().f()`) already worked; only inline *attribute* access aborted.

## Fix

Add a `Call` case that mirrors the existing `Subscript` case exactly: `get_expr(element["value"])` materialises the inline call to its instance, then `resolve_member_on_base(base_expr, attr_name)` resolves the field. On success it sets the result and breaks; on failure it logs and aborts, consistent with the sibling branches.

## Tests

- `inline_instance_attr` (CORE) — `C(v).x`, two inline instances in one expression (`C(3).x + C(4).x`), and dataclass `P(1, 2).x` / `.y`.
- `inline_instance_attr_fail` (CORE) — pins that `C(5).x != 6`.

Both CPython-sane. Also verified: nested inline attribute access (`Outer().inner.v`), and the named-instance / inline-method / `d[k].attr` (subscript) paths are unchanged. Non-class call results and inline method-with-init-arg remain separate pre-existing gaps (unchanged behaviour, not touched by this diff).
