### PR TITLE
[irep2] Consume native code_expression2t in --irep2-native-body (W1-loc Phase C)

### DIFF
--- a/docs/spike-v1k-w1loc.md
+++ b/docs/spike-v1k-w1loc.md
@@ -304,11 +304,14 @@ instrumentation.
 | PR | Kinds made native | Notes |
 |---|---|---|
 | #5866 | `code_block2t` (decl-free), `code_skip2t` | The seam + the decl-free structural leaves; destructor stack never touched. |
-| *(this)* | `code_assign2t` (side-effect-free, non-atomic, non-code-typed source) | The first **value statement**. Guarded by the exact predicates `convert_assign` uses (`has_sideeffect` on both operands, `rhs.type().is_code()`, `is_atomic_symbol`/`has_atomic_read`); anything richer falls back. Design **D3**: the statement's own `code_assign2t::location` is carried; the side-effect-free reduction means the stored instruction is `code2` itself (value-operand locations are dropped by `migrate_expr` regardless), so no round-trip and no `restore_value_locations` stamping is needed. |
+| #5896 | `code_assign2t` (side-effect-free, non-atomic, non-code-typed source) | The first **value statement**. Guarded by the exact predicates `convert_assign` uses (`has_sideeffect` on both operands, `rhs.type().is_code()`, `is_atomic_symbol`/`has_atomic_read`); anything richer falls back. Design **D3**: the statement's own `code_assign2t::location` is carried; the side-effect-free reduction means the stored instruction is `code2` itself (value-operand locations are dropped by `migrate_expr` regardless), so no round-trip and no `restore_value_locations` stamping is needed. |
+| *(this)* | `code_expression2t` (side-effect-free, non-code, non-ternary operand) | The second value statement → one `OTHER`. Guard mirrors `convert_expression`'s non-`OTHER` branches: `has_sideeffect(op)` (lowered), `op.is_code()` (re-dispatched via `convert()`), `op.id()=="if"` (top-level ternary peeled unconditionally into `convert_ifthenelse` at `goto_convert.cpp:507`). Same D3 store-`code2` emission as assign, but located at the statement's own `code_expression2t::location` (which `convert_expression` reads off the operand post-`restore_value_locations`); falls back when that location is nil/empty-file so an inherited block location is never lost. |
 
-*Next:* the remaining single-instruction value statements (`code_expression2t`
-side-effect-free → `OTHER`; `code_return2t` valueless in a non-value function →
-GOTO-to-`return_target`), then the side-effect-bearing statements, which require
+*Next:* `code_return2t` is the obvious sibling but a **trap** — a trailing
+`return;` in a void function is elided by the frontend (empty body, no GOTO), and
+non-tail valueless returns sit under an `if` (unsupported) so the whole body
+falls back; it is hard to exercise in a decl-free top-level block. The remaining
+gains are the side-effect-bearing statements (calls, `++`/`--`), which require
 the IREP2-native `remove_sideeffects` / `do_function_call` reimplementation the
-Conclusion prices as the real cost. Decls (destructor-stack unwind) and gotos
-(target tracking) remain the two structural pieces the block walk still needs.
+Conclusion prices as the real cost, and the two structural pieces the block walk
+still lacks: decls (destructor-stack unwind) and gotos/labels (target tracking).

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01/main.c
@@ -1,0 +1,32 @@
+// Exercises the --irep2-native-body IREP2-native code_expression2t dispatcher
+// (W1-loc spike Phase C, esbmc/esbmc#4715): the decl-free bodies of touch() and
+// discard() contain side-effect-free expression statements (`x;`, `(void)a;`,
+// `b;`) that goto_convert consumes natively as OTHER instructions (code2 stored
+// directly, no legacy round-trip), alongside the native ASSIGN in touch();
+// main() (locals + asserts) falls back to goto_convert_rec. The no-op OTHER must
+// not corrupt the surrounding assignment, and verdict/GOTO must match a run
+// without the flag.
+#include <assert.h>
+
+int g;
+
+void touch(int x)
+{
+  x;
+  g = x + 1;
+}
+
+void discard(int a, int b)
+{
+  (void)a;
+  b;
+}
+
+int main(void)
+{
+  touch(5);
+  assert(g == 6);
+
+  discard(1, 2);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/main.c
@@ -1,0 +1,30 @@
+// _fail sibling of github_4715_irep2_native_body_expr_01 (W1-loc spike Phase C,
+// esbmc/esbmc#4715). Pins that consuming the side-effect-free expression
+// statements natively as OTHER instructions neither corrupts the following
+// assignment nor suppresses bug detection: g is still x+1 after touch(), so the
+// wrong-value assertion is a reachable violation reported as VERIFICATION FAILED
+// under --irep2-native-body.
+#include <assert.h>
+
+int g;
+
+void touch(int x)
+{
+  x;
+  g = x + 1;
+}
+
+void discard(int a, int b)
+{
+  (void)a;
+  b;
+}
+
+int main(void)
+{
+  touch(5);
+  assert(g == 7);
+
+  discard(1, 2);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--irep2-native-body
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -143,11 +143,14 @@ static void restore_value_locations(exprt &code, const locationt &inherited)
 
 // W1-loc spike Phase C (esbmc/esbmc#4715): consume one IREP2 statement `code2`
 // natively (design D3), appending to `dest`, and recurse into nested blocks.
-// Returns false the instant an unsupported kind appears — the caller discards
-// the partial `dest`, so a failed walk never corrupts the fallback body. Only
-// the structural leaves are handled so far; each reads its own code_*2t fields
-// directly (no legacy round-trip) and carries the statement's own location, so
-// the output matches goto_convertt::convert() byte-for-byte on this subset.
+// Returns false the instant an unsupported kind (or a shape whose native
+// emission would not be byte-identical) appears — the caller discards the
+// partial `dest`, so a failed walk never corrupts the fallback body. So far:
+// the decl-free structural leaves (block/skip) and the single-instruction value
+// statements (assign/expression) that reduce to one ASSIGN/OTHER with nothing
+// to lower; each reads its own code_*2t fields directly (no legacy round-trip)
+// and carries the statement's own location, matching goto_convertt::convert()
+// byte-for-byte on this subset.
 bool goto_convert_functionst::convert_native_rec(
   const expr2tc &code2,
   goto_programt &dest)
@@ -218,6 +221,38 @@ bool goto_convert_functionst::convert_native_rec(
     goto_programt::targett t = dest.add_instruction(ASSIGN);
     t->code = code2;
     t->location = assign.location;
+    return true;
+  }
+
+  if (is_code_expression2t(code2))
+  {
+    const code_expression2t &expr_stmt = to_code_expression2t(code2);
+
+    // convert_expression() emits a single OTHER only in its plain else-branch
+    // (goto_convert.cpp:519-530): a side-effect operand is lowered by
+    // remove_sideeffects, a code-typed operand is re-dispatched through convert()
+    // (goto_convert.cpp:501), and a top-level ternary is peeled off
+    // unconditionally into convert_ifthenelse (goto_convert.cpp:507), before
+    // remove_sideeffects runs. Fall back on all of those, deciding with the exact
+    // predicates convert_expression uses on a throwaway legacy view of the
+    // operand.
+    exprt op = migrate_expr_back(expr_stmt.operand);
+    if (op.is_nil() || has_sideeffect(op) || op.is_code() || op.id() == "if")
+      return false;
+
+    // convert_expression locates the OTHER at the operand location, which
+    // restore_value_locations sets to the enclosing statement location. When the
+    // statement carries its own located #location that already IS that location,
+    // so emit code2 directly (migrate_expr drops the operand location, so the
+    // stored code round-trips to code2) at the statement location. Fall back on a
+    // location-less statement, whose operand the round-trip would instead stamp
+    // with an inherited block location.
+    if (expr_stmt.location.is_nil() || expr_stmt.location.get_file().empty())
+      return false;
+
+    goto_programt::targett t = dest.add_instruction(OTHER);
+    t->code = code2;
+    t->location = expr_stmt.location;
     return true;
   }
 


### PR DESCRIPTION
## What

W1-loc spike Phase C (esbmc/esbmc#4715): grow the IREP2-native `goto_convert`
dispatcher `convert_native_rec` to its **second value statement**,
`code_expression2t`, after the `code_assign2t` handler (#5896, on which this
stacks).

A `code_expression2t` whose operand is side-effect-free, non-code, and not a
top-level ternary is emitted as a single `OTHER` by storing the IREP2 node
directly — no whole-body legacy round-trip, located at the statement's own
`code_expression2t::location` (design **D3**; `migrate_expr` drops the operand
location regardless, so the stored code is `code2` itself).

The handler falls back — byte-identically — on every richer shape, via the exact
predicates `convert_expression` uses:
- a side-effect operand (lowered by `remove_sideeffects`),
- a code-typed operand (re-dispatched through `convert()`, `goto_convert.cpp:501`),
- a **top-level ternary** (peeled unconditionally into `convert_ifthenelse` at
  `goto_convert.cpp:507`, before `remove_sideeffects`).

It also falls back on a location-less statement, whose operand the round-trip
would instead stamp with an inherited block location (the one case where
`t->location = expr_stmt.location` would diverge). The flag is **default-off**,
so flag-off behaviour is unchanged.

## Validation

- **Byte-identical** `--goto-functions-only` flag-on vs flag-off across
  `regression/{esbmc,cbmc}` plus expression-statement probes (`(void)x;`, comma,
  `*p;`, bare name) — 0 divergences, **also under `--validate-violation-witness`**.
- **C-Live**: temporary instrumentation confirmed the native `OTHER` fires for
  those probes flag-on and never flag-off.
- Regression tests `github_4715_irep2_native_body_expr_01{,_fail}` — `touch()`
  (native `OTHER x;` + native `ASSIGN g=x+1;`) and `discard()` (`(void)a;`, `b;`)
  go native while `main` falls back; SUCCESSFUL / FAILED verdicts pinned.
- `code-reviewer` verified all three byte-identity claims (location guard, guard
  completeness, `t->code == migrate_expr(tmp)`) and its one comment-accuracy
  finding is applied; migrate / irep2 / goto_convert unit + regression suites
  green; clang-format (Clang 11) clean.

Stacked on #5896 — retarget to `master` once that merges.

Refs #4715.
