### PR TITLE
[python] Reconcile int/float binop operands at construction (V.1k S4)

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4164,6 +4164,66 @@ work-list and doubles as the prereq-6 error-propagation fix); (3) the flip
 itself stays gated on RV2 (this census re-run clean, dual-solver) — flag
 default stays off until the gap is drained.
 
+#### F-A sub-classification (2026-07-11) — the crash mass resolves into six named root causes; one dominates
+
+The "bare-signal" appearance was an artifact of first-error pollution (the
+crashes print their diagnostic via `libc++abi: terminating ...`, and the
+census signature grep surfaced a preceding mypy line instead — no `.ips`
+symbolication needed). Re-sweeping all 246 crashing gap tests and grepping
+the exception text directly:
+
+| Sub-family | Count | Signature (examples) | Root cause |
+|---|---|---|---|
+| **F-A1: unresolved symbol type at an IREP2 consumer** | **116 (47%)** | `type2t::symbolic_type_excp` (`builtin2`, `cast`, `casting-chr-func`) | **the S3 gap proper** — a transient `symbol_type2t` survives into symex/solver code that needs a concrete type (get_width/follow); the single dominant flip work item |
+| F-A2: pointer-offset index | 24 | `Unexpected index type in compute_pointer_offset` (`concat3/11`, `github_3090_*`) | string concat/subscript emits an index shape only the legacy adjust normalises (F-C, larger than first counted) |
+| F-A3: Optional/tuple literal completion | 32 | the pass's own exit-invariant detail lines — `struct literal 'tag-Optional_signedbv...'` / `tag-tuple_*` (`dict17/25/28/31/32_fail`) | S2's arm cannot complete these literals (operand-count vs component mismatch, or unregistered synthetic tags); the invariant *catches* it but the discarded `adjust()` error return (prereq 6) lets execution continue into a crash — F-B and this are one family |
+| F-A4: any-type/void\* typecast | 15 | `Unexpected type in int/ptr typecast` (`github_2992_logic`, `github_3337_*`) | the unannotated-parameter void\* carrier meets a cast the legacy pass reshaped |
+| F-A5: encoding mismatches | 12+9+8+4 | `Bitwuzla error` / `Select on tuple` / call-arg `got struct, expected struct` / `shr` | S4/S5 residue in other node builders; the struct-vs-struct arg mismatch smells like padded-vs-unpadded layouts meeting at a call |
+| F-A6: harness artifact | 7 | `--python-irep2-adjust cannot be specified more than once` (`python_irep2_adjust_*`) | the census harness appended the flag to descs that already carry it — **false gap entries; true gap is 271, pass rate 92.4%** |
+
+**Consequence for ordering.** F-A1 (116) + F-A3/F-B (32+18 overlapping) are
+both S3-shaped: the resolution `python_adjust` performs today
+(member/index sources, aggregate literals) is not yet the *whole* body-wide
+completion — the next work item is drilling one F-A1 reproducer
+(`builtin2` is tiny) to find which node kind carries the surviving
+`symbol_type2t`, then extending the pass arm-by-arm exactly as S1–S4 did.
+Honouring `adjust()`'s error return (prereq 6) should land with the F-A3
+fix so detected inconsistencies degrade to a clean frontend error instead
+of a symex crash.
+
+#### F-A1 drill, round 1 (2026-07-11) — negative results that reshape the fix
+
+Drilling `builtin2` (`chr`/`ord` round-trip) hop-off with throw-site
+instrumentation produced three load-bearing negative results:
+
+1. **The throw is `empty_type2t::get_width`, not `symbol_type2t`'s** — the
+   exception class is shared, and the F-A1 family name ("unresolved symbol
+   type") was wrong in the specific: the surviving type is *empty*, not
+   by-name. All four `get_width` throw sites raise the same
+   `symbolic_type_excp`.
+2. **Bodies are clean at adjust time.** An instrumented walk over every
+   node the pass visits found no empty-typed *expression* (only code
+   statements, which are legitimately typeless). The empty-typed expression
+   that reaches `get_width` is therefore **introduced downstream of the
+   pass** — during goto-convert or symex — so no `python_adjust` arm can
+   fix F-A1 directly, and a speculative empty-symbol re-type arm written
+   during the drill was discarded unproven (C-Live discipline).
+3. **The observable GOTO delta for `builtin2` is narrow**: hop-on carries
+   legacy `adjust_expr_rel`'s integer promotions in the return expression
+   (`(signed int)(back_to_char[0]) == 65`); hop-off compares the raw
+   `char`-typed accesses. Both shapes are IREP2-legal (same-type operands),
+   so the promotions themselves are unlikely to be the crash cause — but
+   they are the only body difference, so the crash path runs through how
+   symex/goto-convert consume the unpromoted form (suspect: the
+   `char[0]`-typed string variable's zero-size array meeting the return
+   binding of `__python_chr`'s `char*`).
+
+**Next probe (round 2):** instrument the *consumer* — catch
+`symbolic_type_excp` at its symex/goto-convert call frames (or log the
+expression being widthed) to name the constructing site, rather than
+walking the pass's view again. The fix will live where that node is built,
+not in `python_adjust`.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4086,6 +4086,48 @@ S4 lives converter-side in `build_binary_expression`; the lambda body is
 the first concrete reproducer for it. That is the next work item, with the
 flag-off GOTO-byte A/B gate the census prescribed.
 
+#### S4 outcome (2026-07-11) — int/float reconciliation landed converter-side; the diverse hop-off sweep is 10/10 green
+
+The gap was narrower than the census framed it: `build_binary_expression`
+already normalises bv/bv width mixes (both the non-relational max-width
+rule and the relational common-width rule) — what it never reconciled was
+the **int/float mix and the float/float width mix**, exactly the casts
+`adjust_expr_binary_arithmetic` inserts post-hoc today. A 30-line block
+after the bitwise int-coercion completes them at construction: the integer
+side converts to the float type, the narrower float widens to the wider (C
+usual arithmetic conversions; CPython agrees for the shapes Python emits).
+The #5581 sub-`int` hazard does not arise — the block deliberately avoids
+`c_implicit_typecast_arithmetic` and its promotion floor, casting directly
+to the float operand's type.
+
+**Gates:** GOTO-byte A/B **byte-identical** vs base on both an
+`int * float` program and the `lambda_default_arg` test (the legacy pass
+re-derives the same casts and becomes a no-op — the census's idempotence
+prediction confirmed); 203/203 div/mod/pow/mult/compare/int8/dtype +
+326/326 math/gamma/round/float/lambda + 76/76 fixture.
+
+**Review outcomes folded in:** `promote_ieee_operands` became provably
+dead under the new block (the reconciliation runs on the same mutated
+operand references before any ieee id is picked) and was **removed** —
+the A/B dump stayed byte-identical to the original base with the removal
+in, which is the empirical C-Dead discharge; `try_resolve_constant_double`
+now peels typecasts over constants so `7 // 2.0`-style folds survive the
+new casts (the F2 model-size regression); the float32-Div parity question
+(F1) is **moot today** — `np.float32` scalars cannot reach the general
+binop path (unsupported constructor; numpy array ops promote in
+`numpy_call_expr`'s own rank table), recorded here in case that changes;
+an equal-width different-format float pair (a future bfloat16) would fall
+through unreconciled — commented at the site (F3).
+
+**Hop-off:** `lambda_default_arg` — the S4 reproducer — now
+**`VERIFICATION SUCCESSFUL` under Bitwuzla and Z3** with
+`clang_cpp_adjust` skipped, and a 10-test diverse sweep (exceptions,
+finally, lambdas, dicts, dunders, strings, f-strings, list ops) is **10/10
+SUCCESSFUL**. Every named flip blocker with a known reproducer is now
+discharged. **Next: the S6 flip-readiness census** — run the *full*
+`regression/python` suite hop-off (the RV2-shaped gate) to enumerate
+whatever long tail remains before the flip itself can be attempted.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4128,6 +4128,42 @@ discharged. **Next: the S6 flip-readiness census** — run the *full*
 `regression/python` suite hop-off (the RV2-shaped gate) to enumerate
 whatever long tail remains before the flip itself can be attempted.
 
+#### S6 flip-readiness census (2026-07-11) — 92.2% of the runnable suite passes hop-off; the 278-test gap classifies into five families
+
+**Method.** All 4,261 `regression/python` test dirs, hop-off (env-gated
+`clang_cpp_adjust` skip + `--python-irep2-adjust`, Bitwuzla, 20 s cap,
+8-way parallel), each CORE test's verdict compared against its `test.desc`
+expectation; then a **hop-on baseline over every non-OK test with the same
+harness/solver/cap** to separate flip-caused failures from pre-existing or
+environmental ones (local build is Bitwuzla-only; some descs pin other
+solvers or `--ir`). KNOWNBUG/FUTURE and no-verdict-expectation descs
+skipped (365).
+
+**Topline: 3,275 of 3,553 runnable CORE tests (92.2%) pass with
+`clang_cpp_adjust` skipped entirely.** 341 of the 619 hop-off failures
+also fail hop-on under the same harness (pre-existing/environmental —
+excluded). The genuine flip gap is **278 tests**, classifying by failure
+signature into:
+
+| Family | ~Count | Signature / examples | Reading |
+|---|---|---|---|
+| **F-A: crashes, unclassified** | ~160 | bare `signal N`, first-error lines are mypy noise | needs crash-report sub-classification (the macOS `.ips` + `atos` recipe); expect them to distribute over F-B–F-E's root causes |
+| **F-B: exit-invariant survivors** | 18 | `python_adjust: symbol 'python_user_main' retains N unresolved ... nodes` — `dict_bool_key`, `dict17/25/28/31`, ... | **S3's real work-list at last**: dict-heavy bodies carry member/index sources `resolve_source` cannot follow; also shows `adjust()`'s error return being ignored (flip prereq 6) lets a detected inconsistency proceed to a crash |
+| **F-C: string/array index lowering** | 12 | `Unexpected index type in computed goto`-style abort — `concat3/11`, `github_3090_2` | string concat/subscript path expects an adjusted index shape |
+| **F-D: bytes/tuple select** | 7+ | `Select operation applied to tuple` — `bytes`, `int_from_bytes_*` | bytes lowered as tuple reaches the solver unadjusted |
+| **F-E: complex/cmath** | ~30 | 23 conservative WRONG verdicts (expected SUCCESSFUL, got FAILED: `cmath_polar_rect_*`, `complex_cmath_log_edges`) + 7 timeouts (`complex_pow_*`) | the complex OM (a struct type) needs a completion the pass doesn't do; wrongness is in the conservative direction (spurious counterexample), not unsound |
+
+**Reading for the flip decision.** The gap is concentrated and
+family-shaped, not diffuse: dicts (F-B), string indexing (F-C), bytes
+(F-D), complex (F-E), plus an unclassified crash mass (F-A) that likely
+folds into the same causes. No family is evidence against the staged
+approach — each is the same "one legacy completion, one arm" pattern that
+S1–S4 retired one by one. **Next steps in order:** (1) sub-classify F-A by
+symbolicated crash site; (2) F-B first among fixes (it is S3's concrete
+work-list and doubles as the prereq-6 error-propagation fix); (3) the flip
+itself stays gated on RV2 (this census re-run clean, dual-solver) — flag
+default stays off until the gap is drained.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -536,13 +536,6 @@ exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
   }
   return build_boolean_chain(logical_expr);
 }
-inline bool is_ieee_op(const exprt &expr)
-{
-  const std::string &id = expr.id().as_string();
-  return id == "ieee_add" || id == "ieee_mul" || id == "ieee_sub" ||
-         id == "ieee_div";
-}
-
 // Attach source location from symbol table if expr is a symbol
 static void attach_symbol_location(exprt &expr, contextt &symbol_table)
 {
@@ -1599,9 +1592,6 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     (rhs.type().is_signedbv() || rhs.type().is_unsignedbv()))
     return math_handler_.handle_int_modulo(lhs, rhs, bin_expr);
 
-  // Promote operands for IEEE operations
-  promote_ieee_operands(bin_expr, lhs, rhs);
-
   // Handle chained comparisons
   if (element.contains("comparators") && element["comparators"].size() > 1)
     return handle_chained_comparisons_logic(element, bin_expr);
@@ -2454,6 +2444,39 @@ exprt python_converter::build_binary_expression(
       return 1;
     return static_cast<const bv_typet &>(t).get_width();
   };
+
+  // S4 width reconciliation (docs/irep2-migration.md, "Call-rewrite
+  // outcome"): complete the int/float and float/float-width mixes the arms
+  // below do not cover — today clang_cpp_adjust's
+  // adjust_expr_binary_arithmetic inserts these casts post-hoc, and after
+  // the B.5 flip nothing would. Mirrors the C usual arithmetic conversions
+  // for the shapes Python emits (CPython semantics agree): the integer side
+  // converts to the float type, the narrower float widens to the wider.
+  // Bitwise operands were already coerced to int above, so no float reaches
+  // a bitwise op; bv/bv mixes keep the existing converter rules below. On
+  // the live pipeline the legacy pass re-derives the same common type and
+  // becomes a no-op on the pre-reconciled operands (A/B byte-parity gated).
+  {
+    const bool lhs_float = lhs.type().is_floatbv();
+    const bool rhs_float = rhs.type().is_floatbv();
+    if (lhs_float && is_bv_or_bool(rhs.type()))
+      rhs = typecast_exprt(rhs, lhs.type());
+    else if (rhs_float && is_bv_or_bool(lhs.type()))
+      lhs = typecast_exprt(lhs, rhs.type());
+    else if (lhs_float && rhs_float && lhs.type() != rhs.type())
+    {
+      // Distinct float types always differ in width today (the frontend
+      // emits IEEE float16/32/64 only); an equal-width different-format
+      // pair (e.g. a future bfloat16) would fall through unreconciled.
+      const unsigned lw = bit_width(lhs.type());
+      const unsigned rw = bit_width(rhs.type());
+      if (lw < rw)
+        lhs = typecast_exprt(lhs, rhs.type());
+      else if (rw < lw)
+        rhs = typecast_exprt(rhs, lhs.type());
+    }
+  }
+
   // Adjust types for non-relational operations
   if (!type_utils::is_relational_op(op))
   {
@@ -2535,18 +2558,3 @@ exprt python_converter::build_binary_expression(
   return bin_expr;
 }
 
-void python_converter::promote_ieee_operands(
-  exprt &bin_expr,
-  const exprt &lhs,
-  const exprt &rhs)
-{
-  if (!is_ieee_op(bin_expr))
-    return;
-
-  const typet &target_type = lhs.type().is_floatbv() ? lhs.type() : rhs.type();
-
-  if (!lhs.type().is_floatbv())
-    bin_expr.op0() = typecast_exprt(lhs, target_type);
-  if (!rhs.type().is_floatbv())
-    bin_expr.op1() = typecast_exprt(rhs, target_type);
-}

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1032,16 +1032,6 @@ private:
   exprt build_binary_expression(const std::string &op, exprt &lhs, exprt &rhs);
 
   /**
-   * @brief Promotes operands for IEEE floating-point operations.
-   *
-   * @param bin_expr The binary expression (operands may be modified).
-   * @param lhs The original left operand.
-   * @param rhs The original right operand.
-   */
-  void
-  promote_ieee_operands(exprt &bin_expr, const exprt &lhs, const exprt &rhs);
-
-  /**
    * @brief Infers function return type from return statements in the body.
    *
    * @param body The JSON AST node representing the function body statements.

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -386,6 +386,14 @@ python_math::try_resolve_constant_double(const exprt &operand) const
     return std::nullopt;
 
   exprt resolved = operand;
+  // Peel typecasts over constants (the S4 operand reconciliation in
+  // build_binary_expression wraps a constant int in a typecast-to-float when
+  // the other operand is float). The numeric value is the inner constant's;
+  // int->float and float->float casts are value-preserving here since the
+  // caller converts to double anyway.
+  while (resolved.id() == "typecast" && resolved.operands().size() == 1 &&
+         resolved.op0().is_constant())
+    resolved = resolved.op0();
   if (!resolved.is_constant())
     return std::nullopt;
 


### PR DESCRIPTION
Step S4 of the V.1k/B.5 milestone (stacked on #5996). `build_binary_expression` already reconciled bv/bv width mixes but never the int/float and float/float mixes — exactly the casts `adjust_expr_binary_arithmetic` inserts today and nothing would insert post-flip. Complete those conversions at construction (integer side to the float type, narrower float widened, per C usual arithmetic conversions) so operands are consistent before migration. Removes the now-dead `promote_ieee_operands`/`is_ieee_op`; GOTO output stays byte-identical to base.
