### PR TITLE
[ir-ieee] fix isfinite for tracked NaN values

### DIFF
--- a/regression/ir-ra/ra-isfinite-nan-sqrt-fail/main.c
+++ b/regression/ir-ra/ra-isfinite-nan-sqrt-fail/main.c
@@ -1,0 +1,14 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double z = sqrt(x);
+  __ESBMC_assert(isfinite(z), "isfinite(sqrt(-1.0)) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isfinite-nan-sqrt-fail/test.desc
+++ b/regression/ir-ra/ra-isfinite-nan-sqrt-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-isfinite-nan-sqrt/main.c
+++ b/regression/ir-ra/ra-isfinite-nan-sqrt/main.c
@@ -1,0 +1,14 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double z = sqrt(x);
+  __ESBMC_assert(!isfinite(z), "isfinite(sqrt(-1.0)) is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-isfinite-nan-sqrt/test.desc
+++ b/regression/ir-ra/ra-isfinite-nan-sqrt/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-isfinite-not-nan/main.c
+++ b/regression/ir-ra/ra-isfinite-not-nan/main.c
@@ -1,0 +1,16 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 1.0);
+  __ESBMC_assume(y == 2.0);
+  double z = x / y;
+  __ESBMC_assert(isfinite(z), "isfinite(1.0 / 2.0) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isfinite-not-nan/test.desc
+++ b/regression/ir-ra/ra-isfinite-not-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -705,7 +705,14 @@ smt_astt smt_solver_baset::convert_is_finite(const expr2tc &expr)
     smt_astt operand = convert_ast(isfinite.value);
     smt_astt pos_ok = mk_le(operand, max_val);
     smt_astt neg_ok = mk_ge(operand, mk_sub(get_zero_real(), max_val));
-    return mk_and(pos_ok, neg_ok);
+    smt_astt finite_check = mk_and(pos_ok, neg_ok);
+    if (ir_ieee)
+    {
+      smt_astt nan_pred = ir_ieee_api->get_nan_pred(operand);
+      if (nan_pred)
+        return mk_and(mk_not(nan_pred), finite_check);
+    }
+    return finite_check;
   }
 
   smt_astt value = convert_ast(isfinite.value);


### PR DESCRIPTION
## Summary

This PR fixes `isfinite()` under the `--ir-ieee` integer/real floating-point encoding by making it consult the existing NaN predicate infrastructure.

Previously, `convert_is_finite` only checked whether the encoded real value lay within the finite floating-point range. Under `--ir-ieee`, NaN values are represented using an unconstrained real together with a tracked NaN predicate. Since `isfinite()` ignored that predicate, NaN values could incorrectly satisfy the finite-range check.

After this change, `isfinite()` returns `false` whenever the operand has a tracked NaN predicate.

## Motivation

Recent `--ir-ieee` work introduced NaN predicate generation and propagation for operations such as:

* `sqrt(x)` when `x < 0`
* `0.0 / 0.0`

These predicates are already consumed by NaN-aware comparisons and by `isnan()`.

However, `isfinite()` still relied solely on the underlying SMT real value. Since NaN values are encoded as unconstrained reals, the solver could assign an arbitrary finite value and incorrectly satisfy the finite-range check.

This failure was reproduced against the current upstream master. For example:

```c
double z = sqrt(-1.0);
__ESBMC_assert(!isfinite(z), "sqrt(-1.0) is not finite");
```

was reported as `VERIFICATION FAILED`, even though the assertion is correct. The SMT-level `isfinite()` check operated only on the unconstrained real used for the NaN result and did not consult its tracked NaN predicate.

This PR makes `isfinite()` respect the existing tracked NaN metadata.

## Changes

This PR updates `smt_solver_baset::convert_is_finite` in:

```text
src/solvers/smt/smt_fp_conv.cpp
```

For the `--ir-ieee` path, `convert_is_finite` now:

* performs the existing finite-range check,
* queries `ir_ieee_api->get_nan_pred(...)`,
* returns `!nan_pred && finite_check` when a tracked NaN predicate exists,
* falls back to the existing finite-range check when no NaN predicate is known.

No additional includes are needed; `ir_ieee_conv.h` was already added to this file in #5517.

The bitvector floating-point path is unchanged.

This PR does not introduce new NaN sources or new propagation rules. It only makes `isfinite()` observe already-tracked NaN predicates.

## Regression Tests

Three new CORE regression tests were added under `regression/ir-ra/`:

* `ra-isfinite-nan-sqrt`

  * Checks that `isfinite(sqrt(-1.0))` correctly evaluates to `false`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-isfinite-nan-sqrt-fail`

  * Failing companion test.
  * Checks that `isfinite(sqrt(-1.0))` cannot incorrectly evaluate to `true`.
  * Expected result: `VERIFICATION FAILED`.

* `ra-isfinite-not-nan`

  * Checks that `isfinite(1.0 / 2.0)` continues to return `true`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

The tests use nondeterministic operands constrained with `__ESBMC_assume` to ensure the expressions reach the `--ir-ieee` SMT encoding path.

## Testing

The focused `isfinite` regression tests were run:

```bash
ctest --test-dir build -R "ra-isfinite" --output-on-failure
```

Result:

```text
3/3 passed
```

The full `ir-ra` regression suite was also run:

```text
172/172 passed
```

## Notes

This PR is intentionally limited to making `isfinite()` observe already-tracked NaN predicates under `--ir-ieee`.
