### PR TITLE
[cpp] Add const overloads for std::list front/back/rbegin/rend

### DIFF
--- a/regression/esbmc-cpp/list/github_6327_const_access/main.cpp
+++ b/regression/esbmc-cpp/list/github_6327_const_access/main.cpp
@@ -1,0 +1,34 @@
+// github #6327: std::list front/back/rbegin/rend must be callable on a const
+// list. The model declared only their mutating overloads, so const access
+// failed to compile. Const overloads are added (front/back return a const
+// reference; rbegin/rend mirror the existing const begin()/end()).
+#include <cassert>
+#include <list>
+
+int endpoints(const std::list<int> &l)
+{
+  return l.front() + l.back();
+}
+
+int rsum(const std::list<int> &l)
+{
+  int s = 0;
+  for (std::list<int>::const_reverse_iterator it = l.rbegin(); it != l.rend();
+       ++it)
+    s += *it;
+  return s;
+}
+
+int main()
+{
+  std::list<int> l;
+  l.push_back(1);
+  l.push_back(2);
+  l.push_back(3);
+
+  const std::list<int> &cl = l;
+  assert(endpoints(cl) == 4); // front 1 + back 3
+  assert(*cl.rbegin() == 3);  // last element
+  assert(rsum(cl) == 6);      // reverse traversal
+  return 0;
+}

--- a/regression/esbmc-cpp/list/github_6327_const_access/test.desc
+++ b/regression/esbmc-cpp/list/github_6327_const_access/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/github_6327_const_access_fail/main.cpp
+++ b/regression/esbmc-cpp/list/github_6327_const_access_fail/main.cpp
@@ -1,0 +1,14 @@
+// Negative companion to github_6327_const_access: front() of the const list is
+// 1, so asserting a wrong value is violated.
+#include <cassert>
+#include <list>
+
+int main()
+{
+  std::list<int> l;
+  l.push_back(1);
+  l.push_back(2);
+  const std::list<int> &cl = l;
+  assert(cl.front() == 42); // wrong on purpose: front is 1
+  return 0;
+}

--- a/regression/esbmc-cpp/list/github_6327_const_access_fail/test.desc
+++ b/regression/esbmc-cpp/list/github_6327_const_access_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -362,6 +362,24 @@ public:
     return reverse_iterator(this, SENTINEL);
   }
 
+  // Const overloads, matching the const begin()/end() pattern above: the
+  // node-based iterator keeps a non-const owner to resolve the sentinel
+  // boundary; cast away const on the receiver, the iterator does not mutate.
+  const_reverse_iterator rbegin() const
+  {
+    const_reverse_iterator it;
+    it.owner = const_cast<list<T> *>(this);
+    it.idx = _sentinel_prev;
+    return it;
+  }
+  const_reverse_iterator rend() const
+  {
+    const_reverse_iterator it;
+    it.owner = const_cast<list<T> *>(this);
+    it.idx = SENTINEL;
+    return it;
+  }
+
   size_type size() const
   {
     return _size;
@@ -381,8 +399,16 @@ public:
   {
     return _pool[_sentinel_next].data;
   }
+  const_reference front() const
+  {
+    return _pool[_sentinel_next].data;
+  }
 
   reference back()
+  {
+    return _pool[_sentinel_prev].data;
+  }
+  const_reference back() const
   {
     return _pool[_sentinel_prev].data;
   }


### PR DESCRIPTION
Fixes #6327.

## Root cause

`std::list::front`, `back`, `rbegin`, and `rend` had no `const` overload in the
bundled `<list>` model, so calling them on a `const` list (or through a `const`
reference) failed to compile:

```cpp
int f(const std::list<int>& l) { return l.front() + l.back(); }
# error: 'this' argument to member function 'front' has type
#        'const std::list<int>', but function is not marked const
# ERROR: PARSING ERROR
```

`src/cpp/library/list` declared these four accessors only in mutating form
(`begin`/`end`/`size`/`empty` already had const overloads).

## Fix

- `front`/`back`: add `const_reference front() const` / `back() const` returning
  the element (`_pool[_sentinel_next/_prev].data`) by const reference; the
  bodies are read-only.
- `rbegin`/`rend`: add `const_reverse_iterator` overloads mirroring the model's
  existing `const begin()/end()` — build the iterator, set `owner` (const-cast
  away on the receiver, as the node iterator keeps a non-const owner to resolve
  the sentinel boundary and never mutates the list) and `idx` (`_sentinel_prev`
  / `SENTINEL`, the same values the non-const `rbegin`/`rend` use).

The non-const overloads are unchanged, so overload resolution for a mutable list
is unaffected (e.g. `l.front() = 10` still works).

## Regression tests

- `list/github_6327_const_access` — `front`/`back` and a reverse traversal
  (`const_reverse_iterator` + `rbegin`/`rend`) over a `const std::list`
  (`VERIFICATION SUCCESSFUL`).
- `list/github_6327_const_access_fail` — asserting a wrong `front()` value on a
  const list, which is violated (`VERIFICATION FAILED`).

## Test suites

No regressions: `esbmc-cpp/list` 7/7, `esbmc-cpp/bug_fixes` 105/105,
`esbmc-cpp/try_catch` 151/151. Cross-checked against clang++.

## Related

Sequence-container audit: `std::vector`/`std::deque` already have const
`front`/`back`; `std::forward_list` is not modelled. `std::list`'s `cbegin`/
`cend` (C++11) are still absent — a minor separate addition. Making list's const
iterators *truly* const-correct (a distinct `const_iterator`, as done for
`std::map`/`std::set` in #6321/#6322) is a separate larger change; this PR
matches list's existing const-iteration approach.
