### PR TITLE
[python] Fix unsound @staticmethod/@classmethod call binding

### DIFF
--- a/regression/python/github_6255_classmethod/main.py
+++ b/regression/python/github_6255_classmethod/main.py
@@ -1,0 +1,9 @@
+class M:
+    factor: int = 3
+
+    @classmethod
+    def scale(cls, x: int) -> int:
+        return x * cls.factor
+
+
+assert M.scale(4) == 12

--- a/regression/python/github_6255_classmethod/test.desc
+++ b/regression/python/github_6255_classmethod/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6255_classmethod_fail/main.py
+++ b/regression/python/github_6255_classmethod_fail/main.py
@@ -1,0 +1,9 @@
+class M:
+    factor: int = 3
+
+    @classmethod
+    def scale(cls, x: int) -> int:
+        return x * cls.factor
+
+
+assert M.scale(4) == 999

--- a/regression/python/github_6255_classmethod_fail/test.desc
+++ b/regression/python/github_6255_classmethod_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$
+assertion return_value\$_scale\$[0-9]+ == 999

--- a/regression/python/github_6255_staticmethod/main.py
+++ b/regression/python/github_6255_staticmethod/main.py
@@ -1,0 +1,8 @@
+class M:
+
+    @staticmethod
+    def twice(x: int) -> int:
+        return x * 2
+
+
+assert M.twice(6) == 12

--- a/regression/python/github_6255_staticmethod/test.desc
+++ b/regression/python/github_6255_staticmethod/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6255_staticmethod_fail/main.py
+++ b/regression/python/github_6255_staticmethod_fail/main.py
@@ -1,0 +1,8 @@
+class M:
+
+    @staticmethod
+    def twice(x: int) -> int:
+        return x * 2
+
+
+assert M.twice(6) == 999

--- a/regression/python/github_6255_staticmethod_fail/test.desc
+++ b/regression/python/github_6255_staticmethod_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$
+assertion return_value\$_twice\$[0-9]+ == 999

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -856,10 +856,8 @@ size_t python_converter::register_function_argument(
   std::string arg_name = element["arg"].get<std::string>();
   typet arg_type;
 
-  if (arg_name == "self")
+  if (arg_name == "self" || arg_name == "cls")
     arg_type = gen_pointer_type(type_handler_.get_typet(current_class_name_));
-  else if (arg_name == "cls")
-    arg_type = any_type();
   else
   {
     if (!element.contains("annotation") || element["annotation"].is_null())

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4974,19 +4974,15 @@ size_t function_call_expr::bind_call_receiver(
     // Check if this is an instance method being called through the class
     // e.g., MyClass.method(instance) where the first param should be 'self'
     const code_typet &func_type = to_code_type(func_symbol->get_type());
-    bool first_param_is_self = false;
+    std::string first_param;
 
     if (!func_type.arguments().empty())
-    {
-      const std::string &first_param =
-        func_type.arguments()[0].get_base_name().as_string();
-      first_param_is_self = (first_param == "self");
-    }
+      first_param = func_type.arguments()[0].get_base_name().as_string();
 
     // If first parameter is 'self' and we have positional arguments,
     // the first positional arg should be treated as 'self', not as a regular argument
     if (
-      first_param_is_self && !call_["args"].empty() &&
+      first_param == "self" && !call_["args"].empty() &&
       (!call_.contains("keywords") || call_["keywords"].empty() ||
        call_["keywords"][0]["arg"] != "self"))
     {
@@ -4994,11 +4990,34 @@ size_t function_call_expr::bind_call_receiver(
       // Don't add a NULL cls parameter
       param_offset = 1;
     }
+    else if (first_param != "self" && first_param != "cls")
+    {
+      // A genuine @staticmethod (or any call whose callee declares no
+      // bound-receiver parameter at all): no implicit argument is bound
+      // here. Previously this branch unconditionally pushed a bogus null
+      // "cls" argument, shifting every real argument one slot and
+      // corrupting arity (github #6255).
+      param_offset = 0;
+    }
     else
     {
-      // Passing a void pointer to the "cls" argument
-      // (V.3: build the void* null via the IREP2 factory).
-      typet t = pointer_typet(empty_typet());
+      // first_param == "cls" (a real @classmethod, or an int/float OM
+      // method using the same cls-first convention for an always-null
+      // receiver slot -- see the int/float special-casing below), or
+      // first_param == "self" with no usable positional argument.
+      //
+      // A real cls must be typed like self -- a pointer to the callee's
+      // own class -- so cls.<attr> resolves through the same
+      // struct-component lookup that already works for self.<attr>
+      // (github #6255); a bare "self" fallback keeps the prior
+      // pointer-to-void placeholder.
+      std::string cls_name = function_id_.get_class();
+      if (cls_name.empty())
+        cls_name =
+          symbol_id::from_string(func_symbol->id.as_string()).get_class();
+      typet t = (first_param == "cls" && !cls_name.empty())
+                  ? gen_pointer_type(type_handler_.get_typet(cls_name))
+                  : pointer_typet(empty_typet());
       call.arguments().push_back(migrate_expr_back(gen_zero(migrate_type(t))));
       param_offset = 1;
 


### PR DESCRIPTION
## Root cause

ESBMC's Python frontend never consults a method's `decorator_list` for `@staticmethod`/`@classmethod` — it infers receiver binding purely from parameter-name convention (`self`/`cls`) at two independent, previously-disagreeing sites:

1. `register_function_argument` (`src/python-frontend/converter/converter_funcdef.cpp`): typed a parameter literally named `self` as `pointer(current_class_name_)` correctly, but a parameter literally named `cls` as bare `any_type()`/`void*` — with no link back to the class. So `cls.<attr>` could never resolve, and unconditionally raised a hard-baked `AttributeError` at conversion time (`M.scale(4)`'s spurious `AttributeError`).
2. `bind_call_receiver`'s `ClassMethod` branch (`src/python-frontend/function_call/expr.cpp`): the code that decides what implicit receiver argument to prepend when calling `ClassName.method(...)` checked *only* `first_param == "self"`. Anything else — including a genuine `@staticmethod`'s real first parameter — fell into an `else` that **unconditionally** pushed a bogus null `void*` "cls" placeholder, shifting every real user argument one slot to the right and corrupting call arity. `M.twice(6)` became `twice(NULL, 6)` against a *one*-parameter function, binding `x = NULL` and leaving `6` an orphaned extra argument.

A correct three-way split already existed once — `check_argument_types` (an optional `--strict-types` diagnostic pass, never wired to actual argument binding) already distinguishes `self`/`cls`/neither correctly.

## Fix

Both sites now mirror that three-way split:
- `self` → bind the caller's first positional argument as before.
- `cls` → push a properly-typed pointer to the **callee's own class** (mirroring how `self` is typed), resolved via `function_id_.get_class()` (falling back to `symbol_id::from_string(func_symbol->id.as_string()).get_class()`) — deliberately *not* `current_class_name_`, which tracks the **caller's** enclosing class at the point `bind_call_receiver` runs, not the callee's (e.g. calling `M.scale(4)` from module-level code, where `current_class_name_` is empty).
- Neither `self` nor `cls` → genuine `@staticmethod`: no implicit argument bound at all (`param_offset = 0`), instead of the prior unconditional null push.

Built-in operational-model methods (`int.bit_length`, `float.is_integer` in `models/int.py`/`float.py`) are *also* `@classmethod`-decorated with an always-unused literal `cls` first parameter followed by the real encapsulated value, called via instance syntax (`x.bit_length()`). Their existing int/float/BinOp special-casing stays nested inside the `cls` branch so they keep working unchanged — verified manually.

## Scope note

Confirmed via git-stash bisection (identical output with the fix applied vs. stashed out) that **inherited classmethod dispatch** is a separate, pre-existing limitation:
```python
class Base:
    factor: int = 10
    @classmethod
    def get_factor(cls): return cls.factor
class Derived(Base):
    factor: int = 20
assert Derived.get_factor() == 20   # VERIFICATION FAILED, assertion NONDET(_Bool), both before and after this fix
```
This is unrelated to and unaffected by this fix — left out of scope rather than folded into this PR.

## Regression tests

Four new tests under `regression/python/`: `github_6255_staticmethod` / `github_6255_classmethod` (the reported reproducers, expect `VERIFICATION SUCCESSFUL`) and `_fail` variants (wrong expected value, expect `VERIFICATION FAILED`). All confirmed via bisection to fail (or behave incorrectly) on the pre-fix binary and pass post-fix — with one caveat noted directly in testing: `github_6255_staticmethod_fail` happens to also produce `VERIFICATION FAILED` on the pre-fix binary too (pre-fix, `M.twice(6)` evaluates to a wrong value that's *also* != 999, so the assertion fires either way); the success-case tests are what actually discriminate pre/post-fix.

## Validation

- Built locally (Z3 + Bitwuzla, macOS aarch64).
- All 4 new tests pass; existing `class-methods` / `class-methods-fail` / `github_3020_9` / `github_3020_10` / `import-class-methods` tests still pass.
- A 261-test targeted class/method/int/float sample and a 400-test general Python sample both pass at 100%.
- Audited every `@classmethod`/`@staticmethod`-decorated method across `models/*.py` (`dataclasses.py`, `decimal.py`, `float.py`, `int.py`); ran the full `dataclass`/`decimal` suites — a batch of apparent timeouts under high parallelism (`-j14`) were individually re-run in isolation and confirmed to pass comfortably within budget (contention artifacts, not regressions).
- `clang-format` (Clang 11, matching CI) clean on the diff.

Fixes #6255
