### PR TITLE
[test] Correct throw_with_nested expectation to match the standard

### DIFF
--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/main.cpp
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/main.cpp
@@ -1,15 +1,18 @@
 // std::throw_with_nested(Outer) throws a type deriving from both Outer and
 // std::nested_exception, capturing the in-flight Inner via current_exception.
-// The outer handler catches it as Outer&, then std::rethrow_if_nested recovers
-// and re-raises the captured Inner.
+// The outer handler catches it as Outer&, then calls std::rethrow_if_nested(o).
 //
-// KNOWNBUG: the thrown combined type is multiple-inheritance (Outer +
-// polymorphic nested_exception). When a non-polymorphic base precedes the
-// polymorphic one, the catch-by-base binding reads the base subobject at the
-// wrong offset, so `o.w` reads garbage and the assertion spuriously fails. This
-// is a pre-existing base-subobject offset bug (construction vs catch) in the
-// C++ frontend/lowering, independent of throw_with_nested itself. Once the MI
-// base-offset handling is fixed this verifies SUCCESSFUL and can move to CORE.
+// `Outer` here is NON-polymorphic. Per [except.nested]/6, rethrow_if_nested is a
+// no-op unless the *static* type of its argument is a polymorphic class (the
+// underlying dynamic_cast<nested_exception*> is otherwise ill-formed, so the
+// library selects the empty overload — see __is_polymorphic in <exception>).
+// So the captured Inner is NOT re-raised, the inner catch(Inner&) never fires,
+// and the trailing assert(0) is reachable. This matches real C++: g++/clang++
+// compile and run this program to that assert(0) (abort). ESBMC is thus
+// correct to report VERIFICATION FAILED; the previous SUCCESSFUL expectation and
+// its "base-offset bug" note were wrong (`o.w == 2` passes -- Outer is the first
+// base, at offset 0). A positive recovery test needs a *polymorphic* Outer, which
+// exercises the MI dynamic_cast cross-cast handled separately.
 #include <exception>
 #include <cassert>
 

--- a/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/test.desc
+++ b/regression/esbmc-cpp/try_catch/lower-exceptions_throw_with_nested_knownbug/test.desc
@@ -1,5 +1,6 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --std c++17
 
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$
+^  file .*main\.cpp line 64 column 5 function main$


### PR DESCRIPTION
The test caught the nested exception by a **non-polymorphic** base `Outer&`, so `std::rethrow_if_nested(o)` is a **no-op**: per [except.nested]/6 its underlying `dynamic_cast<nested_exception*>` is ill-formed for a non-polymorphic operand, so the library selects the empty overload (`__is_polymorphic` SFINAE in `<exception>`). The captured `Inner` is therefore never re-raised, the inner `catch (Inner&)` never fires, and the trailing `assert(0)` is reachable.

**Verified against real compilers:** `g++`/`clang++` compile and run this exact program straight to `assert(0)` (abort, exit 134). ESBMC's `VERIFICATION FAILED` is therefore **correct** — the old `^VERIFICATION SUCCESSFUL$` expectation was wrong, and so was the "base-subobject offset bug" note (independently, `o.w == 2` passes, because `Outer` is the *first* base at offset 0; ESBMC never mis-binds it here).

## Change
- `KNOWNBUG` → `CORE`, expecting `^VERIFICATION FAILED$`, with the reachable `assert(0)` location pinned so the verdict cannot pass vacuously.
- Rewrote the header comment to state the actual `[except.nested]` semantics.

The program is unchanged; only the expectation and comment are corrected to match the C++ standard and real toolchains. A *positive* recovery test (Inner actually re-raised) requires a **polymorphic** `Outer`, which exercises the multiple-inheritance `dynamic_cast` cross-cast — a separate case.

Fixes #4397