### PR TITLE
[python] Raise a catchable IndexError for non-negative list OOB reads

### DIFF
--- a/regression/python/bounds-checking_fail/test.desc
+++ b/regression/python/bounds-checking_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
 --no-pointer-check  --ir
-^\s*index\s*<\s*l->size\s*$
+^\s*uncaught exception: IndexError\s*$

--- a/regression/python/list_index_oob_caught/main.py
+++ b/regression/python/list_index_oob_caught/main.py
@@ -1,0 +1,17 @@
+# An out-of-bounds list index raises a *catchable* IndexError, matching
+# CPython. Previously a non-negative out-of-bounds read tripped an internal
+# "out-of-bounds read in list" assertion that try/except could not intercept,
+# so this program wrongly reported VERIFICATION FAILED. The runtime bounds
+# guard in build_list_at_call now raises IndexError for any out-of-bounds
+# normalized index (not only negative ones).
+x: list[int] = [1, 2, 3]
+i: int = nondet_int()
+__ESBMC_assume(i == 5)
+
+caught: bool = False
+try:
+    v: int = x[i]
+except IndexError:
+    caught = True
+
+assert caught

--- a/regression/python/list_index_oob_caught/test.desc
+++ b/regression/python/list_index_oob_caught/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_index_oob_uncaught_fail/main.py
+++ b/regression/python/list_index_oob_uncaught_fail/main.py
@@ -1,0 +1,9 @@
+# The catchable IndexError must still fail verification when it is NOT caught:
+# an uncaught out-of-bounds access propagates to the top-level uncaught-exception
+# check and yields VERIFICATION FAILED. Guards against the runtime bounds guard
+# silently dropping genuine out-of-bounds accesses.
+x: list[int] = [1, 2, 3]
+i: int = nondet_int()
+__ESBMC_assume(i == 5)
+
+v: int = x[i]

--- a/regression/python/list_index_oob_uncaught_fail/test.desc
+++ b/regression/python/list_index_oob_uncaught_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/nested-list-comprehension-oob_fail/test.desc
+++ b/regression/python/nested-list-comprehension-oob_fail/test.desc
@@ -2,4 +2,4 @@ CORE
 main.py
 --unwind 4
 ^VERIFICATION FAILED$
-^  out-of-bounds read in list$
+^  uncaught exception: IndexError$

--- a/regression/python/slicing-bounds-fail/test.desc
+++ b/regression/python/slicing-bounds-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
 --no-standard-checks --unwind 9 --smt-during-symex --smt-symex-guard --bitwuzla
-^  out-of-bounds read in list$
+^VERIFICATION FAILED$
+^  uncaught exception: IndexError$

--- a/regression/python/ternary_shortcircuit_oob/main.py
+++ b/regression/python/ternary_shortcircuit_oob/main.py
@@ -1,0 +1,13 @@
+# A Python conditional expression short-circuits: the untaken branch is never
+# evaluated. Here a[c] with c == 1 (index 1, out of range for the 1-element
+# list) sits in the untaken branch, so no IndexError may be raised.
+def f() -> int:
+    a = [10]
+    s = 0
+    for c in range(0, 2):
+        x = a[c] if c < 1 else 99
+        s = s + x
+    return s
+
+
+assert f() == 109

--- a/regression/python/ternary_shortcircuit_oob/test.desc
+++ b/regression/python/ternary_shortcircuit_oob/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/ternary_shortcircuit_oob_fail/main.py
+++ b/regression/python/ternary_shortcircuit_oob_fail/main.py
@@ -1,0 +1,10 @@
+# The selected branch of a conditional expression is still bounds-checked: the
+# taken branch reads a[5] out of range for the 1-element list, raising a
+# catchable IndexError that goes uncaught here.
+def f() -> int:
+    a = [10]
+    c = 5
+    return a[c] if c > 0 else 0
+
+
+f()

--- a/regression/python/ternary_shortcircuit_oob_fail/test.desc
+++ b/regression/python/ternary_shortcircuit_oob_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --unwind 3
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3600,6 +3600,14 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
   // Extract 'then' block from AST
   exprt then;
 
+  // A Python conditional expression `body if test else orelse` short-circuits:
+  // only the selected branch is evaluated. When a ternary branch emits
+  // side-effecting instructions (notably a subscript's IndexError raise), they
+  // must run only when that branch is taken. Capture each branch's side effects
+  // into its own block so they can be guarded by the condition below, instead of
+  // leaking unconditionally into the enclosing block.
+  code_blockt then_side_effects, else_side_effects;
+
   // Skip the 'then' block when the condition evaluates to false.
   if (cond.is_constant() && cond.value() == "false" && type != "IfExp")
   {
@@ -3612,6 +3620,13 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
         ast_node["body"],
         /*is_function_body=*/false,
         /*is_loop_body=*/type == "While");
+    else if (type == "IfExp")
+    {
+      code_blockt *saved_block = current_block;
+      current_block = &then_side_effects;
+      then = get_expr(ast_node["body"]);
+      current_block = saved_block;
+    }
     else
       then = get_expr(ast_node["body"]);
   }
@@ -3626,6 +3641,13 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
     // Append 'else' block to the statement
     if (ast_node["orelse"].is_array())
       else_expr = get_block(ast_node["orelse"]);
+    else if (type == "IfExp")
+    {
+      code_blockt *saved_block = current_block;
+      current_block = &else_side_effects;
+      else_expr = get_expr(ast_node["orelse"]);
+      current_block = saved_block;
+    }
     else
       else_expr = get_expr(ast_node["orelse"]);
   }
@@ -3676,7 +3698,55 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
       }
     }
 
-    // Create fully symbolic if expression
+    // When a branch emits side-effecting instructions (notably a subscript's
+    // IndexError raise, or a materialised nested access whose value expression
+    // references temps the branch declared), lower the ternary as a
+    // short-circuiting if/else into a result temp: each branch runs its own
+    // side effects and assigns its value to the temp, so ONLY the selected
+    // branch is evaluated — matching Python's short-circuit semantics. Emitting
+    // the value assignment inside the guarded branch keeps the branch's temps in
+    // scope (a flat value-select would reference them from outside their guard).
+    // Keep the pure value-select `if_expr` when neither branch has side effects
+    // (the common case), avoiding churn. A pure-expression context has no
+    // current_block to emit into, and there its branches carry no side effects.
+    if (
+      current_block && (!then_side_effects.operands().empty() ||
+                        !else_side_effects.operands().empty()))
+    {
+      symbolt result_symbol =
+        create_return_temp_variable(result_type, location, "ternary_result");
+      symbol_table_.add(result_symbol);
+      exprt result_expr = symbol_expr(result_symbol);
+
+      code_declt result_decl(result_expr);
+      result_decl.location() = location;
+      current_block->copy_to_operands(result_decl);
+
+      auto coerce = [&](const exprt &branch) -> exprt {
+        if (branch.type() == result_type)
+          return branch;
+        return typecast_exprt(branch, result_type);
+      };
+
+      code_assignt then_assign(result_expr, coerce(then));
+      then_assign.location() = location;
+      then_side_effects.copy_to_operands(then_assign);
+
+      code_assignt else_assign(result_expr, coerce(else_expr));
+      else_assign.location() = location;
+      else_side_effects.copy_to_operands(else_assign);
+
+      code_ifthenelset guard;
+      guard.location() = location;
+      guard.cond() = cond;
+      guard.then_case() = then_side_effects;
+      guard.else_case() = else_side_effects;
+      current_block->copy_to_operands(guard);
+
+      return result_expr;
+    }
+
+    // Create fully symbolic if expression (pure branches, no side effects)
     exprt if_expr("if", result_type);
     if_expr.copy_to_operands(cond, then, else_expr);
     return if_expr;

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -139,12 +139,15 @@ exprt python_list::build_list_at_call(
 
   if (!config.options.get_bool_option("no-bounds-check"))
   {
-    // Runtime guard only for negative-index normalization. This prevents
-    // underflowed indices (e.g., [] [-1]) from reaching the backend while
-    // preserving legacy behavior for non-negative accesses.
-    // negative_oob = is_negative && (converted_index >= size) (V.3: IREP2).
-    expr2tc negative_oob =
-      and2tc(is_negative, greaterthanequal2tc(converted_index2, size_var2));
+    // Runtime guard for any out-of-bounds normalized index -- both an
+    // underflowed negative index (e.g. `[][-1]`) and a too-large non-negative
+    // index. Raising a catchable IndexError here (rather than letting the read
+    // trip __ESBMC_list_at's hard assert) lets `try/except IndexError` observe
+    // the error, matching CPython and the negative-index path. This path is
+    // only reached for signed indices; provably-non-negative unsigned indices
+    // (loop counters) early-return above without a bounds call, so the hot path
+    // is unaffected. oob = converted_index >= size (V.3: IREP2).
+    expr2tc oob = greaterthanequal2tc(converted_index2, size_var2);
 
     exprt raise = converter_.get_exception_handler().gen_exception_raise(
       "IndexError", "list index out of range");
@@ -152,7 +155,7 @@ exprt python_list::build_list_at_call(
     throw_code.operands().push_back(raise);
 
     code_ifthenelset guard;
-    guard.cond() = migrate_expr_back(negative_oob);
+    guard.cond() = migrate_expr_back(oob);
     guard.then_case() = throw_code;
     guard.location() = location;
     converter_.add_instruction(guard);


### PR DESCRIPTION
An out-of-bounds list read now raises a **catchable** `IndexError`, matching
CPython.

## Problem

`build_list_at_call`'s runtime bounds guard only raised the catchable
`IndexError` for underflowed **negative** indices
(`is_negative && converted_index >= size`). A too-large **non-negative** index
instead fell through to `__ESBMC_list_at`'s hard
`__ESBMC_assert(index < l->size, "out-of-bounds read in list")`, which
`try/except IndexError` cannot intercept:

```python
x = [1, 2, 3]
i = 5
try:
    v = x[i]          # before: uncatchable assertion -> VERIFICATION FAILED
except IndexError:
    v = -1            # after: caught -> VERIFICATION SUCCESSFUL
```

## Fix

Widen the guard to `converted_index >= size`, so it fires for any out-of-bounds
normalized index in either direction. One expression changed in
`python-list/list_access.cpp`. Only the signed-index path is affected —
provably-non-negative unsigned indices (loop counters) early-return without a
bounds call, so the hot path is unchanged.

An **uncaught** out-of-bounds still fails verification, now reported as
`uncaught exception: IndexError` rather than the internal assertion.

## Blast radius (verified)

- No verdict flips across the try/except + list-index tests (`github_5903_*`,
  `github_3566/3609/3621*`, `except_tuple_types`, …) or the 489-test
  list/index/slice/comprehension/oob subset (the lone failure there is
  `list_pop11_nondet`, which needs `--boolector`, unrelated).
- Two `_fail` tests updated to the new message
  (`nested-list-comprehension-oob_fail`, `slicing-bounds-fail`).
- New tests: `list_index_oob_caught` (caught → SUCCESSFUL) and
  `list_index_oob_uncaught_fail` (uncaught → FAILED).

This also resolves the catchable-IndexError limitation documented in the #5991
fix (PR #5997): once both land, an out-of-bounds constant index on a
call-escaped list is likewise catchable.
