### PR TITLE
[docs] Map the remaining python_adjust hop-off gaps after #6340/#6348

### DIFF
--- a/docs/scope-v1k-adjuster.md
+++ b/docs/scope-v1k-adjuster.md
@@ -459,9 +459,23 @@ with the same `Unexpected index type in computer_pointer_offset` — the offendi
 `index2t` reaches `python_adjust` from a site *other* than `build_index` (a
 survived string-element read), so a converter-side fix does not cover it.
 
+**Root cause pinned — a missing array→pointer decay, not an index problem.**
+Instrumenting `goto_symex_statet::fixup_renamed_type` at the deeper
+`irep2_cast_error` (the crash the naive index arm trades into) shows the node
+with `orig_type = pointer` but a renamed value of `constant_array` (a `signedbv[8]`
+of size 1 — the empty string `""`). So a `char*` variable (e.g. `word`) holds a
+**bare array value that was never decayed to `address_of(array)`**. `clang_c_adjust`
+performs this array→pointer decay when an array value meets a pointer context;
+`python_adjust` does not, so the pointer variable carries an array value and any
+pointer use of it (the `*(p+i)` the index arm builds, but also plain pointer
+arithmetic) mismatches at symex rename. The index-over-pointer crash is therefore
+a *symptom*: the real gap is the missing decay, which is broader than indexing and
+must be fixed at the assignment/typecast seam (where `word = ""` should become
+`word = &""[0]`-style), mirroring clang, before the index arm can be sound.
+
 **Direction.** The two low-hanging arms (deref #6340, if2t #6348) are landed and
 the hop-off is at ~95% verdict parity. The remaining gaps are *not* one-arm
-fixes: index-over-pointer needs symex-side type-tracking work beyond the adjust
-arm, and the S3 unresolved-by-name family needs the dict-key-type infrastructure.
-Both are their own scoped efforts; neither should be forced as a mechanical
-adjuster arm.
+fixes: index-over-pointer is really the array→pointer decay gap above (an
+assignment-seam fix, not an index arm), and the S3 unresolved-by-name family
+needs the dict-key-type infrastructure. Both are their own scoped efforts;
+neither should be forced as a mechanical adjuster arm.

--- a/docs/scope-v1k-adjuster.md
+++ b/docs/scope-v1k-adjuster.md
@@ -473,6 +473,17 @@ a *symptom*: the real gap is the missing decay, which is broader than indexing a
 must be fixed at the assignment/typecast seam (where `word = ""` should become
 `word = &""[0]`-style), mirroring clang, before the index arm can be sound.
 
+**✅ FIXED — PR #6363.** Both arms landed together in `python_adjust::adjust_expr`:
+(1) an array→pointer decay on a `code_assign2t` with a pointer target and array
+source (`word = ""` → `word = &array[0]`, with the `address_of` subtype the
+target *pointee* so the value is exactly the target type), and (2) the
+`p[i]`→`*(p+i)` index rewrite. The decay is the load-bearing half — with `word`
+now holding a real pointer, the index arm renames cleanly (no `irep2_cast_error`).
+Census: MATCH 520 → 525 (the 3 index-over-pointer cases plus `string18` and
+`string22_fail`), zero regressions; C-Live on both arms; a matched hop-off test
+pair added. So of the three residual families above, **index-over-pointer is
+resolved**; S3 unresolved-by-name and the math/complex verdicts remain.
+
 **Direction.** The two low-hanging arms (deref #6340, if2t #6348) are landed and
 the hop-off is at ~95% verdict parity. The remaining gaps are *not* one-arm
 fixes: index-over-pointer is really the array→pointer decay gap above (an

--- a/docs/scope-v1k-adjuster.md
+++ b/docs/scope-v1k-adjuster.md
@@ -419,3 +419,49 @@ reconciliation problem, **not needed** for the flip (whose acceptance gate is
 dual-solver *verdict* parity, already met by #6340), and **cosmetic** (verdict
 matches). Deferred/abandoned. The deref fix stands on its own; do not gate the
 flip on this promotion.
+
+### Remaining hop-off gaps — precise map (2026-07-24, post-#6340 + #6348)
+
+With the deref-result arm (#6340), the `if2t` bool-cast arm (#6348), and the
+`--python-irep2-adjust-only` flag in place, a clean census (mypy noise and
+expected uncaught-exceptions filtered out; genuine ESBMC-error signatures only)
+over a 546-test strided sample (every 8th `regression/python` test) gives:
+
+- **520 / 546 verdict-and-error parity (~95%)** between hop-off and the legacy
+  `clang_cpp_adjust` path.
+
+The residual ~5% is now categorised precisely — reproduced signatures, not the
+old vague "F-A" buckets:
+
+| Family | Count (in sample) | Reproduced signature | Root cause | Tractability |
+|---|---|---|---|---|
+| **S3 unresolved-by-name** | 7 | `python_adjust: symbol '…' retains N unresolved by-name (symbol_type2t) node(s) after adjust (V.1k post-adjust invariant violated)` | dict/Optional value nodes whose key/element type clang resolves but `python_adjust` leaves as a transient `symbol_type2t` — needs the dict-key-type infra (the long-standing S3 work-list) | **hard** (multi-step, own infra) |
+| **index-over-pointer** | 3 | `std::runtime_error: Unexpected index type in computer_pointer_offset` (type_byte_size.cpp:338) | an `index2t` whose `source_value` is a `char*` (a Python string / decayed-array parameter). `clang_c_adjust::adjust_index` rewrites `p[i]` → `*(p+i)`; `python_adjust` does not. A naive mirror (`dereference2tc(elem, add2tc(ptr, idx))` — the exact `build_dereference` shape) removes this crash but surfaces a **deeper** `irep2_cast_error` in `goto_symex_statet::fixup_renamed_type` (a function-argument rename where `orig_type` is pointer but the renamed value is not), so the fix needs symex-side type-tracking care, not just the adjust arm. | **hard** (symex rename interaction) |
+| **wrong/absent verdict** | ~4–6 | legacy `SUCCESSFUL` → hop-off `FAILED` (sqrt3, math_gamma_noninteger, github_3690, github_6258) or hop-off no-verdict (complex_pow_float_exponent, div6, jpl, list25, string18, ternary_operator4 — several are the crashes above manifesting as an empty verdict) | SMT-level: mostly the two crash families above surfacing as no-verdict; the true wrong-verdicts cluster on math/complex functions and need per-case triage | **mixed** |
+
+**Notes.**
+- The heterogeneous ternary case the earlier reviewer flagged (`"a" or 0`,
+  pointer-vs-int operands) is **at parity** — both paths report the same verdict
+  (a shared pre-existing mixed-type BoolOp imprecision, not a hop-off gap).
+- `string22_fail` is hop-off-*better*: legacy gives no verdict, hop-off reports
+  `FAILED` correctly.
+- Method reminder (recurring trap): the raw census over-counts by ~40× if mypy
+  `error: … [tag]` lines and expected `uncaught exception: …` in `*_fail` tests
+  are not filtered — grep the genuine ESBMC signatures (`must be boolean`,
+  `terminating due to`, `symbolic_type_excp`, `retains … unresolved by-name`,
+  `Unexpected index type`) present in hop-off **but not** legacy.
+
+**#6323 does not address index-over-pointer.** #6323 ("Build pointer-source
+index arithmetic natively in IREP2") changed the *converter*'s `build_index`
+pointer branch (`plus_exprt` → `add2tc`, `python_expr_builder.cpp`). Re-checked
+after it merged: the three index-over-pointer cases still crash under hop-off
+with the same `Unexpected index type in computer_pointer_offset` — the offending
+`index2t` reaches `python_adjust` from a site *other* than `build_index` (a
+survived string-element read), so a converter-side fix does not cover it.
+
+**Direction.** The two low-hanging arms (deref #6340, if2t #6348) are landed and
+the hop-off is at ~95% verdict parity. The remaining gaps are *not* one-arm
+fixes: index-over-pointer needs symex-side type-tracking work beyond the adjust
+arm, and the S3 unresolved-by-name family needs the dict-key-type infrastructure.
+Both are their own scoped efforts; neither should be forced as a mechanical
+adjuster arm.


### PR DESCRIPTION
Follow-up to the hop-off census (#6329, merged). Records a clean census of the `--python-irep2-adjust-only` hop-off (python_adjust as sole adjuster) **after** the deref-result arm (#6340) and the `if2t` bool-cast arm (#6348): **~95% verdict-and-error parity** with the legacy `clang_cpp_adjust` path over a 546-test strided sample.

Categorises the residual ~5% with **reproduced signatures** (replacing the old vague "F-A" buckets):

- **S3 unresolved-by-name (7)** — `retains N unresolved by-name (symbol_type2t)`; needs the dict-key-type infra.
- **index-over-pointer (3)** — `Unexpected index type in computer_pointer_offset`; an `index2t` over a `char*` that `clang_c_adjust::adjust_index` rewrites `p[i]` to `*(p+i)` but `python_adjust` doesn't. A naive mirror trades the crash for a deeper `irep2_cast_error` in `goto_symex_statet::fixup_renamed_type`, so it needs symex-side type-tracking work. Verified #6323 (converter-side `build_index`) does not cover it.
- **math/complex wrong-or-absent verdict (~4-6)** — mostly the above crashes surfacing as no-verdict; true wrong-verdicts cluster on math/complex functions.

Also records the census-method trap (raw census over-counts ~40x without filtering mypy type-checker lines and expected uncaught exceptions in `*_fail` tests).

Conclusion: the two low-hanging adjuster arms are landed; the remaining gaps are their own scoped efforts, not mechanical arms.
