### PR TITLE
[irep2] Convert a native try/catch in --irep2-native-body

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/main.cpp
@@ -1,0 +1,34 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a source-level
+// try/catch (code_cpp_catch2t) is delegated to the legacy convert()/convert_catch
+// rather than forcing a whole-function fallback, so the statements around it --
+// the local declarations and the trailing return here -- convert natively while
+// convert_catch still owns the CATCH markers, handler targets and stack unwind.
+int f(int x)
+{
+  if (x < 0)
+    throw x;
+  return x;
+}
+
+int compute(int a)
+{
+  int base = 100;
+  int r;
+  try
+  {
+    r = f(a);
+  }
+  catch (int e)
+  {
+    r = -e;
+  }
+  return base + r;
+}
+
+int main()
+{
+  __ESBMC_assert(compute(-5) == 105, "caught, negated, and combined natively");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/main.cpp
@@ -1,0 +1,34 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a source-level
+// try/catch (code_cpp_catch2t) is delegated to the legacy convert()/convert_catch
+// rather than forcing a whole-function fallback, so the statements around it --
+// the local declarations and the trailing return here -- convert natively while
+// convert_catch still owns the CATCH markers, handler targets and stack unwind.
+int f(int x)
+{
+  if (x < 0)
+    throw x;
+  return x;
+}
+
+int compute(int a)
+{
+  int base = 100;
+  int r;
+  try
+  {
+    r = f(a);
+  }
+  catch (int e)
+  {
+    r = -e;
+  }
+  return base + r;
+}
+
+int main()
+{
+  __ESBMC_assert(compute(-5) == 0, "must fail: exception was caught and combined");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -1298,8 +1298,9 @@ bool goto_convert_functionst::convert_native_rec(
     // a fallback. The round-trip drops the value-operand locations inside the
     // blocks, so run the same restore_value_locations pass the legacy body gets.
     // The bodyless CATCH marker form never appears in a function body (it is
-    // synthesised into the goto program by convert_catch), so operands are
-    // always present here; convert() handles either shape regardless.
+    // synthesised into the goto program by convert_catch), so a source-level
+    // cpp-catch here always carries its try block plus >=1 handler -- which is
+    // what convert_catch's assert(operands >= 2) requires.
     exprt op = migrate_expr_back(code2);
     restore_value_locations(op, effective_location(c.location, inherited));
     convert(to_code(op), dest);

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -250,7 +250,9 @@ static const locationt &statement_location(const expr2tc &code2)
 // statement to a plain named symbol with a body and side-effect-free
 // arguments (a single FUNCTION_CALL; the return-unused requirement means
 // do_function_call's temp-symbol machinery is never entered, so this kind
-// carries no shared-counter byte-identity risk). Each reads its own
+// carries no shared-counter byte-identity risk), and a source-level try/catch
+// (code_cpp_catch2t), delegated to the legacy convert()/convert_catch so the
+// statements around it convert natively. Each reads its own
 // code_*2t fields directly (no legacy round-trip) and carries the
 // statement's own location, matching goto_convertt::convert() byte-for-byte
 // on this subset.
@@ -1276,6 +1278,31 @@ bool goto_convert_functionst::convert_native_rec(
     dest.destructive_append(tmp);
     targets.labels.insert({l.label, {target, targets.destructor_stack}});
     target->labels.push_front(l.label);
+    return true;
+  }
+
+  if (is_code_cpp_catch2t(code2))
+  {
+    const code_cpp_catch2t &c = to_code_cpp_catch2t(code2);
+
+    // A source-level try/catch (operands[0] is the try block, operands[1..N]
+    // the handlers). Delegate the whole statement to the legacy convert():
+    // convert_catch (goto_convert.cpp) owns the CATCH push/pop
+    // markers, the per-handler target weave, the end-target gotos and the
+    // throw_stack_size save/restore around the try body -- machinery this
+    // dispatcher does not reproduce natively. The only reason a try/catch
+    // reaches here at all (rather than forcing a whole-function fallback) is to
+    // let the statements around it convert natively. Any gotos/labels/cases the
+    // try body registers in `targets`, and any temp symbols it allocates, are
+    // covered by convert_function's snapshot/restore if a later statement forces
+    // a fallback. The round-trip drops the value-operand locations inside the
+    // blocks, so run the same restore_value_locations pass the legacy body gets.
+    // The bodyless CATCH marker form never appears in a function body (it is
+    // synthesised into the goto program by convert_catch), so operands are
+    // always present here; convert() handles either shape regardless.
+    exprt op = migrate_expr_back(code2);
+    restore_value_locations(op, effective_location(c.location, inherited));
+    convert(to_code(op), dest);
     return true;
   }
 


### PR DESCRIPTION
Part V / W1-loc Phase C (esbmc/esbmc#4715). Lets a source-level `try`/`catch` convert under `--irep2-native-body` instead of forcing a whole-function fallback.

A `try`/`catch` reaches the native walk as a `code_cpp_catch2t` statement (operands[0] is the try block, operands[1..N] the handlers, with each handler's `exception_id` restored by the migrate back-arm). Reproducing `convert_catch`'s machinery natively — the CATCH push/pop markers, the per-handler target vector, the end-target goto weave and the `throw_stack_size` save/restore around the try body — is a large, high-risk job for little gain, since the try body and handlers would still be lowered the same way. So the handler delegates the whole statement to the legacy `convert()` (which dispatches to `convert_catch`), exactly as the sibling cpp-throw path delegates to `convert_throw`. The value is that the statements *around* the try/catch — local declarations, the trailing return — now convert natively rather than dragging the whole function back to `goto_convert_rec`.

Safety: any gotos/labels/switch-cases the try body registers in `targets`, and any temp symbols it allocates, are covered by `convert_function`'s snapshot/restore if a later statement forces a fallback (the same guard the throw path relies on). The round-trip drops the value-operand locations inside the blocks, so the handler runs the same `restore_value_locations` pass the legacy body gets before delegating (it stamps the operands, never the code node's own location).

Verification (byte-identical `--goto-functions-only`, flag-on vs flag-off):
- `regression/esbmc-cpp/cpp`: 579 identical; the 4 remaining mismatches are pre-existing (`cpp_sum_class`, `cpp_sum_class_bug`, `github_4397_cstdlib_namespace`, and `ch19_1` which is `__DATE__`/`__TIME__` and differs flag-off vs flag-off).
- `regression/{esbmc,cbmc}`: 0 mismatch.
- C-Live: a marker confirms the delegation fires under the flag only.

Adds `github_4715_irep2_native_body_trycatch_01{,_fail}` (a try/catch whose surrounding declarations and return convert natively; g++ runtime confirms the caught-and-combined result).
