### PR TITLE
[python] fix CI timeout in github_5931_fail via --incremental-bmc

### DIFF
--- a/regression/python/github_5931_fail/test.desc
+++ b/regression/python/github_5931_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
---unwind 4
+--incremental-bmc
 ^\[Counterexample\]$
 ^VERIFICATION FAILED$


### PR DESCRIPTION
## Problem

`regression/python/github_5931_fail` (added in #5935) times out at the 120s CI cap on the arm64 macOS runner, failing the **arm64 darwin build** check on every currently open PR (#5952, #5951, #5947, #5946, #5945, #5942, #5940, ...). Locally on an M-series machine the `--unwind 4` run already takes ~16s (solver-dominated: ~12s in the decision procedure over 1539 VCCs from the heapq/list operational model); under parallel ctest load on the CI runner it exceeds 120s.

## Fix

Switch the test to `--incremental-bmc`, which finds the same counterexample in ~2.5s locally.

## Soundness of the regression guard

- Buggy model (no-op `heapify`, the original #5931 false proof): the run terminates with `VERIFICATION SUCCESSFUL` (all loops are bounded), so the test's `VERIFICATION FAILED` regex mismatches and the regression is still caught.
- Fixed model: `--incremental-bmc` reports `[Counterexample]` + `VERIFICATION FAILED`, matching both test.desc regexes (validated locally).
- CPython sanity: `scripts/check_python_tests.sh github_5931` passes.