### PR TITLE
[goto] don't destroy the array_init$ construction helper

### DIFF
--- a/regression/esbmc-cpp/cpp/dtor_array_member/test.desc
+++ b/regression/esbmc-cpp/cpp/dtor_array_member/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free/main.cpp
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free/main.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+
+// A class with a class-type member array is constructed via the frontend's
+// `array_init$` helper (a temporary copy of the object).  That helper must not
+// be destroyed on its own: doing so runs each element's destructor a second
+// time.  With a resource-owning element this is a double-free.  Here each
+// element records how many times it is destroyed; every count must be exactly
+// one.  Regression for dtor_array_member (was KNOWNBUG, g double-counted to 6).
+
+int destroyed[3];
+
+struct R
+{
+  int id;
+  ~R() { destroyed[id]++; }
+};
+
+struct Holder
+{
+  R rs[3];
+  Holder()
+  {
+    rs[0].id = 0;
+    rs[1].id = 1;
+    rs[2].id = 2;
+  }
+};
+
+int main()
+{
+  {
+    Holder h;
+  }
+  assert(destroyed[0] == 1);
+  assert(destroyed[1] == 1);
+  assert(destroyed[2] == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free/test.desc
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free_fail/main.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+
+// Negative of dtor_array_member_no_double_free: each element is destroyed
+// exactly once, so asserting it is destroyed *twice* (the pre-fix double-free
+// behaviour) must be violated -> VERIFICATION FAILED.
+
+int destroyed[3];
+
+struct R
+{
+  int id;
+  ~R() { destroyed[id]++; }
+};
+
+struct Holder
+{
+  R rs[3];
+  Holder()
+  {
+    rs[0].id = 0;
+    rs[1].id = 1;
+    rs[2].id = 2;
+  }
+};
+
+int main()
+{
+  {
+    Holder h;
+  }
+  assert(destroyed[0] == 2); // wrong on purpose: it is destroyed once
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/dtor_array_member_no_double_free_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -798,8 +798,17 @@ void goto_convertt::convert_decl(const codet &code, goto_programt &dest)
   }
 
   // do destructor
+  //
+  // The C++ frontend's `array_init$` is a construction helper: it builds an
+  // aggregate/array member, then copies its contents into the object under
+  // construction (`*this = array_init$`).  Giving it an automatic scope-exit
+  // destructor would run the copied members' destructors a second time (and
+  // double-free any resource-owning member), so skip it -- its members are
+  // owned and destroyed through `*this`.  `array_init$` is a reserved
+  // synthetic name (`$` cannot appear in a user identifier), so this cannot
+  // match a user variable.
   code_function_callt destructor;
-  if (get_destructor(ns, s->get_type(), destructor))
+  if (s->name != "array_init$" && get_destructor(ns, s->get_type(), destructor))
   {
     // add "this"
     address_of_exprt this_expr(symbol_expr);


### PR DESCRIPTION
A class with a class-type member array had its elements destroyed twice: the frontend builds the member array through a synthetic `array_init$` local and copies it into `*this`, but `goto_convert` also scheduled a scope-exit destructor for that helper, double-running every element destructor (a double-free for resource-owning members). Skip the automatic destructor for the reserved `array_init$` helper, since its members are already destroyed through the object under construction. Flips `dtor_array_member` KNOWNBUG→CORE and adds double-free positive/negative tests.
