### PR TITLE
[cpp] Add const forward and reverse iteration for std::map/std::multimap

### DIFF
--- a/regression/esbmc-cpp/map/github_6318_map_const_iteration/main.cpp
+++ b/regression/esbmc-cpp/map/github_6318_map_const_iteration/main.cpp
@@ -42,6 +42,15 @@ int main()
   assert(cm.find(1) != cm.end()); // const find/end
   assert(cm.find(9) == cm.end());
 
+  // const reverse iteration
+  int rsum = 0;
+  for (std::map<int, int>::const_reverse_iterator it = cm.rbegin();
+       it != cm.rend();
+       ++it)
+    rsum += it->first;
+  assert(rsum == 3);
+  assert(cm.rbegin()->first == 2); // largest key
+
   std::multimap<int, int> mm;
   mm.insert({1, 10});
   mm.insert({1, 20});

--- a/regression/esbmc-cpp/map/github_6318_map_const_iteration/main.cpp
+++ b/regression/esbmc-cpp/map/github_6318_map_const_iteration/main.cpp
@@ -1,0 +1,50 @@
+// github #6318 (map part): const forward iteration over a std::map / std::multimap
+// must compile. const_iterator was a typedef of the mutable iterator (non-const
+// key/value pointers), and there were no const begin()/end() overloads. Add a
+// distinct const_iterator (const element pointers, const-returning operator*/->)
+// and const begin()/end(), so const iteration works and is truly read-only.
+#include <cassert>
+#include <map>
+
+int sum_values(const std::map<int, int> &m)
+{
+  int t = 0;
+  for (auto &kv : m) // range-for over a const map
+    t += kv.second;
+  return t;
+}
+
+int sum_keys(const std::map<int, int> &m)
+{
+  int s = 0;
+  for (std::map<int, int>::const_iterator it = m.begin(); it != m.end(); ++it)
+    s += it->first;
+  return s;
+}
+
+int mm_count(const std::multimap<int, int> &m)
+{
+  int n = 0;
+  for (auto &kv : m)
+    n++;
+  return n;
+}
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  m[2] = 20;
+  assert(sum_values(m) == 30);
+  assert(sum_keys(m) == 3);
+
+  const std::map<int, int> &cm = m;
+  assert(cm.find(1) != cm.end()); // const find/end
+  assert(cm.find(9) == cm.end());
+
+  std::multimap<int, int> mm;
+  mm.insert({1, 10});
+  mm.insert({1, 20});
+  assert(mm_count(mm) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/map/github_6318_map_const_iteration/test.desc
+++ b/regression/esbmc-cpp/map/github_6318_map_const_iteration/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/github_6318_map_const_iteration_fail/main.cpp
+++ b/regression/esbmc-cpp/map/github_6318_map_const_iteration_fail/main.cpp
@@ -1,0 +1,21 @@
+// Negative companion to github_6318_map_const_iteration: the const map's values
+// sum to 30, so asserting a wrong total is violated.
+#include <cassert>
+#include <map>
+
+int sum_values(const std::map<int, int> &m)
+{
+  int t = 0;
+  for (auto &kv : m)
+    t += kv.second;
+  return t;
+}
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  m[2] = 20;
+  assert(sum_values(m) == 99); // wrong on purpose: sum is 30
+  return 0;
+}

--- a/regression/esbmc-cpp/map/github_6318_map_const_iteration_fail/test.desc
+++ b/regression/esbmc-cpp/map/github_6318_map_const_iteration_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -367,6 +367,150 @@ public:
     }
   };
 
+  class const_reverse_iterator
+  {
+  public:
+    const key_type *it_key;
+    const mapped_type *it_value;
+    value_type it_pair;
+    int it_pos;
+    const int *it_size;
+
+    const_reverse_iterator(const const_reverse_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      this->it_size = x.it_size;
+    }
+    // Convert a (mutable) reverse_iterator to a const_reverse_iterator.
+    const_reverse_iterator(const reverse_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      this->it_size = x.it_size;
+    }
+    const_reverse_iterator()
+    {
+      this->it_pos = -1;
+    }
+    const_reverse_iterator &operator=(const const_reverse_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      this->it_size = x.it_size;
+      return *this;
+    }
+
+    const value_type *operator->()
+    {
+      return &(this->it_pair);
+    }
+
+    const value_type &operator*()
+    {
+      return this->it_pair;
+    }
+
+    const_reverse_iterator &operator++()
+    {
+      if (this->it_pos == 0)
+      {
+        this->it_pos--;
+        this->it_pair.first = Key();
+        this->it_pair.second = T();
+        return *this;
+      }
+      if (this->it_pos == -1)
+      {
+        this->it_pos = *(this->it_size) - 1;
+      }
+      else
+      {
+        this->it_pos--;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_reverse_iterator operator++(int)
+    {
+      if (this->it_pos == 0)
+      {
+        this->it_pos--;
+        this->it_pair.first = Key();
+        this->it_pair.second = T();
+        return *this;
+      }
+      if (this->it_pos == -1)
+      {
+        this->it_pos = *(this->it_size) - 1;
+      }
+      else
+      {
+        this->it_pos--;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    const_reverse_iterator &operator--()
+    {
+      if (this->it_pos == *(this->it_size))
+      {
+        this->it_pos = 0;
+      }
+      else
+      {
+        this->it_pos++;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_reverse_iterator operator--(int)
+    {
+      if (this->it_pos == *(this->it_size))
+      {
+        this->it_pos = 0;
+      }
+      else
+      {
+        this->it_pos++;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    bool operator==(const const_reverse_iterator &it) const
+    {
+      if (this->it_pos == it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first == it.it_pair.first) &&
+        (this->it_pair.second == it.it_pair.second))
+        return true;
+      return false;
+    }
+    bool operator!=(const const_reverse_iterator &it) const
+    {
+      if (this->it_pos != it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first != it.it_pair.first) &&
+        (this->it_pair.second != it.it_pair.second))
+        return true;
+      return false;
+    }
+  };
+
   map()
   {
     this->_size = 0;
@@ -532,6 +676,28 @@ public:
   reverse_iterator rend()
   {
     reverse_iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_size = &(this->_size);
+    it.it_pos = -1;
+    it.it_pair.first = Key();
+    it.it_pair.second = T();
+    return it;
+  }
+  const_reverse_iterator rbegin() const
+  {
+    const_reverse_iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_size = &(this->_size);
+    it.it_pos = this->_size - 1;
+    it.it_pair.first = this->_key[it.it_pos];
+    it.it_pair.second = this->_value[it.it_pos];
+    return it;
+  }
+  const_reverse_iterator rend() const
+  {
+    const_reverse_iterator it;
     it.it_key = this->_key;
     it.it_value = this->_value;
     it.it_size = &(this->_size);
@@ -879,9 +1045,9 @@ public:
     return end_it;
   }
 
-  // const_iterator is a typedef for iterator in this model, so the const
-  // overload the standard requires (github #6063) delegates to the
-  // non-const one; find never writes through the backing arrays.
+  // The const overload the standard requires (github #6063) delegates to the
+  // non-const find (which never writes through the backing arrays); its
+  // iterator result converts to const_iterator via the converting constructor.
   const_iterator find(const key_type &x) const
   {
     return const_cast<map *>(this)->find(x);
@@ -1338,6 +1504,150 @@ public:
     }
   };
 
+  class const_reverse_iterator
+  {
+  public:
+    const key_type *it_key;
+    const mapped_type *it_value;
+    value_type it_pair;
+    int it_pos;
+    const int *it_size;
+
+    const_reverse_iterator(const const_reverse_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      this->it_size = x.it_size;
+    }
+    // Convert a (mutable) reverse_iterator to a const_reverse_iterator.
+    const_reverse_iterator(const reverse_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      this->it_size = x.it_size;
+    }
+    const_reverse_iterator()
+    {
+      this->it_pos = -1;
+    }
+    const_reverse_iterator &operator=(const const_reverse_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      this->it_size = x.it_size;
+      return *this;
+    }
+
+    const value_type *operator->()
+    {
+      return &(this->it_pair);
+    }
+
+    const value_type &operator*()
+    {
+      return this->it_pair;
+    }
+
+    const_reverse_iterator &operator++()
+    {
+      if (this->it_pos == 0)
+      {
+        this->it_pos--;
+        this->it_pair.first = Key();
+        this->it_pair.second = T();
+        return *this;
+      }
+      if (this->it_pos == -1)
+      {
+        this->it_pos = *(this->it_size) - 1;
+      }
+      else
+      {
+        this->it_pos--;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_reverse_iterator operator++(int)
+    {
+      if (this->it_pos == 0)
+      {
+        this->it_pos--;
+        this->it_pair.first = Key();
+        this->it_pair.second = T();
+        return *this;
+      }
+      if (this->it_pos == -1)
+      {
+        this->it_pos = *(this->it_size) - 1;
+      }
+      else
+      {
+        this->it_pos--;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    const_reverse_iterator &operator--()
+    {
+      if (this->it_pos == *(this->it_size))
+      {
+        this->it_pos = 0;
+      }
+      else
+      {
+        this->it_pos++;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_reverse_iterator operator--(int)
+    {
+      if (this->it_pos == *(this->it_size))
+      {
+        this->it_pos = 0;
+      }
+      else
+      {
+        this->it_pos++;
+      }
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    bool operator==(const const_reverse_iterator &it) const
+    {
+      if (this->it_pos == it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first == it.it_pair.first) &&
+        (this->it_pair.second == it.it_pair.second))
+        return true;
+      return false;
+    }
+    bool operator!=(const const_reverse_iterator &it) const
+    {
+      if (this->it_pos != it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first != it.it_pair.first) &&
+        (this->it_pair.second != it.it_pair.second))
+        return true;
+      return false;
+    }
+  };
+
   explicit multimap(const key_compare &comp = key_compare())
   {
     this->_size = 0;
@@ -1578,6 +1888,28 @@ public:
   reverse_iterator rend()
   {
     reverse_iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_size = &(this->_size);
+    it.it_pos = -1;
+    it.it_pair.first = Key();
+    it.it_pair.second = T();
+    return it;
+  }
+  const_reverse_iterator rbegin() const
+  {
+    const_reverse_iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_size = &(this->_size);
+    it.it_pos = this->_size - 1;
+    it.it_pair.first = this->_key[it.it_pos];
+    it.it_pair.second = this->_value[it.it_pos];
+    return it;
+  }
+  const_reverse_iterator rend() const
+  {
+    const_reverse_iterator it;
     it.it_key = this->_key;
     it.it_value = this->_value;
     it.it_size = &(this->_size);

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -134,7 +134,103 @@ public:
     }
   };
 
-  typedef iterator const_iterator;
+  class const_iterator
+  {
+  public:
+    const key_type *it_key;
+    const mapped_type *it_value;
+    value_type it_pair;
+    int it_pos;
+
+    const_iterator(const const_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+    }
+    // Convert a (mutable) iterator to a const_iterator.
+    const_iterator(const iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+    }
+    const_iterator()
+    {
+      this->it_pos = -1;
+    }
+    const_iterator &operator=(const const_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      return *this;
+    }
+
+    const value_type *operator->()
+    {
+      return &(this->it_pair);
+    }
+
+    const value_type &operator*()
+    {
+      return this->it_pair;
+    }
+
+    const_iterator &operator++()
+    {
+      this->it_pos++;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_iterator operator++(int)
+    {
+      this->it_pos++;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    const_iterator &operator--()
+    {
+      this->it_pos--;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_iterator operator--(int)
+    {
+      this->it_pos--;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    bool operator==(const const_iterator &it) const
+    {
+      if (this->it_pos == it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first == it.it_pair.first) &&
+        (this->it_pair.second == it.it_pair.second))
+        return true;
+      return false;
+    }
+    bool operator!=(const const_iterator &it) const
+    {
+      if (this->it_pos != it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first != it.it_pair.first) &&
+        (this->it_pair.second != it.it_pair.second))
+        return true;
+      return false;
+    }
+  };
 
   class reverse_iterator
   {
@@ -395,6 +491,26 @@ public:
   iterator end()
   {
     iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_pos = this->_size;
+    it.it_pair.first = this->_key[it.it_pos];
+    it.it_pair.second = this->_value[it.it_pos];
+    return it;
+  }
+  const_iterator begin() const
+  {
+    const_iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_pos = 0;
+    it.it_pair.first = this->_key[0];
+    it.it_pair.second = this->_value[0];
+    return it;
+  }
+  const_iterator end() const
+  {
+    const_iterator it;
     it.it_key = this->_key;
     it.it_value = this->_value;
     it.it_pos = this->_size;
@@ -989,7 +1105,103 @@ public:
     }
   };
 
-  typedef iterator const_iterator;
+  class const_iterator
+  {
+  public:
+    const key_type *it_key;
+    const mapped_type *it_value;
+    value_type it_pair;
+    int it_pos;
+
+    const_iterator(const const_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+    }
+    // Convert a (mutable) iterator to a const_iterator.
+    const_iterator(const iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+    }
+    const_iterator()
+    {
+      this->it_pos = -1;
+    }
+    const_iterator &operator=(const const_iterator &x)
+    {
+      this->it_key = x.it_key;
+      this->it_pos = x.it_pos;
+      this->it_value = x.it_value;
+      this->it_pair = x.it_pair;
+      return *this;
+    }
+
+    const value_type *operator->()
+    {
+      return &(this->it_pair);
+    }
+
+    const value_type &operator*()
+    {
+      return this->it_pair;
+    }
+
+    const_iterator &operator++()
+    {
+      this->it_pos++;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_iterator operator++(int)
+    {
+      this->it_pos++;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    const_iterator &operator--()
+    {
+      this->it_pos--;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+    const_iterator operator--(int)
+    {
+      this->it_pos--;
+      this->it_pair.first = this->it_key[this->it_pos];
+      this->it_pair.second = this->it_value[this->it_pos];
+      return *this;
+    }
+
+    bool operator==(const const_iterator &it) const
+    {
+      if (this->it_pos == it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first == it.it_pair.first) &&
+        (this->it_pair.second == it.it_pair.second))
+        return true;
+      return false;
+    }
+    bool operator!=(const const_iterator &it) const
+    {
+      if (this->it_pos != it.it_pos)
+        return true;
+      if (
+        (this->it_pair.first != it.it_pair.first) &&
+        (this->it_pair.second != it.it_pair.second))
+        return true;
+      return false;
+    }
+  };
 
   class reverse_iterator
   {
@@ -1324,6 +1536,26 @@ public:
   iterator end()
   {
     iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_pos = this->_size;
+    it.it_pair.first = this->_key[it.it_pos];
+    it.it_pair.second = this->_value[it.it_pos];
+    return it;
+  }
+  const_iterator begin() const
+  {
+    const_iterator it;
+    it.it_key = this->_key;
+    it.it_value = this->_value;
+    it.it_pos = 0;
+    it.it_pair.first = this->_key[0];
+    it.it_pair.second = this->_value[0];
+    return it;
+  }
+  const_iterator end() const
+  {
+    const_iterator it;
     it.it_key = this->_key;
     it.it_value = this->_value;
     it.it_pos = this->_size;


### PR DESCRIPTION
Completes the `std::map` / `std::multimap` const-iteration part of #6318
(the `std::set` / `std::multiset` part is #6321). Together they fully close #6318.

## Root cause

Iterating a `const std::map` / `const std::multimap` — forward or reverse —
failed to compile:

```cpp
int sum(const std::map<int,int>& m){int t=0;for(auto&kv:m)t+=kv.second;return t;}
# ERROR: PARSING ERROR ('begin'/'end' not marked const)
```

`const_iterator` was `typedef iterator` (the *mutable* iterator, with non-const
`it_key`/`it_value`), there were no const `begin()/end()`, and no
`const_reverse_iterator` or const `rbegin()/rend()` at all.

## Fix

- A distinct `const_iterator`: `const key_type*` / `const mapped_type*` element
  pointers, `operator*`/`operator->` returning `const value_type&` /
  `const value_type*`, and an `iterator`→`const_iterator` converting constructor.
- A distinct `const_reverse_iterator` (same, plus a `const int*` size pointer and
  a `reverse_iterator`→`const_reverse_iterator` converting constructor).
- Const `begin()/end()` and `rbegin()/rend()` that build these directly (in a
  const method the buffers and size are `const`, so no `const_cast` is needed).

Applied identically to the `map` and `multimap` definitions. The pre-existing
const `find` still works via the converting constructor (its stale comment is
refreshed). Const iteration is now **truly** read-only — mutating a const map
through a forward or reverse iterator is rejected, matching the standard.

## Regression tests

- `map/github_6318_map_const_iteration` — const range-for, a `const_iterator`
  loop, const `find`/`end`, const **reverse** iteration
  (`const_reverse_iterator` + `rbegin`/`rend`), and const iteration over a
  `multimap` (`VERIFICATION SUCCESSFUL`).
- `map/github_6318_map_const_iteration_fail` — asserting a wrong value sum over a
  const map, which is violated (`VERIFICATION FAILED`).

## Test suites

No regressions: `esbmc-cpp/map` 5/5, `esbmc-cpp/multimap` 2/2,
`esbmc-cpp/bug_fixes` 105/105. Cross-checked against clang++: const forward and
reverse iteration over map and multimap verify, and mutating a const map through
either iterator is rejected by both ESBMC and clang.
