### PR TITLE
[python] Add IREP2-native type completion to python_adjust (V.1k S1)

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3683,6 +3683,64 @@ drift the SMT encoding; *RV-adj6 (eager-vs-lazy source)* — the parity subtlety
 above. Until S1–S6 land and RV2 is discharged the F-P11 converter wall stays
 blocked by design; no further pre-adjust converter drain can proceed ahead of it.
 
+#### S1 outcome (2026-07-11) — `adjust_type` landed; two empirical findings
+
+**S1 is in** (branch `feat/python-adjust-s1-type-completion`):
+`python_adjust::adjust_type` reproduces the legacy completion steps a Python
+body exercises — recursive macro symbol-type expansion, array (VLA) size +
+element-type adjustment, and struct/union member-type recursion followed by
+alignment padding — and `adjust_expr` now completes each node's own type first
+(`with_type` only on change), mirroring the legacy `adjust_expr`'s leading
+`adjust_type(expr.type())`. Three deliberate deviations from the legacy pass,
+documented in the header: an unknown *top-level* type symbol is left by-name
+for the B.4 exit invariant to flag rather than `abort()`ed (an unknown tag
+buried inside an aggregate still aborts downstream in `add_padding`'s
+`ns.follow`); the `vector_typet` half of `is_array_like` has no arm (the
+Python frontend never emits vector types — a census-confirmed dead branch);
+and **type symbols themselves are not yet adjusted** — the legacy `adjust()`
+completes all `is_type` symbols *first* "so that symbolic-type resolution
+always receives fixed up types" (`clang_c_adjust_expr.cpp:31-42`), which
+`clang_cpp_adjust` still does on the live pipeline. **The B.5 flip must add a
+type-symbol pre-pass** (an S-step no entry in the S1–S6 list covers today)
+before `python_adjust` becomes the sole resolver, or `ns.follow`/`add_padding`
+will resolve against unadjusted tag layouts. Padding satisfies RV-adj5 *by
+construction*:
+the pass reuses `add_padding` itself through the lossless
+`migrate_type_back` → `add_padding` → `migrate_type` round-trip rather than
+reimplementing its alignment arithmetic. Gate: 20/20 unit tests
+(`python_adjust_test`, every new branch exercised), 76/76 flag-on fixture +
+acceptance-family regressions, dual-solver (Bitwuzla + Z3) verdict parity,
+stderr byte-parity vs. the unpatched master build.
+
+**Finding 1 — `#is_padding` does not survive the IREP2 round-trip (new
+RV-adj5 sub-hazard, resolved).** `struct_type2t` carries no per-member
+attribute channel, so a padded struct that round-trips through IREP2 loses the
+`#is_padding` component flag; `add_padding` then aligns the existing pad
+member as if it were a regular field (`padding.cpp:262` vs `:276`) and
+double-pads — the legacy idempotence assert (`clang_c_adjust_expr.cpp:741-743`)
+holds only because typet-land preserves the flag. S1 re-derives the flag from
+the reserved pad-member names (`anon_pad$`/`anon_bit_field_pad$`/
+`ext_int_pad$` — `$` cannot appear in a Python identifier) before re-padding;
+idempotence is unit-pinned. **S2 must inherit this re-derivation** when it
+completes `constant_struct2t` literals against a padded layout, and the
+eventual W3/V.2 attribute-carriage design should list `#is_padding` among the
+attributes needing an IREP2-native home.
+
+**Finding 2 — the flag-on pipeline already reports pre-existing B.4
+exit-invariant errors on OM model bodies (pre-S1, master).** Running any
+fixture test flag-on emits ~26 `python_adjust: symbol ... retains an
+unresolved by-name ... node` errors for operational-model functions
+(`min`/`max`/`sorted`/`sum`/`any`/`reversed`/`choice`/...) on the **unpatched
+master build** (A/B-confirmed 2026-07-11; verdicts still SUCCESSFUL because
+`typecheck` does not fail on the pass's error return and `clang_cpp_adjust`'s
+resolution feeds goto-convert). So the B.4 "0 divergences" validation was
+verdict-level; post-`clang_cpp_adjust` OM bodies genuinely retain by-name
+member/index/struct-literal nodes the current `resolve_source` cannot follow.
+This is direct empirical input to RV-adj6 and sizes the real B.5 completion
+gap: S2/S3 must resolve exactly these survivors (or the B.5 flip's exit
+invariant will hard-fail), and the next S-step should start by classifying
+those ~26 bodies' unresolved nodes.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,7 +1,10 @@
 #include <python-frontend/python_adjust.h>
 
+#include <clang-c-frontend/padding.h>
 #include <irep2/irep2_utils.h>
 #include <util/message.h>
+#include <util/migrate.h>
+#include <util/prefix.h>
 #include <vector>
 
 python_adjust::python_adjust(contextt &_context)
@@ -84,6 +87,23 @@ void python_adjust::adjust_expr(expr2tc &expr)
   if (is_nil_expr(expr))
     return;
 
+  // Complete the node's own type first (macro expansion, array size, struct
+  // padding), mirroring the legacy adjust_expr's leading
+  // `adjust_type(expr.type())`. expr2t::type is immutable, so rebuild via
+  // with_type only when completion changed it — on the live (post-
+  // clang_cpp_adjust) pipeline every body type is already complete, so this
+  // is a no-op and the pass stays inert. Caveat: with_type aborts on kinds
+  // with no substitutable type slot (constant_bool, relations, bool ops —
+  // irep2_expr.cpp); those all carry scalar types adjust_type never changes,
+  // so the rebuild is unreachable for them. An adjust_type arm that starts
+  // rewriting scalar types must revisit this.
+  {
+    type2tc t = expr->type;
+    adjust_type(t);
+    if (t != expr->type)
+      expr = expr->with_type(t);
+  }
+
   // Recurse operands first so nested sources resolve inner-to-outer: building
   // `self.b.a` needs `self.b` already resolved to a struct. Foreach_operand
   // mutates each operand in place, so an inner member2t rebuilt below updates
@@ -107,6 +127,112 @@ void python_adjust::adjust_expr(expr2tc &expr)
     expr2tc source = i.source_value;
     if (resolve_source(source))
       expr = index2tc(i.type, source, i.index);
+  }
+}
+
+void python_adjust::adjust_type(type2tc &type)
+{
+  if (is_nil_type(type))
+    return;
+
+  if (is_symbol_type(type))
+  {
+    // Macro expansion only (legacy adjust_type `symbol.is_macro` arm): a
+    // non-macro tag reference stays by-name and is followed at consumption
+    // time — eagerly resolving it here would diverge from the legacy pass's
+    // lazy sources (parity subtlety RV-adj6). Unlike the legacy pass this one
+    // does not abort on an unknown *top-level* type symbol: the by-name type
+    // is left untouched and, where it matters (member/index source, struct
+    // literal), the post-adjust exit invariant flags it as an error instead.
+    // An unknown tag buried inside an aggregate still aborts downstream
+    // (add_padding's alignment() follows it via ns.follow, which asserts the
+    // symbol exists) — the no-abort guarantee is top-level only.
+    const symbolt *s = context.find_symbol(to_symbol_type(type).symbol_name);
+    if (s != nullptr && s->is_type && s->is_macro)
+    {
+      type = s->get_type2();
+      adjust_type(type);
+    }
+    return;
+  }
+
+  if (is_array_type(type))
+  {
+    // Adjust the (VLA) size expression and recurse into the element type
+    // (legacy `is_array_like` arm; its vector_typet half has no analogue here
+    // because the Python frontend never emits vector types). The nodes are
+    // immutable — rebuild only when something changed so the pass stays inert
+    // on complete types.
+    const array_type2t &arr = to_array_type(type);
+    type2tc subtype = arr.subtype;
+    expr2tc size = arr.array_size;
+    adjust_type(subtype);
+    if (!is_nil_expr(size))
+      adjust_expr(size);
+    if (subtype != arr.subtype || size != arr.array_size)
+      type = array_type2tc(subtype, size, arr.size_is_infinite);
+    return;
+  }
+
+  if (is_struct_type(type) || is_union_type(type))
+  {
+    // Complete the aggregate (legacy struct/union arm): recurse the member
+    // types, then insert alignment padding. Padding must reproduce the legacy
+    // layout byte-for-byte (RV-adj5), so reuse add_padding itself through the
+    // lossless type round-trip rather than reimplementing its alignment
+    // arithmetic. On an already-completed type add_padding is a fixpoint
+    // (asserted in the legacy pass), so this arm is idempotent and inert on
+    // the live pipeline. IREP2 has no incomplete aggregates (they stay
+    // symbol_type2t), so the legacy `!type.incomplete()` guard is not needed.
+    auto members = is_struct_type(type) ? to_struct_type(type).members
+                                        : to_union_type(type).members;
+    bool members_changed = false;
+    for (type2tc &member : members)
+    {
+      const type2tc before = member;
+      adjust_type(member);
+      members_changed |= member != before;
+    }
+    if (members_changed)
+    {
+      if (is_struct_type(type))
+      {
+        const struct_type2t &st = to_struct_type(type);
+        type = struct_type2tc(
+          members, st.member_names, st.member_pretty_names, st.name, st.packed);
+      }
+      else
+      {
+        const union_type2t &ut = to_union_type(type);
+        type = union_type2tc(
+          members, ut.member_names, ut.member_pretty_names, ut.name, ut.packed);
+      }
+    }
+
+    typet legacy = migrate_type_back(type);
+    // The #is_padding component flag does not survive the IREP2 round-trip,
+    // and without it add_padding aligns an existing pad member as if it were
+    // a regular field (padding.cpp:262 vs :276), double-padding the struct.
+    // Re-derive it from the four reserved pad-member names add_padding
+    // assigns: they all contain `$`, which cannot appear in a Python
+    // identifier, so only add_padding's own members match. (The #bitfield/
+    // #extint type flags are likewise dropped by the round-trip, but the
+    // Python frontend never emits either, so only #is_padding needs
+    // restoring.)
+    for (auto &comp : to_struct_union_type(legacy).components())
+    {
+      const std::string &name = comp.get_name().as_string();
+      if (
+        has_prefix(name, "anon_pad$") ||
+        has_prefix(name, "anon_bit_field_pad$") ||
+        has_prefix(name, "ext_int_pad$") || name == "$pad")
+        comp.set_is_padding(true);
+    }
+    add_padding(legacy, ns);
+    type2tc padded = migrate_type(legacy);
+    if (padded != type)
+      type = padded;
+    return;
   }
 }
 

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -39,6 +39,30 @@ public:
   /// sources (`self.b.a`) resolve inner-to-outer.
   void adjust_expr(expr2tc &expr);
 
+  /// IREP2-native `clang_c_adjust::adjust_type` (V.1k/B.5 milestone step S1):
+  /// expand a macro `symbol_type2t` to the symbol's type, adjust an array's
+  /// (VLA) size expression and element type, and complete a struct/union by
+  /// recursing its member types and inserting alignment padding. Padding
+  /// reuses the legacy `add_padding` through the type round-trip
+  /// (`migrate_type_back` → `add_padding` → `migrate_type`) — lossless for
+  /// every type the Python frontend emits (a packed *union* would drop its
+  /// packed flag, but the converter emits no unions) — so the layout is
+  /// byte-identical to the legacy pass by construction (risk RV-adj5). A
+  /// non-macro tag reference deliberately stays by-name, exactly as the
+  /// legacy pass leaves it (parity subtlety RV-adj6); IREP2 has no incomplete
+  /// aggregates (an incomplete type stays a `symbol_type2t`), so the legacy
+  /// `!type.incomplete()` guard has no analogue here.
+  ///
+  /// Known S1 scope limits vs the legacy pass, deliberate until later
+  /// S-steps: (1) an unknown top-level type symbol is left by-name for the
+  /// exit invariant instead of abort()ing; (2) no `vector_typet` arm (the
+  /// Python frontend never emits vector types); (3) *type symbols themselves*
+  /// are not adjusted — the legacy adjust() completes all `is_type` symbols
+  /// first so resolution sees fixed-up tags; on the live pipeline
+  /// `clang_cpp_adjust` still does that, and the B.5 flip must add the
+  /// type-symbol pre-pass before this pass becomes the sole resolver.
+  void adjust_type(type2tc &type);
+
 protected:
   contextt &context;
   namespacet ns;

--- a/unit/python-frontend/CMakeLists.txt
+++ b/unit/python-frontend/CMakeLists.txt
@@ -5,7 +5,9 @@ new_unit_test(symbol_id_test "symbol_id_test.cpp" "pythonfrontend")
 new_unit_test(python_class_test "python_class_test.cpp" "pythonfrontend")
 new_unit_test(complex_type_test "complex_type_test.cpp" "pythonfrontend;util_esbmc;bigint")
 new_unit_test(irep2_type_roundtrip_test "irep2_type_roundtrip_test.cpp" "pythonfrontend;util_esbmc;bigint")
-new_unit_test(python_adjust_test "python_adjust_test.cpp" "pythonfrontend;util_esbmc;bigint")
+# clangcfrontend_stuff provides add_padding (padding.cpp), which
+# python_adjust's S1 adjust_type reuses for byte-identical struct layout.
+new_unit_test(python_adjust_test "python_adjust_test.cpp" "pythonfrontend;clangcfrontend_stuff;util_esbmc;bigint")
 new_unit_test(function_call_cache_test "function_call_cache_test.cpp" "pythonfrontend")
 new_unit_test(json_utils_alias_test "json_utils_alias_test.cpp" "pythonfrontend")
 if(NOT WIN32)

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -264,6 +264,10 @@ TEST_CASE(
 {
   // A member2t whose source is already a resolved struct must be left alone
   // (idempotence: re-running the adjuster is a no-op on resolved nodes).
+  // A concrete-struct source drives adjust_type's struct arm through
+  // add_padding, whose alignment arithmetic reads config.ansi_c; set the data
+  // model so the pass does not divide by a zero alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Baz", "z");
 
@@ -341,6 +345,10 @@ TEST_CASE(
   // When the body has nothing to resolve (its member source is already a
   // resolved struct), adjust() must not rewrite the symbol — the value stays
   // byte-identical so the legacy cache and goto-convert body are untouched.
+  // The concrete-struct source drives add_padding, whose alignment arithmetic
+  // reads config.ansi_c; set the data model so it does not divide by a zero
+  // alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Qux", "w");
 

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -5,6 +5,7 @@
 #include <util/context.h>
 #include <util/symbol.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <irep2/irep2_utils.h>
 #include <string>
 #include <vector>
@@ -427,4 +428,208 @@ TEST_CASE(
 
   python_adjust adjuster(ctx);
   REQUIRE(adjuster.adjust());
+}
+
+// --- S1: IREP2-native adjust_type (V.1k/B.5 combined-milestone step S1) ---
+//
+// The padding tests need the target data model set (add_padding's alignment
+// arithmetic reads config.ansi_c); set it explicitly so the tests do not
+// depend on invocation order.
+
+TEST_CASE(
+  "python_adjust S1 adjust_type expands a macro symbol type, chained",
+  "[python-adjust]")
+{
+  // py_alias2 -> py_alias1 -> int32: the macro arm must recurse until the
+  // type is concrete, mirroring clang_c_adjust::adjust_type's is_macro loop.
+  contextt ctx;
+  symbolt alias1;
+  alias1.id = alias1.name = "py_alias1";
+  alias1.mode = "Python";
+  alias1.is_type = true;
+  alias1.is_macro = true;
+  alias1.set_type(get_int32_type());
+  ctx.add(alias1);
+
+  symbolt alias2;
+  alias2.id = alias2.name = "py_alias2";
+  alias2.mode = "Python";
+  alias2.is_type = true;
+  alias2.is_macro = true;
+  alias2.set_type(symbol_type2tc("py_alias1"));
+  ctx.add(alias2);
+
+  type2tc t = symbol_type2tc("py_alias2");
+  python_adjust adjuster(ctx);
+  adjuster.adjust_type(t);
+
+  REQUIRE(t == get_int32_type());
+}
+
+TEST_CASE(
+  "python_adjust S1 adjust_type leaves a non-macro tag by-name",
+  "[python-adjust]")
+{
+  // The RV-adj6 parity subtlety: the legacy pass only overwrites is_macro
+  // symbol types; a struct tag reference stays by-name and is followed at
+  // consumption time. Eagerly resolving it here would diverge.
+  contextt ctx;
+  add_struct_type(ctx, "Foo", "x");
+
+  type2tc t = symbol_type2tc("tag-Foo");
+  const type2tc original = t;
+  python_adjust adjuster(ctx);
+  adjuster.adjust_type(t);
+
+  REQUIRE(t == original);
+}
+
+TEST_CASE(
+  "python_adjust S1 adjust_type completes an array element type",
+  "[python-adjust]")
+{
+  // Array arm: the element type recurses through adjust_type (here a macro
+  // alias expands to int32) while the size expression is preserved.
+  contextt ctx;
+  symbolt alias;
+  alias.id = alias.name = "py_elem_alias";
+  alias.mode = "Python";
+  alias.is_type = true;
+  alias.is_macro = true;
+  alias.set_type(get_int32_type());
+  ctx.add(alias);
+
+  const expr2tc size = gen_long(get_uint64_type(), 4);
+  type2tc t = array_type2tc(symbol_type2tc("py_elem_alias"), size, false);
+  python_adjust adjuster(ctx);
+  adjuster.adjust_type(t);
+
+  REQUIRE(is_array_type(t));
+  REQUIRE(to_array_type(t).subtype == get_int32_type());
+  REQUIRE(to_array_type(t).array_size == size);
+}
+
+TEST_CASE(
+  "python_adjust S1 adjust_type pads a misaligned struct like add_padding",
+  "[python-adjust]")
+{
+  // struct { int8 c; int32 i; } needs 3 bytes of padding after `c` on any
+  // data model with 4-byte int alignment. The pass must reproduce the legacy
+  // add_padding layout exactly (RV-adj5): one unsignedbv(24) padding member
+  // between the fields, total size a multiple of the alignment.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  type2tc t = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "Packed2",
+    false);
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_type(t);
+
+  REQUIRE(is_struct_type(t));
+  const struct_type2t &st = to_struct_type(t);
+  REQUIRE(st.members.size() == 3);
+  REQUIRE(st.member_names[0] == "c");
+  REQUIRE(st.member_names[2] == "i");
+  REQUIRE(is_unsignedbv_type(st.members[1]));
+  REQUIRE(st.members[1]->get_width() == 24);
+
+  // Idempotence: a second pass over the already-padded struct is a no-op —
+  // the inertness guarantee for the live (post-clang_cpp_adjust) pipeline.
+  const type2tc padded = t;
+  adjuster.adjust_type(t);
+  REQUIRE(t == padded);
+}
+
+TEST_CASE(
+  "python_adjust S1 adjust_type pads a union like add_padding, idempotently",
+  "[python-adjust]")
+{
+  // union { int8 b[5]; int32 i; } is 5 bytes wide with 4-byte alignment, so
+  // add_padding appends a trailing `$pad` member widening it to 8 bytes. The
+  // second pass exercises the `$pad` case of the #is_padding re-derivation:
+  // the union arm must be as idempotent as the struct one.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc bytes5 =
+    array_type2tc(signedbv_type2tc(8), gen_long(get_uint64_type(), 5), false);
+  type2tc t = union_type2tc(
+    std::vector<type2tc>{bytes5, get_int32_type()},
+    std::vector<irep_idt>{"b", "i"},
+    std::vector<irep_idt>{"b", "i"},
+    "U1",
+    false);
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_type(t);
+
+  REQUIRE(is_union_type(t));
+  const union_type2t &ut = to_union_type(t);
+  REQUIRE(ut.members.size() == 3);
+  REQUIRE(ut.member_names[2] == "$pad");
+  REQUIRE(is_unsignedbv_type(ut.members[2]));
+
+  const type2tc padded = t;
+  adjuster.adjust_type(t);
+  REQUIRE(t == padded);
+}
+
+TEST_CASE(
+  "python_adjust S1 adjust_type completes a struct member's macro type",
+  "[python-adjust]")
+{
+  // Aggregate-member recursion: a member whose type is a macro alias expands
+  // before padding runs, so the layout is computed over concrete types.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  symbolt alias;
+  alias.id = alias.name = "py_field_alias";
+  alias.mode = "Python";
+  alias.is_type = true;
+  alias.is_macro = true;
+  alias.set_type(get_int32_type());
+  ctx.add(alias);
+
+  type2tc t = struct_type2tc(
+    std::vector<type2tc>{symbol_type2tc("py_field_alias")},
+    std::vector<irep_idt>{"v"},
+    std::vector<irep_idt>{"v"},
+    "Rec1",
+    false);
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_type(t);
+
+  REQUIRE(is_struct_type(t));
+  REQUIRE(to_struct_type(t).members.at(0) == get_int32_type());
+}
+
+TEST_CASE(
+  "python_adjust S1 adjust_expr completes a node's own type",
+  "[python-adjust]")
+{
+  // adjust_expr's leading type-completion (mirroring the legacy adjust_expr's
+  // adjust_type(expr.type())): a symbol whose type is a macro alias is
+  // retyped to the concrete type via with_type.
+  contextt ctx;
+  symbolt alias;
+  alias.id = alias.name = "py_expr_alias";
+  alias.mode = "Python";
+  alias.is_type = true;
+  alias.is_macro = true;
+  alias.set_type(get_int32_type());
+  ctx.add(alias);
+
+  expr2tc e = symbol2tc(symbol_type2tc("py_expr_alias"), "x");
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(e);
+
+  REQUIRE(is_symbol2t(e));
+  REQUIRE(e->type == get_int32_type());
 }


### PR DESCRIPTION
## What

Step **S1** of the V.1k/B.5 combined milestone (`docs/irep2-migration.md`, "Ordered, testable decomposition"): `python_adjust` gains an IREP2-native `adjust_type` reproducing the `clang_c_adjust::adjust_type` completion steps a Python body exercises:

- **Macro symbol-type expansion** (recursive; a non-macro tag deliberately stays by-name — the RV-adj6 lazy-source parity requirement).
- **Array (VLA) size + element-type adjustment.**
- **Struct/union completion**: member-type recursion, then alignment padding. Padding reuses the legacy `add_padding` itself through the `migrate_type_back` → `add_padding` → `migrate_type` round-trip, so the layout is byte-identical to the legacy pass **by construction** (risk RV-adj5) instead of reimplementing its alignment arithmetic.

`adjust_expr` now completes each node's own type first (`with_type` only on change), mirroring the legacy pass's leading `adjust_type(expr.type())`. The pass remains flag-gated (`--python-irep2-adjust`, default off ⇒ byte-identical pipeline).

## Findings recorded in the migration doc

1. **`#is_padding` does not survive the IREP2 round-trip** — without restoring it, `add_padding` aligns an existing pad member as a regular field (`padding.cpp:262` vs `:276`) and double-pads. Fixed by re-deriving the flag from the four reserved pad names (`anon_pad$`/`anon_bit_field_pad$`/`ext_int_pad$`/`$pad` — `$` cannot appear in a Python identifier); idempotence is unit-pinned for both struct and union arms.
2. **Pre-existing (master, A/B-confirmed): the flag-on pipeline already reports ~26 B.4 exit-invariant errors on OM model bodies** (`min`/`max`/`sorted`/…) — verdict-invisible, so the earlier B.4 "0 divergences" validation was verdict-level. This sizes the genuine S2/S3 completion gap and is documented as direct empirical input to RV-adj6.
3. Three deliberate S1 scope limits vs the legacy pass are documented in the header, including the missing **type-symbol pre-pass** the B.5 flip must add before `python_adjust` becomes the sole resolver.

## Gates

- 21/21 unit tests (`python_adjust_test`, 50 assertions) — every new branch exercised, including padding idempotence and the union `$pad` case.
- 76/76 flag-on fixture + acceptance-family regressions (`python_irep2_adjust_*`, `nested-attr*`, `github_4117*`, `dataclass*`, `self_ref_nested_attr_chain*`).
- Dual-solver (Bitwuzla + Z3) verdict parity and stderr byte-parity vs the unpatched master build on the flag-on fixture (pass is inert post-`clang_cpp_adjust`).
- `scripts/check_python_tests.sh python_irep2_adjust` (CPython sanity) green.
- Code-reviewer pass applied: `$pad` prefix gap closed, stray artifacts removed, deviations documented; forward-looking items (type-symbol pre-pass, memoization of completed aggregates) recorded in the doc for S2+.