### PR TITLE
[irep2] Guard as_ulong/as_long against >64-bit truncation (R2)

### DIFF
--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -100,14 +100,20 @@ void expr2t::dump() const
 
 unsigned long constant_int2t::as_ulong() const
 {
-  // XXXjmorse - add assertion that we don't exceed machine word width?
   assert(!value.is_negative());
+  // Guard the documented truncation (R2): to_uint64() shifts every digit
+  // into a 64-bit accumulator, silently dropping the high digits when the
+  // magnitude exceeds 64 bits. is_uint64() is true iff the magnitude fits.
+  assert(value.is_uint64());
   return value.to_uint64();
 }
 
 long constant_int2t::as_long() const
 {
-  // XXXjmorse - add assertion that we don't exceed machine word width?
+  // Guard the documented truncation/overflow (R2): to_int64() negates the
+  // (possibly truncated) to_uint64() magnitude, so it is only correct when
+  // the value fits the signed 64-bit range. is_int64() is sign-aware.
+  assert(value.is_int64());
   return value.to_int64();
 }
 

--- a/src/util/expr_simplifier.cpp
+++ b/src/util/expr_simplifier.cpp
@@ -1648,11 +1648,13 @@ expr2tc index2t::do_simplify() const
       return expr2tc();
 
     const constant_array2t &arr = to_constant_array2t(src);
-    unsigned long the_idx = idx.as_ulong();
-    if (the_idx >= arr.datatype_members.size())
+    // Bound-check on the BigInt (correct at any width) before as_ulong(), so a
+    // wider-than-64-bit index bails out of simplification instead of being
+    // truncated — mirrors the constant_vector path below.
+    if (idx.value >= arr.datatype_members.size())
       return expr2tc();
 
-    return arr.datatype_members[the_idx];
+    return arr.datatype_members[idx.as_ulong()];
   }
 
   if (is_constant_vector2t(src) && is_constant_int2t(idx_e))
@@ -1680,13 +1682,14 @@ expr2tc index2t::do_simplify() const
       return expr2tc();
 
     const constant_string2t &str = to_constant_string2t(src);
-    unsigned long the_idx = idx.as_ulong();
-    if (the_idx >= str.array_size()) // allow reading null term.
+    // BigInt bound-check before as_ulong() (allow reading null term), so a
+    // wider-than-64-bit index bails rather than truncating.
+    if (idx.value >= str.array_size())
       return expr2tc();
 
     // String constants had better be some kind of integer type
     assert(is_bv_type(type));
-    expr2tc c = str.at(the_idx);
+    expr2tc c = str.at(idx.as_ulong());
     assert(c);
     return c;
   }

--- a/src/util/format_constant.cpp
+++ b/src/util/format_constant.cpp
@@ -2,17 +2,18 @@
 #include <util/format_constant.h>
 #include <util/ieee_float.h>
 #include <irep2/irep2_utils.h>
-#include <util/i2string.h>
+#include <util/mp_arith.h>
 
 std::string format_constantt::operator()(const expr2tc &expr)
 {
   if (is_constant_expr(expr))
   {
-    if (is_unsignedbv_type(expr))
-      return i2string(to_constant_int2t(expr).as_ulong());
-
-    if (is_signedbv_type(expr))
-      return i2string(to_constant_int2t(expr).as_long());
+    // Format the full-width value directly from the BigInt. Going through
+    // as_ulong()/as_long() would silently truncate any constant wider than
+    // 64 bits (e.g. __int128) to its low 64 bits (finding R2); integer2string
+    // prints the exact value at any width and handles the sign.
+    if (is_unsignedbv_type(expr) || is_signedbv_type(expr))
+      return integer2string(to_constant_int2t(expr).value);
 
     if (is_fixedbv_type(expr))
       return fixedbvt(to_constant_fixedbv2t(expr).value).format(*this);

--- a/unit/irep2/CMakeLists.txt
+++ b/unit/irep2/CMakeLists.txt
@@ -1,6 +1,7 @@
 new_unit_test(irep2test "irep2.test.cpp" "util_esbmc")
 new_unit_test(irep2refcounttest "refcount.test.cpp" "util_esbmc")
 new_fuzz_test(irep2refcountfuzz "refcount.fuzz.cpp" "util_esbmc")
+new_unit_test(irep2constinttest "const_int.test.cpp" "util_esbmc")
 
 # Microbenchmarks: built but not discovered as ctest cases. Run locally
 # with: ./unit/irep2/irep2bench '[bench]' to capture before/after numbers

--- a/unit/irep2/const_int.test.cpp
+++ b/unit/irep2/const_int.test.cpp
@@ -1,0 +1,128 @@
+// H-A6 — constant_int2t::as_ulong / as_long bounds (R2), verified against the
+// *actual* irep2 implementation (src/irep2/irep2_expr.cpp), not a model.
+//
+// as_ulong()/as_long() forward to BigInt::to_uint64()/to_int64(), which shift
+// every digit into a 64-bit accumulator and therefore SILENTLY TRUNCATE a
+// value whose magnitude exceeds 64 bits (finding R2 in
+// docs/irep2-verification-plan.md). This suite:
+//   * pins the correct round-trip contract for the full in-range boundary set
+//     on the real constant_int2t (would catch a regression in the conversion
+//     itself), and
+//   * documents the out-of-range behaviour both ways: in an asserts-on build
+//     the new is_uint64()/is_int64() guards fire (the value's precondition is
+//     shown false); in NDEBUG the guards are compiled out and the raw
+//     truncation is exhibited — the residual release-mode gap R2 records.
+
+#define CATCH_CONFIG_MAIN // Catch provides main() for this test executable
+#include <catch2/catch.hpp>
+
+#include <cstdint>
+#include <utility>
+
+#include <irep2/irep2.h>
+#include <irep2/irep2_expr.h>
+#include <irep2/irep2_utils.h>
+#include <util/c_types.h>
+#include <util/config.h>
+#include <util/format_constant.h>
+
+namespace
+{
+const constant_int2t &as_uint(BigInt v)
+{
+  static expr2tc held;
+  held = constant_int2tc(get_uint_type(64), std::move(v));
+  return to_constant_int2t(held);
+}
+
+const constant_int2t &as_int(BigInt v)
+{
+  static expr2tc held;
+  held = constant_int2tc(get_int_type(64), std::move(v));
+  return to_constant_int2t(held);
+}
+} // namespace
+
+TEST_CASE(
+  "constant_int2t::as_ulong round-trips every in-range value",
+  "[core][irep2][const_int]")
+{
+  config.ansi_c.word_size = 64;
+
+  REQUIRE(as_uint(BigInt(0u)).as_ulong() == 0u);
+  REQUIRE(as_uint(BigInt(1u)).as_ulong() == 1u);
+  REQUIRE(as_uint(BigInt(0x7fffffffu)).as_ulong() == 0x7fffffffu);
+  REQUIRE(
+    as_uint(BigInt(static_cast<BigInt::ullong_t>(INT64_MAX))).as_ulong() ==
+    static_cast<uint64_t>(INT64_MAX));
+  // Upper boundary: the largest value as_ulong may legitimately return.
+  REQUIRE(
+    as_uint(BigInt(static_cast<BigInt::ullong_t>(UINT64_MAX))).as_ulong() ==
+    UINT64_MAX);
+}
+
+TEST_CASE(
+  "constant_int2t::as_long round-trips the full signed range",
+  "[core][irep2][const_int]")
+{
+  config.ansi_c.word_size = 64;
+
+  REQUIRE(as_int(BigInt(0)).as_long() == 0);
+  REQUIRE(as_int(BigInt(1)).as_long() == 1);
+  REQUIRE(as_int(BigInt(-1)).as_long() == -1);
+  REQUIRE(
+    as_int(BigInt(static_cast<BigInt::llong_t>(INT64_MAX))).as_long() ==
+    INT64_MAX);
+  REQUIRE(
+    as_int(BigInt(static_cast<BigInt::llong_t>(INT64_MIN))).as_long() ==
+    INT64_MIN);
+}
+
+// R2: a magnitude just past the 64-bit boundary. The guards added to
+// as_ulong/as_long are is_uint64()/is_int64(); this pins that they correctly
+// classify the out-of-range value as NOT convertible, which is exactly the
+// precondition the (asserts-on) guard checks.
+TEST_CASE(
+  "constant_int2t rejects out-of-range magnitudes (R2 guard precondition)",
+  "[core][irep2][const_int]")
+{
+  config.ansi_c.word_size = 64;
+
+  const BigInt two_pow_64 =
+    BigInt(static_cast<BigInt::ullong_t>(UINT64_MAX)) + BigInt(1); // 2^64
+  const constant_int2t &big = as_uint(BigInt(two_pow_64));
+
+  REQUIRE_FALSE(big.value.is_uint64()); // as_ulong()'s guard would fire
+  REQUIRE_FALSE(big.value.is_int64());  // as_long()'s guard would fire
+
+#ifdef NDEBUG
+  // Guards compiled out: exhibit the raw truncation R2 records — 2^64 wraps
+  // to 0 in the 64-bit accumulator. (In an asserts-on build the guard aborts
+  // instead, so this call is only exercised under NDEBUG.)
+  REQUIRE(big.as_ulong() == 0u);
+#endif
+}
+
+// format_constantt previously printed unsigned/signed constants via
+// as_ulong()/as_long(), truncating anything wider than 64 bits (and, once
+// the R2 guards are added, aborting in asserts-on builds). It now formats the
+// full-width value straight from the BigInt. This pins that a 128-bit
+// constant prints its exact value rather than the low-64-bit truncation.
+TEST_CASE(
+  "format_constantt prints wide constants without truncation (R2)",
+  "[core][irep2][const_int]")
+{
+  config.ansi_c.word_size = 64;
+  format_constantt fmt;
+
+  // In-range values are unaffected.
+  REQUIRE(fmt(constant_int2tc(get_uint_type(64), BigInt(42u))) == "42");
+  REQUIRE(fmt(constant_int2tc(get_int_type(64), BigInt(-42))) == "-42");
+
+  // 2^64 in a 128-bit unsigned constant must print in full, not as "0".
+  const BigInt two_pow_64 =
+    BigInt(static_cast<BigInt::ullong_t>(UINT64_MAX)) + BigInt(1);
+  REQUIRE(
+    fmt(constant_int2tc(get_uint_type(128), two_pow_64)) ==
+    "18446744073709551616");
+}


### PR DESCRIPTION
Milestone **M1** of the [irep2 verification plan](https://github.com/esbmc/esbmc/blob/master/docs/irep2-verification-plan.md), finding **R2**: `constant_int2t::as_ulong()`/`as_long()` silently truncate magnitudes wider than 64 bits.

Guard both accessors with `BigInt`'s own `is_uint64()`/`is_int64()` preconditions, and make the wide-value callers safe first so the guards never fire on legitimate input: `format_constant.cpp` prints full width via `integer2string`, and `expr_simplifier.cpp` bound-checks constant array/string indices on the `BigInt` before converting. A Tier-B unit test (`unit/irep2/const_int.test.cpp`) pins the round-trip contract and the guard preconditions on the real `constant_int2t`.

Refs #6019
