### PR TITLE
[irep2] Delegate a native local-object decl in --irep2-native-body

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/main.cpp
@@ -1,0 +1,34 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a declaration
+// whose type has a destructor (`T t(base);`) or whose initializer needs
+// lowering (`T u = T(base + 5);`) is delegated to the legacy convert_decl,
+// rather than forcing a whole-function fallback, so the statements around it --
+// the plain local and the assignment here -- convert natively while convert_decl
+// still emits the in-place construction and schedules each object's scope-exit
+// destructor. Both destructors run at the end of the (void) function.
+int dtor_count = 0;
+
+struct T
+{
+  int v;
+  T(int a) : v(a) {}
+  ~T() { dtor_count++; }
+};
+
+int g;
+
+void run(int x)
+{
+  int base = x;
+  T t(base);
+  T u = T(base + 5);
+  g = t.v + u.v;
+}
+
+int main()
+{
+  run(10);
+  __ESBMC_assert(g == 25 && dtor_count == 2, "values and both destructors ran");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/main.cpp
@@ -1,0 +1,34 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a declaration
+// whose type has a destructor (`T t(base);`) or whose initializer needs
+// lowering (`T u = T(base + 5);`) is delegated to the legacy convert_decl,
+// rather than forcing a whole-function fallback, so the statements around it --
+// the plain local and the assignment here -- convert natively while convert_decl
+// still emits the in-place construction and schedules each object's scope-exit
+// destructor. Both destructors run at the end of the (void) function.
+int dtor_count = 0;
+
+struct T
+{
+  int v;
+  T(int a) : v(a) {}
+  ~T() { dtor_count++; }
+};
+
+int g;
+
+void run(int x)
+{
+  int base = x;
+  T t(base);
+  T u = T(base + 5);
+  g = t.v + u.v;
+}
+
+int main()
+{
+  run(10);
+  __ESBMC_assert(g == 25 && dtor_count == 0, "must fail: both destructors ran");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/main.cpp
@@ -1,0 +1,41 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// W1-loc Phase C (esbmc/esbmc#4715): the --irep2-native-body code_expression2t
+// handler now lowers a full-expression temporary_object natively (the guard
+// that previously fell back was over-conservative). A result-used temporary
+// whose ~M is deferred to the enclosing scope's exit leaves a destructor
+// FUNCTION_CALL on the destructor stack when the native code_return2t handler
+// runs; that handler reproduces only the plain, destructor-free RETURN, so it
+// must fall back the moment such an entry is present. Without that fallback the
+// temporary's destructor is dropped and dtor_calls stays 0.
+int dtor_calls = 0;
+
+struct M
+{
+  int w;
+  M(int a) : w(a) {}
+  ~M() { dtor_calls++; }
+};
+
+int use(const M &m)
+{
+  return m.w;
+}
+
+int g;
+
+// The M(1) temporary is deferred to check()'s scope exit, so its ~M call is
+// still on the destructor stack at `return 5;` -> the native return handler
+// falls back and legacy runs the destructor.
+int check()
+{
+  g = use(M(1));
+  return 5;
+}
+
+int main()
+{
+  check();
+  __ESBMC_assert(dtor_calls == 1, "temporary destructor ran across return");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/main.cpp
@@ -1,0 +1,33 @@
+// __ESBMC_assert is a built-in intrinsic; no include needed.
+
+// Negative variant of github_4715_irep2_native_body_temp_dtor_01: the
+// temporary's destructor DOES run across the native return fallback, so
+// asserting it did not run must fail.
+int dtor_calls = 0;
+
+struct M
+{
+  int w;
+  M(int a) : w(a) {}
+  ~M() { dtor_calls++; }
+};
+
+int use(const M &m)
+{
+  return m.w;
+}
+
+int g;
+
+int check()
+{
+  g = use(M(1));
+  return 5;
+}
+
+int main()
+{
+  check();
+  __ESBMC_assert(dtor_calls == 0, "must fail: temporary destructor ran");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--irep2-native-body
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -212,7 +212,10 @@ static const locationt &statement_location(const expr2tc &code2)
 // the structural leaves (block/skip), the single-instruction value statements
 // (assign/expression) that reduce to one ASSIGN/OTHER with nothing to lower,
 // trivial-type declarations (DECL + optional side-effect-free ASSIGN + scope-exit
-// DEAD, the block managing the destructor stack as convert_block does), a value
+// DEAD, the block managing the destructor stack as convert_block does; a
+// declaration whose type has a destructor or whose initializer needs lowering
+// is instead delegated to convert_decl via convert(), so a local object no
+// longer forces a whole-function fallback), a value
 // return (RETURN + unconditional GOTO to the function's end), a
 // side-effect-free `if`/`if-else` whose branches convert natively (the
 // general, unfolded branch shape only — see the assert-fold guard below), a
@@ -452,22 +455,38 @@ bool goto_convert_functionst::convert_native_rec(
       s->static_lifetime || s->get_type().is_code() || s->get_type().is_array())
       return false;
 
-    code_function_callt destructor;
-    if (get_destructor(ns, s->get_type(), destructor))
-      return false;
-
     exprt initializer = is_nil_expr(decl.init) ? static_cast<exprt>(nil_exprt())
                                                : migrate_expr_back(decl.init);
-    // A top-level ternary initializer is side-effect-free yet still lowered to a
-    // DECL/IF/GOTO branch by remove_sideeffects under --validate-violation-witness
-    // (goto_sideeffects.cpp), which a single ASSIGN would not reproduce —
-    // mirror the same guard the assign handler carries.
-    if (
-      initializer.is_not_nil() &&
-      (has_sideeffect(initializer) || initializer.id() == "if" ||
-       (initializer.id() == "sideeffect" &&
-        initializer.statement() == "temporary_object")))
-      return false;
+
+    // convert_decl handles two shapes the plain native path below does not: a
+    // type with a destructor (it pushes a scope-exit destructor FUNCTION_CALL in
+    // addition to the code_dead) and an initializer it lowers specially -- a
+    // temporary_object constructing in place / a call returning by value, plus
+    // any side effect and its full-expression temporary drain, and a top-level
+    // ternary (which remove_sideeffects lowers to a DECL/IF/GOTO branch under
+    // --validate-violation-witness). Delegate those to the legacy convert()
+    // rather than fall back the whole function: convert_decl emits the DECL,
+    // lowers the initializer and pushes the scope-exit entries (code_dead, and
+    // the destructor for a destructible type) onto targets.destructor_stack,
+    // which the native block handler unwinds at scope exit exactly as
+    // convert_block does. Any temps it allocates and any gotos/labels an
+    // initializer registers in `targets` are covered by convert_function's
+    // snapshot/restore on a later fallback. Restore the initializer's
+    // value-operand locations first, as the legacy body round-trip does.
+    code_function_callt destructor;
+    const bool needs_convert_decl =
+      get_destructor(ns, s->get_type(), destructor) ||
+      (initializer.is_not_nil() &&
+       (has_sideeffect(initializer) || initializer.id() == "if" ||
+        (initializer.id() == "sideeffect" &&
+         initializer.statement() == "temporary_object")));
+    if (needs_convert_decl)
+    {
+      exprt op = migrate_expr_back(code2);
+      restore_value_locations(op, effective_location(decl.location, inherited));
+      convert(to_code(op), dest);
+      return true;
+    }
 
     // Emit exactly as convert_decl does: copy() migrates the freshly-built
     // legacy node, so the DECL/ASSIGN instructions match byte-for-byte. Build the

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -441,16 +441,15 @@ bool goto_convert_functionst::convert_native_rec(
     if (s == nullptr)
       return false;
 
-    // convert_decl (goto_convert.cpp) has several paths this native handler
-    // does not reproduce; fall back on each so flag-on stays byte-identical:
+    // Fall back on the two convert_decl shapes this handler neither reproduces
+    // natively nor delegates, so flag-on stays byte-identical:
     //  - a static-lifetime or code-typed symbol is a no-op SKIP,
     //  - an array type may be a VLA needing rewrite_vla_decl / a dynamic-size
-    //    generator — exclude all arrays conservatively,
-    //  - a type with a destructor pushes a second stack entry and lowers a
-    //    FUNCTION_CALL at scope exit,
-    //  - a temporary_object or side-effect initializer is lowered.
-    // What remains is exactly convert_decl's plain path: a DECL, an optional
-    // side-effect-free ASSIGN, and one scope-exit code_dead.
+    //    generator — exclude all arrays conservatively.
+    // A destructible type or an initializer needing lowering is delegated to
+    // convert_decl just below; everything else is convert_decl's plain path
+    // (a DECL, an optional side-effect-free ASSIGN, and one scope-exit code_dead)
+    // reproduced natively after that.
     if (
       s->static_lifetime || s->get_type().is_code() || s->get_type().is_array())
       return false;
@@ -473,13 +472,14 @@ bool goto_convert_functionst::convert_native_rec(
     // initializer registers in `targets` are covered by convert_function's
     // snapshot/restore on a later fallback. Restore the initializer's
     // value-operand locations first, as the legacy body round-trip does.
+    // A top-level temporary_object is itself a side effect, so has_sideeffect
+    // already subsumes it (as the assign handler above relies on); only the
+    // side-effect-free top-level ternary needs the extra id() == "if" test.
     code_function_callt destructor;
     const bool needs_convert_decl =
       get_destructor(ns, s->get_type(), destructor) ||
       (initializer.is_not_nil() &&
-       (has_sideeffect(initializer) || initializer.id() == "if" ||
-        (initializer.id() == "sideeffect" &&
-         initializer.statement() == "temporary_object")));
+       (has_sideeffect(initializer) || initializer.id() == "if"));
     if (needs_convert_decl)
     {
       exprt op = migrate_expr_back(code2);

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -143,23 +143,6 @@ static void restore_value_locations(exprt &code, const locationt &inherited)
   }
 }
 
-// True if `expr` contains a temporary_object side effect anywhere. Lowering one
-// pushes scope-exit entries that die at the end of the full expression
-// (C++ [class.temporary]/4, github #6075/#6076) rather than at block exit, and
-// the native dispatcher does not yet reproduce that interaction with the
-// destructor stack -- see the code_expression2t handler.
-static bool has_temporary_object(const exprt &expr)
-{
-  if (expr.id() == "sideeffect" && expr.statement() == "temporary_object")
-    return true;
-
-  forall_operands (it, expr)
-    if (has_temporary_object(*it))
-      return true;
-
-  return false;
-}
-
 // The location restore_value_locations would propagate into `code`'s value
 // operands: the statement's own when it has one, otherwise whatever the
 // enclosing statement passed down. An empty result means that helper's
@@ -406,13 +389,6 @@ bool goto_convert_functionst::convert_native_rec(
     if (op.is_nil() || op.is_code() || op.id() == "if")
       return false;
 
-    // A temporary_object's scope-exit entries die at the end of the full
-    // expression, not at block exit, so lowering one here would need the
-    // destructor-stack interaction convert_decl/remove_sideeffects implement;
-    // until that is reproduced natively, fall back (C++ `g = use(T(a));`).
-    if (has_temporary_object(op))
-      return false;
-
     if (has_sideeffect(op))
     {
       // remove_sideeffects reads the location for each instruction it emits off
@@ -542,12 +518,18 @@ bool goto_convert_functionst::convert_native_rec(
     // A void function returning a value is a C/C++ constraint violation the
     // frontend rejects, so it never reaches here; only a valueless void return
     // does, which correctly emits just the end-of-function goto below.
-    // convert_return unwinds the destructor stack only when it holds a
-    // destructor FUNCTION_CALL, which cannot happen here: the decl handler
-    // falls back on any type with a destructor, so a native subtree's stack
-    // holds only scope-exit code_dead entries, which convert_return leaves
-    // alone; the enclosing block handler reproduces the (skipped) scope-exit
-    // behaviour via the trailing-goto guard above.
+    // convert_return runs an unwind-before-RETURN whenever the destructor stack
+    // holds a destructor FUNCTION_CALL (C++ [stmt.return]: locals are destroyed
+    // after the value is computed but before the jump; a constant value takes a
+    // simpler sub-path). This native handler reproduces only the plain
+    // (destructor-free) shape, so it must fall back the moment such an entry is
+    // present -- a full-expression temporary lowered by the code_expression2t
+    // handler pushes exactly this (its ~T call), which the decl handler's own
+    // destructor fallback does not cover.
+    for (const codet &d : targets.destructor_stack)
+      if (d.get_statement() == "function_call")
+        return false;
+
     exprt val = is_nil_expr(ret.operand) ? static_cast<exprt>(nil_exprt())
                                          : migrate_expr_back(ret.operand);
     if (


### PR DESCRIPTION
Part V / W1-loc Phase C (esbmc/esbmc#4715). Lets a declaration of a local **object** convert under `--irep2-native-body` instead of forcing a whole-function fallback.

The native `code_decl2t` handler reproduces only convert_decl's plain path (DECL + optional side-effect-free ASSIGN + a scope-exit `code_dead`); it fell back on a type with a destructor and on an initializer that needs lowering. Those two shapes are now delegated to the legacy `convert()`/`convert_decl`, which emits the DECL, lowers the initializer (a `temporary_object` constructing in place, a call returning by value, or any other side effect plus its full-expression temporary drain) and pushes the scope-exit entries — `code_dead` and, for a destructible type, the destructor `FUNCTION_CALL` — onto `targets.destructor_stack`, which the native block handler unwinds at scope exit exactly as `convert_block` does. The value is that the statements around a local object convert natively; a `T t; ... ; ~T` no longer drags its whole function back to `goto_convert_rec`.

Safety mirrors the cpp-throw/try-catch delegations: temps and any gotos/labels an initializer registers in `targets` are covered by `convert_function`'s snapshot/restore on a later fallback, and the initializer's value-operand locations are restored via `restore_value_locations` (which never touches the code node's own location) before delegating.

**Depends on #6290** (temporary_object). A function that *returns* while a destructor-local is still in scope (`T t; return t.v;`) leaves a destructor `FUNCTION_CALL` on the stack at the return; #6290's return handler falls back on exactly that, so such a function takes the legacy path unchanged. Without #6290 this slice would drop the destructor at the return (verified). Stacked on #6290 accordingly.

Verification (byte-identical `--goto-functions-only`, flag-on vs flag-off, measured at the tip of the stack):
- `regression/esbmc-cpp/cpp`: 582 identical; the 4 remaining mismatches are pre-existing (`cpp_sum_class`, `cpp_sum_class_bug`, `github_4397_cstdlib_namespace`, `ch19_1` = `__DATE__`/`__TIME__`).
- `regression/{esbmc,cbmc}`: 1628 / 0.
- C-Live: a marker confirms the delegation fires under the flag only.

Adds `github_4715_irep2_native_body_decl_dtor_01{,_fail}` (a void function whose local object and temporary-initialized local convert natively, both destructors observed at scope exit).
