### PR TITLE
[clang-cpp] Adjust MI thunk this by indirect base's cumulative offset

### DIFF
--- a/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk/main.cpp
@@ -1,0 +1,21 @@
+// github #6288: virtual dispatch through an INDIRECT non-first base subobject.
+// B is a direct base of Middle but only an indirect base of Derived, and sits
+// at a non-zero offset (First is polymorphic, so B cannot be the primary base).
+// Derived::f's thunk must adjust the B* this by B's *cumulative* offset within
+// Derived, otherwise Derived::f reads `d` from the wrong location.
+#include <cassert>
+
+struct First { virtual void g() {} long pad; };
+struct B { int b; virtual int f() { return b; } };
+struct Middle : First, B { };
+struct Derived : Middle { int d; int f() override { return d; } };
+
+int main()
+{
+  Derived x;
+  x.d = 42;
+  x.b = 7;
+  B *p = &x;
+  assert(p->f() == 42);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk_fail/main.cpp
@@ -1,0 +1,19 @@
+// Negative companion to github_6288_indirect_base_thunk: the dispatch reaches
+// Derived::f (returns d == 42), so asserting the pre-fix wrong value (B::b == 7,
+// what a zero this-adjustment would surface) is violated.
+#include <cassert>
+
+struct First { virtual void g() {} long pad; };
+struct B { int b; virtual int f() { return b; } };
+struct Middle : First, B { };
+struct Derived : Middle { int d; int f() override { return d; } };
+
+int main()
+{
+  Derived x;
+  x.d = 42;
+  x.b = 7;
+  B *p = &x;
+  assert(p->f() == 7); // wrong on purpose: dispatch reaches Derived::f, so f()==42
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_6288_indirect_base_thunk_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -122,6 +122,12 @@ static bool is_pure_virtual(const clang::CXXMethodDecl &md)
 #endif
 }
 
+// Defined further down; used by add_thunk_method to size the this-adjustment.
+static std::optional<uint64_t> offset_of_subobject(
+  const clang::ASTContext &ctx,
+  const clang::CXXRecordDecl *D,
+  const clang::CXXRecordDecl *S);
+
 /**
  * @brief Returns the ultimate overridden method for a given CXXMethodDecl.
  *
@@ -317,41 +323,17 @@ void clang_cpp_convertert::add_thunk_method(
   std::string base_class_id, base_class_name;
   get_decl_name(*md.getParent(), base_class_name, base_class_id);
 
-  // Compute the byte offset of the base class sub-object within the derived
-  // class. For non-first base classes in multiple inheritance this is non-zero,
-  // and the thunk must subtract it from its Base* this to recover Derived*.
-  // Sum the per-link non-virtual base offsets along the full inheritance path,
-  // so an *indirect* non-first base (e.g. Derived : Middle, Middle : First, B)
-  // gets its cumulative offset rather than 0 (#6288). Virtual bases have a
-  // dynamic offset that this static subtraction cannot model, so any path
-  // crossing a virtual base is left at 0 (unchanged; tracked separately, #940).
-  uint64_t base_offset = 0;
+  // Byte offset of the base sub-object within the derived class. For non-first
+  // base classes in multiple inheritance this is non-zero, and the thunk must
+  // subtract it from its Base* this to recover Derived*. offset_of_subobject
+  // sums the offset along the full inheritance path, so an *indirect* non-first
+  // base (e.g. Derived : Middle, Middle : First, B) gets its cumulative offset
+  // rather than 0 (#6288). A path crossing a virtual base yields nullopt (its
+  // dynamic offset cannot be statically subtracted); fall back to 0 there,
+  // unchanged from before (tracked separately, #940).
   const clang::CXXRecordDecl *base_rd = md.getParent();
-  if (base_rd != &derived_rd)
-  {
-    clang::CXXBasePaths paths;
-    if (derived_rd.isDerivedFrom(base_rd, paths))
-    {
-      const clang::CXXBasePath &path = paths.front();
-      uint64_t off = 0;
-      bool crosses_virtual = false;
-      for (const auto &elem : path)
-      {
-        if (elem.Base->isVirtual())
-        {
-          crosses_virtual = true;
-          break;
-        }
-        const clang::CXXRecordDecl *link_base =
-          elem.Base->getType()->getAsCXXRecordDecl();
-        const clang::ASTRecordLayout &link_layout =
-          ASTContext->getASTRecordLayout(elem.Class);
-        off += link_layout.getBaseClassOffset(link_base).getQuantity();
-      }
-      if (!crosses_virtual)
-        base_offset = off;
-    }
-  }
+  const uint64_t base_offset =
+    offset_of_subobject(*ASTContext, &derived_rd, base_rd).value_or(0);
 
   // Create the thunk method symbol
   symbolt thunk_func_symb;

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -320,23 +320,36 @@ void clang_cpp_convertert::add_thunk_method(
   // Compute the byte offset of the base class sub-object within the derived
   // class. For non-first base classes in multiple inheritance this is non-zero,
   // and the thunk must subtract it from its Base* this to recover Derived*.
-  // TODO: This loop only searches direct bases of derived_rd. If base_rd is
-  // an indirect base (e.g. Derived : Middle, Middle : B8), base_offset will
-  // incorrectly remain 0. A complete fix requires summing offsets along the
-  // full inheritance path using CXXBasePaths::isDerivedFrom or a recursive
-  // walk — to be addressed as a follow-up.
+  // Sum the per-link non-virtual base offsets along the full inheritance path,
+  // so an *indirect* non-first base (e.g. Derived : Middle, Middle : First, B)
+  // gets its cumulative offset rather than 0 (#6288). Virtual bases have a
+  // dynamic offset that this static subtraction cannot model, so any path
+  // crossing a virtual base is left at 0 (unchanged; tracked separately, #940).
   uint64_t base_offset = 0;
   const clang::CXXRecordDecl *base_rd = md.getParent();
-  const clang::ASTRecordLayout &layout =
-    ASTContext->getASTRecordLayout(&derived_rd);
-  for (const auto &base_spec : derived_rd.bases())
+  if (base_rd != &derived_rd)
   {
-    const clang::CXXRecordDecl *spec_rd =
-      base_spec.getType()->getAsCXXRecordDecl();
-    if (spec_rd == base_rd && !base_spec.isVirtual())
+    clang::CXXBasePaths paths;
+    if (derived_rd.isDerivedFrom(base_rd, paths))
     {
-      base_offset = layout.getBaseClassOffset(base_rd).getQuantity();
-      break;
+      const clang::CXXBasePath &path = paths.front();
+      uint64_t off = 0;
+      bool crosses_virtual = false;
+      for (const auto &elem : path)
+      {
+        if (elem.Base->isVirtual())
+        {
+          crosses_virtual = true;
+          break;
+        }
+        const clang::CXXRecordDecl *link_base =
+          elem.Base->getType()->getAsCXXRecordDecl();
+        const clang::ASTRecordLayout &link_layout =
+          ASTContext->getASTRecordLayout(elem.Class);
+        off += link_layout.getBaseClassOffset(link_base).getQuantity();
+      }
+      if (!crosses_virtual)
+        base_offset = off;
     }
   }
 


### PR DESCRIPTION
Fixes #6288.

## Root cause

When ESBMC builds a derived class's thunk for an overridden virtual method, the
thunk casts the incoming `Base*` `this` back to `Derived*` by subtracting the
byte offset of the `Base` subobject within `Derived`. That offset was computed
by scanning only `derived_rd.bases()` — the *direct* bases. A base reachable
only *indirectly* (e.g. `Derived : Middle`, `Middle : First, B`, where `B` is
the non-first base of `Middle`) is never found by that scan, so `base_offset`
stayed 0 and the `this` adjustment was wrong. A virtual call through such a base
subobject then read derived members from the wrong location, producing a
spurious `VERIFICATION FAILED` on a well-formed program (clang++ runs it fine).

This was a documented TODO in `add_thunk_method`.

## Fix

Compute `base_offset` by summing the per-link non-virtual base offsets along the
full inheritance path (`CXXBasePaths` / `isDerivedFrom`), so an indirect base
gets its cumulative offset. The direct-base case (path length 1) is unchanged.
Paths that cross a *virtual* base keep offset 0 — dynamic virtual-base offsets
cannot be modelled by a static subtraction and are a separate limitation (#940);
this preserves the prior behaviour there rather than computing a wrong value.

This is a targeted correctness fix using the existing mechanism; the broader
"replace ASTRecordLayout with ESBMC's own layout" refactor remains tracked by
#3894.

## Regression tests

- `inheritance/github_6288_indirect_base_thunk` — the reproducer; a virtual call
  through the indirect non-first base `B*` dispatches to `Derived::f` and reads
  the correct derived member (`VERIFICATION SUCCESSFUL`).
- `inheritance/github_6288_indirect_base_thunk_fail` — negative companion
  asserting the pre-fix wrong value, so it is violated (`VERIFICATION FAILED`).

## Test suites

No regressions locally: `inheritance` 79/79, `polymorphism_bringup` 44/44,
`polymorphism_bringup_overload` 47/47, `destructors` 11/11. Deeper 3-level
indirect nesting also verifies and matches clang's runtime result.
