### PR TITLE
[python] Fix false proofs in the heapq operational model

### DIFF
--- a/regression/python/github_5931/main.py
+++ b/regression/python/github_5931/main.py
@@ -1,0 +1,34 @@
+# heapq must be reachable (issue #5931) and must agree with CPython's
+# Lib/heapq.py on the array layout, not merely on "some minimum".
+import heapq
+
+# heapify establishes the invariant: the root is the minimum.
+items: list[int] = [3, 1, 2]
+heapq.heapify(items)
+assert items[0] == 1
+
+# heappop returns the root and preserves the invariant.
+assert heapq.heappop(items) == 1
+assert items[0] == 2
+
+# heappush keeps the smallest at the root.
+heapq.heappush(items, 0)
+assert items[0] == 0
+
+# heappop on a list that is NOT a valid heap returns heap[0], not the
+# minimum. A model that scanned for the minimum would answer 1 here.
+raw: list[int] = [3, 1, 2]
+assert heapq.heappop(raw) == 3
+
+# heapreplace pops the root and pushes item; size is unchanged.
+sized: list[int] = [1, 4, 7]
+assert heapq.heapreplace(sized, 5) == 1
+assert len(sized) == 3
+assert sized[0] == 4
+
+# heappushpop returns item itself when item is no larger than the root.
+assert heapq.heappushpop(sized, 2) == 2
+
+# ...and swaps in item, returning the old root, when item is larger.
+assert heapq.heappushpop(sized, 9) == 4
+assert sized[0] == 5

--- a/regression/python/github_5931/test.desc
+++ b/regression/python/github_5931/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5931_fail/main.py
+++ b/regression/python/github_5931_fail/main.py
@@ -1,0 +1,8 @@
+# Regression for the false proof in issue #5931: the old operational model
+# left heapify() as a no-op, so ESBMC reported VERIFICATION SUCCESSFUL for
+# this program even though CPython raises AssertionError.
+import heapq
+
+items: list[int] = [3, 1, 2]
+heapq.heapify(items)
+assert items[0] == 3

--- a/regression/python/github_5931_fail/test.desc
+++ b/regression/python/github_5931_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 4
+^\[Counterexample\]$
+^VERIFICATION FAILED$

--- a/regression/python/github_5931_float_knownbug/main.py
+++ b/regression/python/github_5931_float_knownbug/main.py
@@ -1,0 +1,17 @@
+# Float heaps are not fully modelled. The frontend types the model's heap
+# elements as int (see models/heapq.py), so heapify() and plain index reads on a
+# float heap are exact, but any value-returning operation (heappop, heapreplace,
+# heappushpop) yields an unconstrained result and heappush() of a float item
+# corrupts the heap. ESBMC therefore reports VERIFICATION FAILED here even
+# though the assertions hold in CPython.
+#
+# This is a loud false alarm, never a false proof: no float program was found
+# for which ESBMC reports SUCCESSFUL while CPython's assertion fails. When float
+# elements are modelled, ESBMC will report SUCCESSFUL, this test will match its
+# expected output, and it should be promoted to CORE.
+import heapq
+
+h: list[float] = [3.5, 1.5, 2.5]
+heapq.heapify(h)
+assert h[0] == 1.5
+assert heapq.heappop(h) == 1.5

--- a/regression/python/github_5931_float_knownbug/test.desc
+++ b/regression/python/github_5931_float_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5931_heappop_fail/main.py
+++ b/regression/python/github_5931_heappop_fail/main.py
@@ -1,0 +1,8 @@
+# Regression for the second false proof in issue #5931: the old model's
+# heappop() scanned for the minimum, but CPython's heappop() returns the
+# root. On a list that is not a valid heap the two disagree, and ESBMC
+# reported VERIFICATION SUCCESSFUL where CPython raises AssertionError.
+import heapq
+
+h: list[int] = [3, 1, 2]
+assert heapq.heappop(h) == 1

--- a/regression/python/github_5931_heappop_fail/test.desc
+++ b/regression/python/github_5931_heappop_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 4
+^\[Counterexample\]$
+^VERIFICATION FAILED$

--- a/regression/python/github_5931_str_knownbug/main.py
+++ b/regression/python/github_5931_str_knownbug/main.py
@@ -1,0 +1,10 @@
+# str elements are not modelled by the Python frontend. ESBMC currently reports
+# VERIFICATION FAILED here (a loud false alarm) even though the assertion holds
+# in CPython. That is sound -- unlike the tuple case, it never yields a false
+# proof -- but it is a real limitation. When str heaps are supported, ESBMC will
+# report SUCCESSFUL, this test will match, and it should be promoted to CORE.
+import heapq
+
+h: list[str] = ["b", "a"]
+heapq.heapify(h)
+assert h[0] == "a"

--- a/regression/python/github_5931_str_knownbug/test.desc
+++ b/regression/python/github_5931_str_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5931_tuple_knownbug_fail/main.py
+++ b/regression/python/github_5931_tuple_knownbug_fail/main.py
@@ -1,0 +1,15 @@
+# Known frontend defect (issue #5931 follow-up): tuple elements in a heap are
+# typed as int by the Python frontend, so the heap layout is modelled wrongly
+# and ESBMC currently reports VERIFICATION SUCCESSFUL for this program even
+# though CPython's heapify() puts (1, 2) at the root and the assertion fails.
+#
+# This reproduces identically against the pre-#5931 heapq model, so it is not a
+# regression introduced by the faithful CPython port. When the frontend learns
+# to type tuple elements, ESBMC will report VERIFICATION FAILED here, this test
+# will start matching its expected output, and it should be promoted to CORE.
+import heapq
+
+h: list = [(1, 5), (1, 2)]
+heapq.heapify(h)
+x = h[0]
+assert x[1] == 5

--- a/regression/python/github_5931_tuple_knownbug_fail/test.desc
+++ b/regression/python/github_5931_tuple_knownbug_fail/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/heapq.py
+++ b/src/python-frontend/models/heapq.py
@@ -1,40 +1,103 @@
-# pylint: disable=unused-argument,useless-return,unidiomatic-typecheck
-# Operational-model stubs for heapq. Argument names on heapify (whose
-# body is intentionally abstract) are part of the API contract matched
-# by ESBMC's converter. The explicit `return None` keeps the function's
-# return-type analysis aligned with the `-> None` annotation. The
-# `type(item) is tuple` test is intentional: in a closed-world FV model
-# the strict identity check is more correct than isinstance(), which
-# would also accept tuple subclasses with potentially different
-# semantics under verification.
-from typing import Any
+# Operational model for heapq, ported from CPython's Lib/heapq.py.
+#
+# The sift routines reproduce CPython's array layout element-for-element, so
+# heap[0], the pop order and tie-breaking all agree with the reference
+# implementation for any input list -- including lists that do not satisfy the
+# heap invariant. A model that merely scanned for the minimum would be unsound:
+# heappop() returns heap[0], which is the minimum only once the invariant
+# holds, and the invariant cannot be checked statically.
+#
+# The element type must be spelled out: without one the frontend infers elements
+# to be lists and mis-compares them, and `list[Any]` makes index assignment
+# through an imported module report a spurious violation. Hence `list[int]`.
+#
+# Only int elements are fully modelled.
+#   float: sound but loud. heapify() and index reads are exact, while the
+#     value-returning operations return an unconstrained result, so ESBMC
+#     reports FAILED on assertions that hold in CPython. No float program was
+#     found for which ESBMC reports SUCCESSFUL while CPython's assertion fails.
+#     Pinned by regression/python/github_5931_float_knownbug.
+#   str: sound but loud, in both directions. Pinned by github_5931_str_knownbug.
+#   tuple: UNSOUND. The frontend types tuple elements as int, so the heap layout
+#     comes out wrong and ESBMC can report SUCCESSFUL on a program CPython
+#     rejects. This is a pre-existing frontend defect, not a property of this
+#     model -- it reproduces identically against the previous model. Pinned by
+#     github_5931_tuple_knownbug_fail.
 
 
-def _heap_key(item: Any):
-    if type(item) is tuple:
-        return item[0]
+def _siftdown(heap: list[int], startpos: int, pos: int) -> None:
+    """Move heap[pos] toward startpos until its parent is no larger."""
+    newitem = heap[pos]
+    while pos > startpos:
+        parentpos = (pos - 1) // 2
+        parent = heap[parentpos]
+        if newitem < parent:
+            heap[pos] = parent
+            pos = parentpos
+        else:
+            break
+    heap[pos] = newitem
+
+
+def _siftup(heap: list[int], pos: int) -> None:
+    """Bubble the smaller child up to heap[pos], then sift the oddball down."""
+    endpos = len(heap)
+    startpos = pos
+    newitem = heap[pos]
+    childpos = 2 * pos + 1
+    while childpos < endpos:
+        rightpos = childpos + 1
+        if rightpos < endpos:
+            left = heap[childpos]
+            right = heap[rightpos]
+            if not left < right:
+                childpos = rightpos
+        heap[pos] = heap[childpos]
+        pos = childpos
+        childpos = 2 * pos + 1
+    heap[pos] = newitem
+    _siftdown(heap, startpos, pos)
+
+
+def heapify(heap: list[int]) -> None:
+    """Transform the list into a heap, in-place."""
+    i = len(heap) // 2 - 1
+    while i >= 0:
+        _siftup(heap, i)
+        i = i - 1
+
+
+def heappush(heap: list[int], item: int) -> None:
+    """Push item onto the heap, maintaining the heap invariant."""
+    heap.append(item)
+    _siftdown(heap, 0, len(heap) - 1)
+
+
+def heappop(heap: list[int]) -> int:
+    """Pop and return the smallest item, maintaining the heap invariant."""
+    lastelt = heap.pop()
+    if len(heap) == 0:
+        return lastelt
+    returnitem = heap[0]
+    heap[0] = lastelt
+    _siftup(heap, 0)
+    return returnitem
+
+
+def heapreplace(heap: list[int], item: int) -> int:
+    """Pop and return the smallest item, then push item; heap size is unchanged."""
+    returnitem = heap[0]
+    heap[0] = item
+    _siftup(heap, 0)
+    return returnitem
+
+
+def heappushpop(heap: list[int], item: int) -> int:
+    """Push item on the heap, then pop and return the smallest item."""
+    if len(heap) > 0:
+        smallest = heap[0]
+        if smallest < item:
+            heap[0] = item
+            _siftup(heap, 0)
+            return smallest
     return item
-
-
-def heapify(heap: list[Any]) -> None:
-    return None
-
-
-def heappush(heap: list[Any], item: Any) -> None:
-    heap.append(item)
-    return None
-
-
-def heappop(heap: list[Any]) -> Any:
-    best_index = 0
-    i = 1
-    while i < len(heap):
-        if _heap_key(heap[i]) < _heap_key(heap[best_index]):
-            best_index = i
-        i = i + 1
-    return heap.pop(best_index)
-
-
-def heappushpop(heap: list[Any], item: Any) -> Any:
-    heap.append(item)
-    return heappop(heap)

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -109,6 +109,7 @@ def _is_imported_model(module_name: str) -> bool:
         "decimal",
         "collections",
         "dataclasses",
+        "heapq",
         "typing",
         "time",
         "threading",


### PR DESCRIPTION
`models/heapq.py` left `heapify()` a no-op and made `heappop()` scan for the minimum, so ESBMC proved `heapify([3,1,2]); h[0]==3` and `heappop([3,1,2])==1`, both of which CPython rejects with an `AssertionError`.

This ports CPython's `Lib/heapq.py` faithfully so the array layout, pop order and tie-breaking agree for any input list, and adds `heapreplace()`. Both false proofs are now pinned by regression tests; `tuple` elements remain unsound because the frontend types them as `int`, a pre-existing defect pinned as a KNOWNBUG.

Fixes #5931
