### PR TITLE
[python] Add verification harnesses for string constants (Tier 1)

### DIFF
--- a/regression/python/harness_string_constants/main.py
+++ b/regression/python/harness_string_constants/main.py
@@ -1,0 +1,38 @@
+# Verification harness for the string module constants
+# (src/python-frontend/models/string.py).
+#
+# The model defines the standard character-class constants. This harness pins
+# the short-string lengths and the boundary characters of each range via O(1)
+# indexing. It is intrinsic-free, so it also runs under CPython.
+#
+# The program is fully concrete, so it is verified with plain BMC. Lengths are
+# checked only on the short constants (digits, octdigits): len() scans to the
+# terminator, and scanning the 52-char ascii_letters would demand a large
+# unwind bound that stresses the solver. ascii_letters' layout is pinned
+# structurally by its boundary indices instead, which need no scan.
+#
+# ENSURES:
+#   E1: digits and octdigits have their documented lengths
+#   E2: the digit / lowercase / uppercase ranges start and end at the right chars
+#   E3: ascii_letters is ascii_lowercase followed by ascii_uppercase
+import string
+
+# E1 — short-string lengths
+assert len(string.digits) == 10
+assert len(string.octdigits) == 8
+
+# E2 — range boundaries via O(1) indexing
+assert string.digits[0] == '0'
+assert string.digits[9] == '9'
+assert string.ascii_lowercase[0] == 'a'
+assert string.ascii_lowercase[25] == 'z'
+assert string.ascii_uppercase[0] == 'A'
+assert string.ascii_uppercase[25] == 'Z'
+
+# E3 — ascii_letters == ascii_lowercase then ascii_uppercase
+assert string.ascii_letters[0] == 'a'
+assert string.ascii_letters[25] == 'z'
+assert string.ascii_letters[26] == 'A'
+assert string.ascii_letters[51] == 'Z'
+
+assert string.hexdigits[0] == '0'

--- a/regression/python/harness_string_constants/test.desc
+++ b/regression/python/harness_string_constants/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 15
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_string_constants_fail/main.py
+++ b/regression/python/harness_string_constants_fail/main.py
@@ -1,0 +1,11 @@
+# Falsification harness for the string module constants
+# (src/python-frontend/models/string.py).
+#
+# string.digits starts with '0', so a wrong boundary-character claim must be
+# falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: string.digits[0] == '1'.  The first digit is '0'.
+import string
+
+assert string.digits[0] == '1'      # F1 — falsifiable (digits starts with '0')

--- a/regression/python/harness_string_constants_fail/main.py
+++ b/regression/python/harness_string_constants_fail/main.py
@@ -8,4 +8,4 @@
 #   F1: string.digits[0] == '1'.  The first digit is '0'.
 import string
 
-assert string.digits[0] == '1'      # F1 — falsifiable (digits starts with '0')
+assert string.digits[0] == '1'  # F1 — falsifiable (digits starts with '0')

--- a/regression/python/harness_string_constants_fail/test.desc
+++ b/regression/python/harness_string_constants_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 15
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fourth Tier-1 model from `docs/python-model-verification-harness-plan.md`
(after heapq #5965, queue #5966, float #5968): verification harnesses for the
`string` module constants.

- `harness_string_constants` — pins the short-string lengths (`digits`,
  `octdigits`) and the range boundaries of `digits` / `ascii_lowercase` /
  `ascii_uppercase` / `ascii_letters` via O(1) indexing (including that
  `ascii_letters` is lowercase followed by uppercase).
- `harness_string_constants_fail` — asserts a wrong boundary character.

Both are concrete and also run clean under CPython; each is ~3 s via
`ctest -R harness_string_constants`.

Implementation note: `len()`/`in` scan to a string's terminator, so pinning the
52-char `ascii_letters` length that way needs a large `--unwind` bound that
timed out under the regression runner (`testing_tool.py`) despite finishing in
~3 s standalone. The layout is pinned by boundary indices instead, which need
no scan, keeping the harness robust at `--unwind 15`.
