### PR TITLE
[irep2] Consume native code_assign2t in --irep2-native-body (W1-loc Phase C)

### DIFF
--- a/docs/spike-v1k-w1loc.md
+++ b/docs/spike-v1k-w1loc.md
@@ -288,3 +288,27 @@ priced as a large cross-frontend program."
 `regression/python` + the model-`.py` corpus + an `esbmc-cpp` smoke stratum. Its
 purpose is to *measure the implementation cost* now that fidelity is settled — it
 is a sizing experiment, not a landable PR, exactly as the V.1k rounds were.
+
+---
+
+## Appendix C — Phase C progress (in flight)
+
+Deliverable (3), grown incrementally (the V-track "one `code_*2t` kind at a
+time" cadence) rather than as a single throw-away branch. The default-off
+`--irep2-native-body` seam and dispatcher `convert_native_rec` land on master
+and grow one supported kind per PR; each PR gates on **byte-identical
+`--goto-functions-only` flag-on vs flag-off** across a cross-frontend corpus
+(the §5 gate 1), with the native path proven reachable (C-Live) by temporary
+instrumentation.
+
+| PR | Kinds made native | Notes |
+|---|---|---|
+| #5866 | `code_block2t` (decl-free), `code_skip2t` | The seam + the decl-free structural leaves; destructor stack never touched. |
+| *(this)* | `code_assign2t` (side-effect-free, non-atomic, non-code-typed source) | The first **value statement**. Guarded by the exact predicates `convert_assign` uses (`has_sideeffect` on both operands, `rhs.type().is_code()`, `is_atomic_symbol`/`has_atomic_read`); anything richer falls back. Design **D3**: the statement's own `code_assign2t::location` is carried; the side-effect-free reduction means the stored instruction is `code2` itself (value-operand locations are dropped by `migrate_expr` regardless), so no round-trip and no `restore_value_locations` stamping is needed. |
+
+*Next:* the remaining single-instruction value statements (`code_expression2t`
+side-effect-free → `OTHER`; `code_return2t` valueless in a non-value function →
+GOTO-to-`return_target`), then the side-effect-bearing statements, which require
+the IREP2-native `remove_sideeffects` / `do_function_call` reimplementation the
+Conclusion prices as the real cost. Decls (destructor-stack unwind) and gotos
+(target tracking) remain the two structural pieces the block walk still needs.

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01/main.c
@@ -1,0 +1,40 @@
+// Exercises the --irep2-native-body IREP2-native assign dispatcher (W1-loc
+// spike Phase C, esbmc/esbmc#4715): the decl-free bodies of set()/set2()/
+// store() are all side-effect-free, non-atomic assignments, so goto_convert
+// consumes each code_assign2t natively (stored directly, no legacy round-trip)
+// while main() (locals + asserts) falls back to goto_convert_rec. The verdict
+// and GOTO must match a run without the flag.
+#include <assert.h>
+
+void set(int *p, int v)
+{
+  *p = v;
+}
+
+void set2(int *a, int x)
+{
+  a[0] = x;
+  a[1] = x + 1;
+}
+
+int g;
+
+void store(int x)
+{
+  g = x;
+}
+
+int main(void)
+{
+  int z = 0;
+  set(&z, 7);
+  assert(z == 7);
+
+  int arr[2];
+  set2(arr, 4);
+  assert(arr[0] == 4 && arr[1] == 5);
+
+  store(9);
+  assert(g == 9);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/main.c
@@ -1,0 +1,40 @@
+// _fail sibling of github_4715_irep2_native_body_assign_01 (W1-loc spike Phase
+// C, esbmc/esbmc#4715). Pins that consuming the decl-free assignment bodies
+// natively does not corrupt the assigned values or suppress bug detection: the
+// value stored by the native code_assign2t in set() must reach main(), so the
+// wrong-value assertion is a reachable violation reported as VERIFICATION
+// FAILED under --irep2-native-body.
+#include <assert.h>
+
+void set(int *p, int v)
+{
+  *p = v;
+}
+
+void set2(int *a, int x)
+{
+  a[0] = x;
+  a[1] = x + 1;
+}
+
+int g;
+
+void store(int x)
+{
+  g = x;
+}
+
+int main(void)
+{
+  int z = 0;
+  set(&z, 7);
+  assert(z == 8);
+
+  int arr[2];
+  set2(arr, 4);
+  assert(arr[0] == 4 && arr[1] == 5);
+
+  store(9);
+  assert(g == 9);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-native-body
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -827,7 +827,7 @@ bool goto_convertt::is_atomic_symbol(const exprt &expr, const namespacet &ns)
 
 /// Returns true if @p expr contains a direct read of any C11 _Atomic variable
 /// (stops early at the first match; does not recurse into address_of).
-static bool has_atomic_read(const exprt &expr, const namespacet &ns)
+bool goto_convertt::has_atomic_read(const exprt &expr, const namespacet &ns)
 {
   if (expr.is_address_of())
     return false;

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -20,6 +20,11 @@ public:
   /// Returns true iff @p expr is a direct reference to a C11 _Atomic variable.
   static bool is_atomic_symbol(const exprt &expr, const namespacet &ns);
 
+  /// Returns true iff @p expr contains a direct read of any C11 _Atomic
+  /// variable (does not recurse into address_of). Shared with the IREP2-native
+  /// body dispatcher so it gates an assignment exactly as convert_assign does.
+  static bool has_atomic_read(const exprt &expr, const namespacet &ns);
+
   goto_convertt(contextt &_context, optionst &_options)
     : context(_context),
       options(_options),

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -148,7 +148,9 @@ static void restore_value_locations(exprt &code, const locationt &inherited)
 // the structural leaves are handled so far; each reads its own code_*2t fields
 // directly (no legacy round-trip) and carries the statement's own location, so
 // the output matches goto_convertt::convert() byte-for-byte on this subset.
-static bool convert_native_rec(const expr2tc &code2, goto_programt &dest)
+bool goto_convert_functionst::convert_native_rec(
+  const expr2tc &code2,
+  goto_programt &dest)
 {
   if (is_code_block2t(code2))
   {
@@ -177,6 +179,45 @@ static bool convert_native_rec(const expr2tc &code2, goto_programt &dest)
     // node equals convert_skip()'s migrate_expr(skip) result — reuse it here
     // instead of round-tripping.
     t->code = code2;
+    return true;
+  }
+
+  if (is_code_assign2t(code2))
+  {
+    const code_assign2t &assign = to_code_assign2t(code2);
+
+    // convert_assign() collapses to a single ASSIGN instruction only when there
+    // is nothing to lower: no side effect in either operand (so goto_sideeffects
+    // never runs, and the value operand locations restore_value_locations would
+    // stamp are dropped again by the final migrate_expr anyway), the source is
+    // not a code-typed statement, and neither side touches a C11 _Atomic object
+    // (which would take the convert_assign_atomic path). Decide with the exact
+    // predicates convert_assign uses, on a throwaway legacy view of the two
+    // operands; any richer shape falls back so flag-on stays byte-identical to
+    // flag-off.
+    //
+    // A top-level ternary is the one non-side-effect shape remove_sideeffects
+    // still enters (goto_sideeffects.cpp:180 early-returns only on
+    // `!has_sideeffect(e) && e.id() != "if"`): under --validate-violation-witness
+    // it lowers `c ? a : b` to a DECL/IF/GOTO branch, which a single ASSIGN would
+    // not reproduce. Mirror that exact entry condition so we fall back on it.
+    exprt lhs = migrate_expr_back(assign.target);
+    exprt rhs = migrate_expr_back(assign.source);
+    if (
+      has_sideeffect(lhs) || has_sideeffect(rhs) || lhs.id() == "if" ||
+      rhs.id() == "if" || rhs.type().is_code() || is_atomic_symbol(lhs, ns) ||
+      has_atomic_read(rhs, ns))
+      return false;
+
+    // For side-effect-free operands the instruction convert_assign emits is
+    // migrate_expr(code_assignt(lhs, rhs)) located at the statement — which
+    // round-trips back to `code2` itself (migrate_expr drops the operand
+    // locations, so none of restore_value_locations' stamping survives in the
+    // stored code). Emit it directly, no round-trip, carrying the statement's
+    // own location, exactly as copy(new_assign, ASSIGN) would.
+    goto_programt::targett t = dest.add_instruction(ASSIGN);
+    t->code = code2;
+    t->location = assign.location;
     return true;
   }
 

--- a/src/goto-programs/goto_convert_functions.h
+++ b/src/goto-programs/goto_convert_functions.h
@@ -67,6 +67,14 @@ protected:
   // flag-off until the native path is complete. Gated on --irep2-native-body.
   bool try_convert_body_native(const expr2tc &body2, goto_programt &dest);
 
+  // Consume one IREP2 statement `code2` natively, appending to `dest`. Returns
+  // false the instant an unsupported kind (or a shape the native emission would
+  // not reproduce byte-identically) appears, so the caller discards the partial
+  // walk and falls back to `goto_convert_rec`. A member so it can reuse the
+  // inherited goto_convertt machinery (has_sideeffect / is_atomic_symbol /
+  // has_atomic_read / ns) to gate the value-statement kinds.
+  bool convert_native_rec(const expr2tc &code2, goto_programt &dest);
+
   void wallop_type_impl(
     irep_idt name,
     typename_mapt &typenames,


### PR DESCRIPTION
## What

W1-loc spike Phase C (esbmc/esbmc#4715): grow the IREP2-native `goto_convert`
dispatcher — after #5866 shipped the seam plus `code_block2t`/`code_skip2t` — to
its **first value statement**, `code_assign2t`.

A side-effect-free, non-atomic, non-code-typed assignment is emitted as a single
`ASSIGN` by storing the IREP2 node directly: no whole-body legacy round-trip and
no `restore_value_locations` stamping (design **D3** — the statement's own
`code_assign2t::location` is carried, and `migrate_expr` drops value-operand
locations anyway, so the stored instruction is `code2` itself).

The handler falls back — byte-identically — on every richer shape, using the
exact predicates `convert_assign` uses:
- side effects on either operand (function-call / `cpp_new` / `++`/`--`/…),
- a **top-level ternary operand** (which `remove_sideeffects` still lowers to a
  branch under `--validate-violation-witness`, `goto_sideeffects.cpp:180`),
- a code-typed source,
- C11 `_Atomic` access on either side.

`convert_native_rec` becomes a member of `goto_convert_functionst` and
`has_atomic_read` a `static` member of `goto_convertt`, so the guard reuses the
inherited machinery. The flag is **default-off**, so flag-off behaviour is
unchanged.

## Validation

- **Byte-identical** `--goto-functions-only` flag-on vs flag-off across
  `regression/{esbmc,cbmc,floats,esbmc-cpp}` plus `_Atomic` and ternary probes —
  0 divergences, **also under `--validate-violation-witness`**.
- **C-Live**: temporary instrumentation confirmed the native assign fires for
  decl-free pointer/global stores and never fires flag-off; the `_Atomic` assign
  correctly falls back.
- Regression tests `github_4715_irep2_native_body_assign_01{,_fail}` (native
  assign bodies + `main` falling back; SUCCESSFUL / FAILED).
- `code-reviewer` caught the ternary guard gap (now fixed); migrate / irep2 /
  goto_convert unit + regression suites green; clang-format (Clang 11) clean.

Refs #4715.
