### PR TITLE
[python] Fold str()/repr() floats via the shortest-repr renderer

### DIFF
--- a/docs/python-issues-triage-report-2026-06-02.md
+++ b/docs/python-issues-triage-report-2026-06-02.md
@@ -4117,9 +4117,9 @@ through to `std::ostringstream << d`, whose default is **6 significant digits**.
 `"{}".format(3.14159265)` to `"3.14159"`. Asserting the *wrong* string verified `SUCCESSFUL` (a
 soundness hole) while asserting the *correct* CPython string reported a spurious `FAILED`.
 
-This is a **separate renderer** from the `%.6f` fixed-decimal `str()` fold that §87 (PR #5945)
+This is a **separate renderer** from the `%.6f` fixed-decimal `str()` fold that PR #5945
 addresses: that one loses *decimals* (`str(0.1234567)` → `"0.123457"`), this one loses *significant
-digits*. Both were live on `master` simultaneously.
+digits*. Both were live on `master` simultaneously. (§87 below consolidates the two renderers.)
 
 **Fix**: render the fallback with the fewest significant digits that still read back as the same
 double — `%.*g` for precision 1..16, returning the first whose `strtod` compares equal, else `%.17g`
@@ -4147,6 +4147,57 @@ regression tests pass unchanged.
 
 ### 86b. Next candidate & everything else: unchanged disposition
 Next: consolidate the remaining float renderers onto the shortest-repr helper, which would let the
-`str()` fold cover the inexact values §87 leaves nondet. The §3 design-level blockers, §3c
-policy-banned timeouts, §3d questionable expectation, and the infeasible `hashlib` case all stand.
-The §5 priority order stands.
+`str()` fold cover the inexact values PR #5945 leaves nondet (done in §87). The §3 design-level
+blockers, §3c policy-banned timeouts, §3d questionable expectation, and the infeasible `hashlib`
+case all stand. The §5 priority order stands.
+
+## 87. 2026-07-22 re-validation (seventy-seventh sweep) & consolidate float str/repr onto one shortest-repr helper
+
+Re-test against current `master`. KNOWNBUG classification unchanged — §3 holds. §86b nominated
+consolidating the float renderers; this sweep does it and, in doing so, closes the `str()`/`repr()`
+soundness/completeness gap PR #5945 left open.
+
+### 87a. Two renderers unified; str()/repr()/f-string now fold inexact floats
+`str()`, `repr()` and f-string interpolation route a constant float through
+`string_handler::convert_to_string` → `cpython_float_str`. PR #5945 (§86's referenced predecessor)
+made that renderer render CPython's `str()` with a fixed `%.6f`-style fold and **refuse** (return
+`nullopt` → nondet string) whenever the 6-decimal spelling was inexact *or* the value fell outside
+CPython's fixed-notation range `[1e-4, 1e16)`. So `str(0.1 + 0.2)`, `str(1e-5)`, `str(1e16)` and
+`repr(0.1234567)` all degraded to a nondet string: a *correct*-value assertion reported a spurious
+`FAILED`, and a *wrong*-value assertion could not be falsified.
+
+Meanwhile §86 (PR #5942) had already given the empty-`"{}"` `format()` renderer
+(`format_float_value`) a **complete** shortest-repr algorithm: a whole value `< 1e16` renders as
+`N.0`; every other value uses the fewest `%.*g` significant digits (1..16, else `%.17g`) that read
+back as the same double — exactly how CPython's `repr` chooses its digits, with `%g`'s
+fixed/exponential cut-over provably agreeing with CPython's `1e16` boundary. That renderer was
+already validated in PR #5942 over ~440,000 doubles (0 mismatches vs CPython `repr`).
+
+**Fix**: make `cpython_float_str` *be* that algorithm (now total — it renders every double, including
+`nan`/`inf`), and delete the duplicate `format_float_value`, routing its two callers to
+`cpython_float_str`. One renderer now backs `str()`, `repr()`, f-strings, and empty-`"{}"`
+`format()`. Because the body is byte-for-byte the PR #5942 algorithm, `str()`/`repr()` inherit that
+440k-double validation for free. The pre-existing `round_to_nearest_guard` still pins `FE_TONEAREST`
+across `snprintf`/`strtod`.
+
+This is a **wrong-value/soundness + completeness fix**: previously-nondet folds are now exact, so
+correct assertions verify `SUCCESSFUL` and wrong ones are provably `FAILED`. New regression pair
+`regression/python/str_repr_shortest_repr{,_fail}` (CORE): the positive covers long-digit `str()`
+(`1.23456789`, `0.30000000000000004`, `123456789.5`), `repr(0.1234567)`, both exponential ranges
+(`1e-05`, `1e16`, `1.5e20`, `1e300`), both sides of the fixed/exp cut-over (`0.0001`, `1e15`), the
+unchanged short/whole cases (`2.5`, `0.1`, `1.0`, `1000000.0`), and f-string interpolation; the
+`_fail` pins the previously-unfalsifiable `str(1.23456789) == "1.23457"` as a real `FAILED`. The
+stale "fold is now refused / nondet" comment in `str_float_precision_loss_fail` is refreshed (that
+value now folds exactly, so the wrong assertion is provably false). All existing
+`str_float_repr_exact` (§86/PR #5945), `str_format_shortest_repr` (§86), `builtin_repr`,
+`complex_repr`, `percent`, and `fstring` regression tests pass unchanged; dual verdict checks confirm
+positives `SUCCESSFUL` and negatives `FAILED`.
+
+`py_format_number`'s explicit-spec renderer (`format(x, ".2f")`, width/sign/grouping) is a distinct
+concern — it uses user-supplied precision, not shortest-repr — and its default-typed float path
+(`format(x, "10")`, no presentation type) still returns `nullopt`; wiring that path to the shared
+helper is the natural next candidate.
+
+### 87b. Everything else: unchanged disposition
+The §3 design-level blockers, §3c policy-banned timeouts, §3d questionable expectation, and the
+infeasible `hashlib` case all stand. The §5 priority order stands.

--- a/regression/python/str_float_precision_loss_fail/main.py
+++ b/regression/python/str_float_precision_loss_fail/main.py
@@ -1,10 +1,9 @@
 def main() -> None:
     # str(0.1234567) needs more than 6 fractional digits; CPython renders the
-    # shortest round-trip repr "0.1234567". The frontend's fixed 6-decimal fold
-    # rounds it to "0.123457", so pre-fix this false assertion verified
-    # SUCCESSFUL (a soundness hole). The fold is now refused when it would lose
-    # precision and a nondet string is emitted instead, so this must be a real
-    # FAILED.
+    # shortest round-trip repr "0.1234567". The old fixed 6-decimal fold rounded
+    # it to "0.123457", so pre-fix this false assertion verified SUCCESSFUL (a
+    # soundness hole). str() now folds to the exact shortest repr, so asserting
+    # the truncated "0.123457" is provably FAILED.
     assert str(0.1234567) == "0.123457"
 
 

--- a/regression/python/str_repr_shortest_repr/main.py
+++ b/regression/python/str_repr_shortest_repr/main.py
@@ -1,0 +1,33 @@
+def main() -> None:
+    # str()/repr()/f-string now fold a constant float to CPython's shortest
+    # round-trip repr instead of refusing it: previously anything needing more
+    # than 6 significant digits, or exponential notation, emitted a nondet
+    # string. str() shares one renderer with "{}".format() now.
+    assert str(1.23456789) == "1.23456789"
+    assert str(3.14159265358979) == "3.14159265358979"
+    assert str(0.30000000000000004) == "0.30000000000000004"
+    assert str(123456789.5) == "123456789.5"
+    assert repr(0.1234567) == "0.1234567"
+
+    # Exponential ranges CPython uses outside [1e-4, 1e16).
+    assert str(1e-05) == "1e-05"
+    assert str(1e16) == "1e+16"
+    assert str(1.5e20) == "1.5e+20"
+    assert str(1e300) == "1e+300"
+
+    # Fixed/exponential cut-over matches CPython on both sides.
+    assert str(0.0001) == "0.0001"
+    assert str(1e15) == "1000000000000000.0"
+
+    # Short and whole-number values were already correct and stay so.
+    assert str(2.5) == "2.5"
+    assert str(0.1) == "0.1"
+    assert str(1.0) == "1.0"
+    assert str(1000000.0) == "1000000.0"
+
+    # f-string interpolation routes through the same renderer.
+    assert f"{1.23456789}" == "1.23456789"
+    assert f"x={0.30000000000000004}" == "x=0.30000000000000004"
+
+
+main()

--- a/regression/python/str_repr_shortest_repr/test.desc
+++ b/regression/python/str_repr_shortest_repr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str_repr_shortest_repr_fail/main.py
+++ b/regression/python/str_repr_shortest_repr_fail/main.py
@@ -1,0 +1,9 @@
+def main() -> None:
+    # str(1.23456789) needs more than 6 significant digits; CPython renders the
+    # shortest round-trip repr "1.23456789". The old fixed 6-digit fold produced
+    # "1.23457", and refusing the fold left a nondet string. str() now folds to
+    # the exact repr, so asserting the wrong 6-digit spelling is provably FAILED.
+    assert str(1.23456789) == "1.23457"
+
+
+main()

--- a/regression/python/str_repr_shortest_repr_fail/test.desc
+++ b/regression/python/str_repr_shortest_repr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <cctype>
 #include <climits>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>
@@ -708,46 +709,36 @@ std::string string_handler::float_to_string(
   return oss.str();
 }
 
-std::optional<std::string> string_handler::cpython_float_str(double d)
+std::string string_handler::cpython_float_str(double d)
 {
-  // std::to_string / setprecision(6) below honour the host FP rounding mode,
-  // which the pipeline can leave non-default; pin FE_TONEAREST so the decimal
-  // fold matches CPython regardless of the host's mode.
-  const round_to_nearest_guard rounding_guard;
+  // A whole value below 1e16 renders as its integer digits plus ".0"
+  // (str(1.0) == "1.0", str(1000000.0) == "1000000.0"); %g would drop the ".0".
+  if (std::isfinite(d) && d == std::floor(d) && std::fabs(d) < 1e16)
+  {
+    std::string s = std::to_string(static_cast<long long>(d));
+    if (std::signbit(d) && s[0] != '-') // str(-0.0) == "-0.0"
+      s.insert(s.begin(), '-');
+    return s + ".0";
+  }
 
-  // CPython spells the non-finite floats "nan"/"inf"/"-inf"; the fixed-notation
-  // fold below cannot produce them.
-  if (std::isnan(d))
-    return "nan";
-  if (std::isinf(d))
-    return d < 0 ? "-inf" : "inf";
-
-  // CPython uses exponential notation outside [1e-4, 1e16); the fixed fold
-  // below cannot reproduce it, so refuse those ranges (str(1e-5) == "1e-05",
-  // str(1e16) == "1e+16", not the fixed spellings).
-  const double mag = std::fabs(d);
-  if (!(d == 0.0 || (mag >= 1e-4 && mag < 1e16)))
-    return std::nullopt;
-
-  std::ostringstream oss;
-  oss << std::fixed << std::setprecision(6) << d;
-  std::string s = oss.str();
-
-  // Match Python's str(float): drop trailing fractional zeros but keep at least
-  // one digit after the dot ("5.0", not "5.").
-  const auto dot = s.find('.');
-  const size_t last_nonzero = s.find_last_not_of('0');
-  if (last_nonzero == dot)
-    s.resize(dot + 2);
-  else
-    s.resize(last_nonzero + 1);
-
-  // The 6-decimal rendering is only CPython's repr when it loses no precision.
-  // If the string does not parse back to the exact same double, the value needs
-  // more digits than were emitted; refuse rather than fold a wrong constant.
-  if (std::strtod(s.c_str(), nullptr) != d)
-    return std::nullopt;
-  return s;
+  // Every other value (and nan/inf) renders with the fewest significant digits
+  // that read back as the same double, which is exactly how CPython's repr
+  // chooses its digits. %g picks fixed vs. exponential on CPython's rule too:
+  // exponential iff the decimal exponent is < -4 or >= the significant-digit
+  // count, which agrees with CPython's 1e16 cut-over because a non-whole float
+  // always needs more significant digits than its exponent. snprintf/strtod
+  // honour the host FP rounding mode; pin FE_TONEAREST so the fold matches
+  // CPython regardless of the host's mode.
+  const round_to_nearest_guard guard;
+  char buf[40];
+  for (int precision = 1; precision < 17; ++precision)
+  {
+    std::snprintf(buf, sizeof(buf), "%.*g", precision, d);
+    if (std::strtod(buf, nullptr) == d)
+      return buf;
+  }
+  std::snprintf(buf, sizeof(buf), "%.17g", d);
+  return buf;
 }
 
 // Parse the leading [[fill]align][0][width] portion of a Python format
@@ -1233,12 +1224,9 @@ exprt string_handler::convert_to_string(const exprt &expr)
     }
     else if (t.is_floatbv())
     {
-      // A fixed 6-decimal fold cannot faithfully reproduce CPython's shortest
-      // round-trip repr for every double (precision loss for values like 1/3,
-      // exponential notation outside [1e-4, 1e16)). cpython_float_str returns
-      // nullopt when it cannot produce the exact spelling; fall back to a sound
-      // nondet string rather than fold a wrong constant that could satisfy a
-      // false assertion.
+      // Fold to CPython's shortest round-trip repr. Only a 64-bit double with a
+      // concrete value is rendered; a 32-bit float or an empty (nondet) value
+      // stays a sound nondet string.
       std::optional<std::string> folded;
       if (!expr.value().empty() && bv_width(t) == 64)
       {

--- a/src/python-frontend/string/string_handler.h
+++ b/src/python-frontend/string/string_handler.h
@@ -907,21 +907,20 @@ private:
     std::size_t width,
     int precision);
 
+public:
   /**
-   * @brief Render a constant double as CPython's str()/repr() would, or return
-   *        nullopt when the result cannot be produced exactly.
+   * @brief Render a constant double as CPython's str()/repr() would: the
+   *        shortest decimal string that reads back as the same double.
    *
-   * The frontend renders floats with a fixed 6-decimal format, which diverges
-   * from CPython's shortest round-trip repr and would otherwise fold to a WRONG
-   * constant string (verifying a false assertion SUCCESSFUL): precision loss
-   * (str(0.333333333) would give "0.333333") and notation (CPython uses
-   * exponential outside [1e-4, 1e16): str(1e-5) == "1e-05", str(1e16) ==
-   * "1e+16"). Fold only when provably CPython's repr: the value is zero or in
-   * CPython's fixed-notation range AND the 6-decimal rendering round-trips to
-   * the exact same double. Otherwise return nullopt so callers emit a sound
-   * nondet string rather than a wrong constant.
+   * A whole value below 1e16 gets the "N.0" spelling; every other finite value
+   * (and nan/inf) uses the fewest %g significant digits that round-trip, which
+   * reproduces CPython's shortest repr and its fixed/exponential cut-over. This
+   * is total: it renders every double, so str()/repr() and f-string
+   * interpolation fold to the exact CPython string for inexact values too
+   * (str(0.1 + 0.2) == "0.30000000000000004", str(1e-5) == "1e-05"). The caller
+   * still emits a nondet string for a 32-bit float or a nondet value.
    */
-  static std::optional<std::string> cpython_float_str(double d);
+  static std::string cpython_float_str(double d);
 };
 
 #endif // PYTHON_FRONTEND_STRING_HANDLER_H

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -107,43 +107,6 @@ static char to_upper_char(char c)
   return static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 }
 
-// Render a constant float as CPython's str() / empty-"{}" field does. A
-// whole-number float below 1e16 renders as its integer digits plus ".0"
-// (str(1.0) == "1.0", str(1000000.0) == "1000000.0").
-//
-// Every other float renders with the fewest significant digits that still read
-// back as the same double, which is exactly how CPython's repr chooses its
-// digits. The default ostream format instead prints 6 significant digits, so it
-// silently truncated str(1.23456789) to "1.23457" and folded the false
-// `"{}".format(1.23456789) == "1.23457"` to true.
-//
-// %g then picks fixed vs. exponential notation on the same rule CPython uses:
-// exponential iff the decimal exponent is < -4 or >= the significant-digit
-// count. The two agree here because a float that is not whole always needs more
-// significant digits than its exponent, and every whole float below 1e16 is
-// handled above; CPython's own cut-over at 1e16 is what the branch encodes.
-static std::string format_float_value(double d)
-{
-  if (std::isfinite(d) && d == std::floor(d) && std::fabs(d) < 1e16)
-  {
-    std::string s = std::to_string(static_cast<long long>(d));
-    if (std::signbit(d) && s[0] != '-') // str(-0.0) == "-0.0"
-      s.insert(s.begin(), '-');
-    return s + ".0";
-  }
-
-  const round_to_nearest_guard guard;
-  char buf[40];
-  for (int precision = 1; precision < 17; ++precision)
-  {
-    std::snprintf(buf, sizeof(buf), "%.*g", precision, d);
-    if (std::strtod(buf, nullptr) == d)
-      return buf;
-  }
-  std::snprintf(buf, sizeof(buf), "%.17g", d);
-  return buf;
-}
-
 static std::string
 format_value_from_json(const nlohmann::json &arg, python_converter &converter)
 {
@@ -168,7 +131,7 @@ format_value_from_json(const nlohmann::json &arg, python_converter &converter)
     if (ov.is_boolean())
       return ov.get<bool>() ? "-1" : "0";
     if (ov.is_number_float())
-      return format_float_value(-ov.get<double>());
+      return string_handler::cpython_float_str(-ov.get<double>());
   }
   if (arg.contains("_type") && arg["_type"] == "Constant")
   {
@@ -187,7 +150,7 @@ format_value_from_json(const nlohmann::json &arg, python_converter &converter)
     if (arg["value"].is_number_integer())
       return std::to_string(arg["value"].get<long long>());
     if (arg["value"].is_number_float())
-      return format_float_value(arg["value"].get<double>());
+      return string_handler::cpython_float_str(arg["value"].get<double>());
     throw std::runtime_error("format() unsupported constant type");
   }
 


### PR DESCRIPTION
Resumes the Python triage plan (`docs/python-issues-triage-report-2026-06-02.md`, §86b next candidate → new §87).

## What
`str()`, `repr()` and f-string interpolation route a constant float through `string_handler::convert_to_string` → `cpython_float_str`. PR #5945 made that renderer fold CPython's `str()` with a fixed 6-decimal spelling and **refuse** (return `nullopt` → nondet string) whenever the 6-decimal form was inexact *or* the value fell outside CPython's fixed-notation range `[1e-4, 1e16)`. So `str(0.1 + 0.2)`, `str(1e-5)`, `str(1e16)`, `repr(0.1234567)` all degraded to a nondet string: a correct-value assertion reported a spurious `FAILED`, and a wrong-value assertion could not be falsified.

Meanwhile §86 (PR #5942) had already given the empty-`{}` `format()` renderer (`format_float_value`) a **complete** shortest-repr algorithm — a whole value `< 1e16` renders as `N.0`; every other value uses the fewest `%.*g` significant digits (1..16, else `%.17g`) that read back as the same double — validated over ~440,000 doubles (0 mismatches vs CPython `repr`).

This PR makes `cpython_float_str` **be** that algorithm (now total — it renders every double, including `nan`/`inf`) and **deletes the duplicate** `format_float_value`, routing its callers to `cpython_float_str`. One renderer now backs `str()`, `repr()`, f-strings and empty-`{}` `format()`. Because the body is byte-for-byte the PR #5942 algorithm, `str()`/`repr()` inherit its 440k-double validation.

## Why
Wrong-value/soundness + completeness fix: previously-nondet folds are now exact, so correct assertions verify `SUCCESSFUL` and wrong ones are provably `FAILED`. The pre-existing `round_to_nearest_guard` still pins `FE_TONEAREST` across `snprintf`/`strtod`.

## Tests
- New pair `regression/python/str_repr_shortest_repr{,_fail}` (CORE): positive covers long-digit `str()` (`1.23456789`, `0.30000000000000004`, `123456789.5`), `repr(0.1234567)`, both exponential ranges (`1e-05`, `1e16`, `1.5e20`, `1e300`), both sides of the fixed/exp cut-over (`0.0001`, `1e15`), unchanged short/whole cases, and f-string interpolation; `_fail` pins `str(1.23456789) == "1.23457"` as a real `FAILED`.
- Refreshed the now-stale comment in `str_float_precision_loss_fail` (that value folds exactly now).
- Existing `str_float_repr_exact`, `str_format_shortest_repr`, `builtin_repr`, `complex_repr`, `percent`, `fstring` tests pass unchanged (affected subset: 49/49 green); clang-format 11 clean.

## Follow-up
`py_format_number`'s explicit-spec renderer is a distinct concern (user-supplied precision, not shortest-repr); its default-typed float path (`format(x, "10")`, no presentation type) still returns `nullopt`. Wiring that path to the shared helper is the next candidate (noted in §87).
