### PR TITLE
[solidity] comment audit: fix inaccurate Solidity frontend comments

### DIFF
--- a/src/solidity-frontend/pattern_check.cpp
+++ b/src/solidity-frontend/pattern_check.cpp
@@ -1,10 +1,9 @@
 /// \file pattern_check.cpp
 /// \brief Implementation of pattern-based vulnerability detection.
 ///
-/// Walks the solc JSON AST to detect known Solidity vulnerability patterns
-/// such as authorization through tx.origin, unchecked external calls, and
-/// other syntactic anti-patterns that can be identified without symbolic
-/// execution.
+/// Walks the solc JSON AST to detect authorization through tx.origin
+/// (SWC-115) — a syntactic anti-pattern identifiable without symbolic
+/// execution. Further patterns are not yet implemented.
 
 #include <solidity-frontend/pattern_check.h>
 #include <util/message.h>

--- a/src/solidity-frontend/solidity_convert_builtin.cpp
+++ b/src/solidity-frontend/solidity_convert_builtin.cpp
@@ -197,7 +197,6 @@ bool solidity_convertert::add_auxiliary_members(
   }
 
   t = string_t;
-  //set_sol_type(t, SolidityGrammar::SolType::STRING);
   get_builtin_symbol(
     "_ESBMC_bind_cname",
     sol_prefix + "_ESBMC_bind_cname",

--- a/src/solidity-frontend/solidity_convert_call.cpp
+++ b/src/solidity-frontend/solidity_convert_call.cpp
@@ -42,7 +42,6 @@ bool solidity_convertert::get_library_function_call(
 
 // library/error/event functions have no definition node
 // the key difference comparing to the `get_non_library_function_call` is that we do not need a this-object as the first argument for the function call
-// the key difference is that we do not add this pointer.
 bool solidity_convertert::get_library_function_call(
   const exprt &func,
   const typet &t,
@@ -338,8 +337,8 @@ void solidity_convertert::get_nondet_expr(const typet &t, exprt &new_expr)
   new_expr.statement("nondet");
 }
 
-// x._ESBMC_bind_cname = _ESBMC_get_nondet_cname();
-//                        ^^^^^^^^^^^^^^^^^^^^^^^^
+// x._ESBMC_bind_cname = _ESBMC_get_nondet_cont_name();
+//                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // for high-level call, we bind the external calls with cname
 // e.g.
 // if(x.cname == Base)

--- a/src/solidity-frontend/solidity_convert_decl.cpp
+++ b/src/solidity-frontend/solidity_convert_decl.cpp
@@ -47,7 +47,7 @@ bool solidity_convertert::get_non_function_decl(
   }
   case SolidityGrammar::ContractBodyElementT::StructDef:
   {
-    return get_struct_class(ast_node); // rule enum-definition
+    return get_struct_class(ast_node); // rule struct-definition
   }
   case SolidityGrammar::ContractBodyElementT::ModifierDef:
   case SolidityGrammar::ContractBodyElementT::FunctionDef:
@@ -1484,7 +1484,7 @@ void solidity_convertert::get_error_definition_name(
   if (cname.empty())
     id = "sol:@" + name + "#" + std::to_string(id_num);
   else
-    // e.g. sol:@C@Base@F@error@1
+    // e.g. sol:@C@Base@F@errmsg#12
     id = "sol:@C@" + cname + "@F@" + name + "#" + std::to_string(id_num);
 }
 

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -2188,7 +2188,6 @@ bool solidity_convertert::get_new_object_expr(
   {
     callee_expr_json = expr["expression"];
   }
-  // nlohmann::json callee_expr_json = expr["expression"];
   if (callee_expr_json.contains("typeName"))
   {
     // case 1
@@ -2415,7 +2414,7 @@ bool solidity_convertert::get_binary_operator_expr(
 
   // 1. Convert LHS and RHS
   // For "Assignment" expression, it's called "leftHandSide" or "rightHandSide".
-  // For "BinaryOperation" expression, it's called "leftExpression" or "leftExpression"
+  // For "BinaryOperation" expression, it's called "leftExpression" or "rightExpression"
   exprt lhs, rhs;
   nlohmann::json rhs_json;
   locationt l;

--- a/src/solidity-frontend/solidity_convert_mapping.cpp
+++ b/src/solidity-frontend/solidity_convert_mapping.cpp
@@ -457,7 +457,7 @@ bool solidity_convertert::get_new_mapping_index_access(
     get_aux_var(aux_name, aux_id);
     symbolt aux_sym;
     std::string debug_modulename = get_modulename_from_path(absolute_path);
-    typet aux_type = value_t; // struct *
+    typet aux_type = value_t; // struct value
     get_default_symbol(
       aux_sym, debug_modulename, aux_type, aux_name, aux_id, location);
     aux_sym.file_local = true;

--- a/src/solidity-frontend/solidity_convert_modifier.cpp
+++ b/src/solidity-frontend/solidity_convert_modifier.cpp
@@ -642,8 +642,6 @@ bool solidity_convertert::get_func_modifier(
       // move the symbol to the context
       symbolt &ret_sym = *move_symbol_to_context(ret_symbol);
       code_declt ret_decl(symbol_expr(ret_sym));
-      //ret_sym.value = func_modifier;
-      // ret_decl.operands().push_back(func_modifier);
       mod_body.operands().insert(mod_body.operands().begin(), ret_decl);
 
       // 2. replace every "return x" to "aux_var = x"

--- a/src/solidity-frontend/solidity_convert_stmt.cpp
+++ b/src/solidity-frontend/solidity_convert_stmt.cpp
@@ -198,9 +198,9 @@ bool solidity_convertert::get_statement(
   const nlohmann::json &stmt,
   exprt &new_expr)
 {
-  // For rule statement
-  // Since this is an additional layer of grammar rules compared to clang C, we do NOT set location here.
-  // Just pass the new_expr reference to the next layer.
+  // For rule statement.
+  // Compute the location up front and apply it to new_expr at the end of the
+  // function (see the new_expr.location() assignment before return).
 
   locationt loc;
   get_location_from_node(stmt, loc);

--- a/src/solidity-frontend/solidity_convert_type.cpp
+++ b/src/solidity-frontend/solidity_convert_type.cpp
@@ -88,8 +88,8 @@ bool solidity_convertert::get_type_description(
   }
   case SolidityGrammar::TypeNameT::PointerArrayToPtr:
   {
-    // auxiliary type: pointer (FuncToPtr decay)
-    // This part is for FunctionToPointer decay only
+    // auxiliary type: pointer (ArrayToPtr decay)
+    // This part is for ArrayToPointer decay only
     assert(typeIdentifier.find("ArrayToPtr") != std::string::npos);
 
     // Array type descriptor is like:
@@ -709,8 +709,6 @@ bool solidity_convertert::get_array_to_pointer_type(
   return false;
 }
 
-// parse a tuple to struct
-
 bool solidity_convertert::get_elementary_type_name_uint(
   SolidityGrammar::ElementaryTypeNameT &type,
   typet &out)
@@ -863,7 +861,6 @@ bool solidity_convertert::get_elementary_type_name(
   case SolidityGrammar::ElementaryTypeNameT::STRING:
   {
     // cpp: std::string str;
-    // new_type = symbol_typet("tag-std::string");
     new_type = string_t;
     break;
   }
@@ -1025,8 +1022,6 @@ bool solidity_convertert::get_parameter_list(
 
   return false;
 }
-
-// parse the state variable
 
 bool solidity_convertert::get_array_pointer_type(
   const nlohmann::json &decl,

--- a/src/solidity-frontend/solidity_convert_util.cpp
+++ b/src/solidity-frontend/solidity_convert_util.cpp
@@ -47,8 +47,7 @@ void solidity_convertert::get_start_location_from_stmt(
   if (current_functionDecl)
     function_name = current_functionName;
 
-  // The src manager of Solidity AST JSON is too encryptic.
-  // For the time being we are setting it to "1".
+  // The line number is derived from the Solidity AST JSON source range.
   location.set_line(get_line_number(ast_node));
   location.set_file(
     absolute_path); // assume absolute_path is the name of the contrace file, since we ran solc in the same directory
@@ -66,8 +65,7 @@ void solidity_convertert::get_final_location_from_stmt(
   if (current_functionDecl)
     function_name = current_functionName;
 
-  // The src manager of Solidity AST JSON is too encryptic.
-  // For the time being we are setting it to "1".
+  // The line number is derived from the Solidity AST JSON source range.
   location.set_line(get_line_number(ast_node, true));
   location.set_file(
     absolute_path); // assume absolute_path is the name of the contrace file, since we ran solc in the same directory

--- a/src/solidity-frontend/solidity_grammar.cpp
+++ b/src/solidity-frontend/solidity_grammar.cpp
@@ -3,7 +3,7 @@
 ///
 /// Maps solc JSON AST node fields (type strings, operator tokens, node kinds)
 /// to the corresponding SolidityGrammar enums. Includes lookup tables for all
-/// uint/int bit-widths, operator precedence, and string-to-enum conversions.
+/// uint/int bit-widths, operator-token mapping, and string-to-enum conversions.
 
 #include <fmt/core.h>
 #include <solidity-frontend/solidity_convert.h>

--- a/src/solidity-frontend/solidity_grammar.h
+++ b/src/solidity-frontend/solidity_grammar.h
@@ -215,9 +215,7 @@ enum ElementaryTypeNameT
   BYTES31,
   BYTES32,
 
-  // TODO: rule signed-integer-type
   // TODO: rule e
-  // TODO: fixed-bytes
   // TODO: fixed
   // TODO: ufixed
   ElementaryTypeNameTError


### PR DESCRIPTION
Audits comments in src/solidity-frontend (Solidity AST → ESBMC IR) against
the current implementation, treating wrong comments as defects.

Fixes (copy-paste / stale / inaccurate):
- solidity_convert_decl.cpp: a StructDef case (calls get_struct_class)
  commented 'rule enum-definition'; an error-id example using the wrong
  separator.
- solidity_convert_type.cpp: the PointerArrayToPtr case (ArrayToPtr decay,
  calls get_array_to_pointer_type) commented as 'FuncToPtr'/'FunctionToPointer
  decay'; two orphaned dividers ('parse a tuple to struct', 'parse the state
  variable') that mislabelled the following functions; a dead commented line.
- solidity_convert_stmt.cpp: a comment claiming get_statement does NOT set
  location — it computes loc and applies new_expr.location() = loc at the end.
- solidity_convert_util.cpp: comments claiming the line number is 'set to 1'
  when it is derived via get_line_number.
- solidity_convert_call.cpp / _expr.cpp: an _ESBMC_get_nondet_cname name
  missing the 'cont_' segment; a 'leftExpression or leftExpression' typo
  (BinaryOperation reads rightExpression).
- solidity_convert_mapping.cpp: aux_type commented '// struct *' where it is a
  struct value.
- solidity_grammar.{h,cpp}: two completed TODOs (signed-integer-type,
  fixed-bytes are implemented); a file brief citing a nonexistent operator-
  precedence table.
- pattern_check.cpp: brief overstated capability (only tx.origin / SWC-115 is
  implemented).
- removed dead commented code in modifier and builtin converters.

No behavioural change: comment-only. Build clean, unit-test binaries pass
(63/64; the one failure is a Z3-4.16-on-aarch64 SMT test, pre-existing and
unrelated), clang-format-11 clean. Note: solc is not installed on the dev box,
so the esbmc-solidity regression suite runs in CI only.