### PR TITLE
[om] Fix std::string operator>/operator< const char* overloads

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6229/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6229/main.cpp
@@ -1,0 +1,28 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string a = "AAAA", b = "AA";
+
+  // Literal-on-the-left overloads must be deterministic: the in-class friend
+  // declared a non-template function that the out-of-line template definition
+  // never matched, so ESBMC modelled the call as an undefined (nondet) function.
+  bool lt1 = ("AAAA" > b);
+  bool lt2 = ("AAAA" > b);
+  assert(lt1 == lt2);
+  assert("AAAA" > b);
+  assert(!("AA" > a));
+  assert(!("AAAA" < b));
+  assert("AA" < a);
+
+  // Literal-on-the-right overloads must even compile: a member
+  // operator>(const char*) and a free operator>(basic_string&, const char*)
+  // both matched, making every such call ambiguous.
+  assert(a > "AA");
+  assert(!(b > "AAAA"));
+  assert(!(a < "AA"));
+  assert(b < "AAAA");
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6229/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6229/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6229_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6229_fail/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string a = "AA";
+
+  // Before the fix, "s > literal" did not even compile (ambiguous between the
+  // member operator>(const char*) and the free operator>(basic_string&, const
+  // char*)). With the fix only the free template survives, and since "AA" is
+  // not greater than "AAAA" this genuinely-false assertion is correctly FAILED.
+  assert(a > "AAAA");
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6229_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6229_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -535,17 +535,7 @@ public:
 
   char *c_str() const;
   bool operator>(basic_string<CharT, Traits, Alloc> &a);
-  bool operator>(const char *a);
-  friend bool
-  operator>(const char *lhs, basic_string<CharT, Traits, Alloc> &rhs);
-  friend bool
-  operator>(basic_string<CharT, Traits, Alloc> &lhs, const char *rhs);
   bool operator<(basic_string<CharT, Traits, Alloc> &a);
-  bool operator<(const char *a);
-  friend bool
-  operator<(const char *lhs, basic_string<CharT, Traits, Alloc> &rhs);
-  friend bool
-  operator<(basic_string<CharT, Traits, Alloc> &lhs, const char *rhs);
   bool operator>=(basic_string<CharT, Traits, Alloc> &a);
   bool operator>=(const char *lhs);
   bool operator<=(basic_string<CharT, Traits, Alloc> &a);
@@ -1244,17 +1234,6 @@ __ESBMC_HIDE:
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-bool basic_string<CharT, Traits, Alloc>::operator>(const char *a)
-{
-__ESBMC_HIDE:
-  __ESBMC_assert(a != NULL, "The parameter must be different than NULL");
-  int i;
-  for (i = 0; this->str[i] != '\0' && this->str[i] == a[i]; i++)
-    ;
-  return (unsigned char)this->str[i] > (unsigned char)a[i];
-}
-
-template <typename CharT, typename Traits, typename Alloc>
 bool operator>(
   const basic_string<CharT, Traits, Alloc> &lhs,
   const basic_string<CharT, Traits, Alloc> &rhs)
@@ -1324,17 +1303,6 @@ __ESBMC_HIDE:
   for (i = 0; this->str[i] != '\0' && this->str[i] == a.str[i]; i++)
     ;
   return (unsigned char)this->str[i] < (unsigned char)a.str[i];
-}
-
-template <typename CharT, typename Traits, typename Alloc>
-bool basic_string<CharT, Traits, Alloc>::operator<(const char *a)
-{
-__ESBMC_HIDE:
-  __ESBMC_assert(a != NULL, "The parameter must be different than NULL");
-  int i;
-  for (i = 0; this->str[i] != '\0' && this->str[i] == a[i]; i++)
-    ;
-  return (unsigned char)this->str[i] < (unsigned char)a[i];
 }
 
 template <typename CharT, typename Traits, typename Alloc>


### PR DESCRIPTION
## Root cause

`std::string`'s `operator>`/`operator<` had `const char*` overloads declared two
ways in `src/cpp/library/string`:

1. **Literal on the left** (`"lit" > s`): declared as an in-class `friend`
   (`friend bool operator>(const char *lhs, basic_string&rhs);`), a
   **non-template** function. The out-of-line definition, however, is a
   separate function **template**. The friend is therefore never actually
   defined, so ESBMC models the call as an unconstrained (nondet) function —
   an unsoundness bug: a genuinely-true assertion depending on the result can
   get a spurious `VERIFICATION FAILED`.
2. **Literal on the right** (`s > "lit"`): a member `operator>(const char*)`
   and the free `operator>(basic_string&, const char*)` template both match,
   so the call doesn't even compile (`use of overloaded operator '>' is
   ambiguous`).

Both issues equally affect `operator<`. #6228 fixed the *length-comparison*
logic in the same operators but explicitly left this declaration/overload
problem for a follow-up (this issue).

## Solution

Drop the member `operator>(const char*)`/`operator<(const char*)` declarations
and all four `friend` declarations, along with their now-orphaned member
definitions. This leaves only the free function templates, which already
access the class's public `str`/`_size` members directly — the same pattern
`operator==`/`operator!=` already use with no friendship required.

## Validation

- Reproduced both bugs pre-fix: the literal-on-left case gives `WARNING: no
  body for function allocator>#C#` and a spurious `VERIFICATION FAILED` on a
  consistency check (`("AAAA" > b) == ("AAAA" > b)` gave a counterexample with
  the two calls disagreeing); the literal-on-right case gives `ERROR: PARSING
  ERROR` / `use of overloaded operator '>' is ambiguous`, matching the exact
  clang diagnostic in the issue.
- New regression tests, both verified to fail before this change and pass
  after:
  - `regression/esbmc-cpp/cpp/github_6229` — literal-on-either-side
    comparisons are deterministic and give the correct result
    (`VERIFICATION SUCCESSFUL`).
  - `regression/esbmc-cpp/cpp/github_6229_fail` — `s > "literal"` now compiles
    and a genuinely-false comparison is correctly reported
    (`VERIFICATION FAILED`); previously this hit the parsing ambiguity error.
- Both new tests agree between Bitwuzla and Z3.
- No regressions: full `esbmc-cpp/string` suite (236 tests) and
  `esbmc-cpp/cpp` suite (582 tests) pass, aside from failures already present
  on master with this change reverted (macOS-local environment quirks:
  `github_2242_1/2`, `github_3897_collision`, `utility2_fail`, and an
  assertion-pretty-print formatting mismatch shared by `github_6200_fail`/
  `github_6227_fail`) — all confirmed unrelated to this change.
- `esbmc-cpp11/14/17/20` suites (228 tests) pass, aside from the two
  pre-existing macOS-local `builtin-template{,_fail}` failures.

Fixes #6229
