### PR TITLE
[irep2] Locate while-condition lowering in --irep2-native-body

### DIFF
--- a/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/main.c
@@ -1,0 +1,22 @@
+// W1-loc spike Phase C (esbmc/esbmc#4715): a `while` whose condition is itself
+// side-effecting (`t--`) is lowered by generate_conditional_branch, which reads
+// the location for each instruction it emits off the operand being lowered
+// rather than off the statement. IREP2 value expressions carry no location, so
+// the back-migrated condition arrived unlocated and those instructions came out
+// with no location at all under --irep2-native-body, while the legacy path had
+// them stamped by restore_value_locations. countdown() below is deliberately
+// free of assignment statements so that it converts natively end to end on the
+// current supported-kind set -- adding one would make the whole function fall
+// back to goto_convert_rec and stop exercising the native path.
+void countdown(unsigned t)
+{
+  while (t--)
+  {
+  }
+}
+
+int main(void)
+{
+  countdown(3);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--irep2-native-body --goto-functions-only
+main\.c line 13 column 3 function countdown\n\s+ASSIGN tmp\$1=t;
+main\.c line 13 column 3 function countdown\n\s+ASSIGN t=t - 1;

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -599,7 +599,17 @@ bool goto_convert_functionst::convert_native_rec(
       // not <call>(): break` before goto_convert ever sees them (confirmed
       // empirically — see docs/spike-v1k-w1loc.md), so this path is reached
       // by a C/C++ `while` whose condition is directly a call.
+      // generate_conditional_branch/remove_sideeffects read the location for
+      // each instruction they emit off the *operand* being lowered, not off the
+      // statement. IREP2 value expressions carry no location, so the
+      // back-migrated condition arrives unlocated and those instructions come
+      // out unlocated too; the legacy path avoids this because
+      // restore_value_locations has already pushed the enclosing statement's
+      // location onto the round-tripped body's value operands. Do the same with
+      // the same helper, so the decrement `while (t--)` lowers to stays located
+      // (instruction locations gate --condition-coverage and witness matching).
       exprt cond_legacy = migrate_expr_back(w.cond);
+      stamp_value_locations(cond_legacy, location);
       generate_conditional_branch(
         gen_not(cond_legacy), z, location, tmp_branch);
     }


### PR DESCRIPTION
generate_conditional_branch reads the location for each instruction it emits
off the operand being lowered, not off the statement. IREP2 value expressions
carry no location, so the back-migrated condition of a side-effecting `while`
arrived unlocated under `--irep2-native-body` and `while (t--)` lowered to
unlocated ASSIGNs, while the legacy path had them stamped by
`restore_value_locations`. Stamp the condition with the same helper.

This is a byte-identity divergence in the W1-loc Phase C gate (#4715), present
since #6106 added side-effecting-condition support. It is currently reachable
only for a function with no assignment statements — anything else falls back to
`goto_convert_rec` wholesale — but becomes broadly reachable as soon as C
assignment statements convert natively, so it wants fixing first.

The regression test is dump-based rather than verdict-based because no current
pass observes these particular instructions' locations; it pins the located
decrement and fails on the unpatched binary.

Refs #4715.
