### PR TITLE
[build] Do not statically link sanitizer builds

### DIFF
--- a/scripts/cmake/BuildStatic.cmake
+++ b/scripts/cmake/BuildStatic.cmake
@@ -2,9 +2,19 @@
 
 message(STATUS "ESBMC will be built in static mode")
 if(NOT APPLE)
-    set(CMAKE_EXE_LINKER_FLAGS " -static")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -fPIC")
-    set(CMAKE_CC_FLAGS "${CMAKE_CC_FLAGS} -static -fPIC")
+    if(CMAKE_BUILD_TYPE STREQUAL "Sanitizer")
+        # Sanitizer runtimes (ASan especially) cannot be fully statically
+        # linked: -static drops the dynamic section that libclang_rt.asan
+        # needs, producing "undefined reference to _DYNAMIC" at link time.
+        # Keep PIC and static dependency archives, but link the executables
+        # dynamically so the sanitizer runtime resolves.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+        set(CMAKE_CC_FLAGS "${CMAKE_CC_FLAGS} -fPIC")
+    else()
+        set(CMAKE_EXE_LINKER_FLAGS " -static")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -fPIC")
+        set(CMAKE_CC_FLAGS "${CMAKE_CC_FLAGS} -static -fPIC")
+    endif()
 endif()
 set(Boost_USE_STATIC_LIBS        ON)
 set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})


### PR DESCRIPTION
The Sanitizers workflow fails at the build step because sanitizer builds inherit `BUILD_STATIC=ON` on Ubuntu, which injects `-static`. ASan's runtime cannot be fully statically linked (`undefined reference to _DYNAMIC`), breaking the `c2goto` link; the same static-glibc binary is the leading suspect for the ubsan `c2goto` segfault while generating `clib32.goto`.

Drop `-static` for the `Sanitizer` build type while keeping PIC and static dependency archives, so the sanitizer runtime links dynamically.

Refs #223