### PR TITLE
[clang-cpp-frontend] Support constructor/destructor function-try-blocks

### DIFF
--- a/regression/esbmc-cpp/try_catch/ctor_ftb_ok/main.cpp
+++ b/regression/esbmc-cpp/try_catch/ctor_ftb_ok/main.cpp
@@ -1,0 +1,18 @@
+// A constructor function-try-block whose subobjects do not throw completes
+// normally; the implicit rethrow is only reached when an exception is active.
+#include <cassert>
+int built;
+struct Base
+{
+  Base() { built = 1; }
+};
+struct Derived : Base
+{
+  Derived() try : Base() {} catch (int) {}
+};
+int main()
+{
+  Derived d;
+  assert(built == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/ctor_ftb_ok/test.desc
+++ b/regression/esbmc-cpp/try_catch/ctor_ftb_ok/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/ctor_ftb_rethrow/main.cpp
+++ b/regression/esbmc-cpp/try_catch/ctor_ftb_rethrow/main.cpp
@@ -1,0 +1,17 @@
+// C++ [except.handle]/15: a handler of a constructor's function-try-block
+// cannot swallow an exception thrown while constructing a base/member
+// subobject; at the end of the handler the exception is rethrown. So the
+// exception here escapes main and terminates -> VERIFICATION FAILED.
+struct Base
+{
+  Base() { throw 5; }
+};
+struct Derived : Base
+{
+  Derived() try : Base() {} catch (int) {}
+};
+int main()
+{
+  Derived d;
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/ctor_ftb_rethrow/test.desc
+++ b/regression/esbmc-cpp/try_catch/ctor_ftb_rethrow/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_01_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1662,10 +1662,17 @@ bool clang_cpp_convertert::get_function_body(
       return true;
   }
 
-  if (new_expr.statement() != "block")
+  if (new_expr.statement() != "block" && new_expr.statement() != "cpp-catch")
     return false;
 
-  code_blockt &body = to_code_block(to_code(new_expr));
+  // A constructor/destructor may use a function-try-block; its body is then a
+  // `cpp-catch` whose first operand is the try block and whose remaining
+  // operands are the handlers. The member/base initializers and the destructor
+  // chain operate on that try block, so `body` points at it in that case.
+  const bool function_try_block = new_expr.statement() == "cpp-catch";
+  code_blockt &body = function_try_block
+                        ? to_code_block(to_code(new_expr.op0()))
+                        : to_code_block(to_code(new_expr));
 
   // if it's a constructor, check for initializers
   if (fd.getKind() == clang::Decl::CXXConstructor)
@@ -1856,6 +1863,25 @@ bool clang_cpp_convertert::get_function_body(
     if (build_destructor_chain(
           static_cast<const clang::CXXDestructorDecl &>(fd), body))
       return true;
+  }
+
+  // C++ [except.handle]/15: if control reaches the end of a handler of a
+  // constructor's or destructor's function-try-block, the currently handled
+  // exception is rethrown — a handler there cannot swallow an exception raised
+  // while constructing/destroying a base or member subobject. Append an
+  // implicit `throw;` to each handler to model this.
+  if (
+    function_try_block && (fd.getKind() == clang::Decl::CXXConstructor ||
+                           fd.getKind() == clang::Decl::CXXDestructor))
+  {
+    codet::operandst &ops = new_expr.operands();
+    for (std::size_t i = 1; i < ops.size(); i++)
+    {
+      code_blockt &handler = to_code_block(to_code(ops[i]));
+      exprt rethrow = side_effect_exprt("cpp-throw", empty_typet());
+      convert_expression_to_code(rethrow);
+      handler.operands().push_back(rethrow);
+    }
   }
 
   return false;


### PR DESCRIPTION
A constructor or destructor with a function-try-block (`C() try : Base() {} catch(...) {}`) has a `cpp-catch` body, not a plain block, so `get_function_body` returned early: the member/base initializers were never emitted (the throwing base ctor was never called) and the object appeared to construct successfully.

This routes the initializers and destructor chain into the try block, and — per C++ [except.handle]/15 — appends an implicit `throw;` to each handler of a constructor's/destructor's function-try-block, since such a handler cannot swallow an exception raised while building a base/member subobject. A non-ctor/dtor function-try-block still swallows normally. Flips `try-catch_tryblock_01_bug` from KNOWNBUG to CORE and adds `ctor_ftb_{rethrow,ok}` regression tests. No regressions across 2369 esbmc-cpp tests.