### PR TITLE
[solver] Make pointer relational comparison a consistent total order

### DIFF
--- a/regression/esbmc/github_5872_ptr_order_fail/main.c
+++ b/regression/esbmc/github_5872_ptr_order_fail/main.c
@@ -1,0 +1,13 @@
+#include <stddef.h>
+
+/* Both directions of <= holding simultaneously for pointers to two distinct
+ * objects would violate antisymmetry; asserting that they do must fail. */
+int main()
+{
+  char a, b;
+  char *p1 = &a, *p2 = &b;
+  int le = (p1 <= p2);
+  int ge = (p2 <= p1);
+  __ESBMC_assert(le && ge, "both directions cannot hold for distinct objects");
+  return 0;
+}

--- a/regression/esbmc/github_5872_ptr_order_fail/test.desc
+++ b/regression/esbmc/github_5872_ptr_order_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_5872_ptr_order_pass/main.c
+++ b/regression/esbmc/github_5872_ptr_order_pass/main.c
@@ -1,0 +1,26 @@
+#include <stddef.h>
+
+/* With the same-object check disabled, relational comparison of pointers to
+ * distinct objects must still behave as a consistent total order: within one
+ * object it is the C-defined offset order, across objects the direction is
+ * arbitrary but the algebraic properties of the operator must hold. */
+int main()
+{
+  char a, b;
+  char *p1 = &a, *p2 = &b;
+  int le = (p1 <= p2);
+  int ge = (p2 <= p1);
+  /* antisymmetry: for distinct objects at most one direction holds */
+  __ESBMC_assert(!(le && ge), "antisymmetry");
+  /* totality: at least one direction must hold */
+  __ESBMC_assert(le || ge, "totality");
+  /* strict order consistency */
+  int lt = (p1 < p2), gt = (p1 > p2);
+  __ESBMC_assert(!(lt && gt), "lt/gt exclusive");
+  __ESBMC_assert(lt || gt, "trichotomy for distinct objects");
+  /* same-object comparisons keep the C-defined offset order */
+  char arr[4];
+  __ESBMC_assert(&arr[1] < &arr[3], "in-object order");
+  __ESBMC_assert(!(&arr[3] <= &arr[1]), "in-object strictness");
+  return 0;
+}

--- a/regression/esbmc/github_5872_ptr_order_pass/main.c
+++ b/regression/esbmc/github_5872_ptr_order_pass/main.c
@@ -18,9 +18,12 @@ int main()
   int lt = (p1 < p2), gt = (p1 > p2);
   __ESBMC_assert(!(lt && gt), "lt/gt exclusive");
   __ESBMC_assert(lt || gt, "trichotomy for distinct objects");
+  /* >= and <= describe the same total order in mirror directions */
+  __ESBMC_assert((p1 >= p2) == (p2 <= p1), ">= mirrors <=");
   /* same-object comparisons keep the C-defined offset order */
   char arr[4];
   __ESBMC_assert(&arr[1] < &arr[3], "in-object order");
+  __ESBMC_assert(&arr[3] >= &arr[1], "in-object order (>=)");
   __ESBMC_assert(!(&arr[3] <= &arr[1]), "in-object strictness");
   return 0;
 }

--- a/regression/esbmc/github_5872_ptr_order_pass/test.desc
+++ b/regression/esbmc/github_5872_ptr_order_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -36,7 +36,10 @@ smt_astt smt_solver_baset::convert_ptr_cmp(
   const expr2tc &templ_expr)
 {
   // Special handling for pointer comparisons (both ops are pointers; otherwise
-  // it's obviously broken).
+  // it's obviously broken). Only the relational operators are lowered here;
+  // pointer (in)equality is handled on the equality path of convert_ast, which
+  // compares the full (object, offset) representation directly, so it never
+  // reaches this function.
   assert(is_pointer_type(side1));
   assert(is_pointer_type(side2));
   assert(is_comp_expr(templ_expr));
@@ -59,30 +62,33 @@ smt_astt smt_solver_baset::convert_ptr_cmp(
   expr2tc s1 = typecast2tc(type, pointer_offset2tc(stype, side1));
   expr2tc s2 = typecast2tc(type, pointer_offset2tc(stype, side2));
   expr2tc same_obj = equality2tc(o1, o2);
+
+  // Lexicographic step: the object ids decide the order; on a tie the offsets
+  // break it. The object comparison is always strict — equal objects fall
+  // through to the offset comparator, which carries the operator's own
+  // strictness (< vs <=). Encoding this once keeps the four operators
+  // consistent.
+  auto lex = [&](const expr2tc &obj_cmp, const expr2tc &off_cmp) {
+    return or2tc(obj_cmp, and2tc(same_obj, off_cmp));
+  };
+
   expr2tc op;
   switch (templ_expr->expr_id)
   {
-  case expr2t::equality_id:
-    op = and2tc(same_obj, equality2tc(s1, s2));
-    break;
-  case expr2t::notequal_id:
-    op = or2tc(notequal2tc(o1, o2), notequal2tc(s1, s2));
-    break;
   case expr2t::lessthan_id:
-    op = or2tc(lessthan2tc(o1, o2), and2tc(same_obj, lessthan2tc(s1, s2)));
+    op = lex(lessthan2tc(o1, o2), lessthan2tc(s1, s2));
     break;
   case expr2t::greaterthan_id:
-    op =
-      or2tc(greaterthan2tc(o1, o2), and2tc(same_obj, greaterthan2tc(s1, s2)));
+    op = lex(greaterthan2tc(o1, o2), greaterthan2tc(s1, s2));
     break;
   case expr2t::lessthanequal_id:
-    op = or2tc(lessthan2tc(o1, o2), and2tc(same_obj, lessthanequal2tc(s1, s2)));
+    op = lex(lessthan2tc(o1, o2), lessthanequal2tc(s1, s2));
     break;
   case expr2t::greaterthanequal_id:
-    op = or2tc(
-      greaterthan2tc(o1, o2), and2tc(same_obj, greaterthanequal2tc(s1, s2)));
+    op = lex(greaterthan2tc(o1, o2), greaterthanequal2tc(s1, s2));
     break;
   default:
+    // equality/notequal never reach here (see above).
     std::unreachable();
   }
   return convert_ast(op);

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -41,39 +41,46 @@ smt_astt smt_solver_baset::convert_ptr_cmp(
   assert(is_pointer_type(side2));
   assert(is_comp_expr(templ_expr));
 
-  /* Compare just the offsets. This is compatible with both C and CHERI-C,
-   * because we already asserted that they point to the same object (unless
-   * --no-pointer-relation-check was specified, in which case the user opted
-   * out of sanity anyway). */
-
-  /* Create a copy of the expression and replace both sides with the respective
-   * typecasted-to-unsigned versions of the offsets. The unsigned comparison is
-   * required because objects could be larger than half the address space, in
-   * which case offsets could flip sign. */
+  /* Compare the (object, offset) pairs lexicographically. Within one object
+   * this is the offset comparison C defines for related pointers, compatible
+   * with both C and CHERI-C. Across objects — reachable only when the
+   * same-object assertion is disabled — it yields an arbitrary but consistent
+   * total order, so the algebraic properties of the operator (e.g.
+   * antisymmetry of <=) still hold; comparing only the offsets would let
+   * p<=q and q<=p be satisfied simultaneously for distinct objects.
+   *
+   * The offsets are typecast to unsigned for the comparison because objects
+   * could be larger than half the address space, in which case offsets could
+   * flip sign. */
   type2tc type = get_uint_type(config.ansi_c.address_width);
   type2tc stype = get_int_type(config.ansi_c.address_width);
+  expr2tc o1 = pointer_object2tc(type, side1);
+  expr2tc o2 = pointer_object2tc(type, side2);
   expr2tc s1 = typecast2tc(type, pointer_offset2tc(stype, side1));
   expr2tc s2 = typecast2tc(type, pointer_offset2tc(stype, side2));
+  expr2tc same_obj = equality2tc(o1, o2);
   expr2tc op;
   switch (templ_expr->expr_id)
   {
   case expr2t::equality_id:
-    op = equality2tc(s1, s2);
+    op = and2tc(same_obj, equality2tc(s1, s2));
     break;
   case expr2t::notequal_id:
-    op = notequal2tc(s1, s2);
+    op = or2tc(notequal2tc(o1, o2), notequal2tc(s1, s2));
     break;
   case expr2t::lessthan_id:
-    op = lessthan2tc(s1, s2);
+    op = or2tc(lessthan2tc(o1, o2), and2tc(same_obj, lessthan2tc(s1, s2)));
     break;
   case expr2t::greaterthan_id:
-    op = greaterthan2tc(s1, s2);
+    op =
+      or2tc(greaterthan2tc(o1, o2), and2tc(same_obj, greaterthan2tc(s1, s2)));
     break;
   case expr2t::lessthanequal_id:
-    op = lessthanequal2tc(s1, s2);
+    op = or2tc(lessthan2tc(o1, o2), and2tc(same_obj, lessthanequal2tc(s1, s2)));
     break;
   case expr2t::greaterthanequal_id:
-    op = greaterthanequal2tc(s1, s2);
+    op = or2tc(
+      greaterthan2tc(o1, o2), and2tc(same_obj, greaterthanequal2tc(s1, s2)));
     break;
   default:
     std::unreachable();


### PR DESCRIPTION
Fixes #5872

## Problem

With `--no-pointer-relation-check`, pointer relational operators (`<`, `<=`, `>`, `>=`) lowered to a comparison of **only the offset** component of ESBMC's `(object, offset)` pointer representation (`convert_ptr_cmp` in `src/solvers/smt/smt_memspace.cpp`). Two distinct, non-array locals both have offset 0 relative to their own object, so `(&a <= &b) && (&b <= &a)` was satisfiable simultaneously — a violation of antisymmetry, which any partial or total order must satisfy (`x<=y ∧ y<=x ⟹ x=y`). This produced a false `VERIFICATION FAILED` on the antisymmetry assertion in the reproducer; CBMC's flat address encoding gives a consistent total order and verifies it.

## Approach

Compare the `(object, offset)` pairs **lexicographically** instead of offset-only:

```
lt:  obj1 <  obj2 || (obj1 == obj2 && off1 <  off2)
lte: obj1 <  obj2 || (obj1 == obj2 && off1 <= off2)
gt:  obj1 >  obj2 || (obj1 == obj2 && off1 >  off2)
gte: obj1 >  obj2 || (obj1 == obj2 && off1 >= off2)
```

- **Same object** (the C-defined case, C11 6.5.8p5): reduces to the offset order used before — behaviour unchanged.
- **Across objects** (reachable only when the same-object assertion is disabled): an arbitrary but consistent total order over object ids, so antisymmetry, totality and transitivity of the operators all hold.

Offsets are still typecast to unsigned for the comparison (objects can exceed half the address space). The default same-object relation check is unaffected — this only changes the fallback semantics the user opted into with `--no-pointer-relation-check`. Pointer equality is handled on a separate path (direct tuple comparison in `smt_solver.cpp`) and is not routed through `convert_ptr_cmp`.

## Testing

New regression tests under `regression/esbmc/github_5872_ptr_order_*`:
- `_pass` (`--no-pointer-relation-check`): antisymmetry, totality, strict-order exclusivity, trichotomy for distinct objects, and unchanged in-object offset order — all `VERIFICATION SUCCESSFUL`.
- `_fail` (`--no-pointer-relation-check`): asserting both directions of `<=` hold for distinct objects must `VERIFICATION FAILED`.

Additional adversarial checks (transitivity across 3 objects, reflexivity/irreflexivity, `<`/`>` and `<=`/`>=` mirroring, one-past-the-end vs start ordering, NULL-pointer comparisons, symbolic/conditional pointers) pass in both bitvector and int-encoding (`--ir`) modes. Full `esbmc`-label regression suite: 4307 tests, no failures attributable to this change (one THOROUGH `--incremental-bmc` C++ test flaked on a parallel-load timeout and passes cleanly in isolation).
