### PR TITLE
[irep2] Lower a native temporary_object in --irep2-native-body

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/main.cpp
@@ -1,0 +1,41 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): the --irep2-native-body code_expression2t
+// handler now lowers a full-expression temporary_object natively (the guard
+// that previously fell back was over-conservative). A result-used temporary
+// whose ~M is deferred to the enclosing scope's exit leaves a destructor
+// FUNCTION_CALL on the destructor stack when the native code_return2t handler
+// runs; that handler reproduces only the plain, destructor-free RETURN, so it
+// must fall back the moment such an entry is present. Without that fallback the
+// temporary's destructor is dropped and dtor_calls stays 0.
+int dtor_calls = 0;
+
+struct M
+{
+  int w;
+  M(int a) : w(a) {}
+  ~M() { dtor_calls++; }
+};
+
+int use(const M &m)
+{
+  return m.w;
+}
+
+int g;
+
+// The M(1) temporary is deferred to check()'s scope exit, so its ~M call is
+// still on the destructor stack at `return 5;` -> the native return handler
+// falls back and legacy runs the destructor.
+int check()
+{
+  g = use(M(1));
+  return 5;
+}
+
+int main()
+{
+  check();
+  __ESBMC_assert(dtor_calls == 1, "temporary destructor ran across return");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/main.cpp
@@ -1,0 +1,33 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// Negative variant of github_4715_irep2_native_body_temp_dtor_01: the
+// temporary's destructor DOES run across the native return fallback, so
+// asserting it did not run must fail.
+int dtor_calls = 0;
+
+struct M
+{
+  int w;
+  M(int a) : w(a) {}
+  ~M() { dtor_calls++; }
+};
+
+int use(const M &m)
+{
+  return m.w;
+}
+
+int g;
+
+int check()
+{
+  g = use(M(1));
+  return 5;
+}
+
+int main()
+{
+  check();
+  __ESBMC_assert(dtor_calls == 0, "must fail: temporary destructor ran");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -143,23 +143,6 @@ static void restore_value_locations(exprt &code, const locationt &inherited)
   }
 }
 
-// True if `expr` contains a temporary_object side effect anywhere. Lowering one
-// pushes scope-exit entries that die at the end of the full expression
-// (C++ [class.temporary]/4, github #6075/#6076) rather than at block exit, and
-// the native dispatcher does not yet reproduce that interaction with the
-// destructor stack -- see the code_expression2t handler.
-static bool has_temporary_object(const exprt &expr)
-{
-  if (expr.id() == "sideeffect" && expr.statement() == "temporary_object")
-    return true;
-
-  forall_operands (it, expr)
-    if (has_temporary_object(*it))
-      return true;
-
-  return false;
-}
-
 // The location restore_value_locations would propagate into `code`'s value
 // operands: the statement's own when it has one, otherwise whatever the
 // enclosing statement passed down. An empty result means that helper's
@@ -406,13 +389,6 @@ bool goto_convert_functionst::convert_native_rec(
     if (op.is_nil() || op.is_code() || op.id() == "if")
       return false;
 
-    // A temporary_object's scope-exit entries die at the end of the full
-    // expression, not at block exit, so lowering one here would need the
-    // destructor-stack interaction convert_decl/remove_sideeffects implement;
-    // until that is reproduced natively, fall back (C++ `g = use(T(a));`).
-    if (has_temporary_object(op))
-      return false;
-
     if (has_sideeffect(op))
     {
       // remove_sideeffects reads the location for each instruction it emits off
@@ -542,12 +518,18 @@ bool goto_convert_functionst::convert_native_rec(
     // A void function returning a value is a C/C++ constraint violation the
     // frontend rejects, so it never reaches here; only a valueless void return
     // does, which correctly emits just the end-of-function goto below.
-    // convert_return unwinds the destructor stack only when it holds a
-    // destructor FUNCTION_CALL, which cannot happen here: the decl handler
-    // falls back on any type with a destructor, so a native subtree's stack
-    // holds only scope-exit code_dead entries, which convert_return leaves
-    // alone; the enclosing block handler reproduces the (skipped) scope-exit
-    // behaviour via the trailing-goto guard above.
+    // convert_return runs an unwind-before-RETURN whenever the destructor stack
+    // holds a destructor FUNCTION_CALL (C++ [stmt.return]: locals are destroyed
+    // after the value is computed but before the jump; a constant value takes a
+    // simpler sub-path). This native handler reproduces only the plain
+    // (destructor-free) shape, so it must fall back the moment such an entry is
+    // present -- a full-expression temporary lowered by the code_expression2t
+    // handler pushes exactly this (its ~T call), which the decl handler's own
+    // destructor fallback does not cover.
+    for (const codet &d : targets.destructor_stack)
+      if (d.get_statement() == "function_call")
+        return false;
+
     exprt val = is_nil_expr(ret.operand) ? static_cast<exprt>(nil_exprt())
                                          : migrate_expr_back(ret.operand);
     if (


### PR DESCRIPTION
Part V / W1-loc Phase C (esbmc/esbmc#4715). Makes the `--irep2-native-body` `code_expression2t` handler lower a full-expression `temporary_object` natively, completing another native-kind slice.

The `has_temporary_object(op)` guard that previously forced a fallback was over-conservative: `remove_sideeffects` already implements the full C++ [class.temporary]/4 scoping the native path needs (it drains a discarded temporary's destructors in place and leaves a used one's scope-exit entries on `targets.destructor_stack` for the block handler to unwind at scope exit). Removing the guard alone, however, regressed 14 esbmc-cpp tests: a temporary whose destructor is deferred to scope exit leaves a destructor FUNCTION_CALL on the stack at a `return`, and the native `code_return2t` handler reproduces only the plain, destructor-free RETURN — legacy `convert_return` instead runs an unwind-before-RETURN whenever the stack holds a destructor (C++ [stmt.return]). Its previous "this cannot happen" assumption relied on the decl handler being the only source of a stack destructor (and it falls back on any type with a destructor); a native temporary is a new source. The fix adds the matching fallback: the return handler falls back the moment the destructor stack holds a destructor call.

Verification (byte-identical `--goto-functions-only`, flag-on vs flag-off):
- `regression/{esbmc,cbmc}`: 1628 identical / 0 mismatch.
- `regression/esbmc-cpp/cpp`: 579 identical; the 4 remaining mismatches are pre-existing (`cpp_sum_class`, `cpp_sum_class_bug`, `github_4397_cstdlib_namespace`, and `ch19_1` which is `__DATE__`/`__TIME__` and differs flag-off vs flag-off).
- C-Live: temporary markers confirm the expression handler lowers a temporary_object natively and the return fallback is reached (e.g. `ch20_5`).

Adds `github_4715_irep2_native_body_temp_dtor_01{,_fail}` pinning the return-fallback case (a temporary whose `~M` must run across the native return); g++ runtime confirms the assertion.

---

Supersedes #6287, which recorded (from probe-only evidence) that this slice was not a guard removal and would need the destructor drain reproduced natively. The full esbmc-cpp sweep here shows the actual failure is narrower — a temporary's destructor lingering on the stack at a `return` — and the fix is a matching fallback in the return handler, not a native drain. #6287 can be closed.
