### PR TITLE
[esbmc] comment audit: fix inaccurate BMC-driver and ranking-synthesis comments

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -122,8 +122,6 @@ void bmct::successful_trace(const symex_target_equationt &eq [[maybe_unused]])
   std::string witness_yaml_output = options.get_option("witness-output-yaml");
 
   goto_tracet goto_trace;
-  // correctness witness, why did goto trace ignore it in the past?
-  // build_successful_goto_trace(eq, ns, goto_trace);
   if (witness_graphml_output != "")
     correctness_graphml_goto_trace(options, ns, goto_trace);
 
@@ -1339,9 +1337,8 @@ void bmct::report_result(smt_resultt &res)
     }
     break;
 
-    // Return failure if we didn't actually check anything, we just emitted the
-    // test information to an SMTLIB formatted file. Causes esbmc to quit
-    // immediately (with no error reported)
+    // SMTLIB-only emission: nothing was actually checked, so return without
+    // reporting any verdict.
   case P_SMTLIB:
     return;
 
@@ -1865,10 +1862,10 @@ smt_resultt bmct::multi_property_check(
   bool is_branch_func_cov =
     options.get_bool_option("branch-function-coverage") ||
     options.get_bool_option("branch-function-coverage-claims");
-  // "k-Path Cov" — keyed off the dedicated boolean (see line ~717
-  // comment); needed in the is_goto_cov disjunction so the
-  // claim_slicer reads the witness comment, matching the form stored
-  // in goto_coveraget::all_claims.
+  // "k-Path Cov" — keyed off the dedicated k-path-coverage-enabled
+  // boolean (see the note where it is set above); needed in the
+  // is_goto_cov disjunction so the claim_slicer reads the witness
+  // comment, matching the form stored in goto_coveraget::all_claims.
   bool is_k_path_cov = options.get_bool_option("k-path-coverage-enabled");
 
   // is_vb: enable verbose output coverage info if the option "--verbosity coverage:N" is set, where N should larger than 0
@@ -1952,7 +1949,7 @@ smt_resultt bmct::multi_property_check(
     // text we stored in insert_assert); otherwise it reads the negated
     // assertion expression. k-path goals are stored the same way as
     // branch / condition goals, so they must be in this disjunction —
-    // otherwise the claim_sig built at line ~1751 disagrees with the
+    // otherwise the claim_sig built just below disagrees with the
     // form in goto_coveraget::all_claims and every JSON entry shows up
     // as uncovered even when reached_claims has the matching reached
     // signature (PR #4330 review).

--- a/src/esbmc/ranking_synthesis.cpp
+++ b/src/esbmc/ranking_synthesis.cpp
@@ -124,9 +124,10 @@ struct loop_skipt
 };
 
 // Forward declarations: subst_parallel and apply_body are used by the
-// loop recognizer (for dereference substitution and not yet measure
-// derivation respectively) but are defined further down alongside the
-// other transition-relation helpers. reaches_head is reused by the
+// loop recognizer (subst_parallel for dereference substitution, apply_body
+// to express path conditions in pre-iteration state) but are defined
+// further down alongside the other transition-relation helpers.
+// reaches_head is reused by the
 // dominance-aware prefix scan below. touches_memory is used by
 // try_inline_pure_helper before its definition.
 expr2tc
@@ -2091,14 +2092,6 @@ bool is_unsat(const expr2tc &formula, optionst &options, const namespacet &ns)
   return solver->dec_solve() == P_UNSATISFIABLE;
 }
 
-/// Derive a candidate difference measure m and its guard-implied lower
-/// bound L from a relational guard `a REL b`. For `a > b`, m = a - b
-/// and the guard implies m >= 1; for `a >= b`, m >= 0; `<`/`<=` swap
-/// the operands. The measure is computed in a type wide enough that the
-/// subtraction of the operand types cannot overflow — signed overflow
-/// would be UB and make the proof unsound. Returns false if the guard
-/// is not relational or its operands are not integer-typed (the
-/// difference/widening is only defined for integers).
 /// Build the widened-int64 difference `(int64)a - (int64)b` if both
 /// operands are scalar BV that we can safely lift without wraparound.
 /// Returns true on success and writes the lifted expression to @p out;
@@ -3458,13 +3451,6 @@ tvt try_prove_termination_by_ranking(
 
     goto_loopst loops(f_it->first, goto_functions, f_it->second);
 
-    // Pre-build the per-loop skip map: for each loop, an entry mapping
-    // its head's location number to its back-edge iterator and the
-    // names of every symbol it modifies. When we analyse a particular
-    // loop, we'll pass a filtered view that excludes that loop itself
-    // (the analysed loop must NOT be in its own skip map — that would
-    // make the entry walker step right over the loop and return empty
-    // seeds).
     // Pre-build the per-loop skip map: for each loop, an entry mapping
     // its head's location number to its back-edge iterator, the
     // names of every symbol it modifies, and its natural exit-target's


### PR DESCRIPTION
Audits comments in src/esbmc (the BMC driver bmc.cpp and the termination
ranking_synthesis.cpp) against the current implementation.

Fixes:
- bmc.cpp: the P_SMTLIB case comment said 'Return failure' but report_result
  is void and the case just returns without reporting any verdict; removed a
  commented-out build_successful_goto_trace call plus a rhetorical question;
  replaced two stale line-number cross-references ('see line ~717',
  'line ~1751') with non-volatile wording.
- ranking_synthesis.cpp: a forward-decl note said apply_body does 'not yet
  measure derivation' in the loop recognizer, but there it re-expresses path
  conditions in pre-iteration state (measure derivation happens in
  prove_loop_terminates); removed an orphaned Doxygen block describing
  measure_from_relational's (m, L) derivation that was mis-attached above
  make_widened_difference (whose own accurate doc is preserved); de-duplicated
  a 'Pre-build the per-loop skip map' comment (kept the more complete one).

No behavioural change: comment-only. Build clean; termination and
condition-coverage smoke runs produce verdicts without crashing;
clang-format-11 clean.