### PR TITLE
[ir-ieee] propagate NaN through unary negation

### DIFF
--- a/regression/ir-ra/ra-neg-nan-fail/main.c
+++ b/regression/ir-ra/ra-neg-nan-fail/main.c
@@ -1,0 +1,15 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = sqrt(x);
+  double z = -y;
+  __ESBMC_assert(!isnan(z), "isnan(-NaN) must be false");
+  return 0;
+}

--- a/regression/ir-ra/ra-neg-nan-fail/test.desc
+++ b/regression/ir-ra/ra-neg-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-neg-nan/main.c
+++ b/regression/ir-ra/ra-neg-nan/main.c
@@ -1,0 +1,15 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = sqrt(x);
+  double z = -y;
+  __ESBMC_assert(isnan(z), "isnan(-NaN) must be true");
+  return 0;
+}

--- a/regression/ir-ra/ra-neg-nan/test.desc
+++ b/regression/ir-ra/ra-neg-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -1568,6 +1568,8 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     if (int_encoding)
     {
       a = mk_neg(args[0]);
+      if (ir_ieee && is_floatbv_type(neg.value))
+        ir_ieee_api->propagate_nan_pred(a, args[0]);
     }
     else if (is_floatbv_type(neg.value))
     {


### PR DESCRIPTION
## Summary

This PR propagates tracked NaN predicates through unary negation under `--ir-ieee`.

Previously, applying unary negation to a value with a tracked NaN predicate created a new SMT expression without copying the associated NaN metadata. As a result, operations such as `isnan(-x)` could no longer observe that the value was NaN, even though IEEE 754 semantics require unary negation to preserve NaN.

After this change, unary negation preserves the existing tracked NaN predicate.

## Motivation

Recent `--ir-ieee` work introduced NaN predicate tracking and propagation for selected IEEE operations. Classification predicates such as `isnan()`, `isfinite()`, `isnormal()`, and `isinf()` now correctly consult that metadata.

However, unary negation still lost the tracked NaN predicate.

For example:

```c
double x = __VERIFIER_nondet_double();
__ESBMC_assume(x == -1.0);

double y = sqrt(x);
double z = -y;

__ESBMC_assert(isnan(z), "negating NaN should remain NaN");
```

Before this fix, ESBMC reported:

```text
VERIFICATION FAILED
```

because the negated SMT expression carried no tracked NaN predicate. Although `sqrt(x)` had already been recorded as NaN by the `--ir-ieee` encoding, the fresh SMT node created by unary negation lost that metadata, allowing the solver to assign the result an arbitrary real value.

This PR preserves the existing NaN predicate across unary negation.

## Changes

This PR updates the `neg_id` handling in:

```text
src/solvers/smt/smt_solver.cpp
```

When integer/real floating-point encoding is enabled, the converter now propagates the operand's tracked NaN predicate immediately after constructing the negated SMT expression:

```cpp
a = mk_neg(args[0]);

if (ir_ieee && is_floatbv_type(neg.value))
  ir_ieee_api->propagate_nan_pred(a, args[0]);
```

This allows the existing propagation performed during assignment to preserve the NaN predicate on the destination variable.

The bitvector floating-point path is unchanged.

This PR does not introduce any new NaN sources or propagation rules. It only preserves already-tracked NaN predicates across unary negation.

## Regression Tests

Two new CORE regression tests were added under `regression/ir-ra/`:

* `ra-neg-nan`

  * Checks that `isnan(-NaN)` evaluates to true.
  * Expected result: `VERIFICATION SUCCESSFUL`.

* `ra-neg-nan-fail`

  * Failing companion test.
  * Checks that `!isnan(-NaN)` does not incorrectly hold.
  * Expected result: `VERIFICATION FAILED`.

The tests use nondeterministic operands constrained with `__ESBMC_assume` instead of compile-time constants. This avoids frontend constant folding and ensures the expressions reach the `--ir-ieee` SMT encoding path.

## Testing

The focused regression tests were run:

```bash
ctest --test-dir build -R "ra-neg-nan" --output-on-failure
```

Result:

```text
2/2 passed
```

The complete `ir-ra` regression suite was also executed:

```bash
ctest --test-dir build -L "ir-ra" -j$(nproc) --timeout 120
```

Result:

```text
182/182 passed
```

## Notes

This PR is intentionally limited to propagating already-tracked NaN predicates through unary negation under `--ir-ieee`.