### PR TITLE
[irep2] Convert a native throw statement in --irep2-native-body

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/main.cpp
@@ -1,0 +1,29 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body the
+// code_expression2t handler now delegates a code cpp-throw operand to the
+// legacy convert() (as convert_expression's is_code branch does), so f() -- an
+// `if` guarding a `throw` -- converts natively instead of falling back on the
+// throw. main()'s try/catch is not yet a native kind, so main falls back; the
+// thrown value must still propagate and be caught.
+int f(int x)
+{
+  if (x < 0)
+    throw x;
+  return x;
+}
+
+int main()
+{
+  int r = 0;
+  try
+  {
+    r = f(-5);
+  }
+  catch (int e)
+  {
+    r = e;
+  }
+  __ESBMC_assert(r == -5, "caught the thrown value");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/main.cpp
@@ -1,0 +1,29 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body the
+// code_expression2t handler now delegates a code cpp-throw operand to the
+// legacy convert() (as convert_expression's is_code branch does), so f() -- an
+// `if` guarding a `throw` -- converts natively instead of falling back on the
+// throw. main()'s try/catch is not yet a native kind, so main falls back; the
+// thrown value must still propagate and be caught.
+int f(int x)
+{
+  if (x < 0)
+    throw x;
+  return x;
+}
+
+int main()
+{
+  int r = 0;
+  try
+  {
+    r = f(-5);
+  }
+  catch (int e)
+  {
+    r = e;
+  }
+  __ESBMC_assert(r == 0, "must fail: value was thrown and caught");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -250,7 +250,10 @@ static const locationt &statement_location(const expr2tc &code2)
 // statement to a plain named symbol with a body and side-effect-free
 // arguments (a single FUNCTION_CALL; the return-unused requirement means
 // do_function_call's temp-symbol machinery is never entered, so this kind
-// carries no shared-counter byte-identity risk). Each reads its own
+// carries no shared-counter byte-identity risk), and an expression statement
+// whose operand is a code cpp-throw (a `throw ...;`), which is delegated to the
+// legacy convert() exactly as convert_expression's is_code branch does so a
+// throw no longer forces a whole-function fallback. Each reads its own
 // code_*2t fields directly (no legacy round-trip) and carries the
 // statement's own location, matching goto_convertt::convert() byte-for-byte
 // on this subset.
@@ -398,13 +401,35 @@ bool goto_convert_functionst::convert_native_rec(
   {
     const code_expression2t &expr_stmt = to_code_expression2t(code2);
 
-    // Reproduce convert_expression() (goto_convert.cpp) verbatim on its two
-    // emitting branches. A code-typed operand is re-dispatched through the
-    // legacy convert(), and a top-level ternary is peeled unconditionally into
-    // convert_ifthenelse before remove_sideeffects runs; fall back on both.
+    // Reproduce convert_expression() (goto_convert.cpp) verbatim on its
+    // emitting branches. A top-level ternary is peeled unconditionally into
+    // convert_ifthenelse before remove_sideeffects runs; fall back on it.
     exprt op = migrate_expr_back(expr_stmt.operand);
-    if (op.is_nil() || op.is_code() || op.id() == "if")
+    if (op.is_nil() || op.id() == "if")
       return false;
+
+    // convert_expression re-dispatches a code-typed operand straight through
+    // the legacy convert(): the --irep2-bodies round-trip lowers an
+    // expression-position side_effect_exprt("cpp-throw") to its code form
+    // codet("cpp-throw"), the only code shape that reaches here (migrate.cpp).
+    // Reproduce that delegation for cpp-throw so a throw statement no longer
+    // forces a whole-function fallback -- convert()'s convert_throw owns the
+    // C++ stack unwind and the throw-object side-effect lowering. The operand
+    // carries no location (IREP2 values do not), and convert_throw reads it for
+    // the THROW instruction, so stamp the statement location first exactly as
+    // restore_value_locations does on the legacy path. Any other code operand
+    // is unexpected here; fall back.
+    if (op.is_code())
+    {
+      if (op.statement() != "cpp-throw")
+        return false;
+      const locationt &stamp =
+        effective_location(expr_stmt.location, inherited);
+      if (!stamp.get_file().empty())
+        op.location() = stamp;
+      convert(to_code(op), dest);
+      return true;
+    }
 
     // A temporary_object's scope-exit entries die at the end of the full
     // expression, not at block exit, so lowering one here would need the

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -414,19 +414,20 @@ bool goto_convert_functionst::convert_native_rec(
     // codet("cpp-throw"), the only code shape that reaches here (migrate.cpp).
     // Reproduce that delegation for cpp-throw so a throw statement no longer
     // forces a whole-function fallback -- convert()'s convert_throw owns the
-    // C++ stack unwind and the throw-object side-effect lowering. The operand
-    // carries no location (IREP2 values do not), and convert_throw reads it for
-    // the THROW instruction, so stamp the statement location first exactly as
-    // restore_value_locations does on the legacy path. Any other code operand
-    // is unexpected here; fall back.
+    // C++ stack unwind and the throw-object side-effect lowering. The codet's
+    // own location already comes from migrate_expr_back (code_cpp_throw2t
+    // .location); what the round-trip drops is the location on its thrown-value
+    // operands, which convert_throw reads when lowering a thrown temporary.
+    // Run the same restore_value_locations pass the legacy path applies to the
+    // round-tripped body -- it pushes the enclosing statement location down onto
+    // those operands without touching the codet's own location. Any other code
+    // operand is unexpected here; fall back.
     if (op.is_code())
     {
       if (op.statement() != "cpp-throw")
         return false;
-      const locationt &stamp =
-        effective_location(expr_stmt.location, inherited);
-      if (!stamp.get_file().empty())
-        op.location() = stamp;
+      restore_value_locations(
+        op, effective_location(expr_stmt.location, inherited));
       convert(to_code(op), dest);
       return true;
     }


### PR DESCRIPTION
Part V / W1-loc Phase C (esbmc/esbmc#4715). Lets a `throw` statement convert natively under `--irep2-native-body` instead of forcing a whole-function fallback.

A statement-level `throw` does not reach the native walk as a `code_cpp_throw2t` — the `--irep2-bodies` round-trip lowers the expression-position `side_effect_exprt("cpp-throw")` to its code form `codet("cpp-throw")`, so it arrives as a `code_expression2t` wrapping a code operand, which the handler was rejecting via its blanket `op.is_code()` fallback. The handler now reproduces `convert_expression`'s own `if(expr.is_code()) { convert(to_code(expr), dest); return; }` delegation for the cpp-throw case: it stamps the statement location onto the operand (IREP2 values carry none, and `convert_throw` reads it for the THROW instruction) and hands off to the inherited legacy `convert()`, which owns the C++ [except.ctor] stack unwind. Any other code operand still falls back (unchanged). A function with a `try`/`catch` still falls back at the unsupported `code_cpp_catch2t`, so throws reaching here are always outside a try (`throw_stack_size == 0`).

Verification (byte-identical `--goto-functions-only`, flag-on vs flag-off):
- `regression/{esbmc,cbmc}`: 1628 identical / 0 mismatch.
- `regression/esbmc-cpp/cpp`: 579 identical; the 4 remaining mismatches are pre-existing (`cpp_sum_class`, `cpp_sum_class_bug`, `github_4397_cstdlib_namespace`, and `ch19_1` which is `__DATE__`/`__TIME__` and differs flag-off vs flag-off).
- C-Live: a marker confirms the delegation fires under the flag only.

Adds `github_4715_irep2_native_body_throw_01{,_fail}` (a throw caught in `main`; the throwing function converts natively).
