### PR TITLE
[goto-programs] Keep quantifier loop summaries linear in trip count

### DIFF
--- a/regression/bitwuzla/github_6154_count_exists_size10/main.c
+++ b/regression/bitwuzla/github_6154_count_exists_size10/main.c
@@ -1,0 +1,31 @@
+// GitHub #6154: the reporter's program.  Merging an if/else inside an unrolled
+// loop used to embed the running value in both mux arms, making the summary
+// 2^n for a trip count of n; at SIZE=10 that tripped the size cap and the
+// existential — which cannot be skolemized — was rejected outright.
+#define SIZE 10
+typedef int idx_t;
+typedef char data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  idx_t idx;
+  int res = 0;
+  for (idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t a_vec[SIZE];
+  idx_t a_idx_vfy;
+  // Every element occurs at least once: the element at the witness index.
+  __ESBMC_assert(
+    __ESBMC_exists(
+      &a_idx_vfy,
+      (0 <= a_idx_vfy && a_idx_vfy < SIZE) &&
+        count(a_vec[a_idx_vfy], a_vec) != 0),
+    "some element occurs in the array");
+  return 0;
+}

--- a/regression/bitwuzla/github_6154_count_exists_size10/test.desc
+++ b/regression/bitwuzla/github_6154_count_exists_size10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 12 --no-standard-checks --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/github_6154_mux_rules/main.c
+++ b/regression/bitwuzla/github_6154_mux_rules/main.c
@@ -1,0 +1,159 @@
+// GitHub #6154: differential check of the branch-merge rewrites.  Each function
+// is evaluated twice over the same nondeterministic array: once outside any
+// quantifier, where BMC unrolls it normally, and once under __ESBMC_exists,
+// where it must be summarized (an existential cannot fall back to
+// skolemization).  Any rewrite that changes the summarized value diverges from
+// the unrolled reference and fails here.
+//
+// Every call takes the bound variable as an argument and reads a[k] in the loop
+// guard.  That dependence is what forces the call through the summarizer: a
+// body that does not mention the bound variable is simply hoisted to a temp and
+// evaluated by ordinary BMC, which would make this test vacuous.
+#define N 8
+#define K 3
+
+// Running value on the left of a non-commutative `-'.
+int sub_left(int a[N], int k)
+{
+  int r = 100;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r - 3;
+  return r;
+}
+
+// Running value on the *right* of `-': must not absorb as if commutative.
+int sub_right(int a[N], int k)
+{
+  int r = 1;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = 50 - r;
+  return r;
+}
+
+// Opposite operators per branch, reconciled by the `A - k' -> `A + (-k)' rule.
+int incdec(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      ++r;
+    else
+      --r;
+  return r;
+}
+
+// Same operator, differing constant: merged by pushing the mux into the operand.
+// Spelled out rather than `+=', which the summarizer does not model.
+int addk(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r + 1;
+    else
+      r = r + 2;
+  return r;
+}
+
+// Multiplicative accumulator, whose identity is 1.  Kept shallow: mixing a
+// nonlinear accumulator with the bitwise one below on a single variable costs
+// Z3 two orders of magnitude more time than either alone.
+int mul(int a[N], int k)
+{
+  int r = 1;
+  for (int i = 0; i < 4; ++i)
+    if (a[i] > a[k])
+      r = r * 3;
+  return r;
+}
+
+// Bitwise accumulator, whose identity is 0.
+int xr(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r ^ 5;
+  return r;
+}
+
+// Unsigned wraparound: the rewrite is exact only in modular arithmetic.
+unsigned wrap(int a[N], int k)
+{
+  unsigned r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r - 7u;
+  return r;
+}
+
+// Mixed-width arms.  Both arms are `int', so the mux may be pushed under the
+// common typecast only if the operands themselves agree in width -- otherwise
+// the wider arm is silently narrowed and the summary computes (int)(char)l.
+int widths(int a[N], int k, char c, long l)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = (int)c;
+    else
+      r = (int)l;
+  return r;
+}
+
+// Equal width, differing signedness: the arms must not be unified on width
+// alone, or the summary reinterprets one of them.
+int signs(int a[N], int k, unsigned char uc, signed char sc)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = (int)uc;
+    else
+      r = (int)sc;
+  return r;
+}
+
+// Early return, folded by the same rewrite as the branch merge.
+int early(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+  {
+    if (a[i] == a[k] + 42)
+      return -1;
+    if (a[i] > a[k])
+      ++r;
+  }
+  return r;
+}
+
+int main()
+{
+  int a[N], i;
+  int r1 = sub_left(a, K), r2 = sub_right(a, K), r3 = incdec(a, K);
+  int r4 = addk(a, K), r5 = mul(a, K), r6 = xr(a, K), r8 = early(a, K);
+  unsigned r7 = wrap(a, K);
+  // 300 does not fit in a char: a narrowing mux would compute 44 instead.
+  int r9 = widths(a, K, 1, 300);
+  // 200 and -56 share the low 8 bits: unifying on width alone confuses them.
+  int r10 = signs(a, K, 200, -56);
+
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && sub_left(a, i) == r1), "sub_left");
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && sub_right(a, i) == r2), "sub_right");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && incdec(a, i) == r3), "incdec");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && addk(a, i) == r4), "addk");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && mul(a, i) == r5), "mul");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && xr(a, i) == r6), "xor");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && wrap(a, i) == r7), "wrap");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && early(a, i) == r8), "early");
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && widths(a, i, 1, 300) == r9), "widths");
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && signs(a, i, 200, -56) == r10), "signs");
+  return 0;
+}

--- a/regression/bitwuzla/github_6154_mux_rules/test.desc
+++ b/regression/bitwuzla/github_6154_mux_rules/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 10 --no-standard-checks --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_count_exists_size10/main.c
+++ b/regression/z3/github_6154_count_exists_size10/main.c
@@ -1,0 +1,31 @@
+// GitHub #6154: the reporter's program.  Merging an if/else inside an unrolled
+// loop used to embed the running value in both mux arms, making the summary
+// 2^n for a trip count of n; at SIZE=10 that tripped the size cap and the
+// existential — which cannot be skolemized — was rejected outright.
+#define SIZE 10
+typedef int idx_t;
+typedef char data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  idx_t idx;
+  int res = 0;
+  for (idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t a_vec[SIZE];
+  idx_t a_idx_vfy;
+  // Every element occurs at least once: the element at the witness index.
+  __ESBMC_assert(
+    __ESBMC_exists(
+      &a_idx_vfy,
+      (0 <= a_idx_vfy && a_idx_vfy < SIZE) &&
+        count(a_vec[a_idx_vfy], a_vec) != 0),
+    "some element occurs in the array");
+  return 0;
+}

--- a/regression/z3/github_6154_count_exists_size10/test.desc
+++ b/regression/z3/github_6154_count_exists_size10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 12 --no-standard-checks --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_count_exists_size10_fail/main.c
+++ b/regression/z3/github_6154_count_exists_size10_fail/main.c
@@ -1,0 +1,30 @@
+// GitHub #6154: negative counterpart of github_6154_count_exists_size10.  A
+// summary that collapsed to something vacuous would report SUCCESSFUL here too,
+// so this pins that the summarized count() carries its real value: over a
+// concrete array where 7 occurs four times, no index yields a count of five.
+#define SIZE 10
+typedef int idx_t;
+typedef char data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  idx_t idx;
+  int res = 0;
+  for (idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t a_vec[SIZE] = {7, 7, 7, 1, 2, 3, 4, 5, 6, 7};
+  idx_t a_idx_vfy;
+  __ESBMC_assert(
+    __ESBMC_exists(
+      &a_idx_vfy,
+      (0 <= a_idx_vfy && a_idx_vfy < SIZE) &&
+        count(a_vec[a_idx_vfy], a_vec) == 5),
+    "no element occurs five times");
+  return 0;
+}

--- a/regression/z3/github_6154_count_exists_size10_fail/test.desc
+++ b/regression/z3/github_6154_count_exists_size10_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 12 --no-standard-checks --z3
+^VERIFICATION FAILED$

--- a/regression/z3/github_6154_count_exists_size20/main.c
+++ b/regression/z3/github_6154_count_exists_size20/main.c
@@ -1,0 +1,25 @@
+// GitHub #6154: twice the trip count of the reported cliff.  The pre-fix
+// summary needed 2^20 nodes here, so this pins that the branch merge no longer
+// grows exponentially rather than that the cap was merely nudged upwards.
+#define SIZE 20
+typedef char data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  int i;
+  __ESBMC_assert(
+    __ESBMC_exists(
+      &i, (0 <= i && i < SIZE) && count(vec[i], vec) != 0),
+    "some element occurs in the array");
+  return 0;
+}

--- a/regression/z3/github_6154_count_exists_size20/test.desc
+++ b/regression/z3/github_6154_count_exists_size20/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 22 --no-standard-checks --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_mux_rules/main.c
+++ b/regression/z3/github_6154_mux_rules/main.c
@@ -1,0 +1,159 @@
+// GitHub #6154: differential check of the branch-merge rewrites.  Each function
+// is evaluated twice over the same nondeterministic array: once outside any
+// quantifier, where BMC unrolls it normally, and once under __ESBMC_exists,
+// where it must be summarized (an existential cannot fall back to
+// skolemization).  Any rewrite that changes the summarized value diverges from
+// the unrolled reference and fails here.
+//
+// Every call takes the bound variable as an argument and reads a[k] in the loop
+// guard.  That dependence is what forces the call through the summarizer: a
+// body that does not mention the bound variable is simply hoisted to a temp and
+// evaluated by ordinary BMC, which would make this test vacuous.
+#define N 8
+#define K 3
+
+// Running value on the left of a non-commutative `-'.
+int sub_left(int a[N], int k)
+{
+  int r = 100;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r - 3;
+  return r;
+}
+
+// Running value on the *right* of `-': must not absorb as if commutative.
+int sub_right(int a[N], int k)
+{
+  int r = 1;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = 50 - r;
+  return r;
+}
+
+// Opposite operators per branch, reconciled by the `A - k' -> `A + (-k)' rule.
+int incdec(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      ++r;
+    else
+      --r;
+  return r;
+}
+
+// Same operator, differing constant: merged by pushing the mux into the operand.
+// Spelled out rather than `+=', which the summarizer does not model.
+int addk(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r + 1;
+    else
+      r = r + 2;
+  return r;
+}
+
+// Multiplicative accumulator, whose identity is 1.  Kept shallow: mixing a
+// nonlinear accumulator with the bitwise one below on a single variable costs
+// Z3 two orders of magnitude more time than either alone.
+int mul(int a[N], int k)
+{
+  int r = 1;
+  for (int i = 0; i < 4; ++i)
+    if (a[i] > a[k])
+      r = r * 3;
+  return r;
+}
+
+// Bitwise accumulator, whose identity is 0.
+int xr(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r ^ 5;
+  return r;
+}
+
+// Unsigned wraparound: the rewrite is exact only in modular arithmetic.
+unsigned wrap(int a[N], int k)
+{
+  unsigned r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = r - 7u;
+  return r;
+}
+
+// Mixed-width arms.  Both arms are `int', so the mux may be pushed under the
+// common typecast only if the operands themselves agree in width -- otherwise
+// the wider arm is silently narrowed and the summary computes (int)(char)l.
+int widths(int a[N], int k, char c, long l)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = (int)c;
+    else
+      r = (int)l;
+  return r;
+}
+
+// Equal width, differing signedness: the arms must not be unified on width
+// alone, or the summary reinterprets one of them.
+int signs(int a[N], int k, unsigned char uc, signed char sc)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+    if (a[i] > a[k])
+      r = (int)uc;
+    else
+      r = (int)sc;
+  return r;
+}
+
+// Early return, folded by the same rewrite as the branch merge.
+int early(int a[N], int k)
+{
+  int r = 0;
+  for (int i = 0; i < N; ++i)
+  {
+    if (a[i] == a[k] + 42)
+      return -1;
+    if (a[i] > a[k])
+      ++r;
+  }
+  return r;
+}
+
+int main()
+{
+  int a[N], i;
+  int r1 = sub_left(a, K), r2 = sub_right(a, K), r3 = incdec(a, K);
+  int r4 = addk(a, K), r5 = mul(a, K), r6 = xr(a, K), r8 = early(a, K);
+  unsigned r7 = wrap(a, K);
+  // 300 does not fit in a char: a narrowing mux would compute 44 instead.
+  int r9 = widths(a, K, 1, 300);
+  // 200 and -56 share the low 8 bits: unifying on width alone confuses them.
+  int r10 = signs(a, K, 200, -56);
+
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && sub_left(a, i) == r1), "sub_left");
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && sub_right(a, i) == r2), "sub_right");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && incdec(a, i) == r3), "incdec");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && addk(a, i) == r4), "addk");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && mul(a, i) == r5), "mul");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && xr(a, i) == r6), "xor");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && wrap(a, i) == r7), "wrap");
+  __ESBMC_assert(__ESBMC_exists(&i, i == K && early(a, i) == r8), "early");
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && widths(a, i, 1, 300) == r9), "widths");
+  __ESBMC_assert(
+    __ESBMC_exists(&i, i == K && signs(a, i, 200, -56) == r10), "signs");
+  return 0;
+}

--- a/regression/z3/github_6154_mux_rules/test.desc
+++ b/regression/z3/github_6154_mux_rules/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 10 --no-standard-checks --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/z3/github_6154_summary_cap_option/main.c
+++ b/regression/z3/github_6154_summary_cap_option/main.c
@@ -1,0 +1,25 @@
+// GitHub #6154: a body that fits the default budget is rejected under a lowered
+// --max-quantifier-summary-nodes, pinning both the option and the reason the
+// rejection now reports.  Without a reason the same message covers a pointer
+// write, a data-dependent trip count and an over-large summary alike.
+#define SIZE 20
+typedef char data_t;
+
+int count(data_t val, data_t vec[SIZE])
+{
+  int res = 0;
+  for (int idx = 0; idx < SIZE; ++idx)
+    if (vec[idx] == val)
+      ++res;
+  return res;
+}
+
+int main()
+{
+  data_t vec[SIZE];
+  int i;
+  __ESBMC_assert(
+    __ESBMC_exists(&i, (0 <= i && i < SIZE) && count(vec[i], vec) != 0),
+    "some element occurs in the array");
+  return 0;
+}

--- a/regression/z3/github_6154_summary_cap_option/test.desc
+++ b/regression/z3/github_6154_summary_cap_option/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 22 --no-standard-checks --z3 --max-quantifier-summary-nodes 50
+cannot model call to .* on a quantified variable inside __ESBMC_forall/__ESBMC_exists
+reason: summary exceeded 50 expression nodes

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -707,6 +707,10 @@ const struct group_opt_templ all_cmd_options[] = {
      boost::program_options::value<int>()->default_value(128)->value_name("nr"),
      "Set maximum number of elements to copy symbolically in realloc (default "
      "is 128)"},
+    {"max-quantifier-summary-nodes",
+     boost::program_options::value<int>()->value_name("nr"),
+     "Set maximum expression size when summarizing a function called inside "
+     "__ESBMC_forall/__ESBMC_exists (default is 20000)"},
     {"enable-unreachability-intrinsic",
      NULL,
      "Enable unreach-call style checking: activates __ESBMC_unreachable() and "

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -100,6 +100,9 @@ protected:
   // can appear in a quantifier body.  Returns false (leaving @p out untouched)
   // for any shape it cannot soundly turn into a pure expression.
   bool summarize_pure_call(const symbolt &fsym, const exprt &call, exprt &out);
+  // Why summarize_pure_call() gave up, keyed by callsite location, so that
+  // the rejection reported for a quantifier body can name the cause.
+  std::map<std::string, std::string> summary_reject_reasons;
   const exprt *find_sideeffect_on_bound_var(
     const exprt &expr,
     const std::set<irep_idt> &bound_vars);

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -314,7 +314,19 @@ struct summary_statet
   std::vector<std::pair<exprt, exprt>> returns;
   std::set<irep_idt> locals;
   unsigned budget;
+  std::size_t max_nodes;
+  /// Why the summary was abandoned, reported alongside the rejection.  Set at
+  /// the originating failure only: callers just propagate `false'.
+  std::string reject;
 };
+
+/// Record why @p st cannot be summarized, and fail.
+bool summary_reject(summary_statet &st, std::string reason)
+{
+  if (st.reject.empty())
+    st.reject = std::move(reason);
+  return false;
+}
 
 bool summary_has_sideeffect(const exprt &e)
 {
@@ -352,6 +364,135 @@ void summary_coerce(exprt &e, const typet &t)
 {
   if (e.type() != t)
     e.make_typecast(t);
+}
+
+/// Whether `if(c, e, e')' may be pushed into the operands of @p id.  `/', `mod',
+/// `index' and `dereference' are excluded because the mux would then select
+/// their operand rather than their result, leaving a single site where the
+/// source had one per arm -- a divisor check, say, would cover only the
+/// selected divisor.  (goto_check does not currently instrument inside a
+/// quantifier body, so this is about not depending on that.)
+bool summary_mux_pushable(const irep_idt &id)
+{
+  static const std::set<irep_idt> ids = {
+    "+",
+    "-",
+    "*",
+    "typecast",
+    "if",
+    "=",
+    "notequal",
+    "<",
+    "<=",
+    ">",
+    ">=",
+    "and",
+    "or",
+    "not",
+    "bitand",
+    "bitor",
+    "bitxor"};
+  return ids.count(id) != 0;
+}
+
+/// Identity element of @p id over integer bitvector type @p t, or nil.
+exprt summary_identity(const irep_idt &id, const typet &t)
+{
+  if (t.id() != "signedbv" && t.id() != "unsignedbv")
+    return nil_exprt();
+  if (id == "+" || id == "-" || id == "bitor" || id == "bitxor")
+    return from_integer(0, t);
+  if (id == "*")
+    return from_integer(1, t);
+  return nil_exprt();
+}
+
+/// Rewrite `A - k' (constant @p k) to `A + (-k)', so that merging it against
+/// `A + k'' pushes the mux under a common `+'.  Modular bitvector arithmetic
+/// makes this exact, including at the type's minimum.
+exprt summary_normalize_sub(const exprt &e)
+{
+  BigInt v;
+  if (
+    e.id() != "-" || e.operands().size() != 2 ||
+    (e.type().id() != "signedbv" && e.type().id() != "unsignedbv") ||
+    e.op1().type() != e.type() || to_integer(e.op1(), v))
+    return e;
+  exprt r("+", e.type());
+  r.copy_to_operands(e.op0(), from_integer(-v, e.type()));
+  return r;
+}
+
+/// Build `if(@p cond, @p then_val, @p else_val)', pushing the mux inwards so an
+/// operand common to both arms is named once instead of copied into each.
+///
+/// Without this, merging the two paths of an if/else inside an unrolled loop
+/// duplicates the whole running value every iteration, making the summary 2^n
+/// for a trip count of n and tripping the size cap at n=10 (GitHub discussion
+/// #6154).  The rewrites below keep the accumulator shape linear:
+/// `if(c, X + k, X)' becomes `X + if(c, k, 0)'.
+exprt summary_mux(const exprt &cond, const exprt &tv, const exprt &ev)
+{
+  if (tv == ev)
+    return tv;
+
+  const exprt t = summary_normalize_sub(tv), e = summary_normalize_sub(ev);
+
+  if (
+    t.id() == e.id() && t.type() == e.type() && !t.operands().empty() &&
+    t.operands().size() == e.operands().size() && summary_mux_pushable(t.id()))
+  {
+    std::size_t diff = 0, ndiff = 0;
+    for (std::size_t i = 0; i < t.operands().size(); i++)
+      if (!(t.operands()[i] == e.operands()[i]))
+      {
+        diff = i;
+        ndiff++;
+      }
+    // The differing operands must already agree in type.  `typecast' does not
+    // constrain its operand's type, so without this the recursive call falls
+    // through to the coercing fallback below and silently narrows the wider
+    // arm -- `(int)c' vs `(int)l' would become `(int)if(c, c, (char)l)'.
+    if (ndiff == 1 && t.operands()[diff].type() == e.operands()[diff].type())
+    {
+      exprt r = t;
+      r.operands()[diff] =
+        summary_mux(cond, t.operands()[diff], e.operands()[diff]);
+      return r;
+    }
+  }
+
+  // `if(c, X op k, X)' -> `X op if(c, k, identity)'.  Tried with either arm as
+  // the grown one, since an if/else may write the variable on either path.
+  for (const bool then_grew : {true, false})
+  {
+    const exprt &g = then_grew ? t : e;
+    const exprt &x = then_grew ? e : t;
+    if (g.operands().size() != 2 || g.type() != x.type())
+      continue;
+    const exprt unit = summary_identity(g.id(), g.type());
+    if (unit.is_nil())
+      continue;
+    // `-' is not commutative: only its left operand may be the running value.
+    const bool left = g.op0() == x;
+    if (!left && (g.id() == "-" || !(g.op1() == x)))
+      continue;
+    const exprt &k = left ? g.op1() : g.op0();
+    if (k.type() != g.type())
+      continue;
+    exprt m =
+      then_grew ? summary_mux(cond, k, unit) : summary_mux(cond, unit, k);
+    exprt r(g.id(), g.type());
+    if (left)
+      r.copy_to_operands(x, m);
+    else
+      r.copy_to_operands(m, x);
+    return r;
+  }
+
+  exprt fallback = ev;
+  summary_coerce(fallback, tv.type());
+  return if_exprt(cond, tv, fallback);
 }
 
 std::size_t summary_node_count(const exprt &e)
@@ -564,14 +705,7 @@ summarize_code(const codet &code, summary_statet &st, const namespacet &ns)
                                              : nullptr;
       if (!tv || !ev)
         continue;
-      if (*tv == *ev)
-        st.env[k] = *tv;
-      else
-      {
-        exprt e = *ev;
-        summary_coerce(e, tv->type());
-        st.env[k] = if_exprt(cv, *tv, e);
-      }
+      st.env[k] = summary_mux(cv, *tv, *ev);
     }
     return true;
   }
@@ -619,8 +753,11 @@ summarize_code(const codet &code, summary_statet &st, const namespacet &ns)
     // pure expression.
     for (bool first = true;; first = false)
     {
-      if (summary_size(st) > max_summary_nodes)
-        return false;
+      if (summary_size(st) > st.max_nodes)
+        return summary_reject(
+          st,
+          "summary exceeded " + std::to_string(st.max_nodes) +
+            " expression nodes (raise --max-quantifier-summary-nodes)");
       if (!(s == "dowhile" && first))
       {
         if (cond->is_nil())
@@ -630,12 +767,15 @@ summarize_code(const codet &code, summary_statet &st, const namespacet &ns)
           return false;
         const int f = summary_fold_bool(cv);
         if (f == -1)
-          return false;
+          return summary_reject(
+            st,
+            "loop condition is not a compile-time constant (data-dependent "
+            "trip count)");
         if (f == 0)
           break;
       }
       if (st.budget == 0)
-        return false;
+        return summary_reject(st, "loop unrolling budget exhausted");
       st.budget--;
       if (!summarize_code(*body, st, ns))
         return false;
@@ -655,7 +795,7 @@ summarize_code(const codet &code, summary_statet &st, const namespacet &ns)
     return true;
   }
 
-  return false;
+  return summary_reject(st, "unsupported statement `" + s.as_string() + "'");
 }
 
 bool goto_convertt::summarize_pure_call(
@@ -663,6 +803,12 @@ bool goto_convertt::summarize_pure_call(
   const exprt &call,
   exprt &out)
 {
+  // Keyed by callsite, not callee: the same function may be summarized at
+  // several sites with different arguments, and a success at one must not
+  // erase -- or a failure at one mis-attribute -- the reason at another.
+  const std::string site = call.find_location().as_string();
+  summary_reject_reasons.erase(site);
+
   const exprt &value = fsym.get_value();
   if (!value.is_code() || fsym.get_type().id() != "code")
     return false;
@@ -678,6 +824,17 @@ bool goto_convertt::summarize_pure_call(
   summary_statet st;
   st.pc = true_exprt();
   st.budget = max_quantifier_inline_depth * max_quantifier_inline_depth;
+  st.max_nodes = max_summary_nodes;
+  const std::string max_nodes_opt =
+    options.get_option("max-quantifier-summary-nodes");
+  if (!max_nodes_opt.empty())
+  {
+    // Read as signed: a negative value would wrap to SIZE_MAX and turn the
+    // guard into an unbounded unroll.  The cap bounds loop unrolling only; a
+    // loop-free callee is bounded by its own source and summarizes regardless.
+    const long long v = std::stoll(max_nodes_opt);
+    st.max_nodes = v > 0 ? static_cast<std::size_t>(v) : 0;
+  }
 
   for (std::size_t i = 0; i < params.size(); i++)
   {
@@ -691,20 +848,28 @@ bool goto_convertt::summarize_pure_call(
   }
 
   if (!summarize_code(to_code(value), st, ns))
+  {
+    if (!st.reject.empty())
+      summary_reject_reasons[site] = st.reject;
     return false;
+  }
 
   // A trailing unconditional return guarantees the summary is total: the last
   // recorded value is the fall-through, earlier returns wrap it as nested
   // if-then-else so the earliest matching guard wins.
   if (st.returns.empty() || summary_fold_bool(st.returns.back().first) != 1)
+  {
+    summary_reject_reasons[site] =
+      "no unconditional return on the callee's fall-through path";
     return false;
+  }
 
   exprt result = st.returns.back().second;
   for (std::size_t i = st.returns.size() - 1; i-- > 0;)
   {
     exprt v = st.returns[i].second;
     summary_coerce(v, result.type());
-    result = if_exprt(st.returns[i].first, v, result);
+    result = summary_mux(st.returns[i].first, v, result);
   }
 
   summary_coerce(result, call.type());
@@ -924,16 +1089,24 @@ void goto_convertt::remove_sideeffects_for_quantifier_body(
   {
     const bool is_call = se->statement() == "function_call" &&
                          se->operands().size() >= 1 && se->op0().is_symbol();
+    std::string why;
+    if (is_call)
+    {
+      auto it = summary_reject_reasons.find(se->find_location().as_string());
+      if (it != summary_reject_reasons.end())
+        why = "; reason: " + it->second;
+    }
     log_error(
       "{}: cannot model {} on a quantified variable inside "
       "__ESBMC_forall/__ESBMC_exists; the quantifier body must be a "
       "side-effect-free expression, possibly calling functions built from "
       "local declarations, assignments, if/else, and loops with a statically "
       "constant trip count, and whose side-effecting arguments are each used "
-      "exactly once",
+      "exactly once{}",
       se->find_location().as_string(),
       is_call ? "call to `" + se->op0().identifier().as_string() + "'"
-              : "side effect `" + se->statement().as_string() + "'");
+              : "side effect `" + se->statement().as_string() + "'",
+      why);
     abort();
   }
 


### PR DESCRIPTION
The quantifier-body summarizer embedded the running value in both if/else mux
arms, so an unrolled accumulator loop grew as 2^n and was rejected at trip count
10. Push the mux under a shared operator instead — `if(c, X + k, X)` becomes
`X + if(c, k, 0)` — keeping the summary linear, so the count() example in
discussion #6154 now verifies. Rejections name their cause and the size cap is
configurable via `--max-quantifier-summary-nodes`.

Addresses https://github.com/esbmc/esbmc/discussions/6154