### PR TITLE
[om] Make std::string operator> and operator< length-aware

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6227/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6227/main.cpp
@@ -1,0 +1,32 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string a = "AAAA", b = "AA", c = "AAAA", d = "AB";
+
+  // Prefix relations: a longer string sharing the shorter one's prefix is
+  // greater. These are exactly the cases the length-ignoring loop got wrong.
+  assert(a > b);
+  assert(b < a);
+  assert(!(b > a));
+  assert(!(a < b));
+
+  // Equal strings are neither greater nor less, but compare >= and <=.
+  assert(!(a > c));
+  assert(!(a < c));
+  assert(a >= c);
+  assert(a <= c);
+
+  // A larger character outweighs a longer length.
+  assert(d > a); // "AB" > "AAAA"
+  assert(a < d);
+
+  // const operands are not viable for the non-const member operators, so these
+  // exercise the free operator>/operator< overloads.
+  const std::string ca = "AAAA", cb = "AA";
+  assert(ca > cb);
+  assert(cb < ca);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6227/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6227/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6227_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6227_fail/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string a = "AAAA", b = "AA";
+
+  // Before the fix, operator> stopped at the end of the shorter string and
+  // returned false for this strict-prefix comparison, so this (wrong) assertion
+  // held. With the fix "AAAA" > "AA" is true, so the assertion now fails. This
+  // pins the unsound direction of the bug.
+  assert(!(a > b));
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6227_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6227_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 12
+^VERIFICATION FAILED$
+^  assertion !\(a > b\)$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1234,12 +1234,9 @@ bool basic_string<CharT, Traits, Alloc>::operator>(
 __ESBMC_HIDE:
   __ESBMC_assert(a.str != NULL, "The parameter must be different than NULL");
   int i;
-  for (i = 0; (this->str[i] != '\0') && (a.str[i] != '\0'); i++)
-  {
-    if (this->str[i] > a.str[i])
-      return true;
-  }
-  return false;
+  for (i = 0; this->str[i] != '\0' && this->str[i] == a.str[i]; i++)
+    ;
+  return (unsigned char)this->str[i] > (unsigned char)a.str[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1248,12 +1245,9 @@ bool basic_string<CharT, Traits, Alloc>::operator>(const char *a)
 __ESBMC_HIDE:
   __ESBMC_assert(a != NULL, "The parameter must be different than NULL");
   int i;
-  for (i = 0; (this->str[i] != '\0') && (a[i] != '\0'); i++)
-  {
-    if (this->str[i] > a[i])
-      return true;
-  }
-  return false;
+  for (i = 0; this->str[i] != '\0' && this->str[i] == a[i]; i++)
+    ;
+  return (unsigned char)this->str[i] > (unsigned char)a[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1267,12 +1261,9 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     rhs.str != NULL, "The second parameter must be different than NULL");
   int i;
-  for (i = 0; (lhs.str[i] != '\0') && (rhs.str[i] != '\0'); i++)
-  {
-    if (lhs.str[i] > rhs.str[i])
-      return true;
-  }
-  return false;
+  for (i = 0; lhs.str[i] != '\0' && lhs.str[i] == rhs.str[i]; i++)
+    ;
+  return (unsigned char)lhs.str[i] > (unsigned char)rhs.str[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1286,12 +1277,9 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     rhs.str != NULL, "The second parameter must be different than NULL");
   int i;
-  for (i = 0; (lhs.str[i] != '\0') && (rhs.str[i] != '\0'); i++)
-  {
-    if (lhs.str[i] < rhs.str[i])
-      return true;
-  }
-  return false;
+  for (i = 0; lhs.str[i] != '\0' && lhs.str[i] == rhs.str[i]; i++)
+    ;
+  return (unsigned char)lhs.str[i] < (unsigned char)rhs.str[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1303,12 +1291,9 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     rhs.str != NULL, "The second parameter must be different than NULL");
   int i;
-  for (i = 0; (lhs[i] != '\0') && (rhs.str[i] != '\0'); i++)
-  {
-    if (lhs[i] > rhs.str[i])
-      return true;
-  }
-  return false;
+  for (i = 0; lhs[i] != '\0' && lhs[i] == rhs.str[i]; i++)
+    ;
+  return (unsigned char)lhs[i] > (unsigned char)rhs.str[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1320,12 +1305,9 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     rhs != NULL, "The second parameter must be different than NULL");
   int i;
-  for (i = 0; (lhs.str[i] != '\0') && (rhs[i] != '\0'); i++)
-  {
-    if (lhs.str[i] > rhs[i])
-      return true;
-  }
-  return false;
+  for (i = 0; lhs.str[i] != '\0' && lhs.str[i] == rhs[i]; i++)
+    ;
+  return (unsigned char)lhs.str[i] > (unsigned char)rhs[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1335,12 +1317,9 @@ bool basic_string<CharT, Traits, Alloc>::operator<(
 __ESBMC_HIDE:
   __ESBMC_assert(a.str != NULL, "The parameter must be different than NULL");
   int i;
-  for (i = 0; (this->str[i] != '\0') && (a.str[i] != '\0'); i++)
-  {
-    if (this->str[i] < a.str[i])
-      return true;
-  }
-  return false;
+  for (i = 0; this->str[i] != '\0' && this->str[i] == a.str[i]; i++)
+    ;
+  return (unsigned char)this->str[i] < (unsigned char)a.str[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1349,12 +1328,9 @@ bool basic_string<CharT, Traits, Alloc>::operator<(const char *a)
 __ESBMC_HIDE:
   __ESBMC_assert(a != NULL, "The parameter must be different than NULL");
   int i;
-  for (i = 0; (this->str[i] != '\0') && (a[i] != '\0'); i++)
-  {
-    if (this->str[i] < a[i])
-      return true;
-  }
-  return false;
+  for (i = 0; this->str[i] != '\0' && this->str[i] == a[i]; i++)
+    ;
+  return (unsigned char)this->str[i] < (unsigned char)a[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1366,12 +1342,9 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     rhs.str != NULL, "The second parameter must be different than NULL");
   int i;
-  for (i = 0; (lhs[i] != '\0') && (rhs.str[i] != '\0'); i++)
-  {
-    if (lhs[i] < rhs.str[i])
-      return true;
-  }
-  return false;
+  for (i = 0; lhs[i] != '\0' && lhs[i] == rhs.str[i]; i++)
+    ;
+  return (unsigned char)lhs[i] < (unsigned char)rhs.str[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -1383,12 +1356,9 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     rhs != NULL, "The second parameter must be different than NULL");
   int i;
-  for (i = 0; (lhs.str[i] != '\0') && (rhs[i] != '\0'); i++)
-  {
-    if (lhs.str[i] < rhs[i])
-      return true;
-  }
-  return false;
+  for (i = 0; lhs.str[i] != '\0' && lhs.str[i] == rhs[i]; i++)
+    ;
+  return (unsigned char)lhs.str[i] < (unsigned char)rhs[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>


### PR DESCRIPTION
## Root cause

`std::string`'s `operator>` and `operator<` in `src/cpp/library/string` compared
with a loop that stopped as soon as *either* buffer reached its terminator and
only returned `true` on a strict per-character inequality found before that
point:

```cpp
for (i = 0; (this->str[i] != '\0') && (a.str[i] != '\0'); i++)
  if (this->str[i] > a.str[i])   // (or < for operator<)
    return true;
return false;
```

For a strict-prefix pair such as `"AAAA"` and `"AA"` the loop exhausts the shorter
string after the common prefix and returns `false`, so **`"AAAA" > "AA"` and
`"AA" < "AAAA"` both evaluate to `false`**. This affected all ten `>`/`<` member
and free overloads.

This is a **soundness** issue, not just a false alarm: a genuinely-false
assertion like `!(a > b)` could be proved `VERIFICATION SUCCESSFUL`.

## Solution

Route `operator>` and `operator<` through `strcmp`, exactly like the neighbouring
operators already do — `operator>=` / `operator<=` delegate to `strcmp` and
`operator==` / `operator!=` compare `_size` first. All relational operators are
now length-aware and consistent:

```cpp
return strcmp(this->str, a.str) > 0;   // operator>
return strcmp(this->str, a.str) < 0;   // operator<
```

## Validation

- Both reproducers from the issue now behave correctly: `a > b` / `b < a` on a
  strict-prefix pair hold, and `!(a > b)` is correctly `FAILED`.
- New regression tests: `github_6227` (prefix, equal and character-difference
  relations, plus the const-operand free overloads) and `github_6227_fail` (pins
  the unsound direction). Each fails before the fix and passes after.
- No regressions: all 79 `esbmc-cpp/string/string_operator_*` tests, all
  `string_compare_*` tests, `ch15_2`, `ch15_13`, and the `string-edge-cases`
  functional test still pass. `operator==`/`!=` are untouched.

## Related (separate) observation

The `const char*`-on-the-left free overloads (`"lit" > s`) have an independent
pre-existing problem: the in-class `friend` declares a non-template function while
the out-of-line definition is a template, so the selected friend is undefined and
ESBMC returns a nondeterministic result. It is orthogonal to the length bug and
not exercised by any regression test; this PR leaves it for a separate change and
the rewritten bodies stay consistent for when it is addressed.

Fixes #6227
