### PR TITLE
[ci] Canonical per-platform release assets + macOS download

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -14,6 +14,11 @@ on:
         description: "Whether to run tests (regression) for this build"
         required: true
         type: boolean
+      canon-names:
+        description: "Upload the build as a canonical esbmc-<platform>.zip release asset"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -24,10 +29,34 @@ jobs:
 
     - name: Build ESBMC
       run: ./scripts/build.sh ${{ inputs.build-flags }}
-    - uses: actions/upload-artifact@v7
+
+    # Default: upload the raw ./release folder under the flag-qualified name that
+    # downstream jobs (benchexec, sv-comp, witness-validation) download verbatim.
+    - name: Upload build artifact
+      if: ${{ !inputs.canon-names }}
+      uses: actions/upload-artifact@v7
       with:
         name: release-${{ inputs.operating-system }}-${{ inputs.build-flags }}
         path: ./release
+
+    # Release pipeline (canon-names): emit a canonical esbmc-<platform>.zip so the
+    # published asset resolves to releases/latest/download/esbmc-<platform>.zip.
+    - name: Package canonical release asset
+      if: ${{ inputs.canon-names }}
+      run: |
+        case "${{ inputs.operating-system }}" in
+          ubuntu*) platform=linux ;;
+          macos*)  platform=macos ;;
+          *)       platform="${{ inputs.operating-system }}" ;;
+        esac
+        echo "PLATFORM=$platform" >> "$GITHUB_ENV"
+        zip -r "esbmc-$platform.zip" ./release
+    - name: Upload canonical release asset
+      if: ${{ inputs.canon-names }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: esbmc-${{ env.PLATFORM }}
+        path: esbmc-${{ env.PLATFORM }}.zip
     
     - name: Check Python regression tests
       if: ${{ inputs.testing == true }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,6 +14,11 @@ on:
         description: "Whether to run tests (regression) for this build"
         required: true
         type: boolean
+      canon-names:
+        description: "Upload the build as a canonical esbmc-windows.zip release asset"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -39,10 +44,25 @@ jobs:
     - uses: actions/checkout@v6
     - name: Configure ESBMC
       run: ./scripts/build.ps1
-    - uses: actions/upload-artifact@v7
+    # Default: upload the raw build folder under the fixed name release.yml downloads.
+    - name: Upload build artifact
+      if: ${{ !inputs.canon-names }}
+      uses: actions/upload-artifact@v7
       with:
         name: release-windows-latest
         path: C:/deps/esbmc
+
+    # Release pipeline (canon-names): emit the canonical esbmc-windows.zip asset.
+    - name: Package canonical release asset
+      if: ${{ inputs.canon-names }}
+      run: Compress-Archive -Path C:/deps/esbmc -DestinationPath esbmc-windows.zip
+      shell: pwsh
+    - name: Upload canonical release asset
+      if: ${{ inputs.canon-names }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: esbmc-windows
+        path: esbmc-windows.zip
     - name: Run Tests
       if: ${{ inputs.testing == true }}
       run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,10 +52,13 @@ jobs:
         name: release-windows-latest
         path: C:/deps/esbmc
 
-    # Release pipeline (canon-names): emit the canonical esbmc-windows.zip asset.
+    # Release pipeline (canon-names): emit the canonical esbmc-windows.zip asset
+    # with a top-level release/ folder, matching the Linux and macOS archives.
     - name: Package canonical release asset
       if: ${{ inputs.canon-names }}
-      run: Compress-Archive -Path C:/deps/esbmc -DestinationPath esbmc-windows.zip
+      run: |
+        Rename-Item -Path C:/deps/esbmc -NewName release
+        Compress-Archive -Path C:/deps/release -DestinationPath esbmc-windows.zip
       shell: pwsh
     - name: Upload canonical release asset
       if: ${{ inputs.canon-names }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ on:
             description: "Whether to run tests (regression) for this build"
             required: true
             type: boolean
+        canon-names:
+            description: "Upload the build as a canonical esbmc-<platform>.zip release asset"
+            required: false
+            default: false
+            type: boolean
     workflow_call:
       inputs:
         operating-system:
@@ -30,6 +35,11 @@ on:
             description: "Whether to run tests (regression) for this build"
             required: true
             type: boolean
+        canon-names:
+            description: "Upload the build as a canonical esbmc-<platform>.zip release asset"
+            required: false
+            default: false
+            type: boolean
 
 jobs:
   build-unix:
@@ -39,6 +49,7 @@ jobs:
       operating-system: ${{ inputs.operating-system }}
       build-flags: ${{ inputs.build-flags }}
       testing: ${{ inputs.testing }}
+      canon-names: ${{ inputs.canon-names }}
 
   build-windows:
     if: ${{ startsWith(inputs.operating-system, 'windows-') }}
@@ -47,3 +58,4 @@ jobs:
       operating-system: ${{ inputs.operating-system }}
       build-flags: ${{ inputs.build-flags }}
       testing: ${{ inputs.testing }}
+      canon-names: ${{ inputs.canon-names }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       operating-system: ${{ matrix.os }}
       build-flags: ${{ matrix.flags }}
       testing: false
+      canon-names: true
 
   build-linux-arm64:
     name: Homebrew compatibility check (Linux ARM64, LLVM 22)
@@ -51,27 +52,23 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build, build-info]
     steps:
+      # The build jobs run with canon-names: true, so each platform already
+      # uploaded its canonical esbmc-<platform>.zip; just fetch and attach them.
       - name: Download Linux Build
         uses: actions/download-artifact@v8
         with:
-          name: 'release-ubuntu-24.04--b RelWithDebInfo -e OFF'
-          path: ./linux-release
-      - name: Create Linux Release file
-        run: zip -r esbmc-linux.zip ./linux-release
+          name: esbmc-linux
+          path: .
       - name: Download Windows Build
         uses: actions/download-artifact@v8
         with:
-          name: release-windows-latest
-          path: ./windows-release
-      - name: Create Windows Release file
-        run: zip -r esbmc-windows.zip ./windows-release
+          name: esbmc-windows
+          path: .
       - name: Download macOS Build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: 'release-macos-latest--b RelWithDebInfo -e OFF -c 21'
-          path: ./macos-release
-      - name: Create macOS Release file
-        run: zip -r esbmc-macos.zip ./macos-release
+          name: esbmc-macos
+          path: .
       - name: Download Info Manual
         uses: actions/download-artifact@v8
         with:

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -41,10 +41,8 @@ solver.
 {{< card link="docs/development/building" title="Build Guide" icon="cog" >}}
 {{< /cards >}} {{< /tab >}}
 
-{{< tab name="macOS" >}} {{< callout type="warning" icon="warning" >}} macOS
-does not have any downloadable builds at the moment. You can however build from
-scratch using our [build](docs/development/building) guide. {{< /callout >}}
-{{< cards >}}
+{{< tab name="macOS" >}} {{< cards >}}
+{{< card link="https://github.com/esbmc/esbmc/releases/latest/download/esbmc-macos.zip" title="Download" icon="download" >}}
 {{< card link="docs/development/building" title="Build Guide" icon="cog" >}}
 {{< /cards >}} {{< /tab >}}
 

--- a/website/content/docs/development/releases.md
+++ b/website/content/docs/development/releases.md
@@ -85,23 +85,29 @@ Push the tag to origin:
 git push --tags
 ```
 
-### Creating the Release Artifacts
+> [!IMPORTANT]
+>
+> Pushing a `v*` tag automatically triggers the
+> [Release](https://github.com/esbmc/esbmc/actions/workflows/release.yml)
+> workflow ("Upload Release Asset"). It builds every platform and creates a
+> **draft** GitHub release named after the tag (e.g. `ESBMC v8.1`), with the
+> canonical `esbmc-linux.zip`, `esbmc-windows.zip`, `esbmc-macos.zip` and
+> `esbmc.info` assets already attached. You do **not** need to run the workflow
+> manually, create the release by hand, or upload any artifacts yourself.
 
-You need to get the build artifacts that will be uploaded. Run a new
-[Release](https://github.com/esbmc/esbmc/actions/workflows/release.yml) job on
-the `master` branch. Download the artifacts and prepare to upload them in the
-next step.
+### Publish the Draft Release
 
-### Creating the Release on GitHub
+Wait for the Release workflow to finish, then open the repository’s
+[Releases](https://github.com/esbmc/esbmc/releases) page and find the draft
+release the workflow created for your tag.
 
-After pushing the tag, GitHub will allow you to create the official release
-associated with that tag through the repository’s Releases page.
-
-1. Select the tag you created and title the release according to your version
-   "Release 8.1" (note the missing v, for consistency with past releases).
-2. Write the release description, which should just be a markdown version of the
-   content written in `/scripts/release-notes.txt` from earlier.
-3. You will need to upload the release artifacts created in the last step.
+1. Confirm the attached assets are present: `esbmc-linux.zip`,
+   `esbmc-windows.zip`, `esbmc-macos.zip` and `esbmc.info`.
+2. Adjust the title if needed — the draft is created as `ESBMC v8.1`; past
+   releases use "Release 8.1" (note the missing v).
+3. Replace the placeholder description with a markdown version of the content
+   written in `/scripts/release-notes.txt` from earlier.
+4. Publish the release.
 
 > [!TIP]
 >

--- a/website/content/docs/setup.md
+++ b/website/content/docs/setup.md
@@ -3,7 +3,7 @@ title: Setup
 weight: 1
 ---
 
-To install ESBMC, download the latest binary for Linux or Windows from
+To install ESBMC, download the latest binary for Linux, Windows or macOS from
 [GitHub](https://github.com/esbmc/esbmc/releases), then save and unzip it on your
 disk.
 


### PR DESCRIPTION
The release pipeline now emits canonical `esbmc-linux.zip`, `esbmc-windows.zip`
and `esbmc-macos.zip` straight from the build job, and the site/docs point at the
macOS build.

- Off-by-default `canon-names` input on the reusable build workflows: when set
  (only by `release.yml`) each platform zips its output into `esbmc-<platform>.zip`
  under a common `release/` folder. The default path keeps the
  `release-<os>-<flags>` artifact names benchexec, sv-comp-stats-refresh,
  witness-validation and PR builds rely on.
- `create-release` just downloads and attaches the pre-zipped assets.
- Homepage macOS Download card + macOS in `setup.md`; drop the build-from-source banner.
- Release guide: pushing a `v*` tag auto-creates a draft release, so publish the
  draft instead of creating releases by hand.
