### PR TITLE
[util] comment audit: fix inaccurate float/simplifier/migrate comments

### DIFF
--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -1931,11 +1931,6 @@ std::string c_expr2stringt::convert_code(const codet &src, unsigned indent)
 std::string
 c_expr2stringt::convert_code_assign(const codet &src, unsigned indent)
 {
-  // Union remangle: If the right hand side is a constant array, containing
-  // byte extract expressions, then it's almost 100% certain to be a flattened
-  // union literal. Precise identification isn't feasible right now, sadly.
-  // In that case, replace with a special intrinsic indicating to the user that
-  // the original code is now meaningless.
   unsigned int precedent = 15;
   std::string tmp = convert(src.op0(), precedent);
   tmp += "=";

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -40,7 +40,6 @@ bool contextt::move(symbolt &symbol, symbolt *&new_symbol)
 void contextt::dump() const
 {
   log_status("\nSymbols:");
-  // Do assignments based on "value".
   foreach_operand([](const symbolt &s) { s.dump(); });
 }
 

--- a/src/util/expr_simplifier.cpp
+++ b/src/util/expr_simplifier.cpp
@@ -891,7 +891,7 @@ struct DivModtor
       if (get_value(c2) == 0)
         return expr2tc();
 
-      // Denominator is one? Simplify to numerator's constant
+      // Denominator is one? x/1 -> x (numerator); x%1 -> 0.
       if (get_value(c2) == 1)
       {
         if constexpr (Div)
@@ -1204,7 +1204,7 @@ expr2tc member2t::do_simplify() const
     unsigned no =
       struct_union_get_component_number(source_value->type, member).value();
 
-    // Clone constant struct, update its field according to this "with".
+    // Project the selected member value out of the constant aggregate.
     expr2tc s;
     if (is_constant_struct2t(source_value))
     {
@@ -2329,7 +2329,7 @@ static expr2tc do_bit_munge_operation(
   const expr2tc &simplified_side_1 = side_1;
   const expr2tc &simplified_side_2 = side_2;
 
-  /* Only support constant folding for integer and's. If you're a float,
+  /* Only constant-fold integer bitwise/shift ops. If you're a float,
    * pointer, or whatever, you're on your own. */
   if (
     is_constant_int2t(simplified_side_1) &&

--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -1012,7 +1012,7 @@ bool operator==(const ieee_floatt &a, const ieee_floatt &b)
   if (a.infinity_flag && b.infinity_flag && (a.sign_flag == b.sign_flag))
     return true;
 
-  // If one is Nan, it's always false
+  // One is infinity and the other is not (or opposite-sign infinities): unequal
   if (a.infinity_flag || b.infinity_flag)
     return false;
 
@@ -1153,7 +1153,6 @@ void ieee_floatt::from_float(const float f)
 void ieee_floatt::make_NaN()
 {
   NaN_flag = true;
-  //sign=false;
   exponent = 0;
   fraction = 0;
   infinity_flag = false;

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -276,8 +276,8 @@ public:
   friend bool operator>(const ieee_floatt &a, const ieee_floatt &b);
   friend bool operator>=(const ieee_floatt &a, const ieee_floatt &b);
 
-  // warning: these do packed equality, not IEEE equality
-  // e.g., NAN==NAN
+  // IEEE-value equality: NaN compares unequal to everything (including
+  // itself), and +0 == -0 despite differing bit patterns.
   friend bool operator==(const ieee_floatt &a, const ieee_floatt &b);
   friend bool operator!=(const ieee_floatt &a, const ieee_floatt &b);
 

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2661,7 +2661,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
   if (expr.id() == "overflow_result--")
   {
-    // Overflow_result : {result = op0 + op1, overflowed = overflow(op0 + op1)}
+    // Overflow_result : {result = op0 - op1, overflowed = overflow(op0 - op1)}
     type = migrate_type(expr.type());
     assert(expr.operands().size() == 2);
     expr2tc op0, op1;
@@ -2677,7 +2677,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
   if (expr.id() == "overflow_result-shr")
   {
-    // Overflow_result : {result = op0 + op1, overflowed = overflow(op0 + op1)}
+    // Overflow_result : {result = op0 >> op1, overflowed = overflow(op0 >> op1)}
     type = migrate_type(expr.type());
     assert(expr.operands().size() == 2);
     expr2tc op0, op1;
@@ -2693,7 +2693,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
   if (expr.id() == "overflow_result-*")
   {
-    // Overflow_result : {result = op0 + op1, overflowed = overflow(op0 + op1)}
+    // Overflow_result : {result = op0 * op1, overflowed = overflow(op0 * op1)}
     type = migrate_type(expr.type());
     assert(expr.operands().size() == 2);
     expr2tc op0, op1;

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -133,16 +133,14 @@ BigInt type_sizet::size_bits(const type2tc &type) const
 
   case type2t::struct_id:
   {
-    // Compute the size of all members of this struct, and add padding bytes
-    // so that they all start on wourd boundries. Also add any trailing bytes
-    // necessary to make arrays align properly if malloc'd, see C89 6.3.3.4.
+    // Sum the sizes of all members. Inter-member and trailing padding
+    // (for word-boundary and array-of-struct alignment; see C89 6.3.3.4) is
+    // inserted by the frontend as explicit padding members, so summing
+    // member sizes already accounts for it.
     BigInt accumulated_size = 0;
     for (auto const &it : to_struct_type(type).members)
       accumulated_size += size_bits(it);
 
-    // At the end of that, the tests above should have rounded accumulated size
-    // up to a size that contains the required trailing padding for array
-    // allocation alignment.
     return accumulated_size;
   }
 
@@ -241,9 +239,10 @@ expr2tc type_sizet::size_bits_expr(const type2tc &type) const
 
   case type2t::struct_id:
   {
-    // Compute the size of all members of this struct, and add padding bytes
-    // so that they all start on wourd boundries. Also add any trailing bytes
-    // necessary to make arrays align properly if malloc'd, see C89 6.3.3.4.
+    // Sum the sizes of all members. Inter-member and trailing padding
+    // (for word-boundary and array-of-struct alignment; see C89 6.3.3.4) is
+    // inserted by the frontend as explicit padding members, so summing
+    // member sizes already accounts for it.
     BigInt acc_cnst = 0;
     expr2tc acc_dyn;
     type2tc t = bitsize_type2();
@@ -257,10 +256,6 @@ expr2tc type_sizet::size_bits_expr(const type2tc &type) const
       else
         acc_dyn = s;
     }
-
-    // At the end of that, the tests above should have rounded accumulated size
-    // up to a size that contains the required trailing padding for array
-    // allocation alignment.
 
     if (!acc_dyn)
       return bitsize(acc_cnst);


### PR DESCRIPTION
Audits comments in src/util (foundational utilities) against the current
implementation, treating wrong comments as defects.

Fixes:
- ieee_float.h: the operator== header claimed 'packed equality, NAN==NAN',
  but the operator does IEEE-value equality (NaN compares unequal to
  everything including itself; +0 == -0). Also a mislabelled infinity check
  commented as a NaN check.
- migrate.cpp: three overflow_result arms carried a copy-pasted
  'result = op0 + op1' comment while building sub / ashr / mul.
- expr_simplifier.cpp: a member2t projection commented as a with2t
  clone-and-update; a Div/Mod x/1 comment omitting the x%1 -> 0 case; a
  bit-munge comment naming only AND for a template used by many
  bitwise/shift ops.
- type_byte_size.cpp: the struct size comment claimed this code rounds/adds
  padding, but padding is inserted by the frontend as explicit members and
  the loop only sums member sizes (C89 6.3.3.4 citation preserved).

Also removes stale/dead comments (a c_expr2string union-remangle note
describing unimplemented behaviour, a stray context.cpp comment, a
commented-out //sign=false referencing a non-existent field).

No behavioural change: comment-only. Build clean, full unit suite (566) and
the esbmc/00* regression subset pass, clang-format-11 clean.