### PR TITLE
[python] Process module imports under --function

### DIFF
--- a/regression/python/github_5898_itertools/test.desc
+++ b/regression/python/github_5898_itertools/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --function first_n --no-bounds-check
-^ERROR: Could not resolve type of receiver in member call
+^ERROR: Cannot open file:.*itertools\.json$

--- a/regression/python/github_5937/main.py
+++ b/regression/python/github_5937/main.py
@@ -1,0 +1,5 @@
+import simple
+
+
+def main() -> None:
+    assert simple.add(1, 2) == 3

--- a/regression/python/github_5937/simple.py
+++ b/regression/python/github_5937/simple.py
@@ -1,0 +1,2 @@
+def add(a: int, b: int) -> int:
+    return a + b

--- a/regression/python/github_5937/test.desc
+++ b/regression/python/github_5937/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
---function pick_one --no-bounds-check
+--function main --incremental-bmc
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5937_fail/main.py
+++ b/regression/python/github_5937_fail/main.py
@@ -1,0 +1,5 @@
+import simple
+
+
+def main() -> None:
+    assert simple.add(1, 2) == 4

--- a/regression/python/github_5937_fail/simple.py
+++ b/regression/python/github_5937_fail/simple.py
@@ -1,0 +1,2 @@
+def add(a: int, b: int) -> int:
+    return a + b

--- a/regression/python/github_5937_fail/test.desc
+++ b/regression/python/github_5937_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--function main --incremental-bmc
+
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -92,6 +92,7 @@ ignored_dirs=(
   "github_4666_2d"
   "github_4666_shape"
   "github_5102_nested_list_copy"
+  "github_5937_fail"
   "torch_mm_allclose"
   "global"
   "infer-func-no-return_fail"

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -244,7 +244,8 @@ std::string python_annotation<Json>::resolve_subscript_type(
       if (
         !idx_node.empty() && idx_node.contains("annotation") &&
         !idx_node["annotation"].is_null() &&
-        extract_type_info(idx_node["annotation"], idx_base_type, idx_element_type) &&
+        extract_type_info(
+          idx_node["annotation"], idx_base_type, idx_element_type) &&
         idx_base_type == "list")
         slice_is_list_var = true;
       // No (or non-list) annotation resolved -- idx may still be an
@@ -4152,6 +4153,7 @@ template <class Json>
 void python_annotation<Json>::add_type_annotation(const std::string &func_name)
 {
   current_line_ = 0;
+  annotating_function_entry_point_ = true;
 
   for (Json &elem : ast_["body"])
   {
@@ -4530,16 +4532,22 @@ void python_annotation<Json>::add_annotation(Json &body)
       continue;
     }
 
-    const std::string function_flag = config.options.get_option("function");
-    if (!function_flag.empty())
+    if (annotating_function_entry_point_)
     {
       if (
         stmt_type == "Expr" && element.contains("value") &&
         element["value"]["_type"] == "Call" &&
         element["value"]["func"]["_type"] == "Name")
       {
-        auto &func_node = json_utils::find_function(
-          ast_["body"], element["value"]["func"]["id"]);
+        // Use the const overload (returns by value, empty on a miss)
+        // rather than the non-const one (returns by reference, throws on a
+        // miss): the callee named here need not be a top-level FunctionDef
+        // in this same ast_ (it could be a builtin or something resolved
+        // elsewhere), and this is a best-effort forward-reference scan, not
+        // a hard requirement.
+        const Json &top_level_body = ast_["body"];
+        Json func_node = json_utils::find_function(
+          top_level_body, element["value"]["func"]["id"]);
         if (!func_node.empty())
           add_annotation(func_node);
       }

--- a/src/python-frontend/python_annotation/python_annotation.h
+++ b/src/python-frontend/python_annotation/python_annotation.h
@@ -265,6 +265,13 @@ private:
   int current_line_;
   std::string python_filename_;
   bool filter_global_elements_ = false;
+  // True only while add_type_annotation(func_name) (the --function
+  // entry-point pass over the *main* module) is running, so add_annotation's
+  // bare-call forward-reference scan is scoped to that module. The scan
+  // searches only the current ast_, so applying it while annotating an
+  // *imported* module (e.g. an OM calling another OM's helper) would throw
+  // on any name that module itself imports (github #5937).
+  bool annotating_function_entry_point_ = false;
   std::vector<Json> referenced_global_elements;
   std::set<std::string> functions_in_analysis_;
   std::set<std::string> resolving_rhs_vars_;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -350,6 +350,78 @@ void python_converter::pre_collect_module_asts(
   }
 }
 
+void python_converter::convert_module_imports(code_blockt &all_imports_block)
+{
+  // Convert imported modules
+  module_locator locator((*ast_json)["ast_output_dir"].get<std::string>());
+
+  // Pre-walk the import graph so each annotator can see subscript usages
+  // from any other module (GitHub #4554).
+  pre_collect_module_asts(*ast_json, locator);
+
+  // Retype each imported module's list parameters from their call sites,
+  // before import_module_into_block annotates and converts them. The entry
+  // module was retyped in python_languaget::parse(); it is read here only to
+  // find the calls that reach into the imported modules (GitHub #5936).
+  std::vector<python_param_annotations::module_ast> modules{
+    {ast_json, nullptr, ""}};
+  for (auto &entry : module_ast_pool_)
+    modules.push_back({&entry.second, &entry.second, entry.first});
+  python_param_annotations::propagate_tuple_list_params(modules);
+
+  for (const auto &elem : (*ast_json)["body"])
+  {
+    if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
+    {
+      if (elem.value("module_not_found", false))
+      {
+        const std::string module_name = (elem["_type"] == "ImportFrom")
+                                          ? elem["module"]
+                                          : elem["names"][0]["name"];
+        log_warning("skipping unresolvable import: {}", module_name);
+        continue;
+      }
+      is_importing_module = true;
+      if (!import_module_into_block(elem, locator, all_imports_block))
+      {
+        const std::string &module_name = (elem["_type"] == "ImportFrom")
+                                           ? elem["module"]
+                                           : elem["names"][0]["name"];
+        throw std::runtime_error(
+          "Cannot open file: " + locator.module_path(module_name));
+      }
+    }
+  }
+
+  // Do the same for imports that appear directly inside functions.
+  for (const auto &elem : (*ast_json)["body"])
+  {
+    if (
+      elem["_type"] != "FunctionDef" || !elem.contains("body") ||
+      !elem["body"].is_array())
+      continue;
+
+    for (const auto &stmt : elem["body"])
+    {
+      if (stmt["_type"] != "ImportFrom" && stmt["_type"] != "Import")
+        continue;
+
+      is_importing_module = true;
+      if (!import_module_into_block(stmt, locator, all_imports_block))
+      {
+        const std::string &module_name = (stmt["_type"] == "ImportFrom")
+                                           ? stmt["module"]
+                                           : stmt["names"][0]["name"];
+        throw std::runtime_error(
+          "Cannot open file: " + locator.module_path(module_name));
+      }
+    }
+  }
+
+  is_importing_module = false;
+  current_python_file = main_python_file;
+}
+
 void python_converter::convert()
 {
   main_python_file = (*ast_json)["filename"].get<std::string>();
@@ -480,6 +552,14 @@ void python_converter::convert()
     // Add intrinsic assignments first
     block.copy_to_operands(intrinsic_block);
 
+    // Convert module-level and function-local imports so imported
+    // functions/classes are bound in the symbol table (github #5937):
+    // without this, any call through an imported module falls through to
+    // the generic "unsupported function" stub.
+    code_blockt imports_block;
+    convert_module_imports(imports_block);
+    block.copy_to_operands(imports_block);
+
     // Convert classes referenced by the function
     for (const auto &clazz : global_scope_.classes())
     {
@@ -551,77 +631,9 @@ void python_converter::convert()
   }
   else
   {
-    // Convert imported modules
-    module_locator locator((*ast_json)["ast_output_dir"].get<std::string>());
-
-    // Pre-walk the import graph so each annotator can see subscript usages
-    // from any other module (GitHub #4554).
-    pre_collect_module_asts(*ast_json, locator);
-
-    // Retype each imported module's list parameters from their call sites,
-    // before import_module_into_block annotates and converts them. The entry
-    // module was retyped in python_languaget::parse(); it is read here only to
-    // find the calls that reach into the imported modules (GitHub #5936).
-    std::vector<python_param_annotations::module_ast> modules{
-      {ast_json, nullptr, ""}};
-    for (auto &entry : module_ast_pool_)
-      modules.push_back({&entry.second, &entry.second, entry.first});
-    python_param_annotations::propagate_tuple_list_params(modules);
-
     // Accumulate all imports
     code_blockt all_imports_block;
-
-    for (const auto &elem : (*ast_json)["body"])
-    {
-      if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
-      {
-        if (elem.value("module_not_found", false))
-        {
-          const std::string module_name = (elem["_type"] == "ImportFrom")
-                                            ? elem["module"]
-                                            : elem["names"][0]["name"];
-          log_warning("skipping unresolvable import: {}", module_name);
-          continue;
-        }
-        is_importing_module = true;
-        if (!import_module_into_block(elem, locator, all_imports_block))
-        {
-          const std::string &module_name = (elem["_type"] == "ImportFrom")
-                                             ? elem["module"]
-                                             : elem["names"][0]["name"];
-          throw std::runtime_error(
-            "Cannot open file: " + locator.module_path(module_name));
-        }
-      }
-    }
-
-    // Do the same for imports that appear directly inside functions.
-    for (const auto &elem : (*ast_json)["body"])
-    {
-      if (
-        elem["_type"] != "FunctionDef" || !elem.contains("body") ||
-        !elem["body"].is_array())
-        continue;
-
-      for (const auto &stmt : elem["body"])
-      {
-        if (stmt["_type"] != "ImportFrom" && stmt["_type"] != "Import")
-          continue;
-
-        is_importing_module = true;
-        if (!import_module_into_block(stmt, locator, all_imports_block))
-        {
-          const std::string &module_name = (stmt["_type"] == "ImportFrom")
-                                             ? stmt["module"]
-                                             : stmt["names"][0]["name"];
-          throw std::runtime_error(
-            "Cannot open file: " + locator.module_path(module_name));
-        }
-      }
-    }
-
-    is_importing_module = false;
-    current_python_file = main_python_file;
+    convert_module_imports(all_imports_block);
 
     // Convert main statements
     exprt main_block = get_block((*ast_json)["body"]);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -614,6 +614,15 @@ private:
     module_locator &locator,
     code_blockt &code);
 
+  /// Converts every module-level and function-local Import/ImportFrom
+  /// statement in the current AST, appending the resulting code to
+  /// `all_imports_block`. Shared by both the whole-module conversion path
+  /// and the --function entry path (github #5937): the latter used to
+  /// build its own code block without ever calling this, so any call
+  /// through an imported module fell through to the unsupported-function
+  /// stub.
+  void convert_module_imports(code_blockt &all_imports_block);
+
   nlohmann::json build_dunder_call(
     const nlohmann::json &object,
     const std::string &dunder_name,


### PR DESCRIPTION
## Summary
Fixes #5937. `--function` never processed module-level or function-local `import` statements, so any call through an imported module fell through to the generic unsupported-function stub (`assert(false)`), turning correct programs into false `VERIFICATION FAILED`. This affected *any* imported module, including ESBMC's own operational models (`math`, `random`, ...).

## Fix
Extracted the existing import-processing logic (previously inline only in the module-scope path of `python_converter::convert()`) into a shared `convert_module_imports()`, called from both the module-scope path (verbatim move, behavior-preserving) and, now, the `--function` path.

## A second, previously-dormant bug this exposed
`python_annotation::add_annotation()` read the global `--function` CLI flag directly to decide whether to run its bare-call forward-reference scan, instead of tracking whether it was specifically annotating the *entry* module (there's a dedicated `add_type_annotation(func_name)` overload for that). Since `import_module_into_block` reuses the same annotator machinery to annotate every *imported* module, and imports were never processed under `--function` before this patch, the bug was latent — annotating an imported module now (correctly) also happens under `--function`, triggering the scan there too. That scan searches only the current module's own AST and hit the *throwing* `find_function` overload on any call to a name the module itself imports (e.g. `random.py` calling `__ESBMC_assume`, defined in `esbmc.py`) — an uncaught `std::runtime_error`.

Root-caused via `lldb` backtrace. Fixed by:
- Adding a member flag (`annotating_function_entry_point_`) set only by the entry-point-specific `add_type_annotation(func_name)` overload, and gating the scan on that instead of the global CLI option.
- Forcing the non-throwing `find_function` overload the surrounding `.empty()` check already assumed (overload resolution was silently picking the throwing reference-returning overload since the argument was a non-const lvalue).

## Existing test updates (not regressions)
Two existing regression tests' expected output changes as a direct result of the underlying bug now being fixed — confirmed via `git stash` against master that both pinned the *pre-fix, buggy* behavior:
- `github_5898` (`random.choice` under `--function`) — now genuinely resolves and verifies (`VERIFICATION SUCCESSFUL`) instead of falling through to the unsupported-function stub.
- `github_5898_itertools` (unmodeled `itertools` import under `--function`) — now fails identically to how the same import fails at module scope (`ERROR: Cannot open file: .../itertools.json`), instead of failing differently before imports were even attempted under `--function`.

Both originating from #5898, whose own "expected behaviour" was a clean result rather than the SIGABRT crash it was filed to fix — confirmed no crash in either direction.

## Regression tests
- `regression/python/github_5937` — `--function main`, calling a function from an imported local module, `VERIFICATION SUCCESSFUL`.
- `regression/python/github_5937_fail` — same, with a deliberately wrong assertion, `VERIFICATION FAILED`.
- `github_5937_fail` added to `scripts/check_python_tests.sh`'s exemption list (its `main()` is never called at Python module scope, mirroring the existing `function-option-fail` precedent).

Verified: the issue's exact reproducer, function-local imports, OM imports (`math`), and the no-import baseline all work correctly under `--function`. All 13 pre-existing `--function`-using regression tests pass (confirmed no performance regression — an initial 926s outlier for `github_5898` was traced to an unrelated orphaned process from a prior session, not this change). All 63 import-related regression tests pass. `scripts/check_python_tests.sh` clean for both new and updated tests.

Fixes #5937
