### PR TITLE
[python] Add regression for symbolic str-in-tuple membership (#5892)

### DIFF
--- a/regression/python/github_5892/main.py
+++ b/regression/python/github_5892/main.py
@@ -1,0 +1,8 @@
+# github #5892: `x in (str_literal, ...)` must be per-element equality, not a
+# substring (strstr) search. With a symbolic string constrained to be a member
+# of the tuple, `x == a or x == b` must hold. Older builds lowered this to
+# strstr and unsoundly accepted the empty string.
+side = nondet_str()
+__ESBMC_assume(len(side) <= 8)
+__ESBMC_assume(side in ('a', 'b'))
+assert side == 'a' or side == 'b'

--- a/regression/python/github_5892/test.desc
+++ b/regression/python/github_5892/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5892_fail/main.py
+++ b/regression/python/github_5892_fail/main.py
@@ -1,0 +1,8 @@
+# github #5892 (negative): the tuple membership assume admits every listed
+# literal, so `side` may legitimately be 'b'. Asserting `side == 'a'` alone must
+# therefore FAIL. This also proves the positive test is non-vacuous: the assume
+# is satisfiable with a value other than 'a'.
+side = nondet_str()
+__ESBMC_assume(len(side) <= 8)
+__ESBMC_assume(side in ('a', 'b'))
+assert side == 'a'

--- a/regression/python/github_5892_fail/test.desc
+++ b/regression/python/github_5892_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
The `x in (str_literal, ...)` unsoundness reported in #5892 (membership lowered
to a `strstr` substring search, accepting values equal to none of the literals)
is already fixed on master (v8.4); it no longer reproduces. Existing tests only
covered concrete-argument tuple membership, so this adds the symbolic
`nondet_str()` case to lock the fix in.

`github_5892` verifies SUCCESSFUL; the `_fail` variant asserts only `side == 'a'`
and must FAIL, proving the membership assume is non-vacuous (it admits `'b'`).

Fixes #5892
