### PR TITLE
[python] Rename json_utils::find_function overloads to name semantics

### DIFF
--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -479,7 +479,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     nlohmann::json func_node;
     if (can_fold)
     {
-      func_node = find_function((*ast_json)["body"], "parse_nested_parens");
+      func_node = try_find_function((*ast_json)["body"], "parse_nested_parens");
       if (func_node.empty())
         can_fold = false;
     }
@@ -752,12 +752,12 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       !is_class(func_name, *ast_json))
     {
       // A call into an unrecognised module (e.g. itertools.islice) has no
-      // definition in the AST, so find_function returns an empty node. Skip
+      // definition in the AST, so try_find_function returns an empty node. Skip
       // loading here and let the call fall through to the "Undefined function
       // - replacing with assert(false)" fallback instead of feeding an empty
       // node to get_function_definition, which would dereference missing
       // fields and abort (issue #5898).
-      const auto &func_node = find_function((*ast_json)["body"], func_name);
+      const auto &func_node = try_find_function((*ast_json)["body"], func_name);
       if (!func_node.empty())
         get_function_definition(func_node);
     }
@@ -781,9 +781,6 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     if (!current_func_name_.empty())
     {
       // Walk the function nesting path (split on "@F@").
-      // Use const ref so the non-throwing find_function overload
-      // (returns empty JSON on miss) is selected instead of the
-      // mutable-ref overload that throws.
       const nlohmann::json &ast_body = (*ast_json)["body"];
       nlohmann::json cur_body = ast_body;
       std::string remaining = current_func_name_;
@@ -801,8 +798,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           part = remaining;
           remaining.clear();
         }
-        auto fn =
-          find_function(static_cast<const nlohmann::json &>(cur_body), part);
+        auto fn = try_find_function(cur_body, part);
         if (fn.empty() || !fn.contains("body") || !fn["body"].is_array())
           break;
         for (const auto &stmt : fn["body"])
@@ -823,7 +819,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     if (
       !locally_shadowed && !type_utils::is_builtin_type(callee) &&
       !type_utils::is_python_model_func(callee) &&
-      !find_function((*ast_json)["body"], callee).empty())
+      !try_find_function((*ast_json)["body"], callee).empty())
     {
       // Collect constant arguments
       bool all_const = true;

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1506,7 +1506,7 @@ void python_converter::handle_function_call_rhs(
       if (!func_name.empty())
       {
         const auto &func_def =
-          json_utils::find_function((*ast_json)["body"], func_name);
+          json_utils::try_find_function((*ast_json)["body"], func_name);
         if (
           !func_def.empty() && func_def.contains("returns") &&
           !func_def["returns"].is_null())
@@ -1839,13 +1839,13 @@ std::string python_converter::call_return_class(const nlohmann::json &rhs) const
   if (json_utils::is_class(fname, *ast_json))
     return "";
 
-  const auto &fn = json_utils::find_function((*ast_json)["body"], fname);
+  const auto &fn = json_utils::try_find_function((*ast_json)["body"], fname);
   if (fn.empty() || !fn.contains("returns") || fn["returns"].is_null())
     return "";
 
   // An @overload stub carries a single-class annotation (`-> Foo`) but the
   // overload set is polymorphic — the real return type is resolved per call
-  // site from the argument types. find_function returns the first stub, so
+  // site from the argument types. try_find_function returns the first stub, so
   // trusting its annotation would mis-type, e.g., a `Literal["bar"] -> Bar`
   // result as `Foo*` (#3057). Leave such results to the existing call-site
   // overload resolution rather than forcing a single Class* here.
@@ -3908,7 +3908,7 @@ void python_converter::get_return_statements(
       // Forward reference: function not yet processed
       // Look up return type from AST
       const auto &func_node =
-        json_utils::find_function((*ast_json)["body"], func_name);
+        json_utils::try_find_function((*ast_json)["body"], func_name);
 
       if (
         !func_node.empty() && func_node.contains("returns") &&

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4200,7 +4200,7 @@ std::optional<exprt> function_call_expr::try_handle_round(bool is_user_imported)
 {
   const std::string &func_name = function_id_.get_function();
   const bool has_user_round =
-    !find_function(converter_.ast()["body"], func_name).empty();
+    !try_find_function(converter_.ast()["body"], func_name).empty();
   if (
     func_name == "round" && call_.contains("func") &&
     call_["func"].value("_type", "") == "Name" && !has_user_round &&
@@ -4234,7 +4234,7 @@ std::optional<exprt> function_call_expr::apply_builtin_dispatch(
   if (
     func_name == "sum" && !is_user_imported && !is_numpy_model_call &&
     (n_args == 1 || n_args == 2) &&
-    find_function(converter_.ast()["body"], func_name).empty())
+    try_find_function(converter_.ast()["body"], func_name).empty())
   {
     exprt arg = converter_.get_expr(call_["args"][0]);
     const typet &at = converter_.ns.follow(arg.type());
@@ -4653,8 +4653,8 @@ std::optional<exprt> function_call_expr::resolve_missing_function_symbol(
 
         // Extract return type from function definition in AST
         typet return_type = empty_typet();
-        const auto &func_node =
-          find_function(converter_.ast()["body"], function_id_.get_function());
+        const auto &func_node = try_find_function(
+          converter_.ast()["body"], function_id_.get_function());
         if (!func_node.empty())
         {
           if (func_node.contains("returns") && !func_node["returns"].is_null())
@@ -5767,7 +5767,7 @@ function_call_expr::find_possible_class_types(const symbolt *obj_symbol) const
 
     // Look up the function definition
     const auto &func_node =
-      json_utils::find_function(converter_.ast()["body"], func_name);
+      json_utils::try_find_function(converter_.ast()["body"], func_name);
 
     if (
       func_node.empty() || !func_node.is_object() ||

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -148,8 +148,9 @@ bool is_module(const std::string &module_name, const JsonType &ast)
   return result;
 }
 
+/// Returns an empty JsonType on a miss. Never throws.
 template <typename JsonType>
-JsonType find_function(const JsonType &json, const std::string &func_name)
+JsonType try_find_function(const JsonType &json, const std::string &func_name)
 {
   for (const auto &elem : json)
   {
@@ -159,8 +160,9 @@ JsonType find_function(const JsonType &json, const std::string &func_name)
   return JsonType();
 }
 
+/// Throws std::runtime_error on a miss.
 template <typename JsonType>
-JsonType &find_function(JsonType &json, const std::string &func_name)
+JsonType &find_function_or_throw(JsonType &json, const std::string &func_name)
 {
   for (auto &elem : json)
   {

--- a/src/python-frontend/math/math_guard_utils.cpp
+++ b/src/python-frontend/math/math_guard_utils.cpp
@@ -79,7 +79,7 @@ bool json_arg_contains_or_is_complex_impl(
       return true;
 
     const nlohmann::json &func_node =
-      json_utils::find_function(converter.ast()["body"], called_name);
+      json_utils::try_find_function(converter.ast()["body"], called_name);
 
     if (!func_node.empty())
     {

--- a/src/python-frontend/param_annotations.cpp
+++ b/src/python-frontend/param_annotations.cpp
@@ -14,8 +14,8 @@ bool is_node(const nlohmann::json &node, const char *type)
 }
 
 /// The top-level FunctionDef named @p name in @p body, or null. Unlike
-/// json_utils::find_function this hands back the node itself, so that a call
-/// site can be probed, and a parameter rewritten, without copying the function.
+/// json_utils::try_find_function this hands back the node itself, so that a
+/// call site can be probed, and a parameter rewritten, without copying it.
 template <typename Json>
 Json *find_function(Json &body, const std::string &name)
 {

--- a/src/python-frontend/python-dict/dict_access.cpp
+++ b/src/python-frontend/python-dict/dict_access.cpp
@@ -216,7 +216,7 @@ exprt python_dict_handler::handle_dict_subscript(
         {
           std::string func_name =
             var_decl["value"]["func"]["id"].get<std::string>();
-          nlohmann::json func_def = json_utils::find_function(
+          nlohmann::json func_def = json_utils::try_find_function(
             converter_.get_ast_json()["body"], func_name);
 
           if (

--- a/src/python-frontend/python-dict/dict_methods.cpp
+++ b/src/python-frontend/python-dict/dict_methods.cpp
@@ -894,7 +894,7 @@ typet python_dict_handler::get_popitem_tuple_type(const exprt &dict_expr)
         {
           std::string func_name =
             var_decl["value"]["func"]["id"].get<std::string>();
-          nlohmann::json func_def = json_utils::find_function(
+          nlohmann::json func_def = json_utils::try_find_function(
             converter_.get_ast_json()["body"], func_name);
           if (
             !func_def.empty() && func_def.contains("returns") &&

--- a/src/python-frontend/python-dict/dict_type_resolution.cpp
+++ b/src/python-frontend/python-dict/dict_type_resolution.cpp
@@ -500,8 +500,8 @@ typet python_dict_handler::resolve_expected_type_for_dict_subscript(
       std::string func_name = call_node["func"]["id"].get<std::string>();
 
       // Find the function definition to get its return type annotation
-      nlohmann::json func_def =
-        json_utils::find_function(converter_.get_ast_json()["body"], func_name);
+      nlohmann::json func_def = json_utils::try_find_function(
+        converter_.get_ast_json()["body"], func_name);
 
       if (
         !func_def.empty() && func_def.contains("returns") &&

--- a/src/python-frontend/python-list/list_type_inference.cpp
+++ b/src/python-frontend/python-list/list_type_inference.cpp
@@ -179,7 +179,7 @@ typet infer_elem_type_from_call_return(
   if (func["_type"] == "Name" && func.contains("id") && func["id"].is_string())
   {
     nlohmann::json function_node =
-      json_utils::find_function(ast["body"], func["id"].get<std::string>());
+      json_utils::try_find_function(ast["body"], func["id"].get<std::string>());
     return get_elem_type_from_return_annotation(function_node, type_handler_);
   }
 
@@ -204,7 +204,7 @@ typet infer_elem_type_from_call_return(
         json_utils::find_class(ast["body"], class_name);
       if (!class_node.is_null() && class_node.contains("body"))
       {
-        nlohmann::json function_node = json_utils::find_function(
+        nlohmann::json function_node = json_utils::try_find_function(
           class_node["body"], func["attr"].get<std::string>());
         return get_elem_type_from_return_annotation(
           function_node, type_handler_);

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -961,7 +961,7 @@ std::string python_annotation<Json>::recover_list_type_from_appends(
   const std::string &scope = get_current_func_name();
   const Json &module_body = ast_["body"];
   Json func =
-    scope.empty() ? Json() : json_utils::find_function(module_body, scope);
+    scope.empty() ? Json() : json_utils::try_find_function(module_body, scope);
   const Json &body =
     (!func.empty() && func.contains("body")) ? func["body"] : module_body;
 
@@ -2663,13 +2663,10 @@ InferResult python_annotation<Json>::infer_type(
   {
     // If RHS is a function name (e.g. g = f), skip annotation so the
     // converter can infer the function-pointer type directly.
-    // Use the non-throwing (const) overload to avoid crashing on names
-    // that are not FunctionDefs.
     if (
       value_type == "Name" && stmt["value"].contains("id") &&
-      !json_utils::find_function(
-         static_cast<const nlohmann::json &>(ast_["body"]),
-         stmt["value"]["id"].template get<std::string>())
+      !json_utils::try_find_function(
+         ast_["body"], stmt["value"]["id"].template get<std::string>())
          .empty())
       return InferResult::UNKNOWN;
 
@@ -3753,12 +3750,9 @@ void python_annotation<Json>::infer_parameter_types(Json &function_element)
             {
               const std::string &def_name =
                 def_node["id"].template get<std::string>();
-              // Use non-throwing (const) overload to avoid crashing when
-              // def_name is a variable (not a FunctionDef).
-              const nlohmann::json &const_body =
-                static_cast<const nlohmann::json &>(ast_["body"]);
+              const nlohmann::json &const_body = ast_["body"];
               // Direct function reference (op=f)?
-              if (!json_utils::find_function(const_body, def_name).empty())
+              if (!json_utils::try_find_function(const_body, def_name).empty())
                 inferred_type = "Any";
               // Function alias (op=g where g=f)?
               else
@@ -3773,7 +3767,7 @@ void python_annotation<Json>::infer_parameter_types(Json &function_element)
                     stmt.contains("value") && stmt["value"].contains("_type") &&
                     stmt["value"]["_type"] == "Name" &&
                     stmt["value"].contains("id") &&
-                    !json_utils::find_function(
+                    !json_utils::try_find_function(
                        const_body,
                        stmt["value"]["id"].template get<std::string>())
                        .empty())
@@ -4206,7 +4200,8 @@ void python_annotation<Json>::get_global_elements(const Json &node)
       {
         try
         {
-          auto func_node = json_utils::find_function(ast_["body"], func_name);
+          auto func_node =
+            json_utils::find_function_or_throw(ast_["body"], func_name);
           get_global_elements(func_node);
         }
         catch (std::runtime_error &)
@@ -4539,14 +4534,11 @@ void python_annotation<Json>::add_annotation(Json &body)
         element["value"]["_type"] == "Call" &&
         element["value"]["func"]["_type"] == "Name")
       {
-        // Use the const overload (returns by value, empty on a miss)
-        // rather than the non-const one (returns by reference, throws on a
-        // miss): the callee named here need not be a top-level FunctionDef
-        // in this same ast_ (it could be a builtin or something resolved
-        // elsewhere), and this is a best-effort forward-reference scan, not
-        // a hard requirement.
+        // Best-effort forward-reference scan: the callee named here need
+        // not be a top-level FunctionDef in this same ast_ (it could be a
+        // builtin or something resolved elsewhere).
         const Json &top_level_body = ast_["body"];
-        Json func_node = json_utils::find_function(
+        Json func_node = json_utils::try_find_function(
           top_level_body, element["value"]["func"]["id"]);
         if (!func_node.empty())
           add_annotation(func_node);

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -513,7 +513,7 @@ bool string_handler::try_extract_const_string_expr(
           if (!path.empty())
           {
             nlohmann::json func_scope =
-              json_utils::find_function(ast["body"], path.back());
+              json_utils::try_find_function(ast["body"], path.back());
             if (
               !func_scope.empty() && try_const_string_from_single_assignment(
                                        bare_name, func_scope, out))
@@ -3308,8 +3308,9 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
       const std::string &scope_func = converter_.get_current_func_name();
       const nlohmann::json &ast = converter_.get_ast_json();
       const nlohmann::json func_node =
-        scope_func.empty() ? nlohmann::json()
-                           : json_utils::find_function(ast["body"], scope_func);
+        scope_func.empty()
+          ? nlohmann::json()
+          : json_utils::try_find_function(ast["body"], scope_func);
       const nlohmann::json &scan_body =
         func_node.contains("body") ? func_node["body"] : ast["body"];
       if (list_var_is_mutated(scan_body, var_name))


### PR DESCRIPTION
Fixes #6078.

`json_utils::find_function` had two same-named overloads with opposite failure semantics, selected purely by the constness of the JSON argument: the const-ref overload returns an empty node on a miss, the non-const-ref overload throws `std::runtime_error`. Which one a call site got was invisible at the call site itself — this already produced one real uncaught-throw crash (fixed in #6073).

This PR renames the pair so the contract is visible at every call site:

- `try_find_function` — non-throwing, returns an empty node on a miss
- `find_function_or_throw` — throws on a miss

All ~25 call sites across `src/python-frontend/` were audited individually for which semantics they actually assume:

- Every site except one already resolved to (and intended) the non-throwing overload → `try_find_function`, mechanical.
- `annotation_conversion.inl` (get_global_elements) intentionally uses throwing semantics inside an existing try/catch → `find_function_or_throw`.
- **Latent bug fixed:** `python-list/list_type_inference.cpp` passed a non-const local (`class_node["body"]`), silently selecting the *throwing* overload with no handler — a method absent from the class body would crash ESBMC. The surrounding code (`get_elem_type_from_return_annotation`) handles empty nodes, so it now uses `try_find_function`. No regression test is included for this site: the branch sits behind several earlier element-type inference fallbacks and I could not construct a Python program that reaches it end-to-end (four shapes attempted, verified via instrumentation) — it is defensive code, and the rename removes the hazard by construction.

Also drops the now-unneeded `static_cast<const nlohmann::json&>` workarounds and the comments explaining overload selection, and updates prose references to the old name.

No functional change apart from the latent-crash fix. Built clean; 1-in-10 and 1-in-50 stride samples of the python regression suite pass (the full 4427-test suite exceeds the local 5-minute cap — CI runs it in full).