### PR TITLE
[goto2c][c2goto][util] comment audit: fix inaccurate backend/model comments

### DIFF
--- a/src/big-int/bigint.cpp
+++ b/src/big-int/bigint.cpp
@@ -94,7 +94,8 @@ copy:
   return 0;
 }
 
-// Subtract unsigned digit strings, return carry. Assumes l1 >= l2!
+// Subtract unsigned digit strings (r = d1 - d2). Assumes l1 >= l2 and
+// d1 >= d2, so there is no borrow out.
 static void digit_sub(
   onedig_t const *d1,
   unsigned l1,

--- a/src/c2goto/library/io.c
+++ b/src/c2goto/library/io.c
@@ -141,7 +141,6 @@ __ESBMC_HIDE:;
   // Set currently reading state
   __esbmc_currently_reading = 1;
 
-  // (rest of existing fgets implementation...)
   _Bool early_termination = 0;
   // check for pre-conditions
   __ESBMC_assert(

--- a/src/c2goto/library/kernel.c
+++ b/src/c2goto/library/kernel.c
@@ -13,7 +13,7 @@
 typedef unsigned int gfp_t;
 
 char user_memory[USER_MEMORY_SPACE];     //mock user memory
-char kernel_memory[KERNEL_MEMORY_SPACE]; //mock user memory
+char kernel_memory[KERNEL_MEMORY_SPACE]; //mock kernel memory
 
 static void check_gfp_flags(gfp_t flags)
 {

--- a/src/c2goto/library/socket_lib.c
+++ b/src/c2goto/library/socket_lib.c
@@ -10,8 +10,8 @@
  * Key design decisions:
  *   - socket()/bind()/listen()/accept()/connect() return non-deterministic
  *     success/failure values within their valid range.
- *   - recv() fills the user buffer with non-deterministic bytes (modeling
- *     attacker-controlled input) and returns a non-deterministic byte count.
+ *   - recv() returns a non-deterministic byte count in [0, len]; the buffer
+ *     contents are left unmodelled (untouched), matching an unmodelled stub.
  *   - send() returns a non-deterministic count of bytes "sent" (0 to len).
  *   - select()/poll() return non-deterministic readiness, preserving the
  *     contract that at least one fd is ready when the return value > 0.

--- a/src/c2goto/library/solidity/solidity_string.c
+++ b/src/c2goto/library/solidity/solidity_string.c
@@ -224,10 +224,6 @@ __ESBMC_HIDE:;
   {
     return; // Early exit if str1 is invalid
   }
-  // Free *str1 only if it was previously allocated (non-NULL)
-  // if (*str1 != NULL) {
-  //     free(*str1);
-  // }
 
   // If str2 is NULL, set *str1 to NULL (avoid dangling pointers)
   if (str2 == NULL)
@@ -250,7 +246,6 @@ char *nondet_string()
 {
 __ESBMC_HIDE:;
   size_t len = nondet_uint();
-  // __ESBMC_assume(len < SIZE_MAX);
 
   for (size_t i = 0; i < len; ++i)
   {

--- a/src/goto2c/expr2c.cpp
+++ b/src/goto2c/expr2c.cpp
@@ -448,7 +448,7 @@ std::string expr2ct::convert_code_assign(const codet &src, unsigned indent)
   dest += "=";
 
   exprt rhs = src.op1();
-  // Form a compound literal if assigning to a struct/union
+  // Form a compound literal if assigning an array/struct/union aggregate
   if (
     src.op1().id() == "array" || src.op1().id() == "array_of" ||
     src.op1().id() == "struct" || src.op1().id() == "union")
@@ -1122,9 +1122,6 @@ std::string expr2ct::convert_struct_union_body(
   std::string tag = struct_union_type.tag().as_string();
 
   dest += "(" + tag + ")";
-
-  //if(struct_union_type.components().size() == 0)
-  //  return dest;
 
   dest += "{";
 

--- a/src/goto2c/goto2c_preprocess.cpp
+++ b/src/goto2c/goto2c_preprocess.cpp
@@ -190,7 +190,7 @@ void goto2ct::extract_symbol_tables()
 //
 // is converted to:
 //
-//  const static int a = 10;
+//  const static int tmp = 10;
 //  const static int b = 10;
 //
 // This will not resolve chains with 3 and more initializers,
@@ -475,7 +475,7 @@ void goto2ct::remove_unsupported_instructions(goto_programt &goto_program)
     if (it->type == ASSIGN)
     {
       const code_assign2t &assign = to_code_assign2t(it->code);
-      // Removing assignments to "dynamic_type2t"
+      // Removing assignments to "dynamic_size2t"
       if (is_dynamic_size2t(assign.target))
         it = goto_program.instructions.erase(it);
     }


### PR DESCRIPTION
Audits comments in goto2c (GOTO→C), the c2goto C operational models, and
big-int against the current implementation.

Fixes:
- goto2c_preprocess.cpp: a comment said assignments to 'dynamic_type2t' but
  the guard is is_dynamic_size2t (no dynamic_type2t exists); a
  simplify_initializers example whose 'after' block renamed tmp→a.
- goto2c/expr2c.cpp: the compound-literal comment said 'struct/union' but the
  condition also covers array/array_of; removed a dead commented early-return.
- c2goto/library/kernel.c: kernel_memory was commented '//mock user memory'
  (copy-paste from user_memory) — now 'mock kernel memory'.
- c2goto/library/socket_lib.c: the file header claimed recv() fills the buffer
  with nondet bytes, but the model deliberately leaves the buffer untouched
  (its own inline comment says so); header now matches.
- c2goto/library/io.c: removed a '(rest of existing fgets implementation...)'
  placeholder sitting before the actual full implementation.
- c2goto/library/solidity/solidity_string.c: removed two dead commented-out
  blocks.
- big-int/bigint.cpp: digit_sub is void, so its 'return carry' note (copied
  from digit_add) was wrong.

No behavioural change: comment-only. esbmc rebuilt (c2goto models are
embedded); a basic verification and a --goto2c conversion both run cleanly;
clang-format-11 clean.

Separately flagged (NOT touched here — needs its own ESBMC-verified fix +
regression): BigInt::div's single-digit-divisor branch (bigint.cpp ~999) seeds
the quotient from the divisor (`q = y`) instead of the dividend, so a >64-bit
dividend divided by a single-limb divisor returns quotient 1, remainder 0.
Reachable from smt_solver.cpp's BigInt::div call.