### PR TITLE
[python] Add verification harnesses for float model (Tier 1)

### DIFF
--- a/regression/python/harness_float_is_integer/main.py
+++ b/regression/python/harness_float_is_integer/main.py
@@ -18,14 +18,14 @@ x: float = nondet_float()
 __ESBMC_assume(-1000.0 <= x <= 1000.0)
 
 r: bool = x.is_integer()
-assert r == (x == int(x))            # E1
+assert r == (x == int(x))  # E1
 if r:
-    assert x == int(x)               # E2
+    assert x == int(x)  # E2
 
 n: int = nondet_int()
 __ESBMC_assume(-1000 <= n <= 1000)
 y: float = float(n)
-assert y.is_integer()                # E3
+assert y.is_integer()  # E3
 
 # Concrete anchors.
 assert (5.0).is_integer()

--- a/regression/python/harness_float_is_integer/main.py
+++ b/regression/python/harness_float_is_integer/main.py
@@ -1,0 +1,33 @@
+# Verification harness for float.is_integer (src/python-frontend/models/float.py).
+#
+# x.is_integer() returns True iff the float x has no fractional part; the model
+# computes this as x == int(x) (int truncates toward zero).
+#
+# REQUIRES:
+#   R1: a nondet float x, bounded to a finite interval so int(x) is well-defined.
+#   R2: a nondet int n, bounded, to build an integral float.
+#
+# ENSURES:
+#   E1: is_integer() agrees with the truncation test: r == (x == int(x))
+#   E2: is_integer() True implies the value equals its truncation
+#   E3: a float built from an int is integral
+#
+# Note: float(n).is_integer() is split across a local (y) because the frontend
+# mis-lowers the chained call float(n).is_integer() into a TypeError.
+x: float = nondet_float()
+__ESBMC_assume(-1000.0 <= x <= 1000.0)
+
+r: bool = x.is_integer()
+assert r == (x == int(x))            # E1
+if r:
+    assert x == int(x)               # E2
+
+n: int = nondet_int()
+__ESBMC_assume(-1000 <= n <= 1000)
+y: float = float(n)
+assert y.is_integer()                # E3
+
+# Concrete anchors.
+assert (5.0).is_integer()
+assert not (5.5).is_integer()
+assert (0.0).is_integer()

--- a/regression/python/harness_float_is_integer/test.desc
+++ b/regression/python/harness_float_is_integer/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_float_is_integer_fail/main.py
+++ b/regression/python/harness_float_is_integer_fail/main.py
@@ -1,0 +1,15 @@
+# Falsification harness for float.is_integer
+# (src/python-frontend/models/float.py).
+#
+# Not every float is integral, so asserting that a nondet float has no
+# fractional part must be falsifiable.
+#
+# REQUIRES:
+#   R1: a nondet float x bounded to a finite interval.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: x.is_integer() for all x.  False e.g. for x == 0.5.
+x: float = nondet_float()
+__ESBMC_assume(-1000.0 <= x <= 1000.0)
+
+assert x.is_integer()        # F1 — falsifiable (non-integral floats exist)

--- a/regression/python/harness_float_is_integer_fail/main.py
+++ b/regression/python/harness_float_is_integer_fail/main.py
@@ -12,4 +12,4 @@
 x: float = nondet_float()
 __ESBMC_assume(-1000.0 <= x <= 1000.0)
 
-assert x.is_integer()        # F1 — falsifiable (non-integral floats exist)
+assert x.is_integer()  # F1 — falsifiable (non-integral floats exist)

--- a/regression/python/harness_float_is_integer_fail/test.desc
+++ b/regression/python/harness_float_is_integer_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION FAILED$


### PR DESCRIPTION
Third Tier-1 model from `docs/python-model-verification-harness-plan.md`
(after heapq #5965 and queue #5966): verification harnesses for
`float.is_integer`.

- `harness_float_is_integer` — nondet float; asserts `is_integer()` agrees with
  the truncation test `x == int(x)`, that a float built from a nondet int is
  integral, plus concrete anchors (`5.0`, `5.5`, `0.0`).
- `harness_float_is_integer_fail` — asserts every nondet float is integral, to
  confirm the check is falsifiable.

Both pass via `ctest -R harness_float_is_integer` (~3 s each).

Implementation note: `float(n).is_integer()` is split across a local because
the frontend mis-lowers the *chained* call into a spurious `TypeError` (same
chained-method-call limitation seen with `int.conjugate().conjugate()` in
#5958). Using an intermediate variable is sound.
