### PR TITLE
[python] Support {:c} and {:%} format types in str.format()

### DIFF
--- a/regression/python/str_format_char_percent/main.py
+++ b/regression/python/str_format_char_percent/main.py
@@ -1,0 +1,12 @@
+# str.format() now supports the {:c} (integer -> character) and {:%}
+# (float -> percentage) presentation types, which previously fell to a nondet
+# fallback.
+assert "{:c}".format(65) == "A"
+assert "{:c}".format(97) == "a"
+assert "{:5c}".format(65) == "    A"
+assert "{:<5c}".format(65) == "A    "
+assert "{:%}".format(0.25) == "25.000000%"
+assert "{:.1%}".format(0.5) == "50.0%"
+assert "{:.0%}".format(0.5) == "50%"
+assert "{:8.2%}".format(0.5) == "  50.00%"
+assert "{:+.1%}".format(0.5) == "+50.0%"

--- a/regression/python/str_format_char_percent/test.desc
+++ b/regression/python/str_format_char_percent/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_format_char_percent_fail/main.py
+++ b/regression/python/str_format_char_percent_fail/main.py
@@ -1,0 +1,2 @@
+# {:c} of 65 is "A", not "B".
+assert "{:c}".format(65) == "B"

--- a/regression/python/str_format_char_percent_fail/test.desc
+++ b/regression/python/str_format_char_percent_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -273,6 +273,18 @@ std::string apply_format_spec(
     body = sgn + digits;
     default_align = '>';
   }
+  else if (kind == KIND_INT && type == 'c')
+  {
+    // {:c} formats an integer as the character with that code point. Fold only
+    // 1-127: code point 0 embeds a NUL, which the null-terminated string model
+    // represents unreliably (comparisons can truncate at it), and code points
+    // > 127 are multi-byte UTF-8 the single-byte string model cannot represent.
+    // Both degrade to the sound nondet fallback.
+    if (ival < 1 || ival > 127)
+      throw std::runtime_error("code point out of foldable range for {:c}");
+    body = std::string(1, static_cast<char>(ival));
+    default_align = '>';
+  }
   else if (
     kind == KIND_FLOAT && (type == 'f' || type == 'F' || type == 'e' ||
                            type == 'E' || type == 'g' || type == 'G'))
@@ -311,6 +323,28 @@ std::string apply_format_spec(
         num = " " + num;
     }
     body = num;
+    default_align = '>';
+  }
+  else if (kind == KIND_FLOAT && type == '%')
+  {
+    // {:%} multiplies by 100, formats like 'f' (default precision 6), and
+    // appends a literal '%'.
+    const round_to_nearest_guard rounding_guard;
+    const int pr = prec >= 0 ? prec : 6;
+    const double pct = dval * 100.0;
+    int n = std::snprintf(nullptr, 0, "%.*f", pr, pct);
+    if (n < 0)
+      throw std::runtime_error("format spec percent error");
+    std::string num(static_cast<size_t>(n), '\0');
+    std::snprintf(&num[0], static_cast<size_t>(n) + 1, "%.*f", pr, pct);
+    if (!num.empty() && num[0] != '-')
+    {
+      if (sign == '+')
+        num = "+" + num;
+      else if (sign == ' ')
+        num = " " + num;
+    }
+    body = num + "%";
     default_align = '>';
   }
   else


### PR DESCRIPTION
## What

Adds two `str.format()` presentation types that previously fell to a nondet fallback: `{:c}` (integer → the character with that code point) and `{:%}` (float → percentage).

## Fix

Two branches in `apply_format_spec`'s body-building switch:

- **`{:c}`** (`kind==KIND_INT`): for a code point in `[1,127]`, the body is the single ASCII character; code point 0 (embeds a NUL, unreliable in the null-terminated string model) and code points > 127 (multi-byte UTF-8, not representable in the single-byte model) stay on the sound nondet path. Right-aligned, matching CPython.
- **`{:%}`** (`kind==KIND_FLOAT`): multiply by 100, format `%.*f` (default precision 6), append `'%'`, with the same `+`/space sign handling as the float branch. CPython computes `value*100` in C `double` too, so the result matches (verified across precision 0/N/default and values like `0.1`, `0.3333`).

Both are additive: they only turn a previously-nondet result into the exact CPython value; every other spec is unchanged.

## Tests

- `str_format_char_percent` (CORE) — `{:c}` on 65/97, width and left-align; `{:%}`, `{:.1%}`, `{:.0%}`, `{:8.2%}`, `{:+.1%}`.
- `str_format_char_percent_fail` (CORE) — pins that `"{:c}".format(65) != "B"`.

Both CPython-sane. `{:d}`/`{:x}`/float/string specs unchanged; format regression 100% clean. Negative `{:%}` depends on the separate pending negative-argument fix (#5830); the `%` sign handling here is already correct for it.
