### PR TITLE
[python] Fix wrong pi constant in math.gamma/lgamma Lanczos branch

### DIFF
--- a/regression/python/math_gamma_noninteger/main.py
+++ b/regression/python/math_gamma_noninteger/main.py
@@ -1,0 +1,9 @@
+import math
+
+# Non-integer argument exercises the Lanczos branch of math.gamma, which
+# scales by sqrt(2 * pi). With the correct value of pi, gamma(0.5) equals
+# sqrt(pi) = 1.7724538509055159 to full working precision. A wrong constant
+# (the former pi = 3.14153) shifts the result by ~1.8e-5, so the 1e-6
+# tolerance below pins the fix.
+r: float = math.gamma(0.5)
+assert math.fabs(r - 1.7724538509055159) < 1e-6

--- a/regression/python/math_gamma_noninteger/test.desc
+++ b/regression/python/math_gamma_noninteger/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math_gamma_noninteger_fail/main.py
+++ b/regression/python/math_gamma_noninteger_fail/main.py
@@ -1,0 +1,7 @@
+import math
+
+# gamma(0.5) = sqrt(pi) = 1.7724538509055159, which is strictly greater than
+# 1.7724. The upper-bound claim below is therefore falsifiable and must yield
+# VERIFICATION FAILED — a negative counterpart to math_gamma_noninteger.
+r: float = math.gamma(0.5)
+assert r < 1.7724

--- a/regression/python/math_gamma_noninteger_fail/test.desc
+++ b/regression/python/math_gamma_noninteger_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION FAILED$

--- a/regression/python/math_lgamma_noninteger/main.py
+++ b/regression/python/math_lgamma_noninteger/main.py
@@ -1,0 +1,8 @@
+import math
+
+# Non-integer argument exercises the Lanczos branch of math.lgamma, which adds
+# 0.5 * log(2 * pi). With the correct value of pi, lgamma(0.5) equals
+# log(sqrt(pi)) = 0.5 * log(pi) = 0.5723649429247001. The former pi = 3.14153
+# shifts the result, so the 1e-6 tolerance pins the fix.
+r: float = math.lgamma(0.5)
+assert math.fabs(r - 0.5723649429247001) < 1e-6

--- a/regression/python/math_lgamma_noninteger/test.desc
+++ b/regression/python/math_lgamma_noninteger/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -626,7 +626,6 @@ def gamma(x: float) -> float:
     Calculate the gamma function of x.
     For positive integers x, this function satisfies gamma(x) = (x - 1)!.
     """
-    pi_const: float = 3.14153
     if x == int(x):
         xi: int = int(x)
         if xi <= 0:
@@ -647,7 +646,7 @@ def gamma(x: float) -> float:
     a: float = _lanczos_sum(z)
 
     t: float = z + 7.0 + 0.5
-    return sqrt(2.0 * pi_const) * pow(t, z + 0.5) * exp(0.0 - t) * a
+    return sqrt(2.0 * pi) * pow(t, z + 0.5) * exp(0.0 - t) * a
 
 
 def ldexp(x: float, i: int) -> float:
@@ -663,7 +662,6 @@ def lgamma(x: float) -> float:
     """
     Calculate the natural logarithm of the absolute value of the gamma function
     """
-    pi_const: float = 3.14153
     if x == int(x):
         xi: int = int(x)
         if xi <= 0:
@@ -682,7 +680,7 @@ def lgamma(x: float) -> float:
     a: float = _lanczos_sum(z)
 
     t: float = z + 7.0 + 0.5
-    return 0.5 * log(2.0 * pi_const) + (z + 0.5) * log(t) - t + log(a)
+    return 0.5 * log(2.0 * pi) + (z + 0.5) * log(t) - t + log(a)
 
 
 def remainder(x: float, y: float) -> float:


### PR DESCRIPTION
The Lanczos approximation branch of `math.gamma` and `math.lgamma` (taken for
non-integer arguments) scaled by a local `pi_const = 3.14153` — a value of pi
wrong in the 5th decimal place — which skewed every non-integer result by
~1.8e-5. This replaces it with the accurate module-level `pi`
(3.141592653589793), already referenced by `degrees`/`radians`, and drops the
duplicated local.

Integer arguments were unaffected (they take the exact factorial branch), so
the existing `math35_gamma` / `math37_lgamma` / `math_edge_*` tests still hold;
the full python `math*` regression subset (190 tests) passes. New regressions
pin the corrected constant: `gamma(0.5) == sqrt(pi)` and
`lgamma(0.5) == log(sqrt(pi))` at 1e-6 tolerance (verified to fail on the
pre-fix model), plus a failing companion.
