### PR TITLE
[clang-c-frontend][clang-cpp-frontend] comment audit: fix inaccurate comments

### DIFF
--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -640,7 +640,6 @@ void clang_c_adjust::adjust_expr_rel(exprt &expr)
 
 void clang_c_adjust::adjust_float_arith(exprt &expr)
 {
-  // equality and disequality on float is not mathematical equality!
   assert(expr.operands().size() == 2);
   auto t = ns.follow(expr.type());
 

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -66,9 +66,9 @@ public:
  * The idea is to look for all components of the union and match
  * the type. If not found, throws an error
  *
+ * @param ns Namespace for looking up the union components
  * @param dest RHS dest
  * @param type Union type
- * @param msg  Message object
  */
   static void
   gen_typecast_to_union(const namespacet &ns, exprt &dest, const typet &type);
@@ -144,7 +144,7 @@ protected:
   /**
    *  Parse function parameters
    *  This function simply contains a loop to populate the code argument list
-   *  and calls get_function_body to parse each individual parameter.
+   *  and calls get_function_param to parse each individual parameter.
    */
   virtual bool get_function_params(
     const clang::FunctionDecl &fd,

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -264,8 +264,8 @@ void clang_c_languaget::build_compiler_args(
   // Increase maximum bracket depth
   compiler_args.push_back("-fbracket-depth=1024");
 
-  // Add -Wunknown-attributes, preprocessed files with GCC generate a bunch
-  // of __leaf__ attributes that we don't care about
+  // Suppress -Wunknown-attributes: GCC-preprocessed files carry a bunch of
+  // __leaf__ etc. attributes that we don't care about
   compiler_args.emplace_back("-Wno-unknown-attributes");
 
   // Suppress incompatible-pointer-types universally; became a hard error in
@@ -458,10 +458,6 @@ void clang_c_languaget::show_parse(std::ostream &)
 
 bool clang_c_languaget::preprocess(const std::string &, std::ostream &)
 {
-// TODO: Check the preprocess situation.
-#if 0
-  return c_preprocess(path, outstream, false);
-#endif
   return false;
 }
 

--- a/src/clang-c-frontend/nested_func_transform.cpp
+++ b/src/clang-c-frontend/nested_func_transform.cpp
@@ -350,7 +350,8 @@ static bool is_non_func_keyword(const std::string &s)
 // Try to parse a function definition starting at toks[idx].
 // Returns true if successful, and fills the nested_func struct.
 // `enclosing_name` is the name of the function we're currently inside.
-// Only call this when brace_depth >= 1 (inside a function body).
+// Parses any function definition; find_nested_functions uses it at file
+// scope to locate enclosers and inside bodies to locate nested definitions.
 static bool try_parse_func_def(
   const std::vector<token> &toks,
   size_t idx,
@@ -1341,7 +1342,6 @@ static std::string capture_param_name(
 //  Identifier rewriting
 // -----------------------------------------------------------------------
 
-// Replace identifiers in `text` according to `replacements` map.
 // Replace identifiers in `text` according to `replacements`.  Scope-aware:
 // names listed in `scope_aware_names` are replaced only when no enclosing
 // scope on the walker's stack declares them (so inner-block declarations

--- a/src/clang-c-frontend/padding.cpp
+++ b/src/clang-c-frontend/padding.cpp
@@ -1,5 +1,5 @@
 /// \file
-/// C++ Language Type Checking
+/// Struct/union padding and alignment computation
 
 #include "padding.h"
 

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -99,7 +99,6 @@ void clang_cpp_adjust::gen_vptr_init_code(
    */
 
   // 1. set the type
-  //typet vtable_type = symbol_typet(comp.type().subtype().id());
   new_code.type() = comp.type();
 
   // 2. LHS: generate the member pointer dereference expression

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2197,7 +2197,6 @@ bool clang_cpp_convertert::get_function_this_pointer_param(
   name = "this";
   id += name;
 
-  //this_param.cmt_base_name("this");
   this_param.cmt_base_name(name);
   this_param.cmt_identifier(id);
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -232,10 +232,9 @@ protected:
     const clang::CXXMethodDecl &cxxmdd,
     typet &ctor_return_type);
   /*
-   * Flag return type in ctor or dtor, e.g.
-   * A default copy constructor would have the return type below:
+   * Flag return type in ctor or dtor by setting it to the marker type
+   * `constructor` (or `destructor`), e.g. a constructor gets:
    * * return_type: constructor
-   *   #default_copy_cons: 1
    *
    * Arguments:
    *  cxxmdd: clang AST node representing the ctor/dtor we are dealing with
@@ -623,4 +622,4 @@ protected:
   bool get_member_expr(const clang::MemberExpr &memb, exprt &new_expr) override;
 };
 
-#endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */
+#endif /* CLANG_CPP_FRONTEND_CLANG_CPP_CONVERT_H_ */


### PR DESCRIPTION
Audits comments in the C and C++ Clang frontends against the current
implementation, treating wrong comments as defects.

C frontend:
- clang_c_convert.h: get_function_params doc said it 'calls
  get_function_body' — it calls get_function_param; gen_typecast_to_union
  had a stale @param msg for a parameter that no longer exists (added the
  real @param ns).
- padding.cpp: the \file banner said 'C++ Language Type Checking'; this is
  the C frontend's struct/union padding/alignment code.
- clang_c_language.cpp: a comment said 'Add -Wunknown-attributes' above a
  line adding the suppress form -Wno-unknown-attributes; removed a dead
  #if 0 preprocess block referencing now-unnamed parameters.
- nested_func_transform.cpp: try_parse_func_def was documented 'only call
  when brace_depth >= 1', but find_nested_functions calls it at file scope
  (depth 0); removed a duplicated rewrite_identifiers doc line.
- clang_c_adjust_expr.cpp: dropped an 'equality/disequality on float'
  comment from adjust_float_arith, which only handles + - * /.

C++ frontend:
- clang_cpp_convert.h: annotate_ctor_dtor_rtn_type doc illustrated a
  fictional #default_copy_cons:1 annotation the code never sets (it only
  sets the marker type constructor/destructor); the closing #endif named
  the C-frontend include guard instead of the C++ one.
- removed two commented-out dead lines (clang_cpp_convert.cpp,
  clang_cpp_adjust_code_gen.cpp).

No behavioural change: comment-only, plus removal of one dead #if 0 block.
Build clean, full unit suite (566) and the esbmc/00* regression subset
pass, clang-format-11 clean.