### PR TITLE
[ir-ieee] add regression coverage for libm NaN results

### DIFF
--- a/regression/ir-ra/ra-asin-nan/main.c
+++ b/regression/ir-ra/ra-asin-nan/main.c
@@ -1,0 +1,9 @@
+#include <math.h>
+
+int main(void)
+{
+  /* The operational model defines asin outside [-1, 1] as NaN. */
+  double r = asin(2.0);
+  __ESBMC_assert(r != r, "asin(2.0) must be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-asin-nan/test.desc
+++ b/regression/ir-ra/ra-asin-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-log-nan/main.c
+++ b/regression/ir-ra/ra-log-nan/main.c
@@ -1,0 +1,9 @@
+#include <math.h>
+
+int main(void)
+{
+  /* The operational model defines log of a negative argument as NaN. */
+  double r = log(-1.0);
+  __ESBMC_assert(r != r, "log(-1.0) must be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-log-nan/test.desc
+++ b/regression/ir-ra/ra-log-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-pow-nan/main.c
+++ b/regression/ir-ra/ra-pow-nan/main.c
@@ -1,0 +1,11 @@
+#include <math.h>
+
+int main(void)
+{
+  /* The operational model defines pow(negative, non-integer) as NaN.
+   * --unwind 1 bounds the exp/expm1 path that is unreachable for this
+   * concrete input; unwinding assertions remain active by default. */
+  double r = pow(-2.0, 0.5);
+  __ESBMC_assert(r != r, "pow(-2.0, 0.5) must be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-pow-nan/test.desc
+++ b/regression/ir-ra/ra-pow-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-remainder-nan/main.c
+++ b/regression/ir-ra/ra-remainder-nan/main.c
@@ -1,0 +1,9 @@
+#include <math.h>
+
+int main(void)
+{
+  /* The operational model defines remainder(±inf, y) as NaN. */
+  double r = remainder(INFINITY, 1.0);
+  __ESBMC_assert(r != r, "remainder(INFINITY, 1.0) must be NaN");
+  return 0;
+}

--- a/regression/ir-ra/ra-remainder-nan/test.desc
+++ b/regression/ir-ra/ra-remainder-nan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## Description

This PR adds regression tests for deterministic NaN results produced by the libm operational models under `--ir-ieee`.

These tests verify that the libm operational models correctly propagate NaN for invalid inputs end-to-end under `--ir-ieee`, from the operational model's `return NAN` branch through the SMT Real encoding to the assertion.

The tests cover deterministic NaN-producing cases for:

- `asin(2.0)`
- `log(-1.0)`
- `pow(-2.0, 0.5)`
- `remainder(INFINITY, 1.0)`

Each test uses a concrete invalid input and verifies that the result is NaN via the IEEE property `x != x`.

The `pow` regression uses `--unwind 1` because the untaken finite-result path contains the `exp`/`expm1` loop. For the chosen concrete input, the NaN branch is taken deterministically, and unwinding assertions remain enabled.

## Changes

- Add `ra-asin-nan`
- Add `ra-log-nan`
- Add `ra-pow-nan`
- Add `ra-remainder-nan`

## Testing

- Focused regression tests: **4/4 passed**
- Full `ir-ra` regression suite: **240/240 passed**