### PR TITLE
[python] Add KNOWNBUG for nested-list equality across mixed construction

### DIFF
--- a/regression/python/list_eq_nested_comprehension/main.py
+++ b/regression/python/list_eq_nested_comprehension/main.py
@@ -1,0 +1,17 @@
+# KNOWNBUG: equality of two lists-of-lists fails when the inner lists were
+# built by DIFFERENT means (here a comprehension on the left vs a literal on
+# the right). Both sides are structurally list[list[int]] and CPython holds.
+#
+# Root cause: __ESBMC_list_eq detects a nested-list element only when its
+# element type_id equals the single list_type_id passed from the == call site
+# (hash of the left operand's type string, list_query.cpp:491). A
+# comprehension-built inner list and a literal inner list are given different
+# type-representation strings by the frontend, so their element type_ids
+# differ; the comparator then byte-compares the two inner-list *pointers*
+# (list.c:330,359) instead of recursing, and reports inequality.
+#
+# The companion test list_eq_nested_same shows the same value compares equal
+# when both sides are built the same way. Fixing this needs the frontend to
+# give structurally-identical nested lists the same type representation.
+m = [[i * j for j in range(2)] for i in range(2)]
+assert m == [[0, 0], [0, 1]]

--- a/regression/python/list_eq_nested_comprehension/test.desc
+++ b/regression/python/list_eq_nested_comprehension/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_eq_nested_same/main.py
+++ b/regression/python/list_eq_nested_same/main.py
@@ -1,0 +1,10 @@
+# Companion (currently-correct) coverage for nested-list equality: element,
+# inner-list, and whole-list comparisons all hold when both operands are built
+# the same way. Pins the behaviour that list_eq_nested_comprehension isolates
+# as broken only across mixed construction (comprehension vs literal).
+m = [[i * j for j in range(2)] for i in range(2)]
+n = [[i * j for j in range(2)] for i in range(2)]
+assert len(m) == 2
+assert m[1] == [0, 1]      # inner-list equality holds
+assert m == m              # same object
+assert m == n              # two comprehensions, same type representation

--- a/regression/python/list_eq_nested_same/test.desc
+++ b/regression/python/list_eq_nested_same/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 10
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## What

Documents, as a KNOWNBUG plus a passing companion, a nested-list `==` limitation: equality of two lists-of-lists fails when the inner lists were built by **different means** — e.g. a comprehension on one side and a literal on the other — even though both are structurally `list[list[int]]` and CPython holds.

## Root cause

`__ESBMC_list_eq` recognises a nested-list element only when its element `type_id` equals the single `list_type_id` passed from the `==` call site (`hash(type_to_string(l1.type()))`, `list_query.cpp:491`). The frontend gives a comprehension-built inner list and a literal inner list different type-representation strings, so their element `type_id`s differ; the comparator then falls to the cross-`type_id` path and byte-compares the two inner-list **pointers** (`list.c:330,359`) instead of recursing, reporting inequality.

A sound fix needs the frontend to give structurally-identical nested lists the same type representation (or the comparator a robust "is this element a list?" predicate independent of the single `list_type_id`); both are out of scope here, so this is filed as a KNOWNBUG.

## Tests

- `list_eq_nested_comprehension` (**KNOWNBUG**) — `[[i*j for j in range(2)] for i in range(2)] == [[0,0],[0,1]]`; CPython holds, ESBMC currently returns FAILED.
- `list_eq_nested_same` (**CORE**) — the same value compares equal when both sides are built the same way (`m == m`, comprehension `== ` comprehension) and inner-list/`len` checks hold; pins the working behaviour and the boundary of the bug.

Both CPython-sane. No code change — this only records the limitation with a reproducer for the eventual frontend fix.
