### PR TITLE
[python] Support x/X/o/b integer bases in f-strings

### DIFF
--- a/regression/python/fstring_int_base/main.py
+++ b/regression/python/fstring_int_base/main.py
@@ -1,0 +1,11 @@
+# f-string integer base presentations x/X/o/b now fold for a constant integer
+# (they were previously unsupported, unlike the format()/str.format() paths).
+assert f"{255:x}" == "ff"
+assert f"{255:X}" == "FF"
+assert f"{8:o}" == "10"
+assert f"{5:b}" == "101"
+assert f"{10:b}" == "1010"
+assert f"{0:x}" == "0"
+assert f"{-255:x}" == "-ff"
+n = 255
+assert f"{n:x}" == "ff"

--- a/regression/python/fstring_int_base/test.desc
+++ b/regression/python/fstring_int_base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/fstring_int_base_fail/main.py
+++ b/regression/python/fstring_int_base_fail/main.py
@@ -1,0 +1,2 @@
+# 255 in hex is "ff", not "FF".
+assert f"{255:x}" == "FF"

--- a/regression/python/fstring_int_base_fail/test.desc
+++ b/regression/python/fstring_int_base_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -909,6 +909,54 @@ exprt string_handler::apply_format_specification(
   if (format == "d" || format == "i" || format == "s")
     return convert_to_string(expr);
 
+  // Integer base presentations: 'x'/'X' (hex), 'o' (octal), 'b' (binary), for a
+  // constant integer value (resolving a symbol's constant value and a negative
+  // unary- literal). A non-constant value falls through to the handling below.
+  if (
+    (format == "x" || format == "X" || format == "o" || format == "b") &&
+    (expr.type().is_signedbv() || expr.type().is_unsignedbv()))
+  {
+    exprt v = expr;
+    if (v.is_symbol())
+    {
+      const symbolt *sym =
+        find_cached_symbol(to_symbol_expr(v).get_identifier().as_string());
+      if (sym && !sym->get_value().is_nil())
+        v = sym->get_value();
+    }
+    if (v.id() == "unary-" && v.operands().size() == 1 && v.op0().is_constant())
+    {
+      BigInt neg_v;
+      if (!to_integer(v.op0(), neg_v))
+        v = from_integer(-neg_v, v.op0().type());
+    }
+    BigInt n;
+    if (v.is_constant() && !to_integer(v, n))
+    {
+      const bool neg = n < 0;
+      BigInt mag = neg ? -n : n;
+      const unsigned base = (format == "o") ? 8 : (format == "b") ? 2 : 16;
+      const char *alpha =
+        (format == "X") ? "0123456789ABCDEF" : "0123456789abcdef";
+      std::string digits;
+      if (mag == 0)
+        digits = "0";
+      while (mag != 0)
+      {
+        digits.insert(digits.begin(), alpha[(mag % base).to_uint64()]);
+        mag /= base;
+      }
+      const std::string out = (neg ? "-" : "") + digits;
+      std::vector<unsigned char> chars(out.begin(), out.end());
+      chars.push_back('\0');
+      return make_char_array_expr(
+        chars, type_handler_.build_array(char_type(), out.size() + 1));
+    }
+    // A non-constant integer falls through: `format` is a base type, never a
+    // float spec, so the `else if` float branch below is correctly skipped and
+    // the tail nondet fallback handles it.
+  }
+
   // Handle float formatting with precision
   else if (format.find(".") != std::string::npos && format.back() == 'f')
   {


### PR DESCRIPTION
## What

Adds the integer base presentation types `x`/`X` (hex), `o` (octal), `b` (binary) to f-strings — `f"{255:x}"` now gives `"ff"` instead of a wrong/nondet result. (The `format()` and `str.format()` paths already handle these; f-strings use a separate, less-complete handler.)

## Fix

A branch in `apply_format_specification`: for a spec of exactly `x`/`X`/`o`/`b` on an integer that resolves to a compile-time constant (directly, via a symbol's constant value, or a `unary-` negative literal), compute the base representation — bare digits, with a leading `-` for negatives, matching CPython (no `0x`/`0o`/`0b` prefix, which only the unhandled `#` flag adds). A non-constant value or a richer spec (`#x`, `08x`, …) falls through to the existing handling, so nothing is mis-folded.

## Tests

- `fstring_int_base` (CORE) — `x`/`X`/`o`/`b`, multi-bit, zero, negative, and a variable.
- `fstring_int_base_fail` (CORE) — pins that `f"{255:x}" != "FF"`.

Both CPython-sane. `d`/`s`/float/width f-string specs unchanged.
