### PR TITLE
[regression] Fix flaky harness_queue_fifo timeout

### DIFF
--- a/regression/python/harness_queue_fifo/test.desc
+++ b/regression/python/harness_queue_fifo/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc --unwind 10
+--unwind 10
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`regression/python/harness_queue_fifo` intermittently fails in CI (e.g. the arm64 darwin build on #6069) at exactly 120.20s — the ctest timeout, not a wrong result.

The cause is `--incremental-bmc --unwind 10`, which re-runs symex+solve at every bound 1..10. Each solve of the queue harness is ~13s, so the cumulative run is ~120s and tips over the 120s cap under CI load.

A single fixed `--unwind 10` completes in ~14s and is equally sound: `--unwind 1` and `--unwind 2` still `VERIFICATION FAILED` on the unwinding assertion, so the bound is genuinely exercised and the FIFO properties are fully proven. The companion `harness_queue_fifo_fail` test is unchanged.