### PR TITLE
[python] Add verification harnesses for cmath model (Tier 3)

### DIFF
--- a/regression/python/harness_cmath_abs/main.py
+++ b/regression/python/harness_cmath_abs/main.py
@@ -1,0 +1,29 @@
+# Verification harness for complex magnitude (abs) via the cmath model
+# (src/python-frontend/models/cmath.py).
+#
+# abs(z) is the modulus sqrt(re^2 + im^2). In IEEE-754 the squared magnitude
+# is NOT exactly re^2 + im^2 (sqrt rounds, and re^2 rounds first), so the only
+# exact facts are non-negativity and the perfect-square anchors below —
+# deliberately chosen because 25 and 169 have exact float square roots.
+#
+# REQUIRES:
+#   R1: nondet real and imaginary parts, bounded to a finite interval.
+#
+# ENSURES (z = complex(a, b), r = abs(z)):
+#   E1: the modulus is non-negative
+#   E2: concrete Pythagorean triples give the exact hypotenuse
+import cmath
+
+a: float = nondet_float()
+b: float = nondet_float()
+__ESBMC_assume(-100.0 <= a <= 100.0)
+__ESBMC_assume(-100.0 <= b <= 100.0)
+
+z: complex = complex(a, b)
+r: float = abs(z)
+
+assert r >= 0.0                             # E1
+
+assert abs(complex(0.0, 0.0)) == 0.0        # E2
+assert abs(complex(3.0, 4.0)) == 5.0        # E2
+assert abs(complex(5.0, 12.0)) == 13.0      # E2

--- a/regression/python/harness_cmath_abs/main.py
+++ b/regression/python/harness_cmath_abs/main.py
@@ -22,8 +22,8 @@ __ESBMC_assume(-100.0 <= b <= 100.0)
 z: complex = complex(a, b)
 r: float = abs(z)
 
-assert r >= 0.0                             # E1
+assert r >= 0.0  # E1
 
-assert abs(complex(0.0, 0.0)) == 0.0        # E2
-assert abs(complex(3.0, 4.0)) == 5.0        # E2
-assert abs(complex(5.0, 12.0)) == 13.0      # E2
+assert abs(complex(0.0, 0.0)) == 0.0  # E2
+assert abs(complex(3.0, 4.0)) == 5.0  # E2
+assert abs(complex(5.0, 12.0)) == 13.0  # E2

--- a/regression/python/harness_cmath_abs/test.desc
+++ b/regression/python/harness_cmath_abs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_cmath_abs_fail/main.py
+++ b/regression/python/harness_cmath_abs_fail/main.py
@@ -1,0 +1,12 @@
+# Falsification harness for complex magnitude (abs)
+# (src/python-frontend/models/cmath.py).
+#
+# abs(3 + 4j) is 5, not 4, so the wrong magnitude claim must be falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: abs(complex(3, 4)) == 4.0.  The modulus is 5.0.
+import cmath
+
+z: complex = complex(3.0, 4.0)
+
+assert abs(z) == 4.0        # F1 — falsifiable (modulus is 5.0)

--- a/regression/python/harness_cmath_abs_fail/main.py
+++ b/regression/python/harness_cmath_abs_fail/main.py
@@ -9,4 +9,4 @@ import cmath
 
 z: complex = complex(3.0, 4.0)
 
-assert abs(z) == 4.0        # F1 — falsifiable (modulus is 5.0)
+assert abs(z) == 4.0  # F1 — falsifiable (modulus is 5.0)

--- a/regression/python/harness_cmath_abs_fail/test.desc
+++ b/regression/python/harness_cmath_abs_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/harness_cmath_predicates/main.py
+++ b/regression/python/harness_cmath_predicates/main.py
@@ -20,6 +20,6 @@ __ESBMC_assume(-1000.0 <= b <= 1000.0)
 
 z: complex = complex(a, b)
 
-assert cmath.isfinite(z)        # E1
-assert not cmath.isnan(z)       # E2
-assert not cmath.isinf(z)       # E3
+assert cmath.isfinite(z)  # E1
+assert not cmath.isnan(z)  # E2
+assert not cmath.isinf(z)  # E3

--- a/regression/python/harness_cmath_predicates/main.py
+++ b/regression/python/harness_cmath_predicates/main.py
@@ -1,0 +1,25 @@
+# Verification harness for cmath.isfinite / isnan / isinf
+# (src/python-frontend/models/cmath.py).
+#
+# A complex value built from bounded (hence finite) components is finite:
+# isfinite is True, isnan and isinf are False.
+#
+# REQUIRES:
+#   R1: nondet real and imaginary parts, bounded to a finite interval.
+#
+# ENSURES (z = complex(a, b) with finite a, b):
+#   E1: cmath.isfinite(z) is True
+#   E2: cmath.isnan(z) is False
+#   E3: cmath.isinf(z) is False
+import cmath
+
+a: float = nondet_float()
+b: float = nondet_float()
+__ESBMC_assume(-1000.0 <= a <= 1000.0)
+__ESBMC_assume(-1000.0 <= b <= 1000.0)
+
+z: complex = complex(a, b)
+
+assert cmath.isfinite(z)        # E1
+assert not cmath.isnan(z)       # E2
+assert not cmath.isinf(z)       # E3

--- a/regression/python/harness_cmath_predicates/test.desc
+++ b/regression/python/harness_cmath_predicates/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
First Tier-3 model from `docs/python-model-verification-harness-plan.md`
(Tier 1 + Tier 2 complete): verification harnesses for the `cmath` model,
restricted to non-transcendental facts (per the plan's guidance to avoid deep
libm paths).

- `harness_cmath_abs` — modulus non-negativity over nondet real/imaginary
  components, plus exact perfect-square anchors (`abs(3+4j)==5`,
  `abs(5+12j)==13`, `abs(0)==0`).
- `harness_cmath_predicates` — `isfinite`/`isnan`/`isinf` on a bounded (finite)
  nondet complex.
- `harness_cmath_abs_fail` — asserts a wrong modulus (`abs(3+4j)==4`).

All pass via `ctest` (~7.5 s each); `abs`/`predicates` auto-skip under CPython
(nondet), `abs_fail` runs under CPython too.

Note: `abs(z)**2 == re**2 + im**2` is deliberately NOT asserted — it does not
hold in IEEE-754 (the squarings and the sqrt each round). An initial draft did
assert it and was falsified by ESBMC, so only non-negativity and exact
integer-triple anchors are pinned. A nice demonstration that the harness
discipline catches plausible-but-unsound floating-point properties.
