### PR TITLE
[ir-ieee] fix isinf for tracked NaN values

### DIFF
--- a/regression/ir-ra/ra-isinf-nan-div-fail/main.c
+++ b/regression/ir-ra/ra-isinf-nan-div-fail/main.c
@@ -1,0 +1,16 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+  __ESBMC_assert(isinf(z), "isinf(0.0/0.0) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isinf-nan-div-fail/test.desc
+++ b/regression/ir-ra/ra-isinf-nan-div-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-isinf-nan-div/main.c
+++ b/regression/ir-ra/ra-isinf-nan-div/main.c
@@ -1,0 +1,16 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+  __ESBMC_assert(!isinf(z), "isinf(0.0/0.0) is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-isinf-nan-div/test.desc
+++ b/regression/ir-ra/ra-isinf-nan-div/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-isinf-nan-sqrt-fail/main.c
+++ b/regression/ir-ra/ra-isinf-nan-sqrt-fail/main.c
@@ -1,0 +1,14 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double z = sqrt(x);
+  __ESBMC_assert(isinf(z), "isinf(sqrt(-1.0)) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isinf-nan-sqrt-fail/test.desc
+++ b/regression/ir-ra/ra-isinf-nan-sqrt-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-isinf-nan-sqrt/main.c
+++ b/regression/ir-ra/ra-isinf-nan-sqrt/main.c
@@ -1,0 +1,14 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double z = sqrt(x);
+  __ESBMC_assert(!isinf(z), "isinf(sqrt(-1.0)) is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-isinf-nan-sqrt/test.desc
+++ b/regression/ir-ra/ra-isinf-nan-sqrt/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-isinf-true-inf/main.c
+++ b/regression/ir-ra/ra-isinf-true-inf/main.c
@@ -1,0 +1,16 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 1.0);
+  __ESBMC_assume(y == 0.0);
+  double z = x / y;
+  __ESBMC_assert(isinf(z), "isinf(1.0/0.0) is true");
+  return 0;
+}

--- a/regression/ir-ra/ra-isinf-true-inf/test.desc
+++ b/regression/ir-ra/ra-isinf-true-inf/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -634,7 +634,14 @@ smt_astt smt_solver_baset::convert_is_inf(const expr2tc &expr)
     smt_astt operand = convert_ast(isinf.value);
     smt_astt pos_inf = mk_gt(operand, max_val);
     smt_astt neg_inf = mk_lt(operand, mk_sub(get_zero_real(), max_val));
-    return mk_or(pos_inf, neg_inf);
+    smt_astt inf_check = mk_or(pos_inf, neg_inf);
+    if (ir_ieee)
+    {
+      smt_astt nan_pred = ir_ieee_api->get_nan_pred(operand);
+      if (nan_pred)
+        return mk_and(mk_not(nan_pred), inf_check);
+    }
+    return inf_check;
   }
 
   smt_astt operand = convert_ast(isinf.value);


### PR DESCRIPTION
## Summary

This PR fixes `isinf()` under the `--ir-ieee` integer/real floating-point encoding by making it consult the existing NaN predicate infrastructure.

Previously, `convert_is_inf` only checked whether the encoded real value lay outside the IEEE finite floating-point range. Under `--ir-ieee`, NaN values are represented using an unconstrained real together with a tracked NaN predicate. Since `isinf()` ignored that predicate, NaN values could incorrectly satisfy the infinity check.

After this change, `isinf()` returns `false` whenever the operand has a tracked NaN predicate.

## Motivation

Recent `--ir-ieee` work introduced NaN predicate generation and propagation for operations such as:

* `sqrt(x)` when `x < 0`
* `0.0 / 0.0`

These predicates are already consumed by NaN-aware comparisons, `isnan()`, `isfinite()`, and `isnormal()`.

However, `isinf()` still relied solely on the underlying SMT real value. This led to two incorrect behaviors.

For values produced by `sqrt(-1.0)`, the NaN result is represented by an unconstrained SMT real. Since `isinf()` ignored the tracked NaN predicate, the solver could assign a value outside the finite range and incorrectly satisfy the infinity check.

For `0.0 / 0.0`, the current `--ir-ieee` encoding uses the existing infinity sentinel for divide-by-zero results while separately tracking that the result is NaN. Without consulting the tracked NaN predicate, `isinf()` incorrectly reported the result as infinite.

Both failures were reproduced against the current upstream master before implementing this fix:

```c
double z = sqrt(-1.0);
__ESBMC_assert(!isinf(z), "isinf(sqrt(-1.0)) must be false");
```

was reported as `VERIFICATION FAILED`.

Likewise:

```c
double z = 0.0 / 0.0;
__ESBMC_assert(!isinf(z), "isinf(0.0/0.0) must be false");
```

was also reported as `VERIFICATION FAILED`.

This PR makes `isinf()` respect the existing tracked NaN metadata.

## Changes

This PR updates `smt_solver_baset::convert_is_inf` in:

```text
src/solvers/smt/smt_fp_conv.cpp
```

For the `--ir-ieee` path, `convert_is_inf` now:

* performs the existing infinity check,
* queries `ir_ieee_api->get_nan_pred(...)`,
* returns `!nan_pred && inf_check` when a tracked NaN predicate exists,
* falls back to the existing infinity check when no NaN predicate is tracked.

No additional includes are needed; `ir_ieee_conv.h` was already added to this file in #5517.

The bitvector floating-point path is unchanged.

This PR does not introduce new NaN sources or new NaN propagation rules. It only makes `isinf()` observe already-tracked NaN predicates.

## Regression Tests

Five new CORE regression tests were added under `regression/ir-ra/`:

* `ra-isinf-nan-sqrt`

  * Checks that `isinf(sqrt(-1.0))` correctly evaluates to `false`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-isinf-nan-sqrt-fail`

  * Failing companion test.
  * Checks that `isinf(sqrt(-1.0))` cannot incorrectly evaluate to `true`.
  * Expected result: `VERIFICATION FAILED`.

* `ra-isinf-nan-div`

  * Checks that `isinf(0.0 / 0.0)` correctly evaluates to `false`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-isinf-nan-div-fail`

  * Failing companion test.
  * Checks that `isinf(0.0 / 0.0)` cannot incorrectly evaluate to `true`.
  * Expected result: `VERIFICATION FAILED`.

* `ra-isinf-true-inf`

  * Checks that `isinf(1.0 / 0.0)` continues to return `true`.
  * Expected result: `VERIFICATION SUCCESSFUL`.

The tests use nondeterministic operands constrained with `__ESBMC_assume` to ensure the expressions reach the `--ir-ieee` SMT encoding path.

## Testing

The focused `isinf` regression tests were run:

```bash
ctest --test-dir build -R "ra-isinf" --output-on-failure
```

Result:

```text
5/5 passed
```

The full `ir-ra` regression suite was also run:

```text
180/180 passed
```

## Notes

This PR is intentionally limited to making `isinf()` observe already-tracked NaN predicates under `--ir-ieee`.