### PR TITLE
[cpp] Fix dynamic exception-spec unexpected/bad_exception recovery

### DIFF
--- a/regression/esbmc-cpp/try_catch/lower-exceptions_dynspec_no_handler_terminate_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_dynspec_no_handler_terminate_fail/main.cpp
@@ -1,0 +1,30 @@
+// A violated dynamic exception specification with NO std::set_unexpected
+// installed runs the default unexpected handler, which must terminate
+// ([except.unexpected]). Terminate here is a spec violation and must be
+// reported as FAILED even though a custom std::set_terminate handler ends the
+// path (abort, modeled as assume(0)): the lowering owns this terminate point
+// and asserts it directly, rather than routing through std::terminate() where
+// the custom handler could silently swallow the violation.
+#include <exception>
+#include <cstdlib>
+
+struct A
+{
+};
+
+void my_terminate()
+{
+  abort();
+}
+
+void f() throw(int)
+{
+  throw A(); // A is not permitted by throw(int) -> default std::unexpected
+}
+
+int main()
+{
+  std::set_terminate(my_terminate);
+  f();
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_dynspec_no_handler_terminate_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_dynspec_no_handler_terminate_fail/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --std c++03
-
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --std c++11
 

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_01/test.desc
@@ -1,5 +1,5 @@
-KNOWNBUG
+CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900 --std c++03
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/main.cpp
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/main.cpp
@@ -1,3 +1,7 @@
+// myfunction()'s throw(int) spec is violated by `throw 'x'` (char), so
+// std::unexpected runs myunexpected, which throws 5 (int) — permitted by the
+// spec, so it propagates and is caught by catch(int). The program terminates
+// normally: VERIFICATION SUCCESSFUL (confirmed against g++ -std=c++11, exit 0).
 #include <iostream>
 #include <exception>
 using namespace std;

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900 --std c++03
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/cpp/exception.cpp
+++ b/src/c2goto/library/cpp/exception.cpp
@@ -84,7 +84,13 @@ __ESBMC_HIDE:;
 void __ESBMC_default_unexpected_handler()
 {
 __ESBMC_HIDE:;
-  std::terminate();
+  // No-op: with no user handler installed, a violated dynamic exception
+  // specification must terminate, but that decision is owned by the GOTO
+  // exception lowering, which asserts it directly (FAILED) when this returns
+  // without throwing. Calling std::terminate() here instead would route through
+  // a custom std::set_terminate handler that could end the path (abort ->
+  // assume(0)) and silently swallow the violation. std::unexpected() still
+  // terminates for a direct user call via its own trailing terminate().
 }
 
 inline std::terminate_handler &__ESBMC_terminate_handler_ref()

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -1098,15 +1098,18 @@ private:
     return disj;
   }
 
-  /// A call to the installed std::unexpected handler — the set_unexpected
-  /// builtin records it as __ESBMC_unexpected — or nil when none is installed.
+  /// A call to the std::unexpected dispatcher (__ESBMC_run_unexpected), which
+  /// invokes the handler installed via std::set_unexpected or, when none is
+  /// installed, the default handler (which calls std::terminate). Nil when the
+  /// exception OM is not linked, in which case the caller falls back to an
+  /// immediate specification-violation.
   expr2tc make_unexpected_call()
   {
-    const symbolt *h = ns.lookup("c:@F@__ESBMC_unexpected");
+    const symbolt *h = ns.lookup("c:@F@__ESBMC_run_unexpected");
     if (!h)
       return expr2tc();
     code_function_callt fc;
-    fc.function() = h->get_value();
+    fc.function() = symbol_exprt(h->id, h->get_type());
     expr2tc call;
     migrate_expr(fc, call);
     return call;
@@ -1306,12 +1309,27 @@ private:
     if (!is_nil_expr(call))
     {
       // Clear `thrown` so the handler runs with no exception in flight; keep
-      // typeid/value so a bare `throw;` in the handler rethrows the original.
+      // typeid/value naming the original exception.
       auto clear = ins(fail);
       clear->make_assignment();
       clear->code = code_assign2tc(thrown, gen_false_expr());
 
+      // Make the original exception the "currently handled" one for the duration
+      // of the handler, so a bare `throw;` in it re-raises the original
+      // ([except.throw]/8, [except.unexpected]) via __ESBMC_rethrow_current
+      // rather than terminating on an empty handled stack.
+      expr2tc push = make_c_helper_call(exception_globals::push_handled_id);
+      if (!is_nil_expr(push))
+        ins(fail)->make_function_call(push);
+
       ins(fail)->make_function_call(call);
+
+      // Balance the handled stack. A throw out of the handler leaves `thrown`
+      // set, so pop preserves the newly in-flight exception; a normal return
+      // leaves it clear and we fall to the violation assert below regardless.
+      expr2tc pop = make_c_helper_call(exception_globals::pop_handled_id);
+      if (!is_nil_expr(pop))
+        ins(fail)->make_function_call(pop);
 
       // Handler returned without throwing -> the specification is violated.
       ins(fail)->make_goto(fail, not_thrown());
@@ -1328,11 +1346,61 @@ private:
         a_cnt->code = adjust_uncaught(-1);
       }
 
-      // Handler rethrew a permitted type -> let it propagate.
+      // Handler threw a permitted type -> let it propagate.
       ins(fail)->make_goto(ret, permitted());
+
+      // Handler threw a disallowed type: substitute std::bad_exception
+      // ([except.unexpected]/2). The substitute propagates when the spec lists
+      // bad_exception, and otherwise stays disallowed and falls through to the
+      // terminate assert — which reports the violation directly (FAILED) instead
+      // of routing through std::terminate(), whose custom handler could end the
+      // path and swallow it.
+      expr2tc bad_exc_obj = build_bad_exception_object();
+      if (!is_nil_expr(bad_exc_obj))
+      {
+        const unsigned bad_id = registry.id_of(bad_exception_name_);
+        auto a_tid = ins(fail);
+        a_tid->make_assignment();
+        a_tid->code = code_assign2tc(
+          type_id, constant_int2tc(type_id->type, BigInt(bad_id)));
+
+        auto a_val = ins(fail);
+        a_val->make_assignment();
+        a_val->code = code_assign2tc(
+          value,
+          typecast2tc(
+            value->type, address_of2tc(bad_exc_obj->type, bad_exc_obj)));
+
+        ins(fail)->make_goto(ret, permitted());
+      }
     }
     // Fall through to fail.
   }
+
+  /// A fresh static std::bad_exception object for the [except.unexpected]/2
+  /// substitution, or nil when the <exception> model's bad_exception is not in
+  /// the symbol table. As with build_bad_cast_throw the object's state is
+  /// irrelevant — only its type identity (recorded in bad_exception_name_ for
+  /// the caller's typeid) and address matter. Built at most once and reused.
+  expr2tc build_bad_exception_object()
+  {
+    if (!is_nil_expr(bad_exception_obj_))
+      return bad_exception_obj_;
+
+    const symbolt *sym = ns.lookup("tag-std::bad_exception");
+    if (!sym)
+      sym = ns.lookup("tag-class std::bad_exception");
+    if (!sym)
+      return expr2tc();
+
+    bad_exception_name_ =
+      irep_idt(id2string(sym->id).substr(4)); // strip "tag-"
+    bad_exception_obj_ = make_exception_storage(migrate_symbol_type(*sym));
+    return bad_exception_obj_;
+  }
+
+  expr2tc bad_exception_obj_;
+  irep_idt bad_exception_name_;
 
   /// Replace a throw with: arm the globals (or, for a rethrow, just re-raise
   /// the in-flight one) and branch to the enclosing dispatch / epilogue.


### PR DESCRIPTION
Fixes #6022.

## Root cause

`remove_exceptions.cpp:make_unexpected_call()` looked up `c:@F@__ESBMC_unexpected`, but the operational-model helper is named `__ESBMC_run_unexpected` — a name drift between #5276 (which added the lookup) and #5326 (which named the OM helper). The lookup always returned nil, so the unexpected-handler dispatch block in `build_dynamic_spec_check` was **dead code**: a disallowed escape from a `throw(T...)` spec went straight to a spec-violation assertion without ever running the installed `std::unexpected` handler.

Correcting the symbol name alone is unsound — it introduces a false negative on `try-catch_terminate_01_bug` and leaves the `bad_exception` cases broken — so this PR implements the full [except.unexpected] recovery chain.

## Fix

1. **Symbol + call shape** — wire `make_unexpected_call` to `__ESBMC_run_unexpected`, built as a `symbol_exprt(id, type)` (mirroring `make_c_helper_call`), not `h->get_value()`.
2. **Bare `throw;` in the handler** — push the original in-flight exception onto the handled-exception stack for the duration of the handler, so a bare `throw;` re-raises the original ([except.throw]/8) via `__ESBMC_rethrow_current` instead of terminating on an empty handled stack; pop to keep the stack balanced.
3. **`std::bad_exception` substitution** ([except.unexpected]/2) — when the handler throws a disallowed type, replace the in-flight exception with a synthesized `std::bad_exception` object (reusing the `build_bad_cast_throw` pattern). It propagates when the spec lists `bad_exception`, and otherwise stays disallowed and falls through to the terminate assert.
4. **Sound terminate** — make the OM default unexpected handler a no-op so a violated spec with **no** installed handler is reported directly by the lowering (FAILED) rather than routed through `std::terminate()`, where a custom `std::set_terminate` that ends the path (`abort()` → `assume(0)`) would silently swallow the violation. `std::unexpected()` still terminates for a direct user call via its own trailing `terminate()`.

## Validation

- **Ground truth** for every changed verdict was confirmed against `g++ -std=c++11/03` (exit 0 = SUCCESSFUL, SIGABRT = FAILED).
- Flips three KNOWNBUG → CORE: `lower-exceptions_uncaught_count_dynspec`, `lower-exceptions_bad_exception_subst`, `try-catch_unexpected_01`.
- Corrects `try-catch_unexpected_04`: its expected `FAILED` was pinned to the buggy output; the handler throws a permitted `int` caught by `catch(int)`, so the ground truth is SUCCESSFUL.
- Adds `lower-exceptions_dynspec_no_handler_terminate_fail` as a soundness regression: a spec violation with no `set_unexpected` + a custom aborting `set_terminate` must stay FAILED. **Verified fails-before / passes-after** by temporarily reverting the OM change (→ false SUCCESSFUL) and rebuilding.
- `try-catch_terminate_01_bug` stays FAILED (no false negative).
- Full `regression/esbmc-cpp/try_catch` suite: **165/165 pass**. Shared `remove_exceptions` pass unaffected: 60 Python exception/`raise`/`try` tests pass; `esbmc-cpp20/cpp/github_4377_expected` passes.

Every new branch is exercised by a passing reproducer (substitution → `bad_exception_subst`/`unexpected_01`; handled-stack push/pop → `terminate_01_bug`; OM no-op → `dynspec_no_handler_terminate_fail`).