### PR TITLE
[goto-programs] Summarize loops and if/else in quantifier bodies

### DIFF
--- a/regression/bitwuzla/github_6154_count_exists/main.c
+++ b/regression/bitwuzla/github_6154_count_exists/main.c
@@ -1,0 +1,26 @@
+// GitHub #6154: loop+if function inside __ESBMC_exists on the bitwuzla backend.
+// vec == {1,1,2,3} makes count(1, vec) == 2.
+#define SIZE 4
+typedef int data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  vec[0] = 1;
+  vec[1] = 1;
+  vec[2] = 2;
+  vec[3] = 3;
+  data_t v;
+  __ESBMC_assert(
+    __ESBMC_exists(&v, count(v, vec) == 2), "some value occurs twice");
+  return 0;
+}

--- a/regression/bitwuzla/github_6154_count_exists/test.desc
+++ b/regression/bitwuzla/github_6154_count_exists/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/github_6154_count_forall/main.c
+++ b/regression/bitwuzla/github_6154_count_forall/main.c
@@ -1,0 +1,21 @@
+// GitHub #6154: bounded-loop + if function inside a forall, on the bitwuzla
+// backend (quantifier encoding differs per solver).
+#define SIZE 4
+typedef int data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  data_t v;
+  __ESBMC_assert(__ESBMC_forall(&v, count(v, vec) <= SIZE), "count bounded");
+  return 0;
+}

--- a/regression/bitwuzla/github_6154_count_forall/test.desc
+++ b/regression/bitwuzla/github_6154_count_forall/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6100_assume_noninline/main.c
+++ b/regression/z3/github_6100_assume_noninline/main.c
@@ -1,13 +1,18 @@
-int myabs(int a)
+// A function whose loop trip count depends on the quantified variable cannot be
+// summarized into a pure quantifier body, so the forall in the assume must be
+// diagnosed rather than silently mismodelled (which would prune all paths and
+// mask the assert below).
+int impure(int a)
 {
-  if (a < 0)
-    return -a;
-  return a;
+  int s = 0;
+  for (int i = 0; i < a; i++)
+    s += i;
+  return s;
 }
 
 int main()
 {
   int x;
-  __ESBMC_assume(__ESBMC_forall(&x, myabs(x) >= 0));
+  __ESBMC_assume(__ESBMC_forall(&x, impure(x) >= 0));
   __ESBMC_assert(0, "unreachable when the assume is mismodelled");
 }

--- a/regression/z3/github_6154_assume_summarized/main.c
+++ b/regression/z3/github_6154_assume_summarized/main.c
@@ -1,0 +1,18 @@
+// GitHub #6154: a summarized callee inside __ESBMC_assume must not over-prune.
+// forall x . nonneg(x) >= 0 is unconditionally true (unlike |x| >= 0, which is
+// false at INT_MIN), so the assume constrains nothing and the assert below is
+// reachable.  A vacuous quantifier would silently make this SUCCESSFUL.
+int nonneg(int a)
+{
+  if (a < 0)
+    return 0;
+  return a;
+}
+
+int main()
+{
+  int x;
+  __ESBMC_assume(__ESBMC_forall(&x, nonneg(x) >= 0));
+  __ESBMC_assert(0, "reachable: the assume is a tautology");
+  return 0;
+}

--- a/regression/z3/github_6154_assume_summarized/test.desc
+++ b/regression/z3/github_6154_assume_summarized/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION FAILED$

--- a/regression/z3/github_6154_count_exists/main.c
+++ b/regression/z3/github_6154_count_exists/main.c
@@ -1,0 +1,27 @@
+// GitHub #6154: the same loop+if function inside __ESBMC_exists.  An existential
+// cannot be skolemized, so this only holds when count() is genuinely summarized
+// into a pure quantifier body.  vec == {1,1,2,3} makes count(1, vec) == 2.
+#define SIZE 4
+typedef int data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  vec[0] = 1;
+  vec[1] = 1;
+  vec[2] = 2;
+  vec[3] = 3;
+  data_t v;
+  __ESBMC_assert(
+    __ESBMC_exists(&v, count(v, vec) == 2), "some value occurs twice");
+  return 0;
+}

--- a/regression/z3/github_6154_count_exists/test.desc
+++ b/regression/z3/github_6154_count_exists/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_count_forall/main.c
+++ b/regression/z3/github_6154_count_forall/main.c
@@ -1,0 +1,22 @@
+// GitHub #6154: a function with a bounded loop and an if inside a quantifier.
+// count(v, vec) is summarized (loop unrolled, if muxed) into a pure expression,
+// so the forall is a genuine quantifier over the fresh bound variable.
+#define SIZE 4
+typedef int data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  data_t v;
+  __ESBMC_assert(__ESBMC_forall(&v, count(v, vec) <= SIZE), "count bounded");
+  return 0;
+}

--- a/regression/z3/github_6154_count_forall/test.desc
+++ b/regression/z3/github_6154_count_forall/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_count_forall_fail/main.c
+++ b/regression/z3/github_6154_count_forall_fail/main.c
@@ -1,0 +1,24 @@
+// GitHub #6154: discriminating failing case.  With every element equal to 7,
+// count(7, vec) == SIZE, so the claim count(v, vec) <= SIZE-1 is false for v==7.
+#define SIZE 4
+typedef int data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  for (int i = 0; i < SIZE; i++)
+    vec[i] = 7;
+  data_t v;
+  __ESBMC_assert(
+    __ESBMC_forall(&v, count(v, vec) <= SIZE - 1), "should fail at v==7");
+  return 0;
+}

--- a/regression/z3/github_6154_count_forall_fail/test.desc
+++ b/regression/z3/github_6154_count_forall_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION FAILED$

--- a/regression/z3/github_6154_differential/main.c
+++ b/regression/z3/github_6154_differential/main.c
@@ -1,0 +1,28 @@
+// GitHub #6154: differential oracle.  `direct' is count() evaluated by ordinary
+// symbolic execution of a real call; the quantified body is the summarized
+// form of the same call.  Pinning them equal at the nondeterministic point c
+// makes any divergence between the summarizer and real execution a test
+// failure, rather than relying on a hand-computed expected value.
+#define SIZE 4
+typedef int data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  data_t c;
+  int direct = count(c, vec);
+  data_t v;
+  __ESBMC_assert(
+    __ESBMC_forall(&v, v != c || count(v, vec) == direct),
+    "summary agrees with real execution");
+  return 0;
+}

--- a/regression/z3/github_6154_differential/test.desc
+++ b/regression/z3/github_6154_differential/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_first_match/main.c
+++ b/regression/z3/github_6154_first_match/main.c
@@ -1,0 +1,25 @@
+// GitHub #6154: companion to github_6154_first_match_fail.  find(5, vec) is 0
+// (the first of the two matches), so the existential holds at v == 5.
+#define SIZE 4
+typedef int data_t;
+
+int find(data_t val, data_t vec[SIZE])
+{
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      return idx;
+  return -1;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  vec[0] = 5;
+  vec[1] = 5;
+  vec[2] = 6;
+  vec[3] = 7;
+  data_t v;
+  __ESBMC_assert(
+    __ESBMC_exists(&v, find(v, vec) == 0), "5 first-matches at index 0");
+  return 0;
+}

--- a/regression/z3/github_6154_first_match/test.desc
+++ b/regression/z3/github_6154_first_match/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_first_match_fail/main.c
+++ b/regression/z3/github_6154_first_match_fail/main.c
@@ -1,0 +1,29 @@
+// GitHub #6154: pins "earliest matching return wins" for an early return inside
+// a loop.  With vec == {5,5,6,7} the only reachable results of find are
+// find(5)==0 (the FIRST match, not the second), find(6)==2, find(7)==3, and -1
+// otherwise -- so no value yields 1 and the existential must fail.  A summarizer
+// that let a later return override an earlier one would give find(5)==1 and
+// wrongly report this SUCCESSFUL.
+#define SIZE 4
+typedef int data_t;
+
+int find(data_t val, data_t vec[SIZE])
+{
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      return idx;
+  return -1;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  vec[0] = 5;
+  vec[1] = 5;
+  vec[2] = 6;
+  vec[3] = 7;
+  data_t v;
+  __ESBMC_assert(
+    __ESBMC_exists(&v, find(v, vec) == 1), "no value first-matches at index 1");
+  return 0;
+}

--- a/regression/z3/github_6154_first_match_fail/test.desc
+++ b/regression/z3/github_6154_first_match_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION FAILED$

--- a/regression/z3/github_6154_ifelse_exists/main.c
+++ b/regression/z3/github_6154_ifelse_exists/main.c
@@ -1,0 +1,18 @@
+// GitHub #6154: an if/else function (no loop) inside __ESBMC_exists.  sgn is
+// summarized into (x > 0 ? 1 : 0); the existential holds for any x > 0.
+int sgn(int x)
+{
+  int r;
+  if (x > 0)
+    r = 1;
+  else
+    r = 0;
+  return r;
+}
+
+int main()
+{
+  int v;
+  __ESBMC_assert(__ESBMC_exists(&v, sgn(v) == 1), "sgn is 1 for some v");
+  return 0;
+}

--- a/regression/z3/github_6154_ifelse_exists/test.desc
+++ b/regression/z3/github_6154_ifelse_exists/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_ifelse_fold/main.c
+++ b/regression/z3/github_6154_ifelse_fold/main.c
@@ -1,0 +1,23 @@
+// GitHub #6154: an if/else condition that folds to a compile-time constant
+// because it depends only on a call-site literal, not the quantifier's bound
+// variable.  pick(v, 1) takes the then-branch unconditionally; pick(v, 0)
+// takes the else-branch unconditionally.
+int pick(int x, int mode)
+{
+  int r;
+  if (mode == 1)
+    r = x;
+  else
+    r = x + 1;
+  return r;
+}
+
+int main()
+{
+  int v;
+  __ESBMC_assert(
+    __ESBMC_forall(&v, pick(v, 1) == v), "fold-true branch summarized");
+  __ESBMC_assert(
+    __ESBMC_forall(&v, pick(v, 0) == v + 1), "fold-false branch summarized");
+  return 0;
+}

--- a/regression/z3/github_6154_ifelse_fold/test.desc
+++ b/regression/z3/github_6154_ifelse_fold/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_nondet_guard/main.c
+++ b/regression/z3/github_6154_nondet_guard/main.c
@@ -1,0 +1,23 @@
+// GitHub #6154: a discarded `__builtin_reduce_add' statement inside a
+// summarized callee lowers, at the raw-AST level the summarizer reads, to a
+// zero-operand nondet side effect (see clang_c_adjust_expr.cpp's
+// dont-care-about-missing-extensions fallback).  This exercises the
+// `e.operands().empty()' guard in summary_apply_effect() that must be checked
+// before op0() is dereferenced.  f cannot be summarized (the discarded call is
+// rejected), so __ESBMC_forall falls back to skolemization/binder handling;
+// the property below still holds because x is returned unmodified.
+typedef int v4si __attribute__((vector_size(16)));
+
+int f(int x, v4si v)
+{
+  __builtin_reduce_add(v);
+  return x;
+}
+
+int main()
+{
+  v4si v = {1, 2, 3, 4};
+  int y;
+  __ESBMC_assert(__ESBMC_forall(&y, f(y, v) == y), "reduce-discard guard");
+  return 0;
+}

--- a/regression/z3/github_6154_nondet_guard/test.desc
+++ b/regression/z3/github_6154_nondet_guard/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --dont-care-about-missing-extensions
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_reject_float_inc/main.c
+++ b/regression/z3/github_6154_reject_float_inc/main.c
@@ -1,0 +1,18 @@
+// GitHub #6154: `++' on a non-integer local is NOT summarizable -- the
+// summary builds `cur + from_integer(1, t)', which is nil for a float, so
+// accepting this crashed once the summary reached the solver.  The callee must
+// be refused, leaving the loop to be unwound normally.
+int f(int n)
+{
+  double d = 0.0;
+  for (int i = 0; i < 3; i++)
+    d++;
+  return n + (int)d;
+}
+
+int main()
+{
+  int k;
+  __ESBMC_assert(__ESBMC_forall(&k, f(k) == k + 3), "float inc not summarized");
+  return 0;
+}

--- a/regression/z3/github_6154_reject_float_inc/test.desc
+++ b/regression/z3/github_6154_reject_float_inc/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3
+^Unwinding loop .* function f$
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_reject_float_inc_fail/main.c
+++ b/regression/z3/github_6154_reject_float_inc_fail/main.c
@@ -1,0 +1,17 @@
+// GitHub #6154: discriminating failing case for the refused float `++'.
+// Falling back to normal unwinding must still evaluate the body, so the false
+// claim f(k) == k + 99 is detected rather than passing vacuously.
+int f(int n)
+{
+  double d = 0.0;
+  for (int i = 0; i < 3; i++)
+    d++;
+  return n + (int)d;
+}
+
+int main()
+{
+  int k;
+  __ESBMC_assert(__ESBMC_forall(&k, f(k) == k + 99), "should fail");
+  return 0;
+}

--- a/regression/z3/github_6154_reject_float_inc_fail/test.desc
+++ b/regression/z3/github_6154_reject_float_inc_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION FAILED$

--- a/regression/z3/github_6154_reject_ptrwrite/main.c
+++ b/regression/z3/github_6154_reject_ptrwrite/main.c
@@ -1,0 +1,18 @@
+// GitHub #6154: a callee that writes through a pointer is NOT summarizable --
+// the summarizer models only local scalars, so accepting this would drop the
+// store.  It must be refused (and the quantifier then diagnosed) rather than
+// silently turned into a pure expression.  __ESBMC_exists has no skolemization
+// fallback, so refusal surfaces as the diagnostic below.
+int store(int a, int *p)
+{
+  *p = a;
+  return a;
+}
+
+int main()
+{
+  int q = 0;
+  int v;
+  __ESBMC_assert(__ESBMC_exists(&v, store(v, &q) == 7), "not summarizable");
+  return 0;
+}

--- a/regression/z3/github_6154_reject_ptrwrite/test.desc
+++ b/regression/z3/github_6154_reject_ptrwrite/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+cannot model call to .* on a quantified variable inside __ESBMC_forall/__ESBMC_exists

--- a/regression/z3/github_6154_while_dowhile/main.c
+++ b/regression/z3/github_6154_while_dowhile/main.c
@@ -1,0 +1,50 @@
+// GitHub #6154: `while' and `do-while' loops (not just `for') with a
+// statically constant trip count, and a `--'/`++' arm on both sides, inside a
+// quantifier body.  sumn unrolls a `while'; inc_once unrolls a `do-while' that
+// executes its body once before the first condition check.
+int sumn(int x)
+{
+  int i = 0;
+  int r = x;
+  while (i < 3)
+  {
+    r = r + 1;
+    i = i + 1;
+  }
+  return r;
+}
+
+int dec_twice(int x)
+{
+  int r = x;
+  int i = 0;
+  while (i < 2)
+  {
+    --r;
+    ++i;
+  }
+  return r;
+}
+
+int inc_once(int x)
+{
+  int r = x;
+  int i = 0;
+  do
+  {
+    r = r + 1;
+    i = i + 1;
+  } while (i < 1);
+  return r;
+}
+
+int main()
+{
+  int v;
+  __ESBMC_assert(__ESBMC_forall(&v, sumn(v) == v + 3), "while-loop summarized");
+  __ESBMC_assert(
+    __ESBMC_forall(&v, dec_twice(v) == v - 2), "while-loop with predecrement");
+  __ESBMC_assert(
+    __ESBMC_forall(&v, inc_once(v) == v + 1), "do-while summarized");
+  return 0;
+}

--- a/regression/z3/github_6154_while_dowhile/test.desc
+++ b/regression/z3/github_6154_while_dowhile/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -600,7 +600,14 @@ _Noreturn void __ESBMC_unreachable();
  * int i = 0;
  * __ESBMC_forall(&i, i < 0);
  *
- * This will return false, because 'i' became a local variable i.e, it means "forall i \in [min(int), (max(int))] . i < 0" */
+ * This will return false, because 'i' became a local variable i.e, it means "forall i \in [min(int), (max(int))] . i < 0"
+ *
+ * The body may call functions built from local declarations, straight-line
+ * assignments, if/else, and loops with a statically constant trip count: such a
+ * callee is summarized (loops unrolled, branches muxed) into a single pure
+ * expression (GitHub #6154).  Functions with a data-dependent trip count,
+ * pointer/array writes, recursion, or other non-summarizable shapes are still
+ * rejected inside a quantifier. */
 
 _Bool __ESBMC_forall(void*, _Bool);
 _Bool __ESBMC_exists(void*, _Bool);

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -95,10 +95,20 @@ protected:
     goto_programt &dest);
   void inline_calls_in_quantifier_body(exprt &expr, unsigned depth);
   bool try_inline_pure_call(const symbolt &fsym, const exprt &call, exprt &out);
+  // Summarize a callee with straight-line assignments, if/else, and
+  // constant-trip-count loops into a single side-effect-free expression so it
+  // can appear in a quantifier body.  Returns false (leaving @p out untouched)
+  // for any shape it cannot soundly turn into a pure expression.
+  bool summarize_pure_call(const symbolt &fsym, const exprt &call, exprt &out);
   const exprt *find_sideeffect_on_bound_var(
     const exprt &expr,
     const std::set<irep_idt> &bound_vars);
   void skolemize_asserted_foralls(exprt &expr, goto_programt &dest);
+  // Rewrite __ESBMC_forall/__ESBMC_exists intrinsic calls into forall/exists
+  // expressions, summarizing calls in the body first, before any hoisting can
+  // freeze the bound variable.  Bodies that cannot be made side-effect-free are
+  // left as calls for the skolemization / quantifier-body fallbacks.
+  void convert_quantifier_calls(exprt &expr);
 
   void remove_assignment(exprt &expr, goto_programt &dest, bool result_is_used);
   void remove_post(exprt &expr, goto_programt &dest, bool result_is_used);

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -428,7 +428,14 @@ static bool summary_apply_effect(const exprt &e, summary_statet &st)
   const bool inc = (s == "preincrement" || s == "postincrement");
   const bool dec = (s == "predecrement" || s == "postdecrement");
   auto it = st.env.find(id);
-  if ((!inc && !dec) || e.operands().size() != 1 || it == st.env.end())
+  // Whitelist the types `cur +/- from_integer(1, t)' is meaningful for, so an
+  // unhandled type degrades to a rejection.  from_integer() returns nil for
+  // anything but an integer bitvector or bool, and a nil operand here left an
+  // ill-formed `cur + nil' in env that crashed once the summary reached the
+  // solver (a `double' local incremented in a summarized loop).
+  if (
+    (!inc && !dec) || e.operands().size() != 1 || it == st.env.end() ||
+    (t.id() != "signedbv" && t.id() != "unsignedbv"))
     return false;
   exprt cur = it->second;
   summary_coerce(cur, t);

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -1,4 +1,6 @@
 #include <goto-programs/goto_convert_class.h>
+#include <irep2/irep2_utils.h>
+#include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>
 #include <util/expr_util.h>
@@ -296,6 +298,414 @@ bool goto_convertt::try_inline_pure_call(
   return true;
 }
 
+namespace
+{
+/// State threaded through the structured-body summarizer.  @ref env maps each
+/// in-scope local (parameters seeded from the call's actual arguments) to its
+/// current symbolic value; @ref pc is the path condition reaching the current
+/// statement; @ref returns records (guard, value) for every `return' in program
+/// order, with the earliest matching guard winning; @ref locals holds every
+/// callee-local identifier, so a read of a not-yet-assigned local can be
+/// detected; @ref budget bounds loop unrolling.
+struct summary_statet
+{
+  std::map<irep_idt, exprt> env;
+  exprt pc;
+  std::vector<std::pair<exprt, exprt>> returns;
+  std::set<irep_idt> locals;
+  unsigned budget;
+};
+
+bool summary_has_sideeffect(const exprt &e)
+{
+  if (e.id() == "sideeffect")
+    return true;
+  forall_operands (it, e)
+    if (summary_has_sideeffect(*it))
+      return true;
+  return false;
+}
+
+/// Fold @p e to a constant boolean: 1 = true, 0 = false, -1 = not a constant.
+/// -1 covers both "genuinely symbolic" and "constant, but the simplifier could
+/// not fold it"; either way the caller rejects the callee, so a stronger
+/// simplifier only widens the set of accepted shapes, it never changes a result.
+int summary_fold_bool(const exprt &e)
+{
+  expr2tc e2;
+  migrate_expr(e, e2);
+  simplify(e2);
+  BigInt v;
+  if (to_integer(e2, v))
+    return -1;
+  return v.is_zero() ? 0 : 1;
+}
+
+/// Keeping the path condition literally `true' (rather than and(true, x)) lets
+/// the totality check below fold it without leaning on the simplifier.
+exprt summary_and(const exprt &a, const exprt &b)
+{
+  return a.is_true() ? b : gen_and(a, b);
+}
+
+void summary_coerce(exprt &e, const typet &t)
+{
+  if (e.type() != t)
+    e.make_typecast(t);
+}
+
+std::size_t summary_node_count(const exprt &e)
+{
+  std::size_t n = 1;
+  forall_operands (it, e)
+    n += summary_node_count(*it);
+  return n;
+}
+
+/// Total size of the summary built so far.  A branch merge embeds the
+/// pre-branch value in both arms, so an unrolled loop containing an if/else
+/// doubles the tracked values per iteration: bounding the iteration count alone
+/// still admits a 2^n-sized expression (a trip count of 18 already costs GBs).
+/// Bounding size instead makes an over-large body degrade to a clean rejection.
+std::size_t summary_size(const summary_statet &st)
+{
+  std::size_t n = 0;
+  for (const auto &kv : st.env)
+    n += summary_node_count(kv.second);
+  for (const auto &r : st.returns)
+    n += summary_node_count(r.first) + summary_node_count(r.second);
+  return n;
+}
+
+static constexpr std::size_t max_summary_nodes = 20000;
+} // namespace
+
+/// Substitute tracked locals in @p e with their env values.  Fails when @p e
+/// has a side effect, takes the address of a tracked local, or — after
+/// substitution — still mentions a callee-local (a read before assignment the
+/// summarizer cannot model).
+static bool summary_eval(const exprt &e, const summary_statet &st, exprt &out)
+{
+  if (summary_has_sideeffect(e) || param_under_address_of(e, st.locals))
+    return false;
+  exprt r = e;
+  replace_symbols_in_expr(r, st.env);
+  if (mentions_symbol(r, st.locals))
+    return false;
+  out.swap(r);
+  return true;
+}
+
+/// Apply a discarded expression statement (or a for-loop iterator) to @p st.
+/// A plain `=' assignment or a bare `++`/`--' on a tracked local scalar updates
+/// its value; a side-effect-free expression has no effect; anything else fails.
+/// The clang frontend lowers an assignment used as a statement (including an
+/// `if'/`for' controlled statement) to a side_effect_exprt("assign") rather
+/// than a code_assignt, which is why this is the only assignment form handled.
+static bool summary_apply_effect(const exprt &e, summary_statet &st)
+{
+  if (!summary_has_sideeffect(e))
+    return true;
+  // A `nondet' side effect carries no operands, so check before reaching op0().
+  if (e.id() != "sideeffect" || e.operands().empty() || !e.op0().is_symbol())
+    return false;
+  const irep_idt &id = e.op0().identifier();
+  if (!st.locals.count(id))
+    return false;
+  const typet &t = e.op0().type();
+  const irep_idt &s = e.statement();
+
+  if (s == "assign" && e.operands().size() == 2)
+  {
+    exprt val;
+    if (!summary_eval(e.op1(), st, val))
+      return false;
+    summary_coerce(val, t);
+    st.env[id] = val;
+    return true;
+  }
+
+  const bool inc = (s == "preincrement" || s == "postincrement");
+  const bool dec = (s == "predecrement" || s == "postdecrement");
+  auto it = st.env.find(id);
+  if ((!inc && !dec) || e.operands().size() != 1 || it == st.env.end())
+    return false;
+  exprt cur = it->second;
+  summary_coerce(cur, t);
+  exprt val(inc ? "+" : "-", t);
+  val.copy_to_operands(cur, from_integer(1, t));
+  it->second = val;
+  return true;
+}
+
+/// Symbolically execute one structured statement of the callee, updating
+/// @p st.  Returns false for any construct the summarizer cannot soundly turn
+/// into a pure expression.
+static bool
+summarize_code(const codet &code, summary_statet &st, const namespacet &ns)
+{
+  const irep_idt &s = code.get_statement();
+
+  if (s == "skip")
+    return true;
+
+  if (s == "block" || s == "decl-block")
+  {
+    forall_operands (it, code)
+      if (!it->is_code() || !summarize_code(to_code(*it), st, ns))
+        return false;
+    return true;
+  }
+
+  if (s == "decl")
+  {
+    if (code.operands().empty() || !code.op0().is_symbol())
+      return false;
+    const irep_idt &id = code.op0().identifier();
+    const symbolt *ls = ns.lookup(id);
+    if (!ls || ls->static_lifetime)
+      return false;
+    st.locals.insert(id);
+    if (code.operands().size() == 2 && code.op1().is_not_nil())
+    {
+      exprt val;
+      if (!summary_eval(code.op1(), st, val))
+        return false;
+      summary_coerce(val, code.op0().type());
+      st.env[id] = val;
+    }
+    else
+      st.env.erase(id);
+    return true;
+  }
+
+  // A source-level assignment reaches us as a side_effect_exprt("assign")
+  // wrapped in a code_expressiont, never as a bare code_assignt, so only the
+  // "expression" form below is handled; anything else falls through to the
+  // conservative rejection at the end.
+  if (s == "expression")
+    return code.operands().size() == 1 && summary_apply_effect(code.op0(), st);
+
+  if (s == "return")
+  {
+    if (code.operands().size() != 1)
+      return false;
+    const code_returnt &r = to_code_return(code);
+    exprt val;
+    if (!r.has_return_value() || !summary_eval(r.return_value(), st, val))
+      return false;
+    st.returns.emplace_back(st.pc, val);
+    return true;
+  }
+
+  if (s == "ifthenelse")
+  {
+    if (code.operands().size() < 2)
+      return false;
+    const code_ifthenelset &i = to_code_ifthenelse(code);
+    // The frontend emits an ifthenelse with two operands when there is no
+    // else branch; op2() is only present with three (cf. convert_ifthenelse).
+    const bool has_else =
+      code.operands().size() == 3 && code.op2().is_not_nil();
+    exprt cv;
+    if (!summary_eval(i.cond(), st, cv))
+      return false;
+    const int f = summary_fold_bool(cv);
+    if (f == 1)
+      return summarize_code(i.then_case(), st, ns);
+    if (f == 0)
+      return !has_else || summarize_code(i.else_case(), st, ns);
+
+    const std::map<irep_idt, exprt> base = st.env;
+    const std::set<irep_idt> outer = st.locals;
+    const exprt saved_pc = st.pc;
+
+    st.pc = summary_and(saved_pc, cv);
+    if (!summarize_code(i.then_case(), st, ns))
+      return false;
+    const std::map<irep_idt, exprt> then_env = st.env;
+
+    st.env = base;
+    st.pc = summary_and(saved_pc, gen_not(cv));
+    if (has_else && !summarize_code(i.else_case(), st, ns))
+      return false;
+    const std::map<irep_idt, exprt> else_env = st.env;
+
+    st.pc = saved_pc;
+    st.env = base;
+    st.locals = outer;
+    // Merge every outer-scope local written on either path; a variable written
+    // in only one branch takes its pre-branch value on the other.  Values only
+    // defined on one path (declared without initializer, assigned in one branch)
+    // are left unset so a later unconditional read bails.  Locals declared
+    // inside a branch drop out of scope with the restore above.
+    std::set<irep_idt> keys;
+    for (const auto &kv : then_env)
+      if (outer.count(kv.first))
+        keys.insert(kv.first);
+    for (const auto &kv : else_env)
+      if (outer.count(kv.first))
+        keys.insert(kv.first);
+    for (const irep_idt &k : keys)
+    {
+      auto ti = then_env.find(k), ei = else_env.find(k), bi = base.find(k);
+      const exprt *tv = ti != then_env.end() ? &ti->second
+                        : bi != base.end()   ? &bi->second
+                                             : nullptr;
+      const exprt *ev = ei != else_env.end() ? &ei->second
+                        : bi != base.end()   ? &bi->second
+                                             : nullptr;
+      if (!tv || !ev)
+        continue;
+      if (*tv == *ev)
+        st.env[k] = *tv;
+      else
+      {
+        exprt e = *ev;
+        summary_coerce(e, tv->type());
+        st.env[k] = if_exprt(cv, *tv, e);
+      }
+    }
+    return true;
+  }
+
+  if (s == "for" || s == "while" || s == "dowhile")
+  {
+    const exprt *cond, *init = nullptr, *iter = nullptr;
+    const codet *body;
+    if (s == "for")
+    {
+      if (code.operands().size() != 4)
+        return false;
+      const code_fort &l = to_code_for(code);
+      init = &l.init();
+      cond = &l.cond();
+      iter = &l.iter();
+      body = &l.body();
+    }
+    else if (s == "while")
+    {
+      if (code.operands().size() != 2)
+        return false;
+      const code_whilet &l = to_code_while(code);
+      cond = &l.cond();
+      body = &l.body();
+    }
+    else
+    {
+      if (code.operands().size() != 2)
+        return false;
+      const code_dowhilet &l = to_code_dowhile(code);
+      cond = &l.cond();
+      body = &l.body();
+    }
+
+    if (
+      init && init->is_not_nil() &&
+      (!init->is_code() || !summarize_code(to_code(*init), st, ns)))
+      return false;
+
+    // Unroll while the loop condition folds to a constant true, threading the
+    // loop counter through env each iteration.  A condition that never folds
+    // (data-dependent trip count), an exhausted budget, or a summary that grew
+    // too large leaves the loop as a call the summarizer cannot turn into a
+    // pure expression.
+    for (bool first = true;; first = false)
+    {
+      if (summary_size(st) > max_summary_nodes)
+        return false;
+      if (!(s == "dowhile" && first))
+      {
+        if (cond->is_nil())
+          return false;
+        exprt cv;
+        if (!summary_eval(*cond, st, cv))
+          return false;
+        const int f = summary_fold_bool(cv);
+        if (f == -1)
+          return false;
+        if (f == 0)
+          break;
+      }
+      if (st.budget == 0)
+        return false;
+      st.budget--;
+      if (!summarize_code(*body, st, ns))
+        return false;
+      // The frontend wraps the loop iterator in a code_expressiont; route it
+      // through summarize_code, which unwraps the statement to apply its effect.
+      if (iter && iter->is_not_nil())
+      {
+        if (iter->is_code())
+        {
+          if (!summarize_code(to_code(*iter), st, ns))
+            return false;
+        }
+        else if (!summary_apply_effect(*iter, st))
+          return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+bool goto_convertt::summarize_pure_call(
+  const symbolt &fsym,
+  const exprt &call,
+  exprt &out)
+{
+  const exprt &value = fsym.get_value();
+  if (!value.is_code() || fsym.get_type().id() != "code")
+    return false;
+
+  const code_typet &ftype = to_code_type(fsym.get_type());
+  if (ftype.has_ellipsis())
+    return false;
+  const code_typet::argumentst &params = ftype.arguments();
+  const exprt::operandst &args = call.op1().operands();
+  if (params.size() != args.size())
+    return false;
+
+  summary_statet st;
+  st.pc = true_exprt();
+  st.budget = max_quantifier_inline_depth * max_quantifier_inline_depth;
+
+  for (std::size_t i = 0; i < params.size(); i++)
+  {
+    const irep_idt &id = params[i].get_identifier();
+    if (id.empty() || summary_has_sideeffect(args[i]))
+      return false;
+    exprt arg = args[i];
+    summary_coerce(arg, params[i].type());
+    st.locals.insert(id);
+    st.env[id] = arg;
+  }
+
+  if (!summarize_code(to_code(value), st, ns))
+    return false;
+
+  // A trailing unconditional return guarantees the summary is total: the last
+  // recorded value is the fall-through, earlier returns wrap it as nested
+  // if-then-else so the earliest matching guard wins.
+  if (st.returns.empty() || summary_fold_bool(st.returns.back().first) != 1)
+    return false;
+
+  exprt result = st.returns.back().second;
+  for (std::size_t i = st.returns.size() - 1; i-- > 0;)
+  {
+    exprt v = st.returns[i].second;
+    summary_coerce(v, result.type());
+    result = if_exprt(st.returns[i].first, v, result);
+  }
+
+  summary_coerce(result, call.type());
+  result.location() = call.find_location();
+  out.swap(result);
+  return true;
+}
+
 /// Inline calls to pure single-return functions occurring under a quantifier
 /// binder, so that the bound variable stays visible in the body for
 /// replace_name_in_body() in smt_solver.cpp.  Hoisting such a call to a temp
@@ -319,7 +729,10 @@ void goto_convertt::inline_calls_in_quantifier_body(exprt &expr, unsigned depth)
   {
     const symbolt *fsym = ns.lookup(expr.op0().identifier());
     exprt inlined;
-    if (!fsym || depth == 0 || !try_inline_pure_call(*fsym, expr, inlined))
+    if (
+      !fsym || depth == 0 ||
+      (!try_inline_pure_call(*fsym, expr, inlined) &&
+       !summarize_pure_call(*fsym, expr, inlined)))
       return;
     expr.swap(inlined);
     inline_calls_in_quantifier_body(expr, depth - 1);
@@ -413,6 +826,33 @@ void goto_convertt::skolemize_asserted_foralls(exprt &expr, goto_programt &dest)
   skolemize_asserted_foralls(expr, dest);
 }
 
+void goto_convertt::convert_quantifier_calls(exprt &expr)
+{
+  if (const symbolt *fsym = quantifier_intrinsic_call(expr, ns))
+  {
+    exprt::operandst &args = expr.op1().operands();
+    if (args.size() == 2)
+    {
+      // Bottom-up: convert any nested quantifier calls first, then summarize
+      // the remaining calls so the bound variable stays free in the body.
+      convert_quantifier_calls(args[1]);
+      inline_calls_in_quantifier_body(args[1], max_quantifier_inline_depth);
+      if (!has_sideeffect(args[1]))
+      {
+        exprt quant(
+          fsym->name == "__ESBMC_forall" ? "forall" : "exists", typet("bool"));
+        quant.copy_to_operands(args[0], args[1]);
+        quant.location() = expr.find_location();
+        expr.swap(quant);
+      }
+    }
+    return;
+  }
+
+  Forall_operands (it, expr)
+    convert_quantifier_calls(*it);
+}
+
 void goto_convertt::remove_sideeffects_for_quantifier_body(
   exprt &body,
   const std::set<irep_idt> &bound_vars,
@@ -480,9 +920,10 @@ void goto_convertt::remove_sideeffects_for_quantifier_body(
     log_error(
       "{}: cannot model {} on a quantified variable inside "
       "__ESBMC_forall/__ESBMC_exists; the quantifier body must be a "
-      "side-effect-free expression, possibly calling functions whose body "
-      "is local declarations followed by a single `return <expr>;' and "
-      "whose side-effecting arguments are each used exactly once",
+      "side-effect-free expression, possibly calling functions built from "
+      "local declarations, assignments, if/else, and loops with a statically "
+      "constant trip count, and whose side-effecting arguments are each used "
+      "exactly once",
       se->find_location().as_string(),
       is_call ? "call to `" + se->op0().identifier().as_string() + "'"
               : "side effect `" + se->statement().as_string() + "'");
@@ -556,6 +997,13 @@ void goto_convertt::remove_sideeffects(
   // on expr.location(), enabling column-accurate branching waypoint matching.
   if (!has_sideeffect(expr) && expr.id() != "if")
     return;
+
+  // Turn quantifier intrinsic calls into forall/exists expressions before the
+  // &&/|| and generic side-effect lowering below, so a nested quantifier's body
+  // is never hoisted into a temp (which would freeze the bound variable).  A
+  // quantifier call is itself a side effect, so the guard above never skips a
+  // convertible expression.
+  convert_quantifier_calls(expr);
 
   // Snapshot for the discarded-temporary_object arm below: entries pushed
   // while lowering this expression describe its full-expression temporaries.


### PR DESCRIPTION
Extends the quantifier-body inliner from #6105 so a callee built from local declarations, assignments, if/else, and loops with a statically constant trip count is summarized into a single side-effect-free expression, keeping the bound variable free under `__ESBMC_forall`/`__ESBMC_exists` instead of hoisting the call to a temp.

Summarization is bounded by expression size rather than iteration count, because a branch merge inside an unrolled loop doubles the summary each iteration. Shapes that cannot be summarized soundly — data-dependent trip counts, pointer writes, `break`/`switch`, recursion — remain rejected and diagnosed.

Addresses https://github.com/esbmc/esbmc/discussions/6154
