### PR TITLE
[python] Reconcile an any-type param stored into an integer attribute

### DIFF
--- a/regression/python/attr_store_unannotated/main.py
+++ b/regression/python/attr_store_unannotated/main.py
@@ -1,0 +1,28 @@
+# Storing an unannotated parameter into an existing integer attribute
+# (self.v = val) crashed ESBMC: the parameter is typed as a pointer, and writing
+# it into a non-pointer field aborted with2t's type-compat assertion. The RHS is
+# now reconciled to the member's integer type.
+class Box:
+    def __init__(self):
+        self.a = 0
+        self.b = 0
+
+    def store(self, val):
+        self.a = val
+
+    def store_both(self, x, y):
+        self.a = x
+        self.b = y
+
+    def get(self):
+        return self.a
+
+
+b = Box()
+b.store(5)
+assert b.a == 5
+assert b.get() == 5
+b.store(-3)
+assert b.a == -3
+b.store_both(7, 8)
+assert b.a == 7 and b.b == 8

--- a/regression/python/attr_store_unannotated/test.desc
+++ b/regression/python/attr_store_unannotated/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/attr_store_unannotated_fail/main.py
+++ b/regression/python/attr_store_unannotated_fail/main.py
@@ -1,0 +1,12 @@
+# store(5) sets self.v to 5, not 99.
+class Box:
+    def __init__(self):
+        self.v = 0
+
+    def store(self, val):
+        self.v = val
+
+
+b = Box()
+b.store(5)
+assert b.v == 99

--- a/regression/python/attr_store_unannotated_fail/test.desc
+++ b/regression/python/attr_store_unannotated_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -422,6 +422,24 @@ void python_converter::handle_assignment_type_adjustments(
   if (target_is_subscript)
     return;
 
+  // Assigning to a struct member (self.attr = value): an unannotated parameter
+  // is typed as the any-type carrier (void*, i.e. a pointer whose subtype is
+  // empty) but holds an integer value round-tripped as (int*)n. Writing that
+  // into a non-pointer integer field aborts with2t's type-compat assertion.
+  // Cast the any-type RHS to the member's declared integer type, recovering the
+  // integer. Restricted to the empty-subtype carrier (matching is_any_ptr in
+  // converter_binop): a genuine pointer value (None, a class instance, a list)
+  // is left untouched so it is not silently reinterpreted as an integer, and a
+  // float member (which would need a bit-reinterpretation) is left unchanged.
+  if (
+    lhs.id() == "member" && rhs.type().is_pointer() &&
+    rhs.type().subtype().id() == "empty" &&
+    (lhs.type().is_signedbv() || lhs.type().is_unsignedbv()))
+  {
+    rhs = typecast_exprt(rhs, lhs.type());
+    return;
+  }
+
   // Handle assignment of function to function pointer variable
   if (
     lhs.type().is_pointer() && lhs.type().subtype().is_code() &&


### PR DESCRIPTION
## What

Storing an unannotated parameter into an existing integer attribute — `def store(self, val): self.a = val` where `self.a` was created as an int — **crashed** ESBMC with an assertion abort (`assert_type_compat_for_with`: a `with2t` member update whose value type is incompatible with the field). An unannotated parameter is typed as a pointer, and writing that pointer into a non-pointer integer field aborts.

## Fix

In `handle_assignment_type_adjustments`: when the assignment target is a struct member whose type is an integer and the RHS is a pointer, cast the RHS to the member's type. An unannotated int parameter is round-tripped as `(int*)n`, so `(int)ptr` recovers the value — the same reconciliation used for the analogous chained-comparison crash. Restricted to integer members; a float field would need a bit-reinterpretation and is left unchanged.

## Tests

- `attr_store_unannotated` (CORE) — an unannotated param stored into an int attribute (positive, negative, two params, and read back).
- `attr_store_unannotated_fail` (CORE) — a wrong value fails (sound).

Both CPython-sane; class/assign regression clean. The guard fires only for integer members, so list/None/string/object attributes are unaffected. A float attribute stored from an unannotated param remains a pre-existing crash, unchanged by this patch.
