### PR TITLE
[python] Add time.time monotonicity coverage (gap was a misdiagnosis)

### DIFF
--- a/regression/python/harness_time_monotonic/main.py
+++ b/regression/python/harness_time_monotonic/main.py
@@ -15,7 +15,7 @@ t0: float = time.time()
 t1: float = time.time()
 t2: float = time.time()
 
-assert t1 == t0 + 1.0       # E1
-assert t2 == t1 + 1.0       # E1
-assert t0 < t1              # E2
-assert t1 < t2              # E2
+assert t1 == t0 + 1.0  # E1
+assert t2 == t1 + 1.0  # E1
+assert t0 < t1  # E2
+assert t1 < t2  # E2

--- a/regression/python/harness_time_monotonic/main.py
+++ b/regression/python/harness_time_monotonic/main.py
@@ -1,0 +1,21 @@
+# Verification harness for time.time monotonicity
+# (src/python-frontend/models/time.py).
+#
+# The model advances a module-level clock by 1.0 on each call, so consecutive
+# time() readings strictly increase. This pins that contract; it was left
+# unharnessed in PR #5973 under the mistaken belief that the module-global
+# clock stalled the converter (it does not — that was machine contention).
+#
+# ENSURES:
+#   E1: each reading is 1.0 greater than the previous one
+#   E2: readings strictly increase across three calls
+import time
+
+t0: float = time.time()
+t1: float = time.time()
+t2: float = time.time()
+
+assert t1 == t0 + 1.0       # E1
+assert t2 == t1 + 1.0       # E1
+assert t0 < t1              # E2
+assert t1 < t2              # E2

--- a/regression/python/harness_time_monotonic/test.desc
+++ b/regression/python/harness_time_monotonic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_time_monotonic_fail/main.py
+++ b/regression/python/harness_time_monotonic_fail/main.py
@@ -11,4 +11,4 @@ import time
 t0: float = time.time()
 t1: float = time.time()
 
-assert t0 == t1       # F1 — falsifiable (readings differ by 1.0)
+assert t0 == t1  # F1 — falsifiable (readings differ by 1.0)

--- a/regression/python/harness_time_monotonic_fail/main.py
+++ b/regression/python/harness_time_monotonic_fail/main.py
@@ -1,0 +1,14 @@
+# Falsification harness for time.time monotonicity
+# (src/python-frontend/models/time.py).
+#
+# The clock advances by 1.0 on each call, so two consecutive readings are never
+# equal; asserting equality must be falsifiable.
+#
+# WRONG PROPERTY (expected to be falsified):
+#   F1: two consecutive time() readings are equal.  They differ by 1.0.
+import time
+
+t0: float = time.time()
+t1: float = time.time()
+
+assert t0 == t1       # F1 — falsifiable (readings differ by 1.0)

--- a/regression/python/harness_time_monotonic_fail/test.desc
+++ b/regression/python/harness_time_monotonic_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 4
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -159,6 +159,8 @@ ignored_dirs=(
   "string-symbolic-8"
   "complex_str_nonconstant"
   "dataclass_factory_kwarg_ignored"
+  "harness_time_monotonic"
+  "harness_time_monotonic_fail"
 )
 
 # Prefixes for ESBMC-specific regression directories that are not suitable for


### PR DESCRIPTION
Resolves the third model gap from the harness-coverage plan (§9) — and it turns
out to be a **misdiagnosis, not a bug**.

The plan recorded `time.time()`'s `global` mutable module clock as stalling the
converter (PR #5973 left its monotonicity unharnessed on that basis). On
investigation it does not reproduce: `time.time()` verifies correctly —
consecutive readings increasing by 1.0, module-level calls, and chained
comparisons all give `VERIFICATION SUCCESSFUL` in ~3 s. The earlier "stops at
Converting" observation was shared-machine CPU contention killing a normally
fast run, not a converter defect (the existing `sleep`/`sleep_fail` tests use
`time.time()` and pass fine).

So instead of a fix this adds the coverage the misdiagnosis had blocked:
- `harness_time_monotonic` — three readings; each is 1.0 greater than the last
  and they strictly increase.
- `harness_time_monotonic_fail` — asserts two consecutive readings are equal.

Both verify as expected. The model's exact `+1.0` increment diverges from real
wall-clock time, so both are added to the `check_python_tests.sh` ignore list.
No model change.
