### PR TITLE
[symex][pointer-analysis] comment audit: fix inaccurate comments, drop stale text

### DIFF
--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -13,7 +13,6 @@ expr2tc build_lhs(smt_convt &smt_conv, const expr2tc &lhs)
   {
   case expr2t::index_id:
   {
-    // An array subscription
     index2t index = to_index2t(new_lhs);
 
     // Build new source value, it might be an index, in case of

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -555,11 +555,12 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
   }
 
   // Model *strp for asprintf/vasprintf: assign a fresh tracked heap allocation.
-  // The buffer size is modelled as 1 byte; exact sizing requires va_list
-  // recovery (G-C, not yet implemented). With --no-bounds-check this is
-  // sufficient to eliminate the false alarms while exact size analysis is
-  // deferred. Users running with --bounds-check should be aware of this
-  // limitation.
+  // The buffer size is modelled as 1 byte; exact sizing would need the
+  // recovered format length (va_list recovery exists — see
+  // recover_va_list_args — but is not yet wired into this allocation's size).
+  // With --no-bounds-check this is sufficient to eliminate the false alarms
+  // while exact size analysis is deferred. Users running with --bounds-check
+  // should be aware of this limitation.
   if (is_allocating && !is_nil_expr(strp) && is_pointer_type(strp->type))
   {
     // Derive char * from strp's declared type (char **) so the dereference

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -426,7 +426,6 @@ expr2tc goto_symext::symex_mem_inf(
   if (is_nil_expr(lhs))
     return expr2tc(); // ignore
 
-  // size
   type2tc type = base_type;
 
   assert(!is_nil_type(base_type));

--- a/src/goto-symex/builtin_functions/memory_ops.cpp
+++ b/src/goto-symex/builtin_functions/memory_ops.cpp
@@ -260,7 +260,8 @@ static inline expr2tc gen_value_by_byte(
       expr2tc local_member =
         member2tc(to_struct_type(type).members[i], src, name);
 
-      // Since it is a symbol, lets start from the old value
+      // Pointer members keep their old value (memset over a pointer is not
+      // modelled byte-wise here)
       if (is_pointer_type(to_struct_type(type).members[i]))
         data.datatype_members[i] = local_member;
 
@@ -1398,10 +1399,8 @@ void goto_symext::intrinsic_memset(
 
     if (!is_constant_int2t(item_offset))
     {
-      /* If we reached here, item_offset is not symbolic
-       * and we don't know what the actual value of it is...
-       *
-       * For now bump_call, later we should expand our simplifier
+      /* item_offset did not simplify to a constant (symbolic or too
+       * complex); for now bump_call, later we should expand our simplifier
        */
       log_debug(
         "memset", "TODO: some simplifications are missing, bumping call");

--- a/src/goto-symex/builtin_functions/misc.cpp
+++ b/src/goto-symex/builtin_functions/misc.cpp
@@ -14,7 +14,8 @@ void goto_symext::replace_races_check(expr2tc &expr)
   if (!options.get_bool_option("data-races-check"))
     return;
 
-  // replace RACE_CHECK(&x) with __ESBMC_races_flag[&x]
+  // replace RACE_CHECK(&x) with __ESBMC_races_flag[key(&x)] (key packing
+  // is described below)
   // recursion is needed for this case: !RACE_CHECK(&x)
   expr->Foreach_operand([this](expr2tc &e) {
     if (!is_nil_expr(e))

--- a/src/goto-symex/builtin_functions/object_size.cpp
+++ b/src/goto-symex/builtin_functions/object_size.cpp
@@ -37,10 +37,11 @@ void goto_symext::intrinsic_builtin_object_size(
   bool use_zero_for_unknown = (type_value == 2 || type_value == 3);
   bool consider_offset = (type_value == 1 || type_value == 3);
 
-  // Helper lambda for creating fallback size values.
-  // GCC's __builtin_object_size returns:
-  //   - (size_t)-1 if the object cannot be determined (for type=0 or 1),
-  //   - 0 if the object cannot be determined (for type=2 or 3).
+  // Helper lambda for creating fallback size values when the object
+  // cannot be determined:
+  //   - type 0/1: an SSIZE_MAX-style cap, 2^(word_size-1)-1 (GCC itself
+  //     returns (size_t)-1),
+  //   - type 2/3: 0.
   // The type parameter encodes whether we want the full size (0/2)
   // or remaining size after pointer offset (1/3).
   auto create_fallback_size = [&](bool use_zero) {
@@ -54,10 +55,8 @@ void goto_symext::intrinsic_builtin_object_size(
 
   if (internal_deref_items.empty())
   {
-    // Unable to determine the underlying object.
-    // Fall back to GCC semantics depending on type:
-    //   type 0/1 → (size_t)-1
-    //   type 2/3 → 0
+    // Unable to determine the underlying object; use the fallback sizes
+    // described above.
     obj_size = create_fallback_size(use_zero_for_unknown);
   }
   else

--- a/src/goto-symex/ctest.cpp
+++ b/src/goto-symex/ctest.cpp
@@ -71,8 +71,8 @@ std::string ctest_generator::clean_variable_name(const std::string &name) const
   var_name.erase(
     std::remove(var_name.begin(), var_name.end(), '$'), var_name.end());
 
-  // If the name contains __VERIFIER_ functions, it's an internal temporary
-  // Extract just a simple name or return empty to trigger fallback naming
+  // Names referencing __VERIFIER_ helpers are internal temporaries;
+  // return empty to trigger fallback naming
   if (
     var_name.find("__VERIFIER_") != std::string::npos ||
     var_name.find("___VERIFIER_") != std::string::npos)
@@ -491,7 +491,7 @@ static std::string file_basename(const std::string &path)
   return slash == std::string::npos ? path : path.substr(slash + 1);
 }
 
-// Write CMakeLists.txt for a C project.
+// Write CMakeLists.txt for the generated test project (C or C++ per cpp_mode).
 // Generates esbmc_verifier.h and force-includes it via target_compile_options.
 // Ensure the original source file compiles correctly.
 static void write_cmake(

--- a/src/goto-symex/dynamic_allocation.cpp
+++ b/src/goto-symex/dynamic_allocation.cpp
@@ -38,7 +38,7 @@ void goto_symext::default_replace_dynamic_allocation(expr2tc &expr)
   if (is_valid_object2t(expr))
   {
     /* alloc */
-    // replace with CPROVER_alloc[POINTER_OBJECT(...)]
+    // replace with __ESBMC_alloc[POINTER_OBJECT(...)]
     const valid_object2t &obj = to_valid_object2t(expr);
 
     expr2tc obj_expr = pointer_object2tc(pointer_type2(), obj.value);
@@ -88,8 +88,8 @@ void goto_symext::default_replace_dynamic_allocation(expr2tc &expr)
   }
   else if (is_deallocated_obj2t(expr))
   {
-    /* !alloc */
-    // replace with CPROVER_alloc[POINTER_OBJECT(...)]
+    /* symbol operand: alloc bit as-is; otherwise !alloc */
+    // replace with __ESBMC_alloc[POINTER_OBJECT(...)]
     const deallocated_obj2t &obj = to_deallocated_obj2t(expr);
 
     expr2tc obj_expr = pointer_object2tc(pointer_type2(), obj.value);
@@ -107,7 +107,7 @@ void goto_symext::default_replace_dynamic_allocation(expr2tc &expr)
   }
   else if (is_dynamic_size2t(expr))
   {
-    // replace with CPROVER_alloc_size[POINTER_OBJECT(...)]
+    // replace with __ESBMC_alloc_size[POINTER_OBJECT(...)]
     //nec: ex37.c
     const dynamic_size2t &size = to_dynamic_size2t(expr);
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -571,8 +571,6 @@ void execution_statet::restore_last_paths()
     new_gs.num_instructions = gs.num_instructions;
     new_gs.guard = gs.guard;
     assert(new_gs.thread_id == gs.thread_id);
-
-    // And that is it!
   }
 
   list.clear();
@@ -1196,8 +1194,9 @@ void execution_statet::switch_to_monitor()
 
   if (monitor_tid != get_active_state_number())
   {
-    // Don't call switch_to_thread -- it'll execute the thread guard, which is
-    // an extremely bad plan.
+    // Bypass switch_to_thread: a monitor switch must not be followed by
+    // update_after_switch_point/execute_guard, and must adopt the source
+    // thread's guard instead.
     last_active_thread = active_thread;
     active_thread = monitor_tid;
     cur_state = &threads_state[active_thread];
@@ -1223,8 +1222,9 @@ void execution_statet::switch_away_from_monitor()
     monitor_tid == active_thread &&
     "Must call switch_from_monitor from monitor thread\n");
 
-  // Don't call switch_to_thread -- it'll execute the thread guard, which is
-  // an extremely bad plan.
+  // Bypass switch_to_thread: a monitor switch must not be followed by
+  // update_after_switch_point/execute_guard, and must adopt the monitor
+  // thread's guard instead.
   last_active_thread = active_thread;
   active_thread = monitor_from_tid;
   cur_state = &threads_state[active_thread];

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -240,8 +240,8 @@ public:
    *  also passes the assignment to a reachability_treet analysis function to
    *  see whether the assignment should be generating a context switch.
    *  @param code Code representing assignment we're making.
-   *  @param guard A guard for the assignment, true by default
-   *  @param type Assignment type, visible by default
+   *  @param hidden Whether the assignment is hidden from the trace.
+   *  @param guard A guard for the assignment.
    */
   void symex_assign(
     const expr2tc &code,
@@ -323,7 +323,8 @@ public:
   /**
    *  Perform a context switch to thread ID i.
    *  Essentially this just updates the counter indicating which thread is
-   *  currently active. It also causes the execution guard to be reexecuted.
+   *  currently active. Callers taking a scheduling switch must follow this
+   *  with update_after_switch_point(), which re-executes the execution guard.
    *  @see execute_guard.
    *  @param i Thread ID to switch to.
    */
@@ -463,8 +464,7 @@ public:
    */
   void calculate_mpor_constraints();
 
-  /** Accessor method for mpor_schedulable. Ensures its access is within bounds
-   *  and is read-only. */
+  /** Read-only accessor for mpor_says_no. */
   bool is_transition_blocked_by_mpor() const
   {
     return mpor_says_no;
@@ -478,7 +478,7 @@ public:
 
   /**
    *  Has a context switch point occurred.
-   *  Four things can justify this:
+   *  Two things can justify this:
    *   1. cswitch forced by atomic end or yield.
    *   2. Global data read/written.
    *  @return True if context switch is now triggered
@@ -656,13 +656,10 @@ public:
 };
 
 /**
- *  Class for performing a DFS thread exploration.
- *  On the whole, just uses the same functionality provided by execution_statet
- *  but with the only modification that this class resets a portion of the
- *  global string pool when it destructs, to prevent string pool inflation.
- *  Specifically; names that have been generated in execution states that are
- *  generated later in execution that this one will all be no longer used after
- *  this one is destructed. So no need to keep their names around.
+ *  Execution state for DFS thread exploration.
+ *  On the whole, just uses the same functionality provided by execution_statet;
+ *  clone() duplicates the target equation (or pushes a solver context under
+ *  --smt-during-symex), and the destructor pops that context again.
  */
 
 class dfs_execution_statet : public execution_statet

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -116,8 +116,6 @@ public:
     unsigned int simplified_claims;
   };
 
-  // Macros
-  //
   /**
    *  Return identifier for goto guards.
    *  These guards are symbolic names for the truth of a guard on a GOTO jump.
@@ -189,7 +187,8 @@ protected:
    *  being jumps where the guards are nondeterministic, it's that we have to
    *  handle editing the unwind bound when these things occur, and set up state
    *  merges in the future to handle each path thats taken.
-   *  @param old_guard Renamed guard on this jump occuring.
+   *  @param old_guard Branch guard, dereferenced but not yet L2-renamed
+   *                   (symex_goto renames it itself).
    */
   virtual void symex_goto(const expr2tc &old_guard);
 
@@ -227,7 +226,7 @@ protected:
    *  Interpret an OTHER instruction.
    *  These can take many forms; memory management functions are OTHERs for
    *  example (ideally they should be intrinsics...), but also printf and
-   *  variable declarations are handled here.
+   *  inline asm are handled here.
    */
   void symex_other(const expr2tc &code);
 
@@ -262,7 +261,9 @@ protected:
    *  Perform incremental SMT solving for assert and assume statements.
    *  @param expr Expression that must be checked.
    *  @param msg Textual message explaining assertion.
-   *  @return Return whether verification succeeded.
+   *  @return True if incremental solving conclusively resolved the claim
+   *          (held, or refuted with a counterexample recorded); false if
+   *          the result was unknown.
    */
   bool check_incremental(const expr2tc &expr, const std::string &msg);
 
@@ -322,7 +323,6 @@ protected:
    *  See merge_gotos - when we're merging states together due to previous
    *  jumps, this function implements the merging of pointer tracking data.
    *  @param merge_state Previously recorded merge snapshot to be merged in.
-   *  @param dest Thread state for previous jump to be merged into.
    */
   void merge_value_sets(const statet::merge_statet &merge_state);
 
@@ -416,10 +416,10 @@ protected:
   virtual void symex_function_call_deref(const expr2tc &call);
 
   /**
-   *  Handle function call to fixed function
-   *  Like symex_function_call_code, but minus an assertion and location
-   *  recording.
-   *  @param code Function code to actually call
+   *  Handle a call to a statically-known function: checks recursion
+   *  bounds, sets up the new frame, assigns arguments, and jumps to the
+   *  body.
+   *  @param call Function call to interpret.
    */
   virtual void symex_function_call_code(const expr2tc &call);
 
@@ -550,13 +550,13 @@ protected:
     const code_function_call2t &func_call);
 
   /**
-   * @brief Intrinsic call for C memset function call
-   * 
+   * @brief Intrinsic call for C memcpy function call
+   *
    * This will either invoke our operational model (at string.c)
    * or try to compute the resulting value directly
-   * 
-   * @param art 
-   * @param func_call memset function call
+   *
+   * @param art
+   * @param func_call memcpy function call
    */
   void intrinsic_memcpy(
     reachability_treet &art,
@@ -904,8 +904,8 @@ protected:
    *  equivalent uses of WITH, or byte_update, and so forth. The end result is
    *  a single new value to be bound to a new symbol.
    *  @param code Code to assign; with lhs and rhs.
-   *  @param type Assignment type, visible by default
-   *  @param kind The step kind, by default is plain BMC
+   *  @param hidden Whether the resulting SSA steps are marked hidden
+   *                (default visible)
    *  @param guard A guard for the assignment, true by default
    */
   virtual void symex_assign(

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -228,7 +228,7 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
         return true;
     }
 
-    // Handle WITH chains for structs where all updates are constants
+    // Handle WITH chains for arrays where all updates are constants
     if (is_array_type(expr->type))
     {
       // Check if this is a chain of WITHs with all constant updates
@@ -246,7 +246,7 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
         current = w.source_value;
       }
 
-      // If we reached a symbol and all updates were constants, propagate
+      // If all updates in the chain were constants, propagate
       if (all_constant_updates)
         return true;
     }
@@ -438,7 +438,7 @@ void goto_symex_statet::rename(expr2tc &expr)
 
 void goto_symex_statet::rename_address(expr2tc &expr)
 {
-  // rename all the symbols with their last known value
+  // rename symbols to their l1 storage names only (no value substitution)
 
   if (is_nil_expr(expr))
   {
@@ -608,8 +608,7 @@ std::vector<stack_framet> goto_symex_statet::gen_stack_trace() const
   call_stackt::const_reverse_iterator it;
   symex_targett::sourcet src;
 
-  // Format is a vector of strings, each recording a particular function
-  // invocation.
+  // Each stack_framet records one function invocation (name + call source).
 
   for (it = call_stack.rbegin(); it != call_stack.rend(); ++it)
   {

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -389,19 +389,18 @@ public:
   void get_original_name(expr2tc &expr) const;
 
   /**
-   *  Print stack trace of state to osstream.
+   *  Print stack trace of state to an output stream.
    *  Takes all the current function calls and produces an indented stack
-   *  trace, then prints it to stdout.
+   *  trace, written to the given stream.
    *  @param indent Number of spaces to indent contents by.
-   *  @param oss output stream to output
+   *  @param os Output stream to write to.
    */
   void print_stack_trace(unsigned int indent, std::ostream &os) const;
 
   /**
-   *  Generate set of strings making up a stack trace.
-   *  From the current thread state, produces a set of strings recording the
-   *  current function invocations on the stack, and returns them.
-   *  @return Vector of strings describing the current function calls in state.
+   *  Generate a stack trace as a vector of stack_framet, one per function
+   *  invocation on the current call stack.
+   *  @return Vector of stack frames.
    */
   std::vector<stack_framet> gen_stack_trace() const;
 

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -231,11 +231,13 @@ void show_goto_trace_gui(
   }
 }
 
-/* 
-   Return true if 
-   - the location's file_name matches the user input
+/*
+   Return true if
+   - the location's file_name matches the user input or one of the
+     user-supplied include files
    - the location is explicitly labeled as user_provided
    - the location is empty
+   - the location is the esbmc_intrinsics.h exception
 */
 bool input_file_check(const locationt &l)
 {
@@ -511,31 +513,6 @@ void correctness_yaml_goto_trace(
   yml.verified_file = options.get_option("input-file");
   log_progress(
     "Generating Correctness Yaml Witness for: {}", yml.verified_file);
-
-#if 0
-  for (const auto &step : goto_trace.steps)
-  {
-    /* checking restrictions for correctness yaml */
-    if (
-      (!(is_valid_witness_step(ns, step))) ||
-      (!(step.is_assume() || step.is_assert())))
-      continue;
-
-    std::string invariant = get_invariant(
-      yml.verified_file,
-      std::atoi(step.pc->location.get_line().c_str()),
-      options);
-
-    if (invariant.empty())
-      continue; /* we don't have to consider this invariant */
-
-    std::string function = step.pc->location.get_function().c_str();
-    get_line_number(
-      yml.verified_file,
-      std::atoi(step.pc->location.get_line().c_str()),
-      options);
-  }
-#endif
 
   yml.generate_yaml(options);
 }

--- a/src/goto-symex/html.cpp
+++ b/src/goto-symex/html.cpp
@@ -435,7 +435,6 @@ html_report::html_report(
   const optionst &_options)
   : goto_trace(goto_trace), ns(ns), options(_options)
 {
-  // TODO: C++20 reverse view
   for (const goto_trace_stept &step : goto_trace.steps)
   {
     if (step.is_assert() && !step.guard)
@@ -529,7 +528,6 @@ const std::string html_report::generate_body() const
     std::unordered_set<size_t> relevant_lines;
     for (const auto &step : goto_trace.steps)
     {
-      // Only insert non-empty file paths
       std::string file_path = step.pc->location.get_file().as_string();
       if (!file_path.empty())
         files.insert(file_path);
@@ -547,7 +545,7 @@ const std::string html_report::generate_body() const
     body << clang_bug_report::counterexample_checkbox;
     body << clang_bug_report::keyboard_navigation_js;
   }
-  // Counter-Example and Arrows
+  // Per-file annotated source tables
   {
     for (const std::string &file : files)
     {
@@ -621,7 +619,6 @@ void html_report::print_file_table(
 
       comment[0] = toupper(comment[0]);
       oss << comment;
-      //oss << "\n" << from_expr(ns, "", step.pc->guard);
     }
     else if (step.pc->is_assign())
     {
@@ -648,7 +645,6 @@ void html_report::print_file_table(
       break;
   }
 
-  // Table begin
   os << fmt::format(R"(<table class="code" data-fileid="{}">)", file.second);
   for (size_t i = 0; i < lines.size(); i++)
   {
@@ -666,7 +662,6 @@ void html_report::print_file_table(
   }
 
   os << "</table><hr class=divider>";
-  // Table end
 }
 
 void html_report::output(std::ostream &oss) const
@@ -697,7 +692,6 @@ html_report::Language html_report::detect_language(const std::string &filepath)
   if (filepath.empty())
     return Language::Unknown;
 
-  // Check file extension
   size_t dot_pos = filepath.find_last_of('.');
   if (dot_pos == std::string::npos)
     return Language::Unknown;
@@ -716,7 +710,6 @@ html_report::Language html_report::detect_language(const std::string &filepath)
 
 std::string html_report::code_lines::to_html() const
 {
-  // TODO: C++23 has constexpr for regex
   // Use static regex objects for better performance
   static const std::regex cpp_keywords_regex(
     "\\b(auto|break|case|char|const|continue|default|do|double|else|enum|"
@@ -730,7 +723,6 @@ std::string html_report::code_lines::to_html() const
     "nonlocal|not|or|pass|raise|return|try|while|with|yield)"
     "\\b(?=[^\"]*(\"[^\"]*\"[^\"]*)*$)");
 
-  // Choose regex based on language
   const std::regex *keywords_regex;
   if (language == Language::Python)
     keywords_regex = &python_keywords_regex;
@@ -740,7 +732,6 @@ std::string html_report::code_lines::to_html() const
     // No highlighting for unknown languages
     return content;
 
-  // Single regex_replace instead of loop
   return std::regex_replace(
     content, *keywords_regex, "<span class='keyword'>$&</span>");
 }

--- a/src/goto-symex/json.cpp
+++ b/src/goto-symex/json.cpp
@@ -19,13 +19,11 @@ bool starts_with(const std::string &str, const std::string &prefix)
          str.compare(0, prefix.size(), prefix) == 0;
 }
 
-// Helper function to check if a path is a system path
 bool is_system_path(const std::string &path)
 {
   return starts_with(std::filesystem::path(path).string(), "/usr/");
 }
 
-// Helper function to read file lines
 std::vector<std::string> read_file_lines(const std::string &filename)
 {
   std::vector<std::string> lines;
@@ -121,7 +119,7 @@ std::set<std::string> find_included_headers(
   return headers;
 }
 
-// Improved value serialization with seen set now inside method
+// Serialise a value to JSON; `seen` tracks pointer addresses to cut cycles.
 json serialize_value(const namespacet &ns, const expr2tc &expr)
 {
   class ValueSerializer

--- a/src/goto-symex/pytest.cpp
+++ b/src/goto-symex/pytest.cpp
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include <unordered_set>
 
-// pytest_generator class implementation
 std::string pytest_generator::extract_module_name(const std::string &input_file)
 {
   std::string module_name = input_file;
@@ -42,7 +41,6 @@ std::string pytest_generator::clean_variable_name(const std::string &name) const
 {
   std::string var_name = name;
 
-  // Remove everything before the last '$' (if present) - for internal symbols like "$nondet_str$15"
   size_t dollar_pos = var_name.rfind('$');
   if (dollar_pos != std::string::npos && dollar_pos > 0)
   {
@@ -306,7 +304,8 @@ pytest_generator::convert_char_array_to_string(const expr2tc &array_expr) const
   const constant_array2t &arr = to_constant_array2t(array_expr);
   std::string result;
 
-  // Convert character array to string (stop at null terminator or -1)
+  // Convert character array to string (stop at null terminator or any
+  // negative value)
   for (const auto &elem : arr.datatype_members)
   {
     if (!is_constant_int2t(elem))
@@ -318,7 +317,7 @@ pytest_generator::convert_char_array_to_string(const expr2tc &array_expr) const
     if (value == 0 || value < 0)
       break;
 
-    // Only include valid ASCII/UTF-8 characters
+    // Only include 7-bit ASCII; non-ASCII bytes are dropped
     if (value > 0 && value <= 127)
     {
       result += static_cast<char>(value.to_int64());

--- a/src/goto-symex/pytest.h
+++ b/src/goto-symex/pytest.h
@@ -33,10 +33,10 @@ private:
   /// Escape string for Python representation
   std::string escape_python_string(const std::string &str) const;
 
-  /// TODO: Convert array to Python list representation
+  /// Convert array to Python list representation
   std::string convert_array_to_python_list(const expr2tc &array_expr) const;
 
-  /// TODO: Convert struct to Python dict representation
+  /// Convert struct to Python dict representation
   std::string convert_struct_to_python_dict(const expr2tc &struct_expr) const;
 
   /// Check if array is a character array (C string)

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -658,14 +658,6 @@ bool reachability_treet::check_thread_viable(unsigned int tid, bool quiet) const
     return false;
   }
 
-#if 0
-  if (por && !ex.is_thread_mpor_schedulable(tid)) {
-    if (!quiet)
-      log_status("Thread unschedulable due to POR");
-    return false;
-  }
-#endif
-
   if (ex.tid_is_set && ex.monitor_tid == tid)
   {
     if (!quiet)

--- a/src/goto-symex/reachability_tree.h
+++ b/src/goto-symex/reachability_tree.h
@@ -55,8 +55,7 @@ inline bool is_esbmc_internal_symbol(const std::string &n)
  *  There are various scheduling possibilities. The default is depth-first
  *  search, where we just follow the algorithm above and return all the
  *  traces to the caller. The "schedule" way combines all paths into one
- *  trace, which is then solved once. Round-robin switches to the next
- *  thread in the set of threads when a context-switch point occurs.
+ *  trace, which is then solved once.
  *
  *  Some kind of scheduling interface/api would be good for the future.
  */
@@ -135,9 +134,10 @@ public:
 
   /**
    *  Determine if a thread can be run.
-   *  Checks that the thread hasn't ended, has an empty stack, is blocked by
-   *  POR and so forth etc. Potentially prints a comment as to why the thread
-   *  is blocked, for user feedback from get_ileave_direction_from_user
+   *  Checks that the thread has not already been explored from this frame,
+   *  has not ended, has a non-empty call stack, and is not the monitor
+   *  thread. Potentially prints a comment as to why the thread is blocked,
+   *  for user feedback from get_ileave_direction_from_user
    *  @param tid Thread ID to switch to
    *  @param quiet If false, will print to stdout why this thread is blocked
    *  @return True if thread is viable; false otherwise.
@@ -179,16 +179,16 @@ public:
    *  to prevent switching with inconsistent state. This method causes that
    *  context switch, which has been decided upon, to actually be taken.
    *  As referred to in the reachability_treet algorithm, this makes up steps
-   *  four and five.
+   *  five and six.
    */
   void create_next_state();
 
   /**
    *  Force a context switch, and take it.
-   *  This causes an analyse_* routine to be called, followed by
-   *  create_new_state. The upshot of this is that if there is a context switch
-   *  that could be taken, we find and take it. This implements steps 3-7 of
-   *  the reachability_treet algorithm.
+   *  Calls decide_ileave_direction, then create_next_state. The upshot of
+   *  this is that if there is a context switch that could be taken, we find
+   *  and take it. This implements steps 4-6 of the reachability_treet
+   *  algorithm.
    *  @return True if context switch was generated and taken
    */
   bool step_next_state();
@@ -307,9 +307,8 @@ protected:
    *  until step_next_state finds an unexplored switch (or the stack
    *  empties). If add_leak_checks is true, add memory-leak checks on
    *  the very last remaining frame before erasing it. On return,
-   *  cur_frame_it points at the parent of the unexplored switch when
-   *  exploration_frames is non-empty; the caller is expected to
-   *  advance cur_frame_it onto the new top. */
+   *  cur_frame_it points at the newly pushed top frame (the unexplored
+   *  switch) when exploration_frames is non-empty. */
   void drain_to_unexplored(bool add_leak_checks);
 
   /** Stack of exploration frames representing the current interleaving.
@@ -330,7 +329,7 @@ protected:
   std::shared_ptr<symex_targett> target_template;
   /** Limit on context switches; -1 for no limit */
   int CS_bound;
-  /** Limit on timeslices (--round-robin) */
+  /** Timeslice limit read from the "time-slice" option; currently unused. */
   int TS_slice;
   /** Number of claims in current --schedule exploration */
   unsigned int schedule_total_claims;
@@ -380,7 +379,7 @@ protected:
    *  may_be_written() gates this flag on address_taken_globals. */
   bool any_indirect_write = false;
 
-  /** Master switch; wired to --cswitch-on-readonly-globals. */
+  /** Master switch; wired to --cswitch-skip-readonly-globals. */
   bool readonly_global_opt = false;
 
   /** Walk all goto instructions once and collect the names of every global

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -95,7 +95,7 @@ void renaming::level2t::get_ident_name(expr2tc &sym) const
 
 void renaming::level1t::rename(expr2tc &expr)
 {
-  // rename all the symbols with their last known value
+  // rename symbols to their l1 activation-record names (no value substitution)
 
   if (is_nil_expr(expr))
     return;

--- a/src/goto-symex/renaming.h
+++ b/src/goto-symex/renaming.h
@@ -208,7 +208,8 @@ public:
     unsigned int l1_num;
     unsigned int t_num;
 
-    // Not a part of comparisons etc,
+    // Derived from the fields above; used as the fast-path primary key in
+    // compare() and by name_rec_hash.
     size_t hash;
   };
 

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -197,7 +197,6 @@ void symex_slicet::run_on_assignment(
   symex_target_equationt::SSA_stept &SSA_step)
 {
   assert(is_symbol2t(SSA_step.lhs));
-  // TODO: create an option to ignore nondet symbols (test case generation)
 
   // An array write `arr_n = arr_m with [const_i := v]` whose lhs is tracked is
   // still kept as a step, but the *store* is dropped (rewritten to the identity
@@ -326,8 +325,8 @@ void symex_slicet::run_on_renumber(symex_target_equationt::SSA_stept &SSA_step)
 
 /**
  * Naive slicer: slice every step after the last assertion
- * @param eq symex formula to be sliced
- * @return number of steps that were ignored
+ * @param steps SSA steps to be sliced
+ * @return always true; the number of ignored steps is reported via ignored()
  */
 bool simple_slice::run(symex_target_equationt::SSA_stepst &steps)
 {

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -26,9 +26,8 @@ protected:
 };
 
 /**
- * Naive slicer: slice every step after the last assertion
- * @param eq symex formula to be sliced
- * @return number of steps that were ignored
+ * Naive slicer: slice every step after the last assertion.
+ * The number of ignored steps is reported via ignored().
  */
 class simple_slice : public slicer
 {
@@ -93,9 +92,9 @@ public:
 
   /**
    * Iterate over all steps of the \eq in REVERSE order,
-   * getting symbol dependencies. If an
-   * assignment, renumber or assume does not contain one
-   * of the dependency symbols, then it will be ignored.
+   * getting symbol dependencies. Assignment and renumber steps whose lhs
+   * is untracked are ignored; assume steps additionally require
+   * --slice-assumes.
    *
    * @param eq symex formula to be sliced
    */
@@ -159,30 +158,6 @@ public:
 
   static expr2tc get_nondet_symbol(const expr2tc &expr);
 
-  /**
-   * Marks SSA_steps to be ignored which have no effects on the target equation,
-   * according to the options set in the `config`.
-   *
-   * Notably, this function depends on the global `config`:
-   *  - "no-slice" in `options` -> perform only simple slicing: ignore everything
-   *    after the final assertion
-   *  - "slice-assumes" in `options` -> also perform slicing of assumption steps
-   *  - `config.no_slice_names` and `config.no_slice_ids` -> suppress slicing of
-   *    particular symbols in non-simple slicing mode.
-   *
-   *    * Note 1: ASSERTS are not sliced, only their symbols are added
-   * into the #depends
-   *
-   *    * Note 2: Similar to ASSERTS, if 'slice-assumes' option is
-   * is not enabled. Then only its symbols are added into the
-   * #depends
-
-   *
-   * @param eq The target equation containing the SSA steps to perform program
-   *           slicing on.
-   * @return Whether any step was sliced away
-   */
-
 protected:
   /// whether assumes should be sliced
   const bool slice_assumes;
@@ -226,21 +201,10 @@ protected:
   bool depends_on_tracked(const expr2tc &expr);
 
   /**
-   * Remove unneeded assumes from the formula
+   * Asserts are never sliced: collect the step's guard/cond symbols into
+   * #depends and record their array reads.
    *
-   * Check if the Assume cond symbol is in the #depends, if
-   * it is not then mark the \SSA_Step as ignored.
-   *
-   * If the assume cond is in the #depends, then add its guards
-   * and cond into the #depends
-   *
-   * Note 1: All the conditions operands are going to be added
-   * into the #depends. This makes that the condition itself as
-   * a "reverse taint"
-   *
-   * TODO: What happens if the ASSUME would result in false?
-   *
-   * @param SSA_step an assume step
+   * @param SSA_step an assert step
    */
   void run_on_assert(symex_target_equationt::SSA_stept &SSA_step) override;
 
@@ -269,8 +233,8 @@ protected:
    * Check if the LHS symbol is in the #depends, if
    * it is not then mark the \SSA_Step as ignored.
    *
-   * If the assume cond is in the #depends, then add its guards
-   * and cond into the #depends
+   * If the LHS is tracked, collect the guard and rhs symbols into #depends
+   * (with dead array-store elision — see the implementation).
    *
    * @param SSA_step an assignment step
    */
@@ -281,11 +245,9 @@ protected:
    *
    * Check if the LHS symbol is in the #depends, if
    * it is not then mark the \SSA_Step as ignored.
+   * Renumber steps never contribute dependencies.
    *
-   * If the assume cond is in the #depends, then add its guards
-   * and cond into the #depends
-   *
-   * @param SSA_step an renumber step
+   * @param SSA_step a renumber step
    */
   void run_on_renumber(symex_target_equationt::SSA_stept &SSA_step) override;
 };

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -221,7 +221,6 @@ void goto_symext::do_simplify(expr2tc &expr)
     simplify(expr);
 }
 
-// Handle side effects
 void goto_symext::handle_sideeffect(
   const expr2tc &lhs,
   const sideeffect2t &effect,
@@ -278,7 +277,6 @@ void goto_symext::handle_sideeffect(
   }
 }
 
-// Handle conditional expressions (if2t)
 bool goto_symext::handle_conditional(
   const expr2tc &lhs,
   const if2t &if_effect,
@@ -344,12 +342,6 @@ void goto_symext::symex_assign(
   // actually true (e.g. linked-list traversals where every
   // dereference goes through the same pointer chain).
   //
-  // Snapshot p's pre-havoc value-set here, then re-assert it as a
-  // SAME-OBJECT disjunction *after* the assignment lands. This pins
-  // the freshly-nondet p to the set of dynamic objects the
-  // symex-time value-set analysis has accumulated so far (e.g. the
-  // chain of `dynamic_N_value` symbols allocated by prior loop
-  // iterations).
   // Snapshot p's pre-havoc value-set entry before symex_assign_rec
   // overwrites it with {unknown}. The k-induction `make_nondet_assign`
   // pass emits one `ASSIGN p = nondet()` per modified-loop variable
@@ -382,14 +374,14 @@ void goto_symext::symex_assign(
         cur_state->value_set.get_entry(is_ptr_havoc_l1_name, "").object_map;
 
       // Rewrite the nondet RHS to the pre-havoc value of the pointer,
-      // mirroring master's behaviour on these benchmarks: master
-      // skips pointer havocs entirely under --add-symex-value-sets,
-      // leaving p bound to whatever SSA value it had before the
-      // (would-be) havoc. The pre-havoc value either resolves
-      // statically to a concrete object address (singleton case —
-      // matches the `p = a` pattern master sees) or to an ITE chain
-      // through prior loop iterations (multi-candidate case — matches
-      // master's SSA chain through `p = p->n` updates). Either way
+      // matching the behaviour these benchmarks relied on before this
+      // pass existed: pointer havocs were skipped entirely under
+      // --add-symex-value-sets, leaving p bound to whatever SSA value
+      // it had before the (would-be) havoc. The pre-havoc value either
+      // resolves statically to a concrete object address (singleton
+      // case, the `p = a` pattern) or to an ITE chain through prior
+      // loop iterations (multi-candidate case, the SSA chain through
+      // `p = p->n` updates). Either way
       // the solver gets a concrete binding rather than a fresh
       // nondet pinned via SAME-OBJECT to one of N candidates, and
       // the inductive-step verdict matches the BC depth-k+1
@@ -548,18 +540,13 @@ void goto_symext::symex_assign(
     }
   }
 
-  // Restore the value-set entry to the pre-havoc set, replacing the
-  // {unknown} the symex assignment just wrote. The next dereference
-  // through this pointer (in `symex_dereference.cpp`) will read this
-  // restored set and synthesize an ITE chain over the actual
-  // candidate objects — without it, the deref-time assume can pin
-  // the resolved address but can't drive the value-load itself,
-  // because the load expression's value-set is {*}/invalid_object.
-  //
-  // We do this in addition to the assume() below: the assume
-  // constrains the solver, the value-set restore drives the deref
-  // ITE. Both are needed for IS to prove list traversals where the
-  // havoc would otherwise unbind p from the chain.
+  // Restore the value-set entry to the pre-havoc set after the
+  // assignment. The next dereference through this pointer (in
+  // `symex_dereference.cpp`) will read this restored set and
+  // synthesize an ITE chain over the actual candidate objects —
+  // without it, the deref-time assume can pin the resolved address
+  // but can't drive the value-load itself, because the load
+  // expression's value-set is {*}/invalid_object.
   if (!is_ptr_havoc_l1_name.empty() && !is_ptr_havoc_pre_object_map.empty())
   {
     // Drop unknown/invalid entries from the restored set. Their
@@ -584,12 +571,6 @@ void goto_symext::symex_assign(
         filtered;
   }
 
-  // Re-assert the pre-havoc points-to set on the freshly-nondet
-  // pointer. See the snapshot above for the rationale. The disjunct
-  // construction mirrors the per-dereference assume in
-  // symex_dereference.cpp: SAME-OBJECT for non-NULL candidates, a
-  // plain equality with NULL, and `unknown`/`invalid` entries abort
-  // the constraint (a partial set would be unsound).
   // Note: an earlier prototype also emitted an explicit
   // assume(SAME-OBJECT(p_new, &candidate_1) || ...) right here. With
   // the value-set restore above in place, that assume is redundant —

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -64,7 +64,6 @@ void symex_dereference_statet::get_value_set(
     goto_symex.options.get_bool_option("add-symex-value-sets") &&
     goto_symex.options.get_bool_option("inductive-step"))
   {
-    // check whether we have a set of objects.
     if (value_set.empty())
       return;
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -22,9 +22,10 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   bool new_guard_false = (is_false(new_guard) || cur_state->guard.is_false());
   bool new_guard_true = is_true(new_guard);
 
-  // new_guard_false = TRUE means that the guard is false,
-  // new_guard_true = TRUE means that the guard is true.
-  // And if both variables are not TRUE we need to ask the solver whether the guard holds.
+  // new_guard_false: the branch is provably not taken (guard simplifies to
+  // false, or the current path is already dead). new_guard_true: the guard
+  // simplifies to true. When neither is known and --smt-symex-guard is on,
+  // ask the solver.
   if (
     !new_guard_false && !new_guard_true &&
     options.get_bool_option("smt-symex-guard"))

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -47,7 +47,7 @@ bool goto_symext::check_incremental(const expr2tc &expr, const std::string &msg)
       // check assertion to produce a counterexample
       assertion(gen_false_expr(), msg);
 
-      // incremental verification succeeded
+      // incremental solving resolved the claim (counterexample will follow)
       return true;
     }
     log_status("Incremental verification returned unknown");
@@ -126,7 +126,7 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
   if (
     options.get_bool_option("smt-symex-assert") &&
     check_incremental(new_expr, msg))
-    return; // Verification succeeded, no further action needed
+    return; // claim fully resolved by incremental solving
 
   symex_witness_assert(new_expr, msg);
 
@@ -237,7 +237,6 @@ void goto_symext::assume(const expr2tc &the_assumption)
 
   cur_state->guard.guard_expr(assumption);
 
-  // Irritatingly, assumption destroys its expr argument
   expr2tc tmp_guard = cur_state->guard.as_expr();
   target->assumption(tmp_guard, assumption, cur_state->source, first_loop);
 
@@ -670,11 +669,9 @@ void goto_symext::run_intrinsic(
     ex_state.get_active_state().level2.rename(v);
     assert(v->expr_id == expr2t::expr_ids::constant_vector_id);
 
-    // Create new vector
     std::vector<expr2tc> members;
     for (const auto &x : to_constant_vector2t(v).datatype_members)
     {
-      // Create a typecast call
       auto typecast = typecast2tc(subtype, x);
       members.push_back(typecast);
     }
@@ -849,7 +846,6 @@ void goto_symext::run_intrinsic(
     if (ex_state.cur_state->guard.is_false())
       return;
 
-    // Get the argument
     expr2tc arg0 = func_call.operands[0];
     internal_deref_items.clear();
     expr2tc deref = dereference2tc(get_empty_type(), arg0);
@@ -1579,7 +1575,6 @@ void goto_symext::add_memory_leak_checks()
 
           /* Rename so that it reflects the current state. */
           assert(cur_state->call_stack.size() >= 1);
-          // cur_state->top().level1.rename(sym_expr2);
           cur_state->rename(sym_expr2);
 
           /* Further below we'll look at the value-set of (the L1 version of)
@@ -1678,7 +1673,6 @@ void goto_symext::add_memory_leak_checks()
               /* value-set assumes L1 symbols */
               s.rlevel = symbol2t::renaming_level::level1_global;
             }
-            // assert(s.rlevel == symbol2t::renaming_level::level1_global);
           }
 
           /* Collect all objects reachable from 'globals' in 'points_to'. */
@@ -1798,9 +1792,7 @@ void goto_symext::add_memory_leak_checks()
           to_symbol2t(to_address_of2t(e).ptr_obj).get_symbol_name());
 
     maybe_global_target = [tgts = std::move(globals_point_to)](expr2tc obj) {
-      // Accumulator for OR-ing conditions
       expr2tc is_any;
-      // Iterate over each (expression, condition) pair in tgts
       for (const auto &[e, g] : tgts)
       {
         /* 'obj' is the address of a statically known dynamic object; 'e' is

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -68,7 +68,8 @@ void goto_symext::symex_decl(const expr2tc &code)
 
   const code_decl2t &decl_code = to_code_decl2t(code2);
 
-  // just do the L2 renaming to preserve locality
+  // allocate a fresh level-1 instance of the declared variable to preserve
+  // locality
   const irep_idt &identifier = decl_code.value;
 
   // Generate dummy symbol as a vehicle for renaming.
@@ -118,7 +119,8 @@ void goto_symext::symex_dead(const expr2tc &code)
 
   const code_dead2t &dead_code = to_code_dead2t(code2);
 
-  // just do the L2 renaming to preserve locality
+  // drop the variable's L1 identity from value-set tracking and the
+  // live-locals map
   const irep_idt &identifier = dead_code.value;
 
   // Generate dummy symbol as a vehicle for renaming.

--- a/src/goto-symex/symex_stack.cpp
+++ b/src/goto-symex/symex_stack.cpp
@@ -16,7 +16,7 @@ expr2tc goto_symex_statet::framet::process_stack_size(
   expr2tc function_irep2 = constant_int2tc(get_uint64_type(), f_size);
   expr2tc limit_irep2 = constant_int2tc(get_uint64_type(), s_size);
 
-  // Ensure that the stack frame size is smaller than the stack limit.
+  // Claim that the stack frame size does not exceed the stack limit.
   return lessthanequal2tc(function_irep2, limit_irep2);
 }
 

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -33,8 +33,7 @@ public:
     }
   };
 
-  // write to a variable - must be symbol
-  // the value is destroyed
+  // write to a variable - lhs must be a symbol
   virtual void assignment(
     const expr2tc &guard,
     const expr2tc &lhs,
@@ -60,7 +59,6 @@ public:
     const bool hidden,
     unsigned loop_number) = 0;
   // record an assumption
-  // cond is destroyed
   virtual void assumption(
     const expr2tc &guard,
     const expr2tc &cond,
@@ -68,7 +66,6 @@ public:
     unsigned loop_number) = 0;
 
   // record an assertion
-  // cond is destroyed
   virtual void assertion(
     const expr2tc &guard,
     const expr2tc &cond,

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -308,8 +308,9 @@ void symex_target_equationt::renumber(
 
 void symex_target_equationt::convert(smt_convt &smt_conv, bool vacuity_mode)
 {
-  // Register address-taken objects first so int-to-ptr casts see the full
-  // set of candidate objects regardless of source-level declaration order.
+  // Pre-register address-of'd string/array literals so int-to-ptr casts see
+  // them regardless of source-level declaration order (see
+  // pre_register_addresses for scope).
   pre_register_addresses(smt_conv, SSA_steps.begin(), SSA_steps.end());
 
   equation_conversion_statet state;
@@ -562,12 +563,11 @@ void runtime_encoded_equationt::flush_latest_instructions()
       // There is in fact, nothing to do
       return;
     }
-
-    // Just roll on
   }
 
-  // Register address-taken objects first so int-to-ptr casts see the full
-  // set of candidate objects regardless of source-level declaration order.
+  // Pre-register address-of'd string/array literals so int-to-ptr casts see
+  // them regardless of source-level declaration order (see
+  // pre_register_addresses for scope).
   pre_register_addresses(conv, run_it, SSA_steps.end());
 
   // Now iterate from the start insn to convert, to the end of the list.

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -30,8 +30,7 @@ public:
     ssa_smt_trace = config.options.get_bool_option("ssa-smt-trace");
   }
 
-  // assignment to a variable - must be symbol
-  // the value is destroyed
+  // assignment to a variable - lhs must be a symbol
   void assignment(
     const expr2tc &guard,
     const expr2tc &lhs,
@@ -58,7 +57,6 @@ public:
     unsigned loop_number) override;
 
   // record an assumption
-  // cond is destroyed
   void assumption(
     const expr2tc &guard,
     const expr2tc &cond,
@@ -66,7 +64,6 @@ public:
     unsigned loop_number) override;
 
   // record an assertion
-  // cond is destroyed
   void assertion(
     const expr2tc &guard,
     const expr2tc &cond,
@@ -131,15 +128,16 @@ public:
 
     expr2tc guard;
 
-    // for ASSIGNMENT
+    // for ASSIGNMENT; RENUMBER reuses lhs = symbol, rhs = new size
     expr2tc lhs, rhs;
     expr2tc original_lhs, original_rhs;
 
-    // for ASSUME/ASSERT. Interned: assertion messages are a small,
-    // highly repetitive set ("dereference failure", "array bounds
-    // violated", ...), so irep_idt both shrinks the inline footprint
-    // (4 bytes vs a 32-byte std::string) and dedups the payload across
-    // the many steps that share a message.
+    // cond: assume/assert condition, assignment equality, or branch guard.
+    // comment interned: assertion messages are a small, highly repetitive
+    // set ("dereference failure", "array bounds violated", ...), so
+    // irep_idt both shrinks the inline footprint (4 bytes vs a 32-byte
+    // std::string) and dedups the payload across the many steps that share
+    // a message.
     expr2tc cond;
     irep_idt comment;
 
@@ -166,7 +164,9 @@ public:
     std::unique_ptr<std::vector<stack_framet>> stack_trace_box;
 
     // Discharged assertion expression used for counterexample trace queries.
-    // Nil for non-assertion steps.
+    // Conversion sets it to the discharged claim for asserts and to true
+    // for ignored steps and other non-assume steps; it stays nil for
+    // non-ignored assumes and before conversion.
     expr2tc cond_expr;
 
     // for slicing
@@ -284,8 +284,8 @@ public:
 
   std::shared_ptr<symex_targett> clone() const override
   {
-    // No pointers or anything that requires ownership modification, can just
-    // duplicate self.
+    // SSA_stept's copy constructor deep-copies its unique_ptr payloads, so
+    // plain member-wise duplication is safe.
     return std::shared_ptr<symex_targett>(new symex_target_equationt(*this));
   }
 

--- a/src/goto-symex/symex_valid_object.cpp
+++ b/src/goto-symex/symex_valid_object.cpp
@@ -33,12 +33,10 @@ void goto_symext::replace_dynamic_allocation(expr2tc &expr)
                          ? to_valid_object2t(expr).value
                          : to_deallocated_obj2t(expr).value;
 
-    // check what we have
     if (is_address_of2t(obj_ref))
     {
       expr2tc &obj_operand = to_address_of2t(obj_ref).ptr_obj;
 
-      // see if that is a good one!
       const expr2tc *identifier = get_object(obj_operand);
 
       if (identifier != nullptr)

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -229,7 +229,6 @@ void create_waypoint(const waypoint &wp, YAML::Emitter &waypoint)
     waypoint << YAML::EndMap;
   }
 
-  // location
   waypoint << YAML::Key << "location" << YAML::Value << YAML::BeginMap;
   waypoint << YAML::Key << "file_name" << YAML::Value << YAML::DoubleQuoted
            << wp.file;
@@ -749,7 +748,6 @@ void _create_yaml_metadata_emitter(
   metadata << YAML::Key << "format_version" << YAML::Value << YAML::DoubleQuoted
            << "2.0";
 
-  // Uuid
   std::string uuid =
     boost::uuids::to_string(boost::uuids::random_generator()());
   metadata << YAML::Key << "uuid" << YAML::Value << YAML::DoubleQuoted << uuid;
@@ -768,7 +766,6 @@ void _create_yaml_metadata_emitter(
   metadata << YAML::Key << "creation_time" << YAML::Value << YAML::DoubleQuoted
            << timestr;
 
-  // Producer
   metadata << YAML::Key << "producer" << YAML::BeginMap;
   std::string producer_str = options.get_option("witness-producer");
   if (producer_str.empty())
@@ -789,24 +786,19 @@ void _create_yaml_metadata_emitter(
            << ESBMC_VERSION;
   metadata << YAML::EndMap;
 
-  // Task
   metadata << YAML::Key << "task" << YAML::BeginMap;
 
-  // Input_files
   metadata << YAML::Key << "input_files" << YAML::BeginSeq;
   metadata << YAML::DoubleQuoted << verifiedfile;
   metadata << YAML::EndSeq;
 
-  // Input_file_hashes
   std::string file_hash;
-  // sha256
   generate_sha256_hash_for_file(verifiedfile.c_str(), file_hash);
   metadata << YAML::Key << "input_file_hashes" << YAML::BeginMap;
   metadata << YAML::Key << YAML::DoubleQuoted << verifiedfile << YAML::Value
            << YAML::DoubleQuoted << file_hash;
   metadata << YAML::EndMap;
 
-  // Specification
   std::string spec;
   if (options.get_bool_option("overflow-check"))
     spec = "G ! overflow";
@@ -888,9 +880,6 @@ void create_violation_yaml_emitter(
 
 void check_replace_invalid_assignment(std::string &assignment)
 {
-  /* replace: SAME-OBJECT(&var1, &var2) into &var1 == &var2 (XXX check if should stay) */
-  //std::regex e ("SAME-OBJECT\\((&([a-zA-Z_0-9]+)), (&([a-zA-Z_0-9]+))\\)");
-  //assignment = std::regex_replace(assignment, e ,"$1 == $3");
   std::smatch m;
   /* looking for undesired in the assignment */
   if (
@@ -1273,7 +1262,6 @@ collect_nondet_values(const symex_target_equationt &target, smt_convt &smt_conv)
   std::vector<collected_nondet_value> results;
   std::unordered_set<std::string> seen_nondets;
 
-  // Use the EXACT same logic as generate_testcase
   for (auto const &SSA_step : target.SSA_steps)
   {
     if (SSA_step.ignore || !smt_conv.l_get(SSA_step.guard).is_true())
@@ -1299,7 +1287,7 @@ collect_nondet_values(const symex_target_equationt &target, smt_convt &smt_conv)
         continue;
       }
 
-      // Deduplicate by symbol name (same as generate_testcase)
+      // Deduplicate by symbol name
       if (seen_nondets.count(sym.thename.as_string()))
       {
         continue;

--- a/src/goto-symex/witnesses.h
+++ b/src/goto-symex/witnesses.h
@@ -267,29 +267,17 @@ std::string get_formated_assignment(
   const goto_trace_stept &step,
   bool yaml);
 
-/**
- *
- */
 bool is_valid_witness_expr(
   const namespacet &ns,
   const irep_container<expr2t> &exp);
 
-/**
- *
- */
 BigInt get_line_number(
   std::string &verified_file,
   BigInt relative_line_number,
   optionst &options);
 
-/**
- *
- */
 int generate_sha256_hash_for_file(const char *path, std::string &output);
 
-/**
- *
- */
 std::string
 get_invariant(std::string verified_file, BigInt line_number, optionst &options);
 
@@ -316,7 +304,6 @@ struct collected_nondet_value
 };
 
 /// Collect all nondet values from SSA
-/// Reuses generate_testcase pattern
 std::vector<collected_nondet_value> collect_nondet_values(
   const symex_target_equationt &target,
   smt_convt &smt_conv);

--- a/src/goto-symex/xml_goto_trace.cpp
+++ b/src/goto-symex/xml_goto_trace.cpp
@@ -116,7 +116,6 @@ void convert(const namespacet &ns, const goto_tracet &goto_trace, xmlt &xml)
     default:
       if (location != previous_location)
       {
-        // just the location
         if (xml_location.name != "")
         {
           xmlt &xml_location_only = xml.new_element("location-only");

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -172,8 +172,8 @@ void dereferencet::dereference_expr(expr2tc &expr, guard2tc &guard, modet mode)
   case expr2t::index_id:
   case expr2t::member_id:
   {
-    // The result of this expression should be scalar: we're transitioning
-    // from a scalar result to a nonscalar result.
+    // Index/member ops applied on top of a dereference: resolve the chain
+    // to a single dereference at the accumulated offset.
 
     expr2tc res = dereference_expr_nonscalar(expr, guard, mode, expr);
 
@@ -211,7 +211,7 @@ void dereferencet::dereference_guard_expr(
     // circuit.
     assert(is_bool_type(expr));
 
-    // Take the current size of the guard, so that we can reset it later.
+    // Save the guard so we can restore it afterwards.
     guard2tc old_guards(guard);
 
     expr->Foreach_operand([this, &guard, &expr](expr2tc &op) {
@@ -360,8 +360,8 @@ expr2tc dereferencet::dereference_expr_nonscalar(
 {
   if (is_dereference2t(expr))
   {
-    /* The first expression we're called with is index2t, member2t or non-scalar
-     * if2t. Thus, expr differs from base. */
+    /* The first expression we're called with is index2t or member2t.
+     * Thus, expr differs from base. */
     assert(expr != base);
 
     // Check that either the base type that these steps are applied to matches
@@ -462,7 +462,7 @@ expr2tc dereferencet::dereference(
 
   type2tc type = ns.follow(to_type);
 
-  // collect objects dest may point to
+  // collect objects src may point to
   value_setst::valuest points_to_set;
 
   dereference_callback.get_value_set(src, points_to_set);
@@ -534,7 +534,6 @@ expr2tc dereferencet::make_failed_symbol(const type2tc &out_type)
 {
   type2tc the_type = out_type;
 
-  // else, do new symbol
   symbolt symbol;
   symbol.id = "symex::invalid_object" + i2string(invalid_counter++);
   symbol.name = "invalid_object";
@@ -641,7 +640,7 @@ void dereferencet::check_pointer_alignment(
 
   BigInt access_size_bits = type_byte_size_bits(type);
 
-  // Only check alignment for byte-aligned accesses
+  // Only check alignment for whole-byte-sized accesses (skip bit-fields)
   if (access_size_bits % 8 != 0)
     return;
 
@@ -898,7 +897,6 @@ enum target_flags
  * - note:
  *   - st = uses stitching via stitch_together_from_byte_array()
  *   - rec = recurses into build_reference_rec()
- *   - rec* = same as rec*, but also restricted recursion into itself or others
  *   - rec' = only restricted recursion into itself
  *
  * src and dst categories:
@@ -1542,7 +1540,6 @@ void dereferencet::construct_from_dyn_struct_offset(
       continue;
     }
 
-    // Round up to word size
     expr2tc field_offset = constant_int2tc(offset->type, offs);
     expr2tc field_top = constant_int2tc(offset->type, offs + field_size);
     expr2tc lower_bound = greaterthanequal2tc(bits_offset, field_offset);
@@ -1602,7 +1599,6 @@ void dereferencet::construct_from_dyn_offset(
 {
   expr2tc orig_value = value;
 
-  // Else, in the case of a scalar access at the bottom,
   assert(config.ansi_c.endianess != configt::ansi_ct::NO_ENDIANESS);
   assert(is_scalar_type(value));
 
@@ -1895,7 +1891,7 @@ void dereferencet::construct_struct_ref_from_dyn_offset(
     accuml = or2tc(accuml, it->first);
   }
 
-  accuml = not2tc(accuml); // Creates a new 'not' expr. Doesn't copy construct.
+  accuml = not2tc(accuml);
   guard2tc tmp_guard = guard;
   tmp_guard.add(accuml);
   bad_base_type_failure(tmp_guard, "legal dynamic offset", "illegal offset");
@@ -2428,7 +2424,7 @@ void dereferencet::bounds_check(
      * Use capability_top2tc and capability_base2tc to get the upper and
      * lower bounds for the capability.
      *
-     * cheri_bounds assertion will be (addr < top && addr > base)
+     * cheri_bounds violation will be (addr >= top || addr < base)
      *
      */
     expr2tc addr = typecast2tc(ptraddr_type2(), deref);
@@ -2492,12 +2488,6 @@ void dereferencet::bounds_check(
   else
   {
     // Calculate size from type.
-
-    // Dance around getting the array type normalized.
-    type2tc new_string_type;
-
-    // XXX -- arrays were assigned names, but we're skipping that for the moment
-    // std::string name = array_name(ns, expr.source_value);
 
     // Firstly, bail if this is an infinite sized array. There are no bounds
     // checks to be performed.

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -55,11 +55,10 @@
  *
  *  A particular point of interest is the byte layout of the data objects we're
  *  dealing with. The underlying SMT objects mean nothing during byte
- *  addressing, only the code in 'type_byte_size' is relevant. To aid
- *  dereferencing, that code ensures that all data objects are word aligned in
- *  all struct fields (and that trailing padding exists). This is so that we
- *  can avoid all scenarios where dereferences cross field boundries, as that
- *  will ultimately be an alignment violation.
+ *  addressing, only the code in 'type_byte_size' is relevant: struct layout
+ *  follows the target ABI (including packed structs). Accesses that cross
+ *  field boundaries or are misaligned are handled by byte-stitching, plus
+ *  alignment assertions where applicable.
  *
  *  The value set tracking code also maintains a 'minimum alignment' piece of
  *  data when the offset is nondeterministic, guarenteeing that the offset used
@@ -72,12 +71,11 @@
  *   * There are two different flavours of offsets, the offset of the pointer
  *     being dereferenced, and the offset caused by the expression that's
  *     dereferencing it.
- *   * 'Scalar step lists' are a list of expressions applied to a struct or
- *     array to access a scalar within the base object. For example, the expr
- *     "foo->bar[baz]" dereferences foo and applies a member then index expr.
- *     The idea behind this is that we can directly pull the scalar value out
- *     of the underlying type if possible, instead of having to compute a
- *     reference to a struct or array in dereference code.
+ *   * Member/index chains applied on top of a dereference (e.g.
+ *     "foo->bar[baz]", which dereferences foo then applies a member and an
+ *     index expr) are folded into a single bit offset (the "lexical
+ *     offset"), so the scalar can be extracted directly instead of having
+ *     to compute a reference to an intermediate struct or array.
  *   * In that vein, building a reference to a struct only happens as a last
  *     resort, and is vigorously asserted against. An exception to this rule
  *     is when the underlying object is a byte array: we have to support this

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -41,14 +41,8 @@ void value_sett::output(std::ostream &out) const
     }
     else
     {
-#if 0
-      const symbolt &symbol=ns.lookup(e.identifier);
-      display_name=symbol.display_name()+e.suffix;
-      identifier=symbol.name;
-#else
       identifier = e.identifier;
       display_name = identifier + e.suffix;
-#endif
     }
 
     out << display_name;

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -36,8 +36,8 @@
  *
  *  The only data element stored is a map from l1 variable names (as strings)
  *  to a record of what objects are stored. Data objects are numbered, with the
- *  mapping for that stored in a global variable, value_sett::object_numbering,
- *  (which will explode into multithreaded death cakes in the future). The
+ *  mapping for that stored in the thread-local static
+ *  value_sett::object_numbering. The
  *  primary interfaces to the value_sett object itself are the 'assign' method
  *  (for interpreting a variable assignment) and the get_value_set method, that
  *  takes a variable and returns the set of things it might point at.
@@ -74,7 +74,6 @@ public:
     xchg_name = ref.xchg_name;
     xchg_num = ref.xchg_num;
     // No need to copy ns, it should be the same in all contexts.
-    // Msg will not change as well
     return *this;
   }
 
@@ -121,7 +120,6 @@ public:
     {
       assert(offset_set);
       offset_alignment = 1;
-      // offset_set = offset_set;
     }
 
     /** Record of the explicit offset into the object. Only valid when
@@ -315,7 +313,9 @@ public:
     std::pair<object_mapt::iterator, bool> res =
       dest.insert(object_mapt::value_type(it->first, it->second));
 
-    // If element already existed, overwrite.
+    // An entry already present for this object number is left untouched:
+    // the assignment below runs only for freshly inserted elements, where
+    // it is a no-op.
     if (res.second)
       res.first->second = it->second;
   }
@@ -678,7 +678,8 @@ protected:
 
 public:
   //********************************** Members ***********************************
-  /** Some crazy static analysis tool. */
+  /** Location number of the instruction this value set is attached to;
+   *  used to identify allocation sites for dynamic objects. */
   unsigned location_number;
   /** Object to assign numbers to objects -- i.e., the numbers in the map of
    *  a @ref object_mapt.

--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -191,23 +191,6 @@ void value_set_analysist::convert(
     {
       xmlt &var = i.new_element("variable");
       var.new_element("identifier").data = value.first.as_string();
-
-#if 0
-      const value_sett::expr_sett &expr_set=
-        v_it->second.expr_set();
-
-      for(value_sett::expr_sett::const_iterator
-          e_it=expr_set.begin();
-          e_it!=expr_set.end();
-          e_it++)
-      {
-        std::string value_str=
-          from_expr(ns, identifier, *e_it);
-
-        var.new_element("value").data=
-          xmlt::escape(value_str);
-      }
-#endif
     }
   }
 }

--- a/src/pointer-analysis/value_set_domain.h
+++ b/src/pointer-analysis/value_set_domain.h
@@ -29,8 +29,6 @@ public:
 
   value_sett *value_set;
 
-  // overloading
-
   virtual bool merge(const value_set_domaint &other, bool keepnew)
   {
     return value_set->make_union(*other.value_set, keepnew);


### PR DESCRIPTION
Audits every comment in src/goto-symex and src/pointer-analysis against
the current implementation, treating wrong comments as defects.

Modified: comments contradicting the code — check_incremental return
semantics, switch_to_thread guard claim, CHERI bounds boundary,
memcpy/memset Doxygen copy-paste, backwards make_union insert note,
stale k-induction pointer-havoc narrative, wrong option names/step
counts, phantom Doxygen params. Removed: CBMC-heritage "value/cond is
destroyed" contracts, implemented TODOs, empty Doxygen blocks,
narration labels, commented-out and #if-0 dead code (the removed
preprocessor-disabled text compiles to nothing; no live code changed).

Two reviewer notes: build_goto_trace.cpp keeps a provably-dead inner
assert/assume re-check (removal deferred to a change with its own
reachability proof), and value_set.h set() now documents that an
existing entry is left untouched — flag if overwrite was the intent.

No behavioural change: full unit suite, esbmc/0*, pthread and witness
regression subsets pass; all files clang-format-11 clean.