### PR TITLE
[python] Derive throw exception ids in python_adjust (flip blocker 1)

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -3966,6 +3966,39 @@ therefore S4 (width reconciliation — largely drained by the keystone W-tasks 1
 and blocker #1 (post-conversion, per the probe above); S5 still trails blocker #1.
 This shortens the critical path to the S6 flip by removing an S-step that read as
 open but is structurally satisfied.
+#### Blocker 1 outcome (2026-07-11) — throw exception ids derived in `python_adjust`; the flip probe now verifies simple programs end-to-end
+
+`adjust_expr` gains a `code_cpp_throw2t` arm: an **empty** `exception_list`
+on an operand-carrying throw is completed via the new
+`derive_exception_ids`, mirroring `convert_exception_id` across every shape
+the frontend emits: `[bare class, direct bases...]` for a class operand
+(both the by-name `symbol_type2t` tag and the S2-resolved `struct_type2t`,
+whose `name` is the bare tag), `"void_ptr"` for the untypeable-raise
+`any_type()` operand (review-caught: `raise pkg.Error(...)` falls back to a
+`pointer(empty)` operand — a conservative-empty policy here would re-create
+the very `front()` crash the arm prevents), a `_ptr` suffix through real
+pointers, and legacy's never-empty synthetic-id fallback. A legacy-filled
+list is untouched (`adjust_side_effect_throw` overwrites unconditionally
+and runs first, so the arm is inert today); a bare re-raise keeps its empty
+list, as legacy does. Second review catch (M2): the type-symbol pre-pass's
+own write-back would have dropped the legacy-only `"bases"` sub-irep before
+this derivation read it — the pre-pass now **re-attaches `"bases"` on the
+legacy view across its write-back**, discharging the `"bases"` half of
+scope limit (4) for the tags it rewrites (unit-pinned end-to-end: a padded
+tag still yields the full `[E, Exception]` chain).
+
+**Flip-probe re-run (same env-gated hop-skip method, reverted after):**
+the four census probes that previously died 4/4 SIGSEGV in
+`remove_exceptions` now verify **4/4 `VERIFICATION SUCCESSFUL` with
+`clang_cpp_adjust` skipped entirely** — the accumulated pass (B.1 source
+resolution + S1 type completion + S2 literals + type-symbol pre-pass +
+exception ids) is already a sufficient resolver for simple programs, and
+the `python_irep2_adjust_nested_attr` fixture case also passes hop-off.
+Harder exception tests still fail hop-off (`except_tuple_types` FAILED:
+catch-side hierarchy matching needs the `"bases"` carriage — blocker 2;
+`try_except_else` retains one exit-invariant survivor), which is the point:
+**blockers 2–5 are now empirically measurable**, and the hop-off run of the
+exception suite is the natural work-list generator for them.
 
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -48,7 +48,25 @@ bool python_adjust::adjust()
     type2tc t = original;
     adjust_type(t);
     if (t != original)
+    {
+      // Preserve the legacy-only "bases" sub-irep across the write-back:
+      // set_type(type2tc) invalidates the legacy cache and the lazy
+      // back-migration reconstructs only components/tag/packed, silently
+      // dropping the inheritance list that exception-hierarchy consumers
+      // (derive_exception_ids below, exception_typeid.cpp, base_type.cpp)
+      // read. Re-attach it on the legacy view so both views stay coherent.
+      // This discharges the "bases" half of scope limit (4) for the tags
+      // this pre-pass rewrites; the remaining legacy-only attributes
+      // (component access, #is_padding) stay cosmetic.
+      const irept bases = symbol->get_type().find("bases");
       symbol->set_type(t);
+      if (bases.is_not_nil())
+      {
+        typet patched = symbol->get_type();
+        patched.set("bases", bases);
+        symbol->set_type(std::move(patched));
+      }
+    }
   }
 
   bool error = false;
@@ -231,6 +249,94 @@ void python_adjust::adjust_expr(expr2tc &expr)
         expr = constant_struct2tc(resolved, ops);
     }
   }
+  else if (is_code_cpp_throw2t(expr))
+  {
+    // Flip blocker #1 (docs/irep2-migration.md, "Flip-probe census"): the
+    // exception-id chain is derived only by clang_cpp_adjust today
+    // (adjust_side_effect_throw); once that hop is gone, every
+    // operand-carrying THROW reaches remove_exceptions with an empty
+    // exception_list and crashes its unguarded front(). Complete an empty
+    // list here from the operand's class type. A list the legacy pass
+    // already filled is left untouched, so this arm is inert until the flip;
+    // a bare re-raise (nil operand) keeps its empty list, as legacy does.
+    // The operand was already recursed above, so under S2 its type may be
+    // the resolved struct rather than the by-name tag — both derive the same
+    // chain.
+    const code_cpp_throw2t &t = to_code_cpp_throw2t(expr);
+    if (t.exception_list.empty() && !is_nil_expr(t.operand))
+    {
+      const std::vector<irep_idt> ids = derive_exception_ids(t.operand->type);
+      if (!ids.empty())
+        expr = code_cpp_throw2tc(t.operand, ids, t.location);
+    }
+  }
+}
+
+std::vector<irep_idt>
+python_adjust::derive_exception_ids(const type2tc &type) const
+{
+  std::vector<irep_idt> ids;
+  derive_exception_ids_rec(type, "", ids);
+  return ids;
+}
+
+void python_adjust::derive_exception_ids_rec(
+  const type2tc &type,
+  const std::string &suffix,
+  std::vector<irep_idt> &ids) const
+{
+  // Mirror clang_cpp_adjust::convert_exception_id for the shapes the Python
+  // frontend emits (remove_exceptions' register_chain builds the transitive
+  // hierarchy from these one-level chains). A pointer operand is real: the
+  // untypeable-raise fallback types the operand any_type() = pointer(empty)
+  // (python_exception_handler get_raise_statement), which legacy derives as
+  // "void_ptr". The trailing never-empty fallback mirrors legacy's — callers
+  // (remove_exceptions) dereference front(), so an unknown shape must yield
+  // a synthetic id that simply never matches a real throw, not an empty
+  // list. (Legacy also appends a `#cpp_type` id when present; that attribute
+  // does not survive migration and Python types never carry it.)
+  if (is_pointer_type(type))
+  {
+    const type2tc &sub = to_pointer_type(type).subtype;
+    if (is_empty_type(sub))
+      ids.emplace_back("void_ptr" + suffix);
+    else
+      derive_exception_ids_rec(sub, "_ptr" + suffix, ids);
+    return;
+  }
+
+  std::string bare;
+  if (is_symbol_type(type))
+  {
+    const std::string id = to_symbol_type(type).symbol_name.as_string();
+    bare = has_prefix(id, "tag-") ? id.substr(4) : id;
+  }
+  else if (is_struct_type(type))
+    // migrate_type stores the legacy `tag` attribute — the bare class name.
+    bare = to_struct_type(type).name.as_string();
+
+  if (!bare.empty())
+  {
+    ids.emplace_back(bare + suffix);
+    // Direct bases, declaration order, one level — exactly the legacy
+    // derivation. The "bases" list lives only on the legacy view of the tag
+    // symbol (the W3 attribute-carriage gap); the type-symbol pre-pass
+    // preserves it across its write-back precisely so this read stays valid.
+    const symbolt *tag = context.find_symbol("tag-" + bare);
+    if (tag != nullptr && tag->is_type && tag->get_type().is_struct())
+    {
+      const irept &bases = tag->get_type().find("bases");
+      for (const auto &b : bases.get_sub())
+      {
+        const std::string bid = b.id().as_string();
+        ids.emplace_back(
+          (has_prefix(bid, "tag-") ? bid.substr(4) : bid) + suffix);
+      }
+    }
+  }
+
+  if (ids.empty())
+    ids.emplace_back(get_type_id(type) + suffix);
 }
 
 void python_adjust::adjust_type(type2tc &type)

--- a/src/python-frontend/python_adjust.h
+++ b/src/python-frontend/python_adjust.h
@@ -93,6 +93,25 @@ protected:
   /// since a member/index cannot be constructed over a raw pointer.
   bool resolve_source(expr2tc &source);
 
+  /// Derive a cpp-throw's exception-id chain from its operand's type,
+  /// mirroring `clang_cpp_adjust::convert_exception_id`: the bare class name
+  /// followed by its direct bases for a class operand (both the by-name
+  /// `symbol_type2t` tag and the S2-resolved `struct_type2t` shape),
+  /// "void_ptr" for the untypeable-raise `any_type()` operand, a `_ptr`
+  /// suffix through real pointers, and — like legacy — a synthetic
+  /// type-id fallback so the result is never empty (remove_exceptions
+  /// dereferences front()). Used by adjust_expr to complete an empty
+  /// `code_cpp_throw2t::exception_list` — flip blocker #1
+  /// (docs/irep2-migration.md, "Flip-probe census").
+  std::vector<irep_idt> derive_exception_ids(const type2tc &type) const;
+
+  /// Recursive worker for derive_exception_ids, threading the legacy `_ptr`
+  /// suffix accumulation.
+  void derive_exception_ids_rec(
+    const type2tc &type,
+    const std::string &suffix,
+    std::vector<irep_idt> &ids) const;
+
   /// Post-adjust strong-invariant probe (V.1k B.4): append to `out` one
   /// human-readable entry per unresolved node reachable from `expr` — a
   /// `member2t`/`index2t` source or `constant_struct2t` type still carrying a

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -6,6 +6,7 @@
 #include <util/symbol.h>
 #include <util/c_types.h>
 #include <util/config.h>
+#include <util/migrate.h>
 #include <irep2/irep2_utils.h>
 #include <string>
 #include <vector>
@@ -964,6 +965,251 @@ TEST_CASE(
   REQUIRE_FALSE(adjuster.adjust());
 
   REQUIRE(ctx.find_symbol("tag-Fwd")->get_type2() == empty_struct);
+}
+
+namespace
+{
+// Register `tag-<name>` whose LEGACY type is a struct carrying a "bases"
+// sub-irep listing `tag-<base>` — the layout python_class_builder::get_bases
+// produces and clang_cpp_adjust::convert_exception_id consumes.
+void add_class_with_base(
+  contextt &ctx,
+  const std::string &name,
+  const std::string &base)
+{
+  struct_typet legacy;
+  legacy.tag(name);
+  exprt &bases = static_cast<exprt &>(legacy.add("bases"));
+  bases.get_sub().emplace_back(irept("tag-" + base));
+
+  symbolt tag;
+  tag.id = tag.name = "tag-" + name;
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(legacy);
+  ctx.add(tag);
+}
+} // namespace
+
+TEST_CASE(
+  "python_adjust completes an empty throw exception list from the class",
+  "[python-adjust]")
+{
+  // Flip blocker #1: a cpp-throw whose exception_list the legacy pass never
+  // derived must get [derived, direct bases...] from its operand's tag —
+  // the same one-level chain convert_exception_id produces.
+  contextt ctx;
+  add_class_with_base(ctx, "E", "Exception");
+
+  const expr2tc operand = symbol2tc(symbol_type2tc("tag-E"), "e");
+  expr2tc thr =
+    code_cpp_throw2tc(operand, std::vector<irep_idt>{}, locationt());
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(thr);
+
+  REQUIRE(is_code_cpp_throw2t(thr));
+  const code_cpp_throw2t &t = to_code_cpp_throw2t(thr);
+  REQUIRE(t.exception_list.size() == 2);
+  REQUIRE(t.exception_list[0] == "E");
+  REQUIRE(t.exception_list[1] == "Exception");
+}
+
+TEST_CASE(
+  "python_adjust leaves a legacy-filled throw exception list untouched",
+  "[python-adjust]")
+{
+  // Inertness on today's pipeline: clang_cpp_adjust already derived the
+  // list; the arm must not re-derive or reorder it.
+  contextt ctx;
+  add_class_with_base(ctx, "E", "Exception");
+
+  const expr2tc operand = symbol2tc(symbol_type2tc("tag-E"), "e");
+  const std::vector<irep_idt> legacy_ids{"E", "Exception"};
+  expr2tc thr = code_cpp_throw2tc(operand, legacy_ids, locationt());
+  const expr2tc original = thr;
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(thr);
+
+  REQUIRE(thr == original);
+}
+
+TEST_CASE(
+  "python_adjust derives void_ptr for an untypeable raise operand",
+  "[python-adjust]")
+{
+  // The attribute-raise fallback (`raise pkg.Error(...)`) types the operand
+  // any_type() = pointer(empty); legacy convert_exception_id derives
+  // "void_ptr" for it. An empty list here would re-create the
+  // remove_exceptions front() crash the arm exists to prevent.
+  contextt ctx;
+  const expr2tc operand =
+    symbol2tc(pointer_type2tc(get_empty_type()), "untyped_exc");
+  expr2tc thr =
+    code_cpp_throw2tc(operand, std::vector<irep_idt>{}, locationt());
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(thr);
+
+  const code_cpp_throw2t &t = to_code_cpp_throw2t(thr);
+  REQUIRE(t.exception_list.size() == 1);
+  REQUIRE(t.exception_list[0] == "void_ptr");
+}
+
+TEST_CASE(
+  "python_adjust gives a non-class throw operand the never-empty fallback",
+  "[python-adjust]")
+{
+  // A shape the converter never emits (int operand) still must not leave an
+  // empty list — remove_exceptions dereferences front(). The synthetic
+  // type-id never matches a real throw, mirroring legacy's fallback.
+  contextt ctx;
+  expr2tc thr = code_cpp_throw2tc(
+    gen_zero(get_int32_type()), std::vector<irep_idt>{}, locationt());
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(thr);
+
+  const code_cpp_throw2t &t = to_code_cpp_throw2t(thr);
+  REQUIRE(t.exception_list.size() == 1);
+  REQUIRE(t.exception_list[0] == "signedbv");
+}
+
+TEST_CASE("python_adjust leaves a bare re-raise untouched", "[python-adjust]")
+{
+  // A bare `raise` lowers to a nil-operand throw with an empty list; legacy
+  // skips it (adjust_side_effect_throw returns early) and so must this arm.
+  contextt ctx;
+  expr2tc thr =
+    code_cpp_throw2tc(expr2tc(), std::vector<irep_idt>{}, locationt());
+  const expr2tc original = thr;
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(thr);
+
+  REQUIRE(thr == original);
+}
+
+TEST_CASE(
+  "python_adjust derives all direct bases of a multi-base class",
+  "[python-adjust]")
+{
+  // register_chain treats the tail as flat direct bases of front(); the
+  // derivation must emit every direct base in declaration order.
+  contextt ctx;
+  struct_typet legacy;
+  legacy.tag("M");
+  exprt &bases = static_cast<exprt &>(legacy.add("bases"));
+  bases.get_sub().emplace_back(irept("tag-A"));
+  bases.get_sub().emplace_back(irept("tag-B"));
+  symbolt tag;
+  tag.id = tag.name = "tag-M";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(legacy);
+  ctx.add(tag);
+
+  const expr2tc operand = symbol2tc(symbol_type2tc("tag-M"), "m");
+  expr2tc thr =
+    code_cpp_throw2tc(operand, std::vector<irep_idt>{}, locationt());
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(thr);
+
+  const code_cpp_throw2t &t = to_code_cpp_throw2t(thr);
+  REQUIRE(t.exception_list.size() == 3);
+  REQUIRE(t.exception_list[0] == "M");
+  REQUIRE(t.exception_list[1] == "A");
+  REQUIRE(t.exception_list[2] == "B");
+}
+
+TEST_CASE(
+  "python_adjust pre-pass write-back preserves bases for the throw chain",
+  "[python-adjust]")
+{
+  // The M2 hazard: the type-symbol pre-pass rewrites a tag (padding fires),
+  // and set_type(type2tc) would drop the legacy-only "bases" sub-irep the
+  // throw derivation reads. The write-back must re-attach it, so a body
+  // throw still derives the full chain after the tag was rewritten.
+  config.ansi_c.set_data_model(configt::LP64);
+
+  contextt ctx;
+  struct_typet legacy;
+  legacy.tag("E");
+  {
+    struct_union_typet::componentt c;
+    c.id("component");
+    c.type() = migrate_type_back(signedbv_type2tc(8));
+    c.set_name("c");
+    c.pretty_name("c");
+    legacy.components().push_back(c);
+    struct_union_typet::componentt i;
+    i.id("component");
+    i.type() = migrate_type_back(get_int32_type());
+    i.set_name("i");
+    i.pretty_name("i");
+    legacy.components().push_back(i);
+  }
+  exprt &bases = static_cast<exprt &>(legacy.add("bases"));
+  bases.get_sub().emplace_back(irept("tag-Exception"));
+  symbolt tag;
+  tag.id = tag.name = "tag-E";
+  tag.mode = "Python";
+  tag.is_type = true;
+  tag.set_type(legacy);
+  ctx.add(tag);
+
+  const expr2tc operand = symbol2tc(symbol_type2tc("tag-E"), "e");
+  const expr2tc thr =
+    code_cpp_throw2tc(operand, std::vector<irep_idt>{}, locationt());
+  const expr2tc body =
+    code_block2tc(std::vector<expr2tc>{code_expression2tc(thr)});
+  add_code_symbol(ctx, "py_adjust_throw_prepass_sym", body);
+
+  python_adjust adjuster(ctx);
+  REQUIRE_FALSE(adjuster.adjust());
+
+  // The pre-pass padded (rewrote) the tag...
+  const symbolt *out_tag = ctx.find_symbol("tag-E");
+  REQUIRE(is_struct_type(out_tag->get_type2()));
+  REQUIRE(to_struct_type(out_tag->get_type2()).members.size() == 3);
+  // ...its legacy view kept the bases...
+  REQUIRE(out_tag->get_type().find("bases").is_not_nil());
+  // ...and the body throw derived the full chain through it.
+  const expr2tc &stored =
+    ctx.find_symbol("py_adjust_throw_prepass_sym")->get_value2();
+  const expr2tc &stmt = to_code_block2t(stored).operands.at(0);
+  const expr2tc &out_thr = to_code_expression2t(stmt).operand;
+  const code_cpp_throw2t &t = to_code_cpp_throw2t(out_thr);
+  REQUIRE(t.exception_list.size() == 2);
+  REQUIRE(t.exception_list[0] == "E");
+  REQUIRE(t.exception_list[1] == "Exception");
+}
+
+TEST_CASE(
+  "python_adjust derives throw ids through an S2-resolved literal operand",
+  "[python-adjust]")
+{
+  // The OM raise shape end-to-end: the throw operand is a by-name struct
+  // literal; operand recursion (S2) retypes it to the resolved struct first,
+  // and the throw arm must derive the chain from that resolved shape.
+  contextt ctx;
+  add_class_with_base(ctx, "E", "Exception");
+
+  const expr2tc lit =
+    constant_struct2tc(symbol_type2tc("tag-E"), std::vector<expr2tc>{});
+  expr2tc thr = code_cpp_throw2tc(lit, std::vector<irep_idt>{}, locationt());
+
+  python_adjust adjuster(ctx);
+  adjuster.adjust_expr(thr);
+
+  const code_cpp_throw2t &t = to_code_cpp_throw2t(thr);
+  REQUIRE(is_constant_struct2t(t.operand));
+  REQUIRE(is_struct_type(t.operand->type));
+  REQUIRE(t.exception_list.size() == 2);
+  REQUIRE(t.exception_list[0] == "E");
+  REQUIRE(t.exception_list[1] == "Exception");
 }
 
 TEST_CASE(


### PR DESCRIPTION
Flip blocker #1 (stacked on #5990). The exception-id chain on throws is derived only by `clang_cpp_adjust`; skip that hop and every operand-carrying THROW reaches `remove_exceptions` with an empty `exception_list`, crashing its unguarded `front()`. `adjust_expr` gains a `code_cpp_throw2t` arm that fills an empty list via `derive_exception_ids`, mirroring `convert_exception_id` across every emitted shape (class bases, `void_ptr` for untypeable raises, pointer suffixing). Inert on the default pipeline, since `adjust_side_effect_throw` fills the list first.
