### PR TITLE
[clang-cpp] Distribute address-of over a conditional lvalue

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6291_cond_ref/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6291_cond_ref/main.cpp
@@ -1,0 +1,17 @@
+// github #6291: a reference bound to a conditional (ternary) lvalue must alias
+// the selected operand. Writing through the reference updates that operand.
+#include <cassert>
+
+int main()
+{
+  int a = 1, b = 2;
+  int &r = (a < b) ? a : b; // a<b true -> r binds to a
+  r = 9;
+  assert(a == 9 && b == 2);
+
+  int c = 5, d = 3;
+  int &s = (c < d) ? c : d; // c<d false -> s binds to d
+  s = 7;
+  assert(d == 7 && c == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6291_cond_ref/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6291_cond_ref/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6291_cond_ref_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6291_cond_ref_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative companion to github_6291_cond_ref: writing through the conditional
+// reference updates the SELECTED operand (a), not the other (b), so asserting
+// the write landed on b is violated.
+#include <cassert>
+
+int main()
+{
+  int a = 1, b = 2;
+  int &r = (a < b) ? a : b; // binds to a
+  r = 9;
+  assert(b == 9); // wrong on purpose: the write lands on a, so b stays 2
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6291_cond_ref_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6291_cond_ref_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -695,9 +695,10 @@ void clang_c_adjust::adjust_address_of(exprt &expr)
   // may be taken or a reference bound to it. Distributing the address-of over
   // the branches lets the resulting pointer alias the selected operand; left
   // as address_of(if(...)) the pointer analysis fails to resolve either arm
-  // (#6291). Only a glvalue conditional (identical arm types) reaches here; the
-  // type check keeps a prvalue conditional (which cannot have its address
-  // taken) from producing an if with mismatched pointer arms.
+  // (#6291). Clang only emits address_of(if) for a genuine lvalue conditional,
+  // whose arms already share a type (adjust_if has also typecast them to the
+  // conditional's type by now); the equal-type check is a defensive guard so a
+  // hypothetical mismatched if never yields an if with divergent pointer arms.
   if (
     op.id() == "if" && op.operands().size() == 3 &&
     op.op1().type() == op.op2().type())

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -690,6 +690,35 @@ void clang_c_adjust::adjust_address_of(exprt &expr)
 
   exprt &op = expr.op0();
 
+  // &(cond ? a : b) is (cond ? &a : &b). In C++ a conditional whose arms are
+  // lvalues of the same type is itself an lvalue ([expr.cond]), so its address
+  // may be taken or a reference bound to it. Distributing the address-of over
+  // the branches lets the resulting pointer alias the selected operand; left
+  // as address_of(if(...)) the pointer analysis fails to resolve either arm
+  // (#6291). Only a glvalue conditional (identical arm types) reaches here; the
+  // type check keeps a prvalue conditional (which cannot have its address
+  // taken) from producing an if with mismatched pointer arms.
+  if (
+    op.id() == "if" && op.operands().size() == 3 &&
+    op.op1().type() == op.op2().type())
+  {
+    exprt addr_true("address_of");
+    addr_true.copy_to_operands(op.op1());
+    addr_true.location() = expr.location();
+    adjust_address_of(addr_true);
+
+    exprt addr_false("address_of");
+    addr_false.copy_to_operands(op.op2());
+    addr_false.location() = expr.location();
+    adjust_address_of(addr_false);
+
+    exprt new_if("if", addr_true.type());
+    new_if.copy_to_operands(op.op0(), addr_true, addr_false);
+    new_if.location() = expr.location();
+    expr.swap(new_if);
+    return;
+  }
+
   // special case: address of function designator
   // ANSI-C 99 section 6.3.2.1 paragraph 4
 


### PR DESCRIPTION
Fixes #6291.

## Root cause

Binding a C++ reference to a conditional (ternary) lvalue and writing through it
did not update the selected operand:

```cpp
int a = 1, b = 2;
int &r = (a < b) ? a : b;  // binds to a
r = 9;
assert(a == 9);            // spurious VERIFICATION FAILED
```

The frontend lowers `int &r = (a<b)?a:b;` to `r = &(a<b ? a : b)`, i.e.
`address_of(if(cond, a, b))`. The pointer analysis cannot resolve which arm such
a pointer refers to, so the later `*r = 9` writes nowhere observable and `a`
keeps its old value. (Direct assignment `((a<b)?a:b) = 9;` was already correct;
only taking the address / binding a reference was affected.)

## Fix

In C++ a conditional whose arms are lvalues of the same type is itself an lvalue
([expr.cond]) whose address is `cond ? &a : &b`. `clang_c_adjust::adjust_address_of`
now distributes the address-of over the branches, producing `if(cond, &a, &b)`
so the pointer aliases the selected operand. The rewrite recurses, so nested
conditionals and array/member arms are handled. It is guarded to fire only when
the two arms have identical types (a glvalue conditional always does; this keeps
a prvalue conditional — whose address cannot be taken — from forming an `if`
with mismatched pointer arms). C is unaffected: its conditional operator is
never an lvalue, so `address_of(if(...))` does not arise there.

## Regression tests

- `cpp/github_6291_cond_ref` — writes through references bound to both the true
  and false arm of a conditional; the selected operand is updated
  (`VERIFICATION SUCCESSFUL`).
- `cpp/github_6291_cond_ref_fail` — negative companion asserting the write
  landed on the *other* operand, so it is violated (`VERIFICATION FAILED`).

## Test suites

No regressions locally: `esbmc-cpp/bug_fixes` 105/105, `esbmc-cpp/inheritance`
79/79, reference tests pass, and a C sample 23/23. The fix was cross-checked
against clang++ runtime results on arrays, struct members, nested conditionals,
a hand-written `const T& max(a,b)`, and nondeterministic conditions.
