### PR TITLE
[python] Resolve empty dereference result types in python_adjust

### DIFF
--- a/regression/python/python_irep2_adjust_char_index/main.py
+++ b/regression/python/python_irep2_adjust_char_index/main.py
@@ -1,0 +1,13 @@
+# Exercises the --python-irep2-adjust deref-result-type arm (docs/scope-v1k-adjuster
+# round-4): a char-array element access chr(c)[0] produces a dereference whose
+# result type the converter leaves empty. Under the flag, clang_cpp_adjust runs
+# first and resolves it, so the pass stays inert and the verdict matches the
+# default path; the arm's own resolution is what the hop-off flip census
+# exercises (it turns this test's symbolic_type_excp crash into a verdict).
+def test_chr_ord() -> bool:
+    char_code = ord('A')
+    back_to_char = chr(char_code)
+    return back_to_char == 'A' and char_code == 65
+
+
+assert test_chr_ord() == True

--- a/regression/python/python_irep2_adjust_char_index/test.desc
+++ b/regression/python/python_irep2_adjust_char_index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -218,6 +218,22 @@ void python_adjust::adjust_expr(expr2tc &expr)
     if (resolve_source(source))
       expr = index2tc(i.type, source, i.index);
   }
+  else if (is_dereference2t(expr) && is_empty_type(expr->type))
+  {
+    // A pointer dereference whose result type the converter left empty -- a
+    // Python element access `s[i]` over a char*-like source (chr()'s result is
+    // the canonical case). clang_cpp_adjust resolves the read type to the
+    // pointee; do the same so symex does not get_width() an empty deref target
+    // (the S3 symbolic_type_excp root, docs/scope-v1k-adjuster round-4). Only
+    // when the pointee is itself concrete; dereference2t is immutable, rebuild.
+    const dereference2t &d = to_dereference2t(expr);
+    if (is_pointer_type(d.value->type))
+    {
+      const type2tc &pointee = to_pointer_type(d.value->type).subtype;
+      if (!is_empty_type(pointee))
+        expr = dereference2tc(pointee, d.value);
+    }
+  }
   else if (is_constant_struct2t(expr) && is_symbol_type(expr->type))
   {
     // S2: aggregate-literal completion — the third relaxed construction

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -225,7 +225,10 @@ void python_adjust::adjust_expr(expr2tc &expr)
     // the canonical case). clang_cpp_adjust resolves the read type to the
     // pointee; do the same so symex does not get_width() an empty deref target
     // (the S3 symbolic_type_excp root, docs/scope-v1k-adjuster round-4). Only
-    // when the pointee is itself concrete; dereference2t is immutable, rebuild.
+    // when the pointee is non-empty -- a void*-like empty pointee is left for
+    // the exit invariant, exactly as clang leaves a void deref empty. An array
+    // operand (clang's `*a` -> `a[0]` rewrite) does not occur on the Python
+    // path (subscripts lower to index2t). dereference2t is immutable, rebuild.
     const dereference2t &d = to_dereference2t(expr);
     if (is_pointer_type(d.value->type))
     {


### PR DESCRIPTION
Part V / `scope-v1k-adjuster.md` (esbmc/esbmc#4715). Clears the dominant `python_adjust`-flip hop-off blocker: the `type2t::symbolic_type_excp` cluster.

`python_adjust` resolves member/index *source* types but had no arm for an empty *result* type on a `dereference2t`. A Python element access such as `chr(c)[0]` is a `dereference2t` whose result type the converter leaves empty; `clang_cpp_adjust` resolves it to the char element type, so on the default pipeline everything is fine — but under the flip (clang skipped) symex called `empty_type2t::get_width()` in `dereferencet::construct_from_array` and threw `symbolic_type_excp`. Root cause pinned in the round-4 drill (`scope-v1k-adjuster.md`).

The fix adds one arm: when a `dereference2t` has an empty result type over a pointer source with a concrete pointee, rebuild it with the pointee type — the same read type `clang_cpp_adjust` resolves.

Verification (throwaway `ESBMC_PY_SKIP_LEGACY_ADJUST` hop-off gate, reverted):
- The 6 `symbolic_type_excp` cases (builtin2, builtin2_fail, cast, cast_fail, casting-chr-func, casting-chr-var-multibyte) go from **crash to correct verdict**.
- Hop-off census over 150 `regression/python` tests: **132→138 match, 16→10 no-verdict, 0 mismatch** — no regressions; the remaining 10 no-verdict are the unrelated hang/unsupported cluster.
- **Inert on the default pipeline** (the `is_empty_type` guard is false once `clang_cpp_adjust` has run): default vs `--python-irep2-adjust` byte-identical on the sampled tests; all 8 flip fixtures pass.

Adds `regression/python/python_irep2_adjust_char_index` (the `chr(ord(...))` element access under `--python-irep2-adjust`; CPython-sane). The enclosing comparison's char→int promotion is a separate, cosmetic gap (verdict already matches); tracked for a follow-up.
