### PR TITLE
[python] Advance the range counter before the loop body for continue

### DIFF
--- a/regression/python/for_range_continue/main.py
+++ b/regression/python/for_range_continue/main.py
@@ -1,0 +1,32 @@
+# `continue` in a `for ... in range(...)` loop previously skipped the counter
+# advance (it was emitted after the body, and continue jumps to the while
+# condition), so the loop never terminated. The counter is now advanced before
+# the body. Covers default/explicit start, a step, and a nested loop.
+s = 0
+for i in range(5):
+    if i % 2:
+        continue
+    s += i
+assert s == 6
+
+t = 0
+for i in range(1, 5):
+    if i == 3:
+        continue
+    t += i
+assert t == 7
+
+u = 0
+for i in range(0, 10, 2):
+    if i == 4:
+        continue
+    u += i
+assert u == 16
+
+r = 0
+for i in range(3):
+    for j in range(3):
+        if j == 1:
+            continue
+        r += 1
+assert r == 6

--- a/regression/python/for_range_continue/test.desc
+++ b/regression/python/for_range_continue/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for_range_continue_fail/main.py
+++ b/regression/python/for_range_continue_fail/main.py
@@ -1,0 +1,7 @@
+# The even values of range(5) sum to 6 (0+2+4), not 5.
+s = 0
+for i in range(5):
+    if i % 2:
+        continue
+    s += i
+assert s == 5

--- a/regression/python/for_range_continue_fail/test.desc
+++ b/regression/python/for_range_continue_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1097,8 +1097,14 @@ class LoopMixin:
         self.ensure_all_locations(loop_var_init, node)
         ast.fix_missing_locations(loop_var_init)
 
-        # Create the body of the while loop, including updating the start and has_next variables
-        while_body = ([loop_var_init] + transformed_body + [
+        # Create the body of the while loop. The loop variable is snapshotted
+        # from the counter, then the counter and has_next are advanced *before*
+        # the loop body — not after — so that a `continue` in the body (which
+        # jumps straight to the while condition) does not skip the advance and
+        # spin forever. This mirrors the index-increment-before-body layout used
+        # by the items/iterable while-lowerings.
+        while_body = ([
+            loop_var_init,
             ast.Assign(
                 targets=[ast.Name(id=start_var, ctx=ast.Store())],
                 value=ast.Call(
@@ -1115,7 +1121,7 @@ class LoopMixin:
                     keywords=[],
                 ),
             ),
-        ])
+        ] + transformed_body)
 
         # Create the while statement
         while_stmt = ast.While(test=while_cond, body=while_body, orelse=[])


### PR DESCRIPTION
## What

Fixes `continue` inside a `for i in range(...)` loop, which previously caused **non-termination** — the unwinding assertion fired at any bound, so the loop never verified.

## Root cause

`_transform_range_for` lowers a range `for` loop into a `while` loop. The counter advance (`start_var = ESBMC_range_next_(start_var, step)`) and the `has_next` update were emitted at the **end** of the while body, after the loop body. `continue` in a `while` loop jumps straight to the condition test, so it skipped the advance and `start_var` never progressed — an infinite loop. (for-over-list and `for ... in d.items()` were unaffected because they advance the index *before* the body.)

## Fix

Move the counter advance and `has_next` update to the **front** of the while body, right after `loop_var_init` (which snapshots `target = start_var`) and before the transformed body. The loop variable is still bound to the current value before the advance, so iteration values and counts are unchanged; a `continue` now advances the counter instead of spinning.

## Tests

- `for_range_continue` (CORE) — `continue` with default/explicit start, a step, and a nested loop.
- `for_range_continue_fail` (CORE) — pins the correct even-sum value.

Both CPython-sane. Verified unchanged: plain range loops, `break`, empty/single-element ranges, negative step, list-append, comprehensions, and a body that reassigns the loop variable (`[99,99,99]`).
