### PR TITLE
[python] Recover tuple dict-value types on subscript and items() reads

### DIFF
--- a/regression/python/github_5444_tuple_value_items/main.py
+++ b/regression/python/github_5444_tuple_value_items/main.py
@@ -1,0 +1,9 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+n = 0
+for k, v in d.items():
+    if k == 1:
+        assert v[0] == 'A'
+    if k == 2:
+        assert v[1] == 'D'
+    n += 1
+assert n == 2

--- a/regression/python/github_5444_tuple_value_items/test.desc
+++ b/regression/python/github_5444_tuple_value_items/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5444_tuple_value_items_fail/main.py
+++ b/regression/python/github_5444_tuple_value_items_fail/main.py
@@ -1,0 +1,9 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+n = 0
+for k, v in d.items():
+    if k == 1:
+        assert v[0] == 'A'
+    if k == 2:
+        assert v[1] == 'C'
+    n += 1
+assert n == 2

--- a/regression/python/github_5444_tuple_value_items_fail/test.desc
+++ b/regression/python/github_5444_tuple_value_items_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/github_5444_tuple_value_items_typed/main.py
+++ b/regression/python/github_5444_tuple_value_items_typed/main.py
@@ -1,0 +1,11 @@
+from typing import Any
+x: Any = 5
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+n = 0
+for k, v in d.items():
+    if k == 1:
+        assert v[0] == 'A'
+    if k == 2:
+        assert v[1] == 'D'
+    n += 1
+assert n == 2

--- a/regression/python/github_5444_tuple_value_items_typed/test.desc
+++ b/regression/python/github_5444_tuple_value_items_typed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5444_tuple_value_subscript/main.py
+++ b/regression/python/github_5444_tuple_value_subscript/main.py
@@ -1,0 +1,15 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+v = d[1]
+assert v[0] == 'A'
+assert v[1] == 'B'
+assert len(v) == 2
+
+t = ('X', 'Y')
+d2 = {1: t}
+w = d2[1]
+assert w[0] == 'X'
+
+nums = {1: (10, 20)}
+p = nums[1]
+assert p[0] == 10
+assert p[1] == 20

--- a/regression/python/github_5444_tuple_value_subscript/test.desc
+++ b/regression/python/github_5444_tuple_value_subscript/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5444_tuple_value_subscript_fail/main.py
+++ b/regression/python/github_5444_tuple_value_subscript_fail/main.py
@@ -1,0 +1,15 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+v = d[1]
+assert v[0] == 'A'
+assert v[1] == 'C'
+assert len(v) == 2
+
+t = ('X', 'Y')
+d2 = {1: t}
+w = d2[1]
+assert w[0] == 'X'
+
+nums = {1: (10, 20)}
+p = nums[1]
+assert p[0] == 10
+assert p[1] == 20

--- a/regression/python/github_5444_tuple_value_subscript_fail/test.desc
+++ b/regression/python/github_5444_tuple_value_subscript_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -512,28 +512,11 @@ void python_converter::handle_assignment_type_adjustments(
     // with Any annotation are excluded.
     if (
       ast_node.contains("_type") && ast_node["_type"] == "AnnAssign" &&
-      !ast_node.value("_inferred_annotation", false) && has_annotation &&
+      !ast_node.value("_inferred_annotation", false) &&
+      !ast_node.value("esbmc_synthesized", false) && has_annotation &&
       ast_node["annotation"].contains("id") &&
       ast_node["annotation"]["id"] == "Any" && lhs.type().is_pointer() &&
-      [this]() {
-        // Check if "from typing import Any" exists in the source file
-        const auto &body = (*ast_json)["body"];
-        for (const auto &stmt : body)
-        {
-          if (
-            stmt.contains("_type") && stmt["_type"] == "ImportFrom" &&
-            stmt.contains("module") && stmt["module"] == "typing" &&
-            stmt.contains("names"))
-          {
-            for (const auto &name : stmt["names"])
-            {
-              if (name.contains("name") && name["name"] == "Any")
-                return true;
-            }
-          }
-        }
-        return false;
-      }())
+      json_utils::is_imported_from(*ast_json, "typing", "Any"))
     {
       if (rhs.type().is_array())
       {
@@ -650,11 +633,20 @@ void python_converter::handle_assignment_type_adjustments(
         lhs.type() = rhs.type();
       }
     }
-    // No annotation or preprocessor-inferred Any: propagate rhs type to lhs.
+    // No annotation or an inferred Any: propagate rhs type to lhs. An "Any"
+    // annotation counts as inferred when flagged by the annotation pass,
+    // when the preprocessor marked it as synthesized (e.g. the items()-loop
+    // value variable `v: Any = ESBMC_vals_N[i]`), or when the module never
+    // imports typing.Any (then no top-level user annotation can be a live
+    // Any). Without this, the declared void* overrides a concrete rhs type —
+    // a tuple dict-value read then misfolds every component access (#5444
+    // latent item).
     else if (
       (!has_annotation ||
-       (ast_node.value("_inferred_annotation", false) &&
-        ast_node["annotation"].value("id", std::string()) == "Any")) &&
+       (ast_node["annotation"].value("id", std::string()) == "Any" &&
+        (ast_node.value("_inferred_annotation", false) ||
+         ast_node.value("esbmc_synthesized", false) ||
+         !json_utils::is_imported_from(*ast_json, "typing", "Any")))) &&
       !rhs.type().is_empty() && lhs.type() != rhs.type() &&
       !rhs.type().is_code() &&
       !(rhs.type().is_pointer() && rhs.type().subtype().id() == "empty"))
@@ -2753,7 +2745,23 @@ void python_converter::get_var_assign(
           const std::string &src = python_dict_handler::get_internal_list_id(
             dict_id, component == "keys");
           if (!src.empty())
+          {
             python_list::copy_type_info(src, lhs_identifier);
+            // Tuple values are recorded under the $dict_value_types$ key,
+            // not the values-list id (github_3719_4), so the copy above is
+            // a no-op for them. Propagate the stored tuple struct type so
+            // the generic list tuple-element read resolves it.
+            if (component == "values")
+            {
+              typet tuple_t =
+                dict_handler_->recorded_tuple_value_type(dict_sym);
+              if (
+                !tuple_t.is_nil() && !tuple_t.is_empty() &&
+                python_list::get_list_type_map_size(lhs_identifier) == 0)
+                python_list::add_type_info_entry(
+                  lhs_identifier, std::string(), tuple_t);
+            }
+          }
         }
       }
 

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -170,6 +170,28 @@ JsonType &find_function(JsonType &json, const std::string &func_name)
   throw std::runtime_error("Function " + func_name + " not found\n");
 }
 
+/// True when `from <module> import <entity>` appears at the AST top level.
+template <typename JsonType>
+bool is_imported_from(
+  const JsonType &ast,
+  const std::string &module,
+  const std::string &entity)
+{
+  for (const auto &stmt : ast["body"])
+  {
+    if (
+      stmt.contains("_type") && stmt["_type"] == "ImportFrom" &&
+      stmt.contains("module") && stmt["module"] == module &&
+      stmt.contains("names"))
+    {
+      for (const auto &name : stmt["names"])
+        if (name.contains("name") && name["name"] == entity)
+          return true;
+    }
+  }
+  return false;
+}
+
 template <typename JsonType>
 const JsonType &
 find_imported_function(const JsonType &ast, const std::string &func_name)

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1551,6 +1551,11 @@ class LoopMixin:
             value=subscript,
             simple=1,
         )
+        # ast2json serializes non-underscore attributes, so the converter can
+        # tell this synthesized annotation apart from a user-written one
+        # (an explicit `v: Any` must keep Any semantics; a synthesized one
+        # must not override the rhs element type).
+        assign.esbmc_synthesized = True
         self.ensure_all_locations(assign, node)
         return assign
 

--- a/src/python-frontend/python-dict/dict_type_resolution.cpp
+++ b/src/python-frontend/python-dict/dict_type_resolution.cpp
@@ -186,6 +186,10 @@ typet python_dict_handler::resolve_expected_type_for_dict_subscript(
     !var_decl["annotation"].contains("slice");
   if (no_annotation || bare_dict_annotation)
   {
+    typet recorded = recorded_tuple_value_type(dict_expr);
+    if (!recorded.is_nil() && !recorded.is_empty())
+      return recorded;
+
     if (
       var_decl.contains("value") && var_decl["value"].is_object() &&
       var_decl["value"].value("_type", std::string()) == "Dict" &&
@@ -516,7 +520,42 @@ typet python_dict_handler::resolve_expected_type_for_dict_subscript(
   }
 
   // Extract the value type from the dict annotation
-  return get_dict_value_type_from_annotation(var_decl["annotation"]);
+  typet result = get_dict_value_type_from_annotation(var_decl["annotation"]);
+  if (result.is_nil() || result.is_empty())
+  {
+    typet recorded = recorded_tuple_value_type(dict_expr);
+    if (!recorded.is_nil() && !recorded.is_empty())
+      return recorded;
+  }
+  return result;
+}
+
+/// Homogeneous tuple values: the struct type recorded at construction
+/// (tagged and string-padded), which neither an annotation nor an AST
+/// literal peek reproduces. Empty when the dict was not built from a
+/// literal or its value types are not a single tuple type.
+typet python_dict_handler::recorded_tuple_value_type(
+  const exprt &dict_expr) const
+{
+  const std::string &vals_id =
+    get_internal_list_id(dict_expr.identifier().as_string(), false);
+  if (vals_id.empty())
+    return empty_typet();
+
+  auto it = python_list::list_type_map.find(dict_value_types_key(vals_id));
+  if (it == python_list::list_type_map.end() || it->second.empty())
+    return empty_typet();
+
+  const typet &first = it->second.front().second;
+  const bool all_same_tuple =
+    converter_.get_tuple_handler().is_tuple_type(first) &&
+    std::all_of(
+      it->second.begin(),
+      it->second.end(),
+      [&first](const std::pair<std::string, typet> &e) {
+        return e.second == first;
+      });
+  return all_same_tuple ? first : static_cast<typet>(empty_typet());
 }
 
 typet python_dict_handler::get_dict_key_type_from_annotation(

--- a/src/python-frontend/python-dict/python_dict_handler.h
+++ b/src/python-frontend/python-dict/python_dict_handler.h
@@ -365,6 +365,13 @@ public:
   typet resolve_expected_type_for_dict_subscript(const exprt &dict_expr);
 
   /**
+   * @brief Stored tuple struct type of a literal dict's values, recorded at
+   * construction; empty unless every value has the same tuple type.
+   * @param dict_expr The dictionary expression (must be a symbol)
+   */
+  typet recorded_tuple_value_type(const exprt &dict_expr) const;
+
+  /**
    * @brief Check and handle dictionary subscript assignment
    *
    * Checks if the target is a dictionary subscript and handles the assignment


### PR DESCRIPTION
Fixes the **latent tuple-values item** of #5444: tuple values stored in a Python dict misread on every access path — `d[k][0]` spuriously fails, `len(d[k])` hard-errors (`strlen` on `empty` type), and `for k, v in d.items(): v[0]` misfolds the component comparison at conversion time (all reproduced on master; all pass CPython 3.12).

Three coordinated changes:

1. **`python-dict/dict_type_resolution.cpp`** — new helper `recorded_tuple_value_type()`: dict construction already records each value's exact stored type (tagged, string-padded tuple struct) under the `$dict_value_types$` key of the shared type map; resolution now returns it for subscript reads when **all** values share one identical tuple type. Guarded so heterogeneous dicts (github_3719_4) are untouched — verified differentially against a pre-patch binary. The existing class-struct read branch then handles the value correctly.

2. **`converter/converter_stmt.cpp`** — the `items()`-loop desugar copies `ESBMC_vals_N = d.values()`; the values-list id deliberately carries no type-map entries, so the copy propagated nothing. Now also propagates the recorded tuple type as a single uniform entry (only when the destination map is empty), letting the already-working list tuple-element read resolve it.

3. **`preprocessor/loop_mixin.py` + `converter_stmt.cpp` + `json_utils.h`** — the desugar emits `v: Any = ESBMC_vals_N[i]`; the declared `Any` (void\*) overrode the resolved tuple struct. The preprocessor now marks its synthesized AnnAssigns with `esbmc_synthesized` (serialized by the vendored ast2json), and the converter treats them as inferred — both in the explicit-Any handler and in rhs-type propagation. A module with no top-level `from typing import Any` is likewise treated as having no live explicit `Any` (new `json_utils::is_imported_from`, which also replaces the equivalent inline lambda). Explicit user-written `x: Any` with the import keeps its existing semantics.

**Tests:** five new regression dirs — `github_5444_tuple_value_subscript`(+`_fail`), `github_5444_tuple_value_items`(+`_fail`), and `github_5444_tuple_value_items_typed` (the coverage-gap reproducer found in review: same loop with an unrelated `from typing import Any` in scope). All validated under CPython 3.12 (`scripts/check_python_tests.sh`) and ESBMC; the items test failed on a pre-patch binary and passes now.

**Validation:** 427 dict/tuple/Any/annotation regression tests pass; 177-test stride sample of the python suite passes (one pre-existing FUTURE-tagged timeout, identical on the pre-patch binary); clang-format 11 clean; yapf clean; pylint clean.

Not addressed here (out of scope, per the issue): parameter-dict element-type erasure across call boundaries (#5444 §1 core blocker is already fixed and pinned by `param_dict_items`/`param_dict_float_value`), and the `shortest_paths` KNOWNBUG flip, which is blocked by SMT blowup (#4803), not the frontend.