### PR TITLE
[cpp] Make std::map::count take a const key_type&

### DIFF
--- a/regression/esbmc-cpp/map/github_6313_count_temporary/main.cpp
+++ b/regression/esbmc-cpp/map/github_6313_count_temporary/main.cpp
@@ -1,0 +1,24 @@
+// github #6313: std::map::count must accept a temporary key and work on a const
+// map. The model declared count(key_type&) (non-const ref), so count(1) failed
+// to compile. It now matches the standard: count(const key_type&) const.
+#include <cassert>
+#include <map>
+
+int query(const std::map<int, int> &m, int k)
+{
+  return m.count(k); // count on a const map
+}
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  m[2] = 20;
+
+  assert(m.count(1) == 1);  // temporary key
+  assert(m.count(3) == 0);
+  assert(query(m, 2) == 1); // const map
+  m.erase(1);
+  assert(m.count(1) == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/map/github_6313_count_temporary/test.desc
+++ b/regression/esbmc-cpp/map/github_6313_count_temporary/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/github_6313_count_temporary_fail/main.cpp
+++ b/regression/esbmc-cpp/map/github_6313_count_temporary_fail/main.cpp
@@ -1,0 +1,12 @@
+// Negative companion to github_6313_count_temporary: key 1 is present, so
+// asserting count(1) == 0 is violated.
+#include <cassert>
+#include <map>
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  assert(m.count(1) == 0); // wrong on purpose: key 1 is present
+  return 0;
+}

--- a/regression/esbmc-cpp/map/github_6313_count_temporary_fail/test.desc
+++ b/regression/esbmc-cpp/map/github_6313_count_temporary_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -721,7 +721,7 @@ public:
     }
   }
 
-  size_type count(key_type &x)
+  size_type count(const key_type &x) const
   {
     if (this->_size != 0)
     {


### PR DESCRIPTION
Fixes #6313.

## Root cause

The bundled `<map>` operational model (`src/cpp/library/map`) declared
`std::map::count` as `size_type count(key_type &x)` — a non-const lvalue
reference and a non-const method. A non-const reference cannot bind to a
temporary, so `m.count(1)` (and `count` on a `const` map) failed to compile and
ESBMC reported a PARSING ERROR on valid C++:

```cpp
std::map<int,int> m; m[1] = 10;
return m.count(1);   // error: cannot bind 'int&' to a temporary
```

`m.count(k)` with an lvalue `k` happened to work, which hid the bug. The
standard signature is `size_type count(const key_type&) const`, which the
model's own `std::multimap`, `std::set`, and `std::multiset` already use.

## Fix

Change `std::map::count` to `size_type count(const key_type &x) const`. The body
only reads `this->_size`, `this->_key`, and `x`, so `const` is sound; it also
enables `count` on a const map.

## Regression tests

- `map/github_6313_count_temporary` — `count` with a temporary key, on a const
  map (via a `const&` parameter), and after `erase` (`VERIFICATION SUCCESSFUL`).
- `map/github_6313_count_temporary_fail` — asserting a present key has count 0,
  which is violated (`VERIFICATION FAILED`).

## Test suites

No regressions: `esbmc-cpp/bug_fixes` 105/105, `esbmc-cpp/set` 2/2,
`esbmc-cpp/multimap` 2/2, `esbmc-cpp/try_catch` 151/151, and the existing
THOROUGH `map/map_count` test all pass. A scan of the other container models
(`set`, `multimap`, `multiset`, `unordered_*`) found no other lookup method
with a non-const key reference — this was the only instance.
