### PR TITLE
[clang-cpp] Place this first in a pointer-to-member function call

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr/main.cpp
@@ -1,0 +1,28 @@
+// github #6293: calling a pointer-to-member function that takes arguments must
+// pass the implicit object as `this` (the first parameter) and the explicit
+// arguments after it. Previously `this` was appended at the back of the
+// member-pointer's parameter list, shifting every explicit argument by one.
+#include <cassert>
+
+struct S
+{
+  int v;
+  int g(int x) { return v + x; }
+  int h(int x, int y) { return v + x * 10 + y; }
+};
+
+int main()
+{
+  S s;
+  s.v = 100;
+
+  int (S::*p)(int) = &S::g;
+  assert((s.*p)(5) == 105);
+
+  S *q = &s;
+  assert((q->*p)(7) == 107);
+
+  int (S::*r)(int, int) = &S::h;
+  assert((s.*r)(3, 4) == 134);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr_fail/main.cpp
@@ -1,0 +1,19 @@
+// Negative companion to github_6293_member_fn_ptr: the call binds `this` and
+// the argument correctly, so g uses v (100) + x (5) == 105; asserting a wrong
+// value is violated.
+#include <cassert>
+
+struct S
+{
+  int v;
+  int g(int x) { return v + x; }
+};
+
+int main()
+{
+  S s;
+  s.v = 100;
+  int (S::*p)(int) = &S::g;
+  assert((s.*p)(5) == 999); // wrong on purpose
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_6293_member_fn_ptr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -199,7 +199,14 @@ void clang_c_adjust::adjust_expr(exprt &expr)
       exprt func = expr.op1();
       code_typet &code_type = to_code_type(func.type().subtype());
       exprt arg0 = address_of_exprt(expr.op0());
-      code_type.arguments().push_back(arg0.type());
+      // The implicit object (`this`) is the *first* parameter of the pointed-to
+      // member function, ahead of the explicit ones. Inserting its type at the
+      // front keeps the parameter list aligned with the call's argument list
+      // (this, arg1, ...); appending it at the back shifted every explicit
+      // argument by one and mismatched `this` for any member function taking
+      // parameters (#6293).
+      code_type.arguments().insert(
+        code_type.arguments().begin(), code_typet::argumentt(arg0.type()));
       expr.swap(func);
     }
   }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -199,12 +199,8 @@ void clang_c_adjust::adjust_expr(exprt &expr)
       exprt func = expr.op1();
       code_typet &code_type = to_code_type(func.type().subtype());
       exprt arg0 = address_of_exprt(expr.op0());
-      // The implicit object (`this`) is the *first* parameter of the pointed-to
-      // member function, ahead of the explicit ones. Inserting its type at the
-      // front keeps the parameter list aligned with the call's argument list
-      // (this, arg1, ...); appending it at the back shifted every explicit
-      // argument by one and mismatched `this` for any member function taking
-      // parameters (#6293).
+      // `this` is the first parameter; appending its type at the back instead
+      // shifted every explicit argument by one (#6293).
       code_type.arguments().insert(
         code_type.arguments().begin(), code_typet::argumentt(arg0.type()));
       expr.swap(func);


### PR DESCRIPTION
Fixes #6293.

## Root cause

Calling a pointer-to-member function that takes one or more arguments, through
an object, aborted verification:

```cpp
struct S { int g(int x) { return x; } };
int (S::*p)(int) = &S::g;
S s;
(s.*p)(3);   // ERROR: argument "...g#this" type mismatch: got struct, expected pointer
```

The `ptr_mem` handling in `clang_c_adjust::adjust_expr` adds the implicit-object
(`this`) type to the member pointer's function type, but appended it to the
*back* of the parameter list:

```cpp
code_type.arguments().push_back(arg0.type());   // this ends up last
```

`this` is the *first* parameter of a member function, ahead of the explicit
ones. Appending it shifted every explicit argument by one, so for `(s.*p)(3)`
the object `s` was matched against the explicit `int` parameter and `3` against
the `this` (`S*`) parameter. The lowered call was `*p(s, (struct S *)3)`. The
zero-argument case happened to work because there was only the object to place.

## Fix

Insert the `this` type at the *front* of the member pointer's parameter list.
Argument reconciliation then matches the implicit object against the `S*`
`this` parameter (taking its address) and each explicit argument against its own
parameter, so the lowered call becomes `*p(&s, 3)`. One-line change; no-argument
calls and the `->*` form are unaffected.

## Regression tests

- `bug_fixes/github_6293_member_fn_ptr` — one- and two-argument member function
  pointers, called via both `.*` and `->*`, reading a member through `this`
  (`VERIFICATION SUCCESSFUL`).
- `bug_fixes/github_6293_member_fn_ptr_fail` — negative companion asserting a
  wrong result (`VERIFICATION FAILED`).

## Test suites

No regressions locally: `esbmc-cpp/bug_fixes` (incl. the existing
`github_4088_*` member-pointer tests), `esbmc-cpp/inheritance`, and
`esbmc-cpp/template` all pass. Non-virtual member-pointer calls now match
clang's runtime results across one/two/multi argument cases.

## Known limitation / follow-up

Virtual dispatch through a member pointer (`&B::g` where `g` is virtual, called
on a derived object) still resolves to the static base method rather than the
override. This is a separate, pre-existing limitation (already `FAILED` on
master before this change) — member pointers to virtual functions need to encode
a vtable offset rather than a function address — and is out of scope here.
