### PR TITLE
[python] Raise TypeError/AttributeError as catchable exceptions

### DIFF
--- a/regression/mopsa/attribute_error/test.desc
+++ b/regression/mopsa/attribute_error/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR\: Attribute \"a\" not found$
+^VERIFICATION FAILED$
+uncaught exception: AttributeError

--- a/regression/numpy/github_4666_scalar_shape_after_index/test.desc
+++ b/regression/numpy/github_4666_scalar_shape_after_index/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: AttributeError: 'x' has no attribute 'shape'
+^VERIFICATION FAILED$
+uncaught exception: AttributeError

--- a/regression/python/comprehension_as_iterable/test.desc
+++ b/regression/python/comprehension_as_iterable/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check
+--unwind 6 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3001_fail/test.desc
+++ b/regression/python/github_3001_fail/test.desc
@@ -1,4 +1,6 @@
 CORE
 main.py
 --unwind 1
-^  AttributeError: object has no attribute 'bar' \(possible types: 'Foo', 'Bar'\)$
+^VERIFICATION FAILED$
+AttributeError: object has no attribute 'bar' \(possible types: 'Foo', 'Bar'\)
+uncaught exception: AttributeError

--- a/regression/python/github_5904_attributeerror_access_fail/main.py
+++ b/regression/python/github_5904_attributeerror_access_fail/main.py
@@ -1,0 +1,8 @@
+# Regression for issue #5904: a missing attribute read must raise a catchable
+# AttributeError (previously aborted frontend conversion).
+def main():
+    x = 5
+    y = x.foo
+
+
+main()

--- a/regression/python/github_5904_attributeerror_access_fail/test.desc
+++ b/regression/python/github_5904_attributeerror_access_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+uncaught exception

--- a/regression/python/github_5904_attributeerror_call_fail/main.py
+++ b/regression/python/github_5904_attributeerror_call_fail/main.py
@@ -1,0 +1,8 @@
+# Regression for issue #5904: a missing method on a builtin value must raise a
+# catchable AttributeError, not a generic "Unsupported function" assertion.
+def main():
+    x = 5
+    x.foo()
+
+
+main()

--- a/regression/python/github_5904_attributeerror_call_fail/test.desc
+++ b/regression/python/github_5904_attributeerror_call_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+uncaught exception

--- a/regression/python/github_5904_attributeerror_caught/main.py
+++ b/regression/python/github_5904_attributeerror_caught/main.py
@@ -1,0 +1,11 @@
+# Regression for issue #5904: an AttributeError from a missing method must be
+# catchable by a matching `except AttributeError` handler.
+def main():
+    x = 5
+    try:
+        x.foo()
+    except AttributeError:
+        pass
+
+
+main()

--- a/regression/python/github_5904_attributeerror_caught/test.desc
+++ b/regression/python/github_5904_attributeerror_caught/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5904_typeerror_caught/main.py
+++ b/regression/python/github_5904_typeerror_caught/main.py
@@ -1,0 +1,10 @@
+# Regression for issue #5904: a TypeError from `int + str` must be catchable by
+# a matching `except TypeError` handler.
+def main():
+    try:
+        y = 1 + "s"
+    except TypeError:
+        pass
+
+
+main()

--- a/regression/python/github_5904_typeerror_caught/test.desc
+++ b/regression/python/github_5904_typeerror_caught/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5904_typeerror_fail/main.py
+++ b/regression/python/github_5904_typeerror_fail/main.py
@@ -1,0 +1,7 @@
+# Regression for issue #5904: `int + str` must raise a catchable TypeError that
+# escapes main() (previously the frontend crashed with a JSON type_error).
+def main():
+    y = 1 + "s"
+
+
+main()

--- a/regression/python/github_5904_typeerror_fail/test.desc
+++ b/regression/python/github_5904_typeerror_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+uncaught exception

--- a/regression/python/github_5904_unannotated_concat/main.py
+++ b/regression/python/github_5904_unannotated_concat/main.py
@@ -1,0 +1,14 @@
+# Regression for issue #5904: the TypeError guard for `str + <non-str>` must NOT
+# misfire on an unannotated operand whose real type is str. `x` here is
+# unannotated (any_type), so its category is unknown; concatenation must still
+# succeed rather than raise a spurious TypeError.
+def f(x) -> str:
+    return x + "!"
+
+
+def main():
+    r = f("hey")
+    assert len(r) == 4
+
+
+main()

--- a/regression/python/github_5904_unannotated_concat/test.desc
+++ b/regression/python/github_5904_unannotated_concat/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5904_userexc_method_fail/main.py
+++ b/regression/python/github_5904_userexc_method_fail/main.py
@@ -1,0 +1,13 @@
+# Regression for issue #5904: a missing method on a user-class instance must
+# raise a catchable AttributeError.
+class Foo:
+    def bar(self) -> int:
+        return 1
+
+
+def main():
+    f = Foo()
+    f.baz()
+
+
+main()

--- a/regression/python/github_5904_userexc_method_fail/test.desc
+++ b/regression/python/github_5904_userexc_method_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+uncaught exception

--- a/regression/python/numeric_tower_float_no_numerator_fail/test.desc
+++ b/regression/python/numeric_tower_float_no_numerator_fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: AttributeError: 'f' has no attribute 'numerator'
+^VERIFICATION FAILED$
+uncaught exception: AttributeError

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -3,6 +3,7 @@
 #include <python-frontend/json_utils.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_dict_handler.h>
+#include <python-frontend/python_exception_handler.h>
 #include <python-frontend/python_expr_builder.h>
 #include <python-frontend/python_list.h>
 #include <python-frontend/python_math.h>
@@ -1796,6 +1797,28 @@ exprt python_converter::handle_array_operations(
       if (!loc.is_nil())
         msg << " at " << loc.get_file() << ":" << loc.get_line();
       throw std::runtime_error(msg.str());
+    }
+    // `str + <non-str>` (e.g. `1 + "s"`) is a Python TypeError. The
+    // concatenation promotion below is only valid when the non-array operand is
+    // itself a character (a 1-char string from indexing/chr(), which
+    // get_python_type_category tags "string"); a genuine number is a type
+    // error. Raise a catchable TypeError so it can escape main() or be caught,
+    // instead of falling into string concatenation, which crashes reading the
+    // numeric operand's AST value as a string (issue #5904).
+    if (lhs_char != rhs_char)
+    {
+      const exprt &other = lhs_char ? rhs : lhs;
+      const std::string cat = get_python_type_category(other.type());
+      // Only raise for a *definitively* non-string operand (numeric, list,
+      // bytes). An empty category is an unannotated any_type (void*) whose real
+      // type is unknown here — a genuinely-str value flows through the
+      // concatenation path fine, so do not misfire a TypeError on it.
+      if (cat != "string" && !cat.empty())
+        return get_exception_handler().gen_exception_raise(
+          "TypeError",
+          "unsupported operand type(s) for +: '" +
+            type_handler_.get_python_type_name(lhs.type()) + "' and '" +
+            type_handler_.get_python_type_name(rhs.type()) + "'");
     }
     return string_handler_.handle_string_concatenation_with_promotion(
       lhs, rhs, left, right);

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1204,17 +1204,15 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           element.contains("value") && element["value"].contains("id")
             ? element["value"]["id"].get<std::string>()
             : std::string();
+        // Raise a catchable Python AttributeError (issue #5904) rather than
+        // aborting the frontend, so it can escape main() (uncaught) or be
+        // suppressed by a matching `except AttributeError`.
         std::ostringstream msg;
-        msg << "AttributeError: '";
-        if (!base_name.empty())
-          msg << base_name;
-        else
-          msg << "object";
-        msg << "' has no attribute '" << attr_name << "'";
-        const locationt loc = get_location_from_decl(element);
-        if (!loc.is_nil())
-          msg << " at " << loc.get_file() << ":" << loc.get_line();
-        throw std::runtime_error(msg.str());
+        msg << "'" << (base_name.empty() ? "object" : base_name)
+            << "' object has no attribute '" << attr_name << "'";
+        expr = get_exception_handler().gen_exception_raise(
+          "AttributeError", msg.str());
+        break;
       }
 
       // Read-modify-set: we may push_back a new component into the class
@@ -1371,8 +1369,13 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           }
           else
           {
-            throw std::runtime_error(
-              "Attribute \"" + attr_name + "\" not found");
+            // Instance of a known class but the attribute genuinely does not
+            // exist: raise a catchable AttributeError (issue #5904) instead of
+            // aborting conversion.
+            expr = get_exception_handler().gen_exception_raise(
+              "AttributeError",
+              "'" + extract_class_name_from_tag(obj_type_name) +
+                "' object has no attribute '" + attr_name + "'");
           }
         }
         else

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4649,29 +4649,36 @@ std::optional<exprt> function_call_expr::resolve_missing_function_symbol(
         const std::string &func_name = function_id_.get_function();
         locationt location = converter_.get_location_from_decl(call_);
 
-        // A method call `recv.foo()` whose receiver type has no such method is a
-        // Python AttributeError, not an unsupported free function. Raise a
-        // catchable AttributeError (issue #5904) so it can escape main()
-        // (uncaught) or be suppressed by `except AttributeError`. Bare
-        // free-function calls (`func()`, a Name) keep the generic
-        // unsupported-function stub below.
+        // A method call `recv.foo()` on a receiver of a *known* type that has
+        // no such method is a Python AttributeError, not an unsupported free
+        // function. Raise a catchable AttributeError (issue #5904) so it can
+        // escape main() (uncaught) or be suppressed by `except AttributeError`.
+        // When the receiver's type is unknown (an imported module such as
+        // `random.choice(...)`, or an unannotated value) we cannot prove the
+        // attribute is missing — the module/object may genuinely provide it and
+        // ESBMC simply does not model it — so fall through to the generic
+        // unsupported-function stub. Bare free-function calls (`func()`, a Name)
+        // likewise keep that stub.
         if (
           call_.contains("func") && call_["func"].is_object() &&
           call_["func"].value("_type", "") == "Attribute")
         {
           const std::string recv = get_object_name();
-          std::string recv_type = type_handler_.get_var_type(recv);
-          if (recv_type.empty())
-            recv_type = "object";
-          // Return the cpp-throw directly (not a nondet placeholder) so it
-          // propagates through nested expression contexts via
-          // contains_cpp_throw, matching how attribute access and the binop
-          // TypeError raise are consumed.
-          exprt raise = converter_.get_exception_handler().gen_exception_raise(
-            "AttributeError",
-            "'" + recv_type + "' object has no attribute '" + func_name + "'");
-          raise.location() = location;
-          return raise;
+          const std::string recv_type = type_handler_.get_var_type(recv);
+          if (!recv_type.empty())
+          {
+            // Return the cpp-throw directly (not a nondet placeholder) so it
+            // propagates through nested expression contexts via
+            // contains_cpp_throw, matching how attribute access and the binop
+            // TypeError raise are consumed.
+            exprt raise =
+              converter_.get_exception_handler().gen_exception_raise(
+                "AttributeError",
+                "'" + recv_type + "' object has no attribute '" + func_name +
+                  "'");
+            raise.location() = location;
+            return raise;
+          }
         }
 
         log_warning(

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4647,10 +4647,36 @@ std::optional<exprt> function_call_expr::resolve_missing_function_symbol(
       else
       {
         const std::string &func_name = function_id_.get_function();
+        locationt location = converter_.get_location_from_decl(call_);
+
+        // A method call `recv.foo()` whose receiver type has no such method is a
+        // Python AttributeError, not an unsupported free function. Raise a
+        // catchable AttributeError (issue #5904) so it can escape main()
+        // (uncaught) or be suppressed by `except AttributeError`. Bare
+        // free-function calls (`func()`, a Name) keep the generic
+        // unsupported-function stub below.
+        if (
+          call_.contains("func") && call_["func"].is_object() &&
+          call_["func"].value("_type", "") == "Attribute")
+        {
+          const std::string recv = get_object_name();
+          std::string recv_type = type_handler_.get_var_type(recv);
+          if (recv_type.empty())
+            recv_type = "object";
+          // Return the cpp-throw directly (not a nondet placeholder) so it
+          // propagates through nested expression contexts via
+          // contains_cpp_throw, matching how attribute access and the binop
+          // TypeError raise are consumed.
+          exprt raise = converter_.get_exception_handler().gen_exception_raise(
+            "AttributeError",
+            "'" + recv_type + "' object has no attribute '" + func_name + "'");
+          raise.location() = location;
+          return raise;
+        }
+
         log_warning(
           "Undefined function '{}' - replacing with assert(false)", func_name);
         // Create a side effect expression with nondet for assignments
-        locationt location = converter_.get_location_from_decl(call_);
         // Create a nondet expression as a placeholder that won't crash
         // This allows the code to continue but marks it as undefined behavior
         exprt nondet_expr("sideeffect", empty_typet());
@@ -5815,7 +5841,7 @@ exprt function_call_expr::generate_attribute_error(
   const typet &expected_type) const
 {
   locationt location = converter_.get_location_from_decl(call_);
-  std::ostringstream error_msg;
+  std::ostringstream detail;
 
   if (possible_classes.size() > 1)
   {
@@ -5827,29 +5853,30 @@ exprt function_call_expr::generate_attribute_error(
         display_classes += ", ";
       display_classes += "'" + possible_classes[i] + "'";
     }
-    error_msg << "AttributeError: object has no attribute '" << method_name
-              << "' (possible types: " << display_classes << ")";
+    detail << "object has no attribute '" << method_name
+           << "' (possible types: " << display_classes << ")";
   }
   else if (possible_classes.size() == 1)
   {
-    error_msg << "AttributeError: '" << possible_classes[0]
-              << "' object has no attribute '" << method_name << "'";
+    detail << "'" << possible_classes[0] << "' object has no attribute '"
+           << method_name << "'";
   }
   else
   {
-    error_msg << "AttributeError: object has no attribute '" << method_name
-              << "'";
+    detail << "object has no attribute '" << method_name << "'";
   }
 
-  log_warning("{}", error_msg.str());
+  log_warning("AttributeError: {}", detail.str());
 
-  // V.3: build the always-fail assert condition in IREP2.
-  code_assertt assert_code(migrate_expr_back(gen_false_expr()));
-  assert_code.location() = location;
-  assert_code.location().user_provided(true);
-  assert_code.location().comment(error_msg.str());
-
-  converter_.add_instruction(assert_code);
+  // Raise a catchable Python AttributeError (issue #5904) rather than a bare
+  // assert(false), so it can escape main() (uncaught) or be suppressed by a
+  // matching `except AttributeError`.
+  exprt raise = converter_.get_exception_handler().gen_exception_raise(
+    "AttributeError", detail.str());
+  codet throw_code("expression");
+  throw_code.location() = location;
+  throw_code.operands().push_back(raise);
+  converter_.add_instruction(throw_code);
 
   // Compute fallback type: use expected_type if valid, otherwise Any
   typet fallback_type = expected_type;
@@ -5862,7 +5889,7 @@ exprt function_call_expr::generate_attribute_error(
   nondet_fallback.statement("nondet");
   nondet_fallback.location() = location;
   nondet_fallback.location().user_provided(true);
-  nondet_fallback.location().comment(error_msg.str());
+  nondet_fallback.location().comment("AttributeError: " + detail.str());
 
   return nondet_fallback;
 }

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -42,6 +42,16 @@ class TypeError(Exception):
         return self.message
 
 
+class AttributeError(Exception):
+    message: str = ""
+
+    def __init__(self, message: str = ""):
+        self.message: str = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
 class IndexError(Exception):
     message: str = ""
 

--- a/src/python-frontend/string/string_builder.cpp
+++ b/src/python-frontend/string/string_builder.cpp
@@ -47,10 +47,16 @@ std::vector<exprt> string_builder::extract_string_chars(
 {
   std::vector<exprt> chars;
 
-  // Handle JSON string constants first
+  // Handle JSON string constants first. Guard on is_string(): a numeric
+  // Constant (e.g. the `1` in `1 + "s"`) reaching here would otherwise throw an
+  // uncaught nlohmann::json type_error and crash the frontend. The binop path
+  // now raises a catchable TypeError before this point (issue #5904); this is a
+  // defensive fallback so any other caller degrades to the expr-based path
+  // below instead of crashing.
   if (
     !json_node.is_null() && json_node.contains("_type") &&
-    json_node["_type"] == "Constant" && json_node.contains("value"))
+    json_node["_type"] == "Constant" && json_node.contains("value") &&
+    json_node["value"].is_string())
   {
     std::string str_value = json_node["value"].get<std::string>();
     chars.reserve(str_value.size());

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -123,13 +123,13 @@ public:
   {
     return (
       name == "BaseException" || name == "Exception" || name == "ValueError" ||
-      name == "TypeError" || name == "IndexError" || name == "KeyError" ||
-      name == "ZeroDivisionError" || name == "AssertionError" ||
-      name == "NameError" || name == "OSError" || name == "FileNotFoundError" ||
-      name == "FileExistsError" || name == "PermissionError" ||
-      name == "NotImplementedError" || name == "ImportError" ||
-      name == "ModuleNotFoundError" || name == "RuntimeError" ||
-      name == "StopIteration" || name == "EOFError");
+      name == "TypeError" || name == "AttributeError" || name == "IndexError" ||
+      name == "KeyError" || name == "ZeroDivisionError" ||
+      name == "AssertionError" || name == "NameError" || name == "OSError" ||
+      name == "FileNotFoundError" || name == "FileExistsError" ||
+      name == "PermissionError" || name == "NotImplementedError" ||
+      name == "ImportError" || name == "ModuleNotFoundError" ||
+      name == "RuntimeError" || name == "StopIteration" || name == "EOFError");
   }
 
   static bool is_c_model_func(const std::string &func_name)

--- a/unit/python-frontend/function_call_expr_error_test.cpp
+++ b/unit/python-frontend/function_call_expr_error_test.cpp
@@ -131,10 +131,11 @@ TEST_CASE(
     exprt result = function_call_expr_test_access::generate_attribute_error(
       fce, "foo", {"MyClass"}, expected);
 
-    // The assert instruction should have been emitted into the block.
+    // A catchable AttributeError throw (issue #5904) should have been emitted
+    // into the block as a code-expression instruction.
     REQUIRE(block.operands().size() == 1);
     REQUIRE(block.operands()[0].is_code());
-    REQUIRE(to_code(block.operands()[0]).get_statement() == "assert");
+    REQUIRE(to_code(block.operands()[0]).get_statement() == "expression");
 
     // Returned expression must be a sideeffect/nondet with the expected type.
     REQUIRE(result.id() == "sideeffect");


### PR DESCRIPTION
The Python frontend did not model dynamic-typing errors as catchable runtime
exceptions, so the SV-COMP per-family verdicts (`! uncaught(TypeError)`,
`! uncaught(AttributeError)`) were unreachable. This makes them real
`cpp-throw`s with the correct typeid, so each escapes `main()` (uncaught) or is
caught by a matching `except`.

## Before / after

| Input | Before | After |
|---|---|---|
| `y = 1 + "s"` | converter crash (`nlohmann::json` type_error) | `VERIFICATION FAILED` — uncaught TypeError |
| `x = 5; x.foo()` | generic `Unsupported function 'foo' is reached` | uncaught AttributeError |
| `x = 5; y = x.foo` | frontend abort (`ERROR: AttributeError: ...`) | uncaught AttributeError |
| `except AttributeError:` | `NameError: name 'AttributeError' is not defined` | resolves & catches |

## Changes

- **Register `AttributeError`** — add the model class to `models/exceptions.py`
  and `"AttributeError"` to `type_utils::is_python_exceptions`.
- **TypeError** on a `str + <non-str>` binary `+` in `handle_array_operations`,
  guarded so an unannotated operand (unknown category) and legitimate char
  concatenation (`s + s[0]`, `"a" + "b"`) are never misflagged. Plus a
  defensive `is_string()` guard in `string_builder` so the numeric-operand path
  can never reach the crashing JSON access.
- **AttributeError** on a missing attribute read, a missing method on a builtin
  value, and a missing method on a user-class instance — all via the existing
  `gen_exception_raise` chokepoint. Bare undefined free-function calls keep the
  generic "Unsupported function" stub.

## Residual (documented)

A method-shaped call to a real-but-ESBMC-unmodeled library method now surfaces
as `AttributeError` rather than "unsupported". Both already `FAILED`, but an
`except AttributeError` wrapper could suppress such a case.

## Tests

- New: `regression/python/github_5904_*` — TypeError/AttributeError uncaught
  (fail) and caught (success) variants, a user-class missing-method case, and an
  unannotated-operand concatenation case that locks in the no-false-TypeError
  guard.
- No regressions: exception/attribute/class/method and string/concat/format
  suites pass; the bare-free-function `Unsupported function` test is preserved.

Fixes #5904