### PR TITLE
[python] Raise a catchable ValueError from list.index(x, start, end)

### DIFF
--- a/regression/python/list_index_range_valueerror/main.py
+++ b/regression/python/list_index_range_valueerror/main.py
@@ -1,0 +1,21 @@
+# list.index(x, start[, end]) now raises a catchable ValueError when x is not
+# present in l[start:end], instead of an uncatchable property violation.
+l = [1, 2, 3, 4]
+try:
+    l.index(9, 1, 3)
+    assert False
+except ValueError:
+    pass
+
+# Present in the whole list but outside the [start:end] window -> ValueError.
+m = [1, 2, 1, 2]
+try:
+    m.index(2, 0, 1)
+    assert False
+except ValueError:
+    pass
+
+# A present element in the window still returns its index (in the original list).
+assert l.index(3, 1, 4) == 2
+assert m.index(2, 2) == 3
+assert l.index(3, -3, -1) == 2

--- a/regression/python/list_index_range_valueerror/test.desc
+++ b/regression/python/list_index_range_valueerror/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_index_range_valueerror_fail/main.py
+++ b/regression/python/list_index_range_valueerror_fail/main.py
@@ -1,0 +1,3 @@
+# An uncaught ValueError from a missing element in the window fails verification.
+l = [1, 2, 3]
+l.index(9, 0, 2)

--- a/regression/python/list_index_range_valueerror_fail/test.desc
+++ b/regression/python/list_index_range_valueerror_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/list_index_start_end_fail/main.py
+++ b/regression/python/list_index_start_end_fail/main.py
@@ -1,7 +1,8 @@
 def main() -> None:
     # 1 is not present in the slice a[1:] (only the leading element is a 1), so
     # list.index(1, 1) raises ValueError. This pins the not-found branch of the
-    # new range search (modelled as a property violation).
+    # range search; the uncaught ValueError makes verification fail here (the
+    # assert would otherwise trip on the a.index(1, 1) == 0 mismatch anyway).
     a = [1, 2, 3]
     assert a.index(1, 1) == 0
 

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -666,8 +666,10 @@ size_t __ESBMC_list_index_range(
       return i;
     ++i;
   }
-  __ESBMC_assert(0, "ValueError: list.index(x): x not in list");
-  return 0;
+  // Not found in l[start:end]. Return the SIZE_MAX sentinel so the frontend can
+  // raise a catchable ValueError (the dict KeyError / list.remove pattern);
+  // asserting here would be an uncatchable property violation instead.
+  return SIZE_MAX;
 }
 
 /* ---------- extend list ---------- */

--- a/src/python-frontend/python-list/list_query.cpp
+++ b/src/python-frontend/python-list/list_query.cpp
@@ -854,17 +854,46 @@ exprt python_list::build_index_range_list_call(
     element_arg = build_address_of(build_symbol(*elem_info.elem_symbol));
 
   // Args: (list, &value-or-ptr, type_id, size, start, end). The start/end
-  // Python ints are cast to the model's int64_t parameters by the call.
-  exprt call = build_call_expr(
-    *func,
-    size_type(),
-    {build_symbol(list),
-     element_arg,
-     build_symbol(*elem_info.elem_type_sym),
-     elem_info.elem_size,
-     start,
-     end});
-  call.location() = elem_info.location;
+  // Python ints are cast to the model's int64_t parameters by the call. The
+  // model returns SIZE_MAX when the element is absent in l[start:end]; raise a
+  // ValueError from the frontend on that path so try/except ValueError can
+  // catch it, mirroring the dict KeyError and list.remove ValueError lowerings.
+  symbolt &idx = converter_.create_tmp_symbol(
+    op, "index_range_ret", size_type(), exprt());
+  code_declt idx_decl(build_symbol(idx));
+  idx_decl.location() = elem_info.location;
+  converter_.add_instruction(idx_decl);
 
-  return call;
+  code_function_callt find_call;
+  find_call.function() = build_symbol(*func);
+  find_call.lhs() = build_symbol(idx);
+  find_call.arguments().push_back(build_symbol(list));
+  find_call.arguments().push_back(element_arg);
+  find_call.arguments().push_back(build_symbol(*elem_info.elem_type_sym));
+  find_call.arguments().push_back(elem_info.elem_size);
+  find_call.arguments().push_back(start);
+  find_call.arguments().push_back(end);
+  find_call.type() = size_type();
+  find_call.location() = elem_info.location;
+  converter_.add_instruction(find_call);
+
+  const BigInt size_max_val = power(2, bv_width(size_type())) - 1;
+  const constant_exprt size_max(size_max_val, size_type());
+  expr2tc idx2, max2;
+  migrate_expr(build_symbol(idx), idx2);
+  migrate_expr(size_max, max2);
+  exprt not_found = migrate_expr_back(equality2tc(idx2, max2));
+
+  exprt raise = converter_.get_exception_handler().gen_exception_raise(
+    "ValueError", "list.index(x): x not in list");
+  codet throw_code("expression");
+  throw_code.operands().push_back(raise);
+
+  code_ifthenelset guard;
+  guard.cond() = not_found;
+  guard.then_case() = throw_code;
+  guard.location() = elem_info.location;
+  converter_.add_instruction(guard);
+
+  return build_symbol(idx);
 }


### PR DESCRIPTION
## What

`list.index(x, start[, end])` (the range form) now raises a **catchable** `ValueError` when `x` is not present in `l[start:end]`, so `try/except ValueError` works. Previously it fired an uncatchable property violation (`__ESBMC_assert(0, "ValueError...")` inside `__ESBMC_list_index_range`).

This is the follow-up flagged in the 1-argument `list.index()` ValueError fix — the two `index` paths are now consistent.

## Fix

- `list.c`: `__ESBMC_list_index_range` returns `SIZE_MAX` on not-found instead of asserting.
- `list_query.cpp`: `build_index_range_list_call` calls the model into a temp, raises a `ValueError` from the frontend when the result is `SIZE_MAX`, and returns the temp — identical to the 1-argument lowering.

## Tests

- `list_index_range_valueerror` (CORE) — a caught `ValueError` for a missing element and for a present element outside the window, plus present-in-window lookups (default/explicit/negative bounds).
- `list_index_range_valueerror_fail` (CORE) — an uncaught `ValueError` fails verification.

Both CPython-sane. Found-in-window `index()` results (returning the original-list index) are unchanged.
