### PR TITLE
[irep2] Fix -Wdangling-reference false positive in const_int test

### DIFF
--- a/unit/irep2/const_int.test.cpp
+++ b/unit/irep2/const_int.test.cpp
@@ -85,7 +85,7 @@ TEST_CASE(
 
   const BigInt two_pow_64 =
     BigInt(static_cast<BigInt::ullong_t>(UINT64_MAX)) + BigInt(1); // 2^64
-  const constant_int2t &big = as_uint(BigInt(two_pow_64));
+  const constant_int2t big = as_uint(BigInt(two_pow_64));
 
   REQUIRE_FALSE(big.value.is_uint64()); // as_ulong()'s guard would fire
   REQUIRE_FALSE(big.value.is_int64());  // as_long()'s guard would fire


### PR DESCRIPTION
The `static llvm-22 DebugOpt` build (GCC 13+, `-Werror`) is failing on `master`:

```
unit/irep2/const_int.test.cpp:93:25: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
```

The test helper `as_uint()` returns `constant_int2t` **by value**, but its result was bound to a `const constant_int2t &`. GCC's `-Wdangling-reference` heuristic flags this even though reference-lifetime-extension makes it safe — a well-known false positive for references bound to by-value function returns.

Copy the value instead of binding a reference. Semantically identical, and the warning disappears. This unblocks the DebugOpt build (also surfacing in every open PR, e.g. #6034).

Test still builds and passes locally:
```
All tests passed (16 assertions in 4 test cases)
```