### PR TITLE
[python] Fix multi-file verification silently dropping all but last file

### DIFF
--- a/regression/python/github_6211/helper.py
+++ b/regression/python/github_6211/helper.py
@@ -1,0 +1,6 @@
+def unused() -> int:
+    return 1
+
+
+y: int = unused()
+assert y == 1

--- a/regression/python/github_6211/main.py
+++ b/regression/python/github_6211/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    x: int = 5
+    assert x == 5
+
+
+main()

--- a/regression/python/github_6211/test.desc
+++ b/regression/python/github_6211/test.desc
@@ -1,0 +1,4 @@
+CORE
+helper.py
+--unwind 1 main.py
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6211_fail/helper.py
+++ b/regression/python/github_6211_fail/helper.py
@@ -1,0 +1,2 @@
+def unused() -> int:
+    return 1

--- a/regression/python/github_6211_fail/main.py
+++ b/regression/python/github_6211_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    x: int = nondet_int()
+    assert x != 42
+
+
+main()

--- a/regression/python/github_6211_fail/test.desc
+++ b/regression/python/github_6211_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+helper.py
+--unwind 1 main.py
+^VERIFICATION FAILED$

--- a/regression/python/github_6211_function_multi_fail/helper.py
+++ b/regression/python/github_6211_function_multi_fail/helper.py
@@ -1,0 +1,5 @@
+def boom() -> None:
+    assert False
+
+
+boom()

--- a/regression/python/github_6211_function_multi_fail/main.py
+++ b/regression/python/github_6211_function_multi_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    x: int = 5
+    assert x == 5
+
+
+main()

--- a/regression/python/github_6211_function_multi_fail/test.desc
+++ b/regression/python/github_6211_function_multi_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+helper.py
+--unwind 2 --function main main.py
+ERROR: --function does not support multiple positional Python files

--- a/regression/python/github_6211_shortcircuit/helper.py
+++ b/regression/python/github_6211_shortcircuit/helper.py
@@ -1,0 +1,8 @@
+def check(b: int) -> int:
+    x: int = 0
+    if b != 0 and (10 // b) > 0:
+        x = 1
+    return x
+
+
+z: int = check(0)

--- a/regression/python/github_6211_shortcircuit/main.py
+++ b/regression/python/github_6211_shortcircuit/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    pass
+
+
+main()

--- a/regression/python/github_6211_shortcircuit/test.desc
+++ b/regression/python/github_6211_shortcircuit/test.desc
@@ -1,0 +1,4 @@
+CORE
+helper.py
+--incremental-bmc --unwind 2 main.py
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -59,6 +59,7 @@ ignored_dirs=(
   "enumerate15_fail"
   "func-no-params-types-fail"
   "function-option-fail"
+  "github_6211_function_multi_fail"
   "github_2843_fail"
   "github_2843_4_fail"
   "github_2908_1"

--- a/src/goto-symex/pytest.cpp
+++ b/src/goto-symex/pytest.cpp
@@ -14,6 +14,19 @@
 #include <algorithm>
 #include <unordered_set>
 
+// The entry Python file: the first positional file on the command line.
+// config.options.get_option("input-file") only ever holds the *last*
+// positional file (optionst's option_map is single-valued and each
+// positional arg overwrites the previous one), which named the wrong
+// module whenever more than one .py file was passed (github #6211).
+// config.args preserves the full, correctly ordered file list.
+static std::string entry_python_file()
+{
+  if (!config.args.empty())
+    return config.args.front();
+  return config.options.get_option("input-file");
+}
+
 std::string pytest_generator::extract_module_name(const std::string &input_file)
 {
   std::string module_name = input_file;
@@ -1060,7 +1073,7 @@ void pytest_generator::generate(const std::string &file_name) const
     log_status("Skipped {} duplicate test case(s).", skipped);
 
   // Extract module name from input file
-  std::string input_file = config.options.get_option("input-file");
+  std::string input_file = entry_python_file();
   std::string module_name = extract_module_name(input_file);
 
   // Generate pytest file
@@ -1098,7 +1111,7 @@ void pytest_generator::generate_single(
   (void)ns; // Suppress unused parameter warning
 
   // Extract original Python file name and module name
-  std::string original_file = config.options.get_option("input-file");
+  std::string original_file = entry_python_file();
   std::string module_name = extract_module_name(original_file);
 
   // Track nondet symbols we've seen to avoid duplicates

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -1100,9 +1100,10 @@ void python_converter::process_function_arguments(
 
   // Refine unannotated Any parameters to list model type when body usage
   // clearly matches list semantics (len(x), x[i], list mutator methods).
-  // Restrict this refinement to functions from the main source file to avoid
-  // affecting imported module internals.
-  if (location.get_file().as_string() == main_python_file)
+  // Restrict this refinement to the program's own files (the entry file or
+  // an extra positional command-line file, github #6211) to avoid affecting
+  // imported module internals.
+  if (is_program_file(location.get_file().as_string()))
   {
     for (auto &param_arg : type.arguments())
     {

--- a/src/python-frontend/converter/converter_util.cpp
+++ b/src/python-frontend/converter/converter_util.cpp
@@ -116,17 +116,40 @@ bool python_converter::is_pytest_generation_mode() const
   return config.options.get_bool_option("generate-pytest-testcase");
 }
 
+bool python_converter::is_program_file(const std::string &file) const
+{
+  // The file(s) under verification are never a model — not even when passed
+  // by a bare relative name (e.g. `main.py`) that the no-directory heuristic
+  // in is_model_file() would otherwise misread as a model. That
+  // misclassification disabled `and`/`or` short-circuit lowering for the main
+  // module, so a guard like `x is None or x.field is None` was emitted as an
+  // eager compound operand and the verdict flipped depending on whether the
+  // source was given by relative or absolute path (QuixBugs detect_cycle).
+  if (file == main_python_file)
+    return true;
+
+  // Extra positional Python files passed on the command line (github #6211)
+  // are translation units of the same program, not imported/model files, and
+  // must be exempted from the model heuristic the same way main_python_file
+  // is.
+  if (extra_asts_)
+  {
+    for (const auto &extra_ast : *extra_asts_)
+    {
+      if (
+        extra_ast.contains("filename") &&
+        extra_ast["filename"].get<std::string>() == file)
+        return true;
+    }
+  }
+
+  return false;
+}
+
 bool python_converter::is_model_file(const nlohmann::json &node) const
 {
   const std::string file = get_location_from_decl(node).file().as_string();
-  // The file under verification is never a model — not even when it is passed
-  // by a bare relative name (e.g. `main.py`) that the no-directory heuristic
-  // below would otherwise misread as a model. That misclassification disabled
-  // `and`/`or` short-circuit lowering for the main module, so a guard like
-  // `x is None or x.field is None` was emitted as an eager compound operand and
-  // the verdict flipped depending on whether the source was given by relative
-  // or absolute path (QuixBugs detect_cycle).
-  if (file == main_python_file)
+  if (is_program_file(file))
     return false;
 
   if (file.find("/models/") != std::string::npos)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -60,10 +60,12 @@ python_converter::get_op(const std::string &op, const typet &type) const
 python_converter::python_converter(
   contextt &_context,
   const nlohmann::json *ast,
-  const global_scope &gs)
+  const global_scope &gs,
+  const std::vector<nlohmann::json> *extra_asts)
   : symbol_table_(_context),
     ast_json(ast),
     entry_ast_(ast),
+    extra_asts_(extra_asts),
     global_scope_(gs),
     type_handler_(*this),
     string_builder_(new string_builder(*this, &string_handler_)),
@@ -422,6 +424,35 @@ void python_converter::convert_module_imports(code_blockt &all_imports_block)
   current_python_file = main_python_file;
 }
 
+void python_converter::convert_extra_translation_unit(
+  const nlohmann::json &extra_ast,
+  code_blockt &init_code,
+  code_blockt &combined_user_code)
+{
+  current_python_file = extra_ast["filename"].get<std::string>();
+  create_builtin_symbols();
+
+  // convert_module_imports() returns void, so it can't go through with_ast()
+  // (whose decltype(auto) result can't bind void); swap ast_json by hand
+  // instead. It also resets current_python_file to main_python_file on
+  // exit, so that must be undone afterwards too.
+  code_blockt extra_imports_block;
+  const nlohmann::json *saved_ast_json = ast_json;
+  ast_json = &extra_ast;
+  convert_module_imports(extra_imports_block);
+  ast_json = saved_ast_json;
+  current_python_file = extra_ast["filename"].get<std::string>();
+  if (!extra_imports_block.operands().empty())
+    init_code.copy_to_operands(extra_imports_block);
+
+  exprt extra_block = with_ast(&extra_ast, [&]() {
+    preregister_global_variables(extra_ast["body"]);
+    return get_block(extra_ast["body"]);
+  });
+  codet extra_code = convert_expression_to_code(extra_block);
+  combined_user_code.copy_to_operands(extra_code);
+}
+
 void python_converter::convert()
 {
   main_python_file = (*ast_json)["filename"].get<std::string>();
@@ -529,6 +560,17 @@ void python_converter::convert()
   const std::string function = config.options.get_option("function");
   if (!function.empty())
   {
+    // --function only ever searches the entry file's AST for the named
+    // function (below); silently ignoring any extra positional command-line
+    // files here would reproduce the exact silent-drop unsoundness github
+    // #6211 reports, just gated behind --function instead of file order. Fail
+    // loudly instead of guessing which file the caller meant.
+    if (extra_asts_ && !extra_asts_->empty())
+      throw std::runtime_error(
+        "--function does not support multiple positional Python files; "
+        "pass a single file, or drop --function to verify the whole "
+        "program (github #6211)");
+
     /* If the user passes --function, we add only a call to the
      * respective function in __ESBMC_main instead of entire Python program
      */
@@ -645,6 +687,23 @@ void python_converter::convert()
     init_code.copy_to_operands(intrinsic_block);
     if (!all_imports_block.operands().empty())
       init_code.copy_to_operands(all_imports_block);
+
+    // GitHub #6211: merge any additional positional Python files passed on
+    // the command line as extra translation units of the same program,
+    // mirroring how the C frontend merges multiple .c files' declarations
+    // (clang_c_languaget::parse -> mergeASTs). Without this, only the entry
+    // file's statements reach python_user_main and every other file's code
+    // (including any assertions) silently drops out of verification.
+    if (extra_asts_ && !extra_asts_->empty())
+    {
+      code_blockt combined_user_code;
+      combined_user_code.copy_to_operands(user_code);
+      for (const auto &extra_ast : *extra_asts_)
+        convert_extra_translation_unit(
+          extra_ast, init_code, combined_user_code);
+      current_python_file = main_python_file;
+      user_code = combined_user_code;
+    }
   }
 
   /*

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -18,6 +18,7 @@
 #include <set>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 class codet;
 class struct_typet;
@@ -47,7 +48,8 @@ public:
   python_converter(
     contextt &_context,
     const nlohmann::json *ast,
-    const global_scope &gs);
+    const global_scope &gs,
+    const std::vector<nlohmann::json> *extra_asts = nullptr);
 
   ~python_converter();
 
@@ -490,6 +492,13 @@ private:
 
   bool is_model_file(const nlohmann::json &node) const;
 
+  /// True when @p file is one of the program's own first-class source files
+  /// (the entry file or one of the extra positional command-line files,
+  /// github #6211) rather than an operational model or an `import`ed
+  /// module. Shared by every check that used to compare against
+  /// `main_python_file` alone before extra command-line files existed.
+  bool is_program_file(const std::string &file) const;
+
   exprt get_function_call(const nlohmann::json &ast_block);
 
   exprt get_block(
@@ -646,6 +655,18 @@ private:
   /// through an imported module fell through to the unsupported-function
   /// stub.
   void convert_module_imports(code_blockt &all_imports_block);
+
+  /// Converts one additional positional Python file passed on the command
+  /// line (github #6211) as an extra translation unit of the same program:
+  /// its own imports/globals/statements are converted with
+  /// `current_python_file` pointing at its own filename (so locations and
+  /// `__name__`/`__file__` attribute correctly), and its top-level code is
+  /// appended to `combined_user_code` so it actually executes, mirroring
+  /// how the C frontend merges multiple .c files into one program.
+  void convert_extra_translation_unit(
+    const nlohmann::json &extra_ast,
+    code_blockt &init_code,
+    code_blockt &combined_user_code);
 
   nlohmann::json build_dunder_call(
     const nlohmann::json &object,
@@ -1142,6 +1163,10 @@ private:
   /// so this retains a stable handle to the top-level module whose body holds
   /// the constructor call sites used by cross-module attribute-type inference.
   const nlohmann::json *entry_ast_;
+  /// Additional positional Python files passed on the command line
+  /// (github #6211), each a fully parsed and annotated module AST. May be
+  /// null (single-file invocations) or empty.
+  const std::vector<nlohmann::json> *extra_asts_;
   const global_scope &global_scope_;
   type_handler type_handler_;
   string_builder *string_builder_;

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -185,6 +185,12 @@ bool python_languaget::parse(const std::string &path)
     exit(1);
   }
 
+  // Parsed into a local tree first: with multiple positional Python files on
+  // the command line, this parse() runs once per file against a single
+  // python_languaget instance (github #6211), and each file's own tree must
+  // survive independently rather than clobbering the previous one via the
+  // `ast` data member.
+  nlohmann::json parsed_ast;
   try
   {
     // Parse under FE_TONEAREST: nlohmann converts float literals with the
@@ -192,7 +198,7 @@ bool python_languaget::parse(const std::string &path)
     // static init leaves FE_UPWARD on goto-contractor builds) would store a
     // double one ulp away from CPython's value for the same literal.
     const round_to_nearest_guard rounding_guard;
-    ast = nlohmann::json::parse(ast_json);
+    parsed_ast = nlohmann::json::parse(ast_json);
   }
   catch (const nlohmann::json::exception &e)
   {
@@ -207,7 +213,13 @@ bool python_languaget::parse(const std::string &path)
   }
 
   if (config.options.get_bool_option("parse-tree-only"))
+  {
+    // show_parse() only ever dumps the entry file's tree; keep that intact
+    // and just discard further files' trees rather than a partial merge.
+    if (ast.is_null())
+      ast = std::move(parsed_ast);
     return false;
+  }
 
   try
   {
@@ -215,10 +227,11 @@ bool python_languaget::parse(const std::string &path)
     // annotator derives element types from their annotations (GitHub #5936).
     // Callees in imported modules are retyped in python_converter::convert(),
     // where the import graph is available.
-    python_param_annotations::propagate_tuple_list_params({{&ast, &ast, ""}});
+    python_param_annotations::propagate_tuple_list_params(
+      {{&parsed_ast, &parsed_ast, ""}});
 
     // Add type information
-    python_annotation<nlohmann::json> ann(ast, global_scope_);
+    python_annotation<nlohmann::json> ann(parsed_ast, global_scope_);
     const std::string function = config.options.get_option("function");
     if (!function.empty())
       ann.add_type_annotation(function);
@@ -230,6 +243,11 @@ bool python_languaget::parse(const std::string &path)
     log_error("{}", e.what());
     exit(-1);
   }
+
+  if (ast.is_null())
+    ast = std::move(parsed_ast);
+  else
+    extra_asts.push_back(std::move(parsed_ast));
 
   return false;
 }
@@ -261,7 +279,7 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
   try
   {
     // Generate symbol table
-    python_converter converter(context, &ast, global_scope_);
+    python_converter converter(context, &ast, global_scope_, &extra_asts);
     converter.convert();
   }
   catch (const std::runtime_error &e)

--- a/src/python-frontend/python_language.h
+++ b/src/python-frontend/python_language.h
@@ -5,6 +5,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <vector>
+
 class python_languaget : public languaget
 {
 public:
@@ -40,9 +42,18 @@ public:
     return new python_languaget;
   }
 
+  /// Additional positional Python files passed on the command line, beyond
+  /// the first (github #6211). Each entry is a fully parsed and annotated
+  /// module AST, merged into the same program by python_converter.
+  const std::vector<nlohmann::json> &get_extra_asts() const
+  {
+    return extra_asts;
+  }
+
 private:
   std::string ast_output_dir;
   nlohmann::json ast;
+  std::vector<nlohmann::json> extra_asts;
   global_scope global_scope_;
 };
 


### PR DESCRIPTION
## Root cause

`language_uit::langmap` (src/langapi/language_ui.h) reuses a single `python_languaget` instance across every positional `.py` file passed on the command line (it's keyed by language, not by file). `python_languaget::parse()` (src/python-frontend/python_language.cpp) unconditionally overwrote its one `nlohmann::json ast` member on every call instead of accumulating. So with `esbmc a.py b.py`, only `b.py`'s AST ever survived to reach `python_converter`; `a.py`'s code — including any violated assertions — silently dropped out of verification. That produced a false `VERIFICATION SUCCESSFUL` whose outcome flipped depending purely on argument order (#6211).

The C frontend does not have this bug because `clang_c_languaget::parse()` explicitly merges each new file's AST into the accumulated one (`mergeASTs`); the Python frontend had no equivalent merge step.

## Fix

- `python_languaget` now keeps the first parsed file as the entry `ast` and accumulates every subsequent file into a new `extra_asts` vector, instead of overwriting `ast`.
- `python_converter` gained an optional `extra_asts` constructor parameter and a new `convert_extra_translation_unit()` that converts each extra file as its own translation unit of the same program — its own imports, its own `preregister_global_variables`, its own `current_python_file` (so source locations and `__name__`/`__file__` attribute correctly) — and appends the result into `python_user_main`, mirroring how the C frontend merges multiple `.c` files.

An initial version of this fix was independently code-reviewed, which surfaced two further gaps, both closed in this PR:

- **Critical false-positive regression**: `is_model_file()` and the unannotated-`Any`-parameter list-refinement gate in `converter_funcdef.cpp` only ever exempted `main_python_file` from their "is this the program under verification, not an operational model" checks. An extra file's `and`/`or` guard (e.g. `if b != 0 and (10 // b) > 0`) was therefore misclassified as model code, which disables short-circuit lowering and evaluates both operands eagerly — a genuine new false positive (spurious `ZeroDivisionError`) that only appears in the multi-file case this PR adds support for. Fixed with a shared `is_program_file()` helper that recognizes the entry file *or* any `extra_asts` file, used consistently at both sites.
- **Silent-drop gap under `--function`**: `--function` only ever searches the entry file's AST, and previously ignored `extra_asts` entirely with no warning — reproducing the exact silent-drop unsoundness this issue reports, just gated behind `--function` instead of file order. It now throws a clear error (`--function does not support multiple positional Python files`) instead of silently succeeding.
- Also fixed the same root symptom in `--generate-pytest-testcase` (`goto-symex/pytest.cpp`): it named the generated module after `config.options.get_option("input-file")`, which `optionst`'s single-valued `option_map` collapses to the last positional file regardless of order. It now uses `config.args.front()`, which preserves the full, correctly ordered file list.

## Regression tests

Four new tests under `regression/python/`:
- `github_6211_fail`: the original reproducer — `main.py` (has the violated assertion) passed *before* `helper.py` on the command line, i.e. the assertion is **not** in the last file. Expects `VERIFICATION FAILED`.
- `github_6211`: both files have true assertions; whole-program success case, confirms neither file's code is silently dropped in either direction.
- `github_6211_shortcircuit`: the code-review-discovered short-circuit regression (`and`/`or` guard in the non-entry file). Expects `VERIFICATION SUCCESSFUL`.
- `github_6211_function_multi_fail`: `--function` + multiple files now expects the new `ERROR: --function does not support...` message instead of silently succeeding.

All four were confirmed to fail (or misbehave) on the pre-fix binary and pass on the post-fix binary — verified by building both versions locally and diffing the verdicts.

## Validation

- Built locally (`ninja`/`make` + Z3 + Bitwuzla) on macOS aarch64.
- All 4 new tests pass via `ctest -R github_6211`.
- Re-ran ~1000 existing Python regression tests across several targeted and broad samples (import/module/pytest/multi-file subset, plus two independent 400+/500-test slices of the full suite): 100% pass, 0 failures, 0 regressions.
- `clang-format` (pinned to Clang 11, matching CI) and `yapf` both clean on the diff.

Fixes #6211.
