### PR TITLE
[python] Extend OM verification harnesses: random, collections, gamma/remainder

### DIFF
--- a/regression/python/harness_collections_counter/main.py
+++ b/regression/python/harness_collections_counter/main.py
@@ -1,0 +1,29 @@
+# Verification harness for collections.Counter
+# (src/python-frontend/models/collections.py).
+#
+# The Counter model maps (int, int) keys to integer counts.  __getitem__
+# returns 0 for a key that was never written; __setitem__ records the count.
+#
+# REQUIRES:
+#   R1: nondet count values exercise arbitrary stored counts.
+#
+# ENSURES:
+#   E1: an unwritten key reads as 0              [default-count contract]
+#   E2: a written key reads back its value       [set/get round-trip]
+#   E3: distinct keys are independent            [no aliasing between keys]
+from collections import Counter
+
+p: int = nondet_int()
+q: int = nondet_int()
+
+c: Counter = Counter()
+
+assert c[(1, 2)] == 0           # E1
+
+c[(1, 2)] = p
+assert c[(1, 2)] == p           # E2
+
+c[(3, 4)] = q
+assert c[(3, 4)] == q           # E3
+assert c[(1, 2)] == p           # E3 (first key unchanged)
+assert c[(9, 9)] == 0           # E1 (still-unwritten key)

--- a/regression/python/harness_collections_counter/test.desc
+++ b/regression/python/harness_collections_counter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_collections_counter_fail/main.py
+++ b/regression/python/harness_collections_counter_fail/main.py
@@ -1,0 +1,14 @@
+# Falsification harness for collections.Counter
+# (src/python-frontend/models/collections.py).
+#
+# Validates the missing-key default: an unwritten key must read as 0, never a
+# positive count.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: Counter()[(9, 9)] == 1.  False — the model returns 0 for keys that
+#       were never written.
+from collections import Counter
+
+c: Counter = Counter()
+
+assert c[(9, 9)] == 1       # F1 — falsifiable (unwritten key is 0)

--- a/regression/python/harness_collections_counter_fail/test.desc
+++ b/regression/python/harness_collections_counter_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/harness_collections_defaultdict/main.py
+++ b/regression/python/harness_collections_defaultdict/main.py
@@ -1,0 +1,25 @@
+# Verification harness for collections.defaultdict
+# (src/python-frontend/models/collections.py).
+#
+# defaultdict(int) is modelled as a plain dict whose missing keys are filled
+# with the factory default (0 for int), tracked by the preprocessor.
+#
+# REQUIRES:
+#   R1: a nondet value exercises an arbitrary stored entry.
+#
+# ENSURES:
+#   E1: reading an absent key yields the factory default 0
+#   E2: an explicitly written key reads back its value
+#   E3: a still-absent key keeps returning the default
+from collections import defaultdict
+
+x: int = nondet_int()
+
+d: dict[int, int] = defaultdict(int)
+
+assert d[7] == 0        # E1
+
+d[7] = x
+assert d[7] == x        # E2
+
+assert d[100] == 0      # E3

--- a/regression/python/harness_collections_defaultdict/test.desc
+++ b/regression/python/harness_collections_defaultdict/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_collections_deque/main.py
+++ b/regression/python/harness_collections_deque/main.py
@@ -1,0 +1,27 @@
+# Verification harness for collections.deque
+# (src/python-frontend/models/collections.py).
+#
+# deque(iterable) is modelled as a list backing store exposing append / pop /
+# len / subscript.  This harness checks the list-copy construction and append.
+#
+# REQUIRES:
+#   R1: three fully non-deterministic integers seed the deque.
+#
+# ENSURES:
+#   E1: len(deque([a, b, c])) == 3               [construction copies all items]
+#   E2: element order is preserved               [d[i] matches the source]
+#   E3: append grows the deque by one at the tail
+from collections import deque
+
+a: int = nondet_int()
+b: int = nondet_int()
+c: int = nondet_int()
+
+d: list[int] = deque([a, b, c])
+
+assert len(d) == 3                              # E1
+assert d[0] == a and d[1] == b and d[2] == c    # E2
+
+d.append(99)
+assert len(d) == 4                              # E3
+assert d[3] == 99                               # E3

--- a/regression/python/harness_collections_deque/test.desc
+++ b/regression/python/harness_collections_deque/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_math_gamma/main.py
+++ b/regression/python/harness_math_gamma/main.py
@@ -1,0 +1,17 @@
+# Verification harness for math.gamma (src/python-frontend/models/math.py).
+#
+# For a positive integer x, gamma(x) == (x - 1)!.  The model computes this
+# branch exactly (an integer factorial widened to float), so the harness uses
+# concrete integer anchors: the general real-valued branch is a transcendental
+# Lanczos approximation whose float encoding is not amenable to symbolic
+# exploration here.
+#
+# ENSURES:
+#   E1: gamma(n) == (n - 1)! for n = 1..5        [integer-argument contract]
+import math
+
+assert math.gamma(1.0) == 1.0      # 0! == 1
+assert math.gamma(2.0) == 1.0      # 1! == 1
+assert math.gamma(3.0) == 2.0      # 2! == 2
+assert math.gamma(4.0) == 6.0      # 3! == 6
+assert math.gamma(5.0) == 24.0     # 4! == 24

--- a/regression/python/harness_math_gamma/test.desc
+++ b/regression/python/harness_math_gamma/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_math_remainder/main.py
+++ b/regression/python/harness_math_remainder/main.py
@@ -1,0 +1,28 @@
+# Verification harness for math.remainder (src/python-frontend/models/math.py).
+#
+# remainder(x, y) is the IEEE 754 remainder: x - n*y where n is the integer
+# nearest to x/y (ties to even).  Its magnitude never exceeds |y|/2.
+#
+# REQUIRES:
+#   R1: x is a finite nondet float (bounded interval); the divisor is the
+#       concrete non-zero value 4.0.
+#
+# ENSURES (r = remainder(x, 4.0)):
+#   E1: r >= -2.0                                [r >= -|y|/2]
+#   E2: r <=  2.0                                [r <=  |y|/2]
+#
+# Concrete anchors pin the round-to-nearest behaviour at representative points.
+import math
+
+x: float = nondet_float()
+
+__ESBMC_assume(-100.0 <= x <= 100.0)
+
+r: float = math.remainder(x, 4.0)
+
+assert r >= -2.0        # E1
+assert r <= 2.0         # E2
+
+assert math.remainder(5.0, 3.0) == -1.0    # nearest multiple of 3 to 5 is 6
+assert math.remainder(7.0, 3.0) == 1.0     # nearest multiple of 3 to 7 is 6
+assert math.remainder(10.0, 4.0) == 2.0    # tie 8/12 -> even multiple 8

--- a/regression/python/harness_math_remainder/test.desc
+++ b/regression/python/harness_math_remainder/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_math_remainder_fail/main.py
+++ b/regression/python/harness_math_remainder_fail/main.py
@@ -1,0 +1,20 @@
+# Falsification harness for math.remainder (src/python-frontend/models/math.py).
+#
+# The IEEE remainder is signed: it can be negative when x/y rounds up.  A
+# non-negativity claim must therefore be falsifiable.
+#
+# REQUIRES:
+#   R1: x is a finite nondet float (bounded interval).
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: remainder(x, 4.0) >= 0.0.  False e.g. for x == 3.0 (nearest multiple
+#       of 4 is 4, so remainder is -1.0).
+import math
+
+x: float = nondet_float()
+
+__ESBMC_assume(-100.0 <= x <= 100.0)
+
+r: float = math.remainder(x, 4.0)
+
+assert r >= 0.0         # F1 — falsifiable (remainder is signed)

--- a/regression/python/harness_math_remainder_fail/test.desc
+++ b/regression/python/harness_math_remainder_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/harness_random_getrandbits/main.py
+++ b/regression/python/harness_random_getrandbits/main.py
@@ -1,0 +1,22 @@
+# Verification harness for random.getrandbits
+# (src/python-frontend/models/random.py).
+#
+# getrandbits(k) returns a non-deterministic integer using exactly k random
+# bits, i.e. a value in [0, 2**k - 1]; k == 0 yields 0.
+#
+# REQUIRES:
+#   R1: k is a bounded non-negative integer (getrandbits raises for k < 0).
+#
+# ENSURES (v = getrandbits(k)):
+#   E1: v >= 0                                   [k random bits are unsigned]
+#   E2: v <= (1 << k) - 1                        [at most k bits set]
+import random
+
+k: int = nondet_int()
+
+__ESBMC_assume(0 <= k <= 16)
+
+v: int = random.getrandbits(k)
+
+assert v >= 0                   # E1
+assert v <= (1 << k) - 1        # E2

--- a/regression/python/harness_random_getrandbits/test.desc
+++ b/regression/python/harness_random_getrandbits/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 20
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_randint/main.py
+++ b/regression/python/harness_random_randint/main.py
@@ -1,0 +1,24 @@
+# Verification harness for random.randint (src/python-frontend/models/random.py).
+#
+# randint(a, b) returns a non-deterministic integer in the closed range [a, b].
+#
+# REQUIRES:
+#   R1: a <= b (randint requires a non-empty range).
+#   R2: a, b bounded so the harness stays finite.
+#
+# ENSURES (v = randint(a, b)):
+#   E1: v >= a                                   [lower bound honoured]
+#   E2: v <= b                                   [upper bound honoured]
+import random
+
+a: int = nondet_int()
+b: int = nondet_int()
+
+__ESBMC_assume(a <= b)
+__ESBMC_assume(-1000 <= a <= 1000)
+__ESBMC_assume(-1000 <= b <= 1000)
+
+v: int = random.randint(a, b)
+
+assert v >= a       # E1
+assert v <= b       # E2

--- a/regression/python/harness_random_randint/test.desc
+++ b/regression/python/harness_random_randint/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_randint_fail/main.py
+++ b/regression/python/harness_random_randint_fail/main.py
@@ -1,0 +1,18 @@
+# Falsification harness for random.randint (src/python-frontend/models/random.py).
+#
+# randint(a, b) is inclusive of b, so a strict upper bound must be falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: randint(a, b) < b.  False whenever the model returns the endpoint b.
+import random
+
+a: int = nondet_int()
+b: int = nondet_int()
+
+__ESBMC_assume(a <= b)
+__ESBMC_assume(-100 <= a <= 100)
+__ESBMC_assume(-100 <= b <= 100)
+
+v: int = random.randint(a, b)
+
+assert v < b        # F1 — falsifiable (b is a legal result)

--- a/regression/python/harness_random_randint_fail/test.desc
+++ b/regression/python/harness_random_randint_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/harness_random_random/main.py
+++ b/regression/python/harness_random_random/main.py
@@ -1,0 +1,16 @@
+# Verification harness for random.random (src/python-frontend/models/random.py).
+#
+# random() returns a non-deterministic float in the half-open interval [0, 1).
+#
+# REQUIRES:
+#   (none) — random() takes no arguments.
+#
+# ENSURES (r = random()):
+#   E1: r >= 0.0                                 [lower bound is inclusive]
+#   E2: r < 1.0                                  [upper bound is exclusive]
+import random
+
+r: float = random.random()
+
+assert r >= 0.0     # E1
+assert r < 1.0      # E2

--- a/regression/python/harness_random_random/test.desc
+++ b/regression/python/harness_random_random/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_randrange/main.py
+++ b/regression/python/harness_random_randrange/main.py
@@ -1,0 +1,21 @@
+# Verification harness for random.randrange
+# (src/python-frontend/models/random.py).
+#
+# randrange(start, stop, step) returns a non-deterministic value of the form
+# start + i*step that lies in [start, stop).
+#
+# REQUIRES:
+#   (none) — concrete arguments exercise the stepped-range arithmetic.
+#
+# ENSURES (v = randrange(3, 20, 4)):
+#   E1: 3 <= v < 20                              [result lies in the range]
+#   E2: (v - 3) % 4 == 0                         [result is on the step grid]
+#   E3: v in {3, 7, 11, 15, 19}                  [exact set of legal values]
+import random
+
+v: int = random.randrange(3, 20, 4)
+
+assert 3 <= v            # E1 lower
+assert v < 20            # E1 upper
+assert (v - 3) % 4 == 0  # E2
+assert v == 3 or v == 7 or v == 11 or v == 15 or v == 19   # E3

--- a/regression/python/harness_random_randrange/test.desc
+++ b/regression/python/harness_random_randrange/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_uniform/main.py
+++ b/regression/python/harness_random_uniform/main.py
@@ -1,0 +1,25 @@
+# Verification harness for random.uniform (src/python-frontend/models/random.py).
+#
+# uniform(a, b) returns a non-deterministic float in the interval bounded by a
+# and b, regardless of which endpoint is larger.
+#
+# REQUIRES:
+#   R1: a, b are finite nondet floats (bounded interval).
+#
+# ENSURES (v = uniform(a, b)):
+#   E1: when a <= b, a <= v <= b                 [ordered endpoints]
+#   E2: when a >  b, b <= v <= a                 [reversed endpoints]
+import random
+
+a: float = nondet_float()
+b: float = nondet_float()
+
+__ESBMC_assume(-1000.0 <= a <= 1000.0)
+__ESBMC_assume(-1000.0 <= b <= 1000.0)
+
+v: float = random.uniform(a, b)
+
+if a <= b:
+    assert a <= v and v <= b        # E1
+else:
+    assert b <= v and v <= a        # E2

--- a/regression/python/harness_random_uniform/test.desc
+++ b/regression/python/harness_random_uniform/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Extend the Python operational-model verification harness suite (follow-up to
#5958) with 13 harnesses across three more models: random bounds
(randint, uniform, getrandbits, randrange, random), collections (deque,
Counter, defaultdict) and math gamma/remainder. Each states explicit
`__ESBMC_assume` preconditions and `assert` postconditions traced per contract
clause, and the suite includes three negative `_fail` variants (inclusive
randint endpoint, Counter zero-default, signed remainder) that falsify
plausible-but-wrong strengthenings.

All harnesses live in `regression/python/` under the `harness_` prefix, pass
via `ctest -R harness_`, and are auto-excluded from the CPython sanity check
where they use ESBMC intrinsics.
