### PR TITLE
[clang-cpp-frontend] Model placement new

### DIFF
--- a/regression/esbmc-cpp/cpp/placement_new/main.cpp
+++ b/regression/esbmc-cpp/cpp/placement_new/main.cpp
@@ -1,0 +1,44 @@
+// Placement new ([expr.new]/11): constructs at the given address with no
+// allocation; the result aliases the placement argument. Covers primitive
+// initializers, class constructors, the discarded-statement form, and the
+// std::nothrow tag (which is NOT memory placement and keeps allocating).
+#include <new>
+#include <cassert>
+
+struct S
+{
+  int v;
+  S(int x) : v(x) {}
+};
+
+struct Self
+{
+  Self *self;
+  Self() : self(this) {}
+};
+
+int main()
+{
+  int x = 0;
+  int *p = new (&x) int(41);
+  assert(x == 41);
+  assert(p == &x);
+
+  char buf[sizeof(S)];
+  S *q = new ((void *)buf) S(7);
+  assert(q->v == 7);
+  assert((void *)q == (void *)buf);
+
+  S s(1);
+  new (&s) S(9);
+  assert(s.v == 9);
+
+  Self t;
+  new (&t) Self;
+  assert(t.self == &t); // `this` in the ctor is the placed object
+
+  int *h = new (std::nothrow) int(5);
+  if (h)
+    assert(*h == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/placement_new/test.desc
+++ b/regression/esbmc-cpp/cpp/placement_new/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/placement_new_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/placement_new_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <new>
+#include <cassert>
+
+int main()
+{
+  int x = 0;
+  new (&x) int(41);
+  assert(x == 0); // must fail: placement new wrote 41 through &x
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/placement_new_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/placement_new_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -871,8 +871,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
             // is the placed object, not a copied-from temp.
             exprt wrap = static_cast<const exprt &>(init.initializer());
             assert(
-              wrap.is_code() &&
-              to_code(wrap).get_statement() == "expression");
+              wrap.is_code() && to_code(wrap).get_statement() == "expression");
             exprt call = wrap.op0();
             replace_new_object_with(target, call);
             comma.copy_to_operands(call);

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -567,6 +567,17 @@ bool clang_cpp_convertert::get_struct_union_class_methods_decls(
   return false;
 }
 
+// Substitute every "new_object" placeholder in @p dest with @p object
+// (mirrors goto_convertt::replace_new_object, which is not visible here).
+static void replace_new_object_with(const exprt &object, exprt &dest)
+{
+  if (dest.id() == "new_object")
+    dest = object;
+  else
+    Forall_operands (it, dest)
+      replace_new_object_with(object, *it);
+}
+
 bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 {
   locationt location;
@@ -811,6 +822,74 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     typet t;
     if (get_type(ne.getType(), t))
       return true;
+
+    // Placement new ([expr.new]/11): no allocation happens; the object is
+    // constructed at the given address, which is also the result. Lower to
+    // comma(<initialize *(T*)place>, (T*)place). Only the reserved
+    // non-allocating ::operator new(size_t, void*) qualifies — a
+    // user-declared pointer-parameter operator new or std::nothrow keeps
+    // the allocating path below. The placement expression appears twice in
+    // the comma, so a side-effecting argument also falls back (with a
+    // warning) rather than being evaluated twice.
+    if (
+      !ne.isArray() && ne.getOperatorNew() &&
+      ne.getOperatorNew()->isReservedGlobalPlacementOperator())
+    {
+      if (ne.getPlacementArg(0)->HasSideEffects(*ASTContext))
+        log_warning(
+          "placement-new address with side effects is not modelled; "
+          "treating as allocating new at {}",
+          location.as_string());
+      else
+      {
+        exprt place;
+        if (get_expr(*ne.getPlacementArg(0), place))
+          return true;
+
+        exprt tp("typecast", t);
+        tp.copy_to_operands(place);
+
+        exprt target("dereference", t.subtype());
+        target.copy_to_operands(tp);
+
+        exprt comma("comma", t);
+        if (ne.hasInitializer())
+        {
+          exprt init;
+          if (get_expr(*ne.getInitializer(), init))
+            return true;
+
+          if (
+            init.id() == "sideeffect" &&
+            init.statement() == "temporary_object" &&
+            static_cast<const exprt &>(init.initializer()).is_not_nil())
+          {
+            // A class-type initializer arrives as a temporary_object whose
+            // initializer wraps the constructor call carrying an
+            // &new_object placeholder (make_temporary): retarget the call
+            // at the placement address and drop the temporary, so `this`
+            // is the placed object, not a copied-from temp.
+            exprt wrap = static_cast<const exprt &>(init.initializer());
+            assert(
+              wrap.is_code() &&
+              to_code(wrap).get_statement() == "expression");
+            exprt call = wrap.op0();
+            replace_new_object_with(target, call);
+            comma.copy_to_operands(call);
+          }
+          else
+          {
+            side_effect_exprt assign("assign");
+            assign.type() = t.subtype();
+            assign.copy_to_operands(target, init);
+            comma.copy_to_operands(assign);
+          }
+        }
+        comma.copy_to_operands(tp);
+        new_expr = comma;
+        break;
+      }
+    }
 
     if (ne.isArray())
     {

--- a/src/cpp/library/new
+++ b/src/cpp/library/new
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <exception>
+#include "OM_compiler_defs.h" // OM_NOEXCEPT
 
 /* These are not in the 'std' namespace */
 
@@ -55,3 +56,16 @@ enum class align_val_t : size_t
 #endif
 
 } // namespace std
+
+namespace std
+{
+// Tag type for non-throwing allocation ([new.syn]); the model's operator
+// new does not throw, so the tag only needs to exist and be passable.
+struct nothrow_t
+{
+};
+const nothrow_t nothrow = {};
+} // namespace std
+
+void *operator new(size_t count, const std::nothrow_t &) OM_NOEXCEPT;
+void *operator new[](size_t count, const std::nothrow_t &) OM_NOEXCEPT;


### PR DESCRIPTION
CXXNewExpr dropped placement arguments: `new (p) T(v)` allocated fresh heap and wrote nothing through `p`, silently mis-verifying every placement-new user. Found while modelling allocator_traits for #6063.
Lower the reserved non-allocating form ([expr.new]/11) to construct through the placement pointer; user-declared operator new, std::nothrow, and side-effecting placement addresses keep the allocating path.
Adds std::nothrow_t to the <new> model.
