### PR TITLE
[regression] Don't let killpg EPERM turn a timeout into an ERROR

### DIFF
--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -366,12 +366,18 @@ class Executor:
                 # Gracefully shut down the whole process group so
                 # grandchildren don't linger and starve the CI runner.
                 if os.name == "posix":
+                    # Best-effort: on macOS killpg can raise EPERM when the
+                    # group holds a process we can no longer signal, which
+                    # otherwise turns a tolerated timeout into a hard ERROR.
                     try:
                         os.killpg(proc.pid, signal.SIGTERM)
                         proc.wait(timeout=_TERM_GRACE)
                     except subprocess.TimeoutExpired:
-                        os.killpg(proc.pid, signal.SIGKILL)
-                    except ProcessLookupError:
+                        try:
+                            os.killpg(proc.pid, signal.SIGKILL)
+                        except OSError:
+                            pass
+                    except OSError:
                         pass
                 else:
                     proc.kill()


### PR DESCRIPTION
On macOS `os.killpg` can raise `PermissionError` (EPERM) when the process group still holds a process the runner can no longer signal. The cleanup only caught `ProcessLookupError`, so the exception escaped and crashed the harness — turning a KNOWNBUG timeout that the tool otherwise tolerates into a hard test ERROR (seen on macOS arm64 for `python/github_4782_object_size`).

Make the SIGTERM/SIGKILL process-group cleanup best-effort by catching `OSError` on both kill paths, so a timeout is reported as a timeout regardless of whether the group can still be signalled.
