### PR TITLE
[clang-cpp] Re-offset dynamic_cast to T* across multiple inheritance

### DIFF
--- a/regression/esbmc-cpp/inheritance/mi_dynamic_cast/main.cpp
+++ b/regression/esbmc-cpp/inheritance/mi_dynamic_cast/main.cpp
@@ -44,5 +44,8 @@ int main()
   B1 *b1 = dynamic_cast<B1 *>(b2); // sibling cross-cast B2* -> B1*
   assert(b1 && b1->x == 1);
 
+  B2 *b2b = dynamic_cast<B2 *>(b1); // reverse cross-cast B1* -> B2* (target offset > 0)
+  assert(b2b && b2b->y == 2);
+
   return 0;
 }

--- a/regression/esbmc-cpp/inheritance/mi_dynamic_cast/test.desc
+++ b/regression/esbmc-cpp/inheritance/mi_dynamic_cast/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --std c++17
 

--- a/regression/esbmc-cpp/inheritance/mi_dynamic_cast_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/mi_dynamic_cast_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --std c++17
 

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -987,12 +987,11 @@ bool clang_cpp_convertert::build_dynamic_cast(
       else
       {
         // For T* the result must point to the T sub-object inside D:
-        //   result = src + (off(T inside D) - off(S inside D))
-        // When both offsets are zero (single inheritance with S and T
-        // at the start of D) the structural typecast is exact.
-        // Otherwise a per-D byte adjustment is required, which we
-        // don't compute yet — refuse the cast instead of silently
-        // emitting a pointer into the wrong sub-object.
+        //   result = (T*)((char*)src - off(S inside D) + off(T inside D))
+        // When both offsets are zero (single inheritance with S and T at
+        // the start of D) the structural typecast is exact; otherwise the
+        // pointer is re-based through char* byte arithmetic, mirroring the
+        // (void*) arm above.
         auto off_S = offset_of_subobject(*ASTContext, D, S);
         auto off_T = offset_of_subobject(*ASTContext, D, T);
         if (!off_S || !off_T)
@@ -1003,16 +1002,28 @@ bool clang_cpp_convertert::build_dynamic_cast(
             D->getNameAsString());
           abort();
         }
-        if (*off_S != 0 || *off_T != 0)
-        {
-          log_error(
-            "dynamic_cast: multiple inheritance with non-zero base "
-            "offset in `{}` is not supported",
-            D->getNameAsString());
-          abort();
-        }
         exprt adj = src_pointer;
-        gen_typecast(ns, adj, target_type);
+        if (*off_S == 0 && *off_T == 0)
+        {
+          // S and T both start at D: the structural typecast is exact.
+          gen_typecast(ns, adj, target_type);
+        }
+        else
+        {
+          typet char_ptr = pointer_typet(char_type());
+          gen_typecast(ns, adj, char_ptr);
+          if (*off_S > 0)
+          {
+            adj = minus_exprt(adj, from_integer(*off_S, index_type()));
+            adj.type() = char_ptr;
+          }
+          if (*off_T > 0)
+          {
+            adj = plus_exprt(adj, from_integer(*off_T, index_type()));
+            adj.type() = char_ptr;
+          }
+          gen_typecast(ns, adj, target_type);
+        }
         result = adj;
       }
       arms.push_back({vt_addr, result});


### PR DESCRIPTION
A `dynamic_cast` to a **pointer** type whose source or target base sits at a non-zero offset inside the runtime type aborted the whole run:

```
ERROR: dynamic_cast: multiple inheritance with non-zero base offset in `D` is not supported
```

So a down-cast from a secondary base (`B2* -> D*`) or a sibling cross-cast (`B2* -> B1*`) was un-verifiable. The `(void*)` arm right above already computed the correct byte re-basing; the `T*` arm refused it (the code comment even stated the formula it "doesn't compute yet").

## Fix
Perform the documented adjustment for the `T*` case:
```
result = (T*)((char*)src - off(S in D) + off(T in D))
```
`src` points at the source base `S` inside the runtime type `D`; subtracting `off(S)` reaches `D`'s start and adding `off(T)` reaches the `T` sub-object — mirroring the `(void*)` arm. The single-inheritance / shared-prefix case (both offsets zero) is guarded to keep the **exact** structural typecast it had, so its lowering is byte-unchanged.

## Verification
- `mi_dynamic_cast` (positive) and `mi_dynamic_cast_fail` (negative) are an existing KNOWNBUG pair; both now pass and are promoted to CORE.
- The positive test is extended with a reverse cross-cast `B1* -> B2*` so **both** the source-offset (`off_S > 0`) and target-offset (`off_T > 0`) adjustments are exercised.
- **Non-vacuity:** `mi_dynamic_cast_fail` asserts the *wrong* value (`b1->x == 2` after `B2*->B1*`, where the correct value is 1) and correctly reports `VERIFICATION FAILED` — proving the cross-cast genuinely re-offsets rather than aliasing the source sub-object.
- Full `inheritance` / `dynamic_cast` / `polymorphism` suites (226 tests): no new failures (the 4 failing are pre-existing Solidity-on-macOS environmental cases). The change cannot regress previously-passing programs: any program reaching the old code path aborted, and the zero-offset path is unchanged.

Fixes #4397