### PR TITLE
[docs] Sync website docs with recent user-facing changes

### DIFF
--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -286,7 +286,7 @@ The `--strict-types` flag enables type compatibility validation for function arg
 ## Module System
 
 - **`__name__`**: Set to `"__main__"` when run directly; set to the module name when imported. Enables `if __name__ == "__main__":` idioms.
-- **Imports**: Standard `import` and `from ... import ...` styles validated at verification time
+- **Imports**: Standard `import` and `from ... import ...` styles validated at verification time. Module-level and function-local imports are also processed when verifying a single function with `--function`, so calls through imported modules (including operational models such as `math` and `random`) resolve there too
 - **Local bindings shadow imported modules**: When a name is both an imported module and a local binding (e.g. a parameter `node` while `from node import Node` is in scope), attribute access such as `node.value` resolves to the local binding, following Python's LEGB rule, rather than to a module member.
 - **Selective imports preserve module-level constants**: `from M import f, C` retains plain `Assign` bindings such as `INT_BOUND = 1024` in addition to `AnnAssign` ones. Tuple-unpacking targets are treated atomically.
 - **Parser package layout**: The Python parser ships as a package under `src/python-frontend/parser/` (entrypoint `parser/__main__.py`, public facade `parser/__init__.py`, import resolution in `parser/import_resolver.py`). The resolver emits deterministic, review-friendly diagnostics for missing modules, cyclic imports, and relative-import rewrites.

--- a/website/content/docs/python/usage.md
+++ b/website/content/docs/python/usage.md
@@ -39,7 +39,7 @@ esbmc main.py --unwind 10
 | `--k-path-max-goals=M` | Per-function goal cap for k-path coverage (default 10000). |
 | `--generate-pytest-testcase` | Generate pytest test cases from counterexamples (see [Pytest Test Generation](./pytest-testgen)) |
 | `--python <path>` | Python interpreter binary to use (searched in `$PATH`; default `python`). It must be Python 3 — ESBMC errors out on a Python 2 interpreter. |
-| `--function <name>` | Verify a single function instead of the entire file |
+| `--function <name>` | Verify a single function instead of the entire file. Module-level and function-local imports are processed, so calls through imported modules resolve as they do at module scope |
 
 ## Writing Verification Harnesses
 

--- a/website/content/docs/solidity/usage.md
+++ b/website/content/docs/solidity/usage.md
@@ -24,10 +24,11 @@ The Solidity compiler `solc` (≥ 0.5.0; ≥ 0.7 recommended) must be reachable 
 
 ## Basic Invocation
 
-Pass a `.sol` file directly:
+Pass a `.sol` file directly, either as a positional argument or via `--sol`:
 
 ```bash
 esbmc contract.sol
+esbmc --sol contract.sol
 ```
 
 If the source declares more than one contract, name the entry point with `--contract`:

--- a/website/content/docs/theory/termination.md
+++ b/website/content/docs/theory/termination.md
@@ -102,7 +102,10 @@ esbmc file.c --termination --max-inductive-step 3 --interval-analysis
 ```
 
 - `--termination` — enable the reduction and the three-pass pipeline above. It
-  is mutually exclusive with `--k-induction` (k-induction takes precedence).
+  is mutually exclusive with `--k-induction`: when both are given,
+  `--termination` takes priority and the run routes to the sequential
+  termination strategy, keeping the verdict deterministic (the parallel
+  k-induction driver has no termination handling).
 - `--max-inductive-step N` — cap how far the inductive step unwinds. The decisive
   non-termination proofs typically fire at small *k* (2 or 3), so a small cap is
   usually enough.

--- a/website/content/docs/usage.md
+++ b/website/content/docs/usage.md
@@ -555,8 +555,11 @@ frame (`push_ctx`/`pop_ctx`) per claim, so the feature is safe under
 `--smt-during-symex` and does not leak between claims. Machine-readable artifacts
 (`--cex-output`, `--generate-testcase`, `--generate-html-report`,
 `--generate-json-report`, `--witness-output-graphml`, `--witness-output-yaml`)
-fan out per witness using the `<ce>-<file>` prefix scheme, one file per witness,
-so it is also safe under `--parallel-solving`. Enumeration is skipped during the
+fan out per witness using the `<phase>-k<K>-<N>-<file>` prefix scheme —
+`<phase>` is the verification phase (`base`/`fwd`/`indstep`/`bmc`), `<K>` the
+unwind bound, and `<N>` a decimal increasing from zero — one file per witness,
+so it is also safe under `--parallel-solving`, and counterexamples found in
+different k-induction phases or k-steps do not overwrite each other. Enumeration is skipped during the
 inductive step of k-induction (a SAT result there means UNKNOWN, not a real
 counterexample).
 
@@ -580,7 +583,8 @@ path and enumerates input vectors on it.
 ## Supported SMT backends {#smt-backends}
 
 ESBMC integrates several SMT solvers directly via their APIs, and on Unix can
-also drive an external solver process over a pipe:
+also drive an external solver process, either interactively over a pipe or in
+one-shot batch mode:
 
 | Backend | Option |
 |---|---|
@@ -591,6 +595,19 @@ also drive an external solver process over a pipe:
 | CVC4 | `--cvc` |
 | Yices | `--yices` |
 | SMTLIB | `--smtlib --smtlib-solver-prog CMD` |
+| Bitwuzllob | `--bitwuzllob` |
+| NeuroSym | `--neurosym` |
+
+Bitwuzllob and NeuroSym are one-shot subprocess backends: ESBMC renders the
+formula to an SMT-LIB2 file and runs an external program on it in batch mode —
+`mallob` in mono mode (Bitwuzla on the massively parallel Mallob platform) for
+Bitwuzllob, and the NeuroSym neural-guided solver (GAN with Z3 fallback,
+QF_BV only) for NeuroSym. The external command is set with
+`--bitwuzllob-prog CMD` / `--neurosym-prog CMD` (every `%f` is replaced by the
+formula file), and counterexamples are reconstructed by a local interactive
+SMT-LIB2 solver given via `--bitwuzllob-model-prog CMD` /
+`--neurosym-model-prog CMD` (e.g. `"z3 -in"`). Neither backend is ever picked
+implicitly, and NeuroSym rejects `--ir` and incremental strategies.
 
 An alternative default solver can be set with `--default-solver SOLVER` (the
 name without the `--`), which suits a shell alias or the `ESBMC_OPTS`


### PR DESCRIPTION
Add the Bitwuzllob and NeuroSym one-shot subprocess backends (#6058) to
the SMT-backends table, document the new per-witness cex-output naming
scheme (#6082), fix the inverted --termination/--k-induction precedence
claim (#6034), and note standalone --sol input (#6064) and import
processing under the Python --function option (#6073).