### PR TITLE
[om] Model <thread>, <mutex> and <condition_variable> over ESBMC's pthread model

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6319_condvar/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_condvar/main.cpp
@@ -1,0 +1,39 @@
+// github #6319: <condition_variable> over ESBMC's pthread condvar. The waiter
+// blocks until the producer publishes, so `data` is visible after the wait.
+//
+// --no-unwinding-assertions is the repo's convention for this shape (see
+// regression/esbmc-unix/01_cond_10): ESBMC's condvar model admits an unbounded
+// run of spurious wake-ups, so `while (!ready) wait(lk);` has no finite unwind
+// bound. github_6319_condvar_fail runs the same program under the same flags
+// and must FAIL, which is what shows the truncated loop still reaches and
+// evaluates the assertion.
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <cassert>
+
+std::mutex m;
+std::condition_variable cv;
+bool ready = false;
+int data = 0;
+
+void producer()
+{
+  std::unique_lock<std::mutex> lk(m);
+  data = 42;
+  ready = true;
+  cv.notify_one();
+}
+
+int main()
+{
+  std::thread t(producer);
+  {
+    std::unique_lock<std::mutex> lk(m);
+    while (!ready)
+      cv.wait(lk);
+    assert(data == 42);
+  }
+  t.join();
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_condvar/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_condvar/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 2 --no-unwinding-assertions --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6319_condvar_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_condvar_fail/main.cpp
@@ -1,0 +1,34 @@
+// github #6319, negative direction: github_6319_condvar with the assertion
+// negated, run under identical flags. It must FAIL, which is what shows the
+// truncated wait loop still reaches and evaluates the assertion -- otherwise
+// --no-unwinding-assertions could be hiding a vacuous SUCCESSFUL there.
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <cassert>
+
+std::mutex m;
+std::condition_variable cv;
+bool ready = false;
+int data = 0;
+
+void producer()
+{
+  std::unique_lock<std::mutex> lk(m);
+  data = 42;
+  ready = true;
+  cv.notify_one();
+}
+
+int main()
+{
+  std::thread t(producer);
+  {
+    std::unique_lock<std::mutex> lk(m);
+    while (!ready)
+      cv.wait(lk);
+    assert(data == 0);
+  }
+  t.join();
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_condvar_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_condvar_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 2 --no-unwinding-assertions --context-bound 2
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6319_condvar_pred/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_condvar_pred/main.cpp
@@ -1,0 +1,35 @@
+// github #6319: the predicate overload of condition_variable::wait, which is a
+// member template of a non-template class -- unlike a free-function template,
+// its body IS converted in an OM header, so the loop really runs. A lambda
+// predicate works because it is used as a functor; note that a lambda is not
+// usable as a std::thread callable, where the conversion to a function pointer
+// is needed and is currently bodyless in the frontend.
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <cassert>
+
+std::mutex m;
+std::condition_variable cv;
+bool ready = false;
+int data = 0;
+
+void producer()
+{
+  std::unique_lock<std::mutex> lk(m);
+  data = 42;
+  ready = true;
+  cv.notify_all();
+}
+
+int main()
+{
+  std::thread t(producer);
+  {
+    std::unique_lock<std::mutex> lk(m);
+    cv.wait(lk, [] { return ready; });
+    assert(data == 42);
+  }
+  t.join();
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_condvar_pred/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_condvar_pred/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 2 --no-unwinding-assertions --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6319_mutex/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_mutex/main.cpp
@@ -1,0 +1,29 @@
+// github #6319: <mutex> is modelled over ESBMC's pthread mutex, so it really
+// excludes concurrent threads rather than being rejected at parse time.
+// Without the lock_guard the increment interleaves and x can end up 1 --
+// that is github_6319_mutex_race_fail, run under the same context bound so the
+// pair differs only in the lock. The bound keeps this under the 120s CI cap
+// (unbounded it enumerates ~31k interleavings); the single-threaded API surface
+// is exercised separately in github_6319_mutex_api.
+#include <mutex>
+#include <thread>
+#include <cassert>
+
+std::mutex m;
+int x = 0;
+
+void w()
+{
+  std::lock_guard<std::mutex> g(m);
+  int t = x;
+  x = t + 1;
+}
+
+int main()
+{
+  std::thread a(w);
+  w();
+  a.join();
+  assert(x == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_mutex/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_mutex/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6319_mutex_api/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_mutex_api/main.cpp
@@ -1,0 +1,37 @@
+// github #6319: single-threaded API surface of the <mutex> model -- lock,
+// try_lock, unlock, lock_guard and unique_lock's ownership tracking. The
+// mutual-exclusion property is checked in github_6319_mutex.
+#include <mutex>
+#include <cassert>
+
+int main()
+{
+  std::mutex n;
+  n.lock();
+  n.unlock();
+
+  {
+    std::lock_guard<std::mutex> g(n);
+  }
+
+  {
+    std::unique_lock<std::mutex> u(n);
+    assert(u.owns_lock());
+    u.unlock();
+    assert(!u.owns_lock());
+    u.lock();
+    assert(u.owns_lock());
+  }
+
+  {
+    std::unique_lock<std::mutex> u(n, std::defer_lock);
+    assert(!u.owns_lock());
+    assert(u.try_lock());
+    u.unlock();
+  }
+
+  assert(n.try_lock());
+  n.unlock();
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_mutex_api/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_mutex_api/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6319_mutex_race_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_mutex_race_fail/main.cpp
@@ -1,0 +1,22 @@
+// github #6319, negative direction: with the lock_guard removed the increment
+// interleaves and the update is lost, so the mutex in github_6319_mutex is
+// doing real work rather than being a no-op.
+#include <thread>
+#include <cassert>
+
+int x = 0;
+
+void w()
+{
+  int t = x;
+  x = t + 1;
+}
+
+int main()
+{
+  std::thread a(w);
+  w();
+  a.join();
+  assert(x == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_mutex_race_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_mutex_race_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --context-bound 2
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6319_thread/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_thread/main.cpp
@@ -1,0 +1,38 @@
+// github #6319: <thread> is modelled over ESBMC's pthread model, so a
+// std::thread really interleaves rather than being rejected at parse time.
+// One live thread at a time: each extra concurrent thread multiplies the
+// interleavings, and CI caps a test at 120s.
+#include <thread>
+#include <cassert>
+
+int g = 0;
+int v = 0;
+
+void w()
+{
+  g = 42;
+}
+
+void *wa(void *p)
+{
+  *(int *)p = 7;
+  return 0;
+}
+
+int main()
+{
+  std::thread e; // a default-constructed thread is not joinable
+  assert(!e.joinable());
+
+  std::thread t(w);
+  assert(t.joinable());
+  t.join();
+  assert(!t.joinable());
+  assert(g == 42); // the spawned function really ran
+
+  std::thread u(wa, &v); // argument through pthread_create's void* slot
+  u.join();
+  assert(v == 7);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_thread/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_thread/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6319_thread_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6319_thread_fail/main.cpp
@@ -1,0 +1,16 @@
+// github #6319: [thread.thread.destr]/1 -- destroying a still-joinable thread
+// calls terminate(); the model reports it as a property violation.
+#include <thread>
+
+int g = 0;
+
+void w()
+{
+  g = 42;
+}
+
+int main()
+{
+  std::thread t(w);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6319_thread_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6319_thread_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$
+std::thread destroyed while joinable

--- a/src/cpp/library/condition_variable
+++ b/src/cpp/library/condition_variable
@@ -1,0 +1,74 @@
+#ifndef STL_CONDITION_VARIABLE
+#define STL_CONDITION_VARIABLE
+
+#include <pthread.h>
+#include <mutex>
+#include "OM_compiler_defs.h"
+
+// Model of <condition_variable> (github #6319) over ESBMC's pthread condvar,
+// so a wait/notify pair gets the same semantics -- including the "caller must
+// hold the mutex" check in pthread_cond_wait -- that the C model implements.
+//
+// Not modelled: the timed waits (wait_for/wait_until and cv_status), which
+// ESBMC has no clock to block against, and condition_variable_any, which would
+// need a lock type the pthread condvar cannot take.
+
+#if __cplusplus >= 201103L
+
+namespace std
+{
+class condition_variable
+{
+  pthread_cond_t __c;
+
+  condition_variable(const condition_variable &);
+  condition_variable &operator=(const condition_variable &);
+
+public:
+  typedef pthread_cond_t *native_handle_type;
+
+  condition_variable()
+  {
+    pthread_cond_init(&__c, OM_NULLPTR);
+  }
+
+  ~condition_variable()
+  {
+    pthread_cond_destroy(&__c);
+  }
+
+  void notify_one() OM_NOEXCEPT
+  {
+    pthread_cond_signal(&__c);
+  }
+
+  void notify_all() OM_NOEXCEPT
+  {
+    pthread_cond_broadcast(&__c);
+  }
+
+  void wait(unique_lock<mutex> &lk)
+  {
+    pthread_cond_wait(&__c, lk.mutex()->native_handle());
+  }
+
+  // [thread.condition.condvar]/13: equivalent to `while (!pred()) wait(lk);`,
+  // which is also what makes a spurious wake-up harmless.
+  template <class Pred>
+  void wait(unique_lock<mutex> &lk, Pred pred)
+  {
+    while (!pred())
+      wait(lk);
+  }
+
+  native_handle_type native_handle()
+  {
+    return &__c;
+  }
+};
+
+} // namespace std
+
+#endif // __cplusplus >= 201103L
+
+#endif // STL_CONDITION_VARIABLE

--- a/src/cpp/library/mutex
+++ b/src/cpp/library/mutex
@@ -1,0 +1,192 @@
+#ifndef STL_MUTEX
+#define STL_MUTEX
+
+#include <pthread.h>
+#include "OM_compiler_defs.h"
+
+// Model of <mutex> (github #6319) over ESBMC's pthread model, so the C++
+// wrappers reach the same lock/unlock semantics -- including the deadlock and
+// double-unlock checks -- that pthread_mutex_* already implement.
+//
+// Not modelled: timed_mutex/shared_mutex and the timed try_lock_for/_until
+// members (ESBMC has no clock to block against), std::lock/std::try_lock
+// (free-function templates, whose instantiated bodies the frontend does not
+// convert -- calls would return nondet), and once_flag/call_once.
+
+#if __cplusplus >= 201103L
+
+namespace std
+{
+struct defer_lock_t
+{
+};
+struct try_to_lock_t
+{
+};
+struct adopt_lock_t
+{
+};
+
+const defer_lock_t defer_lock = defer_lock_t();
+const try_to_lock_t try_to_lock = try_to_lock_t();
+const adopt_lock_t adopt_lock = adopt_lock_t();
+
+class mutex
+{
+  pthread_mutex_t __m;
+
+  mutex(const mutex &);
+  mutex &operator=(const mutex &);
+
+public:
+  mutex() OM_NOEXCEPT
+  {
+    pthread_mutex_init(&__m, OM_NULLPTR);
+  }
+
+  ~mutex()
+  {
+    pthread_mutex_destroy(&__m);
+  }
+
+  void lock()
+  {
+    pthread_mutex_lock(&__m);
+  }
+
+  bool try_lock() OM_NOEXCEPT
+  {
+    return pthread_mutex_trylock(&__m) == 0;
+  }
+
+  void unlock() OM_NOEXCEPT
+  {
+    pthread_mutex_unlock(&__m);
+  }
+
+  typedef pthread_mutex_t *native_handle_type;
+
+  native_handle_type native_handle()
+  {
+    return &__m;
+  }
+};
+
+// A recursive_mutex needs a per-thread ownership count the pthread model does
+// not expose, so it is deliberately absent rather than aliased to mutex --
+// aliasing would report a spurious deadlock on the re-lock that makes the type
+// worth using.
+
+template <class M>
+class lock_guard
+{
+  M &__m;
+
+  lock_guard(const lock_guard &);
+  lock_guard &operator=(const lock_guard &);
+
+public:
+  typedef M mutex_type;
+
+  explicit lock_guard(M &m) : __m(m)
+  {
+    __m.lock();
+  }
+
+  lock_guard(M &m, adopt_lock_t) : __m(m)
+  {
+  }
+
+  ~lock_guard()
+  {
+    __m.unlock();
+  }
+};
+
+template <class M>
+class unique_lock
+{
+  M *__m;
+  bool __owns;
+
+  unique_lock(const unique_lock &);
+  unique_lock &operator=(const unique_lock &);
+
+public:
+  typedef M mutex_type;
+
+  unique_lock() OM_NOEXCEPT : __m(OM_NULLPTR), __owns(false)
+  {
+  }
+
+  explicit unique_lock(M &m) : __m(&m), __owns(true)
+  {
+    __m->lock();
+  }
+
+  unique_lock(M &m, defer_lock_t) OM_NOEXCEPT : __m(&m), __owns(false)
+  {
+  }
+
+  unique_lock(M &m, try_to_lock_t) : __m(&m), __owns(false)
+  {
+    __owns = __m->try_lock();
+  }
+
+  unique_lock(M &m, adopt_lock_t) : __m(&m), __owns(true)
+  {
+  }
+
+  ~unique_lock()
+  {
+    if (__owns)
+      __m->unlock();
+  }
+
+  void lock()
+  {
+    __m->lock();
+    __owns = true;
+  }
+
+  bool try_lock()
+  {
+    __owns = __m->try_lock();
+    return __owns;
+  }
+
+  void unlock()
+  {
+    __m->unlock();
+    __owns = false;
+  }
+
+  M *release() OM_NOEXCEPT
+  {
+    M *r = __m;
+    __m = OM_NULLPTR;
+    __owns = false;
+    return r;
+  }
+
+  bool owns_lock() const OM_NOEXCEPT
+  {
+    return __owns;
+  }
+
+  operator bool() const OM_NOEXCEPT
+  {
+    return __owns;
+  }
+
+  M *mutex() const OM_NOEXCEPT
+  {
+    return __m;
+  }
+};
+
+} // namespace std
+
+#endif // __cplusplus >= 201103L
+
+#endif // STL_MUTEX

--- a/src/cpp/library/thread
+++ b/src/cpp/library/thread
@@ -1,0 +1,134 @@
+#ifndef STL_THREAD
+#define STL_THREAD
+
+#include <pthread.h>
+#include "OM_compiler_defs.h"
+
+// Model of <thread> (github #6319) over ESBMC's pthread model: a std::thread is
+// a pthread_t, so the spawned function becomes a real interleaved thread and
+// the existing race/deadlock checks apply to it unchanged.
+//
+// The callable is passed straight to pthread_create through a cast rather than
+// through a trampoline: a trampoline would have to be a function template, and
+// the frontend does not convert instantiated bodies of function templates
+// defined in OM headers -- the call would silently return nondet and the thread
+// would never run. ESBMC's symex tolerates the arity/return-type mismatch the
+// cast introduces, and a single argument rides in pthread_create's void* slot.
+//
+// So the constructors take function pointers: `void()`, or `void *(void *)`
+// with pthread_create's argument. A functor, a capturing lambda, or a
+// multi-argument callable is rejected at conversion rather than mismodelled.
+// A *captureless* lambda ought to work via its conversion to a function
+// pointer, but that conversion operator is currently bodyless in the frontend
+// (independently of this header: `void (*f)() = []{ g = 5; }; f();` already
+// loses the write), so it yields a nondet pointer. std::this_thread::sleep_*
+// and yield are absent: ESBMC has no clock and interleaves at every step.
+
+#if __cplusplus >= 201103L
+
+namespace std
+{
+class thread
+{
+  pthread_t __t;
+  bool __joinable;
+
+  thread(const thread &);
+  thread &operator=(const thread &);
+
+public:
+  typedef pthread_t native_handle_type;
+
+  class id
+  {
+    pthread_t __v;
+
+  public:
+    id() OM_NOEXCEPT : __v(0)
+    {
+    }
+    explicit id(pthread_t v) OM_NOEXCEPT : __v(v)
+    {
+    }
+    bool operator==(const id &o) const OM_NOEXCEPT
+    {
+      return __v == o.__v;
+    }
+    bool operator!=(const id &o) const OM_NOEXCEPT
+    {
+      return !(*this == o);
+    }
+  };
+
+  thread() OM_NOEXCEPT : __t(0), __joinable(false)
+  {
+  }
+
+  explicit thread(void (*f)()) : __joinable(true)
+  {
+    pthread_create(&__t, OM_NULLPTR, (void *(*)(void *))f, OM_NULLPTR);
+  }
+
+  thread(void *(*f)(void *), void *arg) : __joinable(true)
+  {
+    pthread_create(&__t, OM_NULLPTR, f, arg);
+  }
+
+  ~thread()
+  {
+    // [thread.thread.destr]/1: terminate() if still joinable. Model it as a
+    // property violation so a forgotten join/detach is reported rather than
+    // silently accepted.
+    __ESBMC_assert(
+      !__joinable,
+      "std::thread destroyed while joinable ([thread.thread.destr])");
+  }
+
+  bool joinable() const OM_NOEXCEPT
+  {
+    return __joinable;
+  }
+
+  void join()
+  {
+    pthread_join(__t, OM_NULLPTR);
+    __joinable = false;
+  }
+
+  void detach()
+  {
+    pthread_detach(__t);
+    __joinable = false;
+  }
+
+  id get_id() const OM_NOEXCEPT
+  {
+    return __joinable ? id(__t) : id();
+  }
+
+  native_handle_type native_handle()
+  {
+    return __t;
+  }
+
+  void swap(thread &o) OM_NOEXCEPT
+  {
+    pthread_t t = __t;
+    bool j = __joinable;
+    __t = o.__t;
+    __joinable = o.__joinable;
+    o.__t = t;
+    o.__joinable = j;
+  }
+
+  static unsigned hardware_concurrency() OM_NOEXCEPT
+  {
+    return 1;
+  }
+};
+
+} // namespace std
+
+#endif // __cplusplus >= 201103L
+
+#endif // STL_THREAD


### PR DESCRIPTION
Towards #6319 — adds `<thread>`, `<mutex>` and `<condition_variable>`.
`<future>`, also listed there, is **not** included; see *Scope* below, so the
issue should stay open.

## Root cause

Not a defect but a gap: `src/cpp/library/` bundles none of `<thread>`,
`<mutex>` or `<condition_variable>`, so `#include <thread>` fails at parse time (`fatal error: 'thread' file not
found` → `PARSING ERROR`). ESBMC already verifies concurrency at the pthread
level; only the C++ wrappers were missing.

## Fix

Three operational models over the existing pthread model, so the C++ types inherit
the interleaving semantics and the lock/deadlock checks that `pthread_mutex_*`
and `pthread_create` already implement, rather than getting a second,
independent concurrency semantics.

`<mutex>`: `std::mutex` wraps `pthread_mutex_t`; `lock_guard` and `unique_lock`
are RAII wrappers with ownership tracking (`defer_lock` / `try_to_lock` /
`adopt_lock`, `owns_lock`, `release`).

`<thread>`: `std::thread` wraps `pthread_t`; `join`/`detach`/`joinable`/`swap`/
`get_id`. Destroying a still-joinable thread is reported as a property
violation, per [thread.thread.destr]/1.

`<condition_variable>`: `std::condition_variable` wraps `pthread_cond_t`;
`wait`, `notify_one`, `notify_all`, and the `wait(lk, pred)` overload. That
overload is a member template of a non-template class, which — unlike a
free-function template — does get its body converted in an OM header; I probed
that before relying on it, since a bodyless `wait` would be a silent no-op.

### Design decision: no trampoline

The callable is handed to `pthread_create` through a cast rather than a
trampoline. A trampoline would have to be a function template, and the frontend
does not convert instantiated bodies of function templates defined in OM headers
— the call would return nondet and the thread would silently never run, which is
exactly the failure mode a verifier must not have. ESBMC's symex tolerates the
arity/return-type mismatch the cast introduces (checked directly against
`pthread_create` before the header was written), and a single argument rides in
`pthread_create`'s `void *` slot.

So the constructors take function pointers: `void()`, or `void *(void *)` plus
its argument. A functor, a capturing lambda, or a multi-argument callable is
rejected at conversion rather than mismodelled.

## Scope and limitations

Deliberately absent, each for a stated reason rather than for convenience:

- `<future>` — the issue scopes it as part of the same larger effort. It needs
  shared state with a result slot and exception propagation, which is a
  different shape from the three thin wrappers here.
- Timed waits (`wait_for` / `wait_until`, `cv_status`) and
  `condition_variable_any` — no clock, and no lock type the pthread condvar can
  take.
- `std::recursive_mutex` — needs a per-thread ownership count the pthread model
  does not expose. Aliasing it to `mutex` would report a spurious deadlock on
  the re-lock, so it is absent rather than wrong.
- `timed_mutex`, `shared_mutex`, `try_lock_for/_until`, `this_thread::sleep_*` —
  ESBMC has no clock.
- `std::lock` / `std::try_lock` / `call_once` — free-function templates, bodies
  not converted.

Found while testing, and **pre-existing** (independent of this change): the
captureless-lambda → function-pointer conversion operator is bodyless, so
`void (*f)() = []{ g = 5; }; f();` loses the write with no `<thread>` involved.
That is why `std::thread t([]{...})` is not claimed to work. Worth its own issue.

## Tests

Under `regression/esbmc-cpp/cpp/`, all `--std c++11`:

- `github_6319_thread` — join/joinable/default-ctor and the `void *(void *)`
  argument ctor; asserts the spawned function's write is observed, so a thread
  that never ran would fail the test.
- `github_6319_thread_fail` — a thread destroyed while joinable; FAILED, matched
  on the violation message.
- `github_6319_mutex` — two threads incrementing a counter under a `lock_guard`;
  `x == 2` holds.
- `github_6319_mutex_race_fail` — the same program with the `lock_guard`
  removed; FAILED on the lost update. This is what makes the mutex test
  load-bearing rather than a no-op check.
- `github_6319_mutex_api` — single-threaded API surface of `mutex`,
  `lock_guard`, `unique_lock`.

Plus three condvar tests: `github_6319_condvar` (producer publishes under the
lock, waiter observes it after `while (!ready) cv.wait(lk);`),
`github_6319_condvar_pred` (the predicate overload, with a lambda predicate),
and `github_6319_condvar_fail` (the same program with the assertion negated).

The condvar tests carry `--unwind 2 --no-unwinding-assertions`, the repo's
existing convention for this shape (`regression/esbmc-unix/01_cond_10`):
ESBMC's condvar model admits an unbounded run of spurious wake-ups, so the wait
loop has no finite unwind bound. I checked this is pre-existing model behaviour
and not something the C++ wrapper introduces — the equivalent **C** program
unwinds identically. Because a truncated loop can hide a vacuous SUCCESSFUL,
`github_6319_condvar_fail` runs the same program under the same flags and must
FAIL; that is what shows the assertion is still reached and evaluated.

The two-thread pair runs under `--context-bound 2`: unbounded it enumerates
~31k interleavings and takes 87s, too close to CI's 120s cap. Both halves of the
pair carry the same bound, and the race is still found under it, so the bound
does not weaken what the pair demonstrates. The tests are split by thread count
for the same reason — each extra live thread multiplies interleavings.

## Suites

Full `regression/esbmc-cpp*` (2563 tests) — 9 failures, exactly the same nine
pre-existing macOS/libc++ ones the unpatched tree produces, no new ones. No
existing OM header includes `<mutex>`, `<thread>` or `<condition_variable>`, so
nothing resolves differently; all three are inert below C++11.
