### PR TITLE
[python] Support except with a tuple of exception types

### DIFF
--- a/regression/python/except_tuple_types/main.py
+++ b/regression/python/except_tuple_types/main.py
@@ -1,0 +1,28 @@
+# `except (A, B):` catches any of the listed exception types. This previously
+# crashed ESBMC (a json operator[] assertion, because the tuple type node has
+# no "id"). Covers both listed types, a third type, the `as e` binding, body
+# execution, and dispatch to a following handler when the tuple does not match.
+caught = 0
+try:
+    raise KeyError()
+except (ValueError, KeyError):
+    caught = 1
+assert caught == 1
+
+try:
+    raise ValueError()
+except (ValueError, KeyError, IndexError):
+    pass
+
+try:
+    raise IndexError()
+except (ValueError, KeyError):
+    assert False   # not one of the listed types here...
+except IndexError:
+    caught = 2
+assert caught == 2
+
+try:
+    raise ValueError("boom")
+except (ValueError, KeyError) as e:
+    assert str(e) == "boom"

--- a/regression/python/except_tuple_types/test.desc
+++ b/regression/python/except_tuple_types/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/except_tuple_types_fail/main.py
+++ b/regression/python/except_tuple_types_fail/main.py
@@ -1,0 +1,5 @@
+# A type not in the tuple is not caught and propagates as an uncaught exception.
+try:
+    raise TypeError()
+except (ValueError, KeyError):
+    pass

--- a/regression/python/except_tuple_types_fail/test.desc
+++ b/regression/python/except_tuple_types_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -354,18 +354,28 @@ void python_exception_handler::get_raise_statement(
   block.move_to_operands(code_expr);
 }
 
-void python_exception_handler::get_except_handler_statement(
+// Emit a single catch block for `type_node` (an exception-type Name node, or
+// null for a bare `except:`), running the handler body. Appends it to `block`.
+void python_exception_handler::emit_catch_block(
   const nlohmann::json &element,
+  const nlohmann::json &type_node,
   codet &block)
 {
   symbolt *exception_symbol = nullptr;
   typet exception_type;
 
   // Create exception variable symbol before processing body
-  if (!element["type"].is_null())
+  if (!type_node.is_null())
   {
+    // Only a bare name (`except ValueError:`) is modelled. A dotted type such
+    // as `except socket.error:` is an Attribute node with no "id"; reject it
+    // with a clean diagnostic rather than crashing on the missing json key.
+    if (!type_node.contains("id"))
+      throw std::runtime_error(
+        "except with a dotted/attribute exception type is not supported");
+
     exception_type =
-      type_handler_.get_typet(element["type"]["id"].get<std::string>());
+      type_handler_.get_typet(type_node["id"].get<std::string>());
 
     std::string name;
     symbol_id sid = converter_.create_symbol_id();
@@ -422,6 +432,27 @@ void python_exception_handler::get_except_handler_statement(
   }
 
   block.move_to_operands(catch_block);
+}
+
+void python_exception_handler::get_except_handler_statement(
+  const nlohmann::json &element,
+  codet &block)
+{
+  const nlohmann::json &type_node = element["type"];
+
+  // `except (A, B, ...):` lists several exception types as a tuple and catches
+  // any of them. Model it as one catch block per type, each running the same
+  // body (mirroring `except A: <body>` followed by `except B: <body>`).
+  if (
+    !type_node.is_null() && type_node.contains("_type") &&
+    type_node["_type"] == "Tuple")
+  {
+    for (const auto &elt : type_node["elts"])
+      emit_catch_block(element, elt, block);
+    return;
+  }
+
+  emit_catch_block(element, type_node, block);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/python-frontend/python_exception_handler.h
+++ b/src/python-frontend/python_exception_handler.h
@@ -74,6 +74,13 @@ public:
   void
   get_except_handler_statement(const nlohmann::json &element, codet &block);
 
+  // Emit one catch block for a single exception-type node (or null for a bare
+  // `except:`); used per type when `except (A, B):` lists a tuple of types.
+  void emit_catch_block(
+    const nlohmann::json &element,
+    const nlohmann::json &type_node,
+    codet &block);
+
   // -----------------------------------------------------------------------
   // Assertion helpers (previously python_converter private methods)
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## What

`except (ValueError, KeyError):` — a tuple of exception types — **crashed** ESBMC with a json `operator[]` assertion abort. `get_except_handler_statement` read `element["type"]["id"]`, assuming the type node is a `Name` (with an `"id"`), but a tuple of types is a `Tuple` node (it has `"elts"`, no `"id"`). This is a common pattern, so the crash blocked verifying any program using it.

## Fix

Factor the single-handler logic into `emit_catch_block(element, type_node, block)` (unchanged, but keyed off the passed `type_node`). `get_except_handler_statement` now dispatches: for a `Tuple` type node it emits one catch block per listed type; otherwise a single catch block as before (including the bare `except:` / null path). This models `except (A, B): <body>` as `except A: <body>` followed by `except B: <body>`.

## Tests

- `except_tuple_types` (CORE) — a tuple catching either listed type, a three-type tuple, dispatch to a following handler when the tuple doesn't match, and the `as e` binding (`str(e)`).
- `except_tuple_types_fail` (CORE) — a type not in the tuple propagates uncaught.

Both CPython-sane; regression clean. Verified: the `as e` binding works across the emitted blocks with no symbol-table conflict, bodies with locals/loops/calls convert correctly, and single-type / bare `except:` are unchanged.

Also guards the pre-existing crash on a dotted/`Attribute` exception type (`except socket.error:` or such a type inside the tuple) — it likewise lacks `"id"` and asserted; it now emits a clean "not supported" diagnostic instead of aborting.
