### PR TITLE
[docs] Add Debian and Homebrew packaging guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ sudo apt install esbmc
 
 This method is recommended for general users and supports Ubuntu 22.04 (Jammy) and 24.04 (Noble).
 
+### Homebrew (macOS and Linux)
+
+ESBMC is available in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/e/esbmc.rb):
+
+```
+brew install esbmc
+```
+
+This installs `esbmc` together with its bundled SMT solvers (Z3, Bitwuzla).
+
 ### GitHub Release
 
 You can also download the latest ESBMC binary for Ubuntu and Windows from the [releases page](https://github.com/esbmc/esbmc/releases).

--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ This method is recommended for general users and supports Ubuntu 22.04 (Jammy) a
 
 ### Homebrew (macOS and Linux)
 
-ESBMC is available in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/e/esbmc.rb):
-
 ```
 brew install esbmc
 ```

--- a/website/content/docs/development/_index.md
+++ b/website/content/docs/development/_index.md
@@ -30,6 +30,8 @@ start with the [Build Guide](/docs/development/building) and the
 {{< cards >}}
   {{< card link="/docs/development/releases" title="Releases" subtitle="How to prepare and publish a new ESBMC release." >}}
   {{< card link="/docs/development/ppa-maintenance" title="PPA Maintenance" subtitle="Maintaining the Ubuntu PPA packages." >}}
+  {{< card link="/docs/development/debian-packaging" title="Debian Packaging" subtitle="Packaging ESBMC for the official Debian archive." >}}
+  {{< card link="/docs/development/homebrew-packaging" title="Homebrew Packaging" subtitle="Adding and maintaining a Homebrew formula." >}}
   {{< card link="/docs/development/benchexec" title="Benchexec" subtitle="Running ESBMC under BenchExec for reproducible benchmarking." >}}
   {{< card link="/docs/development/sv-comp-and-test-comp-faq" title="SV-COMP and Test-COMP" subtitle="FAQ for the competition configurations." >}}
 {{< /cards >}}

--- a/website/content/docs/development/debian-packaging.md
+++ b/website/content/docs/development/debian-packaging.md
@@ -1,0 +1,324 @@
+---
+title: Debian Packaging Guide
+---
+
+This document explains how ESBMC is packaged for the **official Debian archive**
+and how to maintain that package. It is aimed at anyone who wants to update the
+package for a new upstream release or take over its maintenance.
+
+> [!NOTE]
+>
+> This is **distinct** from the Ubuntu PPA. The PPA
+> ([PPA Maintenance](/docs/development/ppa-maintenance)) ships pre-built
+> binaries to Launchpad for Ubuntu users. The Debian package goes through the
+> Debian archive's review process (mentors + a Debian Developer sponsor) and is
+> built from source on Debian `unstable` (sid).
+
+## Overview
+
+- Debian source package name: `esbmc`
+- Packaging is developed on Salsa: <https://salsa.debian.org/WeiqiWang/esbmc>
+- Uploads for sponsorship go to <https://mentors.debian.net/package/esbmc/>
+- Sponsorship is tracked by an **RFS** ("Request For Sponsorship") bug against
+  the `sponsorship-requests` pseudo-package.
+
+Debian does not let a non–Debian-Developer upload directly. The workflow is:
+build a correct source package → upload it to mentors → file an RFS bug → a
+Debian Developer reviews it and, if satisfied, uploads it on your behalf.
+
+## The Five Essentials
+
+Modern Debian packaging converges on five conventions. Every choice below
+follows them:
+
+1. **`dh`** — the `debhelper` sequencer drives `debian/rules`.
+2. **`3.0 (quilt)`** — the source package format; upstream stays pristine and
+   all Debian changes live as patches under `debian/patches/`.
+3. **git** — the packaging history is kept in git.
+4. **Salsa** — Debian's GitLab hosts the packaging repository and runs CI.
+5. **DEP-5** — the machine-readable `debian/copyright` format.
+
+## Before You Begin
+
+### Install the toolchain
+
+```bash
+sudo apt install build-essential devscripts debmake debhelper \
+                 dh-make quilt git-buildpackage \
+                 lintian sbuild mmdebstrap piuparts
+```
+
+### Set your identity
+
+`devscripts` tools read your name and email from the environment. Put these in
+`~/.bashrc` so every tool (and the changelog) is consistent:
+
+```bash
+export DEBEMAIL="lukewang19@icloud.com"
+export DEBFULLNAME="Weiqi Wang"
+```
+
+The **same** identity — email, OpenPGP key, and Salsa SSH key — must match
+across `debian/changelog`, the GPG signature on the upload, and your Salsa
+account. Mismatches are the most common reason an upload or a push is rejected.
+
+### Read the manual first
+
+Debian packaging practice changes over time, and the authoritative sources are
+online — not your local tooling and not an LLM's training data. Before touching
+`debian/`, read at least:
+
+- [Debian Debmake Manual](https://www.debian.org/doc/manuals/debmake-doc/) —
+  the modern hands-on tutorial (Chapter 5, "Simple packaging", is the core).
+- [Debian Policy Manual](https://www.debian.org/doc/debian-policy/) — the
+  normative rules.
+- [Debian Developer's Reference](https://www.debian.org/doc/manuals/developers-reference/)
+  — process and etiquette.
+
+> [!TIP] Tip
+>
+> The single source of truth for *current* practice is a clean `sid` build plus
+> the online Policy/lintian. An old host (e.g. an LTS release) ships an old
+> `lintian`/`debhelper` that will not warn about today's issues.
+
+## Where Things Live
+
+- **Salsa packaging repo**: `git@salsa.debian.org:WeiqiWang/esbmc.git`
+  - `debian/latest` — the packaging branch (default).
+  - `upstream/latest` — imported upstream sources.
+  - Tag `upstream/8.4.0+dfsg` — the DFSG-clean upstream import.
+  - Layout follows `git-buildpackage`; `debian/gbp.conf` sets `pristine-tar =
+    False`.
+- **CI**: `debian/salsa-ci.yml` runs a full `sid` build and the standard checks
+  (this satisfies the "build and test on sid" requirement even without a local
+  sid box).
+
+## Version Scheme
+
+ESBMC ships a `+dfsg` repack (see [Producing a DFSG-clean
+tarball](#producing-a-dfsg-clean-tarball) below), so the version looks like:
+
+```
+8.4.0+dfsg-1
+└───┘ └──┘ └┘
+  │     │   └ Debian revision (starts at 1; bump for packaging-only changes)
+  │     └──── +dfsg marks a repacked upstream tarball
+  └────────── upstream version (matches the v8.4 git tag)
+```
+
+Until the package is accepted into Debian, keep the revision at `-1` and
+overwrite the upload on mentors rather than bumping — there is no history to
+preserve yet.
+
+## Packaging Workflow
+
+### Producing a DFSG-clean tarball
+
+Debian only ships source that complies with the Debian Free Software
+Guidelines. ESBMC's upstream tree contains a few non-source or non-free bits
+(pre-built Qt binaries, `.DS_Store`, IDE `*.pro.user` files) that must be
+stripped. `debian/copyright` lists them under `Files-Excluded:`, and
+`mk-origtargz` applies that list while repacking:
+
+```bash
+# Export the exact upstream tag, then repack it into a +dfsg orig tarball
+git archive --format=tar --prefix=esbmc-8.4.0/ v8.4 | xz > /tmp/esbmc-8.4.0.tar.xz
+mk-origtargz --repack --compression xz --repack-suffix +dfsg \
+             --copyright-file debian/copyright \
+             /tmp/esbmc-8.4.0.tar.xz
+```
+
+This produces `esbmc_8.4.0+dfsg.orig.tar.xz` with the excluded files removed.
+
+> [!IMPORTANT]
+>
+> When (re)building the Salsa git repo from scratch, upstream's `.gitignore`
+> contains `build*` (no leading slash), which matches at **every** level and
+> silently drops tracked source files on a fresh `git add -A`. Force past it
+> with `git add -f -A .` and verify the staged file count matches the tarball's.
+
+### debian/control — declare minimal, justified dependencies
+
+List only what the build actually uses, and be ready to justify every line. The
+best evidence is the upstream build system itself.
+
+**Worked example — Boost.** ESBMC's `CMakeLists.txt` asks for exactly these
+components:
+
+```cmake
+find_package(Boost REQUIRED
+  COMPONENTS date_time program_options iostreams
+  OPTIONAL_COMPONENTS system filesystem)
+```
+
+So the Build-Depends needs those five component `-dev` packages plus the core
+headers (many parts of ESBMC use header-only Boost via `${Boost_INCLUDE_DIRS}`)
+— **not** the `libboost-all-dev` metapackage, which pulls in dozens of unused
+libraries:
+
+```
+libboost-dev,
+libboost-date-time-dev,
+libboost-program-options-dev,
+libboost-iostreams-dev,
+libboost-filesystem-dev,
+libboost-system-dev,
+```
+
+> [!TIP] Tip
+>
+> Only pin a version (`foo (>= X)`) when you *know* a feature needs it, and add
+> a short comment saying why. Runtime library dependencies are computed
+> automatically by `${shlibs:Depends}` — do not hand-write shared-library
+> versions. Do not list packages that `build-essential` already provides (e.g.
+> `libc6-dev`); `lintian` flags that as an error.
+
+### debian/rules — keep it to `dh`
+
+A CMake project needs almost nothing beyond the sequencer:
+
+```makefile
+#!/usr/bin/make -f
+%:
+	dh $@
+```
+
+Add an `override_dh_auto_configure` only if you must pass CMake flags. With
+`debhelper-compat (= 14)`, `dh` exports `SOURCE_DATE_EPOCH` and handles
+reproducible-build concerns for you — never embed the build machine's wall-clock
+time. (ESBMC's version string uses the git hash, not a build timestamp, so there
+is nothing extra to do here.)
+
+### Building in a clean sid chroot with sbuild
+
+A clean chroot contains **only** your declared Build-Depends, so it is the only
+way to prove the dependency list is both sufficient and minimal — if you trimmed
+too much, the build fails immediately.
+
+```bash
+# One-time: create a sid chroot (rootless unshare backend)
+mmdebstrap --variant=buildd --components=main \
+           unstable ~/.cache/sbuild/unstable-amd64.tar.zst
+
+# Build the source package, then build it in the chroot
+dpkg-buildpackage -S -sa -us -uc
+sbuild --dist=unstable ../esbmc_8.4.0+dfsg-1.dsc
+```
+
+> [!TIP] Tip
+>
+> On a non-Debian host (e.g. Ubuntu) `mmdebstrap` may fail with `NO_PUBKEY`
+> because the host lacks current Debian archive keys. Install a recent
+> `debian-archive-keyring` and point `mmdebstrap` at it, or drop its
+> `trusted.gpg.d/*.asc` files into `/etc/apt/trusted.gpg.d/`. If your host's
+> `sbuild` is too old to drive the unshare backend, rely on Salsa CI for the
+> authoritative sid build.
+
+### Running lintian
+
+```bash
+lintian --profile debian --info ../esbmc_8.4.0+dfsg-1_source.changes
+```
+
+Fix every error and warning. Understand — do not just silence — each tag; the
+`--info` flag prints an explanation and a policy reference for each one.
+
+### Signing and uploading to mentors
+
+```bash
+debsign -k <YOUR_GPG_FINGERPRINT> ../esbmc_8.4.0+dfsg-1_source.changes
+dput mentors ../esbmc_8.4.0+dfsg-1_source.changes
+```
+
+If you re-upload the same version, `dput` skips it because its `.upload` log
+already lists the file — force it with `dput -f mentors ...`.
+
+### Filing the RFS and working with a sponsor
+
+File a Request-For-Sponsorship bug so a Debian Developer knows the package is
+ready for review:
+
+```bash
+# reportbug guides you through it; the bug goes to sponsorship-requests
+reportbug --severity=wishlist sponsorship-requests
+```
+
+Then wait for a sponsor. When they review, expect questions about specific
+choices ("why this dependency?", "why this version?"). Answer them from your own
+understanding — that, not the files, is what earns the upload.
+
+## After Acceptance: Ongoing Maintenance
+
+- **New upstream release**: `uscan` (driven by `debian/watch`) downloads and
+  repacks the new tarball; import it with `gbp import-orig --uscan`, update
+  `debian/changelog` with `dch`, rebuild, re-test on sid, and upload.
+- **Bugs**: handle reports via the Debian BTS (`bts` from `devscripts`). Treat
+  each report as useful signal, not criticism.
+- **Standards**: bump `Standards-Version` when Policy changes and re-check with
+  `lintian`.
+
+## Working with AI Assistance
+
+Using an LLM to draft packaging is acceptable, but the maintainer — not the
+tool — is accountable for the result. The practical rules are the same ones
+Homebrew states explicitly in its
+[Responsible AI Usage](https://docs.brew.sh/Responsible-AI-Usage) policy and
+that Debian reviewers expect informally:
+
+- Read, run, and test every change yourself before asking a human to review it.
+- Be able to explain and defend **every** field in `debian/` in your own words.
+- LLM training data goes stale — verify current practice against a clean `sid`
+  build and the online Policy/lintian, not the model's memory.
+- Be able to address every review comment yourself, even when the tool cannot.
+
+## Common Issues
+
+### `debhelper-compat` mismatch on an old host
+
+**Symptom**: `dpkg-buildpackage` refuses because the host's `debhelper` is older
+than the compat level in `debian/control`.
+
+**Fix**: build the source package with `-d` (skip the build-dep check) and do
+the real build in an sbuild sid chroot, which has the correct `debhelper`.
+
+### mentors: "Package has already been uploaded"
+
+**Fix**: `dput -f mentors ../esbmc_*_source.changes` to force a re-upload of the
+same version.
+
+### lintian error: `build-depends-on-build-essential-package-without-using-version`
+
+**Cause**: listing a package that `build-essential` already guarantees (e.g.
+`libc6-dev`) without a version.
+
+**Fix**: remove the dependency entirely — it is implied.
+
+## Useful Commands
+
+```bash
+# Inspect a built source package
+dpkg-source -I ../esbmc_*.dsc
+
+# Compare two builds of the package
+debdiff ../esbmc_8.4.0+dfsg-1.dsc ../esbmc_8.4.0+dfsg-2.dsc
+
+# Check the watch file resolves the latest upstream
+uscan --report --verbose
+
+# Verify version ordering
+dpkg --compare-versions 8.4.0+dfsg-1 lt 8.4.0+dfsg-2 && echo ok
+```
+
+## Related Resources
+
+- [Debian Debmake Manual](https://www.debian.org/doc/manuals/debmake-doc/)
+- [Debian Policy Manual](https://www.debian.org/doc/debian-policy/)
+- [Debian Developer's Reference](https://www.debian.org/doc/manuals/developers-reference/)
+- [Debian Mentors](https://mentors.debian.net/)
+- [Debian Code Search](https://codesearch.debian.net/) — find how other packages solve a problem
+- [ESBMC PPA Maintenance Guide](/docs/development/ppa-maintenance)
+
+---
+
+**Maintainer**: Weiqi Wang <lukewang19@icloud.com>
+**Last Updated**: 2026-07-24

--- a/website/content/docs/development/debian-packaging.md
+++ b/website/content/docs/development/debian-packaging.md
@@ -259,17 +259,29 @@ understanding — that, not the files, is what earns the upload.
 
 ## Working with AI Assistance
 
-Using an LLM to draft packaging is acceptable, but the maintainer — not the
-tool — is accountable for the result. The practical rules are the same ones
-Homebrew states explicitly in its
-[Responsible AI Usage](https://docs.brew.sh/Responsible-AI-Usage) policy and
-that Debian reviewers expect informally:
+Debian has **no formal policy** on AI-assisted contributions. A draft general
+resolution proposed by Lucas Nussbaum in February 2026 debated whether and how
+to allow LLM-generated work, but the discussion subsided without a vote — Debian
+[decided not to decide](https://lwn.net/Articles/1015143/), and such
+contributions are handled case-by-case under existing policy. The developers had
+not even converged on a shared definition of an "AI-generated contribution."
 
-- Read, run, and test every change yourself before asking a human to review it.
-- Be able to explain and defend **every** field in `debian/` in your own words.
+What the discussion *did* make clear is the operative principle: the
+maintainer — not the tool — is accountable for everything uploaded to the
+archive. The draft GR's own conditions are a sound conservative guide, and they
+echo Homebrew's explicit
+[Responsible AI Usage](https://docs.brew.sh/Responsible-AI-Usage) policy:
+
+- Read, build, and test every change yourself before asking a human to review it.
+- Be able to explain and defend **every** field in `debian/` in your own words —
+  you vouch for its technical merit, security, and license compliance.
+- Disclose AI assistance when a significant portion of a contribution comes from
+  a tool with little manual modification.
 - LLM training data goes stale — verify current practice against a clean `sid`
   build and the online Policy/lintian, not the model's memory.
 - Be able to address every review comment yourself, even when the tool cannot.
+- Never feed non-public or sensitive project material (private lists, embargoed
+  security reports) to a generative-AI service.
 
 ## Common Issues
 

--- a/website/content/docs/development/homebrew-packaging.md
+++ b/website/content/docs/development/homebrew-packaging.md
@@ -1,0 +1,135 @@
+---
+title: Homebrew Packaging Guide
+---
+
+This document explains how ESBMC can be packaged for
+[Homebrew](https://brew.sh), the macOS/Linux package manager, and what a
+maintainer must do to get a formula accepted and keep it current.
+
+> [!NOTE]
+>
+> Status: ESBMC is **not yet in `homebrew/core`**. This is a how-to and a
+> reading list for adding and maintaining a formula, not a description of an
+> existing one.
+
+## Overview
+
+Homebrew has three kinds of packages:
+
+- **Formula** — open-source software Homebrew builds from source. This is what
+  ESBMC would be.
+- **Cask** — a pre-built binary application (not applicable here).
+- **Tap** — a third-party repository of formulae. You can ship a formula from
+  your own tap immediately; getting it into the official `homebrew/core` tap
+  requires meeting the acceptance policy below.
+
+## Acceptance Requirements for `homebrew/core`
+
+Before writing anything, confirm ESBMC qualifies (it does):
+
+- **Open-source with a DFSG-compatible license** — ESBMC is Apache-2.0. ✓
+- **A stable, upstream-tagged version** — Homebrew requires a tagged release
+  with a downloadable tarball (git checkouts and untagged software are rejected
+  because bottles cannot be built for them). ESBMC tags releases as `vX.Y`
+  (e.g. `v8.4`). ✓
+- **Buildable from source** (or a cross-platform binary). ✓
+- **Notability** — the project must be established and widely used; new formulae
+  are held to a higher standard than existing ones.
+
+> [!IMPORTANT]
+>
+> Check `homebrew/core` for prior pull requests first — a previous rejection may
+> record an unresolved licensing, security, or maintenance concern.
+
+## Manuals to Read First
+
+Homebrew's rules are documented; read these before submitting:
+
+- [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook) — the authoritative
+  formula DSL and testing reference.
+- [Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae) — what
+  qualifies for `homebrew/core`.
+- [Package Acceptance Policy](https://docs.brew.sh/Package-Acceptance-Policy) —
+  general standards.
+- [How To Open a Homebrew Pull Request](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request).
+- [Responsible AI Usage](https://docs.brew.sh/Responsible-AI-Usage) — required
+  reading if you used an LLM (see below).
+- [Homebrew/homebrew-core Maintainer Guide](https://docs.brew.sh/Homebrew-homebrew-core-Maintainer-Guide).
+
+## Creating the Formula
+
+```bash
+# Generate a template from the release tarball
+brew create https://github.com/esbmc/esbmc/archive/refs/tags/v8.4.tar.gz
+```
+
+Then refine the generated Ruby formula:
+
+- Use upstream's canonical homepage (`https://esbmc.org`) and an immutable
+  source URL (the tagged tarball), verified with a SHA-256.
+- Declare **only** required dependencies (ESBMC needs a C++ toolchain, CMake,
+  Boost, Z3, GMP, fmt, yaml-cpp, and LLVM/Clang — mirror the real build system,
+  as in the [Debian dependency example](/docs/development/debian-packaging#debiancontrol--declare-minimal-justified-dependencies)).
+- Add a meaningful `test do` block — for a verifier, feed ESBMC a tiny program
+  with a known bug and assert it reports `VERIFICATION FAILED`, plus a safe
+  program that reports `VERIFICATION SUCCESSFUL`.
+
+## Building, Testing, and Auditing
+
+Run the same checks Homebrew CI runs, locally, before submitting:
+
+```bash
+# Build from source exactly as a reviewer would
+HOMEBREW_NO_INSTALL_FROM_SOURCE=1 brew install --build-from-source esbmc
+
+# Style, audit (for a new formula), and the formula's own test block
+brew style esbmc
+brew audit --new --strict --online esbmc
+brew test esbmc
+
+# Or run the combined online checks in one shot
+brew lgtm --online
+```
+
+## Opening the Pull Request
+
+```bash
+# Branch from the latest default branch of your homebrew-core fork
+git checkout -b esbmc-new origin/HEAD
+
+# After editing the formula, commit with Homebrew's "<name> <version>" convention
+git commit -am "esbmc 8.4.0"
+
+git push --set-upstream <your-fork> esbmc-new
+```
+
+Then open the PR on GitHub and explain the rationale.
+
+## Working with AI Assistance
+
+Homebrew's [Responsible AI Usage](https://docs.brew.sh/Responsible-AI-Usage)
+policy permits LLM assistance **with disclosure and full human accountability**:
+
+- **Disclose** in the pull request that AI was used, and explain how you
+  verified the changes (the PR template asks for this).
+- "AI is not responsible for its output: **you** are responsible for the output
+  of the AI tools you use."
+- **Review it yourself first** — do not ask other humans to review AI-generated
+  code until you have read it, run it, tested it, and understood it.
+- **Scrutinize mission-critical code** — anything touching installation,
+  security, downloads, or the `Formula` DSL — more carefully.
+- You must be able to **address every review comment yourself**, even when the
+  AI cannot.
+
+## Related Resources
+
+- [Homebrew Documentation](https://docs.brew.sh/)
+- [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)
+- [ESBMC Debian Packaging Guide](/docs/development/debian-packaging)
+- [ESBMC PPA Maintenance Guide](/docs/development/ppa-maintenance)
+
+---
+
+**Maintainer**: Weiqi Wang <lukewang19@icloud.com>
+**Last Updated**: 2026-07-24

--- a/website/content/docs/development/homebrew-packaging.md
+++ b/website/content/docs/development/homebrew-packaging.md
@@ -8,9 +8,11 @@ maintainer must do to get a formula accepted and keep it current.
 
 > [!NOTE]
 >
-> Status: ESBMC is **not yet in `homebrew/core`**. This is a how-to and a
-> reading list for adding and maintaining a formula, not a description of an
-> existing one.
+> Status: ESBMC is **now in `homebrew/core`** — install it with
+> `brew install esbmc`. The
+> [`esbmc` formula](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/e/esbmc.rb)
+> is the canonical example for the workflow below; this guide remains the
+> reference for keeping it current.
 
 ## Overview
 

--- a/website/content/docs/setup.md
+++ b/website/content/docs/setup.md
@@ -3,7 +3,20 @@ title: Setup
 weight: 1
 ---
 
-To install ESBMC, download the latest binary for Linux, Windows or macOS from
+## Homebrew (macOS and Linux)
+
+On macOS or Linux with [Homebrew](https://brew.sh), install ESBMC with:
+
+```sh
+brew install esbmc
+```
+
+This pulls in the bundled SMT solvers (Z3, Bitwuzla) and puts `esbmc` on your
+`PATH`.
+
+## Prebuilt binaries
+
+Alternatively, download the latest binary for Linux, Windows or macOS from
 [GitHub](https://github.com/esbmc/esbmc/releases), then save and unzip it on your
 disk.
 

--- a/website/content/docs/setup.md
+++ b/website/content/docs/setup.md
@@ -3,22 +3,34 @@ title: Setup
 weight: 1
 ---
 
-## Homebrew (macOS and Linux)
+## Ubuntu
 
-On macOS or Linux with [Homebrew](https://brew.sh), install ESBMC with:
+The easiest way to install ESBMC on Ubuntu is through our official
+[PPA](https://launchpad.net/~esbmc/+archive/ubuntu/esbmc), which provides
+releases for automatic installation:
+
+```sh
+sudo add-apt-repository ppa:esbmc/esbmc
+sudo apt update
+sudo apt install esbmc
+```
+
+This method is recommended for general users and supports Ubuntu 22.04 (Jammy)
+and 24.04 (Noble).
+
+## Homebrew (macOS and Linux)
 
 ```sh
 brew install esbmc
 ```
 
-This pulls in the bundled SMT solvers (Z3, Bitwuzla) and puts `esbmc` on your
-`PATH`.
+This installs `esbmc` together with its bundled SMT solvers (Z3, Bitwuzla).
 
-## Prebuilt binaries
+## GitHub Release
 
-Alternatively, download the latest binary for Linux, Windows or macOS from
-[GitHub](https://github.com/esbmc/esbmc/releases), then save and unzip it on your
-disk.
+You can also download the latest binary for Linux, Windows or macOS from the
+[releases page](https://github.com/esbmc/esbmc/releases), then save and unzip it
+on your disk.
 
 Once unzipped, read the license before running ESBMC. The distribution is split
 into two directories:


### PR DESCRIPTION
Adds two developer docs under `website/content/docs/development/`, alongside the existing PPA guide:

- **Debian Packaging Guide** — packaging ESBMC for the official Debian archive: the five conventions (dh, 3.0 (quilt), git, Salsa, DEP-5), DFSG repacking, minimal/justified Build-Depends (worked Boost example from CMakeLists), clean-chroot builds with sbuild, lintian, and the mentors + RFS + sponsor flow, plus ongoing maintenance.
- **Homebrew Packaging Guide** — acceptance requirements, the manuals to read, creating/auditing a formula (`brew audit --new --strict`, `brew lgtm --online`), and the PR flow.

Both include a short 'Working with AI Assistance' section aligned with Homebrew's Responsible AI Usage policy and Debian's maintainer-accountability expectations. Wires both into the Development index cards.