### PR TITLE
[c++] Bind the parameter of explicitly-defaulted operators

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4377_defaulted_assign/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_defaulted_assign/main.cpp
@@ -1,0 +1,36 @@
+// An explicitly-defaulted assignment operator is defaulted but not implicit,
+// so its unnamed parameter was left unbound and the synthesised body read a
+// nondet operand (github #4377).
+#include <cassert>
+#include <utility>
+
+struct Copyable
+{
+  int x;
+  int y;
+  Copyable &operator=(const Copyable &) = default;
+};
+
+struct Movable
+{
+  int x;
+  Movable(int v) : x(v)
+  {
+  }
+  Movable(Movable &&) = default;
+  Movable &operator=(Movable &&) = default;
+};
+
+int main()
+{
+  Copyable a{1, 2}, b{30, 40};
+  a = b;
+  assert(a.x == 30);
+  assert(a.y == 40);
+
+  Movable m(1), n(7);
+  m = std::move(n);
+  assert(m.x == 7);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_defaulted_assign/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_defaulted_assign/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_defaulted_assign_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_defaulted_assign_fail/main.cpp
@@ -1,0 +1,18 @@
+// Negative direction for github #4377: a defaulted assignment must copy the
+// real operand, so a wrong expectation has to be reported as a violation
+// rather than satisfied by a nondet value.
+#include <cassert>
+
+struct Copyable
+{
+  int x;
+  Copyable &operator=(const Copyable &) = default;
+};
+
+int main()
+{
+  Copyable a{1}, b{30};
+  a = b;
+  assert(a.x == 1); // must fail: a.x is 30 after the assignment
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_defaulted_assign_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_defaulted_assign_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4377_defaulted_compare/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_defaulted_compare/main.cpp
@@ -1,0 +1,33 @@
+// Defaulted comparison operators are neither implicit nor constructors, so
+// their unnamed parameter was left unbound (github #4377). For operator<=>
+// the unbound operand carried a struct type into the SMT typecast and aborted
+// the solver rather than producing a counterexample.
+#include <compare>
+#include <cassert>
+
+struct Eq
+{
+  int x;
+  int y;
+  bool operator==(const Eq &) const = default;
+};
+
+struct Ord
+{
+  int x;
+  auto operator<=>(const Ord &) const = default;
+};
+
+int main()
+{
+  Eq a{1, 2}, b{1, 2}, c{1, 3};
+  assert(a == b);
+  assert(!(a == c));
+
+  Ord p{1}, q{2};
+  assert(p < q);
+  assert(!(q < p));
+  assert(q > p);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_defaulted_compare/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_defaulted_compare/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2440,9 +2440,13 @@ void clang_cpp_convertert::name_param_and_continue(
   const clang::DeclContext *dcxt = pd.getParentFunctionOrMethod();
   if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(dcxt))
   {
-    if (
-      (is_CopyOrMoveOperator(*md) && md->isImplicit()) ||
-      (is_ConstructorOrDestructor(*md) && is_defaulted_ctor(*md)))
+    /* Every implicit or explicitly-defaulted method gets a compiler-synthesised
+     * body that refers to its parameter, so the parameter needs a name even
+     * though the declaration leaves it unnamed. Testing isImplicit() alone left
+     * `= default` assignment and comparison operators — which are defaulted but
+     * not implicit — with an unnamed parameter, so their synthesised body read
+     * from an unbound operand (github #4377). */
+    if (md->isImplicit() || md->isDefaulted())
     {
       get_decl_name(*md, name, id);
 


### PR DESCRIPTION
## Root cause

`name_param_and_continue` (`src/clang-cpp-frontend/clang_cpp_convert.cpp`) named the
unnamed parameter of a compiler-synthesised method only when it was an *implicit*
copy/move assignment operator or a defaulted constructor:

```cpp
(is_CopyOrMoveOperator(*md) && md->isImplicit()) ||
(is_ConstructorOrDestructor(*md) && is_defaulted_ctor(*md))
```

An operator written `= default` is defaulted but **not** implicit, and a defaulted
comparison operator is neither a copy/move operator nor a constructor. Neither clause
matched, so their parameter kept an empty identifier while clang still synthesised a
body referring to it. The body then read from an unbound operand:

```
operator= (c:@S@Q@F@operator=#&1$@S@Q#):
        ASSIGN this->x=->x;          <-- RHS has no base expression
```

## Solution

Name the parameter for any method that is implicit **or** defaulted. Every such method
gets a synthesised body that refers to its parameter, so this is the condition that
actually characterises the cases needing a name, and it subsumes both original clauses.

## Impact

The unbound operand did not merely produce a wrong value — it aborted the run:

| Case | std | Before | After |
|---|---|---|---|
| defaulted copy assignment | c++17 | abort in `member2t` (`irep2_expr.h:1569`) | SUCCESSFUL |
| defaulted move assignment | c++17 | abort in `member2t` | SUCCESSFUL |
| defaulted `operator==` | c++20 | `dereference failure: Incorrect alignment` (spurious counterexample) | SUCCESSFUL |
| defaulted `operator<=>` | c++20 | `ERROR: Unexpected type in int/ptr typecast` | SUCCESSFUL |

`= default` on an assignment operator is everyday C++17, so this was reachable well
outside the C++20 comparison corner. This also resolves the `<compare>` item of #4377,
whose solver abort was downstream of the same unbound operand.

## Validation

- New tests fail before the fix and pass after — `github_4377_defaulted_assign` aborts
  pre-fix, `github_4377_defaulted_compare` aborts pre-fix, both SUCCESSFUL post-fix.
- `github_4377_defaulted_assign_fail` fails in both directions, pinning that the fix does
  not mask genuine violations.
- `esbmc-cpp/cpp`, `esbmc-cpp/inheritance`, `esbmc-cpp/destructors`, `esbmc-cpp/template`,
  `esbmc-cpp11`, `esbmc-cpp14`, `esbmc-cpp17`, `esbmc-cpp20`: 900 tests, no new failures.
  The pre-existing failures (`github_2242_*`, `github_3897_collision`, `utility2_fail`,
  `builtin-template*`) were confirmed against an unpatched baseline build and are the
  known macOS host-header/libc++ breakage under `--no-abstracted-cpp-includes`.

Refs #4377