### PR TITLE
[python] Fold min()/max() over a string to the extreme character

### DIFF
--- a/regression/python/min_max_string/main.py
+++ b/regression/python/min_max_string/main.py
@@ -1,0 +1,12 @@
+# min()/max() over a string return the extreme character (min("cba") == "a").
+# Previously the single string-iterable form fell to the runtime model, which
+# only handles list/tuple iterables, and gave a wrong result. Now folded over
+# the constant string's characters (literal and constant-variable forms).
+assert min("cba") == "a"
+assert max("cba") == "c"
+assert min("z") == "z"
+assert min("31524") == "1"
+assert max("aAzZ") == "z"
+s = "dcba"
+assert min(s) == "a"
+assert max(s) == "d"

--- a/regression/python/min_max_string/test.desc
+++ b/regression/python/min_max_string/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/min_max_string_fail/main.py
+++ b/regression/python/min_max_string_fail/main.py
@@ -1,0 +1,2 @@
+# min("cba") is "a", not "c".
+assert min("cba") == "c"

--- a/regression/python/min_max_string_fail/test.desc
+++ b/regression/python/min_max_string_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1553,9 +1553,42 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
       return PyConstValue::make_float(rounded);
     }
 
-    // Built-in: min(), max() for two int arguments
+    // Built-in: min(), max()
     if (func_name == "min" || func_name == "max")
     {
+      const bool want_min = (func_name == "min");
+
+      // A key=/default= keyword changes the result (min(s, key=...) compares
+      // key(x), not x), which this fold does not apply; defer such calls to the
+      // runtime model rather than fold a wrong value.
+      if (node.contains("keywords") && !node["keywords"].empty())
+        return std::nullopt;
+
+      // Single string argument: min/max over the characters, returning the
+      // extreme character as a one-character string (min("cba") == "a"). Other
+      // single-iterable kinds (lists, tuples) are left to the runtime model.
+      // Fold only over ASCII: a non-ASCII str is multi-byte UTF-8 in
+      // string_val, where a per-byte comparison does not match CPython's
+      // per-code-point ordering, so defer those to the runtime model. Compare
+      // as unsigned char so the ordering is by byte value.
+      if (node["args"].size() == 1)
+      {
+        auto it = eval_expr(node["args"][0], env);
+        if (!it || it->kind != PyConstValue::STRING || it->string_val.empty())
+          return std::nullopt;
+        unsigned char best = static_cast<unsigned char>(it->string_val[0]);
+        for (char c : it->string_val)
+        {
+          const unsigned char uc = static_cast<unsigned char>(c);
+          if (uc >= 0x80)
+            return std::nullopt;
+          if (want_min ? (uc < best) : (uc > best))
+            best = uc;
+        }
+        return PyConstValue::make_string(std::string(1, static_cast<char>(best)));
+      }
+
+      // Two int arguments: min(a, b) / max(a, b).
       if (node["args"].size() != 2)
         return std::nullopt;
       auto a = eval_expr(node["args"][0], env);
@@ -1564,7 +1597,7 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
         !a || !b || a->kind != PyConstValue::INT ||
         b->kind != PyConstValue::INT)
         return std::nullopt;
-      if (func_name == "min")
+      if (want_min)
         return PyConstValue::make_int(std::min(a->int_val, b->int_val));
       return PyConstValue::make_int(std::max(a->int_val, b->int_val));
     }

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1585,7 +1585,8 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
           if (want_min ? (uc < best) : (uc > best))
             best = uc;
         }
-        return PyConstValue::make_string(std::string(1, static_cast<char>(best)));
+        return PyConstValue::make_string(
+          std::string(1, static_cast<char>(best)));
       }
 
       // Two int arguments: min(a, b) / max(a, b).


### PR DESCRIPTION
## What

Folds `min()` / `max()` over a **string** to the extreme character — `min("cba") == "a"` — which previously fell to the runtime model (which only handles list/tuple iterables) and gave a wrong result.

## Fix

The constant-eval `min`/`max` fold handled only the two-int form `min(a, b)`. Extend it: for a single argument that evaluates to a constant string, iterate its characters and return the min/max character as a one-character string. Compared as `unsigned char`; folds **ASCII only** — a non-ASCII `str` is multi-byte UTF-8 in the value buffer, where a per-byte comparison would not match CPython's per-code-point ordering, so those defer to the runtime model (`nullopt`). Empty string also defers (CPython raises `ValueError`). List/tuple single-iterables are unchanged (still handled by the runtime model). The two-int path is unchanged.

## Tests

- `min_max_string` (CORE) — `min`/`max` over multi-char, single-char, digit, and mixed-case strings, plus a constant-variable form.
- `min_max_string_fail` (CORE) — pins that `min("cba") != "c"`.

Both CPython-sane. `min(3,5)`/`max(3,5)` and `min([...])` unchanged; non-ASCII and empty strings stay on the sound runtime path.

A `key=`/`default=` keyword (which changes the result) also defers to the runtime model rather than folding a wrong value.
