### PR TITLE
[build] Auto-detect the macOS SDK for C2GOTO_SYSROOT

### DIFF
--- a/scripts/build-esbmc-mac.sh
+++ b/scripts/build-esbmc-mac.sh
@@ -51,7 +51,6 @@ CPU_COUNT=$(($(sysctl -n hw.ncpu) + 1))
 
 # Get paths
 PATH_LLVM=$(brew --prefix llvm)
-PATH_SDK=$(xcrun --show-sdk-path)
 PATH_Z3=$(brew --prefix z3)
 
 # Function to install Boolector
@@ -88,7 +87,6 @@ CMAKE_ARGS=(
     -DENABLE_Z3=1
     -DCMAKE_BUILD_TYPE=Debug
     -DZ3_DIR="$PATH_Z3"
-    -DC2GOTO_SYSROOT="$PATH_SDK"
     -DClang_DIR="$PATH_LLVM/lib/cmake/clang"
 )
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -209,7 +209,6 @@ prepare_platform_config() {
       BASE_ARGS+=(
         "-DLLVM_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
         "-DClang_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
-        "-DC2GOTO_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
       )
 
       SOLVER_FLAGS+=("-DENABLE_GOTO_CONTRACTOR=OFF" "-DENABLE_Z3=ON")

--- a/scripts/cmake/AppleConfiguration.cmake
+++ b/scripts/cmake/AppleConfiguration.cmake
@@ -18,4 +18,35 @@ if(APPLE)
     set(OS_C2GOTO_FLAGS "")
     set(OS_INCLUDE_LIBS "")
     set(OS_Z3_LIBS "stdc++ -pthread")
+
+    # macOS has had no /usr/include since 10.14, so the C library headers are
+    # reachable only through an SDK. Both c2goto and every runtime parse
+    # (ESBMC_C2GOTO_SYSROOT, baked into ac_config.h) need one; without it the
+    # build dies while generating the libc models, on a "'complex.h' file not
+    # found" that names neither CMake nor the SDK (esbmc/esbmc#6234).
+    if(NOT DEFINED C2GOTO_SYSROOT)
+        if(CMAKE_OSX_SYSROOT AND IS_DIRECTORY "${CMAKE_OSX_SYSROOT}")
+            set(detected_sdk "${CMAKE_OSX_SYSROOT}")
+        else()
+            execute_process(COMMAND xcrun --show-sdk-path
+                OUTPUT_VARIABLE detected_sdk
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+                RESULT_VARIABLE xcrun_result)
+            if(NOT xcrun_result EQUAL 0 OR NOT detected_sdk)
+                set(detected_sdk "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk")
+            endif()
+        endif()
+        set(C2GOTO_SYSROOT "${detected_sdk}" CACHE PATH
+            "SDK the C/C++ frontend parses against (auto-detected on macOS)")
+    endif()
+
+    if(NOT IS_DIRECTORY "${C2GOTO_SYSROOT}")
+        message(FATAL_ERROR
+            "C2GOTO_SYSROOT is '${C2GOTO_SYSROOT}', which is not a directory. "
+            "ESBMC needs a macOS SDK to find the system headers. Install the "
+            "command line tools with 'xcode-select --install', or pass "
+            "-DC2GOTO_SYSROOT=<path to MacOSX.sdk>.")
+    endif()
+    message(STATUS "C2GOTO_SYSROOT: ${C2GOTO_SYSROOT}")
 endif()

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(c2goto PROPERTIES
   PRIVATE_HEADER "${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/libc.h;${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/libm.h;${CMAKE_CURRENT_BINARY_DIR}/c2goto-hdr/headers/libc_hdr.h")
 
 
-if(DEFINED C2GOTO_SYSROOT)
+if(C2GOTO_SYSROOT)
   set(multiarch_flags --sysroot "${C2GOTO_SYSROOT}")
 endif()
 

--- a/website/content/docs/development/building.md
+++ b/website/content/docs/development/building.md
@@ -132,8 +132,7 @@ cd esbmc
 cmake -GNinja -Bbuild -DDOWNLOAD_DEPENDENCIES=1 -DENABLE_Z3=1 \
   -DLLVM_DIR=$(brew --prefix llvm@21)/lib/cmake/llvm \
   -DClang_DIR=$(brew --prefix llvm@21)/lib/cmake/clang \
-  -DZ3_DIR=$(brew --prefix z3) \
-  -DC2GOTO_SYSROOT=$(xcrun --show-sdk-path)
+  -DZ3_DIR=$(brew --prefix z3)
 ninja -C build
 ```
 
@@ -148,8 +147,14 @@ optionally installs Boolector/Bitwuzla, and installs `esbmc` globally:
 {{% /details %}}
 
 {{% details title="Xcode SDK" closed="true" %}} A full Xcode or the Command Line
-Tools SDK is required. If `xcrun --show-sdk-path` fails, install the tools with
-`xcode-select --install`. {{% /details %}}
+Tools SDK is required — macOS keeps the C library headers inside the SDK rather
+than in `/usr/include`. CMake detects it automatically (`CMAKE_OSX_SYSROOT`,
+then `xcrun --show-sdk-path`) and stores it in `C2GOTO_SYSROOT`; pass
+`-DC2GOTO_SYSROOT=<path to MacOSX.sdk>` only to override that choice. If
+`xcrun --show-sdk-path` fails, install the tools with `xcode-select --install`.
+
+A build that ends up with no SDK fails while generating the libc models, with
+`complex.c:1:10: fatal error: 'complex.h' file not found`. {{% /details %}}
 
 {{% /steps %}} {{< /tab >}}
 


### PR DESCRIPTION
`C2GOTO_SYSROOT` had no default, so a `cmake` line that omitted it built a
sysroot-less `c2goto`; with no `/usr/include` on macOS the build then failed
while generating the libc models on `'complex.h' file not found`, and the
binary would have failed on any program including a system header. Detect the
SDK from `CMAKE_OSX_SYSROOT` or `xcrun`, fail at configure time when none
resolves, and drop the flag from the build scripts so CI exercises the
detection path.

Fixes #6234