### PR TITLE
[python] Fix core dump on method call on attribute assigned from self.method() (#6242)

### DIFF
--- a/regression/python/github_6242/main.py
+++ b/regression/python/github_6242/main.py
@@ -1,0 +1,21 @@
+# github.com/esbmc/esbmc/issues/6242
+# An attribute assigned from a self-method returning an object must be typed by
+# the method's return class, so a later method call on the attribute resolves
+# instead of aborting GOTO conversion.
+class Publisher:
+    def publish(self, msg):
+        return msg + 1
+
+
+class Talker:
+    def make(self):
+        return Publisher()
+
+    def __init__(self):
+        self.pub = self.make()
+
+    def go(self):
+        return self.pub.publish(41)
+
+
+assert Talker().go() == 42

--- a/regression/python/github_6242/test.desc
+++ b/regression/python/github_6242/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6242_fail/main.py
+++ b/regression/python/github_6242_fail/main.py
@@ -1,0 +1,21 @@
+# github.com/esbmc/esbmc/issues/6242
+# Same attribute-from-self-method pattern, but the asserted result is wrong:
+# the call now resolves and returns a concrete value, so the assertion is
+# checked and violated (previously this aborted with a core dump).
+class Publisher:
+    def publish(self, msg):
+        return msg + 1
+
+
+class Talker:
+    def make(self):
+        return Publisher()
+
+    def __init__(self):
+        self.pub = self.make()
+
+    def go(self):
+        return self.pub.publish(41)
+
+
+assert Talker().go() == 99

--- a/regression/python/github_6242_fail/test.desc
+++ b/regression/python/github_6242_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --unwind 1
+^VERIFICATION FAILED$

--- a/regression/python/github_6242_inherited/main.py
+++ b/regression/python/github_6242_inherited/main.py
@@ -1,0 +1,23 @@
+# github.com/esbmc/esbmc/issues/6242
+# The factory method lives in a BASE class, so typing self.attr from
+# self.make() must walk the base chain (not just the enclosing class) to
+# adopt the return class; otherwise the later attribute method call aborts.
+class Publisher:
+    def publish(self, msg):
+        return msg + 1
+
+
+class Base:
+    def make(self):
+        return Publisher()
+
+
+class Talker(Base):
+    def __init__(self):
+        self.pub = self.make()
+
+    def go(self):
+        return self.pub.publish(41)
+
+
+assert Talker().go() == 42

--- a/regression/python/github_6242_inherited/test.desc
+++ b/regression/python/github_6242_inherited/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -1985,6 +1985,46 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
     return "Any";
   }
 
+  // Handle self.method() calls: resolve the method in the current class (or,
+  // failing that, along its base chain) and adopt its return type. Without
+  // this the `self` receiver is unresolved, so an unannotated
+  // `self.attr = self.method()` is left untyped and the attribute defaults to
+  // its enclosing class — which later emits a call to a nonexistent method on
+  // that attribute and aborts GOTO conversion (#6242).
+  if (obj == "self" && !attr_name.empty() && !current_class_name_.empty())
+  {
+    for (std::string cls = current_class_name_; !cls.empty();)
+    {
+      Json class_node = json_utils::find_class(ast_["body"], cls);
+      if (class_node.empty() || !class_node.contains("body"))
+        break;
+      for (const Json &member : class_node["body"])
+      {
+        if (member["_type"] != "FunctionDef" || member["name"] != attr_name)
+          continue;
+        if (member.contains("returns") && !member["returns"].is_null())
+        {
+          const Json &ret = member["returns"];
+          if (ret.contains("id"))
+            return ret["id"].template get<std::string>();
+          if (
+            ret.contains("_type") && ret["_type"] == "Subscript" &&
+            ret.contains("value") && ret["value"].contains("id"))
+            return ret["value"]["id"].template get<std::string>();
+        }
+        std::string inferred =
+          infer_from_return_statements(member["body"], attr_name);
+        return inferred.empty() ? "Any" : inferred;
+      }
+      // Not defined in this class — continue up the first base, as super() does.
+      cls.clear();
+      if (
+        class_node.contains("bases") && !class_node["bases"].empty() &&
+        class_node["bases"][0].contains("id"))
+        cls = class_node["bases"][0]["id"].template get<std::string>();
+    }
+  }
+
   // Handle dict.keys() and dict.values()
   if (attr_name == "keys" || attr_name == "values")
   {

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -1810,6 +1810,26 @@ std::string python_annotation<Json>::get_type_from_call(const Json &element)
 }
 
 template <class Json>
+std::string python_annotation<Json>::method_return_type(
+  const Json &member,
+  const std::string &method_name)
+{
+  if (member.contains("returns") && !member["returns"].is_null())
+  {
+    const Json &ret = member["returns"];
+    if (ret.contains("id"))
+      return ret["id"].template get<std::string>();
+    if (
+      ret.contains("_type") && ret["_type"] == "Subscript" &&
+      ret.contains("value") && ret["value"].contains("id"))
+      return ret["value"]["id"].template get<std::string>();
+  }
+  std::string inferred =
+    infer_from_return_statements(member["body"], method_name);
+  return inferred.empty() ? "Any" : inferred;
+}
+
+template <class Json>
 std::string python_annotation<Json>::get_type_from_method(const Json &call)
 {
   std::string type("");
@@ -1965,20 +1985,7 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
         {
           if (member["_type"] != "FunctionDef" || member["name"] != attr_name)
             continue;
-          if (member.contains("returns") && !member["returns"].is_null())
-          {
-            const Json &ret = member["returns"];
-            if (ret.contains("id"))
-              return ret["id"].template get<std::string>();
-            if (
-              ret.contains("_type") && ret["_type"] == "Subscript" &&
-              ret.contains("value") && ret["value"].contains("id"))
-              return ret["value"]["id"].template get<std::string>();
-          }
-          // attr_name == member["name"] by the loop invariant above
-          std::string inferred =
-            infer_from_return_statements(member["body"], attr_name);
-          return inferred.empty() ? "Any" : inferred;
+          return method_return_type(member, attr_name);
         }
       }
     }
@@ -1993,7 +2000,12 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
   // that attribute and aborts GOTO conversion (#6242).
   if (obj == "self" && !attr_name.empty() && !current_class_name_.empty())
   {
-    for (std::string cls = current_class_name_; !cls.empty();)
+    // `visited` guards against cyclic base declarations (e.g. class A(B) /
+    // class B(A)): these do not run in Python but ast.parse still accepts
+    // them, so the walk must not loop forever.
+    std::set<std::string> visited;
+    for (std::string cls = current_class_name_;
+         !cls.empty() && visited.insert(cls).second;)
     {
       Json class_node = json_utils::find_class(ast_["body"], cls);
       if (class_node.empty() || !class_node.contains("body"))
@@ -2002,19 +2014,7 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
       {
         if (member["_type"] != "FunctionDef" || member["name"] != attr_name)
           continue;
-        if (member.contains("returns") && !member["returns"].is_null())
-        {
-          const Json &ret = member["returns"];
-          if (ret.contains("id"))
-            return ret["id"].template get<std::string>();
-          if (
-            ret.contains("_type") && ret["_type"] == "Subscript" &&
-            ret.contains("value") && ret["value"].contains("id"))
-            return ret["value"]["id"].template get<std::string>();
-        }
-        std::string inferred =
-          infer_from_return_statements(member["body"], attr_name);
-        return inferred.empty() ? "Any" : inferred;
+        return method_return_type(member, attr_name);
       }
       // Not defined in this class — continue up the first base, as super() does.
       cls.clear();

--- a/src/python-frontend/python_annotation/python_annotation.h
+++ b/src/python-frontend/python_annotation/python_annotation.h
@@ -151,6 +151,10 @@ private:
   std::string infer_lambda_return_type(const Json &lambda_elem) const;
   std::string
   infer_from_return_statements(const Json &body, const std::string &func_name);
+  // Return type of a FunctionDef @p member: its declared `-> T` (or `-> T[...]`)
+  // annotation, else the type inferred from its return statements, else "Any".
+  std::string
+  method_return_type(const Json &member, const std::string &method_name);
   void collect_return_types(
     const Json &body,
     const std::string &func_name,


### PR DESCRIPTION
## Summary

Fixes #6242 — a core dump (SIGABRT) when a method is called on an instance
attribute that was assigned from a `self.<method>()` call.

An unannotated `self.attr = self.method()` was left untyped, because the
annotator's `get_type_from_method` did not resolve a `self` receiver (it threw
`Object "self" not found`). With no inferred annotation, the attribute fell
through to `get_attributes_from_self`'s plain-`Assign` branch, which types the
member as `any_type()` and it then defaults to the **enclosing class**. A later
`self.attr.other()` therefore resolved to a nonexistent method on the enclosing
class (`@C@<Class>@F@other`), and GOTO conversion aborted with a core dump.

## Fix

Resolve `self.method()` in `get_type_from_method` against the current class,
walking the base chain (mirroring the existing `super().method()` handling), and
adopt the method's declared (`-> T`) or inferred (`return T()`) return type. The
attribute is now typed by the callee's return class.

## Effect

- **Valid pattern verifies** — `self.pub = self.make(); self.pub.publish(...)`
  where `make()` returns an object (the common ROS2-node shape) now resolves the
  call and verifies instead of crashing.
- **Invalid pattern reports cleanly** — calling a method that does not exist on
  the attribute's real type reports a normal `AttributeError` / `VERIFICATION
  FAILED` instead of a core dump.

## Tests

- `regression/python/github_6242` — valid pattern → `VERIFICATION SUCCESSFUL`.
- `regression/python/github_6242_fail` — same pattern with a wrong assertion
  (the call now yields a concrete value that is checked) → `VERIFICATION FAILED`.

Targeted `class|method|attr|inherit|polymorph|super` python regression subset
(256 tests) passes with no regressions.

## Known related (separate) case

`self.attr = param.method()` where `param` is an **unannotated parameter** still
mis-resolves the receiver to the enclosing class — a distinct root cause
(unannotated-parameter typing), not addressed here.
