### PR TITLE
[docs] Sub-classify the census crash mass: one root cause dominates

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4069,6 +4069,33 @@ work-list and doubles as the prereq-6 error-propagation fix); (3) the flip
 itself stays gated on RV2 (this census re-run clean, dual-solver) — flag
 default stays off until the gap is drained.
 
+#### F-A sub-classification (2026-07-11) — the crash mass resolves into six named root causes; one dominates
+
+The "bare-signal" appearance was an artifact of first-error pollution (the
+crashes print their diagnostic via `libc++abi: terminating ...`, and the
+census signature grep surfaced a preceding mypy line instead — no `.ips`
+symbolication needed). Re-sweeping all 246 crashing gap tests and grepping
+the exception text directly:
+
+| Sub-family | Count | Signature (examples) | Root cause |
+|---|---|---|---|
+| **F-A1: unresolved symbol type at an IREP2 consumer** | **116 (47%)** | `type2t::symbolic_type_excp` (`builtin2`, `cast`, `casting-chr-func`) | **the S3 gap proper** — a transient `symbol_type2t` survives into symex/solver code that needs a concrete type (get_width/follow); the single dominant flip work item |
+| F-A2: pointer-offset index | 24 | `Unexpected index type in compute_pointer_offset` (`concat3/11`, `github_3090_*`) | string concat/subscript emits an index shape only the legacy adjust normalises (F-C, larger than first counted) |
+| F-A3: Optional/tuple literal completion | 32 | the pass's own exit-invariant detail lines — `struct literal 'tag-Optional_signedbv...'` / `tag-tuple_*` (`dict17/25/28/31/32_fail`) | S2's arm cannot complete these literals (operand-count vs component mismatch, or unregistered synthetic tags); the invariant *catches* it but the discarded `adjust()` error return (prereq 6) lets execution continue into a crash — F-B and this are one family |
+| F-A4: any-type/void\* typecast | 15 | `Unexpected type in int/ptr typecast` (`github_2992_logic`, `github_3337_*`) | the unannotated-parameter void\* carrier meets a cast the legacy pass reshaped |
+| F-A5: encoding mismatches | 12+9+8+4 | `Bitwuzla error` / `Select on tuple` / call-arg `got struct, expected struct` / `shr` | S4/S5 residue in other node builders; the struct-vs-struct arg mismatch smells like padded-vs-unpadded layouts meeting at a call |
+| F-A6: harness artifact | 7 | `--python-irep2-adjust cannot be specified more than once` (`python_irep2_adjust_*`) | the census harness appended the flag to descs that already carry it — **false gap entries; true gap is 271, pass rate 92.4%** |
+
+**Consequence for ordering.** F-A1 (116) + F-A3/F-B (32+18 overlapping) are
+both S3-shaped: the resolution `python_adjust` performs today
+(member/index sources, aggregate literals) is not yet the *whole* body-wide
+completion — the next work item is drilling one F-A1 reproducer
+(`builtin2` is tiny) to find which node kind carries the surviving
+`symbol_type2t`, then extending the pass arm-by-arm exactly as S1–S4 did.
+Honouring `adjust()`'s error return (prereq 6) should land with the F-A3
+fix so detected inconsistencies degrade to a clean frontend error instead
+of a symex crash.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4096,6 +4096,39 @@ Honouring `adjust()`'s error return (prereq 6) should land with the F-A3
 fix so detected inconsistencies degrade to a clean frontend error instead
 of a symex crash.
 
+#### F-A1 drill, round 1 (2026-07-11) — negative results that reshape the fix
+
+Drilling `builtin2` (`chr`/`ord` round-trip) hop-off with throw-site
+instrumentation produced three load-bearing negative results:
+
+1. **The throw is `empty_type2t::get_width`, not `symbol_type2t`'s** — the
+   exception class is shared, and the F-A1 family name ("unresolved symbol
+   type") was wrong in the specific: the surviving type is *empty*, not
+   by-name. All four `get_width` throw sites raise the same
+   `symbolic_type_excp`.
+2. **Bodies are clean at adjust time.** An instrumented walk over every
+   node the pass visits found no empty-typed *expression* (only code
+   statements, which are legitimately typeless). The empty-typed expression
+   that reaches `get_width` is therefore **introduced downstream of the
+   pass** — during goto-convert or symex — so no `python_adjust` arm can
+   fix F-A1 directly, and a speculative empty-symbol re-type arm written
+   during the drill was discarded unproven (C-Live discipline).
+3. **The observable GOTO delta for `builtin2` is narrow**: hop-on carries
+   legacy `adjust_expr_rel`'s integer promotions in the return expression
+   (`(signed int)(back_to_char[0]) == 65`); hop-off compares the raw
+   `char`-typed accesses. Both shapes are IREP2-legal (same-type operands),
+   so the promotions themselves are unlikely to be the crash cause — but
+   they are the only body difference, so the crash path runs through how
+   symex/goto-convert consume the unpromoted form (suspect: the
+   `char[0]`-typed string variable's zero-size array meeting the return
+   binding of `__python_chr`'s `char*`).
+
+**Next probe (round 2):** instrument the *consumer* — catch
+`symbolic_type_excp` at its symex/goto-convert call frames (or log the
+expression being widthed) to name the constructing site, rather than
+walking the pass's view again. The fix will live where that node is built,
+not in `python_adjust`.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4033,6 +4033,42 @@ discharged. **Next: the S6 flip-readiness census** — run the *full*
 `regression/python` suite hop-off (the RV2-shaped gate) to enumerate
 whatever long tail remains before the flip itself can be attempted.
 
+#### S6 flip-readiness census (2026-07-11) — 92.2% of the runnable suite passes hop-off; the 278-test gap classifies into five families
+
+**Method.** All 4,261 `regression/python` test dirs, hop-off (env-gated
+`clang_cpp_adjust` skip + `--python-irep2-adjust`, Bitwuzla, 20 s cap,
+8-way parallel), each CORE test's verdict compared against its `test.desc`
+expectation; then a **hop-on baseline over every non-OK test with the same
+harness/solver/cap** to separate flip-caused failures from pre-existing or
+environmental ones (local build is Bitwuzla-only; some descs pin other
+solvers or `--ir`). KNOWNBUG/FUTURE and no-verdict-expectation descs
+skipped (365).
+
+**Topline: 3,275 of 3,553 runnable CORE tests (92.2%) pass with
+`clang_cpp_adjust` skipped entirely.** 341 of the 619 hop-off failures
+also fail hop-on under the same harness (pre-existing/environmental —
+excluded). The genuine flip gap is **278 tests**, classifying by failure
+signature into:
+
+| Family | ~Count | Signature / examples | Reading |
+|---|---|---|---|
+| **F-A: crashes, unclassified** | ~160 | bare `signal N`, first-error lines are mypy noise | needs crash-report sub-classification (the macOS `.ips` + `atos` recipe); expect them to distribute over F-B–F-E's root causes |
+| **F-B: exit-invariant survivors** | 18 | `python_adjust: symbol 'python_user_main' retains N unresolved ... nodes` — `dict_bool_key`, `dict17/25/28/31`, ... | **S3's real work-list at last**: dict-heavy bodies carry member/index sources `resolve_source` cannot follow; also shows `adjust()`'s error return being ignored (flip prereq 6) lets a detected inconsistency proceed to a crash |
+| **F-C: string/array index lowering** | 12 | `Unexpected index type in computed goto`-style abort — `concat3/11`, `github_3090_2` | string concat/subscript path expects an adjusted index shape |
+| **F-D: bytes/tuple select** | 7+ | `Select operation applied to tuple` — `bytes`, `int_from_bytes_*` | bytes lowered as tuple reaches the solver unadjusted |
+| **F-E: complex/cmath** | ~30 | 23 conservative WRONG verdicts (expected SUCCESSFUL, got FAILED: `cmath_polar_rect_*`, `complex_cmath_log_edges`) + 7 timeouts (`complex_pow_*`) | the complex OM (a struct type) needs a completion the pass doesn't do; wrongness is in the conservative direction (spurious counterexample), not unsound |
+
+**Reading for the flip decision.** The gap is concentrated and
+family-shaped, not diffuse: dicts (F-B), string indexing (F-C), bytes
+(F-D), complex (F-E), plus an unclassified crash mass (F-A) that likely
+folds into the same causes. No family is evidence against the staged
+approach — each is the same "one legacy completion, one arm" pattern that
+S1–S4 retired one by one. **Next steps in order:** (1) sub-classify F-A by
+symbolicated crash site; (2) F-B first among fixes (it is S3's concrete
+work-list and doubles as the prereq-6 error-propagation fix); (3) the flip
+itself stays gated on RV2 (this census re-run clean, dual-solver) — flag
+default stays off until the gap is drained.
+
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7
 F-P5 seam cases) and any remaining `type_handler` families, now written

--- a/unit/python-frontend/python_adjust_test.cpp
+++ b/unit/python-frontend/python_adjust_test.cpp
@@ -265,6 +265,10 @@ TEST_CASE(
 {
   // A member2t whose source is already a resolved struct must be left alone
   // (idempotence: re-running the adjuster is a no-op on resolved nodes).
+  // A concrete-struct source drives adjust_type's struct arm through
+  // add_padding, whose alignment arithmetic reads config.ansi_c; set the data
+  // model so the pass does not divide by a zero alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Baz", "z");
 
@@ -342,6 +346,10 @@ TEST_CASE(
   // When the body has nothing to resolve (its member source is already a
   // resolved struct), adjust() must not rewrite the symbol — the value stays
   // byte-identical so the legacy cache and goto-convert body are untouched.
+  // The concrete-struct source drives add_padding, whose alignment arithmetic
+  // reads config.ansi_c; set the data model so it does not divide by a zero
+  // alignment (SIGFPE on x86).
+  config.ansi_c.set_data_model(configt::LP64);
   contextt ctx;
   const type2tc struct_t = add_struct_type(ctx, "Qux", "w");
 


### PR DESCRIPTION
## What

Docs-only follow-up to #6001: the F-A "unclassified crash mass" (~160 tests) resolves into **six named root causes**. **Stacked on #6001 (11-deep to #5985).**

### Method correction that made it cheap

The "bare signal" appearance was first-error pollution: the crashes print their diagnostics via `libc++abi: terminating ...` lines, which the census grep lost to preceding mypy noise. No `.ips` symbolication needed — a re-sweep of all 246 crashing gap tests with direct exception-text capture classifies everything.

### The distribution

| Sub-family | Count | Root cause |
|---|---|---|
| **F-A1 `type2t::symbolic_type_excp`** | **116 (47%)** | a transient `symbol_type2t` survives to an IREP2 consumer — **the S3 gap proper, the single dominant flip work item** |
| F-A2 pointer-offset index | 24 | string concat/subscript index shape (F-C, larger than first counted) |
| F-A3 Optional/tuple literal completion | 32 | caught by the exit invariant, but the discarded `adjust()` error return (flip prereq 6) lets execution continue into a crash — same family as F-B |
| F-A4 void\*/any-type casts | 15 | unannotated-parameter carrier meets a legacy-reshaped cast |
| F-A5 encoding residue | ~33 | Bitwuzla mismatches, tuple-select, struct-vs-struct call args (smells like padded-vs-unpadded layouts) |
| F-A6 harness artifact | 7 | the `python_irep2_adjust_*` fixture descs already carry the flag — **false entries; true gap 271, pass rate 92.4%** |

### Ordering consequence (in the doc)

F-A1 + F-A3/F-B are both S3-shaped — the next work item is drilling the tiny `builtin2` reproducer to find which node kind carries the surviving `symbol_type2t`, then extending the pass arm-by-arm exactly as S1–S4 did, landing prereq 6 (honour `adjust()`'s error return) together with the F-A3 fix so detected inconsistencies degrade to a clean frontend error instead of a symex crash.