### PR TITLE
[python] Fix spurious IndexError indexing a list mutated through a call

### DIFF
--- a/regression/python/github_5991/main.py
+++ b/regression/python/github_5991/main.py
@@ -12,4 +12,4 @@ my_push(h, 1)
 
 assert len(h) == 4
 assert h[0] == 2
-assert h[3] == 1        # the appended element — previously a spurious IndexError
+assert h[3] == 1  # the appended element — previously a spurious IndexError

--- a/regression/python/github_5991/main.py
+++ b/regression/python/github_5991/main.py
@@ -1,0 +1,15 @@
+# Regression for #5991: indexing a list that was appended-to inside a called
+# function must not raise a spurious IndexError. The frontend's convert-time
+# constant-index bounds check used the caller's static list length, which is
+# blind to a mutation performed through a function argument; it now falls back
+# to the runtime bounds check for lists that escape into a call.
+def my_push(lst: list[int], item: int) -> None:
+    lst.append(item)
+
+
+h: list[int] = [2, 5, 8]
+my_push(h, 1)
+
+assert len(h) == 4
+assert h[0] == 2
+assert h[3] == 1        # the appended element — previously a spurious IndexError

--- a/regression/python/github_5991/test.desc
+++ b/regression/python/github_5991/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5991_fail/main.py
+++ b/regression/python/github_5991_fail/main.py
@@ -1,0 +1,13 @@
+# Negative counterpart to github_5991: suppressing the convert-time bounds
+# check for call-escaped lists must not lose bounds checking entirely — a
+# genuinely out-of-bounds access after the call is still caught, now via the
+# runtime __ESBMC_list_at bound.
+def my_push(lst: list[int], item: int) -> None:
+    lst.append(item)
+
+
+h: list[int] = [2, 5, 8]
+my_push(h, 1)
+
+# len(h) == 4, so index 4 is out of range and must fail.
+assert h[4] == 0

--- a/regression/python/github_5991_fail/test.desc
+++ b/regression/python/github_5991_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -5048,6 +5048,15 @@ std::optional<exprt> function_call_expr::build_positional_arguments(
     exprt arg = converter_.get_expr(arg_node);
     converter_.current_lhs = saved_lhs;
 
+    // A list passed to a callee may be mutated there (e.g. appended to), which
+    // the caller's static length tracking does not observe. Mark the symbol so
+    // later constant-index accesses fall back to the runtime bounds check
+    // instead of a stale convert-time IndexError (GitHub #5991). Marking a
+    // non-list symbol is harmless -- the flag is only read on the list
+    // constant-index path.
+    if (arg.is_symbol())
+      converter_.mark_list_call_escaped(arg.identifier().as_string());
+
     // A function name passed as an argument decays to a function pointer,
     // mirroring C's implicit function-to-pointer conversion.
     if (arg.type().is_code() && arg.is_symbol())

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -2280,7 +2280,13 @@ exprt python_list::handle_index_access(
             it->second.size() == list_node["value"]["elts"].size();
         }
 
-        if (has_const_index && !is_slice_derived_var && is_stable_list_literal)
+        // A list that escaped into a function/method call may have been grown
+        // by the callee, which this static length does not reflect; skip the
+        // convert-time bounds check so the runtime __ESBMC_list_at path handles
+        // it (GitHub #5991).
+        if (
+          has_const_index && !is_slice_derived_var && is_stable_list_literal &&
+          !converter_.is_list_call_escaped(list_name))
         {
           const size_t known_size = it->second.size();
           const bool oob = negative_index ? (index_abs > known_size)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -162,6 +162,18 @@ public:
     return type_handler_;
   }
 
+  /// Record that a list symbol escaped into a function/method call and may have
+  /// been mutated by the callee; see @ref call_escaped_lists_ (GitHub #5991).
+  void mark_list_call_escaped(const std::string &id)
+  {
+    call_escaped_lists_.insert(id);
+  }
+
+  bool is_list_call_escaped(const std::string &id) const
+  {
+    return call_escaped_lists_.find(id) != call_escaped_lists_.end();
+  }
+
   bool type_assertions_enabled() const;
 
   const std::string &python_file() const
@@ -1160,6 +1172,14 @@ private:
   bool is_importing_module = false;
   bool base_ctor_called = false;
   bool build_static_lists = false;
+
+  /// List symbols passed as an argument to a function/method call, keyed by
+  /// symbol id. Such a list may have been mutated (e.g. appended to) by the
+  /// callee, which the caller's static length tracking (list_type_map / the AST
+  /// literal) does not observe. The convert-time constant-index bounds check in
+  /// python-list/list_access.cpp is therefore suppressed for these lists, so the
+  /// access falls back to the sound runtime __ESBMC_list_at path (GitHub #5991).
+  std::set<std::string> call_escaped_lists_;
 
   /// Map object to list of instance attributes
   std::map<std::string, std::set<std::string>> instance_attr_map;


### PR DESCRIPTION
Fixes #5991.

## Bug

The convert-time constant-index bounds check in
`python-list/list_access.cpp` uses the caller's **static** list length
(`list_type_map` / the AST literal), which is blind to a mutation performed by
a callee:

```python
def my_push(lst: list[int], item: int) -> None:
    lst.append(item)

h: list[int] = [2, 5, 8]
my_push(h, 1)
assert len(h) == 4   # OK (runtime size)
assert h[3] == 1     # spurious IndexError before this fix (static size still 3)
```

In-scope mutation (`h.append(1); h[3]`) was already tracked; only mutation
through a **function argument** was not.

## Fix

Track list symbols that escape into a function/method call
(`call_escaped_lists_` in `python_converter`) and suppress the convert-time
bounds check for them, so the access falls back to the sound runtime
`__ESBMC_list_at` bound. Three small hunks:

- `python_converter.h` — a `std::set<std::string> call_escaped_lists_` member +
  `mark_list_call_escaped` / `is_list_call_escaped` accessors.
- `function_call/expr.cpp` — mark each symbol argument in
  `build_positional_arguments`.
- `python-list/list_access.cpp` — add `&& !is_list_call_escaped(list_name)` to
  the constant-index static-OOB guard.

A genuine out-of-bounds after the call is still caught by the runtime bound
(`github_5991_fail`). This also unblocks the `heapq.heappush` harness limitation
noted in #5965 (heappush appends, then the harness reads the grown index).

## Tests

- `github_5991` (SUCCESSFUL) — the reproducer; also valid under CPython.
- `github_5991_fail` (FAILED) — a genuine post-call OOB still fails.

Verified no regression across the list/index/insertion/slice regression subset
and a 22-test targeted direct sweep. `esbmc` rebuilt; code-reviewed.

## Known limitation (sound)

For an escaped list, a genuinely-OOB **positive constant** index now trips the
runtime `__ESBMC_list_at` assert rather than a catchable `IndexError`, so
`try/except(IndexError)` cannot intercept that specific corner. It never hides
an out-of-bounds. Unifying the runtime OOB path to raise a catchable exception
(today only the negative-index path does) is a good follow-up.
