### PR TITLE
[docs] add Code Comments guideline to reduce comment noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,14 @@ Before implementing any feature or bug fix, always work on a dedicated branch:
 - After implementation, simplify and clean up the code aggressively — remove unnecessary conditional checks while ensuring correctness.
 - Run ESBMC over your solution to formally check that it works and does not introduce new errors.
 
+## Code Comments
+
+Write few comments — favour self-explanatory code (clear names, small functions) over narration. Keep added comments to a minimum in PRs; excess comments are noise reviewers must wade through.
+
+- **Do not** restate what the code plainly does (`i++; // increment i`), label structure (`// constructor`, `// helpers`), narrate the change or its history (`// added null check`, `// was: foo()`), or echo a function/variable name in prose.
+- **Do** comment only when it adds what the code cannot convey: a non-obvious *why* (rationale, trade-off, workaround with an issue/PR link), a caveat or invariant a caller must respect, a citation to the C/C++ standard or a solver/algorithm detail, or genuinely subtle logic. One line beats a paragraph.
+- Preserve existing meaningful comments and the file's established doc conventions (e.g. Doxygen-style headers where already used). Match the surrounding comment density rather than exceeding it.
+
 ## Post-implementation Pass
 
 After implementing any non-trivial coding task, before committing:


### PR DESCRIPTION
## What

Adds a **Code Comments** section to `CLAUDE.md` (mirrored to `AGENTS.md` via its existing symlink) instructing coding agents to write few comments and favour self-explanatory code.

## Why

Agent-generated PRs tend to over-comment — restating what the code plainly does, labelling structure, and narrating the change history. This adds noise that reviewers must wade through and that rots as the code evolves. The new guideline draws a clear line between comments that add nothing and comments that capture what the code cannot convey (a non-obvious *why*, caller-facing invariants, standard/solver citations, genuinely subtle logic), while preserving existing meaningful comments and established doc conventions.

## Notes

- Docs-only change; no code or tests affected.
- `AGENTS.md` is a symlink to `CLAUDE.md`, so both stay in sync automatically.