### PR TITLE
[goto-convert] Elide extra copies of an RVO'd function-call initializer

### DIFF
--- a/regression/esbmc-cpp/cpp/github_2306/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_2306/main.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+
+int count;
+
+class A
+{
+public:
+  int num;
+  A(int n) : num(n)
+  {
+  }
+  ~A()
+  {
+    count++;
+  }
+};
+
+A func(int n)
+{
+  return A(n);
+}
+
+void dtor()
+{
+  A a = func(1);
+  assert(a.num == 1);
+}
+
+int main()
+{
+  dtor();
+  assert(count == 1);
+}

--- a/regression/esbmc-cpp/cpp/github_2306/test.desc
+++ b/regression/esbmc-cpp/cpp/github_2306/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_2306_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_2306_fail/main.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+
+int count;
+
+class A
+{
+public:
+  int num;
+  A(int n) : num(n)
+  {
+  }
+  ~A()
+  {
+    count++;
+  }
+};
+
+A func(int n)
+{
+  return A(n);
+}
+
+void dtor()
+{
+  A a = func(1);
+  assert(a.num == 1);
+}
+
+int main()
+{
+  dtor();
+  assert(count == 2); // deliberately wrong: count is actually 1
+}

--- a/regression/esbmc-cpp/cpp/github_2306_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_2306_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_2306_multi/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_2306_multi/main.cpp
@@ -1,0 +1,44 @@
+#include <cassert>
+
+int ctor_count;
+int dtor_count;
+
+class A
+{
+public:
+  int num;
+  A(int n) : num(n)
+  {
+    ctor_count++;
+  }
+  ~A()
+  {
+    dtor_count++;
+  }
+};
+
+int helper(int x)
+{
+  return x + 1;
+}
+
+A func(int n)
+{
+  return A(helper(n));
+}
+
+void two_calls()
+{
+  A a = func(1);
+  A b = func(2);
+  assert(a.num == 2);
+  assert(b.num == 3);
+}
+
+int main()
+{
+  two_calls();
+  assert(ctor_count == 2);
+  assert(dtor_count == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_2306_multi/test.desc
+++ b/regression/esbmc-cpp/cpp/github_2306_multi/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -795,6 +795,32 @@ void goto_convertt::convert_decl(const codet &code, goto_programt &dest)
       replace_new_object(var, ctor_code);
       convert(to_code(ctor_code), dest);
     }
+    else if (
+      initializer.id() == "sideeffect" &&
+      initializer.statement() == "temporary_object" &&
+      initializer.operands().size() == 1 &&
+      initializer.op0().id() == "sideeffect" &&
+      initializer.op0().statement() == "function_call")
+    {
+      // A temporary_object wrapping a plain (non-constructor) function call
+      // (C++ `T t = f(...);` where f returns T by value): call it with `var`
+      // as the lhs directly instead of routing the result through a fresh
+      // return_value$ temporary. The generic path below would give that
+      // temporary its own scope-exit destructor for what is semantically the
+      // same object as `var` (github #2306). `var`'s own destructor is
+      // scheduled below via targets.destructor_stack regardless of which
+      // branch above ran; if that destructor appears to not fire for a
+      // function ending in an explicit `return <expr>;`, look at
+      // convert_return's handling of its local unwind program instead of
+      // here -- that path is a separate, pre-existing gap.
+      const exprt &call_expr = initializer.op0();
+      code_function_callt call;
+      call.location() = call_expr.location();
+      call.lhs() = var;
+      call.function() = call_expr.op0();
+      call.arguments() = call_expr.op1().operands();
+      convert_function_call(call, dest);
+    }
     else
     {
       goto_programt sideeffects;


### PR DESCRIPTION
## Summary
Fixes #2306. `A a = func(1);` (where `func` returns `A` by value) was calling `~A()` three times instead of once.

## Root cause
Confirmed via `--goto-functions-only` GOTO IR inspection: the frontend/goto-convert pipeline materialized two extra plumbing temporaries (`return_value$_func$1`, `tmp$2`) between the function call and the final variable `a`, connected by plain (non-constructor) struct assigns. Each of the three objects (`a`, `tmp$2`, `return_value$_func$1`) independently got its own scope-exit `~A()` call — even though only *one* object was ever constructed (inside `func`, via `A(n)`).

Confirmed via a real Clang AST dump (`clang++ -std=c++17 -Xclang -ast-dump`) that under C++17's guaranteed-copy-elision semantics, the source AST has **no copy-constructor call at all** for this pattern — `a` is directly initialized from the call's materialized temporary. The correct destructor count is exactly 1, matching the issue's own `assert(count == 1)`.

## Fix
`src/goto-programs/goto_convert.cpp`, `goto_convertt::convert_decl` already has a special case that elides a *direct constructor call* initializer (`A a = A(1);`) by retargeting the constructor straight into `var`. This adds the analogous case for a *plain function call* returning the class by value (`A a = func(1);`): call it with `var` as the lhs directly, instead of routing the result through a fresh `return_value$` temporary. The two cases are structurally disjoint by construction (`make_temporary` produces a different irep shape for constructor vs. plain-call temporaries), so this is a genuinely new, mutually-exclusive branch alongside the existing one.

## Mode C note
Doesn't apply here: `convert_decl` is ESBMC's own AST→GOTO lowering pass, not a program under verification, and no faithful `__ESBMC_unreachable()` self-hosting harness is buildable (would require symbolically executing ESBMC's own `boost::multi_index`-backed `contextt`). The three regression tests plus a `git stash` differential (confirming the branch changes real behaviour, not dead weight) serve as the reachability evidence instead.

## Regression tests
- `regression/esbmc-cpp/cpp/github_2306` — issue's exact reproducer, `VERIFICATION SUCCESSFUL`.
- `regression/esbmc-cpp/cpp/github_2306_fail` — deliberately wrong destructor-count assertion, `VERIFICATION FAILED`.
- `regression/esbmc-cpp/cpp/github_2306_multi` — two sequential RVO'd calls with a side-effecting argument, checking both constructor and destructor counts.

Ran the full `esbmc-cpp/cpp/` suite plus `esbmc-cpp/destructors/`, `esbmc-cpp11/constructors/`, `esbmc-cpp11/cpp/`, `esbmc-cpp14/cpp/` (91 additional tests): no new failures (3 pre-existing macOS-environment failures, confirmed identical on unmodified master via `git stash`).

## Found but out of scope (filed as candidates for follow-up issues)
Confirmed pre-existing via `git stash` against master, orthogonal failure modes in different code paths:
1. The call result used mid-expression rather than as a direct decl-initializer (e.g. `int r = func(5).num + func(6).num;`) double-counts destructors differently.
2. A discarded call result's destructor never fires (`func(1);` as a standalone statement).
3. `convert_return` discards its local destructor-unwind program into an unused `dummy` `goto_programt` (`goto_convert.cpp` ~line 1550), so a function ending in an explicit `return <expr>;` skips its locals' destructors entirely — found while reviewing this exact code path, arguably the most severe of the three since it silently drops all local-object cleanup for that shape.

Fixes #2306
