### PR TITLE
[ir-ieee] generate NaN for invalid FMA operations

### DIFF
--- a/regression/ir-ra/ra-fma-add-inf-nan-fail/main.c
+++ b/regression/ir-ra/ra-fma-add-inf-nan-fail/main.c
@@ -1,0 +1,21 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(+inf, +inf, -inf): product is +inf; adding -inf is invalid (NaN) */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(y > DBL_MAX);
+  __ESBMC_assume(z < -DBL_MAX);
+  double r = fma(x, y, z);
+
+  __ESBMC_assert(r > -100.0, "fma(+inf, +inf, -inf) > -100.0 should not hold (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-add-inf-nan-fail/test.desc
+++ b/regression/ir-ra/ra-fma-add-inf-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fma-add-inf-nan/main.c
+++ b/regression/ir-ra/ra-fma-add-inf-nan/main.c
@@ -1,0 +1,21 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(+inf, +inf, -inf): product is +inf; adding -inf is invalid (NaN) */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(y > DBL_MAX);
+  __ESBMC_assume(z < -DBL_MAX);
+  double r = fma(x, y, z);
+
+  __ESBMC_assert(!(r > -100.0), "fma(+inf, +inf, -inf) > -100.0 is false (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-add-inf-nan/test.desc
+++ b/regression/ir-ra/ra-fma-add-inf-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-add-inf-not-nan/main.c
+++ b/regression/ir-ra/ra-fma-add-inf-not-nan/main.c
@@ -1,0 +1,21 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(+inf, +inf, +inf) = +inf: same-sign infinite addend, not NaN */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(y > DBL_MAX);
+  __ESBMC_assume(z > DBL_MAX);
+  double r = fma(x, y, z);
+
+  __ESBMC_assert(r > DBL_MAX, "fma(+inf, +inf, +inf) should be +inf");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-add-inf-not-nan/test.desc
+++ b/regression/ir-ra/ra-fma-add-inf-not-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-add-neginf-nan/main.c
+++ b/regression/ir-ra/ra-fma-add-neginf-nan/main.c
@@ -1,0 +1,21 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(+inf, -inf, +inf): product is -inf; adding +inf is invalid (NaN) */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(y < -DBL_MAX);
+  __ESBMC_assume(z > DBL_MAX);
+  double r = fma(x, y, z);
+
+  __ESBMC_assert(!(r > -100.0), "fma(+inf, -inf, +inf) > -100.0 is false (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-add-neginf-nan/test.desc
+++ b/regression/ir-ra/ra-fma-add-neginf-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-finite-overflow-not-nan-fail/main.c
+++ b/regression/ir-ra/ra-fma-finite-overflow-not-nan-fail/main.c
@@ -1,0 +1,18 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double z = __VERIFIER_nondet_double();
+  /* fma(DBL_MAX, 2.0, -inf): both factors finite; no invalid operation.
+   * The result is not NaN, so asserting r != r (self-inequality) must fail. */
+  __ESBMC_assume(z < -DBL_MAX);
+  double r = fma(DBL_MAX, 2.0, z);
+
+  __ESBMC_assert(r != r, "fma(DBL_MAX, 2.0, -inf) != itself should not hold (not NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-finite-overflow-not-nan-fail/test.desc
+++ b/regression/ir-ra/ra-fma-finite-overflow-not-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fma-finite-overflow-not-nan/main.c
+++ b/regression/ir-ra/ra-fma-finite-overflow-not-nan/main.c
@@ -1,0 +1,20 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double z = __VERIFIER_nondet_double();
+  /* fma(DBL_MAX, 2.0, -inf): both factors are finite, so the intermediate
+   * product is an exact finite real in the FMA model even though it would
+   * overflow to +inf in a standalone ieee_mul.  Adding -inf to a finite
+   * exact product is not an invalid operation; the result is -inf, not NaN. */
+  __ESBMC_assume(z < -DBL_MAX);
+  double r = fma(DBL_MAX, 2.0, z);
+
+  __ESBMC_assert(r == r, "fma(DBL_MAX, 2.0, -inf) should not be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-finite-overflow-not-nan/test.desc
+++ b/regression/ir-ra/ra-fma-finite-overflow-not-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-mul-inf-zero-nan/main.c
+++ b/regression/ir-ra/ra-fma-mul-inf-zero-nan/main.c
@@ -1,0 +1,18 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(+inf, 0, z): +inf * 0 is an invalid operation producing NaN */
+  __ESBMC_assume(x > DBL_MAX);
+  double r = fma(x, 0.0, z);
+
+  __ESBMC_assert(!(r > -100.0), "fma(+inf, 0, z) > -100.0 is false (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-mul-inf-zero-nan/test.desc
+++ b/regression/ir-ra/ra-fma-mul-inf-zero-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-mul-zero-inf-nan-fail/main.c
+++ b/regression/ir-ra/ra-fma-mul-zero-inf-nan-fail/main.c
@@ -1,0 +1,18 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(0, +inf, z): 0 * +inf is an invalid operation producing NaN */
+  __ESBMC_assume(y > DBL_MAX);
+  double r = fma(0.0, y, z);
+
+  __ESBMC_assert(r > -100.0, "fma(0, +inf, z) > -100.0 should not hold (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-mul-zero-inf-nan-fail/test.desc
+++ b/regression/ir-ra/ra-fma-mul-zero-inf-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fma-mul-zero-inf-nan/main.c
+++ b/regression/ir-ra/ra-fma-mul-zero-inf-nan/main.c
@@ -1,0 +1,18 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double y = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(0, +inf, z): 0 * +inf is an invalid operation producing NaN */
+  __ESBMC_assume(y > DBL_MAX);
+  double r = fma(0.0, y, z);
+
+  __ESBMC_assert(!(r > -100.0), "fma(0, +inf, z) > -100.0 is false (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-mul-zero-inf-nan/test.desc
+++ b/regression/ir-ra/ra-fma-mul-zero-inf-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fma-one-inf-factor-nan-fail/main.c
+++ b/regression/ir-ra/ra-fma-one-inf-factor-nan-fail/main.c
@@ -1,0 +1,20 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(+inf, 2.0, -inf): one infinite factor, finite nonzero second factor.
+   * Product is +inf; adding -inf is an invalid operation (NaN). */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(z < -DBL_MAX);
+  double r = fma(x, 2.0, z);
+
+  __ESBMC_assert(r > -100.0, "fma(+inf, 2.0, -inf) > -100.0 should not hold (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-one-inf-factor-nan-fail/test.desc
+++ b/regression/ir-ra/ra-fma-one-inf-factor-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fma-one-inf-factor-nan/main.c
+++ b/regression/ir-ra/ra-fma-one-inf-factor-nan/main.c
@@ -1,0 +1,20 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double z = __VERIFIER_nondet_double();
+  /* fma(+inf, 2.0, -inf): one infinite factor, finite nonzero second factor.
+   * Product is +inf; adding -inf is an invalid operation (NaN). */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(z < -DBL_MAX);
+  double r = fma(x, 2.0, z);
+
+  __ESBMC_assert(!(r > -100.0), "fma(+inf, 2.0, -inf) > -100.0 is false (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fma-one-inf-factor-nan/test.desc
+++ b/regression/ir-ra/ra-fma-one-inf-factor-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -752,12 +752,12 @@ smt_astt ir_ieee_convt::encode_ieee_fma(const expr2tc &expr)
     smt_astt v1_neg = ctx->mk_lt(val1, zero);
     smt_astt v2_pos = ctx->mk_gt(val2, zero);
     smt_astt v2_neg = ctx->mk_lt(val2, zero);
-    smt_astt same_sign = ctx->mk_or(
-      ctx->mk_and(v1_pos, v2_pos), ctx->mk_and(v1_neg, v2_neg));
-    smt_astt opp_sign = ctx->mk_or(
-      ctx->mk_and(v1_pos, v2_neg), ctx->mk_and(v1_neg, v2_pos));
-    smt_astt either_factor_inf = ctx->mk_or(
-      is_inf_real(val1, fbv_type), is_inf_real(val2, fbv_type));
+    smt_astt same_sign =
+      ctx->mk_or(ctx->mk_and(v1_pos, v2_pos), ctx->mk_and(v1_neg, v2_neg));
+    smt_astt opp_sign =
+      ctx->mk_or(ctx->mk_and(v1_pos, v2_neg), ctx->mk_and(v1_neg, v2_pos));
+    smt_astt either_factor_inf =
+      ctx->mk_or(is_inf_real(val1, fbv_type), is_inf_real(val2, fbv_type));
     smt_astt add_nan = ctx->mk_and(
       either_factor_inf,
       ctx->mk_or(

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -735,9 +735,39 @@ smt_astt ir_ieee_convt::encode_ieee_fma(const expr2tc &expr)
     auto bounds =
       apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
     store_interval(real_result, bounds.first, bounds.second);
+
+    // 0 × ±∞ in the multiply sub-step is an invalid operation.
+    smt_astt zero = ctx->get_zero_real();
+    smt_astt mul_nan = ctx->mk_or(
+      ctx->mk_and(ctx->mk_eq(val1, zero), is_inf_real(val2, fbv_type)),
+      ctx->mk_and(is_inf_real(val1, fbv_type), ctx->mk_eq(val2, zero)));
+
+    // An infinite product combined with an opposite-signed infinite addend is
+    // an invalid operation.  In IEEE 754 FMA the intermediate product is
+    // computed at infinite precision, so it is infinite only when a factor is
+    // infinite — a pair of large finite values whose product merely overflows
+    // is NOT an invalid operation.  We therefore check factor infiniteness
+    // rather than the magnitude of the intermediate product.
+    smt_astt v1_pos = ctx->mk_gt(val1, zero);
+    smt_astt v1_neg = ctx->mk_lt(val1, zero);
+    smt_astt v2_pos = ctx->mk_gt(val2, zero);
+    smt_astt v2_neg = ctx->mk_lt(val2, zero);
+    smt_astt same_sign = ctx->mk_or(
+      ctx->mk_and(v1_pos, v2_pos), ctx->mk_and(v1_neg, v2_neg));
+    smt_astt opp_sign = ctx->mk_or(
+      ctx->mk_and(v1_pos, v2_neg), ctx->mk_and(v1_neg, v2_pos));
+    smt_astt either_factor_inf = ctx->mk_or(
+      is_inf_real(val1, fbv_type), is_inf_real(val2, fbv_type));
+    smt_astt add_nan = ctx->mk_and(
+      either_factor_inf,
+      ctx->mk_or(
+        ctx->mk_and(same_sign, is_neg_inf_real(val3, fbv_type)),
+        ctx->mk_and(opp_sign, is_pos_inf_real(val3, fbv_type))));
+
     smt_astt nan_p = combine_nan_preds(
       combine_nan_preds(get_nan_pred(val1), get_nan_pred(val2)),
-      get_nan_pred(val3));
+      combine_nan_preds(
+        get_nan_pred(val3), combine_nan_preds(mul_nan, add_nan)));
     if (nan_p)
       store_nan_pred(real_result, nan_p);
     return real_result;


### PR DESCRIPTION
## Summary

This PR extends the `--ir-ieee` SMT real-arithmetic encoding to generate NaN predicates for invalid IEEE 754 fused multiply-add (FMA) operations.

Previously, `encode_ieee_fma()` propagated NaN only when one of its operands was already tracked as NaN. It did not generate a new NaN predicate when the FMA operation itself was invalid, causing `isnan(fma(...))` and NaN-sensitive comparisons to produce incorrect results for symbolic infinities.

## Motivation

Under `--ir-ieee`, symbolic FMA operations should follow IEEE 754 invalid-operation semantics.

For example:

```c
#include <math.h>

extern double __VERIFIER_nondet_double(void);

int main(void)
{
  double x = __VERIFIER_nondet_double();
  double z = __VERIFIER_nondet_double();

  __ESBMC_assume(isinf(x) && x > 0.0);
  __ESBMC_assume(isinf(z) && z < 0.0);

  double result = fma(x, 2.0, z);

  __ESBMC_assert(
    isnan(result),
    "infinite product plus opposite infinity is NaN");
}
```

Before this change, the SMT encoding did not generate a NaN predicate for this symbolic invalid operation, so the assertion incorrectly failed.

Constant expressions involving infinities may be simplified before reaching the SMT encoder. The regression tests therefore use symbolic operands to exercise the `encode_ieee_fma()` path directly.

## Changes

This PR updates:

```text
src/solvers/smt/fp/ir_ieee_conv.cpp
```

to generate NaN predicates for two classes of invalid FMA operations.

### Invalid multiplication sub-operation

A NaN predicate is generated when the multiplication part of the FMA performs a zero-times-infinity operation:

| Condition | Result |
|---|---|
| `0 × +∞` | NaN |
| `0 × -∞` | NaN |
| `+∞ × 0` | NaN |
| `-∞ × 0` | NaN |

### Infinite product with an opposite-signed infinite addend

A NaN predicate is also generated when the exact product is infinite and the addend is an infinity with the opposite sign:

| Product | Addend | Result |
|---|---|---|
| `+∞` | `-∞` | NaN |
| `-∞` | `+∞` | NaN |

The product sign is derived directly from the signs of the multiplication operands.

The implementation intentionally does not classify the intermediate product as infinite based solely on its magnitude. This distinction is important for fused semantics: two finite operands may produce a value outside the normal floating-point range, but that finite-product overflow must not be treated as an invalid infinite-product-plus-infinity operation.

The new invalid-operation predicates are combined with the existing NaN predicates already propagated from the three FMA operands.

## Regression Tests

This PR adds the following regression tests:

| Test | Scenario | Expected result |
|---|---|---|
| `ra-fma-mul-zero-inf-nan` | `fma(0, +∞, z)` produces NaN | `VERIFICATION SUCCESSFUL` |
| `ra-fma-mul-zero-inf-nan-fail` | Companion assertion expecting a non-NaN result | `VERIFICATION FAILED` |
| `ra-fma-mul-inf-zero-nan` | `fma(+∞, 0, z)` operand-order variant | `VERIFICATION SUCCESSFUL` |
| `ra-fma-add-inf-nan` | `fma(+∞, +∞, -∞)` produces NaN | `VERIFICATION SUCCESSFUL` |
| `ra-fma-add-inf-nan-fail` | Companion assertion expecting a non-NaN result | `VERIFICATION FAILED` |
| `ra-fma-add-neginf-nan` | `fma(+∞, -∞, +∞)` sign variant | `VERIFICATION SUCCESSFUL` |
| `ra-fma-add-inf-not-nan` | `fma(+∞, +∞, +∞)` remains positive infinity | `VERIFICATION SUCCESSFUL` |
| `ra-fma-one-inf-factor-nan` | `fma(+∞, 2.0, -∞)` with one infinite factor produces NaN | `VERIFICATION SUCCESSFUL` |
| `ra-fma-one-inf-factor-nan-fail` | Companion assertion expecting a non-NaN result | `VERIFICATION FAILED` |
| `ra-fma-finite-overflow-not-nan` | `fma(DBL_MAX, 2.0, -∞)` is not classified as NaN solely because both factors are finite | `VERIFICATION SUCCESSFUL` |
| `ra-fma-finite-overflow-not-nan-fail` | Companion assertion incorrectly expecting NaN | `VERIFICATION FAILED` |

The finite-overflow control verifies that a large product formed from two finite operands is not mistaken for an exact infinite product when generating the invalid-operation NaN predicate.

## Validation

All targeted FMA tests pass:

```text
16/16 tests passed
```

The complete `ir-ra` regression suite also passes after excluding the independently reproduced baseline timeout in `ra-interval-lift-mul-rtz-both-tracked`:

```text
224/224 tests passed
0 tests failed
```

## Scope

This PR is intentionally limited to invalid-operation NaN generation for `encode_ieee_fma()` under `--ir-ieee`.

It does not:

- Change FMA numerical evaluation or rounding.
- Change interval propagation.
- Change existing NaN propagation from operands.
- Affect non-FMA arithmetic operations.
- Modify the bitvector floating-point encoding.
- Change constant-folding behaviour.