### PR TITLE
[om] make <type_traits> and char_traits parse under -std=c++03

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/type_traits_cxx03/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/type_traits_cxx03/main.cpp
@@ -1,0 +1,39 @@
+// <type_traits> is pulled in unconditionally by <memory>, <string>, <cmath>
+// and friends, so it must parse under -std=c++03. Exercise the traits that
+// C++03 can actually name (no alias or variable templates).
+#include <string>
+#include <stdexcept>
+#include <memory>
+#include <cmath>
+#include <type_traits>
+#include <cassert>
+
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value, int>::type only_integral(T)
+{
+  return 1;
+}
+
+int main()
+{
+  assert(std::is_integral<int>::value);
+  assert(!std::is_integral<double>::value);
+  assert(std::is_floating_point<double>::value);
+  assert(std::is_arithmetic<char>::value);
+  assert(std::is_pointer<int *>::value);
+  assert(!std::is_reference<int>::value);
+  assert(std::is_lvalue_reference<int &>::value);
+  assert(!std::is_rvalue_reference<int>::value);
+  assert(std::extent<int[5]>::value == 5);
+
+  assert((std::is_same<int, int>::value));
+  assert(!(std::is_same<int, long>::value));
+  assert((std::is_same<std::remove_cv<const int>::type, int>::value));
+  assert((std::is_same<std::make_unsigned<int>::type, unsigned int>::value));
+  assert((std::is_same<std::make_signed<unsigned int>::type, int>::value));
+  assert((std::is_same<std::decay<const int &>::type, int>::value));
+  assert((std::is_same<std::conditional<true, int, long>::type, int>::value));
+
+  assert(only_integral(3) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/type_traits_cxx03/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/type_traits_cxx03/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++03
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/type_traits_cxx03_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/type_traits_cxx03_fail/main.cpp
@@ -1,0 +1,39 @@
+// <type_traits> is pulled in unconditionally by <memory>, <string>, <cmath>
+// and friends, so it must parse under -std=c++03. Exercise the traits that
+// C++03 can actually name (no alias or variable templates).
+#include <string>
+#include <stdexcept>
+#include <memory>
+#include <cmath>
+#include <type_traits>
+#include <cassert>
+
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value, int>::type only_integral(T)
+{
+  return 1;
+}
+
+int main()
+{
+  assert(std::is_integral<int>::value);
+  assert(!std::is_integral<double>::value);
+  assert(std::is_floating_point<double>::value);
+  assert(std::is_arithmetic<char>::value);
+  assert(std::is_pointer<int *>::value);
+  assert(!std::is_reference<int>::value);
+  assert(std::is_lvalue_reference<int &>::value);
+  assert(!std::is_rvalue_reference<int>::value);
+  assert(std::extent<int[5]>::value == 6); // negative variant: 5, not 6
+
+  assert((std::is_same<int, int>::value));
+  assert(!(std::is_same<int, long>::value));
+  assert((std::is_same<std::remove_cv<const int>::type, int>::value));
+  assert((std::is_same<std::make_unsigned<int>::type, unsigned int>::value));
+  assert((std::is_same<std::make_signed<unsigned int>::type, int>::value));
+  assert((std::is_same<std::decay<const int &>::type, int>::value));
+  assert((std::is_same<std::conditional<true, int, long>::type, int>::value));
+
+  assert(only_integral(3) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/type_traits_cxx03_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/type_traits_cxx03_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++03
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/ch13_3/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900 --std c++03
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/OM_compiler_defs.h
+++ b/src/cpp/library/OM_compiler_defs.h
@@ -12,7 +12,9 @@
 #if __cplusplus >= 201103L
 #  define OM_CONSTEXPR constexpr
 #  define OM_NOEXCEPT noexcept
+#  define OM_NULLPTR nullptr
 #else
 #  define OM_CONSTEXPR
 #  define OM_NOEXCEPT
+#  define OM_NULLPTR 0
 #endif

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2,6 +2,7 @@
 #define STL_STRING
 
 #include "definitions.h"
+#include "OM_compiler_defs.h" // OM_NOEXCEPT
 #include "cstring"
 #include "cstdio"
 #include "cassert"
@@ -16,12 +17,12 @@ namespace std
 template <class charT>
 struct char_traits
 {
-  using char_type = charT;
-  using int_type = int;
-  using off_type = std::ptrdiff_t;
-  using pos_type = std::size_t;
+  typedef charT char_type;
+  typedef int int_type;
+  typedef std::ptrdiff_t off_type;
+  typedef std::size_t pos_type;
 
-  static void assign(char_type &c1, const char_type &c2) noexcept
+  static void assign(char_type &c1, const char_type &c2) OM_NOEXCEPT
   {
     c1 = c2;
   }
@@ -33,12 +34,12 @@ struct char_traits
     return s;
   }
 
-  static bool eq(char_type c1, char_type c2) noexcept
+  static bool eq(char_type c1, char_type c2) OM_NOEXCEPT
   {
     return c1 == c2;
   }
 
-  static bool lt(char_type c1, char_type c2) noexcept
+  static bool lt(char_type c1, char_type c2) OM_NOEXCEPT
   {
     return c1 < c2;
   }
@@ -69,7 +70,7 @@ struct char_traits
     for (std::size_t i = 0; i < n; ++i)
       if (eq(s[i], a))
         return s + i;
-    return nullptr;
+    return OM_NULLPTR;
   }
 
   static char_type *move(char_type *dest, const char_type *src, std::size_t n)
@@ -82,27 +83,27 @@ struct char_traits
     return static_cast<char_type *>(memcpy(dest, src, n * sizeof(charT)));
   }
 
-  static int_type eof() noexcept
+  static int_type eof() OM_NOEXCEPT
   {
     return EOF;
   }
 
-  static int_type to_int_type(char_type c) noexcept
+  static int_type to_int_type(char_type c) OM_NOEXCEPT
   {
     return static_cast<unsigned char>(c);
   }
 
-  static char_type to_char_type(int_type c) noexcept
+  static char_type to_char_type(int_type c) OM_NOEXCEPT
   {
     return static_cast<char_type>(c);
   }
 
-  static bool eq_int_type(int_type c1, int_type c2) noexcept
+  static bool eq_int_type(int_type c1, int_type c2) OM_NOEXCEPT
   {
     return c1 == c2;
   }
 
-  static int_type not_eof(int_type c) noexcept
+  static int_type not_eof(int_type c) OM_NOEXCEPT
   {
     return (c == eof()) ? 0 : c;
   }

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -1,7 +1,14 @@
 #ifndef ESBMC_TYPE_TRAITS
 #define ESBMC_TYPE_TRAITS
 
-#include "utility" // for remove_reference, declval
+#include "utility"            // for remove_reference, remove_extent, declval
+#include "OM_compiler_defs.h" // OM_CONSTEXPR, OM_NOEXCEPT
+
+// The traits below are spelled so that they also parse under --std c++03,
+// because <memory>, <string>, <stdexcept>, <cmath> and <list> pull this header
+// in unconditionally. Everything that has no C++03 spelling — alias templates,
+// variable templates, rvalue references, variadic templates — lives in the
+// guarded block at the bottom of the file.
 
 namespace std
 {
@@ -10,14 +17,21 @@ namespace std
 template <class T, T v>
 struct integral_constant
 {
+#if __cplusplus >= 201103L
   static constexpr T value = v;
+#else
+  // In-class initialisation is only well-formed for integral/enum T, which is
+  // all this header ever instantiates (bool for the is_* traits, size_t for
+  // extent). Still a constant expression, so SFINAE and array bounds work.
+  static const T value = v;
+#endif
   typedef T value_type;
   typedef integral_constant type;
-  constexpr operator value_type() const noexcept
+  OM_CONSTEXPR operator value_type() const OM_NOEXCEPT
   {
     return value;
   }
-  constexpr value_type operator()() const noexcept
+  OM_CONSTEXPR value_type operator()() const OM_NOEXCEPT
   {
     return value;
   }
@@ -37,8 +51,6 @@ struct conditional<false, T, F>
 {
   typedef F type;
 };
-template <bool B, class T, class F>
-using conditional_t = typename conditional<B, T, F>::type;
 
 // enable_if
 template <bool B, class T = void>
@@ -50,8 +62,6 @@ struct enable_if<true, T>
 {
   typedef T type;
 };
-template <bool B, class T = void>
-using enable_if_t = typename enable_if<B, T>::type;
 
 // remove_const / remove_volatile / remove_cv
 template <class T>
@@ -84,8 +94,6 @@ struct remove_cv<const volatile T>
 {
   typedef T type;
 };
-template <class T>
-using remove_cv_t = typename remove_cv<T>::type;
 
 // remove_pointer
 template <class T>
@@ -183,11 +191,9 @@ struct is_integral_base<unsigned long long> : true_type
 } // namespace detail
 
 template <class T>
-struct is_integral : detail::is_integral_base<remove_cv_t<T>>
+struct is_integral : detail::is_integral_base<typename remove_cv<T>::type>
 {
 };
-template <class T>
-inline constexpr bool is_integral_v = is_integral<T>::value;
 
 // is_floating_point
 namespace detail
@@ -211,11 +217,10 @@ struct is_floating_point_base<long double> : true_type
 } // namespace detail
 
 template <class T>
-struct is_floating_point : detail::is_floating_point_base<remove_cv_t<T>>
+struct is_floating_point
+  : detail::is_floating_point_base<typename remove_cv<T>::type>
 {
 };
-template <class T>
-inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
 
 // is_arithmetic
 template <class T>
@@ -223,16 +228,12 @@ struct is_arithmetic
   : integral_constant<bool, is_integral<T>::value || is_floating_point<T>::value>
 {
 };
-template <class T>
-inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
 
 // is_enum
 template <class T>
 struct is_enum : integral_constant<bool, __is_enum(T)>
 {
 };
-template <class T>
-inline constexpr bool is_enum_v = is_enum<T>::value;
 
 // underlying_type — ::type is only present when T is an enumeration type
 template <class T, bool = is_enum<T>::value>
@@ -244,24 +245,18 @@ struct underlying_type<T, true>
 {
   typedef __underlying_type(T) type;
 };
-template <class T>
-using underlying_type_t = typename underlying_type<T>::type;
 
 // is_signed
 template <class T>
 struct is_signed : integral_constant<bool, __is_signed(T)>
 {
 };
-template <class T>
-inline constexpr bool is_signed_v = is_signed<T>::value;
 
 // is_unsigned
 template <class T>
 struct is_unsigned : integral_constant<bool, __is_unsigned(T)>
 {
 };
-template <class T>
-inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
 
 // is_trivially_copyable (needed by std::bit_cast)
 template <class T>
@@ -269,9 +264,6 @@ struct is_trivially_copyable
   : integral_constant<bool, __is_trivially_copyable(T)>
 {
 };
-template <class T>
-inline constexpr bool is_trivially_copyable_v =
-  is_trivially_copyable<T>::value;
 
 // is_array
 template <class T>
@@ -286,8 +278,6 @@ template <class T, size_t _Np>
 struct is_array<T[_Np]> : true_type
 {
 };
-template <class T>
-inline constexpr bool is_array_v = is_array<T>::value;
 
 // extent — number of elements in the first array dimension (0 for non-arrays)
 template <class T, size_t _Np = 0>
@@ -310,8 +300,6 @@ template <class T, size_t _Ip, size_t _Np>
 struct extent<T[_Ip], _Np> : extent<T, _Np - 1>
 {
 };
-template <class T>
-inline constexpr size_t extent_v = extent<T>::value;
 
 // is_same
 template <class T, class U>
@@ -322,16 +310,12 @@ template <class T>
 struct is_same<T, T> : true_type
 {
 };
-template <class T, class U>
-inline constexpr bool is_same_v = is_same<T, U>::value;
 
 // is_void
 template <class T>
-struct is_void : is_same<void, remove_cv_t<T>>
+struct is_void : is_same<void, typename remove_cv<T>::type>
 {
 };
-template <class T>
-inline constexpr bool is_void_v = is_void<T>::value;
 
 // is_pointer
 template <class T>
@@ -354,8 +338,6 @@ template <class T>
 struct is_pointer<T *const volatile> : true_type
 {
 };
-template <class T>
-inline constexpr bool is_pointer_v = is_pointer<T>::value;
 
 // is_reference
 template <class T>
@@ -370,10 +352,14 @@ template <class T>
 struct is_rvalue_reference : false_type
 {
 };
+#if __cplusplus >= 201103L
+// C++03 has no rvalue references, so the primary template already answers
+// false for every type it can name.
 template <class T>
 struct is_rvalue_reference<T &&> : true_type
 {
 };
+#endif
 template <class T>
 struct is_reference : integral_constant<bool, is_lvalue_reference<T>::value ||
                                                 is_rvalue_reference<T>::value>
@@ -433,8 +419,6 @@ struct make_unsigned<unsigned long long>
 {
   typedef unsigned long long type;
 };
-template <class T>
-using make_unsigned_t = typename make_unsigned<T>::type;
 
 // make_signed
 template <class T>
@@ -489,25 +473,42 @@ struct make_signed<long long>
 {
   typedef long long type;
 };
-template <class T>
-using make_signed_t = typename make_signed<T>::type;
 
 // decay
 template <class T>
 struct decay
 {
 private:
-  typedef remove_reference_t<T> U;
+  typedef typename remove_reference<T>::type U;
+  typedef typename conditional<
+    false /* is_function<U> */,
+    U *,
+    typename remove_cv<U>::type>::type non_array_type;
 
 public:
-  typedef conditional_t<
+  typedef typename conditional<
     is_array<U>::value,
     typename remove_extent<U>::type *,
-    conditional_t<false /* is_function<U> */, U *, remove_cv_t<U>>>
-    type;
+    non_array_type>::type type;
 };
+
+// is_constructible (simplified via Clang builtin)
+#if __cplusplus >= 201103L
+template <class T, class... Args>
+struct is_constructible
+  : integral_constant<bool, __is_constructible(T, Args...)>
+{
+};
+#else
+// C++03 has no variadic templates; <vector> only ever asks about the
+// default constructor.
 template <class T>
-using decay_t = typename decay<T>::type;
+struct is_constructible : integral_constant<bool, __is_constructible(T)>
+{
+};
+#endif
+
+#if __cplusplus >= 201103L
 
 // void_t (C++17)
 template <class...>
@@ -540,25 +541,12 @@ template <class F, class... Args>
 struct is_invocable : decltype(detail::test_invocable<F, Args...>(0))
 {
 };
-template <class F, class... Args>
-inline constexpr bool is_invocable_v = is_invocable<F, Args...>::value;
 
 // is_invocable_r
 template <class R, class F, class... Args>
 struct is_invocable_r : decltype(detail::test_invocable_r<R, F, Args...>(0))
 {
 };
-template <class R, class F, class... Args>
-inline constexpr bool is_invocable_r_v = is_invocable_r<R, F, Args...>::value;
-
-// is_constructible (simplified via Clang builtin)
-template <class T, class... Args>
-struct is_constructible
-  : integral_constant<bool, __is_constructible(T, Args...)>
-{
-};
-template <class T, class... Args>
-inline constexpr bool is_constructible_v = is_constructible<T, Args...>::value;
 
 // is_convertible (simplified)
 namespace detail
@@ -573,8 +561,59 @@ template <class From, class To>
 struct is_convertible : decltype(detail::test_convertible<From, To>(0))
 {
 };
+
+// Alias templates (C++11) and variable templates (C++14/17). Grouped here
+// because none of them has a C++03 spelling.
+template <bool B, class T, class F>
+using conditional_t = typename conditional<B, T, F>::type;
+template <bool B, class T = void>
+using enable_if_t = typename enable_if<B, T>::type;
+template <class T>
+using remove_cv_t = typename remove_cv<T>::type;
+template <class T>
+using underlying_type_t = typename underlying_type<T>::type;
+template <class T>
+using make_unsigned_t = typename make_unsigned<T>::type;
+template <class T>
+using make_signed_t = typename make_signed<T>::type;
+template <class T>
+using decay_t = typename decay<T>::type;
+
+template <class T>
+inline constexpr bool is_integral_v = is_integral<T>::value;
+template <class T>
+inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+template <class T>
+inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+template <class T>
+inline constexpr bool is_enum_v = is_enum<T>::value;
+template <class T>
+inline constexpr bool is_signed_v = is_signed<T>::value;
+template <class T>
+inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
+template <class T>
+inline constexpr bool is_trivially_copyable_v =
+  is_trivially_copyable<T>::value;
+template <class T>
+inline constexpr bool is_array_v = is_array<T>::value;
+template <class T>
+inline constexpr size_t extent_v = extent<T>::value;
+template <class T, class U>
+inline constexpr bool is_same_v = is_same<T, U>::value;
+template <class T>
+inline constexpr bool is_void_v = is_void<T>::value;
+template <class T>
+inline constexpr bool is_pointer_v = is_pointer<T>::value;
+template <class F, class... Args>
+inline constexpr bool is_invocable_v = is_invocable<F, Args...>::value;
+template <class R, class F, class... Args>
+inline constexpr bool is_invocable_r_v = is_invocable_r<R, F, Args...>::value;
+template <class T, class... Args>
+inline constexpr bool is_constructible_v = is_constructible<T, Args...>::value;
 template <class From, class To>
 inline constexpr bool is_convertible_v = is_convertible<From, To>::value;
+
+#endif // __cplusplus >= 201103L
 
 } // namespace std
 


### PR DESCRIPTION
`src/cpp/library/type_traits` used C++11-only syntax with no `__cplusplus` guards, so any C++03 TU reaching `<memory>`, `<string>`, `<stdexcept>` or `<cmath>` failed to parse before verification. Respell the core traits to parse under C++03 and gate the C++11-only surface (`_t`/`_v` aliases, `void_t`, `is_invocable`, …) behind `#if __cplusplus >= 201103L`; `char_traits` drops its aliases/`noexcept` and `OM_NULLPTR` is added. The C++11+ path is unchanged in meaning. Adds `type_traits_cxx03{,_fail}`.
