### PR TITLE
[c++] init virtual bases only in the most-derived constructor

### DIFF
--- a/regression/esbmc-cpp/inheritance/github_938/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_938/main.cpp
@@ -1,0 +1,45 @@
+// esbmc/esbmc#938: a virtual base subobject is initialised only by the
+// most-derived (complete-object) constructor. Here D lists A(x) in its
+// mem-initialiser list, so the shared A::m_x is initialised and the
+// assertion holds. Compare llbmc_virtual_inheritance-wrong, where D omits
+// A(x) and A::m_x is left indeterminate.
+#include <cassert>
+
+class A
+{
+public:
+  A() {}
+  A(int x) : m_x(x) {}
+  int getX() { return m_x; }
+
+protected:
+  int m_x;
+};
+
+class B : virtual public A
+{
+public:
+  B() {}
+  B(int x) : A(x) {}
+};
+
+class C : virtual public A
+{
+public:
+  C() {}
+  C(int x) : A(x) {}
+};
+
+class D : public B, public C
+{
+public:
+  D() {}
+  D(int x) : A(x), B(x), C(x) {}
+};
+
+int main()
+{
+  A *a = new D(42);
+  assert(a->getX() == 42);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_938/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_938/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_938_delegating/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_938_delegating/main.cpp
@@ -1,0 +1,31 @@
+// esbmc/esbmc#938, delegating-constructor edge: a delegating constructor must
+// forward its own completeness to the target constructor (C1->C1, C2->C2).
+// Here B() delegates to B(7); when B is a base subobject of D, B() is a
+// base-object constructor, so the delegated B(7) must NOT re-initialise the
+// virtual base A. D (most-derived) default-constructs A, leaving A::m == 0.
+#include <cassert>
+
+struct A
+{
+  int m;
+  A() : m(0) {}
+  A(int x) : m(x) {}
+};
+
+struct B : virtual A
+{
+  B(int x) : A(x) {}
+  B() : B(7) {}
+};
+
+struct D : B
+{
+  D() : B() {}
+};
+
+int main()
+{
+  D d;
+  assert(d.m == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_938_delegating/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_938_delegating/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance-wrong/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/polymorphism_bringup_overload/llbmc_virtual_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup_overload/llbmc_virtual_inheritance-wrong/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -65,8 +65,11 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
   exprt::operandst &body_ops = ctor_body.operands();
   std::size_t insert_at = 0;
   while (!is_dtor && insert_at < body_ops.size() &&
-         body_ops[insert_at].has_operands() &&
-         body_ops[insert_at].op0().get_bool("#is_base_ctor_call"))
+         ((body_ops[insert_at].has_operands() &&
+           body_ops[insert_at].op0().get_bool("#is_base_ctor_call")) ||
+          // A virtual-base ctor call wrapped in `if(__is_complete){...}`
+          // (esbmc/esbmc#938) is still a leading base-subobject construction.
+          body_ops[insert_at].get_bool("#base_ctor_call_guard")))
     ++insert_at;
 
   // iterate over the `components` and initialize each virtual pointers

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1093,6 +1093,11 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       call.arguments().push_back(arg);
     }
 
+    // Inherited constructors are lowered as base-object constructor calls, so
+    // the complete-object virtual-base initialisation must be suppressed.
+    if (ice.getConstructor()->getParent()->getNumVBases() > 0)
+      call.arguments().push_back(gen_boolean(false));
+
     call.set("constructor", 1);
     new_expr.swap(call);
     break;
@@ -1542,6 +1547,15 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
   return false;
 }
 
+// A constructor needs the hidden `__is_complete` parameter iff its class has
+// one or more virtual base subobjects (directly or transitively). getNumVBases
+// returns the flattened set of virtual bases collected at this class, so it is
+// nonzero for every class in a hierarchy that reaches a virtual base. See #938.
+static bool ctor_needs_is_complete_param(const clang::CXXConstructorDecl &cxxcd)
+{
+  return cxxcd.getParent()->getNumVBases() > 0;
+}
+
 bool clang_cpp_convertert::get_constructor_call(
   const clang::CXXConstructExpr &constructor_call,
   exprt &new_expr)
@@ -1613,6 +1627,24 @@ bool clang_cpp_convertert::get_constructor_call(
       return true;
 
     call.arguments().push_back(single_arg);
+  }
+
+  // Append the hidden `__is_complete` flag for constructors of classes with
+  // virtual bases: a base-class constructor call (base_ctor_derived) is a
+  // base-object construction and must not initialise the shared virtual base,
+  // whereas any other construction site is the most-derived/complete object.
+  // A delegating call forwards the enclosing ctor's completeness verbatim.
+  if (ctor_needs_is_complete_param(*constructor_call.getConstructor()))
+  {
+    if (new_expr.get_bool("#delegating_ctor"))
+    {
+      symbolt *ic =
+        context.find_symbol(new_expr.get("#delegating_ctor_is_complete"));
+      assert(ic);
+      call.arguments().push_back(symbol_expr(*ic));
+    }
+    else
+      call.arguments().push_back(gen_boolean(!new_expr.base_ctor_derived()));
   }
 
   call.set("constructor", 1);
@@ -1908,6 +1940,14 @@ bool clang_cpp_convertert::get_function_body(
         initializer.set(
           "#delegating_ctor_this", ftype.arguments().at(0).get("#identifier"));
         initializer.set("#delegating_ctor", 1);
+        // For a class with virtual bases, a delegating constructor must pass
+        // its own completeness on to the target constructor (C1->C1, C2->C2):
+        // a base-object delegating ctor must not let the target re-initialise
+        // the virtual base. Forward the enclosing ctor's `__is_complete`. #938
+        if (ctor_needs_is_complete_param(cxxcd))
+          initializer.set(
+            "#delegating_ctor_is_complete",
+            ftype.arguments().back().get("#identifier"));
         if (get_expr(*init->getInit(), initializer))
           return true;
         initializers.push_back(initializer);
@@ -1921,6 +1961,28 @@ bool clang_cpp_convertert::get_function_body(
         initializer.base_ctor_derived(true);
         if (get_expr(*init->getInit(), initializer))
           return true;
+
+        // A virtual base subobject is initialised only by the most-derived
+        // (complete-object) constructor. Guard its initializer with the hidden
+        // `__is_complete` flag so base-object constructor calls skip it, per
+        // [class.base.init]/7 and the Itanium C1/C2 split. See #938.
+        if (init->isBaseVirtual())
+        {
+          const irep_idt is_complete_id =
+            ftype.arguments().back().get("#identifier");
+          symbolt *s = context.find_symbol(is_complete_id);
+          assert(s);
+          convert_expression_to_code(initializer);
+          code_ifthenelset guard;
+          guard.cond() = symbol_expr(*s);
+          guard.then_case() = to_code(initializer);
+          // Tag so gen_vptr_initializations still treats this as a leading
+          // base-subobject constructor call and inserts the vptr assignments
+          // *after* it (the guard's op0 is the condition, not the call).
+          guard.set("#base_ctor_call_guard", true);
+          initializer.swap(guard);
+        }
+
         initializers.push_back(initializer);
         init_sym_uptodate = false;
       }
@@ -2248,6 +2310,47 @@ bool clang_cpp_convertert::get_function_this_pointer_param(
   return false;
 }
 
+bool clang_cpp_convertert::get_cxx_constructor_is_complete_param(
+  const clang::CXXConstructorDecl &cxxcd,
+  code_typet::argumentt &param)
+{
+  param.type() = bool_typet();
+
+  locationt location_begin;
+  get_location_from_decl(cxxcd, location_begin);
+
+  std::string id, name;
+  get_decl_name(cxxcd, name, id);
+
+  name = "__is_complete";
+  id += name;
+
+  param.cmt_base_name(name);
+  param.cmt_identifier(id);
+
+  // If the constructor is not defined we still need the parameter in the type
+  // (so call sites stay arity-consistent), but no symbol is required as the
+  // body -- and thus the guard reading it -- is never generated.
+  if (!cxxcd.isDefined())
+    return false;
+
+  symbolt param_symbol;
+  get_default_symbol(
+    param_symbol,
+    get_modulename_from_path(location_begin.file().as_string()),
+    param.type(),
+    name,
+    id,
+    location_begin);
+
+  param_symbol.lvalue = true;
+  param_symbol.is_parameter = true;
+  param_symbol.file_local = true;
+
+  context.move_symbol_to_context(param_symbol);
+  return false;
+}
+
 bool clang_cpp_convertert::get_function_params(
   const clang::FunctionDecl &fd,
   code_typet::argumentst &params)
@@ -2275,8 +2378,13 @@ bool clang_cpp_convertert::get_function_params(
   if (get_function_this_pointer_param(cxxmd, params))
     return true;
 
-  // reserve space for `this' pointer and params
-  params.resize(1 + fd.parameters().size());
+  // Constructors of classes with virtual bases carry a trailing
+  // `__is_complete` flag (Itanium C1/C2 split); reserve a slot for it.
+  const auto *cxxcd = llvm::dyn_cast<clang::CXXConstructorDecl>(&fd);
+  const bool needs_is_complete = cxxcd && ctor_needs_is_complete_param(*cxxcd);
+
+  // reserve space for `this' pointer, params and (optionally) `__is_complete'
+  params.resize(1 + fd.parameters().size() + (needs_is_complete ? 1 : 0));
 
   // TODO: replace the loop with get_function_params
   // Parse other args
@@ -2291,6 +2399,16 @@ bool clang_cpp_convertert::get_function_params(
     // All args are added shifted by one position, because
     // of the this pointer (first arg)
     params[i + 1].swap(param);
+  }
+
+  // Append `__is_complete' as the last parameter so the constructor body can
+  // gate virtual-base initialisation on it.
+  if (needs_is_complete)
+  {
+    code_typet::argumentt is_complete_param;
+    if (get_cxx_constructor_is_complete_param(*cxxcd, is_complete_param))
+      return true;
+    params.back().swap(is_complete_param);
   }
 
   return false;

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -262,6 +262,19 @@ protected:
     exprt &initializer);
 
   /*
+   * Constructors of a class with virtual bases carry a hidden trailing
+   * `__is_complete` boolean parameter that models the Itanium C1/C2 split:
+   * only the most-derived (complete-object) constructor initialises the
+   * shared virtual base subobjects, while base-object constructor calls skip
+   * them. This appends that parameter (and its symbol) for such constructors;
+   * classes without virtual bases are left with their original signature.
+   * See esbmc/esbmc#938.
+   */
+  bool get_cxx_constructor_is_complete_param(
+    const clang::CXXConstructorDecl &cxxcd,
+    code_typet::argumentt &param);
+
+  /*
    * This is an ancillary function deciding whether we need
    * need to build an new_object when dealing with constructor_call
    */


### PR DESCRIPTION
## Root cause

Under virtual (diamond) inheritance ESBMC allowed **intermediate** base
constructors to (re)initialise the **shared virtual base** subobject. For

```cpp
class A { A(){} A(int x):m_x(x){} int getX(){return m_x;} int m_x; };
class B : virtual A { B(int x):A(x){} };
class C : virtual A { C(int x):A(x){} };
class D : public B, public C { D(int x):B(x),C(x){} };   // note: no A(x)
```

`D(int x) : B(x), C(x)` does **not** list the virtual base `A`, so per C++
[class.base.init]/7 only `D` (the most-derived / complete object) initialises
`A` — here by `A()`, leaving `A::m_x` indeterminate. ESBMC instead let `B`'s
and `C`'s constructors run `A(x)` when building the `D` subobjects, so
`new D(42)->getX()` was proven `== 42` and ESBMC returned
`VERIFICATION SUCCESSFUL` where the correct verdict is `FAILED`.

This is the Itanium **C1/C2 constructor split** (complete-object vs
base-object constructor), which ESBMC did not model.

## Solution

- Constructors of classes that have virtual bases (`getNumVBases() > 0`) gain a
  hidden trailing `__is_complete` boolean parameter. Classes without virtual
  bases keep their original signature, so non-diamond code is untouched.
- Virtual-base initialisers in the constructor body are wrapped in
  `if (__is_complete) { … }`.
- At the two constructor-call construction sites, the flag is set to
  `true` for complete-object construction and `false` for base-object
  constructor calls (`base_ctor_derived`). A **delegating** constructor
  forwards its own `__is_complete` verbatim (C1→C1 / C2→C2) so the
  double-init cannot re-enter through the delegation edge.
- `gen_vptr_initializations` now recognises the guarded (`if`-wrapped)
  virtual-base ctor call (`#base_ctor_call_guard`) as a leading
  base-subobject construction, so the vtable-pointer assignments are still
  inserted **after** all base ctors run — otherwise a complete object of an
  abstract-rooted diamond would keep the base's pure-virtual (null) vtable
  slot and virtual dispatch would NULL-deref.

## Validation

- The issue's own reproducer now correctly reports `VERIFICATION FAILED`; a
  variant where `D` lists `A(x)` reports `SUCCESSFUL`. Confirmed against real
  `clang++` for the delegating edge case (`d.m == 0`).
- Regression tests: the three `llbmc_virtual_inheritance-wrong` tests (which
  *are* this bug) are promoted `KNOWNBUG` → `CORE`; new passing tests
  `github_938` (most-derived initialises the vbase) and
  `github_938_delegating` (base-object delegating ctor must not re-init the
  vbase) are added.
- C++ regression suites pass with no new failures: `inheritance` (73/73),
  `polymorphism_bringup` (45/45), `polymorphism_bringup_overload` (49/49),
  `inheritance_bringup`, `destructors`, `cbmc`, `template`,
  `gcc-template-tests`, `bug_fixes`, `OM_sanity_checks`. Verified copy/move,
  by-value passing, member-of-diamond, delegating, and 3-level (`E : D`)
  hierarchies.

Fixes #938.
