### PR TITLE
[c++] add regression test for range-based for over std::vector (#2771)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_2771/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_2771/main.cpp
@@ -1,0 +1,15 @@
+// esbmc/esbmc#2771: a range-based for loop over a std::vector used to report
+// "Couldn't determine upper bound for range-based for loop". It now iterates
+// correctly; check the visited elements sum as expected.
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<int> numbers = {10, 20, 30, 40};
+  int sum = 0;
+  for (int num : numbers)
+    sum += num;
+  assert(sum == 100);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_2771/test.desc
+++ b/regression/esbmc-cpp/cpp/github_2771/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## Root cause / status

A range-based `for` loop over a `std::vector` used to report *"Couldn't determine upper bound for range-based for loop"*. It **iterates correctly on master**.

## Solution

Test-only: lock the fixed behaviour with a range-based `for` over `std::vector<int>` that sums the visited elements and asserts the total.

## Validation

`VERIFICATION SUCCESSFUL` on master (`--unwind 6`); runs in the `esbmc-cpp/cpp` suite.

Refs #2771.