### PR TITLE
[python] Add verification harnesses for torch model (Tier 3)

### DIFF
--- a/docs/python-model-verification-harness-plan.md
+++ b/docs/python-model-verification-harness-plan.md
@@ -1,7 +1,8 @@
 # Plan: extend verification-harness coverage of the Python operational models
 
 **Status:** EXECUTED — Tiers 1–3 complete (see §9); all surfaced model gaps
-resolved (see §10). `torch` intentionally deferred.
+resolved (see §10). `torch` was subsequently harnessed (PR #6017); no model
+remains uncovered.
 **Date:** 2026-07-10 (proposal); 2026-07-11 (execution)
 **Related:** PR #5958 (math ints / int / builtins / nondet), PR #5961 (random /
 collections / gamma-remainder), PR #5963 (gamma/lgamma wrong-π model fix). This
@@ -241,12 +242,19 @@ runs can spuriously time out — see §8).
 | 3 | re | #5981 | literal match/search/fullmatch; char-class patterns return an unconstrained bool (model gap) |
 | 3 | threading | #5983 | Lock mutual exclusion; requires `--data-races-check` or the proof is vacuous |
 | 3 | numpy | #5984 | concrete array/reduce/scalar-math; `np.add` unsupported, `np.sum` constants-only |
+| 3 | torch | #6017 | mm right-identity, allclose reflexivity/discrimination, cat width+value; concrete anchors, minimal tensors to fit the CI budget |
 
 **Audited and skipped.** `typing` — pure type-alias stubs, no runtime surface.
 `consensus` — trivial `hash()==42`, negligible value.
 
-**Deferred.** `torch` — heaviest tensor model, and like numpy it has no nondet
-surface, so it adds nothing beyond what numpy already demonstrates.
+**Torch, revisited.** `torch` was initially deferred as "no nondet surface, so
+it adds nothing beyond numpy." On closer inspection the torch model carries real
+algorithmic contracts numpy's constant stubs lack — a triple-loop matrix
+multiply (`mm`/`matmul`), column concatenation (`cat`), and an element-wise
+tolerance compare (`allclose`) — so it was harnessed with concrete anchors
+(PR #6017). Like the other float-heavy models, `cat`+`allclose` stacked in one
+harness blows the CI budget, so tensor sizes and unwind bounds are kept minimal
+and value checks use direct indexing rather than a second model call.
 
 ## 10. Model gaps surfaced — all resolved
 

--- a/regression/python/harness_torch_allclose/main.py
+++ b/regression/python/harness_torch_allclose/main.py
@@ -1,0 +1,19 @@
+# Verification harness for the torch operational model — torch.allclose.
+#
+# Contract clauses (torch.allclose: element-wise |a-b| <= atol + rtol*|b|):
+#   E1  reflexivity: a tensor is allclose to itself.
+#   E2  discrimination: tensors differing by more than the tolerance are NOT
+#       allclose (the check is not the constant True).
+#
+# Concrete anchors (float-heavy model, no nondet surface). The E2 anchor differs
+# by 1.0 in one cell, far above the default atol (1e-8) + rtol*|b| band.
+import torch
+
+A = [[1.0, 2.0], [3.0, 4.0]]
+B = [[1.0, 2.0], [3.0, 5.0]]
+
+# E1: reflexive.
+assert torch.allclose(A, A)
+
+# E2: a 1.0 discrepancy is rejected.
+assert not torch.allclose(A, B)

--- a/regression/python/harness_torch_allclose/test.desc
+++ b/regression/python/harness_torch_allclose/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_torch_allclose_fail/main.py
+++ b/regression/python/harness_torch_allclose_fail/main.py
@@ -1,0 +1,13 @@
+# Negative harness for the torch operational model — torch.allclose.
+#
+# Pins the teeth of the E2 discrimination clause (see harness_torch_allclose):
+# the plausible-but-wrong strengthening "allclose tolerates any small-looking
+# discrepancy" is falsified. B differs from A by 1.0 in one cell, far above the
+# default atol (1e-8) + rtol*|b| band, so allclose(A, B) is False and asserting
+# it True must fail.
+import torch
+
+A = [[1.0, 2.0], [3.0, 4.0]]
+B = [[1.0, 2.0], [3.0, 5.0]]
+
+assert torch.allclose(A, B)

--- a/regression/python/harness_torch_allclose_fail/test.desc
+++ b/regression/python/harness_torch_allclose_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/harness_torch_cat_shape/main.py
+++ b/regression/python/harness_torch_cat_shape/main.py
@@ -1,0 +1,24 @@
+# Verification harness for the torch operational model — torch.cat (dim == 1).
+#
+# Contract clauses (torch.cat along columns: rows stay aligned, columns append):
+#   E1  width additivity: the result width is the sum of the operands' widths,
+#       the row count is unchanged.
+#   E2  value preservation: the left block is A's column, the right block B's.
+#
+# Concrete anchors (float-heavy model, no nondet surface). Minimal 1x1 operands
+# keep cat's nested-list construction within the CI budget; values are checked
+# by direct element indexing (layering allclose on top blows the budget).
+import torch
+
+A = [[1.0]]  # 1 x 1
+B = [[2.0]]  # 1 x 1
+
+C = torch.cat([A, B], 1)  # -> 1 x 2
+
+# E1: shape is (1, 1+1).
+assert len(C) == 1
+assert len(C[0]) == 2
+
+# E2: columns are concatenated in order (A's block, then B's).
+assert C[0][0] == 1.0
+assert C[0][1] == 2.0

--- a/regression/python/harness_torch_cat_shape/test.desc
+++ b/regression/python/harness_torch_cat_shape/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_torch_mm_identity/main.py
+++ b/regression/python/harness_torch_mm_identity/main.py
@@ -1,0 +1,18 @@
+# Verification harness for the torch operational model — torch.mm.
+#
+# Contract clause (torch.mm: 2-D matrix product A(n x k) . B(k x m) -> (n x m)):
+#   E1  right identity: mm(A, I) == A for the k x k identity I. This exercises
+#       the full dot-product loop (each output is a sum of A[i][t]*I[t][j]).
+#
+# torch tensors are float-heavy nested lists with no nondet-friendly surface,
+# so this harness uses concrete anchors — the established tactic for float-heavy
+# models (cf. cmath, numpy). torch.allclose is the tensor-equality oracle; a
+# single mm result is cached in a local to keep the symbolic budget small.
+import torch
+
+A = [[1.0, 2.0], [3.0, 4.0]]
+I = [[1.0, 0.0], [0.0, 1.0]]
+
+# E1: A . I must equal A element-for-element.
+product = torch.mm(A, I)
+assert torch.allclose(product, A)

--- a/regression/python/harness_torch_mm_identity/test.desc
+++ b/regression/python/harness_torch_mm_identity/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -170,6 +170,7 @@ ignored_prefixes=(
   "github_4666_"
   "github_4668_"
   "harness_numpy_"
+  "harness_torch_"
 )
 
 for dir in */; do


### PR DESCRIPTION
Closes out the last remaining model in the Python operational-model
verification-harness effort (`docs/python-model-verification-harness-plan.md`).

The plan had deferred `torch` as "adds nothing beyond numpy," but the torch
model actually carries real algorithmic contracts — a triple-loop matrix
multiply, column concatenation, and an element-wise tolerance compare — richer
than numpy's mostly-constant stubs. That makes it worth a contract harness.

### Harnesses (all concrete anchors — float-heavy tensors have no nondet surface)

| Harness | Contract | Verdict | Time |
|---|---|---|---|
| `harness_torch_mm_identity` | `mm(A, I) == A` (full dot-product loop) | SUCCESSFUL | ~17s |
| `harness_torch_allclose` | reflexivity + discrimination (a 1.0 gap is rejected) | SUCCESSFUL | ~11s |
| `harness_torch_cat_shape` | cat width-additivity + column value preservation | SUCCESSFUL | ~27s |
| `harness_torch_allclose_fail` | pins allclose's teeth (close-but-1.0-apart → FAILED on the intended assertion) | FAILED | ~10s |

Each runs well under the 120 s CI cap. `check_python_tests.sh` gains a
`harness_torch_` prefix in `ignored_prefixes` (torch imports with plain lists
are not CPython-runnable), mirroring the existing `harness_numpy_` handling.

Follows the established §2 methodology: nondet-free concrete anchors, a `_fail`
sibling proving the positive check has teeth, minimal tensor sizes and unwind
bounds to stay within budget.