### PR TITLE
[test] emit east const in generated nondet value tables

### DIFF
--- a/regression/witnesses/test_case_generation/ctest_gen_pointer/main.c
+++ b/regression/witnesses/test_case_generation/ctest_gen_pointer/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+void *__VERIFIER_nondet_pointer(void);
+
+int main()
+{
+  void *p = __VERIFIER_nondet_pointer();
+  assert(p != 0);
+  return 0;
+}

--- a/regression/witnesses/test_case_generation/ctest_gen_pointer/test.desc
+++ b/regression/witnesses/test_case_generation/ctest_gen_pointer/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--generate-ctest-testcase
+^Generated CTest test case\: test_case\.c$
+^VERIFICATION FAILED$
+CHECK_FILE test_case.c contains static void\* const v\[\]
+CHECK_FILE test_case.c absent static const void\*

--- a/regression/witnesses/test_case_generation/ctest_gen_pointer_cpp/main.cpp
+++ b/regression/witnesses/test_case_generation/ctest_gen_pointer_cpp/main.cpp
@@ -1,0 +1,10 @@
+#include <cassert>
+
+extern "C" void *__VERIFIER_nondet_pointer(void);
+
+int main()
+{
+  void *p = __VERIFIER_nondet_pointer();
+  assert(p != nullptr);
+  return 0;
+}

--- a/regression/witnesses/test_case_generation/ctest_gen_pointer_cpp/test.desc
+++ b/regression/witnesses/test_case_generation/ctest_gen_pointer_cpp/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.cpp
+--std c++11 --generate-ctest-testcase
+^Generated CTest test case\: test_case\.cpp$
+^VERIFICATION FAILED$
+CHECK_FILE test_case.cpp contains static void\* const v\[\]
+CHECK_FILE test_case.cpp absent static const void\*

--- a/src/goto-symex/ctest.cpp
+++ b/src/goto-symex/ctest.cpp
@@ -375,7 +375,9 @@ static void write_nondet_functions(
 
     out << c_type << " __VERIFIER_nondet_" << verifier_type << "(void) {\n";
     out << "  static int i = 0;\n";
-    out << "  static const " << c_type << " v[] = { ";
+    // East const: c_type is "void*" for pointers, so a leading const would
+    // qualify the pointee and make `return v[i++]` discard it.
+    out << "  static " << c_type << " const v[] = { ";
     for (size_t j = 0; j < values.size(); ++j)
     {
       if (j > 0)


### PR DESCRIPTION
`type_to_c_string` returns `"void*"` for pointers, so `static const <type> v[]` composed to an array of pointer-to-const-void and the following `return v[i++]` discarded a qualifier — a hard error in C++ and a constraint violation in C. Every generated test case whose counterexample contains a nondet pointer therefore failed to compile.

East const binds to the array element instead, which is the identical type for all scalar spellings. Adds two regression tests pinning the emitted declaration via `CHECK_FILE`; both were confirmed to fail on a pre-patch binary.

Fixes #6207