### PR TITLE
[cpp] Make std::deque const-iterable and fix iterator operators

### DIFF
--- a/regression/esbmc-cpp/deque/deque_const_iteration/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_const_iteration/main.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+#include <deque>
+
+static int sum(const std::deque<int> &d)
+{
+  int s = 0;
+  for (int x : d)
+    s += x;
+  return s;
+}
+
+static int sum_it(const std::deque<int> &d)
+{
+  int s = 0;
+  for (std::deque<int>::const_iterator it = d.begin(); it != d.end(); ++it)
+    s += *it;
+  return s;
+}
+
+int main()
+{
+  std::deque<int> d;
+  d.push_back(1);
+  d.push_back(2);
+  d.push_back(3);
+  assert(sum(d) == 6);
+  assert(sum_it(d) == 6);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_const_iteration/test.desc
+++ b/regression/esbmc-cpp/deque/deque_const_iteration/test.desc
@@ -2,4 +2,3 @@ CORE
 main.cpp
 --std=c++17 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-^EXIT=0$

--- a/regression/esbmc-cpp/deque/deque_const_iteration/test.desc
+++ b/regression/esbmc-cpp/deque/deque_const_iteration/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$

--- a/regression/esbmc-cpp/deque/deque_const_iteration_fail/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_const_iteration_fail/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+#include <deque>
+
+static int sum(const std::deque<int> &d)
+{
+  int s = 0;
+  for (int x : d)
+    s += x;
+  return s;
+}
+
+int main()
+{
+  std::deque<int> d;
+  d.push_back(1);
+  d.push_back(2);
+  assert(sum(d) == 99);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_const_iteration_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_const_iteration_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_iterator_ops/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_iterator_ops/main.cpp
@@ -1,0 +1,26 @@
+#include <cassert>
+#include <deque>
+
+int main()
+{
+  std::deque<int> d;
+  d.push_back(10);
+  d.push_back(20);
+  d.push_back(30);
+
+  std::deque<int>::iterator it = d.begin();
+  it += 2;
+  assert(*it == 30);
+
+  --it;
+  assert(*it == 20);
+
+  it -= 1;
+  assert(*it == 10);
+
+  std::deque<int>::iterator post = it++;
+  assert(*post == 10);
+  assert(*it == 20);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_iterator_ops/test.desc
+++ b/regression/esbmc-cpp/deque/deque_iterator_ops/test.desc
@@ -2,4 +2,3 @@ CORE
 main.cpp
 --std=c++17 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-^EXIT=0$

--- a/regression/esbmc-cpp/deque/deque_iterator_ops/test.desc
+++ b/regression/esbmc-cpp/deque/deque_iterator_ops/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -73,11 +73,15 @@ public:
     }
     iterator &operator--()
     {
-      return iterator(--pointer, --pos, vec_pos);
+      --pointer;
+      --pos;
+      return *this;
     }
     iterator operator--(int b)
     {
-      return iterator(pointer--, pos--, vec_pos);
+      iterator temp = *this;
+      --(*this);
+      return temp;
     }
 
     bool operator==(const iterator &i) const
@@ -126,20 +130,24 @@ public:
 
     iterator &operator+=(int n)
     {
-      return iterator(pointer += n, pos += n, vec_pos);
+      pointer += n;
+      pos += n;
+      return *this;
     }
     iterator &operator-=(int n)
     {
-      return iterator(pointer -= n, pos -= n, vec_pos);
+      pointer -= n;
+      pos -= n;
+      return *this;
     }
   };
 
   class const_iterator
   {
   public:
-    T *pointer;
+    const T *pointer;
     int pos;
-    T *vec_pos;
+    const T *vec_pos;
 
     const_iterator(const const_iterator &i)
     {
@@ -150,11 +158,11 @@ public:
     const_iterator()
     {
     }
-    const_iterator(T *p)
+    const_iterator(const T *p)
     {
       pointer = p;
     }
-    const_iterator(T *ppointer, int ppos, T *pvec_pos)
+    const_iterator(const T *ppointer, int ppos, const T *pvec_pos)
     {
       pointer = ppointer;
       pos = ppos;
@@ -168,29 +176,37 @@ public:
       return *this;
     }
 
-    T *operator->();
+    const T *operator->();
 
-    T &operator*()
+    const T &operator*()
     {
       return vec_pos[pos];
     }
 
     const_iterator &operator++()
     {
-      return const_iterator(++pointer, ++pos, vec_pos);
+      ++pointer;
+      ++pos;
+      return *this;
     }
     const_iterator operator++(int b)
     {
-      return const_iterator(pointer++, pos++, vec_pos);
+      const_iterator temp = *this;
+      ++(*this);
+      return temp;
     }
 
     const_iterator &operator--()
     {
-      return const_iterator(--pointer, --pos, vec_pos);
+      --pointer;
+      --pos;
+      return *this;
     }
     const_iterator operator--(int b)
     {
-      return const_iterator(pointer--, pos--, vec_pos);
+      const_iterator temp = *this;
+      --(*this);
+      return temp;
     }
 
     bool operator==(const const_iterator &i) const
@@ -226,11 +242,15 @@ public:
 
     const_iterator &operator+=(int n)
     {
-      return const_iterator(pointer += n, pos += n, vec_pos);
+      pointer += n;
+      pos += n;
+      return *this;
     }
     const_iterator &operator-=(int n)
     {
-      return const_iterator(pointer -= n, pos -= n, vec_pos);
+      pointer -= n;
+      pos -= n;
+      return *this;
     }
   };
 
@@ -542,7 +562,6 @@ public:
   const_iterator end() const
   {
     int n = _size + 1;
-    buf[n] = T();
     const_iterator buffer(buf + n, n, buf);
     return buffer;
   }


### PR DESCRIPTION
## Root cause

The bundled `<deque>` operational model (`src/cpp/library/deque`) stores elements
in a member array `T buf[DEQUE_CAPACITY]`. Its `const_iterator` held non-const
`T *pointer`/`T *vec_pos` with `T*` constructors. In a `const` member —
`begin() const`, `end() const` — `buf` decays to `const T*`, which cannot bind to
those `T*` constructors, so a `const_iterator` could not be constructed and
iterating over a `const std::deque` produced a `PARSING ERROR`:

```cpp
int sum(const std::deque<int>& d) {
  int s = 0;
  for (int x : d) s += x;   // error: no matching constructor for const_iterator
  return s;
}
```

Because `const_iterator` never compiled, three latent defects were masked:

1. `operator++`/`operator--`/`operator+=`/`operator-=` returned `const_iterator&`
   but returned a temporary — ill-formed once instantiated.
2. `end() const` wrote a sentinel `buf[n] = T()` into logically-`const` storage;
   the value is never read (`operator==` compares only `pointer`).
3. `operator*` returned non-const `T&`, which would wrongly accept mutation
   through a const iterator.

The **non-const** `iterator` had the same return-a-temporary-by-reference defect
in `operator--()`, `operator+=`, and `operator-=` (its `operator++` was already
correct) — latent for the same reason (never instantiated by existing tests).

## Fix

- Make `const_iterator` genuinely const-correct: `const T*` members/constructors,
  `const T&`/`const T*` from `operator*`/`operator->`.
- Rewrite the const_iterator increment/decrement/compound-assign operators to the
  standard "mutate members, return *this" form (post-inc/dec return by value).
- Drop the redundant sentinel write in `end() const`.
- Apply the same well-formedness fix to the non-const `iterator` operator--()/
  operator+=/operator-=, so `--it`, `it += n`, `it -= n` work.

Non-const forward iteration is unchanged; mutation through a const iterator is now
correctly rejected, matching clang.

## Tests

- `regression/esbmc-cpp/deque/deque_const_iteration` — const range-for and an
  explicit `const_iterator` loop over a const deque both verify SUCCESSFUL
  (previously a parse error).
- `regression/esbmc-cpp/deque/deque_const_iteration_fail` — same const range-for,
  wrong expected sum, verifies FAILED (guards against a vacuous pass).
- `regression/esbmc-cpp/deque/deque_iterator_ops` — `it += n`, `--it`, `it -= n`,
  and post-increment on a non-const iterator verify SUCCESSFUL.

## Validation

- Probed vs `clang++ -std=c++17`: const range-for / explicit-iterator / post-incr
  accepted and correct; wrong-value variant fails under both; mutation through a
  const iterator is rejected by both (operator* returns a const value).
- No regressions: `esbmc-cpp/bug_fixes` 105/105; all 55 existing deque tests parse
  cleanly, and deque_constructor/deque_erase/deque_overflow/deque_swap confirmed
  SUCCESSFUL at their real `--unwind 10` bound.

Fixes #6334.
