### PR TITLE
[cpp] Add a const overload for std::map::at

### DIFF
--- a/regression/esbmc-cpp/map/github_6316_const_at/main.cpp
+++ b/regression/esbmc-cpp/map/github_6316_const_at/main.cpp
@@ -1,0 +1,29 @@
+// github #6316: std::map::at must be callable on a const map. The model only
+// declared the mutating overload, so at on a const map failed to compile. The
+// const overload returns the mapped value and throws std::out_of_range when the
+// key is absent, matching the standard and the vector::at model.
+#include <cassert>
+#include <map>
+#include <stdexcept>
+
+int lookup(const std::map<int, int> &m, int k)
+{
+  return m.at(k);
+}
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  m[2] = 20;
+
+  assert(lookup(m, 1) == 10);
+  assert(lookup(m, 2) == 20);
+
+  const std::map<int, int> &cm = m;
+  bool threw = false;
+  try { cm.at(99); }
+  catch (std::out_of_range &) { threw = true; }
+  assert(threw);
+  return 0;
+}

--- a/regression/esbmc-cpp/map/github_6316_const_at/test.desc
+++ b/regression/esbmc-cpp/map/github_6316_const_at/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/github_6316_const_at_fail/main.cpp
+++ b/regression/esbmc-cpp/map/github_6316_const_at_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative companion to github_6316_const_at: at returns the stored value (10),
+// so asserting a wrong value is violated.
+#include <cassert>
+#include <map>
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  const std::map<int, int> &cm = m;
+  assert(cm.at(1) == 42); // wrong on purpose: value is 10
+  return 0;
+}

--- a/regression/esbmc-cpp/map/github_6316_const_at_fail/test.desc
+++ b/regression/esbmc-cpp/map/github_6316_const_at_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -476,6 +476,20 @@ public:
     }
   }
 
+  // const overload: std::map::at performs no insertion and throws
+  // std::out_of_range when the key is absent ([map.access]). Required so
+  // `at` is usable on a const map / through a const reference.
+  const mapped_type &at(const Key &x) const
+  {
+    unsigned int s = this->_size;
+    for (unsigned int i = 0; i < s; i++)
+    {
+      if (this->_key[i] == x)
+        return this->_value[i];
+    }
+    throw std::out_of_range();
+  }
+
   bool empty() const
   {
     if (this->_size == 0)


### PR DESCRIPTION
Fixes #6316.

## Root cause

The bundled `<map>` operational model (`src/cpp/library/map`) declared only the
mutating overload `mapped_type &at(const Key&)`. A non-const method cannot be
called on a const object, so `at` on a `const` map (or through a `const`
reference) failed to compile and ESBMC reported a PARSING ERROR on valid C++:

```cpp
int lookup(const std::map<int,int> &m) { return m.at(1); }
# error: 'this' argument to member function 'at' has type
#        'const std::map<int, int>', but function is not marked const
```

## Fix

Add the standard `const` overload
`const mapped_type &at(const Key &x) const`: it searches for the key, returns
the mapped value, and `throw std::out_of_range()` when the key is absent
([map.access]). This mirrors the const/non-const `at` pair the `<vector>` model
already provides. The pre-existing non-const overload (and its behaviour) is
unchanged, so overload resolution is unaffected for non-const maps.

## Regression tests

- `map/github_6316_const_at` — `at` via a `const std::map&` for two keys, and an
  absent-key lookup that throws `std::out_of_range` and is caught
  (`VERIFICATION SUCCESSFUL`).
- `map/github_6316_const_at_fail` — asserting a wrong value from a const `at`,
  which is violated (`VERIFICATION FAILED`).

## Test suites

No regressions: `esbmc-cpp/map` 3/3, `esbmc-cpp/bug_fixes` 105/105,
`esbmc-cpp/try_catch` 151/151.

## Related / follow-up

`std::map::begin/end/rbegin/rend` also lack `const` overloads, and `std::set`'s
`const` `begin`/`end`/`find` overloads exist but do not compile (the iterator
model binds a `const` key array to a non-const pointer). Making the container
iterators const-correct is a larger change, reported and tracked separately.
