### PR TITLE
[ir-ieee] implement nearbyint for real arithmetic

### DIFF
--- a/regression/ir-ra/ra-nearbyint-integral/main.c
+++ b/regression/ir-ra/ra-nearbyint-integral/main.c
@@ -1,0 +1,15 @@
+/* Already-integral input: nearbyint(3.0) == 3.0 under any rounding mode */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 3.0);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == 3.0, "nearbyint of an integer returns that integer");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-integral/test.desc
+++ b/regression/ir-ra/ra-nearbyint-integral/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-nan/main.c
+++ b/regression/ir-ra/ra-nearbyint-nan/main.c
@@ -1,0 +1,15 @@
+/* NaN propagation: nearbyint(sqrt(-1)) must be NaN */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.0);
+  double y = nearbyint(sqrt(x));
+  __ESBMC_assert(isnan(y), "nearbyint of NaN is NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-nan/test.desc
+++ b/regression/ir-ra/ra-nearbyint-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rta-tie-neg/main.c
+++ b/regression/ir-ra/ra-nearbyint-rta-tie-neg/main.c
@@ -1,0 +1,15 @@
+/* RTA tie at -0.5: negative, round away from zero -> -1 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -0.5);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == -1.0, "RTA: tie at -0.5 rounds away from zero to -1");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rta-tie-neg/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rta-tie-neg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rta-tie-pos/main.c
+++ b/regression/ir-ra/ra-nearbyint-rta-tie-pos/main.c
@@ -1,0 +1,15 @@
+/* RTA tie at 0.5: positive, round away from zero -> 1 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 0.5);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == 1.0, "RTA: tie at 0.5 rounds away from zero to 1");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rta-tie-pos/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rta-tie-pos/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rte-fail/main.c
+++ b/regression/ir-ra/ra-nearbyint-rte-fail/main.c
@@ -1,0 +1,15 @@
+/* Failing companion: RTE rounds x in (0.5,1.5) to 1, so assert != 1 must fail */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.5 && x < 1.5);
+  double y = nearbyint(x);
+  __ESBMC_assert(y != 1.0, "should be unreachable");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rte-fail/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rte-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-nearbyint-rte-tie-15/main.c
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-15/main.c
@@ -1,0 +1,15 @@
+/* RTE tie at 1.5: floor=1 (odd) so round up to 2 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 1.5);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == 2.0, "RTE tie at 1.5 rounds to 2");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rte-tie-15/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-15/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rte-tie-25/main.c
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-25/main.c
@@ -1,0 +1,15 @@
+/* RTE tie at 2.5: floor=2 (even) so stay at 2 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == 2.5);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == 2.0, "RTE tie at 2.5 rounds to 2");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rte-tie-25/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-25/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rte-tie-neg15/main.c
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-neg15/main.c
@@ -1,0 +1,15 @@
+/* RTE tie at -1.5: floor=-2 (even) so stay at -2 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -1.5);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == -2.0, "RTE tie at -1.5 rounds to -2");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rte-tie-neg15/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-neg15/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rte-tie-neg25/main.c
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-neg25/main.c
@@ -1,0 +1,15 @@
+/* RTE tie at -2.5: floor=-3 (odd) so round up to -2 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x == -2.5);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == -2.0, "RTE tie at -2.5 rounds to -2");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rte-tie-neg25/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rte-tie-neg25/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rtn-neg/main.c
+++ b/regression/ir-ra/ra-nearbyint-rtn-neg/main.c
@@ -1,0 +1,15 @@
+/* RTN (round toward -inf): x in (-2,-1) -> -2 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > -2.0 && x < -1.0);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == -2.0, "RTN: nearbyint of (-2,-1) is -2");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rtn-neg/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rtn-neg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rtn-pos/main.c
+++ b/regression/ir-ra/ra-nearbyint-rtn-pos/main.c
@@ -1,0 +1,15 @@
+/* RTN (round toward -inf): x in (1,2) -> 1 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 1.0 && x < 2.0);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == 1.0, "RTN: nearbyint of (1,2) is 1");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rtn-pos/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rtn-pos/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rtp-neg/main.c
+++ b/regression/ir-ra/ra-nearbyint-rtp-neg/main.c
@@ -1,0 +1,15 @@
+/* RTP (round toward +inf): x in (-2,-1) -> -1 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > -2.0 && x < -1.0);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == -1.0, "RTP: nearbyint of (-2,-1) is -1");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rtp-neg/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rtp-neg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rtp-pos/main.c
+++ b/regression/ir-ra/ra-nearbyint-rtp-pos/main.c
@@ -1,0 +1,15 @@
+/* RTP (round toward +inf): x in (0,1) -> 1 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.0 && x < 1.0);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == 1.0, "RTP: nearbyint of (0,1) is 1");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rtp-pos/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rtp-pos/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rtz-neg/main.c
+++ b/regression/ir-ra/ra-nearbyint-rtz-neg/main.c
@@ -1,0 +1,15 @@
+/* RTZ (truncate toward 0): x in (-2,-1) -> -1 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > -2.0 && x < -1.0);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == -1.0, "RTZ: nearbyint of (-2,-1) is -1");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rtz-neg/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rtz-neg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nearbyint-rtz-pos/main.c
+++ b/regression/ir-ra/ra-nearbyint-rtz-pos/main.c
@@ -1,0 +1,15 @@
+/* RTZ (truncate toward 0): x in (1,2) -> 1 */
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 1.0 && x < 2.0);
+  double y = nearbyint(x);
+  __ESBMC_assert(y == 1.0, "RTZ: nearbyint of (1,2) is 1");
+  return 0;
+}

--- a/regression/ir-ra/ra-nearbyint-rtz-pos/test.desc
+++ b/regression/ir-ra/ra-nearbyint-rtz-pos/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -1117,9 +1117,77 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
   case expr2t::nearbyint_id:
   {
     assert(is_floatbv_type(expr));
-    a = fp_api->mk_smt_nearbyint_from_float(
-      convert_ast(to_nearbyint2t(expr).from),
-      convert_rounding_mode(to_nearbyint2t(expr).rounding_mode));
+    if (int_encoding)
+    {
+      const nearbyint2t &ni = to_nearbyint2t(expr);
+      const expr2tc &rm = ni.rounding_mode;
+      smt_astt operand = convert_ast(ni.from);
+
+      smt_astt zero = mk_smt_real("0");
+      smt_astt one = mk_smt_real("1");
+      smt_astt half = mk_smt_real("0.5");
+
+      // floor(x): SMT real2int rounds toward -inf; lift back to Real.
+      smt_astt floor_v = mk_int2real(mk_real2int(operand));
+      // ceil(x): floor+1 unless x is already integral.
+      smt_astt ceil_v =
+        mk_ite(mk_isint(operand), operand, mk_add(floor_v, one));
+      // Fractional part in [0,1) for all real x (also negative).
+      smt_astt frac = mk_sub(operand, floor_v);
+
+      if (smt_fp_rounding_utils::is_round_to_minus_inf(rm))
+      {
+        a = floor_v;
+      }
+      else if (smt_fp_rounding_utils::is_round_to_plus_inf(rm))
+      {
+        a = ceil_v;
+      }
+      else if (smt_fp_rounding_utils::is_round_to_zero(rm))
+      {
+        // Reuse existing RTZ helper; its integer result is lifted to Real.
+        a = mk_int2real(round_real_to_int(operand));
+      }
+      else if (smt_fp_rounding_utils::is_nearest_rounding_mode(rm))
+      {
+        // Round half to even: tie goes to whichever of floor, floor+1 is even.
+        // floor/2 is an integer iff floor is even — works for negative floors too
+        // (e.g. -2/2 = -1: integer = even; -3/2 = -1.5: not integer = odd).
+        smt_astt two = mk_smt_real("2");
+        smt_astt floor_is_even = mk_isint(mk_div(floor_v, two));
+        smt_astt tie_rte = mk_ite(floor_is_even, floor_v, mk_add(floor_v, one));
+        a = mk_ite(
+          mk_lt(frac, half),
+          floor_v,
+          mk_ite(mk_gt(frac, half), mk_add(floor_v, one), tie_rte));
+      }
+      else if (smt_fp_rounding_utils::is_round_to_away(rm))
+      {
+        // At a 0.5 tie, round toward the integer farther from zero:
+        //   x >= 0: ceil is farther  -> use strict-less so tie picks ceil.
+        //   x <  0: floor is farther -> use <=      so tie picks floor.
+        smt_astt away_pos = mk_ite(mk_lt(frac, half), floor_v, ceil_v);
+        smt_astt away_neg = mk_ite(mk_le(frac, half), floor_v, ceil_v);
+        a = mk_ite(mk_le(zero, operand), away_pos, away_neg);
+      }
+      else
+      {
+        // Symbolic or unsupported rounding mode: produce an unconstrained
+        // integer-valued Real (sound but non-deterministically chosen).
+        smt_astt fresh = mk_fresh(mk_real_sort(), "ra_nearbyint::", nullptr);
+        assert_ast(mk_isint(fresh));
+        a = fresh;
+      }
+
+      if (ir_ieee)
+        ir_ieee_api->propagate_nan_pred(a, operand);
+    }
+    else
+    {
+      a = fp_api->mk_smt_nearbyint_from_float(
+        convert_ast(to_nearbyint2t(expr).from),
+        convert_rounding_mode(to_nearbyint2t(expr).rounding_mode));
+    }
     break;
   }
   case expr2t::if_id:


### PR DESCRIPTION
## Summary

This PR implements `nearbyint()` under `--ir-ieee` using SMT real arithmetic.

Previously, `nearbyint()` always followed the bitvector floating-point path, even when `--ir-ieee` was enabled. Since the real-arithmetic encoding represents floating-point values as SMT `Real` rather than IEEE floating-point sorts, this resulted in an invalid solver call and caused ESBMC to crash.

This change adds a dedicated real-arithmetic implementation for `nearbyint()` under `--ir-ieee`, while leaving the existing bitvector floating-point path unchanged.

## Motivation

The `--ir-ieee` encoding already supports IEEE-aware handling of floating-point values using SMT real arithmetic. However, `nearbyint()` still unconditionally invoked the bitvector floating-point API, which expects an SMT floating-point sort.

For example:

```c
#include <math.h>

extern int __ESBMC_rounding_mode;
extern double __VERIFIER_nondet_double(void);

int main(void)
{
  __ESBMC_rounding_mode = 0;

  double x = __VERIFIER_nondet_double();
  __ESBMC_assume(x == 2.7);

  double y = nearbyint(x);

  __ESBMC_assert(y == 3.0, "nearest-even rounding");
  return 0;
}
```

Before this change, ESBMC crashed while encoding `nearbyint()` under `--ir-ieee`.

Functions that rely on `nearbyint()` internally—including `floor()`, `ceil()`, `trunc()`, and `rint()`—reached the same unsupported encoding path and crashed for the same reason. This fix provides the shared real-arithmetic implementation required by those operations.

## Changes

In `src/solvers/smt/smt_solver.cpp`, the `nearbyint_id` conversion now detects the integer/real floating-point encoding and performs rounding directly using SMT integer and real operations instead of invoking the floating-point backend.

The implementation first constructs:

```text
floor(x) = int2real(real2int(x))
```

and:

```text
ceil(x) = ite(isint(x), x, floor(x) + 1)
```

It then implements the supported ESBMC rounding modes:

- Round to nearest, ties to even (RTE)
- Round to nearest, ties away from zero (RTA)
- Round toward zero (RTZ)
- Round toward positive infinity (RTP)
- Round toward negative infinity (RTN)

For RTE, ties are resolved by checking whether the lower integer is even. For RTZ, the implementation reuses the existing `round_real_to_int()` helper and lifts the integer result back to SMT `Real`.

If the rounding mode is symbolic or unsupported, the implementation returns a fresh integer-valued SMT real as a sound over-approximation.

Tracked NaN predicates are also propagated from the operand to the result:

```cpp
if (ir_ieee)
  ir_ieee_api->propagate_nan_pred(a, operand);
```

The existing bitvector floating-point implementation remains unchanged.

## Regression Tests

Fifteen new CORE regression tests were added under `regression/ir-ra/`:

| Test | Purpose | Expected result |
|------|---------|-----------------|
| `ra-nearbyint-rte-tie-15` | RTE: `1.5` rounds to `2.0` | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rte-tie-25` | RTE: `2.5` rounds to `2.0` | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rte-tie-neg15` | RTE: `-1.5` rounds to `-2.0` | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rte-tie-neg25` | RTE: `-2.5` rounds to `-2.0` | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rta-tie-pos` | RTA: `0.5` rounds away from zero to `1.0` | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rta-tie-neg` | RTA: `-0.5` rounds away from zero to `-1.0` | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rtp-pos` | RTP for a positive non-integral value | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rtp-neg` | RTP for a negative non-integral value | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rtn-pos` | RTN for a positive non-integral value | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rtn-neg` | RTN for a negative non-integral value | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rtz-pos` | RTZ for a positive non-integral value | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rtz-neg` | RTZ for a negative non-integral value | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-integral` | An already-integral value remains unchanged | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-nan` | `nearbyint(NaN)` remains NaN | `VERIFICATION SUCCESSFUL` |
| `ra-nearbyint-rte-fail` | Failing companion for the RTE interval case | `VERIFICATION FAILED` |

The tests use nondeterministic operands constrained with `__ESBMC_assume()` so the expressions reach the `--ir-ieee` SMT encoding path instead of being simplified as compile-time constants.

## Testing

The focused `nearbyint` regression tests were run:

```bash
ctest --test-dir build -R "ra-nearbyint" --output-on-failure
```

Result:

```text
15/15 passed
```

The complete `ir-ra` regression suite was also run:

```bash
ctest --test-dir build -L "ir-ra" -j$(nproc) --timeout 120
```

Result:

```text
204/204 passed
```

## Notes

This PR is intentionally limited to implementing the shared `nearbyint()` real-arithmetic encoding used under `--ir-ieee`.

It does not modify the existing bitvector floating-point implementation, introduce new NaN sources, change arithmetic interval-enclosure rules, or add separate encodings for `floor()`, `ceil()`, `trunc()`, or `rint()`. Those functions benefit indirectly when their operational models reach the corrected `nearbyint()` path.