### PR TITLE
[build] Fix macOS static build zstd/ICU link failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,27 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
         message(STATUS "Found Flex keg installed by Homebrew at ${BREW_FLEX_PREFIX}")
         set(FLEX_EXECUTABLE "${BREW_FLEX_PREFIX}/bin/flex")
     endif()
+
+    # Homebrew's static Boost.Iostreams injects bare -l names for its
+    # compression/ICU backends (zstd + icu{data,i18n,uc}) with no search path,
+    # so the static link fails with "library 'zstd' not found" (esbmc/esbmc#6234).
+    # zstd is symlinked into $(brew --prefix)/lib; icu4c is keg-only. Add both as
+    # link dirs — CMAKE_PREFIX_PATH cannot help, the names bypass find_library.
+    if(BUILD_STATIC)
+        foreach(brew_keg "" icu4c)
+            execute_process(
+                COMMAND brew --prefix ${brew_keg}
+                RESULT_VARIABLE BREW_KEG_RESULT
+                OUTPUT_VARIABLE BREW_KEG_PREFIX
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+            )
+            if(BREW_KEG_RESULT EQUAL 0 AND IS_DIRECTORY "${BREW_KEG_PREFIX}/lib")
+                message(STATUS "Adding Homebrew link directory ${BREW_KEG_PREFIX}/lib")
+                link_directories("${BREW_KEG_PREFIX}/lib")
+            endif()
+        endforeach()
+    endif()
 endif()
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -201,12 +201,10 @@ prepare_platform_config() {
       if [[ -z "$STATIC" ]]; then
         STATIC=OFF
       fi
-      if [[ "$STATIC" == "ON" ]]; then
-        error "static macOS build is currently not supported"
-      fi
-      log "Configuring macOS build with llvm/clang ${CLANG_VERSION}"
+      log "Configuring macOS build with llvm/clang ${CLANG_VERSION} (static=$STATIC)"
 
       BASE_ARGS+=(
+        "-DBUILD_STATIC=$STATIC"
         "-DLLVM_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
         "-DClang_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
       )


### PR DESCRIPTION
Homebrew's static Boost.Iostreams variant (`libboost_iostreams-variant-static.cmake`) hardcodes bare `-l` names for its compression/ICU backends (`bz2 icudata icui18n icuuc lzma z zstd`) into the target link interface with no search path. `bz2`/`lzma`/`z` resolve from the macOS SDK, but `zstd` (in `$(brew --prefix)/lib`) and the keg-only ICU libs do not, so `-DBUILD_STATIC=ON` failed the `c2goto` link with `ld: library 'zstd' not found`. `CMAKE_PREFIX_PATH` cannot help because the bare names bypass `find_library`.

On Darwin + `BUILD_STATIC`, this adds `$(brew --prefix)/lib` and the keg-only `$(brew --prefix icu4c)/lib` via `link_directories`, and lifts the `build.sh` guard that hard-errored on static macOS builds. The added block degrades gracefully when `brew`/`icu4c` are absent and leaves dynamic builds untouched (it is nested under `if(BUILD_STATIC)`).

The resulting binary still loads Homebrew`'s zstd/ICU dylibs at runtime; fully-static linking is unavailable on macOS (no static libSystem), consistent with `BuildStatic.cmake` already skipping `-static` on Apple.

Verified locally (arm64, LLVM@18): static configure emits the two `Adding Homebrew link directory` messages, `c2goto` and `esbmc` link and run (`ESBMC version 8.4.0 aarch64 macos`), and a smoke C test verifies correctly.

Fixes #6234