### PR TITLE
[python] Fold list.index(x, start[, end]) on a literal receiver

### DIFF
--- a/regression/python/list_index_start/main.py
+++ b/regression/python/list_index_start/main.py
@@ -1,0 +1,10 @@
+# list.index(x, start[, end]) on a literal receiver now folds. Only the
+# single-argument form was folded before; the start/end form fell through to
+# the OM, which errors on a literal receiver. The search is restricted to
+# l[start:end] but the returned index is in the original sequence.
+assert [1, 2, 1, 2].index(2, 2) == 3
+assert [1, 2, 1, 2, 1].index(1, 1, 4) == 2
+assert [1, 2, 1, 2].index(2, -2) == 3
+assert [1, 2, 3].index(2, 0) == 1
+# tuples share the fold
+assert (1, 2, 1, 2).index(2, 2) == 3

--- a/regression/python/list_index_start/test.desc
+++ b/regression/python/list_index_start/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_index_start_fail/main.py
+++ b/regression/python/list_index_start_fail/main.py
@@ -1,0 +1,2 @@
+# [1, 2, 1, 2].index(2, 2) is 3 (the second 2), not 1.
+assert [1, 2, 1, 2].index(2, 2) == 1

--- a/regression/python/list_index_start_fail/test.desc
+++ b/regression/python/list_index_start_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1121,24 +1121,56 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
       // Both LIST and TUPLE store their elements in tuple_val; a list literal
       // receiver folds the same way a tuple one does. Without covering LIST,
       // `[...].index(x)` fell through to the OM, whose value matching returns
-      // a wrong index for a literal receiver.
+      // a wrong index for a literal receiver. The optional start/end arguments
+      // (list.index(x, start[, end])) restrict the search to l[start:end] but
+      // return the index in the original sequence.
       if (
         !recv ||
         (recv->kind != PyConstValue::TUPLE &&
          recv->kind != PyConstValue::LIST) ||
-        node["args"].size() != 1)
+        node["args"].empty() || node["args"].size() > 3)
         return std::nullopt;
 
       auto needle = eval_expr(node["args"][0], env);
       if (!needle)
         return std::nullopt;
 
-      for (size_t i = 0; i < recv->tuple_val.size(); ++i)
+      const long long n = static_cast<long long>(recv->tuple_val.size());
+      long long start = 0;
+      long long stop = n;
+      if (node["args"].size() >= 2)
       {
-        if (pyconst_equal(recv->tuple_val[i], *needle))
-          return PyConstValue::make_int(static_cast<long long>(i));
+        auto s = eval_expr(node["args"][1], env);
+        if (!s || s->kind != PyConstValue::INT)
+          return std::nullopt;
+        start = s->int_val;
+        if (start < 0)
+          start += n;
+        if (start < 0)
+          start = 0;
+        if (start > n)
+          start = n;
       }
-      return std::nullopt;
+      if (node["args"].size() == 3)
+      {
+        auto e = eval_expr(node["args"][2], env);
+        if (!e || e->kind != PyConstValue::INT)
+          return std::nullopt;
+        stop = e->int_val;
+        if (stop < 0)
+          stop += n;
+        if (stop < 0)
+          stop = 0;
+        if (stop > n)
+          stop = n;
+      }
+
+      for (long long i = start; i < stop; ++i)
+      {
+        if (pyconst_equal(recv->tuple_val[static_cast<size_t>(i)], *needle))
+          return PyConstValue::make_int(i);
+      }
+      return std::nullopt; // not found: let the OM raise ValueError
     }
 
     // list/tuple .count(x) on a constant receiver folds at conversion time.


### PR DESCRIPTION
## What

Fixes `list.index(x, start[, end])` (the start/end form) on a **literal receiver** — `[1,2,1,2].index(2,2)` errored with `ERROR: Object "" not found`.

## Root cause

The constant-eval fold for `list`/`tuple` `.index()` on a literal receiver only handled the single-argument form; with a `start`/`end` argument it declined and fell through to the operational model, which errors for a literal receiver (the variable-receiver form works).

## Fix

Extend the existing fold to accept 2 or 3 arguments: evaluate the optional `start`/`end` integer args, normalize them like Python slice bounds (negative → `+= len`, then clamp into `[0, len]`), and search `l[start:end]`, returning the index in the **original** sequence. A non-constant arg or a not-found result still declines to the OM (matching the pre-existing 1-arg behavior).

## Tests

- `list_index_start` (CORE) — start, start+end, negative start, `start=0`, and the tuple form.
- `list_index_start_fail` (CORE) — pins that `[1,2,1,2].index(2,2) == 3`, not 1.

Both CPython-sane. The 1-arg `.index`/`.count` fold is unchanged; not-found-on-a-literal remains a separate pre-existing limitation (it affects the 1-arg form too).
