### PR TITLE
[python] Fold repr() of a bare int or float to str(value)

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -3996,3 +3996,51 @@ a false `SUCCESSFUL`**): the `format()` builtin with a negative float and an emp
 `repr()` of a bare float/int still does not fold. The §3 design-level blockers, §3c policy-banned
 timeouts, §3d questionable expectation, and the infeasible `hashlib` case all stand. The §5 priority
 order stands.
+
+## 85. 2026-07-09 re-validation (seventy-fifth sweep) & repr() of a bare int/float
+
+Re-test against current `master`. KNOWNBUG classification unchanged — §3 holds. This sweep takes the
+second §83b/§84b-named follow-up (the sibling of the §84 `format()` empty-spec float sweep): `repr()`
+of a bare int or float did not fold.
+
+### 85a. Feature restored: `repr(<int>)` / `repr(<float>)` folds to `str(value)`
+
+**`repr(5)` / `repr(1.0)` (and any bare int/float) hit the general-call handler
+(`WARNING: Undefined function 'repr' - replacing with assert(false)`), so a program using them reported
+a spurious `FAILED` instead of folding to `"5"` / `"1.0"`.**
+
+The `repr()` dispatch-table entry (`src/python-frontend/function_call/expr.cpp`) folded only the
+`complex` case and delegated everything else — including bare ints and floats — to
+`handle_general_function_call`, which treats `repr` as an undefined user function. `str()` of the same
+value already folded (via the builtin-type-constructor entry → `build_constant_from_arg` /
+`convert_to_string`); only the `repr()` side was missing. For an int or a float
+`repr(x) == str(x)` in Python (only `str`/container/object reprs differ — `repr("x")` adds quotes,
+`repr(True)` is `"True"`), so the numeric case can reuse the exact `str()` folding.
+
+**Fix**: in the `repr()` action, after the `complex` check, route an int- or float-typed operand
+through `converter_.get_string_handler().convert_to_string(value_expr)` — the same helper `str()`'s
+numeric path uses, which folds a constant to a char-array literal and dispatches a non-constant to the
+matching `__python_*_to_str` runtime model. The gate excludes `bool` and every non-numeric type
+(`!vt.is_bool() && (is_integer_type(vt) || vt.is_floatbv())`), so `repr` of a string, bool, list or
+object keeps the general-call fallback — a clean error, never a wrong fold. This restores working
+behaviour and cannot introduce a false `SUCCESSFUL` (an unmodelled `repr` still errors). Because it
+delegates to the shared `str()` renderer, it inherits — and adds no new instance of — `str()`'s known
+float gap (>6 fractional digits / scientific notation), which remains the §80 follow-up.
+
+New regression pair `regression/python/builtin_repr_int_float{,_fail}` (CORE): the positive is the
+liveness witness for the new branch, covering int literals (positive/negative/zero/large), whole and
+dyadic-fractional float literals (`repr(1.0)` keeps `"1.0"`, `repr(-0.125)`), a non-constant int that
+exercises the runtime `__python_*_to_str` path (`repr(x) == "42"`), and `repr(x) == str(x)`
+consistency; the `_fail` pins the previously-erroring `repr(-1.0) == "-1"`, now correctly `FAILED`.
+Every positive assertion was differential-tested bit-for-bit against CPython (`repr(v) == str(v)` for
+all cited ints and floats); the focused `repr`/`str`/`format`/`fstring`/`percent` ctest subset
+(168 tests) passes 100%. The constant folds are solver-agnostic; the non-constant `repr(x)` case
+lowers to the same runtime model as `str(x)`.
+
+### 85b. Next candidate & everything else: unchanged disposition
+With both §84b candidates now closed (`format()` empty-spec float in §84 / PR, `repr()` int/float
+here), the natural next sweep is a fresh idiom battery against `master` to surface the next isolated,
+soundly-fixable defect (`repr` of a **string** — needing quote-wrapping and escaping — and `repr` of a
+`bool`/`None` remain deliberately out of scope: each is a clean error, never a false `SUCCESSFUL`). The
+§3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the infeasible
+`hashlib` case all stand. The §5 priority order stands.

--- a/regression/python/builtin_repr_int_float/main.py
+++ b/regression/python/builtin_repr_int_float/main.py
@@ -1,0 +1,36 @@
+def main() -> None:
+    # repr() of an int or a float previously routed to the general-call handler
+    # ("Undefined function 'repr'"). It now folds to str(value), since
+    # repr(x) == str(x) for ints and floats in Python (only str/container/object
+    # reprs differ). str() already folded these; this closes the repr() side.
+
+    # Integer literals (positive, negative, zero, large).
+    assert repr(5) == "5"
+    assert repr(-5) == "-5"
+    assert repr(0) == "0"
+    assert repr(1000000) == "1000000"
+    assert repr(-1000000) == "-1000000"
+
+    # Float literals: whole-number floats keep CPython's ".0" suffix.
+    assert repr(1.0) == "1.0"
+    assert repr(-1.0) == "-1.0"
+    assert repr(0.0) == "0.0"
+    assert repr(100.0) == "100.0"
+    assert repr(-1000000.0) == "-1000000.0"
+    # Fractional floats (exactly-representable dyadic values for stability).
+    assert repr(1.5) == "1.5"
+    assert repr(-2.5) == "-2.5"
+    assert repr(0.25) == "0.25"
+    assert repr(-0.125) == "-0.125"
+
+    # A non-constant int routes to the runtime model, matching str(x).
+    x: int = 40
+    x = x + 2
+    assert repr(x) == "42"
+
+    # repr(x) is str(x) for numbers.
+    assert repr(7) == str(7)
+    assert repr(3.5) == str(3.5)
+
+
+main()

--- a/regression/python/builtin_repr_int_float/test.desc
+++ b/regression/python/builtin_repr_int_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/builtin_repr_int_float_fail/main.py
+++ b/regression/python/builtin_repr_int_float_fail/main.py
@@ -1,0 +1,9 @@
+def main() -> None:
+    # repr() of a float now folds to str(value), so this false assertion is a
+    # real FAILED: repr(-1.0) is "-1.0", not "-1". Pre-fix repr() of a number
+    # routed to the general-call handler ("Undefined function 'repr'") rather
+    # than folding at all.
+    assert repr(-1.0) == "-1"
+
+
+main()

--- a/regression/python/builtin_repr_int_float_fail/test.desc
+++ b/regression/python/builtin_repr_int_float_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -3597,10 +3597,23 @@ function_call_expr::get_dispatch_table()
            format_complex_string(real_val, imag_val));
        }
        exprt value_expr = converter_.get_expr(arg);
-       if (
-         !value_expr.is_nil() && value_expr.statement() != "cpp-throw" &&
-         is_complex_type(value_expr.type()))
-         return handle_complex_to_str();
+       if (!value_expr.is_nil() && value_expr.statement() != "cpp-throw")
+       {
+         if (is_complex_type(value_expr.type()))
+           return handle_complex_to_str();
+         // repr(x) == str(x) for an int or a float (only str/container/object
+         // reprs differ from str), so reuse str()'s numeric folding via
+         // convert_to_string: it folds a constant to a char-array literal and
+         // dispatches a non-constant to the matching __python_*_to_str model.
+         // Bool, strings and everything else keep the general-call fallback
+         // (repr(True) is "True", repr("x") adds quotes) — a clean error, never
+         // a wrong fold.
+         const typet &vt = value_expr.type();
+         if (
+           !vt.is_bool() &&
+           (type_utils::is_integer_type(vt) || vt.is_floatbv()))
+           return converter_.get_string_handler().convert_to_string(value_expr);
+       }
        return handle_general_function_call();
      },
      "repr()"},


### PR DESCRIPTION
## What

`repr()` of a bare int or float did not fold: `repr(5)` / `repr(1.0)` hit the general-call handler (`WARNING: Undefined function 'repr' - replacing with assert(false)`), so any program using them reported a spurious `FAILED` instead of folding to `"5"` / `"1.0"`. `str()` of the same value already folded — only the `repr()` side was missing.

For an int or a float, `repr(x) == str(x)` in Python (only `str`/container/object reprs differ — `repr("x")` adds quotes, `repr(True)` is `"True"`), so the numeric case can reuse the exact `str()` folding.

## How

In the `repr()` dispatch-table entry (`src/python-frontend/function_call/expr.cpp`), after the `complex` check, route an int- or float-typed operand through `convert_to_string` — the same helper `str()`'s numeric path already uses (folds a constant to a char-array literal, dispatches a non-constant to the matching `__python_*_to_str` runtime model). The gate is `!vt.is_bool() && (is_integer_type(vt) || vt.is_floatbv())`, so `repr` of a string, bool, list or object keeps the clean general-call fallback — a clean error, never a wrong fold.

This restores working behaviour and cannot introduce a false `SUCCESSFUL` (an unmodelled `repr` still errors). It shares the `str()` renderer, so it introduces no new divergence beyond `str()`'s known float gap (>6 fractional digits / scientific notation), tracked separately.

## Tests

New regression pair (CORE), both included:
- `regression/python/builtin_repr_int_float` — liveness witness: int literals (±, zero, large), whole/dyadic-fractional float literals (`repr(1.0)`→`"1.0"`, `repr(-0.125)`), a **non-constant** int exercising the runtime `__python_*_to_str` path (`repr(x)==\"42\"`), and `repr(x)==str(x)` consistency.
- `regression/python/builtin_repr_int_float_fail` — pins the previously-erroring `repr(-1.0) == "-1"`, now correctly `FAILED`.

Every positive assertion was differential-tested against CPython (`repr(v)==str(v)` for all cited numbers). The focused `repr`/`str`/`format`/`fstring`/`percent` ctest subset (168 tests) passes 100%.

Companion to the `format()` empty-spec float sweep (documented as §84); this closes the second deferred candidate in `docs/python-issues-triage-report-2026-06-02.md` §84b (documented as §85). Independent of that PR (touches `expr.cpp`, not `str_conv.cpp`).