### PR TITLE
[k-induction] Reject --base-k-step 0 (unwind 0 = unbounded unwinding)

### DIFF
--- a/regression/k-induction/github_6093/main.c
+++ b/regression/k-induction/github_6093/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int idx, max, res;
+
+  __ESBMC_assume(0 <= max);
+  res = 0;
+  idx = 0;
+
+  while (idx < max)
+  {
+    ++idx;
+    ++res;
+  }
+  __ESBMC_assert(idx == max, "A.1");
+}

--- a/regression/k-induction/github_6093/test.desc
+++ b/regression/k-induction/github_6093/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--loop-invariant --base-k-step 0 --max-k-step 2
+^ERROR: Please specify --base-k-step >= 1

--- a/regression/k-induction/github_6093_pass/main.c
+++ b/regression/k-induction/github_6093_pass/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int i, s = 0;
+  for (i = 0; i < 3; i++)
+    s++;
+  __ESBMC_assert(s == 3, "s_eq_3");
+}

--- a/regression/k-induction/github_6093_pass/test.desc
+++ b/regression/k-induction/github_6093_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --base-k-step 2 --max-k-step 10
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -458,7 +458,8 @@ const struct group_opt_templ all_cmd_options[] = {
      "Set max number of iteration (default is 50)"},
     {"base-k-step",
      boost::program_options::value<int>()->default_value(1)->value_name("nr"),
-     "Start the base case from n step (default is 1)"},
+     "Start the base case from n step (n >= 1, default is 1); n = 0 is "
+     "rejected because it sets --unwind 0 (unlimited)"},
     {"show-cex",
      NULL,
      "Print the counter-example produced by the inductive step"},

--- a/src/esbmc/parseoptions/command_line_options.cpp
+++ b/src/esbmc/parseoptions/command_line_options.cpp
@@ -414,6 +414,18 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     options.set_option("smt-during-symex", true);
   }
 
+  // A base-case start of k = 0 sets --unwind 0, which ESBMC treats as
+  // "unlimited" (loop termination is gated on max_unwind != 0), so the base
+  // case would unwind forever instead of running k = 0. Reject it up front,
+  // independently of --unlimited-k-steps (discussion #6093).
+  if (strtoul(cmdline.getval("base-k-step"), nullptr, 10) == 0)
+  {
+    log_error(
+      "Please specify --base-k-step >= 1: a base case of k = 0 sets "
+      "--unwind 0, which ESBMC treats as unlimited unwinding.");
+    abort();
+  }
+
   // check the user's parameters to run incremental verification
   if (!cmdline.isset("unlimited-k-steps"))
   {


### PR DESCRIPTION
Fixes #6093

## Problem

`esbmc --loop-invariant --base-k-step 0 --max-k-step 2 while-inc1-3.cpp`
unwinds the loop unboundedly, ignoring `--max-k-step 2`, instead of running
a bounded k-induction sweep.

## Root Cause

`--base-k-step 0` seeds the base-case loop at `k = 0`, and every k-induction
base-case driver sets the unwind bound from the current k:
`set_option("unwind", integer2string(k_step))`. ESBMC treats `--unwind 0` as
**unlimited** — loop termination is gated on `max_unwind != 0 && unwind >=
max_unwind` (`symex_goto.cpp`, `symex_function.cpp`), so `max_unwind == 0`
never stops a loop. The base case at `k = 0` therefore unwinds forever. The
existing validation only checks `base-k-step < max-k-step`, so `0` slips
through.

## Approach

Reject `--base-k-step 0` up front in `get_command_line_options` (which runs
for every invocation, before any strategy) with a clear error, matching the
existing `--k-step`/`--max-k-step` validation. k-induction's base case must
start at `k >= 1`; `k = 0` cannot be represented as an unwind bound because
`0` is the "unlimited" sentinel. The option help now documents `n >= 1`.

## Testing

- `regression/k-induction/github_6093` (Mark's exact reproducer): now aborts
  with `ERROR: Please specify --base-k-step >= 1 ...` instead of unwinding
  unboundedly.
- `regression/k-induction/github_6093_pass`: a valid `--base-k-step 2` run
  still verifies SUCCESSFUL, confirming the guard only rejects `k = 0`.
- Full `k-induction` suite (194 tests, incl. parallel) passes; defaults and
  valid `--base-k-step >= 1` are unaffected.
