### PR TITLE
[python] Add verification harnesses for @dataclass synthesis (Tier 2)

### DIFF
--- a/regression/python/harness_dataclass_default/main.py
+++ b/regression/python/harness_dataclass_default/main.py
@@ -1,0 +1,30 @@
+# Verification harness for @dataclass default field values
+# (preprocessor src/python-frontend/preprocessor/dataclass_mixin.py).
+#
+# A field with a default is filled from that default when the argument is
+# omitted, and overridden when supplied.
+#
+# REQUIRES:
+#   R1: a nondet integer for the required field.
+#
+# ENSURES (for Config with a: int, b: int = 10):
+#   E1: the required field takes the positional argument
+#   E2: an omitted field takes its default (10)
+#   E3: a supplied field overrides the default
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    a: int
+    b: int = 10
+
+
+x: int = nondet_int()
+
+c = Config(x)
+assert c.a == x         # E1
+assert c.b == 10        # E2
+
+c2 = Config(x, 20)
+assert c2.b == 20       # E3

--- a/regression/python/harness_dataclass_default/main.py
+++ b/regression/python/harness_dataclass_default/main.py
@@ -23,8 +23,8 @@ class Config:
 x: int = nondet_int()
 
 c = Config(x)
-assert c.a == x         # E1
-assert c.b == 10        # E2
+assert c.a == x  # E1
+assert c.b == 10  # E2
 
 c2 = Config(x, 20)
-assert c2.b == 20       # E3
+assert c2.b == 20  # E3

--- a/regression/python/harness_dataclass_default/test.desc
+++ b/regression/python/harness_dataclass_default/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_dataclass_eq_fail/main.py
+++ b/regression/python/harness_dataclass_eq_fail/main.py
@@ -21,4 +21,4 @@ b: int = nondet_int()
 p = Point(a, b)
 q = Point(a, b + 1)
 
-assert p == q       # F1 — falsifiable (y fields differ)
+assert p == q  # F1 — falsifiable (y fields differ)

--- a/regression/python/harness_dataclass_eq_fail/main.py
+++ b/regression/python/harness_dataclass_eq_fail/main.py
@@ -1,0 +1,24 @@
+# Falsification harness for @dataclass generated __eq__
+# (preprocessor src/python-frontend/preprocessor/dataclass_mixin.py).
+#
+# The generated __eq__ compares all fields, so instances differing in any field
+# are unequal; asserting equality then must be falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: Point(a, b) == Point(a, b + 1).  The y fields differ.
+from dataclasses import dataclass
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
+
+
+a: int = nondet_int()
+b: int = nondet_int()
+
+p = Point(a, b)
+q = Point(a, b + 1)
+
+assert p == q       # F1 — falsifiable (y fields differ)

--- a/regression/python/harness_dataclass_eq_fail/test.desc
+++ b/regression/python/harness_dataclass_eq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/harness_dataclass_fields/main.py
+++ b/regression/python/harness_dataclass_fields/main.py
@@ -1,0 +1,35 @@
+# Verification harness for @dataclass synthesis
+# (preprocessor src/python-frontend/preprocessor/dataclass_mixin.py; the
+# src/python-frontend/models/dataclasses.py stubs are overridden by it).
+#
+# @dataclass synthesizes __init__ (positional field assignment) and __eq__
+# (field-wise comparison). This harness verifies both over nondet inputs.
+#
+# REQUIRES:
+#   R1: two nondet integers seed the fields, exploring all field values.
+#
+# ENSURES (for Point(a, b)):
+#   E1: positional arguments are stored in the declared fields
+#   E2: the generated __eq__ makes two instances equal iff all fields match
+#   E3: differing a field makes them unequal
+from dataclasses import dataclass
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
+
+
+a: int = nondet_int()
+b: int = nondet_int()
+
+p = Point(a, b)
+assert p.x == a         # E1
+assert p.y == b         # E1
+
+q = Point(a, b)
+assert p == q           # E2
+
+r = Point(a + 1, b)
+assert p != r           # E3

--- a/regression/python/harness_dataclass_fields/main.py
+++ b/regression/python/harness_dataclass_fields/main.py
@@ -25,11 +25,11 @@ a: int = nondet_int()
 b: int = nondet_int()
 
 p = Point(a, b)
-assert p.x == a         # E1
-assert p.y == b         # E1
+assert p.x == a  # E1
+assert p.y == b  # E1
 
 q = Point(a, b)
-assert p == q           # E2
+assert p == q  # E2
 
 r = Point(a + 1, b)
-assert p != r           # E3
+assert p != r  # E3

--- a/regression/python/harness_dataclass_fields/test.desc
+++ b/regression/python/harness_dataclass_fields/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_dataclass_replace/main.py
+++ b/regression/python/harness_dataclass_replace/main.py
@@ -1,0 +1,33 @@
+# Verification harness for dataclasses.replace on a @dataclass
+# (preprocessor src/python-frontend/preprocessor/dataclass_mixin.py).
+#
+# replace(obj, **changes) returns a new instance with the named fields
+# overridden and the rest copied.
+#
+# REQUIRES:
+#   R1: three nondet integers (two initial fields, one replacement value).
+#
+# ENSURES (p = Point(a, b); p2 = replace(p, x=c)):
+#   E1: the replaced field takes the new value
+#   E2: the untouched field is copied from the original
+#   E3: the original instance is unchanged
+from dataclasses import dataclass, replace
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
+
+
+a: int = nondet_int()
+b: int = nondet_int()
+c: int = nondet_int()
+
+p = Point(a, b)
+p2 = replace(p, x=c)
+
+assert p2.x == c        # E1
+assert p2.y == b        # E2
+assert p.x == a         # E3
+assert p.y == b         # E3

--- a/regression/python/harness_dataclass_replace/main.py
+++ b/regression/python/harness_dataclass_replace/main.py
@@ -27,7 +27,7 @@ c: int = nondet_int()
 p = Point(a, b)
 p2 = replace(p, x=c)
 
-assert p2.x == c        # E1
-assert p2.y == b        # E2
-assert p.x == a         # E3
-assert p.y == b         # E3
+assert p2.x == c  # E1
+assert p2.y == b  # E2
+assert p.x == a  # E3
+assert p.y == b  # E3

--- a/regression/python/harness_dataclass_replace/test.desc
+++ b/regression/python/harness_dataclass_replace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 6
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Tier-2 model from `docs/python-model-verification-harness-plan.md`.

**Audit result** (dataclasses + typing, per the plan's "audit before
investing"):
- `typing` — pure type-alias stubs (`__class_getitem__` returns `cls`,
  `TypeVar` returns `object`); no runtime behaviour to verify. Skipped.
- `dataclasses` — the model functions are degenerate no-op stubs, but the real
  behaviour is the preprocessor's `@dataclass` synthesis
  (`dataclass_mixin.py`), which is nondet-friendly and worth harnessing.

Harnesses for the synthesized behaviour:
- `harness_dataclass_fields` — generated `__init__` field storage and `__eq__`
  (equal iff all fields match) over nondet inputs.
- `harness_dataclass_default` — default field value filled when omitted,
  overridden when supplied.
- `harness_dataclass_replace` — `dataclasses.replace` overrides one field,
  copies the rest, and does not mutate the original.
- `harness_dataclass_eq_fail` — two instances differing in one field asserted
  equal, to confirm the generated `__eq__` check is falsifiable.

All four pass via `ctest` (~3 s each); auto-skipped under CPython (nondet).
