### PR TITLE
[om] Add <atomic> operational model

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6025/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6025/main.cpp
@@ -1,0 +1,57 @@
+#include <atomic>
+#include <cassert>
+
+int arr[4];
+
+int main()
+{
+  std::atomic<int> a{5};
+  assert(a.load() == 5);
+  a.store(7);
+  assert(a == 7);
+  assert(a.exchange(9) == 7);
+  assert(a.load() == 9);
+
+  int expected = 9;
+  assert(a.compare_exchange_strong(expected, 11));
+  assert(a.load() == 11);
+  expected = 99;
+  assert(!a.compare_exchange_weak(expected, 13));
+  assert(expected == 11);
+  assert(a.load() == 11);
+
+  assert(a.fetch_and(3) == 11);
+  assert(a.load() == 3);
+  assert(a.fetch_or(4) == 3);
+  assert(a.load() == 7);
+  assert(a.fetch_xor(1) == 7);
+  assert(a.load() == 6);
+
+  assert(++a == 7);
+  assert(a++ == 7);
+  assert(a.load() == 8);
+  assert((a += 2) == 10);
+  assert((a -= 4) == 6);
+  assert(--a == 5);
+  assert(a-- == 5);
+  assert(a.load() == 4);
+
+  std::atomic<int *> p{&arr[1]};
+  assert(p.fetch_add(2) == &arr[1]);
+  assert(p.load() == &arr[3]);
+  assert(p.fetch_sub(1) == &arr[3]);
+  assert(++p == &arr[3]);
+
+  std::atomic_flag f = ATOMIC_FLAG_INIT;
+  assert(!f.test_and_set());
+  assert(f.test_and_set());
+  f.clear();
+  assert(!f.test());
+
+  std::atomic_int ti{1};
+  std::atomic_size_t ts{2};
+  assert(ti.load() == 1 && ts.load() == 2);
+
+  std::atomic_thread_fence(std::memory_order_acquire);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6025/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6025/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6025_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6025_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <atomic>
+#include <cassert>
+
+int main()
+{
+  std::atomic<int> a{5};
+  int expected = 9;
+  // CAS with a wrong expected value fails and writes back the current
+  // value; asserting success must be violated.
+  assert(a.compare_exchange_strong(expected, 11));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6025_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6025_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6025_threads/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6025_threads/main.cpp
@@ -1,0 +1,22 @@
+#include <atomic>
+#include <pthread.h>
+#include <cassert>
+
+std::atomic<int> counter{0};
+
+void *worker(void *)
+{
+  counter.fetch_add(1);
+  return nullptr;
+}
+
+int main()
+{
+  pthread_t t1, t2;
+  pthread_create(&t1, nullptr, worker, nullptr);
+  pthread_create(&t2, nullptr, worker, nullptr);
+  pthread_join(t1, nullptr);
+  pthread_join(t2, nullptr);
+  assert(counter.load() == 2); // atomicity: no lost updates
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6025_threads/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6025_threads/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6025_threads_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6025_threads_fail/main.cpp
@@ -1,0 +1,24 @@
+#include <atomic>
+#include <pthread.h>
+#include <cassert>
+
+std::atomic<int> counter{0};
+
+void *worker(void *)
+{
+  // load and store are individually atomic but the increment is not
+  // indivisible: a lost update is possible.
+  counter.store(counter.load() + 1);
+  return nullptr;
+}
+
+int main()
+{
+  pthread_t t1, t2;
+  pthread_create(&t1, nullptr, worker, nullptr);
+  pthread_create(&t2, nullptr, worker, nullptr);
+  pthread_join(t1, nullptr);
+  pthread_join(t2, nullptr);
+  assert(counter.load() == 2); // must fail: lost update reachable
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6025_threads_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6025_threads_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/cpp/library/atomic
+++ b/src/cpp/library/atomic
@@ -1,0 +1,375 @@
+#ifndef STL_ATOMIC
+#define STL_ATOMIC
+
+#include <cstddef>
+#include "OM_compiler_defs.h" // OM_CONSTEXPR, OM_NOEXCEPT
+
+// Sequentially-consistent model of <atomic> (github #6025): every access is
+// wrapped in an __ESBMC_atomic_begin/end section, which makes the operations
+// indivisible under ESBMC's interleaving semantics. Weaker memory orders are
+// accepted and treated as seq_cst — a sound over-approximation is NOT claimed
+// for weak-memory litmus tests; this models SC executions only.
+//
+// Free-function templates (std::atomic_load, kill_dependency, ...) are
+// deliberately absent: the frontend does not convert instantiated bodies of
+// free-function templates defined in OM headers (calls would return nondet).
+// Member functions of class templates convert correctly.
+
+#if __cplusplus >= 201103L
+
+namespace std
+{
+typedef enum memory_order
+{
+  memory_order_relaxed,
+  memory_order_consume,
+  memory_order_acquire,
+  memory_order_release,
+  memory_order_acq_rel,
+  memory_order_seq_cst
+} memory_order;
+
+inline void atomic_thread_fence(memory_order) OM_NOEXCEPT
+{
+  // Only seq_cst executions are modelled; fences add nothing under SC.
+}
+
+inline void atomic_signal_fence(memory_order) OM_NOEXCEPT
+{
+}
+
+template <class T>
+struct atomic
+{
+  T __val;
+
+  atomic() OM_NOEXCEPT = default;
+  OM_CONSTEXPR atomic(T v) OM_NOEXCEPT : __val(v)
+  {
+  }
+  atomic(const atomic &) = delete;
+  atomic &operator=(const atomic &) = delete;
+
+  bool is_lock_free() const OM_NOEXCEPT
+  {
+    return true;
+  }
+
+  void store(T v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    __val = v;
+    __ESBMC_atomic_end();
+  }
+
+  T load(memory_order = memory_order_seq_cst) const OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T r = __val;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  operator T() const OM_NOEXCEPT
+  {
+    return load();
+  }
+
+  T operator=(T v) OM_NOEXCEPT
+  {
+    store(v);
+    return v;
+  }
+
+  T exchange(T v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T r = __val;
+    __val = v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  bool compare_exchange_strong(
+    T &expected,
+    T desired,
+    memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    bool ok = __val == expected;
+    if (ok)
+      __val = desired;
+    else
+      expected = __val;
+    __ESBMC_atomic_end();
+    return ok;
+  }
+
+  bool compare_exchange_strong(
+    T &expected,
+    T desired,
+    memory_order,
+    memory_order) OM_NOEXCEPT
+  {
+    return compare_exchange_strong(expected, desired);
+  }
+
+  // Spurious failure is not modelled: weak behaves like strong, so
+  // retry-loop iterations driven purely by spurious failures are absent.
+  bool compare_exchange_weak(
+    T &expected,
+    T desired,
+    memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    return compare_exchange_strong(expected, desired);
+  }
+
+  bool compare_exchange_weak(
+    T &expected,
+    T desired,
+    memory_order,
+    memory_order) OM_NOEXCEPT
+  {
+    return compare_exchange_strong(expected, desired);
+  }
+
+  T fetch_add(T v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T r = __val;
+    __val = r + v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  T fetch_sub(T v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T r = __val;
+    __val = r - v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  T fetch_and(T v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T r = __val;
+    __val = r & v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  T fetch_or(T v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T r = __val;
+    __val = r | v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  T fetch_xor(T v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T r = __val;
+    __val = r ^ v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  T operator++() OM_NOEXCEPT
+  {
+    return fetch_add(T(1)) + T(1);
+  }
+  T operator++(int) OM_NOEXCEPT
+  {
+    return fetch_add(T(1));
+  }
+  T operator--() OM_NOEXCEPT
+  {
+    return fetch_sub(T(1)) - T(1);
+  }
+  T operator--(int) OM_NOEXCEPT
+  {
+    return fetch_sub(T(1));
+  }
+  T operator+=(T v) OM_NOEXCEPT
+  {
+    return fetch_add(v) + v;
+  }
+  T operator-=(T v) OM_NOEXCEPT
+  {
+    return fetch_sub(v) - v;
+  }
+};
+
+template <class T>
+struct atomic<T *>
+{
+  T *__val;
+
+  atomic() OM_NOEXCEPT = default;
+  OM_CONSTEXPR atomic(T *v) OM_NOEXCEPT : __val(v)
+  {
+  }
+  atomic(const atomic &) = delete;
+  atomic &operator=(const atomic &) = delete;
+
+  bool is_lock_free() const OM_NOEXCEPT
+  {
+    return true;
+  }
+
+  void store(T *v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    __val = v;
+    __ESBMC_atomic_end();
+  }
+
+  T *load(memory_order = memory_order_seq_cst) const OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T *r = __val;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  operator T *() const OM_NOEXCEPT
+  {
+    return load();
+  }
+
+  T *operator=(T *v) OM_NOEXCEPT
+  {
+    store(v);
+    return v;
+  }
+
+  T *exchange(T *v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T *r = __val;
+    __val = v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  bool compare_exchange_strong(
+    T *&expected,
+    T *desired,
+    memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    bool ok = __val == expected;
+    if (ok)
+      __val = desired;
+    else
+      expected = __val;
+    __ESBMC_atomic_end();
+    return ok;
+  }
+
+  bool compare_exchange_weak(
+    T *&expected,
+    T *desired,
+    memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    return compare_exchange_strong(expected, desired);
+  }
+
+  T *fetch_add(ptrdiff_t v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T *r = __val;
+    __val = r + v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  T *fetch_sub(ptrdiff_t v, memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    T *r = __val;
+    __val = r - v;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  T *operator++() OM_NOEXCEPT
+  {
+    return fetch_add(1) + 1;
+  }
+  T *operator++(int) OM_NOEXCEPT
+  {
+    return fetch_add(1);
+  }
+  T *operator--() OM_NOEXCEPT
+  {
+    return fetch_sub(1) - 1;
+  }
+  T *operator--(int) OM_NOEXCEPT
+  {
+    return fetch_sub(1);
+  }
+};
+
+struct atomic_flag
+{
+  bool __val;
+
+  OM_CONSTEXPR atomic_flag() OM_NOEXCEPT : __val(false)
+  {
+  }
+  atomic_flag(const atomic_flag &) = delete;
+  atomic_flag &operator=(const atomic_flag &) = delete;
+
+  bool test_and_set(memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    bool r = __val;
+    __val = true;
+    __ESBMC_atomic_end();
+    return r;
+  }
+
+  void clear(memory_order = memory_order_seq_cst) OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    __val = false;
+    __ESBMC_atomic_end();
+  }
+
+  bool test(memory_order = memory_order_seq_cst) const OM_NOEXCEPT
+  {
+    __ESBMC_atomic_begin();
+    bool r = __val;
+    __ESBMC_atomic_end();
+    return r;
+  }
+};
+
+#define ATOMIC_FLAG_INIT                                                       \
+  {                                                                            \
+  }
+
+typedef atomic<bool> atomic_bool;
+typedef atomic<char> atomic_char;
+typedef atomic<signed char> atomic_schar;
+typedef atomic<unsigned char> atomic_uchar;
+typedef atomic<short> atomic_short;
+typedef atomic<unsigned short> atomic_ushort;
+typedef atomic<int> atomic_int;
+typedef atomic<unsigned int> atomic_uint;
+typedef atomic<long> atomic_long;
+typedef atomic<unsigned long> atomic_ulong;
+typedef atomic<long long> atomic_llong;
+typedef atomic<unsigned long long> atomic_ullong;
+typedef atomic<size_t> atomic_size_t;
+typedef atomic<ptrdiff_t> atomic_ptrdiff_t;
+} // namespace std
+
+#endif // __cplusplus >= 201103L
+
+#endif // STL_ATOMIC


### PR DESCRIPTION
Sequentially-consistent <atomic> model: std::atomic<T> for integral and pointer types (load/store/exchange/CAS/fetch-ops/operators), atomic_flag, memory_order, and no-op fences, every operation wrapped in __ESBMC_atomic_begin/end so it is indivisible under interleaving.
Two threads doing fetch_add verify to the exact count while a split load()/store() increment exhibits the lost update — both pinned as regression tests, plus a g++-validated sequential battery.
Weak memory orders are treated as seq_cst and free-function templates are omitted (no GOTO body, same finding as #6127); caveats documented in the header.
Fixes #6025
