### PR TITLE
[python] V.1k: build single-char pointer-deref comparison in IREP2

### DIFF
--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -335,17 +335,20 @@ exprt python_converter::handle_string_comparison(
         return index2tc(migrate_type(char_type()), expr2, index2);
       }
 
-      // Pointer path: reproduce the legacy dereference node verbatim — its
-      // two-arg constructor takes char_type().subtype() (nil), not char_type(),
-      // as the result type — then migrate it forward for a uniform expr2tc.
+      // Pointer path: build the pointer-plus-index arithmetic and the
+      // dereference natively in IREP2 (V.1k arith site). The legacy two-arg
+      // dereference_exprt(op, tp) ctor sets the result type to tp.subtype()
+      // (nil, since char_type() is not a pointer type) rather than tp
+      // itself; migrate_type(char_type().subtype()) reproduces that exact
+      // quirk byte-for-byte.
       exprt ptr = expr;
       if (!ptr.type().is_pointer())
         ptr = address_of_exprt(expr);
-      plus_exprt ptr_plus(ptr, index);
-      ptr_plus.type() = ptr.type();
-      expr2tc deref2;
-      migrate_expr(dereference_exprt(ptr_plus, char_type()), deref2);
-      return deref2;
+      expr2tc ptr2, index2;
+      migrate_expr(ptr, ptr2);
+      migrate_expr(index, index2);
+      expr2tc ptr_plus2 = add2tc(ptr2->type, ptr2, index2);
+      return dereference2tc(migrate_type(char_type().subtype()), ptr_plus2);
     };
 
     char literal_char = 0;


### PR DESCRIPTION
## Summary
- Continues Phase V.1k of `docs/irep2-migration.md` (the arith-site drains listed in `docs/scope-v1k-adjuster.md` §3.2 / `docs/irep2-keystone-implementation-plan.md` item 4).
- `handle_string_comparison`'s single-character fast path built the `char*` deref operand via a legacy `plus_exprt` + `dereference_exprt` pair before migrating forward. Build the pointer-plus-index arithmetic and the dereference directly as `add2tc`/`dereference2tc`, the same inline pattern used by the other V.1k arith-site drains (`python_set.cpp`, `list_access.cpp` slice bounds).
- The legacy two-arg `dereference_exprt(op, tp)` ctor stores `tp.subtype()` (nil, since `char_type()` isn't a pointer type) as the result type rather than `tp` itself. `migrate_type(char_type().subtype())` reproduces that exact quirk so the emitted node — and hence the GOTO program — is byte-for-byte unchanged.

## Test plan
- [x] Rebuilt `esbmc` and diffed `--goto-functions-only` output old vs. new on two repros exercising this comparison path (array-typed and, via string concatenation, pointer-typed string operands) — identical modulo timing lines.
- [x] `ctest -L python -R "char|string|compar|none|None"` — 514/514 pass (100%).
- [x] `single-char1`, `single-char1_fail`, `github_3041_2_comparison`, `github_3041_2_comparison_fail`, `github_3127`, `github_3127_fail` hold their expected verdicts under both Bitwuzla (default) and Z3.
- [x] `scripts/check_python_tests.sh` CPython sanity on the affected tests.
