### PR TITLE
[contracts] resolve struct "tag" pointee before pointer-param havoc (#6356)

### DIFF
--- a/regression/function_contract/replace_struct_ptr_havoc_fail/main.c
+++ b/regression/function_contract/replace_struct_ptr_havoc_fail/main.c
@@ -1,0 +1,25 @@
+/* replace_struct_ptr_havoc_fail (issue #6356):
+ * Negative counterpart of replace_struct_ptr_havoc_pass. The ensures only
+ * bounds the field (>= 0), so the pointer-parameter havoc must leave it
+ * nondet; asserting it kept its old value must therefore FAIL. Guards against
+ * the fix regressing into a havoc that doesn't actually nondet the struct
+ * (which would make the ensures ASSUME vacuous and spuriously verify).
+ * Expected: VERIFICATION FAILED
+ */
+typedef struct { int received; } S;
+
+void f(S *self)
+{
+    __ESBMC_requires(self != 0);
+    __ESBMC_ensures(self->received >= 0);
+    self->received = 5;
+}
+
+int main(void)
+{
+    S s;
+    s.received = 42;
+    f(&s);
+    __ESBMC_assert(s.received == 42, "must fail: havoc makes received nondet");
+    return 0;
+}

--- a/regression/function_contract/replace_struct_ptr_havoc_fail/test.desc
+++ b/regression/function_contract/replace_struct_ptr_havoc_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract f --unwind 5
+^VERIFICATION FAILED$

--- a/regression/function_contract/replace_struct_ptr_havoc_pass/main.c
+++ b/regression/function_contract/replace_struct_ptr_havoc_pass/main.c
@@ -1,0 +1,27 @@
+/* replace_struct_ptr_havoc_pass (issue #6356):
+ * --replace-call-with-contract on a struct-pointer parameter whose contract
+ * has BOTH a null-check `requires` and a member-deref `ensures` used to abort
+ * with "Unexpected type ID symbol reached SMT conversion". The pointer-param
+ * havoc built `*arg = nondet(pointee)` without resolving the struct "tag"
+ * (symbol_type2t) pointee, so a symbol type reached SMT sort conversion.
+ * Here the ensures pins the field, so the post-state is known and the caller's
+ * assertion holds.
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+typedef struct { int received; } S;
+
+void f(S *self, int v)
+{
+    __ESBMC_requires(self != 0);
+    __ESBMC_ensures(self->received == v);
+    self->received = v;
+}
+
+int main(void)
+{
+    S s;
+    s.received = 0;
+    f(&s, 7);
+    __ESBMC_assert(s.received == 7, "ensures pins received to v");
+    return 0;
+}

--- a/regression/function_contract/replace_struct_ptr_havoc_pass/test.desc
+++ b/regression/function_contract/replace_struct_ptr_havoc_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract f --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -3854,7 +3854,14 @@ void code_contractst::generate_replacement_at_call(
         continue;
 
       const pointer_type2t &ptr_type = to_pointer_type(param_type);
-      type2tc pointee_type = ptr_type.subtype;
+      // Resolve a struct/union "tag" pointee (symbol_type2t) to its concrete
+      // type. A pointer to a named struct migrates with an unresolved symbol
+      // subtype; leaving it unresolved makes the dereference2tc / gen_nondet
+      // below propagate a symbol type all the way to SMT sort conversion, which
+      // aborts with "Unexpected type ID symbol reached SMT conversion" (#6356).
+      // The other pointer-havoc paths already apply this ns.follow() step; this
+      // one was missing it. ns.follow() is a no-op for non-symbol types.
+      type2tc pointee_type = ns.follow(ptr_type.subtype);
 
       // Skip void*, function pointers, and unknown/nil pointed-to types
       if (


### PR DESCRIPTION
Fixes #6356.

## Problem

`--replace-call-with-contract` aborts with

```
ERROR: Unexpected type ID symbol reached SMT conversion
```

whenever a struct-pointer parameter carries **both** a null-check `requires`
and a member-deref `ensures`:

```c
typedef struct { int received; } S;
void f(S *self, int v) {
    __ESBMC_requires(self != 0);
    __ESBMC_ensures(self->received == v);
    self->received = v;
}
```

`esbmc repro.c --function f --enforce-contract f` verifies fine; only contract
**replacement** crashes.

## Root cause

The conservative pointer-parameter havoc in `generate_replacement_at_call`
(`src/goto-programs/contracts/contracts.cpp`) builds `*arg = nondet(pointee)`
directly from `pointer_type2t::subtype`. For a pointer to a *named* struct that
subtype is an unresolved `symbol_type2t` ("tag") type, so both the
`dereference2tc` and the `gen_nondet` RHS carry a symbol type that survives to
SMT sort conversion, where `convert_sort()` hits its `default:` case and
`abort()`s on `symbol_id`.

- A primitive `int *` pointee is already concrete → only named/struct pointees crash.
- The havoc assignment only reaches the solver when a live VCC (e.g. the
  `requires` ASSERT) keeps it from being sliced away → both a `requires` and a
  member-deref `ensures` are needed to trigger it.

## Fix

Resolve the pointee with `ns.follow()` before building the havoc:

```cpp
-      type2tc pointee_type = ptr_type.subtype;
+      type2tc pointee_type = ns.follow(ptr_type.subtype);
```

This matches the resolution the other pointer-havoc paths in this file already
perform (see the `ns.follow(pointee)` calls elsewhere in `contracts.cpp`).
`ns.follow()` is a no-op for non-symbol types.

## Tests

Two new regression tests under `regression/function_contract/`:

- `replace_struct_ptr_havoc_pass` — the previously-aborting program now
  `VERIFICATION SUCCESSFUL`.
- `replace_struct_ptr_havoc_fail` — negative control: an `ensures` that only
  bounds the field must leave the havoc'd struct nondet, so a caller assertion
  on the old value must still `FAIL`. Guards against a vacuous-assume
  regression (i.e. the fix must not silently stop havocing the struct).

Full `function_contract` regression suite passes locally (**271/271**, plus the
two new tests), no regressions. Changed lines are clang-format-11 clean.