### PR TITLE
[python] Decay a returned function designator in python_adjust

### DIFF
--- a/docs/roadmap/scope-v1k-adjuster.md
+++ b/docs/roadmap/scope-v1k-adjuster.md
@@ -544,3 +544,42 @@ four no-verdict cases (`github_3012_3_fail`, `higher-order3`,
 `int_to_bytes_kwargs_fail`, `ternary_string_fail`,
 `github_4796_object_handle_eq_fail`) — each needing its own triage rather than a
 shared mechanism.
+
+### Per-case triage round 1 — `higher-order3` was a missing function→pointer decay (2026-07-25)
+
+Triaging the no-verdict list one case at a time immediately paid off: three of
+the five turned out to have *distinct* signatures, and the first is another
+one-arm structural mirror, not a per-case oddity.
+
+| Case | Reproduced signature under hop-off |
+|---|---|
+| `higher-order3` | `ERROR: Unexpected type in int/ptr typecast` (`smt_casts.cpp:228`), plus `No target candidate for function call *times3` |
+| `github_3012_3_fail` | `bitwuzla: … term with unexpected sort at index 0` |
+| `int_to_bytes_kwargs_fail` | `ERROR: shr` |
+| `ternary_string_fail`, `github_4796_object_handle_eq_fail` | silent no-verdict |
+
+**✅ FIXED — `higher-order3`.** The GOTO diff against legacy pins it in one line:
+legacy emits `RETURN: &make_multiplier@F@mul`, the hop-off emits
+`RETURN: make_multiplier@F@mul` — a bare code-typed *function designator*. The
+caller then holds `typecast(mul, double (*)(void *))`, which
+`convert_typecast_to_ints` cannot encode (its `from` is neither sbv/ubv/fbv/fpbv
+nor bool) and which symex cannot resolve to a call target.
+`clang_c_adjust::adjust_symbol_expr` (`clang_c_adjust_expr.cpp:246-253`) decays
+*every* code-typed symbol reference to an implicit `&f` ("special case: this is
+sugar for &f", C11 6.3.2.1p4); `python_adjust` did not. The fix is a
+`code_return2t` arm mirroring it at the one seam Python reaches this from —
+deliberately narrower than clang's universal symbol decay, because the callee
+position of a call is already owned by `wrap_function_pointer_callee` and a
+blanket decay would fight it. Same family as the array→pointer decay (#6363):
+**the third "per-case" bucket entry to dissolve into a missing clang mirror.**
+
+**Note on closure capture.** The matched test pair deliberately returns a
+*non-capturing* nested `def`. `higher-order3`'s own `make_multiplier(3)` /
+`times3(4)` free-variable capture is wrong on **both** paths (an
+`assert times3(4) == 12` fails under legacy too) — a pre-existing frontend gap,
+at parity, and out of scope here.
+
+**Direction, restated.** The per-case list is not a homogeneous bucket. Reproduce
+each signature separately before assuming a shared cause: two of the five are
+solver-level (`bitwuzla` sort, `shr`) and two are still silent. The remaining
+four are the next slices.

--- a/regression/python/python_irep2_adjust_only_func_decay/main.py
+++ b/regression/python/python_irep2_adjust_only_func_decay/main.py
@@ -1,0 +1,14 @@
+# Exercises the --python-irep2-adjust-only function->pointer decay arm: a
+# factory returns a bare code-typed designator, which must decay to `&triple`
+# (C11 6.3.2.1p4) before symex, or the indirect call has no target and SMT
+# encoding aborts on "Unexpected type in int/ptr typecast". No free variable is
+# captured -- closure capture is a separate, pre-existing gap on both paths.
+def get_tripler():
+    def triple(x: int) -> int:
+        return x * 3
+
+    return triple
+
+
+f = get_tripler()
+assert f(4) == 12

--- a/regression/python/python_irep2_adjust_only_func_decay/test.desc
+++ b/regression/python/python_irep2_adjust_only_func_decay/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_only_func_decay_fail/main.py
+++ b/regression/python/python_irep2_adjust_only_func_decay_fail/main.py
@@ -1,0 +1,12 @@
+# Negative counterpart: the same decayed function pointer under the hop-off
+# path, with a false assertion. The decay must reach the solver and report the
+# violation, not mask it behind an unresolvable indirect call.
+def get_tripler():
+    def triple(x: int) -> int:
+        return x * 3
+
+    return triple
+
+
+f = get_tripler()
+assert f(4) == 99

--- a/regression/python/python_irep2_adjust_only_func_decay_fail/test.desc
+++ b/regression/python/python_irep2_adjust_only_func_decay_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -303,6 +303,22 @@ void python_adjust::adjust_expr(expr2tc &expr)
       address_of2tc(pointee, index2tc(elem, a.source, gen_zero(index_type2())));
     expr = code_assign2tc(a.target, decayed, a.location);
   }
+  else if (
+    is_code_return2t(expr) && !is_nil_expr(to_code_return2t(expr).operand) &&
+    is_code_type(to_code_return2t(expr).operand->type))
+  {
+    // Function→pointer decay at the return seam (C11 6.3.2.1p4): a closure
+    // factory (`def make(k): def mul(x): ...; return mul`) returns a bare
+    // code-typed designator, but the caller stores it in a function pointer.
+    // clang_c_adjust decays every code-typed symbol reference to `&f`
+    // (adjust_symbol_expr, "sugar for &f"); mirror it at the one seam Python
+    // reaches it from. Without it symex sees `typecast(mul, void(*)())` and
+    // aborts at SMT encoding ("Unexpected type in int/ptr typecast"), and the
+    // indirect call has no resolvable target.
+    const code_return2t &r = to_code_return2t(expr);
+    expr =
+      code_return2tc(address_of2tc(r.operand->type, r.operand), r.location);
+  }
   else if (is_constant_struct2t(expr) && is_symbol_type(expr->type))
   {
     // S2: aggregate-literal completion — the third relaxed construction


### PR DESCRIPTION
## Problem

Under `--python-irep2-adjust-only` (the V.4 hop-off, where `python_adjust`
*replaces* `clang_cpp_adjust` on the Python path), a factory returning a nested
`def` lowers to a bare code-typed function designator:

```
# hop-off                        # legacy
RETURN: make_multiplier@F@mul    RETURN: &make_multiplier@F@mul
```

The caller then holds `typecast(mul, double (*)(void *))`.
`convert_typecast_to_ints` cannot encode that — its `from` is neither
sbv/ubv/fbv/fpbv nor bool — so encoding aborts:

```
No target candidate for function call *times3
ERROR: Unexpected type in int/ptr typecast
```

`regression/python/higher-order3` reports `VERIFICATION SUCCESSFUL` on the
default path and no verdict at all under the flag. It is one of the five
"no-verdict" divergences listed in `docs/roadmap/scope-v1k-adjuster.md`.

## Fix

`clang_c_adjust::adjust_symbol_expr` (`clang_c_adjust_expr.cpp:246-253`) decays
*every* code-typed symbol reference to an implicit `&f` — "special case: this is
sugar for &f", C11 6.3.2.1p4. `python_adjust` did not. This adds a
`code_return2t` arm mirroring it.

The arm is deliberately narrower than clang's universal symbol decay: the callee
position of a call is already owned by `wrap_function_pointer_callee`, so a
blanket decay would fight it. `return` is the one seam the Python frontend
reaches a bare designator from.

Same family as the array→pointer decay (#6363) — the third "per-case" divergence
to dissolve into a missing `clang_c_adjust` mirror rather than needing its own
infrastructure.

## Scope

`python_adjust` is constructed **only** under the flag
(`python_language.cpp:299-303`), so the default pipeline is untouched by
construction.

## Verification

- `higher-order3` under the flag: `ERROR: Unexpected type in int/ptr typecast` →
  `VERIFICATION SUCCESSFUL`, matching the default path; the GOTO body is now
  byte-identical to legacy at the return (`RETURN: &make_multiplier@F@mul`).
- Matched hop-off test pair added
  (`python_irep2_adjust_only_func_decay{,_fail}`), both agreeing with the
  default path. The pair returns a *non-capturing* nested `def` on purpose:
  `higher-order3`'s own free-variable capture is wrong on **both** paths (an
  `assert times3(4) == 12` fails under legacy too) — a pre-existing frontend gap,
  at parity, and out of scope here.
- `ctest -R regression/python/python_irep2_adjust`: 16/16 pass.
- Branch liveness (C-Live) is shown directly by the GOTO diff, not just a
  reachability VCC: the emitted body changes from `mul` to `&mul`.

`docs/roadmap/scope-v1k-adjuster.md` records the per-case triage round, including
the three now-distinct signatures behind the remaining four divergences
(`bitwuzla` sort error, `ERROR: shr`, and two silent no-verdicts) as the next
slices.