### PR TITLE
[ir-ieee] model NaN for nondeterministic floating-point values

### DIFF
--- a/regression/ir-ra/ra-nondet-float-nan/main.c
+++ b/regression/ir-ra/ra-nondet-float-nan/main.c
@@ -1,0 +1,10 @@
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  /* Single-precision nondet float also gets a NaN predicate. */
+  float x = __VERIFIER_nondet_float();
+
+  __ESBMC_assert(x == x, "unconstrained nondet float may be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-nondet-float-nan/test.desc
+++ b/regression/ir-ra/ra-nondet-float-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-nondet-nan-assume-not-nan/main.c
+++ b/regression/ir-ra/ra-nondet-nan-assume-not-nan/main.c
@@ -1,0 +1,13 @@
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  /* After assuming x > 0, the NaN predicate is forced false by
+   * apply_nan_cmp: (NaN > 0) is false under IEEE 754 semantics, so the
+   * assume eliminates the NaN case.  Self-equality must hold. */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.0);
+
+  __ESBMC_assert(x == x, "nondet double constrained to > 0 is not NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-nondet-nan-assume-not-nan/test.desc
+++ b/regression/ir-ra/ra-nondet-nan-assume-not-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-nondet-nan/main.c
+++ b/regression/ir-ra/ra-nondet-nan/main.c
@@ -1,0 +1,11 @@
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  /* A nondet double may be NaN.  An unconstrained nondet double that equals
+   * itself (which NaN does not) must not be assumed without justification. */
+  double x = __VERIFIER_nondet_double();
+
+  __ESBMC_assert(x == x, "unconstrained nondet double may be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-nondet-nan/test.desc
+++ b/regression/ir-ra/ra-nondet-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -2114,6 +2114,15 @@ smt_astt smt_solver_baset::convert_terminal(const expr2tc &expr)
 
     ir_ieee_api->assert_symbol_range(name, sym_ast, sym);
 
+    if (
+      ir_ieee && is_floatbv_type(sym.type) &&
+      name.rfind("nondet$symex::nondet", 0) == 0)
+    {
+      smt_astt nan_pred =
+        mk_fresh(mk_bool_sort(), "ir_ieee::nondet_nan::", nullptr);
+      ir_ieee_api->store_nan_pred(sym_ast, nan_pred);
+    }
+
     return sym_ast;
   }
 


### PR DESCRIPTION
## Description

Under `--ir-ieee`, nondeterministic floating-point values should be allowed to represent IEEE-754 NaNs. Nondeterministic floating-point symbols were previously treated as ordinary SMT Real variables with no associated NaN predicate, so the solver could not explore NaN behaviour for unconstrained nondeterministic inputs.

This change assigns a fresh, unconstrained NaN predicate to nondeterministic floating-point symbols when they are created in the SMT backend. The predicate is stored using the existing `store_nan_pred()` infrastructure, allowing the solver to choose whether a nondeterministic value is NaN or a normal floating-point value.

No new propagation or comparison logic is introduced. Existing IEEE semantics continue to handle NaN correctly; for example, assumptions such as `x > 0` naturally eliminate the NaN case through the existing comparison encoding.

## Changes

- Assign a fresh unconstrained NaN predicate to nondeterministic floating-point symbols under `--ir-ieee`.
- Reuse the existing NaN predicate infrastructure without changing IEEE comparison semantics.
- Add regression tests covering:
  - unconstrained nondeterministic `double` values,
  - unconstrained nondeterministic `float` values,
  - elimination of the NaN case after a constraining assumption (`x > 0`).

## Testing

- Focused regression tests: **3/3 passed**
- Full `ir-ra` regression suite: **236/236 passed**