### PR TITLE
[python] Add KNOWNBUG for inline-instance method reading self.attr

### DIFF
--- a/regression/python/inline_instance_method_self/main.py
+++ b/regression/python/inline_instance_method_self/main.py
@@ -1,0 +1,17 @@
+# KNOWNBUG: calling a method that reads self.<attr> on an inline (unnamed)
+# class instance returns a wrong result. The named form (c = C(5); c.get())
+# works, and inline attribute access (C(5).x, PR #5821) works, but an inline
+# instance is not materialised as the method's `self`, so self.x reads
+# garbage. A method whose name collides with a dict method (get/pop/...)
+# additionally misroutes to the dict handler ("Dictionary variable not
+# found"). The fix needs the method-dispatch path (function_call/expr.cpp,
+# obj_symbol resolution) to spill an inline receiver into a temp used as self.
+class C:
+    def __init__(self, v):
+        self.x = v
+
+    def compute(self):
+        return self.x * 2
+
+
+assert C(5).compute() == 10

--- a/regression/python/inline_instance_method_self/test.desc
+++ b/regression/python/inline_instance_method_self/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## What

Pins a KNOWNBUG reproducer: calling a method that reads `self.<attr>` on an **inline (unnamed) class instance** returns a wrong result.

```python
class C:
    def __init__(self, v):
        self.x = v
    def compute(self):
        return self.x * 2

assert C(5).compute() == 10   # VERIFICATION FAILED (should hold)
```

## Why it's a KNOWNBUG (not a fix)

The bug is real but the fix is a multi-point change larger than one focused PR. The scope:
- The **named** form (`c = C(5); c.compute()`) works.
- Inline **attribute** access (`C(5).x`) works since #5821.
- Only the inline **method-dispatch** path is affected: the inline instance is not materialised as the method's `self`, so `self.x` reads garbage. A method whose name collides with a dict method (`get`/`pop`/…) additionally misroutes to the dict handler (`ERROR: Dictionary variable not found`).

The fix requires three coordinated changes (explored, not landed): (1) `type_handler::get_var_classname` to resolve an inline `Call`'s class; (2) `receiver_is_non_dict_object` to defer an inline receiver to instance dispatch; and (3) the method-dispatch path (`function_call/expr.cpp`, `obj_symbol` resolution ~L3692) to spill the inline receiver into a temp used as `self` — with `obj_symbol_id` kept consistent for `update_instance_from_self` and `finalize_call`. (1)+(2) alone convert the error into a wrong verdict, so all three must land together.

## Test

- `regression/python/inline_instance_method_self` (KNOWNBUG) — valid CPython reference (asserted holds), recorded as expected-fail. The test comment carries the root-cause roadmap for the eventual fix.
