### PR TITLE
[k-induction] Clarify --base-k-step/--k-step vs --max-k-step error

### DIFF
--- a/regression/k-induction/github_441_1/test.desc
+++ b/regression/k-induction/github_441_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --k-induction --k-step 9 --max-k-step 4
-^ERROR: Please specify --k-step smaller than max-k-step if you want to use incremental verification.
+^ERROR: --k-step \(9\) must be smaller than --max-k-step \(4\)\.

--- a/regression/k-induction/github_441_2/test.desc
+++ b/regression/k-induction/github_441_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --k-induction --k-step 4 --max-k-step 4
-^ERROR: Please specify --k-step smaller than max-k-step if you want to use incremental verification.
+^ERROR: --k-step \(4\) must be smaller than --max-k-step \(4\)\.

--- a/regression/k-induction/github_6094/main.c
+++ b/regression/k-induction/github_6094/main.c
@@ -1,0 +1,1 @@
+int main(void) {}

--- a/regression/k-induction/github_6094/test.desc
+++ b/regression/k-induction/github_6094/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --base-k-step 2 --max-k-step 2
+^ERROR: --base-k-step \(2\) must be smaller than --max-k-step \(2\)\.

--- a/regression/k-induction/github_6094_1/main.c
+++ b/regression/k-induction/github_6094_1/main.c
@@ -1,0 +1,1 @@
+int main(void) {}

--- a/regression/k-induction/github_6094_1/test.desc
+++ b/regression/k-induction/github_6094_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --base-k-step 1 --max-k-step 2
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/parseoptions/bmc_strategy.cpp
+++ b/src/esbmc/parseoptions/bmc_strategy.cpp
@@ -235,8 +235,9 @@ int esbmc_parseoptionst::do_bmc_strategy(
   if (k_step_base >= max_k_step)
   {
     log_error(
-      "Please specify --base-k-step smaller than max-k-step if you want "
-      "to use incremental verification.");
+      "--base-k-step ({}) must be smaller than --max-k-step ({}).",
+      k_step_base,
+      max_k_step);
     abort();
   }
 

--- a/src/esbmc/parseoptions/command_line_options.cpp
+++ b/src/esbmc/parseoptions/command_line_options.cpp
@@ -426,21 +426,21 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     // Get the start of the base-case, default 1
     uint64_t k_step_base = strtoul(cmdline.getval("base-k-step"), nullptr, 10);
 
-    // check whether k-step is greater than max-k-step
     if (k_step_inc >= max_k_step)
     {
       log_error(
-        "Please specify --k-step smaller than max-k-step if you want to use "
-        "incremental verification.");
+        "--k-step ({}) must be smaller than --max-k-step ({}).",
+        k_step_inc,
+        max_k_step);
       abort();
     }
 
-    // check whether k_step_inc is greater than max-k-step
     if (k_step_base >= max_k_step)
     {
       log_error(
-        "Please specify --base-k-step smaller than max-k-step if you want "
-        "to use incremental verification.");
+        "--base-k-step ({}) must be smaller than --max-k-step ({}).",
+        k_step_base,
+        max_k_step);
       abort();
     }
   }

--- a/src/esbmc/parseoptions/k_induction.cpp
+++ b/src/esbmc/parseoptions/k_induction.cpp
@@ -210,8 +210,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
   if (k_step_base >= max_k_step)
   {
     log_error(
-      "Please specify --base-k-step smaller than max-k-step if you want "
-      "to use incremental verification.");
+      "--base-k-step ({}) must be smaller than --max-k-step ({}).",
+      k_step_base,
+      max_k_step);
     abort();
   }
 


### PR DESCRIPTION
Clarify the error printed when `--base-k-step` or `--k-step` is not smaller
than `--max-k-step`. Drops the misleading "if you want to use incremental
verification" clause, which collides with the separate `--incremental-bmc`
flag, and prints the offending values so the constraint is explicit.

Fixes #6094