### PR TITLE
[python] Build pointer-source index arithmetic natively in IREP2

### DIFF
--- a/regression/numpy/index_param_pointer/main.py
+++ b/regression/numpy/index_param_pointer/main.py
@@ -1,0 +1,17 @@
+# Indexing a numpy-array function parameter: the parameter decays to a pointer
+# to its element type, so `a[i]` lowers to `*(a + i)` (pointer arithmetic) built
+# natively in IREP2 (add2t over a pointer lhs) rather than a direct array index.
+import numpy as np
+
+
+def first(a) -> int:
+    return a[0]
+
+
+def third(a) -> int:
+    return a[2]
+
+
+d = np.array([7, 8, 9])
+assert first(d) == 7
+assert third(d) == 9

--- a/regression/numpy/index_param_pointer/test.desc
+++ b/regression/numpy/index_param_pointer/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/index_param_pointer_fail/main.py
+++ b/regression/numpy/index_param_pointer_fail/main.py
@@ -1,0 +1,17 @@
+# Indexing a numpy-array function parameter: the parameter decays to a pointer
+# to its element type, so `a[i]` lowers to `*(a + i)` (pointer arithmetic) built
+# natively in IREP2 (add2t over a pointer lhs) rather than a direct array index.
+import numpy as np
+
+
+def first(a) -> int:
+    return a[0]
+
+
+def third(a) -> int:
+    return a[2]
+
+
+d = np.array([7, 8, 9])
+assert first(d) == 7
+assert third(d) == 0  # must fail

--- a/regression/numpy/index_param_pointer_fail/test.desc
+++ b/regression/numpy/index_param_pointer_fail/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -121,11 +121,14 @@ exprt build_index(const exprt &arr, const exprt &idx, const typet &t)
   // A pointer source (e.g. a numpy-array function parameter, decayed the
   // same way a C array parameter decays to a pointer to its element type)
   // indexes like plain C pointer arithmetic: `arr[idx]` is `*(arr + idx)`,
-  // not a direct array index over the pointer itself.
+  // not a direct array index over the pointer itself. Build the `arr + idx`
+  // natively in IREP2: add2t over a pointer lhs is exactly the round-trip of
+  // the legacy plus_exprt whose result type was the pointer type (the pointer
+  // operand short-circuits the mismatched-width consistency check, so no
+  // reconciliation is needed).
   if (is_pointer_type(arr2->type))
   {
-    plus_exprt ptr_plus_idx(arr, idx);
-    ptr_plus_idx.type() = arr.type();
+    exprt ptr_plus_idx = migrate_expr_back(add2tc(arr2->type, arr2, idx2));
     return build_dereference(ptr_plus_idx, t);
   }
   return index_exprt(arr, idx, t);


### PR DESCRIPTION
Part V / `scope-v1k-adjuster.md` Goal A (converter-construction 100%, esbmc/esbmc#4715). Drains the **last legacy-arith construction site** in the Python converter.

`build_index` (`python_expr_builder.cpp`) handles indexing a pointer-typed source — a numpy-array function parameter that decays to a pointer to its element type, so `a[i]` is `*(a + i)` (pointer arithmetic), not a direct array index. That `a + i` was the one remaining site still built with a legacy `plus_exprt`; everything around it (the array/symbol `index2t` paths, `build_add`, `build_sub`, the comparison/bool builders) is already IREP2-native.

It now builds `add2tc(arr2->type, arr2, idx2)` and back-migrates — the byte-identical round-trip of the legacy `plus_exprt(arr, idx)` whose result type was the pointer type. No width reconciliation is needed: `add2t`'s mismatched-width consistency check (`irep2_expr.cpp:assert_arith_2ops_consistency`) short-circuits on the pointer operand (`p1 || …`), so `pointer + int` is accepted directly. This mirrors the existing `build_add` helper in the same file.

Verification:
- **Byte-identical** `--goto-functions-only` (master vs this change) across the full **numpy suite: 576 / 576 identical** (after normalizing the per-run `esbmc-python-astgen-<hash>` temp path, its `__file__` byte-array encoding, and `ESBMC_unpack_temp_<addr>` names).
- **C-Live**: a temporary marker confirmed the pointer-index branch fires (9× on `def first(a): return a[0]` with a numpy array passed); byte-identical on that probe too.
- Adds `regression/numpy/index_param_pointer{,_fail}` (indexing a numpy-array parameter), verifying SUCCESSFUL / FAILED.

With this, the Python converter's expression construction has no legacy `*_exprt` arithmetic left at the returned seam.
