### PR TITLE
[C verificaiton] fix spurious loop pruning from stale phi-assignment intervals

### DIFF
--- a/regression/esbmc/github_interval_guard_phi/main.c
+++ b/regression/esbmc/github_interval_guard_phi/main.c
@@ -1,0 +1,22 @@
+#define SIZE 10
+typedef int idx_t;
+typedef char data_t;
+int main()
+{
+  data_t vec[SIZE];
+  idx_t prv_idx = SIZE - 1;
+  idx_t cur_idx = 0;
+  idx_t nxt_idx;
+  int loop_idx_vfy = 0;
+  while (cur_idx != prv_idx)
+  {
+    if (vec[cur_idx] == 3)
+      nxt_idx = (cur_idx + prv_idx) / 2;
+    else
+      nxt_idx = 0;
+    prv_idx = cur_idx;
+    cur_idx = nxt_idx;
+    ++loop_idx_vfy;
+  }
+  __ESBMC_assert(cur_idx == prv_idx, "end: idxs equal");
+}

--- a/regression/esbmc/github_interval_guard_phi/test.desc
+++ b/regression/esbmc/github_interval_guard_phi/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 5 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_interval_guard_phi_fail/main.c
+++ b/regression/esbmc/github_interval_guard_phi_fail/main.c
@@ -1,0 +1,22 @@
+#define SIZE 10
+typedef int idx_t;
+typedef char data_t;
+int main()
+{
+  data_t vec[SIZE];
+  idx_t prv_idx = SIZE - 1;
+  idx_t cur_idx = 0;
+  idx_t nxt_idx;
+  int loop_idx_vfy = 0;
+  while (cur_idx != prv_idx)
+  {
+    if (vec[cur_idx] == 3)
+      nxt_idx = (cur_idx + prv_idx) / 2;
+    else
+      nxt_idx = 0;
+    prv_idx = cur_idx;
+    cur_idx = nxt_idx;
+    ++loop_idx_vfy;
+  }
+  __ESBMC_assert(cur_idx == prv_idx, "end: idxs equal");
+}

--- a/regression/esbmc/github_interval_guard_phi_fail/test.desc
+++ b/regression/esbmc/github_interval_guard_phi_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 3 --compact-trace
+^VERIFICATION FAILED$
+loop_idx_vfy = 3

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1249,7 +1249,8 @@ void interval_domaint::phi_join_with_snapshot(
   switch (src.index())
   {
   case 0:
-    join_intervals<integer_intervalt>(std::get<0>(src), std::get<0>(dst), false);
+    join_intervals<integer_intervalt>(
+      std::get<0>(src), std::get<0>(dst), false);
     break;
   case 1:
     join_intervals<real_intervalt>(std::get<1>(src), std::get<1>(dst), false);

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1219,6 +1219,49 @@ bool interval_domaint::join(
   return result;
 }
 
+void interval_domaint::phi_join_with_snapshot(
+  const expr2tc &lhs,
+  const std::shared_ptr<interval_map> &if_snapshot)
+{
+  if (!is_symbol2t(lhs))
+    return;
+  const irep_idt &name = to_symbol2t(lhs).thename;
+  const auto if_it = if_snapshot->find(name);
+
+  copy_if_needed();
+
+  if (if_it == if_snapshot->end())
+  {
+    // JOIN(TOP, else) = TOP
+    intervals->erase(name);
+    return;
+  }
+
+  const auto dst_it = intervals->find(name);
+  if (dst_it == intervals->end())
+    return; // JOIN(if, TOP) = TOP
+
+  const auto &src = if_it->second;
+  auto &dst = dst_it->second;
+  if (src.index() != dst.index())
+    return;
+
+  switch (src.index())
+  {
+  case 0:
+    join_intervals<integer_intervalt>(std::get<0>(src), std::get<0>(dst), false);
+    break;
+  case 1:
+    join_intervals<real_intervalt>(std::get<1>(src), std::get<1>(dst), false);
+    break;
+  case 2:
+    join_intervals<wrapped_interval>(std::get<2>(src), std::get<2>(dst), false);
+    break;
+  default:
+    break;
+  }
+}
+
 void interval_domaint::assign(const expr2tc &expr, const bool recursive)
 {
   assert(is_code_assign2t(expr));

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -196,6 +196,14 @@ public:
    */
   void process_instruction(goto_programt::const_targett from);
 
+  /** JOIN the if-branch snapshot value with the current (else-branch) domain
+   *  value for lhs.  Both SSA variables for a base name share the same key, so
+   *  by the time phi_function runs only the else-branch value remains; the
+   *  snapshot preserves the if-branch value for the correct HULL computation. */
+  void phi_join_with_snapshot(
+    const expr2tc &lhs,
+    const std::shared_ptr<interval_map> &if_snapshot);
+
   /**
    * @brief Uses the abstract state to simplify a given expression using context-
    * specific information.

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -103,6 +103,7 @@ public:
     guard2tc guard;
     unsigned int thread_id;
     variable_name_sett local_variables;
+    std::shared_ptr<void> interval_snapshot; // interval_domaint::interval_map; set in symex_goto.cpp
 
     explicit merge_statet(const goto_symex_statet &s)
       : num_instructions(s.num_instructions),
@@ -122,7 +123,8 @@ public:
         value_set(s.value_set),
         guard(s.guard),
         thread_id(s.thread_id),
-        local_variables(s.local_variables)
+        local_variables(s.local_variables),
+        interval_snapshot(s.interval_snapshot)
     {
     }
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -103,7 +103,8 @@ public:
     guard2tc guard;
     unsigned int thread_id;
     variable_name_sett local_variables;
-    std::shared_ptr<void> interval_snapshot; // interval_domaint::interval_map; set in symex_goto.cpp
+    std::shared_ptr<void>
+      interval_snapshot; // interval_domaint::interval_map; set in symex_goto.cpp
 
     explicit merge_statet(const goto_symex_statet &s)
       : num_instructions(s.num_instructions),

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -222,6 +222,13 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   merge_state_list.emplace_back(*cur_state);
   record_branch_sibling(new_state_pc, std::prev(merge_state_list.end()));
 
+  // Capture the interval domain at the if-branch end so phi_function can JOIN
+  // both branches.  Deep-copy so subsequent else-branch writes don't corrupt it.
+  if (interval_domain_state)
+    merge_state_list.back().interval_snapshot =
+      std::make_shared<interval_domaint::interval_map>(
+        *interval_domain_state->intervals);
+
   // adjust guards
   if (new_guard_true)
   {
@@ -461,6 +468,17 @@ void goto_symext::phi_function(const statet::merge_statet &merge_state)
     cur_state->rename_type(new_lhs);
     cur_state->rename_type(rhs);
     cur_state->assignment(new_lhs, rhs);
+
+    // process_instruction never sees synthetic phi assignments; update the
+    // interval domain here using the if-branch snapshot so the JOIN is correct
+    // (both SSA names share the same base-name key in the domain).
+    if (interval_domain_state && !cur_state->guard.is_false() &&
+        !merge_state.guard.is_false())
+    {
+      auto snap = std::static_pointer_cast<interval_domaint::interval_map>(
+        merge_state.interval_snapshot);
+      interval_domain_state->phi_join_with_snapshot(new_lhs, snap);
+    }
 
     target->assignment(
       gen_true_expr(),

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -472,8 +472,9 @@ void goto_symext::phi_function(const statet::merge_statet &merge_state)
     // process_instruction never sees synthetic phi assignments; update the
     // interval domain here using the if-branch snapshot so the JOIN is correct
     // (both SSA names share the same base-name key in the domain).
-    if (interval_domain_state && merge_state.interval_snapshot &&
-        !cur_state->guard.is_false() && !merge_state.guard.is_false())
+    if (
+      interval_domain_state && merge_state.interval_snapshot &&
+      !cur_state->guard.is_false() && !merge_state.guard.is_false())
     {
       auto snap = std::static_pointer_cast<interval_domaint::interval_map>(
         merge_state.interval_snapshot);

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -472,8 +472,8 @@ void goto_symext::phi_function(const statet::merge_statet &merge_state)
     // process_instruction never sees synthetic phi assignments; update the
     // interval domain here using the if-branch snapshot so the JOIN is correct
     // (both SSA names share the same base-name key in the domain).
-    if (interval_domain_state && !cur_state->guard.is_false() &&
-        !merge_state.guard.is_false())
+    if (interval_domain_state && merge_state.interval_snapshot &&
+        !cur_state->guard.is_false() && !merge_state.guard.is_false())
     {
       auto snap = std::static_pointer_cast<interval_domaint::interval_map>(
         merge_state.interval_snapshot);

--- a/src/python-frontend/python-dict/dict_methods.cpp
+++ b/src/python-frontend/python-dict/dict_methods.cpp
@@ -1362,8 +1362,7 @@ exprt python_dict_handler::handle_dict_update(
   // CPython: dict.update([E], **F) — at most one positional iterable plus any
   // number of keyword pairs.
   if (args.size() > 1)
-    throw std::runtime_error(
-      "update() takes at most one positional argument");
+    throw std::runtime_error("update() takes at most one positional argument");
 
   // Apply each keyword argument as dict[name] = value. Runs after the optional
   // positional source so `d.update(other, k=v)` matches CPython's order.

--- a/src/python-frontend/python-list/list_query.cpp
+++ b/src/python-frontend/python-list/list_query.cpp
@@ -915,8 +915,8 @@ exprt python_list::build_index_range_list_call(
   // model returns SIZE_MAX when the element is absent in l[start:end]; raise a
   // ValueError from the frontend on that path so try/except ValueError can
   // catch it, mirroring the dict KeyError and list.remove ValueError lowerings.
-  symbolt &idx = converter_.create_tmp_symbol(
-    op, "index_range_ret", size_type(), exprt());
+  symbolt &idx =
+    converter_.create_tmp_symbol(op, "index_range_ret", size_type(), exprt());
   code_declt idx_decl(build_symbol(idx));
   idx_decl.location() = elem_info.location;
   converter_.add_instruction(idx_decl);


### PR DESCRIPTION
The online interval domain (--interval-symex-guard) was producing spurious VERIFICATION FAILED on loops containing if-else blocks. After one loop iteration the guard evaluator incorrectly concluded the loop exit condition was always true and pruned the loop continuation path.

Root cause: the domain maps variables by base name (symbol2t::thename), so both SSA versions of a variable in an if-else share the same key. The execution order is:

if-branch:   nxt_idx = (cur+prv)/2  →  domain["nxt_idx"] = [0,4]
else-branch: nxt_idx = 0            →  domain["nxt_idx"] = [0,0]   ← overwrites
phi-merge:   phi_function queries domain["nxt_idx"] for both sides
             → JOIN([0,0], [0,0]) = [0,0]  instead of JOIN([0,4], [0,0]) = [0,4]

With nxt_idx stuck at [0,0], the domain deduced cur_idx == prv_idx was always true and set new_guard_true, dropping the loop-exit condition from the guard and triggering a false counterexample.

Fix

At the end of each if-branch (when symex_goto stashes the merge_stateT), take a deep copy of the domain and store it in a new merge_stateT::interval_snapshot field. In phi_function, instead of querying the (already-overwritten) domain for both sides, JOIN the if-branch snapshot value with the current else-branch domain value via phi_join_with_snapshot.

The deep copy is necessary because the domain uses copy-on-write semantics: a shared_ptr alias would be mutated by the else-branch's first write.

Storing the snapshot directly in merge_stateT (rather than an external map keyed by pointer) ties the snapshot lifetime to the merge-state object, eliminating the need for explicit cleanup and any dangling-pointer risk.