### PR TITLE
[contracts] discharge is_fresh in requires under contract replacement (#6380)

### DIFF
--- a/regression/function_contract/replace_is_fresh_polyvec_pass/main.c
+++ b/regression/function_contract/replace_is_fresh_polyvec_pass/main.c
@@ -1,0 +1,36 @@
+/* replace_is_fresh_polyvec_pass: the real-world motivating pattern for #6380 --
+ * a "vector of objects" wrapper, itself requiring the whole vector be fresh,
+ * that calls a per-element function on each element in a loop, where the
+ * per-element function's own contract requires the element be fresh.
+ *
+ * This mirrors mlkem-native's mlk_polyvec_reduce looping over MLKEM_K
+ * polynomials calling mlk_poly_reduce once per element. Before #6380 the
+ * poly-level is_fresh precondition could not be discharged under contract
+ * replacement (it failed vacuously), forcing a rewrite to != NULL and losing
+ * the non-aliasing guarantee. With the assert-side lowering, is_fresh(&v->vec[k])
+ * on the fresh vector's elements verifies. Expected: SUCCESSFUL.
+ */
+#define K 3
+#define N 4
+typedef struct { int coeffs[N]; } poly;
+typedef struct { poly vec[K]; } polyvec;
+
+void poly_reduce(poly *r)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(r, sizeof(poly)));
+  __ESBMC_assigns(r->coeffs);
+  __ESBMC_ensures(r->coeffs[0] == 0);
+  for (int i = 0; i < N; i++)
+    r->coeffs[i] = 0;
+}
+
+void polyvec_reduce(polyvec *v)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(v, sizeof(polyvec)));
+  __ESBMC_assigns(v->vec);
+  __ESBMC_ensures(v->vec[0].coeffs[0] == 0);
+  for (int k = 0; k < K; k++)
+    poly_reduce(&v->vec[k]);
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/replace_is_fresh_polyvec_pass/test.desc
+++ b/regression/function_contract/replace_is_fresh_polyvec_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function polyvec_reduce --enforce-contract polyvec_reduce --unwind 6 --replace-call-with-contract poly_reduce
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/replace_is_fresh_requires_pass/main.c
+++ b/regression/function_contract/replace_is_fresh_requires_pass/main.c
@@ -1,0 +1,36 @@
+/* replace_is_fresh_requires_pass: a callee whose requires contains
+ * __ESBMC_is_fresh must be dischargeable under --replace-call-with-contract.
+ *
+ * Regression for #6380: the replace path asserted the callee's requires clause
+ * verbatim, but __ESBMC_is_fresh was only lowered on the assume/enforce side.
+ * On the assert side its return-value temp was left undefined, so the requires
+ * assertion failed vacuously ("Could not find definition for temporary
+ * variable return_value$___ESBMC_is_fresh"), no matter what the caller passed.
+ *
+ * Here touch_outer is enforced (its own is_fresh(o) allocates a valid Outer),
+ * and touch_inner is replaced at both call sites. Its is_fresh(&o->a) /
+ * is_fresh(&o->b) preconditions are now lowered to valid_object() checks on the
+ * actual arguments, which hold because o->a and o->b are valid sub-objects of
+ * the fresh o. Expected: SUCCESSFUL.
+ */
+typedef struct { int x; } Inner;
+typedef struct { Inner a; Inner b; } Outer;
+
+void touch_inner(Inner *p)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(Inner)));
+  __ESBMC_assigns(p->x);
+  __ESBMC_ensures(p->x == 0);
+  p->x = 0;
+}
+
+void touch_outer(Outer *o)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(o, sizeof(Outer)));
+  __ESBMC_assigns(o->a, o->b);
+  __ESBMC_ensures(o->a.x == 0 && o->b.x == 0);
+  touch_inner(&o->a);
+  touch_inner(&o->b);
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/replace_is_fresh_requires_pass/test.desc
+++ b/regression/function_contract/replace_is_fresh_requires_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function touch_outer --enforce-contract touch_outer --replace-call-with-contract touch_inner
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/replace_is_fresh_requires_weak_caller_fail/main.c
+++ b/regression/function_contract/replace_is_fresh_requires_weak_caller_fail/main.c
@@ -1,0 +1,29 @@
+/* replace_is_fresh_requires_weak_caller_fail: the requires-side is_fresh lowered
+ * at a replace call site must be a REAL check, not vacuously true (#6380).
+ *
+ * touch_outer promises only o != NULL -- strictly weaker than fresh -- and
+ * cannot establish that o->a is a valid object, so touch_inner's is_fresh(&o->a)
+ * precondition is genuinely not discharged. Expected: FAILED, on the
+ * "contract requires / VALID_OBJECT(&o->a)" property. If this ever reports
+ * SUCCESSFUL the assert-side lowering has regressed to a vacuous pass.
+ */
+typedef struct { int x; } Inner;
+typedef struct { Inner a; Inner b; } Outer;
+
+void touch_inner(Inner *p)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(Inner)));
+  __ESBMC_assigns(p->x);
+  __ESBMC_ensures(p->x == 0);
+  p->x = 0;
+}
+
+void touch_outer(Outer *o)
+{
+  __ESBMC_requires(o != ((void *)0));
+  __ESBMC_assigns(o->a);
+  __ESBMC_ensures(1);
+  touch_inner(&o->a);
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/replace_is_fresh_requires_weak_caller_fail/test.desc
+++ b/regression/function_contract/replace_is_fresh_requires_weak_caller_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function touch_outer --enforce-contract touch_outer --replace-call-with-contract touch_inner
+^VERIFICATION FAILED$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -1520,8 +1520,8 @@ goto_programt code_contractst::generate_checking_wrapper(
 
     // Replace is_fresh temp vars with verification: valid_object(ptr) && is_dynamic[ptr]
     if (!is_fresh_mappings.empty())
-      ensures_guard =
-        replace_is_fresh_in_ensures_expr(ensures_guard, is_fresh_mappings);
+      ensures_guard = replace_is_fresh_temps(
+        ensures_guard, is_fresh_mappings, /*require_dynamic=*/true);
   }
 
   // Extract struct member accesses to temporary variables before ASSERT
@@ -1950,9 +1950,10 @@ code_contractst::extract_is_fresh_mappings_from_body(
   return mappings;
 }
 
-expr2tc code_contractst::replace_is_fresh_in_ensures_expr(
+expr2tc code_contractst::replace_is_fresh_temps(
   const expr2tc &expr,
-  const std::vector<is_fresh_mapping_t> &mappings) const
+  const std::vector<is_fresh_mapping_t> &mappings,
+  bool require_dynamic) const
 {
   if (is_nil_expr(expr))
     return expr;
@@ -1964,8 +1965,25 @@ expr2tc code_contractst::replace_is_fresh_in_ensures_expr(
     {
       if (sym.thename == mapping.temp_var_name)
       {
-        // Replace with: valid_object(ptr) && is_dynamic[POINTER_OBJECT(ptr)]
+        // Lower is_fresh(p) to a concrete predicate on the pointed-to object.
+        //
+        // ensures side (require_dynamic == true):
+        //   valid_object(p) && is_dynamic[POINTER_OBJECT(p)] -- the
+        //   postcondition promises a freshly heap-allocated object.
+        //
+        // requires side at a --replace-call-with-contract call site
+        // (require_dynamic == false):
+        //   valid_object(p) only. The precondition is *asserted* against the
+        //   caller's argument here, and a real caller legitimately passes a
+        //   live stack object or an interior sub-object (e.g. &v->vec[k] of a
+        //   fresh vector) -- valid, but not heap-dynamic. Requiring is_dynamic
+        //   would reject every such caller and make is_fresh unusable under
+        //   contract replacement; the frame guarantee is carried by the
+        //   callee's assigns clause, not by heap-freshness. (#6380)
         expr2tc valid_obj = valid_object2tc(mapping.ptr_expr);
+        if (!require_dynamic)
+          return valid_obj;
+
         expr2tc ptr_obj = pointer_object2tc(pointer_type2(), mapping.ptr_expr);
 
         const symbolt *dyn_sym = ns.lookup("c:@__ESBMC_is_dynamic");
@@ -1984,8 +2002,8 @@ expr2tc code_contractst::replace_is_fresh_in_ensures_expr(
   }
 
   expr2tc new_expr = expr;
-  new_expr->Foreach_operand([this, &mappings](expr2tc &op) {
-    op = replace_is_fresh_in_ensures_expr(op, mappings);
+  new_expr->Foreach_operand([this, &mappings, require_dynamic](expr2tc &op) {
+    op = replace_is_fresh_temps(op, mappings, require_dynamic);
   });
 
   return new_expr;
@@ -3738,6 +3756,65 @@ void code_contractst::generate_replacement_at_call(
   };
 
   // 1. Assert requires clause (check precondition at call site)
+  //
+  // Lower any __ESBMC_is_fresh(p, n) in the requires clause to a concrete,
+  // dischargeable predicate before asserting it. On the assume/enforce side
+  // is_fresh is realised by allocation (section 0 of generate_checking_wrapper);
+  // here the precondition is *checked* against the caller's argument, so the
+  // raw is_fresh() intrinsic -- whose return-value temp is never defined in the
+  // caller -- would be asserted against an undefined value and fail vacuously
+  // (#6380). We build the temp -> pointer mapping from the *actual* argument at
+  // this call site (with its real pointee type, so we never dereference through
+  // the frontend's void* cast), then replace_is_fresh_temps rewrites the temp
+  // to valid_object() on the pointed-to object.
+  if (!is_nil_expr(requires_clause) && function_symbol.get_type().is_code())
+  {
+    const code_typet &code_type = to_code_type(function_symbol.get_type());
+    const code_typet::argumentst &params = code_type.arguments();
+
+    std::vector<is_fresh_mapping_t> req_is_fresh;
+    forall_goto_program_instructions (it, function_body)
+    {
+      if (!it->is_function_call() || !is_code_function_call2t(it->code))
+        continue;
+      const code_function_call2t &c = to_code_function_call2t(it->code);
+      if (
+        !is_symbol2t(c.function) ||
+        !is_fresh_function(to_symbol2t(c.function).thename.as_string()) ||
+        c.operands.size() < 2 || is_nil_expr(c.ret) || !is_symbol2t(c.ret))
+        continue;
+
+      // Recover the guarded pointer, stripping the void* cast the frontend
+      // inserts, then rebind the callee's formal parameter to the actual
+      // argument passed at this call site.
+      expr2tc ptr = c.operands[0];
+      while (is_typecast2t(ptr))
+        ptr = to_typecast2t(ptr).from;
+      for (size_t i = 0; i < params.size() && i < actual_args.size(); ++i)
+      {
+        expr2tc param_expr =
+          symbol2tc(migrate_type(params[i].type()), params[i].get_identifier());
+        ptr = replace_symbol_in_expr(ptr, param_expr, actual_args[i]);
+      }
+      if (!is_pointer_type(ptr->type))
+        continue;
+
+      // valid_object() takes a pointer operand (cf. the canonical
+      // valid_object2tc(address_of(obj)) in dereference.cpp), so pass the
+      // argument pointer directly -- do not dereference it, which would both
+      // add a spurious bounds check and (through the frontend's void* cast)
+      // build an ill-typed array-select.
+      is_fresh_mapping_t m;
+      m.temp_var_name = to_symbol2t(c.ret).thename;
+      m.ptr_expr = ptr;
+      req_is_fresh.push_back(m);
+    }
+
+    if (!req_is_fresh.empty())
+      requires_clause = replace_is_fresh_temps(
+        requires_clause, req_is_fresh, /*require_dynamic=*/false);
+  }
+
   add_contract_clause(
     requires_clause, ASSERT, "contract requires", "contract requires");
 

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -486,13 +486,18 @@ private:
   std::vector<is_fresh_mapping_t>
   extract_is_fresh_mappings_from_body(const goto_programt &function_body) const;
 
-  /// \brief Replace is_fresh temporary variables in ensures with verification expressions
+  /// \brief Replace is_fresh temporary variables with a concrete predicate.
   /// \param expr Expression containing is_fresh temp variables
   /// \param mappings Vector of is_fresh mappings
-  /// \return Expression with is_fresh temp variables replaced by verification expressions
-  expr2tc replace_is_fresh_in_ensures_expr(
+  /// \param require_dynamic true for ensures (valid_object && is_dynamic);
+  ///   false for a requires clause asserted at a --replace-call-with-contract
+  ///   call site (valid_object only, so live stack/interior sub-objects are
+  ///   accepted, #6380).
+  /// \return Expression with is_fresh temp variables replaced
+  expr2tc replace_is_fresh_temps(
     const expr2tc &expr,
-    const std::vector<is_fresh_mapping_t> &mappings) const;
+    const std::vector<is_fresh_mapping_t> &mappings,
+    bool require_dynamic) const;
 
   /// \brief Havoc assigns targets (similar to loop invariant approach)
   /// \param assigns_clause Assigns clause expression


### PR DESCRIPTION
## What

Fixes #6380: `__ESBMC_is_fresh` in a `requires` clause could not be discharged under `--replace-call-with-contract`, so is_fresh was effectively unusable for compositional (replace-side) verification.

## Root cause

`generate_replacement_at_call` asserted the replaced callee's `requires` clause **verbatim**. But `__ESBMC_is_fresh` was only lowered on the assume/enforce side (section 0 of the checking wrapper, which allocates the fresh object). On the assert side its `return_value$___ESBMC_is_fresh` temporary was never defined, so the requires assertion was checked against an undefined value and **failed vacuously for every caller** — regardless of nesting, sub-object access, or whether the enclosing object was itself fresh. (Minimal trigger: any replaced callee with is_fresh in `requires`, even passing a base pointer directly.)

## Fix

Before asserting the requires clause, lower each `is_fresh(p)` to a concrete predicate on the **actual argument** at the call site:

- Assert `valid_object(p)` on the caller's argument pointer.
- **Drop** the `is_dynamic` conjunct used on the ensures side: a real caller legitimately passes a live stack object or an interior sub-object (e.g. `&v->vec[k]` of a fresh vector) — valid, but not heap-dynamic. Requiring `is_dynamic` would reject every real caller. The frame guarantee is carried by the callee's `assigns` clause, not by heap-freshness.
- The mapping is built from the actual argument (with its real pointee type), so we never dereference through the frontend's `void*` cast.

`replace_is_fresh_in_ensures_expr` is generalised to `replace_is_fresh_temps(..., bool require_dynamic)` serving both sides (ensures: `true`, requires: `false`).

This unblocks the real-world motivating pattern — a fresh-vector wrapper (`mlk_polyvec_reduce`) looping over a per-element is_fresh callee (`mlk_poly_reduce`) — which now verifies compositionally with is_fresh intact, instead of forcing a rewrite to `!= NULL` that loses the non-aliasing guarantee.

## Tests

Three regression tests under `regression/function_contract/`:

- `replace_is_fresh_requires_pass` — nested is_fresh on struct sub-objects → SUCCESSFUL.
- `replace_is_fresh_polyvec_pass` — the vector-of-objects loop pattern → SUCCESSFUL.
- `replace_is_fresh_requires_weak_caller_fail` — a caller establishing only `!= NULL` cannot discharge the callee's is_fresh; guards against a vacuous-pass regression → FAILED.

Full `function_contract` suite green (no regressions). Depends on #6356/#6298, both already in `master`.
