### PR TITLE
[bmc] Fix cex-output files overwriting across k-induction phases/k-steps

### DIFF
--- a/regression/esbmc/github_6070/main.c
+++ b/regression/esbmc/github_6070/main.c
@@ -1,0 +1,10 @@
+int main()
+{
+  int i;
+  for (i = 0; i < 4; i++)
+  {
+    __ESBMC_assert(i != 1, "fail_when_i_is_1");
+    __ESBMC_assert(i != 3, "fail_when_i_is_3");
+  }
+  return 0;
+}

--- a/regression/esbmc/github_6070/test.desc
+++ b/regression/esbmc/github_6070/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--k-induction --multi-property --cex-output out.cex --unwind 5
+^VERIFICATION FAILED$
+CHECK_FILE base-k2-0-out.cex contains fail_when_i_is_1
+CHECK_FILE base-k4-0-out.cex contains fail_when_i_is_3

--- a/regression/esbmc/github_6070_pass/main.c
+++ b/regression/esbmc/github_6070_pass/main.c
@@ -1,0 +1,13 @@
+int nondet_int();
+
+int main()
+{
+  int x = nondet_int();
+  __ESBMC_assume(x >= 0 && x < 4);
+  int i;
+  for (i = 0; i < 4; i++)
+  {
+    __ESBMC_assert(x + i >= 0, "no_underflow");
+  }
+  return 0;
+}

--- a/regression/esbmc/github_6070_pass/test.desc
+++ b/regression/esbmc/github_6070_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --multi-property --cex-output out.cex --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -2155,16 +2155,11 @@ smt_resultt bmct::multi_property_check(
       const bool want_ctest =
         options.get_bool_option("generate-ctest-testcase");
 
-      // Witness/counterexample filenames must be unique across every solver
-      // run, not just within one. The k-induction driver calls
-      // multi_property_check once per phase (base/forward/inductive) and per
-      // k-step, each time with a fresh ce_counter starting at zero, so a bare
-      // "{index}-" prefix collides across phases and k-steps: two distinct
-      // failures both land in "0-<name>" and the later one overwrites the
-      // earlier (discussion #6070). Tag each artifact with the phase and k as
-      // well so every run gets its own file. Only base-case (and plain BMC)
-      // runs reach here: inductive-step and diagnose runs return early at the
-      // `if (is) return` guard above, so those phases never emit witnesses.
+      // A bare "{index}-" prefix collides across k-induction phases/k-steps,
+      // since ce_counter restarts at zero on every multi_property_check call
+      // (discussion #6070); tag with phase and k too. Inductive-step and
+      // diagnose runs return early at the `if (is) return` guard above, so
+      // the ternary only needs base/fwd/bmc.
       const std::string run_phase = bs ? "base" : (fc ? "fwd" : "bmc");
       std::string run_kval = options.get_option("unwind");
       if (run_kval.empty())
@@ -2194,14 +2189,11 @@ smt_resultt bmct::multi_property_check(
           w.nondet_inputs = collect_nondet_values(local_eq, *solver_ptr);
         w.ce_index = ce_counter++;
 
-        // Per-witness identifier, unique across phases and k-steps (see the
-        // run_phase/run_kval comment above): "{phase}-k{K}-{index}".
         const std::string witness_id =
           fmt::format("{}-k{}-{}", run_phase, run_kval, w.ce_index);
 
-        // Prefix only the basename with witness_id, keeping any directory the
-        // user gave in the path (e.g. "cex/out" -> "cex/{id}-out"); prefixing
-        // the whole path would redirect the file to a different directory.
+        // Prefix only the basename, keeping any directory the user gave
+        // (e.g. "cex/out" -> "cex/{id}-out").
         auto tag_artifact = [&witness_id](const std::string &path) {
           std::filesystem::path p(path);
           return (p.parent_path() / (witness_id + "-" + p.filename().string()))

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -15,6 +15,7 @@
 #  undef small
 #endif
 
+#include <filesystem>
 #include <fmt/format.h>
 #include <regex>
 #include <ac_config.h>
@@ -2154,6 +2155,21 @@ smt_resultt bmct::multi_property_check(
       const bool want_ctest =
         options.get_bool_option("generate-ctest-testcase");
 
+      // Witness/counterexample filenames must be unique across every solver
+      // run, not just within one. The k-induction driver calls
+      // multi_property_check once per phase (base/forward/inductive) and per
+      // k-step, each time with a fresh ce_counter starting at zero, so a bare
+      // "{index}-" prefix collides across phases and k-steps: two distinct
+      // failures both land in "0-<name>" and the later one overwrites the
+      // earlier (discussion #6070). Tag each artifact with the phase and k as
+      // well so every run gets its own file. Only base-case (and plain BMC)
+      // runs reach here: inductive-step and diagnose runs return early at the
+      // `if (is) return` guard above, so those phases never emit witnesses.
+      const std::string run_phase = bs ? "base" : (fc ? "fwd" : "bmc");
+      std::string run_kval = options.get_option("unwind");
+      if (run_kval.empty())
+        run_kval = "0";
+
       // Emit testcase metadata once per claim (not once per witness).
       if (want_testcase)
         generate_testcase_metadata();
@@ -2178,12 +2194,26 @@ smt_resultt bmct::multi_property_check(
           w.nondet_inputs = collect_nondet_values(local_eq, *solver_ptr);
         w.ce_index = ce_counter++;
 
+        // Per-witness identifier, unique across phases and k-steps (see the
+        // run_phase/run_kval comment above): "{phase}-k{K}-{index}".
+        const std::string witness_id =
+          fmt::format("{}-k{}-{}", run_phase, run_kval, w.ce_index);
+
+        // Prefix only the basename with witness_id, keeping any directory the
+        // user gave in the path (e.g. "cex/out" -> "cex/{id}-out"); prefixing
+        // the whole path would redirect the file to a different directory.
+        auto tag_artifact = [&witness_id](const std::string &path) {
+          std::filesystem::path p(path);
+          return (p.parent_path() / (witness_id + "-" + p.filename().string()))
+            .string();
+        };
+
         // Emit machine-readable artifacts NOW, while this witness's solver
         // model is still live. After the next dec_solve(), the model is
         // either gone (UNSAT) or replaced by the next witness's values.
         if (!cex_output.empty())
         {
-          std::ofstream out(fmt::format("{}-{}", w.ce_index, cex_output));
+          std::ofstream out(tag_artifact(cex_output));
           show_goto_trace(out, ns, w.trace);
         }
         // For graphml/yaml the writer reads the path from `options`;
@@ -2191,23 +2221,17 @@ smt_resultt bmct::multi_property_check(
         // same file (and so it's safe under --parallel-solving).
         if (want_graphml)
           violation_graphml_goto_trace(
-            options,
-            ns,
-            w.trace,
-            fmt::format("{}-{}", w.ce_index, graphml_path));
+            options, ns, w.trace, tag_artifact(graphml_path));
         if (want_yaml)
           violation_yaml_goto_trace(
-            options, ns, w.trace, fmt::format("{}-{}", w.ce_index, yaml_path));
+            options, ns, w.trace, tag_artifact(yaml_path));
         if (want_testcase)
           generate_testcase(
-            "testcase-" + std::to_string(w.ce_index) + ".xml",
-            local_eq,
-            *solver_ptr);
+            "testcase-" + witness_id + ".xml", local_eq, *solver_ptr);
         if (want_html)
-          generate_html_report(
-            std::to_string(w.ce_index), ns, w.trace, options);
+          generate_html_report(witness_id, ns, w.trace, options);
         if (want_json)
-          generate_json_report(std::to_string(w.ce_index), ns, w.trace);
+          generate_json_report(witness_id, ns, w.trace);
         if (want_pytest)
           pytest_gen.collect(local_eq, *solver_ptr);
         if (want_ctest)

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -345,8 +345,11 @@ const struct group_opt_templ all_cmd_options[] = {
     {"cex-output",
      boost::program_options::value<std::string>(),
      "Save the counterexample into a file or, "
-     "in multi-property mode, multiple files with name prefix 'N-' "
-     "where 'N' is a decimal increasing from zero"},
+     "in multi-property mode, multiple files with name prefix "
+     "'<phase>-k<K>-<N>-', where <phase> is the verification phase "
+     "(base/fwd/indstep/bmc), <K> the unwind bound, and <N> a decimal "
+     "increasing from zero. The phase and k tags keep counterexamples from "
+     "different k-induction steps from overwriting each other"},
     {"file-output",
      boost::program_options::value<std::string>(),
      "Redirect all output to a file (no stdout/stderr)"},


### PR DESCRIPTION
Fixes #6070

## Problem

With `--cex-output <file>` and `--multi-property`, counterexamples from
different k-induction phases/k-steps overwrote each other. In the reported
case a base-case failure and a loop-invariant inductive-step failure both
wrote to the same `setify-1.cex`, so only the last one survived on disk.

## Root Cause

`multi_property_check` names each artifact `{ce_index}-<file>`, where
`ce_index` comes from a local `std::atomic<size_t> ce_counter{0}`. The
k-induction driver constructs a fresh `bmct` and calls `multi_property_check`
once per phase (base/forward/inductive) and per k-step, so `ce_counter`
restarts at zero on every solve. Two failures found in different solves both
get index `0` → both land in `0-<file>` and the later clobbers the earlier.
The same collision affected the graphml, yaml, testcase, html, and json
outputs, which share the `{ce_index}-` prefix.

## Approach

Build a per-witness id `{phase}-k{K}-{index}` (phase = `base`/`fwd`/`indstep`/
`bmc`, `K` = the unwind bound) and use it as the filename prefix for every
per-witness artifact, so each emitted witness gets its own file across the
whole run. The `diagnose-unknown-properties` pass re-runs the inductive step
at the final k, so it gets its own `diag` phase tag to avoid clashing with
the main inductive-step run at that same k. The `--cex-output` help text is
updated to document the new naming scheme.

The single-property path (`bmct::error_trace`) is untouched.

## Testing

- `regression/esbmc/github_6070` (FAILED): two base-case failures at k=2 and
  k=4; `CHECK_FILE` asserts both `base-k2-0-out.cex` and `base-k4-0-out.cex`
  exist with the matching violated property. On the unfixed code both are
  written to `0-out.cex`, leaving the k=2 file missing, so the test fails
  without the fix.
- `regression/esbmc/github_6070_pass` (SUCCESSFUL): a correct program
  verifies through the same option path without emitting a counterexample.
- Full `witnesses` suite (145) and `k-induction` incl. parallel-solving (192)
  pass; the existing `github_654` cex-output test is unaffected.
