### PR TITLE
[om] Add missing type_traits, unique_ptr and basic_string members

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6183/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6183/main.cpp
@@ -1,0 +1,56 @@
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <type_traits>
+
+struct Plain
+{
+  int x;
+};
+struct Poly
+{
+  virtual ~Poly()
+  {
+  }
+};
+struct NonTrivialDtor
+{
+  ~NonTrivialDtor()
+  {
+  }
+};
+
+int main()
+{
+  static_assert(std::is_class<Plain>::value, "");
+  static_assert(!std::is_class<int>::value, "");
+  static_assert(std::is_polymorphic<Poly>::value, "");
+  static_assert(!std::is_polymorphic<Plain>::value, "");
+  static_assert(std::is_trivially_default_constructible<Plain>::value, "");
+  static_assert(!std::is_trivially_default_constructible<Poly>::value, "");
+  static_assert(std::is_trivially_destructible<Plain>::value, "");
+  static_assert(!std::is_trivially_destructible<NonTrivialDtor>::value, "");
+
+  std::size_t n = 2;
+
+  std::unique_ptr<int> p(new int(7));
+  assert(p.get() != nullptr);
+  p = nullptr;
+  assert(p.get() == nullptr);
+  assert(!p);
+
+  std::unique_ptr<int> q = nullptr;
+  assert(q.get() == nullptr);
+
+  // The aws-sdk-cpp shape: the nullptr_t ctor must be non-explicit for the
+  // conditional operator to find a common type.
+  std::unique_ptr<int[]> arr =
+    (n > 0) ? std::unique_ptr<int[]>(new int[n]) : nullptr;
+  assert(arr.get() != nullptr);
+  arr[0] = 5;
+  assert(arr[0] == 5);
+  arr = nullptr;
+  assert(arr.get() == nullptr);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6183/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6183/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6183_2/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6183_2/main.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+#include <string>
+
+// [string.access] p1 requires the const overload; indexing a const reference
+// is ubiquitous in codec/parser code.
+static char at(const std::string &s, unsigned i)
+{
+  return s[i];
+}
+
+int main()
+{
+  std::string s("ab");
+  s.reserve(16);
+  s.push_back('c');
+
+  assert(s.size() == 3);
+  assert(at(s, 0) == 'a');
+  assert(at(s, 1) == 'b');
+  assert(at(s, 2) == 'c');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6183_2/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6183_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6183_2_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6183_2_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <string>
+
+static char at(const std::string &s, unsigned i)
+{
+  return s[i];
+}
+
+int main()
+{
+  std::string s("ab");
+  s.push_back('c');
+  // Must fail: push_back appended 'c', so the const operator[] reads 'c'.
+  assert(at(s, 2) == 'z');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6183_2_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6183_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6183_3/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6183_3/main.cpp
@@ -1,0 +1,8 @@
+// <cstdlib> alone must make std::size_t visible, as libstdc++ does.
+#include <cstdlib>
+
+int main()
+{
+  std::size_t n = 3;
+  return n == 3 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/github_6183_3/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6183_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6183_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6183_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+#include <memory>
+
+int main()
+{
+  std::unique_ptr<int> p(new int(7));
+  p = nullptr;
+  // Must fail: assigning nullptr releases the pointee and stores null.
+  assert(p.get() != nullptr);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6183_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6183_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/cstdlib
+++ b/src/cpp/library/cstdlib
@@ -48,6 +48,7 @@ using ::wctomb;
 using ::div_t;
 using ::ldiv_t;
 using ::lldiv_t;
+using ::size_t;
 
 #if __cplusplus >= 201703L
 using ::aligned_alloc;

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -231,8 +231,21 @@ public:
   {
   }
 
+  // [unique.ptr.single.ctor] p1: deliberately non-explicit, so that
+  // `cond ? make_unique<T>() : nullptr` and copy-initialisation work.
+  constexpr unique_ptr(nullptr_t) noexcept : ptr(nullptr), deleter(D())
+  {
+  }
+
   unique_ptr(const unique_ptr &) = delete;
   unique_ptr &operator=(const unique_ptr &) = delete;
+
+  // [unique.ptr.single.asgn] p5
+  unique_ptr &operator=(nullptr_t) noexcept
+  {
+    reset();
+    return *this;
+  }
 
   unique_ptr(unique_ptr &&other) noexcept
     : ptr(other.ptr), deleter(std::move(other.deleter))
@@ -348,8 +361,21 @@ public:
   {
   }
 
+  // [unique.ptr.single.ctor] p1: deliberately non-explicit, so that
+  // `cond ? make_unique<T>() : nullptr` and copy-initialisation work.
+  constexpr unique_ptr(nullptr_t) noexcept : ptr(nullptr), deleter(D())
+  {
+  }
+
   unique_ptr(const unique_ptr &) = delete;
   unique_ptr &operator=(const unique_ptr &) = delete;
+
+  // [unique.ptr.single.asgn] p5
+  unique_ptr &operator=(nullptr_t) noexcept
+  {
+    reset();
+    return *this;
+  }
 
   unique_ptr(unique_ptr &&other) noexcept
     : ptr(other.ptr), deleter(std::move(other.deleter))

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -538,6 +538,9 @@ public:
   //TODO: operator+
 
   char &operator[](size_t pos);
+  const char &operator[](size_t pos) const;
+  void push_back(char c);
+  void reserve(size_t n = 0);
   char at(size_t pos) const;
   char front() const;
   char back() const;
@@ -1446,6 +1449,36 @@ char &basic_string<CharT, Traits, Alloc>::operator[](size_t pos)
     return this->str[pos];
 }
 
+// Stricter than [string.access] p1, which makes s[s.size()] return the null
+// character: basic_string(int) sets _size without initialising str[], so
+// str[_size] is not reliably '\0' and returning it would yield an
+// unconstrained byte. Do not widen this bound to pos <= _size; to model the
+// standard, return a static '\0' for pos == _size instead.
+template <typename CharT, typename Traits, typename Alloc>
+const char &basic_string<CharT, Traits, Alloc>::operator[](size_t pos) const
+{
+__ESBMC_HIDE:
+  __ESBMC_assert(pos < this->_size, "Error! Invalid access memory area");
+  return this->str[pos];
+}
+
+template <typename CharT, typename Traits, typename Alloc>
+void basic_string<CharT, Traits, Alloc>::push_back(char c)
+{
+__ESBMC_HIDE:
+  *this += c;
+}
+
+// The model's buffer is a fixed-size array, so a request that fits is already
+// satisfied; a larger one cannot be modelled and is reported rather than
+// silently ignored.
+template <typename CharT, typename Traits, typename Alloc>
+void basic_string<CharT, Traits, Alloc>::reserve(size_t n)
+{
+__ESBMC_HIDE:
+  __ESBMC_assert(n < STRING_CAPACITY, "String capacity exceeded");
+}
+
 template <typename CharT, typename Traits, typename Alloc>
 char basic_string<CharT, Traits, Alloc>::at(size_t pos) const
 {
@@ -1581,6 +1614,8 @@ basic_string<CharT, Traits, Alloc> &
 basic_string<CharT, Traits, Alloc>::operator+=(char s)
 {
 __ESBMC_HIDE:
+  // Guards the strcpy below, which writes _size + 2 bytes into str[].
+  __ESBMC_assert(this->_size + 1 < STRING_CAPACITY, "String capacity exceeded");
   int totalLen = this->_size + 1;
   char temp[totalLen + 1];
   int i = 0;
@@ -1638,10 +1673,13 @@ __ESBMC_HIDE:
   s._size = _tsz;
 }
 
+// The storage is a fixed buffer, so the capacity is constant; returning _size
+// instead would break [string.capacity]'s capacity() >= res_arg guarantee
+// after reserve(). One byte is kept for the terminator.
 template <typename CharT, typename Traits, typename Alloc>
 size_t basic_string<CharT, Traits, Alloc>::capacity() const
 {
-  return this->_size;
+  return STRING_CAPACITY - 1;
 }
 
 template <typename CharT, typename Traits, typename Alloc>

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -301,6 +301,32 @@ struct is_trivially_copyable
 {
 };
 
+// is_class
+template <class T>
+struct is_class : integral_constant<bool, __is_class(T)>
+{
+};
+
+// is_polymorphic
+template <class T>
+struct is_polymorphic : integral_constant<bool, __is_polymorphic(T)>
+{
+};
+
+// is_trivially_default_constructible
+template <class T>
+struct is_trivially_default_constructible
+  : integral_constant<bool, __is_trivially_constructible(T)>
+{
+};
+
+// is_trivially_destructible
+template <class T>
+struct is_trivially_destructible
+  : integral_constant<bool, __is_trivially_destructible(T)>
+{
+};
+
 // is_array
 template <class T>
 struct is_array : false_type
@@ -662,6 +688,16 @@ inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
 template <class T>
 inline constexpr bool is_trivially_copyable_v =
   is_trivially_copyable<T>::value;
+template <class T>
+inline constexpr bool is_class_v = is_class<T>::value;
+template <class T>
+inline constexpr bool is_polymorphic_v = is_polymorphic<T>::value;
+template <class T>
+inline constexpr bool is_trivially_default_constructible_v =
+  is_trivially_default_constructible<T>::value;
+template <class T>
+inline constexpr bool is_trivially_destructible_v =
+  is_trivially_destructible<T>::value;
 template <class T>
 inline constexpr bool is_array_v = is_array<T>::value;
 template <class T>


### PR DESCRIPTION
Fixes #6183.

## Root cause

ESBMC's C++ operational model under `src/cpp/library/` was missing members that
aws-sdk-cpp (and most modern C++) relies on, so translation units GCC accepts
were rejected at parse time. Five gaps, all in the model rather than the
frontend — the clang builtins the traits need (`__is_class`,
`__is_polymorphic`, `__is_trivially_constructible`,
`__is_trivially_destructible`) were already accepted, they simply had no
`std::` spelling.

## Solution

- **`<type_traits>`** — `is_class`, `is_polymorphic`,
  `is_trivially_default_constructible`, `is_trivially_destructible`, plus the
  `_v` variants, built on the existing builtins.
- **`<memory>`** — `unique_ptr(nullptr_t)` and `operator=(nullptr_t)` on both
  the primary template and the `T[]` specialisation. The constructor is
  `constexpr` and deliberately non-explicit per [unique.ptr.single.ctor] p1,
  which is what makes the `cond ? MakeUniqueArray<T>(n) : nullptr` shape in the
  issue compile; the assignment delegates to `reset()` per
  [unique.ptr.single.asgn] p5.
- **`<string>`** — const `operator[]` per [string.access] p1, `push_back` and
  `reserve`.
- **`<cstdlib>`** — `using ::size_t;`, matching libstdc++.

Two changes fell out of review of the above:

- `capacity()` returned `size()`, which contradicts [string.capacity]'s
  `capacity() >= res_arg` guarantee once `reserve()` exists. It now returns the
  fixed buffer size, which is also honest about the model's storage.
- `operator+=(char)` writes `_size + 2` bytes into a 128-byte buffer with no
  guard. Since `push_back` delegates to it, the guard belongs there rather than
  in `push_back`, which closes the overflow for both entry points.

`shared_ptr` (gap 4 in the issue) is deliberately not addressed: reference
counting and `weak_ptr` need a real model, not a header addition.

## Two judgement calls

**`reserve` is an asserted no-op.** The buffer is a fixed `char[128]`, so a
request that fits is already satisfied; a larger one cannot be modelled and is
reported rather than silently ignored.

**The new const `operator[]` keeps the strict `pos < _size` bound**, even
though [string.access] p1 makes `s[s.size()]` well-defined. Widening it to
`pos <= _size` would be *unsound*: `basic_string(int)` sets `_size` without
initialising `str[]`, so `str[_size]` is not reliably `'\0'` and returning it
would yield an unconstrained byte the solver could pin to any value. A spurious
failure is preferable to a silent wrong value in a verifier. The reasoning and
the sound alternative (return a static `'\0'` for `pos == _size`) are recorded
in a comment so the next reader doesn't "fix" it into the unsound form.

## Validation

- Five regression tests under `regression/esbmc-cpp/cpp/github_6183*`,
  confirmed **failing before the patch** (verified against a rebuilt unpatched
  baseline, where all fail with `PARSING ERROR`) and passing after.
- The assertions were **mutation-tested**: variants with deliberately wrong
  expectations all fail, so nothing passes vacuously.
- Both capacity guards were shown **reachable**, so they are live checks rather
  than dead instrumentation.
- **1,931 existing C++ regression tests pass.** Four failures in
  `esbmc-cpp/cpp` (`github_2242_1`, `github_2242_2`, `github_3897_collision`,
  `utility2_fail`) are pre-existing and reproduce identically on an unpatched
  baseline — three use host-header flags that bypass the OM entirely, a known
  macOS libc++ issue.