### PR TITLE
[clang-cpp-frontend] Initialise vptr in cross-TU constructor bodies

### DIFF
--- a/regression/esbmc-cpp/cpp/ch10_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch10_4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 point.cpp circle.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/main.cpp
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/main.cpp
@@ -1,0 +1,13 @@
+#include "shape.h"
+#include <cassert>
+int main()
+{
+  Shape s(7);
+  Shape *p = &s;
+  assert(p->kind() == 1); // base object dispatches to Shape::kind
+
+  Circle c(9);
+  Circle *q = &c;
+  assert(q->kind() == 2); // derived object dispatches to Circle::kind
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/shape.cpp
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/shape.cpp
@@ -1,0 +1,5 @@
+#include "shape.h"
+Shape::Shape(int id) : id_(id) {}
+int Shape::kind() const { return 1; }
+Circle::Circle(int id) : Shape(id) {}
+int Circle::kind() const { return 2; }

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/shape.h
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/shape.h
@@ -1,0 +1,20 @@
+#pragma once
+// The virtual method AND the constructor are only declared here; both are
+// defined in shape.cpp — a different translation unit from main.cpp.  The vptr
+// initialisation a constructor performs used to be driven by a flag that was
+// only set while the *class* was being converted, so a constructor body
+// converted in another TU emitted no vptr assignment.  Virtual dispatch then
+// found no target ("dereference failure: invalid pointer").
+class Shape
+{
+public:
+  Shape(int id);
+  virtual int kind() const; // base returns 1
+  int id_;
+};
+class Circle : public Shape
+{
+public:
+  Circle(int id);
+  int kind() const override; // returns 2
+};

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/test.desc
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+shape.cpp --unwind 2
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/main.cpp
@@ -1,0 +1,10 @@
+#include "shape.h"
+#include <cassert>
+int main()
+{
+  Shape s(7);
+  Shape *p = &s;
+  // Shape::kind() returns 1, so this assertion must fail.
+  assert(p->kind() == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/shape.cpp
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/shape.cpp
@@ -1,0 +1,5 @@
+#include "shape.h"
+Shape::Shape(int id) : id_(id) {}
+int Shape::kind() const { return 1; }
+Circle::Circle(int id) : Shape(id) {}
+int Circle::kind() const { return 2; }

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/shape.h
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/shape.h
@@ -1,0 +1,20 @@
+#pragma once
+// The virtual method AND the constructor are only declared here; both are
+// defined in shape.cpp — a different translation unit from main.cpp.  The vptr
+// initialisation a constructor performs used to be driven by a flag that was
+// only set while the *class* was being converted, so a constructor body
+// converted in another TU emitted no vptr assignment.  Virtual dispatch then
+// found no target ("dereference failure: invalid pointer").
+class Shape
+{
+public:
+  Shape(int id);
+  virtual int kind() const; // base returns 1
+  int id_;
+};
+class Circle : public Shape
+{
+public:
+  Circle(int id);
+  int kind() const override; // returns 2
+};

--- a/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/vptr_cross_tu_ctor_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+shape.cpp --unwind 2
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2316,12 +2316,33 @@ bool clang_cpp_convertert::annotate_class_method(
     {
       fd_symb->set_type(component_type);
       /*
-       * we indicate the need for vptr initializations in contructor.
-       * vptr initializations will be added in the adjuster.
+       * We indicate the need for vptr initializations in the ctor/dtor;
+       * they are added in the adjuster.
+       *
+       * `has_vptr_component` is only set while the enclosing class is being
+       * converted, so it is stale (false) when a ctor/dtor body is converted
+       * in a different translation unit than the one that first set up the
+       * class' vtable — the vptr init would then be dropped and virtual calls
+       * during construction/destruction would find no target (multi-TU
+       * polymorphic classes). Fall back to inspecting the already-built class
+       * symbol for a vtable-pointer component, exactly as the adjuster does.
        */
+      bool needs_vptr_init = has_vptr_component;
+      if (!needs_vptr_init)
+      {
+        const symbolt *class_symb = context.find_symbol(parent_class_id);
+        if (class_symb && class_symb->get_type().is_struct())
+          for (const auto &c :
+               to_struct_type(class_symb->get_type()).components())
+            if (c.get_bool("is_vtptr"))
+            {
+              needs_vptr_init = true;
+              break;
+            }
+      }
       {
         exprt v = fd_symb->get_value();
-        v.need_vptr_init(has_vptr_component);
+        v.need_vptr_init(needs_vptr_init);
         fd_symb->set_value(std::move(v));
       }
     }


### PR DESCRIPTION
The need for a constructor/destructor to initialise the class vptr was taken from the transient `has_vptr_component` flag, which is only set while the enclosing class is being converted. When a ctor/dtor body is defined in a different translation unit than the one that first set up the class' vtable, the flag is stale (false), so the body emitted no vptr assignment; a virtual call on such an object then found no target and reported a spurious `dereference failure: invalid pointer`.

This falls back to inspecting the already-built class symbol for a vtable-pointer component — exactly the condition the adjuster uses. Flips `cpp/ch10_4` from KNOWNBUG to CORE and adds `vptr_cross_tu_ctor{,_fail}` regression tests. No regressions across 2367 esbmc-cpp tests.