### PR TITLE
[docs] V.1k/S6: corrected census - round 2's F-A1 finding was also wrong

### DIFF
--- a/docs/irep2-migration.md
+++ b/docs/irep2-migration.md
@@ -4130,10 +4130,12 @@ whatever long tail remains before the flip itself can be attempted.
 
 #### S6 flip-readiness census (2026-07-11) — 92.2% of the runnable suite passes hop-off; the 278-test gap classifies into five families
 
-> **2026-07-15 — figure is stale, see "F-A1 drill, round 2" below.** Spot-checks
-> of this census's own named F-A1/F-B examples no longer reproduce on current
-> master; a corpus-wide crash sweep found zero surviving F-A1 crashes. The true
-> gap is smaller than 278/271; a fresh census is needed for an exact number.
+> **2026-07-15 — figure re-measured, see "Census re-run, corrected" below.**
+> An intermediate same-day finding ("F-A1 drill, round 2") claimed the gap
+> had shrunk; that claim was itself wrong (a spot-check methodology bug,
+> corrected in the same section) and is superseded by a properly re-run
+> census: **438/4054 (89.2% pass)** — the gap is *larger* than 278/271, not
+> smaller. F-A1/F-A3/F-B are all still live at roughly their original scale.
 
 **Method.** All 4,261 `regression/python` test dirs, hop-off (env-gated
 `clang_cpp_adjust` skip + `--python-irep2-adjust`, Bitwuzla, 20 s cap,
@@ -4229,7 +4231,15 @@ expression being widthed) to name the constructing site, rather than
 walking the pass's view again. The fix will live where that node is built,
 not in `python_adjust`.
 
-#### F-A1 drill, round 2 (2026-07-15) — the reproducers are gone; the census figure is stale
+#### F-A1 drill, round 2 (2026-07-15) — RETRACTED, see "Census re-run, corrected" below
+
+> **This section's finding is wrong.** `builtin2`/`cast` still crash 5/5
+> when invoked with their own `test.desc` flags; the corpus-wide sweep below
+> that claimed "zero surviving F-A1 crashes" ran the same buggy census
+> script (an unexported `$OUT` swallowing every gap write) later found and
+> fixed in "F-B prereq-6 fix". Left as originally written for the record of
+> what was (wrongly) concluded and why; do not cite the "gone"/"zero hits"
+> claims below as current.
 
 Ran the round-2 probe: all four `get_width` throw sites (`empty_type2t`,
 `symbol_type2t`, `cpp_name_type2t`, `code_type2t`) instrumented with a
@@ -4334,6 +4344,65 @@ until a corrected, exit-code-aware census actually re-measures it — the
 positive finding for F-A1 (empty_type2t crashes) stands on its own separate,
 correctly-attributed evidence (§ "F-A1 drill, round 2" above) and is not
 affected by this correction.
+
+#### Census re-run, corrected (2026-07-15) — round 2's F-A1 "doesn't reproduce" finding was ALSO wrong; verified gap is 438/4054 (89.2% pass), worse than the stale 92.4%
+
+The census script bug flagged just above (crash detection only grepped
+subprocess stdout, never checked the exit code) had one more consequence,
+found while fixing it: the script's `check_one` function used `$OUT` — the
+gap-log path — **without exporting it**. `export -f check_one` exports the
+*function*, but `xargs -P N ... bash -c 'check_one "$@"'` runs each call in a
+**new** child bash process that does not inherit unexported shell variables,
+so every write inside `check_one` targeted an empty-string path and silently
+vanished — this is why every census attempt this session (round 2's corpus
+sweep, and the first attempt at this re-run) reported `gap=0`/`mismatches=0`
+regardless of what was actually happening. Fixed with `export OUT`; confirmed
+by first reproducing the bug in isolation (a hand-rolled single-test harness
+that reported 0 even though a direct manual run of the exact same command
+showed a clean gap), then verifying the fix catches it.
+
+**With the export fixed and exit codes checked, the corrected census (all
+4,054 `CORE`, non-solver-pinned `regression/python` tests, hop-off,
+`--python-irep2-adjust`, 8s cap, 8-way parallel) found 438 gap tests: 268
+`GAP-CRASH` (206 SIGABRT, 45 rc=254/255 harness-exit-code artifacts, 12
+SIGSEGV, 1 SIGBUS), 92 `GAP-VERDICT` (ran to completion, wrong output), 78
+`GAP-TIMEOUT`.** That is **89.2% pass**, not an improvement on the
+2026-07-11 census's stale 92.4% — the true current gap is *larger*, not
+smaller as round 2 concluded.
+
+**Round 2's F-A1 finding was also wrong, verified this time with the
+discipline the F-B correction above demanded.** `builtin2` and `cast` — the
+exact two round-1/round-2 F-A1 reproducers — are both in the `GAP-CRASH`
+list (`rc=134`, `libc++abi: terminating due to uncaught exception of type
+type2t::symbolic_type_excp`, the identical signature named in round 1).
+Reproduced 5/5 across both tests with their exact `test.desc` flags
+(`builtin2`: `--unwind 1`; `cast`: `--incremental-bmc`) — not
+nondeterministic, not an artifact of a missing flag. Round 2's own
+methodology mistake (§ "F-B prereq-6 fix" above: spot-checking with a
+simplified command instead of the test's pinned flags) is confirmed as the
+cause here too, on inspection: round 2's session did not record which exact
+invocation it used for `builtin2`/`cast`, only the (wrong) conclusion.
+
+**Net effect: retract round 2's headline finding in full.** Neither the
+F-A1 crash family nor the F-B struct-literal family has shrunk since the
+2026-07-11 census; both are still live, at roughly their originally-measured
+size (F-A1 116, F-A3/F-B 32+18 named then; this census's 268 crashes +
+92 verdict mismatches are consistent with that scale, not a reduction). The
+`--python-irep2-adjust` flip remains gated on the same S3/F-A1 root-cause
+work round 1 scoped and never finished: instrument the symex/goto-convert
+*consumer* of the surviving empty-typed node (not `python_adjust`) to name
+the constructing site — see "F-A1 drill, round 1" above, still the correct
+next step, now on considerably firmer evidence than either "round" that
+followed it produced.
+
+**Process lesson, stated once more because it recurred:** two sessions in a
+row, a "the bug doesn't reproduce anymore" conclusion was reached from a
+spot-check that did not exactly replay the failing test's `test.desc` flags,
+and both times the real answer was the opposite. Any future "does X still
+reproduce" check on a *named regression test* must invoke it with that
+test's own flags, parsed the same way the test harness parses them — never
+a hand-typed approximation — before the result is trusted enough to write
+into this document.
 
 ### Phase V.1a — Type construction → `type2tc` end-to-end (extends Phase 4.3)
 Finish what Phase 4.3 deferred: the tuple/optional **struct** builders (§15.7


### PR DESCRIPTION
## Summary
- Stacked on #6089 (the prereq-6 error-return fix) — continues Part V of `docs/irep2-migration.md`: a corrected S6 flip-readiness census re-run.
- Found and fixed a second bug in the census harness (on top of the exit-code-detection bug fixed in #6089): `check_one` used `$OUT` (the gap-log path) without `export`ing it, so every gap write inside the `xargs`-spawned child process silently went to an empty path. This is why every census attempt this session — including the same-day "F-A1 drill round 2" entry — reported `gap=0`/`mismatches=0` regardless of what was actually happening.
- With both bugs fixed, the corrected census (4,054 `CORE` `regression/python` tests, hop-off, `--python-irep2-adjust`) found **438 gap tests (268 crashes, 92 wrong-verdict, 78 timeout) = 89.2% pass** — *worse* than the stale 92.2%/92.4% figure, not better as round 2 concluded.
- **Retracts round 2's F-A1 finding.** `builtin2` and `cast` (round 2's own named reproducers) crash 5/5 when invoked with their exact `test.desc` flags — round 2's spot-check used a simplified command instead and missed it, the same methodology mistake the prereq-6 fix's `dict17` correction already identified once this session. Both corrections are now recorded in `docs/irep2-migration.md`, left visible in place (not deleted) so the record shows what was concluded and why it was wrong.
- Restates the still-correct next step from round 1 (never actually completed by either "round" that followed it): instrument the symex/goto-convert *consumer* of the surviving empty-typed node to name the constructing site — the fix does not live in `python_adjust`.

## Test plan
- [x] Reproduced the census script's `$OUT`-export bug in isolation (a hand-rolled single-test harness that reported 0 gaps even though a direct manual run of the identical command showed a clean, expected gap), then verified the fix (`export OUT`) catches it.
- [x] `builtin2` and `cast` reproduced crashing 5/5 with their exact pinned flags (`--unwind 1` and `--incremental-bmc` respectively) — not flaky, not flag-sensitive.
- [x] Docs-only change; `ctest -R "python_irep2_adjust|python_adjust"` — 52/52 pass (no code touched by this PR).
