### PR TITLE
[python] Refuse consteval seeds for mutated, aliased, or rebound globals

### DIFF
--- a/regression/python/github_5955_alias_boolop_fail/main.py
+++ b/regression/python/github_5955_alias_boolop_fail/main.py
@@ -1,0 +1,6 @@
+# `l or [9]` yields l itself, so m aliases l and the append invalidates the
+# seed; the assert must not fold to a proof (GitHub #5955 review F1).
+l = [1, 2]
+m = l or [9]
+m.append(3)
+assert l.count(3) == 0

--- a/regression/python/github_5955_alias_boolop_fail/test.desc
+++ b/regression/python/github_5955_alias_boolop_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_alias_builtin_arg_fail/main.py
+++ b/regression/python/github_5955_alias_builtin_arg_fail/main.py
@@ -1,0 +1,6 @@
+# min([l]) returns l itself: a container-literal argument smuggles the
+# reference past the pure-builtin exemption (GitHub #5955 review F3).
+l = [1, 2]
+m = min([l])
+m.append(3)
+assert l.count(3) == 0

--- a/regression/python/github_5955_alias_builtin_arg_fail/test.desc
+++ b/regression/python/github_5955_alias_builtin_arg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_alias_walrus_fail/main.py
+++ b/regression/python/github_5955_alias_walrus_fail/main.py
@@ -1,0 +1,6 @@
+# The walrus binds m as an alias of l outside any assignment statement; the
+# append invalidates the seed (GitHub #5955 review F2).
+l = [1, 2]
+if (m := l):
+    m.append(3)
+assert l.count(3) == 0

--- a/regression/python/github_5955_alias_walrus_fail/test.desc
+++ b/regression/python/github_5955_alias_walrus_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_fold_retention/main.py
+++ b/regression/python/github_5955_fold_retention/main.py
@@ -1,0 +1,13 @@
+# Guards against over-poisoning: at --unwind 1 only a successful conversion-
+# time fold can verify the count() assert (the operational model searches
+# with a loop that would truncate). A string global through a pure function
+# must also still seed and fold. len() is loop-free either way and is kept
+# only as a smoke check.
+S = "abcdefabcdef"
+def mid(s: str) -> str:
+    return s[1:5]
+assert mid(S) == "bcde"
+
+L = [1, 2, 3]
+assert L.count(2) == 1
+assert len(L) == 3

--- a/regression/python/github_5955_fold_retention/test.desc
+++ b/regression/python/github_5955_fold_retention/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5955_for_rebind_fail/main.py
+++ b/regression/python/github_5955_for_rebind_fail/main.py
@@ -1,0 +1,5 @@
+# The for target rebinds l without an assignment statement (GitHub #5955).
+l = [1, 2]
+for l in [[9, 9]]:
+    pass
+assert l.count(9) == 0

--- a/regression/python/github_5955_for_rebind_fail/test.desc
+++ b/regression/python/github_5955_for_rebind_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_global_rebind_fail/main.py
+++ b/regression/python/github_5955_global_rebind_fail/main.py
@@ -1,0 +1,10 @@
+# f() rebinds x via `global` with no module-level assignment statement, so
+# the write-once seed x=1 is stale and must not fold (GitHub #5955).
+x = 1
+def f() -> None:
+    global x
+    x = 2
+def g(v: int) -> int:
+    return v
+f()
+assert g(x) == 1

--- a/regression/python/github_5955_global_rebind_fail/test.desc
+++ b/regression/python/github_5955_global_rebind_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_mutated_seed/main.py
+++ b/regression/python/github_5955_mutated_seed/main.py
@@ -1,0 +1,6 @@
+# Post-fix contract: a mutated global list is never seeded, so these asserts
+# go through the list operational model and verify against the real value.
+l = [1, 2]
+l.append(3)
+assert l.count(3) == 1
+assert l == [1, 2, 3]

--- a/regression/python/github_5955_mutated_seed/test.desc
+++ b/regression/python/github_5955_mutated_seed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5955_mutated_seed_fail/main.py
+++ b/regression/python/github_5955_mutated_seed_fail/main.py
@@ -1,0 +1,6 @@
+# The assert folder seeded l with its literal [1, 2]: the append is not an
+# assignment statement, so the write-once heuristic missed it and the stale
+# seed folded this failing assert to True (GitHub #5955).
+l = [1, 2]
+l.append(3)
+assert l.count(3) == 0

--- a/regression/python/github_5955_mutated_seed_fail/test.desc
+++ b/regression/python/github_5955_mutated_seed_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_nested_rebind_fail/main.py
+++ b/regression/python/github_5955_nested_rebind_fail/main.py
@@ -1,0 +1,8 @@
+# The rebind sits inside an if-body: a top-level-only write scan counts one
+# write and seeds the stale [1, 2] (GitHub #5955).
+def t() -> bool:
+    return True
+l = [1, 2]
+if t():
+    l = [3, 3, 3]
+assert l.count(3) == 0

--- a/regression/python/github_5955_nested_rebind_fail/test.desc
+++ b/regression/python/github_5955_nested_rebind_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_scalar_rebind_fail/main.py
+++ b/regression/python/github_5955_scalar_rebind_fail/main.py
@@ -1,0 +1,8 @@
+# Scalar variant of the nested rebind: proves the write counter, not
+# container mutation, is the mechanism (GitHub #5955).
+def t() -> bool:
+    return True
+x = 1
+if t():
+    x = 2
+assert int(x) == 1

--- a/regression/python/github_5955_scalar_rebind_fail/test.desc
+++ b/regression/python/github_5955_scalar_rebind_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_5955_stale_operand_fail/main.py
+++ b/regression/python/github_5955_stale_operand_fail/main.py
@@ -1,0 +1,8 @@
+# Stale-seed false proof through an operand: x seeded as [1] made the literal
+# receiver's index() fold to 0 (GitHub #5955), but CPython's x is [1, 2] at
+# the call, so the assert must not verify. (Post-fix the unseeded x reaches
+# the list model, whose nested-element matching raises ValueError here — a
+# separate limitation; either way this is VERIFICATION FAILED, not a proof.)
+x = [1]
+x.append(2)
+assert [[1], [1, 2]].index(x) == 0

--- a/regression/python/github_5955_stale_operand_fail/test.desc
+++ b/regression/python/github_5955_stale_operand_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/list_literal_index_start/main.py
+++ b/regression/python/list_literal_index_start/main.py
@@ -1,0 +1,50 @@
+# list.index() on a *literal* receiver dropped its start/end arguments and
+# folded to a constant 0, so `[1, 2, 1].index(1, 1) == 0` verified SUCCESSFUL
+# for a program CPython rejects. A named receiver was already correct.
+assert [1, 2, 1].index(1, 1) == 2
+assert [1, 2, 1].index(1) == 0
+assert [1, 2, 1].index(2) == 1
+assert [1, 2, 1].index(1, -2) == 2
+assert [1, 2, 3, 2].index(2, 2, 4) == 3
+
+# count() on a literal receiver stays correct.
+assert [1, 2, 2, 3].count(2) == 2
+assert [1, 2, 2, 3].count(9) == 0
+
+# Assigning the result (instead of asserting on it directly) bypasses the
+# assert-level constant fold, so these exercise the conversion-time fold in
+# handle_list_index/handle_list_count.
+start_idx: int = [1, 2, 1].index(1, 1)
+assert start_idx == 2
+two_count: int = [1, 2, 2, 3].count(2)
+assert two_count == 2
+
+# A named receiver is unchanged.
+values = [1, 2, 1]
+assert values.index(1, 1) == 2
+
+# A named receiver is never folded from its stale literal value: module-level
+# constant seeding cannot see in-place mutation, so these must go through the
+# list model.
+mutated = [2, 1]
+mutated.insert(0, 1)
+mut_idx: int = mutated.index(1)
+assert mut_idx == 0
+grown = [1, 2]
+grown.append(2)
+grown_cnt: int = grown.count(2)
+assert grown_cnt == 2
+
+# CPython compares bool/int/float numerically across kinds in the fold.
+bool_cnt: int = [True, 1].count(1)
+assert bool_cnt == 2
+float_idx: int = [1, 1.0].index(1.0)
+assert float_idx == 0
+
+# An absent element still raises a catchable ValueError.
+try:
+    [1, 2].index(9)
+    raised = False
+except ValueError:
+    raised = True
+assert raised

--- a/regression/python/list_literal_index_start/test.desc
+++ b/regression/python/list_literal_index_start/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_literal_index_start_fail/main.py
+++ b/regression/python/list_literal_index_start_fail/main.py
@@ -1,0 +1,3 @@
+# Pins the false proof: the dropped start argument folded index() to 0, so this
+# claim verified. CPython's [1, 2, 1].index(1, 1) is 2.
+assert [1, 2, 1].index(1, 1) == 0

--- a/regression/python/list_literal_index_start_fail/test.desc
+++ b/regression/python/list_literal_index_start_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -32,6 +32,7 @@
 #include <unordered_map>
 #include <boost/algorithm/string/predicate.hpp>
 #include <optional>
+#include <python-frontend/python_consteval.h>
 #include <regex>
 #include <stdexcept>
 #include <unordered_set>
@@ -1897,14 +1898,65 @@ exprt function_call_expr::handle_list_remove() const
   return result;
 }
 
+const symbolt *function_call_expr::resolve_list_receiver_symbol(
+  std::string &display_name) const
+{
+  if (const symbolt *named = get_object_list_symbol(display_name))
+    return named;
+
+  const nlohmann::json &receiver = call_["func"]["value"];
+  if (receiver.value("_type", "") != "List")
+    return nullptr;
+
+  // Converting the literal emits its list_create/list_push instructions and
+  // yields the temporary symbol that holds the list.
+  display_name = "[list literal]";
+  const exprt list = converter_.get_expr(receiver);
+  if (!list.is_symbol())
+    return nullptr;
+
+  return converter_.find_symbol(list.identifier().as_string());
+}
+
+std::optional<exprt> function_call_expr::fold_constant_list_query() const
+{
+  // A wholly literal `[...].count(x)` / `[...].index(x[, start[, end]])` folds
+  // here so the result stays independent of --unwind: the list model searches
+  // with a loop, and a truncated one silently mis-verifies. The evaluator
+  // implements CPython's semantics, including index()'s start/end slicing and
+  // numeric equality across bool/int/float. An absent element (index raises
+  // ValueError) yields no value and falls through to the model, which lowers
+  // the exception.
+  //
+  // Only a *literal* receiver folds: a named receiver may have been mutated
+  // (append/insert/subscript store) or shadowed in an inner scope, neither of
+  // which module-level constant seeding can see, so folding it would bake in
+  // a stale value. The evaluator is likewise given an empty module so the
+  // needle and start/end operands fold only when they are literals
+  // themselves, never through seeded globals with the same blind spots.
+  if (call_["func"]["value"].value("_type", "") != "List")
+    return std::nullopt;
+
+  static const nlohmann::json no_module;
+  python_consteval evaluator(no_module);
+  const auto folded = evaluator.try_eval_global_expr(call_);
+  if (!folded || folded->kind != PyConstValue::INT)
+    return std::nullopt;
+
+  return from_integer(folded->int_val, long_long_int_type());
+}
+
 exprt function_call_expr::handle_list_count() const
 {
   const auto &args = call_["args"];
   if (args.size() != 1)
     throw std::runtime_error("list.count() takes exactly one argument");
 
+  if (std::optional<exprt> folded = fold_constant_list_query())
+    return *folded;
+
   std::string list_display_name;
-  const symbolt *list_symbol = get_object_list_symbol(list_display_name);
+  const symbolt *list_symbol = resolve_list_receiver_symbol(list_display_name);
   materialize_list_symbol(list_symbol);
   if (!list_symbol)
     throw std::runtime_error("List variable not found: " + list_display_name);
@@ -1920,8 +1972,11 @@ exprt function_call_expr::handle_list_index() const
   if (args.empty() || args.size() > 3)
     throw std::runtime_error("list.index() takes one to three arguments");
 
+  if (std::optional<exprt> folded = fold_constant_list_query())
+    return *folded;
+
   std::string list_display_name;
-  const symbolt *list_symbol = get_object_list_symbol(list_display_name);
+  const symbolt *list_symbol = resolve_list_receiver_symbol(list_display_name);
   materialize_list_symbol(list_symbol);
   if (!list_symbol)
     throw std::runtime_error("List variable not found: " + list_display_name);
@@ -2211,9 +2266,15 @@ bool function_call_expr::is_list_method_call() const
     return false;
 
   // Tuples are claimed earlier; only claim count/index here when the receiver
-  // resolves to a list symbol so str receivers fall through.
+  // resolves to a list symbol so str receivers fall through. A list *literal*
+  // receiver has no symbol yet, so claim it on the AST node: otherwise it fell
+  // through to the general-call handler, which folded `[1, 2, 1].index(1, 1)`
+  // to a constant 0 and verified false assertions.
   if (method_name == "count" || method_name == "index")
   {
+    if (call_["func"]["value"].value("_type", "") == "List")
+      return true;
+
     std::string dummy;
     const symbolt *sym = get_object_list_symbol(dummy);
     const typet list_type = type_handler_.get_list_type();

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -142,6 +142,30 @@ private:
    * for error messages (e.g. "mylist" or "nested[0]").
    */
   const symbolt *get_object_list_symbol(std::string &display_name) const;
+
+  /**
+   * @brief Resolve the list receiver of a method call to a symbol.
+   *
+   * A named receiver (`a.index(x)`) resolves through get_object_list_symbol. A
+   * list *literal* receiver (`[1, 2, 1].index(x)`) has no named symbol, so it
+   * is converted here and the temporary symbol its construction creates is
+   * returned. Without this the call fell through to the general-call handler,
+   * which folded `index()` to a constant 0 and verified false assertions.
+   *
+   * @param display_name Receiver name for diagnostics, when there is one.
+   * @return The receiver's symbol, or null when it is neither.
+   */
+  const symbolt *resolve_list_receiver_symbol(std::string &display_name) const;
+
+  /**
+   * @brief Fold a wholly literal list.count()/list.index() at conversion time.
+   *
+   * Keeps the result independent of --unwind: the list model searches with a
+   * loop, so a truncated one would silently mis-verify. Returns nothing when
+   * the receiver is not a list literal, when any operand is not itself a
+   * literal, or when index() would raise ValueError.
+   */
+  std::optional<exprt> fold_constant_list_query() const;
   void materialize_list_symbol(const symbolt *sym) const;
 
   /*

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -3,6 +3,7 @@
 #include <cctype>
 #include <cmath>
 #include <functional>
+#include <unordered_set>
 
 static double round_ties_to_even_consteval(const double value)
 {
@@ -307,6 +308,193 @@ std::optional<PyConstValue> python_consteval::try_eval_call(
   return PyConstValue::make_none();
 }
 
+// A seeded container is a snapshot; if any element is itself mutable, code
+// like `m = l[0]` hands out a live reference the alias scan below cannot
+// see, so only containers of recursively immutable elements are seedable.
+static bool is_recursively_immutable(const PyConstValue &v)
+{
+  switch (v.kind)
+  {
+  case PyConstValue::NONE:
+  case PyConstValue::BOOL:
+  case PyConstValue::INT:
+  case PyConstValue::FLOAT:
+  case PyConstValue::STRING:
+    return true;
+  case PyConstValue::LIST:
+    return false;
+  case PyConstValue::TUPLE:
+    for (const auto &e : v.tuple_val)
+      if (!is_recursively_immutable(e))
+        return false;
+    return true;
+  }
+  return false;
+}
+
+// Names whose container value could change without any assignment statement:
+// mutated in place through a non-pure method or a subscript store/delete,
+// aliased (bare-name assignment RHS, ternary branch, return value, parameter
+// default), or passed to a callee that may mutate them (issue #5955). The
+// scan walks the whole module, function bodies included, since a top-level
+// call can execute them. Seeding is an optimization, so every doubtful shape
+// poisons: a lost seed only means the fold falls through to the operational
+// model.
+static std::unordered_set<std::string>
+collect_unsafe_container_names(const nlohmann::json &ast)
+{
+  std::unordered_set<std::string> unsafe;
+
+  // Peel subscript/attribute chains so `l[0].append(x)` poisons `l`.
+  auto poison = [&unsafe](const nlohmann::json &node) {
+    const nlohmann::json *base = &node;
+    while (base->is_object() &&
+           (base->value("_type", "") == "Subscript" ||
+            base->value("_type", "") == "Attribute") &&
+           base->contains("value"))
+      base = &(*base)["value"];
+    if (
+      base->is_object() && base->value("_type", "") == "Name" &&
+      base->contains("id"))
+      unsafe.insert((*base)["id"].get<std::string>());
+  };
+
+  // Poison every Name anywhere beneath a node — the fallback for alias
+  // shapes not proven reference-free below.
+  std::function<void(const nlohmann::json &)> poison_all_names =
+    [&](const nlohmann::json &node) {
+      if (node.is_array())
+      {
+        for (const auto &e : node)
+          poison_all_names(e);
+        return;
+      }
+      if (!node.is_object())
+        return;
+      if (node.value("_type", "") == "Name")
+        poison(node);
+      for (const auto &child : node)
+        poison_all_names(child);
+    };
+
+  // Poison every name an expression could hand back a reference through.
+  // Default-deny: any shape not proven reference-free poisons every Name
+  // beneath it — a lost seed only costs a fold, never soundness. The
+  // reference-free shapes rely on the immutable-element seed gate below:
+  // BinOp/Subscript/comprehension results are fresh objects or element
+  // reads, and a seeded container's elements are all unaliasable scalars.
+  // Call results are covered by the walk's Call rule, which poisons any
+  // argument a callee could return an alias of.
+  std::function<void(const nlohmann::json &)> poison_aliases =
+    [&](const nlohmann::json &node) {
+      if (!node.is_object())
+        return;
+      const std::string t = node.value("_type", "");
+      if (t == "Name")
+        poison(node);
+      else if (
+        (t == "Tuple" || t == "List" || t == "Set") && node.contains("elts"))
+        for (const auto &e : node["elts"])
+          poison_aliases(e);
+      else if (t == "IfExp" || t == "BoolOp")
+      {
+        // Both yield one of their operands.
+        if (node.contains("body"))
+          poison_aliases(node["body"]);
+        if (node.contains("orelse"))
+          poison_aliases(node["orelse"]);
+        if (node.contains("values"))
+          for (const auto &v : node["values"])
+            poison_aliases(v);
+      }
+      else if (t == "Starred" && node.contains("value"))
+        poison_aliases(node["value"]);
+      else if (t == "Dict" && node.contains("values"))
+        for (const auto &v : node["values"])
+          poison_aliases(v);
+      else if (
+        t != "Constant" && t != "BinOp" && t != "UnaryOp" && t != "Compare" &&
+        t != "Call" && t != "Subscript" && t != "Attribute" &&
+        t != "JoinedStr" && t != "ListComp" && t != "SetComp" &&
+        t != "DictComp" && t != "GeneratorExp")
+        poison_all_names(node);
+    };
+
+  static const std::unordered_set<std::string> pure_methods = {
+    "count", "index"};
+  static const std::unordered_set<std::string> pure_builtins = {
+    "len", "sorted", "min", "max", "sum", "any", "all", "str", "tuple", "list"};
+
+  std::function<void(const nlohmann::json &)> walk =
+    [&](const nlohmann::json &node) {
+      if (node.is_array())
+      {
+        for (const auto &e : node)
+          walk(e);
+        return;
+      }
+      if (!node.is_object())
+        return;
+
+      const std::string t = node.value("_type", "");
+
+      if (
+        t == "Attribute" && node.contains("value") &&
+        !pure_methods.count(node.value("attr", "")))
+        poison(node["value"]);
+      else if (
+        t == "Subscript" && node.contains("value") && node.contains("ctx") &&
+        (node["ctx"].value("_type", "") == "Store" ||
+         node["ctx"].value("_type", "") == "Del"))
+        poison(node["value"]);
+      else if (t == "Call")
+      {
+        const bool pure_callee =
+          node.contains("func") && node["func"].is_object() &&
+          node["func"].value("_type", "") == "Name" &&
+          pure_builtins.count(node["func"].value("id", ""));
+        // A pure builtin neither mutates nor returns an alias of a bare Name
+        // argument (min(l) yields an element, unaliasable by the immutable-
+        // element seed gate), so those are exempt. A container-literal
+        // argument can smuggle the reference out — min([l]) IS l — so every
+        // other argument shape poisons regardless of the callee. Starred
+        // call arguments cannot reach a fold today: the AST preprocessor
+        // rejects f(*l) with a TypeError before conversion.
+        auto poison_argument = [&](const nlohmann::json &a) {
+          if (pure_callee && a.is_object() && a.value("_type", "") == "Name")
+            return;
+          poison_aliases(a);
+        };
+        if (node.contains("args"))
+          for (const auto &a : node["args"])
+            poison_argument(a);
+        if (node.contains("keywords"))
+          for (const auto &kw : node["keywords"])
+            if (kw.is_object() && kw.contains("value"))
+              poison_argument(kw["value"]);
+      }
+      else if (t == "NamedExpr" && node.contains("value"))
+        // The walrus target aliases the value wherever the expression
+        // appears (if conditions, call arguments, comprehension guards).
+        poison_aliases(node["value"]);
+      else if (
+        (t == "Assign" || t == "AnnAssign" || t == "Return") &&
+        node.contains("value") && !node["value"].is_null())
+        poison_aliases(node["value"]);
+      else if (
+        t == "FunctionDef" && node.contains("args") &&
+        node["args"].is_object() && node["args"].contains("defaults"))
+        for (const auto &d : node["args"]["defaults"])
+          poison_aliases(d);
+
+      for (const auto &child : node)
+        walk(child);
+    };
+
+  walk(ast);
+  return unsafe;
+}
+
 void python_consteval::seed_globals(Env &env)
 {
   if (!ast_.contains("body") || !ast_["body"].is_array())
@@ -341,6 +529,9 @@ void python_consteval::seed_globals(Env &env)
       count_target(stmt["target"]);
   }
 
+  const std::unordered_set<std::string> container_unsafe =
+    collect_unsafe_container_names(ast_);
+
   auto seed_one =
     [&](const nlohmann::json &target, const nlohmann::json &value) {
       if (!target.contains("_type") || target["_type"] != "Name")
@@ -349,8 +540,23 @@ void python_consteval::seed_globals(Env &env)
       if (write_count[name] != 1)
         return;
       auto val = eval_expr(value, env);
-      if (val)
-        env[name] = *val;
+      if (!val)
+        return;
+      // A container may change without an assignment statement — through a
+      // mutating method, subscript store, alias, or escape into a callee —
+      // so a seed here would bake in a stale value (issue #5955). Scalars
+      // are immutable, so mutation cannot invalidate them; rebinding
+      // through nested compound statements or `global` is a remaining
+      // write-count gap (issue #5955 follow-up).
+      if (val->kind == PyConstValue::LIST || val->kind == PyConstValue::TUPLE)
+      {
+        if (container_unsafe.count(name))
+          return;
+        for (const auto &e : val->tuple_val)
+          if (!is_recursively_immutable(e))
+            return;
+      }
+      env[name] = *val;
     };
 
   for (const auto &stmt : ast_["body"])

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -76,10 +76,42 @@ bool PyConstValue::is_truthy() const
   return false;
 }
 
+// CPython int/float equality is exact. A double equals a long long only when
+// it is integral and in long long range; comparing after casting the float
+// side stays exact, where casting the int side to double could collide with a
+// neighboring value above 2^53.
+static bool int_equals_double(long long i, double f)
+{
+  if (std::floor(f) != f)
+    return false;
+  if (f < -9223372036854775808.0 || f >= 9223372036854775808.0)
+    return false;
+  return static_cast<long long>(f) == i;
+}
+
 static bool pyconst_equal(const PyConstValue &lhs, const PyConstValue &rhs)
 {
   if (lhs.kind != rhs.kind)
-    return false;
+  {
+    // CPython compares bool/int/float numerically across kinds:
+    // True == 1 == 1.0. Any other kind mix is unequal.
+    const auto is_numeric = [](const PyConstValue &v) {
+      return v.kind == PyConstValue::BOOL || v.kind == PyConstValue::INT ||
+             v.kind == PyConstValue::FLOAT;
+    };
+    if (!is_numeric(lhs) || !is_numeric(rhs))
+      return false;
+
+    const auto as_int = [](const PyConstValue &v) {
+      return v.kind == PyConstValue::BOOL ? (v.bool_val ? 1LL : 0LL)
+                                          : v.int_val;
+    };
+    if (lhs.kind == PyConstValue::FLOAT)
+      return int_equals_double(as_int(rhs), lhs.float_val);
+    if (rhs.kind == PyConstValue::FLOAT)
+      return int_equals_double(as_int(lhs), rhs.float_val);
+    return as_int(lhs) == as_int(rhs);
+  }
 
   switch (lhs.kind)
   {

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -500,11 +500,14 @@ void python_consteval::seed_globals(Env &env)
   if (!ast_.contains("body") || !ast_["body"].is_array())
     return;
 
-  // Count every top-level write to each name (any Assign/AnnAssign/AugAssign
-  // target, including names bound through tuple/list unpacking). A name written
-  // more than once does not have a single stable module-scope value, so seeding
-  // it with its final value could mis-evaluate an assert that runs at an
-  // earlier program point — only single-write names are safe to seed.
+  // Count every module-scope write to each name (any Assign/AnnAssign/
+  // AugAssign target — including tuple/list/starred unpacking — plus
+  // `except ... as` bindings), walking through module-level compound
+  // statements but not into function or class bodies, which write their own
+  // scope. A name written more than once does not have a single stable
+  // module-scope value, so seeding it with its final value could
+  // mis-evaluate an assert that runs at an earlier program point — only
+  // single-write names are safe to seed.
   std::unordered_map<std::string, int> write_count;
   std::function<void(const nlohmann::json &)> count_target =
     [&](const nlohmann::json &tgt) {
@@ -516,18 +519,66 @@ void python_consteval::seed_globals(Env &env)
       else if ((tt == "Tuple" || tt == "List") && tgt.contains("elts"))
         for (const auto &e : tgt["elts"])
           count_target(e);
+      else if (tt == "Starred" && tgt.contains("value"))
+        count_target(tgt["value"]);
+    };
+  std::function<void(const nlohmann::json &)> count_stmt_writes =
+    [&](const nlohmann::json &stmt) {
+      if (!stmt.contains("_type"))
+        return;
+      const std::string &t = stmt["_type"];
+      if (t == "FunctionDef" || t == "AsyncFunctionDef" || t == "ClassDef")
+        return;
+      if (t == "Assign" && stmt.contains("targets"))
+        for (const auto &tgt : stmt["targets"])
+          count_target(tgt);
+      else if (
+        (t == "AnnAssign" || t == "AugAssign") && stmt.contains("target"))
+        count_target(stmt["target"]);
+      // For-loop targets and `with ... as` bindings need no cases here:
+      // the AST preprocessor rewrites for-loops into while-loops whose
+      // per-iteration `target = arr[i]` assignment the recursion below
+      // counts, and `with` never survives to a fold. Revisit if either
+      // changes.
+      if (stmt.contains("handlers") && stmt["handlers"].is_array())
+        for (const auto &h : stmt["handlers"])
+        {
+          if (h.is_object() && h.contains("name") && h["name"].is_string())
+            ++write_count[h["name"].get<std::string>()];
+          if (h.is_object() && h.contains("body") && h["body"].is_array())
+            for (const auto &sub : h["body"])
+              count_stmt_writes(sub);
+        }
+      for (const char *key : {"body", "orelse", "finalbody"})
+        if (stmt.contains(key) && stmt[key].is_array())
+          for (const auto &sub : stmt[key])
+            count_stmt_writes(sub);
     };
   for (const auto &stmt : ast_["body"])
-  {
-    if (!stmt.contains("_type"))
-      continue;
-    const std::string &t = stmt["_type"];
-    if (t == "Assign" && stmt.contains("targets"))
-      for (const auto &tgt : stmt["targets"])
-        count_target(tgt);
-    else if ((t == "AnnAssign" || t == "AugAssign") && stmt.contains("target"))
-      count_target(stmt["target"]);
-  }
+    count_stmt_writes(stmt);
+
+  // Names any function can rebind via `global` have no stable module-scope
+  // value either; collect them across the whole AST (this scan must descend
+  // into function bodies, unlike the write counter).
+  std::unordered_set<std::string> global_rebound;
+  std::function<void(const nlohmann::json &)> collect_global_decls =
+    [&](const nlohmann::json &node) {
+      if (node.is_array())
+      {
+        for (const auto &e : node)
+          collect_global_decls(e);
+        return;
+      }
+      if (!node.is_object())
+        return;
+      if (node.value("_type", "") == "Global" && node.contains("names"))
+        for (const auto &n : node["names"])
+          if (n.is_string())
+            global_rebound.insert(n.get<std::string>());
+      for (const auto &child : node)
+        collect_global_decls(child);
+    };
+  collect_global_decls(ast_);
 
   const std::unordered_set<std::string> container_unsafe =
     collect_unsafe_container_names(ast_);
@@ -537,7 +588,7 @@ void python_consteval::seed_globals(Env &env)
       if (!target.contains("_type") || target["_type"] != "Name")
         return;
       const std::string name = target["id"].get<std::string>();
-      if (write_count[name] != 1)
+      if (write_count[name] != 1 || global_rebound.count(name))
         return;
       auto val = eval_expr(value, env);
       if (!val)
@@ -545,9 +596,8 @@ void python_consteval::seed_globals(Env &env)
       // A container may change without an assignment statement — through a
       // mutating method, subscript store, alias, or escape into a callee —
       // so a seed here would bake in a stale value (issue #5955). Scalars
-      // are immutable, so mutation cannot invalidate them; rebinding
-      // through nested compound statements or `global` is a remaining
-      // write-count gap (issue #5955 follow-up).
+      // are immutable, so for them the write counter and the `global` set
+      // above are sufficient.
       if (val->kind == PyConstValue::LIST || val->kind == PyConstValue::TUPLE)
       {
         if (container_unsafe.count(name))


### PR DESCRIPTION
`seed_globals` admitted any single-assignment global into the fold environment, but in-place mutation (`l.append`), aliasing (`m = l`, walrus, BoolOp, `min([l])`), escape into callees, rebinds inside module-level compound statements, and `global` declarations all change a value without a top-level assignment statement — so the assert and str-slice folders folded from stale seeds and verified false assertions. Add a default-deny escape scan that refuses to seed such containers (requiring seeded elements to be immutable), count writes recursively through module-level compound statements, and never seed a name any function declares `global`.

Adds 11 regression tests under `regression/python/github_5955_*`: nine false-proof pins (mutation, stale operand, BoolOp/walrus/builtin-arg aliases, nested/scalar/for-target/global rebinds), a post-fix model contract, and an `--unwind 1` fold-retention guard against over-poisoning.

Stacked on #5954 (the stale-operand test needs its literal-receiver fix); only the last two commits are new once that merges.

Fixes #5955