### PR TITLE
[python] Reconcile pointer operand in a chained comparison

### DIFF
--- a/regression/python/chained_compare_unannotated/main.py
+++ b/regression/python/chained_compare_unannotated/main.py
@@ -1,0 +1,43 @@
+# A chained comparison (a <= x <= b) whose middle operand is an unannotated
+# parameter crashed ESBMC: the parameter is typed as a pointer, and while the
+# first comparison was type-reconciled, the loop that builds the remaining
+# comparisons left a pointer-vs-int compare that aborted the SMT backend
+# (convert_ptr_cmp). The pointer operand is now reconciled like the first.
+class Range:
+    def __init__(self, lo, hi):
+        self.lo = lo
+        self.hi = hi
+
+    def check(self, x):
+        return self.lo <= x <= self.hi
+
+
+r = Range(1, 10)
+assert r.check(5)
+assert r.check(1)
+assert r.check(10)
+assert not r.check(0)
+assert not r.check(20)
+
+
+# Unannotated free-function parameters in a chained comparison.
+def between(a, b, c):
+    return a <= b <= c
+
+
+assert between(1, 2, 3)
+assert not between(3, 2, 1)
+
+
+# One bound a literal, the other a self attribute.
+class Upper:
+    def __init__(self, hi):
+        self.hi = hi
+
+    def ok(self, x):
+        return 0 <= x <= self.hi
+
+
+u = Upper(10)
+assert u.ok(5)
+assert not u.ok(11)

--- a/regression/python/chained_compare_unannotated/test.desc
+++ b/regression/python/chained_compare_unannotated/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/chained_compare_unannotated_fail/main.py
+++ b/regression/python/chained_compare_unannotated_fail/main.py
@@ -1,0 +1,11 @@
+# 20 is not within [1, 10], so the chained comparison is False.
+class Range:
+    def __init__(self, lo, hi):
+        self.lo = lo
+        self.hi = hi
+
+    def check(self, x):
+        return self.lo <= x <= self.hi
+
+
+assert Range(1, 10).check(20)

--- a/regression/python/chained_compare_unannotated_fail/test.desc
+++ b/regression/python/chained_compare_unannotated_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -697,6 +697,25 @@ exprt python_converter::handle_chained_comparisons_logic(
     }
     else
     {
+      // Reconcile a pointer operand against an integer one before building the
+      // comparison, mirroring the first comparison (bin_expr). An unannotated
+      // param is typed as a pointer but holds an integer value round-tripped as
+      // (int*)n; building `ptr <= int` raw here aborts in the SMT backend
+      // (convert_ptr_cmp). Cast the pointer to the integer operand's type,
+      // exactly as the reconciled first comparison does for an integer bound
+      // (get_binary_operator_expr, "cast void* to integer"). Restricted to
+      // integers: a float bound is reconciled differently there (the float is
+      // bitcast to the pointer type), so folding it in here would make the two
+      // conjuncts of `a <= x <= b` reconstruct x inconsistently. A float-bounded
+      // chained comparison over an unannotated param stays a pre-existing
+      // crash, unchanged by this patch.
+      auto is_integer = [](const typet &t) {
+        return t.is_signedbv() || t.is_unsignedbv();
+      };
+      if (op1.type().is_pointer() && is_integer(op2.type()))
+        op1 = typecast_exprt(op1, op2.type());
+      else if (op2.type().is_pointer() && is_integer(op1.type()))
+        op2 = typecast_exprt(op2, op1.type());
       exprt logical_expr(
         python_frontend::map_operator(op, bool_type()), bool_type());
       logical_expr.copy_to_operands(op1, op2);


### PR DESCRIPTION
## What

A chained comparison `a <= x <= b` whose middle operand `x` is an **unannotated parameter** crashed ESBMC with an assertion abort (`is_pointer_type(side2)` in `convert_ptr_cmp`). An unannotated parameter is typed as a pointer; the chained comparison desugars to `(a <= x) and (x <= b)`, and while the first comparison was type-reconciled (the pointer operand cast to the arithmetic operand's type), `handle_chained_comparisons_logic` built the remaining comparisons raw, leaving a `pointer <= int` compare that the SMT backend rejects.

## Fix

In the per-pair loop of `handle_chained_comparisons_logic`, before building a comparison, cast a pointer operand to the other operand's **integer** type — mirroring the reconciliation the first comparison already applies to an integer bound. Pointer-vs-pointer comparisons are left unchanged (they are valid), and string operands are handled by the string branch above. A **float** bound is reconciled differently by the first comparison (the float is bitcast to the pointer type), so it is intentionally left out here to keep both conjuncts consistent — a float-bounded chained comparison over an unannotated parameter remains a pre-existing crash, unchanged by this patch.

## Tests

- `chained_compare_unannotated` (CORE) — `self.lo <= x <= self.hi` (unannotated method param), unannotated free-function params (`a <= b <= c`), and one-literal-one-attribute bounds.
- `chained_compare_unannotated_fail` (CORE) — an out-of-range value makes the chained comparison False.

Both CPython-sane; comparison regression clean. Existing chained comparisons (local ints, all-self-attribute, annotated params, strings, floats, 4-way) are unchanged. (An orthogonal inline-instance limitation — a method call on a *temporary* receiver like `Upper(10).ok(5)` — is avoided in the tests by using a variable receiver.)
