### PR TITLE
[k-induction] Make --termination take priority over k-induction

### DIFF
--- a/regression/termination/github_6031-terminating/main.c
+++ b/regression/termination/github_6031-terminating/main.c
@@ -1,0 +1,15 @@
+extern int __VERIFIER_nondet_int(void);
+
+// Companion to github_6031: a terminating program under the same flag
+// combination (--termination --k-induction-parallel). The loop always
+// terminates, so the sequential termination strategy (which --termination
+// now routes to instead of the parallel driver) must report VERIFICATION
+// SUCCESSFUL. This pins that the priority routing is not a blanket "always
+// FAILED".
+int main()
+{
+  int n = __VERIFIER_nondet_int();
+  while (n < 10)
+    n++;
+  return 0;
+}

--- a/regression/termination/github_6031-terminating/test.desc
+++ b/regression/termination/github_6031-terminating/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--termination --k-induction-parallel
+Both k-induction and --termination specified. Using --termination.
+^VERIFICATION SUCCESSFUL$

--- a/regression/termination/github_6031/main.c
+++ b/regression/termination/github_6031/main.c
@@ -1,0 +1,27 @@
+#include <stdbool.h>
+
+// Regression for issue #6031: combining --termination with
+// --k-induction-parallel produced non-deterministic, sometimes unsound
+// VERIFICATION SUCCESSFUL. The program does not terminate (the while(true)
+// loop never exits), so --termination must report VERIFICATION FAILED
+// deterministically. --termination now takes priority over the parallel
+// k-induction driver, which has no termination-property interpretation.
+int a;
+int main()
+{
+  while (true)
+  {
+    if (a == 0)
+      a = 1;
+    else if (a == 1)
+      a = 2;
+    else if (a == 2)
+    {
+      if (true)
+        a = 3;
+    }
+    else
+      __VERIFIER_error();
+  }
+  return 0;
+}

--- a/regression/termination/github_6031/test.desc
+++ b/regression/termination/github_6031/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--termination --k-induction-parallel
+Both k-induction and --termination specified. Using --termination.
+^VERIFICATION FAILED$

--- a/src/esbmc/parseoptions/command_line_options.cpp
+++ b/src/esbmc/parseoptions/command_line_options.cpp
@@ -551,14 +551,15 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     cmdline.isset("check-vacuity") || cmdline.isset("loop-invariant-check"))
     options.set_option("check-vacuity", true);
 
-  // Check for conflicting strategies
-  if (cmdline.isset("k-induction") && cmdline.isset("termination"))
+  // Conflicting strategies: --termination checks a different property and
+  // takes priority over k-induction. Disable both k-induction variants so
+  // only the termination strategy runs (#6031).
+  if (options.is_kind() && cmdline.isset("termination"))
   {
     log_warning(
-      "Both --k-induction and --termination specified. "
-      "Using --k-induction (which does not include termination checking).");
-    // Optionally disable termination flag
-    options.set_option("termination", false);
+      "Both k-induction and --termination specified. Using --termination.");
+    options.set_option("k-induction", false);
+    options.set_option("k-induction-parallel", false);
   }
 
   // interval-symex-guard is designed for plain BMC loop-counter tracking.

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -205,7 +205,10 @@ int esbmc_parseoptionst::doit()
   // Eventually we will modify it and implement parallel version for all
   // available strategies. Just run it first before everything else
   // for now.
-  if (cmdline.isset("k-induction-parallel"))
+  //
+  // The parallel driver has no termination interpretation, so --termination
+  // takes priority: fall through to the sequential strategy instead (#6031).
+  if (cmdline.isset("k-induction-parallel") && !cmdline.isset("termination"))
     return doit_k_induction_parallel();
 
   // Parse ESBMC options (CMD + set internal options)

--- a/src/esbmc/parseoptions/process_goto_program.cpp
+++ b/src/esbmc/parseoptions/process_goto_program.cpp
@@ -259,9 +259,12 @@ bool esbmc_parseoptionst::process_goto_program(
       }
     }
 
-    bool is_k_induction = cmdline.isset("inductive-step") ||
-                          cmdline.isset("k-induction") ||
-                          cmdline.isset("k-induction-parallel");
+    // Under --termination, goto_termination does its own havoc, so
+    // goto_k_induction must not also run (#6031).
+    bool is_k_induction =
+      (cmdline.isset("inductive-step") || cmdline.isset("k-induction") ||
+       cmdline.isset("k-induction-parallel")) &&
+      !options.get_bool_option("termination");
 
     // --termination reuses k-induction's havoc machinery via
     // goto_termination, so the post-havoc invariant injection applies


### PR DESCRIPTION
The parallel k-induction driver interprets its results as assertion reachability and has no termination handling, so combining it with --termination produced non-deterministic and sometimes unsound VERIFICATION SUCCESSFUL for a failing program (#6031).

Make --termination take priority over both k-induction variants (inverting the previous k-induction-wins rule) so the run routes to the sequential termination strategy and the verdict is deterministic. Adds two regression tests.

Fixes #6031