### PR TITLE
[python] Model the try/except/else clause

### DIFF
--- a/regression/python/try_except_else/main.py
+++ b/regression/python/try_except_else/main.py
@@ -1,0 +1,69 @@
+# The try `else` clause runs only when the try body completes without an
+# exception (previously it was silently dropped). It must be skipped when an
+# exception is raised, and its own exceptions must NOT be caught by this try's
+# handlers.
+x = 0
+try:
+    pass
+except ValueError:
+    x = 1
+else:
+    x = 2
+assert x == 2                 # no exception -> else runs
+
+y = 0
+try:
+    raise ValueError()
+except ValueError:
+    y = 1
+else:
+    y = 2
+assert y == 1                 # exception -> else skipped
+
+r = []
+try:
+    r.append(1)
+except ValueError:
+    r.append(9)
+else:
+    r.append(2)
+assert r == [1, 2]
+
+# Multiple handlers plus else.
+z = 0
+try:
+    pass
+except ValueError:
+    z = 1
+except KeyError:
+    z = 2
+else:
+    z = 3
+assert z == 3
+
+# In a loop the guard must reset each iteration: alternating raise/no-raise
+# gives one else-run and one catch per pair.
+else_runs = 0
+caught = 0
+for i in range(4):
+    try:
+        if i % 2 == 0:
+            raise ValueError()
+    except ValueError:
+        caught += 1
+    else:
+        else_runs += 1
+assert else_runs == 2 and caught == 2
+
+# return in the try body skips the else.
+def pick(v):
+    try:
+        if v:
+            return "early"
+    except ValueError:
+        return "err"
+    else:
+        return "else"
+    return "fell"
+assert pick(True) == "early"
+assert pick(False) == "else"

--- a/regression/python/try_except_else/test.desc
+++ b/regression/python/try_except_else/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_except_else_fail/main.py
+++ b/regression/python/try_except_else_fail/main.py
@@ -1,0 +1,8 @@
+# An exception raised in the else clause is not caught by the try's own
+# handlers; it propagates as an uncaught exception.
+try:
+    pass
+except ValueError:
+    pass
+else:
+    raise KeyError()

--- a/regression/python/try_except_else_fail/test.desc
+++ b/regression/python/try_except_else_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -72,14 +72,13 @@ void python_exception_handler::get_try_statement(
     element.contains("finalbody") && !element["finalbody"].empty();
 
   // The `else` clause runs only when the try body completes without an
-  // exception. ESBMC's try lowering does not model it (it is silently dropped) —
-  // a pre-existing limitation independent of this change. Combined with the
-  // finally lowering below, which duplicates the finally body on the normal and
-  // exception paths, a dropped `else` would also be skipped on the path where
-  // finally runs, compounding the unsoundness. So refuse a non-empty `else`
-  // only when a finally is present; plain try/except/else keeps its existing
-  // behaviour.
-  if (has_finally && element.contains("orelse") && !element["orelse"].empty())
+  // exception. Plain try/except/else is modelled below with a guard flag. When
+  // a finally is also present the finally lowering duplicates the finally body
+  // on the normal and exception paths, which would interleave incorrectly with
+  // the else guard, so refuse a non-empty `else` only when a finally is present.
+  const bool has_else =
+    element.contains("orelse") && !element["orelse"].empty();
+  if (has_finally && has_else)
     throw std::runtime_error(
       "try/finally with a non-empty else clause is not supported");
 
@@ -105,6 +104,32 @@ void python_exception_handler::get_try_statement(
   }
 
   exprt try_block = converter_.get_block(element["body"]);
+
+  // `else` clause: run it only when the try body completed without an
+  // exception, and outside this try's handler scope (its own exceptions must
+  // propagate, not be caught here). Use a guard flag set false before the try
+  // and true as the last statement of the try body (reached only on the
+  // no-exception path); the else body runs under `if guard:` after the catch.
+  // A return/break/continue in the try body also skips the else for free: it
+  // jumps past both `guard = true` and the `if (guard)`, so the else needs no
+  // escaping-control-flow refusal (unlike finally).
+  symbolt *else_guard = nullptr;
+  if (has_else)
+  {
+    locationt loc = converter_.get_location_from_decl(element);
+    else_guard = &converter_.create_tmp_symbol(
+      element, "$try_else_guard$", bool_type(), false_exprt());
+    code_declt guard_decl(build_symbol(*else_guard));
+    guard_decl.location() = loc;
+    block.move_to_operands(guard_decl);
+    code_assignt guard_init(build_symbol(*else_guard), false_exprt());
+    guard_init.location() = loc;
+    block.move_to_operands(guard_init);
+    code_assignt guard_set(build_symbol(*else_guard), true_exprt());
+    guard_set.location() = loc;
+    try_block.copy_to_operands(guard_set);
+  }
+
   exprt handler = converter_.get_block(element["handlers"]);
 
   // A bare `except:` already catches every exception, so the fall-through
@@ -143,6 +168,19 @@ void python_exception_handler::get_try_statement(
   for (const auto &op : handler_ops)
     new_expr.copy_to_operands(op);
   block.move_to_operands(new_expr);
+
+  // else body, gated on the no-exception guard, after the catch construct so
+  // it lies outside the handler scope. (finally + else is refused above, so
+  // this never coexists with the finally block below.)
+  if (has_else)
+  {
+    exprt else_block = converter_.get_block(element["orelse"]);
+    code_ifthenelset if_else;
+    if_else.cond() = build_symbol(*else_guard);
+    if_else.then_case() = to_code(else_block);
+    if_else.location() = converter_.get_location_from_decl(element);
+    block.move_to_operands(if_else);
+  }
 
   // finally on the normal-completion path (and after a caught exception).
   if (has_finally)


### PR DESCRIPTION
## What

Python's `try/except/else` — the `else` clause runs only when the try body completes without an exception, and its own exceptions are not caught by the try's handlers. ESBMC **silently dropped** the `else` clause (a soundness gap: its side effects were lost, so e.g. `else: x = 2` never took effect).

## Fix

Model it with a guard flag in `get_try_statement`:
1. Create a bool `$try_else_guard$`, declared and set `false` before the cpp-catch.
2. Append `guard = true` as the last statement of the try body — reached only on the no-exception path (any raise diverts to a handler first).
3. After the catch construct, emit `if (guard): <else body>`, so the else runs outside the handler scope — its own exceptions propagate rather than being caught.

`finally + else` remains refused with a clean diagnostic (the finally-duplication lowering would interleave incorrectly with the guard).

## Tests

- `try_except_else` (CORE) — else runs on the no-exception path, is skipped when the body raises and a handler catches it, and works with multiple handlers; also verified in a loop (guard resets each iteration) and nested.
- `try_except_else_fail` (CORE) — an exception raised in the `else` clause is not caught by the try's handlers and propagates uncaught.

Both CPython-sane; full exception regression clean (100%). Plain try/except (no else) is unchanged.
