### PR TITLE
[docs] Refresh the symbolic-exception design note to match the tree

### DIFF
--- a/docs/design-symbolic-exceptions.md
+++ b/docs/design-symbolic-exceptions.md
@@ -28,15 +28,30 @@ function calls.
 A goto-functions transformation, `remove_exceptions`
 (`src/goto-programs/remove_exceptions.cpp`), runs after
 `remove_no_op`/`remove_unreachable` and **before** `goto_partial_inline`
-(`src/esbmc/esbmc_parseoptions.cpp`). It runs unconditionally.
+(`src/esbmc/parseoptions/process_goto_program.cpp`). It runs unconditionally.
 
-### Global exception state (`exception_globals.{h,cpp}`)
+### Exception state (`exception_globals.{h,cpp}`)
 
-Three zero-initialised globals carry the in-flight exception:
+Five zero-initialised globals carry the in-flight exception. They are
+**thread-local**: a propagating exception, its type and its object belong to the
+thread that raised it, and symex routes thread-local globals to a per-thread
+instance (`renaming.cpp`), so one thread cannot observe, catch, or clear
+another's in-flight exception. That is what makes the lowered dispatch sound
+under concurrency.
 
 - `__ESBMC_exc_thrown : _Bool` — is an exception propagating?
 - `__ESBMC_exc_typeid : size_t` — dynamic type id of the thrown object.
 - `__ESBMC_exc_value  : void*`  — pointer to a static copy of the object.
+- `__ESBMC_exc_uncaught_count : size_t` — exceptions thrown (or rethrown) in this
+  thread that have not yet entered their matching handler; backs
+  `std::uncaught_exception(s)` ([except.uncaught]).
+- `__ESBMC_exc_terminate_reason : size_t` — which terminate point routed into
+  `std::terminate()` (generic / uncaught / noexcept / exception-spec /
+  no-active-exception), so the default handler keeps the original diagnostic.
+
+Three bodyless intrinsics support rethrow and the handled-exception stack:
+`__ESBMC_push_handled_exception`, `__ESBMC_pop_handled_exception`,
+`__ESBMC_rethrow_current_exception`.
 
 ### Type-id registry (`exception_typeid.{h,cpp}`)
 
@@ -69,6 +84,10 @@ unsupported. Per function it:
 - `throw;` (rethrow) re-raises from the globals;
 - asserts *uncaught* at `main`'s epilogue.
 
+Exception specifications are **function metadata** (`goto_functiont::exception_spec`),
+not instructions: the `THROW_DECL` / `THROW_DECL_END` instruction kinds were
+removed (see the note on slots 19 and 20 in `goto_program.h`).
+
 **Unclosed-region rebalancing.** `remove_unreachable` runs before this pass and
 prunes the empty `CATCH` pop + skip-GOTO of a try whose body cannot complete
 normally — the common `try: <op that raises>; assert False; except E:` idiom,
@@ -88,16 +107,50 @@ re-inserts a behaviour-neutral `GOTO <next>` after any pop that lacks one.
 Lowered: C++ class **and primitive** throws (`throw 1`); reference, value (incl.
 single-inheritance base-by-value slicing), pointer (`catch (T*)`) and `void*`
 catches, and catch-all; nested try with inner→outer propagation; inter-procedural
-propagation through direct and indirect calls; rethrow; uncaught detection at both
-`main` and `__ESBMC_main` (the latter covers exceptions from global constructors
-during static initialisation); `noexcept` / `throw()` enforcement (an exception
-escaping a no-throw function → terminate, asserted at its epilogue); and
+propagation through direct and indirect calls; rethrow; multiple inheritance
+(catch-by-base rebinds to the correct base subobject offset); uncaught detection
+at both `main` and `__ESBMC_main` (the latter covers exceptions from global
+constructors during static initialisation); `noexcept` / `throw()` enforcement (an
+exception escaping a no-throw function → terminate, asserted at its epilogue); and
 **dynamic exception specifications** (`throw(T...)`): the epilogue check
 generalises the noexcept one — an exception in flight whose type is not in the
 specification's allowed set (`__ESBMC_exc_typeid ∈ { id(U) : U <: some listed T }`)
-is a specification violation, reported as "not allowed by declaration"
-(`std::unexpected` / handler dispatch is modelled on neither the old nor the new
-path).
+runs `std::unexpected` and re-checks, with `std::bad_exception` substitution when
+the specification allows it ([except.throw]/8, [except.unexpected]), otherwise
+reporting "not allowed by declaration".
+
+**Concurrency.** Because the exception state is thread-local, concurrent programs
+that use exceptions lower soundly. Two thread shapes are still declined (below).
+
+**Standard-library surface.** `std::set_terminate` / `std::set_unexpected` are
+honoured: the operational model (`src/cpp/library/exception`) stores the installed
+handler and `terminate()` / `unexpected()` dispatch to it. `std::exception_ptr`,
+`current_exception`, `make_exception_ptr` and `rethrow_exception` are modelled, as
+is `std::uncaught_exception(s)` (backed by `__ESBMC_exc_uncaught_count`).
+`std::throw_with_nested` / `std::rethrow_if_nested` lower with conforming
+[except.nested]/6 semantics — including the no-op case when the argument's
+*static* type is non-polymorphic.
+
+A failing `dynamic_cast<T&>` lowers to a call to the bodyless intrinsic
+`__ESBMC_throw_bad_cast`; the pass rewrites that call into an ordinary `THROW` of
+a synthesized `std::bad_cast` (`build_bad_cast_throw`) so the rest of the pipeline
+lowers it like any other throw. This works whether or not the program pulls in
+`<typeinfo>`.
+
+The **`std` exception hierarchy** lowers through the same machinery, with no
+std-specific handling: the frontend flattens a thrown std type's base chain into
+the `THROW` `exception_list` (e.g. `THROW std::runtime_error, std::exception`),
+which `register_chain` ingests, so both root and mid-hierarchy base handlers match
+(`throw std::range_error` selects `catch (std::runtime_error&)` over
+`catch (std::exception&)`). Throwing `std::bad_alloc` from `new`, calling `what()`
+in a handler, and user types deriving from `std::exception` all lower. (One
+orthogonal caveat: a `std::string` exception message drives the unbounded `strlen`
+model, so such programs need an `--unwind` bound.)
+
+**Destructor unwinding** is handled at the GOTO frontend (`convert_throw`), not in
+the lowering pass: a throw runs the destructors of the automatic objects between
+the throw point and the nearest enclosing try block ([except.ctor]), excluding the
+thrown object itself.
 
 **Python** lowers too: try/except/raise share the same THROW/CATCH machinery, the
 registry ingests Python exception ancestry from THROW `exception_list`s, and the
@@ -107,32 +160,6 @@ entry/uncaught anchor is `__ESBMC_main` (which wraps `python_user_main`). All
 from `math.factorial(-1)` — and the common `try: <raises>; assert False; except
 E:` idiom).
 
-A failing `dynamic_cast<T&>` lowers to a call to the bodyless intrinsic
-`__ESBMC_throw_bad_cast`; the pass rewrites that call into an ordinary `THROW` of
-a synthesized `std::bad_cast` (`build_bad_cast_throw`) so the rest of the pipeline
-lowers it like any other throw. If `<typeinfo>`'s `std::bad_cast` is not in the
-symbol table the program is reported as unsupported (see below).
-
-The **`std` exception hierarchy** lowers through the same machinery, with no
-std-specific handling: the frontend flattens a thrown std type's base chain into
-the `THROW` `exception_list` (e.g. `THROW std::runtime_error, std::exception`),
-which `register_chain` ingests, so a `catch (std::exception&)` base handler's
-guard matches. Throwing `std::bad_alloc` from `new`, calling `what()` in a
-handler, and user types deriving from `std::exception` all lower. (Two orthogonal
-caveats: a `std::string` exception message drives the unbounded `strlen` model,
-so such programs need an `--unwind` bound; and the frontend can omit intermediate
-bases from the flattened chain, so a catch on a mid-hierarchy base may not match —
-a frontend chain-completeness matter, not a lowering one.)
-
-**Destructor unwinding** is handled at the GOTO frontend (`convert_throw`), not in
-the lowering pass: a throw runs the destructors of the automatic objects between
-the throw point and the nearest enclosing try block ([except.ctor]), excluding the
-thrown object itself.
-
-`std::set_terminate` / `std::set_unexpected` are honoured: the operational model
-(`src/cpp/library/exception`) stores the installed handler and `terminate()` /
-`unexpected()` dispatch to it.
-
 ## Unsupported programs (reported as errors)
 
 Because lowering is the only exception path, an exception-using program outside
@@ -141,34 +168,45 @@ throws the ESBMC fatal-error idiom — a `std::string` caught by
 `process_goto_program` — logging `exception lowering: cannot lower <construct>`
 and stopping verification cleanly, rather than `abort()`/SIGABRT). The residual:
 
-- **concurrent programs that use exceptions** — the exception state is one global
-  tuple, not per-thread, so the lowered dispatch is unsound across threads (one
-  thread could observe or clear another's in-flight exception); per-thread state
-  is a separate, unimplemented feature;
+- **a thread with an unresolved start routine** (reached through a computed
+  pointer) and **a thread start routine that is also called directly** by name.
+  `is_entry` is a per-function property, but terminate-on-escape is only correct
+  on the thread-entry edge, so neither shape gets a sound per-function
+  uncaught-escape check. Declining is sound — it never validates a buggy program.
+  A sound-but-imprecise residual remains: a routine that is a clean `&worker`
+  thread entry *and* is also invoked through an indirect call elsewhere keeps
+  `is_entry` on that path, so an exception the indirect caller would catch is
+  over-reported as a terminate. Fixing that needs call-site-sensitive enforcement
+  at the pthread trampoline, blocked until thread-local state propagates across
+  its indirect call;
 - **`--function` isolated verification** of exception code (no `__ESBMC_main`
   whole-program entry, so an uncaught exception could be silently accepted);
-- **`dynamic_cast<T&>` whose `std::bad_cast` is unavailable** (the program never
-  pulls in `<typeinfo>`, so the failure-path intrinsic cannot be lowered);
-- a few unusual shapes (a value-catch without a copy binding, e.g.
-  `std::bad_exception` by value; a malformed catch clause).
+- a few unusual shapes: a value catch without a copy binding (e.g.
+  `std::bad_exception` by value), an unsupported handler shape, a malformed or
+  unmatched/trailing catch clause, a throw of an unsupported type.
 
 An exception-**free** program in any of these categories is unaffected: the pass
 is a silent no-op for it (`report_unsupported` returns early via the
-`program_uses_exceptions` guard).
+`program_uses_exceptions` guard), and the thread-shape checks only fire when the
+program actually throws or catches.
 
 ## Testing
 
-`regression/esbmc-cpp/try_catch/lower-exceptions_*` exercise the lowered path
-(simple, value-fail, nested, uncaught, rethrow, inter-procedural, indirect-call,
-value-catch, slice, primitive-fallback, empty catch-all). The unsupported-program
-errors are pinned by `lower-exceptions_concurrent` and
-`lower-exceptions_bad_cast_unsupported` (each asserting the hard error), with
-`lower-exceptions_concurrent_no_exc` as a positive control (an exception-free
-concurrent program still verifies). `unit/goto-programs/exception_typeid.test.cpp`
-covers the registry.
+`regression/esbmc-cpp/try_catch/lower-exceptions_*` (52 tests) exercise the
+lowered path: simple, value-fail, nested, uncaught, rethrow, inter-procedural,
+indirect-call, value-catch, slice, primitive-fallback, empty catch-all, multiple
+inheritance, `exception_ptr` / `make_exception_ptr`, `uncaught_exceptions`
+counting, static-init escape, `noexcept` and dynamic-spec enforcement,
+`bad_exception` substitution, `std` base-class catches, and `dynamic_cast`
+`bad_cast` with and without `<typeinfo>`. The declined thread shapes are pinned by
+`lower-exceptions_concurrent_dualuse`, `lower-exceptions_thread_computed_routine`
+and `..._fail`, with `lower-exceptions_concurrent`,
+`lower-exceptions_concurrent_throw_decl` and `lower-exceptions_concurrent_no_exc`
+as positive controls (concurrent programs that *do* lower).
+`unit/goto-programs/exception_typeid.test.cpp` covers the registry.
 
 The removed branches were discharged with a Mode-C C-Dead proof: after
-`remove_exceptions` runs, no `THROW`/`CATCH`/`THROW_DECL`/`THROW_DECL_END`
-instruction survives to symex (confirmed by `--goto-functions-only` dumps under
-both Bitwuzla and Z3); the `default:` case in symex's instruction switch
-(`log_error` + `abort`) is the backstop that would fire visibly if one ever did.
+`remove_exceptions` runs, no `THROW`/`CATCH` instruction survives to symex
+(confirmed by `--goto-functions-only` dumps under both Bitwuzla and Z3); the
+`default:` case in symex's instruction switch (`log_error` + `abort`) is the
+backstop that would fire visibly if one ever did.


### PR DESCRIPTION
`docs/design-symbolic-exceptions.md` was last updated at #5244 (2026-06-08) and
had drifted from the tree. The lowering work of #5075 is complete — and has since
gone further than the note describes, so the note now *understates* what ESBMC
supports and lists shipped features as unsupported.

Verified against `master` (453c4d84a8): `esbmc-cpp/try_catch` 172/172,
`regression/python` exception tests 35/35, unit suite 547/547.

## Corrections

| Note said | Tree does |
|---|---|
| "Three zero-initialised globals" | Five, and **thread-local** (`is_thread_local`), plus the three rethrow / handled-stack intrinsics |
| Concurrent exception programs unsupported — "the exception state is one global tuple, not per-thread" | Thread-local state makes them lower soundly; `lower-exceptions_concurrent` expects `VERIFICATION SUCCESSFUL`, not the hard error the note claimed it pinned |
| `dynamic_cast<T&>` without `<typeinfo>` declined | Supported (`lower-exceptions_bad_cast_no_typeinfo{,_fail}`) |
| `std::unexpected` "modelled on neither the old nor the new path" | Modelled via `__ESBMC_run_unexpected`, with `std::bad_exception` substitution ([except.throw]/8) — #6240 |
| std mid-hierarchy base catch "may not match" | Matches: `throw std::range_error` selects `catch (std::runtime_error&)` over `catch (std::exception&)` |
| `THROW_DECL` / `THROW_DECL_END` described as current | Removed as instruction kinds; specs are `goto_functiont::exception_spec` metadata |
| Call site `src/esbmc/esbmc_parseoptions.cpp` | Moved to `src/esbmc/parseoptions/process_goto_program.cpp` |
| Testing: ~11 tests; names `lower-exceptions_bad_cast_unsupported` | 52 tests; that name does not exist — replaced with the real ones |

## Additions

Previously undocumented surface: `std::exception_ptr` / `current_exception` /
`make_exception_ptr` / `rethrow_exception`, `std::uncaught_exception(s)` (backed
by `__ESBMC_exc_uncaught_count`), multiple-inheritance catch-by-base subobject
re-offset, and the `terminate_reason` classification that preserves the original
diagnostic through `std::terminate()`.

The residual unsupported list is narrowed to what `remove_exceptions.cpp`
actually declines: the two thread shapes (unresolved start routine; start routine
also called directly), `--function` isolated verification, and the malformed /
unbindable catch shapes — including the sound-but-imprecise gap where a routine
that is both a clean thread entry and an indirect-call target over-reports a
terminate.

## Scope

Documentation only — no source or test changes.

Relates to #5075.
