### PR TITLE
[python] V.1k(b) B.4: cover constant_struct2t in post-adjust invariant

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3575,23 +3575,27 @@ correct foundation for that combined effort.
 The one piece of B.4 that *is* separable from the collapsed B.3/B.4/B.5 milestone
 above landed on its own: the **post-adjust strong-invariant exit check**.
 `python_adjust::adjust()` now walks each resolved body via a recursive
-`has_unresolved_source` probe and, if any `member2t`/`index2t` source survived
-resolution as a transient `symbol_type2t` (e.g. one that follows to a
-non-aggregate scalar rather than a struct/array), `log_error`s naming the symbol
-and returns `true` (error) instead of the previous unconditional `false`. This
-re-enforces, at pass exit, exactly the strong source invariant the V.1k relaxed
-construction assert deferred.
+`has_unresolved_source` probe and, if any node still carries a transient
+`symbol_type2t` the pass could not resolve, `log_error`s naming the symbol and
+returns `true` (error) instead of the previous unconditional `false`. The probe
+covers **all three relaxed construction asserts** (`irep2_expr.h`): a
+`member2t`/`index2t` source that follows to a non-aggregate rather than a
+struct/array, **and** a `constant_struct2t` whose own type is still a by-name
+`symbol_type2t` (the aggregate-literal assert the B.2 wiring relaxed). This
+re-enforces, at pass exit, exactly the strong invariant those relaxed asserts
+deferred.
 
 Crucially this does **not** cross the `clang_cpp_adjust` boundary the milestone
 above cannot half-cross: it only *verifies* the pass's own output, it does not
 move or replace `clang_cpp_adjust`. On the live pipeline the pass runs *after*
-`clang_cpp_adjust`, which resolves every source, so the check never fires — the
-pass stays inert (flag off ⇒ not run at all; flag on ⇒ 7/7 `python_irep2_adjust_*`
-fixture tests green, 0 divergences with the check active). It is a
-**dead-but-tested safety net** that deterministically catches a B.5-era
-resolution bug once the pass becomes the sole resolver. Unit-tested both ways
-(`unit/python-frontend/python_adjust_test.cpp`): a resolved-struct body ⇒
-`adjust()` returns `false`; a scalar-following survivor ⇒ `adjust()` returns
+`clang_cpp_adjust`, which resolves every by-name aggregate, so the check never
+fires — the pass stays inert (flag off ⇒ not run at all; flag on ⇒ 7/7
+`python_irep2_adjust_*` fixture tests green, 0 divergences with the full
+three-assert check active). It is a **dead-but-tested safety net** that
+deterministically catches a B.5-era resolution bug once the pass becomes the sole
+resolver. Unit-tested each way (`unit/python-frontend/python_adjust_test.cpp`): a
+resolved-struct body ⇒ `adjust()` returns `false`; a scalar-following member
+survivor and a by-name `constant_struct2t` survivor each ⇒ `adjust()` returns
 `true`. The B.5 combined-milestone framing is unchanged; this only pins the exit
 contract that milestone must satisfy.
 

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3570,6 +3570,31 @@ across the `clang_cpp_adjust` boundary, because that boundary cannot be half-cro
 relaxed asserts (`member2t`/`index2t`/`constant_struct2t` for `symbol_id`) remain the
 correct foundation for that combined effort.
 
+#### B.4 post-adjust exit invariant — landed ahead of the collapsed milestone (2026-07-10)
+
+The one piece of B.4 that *is* separable from the collapsed B.3/B.4/B.5 milestone
+above landed on its own: the **post-adjust strong-invariant exit check**.
+`python_adjust::adjust()` now walks each resolved body via a recursive
+`has_unresolved_source` probe and, if any `member2t`/`index2t` source survived
+resolution as a transient `symbol_type2t` (e.g. one that follows to a
+non-aggregate scalar rather than a struct/array), `log_error`s naming the symbol
+and returns `true` (error) instead of the previous unconditional `false`. This
+re-enforces, at pass exit, exactly the strong source invariant the V.1k relaxed
+construction assert deferred.
+
+Crucially this does **not** cross the `clang_cpp_adjust` boundary the milestone
+above cannot half-cross: it only *verifies* the pass's own output, it does not
+move or replace `clang_cpp_adjust`. On the live pipeline the pass runs *after*
+`clang_cpp_adjust`, which resolves every source, so the check never fires — the
+pass stays inert (flag off ⇒ not run at all; flag on ⇒ 7/7 `python_irep2_adjust_*`
+fixture tests green, 0 divergences with the check active). It is a
+**dead-but-tested safety net** that deterministically catches a B.5-era
+resolution bug once the pass becomes the sole resolver. Unit-tested both ways
+(`unit/python-frontend/python_adjust_test.cpp`): a resolved-struct body ⇒
+`adjust()` returns `false`; a scalar-following survivor ⇒ `adjust()` returns
+`true`. The B.5 combined-milestone framing is unchanged; this only pins the exit
+contract that milestone must satisfy.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,6 +1,7 @@
 #include <python-frontend/python_adjust.h>
 
 #include <irep2/irep2_utils.h>
+#include <util/message.h>
 #include <vector>
 
 python_adjust::python_adjust(contextt &_context)
@@ -16,6 +17,7 @@ bool python_adjust::adjust()
   context.Foreach_operand_in_order(
     [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
 
+  bool error = false;
   for (symbolt *symbol : symbol_list)
   {
     if (symbol->is_type)
@@ -42,9 +44,25 @@ bool python_adjust::adjust()
     // symbol_type member sources.
     if (value != original)
       symbol->set_value(value);
+
+    // Post-adjust strong invariant (V.1k B.4): re-enforce what the relaxed
+    // member2t/index2t construction assert deferred — no member/index source may
+    // survive as a transient symbol_type2t. On the live pipeline this pass runs
+    // after clang_cpp_adjust, which already resolves every source, so the check
+    // never fires and the pass stays inert; it is a dead-but-tested safety net
+    // that deterministically catches a B.5-era resolution bug once the pass
+    // replaces clang_cpp_adjust and becomes the sole resolver.
+    if (has_unresolved_source(value))
+    {
+      log_error(
+        "python_adjust: symbol `{}' retains an unresolved member/index source "
+        "after adjust (V.1k post-adjust invariant violated)",
+        symbol->id.as_string());
+      error = true;
+    }
   }
 
-  return false;
+  return error;
 }
 
 namespace
@@ -110,4 +128,25 @@ bool python_adjust::resolve_source(expr2tc &source)
 
   source = source->with_type(resolved);
   return true;
+}
+
+bool python_adjust::has_unresolved_source(const expr2tc &expr) const
+{
+  if (is_nil_expr(expr))
+    return false;
+
+  // A member/index whose source type is still a symbol_type2t is unresolved:
+  // resolve_source could not follow it to a concrete aggregate (e.g. it follows
+  // to a non-aggregate scalar), so the strong construction invariant is unmet.
+  if (is_member2t(expr) && is_symbol_type(to_member2t(expr).source_value->type))
+    return true;
+  if (is_index2t(expr) && is_symbol_type(to_index2t(expr).source_value->type))
+    return true;
+
+  bool found = false;
+  expr->foreach_operand([this, &found](const expr2tc &e) {
+    if (has_unresolved_source(e))
+      found = true;
+  });
+  return found;
 }

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -45,18 +45,20 @@ bool python_adjust::adjust()
     if (value != original)
       symbol->set_value(value);
 
-    // Post-adjust strong invariant (V.1k B.4): re-enforce what the relaxed
-    // member2t/index2t construction assert deferred — no member/index source may
-    // survive as a transient symbol_type2t. On the live pipeline this pass runs
-    // after clang_cpp_adjust, which already resolves every source, so the check
-    // never fires and the pass stays inert; it is a dead-but-tested safety net
-    // that deterministically catches a B.5-era resolution bug once the pass
-    // replaces clang_cpp_adjust and becomes the sole resolver.
+    // Post-adjust strong invariant (V.1k B.4): re-enforce what the three relaxed
+    // construction asserts deferred — no member2t/index2t source and no
+    // constant_struct2t type may survive as a transient symbol_type2t. On the
+    // live pipeline this pass runs after clang_cpp_adjust, which already resolves
+    // every by-name aggregate, so the check never fires and the pass stays inert;
+    // it is a dead-but-tested safety net that deterministically catches a
+    // B.5-era resolution bug once the pass replaces clang_cpp_adjust and becomes
+    // the sole resolver.
     if (has_unresolved_source(value))
     {
       log_error(
-        "python_adjust: symbol `{}' retains an unresolved member/index source "
-        "after adjust (V.1k post-adjust invariant violated)",
+        "python_adjust: symbol `{}' retains an unresolved by-name "
+        "(symbol_type2t) member/index/struct-literal node after adjust (V.1k "
+        "post-adjust invariant violated)",
         symbol->id.as_string());
       error = true;
     }
@@ -141,6 +143,11 @@ bool python_adjust::has_unresolved_source(const expr2tc &expr) const
   if (is_member2t(expr) && is_symbol_type(to_member2t(expr).source_value->type))
     return true;
   if (is_index2t(expr) && is_symbol_type(to_index2t(expr).source_value->type))
+    return true;
+  // A constant_struct2t is the third relaxed construction assert (irep2_expr.h):
+  // its own type may be a transient by-name symbol_type2t until the aggregate is
+  // followed. Post-adjust it must be a resolved struct too.
+  if (is_constant_struct2t(expr) && is_symbol_type(expr->type))
     return true;
 
   bool found = false;

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -26,8 +26,10 @@ class python_adjust
 public:
   explicit python_adjust(contextt &_context);
 
-  /// Walk every non-type symbol's IREP2 value. Returns false on success,
-  /// mirroring `clang_c_adjust::adjust()`.
+  /// Walk every non-type symbol's IREP2 value. Returns true on error —
+  /// specifically if the post-adjust strong invariant is violated (a
+  /// member2t/index2t source still carries an unresolved `symbol_type2t` after
+  /// resolution); false on success, mirroring `clang_c_adjust::adjust()`.
   bool adjust();
 
   /// Recursively visit `expr` and its sub-expressions, resolving transient
@@ -47,4 +49,10 @@ protected:
   /// `pointer→tag-Cls` instance pointer — both arrive as a symbol_type2t source,
   /// since a member/index cannot be constructed over a raw pointer.
   bool resolve_source(expr2tc &source);
+
+  /// Post-adjust strong-invariant probe (V.1k B.4): true if any `member2t` or
+  /// `index2t` reachable from `expr` still has a `symbol_type2t` source — a
+  /// source the pass could not resolve to an aggregate (e.g. one that follows to
+  /// a non-aggregate scalar). Recursive.
+  bool has_unresolved_source(const expr2tc &expr) const;
 };

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -28,8 +28,9 @@ public:
 
   /// Walk every non-type symbol's IREP2 value. Returns true on error —
   /// specifically if the post-adjust strong invariant is violated (a
-  /// member2t/index2t source still carries an unresolved `symbol_type2t` after
-  /// resolution); false on success, mirroring `clang_c_adjust::adjust()`.
+  /// member2t/index2t source or a constant_struct2t type still carries an
+  /// unresolved `symbol_type2t` after resolution); false on success, mirroring
+  /// `clang_c_adjust::adjust()`.
   bool adjust();
 
   /// Recursively visit `expr` and its sub-expressions, resolving transient
@@ -50,9 +51,10 @@ protected:
   /// since a member/index cannot be constructed over a raw pointer.
   bool resolve_source(expr2tc &source);
 
-  /// Post-adjust strong-invariant probe (V.1k B.4): true if any `member2t` or
-  /// `index2t` reachable from `expr` still has a `symbol_type2t` source — a
-  /// source the pass could not resolve to an aggregate (e.g. one that follows to
-  /// a non-aggregate scalar). Recursive.
+  /// Post-adjust strong-invariant probe (V.1k B.4): true if any node reachable
+  /// from `expr` still carries a transient `symbol_type2t` the pass could not
+  /// resolve — a `member2t`/`index2t` source that follows to a non-aggregate, or
+  /// a `constant_struct2t` whose own type is still by-name. Covers all three
+  /// relaxed construction asserts (irep2_expr.h). Recursive.
   bool has_unresolved_source(const expr2tc &expr) const;
 };

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -406,3 +406,25 @@ TEST_CASE(
   python_adjust adjuster(ctx);
   REQUIRE(adjuster.adjust());
 }
+
+TEST_CASE(
+  "python_adjust B.4 adjust() flags an unresolved constant_struct type "
+  "post-adjust",
+  "[python-adjust]")
+{
+  // constant_struct2t is the third relaxed construction assert (irep2_expr.h):
+  // its own type may be a transient by-name symbol_type2t. The pass does not
+  // resolve aggregate-literal types (that is the B.5-era whole-body resolution),
+  // so a survivor must be caught by the post-adjust invariant and adjust() must
+  // return true (error).
+  contextt ctx;
+  const expr2tc lit = constant_struct2tc(
+    symbol_type2tc("tag-Rec"),
+    std::vector<expr2tc>{gen_zero(get_int32_type())});
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(lit)});
+  add_code_symbol(ctx, "py_adjust_struct_lit_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE(adjuster.adjust());
+}

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -378,3 +378,31 @@ TEST_CASE(
   // The body must remain nil — adjust() neither materialises nor rewrites it.
   REQUIRE(is_nil_expr(ctx.find_symbol("py_adjust_code_nil_sym")->get_value2()));
 }
+
+TEST_CASE(
+  "python_adjust B.4 adjust() flags an unresolved member source post-adjust",
+  "[python-adjust]")
+{
+  // A code body reads `obj.x` where obj's tag follows to a scalar (tag-Scalar ->
+  // int): resolve_source must NOT retype the source to a non-aggregate, so the
+  // transient symbol_type2t source survives adjust. The post-adjust
+  // strong-invariant check catches the survivor and adjust() returns true
+  // (error) — the negative of the resolved-struct case above, which returns
+  // false. This is the B.5-era mis-resolution the safety net exists to catch.
+  contextt ctx;
+  symbolt scalar_type_sym;
+  scalar_type_sym.id = scalar_type_sym.name = "tag-Scalar";
+  scalar_type_sym.mode = "Python";
+  scalar_type_sym.is_type = true;
+  scalar_type_sym.set_type(get_int32_type());
+  ctx.add(scalar_type_sym);
+
+  const expr2tc source = symbol2tc(symbol_type2tc("tag-Scalar"), "obj");
+  const expr2tc member = member2tc(get_int32_type(), source, "x");
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(member)});
+  add_code_symbol(ctx, "py_adjust_unresolved_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE(adjuster.adjust());
+}


### PR DESCRIPTION
Completes `python_adjust`'s post-adjust strong-invariant check across all three relaxed IREP2 construction asserts: `has_unresolved_source` already flagged a `member2t`/`index2t` source left as a transient `symbol_type2t` (#5946), and now also flags a `constant_struct2t` whose own type is still by-name. This closes the exit contract the B.5 milestone must satisfy, so no by-name node slips past the pass. Inert on the live pipeline (runs after `clang_cpp_adjust`); unit-tested 14/14 plus 7/7 flag-on fixtures.
