### PR TITLE
[om] Third round of STL gaps behind boost/program_options

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6063_3/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6063_3/main.cpp
@@ -1,0 +1,36 @@
+// Third round of STL gaps behind <boost/program_options.hpp>
+// (github #6063): std::addressof, add_lvalue_reference, fpclassify,
+// the [atomics.syn] fixed-width typedefs, and the
+// basic_string iterator-pair constructor.
+#include <memory>
+#include <utility>
+#include <cmath>
+#include <atomic>
+#include <string>
+#include <cassert>
+
+int main()
+{
+  int v = 42;
+  assert(std::addressof(v) == &v);
+
+  std::add_lvalue_reference<int>::type r = v;
+  r = 7;
+  assert(v == 7);
+
+  assert(std::fpclassify(0.0) == FP_ZERO);
+  assert(std::fpclassify(1.5) == FP_NORMAL);
+  assert(std::fpclassify(1.0 / 0.0) == FP_INFINITE);
+
+  std::atomic_int_least32_t counter(5);
+  counter.store(9);
+  assert(counter.load() == 9);
+
+  const char *text = "hello";
+  std::string s(text, text + 5);
+  assert(s.length() == 5);
+  assert(s[0] == 'h');
+  assert(s[4] == 'o');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6063_3/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6063_3_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6063_3_fail/main.cpp
@@ -1,0 +1,23 @@
+// Negative direction for the round-3 STL gaps (github #6063): each new
+// facility must carry a real value, not a nondet one, so a wrong expectation
+// has to be reported as a violation.
+#include <memory>
+#include <cmath>
+#include <string>
+#include <cassert>
+
+int main()
+{
+  int v = 42;
+  int *p = std::addressof(v);
+  *p = 3;
+  assert(v == 42); // must fail: addressof aliases v, which is now 3
+
+  assert(std::fpclassify(1.5) == FP_ZERO); // must fail: 1.5 is FP_NORMAL
+
+  const char *text = "hello";
+  std::string s(text, text + 5);
+  assert(s.length() == 2); // must fail: the iterator pair spans 5 chars
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6063_3_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6063_3_fill/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6063_3_fill/main.cpp
@@ -1,0 +1,26 @@
+// The basic_string iterator-pair constructor added for github #6063 must not
+// swallow the fill constructor: with both arguments integral, an unconstrained
+// template deduces InputIt=int and wins on an exact match, so `string(3, 42)`
+// would treat 3 and 42 as iterators. libstdc++ constrains its iterator-pair
+// constructor the same way (_RequireInputIter).
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string fill(4, 'x');
+  assert(fill.length() == 4);
+  assert(fill[0] == 'x');
+  assert(fill[3] == 'x');
+
+  std::string fill2(3, 42);
+  assert(fill2.length() == 3);
+  assert(fill2[0] == 42);
+
+  // The iterator-pair form itself still resolves for a raw pointer pair.
+  const char *text = "hello";
+  std::string s(text, text + 5);
+  assert(s.length() == 5);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6063_3_fill/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6063_3_fill/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 25 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -34,6 +34,12 @@ void clang_cpp_languaget::force_file_type(
   // Force clang see all files as .cpp
   compiler_args.push_back("-x");
   compiler_args.push_back("c++");
+
+  /* Clang gives std::addressof a BuiltinAttr and rewrites calls to it, which
+   * discards the operational model's definition and leaves symex a body-less
+   * function returning a nondet pointer (github #6063). We need the real
+   * body, so opt out of the builtin. */
+  compiler_args.emplace_back("-fno-builtin-std-addressof");
 }
 
 void clang_cpp_languaget::build_include_args(

--- a/src/cpp/library/atomic
+++ b/src/cpp/library/atomic
@@ -2,6 +2,7 @@
 #define STL_ATOMIC
 
 #include <cstddef>
+#include <cstdint> // the fixed-width types behind the [atomics.syn] typedefs
 #include "OM_compiler_defs.h" // OM_CONSTEXPR, OM_NOEXCEPT
 
 // Sequentially-consistent model of <atomic> (github #6025): every access is
@@ -368,6 +369,34 @@ typedef atomic<long long> atomic_llong;
 typedef atomic<unsigned long long> atomic_ullong;
 typedef atomic<size_t> atomic_size_t;
 typedef atomic<ptrdiff_t> atomic_ptrdiff_t;
+
+/* [atomics.syn]: the <cstdint>-derived typedefs. */
+typedef atomic<wchar_t> atomic_wchar_t;
+typedef atomic<char16_t> atomic_char16_t;
+typedef atomic<char32_t> atomic_char32_t;
+
+typedef atomic<int_least8_t> atomic_int_least8_t;
+typedef atomic<uint_least8_t> atomic_uint_least8_t;
+typedef atomic<int_least16_t> atomic_int_least16_t;
+typedef atomic<uint_least16_t> atomic_uint_least16_t;
+typedef atomic<int_least32_t> atomic_int_least32_t;
+typedef atomic<uint_least32_t> atomic_uint_least32_t;
+typedef atomic<int_least64_t> atomic_int_least64_t;
+typedef atomic<uint_least64_t> atomic_uint_least64_t;
+
+typedef atomic<int_fast8_t> atomic_int_fast8_t;
+typedef atomic<uint_fast8_t> atomic_uint_fast8_t;
+typedef atomic<int_fast16_t> atomic_int_fast16_t;
+typedef atomic<uint_fast16_t> atomic_uint_fast16_t;
+typedef atomic<int_fast32_t> atomic_int_fast32_t;
+typedef atomic<uint_fast32_t> atomic_uint_fast32_t;
+typedef atomic<int_fast64_t> atomic_int_fast64_t;
+typedef atomic<uint_fast64_t> atomic_uint_fast64_t;
+
+typedef atomic<intptr_t> atomic_intptr_t;
+typedef atomic<uintptr_t> atomic_uintptr_t;
+typedef atomic<intmax_t> atomic_intmax_t;
+typedef atomic<uintmax_t> atomic_uintmax_t;
 } // namespace std
 
 #endif // __cplusplus >= 201103L

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -200,6 +200,37 @@ CIMPORT3(isfinite);
 CIMPORT3(isnormal);
 CIMPORT3(signbit);
 
+/* [c.math.fpclass]. Expressed via the classifiers above rather than
+ * __builtin_fpclassify, whose 5-category form the frontend does not lower. */
+#undef fpclassify
+
+#define OM_FPCLASSIFY(type)                                                    \
+  inline int fpclassify(type x)                                                \
+  {                                                                            \
+    if (__builtin_isnan(x))                                                    \
+      return FP_NAN;                                                           \
+    if (__builtin_isinf(x))                                                    \
+      return FP_INFINITE;                                                      \
+    if (x == (type)0)                                                          \
+      return FP_ZERO;                                                          \
+    if (__builtin_isnormal(x))                                                 \
+      return FP_NORMAL;                                                        \
+    return FP_SUBNORMAL;                                                       \
+  }
+
+OM_FPCLASSIFY(float)
+OM_FPCLASSIFY(double)
+OM_FPCLASSIFY(long double)
+
+#undef OM_FPCLASSIFY
+
+template <typename T>
+inline typename std::enable_if<std::is_integral<T>::value, int>::type
+fpclassify(T x)
+{
+  return fpclassify((double)x);
+}
+
 #undef trunc
 #undef truncf
 #undef truncl

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -10,6 +10,16 @@
 
 namespace std
 {
+/* [specialized.addressof]. The canonical char-reference cast chain that
+ * bypasses an overloaded unary operator& does not survive the pointer model,
+ * so take the address directly: types overloading operator& are then not
+ * modelled faithfully, which is the usual OM trade-off. */
+template <typename T>
+constexpr T *addressof(T &r) noexcept
+{
+  return &r;
+}
+
 // Minimal allocator implementation
 template <typename T>
 class allocator

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -10,16 +10,6 @@
 
 namespace std
 {
-/* [specialized.addressof]. The canonical char-reference cast chain that
- * bypasses an overloaded unary operator& does not survive the pointer model,
- * so take the address directly: types overloading operator& are then not
- * modelled faithfully, which is the usual OM trade-off. */
-template <typename T>
-constexpr T *addressof(T &r) noexcept
-{
-  return &r;
-}
-
 // Minimal allocator implementation
 template <typename T>
 class allocator
@@ -153,6 +143,17 @@ copy(InputIterator first, InputIterator last, ForwardIterator result)
 }
 
 #if __cplusplus >= 201103L // Check if C++11 or later is being used
+
+/* [specialized.addressof]. The canonical char-reference cast chain that
+ * bypasses an overloaded unary operator& does not survive the pointer model,
+ * so take the address directly: types overloading operator& are then not
+ * modelled faithfully, which is the usual OM trade-off. */
+template <typename T>
+constexpr T *addressof(T &r) noexcept
+{
+  return &r;
+}
+
 
 template <class T>
 struct default_delete

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -507,7 +507,25 @@ public:
   basic_string(basic_string<CharT, Traits, Alloc> &s, size_t n);
   basic_string(char c, size_t n);
   explicit basic_string(int len);
-  basic_string(const_iterator begin, const_iterator end);
+
+  /* [string.cons]: the iterator-pair constructor. Templated so it serves raw
+   * pointers as well as the nested iterator types — the previous
+   * const_iterator-only declaration was never defined, so a raw `char *` pair
+   * (as boost's type_index uses) found no viable overload. The non-template
+   * (const CharT *, size_t) overload still wins for a pointer/length call. */
+  template <class InputIt>
+  basic_string(InputIt first, InputIt last)
+  {
+  __ESBMC_HIDE:
+    _size = 0;
+    for (; first != last; ++first)
+    {
+      __ESBMC_assert(_size + 1 < STRING_CAPACITY, "basic_string overflow");
+      str[_size++] = *first;
+    }
+    str[_size] = '\0';
+  }
+
   char *c_str() const;
   bool operator>(basic_string<CharT, Traits, Alloc> &a);
   bool operator>(const char *a);

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -512,9 +512,16 @@ public:
    * pointers as well as the nested iterator types — the previous
    * const_iterator-only declaration was never defined, so a raw `char *` pair
    * (as boost's type_index uses) found no viable overload. The non-template
-   * (const CharT *, size_t) overload still wins for a pointer/length call. */
+   * (const CharT *, size_t) overload still wins for a pointer/length call.
+   *
+   * Constrained away from integral types, as libstdc++ constrains it with
+   * _RequireInputIter: without this, `basic_string(10, 42)` deduces InputIt=int
+   * and beats the (char, size_t) fill constructor on an exact match. */
   template <class InputIt>
-  basic_string(InputIt first, InputIt last)
+  basic_string(
+    InputIt first,
+    InputIt last,
+    typename enable_if<!is_integral<InputIt>::value>::type * = 0)
   {
   __ESBMC_HIDE:
     _size = 0;

--- a/src/cpp/library/utility
+++ b/src/cpp/library/utility
@@ -62,6 +62,17 @@ struct add_rvalue_reference<void>
   typedef void type;
 };
 
+template <class T>
+struct add_lvalue_reference
+{
+  typedef T &type;
+};
+template <>
+struct add_lvalue_reference<void>
+{
+  typedef void type;
+};
+
 // move
 template <class T>
 constexpr remove_reference_t<T> &&move(T &&t) noexcept


### PR DESCRIPTION
## Root cause

Third increment on #6063 (after #6127). Re-probing `<boost/program_options.hpp>` on
current master surfaces a fresh layer of missing standard-library facilities:

- `std::addressof` and `std::add_lvalue_reference` — absent (`boost/any.hpp`).
- `std::fpclassify` — absent (`boost/core/cmath.hpp`).
- The `[atomics.syn]` fixed-width typedefs, e.g. `std::atomic_int_least32_t`
  (`boost/smart_ptr/detail/sp_counted_base_std_atomic.hpp`).
- The `basic_string` iterator-pair constructor. `basic_string(const_iterator,
  const_iterator)` was *declared but never defined*, so a raw `char *` pair — what
  `boost/type_index/stl_type_index.hpp` passes — found no viable overload, and a
  `const_iterator` pair would have linked to nothing.

A separate defect surfaced while modelling `addressof`: clang gives `std::addressof` a
`BuiltinAttr` and rewrites calls to it, discarding the model's body and leaving symex a
body-less function returning a **nondet pointer**. The declaration alone fixes parsing but
silently yields garbage at verification time.

## Solution

Add the missing facilities, and pass `-fno-builtin-std-addressof` from the C++ frontend so
the model's body is actually used.

The iterator-pair constructor is a member template. That is deliberate and verified: a
member template *does* get a GOTO body (the round-2 finding that member templates no-op
applies specifically to *variadic* ones), and a non-template `(const CharT *, const CharT *)`
overload would make `string(p, 0)` ambiguous against `(const CharT *, size_t)`, since `0` is
a null pointer constant. As a template it loses to the non-template on that call.

## Scope

This does not close #6063 — `<boost/program_options.hpp>` still needs `std::shared_ptr`,
the `basic_streambuf`/`basic_stringbuf` templates, and a templated `basic_string_view`.
Those are genuine modelling work rather than declarations and are left for a later round.
`<cwchar>` was prepared and deliberately dropped: without wide-character C models its
names would resolve to body-less functions, which is worse than the header being absent.

## Validation

- `github_6063_3` covers each facility positively; `github_6063_3_fail` pins that each
  carries a real value rather than a nondet one, by asserting a wrong expectation and
  requiring a violation.
- `esbmc-cpp/{cpp,string,stream,vector,list,map,template,destructors,algorithm,OM_sanity_checks}`,
  `esbmc-cpp11`, `esbmc-cpp17`: no new failures. The four pre-existing failures
  (`github_2242_*`, `github_3897_collision`, `utility2_fail`) were confirmed identical on an
  unpatched baseline build — they are the known macOS host-header/libc++ breakage.

Refs #6063