### PR TITLE
[clang-cpp-frontend] Evaluate the operand of a polymorphic typeid

### DIFF
--- a/regression/esbmc-cpp/try_catch/try-catch_typeid_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_typeid_01_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/typeid_null_deref/main.cpp
+++ b/regression/esbmc-cpp/try_catch/typeid_null_deref/main.cpp
@@ -1,0 +1,11 @@
+// C++ [expr.typeid]/2: typeid applied to *p, where p is a null pointer and the
+// type is polymorphic, evaluates the operand and must fail (the standard
+// mandates std::bad_typeid). ESBMC reports the null dereference -> FAILED.
+#include <typeinfo>
+struct Poly { virtual void m() {} };
+int main()
+{
+  Poly *p = 0;
+  const char *n = typeid(*p).name();
+  return n ? 0 : 1;
+}

--- a/regression/esbmc-cpp/try_catch/typeid_null_deref/test.desc
+++ b/regression/esbmc-cpp/try_catch/typeid_null_deref/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 3 --no-unwinding-assertions
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/typeid_valid_deref/main.cpp
+++ b/regression/esbmc-cpp/try_catch/typeid_valid_deref/main.cpp
@@ -1,0 +1,14 @@
+// typeid on a valid polymorphic object (both via a non-null dereference and a
+// plain lvalue) must not fault.
+#include <typeinfo>
+#include <cassert>
+struct Poly { virtual void m() {} };
+int main()
+{
+  Poly obj;
+  Poly *p = &obj;
+  const char *n1 = typeid(*p).name();
+  const char *n2 = typeid(obj).name();
+  assert(n1 != 0 && n2 != 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/typeid_valid_deref/test.desc
+++ b/regression/esbmc-cpp/try_catch/typeid_valid_deref/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 3 --no-unwinding-assertions
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1116,6 +1116,12 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       static_cast<const clang::CXXTypeidExpr &>(stmt);
 
     std::string type_name;
+    // For a polymorphic glvalue operand, [expr.typeid]/2 requires the operand
+    // to be evaluated (the dynamic type is read from the object's vtable). We
+    // model that by reading the operand's vtable pointer, so a typeid applied
+    // to `*p` with a null `p` faults on the dereference — the standard mandates
+    // std::bad_typeid there. `vtable_read` holds that read when applicable.
+    exprt vtable_read = nil_exprt();
     if (cxxtid.isTypeOperand())
     {
       const clang::QualType qtype = cxxtid.getTypeOperand(*ASTContext);
@@ -1124,9 +1130,34 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     else
     {
       const clang::QualType qtype = cxxtid.getExprOperand()->getType();
-      if (!cxxtid.isMostDerived(*ASTContext) && qtype->getAsCXXRecordDecl())
-        log_warning("Typeid for polymorphism is not implemented");
       type_name = qtype.getAsString();
+
+      const clang::CXXRecordDecl *rd = qtype->getAsCXXRecordDecl();
+      // [expr.typeid]/2 singles out the case where the operand is obtained by
+      // dereferencing a pointer: a null pointer there yields std::bad_typeid.
+      // Detect that `*p` form at the AST level so a plain lvalue operand (which
+      // cannot be null) keeps its existing handling untouched.
+      const auto *unary = llvm::dyn_cast<clang::UnaryOperator>(
+        cxxtid.getExprOperand()->IgnoreParenImpCasts());
+      const bool is_deref_operand =
+        unary && unary->getOpcode() == clang::UO_Deref;
+      if (
+        !cxxtid.isMostDerived(*ASTContext) && rd && rd->isPolymorphic() &&
+        is_deref_operand)
+      {
+        exprt operand;
+        if (get_expr(*cxxtid.getExprOperand(), operand))
+          return true;
+
+        const typet &op_type = ns.follow(operand.type());
+        if (operand.id() == "dereference" && op_type.is_struct())
+          for (const auto &comp : to_struct_type(op_type).components())
+            if (comp.get_bool("is_vtptr"))
+            {
+              vtable_read = member_exprt(operand, comp.name(), comp.type());
+              break;
+            }
+      }
     }
 
     exprt size = constant_exprt(
@@ -1148,7 +1179,15 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     // Front end can't account for polymorphism
     exprt sym("struct", t);
     sym.copy_to_operands(address_of_exprt(string_name));
-    sym.copy_to_operands(gen_zero(pointer_type()));
+    if (vtable_read.is_not_nil())
+    {
+      // Reading the vtable pointer dereferences the operand, so a null operand
+      // faults here (modelling std::bad_typeid). Cast to the field type.
+      gen_typecast(ns, vtable_read, pointer_type());
+      sym.copy_to_operands(vtable_read);
+    }
+    else
+      sym.copy_to_operands(gen_zero(pointer_type()));
     make_temporary(sym);
 
     new_expr = sym;


### PR DESCRIPTION
`typeid` never touched its operand, so `typeid(*p)` on a polymorphic type with a null `p` silently produced a `type_info` instead of faulting — C++ [expr.typeid]/2 requires the operand to be evaluated (the dynamic type is read from the object's vtable) and mandates `std::bad_typeid` for a null dereferenced pointer.

For a polymorphic operand of the form `*p`, this reads the object's vtable pointer into the `type_info`'s second field so the dereference is checked; a null pointer then faults. Plain lvalue operands (which cannot be null) keep their existing handling. Flips `try-catch_typeid_01_bug` from KNOWNBUG to CORE and adds `typeid_{null,valid}_deref` regression tests. No regressions across 2369 esbmc-cpp tests.