### PR TITLE
[python] Add verification harnesses for re model (Tier 3)

### DIFF
--- a/regression/python/harness_re_match/main.py
+++ b/regression/python/harness_re_match/main.py
@@ -15,7 +15,7 @@
 #   E4: a string shorter than the pattern does not match
 import re
 
-assert re.match("abc", "abc")           # E1
-assert re.match("abc", "abcdef")        # E2
-assert not re.match("abc", "xbc")       # E3
-assert not re.match("abc", "ab")        # E4
+assert re.match("abc", "abc")  # E1
+assert re.match("abc", "abcdef")  # E2
+assert not re.match("abc", "xbc")  # E3
+assert not re.match("abc", "ab")  # E4

--- a/regression/python/harness_re_match/main.py
+++ b/regression/python/harness_re_match/main.py
@@ -1,0 +1,21 @@
+# Verification harness for re.match on literal patterns
+# (src/python-frontend/models/re.py).
+#
+# re.match(pattern, string) reports whether the pattern matches at the START of
+# the string. This harness uses literal patterns, which the model handles
+# exactly. (Character-class patterns such as [a-z] are not soundly modelled —
+# they return an unconstrained result — so they are avoided here.)
+#
+# This test is concrete and also runs under CPython.
+#
+# ENSURES:
+#   E1: a literal matches an equal string
+#   E2: a literal matches a string it is a prefix of (match anchors at start)
+#   E3: a differing first character does not match
+#   E4: a string shorter than the pattern does not match
+import re
+
+assert re.match("abc", "abc")           # E1
+assert re.match("abc", "abcdef")        # E2
+assert not re.match("abc", "xbc")       # E3
+assert not re.match("abc", "ab")        # E4

--- a/regression/python/harness_re_match/test.desc
+++ b/regression/python/harness_re_match/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_re_match_fail/main.py
+++ b/regression/python/harness_re_match_fail/main.py
@@ -1,0 +1,11 @@
+# Falsification harness for re.match on literal patterns
+# (src/python-frontend/models/re.py).
+#
+# re.match anchors at the start, so a literal that does not begin the string
+# does not match; asserting a match must be falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: re.match("abc", "xyz").  "abc" is not a prefix of "xyz".
+import re
+
+assert re.match("abc", "xyz")       # F1 — falsifiable (no prefix match)

--- a/regression/python/harness_re_match_fail/main.py
+++ b/regression/python/harness_re_match_fail/main.py
@@ -8,4 +8,4 @@
 #   F1: re.match("abc", "xyz").  "abc" is not a prefix of "xyz".
 import re
 
-assert re.match("abc", "xyz")       # F1 — falsifiable (no prefix match)
+assert re.match("abc", "xyz")  # F1 — falsifiable (no prefix match)

--- a/regression/python/harness_re_match_fail/test.desc
+++ b/regression/python/harness_re_match_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION FAILED$

--- a/regression/python/harness_re_search_fullmatch/main.py
+++ b/regression/python/harness_re_search_fullmatch/main.py
@@ -14,7 +14,7 @@
 #   E4: search fails when the substring is absent
 import re
 
-assert re.fullmatch("abc", "abc")       # E1
+assert re.fullmatch("abc", "abc")  # E1
 assert not re.fullmatch("abc", "abcd")  # E2
-assert re.search("bc", "abcd")          # E3
-assert not re.search("xy", "abcd")      # E4
+assert re.search("bc", "abcd")  # E3
+assert not re.search("xy", "abcd")  # E4

--- a/regression/python/harness_re_search_fullmatch/main.py
+++ b/regression/python/harness_re_search_fullmatch/main.py
@@ -1,0 +1,20 @@
+# Verification harness for re.search and re.fullmatch on literal patterns
+# (src/python-frontend/models/re.py).
+#
+# search finds the pattern anywhere in the string; fullmatch requires the
+# pattern to match the entire string. Literal patterns are used (see
+# harness_re_match for why character classes are avoided).
+#
+# This test is concrete and also runs under CPython.
+#
+# ENSURES:
+#   E1: fullmatch succeeds only when the whole string equals the pattern
+#   E2: fullmatch fails when the string has trailing characters
+#   E3: search finds a substring anywhere in the string
+#   E4: search fails when the substring is absent
+import re
+
+assert re.fullmatch("abc", "abc")       # E1
+assert not re.fullmatch("abc", "abcd")  # E2
+assert re.search("bc", "abcd")          # E3
+assert not re.search("xy", "abcd")      # E4

--- a/regression/python/harness_re_search_fullmatch/test.desc
+++ b/regression/python/harness_re_search_fullmatch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Second Tier-3 model from `docs/python-model-verification-harness-plan.md`
(after cmath #5977): verification harnesses for the `re` model on literal
patterns.

- `harness_re_match` — start-anchored literal matching: equal string, prefix
  match, mismatched first char, string shorter than the pattern.
- `harness_re_search_fullmatch` — `search` finds a substring anywhere;
  `fullmatch` requires the whole string to match.
- `harness_re_match_fail` — asserts a non-matching literal, to confirm the
  check is falsifiable.

All three are concrete and pass via `ctest` (~5–9 s each); they also run under
CPython.

Restricted to literal patterns on purpose: **character-class patterns are not
soundly modelled** — `re.match("[a-z]", "H")` returns an *unconstrained* bool
(it can be True) rather than False, so char-class assertions are non-
deterministic. That looks like a genuine model gap worth a separate fix; this
PR steers clear of it.
