### PR TITLE
[contracts] Preserve jumps to a replaced call at a branch target (#6364)

### DIFF
--- a/regression/function_contract/replace_call_branch_target_fail/main.c
+++ b/regression/function_contract/replace_call_branch_target_fail/main.c
@@ -1,0 +1,40 @@
+/* replace_call_branch_target_fail (issue #6364):
+ * Negative counterpart: force the else path and assert the negation of fb's
+ * postcondition. With the branch-target replacement correctly applied, fb's
+ * contract sets b_done == 1, so asserting !b_done must fail (rather than being
+ * spuriously provable because the replacement was dropped).
+ *
+ * Expected: VERIFICATION FAILED
+ */
+typedef struct
+{
+  int received;
+} T;
+_Bool b_done = 0;
+
+void fb(T *self, int v)
+{
+  __ESBMC_requires(self != 0);
+  __ESBMC_assigns(self->received, b_done);
+  __ESBMC_ensures(self->received == v);
+  __ESBMC_ensures(b_done == 1);
+  self->received = v;
+  b_done = 1;
+}
+
+int main(void)
+{
+  T t2;
+  int c;
+  __ESBMC_assume(c == 1);
+  if (c == 0)
+  {
+    fb(&t2, 2);
+  }
+  else
+  {
+    fb(&t2, 2);
+  }
+  __ESBMC_assert(!b_done, "b_done is set by fb's contract, so this must fail");
+  return 0;
+}

--- a/regression/function_contract/replace_call_branch_target_fail/test.desc
+++ b/regression/function_contract/replace_call_branch_target_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract *
+^VERIFICATION FAILED$

--- a/regression/function_contract/replace_call_branch_target_pass/main.c
+++ b/regression/function_contract/replace_call_branch_target_pass/main.c
@@ -1,0 +1,54 @@
+/* replace_call_branch_target_pass (issue #6364):
+ * A contracted call sitting at a branch-target position (the first instruction
+ * of the `else` branch) must keep its contract replacement. Before the fix the
+ * replacement was spliced *before* the call and the incoming jump landed on the
+ * post-replacement SKIP, so on the else path fb's contract (which sets b_done)
+ * was dropped and b_done was left unconstrained, spuriously failing the assert.
+ *
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+typedef struct
+{
+  int received;
+} T;
+_Bool a_done = 0, b_done = 0;
+
+void fa(T *self, int v)
+{
+  __ESBMC_requires(self != 0);
+  __ESBMC_assigns(self->received, a_done);
+  __ESBMC_ensures(self->received == v);
+  __ESBMC_ensures(a_done == 1);
+  self->received = v;
+  a_done = 1;
+}
+
+void fb(T *self, int v)
+{
+  __ESBMC_requires(self != 0);
+  __ESBMC_assigns(self->received, b_done);
+  __ESBMC_ensures(self->received == v);
+  __ESBMC_ensures(b_done == 1);
+  self->received = v;
+  b_done = 1;
+}
+
+int main(void)
+{
+  T t1, t2;
+  int c;
+  __ESBMC_assume(c == 0 || c == 1);
+  if (c == 0)
+  {
+    fb(&t2, 2);
+    fa(&t1, 1);
+  }
+  else
+  {
+    fb(&t2, 2);
+    fa(&t1, 1);
+  }
+  if (a_done)
+    __ESBMC_assert(b_done, "b_done must hold whenever a_done does");
+  return 0;
+}

--- a/regression/function_contract/replace_call_branch_target_pass/test.desc
+++ b/regression/function_contract/replace_call_branch_target_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract *
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/replace_call_switch_case_pass/main.c
+++ b/regression/function_contract/replace_call_switch_case_pass/main.c
@@ -1,0 +1,33 @@
+/* replace_call_switch_case_pass (issue #6364):
+ * A contracted call at a switch-case entry is also a jump target (the switch
+ * dispatch jumps to each case label). Its replacement must not be dropped, so
+ * g is set in every reached case. Distinct jump-target origin from the
+ * else-branch case; verified to be spuriously FAILED before the fix.
+ *
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+int g = 0;
+
+void setg(int v)
+{
+  __ESBMC_assigns(g);
+  __ESBMC_ensures(g == v);
+  g = v;
+}
+
+int main(void)
+{
+  int c;
+  __ESBMC_assume(c == 0 || c == 1);
+  switch (c)
+  {
+  case 0:
+    setg(5);
+    break;
+  case 1:
+    setg(5);
+    break;
+  }
+  __ESBMC_assert(g == 5, "g is set by the contract in every reached case");
+  return 0;
+}

--- a/regression/function_contract/replace_call_switch_case_pass/test.desc
+++ b/regression/function_contract/replace_call_switch_case_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract *
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -3916,11 +3916,18 @@ void code_contractst::generate_replacement_at_call(
   add_contract_clause(
     ensures_guard, ASSUME, "contract ensures", "contract ensures");
 
-  // Replace call with replacement code
-  // Insert replacement code before the call instruction
-  // destructive_insert inserts BEFORE the target (unlike insert_swap which inserts AFTER)
-
-  // Debug: log replacement code generation
+  // Replace the call with the replacement code.
+  //
+  // The replacement must take over the call's slot so that any GOTO or label
+  // targeting the call lands on the replacement. destructive_insert() splices
+  // the replacement *before* the call and leaves the call's iterator identity
+  // unchanged, so a call at a branch-target position (e.g. the first
+  // instruction of an `else` branch) kept incoming jumps pointing at the
+  // post-replacement (now SKIP) call — the whole replacement was skipped on
+  // that path, silently dropping the contract (#6364). insert_swap() moves the
+  // replacement's first instruction into the call's slot (preserving jumps to
+  // it) and relocates the original instruction after it; for a call that is not
+  // a jump target the two are equivalent.
   size_t replacement_size = replacement.instructions.size();
   log_debug(
     "contracts",
@@ -3929,19 +3936,12 @@ void code_contractst::generate_replacement_at_call(
 
   if (!replacement.instructions.empty())
   {
-    // Debug: log what we're inserting
-    log_debug(
-      "contracts",
-      "Inserting {} instructions before call instruction",
-      replacement_size);
-
-    caller_body.destructive_insert(call_instruction, replacement);
-
-    // Debug: verify insertion
-    log_debug(
-      "contracts",
-      "Call instruction after insertion: type={}",
-      (int)call_instruction->type);
+    // Turn the original call into a SKIP first so that, once insert_swap moves
+    // it after the replacement, it is inert. call_instruction then points at
+    // the replacement's first instruction, which is exactly what incoming
+    // jumps should reach.
+    call_instruction->make_skip();
+    caller_body.insert_swap(call_instruction, replacement);
   }
   else
   {
@@ -3949,16 +3949,8 @@ void code_contractst::generate_replacement_at_call(
       "contracts",
       "No replacement code generated for function {}",
       id2string(function_symbol.name));
+    call_instruction->make_skip();
   }
-
-  // Mark the original call as SKIP
-  call_instruction->make_skip();
-
-  // Debug: verify skip
-  log_debug(
-    "contracts",
-    "Call instruction marked as SKIP: type={}",
-    (int)call_instruction->type);
 }
 
 // ========== Pointer validity assumptions support ==========


### PR DESCRIPTION
## Summary
Fixes #6364 — `--replace-call-with-contract` silently dropped the entire contract replacement for a call at a **jump-target position** (the first instruction of an `else` branch, a `switch` case, or any call reached directly by a `goto`/label), producing a **spurious `VERIFICATION FAILED`** on correct programs.

## Root cause
`code_contractst::generate_replacement_at_call` spliced the replacement *before* the call with `destructive_insert()` and then `make_skip()`-ed the call. The call's iterator identity was unchanged, so any GOTO/label targeting the call still landed on the post-replacement (now `SKIP`) call and jumped straight over the replacement. On that path the callee contributed no `assert requires` / havoc / `assume ensures`, leaving the globals/out-params it constrains unconstrained.

## Fix
Use `goto_programt::insert_swap` ("insertion that preserves jumps to target"): it moves the replacement's first instruction into the call's slot (so incoming jumps reach the replacement) and relocates the original call after it. The call is `make_skip()`-ed first so the relocated copy is inert. For a call that is not a jump target this is equivalent to the old splice.

Confirmed on the transformed GOTO: the `else`-entry label now lands on the replacement's first `assert requires`; before the fix it landed past the whole replacement.

## Scope note
The trigger is a call **at a jump-target position**. Verified affected (spuriously `FAILED` before, `SUCCESSFUL` after): `else`-branch entry, `switch`-case entry, and a call after an explicit `goto`/label. A plain `for`/`while` body call is *not* affected — the back-edge targets the loop condition and the call is fallen into, not jumped to (the loop wording in the issue is inaccurate in that respect).

## Tests
- `replace_call_branch_target_pass` — contracted call at an `else`-branch entry; property holds → `SUCCESSFUL` (was spuriously `FAILED`).
- `replace_call_branch_target_fail` — the else-branch call's contract *is* applied, so asserting its negation → `FAILED` (was spuriously `SUCCESSFUL`).
- `replace_call_switch_case_pass` — contracted call at a `switch`-case entry (distinct jump-target origin).

