### PR TITLE
[build] Require LLVM/Clang 18 and reject mismatched toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ESBMC_VERSION "${ESBMC_VERSION_MAJOR}.${ESBMC_VERSION_MINOR}.${ESBMC_VERSION
 # The only default solver available is smtlib
 set(ESBMC_AVAILABLE_SOLVERS "smtlib")
 
+set(MIN_SUPPORTED_LLVM_VERSION_MAJOR 18)
 set(MAX_SUPPORTED_LLVM_VERSION_MAJOR 22)
 
 #################################

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,12 +46,11 @@ COMPILER_ENV=()
 
 STATIC=""
 COVERAGE=OFF
-CLANG_VERSION=16
-MIN_MACOS_CLANG_VERSION=17
-
-if [[ "$OS" == "Darwin" ]]; then
-  CLANG_VERSION="$MIN_MACOS_CLANG_VERSION"
-fi
+# ESBMC uses Clang-18 APIs (e.g. isExplicitObjectMemberFunction); 18 is the
+# minimum supported toolchain on every platform (mirrors
+# MIN_SUPPORTED_LLVM_VERSION_MAJOR in CMakeLists.txt).
+MIN_CLANG_VERSION=18
+CLANG_VERSION="$MIN_CLANG_VERSION"
 
 GMP_VERSION="6.3.0"
 GMP_TARBALL="gmp-${GMP_VERSION}.tar.xz"
@@ -77,8 +76,8 @@ validate_clang_version() {
     error "invalid clang version '$CLANG_VERSION': expected numeric major version"
   fi
 
-  if [[ "$OS" == "Darwin" ]] && (( CLANG_VERSION < MIN_MACOS_CLANG_VERSION )); then
-    error "macOS requires llvm/clang >= ${MIN_MACOS_CLANG_VERSION}; got $CLANG_VERSION"
+  if (( CLANG_VERSION < MIN_CLANG_VERSION )); then
+    error "ESBMC requires llvm/clang >= ${MIN_CLANG_VERSION}; got $CLANG_VERSION"
   fi
 }
 
@@ -557,7 +556,7 @@ Options [defaults]:
   -r ON|OFF  enable/disable 'benchbringup' [OFF]
   -d         enable debug output for this script and c2goto
   -S ON|OFF  enable/disable static build [ON for Ubuntu, OFF for macOS]
-  -c VERS    use packaged clang-VERS [16 on Linux, >=17 required on macOS]
+  -c VERS    use packaged clang-VERS [default 18; >=18 required on all platforms]
   -C         build an SV-COMP version [disabled]
   -B ON|OFF  enable/disable esbmc bundled libc [ON]
   -x ON|OFF  enable/disable esbmc cheri [OFF]

--- a/scripts/cmake/SetupLocalLLVM.cmake
+++ b/scripts/cmake/SetupLocalLLVM.cmake
@@ -18,6 +18,11 @@ if(NOT (("${LLVM_DIR}" STREQUAL "LLVM_DIR-NOTFOUND") OR ("${LLVM_DIR}" STREQUAL 
     PATHS ${LLVM_DIR}
     NO_DEFAULT_PATH
   )
+  # Snapshot the version from the LLVM_DIR tree: find_package(Clang) below
+  # transitively re-includes LLVMConfig and overwrites LLVM_VERSION with the
+  # Clang_DIR tree's version, masking a mismatched toolchain.
+  set(_ESBMC_LLVM_DIR_VERSION "${LLVM_VERSION}")
+  set(_ESBMC_LLVM_DIR_VERSION_MAJOR "${LLVM_VERSION_MAJOR}")
 
   find_package(Clang REQUIRED CONFIG
     PATHS ${Clang_DIR}
@@ -25,7 +30,24 @@ if(NOT (("${LLVM_DIR}" STREQUAL "LLVM_DIR-NOTFOUND") OR ("${LLVM_DIR}" STREQUAL 
   )
 else()
   find_package(LLVM REQUIRED CONFIG)
+  set(_ESBMC_LLVM_DIR_VERSION "${LLVM_VERSION}")
+  set(_ESBMC_LLVM_DIR_VERSION_MAJOR "${LLVM_VERSION_MAJOR}")
   find_package(Clang REQUIRED CONFIG)
+endif()
+
+# LLVM_DIR and Clang_DIR must resolve to the same toolchain. Mixing, e.g.,
+# libLLVM-16 with libclang-cpp-18 produces a cryptic link-time
+# "DSO missing from command line" failure late in the build (esbmc #6005).
+# Compare the major version: that is the shared-library soname boundary that
+# actually breaks linking, matching the MIN/MAX checks below.
+if(NOT _ESBMC_LLVM_DIR_VERSION_MAJOR EQUAL LLVM_VERSION_MAJOR)
+  message(FATAL_ERROR
+    "LLVM_DIR and Clang_DIR resolve to different toolchains "
+    "(LLVM ${_ESBMC_LLVM_DIR_VERSION} vs Clang ${LLVM_VERSION}). "
+    "Point both at the same LLVM/Clang install, e.g. "
+    "-DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm "
+    "-DClang_DIR=/usr/lib/llvm-18/lib/cmake/clang, "
+    "and reconfigure in a clean build directory.")
 endif()
 
 if(LLVM_PACKAGE_BUGREPORT STREQUAL https://github.com/CTSRD-CHERI/llvm-project/issues)
@@ -97,8 +119,10 @@ if(${LLVM_VERSION_MAJOR} GREATER ${MAX_SUPPORTED_LLVM_VERSION_MAJOR})
                   "supported (${MAX_SUPPORTED_LLVM_VERSION_MAJOR})")
 endif()
 
-if(${LLVM_VERSION_MAJOR} LESS 11)
-  message(FATAL_ERROR "Could not find LLVM/Clang >= 11.0 at all: please specify with -DLLVM_DIR/-DClang_DIR")
+if(${LLVM_VERSION_MAJOR} LESS ${MIN_SUPPORTED_LLVM_VERSION_MAJOR})
+  message(FATAL_ERROR "ESBMC requires LLVM/Clang >= ${MIN_SUPPORTED_LLVM_VERSION_MAJOR} "
+                      "(found ${LLVM_VERSION_MAJOR}): please install a newer toolchain and "
+                      "specify it with -DLLVM_DIR/-DClang_DIR")
 else()
   message(STATUS "LLVM version: ${LLVM_VERSION}")
 endif()

--- a/website/content/docs/development/building.md
+++ b/website/content/docs/development/building.md
@@ -360,6 +360,13 @@ how your system LLVM was packaged you may also need `libzstd-dev` and
 package Clang 18 or newer, install one from <https://apt.llvm.org> and bump the
 version number in the package names and paths above.
 
+Keep `LLVM_DIR` and `Clang_DIR` on the **same** toolchain version. Mixing them
+(e.g. `LLVM_DIR` on `llvm-16` while `Clang_DIR` is `clang-18`) links
+`libLLVM-16` against `libclang-cpp-18` and fails late with
+`undefined reference … DSO missing from command line`; ESBMC now stops such a
+configuration at CMake time. When switching compiler versions, reconfigure in a
+fresh build directory — a stale `CMakeCache.txt` keeps the old paths.
+
 ### Build the solvers
 
 {{% details title="Boolector" closed="true" %}}


### PR DESCRIPTION
Fix the two build failures from discussion #6005 (docs landed in #6007). Raise the LLVM/Clang floor to 18 in CMake and `build.sh` — the C++ frontend now calls the Clang-18 API `isExplicitObjectMemberFunction` — so the requirement surfaces at configure time. Also snapshot the LLVM major before `find_package(Clang)` and `FATAL_ERROR` on a major-version mismatch, turning a cryptic mismatched-toolchain link error into an actionable configure-time message.
