### PR TITLE
[clang-frontend] Base a bool bitfield on an unsigned bitvector

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6304_bool_bitfield/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6304_bool_bitfield/main.cpp
@@ -1,0 +1,29 @@
+// github #6304: a bool bitfield used in a boolean context (&&, ||, !, if,
+// assertion) previously aborted ESBMC with an internal type assertion, because
+// the bitfield migrated to unsignedbv[1] but its legacy type stayed `bool`, so
+// the boolean-context coercion inserted no cast. Basing the bitfield on an
+// unsigned bitvector (as integer bitfields already are) fixes it.
+#include <cassert>
+
+struct F
+{
+  bool a : 1, b : 1, c : 1;
+};
+
+int main()
+{
+  F f{};
+  f.a = 1;
+  f.c = 1;
+
+  assert(f.a && !f.b && f.c);   // &&, !
+  assert(f.a || f.b);           // ||
+  if (f.a)                      // if
+    assert(!f.b);
+
+  bool x = f.a;                 // read into a bool
+  assert(x);
+  f.b = f.a;                    // bitfield-to-bitfield
+  assert(f.b);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6304_bool_bitfield/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6304_bool_bitfield/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6304_bool_bitfield_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6304_bool_bitfield_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative companion to github_6304_bool_bitfield: the bool bitfield holds
+// true, so asserting it is false is violated.
+#include <cassert>
+
+struct F
+{
+  bool a : 1;
+};
+
+int main()
+{
+  F f{};
+  f.a = 1;
+  assert(!f.a); // wrong on purpose: f.a is true
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6304_bool_bitfield_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6304_bool_bitfield_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1935,6 +1935,15 @@ bool clang_c_convertert::get_bitfield_type(
     return true;
 
   new_type = orig_type;
+  // A `bool` bitfield migrates to unsignedbv[N] (a bool has no fixed width the
+  // narrowing can key on), but its legacy id stays "bool", so gen_typecast_bool
+  // treats a read as already-bool and skips the cast -- leaving a non-bool
+  // operand in an &&/||/if that trips a goto-check type assertion. Base the
+  // bitfield on an unsigned bitvector, as integer bitfields already are, so the
+  // boolean-context coercion inserts the cast; the migrated type is unchanged
+  // (#6304).
+  if (new_type.id() == "bool")
+    new_type.id("unsignedbv");
   new_type.width(result.Val.getInt().getSExtValue());
   new_type.set("#bitfield", true);
   new_type.subtype() = orig_type;


### PR DESCRIPTION
Fixes #6304.

## Root cause

A C++ `bool` bitfield used in a boolean context (`&&`, `||`, `!`, `if`, an
assertion) aborted ESBMC with an internal assertion:

```
struct F { bool a : 1, b : 1, c : 1; };
... assert(f.a && !f.b && f.c);
# Assertion failed: (is_bool_type(e)), file goto_check.cpp, line 1123.
```

`migrate_type0` maps a `bool` bitfield to `unsignedbv[N]` (a `bool` has no
fixed width the narrowing can key on). But the *legacy* type keeps the id
`"bool"`, so `gen_typecast_bool` — used by the `&&`/`||`/`if` lowering — treats
a read as already-bool and inserts no cast. After migration the operand is
`unsignedbv[1]`, violating the goto-check invariant that `&&`/`||` operands are
bool. Integer bitfields don't hit this (their legacy id is `signedbv`/
`unsignedbv`, so the cast is inserted); C doesn't (clang promotes the bitfield
to `int` in the AST). A plain read/assign hit a matching mismatch in the `with`
type check.

## Fix

In `clang_c_convertert::get_bitfield_type`, change a `bool` underlying type's id
from `"bool"` to `"unsignedbv"` before applying the bitfield width — so a bool
bitfield is represented as an unsigned bitvector exactly like an integer
bitfield, and the boolean-context coercion inserts the cast to bool. The
migrated type (`unsignedbv[1]`) is unchanged, so nothing else about the encoding
moves; the `#bitfield` marker and the `bool` subtype are preserved.

## Regression tests

- `cpp/github_6304_bool_bitfield` — a bool bitfield in `&&`, `||`, `!`, `if`,
  read into a `bool`, and bitfield-to-bitfield assignment (`VERIFICATION
  SUCCESSFUL`).
- `cpp/github_6304_bool_bitfield_fail` — negative companion asserting a false
  value for a set bitfield (`VERIFICATION FAILED`).

## Test suites

No regressions: `esbmc-cpp/cpp` bitfield tests (`github_4281_{packed,unpacked}_
bitfield_ctor`), the C bitfield tests (`39_bitfields`, `39_bitfields2`,
`bitfield_zero_offset_narrow`, `struct_bitfields_15`), and `esbmc-cpp/bug_fixes`
(105/105) all pass. The behaviour was cross-checked against clang++ for
`&&`/`||`/`!`/`if`, bool-read, and a correctly-detected wrong assertion; integer
bitfields and C bool bitfields are unaffected.
