### PR TITLE
[goto-programs] Skip destructor when deleting a null pointer

### DIFF
--- a/regression/esbmc-cpp/cpp/delete_null_no_dtor/main.cpp
+++ b/regression/esbmc-cpp/cpp/delete_null_no_dtor/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+int dtor_count;
+struct A
+{
+  virtual ~A() { dtor_count++; }
+};
+int main()
+{
+  {
+    A *p = nullptr;
+    delete p; // [expr.delete]/7: no destructor call, no-op
+  }
+  assert(dtor_count == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/delete_null_no_dtor/test.desc
+++ b/regression/esbmc-cpp/cpp/delete_null_no_dtor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/delete_null_no_dtor_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/delete_null_no_dtor_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+int dtor_count;
+struct A
+{
+  virtual ~A() { dtor_count++; }
+};
+int main()
+{
+  A *p = new A();
+  delete p; // destructor must still run for non-null
+  assert(dtor_count == 0); // must fail: non-null delete runs the destructor
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/delete_null_no_dtor_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/delete_null_no_dtor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1084,7 +1084,24 @@ void goto_convertt::convert_cpp_delete(const codet &code, goto_programt &dest)
 
       codet tmp_code = to_code(destructor);
       replace_new_object(deref_op, tmp_code);
-      convert(tmp_code, dest);
+
+      // C++ [expr.delete]/7: deleting a null pointer invokes no destructor.
+      goto_programt dtor_prog;
+      convert(tmp_code, dtor_prog);
+
+      goto_programt::targett t_skip = dtor_prog.add_instruction(SKIP);
+      t_skip->location = code.location();
+
+      goto_programt::targett t_null = dest.add_instruction();
+      t_null->make_goto(t_skip);
+      exprt is_null("not", typet("bool"));
+      exprt non_null("typecast", typet("bool"));
+      non_null.copy_to_operands(tmp_op);
+      is_null.move_to_operands(non_null);
+      migrate_expr(is_null, t_null->guard);
+      t_null->location = code.location();
+
+      dest.destructive_append(dtor_prog);
     }
     else
       assert(0);


### PR DESCRIPTION
convert_cpp_delete invoked the destructor unconditionally, but C++ [expr.delete]/7 requires a null operand to invoke none — the virtual destructor dispatch on this==NULL raised a false NULL-deref alarm.
Guard the destructor program with a null check; the trailing free already handles null.
Latent until #6117 ran destructors on explicit-return paths (std::function's moved-from temporary does `delete nullptr` in ~function()); merging this unblocks #6117.
