### PR TITLE
[solver] comment audit: fix inaccurate SMT/SAT comments

### DIFF
--- a/src/solvers/sat/bitblast_conv.cpp
+++ b/src/solvers/sat/bitblast_conv.cpp
@@ -748,7 +748,7 @@ void bitblast_convt::unsigned_divider(
   sat_api->assert_lit(
     sat_api->limplies(is_not_zero, lt_or_le(false, rem, op1, false)));
 
-  // "op1 != 0 => res <= op0"
+  // "op1 != 0 => rem <= op0"
 
   sat_api->assert_lit(
     sat_api->limplies(is_not_zero, lt_or_le(true, rem, op0, false)));

--- a/src/solvers/smt/array_conv.h
+++ b/src/solvers/smt/array_conv.h
@@ -107,7 +107,6 @@ public:
   typedef smt_solver_baset::ast_vec ast_vect;
   typedef std::vector<ast_vect> array_update_vect;
 
-  // Fgasdf
   struct index_map_rec
   {
     expr2tc idx;

--- a/src/solvers/smt/smt_ast.h
+++ b/src/solvers/smt/smt_ast.h
@@ -56,8 +56,7 @@ public:
    *  for some special cases up to the backend, there may be optimizations made
    *  for array or tuple assigns, and so forth.
    *  @param ctx SMT context to do the assignment in.
-   *  @param sym Symbol to assign to
-   *  @return AST representing the assigned symbol */
+   *  @param sym Symbol to assign to */
   virtual void assign(smt_solver_baset *ctx, smt_astt sym) const;
 
   /** Abstractly produce an "update", i.e., an array 'with' or tuple 'with'.

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -175,7 +175,6 @@ smt_astt smt_solver_baset::convert_bitcast(const expr2tc &expr)
   }
   else if (is_bv_type(to_type))
   {
-    // Under --ir-ieee, float values are real-encoded; bit-pattern reinterpretation
     // Under integer encoding (--ir/--ir-ieee), fixed- and floating-point values are
     // real-encoded; fall back to value-based typecast.
     if (int_encoding && (is_fixedbv_type(from) || is_floatbv_type(from)))

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -320,7 +320,7 @@ smt_solver_baset::convert_typecast_to_ints_from_unsigned(const typecast2t &cast)
   unsigned from_width = cast.from->type->get_width();
 
   if (from_width == to_width)
-    return a; // output = output
+    return a;
 
   if (from_width < to_width)
     return mk_zero_ext(a, (to_width - from_width));

--- a/src/solvers/smt/smt_solver.h
+++ b/src/solvers/smt/smt_solver.h
@@ -480,7 +480,6 @@ public:
    *  @param s the sort.
    *  @param theint Integer representation of the bitvector. Any excess bits
    *         in the stored integer should be ignored.
-   *  @param w Width, in bits, of the bitvector to create.
    *  @return The newly created terminal smt_ast of this bitvector. */
   virtual smt_astt mk_smt_bv(const BigInt &theint, smt_sortt s) = 0;
 
@@ -578,8 +577,9 @@ public:
    *  @name Integer overflow solver-converter API. */
 
   /** Detect integer arithmetic overflows. Takes an expression that is one of
-   *  add / sub / mul, and evaluates whether its operation applied to its
-   *  operands will result in an integer overflow or underflow.
+   *  add / sub / mul / div / modulus / shl, and evaluates whether its
+   *  operation applied to its operands will result in an integer overflow or
+   *  underflow.
    *  @param expr Expression to test for arithmetic overflows in.
    *  @return Boolean valued AST representing whether an overflow occurs. */
   virtual smt_astt overflow_arith(const expr2tc &expr);

--- a/src/solvers/smt/smt_sort.h
+++ b/src/solvers/smt/smt_sort.h
@@ -137,7 +137,7 @@ public:
 private:
   /** Data size of the sort.
    * For bitvectors and floating-points, this is the bit width,
-   * for arrays, the range BV bit width,
+   * for arrays, the domain (index) bit width,
    * For everything else, undefined */
   size_t data_width;
 

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -58,8 +58,9 @@ static const std::unordered_map<std::string, solver_creator *> esbmc_solvers = {
 #endif
 };
 
-// Order encodes default priority: first compiled-in entry (excluding smtlib)
-// is selected when no solver is explicitly requested.
+// Order encodes default priority: the first compiled-in entry that is not
+// smtlib, bitwuzllob or neurosym is selected when no solver is explicitly
+// requested (those three depend on external programs; see pick_default_solver).
 static const std::string all_solvers[] = {
   "smtlib",
   "bitwuzllob",


### PR DESCRIPTION
Audits comments in src/solvers (the SMT/SAT backend layer) against the
current implementation, treating wrong comments about encoding as defects.

Fixes:
- smt_sort.h: `data_width` for arrays is the domain (index) width, not the
  range width (get_domain_width() returns it; array ctors store dom_width).
- smt_solver.h: overflow_arith handles add/sub/mul/div/modulus/shl (doc said
  only add/sub/mul); removed a stale `@param w` on the mk_smt_bv(theint, sort)
  overload that has no such parameter.
- smt_ast.h: assign() returns void — removed a stale `@return`.
- solve.cpp: the default-solver priority note now names all three backends
  pick_default_solver() skips (smtlib, bitwuzllob, neurosym), not just smtlib.
- bitblast_conv.cpp: the unsigned-divider constraint comment said `res <= op0`
  but the code asserts `rem <= op0` (a sound helper bound); comment now matches.
- smt_bitcast.cpp / smt_casts.cpp / array_conv.h: removed a dangling duplicate
  comment fragment, a '// output = output' label, and a '// Fgasdf' junk label.

No behavioural change: comment-only. Build clean, full unit suite (566) and
the esbmc/00* regression subset pass, clang-format-11 clean.