### PR TITLE
[test] Un-KNOWNBUG the two list::sort regressions

### DIFF
--- a/regression/esbmc-cpp/list/list_sort_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_sort_bug-2/test.desc
@@ -1,4 +1,5 @@
-KNOWNBUG
+THOROUGH
 main.cpp
---unwind 5 --no-unwinding-assertions --timeout 900
+--unwind 6 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$
+^  file .*main\.cpp line 44 column 3 function main$

--- a/regression/esbmc-cpp/template/list_sort_bug/test.desc
+++ b/regression/esbmc-cpp/template/list_sort_bug/test.desc
@@ -1,4 +1,5 @@
-KNOWNBUG
+THOROUGH
 main.cpp
---unwind 5 --no-unwinding-assertions --timeout 900
+--unwind 6 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$
+^  file .*main\.cpp line 33 column 3 function main$


### PR DESCRIPTION
Both `list/list_sort_bug-2` and `template/list_sort_bug` ran at `--unwind 5` with `--no-unwinding-assertions`, one iteration short of the 6-iteration `strcpy` of the literal `"Three"` in the string OM. `loop_bound_exceeded` then assumes the negated loop guard, which is false for a concrete loop, so the path died and every assertion after `sort()` was vacuously true — reported as `VERIFICATION SUCCESSFUL`, indistinguishable from a proof.

At `--unwind 6` both detect their intended assertion (`main.cpp:33` and `main.cpp:44`), so the expected violated-property location is pinned alongside the verdict; a future vacuous run can no longer pass on the verdict line alone. They run ~135s, so they join the THOROUGH tier alongside the sibling `list_sort*` tests rather than risking the CORE time cap.

Refs #4397