### PR TITLE
[python] Support multiple if-clauses in a comprehension

### DIFF
--- a/regression/python/comprehension_multiple_if/main.py
+++ b/regression/python/comprehension_multiple_if/main.py
@@ -1,0 +1,16 @@
+# A comprehension may have several `if` clauses in one generator
+# ([x for x in A if c1 if c2]), which is equivalent to conjoining them
+# (if c1 and c2). ESBMC previously rejected this with NotImplementedError.
+# List and set comprehensions now conjoin the conditions.
+r = [x for x in range(6) if x > 1 if x < 5]
+assert r == [2, 3, 4]
+
+r3 = [x for x in range(8) if x > 0 if x % 2 == 0 if x < 7]
+assert r3 == [2, 4, 6]
+
+s = {x for x in range(6) if x > 2 if x < 5}
+assert s == {3, 4}
+
+# Single-if and `and` forms are unchanged.
+assert [x for x in range(6) if x % 2 == 0] == [0, 2, 4]
+assert [x for x in range(6) if x > 1 and x < 5] == [2, 3, 4]

--- a/regression/python/comprehension_multiple_if/test.desc
+++ b/regression/python/comprehension_multiple_if/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/comprehension_multiple_if_fail/main.py
+++ b/regression/python/comprehension_multiple_if_fail/main.py
@@ -1,0 +1,3 @@
+# Both conditions must hold: 0 and 1 are excluded by `if x > 1`.
+r = [x for x in range(6) if x > 1 if x < 5]
+assert r == [0, 1, 2, 3, 4]

--- a/regression/python/comprehension_multiple_if_fail/test.desc
+++ b/regression/python/comprehension_multiple_if_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/generator_mixin.py
+++ b/src/python-frontend/preprocessor/generator_mixin.py
@@ -91,9 +91,6 @@ class GeneratorMixin:
             [f(i,j) for i in A for j in B]  =>  for i in A: for j in B: tmp.append(f(i,j))
         """
         for generator in node.generators:
-            if len(getattr(generator, "ifs", [])) > 1:
-                raise NotImplementedError(
-                    "Only a single if-condition is supported in list comprehensions")
             if getattr(generator, "is_async", False):
                 raise NotImplementedError("Async list comprehensions are not supported")
 
@@ -126,8 +123,7 @@ class GeneratorMixin:
         loop_body = [append_expr]
         for generator in reversed(node.generators):
             if generator.ifs:
-                cond = self.visit(generator.ifs[0])
-                self.ensure_all_locations(cond, generator.ifs[0])
+                cond = self._combine_comprehension_ifs(generator.ifs)
                 if_stmt = ast.If(test=cond, body=loop_body, orelse=[])
                 self.ensure_all_locations(if_stmt, generator.ifs[0])
                 ast.fix_missing_locations(if_stmt)
@@ -209,6 +205,10 @@ class GeneratorMixin:
         genexp_node = self._isolate_genexp_targets(genexp_node)
 
         for generator in genexp_node.generators:
+            # Generator-expression lowering (sum/any/all/... over a genexp) has
+            # a separate, currently-incomplete path; keep rejecting multiple
+            # `if` clauses here rather than emit a misleading verdict. List and
+            # set comprehensions (via _lower_listcomp) do support them.
             if len(getattr(generator, "ifs", [])) > 1:
                 raise NotImplementedError(
                     "Only a single if-condition is supported in generator expressions")
@@ -216,6 +216,22 @@ class GeneratorMixin:
                 raise NotImplementedError("Async generator expressions are not supported")
 
         return genexp_node
+
+    def _combine_comprehension_ifs(self, ifs):
+        """Combine a generator's `if` clauses into one condition.
+
+        Python allows several `if` clauses in a single comprehension generator
+        (`[x for x in A if c1 if c2]`), which is equivalent to conjoining them
+        (`if c1 and c2`). Return the visited single condition, or a BoolOp(And)
+        over all of them.
+        """
+        if len(ifs) == 1:
+            cond = self.visit(ifs[0])
+        else:
+            cond = ast.BoolOp(op=ast.And(), values=[self.visit(i) for i in ifs])
+        self.ensure_all_locations(cond, ifs[0])
+        ast.fix_missing_locations(cond)
+        return cond
 
     def _build_reduction_guard(self, tmp_name, source_node, negated):
         guard_expr = self.create_name_node(tmp_name, ast.Load(), source_node)


### PR DESCRIPTION
## What

A Python comprehension may have several `if` clauses in one generator — `[x for x in A if c1 if c2]` — which is exactly equivalent to conjoining them (`if c1 and c2`). ESBMC rejected this with `NotImplementedError("Only a single if-condition is supported...")`. **List and set** comprehensions now conjoin the conditions.

## Fix

In `_lower_listcomp` (which lowers both list and set comprehensions): drop the `len(ifs) > 1` rejection and build the filter condition from all `if` clauses via a new `_combine_comprehension_ifs` helper — a single clause is `visit(ifs[0])`, several become `BoolOp(And, [...])`. This matches Python's left-to-right, short-circuiting semantics.

Generator expressions keep their single-`if` restriction: that lowering path is separately incomplete (a `sum(x for x in ... if c)` gives a wrong result even with one `if`), so removing its rejection would turn a clean "not supported" into a misleading verdict.

## Tests

- `comprehension_multiple_if` (CORE) — 2- and 3-clause list comprehensions and a 2-clause set comprehension; single-`if`/`and`/no-`if` forms unchanged.
- `comprehension_multiple_if_fail` (CORE) — both conditions must hold (a value passing only the first is excluded).

Both CPython-sane; comprehension regression clean. Set comprehensions route through the same `_lower_listcomp` path, so they are fixed by the same change.
