### PR TITLE
[python] Fix SMT-encoder segfault on explicit-Any ctor assignment

### DIFF
--- a/regression/python/github_2848_any_ctor/main.py
+++ b/regression/python/github_2848_any_ctor/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def get(self) -> int:
+        return self.v
+
+
+x: Any = C(7)
+assert x.v == 7
+assert x.get() == 7
+
+f: Any = lambda a: a + 1
+assert f(2) == 3

--- a/regression/python/github_2848_any_ctor/test.desc
+++ b/regression/python/github_2848_any_ctor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2848_any_ctor_fail/main.py
+++ b/regression/python/github_2848_any_ctor_fail/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def get(self) -> int:
+        return self.v
+
+
+x: Any = C(7)
+assert x.v == 8
+assert x.get() == 7
+
+f: Any = lambda a: a + 1
+assert f(2) == 3

--- a/regression/python/github_2848_any_ctor_fail/test.desc
+++ b/regression/python/github_2848_any_ctor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -510,12 +510,16 @@ void python_converter::handle_assignment_type_adjustments(
     // and annotated `x: Any = value`.
     // Preprocessor-generated AnnAssign nodes
     // with Any annotation are excluded.
+    // Constructor calls must fall through to the regular ctor machinery:
+    // returning early here would emit no constructor call at all, leaving a
+    // nil assignment that crashes the SMT encoder.
     if (
       ast_node.contains("_type") && ast_node["_type"] == "AnnAssign" &&
       !ast_node.value("_inferred_annotation", false) &&
       !ast_node.value("esbmc_synthesized", false) && has_annotation &&
       ast_node["annotation"].contains("id") &&
       ast_node["annotation"]["id"] == "Any" && lhs.type().is_pointer() &&
+      !is_ctor_call && !rhs.type().is_code() &&
       json_utils::is_imported_from(*ast_json, "typing", "Any"))
     {
       if (rhs.type().is_array())


### PR DESCRIPTION
Stacked on #6110 (the last two commits are new). Towards #2848.
`x: Any = C(7)` segfaulted the SMT encoder: the explicit-Any handler matched the AnnAssign before the constructor machinery ran, cast the code-typed ctor-call expression to void*, and returned early, so a nil assignment reached the encoder.
Exclude ctor calls and code-typed rhs from the explicit-Any block so they fall through to the regular paths; lambdas under explicit Any keep working.
Tests github_2848_any_ctor{,_fail}, CPython-validated; 579 dict/tuple/Any/class regression tests pass.
