### PR TITLE
[test] Match pretty1 to Clang's __PRETTY_FUNCTION__ spelling

### DIFF
--- a/regression/esbmc-cpp/gcc-template-tests/pretty1/main.cpp
+++ b/regression/esbmc-cpp/gcc-template-tests/pretty1/main.cpp
@@ -11,10 +11,12 @@
 static size_t current = 0;
 static bool error = false;
 
+// ESBMC uses a Clang frontend, so __PRETTY_FUNCTION__ follows Clang's
+// spelling ("X<void>::X() [T = void]"), not GCC's ("X<T>::X() [with T = void]").
 static char const *names[] =
 {
-  "X<T>::X() [with T = void]",
-  "X<T>::~X() [with T = void]",
+  "X<void>::X() [T = void]",
+  "X<void>::~X() [T = void]",
   0
 };
 

--- a/regression/esbmc-cpp/gcc-template-tests/pretty1/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/pretty1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
---unwind 10
+--unwind 25
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The test hard-coded GCC's pretty-function format (`X<T>::X() [with T = void]`), but ESBMC uses a Clang frontend, which spells the same template member as `X<void>::X() [T = void]`. The `strcmp` against the GCC strings therefore set `error` and the guarded assert fired — reported `VERIFICATION FAILED` and marked KNOWNBUG — even though `__PRETTY_FUNCTION__` itself is plumbed through correctly (verified independently: ESBMC reproduces the Clang spelling exactly for both ctor and dtor).

Align `names[]` with the Clang spelling and raise `--unwind 10` → `25` so the 24-character `strcmp` runs to completion. Unwinding assertions stay on, so a truncated run would fail rather than pass vacuously — the earlier `--unwind 10` was itself one cause of the mismatch. The test again verifies its original intent: distinct, correct constructor vs destructor pretty-function strings for a template (PR 7768).

Non-vacuity checked by corrupting each expected name in turn, which yields `VERIFICATION FAILED` at the corresponding assert (line 39 for the ctor, line 42 for the dtor). Full `gcc-template-tests` group: 32/32 pass.

Refs #4397