### PR TITLE
[ir-ieee] approximate underflow and preserve interval soundness

### DIFF
--- a/regression/ir-ra/ra-interval-lift-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo::0\| \|smt_conv::ra_lo::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\+ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|
+\(\/ \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-div-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo::0\| \|smt_conv::ra_lo::0\|
-\(\/ \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|
+\(< \|smt_conv::ra_lo::0\| 0
+\(\/ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-div-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\/ \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-div-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\/ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked-single/test.desc
@@ -3,6 +3,6 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|
+\(\/ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_lo_dn::0\|
-\(\/ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\/ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\/ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\/ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rtz-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rtz-both-tracked-single/test.desc
@@ -3,6 +3,6 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_hi_tz::0\|
+\(\/ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rtz-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rtz-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_lo_tz::0\|
-\(\/ \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_hi_tz::0\|
-\(< 0\.0 \|smt_conv::ra_lo_tz::0\|
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\/ \|c:main.c@
+\(< 0\.0 \|smt_conv::ra_hi_tz::0\|
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rtz-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rtz-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\/ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rtz-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rtz-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\/ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rup-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rup-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_hi_up::0\|
+\(\/ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-div-rup-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rup-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|
-\(\/ \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_hi_up::0\|
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\/ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-div-rup-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rup-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\/ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-div-rup-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rup-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\/ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-both-tracked-single/test.desc
@@ -3,6 +3,6 @@ main.c
 --ir-ieee --z3 --smt-formula-only
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo::0\| \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\* \|c:main.c@
 \(check-sat\)

--- a/regression/ir-ra/ra-interval-lift-mul-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-both-tracked/test.desc
@@ -3,6 +3,6 @@ main.c
 --ir-ieee --z3 --smt-formula-only
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo::0\| \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\* \|c:main.c@
 \(check-sat\)

--- a/regression/ir-ra/ra-interval-lift-mul-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\* \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\* \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-rdn-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rdn-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\* \|c:main.c@
 8388608
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-rdn-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rdn-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\* \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-rtz-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rtz-both-tracked-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\* \|c:main.c@
 8388608
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-rtz-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rtz-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\* \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-rtz-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rtz-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\* \|c:main.c@
 8388608
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-rtz-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rtz-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\* \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\* \|c:main.c@
 22204460492503131
 (^VERIFICATION FAILED$|^Building error trace$)
 

--- a/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\* \|c:main.c@
 (8388608|\(/ 1\.0 0\.0\))
-^Solving with solver Z3
+Solving with solver Z3

--- a/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\* \|c:main.c@
 (22204460492503131|\(/ 1\.0 0\.0\))
-^Solving with solver Z3
+Solving with solver Z3

--- a/regression/ir-ra/ra-interval-lift-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\+ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_lo_dn::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\+ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_lo_dn::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\+ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\+ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(\+ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_lo_aw::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\+ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-div-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-div-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_hi_aw::0\|
+\(\/ \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-div-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-div-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_lo_aw::0\|
-\(\/ \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_hi_aw::0\|
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\/ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-div-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-div-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\/ \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-div-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-div-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\/ \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\/ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\* \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\* \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\* \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\* \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\* \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-rna-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(\+ \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_hi_aw::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(- \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_hi_aw::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(- \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(- \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_aw::0\|
-\(ite
+\(< \|smt_conv::ra_lo_aw::0\| 0
+\(- \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_lo_tz::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\+ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_lo_tz::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\+ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\+ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(\+ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\+ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\+ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\+ \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(\+ \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(\+ \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-both-tracked-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(- \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-sub-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-both-tracked/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(\- \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-sub-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-one-fresh-single/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(- \|c:main.c@
 5960464477539063
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-sub-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-one-fresh/test.desc
@@ -3,8 +3,8 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo::0\|
-\(ite
+\(< \|smt_conv::ra_lo::0\| 0
+\(- \|c:main.c@
 5551115123125783
 ^VERIFICATION FAILED$
 

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(- \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(- \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(- \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_dn::0\|
-\(ite
+\(< \|smt_conv::ra_lo_dn::0\| 0
+\(- \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_hi_tz::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(- \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_hi_tz::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(- \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(- \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_tz::0\|
-\(ite
+\(< \|smt_conv::ra_lo_tz::0\| 0
+\(- \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_hi_up::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(- \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_hi_up::0\|\)
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(- \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh-single/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(- \|c:main.c@
 8388608
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh/test.desc
@@ -3,7 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
-\(- \|smt_conv::ra_lo_up::0\|
-\(ite
+\(< \|smt_conv::ra_lo_up::0\| 0
+\(- \|c:main.c@
 22204460492503131
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-mul-no-underflow-pass/main.c
+++ b/regression/ir-ra/ra-mul-no-underflow-pass/main.c
@@ -1,0 +1,7 @@
+int main(void)
+{
+  float x = 0.5f;
+  float y = x * x;
+  __ESBMC_assert(y > 0.0f, "0.5 * 0.5 = 0.25 is above the subnormal threshold");
+  return 0;
+}

--- a/regression/ir-ra/ra-mul-no-underflow-pass/test.desc
+++ b/regression/ir-ra/ra-mul-no-underflow-pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-mul-rup-flush-then-div-fail/main.c
+++ b/regression/ir-ra/ra-mul-rup-flush-then-div-fail/main.c
@@ -1,0 +1,15 @@
+/* Without interval widening, y's stored interval excludes 0 after flush,
+ * making the div constraint UNSAT -- a false-safe verdict. */
+extern float __VERIFIER_nondet_float(void);
+extern int __ESBMC_rounding_mode;
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* FE_UPWARD */
+  float x = __VERIFIER_nondet_float();
+  __ESBMC_assume(x > 0.0f && x < 1e-22f);
+  float y = x * x; /* flushes to zero */
+  float z = 1.0f / y; /* division by flushed zero yields +inf */
+  __ESBMC_assert(z < 1e30f, "result of div-by-flushed-zero must be finite");
+  return 0;
+}

--- a/regression/ir-ra/ra-mul-rup-flush-then-div-fail/test.desc
+++ b/regression/ir-ra/ra-mul-rup-flush-then-div-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-mul-subnormal-underflow-fail/main.c
+++ b/regression/ir-ra/ra-mul-subnormal-underflow-fail/main.c
@@ -1,0 +1,12 @@
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float x = __VERIFIER_nondet_float();
+  /* Any nonzero x with |x| < 2^-74.5 has x*x < 2^-149 (float min subnormal),
+   * so IEEE 754 rounds x*x to zero. */
+  __ESBMC_assume(x > 0.0f && x < 1e-22f);
+  float y = x * x;
+  __ESBMC_assert(y != 0.0f, "float mul of tiny x underflows to zero");
+  return 0;
+}

--- a/regression/ir-ra/ra-mul-subnormal-underflow-fail/test.desc
+++ b/regression/ir-ra/ra-mul-subnormal-underflow-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -410,6 +410,15 @@ std::pair<smt_astt, smt_astt> ir_ieee_convt::apply_ieee754_rtz_enclosure(
   return {ra_lo, ra_hi};
 }
 
+std::pair<smt_astt, smt_astt>
+ir_ieee_convt::widen_for_flush(smt_astt lo, smt_astt hi)
+{
+  smt_astt zero_r = ctx->get_zero_real();
+  return {
+    ctx->mk_ite(ctx->mk_lt(lo, zero_r), lo, zero_r),
+    ctx->mk_ite(ctx->mk_lt(zero_r, hi), hi, zero_r)};
+}
+
 std::pair<smt_astt, smt_astt> ir_ieee_convt::apply_enclosure(
   smt_astt real_result,
   smt_astt lo_r,
@@ -465,7 +474,6 @@ smt_astt ir_ieee_convt::encode_ieee_add(const expr2tc &expr)
     smt_astt hi_r = ctx->mk_add(iv1.hi, iv2.hi);
     auto bounds =
       apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
-    store_interval(real_result, bounds.first, bounds.second);
 
     // +∞ + (−∞) and (−∞) + (+∞) are invalid operations that produce NaN.
     smt_astt invalid_op_nan = ctx->mk_or(
@@ -476,9 +484,12 @@ smt_astt ir_ieee_convt::encode_ieee_add(const expr2tc &expr)
     smt_astt nan_p = combine_nan_preds(
       combine_nan_preds(get_nan_pred(side1), get_nan_pred(side2)),
       invalid_op_nan);
+    smt_astt flushed = ctx->mk_subnormal_flush(real_result, fbv_type);
+    auto [lo_w, hi_w] = widen_for_flush(bounds.first, bounds.second);
+    store_interval(flushed, lo_w, hi_w);
     if (nan_p)
-      store_nan_pred(real_result, nan_p);
-    return real_result;
+      store_nan_pred(flushed, nan_p);
+    return flushed;
   }
   return ctx->apply_ieee754_semantics(
     real_result, fbv_type, nullptr, rounding_mode);
@@ -502,7 +513,6 @@ smt_astt ir_ieee_convt::encode_ieee_sub(const expr2tc &expr)
     smt_astt hi_r = ctx->mk_sub(iv1.hi, iv2.lo);
     auto bounds =
       apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
-    store_interval(real_result, bounds.first, bounds.second);
 
     // +∞ − (+∞) and (−∞) − (−∞) are invalid operations that produce NaN.
     smt_astt invalid_op_nan = ctx->mk_or(
@@ -513,9 +523,12 @@ smt_astt ir_ieee_convt::encode_ieee_sub(const expr2tc &expr)
     smt_astt nan_p = combine_nan_preds(
       combine_nan_preds(get_nan_pred(side1), get_nan_pred(side2)),
       invalid_op_nan);
+    smt_astt flushed = ctx->mk_subnormal_flush(real_result, fbv_type);
+    auto [lo_w, hi_w] = widen_for_flush(bounds.first, bounds.second);
+    store_interval(flushed, lo_w, hi_w);
     if (nan_p)
-      store_nan_pred(real_result, nan_p);
-    return real_result;
+      store_nan_pred(flushed, nan_p);
+    return flushed;
   }
   return ctx->apply_ieee754_semantics(
     real_result, fbv_type, nullptr, rounding_mode);
@@ -564,7 +577,6 @@ smt_astt ir_ieee_convt::encode_ieee_mul(const expr2tc &expr)
         ctx->mk_ite(ctx->mk_le(p4, p3), p3, p4)));
     auto bounds =
       apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
-    store_interval(real_result, bounds.first, bounds.second);
 
     // 0 × ±∞ and ±∞ × 0 are invalid operations that produce NaN.
     // When both operands are the same value it can be neither zero nor
@@ -583,9 +595,12 @@ smt_astt ir_ieee_convt::encode_ieee_mul(const expr2tc &expr)
     smt_astt nan_p = combine_nan_preds(
       combine_nan_preds(get_nan_pred(side1), get_nan_pred(side2)),
       invalid_op_nan);
+    smt_astt flushed = ctx->mk_subnormal_flush(real_result, fbv_type);
+    auto [lo_w, hi_w] = widen_for_flush(bounds.first, bounds.second);
+    store_interval(flushed, lo_w, hi_w);
     if (nan_p)
-      store_nan_pred(real_result, nan_p);
-    return real_result;
+      store_nan_pred(flushed, nan_p);
+    return flushed;
   }
   return ctx->apply_ieee754_semantics(
     real_result, fbv_type, operand_is_zero, rounding_mode);
@@ -663,8 +678,15 @@ smt_astt ir_ieee_convt::encode_ieee_div(const expr2tc &expr)
 
     auto bounds =
       apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
-    smt_astt a = ctx->mk_ite(div_by_zero, inf_result, real_result);
-    store_interval(a, bounds.first, bounds.second);
+    smt_astt flushed = ctx->mk_subnormal_flush(real_result, fbv_type);
+    smt_astt a = ctx->mk_ite(div_by_zero, inf_result, flushed);
+    // When div_by_zero fires (denominator flushed to zero), the result is
+    // ±sentinel (infinity).  Widen to [−sentinel, sentinel] in that branch;
+    // otherwise widen to include zero for the subnormal-flush case.
+    auto [lo_w, hi_w] = widen_for_flush(bounds.first, bounds.second);
+    smt_astt lo_a = ctx->mk_ite(div_by_zero, ctx->mk_sub(zero, sentinel), lo_w);
+    smt_astt hi_a = ctx->mk_ite(div_by_zero, sentinel, hi_w);
+    store_interval(a, lo_a, hi_a);
     smt_astt zero_div_zero_nan =
       ctx->mk_and(ctx->mk_eq(side1, zero), div_by_zero);
     // ±∞ / ±∞ is an invalid operation that produces NaN.
@@ -734,7 +756,6 @@ smt_astt ir_ieee_convt::encode_ieee_fma(const expr2tc &expr)
 
     auto bounds =
       apply_enclosure(real_result, lo_r, hi_r, fbv_type, rounding_mode);
-    store_interval(real_result, bounds.first, bounds.second);
 
     // 0 × ±∞ in the multiply sub-step is an invalid operation.
     smt_astt zero = ctx->get_zero_real();
@@ -768,9 +789,12 @@ smt_astt ir_ieee_convt::encode_ieee_fma(const expr2tc &expr)
       combine_nan_preds(get_nan_pred(val1), get_nan_pred(val2)),
       combine_nan_preds(
         get_nan_pred(val3), combine_nan_preds(mul_nan, add_nan)));
+    smt_astt flushed = ctx->mk_subnormal_flush(real_result, fbv_type);
+    auto [lo_w, hi_w] = widen_for_flush(bounds.first, bounds.second);
+    store_interval(flushed, lo_w, hi_w);
     if (nan_p)
-      store_nan_pred(real_result, nan_p);
-    return real_result;
+      store_nan_pred(flushed, nan_p);
+    return flushed;
   }
 
   return ctx->apply_ieee754_semantics(

--- a/src/solvers/smt/fp/ir_ieee_conv.h
+++ b/src/solvers/smt/fp/ir_ieee_conv.h
@@ -173,6 +173,10 @@ private:
     smt_astt hi_r,
     const floatbv_type2t &fbv_type,
     const expr2tc &rounding_mode);
+
+  /** Widen [lo, hi] to [min(0,lo), max(0,hi)] so that the zero produced by
+   *  mk_subnormal_flush is always within the stored interval. */
+  std::pair<smt_astt, smt_astt> widen_for_flush(smt_astt lo, smt_astt hi);
 };
 
 #endif /* SOLVERS_SMT_FP_IR_IEEE_CONV_H_ */

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -515,11 +515,18 @@ smt_solver_baset::mk_subnormal_flush(smt_astt r, const floatbv_type2t &fbv_type)
   const auto double_spec = ieee_float_spect::double_precision();
   const auto single_spec = ieee_float_spect::single_precision();
   smt_astt min_sub;
+  // get_double_min_subnormal()/get_single_min_subnormal() are decimal
+  // literals deliberately rounded UP to stay conservative when used as an
+  // enclosure epsilon elsewhere; that rounding makes them exceed the true
+  // 2^-1074 / 2^-149 boundary, so reusing them here would flush the
+  // smallest representable subnormal itself to zero. Use the exact
+  // power-of-two fraction instead, so only real results that are not
+  // representable at all get flushed.
   if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
-    min_sub = get_double_min_subnormal();
+    min_sub = mk_smt_real("1/" + integer2string(power(2, 1074)));
   else if (
     fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
-    min_sub = get_single_min_subnormal();
+    min_sub = mk_smt_real("1/" + integer2string(power(2, 149)));
   else
     return r;
   smt_astt zero = get_zero_real();

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -50,7 +50,7 @@ smt_astt smt_solver_baset::apply_ieee754_semantics(
       assert_ast(mk_le(ra_lo, real_result));
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));
-      return real_result;
+      return mk_subnormal_flush(real_result, fbv_type);
     };
 
     auto select_nearest_eps =
@@ -161,7 +161,7 @@ smt_astt smt_solver_baset::apply_ieee754_semantics(
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));
 
-      return real_result;
+      return mk_subnormal_flush(real_result, fbv_type);
     }
     else if (smt_fp_rounding_utils::is_round_to_plus_inf(rounding_mode))
     {
@@ -204,7 +204,7 @@ smt_astt smt_solver_baset::apply_ieee754_semantics(
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));
 
-      return real_result;
+      return mk_subnormal_flush(real_result, fbv_type);
     }
     else if (smt_fp_rounding_utils::is_round_to_minus_inf(rounding_mode))
     {
@@ -249,7 +249,7 @@ smt_astt smt_solver_baset::apply_ieee754_semantics(
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));
 
-      return real_result;
+      return mk_subnormal_flush(real_result, fbv_type);
     }
     else if (smt_fp_rounding_utils::is_round_to_zero(rounding_mode))
     {
@@ -307,7 +307,7 @@ smt_astt smt_solver_baset::apply_ieee754_semantics(
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));
 
-      return real_result;
+      return mk_subnormal_flush(real_result, fbv_type);
     }
     else if (smt_fp_rounding_utils::is_round_to_away(rounding_mode))
     {
@@ -363,7 +363,7 @@ smt_astt smt_solver_baset::apply_ieee754_semantics(
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));
 
-      return real_result;
+      return mk_subnormal_flush(real_result, fbv_type);
     }
     else
     {
@@ -507,6 +507,24 @@ smt_astt smt_solver_baset::get_single_max_normal()
   static const std::string val =
     integer2string((power(2, 24) - 1) * power(2, 104));
   return mk_smt_real(val);
+}
+
+smt_astt
+smt_solver_baset::mk_subnormal_flush(smt_astt r, const floatbv_type2t &fbv_type)
+{
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt min_sub;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+    min_sub = get_double_min_subnormal();
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+    min_sub = get_single_min_subnormal();
+  else
+    return r;
+  smt_astt zero = get_zero_real();
+  smt_astt abs_r = mk_ite(mk_lt(r, zero), mk_sub(zero, r), r);
+  return mk_ite(mk_lt(abs_r, min_sub), zero, r);
 }
 
 smt_astt smt_solver_baset::get_double_inf_sentinel()

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -2121,6 +2121,14 @@ smt_astt smt_solver_baset::convert_terminal(const expr2tc &expr)
       smt_astt nan_pred =
         mk_fresh(mk_bool_sort(), "ir_ieee::nondet_nan::", nullptr);
       ir_ieee_api->store_nan_pred(sym_ast, nan_pred);
+
+      // A nondet float is otherwise an unconstrained real. Without this,
+      // it can take a value strictly between 0 and the smallest subnormal
+      // (a magnitude no floating-point operation ever produces), which
+      // breaks identities like x+0==x now that mk_subnormal_flush()
+      // distinguishes that gap from zero.
+      const floatbv_type2t &fbv_type = to_floatbv_type(sym.type);
+      assert_ast(mk_eq(sym_ast, mk_subnormal_flush(sym_ast, fbv_type)));
     }
 
     return sym_ast;

--- a/src/solvers/smt/smt_solver.h
+++ b/src/solvers/smt/smt_solver.h
@@ -449,6 +449,11 @@ public:
   smt_astt get_single_min_subnormal();
   // Returns SMT AST representing single precision maximum normal value (~3.4028234663852886e+38)
   smt_astt get_single_max_normal();
+  // Under --ir-ieee, returns ite(|r| < min_subnormal, 0, r) for single/double,
+  // modelling IEEE 754 flush-to-zero for results below the subnormal threshold.
+  // Returns r unchanged for unsupported formats.
+  smt_astt mk_subnormal_flush(smt_astt r, const floatbv_type2t &fbv_type);
+
   // Returns SMT AST for the integer-encoding sentinel for double +∞: max_normal+1
   smt_astt get_double_inf_sentinel();
   // Returns SMT AST for the integer-encoding sentinel for single +∞: max_normal+1


### PR DESCRIPTION
## Summary

This PR adds a sound approximation of IEEE-754 underflow to the `--ir-ieee` encoding.

Subnormal results are approximated using flush-to-zero (FTZ), while tracked intervals are widened before flushing to preserve soundness.

This change is limited to the `--ir-ieee` encoding and does not affect the existing `floatbv` encoding.

## Changes

- Add flush-to-zero handling for subnormal floating-point results.
- Preserve interval soundness by widening tracked bounds before applying the underflow approximation.
- Apply the approximation consistently across supported floating-point operations and rounding modes.
- Add regression tests covering:
  - multiplication without underflow,
  - multiplication producing a subnormal result,
  - multiplication followed by division after flushing.
- Update interval-lifting regression expectations to match the SMT generated by interval widening.

## Review Notes

The implementation and new regression tests are contained in the first commit.

The second commit contains only mechanical updates to existing `test.desc` files. These updates are required because interval widening changes the generated SMT expression shape across interval-lifting variants. They do not change solver behaviour.

## Testing

```bash
perl regression/test.pl \
  -c "$(realpath build/src/esbmc/esbmc)" \
  -p regression/ir-ra/*/
```

Result:

```text
243 tests
All tests were successful
```

## Commits

1. **[ir-ieee] approximate underflow and preserve interval soundness**
   - Implementation changes.
   - New regression tests.

2. **[ir-ieee] update interval-lifting regression expectations**
   - Mechanical updates to regression descriptors reflecting the SMT generated by interval widening.