### PR TITLE
[python] Guard undefined-module call to avoid SIGABRT in --function

### DIFF
--- a/regression/python/github_5898/main.py
+++ b/regression/python/github_5898/main.py
@@ -1,0 +1,6 @@
+import random
+
+
+def pick_one() -> int:
+    result = random.choice([1, 2, 3])
+    return result

--- a/regression/python/github_5898/test.desc
+++ b/regression/python/github_5898/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--function pick_one --no-bounds-check
+^VERIFICATION FAILED$
+Unsupported function 'choice' is reached

--- a/regression/python/github_5898_itertools/main.py
+++ b/regression/python/github_5898_itertools/main.py
@@ -1,0 +1,6 @@
+import itertools
+
+
+def first_n(iterable, n: int):
+    result = list(itertools.islice(iterable, n))
+    return result

--- a/regression/python/github_5898_itertools/test.desc
+++ b/regression/python/github_5898_itertools/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--function first_n --no-bounds-check
+^ERROR: Could not resolve type of receiver in member call

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -751,9 +751,15 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       !type_utils::is_python_model_func(func_name) &&
       !is_class(func_name, *ast_json))
     {
+      // A call into an unrecognised module (e.g. itertools.islice) has no
+      // definition in the AST, so find_function returns an empty node. Skip
+      // loading here and let the call fall through to the "Undefined function
+      // - replacing with assert(false)" fallback instead of feeding an empty
+      // node to get_function_definition, which would dereference missing
+      // fields and abort (issue #5898).
       const auto &func_node = find_function((*ast_json)["body"], func_name);
-      assert(!func_node.empty());
-      get_function_definition(func_node);
+      if (!func_node.empty())
+        get_function_definition(func_node);
     }
   }
 


### PR DESCRIPTION
Under `--function` mode the frontend preloads every callee's definition, but a call into an unrecognised module (e.g. `itertools.islice`, `random.choice`) has no AST node, so `find_function` returns empty. The old code asserted non-empty and fed the empty node to `get_function_definition`, which in release builds dereferenced missing JSON fields and aborted with an uncaught `nlohmann::json` type_error (SIGABRT).

Guard the load so the call instead falls through to the existing "Undefined function - replacing with assert(false)" handling. Adds two regression tests (`github_5898`, `github_5898_itertools`) that abort pre-fix and pass post-fix.

Fixes #5898
