### PR TITLE
[python] Handle negative literal arguments in str.format()/format()

### DIFF
--- a/regression/python/str_format_negative/main.py
+++ b/regression/python/str_format_negative/main.py
@@ -1,0 +1,15 @@
+# str.format() / format() now handle a negative literal argument. Previously
+# a negative (parsed as UnaryOp(USub, Constant)) was rejected, degrading the
+# whole call to a nondet string, so even "{}".format(-5) could not verify.
+assert "{}".format(-5) == "-5"
+assert "{:d}".format(-5) == "-5"
+assert "{:x}".format(-255) == "-ff"
+assert "{:5d}".format(-42) == "  -42"
+assert "{:.1f}".format(-2.5) == "-2.5"
+assert "{} and {}".format(-1, -2) == "-1 and -2"
+assert "{}-{}".format(5, -3) == "5--3"
+assert format(-7) == "-7"
+# -0 renders "0" (not "-0"); -True/-False fold numerically.
+assert "{}".format(-0) == "0"
+assert "{}".format(-True) == "-1"
+assert "{}".format(-False) == "0"

--- a/regression/python/str_format_negative/test.desc
+++ b/regression/python/str_format_negative/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_format_negative_fail/main.py
+++ b/regression/python/str_format_negative_fail/main.py
@@ -1,0 +1,2 @@
+# "{}".format(-5) is "-5", not "5".
+assert "{}".format(-5) == "5"

--- a/regression/python/str_format_negative_fail/test.desc
+++ b/regression/python/str_format_negative_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -111,6 +111,32 @@ static std::string
 format_value_from_json(const nlohmann::json &arg, python_converter &converter)
 {
   std::string value;
+  // A negative literal parses as UnaryOp(USub, Constant); numerically negate a
+  // constant numeric operand so str.format()/format() handle negatives
+  // (otherwise the whole call degrades to a nondet string). Fold numerically
+  // rather than string-prepending '-' so -0 renders "0" (not "-0"). A nested
+  // unary (--5), a non-numeric operand (-"a", a TypeError in CPython), and
+  // UAdd/Invert fall through to the throw below and stay on the nondet path.
+  if (
+    arg.contains("_type") && arg["_type"] == "UnaryOp" && arg.contains("op") &&
+    arg["op"].is_object() &&
+    arg["op"].value("_type", std::string()) == "USub" &&
+    arg.contains("operand") && arg["operand"].is_object() &&
+    arg["operand"].value("_type", std::string()) == "Constant" &&
+    arg["operand"].contains("value"))
+  {
+    const auto &ov = arg["operand"]["value"];
+    if (ov.is_number_integer())
+      return std::to_string(-ov.get<long long>());
+    if (ov.is_boolean())
+      return ov.get<bool>() ? "-1" : "0";
+    if (ov.is_number_float())
+    {
+      std::ostringstream oss;
+      oss << -ov.get<double>();
+      return oss.str();
+    }
+  }
   if (arg.contains("_type") && arg["_type"] == "Constant")
   {
     if (arg.contains("_bigint"))
@@ -153,9 +179,25 @@ std::string apply_format_spec(
 {
   // Only constant numeric/string literals are folded; anything else (a
   // variable, a computed value) throws and degrades to the nondet fallback.
-  if (arg.value("_type", std::string()) != "Constant" || !arg.contains("value"))
+  // A negative literal parses as UnaryOp(USub, Constant); unwrap it so numeric
+  // specs (including grouping) work on negatives too.
+  const nlohmann::json *cnode = &arg;
+  bool negate = false;
+  if (
+    arg.value("_type", std::string()) == "UnaryOp" && arg.contains("op") &&
+    arg["op"].is_object() &&
+    arg["op"].value("_type", std::string()) == "USub" &&
+    arg.contains("operand") && arg["operand"].is_object() &&
+    arg["operand"].value("_type", std::string()) == "Constant")
+  {
+    cnode = &arg["operand"];
+    negate = true;
+  }
+  if (
+    cnode->value("_type", std::string()) != "Constant" ||
+    !cnode->contains("value"))
     throw std::runtime_error("format spec on a non-constant value");
-  const auto &val = arg["value"];
+  const auto &val = (*cnode)["value"];
 
   enum
   {
@@ -188,6 +230,17 @@ std::string apply_format_spec(
   }
   else
     throw std::runtime_error("format spec on an unsupported constant type");
+
+  // Apply a leading unary minus to the folded numeric value.
+  if (negate)
+  {
+    if (kind == KIND_INT)
+      ival = -ival;
+    else if (kind == KIND_FLOAT)
+      dval = -dval;
+    else
+      throw std::runtime_error("unary minus on a non-numeric format value");
+  }
 
   // Parse the spec.
   size_t p = 0;


### PR DESCRIPTION
## What

Fixes `str.format()` / the `format()` builtin for a **negative literal argument** — even `"{}".format(-5) == "-5"` could not verify.

## Root cause

A negative literal parses as `UnaryOp(USub, Constant)`. Two functions rejected it:
- `format_value_from_json` (renders a `{}` field) threw on the `UnaryOp`, and on a throw the **whole** format call degrades to a nondet string — so nothing formatted.
- `apply_format_spec` (renders a `{:spec}` field) likewise only accepted a bare `Constant`.

## Fix

Handle `UnaryOp(USub, Constant)` in both, folding **numerically**:
- `format_value_from_json`: for a numeric-Constant operand, return the negated number's rendering. Folding numerically (not string-prepending `"-"`) keeps it sound: `-0` → `"0"`, `-True` → `"-1"`, `-False` → `"0"`. A nested unary (`--5`), a non-numeric operand (`-"a"`, `-None` — TypeErrors in CPython), and `UAdd`/`Invert` fall through to the existing throw → **sound nondet**, never a wrong value.
- `apply_format_spec`: unwrap to the inner `Constant`, set a `negate` flag, and negate `ival`/`dval` after folding (throwing for a non-numeric operand). Correct across `d`/`x`/`X`/`o`/`b` and float (`"{:x}".format(-255)` → `"-ff"`, `"{:5d}".format(-42)` → `"  -42"`).

## Tests

- `str_format_negative` (CORE) — `{}`, `{:d}`, `{:x}`, width, `{:.1f}`, two-arg, mixed, `format(-7)`, and the `-0`/`-True`/`-False` soundness edge cases.
- `str_format_negative_fail` (CORE) — pins that `"{}".format(-5) != "5"`.

Both CPython-sane. Positives and string args unchanged; the focused format regression is 100% clean. Composes cleanly with the sibling grouping fix (#5829): once both land, `"{:,}".format(-12345)` → `"-12,345"`.
