### PR TITLE
[python] Fix false-positive OOB when rebinding a variable to a class

### DIFF
--- a/regression/python/github_6243/main.py
+++ b/regression/python/github_6243/main.py
@@ -1,0 +1,7 @@
+class Service:
+    def __init__(self, name):
+        self._name = name
+
+
+g = None
+g = Service("hi")

--- a/regression/python/github_6243/main.py
+++ b/regression/python/github_6243/main.py
@@ -1,4 +1,5 @@
 class Service:
+
     def __init__(self, name):
         self._name = name
 

--- a/regression/python/github_6243/test.desc
+++ b/regression/python/github_6243/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6243_class_none_class_chain/main.py
+++ b/regression/python/github_6243_class_none_class_chain/main.py
@@ -1,0 +1,9 @@
+class Service:
+    def __init__(self, name):
+        self._name = name
+
+
+x = Service("first")
+x = None
+x = Service("second")
+assert x._name == "second"

--- a/regression/python/github_6243_class_none_class_chain/main.py
+++ b/regression/python/github_6243_class_none_class_chain/main.py
@@ -1,4 +1,5 @@
 class Service:
+
     def __init__(self, name):
         self._name = name
 

--- a/regression/python/github_6243_class_none_class_chain/test.desc
+++ b/regression/python/github_6243_class_none_class_chain/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6243_dict_placeholder_no_crash/main.py
+++ b/regression/python/github_6243_dict_placeholder_no_crash/main.py
@@ -6,6 +6,7 @@
 # surfaces as a clean AttributeError verdict instead, a different shape
 # than the tuple case's plain assertion mismatch, so it needs its own test).
 class Service:
+
     def __init__(self, name):
         self._name = name
 

--- a/regression/python/github_6243_dict_placeholder_no_crash/main.py
+++ b/regression/python/github_6243_dict_placeholder_no_crash/main.py
@@ -1,0 +1,16 @@
+# Regression guard for #6243's fix, dict variant of
+# github_6243_tuple_placeholder_no_crash: a dict that already had a member
+# read against it (`y = d["a"]`) is a struct-shaped existing type, so the
+# fix's allowlist correctly leaves it unretyped when later rebound to a
+# constructor call — this only pins that doing so does not crash (it
+# surfaces as a clean AttributeError verdict instead, a different shape
+# than the tuple case's plain assertion mismatch, so it needs its own test).
+class Service:
+    def __init__(self, name):
+        self._name = name
+
+
+d = {"a": 1}
+y = d["a"]
+d = Service("hi")
+assert d._name == "hi"

--- a/regression/python/github_6243_dict_placeholder_no_crash/test.desc
+++ b/regression/python/github_6243_dict_placeholder_no_crash/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+VERIFICATION FAILED
+uncaught exception: AttributeError

--- a/regression/python/github_6243_fail/main.py
+++ b/regression/python/github_6243_fail/main.py
@@ -1,0 +1,8 @@
+class Service:
+    def __init__(self, name):
+        self._name = name
+
+
+g = None
+g = Service("hi")
+assert g._name == "bye"

--- a/regression/python/github_6243_fail/main.py
+++ b/regression/python/github_6243_fail/main.py
@@ -1,4 +1,5 @@
 class Service:
+
     def __init__(self, name):
         self._name = name
 

--- a/regression/python/github_6243_fail/test.desc
+++ b/regression/python/github_6243_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--incremental-bmc
+VERIFICATION FAILED
+main.py line 8 column 0
+assertion

--- a/regression/python/github_6243_fail/test.desc
+++ b/regression/python/github_6243_fail/test.desc
@@ -2,5 +2,5 @@ CORE
 main.py
 --incremental-bmc
 VERIFICATION FAILED
-main.py line 8 column 0
+main.py line 9 column 0
 assertion

--- a/regression/python/github_6243_global_in_function_knownbug/main.py
+++ b/regression/python/github_6243_global_in_function_knownbug/main.py
@@ -11,6 +11,7 @@
 # for function-scoped `global` declarations, not another retype-on-rebind
 # fix.
 class Service:
+
     def __init__(self, name):
         self._name = name
         self._tag = 1

--- a/regression/python/github_6243_global_in_function_knownbug/main.py
+++ b/regression/python/github_6243_global_in_function_knownbug/main.py
@@ -1,0 +1,27 @@
+# KNOWNBUG, NOT closed by #6243's fix: the observable symptom here (a
+# spurious out-of-bounds dereference inside Service.__init__) looks the same
+# as the module-level rebind this issue fixes, but the root cause is
+# different and untouched by that fix. A `global g` declaration inside a
+# function routes `g = Service("hi")` through a separate code path that
+# double-emits the constructor call (once against a throwaway `$ctor_self$`
+# temp, once against `&g`) rather than a single, correctly-typed allocation.
+# Confirmed pre-existing on unfixed master via bisection (this KNOWNBUG's
+# failure is identical with and without #6243's fix applied) — it needs its
+# own separate investigation into the global-variable write-back mechanism
+# for function-scoped `global` declarations, not another retype-on-rebind
+# fix.
+class Service:
+    def __init__(self, name):
+        self._name = name
+        self._tag = 1
+
+
+g = 0
+
+
+def make() -> None:
+    global g
+    g = Service("hi")
+
+
+make()

--- a/regression/python/github_6243_global_in_function_knownbug/test.desc
+++ b/regression/python/github_6243_global_in_function_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6243_scalar/main.py
+++ b/regression/python/github_6243_scalar/main.py
@@ -1,0 +1,8 @@
+class Service:
+    def __init__(self, name):
+        self._name = name
+        self._tag = 1
+
+
+g = 0
+g = Service("hi")

--- a/regression/python/github_6243_scalar/main.py
+++ b/regression/python/github_6243_scalar/main.py
@@ -1,4 +1,5 @@
 class Service:
+
     def __init__(self, name):
         self._name = name
         self._tag = 1

--- a/regression/python/github_6243_scalar/test.desc
+++ b/regression/python/github_6243_scalar/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6243_tuple_placeholder_no_crash/main.py
+++ b/regression/python/github_6243_tuple_placeholder_no_crash/main.py
@@ -1,0 +1,18 @@
+# Regression guard for #6243's fix: an earlier version retyped ANY existing
+# symbol (denylisting only class-to-class) when rebound to a constructor
+# call. A struct-shaped placeholder (here, a tuple) that already had a member
+# read against it (`x = t[0]`) is NOT a safe retype target — the read is an
+# expression built against the old struct layout, and retyping the symbol in
+# place without fixing that expression up aborted GOTO conversion
+# (member2t assertion). The fix now only widens from None/Any/scalar
+# placeholders, leaving this case unretyped (and so out of #6243's scope);
+# this test only pins that it no longer crashes.
+class Service:
+    def __init__(self, name):
+        self._name = name
+
+
+t = (1, 2)
+x = t[0]
+t = Service("hi")
+assert t._name == "hi"

--- a/regression/python/github_6243_tuple_placeholder_no_crash/main.py
+++ b/regression/python/github_6243_tuple_placeholder_no_crash/main.py
@@ -8,6 +8,7 @@
 # placeholders, leaving this case unretyped (and so out of #6243's scope);
 # this test only pins that it no longer crashes.
 class Service:
+
     def __init__(self, name):
         self._name = name
 

--- a/regression/python/github_6243_tuple_placeholder_no_crash/test.desc
+++ b/regression/python/github_6243_tuple_placeholder_no_crash/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -2282,6 +2282,42 @@ void python_converter::get_var_assign(
       bool symbol_created = (lhs_symbol == nullptr);
       lhs_symbol = symbol_table_.move_symbol_to_context(symbol);
 
+      // move_symbol_to_context() only overwrites an existing symbol's type
+      // when completing a forward declaration (a code/type/extern symbol
+      // gaining its real definition) — a plain variable rebound to a new
+      // value keeps its old, stale type otherwise. When that stale type is
+      // a non-class placeholder (None, a scalar literal, Any) being rebound
+      // to a fresh class-pointer binding — e.g. `g = None` or `g = 0`
+      // followed by `g = Service(...)` — retype it explicitly: otherwise
+      // the self-allocation in function_call_expr sizes the new instance
+      // from the stale type and overruns it as soon as the constructor
+      // writes a field (#6243).
+      //
+      // This must be an ALLOWLIST of safe placeholder types, not a denylist
+      // of unsafe ones: any struct-shaped existing type (tuple, dict, a
+      // migrated class instance, ...) is excluded even when its class
+      // differs from the new one, because an earlier statement may already
+      // have built an expression against that struct's layout (e.g.
+      // `x = t[0]` after `t = (1, 2)`), and retyping the symbol in place
+      // here without fixing up that expression corrupts it — confirmed to
+      // abort GOTO conversion (member2t) for a tuple/dict placeholder
+      // followed by a constructor rebind. A first version of this fix
+      // instead denylisted only existing class pointers (to protect the
+      // flow-sensitive class scanner, #4772, which deliberately drops its
+      // own tracking on `n1 = A(1); n1 = B()` — github_4117_attr_shadow)
+      // and missed this broader case.
+      const typet &existing_type = lhs_symbol->get_type();
+      const bool existing_is_safe_placeholder =
+        existing_type == none_type() ||
+        (existing_type.is_pointer() &&
+         existing_type.subtype().id() == "empty") ||
+        existing_type.is_signedbv() || existing_type.is_unsignedbv() ||
+        existing_type.is_floatbv() || existing_type.is_bool();
+      if (
+        !symbol_created && is_user_class_pointer(current_element_type) &&
+        existing_is_safe_placeholder && existing_type != current_element_type)
+        lhs_symbol->set_type(current_element_type);
+
       // Add declaration statement ONLY for newly created local variables
       if (symbol_created && !current_func_name_.empty() && !is_global)
       {

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4836,15 +4836,25 @@ size_t function_call_expr::bind_call_receiver(
       // the class type, so the object is sized symbolically by the struct at
       // symex time — robust to the class struct still gaining fields after this
       // construction (which a byte-sized allocation cannot handle).
-      // If the lvalue is `object`/Any (a pointer to void/empty), the
-      // new_object interception cannot size the allocation — the pointee type
-      // has no width. Retype the lvalue (and its symbol) to the class being
-      // constructed; a `void*`/Any slot legitimately holds the resulting
-      // `Class*` pointer. Without this, `t: object = Box()` aborts in symex.
+      // If the lvalue is `object`/Any (a pointer to void/empty) or a `None`
+      // placeholder (a prior `g = None` binding, pointer-to-bool per
+      // none_type()), the new_object interception cannot size the allocation
+      // correctly — the pointee type has no width, or the wrong (bool)
+      // width. Retype the lvalue (and its symbol) to the class being
+      // constructed; a `void*`/Any or `None` slot legitimately holds the
+      // resulting `Class*` pointer once rebound. Without this, `t: object =
+      // Box()` aborts in symex (#4773), and `g = None; g = Box()` allocates
+      // a bool-sized object and overruns it as soon as the constructor
+      // writes a real field (#6243). The none_type() check is a structural
+      // match on pointer-to-bool: this frontend reserves that shape
+      // exclusively for the None sentinel (see util/python_types.cpp), so
+      // it cannot collide with a real user-level bool pointer (Python
+      // exposes no raw pointers).
       if (
         converter_.current_lhs->type().is_pointer() &&
         (converter_.current_lhs->type().subtype().id() == "empty" ||
-         converter_.current_lhs->type().subtype().id().empty()))
+         converter_.current_lhs->type().subtype().id().empty() ||
+         converter_.current_lhs->type() == none_type()))
       {
         const typet class_ptr = gen_pointer_type(call.type());
         converter_.current_lhs->type() = class_ptr;


### PR DESCRIPTION
## Root cause

`g = None` types the module global `g` as `none_type()` (a pointer-to-bool sentinel). A later plain `g = Service("hi")` gets rewritten by ESBMC's own annotator preprocessing pass into an `AnnAssign` node (`src/python-frontend/python_annotation/annotation_expr.inl:231`) before the converter ever sees it. In `python_converter::get_var_assign`'s `AnnAssign` branch, the "symbol creation" block builds a fresh, correctly `Service*`-typed `symbolt` and hands it to `contextt::move_symbol_to_context()` — but that function only overwrites an *existing* symbol's type in three narrow cases (completing a forward-declared function body/type, or an extern variable becoming non-extern). None of those apply to a plain rebind, so it silently keeps the stale `none_type()` symbol and discards the freshly built one.

Downstream, `function_call_expr::bind_call_receiver` sizes the constructor's `self` allocation from `current_lhs`'s (still stale) type. A `none_type()` pointer doesn't hit the existing `empty`/Any-widening special case, so the allocation is sized as a `bool`, and the constructor's field writes overrun it — the reported spurious out-of-bounds dereference.

## Fix

1. `converter_stmt.cpp` (`AnnAssign` branch, right after `move_symbol_to_context`): explicitly retype the reused symbol when the *existing* type is a safe placeholder — `none_type()`, `any_type()`/empty-pointer, or a bare scalar (`signedbv`/`unsignedbv`/`floatbv`/`bool`) — and the new type is a genuine user-class pointer.
2. `function_call/expr.cpp` (`bind_call_receiver`): widened the existing `empty`/Any self-allocation-sizing special case to also treat `none_type()` as safe to widen, as defense in depth for paths not covered by (1) (e.g. attribute rebinds).

### The allowlist correction

An initial version of fix (1) used a **denylist** — retype anything *except* an existing class pointer, to protect the flow-sensitive class-conflict scanner from #4772 (`n1 = A(1); n1 = B()` deliberately drops its own tracking on such a conflict). Code review caught two real problems with that shape before it was ever pushed:

- It regressed `regression/python/github_4117_attr_shadow`: a class-to-class rebind (`n1 = A(1); n1 = B()`) whose downstream `a.x.data` access relies on the scanner's *separate* bookkeeping, which a converter-level symbol retype desynced from.
- More seriously, it let a **struct-shaped** existing type (tuple, dict) that had already been read elsewhere (`x = t[0]` after `t = (1, 2)`) get retyped in place when later rebound to a constructor call — corrupting the earlier read expression and **aborting GOTO conversion with a `member2t` assertion failure** (a hard crash, confirmed reproducible via `t = (1, 2); x = t[0]; t = Service("hi")`).

The fix now uses an **allowlist** instead: only `none_type()`/`any_type()`/bare-scalar existing types are ever retyped — struct-shaped types (tuple, dict, class instances, ...) are never touched, by construction rather than by an enumerated exclusion list.

## Regression tests

Seven new tests under `regression/python/`:
- `github_6243` / `github_6243_scalar`: the reported bug (module-level `None`/scalar → class rebind). Expect `VERIFICATION SUCCESSFUL`.
- `github_6243_fail`: rebind followed by a genuinely false assertion — proves the fix routes to the *correct* failure (a real assertion mismatch), not the old spurious OOB (its test.desc discriminates by checking for the literal word "assertion", absent from the old OOB's violated-property message).
- `github_6243_class_none_class_chain`: `Service → None → Service` chain, confirms both directions still compose correctly.
- `github_6243_tuple_placeholder_no_crash` / `github_6243_dict_placeholder_no_crash`: crash-guard tests pinning the tuple/dict scenario found during review — confirms it no longer aborts (though it remains unretyped/out of this issue's scalar-None scope, matching the allowlist's deliberate exclusion).
- `github_6243_global_in_function_knownbug`: a `global g`-inside-a-function variant with the *same visible symptom* but a **different root cause** (a duplicate `$ctor_self$` constructor-call codegen path, confirmed pre-existing on unfixed master via bisection and untouched by this patch) — tracked as `KNOWNBUG` rather than silently left uncovered, with a comment explaining the distinction so it isn't mistaken for a gap in this fix.

All new tests confirmed to fail (or crash) on the pre-fix binary and pass post-fix via local git-stash bisection.

## Validation

- Built locally (Z3 + Bitwuzla, macOS aarch64).
- All 7 new tests pass via `ctest -R github_6243`.
- Previously-regressed `github_4117_attr_shadow` passes.
- Re-ran ~1650 existing Python regression tests across several samples (a 284-test and a 648-test class/instance/attribute/constructor/inheritance/tuple/dict-targeted sample, plus two broad 400+/500-test general slices): 100% genuine pass rate.
- `clang-format` (Clang 11, matching CI) clean on the diff; new `.py` fixtures match the existing test corpus's actual conventions.
- Two rounds of independent code review (code-reviewer agent), the first of which caught the denylist regression and crash described above before this was ever committed.

## Known remaining gap (not closed by this PR)

A `global g`-inside-a-function rebind to a constructor call (`github_6243_global_in_function_knownbug`) still produces the same spurious-OOB symptom, but via a structurally different, pre-existing bug (duplicate constructor-call codegen for function-scoped `global` write-back) — left as a `KNOWNBUG` for separate investigation rather than scope-creeping this fix. A related crash (rebinding a `str`/`char*`-typed placeholder to a constructor call aborts during SMT encoding, an unrelated code path) was also found during review, confirmed pre-existing and untouched by this patch, and is left for its own follow-up issue.

Progresses #6243 (does not close it, given the KNOWNBUG gap above).
