### PR TITLE
[solver] Return tvt from get_bool instead of fabricating false

### DIFF
--- a/regression/z3/github_6191/main.c
+++ b/regression/z3/github_6191/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int a[12];
+  int i;
+  __ESBMC_assert(
+    __ESBMC_forall(&i, !(0 <= i && i < 12) || a[i] != a[0]), "false forall");
+  return 0;
+}

--- a/regression/z3/github_6191/test.desc
+++ b/regression/z3/github_6191/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--z3 --unwind 13 --no-standard-checks
+^VERIFICATION FAILED$
+^Violated property:$
+\A(?![\s\S]*Can't get boolean value)[\s\S]*\Z

--- a/regression/z3/github_6191_attribution/main.c
+++ b/regression/z3/github_6191_attribution/main.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int a[12], b[12], i, j;
+  __ESBMC_assume(__ESBMC_forall(&j, !(0 <= j && j < 12) || b[j] == 7));
+  __ESBMC_assert(__ESBMC_forall(&j, !(0 <= j && j < 12) || b[j] == 7), "holds");
+  __ESBMC_assert(
+    __ESBMC_forall(&i, !(0 <= i && i < 12) || a[i] != a[0]), "genuine");
+  return 0;
+}

--- a/regression/z3/github_6191_attribution/test.desc
+++ b/regression/z3/github_6191_attribution/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--z3 --unwind 13 --no-standard-checks
+^VERIFICATION FAILED$
+^  genuine$
+\A(?![\s\S]*Can't get boolean value)[\s\S]*\Z

--- a/regression/z3/github_6191_success/main.c
+++ b/regression/z3/github_6191_success/main.c
@@ -1,0 +1,10 @@
+int zeroed[12];
+
+int main()
+{
+  int i;
+  __ESBMC_assert(
+    __ESBMC_forall(&i, !(0 <= i && i < 12) || zeroed[i] == 0),
+    "true forall");
+  return 0;
+}

--- a/regression/z3/github_6191_success/test.desc
+++ b/regression/z3/github_6191_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --unwind 13 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -72,6 +72,8 @@ void build_goto_trace(
     if (SSA_step.hidden)
       continue;
 
+    // is_true() also drops steps whose guard the solver could not evaluate:
+    // such a step has no authentic state to report (see #6191).
     if (SSA_step.ignore || !smt_conv.l_get(SSA_step.guard).is_true())
       continue;
 
@@ -135,8 +137,14 @@ void build_goto_trace(
       }
     }
 
+    // An unevaluatable assertion condition (e.g. one still containing a
+    // quantifier) must render as violated, not as held: this is the assertion
+    // the solver already reported as failing. Hence is_true(), not !is_false().
     if (SSA_step.is_assert())
-      goto_trace_step.guard = !smt_conv.l_get(SSA_step.cond_expr).is_false();
+      goto_trace_step.guard = smt_conv.l_get(SSA_step.cond_expr).is_true();
+    // Keeps the opposite idiom on purpose: here guard is a direction bit, not
+    // a violation flag, so unknown has no fail-safe value and flipping would
+    // swap one invented branch direction for another.
     else if (SSA_step.is_assume() || SSA_step.is_branching())
       goto_trace_step.guard = !smt_conv.l_get(SSA_step.cond).is_false();
 

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -696,7 +696,7 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
     t->sort);
 }
 
-bool bitwuzla_convt::get_bool(smt_astt a)
+tvt bitwuzla_convt::get_bool(smt_astt a)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
 
@@ -705,18 +705,13 @@ bool bitwuzla_convt::get_bool(smt_astt a)
 
   assert(result != NULL && "Bitwuzla returned null bv value string");
 
-  bool res;
   if (!strcmp(result, "true"))
-    res = true;
-  else if (!strcmp(result, "false"))
-    res = false;
-  else
-  {
-    log_error("Can't get boolean value from Bitwuzla: {}", result);
-    abort();
-  }
+    return tvt(true);
+  if (!strcmp(result, "false"))
+    return tvt(false);
 
-  return res;
+  log_error("Can't get boolean value from Bitwuzla: {}", result);
+  abort();
 }
 
 BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -97,7 +97,7 @@ public:
   smt_astt
   convert_array_of(smt_astt init_val, unsigned long domain_width) override;
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
     override;

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -646,21 +646,22 @@ smt_astt boolector_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
     t->sort);
 }
 
-bool boolector_convt::get_bool(smt_astt a)
+tvt boolector_convt::get_bool(smt_astt a)
 {
   const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
   const char *result = boolector_bv_assignment(btor, ast->a);
 
   assert(result != NULL && "Boolector returned null bv assignment string");
 
-  bool res;
+  // A default-constructed tvt holds an indeterminate value, not TV_UNKNOWN.
+  tvt res(tvt::TV_UNKNOWN);
   switch (*result)
   {
   case '1':
-    res = true;
+    res = tvt(true);
     break;
   case '0':
-    res = false;
+    res = tvt(false);
     break;
   default:
     log_error("Can't get boolean value from Boolector");

--- a/src/solvers/boolector/boolector_conv.h
+++ b/src/solvers/boolector/boolector_conv.h
@@ -97,7 +97,7 @@ public:
   smt_astt
   convert_array_of(smt_astt init_val, unsigned long domain_width) override;
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
     override;

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -45,11 +45,11 @@ smt_resultt cvc_convt::dec_solve()
   return P_UNSATISFIABLE;
 }
 
-bool cvc_convt::get_bool(smt_astt a)
+tvt cvc_convt::get_bool(smt_astt a)
 {
   auto const *ca = to_solver_smt_ast<cvc_smt_ast>(a);
   CVC4::Expr e = smt.getValue(ca->a);
-  return e.getConst<bool>();
+  return tvt(e.getConst<bool>());
 }
 
 ieee_floatt cvc_convt::get_fpbv(smt_astt a)

--- a/src/solvers/cvc4/cvc_conv.h
+++ b/src/solvers/cvc4/cvc_conv.h
@@ -21,7 +21,7 @@ public:
   smt_resultt dec_solve() override;
   const std::string solver_text() override;
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   ieee_floatt get_fpbv(smt_astt a) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)

--- a/src/solvers/cvc5/cvc5_conv.cpp
+++ b/src/solvers/cvc5/cvc5_conv.cpp
@@ -44,11 +44,11 @@ smt_resultt cvc5_convt::dec_solve()
   return P_UNSATISFIABLE;
 }
 
-bool cvc5_convt::get_bool(smt_astt a)
+tvt cvc5_convt::get_bool(smt_astt a)
 {
   auto const *ca = to_solver_smt_ast<cvc5_smt_ast>(a);
   cvc5::Term e = slv.getValue(ca->a);
-  return e.getBooleanValue();
+  return tvt(e.getBooleanValue());
 }
 
 ieee_floatt cvc5_convt::get_fpbv(smt_astt a)

--- a/src/solvers/cvc5/cvc5_conv.h
+++ b/src/solvers/cvc5/cvc5_conv.h
@@ -24,7 +24,7 @@ public:
   smt_resultt dec_solve() override;
   const std::string solver_text() override;
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   ieee_floatt get_fpbv(smt_astt a) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -97,17 +97,18 @@ smt_resultt mathsat_convt::dec_solve()
   return P_ERROR;
 }
 
-bool mathsat_convt::get_bool(smt_astt a)
+tvt mathsat_convt::get_bool(smt_astt a)
 {
   const mathsat_smt_ast *mast = to_solver_smt_ast<mathsat_smt_ast>(a);
   msat_term t = msat_get_model_value(env, mast->a);
   check_msat_error(t);
 
-  bool res;
+  // A default-constructed tvt holds an indeterminate value, not TV_UNKNOWN.
+  tvt res(tvt::TV_UNKNOWN);
   if (msat_term_is_true(env, t))
-    res = true;
+    res = tvt(true);
   else if (msat_term_is_false(env, t))
-    res = false;
+    res = tvt(false);
   else
   {
     log_error("Boolean model value is neither true or false");

--- a/src/solvers/mathsat/mathsat_conv.h
+++ b/src/solvers/mathsat/mathsat_conv.h
@@ -134,7 +134,7 @@ public:
   void push_ctx() override;
   void pop_ctx() override;
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   ieee_floatt get_fpbv(smt_astt a) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -3107,12 +3107,18 @@ expr2tc smt_solver_baset::get(const expr2tc &expr)
     // we return it, without casting to the ternary if type.
     if2t i = to_if2t(res);
 
+    // c is null when the solver produced no value for the condition (e.g. it
+    // still contains a quantifier); fall through to the operand recursion
+    // below, which handles unresolved sub-expressions.
     expr2tc c = get(i.cond);
-    if (is_true(c))
-      return get(i.true_value);
+    if (c)
+    {
+      if (is_true(c))
+        return get(i.true_value);
 
-    if (is_false(c))
-      return get(i.false_value);
+      if (is_false(c))
+        return get(i.false_value);
+    }
   }
 
   default:;
@@ -3185,7 +3191,14 @@ expr2tc smt_solver_baset::get_by_ast(const type2tc &type, smt_astt a)
   switch (type->type_id)
   {
   case type2t::bool_id:
-    return get_bool(a) ? gen_true_expr() : gen_false_expr();
+  {
+    // A null expr2tc is the established "solver produced no value" signal; the
+    // get() callers already treat it as unresolved (see #6191).
+    tvt val = get_bool(a);
+    if (val.is_unknown())
+      return expr2tc();
+    return val.is_true() ? gen_true_expr() : gen_false_expr();
+  }
 
   case type2t::unsignedbv_id:
   case type2t::signedbv_id:
@@ -3876,7 +3889,7 @@ tvt smt_solver_baset::l_get(smt_astt a)
   auto it = l_get_cache.find(a);
   if (it != l_get_cache.end())
     return it->second;
-  tvt res = get_bool(a) ? tvt(true) : tvt(false);
+  tvt res = get_bool(a);
   l_get_cache.emplace(a, res);
   return res;
 }

--- a/src/solvers/smt/smt_solver.h
+++ b/src/solvers/smt/smt_solver.h
@@ -550,8 +550,10 @@ public:
 
   /** Extract the assignment to a boolean variable from the SMT solver's model.
    *  @param a The AST whose value we wish to know.
-   *  @return Expression representation of a's value, as a constant_bool2tc */
-  virtual bool get_bool(smt_astt a) = 0;
+   *  @return a's value, or tvt::TV_UNKNOWN when the solver cannot reduce it to
+   *          a ground boolean. That is an expected outcome for terms that still
+   *          contain a quantifier: callers must not invent a value for it. */
+  virtual tvt get_bool(smt_astt a) = 0;
 
   /** Extract the assignment to a bitvector from the SMT solver's model.
    *  @param a The AST whose value we wish to know.

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -165,12 +165,7 @@ expr2tc smt_tuple_node_flattener::tuple_get_rec(tuple_node_smt_astt tuple)
     {
       res = expr2tc(); // XXX currently unimplemented
     }
-    else if (is_bool_type(it))
-    {
-      res =
-        ctx->get_bool(tuple->elements[i]) ? gen_true_expr() : gen_false_expr();
-    }
-    else if (is_number_type(it) || is_union_type(it))
+    else if (is_bool_type(it) || is_number_type(it) || is_union_type(it))
     {
       res = ctx->get_by_ast(it, tuple->elements[i]);
     }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -877,7 +877,11 @@ tvt smtlib_convt::l_get(smt_astt a)
 
   if (second.token == TOK_SIMPLESYM && second.data == "???")
   {
-    /* Yices sometimes returns '???', e.g. when using get-value of stores */
+    /* Yices sometimes returns '???', e.g. when using get-value of stores.
+     * That is an incomplete model rather than a quantified term, so log it:
+     * get_bool() no longer aborts here, and the two causes of TV_UNKNOWN
+     * would otherwise be indistinguishable in a bug report. */
+    log_debug("solver", "smtlib solver returned no boolean value (unknown)");
     return tvt(tvt::TV_UNKNOWN);
   }
 
@@ -891,16 +895,9 @@ tvt smtlib_convt::l_get(smt_astt a)
   abort();
 }
 
-bool smtlib_convt::get_bool(smt_astt a)
+tvt smtlib_convt::get_bool(smt_astt a)
 {
-  tvt tv = l_get(a);
-
-  if (tv.is_true())
-    return true;
-  if (tv.is_false())
-    return false;
-
-  abort();
+  return l_get(a);
 }
 
 const std::string smtlib_convt::solver_text()

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -288,7 +288,7 @@ public:
 
   sexpr get_value(smt_astt a) const;
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   tvt l_get(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   expr2tc

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -797,7 +797,7 @@ yices_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
   return default_convert_array_of(init_val, domain_width, this);
 }
 
-bool yices_convt::get_bool(smt_astt a)
+tvt yices_convt::get_bool(smt_astt a)
 {
   int32_t val;
   const yices_smt_ast *ast = to_solver_smt_ast<yices_smt_ast>(a);
@@ -807,7 +807,7 @@ bool yices_convt::get_bool(smt_astt a)
     abort();
   }
 
-  return val ? true : false;
+  return tvt(val != 0);
 }
 
 BigInt yices_convt::get_bv(smt_astt a, bool is_signed)

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -148,7 +148,7 @@ public:
   expr2tc
   tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
     override;

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1265,7 +1265,7 @@ expr2tc z3_convt::tuple_get(const expr2tc &expr)
 
 // ***************************** 'get' api *******************************
 
-bool z3_convt::get_bool(smt_astt a)
+tvt z3_convt::get_bool(smt_astt a)
 {
   const z3_smt_ast *za = to_solver_smt_ast<z3_smt_ast>(a);
   // Set the model_completion to TRUE.
@@ -1273,24 +1273,18 @@ bool z3_convt::get_bool(smt_astt a)
   // which are essentially don't cares.
   z3::expr e = solver.get_model().eval(za->a, true);
 
-  Z3_lbool result = Z3_get_bool_value(z3_ctx, e);
-
-  bool res;
-  switch (result)
+  switch (Z3_get_bool_value(z3_ctx, e))
   {
   case Z3_L_TRUE:
-    res = true;
-    break;
+    return tvt(true);
   case Z3_L_FALSE:
-    res = false;
-    break;
+    return tvt(false);
   default:
-    // Note: quantifiers may result in undefined values
-    log_warning("Can't get boolean value from Z3. Returning false");
-    res = false;
+    // Terms still containing a quantifier have no ground value; report the
+    // absence rather than inventing one (see #6191).
+    log_debug("solver", "Z3 returned no boolean value; term is unevaluatable");
+    return tvt(tvt::TV_UNKNOWN);
   }
-
-  return res;
 }
 
 BigInt z3_convt::get_bv(smt_astt a, bool is_signed)

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -38,7 +38,7 @@ public:
   void pop_ctx() override;
   smt_resultt dec_solve() override;
 
-  bool get_bool(smt_astt a) override;
+  tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   ieee_floatt get_fpbv(smt_astt a) override;
   bool


### PR DESCRIPTION
z3_convt::get_bool() returned false when Z3 could not reduce a term to a
ground boolean, which happens for terms still containing a quantifier, so
counterexamples carried invented assignments users could not tell apart
from real ones. get_bool now returns tvt, letting backends report the
absence of a value; l_get propagates it and get_by_ast yields a null
expr2tc, the existing "unresolved" signal.

Fixes #6191

### Notes for reviewers

- `build_goto_trace.cpp` flips the assert guard to `is_true()`. Without it the
  unknown renders as "held" and the `Violated property:` block disappears from
  exactly the traces this issue is about — confirmed empirically. The
  assume/branching line deliberately keeps `!is_false()`: there `guard` is a
  direction bit with no fail-safe value.
- `get()`'s ternary-if case gained a null check, since a bool-typed condition
  can now legitimately resolve to no value.
- `smtlib_convt::get_bool` previously aborted on the `TV_UNKNOWN` that `l_get`
  already produced for Yices' incomplete-model sentinel; it now propagates,
  with a `log_debug` so that cause stays distinguishable from a quantifier.
- `explicit tvt(bool)` and the absence of `operator bool` mean every former
  `bool` use of `get_bool` is a compile error, so the compiler found all call
  sites.

### Testing

Three regression tests under `regression/z3/`: the issue reproducer (asserts
the warning is gone *and* the violated property still renders), a holding
quantified assert, and a multi-assert case pinning that the genuine violation
is the one reported.

Locally: z3/bitwuzla/smtlib/k-induction/witnesses 310/310, esbmc C suite
1481/1489. The 8 failures (bitvector_02/03, char16/32-lit, github_1537) and 2
float failures are pre-existing — verified by stashing the patch and
re-running on master. clang-format 11 clean.

Boolector, MathSAT, CVC4, CVC5 and Yices are disabled in my local build, so
their (mechanical, two-line) changes were reviewed by inspection but not
compiled here; CI is the first build that covers them.