### PR TITLE
[python] Add KeyboardInterrupt to the exception model (#6258)

### DIFF
--- a/regression/python/github_6258/main.py
+++ b/regression/python/github_6258/main.py
@@ -1,0 +1,10 @@
+# github.com/esbmc/esbmc/issues/6258
+# KeyboardInterrupt is a builtin exception; referencing/catching it must not
+# raise a spurious NameError.
+caught = False
+try:
+    raise KeyboardInterrupt("stop")
+    caught = False
+except KeyboardInterrupt:
+    caught = True
+assert caught

--- a/regression/python/github_6258/test.desc
+++ b/regression/python/github_6258/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6258_fail/main.py
+++ b/regression/python/github_6258_fail/main.py
@@ -1,0 +1,10 @@
+# github.com/esbmc/esbmc/issues/6258
+# Same builtin-exception handling, but the asserted outcome is wrong: the
+# except block runs, so `caught` is True and `assert not caught` must fail.
+caught = False
+try:
+    raise KeyboardInterrupt("stop")
+    caught = False
+except KeyboardInterrupt:
+    caught = True
+assert not caught

--- a/regression/python/github_6258_fail/test.desc
+++ b/regression/python/github_6258_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-unwinding-assertions --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -22,6 +22,16 @@ class Exception(BaseException):
         return self.message
 
 
+class KeyboardInterrupt(BaseException):
+    message: str = ""
+
+    def __init__(self, message: str):
+        self.message: str = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
 class ValueError(Exception):
     message: str = ""
 


### PR DESCRIPTION
## Summary
Fixes #6258 — `KeyboardInterrupt`, a standard built-in exception, was missing from `models/exceptions.py`, so any program referencing it (e.g. `except KeyboardInterrupt:`) failed with a spurious `NameError`.

## Fix
Add `KeyboardInterrupt(BaseException)` to the auto-loaded exception model, using the same required-argument `__init__` as `BaseException`/`Exception`. This keeps both `except KeyboardInterrupt:` and `raise KeyboardInterrupt(...)` working. (A default-argument signature was tried first but tripped a `migrate expr failed` crash when raising a no-arg `BaseException`-direct model exception — a separate narrow edge case that the required-arg signature avoids.)

## Tests
- `regression/python/github_6258` — raise + catch `KeyboardInterrupt` → `VERIFICATION SUCCESSFUL`.
- `regression/python/github_6258_fail` — wrong expected outcome → `VERIFICATION FAILED`.

The exception/try/raise python regression subset (41 tests) passes with no regressions.
