### PR TITLE
[om] Wire std::unexpected into dynamic exception spec checks

### DIFF
--- a/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_subst/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_bad_exception_subst/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --std c++03
 

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_uncaught_count_dynspec/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --std c++11
 

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_01/test.desc
@@ -1,5 +1,5 @@
-KNOWNBUG
+CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900 --std c++03
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/main.cpp
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/main.cpp
@@ -1,3 +1,8 @@
+// myfunction's throw(int) spec is violated by `throw 'x'` (char), which runs
+// myunexpected(); it throws 5, an int, which the spec permits, so it
+// propagates and is caught by catch(int). Ground-truthed against real
+// clang++ -std=c++03: prints "unexpected called" / "caught int", exits 0 --
+// a well-defined recovery, not a violation (github #6022).
 #include <iostream>
 #include <exception>
 using namespace std;

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900 --std c++03
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/cpp/exception.cpp
+++ b/src/c2goto/library/cpp/exception.cpp
@@ -188,9 +188,30 @@ extern "C" void __ESBMC_rethrow_current_exception()
 __ESBMC_HIDE:;
   if (__ESBMC_exception_detail::__ESBMC_handled_exception_depth == 0)
   {
-    __ESBMC_exc_terminate_reason =
-      __ESBMC_exception_detail::__ESBMC_terminate_reason_no_active;
-    std::terminate();
+    // No catch has entered a handler for this exception yet, but one may
+    // still be actively propagating -- a bare `throw;` from within
+    // std::unexpected() ([except.unexpected]) re-raises the exception whose
+    // dynamic-exception-specification it is resolving, before any handler
+    // for it exists. The lowering of that call clears `thrown` but preserves
+    // typeid/value for exactly this case, so a nonzero typeid here means an
+    // in-flight exception, not "none". This is context-insensitive (any bare
+    // rethrow with an empty handled-stack takes this path, not only one from
+    // std::unexpected()); a bare `throw;` from a destructor unwinding past a
+    // not-yet-handled exception would, per [except.terminate], have to
+    // terminate unconditionally instead. That path is not modelled anywhere
+    // in this lowering today (no destructor/unwind-specific handling exists
+    // in remove_exceptions.cpp), so it is not currently reachable -- scope
+    // this narrower (e.g. a dedicated in-unexpected-handler flag) if that
+    // ever changes.
+    if (__ESBMC_exc_typeid == 0)
+    {
+      __ESBMC_exc_terminate_reason =
+        __ESBMC_exception_detail::__ESBMC_terminate_reason_no_active;
+      std::terminate();
+    }
+    __ESBMC_exc_thrown = 1;
+    __ESBMC_exc_uncaught_count = __ESBMC_exc_uncaught_count + 1;
+    return;
   }
 
   __SIZE_TYPE__ top =

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -397,6 +397,13 @@ private:
   // it silently.
   bool thread_entry_unresolved = false;
   unsigned storage_counter = 0;
+  // A synthesized std::bad_exception THROW (operand + exception_list), built
+  // once and reused at every dynamic-spec-check site that needs the
+  // [except.unexpected] substitution, mirroring build_bad_cast_throw's single
+  // shared instance. Populated lazily by bad_exception_throw() on first use;
+  // nil (and cached as such) when <exception> is not resolvable.
+  expr2tc bad_exception_throw_;
+  bool bad_exception_throw_built_ = false;
   // Dynamic types of every real (operand-carrying) throw in the program, in
   // first-seen order. Used to partition the entry-epilogue uncaught-exception
   // property by type so the verdict names the escaping exception. This is the
@@ -525,6 +532,40 @@ private:
     // only its type identity and address matter to the handler).
     expr2tc operand = make_exception_storage(migrate_symbol_type(*sym));
     return code_cpp_throw2tc(operand, exception_list);
+  }
+
+  /// A synthesized std::bad_exception THROW, or nil when <exception> is not
+  /// resolvable (the program cannot reference a dynamic exception
+  /// specification without it). Same construction as build_bad_cast_throw;
+  /// built once and cached, since a program either has std::bad_exception
+  /// available at every call site or none.
+  expr2tc bad_exception_throw()
+  {
+    if (bad_exception_throw_built_)
+      return bad_exception_throw_;
+    bad_exception_throw_built_ = true;
+
+    const symbolt *sym = ns.lookup("tag-std::bad_exception");
+    if (!sym)
+      sym = ns.lookup("tag-class std::bad_exception");
+    if (!sym)
+      return bad_exception_throw_;
+
+    std::vector<irep_idt> exception_list;
+    const std::string tag = id2string(sym->id);
+    exception_list.emplace_back(tag.substr(4)); // strip "tag-"
+    if (sym->get_type().id() == "struct")
+    {
+      const struct_typet &st = to_struct_type(sym->get_type());
+      const exprt &bases = static_cast<const exprt &>(st.find("bases"));
+      if (bases.is_not_nil())
+        for (const auto &base : bases.get_sub())
+          exception_list.emplace_back(id2string(base.id()).substr(4));
+    }
+
+    expr2tc operand = make_exception_storage(migrate_symbol_type(*sym));
+    bad_exception_throw_ = code_cpp_throw2tc(operand, exception_list);
+    return bad_exception_throw_;
   }
 
   /// Replace each __ESBMC_throw_bad_cast() call — the bodyless intrinsic a
@@ -1098,15 +1139,16 @@ private:
     return disj;
   }
 
-  /// A call to the installed std::unexpected handler — the set_unexpected
-  /// builtin records it as __ESBMC_unexpected — or nil when none is installed.
+  /// A call to __ESBMC_run_unexpected(), the OM entry point that invokes the
+  /// installed std::unexpected handler (or the default, which calls
+  /// std::terminate()) — nil when the exception OM is not linked.
   expr2tc make_unexpected_call()
   {
-    const symbolt *h = ns.lookup("c:@F@__ESBMC_unexpected");
+    const symbolt *h = ns.lookup("c:@F@__ESBMC_run_unexpected");
     if (!h)
       return expr2tc();
     code_function_callt fc;
-    fc.function() = h->get_value();
+    fc.function() = symbol_exprt(h->id, h->get_type());
     expr2tc call;
     migrate_expr(fc, call);
     return call;
@@ -1252,10 +1294,12 @@ private:
   /// Enforce a dynamic exception specification throw(allowed...) (including the
   /// empty throw()) at the epilogue. When an exception the spec does not permit
   /// is propagating out, run the std::unexpected handler and re-check: a handler
-  /// that rethrows a permitted type lets it propagate; anything else (handler
-  /// returns, rethrows a disallowed type, or no handler installed) is a
-  /// violation. Mirrors the imperative goto_symext path: one handler call, no
-  /// std::bad_exception substitution.
+  /// that rethrows a permitted type lets it propagate; a handler that rethrows a
+  /// type the spec doesn't allow is replaced by std::bad_exception when the spec
+  /// includes it ([except.unexpected]) and propagates from there; anything else
+  /// (handler returns, rethrows a disallowed type with no std::bad_exception in
+  /// the spec, or no handler installed) is a violation. The imperative
+  /// goto_symext path does not model this substitution.
   void build_dynamic_spec_check(
     goto_programt &body,
     goto_programt::targett epilogue,
@@ -1330,6 +1374,35 @@ private:
 
       // Handler rethrew a permitted type -> let it propagate.
       ins(fail)->make_goto(ret, permitted());
+
+      // Handler rethrew a type the specification does not allow. Per
+      // [except.unexpected], if the specification includes std::bad_exception
+      // the escaping exception is *replaced* by one and propagation continues
+      // from here; otherwise the specification is genuinely violated (falls
+      // through to fail).
+      expr2tc bad_exc = bad_exception_throw();
+      if (!is_nil_expr(bad_exc))
+      {
+        const code_cpp_throw2t &be = to_code_cpp_throw2t(bad_exc);
+        const irep_idt &bad_exc_name = be.exception_list.front();
+        if (
+          std::find(allowed.begin(), allowed.end(), bad_exc_name) !=
+          allowed.end())
+        {
+          const unsigned bad_tid = registry.id_of(bad_exc_name);
+          auto a_tid = ins(fail);
+          a_tid->make_assignment();
+          a_tid->code = code_assign2tc(
+            type_id, constant_int2tc(type_id->type, BigInt(bad_tid)));
+
+          auto a_val = ins(fail);
+          a_val->make_assignment();
+          expr2tc addr = address_of2tc(be.operand->type, be.operand);
+          a_val->code = code_assign2tc(value, typecast2tc(value->type, addr));
+
+          ins(fail)->make_goto(ret);
+        }
+      }
     }
     // Fall through to fail.
   }


### PR DESCRIPTION
## Root cause

`src/goto-programs/remove_exceptions.cpp`'s `make_unexpected_call()` looked up the
wrong OM symbol for the installed `std::unexpected` handler
(`c:@F@__ESBMC_unexpected` instead of the real `c:@F@__ESBMC_run_unexpected`), so
the lookup always failed and the handler dispatch in `build_dynamic_spec_check`
was dead code: every disallowed escape from a `throw(T...)` spec went straight
to an unconditional "exception specification violated" assertion, whether or
not a `set_unexpected` handler was installed and would have recovered.

Fixing just the symbol regresses `try-catch_terminate_01_bug` and
`try-catch_unexpected_04`, because a sound fix needed two more pieces:

1. **A bare `throw;` inside a custom unexpected handler must re-raise the
   exception whose spec it is resolving** ([except.unexpected]) — but
   `__ESBMC_rethrow_current_exception()` always called `std::terminate()`
   when the handled-exception stack was empty, which it always is here (no
   catch has entered a handler for this exception yet — it's still
   propagating past the spec boundary). It now falls back to the still-set
   `typeid`/`value` globals (deliberately preserved across the handler call
   for exactly this case, per an existing comment), mirroring the same
   fallback `__ESBMC_current_exception_raw` already uses for the identical
   "in flight but not yet on the handled stack" situation.
2. **`std::bad_exception` substitution.** When the handler itself throws a
   type the spec disallows, [except.unexpected] says: if the spec includes
   `std::bad_exception`, the escaping exception is *replaced* by one and
   propagation continues from the violated function's call site; otherwise
   the spec is genuinely violated. New helper `bad_exception_throw()` mirrors
   the existing `build_bad_cast_throw()` pattern (lazy, cached, resolves
   `tag-std::bad_exception`/`tag-class std::bad_exception`).

## Validation

- Ground-truthed every changed-verdict scenario against real
  `clang++ -std=c++03` before touching test.desc files — not just standard
  reading. Confirmed `try-catch_unexpected_04`'s existing `test.desc`
  (`CORE`, expected `VERIFICATION FAILED`) was itself wrong: the program is
  well-defined (`myfunction` throws `char`, violates `throw(int)`,
  `myunexpected()` substitutes `throw 5` which *is* permitted, caught
  normally, prints `unexpected called`/`caught int`, exits 0) — corrected to
  `VERIFICATION SUCCESSFUL`.
- Promoted 3 `KNOWNBUG` tests to `CORE` now that they pass:
  `lower-exceptions_uncaught_count_dynspec`, `lower-exceptions_bad_exception_subst`
  (the exact bad_exception-substitution scenario), and
  `try-catch_unexpected_01` (also needed `--std c++03` added — it previously
  failed to even parse under the default C++17, unrelated to this fix).
- `try-catch_terminate_01_bug` still correctly reports `VERIFICATION FAILED`,
  now for the *right* reason: its first try block (spec includes
  `bad_exception`) correctly recovers via substitution; its second try block
  (spec does not include `bad_exception`) correctly hits the
  "exception specification violated" property.
- Dual-solver agreement (Bitwuzla + Z3) confirmed on every changed-verdict
  test.
- **Mode C dead-code proof** (via the `esbmc-verifier` agent, using
  `__ESBMC_unreachable()` + `--enable-unreachability-intrinsic`): all 3
  new/restructured branches confirmed reachable — the
  `__ESBMC_rethrow_current_exception` fallback, and both nesting levels of
  the bad_exception-substitution check in `build_dynamic_spec_check`.
- No regressions: `esbmc-cpp/try_catch` (165/165 passing),
  `esbmc-cpp/cpp`, `esbmc-cpp11/14/17/20`, and
  `destructors`/`inheritance`/`polymorphism_bringup`/`bug_fixes`/`cbmc`
  suites all pass, aside from failures already present on master
  (macOS-local environment quirks unrelated to this change).

Fixes #6022
