### PR TITLE
[python] V.1k(b) B.4: enforce post-adjust member/index resolution

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3570,6 +3570,31 @@ across the `clang_cpp_adjust` boundary, because that boundary cannot be half-cro
 relaxed asserts (`member2t`/`index2t`/`constant_struct2t` for `symbol_id`) remain the
 correct foundation for that combined effort.
 
+#### B.4 post-adjust exit invariant — landed ahead of the collapsed milestone (2026-07-10)
+
+The one piece of B.4 that *is* separable from the collapsed B.3/B.4/B.5 milestone
+above landed on its own: the **post-adjust strong-invariant exit check**.
+`python_adjust::adjust()` now walks each resolved body via a recursive
+`has_unresolved_source` probe and, if any `member2t`/`index2t` source survived
+resolution as a transient `symbol_type2t` (e.g. one that follows to a
+non-aggregate scalar rather than a struct/array), `log_error`s naming the symbol
+and returns `true` (error) instead of the previous unconditional `false`. This
+re-enforces, at pass exit, exactly the strong source invariant the V.1k relaxed
+construction assert deferred.
+
+Crucially this does **not** cross the `clang_cpp_adjust` boundary the milestone
+above cannot half-cross: it only *verifies* the pass's own output, it does not
+move or replace `clang_cpp_adjust`. On the live pipeline the pass runs *after*
+`clang_cpp_adjust`, which resolves every source, so the check never fires — the
+pass stays inert (flag off ⇒ not run at all; flag on ⇒ 7/7 `python_irep2_adjust_*`
+fixture tests green, 0 divergences with the check active). It is a
+**dead-but-tested safety net** that deterministically catches a B.5-era
+resolution bug once the pass becomes the sole resolver. Unit-tested both ways
+(`unit/python-frontend/python_adjust_test.cpp`): a resolved-struct body ⇒
+`adjust()` returns `false`; a scalar-following survivor ⇒ `adjust()` returns
+`true`. The B.5 combined-milestone framing is unchanged; this only pins the exit
+contract that milestone must satisfy.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,6 +1,7 @@
 #include <python-frontend/python_adjust.h>
 
 #include <irep2/irep2_utils.h>
+#include <util/message.h>
 #include <vector>
 
 python_adjust::python_adjust(contextt &_context)
@@ -16,6 +17,7 @@ bool python_adjust::adjust()
   context.Foreach_operand_in_order(
     [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
 
+  bool error = false;
   for (symbolt *symbol : symbol_list)
   {
     if (symbol->is_type)
@@ -42,9 +44,25 @@ bool python_adjust::adjust()
     // symbol_type member sources.
     if (value != original)
       symbol->set_value(value);
+
+    // Post-adjust strong invariant (V.1k B.4): re-enforce what the relaxed
+    // member2t/index2t construction assert deferred — no member/index source may
+    // survive as a transient symbol_type2t. On the live pipeline this pass runs
+    // after clang_cpp_adjust, which already resolves every source, so the check
+    // never fires and the pass stays inert; it is a dead-but-tested safety net
+    // that deterministically catches a B.5-era resolution bug once the pass
+    // replaces clang_cpp_adjust and becomes the sole resolver.
+    if (has_unresolved_source(value))
+    {
+      log_error(
+        "python_adjust: symbol `{}' retains an unresolved member/index source "
+        "after adjust (V.1k post-adjust invariant violated)",
+        symbol->id.as_string());
+      error = true;
+    }
   }
 
-  return false;
+  return error;
 }
 
 namespace
@@ -110,4 +128,25 @@ bool python_adjust::resolve_source(expr2tc &source)
 
   source = source->with_type(resolved);
   return true;
+}
+
+bool python_adjust::has_unresolved_source(const expr2tc &expr) const
+{
+  if (is_nil_expr(expr))
+    return false;
+
+  // A member/index whose source type is still a symbol_type2t is unresolved:
+  // resolve_source could not follow it to a concrete aggregate (e.g. it follows
+  // to a non-aggregate scalar), so the strong construction invariant is unmet.
+  if (is_member2t(expr) && is_symbol_type(to_member2t(expr).source_value->type))
+    return true;
+  if (is_index2t(expr) && is_symbol_type(to_index2t(expr).source_value->type))
+    return true;
+
+  bool found = false;
+  expr->foreach_operand([this, &found](const expr2tc &e) {
+    if (has_unresolved_source(e))
+      found = true;
+  });
+  return found;
 }

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -26,8 +26,10 @@ class python_adjust
 public:
   explicit python_adjust(contextt &_context);
 
-  /// Walk every non-type symbol's IREP2 value. Returns false on success,
-  /// mirroring `clang_c_adjust::adjust()`.
+  /// Walk every non-type symbol's IREP2 value. Returns true on error —
+  /// specifically if the post-adjust strong invariant is violated (a
+  /// member2t/index2t source still carries an unresolved `symbol_type2t` after
+  /// resolution); false on success, mirroring `clang_c_adjust::adjust()`.
   bool adjust();
 
   /// Recursively visit `expr` and its sub-expressions, resolving transient
@@ -47,4 +49,10 @@ protected:
   /// `pointer→tag-Cls` instance pointer — both arrive as a symbol_type2t source,
   /// since a member/index cannot be constructed over a raw pointer.
   bool resolve_source(expr2tc &source);
+
+  /// Post-adjust strong-invariant probe (V.1k B.4): true if any `member2t` or
+  /// `index2t` reachable from `expr` still has a `symbol_type2t` source — a
+  /// source the pass could not resolve to an aggregate (e.g. one that follows to
+  /// a non-aggregate scalar). Recursive.
+  bool has_unresolved_source(const expr2tc &expr) const;
 };

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -378,3 +378,31 @@ TEST_CASE(
   // The body must remain nil — adjust() neither materialises nor rewrites it.
   REQUIRE(is_nil_expr(ctx.find_symbol("py_adjust_code_nil_sym")->get_value2()));
 }
+
+TEST_CASE(
+  "python_adjust B.4 adjust() flags an unresolved member source post-adjust",
+  "[python-adjust]")
+{
+  // A code body reads `obj.x` where obj's tag follows to a scalar (tag-Scalar ->
+  // int): resolve_source must NOT retype the source to a non-aggregate, so the
+  // transient symbol_type2t source survives adjust. The post-adjust
+  // strong-invariant check catches the survivor and adjust() returns true
+  // (error) — the negative of the resolved-struct case above, which returns
+  // false. This is the B.5-era mis-resolution the safety net exists to catch.
+  contextt ctx;
+  symbolt scalar_type_sym;
+  scalar_type_sym.id = scalar_type_sym.name = "tag-Scalar";
+  scalar_type_sym.mode = "Python";
+  scalar_type_sym.is_type = true;
+  scalar_type_sym.set_type(get_int32_type());
+  ctx.add(scalar_type_sym);
+
+  const expr2tc source = symbol2tc(symbol_type2tc("tag-Scalar"), "obj");
+  const expr2tc member = member2tc(get_int32_type(), source, "x");
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(member)});
+  add_code_symbol(ctx, "py_adjust_unresolved_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE(adjuster.adjust());
+}


### PR DESCRIPTION
## What

Adds the **post-adjust strong-invariant exit check** to the IREP2-native Python adjuster (`python_adjust`). After resolving each code body, `adjust()` probes the tree via a new recursive `has_unresolved_source` and, if any `member2t`/`index2t` source survived resolution as a transient `symbol_type2t` (e.g. one that follows to a non-aggregate scalar rather than a struct/array), it `log_error`s naming the symbol and returns `true` (error) instead of the previous unconditional `false`. This re-enforces, at pass exit, the strong source invariant the V.1k relaxed `member2t`/`index2t` construction assert deferred.

## Why

This is the one piece of B.4 that is **separable** from the collapsed B.3/B.4/B.5 milestone (a complete IREP2-native adjuster supplanting `clang_cpp_adjust`, per #5623/#5654). It only *verifies* the pass's own output — it does **not** move or replace `clang_cpp_adjust`, so it never crosses the boundary that "cannot be half-crossed" (two resolvers over the same nodes is unsound).

On the live pipeline the pass runs *after* `clang_cpp_adjust`, which resolves every source, so the check never fires and the pass stays inert. It is a **dead-but-tested safety net** that deterministically catches a B.5-era resolution bug once the pass becomes the sole resolver — pinning the exit contract that milestone must satisfy. See `docs/irep2-migration.md` → "B.4 post-adjust exit invariant".

## Validation

- **Unit** (`python_adjust_test`): 13/13 pass. New case drives the branch red→green — a resolved-struct body ⇒ `adjust()` returns `false`; a scalar-following survivor ⇒ `adjust()` returns `true`.
- **Flag-on fixtures**: `python_irep2_adjust_*` 7/7 green, 0 divergences with the check active (inert on the live pipeline).
- Flag off (default) ⇒ the pass is not run at all; behaviour byte-identical.
- `clang-format` clean; `esbmc` builds.

## Regression tests

- Passing: the resolved-struct unit case (`adjust()` returns `false`) + the 7 flag-on `python_irep2_adjust_*` fixtures.
- Failing (invariant-violation): the new scalar-following survivor unit case (`adjust()` returns `true`), which would silently pass before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)