### PR TITLE
[cpp] Make std::string::substr(pos, n) const

### DIFF
--- a/regression/esbmc-cpp/string/string_substr_const/main.cpp
+++ b/regression/esbmc-cpp/string/string_substr_const/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+#include <string>
+
+static std::string tail(const std::string &s)
+{
+  return s.substr(1, 3);
+}
+
+int main()
+{
+  const std::string s = "hello";
+  assert(tail(s) == "ell");
+  assert(s.substr(2) == "llo");
+  return 0;
+}

--- a/regression/esbmc-cpp/string/string_substr_const/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_const/test.desc
@@ -2,4 +2,3 @@ CORE
 main.cpp
 --std=c++17 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-^EXIT=0$

--- a/regression/esbmc-cpp/string/string_substr_const/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_const/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$

--- a/regression/esbmc-cpp/string/string_substr_const_fail/main.cpp
+++ b/regression/esbmc-cpp/string/string_substr_const_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+#include <string>
+
+static std::string tail(const std::string &s)
+{
+  return s.substr(1, 3);
+}
+
+int main()
+{
+  const std::string s = "hello";
+  assert(tail(s) == "xxx");
+  return 0;
+}

--- a/regression/esbmc-cpp/string/string_substr_const_fail/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_const_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1025,7 +1025,7 @@ public:
   size_t copy(char *s, size_t n, size_t pos = 0) const;
   const char *data() const;
 
-  basic_string<CharT, Traits, Alloc> substr(size_t pos, size_t n)
+  basic_string<CharT, Traits, Alloc> substr(size_t pos, size_t n) const
   {
   __ESBMC_HIDE:
     __ESBMC_assert(pos >= 0, "The first parameter must be greater than zero");


### PR DESCRIPTION
## Root cause

The bundled `<string>` operational model (`src/cpp/library/string`) declares two
`substr` overloads:

- `basic_string substr(size_t pos, size_t n)` — **non-const**
- `basic_string substr(size_t pos) const`

Calling `s.substr(pos, n)` on a `const` string (or through a `const` reference)
matches neither: the two-argument form is not const (so `this` cannot bind), and
the one-argument const form requires a single argument. Clang reports "no matching
member function for call to 'substr'" and ESBMC returns `PARSING ERROR`. The
standard `substr` is a single const member (`substr(size_type pos = 0, size_type n = npos) const`).

```cpp
bool f(const std::string& s) { return s.substr(1, 3) == "ell"; } // PARSING ERROR
```

## Fix

Mark the two-argument `substr(size_t pos, size_t n)` `const`. Its body only reads
`length()` and `str[i]` and returns a freshly constructed string, so `const` is
sound. This mirrors the existing const one-argument overload and the standard.

## Tests

- `regression/esbmc-cpp/string/string_substr_const` — const string `substr(1,3)`
  and `substr(2)` verify SUCCESSFUL (previously a parse error).
- `regression/esbmc-cpp/string/string_substr_const_fail` — same const `substr`,
  wrong expected value, verifies FAILED (guards against a vacuous pass).

## Validation

- Probed vs `clang++ -std=c++17`: const `substr(pos,n)`/`substr(pos)` accepted and
  correct; wrong-value variant fails identically under both.
- No regressions: `esbmc-cpp/string` 35/35, `esbmc-cpp/bug_fixes` 105/105 (non-KNOWNBUG).

Fixes #6332.