### PR TITLE
[python] Remove stale min/max-over-string KNOWNBUG

### DIFF
--- a/regression/python/min_max_string/main.py
+++ b/regression/python/min_max_string/main.py
@@ -10,3 +10,6 @@ assert max("aAzZ") == "z"
 s = "dcba"
 assert min(s) == "a"
 assert max(s) == "d"
+# Repeated characters compare by value, not by first occurrence.
+assert min("banana") == "a"
+assert max("banana") == "n"

--- a/regression/python/min_max_string_knownbug/main.py
+++ b/regression/python/min_max_string_knownbug/main.py
@@ -1,6 +1,0 @@
-# KNOWNBUG: min()/max() over a string should compare its characters
-# (min("banana") == "a", max("banana") == "n"), but ESBMC returns the wrong
-# result. min()/max() over a list or tuple works; a string argument is not
-# routed through the character-iterating comparison in handle_min_max.
-assert min("banana") == "a"
-assert max("banana") == "n"

--- a/regression/python/min_max_string_knownbug/test.desc
+++ b/regression/python/min_max_string_knownbug/test.desc
@@ -1,4 +1,0 @@
-KNOWNBUG
-main.py
---unwind 8
-^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The min()/max()-over-string bug was fixed by #5840, which added the CORE `min_max_string` test. #5856 later added a KNOWNBUG for the same behaviour, but ESBMC now returns `VERIFICATION SUCCESSFUL` for it, so `testing_tool.py` reports "passed but marked KNOWNBUG" and exits 77 — failing the Python regression job on every open PR.

Fold the repeated-character case (`min/max("banana")`) into the existing CORE `min_max_string` test and drop the redundant KNOWNBUG directory.

Fixes the shared CI failure across all currently open PRs.