### PR TITLE
[python] Fix re bare char-class [x-y] returning a nondet result

### DIFF
--- a/regression/python/re_char_class_single/main.py
+++ b/regression/python/re_char_class_single/main.py
@@ -1,0 +1,26 @@
+# Regression test for the bare single-character class [x-y] in re.match /
+# re.search / re.fullmatch (src/python-frontend/models/re.py).
+#
+# Before the fix, a pattern like "[a-z]" (no quantifier) was not recognised by
+# try_match_char_class_range (which required a length-6 quantified pattern), so
+# match() fell through to its non-deterministic fallback and returned an
+# unconstrained bool. This test pins the correct behaviour: "[x-y]" matches
+# exactly one character in the range.
+import re
+
+# match: anchors at the start, one in-range char suffices.
+assert re.match("[a-z]", "h")
+assert re.match("[a-z]", "hello")
+assert not re.match("[a-z]", "H")
+assert not re.match("[a-z]", "")
+assert re.match("[0-9]", "5")
+assert not re.match("[0-9]", "x")
+
+# fullmatch: the whole string must be exactly one in-range char.
+assert re.fullmatch("[a-z]", "h")
+assert not re.fullmatch("[a-z]", "hh")
+assert not re.fullmatch("[a-z]", "H")
+
+# search: an in-range char anywhere in the string.
+assert re.search("[0-9]", "abc5")
+assert not re.search("[0-9]", "abc")

--- a/regression/python/re_char_class_single/test.desc
+++ b/regression/python/re_char_class_single/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/re_char_class_single_fail/main.py
+++ b/regression/python/re_char_class_single_fail/main.py
@@ -6,4 +6,4 @@
 # non-deterministic result for the unrecognised "[a-z]" pattern.
 import re
 
-assert re.match("[a-z]", "H")       # falsifiable — 'H' is not in [a-z]
+assert re.match("[a-z]", "H")  # falsifiable — 'H' is not in [a-z]

--- a/regression/python/re_char_class_single_fail/main.py
+++ b/regression/python/re_char_class_single_fail/main.py
@@ -1,0 +1,9 @@
+# Falsification counterpart for the bare single-character class fix
+# (src/python-frontend/models/re.py).
+#
+# 'H' is uppercase, so it is not in [a-z]; asserting a match must fail. Before
+# the fix this assertion could spuriously hold because the model returned a
+# non-deterministic result for the unrecognised "[a-z]" pattern.
+import re
+
+assert re.match("[a-z]", "H")       # falsifiable — 'H' is not in [a-z]

--- a/regression/python/re_char_class_single_fail/test.desc
+++ b/regression/python/re_char_class_single_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 12
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -34,13 +34,17 @@ def try_match_char_class_range(pattern: str,
                                prefix_only: bool = False) -> int:
     """Match [x-y]+ or [x-y]* patterns.
 
+    Handles the bare single-character class ``[x-y]`` (length 5, no quantifier,
+    matches exactly one character in the range) as well as ``[x-y]+`` and
+    ``[x-y]*`` (length 6).
+
     When ``prefix_only`` is False (default, used by ``fullmatch``), every
     character of ``string`` must lie in [x-y]. When True (used by ``match``),
     only the leading run of in-range characters is required: ``+`` needs at
     least one such character, ``*`` always matches at the start of the
     string. This mirrors CPython's at-the-start semantics for ``re.match``.
     """
-    if pattern_len != 6:
+    if pattern_len != 5 and pattern_len != 6:
         return -1
 
     # Extract pattern characters to avoid constant folding issues
@@ -50,13 +54,26 @@ def try_match_char_class_range(pattern: str,
     if not (ch0 == '[' and ch2 == '-' and ch4 == ']'):
         return -1
 
-    quantifier: str = pattern[5]
-    if quantifier != '+' and quantifier != '*':
-        return -1
-
     start_char: str = pattern[1]
     end_char: str = pattern[3]
     string_len: int = len(string)
+
+    # Bare class ``[x-y]``: match exactly one character in the range. Without a
+    # quantifier the whole match consumes a single character, so ``fullmatch``
+    # additionally requires the string to be that one character.
+    if pattern_len == 5:
+        if string_len == 0:
+            return 0
+        c0_single: str = string[0]
+        if c0_single < start_char or c0_single > end_char:
+            return 0
+        if prefix_only:
+            return 1
+        return 1 if string_len == 1 else 0
+
+    quantifier: str = pattern[5]
+    if quantifier != '+' and quantifier != '*':
+        return -1
 
     if string_len == 0:
         return 1 if quantifier == '*' else 0
@@ -367,6 +384,25 @@ def search(pattern: str, string: str) -> bool:
                 return True
             pos = pos + 1
         return False
+
+    # Bare single-character class "[x-y]": present anywhere in the string when
+    # some character lies in the range. Recognised here so search() does not
+    # fall through to the non-deterministic result for this common pattern.
+    if pattern_len == 5:
+        cc0: str = pattern[0]
+        cc2: str = pattern[2]
+        cc4: str = pattern[4]
+        if cc0 == '[' and cc2 == '-' and cc4 == ']':
+            start_char: str = pattern[1]
+            end_char: str = pattern[3]
+            string_len: int = len(string)
+            p: int = 0
+            while p < string_len:
+                cc: str = string[p]
+                if cc >= start_char and cc <= end_char:
+                    return True
+                p = p + 1
+            return False
 
     # For patterns with metacharacters, use nondeterministic behavior
     has_match: bool = __VERIFIER_nondet_bool()


### PR DESCRIPTION
Fixes a model gap surfaced by the harness-coverage effort (PR #5981).

**Bug.** `re.match` / `re.search` / `re.fullmatch` on a *bare* single-character
class such as `"[a-z]"` (no quantifier) fell through to the model's
non-deterministic fallback and returned an unconstrained bool — so
`re.match("[a-z]", "H")` could evaluate to True even though `H` is uppercase.
The recognizer `try_match_char_class_range` only accepted the length-6
quantified forms `"[x-y]+"` / `"[x-y]*"`, and `search()` used a nondet result
for any metacharacter pattern.

**Fix.**
- `try_match_char_class_range` now also handles the length-5 bare class: match
  exactly one character in `[x-y]` (and, for `fullmatch`, require the string to
  be that single character).
- `search()` recognises the bare class before its nondet fallback: present iff
  some character of the string lies in the range.

**Tests.** `re_char_class_single` (match/search/fullmatch, positive and
negative anchors) and `re_char_class_single_fail` (asserts the impossible
`re.match("[a-z]", "H")`). Both run under CPython too. The existing re tests
(`github_3013`, `github_3153`, `github_4354*`, `github_4664_charclass/digit/
fullmatch`, `re1`) all still pass — the change is guarded by the `[`/`-`/`]`
shape, so literal patterns are unaffected.
