### PR TITLE
[cpp] comment audit: fix inaccurate CUDA/SystemC operational-model comments

### DIFF
--- a/src/cpp/library/CUDA/cuda_runtime_api.h
+++ b/src/cpp/library/CUDA/cuda_runtime_api.h
@@ -404,8 +404,8 @@ cudaError_t cudaSetDevice(int device)
     if (auxDevice->id == device)
     { //Checks if the device
       if (auxDevice->active == 1)
-      {                                     //Verifies that the device is active
-        return cudaErrorDeviceAlreadyInUse; //cudaErrorDeviceAlreadyInUse
+      { //Verifies that the device is active
+        return cudaErrorDeviceAlreadyInUse;
         lastError = cudaErrorDeviceAlreadyInUse;
       }
       auxDevice->active = 1;

--- a/src/cpp/library/CUDA/cudnn.h
+++ b/src/cpp/library/CUDA/cudnn.h
@@ -138,7 +138,7 @@ typedef enum cudnnnanpropagation cudnnNanPropagation_t;
 
 float sigmoidFunction(float u)
 {
-  //lookuptable of sigmoid function variating from -20 to 20 with .00 of resolution
+  // lookup table of the sigmoid function over u in [-20, 20] with 0.01 resolution (4000 entries)
   float lookup[4000] = {
     0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000,
     0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000,
@@ -976,7 +976,8 @@ float *universal_img2col(
             int y = h * stride + i - padding;
             int x = w * stride + j - padding;
 
-            // Check if current position is inside padding area
+            // Copy real data if position is inside the image; otherwise it
+            // falls in the padding area
             if (y >= 0 && y < height && x >= 0 && x < width)
             {
               columns[row * output_height * output_width + col] =

--- a/src/cpp/library/OM_compiler_defs.h
+++ b/src/cpp/library/OM_compiler_defs.h
@@ -1,4 +1,4 @@
-// Header to define some compmiler diagnostic tweaks for OMs
+// Compiler diagnostic tweaks and C++03/C++11 compatibility macros for OMs
 #pragma once
 
 #define DO_PRAGMA(x) _Pragma(#x)

--- a/src/cpp/library/systemc/communication/sc_signal_ports.h
+++ b/src/cpp/library/systemc/communication/sc_signal_ports.h
@@ -3,7 +3,7 @@
 
 #include "signal.h"
 template <class T>
-class sc_signal; // pre-declaration of sc_signal
+class sc_signal;
 
 #define sc_out sc_inout
 


### PR DESCRIPTION
Audits comments in src/cpp/library (ESBMC's C++/CUDA/SystemC operational
models) against what the models actually do, treating wrong comments as
defects.

Fixes:
- CUDA/cudnn.h: an im2col comment labelled the in-bounds branch 'inside
  padding area' — the guarded branch copies real data; the else branch is
  the padding case. Also a garbled sigmoid lookup-table note ('.00 of
  resolution') now reads '[-20, 20] with 0.01 resolution (4000 entries)'.
- OM_compiler_defs.h: the banner claimed only 'compiler diagnostic tweaks'
  but the file also defines the C++03/C++11 compat macros OM_CONSTEXPR /
  OM_NOEXCEPT / OM_NULLPTR.
- CUDA/cuda_runtime_api.h and systemc sc_signal_ports.h: removed redundant
  echo comments.

No behavioural change: comment-only. esbmc rebuilt (OM headers are embedded),
unit suite (566) passes, a CUDA regression case verifies SUCCESSFUL,
clang-format-11 clean.

Note (out of scope, flagged for a separate look): the sigmoid indexing
`(int)u * 100` truncates u before scaling, so the table's 0.01 granularity
isn't exercised at runtime; and CUDA/sm_atomic_functions.h atomicDec's
condition looks inconsistent with its documented CUDA semantics. Both are
code-level, not comment defects.