### PR TITLE
[ir-ieee] fix isnormal for tracked NaN values

### DIFF
--- a/regression/ir-ra/ra-isnormal-nan-sqrt-fail/main.c
+++ b/regression/ir-ra/ra-isnormal-nan-sqrt-fail/main.c
@@ -1,0 +1,14 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double z = sqrt(x);
+  __ESBMC_assert(isnormal(z), "isnormal(sqrt(-1.0)) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isnormal-nan-sqrt-fail/test.desc
+++ b/regression/ir-ra/ra-isnormal-nan-sqrt-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-isnormal-nan-sqrt/main.c
+++ b/regression/ir-ra/ra-isnormal-nan-sqrt/main.c
@@ -1,0 +1,14 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double z = sqrt(x);
+  __ESBMC_assert(!isnormal(z), "isnormal(sqrt(-1.0)) is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-isnormal-nan-sqrt/test.desc
+++ b/regression/ir-ra/ra-isnormal-nan-sqrt/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-isnormal-not-nan/main.c
+++ b/regression/ir-ra/ra-isnormal-not-nan/main.c
@@ -1,0 +1,13 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 1.0);
+  __ESBMC_assert(isnormal(x), "isnormal(1.0) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isnormal-not-nan/test.desc
+++ b/regression/ir-ra/ra-isnormal-not-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -674,7 +674,14 @@ smt_astt smt_solver_baset::convert_is_normal(const expr2tc &expr)
     // |f| <= max_normal: f <= max_normal && f >= -max_normal
     smt_astt below_max =
       mk_and(mk_le(operand, max_val), mk_ge(operand, neg_max));
-    return mk_and(above_min, below_max);
+    smt_astt normal_check = mk_and(above_min, below_max);
+    if (ir_ieee)
+    {
+      smt_astt nan_pred = ir_ieee_api->get_nan_pred(operand);
+      if (nan_pred)
+        return mk_and(mk_not(nan_pred), normal_check);
+    }
+    return normal_check;
   }
 
   smt_astt operand = convert_ast(isnormal.value);


### PR DESCRIPTION
## Summary

This PR fixes `isnormal()` under the `--ir-ieee` integer/real floating-point encoding by making it consult the existing NaN predicate infrastructure.

Previously, `convert_is_normal` only checked whether the encoded real value lay within the IEEE normal floating-point range. Under `--ir-ieee`, NaN values are represented using an unconstrained real together with a tracked NaN predicate. Since `isnormal()` ignored that predicate, NaN values could incorrectly satisfy the normal-range check.

After this change, `isnormal()` returns `false` whenever the operand has a tracked NaN predicate.

## Motivation

Recent `--ir-ieee` work introduced NaN predicate generation and propagation for operations such as:

- `sqrt(x)` when `x < 0`
- `0.0 / 0.0`

These predicates are already consumed by NaN-aware comparisons, `isnan()`, and `isfinite()`.

However, `isnormal()` still relied solely on the underlying SMT real value. Since NaN values are encoded as unconstrained reals, the solver could assign an arbitrary normal value and incorrectly satisfy the normal-range check.

This failure was reproduced against the current upstream master. For example:

```c
double z = sqrt(-1.0);
__ESBMC_assert(!isnormal(z), "sqrt(-1.0) is not normal");
```

was reported as `VERIFICATION FAILED`, even though the assertion is correct. The SMT-level `isnormal()` check operated only on the unconstrained real used for the NaN result and did not consult its tracked NaN predicate.

This PR makes `isnormal()` respect the existing tracked NaN metadata.

## Changes

This PR updates `smt_solver_baset::convert_is_normal` in:

```text
src/solvers/smt/smt_fp_conv.cpp
```

For the `--ir-ieee` path, `convert_is_normal` now:

- performs the existing normal-range check,
- queries `ir_ieee_api->get_nan_pred(...)`,
- returns `!nan_pred && normal_check` when a tracked NaN predicate exists,
- falls back to the existing normal-range check when no NaN predicate is tracked.

No additional includes are needed; `ir_ieee_conv.h` was already added to this file in #5517.

The bitvector floating-point path is unchanged.

This PR does not introduce new NaN sources or new NaN propagation rules. It only makes `isnormal()` observe already-tracked NaN predicates.

## Regression Tests

Three new CORE regression tests were added under `regression/ir-ra/`:

- `ra-isnormal-nan-sqrt`

  - Checks that `isnormal(sqrt(-1.0))` correctly evaluates to `false`.
  - Expected result: `VERIFICATION SUCCESSFUL`.

- `ra-isnormal-nan-sqrt-fail`

  - Failing companion test.
  - Checks that `isnormal(sqrt(-1.0))` cannot incorrectly evaluate to `true`.
  - Expected result: `VERIFICATION FAILED`.

- `ra-isnormal-not-nan`

  - Checks that `isnormal(1.0)` continues to return `true`.
  - Expected result: `VERIFICATION SUCCESSFUL`.

The tests use nondeterministic operands constrained with `__ESBMC_assume` to ensure the expressions reach the `--ir-ieee` SMT encoding path.

## Testing

The focused `isnormal` regression tests were run:

```bash
ctest --test-dir build -R "ra-isnormal" --output-on-failure
```

Result:

```text
3/3 passed
```

The full `ir-ra` regression suite was also run:

```text
175/175 passed
```

## Notes

This PR is intentionally limited to making `isnormal()` observe already-tracked NaN predicates under `--ir-ieee`.