### PR TITLE
[python] Materialize function-returned aggregate for membership tests

### DIFF
--- a/regression/python/github_5893/main.py
+++ b/regression/python/github_5893/main.py
@@ -1,0 +1,7 @@
+def choices():
+    return (1, 2)
+
+
+x = 3
+if x in choices():
+    assert x == 1 or x == 2

--- a/regression/python/github_5893/test.desc
+++ b/regression/python/github_5893/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5893_dict/main.py
+++ b/regression/python/github_5893_dict/main.py
@@ -1,0 +1,7 @@
+def choices():
+    return {"a": 1, "b": 2}
+
+
+x = "a"
+if x in choices():
+    assert x == "a" or x == "b"

--- a/regression/python/github_5893_dict/test.desc
+++ b/regression/python/github_5893_dict/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5893_fail/main.py
+++ b/regression/python/github_5893_fail/main.py
@@ -1,0 +1,7 @@
+def choices():
+    return (1, 2)
+
+
+x = 2
+if x in choices():
+    assert x == 1

--- a/regression/python/github_5893_fail/test.desc
+++ b/regression/python/github_5893_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$

--- a/regression/python/github_5893_str/main.py
+++ b/regression/python/github_5893_str/main.py
@@ -1,0 +1,7 @@
+def choices():
+    return ("a", "b")
+
+
+x = "a"
+if x in choices():
+    assert x == "a" or x == "b"

--- a/regression/python/github_5893_str/test.desc
+++ b/regression/python/github_5893_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -758,6 +758,17 @@ exprt python_converter::handle_membership_operator(
     const struct_typet &struct_type = to_struct_type(rhs_resolved_type);
     const irep_idt kind = python_aggregate_kind(struct_type);
 
+    // A function-returned aggregate arrives as a raw code_function_callt (or a
+    // side-effect), not an addressable value. Both the dict and tuple handlers
+    // build member accesses over it (`.keys`, `.element_i`) and migrate them to
+    // IREP2, which trips the member2t struct assertion (#5893). Materialise it
+    // into a temporary struct lvalue first, exactly as the unpacking/subscript
+    // paths do. prepare_rhs_for_unpacking is type-agnostic — it materialises a
+    // side-effect into a temp of rhs.type() — so it serves both branches.
+    if ((rhs.is_function_call() || rhs.id() == "sideeffect") && current_block)
+      rhs =
+        tuple_handler_->prepare_rhs_for_unpacking(element, rhs, *current_block);
+
     // Recognise a dict by its struct tag as well as its aggregate-kind marker.
     // The kind irep can be dropped while a dict value flows through type
     // inference (e.g. a dict comprehension result), but the `__python_dict__`


### PR DESCRIPTION
## Problem

`x in f()` crashed when `f()` returned a tuple or dict (#5893):

```python
def choices():
    return (1, 2)

x = 3
if x in choices():          # member2t struct assertion abort
    assert x == 1 or x == 2
```

- Tuple return → `member2t` constructor assertion in `irep2_expr.h`
- Dict return → `irep2_cast_error`

Inline literals (`x in (1, 2)`) and *indexing* a returned tuple both worked — only membership crashed.

## Root cause

The struct type is **not** lost across the return boundary — `rhs.type()` is the correct tuple/dict struct type. The problem is the **expression kind**: `choices()` arrives as a raw `code_function_callt` statement, not an addressable value. The membership handler builds `.element_i` / `.keys` member accesses over it and **eagerly migrates** them to IREP2 *before* side-effect lifting, so the member source is a non-struct call node → assertion.

The subscript path works because it never migrates eagerly; migration is deferred to goto-convert, after side-effect removal lifts the call into a temporary struct lvalue.

## Fix

In `handle_membership_operator`, materialize a function-call / side-effect `rhs` into a temporary struct lvalue **before** dispatching, reusing the existing `tuple_handler::prepare_rhs_for_unpacking` helper (already used by the unpacking and subscript paths). The helper is type-agnostic, so hoisting it above both the dict and tuple branches fixes both crash classes.

## Tests

Added under `regression/python/`:

- `github_5893` — int tuple → SUCCESSFUL (was member2t abort)
- `github_5893_str` — str tuple → SUCCESSFUL
- `github_5893_fail` — violable assertion → FAILED (proves the OR-chain is actually evaluated)
- `github_5893_dict` — returned dict → SUCCESSFUL (was irep2_cast_error)

All 4 pass under ctest and CPython sanity (`scripts/check_python_tests.sh`). The 374-test Python membership/tuple/dict/contains regression subset passes with no regressions.

Fixes #5893
