### PR TITLE
[python] Fix false proofs on list-literal count()/index() calls

### DIFF
--- a/regression/python/list_literal_index_start/main.py
+++ b/regression/python/list_literal_index_start/main.py
@@ -1,0 +1,50 @@
+# list.index() on a *literal* receiver dropped its start/end arguments and
+# folded to a constant 0, so `[1, 2, 1].index(1, 1) == 0` verified SUCCESSFUL
+# for a program CPython rejects. A named receiver was already correct.
+assert [1, 2, 1].index(1, 1) == 2
+assert [1, 2, 1].index(1) == 0
+assert [1, 2, 1].index(2) == 1
+assert [1, 2, 1].index(1, -2) == 2
+assert [1, 2, 3, 2].index(2, 2, 4) == 3
+
+# count() on a literal receiver stays correct.
+assert [1, 2, 2, 3].count(2) == 2
+assert [1, 2, 2, 3].count(9) == 0
+
+# Assigning the result (instead of asserting on it directly) bypasses the
+# assert-level constant fold, so these exercise the conversion-time fold in
+# handle_list_index/handle_list_count.
+start_idx: int = [1, 2, 1].index(1, 1)
+assert start_idx == 2
+two_count: int = [1, 2, 2, 3].count(2)
+assert two_count == 2
+
+# A named receiver is unchanged.
+values = [1, 2, 1]
+assert values.index(1, 1) == 2
+
+# A named receiver is never folded from its stale literal value: module-level
+# constant seeding cannot see in-place mutation, so these must go through the
+# list model.
+mutated = [2, 1]
+mutated.insert(0, 1)
+mut_idx: int = mutated.index(1)
+assert mut_idx == 0
+grown = [1, 2]
+grown.append(2)
+grown_cnt: int = grown.count(2)
+assert grown_cnt == 2
+
+# CPython compares bool/int/float numerically across kinds in the fold.
+bool_cnt: int = [True, 1].count(1)
+assert bool_cnt == 2
+float_idx: int = [1, 1.0].index(1.0)
+assert float_idx == 0
+
+# An absent element still raises a catchable ValueError.
+try:
+    [1, 2].index(9)
+    raised = False
+except ValueError:
+    raised = True
+assert raised

--- a/regression/python/list_literal_index_start/test.desc
+++ b/regression/python/list_literal_index_start/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_literal_index_start_fail/main.py
+++ b/regression/python/list_literal_index_start_fail/main.py
@@ -1,0 +1,3 @@
+# Pins the false proof: the dropped start argument folded index() to 0, so this
+# claim verified. CPython's [1, 2, 1].index(1, 1) is 2.
+assert [1, 2, 1].index(1, 1) == 0

--- a/regression/python/list_literal_index_start_fail/test.desc
+++ b/regression/python/list_literal_index_start_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -32,6 +32,7 @@
 #include <unordered_map>
 #include <boost/algorithm/string/predicate.hpp>
 #include <optional>
+#include <python-frontend/python_consteval.h>
 #include <regex>
 #include <stdexcept>
 #include <unordered_set>
@@ -1897,14 +1898,65 @@ exprt function_call_expr::handle_list_remove() const
   return result;
 }
 
+const symbolt *function_call_expr::resolve_list_receiver_symbol(
+  std::string &display_name) const
+{
+  if (const symbolt *named = get_object_list_symbol(display_name))
+    return named;
+
+  const nlohmann::json &receiver = call_["func"]["value"];
+  if (receiver.value("_type", "") != "List")
+    return nullptr;
+
+  // Converting the literal emits its list_create/list_push instructions and
+  // yields the temporary symbol that holds the list.
+  display_name = "[list literal]";
+  const exprt list = converter_.get_expr(receiver);
+  if (!list.is_symbol())
+    return nullptr;
+
+  return converter_.find_symbol(list.identifier().as_string());
+}
+
+std::optional<exprt> function_call_expr::fold_constant_list_query() const
+{
+  // A wholly literal `[...].count(x)` / `[...].index(x[, start[, end]])` folds
+  // here so the result stays independent of --unwind: the list model searches
+  // with a loop, and a truncated one silently mis-verifies. The evaluator
+  // implements CPython's semantics, including index()'s start/end slicing and
+  // numeric equality across bool/int/float. An absent element (index raises
+  // ValueError) yields no value and falls through to the model, which lowers
+  // the exception.
+  //
+  // Only a *literal* receiver folds: a named receiver may have been mutated
+  // (append/insert/subscript store) or shadowed in an inner scope, neither of
+  // which module-level constant seeding can see, so folding it would bake in
+  // a stale value. The evaluator is likewise given an empty module so the
+  // needle and start/end operands fold only when they are literals
+  // themselves, never through seeded globals with the same blind spots.
+  if (call_["func"]["value"].value("_type", "") != "List")
+    return std::nullopt;
+
+  static const nlohmann::json no_module;
+  python_consteval evaluator(no_module);
+  const auto folded = evaluator.try_eval_global_expr(call_);
+  if (!folded || folded->kind != PyConstValue::INT)
+    return std::nullopt;
+
+  return from_integer(folded->int_val, long_long_int_type());
+}
+
 exprt function_call_expr::handle_list_count() const
 {
   const auto &args = call_["args"];
   if (args.size() != 1)
     throw std::runtime_error("list.count() takes exactly one argument");
 
+  if (std::optional<exprt> folded = fold_constant_list_query())
+    return *folded;
+
   std::string list_display_name;
-  const symbolt *list_symbol = get_object_list_symbol(list_display_name);
+  const symbolt *list_symbol = resolve_list_receiver_symbol(list_display_name);
   materialize_list_symbol(list_symbol);
   if (!list_symbol)
     throw std::runtime_error("List variable not found: " + list_display_name);
@@ -1920,8 +1972,11 @@ exprt function_call_expr::handle_list_index() const
   if (args.empty() || args.size() > 3)
     throw std::runtime_error("list.index() takes one to three arguments");
 
+  if (std::optional<exprt> folded = fold_constant_list_query())
+    return *folded;
+
   std::string list_display_name;
-  const symbolt *list_symbol = get_object_list_symbol(list_display_name);
+  const symbolt *list_symbol = resolve_list_receiver_symbol(list_display_name);
   materialize_list_symbol(list_symbol);
   if (!list_symbol)
     throw std::runtime_error("List variable not found: " + list_display_name);
@@ -2211,9 +2266,15 @@ bool function_call_expr::is_list_method_call() const
     return false;
 
   // Tuples are claimed earlier; only claim count/index here when the receiver
-  // resolves to a list symbol so str receivers fall through.
+  // resolves to a list symbol so str receivers fall through. A list *literal*
+  // receiver has no symbol yet, so claim it on the AST node: otherwise it fell
+  // through to the general-call handler, which folded `[1, 2, 1].index(1, 1)`
+  // to a constant 0 and verified false assertions.
   if (method_name == "count" || method_name == "index")
   {
+    if (call_["func"]["value"].value("_type", "") == "List")
+      return true;
+
     std::string dummy;
     const symbolt *sym = get_object_list_symbol(dummy);
     const typet list_type = type_handler_.get_list_type();

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -142,6 +142,30 @@ private:
    * for error messages (e.g. "mylist" or "nested[0]").
    */
   const symbolt *get_object_list_symbol(std::string &display_name) const;
+
+  /**
+   * @brief Resolve the list receiver of a method call to a symbol.
+   *
+   * A named receiver (`a.index(x)`) resolves through get_object_list_symbol. A
+   * list *literal* receiver (`[1, 2, 1].index(x)`) has no named symbol, so it
+   * is converted here and the temporary symbol its construction creates is
+   * returned. Without this the call fell through to the general-call handler,
+   * which folded `index()` to a constant 0 and verified false assertions.
+   *
+   * @param display_name Receiver name for diagnostics, when there is one.
+   * @return The receiver's symbol, or null when it is neither.
+   */
+  const symbolt *resolve_list_receiver_symbol(std::string &display_name) const;
+
+  /**
+   * @brief Fold a wholly literal list.count()/list.index() at conversion time.
+   *
+   * Keeps the result independent of --unwind: the list model searches with a
+   * loop, so a truncated one would silently mis-verify. Returns nothing when
+   * the receiver is not a list literal, when any operand is not itself a
+   * literal, or when index() would raise ValueError.
+   */
+  std::optional<exprt> fold_constant_list_query() const;
   void materialize_list_symbol(const symbolt *sym) const;
 
   /*

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -76,10 +76,42 @@ bool PyConstValue::is_truthy() const
   return false;
 }
 
+// CPython int/float equality is exact. A double equals a long long only when
+// it is integral and in long long range; comparing after casting the float
+// side stays exact, where casting the int side to double could collide with a
+// neighboring value above 2^53.
+static bool int_equals_double(long long i, double f)
+{
+  if (std::floor(f) != f)
+    return false;
+  if (f < -9223372036854775808.0 || f >= 9223372036854775808.0)
+    return false;
+  return static_cast<long long>(f) == i;
+}
+
 static bool pyconst_equal(const PyConstValue &lhs, const PyConstValue &rhs)
 {
   if (lhs.kind != rhs.kind)
-    return false;
+  {
+    // CPython compares bool/int/float numerically across kinds:
+    // True == 1 == 1.0. Any other kind mix is unequal.
+    const auto is_numeric = [](const PyConstValue &v) {
+      return v.kind == PyConstValue::BOOL || v.kind == PyConstValue::INT ||
+             v.kind == PyConstValue::FLOAT;
+    };
+    if (!is_numeric(lhs) || !is_numeric(rhs))
+      return false;
+
+    const auto as_int = [](const PyConstValue &v) {
+      return v.kind == PyConstValue::BOOL ? (v.bool_val ? 1LL : 0LL)
+                                          : v.int_val;
+    };
+    if (lhs.kind == PyConstValue::FLOAT)
+      return int_equals_double(as_int(rhs), lhs.float_val);
+    if (rhs.kind == PyConstValue::FLOAT)
+      return int_equals_double(as_int(lhs), rhs.float_val);
+    return as_int(lhs) == as_int(rhs);
+  }
 
   switch (lhs.kind)
   {


### PR DESCRIPTION
A list-literal receiver like `[1, 2, 1].index(1, 1)` wasn't claimed as a list method call, so it fell through to the general-call handler, which dropped the start/end arguments and folded to 0 — verifying false assertions. Claim literal receivers: fold wholly-literal queries at conversion time (with CPython cross-kind numeric equality) and route the rest through the list model; named receivers stay on the model path since constant seeding can't see mutation or shadowing. Adds `list_literal_index_start` and a `_fail` pinning the false proof.
