### PR TITLE
[clang-cpp-frontend] Destroy each element of array-typed class members

### DIFF
--- a/regression/esbmc-cpp/cpp/dtor_array_member/main.cpp
+++ b/regression/esbmc-cpp/cpp/dtor_array_member/main.cpp
@@ -1,9 +1,16 @@
 // C++ [class.dtor]/9: an array member of class type must have each element
-// destroyed in reverse index order. The build_destructor_chain in
-// clang_cpp_convert.cpp currently skips array members because
-// QualType::getAsCXXRecordDecl returns null for array types. Once array
-// members are handled, ~C will increment g three times and this test will
-// start passing.
+// destroyed in reverse index order. build_destructor_chain in
+// clang_cpp_convert.cpp now handles array members (see the isolated,
+// passing dtor_array_member_heap test), so ~C destroys a[2], a[1], a[0].
+//
+// This stack-scoped variant still fails for two orthogonal, pre-existing
+// reasons the destructor-chain fix does not touch:
+//   1. B is empty, so assigning the reconstituted `C c = tmp$1` value trips
+//      "assignment to constant_array not handled" in goto-symex (constant
+//      array LHS is not projected like constant_struct/constant_union).
+//   2. A local `C c;` is materialised through a temporary that is then also
+//      destroyed, so the element destructors would run twice (g == 6).
+// Once both are addressed this test should assert g == 3 cleanly.
 #include <cassert>
 
 int g;

--- a/regression/esbmc-cpp/cpp/dtor_array_member_2d/main.cpp
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_2d/main.cpp
@@ -1,0 +1,28 @@
+// Multidimensional array member: build_destructor_chain recurses through
+// each array dimension so every leaf element is destroyed. Here ~C runs
+// ~B on all 2*3 elements of the B a[2][3] member (g == 6).
+#include <cassert>
+
+int g;
+
+struct B
+{
+  int x;
+  ~B()
+  {
+    g++;
+  }
+};
+
+struct C
+{
+  B a[2][3];
+};
+
+int main()
+{
+  C *c = new C();
+  delete c;
+  assert(g == 6);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dtor_array_member_2d/test.desc
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_2d/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/dtor_array_member_heap/main.cpp
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_heap/main.cpp
@@ -1,0 +1,33 @@
+// C++ [class.dtor]/9: an array member of class type must have each element
+// destroyed. build_destructor_chain in clang_cpp_convert.cpp used to skip
+// array members because QualType::getAsCXXRecordDecl returns null for array
+// types, so ~C had an empty body and no ~B ran. Now every element is
+// destroyed, so ~C runs ~B once per element (three times here).
+//
+// A heap object (new/delete) is used so the destructor is invoked exactly
+// once, isolating the per-element member-destruction behaviour.
+#include <cassert>
+
+int g;
+
+struct B
+{
+  int x;
+  ~B()
+  {
+    g++;
+  }
+};
+
+struct C
+{
+  B a[3];
+};
+
+int main()
+{
+  C *c = new C();
+  delete c;
+  assert(g == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dtor_array_member_heap/test.desc
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_heap/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/dtor_array_member_heap_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_heap_fail/main.cpp
@@ -1,0 +1,28 @@
+// Negative counterpart of dtor_array_member_heap: exactly one ~B runs per
+// array element, so g is 3 after destroying a[3]. Asserting g == 4 must fail,
+// pinning the element count (and catching any spurious extra destructor call).
+#include <cassert>
+
+int g;
+
+struct B
+{
+  int x;
+  ~B()
+  {
+    g++;
+  }
+};
+
+struct C
+{
+  B a[3];
+};
+
+int main()
+{
+  C *c = new C();
+  delete c;
+  assert(g == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dtor_array_member_heap_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_heap_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -26,6 +26,7 @@ CC_DIAGNOSTIC_POP()
 #include <util/std_expr.h>
 #include <fmt/core.h>
 #include <clang-c-frontend/typecast.h>
+#include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/exception_specification.h>
 #include <util/string_constant.h>
@@ -1609,7 +1610,15 @@ bool clang_cpp_convertert::build_destructor_chain(
   for (const clang::FieldDecl *field : llvm::reverse(fields))
   {
     clang::QualType qt = field->getType();
-    const clang::CXXRecordDecl *rec = qt->getAsCXXRecordDecl();
+
+    // An array member of class type has each element destroyed; peel the
+    // (possibly nested) array dimensions to reach the element record type,
+    // since QualType::getAsCXXRecordDecl returns null for array types.
+    clang::QualType elem_qt = qt;
+    while (const clang::ArrayType *at = ASTContext->getAsArrayType(elem_qt))
+      elem_qt = at->getElementType();
+
+    const clang::CXXRecordDecl *rec = elem_qt->getAsCXXRecordDecl();
     if (!rec)
       continue;
     const symbolt *sym = lookup_dtor(rec->getDestructor());
@@ -1622,8 +1631,43 @@ bool clang_cpp_convertert::build_destructor_chain(
 
     std::string field_name, field_id;
     get_decl_name(*field, field_name, field_id);
-    emit_dtor_call(
-      *sym, address_of_exprt(member_exprt(deref, field_name, field_type)));
+    exprt member = member_exprt(deref, field_name, field_type);
+
+    if (qt->isArrayType())
+    {
+      // C++ [class.dtor]/9: array elements are destroyed in reverse index
+      // order.  Emit one destructor call per element, recursing into nested
+      // arrays so every leaf element is destroyed.
+      std::function<bool(const exprt &)> destroy_elements =
+        [&](const exprt &arr) -> bool {
+        const array_typet &arr_type = to_array_type(ns.follow(arr.type()));
+        BigInt count;
+        if (to_integer(arr_type.size(), count))
+        {
+          log_error("cannot determine array size for member dtor chain");
+          return true;
+        }
+
+        const typet &elem_type = arr_type.subtype();
+        for (BigInt i = 0; i < count; ++i)
+        {
+          index_exprt element(
+            arr, from_integer(count - 1 - i, index_type()), elem_type);
+          if (ns.follow(elem_type).is_array())
+          {
+            if (destroy_elements(element))
+              return true;
+          }
+          else
+            emit_dtor_call(*sym, address_of_exprt(element));
+        }
+        return false;
+      };
+      if (destroy_elements(member))
+        return true;
+    }
+    else
+      emit_dtor_call(*sym, address_of_exprt(member));
   }
 
   // 2. Direct non-virtual base subobjects, reverse declaration order.


### PR DESCRIPTION
## Problem

`build_destructor_chain` in `clang_cpp_convert.cpp` skipped array data members entirely because `QualType::getAsCXXRecordDecl()` returns null for array types. A class with an array member of class type therefore generated an **empty destructor** — no element destructors ran:

```cpp
struct B { int x; ~B() { g++; } };
struct C { B a[3]; };   // ~C() was empty; ~B never called for a[0..2]
```

## Fix

In the member-subobject pass, peel the (possibly nested) array dimensions to reach the element record type. When the member is an array, emit one destructor call per element in **reverse index order** per C++ [class.dtor]/9, recursing through multidimensional arrays so every leaf element is destroyed. Non-array members are unchanged.

The GOTO for `~C` now correctly emits:

```
~B(&this->a[2])
~B(&this->a[1])
~B(&this->a[0])
```

The unresolvable-array-size path propagates via the function's existing `return true` error path rather than aborting.

## Tests

Two isolated regression tests (heap-allocated so the destructor is invoked exactly once):

- `dtor_array_member_heap` (CORE, `VERIFICATION SUCCESSFUL`, `g == 3`)
- `dtor_array_member_heap_fail` (CORE, `VERIFICATION FAILED`, asserts `g == 4`, pinning the element count)

The pre-existing stack-scoped `dtor_array_member` KNOWNBUG remains, now with an updated comment documenting the two **orthogonal, pre-existing** bugs that still block it (empty-struct `constant_array` LHS not projected in goto-symex; spurious temporary destruction of default-constructed locals). Those are separate follow-ups.

No new regressions in the `esbmc-cpp/cpp` subset (the 3 failing tests there fail identically on master — macOS SDK/env issues).
