### PR TITLE
[python] Raise TypeError for list + non-list (#6265)

### DIFF
--- a/regression/python/github_6265/main.py
+++ b/regression/python/github_6265/main.py
@@ -1,0 +1,13 @@
+# github.com/esbmc/esbmc/issues/6265
+# Regression guard: genuine list + list concatenation must still verify.
+def main() -> None:
+    a = [1, 2]
+    b = [3, 4]
+    c = a + b
+    assert len(c) == 4 and c[0] == 1 and c[3] == 4
+
+    d = a + [i for i in range(3)]
+    assert len(d) == 5
+
+
+main()

--- a/regression/python/github_6265/test.desc
+++ b/regression/python/github_6265/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6265_fail/main.py
+++ b/regression/python/github_6265_fail/main.py
@@ -1,0 +1,9 @@
+# github.com/esbmc/esbmc/issues/6265
+# list + non-list is a TypeError in Python (only list + list concatenates).
+# Uncaught -> VERIFICATION FAILED.
+def main() -> None:
+    xs = [1, 2]
+    ys = xs + 3
+
+
+main()

--- a/regression/python/github_6265_fail/test.desc
+++ b/regression/python/github_6265_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -2254,6 +2254,24 @@ exprt python_converter::handle_list_operations(
     return list.build_concat_list_call(lhs, rhs, element);
   }
 
+  // list + <definitely-non-list> is a Python TypeError ("can only concatenate
+  // list ... to list") — only list + list concatenates. The concat case above
+  // already consumed list and any-typed (void*) right operands, so raise a
+  // catchable TypeError (uncaught -> VERIFICATION FAILED) for a definite
+  // scalar/string right operand. Unknown/other types are left untouched to
+  // avoid misfiring on imprecise frontend typing (#6265).
+  if (lhs.type() == list_type && op == "Add")
+  {
+    const typet &rt = rhs.type();
+    if (
+      rt.is_signedbv() || rt.is_unsignedbv() || rt.is_floatbv() ||
+      type_utils::is_string_type(rt))
+      return get_exception_handler().gen_exception_raise(
+        "TypeError",
+        "can only concatenate list (not \"" +
+          type_handler_.get_python_type_name(rt) + "\") to list");
+  }
+
   // List repetition
   if ((lhs.type() == list_type || rhs.type() == list_type) && op == "Mult")
   {


### PR DESCRIPTION
## Summary
Fixes #6265 — `list + <non-list>` (e.g. `[1,2] + 3`) was silently accepted (`VERIFICATION SUCCESSFUL`), a false negative for the exception-safety (`dynamic-typing`) property family.

In `handle_list_operations`, only `list + list` (and `list + <any-typed>`) was handled as concatenation; a definite non-list right operand fell through and produced no exception.

## Fix
After the concatenation case, raise a **catchable** `TypeError` (`"can only concatenate list ... to list"`) when the left operand is a list, the op is `+`, and the right operand is a definite scalar/string (int/float/bool/str). This mirrors the existing catchable `str + <non-str>` TypeError. Unknown/any-typed operands are intentionally left untouched to avoid misfiring on imprecise frontend typing.

## Effect
- `[1,2] + 3`, `[1,2] + "x"` → uncaught `TypeError` → `VERIFICATION FAILED` (matches CPython `can only concatenate list (not "int") to list`).
- `list + list` and `list + <comprehension>` continue to concatenate and verify.

## Tests
- `regression/python/github_6265_fail` — `list + int` → `VERIFICATION FAILED`.
- `regression/python/github_6265` — `list + list` and `list + comprehension` → `VERIFICATION SUCCESSFUL`.

Validated against the python list/string/concat/comprehension regression subset.
