### PR TITLE
[python] Materialize list(range(N)) for module-constant N

### DIFF
--- a/regression/python/list_range_comp_shadow_fail/main.py
+++ b/regression/python/list_range_comp_shadow_fail/main.py
@@ -1,0 +1,7 @@
+# A module constant N must NOT be folded into a comprehension that rebinds N as
+# its loop variable: here range(N) uses the loop value (0,1,2), so data is
+# [[], [0], [0,1]] and data[0][0] is a genuine IndexError. Folding N->10 would
+# mask this real bug (false VERIFICATION SUCCESSFUL).
+N = 10
+data = [list(range(N)) for N in range(3)]
+x = data[0][0]

--- a/regression/python/list_range_comp_shadow_fail/test.desc
+++ b/regression/python/list_range_comp_shadow_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/list_range_const_var/main.py
+++ b/regression/python/list_range_const_var/main.py
@@ -1,0 +1,16 @@
+# list(range(N)) with a compile-time-constant N must materialise real elements,
+# not the nondet-garbage symbolic list (which raised a false dereference).
+N = 10
+l = list(range(N))
+assert len(l) == 10
+assert l[0] == 0
+assert l[3] == 3
+assert l[9] == 9
+
+# A constant used as range() args in a nested position (list()) and with
+# start/step folds too.
+M = 3
+r = list(range(1, 10, M))
+assert r[0] == 1
+assert r[1] == 4
+assert len(r) == 3

--- a/regression/python/list_range_const_var/test.desc
+++ b/regression/python/list_range_const_var/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_range_const_var_fail/main.py
+++ b/regression/python/list_range_const_var_fail/main.py
@@ -1,0 +1,3 @@
+N = 10
+l = list(range(N))
+assert l[3] == 99  # actual value is 3

--- a/regression/python/list_range_const_var_fail/test.desc
+++ b/regression/python/list_range_const_var_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/module_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/module_rewrite_mixin.py
@@ -188,6 +188,93 @@ class ModuleRewriteMixin:
         """Run the range-alias and range-wrapper rewrites on *module_node*."""
         self._rewrite_range_aliases(module_node, seed=alias_seed)
         self._inline_range_wrappers(module_node, seed=wrapper_seed)
+        self._fold_module_const_range_args(module_node)
+
+    @staticmethod
+    def _int_literal_value(node):
+        """Int value of an integer-literal AST node (or unary +/- of one), else
+        None. Booleans are excluded — ``True``/``False`` are not range sizes."""
+        if isinstance(node, ast.Constant) and isinstance(node.value, int) \
+                and not isinstance(node.value, bool):
+            return node.value
+        if isinstance(node, ast.UnaryOp) and isinstance(node.operand, ast.Constant) \
+                and isinstance(node.operand.value, int) \
+                and not isinstance(node.operand.value, bool):
+            if isinstance(node.op, ast.USub):
+                return -node.operand.value
+            if isinstance(node.op, ast.UAdd):
+                return node.operand.value
+        return None
+
+    def _collect_module_const_ints(self, module_node):
+        """Names bound exactly once, unconditionally at module top level, to an
+        integer literal, and never rebound — genuine module constants.
+
+        ``_rebound_module_names`` already flags names assigned more than once,
+        assigned inside any conditional/loop/``with``, or declared ``global``,
+        so excluding it leaves only names that hold one fixed integer on every
+        path. Comprehension / generator-expression loop targets are a separate
+        local scope that ``_rebound_module_names`` does not see, so they are
+        excluded explicitly: a same-named module constant must never be folded
+        into ``[... range(N) ... for N in ...]``, where ``N`` is the loop
+        variable, not the constant."""
+        rebound = self._rebound_module_names(module_node)
+        # Names bound in a scope/position _rebound_module_names does not track:
+        # comprehension/genexp loop targets (their own local scope) and walrus
+        # (``:=``) targets. A same-named module constant must not be folded into
+        # any of these — the name may hold a different value there.
+        local_binds = set()
+        for node in ast.walk(module_node):
+            if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+                for gen in node.generators:
+                    local_binds |= self._target_names(gen.target)
+            elif isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+                local_binds.add(node.target.id)
+        consts = {}
+        for stmt in module_node.body:
+            if (isinstance(stmt, ast.Assign) and len(stmt.targets) == 1
+                    and isinstance(stmt.targets[0], ast.Name)):
+                name = stmt.targets[0].id
+                value = self._int_literal_value(stmt.value)
+                if (value is not None and name not in rebound and name not in local_binds):
+                    consts[name] = value
+        return consts
+
+    def _fold_module_const_range_args(self, module_node):
+        """Replace module-constant ``Name`` args of ``range()`` calls with their
+        integer literals.
+
+        ``list(range(N))`` with a constant ``N`` otherwise takes the *symbolic*
+        range path, which builds a list whose ``size`` is set but whose elements
+        are nondet garbage — reading/slicing/copying it raises a spurious
+        ``dereference failure`` (an unsound false positive). Folding a genuine
+        constant so the *concrete* range path materialises real elements removes
+        the false alarm. ``_iter_module_scope`` skips any nested function/class
+        scope that locally rebinds the name, so a shadowing parameter/local is
+        never folded to the module constant.
+
+        Only ``list(range(...))`` / ``tuple(range(...))`` — the sequence
+        *materialisation* contexts where the false deref occurs — are folded. A
+        ``range()`` used directly as a ``for`` iterable is left untouched: it
+        never materialises elements, and its lowering models a zero ``step`` as
+        a runtime ``step != 0`` assertion that folding to a literal would turn
+        into a preprocess-time error (regression/python/range23_fail)."""
+        consts = self._collect_module_const_ints(module_node)
+        if not consts:
+            return
+        for n in self._iter_module_scope(module_node, set(consts)):
+            if not (isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                    and n.func.id in ("list", "tuple") and len(n.args) == 1 and not n.keywords):
+                continue
+            inner = n.args[0]
+            if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name)
+                    and inner.func.id == "range" and not inner.keywords):
+                continue
+            for i, arg in enumerate(inner.args):
+                if isinstance(arg, ast.Name) and arg.id in consts:
+                    folded = ast.Constant(value=consts[arg.id])
+                    ast.copy_location(folded, arg)
+                    inner.args[i] = folded
 
     def _rewrite_range_aliases(self, module_node, seed=frozenset()):
         """Rewrite module-scope alias = range (and chains) to canonical range."""


### PR DESCRIPTION
`list(range(N))` where N is a variable took the *symbolic*-range path, which sets the list size but leaves elements as nondet garbage; indexing/slicing/copying then raised a **spurious `dereference failure`** — an unsound false positive on a common idiom (`N=10; l=list(range(N)); l[3]` wrongly reported a bug).

The fix folds `range()`'s Name args to their integer literals so the *concrete* path materializes real elements, but only for a **genuine module constant**: bound once, unconditionally, at module top level, never rebound (`_rebound_module_names`), not shadowed by a nested scope (`_iter_module_scope`), and not a comprehension/genexp/walrus target. Only `list()`/`tuple()`-wrapped ranges are folded — a `range()` used as a for-iterable stays symbolic so a zero `step` is still modelled as a runtime `step != 0` assertion.

Three code-review rounds hardened the soundness gates (conditional-assign, function-param shadow, and comprehension-loop-variable shadow were each caught and fixed). Regression tests: `list_range_const_var` (CORE), `list_range_const_var_fail`, and `list_range_comp_shadow_fail` (pins the comprehension-shadow boundary — folding there would mask a real IndexError). Validated: 49 mopsa + 135 comprehension/range/loop + 105 other python tests pass; ESBMC and CPython agree.

Note: this also makes `regression/mopsa/list_in_loop` emit an honest timeout instead of the previous fast *false* deref (the underlying 1000-element scalability wall keeps it KNOWNBUG).