### PR TITLE
[goto-programs] comment audit: fix inaccurate comments, strip stale line refs

### DIFF
--- a/src/goto-programs/abstract-interpretation/bitwise_bounds.h
+++ b/src/goto-programs/abstract-interpretation/bitwise_bounds.h
@@ -611,7 +611,7 @@ INT_X signed_max_xor(INT_X a, INT_X b, INT_X c, INT_X d)
  * Original lower bound on signed interval XOR, inspired by the case-based algorithm
  * for signed interval OR in Henry S. Warren Jr., "Hacker's Delight", 2003
  * @author Edoardo Manino.
- * @brief Maximum value of x ^ y given x in [a,b] and y in [c,d], potentially negative
+ * @brief Minimum value of x ^ y given x in [a,b] and y in [c,d], potentially negative
  * @param a Min value of variable x
  * @param b Max value of variable x
  * @param c Min value of variable y

--- a/src/goto-programs/abstract-interpretation/gcse.h
+++ b/src/goto-programs/abstract-interpretation/gcse.h
@@ -31,7 +31,7 @@
  *      then just replace the abstract state with "new".
  *   Otherwise, compute the intersection between "prev" and "new".
  * - Transform operator:
- *   + END_FUNCTION: all local variables are not available anymore
+ *   + RETURN: the returned expression (and sub-expressions) is now available
  *   + ASSIGN: RHS (and sub-expressions) is now available, LHS (and dependencies) is not available anymore
  *   + GOTO/ASSERT/ASSUME: guard (and sub-expressions) is now available
  *   + DECL/DEAD: variable is no longer available
@@ -117,8 +117,8 @@ public:
  * @brief Global Common Subexpression Elimination algorithm
  *
  * Compute all common subexpression in a goto program. 
- * For each common subexpression, a new intermediate variable 
- * `__esbmc_cse_symbol$` is created and assigned to the common
+ * For each common subexpression, a new intermediate variable
+ * `__ESBMC_cse_symbol$` is created and assigned to the common
  * value.
  *
  * In ESBMC, the main advantage is for sequential dereferences/with

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -430,7 +430,7 @@ void dump_intervals(
     [[maybe_unused]] auto print_vars = [&out, &i_it](const auto &map) {
       for (const auto &interval : map)
       {
-        // "state,var,min,max,bot,top";
+        // "state,line,column,function,var,min,max,bot,top";
         out << fmt::format(
           "{},{},{},{},{},{},{},{},{}\n",
           i_it->location_number,

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -67,8 +67,7 @@ public:
     enable_contraction_for_abstract_states; /// Use contractor for <= operations
   static bool
     enable_wrapped_intervals; /// Enabled wrapped intervals (disables Integers)
-  static bool
-    enable_real_intervals; /// Enabled wrapped intervals (disables Integers)
+  static bool enable_real_intervals; /// Enable real (floating-point) intervals
   static bool enable_assume_asserts; /// Asserts are propagates as assumptions
   static bool
     enable_eval_assumptions; /// Try to evaluate in a guard in a TVT to accelerate bottoms

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -136,7 +136,7 @@ public:
     *this = over_meet(*this, value);
   }
 
-  void make_ge_than(const BigInt &v) override // add upper bound
+  void make_ge_than(const BigInt &v) override // add lower bound
   {
     wrapped_interval value(t);
     value.set_lower(v);
@@ -144,7 +144,7 @@ public:
     *this = over_meet(*this, value);
   }
 
-  void make_ge_than(const wrapped_interval &rhs) // add upper bound
+  void make_ge_than(const wrapped_interval &rhs) // add lower bound
   {
     if (rhs.is_bottom())
     {
@@ -1173,7 +1173,6 @@ public:
   friend wrapped_interval
   operator/(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    // [a_0, a_1] + [b_0, b_1] = [a_0+b_0, a_1 + b_1]
     std::vector<wrapped_interval> r;
 
     wrapped_interval zero(lhs.t);

--- a/src/goto-programs/assign_params_as_non_det.cpp
+++ b/src/goto-programs/assign_params_as_non_det.cpp
@@ -177,7 +177,7 @@ bool assign_params_as_non_det::runOnFunction(
       ASSIGN,
       l);
 
-    // Wrap the four instructions just inserted (DECL flag, ASSIGN flag, DECL
+    // Wrap the six instructions just inserted (DECL flag, ASSIGN flag, DECL
     // obj, ASSIGN obj, ASSUME, ASSIGN addr) so they are guarded by the flag.
     //! hack: we use !flag (forward jump over the body) so the condition is not
     //! counted in goto_coverage.

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -699,8 +699,9 @@ void goto_convertt::do_function_call_symbol(
       !is_loop_invariant && !is_requires && !is_ensures)
       return;
 
-    // Rafael's invariant merging: combine consecutive __invariant() calls
-    // into a single LOOP_INVARIANT instruction for efficiency
+    // Rafael's invariant merging: combine consecutive
+    // __ESBMC_loop_invariant() calls into a single LOOP_INVARIANT
+    // instruction for efficiency
     // not tested yet, but should be correct
     goto_programt::targett t;
     expr2tc guard;

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -94,7 +94,7 @@ public:
   ///   2. Havoc all potentially modified locations:
   ///      - Assigns clause targets (if specified)
   ///      - Static lifetime global variables (conservative)
-  ///      - Memory locations through pointer parameters (TODO)
+  ///      - Memory locations through pointer parameters
   ///   3. Assume ensures clause (assume postcondition)
   ///
   /// CRITICAL: We must havoc everything the function might modify,

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -628,7 +628,7 @@ void goto_checkt::input_overflow_check(
         "Unsupported type {}, skip overflow checking", type_id.as_string());
   }
 
-  if (buf_overflow) // FIX ME! add assert(0) to output the error msg
+  if (buf_overflow)
   {
     goto_programt::targett t = new_code.add_instruction(ASSERT);
     t->guard = gen_false_expr();
@@ -1026,7 +1026,7 @@ void goto_checkt::bounds_check(
     "array bounds violated: " + array_name(ns, ind.source_value);
   const expr2tc &the_index = ind.index;
 
-  // Lower bound access should be greater than zero
+  // Lower bound: index must be non-negative (>= 0)
   expr2tc zero = gen_zero(the_index->type);
   assert(!is_nil_expr(zero));
 

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -604,7 +604,6 @@ private:
    * assume(0). It will also search for the last loop in the program based
    * on location.
    * @param goto_functions goto program functions
-   * @param vector result from the contractor.
    */
   void insert_assume(goto_functionst goto_functions);
 

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1586,7 +1586,7 @@ void goto_convertt::convert_return(
     // code form codet("cpp-throw"). A throw has void type and cannot be used
     // as a return value; convert it as a statement and return early (the throw
     // is unconditional, so no RETURN instruction is needed).
-    // Mirrors the same guard in convert_expression (line ~475).
+    // Mirrors the `expr.is_code()` guard in convert_expression.
     if (
       new_code.return_value().is_code() &&
       to_code(new_code.return_value()).get_statement() == "cpp-throw")

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -116,10 +116,10 @@ static void stamp_value_locations(exprt &expr, const locationt &loc)
 // statement's #location, but the legacy->IREP2->legacy body round-trip drops it
 // from the value operands. goto_convert then generates instructions from those
 // operands (e.g. the tmp/GOTO sequence a `&&`/`||` short-circuit lowers to,
-// whose location is read from the operand at goto_sideeffects.cpp:242) with an
+// whose location is read from the operand at goto_sideeffects.cpp) with an
 // empty location -- breaking any pass keyed on instruction location, e.g.
 // --condition-coverage skips conditions whose file is not the source file
-// (goto_coverage.cpp:947), reporting 0 conditions and a spurious SUCCESSFUL.
+// (goto_coverage.cpp), reporting 0 conditions and a spurious SUCCESSFUL.
 // Restore the frontend invariant by pushing each statement's location down onto
 // its location-less value operands. Each nested statement governs its subtree.
 static void restore_value_locations(exprt &code, const locationt &inherited)
@@ -234,7 +234,7 @@ bool goto_convert_functionst::convert_native_rec(
     if (has_sideeffect(lhs) || lhs.id() == "if")
       return false;
 
-    // convert_assign()'s function-call special case (goto_convert.cpp:998)
+    // convert_assign()'s function-call special case (goto_convert.cpp)
     // dispatches a call-valued rhs straight to do_function_call(), bypassing
     // the atomic checks the generic path below applies — a call result
     // assigned to a C11 _Atomic lhs is NOT wrapped atomically in legacy
@@ -282,7 +282,7 @@ bool goto_convert_functionst::convert_native_rec(
     // flag-off.
     //
     // A top-level ternary is the one non-side-effect shape remove_sideeffects
-    // still enters (goto_sideeffects.cpp:180 early-returns only on
+    // still enters (goto_sideeffects.cpp early-returns only on
     // `!has_sideeffect(e) && e.id() != "if"`): under --validate-violation-witness
     // it lowers `c ? a : b` to a DECL/IF/GOTO branch, which a single ASSIGN would
     // not reproduce. Mirror that exact entry condition so we fall back on it.
@@ -309,10 +309,10 @@ bool goto_convert_functionst::convert_native_rec(
     const code_expression2t &expr_stmt = to_code_expression2t(code2);
 
     // convert_expression() emits a single OTHER only in its plain else-branch
-    // (goto_convert.cpp:519-530): a side-effect operand is lowered by
+    // (goto_convert.cpp): a side-effect operand is lowered by
     // remove_sideeffects, a code-typed operand is re-dispatched through convert()
-    // (goto_convert.cpp:501), and a top-level ternary is peeled off
-    // unconditionally into convert_ifthenelse (goto_convert.cpp:507), before
+    // (goto_convert.cpp), and a top-level ternary is peeled off
+    // unconditionally into convert_ifthenelse (goto_convert.cpp), before
     // remove_sideeffects runs. Fall back on all of those, deciding with the exact
     // predicates convert_expression uses on a throwaway legacy view of the
     // operand.
@@ -344,14 +344,14 @@ bool goto_convert_functionst::convert_native_rec(
     if (s == nullptr)
       return false;
 
-    // convert_decl (goto_convert.cpp:705) has several paths this native handler
+    // convert_decl (goto_convert.cpp) has several paths this native handler
     // does not reproduce; fall back on each so flag-on stays byte-identical:
-    //  - a static-lifetime or code-typed symbol is a no-op SKIP (:730),
+    //  - a static-lifetime or code-typed symbol is a no-op SKIP,
     //  - an array type may be a VLA needing rewrite_vla_decl / a dynamic-size
-    //    generator (:734) — exclude all arrays conservatively,
+    //    generator — exclude all arrays conservatively,
     //  - a type with a destructor pushes a second stack entry and lowers a
-    //    FUNCTION_CALL at scope exit (:800),
-    //  - a temporary_object or side-effect initializer is lowered (:760-787).
+    //    FUNCTION_CALL at scope exit,
+    //  - a temporary_object or side-effect initializer is lowered.
     // What remains is exactly convert_decl's plain path: a DECL, an optional
     // side-effect-free ASSIGN, and one scope-exit code_dead.
     if (
@@ -366,7 +366,7 @@ bool goto_convert_functionst::convert_native_rec(
                                                : migrate_expr_back(decl.init);
     // A top-level ternary initializer is side-effect-free yet still lowered to a
     // DECL/IF/GOTO branch by remove_sideeffects under --validate-violation-witness
-    // (goto_sideeffects.cpp:180), which a single ASSIGN would not reproduce —
+    // (goto_sideeffects.cpp), which a single ASSIGN would not reproduce —
     // mirror the same guard the assign handler carries.
     if (
       initializer.is_not_nil() &&
@@ -404,7 +404,7 @@ bool goto_convert_functionst::convert_native_rec(
   {
     const code_return2t &ret = to_code_return2t(code2);
 
-    // convert_return (goto_convert.cpp:1468) emits, for the plain case, a RETURN
+    // convert_return (goto_convert.cpp) emits, for the plain case, a RETURN
     // instruction (only when the function returns a value) followed by an
     // unconditional GOTO to the end-of-function target. Reproduce that exactly,
     // and fall back on every shape convert_return transforms, deciding with the
@@ -451,7 +451,7 @@ bool goto_convert_functionst::convert_native_rec(
   {
     const code_ifthenelse2t &ite = to_code_ifthenelse2t(code2);
 
-    // A side-effecting guard needs remove_sideeffects (goto_convert.cpp:1814),
+    // A side-effecting guard needs remove_sideeffects (goto_convert.cpp),
     // which this kind doesn't reproduce; the condition-coverage options
     // suppress that call regardless, so fall back on those too.
     if (
@@ -489,7 +489,7 @@ bool goto_convert_functionst::convert_native_rec(
       }
     }
 
-    // generate_ifthenelse (goto_convert.cpp:1657) folds a branch that reduces
+    // generate_ifthenelse (goto_convert.cpp) folds a branch that reduces
     // to a lone `assert(false)` directly into the guard instead of emitting
     // the general shape below (--validate-violation-witness disables this);
     // fall back rather than reproduce the fold.
@@ -584,7 +584,7 @@ bool goto_convert_functionst::convert_native_rec(
     goto_programt tmp_branch;
     if (has_sideeffect(w.cond))
     {
-      // convert_while (goto_convert.cpp:1255) builds this branch via the
+      // convert_while (goto_convert.cpp) builds this branch via the
       // shared generate_conditional_branch helper, which itself decomposes
       // &&/||/not and calls remove_sideeffects() at the leaf. Delegate to
       // that helper verbatim instead of reimplementing it, so a direct call
@@ -688,7 +688,7 @@ bool goto_convert_functionst::convert_native_rec(
   {
     const code_assert2t &a = to_code_assert2t(code2);
 
-    // convert_assert (goto_convert.cpp:1103) removes side effects from the
+    // convert_assert (goto_convert.cpp) removes side effects from the
     // guard before emitting; require a side-effect-free guard for the same
     // reason as every other statement kind here. code_assert2t's guard is
     // already expr2tc, so (unlike the legacy-exprt kinds) there is no

--- a/src/goto-programs/goto_coverage.h
+++ b/src/goto-programs/goto_coverage.h
@@ -113,7 +113,6 @@ public:
   size_t k_path_max_goals = 10000;
 
 protected:
-  // turn a OP b OP c into a list a, b, c
   expr2tc handle_single_guard(const expr2tc &expr, bool top_level);
   void handle_operands_guard(
     const expr2tc &expr,

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -329,11 +329,6 @@ static bool symbol_name_matches(
          s.compare(suffix_pos, d.size(), d) == 0;
 }
 
-/// Shared implementation used by both the legacy loop-invariant pass and the
-/// combined loop-invariant + k-induction pass.  See the declaration of
-/// goto_loop_invariantt::extract_and_remove_side_effects for a high-level
-/// description; this helper just takes an explicit goto_function parameter so
-/// it can be reused from both passes.
 /// Local helper: collect all symbol names reachable from an expression tree.
 static void
 collect_symbols_local(const expr2tc &expr, std::set<irep_idt> &symbols)
@@ -355,6 +350,11 @@ collect_symbols_local(const expr2tc &expr, std::set<irep_idt> &symbols)
   }
 }
 
+/// Shared implementation used by both the legacy loop-invariant pass and the
+/// combined loop-invariant + k-induction pass.  See the declaration of
+/// goto_loop_invariantt::extract_and_remove_side_effects for a high-level
+/// description; this helper just takes an explicit goto_function parameter so
+/// it can be reused from both passes.
 static void extract_and_remove_side_effects_impl(
   goto_functiont &goto_function,
   goto_programt::targett loop_head,

--- a/src/goto-programs/goto_loop_invariant.h
+++ b/src/goto-programs/goto_loop_invariant.h
@@ -148,10 +148,6 @@ protected:
  * The branch uses std::list::splice() rather than insert_swap() so that
  * existing backward-GOTO targets (which point to original_loop_head) are
  * not disturbed.
- *
- * Loops whose bodies contain forward GOTOs that jump outside the loop are
- * skipped (too complex to copy safely); they fall back to the ASSUME-only
- * k-induction acceleration provided by goto_k_inductiont.
  */
 class goto_loop_invariant_combinedt : public goto_loopst
 {
@@ -175,10 +171,8 @@ private:
   /**
    * Copy the loop body instructions (from the instruction immediately after
    * @p loop_head up to, but not including, @p loop_exit) into @p out.
-   *
-   * Returns false and leaves @p out empty when the loop body contains a
-   * forward GOTO whose target is outside the loop body – such loops are too
-   * complex to inline safely and Branch 1 is skipped for them.
+   * Intra-loop jump targets are remapped to the copied instructions; targets
+   * outside the loop are left unchanged.
    */
   void copy_loop_body(
     goto_programt::targett loop_head,

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -63,7 +63,7 @@ class goto_programt
 {
 public:
   /*! \brief copy constructor
-      \param[in] src an empty goto program
+      \param[in] src the goto program to copy from
   */
   inline goto_programt(const goto_programt &src)
   {
@@ -76,7 +76,7 @@ public:
   }
 
   /*! \brief assignment operator
-      \param[in] src an empty goto program
+      \param[in] src the goto program to copy from
   */
   inline goto_programt &operator=(const goto_programt &src)
   {
@@ -126,7 +126,7 @@ public:
       return *loop_contract_data;
     }
 
-    //! the target for gotos and for start_thread nodes
+    //! the targets for gotos and catch
     typedef std::list<class instructiont>::iterator targett;
     typedef std::list<class instructiont>::const_iterator const_targett;
     typedef std::list<targett> targetst;
@@ -637,7 +637,7 @@ public:
     return --tmp;
   }
 
-  //! Adds an instruction of given type at the end.
+  //! Adds a copy of the given instruction at the end.
   //! \return The newly added instruction.
   inline targett add_instruction(instructiont &instruction)
   {

--- a/src/goto-programs/read_bin_goto_object.h
+++ b/src/goto-programs/read_bin_goto_object.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <string>
 
-/** Parses `in`. If failing to do so, a message is printed to `msg_hndlr`.
+/** Parses `in`. On failure an error is logged via log_error.
  *  @return true on error, false on success */
 bool read_bin_goto_object(
   std::istream &in,

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -42,8 +42,5 @@ bool write_goto_binary(
     }
   }
 
-  //irepconverter.output_map(f);
-  //irepconverter.output_string_map(f);
-
   return false;
 }


### PR DESCRIPTION
Audits every comment in src/goto-programs (including the
abstract-interpretation/ and contracts/ subdirs) against the current
implementation, treating wrong comments as defects.

Copy-paste / inaccurate-doc fixes:
- abstract-interpretation: make_ge_than labelled 'add upper bound' but adds
  the lower bound; operator/ (division) carried an interval-addition formula;
  signed_min_xor documented as 'Maximum' (it computes the minimum);
  interval_domain enable_real_intervals had the wrapped-intervals blurb;
  gcse design doc listed a non-existent END_FUNCTION case (it's RETURN) and
  mis-cased __ESBMC_cse_symbol; interval_analysis CSV header listed 6 of 9
  emitted columns.
- goto_program.h: copy-ctor/assignment 'src' param called 'an empty goto
  program'; add_instruction copy overload mislabelled 'of given type';
  'targets for gotos and start_thread' (ESBMC has no START_THREAD) -> catch.
- goto_loop_invariant: copy_loop_body documented a forward-GOTO skip /
  return-false path that does not exist; a 'Shared implementation' doc block
  sat above the wrong helper.
- goto_check buffer-overflow FIXME already implemented; array lower-bound
  comment '> 0' -> '>= 0' (code uses >=); builtin __invariant ->
  __ESBMC_loop_invariant; read_bin_goto_object msg_hndlr param removed;
  contracts pointer-param havoc no longer a TODO.

Also strips volatile '.cpp:NNN' line-number cross-references in
goto_convert_functions.cpp (file + function names kept), which had drifted
as the referenced files grew.

No behavioural change: comment-only (plus removing two already-commented-out
lines in write_goto_binary.cpp). Build clean, full unit suite (566) and the
esbmc/00* regression subset pass, clang-format-11 clean.