### PR TITLE
[goto-programs] Replay side effects of every clustered loop invariant

### DIFF
--- a/regression/loop-invariants/github_6114/main.c
+++ b/regression/loop-invariants/github_6114/main.c
@@ -1,0 +1,19 @@
+// discussion #6114: an earlier quantifier invariant in a multi-clause cluster
+// must be re-evaluated after havoc, not left at its (vacuous) pre-loop value.
+#define N 4
+int main()
+{
+  int a[N];
+  int i = 0;
+  int k;
+  __ESBMC_loop_invariant(
+    __ESBMC_forall(&k, !(0 <= k) || !(k < i) || a[k] == 0));
+  __ESBMC_loop_invariant(__ESBMC_forall(&k, k + 1 == 1 + k));
+  __ESBMC_loop_invariant(0 <= i && i <= N);
+  while (i < N)
+  {
+    a[i] = 0;
+    ++i;
+    __ESBMC_assert(a[0] == 0, "a0 is zero");
+  }
+}

--- a/regression/loop-invariants/github_6114/test.desc
+++ b/regression/loop-invariants/github_6114/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--multi-property --result-only --loop-invariant --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_6114_fail/main.c
+++ b/regression/loop-invariants/github_6114_fail/main.c
@@ -1,0 +1,19 @@
+// discussion #6114 (negative): a wrong earlier quantifier invariant must still
+// be caught once it is re-evaluated after havoc, so the verdict stays FAILED.
+#define N 4
+int main()
+{
+  int a[N];
+  int i = 0;
+  int k;
+  __ESBMC_loop_invariant(
+    __ESBMC_forall(&k, !(0 <= k) || !(k < i) || a[k] == 1));
+  __ESBMC_loop_invariant(__ESBMC_forall(&k, k + 1 == 1 + k));
+  __ESBMC_loop_invariant(0 <= i && i <= N);
+  while (i < N)
+  {
+    a[i] = 0;
+    ++i;
+    __ESBMC_assert(a[0] == 1, "a0 is one");
+  }
+}

--- a/regression/loop-invariants/github_6114_fail/main.c
+++ b/regression/loop-invariants/github_6114_fail/main.c
@@ -1,5 +1,8 @@
-// discussion #6114 (negative): a wrong earlier quantifier invariant must still
-// be caught once it is re-evaluated after havoc, so the verdict stays FAILED.
+// discussion #6114 (negative): the earlier quantifier invariant is not
+// inductive (a[k] == 1 never holds, since the body writes 0). The fix must
+// re-evaluate it after havoc, so its inductive step is caught (FAILED). Without
+// the fix it keeps its vacuous pre-loop value and passes spuriously. No user
+// assertion, so the only checkable property is the wrong invariant itself.
 #define N 4
 int main()
 {
@@ -14,6 +17,5 @@ int main()
   {
     a[i] = 0;
     ++i;
-    __ESBMC_assert(a[0] == 1, "a0 is one");
   }
 }

--- a/regression/loop-invariants/github_6114_fail/test.desc
+++ b/regression/loop-invariants/github_6114_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--multi-property --result-only --loop-invariant --no-standard-checks
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -492,6 +492,16 @@ static void extract_and_remove_side_effects_impl(
       continue;
     }
 
+    // Consecutive __ESBMC_loop_invariant() calls for the same loop lower to
+    // several adjacent LOOP_INVARIANT instructions (issue #3936), separated
+    // only by the DECL/ASSIGN that compute each invariant's temporaries. Skip
+    // past an earlier LOOP_INVARIANT so we keep collecting the side effects of
+    // *every* invariant in the cluster, not just the nearest one; otherwise a
+    // quantifier invariant that is not the last in the cluster is never
+    // re-evaluated after havoc and its stale pre-loop value is assumed.
+    if (search->is_loop_invariant())
+      continue;
+
     break;
   }
 


### PR DESCRIPTION
## Problem (discussion #6114)

`--loop-invariant` returns a spurious `VERIFICATION FAILED` when a loop has
**multiple** `__ESBMC_loop_invariant()` clauses of which **more than one**
contains a quantifier. The two programs in the discussion differ only in
whether the trivial second invariant is `n + 1 == 1 + n` (passes) or
`__ESBMC_forall(&n, n + 1 == 1 + n)` (fails) — the invariant content is
tautological, so both should give the same verdict.

## Root cause

Each `__ESBMC_forall`/`__ESBMC_exists` lowers to
`DECL/ASSIGN return_value$___ESBMC_forall$N = forall(...)`. That intervening
`ASSIGN` makes the invariant-merging in `builtin_functions.cpp` emit **several
adjacent `LOOP_INVARIANT` instructions** instead of one.

The loop-invariant pass must replay each invariant's side-effect
(`DECL/ASSIGN/FUNCTION_CALL`) after the havoc step so the quantifier is
re-evaluated in the havoc'd state. `extract_and_remove_side_effects_impl`
walked backwards from the *nearest* `LOOP_INVARIANT` and `break`-ed on the
*earlier* one in the same cluster, so a quantifier invariant that was **not
the last clause** never got its `ASSIGN` replayed. It kept its stale,
vacuously-true pre-loop value, was `ASSUME`d stale after havoc, and the
inductive step lost the real invariant → spurious failure.

The sibling `extract_invariants_near` already clusters adjacent
`LOOP_INVARIANT` instructions (its "Phase 2", issue #3936); only the
side-effect extraction lacked the same clustering.

## Fix

Skip past earlier `LOOP_INVARIANT` instructions during the backward walk so
the side effects of **every** invariant in the cluster are collected, not just
the nearest one. Two-line change, aligned with the existing clustering logic.

## Tests

- `regression/loop-invariants/github_6114` — earlier quantifier invariant
  carries the proof; **SUCCESSFUL** (reports FAILED without the fix).
- `regression/loop-invariants/github_6114_fail` — a wrong earlier quantifier
  invariant must still be caught; stays **FAILED** (guards soundness).

Verified the PASS test fails on the unfixed binary and passes on the fixed
one. Full `loop-invariants` (65) and `k-induction` (196) suites pass with no
regression; both setify programs from the discussion now verify SUCCESSFUL.