### PR TITLE
[docs] Document how to choose between the two loop-invariant modes

### DIFF
--- a/regression/loop-invariants/mode_bound_independent_combined/main.c
+++ b/regression/loop-invariants/mode_bound_independent_combined/main.c
@@ -1,0 +1,20 @@
+/* The assertion follows from the invariant alone, so the inductive step closes
+ * at k = 2 and the cost does not grow with the loop bound.  A bound of 100000
+ * is far beyond what bounded unrolling could reach within the k-step limit. */
+#include <assert.h>
+
+int main(void)
+{
+  unsigned int x = 0;
+  unsigned int y = 0;
+
+  __ESBMC_loop_invariant(x == y);
+  while (x < 100000)
+  {
+    x++;
+    y++;
+  }
+
+  assert(x == y);
+  return 0;
+}

--- a/regression/loop-invariants/mode_bound_independent_combined/test.desc
+++ b/regression/loop-invariants/mode_bound_independent_combined/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant
+^VERIFICATION SUCCESSFUL$
+Solution found by the inductive step

--- a/regression/loop-invariants/mode_exit_reasoning_check/main.c
+++ b/regression/loop-invariants/mode_exit_reasoning_check/main.c
@@ -1,0 +1,21 @@
+/* The assertion needs the invariant AND the negated loop condition:
+ * sum == i * 10 together with !(i < 1000) gives i == 1000, hence sum == 10000.
+ * Only --loop-invariant-check performs that exit reasoning, so it discharges
+ * this regardless of the bound; --loop-invariant falls back to unrolling. */
+#include <assert.h>
+
+int main(void)
+{
+  unsigned int i = 0;
+  unsigned int sum = 0;
+
+  __ESBMC_loop_invariant(i <= 1000 && sum == i * 10);
+  while (i < 1000)
+  {
+    sum += 10;
+    i++;
+  }
+
+  assert(sum == 10000);
+  return 0;
+}

--- a/regression/loop-invariants/mode_exit_reasoning_check/test.desc
+++ b/regression/loop-invariants/mode_exit_reasoning_check/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--loop-invariant-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/mode_exit_reasoning_check_fail/main.c
+++ b/regression/loop-invariants/mode_exit_reasoning_check_fail/main.c
@@ -1,0 +1,21 @@
+/* The assertion needs the invariant AND the negated loop condition:
+ * sum == i * 10 together with !(i < 1000) gives i == 1000, hence sum == 10000.
+ * Only --loop-invariant-check performs that exit reasoning, so it discharges
+ * this regardless of the bound; --loop-invariant falls back to unrolling. */
+#include <assert.h>
+
+int main(void)
+{
+  unsigned int i = 0;
+  unsigned int sum = 0;
+
+  __ESBMC_loop_invariant(i <= 1000 && sum == i * 10);
+  while (i < 1000)
+  {
+    sum += 10;
+    i++;
+  }
+
+  assert(sum == 9990);
+  return 0;
+}

--- a/regression/loop-invariants/mode_exit_reasoning_check_fail/test.desc
+++ b/regression/loop-invariants/mode_exit_reasoning_check_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--loop-invariant-check
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/quantified_array_invariant/main.c
+++ b/regression/loop-invariants/quantified_array_invariant/main.c
@@ -1,0 +1,47 @@
+/* Quantified postcondition over an array filled by the loop (GitHub #6217).
+ * __ESBMC_forall(&i, !(i < N) || ...) needs i == N at exit, so it is exit
+ * reasoning and wants --loop-invariant-check.  The loop is cut rather than
+ * unrolled, so --unwind only has to cover the rest of the function and the
+ * cost is independent of N. */
+#include <stdint.h>
+
+#define N 1024
+#define Q 3329
+
+typedef struct
+{
+  int16_t e[N];
+} poly;
+
+static int16_t reduce(int16_t c)
+{
+  __ESBMC_requires(c > -Q && c < Q);
+  __ESBMC_ensures(__ESBMC_return_value >= 0 && __ESBMC_return_value < Q);
+
+  if (c < 0)
+    c = (int16_t)(c + Q);
+  return c;
+}
+
+void normalise(poly *p)
+{
+  unsigned i, j;
+  __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(poly)));
+  __ESBMC_ensures(__ESBMC_forall(&i, !(i < N) || (p->e[i] >= 0 && p->e[i] < Q)));
+
+  __ESBMC_loop_invariant(
+    i <= N && __ESBMC_forall(&j, !(j < i) || (p->e[j] >= 0 && p->e[j] < Q)));
+  for (i = 0; i < N; i++)
+  {
+    int16_t c = p->e[i];
+    __ESBMC_assume(c > -Q && c < Q);
+    p->e[i] = reduce(c);
+  }
+}
+
+int main(void)
+{
+  poly p;
+  normalise(&p);
+  return 0;
+}

--- a/regression/loop-invariants/quantified_array_invariant/test.desc
+++ b/regression/loop-invariants/quantified_array_invariant/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function normalise --enforce-contract normalise --no-pointer-check --unwind 8 --loop-invariant-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/quantified_array_invariant_fail/main.c
+++ b/regression/loop-invariants/quantified_array_invariant_fail/main.c
@@ -1,0 +1,47 @@
+/* Quantified postcondition over an array filled by the loop (GitHub #6217).
+ * __ESBMC_forall(&i, !(i < N) || ...) needs i == N at exit, so it is exit
+ * reasoning and wants --loop-invariant-check.  The loop is cut rather than
+ * unrolled, so --unwind only has to cover the rest of the function and the
+ * cost is independent of N. */
+#include <stdint.h>
+
+#define N 1024
+#define Q 3329
+
+typedef struct
+{
+  int16_t e[N];
+} poly;
+
+static int16_t reduce(int16_t c)
+{
+  __ESBMC_requires(c > -Q && c < Q);
+  __ESBMC_ensures(__ESBMC_return_value >= 0 && __ESBMC_return_value < Q);
+
+  if (c < 0)
+    c = (int16_t)(c + Q);
+  return c;
+}
+
+void normalise(poly *p)
+{
+  unsigned i, j;
+  __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(poly)));
+  __ESBMC_ensures(__ESBMC_forall(&i, !(i < N) || (p->e[i] >= 0 && p->e[i] < 100)));
+
+  __ESBMC_loop_invariant(
+    i <= N && __ESBMC_forall(&j, !(j < i) || (p->e[j] >= 0 && p->e[j] < Q)));
+  for (i = 0; i < N; i++)
+  {
+    int16_t c = p->e[i];
+    __ESBMC_assume(c > -Q && c < Q);
+    p->e[i] = reduce(c);
+  }
+}
+
+int main(void)
+{
+  poly p;
+  normalise(&p);
+  return 0;
+}

--- a/regression/loop-invariants/quantified_array_invariant_fail/test.desc
+++ b/regression/loop-invariants/quantified_array_invariant_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function normalise --enforce-contract normalise --no-pointer-check --unwind 8 --loop-invariant-check
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -485,10 +485,13 @@ const struct group_opt_templ all_cmd_options[] = {
      "Set max k value for the inductive step"},
     {"loop-invariant",
      NULL,
-     "Verify using loop invariant + k-induction (combined mode)"},
+     "Verify using loop invariant + k-induction (combined mode). Still unwinds "
+     "the loop; use when the property follows from the invariant alone"},
     {"loop-invariant-check",
      NULL,
-     "Verify using loop invariant inductive check (standalone mode)"},
+     "Verify using loop invariant havoc abstraction (standalone mode). Cuts "
+     "the loop, so cost is independent of the bound; the only mode that "
+     "reasons about the loop exit condition"},
     {"loop-frame-rule",
      NULL,
      "Enable frame rule for loop invariant checking "

--- a/website/content/docs/loop-invariants.md
+++ b/website/content/docs/loop-invariants.md
@@ -14,19 +14,41 @@ prohibitive or hit iteration limits.
 
 Like [function contracts](/docs/function-contracts), loop invariants are
 expressed with built-in constructs placed in the source. The core construct is
-`__ESBMC_loop_invariant(condition)`, placed within the loop body.
+`__ESBMC_loop_invariant(condition)`, placed **before the loop** as a statement
+ending with `;`.
+
+## Choosing a Mode
+
+ESBMC provides **two distinct modes**, and picking the wrong one is the most
+common reason a correct invariant appears not to help. The deciding question is
+**what your post-loop property needs in order to follow**:
+
+| Your property follows from…                                       | Use                      | Cost in the loop bound         |
+| ----------------------------------------------------------------- | ------------------------ | ------------------------------ |
+| the invariant **alone**                                            | `--loop-invariant`       | independent — closes at `k = 2` |
+| the invariant **together with the negated loop condition**         | `--loop-invariant-check` | independent — loop is cut      |
+
+The second row is easy to miss. An invariant like `i <= N && sum == i * 10`
+only yields `sum == N * 10` once you also know `!(i < N)`, i.e. `i == N` at
+exit. That final step is *exit reasoning*, and only `--loop-invariant-check`
+performs it. Under `--loop-invariant` such a property falls back to bounded
+unrolling and will report `VERIFICATION UNKNOWN` once the bound exceeds the
+k-induction step limit.
+
+Properties over an array filled by the loop — `__ESBMC_forall(&i, !(i < N) ||
+p[i] == 0)` and friends — are almost always in the second row, since they need
+`i == N` at exit.
 
 ## Verification Modes
 
-ESBMC provides **two distinct modes** for loop invariant verification.
+### `--loop-invariant` — Combined Mode
 
-### `--loop-invariant` — Combined Mode (Default, Recommended)
+Integrates invariant checking with k-induction. The invariant is used as an
+assumption that strengthens the inductive step, so whenever the property
+follows from the invariant alone, verification closes at a small `k`
+regardless of how large the loop bound is.
 
-This is the recommended mode. It integrates invariant checking with k-induction
-for robust analysis, eliminating the spurious counterexamples that the legacy
-mode could produce for correct-but-weak invariants.
-
-> **Note:** `--loop-invariant` now implicitly enables k-induction. No extra
+> **Note:** `--loop-invariant` implicitly enables k-induction. No extra
 > flags are required.
 
 **How it works — two-branch transformation:**
@@ -56,47 +78,107 @@ GOTO loop_head
 | Correct but weak      | Passes                                               | Proves property via forward condition |
 | Correct and strong    | Passes                                               | Closes at inductive step              |
 
-### `--loop-invariant-check` — Legacy Mode
+The last row holds when the property follows from the invariant alone. If it
+also needs the negated loop condition, the inductive step cannot close and
+k-induction falls back to unrolling — see [Choosing a Mode](#choosing-a-mode).
 
-The original three-part havoc abstraction is preserved under this flag for
-backward compatibility. It replaces the annotated loop with:
+### `--loop-invariant-check` — Havoc Abstraction Mode
+
+Applies the classic Hoare rule, replacing the annotated loop with:
 
 1. **Base-case assertion** — invariant holds on entry
 2. **Havoc + Assume** — abstracts the loop body nondeterministically
 3. **Inductive-step assertion** — invariant still holds after one iteration
 
-This mode avoids loop unrolling entirely, making it faster when the only goal is
-checking invariant inductivity without k-induction overhead. However, it **may
-produce spurious counterexamples** for invariants that are correct but weak,
-because the havoc step can assign values outside the expected program state
-without proper constraint propagation.
+The loop is then cut, so this mode **avoids loop unrolling entirely** and its
+cost does not grow with the loop bound. It is the only mode that performs exit
+reasoning (`invariant && !condition` at the loop exit), which makes it the
+required choice for the second row of [Choosing a Mode](#choosing-a-mode).
 
-> Use `--loop-invariant-check` only when speed is the priority and you
-> understand the false-positive risk.
+Two caveats:
 
-## Example: Basic Loop Invariant Usage
+- It **may produce spurious counterexamples** for invariants that are correct
+  but too weak, because the havoc step can assign values outside the expected
+  program state without proper constraint propagation. Strengthen the invariant
+  until it entails the property you are proving.
+- Cutting the loop establishes **partial correctness** only: termination is not
+  proved. Use `--termination` separately if you need it.
+
+## Example: Property Follows From the Invariant Alone
+
+`x == y` is exactly what the assertion needs, so the inductive step closes at
+`k = 2` and the loop bound is irrelevant — this verifies as quickly at `100000`
+as at `10`.
 
 ```c
-int main() {
-    int i = 0;
-    int sum = 0;
+#include <assert.h>
 
-    __ESBMC_loop_invariant(i >= 0 && i <= 1000 && sum == i * 10);
+int main(void) {
+    unsigned int x = 0;
+    unsigned int y = 0;
+
+    __ESBMC_loop_invariant(x == y);
+    while (x < 100000) {
+        x++;
+        y++;
+    }
+
+    assert(x == y);
+    return 0;
+}
+```
+
+```bash
+esbmc file.c --loop-invariant
+# VERIFICATION SUCCESSFUL — Solution found by the inductive step (k = 2)
+```
+
+## Example: Property Needs the Exit Condition
+
+Here `sum == 10000` follows only from `sum == i * 10` *and* `i == 1000`, and
+the latter needs `!(i < 1000)` at exit. This is the case that requires
+`--loop-invariant-check`; under `--loop-invariant` it reports
+`VERIFICATION UNKNOWN` because the bound exceeds the k-induction step limit.
+
+```c
+#include <assert.h>
+
+int main(void) {
+    unsigned int i = 0;
+    unsigned int sum = 0;
+
+    __ESBMC_loop_invariant(i <= 1000 && sum == i * 10);
     while (i < 1000) {
         sum += 10;
         i++;
     }
 
-    assert(sum == 10000);  // Successfully verified
+    assert(sum == 10000);
     return 0;
 }
 ```
 
-Verify with:
-
 ```bash
-esbmc file.c --loop-invariant
+esbmc file.c --loop-invariant-check
+# VERIFICATION SUCCESSFUL
 ```
+
+The same shape appears whenever a loop fills an array and the postcondition
+quantifies over it, which is why array contracts under `--enforce-contract`
+normally want `--loop-invariant-check`:
+
+```c
+__ESBMC_ensures(__ESBMC_forall(&i, !(i < N) || (a->e[i] >= 0 && a->e[i] < Q)));
+
+__ESBMC_loop_invariant(i <= N && __ESBMC_forall(&j, !(j < i) ||
+                       (a->e[j] >= 0 && a->e[j] < Q)));
+for (i = 0; i < N; i++)
+  a->e[i] = reduce(a->e[i]);
+```
+
+With `--loop-invariant-check` this discharges in a fraction of a second for any
+`N`, and `--unwind` only has to cover the rest of the function rather than the
+loop.
 
 ## Companion Options
 
@@ -122,17 +204,21 @@ incorrect invariant will lead to a failed base-case assertion in
 `--loop-invariant` mode, or potentially a spurious result in
 `--loop-invariant-check` mode.
 
-> **Note:** The integer overflow false-positive issue present in the legacy mode
-> (caused by unconstrained havoc operations) has been resolved in the new
-> `--loop-invariant` combined mode. If you observe such false positives, ensure
-> you are not using `--loop-invariant-check`.
+> **Note:** `--loop-invariant-check` havocs every loop-modified variable, so an
+> invariant that does not constrain them enough can yield a false positive
+> (commonly an integer-overflow report). `--loop-invariant` does not have this
+> failure mode. If you hit it, either strengthen the invariant or, when the
+> property follows from the invariant alone, switch to `--loop-invariant`.
 
-## Backward Compatibility
+## Mode Summary
 
-The `--loop-invariant` flag now routes to the new combined mode. The legacy
-behavior is accessible via `--loop-invariant-check`. Programs without loop
-invariant annotations continue to use the standard k-induction unwinding
-approach.
+|                          | Unrolls the loop | Exit reasoning | Weak invariant           |
+| ------------------------ | ---------------- | -------------- | ------------------------ |
+| `--loop-invariant`       | yes              | no             | falls back to unrolling  |
+| `--loop-invariant-check` | no               | yes            | may report false positive |
+
+Programs without loop invariant annotations continue to use the standard
+k-induction unwinding approach under either flag.
 
 ## Loop Frame Rule (`--loop-frame-rule`)
 


### PR DESCRIPTION
## What

`website/content/docs/loop-invariants.md` recommended `--loop-invariant` unconditionally and presented `--loop-invariant-check` as a legacy mode to avoid ("only when speed is the priority and you understand the false-positive risk"). That steer is backwards for a common class of properties, and the page's own worked example did not verify under the flag it recommended.

## Why

The two modes differ in whether they perform **exit reasoning** — using `invariant && !condition` at the loop exit:

| bound | `--k-induction` | `--loop-invariant` | `--loop-invariant-check` |
|---|---|---|---|
| 40 | SUCCESSFUL | SUCCESSFUL | SUCCESSFUL |
| 100 | UNKNOWN | UNKNOWN | **SUCCESSFUL** |
| 1000 | UNKNOWN | UNKNOWN | **SUCCESSFUL** |

(`i <= N && sum == i * 10` proving `sum == N * 10`, which needs `i == N` at exit.)

Combined mode is not at fault — when the property follows from the invariant *alone* it closes at `k = 2` independently of the bound, verified here at a bound of 100000. But when the property also needs the negated loop condition, it falls back to unrolling and reports UNKNOWN past the k-step limit. Only `--loop-invariant-check` cuts the loop and discharges the exit step.

This is what a user hit in #6217: a quantified postcondition over a loop-filled array (`__ESBMC_forall(&i, !(i < N) || ...)`) is always in the second row, since it needs `i == N` at exit. Following the documentation led them away from the one mode that handles it. With `--loop-invariant-check` their reproducer verifies in 0.3s flat from N=256 to N=16384, against 294s for the fully-unrolled encoding.

## Changes

- Lead with a **Choosing a Mode** section stating the criterion, plus a summary table.
- Replace the worked example (which returned `VERIFICATION UNKNOWN` under `--loop-invariant`) with two examples, one per case, both verified.
- Retire the "legacy mode" framing; keep the accurate spurious-counterexample caveat and add that cutting the loop establishes partial correctness only.
- Drop the claim that the invariant goes *within the loop body* — it contradicted the frame-rule section on the same page, and 51 of 64 existing tests place it before the loop.
- Extend the two `--help` strings with the same distinction.

## Tests

Five tests in `regression/loop-invariants/`, covering both sides of the criterion and both verdicts:

- `mode_exit_reasoning_check` / `_fail` — property needs the exit condition
- `mode_bound_independent_combined` — property follows from the invariant alone, bound 100000, closes at the inductive step
- `quantified_array_invariant` / `_fail` — the #6217 shape under `--enforce-contract`; the failing variant guards against the fast discharge going vacuous

`loop-invariants` 73/73, `function_contract` 271/271, `k-induction` 196/196. clang-format clean.

Refs #6217.