### PR TITLE
[cpp] Add std::vector::data()

### DIFF
--- a/regression/esbmc-cpp/vector/github_6330_data/main.cpp
+++ b/regression/esbmc-cpp/vector/github_6330_data/main.cpp
@@ -1,0 +1,24 @@
+// github #6330: std::vector::data() ([vector.data], C++11) returns a pointer to
+// the contiguous storage. It was missing from the model. data() and its const
+// overload return the underlying buffer, so reads/writes alias the vector.
+#include <cassert>
+#include <vector>
+
+int first(const std::vector<int> &v)
+{
+  return v.data()[0]; // const data()
+}
+
+int main()
+{
+  std::vector<int> v = {1, 2, 3};
+
+  int *p = v.data();
+  assert(p[0] == 1 && p[2] == 3);
+
+  p[1] = 9; // write through data() aliases the vector
+  assert(v[1] == 9);
+
+  assert(first(v) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/github_6330_data/test.desc
+++ b/regression/esbmc-cpp/vector/github_6330_data/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/github_6330_data_fail/main.cpp
+++ b/regression/esbmc-cpp/vector/github_6330_data_fail/main.cpp
@@ -1,0 +1,11 @@
+// Negative companion to github_6330_data: data()[0] is 1, so asserting a wrong
+// value is violated.
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v = {1, 2, 3};
+  assert(v.data()[0] == 42); // wrong on purpose: it is 1
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/github_6330_data_fail/test.desc
+++ b/regression/esbmc-cpp/vector/github_6330_data_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -728,6 +728,16 @@ public:
     return buf[_size - 1];
   }
 
+  // Direct access to the underlying contiguous storage ([vector.data]).
+  pointer data()
+  {
+    return buf;
+  }
+  const_pointer data() const
+  {
+    return buf;
+  }
+
   // modifiers:
 
   void push_back(const T &x)


### PR DESCRIPTION
Fixes #6330.

## Root cause

`std::vector::data()` ([vector.data], since C++11) was missing from the bundled
`<vector>` model, so any use failed to compile:

```cpp
std::vector<int> v = {1,2,3}; int *p = v.data();
# error: no member named 'data' in 'std::vector<int>'
# ERROR: PARSING ERROR
```

`src/cpp/library/vector` stores its elements in a contiguous heap buffer `buf`
(a `T*`) that `front()`/`back()`/`operator[]` already index, but exposed no
`data()` accessor.

## Fix

Add `pointer data()` and `const_pointer data() const`, both returning `buf`.
Because they return the vector's own storage, reads and writes through the
returned pointer alias the vector, matching the standard.

## Regression tests

- `vector/github_6330_data` — reading via `data()`, writing through it (and
  observing the change in the vector), and const `data()` through a const
  reference (`VERIFICATION SUCCESSFUL`).
- `vector/github_6330_data_fail` — asserting a wrong `data()[0]` value, which is
  violated (`VERIFICATION FAILED`).

## Test suites

No regressions: `esbmc-cpp/vector` 10/10, `esbmc-cpp/bug_fixes` 105/105.
Behaviour cross-checked against clang++ for read, write-through, const access,
and a single-element vector.
