### PR TITLE
[ir-ieee] preserve constant NaNs in SMT Real encoding

### DIFF
--- a/regression/ir-ra/ra-const-nan-pred-fail/main.c
+++ b/regression/ir-ra/ra-const-nan-pred-fail/main.c
@@ -1,0 +1,9 @@
+int main(void)
+{
+  /* __builtin_nan("0") folds to a constant_floatbv NaN in the GOTO IR.
+   * Asserting n > 0.0 must fail: NaN makes ordered comparisons return false. */
+  double n = __builtin_nan("0");
+
+  __ESBMC_assert(n > 0.0, "NaN > 0.0 should not hold");
+  return 0;
+}

--- a/regression/ir-ra/ra-const-nan-pred-fail/test.desc
+++ b/regression/ir-ra/ra-const-nan-pred-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-const-nan-pred/main.c
+++ b/regression/ir-ra/ra-const-nan-pred/main.c
@@ -1,0 +1,12 @@
+int main(void)
+{
+  /* __builtin_nan("0") folds to a constant_floatbv NaN in the GOTO IR,
+   * exercising the constant-NaN path in convert_terminal under --ir-ieee.
+   * All ordered comparisons on NaN return false. */
+  double n = __builtin_nan("0");
+
+  __ESBMC_assert(!(n > 0.0), "NaN > 0.0 is false");
+  __ESBMC_assert(!(n < 0.0), "NaN < 0.0 is false");
+  __ESBMC_assert(!(n == 0.0), "NaN == 0.0 is false");
+  return 0;
+}

--- a/regression/ir-ra/ra-const-nan-pred/test.desc
+++ b/regression/ir-ra/ra-const-nan-pred/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fmod-finite-not-nan/main.c
+++ b/regression/ir-ra/ra-fmod-finite-not-nan/main.c
@@ -1,0 +1,19 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  /* fmod(finite, finite nonzero): well-defined, not NaN */
+  __ESBMC_assume(x > 0.0 && x < DBL_MAX);
+  __ESBMC_assume(y > 0.0 && y < DBL_MAX);
+  double r = fmod(x, y);
+
+  __ESBMC_assert(r == r, "fmod(finite, finite) should not be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-fmod-finite-not-nan/test.desc
+++ b/regression/ir-ra/ra-fmod-finite-not-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fmod-inf-nan-fail/main.c
+++ b/regression/ir-ra/ra-fmod-inf-nan-fail/main.c
@@ -1,0 +1,19 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  /* fmod(+inf, finite): infinite dividend is an invalid operation (NaN) */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(y > 0.0 && y < DBL_MAX);
+  double r = fmod(x, y);
+
+  __ESBMC_assert(r > -100.0, "fmod(+inf, finite) > -100.0 should not hold (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fmod-inf-nan-fail/test.desc
+++ b/regression/ir-ra/ra-fmod-inf-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fmod-inf-nan/main.c
+++ b/regression/ir-ra/ra-fmod-inf-nan/main.c
@@ -1,0 +1,19 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  /* fmod(+inf, finite): infinite dividend is an invalid operation (NaN) */
+  __ESBMC_assume(x > DBL_MAX);
+  __ESBMC_assume(y > 0.0 && y < DBL_MAX);
+  double r = fmod(x, y);
+
+  __ESBMC_assert(!(r > -100.0), "fmod(+inf, finite) > -100.0 is false (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fmod-inf-nan/test.desc
+++ b/regression/ir-ra/ra-fmod-inf-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fmod-nan-prop/main.c
+++ b/regression/ir-ra/ra-fmod-nan-prop/main.c
@@ -1,0 +1,11 @@
+#include <math.h>
+
+int main(void)
+{
+  /* fmod(NaN, 1.0): NaN operand propagates through fmod */
+  double s = sqrt(-1.0);
+  double r = fmod(s, 1.0);
+
+  __ESBMC_assert(!(r > -100.0), "fmod(NaN, 1.0) > -100.0 is false (NaN propagated)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fmod-nan-prop/test.desc
+++ b/regression/ir-ra/ra-fmod-nan-prop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-fmod-zero-div-nan-fail/main.c
+++ b/regression/ir-ra/ra-fmod-zero-div-nan-fail/main.c
@@ -1,0 +1,17 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  /* fmod(x, 0): zero divisor is an invalid operation (NaN) */
+  __ESBMC_assume(x > 0.0 && x < DBL_MAX);
+  double r = fmod(x, 0.0);
+
+  __ESBMC_assert(r > -100.0, "fmod(finite, 0) > -100.0 should not hold (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fmod-zero-div-nan-fail/test.desc
+++ b/regression/ir-ra/ra-fmod-zero-div-nan-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-fmod-zero-div-nan/main.c
+++ b/regression/ir-ra/ra-fmod-zero-div-nan/main.c
@@ -1,0 +1,17 @@
+#include <float.h>
+#include <math.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  /* fmod(x, 0): zero divisor is an invalid operation (NaN) */
+  __ESBMC_assume(x > 0.0 && x < DBL_MAX);
+  double r = fmod(x, 0.0);
+
+  __ESBMC_assert(!(r > -100.0), "fmod(finite, 0) > -100.0 is false (NaN)");
+  return 0;
+}

--- a/regression/ir-ra/ra-fmod-zero-div-nan/test.desc
+++ b/regression/ir-ra/ra-fmod-zero-div-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -2014,8 +2014,19 @@ smt_astt smt_solver_baset::convert_terminal(const expr2tc &expr)
     const constant_floatbv2t &thereal = to_constant_floatbv2t(expr);
     if (int_encoding)
     {
-      if (thereal.value.is_zero() || thereal.value.is_NaN())
+      if (thereal.value.is_zero())
         return mk_smt_real("0");
+      if (thereal.value.is_NaN())
+      {
+        if (ir_ieee)
+        {
+          smt_astt nan_var =
+            mk_fresh(mk_real_sort(), "ir_ieee::nan_const::", nullptr);
+          ir_ieee_api->store_nan_pred(nan_var, mk_smt_bool(true));
+          return nan_var;
+        }
+        return mk_smt_real("0");
+      }
       if (thereal.value.is_infinity())
       {
         // Encode ±∞ as ±double_inf_sentinel (one above double max_normal) for
@@ -2024,7 +2035,7 @@ smt_astt smt_solver_baset::convert_terminal(const expr2tc &expr)
         // float) produces the same value as a double IEEE_DIV(x,0) result.
         // The double sentinel exceeds both single and double max_normal, so
         // isinf/isfinite predicates work correctly for both precisions.
-        // NaN handling is deferred to the IEEE corner-case phase.
+        // NaN is handled above; infinity is encoded as a sentinel value here.
         smt_astt sentinel = get_double_inf_sentinel();
         if (thereal.value.get_sign())
           return mk_sub(get_zero_real(), sentinel);


### PR DESCRIPTION
## Description

Under `--ir-ieee`, constant floating-point NaNs were previously encoded as the SMT Real value `0` in `convert_terminal()`. This discarded the NaN predicate and caused constant NaNs to be treated as ordinary numeric values.

This change preserves constant NaNs by introducing a fresh SMT Real together with a permanently true NaN predicate, using the same fresh-variable-plus-predicate mechanism already used by the `--ir-ieee` arithmetic and mathematical-function encodings.

Non-`--ir-ieee` behaviour is unchanged.

## Changes

- Preserve constant NaNs under `--ir-ieee` by:
  - creating a fresh SMT Real for constant NaN values;
  - attaching an unconditional NaN predicate with `store_nan_pred()`.
- Keep zero and infinity handling unchanged.
- Update the nearby comment to reflect that NaNs are handled before infinity encoding.

## Regression Tests

Added the following regression tests:

- `ra-const-nan-pred`
- `ra-const-nan-pred-fail`
- `ra-fmod-inf-nan`
- `ra-fmod-inf-nan-fail`
- `ra-fmod-zero-div-nan`
- `ra-fmod-zero-div-nan-fail`
- `ra-fmod-nan-prop`
- `ra-fmod-finite-not-nan`

The constant-NaN regression uses `__builtin_nan("0")`, which is lowered to a constant floating-point NaN and exercises the `convert_terminal()` path directly.

The `fmod` tests cover the main consumer of this fix: its operational model returns the constant `NAN` for invalid-operation cases, including an infinite dividend, a zero divisor, and NaN propagation. Those results now reach the solver with the correct NaN predicate through the fixed constant encoding.

## Validation

- Targeted regression tests: **8/8 passed**
- Full `ir-ra` regression suite: **231/231 passed**