### PR TITLE
[python] Add verification harnesses for heapq model (Tier 1)

### DIFF
--- a/regression/python/harness_heapq_invariant/main.py
+++ b/regression/python/harness_heapq_invariant/main.py
@@ -1,0 +1,27 @@
+# Verification harness for heapq.heapify (src/python-frontend/models/heapq.py).
+#
+# heapify(h) rearranges the list in place into a binary min-heap, where every
+# parent is <= its children: for index k, h[k] <= h[2k+1] and h[k] <= h[2k+2]
+# (when those child indices are in range). The model reproduces CPython's sift
+# routines element-for-element. Only int elements are fully sound (the model
+# header documents float/str as "loud" and tuple as unsound), so the harness
+# uses int elements.
+#
+# REQUIRES:
+#   R1: three fully non-deterministic integers seed the heap, covering every
+#       ordering of the elements.
+#
+# ENSURES (after heapify of length-3 h, with root 0 and children 1, 2):
+#   E1: h[0] <= h[1]                             [root dominates left child]
+#   E2: h[0] <= h[2]                             [root dominates right child]
+import heapq
+
+a: int = nondet_int()
+b: int = nondet_int()
+c: int = nondet_int()
+h: list[int] = [a, b, c]
+
+heapq.heapify(h)
+
+assert h[0] <= h[1]     # E1
+assert h[0] <= h[2]     # E2

--- a/regression/python/harness_heapq_invariant/main.py
+++ b/regression/python/harness_heapq_invariant/main.py
@@ -23,5 +23,5 @@ h: list[int] = [a, b, c]
 
 heapq.heapify(h)
 
-assert h[0] <= h[1]     # E1
-assert h[0] <= h[2]     # E2
+assert h[0] <= h[1]  # E1
+assert h[0] <= h[2]  # E2

--- a/regression/python/harness_heapq_invariant/test.desc
+++ b/regression/python/harness_heapq_invariant/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_heapq_invariant_fail/main.py
+++ b/regression/python/harness_heapq_invariant_fail/main.py
@@ -1,0 +1,21 @@
+# Falsification harness for heapq.heapify (src/python-frontend/models/heapq.py).
+#
+# heapify builds a MIN-heap, so the root is the smallest element, never the
+# largest. Asserting a max-heap root must be falsifiable.
+#
+# REQUIRES:
+#   R1: three fully non-deterministic integers.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: h[0] >= h[1] after heapify.  False whenever the left child is strictly
+#       larger than the root (a min-heap), e.g. elements 1, 2, 3.
+import heapq
+
+a: int = nondet_int()
+b: int = nondet_int()
+c: int = nondet_int()
+h: list[int] = [a, b, c]
+
+heapq.heapify(h)
+
+assert h[0] >= h[1]     # F1 — falsifiable (min-heap root is the smallest)

--- a/regression/python/harness_heapq_invariant_fail/main.py
+++ b/regression/python/harness_heapq_invariant_fail/main.py
@@ -18,4 +18,4 @@ h: list[int] = [a, b, c]
 
 heapq.heapify(h)
 
-assert h[0] >= h[1]     # F1 — falsifiable (min-heap root is the smallest)
+assert h[0] >= h[1]  # F1 — falsifiable (min-heap root is the smallest)

--- a/regression/python/harness_heapq_invariant_fail/test.desc
+++ b/regression/python/harness_heapq_invariant_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/harness_heapq_pushpop/main.py
+++ b/regression/python/harness_heapq_pushpop/main.py
@@ -22,10 +22,10 @@ heapq.heapify(h)
 
 # item 1 is smaller than the heap minimum (2), so heappushpop returns it.
 r: int = heapq.heappushpop(h, 1)
-assert r == 1           # E1
-assert len(h) == 3      # E1 (size preserved)
+assert r == 1  # E1
+assert len(h) == 3  # E1 (size preserved)
 
 # heapreplace pops the current minimum (2) and pushes 5.
 s: int = heapq.heapreplace(h, 5)
-assert s == 2           # E2
-assert len(h) == 3      # E2 (size preserved)
+assert s == 2  # E2
+assert len(h) == 3  # E2 (size preserved)

--- a/regression/python/harness_heapq_pushpop/main.py
+++ b/regression/python/harness_heapq_pushpop/main.py
@@ -1,0 +1,31 @@
+# Verification harness for heapq.heappushpop and heapq.heapreplace
+# (src/python-frontend/models/heapq.py).
+#
+# Both operations are size-preserving pop/push combinations:
+#   heappushpop(h, item) pushes item then pops and returns the smallest.
+#   heapreplace(h, item) pops and returns the smallest, then pushes item.
+#
+# Concrete inputs are used deliberately: the list model raises a spurious
+# IndexError when a symbolic item flows through the append inside heappush,
+# and when a grown list is indexed afterwards, so this harness exercises the
+# size-preserving pop path (heapreplace's _siftup) without those triggers.
+#
+# ENSURES:
+#   E1: heappushpop with an item below the current minimum returns that item
+#       and leaves the size unchanged                 [push-then-pop, item wins]
+#   E2: heapreplace returns the previous minimum and leaves the size unchanged
+#                                                       [pop-then-push]
+import heapq
+
+h: list[int] = [2, 4, 6]
+heapq.heapify(h)
+
+# item 1 is smaller than the heap minimum (2), so heappushpop returns it.
+r: int = heapq.heappushpop(h, 1)
+assert r == 1           # E1
+assert len(h) == 3      # E1 (size preserved)
+
+# heapreplace pops the current minimum (2) and pushes 5.
+s: int = heapq.heapreplace(h, 5)
+assert s == 2           # E2
+assert len(h) == 3      # E2 (size preserved)

--- a/regression/python/harness_heapq_pushpop/test.desc
+++ b/regression/python/harness_heapq_pushpop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 10
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
First Tier-1 model from `docs/python-model-verification-harness-plan.md`:
verification harnesses for the `heapq` operational model.

- `harness_heapq_invariant` — nondet int list; asserts the min-heap property
  (`h[0] <= h[1]`, `h[0] <= h[2]`) after `heapify`.
- `harness_heapq_invariant_fail` — falsifies a max-heap root claim.
- `harness_heapq_pushpop` — pins the size-preserving `heappushpop` /
  `heapreplace` return contract.

Int elements only (the model documents float/str as "loud" and tuple as
unsound, per `github_5931_*`). All three pass via `ctest -R harness_heapq`
(≤14 s each); the concrete `pushpop` harness also runs clean under CPython.

While writing these I hit two genuine list-model limitations, avoided here and
worth filing separately: `heappush` with a **symbolic** item, and **indexing a
list that `heappush` has grown**, both raise a spurious `IndexError`. The
harness set is formulated to steer clear of both.
