### PR TITLE
[python] Add verification harnesses for decimal model (Tier 2)

### DIFF
--- a/regression/python/harness_decimal_identities/main.py
+++ b/regression/python/harness_decimal_identities/main.py
@@ -1,0 +1,29 @@
+# Verification harness for decimal.Decimal arithmetic
+# (src/python-frontend/models/decimal.py).
+#
+# The Decimal model implements fixed-point arithmetic (sign / coefficient /
+# exponent). Decimal() only accepts constant arguments, so the harness uses
+# concrete literals and checks algebraic identities that must hold for any
+# faithful arithmetic.
+#
+# ENSURES (a = 1.5, b = 2.5):
+#   E1: addition and multiplication commute
+#   E2: 0 is the additive identity and a - a == 0
+#   E3: 1 is the multiplicative identity
+#   E4: negation is an involution and abs is sign-independent
+#   E5: a concrete sum has the expected value
+from decimal import Decimal
+
+a: Decimal = Decimal("1.5")
+b: Decimal = Decimal("2.5")
+zero: Decimal = Decimal("0")
+one: Decimal = Decimal("1")
+
+assert a + b == b + a           # E1
+assert a * b == b * a           # E1
+assert a + zero == a            # E2
+assert a - a == zero            # E2
+assert a * one == a            # E3
+assert -(-a) == a               # E4
+assert abs(-a) == abs(a)        # E4
+assert a + b == Decimal("4.0")  # E5

--- a/regression/python/harness_decimal_identities/main.py
+++ b/regression/python/harness_decimal_identities/main.py
@@ -19,11 +19,11 @@ b: Decimal = Decimal("2.5")
 zero: Decimal = Decimal("0")
 one: Decimal = Decimal("1")
 
-assert a + b == b + a           # E1
-assert a * b == b * a           # E1
-assert a + zero == a            # E2
-assert a - a == zero            # E2
-assert a * one == a            # E3
-assert -(-a) == a               # E4
-assert abs(-a) == abs(a)        # E4
+assert a + b == b + a  # E1
+assert a * b == b * a  # E1
+assert a + zero == a  # E2
+assert a - a == zero  # E2
+assert a * one == a  # E3
+assert -(-a) == a  # E4
+assert abs(-a) == abs(a)  # E4
 assert a + b == Decimal("4.0")  # E5

--- a/regression/python/harness_decimal_identities/test.desc
+++ b/regression/python/harness_decimal_identities/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_decimal_identities_fail/main.py
+++ b/regression/python/harness_decimal_identities_fail/main.py
@@ -11,4 +11,4 @@ from decimal import Decimal
 a: Decimal = Decimal("1.5")
 b: Decimal = Decimal("2.5")
 
-assert a == b       # F1 — falsifiable (distinct values)
+assert a == b  # F1 — falsifiable (distinct values)

--- a/regression/python/harness_decimal_identities_fail/main.py
+++ b/regression/python/harness_decimal_identities_fail/main.py
@@ -1,0 +1,14 @@
+# Falsification harness for decimal.Decimal equality
+# (src/python-frontend/models/decimal.py).
+#
+# Decimal("1.5") and Decimal("2.5") are distinct values, so asserting their
+# equality must be falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: Decimal("1.5") == Decimal("2.5").
+from decimal import Decimal
+
+a: Decimal = Decimal("1.5")
+b: Decimal = Decimal("2.5")
+
+assert a == b       # F1 — falsifiable (distinct values)

--- a/regression/python/harness_decimal_identities_fail/test.desc
+++ b/regression/python/harness_decimal_identities_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION FAILED$


### PR DESCRIPTION
Second Tier-2 model from `docs/python-model-verification-harness-plan.md`
(after exceptions #5971): verification harnesses for `decimal.Decimal`
arithmetic.

- `harness_decimal_identities` — algebraic identities on concrete values:
  commutativity of `+` and `*`, additive/multiplicative identities,
  `a - a == 0`, negation involution, `abs` sign-independence, and a concrete
  sum (`1.5 + 2.5 == 4.0`).
- `harness_decimal_identities_fail` — asserts two distinct Decimals are equal,
  to confirm the check is falsifiable.

Both pass via `ctest` and under CPython. `Decimal()` only accepts constant
arguments (the preprocessor rejects non-constant ones, so nondet payloads are
unavailable), hence the concrete formulation — matching how the model's
arithmetic is exercised in practice.
