### PR TITLE
[goto-programs] Destruct discarded call-result temporaries

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6076/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6076/main.cpp
@@ -1,0 +1,28 @@
+#include <assert.h>
+int dtor_count;
+
+class A
+{
+public:
+  int num;
+  A(int n) : num(n) {}
+  ~A() { dtor_count++; }
+};
+
+A func(int n) { return A(n); }
+
+int main()
+{
+  func(1);
+  assert(dtor_count == 1);
+  func(2);
+  func(3);
+  assert(dtor_count == 3);
+  A(7);
+  assert(dtor_count == 4);
+  (void)func(5);
+  assert(dtor_count == 5);
+  dtor_count > 0 ? func(6) : func(7);
+  assert(dtor_count == 6);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6076/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6076/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6076_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6076_fail/main.cpp
@@ -1,0 +1,19 @@
+#include <assert.h>
+int dtor_count;
+
+class A
+{
+public:
+  int num;
+  A(int n) : num(n) {}
+  ~A() { dtor_count++; }
+};
+
+A func(int n) { return A(n); }
+
+int main()
+{
+  func(1);
+  assert(dtor_count == 0); // must fail: the discarded temporary is destructed
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6076_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6076_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -96,7 +96,10 @@ protected:
   remove_function_call(exprt &expr, goto_programt &dest, bool result_is_used);
   void remove_cpp_new(exprt &expr, goto_programt &dest, bool result_is_used);
   void remove_cpp_delete(exprt &expr, goto_programt &dest);
-  void remove_temporary_object(exprt &expr, goto_programt &dest);
+  void remove_temporary_object(
+    exprt &expr,
+    goto_programt &dest,
+    bool result_is_used);
   void remove_statement_expression(
     exprt &expr,
     goto_programt &dest,

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -180,6 +180,10 @@ void goto_convertt::remove_sideeffects(
   if (!has_sideeffect(expr) && expr.id() != "if")
     return;
 
+  // Snapshot for the discarded-temporary_object arm below: entries pushed
+  // while lowering this expression describe its full-expression temporaries.
+  std::size_t stack_size = targets.destructor_stack.size();
+
   if (expr.is_and() || expr.is_or())
   {
     if (!expr.is_boolean())
@@ -587,7 +591,40 @@ void goto_convertt::remove_sideeffects(
     else if (statement == "cpp_delete" || statement == "cpp_delete[]")
       remove_cpp_delete(expr, dest);
     else if (statement == "temporary_object")
-      remove_temporary_object(expr, dest);
+    {
+      const locationt location = expr.find_location();
+      remove_temporary_object(expr, dest, result_is_used);
+
+      // A discarded temporary dies at the end of its full expression
+      // (C++ [class.temporary]/4, github #6076), not at block exit: emit
+      // the scope-exit entries pushed while lowering this expression
+      // (destructors before DEADs, innermost temporaries first) right here.
+      // A result that is used keeps block-level scope, as does anything
+      // without a pending destructor call (plain DEADs of C-style temps).
+      if (!result_is_used)
+      {
+        bool have_destructor = false;
+        for (std::size_t i = stack_size; i < targets.destructor_stack.size();
+             i++)
+          if (targets.destructor_stack[i].get_statement() == "function_call")
+          {
+            have_destructor = true;
+            break;
+          }
+
+        if (have_destructor)
+        {
+          while (targets.destructor_stack.size() > stack_size)
+          {
+            codet d_code = targets.destructor_stack.back();
+            targets.destructor_stack.pop_back();
+            d_code.location() = location;
+            convert(d_code, dest);
+          }
+          expr.make_nil();
+        }
+      }
+    }
     else if (statement == "nondet")
     {
       // these are fine
@@ -1200,10 +1237,24 @@ void goto_convertt::remove_cpp_delete(exprt &expr, goto_programt &dest)
   expr.make_nil();
 }
 
-void goto_convertt::remove_temporary_object(exprt &expr, goto_programt &dest)
+void goto_convertt::remove_temporary_object(
+  exprt &expr,
+  goto_programt &dest,
+  bool result_is_used)
 {
   if (expr.operands().size() != 1 && expr.operands().size() != 0)
     throw "temporary_object takes 0 or 1 operands";
+
+  // A discarded temporary whose value is already materialized in a symbol
+  // (e.g. the return_value$ of a discarded call, github #6076) needs no
+  // second copy: reuse that symbol as the object's identity, so it is
+  // destructed exactly once.
+  if (!result_is_used && expr.operands().size() == 1 && expr.op0().is_symbol())
+  {
+    exprt tmp = expr.op0();
+    expr.swap(tmp);
+    return;
+  }
 
   symbolt &new_symbol = new_tmp_symbol(expr.type());
 


### PR DESCRIPTION
A class-by-value call result discarded as an expression statement never
ran its destructor (`func(1);`, `(void)func(1);`, discarded ternary).
Its temporary_object now reuses the materialized `return_value$` symbol
instead of a second copy, and the scope-exit entries pushed while
lowering a discarded temporary_object are emitted at the end of the
full expression (C++ [class.temporary]/4) instead of block exit.

Known approximation: a temporary in a non-final comma operand is
destructed at the comma sequence point, one full expression too early
(previously block exit — a whole block too late). Temporaries nested in
used subexpressions (`g(func(1));`, `func(1).num + 1;`) keep block-exit
scope; that duplication/mis-count is tracked by #6075. The pre-existing
lifetime-extension gap (`const A &r = func(1);` never destructs) is
unchanged by this patch.

Fixes #6076