### PR TITLE
[jimple][ld] comment audit: fix inaccurate comments, drop dead code

### DIFF
--- a/src/jimple-frontend/AST/jimple_class_field.cpp
+++ b/src/jimple-frontend/AST/jimple_class_field.cpp
@@ -7,8 +7,6 @@ exprt jimple_class_field::to_exprt(
   const std::string &,
   const std::string &) const
 {
-  // Dummy will be return expression. It will just hold the type
-  exprt dummy;
   typet t = type.to_typet(ctx);
   std::string id;
   id = "tag-" + name;
@@ -18,11 +16,8 @@ exprt jimple_class_field::to_exprt(
 
 void jimple_class_field::from_json(const json &j)
 {
-  // Method modifiers
   modifiers = j.at("modifiers").get<jimple_modifiers>();
-  // Method type
   j.at("type").get_to(type);
-  // Method Name
   j.at("name").get_to(this->name);
 }
 std::string jimple_class_field::to_string() const

--- a/src/jimple-frontend/AST/jimple_expr.h
+++ b/src/jimple-frontend/AST/jimple_expr.h
@@ -378,7 +378,6 @@ public:
   }
 
   const std::string mode; // Int, char, long, etc... e.g. Random().nextInt()
-  //std::string bound;
   virtual exprt to_exprt(
     contextt &ctx,
     const std::string &class_name,

--- a/src/jimple-frontend/AST/jimple_method.cpp
+++ b/src/jimple-frontend/AST/jimple_method.cpp
@@ -7,7 +7,8 @@ exprt jimple_method::to_exprt(
   const std::string &class_name,
   const std::string &) const
 {
-  // Dummy will be return expression. It will just hold the type
+  // Returned as an empty placeholder; the method symbol is registered via
+  // move_symbol_to_context below.
   exprt dummy;
   code_typet method_type;
   typet inner_type;

--- a/src/jimple-frontend/AST/jimple_statement.cpp
+++ b/src/jimple-frontend/AST/jimple_statement.cpp
@@ -168,76 +168,6 @@ exprt jimple_assignment::to_exprt(
   return assign;
 }
 
-/*
-std::string jimple_assignment_deref::to_string() const
-{
-  std::ostringstream oss;
-  oss << "Assignment: " << variable << "[" << pos->to_string()
-      << "]  = " << expr->to_string();
-  return oss.str();
-}
-
-void jimple_assignment_deref::from_json(const json &j)
-{
-  j.at("name").get_to(variable);
-  expr = jimple_expr::get_expression(j.at("value"));
-  pos = jimple_expr::get_expression(j.at("pos"));
-}
-
-exprt jimple_assignment_deref::to_exprt(
-  contextt &ctx,
-  const std::string &class_name,
-  const std::string &function_name) const
-{
-  jimple_symbol s(variable);
-
-  jimple_deref d(pos, std::make_shared<jimple_symbol>(s));
-
-  code_assignt assign(
-    d.to_exprt(ctx, class_name, function_name),
-    expr->to_exprt(ctx, class_name, function_name));
-  return assign;
-}
-
-std::string jimple_assignment_field::to_string() const
-{
-  std::ostringstream oss;
-  oss << "Assignment: " << variable << "->" << field << " = " << expr->to_string();
-  return oss.str();
-}
-
-void jimple_assignment_field::from_json(const json &j)
-{
-  j.at("name").get_to(variable);
-  j.at("field").get_to(field);
-  expr = jimple_expr::get_expression(j.at("value"));
-}
-
-exprt jimple_assignment_field::to_exprt(
-  contextt &ctx,
-  const std::string &class_name,
-  const std::string &function_name) const
-{
-    // 1. Look over the local scope
-  auto symbol_name = get_symbol_name(class_name, function_name, variable);
-  symbolt &s = *ctx.find_symbol(symbol_name);
-  member_exprt op(symbol_expr(s), "tag-" + field, s.get_type());
-  exprt &base = op.struct_op();
-  if(base.type().is_pointer())
-  {
-    exprt deref("dereference");
-    deref.type() = base.type().subtype();
-    deref.move_to_operands(base);
-    base.swap(deref);
-  }
-
-  code_assignt assign(
-    op,
-    expr->to_exprt(ctx, class_name, function_name));
-  return assign;
-}
-*/
-
 std::string jimple_if::to_string() const
 {
   std::ostringstream oss;
@@ -367,7 +297,7 @@ exprt jimple_invoke::to_exprt(
     return skip;
   }
 
-  // Don't care for Random
+  // Don't care for String
   if (base_class == "java.lang.String")
   {
     code_skipt skip;

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -15,7 +15,8 @@ loc_from_node(const pugi::xml_node &n, const std::string &file)
 {
   LdLocation loc;
   loc.file = file;
-  // PLCopen XML does not standardise source coordinates; use addData if present.
+  // PLCopen XML does not standardise source coordinates; use the
+  // lineNumber/columnNumber attributes when present.
   if (auto line_attr = n.attribute("lineNumber"))
     loc.line = static_cast<unsigned>(line_attr.as_uint());
   if (auto col_attr = n.attribute("columnNumber"))

--- a/src/ld-frontend/verify/ld_verify.h
+++ b/src/ld-frontend/verify/ld_verify.h
@@ -6,7 +6,7 @@
 //   PLCopen XML → Parser → TypeChecker → LdIRBuilder → ld_converter
 //   → property_encoder → ESBMC engine → JSON report
 //
-// This class is used by the ld-verify CLI and by ld_languaget.
+// This class is used by the ld-verify CLI (tools/ld-verify).
 struct LdVerifyOptions
 {
   std::string program_path; // PLCopen XML or .ld input


### PR DESCRIPTION
Audits comments in the Jimple (Java/Kotlin) and LD (PLC/ladder-logic)
frontends against the current implementation.

Jimple:
- jimple_class_field.cpp: from_json had 'Method modifiers/type/Name' labels
  copy-pasted from jimple_method (it's a field, and they narrated the next
  line); to_exprt had a dead 'dummy will be the return expression' comment
  and an unused local (it returns comp).
- jimple_method.cpp: clarified that the returned dummy is an empty
  placeholder (the type/symbol are registered via move_symbol_to_context).
- jimple_statement.cpp: a 'Don't care for Random' comment sat above a
  java.lang.String guard; removed a 69-line commented-out block implementing
  jimple_assignment_deref/jimple_assignment_field (neither class exists).
- jimple_expr.h: removed a dead commented-out member.

LD:
- ld_verify.h: the class is used only by the ld-verify CLI (tools/ld-verify),
  not by ld_languaget.
- plcopen_xml_parser.cpp: the code reads lineNumber/columnNumber attributes,
  not an addData element.

No behavioural change: comment/dead-code only (the removed code was an unused
local, a commented-out member, and a fully commented-out block). Build clean,
clang-format-11 clean. Jimple/LD regression needs JDK/PLC config and runs in
CI.