### PR TITLE
[testing] Pin pointer-to-member support with regression tests

### DIFF
--- a/regression/esbmc-cpp/cpp/github_2672/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_2672/main.cpp
@@ -1,0 +1,38 @@
+// Pointer-to-member support (github #2672): .* and ->* on both data and
+// function members, including reassignment and passing as arguments.
+#include <cassert>
+
+class Test
+{
+public:
+  int value;
+  int get() { return value; }
+  int twice() { return 2 * value; }
+};
+
+int call(Test *p, int (Test::*m)())
+{
+  return (p->*m)();
+}
+
+int main()
+{
+  Test t;
+  t.value = 8;
+
+  int (Test::*memPtr)() = &Test::get;
+  assert((t.*memPtr)() == 8);
+  memPtr = &Test::twice;
+  assert((t.*memPtr)() == 16);
+
+  assert(call(&t, &Test::get) == 8);
+  assert(call(&t, &Test::twice) == 16);
+
+  int Test::*vPtr = &Test::value;
+  assert(t.*vPtr == 8);
+  t.*vPtr = 5;
+  assert(t.value == 5);
+  Test *tp = &t;
+  assert(tp->*vPtr == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_2672/test.desc
+++ b/regression/esbmc-cpp/cpp/github_2672/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_2672_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_2672_fail/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+class Test
+{
+public:
+  int value;
+  int get() { return value; }
+  int twice() { return 2 * value; }
+};
+
+int main()
+{
+  Test t;
+  t.value = 8;
+
+  int (Test::*memPtr)() = &Test::get;
+  memPtr = &Test::twice; // reassignment must be respected
+  assert((t.*memPtr)() == 8); // must fail: twice() returns 16
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_2672_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_2672_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
The `Unrecognized clang builtin type <bound member function type>`
crash reported against ESBMC 7.10.0 no longer reproduces on master:
the issue's exact program parses and verifies, and `.*` / `->*` are
semantically correct on data and function members — reassignment,
argument passing, and writes through data-member pointers all verify
(g++-validated), with a negative twin confirming violations are still
detected. Pin it with a regression pair so the support cannot silently
regress.

Fixes #2672