### PR TITLE
[python] Raise a catchable ValueError for a slice with step 0

### DIFF
--- a/regression/python/list-slice-step-zero_fail/main.py
+++ b/regression/python/list-slice-step-zero_fail/main.py
@@ -1,5 +1,5 @@
 # Regression for issue #4293: list slice with step==0.
-# CPython raises ValueError("slice step cannot be zero"); ESBMC reports it
-# via a failing assertion so verification flags the bad slice.
+# CPython raises ValueError("slice step cannot be zero"); ESBMC raises a
+# catchable ValueError, and this uncaught one makes verification fail here.
 xs = [10, 20, 30]
 ys = xs[::0]

--- a/regression/python/slice_step_zero_valueerror/main.py
+++ b/regression/python/slice_step_zero_valueerror/main.py
@@ -1,0 +1,24 @@
+# A slice with step 0 raises a catchable ValueError (previously an uncatchable
+# property violation). Covers list and string slices.
+try:
+    [1, 2, 3][::0]
+    assert False
+except ValueError:
+    pass
+
+try:
+    "abc"[::0]
+    assert False
+except ValueError:
+    pass
+
+l = [1, 2, 3, 4]
+try:
+    l[1::0]
+    assert False
+except ValueError:
+    pass
+
+# Valid slices are unchanged.
+assert [0, 1, 2, 3, 4][::2] == [0, 2, 4]
+assert [1, 2, 3][::-1] == [3, 2, 1]

--- a/regression/python/slice_step_zero_valueerror/test.desc
+++ b/regression/python/slice_step_zero_valueerror/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/slice_step_zero_valueerror_fail/main.py
+++ b/regression/python/slice_step_zero_valueerror_fail/main.py
@@ -1,0 +1,2 @@
+# An uncaught ValueError from a zero step fails verification.
+x = [1, 2, 3][::0]

--- a/regression/python/slice_step_zero_valueerror_fail/test.desc
+++ b/regression/python/slice_step_zero_valueerror_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -798,18 +798,18 @@ exprt python_list::handle_range_slice(
       step_val = 1; // continue with valid value to keep IR consistent
     }
   }
-  // Python raises ValueError on step==0; emit a failing assertion so
-  // verification reports it rather than silently producing a slice.
-  // code_assertt does not insert assume(false), so the rest of the slice
-  // IR still runs with step_val==1 — that is harmless: the violation is
-  // already reported by the checker.
+  // Python raises ValueError on step==0. Raise it from the frontend (a
+  // cpp-throw) so try/except ValueError can catch it — a code_assert would be
+  // an uncatchable property violation. The raise diverts control, so the rest
+  // of the slice IR (kept consistent with step_val==1) is a dead path.
   if (literal_zero_step)
   {
-    // V.3: build the always-fail assert condition in IREP2.
-    code_assertt step_assert(migrate_expr_back(gen_false_expr()));
-    step_assert.location() = converter_.get_location_from_decl(slice_node);
-    step_assert.location().comment("ValueError: slice step cannot be zero");
-    converter_.add_instruction(step_assert);
+    exprt raise = converter_.get_exception_handler().gen_exception_raise(
+      "ValueError", "slice step cannot be zero");
+    codet throw_code("expression");
+    throw_code.operands().push_back(raise);
+    throw_code.location() = converter_.get_location_from_decl(slice_node);
+    converter_.add_instruction(throw_code);
   }
   bool negative_step = (step_val < 0);
 


### PR DESCRIPTION
## What

A slice with a step of 0 (`[1,2,3][::0]`, `"abc"[::0]`) now raises a **catchable** `ValueError`, so `try/except ValueError` works. Previously it fired an uncatchable property violation (`code_assertt(false)`).

## Fix

Replace the always-failing assert with a frontend `cpp-throw` `ValueError` (`gen_exception_raise("ValueError", "slice step cannot be zero")`), the same catchable-exception pattern used by `list.remove`, dict `KeyError`, and `list.index`. The raise is unconditional inside the `literal_zero_step` branch — a literal 0 step always raises in Python — and diverts control, so the subsequent slice IR (kept consistent with `step_val==1`) is a dead path. The shared slice path covers both list and string slices.

## Tests

- `slice_step_zero_valueerror` (CORE) — a caught `ValueError` for list and string zero-step slices (with and without a start), plus valid slices unchanged.
- `slice_step_zero_valueerror_fail` (CORE) — an uncaught `ValueError` fails verification.
- The existing `list-slice-step-zero_fail` still fails on the uncaught ValueError; its stale comment is updated.

Both CPython-sane. A runtime/symbolic zero step (`l[::s]` where `s` may be 0) remains unhandled — a pre-existing limitation, unchanged.
