### PR TITLE
[docs] correct and strengthen the JBMC goto-binary PoC plan

### DIFF
--- a/docs/jbmc-goto-binary-poc-plan.md
+++ b/docs/jbmc-goto-binary-poc-plan.md
@@ -1,7 +1,7 @@
 # PoC: Verifying JBMC-produced GOTO Programs with ESBMC
 
 **Status:** PROPOSED (plan only — no implementation yet)
-**Date:** 2026-07-18
+**Date:** 2026-07-18 (revised after technical review, 2026-07-18)
 **Related:** [`docs/cprover-support-roadmap.md`](cprover-support-roadmap.md) (the CBMC
 goto-binary ingestion effort this builds on), `src/jimple-frontend/` (an unrelated,
 pre-existing Java route)
@@ -15,61 +15,114 @@ Java bytecode, reusing the CBMC goto-binary reader that already exists in the tr
 
 This is a **feasibility PoC**, not a Java frontend. Success means: a handful of small
 Java programs are verified end-to-end by ESBMC via JBMC, with verdicts matching JBMC's
-own, and a measured, itemised list of what blocks the rest.
+own, and a measured, itemised list of what blocks the rest. §4.1 states the success
+criteria precisely.
 
 ### Why this is worth a PoC
 
 ESBMC's Java story today is `src/jimple-frontend/` — a source-language frontend for
 Soot's Jimple IR, fed by JSON produced by an external tool. Its Java type handling is
-shallow (`src/jimple-frontend/AST/jimple_type.h:59-69` maps `java.lang.String` and
-`java.lang.AssertionError` to `INT` with `// TODO: handle this properly`), and it is
-gated behind an optional build flag with 10 regression tests.
+shallow (`src/jimple-frontend/AST/jimple_type.h` maps `java.lang.String`,
+`java.lang.AssertionError`, `java.lang.Runtime` and `java.lang.Class` to `INT`, each
+with `// TODO: handle this properly`), and it is gated behind the optional
+`ENABLE_JIMPLE_FRONTEND` build flag with 15 regression tests under `regression/jimple/`.
 
 Meanwhile ESBMC has, over roughly 30 merged PRs, built a mature reader for CBMC's
-goto-binary format (`read_cbmc_goto_object.cpp`, `cbmc_adapter.cpp`, ~2000 lines, 131
-regression fixtures under `regression/goto-transcoder/`). JBMC is built on the same
-CPROVER codebase and emits the same IR. If that reader can be pointed at Java, ESBMC
-gets a Java frontend largely for free — and reuses the JVM semantics, class loading,
-and Java runtime models that the CPROVER project already maintains.
+goto-binary format (`src/goto-programs/read_cbmc_goto_object.cpp` +
+`src/goto-programs/cbmc_adapter.cpp`, ~2000 lines, 131 regression fixtures under
+`regression/goto-transcoder/`). JBMC is built on the same CPROVER codebase and emits the
+same IR. If that reader can be pointed at Java, ESBMC gets a Java frontend largely for
+free — and reuses the JVM semantics, class loading, and Java runtime models that the
+CPROVER project already maintains.
+
+**Scope of that "for free" claim.** It applies to *IR ingestion*, not to verification
+capability. Java semantics that JBMC discharges in its solver rather than in its GOTO
+program — string refinement above all (§5) — do not transfer with the binary. This plan
+does not assume otherwise.
 
 ---
 
 ## 2. What is already established
 
-The probes below were run against `jbmc`/`cbmc` **6.5.0** and ESBMC at `c3deaba546`,
-on OpenJDK 21. They are cheap to reproduce; §7 records the exact commands.
+### 2.1 Provenance of the measurements
 
-### 2.1 JBMC cannot write a goto binary, but a route exists
+Two independent probe runs are reported below. Distinguishing them matters, because the
+absolute counts in §2.5 and §2.6 are corpus-dependent and only the *directional*
+conclusions replicate.
 
-`jbmc` has no `--write-goto-binary` / `--outfile` for GOTO; its `--gb` flag *reads* one.
+| | Run 1 (original) | Run 2 (review replication) |
+|---|---|---|
+| `jbmc`/`cbmc` | 6.5.0 (Ubuntu, Diffblue `.deb`) | 6.8.0 (macOS, Homebrew) |
+| ESBMC | `c3deaba546` | `8.4.0`, feature branch, aarch64 |
+| JDK | OpenJDK 21 | none — corpus taken from `core-models.jar` |
+| Corpus | hand-written `Rich.java` | `java.lang.Integer` + transitive models |
+
+All ESBMC line references in this document are as they appear at **`c3deaba546`**, the
+commit Run 1 was measured against. Several have since drifted on `master`; §2.4 records
+the drift explicitly rather than silently restating master's numbers.
+
+Upstream CPROVER references are to `diffblue/cbmc` `develop` at
+`ff8e1122feffbe0c067b88a9ce44840a99a99428` (2026-07-17, version 6.10.0).
+
+### 2.2 JBMC cannot write a goto binary, but a route exists
+
+`jbmc` has no `--write-goto-binary`, and no goto-binary output path of any kind: its
+`--gb` flag *reads* one (`OPT_JAVA_GOTO_BINARY`,
+`jbmc/src/java_bytecode/java_bytecode_language.h:159-165`, help text "goto-binary file
+to be checked"), and `grep -rn write_goto_binary jbmc/` returns nothing.
+
+> **Trap.** `--outfile` *does* exist for `jbmc` — it arrives via `OPT_SOLVER`
+> (`src/goto-checker/solver_factory.h:120`) and writes the **SAT/SMT formula**, not a
+> GOTO program. It is not an escape hatch.
+
 The C-mode `goto-instrument` in the same distribution cannot read `.class` files
-(`not a goto binary`). However, the CPROVER distribution ships **`symtab2gb`**, which
-compiles a JSON symbol table into a goto binary. That yields a working pipeline:
+(`not a goto binary`); it registers only C and C++ frontends
+(`src/goto-instrument/goto_instrument_languages.cpp:19-23`). However, the CPROVER
+distribution ships **`symtab2gb`**, which compiles a JSON symbol table into a goto
+binary. That yields a working pipeline:
 
 ```
 Test.java ──javac──> Test.class
-   └─ jbmc Test -cp .:/usr/lib/core-models.jar --no-lazy-methods \
+   └─ jbmc Test -cp .:<core-models.jar> --no-lazy-methods \
                 --show-symbol-table --json-ui                    ──> symtab.json
    └─ extract the {"symbolTable": …} element                     ──> st.json
    └─ symtab2gb st.json --out jbmc.goto                          ──> 0x7f 'G' 'B' 'F', v6
 ```
 
-The output header is byte-for-byte the format ESBMC's reader targets:
+**This pipeline was independently re-run in Run 2** on cbmc 6.8.0/macOS with a different
+corpus, and works end to end: `symtab2gb` exits 0 and emits a 768 KiB binary whose header
+is
 
 ```
-00000000: 7f47 4246 06a9 0100 3e65 6d70 7479 004e   .GBF....>empty.N
+00000000: 7f47 4246 068c 0c00 8c01 7374 7275 6374  .GBF......struct
 ```
 
+i.e. `0x7f 'G' 'B' 'F'`, version **6** — byte-for-byte the format ESBMC's reader targets.
 `goto-instrument --show-goto-functions jbmc.goto` reads it back cleanly, and
 `goto-instrument --drop-unused-functions` rewrites a still-valid binary — so this is a
-genuinely shared format, not a JBMC-private dialect. Note the converse does **not** hold:
-`cbmc` in C mode on the same file dies with an invariant failure in `goto_symex.cpp`.
-Format-compatible is not the same as interchangeable.
+genuinely shared format, not a JBMC-private dialect.
+
+`GOTO_BINARY_VERSION` is defined once, in shared code
+(`src/goto-programs/write_goto_binary.h:15`), and was checked to be **6** at every 6.x
+release tag from 6.0.0 through 6.10.0. The format conclusion is therefore stable across
+the whole 6.x line, not just the two versions probed.
+
+Note the converse does **not** hold: `cbmc` in C mode on the same file dies with an
+invariant failure in `goto_symex.cpp`. This is expected rather than surprising — `cbmc`
+registers `ansi_c`, `statement_list`, `cpp` and `json_symtab`, but not `java_bytecode`
+(`src/cbmc/cbmc_languages.cpp:21-27`), so symbols carrying `mode == "java"` have no
+registered language handler (`src/langapi/mode.cpp:51`). **Format-compatible is not the
+same as interchangeable**, and ESBMC will need its own answer to the same `mode` question.
 
 **Both `--no-lazy-methods` and an explicit models classpath are load-bearing**, and the
-classpath matters more. JBMC loads classes on demand, and `core-models.jar` is *not*
-auto-loaded (there is no `--java-core-models` flag; the Ubuntu package merely drops it at
-`/usr/lib/core-models.jar`). Measured function counts for the same Java program:
+classpath matters more. JBMC loads classes on demand — lazy is the default,
+`options.set_option("lazy-methods", !cmd.isset("no-lazy-methods"))`
+(`jbmc/src/java_bytecode/java_bytecode_language.cpp:109`) — and `core-models.jar` is *not*
+auto-loaded. The classpath is built solely from `--classpath`/`--cp`/`-jar`/JSON config
+(`java_bytecode_language.cpp:296-299`): there is no default entry, no `CLASSPATH`
+environment fallback, no hardcoded models path, and no `--java-core-models` flag.
+(`--java-cp-include-files` is a regex *filter* over files to load, not a classpath adder.)
+Measured function counts for the same Java program (Run 1):
 
 | configuration | functions |
 |---|---|
@@ -81,7 +134,14 @@ auto-loaded (there is no `--java-core-models` flag; the Ubuntu package merely dr
 A ~48x spread. Any binary built without both flags silently omits method bodies, and any
 verdict from it is meaningful only relative to whatever happened to be on the classpath.
 
-### 2.2 ESBMC already reads a JBMC binary — structurally
+> **`core-models.jar` is not at a portable path.** Verified locations:
+> `/usr/lib/core-models.jar` in **Diffblue's release `.deb`** (`jbmc/CMakeLists.txt:32-38`
+> installs to `${CMAKE_INSTALL_LIBDIR}`); `/opt/homebrew/Cellar/cbmc/<version>/libexec/lib/core-models.jar`
+> on **Homebrew/macOS**. The **Ubuntu archive `jbmc` package is different from Diffblue's
+> `.deb` and ships no jar at all** — only `/usr/bin/jbmc` and a man page. The harness must
+> locate the jar, not assume it (§7).
+
+### 2.3 ESBMC already reads a JBMC binary — structurally
 
 Feeding the above to ESBMC:
 
@@ -95,25 +155,49 @@ ERROR: Unexpected side-effect statement: java_new_array
 ```
 
 This is a far better starting position than a blank sheet. The magic-byte dispatch
-(`goto_binary_reader.cpp:22-47`), the varint irep grammar, the symbol table, the
-function/instruction tables, and most of `cbmc_adapter`'s type and expression rewriting
-all worked on Java input without modification. Execution reaches
+(`src/goto-programs/goto_binary_reader.cpp:22-47`), the varint irep grammar, the symbol
+table, the function/instruction tables, and most of `cbmc_adapter`'s type and expression
+rewriting all worked on Java input without modification. Execution reaches
 `src/util/migrate.cpp:2098` — i.e. the failure is in *Java-specific irep vocabulary*,
 not in format or structure.
 
-Two defects observed in passing, both worth fixing regardless of this PoC:
+Two defects observed in passing, both worth fixing regardless of this PoC, and **both
+reproduced in Run 2** (exit code 134 = SIGABRT in each case):
 
 - ESBMC **crashes (SIGABRT/core dump)** on the unsupported construct rather than
-  exiting cleanly. The tree already has the right pattern for this — `expand_anon_struct`
-  throws a `std::string` caught in `goto_program.cpp:283-287`, pinned by the
-  `regression/goto-transcoder/cbmc_anon_aggregate` test.
+  exiting cleanly — `migrate.cpp:2098` logs the error and `migrate.cpp:2099` calls
+  `abort()`. The tree already has the right pattern for this: `expand_anon_struct`
+  throws a `std::string` (`cbmc_adapter.cpp:791-793` at `c3deaba546`) which is caught in
+  **`src/esbmc/parseoptions/goto_program.cpp:283-287`** — note the path, there is also an
+  unrelated `src/goto-programs/goto_program.cpp` whose lines 283-287 are successor
+  computation.
 - ESBMC also core-dumps *after* correctly printing `ERROR: 'x.goto' is not a
   goto-binary.` — a clean-error path that still aborts.
 
-### 2.3 The Java-specific surface is small and measurable
+> **Run 2 caveat on the diagnostic.** With a different corpus and a newer ESBMC, the first
+> blocker surfaced as a bare `ERROR: string` before the abort, rather than a message
+> naming the construct. Whether this is corpus-specific, branch-specific, or a genuine
+> regression in error reporting was not determined. Phase 1 depends on this diagnostic
+> being informative, so **confirming it on `master`/x86-64 is a Phase 0 task**, not an
+> assumption.
+
+### 2.4 Drift between `c3deaba546` and current `master`
+
+Recorded so a later reader does not mistake stale-but-correct citations for errors:
+
+- `regression/goto-transcoder/` held **131** fixtures at `c3deaba546`; **137** on master.
+- **The `cbmc_anon_aggregate` precedent has changed.** At `c3deaba546` its `test.desc`
+  expected `^ERROR: CBMC adapter: anonymous aggregate types are not yet supported` — it
+  genuinely pinned the graceful-error path. On master it expects
+  `^VERIFICATION SUCCESSFUL$`, i.e. anonymous aggregates are now *supported* and the test
+  no longer pins graceful failure. **Phase 1 and Phase 5 must therefore create their own
+  unsupported-construct fixture rather than copying a test that no longer demonstrates
+  the pattern.**
+
+### 2.5 The Java-specific surface is small and measurable
 
 Walking every irep in the symbol table of a Java program exercising inheritance,
-virtual dispatch, arrays, `instanceof`, and `try`/`catch`:
+virtual dispatch, arrays, `instanceof`, and `try`/`catch` (Run 1):
 
 | Construct | Kind | Occurrences |
 |---|---|---|
@@ -131,52 +215,91 @@ already handles: `signedbv`, `pointer`, `struct_tag`, `member`, `dereference`, `
 `block`, `code`, `constant`, `floatbv`. **No new number theory, no new memory model.**
 
 **Treat this table as a lower bound.** It was measured on a binary built *without*
-`core-models.jar` — i.e. the ~52-function configuration from §2.1, not the 2500-function
+`core-models.jar` — i.e. the ~52-function configuration from §2.2, not the 2500-function
 one. A full-models binary may well contain constructs this corpus never reached (JVM
 concurrency instrumentation, `java_super_method_call`, generics attributes, lambda method
 handles). Phase 1 exists precisely to replace this estimate with a measurement over the
 real configuration.
 
 Additional Java-specific ids exist in `src/util/irep_ids.def` upstream that the corpus did
-not exercise: `java_super_method_call`, `exception_list`, `exception_id`,
-`exception_landingpad`, `throw_decl`, the `C_java_generic*` family, and
-`java_lambda_method_handle*`. (`java_new_array_data` is not in this list — see §2.4,
-where it is the one construct that survives JBMC's lowering.)
+not exercise; all spellings verified against `develop`: `java_super_method_call` (:612),
+`exception_list` (:543), `exception_id` (:544), `exception_landingpad` (:616),
+`throw_decl` (:765), the four-member `C_java_generic*` family —
+`C_java_generic_parameter` (:692), `C_java_generics_class_type` (:693),
+`C_java_implicitly_generic_class_type` (:694), `C_java_generic_symbol` (:695) — and
+`java_lambda_method_handle{,_index,s}` (:700-702).
 
-### 2.4 The decisive finding: JBMC's own pipeline lowers most of it
+### 2.6 The decisive finding: JBMC's own pipeline lowers most of it
 
-`jbmc --show-goto-functions` reveals that JBMC's driver (`jbmc_parse_options.cpp`)
-unconditionally runs `remove_instanceof`, `remove_virtual_functions`, `remove_exceptions`,
-and `remove_java_new` before symex. Comparing what survives in each route (counts are
-word-boundary matched — a naive `grep -c java_new` substring-matches `java_new_array` and
-inflates the result):
+`jbmc --show-goto-functions` reveals that JBMC's driver (`jbmc_parse_options.cpp`) runs
+`remove_instanceof` (:691), `remove_virtual_functions` (:698) and `remove_java_new` (:730)
+unconditionally in `process_goto_function`, alongside `remove_returns` (:705),
+`replace_java_nondet` (:707) and `convert_nondet` (:710).
 
-| Construct | Route A (`symtab2gb`) | Route B (JBMC-internal, post-lowering) |
+**`remove_exceptions` is the exception to "unconditional", though the net effect is the
+same.** It runs at `:719` *only* when `using_symex_driven_loading`
+(`--symex-driven-lazy-loading`, set at `:688-689`); otherwise it runs in
+`process_goto_functions` at `:829`, which itself early-returns at `:826` when
+symex-driven loading is on. So it always runs exactly once, but **in one of two places,
+with different fidelity** — the in-function variant leaves dead catch sites behind
+(comment at `:712-715`). A PoC that relies on exception lowering must state which mode it
+measured.
+
+Comparing what survives in each route (counts are word-boundary matched — a naive
+`grep -c java_new` substring-matches `java_new_array` and inflates the result):
+
+| Construct | Route A (`symtab2gb`)<br>Run 1 / **Run 2** | Route B (post-lowering)<br>Run 1 / **Run 2** |
 |---|---|---|
-| `java_new` | 2 | **0** |
-| `java_new_array` | 11 | **0** |
-| `java_instanceof` | 1 | **0** |
-| `virtual_function` | 2 | **0** |
-| `CATCH` (`push`/`pop_catch`) | 4 | **0** |
-| `java_new_array_data` | 0 | 11 |
-| `side_effect statement="allocate"` | 2 | 15 |
+| `java_new` | 2 / **28** | 0 / **0** |
+| `java_new_array` | 11 / **11** | 0 / **0** |
+| `java_instanceof` | 1 / **38** | 0 / **0** |
+| `virtual_function` | 2 / **77** | 0 / **0** |
+| `CATCH` (`push`/`pop_catch`) | 4 / **2** | 0 / **0** |
+| `java_new_array_data` | 0 / **0** | 11 / **11** |
+| `side_effect statement="allocate"` | 2 / **24** | 15 / **68** |
+
+Absolute counts differ because the corpora differ; **the directional result replicates
+exactly across both runs, two cbmc versions, and two platforms**: every Java-specific
+construct in Route A goes to zero in Route B.
 
 `symtab2gb` performs goto-conversion only — it does **not** run the Java lowering passes,
-because those live in JBMC's driver, not in the symbol-table-to-GOTO tool.
+because those live in JBMC's driver, not in the symbol-table-to-GOTO tool. This is
+structural, not incidental: `symtab2gb`'s `register_languages()`
+(`src/symtab2gb/symtab2gb_parse_options.cpp:146-153`) registers only `json_symtab_language`
+and `ansi_c_language` — **the Java frontend is not linked into the binary at all**, so no
+amount of flag-tuning will make it lower Java.
 
 So JBMC's own lowering is more thorough than expected: it eliminates object *and* array
 allocation too, rewriting `java_new`/`java_new_array` into CBMC's generic
-`side_effect statement="allocate"`. The residual Java-specific surface is a single
-construct, **`java_new_array_data`**, plus the `allocate` side effect itself — which,
-despite being generic CPROVER vocabulary, ESBMC does **not** currently handle:
-`src/util/migrate.cpp:1937-1961` recognises `malloc`, `realloc`, `alloca`, `cpp_new`,
-`va_arg` but not `allocate`, and `cbmc_adapter.cpp` has no mapping for it (CBMC C-mode
-binaries reach ESBMC as `FUNCTION_CALL malloc`, which the adapter rewrites at
-`cbmc_adapter.cpp:1300-1303`). Class identifiers and Java array types are then plain
+`side_effect_exprt(ID_allocate, ...)` (`remove_java_new.cpp:100-105`, `:154-160`; the
+in-source comment reads "we produce a malloc side-effect, which stays").
+
+The residual Java-specific surface is a single construct, **`java_new_array_data`**, plus
+the `allocate` side effect itself.
+
+> **Framing correction.** `java_new_array_data` does not *survive* lowering — it is
+> **introduced by** it: `remove_java_new.cpp:240-241` constructs
+> `side_effect_exprt(ID_java_new_array_data, allocate_data_type, location)` for the array
+> payload. It then reaches symex and is interpreted natively there
+> (`src/goto-symex/goto_symex.cpp:76`, `src/goto-symex/symex_builtin_functions.cpp:502,522`).
+> The practical consequence is *stronger* than "one leftover construct": lowering does not
+> eliminate Java-specific vocabulary, it **substitutes** a construct whose semantics live
+> in CPROVER's symex, which ESBMC must therefore reimplement rather than inherit.
+
+`allocate` — despite being generic CPROVER vocabulary — ESBMC does **not** currently
+handle: the string `"allocate"` appears nowhere in `src/`. `src/util/migrate.cpp`
+dispatches side-effect statements in two places: a `#size` guard at :1936-1938 covering
+`malloc`, `realloc`, `alloca`, `va_arg`; and an `allockind` dispatch from :1953 covering
+`malloc`, `realloc`, `alloca`, `cpp_new`, `cpp_new[]`, `nondet`, `va_arg`,
+`function_call`, `printf`, `printf2`. Neither recognises `allocate`. `cbmc_adapter.cpp`
+has no mapping for it either — CBMC C-mode binaries instead reach ESBMC as
+`FUNCTION_CALL malloc`, which the adapter rewrites at `cbmc_adapter.cpp:1300-1303` via
+`build_mem_rhs` (`:1040-1067`). Class identifiers and Java array types are then plain
 structs.
 
-This reframes the whole PoC: **the cheap win is getting the lowered model out of JBMC,
-not teaching ESBMC to lower Java.** Two constructs, not seven.
+This reframes the PoC: **the cheap win is getting the lowered model out of JBMC, not
+teaching ESBMC to lower Java.** Two constructs, not seven — with the caveat above that
+one of the two carries symex-level semantics.
 
 ---
 
@@ -196,7 +319,7 @@ JVM semantics" rationale.
 Add a `--write-goto-binary <file>` to `jbmc`, dumping the goto model after its existing
 lowering passes. `write_goto_binary()` lives in *shared* `src/goto-programs/`, and
 `GOTO_BINARY_VERSION 6` is defined there once for all CPROVER tools — there is no
-Java-specific writer, and `grep -rn write_goto_binary jbmc/src/` returns nothing. So this
+Java-specific writer, and no `jbmc/` source file calls `write_goto_binary`. So this
 is plumbing, not new semantics — plausibly a few dozen lines upstream. ESBMC then needs
 only `allocate` + `java_new_array_data` plus Java struct-layout conventions.
 
@@ -204,9 +327,15 @@ only `allocate` + `java_new_array_data` plus Java struct-layout conventions.
 path for Phase 1.** Phase 1 below is deliberately route-agnostic so it delivers value
 before any upstream dependency resolves.
 
-A cheap hedge exists if upstream is slow: JBMC's lowering passes are ordinary CPROVER
-library calls, so a small out-of-tree driver (or a patched local JBMC build) can do
-load → lower → `write_goto_binary` without waiting for a merged flag.
+**Upstream dependency is the schedule risk, not the technical risk.** Route B's ESBMC-side
+work is small; its exposure is that a third-party maintainer must accept a flag on their
+schedule, and §8 Q1 is genuinely open. The hedge: JBMC's lowering passes are ordinary
+CPROVER library calls, so a small out-of-tree driver (or a patched local JBMC build) can
+do load → lower → `write_goto_binary` without waiting for a merged flag. **Phase 3 should
+build that driver first and open the upstream PR second**, so no phase of this PoC blocks
+on review latency. A permanently-unmerged flag degrades Route B to "requires a patched
+JBMC" — usable for a PoC, not for a shipped feature; that trade-off should be decided
+before any user-facing commitment.
 
 ---
 
@@ -215,29 +344,58 @@ load → lower → `write_goto_binary` without waiting for a merged flag.
 Each phase ends in a decision, not just an artefact. **Any phase may end the PoC**;
 that is a successful outcome if the blocker is named and evidenced.
 
+### 4.1 Success criteria
+
+The PoC is a **success** if Phase 2 exits green: T1–T3 corpus programs verify under
+`esbmc --binary`, with verdicts (SUCCESSFUL/FAILED per property) matching JBMC's on the
+same programs, and every divergence classified per §5.
+
+The PoC is an **informative failure** — still a valid outcome — if it terminates at any
+phase with a named, evidenced blocker plus a reproducer.
+
+It is a **failure** only if it terminates without either.
+
+**Soundness bar.** No verdict produced by this PoC may be reported as a verification
+result for a Java program unless the model-completeness question in §5 is answered for
+that program. Until then, all results are "ESBMC agrees with JBMC on this binary" — a
+statement about IR ingestion, not about Java. This distinction must appear in the
+Phase 5 write-up.
+
 ### Phase 0 — Reproducible harness (0.5 day)
 
-Script the §2.1 pipeline (`javac` → `jbmc` → extract → `symtab2gb`) plus the ESBMC
-invocation, so every later result is one command. Pin `jbmc`/`cbmc` version in the
-output. Add a corpus of ~8 Java programs in tiers: (T1) integer/boolean arithmetic and
-asserts, no allocation; (T2) arrays; (T3) objects and fields; (T4) inheritance and
-virtual calls; (T5) `try`/`catch`.
+Script the §2.2 pipeline (`javac` → `jbmc` → extract → `symtab2gb`) plus the ESBMC
+invocation, so every later result is one command. The harness must:
+
+- **Locate `core-models.jar` rather than hardcode it** (§2.2), and fail loudly if absent —
+  a missing jar silently produces a 50-function model, not an error.
+- Record `jbmc --version`, `cbmc --version`, the ESBMC commit, the JDK version, and the
+  resolved jar path into every output artefact.
+- **Confirm the §2.3 diagnostic still names the offending construct** on `master`/x86-64
+  before Phase 1 depends on it.
+
+Add a corpus of ~8 Java programs in tiers: (T1) integer/boolean arithmetic and asserts, no
+allocation; (T2) arrays; (T3) objects and fields; (T4) inheritance and virtual calls;
+(T5) `try`/`catch`. **Every tier must be string-free** (§5), and each program must carry
+both a passing and a failing property so verdict matching is falsifiable in both
+directions.
 
 *Exit:* one command produces a goto binary + an ESBMC verdict per corpus program.
 
 ### Phase 1 — Fail gracefully, then measure (1 day)
 
-Convert the `abort()` on unknown Java side effects into the existing throw/catch clean-exit
-pattern (`cbmc_adapter.cpp:791-793` + `goto_program.cpp:283-287`), and fix the
-core-dump-after-clean-error path from §2.2. Then run the whole corpus and record, per
-program, the *first* unsupported construct.
+Convert the `abort()` at `migrate.cpp:2098-2099` on unknown Java side effects into the
+existing throw/catch clean-exit pattern (`cbmc_adapter.cpp:791-793` →
+`src/esbmc/parseoptions/goto_program.cpp:283-287`), and fix the core-dump-after-clean-error
+path from §2.3. Add a fixture pinning the new graceful-error message — **do not reuse
+`cbmc_anon_aggregate`, which no longer pins that behaviour** (§2.4). Then run the whole
+corpus and record, per program, the *first* unsupported construct.
 
 This is the single highest-value phase: it converts "ESBMC crashes on Java" into a
 ranked, evidence-backed work-list, and it is useful to the CBMC roadmap independently
 of Java.
 
 *Exit:* a table of constructs ranked by how many corpus programs each blocks.
-**Decision point:** if the list is dominated by constructs outside §2.3 — i.e. the
+**Decision point:** if the list is dominated by constructs outside §2.5 — i.e. the
 simple corpus was misleading — reassess scope before writing any adapter code.
 
 ### Phase 2 — allocation side effects (2–3 days)
@@ -245,9 +403,14 @@ simple corpus was misleading — reassess scope before writing any adapter code.
 Map CBMC's `side_effect statement="allocate"` and Java's `java_new_array_data` onto
 ESBMC `sideeffect` allocation, following the `malloc`/`alloca` precedent in
 `cbmc_adapter.cpp:1040-1067` and extending the statement dispatch at
-`src/util/migrate.cpp:1937-1961`. Array allocation additionally carries a length operand
+`src/util/migrate.cpp:1953+`. Array allocation additionally carries a length operand
 and JBMC's own `array-create-negative-size` check (already present as a plain assertion
 in the binary — ESBMC should inherit it, not re-derive it).
+
+**`java_new_array_data` is the harder half** and should be scheduled first, not second:
+per §2.6 its semantics live in CPROVER's `symex_builtin_functions.cpp`, so this is not a
+vocabulary mapping but a behavioural port. If it does not fit the `sideeffect` model in
+~1 day, that is a Phase 2 decision point, not an overrun.
 
 `allocate` is worth doing on its own merits: it is generic CPROVER vocabulary that any
 `goto-instrument`-lowered binary may contain, so this benefits the CBMC roadmap too.
@@ -260,31 +423,58 @@ dispatch, `instanceof`, and exceptions for free.
 **This is the PoC's minimum publishable result:** it demonstrates the whole chain works
 on real Java.
 
-### Phase 3 — Route B upstream (parallel, 2–3 days + review latency)
+### Phase 3 — Route B (parallel, 2–3 days + review latency)
 
-Prototype `jbmc --write-goto-binary`, confirm the emitted binary is lowered as §2.4
-predicts, and re-run the corpus through it. Open an upstream PR against `diffblue/cbmc`.
+Build the out-of-tree lowering driver **first** (load → lower → `write_goto_binary`),
+confirm the emitted binary is lowered as §2.6 predicts, and re-run the corpus through it.
+*Then* open an upstream PR against `diffblue/cbmc` for `jbmc --write-goto-binary`. Record
+which `remove_exceptions` mode was measured (§2.6).
 
 *Exit:* T4/T5 (virtual dispatch, exceptions) verify through the lowered route with no
-further ESBMC adapter work — or a concrete statement of what still fails.
+further ESBMC adapter work — or a concrete statement of what still fails. Upstream merge
+is explicitly **not** an exit criterion.
 
 ### Phase 4 — Java runtime models (spike only, 1 day)
 
-Partly answered already by §2.1: models arrive in the binary **only** if `core-models.jar`
+Partly answered already by §2.2: models arrive in the binary **only** if `core-models.jar`
 is put on the classpath explicitly, and doing so with `--no-lazy-methods` inflates the
 model to ~2500 functions. Two things remain to determine:
 
 - **Scale.** Is a 2500-function goto binary tractable for ESBMC's symex at all? This is
-  the practical gate on non-trivial Java, and it is cheap to measure.
-- **Coverage.** `core-models.jar` is narrower than its name suggests — 91 classes, mostly
-  `java.lang`; `java.util` collections are essentially unmodelled. Unmodelled library
-  methods become bodyless stubs, so a corpus touching collections is verifying against
-  nothing.
+  the practical gate on non-trivial Java, and it is cheap to measure. Record wall-clock
+  and peak RSS, not just pass/fail.
+- **Coverage.** `core-models.jar` is narrower than its name suggests. The shipped jar
+  contains **exactly 91 class entries** (85 top-level, 6 inner): 77 in `java/lang/`, 10 in
+  `java/lang/reflect/`, 3 `sun/misc/`, 3 `org/sosy_lab/sv_benchmarks/`, 3
+  `java/util/regex/`, and **exactly two in `java/util/` — of which the only
+  collection-adjacent class is `Random`**. No `ArrayList`, `HashMap`, `LinkedList`,
+  `List`, `Map`, `Set`, `Collection`, or `Iterator`. Unmodelled library methods become
+  bodyless stubs, so a corpus touching collections is verifying against nothing.
 
-**`java.lang.String` is a special case and a genuine risk.** It is not modelled by the JAR
-at all — JBMC handles it via `java_string_library_preprocess.cpp` and CBMC's **string
-refinement solver**. ESBMC has no string-refinement backend, so string-heavy Java may be
-out of reach through this route regardless of how well IR ingestion works. Establish
+  > **Do not check this against the `java-models-library` repo's current HEAD.** That HEAD
+  > *does* contain `ArrayList.java`, `HashMap.java`, `LinkedList.java` and more. CBMC pins
+  > a 2022 submodule commit (`c7835345`) which does not, and the **shipped jar is what
+  > matters**. Inspect the jar, not the repo.
+
+**`java.lang.String` is a special case and a genuine risk.**
+
+> **Corrected from the original plan, which stated String is "not modelled by the JAR at
+> all". That is false as literally written.** `java/lang/String.class` *is* in
+> `core-models.jar` (22,469 bytes), alongside `StringBuilder`, `StringBuffer`,
+> `AbstractStringBuilder` and `CharSequence`. But it is a **thin shim, not an
+> implementation**: the 4,401-line source references `org.cprover.CProverString` 71 times.
+> Real semantics come from `jbmc/src/java_bytecode/java_string_library_preprocess.cpp`,
+> which maps `CProverString.*` signatures onto `ID_cprover_string_*` primitives, and from
+> CBMC's **string refinement solver** — which `jbmc` enables **by default**
+> (`jbmc_parse_options.cpp:98` sets `refine-strings` true; the opt-*out* is
+> `--no-refine-strings`).
+
+The risk is unchanged and arguably sharper: the presence of a String model in the jar is
+misleading, because the model delegates to a solver ESBMC does not have. ESBMC has no
+string-refinement backend (`string_refinement`, `string_constraint` and `refine_string`
+have zero hits in `src/`), so string-heavy Java is out of reach through this route
+regardless of how well IR ingestion works. **A binary built with string models present
+will ingest and produce verdicts — those verdicts are not trustworthy.** Establish
 whether the corpus can avoid strings, and if not, say so plainly.
 
 *Exit:* a scale number, a coverage statement, and a yes/no on strings. **Do not build a
@@ -293,11 +483,32 @@ linking mechanism in this PoC.**
 ### Phase 5 — Report and regression fixtures (1 day)
 
 Land whatever works as `regression/goto-transcoder/`-style fixtures — checked-in `.goto`
-binaries with `test.desc`, matching the 131 existing CBMC fixtures, including negative
-`_fail` variants and an unsupported-construct test pinning the graceful-error message
-(the `cbmc_anon_aggregate` pattern). Write up the verdict.
+binaries with `test.desc`, matching the existing CBMC fixtures, including negative
+`_fail` variants and a **new** unsupported-construct test pinning the graceful-error
+message (§2.4). Write up the verdict, including the soundness statement from §4.1.
 
 **Budget: ~7 working days plus upstream review latency**, with a go/no-go after Phase 1.
+The estimate assumes no Phase-2 overrun on `java_new_array_data`; §7 records the
+assumptions the budget rests on.
+
+### 4.2 Testing and maintenance
+
+- **Fixture durability.** Checked-in `.goto` binaries are opaque and version-locked. They
+  are pinned to `GOTO_BINARY_VERSION 6`, which has held across 6.0.0–6.10.0 (§2.2), so the
+  near-term risk is low — but a version 7 would invalidate every fixture at once. Each
+  fixture must record the `jbmc` version that produced it, and the harness (Phase 0) must
+  be able to regenerate them from source, so a bump is a re-run rather than an
+  archaeology exercise.
+- **CI cost.** Java fixtures require a JDK and a `core-models.jar` on the runner. If Java
+  fixtures are gated behind a build flag as the jimple frontend is, state which flag; if
+  they run unconditionally, the JDK becomes a CI dependency. Decide in Phase 5, not later.
+- **Relationship to `src/jimple-frontend/`.** This route does not replace it, and no
+  deprecation is proposed here. If the PoC succeeds, "two Java routes, both partial" is a
+  maintenance question that needs an owner and an explicit decision.
+- **Upstream tracking.** Route B ties ESBMC to CPROVER internals (`remove_java_new`'s
+  choice of `ID_allocate`, `java_new_array_data`'s symex semantics). These are not a
+  stable API. Breakage will show up as ingestion failures on a new `jbmc` release; the
+  Phase 0 harness is what makes that cheap to diagnose.
 
 ---
 
@@ -305,22 +516,35 @@ binaries with `test.desc`, matching the 131 existing CBMC fixtures, including ne
 
 Stated in advance so the PoC can honestly fail:
 
-- **Model completeness cannot be established.** §2.1 shows the model size swings 50→2500
+- **Model completeness cannot be established.** §2.2 shows the model size swings 50→2500
   functions on flags alone. If we cannot state confidently that a given binary contains
   every method the program reaches, every verdict is relative to an unknown classpath and
-  the whole exercise is unsound. This is the most serious risk.
+  the whole exercise is unsound. This is the most serious risk, because it fails
+  *silently* — a short model produces a clean SUCCESSFUL, not an error.
 - **Scale.** If ESBMC's symex cannot handle a 2500-function model in reasonable time, the
   route works only for programs that touch almost no library code.
-- **Strings.** JBMC delegates `java.lang.String` to CBMC's string refinement solver, which
-  ESBMC does not have. If the corpus cannot avoid strings, this is a hard stop for a large
-  class of real Java, independent of everything else in this plan.
+- **Strings.** JBMC delegates `java.lang.String` to CBMC's string refinement solver, on by
+  default, which ESBMC does not have. If the corpus cannot avoid strings, this is a hard
+  stop for a large class of real Java, independent of everything else in this plan.
 - **`java.util` is unmodelled.** Collections-using code verifies against bodyless stubs.
+- **`java_new_array_data` needs symex-level work.** If porting CPROVER's symex handling
+  (§2.6) rather than mapping a side effect turns out to be the real Phase 2 cost, the
+  "two constructs" framing understates the work.
 - **Java struct conventions leak everywhere.** If `@class_identifier` / `java::array[T]`
   layouts turn out to need special handling across the adapter rather than being plain
   structs, the "reuse the CBMC reader" premise weakens.
+- **`mode == "java"` symbols.** `cbmc` fails on JBMC binaries partly because it has no
+  handler for Java-mode symbols (§2.2). ESBMC must answer the same question; if the answer
+  requires a language handler, "no Java frontend" is harder to hold.
 - **Verdict divergence.** If ESBMC and JBMC disagree on corpus programs, the *reason*
   matters more than the count: a JVM-semantics gap is a no; a known ESBMC pointer-model
   difference is a tracked bug.
+
+### Risks accepted without mitigation in this PoC
+
+Named so they are not mistaken for oversights: JVM concurrency, reflection, generics,
+`invokedynamic`/lambdas, and performance are all out of scope (§6). Any of them appearing
+in the Phase 1 work-list is a scope signal, not a task.
 
 ---
 
@@ -328,14 +552,22 @@ Stated in advance so the PoC can honestly fail:
 
 Not a Java frontend. No `.class`/`.jar` parsing in ESBMC. No replacement of, or
 integration with, `src/jimple-frontend/`. No JVM concurrency, reflection, generics, or
-`invokedynamic`/lambdas. No performance work.
+`invokedynamic`/lambdas. No performance work. No string-refinement backend.
 
 ---
 
 ## 7. Reproducing the §2 probes
 
+Portable across the distributions in §2.2. Run 2 executed the first block on cbmc 6.8.0 /
+macOS / aarch64.
+
 ```sh
-MODELS=/usr/lib/core-models.jar
+# Locate the models jar rather than assuming a path (see §2.2).
+MODELS=$(ls /usr/lib/core-models.jar \
+            /opt/homebrew/Cellar/cbmc/*/libexec/lib/core-models.jar 2>/dev/null | head -1)
+[ -n "$MODELS" ] || { echo "core-models.jar not found; results would be meaningless"; exit 1; }
+jbmc --version; cbmc --version; esbmc --version
+
 javac Test.java
 jbmc Test -cp .:$MODELS --no-lazy-methods --show-symbol-table --json-ui > symtab.json
 python3 -c "import json;d=json.load(open('symtab.json'));\
@@ -343,17 +575,17 @@ json.dump([e for e in d if 'symbolTable' in e][0], open('st.json','w'))"
 symtab2gb st.json --out jbmc.goto
 xxd jbmc.goto | head -1                       # expect: 7f47 4246 06…
 goto-instrument --show-goto-functions jbmc.goto | head    # round-trip sanity
-esbmc --binary jbmc.goto --goto-functions-only
+esbmc --binary jbmc.goto --goto-functions-only; echo "exit=$?"   # expect 134 (SIGABRT) today
 
-# Model size vs flags (§2.1) — expect roughly 50 / 52 / 72 / 2500
+# Model size vs flags (§2.2) — expect roughly 50 / 52 / 72 / 2500
 for cp in "-cp ." "-cp .:$MODELS"; do for lz in "" "--no-lazy-methods"; do
   printf '%-42s %s\n' "$cp $lz" "$(jbmc Rich $cp $lz --list-goto-functions 2>/dev/null | wc -l)"
 done; done
 
-# Route A vs Route B construct survival (§2.4).
+# Route A vs Route B construct survival (§2.6).
 # -oE with \b is required: a plain `grep -c java_new` also matches java_new_array.
-jbmc Rich --no-lazy-methods --show-goto-functions > routeB.txt
-goto-instrument --show-goto-functions rich.goto > routeA.txt
+jbmc Rich -cp .:$MODELS --no-lazy-methods --show-goto-functions > routeB.txt
+goto-instrument --show-goto-functions jbmc.goto > routeA.txt
 for k in 'java_new\b' 'java_new_array\b' 'java_new_array_data\b' \
          'java_instanceof\b' 'virtual_function\b' 'CATCH' 'statement="allocate"'; do
   printf '%-26s A=%-3s B=%s\n' "$k" \
@@ -361,22 +593,49 @@ for k in 'java_new\b' 'java_new_array\b' 'java_new_array_data\b' \
 done
 ```
 
+`Rich.java` is the §2.5 corpus program: a single file exercising inheritance, virtual
+dispatch, arrays, `instanceof`, and `try`/`catch`, and **no strings**. Phase 0 checks it
+in alongside the harness; until then the absolute counts above are not reproducible from
+this document alone — only the Route A → Route B *direction* is.
+
+**Run 2 alternative with no JDK.** The pipeline can be exercised without compiling
+anything by using a class already inside the models jar, which is how the replication in
+§2.2/§2.6 was performed:
+
+```sh
+jbmc java.lang.Integer -cp $MODELS --show-symbol-table --json-ui > symtab.json
+```
+
+### Assumptions the ~7-day budget rests on
+
+1. Phase 2's `java_new_array_data` work fits the existing `sideeffect` model (§2.6 flags
+   this as the likeliest overrun).
+2. The Phase 1 diagnostic names the offending construct (§2.3 Run 2 caveat).
+3. A string-free corpus is achievable at every tier (§5).
+4. Phase 3's out-of-tree driver is written before, and independently of, upstream review.
+
 ---
 
 ## 8. Open questions for upstream
 
 1. Would `diffblue/cbmc` accept a `jbmc --write-goto-binary` flag? (No such writer exists
-   in `jbmc/src/` today, and `--outfile` is the SMT/DIMACS formula, not GOTO — an easy trap.)
+   in `jbmc/` today, and `--outfile` is the SMT/DIMACS formula, not GOTO — an easy trap.)
 2. Is `symtab2gb` on JBMC symbol tables a supported use, or an accident that may break?
+   It works empirically on 6.5.0 and 6.8.0, but `symtab2gb` does not link the Java
+   frontend (§2.6), so the input is arguably outside its intended domain.
 3. Is there a recommended way to state, for a given binary, that class loading was
    complete for the program's reachable set — or is classpath discipline the only answer?
+   (§5 treats this as the PoC's most serious soundness risk.)
+4. Is `remove_java_new`'s lowering to `ID_allocate` + `ID_java_new_array_data` a stable
+   contract, or an implementation detail that may change? Route B's ESBMC-side work
+   depends on it.
 
 ### Version note
 
-Probes were run against locally installed `jbmc`/`cbmc` **6.5.0**; upstream `develop` is at
-**6.10.0**. `GOTO_BINARY_VERSION` is **6** in both, so the format conclusions hold, but
-Phase 0 should re-confirm the construct inventory against a current build before any
-upstream PR is opened.
+Run 1 probed `jbmc`/`cbmc` **6.5.0**; Run 2 replicated on **6.8.0**; upstream `develop` is
+at **6.10.0**. `GOTO_BINARY_VERSION` is **6** at every 6.x release tag from 6.0.0 through
+6.10.0, so the format conclusions hold across the line. Phase 0 should still re-confirm
+the construct inventory against a current build before any upstream PR is opened.
 
 ---
 
@@ -388,10 +647,20 @@ upstream PR is opened.
 - L. Cordeiro, D. Kroening, P. Schrammel, "JBMC: Bounded Model Checking for Java Bytecode
   (Competition Contribution)", TACAS 2019, LNCS 11429, pp. 219–223
   ([doi:10.1007/978-3-030-17502-3_17](https://doi.org/10.1007/978-3-030-17502-3_17)).
+- R. Brenguier, L. Cordeiro, D. Kroening, P. Schrammel, "JBMC: A Bounded Model Checking
+  Tool for Java Bytecode", arXiv:2302.02381 (2023)
+  ([doi:10.48550/arXiv.2302.02381](https://doi.org/10.48550/arXiv.2302.02381)). An
+  extended technical report; **arXiv preprint, not peer-reviewed** — no DBLP record beyond
+  the CoRR entry. Note the author list differs from the CAV 2018 paper (adds Brenguier,
+  drops Kesseli and Trtík); it is not a substitute citation for it.
 
-Both describe JBMC's architecture and Java operational model. Neither documents lazy class
-loading — for that behaviour the source is authoritative
-(`jbmc/src/java_bytecode/lazy_goto_model.h`), as are `jbmc/src/java_bytecode/README.md` for
-exception lowering and [diffblue/java-models-library](https://github.com/diffblue/java-models-library)
-for `core-models.jar`. Note that <https://diffblue.github.io/cbmc/> documents CBMC/C only
-and has no Java section; JBMC documentation is effectively in-repo.
+All three describe JBMC's architecture and Java operational model. **None of the three
+documents lazy class loading or goto-binary output** — verified by full-text search of
+each. For those behaviours the source is authoritative
+(`jbmc/src/java_bytecode/lazy_goto_model.h`, `java_bytecode_language.cpp:109`), as is
+`jbmc/src/java_bytecode/README.md` (887 lines; exception lowering at :467-510,
+`java_new_array_data` example at :439) and
+[diffblue/java-models-library](https://github.com/diffblue/java-models-library) for
+`core-models.jar` — subject to the pinned-commit caveat in Phase 4. Note that
+<https://diffblue.github.io/cbmc/> documents CBMC/C only and has no Java section; JBMC
+documentation is effectively in-repo.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #6173. A technical review of `docs/jbmc-goto-binary-poc-plan.md` against upstream sources, followed by a revision correcting four factual errors and seven smaller ones, and adding the sections a PoC plan needs to be falsifiable (success criteria, soundness bar, testing/maintenance, budget assumptions).

**No change of direction.** The plan's central finding — that JBMC's own lowering passes eliminate nearly all Java-specific IR, so the cheap path is extracting the lowered model rather than reimplementing lowering in ESBMC — replicated independently and is now better evidenced. Route B remains the recommendation.

## Review methodology

1. **Upstream source verification** against `diffblue/cbmc` `develop` @ `ff8e1122feffbe0c067b88a9ce44840a99a99428` (6.10.0) — every cited CPROVER file, flag, irep id, and lowering pass read at source.
2. **ESBMC source verification at the doc's pinned commit `c3deaba546`**, not `master`. This mattered: several citations look wrong against `master` but are correct as pinned. Drift is now recorded in a new §2.4 rather than silently restated.
3. **Independent probe replication (Run 2)** on `jbmc`/`cbmc` **6.8.0** / macOS / aarch64, with a different corpus (classes from `core-models.jar`, no JDK required) — deliberately varying version, platform, and corpus to test whether the conclusions were artefacts of the original setup.
4. **Citation verification** of all references against DBLP and full paper text.

## Key issues identified

**Major**

- **`java.lang.String` claim was false.** The plan stated String is "not modelled by the JAR at all". `String.class` *is* in `core-models.jar` (22,469 bytes), as are `StringBuilder`/`StringBuffer`/`CharSequence`. It is a shim referencing `org.cprover.CProverString` 71 times. Also corrected: string refinement is **on by default** in `jbmc` (`--no-refine-strings` to disable), not opt-in. The risk conclusion is unchanged and arguably sharper — the model's presence is misleading precisely because it delegates to a solver ESBMC lacks.
- **`java_new_array_data` framing was backwards.** It does not *survive* lowering; it is **introduced by** `remove_java_new` (`remove_java_new.cpp:240-241`) and interpreted natively in CPROVER's symex (`symex_builtin_functions.cpp:502,522`). Lowering **substitutes** Java vocabulary rather than eliminating it. This makes Phase 2 a behavioural port rather than a vocabulary mapping — the likeliest source of budget overrun, now flagged as such.
- **`remove_exceptions` is not unconditional.** It runs at `jbmc_parse_options.cpp:719` only under `--symex-driven-lazy-loading`, otherwise at `:829`, and the two paths differ in fidelity (the in-function variant leaves dead catch sites). Net effect is "exactly once", but a PoC relying on exception lowering must say which mode it measured.
- **`core-models.jar` is not at a portable path.** `/usr/lib/core-models.jar` is **Diffblue's release `.deb`**; the **Ubuntu archive `jbmc` package ships no jar at all**; Homebrew/macOS puts it under `/opt/homebrew/Cellar/cbmc/<version>/libexec/lib/`. §7 as written did not run outside the original environment.

**Minor**

- Jimple frontend has **15** regression tests, not 10 (true at both commits — not drift).
- `goto_program.cpp:283-287` is ambiguous: the catch is in `src/esbmc/parseoptions/goto_program.cpp`; the same lines in `src/goto-programs/goto_program.cpp` are unrelated successor computation.
- The `migrate.cpp` recognised-statement list omitted `cpp_new[]`, `nondet`, `function_call`, `printf`, `printf2`. The "but not `allocate`" conclusion stands — `"allocate"` appears nowhere in `src/`.
- **The `cbmc_anon_aggregate` precedent has changed on `master`**: its `test.desc` now expects `^VERIFICATION SUCCESSFUL$` rather than the graceful-error message it pinned at `c3deaba546`. Phase 1 can no longer copy it and must create its own fixture. Called out explicitly.
- `C_java_generic*` has four members, not three.
- §7's script referenced an undefined `Rich.java`, so it was not runnable from the document alone.
- arXiv:2302.02381 — the most detailed JBMC description — was uncited.

## Claims independently confirmed (Run 2)

Worth recording, since these carry the argument:

- The `symtab2gb` pipeline works end to end on 6.8.0: exit 0, header `7f47 4246 06` — `0x7f 'G' 'B' 'F'` v6.
- **Both §2.3 defects reproduce**: exit 134 (SIGABRT) on the JBMC binary, and exit 134 *after* correctly printing `is not a goto-binary`.
- **The Route A → Route B lowering result replicates exactly** across two cbmc versions, two platforms, and two corpora: `java_new`, `java_new_array`, `java_instanceof`, `virtual_function` and `CATCH` all go to **0**; `java_new_array_data` 0 → 11. Absolute counts differ (corpus-dependent); the direction does not.
- `GOTO_BINARY_VERSION` is **6** at every 6.x tag from 6.0.0 through 6.10.0 — a stronger claim than the original two-version check.
- `"allocate"` has zero occurrences in ESBMC `src/`; ESBMC has no string-refinement backend (`string_refinement`, `string_constraint`, `refine_string` — zero hits).
- Both original citations **VERIFIED**: title verbatim, authors, venue, pages and DOI all correct, and both genuinely support the claim made. Neither documents lazy class loading, exactly as stated.

## Improvements implemented

- **New §2.1 provenance table** distinguishing Run 1 from Run 2, so corpus-dependent absolute counts are never mistaken for reproducible constants.
- **New §2.4** recording drift between `c3deaba546` and `master` (131 → 137 fixtures; the `cbmc_anon_aggregate` change).
- **New §4.1 success criteria** with three outcomes (success / informative failure / failure) and a **soundness bar**: no verdict may be reported as a Java verification result until model completeness is established for that program. Until then results are "ESBMC agrees with JBMC on this binary" — a statement about IR ingestion, not about Java.
- **New §4.2 testing and maintenance**: fixture durability under a hypothetical `GOTO_BINARY_VERSION` bump, CI cost of a JDK dependency, the unresolved relationship to `src/jimple-frontend/`, and upstream-API tracking.
- **Phase 3 resequenced** — build the out-of-tree lowering driver *first*, open the upstream PR *second*, so no phase blocks on third-party review latency. Upstream merge is explicitly not an exit criterion.
- **§7 made portable**: locates the models jar instead of hardcoding it, fails loudly when absent (a missing jar silently yields a 50-function model, not an error), records all tool versions, and documents the no-JDK replication route.
- **Budget assumptions stated as falsifiable premises** rather than left implicit.
- Scope of the "Java frontend for free" claim bounded to *IR ingestion* — solver-side semantics such as string refinement do not transfer with the binary.
- New §8 Q4: is `remove_java_new`'s lowering to `ID_allocate` + `ID_java_new_array_data` a stable contract or an implementation detail?

## References consulted

- `diffblue/cbmc` @ `ff8e1122` (6.10.0) — `jbmc_parse_options.{h,cpp}`, `java_bytecode_language.{h,cpp}`, `remove_java_new.cpp`, `java_string_library_preprocess.cpp`, `symtab2gb_parse_options.cpp`, `write_goto_binary.h`, `irep_ids.def`, `cbmc_languages.cpp`, `goto_instrument_languages.cpp`, `jbmc/src/java_bytecode/README.md`
- `diffblue/java-models-library` @ pinned submodule `c7835345`, and the shipped jar from `ubuntu-24.04-cbmc-6.10.0-Linux.deb`
- Cordeiro, Kesseli, Kroening, Schrammel, Trtík, *JBMC: A Bounded Model Checking Tool for Verifying Java Bytecode*, CAV 2018, LNCS 10981, pp. 183–190, doi:10.1007/978-3-319-96145-3_10 — **verified**
- Cordeiro, Kroening, Schrammel, *JBMC: Bounded Model Checking for Java Bytecode (Competition Contribution)*, TACAS 2019, LNCS 11429, pp. 219–223, doi:10.1007/978-3-030-17502-3_17 — **verified**
- Brenguier, Cordeiro, Kroening, Schrammel, *JBMC: A Bounded Model Checking Tool for Java Bytecode*, arXiv:2302.02381 (2023) — **newly cited, flagged as a preprint** with a different author list from the CAV paper

## Remaining risks, assumptions and open questions

- **Unresolved (now a Phase 0 task, not an assumption).** In Run 2 the first blocker surfaced as a bare `ERROR: string` before the abort, rather than a message naming the construct. Whether that is corpus-specific, branch-specific (Run 2's ESBMC was a feature branch on aarch64), or a genuine regression in error reporting was **not determined**. Phase 1's entire value depends on that diagnostic being informative, so it must be confirmed on `master`/x86-64 first.
- **Not empirically re-verified**: that `cbmc` in C mode fails on a JBMC binary. The language-registration evidence (`cbmc_languages.cpp:21-27` registers no `java_bytecode`) makes it well-founded, and the doc now gives that mechanism rather than resting on the observed invariant failure alone.
- **Run 2 used no JDK**, so the `javac`-fronted path and the 50/52/72/2500 function-count table were not re-measured — only the `symtab2gb` and lowering-comparison stages were.
- **Model completeness remains the PoC's most serious risk**, unchanged from the original. It fails *silently*: an incomplete model yields a clean `SUCCESSFUL`, not an error. §8 Q3 asks upstream whether anything better than classpath discipline exists.
- **Phase 2's estimate is the one most likely to move**, for the `java_new_array_data` reason above.
