### PR TITLE
[python] Apply scalar default arguments for lambda/function-pointer calls

### DIFF
--- a/regression/python/lambda_default_arg/main.py
+++ b/regression/python/lambda_default_arg/main.py
@@ -1,0 +1,35 @@
+# A lambda bound to a variable applies its default arguments when the argument
+# is omitted (previously the parameter was modelled as nondet). Covers int,
+# float, bool and negative defaults, multiple defaults, and partial
+# application; an explicitly supplied argument overrides the default.
+f = lambda x, y=2: x * y
+assert f(3) == 6
+assert f(3, 5) == 15
+
+g = lambda x=10: x + 1
+assert g() == 11
+
+h = lambda a, b=2, c=3: a + b + c
+assert h(1) == 6
+assert h(1, 10) == 14
+
+p = lambda x, y=1.5: x + y
+assert p(2) == 3.5
+
+q = lambda x, y=-5: x + y
+assert q(10) == 5
+
+b = lambda x, flag=True: flag
+assert b(1) == True
+
+# A lambda without defaults is unchanged.
+n = lambda x, y: x * y
+assert n(3, 2) == 6
+
+# A def-bound function variable also fills scalar defaults through the same
+# indirect-call path (a string default is left nondet, not asserted here).
+def scaled(v, factor=3):
+    return v * factor
+op = scaled
+assert op(4) == 12
+assert op(4, 2) == 8

--- a/regression/python/lambda_default_arg/test.desc
+++ b/regression/python/lambda_default_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda_default_arg_fail/main.py
+++ b/regression/python/lambda_default_arg_fail/main.py
@@ -1,0 +1,3 @@
+# The default y=2 makes f(3) == 6, not 99.
+f = lambda x, y=2: x * y
+assert f(3) == 99

--- a/regression/python/lambda_default_arg_fail/test.desc
+++ b/regression/python/lambda_default_arg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -623,6 +623,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // the symbol's value (address_of(func)), because gen_pointer_type
       // does not preserve the full code_typet (return type + arguments).
       bool resolved = false;
+      const code_typet *resolved_func_type = nullptr;
       if (
         var_symbol->get_value().is_address_of() &&
         !var_symbol->get_value().operands().empty() &&
@@ -632,8 +633,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           var_symbol->get_value().operands()[0].identifier());
         if (target_func && target_func->get_type().is_code())
         {
-          const code_typet &func_type = to_code_type(target_func->get_type());
-          call.type() = func_type.return_type();
+          resolved_func_type = &to_code_type(target_func->get_type());
+          call.type() = resolved_func_type->return_type();
           resolved = true;
         }
       }
@@ -641,9 +642,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // Try to get return type from the pointer's subtype
       if (!resolved && var_symbol->get_type().subtype().is_code())
       {
-        const code_typet &func_type =
-          to_code_type(var_symbol->get_type().subtype());
-        call.type() = func_type.return_type();
+        resolved_func_type = &to_code_type(var_symbol->get_type().subtype());
+        call.type() = resolved_func_type->return_type();
         resolved = true;
       }
 
@@ -662,6 +662,29 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           if (arg_expr.type().is_code() && arg_expr.is_symbol())
             arg_expr = address_of_exprt(arg_expr);
           call.arguments().push_back(arg_expr);
+        }
+      }
+
+      // Fill omitted trailing parameters that carry a default value (e.g. a
+      // `lambda x, y=2: ...` called with fewer arguments), so symex does not
+      // model them as nondet. Stop at the first parameter that cannot be
+      // filled so the remaining positional arguments stay aligned: either it
+      // has no default, or its default is a string/array. A string default is
+      // stored raw (a char array) and needs the string_constantt/address-of
+      // conversion finalize_call applies to direct calls; pushing it here would
+      // pass an unconverted array->pointer argument (right content but wrong
+      // len()), so leave it — and everything after it — nondet as before.
+      if (resolved_func_type)
+      {
+        const auto &params = resolved_func_type->arguments();
+        for (size_t i = call.arguments().size(); i < params.size(); ++i)
+        {
+          if (!params[i].has_default_value())
+            break;
+          const exprt &default_val = params[i].default_value();
+          if (default_val.type().is_array())
+            break;
+          call.arguments().push_back(default_val);
         }
       }
 

--- a/src/python-frontend/python_lambda.cpp
+++ b/src/python-frontend/python_lambda.cpp
@@ -283,6 +283,39 @@ void python_lambda::process_lambda_parameters(
 
     context_.add(param_symbol);
   }
+
+  // Trailing positional parameters may carry default values
+  // (lambda x, y=2: ...). Record them on the argument slots so the call site
+  // fills omitted arguments, matching process_function_arguments for defs;
+  // without this the omitted parameter is left nondet.
+  if (
+    args_node.contains("defaults") && args_node["defaults"].is_array() &&
+    !args_node["defaults"].empty())
+  {
+    const auto &defaults = args_node["defaults"];
+    const size_t n_args = lambda_type.arguments().size();
+    const size_t defaults_count = defaults.size();
+    if (defaults_count <= n_args)
+    {
+      for (size_t i = 0; i < defaults_count; ++i)
+      {
+        if (defaults[i].is_null())
+          continue;
+        auto &arg = lambda_type.arguments()[n_args - defaults_count + i];
+        exprt default_expr = converter_.get_expr(defaults[i]);
+        // String/aggregate defaults need the string_constantt + address-of
+        // conversion that finalize_call applies to def parameters, which is not
+        // yet wired through the lambda indirect-call path. Record only scalar
+        // defaults; a string default is left as the existing nondet rather than
+        // a mis-cast pointer.
+        if (default_expr.type().is_array() || arg.type().is_pointer())
+          continue;
+        if (default_expr.type() != arg.type())
+          default_expr = typecast_exprt(default_expr, arg.type());
+        arg.default_value() = default_expr;
+      }
+    }
+  }
 }
 
 exprt python_lambda::process_lambda_body(


### PR DESCRIPTION
## What

A function-pointer variable now fills omitted **scalar** default arguments through the indirect-call path. Chiefly this fixes lambdas bound to a variable: `f = lambda x, y=2: x*y; f(3)` previously left `y` **nondet** ("missing argument for parameter ...; modelled as nondet") and gave wrong results, while regular `def` functions already handled defaults. The same path also now fills scalar defaults for a `def`-bound variable (`g = some_def; g(3)`).

## Root cause & fix

Two gaps:
1. `process_lambda_parameters` never recorded the AST `defaults` onto the lambda's `code_typet` argument slots. Now it does, mirroring `process_function_arguments`. Scoped to scalar defaults — a string default is skipped (left nondet), since it needs the `string_constantt`/address-of conversion `finalize_call` applies to direct calls.
2. The indirect-call-through-function-pointer path in `converter_funcall.cpp` only pushed the *provided* arguments. It now captures the resolved target `code_typet` and appends each omitted trailing parameter's `default_value()`, stopping at the first parameter with no default **or** an array/string default (so positional arguments stay aligned and an unconverted array→pointer argument is never passed — a `def`-bound variable with a string default stays cleanly nondet, as before).

## Tests

- `lambda_default_arg` (CORE) — lambda int/float/bool/negative defaults, multiple defaults, partial application, override; a `def`-bound variable filling a scalar default; no-default and no-arg lambdas unchanged.
- `lambda_default_arg_fail` (CORE) — pins that the default makes `f(3) == 6`, not `99`.

Both CPython-sane; regression clean. Out of scope (still nondet, pre-existing, verified sound): a **string** default via a function variable, and an **inline** `(lambda x, y=1: ...)(a)` call (func type `Lambda`, not a `Name` variable).
