### PR TITLE
[python] Bind None result of implicitly-None-returning functions

### DIFF
--- a/regression/python/github_5914/main.py
+++ b/regression/python/github_5914/main.py
@@ -1,0 +1,5 @@
+def f() -> None:
+    pass
+
+result = f()
+assert (result is None)

--- a/regression/python/github_5914/test.desc
+++ b/regression/python/github_5914/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5914_bare/main.py
+++ b/regression/python/github_5914_bare/main.py
@@ -1,0 +1,7 @@
+def f(x: int) -> None:
+    if x > 0:
+        return
+    return
+
+r = f(5)
+assert (r is None)

--- a/regression/python/github_5914_bare/test.desc
+++ b/regression/python/github_5914_bare/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5914_fail/main.py
+++ b/regression/python/github_5914_fail/main.py
@@ -1,0 +1,5 @@
+def f() -> None:
+    pass
+
+result = f()
+assert (result is not None)

--- a/regression/python/github_5914_fail/test.desc
+++ b/regression/python/github_5914_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -167,6 +167,44 @@ bool python_converter::function_has_missing_return_paths(
   return true; // No explicit return found
 }
 
+bool python_converter::function_is_generator(
+  const nlohmann::json &function_node)
+{
+  // A function is a generator iff its own body contains a `yield` / `yield from`
+  // expression. Recurse through nested statement bodies but stop at nested
+  // function/lambda scopes: a yield inside those belongs to the inner
+  // generator, not this one.
+  std::function<bool(const nlohmann::json &)> scan =
+    [&](const nlohmann::json &node) -> bool {
+    if (node.is_object())
+    {
+      auto it = node.find("_type");
+      if (it != node.end() && it->is_string())
+      {
+        const std::string &kind = it->get_ref<const std::string &>();
+        if (kind == "Yield" || kind == "YieldFrom")
+          return true;
+        if (
+          kind == "FunctionDef" || kind == "AsyncFunctionDef" ||
+          kind == "Lambda")
+          return false;
+      }
+      for (const auto &child : node.items())
+        if (scan(child.value()))
+          return true;
+    }
+    else if (node.is_array())
+    {
+      for (const auto &child : node)
+        if (scan(child))
+          return true;
+    }
+    return false;
+  };
+
+  return scan(function_node["body"]);
+}
+
 TypeFlags
 python_converter::infer_types_from_returns(const nlohmann::json &function_body)
 {
@@ -1436,9 +1474,12 @@ void python_converter::get_function_definition(
   // a defined None value rather than a nondet slot — matching the already-
   // correct `return None` path (issue #5914). Constructors ("constructor"
   // return type) and library/import models, whose void calls exist only for
-  // side effects, are left as-is.
+  // side effects, are left as-is. Generators (functions containing `yield`)
+  // also have an empty return type here but do NOT implicitly return None —
+  // calling one yields a generator object — so they must not be promoted.
   if (
-    type.return_type().is_empty() && !is_loading_models && !is_importing_module)
+    type.return_type().is_empty() && !is_loading_models &&
+    !is_importing_module && !function_is_generator(function_node))
   {
     type.return_type() = none_type();
     added_symbol->set_type(type);

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -932,10 +932,13 @@ void python_converter::validate_return_paths(
   const code_typet &type,
   exprt &function_body)
 {
-  // Skip validation for void returns and constructors
+  // Skip validation for void/None returns and constructors. A None-returning
+  // function (none_type()) implicitly returns None when it falls off the end,
+  // so a "missing" return path is correct Python, not a defect.
   if (
     type.return_type().is_empty() ||
     type.return_type().id() == typet::t_empty ||
+    type.return_type() == none_type() ||
     type.return_type().id() == "constructor" ||
     !function_has_missing_return_paths(function_node))
   {
@@ -1426,6 +1429,25 @@ void python_converter::get_function_definition(
   if (type_assertions_enabled())
     get_typechecker().inject_parameter_type_assertions(
       function_node, id, type, function_body);
+
+  // Python semantics: a user function with no value-returning path implicitly
+  // returns None. Model such a function as returning none_type() and append an
+  // explicit `return None`, so a caller that binds the result (`x = f()`) gets
+  // a defined None value rather than a nondet slot — matching the already-
+  // correct `return None` path (issue #5914). Constructors ("constructor"
+  // return type) and library/import models, whose void calls exist only for
+  // side effects, are left as-is.
+  if (
+    type.return_type().is_empty() && !is_loading_models && !is_importing_module)
+  {
+    type.return_type() = none_type();
+    added_symbol->set_type(type);
+
+    code_returnt implicit_none;
+    implicit_none.return_value() = gen_zero(none_type());
+    implicit_none.location() = get_location_from_decl(function_node);
+    function_body.copy_to_operands(implicit_none);
+  }
 
   // Add ESBMC_Hide label for models/imports
   if (is_loading_models || is_importing_module)

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3782,6 +3782,14 @@ void python_converter::get_return_statements(
           wrap_in_optional(none_expr, current_func_return_type_);
       }
     }
+    // A bare `return` yields None. When the function returns None — either
+    // already typed none_type(), or still an empty placeholder that the funcdef
+    // will promote to none_type() (issue #5914) — give the RETURN an explicit
+    // None value so it matches the declared none_type() slot at the call site.
+    else if (
+      current_func_return_type_ == none_type() ||
+      current_func_return_type_.is_empty())
+      return_code.return_value() = gen_zero(none_type());
 
     target_block.copy_to_operands(return_code);
     return;

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -971,9 +971,18 @@ exprt function_call_builder::build() const
       auto &symbol_table = converter_.symbol_table();
       locationt location = converter_.get_location_from_decl(call_);
 
-      code_typet trampoline_type;
-      trampoline_type.return_type() = empty_typet();
-      typet param_type = pointer_typet(trampoline_type);
+      if (call_["args"].size() != 1)
+        throw std::runtime_error(func_name + " takes exactly one argument");
+      exprt arg = converter_.get_expr(call_["args"][0]);
+      if (arg.type().is_code())
+        arg = build_address_of(arg);
+
+      // intrinsic_spawn_thread requires a *literal* address_of(symbol); a
+      // typecast around it trips its is_address_of2t assertion. The trampoline
+      // returns None, whose GOTO return type is none_type() rather than void
+      // (issue #5914), so derive the parameter type from the actual address
+      // expression instead of forcing pointer-to-void() and typecasting.
+      typet param_type = arg.type();
 
       code_typet fn_type;
       fn_type.return_type() = uint_type();
@@ -986,14 +995,6 @@ exprt function_call_builder::build() const
           converter_.python_file(), func_name, symbol_id, location, fn_type);
         converter_.add_symbol(symbol);
       }
-
-      if (call_["args"].size() != 1)
-        throw std::runtime_error(func_name + " takes exactly one argument");
-      exprt arg = converter_.get_expr(call_["args"][0]);
-      if (arg.type().is_code())
-        arg = build_address_of(arg);
-      if (arg.type() != param_type)
-        arg = build_typecast(arg, param_type);
 
       code_function_callt call;
       call.function() = symbol_exprt(symbol_id, fn_type);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -366,6 +366,8 @@ private:
 
   bool function_has_missing_return_paths(const nlohmann::json &function_node);
 
+  bool function_is_generator(const nlohmann::json &function_node);
+
   exprt materialize_list_function_call(
     const exprt &expr,
     const nlohmann::json &element,


### PR DESCRIPTION
A function returning None implicitly (body `pass`, fall-through, or bare
`return`) was lowered as `void`, so a caller binding its result (`r = f()`)
dropped the assignment and left `r` nondeterministic — `assert r is None`
wrongly failed. Promote such user functions to `none_type()` with an explicit
`return None` (matching the `return None` path) and adjust the thread-spawn
lowering to accept a None-returning trampoline.

Fixes #5914