### PR TITLE
[clang-cpp-frontend] Don't crash on a function-type catch clause

### DIFF
--- a/regression/esbmc-cpp/try_catch/func_type_catch/main.cpp
+++ b/regression/esbmc-cpp/try_catch/func_type_catch/main.cpp
@@ -1,0 +1,26 @@
+// A catch parameter that names a function type (`exception()`) is ill-formed
+// but accepted by the parser; it produced an empty exception-id vector and
+// crashed the adjuster (ids.front() on an empty vector). It can never match a
+// real throw, so the thrown int is handled by the following catch.
+#include <exception>
+#include <cassert>
+using std::exception;
+
+int main()
+{
+  int caught = 0;
+  try
+  {
+    throw 42;
+  }
+  catch (exception())
+  {
+    caught = -1;
+  }
+  catch (int e)
+  {
+    caught = e;
+  }
+  assert(caught == 42);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/func_type_catch/test.desc
+++ b/regression/esbmc-cpp/try_catch/func_type_catch/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 3 --no-unwinding-assertions
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/func_type_catch_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/func_type_catch_fail/main.cpp
@@ -1,0 +1,24 @@
+// Negative variant: the int is caught by `catch (int)`, not the function-type
+// clause, so caught == 42 and asserting it equals -1 must fail.
+#include <exception>
+#include <cassert>
+using std::exception;
+
+int main()
+{
+  int caught = 0;
+  try
+  {
+    throw 42;
+  }
+  catch (exception())
+  {
+    caught = -1;
+  }
+  catch (int e)
+  {
+    caught = e;
+  }
+  assert(caught == -1);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/func_type_catch_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/func_type_catch_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 3 --no-unwinding-assertions
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/try-catch_rethrow_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_rethrow_01_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_rethrow_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_rethrow_02_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -479,6 +479,15 @@ void clang_cpp_adjust::convert_exception_id(
   std::string cpp_type = type.get("#cpp_type").as_string();
   if (!cpp_type.empty())
     ids.emplace_back(cpp_type + suffix);
+
+  // Fallback: an unusual catch parameter type (e.g. a function type, as in the
+  // ill-formed `catch (exception())`) matches none of the cases above and would
+  // leave `ids` empty, which callers such as adjust_catch dereference via
+  // `ids.front()`. Emit the type's own id so the result is never empty; such a
+  // synthetic id simply never matches a real throw, which is the intended
+  // behaviour for a catch clause that cannot name a throwable type.
+  if (ids.empty())
+    ids.emplace_back(id2string(type.id()) + suffix);
 }
 
 void clang_cpp_adjust::adjust_side_effect_function_call(


### PR DESCRIPTION
A catch clause whose parameter names a function type (e.g. the ill-formed `catch (exception())`) matched none of the cases in `convert_exception_id`, so it returned an empty id vector; `adjust_catch` then read `ids.front()` past the end and segfaulted while adjusting the code.

This gives `convert_exception_id` a fallback that emits the type's own id when nothing else matched, so the result is never empty (the synthetic id never matches a real throw — correct for a clause that cannot name a throwable type). Flips `try-catch_rethrow_01_bug` and `try-catch_rethrow_02_bug` from KNOWNBUG to CORE and adds `func_type_catch{,_fail}` regression tests. No regressions across 2369 esbmc-cpp tests.