### PR TITLE
[cpp] Make typeid on a polymorphic glvalue report the dynamic type

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic/main.cpp
@@ -1,0 +1,90 @@
+// github #6310: typeid on a polymorphic glvalue must reflect the *dynamic*
+// type. It used to be keyed on the operand's static type, so typeid(*p) with
+// p an A* answered "A" whatever p pointed at.
+#include <cassert>
+#include <cstring>
+#include <typeinfo>
+
+struct A
+{
+  virtual ~A()
+  {
+  }
+};
+struct B : A
+{
+};
+struct C : A
+{
+};
+struct D : B
+{
+};
+
+struct M1
+{
+  virtual ~M1()
+  {
+  }
+};
+struct M2
+{
+  virtual ~M2()
+  {
+  }
+};
+struct MD : M1, M2
+{
+};
+
+extern bool nondet_bool();
+
+int main()
+{
+  A *p = new B();
+  A *q = new C();
+  A *r = new D();
+  A a;
+  B b;
+  A &ref = b;
+
+  assert(typeid(*p) == typeid(B));
+  assert(typeid(*p) != typeid(A));
+  assert(typeid(*q) == typeid(C));
+  assert(typeid(*p) != typeid(*q));
+  assert(typeid(*r) == typeid(D)); // two levels down
+  assert(typeid(*r) != typeid(B));
+  assert(typeid(ref) == typeid(B)); // through a base reference
+  assert(typeid(ref) == typeid(*p));
+  assert(typeid(*p) != typeid(int));
+
+  // A most-derived operand still answers its own type.
+  assert(typeid(a) == typeid(A));
+  assert(typeid(b) == typeid(B));
+  assert(typeid(a) != typeid(b));
+
+  // name() follows the dynamic type too.
+  assert(strcmp(typeid(*p).name(), typeid(B).name()) == 0);
+
+  delete p;
+  delete q;
+  delete r;
+
+  // Either base subobject's vptr answers with the most-derived type.
+  MD md;
+  M1 *m1 = &md;
+  M2 *m2 = &md;
+  assert(typeid(*m1) == typeid(MD));
+  assert(typeid(*m2) == typeid(MD));
+  assert(typeid(*m1) == typeid(*m2));
+  assert(typeid(*m2) != typeid(M2));
+
+  // The dynamic type is not a compile-time constant here.
+  bool c = nondet_bool();
+  A *s = c ? (A *)new C() : (A *)new B();
+  assert((typeid(*s) == typeid(C)) == c);
+  assert(typeid(*s) != typeid(A));
+  delete s;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic_fail/main.cpp
@@ -1,0 +1,26 @@
+// github #6310, negative direction: the dynamic type must be able to make a
+// typeid comparison false, so the checks in github_6310_typeid_dynamic are not
+// vacuously discharged.
+#include <cassert>
+#include <typeinfo>
+
+struct A
+{
+  virtual ~A()
+  {
+  }
+};
+struct B : A
+{
+};
+struct C : A
+{
+};
+
+int main()
+{
+  A *p = new B();
+  assert(typeid(*p) == typeid(C));
+  delete p;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6310_typeid_dynamic_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1221,44 +1221,38 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
     std::string type_name;
     // For a polymorphic glvalue operand, [expr.typeid]/2 requires the operand
-    // to be evaluated (the dynamic type is read from the object's vtable). We
-    // model that by reading the operand's vtable pointer, so a typeid applied
-    // to `*p` with a null `p` faults on the dereference — the standard mandates
-    // std::bad_typeid there. `vtable_read` holds that read when applicable.
+    // to be evaluated: the answer is the *dynamic* type, which is only
+    // reachable through the object's vtable. `vtable_read` holds that read when
+    // applicable; it also faults on a null `*p`, as std::bad_typeid mandates.
     exprt vtable_read = nil_exprt();
+    // Name of the vtable component holding the dynamic type's printed name,
+    // empty unless the operand is a polymorphic glvalue.
+    irep_idt dynamic_name_comp;
     if (cxxtid.isTypeOperand())
     {
       const clang::QualType qtype = cxxtid.getTypeOperand(*ASTContext);
-      type_name = qtype.getAsString();
+      type_name = rtti_type_name(qtype);
     }
     else
     {
       const clang::QualType qtype = cxxtid.getExprOperand()->getType();
-      type_name = qtype.getAsString();
+      type_name = rtti_type_name(qtype);
 
       const clang::CXXRecordDecl *rd = qtype->getAsCXXRecordDecl();
-      // [expr.typeid]/2 singles out the case where the operand is obtained by
-      // dereferencing a pointer: a null pointer there yields std::bad_typeid.
-      // Detect that `*p` form at the AST level so a plain lvalue operand (which
-      // cannot be null) keeps its existing handling untouched.
-      const auto *unary = llvm::dyn_cast<clang::UnaryOperator>(
-        cxxtid.getExprOperand()->IgnoreParenImpCasts());
-      const bool is_deref_operand =
-        unary && unary->getOpcode() == clang::UO_Deref;
-      if (
-        !cxxtid.isMostDerived(*ASTContext) && rd && rd->isPolymorphic() &&
-        is_deref_operand)
+      if (!cxxtid.isMostDerived(*ASTContext) && rd && rd->isPolymorphic())
       {
         exprt operand;
         if (get_expr(*cxxtid.getExprOperand(), operand))
           return true;
 
         const typet &op_type = ns.follow(operand.type());
-        if (operand.id() == "dereference" && op_type.is_struct())
+        if (op_type.is_struct())
           for (const auto &comp : to_struct_type(op_type).components())
             if (comp.get_bool("is_vtptr"))
             {
               vtable_read = member_exprt(operand, comp.name(), comp.type());
+              dynamic_name_comp = rtti_name_component_id(
+                to_pointer_type(comp.type()).subtype().identifier());
               break;
             }
       }
@@ -1277,9 +1271,21 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     // assigned to the temporary object
     // tmp = { .__name=&"int"[0], .std::type_info@vtable_pointer=0 }
     // const std::type_info& = &tmp
-    // Front end can't account for polymorphism
+    // type_info identity is the __name pointer, so for a polymorphic glvalue
+    // __name is taken from the vtable the object actually points at rather than
+    // from the operand's static type -- that is what makes the result reflect
+    // the dynamic type (#6310).
+    exprt name = address_of_exprt(string_name);
+    if (!dynamic_name_comp.empty())
+    {
+      name = member_exprt(
+        dereference_exprt(vtable_read, vtable_read.type()),
+        dynamic_name_comp,
+        pointer_typet(char_type()));
+    }
+
     exprt sym("struct", t);
-    sym.copy_to_operands(address_of_exprt(string_name));
+    sym.copy_to_operands(name);
     if (vtable_read.is_not_nil())
     {
       // Reading the vtable pointer dereferences the operand, so a null operand

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -345,6 +345,15 @@ protected:
    */
   std::string vtable_type_prefix = "virtual_table::";
   std::string vtable_ptr_suffix = "@vtable_pointer";
+  /* Leading component of every vtable type: a pointer to the printed name of
+   * the most-derived class the vtable belongs to. Reading it through an
+   * object's vptr is how `typeid` recovers the dynamic type (#6310). */
+  static irep_idt rtti_name_component_id(const irep_idt &vtable_type_id);
+  static struct_typet::componentt
+  rtti_name_component(const irep_idt &vtable_type_id);
+  /* The single spelling of a type used as typeid identity; see #6310. */
+  static std::string rtti_type_name(const clang::QualType &qtype);
+  static std::string rtti_type_name(const clang::CXXRecordDecl &rd);
   // if a class/struct has vptr component, it needs to be initialized in ctor
   bool has_vptr_component = false;
   std::string thunk_prefix = "thunk::";

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -31,6 +31,7 @@ CC_DIAGNOSTIC_POP()
 #include <util/arith/arith_tools.h>
 #include <util/lang/c_types.h>
 #include <util/expr/expr_util.h>
+#include <util/expr/string_constant.h>
 #include <util/message/message.h>
 #include <util/irep/std_code.h>
 #include <util/irep/std_expr.h>
@@ -175,6 +176,52 @@ symbolt *clang_cpp_convertert::check_vtable_type_symbol_existence(
   return context.find_symbol(vt_name);
 }
 
+/* typeid identity is the address of the printed type name, so every spelling of
+ * one type must print identically. Route record types through the record decl
+ * so that sugar (typedefs, elaborated `struct X`) cannot make the same class
+ * print two ways -- which is also what [expr.typeid]/1 requires, the operand's
+ * cv-qualifiers and typedefs being irrelevant. */
+std::string clang_cpp_convertert::rtti_type_name(const clang::QualType &qtype)
+{
+  if (const clang::CXXRecordDecl *rd = qtype->getAsCXXRecordDecl())
+    return rtti_type_name(*rd);
+  return qtype.getUnqualifiedType().getAsString();
+}
+
+std::string clang_cpp_convertert::rtti_type_name(const clang::CXXRecordDecl &rd)
+{
+#if CLANG_VERSION_MAJOR >= 22
+  const clang::QualType qtype = rd.getASTContext().getCanonicalTagType(&rd);
+#else
+  const clang::QualType qtype = rd.getASTContext().getRecordType(&rd);
+#endif
+  // The canonical type prints with the tag keyword ("struct B"); an operand's
+  // sugared type does not. Suppress it so both spellings agree and name() keeps
+  // reading as it did before.
+  clang::PrintingPolicy pp = rd.getASTContext().getPrintingPolicy();
+  pp.SuppressTagKeyword = true;
+  return qtype.getAsString(pp);
+}
+
+irep_idt
+clang_cpp_convertert::rtti_name_component_id(const irep_idt &vtable_type_id)
+{
+  return vtable_type_id.as_string() + "::@rtti_name";
+}
+
+struct_typet::componentt
+clang_cpp_convertert::rtti_name_component(const irep_idt &vtable_type_id)
+{
+  struct_typet::componentt c;
+  c.type() = pointer_typet(char_type());
+  c.set_name(rtti_name_component_id(vtable_type_id));
+  c.set("base_name", "@rtti_name");
+  c.set("pretty_name", "@rtti_name");
+  c.set("access", "public");
+  c.set("is_rtti_name", true);
+  return c;
+}
+
 symbolt *clang_cpp_convertert::add_vtable_type_symbol(
   const struct_typet::componentt &comp,
   struct_typet &type)
@@ -199,6 +246,11 @@ symbolt *clang_cpp_convertert::add_vtable_type_symbol(
   {
     struct_typet st;
     st.set("name", vt_type_symb.id);
+    // Every vtable leads with the most-derived type's name, the way a real
+    // Itanium-ABI vtable leads with a type_info pointer. `typeid` on a
+    // polymorphic glvalue reads it through the object's vptr, which is the only
+    // way the dynamic type is available at a use site typed by a base (#6310).
+    st.components().push_back(rtti_name_component(vt_name));
     vt_type_symb.set_type(std::move(st));
   }
   vt_type_symb.is_type = true;
@@ -695,6 +747,16 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
     exprt values("struct", symbol_typet(vt_symb_type->id));
     for (const auto &compo : vt_type.components())
     {
+      if (compo.get_bool("is_rtti_name"))
+      {
+        // The vtable belongs to the most-derived class cxxrd, whatever base
+        // class' vptr selects it, so this is where the dynamic type is pinned.
+        exprt name = address_of_exprt(string_constantt(rtti_type_name(cxxrd)));
+        gen_typecast(ns, name, compo.type());
+        values.operands().push_back(name);
+        continue;
+      }
+
       std::map<irep_idt, exprt>::const_iterator cit2 =
         switch_map.find(compo.get("virtual_name").as_string());
       assert(cit2 != switch_map.end());


### PR DESCRIPTION
Fixes #6310.

## Root cause

`std::type_info` identity in ESBMC's model (`src/cpp/library/typeinfo`) is the
`__name` pointer, and `CXXTypeidExprClass` filled `__name` from the operand's
**static** type. For `typeid(*p)` with `p` an `A*`, that is `"A"` regardless of
what `p` points at, so every runtime type query answered by the static type:
`typeid(*p) == typeid(B)` was false, `typeid(*p) == typeid(A)` was true, and two
objects with different dynamic types compared equal. The vtable pointer was read
into the second field but never used for identity.

## Fix

Give every vtable a leading `@rtti_name` component holding a pointer to the
printed name of the **most-derived** class the vtable belongs to — structurally
what an Itanium-ABI vtable does by carrying a `type_info` pointer. A polymorphic
glvalue then takes `__name` from `(*vptr).@rtti_name` instead of from its static
type, which is the only place the dynamic type is available at a use site typed
by a base.

Storing the *name* rather than the vtable address matters: ESBMC emits a
separate vtable per (vptr-class, most-derived-class) pair, so `virtual_table::A@B`
and `virtual_table::B@B` are distinct addresses that both denote dynamic type
`B`. Keying identity on the vtable address would therefore answer differently
depending on which base subobject the operand was reached through; keying on the
name it carries is stable across all of them, and multiple inheritance works for
the same reason (both `M1*` and `M2*` into an `MD` object reach a vtable naming
`MD`).

Two supporting details:

- Identity is pointer equality on an interned string, so a type must print
  identically everywhere. `rtti_type_name` routes record types through the
  record decl and suppresses the tag keyword, so sugar (typedefs, elaborated
  `struct X`) cannot make one class print two ways. This also matches
  [expr.typeid]/1, under which typedefs and cv-qualifiers are irrelevant.
- The vtable read now fires for any polymorphic glvalue, not only the `*p` form,
  so `typeid(ref)` through a base reference is answered dynamically too. The
  existing null-`*p` fault that models `std::bad_typeid` is unchanged.

The model in `src/cpp/library/typeinfo` needed no change — `operator==`,
`name()`, `hash_code()` and `before()` all key on `__name`, which is now the
dynamic name. `name()` gains the same fix for free.

## Tests

- `regression/esbmc-cpp/cpp/github_6310_typeid_dynamic` — the issue reproducer
  plus: two-level derivation, cross-hierarchy inequality, a base reference,
  most-derived operands (unchanged behaviour), `name()`, multiple inheritance
  through either base, and a case where the dynamic type depends on a nondet
  bool so the answer cannot be constant-folded. Fails on unpatched master.
- `regression/esbmc-cpp/cpp/github_6310_typeid_dynamic_fail` — `typeid(*p) ==
  typeid(C)` for a `B` object; FAILED. This one also fails-as-expected before
  the patch (for the wrong reason), so it is a non-vacuity guard for the
  positive test rather than a second reproducer.

## Suites

Full `regression/esbmc-cpp*` (2555 tests) run patched and compared against an
unpatched build of the same tree. Same 9 failures either way — all pre-existing
macOS/libc++ environment failures (`github_2242_*`, `github_3897_collision`,
`github_6200_fail`, `github_6227_fail`, `github_6229_fail`, `utility2_fail`,
`builtin-template*`). A further 14 tests timed out only in a `-j14` run and pass
in under a second when re-run unloaded, so they are load artefacts, not
regressions; the polymorphism, inheritance, virtual-dispatch, typeid and
typeinfo suites (251 tests) are green.
