### PR TITLE
[python] Add KNOWNBUG for min()/max() over a string

### DIFF
--- a/regression/python/min_max_list_works/main.py
+++ b/regression/python/min_max_list_works/main.py
@@ -1,0 +1,8 @@
+# min()/max() over a list or tuple (including lists of strings) works; this
+# pins the boundary of the string-argument limitation in min_max_string_knownbug.
+assert min([3, 1, 2]) == 1
+assert max([3, 1, 2]) == 3
+assert min(["b", "a", "c"]) == "a"
+assert max(["b", "a", "c"]) == "c"
+assert min((5, 2, 8)) == 2
+assert max((5, 2, 8)) == 8

--- a/regression/python/min_max_list_works/test.desc
+++ b/regression/python/min_max_list_works/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/min_max_string_knownbug/main.py
+++ b/regression/python/min_max_string_knownbug/main.py
@@ -1,0 +1,6 @@
+# KNOWNBUG: min()/max() over a string should compare its characters
+# (min("banana") == "a", max("banana") == "n"), but ESBMC returns the wrong
+# result. min()/max() over a list or tuple works; a string argument is not
+# routed through the character-iterating comparison in handle_min_max.
+assert min("banana") == "a"
+assert max("banana") == "n"

--- a/regression/python/min_max_string_knownbug/test.desc
+++ b/regression/python/min_max_string_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## What

Documents, as a KNOWNBUG plus a passing companion, that `min()`/`max()` over a **string** returns the wrong result — `min("banana")` should compare the string's characters and yield `"a"` (and `max` `"n"`), but ESBMC does not.

## Root cause

`handle_min_max` routes a tuple argument (struct) and a list argument through a character/element comparison chain, but a string argument (a `char*`/char array, not a struct) is not iterated over its characters, so the comparison yields the wrong value.

## Tests

- `min_max_string_knownbug` (**KNOWNBUG**) — `min("banana") == "a"`, `max("banana") == "n"`.
- `min_max_list_works` (**CORE**) — `min`/`max` over int lists, string lists, and tuples all correct, pinning the working boundary.

Both CPython-sane. No code change — this records the limitation with a reproducer; the fix (route a string argument through the character-iterating comparison) is left as follow-up.
