### PR TITLE
[python] Keep the .0 on a negative whole-number float in str.format "{}"

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -3948,3 +3948,51 @@ with the `str()` negative-float gap, left out of scope.
 ### 82b. Everything else: unchanged disposition
 The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
 infeasible `hashlib` case all stand. The §5 priority order stands.
+
+## 83. 2026-07-08 re-validation (seventy-third sweep) & str.format() negative whole-number float
+
+Re-test against current `master`. KNOWNBUG classification unchanged — §3 holds. §82 fixed the
+positive `"{}".format(1.0)` whole-number-float `.0` drop but left the **negative** counterpart on the
+old code path; this sweep closes it — the same wrong-value/soundness class (false `SUCCESSFUL`).
+
+### 83a. New isolated, soundly-fixable defect found & fixed
+**A negative whole-number float in an empty `"{}"` replacement field dropped the `.0`, so
+`"{}".format(-1.0)` folded to `"-1"` and the false `assert "{}".format(-1.0) == "-1"` verified
+`SUCCESSFUL`.**
+
+`format_value_from_json` (`src/python-frontend/string/string_method_handler.cpp`) formats an empty
+`{}` field. A negative literal parses as `UnaryOp(USub, Constant)`, and that branch rendered a float
+with a raw `std::ostringstream << -value` — the exact default-format divergence §82 fixed for the
+positive `Constant` branch, but never mirrored here. So `"{}".format(-1.0)` folded to `"-1"` (and
+`"{}".format(-1000000.0)` to `"-1e+06"`, `"{}".format(-0.0)` to `"-0"`), while the positive
+`"{}".format(1.0)` already rendered `"1.0"` correctly. The false `"{}".format(-1.0) == "-1"` then
+verified `SUCCESSFUL` (a soundness hole) while the valid `== "-1.0"` reported a spurious `FAILED`.
+The f-string path (`f"{-1.0}"`) already rendered `"-1.0"` correctly; only the `str.format()` negative
+empty-field fold diverged.
+
+**Fix (de-duplicate, no new divergence)**: extract the whole-number-float rendering §82 added into a
+single `format_float_value(double)` helper and route both the positive `Constant` branch and the
+negative `UnaryOp(USub)` branch through it. A whole-number float with `d == floor(d)` and
+`|d| < 1e16` renders as its integer digits plus `".0"` (`str(-1000000.0) == "-1000000.0"`), which is
+provably correct; `std::signbit` re-adds the sign so `-0.0` renders `"-0.0"`. Every other float keeps
+the prior `std::ostringstream` behaviour, which already matches CPython's exponential form for
+`|x| >= 1e16` and `|x| < 1e-4` — the fix deliberately does *not* widen that range (which §82's review
+showed would trade one divergence for another).
+
+This is a **wrong-value/soundness fix**. New regression pair
+`regression/python/str_format_neg_whole_float{,_fail}` (CORE): the positive covers negative
+whole-number floats (`-1.0`/`-2.0`/`-100.0`/`-1000000.0`/`-0.0`), unchanged negative fractional cases
+(`-0.5`/`-1.5`), the still-correct positive case, and a mixed field (`"x={} y={}".format(-3.0, -4)`);
+the `_fail` pins the previously-false-`SUCCESSFUL` `"{}".format(-1.0) == "-1"`, now correctly
+`FAILED`. CPython sanity confirms every positive assertion holds and the `_fail` claim is genuinely
+false; dual-solver Bitwuzla + Z3 agree on the positive test; all 41 existing
+`fstring`/`format`/`percent`/`repr` regression tests pass unchanged.
+
+### 83b. Next candidate & everything else: unchanged disposition
+Next soundly-fixable candidates observed but deferred (each a clean error / spurious `FAILED`, **never
+a false `SUCCESSFUL`**): the `format()` builtin with a negative float and an empty spec
+(`format(-1.0)`) throws `format() spec '' is not supported for this value` even though the equivalent
+`"{}".format(-1.0)` now folds — a `UnaryOp`-routing gap in the `format()` empty-spec path; and
+`repr()` of a bare float/int still does not fold. The §3 design-level blockers, §3c policy-banned
+timeouts, §3d questionable expectation, and the infeasible `hashlib` case all stand. The §5 priority
+order stands.

--- a/regression/python/str_format_neg_whole_float/main.py
+++ b/regression/python/str_format_neg_whole_float/main.py
@@ -1,0 +1,22 @@
+def main() -> None:
+    # A negative literal is a UnaryOp(USub, Constant); the empty "{}" field must
+    # format it with str(), which keeps CPython's ".0" suffix on a whole-number
+    # float: "{}".format(-1.0) is "-1.0", not "-1". Pre-fix the negative branch
+    # used a raw ostream fold that dropped the ".0" (the positive branch already
+    # kept it), so this was a false SUCCESSFUL.
+    assert "{}".format(-1.0) == "-1.0"
+    assert "{}".format(-2.0) == "-2.0"
+    assert "{}".format(-100.0) == "-100.0"
+    assert "{}".format(-1000000.0) == "-1000000.0"
+    # Signed zero keeps its sign: str(-0.0) == "-0.0".
+    assert "{}".format(-0.0) == "-0.0"
+    # Negative fractional floats were already correct and stay so (only exactly
+    # representable dyadic values are asserted for cross-platform stability).
+    assert "{}".format(-0.5) == "-0.5"
+    assert "{}".format(-1.5) == "-1.5"
+    # Positive whole-number floats and non-float fields are unaffected.
+    assert "{}".format(1.0) == "1.0"
+    assert "x={} y={}".format(-3.0, -4) == "x=-3.0 y=-4"
+
+
+main()

--- a/regression/python/str_format_neg_whole_float/test.desc
+++ b/regression/python/str_format_neg_whole_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_format_neg_whole_float_fail/main.py
+++ b/regression/python/str_format_neg_whole_float_fail/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    # Pre-fix, an empty "{}" field formatted -1.0 as "-1" (dropping the ".0"),
+    # so this false assertion verified SUCCESSFUL. CPython gives "-1.0", so it
+    # must be a real FAILED.
+    assert "{}".format(-1.0) == "-1"
+
+
+main()

--- a/regression/python/str_format_neg_whole_float_fail/test.desc
+++ b/regression/python/str_format_neg_whole_float_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -107,6 +107,26 @@ static char to_upper_char(char c)
   return static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 }
 
+// Render a constant float as CPython's str() / empty-"{}" field does. A
+// whole-number float below 1e16 renders as its integer digits plus ".0"
+// (str(1.0) == "1.0", str(1000000.0) == "1000000.0"); the default ostream
+// format drops the ".0" and switches to exponential at 1e6, so fold that case
+// exactly. Every other float keeps the ostream behaviour, which already matches
+// CPython's exponential form for |x| >= 1e16 and |x| < 1e-4.
+static std::string format_float_value(double d)
+{
+  if (std::isfinite(d) && d == std::floor(d) && std::fabs(d) < 1e16)
+  {
+    std::string s = std::to_string(static_cast<long long>(d));
+    if (std::signbit(d) && s[0] != '-') // str(-0.0) == "-0.0"
+      s.insert(s.begin(), '-');
+    return s + ".0";
+  }
+  std::ostringstream oss;
+  oss << d;
+  return oss.str();
+}
+
 static std::string
 format_value_from_json(const nlohmann::json &arg, python_converter &converter)
 {
@@ -131,11 +151,7 @@ format_value_from_json(const nlohmann::json &arg, python_converter &converter)
     if (ov.is_boolean())
       return ov.get<bool>() ? "-1" : "0";
     if (ov.is_number_float())
-    {
-      std::ostringstream oss;
-      oss << -ov.get<double>();
-      return oss.str();
-    }
+      return format_float_value(-ov.get<double>());
   }
   if (arg.contains("_type") && arg["_type"] == "Constant")
   {
@@ -154,26 +170,7 @@ format_value_from_json(const nlohmann::json &arg, python_converter &converter)
     if (arg["value"].is_number_integer())
       return std::to_string(arg["value"].get<long long>());
     if (arg["value"].is_number_float())
-    {
-      const double d = arg["value"].get<double>();
-      // A whole-number float below 1e16 renders in CPython's str() as its
-      // integer digits plus ".0" (str(1.0) == "1.0", str(1000000.0) ==
-      // "1000000.0"). The default ostream format got this wrong: it dropped the
-      // ".0" and switched to exponential at 1e6. Fold that case exactly. Every
-      // other float keeps the prior ostream behaviour, which already matches
-      // CPython's exponential form for |x| >= 1e16 and |x| < 1e-4; a fixed "%f"
-      // would only trade one divergence range for another.
-      if (std::isfinite(d) && d == std::floor(d) && std::fabs(d) < 1e16)
-      {
-        std::string s = std::to_string(static_cast<long long>(d));
-        if (std::signbit(d) && s[0] != '-') // str(-0.0) == "-0.0"
-          s.insert(s.begin(), '-');
-        return s + ".0";
-      }
-      std::ostringstream oss;
-      oss << d;
-      return oss.str();
-    }
+      return format_float_value(arg["value"].get<double>());
     throw std::runtime_error("format() unsupported constant type");
   }
 


### PR DESCRIPTION
An empty `"{}"` replacement field formats a value with `str()`. A negative float literal parses as `UnaryOp(USub, Constant)`, and `format_value_from_json` rendered that case with a raw `std::ostringstream << -value`, whose default 6-significant-digit format drops the `.0` (`-1.0` → `"-1"`) and switches to exponential at 1e6 (`-1000000.0` → `"-1e+06"`).

Consequently the false `assert "{}".format(-1.0) == "-1"` verified **SUCCESSFUL** (a soundness hole), while the valid `== "-1.0"` reported a spurious `FAILED`. PR #5809 fixed exactly this divergence for the *positive* `Constant` branch but never mirrored it onto the negative `UnaryOp` branch; the f-string path (`f"{-1.0}"`) was already correct.

## Fix

Extract the whole-number-float rendering §5809 added into a single `format_float_value(double)` helper and route **both** the positive `Constant` branch and the negative `UnaryOp(USub)` branch through it. A whole-number float with `d == floor(d)` and `|d| < 1e16` renders as its integer digits plus `".0"` (`"{}".format(-1000000.0) == "-1000000.0"`); `std::signbit` re-adds the sign so `"{}".format(-0.0) == "-0.0"`. Every other float keeps the prior `std::ostringstream` behaviour, which already matches CPython's exponential form for `|x| >= 1e16` and `|x| < 1e-4` — deliberately not widened (that trade-off was rejected in the #5809 review).

## Validation

- New CORE regression pair `regression/python/str_format_neg_whole_float{,_fail}`: the positive covers negative whole-number floats (`-1.0`/`-2.0`/`-100.0`/`-1000000.0`/`-0.0`), unchanged negative fractional cases, the still-correct positive case, and a mixed field; the `_fail` pins the previously-false-`SUCCESSFUL` `"{}".format(-1.0) == "-1"` as a real `FAILED`.
- CPython sanity: every positive assertion holds; the `_fail` claim is genuinely false.
- Dual-solver Bitwuzla + Z3 agree on the positive test.
- All 41 existing `fstring`/`format`/`percent`/`repr` regression tests pass unchanged.

Part of the ongoing Python soundness sweep documented in `docs/python-issues-triage-report-2026-06-02.md` (§83).