### PR TITLE
[om] Fix basic_string(const char*, size_t) range constructor

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6199/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6199/main.cpp
@@ -1,0 +1,34 @@
+#include <cassert>
+#include <cstring>
+#include <string>
+
+// [string.cons] constructs a basic_string from the range [s, s + n). n is
+// unrelated to strlen(s), and the range may contain embedded null characters.
+int main()
+{
+  const char *lit = "AAAA=";
+
+  // The exact-length form string(s, strlen(s)) is legal and must be accepted.
+  std::string a(lit, 5);
+  assert(a.length() == 5);
+  assert(a[0] == 'A');
+  assert(a[4] == '=');
+
+  std::string b(lit, std::strlen(lit));
+  assert(b.length() == 5);
+
+  // Embedded null characters inside the range are preserved, and length()
+  // agrees with the copied contents rather than stopping at the first '\0'.
+  const char buf[6] = {'a', 'b', '\0', 'c', 'd', '\0'};
+  std::string c(buf, 5);
+  assert(c.length() == 5);
+  assert(c[0] == 'a');
+  assert(c[3] == 'c');
+  assert(c[4] == 'd');
+
+  // n == 0 is permitted and yields an empty string.
+  std::string d("ignored", 0);
+  assert(d.length() == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6199/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6199/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6199_capacity_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6199_capacity_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <string>
+
+int main()
+{
+  // n >= STRING_CAPACITY (128) cannot be represented by the model's fixed
+  // buffer, so the constructor reports the capacity limit rather than writing
+  // out of bounds. This is a model limitation, not a claim about C++ semantics.
+  const char *s = "abc";
+  std::string big(s, 200);
+
+  return (int)big.length();
+}

--- a/regression/esbmc-cpp/cpp/github_6199_capacity_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6199_capacity_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 12
+^VERIFICATION FAILED$
+^  String capacity exceeded$

--- a/regression/esbmc-cpp/cpp/github_6199_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6199_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <string>
+
+int main()
+{
+  // The null check must run before any dereference: with n == 0 nothing is
+  // copied, so the only property that can fire is the null precondition. This
+  // pins the argument order (previously strlen(s) was evaluated first and a
+  // null s produced a misleading dereference failure inside strlen).
+  const char *p = 0;
+  std::string s(p, 0);
+
+  return (int)s.length();
+}

--- a/regression/esbmc-cpp/cpp/github_6199_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6199_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 12
+^VERIFICATION FAILED$
+^  invalid basic_string$

--- a/regression/esbmc-cpp/string/string_operator_greater_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_8_bug/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 20 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_8_bug/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 20 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_operator_less_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_8_bug/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 20 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_operator_less_eq_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_8_bug/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 20 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1154,14 +1154,16 @@ template <typename CharT, typename Traits, typename Alloc>
 basic_string<CharT, Traits, Alloc>::basic_string(const CharT *s, size_t n)
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(n < strlen(s), "basic_string overflow");
+  // [string.cons]: constructs from the range [s, s + n); n is unrelated to
+  // strlen(s) and the range may contain embedded null characters. Check for
+  // null before any dereference, then copy exactly n characters.
   __ESBMC_assert(s != NULL, "invalid basic_string");
+  __ESBMC_assert(n < STRING_CAPACITY, "String capacity exceeded");
 
-  int i;
   _size = n;
-  for (i = 0; (i < _size) && (s[i] != '\0'); i++)
+  for (size_t i = 0; i < n; i++)
     str[i] = s[i];
-  str[i] = '\0';
+  str[n] = '\0';
 }
 
 template <typename CharT, typename Traits, typename Alloc>


### PR DESCRIPTION
The `basic_string(const CharT*, size_t)` model in `src/cpp/library/string` diverged from [string.cons] in three ways: a bogus `n < strlen(s)` precondition rejected `std::string(s, strlen(s))`, the copy loop truncated at embedded nulls, and `strlen(s)` was evaluated before the `s != NULL` check. Rewrite it to null-check before any dereference, copy exactly `n` characters, and use the file's `n < STRING_CAPACITY` capacity guard. Adds regression tests `github_6199`, `github_6199_fail`, and `github_6199_capacity_fail`.

Fixes #6199

<details>
<summary>Root cause, solution, validation, and follow-up note</summary>

## Root cause

The `basic_string(const CharT *s, size_t n)` model in `src/cpp/library/string`
diverged from [string.cons] in three ways:

1. **Bogus precondition.** `__ESBMC_assert(n < strlen(s), "basic_string overflow")`
   invented a requirement the standard does not have. `[s, s + n)` only needs to
   be a valid range; `n` is unrelated to `strlen(s)`. This rejected the idiomatic
   exact-length form `std::string(s, strlen(s))` and any `n >= strlen(s)` with a
   spurious `VERIFICATION FAILED`. It surfaced in practice on `Aws::String(str,
   strlen(str))` from aws-sdk-cpp.
2. **Truncation at embedded nulls.** The copy loop condition `(i < _size) &&
   (s[i] != '\0')` stopped early on an embedded `'\0'` while `_size` was already
   `n`, so `length()` disagreed with the actual contents — a silently wrong value.
3. **Deref before null check.** `strlen(s)` was evaluated before the `s != NULL`
   assertion, so a null argument produced a dereference failure *inside* `strlen`
   rather than the intended `invalid basic_string` diagnostic.

## Solution

Rewrite the constructor to follow [string.cons]:

```cpp
basic_string(const CharT *s, size_t n)
{
__ESBMC_HIDE:
  __ESBMC_assert(s != NULL, "invalid basic_string");
  __ESBMC_assert(n < STRING_CAPACITY, "String capacity exceeded");

  _size = n;
  for (size_t i = 0; i < n; i++)
    str[i] = s[i];
  str[n] = '\0';
}
```

- Check for null **before** any dereference (defect 3).
- Copy exactly `n` characters, preserving embedded nulls (defect 2).
- Drop the `strlen` precondition; replace it with the file's conventional
  capacity guard, since `str[n]` must stay inside the fixed 128-byte buffer
  (defect 1). This reports a *model limitation*, not a C++ semantic claim.

## Validation

- All three reproducers from the issue now behave correctly: `std::string("AAAA=",
  5)` → `SUCCESSFUL`; the embedded-null program preserves `s[3]`/`s[4]`; the null
  argument reports `invalid basic_string` at the right location.
- New regression tests: `github_6199` (positive: exact-length, `strlen`,
  embedded nulls, `n == 0`), `github_6199_fail` (null precondition), and
  `github_6199_capacity_fail` (capacity guard). Each fails before the fix and
  passes after.
- All 18 existing string tests that construct via this overload pass, as does the
  `github_6063` iterator-pair family. The `(const char*, size_t)` overload is used
  nowhere else in the regression tree, so the blast radius is contained.
- The four `string_operator_*_8_bug` tests were only reaching `VERIFICATION
  FAILED` because the removed overflow assert fired on `string("AA", 2)`. With
  that false alarm gone they now fail at their intended assertion — but only once
  the `string('A', 12)` fill loop is fully unwound, so their bound is raised from
  10 to 20 (at 10 the truncated loop was silently dropped under
  `--no-unwinding-assertions`).

## Note (out of scope, separate follow-up)

Verifying this fix unmasked a pre-existing unsoundness in the string relational
operators (`operator>`/`<`/`>=`/`<=`): they iterate only while *both* buffers are
non-null and ignore length differences, so `"AAAA" > "AA"` evaluates to `false`.
It is being tracked/fixed separately and does not affect any verdict in this PR.

</details>
