### PR TITLE
[regression] Pin quantifier-in-helper-return tests from #6123

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_6123/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_6123/main.cpp
@@ -1,0 +1,94 @@
+// GitHub discussion #6123: asserts calling helper functions whose return
+// value is a quantifier containing function calls. Before PR #6105 the calls
+// were hoisted out of the binder, freezing the bound variable ("unique 3"
+// failed spuriously).
+#define SIZE 4
+typedef int data_t;
+typedef int idx_t;
+
+bool fun_in_lelt(idx_t lo, idx_t primary, idx_t hi)
+{
+  return lo <= primary && primary < SIZE && primary < hi;
+}
+
+#define macro_in_lelt(a, b, c) (((a <= b) && (b < SIZE) && (b < c)))
+
+bool lt_hi_1(data_t vec[SIZE], idx_t hi)
+{
+  idx_t a_idx;
+  return __ESBMC_forall(
+    &a_idx, !(0 <= a_idx) || !(a_idx < SIZE) || vec[a_idx] < hi);
+}
+
+bool lt_hi_2(data_t vec[SIZE], idx_t hi)
+{
+  idx_t a_idx;
+  return __ESBMC_forall(
+    &a_idx, !(fun_in_lelt(0, a_idx, SIZE)) || vec[a_idx] < hi);
+}
+
+bool unique_vec_1(data_t vec[SIZE], idx_t lo, idx_t hi)
+{
+  idx_t a_idx, b_idx;
+  return __ESBMC_forall(
+    &a_idx,
+    !(0 <= a_idx) || !(a_idx < SIZE) ||
+      __ESBMC_forall(
+        &b_idx,
+        !(0 <= b_idx) || !(b_idx < SIZE) || !(a_idx != b_idx) ||
+          vec[a_idx] != vec[b_idx]));
+}
+
+bool unique_vec_2(data_t vec[SIZE], idx_t lo, idx_t hi)
+{
+  idx_t a_idx, b_idx;
+  return __ESBMC_forall(
+    &a_idx,
+    !(macro_in_lelt(0, a_idx, hi)) ||
+      __ESBMC_forall(
+        &b_idx,
+        !(macro_in_lelt(0, b_idx, hi)) || !(a_idx != b_idx) ||
+          vec[a_idx] != vec[b_idx]));
+}
+
+bool unique_vec_3(data_t vec[SIZE], idx_t lo, idx_t hi)
+{
+  idx_t a_idx, b_idx;
+  return __ESBMC_forall(
+    &a_idx,
+    !(fun_in_lelt(0, a_idx, hi)) ||
+      __ESBMC_forall(
+        &b_idx,
+        !(fun_in_lelt(0, b_idx, hi)) || !(a_idx != b_idx) ||
+          vec[a_idx] != vec[b_idx]));
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  vec[0] = 0;
+  vec[1] = 1;
+  vec[2] = 2;
+  vec[3] = 3;
+
+  idx_t a_idx, b_idx;
+  idx_t lo = 0;
+  idx_t hi = SIZE;
+
+  __ESBMC_assert(lt_hi_1(vec, hi), "lt 1");
+  __ESBMC_assert(lt_hi_2(vec, hi), "lt 2");
+
+  __ESBMC_assert(
+    __ESBMC_forall(
+      &a_idx,
+      !(0 <= a_idx) || !(a_idx < SIZE) ||
+        __ESBMC_forall(
+          &b_idx,
+          !(0 <= b_idx) || !(b_idx < SIZE) || !(a_idx != b_idx) ||
+            vec[a_idx] != vec[b_idx])),
+    "unique 0");
+
+  __ESBMC_assert(unique_vec_1(vec, 0, SIZE), "unique 1");
+  __ESBMC_assert(unique_vec_2(vec, 0, SIZE), "unique 2");
+  __ESBMC_assert(unique_vec_3(vec, 0, SIZE), "unique 3");
+}

--- a/regression/esbmc-cpp/bug_fixes/github_6123/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_6123/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--no-standard-checks --multi-property
+^VERIFICATION SUCCESSFUL$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -366,12 +366,18 @@ class Executor:
                 # Gracefully shut down the whole process group so
                 # grandchildren don't linger and starve the CI runner.
                 if os.name == "posix":
+                    # Best-effort: on macOS killpg can raise EPERM when the
+                    # group holds a process we can no longer signal, which
+                    # otherwise turns a tolerated timeout into a hard ERROR.
                     try:
                         os.killpg(proc.pid, signal.SIGTERM)
                         proc.wait(timeout=_TERM_GRACE)
                     except subprocess.TimeoutExpired:
-                        os.killpg(proc.pid, signal.SIGKILL)
-                    except ProcessLookupError:
+                        try:
+                            os.killpg(proc.pid, signal.SIGKILL)
+                        except OSError:
+                            pass
+                    except OSError:
                         pass
                 else:
                     proc.kill()

--- a/regression/z3/github_6123/main.c
+++ b/regression/z3/github_6123/main.c
@@ -1,0 +1,34 @@
+/* GitHub discussion #6123: quantifiers reached through a helper function's
+ * return statement, with pure-function calls in the quantifier bodies
+ * (including a nested quantifier whose body also contains a call). */
+#include <stdbool.h>
+
+#define SIZE 4
+
+bool in_range(int lo, int i, int hi)
+{
+  return lo <= i && i < SIZE && i < hi;
+}
+
+bool all_lt(int vec[SIZE], int hi)
+{
+  int i;
+  return __ESBMC_forall(&i, !in_range(0, i, SIZE) || vec[i] < hi);
+}
+
+bool all_unique(int vec[SIZE], int hi)
+{
+  int i, j;
+  return __ESBMC_forall(
+    &i,
+    !in_range(0, i, hi) ||
+      __ESBMC_forall(&j, !in_range(0, j, hi) || !(i != j) || vec[i] != vec[j]));
+}
+
+int main()
+{
+  int vec[SIZE] = {0, 1, 2, 3};
+
+  __ESBMC_assert(all_lt(vec, SIZE), "all elements below SIZE");
+  __ESBMC_assert(all_unique(vec, SIZE), "all elements unique");
+}

--- a/regression/z3/github_6123/test.desc
+++ b/regression/z3/github_6123/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--z3 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6123_fail/main.c
+++ b/regression/z3/github_6123_fail/main.c
@@ -1,0 +1,28 @@
+/* GitHub discussion #6123 (negative): the quantifier behind the helper's
+ * return must stay falsifiable. vec contains a duplicate, so uniqueness
+ * fails; a change that makes the quantifier vacuously true (the other wrong
+ * verdict PR #6105 fixed) would turn this into a spurious SUCCESSFUL. */
+#include <stdbool.h>
+
+#define SIZE 4
+
+bool in_range(int lo, int i, int hi)
+{
+  return lo <= i && i < SIZE && i < hi;
+}
+
+bool all_unique(int vec[SIZE], int hi)
+{
+  int i, j;
+  return __ESBMC_forall(
+    &i,
+    !in_range(0, i, hi) ||
+      __ESBMC_forall(&j, !in_range(0, j, hi) || !(i != j) || vec[i] != vec[j]));
+}
+
+int main()
+{
+  int vec[SIZE] = {0, 1, 2, 2};
+
+  __ESBMC_assert(all_unique(vec, SIZE), "all elements unique");
+}

--- a/regression/z3/github_6123_fail/test.desc
+++ b/regression/z3/github_6123_fail/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--z3 --incremental-bmc
+^VERIFICATION FAILED$


### PR DESCRIPTION
Discussion #6123's spurious "unique 3" failure came from an assert calling a helper whose return value is an `__ESBMC_forall` with calls in the quantifier body — fixed by #6105, but only assert-site quantifiers were tested.
Pin the helper-return context: the discussion reproducer plus reduced C positive/negative variants (positives verified to fail on pre-#6105 binaries).
All three verified under Bitwuzla and Z3.
