### PR TITLE
[irep2] Add H-A4 BigInt CRC heap-path test

### DIFF
--- a/unit/irep2/CMakeLists.txt
+++ b/unit/irep2/CMakeLists.txt
@@ -1,4 +1,5 @@
 new_unit_test(irep2test "irep2.test.cpp" "util_esbmc")
+new_unit_test(irep2crcbiginttest "crc_bigint.test.cpp" "util_esbmc")
 new_unit_test(irep2refcounttest "refcount.test.cpp" "util_esbmc")
 new_fuzz_test(irep2refcountfuzz "refcount.fuzz.cpp" "util_esbmc")
 new_unit_test(irep2constinttest "const_int.test.cpp" "util_esbmc")

--- a/unit/irep2/crc_bigint.test.cpp
+++ b/unit/irep2/crc_bigint.test.cpp
@@ -1,0 +1,49 @@
+// H-A4: BigInt CRC ingestion (feed_bigint in irep2_crc.cpp). The magnitude is
+// dumped into a 256-byte stack buffer, growing a heap buffer by doubling when
+// the value is larger; the sign byte is fed first. This covers the multi-
+// doubling heap path (which the existing 512-byte case does not reach) and the
+// sign mixing on that path.
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <string>
+
+#include <big-int/bigint.hh>
+#include <irep2/irep2.h>
+#include <irep2/irep2_expr.h>
+#include <irep2/irep2_utils.h>
+#include <util/c_types.h>
+#include <util/config.h>
+
+namespace
+{
+size_t crc_of(const BigInt &v)
+{
+  return constant_int2tc(get_int_type(64), v)->crc();
+}
+} // namespace
+
+// ~1500 bytes of magnitude forces several doublings (256->512->1024->2048);
+// the resize loop must terminate and the CRC be deterministic and sensitive
+// to a byte well past the stack buffer.
+TEST_CASE("BigInt CRC over the multi-doubling heap path", "[core][irep2]")
+{
+  const std::string hex(3000, 'f');
+  const BigInt v(hex.c_str(), 16);
+
+  REQUIRE(crc_of(v) == crc_of(v));
+
+  std::string other = hex;
+  other.back() = 'e';
+  REQUIRE(crc_of(v) != crc_of(BigInt(other.c_str(), 16)));
+}
+
+// The sign byte is fed before the magnitude, so a value and its negation
+// differ even when the magnitude takes the heap path.
+TEST_CASE("BigInt CRC mixes sign on the heap path", "[core][irep2]")
+{
+  const std::string hex(3000, 'f');
+  const BigInt v(hex.c_str(), 16);
+  REQUIRE(crc_of(v) != crc_of(-v));
+}


### PR DESCRIPTION
Milestone M3 of the [irep2 verification plan](https://github.com/esbmc/esbmc/blob/master/docs/irep2-verification-plan.md) — harness H-A4 (BigInt CRC ingestion).

`feed_bigint` (`irep2_crc.cpp`) dumps a BigInt magnitude into a 256-byte stack buffer and grows a heap buffer by doubling for larger values, feeding a sign byte first. The existing `irep2.test.cpp` case (512-byte magnitude) fits on the first heap allocation and never runs the resize loop. This adds a Tier-B test with a ~1500-byte magnitude (forcing 256->512->1024->2048 — two resizes), checking that:

- the resize loop terminates and the CRC is deterministic across it;
- the CRC is sensitive to a byte well past the stack buffer;
- the sign is still mixed on the heap path (a value and its negation differ).

Pure verification of existing behaviour; no source change. clang-format-11 clean.

Refs #6019