### PR TITLE
[python] comment audit: fix inaccurate Python frontend and model comments

### DIFF
--- a/src/python-frontend/class/python_class_builder.cpp
+++ b/src/python-frontend/class/python_class_builder.cpp
@@ -106,7 +106,7 @@ void python_class_builder::get_members(
       conv_.get_function_definition(n);
 
       std::string saved_func_for_lookup = conv_.current_func_name_;
-      conv_.current_func_name_ = mname; // Apenas o nome simples
+      conv_.current_func_name_ = mname;
       symbol_id method_sid = conv_.create_symbol_id();
       conv_.current_func_name_ = saved_func_for_lookup;
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -4476,7 +4476,7 @@ exprt python_converter::get_block(
     case StatementType::PASS:
     // Imports are handled by parser.py so we can just ignore here.
     case StatementType::IMPORT:
-      // TODO: Raises are ignored for now. Handling case to avoid calling abort() on default.
+      // PASS and IMPORT need no action here; break to avoid the default throw.
       break;
     case StatementType::UNKNOWN:
     default:

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -42,8 +42,6 @@ using namespace python_expr;
 
 namespace
 {
-// Constants for UTF-8 encoding
-
 // Constants for symbol parsing
 constexpr const char *CLASS_MARKER = "@C@";
 constexpr const char *FUNCTION_MARKER = "@F@";
@@ -5569,8 +5567,9 @@ exprt function_call_expr::finalize_call(
               converter_.wrap_in_optional(default_val, param_info.type());
         }
 
-        // Convert array to pointer if parameter type is pointer
-        // This matches the behavior for positional arguments (line 2470-2480)
+        // Convert array to pointer if parameter type is pointer, matching the
+        // conversion applied to positional arguments in
+        // build_positional_arguments().
         const typet &param_type = param_info.type();
         if (default_val.type().is_array() && param_type.is_pointer())
         {

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -352,8 +352,8 @@ private:
 
   /*
    * Handles min() or max() function calls by generating conditional expressions.
-   * Currently supports exactly 2 arguments.
-   * @TODO: Support multiple arguments.
+   * Accepts a single iterable/tuple argument or two or more positional
+   * arguments, building a comparison chain.
    * For min(a, b), generates: a < b ? a : b
    * For max(a, b), generates: a > b ? a : b
    * Performs type compatibility checking with automatic int-to-float promotion.

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -9,11 +9,6 @@
 # This module is itself the source of max() / min() for the verification
 # model. Rewriting the explicit branch forms here as max()/min() would
 # create a self-reference: the model would call into itself.
-# def abs(x:float) -> float:
-#     if x >= 0:
-#         return x
-#     else:
-#         return -x
 
 
 def all(iterable: list[Any]) -> bool:

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -247,7 +247,7 @@ def match(pattern: str, string: str) -> bool:
     """
     pattern_len: int = len(pattern)
 
-    # Empty pattern
+    # Empty or single-char pattern: treated as an unconditional match (over-approximation)
     if pattern_len <= 1:
         return True
 

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2453,7 +2453,8 @@ exprt numpy_call_expr::create_expr_from_call()
     }
 
     // numpy.linalg.eig — eigenvalues (only) of a square real matrix.
-    // Returns a 1-D list of eigenvalues sorted in descending order.
+    // Returns a 1-D list of eigenvalues (2x2: descending; 3x3 diagonal: in
+    // diagonal order).
     // Only concrete 2x2 and 3x3 real matrices with real eigenvalues are
     // supported; complex eigenvalues are rejected with an explicit error.
     if (function == "eig")

--- a/src/python-frontend/python-dict/python_dict_handler.h
+++ b/src/python-frontend/python-dict/python_dict_handler.h
@@ -630,9 +630,6 @@ private:
   /// Reference to the type handler for type operations
   type_handler &type_handler_;
 
-  /// Counter for generating unique dictionary variable names
-  static int dict_counter_;
-
   /// Maps dict struct symbol id to its internal keys-list symbol id.
   /// Populated in create_dict_from_literal; queried when lowering
   /// ESBMC_keys_N = d.keys() to propagate list_type_map entries.

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -45,7 +45,6 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
   // Calculate element size in bytes
   exprt elem_size;
 
-  // For list pointers (PyListObj*), use pointer size
   typet list_type = converter_.get_type_handler().get_list_type();
   // None type: store pointer directly without copying
   // Set size to 0 so memcpy is skipped and NULL is preserved

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -4355,7 +4355,6 @@ void python_annotation<Json>::annotate_class(Json &class_element)
 {
   std::string saved_class_name = current_class_name_;
   std::string saved_context = current_func_name_context_;
-  //    current_func_name_context_ = ""; // Reset for class methods
 
   current_class_name_ = class_element["name"].template get<std::string>();
 

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -818,7 +818,7 @@ static bool parse_format_padding(
 }
 
 // Apply fill/align/width padding to a literal string per Python's
-// format-spec mini-language. Returns padded as a fresh char_array expr.
+// format-spec mini-language. Returns the padded string.
 static std::string
 apply_padding(const std::string &input, char fill, char align, int width)
 {

--- a/src/python-frontend/string/string_handler.h
+++ b/src/python-frontend/string/string_handler.h
@@ -201,10 +201,8 @@ public:
 
   /**
    * @brief Handle string repetition
-   * @param op multiply operator (Eq, Mult)
    * @param lhs Left operand
    * @param rhs Right operand
-   * @param element JSON element with location info
    * @return Repetition expression
    */
   exprt handle_string_repetition(exprt &lhs, exprt &rhs);
@@ -580,7 +578,7 @@ public:
   handle_string_casefold(const exprt &string_obj, const locationt &location);
 
   /**
-   * @brief Handle str.count() method (constant-only support)
+   * @brief Handle str.count() method (constant fold, else runtime model)
    */
   exprt handle_string_count(
     const exprt &string_obj,


### PR DESCRIPTION
Audits comments in src/python-frontend (frontend + operational models)
against the current implementation, treating wrong comments as defects.

Fixes:
- converter_stmt.cpp: a 'Raises are ignored for now ... abort()' note on the
  PASS/IMPORT break — RAISE has its own live handler, and the default path
  throws (not abort()).
- string handlers: handle_string_repetition Doxygen listed @param op/@param
  element that don't exist; apply_padding was documented as returning a
  'char_array expr' (it returns std::string); str.count() is no longer
  constant-only (it has a runtime model, __python_str_count).
- function_call/expr: min()/max() was documented 'exactly 2 arguments' but
  handles >=2 positional args and a single iterable; removed an orphaned
  'Constants for UTF-8 encoding' label and a stale '(line 2470-2480)' ref.
- numpy_call_expr.cpp: linalg.eig 'sorted in descending order' only holds
  for the 2x2 branch; the 3x3 diagonal branch returns diagonal order.
- models/re.py: a '# Empty pattern' label hid that the <=1 guard also matches
  single-char patterns unconditionally (over-approximation).
- models/builtins.py: removed a commented-out abs implementation (no abs
  model exists in the file).
- removed redundant/dead comments (class builder, list_mutation, annotation)
  and one dead never-referenced static member (dict_counter_).

No behavioural change: comment-only plus one dead-member removal. esbmc
rebuilt (models/*.py are FLAIL-mangled into the binary), unit suite (566)
passes, pylint 10/10 and CPython sanity (scripts/check_python_tests.sh) pass,
targeted Python regression cases verify as expected, clang-format-11 clean.