### PR TITLE
[python] Fix crash raising a no-argument custom exception

### DIFF
--- a/regression/python/raise_custom_init_exception/main.py
+++ b/regression/python/raise_custom_init_exception/main.py
@@ -1,0 +1,16 @@
+# A custom exception with its own __init__ (with or without arguments) still
+# builds a proper instance carrying its attributes (the no-arg cpp-throw fix
+# must not clobber these).
+class F(Exception):
+    def __init__(self, code):
+        self.code = code
+
+
+def main() -> None:
+    try:
+        raise F(5)
+    except F as e:
+        assert e.code == 5
+
+
+main()

--- a/regression/python/raise_custom_init_exception/test.desc
+++ b/regression/python/raise_custom_init_exception/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/raise_noarg_custom_exception/main.py
+++ b/regression/python/raise_noarg_custom_exception/main.py
@@ -1,0 +1,31 @@
+# Raising a no-argument custom exception whose class inherits __init__ (e.g.
+# class E(Exception): pass; raise E()) previously crashed ESBMC — get_expr
+# lowered E() to a bare cpp-throw side-effect, which was then wrapped in another
+# cpp-throw and aborted value_set's make_member. It is now caught normally.
+class E(Exception):
+    pass
+
+
+def main() -> None:
+    caught = 0
+    try:
+        raise E()
+    except E:
+        caught = 1
+    assert caught == 1
+
+    try:
+        raise E()
+    except E as e:
+        caught = 2
+    assert caught == 2
+
+    # Caught by a base class too.
+    try:
+        raise E()
+    except Exception:
+        caught = 3
+    assert caught == 3
+
+
+main()

--- a/regression/python/raise_noarg_custom_exception/test.desc
+++ b/regression/python/raise_noarg_custom_exception/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/raise_noarg_custom_exception_fail/main.py
+++ b/regression/python/raise_noarg_custom_exception_fail/main.py
@@ -1,0 +1,4 @@
+# A no-argument custom exception that is not caught propagates uncaught.
+class E(Exception):
+    pass
+raise E()

--- a/regression/python/raise_noarg_custom_exception_fail/test.desc
+++ b/regression/python/raise_noarg_custom_exception_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -336,6 +336,25 @@ void python_exception_handler::get_raise_statement(
       tmp.location() = location;
       raise = tmp;
     }
+    else if (
+      raise.id() == "sideeffect" && raise.get("statement") == "cpp-throw")
+    {
+      // A no-argument exception constructor whose class inherits __init__
+      // (e.g. `raise E()` where `class E(Exception): pass`) lowers to a bare
+      // cpp-throw side-effect rather than a constructed instance. Wrapping it
+      // in the cpp-throw built below would nest two throws and hand value_set
+      // a non-struct operand, aborting in make_member. Synthesize a
+      // zero-initialised instance instead, as the _init_undefined path does
+      // for classes with no __init__ at all. (A constructor with arguments or
+      // a custom __init__ yields a proper instance and keeps the paths above.)
+      if (type.is_empty())
+        type = any_type();
+      typet resolved = type;
+      if (resolved.id() == "symbol")
+        resolved = converter_.name_space().follow(type);
+      raise = gen_zero(resolved);
+      raise.type() = type;
+    }
     else
     {
       if (type.is_empty())


### PR DESCRIPTION
## What

Raising a no-argument custom exception whose class inherits `__init__` — e.g. `class E(Exception): pass` then `raise E()` — **crashed** ESBMC with an internal assertion abort (`make_member` on a non-struct type, `value_set.cpp:1540`). It now works: the exception is raised and caught normally.

## Root cause & fix

For this case `get_expr(element["exc"])` returns a bare `cpp-throw` side-effect (a degenerate re-throw) instead of a constructed instance. `get_raise_statement` then wraps it in *another* `cpp-throw`, nesting two throws and handing value_set a non-struct operand.

The fix adds one branch to the custom-exception path: when `raise` is a `cpp-throw` side-effect, synthesize a zero-initialised instance of the class struct (the same synthesis the existing `_init_undefined` branch uses for classes with no `__init__` at all). A constructor with arguments, or a custom `__init__` (with or without arguments), yields a proper instance (a `symbol`) and keeps the existing paths, so their attributes are preserved.

## Tests

- `raise_noarg_custom_exception` (CORE) — `raise E()` caught by `except E`, `except E as e`, and `except Exception`.
- `raise_noarg_custom_exception_fail` (CORE) — an uncaught no-arg custom exception propagates (FAILED).
- `raise_custom_init_exception` (CORE) — a custom `__init__` still carries its attribute (`e.code == 5`), guarding against the synthesis clobbering it.

Both CPython-sane; exception/class regression clean. (`str(e)` of a no-arg custom exception is still imprecise — a separate, pre-existing limitation — but is now a sound result rather than a crash.)
