### PR TITLE
[clang-cpp-frontend] Fix placement new without initializer

### DIFF
--- a/regression/esbmc-cpp/cpp/placement_new_no_init/main.cpp
+++ b/regression/esbmc-cpp/cpp/placement_new_no_init/main.cpp
@@ -1,0 +1,38 @@
+// Placement new with no initializer: `new (p) T;` for a non-class T.
+// Default-initializing a non-class type performs no initialization
+// ([dcl.init.general]), so the expression is just the placement address.
+// Clang attaches no initializer child to such a CXXNewExpr, which used to
+// yield a one-operand "comma" and an out-of-bounds read in adjust_comma.
+// See esbmc/esbmc#6184.
+#include <new>
+#include <cassert>
+
+int main()
+{
+  // Scalar, no initializer.
+  alignas(int) char ibuf[sizeof(int)];
+  int *p = new (ibuf) int;
+  assert((void *)p == (void *)ibuf); // result aliases the placement address
+  *p = 42;                           // default-init leaves it indeterminate
+  assert(*p == 42);
+
+  // unsigned char: the aws-sdk-cpp ByteBuffer element type from #6184.
+  unsigned char cbuf[1];
+  unsigned char *q = new (cbuf) unsigned char;
+  *q = 7;
+  assert(*q == 7);
+
+  // The Aws::NewArray shape: `new (base + i) T;` in a loop.
+  alignas(int) char abuf[3 * sizeof(int)];
+  int *base = (int *)abuf;
+  for (int i = 0; i < 3; ++i)
+  {
+    int *e = new (base + i) int;
+    *e = i;
+  }
+  assert(base[0] == 0);
+  assert(base[1] == 1);
+  assert(base[2] == 2);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/placement_new_no_init/test.desc
+++ b/regression/esbmc-cpp/cpp/placement_new_no_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/placement_new_no_init_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/placement_new_no_init_fail/main.cpp
@@ -1,0 +1,14 @@
+// Negative counterpart of placement_new_no_init (esbmc/esbmc#6184): after the
+// fix, `new (p) T;` reaches a clean counterexample instead of the SIGABRT the
+// malformed one-operand comma used to cause.
+#include <new>
+#include <cassert>
+
+int main()
+{
+  alignas(int) char buf[sizeof(int)];
+  int *p = new (buf) int;
+  *p = 42;
+  assert(*p == 43); // must fail: the store above wrote 42
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/placement_new_no_init_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/placement_new_no_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1586,6 +1586,7 @@ void clang_c_adjust::adjust_comma(exprt &expr)
 {
   adjust_operands(expr);
 
+  assert(expr.operands().size() == 2);
   expr.type() = expr.op1().type();
 }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -850,40 +850,47 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
         exprt tp("typecast", t);
         tp.copy_to_operands(place);
 
+        // Default-initialising a non-class type performs no initialisation
+        // ([dcl.init.general]), so clang attaches no initializer and there is
+        // nothing to sequence: `new (p) int;` is just (int *)p. Emitting a
+        // comma here would leave it with a single operand and corrupt every
+        // downstream op1() access (esbmc/esbmc#6184).
+        if (!ne.hasInitializer())
+        {
+          new_expr = tp;
+          break;
+        }
+
         exprt target("dereference", t.subtype());
         target.copy_to_operands(tp);
 
-        exprt comma("comma", t);
-        if (ne.hasInitializer())
-        {
-          exprt init;
-          if (get_expr(*ne.getInitializer(), init))
-            return true;
+        exprt init;
+        if (get_expr(*ne.getInitializer(), init))
+          return true;
 
-          if (
-            init.id() == "sideeffect" &&
-            init.statement() == "temporary_object" &&
-            static_cast<const exprt &>(init.initializer()).is_not_nil())
-          {
-            // A class-type initializer arrives as a temporary_object whose
-            // initializer wraps the constructor call carrying an
-            // &new_object placeholder (make_temporary): retarget the call
-            // at the placement address and drop the temporary, so `this`
-            // is the placed object, not a copied-from temp.
-            exprt wrap = static_cast<const exprt &>(init.initializer());
-            assert(
-              wrap.is_code() && to_code(wrap).get_statement() == "expression");
-            exprt call = wrap.op0();
-            replace_new_object_with(target, call);
-            comma.copy_to_operands(call);
-          }
-          else
-          {
-            side_effect_exprt assign("assign");
-            assign.type() = t.subtype();
-            assign.copy_to_operands(target, init);
-            comma.copy_to_operands(assign);
-          }
+        exprt comma("comma", t);
+        if (
+          init.id() == "sideeffect" && init.statement() == "temporary_object" &&
+          static_cast<const exprt &>(init.initializer()).is_not_nil())
+        {
+          // A class-type initializer arrives as a temporary_object whose
+          // initializer wraps the constructor call carrying an
+          // &new_object placeholder (make_temporary): retarget the call
+          // at the placement address and drop the temporary, so `this`
+          // is the placed object, not a copied-from temp.
+          exprt wrap = static_cast<const exprt &>(init.initializer());
+          assert(
+            wrap.is_code() && to_code(wrap).get_statement() == "expression");
+          exprt call = wrap.op0();
+          replace_new_object_with(target, call);
+          comma.copy_to_operands(call);
+        }
+        else
+        {
+          side_effect_exprt assign("assign");
+          assign.type() = t.subtype();
+          assign.copy_to_operands(target, init);
+          comma.copy_to_operands(assign);
         }
         comma.copy_to_operands(tp);
         new_expr = comma;


### PR DESCRIPTION
## Summary

Fixes #6184 — a SIGABRT during GOTO conversion (surfacing as varying glibc pthread
assertions) when converting `Aws::Utils::Array<unsigned char>` from aws-sdk-cpp.

The reported symptom looked like an `irept` reference-count use-after-free under `SHARING`,
but the actual cause is an **out-of-bounds vector read on a malformed expression**, a
regression from #6133 (`Model placement new`).

## Root cause

Default-initialising a non-class type performs no initialisation
([dcl.init.general]/6.4), so clang attaches **no** initializer to the `new (p) T;` form for a
non-class `T` (e.g. `new (p) int;`, or `new (pointerToT + i) T;` with `T = unsigned char` in
`Aws::NewArray`). The placement-new lowering in `clang_cpp_convert.cpp` nonetheless created a
`comma` node and only ever added its **second** operand (`tp`), leaving a one-operand comma.

Downstream `op1()` accesses on that node then read past the end of the operand vector:
`clang_c_adjust::adjust_comma` (`clang_c_adjust_expr.cpp:1589`) and `convert_operand_pair`
(`migrate.cpp:592`). Because the read lands on whatever heap bytes are adjacent, the abort
site — and thus the error message — varies with allocation layout, which is exactly the
"varies run to run" behaviour in the issue. A clang AST dump confirms only the non-class,
no-initializer form lacks an init child; `new (p) int();`, `new (p) S;` and `new (p) T;`
(class types) all carry one and were unaffected.

## Fix

Emit the bare typecast `(T*)place` for the no-initializer case — for a non-class type there is
nothing to sequence and the new-expression's value is just the placement address ([expr.new]).
A `comma` is now only ever built on a path that gives it two operands. An
`assert(operands().size() == 2)` is added to `adjust_comma` as a debug-only tripwire documenting
the invariant (RelWithDebInfo compiles with `-DNDEBUG`, so it is zero-cost in release).

## Testing

- New self-contained regression pair (no AWS headers):
  `regression/esbmc-cpp/cpp/placement_new_no_init/` (SUCCESSFUL — scalar, `unsigned char`,
  and the `Aws::NewArray` loop shape, asserting the result aliases the placement address) and
  `placement_new_no_init_fail/` (FAILED — reaches a clean counterexample instead of the SIGABRT).
- Minimal reproducer `int *p = new (buf) int; *p = 42;` went from `exit 134` to
  `VERIFICATION SUCCESSFUL`; the with-initializer control was and remains SUCCESSFUL.
- The issue's AWS reproducer no longer aborts; it now advances to an orthogonal, documented
  `std::shared_ptr`/`allocate_shared` OM gap (tracked separately), which is out of scope here.
- Full `esbmc-cpp/cpp` suite green (the sole timeout, the THOROUGH `ch13_10`, reaches its
  expected `VERIFICATION FAILED` when run with adequate time).