### PR TITLE
[test] Fix the ill-formed Constructor17 source

### DIFF
--- a/regression/esbmc-cpp11/constructors/Constructor17/main.cpp
+++ b/regression/esbmc-cpp11/constructors/Constructor17/main.cpp
@@ -1,3 +1,5 @@
+#include <cassert>
+
 class C
 {
 public:
@@ -16,7 +18,7 @@ int main(int argc, char *argv[])
 {
   int i = 10;
   int &ref = i;
-  C *pc = new C((char &)ref);
+  C *pc = new C(ref);
   assert(pc->v == 10);
   D d;
   d.r = 10;

--- a/regression/esbmc-cpp11/constructors/Constructor17/test.desc
+++ b/regression/esbmc-cpp11/constructors/Constructor17/test.desc
@@ -1,7 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
-^EXIT=0$
-^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-^warning: ignoring


### PR DESCRIPTION
The test never compiled: `new C((char &)ref)` binds a `char` lvalue to `C`'s `int &` parameter, which no conforming compiler accepts (`clang++ -std=c++11` rejects it with *no matching constructor*), and `assert` was used without including `<cassert>`. ESBMC therefore stopped at `PARSING ERROR`, so the case was marked KNOWNBUG — the defect was in the test source, not in ESBMC.

Drop the invalid reinterpreting cast and include `<cassert>`, leaving the constructs the test was written for: a reference parameter bound through `new`, and aggregate copy-construction through `new`. The corrected program compiles, runs and exits 0 under `clang++`, and ESBMC now reports `VERIFICATION SUCCESSFUL`. Non-vacuity checked by flipping the first assertion to `pc->v == 11`, which yields `VERIFICATION FAILED` at that line.

Also drops the stale `^EXIT=0$` / `^SIGNAL=0$` / `^warning: ignoring` regexes — neither the harness nor ESBMC emits any of them, so they could never have matched. Full `esbmc-cpp11` suite: 127/127 pass.

Refs #4397