### PR TITLE
[python] Drop dead ieee_binop and refresh the V.1k keystone plan

### DIFF
--- a/docs/irep2-keystone-implementation-plan.md
+++ b/docs/irep2-keystone-implementation-plan.md
@@ -5,6 +5,17 @@ Working plan for the IREP2-native resolution keystone tracked in
 `feat/python-irep2-adjust-keystone` and is the execution roadmap; the
 canonical record stays in `irep2-migration.md`. Delete on merge.
 
+> **Status (2026-07-22).** Every W and D site in the ordered list below has
+> landed — task 4's "deferred, entangled" residue closed with
+> [#5725](https://github.com/esbmc/esbmc/pull/5725), and the retain boundary for
+> custom `isinstance`/`isnone` nodes is a finding, not outstanding work. The one
+> item still open is the **float residue** (task 6's last bullet), and its file
+> citations had gone stale — they are corrected in place below. Several paths
+> named here also moved when `python-frontend` was split into subdirectories
+> (`python_math.cpp` → `math/`, `numpy_call_expr.cpp` → `numpy/`); the entries
+> keep their original wording with the current location noted, rather than being
+> silently rewritten, so the commit trail stays legible.
+
 ## What the spike established (see irep2-migration.md, "Spike result 2026-06-30")
 
 The residual that blocks the converter from building IREP2 directly is two
@@ -62,18 +73,26 @@ matched-text parity over the affected regression suite, asserts build.
    (The doc's stale `python_list.cpp:4120/4533` line numbers; python-list is now
    split. Other list loop conditions — `list_access`, `list_construction:165`,
    `list_comprehension:494` — were already migrated by earlier V.3 sweeps.)
-4. **W** [PARTIAL] `python_math.cpp` floor-div/modulo sign-correction trees —
-   the four `value < 0` sign tests migrated via a shared `build_sign_test`
-   helper. Commit 5642865dfa. REMAINING in these trees (deferred, entangled):
-   the `mod(lhs,rhs)` node (nested width-hazard on lhs/rhs), the bool `xor`
-   (must stay bool-xor, not bitxor — #4548 Bitwuzla crash), `and`, the modulo
-   `if(cond, rhs, 0)` (mismatched branch widths), and the outer `+`/`-`.
+4. **W** [DONE] `python_math.cpp` floor-div/modulo sign-correction trees — the
+   four `value < 0` sign tests migrated via a shared `build_sign_test` helper
+   (commit 5642865dfa), and the residue this entry once listed as "deferred,
+   entangled" — the `mod(lhs,rhs)` node, the bool `xor` (still bool-xor, not
+   bitxor — #4548), `and`, the modulo `if(cond, rhs, 0)`, and the outer `+`/`-`
+   — all landed in [#5725](https://github.com/esbmc/esbmc/pull/5725) via
+   `python_expr::build_{mod,and,xor,if,add,sub}`. The file has since moved to
+   `src/python-frontend/math/python_math.cpp`; the call sites are its
+   `handle_floor_division` / `handle_int_modulo`.
 4b. **W** [DONE] `list_mutation.cpp:935` — `idx < str_len` in
    build_extend_list_call. Commit fe23ac42b5. **With this, every clean
    loop-condition / sign-test width-hazard is drained.** A full census
    (`grep '("<"' etc. across src/python-frontend`) leaves only: the entangled
-   `python_math` tree nodes (task 4 remaining) and one float site
-   `numpy_call_expr.cpp:2503` (ieee_sub + rounding-mode — a different hazard).
+   `python_math` tree nodes (task 4, since drained — see above) and one float
+   site then cited as `numpy_call_expr.cpp:2503` (ieee_sub + rounding-mode — a
+   different hazard). **Both citations are now stale:** `numpy_call_expr.cpp`
+   builds no `ieee_*` nodes at all, and the float residue lives in
+   `src/python-frontend/math/complex_handler.cpp` (the `exprt("ieee_add")`
+   family in `complex_pow`'s operand dispatch). `complex_mul`/`complex_div`/
+   `complex_log` there are already `ieee_*2tc`.
 
 5. **D** [PARTIAL] `builtins.cpp:369` isinstance is-None — DONE (commit
    9a7755247f). **Key finding: the F-P11 wall is milder than framed here.**
@@ -109,9 +128,14 @@ matched-text parity over the affected regression suite, asserts build.
      `__getitem__` path) → `build_dereference` (commit a22a6486fe). The base is a
      pointer-to-tuple parameter; build_dereference handles #cpp_type + dyn-array
      fallback. github_4539 suite (9) + A/B parity.
-   - [TODO, risky] `numpy_call_expr.cpp:1607` complex int→double — FLOAT
-     (ieee ops + rounding-mode; the `out.type()=...` + adjust_float_arith
-     rounding-mode is the known-fragile migration path, defer).
+   - [TODO, risky] The float residue — `ieee_*` construction plus the
+     rounding-mode/`adjust_float_arith` path, still the known-fragile migration.
+     Originally cited as `numpy_call_expr.cpp:1607`; **that citation is stale**
+     (no `ieee_*` nodes remain in that file). What is left is the
+     `exprt("ieee_add"/"ieee_sub"/"ieee_mul"/"ieee_div")` dispatch in
+     `src/python-frontend/math/complex_handler.cpp`. Its sibling helpers
+     (`complex_mul`, `complex_div`, `complex_log`) are already IREP2, so this is
+     the last legacy float site on the converter's complex path.
 
 ## Verification protocol per commit
 

--- a/src/python-frontend/math/complex_handler.cpp
+++ b/src/python-frontend/math/complex_handler.cpp
@@ -78,16 +78,6 @@ const symbolt *complex_handler::find_cached_symbol(const std::string &id) const
 // Shared IEEE / complex arithmetic helpers
 // -----------------------------------------------------------------------
 
-exprt complex_handler::ieee_binop(
-  const irep_idt &id,
-  const exprt &x,
-  const exprt &y)
-{
-  exprt out(id, cached_double_type());
-  out.copy_to_operands(x, y);
-  return out;
-}
-
 exprt complex_handler::complex_mul(const exprt &x, const exprt &y) const
 {
   // V.3: build the whole complex product in IREP2, back-migrating once. Members
@@ -95,7 +85,7 @@ exprt complex_handler::complex_mul(const exprt &x, const exprt &y) const
   // complex_member); each IEEE op carries the default __ESBMC_rounding_mode
   // symbol migrate_expr attaches to a legacy ieee_* node; the double-typed
   // result needs no typecast -- so this back-migrates to the same struct the
-  // legacy make_complex(ieee_binop...) path produced (goto byte-identical,
+  // legacy make_complex(ieee_*) path produced (goto byte-identical,
   // verified via --goto-functions-only diff on the complex-power tests).
   // Mirrors complex_member / complex_typecast.
   const type2tc dt2 = migrate_type(cached_double_type());
@@ -131,7 +121,7 @@ exprt complex_handler::complex_div(
   // the double-typed .real/.imag members (member2t over the complex struct, as
   // complex_member does) and each IEEE op carries the default
   // __ESBMC_rounding_mode symbol migrate_expr attaches to a legacy ieee_* node
-  // -- so the back-migrated struct matches the legacy make_complex(ieee_binop)
+  // -- so the back-migrated struct matches the legacy make_complex(ieee_*)
   // path (goto byte-identical). Like complex_mul.
   const type2tc dt2 = migrate_type(cached_double_type());
   const expr2tc rm = symbol2tc(get_int32_type(), "c:@__ESBMC_rounding_mode");
@@ -198,7 +188,7 @@ exprt complex_handler::complex_log(
   // V.3: build |z|^2 = zr*zr + zi*zi in IREP2, back-migrating once for the
   // legacy handle_sqrt consumer. The IEEE ops carry the default
   // __ESBMC_rounding_mode symbol migrate_expr attaches to a legacy ieee_* node,
-  // so the back-migrated node matches the legacy ieee_binop tree (goto
+  // so the back-migrated node matches the legacy ieee_* tree (goto
   // byte-identical). Like complex_mul.
   const type2tc dt2 = migrate_type(dt);
   const expr2tc rm = symbol2tc(get_int32_type(), "c:@__ESBMC_rounding_mode");
@@ -572,7 +562,7 @@ exprt complex_handler::handle_binary_op(
     // complex struct, as complex_member does) and each IEEE op carries the
     // default __ESBMC_rounding_mode symbol migrate_expr attaches to a legacy
     // ieee_* node -- so the back-migrated struct matches the legacy
-    // make_complex(ieee_binop...) path (goto byte-identical). Like complex_mul.
+    // make_complex(ieee_*) path (goto byte-identical). Like complex_mul.
     const type2tc dt2 = migrate_type(cached_double_type());
     const expr2tc rm = symbol2tc(get_int32_type(), "c:@__ESBMC_rounding_mode");
     expr2tc lhs2, rhs2;

--- a/src/python-frontend/math/complex_handler.h
+++ b/src/python-frontend/math/complex_handler.h
@@ -107,9 +107,6 @@ private:
 
   // ---- shared IEEE / complex arithmetic helpers ----
 
-  /// Builds a binary IEEE-754 operation node (e.g. ieee_add, ieee_mul).
-  static exprt ieee_binop(const irep_idt &id, const exprt &x, const exprt &y);
-
   /// Complex multiplication: (a+bi)(c+di) = (ac-bd)+(ad+bc)i.
   exprt complex_mul(const exprt &x, const exprt &y) const;
 


### PR DESCRIPTION
Two pieces of closeout for the V.1k keystone plan, found while checking what
that plan still has outstanding.

## Dead code

`complex_handler::ieee_binop` has **no callers anywhere in `src/` or `unit/`** —
only its declaration, its definition, and four comments naming it. It was
orphaned when the V.3 work replaced its call sites with the `ieee_*2tc` builders
(`complex_mul`, `complex_div`, `complex_log` all construct IREP2 directly now).
Removed, and the four comments reworded so they don't cite a function that no
longer exists — they still record the byte-identity relationship to the legacy
`ieee_*` tree, which is the useful part.

This is dead-*function* removal, not a branch removal, so the repo's Mode C
reachability obligation doesn't apply: "no callers in the tree" is a
compile-time fact and the link step is the proof.

## Stale plan document

`docs/irep2-keystone-implementation-plan.md` had drifted from the code:

- **Task 4 was `[PARTIAL]`**, listing `mod`, the bool `xor`, `and`, the modulo
  `if(cond, rhs, 0)` and the outer `+`/`-` as "deferred, entangled". All five
  landed in #5725 via `python_expr::build_{mod,and,xor,if,add,sub}`. Marked
  `[DONE]`.
- **The float-residue citations were wrong.** Tasks 4b and 6 point at
  `numpy_call_expr.cpp:2503` / `:1607`; that file builds no `ieee_*` nodes at
  all today. The genuine remaining site is the
  `exprt("ieee_add"/"ieee_sub"/"ieee_mul"/"ieee_div")` dispatch in
  `math/complex_handler.cpp`. Corrected in place.
- Several paths moved when `python-frontend` was split into subdirectories
  (`python_math.cpp` → `math/`, `numpy_call_expr.cpp` → `numpy/`). Entries keep
  their original wording with the current location noted, rather than being
  silently rewritten, so the commit trail stays legible.
- Added a status header: every W and D site has landed, and the float residue is
  the single open item.

## Testing

- `regression/python/*complex*` — 5 tests reported `Timeout` under `ctest -j4`
  on this machine; each was re-run in isolation and gives its expected verdict
  (`complex_pow_complex_exp` takes **4.1 s** alone against a 120 s limit), so
  those are host contention, not regressions.
- `scripts/check_python_tests.sh complex` — all tests behaved as expected under
  CPython.
- clang-format (Clang 11) clean.
