### PR TITLE
[python] Add verification harnesses for exceptions model (Tier 2)

### DIFF
--- a/regression/python/harness_exceptions_dispatch/main.py
+++ b/regression/python/harness_exceptions_dispatch/main.py
@@ -1,0 +1,32 @@
+# Verification harness for exception dispatch
+# (src/python-frontend/models/exceptions.py; symbolic exception lowering,
+# docs/design-symbolic-exceptions.md).
+#
+# A nondet integer decides which exception type is raised, and the harness
+# checks that the matching handler runs and correlates with the path taken.
+#
+# REQUIRES:
+#   R1: a non-deterministic integer selects the raise site, exploring both
+#       the ValueError and TypeError paths.
+#
+# ENSURES (which records the handler that ran):
+#   E1: exactly one handler runs (which is 1 or 2)   [some handler catches]
+#   E2: the ValueError handler runs iff x > 0         [dispatch matches the
+#       raised type, which is tied to the path condition]
+x: int = nondet_int()
+which: int = 0
+
+try:
+    if x > 0:
+        raise ValueError("pos")
+    else:
+        raise TypeError("nonpos")
+except ValueError:
+    which = 1
+    assert x > 0
+except TypeError:
+    which = 2
+    assert x <= 0
+
+assert which == 1 or which == 2         # E1
+assert (which == 1) == (x > 0)          # E2

--- a/regression/python/harness_exceptions_dispatch/main.py
+++ b/regression/python/harness_exceptions_dispatch/main.py
@@ -28,5 +28,5 @@ except TypeError:
     which = 2
     assert x <= 0
 
-assert which == 1 or which == 2         # E1
-assert (which == 1) == (x > 0)          # E2
+assert which == 1 or which == 2  # E1
+assert (which == 1) == (x > 0)  # E2

--- a/regression/python/harness_exceptions_dispatch/test.desc
+++ b/regression/python/harness_exceptions_dispatch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_exceptions_dispatch_fail/main.py
+++ b/regression/python/harness_exceptions_dispatch_fail/main.py
@@ -23,4 +23,4 @@ except ValueError:
 except TypeError:
     which = 2
 
-assert (which == 1) == (x <= 0)         # F1 — falsifiable (inverted)
+assert (which == 1) == (x <= 0)  # F1 — falsifiable (inverted)

--- a/regression/python/harness_exceptions_dispatch_fail/main.py
+++ b/regression/python/harness_exceptions_dispatch_fail/main.py
@@ -1,0 +1,26 @@
+# Falsification harness for exception dispatch
+# (src/python-frontend/models/exceptions.py).
+#
+# The ValueError handler runs on the x > 0 path, not the x <= 0 path, so
+# claiming the opposite correlation must be falsifiable.
+#
+# REQUIRES:
+#   R1: a non-deterministic integer selects the raise site.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: (which == 1) == (x <= 0).  The ValueError handler (which == 1) runs
+#       iff x > 0, so this is inverted.
+x: int = nondet_int()
+which: int = 0
+
+try:
+    if x > 0:
+        raise ValueError("pos")
+    else:
+        raise TypeError("nonpos")
+except ValueError:
+    which = 1
+except TypeError:
+    which = 2
+
+assert (which == 1) == (x <= 0)         # F1 — falsifiable (inverted)

--- a/regression/python/harness_exceptions_dispatch_fail/test.desc
+++ b/regression/python/harness_exceptions_dispatch_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/harness_exceptions_hierarchy/main.py
+++ b/regression/python/harness_exceptions_hierarchy/main.py
@@ -15,4 +15,4 @@ try:
 except Exception:
     caught = True
 
-assert caught       # E1, E2
+assert caught  # E1, E2

--- a/regression/python/harness_exceptions_hierarchy/main.py
+++ b/regression/python/harness_exceptions_hierarchy/main.py
@@ -1,0 +1,18 @@
+# Verification harness for exception class hierarchy
+# (src/python-frontend/models/exceptions.py).
+#
+# ValueError subclasses Exception, so an `except Exception` handler catches a
+# raised ValueError. This is intrinsic-free and also runs under CPython.
+#
+# ENSURES:
+#   E1: an `except Exception` handler catches a raised ValueError [subclass is
+#       caught by a base-class handler]
+#   E2: control reaches the handler exactly once
+caught: bool = False
+
+try:
+    raise ValueError("boom")
+except Exception:
+    caught = True
+
+assert caught       # E1, E2

--- a/regression/python/harness_exceptions_hierarchy/test.desc
+++ b/regression/python/harness_exceptions_hierarchy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_exceptions_message/main.py
+++ b/regression/python/harness_exceptions_message/main.py
@@ -14,6 +14,6 @@ try:
     raise ValueError("specific-message")
 except ValueError as e:
     caught = True
-    assert str(e) == "specific-message"      # E1
+    assert str(e) == "specific-message"  # E1
 
-assert caught                                 # E2
+assert caught  # E2

--- a/regression/python/harness_exceptions_message/main.py
+++ b/regression/python/harness_exceptions_message/main.py
@@ -1,0 +1,19 @@
+# Verification harness for exception message payloads
+# (src/python-frontend/models/exceptions.py).
+#
+# The message passed to an exception constructor survives to the handler:
+# str(e) returns it. This is intrinsic-free and also runs under CPython.
+#
+# ENSURES:
+#   E1: the caught exception carries the message it was raised with [payload
+#       survives the raise/catch round-trip]
+#   E2: control reaches the handler
+caught: bool = False
+
+try:
+    raise ValueError("specific-message")
+except ValueError as e:
+    caught = True
+    assert str(e) == "specific-message"      # E1
+
+assert caught                                 # E2

--- a/regression/python/harness_exceptions_message/test.desc
+++ b/regression/python/harness_exceptions_message/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 20
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
First Tier-2 model from `docs/python-model-verification-harness-plan.md` (Tier 1
— heapq/queue/float/string/enum — complete in #5965/#5966/#5968/#5969/#5970):
verification harnesses for the `exceptions` model and ESBMC's symbolic
exception lowering (`docs/design-symbolic-exceptions.md`).

- `harness_exceptions_dispatch` — a nondet integer selects the raise site;
  asserts the matching handler runs and that the ValueError handler fires iff
  `x > 0`.
- `harness_exceptions_hierarchy` — an `except Exception` handler catches a
  raised `ValueError` (base catches subclass).
- `harness_exceptions_message` — the message payload survives the raise/catch
  round-trip (`str(e)` returns it).
- `harness_exceptions_dispatch_fail` — inverts the dispatch correlation, to
  confirm the check is falsifiable.

Each passes via `ctest` in ~3 s; `hierarchy` and `message` also run under
CPython. (The shared dev box is heavily loaded, so a *parallel* local ctest run
can spuriously time a test out; each was confirmed green run individually.)
