### PR TITLE
[python] Add verification harnesses for datetime/time/os stubs (Tier 2)

### DIFF
--- a/regression/python/harness_datetime_fields/main.py
+++ b/regression/python/harness_datetime_fields/main.py
@@ -20,10 +20,10 @@ __ESBMC_assume(1 <= d <= 31)
 
 dt = datetime(y, mo, d)
 
-assert dt.year == y           # E1
-assert dt.month == mo         # E1
-assert dt.day == d            # E1
-assert dt.hour == 0           # E2
-assert dt.minute == 0         # E2
-assert dt.second == 0         # E2
-assert dt.microsecond == 0    # E2
+assert dt.year == y  # E1
+assert dt.month == mo  # E1
+assert dt.day == d  # E1
+assert dt.hour == 0  # E2
+assert dt.minute == 0  # E2
+assert dt.second == 0  # E2
+assert dt.microsecond == 0  # E2

--- a/regression/python/harness_datetime_fields/main.py
+++ b/regression/python/harness_datetime_fields/main.py
@@ -1,0 +1,29 @@
+# Verification harness for datetime.datetime
+# (src/python-frontend/models/datetime.py).
+#
+# datetime(year, month, day) stores the calendar fields and defaults the time
+# fields (hour/minute/second/microsecond) to 0.
+#
+# REQUIRES:
+#   R1: nondet year, and month/day bounded to valid calendar ranges.
+#
+# ENSURES:
+#   E1: the stored year/month/day match the constructor arguments
+#   E2: the time fields default to 0
+from datetime import datetime
+
+y: int = nondet_int()
+mo: int = nondet_int()
+d: int = nondet_int()
+__ESBMC_assume(1 <= mo <= 12)
+__ESBMC_assume(1 <= d <= 31)
+
+dt = datetime(y, mo, d)
+
+assert dt.year == y           # E1
+assert dt.month == mo         # E1
+assert dt.day == d            # E1
+assert dt.hour == 0           # E2
+assert dt.minute == 0         # E2
+assert dt.second == 0         # E2
+assert dt.microsecond == 0    # E2

--- a/regression/python/harness_datetime_fields/test.desc
+++ b/regression/python/harness_datetime_fields/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_datetime_fields_fail/main.py
+++ b/regression/python/harness_datetime_fields_fail/main.py
@@ -1,0 +1,14 @@
+# Falsification harness for datetime.datetime
+# (src/python-frontend/models/datetime.py).
+#
+# The time fields default to 0, so claiming a non-zero default must be
+# falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: datetime(y, 6, 15).hour == 1.  The hour defaults to 0.
+from datetime import datetime
+
+y: int = nondet_int()
+dt = datetime(y, 6, 15)
+
+assert dt.hour == 1       # F1 — falsifiable (hour defaults to 0)

--- a/regression/python/harness_datetime_fields_fail/main.py
+++ b/regression/python/harness_datetime_fields_fail/main.py
@@ -11,4 +11,4 @@ from datetime import datetime
 y: int = nondet_int()
 dt = datetime(y, 6, 15)
 
-assert dt.hour == 1       # F1 — falsifiable (hour defaults to 0)
+assert dt.hour == 1  # F1 — falsifiable (hour defaults to 0)

--- a/regression/python/harness_datetime_fields_fail/test.desc
+++ b/regression/python/harness_datetime_fields_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/harness_os_listdir/main.py
+++ b/regression/python/harness_os_listdir/main.py
@@ -1,0 +1,18 @@
+# Verification harness for os.listdir (src/python-frontend/models/os.py).
+#
+# The os model returns a fixed two-entry directory listing ["foo", "bar"], a
+# deterministic stand-in for filesystem contents under verification. The model
+# deliberately diverges from CPython's os.listdir, so this test is verified
+# with ESBMC only (excluded from the CPython sanity sweep in
+# scripts/check_python_tests.sh).
+#
+# ENSURES:
+#   E1: listdir returns two entries
+#   E2: the entries are "foo" and "bar" in order
+import os
+
+entries: list[str] = os.listdir("/some/path")
+
+assert len(entries) == 2          # E1
+assert entries[0] == "foo"        # E2
+assert entries[1] == "bar"        # E2

--- a/regression/python/harness_os_listdir/main.py
+++ b/regression/python/harness_os_listdir/main.py
@@ -13,6 +13,6 @@ import os
 
 entries: list[str] = os.listdir("/some/path")
 
-assert len(entries) == 2          # E1
-assert entries[0] == "foo"        # E2
-assert entries[1] == "bar"        # E2
+assert len(entries) == 2  # E1
+assert entries[0] == "foo"  # E2
+assert entries[1] == "bar"  # E2

--- a/regression/python/harness_os_listdir/test.desc
+++ b/regression/python/harness_os_listdir/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_time_sleep/main.py
+++ b/regression/python/harness_time_sleep/main.py
@@ -1,0 +1,20 @@
+# Verification harness for time.sleep (src/python-frontend/models/time.py).
+#
+# time.sleep(seconds) models the delay as a no-op guarded by an assertion that
+# the delay is non-negative.
+#
+# REQUIRES:
+#   R1: a nondet, non-negative, bounded delay.
+#
+# ENSURES:
+#   E1: a non-negative delay is accepted (the model's assertion holds and
+#       control returns normally)
+import time
+
+s: float = nondet_float()
+__ESBMC_assume(s >= 0.0)
+__ESBMC_assume(s <= 1000.0)
+
+time.sleep(s)
+
+assert True     # E1 — reaching here means sleep did not fault

--- a/regression/python/harness_time_sleep/main.py
+++ b/regression/python/harness_time_sleep/main.py
@@ -17,4 +17,4 @@ __ESBMC_assume(s <= 1000.0)
 
 time.sleep(s)
 
-assert True     # E1 — reaching here means sleep did not fault
+assert True  # E1 — reaching here means sleep did not fault

--- a/regression/python/harness_time_sleep/test.desc
+++ b/regression/python/harness_time_sleep/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_time_sleep_fail/main.py
+++ b/regression/python/harness_time_sleep_fail/main.py
@@ -14,4 +14,4 @@ s: float = nondet_float()
 __ESBMC_assume(s < 0.0)
 __ESBMC_assume(s >= -1000.0)
 
-time.sleep(s)   # trips the model's assert seconds >= 0.0
+time.sleep(s)  # trips the model's assert seconds >= 0.0

--- a/regression/python/harness_time_sleep_fail/main.py
+++ b/regression/python/harness_time_sleep_fail/main.py
@@ -1,0 +1,17 @@
+# Falsification harness for time.sleep (src/python-frontend/models/time.py).
+#
+# sleep() guards its body with `assert seconds >= 0.0`, so a negative delay
+# must trip that assertion.
+#
+# REQUIRES:
+#   R1: a nondet, strictly-negative, bounded delay.
+#
+# WRONG SETUP (expected to be falsified):
+#   F1: time.sleep(s) with s < 0 reaches the model's `assert seconds >= 0.0`.
+import time
+
+s: float = nondet_float()
+__ESBMC_assume(s < 0.0)
+__ESBMC_assume(s >= -1000.0)
+
+time.sleep(s)   # trips the model's assert seconds >= 0.0

--- a/regression/python/harness_time_sleep_fail/test.desc
+++ b/regression/python/harness_time_sleep_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -102,6 +102,7 @@ ignored_dirs=(
   "input3"
   "input5"
   "input6"
+  "harness_os_listdir"
   "github_3712"
   "github_3713"
   "github_3713_1"


### PR DESCRIPTION
Tier-2 cheap-stub models from `docs/python-model-verification-harness-plan.md`
(after exceptions #5971 and decimal #5972): harnesses for `datetime`, `time`,
and `os`.

- `harness_datetime_fields` — nondet year/month/day; checks `datetime()` stores
  the calendar fields and defaults hour/minute/second/microsecond to 0.
  `harness_datetime_fields_fail` claims a non-zero hour default.
- `harness_time_sleep` — a non-negative nondet delay is accepted;
  `harness_time_sleep_fail` uses a negative delay to trip the model's
  `assert seconds >= 0.0` guard.
- `harness_os_listdir` — pins the model's fixed `["foo","bar"]` listing.

Each passes via `ctest` (~3 s). The datetime/time harnesses are nondet, so the
CPython sanity sweep auto-skips them; `os.listdir` deliberately diverges from
CPython, so it is added to the `check_python_tests.sh` ignore list.

Note: `time.time()`'s monotonic-counter property was not harnessed — its
`global` mutable module state stalls the converter (stops at "Converting"); the
`sleep` guard is covered instead.
