### PR TITLE
[python] De-flake harness_threading_lock_mutex (120s CI timeout)

### DIFF
--- a/regression/python/harness_threading_lock_mutex/main.py
+++ b/regression/python/harness_threading_lock_mutex/main.py
@@ -11,6 +11,13 @@
 # and --data-races-check (the flag that keeps interleaving generation alive;
 # without it the search terminates early and the claim passes vacuously).
 #
+# Bounded --unwind 2 (not --incremental-bmc): the user code is loop-free and the
+# threading model's start/join fully unroll within one step, so a single bounded
+# solve is complete here — unwinding assertions stay ON, so an insufficient bound
+# would surface as VERIFICATION FAILED, never a false SUCCESSFUL. This avoids the
+# incremental re-solve overhead that pushed this proof to ~115s against the CI's
+# 120s cap and made it flaky. Do not restore --incremental-bmc.
+#
 # ENSURES:
 #   E1: under the Lock, counter == 2 in every schedule [mutual exclusion holds]
 import threading

--- a/regression/python/harness_threading_lock_mutex/test.desc
+++ b/regression/python/harness_threading_lock_mutex/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc --context-bound 2 --data-races-check
+--unwind 2 --context-bound 2 --data-races-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_threading_lock_mutex_fail/test.desc
+++ b/regression/python/harness_threading_lock_mutex_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc --context-bound 2 --data-races-check
+--unwind 2 --context-bound 2 --data-races-check
 ^VERIFICATION FAILED$


### PR DESCRIPTION
## Problem

The required check `static llvm-22 DebugOpt (ubuntu-24.04)` was intermittently failing on the single test `regression/python/harness_threading_lock_mutex`. When it **passes** it takes **114.68s / 117.53s** against the DebugOpt suite's hard **120s per-test cap** (`ESBMC_REGRESS_TIMEOUT=120`, which overrides `test.desc`), so any runner load tips it into a `TIMEOUT`. Because it is a *required* check under `strict` branch protection, it randomly blocked unrelated PRs (observed on #5995 and #6015 — a help-group reorder that cannot affect a data-race test), confirming it is environmental, not a regression.

## Fix

Swap `--incremental-bmc` for a fixed `--unwind 2` in both the pass and `_fail` `test.desc`. `--incremental-bmc` re-solves at every bound; the user code is loop-free and the threading model's `start`/`join` fully unroll within one step, so a single bounded solve is complete here.

**Soundness:** unwinding assertions stay **ON** (no `--no-unwinding-assertions`), so an insufficient bound would surface as `VERIFICATION FAILED`, never a false `SUCCESSFUL`. `--context-bound 2` and `--data-races-check` are unchanged, so the explored interleaving set — and the non-vacuous `_fail` twin — are identical to before. Only *how* the bound is reached changes, not *what* is proven.

## Validation

- Local cost halves: **18.6s -> 9.9s** (extrapolates CI ~115s -> ~55-60s, comfortable headroom under 120s).
- Verdicts unchanged and **dual-solver agreed (Bitwuzla + Z3)**: pass -> `SUCCESSFUL`, `_fail` -> `FAILED`.
- CPython sanity (`scripts/check_python_tests.sh`): pass exits 0, `_fail` exits non-zero.

The pass `main.py` gains a comment explaining the bounded-unwind choice so `--incremental-bmc` is not reintroduced.
