### PR TITLE
[regression] Fix neurosym logic-qf-bv expected status string

### DIFF
--- a/regression/neurosym/logic-qf-bv/test.desc
+++ b/regression/neurosym/logic-qf-bv/test.desc
@@ -3,4 +3,4 @@ main.c
 --neurosym --smt-formula-only
 \(set-logic QF_BV\)
 \(check-sat\)
-SMT formula dumped successfully
+SMT formula written to standard output


### PR DESCRIPTION
PR #6060 changed `smtlib_convt::dump_smt()` to emit `SMT formula written to standard output` and return an empty string, but the `neurosym/logic-qf-bv` test still expected the old `SMT formula dumped successfully` text. Under `--neurosym --smt-formula-only` the backend delegates to that base dump path, so the test now matches the current message. This unblocks the neurosym test that is red on master and failing CI on every open PR.
