### PR TITLE
[python] Type inner elements of list values read out of dicts

### DIFF
--- a/regression/python/github_2848_any_ctor/main.py
+++ b/regression/python/github_2848_any_ctor/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def get(self) -> int:
+        return self.v
+
+
+x: Any = C(7)
+assert x.v == 7
+assert x.get() == 7
+
+f: Any = lambda a: a + 1
+assert f(2) == 3

--- a/regression/python/github_2848_any_ctor/test.desc
+++ b/regression/python/github_2848_any_ctor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2848_any_ctor_fail/main.py
+++ b/regression/python/github_2848_any_ctor_fail/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+class C:
+    def __init__(self, v: int):
+        self.v = v
+
+    def get(self) -> int:
+        return self.v
+
+
+x: Any = C(7)
+assert x.v == 8
+assert x.get() == 7
+
+f: Any = lambda a: a + 1
+assert f(2) == 3

--- a/regression/python/github_2848_any_ctor_fail/test.desc
+++ b/regression/python/github_2848_any_ctor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/github_5444_dict_list_value/main.py
+++ b/regression/python/github_5444_dict_list_value/main.py
@@ -1,0 +1,13 @@
+d = {1: [(1, 2), (3, 4)], 2: [(5, 6)]}
+a = d[1]
+t = a[1]
+assert t[0] == 3
+assert t[1] == 4
+b = d[2]
+u = b[0]
+assert u[1] == 6
+
+nums = {1: [10, 20, 30]}
+lst = nums[1]
+assert lst[1] == 20
+assert len(lst) == 3

--- a/regression/python/github_5444_dict_list_value/test.desc
+++ b/regression/python/github_5444_dict_list_value/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5444_dict_list_value_fail/main.py
+++ b/regression/python/github_5444_dict_list_value_fail/main.py
@@ -1,0 +1,13 @@
+d = {1: [(1, 2), (3, 4)], 2: [(5, 6)]}
+a = d[1]
+t = a[1]
+assert t[0] == 4
+assert t[1] == 4
+b = d[2]
+u = b[0]
+assert u[1] == 6
+
+nums = {1: [10, 20, 30]}
+lst = nums[1]
+assert lst[1] == 20
+assert len(lst) == 3

--- a/regression/python/github_5444_dict_list_value_fail/test.desc
+++ b/regression/python/github_5444_dict_list_value_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION FAILED$

--- a/regression/python/github_5444_tuple_value_get/main.py
+++ b/regression/python/github_5444_tuple_value_get/main.py
@@ -1,0 +1,14 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+v = d.get(1)
+assert v is not None
+assert v[0] == 'A'
+assert v[1] == 'B'
+
+m = d.get(3)
+assert m is None
+
+nums = {1: (10, 20)}
+w = nums.get(2, (0, 0))
+assert w[0] == 0
+u = nums.get(1, (0, 0))
+assert u[1] == 20

--- a/regression/python/github_5444_tuple_value_get/test.desc
+++ b/regression/python/github_5444_tuple_value_get/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_5444_tuple_value_get_fail/main.py
+++ b/regression/python/github_5444_tuple_value_get_fail/main.py
@@ -1,0 +1,14 @@
+d = {1: ('A', 'B'), 2: ('C', 'D')}
+v = d.get(1)
+assert v is not None
+assert v[0] == 'A'
+assert v[1] == 'A'
+
+m = d.get(3)
+assert m is None
+
+nums = {1: (10, 20)}
+w = nums.get(2, (0, 0))
+assert w[0] == 0
+u = nums.get(1, (0, 0))
+assert u[1] == 20

--- a/regression/python/github_5444_tuple_value_get_fail/test.desc
+++ b/regression/python/github_5444_tuple_value_get_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1498,8 +1498,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     // the value field before dispatching to the tuple handler.
     if (
       array_type.is_struct() &&
-      to_struct_type(array_type).tag().as_string().starts_with(
-        "tag-Optional_"))
+      to_struct_type(array_type).tag().as_string().starts_with("tag-Optional_"))
     {
       exprt unwrapped = unwrap_optional_if_needed(array, element);
       if (tuple_handler_->is_tuple_type(unwrapped.type()))

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1493,6 +1493,21 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         array_type = pointed;
       }
     }
+    // Unwrap Optional[tuple] (e.g. `v = d.get(k); v[0]`): subscripting
+    // implies the payload is present (None would be a TypeError), so read
+    // the value field before dispatching to the tuple handler.
+    if (
+      array_type.is_struct() &&
+      to_struct_type(array_type).tag().as_string().starts_with(
+        "tag-Optional_"))
+    {
+      exprt unwrapped = unwrap_optional_if_needed(array, element);
+      if (tuple_handler_->is_tuple_type(unwrapped.type()))
+      {
+        array = unwrapped;
+        array_type = unwrapped.type();
+      }
+    }
     if (tuple_handler_->is_tuple_type(array_type))
     {
       expr = tuple_handler_->handle_tuple_subscript(array, slice, element);

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -510,12 +510,16 @@ void python_converter::handle_assignment_type_adjustments(
     // and annotated `x: Any = value`.
     // Preprocessor-generated AnnAssign nodes
     // with Any annotation are excluded.
+    // Constructor calls must fall through to the regular ctor machinery:
+    // returning early here would emit no constructor call at all, leaving a
+    // nil assignment that crashes the SMT encoder.
     if (
       ast_node.contains("_type") && ast_node["_type"] == "AnnAssign" &&
       !ast_node.value("_inferred_annotation", false) &&
       !ast_node.value("esbmc_synthesized", false) && has_annotation &&
       ast_node["annotation"].contains("id") &&
       ast_node["annotation"]["id"] == "Any" && lhs.type().is_pointer() &&
+      !is_ctor_call && !rhs.type().is_code() &&
       json_utils::is_imported_from(*ast_json, "typing", "Any"))
     {
       if (rhs.type().is_array())

--- a/src/python-frontend/python-dict/dict_access.cpp
+++ b/src/python-frontend/python-dict/dict_access.cpp
@@ -249,6 +249,34 @@ exprt python_dict_handler::handle_dict_subscript(
       }
     }
 
+    // Fallback: element type recorded at construction (literal dict whose
+    // values are lists with a uniform element type).
+    if (
+      python_list::get_list_type_map_size(list_result.id.as_string()) == 0 &&
+      dict_expr.is_symbol())
+    {
+      const std::string &vals_id =
+        get_internal_list_id(dict_expr.identifier().as_string(), false);
+      if (!vals_id.empty())
+      {
+        auto it =
+          python_list::list_type_map.find(dict_value_list_elems_key(vals_id));
+        if (it != python_list::list_type_map.end() && !it->second.empty())
+        {
+          const typet &first = it->second.front().second;
+          const bool uniform = std::all_of(
+            it->second.begin(),
+            it->second.end(),
+            [&first](const std::pair<std::string, typet> &e) {
+              return e.second == first;
+            });
+          if (uniform)
+            python_list::list_type_map[list_result.id.as_string()].push_back(
+              std::make_pair(std::string(), first));
+        }
+      }
+    }
+
     return build_symbol(list_result);
   }
 

--- a/src/python-frontend/python-dict/dict_construction.cpp
+++ b/src/python-frontend/python-dict/dict_construction.cpp
@@ -620,6 +620,30 @@ exprt python_dict_handler::create_dict_from_literal(
         dict_value_types_key(values_list.id.as_string()),
         std::string(),
         value_expr.type());
+
+      // A list value: record its uniform element type so a later d[k] list
+      // read can type the inner elements (e.g. a list-of-tuples value, which
+      // otherwise dereferences to void and aborts the dereference layer).
+      if (value_expr.type() == list_type && value_expr.is_symbol())
+      {
+        auto it =
+          python_list::list_type_map.find(value_expr.identifier().as_string());
+        if (it != python_list::list_type_map.end() && !it->second.empty())
+        {
+          const typet &first = it->second.front().second;
+          const bool uniform = std::all_of(
+            it->second.begin(),
+            it->second.end(),
+            [&first](const std::pair<std::string, typet> &e) {
+              return e.second == first;
+            });
+          if (uniform)
+            list_handler.add_type_info(
+              dict_value_list_elems_key(values_list.id.as_string()),
+              std::string(),
+              first);
+        }
+      }
     }
   }
 

--- a/src/python-frontend/python-dict/dict_methods.cpp
+++ b/src/python-frontend/python-dict/dict_methods.cpp
@@ -197,8 +197,26 @@ exprt python_dict_handler::handle_dict_get(
   }
   else
   {
-    exprt value_as_typed = build_typecast(obj_value, result_type);
-    retrieved_value = value_as_typed;
+    namespacet ns(symbol_table_);
+    typet underlying = result_type;
+    if (underlying.id() == "symbol")
+      underlying = ns.follow(underlying);
+    if (underlying.is_struct())
+    {
+      // A struct value (e.g. a tuple) is stored by address; casting the
+      // void* payload directly to the struct type builds an ill-formed
+      // scalar typecast that aborts the value-set walker. Cast to a struct
+      // pointer and dereference instead (mirrors handle_dict_subscript).
+      exprt value_as_struct_ptr =
+        build_typecast(obj_value, pointer_typet(underlying));
+      retrieved_value = build_dereference(value_as_struct_ptr, underlying);
+      retrieved_value.type() = underlying;
+    }
+    else
+    {
+      exprt value_as_typed = build_typecast(obj_value, result_type);
+      retrieved_value = value_as_typed;
+    }
   }
 
   exprt then_value =
@@ -431,8 +449,26 @@ exprt python_dict_handler::handle_dict_setdefault(
   }
   else
   {
-    exprt value_as_typed = build_typecast(obj_value, result_type);
-    retrieved_value = value_as_typed;
+    namespacet ns(symbol_table_);
+    typet underlying = result_type;
+    if (underlying.id() == "symbol")
+      underlying = ns.follow(underlying);
+    if (underlying.is_struct())
+    {
+      // A struct value (e.g. a tuple) is stored by address; casting the
+      // void* payload directly to the struct type builds an ill-formed
+      // scalar typecast that aborts the value-set walker. Cast to a struct
+      // pointer and dereference instead (mirrors handle_dict_subscript).
+      exprt value_as_struct_ptr =
+        build_typecast(obj_value, pointer_typet(underlying));
+      retrieved_value = build_dereference(value_as_struct_ptr, underlying);
+      retrieved_value.type() = underlying;
+    }
+    else
+    {
+      exprt value_as_typed = build_typecast(obj_value, result_type);
+      retrieved_value = value_as_typed;
+    }
   }
 
   code_assignt value_assign(build_symbol(result_var), retrieved_value);

--- a/src/python-frontend/python-dict/python_dict_handler.h
+++ b/src/python-frontend/python-dict/python_dict_handler.h
@@ -499,6 +499,14 @@ public:
     return "$dict_value_types$" + vals_id;
   }
 
+  /// Key under which the (uniform) element type of list-typed dict values is
+  /// recorded, so a d[k] list read can type the inner elements (e.g. a
+  /// list-of-tuples value). Same collision-free naming scheme as above.
+  static std::string dict_value_list_elems_key(const std::string &vals_id)
+  {
+    return "$dict_value_list_elems$" + vals_id;
+  }
+
   /**
    * @brief Handles dict.update() method calls.
    * Implements Python's dict.update(other) semantics:

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -2001,12 +2001,14 @@ exprt python_list::handle_index_access(
                 {
                   const auto &key_node = list_node["value"]["slice"];
 
-                  // Handle constant string key
+                  // Handle a constant key of any JSON scalar type
+                  // (string, int, bool); comparing the JSON values directly
+                  // avoids get<std::string>() throwing on an int key (d[1]).
                   if (
                     key_node["_type"] == "Constant" &&
                     key_node.contains("value"))
                   {
-                    std::string key = key_node["value"].get<std::string>();
+                    const auto &key_val = key_node["value"];
 
                     // For dict literals, get the corresponding value
                     if (
@@ -2022,7 +2024,8 @@ exprt python_list::handle_index_access(
                       {
                         if (
                           keys[i]["_type"] == "Constant" &&
-                          keys[i]["value"].get<std::string>() == key)
+                          keys[i].contains("value") &&
+                          keys[i]["value"] == key_val)
                         {
                           // Found the value: now get its element type
                           // (promotion-aware, see infer_literal_element_type).


### PR DESCRIPTION
Stacked on #6112 (only the last commit is new); part of the #5444 tuple-values family.
Two aborts fixed: `lst = d[k]; lst[i]` on list-of-tuples dict values died in the dereference layer (the read-site symbol had no element type — construction now records the uniform element type and the subscript read propagates it), and `for x in d[1]:` crashed on int keys in the element-type scan (constant keys are now matched as JSON values).
`for pair in d[1]:` over list-of-tuples still aborts further down — deliberately out of scope, reproducer retained.
Tests github_5444_dict_list_value{,_fail}, CPython-validated; 721 dict/tuple/list regression tests pass.
