### PR TITLE
[goto-symex] Reject delete through non-virtual-dtor base subobject

### DIFF
--- a/regression/esbmc-cpp/cpp/llbmc_invalid_delete/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_invalid_delete/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/destructors/github_6263_nonvirtual_base_delete/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6263_nonvirtual_base_delete/main.cpp
@@ -1,0 +1,31 @@
+// github #6263: deleting through a pointer to a *non-primary* base subobject
+// whose class has no virtual destructor is a bad-free ([expr.delete]p3): the
+// non-virtual ~Base2 is statically bound, so operator delete receives the
+// unadjusted subobject pointer (8 bytes into the Derived allocation) instead
+// of the allocation base. ESBMC must report this, not silently accept it.
+class Base1
+{
+public:
+  virtual int f(void) { return 21; }
+};
+
+class Base2
+{
+public:
+  virtual int g(void) { return 21; }
+};
+
+class Derived : public Base1, public Base2
+{
+public:
+  virtual int f(void) { return 42; }
+  virtual int g(void) { return 42; }
+};
+
+int main()
+{
+  Base2 *o = new Derived();
+  int r = o->g();
+  delete o;
+  return r;
+}

--- a/regression/esbmc-cpp/destructors/github_6263_nonvirtual_base_delete/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6263_nonvirtual_base_delete/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions
+^VERIFICATION FAILED$
+^  Operand of free must have zero pointer offset$

--- a/regression/esbmc-cpp/destructors/github_6263_virtual_base_delete_ok/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6263_virtual_base_delete_ok/main.cpp
@@ -1,0 +1,28 @@
+// github #6263 (companion): deleting through a pointer to a non-primary base
+// subobject IS well-defined when that base has a virtual destructor -- the
+// virtual deleting destructor adjusts the interior pointer back to the
+// complete object before freeing. ESBMC must keep accepting this; the #6263
+// fix narrows the base-subobject relaxation to exactly this case.
+struct Base1
+{
+  int a;
+  virtual ~Base1() {}
+};
+
+struct Base2
+{
+  int b;
+  virtual ~Base2() {}
+};
+
+struct Derived : Base1, Base2
+{
+  int c;
+};
+
+int main()
+{
+  Base2 *o = new Derived(); // Base2 subobject sits at a non-zero offset
+  delete o;                 // virtual ~Base2 -> well-defined
+  return 0;
+}

--- a/regression/esbmc-cpp/destructors/github_6263_virtual_base_delete_ok/test.desc
+++ b/regression/esbmc-cpp/destructors/github_6263_virtual_base_delete_ok/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_multiple_inheritance-wrong/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/polymorphism_bringup_overload/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup_overload/llbmc_multiple_inheritance-wrong/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <goto-programs/destructor.h>
 #include <goto-symex/goto_symex.h>
 #include <string>
 #include <util/arith_tools.h>
@@ -9,6 +10,7 @@
 #include <util/migrate.h>
 #include <util/std_types.h>
 #include <util/type_byte_size.h>
+#include <utility>
 #include <vector>
 #include <algorithm>
 
@@ -16,13 +18,13 @@
 // base_subobject_name() in clang-c-frontend/clang_c_convert.h (#1866, #3894).
 static const std::string base_subobject_prefix = "@base@";
 
-// Collect the byte offsets of every (transitively) nested base subobject of
-// `t`, relative to the start of `t`.
+// Collect the byte offset and class type of every (transitively) nested base
+// subobject of `t`, relative to the start of `t`.
 static void collect_base_subobject_offsets(
   const type2tc &t,
   const namespacet &ns,
   const BigInt &base,
-  std::vector<BigInt> &out)
+  std::vector<std::pair<BigInt, type2tc>> &out)
 {
   if (is_nil_type(t))
     return;
@@ -40,9 +42,35 @@ static void collect_base_subobject_offsets(
       continue;
 
     const BigInt off = base + member_offset(ft, st.member_names[i], &ns);
-    out.push_back(off);
+    out.emplace_back(off, st.members[i]);
     collect_base_subobject_offsets(st.members[i], ns, off, out);
   }
+}
+
+// True iff the class `t` (a base-subobject type) has a virtual destructor.
+// Deleting through a base pointer is only well-defined ([expr.delete]p3) when
+// the pointer's static (base) type has a virtual destructor: only then does the
+// virtual deleting destructor adjust an interior subobject pointer back to the
+// complete object before calling operator delete. Absent one the destructor is
+// statically bound and operator delete receives the unadjusted subobject
+// pointer -- a genuine bad-free -- so that offset must not be admitted.
+static bool base_has_virtual_destructor(const type2tc &t, const namespacet &ns)
+{
+  const type2tc ft = ns.follow(t);
+  if (!is_struct_type(ft))
+    return false;
+
+  const irep_idt &tag = to_struct_type(ft).name;
+  if (tag.empty())
+    return false;
+
+  const symbolt *sym = ns.lookup("tag-" + id2string(tag));
+  if (sym == nullptr || sym->get_type().id() != "struct")
+    return false;
+
+  const struct_typet::componentt *dtor =
+    get_destructor_component(ns, to_struct_type(sym->get_type()));
+  return dtor != nullptr && dtor->get_bool("is_virtual");
 }
 
 expr2tc goto_symext::symex_malloc(
@@ -775,21 +803,26 @@ void goto_symext::symex_free(const expr2tc &expr)
       expr2tc eq = equality2tc(offset, gen_ulong(0));
 
       // C++ permits `delete p` where p points at a *base subobject* of the
-      // complete object -- the deleting destructor adjusts back to the
+      // complete object *only when that base has a virtual destructor* -- the
+      // virtual deleting destructor adjusts the interior pointer back to the
       // complete object before freeing. Under the nested base-subobject model
       // such an upcast pointer legitimately carries a non-zero offset. The
       // deallocation below keys on pointer_object(), so it already clears the
       // right allocation; only this assertion needs to admit those offsets.
-      // Arbitrary interior pointers (delete (p+1), delete &arr[1]) are still
-      // rejected, and C free() is unaffected. See #1866, #3894.
+      // A base with no virtual destructor is statically bound: operator delete
+      // then receives the unadjusted subobject pointer, a genuine bad-free
+      // ([expr.delete]p3), so its offset stays rejected. Arbitrary interior
+      // pointers (delete (p+1), delete &arr[1]) are also still rejected, and C
+      // free() is unaffected. See #1866, #3894, #6263.
       if (is_code_cpp_delete2t(expr) || is_code_cpp_del_array2t(expr))
       {
-        std::vector<BigInt> base_offsets;
+        std::vector<std::pair<BigInt, type2tc>> base_offsets;
         collect_base_subobject_offsets(
           item.object->type, ns, BigInt(0), base_offsets);
-        for (const BigInt &bo : base_offsets)
-          if (bo != 0)
-            eq = or2tc(eq, equality2tc(offset, gen_ulong(bo.to_uint64())));
+        for (const auto &bo : base_offsets)
+          if (bo.first != 0 && base_has_virtual_destructor(bo.second, ns))
+            eq =
+              or2tc(eq, equality2tc(offset, gen_ulong(bo.first.to_uint64())));
       }
 
       g.guard_expr(eq);


### PR DESCRIPTION
Fixes #6263.

## Root cause

`symex_free()` in `src/goto-symex/builtin_functions/memory_alloc.cpp` relaxed
its "operand of free must have zero pointer offset" assertion to admit *any*
base-subobject offset for a C++ `delete` (added by the nested base-subobject
work for #1866/#3894, PR #6181). That relaxation is only sound when the base
class has a **virtual destructor**: only then does the virtual deleting
destructor adjust an interior subobject pointer back to the complete object
before `operator delete` runs. The check admitted every base-subobject offset
unconditionally, so deleting through a *non-primary* base pointer whose class
has no virtual destructor — a genuine bad-free under [expr.delete]p3 — was
silently accepted (`VERIFICATION SUCCESSFUL`), a soundness regression.

## Fix

Gate the base-subobject relaxation on a new `base_has_virtual_destructor()`:
`collect_base_subobject_offsets()` now yields `(offset, type)` pairs, and an
offset is admitted only when the base class at that offset actually has a
virtual destructor (resolved via its type-symbol's `methods()` and the
`is_virtual` flag, reusing `get_destructor_component()`). Bases without a
virtual destructor keep the zero-offset requirement, so the bad-free is
reported. Offset-0 deletes, arbitrary interior pointers, and C `free()` are
unaffected.

## Regression tests

- `destructors/github_6263_nonvirtual_base_delete` — the issue reproducer
  (non-primary base, no virtual dtor) → `VERIFICATION FAILED` (bad-free).
- `destructors/github_6263_virtual_base_delete_ok` — non-primary base *with* a
  virtual dtor → `VERIFICATION SUCCESSFUL`, locking in the preserved relaxation.
- Promoted `cpp/llbmc_invalid_delete` and three
  `*/llbmc_multiple_inheritance-wrong` copies (which encode this exact bug) from
  KNOWNBUG / wrong-SUCCESSFUL expectations to CORE `VERIFICATION FAILED`.

## Test suites

`destructors`, `inheritance`, `polymorphism_bringup*` and the new tests pass
locally (all < 1s each, within the CI 120s cap). The virtual-destructor
delete paths (`github_6198*`) remain `SUCCESSFUL`.
