### PR TITLE
[c++] add regression test for operator new raw byte count (#2004)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_2004/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_2004/main.cpp
@@ -1,0 +1,23 @@
+// esbmc/esbmc#2004: `operator new(n)` with a raw byte count (not a sizeof)
+// used to abort with type2t::symbolic_type_excp because the result was a
+// dereference of a void pointer. It must now allocate n raw bytes and return
+// a usable pointer.
+#include <cstdlib>
+#include <cassert>
+
+struct aaaa
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  void *foo = operator new(8);
+  aaaa *p = static_cast<aaaa *>(foo);
+  p->a = 5;
+  p->b = 7;
+  assert(p->a + p->b == 12);
+  operator delete(foo);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_2004/test.desc
+++ b/regression/esbmc-cpp/cpp/github_2004/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## Root cause / status

`operator new(n)` with a **raw byte count** (not a `sizeof(T)` expression) used to abort with `type2t::symbolic_type_excp`: the generated GOTO dereferenced a `void` pointer (`*return_value$_operator new$1 = nil`). This is **already fixed on master** (the operator-new lowering now allocates `n` raw bytes and returns a usable pointer, refs #5337).

## Solution

Test-only: lock the fixed behaviour. The existing `cpp/operator_new` test only exercises the `operator new(sizeof(T))` path; this adds the raw-byte-count path from the issue: allocate 8 bytes, use the pointer as a struct, and free it.

## Validation

`VERIFICATION SUCCESSFUL` on master; runs in the `esbmc-cpp/cpp` suite.

Refs #2004.