### PR TITLE
[python] Fix (a // b) ** n folding to 0 for non-constant operands

### DIFF
--- a/regression/python/github_5915-nondet/main.py
+++ b/regression/python/github_5915-nondet/main.py
@@ -1,0 +1,11 @@
+# Generalisation of #5915: `(a OP b) ** n` with a non-constant base was mis-folded
+# to a compile-time constant (0 or 1) because handle_power read the empty value
+# string of the non-constant base as 0. The base must stay symbolic.
+a = nondet_int()
+b = nondet_int()
+__ESBMC_assume(a == 7 and b == 2)
+assert (a + b) ** 2 == 81
+assert (a - b) ** 2 == 25
+assert (a * b) ** 2 == 196
+assert (a // b) ** 2 == 9
+assert (a % b) ** 3 == 1

--- a/regression/python/github_5915-nondet/test.desc
+++ b/regression/python/github_5915-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5915/main.py
+++ b/regression/python/github_5915/main.py
@@ -1,0 +1,8 @@
+# https://github.com/esbmc/esbmc/issues/5915
+# (a // b) ** 2 was constant-folded to 0 at conversion time because handle_power
+# read the empty value string of the non-constant floor-division base as 0.
+a = nondet_int()
+b = nondet_int()
+__ESBMC_assume(a == 10 and b == 3)
+result = (a // b) ** 2
+assert result == 9

--- a/regression/python/github_5915/test.desc
+++ b/regression/python/github_5915/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5915_cf/main.py
+++ b/regression/python/github_5915_cf/main.py
@@ -1,0 +1,9 @@
+# Positive companion of github_5915_cf_fail: pinning c <= 0 forces n == 2, so
+# (n + 0) ** 2 is exactly 4. The old fold to the stale value 3 gave 9 and
+# reported this as violated; a sound symbolic base makes it hold.
+c = nondet_int()
+n = 2
+if c > 0:
+    n = 3
+__ESBMC_assume(c <= 0)
+assert (n + 0) ** 2 == 4

--- a/regression/python/github_5915_cf/test.desc
+++ b/regression/python/github_5915_cf/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5915_cf_fail/main.py
+++ b/regression/python/github_5915_cf_fail/main.py
@@ -1,0 +1,10 @@
+# Soundness guard for #5915 (control-flow-reassigned power base).
+# n is 2 or 3 depending on the nondet branch, so (n + 0) ** 2 is 4 or 9.
+# The old fold read n's stale symbol-table value (3) through the +,-,*,/ tree
+# and proved `== 9` even on the n == 2 path -- a false negative. The base must
+# stay symbolic, so this assertion must be VIOLATED.
+c = nondet_int()
+n = 2
+if c > 0:
+    n = 3
+assert (n + 0) ** 2 == 9

--- a/regression/python/github_5915_cf_fail/test.desc
+++ b/regression/python/github_5915_cf_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/regression/python/github_5915_const_symbol/main.py
+++ b/regression/python/github_5915_const_symbol/main.py
@@ -1,0 +1,8 @@
+# #5915 follow-up: a constant-valued symbol used as a power base stays exact even
+# though the frontend no longer folds symbols -- symex concretises b and d, so the
+# multiplication tree yields the exact integer result.
+b = 3
+d = 4
+assert b ** 2 == 9
+assert (b + d) ** 2 == 49
+assert (d - b) ** 3 == 1

--- a/regression/python/github_5915_const_symbol/test.desc
+++ b/regression/python/github_5915_const_symbol/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5915_fail/main.py
+++ b/regression/python/github_5915_fail/main.py
@@ -1,0 +1,7 @@
+# Negative guard for #5915: result is 9, so `result == 0` must be violated.
+# If the bogus compile-time fold to 0 ever returns, this would wrongly SUCCEED.
+a = nondet_int()
+b = nondet_int()
+__ESBMC_assume(a == 10 and b == 3)
+result = (a // b) ** 2
+assert result == 0

--- a/regression/python/github_5915_fail/test.desc
+++ b/regression/python/github_5915_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -325,16 +325,22 @@ python_math::try_fold_int_constant(const exprt &expr) const
     }
   }
 
-  // Symbol assigned a compile-time integer (e.g. `a = 2`); resolve one level.
-  // A nondet / unconstrained symbol resolves to a non-constant value, so it
-  // yields nullopt rather than a fabricated 0 (issue #5915).
+  // Do NOT resolve a symbol to its symbol-table value. That value holds only
+  // the last *statically* assigned constant, which is unsound to fold when the
+  // variable is reassigned under control flow: e.g.
+  //     n = 2
+  //     if c: n = 3
+  //     x = 5 ** n
+  // leaves the symbol value at 3, so folding would prove `x == 125` even
+  // though x is 25 on the `not c` path -- a false negative. The general
+  // expression path (goto-symex SSA) keeps such a symbol symbolic; the fold
+  // path must do the same. A genuinely single-assigned constant (e.g. a
+  // module-level `a = 2`) is still handled correctly: for the base, symex
+  // concretises the symbol in the integer multiplication tree, so the result
+  // stays exact; for a symbolic exponent it flows to pow() (double) exactly as
+  // a bare-symbol exponent already did before this fix (issue #5915).
   if (expr.is_symbol())
-  {
-    const exprt resolved = resolve_symbol(expr);
-    if (resolved.is_constant() || is_basic_math_expr(resolved))
-      return try_fold_int_constant(resolved);
     return std::nullopt;
-  }
 
   // +,-,*,/ over sub-expressions that each fold to an integer constant.
   if (is_basic_math_expr(expr) && expr.operands().size() == 2)
@@ -546,9 +552,9 @@ exprt python_math::handle_power(exprt lhs, exprt rhs)
   // exponent (e.g. `2 ** (a + 1)`) must stay symbolic -- folding it silently
   // read an empty value string as 0 (issue #5915). This also correctly handles
   // negative exponents, which Python's ** returns as float.
-  std::optional<BigInt> exponent_opt;
-  if (rhs.is_constant() || is_basic_math_expr(rhs))
-    exponent_opt = try_fold_int_constant(rhs);
+  // try_fold_int_constant returns nullopt for anything non-constant, so it is
+  // safe to call directly.
+  const std::optional<BigInt> exponent_opt = try_fold_int_constant(rhs);
   if (!exponent_opt.has_value())
     return handle_power_symbolic(lhs, rhs);
   const BigInt exponent = *exponent_opt;
@@ -567,9 +573,7 @@ exprt python_math::handle_power(exprt lhs, exprt rhs)
   // base or a +,-,*,/ tree over a symbolic operand (e.g. `(a // b)`, whose
   // operand is a `/` sub-expression) stays symbolic and flows into the
   // multiplication tree (build_power_expression) below (issue #5915).
-  std::optional<BigInt> resolved_base_value;
-  if (lhs.is_constant() || is_basic_math_expr(lhs))
-    resolved_base_value = try_fold_int_constant(lhs);
+  const std::optional<BigInt> resolved_base_value = try_fold_int_constant(lhs);
 
   // Cap constant folding to keep conversion fast; large symbolic trees are
   // cheaper than huge BigInt powers.

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -306,6 +306,71 @@ exprt python_math::resolve_symbol(const exprt &operand) const
   return operand;
 }
 
+std::optional<BigInt>
+python_math::try_fold_int_constant(const exprt &expr) const
+{
+  // Genuine integer literal.
+  if (expr.is_constant())
+  {
+    if (!(expr.type().is_signedbv() || expr.type().is_unsignedbv()))
+      return std::nullopt; // reject float / non-integer constants
+    try
+    {
+      return binary2integer(
+        expr.value().as_string(), expr.type().is_signedbv());
+    }
+    catch (...)
+    {
+      return std::nullopt;
+    }
+  }
+
+  // Symbol assigned a compile-time integer (e.g. `a = 2`); resolve one level.
+  // A nondet / unconstrained symbol resolves to a non-constant value, so it
+  // yields nullopt rather than a fabricated 0 (issue #5915).
+  if (expr.is_symbol())
+  {
+    const exprt resolved = resolve_symbol(expr);
+    if (resolved.is_constant() || is_basic_math_expr(resolved))
+      return try_fold_int_constant(resolved);
+    return std::nullopt;
+  }
+
+  // +,-,*,/ over sub-expressions that each fold to an integer constant.
+  if (is_basic_math_expr(expr) && expr.operands().size() == 2)
+  {
+    const std::optional<BigInt> l = try_fold_int_constant(expr.operands()[0]);
+    if (!l.has_value())
+      return std::nullopt;
+    const std::optional<BigInt> r = try_fold_int_constant(expr.operands()[1]);
+    if (!r.has_value())
+      return std::nullopt;
+
+    const irep_idt &id = expr.id();
+    if (id == "+")
+      return *l + *r;
+    if (id == "-")
+      return *l - *r;
+    if (id == "*")
+      return *l * *r;
+    if (id == "/" && *r != 0)
+      return *l / *r;
+  }
+
+  return std::nullopt;
+}
+
+exprt python_math::compute_expr(const exprt &expr) const
+{
+  // Fold to a constant only when the expression is genuinely a compile-time
+  // integer; otherwise return it unchanged so callers keep a symbolic encoding
+  // rather than a fabricated 0 read from a non-constant operand (issue #5915).
+  if (std::optional<BigInt> value = try_fold_int_constant(expr);
+      value.has_value())
+    return from_integer(*value, expr.type());
+  return expr;
+}
+
 std::optional<double>
 python_math::try_resolve_constant_double(const exprt &operand) const
 {
@@ -415,38 +480,6 @@ const symbolt &python_math::get_c_math_symbol_cached(
   return *symbol;
 }
 
-exprt python_math::compute_expr(const exprt &expr) const
-{
-  // Resolve operands to their constant values
-  const exprt lhs = resolve_symbol(expr.operands().at(0));
-  const exprt rhs = resolve_symbol(expr.operands().at(1));
-
-  // Convert to BigInt for computation
-  const BigInt op1 =
-    binary2integer(lhs.value().as_string(), lhs.type().is_signedbv());
-  const BigInt op2 =
-    binary2integer(rhs.value().as_string(), rhs.type().is_signedbv());
-
-  // Perform the math operation
-  BigInt result;
-  if (expr.id() == "+")
-    result = op1 + op2;
-  else if (expr.id() == "-")
-    result = op1 - op2;
-  else if (expr.id() == "*")
-    result = op1 * op2;
-  else if (expr.id() == "/")
-    result = op1 / op2;
-  else
-    throw std::runtime_error("Unsupported math operation: " + expr.id_string());
-
-  // Return the result as a constant expression. V.3: build the folded
-  // integer constant in IREP2 and back-migrate once -- the operands were read
-  // as bitvector integers, so lhs.type() is always integer here and the
-  // constant_int2t round-trips exactly to the same constant_exprt.
-  return migrate_expr_back(constant_int2tc(migrate_type(lhs.type()), result));
-}
-
 exprt python_math::handle_power_symbolic(exprt base, exprt exp)
 {
   // Convert arguments to double type if needed
@@ -508,29 +541,17 @@ exprt python_math::handle_power(exprt lhs, exprt rhs)
   if (lhs.type().is_floatbv() || rhs.type().is_floatbv())
     return handle_power_symbolic(lhs, rhs);
 
-  // Resolve exponent first. If it is non-constant, we can return early without
-  // spending time resolving the base.
-  exprt resolved_rhs = rhs;
-  if (is_basic_math_expr(rhs))
-    resolved_rhs = compute_expr(rhs);
-
-  // If rhs is still not constant or is a float, delegate to pow() for
-  // soundness. This correctly handles symbolic exponents and negative exponents
-  // (which Python's ** returns as float).
-  if (!resolved_rhs.is_constant() || resolved_rhs.type().is_floatbv())
+  // Resolve the exponent first: if it is not a compile-time integer, return
+  // early via pow() without resolving the base. A symbolic or nondet-containing
+  // exponent (e.g. `2 ** (a + 1)`) must stay symbolic -- folding it silently
+  // read an empty value string as 0 (issue #5915). This also correctly handles
+  // negative exponents, which Python's ** returns as float.
+  std::optional<BigInt> exponent_opt;
+  if (rhs.is_constant() || is_basic_math_expr(rhs))
+    exponent_opt = try_fold_int_constant(rhs);
+  if (!exponent_opt.has_value())
     return handle_power_symbolic(lhs, rhs);
-
-  // Convert rhs to integer exponent
-  BigInt exponent;
-  try
-  {
-    exponent = binary2integer(
-      resolved_rhs.value().as_string(), resolved_rhs.type().is_signedbv());
-  }
-  catch (...)
-  {
-    return handle_power_symbolic(lhs, rhs);
-  }
+  const BigInt exponent = *exponent_opt;
 
   // Negative exponents: Python returns a float (e.g. 2**-1 == 0.5)
   if (exponent < 0)
@@ -542,25 +563,13 @@ exprt python_math::handle_power(exprt lhs, exprt rhs)
   if (exponent == 1)
     return lhs;
 
-  exprt resolved_lhs = lhs;
-  if (is_basic_math_expr(lhs))
-    resolved_lhs = compute_expr(lhs);
-
+  // Fold the base only when it is genuinely a compile-time integer. A nondet
+  // base or a +,-,*,/ tree over a symbolic operand (e.g. `(a // b)`, whose
+  // operand is a `/` sub-expression) stays symbolic and flows into the
+  // multiplication tree (build_power_expression) below (issue #5915).
   std::optional<BigInt> resolved_base_value;
-  if (
-    resolved_lhs.is_constant() &&
-    (resolved_lhs.type().is_signedbv() || resolved_lhs.type().is_unsignedbv()))
-  {
-    try
-    {
-      resolved_base_value = binary2integer(
-        resolved_lhs.value().as_string(), resolved_lhs.type().is_signedbv());
-    }
-    catch (...)
-    {
-      // Fall back to symbolic encoding if constant conversion fails.
-    }
-  }
+  if (lhs.is_constant() || is_basic_math_expr(lhs))
+    resolved_base_value = try_fold_int_constant(lhs);
 
   // Cap constant folding to keep conversion fast; large symbolic trees are
   // cheaper than huge BigInt powers.

--- a/src/python-frontend/python_math.h
+++ b/src/python-frontend/python_math.h
@@ -39,10 +39,12 @@ private:
   exprt resolve_symbol(const exprt &operand) const;
 
   /// Fold an expression to an integer constant *only* when it genuinely is one:
-  /// an integer literal, a symbol assigned an integer constant, or a +,-,*,/
-  /// tree whose leaves all fold to integer constants. Returns std::nullopt for
-  /// anything symbolic/nondet, so callers keep a symbolic encoding rather than
-  /// fabricating a bogus 0 from an empty value string (issue #5915).
+  /// an integer literal, or a +,-,*,/ tree whose leaves all fold to integer
+  /// constants. Symbols are deliberately NOT resolved: their symbol-table value
+  /// holds only the last statically-assigned constant, which is unsound to fold
+  /// when the variable is reassigned under control flow (a false negative).
+  /// Returns std::nullopt for anything symbolic/nondet, so callers keep a
+  /// symbolic encoding rather than fabricating a bogus constant (issue #5915).
   std::optional<BigInt> try_fold_int_constant(const exprt &expr) const;
 
   /// Resolve a constant-like expression (constant or constant-valued symbol)

--- a/src/python-frontend/python_math.h
+++ b/src/python-frontend/python_math.h
@@ -38,6 +38,13 @@ private:
    */
   exprt resolve_symbol(const exprt &operand) const;
 
+  /// Fold an expression to an integer constant *only* when it genuinely is one:
+  /// an integer literal, a symbol assigned an integer constant, or a +,-,*,/
+  /// tree whose leaves all fold to integer constants. Returns std::nullopt for
+  /// anything symbolic/nondet, so callers keep a symbolic encoding rather than
+  /// fabricating a bogus 0 from an empty value string (issue #5915).
+  std::optional<BigInt> try_fold_int_constant(const exprt &expr) const;
+
   /// Resolve a constant-like expression (constant or constant-valued symbol)
   /// to a host double when possible.
   std::optional<double> try_resolve_constant_double(const exprt &operand) const;
@@ -126,14 +133,15 @@ public:
     const nlohmann::json &element);
 
   /**
-   * @brief Compute a mathematical expression with constant operands
-   * 
-   * Evaluates binary arithmetic operations (+, -, *, /) when both operands
-   * are constants or can be resolved to constants via symbol lookup.
-   * 
-   * @param expr The binary expression to evaluate
-   * @return A constant expression with the computed result
-   * @throws std::runtime_error if operation is unsupported
+   * @brief Fold a +,-,*,/ expression to a constant when it is genuinely one.
+   *
+   * Returns a constant expression when @p expr (and all its operands) resolve
+   * to integer constants; otherwise returns @p expr unchanged so callers keep
+   * a symbolic encoding. Never fabricates a 0 from a non-constant operand
+   * (issue #5915).
+   *
+   * @param expr A +,-,*,/ binary expression
+   * @return The folded constant, or @p expr unchanged if not constant
    */
   exprt compute_expr(const exprt &expr) const;
 


### PR DESCRIPTION
handle_power folded a +,-,*,/ base or exponent by reading each operand's value string, which `binary2integer` silently reads as 0 for a non-constant operand (a nondet symbol, or a nested sub-expression such as the floor-division a/b), so `(a // b) ** 2` collapsed to `0 ** 2 = 0`. Now fold only when the expression genuinely resolves to an integer constant; otherwise keep it symbolic (preserving legitimate folds like `c ** (a + b)`). The shared sound helper also fixes complex `**` with a non-constant exponent.

Fixes #5915.