### PR TITLE
[c++] Dispatch delete through the virtual destructor slot

### DIFF
--- a/regression/esbmc-cpp/destructors/github_6198/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198/main.cpp
@@ -1,0 +1,37 @@
+#include <cassert>
+
+int order[8];
+int n = 0;
+
+struct A
+{
+  virtual ~A()
+  {
+    order[n++] = 1;
+  }
+};
+struct B : A
+{
+  ~B()
+  {
+    order[n++] = 2;
+  }
+};
+struct C : B
+{
+  ~C()
+  {
+    order[n++] = 3;
+  }
+};
+
+int main()
+{
+  A *p = new C();
+  delete p;
+  // [expr.delete]/3, [class.dtor]/9: the virtual destructor dispatches to the
+  // most-derived one, and the bases are destroyed in reverse order.
+  assert(n == 3);
+  assert(order[0] == 3 && order[1] == 2 && order[2] == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6198/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--incremental-bmc
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/destructors/github_6198_fail/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_fail/main.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+
+int n = 0;
+
+struct A
+{
+  virtual ~A()
+  {
+    n += 1;
+  }
+};
+struct C : A
+{
+  ~C()
+  {
+    n += 10;
+  }
+};
+
+int main()
+{
+  A *p = new C();
+  delete p;
+  // ~C must run too, so this is unreachable.
+  assert(n == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6198_fail/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--incremental-bmc
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/destructors/github_6198_in_destructor/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_in_destructor/main.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+
+int n = 0;
+
+struct A
+{
+  virtual ~A()
+  {
+    n += 1;
+  }
+};
+struct C : A
+{
+  ~C()
+  {
+    n += 10;
+  }
+};
+
+struct Holder
+{
+  A *q;
+  ~Holder()
+  {
+    delete q;
+  }
+};
+
+int main()
+{
+  {
+    Holder h;
+    h.q = new C();
+  }
+  // Virtual dispatch must also work for a delete inside a destructor body.
+  assert(n == 11);
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6198_in_destructor/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198_in_destructor/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--incremental-bmc
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/destructors/github_6198_intermediate_base/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_intermediate_base/main.cpp
@@ -1,0 +1,36 @@
+#include <cassert>
+
+int order[8];
+int n = 0;
+
+struct A
+{
+  virtual ~A()
+  {
+    order[n++] = 1;
+  }
+};
+struct B : A
+{
+  ~B()
+  {
+    order[n++] = 2;
+  }
+};
+struct C : B
+{
+  ~C()
+  {
+    order[n++] = 3;
+  }
+};
+
+int main()
+{
+  // Delete through the intermediate base, not the root.
+  B *p = new C();
+  delete p;
+  assert(n == 3);
+  assert(order[0] == 3 && order[1] == 2 && order[2] == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6198_intermediate_base/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198_intermediate_base/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--incremental-bmc
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/destructors/github_6198_multiple_inheritance/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_multiple_inheritance/main.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+
+int n = 0;
+
+struct A
+{
+  virtual ~A()
+  {
+    n += 1;
+  }
+};
+struct B
+{
+  virtual ~B()
+  {
+    n += 10;
+  }
+};
+struct C : A, B
+{
+  ~C()
+  {
+    n += 100;
+  }
+};
+
+int main()
+{
+  A *p = new C();
+  delete p;
+  // Expected 111. ~C overrides two base destructors, so
+  // get_ultimate_overridden_method() (clang_cpp_convert_vft.cpp) stops at its
+  // `size_overridden_methods() == 1` guard and keys the vtable slot by ~C's
+  // own id instead of ~A's, leaving the slot bound to ~A. Tracked by #1866 /
+  // #3894 alongside the other multiple-inheritance layout defects.
+  assert(n == 111);
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6198_multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198_multiple_inheritance/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--incremental-bmc
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/destructors/github_6198_non_virtual/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_non_virtual/main.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+
+int n = 0;
+
+struct A
+{
+  ~A()
+  {
+    n += 1;
+  }
+};
+struct C : A
+{
+  ~C()
+  {
+    n += 10;
+  }
+};
+
+int main()
+{
+  A *p = new C();
+  delete p;
+  // A non-virtual destructor stays statically bound: only ~A runs.
+  assert(n == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6198_non_virtual/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198_non_virtual/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--incremental-bmc
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/destructors/github_6198_null_base/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_null_base/main.cpp
@@ -1,0 +1,28 @@
+#include <cassert>
+
+int n = 0;
+
+struct A
+{
+  virtual ~A()
+  {
+    n += 1;
+  }
+};
+struct C : A
+{
+  ~C()
+  {
+    n += 10;
+  }
+};
+
+int main()
+{
+  A *p = 0;
+  // [expr.delete]/7: no destructor runs, and the null guard must skip the
+  // vtable read rather than dereferencing a null vptr.
+  delete p;
+  assert(n == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6198_null_base/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198_null_base/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--incremental-bmc --memory-leak-check
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/destructors/github_6198_use_after_delete/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_use_after_delete/main.cpp
@@ -1,0 +1,21 @@
+struct A
+{
+  int v;
+  virtual ~A()
+  {
+  }
+};
+struct C : A
+{
+  ~C()
+  {
+  }
+};
+
+int main()
+{
+  A *p = new C();
+  delete p;
+  // Virtual dispatch must not hide the use-after-free.
+  return p->v;
+}

--- a/regression/esbmc-cpp/destructors/github_6198_use_after_delete/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6198_use_after_delete/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--incremental-bmc
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -61,7 +61,19 @@ public:
     side_effect_expr_function_callt &expr) override;
   void adjust_reference(exprt &expr) override;
   void adjust_new(exprt &expr);
+  void adjust_cpp_delete(side_effect_exprt &expr);
   void adjust_cpp_member(member_exprt &expr);
+
+  /**
+   * The callee of a `delete` expression's destructor call: the virtual function
+   * table slot reached through \p object, so that the most-derived destructor
+   * runs ([expr.delete]/3, [class.dtor]/9), or the destructor symbol itself
+   * when it is not virtual.
+   */
+  exprt destructor_binding(
+    const struct_typet &class_type,
+    const struct_typet::componentt &dtor,
+    const exprt &object);
 
   /**
    * Adjusts a C++ pseudo-destructor call expression.

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -97,18 +97,7 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
   }
   else if (statement == "cpp_delete" || statement == "cpp_delete[]")
   {
-    adjust_operands(expr);
-    // adjust side effect node to explicitly call class destructor
-    // e.g. the adjustment here will add the following instruction in GOTO:
-    // FUNCTION_CALL:  ~t2(&(*p))
-    code_function_callt destructor;
-    if (get_destructor(ns, expr.type(), destructor))
-    {
-      exprt new_object("new_object", expr.type());
-
-      destructor.arguments().push_back(address_of_exprt(new_object));
-      expr.set("destructor", destructor);
-    }
+    adjust_cpp_delete(expr);
   }
   else if (statement == "temporary_object")
   {
@@ -130,6 +119,96 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
   }
   else
     clang_c_adjust::adjust_side_effect(expr);
+}
+
+void clang_cpp_adjust::adjust_cpp_delete(side_effect_exprt &expr)
+{
+  adjust_operands(expr);
+
+  // adjust side effect node to explicitly call class destructor
+  // e.g. the adjustment here will add the following instruction in GOTO:
+  // FUNCTION_CALL:  ~t2(&(*p))
+  const struct_typet *class_type = resolve_class_type(ns, expr.type());
+  if (class_type == nullptr)
+    return;
+
+  const struct_typet::componentt *dtor =
+    get_destructor_component(ns, *class_type);
+  if (dtor == nullptr)
+    return;
+
+  exprt new_object("new_object", expr.type());
+
+  code_function_callt destructor;
+  destructor.function() = destructor_binding(*class_type, *dtor, new_object);
+  destructor.arguments().push_back(address_of_exprt(new_object));
+  expr.set("destructor", destructor);
+}
+
+exprt clang_cpp_adjust::destructor_binding(
+  const struct_typet &class_type,
+  const struct_typet::componentt &dtor,
+  const exprt &object)
+{
+  exprt static_binding("symbol", dtor.type());
+  static_binding.identifier(dtor.name());
+
+  if (!dtor.get_bool("is_virtual"))
+    return static_binding;
+
+  // The slot is keyed by the destructor's `virtual_name`, i.e. the id of the
+  // ultimate overridden destructor. Select the vtable pointer whose table
+  // actually carries that slot rather than assuming the class's own vptr comes
+  // first among the components.
+  const struct_typet::componentt *vptr = nullptr;
+  const struct_typet::componentt *slot = nullptr;
+  const typet *vtable_type = nullptr;
+
+  for (const auto &comp : class_type.components())
+  {
+    if (!comp.get_bool("is_vtptr"))
+      continue;
+
+    const typet &candidate = ns.follow(comp.type().subtype());
+    if (candidate.id() != "struct")
+      continue;
+
+    for (const auto &entry : to_struct_type(candidate).components())
+      if (entry.get("virtual_name") == dtor.get("virtual_name"))
+      {
+        vptr = &comp;
+        slot = &entry;
+        vtable_type = &candidate;
+        break;
+      }
+
+    if (slot != nullptr)
+      break;
+  }
+
+  // A class with a virtual destructor always carries a vtable pointer and a
+  // matching slot: both are emitted together when the vtable is built. Falling
+  // back to the static destructor here would silently skip the derived
+  // destructors' side effects, so fail loudly instead.
+  if (slot == nullptr)
+  {
+    log_error(
+      "{}: no virtual table slot for destructor `{}` of `{}`",
+      __func__,
+      dtor.name(),
+      class_type.tag());
+    abort();
+  }
+
+  // *object.@vtable_pointer->~T#
+  member_exprt vptr_member(object, vptr->name(), vptr->type());
+  dereference_exprt vtable(vptr_member, vptr->type());
+  // No further adjust pass runs over this expression, so resolve the vtable
+  // symbol type here: member2t requires a resolved struct source.
+  vtable.type() = *vtable_type;
+
+  member_exprt slot_member(vtable, slot->name(), slot->type());
+  return dereference_exprt(slot_member, slot->type());
 }
 
 void clang_cpp_adjust::adjust_new(exprt &expr)

--- a/src/goto-programs/destructor.cpp
+++ b/src/goto-programs/destructor.cpp
@@ -1,66 +1,78 @@
 #include <goto-programs/destructor.h>
 
+const struct_typet *resolve_class_type(const namespacet &ns, const typet &type)
+{
+  if (type.id() == "symbol")
+    return resolve_class_type(ns, ns.follow(type));
+
+  if (type.id() != "struct")
+    return nullptr;
+
+  // An inline struct type embedded in a function body can be a degraded copy
+  // of the class type: the --irep2-bodies round-trip strips the C++ `methods`
+  // sub and component attributes, because IREP2 struct types store only data
+  // members. Resolve it back to the authoritative type symbol via its tag so
+  // callers see the full method list and the self-reference comparison
+  // matches. Falls back to the inline type for anonymous structs and when no
+  // symbol is bound (the legacy flag-off type already carries its methods, so
+  // this is a no-op there).
+  const irep_idt &tag = type.get("tag");
+  const symbolt *type_sym =
+    tag.empty() ? nullptr : ns.lookup("tag-" + id2string(tag));
+
+  return &to_struct_type(
+    (type_sym != nullptr && type_sym->get_type().id() == "struct")
+      ? type_sym->get_type()
+      : type);
+}
+
+const struct_typet::componentt *
+get_destructor_component(const namespacet &ns, const struct_typet &struct_type)
+{
+  for (const auto &component : struct_type.methods())
+  {
+    if (!component.type().is_code())
+      continue;
+
+    const code_typet &code_type = to_code_type(component.type());
+
+    if (
+      code_type.return_type().id() != "destructor" ||
+      code_type.arguments().size() != 1)
+      continue;
+
+    const typet &arg_type = code_type.arguments().front().type();
+
+    if (
+      arg_type.id() == "pointer" &&
+      ns.follow(arg_type.subtype()) == struct_type)
+      return &component;
+  }
+
+  return nullptr;
+}
+
 bool get_destructor(
   const namespacet &ns,
   const typet &type,
   code_function_callt &destructor)
 {
-  if (type.id() == "symbol")
-  {
-    return get_destructor(ns, ns.follow(type), destructor);
-  }
+  const struct_typet *struct_type = resolve_class_type(ns, type);
+  if (struct_type == nullptr)
+    return false;
 
-  if (type.id() == "struct")
-  {
-    // An inline struct type embedded in a function body can be a degraded copy
-    // of the class type: the --irep2-bodies round-trip strips the C++ `methods`
-    // sub and component attributes, because IREP2 struct types store only data
-    // members. Resolve it back to the authoritative type symbol via its tag so
-    // the scan below sees the full method list and the self-reference
-    // comparison matches. Falls back to the inline type for anonymous structs
-    // and when no symbol is bound (the legacy flag-off type already carries its
-    // methods, so this is a no-op there).
-    const irep_idt &tag = type.get("tag");
-    const symbolt *type_sym =
-      tag.empty() ? nullptr : ns.lookup("tag-" + id2string(tag));
-    const typet &resolved =
-      (type_sym != nullptr && type_sym->get_type().id() == "struct")
-        ? type_sym->get_type()
-        : type;
+  const struct_typet::componentt *component =
+    get_destructor_component(ns, *struct_type);
 
-    const struct_typet &struct_type = to_struct_type(resolved);
+  if (component == nullptr)
+    return false;
 
-    const struct_typet::componentst &components = struct_type.methods();
+  exprt symbol_expr("symbol", component->type());
+  symbol_expr.identifier(component->name());
 
-    for (const auto &component : components)
-    {
-      if (component.type().is_code())
-      {
-        const code_typet &code_type = to_code_type(component.type());
+  code_function_callt function_call;
+  function_call.function() = symbol_expr;
 
-        if (
-          code_type.return_type().id() == "destructor" &&
-          code_type.arguments().size() == 1)
-        {
-          const typet &arg_type = code_type.arguments().front().type();
-
-          if (
-            arg_type.id() == "pointer" &&
-            ns.follow(arg_type.subtype()) == resolved)
-          {
-            exprt symbol_expr("symbol", component.type());
-            symbol_expr.identifier(component.name());
-
-            code_function_callt function_call;
-            function_call.function() = symbol_expr;
-
-            destructor = function_call;
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return false;
+  destructor = function_call;
+  return true;
 }

--- a/src/goto-programs/destructor.h
+++ b/src/goto-programs/destructor.h
@@ -3,6 +3,20 @@
 
 #include <util/namespace.h>
 #include <util/std_code.h>
+#include <util/std_types.h>
+
+/// Follows \p type to the authoritative class type symbol, or nullptr when it
+/// does not resolve to a struct.
+///
+/// The result points either into the symbol table or, for a tag that is not
+/// bound, into \p type itself, so it stays valid only as long as both do:
+/// callers must not pass a temporary, nor erase symbols before using it.
+const struct_typet *resolve_class_type(const namespacet &ns, const typet &type);
+
+/// The destructor method component of \p struct_type, or nullptr when it has
+/// none. The result points into \p struct_type and shares its lifetime.
+const struct_typet::componentt *
+get_destructor_component(const namespacet &ns, const struct_typet &struct_type);
 
 bool get_destructor(
   const namespacet &ns,

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1109,7 +1109,12 @@ void goto_convertt::convert_cpp_delete(const codet &code, goto_programt &dest)
     }
     else if (code.statement() == "cpp_delete")
     {
-      exprt deref_op("dereference", tmp_op.type().subtype());
+      // Follow the pointee: a virtually-bound destructor reads the vtable
+      // pointer out of this dereference, and member2t needs a resolved struct
+      // source. This cannot move to the C++ adjuster, because the
+      // replace_new_object below substitutes the placeholder node wholesale,
+      // type included. Only the C++ frontend emits cpp_delete.
+      exprt deref_op("dereference", ns.follow(tmp_op.type().subtype()));
       deref_op.copy_to_operands(tmp_op);
 
       codet tmp_code = to_code(destructor);


### PR DESCRIPTION
## Root cause

`clang_cpp_adjust_expr.cpp` built the `delete` destructor call statically via `get_destructor()`, which scans for a `destructor`-returning component without ever consulting `is_virtual`. So `delete p` through an `A*` always lowered to a static call

```
FUNCTION_CALL:  ~A(&(*p))
```

and the derived destructors — along with their side effects, member destruction and resource release — were silently skipped.

## Solution

Bind the call to the virtual function table slot the frontend already emits, so `delete` lowers exactly like an ordinary virtual call:

```
FUNCTION_CALL:  *p->struct A@vtable_pointer->c:@S@A@F@~A#(&(*p))
```

The binding happens in the **adjust** phase rather than at the `CXXDeleteExpr` site in the converter. That placement is what avoids the `member2t` blocker described in the issue: the adjuster works on an already-resolved type instead of composing a clang `MemberExpr`, so a `delete` inside a destructor body works. `esbmc-cpp11/lambda` — the `std::function` suite named in the issue as broken by the converter-side approach — passes.

The slot is located by the `is_vtptr` flag and the `virtual_name` key rather than by reconstructing mangled names, and the vtable pointer is chosen as the one whose table actually carries the matching slot, so nothing depends on component ordering.

`destructor.cpp` is refactored to expose `resolve_class_type` and `get_destructor_component`; `get_destructor` becomes a thin adapter over them and keeps its signature, so existing `goto-programs` callers are untouched.

One line lands outside the C++ frontend. `convert_cpp_delete` built `*p` with an unfollowed symbol type; that was harmless while the result only fed an `address_of`, but a virtually-bound destructor reads the vtable pointer *through* that dereference, and `member2t` requires a resolved struct source — unresolved, it reached symex and aborted in `symbol_type2t::get_width()`. It cannot move into the C++ adjuster, because `replace_new_object` substitutes the placeholder node wholesale, type included. Only the C++ frontend emits `cpp_delete`.

A class with a virtual destructor always carries a vtable pointer and a matching slot. If neither is found the frontend now fails loudly rather than falling back to the static destructor, since a silent fallback would reintroduce exactly the false `VERIFICATION SUCCESSFUL` this fixes.

## Known limitation (pre-existing, not a regression)

Multiple inheritance still runs only the static destructor. `get_ultimate_overridden_method` (`clang_cpp_convert_vft.cpp:138`) walks `while (size_overridden_methods() == 1)`, so a `~C` overriding *two* base destructors exits the loop immediately and keys its vtable slot by its own id instead of the ultimate overridden destructor's, leaving the slot bound to the base destructor. Ordinary virtual methods are unaffected, since they usually override exactly one base method; destructors are the common case where the count is ≥ 2.

A correct fix needs a per-base destructor slot keyed by that base's id, which is the nested-subobject vtable work tracked under #1866 / #3894. It is pinned here as `github_6198_multiple_inheritance` (KNOWNBUG) with the root cause recorded in the test, so the gap is documented rather than invisible.

## Validation

Eight regression tests under `regression/esbmc-cpp/destructors/`:

| test | expects | purpose |
| --- | --- | --- |
| `github_6198` | SUCCESSFUL | the reproducer; pins destruction *order* `{3,2,1}`, not just the count |
| `github_6198_fail` | FAILED | `n == 1` must be unreachable, so the fix cannot be vacuous |
| `github_6198_non_virtual` | SUCCESSFUL | non-virtual destructors stay statically bound (guards against over-binding) |
| `github_6198_in_destructor` | SUCCESSFUL | `delete` inside a destructor body — the blocker in the issue |
| `github_6198_intermediate_base` | SUCCESSFUL | delete through an intermediate base, exercising vtable-pointer selection |
| `github_6198_null_base` | SUCCESSFUL | `[expr.delete]/7`: the null guard must skip the vtable read |
| `github_6198_use_after_delete` | FAILED | virtual dispatch must not mask a use-after-free |
| `github_6198_multiple_inheritance` | KNOWNBUG | documents the MI gap above |

`github_6198`, `github_6198_fail` and `github_6198_in_destructor` were confirmed to **fail before the fix and pass after**, by rebuilding the pre-fix binary. `github_6198_non_virtual` passes both before and after, which is what makes it a useful guard.

Full `esbmc-cpp` sweep (all of `esbmc-cpp`, `esbmc-cpp11`, `esbmc-cpp14`, `esbmc-cpp17`, `esbmc-cpp20`): **2469 of 2470 tests, 6 failures, all pre-existing.** Three fail at *parsing* on macOS SDK header search paths (`github_2242_1/2`, `builtin-template{,-fail}`), one on a header name collision (`github_3897_collision`), and `utility2_fail` correctly reports `VERIFICATION FAILED` under a known `--multi-property` output-format mismatch. None can be reached by destructor dispatch. The single test that did not complete, `esbmc-cpp/unix/10_bicycle_03`, is a long-running KNOWNBUG concurrency test whose GOTO program contains zero virtually-bound destructor calls, so this change cannot affect it.

Bitwuzla and Z3 agree on both the positive and the negative case. Formatting verified with clang-format 11, as CI uses.

Fixes #6198
