### PR TITLE
[python] Derive catch exception ids at construction (flip blocker 2)

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4000,6 +4000,34 @@ catch-side hierarchy matching needs the `"bases"` carriage — blocker 2;
 **blockers 2–5 are now empirically measurable**, and the hop-off run of the
 exception suite is the natural work-list generator for them.
 
+#### Blocker 2 outcome (2026-07-11) — catch ids derived at construction; the exception suite holds correct verdicts hop-off
+
+The blocker-2 diagnosis sharpened on implementation: the catch side's
+failure mode was not the `"bases"` hierarchy after all, but the same
+missing-id disease as blocker 1 in a different organ. The per-handler
+`"exception_id"` attribute is set only by `clang_cpp_adjust::adjust_catch`
+(from the block's type; `clang_cpp_adjust_code.cpp:206-225`), and the
+source-form cpp-catch **migration reads that attribute**
+(`migrate.cpp:2488-2526`) — skip the hop and every handler migrates with an
+empty id that matches no throw, so catches silently never fire (the
+`except_tuple_types` wrong verdict). Fix: `emit_catch_block` now derives
+the id at construction — bare class name for a class tag, `"ellipsis"` for
+the bare-except catch-all, the type id otherwise — exactly what
+`adjust_catch`'s `convert_exception_id` `front()` yields for each shape.
+The legacy pass still runs today and overwrites with the identical value:
+**GOTO-byte A/B parity verified** (`--goto-functions-only`, stash method,
+byte-identical), 43/43 `regression/python` exception tests green.
+
+**Hop-off validation:** `except_tuple_types{,_fail}`, `try_except_else`,
+`list_index_valueerror{,_fail}` all give **correct verdicts** (positives
+SUCCESSFUL, negatives FAILED) with `clang_cpp_adjust` skipped — catch
+matching now works end-to-end without the legacy hop, throw + catch both.
+A broader hop-off sample (`dict40`, `raise_noarg_custom_exception`,
+`contains_dunder` pass) narrows the remaining gap to programs that produce
+**no verdict** hop-off: `try_finally` and `lambda_default_arg` (crash/hang
+— the S3 member/index-at-scale and S5 argument-cast families). Those are
+the blocker-3+ work-list.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -465,6 +465,33 @@ void python_exception_handler::emit_catch_block(
     catch_block.type().set("ellipsis", true);
   }
 
+  // Flip blocker #2 (docs/irep2-migration.md, "Flip-probe census"): derive
+  // the per-handler exception id at construction, exactly as
+  // clang_cpp_adjust::adjust_catch does from this same block type. That pass
+  // still runs today and overwrites the attribute with the identical value
+  // (its convert_exception_id front() is the bare class name for a class
+  // tag, "ellipsis" for the catch-all, and the type id for the degenerate
+  // non-throwable shapes — modulo legacy's `_ptr` recursion on array/pointer
+  // catch types, whose synthetic ids never name a throwable Python class
+  // either way), so the pipeline stays byte-identical — but migration reads
+  // this attribute (migrate.cpp, source-form cpp-catch), and once the flip
+  // removes the legacy hop, an unset attribute migrates as an empty id that
+  // matches no throw.
+  {
+    const typet &ct = catch_block.type();
+    std::string exc_id;
+    if (ct.id() == "symbol")
+    {
+      const std::string tid = ct.identifier().as_string();
+      exc_id = tid.rfind("tag-", 0) == 0 ? tid.substr(4) : tid;
+    }
+    else if (ct.ellipsis())
+      exc_id = "ellipsis";
+    else
+      exc_id = ct.id().as_string();
+    catch_block.set("exception_id", exc_id);
+  }
+
   block.move_to_operands(catch_block);
 }
 


### PR DESCRIPTION
Flip blocker #2 (stacked on #5992), symmetric to the throw side. The per-handler `exception_id` on catch blocks is set only by `clang_cpp_adjust::adjust_catch`; skip that hop and every handler migrates with an empty id that matches no throw, so catches silently never fire. `emit_catch_block` now derives the id at construction (class name, `"ellipsis"` for bare `except:`, or the type id), matching the legacy value. Inert on the default pipeline; legacy still overwrites with the identical id.
