### PR TITLE
[python] Add verification harnesses for enum model (Tier 1)

### DIFF
--- a/regression/python/harness_enum_eq/main.py
+++ b/regression/python/harness_enum_eq/main.py
@@ -1,0 +1,31 @@
+# Verification harness for enum.Enum equality/value
+# (src/python-frontend/models/enum.py).
+#
+# Enum members compare by identity within a class: a member equals itself and
+# differs from every other member; .value exposes the assigned integer. This
+# harness pins those contracts for a concrete enum. Members are fixed literals,
+# so the program is concrete.
+#
+# ENSURES:
+#   E1: a member equals itself (reflexivity), and != is its negation
+#   E2: distinct members are not equal
+#   E3: __ne__ is exactly the negation of __eq__
+#   E4: .value returns the assigned integer
+from enum import Enum
+
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+
+assert Color.RED == Color.RED                       # E1
+assert not (Color.RED != Color.RED)                 # E1
+assert Color.RED != Color.GREEN                     # E2
+assert not (Color.RED == Color.GREEN)               # E2
+assert (Color.RED != Color.BLUE) == (not (Color.RED == Color.BLUE))   # E3
+
+assert Color.RED.value == 1                         # E4
+assert Color.GREEN.value == 2                       # E4
+assert Color.BLUE.value == 3                        # E4

--- a/regression/python/harness_enum_eq/main.py
+++ b/regression/python/harness_enum_eq/main.py
@@ -20,12 +20,12 @@ class Color(Enum):
     BLUE = 3
 
 
-assert Color.RED == Color.RED                       # E1
-assert not (Color.RED != Color.RED)                 # E1
-assert Color.RED != Color.GREEN                     # E2
-assert not (Color.RED == Color.GREEN)               # E2
-assert (Color.RED != Color.BLUE) == (not (Color.RED == Color.BLUE))   # E3
+assert Color.RED == Color.RED  # E1
+assert not (Color.RED != Color.RED)  # E1
+assert Color.RED != Color.GREEN  # E2
+assert not (Color.RED == Color.GREEN)  # E2
+assert (Color.RED != Color.BLUE) == (not (Color.RED == Color.BLUE))  # E3
 
-assert Color.RED.value == 1                         # E4
-assert Color.GREEN.value == 2                       # E4
-assert Color.BLUE.value == 3                        # E4
+assert Color.RED.value == 1  # E4
+assert Color.GREEN.value == 2  # E4
+assert Color.BLUE.value == 3  # E4

--- a/regression/python/harness_enum_eq/test.desc
+++ b/regression/python/harness_enum_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_enum_eq_fail/main.py
+++ b/regression/python/harness_enum_eq_fail/main.py
@@ -1,0 +1,17 @@
+# Falsification harness for enum.Enum equality
+# (src/python-frontend/models/enum.py).
+#
+# Distinct enum members are never equal, so asserting equality between two of
+# them must be falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: Color.RED == Color.GREEN.  They are distinct members.
+from enum import Enum
+
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+
+
+assert Color.RED == Color.GREEN     # F1 — falsifiable (distinct members)

--- a/regression/python/harness_enum_eq_fail/main.py
+++ b/regression/python/harness_enum_eq_fail/main.py
@@ -14,4 +14,4 @@ class Color(Enum):
     GREEN = 2
 
 
-assert Color.RED == Color.GREEN     # F1 — falsifiable (distinct members)
+assert Color.RED == Color.GREEN  # F1 — falsifiable (distinct members)

--- a/regression/python/harness_enum_eq_fail/test.desc
+++ b/regression/python/harness_enum_eq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION FAILED$


### PR DESCRIPTION
Final Tier-1 model from `docs/python-model-verification-harness-plan.md`
(after heapq #5965, queue #5966, float #5968, string #5969): verification
harnesses for `enum.Enum`.

- `harness_enum_eq` — pins member equality (reflexivity, distinctness, `__ne__`
  as the negation of `__eq__`) and `.value` access for a concrete enum.
- `harness_enum_eq_fail` — asserts two distinct members are equal, to confirm
  the check is falsifiable.

Both pass via `ctest -R harness_enum` (~3.5 s each); `harness_enum_eq` also runs
clean under CPython.

Note: enum members are concrete literals and the frontend does not support
flowing a symbolically-selected member through a variable — a ternary or
if/else assignment of enum members fails type inference / `address_of` lowering
— so a nondet-select harness was dropped in favour of the concrete contracts.

This completes Tier 1 of the harness-coverage plan (heapq, queue, float,
string, enum).
