### PR TITLE
[scripts] add the JBMC PoC pipeline harness

### DIFF
--- a/docs/jbmc-goto-binary-poc-plan.md
+++ b/docs/jbmc-goto-binary-poc-plan.md
@@ -437,9 +437,25 @@ JDK).
 The ~8-program tiered corpus is **not** landed: it cannot be compiled, and
 therefore cannot be validated, without a JDK. Checking in unvalidated `.java`
 files — or opaque `.class` files — was rejected in favour of leaving the gap
-explicit. Note that `command -v javac` is not a usable JDK probe on macOS,
-which ships a stub that exists on PATH and exits 0 while reporting no runtime;
-the harness matches the version string instead.
+explicit.
+
+Scope of validation: the `--class` route is exercised end to end; the
+`--source` route is **untested**, since it needs the same absent JDK. Two
+traps found while building it are worth recording. `command -v javac` is not a
+usable JDK probe on macOS, which ships a stub that exists on PATH and exits 0
+while reporting no runtime — match the version string instead. And an empty
+bash array expanded under `set -u` aborts on bash 3.2 (stock on macOS) but not
+on bash 5, so a Linux CI run will not catch it; `${A[@]+"${A[@]}"}` is
+required.
+
+The manifest records the symbol count, which is the direct measurement of the
+§2.2 completeness risk (16463 symbols for `java.lang.Integer` with
+`--no-lazy-methods` against `core-models.jar`, 1548 without). `MIN_SYMBOLS`
+enforces a floor when the caller knows what to expect; there is no defensible
+universal value, so it is opt-in rather than guessed. The ESBMC *commit* is not
+recorded — `esbmc --version` does not carry one — so the manifest records the
+resolved binary path instead, which at least distinguishes a build-tree binary
+from a packaged one.
 
 ### Phase 1 — Fail gracefully, then measure (1 day)
 

--- a/docs/jbmc-goto-binary-poc-plan.md
+++ b/docs/jbmc-goto-binary-poc-plan.md
@@ -426,6 +426,21 @@ directions.
 
 *Exit:* one command produces a goto binary + an ESBMC verdict per corpus program.
 
+**Status: harness landed, corpus outstanding.** `scripts/jbmc-poc-pipeline.sh`
+implements the pipeline half — jar discovery (fatal when absent or mis-set),
+`--no-lazy-methods`, symbol-table extraction, `symtab2gb`, the ESBMC run, and a
+`manifest.txt` recording jbmc/cbmc/ESBMC versions, the ESBMC source commit, the
+resolved jar, the goto header bytes and the verdict. It accepts either a class
+from `core-models.jar` (the no-JDK route) or a `--source File.java` (needs a
+JDK).
+
+The ~8-program tiered corpus is **not** landed: it cannot be compiled, and
+therefore cannot be validated, without a JDK. Checking in unvalidated `.java`
+files — or opaque `.class` files — was rejected in favour of leaving the gap
+explicit. Note that `command -v javac` is not a usable JDK probe on macOS,
+which ships a stub that exists on PATH and exits 0 while reporting no runtime;
+the harness matches the version string instead.
+
 ### Phase 1 — Fail gracefully, then measure (1 day)
 
 Convert **both** abort sites into the existing throw/catch clean-exit pattern

--- a/scripts/jbmc-poc-pipeline.sh
+++ b/scripts/jbmc-poc-pipeline.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Run the JBMC -> goto-binary -> ESBMC pipeline described in
+# docs/jbmc-goto-binary-poc-plan.md §2.2, and record everything a later reader
+# needs to reproduce the result.
+#
+#   scripts/jbmc-poc-pipeline.sh --class java.lang.Integer
+#   scripts/jbmc-poc-pipeline.sh --source T1Arith.java --class T1Arith
+#
+# Every run writes <outdir>/manifest.txt with the tool versions, the resolved
+# models jar and the ESBMC verdict, because a verdict from this pipeline is
+# meaningful only relative to the classpath that produced the model (§2.2: the
+# function count swings ~48x on flags alone).
+
+set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# macOS ships a javac stub that exists on PATH and exits 0 while reporting "no
+# Java runtime" on stderr, so `command -v javac` is not a usable probe. Match
+# the version string instead.
+javac_version() {
+  local v
+  v=$(javac -version 2>&1 | head -1)
+  case "$v" in
+    javac\ *) echo "$v" ;;
+    *) echo "not present" ;;
+  esac
+}
+
+CLASS=""
+SOURCE=""
+OUTDIR="jbmc-poc-out"
+ESBMC="${ESBMC:-esbmc}"
+ESBMC_ARGS=()
+
+usage() {
+  cat >&2 <<EOF
+usage: $0 --class <fully.qualified.Class> [--source <File.java>]
+          [--outdir <dir>] [-- <extra esbmc args>]
+
+  --class   class to verify; required. Taken from core-models.jar unless
+            --source is given.
+  --source  Java source to compile first. Requires a JDK on PATH.
+  --outdir  where artefacts land (default: $OUTDIR).
+EOF
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --class)  CLASS="${2:-}"; shift 2 ;;
+    --source) SOURCE="${2:-}"; shift 2 ;;
+    --outdir) OUTDIR="${2:-}"; shift 2 ;;
+    --)       shift; ESBMC_ARGS=("$@"); break ;;
+    -h|--help) usage ;;
+    *) die "unknown argument '$1' (try --help)" ;;
+  esac
+done
+
+[ -n "$CLASS" ] || usage
+
+for tool in jbmc cbmc symtab2gb python3; do
+  command -v "$tool" >/dev/null || die "'$tool' not found on PATH"
+done
+command -v "$ESBMC" >/dev/null || die "esbmc not found (set ESBMC=/path/to/esbmc)"
+
+# core-models.jar is not at a portable path and is never loaded by default
+# (§2.2). Without it jbmc silently emits a ~50-function model instead of
+# failing, so an unfound jar has to be fatal rather than a warning.
+MODELS="${CORE_MODELS_JAR:-}"
+if [ -z "$MODELS" ]; then
+  for candidate in \
+      /usr/lib/core-models.jar \
+      /opt/homebrew/Cellar/cbmc/*/libexec/lib/core-models.jar \
+      /usr/local/Cellar/cbmc/*/libexec/lib/core-models.jar \
+      /usr/lib/cbmc/core-models.jar; do
+    [ -f "$candidate" ] && { MODELS="$candidate"; break; }
+  done
+fi
+# Validate the path itself, not just that one was chosen: a typo'd
+# CORE_MODELS_JAR would otherwise reach jbmc, which loads what it can and
+# reports success on a model missing most of its method bodies.
+[ -n "$MODELS" ] || die "core-models.jar not found; a model built without it \
+is ~50 functions and any verdict from it is meaningless (see plan §2.2). \
+Set CORE_MODELS_JAR to override."
+[ -f "$MODELS" ] || die "core-models.jar '$MODELS' does not exist"
+
+mkdir -p "$OUTDIR"
+CP="$MODELS"
+
+if [ -n "$SOURCE" ]; then
+  [ "$(javac_version)" != "not present" ] \
+    || die "--source needs a working JDK; javac reports no Java runtime"
+  javac -d "$OUTDIR" "$SOURCE" || die "javac failed on $SOURCE"
+  CP="$OUTDIR:$MODELS"
+fi
+
+# --no-lazy-methods is load-bearing: lazy loading is jbmc's default and omits
+# method bodies the program reaches (§2.2).
+jbmc "$CLASS" -cp "$CP" --no-lazy-methods --show-symbol-table --json-ui \
+  > "$OUTDIR/symtab.json" 2> "$OUTDIR/jbmc.log" \
+  || die "jbmc failed; see $OUTDIR/jbmc.log"
+
+python3 - "$OUTDIR/symtab.json" "$OUTDIR/st.json" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    doc = json.load(f)
+tables = [e for e in doc if "symbolTable" in e]
+if not tables:
+    sys.exit("no symbolTable element in jbmc --json-ui output")
+with open(sys.argv[2], "w", encoding="utf-8") as f:
+    json.dump(tables[0], f)
+print(f"symbols: {len(tables[0]['symbolTable'])}")
+PY
+
+symtab2gb "$OUTDIR/st.json" --out "$OUTDIR/model.goto" \
+  || die "symtab2gb failed"
+
+set +e
+"$ESBMC" --binary "$OUTDIR/model.goto" "${ESBMC_ARGS[@]}" \
+  > "$OUTDIR/esbmc.log" 2>&1
+ESBMC_STATUS=$?
+set -e
+
+# symtab2gb has no --version; cbmc ships alongside it from the same build.
+{
+  echo "class:        $CLASS"
+  [ -n "$SOURCE" ] && echo "source:       $SOURCE"
+  echo "models-jar:   $MODELS"
+  echo "jbmc:         $(jbmc --version 2>&1 | head -1)"
+  echo "cbmc:         $(cbmc --version 2>&1 | head -1)"
+  echo "esbmc:        $("$ESBMC" --version 2>&1 | head -1)"
+  echo "esbmc-src:    $(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse \
+                          --short HEAD 2>/dev/null || echo unknown)"
+  echo "javac:        $(javac_version)"
+  echo "goto-header:  $(od -An -tx1 -N4 "$OUTDIR/model.goto" | tr -d ' ')"
+  echo "esbmc-status: $ESBMC_STATUS"
+  echo "esbmc-tail:   $(tail -3 "$OUTDIR/esbmc.log" | tr '\n' ' ')"
+} > "$OUTDIR/manifest.txt"
+
+cat "$OUTDIR/manifest.txt"
+exit "$ESBMC_STATUS"

--- a/scripts/jbmc-poc-pipeline.sh
+++ b/scripts/jbmc-poc-pipeline.sh
@@ -49,9 +49,9 @@ EOF
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --class)  CLASS="${2:-}"; shift 2 ;;
-    --source) SOURCE="${2:-}"; shift 2 ;;
-    --outdir) OUTDIR="${2:-}"; shift 2 ;;
+    --class)  [ $# -ge 2 ] || die "--class needs a value"; CLASS="$2"; shift 2 ;;
+    --source) [ $# -ge 2 ] || die "--source needs a value"; SOURCE="$2"; shift 2 ;;
+    --outdir) [ $# -ge 2 ] || die "--outdir needs a value"; OUTDIR="$2"; shift 2 ;;
     --)       shift; ESBMC_ARGS=("$@"); break ;;
     -h|--help) usage ;;
     *) die "unknown argument '$1' (try --help)" ;;
@@ -60,7 +60,7 @@ done
 
 [ -n "$CLASS" ] || usage
 
-for tool in jbmc cbmc symtab2gb python3; do
+for tool in jbmc symtab2gb python3; do
   command -v "$tool" >/dev/null || die "'$tool' not found on PATH"
 done
 command -v "$ESBMC" >/dev/null || die "esbmc not found (set ESBMC=/path/to/esbmc)"
@@ -86,6 +86,11 @@ is ~50 functions and any verdict from it is meaningless (see plan §2.2). \
 Set CORE_MODELS_JAR to override."
 [ -f "$MODELS" ] || die "core-models.jar '$MODELS' does not exist"
 
+# Start from an empty directory: a run that dies partway would otherwise leave
+# the previous run's manifest and model.goto in place, and a reader collecting
+# artefacts afterwards would get a stale, plausible-looking record of a
+# different class. Stale .class files would also linger on the classpath below.
+rm -rf "$OUTDIR"
 mkdir -p "$OUTDIR"
 CP="$MODELS"
 
@@ -102,7 +107,7 @@ jbmc "$CLASS" -cp "$CP" --no-lazy-methods --show-symbol-table --json-ui \
   > "$OUTDIR/symtab.json" 2> "$OUTDIR/jbmc.log" \
   || die "jbmc failed; see $OUTDIR/jbmc.log"
 
-python3 - "$OUTDIR/symtab.json" "$OUTDIR/st.json" <<'PY'
+SYMBOLS=$(python3 - "$OUTDIR/symtab.json" "$OUTDIR/st.json" <<'PY'
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     doc = json.load(f)
@@ -111,14 +116,28 @@ if not tables:
     sys.exit("no symbolTable element in jbmc --json-ui output")
 with open(sys.argv[2], "w", encoding="utf-8") as f:
     json.dump(tables[0], f)
-print(f"symbols: {len(tables[0]['symbolTable'])}")
+print(len(tables[0]["symbolTable"]))
 PY
+)
+
+# Model size is the direct measurement of the completeness risk in §2.2 (16463
+# symbols with --no-lazy-methods against core-models.jar, 1548 without: a
+# truncated model yields a clean SUCCESSFUL, not an error). Always record it.
+# MIN_SYMBOLS enforces a floor when the caller knows what to expect; there is
+# no defensible universal value, so it is opt-in rather than guessed.
+if [ -n "${MIN_SYMBOLS:-}" ] && [ "$SYMBOLS" -lt "$MIN_SYMBOLS" ]; then
+  die "symbol table has $SYMBOLS symbols, below MIN_SYMBOLS=$MIN_SYMBOLS; \
+the model is probably truncated and any verdict from it is meaningless"
+fi
 
 symtab2gb "$OUTDIR/st.json" --out "$OUTDIR/model.goto" \
   || die "symtab2gb failed"
 
+# ${A[@]+"${A[@]}"} rather than "${A[@]}": bash 3.2 (stock on macOS) treats an
+# empty array as unset under `set -u` and aborts, which would fire on the
+# default invocation after all the expensive work is already done.
 set +e
-"$ESBMC" --binary "$OUTDIR/model.goto" "${ESBMC_ARGS[@]}" \
+"$ESBMC" --binary "$OUTDIR/model.goto" ${ESBMC_ARGS[@]+"${ESBMC_ARGS[@]}"} \
   > "$OUTDIR/esbmc.log" 2>&1
 ESBMC_STATUS=$?
 set -e
@@ -129,11 +148,11 @@ set -e
   [ -n "$SOURCE" ] && echo "source:       $SOURCE"
   echo "models-jar:   $MODELS"
   echo "jbmc:         $(jbmc --version 2>&1 | head -1)"
-  echo "cbmc:         $(cbmc --version 2>&1 | head -1)"
+  echo "cbmc:         $(cbmc --version 2>&1 | head -1 || echo 'not present')"
   echo "esbmc:        $("$ESBMC" --version 2>&1 | head -1)"
-  echo "esbmc-src:    $(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse \
-                          --short HEAD 2>/dev/null || echo unknown)"
+  echo "esbmc-path:   $(command -v "$ESBMC")"
   echo "javac:        $(javac_version)"
+  echo "symbols:      $SYMBOLS"
   echo "goto-header:  $(od -An -tx1 -N4 "$OUTDIR/model.goto" | tr -d ' ')"
   echo "esbmc-status: $ESBMC_STATUS"
   echo "esbmc-tail:   $(tail -3 "$OUTDIR/esbmc.log" | tr '\n' ' ')"


### PR DESCRIPTION
## Objective

Phase 0 of `docs/jbmc-goto-binary-poc-plan.md`: script the §2.2 pipeline so every later PoC result is one command, and record enough provenance that a verdict can be interpreted months later.

## Design decisions

A verdict from this pipeline is meaningful only relative to the classpath that produced the model — §2.2 measures a ~48x swing in model size on flags alone, and a truncated model yields a clean `SUCCESSFUL` rather than an error. Two consequences shape the script:

- An absent or mis-set `core-models.jar` is **fatal**, not a warning.
- `--no-lazy-methods` is always passed, since lazy loading is jbmc's default and silently omits reachable method bodies.

Every run writes `manifest.txt` with tool versions, resolved jar, symbol count, goto header bytes and verdict.

## Implementation

`scripts/jbmc-poc-pipeline.sh`: locate jar → optional `javac` → `jbmc --show-symbol-table --json-ui` → extract the `symbolTable` element → `symtab2gb` → `esbmc --binary` → manifest. Accepts a class from `core-models.jar` (no JDK needed) or `--source File.java`.

The second commit hardens it after review found three silent-degradation paths:

- Expanding an empty array under `set -u` aborts on **bash 3.2** (stock on macOS) but not bash 5, so the default invocation died after `jbmc` and `symtab2gb` had already run and before any manifest was written — and Linux CI would never have caught it.
- A failed run left the previous run's `manifest.txt` in place, describing a *different class*.
- `esbmc-src` recorded the script repo's commit, which is unrelated to the binary that produced the verdict.

## Validation

Exercised end to end under stock bash 3.2, plus nine failure paths (missing/mis-set jar, missing value after each flag, no `--class`, `--source` without a JDK, missing esbmc, `MIN_SYMBOLS` above and below the real count, extra esbmc args). All exit non-zero with a specific message; the happy path produces a valid `0x7f G B F` v6 binary and a real verdict.

Measured evidence recorded in the plan: 16463 symbols for `java.lang.Integer` with `--no-lazy-methods` against the jar, 1548 without.

## Known limitations

- The `--source` route is **untested** — no JDK was available on the measuring machine.
- The ~8-program tiered corpus is **not** included: it cannot be compiled and therefore cannot be validated without a JDK. Checking in unvalidated `.java` or opaque `.class` files was rejected in favour of leaving the gap explicit.
- The ESBMC *commit* is not recorded — `esbmc --version` does not carry one — so the manifest records the resolved binary path instead, which at least distinguishes a build-tree binary from a packaged one.
- `MIN_SYMBOLS` is opt-in rather than defaulted: a fixed floor would not catch lazy loading (1548 > any plausible threshold), so there is no defensible universal value.

## Roadmap contribution

Delivers the reusable half of Phase 0, so Phases 1–4 produce comparable, provenance-stamped artefacts instead of ad-hoc shell history. Future work enabled: the tiered corpus, and the Phase 4 scale measurement, which needs exactly the symbol-count and wall-clock data this records.
