### PR TITLE
[cpp] Make std::set/std::multiset const iterators const-correct

### DIFF
--- a/regression/esbmc-cpp/set/github_6318_const_iteration/main.cpp
+++ b/regression/esbmc-cpp/set/github_6318_const_iteration/main.cpp
@@ -1,0 +1,49 @@
+// github #6318 (set/multiset part): const iteration over a std::set / std::multiset
+// must compile. The const begin/end/find/rbegin/rend overloads were declared but
+// did not compile because const_iterator/const_reverse_iterator held a non-const
+// element pointer. They now hold `const key_type*` and return const references,
+// so const iteration works and is truly read-only (mutation is rejected).
+#include <cassert>
+#include <set>
+
+int sum(const std::set<int> &s)
+{
+  int t = 0;
+  for (auto &x : s) // range-for over a const set
+    t += x;
+  return t;
+}
+
+bool has(const std::set<int> &s, int k)
+{
+  return s.find(k) != s.end(); // const find/end
+}
+
+int msize(const std::multiset<int> &s)
+{
+  int n = 0;
+  for (std::multiset<int>::const_iterator it = s.begin(); it != s.end(); ++it)
+    n++;
+  return n;
+}
+
+int main()
+{
+  std::set<int> s;
+  s.insert(1);
+  s.insert(2);
+  s.insert(3);
+  assert(sum(s) == 6);
+  assert(has(s, 2));
+  assert(!has(s, 9));
+  assert(*s.begin() == 1); // via non-const, still fine
+
+  const std::set<int> &cs = s;
+  assert(*cs.begin() == 1); // const begin deref
+
+  std::multiset<int> ms;
+  ms.insert(5);
+  ms.insert(5);
+  assert(msize(ms) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/set/github_6318_const_iteration/test.desc
+++ b/regression/esbmc-cpp/set/github_6318_const_iteration/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/set/github_6318_const_iteration_fail/main.cpp
+++ b/regression/esbmc-cpp/set/github_6318_const_iteration_fail/main.cpp
@@ -1,0 +1,22 @@
+// Negative companion to github_6318_const_iteration: the const set sums to 6,
+// so asserting a wrong total is violated.
+#include <cassert>
+#include <set>
+
+int sum(const std::set<int> &s)
+{
+  int t = 0;
+  for (auto &x : s)
+    t += x;
+  return t;
+}
+
+int main()
+{
+  std::set<int> s;
+  s.insert(1);
+  s.insert(2);
+  s.insert(3);
+  assert(sum(s) == 99); // wrong on purpose: sum is 6
+  return 0;
+}

--- a/regression/esbmc-cpp/set/github_6318_const_iteration_fail/test.desc
+++ b/regression/esbmc-cpp/set/github_6318_const_iteration_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -131,7 +131,7 @@ public:
   public:
   public:
     int pos;
-    key_type *base;
+    const key_type *base;
 
     const_iterator(const const_iterator &i)
     {
@@ -145,7 +145,7 @@ public:
       base = i.base;
     }
 
-    const_iterator(key_type *bbase, int ppos)
+    const_iterator(const key_type *bbase, int ppos)
     {
       __ESBMC_assert(bbase != NULL, "Invalid null pointer");
       pos = ppos;
@@ -162,12 +162,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    const value_type *operator->()
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    const value_type &operator*()
     {
       return base[pos];
     }
@@ -306,7 +306,7 @@ public:
   {
   public:
     int pos;
-    key_type *base;
+    const key_type *base;
 
     const_reverse_iterator(const const_reverse_iterator &i)
     {
@@ -314,7 +314,7 @@ public:
       base = i.base;
     }
 
-    const_reverse_iterator(key_type *bbase, int ppos)
+    const_reverse_iterator(const key_type *bbase, int ppos)
     {
       __ESBMC_assert(bbase != NULL, "Invalid null pointer");
       pos = ppos;
@@ -331,12 +331,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    const value_type *operator->()
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    const value_type &operator*()
     {
       return base[pos];
     }
@@ -847,7 +847,7 @@ public:
   public:
   public:
     int pos;
-    key_type *base;
+    const key_type *base;
 
     const_iterator(const const_iterator &i)
     {
@@ -861,7 +861,7 @@ public:
       base = i.base;
     }
 
-    const_iterator(key_type *bbase, int ppos)
+    const_iterator(const key_type *bbase, int ppos)
     {
       __ESBMC_assert(bbase != NULL, "Invalid null pointer");
       pos = ppos;
@@ -878,12 +878,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    const value_type *operator->()
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    const value_type &operator*()
     {
       return base[pos];
     }
@@ -1021,7 +1021,7 @@ public:
   {
   public:
     int pos;
-    key_type *base;
+    const key_type *base;
 
     const_reverse_iterator(const const_reverse_iterator &i)
     {
@@ -1029,7 +1029,7 @@ public:
       base = i.base;
     }
 
-    const_reverse_iterator(key_type *bbase, int ppos)
+    const_reverse_iterator(const key_type *bbase, int ppos)
     {
       __ESBMC_assert(bbase != NULL, "Invalid null pointer");
       pos = ppos;
@@ -1046,12 +1046,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    const value_type *operator->()
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    const value_type &operator*()
     {
       return base[pos];
     }


### PR DESCRIPTION
Addresses the `std::set` / `std::multiset` portion of #6318.

## Root cause

Const iteration over a `std::set` / `std::multiset` failed to compile:

```cpp
int sum(const std::set<int> &s) { int t=0; for (auto &x : s) t+=x; return t; }
# error: no matching constructor for 'const_iterator' /
#        assigning 'const int[500]' to 'int*'
# ERROR: PARSING ERROR
```

The bundled `<set>` model (`src/cpp/library/set`) *declared* const
`begin`/`end`/`find`/`rbegin`/`rend` returning a distinct `const_iterator` /
`const_reverse_iterator`, but those classes held a **non-const** `key_type*`
base, a non-const pointer constructor, and `operator*`/`operator->` returning
non-const references. So inside a const method — where `buf` is a
`const key_type[]` — they could neither be constructed nor legitimately expose
elements.

## Fix

Make `const_iterator` and `const_reverse_iterator` genuinely const-correct:
`base` becomes `const key_type*`, the pointer constructor takes
`const key_type*`, and `operator*`/`operator->` return `const value_type&` /
`const value_type*`. Applied identically to the `set` and `multiset`
definitions. No `const_cast` — this is the correct fix, not a compile-only
shortcut, so mutation through a const set is now rejected exactly as the
standard requires. The `const_iterator(const iterator&)` conversion still works
(a non-const element pointer binds to a const one).

## Regression tests

- `set/github_6318_const_iteration` — range-for over a const `set`, const
  `find`/`end`, const `begin` deref, and a `const_iterator` loop over a const
  `multiset` (`VERIFICATION SUCCESSFUL`).
- `set/github_6318_const_iteration_fail` — asserting a wrong sum over a const
  set, which is violated (`VERIFICATION FAILED`).

## Test suites

No regressions: `esbmc-cpp/set` 2/2, `esbmc-cpp/multiset` 3/3, `esbmc-cpp/map`
3/3, `esbmc-cpp/bug_fixes` 105/105. Behaviour cross-checked against clang++:
const range-for/find/begin over set and multiset verify, and mutating a const
set through the iterator is rejected by both ESBMC and clang.

## Scope / remaining

This resolves const iteration for `std::set`/`std::multiset`. `std::map`'s
`begin`/`end`/`rbegin`/`rend` still lack const overloads entirely (a structurally
different iterator that stores parallel key/value pointers); that remains tracked
under #6318 and is left for a separate change.
