### PR TITLE
[python] Add KNOWNBUG for bytes method result mis-folded to str

### DIFF
--- a/regression/python/bytes_method_not_str_fail/main.py
+++ b/regression/python/bytes_method_not_str_fail/main.py
@@ -1,0 +1,11 @@
+# KNOWNBUG (unsound false-SUCCESSFUL): a bytes method result is mis-folded to
+# str, so an (always-False in CPython) bytes-vs-str comparison verifies. In
+# CPython b"abc".upper() is b"ABC" (bytes), and b"ABC" == "ABC" is False, so
+# this assertion must FAIL. ESBMC proves it because python_consteval's
+# Constant handler (python_consteval.cpp:728) folds a bytes literal to a
+# STRING (the real bytes live in `encoded_bytes` / the node is tagged
+# `esbmc_type_annotation: "bytes"`, both ignored), so the .upper() fold
+# produces a str. A one-line "decline bytes in the Constant handler" fix would
+# break the ~260 bytes tests that depend on that same fold; the sound fix
+# needs a dedicated BYTES kind in PyConstValue so bytes fold as bytes.
+assert b"abc".upper() == "ABC"

--- a/regression/python/bytes_method_not_str_fail/test.desc
+++ b/regression/python/bytes_method_not_str_fail/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--no-unwinding-assertions --unwind 4
+^VERIFICATION FAILED$


### PR DESCRIPTION
## What

Pins a KNOWNBUG for a confirmed **unsoundness**: a bytes method result is mis-folded to `str`, so an always-False bytes-vs-str comparison verifies SUCCESSFUL.

```python
assert b"abc".upper() == "ABC"   # ESBMC: VERIFICATION SUCCESSFUL (unsound)
```

In CPython `b"abc".upper()` is `b"ABC"` (bytes) and `b"ABC" == "ABC"` is `False`, so a sound verifier must report `VERIFICATION FAILED` (the assertion is violated).

## Root cause

`python_consteval`'s `Constant` handler (`python_consteval.cpp:728`) folds a bytes literal to a `STRING` `PyConstValue`: a bytes literal decodes to the same JSON `value` string as a str literal, and the handler ignores the `encoded_bytes` field / the `esbmc_type_annotation: "bytes"` tag the parser adds. So `b"abc".upper()` folds through the string-method path and yields a `str`.

## Why a KNOWNBUG (not a fix)

The obvious one-line fix — decline bytes in the `Constant` handler — would regress the ~260 existing `b"..."`-literal bytes tests (`bytes_encode_decode`, `bytes_equality`, `bytes_find`, `bytes_hex`, …), all of which depend on that same const-fold to work at all. The sound fix needs a dedicated `BYTES` kind in `PyConstValue` so bytes fold *as bytes* (distinguishable from str in comparisons), which is a larger refactor. Pinning the reproducer tracks the unsoundness until that lands.

## Test

- `regression/python/bytes_method_not_str_fail` (KNOWNBUG) — valid CPython reference (the assertion is False), recorded as expected-fail; the comment carries the root-cause roadmap.
