### PR TITLE
[om] Fill STL gaps blocking boost/program_options parsing

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6063/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6063/main.cpp
@@ -1,0 +1,41 @@
+// STL model gaps surfaced by <boost/program_options.hpp> (github #6063):
+// string::size_type, const map::find, std::wstring, <iosfwd>, and the
+// std-namespace aliases of <cstring>/<cstdio>, plus is_const /
+// is_member_pointer from <type_traits>.
+#include <iosfwd>
+#include <string>
+#include <map>
+#include <cstring>
+#include <cstdio>
+#include <type_traits>
+#include <cassert>
+
+typedef std::wstring *wstring_is_declared;
+
+int lookup(const std::map<int, int> &m)
+{
+  return m.find(1)->second;
+}
+
+struct S
+{
+  int m;
+};
+
+int main()
+{
+  std::string s("abc");
+  std::string::size_type i = s.find('b');
+  assert(i == 1);
+
+  std::map<int, int> m;
+  m[1] = 42;
+  assert(lookup(m) == 42);
+
+  assert(std::strlen("hello") == 5);
+  assert(std::strcmp("a", "a") == 0);
+
+  static_assert(std::is_const<const int>::value, "is_const");
+  static_assert(std::is_member_pointer<int S::*>::value, "is_member_pointer");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6063/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6063/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6063_2/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6063_2/main.cpp
@@ -1,0 +1,44 @@
+// Second round of STL gaps behind <boost/program_options.hpp>
+// (github #6063): allocator_traits, basic_ostream/basic_istream alias
+// templates, std::streamsize, is_function / alignment_of / is_base_of.
+#include <memory>
+#include <ostream>
+#include <istream>
+#include <iostream>
+#include <ios>
+#include <type_traits>
+#include <cassert>
+
+void log_to(std::basic_ostream<char> &os)
+{
+}
+
+struct B
+{
+};
+struct D : B
+{
+};
+
+int main()
+{
+  std::allocator<int> a;
+  typedef std::allocator_traits<std::allocator<int>> AT;
+  int *p = AT::allocate(a, 2);
+  AT::construct(a, p, 41);
+  *p += 1;
+  assert(*p == 42);
+  AT::destroy(a, p);
+  AT::deallocate(a, p, 2);
+
+  log_to(std::cout);
+  std::streamsize n = 5;
+  assert(n == 5);
+
+  static_assert(std::is_function<void(int)>::value, "fn");
+  static_assert(!std::is_function<int>::value, "nfn");
+  static_assert(std::alignment_of<int>::value == alignof(int), "al");
+  static_assert(std::is_base_of<B, D>::value, "bd");
+  static_assert(!std::is_base_of<D, B>::value, "db");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6063_2/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6063_2_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6063_2_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  std::allocator<int> a;
+  typedef std::allocator_traits<std::allocator<int>> AT;
+  int *p = AT::allocate(a, 1);
+  AT::construct(a, p, 7);
+  assert(*p == 8); // must fail: construct stored 7
+  AT::deallocate(a, p, 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6063_2_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---incremental-bmc
+--std c++17 --incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6063_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6063_fail/main.cpp
@@ -1,0 +1,15 @@
+#include <map>
+#include <cassert>
+
+int lookup(const std::map<int, int> &m)
+{
+  return m.find(1)->second;
+}
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 42;
+  assert(lookup(m) == 7); // must fail: const find returns the stored 42
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6063_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/cstdio
+++ b/src/cpp/library/cstdio
@@ -1,1 +1,47 @@
+#pragma once
+
 #include <stdio.h>
+
+// [cstdio.syn]: <cstdio> declares the C I/O functions in namespace std
+// (github #6063). Mirrors the cstdlib model's approach.
+namespace std
+{
+using ::size_t;
+using ::FILE;
+
+using ::clearerr;
+using ::fclose;
+using ::feof;
+using ::ferror;
+using ::fflush;
+using ::fgetc;
+using ::fgets;
+using ::fopen;
+using ::fprintf;
+using ::fputc;
+using ::fputs;
+using ::fread;
+using ::fscanf;
+using ::fseek;
+using ::ftell;
+using ::fwrite;
+using ::getc;
+using ::getchar;
+using ::printf;
+using ::putc;
+using ::putchar;
+using ::puts;
+using ::remove;
+using ::rename;
+using ::rewind;
+using ::scanf;
+using ::snprintf;
+using ::sprintf;
+using ::sscanf;
+using ::tmpfile;
+using ::tmpnam;
+using ::vfprintf;
+using ::vprintf;
+using ::vsnprintf;
+using ::vsprintf;
+} // namespace std

--- a/src/cpp/library/cstring
+++ b/src/cpp/library/cstring
@@ -1,1 +1,31 @@
+#pragma once
+
 #include <string.h>
+
+// [cstring.syn]: <cstring> declares the C string functions in namespace std
+// (github #6063). Mirrors the cstdlib model's approach.
+namespace std
+{
+using ::size_t;
+
+using ::memchr;
+using ::memcmp;
+using ::memcpy;
+using ::memmove;
+using ::memset;
+using ::strcat;
+using ::strchr;
+using ::strcmp;
+using ::strcpy;
+using ::strcspn;
+using ::strerror;
+using ::strlen;
+using ::strncat;
+using ::strncmp;
+using ::strncpy;
+using ::strpbrk;
+using ::strrchr;
+using ::strspn;
+using ::strstr;
+using ::strtok;
+} // namespace std

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -7,6 +7,10 @@
 
 namespace std
 {
+// <ios> declares std::streamsize; the model defines it globally in
+// definitions.h (github #6063).
+using ::streamsize;
+
 enum _Ios_Fmtflags
 {
   __boolalpha = 1L << 0,

--- a/src/cpp/library/iosfwd
+++ b/src/cpp/library/iosfwd
@@ -1,0 +1,11 @@
+#ifndef STL_IOSFWD
+#define STL_IOSFWD
+
+// The operational model's stream classes (ios, istream, ostream) are plain
+// classes, not the standard's basic_* templates, so they cannot be
+// forward-declared with the standard <iosfwd> signatures. Pull in the model
+// headers instead; they are small, and code including <iosfwd> only needs
+// the stream names to be usable in declarations (github #6063).
+#include "iostream"
+
+#endif

--- a/src/cpp/library/istream
+++ b/src/cpp/library/istream
@@ -318,6 +318,13 @@ ios::streampos istream::tellg()
 {
   return _filepos;
 }
+#if __cplusplus >= 201103L
+template <class charT>
+struct char_traits;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_istream = istream;
+#endif
+
 } // namespace std
 
 namespace std

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -763,6 +763,14 @@ public:
     return end_it;
   }
 
+  // const_iterator is a typedef for iterator in this model, so the const
+  // overload the standard requires (github #6063) delegates to the
+  // non-const one; find never writes through the backing arrays.
+  const_iterator find(const key_type &x) const
+  {
+    return const_cast<map *>(this)->find(x);
+  }
+
   key_compare key_comp() const
   {
     return key_compare();

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -6,6 +6,7 @@
 #include "utility"
 #include "type_traits"
 #include "stdlib.h"
+#include "new" // placement new for allocator construct
 
 namespace std
 {
@@ -37,7 +38,11 @@ public:
 
   pointer allocate(size_type n)
   {
-    return static_cast<pointer>(malloc(n * sizeof(T)));
+    pointer p = static_cast<pointer>(malloc(n * sizeof(T)));
+    // allocate() reports failure by throwing bad_alloc, never by returning
+    // null; the throw path is not modelled.
+    __ESBMC_assume(p != 0);
+    return p;
   }
 
   void deallocate(pointer ptr, size_type)
@@ -45,16 +50,25 @@ public:
     free(ptr);
   }
 
-  template <typename U, typename... Args>
-  void construct(U *ptr, Args &&...args)
+  // Non-template members on purpose: the frontend gives member templates of
+  // OM class templates no GOTO body, so the variadic construct/destroy were
+  // silent no-ops (github #6063).
+  // Assignment rather than placement new: the frontend drops the
+  // initializer of a placement new with primitive type, and in the model
+  // assignment into raw storage is how construction is represented anyway.
+  void construct(pointer ptr, const value_type &v)
   {
-    new (ptr) U(args...);
+    *ptr = v;
   }
 
-  template <typename U>
-  void destroy(U *ptr)
+  void construct(pointer ptr)
   {
-    ptr->~U();
+    *ptr = value_type();
+  }
+
+  void destroy(pointer ptr)
+  {
+    ptr->~value_type();
   }
 
   size_type max_size() const
@@ -147,6 +161,52 @@ struct default_delete
     delete ptr;
   }
 };
+
+#if __cplusplus >= 201103L
+// Minimal allocator_traits (github #6063): delegates to the allocator's own
+// members. Static member functions of class templates convert to GOTO
+// correctly (unlike free-function templates in OM headers).
+template <class Alloc>
+struct allocator_traits
+{
+  typedef Alloc allocator_type;
+  typedef typename Alloc::value_type value_type;
+  typedef value_type *pointer;
+  typedef const value_type *const_pointer;
+  typedef size_t size_type;
+  typedef ptrdiff_t difference_type;
+
+  static pointer allocate(Alloc &a, size_type n)
+  {
+    return a.allocate(n);
+  }
+
+  static void deallocate(Alloc &a, pointer p, size_type n)
+  {
+    a.deallocate(p, n);
+  }
+
+  static void construct(Alloc &a, pointer p, const value_type &v)
+  {
+    a.construct(p, v);
+  }
+
+  static void construct(Alloc &a, pointer p)
+  {
+    a.construct(p);
+  }
+
+  static void destroy(Alloc &a, pointer p)
+  {
+    a.destroy(p);
+  }
+
+  static size_type max_size(const Alloc &a)
+  {
+    return a.max_size();
+  }
+};
+#endif
 
 // Partial specialization of default_delete for array types
 template <class T>

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -123,6 +123,17 @@ inline ostream &operator<<(ostream &o, const smanip &val)
   return o;
 }
 
+#if __cplusplus >= 201103L
+// The model's streams are plain classes; expose the standard's template
+// names as alias templates so declarations mentioning
+// std::basic_ostream<CharT, Traits> parse (github #6063). Only the char
+// instantiation is meaningful.
+template <class charT>
+struct char_traits;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_ostream = ostream;
+#endif
+
 } // namespace std
 
 namespace std

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -116,6 +116,12 @@ template <
 class basic_string
 {
 public:
+  typedef CharT value_type;
+  typedef Traits traits_type;
+  typedef Alloc allocator_type;
+  typedef size_t size_type;
+  typedef std::ptrdiff_t difference_type;
+
   static const size_t npos = static_cast<size_t>(-1);
   char *str;
   int _size;
@@ -1092,6 +1098,10 @@ private:
 };
 
 typedef basic_string<char> string;
+// Declaration-level model: the underlying storage is char-based, which is
+// enough to parse interfaces taking std::wstring (github #6063); wide-string
+// operations are not modelled.
+typedef basic_string<wchar_t> wstring;
 } // namespace std
 
 namespace std

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -375,6 +375,26 @@ struct is_pointer<T *const volatile> : true_type
 {
 };
 
+// is_base_of (Clang builtin, also valid pre-C++11)
+template <class Base, class Derived>
+struct is_base_of : integral_constant<bool, __is_base_of(Base, Derived)>
+{
+};
+
+// is_function (Clang builtin, also valid pre-C++11)
+template <class T>
+struct is_function : integral_constant<bool, __is_function(T)>
+{
+};
+
+#if __cplusplus >= 201103L
+// alignment_of
+template <class T>
+struct alignment_of : integral_constant<size_t, alignof(T)>
+{
+};
+#endif
+
 // is_reference
 template <class T>
 struct is_lvalue_reference : false_type
@@ -621,6 +641,12 @@ template <class T>
 inline constexpr bool is_volatile_v = is_volatile<T>::value;
 template <class T>
 inline constexpr bool is_member_pointer_v = is_member_pointer<T>::value;
+template <class Base, class Derived>
+inline constexpr bool is_base_of_v = is_base_of<Base, Derived>::value;
+template <class T>
+inline constexpr bool is_function_v = is_function<T>::value;
+template <class T>
+inline constexpr size_t alignment_of_v = alignment_of<T>::value;
 template <class T>
 inline constexpr bool is_integral_v = is_integral<T>::value;
 template <class T>

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -95,6 +95,42 @@ struct remove_cv<const volatile T>
   typedef T type;
 };
 
+// is_const / is_volatile
+template <class T>
+struct is_const : false_type
+{
+};
+template <class T>
+struct is_const<const T> : true_type
+{
+};
+template <class T>
+struct is_volatile : false_type
+{
+};
+template <class T>
+struct is_volatile<volatile T> : true_type
+{
+};
+
+// is_member_pointer
+namespace detail
+{
+template <class T>
+struct is_member_pointer_base : false_type
+{
+};
+template <class T, class U>
+struct is_member_pointer_base<T U::*> : true_type
+{
+};
+} // namespace detail
+template <class T>
+struct is_member_pointer
+  : detail::is_member_pointer_base<typename remove_cv<T>::type>
+{
+};
+
 // remove_pointer
 template <class T>
 struct remove_pointer
@@ -579,6 +615,12 @@ using make_signed_t = typename make_signed<T>::type;
 template <class T>
 using decay_t = typename decay<T>::type;
 
+template <class T>
+inline constexpr bool is_const_v = is_const<T>::value;
+template <class T>
+inline constexpr bool is_volatile_v = is_volatile<T>::value;
+template <class T>
+inline constexpr bool is_member_pointer_v = is_member_pointer<T>::value;
 template <class T>
 inline constexpr bool is_integral_v = is_integral<T>::value;
 template <class T>


### PR DESCRIPTION
Fixes the four standard-library gaps named in #6063 plus the conformance layer behind them: basic_string member typedefs and std::wstring, const-qualified map::find, an <iosfwd> stub, namespace std aliases in <cstring>/<cstdio>, and missing type_traits.
std::addressof is deliberately omitted: OM free-function templates get no GOTO body (calls return nondet), so shipping it would trade an honest parse error for silent false alarms.
The original four errors are gone; deeper gaps (templated streams, allocator_traits, shared_ptr) stay tracked in #6063.
