### PR TITLE
[python] Add verification harnesses for queue model (Tier 1)

### DIFF
--- a/regression/python/harness_queue_empty_full/main.py
+++ b/regression/python/harness_queue_empty_full/main.py
@@ -1,0 +1,36 @@
+# Verification harness for Queue.empty / full / qsize
+# (src/python-frontend/models/queue.py).
+#
+# empty() is True iff qsize() == 0; full() is True iff maxsize > 0 and
+# qsize() >= maxsize. The model tracks maxsize but put() does not block on it.
+#
+# REQUIRES:
+#   R1: two non-deterministic integer payloads; a bounded maxsize of 2.
+#
+# ENSURES:
+#   E1: a fresh bounded queue is empty and not full
+#   E2: below capacity: not empty, not full, qsize tracks the count
+#   E3: at capacity: full() becomes True exactly when qsize == maxsize
+#   E4: after a get(), it is neither full nor empty again
+from queue import Queue
+
+a: int = nondet_int()
+b: int = nondet_int()
+
+q: Queue = Queue(2)          # maxsize == 2
+
+assert q.empty()             # E1
+assert not q.full()          # E1
+
+q.put(a)
+assert not q.empty()         # E2
+assert q.qsize() == 1        # E2
+assert not q.full()          # E2
+
+q.put(b)
+assert q.full()              # E3 (qsize 2 >= maxsize 2)
+assert q.qsize() == 2        # E3
+
+x: int = q.get()
+assert not q.full()          # E4
+assert not q.empty()         # E4

--- a/regression/python/harness_queue_empty_full/main.py
+++ b/regression/python/harness_queue_empty_full/main.py
@@ -17,20 +17,20 @@ from queue import Queue
 a: int = nondet_int()
 b: int = nondet_int()
 
-q: Queue = Queue(2)          # maxsize == 2
+q: Queue = Queue(2)  # maxsize == 2
 
-assert q.empty()             # E1
-assert not q.full()          # E1
+assert q.empty()  # E1
+assert not q.full()  # E1
 
 q.put(a)
-assert not q.empty()         # E2
-assert q.qsize() == 1        # E2
-assert not q.full()          # E2
+assert not q.empty()  # E2
+assert q.qsize() == 1  # E2
+assert not q.full()  # E2
 
 q.put(b)
-assert q.full()              # E3 (qsize 2 >= maxsize 2)
-assert q.qsize() == 2        # E3
+assert q.full()  # E3 (qsize 2 >= maxsize 2)
+assert q.qsize() == 2  # E3
 
 x: int = q.get()
-assert not q.full()          # E4
-assert not q.empty()         # E4
+assert not q.full()  # E4
+assert not q.empty()  # E4

--- a/regression/python/harness_queue_empty_full/test.desc
+++ b/regression/python/harness_queue_empty_full/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_queue_fifo/main.py
+++ b/regression/python/harness_queue_fifo/main.py
@@ -21,10 +21,10 @@ q.put(a)
 q.put(b)
 q.put(c)
 
-assert q.qsize() == 3        # E1
-assert not q.empty()         # E1
-assert q.get() == a          # E2
-assert q.get() == b          # E2
-assert q.get() == c          # E2
-assert q.empty()             # E3
-assert q.qsize() == 0        # E3
+assert q.qsize() == 3  # E1
+assert not q.empty()  # E1
+assert q.get() == a  # E2
+assert q.get() == b  # E2
+assert q.get() == c  # E2
+assert q.empty()  # E3
+assert q.qsize() == 0  # E3

--- a/regression/python/harness_queue_fifo/main.py
+++ b/regression/python/harness_queue_fifo/main.py
@@ -1,0 +1,30 @@
+# Verification harness for queue.Queue (src/python-frontend/models/queue.py).
+#
+# queue.Queue is a list-backed FIFO: put() appends, get() removes and returns
+# the oldest element. Under sequential symbolic execution there is no blocking.
+#
+# REQUIRES:
+#   R1: three fully non-deterministic integers exercise arbitrary payloads.
+#
+# ENSURES (after put(a), put(b), put(c)):
+#   E1: qsize() reports 3, and empty() is False    [enqueue tracking]
+#   E2: get() returns a, then b, then c            [first-in-first-out order]
+#   E3: the queue is empty afterwards               [every element dequeued once]
+from queue import Queue
+
+a: int = nondet_int()
+b: int = nondet_int()
+c: int = nondet_int()
+
+q: Queue = Queue()
+q.put(a)
+q.put(b)
+q.put(c)
+
+assert q.qsize() == 3        # E1
+assert not q.empty()         # E1
+assert q.get() == a          # E2
+assert q.get() == b          # E2
+assert q.get() == c          # E2
+assert q.empty()             # E3
+assert q.qsize() == 0        # E3

--- a/regression/python/harness_queue_fifo/test.desc
+++ b/regression/python/harness_queue_fifo/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_queue_fifo_fail/main.py
+++ b/regression/python/harness_queue_fifo_fail/main.py
@@ -18,4 +18,4 @@ q: Queue = Queue()
 q.put(a)
 q.put(b)
 
-assert q.get() == b          # F1 — falsifiable (FIFO returns a first)
+assert q.get() == b  # F1 — falsifiable (FIFO returns a first)

--- a/regression/python/harness_queue_fifo_fail/main.py
+++ b/regression/python/harness_queue_fifo_fail/main.py
@@ -1,0 +1,21 @@
+# Falsification harness for queue.Queue (src/python-frontend/models/queue.py).
+#
+# A FIFO returns the FIRST element enqueued, not the last. Asserting LIFO order
+# on a Queue must be falsifiable.
+#
+# REQUIRES:
+#   R1: two distinct non-deterministic integers (a != b) so the order matters.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: after put(a), put(b), get() == b.  A FIFO returns a first.
+from queue import Queue
+
+a: int = nondet_int()
+b: int = nondet_int()
+__ESBMC_assume(a != b)
+
+q: Queue = Queue()
+q.put(a)
+q.put(b)
+
+assert q.get() == b          # F1 — falsifiable (FIFO returns a first)

--- a/regression/python/harness_queue_fifo_fail/test.desc
+++ b/regression/python/harness_queue_fifo_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 10
+^VERIFICATION FAILED$

--- a/regression/python/harness_queue_lifo/main.py
+++ b/regression/python/harness_queue_lifo/main.py
@@ -21,8 +21,8 @@ q.put(a)
 q.put(b)
 q.put(c)
 
-assert q.qsize() == 3        # E1
-assert q.get() == c          # E2
-assert q.get() == b          # E2
-assert q.get() == a          # E2
-assert q.empty()             # E3
+assert q.qsize() == 3  # E1
+assert q.get() == c  # E2
+assert q.get() == b  # E2
+assert q.get() == a  # E2
+assert q.empty()  # E3

--- a/regression/python/harness_queue_lifo/main.py
+++ b/regression/python/harness_queue_lifo/main.py
@@ -1,0 +1,28 @@
+# Verification harness for queue.LifoQueue (src/python-frontend/models/queue.py).
+#
+# queue.LifoQueue is a list-backed LIFO (stack): put() appends, get() removes
+# and returns the most recently added element.
+#
+# REQUIRES:
+#   R1: three fully non-deterministic integers exercise arbitrary payloads.
+#
+# ENSURES (after put(a), put(b), put(c)):
+#   E1: qsize() reports 3                          [enqueue tracking]
+#   E2: get() returns c, then b, then a            [last-in-first-out order]
+#   E3: the queue is empty afterwards               [every element popped once]
+from queue import LifoQueue
+
+a: int = nondet_int()
+b: int = nondet_int()
+c: int = nondet_int()
+
+q: LifoQueue = LifoQueue()
+q.put(a)
+q.put(b)
+q.put(c)
+
+assert q.qsize() == 3        # E1
+assert q.get() == c          # E2
+assert q.get() == b          # E2
+assert q.get() == a          # E2
+assert q.empty()             # E3

--- a/regression/python/harness_queue_lifo/test.desc
+++ b/regression/python/harness_queue_lifo/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 10
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Second Tier-1 model from `docs/python-model-verification-harness-plan.md`
(after heapq in #5965): verification harnesses for the `queue` operational
model.

- `harness_queue_fifo` — nondet payloads; asserts `Queue`'s FIFO get order with
  `qsize()`/`empty()` tracking.
- `harness_queue_lifo` — asserts `LifoQueue`'s LIFO get order.
- `harness_queue_empty_full` — pins the `empty()`/`full()`/`qsize()` contract
  against a bounded `maxsize`.
- `harness_queue_fifo_fail` — asserts LIFO order on a FIFO to confirm the check
  is falsifiable.

All four pass via `ctest -R harness_queue` (≤13 s each). Unlike the heapq
list-model (#5965), Queue drives nondet payloads cleanly — it appends and pops
without indexing, so none of the list-model IndexError triggers apply.
