### PR TITLE
[python] Add type-symbol pre-pass to python_adjust (V.1k B.5 prep)

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3817,6 +3817,60 @@ flip removes the `clang_cpp_adjust` hop, that derivation must be re-homed
 (either into `python_adjust` before the eager literal retype, or taught to
 read the resolved `struct_type2t::name`).
 
+#### Flip-probe census (2026-07-11) — the S4/S5 questions answered empirically; ordered flip-blocker list
+
+**Method.** A local, uncommitted probe gated the `clang_cpp_adjust` hop
+(`python_language.cpp:273`) behind an environment variable and ran four
+trivial flag-on programs — scalar-param call (`f(1)` into `x: float`),
+mixed-width arithmetic (`int * float`), class attribute
+(`C(4).v`), and list subscript (`l[1]`) — against the same binary with the
+hop on (baseline: 4/4 `VERIFICATION SUCCESSFUL`) and off.
+
+**Result: 4/4 SIGSEGV** — every probe, including ones with no user
+exceptions or classes at all, crashes after GOTO generation inside
+`exception_loweringt::run`'s THROW scan (`remove_exceptions.cpp:128-138`,
+crash-report symbolication). Root cause confirmed by source audit:
+`exception_list` is populated **exclusively** by `clang_cpp_adjust`
+(`clang_cpp_adjust_expr.cpp:403-411`); the Python frontend itself only emits
+an empty list for bare re-raises (`python_exception_handler.cpp:229`). The
+OM model bodies contain `raise IndexError(...)` throws even for a plain list
+subscript, so with the hop skipped every operand-carrying THROW reaches the
+unguarded `t.exception_list.front()` on an empty vector. (That `.front()` is
+also a crash-not-diagnostic fragility worth hardening in the flip-era work;
+not shipped now — the branch is unreachable on the normal pipeline.)
+
+**Consequences.**
+1. **Exception-id re-homing is the FIRST flip blocker**, not one item among
+   several: S3/S4/S5 completion gaps cannot even be *measured* empirically
+   until throws carry ids without `clang_cpp_adjust`. The natural home is
+   converter-side at throw construction (`python_exception_handler` knows the
+   class and its bases when it builds the cpp-throw), which also retires the
+   `"bases"`-at-lowering dependency for the *throw* side; catch-side
+   hierarchy matching still needs the `"bases"` carriage (scope limit 4).
+2. **S4 placement is settled by construction-assert reasoning**: IREP2
+   arith/relational constructors reject mismatched widths, so a
+   post-migration pass can never see the nodes S4 would fix — width
+   reconciliation must live **converter-side**, i.e. in
+   `build_binary_expression` (the F-P11 chokepoint) via the proven
+   width-hazard recipe (`c_implicit_typecast_arithmetic` + the #5581
+   sub-`int`-width narrow-back guard). Validation lever: once the converter
+   reconciles inline, the legacy `adjust_expr_binary_arithmetic` becomes a
+   no-op on those nodes, so flag-off GOTO-byte A/B parity gates the change
+   *today*, before any flip.
+3. **S5 (call-argument casts) remains open but bounded**: the legacy pass
+   `gen_typecast`s every argument to its declared parameter type
+   (`clang_c_adjust_expr.cpp:933-961`); the converter performs its own
+   pointer/struct coercions (`function_call/expr.cpp:5130-5174`) but general
+   scalar param casts are unverified — measurable only after blocker 1.
+
+**Ordered flip-blocker list (supersedes the scattered notes above):**
+(1) exception-id derivation re-homed to the Python path; (2) `"bases"`
+carriage for catch-side hierarchy matching (scope limit 4 / W3-V.2);
+(3) S3 member/index source resolution at scale (the B.3 pointer-source
+finding); (4) S4 converter-side width reconciliation in
+`build_binary_expression`; (5) S5 argument-cast census + completion;
+(6) honour `adjust()`'s error return at the `python_language.cpp` call site.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3919,6 +3919,54 @@ Blocker #1's list entry (1) is refined accordingly: *re-home the derivation to a
 post-conversion pass that reads resolved operand types — not to throw
 construction.*
 
+#### S3 assessment (2026-07-12) — member/index operand coercion is structurally N/A for IREP2; S3 ≈ already done
+
+The S-list frames S3 as "reproduce the pointer-deref / `p[i]`→`*(p+i)` / index
+typecast steps for the pointer-backed Python container/instance sources"
+(mirroring `clang_c_adjust::adjust_index`/`adjust_member`). A code audit shows
+that framing is a **legacy-`exprt` view that does not carry over to IREP2** — the
+Key-implementation-insight of `irep2-keystone-implementation-plan.md` (§"most of
+`clang_cpp_adjust`'s completion must happen at converter construction") is right,
+and this pins it for the index/member surface specifically:
+
+- **`index2t`/`member2t` cannot hold a pointer source.** The construction asserts
+  permit only array/vector (`index2t`, `irep2_expr.h:1646`) or struct/union
+  (`member2t`) sources, plus the transient `symbol_type` B.1 resolves. So there is
+  **no pointer-sourced `index2t` to desugar** — the `p[i]`→`*(p+i)` rewrite
+  (`clang_c_adjust_expr.cpp:487-495`) and `adjust_member`'s base-wrapping
+  (`:296-312`) are structurally unreachable on IREP2 nodes.
+- **The converter already does the desugaring at construction.** `build_index`
+  (`python_expr_builder.cpp:106-122`) falls back to the legacy `index_exprt` for a
+  dyn-array/pointer source (Python lists, strings, dicts — the pointer-backed
+  containers) and only builds an `index2t` over an array/vector/`symbol_type`
+  source; `build_deref_member` (`:92-101`) pre-builds the `dereference2t` for a
+  pointer-to-struct instance, so the `member2t` source is already the resolved
+  struct. The pointer cases the S-list worried about therefore never reach an
+  IREP2 node needing coercion — they ride the legacy node `clang_cpp_adjust` still
+  owns until V.3 migrates *that* builder, a separate track.
+- **The one IREP2-applicable step — the `symbol_type` source follow — is already
+  B.1, and already unit-tested** for both arms (`python_adjust_test.cpp`: "B.1
+  follows a direct symbol_type member source to its struct" and "…index source to
+  its array").
+
+**Residual.** The sole `adjust_index` step with no converter/B.1 analogue is the
+index-operand typecast `gen_typecast(ns, index_expr, index_type())`
+(`clang_c_adjust_expr.cpp:484`): `build_index` migrates the index operand raw, and
+today `clang_cpp_adjust` supplies the `index_type()` cast (visible as the
+`[(signed long int)i]` casts in flag-off GOTO). Whether an IREP2 `index2t` *needs*
+that cast post-flip is a **symex-tolerance question that cannot be settled without
+the flip** (on the flag-on pipeline `clang_cpp_adjust` still runs first and
+supplies it, so any `python_adjust` reproduction is a byte-identical no-op — an
+inert-but-unverifiable-for-necessity capability). Recorded as an open flip-era
+item, not built speculatively.
+
+**Consequence for the plan.** S3 is **≈ done**: its only IREP2-applicable behaviour
+(symbol-type source following) landed in B.1. The remaining pre-flip S-work is
+therefore S4 (width reconciliation — largely drained by the keystone W-tasks 1–4b)
+and blocker #1 (post-conversion, per the probe above); S5 still trails blocker #1.
+This shortens the critical path to the S6 flip by removing an S-step that read as
+open but is structurally satisfied.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3780,7 +3780,35 @@ asserts only the type kind, so that mismatch would otherwise reach symex
 silently). The flag-on pipeline is exit-invariant-clean for the first time —
 the B.5 flip's hard-fail risk from Finding 2 is retired.
 
-**Flip note (S6 prerequisite, alongside the type-symbol pre-pass above):**
+#### Type-symbol pre-pass (2026-07-11) — the S1-documented S-gap closed
+
+`adjust()` now mirrors `clang_c_adjust::adjust()`'s two-phase order: a
+pre-pass completes every **Python-mode** `is_type` symbol's IREP2 type via
+`adjust_type` (macro expansion + padding, write-back only on change) before
+the value walk, so symbolic-type resolution always follows fixed-up tags.
+The mode scoping is load-bearing, not cosmetic: C/C++-header types can carry
+bitfields whose `#bitfield` flag does not survive the IREP2 round-trip —
+re-padding those from the migrated view would write a corrupted layout back
+into the table — while every converter-emitted tag is mode `"Python"`
+(`create_symbol`, `converter_util.cpp`). Incomplete (forward-declared) tags
+migrate to a 0-member struct view; `add_padding` is a no-op there and the
+change-detection guard prevents any lossy write-back (unit-pinned, along
+with the completed-tag, non-Python-skip, and pre-pass→value-walk chain
+cases). Inert on the live flag-on pipeline (0 exit-invariant errors,
+dual-solver verdicts unchanged, 76/76 fixture). Remaining legacy completion
+**not** yet reproduced, both recorded as scope limits in `python_adjust.h`:
+non-type symbols' *own* types (`adjust_symbol`,
+`clang_c_adjust_expr.cpp:70-74` — limit 3), and **legacy-only struct
+metadata across a firing write-back** (limit 4, review-caught, latent):
+`set_type(type2tc)` drops the `"bases"` sub-irep that
+`exception_typeid.cpp:37` and `base_type.cpp:421` read for Python
+exception-hierarchy/catch matching (plus component `access`/`#is_padding`
+cosmetics). Inert while the write-back never fires; the flip must either
+re-attach preserved sub-ireps on a legacy write-back or land the W3/V.2
+IREP2-native carriage for `"bases"` first — and should also start honouring
+`adjust()`'s error return at the `python_language.cpp` call site.
+
+**Flip note (S6 prerequisite):**
 cpp-throw catch matching is safe under S2 only because exception ids are
 derived *upstream* — `clang_cpp_adjust::convert_exception_id` builds
 `code_cpp_throw2t`'s `exception_list` from the thrown *symbol* type's

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3871,6 +3871,54 @@ finding); (4) S4 converter-side width reconciliation in
 `build_binary_expression`; (5) S5 argument-cast census + completion;
 (6) honour `adjust()`'s error return at the `python_language.cpp` call site.
 
+#### Blocker #1 re-homing probe (2026-07-12) — "at throw construction" is refuted; the derivation needs the post-conversion state
+
+The census above placed blocker #1's natural home "converter-side at throw
+construction (`python_exception_handler` knows the class and its bases when it
+builds the cpp-throw)". A direct probe **refutes that placement.**
+
+**Method.** Made `clang_cpp_adjust::convert_exception_id` a namespace-parameterised
+`static` (behaviour-preserving: the three in-tree call sites and two recursive
+calls pass `ns`; baseline unchanged) and called it at the operand-carrying
+cpp-throw construction in `python_exception_handler::get_raise_statement`
+(`:382`), attaching the derived `exception_list` exactly as
+`adjust_side_effect_throw` does. Intended to be inert (the still-running
+`clang_cpp_adjust` hop overwrites the list with a byte-identical one) and to be
+validated by a temporary parity assert in `adjust_side_effect_throw`.
+
+**Result: SIGSEGV during conversion**, before any parity assert could fire.
+`convert_exception_id`'s symbol arm dereferences `ns.lookup(identifier)->get_type()`
+with **no null guard** (`clang_cpp_adjust_expr.cpp:455`); at construction time
+`identifier` is the by-name tag `type_handler::get_typet(exc_name)` emits
+(observed: `tag-ValueError`), which **does not resolve** in the converter's
+namespace — the Python exception class lives under a mangled id
+(`py:…@C@ValueError@…`), never under `tag-ValueError`, so the lookup returns
+`nullptr`. Baseline (hop on) is green on the same program, so the legacy pass
+does **not** take that failing lookup: by the time `clang_cpp_adjust` runs it has
+already `adjust_expr`'d the throw operand, so it derives ids from the *resolved*
+operand type (concrete struct / `#cpp_type`), not the transient `symbol_type`
+present at construction.
+
+**Consequences.**
+1. **Blocker #1's home is a post-conversion pass, not throw construction.** The
+   derivation depends on operand-type resolution (symbol→struct following, or the
+   `#cpp_type`/`bases` a completed table carries) that only exists *after*
+   conversion. Re-homing must therefore run where that state is available — a
+   converter-side pass over the finished symbol table *before* `clang_cpp_adjust`,
+   or (aligning with the S-series end state) inside `python_adjust`, which already
+   runs post-conversion and becomes the sole resolver after the S6 flip. This
+   also entangles blocker #1 with S3 (member/index/operand resolution): the id
+   source is the *resolved* operand, so #1 sits downstream of S3, not ahead of it.
+2. **`convert_exception_id`'s unguarded `ns.lookup(...)->get_type()` is a latent
+   crash-vs-diagnostic fragility** — a sibling of the `remove_exceptions`
+   `t.exception_list.front()` one flagged above. Both should be hardened in the
+   flip-era work; both are unreachable on the current pipeline (the lookup only
+   sees resolved types post-`adjust_expr`), so neither is shipped now.
+
+Blocker #1's list entry (1) is refined accordingly: *re-home the derivation to a
+post-conversion pass that reads resolved operand types — not to throw
+construction.*
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -20,6 +20,37 @@ bool python_adjust::adjust()
   context.Foreach_operand_in_order(
     [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
 
+  // Type symbols first, so symbolic-type resolution below always receives
+  // fixed-up (macro-expanded, padded) tags — the same two-phase structure as
+  // clang_c_adjust::adjust() (clang_c_adjust_expr.cpp:31-42). Scoped to
+  // Python-mode symbols (RV-adj4): every converter-emitted tag is mode
+  // "Python" (create_symbol, converter_util.cpp), while C/C++-header types
+  // may contain bitfields whose #bitfield flag does not survive the IREP2
+  // round-trip — re-padding those from the migrated view would write back a
+  // corrupted layout. Inert on the live flag-on pipeline: clang_cpp_adjust
+  // already completed every table type and adjust_type is a fixpoint on
+  // complete types, so the write-back never fires until the flip makes this
+  // pass the sole resolver.
+  // Two further round-trip losses bound what the write-back below may carry
+  // (both inert while the write-back never fires, both flip-era work): an
+  // explicit "alignment" attribute is dropped by migrate_type, so an
+  // over-aligned tag would be under-padded vs the legacy pass (the Python
+  // frontend emits none); and legacy-only sub-ireps — most importantly the
+  // "bases" list exception_typeid.cpp and base_type.cpp read for the
+  // exception hierarchy — do not survive set_type(type2tc). See scope limit
+  // (4) in the header.
+  for (symbolt *symbol : symbol_list)
+  {
+    if (!symbol->is_type || symbol->mode != "Python")
+      continue;
+
+    const type2tc original = symbol->get_type2();
+    type2tc t = original;
+    adjust_type(t);
+    if (t != original)
+      symbol->set_type(t);
+  }
+
   bool error = false;
   for (symbolt *symbol : symbol_list)
   {

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -28,11 +28,14 @@ class python_adjust
 public:
   explicit python_adjust(contextt &_context);
 
-  /// Walk every non-type symbol's IREP2 value. Returns true on error —
+  /// Two-phase walk mirroring `clang_c_adjust::adjust()`: first complete
+  /// every type symbol's IREP2 type via adjust_type (macro expansion,
+  /// padding), so the value resolution below always follows fixed-up tags;
+  /// then walk every code symbol's IREP2 value. Returns true on error —
   /// specifically if the post-adjust strong invariant is violated (a
   /// member2t/index2t source or a constant_struct2t type still carries an
-  /// unresolved `symbol_type2t` after resolution); false on success, mirroring
-  /// `clang_c_adjust::adjust()`.
+  /// unresolved `symbol_type2t` after resolution, or a resolved literal's
+  /// operand count disagrees with its component list); false on success.
   bool adjust();
 
   /// Recursively visit `expr` and its sub-expressions, resolving transient
@@ -60,14 +63,22 @@ public:
   /// aggregates (an incomplete type stays a `symbol_type2t`), so the legacy
   /// `!type.incomplete()` guard has no analogue here.
   ///
-  /// Known S1 scope limits vs the legacy pass, deliberate until later
-  /// S-steps: (1) an unknown top-level type symbol is left by-name for the
-  /// exit invariant instead of abort()ing; (2) no `vector_typet` arm (the
-  /// Python frontend never emits vector types); (3) *type symbols themselves*
-  /// are not adjusted — the legacy adjust() completes all `is_type` symbols
-  /// first so resolution sees fixed-up tags; on the live pipeline
-  /// `clang_cpp_adjust` still does that, and the B.5 flip must add the
-  /// type-symbol pre-pass before this pass becomes the sole resolver.
+  /// Known scope limits vs the legacy pass, deliberate until later S-steps:
+  /// (1) an unknown top-level type symbol is left by-name for the exit
+  /// invariant instead of abort()ing; (2) no `vector_typet` arm (the Python
+  /// frontend never emits vector types); (3) non-type symbols' *own* types
+  /// (e.g. a function's code type) are not adjusted — the legacy
+  /// adjust_symbol completes them (`clang_c_adjust_expr.cpp:70-74`), and
+  /// `clang_cpp_adjust` still does on the live pipeline. Type symbols ARE
+  /// completed: adjust() runs a type-symbol pre-pass before value
+  /// resolution, mirroring the legacy two-phase order. (4) The pre-pass
+  /// write-back (`set_type(type2tc)`) cannot carry legacy-only struct
+  /// metadata — the `"bases"` sub-irep (read by exception_typeid.cpp and
+  /// base_type.cpp for Python exception-hierarchy/catch matching) and
+  /// component `access`/`#is_padding` flags are lost if the write-back
+  /// fires. Inert today (the write-back never fires post-clang_cpp_adjust);
+  /// the B.5 flip must either re-attach the preserved sub-ireps on a legacy
+  /// write-back or move the `"bases"` carriage to IREP2 (W3/V.2) first.
   void adjust_type(type2tc &type);
 
 protected:

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -815,6 +815,150 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "python_adjust pre-pass completes a Python tag symbol in the table",
+  "[python-adjust]")
+{
+  // The type-symbol pre-pass (mirroring clang_c_adjust::adjust()'s first
+  // loop): an unpadded Python-mode tag with a macro-typed member is
+  // macro-expanded and padded in the symbol table itself, so later
+  // resolution follows the fixed-up layout.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  symbolt alias;
+  alias.id = alias.name = "py_prepass_alias";
+  alias.mode = "Python";
+  alias.is_type = true;
+  alias.is_macro = true;
+  alias.set_type(signedbv_type2tc(8));
+  ctx.add(alias);
+
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{symbol_type2tc("py_prepass_alias"), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "PrePad",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-PrePad";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(unpadded);
+  ctx.add(tag);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  const type2tc &stored = ctx.find_symbol("tag-PrePad")->get_type2();
+  REQUIRE(is_struct_type(stored));
+  const struct_type2t &st = to_struct_type(stored);
+  REQUIRE(st.members.size() == 3);
+  REQUIRE(st.members[0] == signedbv_type2tc(8));
+  REQUIRE(is_unsignedbv_type(st.members[1]));
+  REQUIRE(st.member_names[2] == "i");
+}
+
+TEST_CASE(
+  "python_adjust pre-pass skips a non-Python type symbol",
+  "[python-adjust]")
+{
+  // C/C++-header types may carry bitfields whose #bitfield flag the IREP2
+  // round-trip drops; the pre-pass must not re-pad them (RV-adj4 scoping).
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "CPad",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-CPad";
+  tag.mode = "C";
+  tag.is_type = true;
+  tag.set_type(unpadded);
+  ctx.add(tag);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  REQUIRE(ctx.find_symbol("tag-CPad")->get_type2() == unpadded);
+}
+
+TEST_CASE(
+  "python_adjust pre-pass output feeds the value walk's resolution",
+  "[python-adjust]")
+{
+  // End-to-end across the two phases: the tag starts unpadded in the table;
+  // the pre-pass pads it, and the value walk's resolve_source then follows a
+  // transient member source to the *padded* layout — the reason the type
+  // pre-pass must run first (clang_c_adjust's "so that symbolic-type
+  // resolution always receives fixed up types").
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc unpadded = struct_type2tc(
+    std::vector<type2tc>{signedbv_type2tc(8), get_int32_type()},
+    std::vector<irep_idt>{"c", "i"},
+    std::vector<irep_idt>{"c", "i"},
+    "Chain",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-Chain";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(unpadded);
+  ctx.add(tag);
+
+  const expr2tc source = symbol2tc(symbol_type2tc("tag-Chain"), "obj");
+  const expr2tc member = member2tc(get_int32_type(), source, "i");
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(member)});
+  add_code_symbol(ctx, "py_adjust_chain_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  const expr2tc &stored = ctx.find_symbol("py_adjust_chain_sym")->get_value2();
+  const expr2tc &stmt = to_code_block2t(stored).operands.at(0);
+  const expr2tc &resolved = to_code_expression2t(stmt).operand;
+  REQUIRE(is_member2t(resolved));
+  const type2tc &src_type = to_member2t(resolved).source_value->type;
+  REQUIRE(is_struct_type(src_type));
+  REQUIRE(to_struct_type(src_type).members.size() == 3);
+}
+
+TEST_CASE(
+  "python_adjust pre-pass leaves an empty (incomplete) tag unchanged",
+  "[python-adjust]")
+{
+  // A forward-declared class tag (python_class_builder::ensure_sym) is an
+  // incomplete struct with no components; the pre-pass must pass through
+  // without padding or crashing, and without writing the symbol back.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  const type2tc empty_struct = struct_type2tc(
+    std::vector<type2tc>{},
+    std::vector<irep_idt>{},
+    std::vector<irep_idt>{},
+    "Fwd",
+    false);
+  symbolt tag;
+  tag.id = tag.name = "tag-Fwd";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(empty_struct);
+  ctx.add(tag);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  REQUIRE(ctx.find_symbol("tag-Fwd")->get_type2() == empty_struct);
+}
+
+TEST_CASE(
   "python_adjust S1 adjust_expr completes a node's own type",
   "[python-adjust]")
 {

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -316,6 +316,10 @@ TEST_CASE(
   // adjust() walks code symbols, resolving transient member sources in the
   // body and writing the symbol back. The body wraps `obj.x` (obj : tag-Foo);
   // after adjust() the stored body's member source is the resolved struct.
+  // The pre-pass adjust_type's the concrete tag-Foo struct, driving
+  // add_padding's alignment arithmetic (config.ansi_c); set the data model so
+  // it does not divide by a zero alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Foo", "x");
 
@@ -777,6 +781,10 @@ TEST_CASE(
   // carries a resolved struct type is flagged when its operand count
   // disagrees with the component list (constant_struct2t's constructor
   // asserts only the type kind, so this would otherwise reach symex).
+  // The pre-pass adjust_type's the concrete tag-Mismatch struct, driving
+  // add_padding's alignment arithmetic (config.ansi_c); set the data model so
+  // it does not divide by a zero alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Mismatch", "x");
 


### PR DESCRIPTION
## What

Closes the S-gap the S1 outcome documented (`docs/irep2-migration.md`): the legacy `clang_c_adjust::adjust()` completes all `is_type` symbols **first**, "so that symbolic-type resolution always receives fixed up types" — `python_adjust` had no analogue. **Stacked on #5988 (S2), which is stacked on #5985 (S1)**; retarget as the stack merges.

`adjust()` now runs a type-symbol pre-pass before the value walk: for every `is_type` symbol with `mode == "Python"`, complete its IREP2 type via `adjust_type` (macro expansion + padding), writing back only on change.

### Why the mode scoping is load-bearing

C/C++-header types can carry bitfields whose `#bitfield` flag does not survive the IREP2 round-trip — re-padding those from the migrated view would write a corrupted layout back into the table. Every converter-emitted tag is `mode "Python"` (`create_symbol`, `converter_util.cpp`; `python_class_builder::ensure_sym`), so the scope covers exactly the tags this pass owns (RV-adj4).

### Safety analysis (review-verified)

- **Incomplete (forward-declared) tags**: migrate to a 0-member struct view; `add_padding` is a no-op there and the change-detection guard prevents any lossy write-back — the legacy `incomplete` flag survives in the untouched cache (unit-pinned).
- **`ns.follow` coherence**: both the IREP2 overload and the legacy view read through the updated caches — no stale-view desync (review-verified both directions).
- **Latent, recorded as scope limit (4)**: a *firing* write-back cannot carry legacy-only struct metadata — notably the `"bases"` sub-irep that `exception_typeid.cpp`/`base_type.cpp` read for Python exception-hierarchy catch matching. Inert today (the write-back never fires post-`clang_cpp_adjust`, fixture-validated); the B.5 flip must re-attach preserved sub-ireps or land the W3/V.2 IREP2-native carriage first. Recorded in `python_adjust.h` and the migration doc as a flip prerequisite.

## Gates

- 31/31 unit tests (83 assertions): completed-tag (macro member + padding), non-Python skip, incomplete-tag pass-through, and the two-phase chain test (pre-pass output consumed by `resolve_source` in the value walk).
- Flag-on pipeline: 0 exit-invariant errors, Bitwuzla + Z3, verdicts unchanged; 76/76 fixture + acceptance families.
- `scripts/check_python_tests.sh python_irep2_adjust` green; clang-format clean.
- Code-reviewer pass applied: the `"bases"` latent loss documented as scope limit (4) + doc framing corrected, copy idiom simplified, alignment-attribute round-trip caveat recorded, integration test added.