### PR TITLE
[python] Complete by-name struct literals in python_adjust (V.1k S2)

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3741,6 +3741,42 @@ gap: S2/S3 must resolve exactly these survivors (or the B.5 flip's exit
 invariant will hard-fail), and the next S-step should start by classifying
 those ~26 bodies' unresolved nodes.
 
+#### S2 outcome (2026-07-11) — survivors classified (100% exception literals); aggregate-literal completion landed; flag-on exit invariant now clean
+
+**Classification (the S1-outcome action item).** The exit-invariant
+diagnostics were enriched (`collect_unresolved_sources`: one entry per node —
+kind, by-name tag, member name), and the full survivor census on the flag-on
+pipeline is decisive: **116 unresolved nodes, 100% `constant_struct2t`
+literals with by-name exception tags** — 101 `tag-IndexError`, 10
+`tag-ValueError`, 5 `tag-ZeroDivisionError` (the OM model bodies' `raise
+IndexError(...)` literals) — and **zero** member/index survivors. So S2 alone
+drains the entire pre-existing work-list, and S3 (member/index operand
+coercion) has **no pre-existing survivors**: its work only materialises when
+the converter starts emitting pre-adjust nodes or at the flip.
+
+**S2 is in** (branch `feat/python-adjust-s2-aggregate-literal`, stacked on
+S1): `adjust_expr` gains a `constant_struct2t` arm — guard-lookup the tag (no
+abort on an unknown symbol; the exit invariant flags it instead), `ns.follow`
+to the struct, complete it via S1's `adjust_type` (padding), insert
+`gen_zero` padding operands at the reserved `$`-named component positions
+when the literal lacks them (mirroring the legacy `adjust_struct` insertion,
+`clang_c_adjust_expr.cpp:152-176`), and rebuild with the resolved type. This
+resolves *eagerly* where the legacy pass leaves the literal's type lazily
+by-name — the RV-adj6 divergence, deliberate and now exercised: IREP2's
+strong construction invariant requires the resolved type on the node. On
+today's pipeline the survivors' operands were already padded by
+`clang_cpp_adjust`, so only the retype fires; the insertion path serves
+converter-built literals post-flip (unit-pinned).
+
+**Acceptance.** Flag-on exit-invariant errors: **26 symbols / 116 nodes → 0**,
+dual-solver (Bitwuzla + Z3) verdicts unchanged; exception-heavy regressions
+(`try_except_else{,_fail}`, `except_tuple_types{,_fail}`,
+`list_index_valueerror{,_fail}`, `slice_step_zero_valueerror`) hold identical
+verdicts flag-on vs flag-off (the eager retype does not disturb cpp-throw
+catch matching); 76/76 fixture + acceptance families; 24/24 unit tests. The
+flag-on pipeline is exit-invariant-clean for the first time — the B.5 flip's
+hard-fail risk from Finding 2 is retired.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3780,7 +3780,35 @@ asserts only the type kind, so that mismatch would otherwise reach symex
 silently). The flag-on pipeline is exit-invariant-clean for the first time —
 the B.5 flip's hard-fail risk from Finding 2 is retired.
 
-**Flip note (S6 prerequisite, alongside the type-symbol pre-pass above):**
+#### Type-symbol pre-pass (2026-07-11) — the S1-documented S-gap closed
+
+`adjust()` now mirrors `clang_c_adjust::adjust()`'s two-phase order: a
+pre-pass completes every **Python-mode** `is_type` symbol's IREP2 type via
+`adjust_type` (macro expansion + padding, write-back only on change) before
+the value walk, so symbolic-type resolution always follows fixed-up tags.
+The mode scoping is load-bearing, not cosmetic: C/C++-header types can carry
+bitfields whose `#bitfield` flag does not survive the IREP2 round-trip —
+re-padding those from the migrated view would write a corrupted layout back
+into the table — while every converter-emitted tag is mode `"Python"`
+(`create_symbol`, `converter_util.cpp`). Incomplete (forward-declared) tags
+migrate to a 0-member struct view; `add_padding` is a no-op there and the
+change-detection guard prevents any lossy write-back (unit-pinned, along
+with the completed-tag, non-Python-skip, and pre-pass→value-walk chain
+cases). Inert on the live flag-on pipeline (0 exit-invariant errors,
+dual-solver verdicts unchanged, 76/76 fixture). Remaining legacy completion
+**not** yet reproduced, both recorded as scope limits in `python_adjust.h`:
+non-type symbols' *own* types (`adjust_symbol`,
+`clang_c_adjust_expr.cpp:70-74` — limit 3), and **legacy-only struct
+metadata across a firing write-back** (limit 4, review-caught, latent):
+`set_type(type2tc)` drops the `"bases"` sub-irep that
+`exception_typeid.cpp:37` and `base_type.cpp:421` read for Python
+exception-hierarchy/catch matching (plus component `access`/`#is_padding`
+cosmetics). Inert while the write-back never fires; the flip must either
+re-attach preserved sub-ireps on a legacy write-back or land the W3/V.2
+IREP2-native carriage for `"bases"` first — and should also start honouring
+`adjust()`'s error return at the `python_language.cpp` call site.
+
+**Flip note (S6 prerequisite):**
 cpp-throw catch matching is safe under S2 only because exception ids are
 derived *upstream* — `clang_cpp_adjust::convert_exception_id` builds
 `code_cpp_throw2t`'s `exception_list` from the thrown *symbol* type's
@@ -3788,6 +3816,156 @@ identifier (`substr(4)` off the `tag-` name) before this pass runs. Once the
 flip removes the `clang_cpp_adjust` hop, that derivation must be re-homed
 (either into `python_adjust` before the eager literal retype, or taught to
 read the resolved `struct_type2t::name`).
+
+#### Flip-probe census (2026-07-11) — the S4/S5 questions answered empirically; ordered flip-blocker list
+
+**Method.** A local, uncommitted probe gated the `clang_cpp_adjust` hop
+(`python_language.cpp:273`) behind an environment variable and ran four
+trivial flag-on programs — scalar-param call (`f(1)` into `x: float`),
+mixed-width arithmetic (`int * float`), class attribute
+(`C(4).v`), and list subscript (`l[1]`) — against the same binary with the
+hop on (baseline: 4/4 `VERIFICATION SUCCESSFUL`) and off.
+
+**Result: 4/4 SIGSEGV** — every probe, including ones with no user
+exceptions or classes at all, crashes after GOTO generation inside
+`exception_loweringt::run`'s THROW scan (`remove_exceptions.cpp:128-138`,
+crash-report symbolication). Root cause confirmed by source audit:
+`exception_list` is populated **exclusively** by `clang_cpp_adjust`
+(`clang_cpp_adjust_expr.cpp:403-411`); the Python frontend itself only emits
+an empty list for bare re-raises (`python_exception_handler.cpp:229`). The
+OM model bodies contain `raise IndexError(...)` throws even for a plain list
+subscript, so with the hop skipped every operand-carrying THROW reaches the
+unguarded `t.exception_list.front()` on an empty vector. (That `.front()` is
+also a crash-not-diagnostic fragility worth hardening in the flip-era work;
+not shipped now — the branch is unreachable on the normal pipeline.)
+
+**Consequences.**
+1. **Exception-id re-homing is the FIRST flip blocker**, not one item among
+   several: S3/S4/S5 completion gaps cannot even be *measured* empirically
+   until throws carry ids without `clang_cpp_adjust`. The natural home is
+   converter-side at throw construction (`python_exception_handler` knows the
+   class and its bases when it builds the cpp-throw), which also retires the
+   `"bases"`-at-lowering dependency for the *throw* side; catch-side
+   hierarchy matching still needs the `"bases"` carriage (scope limit 4).
+2. **S4 placement is settled by construction-assert reasoning**: IREP2
+   arith/relational constructors reject mismatched widths, so a
+   post-migration pass can never see the nodes S4 would fix — width
+   reconciliation must live **converter-side**, i.e. in
+   `build_binary_expression` (the F-P11 chokepoint) via the proven
+   width-hazard recipe (`c_implicit_typecast_arithmetic` + the #5581
+   sub-`int`-width narrow-back guard). Validation lever: once the converter
+   reconciles inline, the legacy `adjust_expr_binary_arithmetic` becomes a
+   no-op on those nodes, so flag-off GOTO-byte A/B parity gates the change
+   *today*, before any flip.
+3. **S5 (call-argument casts) remains open but bounded**: the legacy pass
+   `gen_typecast`s every argument to its declared parameter type
+   (`clang_c_adjust_expr.cpp:933-961`); the converter performs its own
+   pointer/struct coercions (`function_call/expr.cpp:5130-5174`) but general
+   scalar param casts are unverified — measurable only after blocker 1.
+
+**Ordered flip-blocker list (supersedes the scattered notes above):**
+(1) exception-id derivation re-homed to the Python path; (2) `"bases"`
+carriage for catch-side hierarchy matching (scope limit 4 / W3-V.2);
+(3) S3 member/index source resolution at scale (the B.3 pointer-source
+finding); (4) S4 converter-side width reconciliation in
+`build_binary_expression`; (5) S5 argument-cast census + completion;
+(6) honour `adjust()`'s error return at the `python_language.cpp` call site.
+
+#### Blocker #1 re-homing probe (2026-07-12) — "at throw construction" is refuted; the derivation needs the post-conversion state
+
+The census above placed blocker #1's natural home "converter-side at throw
+construction (`python_exception_handler` knows the class and its bases when it
+builds the cpp-throw)". A direct probe **refutes that placement.**
+
+**Method.** Made `clang_cpp_adjust::convert_exception_id` a namespace-parameterised
+`static` (behaviour-preserving: the three in-tree call sites and two recursive
+calls pass `ns`; baseline unchanged) and called it at the operand-carrying
+cpp-throw construction in `python_exception_handler::get_raise_statement`
+(`:382`), attaching the derived `exception_list` exactly as
+`adjust_side_effect_throw` does. Intended to be inert (the still-running
+`clang_cpp_adjust` hop overwrites the list with a byte-identical one) and to be
+validated by a temporary parity assert in `adjust_side_effect_throw`.
+
+**Result: SIGSEGV during conversion**, before any parity assert could fire.
+`convert_exception_id`'s symbol arm dereferences `ns.lookup(identifier)->get_type()`
+with **no null guard** (`clang_cpp_adjust_expr.cpp:455`); at construction time
+`identifier` is the by-name tag `type_handler::get_typet(exc_name)` emits
+(observed: `tag-ValueError`), which **does not resolve** in the converter's
+namespace — the Python exception class lives under a mangled id
+(`py:…@C@ValueError@…`), never under `tag-ValueError`, so the lookup returns
+`nullptr`. Baseline (hop on) is green on the same program, so the legacy pass
+does **not** take that failing lookup: by the time `clang_cpp_adjust` runs it has
+already `adjust_expr`'d the throw operand, so it derives ids from the *resolved*
+operand type (concrete struct / `#cpp_type`), not the transient `symbol_type`
+present at construction.
+
+**Consequences.**
+1. **Blocker #1's home is a post-conversion pass, not throw construction.** The
+   derivation depends on operand-type resolution (symbol→struct following, or the
+   `#cpp_type`/`bases` a completed table carries) that only exists *after*
+   conversion. Re-homing must therefore run where that state is available — a
+   converter-side pass over the finished symbol table *before* `clang_cpp_adjust`,
+   or (aligning with the S-series end state) inside `python_adjust`, which already
+   runs post-conversion and becomes the sole resolver after the S6 flip. This
+   also entangles blocker #1 with S3 (member/index/operand resolution): the id
+   source is the *resolved* operand, so #1 sits downstream of S3, not ahead of it.
+2. **`convert_exception_id`'s unguarded `ns.lookup(...)->get_type()` is a latent
+   crash-vs-diagnostic fragility** — a sibling of the `remove_exceptions`
+   `t.exception_list.front()` one flagged above. Both should be hardened in the
+   flip-era work; both are unreachable on the current pipeline (the lookup only
+   sees resolved types post-`adjust_expr`), so neither is shipped now.
+
+Blocker #1's list entry (1) is refined accordingly: *re-home the derivation to a
+post-conversion pass that reads resolved operand types — not to throw
+construction.*
+
+#### S3 assessment (2026-07-12) — member/index operand coercion is structurally N/A for IREP2; S3 ≈ already done
+
+The S-list frames S3 as "reproduce the pointer-deref / `p[i]`→`*(p+i)` / index
+typecast steps for the pointer-backed Python container/instance sources"
+(mirroring `clang_c_adjust::adjust_index`/`adjust_member`). A code audit shows
+that framing is a **legacy-`exprt` view that does not carry over to IREP2** — the
+Key-implementation-insight of `irep2-keystone-implementation-plan.md` (§"most of
+`clang_cpp_adjust`'s completion must happen at converter construction") is right,
+and this pins it for the index/member surface specifically:
+
+- **`index2t`/`member2t` cannot hold a pointer source.** The construction asserts
+  permit only array/vector (`index2t`, `irep2_expr.h:1646`) or struct/union
+  (`member2t`) sources, plus the transient `symbol_type` B.1 resolves. So there is
+  **no pointer-sourced `index2t` to desugar** — the `p[i]`→`*(p+i)` rewrite
+  (`clang_c_adjust_expr.cpp:487-495`) and `adjust_member`'s base-wrapping
+  (`:296-312`) are structurally unreachable on IREP2 nodes.
+- **The converter already does the desugaring at construction.** `build_index`
+  (`python_expr_builder.cpp:106-122`) falls back to the legacy `index_exprt` for a
+  dyn-array/pointer source (Python lists, strings, dicts — the pointer-backed
+  containers) and only builds an `index2t` over an array/vector/`symbol_type`
+  source; `build_deref_member` (`:92-101`) pre-builds the `dereference2t` for a
+  pointer-to-struct instance, so the `member2t` source is already the resolved
+  struct. The pointer cases the S-list worried about therefore never reach an
+  IREP2 node needing coercion — they ride the legacy node `clang_cpp_adjust` still
+  owns until V.3 migrates *that* builder, a separate track.
+- **The one IREP2-applicable step — the `symbol_type` source follow — is already
+  B.1, and already unit-tested** for both arms (`python_adjust_test.cpp`: "B.1
+  follows a direct symbol_type member source to its struct" and "…index source to
+  its array").
+
+**Residual.** The sole `adjust_index` step with no converter/B.1 analogue is the
+index-operand typecast `gen_typecast(ns, index_expr, index_type())`
+(`clang_c_adjust_expr.cpp:484`): `build_index` migrates the index operand raw, and
+today `clang_cpp_adjust` supplies the `index_type()` cast (visible as the
+`[(signed long int)i]` casts in flag-off GOTO). Whether an IREP2 `index2t` *needs*
+that cast post-flip is a **symex-tolerance question that cannot be settled without
+the flip** (on the flag-on pipeline `clang_cpp_adjust` still runs first and
+supplies it, so any `python_adjust` reproduction is a byte-identical no-op — an
+inert-but-unverifiable-for-necessity capability). Recorded as an open flip-era
+item, not built speculatively.
+
+**Consequence for the plan.** S3 is **≈ done**: its only IREP2-applicable behaviour
+(symbol-type source following) landed in B.1. The remaining pre-flip S-work is
+therefore S4 (width reconciliation — largely drained by the keystone W-tasks 1–4b)
+and blocker #1 (post-conversion, per the probe above); S5 still trails blocker #1.
+This shortens the critical path to the S6 flip by removing an S-step that read as
+open but is structurally satisfied.
 
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3773,9 +3773,21 @@ dual-solver (Bitwuzla + Z3) verdicts unchanged; exception-heavy regressions
 (`try_except_else{,_fail}`, `except_tuple_types{,_fail}`,
 `list_index_valueerror{,_fail}`, `slice_step_zero_valueerror`) hold identical
 verdicts flag-on vs flag-off (the eager retype does not disturb cpp-throw
-catch matching); 76/76 fixture + acceptance families; 24/24 unit tests. The
-flag-on pipeline is exit-invariant-clean for the first time — the B.5 flip's
-hard-fail risk from Finding 2 is retired.
+catch matching); 76/76 fixture + acceptance families; 27/27 unit tests. The
+exit invariant additionally flags a *resolved*-struct literal whose operand
+count disagrees with its component list (`constant_struct2t`'s constructor
+asserts only the type kind, so that mismatch would otherwise reach symex
+silently). The flag-on pipeline is exit-invariant-clean for the first time —
+the B.5 flip's hard-fail risk from Finding 2 is retired.
+
+**Flip note (S6 prerequisite, alongside the type-symbol pre-pass above):**
+cpp-throw catch matching is safe under S2 only because exception ids are
+derived *upstream* — `clang_cpp_adjust::convert_exception_id` builds
+`code_cpp_throw2t`'s `exception_list` from the thrown *symbol* type's
+identifier (`substr(4)` off the `tag-` name) before this pass runs. Once the
+flip removes the `clang_cpp_adjust` hop, that derivation must be re-homed
+(either into `python_adjust` before the eager literal retype, or taught to
+read the resolved `struct_type2t::name`).
 
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -20,6 +20,37 @@ bool python_adjust::adjust()
   context.Foreach_operand_in_order(
     [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
 
+  // Type symbols first, so symbolic-type resolution below always receives
+  // fixed-up (macro-expanded, padded) tags — the same two-phase structure as
+  // clang_c_adjust::adjust() (clang_c_adjust_expr.cpp:31-42). Scoped to
+  // Python-mode symbols (RV-adj4): every converter-emitted tag is mode
+  // "Python" (create_symbol, converter_util.cpp), while C/C++-header types
+  // may contain bitfields whose #bitfield flag does not survive the IREP2
+  // round-trip — re-padding those from the migrated view would write back a
+  // corrupted layout. Inert on the live flag-on pipeline: clang_cpp_adjust
+  // already completed every table type and adjust_type is a fixpoint on
+  // complete types, so the write-back never fires until the flip makes this
+  // pass the sole resolver.
+  // Two further round-trip losses bound what the write-back below may carry
+  // (both inert while the write-back never fires, both flip-era work): an
+  // explicit "alignment" attribute is dropped by migrate_type, so an
+  // over-aligned tag would be under-padded vs the legacy pass (the Python
+  // frontend emits none); and legacy-only sub-ireps — most importantly the
+  // "bases" list exception_typeid.cpp and base_type.cpp read for the
+  // exception hierarchy — do not survive set_type(type2tc). See scope limit
+  // (4) in the header.
+  for (symbolt *symbol : symbol_list)
+  {
+    if (!symbol->is_type || symbol->mode != "Python")
+      continue;
+
+    const type2tc original = symbol->get_type2();
+    type2tc t = original;
+    adjust_type(t);
+    if (t != original)
+      symbol->set_type(t);
+  }
+
   bool error = false;
   for (symbolt *symbol : symbol_list)
   {

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -405,7 +405,6 @@ void python_adjust::collect_unresolved_sources(
       std::to_string(to_struct_type(expr->type).members.size()) +
       " component(s)");
 
-  expr->foreach_operand([this, &out](const expr2tc &e) {
-    collect_unresolved_sources(e, out);
-  });
+  expr->foreach_operand(
+    [this, &out](const expr2tc &e) { collect_unresolved_sources(e, out); });
 }

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -50,19 +50,25 @@ bool python_adjust::adjust()
 
     // Post-adjust strong invariant (V.1k B.4): re-enforce what the three relaxed
     // construction asserts deferred — no member2t/index2t source and no
-    // constant_struct2t type may survive as a transient symbol_type2t. On the
-    // live pipeline this pass runs after clang_cpp_adjust, which already resolves
-    // every by-name aggregate, so the check never fires and the pass stays inert;
-    // it is a dead-but-tested safety net that deterministically catches a
-    // B.5-era resolution bug once the pass replaces clang_cpp_adjust and becomes
-    // the sole resolver.
-    if (has_unresolved_source(value))
+    // constant_struct2t type may survive as a transient symbol_type2t, and a
+    // resolved-struct literal must carry one operand per component. Pre-S2
+    // this fired on every flag-on run (the OM exception literals,
+    // docs/irep2-migration.md "S1 outcome" finding 2); S2's aggregate-literal
+    // completion drained those, so a firing now means a node shape the
+    // remaining S-steps (S3+) must resolve — the per-node detail below is
+    // that work-list.
+    std::vector<std::string> unresolved;
+    collect_unresolved_sources(value, unresolved);
+    if (!unresolved.empty())
     {
       log_error(
-        "python_adjust: symbol `{}' retains an unresolved by-name "
-        "(symbol_type2t) member/index/struct-literal node after adjust (V.1k "
-        "post-adjust invariant violated)",
-        symbol->id.as_string());
+        "python_adjust: symbol `{}' retains {} unresolved by-name "
+        "(symbol_type2t) node(s) after adjust (V.1k post-adjust invariant "
+        "violated):",
+        symbol->id.as_string(),
+        unresolved.size());
+      for (const std::string &entry : unresolved)
+        log_error("  {}", entry);
       error = true;
     }
   }
@@ -80,6 +86,17 @@ bool is_resolved_aggregate(const type2tc &t)
   return is_struct_type(t) || is_union_type(t) || is_array_type(t) ||
          is_vector_type(t);
 }
+
+// The four reserved pad-member names add_padding assigns (padding.cpp). The
+// exact-prefix match matters: `$` cannot appear in a Python identifier, but
+// OM struct tags originate from C/C++ headers where Clang accepts `$` as an
+// extension — a substring test could misfire on a legitimate member.
+bool is_padding_member_name(const std::string &name)
+{
+  return has_prefix(name, "anon_pad$") ||
+         has_prefix(name, "anon_bit_field_pad$") ||
+         has_prefix(name, "ext_int_pad$") || name == "$pad";
+}
 } // namespace
 
 void python_adjust::adjust_expr(expr2tc &expr)
@@ -96,7 +113,12 @@ void python_adjust::adjust_expr(expr2tc &expr)
   // with no substitutable type slot (constant_bool, relations, bool ops —
   // irep2_expr.cpp); those all carry scalar types adjust_type never changes,
   // so the rebuild is unreachable for them. An adjust_type arm that starts
-  // rewriting scalar types must revisit this.
+  // rewriting scalar types must revisit this. A by-name constant_struct2t is
+  // excluded: a bare with_type retype would skip the S2 arm's padding-operand
+  // insertion (a macro tag would expand here), leaving a literal whose
+  // operand count silently disagrees with its resolved type — the S2 arm
+  // below owns that node shape entirely.
+  if (!(is_constant_struct2t(expr) && is_symbol_type(expr->type)))
   {
     type2tc t = expr->type;
     adjust_type(t);
@@ -127,6 +149,56 @@ void python_adjust::adjust_expr(expr2tc &expr)
     expr2tc source = i.source_value;
     if (resolve_source(source))
       expr = index2tc(i.type, source, i.index);
+  }
+  else if (is_constant_struct2t(expr) && is_symbol_type(expr->type))
+  {
+    // S2: aggregate-literal completion — the third relaxed construction
+    // assert. The legacy adjust_struct (clang_c_adjust_expr.cpp:152-176)
+    // follows the type only to read components, inserts padding operands and
+    // leaves the literal's own type lazily by-name; IREP2's strong invariant
+    // requires the resolved type on the node, so this arm resolves eagerly
+    // (the RV-adj6 divergence, understood and deliberate). On today's
+    // pipeline the by-name survivors are the OM exception literals
+    // (raise IndexError(...) et al., docs/irep2-migration.md "S1 outcome"
+    // finding 2): their operands were already padded by the legacy pass, so
+    // only the retype fires; the padding-operand insertion below completes a
+    // converter-built literal once the flip makes this pass the sole
+    // resolver.
+    // Guard the follow: ns.follow asserts on an unknown tag, but an
+    // unresolvable literal must instead survive to the exit invariant
+    // (mirrors the top-level-symbol no-abort deviation in adjust_type).
+    const symbolt *s =
+      context.find_symbol(to_symbol_type(expr->type).symbol_name);
+    if (s == nullptr || !s->is_type)
+      return;
+    type2tc resolved = ns.follow(expr->type);
+    if (is_struct_type(resolved))
+    {
+      // Complete (pad) the followed type first so operand positions match
+      // the final component list. Idempotent when already padded (S1).
+      adjust_type(resolved);
+      const struct_type2t &st = to_struct_type(resolved);
+      std::vector<expr2tc> ops = to_constant_struct2t(expr).datatype_members;
+      // Mirror the legacy already-padded heuristic: only insert padding
+      // operands when the literal doesn't have them yet. Pad members are
+      // recognised by the reserved `$` names (see the re-derivation in
+      // adjust_type); inserting at component position i keeps the remaining
+      // value operands aligned, exactly like the legacy insertion loop.
+      if (ops.size() != st.members.size())
+      {
+        for (size_t i = 0; i < st.members.size(); i++)
+        {
+          const bool is_pad =
+            is_padding_member_name(st.member_names[i].as_string());
+          if (is_pad && i <= ops.size())
+            ops.insert(ops.begin() + i, gen_zero(st.members[i]));
+        }
+      }
+      // Rebuild only when the literal is structurally consistent; a residual
+      // mismatch is left by-name for the exit invariant to flag.
+      if (ops.size() == st.members.size())
+        expr = constant_struct2tc(resolved, ops);
+    }
   }
 }
 
@@ -220,14 +292,8 @@ void python_adjust::adjust_type(type2tc &type)
     // Python frontend never emits either, so only #is_padding needs
     // restoring.)
     for (auto &comp : to_struct_union_type(legacy).components())
-    {
-      const std::string &name = comp.get_name().as_string();
-      if (
-        has_prefix(name, "anon_pad$") ||
-        has_prefix(name, "anon_bit_field_pad$") ||
-        has_prefix(name, "ext_int_pad$") || name == "$pad")
+      if (is_padding_member_name(comp.get_name().as_string()))
         comp.set_is_padding(true);
-    }
     add_padding(legacy, ns);
     type2tc padded = migrate_type(legacy);
     if (padded != type)
@@ -258,28 +324,57 @@ bool python_adjust::resolve_source(expr2tc &source)
   return true;
 }
 
-bool python_adjust::has_unresolved_source(const expr2tc &expr) const
+void python_adjust::collect_unresolved_sources(
+  const expr2tc &expr,
+  std::vector<std::string> &out) const
 {
   if (is_nil_expr(expr))
-    return false;
+    return;
 
   // A member/index whose source type is still a symbol_type2t is unresolved:
   // resolve_source could not follow it to a concrete aggregate (e.g. it follows
   // to a non-aggregate scalar), so the strong construction invariant is unmet.
+  // Each entry names the node kind and the by-name tag — together they are the
+  // classification the B.5 resolution steps work from.
   if (is_member2t(expr) && is_symbol_type(to_member2t(expr).source_value->type))
-    return true;
+  {
+    const member2t &m = to_member2t(expr);
+    out.push_back(
+      "member `." + m.member.as_string() + "' over by-name source `" +
+      to_symbol_type(m.source_value->type).symbol_name.as_string() + "'");
+  }
   if (is_index2t(expr) && is_symbol_type(to_index2t(expr).source_value->type))
-    return true;
+    out.push_back(
+      "index over by-name source `" +
+      to_symbol_type(to_index2t(expr).source_value->type)
+        .symbol_name.as_string() +
+      "'");
   // A constant_struct2t is the third relaxed construction assert (irep2_expr.h):
   // its own type may be a transient by-name symbol_type2t until the aggregate is
   // followed. Post-adjust it must be a resolved struct too.
   if (is_constant_struct2t(expr) && is_symbol_type(expr->type))
-    return true;
+    out.push_back(
+      "struct literal with by-name type `" +
+      to_symbol_type(expr->type).symbol_name.as_string() + "'");
+  // A resolved-struct literal must also be structurally consistent: the S2
+  // completion only rebuilds when the operand count matches the component
+  // list, so a count mismatch here means some other path retyped the literal
+  // without inserting its padding operands — catch it before it reaches
+  // migration/symex (constant_struct2t's constructor asserts only the type
+  // kind, not the operand count).
+  if (
+    is_constant_struct2t(expr) && is_struct_type(expr->type) &&
+    to_constant_struct2t(expr).datatype_members.size() !=
+      to_struct_type(expr->type).members.size())
+    out.push_back(
+      "struct literal `" + to_struct_type(expr->type).name.as_string() +
+      "' with " +
+      std::to_string(to_constant_struct2t(expr).datatype_members.size()) +
+      " operand(s) against " +
+      std::to_string(to_struct_type(expr->type).members.size()) +
+      " component(s)");
 
-  bool found = false;
-  expr->foreach_operand([this, &found](const expr2tc &e) {
-    if (has_unresolved_source(e))
-      found = true;
+  expr->foreach_operand([this, &out](const expr2tc &e) {
+    collect_unresolved_sources(e, out);
   });
-  return found;
 }

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -3,6 +3,8 @@
 #include <util/context.h>
 #include <util/namespace.h>
 #include <irep2/irep2.h>
+#include <string>
+#include <vector>
 
 /// V.1k (b) IREP2-native Python adjuster (phases B.0–B.2).
 ///
@@ -35,8 +37,13 @@ public:
 
   /// Recursively visit `expr` and its sub-expressions, resolving transient
   /// `symbol_type2t` member2t/index2t sources to their followed aggregate type
-  /// (the V.1k two-phase source invariant). Recurses operands first, so nested
-  /// sources (`self.b.a`) resolve inner-to-outer.
+  /// (the V.1k two-phase source invariant), and completing a by-name
+  /// `constant_struct2t` literal (S2): follow + pad its type and insert
+  /// zero-valued padding operands when missing. Note S2 resolves *eagerly*
+  /// where the legacy adjust_struct leaves the literal's type lazily by-name
+  /// (the deliberate RV-adj6 divergence — IREP2's strong construction
+  /// invariant requires the resolved type on the node). Recurses operands
+  /// first, so nested sources (`self.b.a`) resolve inner-to-outer.
   void adjust_expr(expr2tc &expr);
 
   /// IREP2-native `clang_c_adjust::adjust_type` (V.1k/B.5 milestone step S1):
@@ -75,10 +82,15 @@ protected:
   /// since a member/index cannot be constructed over a raw pointer.
   bool resolve_source(expr2tc &source);
 
-  /// Post-adjust strong-invariant probe (V.1k B.4): true if any node reachable
-  /// from `expr` still carries a transient `symbol_type2t` the pass could not
-  /// resolve — a `member2t`/`index2t` source that follows to a non-aggregate, or
-  /// a `constant_struct2t` whose own type is still by-name. Covers all three
-  /// relaxed construction asserts (irep2_expr.h). Recursive.
-  bool has_unresolved_source(const expr2tc &expr) const;
+  /// Post-adjust strong-invariant probe (V.1k B.4): append to `out` one
+  /// human-readable entry per unresolved node reachable from `expr` — a
+  /// `member2t`/`index2t` source or `constant_struct2t` type still carrying a
+  /// transient `symbol_type2t` (the three relaxed construction asserts,
+  /// irep2_expr.h), or a resolved-struct literal whose operand count
+  /// disagrees with its component list. adjust() logs these entries when the
+  /// exit invariant fires — the per-node detail is the work-list the B.5-era
+  /// resolution steps (S3+) drain. Recursive.
+  void collect_unresolved_sources(
+    const expr2tc &expr,
+    std::vector<std::string> &out) const;
 };

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -28,11 +28,14 @@ class python_adjust
 public:
   explicit python_adjust(contextt &_context);
 
-  /// Walk every non-type symbol's IREP2 value. Returns true on error —
+  /// Two-phase walk mirroring `clang_c_adjust::adjust()`: first complete
+  /// every type symbol's IREP2 type via adjust_type (macro expansion,
+  /// padding), so the value resolution below always follows fixed-up tags;
+  /// then walk every code symbol's IREP2 value. Returns true on error —
   /// specifically if the post-adjust strong invariant is violated (a
   /// member2t/index2t source or a constant_struct2t type still carries an
-  /// unresolved `symbol_type2t` after resolution); false on success, mirroring
-  /// `clang_c_adjust::adjust()`.
+  /// unresolved `symbol_type2t` after resolution, or a resolved literal's
+  /// operand count disagrees with its component list); false on success.
   bool adjust();
 
   /// Recursively visit `expr` and its sub-expressions, resolving transient
@@ -60,14 +63,22 @@ public:
   /// aggregates (an incomplete type stays a `symbol_type2t`), so the legacy
   /// `!type.incomplete()` guard has no analogue here.
   ///
-  /// Known S1 scope limits vs the legacy pass, deliberate until later
-  /// S-steps: (1) an unknown top-level type symbol is left by-name for the
-  /// exit invariant instead of abort()ing; (2) no `vector_typet` arm (the
-  /// Python frontend never emits vector types); (3) *type symbols themselves*
-  /// are not adjusted — the legacy adjust() completes all `is_type` symbols
-  /// first so resolution sees fixed-up tags; on the live pipeline
-  /// `clang_cpp_adjust` still does that, and the B.5 flip must add the
-  /// type-symbol pre-pass before this pass becomes the sole resolver.
+  /// Known scope limits vs the legacy pass, deliberate until later S-steps:
+  /// (1) an unknown top-level type symbol is left by-name for the exit
+  /// invariant instead of abort()ing; (2) no `vector_typet` arm (the Python
+  /// frontend never emits vector types); (3) non-type symbols' *own* types
+  /// (e.g. a function's code type) are not adjusted — the legacy
+  /// adjust_symbol completes them (`clang_c_adjust_expr.cpp:70-74`), and
+  /// `clang_cpp_adjust` still does on the live pipeline. Type symbols ARE
+  /// completed: adjust() runs a type-symbol pre-pass before value
+  /// resolution, mirroring the legacy two-phase order. (4) The pre-pass
+  /// write-back (`set_type(type2tc)`) cannot carry legacy-only struct
+  /// metadata — the `"bases"` sub-irep (read by exception_typeid.cpp and
+  /// base_type.cpp for Python exception-hierarchy/catch matching) and
+  /// component `access`/`#is_padding` flags are lost if the write-back
+  /// fires. Inert today (the write-back never fires post-clang_cpp_adjust);
+  /// the B.5 flip must either re-attach the preserved sub-ireps on a legacy
+  /// write-back or move the `"bases"` carriage to IREP2 (W3/V.2) first.
   void adjust_type(type2tc &type);
 
 protected:

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -422,10 +422,10 @@ TEST_CASE(
   "[python-adjust]")
 {
   // constant_struct2t is the third relaxed construction assert (irep2_expr.h):
-  // its own type may be a transient by-name symbol_type2t. The pass does not
-  // resolve aggregate-literal types (that is the B.5-era whole-body resolution),
-  // so a survivor must be caught by the post-adjust invariant and adjust() must
-  // return true (error).
+  // its own type may be a transient by-name symbol_type2t. S2 resolves a
+  // *registered* tag (tests below); this literal's tag-Rec is unregistered,
+  // so it must survive resolution and be caught by the post-adjust invariant:
+  // adjust() returns true (error).
   contextt ctx;
   const expr2tc lit = constant_struct2tc(
     symbol_type2tc("tag-Rec"),
@@ -616,6 +616,202 @@ TEST_CASE(
 
   REQUIRE(is_struct_type(t));
   REQUIRE(to_struct_type(t).members.at(0) == get_int32_type());
+}
+
+TEST_CASE(
+  "python_adjust S2 completes a by-name struct literal to its resolved type",
+  "[python-adjust]")
+{
+  // The OM exception-literal shape (raise IndexError(...)): a
+  // constant_struct2t typed by-name whose operands are already complete. S2
+  // retypes it to the followed struct — eagerly, unlike the legacy
+  // adjust_struct (RV-adj6) — and the exit invariant stops flagging it.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc struct_t = add_struct_type(ctx, "Exc", "id");
+
+  const expr2tc lit = constant_struct2tc(
+    symbol_type2tc("tag-Exc"),
+    std::vector<expr2tc>{gen_zero(get_int32_type())});
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(lit)});
+  add_code_symbol(ctx, "py_adjust_s2_lit_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  const expr2tc &stored = ctx.find_symbol("py_adjust_s2_lit_sym")->get_value2();
+  const expr2tc &stmt = to_code_block2t(stored).operands.at(0);
+  const expr2tc &resolved = to_code_expression2t(stmt).operand;
+  REQUIRE(is_constant_struct2t(resolved));
+  REQUIRE(resolved->type == struct_t);
+  REQUIRE(to_constant_struct2t(resolved).datatype_members.size() == 1);
+}
+
+TEST_CASE(
+  "python_adjust S2 inserts missing padding operands into a struct literal",
+  "[python-adjust]")
+{
+  // A converter-built literal carries only the value operands; the followed
+  // struct pads to { c, anon_pad$, i } (S1), so S2 must insert a zero pad
+  // operand at position 1, mirroring the legacy adjust_struct insertion.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "PadLit",
+    false);
+  symbolt type_sym;
+  type_sym.id = type_sym.name = "tag-PadLit";
+  type_sym.mode = "Python";
+  type_sym.is_type = true;
+  type_sym.set_type(unpadded);
+  ctx.add(type_sym);
+
+  expr2tc lit = constant_struct2tc(
+    symbol_type2tc("tag-PadLit"),
+    std::vector<expr2tc>{
+      gen_zero(signedbv_type2tc(8)), gen_zero(get_int32_type())});
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(lit);
+
+  REQUIRE(is_constant_struct2t(lit));
+  REQUIRE(is_struct_type(lit->type));
+  const struct_type2t &st = to_struct_type(lit->type);
+  const constant_struct2t &cs = to_constant_struct2t(lit);
+  REQUIRE(st.members.size() == 3);
+  REQUIRE(cs.datatype_members.size() == 3);
+  REQUIRE(is_unsignedbv_type(cs.datatype_members[1]->type));
+  REQUIRE(cs.datatype_members[1]->type->get_width() == 24);
+  REQUIRE(cs.datatype_members[2]->type == get_int32_type());
+
+  // Idempotence: the completed literal is stable under a second walk.
+  const expr2tc done = lit;
+  adjuster.adjust_expr(lit);
+  REQUIRE(lit == done);
+}
+
+TEST_CASE(
+  "python_adjust S2 completes a macro-tag struct literal",
+  "[python-adjust]")
+{
+  // A literal typed by a macro alias of a struct: the leading type-completion
+  // block must NOT retype it bare (that would skip the padding-operand
+  // insertion); the S2 arm owns the shape end-to-end and pads it.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "MacroLit",
+    false);
+  symbolt alias;
+  alias.id = alias.name = "py_struct_alias";
+  alias.mode = "Python";
+  alias.is_type = true;
+  alias.is_macro = true;
+  alias.set_type(unpadded);
+  ctx.add(alias);
+
+  expr2tc lit = constant_struct2tc(
+    symbol_type2tc("py_struct_alias"),
+    std::vector<expr2tc>{
+      gen_zero(signedbv_type2tc(8)), gen_zero(get_int32_type())});
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(lit);
+
+  REQUIRE(is_constant_struct2t(lit));
+  REQUIRE(is_struct_type(lit->type));
+  REQUIRE(to_struct_type(lit->type).members.size() == 3);
+  REQUIRE(to_constant_struct2t(lit).datatype_members.size() == 3);
+}
+
+TEST_CASE(
+  "python_adjust S2 leaves a structurally short literal for the invariant",
+  "[python-adjust]")
+{
+  // A literal missing a *value* operand (only `c`, no `i`): pad insertion
+  // cannot make the counts match, so the literal must stay by-name and be
+  // flagged — never rebuilt with misaligned operands.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "ShortLit",
+    false);
+  symbolt type_sym;
+  type_sym.id = type_sym.name = "tag-ShortLit";
+  type_sym.mode = "Python";
+  type_sym.is_type = true;
+  type_sym.set_type(unpadded);
+  ctx.add(type_sym);
+
+  const expr2tc lit = constant_struct2tc(
+    symbol_type2tc("tag-ShortLit"),
+    std::vector<expr2tc>{gen_zero(signedbv_type2tc(8))});
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(lit)});
+  add_code_symbol(ctx, "py_adjust_s2_short_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE(adjuster.adjust());
+}
+
+TEST_CASE(
+  "python_adjust invariant flags a resolved literal with an operand-count "
+  "mismatch",
+  "[python-adjust]")
+{
+  // The durable half of the S2 safety net: even a literal that already
+  // carries a resolved struct type is flagged when its operand count
+  // disagrees with the component list (constant_struct2t's constructor
+  // asserts only the type kind, so this would otherwise reach symex).
+  contextt ctx;
+  const type2tc struct_t = add_struct_type(ctx, "Mismatch", "x");
+
+  const expr2tc lit = constant_struct2tc(struct_t, std::vector<expr2tc>{});
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(lit)});
+  add_code_symbol(ctx, "py_adjust_s2_mismatch_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE(adjuster.adjust());
+}
+
+TEST_CASE(
+  "python_adjust S2 leaves a scalar-tag struct literal for the invariant",
+  "[python-adjust]")
+{
+  // tag-Scalar follows to int (not a struct): S2 must not retype the literal;
+  // the survivor is flagged by the exit invariant instead.
+  contextt ctx;
+  symbolt scalar_type_sym;
+  scalar_type_sym.id = scalar_type_sym.name = "tag-Scalar";
+  scalar_type_sym.mode = "Python";
+  scalar_type_sym.is_type = true;
+  scalar_type_sym.set_type(get_int32_type());
+  ctx.add(scalar_type_sym);
+
+  const expr2tc lit = constant_struct2tc(
+    symbol_type2tc("tag-Scalar"),
+    std::vector<expr2tc>{gen_zero(get_int32_type())});
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(lit)});
+  add_code_symbol(ctx, "py_adjust_s2_scalar_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE(adjuster.adjust());
 }
 
 TEST_CASE(

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -316,6 +316,10 @@ TEST_CASE(
   // adjust() walks code symbols, resolving transient member sources in the
   // body and writing the symbol back. The body wraps `obj.x` (obj : tag-Foo);
   // after adjust() the stored body's member source is the resolved struct.
+  // The pre-pass adjust_type's the concrete tag-Foo struct, driving
+  // add_padding's alignment arithmetic (config.ansi_c); set the data model so
+  // it does not divide by a zero alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Foo", "x");
 
@@ -777,6 +781,10 @@ TEST_CASE(
   // carries a resolved struct type is flagged when its operand count
   // disagrees with the component list (constant_struct2t's constructor
   // asserts only the type kind, so this would otherwise reach symex).
+  // The pre-pass adjust_type's the concrete tag-Mismatch struct, driving
+  // add_padding's alignment arithmetic (config.ansi_c); set the data model so
+  // it does not divide by a zero alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Mismatch", "x");
 
@@ -812,6 +820,150 @@ TEST_CASE(
 
   python_adjust adjuster(ctx);
   REQUIRE(adjuster.adjust());
+}
+
+TEST_CASE(
+  "python_adjust pre-pass completes a Python tag symbol in the table",
+  "[python-adjust]")
+{
+  // The type-symbol pre-pass (mirroring clang_c_adjust::adjust()'s first
+  // loop): an unpadded Python-mode tag with a macro-typed member is
+  // macro-expanded and padded in the symbol table itself, so later
+  // resolution follows the fixed-up layout.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  symbolt alias;
+  alias.id = alias.name = "py_prepass_alias";
+  alias.mode = "Python";
+  alias.is_type = true;
+  alias.is_macro = true;
+  alias.set_type(signedbv_type2tc(8));
+  ctx.add(alias);
+
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{symbol_type2tc("py_prepass_alias"), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "PrePad",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-PrePad";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(unpadded);
+  ctx.add(tag);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  const type2tc &stored = ctx.find_symbol("tag-PrePad")->get_type2();
+  REQUIRE(is_struct_type(stored));
+  const struct_type2t &st = to_struct_type(stored);
+  REQUIRE(st.members.size() == 3);
+  REQUIRE(st.members[0] == signedbv_type2tc(8));
+  REQUIRE(is_unsignedbv_type(st.members[1]));
+  REQUIRE(st.member_names[2] == "i");
+}
+
+TEST_CASE(
+  "python_adjust pre-pass skips a non-Python type symbol",
+  "[python-adjust]")
+{
+  // C/C++-header types may carry bitfields whose #bitfield flag the IREP2
+  // round-trip drops; the pre-pass must not re-pad them (RV-adj4 scoping).
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "CPad",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-CPad";
+  tag.mode = "C";
+  tag.is_type = true;
+  tag.set_type(unpadded);
+  ctx.add(tag);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  REQUIRE(ctx.find_symbol("tag-CPad")->get_type2() == unpadded);
+}
+
+TEST_CASE(
+  "python_adjust pre-pass output feeds the value walk's resolution",
+  "[python-adjust]")
+{
+  // End-to-end across the two phases: the tag starts unpadded in the table;
+  // the pre-pass pads it, and the value walk's resolve_source then follows a
+  // transient member source to the *padded* layout — the reason the type
+  // pre-pass must run first (clang_c_adjust's "so that symbolic-type
+  // resolution always receives fixed up types").
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "Chain",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-Chain";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(unpadded);
+  ctx.add(tag);
+
+  const expr2tc source = symbol2tc(symbol_type2tc("tag-Chain"), "obj");
+  const expr2tc member = member2tc(get_int32_type(), source, "i");
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(member)});
+  add_code_symbol(ctx, "py_adjust_chain_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  const expr2tc &stored = ctx.find_symbol("py_adjust_chain_sym")->get_value2();
+  const expr2tc &stmt = to_code_block2t(stored).operands.at(0);
+  const expr2tc &resolved = to_code_expression2t(stmt).operand;
+  REQUIRE(is_member2t(resolved));
+  const type2tc &src_type = to_member2t(resolved).source_value->type;
+  REQUIRE(is_struct_type(src_type));
+  REQUIRE(to_struct_type(src_type).members.size() == 3);
+}
+
+TEST_CASE(
+  "python_adjust pre-pass leaves an empty (incomplete) tag unchanged",
+  "[python-adjust]")
+{
+  // A forward-declared class tag (python_class_builder::ensure_sym) is an
+  // incomplete struct with no components; the pre-pass must pass through
+  // without padding or crashing, and without writing the symbol back.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc empty_struct = struct_type2tc(
+    std::vector<type2tc>{},
+    std::vector<irep_idt>{},
+    std::vector<irep_idt>{},
+    "Fwd",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-Fwd";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(empty_struct);
+  ctx.add(tag);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  REQUIRE(ctx.find_symbol("tag-Fwd")->get_type2() == empty_struct);
 }
 
 TEST_CASE(


### PR DESCRIPTION
Step S2 of the V.1k/B.5 milestone (stacked on #5985). A census of the flag-on survivors is decisive: all 116 unresolved nodes are `constant_struct2t` literals with by-name exception tags, with zero member/index survivors. `adjust_expr` gains a `constant_struct2t` arm that resolves the tag, completes the struct via S1's `adjust_type`, inserts padding operands, and rebuilds with the resolved type — draining the entire work-list (116→0). Also flags resolved-struct literals whose operand count disagrees with their component list.
