### PR TITLE
[solver] don't flatten a struct to a bitvector under --ir

### DIFF
--- a/regression/esbmc-cpp/map/map_char_key_ir/main.cpp
+++ b/regression/esbmc-cpp/map/map_char_key_ir/main.cpp
@@ -1,0 +1,16 @@
+// Byte-granular access to a struct with a char-keyed map forces ESBMC to
+// address a single byte of the map object. Under --ir the struct has no
+// bit-vector representation, and flattening it used to abort the solver with
+// "Z3 error operator is applied to arguments of the wrong sort".
+#include <map>
+#include <cassert>
+
+int main()
+{
+  std::map<char, int> m;
+  m['a'] = 1;
+  m['b'] = 2;
+  assert(m['a'] == 1);
+  assert(m['b'] == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/map/map_char_key_ir/test.desc
+++ b/regression/esbmc-cpp/map/map_char_key_ir/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--ir --unwind 2
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/map_char_key_ir_big_endian/main.cpp
+++ b/regression/esbmc-cpp/map/map_char_key_ir_big_endian/main.cpp
@@ -1,0 +1,16 @@
+// Byte-granular access to a struct with a char-keyed map forces ESBMC to
+// address a single byte of the map object. Under --ir the struct has no
+// bit-vector representation, and flattening it used to abort the solver with
+// "Z3 error operator is applied to arguments of the wrong sort".
+#include <map>
+#include <cassert>
+
+int main()
+{
+  std::map<char, int> m;
+  m['a'] = 1;
+  m['b'] = 2;
+  assert(m['a'] == 1);
+  assert(m['b'] == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/map/map_char_key_ir_big_endian/test.desc
+++ b/regression/esbmc-cpp/map/map_char_key_ir_big_endian/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--ir --unwind 2 --big-endian
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/map_char_key_ir_fail/main.cpp
+++ b/regression/esbmc-cpp/map/map_char_key_ir_fail/main.cpp
@@ -1,0 +1,16 @@
+// Byte-granular access to a struct with a char-keyed map forces ESBMC to
+// address a single byte of the map object. Under --ir the struct has no
+// bit-vector representation, and flattening it used to abort the solver with
+// "Z3 error operator is applied to arguments of the wrong sort".
+#include <map>
+#include <cassert>
+
+int main()
+{
+  std::map<char, int> m;
+  m['a'] = 1;
+  m['b'] = 2;
+  assert(m['a'] == 1);
+  assert(m['b'] == 3); // negative variant: 2, not 3
+  return 0;
+}

--- a/regression/esbmc-cpp/map/map_char_key_ir_fail/test.desc
+++ b/regression/esbmc-cpp/map/map_char_key_ir_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--ir --unwind 2
+
+^  file .*main\.cpp line 14 .*function main$
+^VERIFICATION FAILED$

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1484,8 +1484,15 @@ void dereferencet::construct_from_dyn_struct_offset(
 
   // if we are accessing the struct using a byte, we can ignore alignment
   // rules, so convert the struct to bv and dispatch it to
-  // construct_from_dyn_offset
-  if (access_sz == config.ansi_c.char_width)
+  // construct_from_dyn_offset.
+  //
+  // Not under integer/real encoding (--ir): there a struct has no bit-vector
+  // representation, and the extract/concat needed to reinterpret one aborts
+  // the solver with a sort mismatch. Fall through to the member-wise path
+  // below, which addresses each field directly. A byte access satisfies every
+  // alignment constraint anyway, so nothing is lost by taking the slow path.
+  const bool int_encoding = options.get_bool_option("int-encoding");
+  if (access_sz == config.ansi_c.char_width && !int_encoding)
   {
     uint64_t struct_bits = type_byte_size_bits(value->type, &ns).to_uint64();
     value = bitcast2tc(get_uint_type(struct_bits), value);


### PR DESCRIPTION
Under `--ir`, a single-byte struct access bitcasts the whole struct to a bitvector; integer/real encoding then emits a bitvector `extract` on an `Int`, so Z3 aborts with a sort error (e.g. `map<char,int>` and other sub-`short` keys). Skip the flatten shortcut when `int-encoding` is set and fall through to the member-wise path, which needs no bitcast and is alignment-safe for one byte. Bitvector mode is byte-for-byte unchanged. Adds three `map_char_key_ir*` tests.
