### PR TITLE
[python] Assign the materialized temp for len() of an inline string call

### DIFF
--- a/regression/python/len_inline_format/main.py
+++ b/regression/python/len_inline_format/main.py
@@ -1,0 +1,8 @@
+# len() applied directly to an inline string-returning call whose result is a
+# constant char array -- e.g. "{}".format(x) or s.replace(...) -- previously
+# reported a spurious "array bounds violated" in strlen: the materialized temp
+# was declared but never assigned, so strlen ran over uninitialised bytes.
+assert len("{}".format("hi")) == 2
+assert len("{:d}".format(65)) == 2
+assert len("{}-{}".format("ab", "cd")) == 5
+assert len("hi".replace("h", "H")) == 2

--- a/regression/python/len_inline_format/test.desc
+++ b/regression/python/len_inline_format/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/len_inline_format_fail/main.py
+++ b/regression/python/len_inline_format_fail/main.py
@@ -1,0 +1,2 @@
+# len("{}".format("hi")) is 2, not 3.
+assert len("{}".format("hi")) == 3

--- a/regression/python/len_inline_format_fail/test.desc
+++ b/regression/python/len_inline_format_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -5227,12 +5227,19 @@ std::optional<exprt> function_call_expr::build_positional_arguments(
       }
       else if (arg.is_constant())
       {
-        // Constant array (e.g., folded string concat) must be materialized before address_of_exprt.
+        // Constant array (e.g. a folded string concat or a str-method result
+        // like "{}".format(x)) must be materialized before address_of_exprt.
+        // The DECL alone leaves the temp uninitialised, so strlen/get_object_size
+        // over it reads nondet bytes and runs past the array bounds; emit an
+        // explicit assignment of the constant value (mirrors the list path).
         symbolt &tmp = converter_.create_tmp_symbol(
-          call_, "$const_str_arg$", arg.type(), arg);
+          call_, "$const_str_arg$", arg.type(), exprt());
         code_declt tmp_decl(build_symbol(tmp));
         tmp_decl.location() = location;
         converter_.current_block->copy_to_operands(tmp_decl);
+        code_assignt tmp_assign(build_symbol(tmp), arg);
+        tmp_assign.location() = location;
+        converter_.current_block->copy_to_operands(tmp_assign);
         arg = build_symbol(tmp);
       }
       call.arguments().push_back(build_address_of(arg));


### PR DESCRIPTION
## What

Fixes a spurious `dereference failure: array bounds violated` when `len()` is applied **directly to an inline string-returning call** whose result is a constant char array — e.g. `len("{}".format("hi"))` or `len("hi".replace("h","H"))`. Assigning to a variable first (`s = "{}".format("hi"); len(s)`) already worked.

## Root cause

When such an argument is materialized before `address_of` (needed to call `strlen`), the `else if (arg.is_constant())` branch emitted only a `DECL` for the temp, never assigning the constant value to it. The GOTO was:

```
DECL signed char [3] $const_str_arg$;
FUNCTION_CALL: r = strlen(&$const_str_arg$)   // temp uninitialised
```

`strlen` then scanned uninitialised (nondet) bytes with no guaranteed terminator and ran past the array bounds. The sibling list-materialization path a few lines above already emits both a DECL and a `code_assignt`; the string path was missing the assignment.

## Fix

Emit the `code_assignt(build_symbol(tmp), arg)` after the DECL, mirroring the list path, so the temp holds the constant string before `strlen` reads it.

## Tests

- `len_inline_format` (CORE) — `len("{}".format(...))`, `len("{:d}".format(65))`, a longer `len("{}-{}".format(...))`, and `len("hi".replace(...))`.
- `len_inline_format_fail` (CORE) — pins that `len("{}".format("hi")) != 3`.

Both CPython-sane. Previously-working `len("hi")`, `len("a"+"b")`, `len("hi".upper())`, `len(var)`, and `len([...])` are unchanged.
