### PR TITLE
[test] Point ctest_gen_multifile_cov CHECK_FILE at the real output

### DIFF
--- a/regression/witnesses/test_case_generation/ctest_gen_multifile_cov/test.desc
+++ b/regression/witnesses/test_case_generation/ctest_gen_multifile_cov/test.desc
@@ -4,5 +4,5 @@ main.c --branch-coverage --generate-ctest-testcase
 ^Branch Coverage: 100%$
 ^Generated 4 CTest test case\(s\) with CMakeLists\.txt
 ^VERIFICATION FAILED$
-CHECK_FILE CMakeLists.txt contains ^add_executable\(test_case_1 "[^"]*/main\.c" "[^"]*/helper\.c" test_case_1\.c\)$
-CHECK_FILE CMakeLists.txt contains ^add_executable\(test_case_4 "[^"]*/main\.c" "[^"]*/helper\.c" test_case_4\.c\)$
+CHECK_FILE esbmc-ctest/CMakeLists.txt contains ^add_executable\(test_case_1 [^ ]*/main\.c [^ ]*/helper\.c test_case_1\.c\)$
+CHECK_FILE esbmc-ctest/CMakeLists.txt contains ^add_executable\(test_case_4 [^ ]*/main\.c [^ ]*/helper\.c test_case_4\.c\)$


### PR DESCRIPTION
The `ctest_gen_multifile_cov` regression test fails on master, blocking the required Ubuntu check on unrelated PRs. Its two `CHECK_FILE` lines are wrong in two independent ways:

1. **Missing the `esbmc-ctest/` prefix.** The generated project moved into a dedicated directory in #6219, so the lookup reports `CHECK_FILE file not found: CMakeLists.txt`.
2. **Quoted-path expectations the writer never emits.** `sources_to_cmake_list` (`src/goto-symex/ctest.cpp:545`) joins bare absolute paths with spaces, so `"[^"]*/main\.c"` cannot match even once the path is corrected.

All eleven sibling tests in `regression/witnesses/test_case_generation/` already use `CHECK_FILE esbmc-ctest/CMakeLists.txt` with unquoted paths; this one was the only outlier. Aligned it with them.

Verified: the test now passes, and the full `test_case_generation` suite is green (37/37).