### PR TITLE
[python] Dispatch bool() to a user-defined __bool__

### DIFF
--- a/regression/python/bool_dunder/main.py
+++ b/regression/python/bool_dunder/main.py
@@ -1,0 +1,23 @@
+# bool(obj) now dispatches to a user-defined __bool__ (it previously cast the
+# object pointer, which is always truthy).
+class Always:
+    def __bool__(self):
+        return False
+
+
+class Positive:
+    def __init__(self, v):
+        self.v = v
+
+    def __bool__(self):
+        return self.v > 0
+
+
+assert bool(Always()) == False
+assert bool(Positive(5)) == True
+assert bool(Positive(-1)) == False
+# bool on primitives is unchanged.
+assert bool(5) == True
+assert bool(0) == False
+assert bool("") == False
+assert bool([1]) == True

--- a/regression/python/bool_dunder/test.desc
+++ b/regression/python/bool_dunder/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bool_dunder_fail/main.py
+++ b/regression/python/bool_dunder_fail/main.py
@@ -1,0 +1,7 @@
+# __bool__ returns False, so bool(C()) is False, not True.
+class C:
+    def __bool__(self):
+        return False
+
+
+assert bool(C()) == True

--- a/regression/python/bool_dunder_fail/test.desc
+++ b/regression/python/bool_dunder_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 3
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_dunder.cpp
+++ b/src/python-frontend/converter/converter_dunder.cpp
@@ -298,6 +298,7 @@ exprt python_converter::dispatch_unary_dunder_operator(
     {"USub", "__neg__"},
     {"UAdd", "__pos__"},
     {"abs", "__abs__"},
+    {"bool", "__bool__"},
     {"complex", "__complex__"},
     {"float", "__float__"},
     {"int", "__int__"},

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -930,6 +930,13 @@ exprt function_call_expr::build_constant_from_arg() const
     if (value_expr.statement() == "cpp-throw")
       return value_expr;
 
+    // A custom object defining __bool__ decides its own truthiness; otherwise
+    // the value's own type (numeric/pointer) is cast to bool below.
+    exprt dunder_result = converter_.dispatch_unary_dunder_operator(
+      "bool", value_expr, converter_.get_location_from_decl(call_));
+    if (!dunder_result.is_nil())
+      return dunder_result;
+
     if (is_complex_type(value_expr.type()))
       return complex_to_bool_expr(value_expr);
 


### PR DESCRIPTION
## What

`bool(obj)` now dispatches to a user-defined `__bool__`. Previously it cast the object (a `Class*` pointer) to bool, which is always truthy — so `bool(C())` where `C.__bool__` returns `False` wrongly evaluated to `True`.

## Fix

Mirrors the existing `str(obj)` → `__str__` dispatch that sits right below the `bool` handler:
- Add `{"bool", "__bool__"}` to `unary_dunder_map` (which already maps `abs→__abs__`, `int→__int__`, `str→__str__`, …).
- In the `bool` builtin handler, call `dispatch_unary_dunder_operator("bool", …)` before the primitive cast; a non-nil result (the `__bool__` call) is returned, otherwise the existing complex/primitive path runs unchanged.

`dispatch_unary_dunder_operator` only fires for a struct/class operand whose class defines `__bool__`, so primitives (`bool(5)`, `bool("")`, `bool([1])`), complex numbers, and classes without `__bool__` all fall through unchanged.

## Scope note

The `not obj` operator and `bool(obj)` for a class with only `__len__` (Python's truthiness fallback) are separate paths, left as-is.

## Tests

- `bool_dunder` (CORE) — `__bool__` returning False/True and a field-based `self.v>0`, plus primitives unchanged.
- `bool_dunder_fail` (CORE) — pins that `bool(C())` (with `__bool__` → False) is not True.

Both CPython-sane.
