### PR TITLE
[python] Fix dict.get() abort and misread on tuple values

### DIFF
--- a/regression/python/github_2848_any_ctor/main.py
+++ b/regression/python/github_2848_any_ctor/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def get(self) -> int:
+        return self.v
+
+
+x: Any = C(7)
+assert x.v == 7
+assert x.get() == 7
+
+f: Any = lambda a: a + 1
+assert f(2) == 3

--- a/regression/python/github_2848_any_ctor/test.desc
+++ b/regression/python/github_2848_any_ctor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2848_any_ctor_fail/main.py
+++ b/regression/python/github_2848_any_ctor_fail/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def get(self) -> int:
+        return self.v
+
+
+x: Any = C(7)
+assert x.v == 8
+assert x.get() == 7
+
+f: Any = lambda a: a + 1
+assert f(2) == 3

--- a/regression/python/github_2848_any_ctor_fail/test.desc
+++ b/regression/python/github_2848_any_ctor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/github_5444_tuple_value_get/main.py
+++ b/regression/python/github_5444_tuple_value_get/main.py
@@ -1,0 +1,14 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+v = d.get(1)
+assert v is not None
+assert v[0] == 'A'
+assert v[1] == 'B'
+
+m = d.get(3)
+assert m is None
+
+nums = {1: (10, 20)}
+w = nums.get(2, (0, 0))
+assert w[0] == 0
+u = nums.get(1, (0, 0))
+assert u[1] == 20

--- a/regression/python/github_5444_tuple_value_get/test.desc
+++ b/regression/python/github_5444_tuple_value_get/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5444_tuple_value_get_fail/main.py
+++ b/regression/python/github_5444_tuple_value_get_fail/main.py
@@ -1,0 +1,14 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+v = d.get(1)
+assert v is not None
+assert v[0] == 'A'
+assert v[1] == 'A'
+
+m = d.get(3)
+assert m is None
+
+nums = {1: (10, 20)}
+w = nums.get(2, (0, 0))
+assert w[0] == 0
+u = nums.get(1, (0, 0))
+assert u[1] == 20

--- a/regression/python/github_5444_tuple_value_get_fail/test.desc
+++ b/regression/python/github_5444_tuple_value_get_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1498,8 +1498,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     // the value field before dispatching to the tuple handler.
     if (
       array_type.is_struct() &&
-      to_struct_type(array_type).tag().as_string().starts_with(
-        "tag-Optional_"))
+      to_struct_type(array_type).tag().as_string().starts_with("tag-Optional_"))
     {
       exprt unwrapped = unwrap_optional_if_needed(array, element);
       if (tuple_handler_->is_tuple_type(unwrapped.type()))

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1493,6 +1493,21 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         array_type = pointed;
       }
     }
+    // Unwrap Optional[tuple] (e.g. `v = d.get(k); v[0]`): subscripting
+    // implies the payload is present (None would be a TypeError), so read
+    // the value field before dispatching to the tuple handler.
+    if (
+      array_type.is_struct() &&
+      to_struct_type(array_type).tag().as_string().starts_with(
+        "tag-Optional_"))
+    {
+      exprt unwrapped = unwrap_optional_if_needed(array, element);
+      if (tuple_handler_->is_tuple_type(unwrapped.type()))
+      {
+        array = unwrapped;
+        array_type = unwrapped.type();
+      }
+    }
     if (tuple_handler_->is_tuple_type(array_type))
     {
       expr = tuple_handler_->handle_tuple_subscript(array, slice, element);

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -510,12 +510,16 @@ void python_converter::handle_assignment_type_adjustments(
     // and annotated `x: Any = value`.
     // Preprocessor-generated AnnAssign nodes
     // with Any annotation are excluded.
+    // Constructor calls must fall through to the regular ctor machinery:
+    // returning early here would emit no constructor call at all, leaving a
+    // nil assignment that crashes the SMT encoder.
     if (
       ast_node.contains("_type") && ast_node["_type"] == "AnnAssign" &&
       !ast_node.value("_inferred_annotation", false) &&
       !ast_node.value("esbmc_synthesized", false) && has_annotation &&
       ast_node["annotation"].contains("id") &&
       ast_node["annotation"]["id"] == "Any" && lhs.type().is_pointer() &&
+      !is_ctor_call && !rhs.type().is_code() &&
       json_utils::is_imported_from(*ast_json, "typing", "Any"))
     {
       if (rhs.type().is_array())

--- a/src/python-frontend/python-dict/dict_methods.cpp
+++ b/src/python-frontend/python-dict/dict_methods.cpp
@@ -197,8 +197,26 @@ exprt python_dict_handler::handle_dict_get(
   }
   else
   {
-    exprt value_as_typed = build_typecast(obj_value, result_type);
-    retrieved_value = value_as_typed;
+    namespacet ns(symbol_table_);
+    typet underlying = result_type;
+    if (underlying.id() == "symbol")
+      underlying = ns.follow(underlying);
+    if (underlying.is_struct())
+    {
+      // A struct value (e.g. a tuple) is stored by address; casting the
+      // void* payload directly to the struct type builds an ill-formed
+      // scalar typecast that aborts the value-set walker. Cast to a struct
+      // pointer and dereference instead (mirrors handle_dict_subscript).
+      exprt value_as_struct_ptr =
+        build_typecast(obj_value, pointer_typet(underlying));
+      retrieved_value = build_dereference(value_as_struct_ptr, underlying);
+      retrieved_value.type() = underlying;
+    }
+    else
+    {
+      exprt value_as_typed = build_typecast(obj_value, result_type);
+      retrieved_value = value_as_typed;
+    }
   }
 
   exprt then_value =
@@ -431,8 +449,26 @@ exprt python_dict_handler::handle_dict_setdefault(
   }
   else
   {
-    exprt value_as_typed = build_typecast(obj_value, result_type);
-    retrieved_value = value_as_typed;
+    namespacet ns(symbol_table_);
+    typet underlying = result_type;
+    if (underlying.id() == "symbol")
+      underlying = ns.follow(underlying);
+    if (underlying.is_struct())
+    {
+      // A struct value (e.g. a tuple) is stored by address; casting the
+      // void* payload directly to the struct type builds an ill-formed
+      // scalar typecast that aborts the value-set walker. Cast to a struct
+      // pointer and dereference instead (mirrors handle_dict_subscript).
+      exprt value_as_struct_ptr =
+        build_typecast(obj_value, pointer_typet(underlying));
+      retrieved_value = build_dereference(value_as_struct_ptr, underlying);
+      retrieved_value.type() = underlying;
+    }
+    else
+    {
+      exprt value_as_typed = build_typecast(obj_value, result_type);
+      retrieved_value = value_as_typed;
+    }
   }
 
   code_assignt value_assign(build_symbol(result_var), retrieved_value);


### PR DESCRIPTION
Stacked on #6111 (only the last commit is new); part of the #5444 tuple-values family.
`d.get(k)` on tuple-valued dicts aborted ESBMC: the fallback cast the void* payload directly to the struct type, an ill-formed scalar typecast that blew up the value-set walker — newly reachable since #6109 made dict value-type resolution return tuple struct types.
Cast struct results to a struct pointer and dereference instead; `d.get(k)` with no default returns Optional[tuple] and subscripting unwraps the payload first, while `is None` semantics are unchanged.
Tests github_5444_tuple_value_get{,_fail}, CPython-validated; 395 dict/tuple/optional regression tests pass.
