### PR TITLE
[ir-ieee] propagate NaN through conditional expressions

### DIFF
--- a/regression/ir-ra/ra-ite-nan-false-fail/main.c
+++ b/regression/ir-ra/ra-ite-nan-false-fail/main.c
@@ -1,0 +1,18 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = sqrt(x);
+  int c = __VERIFIER_nondet_int();
+  __ESBMC_assume(c < 0);
+  double z = (c > 0) ? 0.0 : y;
+  __ESBMC_assert(!isnan(z), "false branch NaN: z must not be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-ite-nan-false-fail/test.desc
+++ b/regression/ir-ra/ra-ite-nan-false-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-ite-nan-false/main.c
+++ b/regression/ir-ra/ra-ite-nan-false/main.c
@@ -1,0 +1,18 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = sqrt(x);
+  int c = __VERIFIER_nondet_int();
+  __ESBMC_assume(c < 0);
+  double z = (c > 0) ? 0.0 : y;
+  __ESBMC_assert(isnan(z), "false branch NaN: z must be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-ite-nan-false/test.desc
+++ b/regression/ir-ra/ra-ite-nan-false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-ite-nan-true-fail/main.c
+++ b/regression/ir-ra/ra-ite-nan-true-fail/main.c
@@ -1,0 +1,18 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = sqrt(x);
+  int c = __VERIFIER_nondet_int();
+  __ESBMC_assume(c != 0);
+  double z = c ? y : 0.0;
+  __ESBMC_assert(!isnan(z), "true branch NaN: z must not be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-ite-nan-true-fail/test.desc
+++ b/regression/ir-ra/ra-ite-nan-true-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-ite-nan-true/main.c
+++ b/regression/ir-ra/ra-ite-nan-true/main.c
@@ -1,0 +1,18 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = sqrt(x);
+  int c = __VERIFIER_nondet_int();
+  __ESBMC_assume(c != 0);
+  double z = c ? y : 0.0;
+  __ESBMC_assert(isnan(z), "true branch NaN: z must be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-ite-nan-true/test.desc
+++ b/regression/ir-ra/ra-ite-nan-true/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-ite-non-nan/main.c
+++ b/regression/ir-ra/ra-ite-non-nan/main.c
@@ -1,0 +1,18 @@
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0;
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = sqrt(x);
+  int c = __VERIFIER_nondet_int();
+  __ESBMC_assume(c != 0);
+  double z = c ? 0.0 : y;
+  __ESBMC_assert(!isnan(z), "non-NaN branch selected: z must not be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-ite-non-nan/test.desc
+++ b/regression/ir-ra/ra-ite-non-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -1116,6 +1116,17 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     args[1] = convert_ast(if_ref.true_value);
     args[2] = convert_ast(if_ref.false_value);
     a = args[1]->ite(this, args[0], args[2]);
+    if (ir_ieee && is_floatbv_type(expr->type))
+    {
+      smt_astt np_t = ir_ieee_api->get_nan_pred(args[1]);
+      smt_astt np_f = ir_ieee_api->get_nan_pred(args[2]);
+      if (np_t || np_f)
+      {
+        smt_astt t = np_t ? np_t : mk_smt_bool(false);
+        smt_astt f = np_f ? np_f : mk_smt_bool(false);
+        ir_ieee_api->store_nan_pred(a, mk_ite(args[0], t, f));
+      }
+    }
     break;
   }
   case expr2t::isnan_id:


### PR DESCRIPTION
## Summary

This PR propagates tracked NaN predicates through conditional (`?:`) expressions under `--ir-ieee`.

Previously, when a conditional expression produced a floating-point value with a tracked NaN predicate, the SMT ITE expression created during lowering did not inherit that predicate. As a result, operations such as `isnan()` applied to the conditional result could no longer observe that the selected branch was NaN, even though the program semantics required it.

After this change, conditional expressions preserve tracked NaN predicates from the selected branch.

## Motivation

Recent `--ir-ieee` work introduced NaN predicate tracking and propagation for IEEE floating-point operations. Classification predicates such as `isnan()`, `isfinite()`, `isnormal()`, and `isinf()` now correctly consult that metadata, and recent fixes extended propagation through unary negation and `fabs()`.

However, conditional expressions still lost tracked NaN predicates.

For example:

```c
double x = __VERIFIER_nondet_double();
__ESBMC_assume(x == -1.0);

double y = sqrt(x);   /* NaN */

int c = __VERIFIER_nondet_int();
__ESBMC_assume(c != 0);

double z = c ? y : 0.0;

__ESBMC_assert(isnan(z), "selected branch is NaN");
```

Before this fix, ESBMC reported **VERIFICATION FAILED** because the SMT ITE node carried no associated NaN predicate. The downstream assignment therefore propagated no NaN metadata to `z`, allowing the solver to treat `z` as an unconstrained real value instead of a tracked NaN.

## Changes

In `src/solvers/smt/smt_solver.cpp`, the `if_id` conversion now propagates NaN predicates to the SMT ITE expression:

```cpp
a = args[1]->ite(this, args[0], args[2]);

if (ir_ieee && is_floatbv_type(expr->type))
{
    smt_astt np_t = ir_ieee_api->get_nan_pred(args[1]);
    smt_astt np_f = ir_ieee_api->get_nan_pred(args[2]);

    if (np_t || np_f)
        ir_ieee_api->store_nan_pred(
            a,
            mk_ite(args[0],
                   np_t ? np_t : mk_smt_bool(false),
                   np_f ? np_f : mk_smt_bool(false)));
}
```

The stored predicate mirrors the semantics of the conditional expression:

```text
nan_pred(result) =
    ite(condition,
        nan_pred(true_branch),
        nan_pred(false_branch))
```

If one branch has no tracked NaN predicate, it contributes `false`. This ensures the resulting predicate reflects whichever branch is selected at runtime.

The bitvector floating-point path is unchanged.

## Regression Tests

Five new CORE regression tests were added under `regression/ir-ra/`:

| Test | Purpose | Expected result |
|------|---------|-----------------|
| `ra-ite-nan-true` | NaN selected from the true branch | `VERIFICATION SUCCESSFUL` |
| `ra-ite-nan-true-fail` | Negative companion for the true branch | `VERIFICATION FAILED` |
| `ra-ite-nan-false` | NaN selected from the false branch | `VERIFICATION SUCCESSFUL` |
| `ra-ite-nan-false-fail` | Negative companion for the false branch | `VERIFICATION FAILED` |
| `ra-ite-non-nan` | Non-NaN branch selected | `VERIFICATION SUCCESSFUL` |

All tests generate NaN via:

```c
double x = __VERIFIER_nondet_double();
__ESBMC_assume(x == -1.0);
double y = sqrt(x);
```

This avoids frontend constant folding and exercises the `--ir-ieee` SMT encoding path directly.

## Testing

```bash
ctest --test-dir build -R "ra-ite" --output-on-failure
```

```
5/5 passed
```

```bash
ctest --test-dir build -L "ir-ra" -j$(nproc) --timeout 120
```

```
189/189 passed
```

## Notes

This PR is intentionally limited to propagating already-tracked NaN predicates through conditional expressions under `--ir-ieee`.