### PR TITLE
[clang-cpp] Key MI override thunks by each base's virtual_name

### DIFF
--- a/regression/esbmc-cpp/destructors/github_6198_multiple_inheritance/main.cpp
+++ b/regression/esbmc-cpp/destructors/github_6198_multiple_inheritance/main.cpp
@@ -28,11 +28,11 @@ int main()
 {
   A *p = new C();
   delete p;
-  // Expected 111. ~C overrides two base destructors, so
-  // get_ultimate_overridden_method() (clang_cpp_convert_vft.cpp) stops at its
-  // `size_overridden_methods() == 1` guard and keys the vtable slot by ~C's
-  // own id instead of ~A's, leaving the slot bound to ~A. Tracked by #1866 /
-  // #3894 alongside the other multiple-inheritance layout defects.
+  // Expected 111: ~C runs (100) and chains to both base destructors ~A (1) and
+  // ~B (10). ~C overrides two base destructors, so get_ultimate_overridden_
+  // method() cannot pick a unique base; each per-base thunk is now re-keyed by
+  // that base's own virtual_name so both base vtable slots dispatch to ~C's
+  // deleting destructor (#6198).
   assert(n == 111);
   return 0;
 }

--- a/regression/esbmc-cpp/inheritance/github_6198_method_multioverride/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_6198_method_multioverride/main.cpp
@@ -1,0 +1,25 @@
+// github #6198: a single derived method overriding the *same signature* from
+// two independent bases must override BOTH base vtable slots. Previously the
+// per-base thunks inherited the derived method's virtual_name (which, for a
+// multi-override, get_ultimate_overridden_method keys by the derived method
+// itself), so neither base slot was overridden and dispatch through a base
+// pointer wrongly called the original base method.
+#include <cassert>
+
+int n = 0;
+
+struct A { virtual void f() { n = 1; } };
+struct B { virtual void f() { n = 10; } };
+struct C : A, B { void f() override { n = 100; } };
+
+int main()
+{
+  C c;
+  A *pa = &c;
+  B *pb = &c;
+  pa->f();          // through A's vtable -> C::f
+  assert(n == 100);
+  pb->f();          // through B's vtable -> C::f
+  assert(n == 100);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_6198_method_multioverride/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_6198_method_multioverride/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.cpp
 --incremental-bmc
-
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_6198_method_multioverride_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_6198_method_multioverride_fail/main.cpp
@@ -1,0 +1,19 @@
+// Negative companion to github_6198_method_multioverride: dispatch through the
+// second base B* must reach C::f (n == 100), so asserting the pre-fix wrong
+// value (the original B::f side effect, n == 10) is violated.
+#include <cassert>
+
+int n = 0;
+
+struct A { virtual void f() { n = 1; } };
+struct B { virtual void f() { n = 10; } };
+struct C : A, B { void f() override { n = 100; } };
+
+int main()
+{
+  C c;
+  B *pb = &c;
+  pb->f();
+  assert(n == 10); // wrong on purpose: the fix makes this C::f, so n == 100
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_6198_method_multioverride_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_6198_method_multioverride_fail/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.cpp
 --incremental-bmc
-
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -489,7 +489,8 @@ protected:
   void add_thunk_component_to_type(
     const symbolt &thunk_func_symb,
     struct_typet &type,
-    const struct_typet::componentt &comp);
+    const struct_typet::componentt &comp,
+    const irep_idt &virtual_name);
   /*
    * Set an intuitive name to thunk function
    */

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -371,8 +371,20 @@ void clang_cpp_convertert::add_thunk_method(
   symbolt &added_thunk_symbol =
     *context.move_symbol_to_context(thunk_func_symb);
 
+  // The thunk populates a slot in *this base's* vtable, so it must be keyed by
+  // the base method's virtual_name, not the derived method's. These coincide
+  // for single inheritance, but when the derived method overrides the same
+  // signature from several bases (e.g. every derived destructor, or C::f with
+  // A::f and B::f), get_ultimate_overridden_method() cannot pick a unique base
+  // and keys `component` by the derived method itself. Recover the correct key
+  // per overridden base here so each base's slot is actually overridden (#6198).
+  std::string base_virtual_name, base_virtual_id;
+  get_decl_name(
+    *get_ultimate_overridden_method(&md), base_virtual_name, base_virtual_id);
+
   // add thunk function as a `method` in the derived class' type
-  add_thunk_component_to_type(added_thunk_symbol, type, component);
+  add_thunk_component_to_type(
+    added_thunk_symbol, type, component, base_virtual_id);
 }
 
 void clang_cpp_convertert::set_thunk_name(
@@ -568,11 +580,13 @@ void clang_cpp_convertert::add_thunk_method_body_no_return(
 void clang_cpp_convertert::add_thunk_component_to_type(
   const symbolt &thunk_func_symb,
   struct_typet &type,
-  const struct_typet::componentt &comp)
+  const struct_typet::componentt &comp,
+  const irep_idt &virtual_name)
 {
   struct_typet::componentt new_compo = comp;
   new_compo.type() = thunk_func_symb.get_type();
   new_compo.set_name(thunk_func_symb.id);
+  new_compo.set("virtual_name", virtual_name);
   type.methods().push_back(new_compo);
 }
 


### PR DESCRIPTION
Fixes #6198.

## Root cause

When a single derived method overrides the *same* virtual signature inherited
from two or more independent bases — every derived destructor (which overrides
all base virtual destructors), or `struct C : A, B` where both `A` and `B`
declare `virtual void f()` — dispatch through a base pointer wrongly called the
original base method instead of the derived override.

The per-base *thunks* that populate each base's vtable slot are built by
`add_thunk_component_to_type`, which copied the derived method's component and
therefore its `virtual_name`. That name comes from
`get_ultimate_overridden_method()`, whose loop only walks a chain while
`size_overridden_methods() == 1`; for a multi-override it cannot pick a unique
base and keys the derived component by the derived method itself. Both thunks
inherited that key, so neither overrode the base vtable slots. The base method's
own inherited entry (copied into the class by `get_base_components_methods`)
then won, and a `Base*` call dispatched to the un-overridden base method.

## Fix

In `add_thunk_method`, compute each overridden base method's own ultimate
`virtual_name` and set it on that thunk's component, so the thunk overrides the
correct slot in that base's vtable.

This is surgical: for single inheritance and single-lineage deep chains, the
ultimate overridden method of any base in the lineage equals the derived
method's ultimate, so the key is unchanged. Only a genuine multi-override
(same signature from 2+ independent bases) changes behaviour.

## Regression tests

- `destructors/github_6198_multiple_inheritance` — promoted KNOWNBUG → CORE; a
  derived destructor now runs all three destructors (`n == 111`).
- `inheritance/github_6198_method_multioverride` — a non-destructor method
  overriding `A::f` and `B::f`; dispatch through both `A*` and `B*` reaches
  `C::f` (`VERIFICATION SUCCESSFUL`).
- `inheritance/github_6198_method_multioverride_fail` — negative companion
  asserting the pre-fix wrong value, so it is violated (`VERIFICATION FAILED`).

## Test suites

Ran locally with no regressions: `inheritance` 79/79, `polymorphism_bringup`
44/44, `polymorphism_bringup_overload` 47/47, `destructors` 11/11, `try_catch`
151/151. The three-independent-base variant also verifies.

## Known limitation / follow-up

Destructor chaining through a *virtual* base in a diamond hierarchy
(`struct L : virtual V`) via `delete` still reports a spurious failure. This is
a separate vbase-offset limitation — confirmed already failing on `master`
before this change — and is out of scope here.
