### PR TITLE
[goto-programs] Assume pure loop invariants before side-effecting ones

### DIFF
--- a/regression/loop-invariants/github_6189/main.c
+++ b/regression/loop-invariants/github_6189/main.c
@@ -1,0 +1,33 @@
+/*
+ * Regression test for issue #6189: a loop invariant that calls a function
+ * whose own loop is bounded by a havoc'd variable, where that variable is
+ * constrained by a *separate* invariant.
+ *
+ * In the inductive step hi_idx is havoc'd, so loop(hi_idx) can only be
+ * bounded once hi_idx <= SIZE is assumed. The instrumentation must assume the
+ * pure constraint hi_idx <= SIZE before evaluating loop(hi_idx); otherwise the
+ * inner loop is symex'd with an unconstrained bound and its unwinding
+ * assertion fails spuriously. Ordering of the two invariants must not matter.
+ */
+#define SIZE 5
+typedef int idx_t;
+
+int loop(idx_t hi_idx)
+{
+  int res = 0;
+  idx_t idx;
+#pragma unroll SIZE + 1
+  for (idx = 0; idx < hi_idx; ++idx)
+    ++res;
+  return res;
+}
+
+int main()
+{
+  idx_t hi_idx = 0;
+  __ESBMC_loop_invariant(hi_idx <= SIZE);
+  __ESBMC_loop_invariant(loop(hi_idx) == hi_idx);
+  while (hi_idx < SIZE)
+    ++hi_idx;
+  __ESBMC_assert(hi_idx == SIZE, "end: hi_idx");
+}

--- a/regression/loop-invariants/github_6189/test.desc
+++ b/regression/loop-invariants/github_6189/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--multi-property --result-only --loop-invariant-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_6189_fail/main.c
+++ b/regression/loop-invariants/github_6189_fail/main.c
@@ -1,0 +1,29 @@
+/*
+ * Negative variant of issue #6189: same shape, but the second invariant
+ * asserts the wrong value for the function call. With hi_idx <= SIZE assumed
+ * first, loop(hi_idx) is now properly bounded and evaluates to hi_idx, so the
+ * inductive step ASSERT of loop(hi_idx) == hi_idx + 1 must fail. This guards
+ * against the reordering vacuously accepting a wrong invariant.
+ */
+#define SIZE 5
+typedef int idx_t;
+
+int loop(idx_t hi_idx)
+{
+  int res = 0;
+  idx_t idx;
+#pragma unroll SIZE + 1
+  for (idx = 0; idx < hi_idx; ++idx)
+    ++res;
+  return res;
+}
+
+int main()
+{
+  idx_t hi_idx = 0;
+  __ESBMC_loop_invariant(hi_idx <= SIZE);
+  __ESBMC_loop_invariant(loop(hi_idx) == hi_idx + 1);
+  while (hi_idx < SIZE)
+    ++hi_idx;
+  __ESBMC_assert(hi_idx == SIZE, "end: hi_idx");
+}

--- a/regression/loop-invariants/github_6189_fail/test.desc
+++ b/regression/loop-invariants/github_6189_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--multi-property --result-only --loop-invariant-check
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_6189_multi/main.c
+++ b/regression/loop-invariants/github_6189_multi/main.c
@@ -1,0 +1,38 @@
+/*
+ * Issue #6189, multiple side-effecting invariants. Two invariants each call a
+ * function whose loop is bounded by the havoc'd variable x, and a third, pure
+ * invariant (x <= SIZE) supplies that bound. The pure conjunct must be assumed
+ * before both calls so f(x) and g(x) are symex'd with x <= SIZE; the two calls
+ * themselves keep their source order.
+ */
+#define SIZE 5
+
+int f(int n)
+{
+  int r = 0;
+#pragma unroll SIZE + 1
+  for (int i = 0; i < n; ++i)
+    ++r;
+  return r;
+}
+
+int g(int n)
+{
+  int r = 0;
+#pragma unroll SIZE + 1
+  for (int i = 0; i < n; ++i)
+    r += 2;
+  return r;
+}
+
+int main()
+{
+  int x = 0;
+  __ESBMC_loop_invariant(x <= SIZE);
+  __ESBMC_loop_invariant(f(x) == x);
+  __ESBMC_loop_invariant(g(x) == 2 * x);
+  for (x = 0; x < SIZE; ++x)
+  {
+  }
+  __ESBMC_assert(x == SIZE, "end");
+}

--- a/regression/loop-invariants/github_6189_multi/test.desc
+++ b/regression/loop-invariants/github_6189_multi/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--multi-property --result-only --loop-invariant-check
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -38,6 +38,7 @@
 #include <util/std_expr.h>
 #include <util/options.h>
 #include <irep2/irep2_utils.h>
+#include <functional>
 #include <map>
 
 // ---------------------------------------------------------------------------
@@ -629,28 +630,77 @@ void goto_loop_invariantt::insert_havoc_and_assume_before_condition(
       loop_assigns, dest, loop_head->location);
   }
 
-  // Emit side-effect instructions (use havoc'd variables).
+  // Symbols defined by the extracted side-effect block (function-call results
+  // and their temporaries). A conjunct that reads one of these is assumed
+  // *after* the side effects; one that does not is a pure constraint on the
+  // havoc'd variables and is assumed *before* them, so it bounds any havoc'd
+  // value feeding a side-effecting invariant — e.g. a function call whose body
+  // loops over that value. Without this ordering the call is symex'd with an
+  // unconstrained nondet bound and its inner loop's unwinding assertion fails
+  // spuriously (issue #6189).
+  std::set<irep_idt> side_effect_defs;
   for (const auto &instr : side_effects.instructions)
-    dest.instructions.push_back(instr);
-
-  // Assume invariants (entering the loop).
-  for (const auto &invariant : invariants)
   {
-    expr2tc inst_invariant = invariant;
-
-    // If frame rule is enabled, replace any old() references with snapshots
-    if (use_frame_rule && active_frame_enforcer)
+    if (instr.is_assign() && is_code_assign2t(instr.code))
     {
-      inst_invariant =
-        active_frame_enforcer->replace_old_with_snapshots(invariant);
+      const code_assign2t &a = to_code_assign2t(instr.code);
+      if (is_symbol2t(a.target))
+        side_effect_defs.insert(to_symbol2t(a.target).get_symbol_name());
     }
+    else if (instr.is_function_call() && is_code_function_call2t(instr.code))
+    {
+      const code_function_call2t &fc = to_code_function_call2t(instr.code);
+      if (!is_nil_expr(fc.ret) && is_symbol2t(fc.ret))
+        side_effect_defs.insert(to_symbol2t(fc.ret).get_symbol_name());
+    }
+  }
 
-    // Create assume instruction: just the invariant
+  auto uses_side_effect = [&side_effect_defs](const expr2tc &conjunct) {
+    std::set<irep_idt> syms;
+    collect_symbols_local(conjunct, syms);
+    for (const auto &s : syms)
+      if (side_effect_defs.count(s))
+        return true;
+    return false;
+  };
+
+  // Flatten top-level conjunctions so a pure conjunct can be split out even when
+  // the frontend folded it together with a side-effecting one into `a && b`.
+  // The conjunct guards are themselves pure: any embedded call has already been
+  // hoisted into the side_effects block (see file header).
+  std::function<void(const expr2tc &)> partition;
+  std::vector<expr2tc> pure, impure;
+  partition = [&](const expr2tc &e) {
+    if (is_and2t(e))
+    {
+      partition(to_and2t(e).side_1);
+      partition(to_and2t(e).side_2);
+    }
+    else
+      (uses_side_effect(e) ? impure : pure).push_back(e);
+  };
+  for (const auto &invariant : invariants)
+    partition(invariant);
+
+  auto emit_assume = [&](const expr2tc &conjunct) {
+    expr2tc inst = conjunct;
+    if (use_frame_rule && active_frame_enforcer)
+      inst = active_frame_enforcer->replace_old_with_snapshots(conjunct);
+
     goto_programt::targett t = dest.add_instruction(ASSUME);
-    t->guard = inst_invariant;
+    t->guard = inst;
     t->location = loop_head->location;
     t->location.comment("loop invariant step case");
-  }
+  };
+
+  // Assume pure conjuncts, run the side effects under those constraints, then
+  // assume the side-effect-dependent conjuncts.
+  for (const auto &conjunct : pure)
+    emit_assume(conjunct);
+  for (const auto &instr : side_effects.instructions)
+    dest.instructions.push_back(instr);
+  for (const auto &conjunct : impure)
+    emit_assume(conjunct);
 
   // Note: active_frame_enforcer is NOT deleted here.
   // It is reused in insert_inductive_step_and_termination for the ASSERT


### PR DESCRIPTION
Closes the loop-invariant issue in discussion #6189.

## Problem (discussion #6189)

`--loop-invariant-check` reports a spurious `VERIFICATION FAILED` when one
invariant calls a function whose own loop is bounded by a variable that a
*separate* invariant constrains:

```c
int loop(idx_t hi) { int r=0; idx_t i;
  #pragma unroll SIZE+1
  for (i=0; i<hi; ++i) ++r; return r; }
...
__ESBMC_loop_invariant( hi_idx <= SIZE );
__ESBMC_loop_invariant( loop(hi_idx) == hi_idx );
```

The inner loop's `unwinding assertion loop 3 ... function loop` fails even
though `#pragma unroll SIZE+1` (bound 6) is enough for `hi_idx <= SIZE`.

## Root cause

In the inductive step the pass havocs the loop variables, then replays each
invariant's side effect (`DECL/FUNCTION_CALL`) so a call is re-evaluated in
the havoc'd state. It emitted **all** side effects first and **all** `ASSUME`s
afterwards. So `loop(hi_idx)` was symex'd with `hi_idx` an unconstrained
nondet; its inner loop needs up to `INT_MAX` iterations against an unroll
bound of 6, and the unwinding assertion fails. The `hi_idx <= SIZE` invariant
that would bound it was `ASSUME`d one step too late. The base case is
unaffected because `hi_idx == 0` there, so `loop(0)` runs zero iterations.

## Fix

In `insert_havoc_and_assume_before_condition`, split each invariant into its
top-level conjuncts and partition them: a conjunct that references a symbol
defined by the extracted side-effect block is *call-dependent*; the rest are
*pure* constraints on the havoc'd variables. Assume the pure conjuncts first,
replay the side effects under those constraints, then assume the call-dependent
conjuncts. `loop(hi_idx)` is now evaluated with `hi_idx <= SIZE` in scope and
unrolls within bound.

Reordering is sound: `ASSUME(A); ASSUME(B)` and `ASSUME(B); ASSUME(A)` impose
the same path condition; moving a pure constraint earlier only tightens the
state in which the call is evaluated, never adds behaviour. The change touches
only the step-case `ASSUME`s -- the side-effect block is emitted unchanged, so
call-to-call ordering is preserved -- and the base/inductive `ASSERT`s are
untouched. Splitting on `&&` makes it independent of the order the clauses are
written in.

**Precondition:** an invariant's function call is assumed pure w.r.t. the
globals/heap that other invariants read. A call with global side effects makes
the base/inductive ASSERT order ill-defined independently of this change.

**On the `end: hi_idx` UNKNOWN from the discussion.** With this fix the
unmodified program verifies fully -- the outer `end: hi_idx` is proven, not
UNKNOWN. The UNKNOWN only appeared in the workaround variant that adds
`__ESBMC_assume(hi_idx < SIZE)` *inside* `loop()`: the outer invariant allows
`hi_idx == SIZE`, so `hi_idx < SIZE` is `assume(false)` on that path and the
exit assertion is discharged vacuously (ESBMC now flags this as a vacuous
discharge). The workaround is no longer needed.

## Testing

- `regression/loop-invariants/github_6189` -- the reproducer; **SUCCESSFUL**
  (reports FAILED without the fix), and the outer `end: hi_idx` is proven.
- `regression/loop-invariants/github_6189_fail` -- a wrong call-value invariant
  (`loop(hi_idx) == hi_idx + 1`) must still be caught; stays **FAILED** (guards
  against the reordering vacuously accepting a bad invariant).
- `regression/loop-invariants/github_6189_multi` -- two call-carrying invariants
  under one pure bound; **SUCCESSFUL**.

Verified the PASS test fails on the unfixed binary and passes on the fixed one.
Full `loop-invariants` (68) suite passes with no regression.
