### PR TITLE
[goto-programs] loop-invariant: under --ir, fall back to BMC for constant-bounded loops with a post-loop check

### DIFF
--- a/regression/loop-invariants/nla_egcd_ir_false/main.c
+++ b/regression/loop-invariants/nla_egcd_ir_false/main.c
@@ -1,0 +1,33 @@
+// Reduced from SV-COMP nla-digbench-scaling/egcd-ll_unwindbound5.c
+// (unreach-call expected_verdict: FALSE -- loop capped at 5 iterations).
+// The three in-loop relations are a genuine mutually-inductive invariant,
+// annotated as __ESBMC_loop_invariant. --loop-invariant-check --ir wrongly
+// reports SUCCESSFUL without this fix.
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *)
+  __attribute__((__nothrow__, __leaf__)) __attribute__((__noreturn__));
+void reach_error() { __assert_fail("0", "egcd.c", 1, "reach_error"); }
+extern int __VERIFIER_nondet_int(void);
+void assume_abort_if_not(int c) { if (!c) abort(); }
+void __VERIFIER_assert(int cond) { if (!cond) { ERROR: {reach_error();} } }
+
+int counter = 0;
+int main() {
+  long long a, b, p, q, r, s;
+  int x = __VERIFIER_nondet_int();
+  int y = __VERIFIER_nondet_int();
+  assume_abort_if_not(x >= 1);
+  assume_abort_if_not(y >= 1);
+  a = x; b = y; p = 1; q = 0; r = 0; s = 1;
+
+  __ESBMC_loop_invariant(1 == p * s - r * q);
+  __ESBMC_loop_invariant(a == y * r + x * p);
+  __ESBMC_loop_invariant(b == x * q + y * s);
+  while (counter++ < 5) {
+    if (!(a != b)) break;
+    if (a > b) { a = a - b; p = p - q; r = r - s; }
+    else       { b = b - a; q = q - p; s = s - r; }
+  }
+  __VERIFIER_assert(a - b == 0);
+  return 0;
+}

--- a/regression/loop-invariants/nla_egcd_ir_false/test.desc
+++ b/regression/loop-invariants/nla_egcd_ir_false/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--loop-invariant-check --ir --z3
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/nla_geo2_ir_true/main.c
+++ b/regression/loop-invariants/nla_geo2_ir_true/main.c
@@ -1,0 +1,26 @@
+// Reduced from SV-COMP nla-digbench-scaling/geo2-ll_unwindbound5.c
+// (unreach-call expected_verdict: TRUE). Constant-bounded loop with a post-loop
+// assertion: this fix skips the summary under --ir, but k-induction/BMC re-proves
+// the small bound, so the correct SUCCESSFUL verdict is preserved (guards against
+// the fix over-approximating away a safe task).
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *)
+  __attribute__((__nothrow__, __leaf__)) __attribute__((__noreturn__));
+void reach_error() { __assert_fail("0", "geo2.c", 1, "reach_error"); }
+extern int __VERIFIER_nondet_int(void);
+void __VERIFIER_assert(int cond) { if (!cond) { ERROR: {reach_error();} } }
+
+int counter = 0;
+int main() {
+  int z = __VERIFIER_nondet_int();
+  int k = __VERIFIER_nondet_int();
+  unsigned long long x = 1, y = 1, c = 1;
+
+  __ESBMC_loop_invariant(1 + x * z - x - z * y == 0);
+  while (counter++ < 5) {
+    if (!(c < k)) break;
+    c = c + 1; x = x * z + 1; y = y * z;
+  }
+  __VERIFIER_assert(1 + x * z - x - z * y == 0);
+  return 0;
+}

--- a/regression/loop-invariants/nla_geo2_ir_true/test.desc
+++ b/regression/loop-invariants/nla_geo2_ir_true/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--loop-invariant-check --ir --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/nla_prodbin_ir_false/main.c
+++ b/regression/loop-invariants/nla_prodbin_ir_false/main.c
@@ -1,0 +1,31 @@
+// Reduced from SV-COMP nla-digbench-scaling/prodbin-ll_unwindbound1.c
+// (unreach-call expected_verdict: FALSE -- the loop is capped at 1 iteration,
+// so z == a*b cannot yet hold and reach_error() is reachable).
+// The in-loop relation z + x*y == a*b is a genuine loop invariant, annotated
+// here as __ESBMC_loop_invariant. Under --loop-invariant-check --ir the loop
+// summary abstracts the iteration cap and (with Int-sort arithmetic) discharges
+// the post-loop assertion -> wrong VERIFICATION SUCCESSFUL without this fix.
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *)
+  __attribute__((__nothrow__, __leaf__)) __attribute__((__noreturn__));
+void reach_error() { __assert_fail("0", "prodbin.c", 1, "reach_error"); }
+extern int __VERIFIER_nondet_int(void);
+void assume_abort_if_not(int c) { if (!c) abort(); }
+void __VERIFIER_assert(int cond) { if (!cond) { ERROR: {reach_error();} } }
+
+int counter = 0;
+int main() {
+  int a = __VERIFIER_nondet_int();
+  int b = __VERIFIER_nondet_int();
+  assume_abort_if_not(b >= 1);
+  long long x = a, y = b, z = 0;
+
+  __ESBMC_loop_invariant(z + x * y == (long long) a * b);
+  while (counter++ < 1) {
+    if (!(y != 0)) break;
+    if (y % 2 == 1) { z = z + x; y = y - 1; }
+    x = 2 * x; y = y / 2;
+  }
+  __VERIFIER_assert(z == (long long) a * b);
+  return 0;
+}

--- a/regression/loop-invariants/nla_prodbin_ir_false/test.desc
+++ b/regression/loop-invariants/nla_prodbin_ir_false/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--loop-invariant-check --ir --z3
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -37,6 +37,7 @@
 #include <util/i2string.h>
 #include <util/std_expr.h>
 #include <util/options.h>
+#include <util/prefix.h>
 #include <irep2/irep2_utils.h>
 #include <map>
 #include <set>
@@ -277,6 +278,13 @@ static bool loop_has_constant_bound(const loopst &loop)
     return false;
   };
 
+  // Instruction addresses in the loop body [head, exit), so an exit branch is
+  // one whose target is not in this set (O(log n) lookup instead of a nested
+  // O(n) scan per branch).
+  std::set<const goto_programt::instructiont *> body;
+  for (goto_programt::targett s = head; s != exit; ++s)
+    body.insert(&*s);
+
   // Walk the loop, tracking copies of monotone counters; at each branch that
   // EXITS the loop, test whether it bounds a counter above by a constant.
   for (goto_programt::targett it = head; it != exit; ++it)
@@ -298,28 +306,15 @@ static bool loop_has_constant_bound(const loopst &loop)
     }
     if (!it->is_goto() || is_nil_expr(it->guard) || is_true(it->guard))
       continue;
-    // Does this branch leave the loop body [head, exit)?
+    // Does this branch leave the loop body [head, exit)?  A target outside the
+    // body set (including the exit instruction itself) is an exit edge.
     bool exits = false;
     for (const goto_programt::targett &tgt : it->targets)
-    {
-      if (tgt == exit)
+      if (!body.count(&*tgt))
       {
         exits = true;
         break;
       }
-      bool inside = false;
-      for (goto_programt::targett s = head; s != exit; ++s)
-        if (s == tgt)
-        {
-          inside = true;
-          break;
-        }
-      if (!inside)
-      {
-        exits = true;
-        break;
-      }
-    }
     if (exits && exits_when_counter_large(it->guard))
       return true;
   }
@@ -349,12 +344,15 @@ loop_has_post_loop_assertion(const loopst &loop, goto_functiont &goto_function)
     const code_function_call2t &call = to_code_function_call2t(ins.code);
     if (!is_symbol2t(call.function))
       return false;
-    const std::string name = id2string(to_symbol2t(call.function).thename);
-    return name.find("__VERIFIER_assert") != std::string::npos ||
-           name.find("reach_error") != std::string::npos ||
-           name.find("__assert_fail") != std::string::npos ||
-           name.find("__VERIFIER_error") != std::string::npos ||
-           name.find("abort") != std::string::npos;
+    // The clang frontend mangles function symbols as "c:@F@<name>"; strip that
+    // prefix and match the base name EXACTLY, so a helper whose name merely
+    // contains a keyword (e.g. assume_abort_if_not contains "abort") is not
+    // mistaken for a property/terminator call.
+    const std::string full = id2string(to_symbol2t(call.function).thename);
+    const std::string name = has_prefix(full, "c:@F@") ? full.substr(5) : full;
+    return name == "__VERIFIER_assert" || name == "reach_error" ||
+           name == "__assert_fail" || name == "__VERIFIER_error" ||
+           name == "abort";
   };
   goto_programt::targett exit = loop.get_original_loop_exit();
   for (goto_programt::targett it = exit;
@@ -391,12 +389,14 @@ void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
   // completeness loss. Gate the skip on the integer encoding.
   const bool int_encoding = config.options.get_bool_option("ir") ||
                             config.options.get_bool_option("ir-ieee");
-  if (int_encoding && loop_has_constant_bound(loop) &&
-      loop_has_post_loop_assertion(loop, goto_function))
+  if (
+    int_encoding && loop_has_constant_bound(loop) &&
+    loop_has_post_loop_assertion(loop, goto_function))
   {
     log_status(
       "loop-invariant: constant-bounded loop with a post-loop property check "
-      "under --ir; skipping the integer-encoding-unsound summary and leaving it "
+      "under --ir; skipping the integer-encoding-unsound summary and leaving "
+      "it "
       "to k-induction/BMC");
     return;
   }

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -39,6 +39,7 @@
 #include <util/options.h>
 #include <irep2/irep2_utils.h>
 #include <map>
+#include <set>
 
 // ---------------------------------------------------------------------------
 // Shared helper: extract the loop invariant near a loop head
@@ -177,6 +178,193 @@ void goto_loop_invariantt::goto_loop_invariant()
   }
 }
 
+/// A *sufficient* syntactic condition that the loop runs a bounded number of
+/// iterations: it contains a monotone counter (a variable whose every body
+/// assignment is `v = v + c` for a positive constant c) and a branch that
+/// LEAVES the loop when that counter -- or a variable just copied from it --
+/// reaches a constant upper bound (`e < K` / `e <= K`). This covers ordinary
+/// for-loops and the SV-COMP `counter++ < N` idiom (increment at the loop head,
+/// guard testing a temporary copy), including a counter shared across nested
+/// loops and loops with extra early-exit `break`s (an early exit only makes the
+/// loop terminate sooner).
+///
+/// For such a loop the loop-invariant SUMMARY (havoc; assume(I && !guard)) is
+/// UNSOUND: it abstracts the iteration cap and proves the *unbounded-completion*
+/// property, producing wrong-TRUE on bounded-FALSE programs (the SV-COMP
+/// *_unwindbound* family). We therefore leave the real loop in place for
+/// k-induction / BMC, whose base case + unwinding assertion decides a bounded
+/// loop soundly. Genuinely unbounded / data-dependent loops are NOT matched
+/// (no constant bound), so their invariant summary -- which is sound there -- is
+/// kept and recovery is preserved.
+static bool loop_has_constant_bound(const loopst &loop)
+{
+  goto_programt::targett head = loop.get_original_loop_head();
+  goto_programt::targett exit = loop.get_original_loop_exit();
+
+  auto pos_const = [](const expr2tc &e) {
+    return is_constant_int2t(e) && to_constant_int2t(e).value.to_int64() > 0;
+  };
+  auto is_pos_inc = [&](const expr2tc &lhs, const expr2tc &rhs) {
+    if (!is_add2t(rhs))
+      return false;
+    const add2t &a = to_add2t(rhs);
+    return (a.side_1 == lhs && pos_const(a.side_2)) ||
+           (a.side_2 == lhs && pos_const(a.side_1));
+  };
+
+  // Pass 1: monotone counters = symbols whose EVERY body assignment is v=v+c
+  // (c>0). Multiple increments are fine (a counter shared across nested loops);
+  // any other assignment (reset, copy) disqualifies the symbol.
+  std::set<irep_idt> candidates, disqualified;
+  for (goto_programt::targett it = head; it != exit; ++it)
+  {
+    if (!it->is_assign())
+      continue;
+    const code_assign2t &as = to_code_assign2t(it->code);
+    if (!is_symbol2t(as.target))
+      continue;
+    const irep_idt name = to_symbol2t(as.target).get_symbol_name();
+    if (is_pos_inc(as.target, as.source))
+      candidates.insert(name);
+    else
+      disqualified.insert(name);
+  }
+  std::set<irep_idt> monotone;
+  for (const irep_idt &n : candidates)
+    if (!disqualified.count(n))
+      monotone.insert(n);
+  if (monotone.empty())
+    return false;
+
+  // Helper: is `name` a monotone counter or a current copy of one?
+  std::set<irep_idt> copies;
+  auto is_counter = [&](const expr2tc &e) {
+    return is_symbol2t(e) &&
+           (monotone.count(to_symbol2t(e).get_symbol_name()) ||
+            copies.count(to_symbol2t(e).get_symbol_name()));
+  };
+  // Helper: does the GOTO-out condition `g` fire when a monotone counter grows
+  // PAST a constant? Handles every encoding ESBMC may produce -- the raw
+  // `!(e < K)` / `!(e <= K)` and the form `--interval-analysis` canonicalises
+  // to, `e >= K` / `e > K` (and the constant-on-the-left mirrors).
+  auto exits_when_counter_large = [&](const expr2tc &guard) -> bool {
+    expr2tc c = guard;
+    bool neg = false;
+    if (is_not2t(c))
+    {
+      c = to_not2t(c).value;
+      neg = true;
+    }
+    int kind; // 0:<  1:<=  2:>  3:>=
+    if (is_lessthan2t(c))
+      kind = 0;
+    else if (is_lessthanequal2t(c))
+      kind = 1;
+    else if (is_greaterthan2t(c))
+      kind = 2;
+    else if (is_greaterthanequal2t(c))
+      kind = 3;
+    else
+      return false;
+    const expr2tc &lhs = *c->get_sub_expr(0);
+    const expr2tc &rhs = *c->get_sub_expr(1);
+    // counter on the left, constant on the right
+    if (is_counter(lhs) && is_constant_int2t(rhs))
+      return neg ? (kind == 0 || kind == 1) : (kind == 2 || kind == 3);
+    // constant on the left, counter on the right (mirrored)
+    if (is_constant_int2t(lhs) && is_counter(rhs))
+      return neg ? (kind == 2 || kind == 3) : (kind == 0 || kind == 1);
+    return false;
+  };
+
+  // Walk the loop, tracking copies of monotone counters; at each branch that
+  // EXITS the loop, test whether it bounds a counter above by a constant.
+  for (goto_programt::targett it = head; it != exit; ++it)
+  {
+    if (it->is_assign())
+    {
+      const code_assign2t &as = to_code_assign2t(it->code);
+      if (is_symbol2t(as.target))
+      {
+        const irep_idt t = to_symbol2t(as.target).get_symbol_name();
+        if (
+          is_symbol2t(as.source) &&
+          monotone.count(to_symbol2t(as.source).get_symbol_name()))
+          copies.insert(t);
+        else
+          copies.erase(t);
+      }
+      continue;
+    }
+    if (!it->is_goto() || is_nil_expr(it->guard) || is_true(it->guard))
+      continue;
+    // Does this branch leave the loop body [head, exit)?
+    bool exits = false;
+    for (const goto_programt::targett &tgt : it->targets)
+    {
+      if (tgt == exit)
+      {
+        exits = true;
+        break;
+      }
+      bool inside = false;
+      for (goto_programt::targett s = head; s != exit; ++s)
+        if (s == tgt)
+        {
+          inside = true;
+          break;
+        }
+      if (!inside)
+      {
+        exits = true;
+        break;
+      }
+    }
+    if (exits && exits_when_counter_large(it->guard))
+      return true;
+  }
+  return false;
+}
+
+// Is there a property check AFTER the loop (between the loop exit and the end of
+// the function)?  The bounded-loop wrong-TRUE risk is specific to such post-loop
+// checks: the summary discharges them against an exit state whose iteration cap
+// has been abstracted away, proving the unbounded-completion version.  When a
+// loop's only checks are IN-loop (re-verified every iteration by the summary's
+// preserve obligation), summarising is sound regardless of the bound.
+//
+// CRUCIAL: at this pass the SV-COMP property is NOT an ASSERT instruction -- it
+// is a FUNCTION_CALL to __VERIFIER_assert / reach_error / __assert_fail /
+// __VERIFIER_error / abort (reach_error's own ASSERT 0 lives in a separate
+// function).  A previous version checked only is_assert() and therefore missed
+// these, summarised bounded-false loops, and reintroduced 26 wrong-TRUE.  So we
+// match both is_assert() and calls to the assertion/error family (by name,
+// conservatively: any hit means "skip", which errs on the sound side).
+static bool
+loop_has_post_loop_assertion(const loopst &loop, goto_functiont &goto_function)
+{
+  auto is_property_call = [](const goto_programt::instructiont &ins) -> bool {
+    if (!ins.is_function_call() || !is_code_function_call2t(ins.code))
+      return false;
+    const code_function_call2t &call = to_code_function_call2t(ins.code);
+    if (!is_symbol2t(call.function))
+      return false;
+    const std::string name = id2string(to_symbol2t(call.function).thename);
+    return name.find("__VERIFIER_assert") != std::string::npos ||
+           name.find("reach_error") != std::string::npos ||
+           name.find("__assert_fail") != std::string::npos ||
+           name.find("__VERIFIER_error") != std::string::npos ||
+           name.find("abort") != std::string::npos;
+  };
+  goto_programt::targett exit = loop.get_original_loop_exit();
+  for (goto_programt::targett it = exit;
+       it != goto_function.body.instructions.end();
+       ++it)
+    if (it->is_assert() || is_property_call(*it))
+      return true;
+  return false;
+}
+
 void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
 {
   // Get current loop head and loop exit
@@ -187,6 +375,31 @@ void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
 
   if (invariants.empty())
     return;
+
+  // Soundness guard: do not summarise a constant-bounded loop that is FOLLOWED
+  // BY A PROPERTY CHECK. The summary abstracts the iteration cap and would prove
+  // the unbounded-completion property (wrong-TRUE on bounded-false tasks) for a
+  // post-loop assertion/error call. Leaving the real loop in place lets
+  // k-induction/BMC decide it soundly. A constant-bounded loop whose only checks
+  // are in-loop is still summarised (the preserve obligation re-checks them every
+  // iteration, so the bound is irrelevant to their soundness).
+  // The summary is only UNSOUND under the integer/real encoding (--ir /
+  // --ir-ieee): with Int-sort arithmetic the abstracted post-state discharges a
+  // post-loop property the real bounded run violates (wrong-TRUE). Under the
+  // default bit-vector encoding the same summary is sound AND is often the only
+  // cheap way to crack a nonlinear bounded loop, so skipping it there is a pure
+  // completeness loss. Gate the skip on the integer encoding.
+  const bool int_encoding = config.options.get_bool_option("ir") ||
+                            config.options.get_bool_option("ir-ieee");
+  if (int_encoding && loop_has_constant_bound(loop) &&
+      loop_has_post_loop_assertion(loop, goto_function))
+  {
+    log_status(
+      "loop-invariant: constant-bounded loop with a post-loop property check "
+      "under --ir; skipping the integer-encoding-unsound summary and leaving it "
+      "to k-induction/BMC");
+    return;
+  }
 
   log_status(
     "Processing {} loop invariant{}",


### PR DESCRIPTION
Fixes #5932.

### Problem

`--loop-invariant-check --ir` can report `VERIFICATION SUCCESSFUL` on a false program. The
root cause is **not** the loop summary itself but the `--ir` (SMT Int-sort) encoding
**certifying an invariant as inductive when it holds only over mathematical integers, not over
machine integers** — the standard `--ir` overflow blind spot.

Concretely, for `nla-digbench-scaling/prodbin-ll_unwindbound1.c` the in-loop relation
`z + x*y == (long long)a*b` (annotated as `__ESBMC_loop_invariant`) is:

- **inductive under `--ir`** — stripping the post-loop property, `--loop-invariant-check --ir`
  reports `SUCCESSFUL` (the inductive step passes); so ESBMC trusts the summary and discharges
  the post-loop `__VERIFIER_assert(z == a*b)` → wrong `SUCCESSFUL`;
- **not inductive under bit-vectors** — plain `--loop-invariant-check` reports
  `Violated property: loop invariant inductive step` (the equality is not preserved once
  `x = 2*x` overflows and `y = y/2` truncates), so ESBMC rejects the invariant and returns
  `FAILED`.

Adding overflow semantics back removes the unsoundness: `--loop-invariant-check --ir
--overflow-check` reports `FAILED`. So this is an integer-encoding soundness gap, orthogonal to
loop bounds.

### What this PR does (a targeted, sound-direction mitigation — not a general fix)

For a **constant-bounded** loop that is **followed by a property check**, under `--ir`, skip the
summary and leave the concrete loop to k-induction/BMC — which unrolls the constant bound and
decides it soundly (no summary, no trusted invariant). This removes the wrong-`SUCCESSFUL` on the
bounded `nla-digbench-scaling *_unwindbound*` family.

- `loop_has_constant_bound(loop)` — sufficient syntactic test: a monotone counter (`v = v + c`,
  c>0, on every body assignment) bounded above by a constant in a loop-exit branch. Handles
  `!(e<K)`/`!(e<=K)`, the `--interval-analysis`-canonical `e>=K`/`e>K` and mirrors, a counter
  shared across nested loops, and extra `break` exits.
- `loop_has_post_loop_assertion(loop, fn)` — a property check (ASSERT, or a call to
  `__VERIFIER_assert`/`reach_error`/`__assert_fail`/`__VERIFIER_error`/`abort`) follows the loop.
  In-loop-only checks are still summarised (re-checked every iteration).
- Gated on `--ir`/`--ir-ieee` only.

### Scope and known limitation

This is deliberately narrow. It does **not** fix the underlying `--ir` invariant-soundness gap; it
only removes the summary for the constant-bounded case, where BMC is a sound fallback. **Unbounded
loops with the same overflow-unsound invariant are still wrong-`SUCCESSFUL` under `--ir` and are
not caught by this PR**, e.g.:

```c
long long x = 1, i = 0;
__ESBMC_loop_invariant(x >= 1);            // inductive over Z, not over machine ints (x wraps < 0)
while (i < n) { x = 2 * x; i = i + 1; }    // n nondet -> not constant-bounded, this PR does not fire
__VERIFIER_assert(x >= 1);                 // false under bit-vectors
```
`--loop-invariant-check --ir` reports `SUCCESSFUL` (wrong) here both before and after this PR;
bit-vectors report `FAILED`.

The **general** fix is to re-check every `--ir` "true" under bit-vector `--overflow-check` (an
overflow gate), which catches both the bounded and unbounded cases. I'm happy to reframe this PR
around that if maintainers prefer a single mechanism; this narrower change is a cheap, sound
fallback for the common bounded case and does not depend on re-solving under a second encoding.

### Why the default (bit-vector) path is unaffected — structurally, not by luck

The skip fires only under `--ir`, so non-`--ir` runs are byte-for-byte unchanged. And bit-vectors
cannot produce this wrong-`SUCCESSFUL` in the first place: (i) a non-machine-inductive invariant is
rejected at the inductive-step assertion (as above), and (ii) for a genuinely inductive invariant
the summary is a sound over-approximation of the reachable exit states, so under a sound solver it
can only cause spurious `FAILED`, never wrong-`SUCCESSFUL`.

### Results / tests

| task (`--loop-invariant-check --ir --z3`) | expected | before | after |
|---|---|---|---|
| `prodbin-ll_unwindbound1` (annot.) | false | `SUCCESSFUL` ✗ | `FAILED` ✓ |
| `egcd-ll_unwindbound5` (annot.) | false | `SUCCESSFUL` ✗ | `FAILED` ✓ |
| `geo2-ll_unwindbound5` (annot.) | true | `SUCCESSFUL` | `SUCCESSFUL` ✓ (skip fires, BMC re-proves) |

Added as `regression/loop-invariants/{nla_prodbin_ir_false, nla_egcd_ir_false, nla_geo2_ir_true}`.

### Note

Under `--ir`, a genuinely safe constant-bounded loop with a post-loop assertion is now decided by
BMC instead of the summary; for a very large bound BMC may not finish in the time budget. The
change does not affect `--validate-correctness-witness` / `--loop-invariant`, which use
`goto_loop_invariant_combined` (concrete loop + k-induction), a different path.