### PR TITLE
[python] Add verification harnesses for threading.Lock mutex (Tier 3)

### DIFF
--- a/regression/python/harness_threading_lock_mutex/main.py
+++ b/regression/python/harness_threading_lock_mutex/main.py
@@ -1,0 +1,37 @@
+# Verification harness for threading.Lock mutual exclusion
+# (src/python-frontend/models/threading.py).
+#
+# Two threads each perform a read-modify-write on a shared global while holding
+# the same Lock. Because acquire()/release() serialise the critical section,
+# both increments land and the final counter is exactly 2 in every interleaving
+# — the Lock provides mutual exclusion. (Without the Lock this is the classic
+# lost-update race; see regression/python/threading_thread_increment_race_fail.)
+#
+# The proof requires exploring thread interleavings: run with --context-bound 2
+# and --data-races-check (the flag that keeps interleaving generation alive;
+# without it the search terminates early and the claim passes vacuously).
+#
+# ENSURES:
+#   E1: under the Lock, counter == 2 in every schedule [mutual exclusion holds]
+import threading
+
+counter: int = 0
+lock = threading.Lock()
+
+
+def bump() -> None:
+    global counter
+    lock.acquire()
+    tmp: int = counter
+    counter = tmp + 1
+    lock.release()
+
+
+t1 = threading.Thread(target=bump)
+t2 = threading.Thread(target=bump)
+t1.start()
+t2.start()
+t1.join()
+t2.join()
+
+assert counter == 2       # E1

--- a/regression/python/harness_threading_lock_mutex/main.py
+++ b/regression/python/harness_threading_lock_mutex/main.py
@@ -34,4 +34,4 @@ t2.start()
 t1.join()
 t2.join()
 
-assert counter == 2       # E1
+assert counter == 2  # E1

--- a/regression/python/harness_threading_lock_mutex/test.desc
+++ b/regression/python/harness_threading_lock_mutex/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --context-bound 2 --data-races-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_threading_lock_mutex_fail/main.py
+++ b/regression/python/harness_threading_lock_mutex_fail/main.py
@@ -1,0 +1,33 @@
+# Falsification harness for threading.Lock mutual exclusion
+# (src/python-frontend/models/threading.py).
+#
+# Under the Lock both increments land, so the final counter is 2, never 1.
+# Asserting the smaller value must therefore be falsifiable — this is the
+# non-vacuous counterpart to harness_threading_lock_mutex (it confirms the
+# interleaving search actually drives counter to 2 rather than passing
+# vacuously). Same flags: --context-bound 2 --data-races-check.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: counter == 1 after two locked increments.  Mutual exclusion gives 2.
+import threading
+
+counter: int = 0
+lock = threading.Lock()
+
+
+def bump() -> None:
+    global counter
+    lock.acquire()
+    tmp: int = counter
+    counter = tmp + 1
+    lock.release()
+
+
+t1 = threading.Thread(target=bump)
+t2 = threading.Thread(target=bump)
+t1.start()
+t2.start()
+t1.join()
+t2.join()
+
+assert counter == 1       # F1 — falsifiable (locked increments give 2)

--- a/regression/python/harness_threading_lock_mutex_fail/main.py
+++ b/regression/python/harness_threading_lock_mutex_fail/main.py
@@ -30,4 +30,4 @@ t2.start()
 t1.join()
 t2.join()
 
-assert counter == 1       # F1 — falsifiable (locked increments give 2)
+assert counter == 1  # F1 — falsifiable (locked increments give 2)

--- a/regression/python/harness_threading_lock_mutex_fail/test.desc
+++ b/regression/python/harness_threading_lock_mutex_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --context-bound 2 --data-races-check
+^VERIFICATION FAILED$


### PR DESCRIPTION
Third Tier-3 model from `docs/python-model-verification-harness-plan.md`, in the
concurrency-harness style (after cmath #5977 and re #5981).

- `harness_threading_lock_mutex` — two threads increment a shared global under a
  `threading.Lock`; proves the final counter is exactly **2 in every
  interleaving** (mutual exclusion holds). This complements the existing
  *unlocked* lost-update race test (`threading_thread_increment_race_fail`) and
  the *sequential* lock test (`threading_lock_safe`) — neither proves mutual
  exclusion under real thread interleaving.
- `harness_threading_lock_mutex_fail` — asserts the counter is 1, to confirm the
  interleaving search actually drives it to 2 rather than passing vacuously.

Both use `--context-bound 2 --data-races-check`. **`--data-races-check` is
required for soundness**: without it the interleaving search terminates early
and the claim passes vacuously — I verified this by checking that a
deliberately-wrong `counter == 5` assertion passes *without* the flag. The
positive proof explores all schedules (~40 s); the negative finds its
counterexample fast (~5 s). Both also run under real CPython threading
(deterministic under the lock).
