### PR TITLE
[goto-programs] Re-offset catch-by-base binding for MI thrown types

### DIFF
--- a/regression/esbmc-cpp/try_catch/catch_base_offset_mi/main.cpp
+++ b/regression/esbmc-cpp/try_catch/catch_base_offset_mi/main.cpp
@@ -1,0 +1,56 @@
+// Catching a multiple-inheritance thrown object by a base that sits at a
+// non-zero offset inside the dynamic type must re-base the bound pointer to the
+// correct subobject. `throw PA()` stores a pointer to the most-derived object
+// (= the P subobject at offset 0); catching A& must yield value + off(A in PA),
+// not a plain reinterpret. Both the offset-0 (first base) and offset-N (second
+// base) directions are exercised. Regression for the catch-by-base offset bug.
+#include <cassert>
+
+struct A
+{
+  int a;
+  A() : a(1)
+  {
+  }
+};
+
+struct P
+{
+  virtual ~P()
+  {
+  }
+  int p;
+  P() : p(9)
+  {
+  }
+};
+
+struct AP : A, P   // A first  -> off(A in AP) == 0
+{
+};
+
+struct PA : P, A   // A second -> off(A in PA) != 0
+{
+};
+
+int main()
+{
+  try
+  {
+    throw AP();
+  }
+  catch (A &a)
+  {
+    assert(a.a == 1);
+  }
+
+  try
+  {
+    throw PA();
+  }
+  catch (A &a)
+  {
+    assert(a.a == 1);
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/catch_base_offset_mi/test.desc
+++ b/regression/esbmc-cpp/try_catch/catch_base_offset_mi/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.cpp
 --std c++17
-
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/catch_base_offset_mi_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/catch_base_offset_mi_fail/main.cpp
@@ -1,0 +1,40 @@
+// Negative counterpart: after `throw PA()` caught as A& (A at a non-zero offset
+// in PA), a.a is 1, never P's p (9). Asserting the P value must FAIL, proving
+// the binding re-bases to the A subobject rather than aliasing P's memory.
+#include <cassert>
+
+struct A
+{
+  int a;
+  A() : a(1)
+  {
+  }
+};
+
+struct P
+{
+  virtual ~P()
+  {
+  }
+  int p;
+  P() : p(9)
+  {
+  }
+};
+
+struct PA : P, A
+{
+};
+
+int main()
+{
+  try
+  {
+    throw PA();
+  }
+  catch (A &a)
+  {
+    assert(a.a == 9);
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/catch_base_offset_mi_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/catch_base_offset_mi_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$
+^  file .*main\.cpp line 37 column 5 function main$

--- a/src/goto-programs/exception_typeid.cpp
+++ b/src/goto-programs/exception_typeid.cpp
@@ -120,3 +120,13 @@ exception_typeidt::concrete_subtype_ids(const irep_idt &caught) const
       ids.insert(id);
   return ids;
 }
+
+std::vector<std::pair<irep_idt, unsigned>>
+exception_typeidt::concrete_subtypes(const irep_idt &caught) const
+{
+  std::vector<std::pair<irep_idt, unsigned>> out;
+  for (const auto &[name, id] : name_to_id)
+    if (is_subtype(name, caught))
+      out.emplace_back(name, id);
+  return out;
+}

--- a/src/goto-programs/exception_typeid.h
+++ b/src/goto-programs/exception_typeid.h
@@ -72,6 +72,13 @@ public:
   /// right-hand side of the catch-match guard.
   std::set<unsigned> concrete_subtype_ids(const irep_idt &caught) const;
 
+  /// { (T, id_of(T)) : T <: caught } over all *registered* program types.
+  /// Like concrete_subtype_ids but keeps the names, so a caller can recover
+  /// each dynamic type's struct (e.g. to compute a base-subobject offset for
+  /// catch-by-base binding).
+  std::vector<std::pair<irep_idt, unsigned>>
+  concrete_subtypes(const irep_idt &caught) const;
+
   /// Number of registered program types (excludes lazily-added unknowns).
   std::size_t size() const
   {

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -11,7 +11,11 @@
 #include <util/std_types.h>
 #include <util/std_expr.h>
 #include <util/message.h>
+#include <util/type_byte_size.h>
+#include <util/c_types.h>
 #include <irep2/irep2_utils.h>
+
+#include <optional>
 
 #include <algorithm>
 
@@ -993,6 +997,63 @@ private:
     }
   }
 
+  /// Byte offset of the *direct* base subobject of class @p target_tag inside
+  /// struct @p st, or nullopt when @p st has no such direct base. Only direct
+  /// bases are resolved: a transitive or absent base returns nullopt, so the
+  /// caller keeps the plain (unadjusted) cast rather than ever emitting a wrong
+  /// offset.
+  std::optional<BigInt>
+  direct_base_offset(const type2tc &st, const irep_idt &target_tag)
+  {
+    if (!is_struct_type(st))
+      return std::nullopt;
+    const struct_type2t &s = to_struct_type(st);
+    const std::string want = "@base@" + id2string(target_tag);
+    for (const irep_idt &m : s.member_names)
+      if (m.as_string() == want)
+        return member_offset(st, m, &ns);
+    return std::nullopt;
+  }
+
+  /// The `catch_ptr_type` view of the stored thrown object for a catch of class
+  /// @p catch_type. `value` points at the *most-derived* object, so when the
+  /// caught type is a base sitting at a non-zero offset inside the dynamic type
+  /// (multiple inheritance), the pointer is re-based per the runtime type_id:
+  ///   type_id == id(D) ? (T*)((char*)value + off(T in D)) : (T*)value
+  /// Only non-zero-offset bases add an arm, so a single-inheritance / exact /
+  /// first-base catch keeps exactly the plain `(T*)value` it had.
+  expr2tc catch_object_pointer(
+    const type2tc &catch_ptr_type,
+    const irep_idt &catch_type)
+  {
+    expr2tc result = typecast2tc(catch_ptr_type, value);
+
+    const irep_idt target_tag = "tag-" + id2string(catch_type);
+    const type2tc char_ptr = pointer_type2tc(get_uint8_type());
+    for (const auto &[dname, id] : registry.concrete_subtypes(catch_type))
+    {
+      const symbolt *dsym = ns.lookup(irep_idt("tag-" + id2string(dname)));
+      if (!dsym)
+        continue;
+      std::optional<BigInt> off =
+        direct_base_offset(migrate_type(dsym->get_type()), target_tag);
+      if (!off || *off == 0)
+        continue;
+      expr2tc rebased = typecast2tc(
+        catch_ptr_type,
+        add2tc(
+          char_ptr,
+          typecast2tc(char_ptr, value),
+          constant_int2tc(index_type2(), *off)));
+      result = if2tc(
+        catch_ptr_type,
+        equality2tc(type_id, constant_int2tc(type_id->type, BigInt(id))),
+        rebased,
+        result);
+    }
+    return result;
+  }
+
   /// Insert `__ESBMC_exc_thrown = false` before a handler and rewrite its
   /// `var = NONDET` binding to read the thrown object via __ESBMC_exc_value:
   ///   catch (T &v): v is a T* — bind the address      v = (T*)value
@@ -1021,11 +1082,13 @@ private:
       // the stored object/pointer out: var = *(decltype(var)*)value. The two
       // pointer-typed forms are told apart by the catch type's `_ptr` suffix.
       bool ref_catch = is_pointer_type(var->type) && !is_pointer_catch(h.type);
-      expr2tc src =
-        ref_catch
-          ? typecast2tc(var->type, value)
-          : dereference2tc(
-              var->type, typecast2tc(pointer_type2tc(var->type), value));
+      // View the stored object as the caught class, re-basing to the correct
+      // base subobject when the catch is by a non-zero-offset base of a
+      // multiple-inheritance dynamic type (else a plain cast).
+      type2tc catch_ptr_type =
+        ref_catch ? var->type : pointer_type2tc(var->type);
+      expr2tc obj_ptr = catch_object_pointer(catch_ptr_type, h.type);
+      expr2tc src = ref_catch ? obj_ptr : dereference2tc(var->type, obj_ptr);
       bind->code = code_assign2tc(var, src);
       before_body = bind;
     }


### PR DESCRIPTION
A catch handler binds its parameter with a plain `v = (T*)value`, where `value` points at the **most-derived** thrown object (`make_landing`, `remove_exceptions.cpp`). When the caught type `T` is a base sitting at a **non-zero offset** inside the dynamic type (multiple inheritance), this reads the wrong subobject:

```cpp
struct A { int a; A():a(1){} };
struct P { virtual ~P(){} int p; P():p(9){} };
struct PA : P, A {};              // A at a non-zero offset in PA
try { throw PA(); }
catch (A &a) { assert(a.a == 1); } // read P's memory -> spurious FAILED
```

## Fix
Re-base the bound pointer per the runtime `type_id`: for each concrete subtype `D` of the caught class whose direct-base offset of `T` is non-zero, emit

```
type_id == id(D) ? (T*)((char*)value + off(T in D)) : <previous>
```

defaulting to the plain `(T*)value`. Because an arm is added **only** for a non-zero offset, an offset-0 catch (single inheritance, exact type, or first base) keeps byte-for-byte the binding it had — the blast radius is limited to multiple-inheritance base catches. A new `exception_typeidt::concrete_subtypes` recovers each dynamic type's struct so `member_offset` can compute the base offset. Value catches re-use the same adjusted pointer before the copy.

Transitive/absent bases resolve to `nullopt` and keep the plain cast — sound (never a wrong offset), just not yet re-offset; both directions of the fixed test are direct bases.

## Verification
- `mi_base_subobject_catch` (KNOWNBUG → CORE): covers both `throw AP()` (A first, offset 0) and `throw PA()` (A second, offset ≠ 0), caught as `A&`.
- New `catch_base_offset_mi` (positive, both directions) and `catch_base_offset_mi_fail` (negative: asserting P's value after the re-offset must FAIL, pinned to the violated line) — proves the binding genuinely re-bases rather than aliasing.
- Full `try_catch` / exception regression (207 C++ tests) and `esbmc-cpp/cpp` (581): no new failures. The only failing tests are pre-existing environmental ones (Solidity-on-macOS; libc++ `<cctype>` header paths; `std::pair` alignment), confirmed identical on master. The change is inert for every offset-0 catch, so non-MI exception handling is unaffected.

Note: `lower-exceptions_throw_with_nested_knownbug` stays KNOWNBUG — its `Outer` base is at offset 0 (already correct); its remaining failure is a separate `std::rethrow_if_nested` recovery issue, not this offset bug.

Fixes #4397