### PR TITLE
[docs] Drop asm/printf from the W1-loc native-kind ladder

### DIFF
--- a/docs/spike-v1k-w1loc.md
+++ b/docs/spike-v1k-w1loc.md
@@ -346,6 +346,33 @@ do/while, for, switch, break, continue, goto, label, assert, assume, call all
 convert natively, and with the side-effecting-condition row above every one of
 them accepts a side-effecting condition too. What remains is a
 `temporary_object` in an expression statement (its scope-exit entries die at
-end-of-full-expression rather than at block exit, #6177), the C++-only kinds —
-`code_cpp_catch2t` / `code_cpp_throw2t` and the `try`/`catch` target machinery —
-and the `code_asm2t` / `code_printf2t` leaves.
+end-of-full-expression rather than at block exit, #6177) and the C++-only kinds —
+`code_cpp_catch2t` / `code_cpp_throw2t` and the `try`/`catch` target machinery.
+
+**Correction — the `code_asm2t` / `code_printf2t` "leaves" are not reachable
+native kinds and are dropped from the ladder.** A native handler for either would
+be dead instrumentation (C-Live cannot be discharged), because neither reaches
+`convert_native_rec` as a body statement in the clang pipeline:
+
+- **`code_asm2t`.** The C frontend lowers every `GCCAsmStmt` / `MSAsmStmt` to a
+  `code_skipt()` (`clang_c_convert.cpp:3480`, "we ignore them"), so a function
+  body never carries an `asm` statement. `code_asm2t` is produced *only* by
+  `migrate_expr` on a legacy `codet("asm")` (`migrate.cpp:2272`), a node that
+  arises from reading an external CBMC goto-binary — a path that does not run
+  goto-conversion at all. A throwaway `void f(){int x=a; __asm__("nop"); x=x+b;}`
+  probe confirmed it: flag-on vs flag-off `--goto-functions-only` are
+  byte-identical and the body converts natively, but the `asm` never appears —
+  it was elided to a skip upstream, so the (implemented, then reverted) native
+  arm never fired.
+- **`code_printf2t`.** It is synthesised *during* goto-conversion by `do_printf`
+  (`builtin_functions.cpp:218`), reached through `do_function_call` when a
+  `printf`-family call is lowered. A `printf(...)` statement in a body is a
+  `code_expression2t` wrapping a `sideeffect2t(function_call)`, which the #6177
+  expression handler already converts natively — its `remove_sideeffects`
+  delegation calls `do_function_call` → `do_printf`, emitting the `OTHER PRINTF`
+  inline. Confirmed byte-identical on a `void f(int a){ printf("x=%d\n", a); g=a; }`
+  probe. So printf is *already* covered indirectly; a dedicated `code_printf2t`
+  statement handler would never be reached.
+
+The genuine remaining reachable slices are therefore `temporary_object` and the
+C++ throw/catch machinery; the next native-kind PR should target the former.


### PR DESCRIPTION
Part V / W1-loc Phase C (esbmc/esbmc#4715). The spike doc's "Next" section listed `code_asm2t` and `code_printf2t` as remaining native-kind "leaves". Empirically neither reaches `convert_native_rec` as a body statement in the clang pipeline, so a native handler for either would be dead instrumentation (C-Live undischargeable):

- **asm** — the C frontend lowers `GCCAsmStmt`/`MSAsmStmt` to `code_skipt()` (`clang_c_convert.cpp:3480`). `code_asm2t` is only ever produced by migrating a legacy `codet("asm")` from an external CBMC goto-binary, a path that skips goto-conversion. A throwaway probe (implemented then reverted) confirmed the arm never fires.
- **printf** — `code_printf2t` is synthesised during conversion by `do_printf`, reached via `do_function_call`. A `printf(...)` body statement is a `code_expression2t` wrapping a `sideeffect2t(function_call)`, already converted natively by the #6177 expression handler (whose `remove_sideeffects` delegation emits the `OTHER PRINTF` inline). Confirmed byte-identical flag-on vs flag-off.

Re-scopes the remaining reachable slices to `temporary_object` (the next PR target) and the C++ throw/catch machinery. Docs-only.
