### PR TITLE
[clang-cpp] Null-terminate the typeid type_info name string

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6308_typeid_name/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6308_typeid_name/main.cpp
@@ -1,0 +1,22 @@
+// github #6308: type_info::name() must return a null-terminated string, so C
+// string operations on it are well-defined. The name array was sized without a
+// slot for the terminating '\0', so strlen ran off the end.
+#include <cassert>
+#include <typeinfo>
+#include <cstring>
+
+struct A {};
+struct P { virtual ~P() {} };
+
+int main()
+{
+  assert(strlen(typeid(int).name()) > 0);
+  assert(strlen(typeid(A).name()) > 0);
+
+  P p;
+  assert(strlen(typeid(p).name()) > 0);
+
+  const char *n = typeid(double).name();
+  assert(n[0] != '\0'); // first byte readable, string non-empty
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6308_typeid_name/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6308_typeid_name/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6308_typeid_name_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6308_typeid_name_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative companion to github_6308_typeid_name: two distinct types have
+// distinct type_info, so asserting they are equal is violated.
+#include <cassert>
+#include <typeinfo>
+
+struct A {};
+struct B {};
+
+int main()
+{
+  assert(typeid(A) == typeid(B)); // wrong on purpose: distinct types
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6308_typeid_name_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6308_typeid_name_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1264,13 +1264,10 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       }
     }
 
-    exprt size = constant_exprt(
-      integer2binary(type_name.size(), bv_width(size_type())),
-      integer2string(type_name.size()),
-      size_type());
-
-    typet arr = array_typet(char_type(), size);
-    string_constantt string_name(type_name, arr, string_constantt::k_default);
+    // Size the array as type_name.size() + 1 so the stored string keeps its
+    // terminating '\0'; type_info::name() returns this pointer, and reading it
+    // as a C string (e.g. strlen) would otherwise run off the end (#6308).
+    string_constantt string_name(type_name);
 
     typet t;
     if (get_type(cxxtid.getType(), t))


### PR DESCRIPTION
Fixes #6308.

## Root cause

`std::type_info::name()` returned a string that was not null-terminated, so any
C string operation on it read past the end:

```cpp
assert(strlen(typeid(int).name()) > 0);   // spurious VERIFICATION FAILED
```

`CXXTypeidExprClass` built the name string constant with an array type sized
`type_name.size()` — no slot for the terminating `'\0'`. `name()` returns that
pointer, so `strlen` runs off the end. Normal string literals avoid this because
clang's `StringLiteral` type already includes the null terminator.

## Fix

Build the name with the size-aware `string_constantt(value)` constructor, which
sizes the backing array as `value.size() + 1` and null-terminates it (the same
representation a normal string literal gets). The `type_info` pointer-equality
that `operator==`/`operator!=` rely on is preserved (identical type names still
intern to the same address).

## Regression tests

- `cpp/github_6308_typeid_name` — `strlen(typeid(T).name()) > 0` for a builtin,
  a class, and a polymorphic object, plus reading the first byte
  (`VERIFICATION SUCCESSFUL`).
- `cpp/github_6308_typeid_name_fail` — asserting two distinct types compare
  equal, which is violated (`VERIFICATION FAILED`).

## Test suites

No regressions: the existing typeid tests (`cpp/typeinfo`,
`try_catch/typeid_null_deref`, `typeid_valid_deref`, `try-catch_typeid_01_bug`,
`vector/ch10_6`) and the full `try_catch` suite (151/151) pass.

## Note / follow-up

`typeid` on a *polymorphic glvalue* (`typeid(*p)`) still compares by the static
type name rather than the dynamic type, so `typeid(*p) == typeid(Derived)` is not
yet modelled. That is a separate, larger RTTI gap reported independently and out
of scope here.
