### PR TITLE
[python] Lower sqrt to ieee_sqrt and decay &array in python_adjust

### DIFF
--- a/docs/roadmap/scope-v1k-adjuster.md
+++ b/docs/roadmap/scope-v1k-adjuster.md
@@ -673,3 +673,55 @@ math/float (`math13`, `math_edge_frexp_success`, `sqrt5`,
 `cmath_polar_rect_semantics_success_07`), which points at the parked S4
 arithmetic-conversion work rather than at six independent causes — but that is a
 hypothesis from the names, not a triaged finding.
+
+### Per-case triage round 4 — the math cluster was `sqrt`, not S4 (2026-07-25)
+
+The round-3 hypothesis above was **wrong**: the math/float cluster has nothing to
+do with arithmetic conversion. `sqrt5`'s counterexample shows `result = -NAN`,
+and the GOTO diff isolates it to one instruction:
+
+```
+legacy:  ASSIGN result = ieee_sqrt((double)x, __ESBMC_rounding_mode)
+hop-off: FUNCTION_CALL: result = sqrt((double)x)
+```
+
+`python_math::handle_sqrt` emits a call to `c:@F@sqrt` whenever the argument is
+not a foldable constant; `clang_c_adjust` rewrites that call to the `ieee_sqrt`
+intrinsic (`clang_c_adjust_expr.cpp:1414-1423`), and `python_adjust` did not, so
+the hop-off ran the library model, which returns NaN. Fixed by mirroring the
+lowering — closing `sqrt5`, `math13`, and
+`cmath_polar_rect_semantics_success_07`, the last of which this document had
+recorded as a standing *false alarm*. It was not; it was this.
+
+**Method note — match the field the legacy guard matches.** A first attempt
+compared `symbol2t::thename` (the full identifier, `c:@F@sqrt`) against
+`"sqrt"`, and the arm silently never fired. The legacy guard uses the symbol's
+**base** name (`to_symbol_expr(f_op).name()`) and applies the `py:` exclusion to
+the *identifier*. IREP2's `symbol2t` carries only the identifier, so the base
+name must be recovered (segment after the last `@`). A non-firing arm looks
+exactly like a wrong hypothesis — check the arm fires before discarding the
+theory.
+
+**Also landed: `&array` → `&array[0]` at the node level.** `clang_c_adjust::adjust_address_of`
+(`clang_c_adjust_expr.cpp:743-754`) decays unconditionally; #6363 added only the
+assignment-seam form, which never reaches an `address_of` nested inside an
+aggregate literal. The OM raise sites build `{ .message = &"math domain error" }`
+with a `char*` member, so the literal carried a `char(*)[N]`. **This flips no
+verdict in the sampled corpus** — it closes a structural parity gap (the hop-off
+GOTO now matches legacy byte-for-byte at those sites), and is recorded as such
+rather than as a divergence fix.
+
+**Remaining after round 4** — a stride-12 census (366 tests) leaves five genuine
+divergences: `github_3078_fail`, `github_4784_isnone_short_circuit_fail` (no
+verdict), `github_3690`, `math_edge_frexp_success`,
+`github_4745_pep604_class_attr` (legacy SUCCESSFUL → hop-off FAILED), plus
+`ternary_string_fail`, `github_2934_2`, `none3`, `optional6` from the wider
+stride-6 run. `math_edge_frexp_success` is `frexp`, so the "one missing intrinsic
+lowering per math builtin" shape may repeat — check `clang_c_adjust`'s builtin
+list before assuming anything deeper.
+
+**Census artifact, restated.** Any test whose own `test.desc` already carries
+`--python-irep2-adjust-only` (`python_irep2_adjust_only_*`) appears as a
+divergence in this census, because both of its columns are hop-off runs and the
+40 s cap bites under 12-way parallelism. They pass under `ctest`. Filter them
+out before counting.

--- a/regression/python/python_irep2_adjust_only_addrof_decay/main.py
+++ b/regression/python/python_irep2_adjust_only_addrof_decay/main.py
@@ -1,0 +1,16 @@
+# Exercises the --python-irep2-adjust-only `&array` -> `&array[0]` decay. The
+# raise sites in the operational models build a struct literal
+# `{ .message = &"..." }` whose member is a `char*`; without the decay the
+# literal carries a `char(*)[N]` and the member type disagrees with its
+# initialiser. Catching the raised ValueError forces that literal to be built.
+import math
+
+
+def safe_sqrt(x: float) -> float:
+    try:
+        return math.sqrt(x)
+    except ValueError:
+        return -1.0
+
+
+assert safe_sqrt(-1.0) == -1.0

--- a/regression/python/python_irep2_adjust_only_addrof_decay/test.desc
+++ b/regression/python/python_irep2_adjust_only_addrof_decay/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_only_addrof_decay_fail/main.py
+++ b/regression/python/python_irep2_adjust_only_addrof_decay_fail/main.py
@@ -1,0 +1,14 @@
+# Negative counterpart: same decayed string-literal address in the model's raise
+# path, with a false assertion. The hop-off must still reach the solver and
+# report the violation.
+import math
+
+
+def safe_sqrt(x: float) -> float:
+    try:
+        return math.sqrt(x)
+    except ValueError:
+        return -1.0
+
+
+assert safe_sqrt(-1.0) == 99.0

--- a/regression/python/python_irep2_adjust_only_addrof_decay_fail/test.desc
+++ b/regression/python/python_irep2_adjust_only_addrof_decay_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 2
+^VERIFICATION FAILED$

--- a/regression/python/python_irep2_adjust_only_sqrt_intrinsic/main.py
+++ b/regression/python/python_irep2_adjust_only_sqrt_intrinsic/main.py
@@ -1,0 +1,14 @@
+# Exercises the --python-irep2-adjust-only sqrt -> ieee_sqrt lowering. A
+# non-constant argument makes python_math::handle_sqrt emit a call to
+# `c:@F@sqrt` rather than constant-folding; that call must become the ieee_sqrt
+# intrinsic, as clang_c_adjust does. Running the library model instead yields
+# NaN, so the equality below would fail.
+import math
+
+
+def root(n: int) -> float:
+    return math.sqrt(n)
+
+
+x = 9 if True else 4
+assert root(x) == 3.0

--- a/regression/python/python_irep2_adjust_only_sqrt_intrinsic/test.desc
+++ b/regression/python/python_irep2_adjust_only_sqrt_intrinsic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_only_sqrt_intrinsic_fail/main.py
+++ b/regression/python/python_irep2_adjust_only_sqrt_intrinsic_fail/main.py
@@ -1,0 +1,12 @@
+# Negative counterpart: the lowered ieee_sqrt must reach the solver and report a
+# real violation, not be masked by a NaN result that compares false against
+# everything.
+import math
+
+
+def root(n: int) -> float:
+    return math.sqrt(n)
+
+
+x = 9 if True else 4
+assert root(x) == 4.0

--- a/regression/python/python_irep2_adjust_only_sqrt_intrinsic_fail/test.desc
+++ b/regression/python/python_irep2_adjust_only_sqrt_intrinsic_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -281,6 +281,22 @@ void python_adjust::adjust_expr(expr2tc &expr)
       i.false_value);
   }
   else if (
+    is_address_of2t(expr) && is_array_type(to_address_of2t(expr).ptr_obj->type))
+  {
+    // `&array` decays to `&array[0]`, exactly as clang_c_adjust::adjust_address_of
+    // does (clang_c_adjust_expr.cpp:743-754). This is the node-level counterpart
+    // of the assignment-seam decay below: the operand need not be near an
+    // assignment at all -- the OM raise sites build a struct literal
+    // `{ .message = &"math domain error" }` whose member is a `char*`, so
+    // without the decay the literal carries a `char(*)[N]` and the member type
+    // silently disagrees with its initialiser. Idempotent: the rewritten operand
+    // is an index2t of element type, so the arm cannot re-fire.
+    const address_of2t &a = to_address_of2t(expr);
+    const type2tc &elem = to_array_type(a.ptr_obj->type).subtype;
+    expr =
+      address_of2tc(elem, index2tc(elem, a.ptr_obj, gen_zero(index_type2())));
+  }
+  else if (
     is_code_assign2t(expr) &&
     is_pointer_type(to_code_assign2t(expr).target->type) &&
     is_array_type(to_code_assign2t(expr).source->type))

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -460,6 +460,33 @@ void python_adjust::adjust_expr(expr2tc &expr)
     // Expression-form call (e.g. `assert f(3) == 6`): the callee is the
     // sideeffect operand.
     const sideeffect2t &s = to_sideeffect2t(expr);
+
+    // A C-library sqrt call lowers to the ieee_sqrt intrinsic instead of
+    // executing the model, mirroring clang_c_adjust
+    // (clang_c_adjust_expr.cpp:1414-1423). math.sqrt builds a call to
+    // `c:@F@sqrt` (python_math::handle_sqrt), and without the lowering the
+    // hop-off runs the library model, which yields NaN -- so
+    // `math.sqrt(9) == 3.0` reports a spurious violation. The legacy guard
+    // matches the symbol's *base* name and excludes `py:` user functions; in
+    // IREP2 symbol2t carries only the full identifier, so take the segment
+    // after the last '@'. The rounding mode matches migrate_expr's default for
+    // a legacy ieee_sqrt with no explicit mode (migrate.cpp:1437).
+    if (is_symbol2t(s.operand) && s.arguments.size() == 1)
+    {
+      const std::string id = to_symbol2t(s.operand).thename.as_string();
+      const std::string base = id.substr(id.find_last_of('@') + 1);
+      if (
+        !has_prefix(id, "py:") && (base == "sqrt" || base == "sqrtf" ||
+                                   base == "sqrtd" || base == "sqrtl"))
+      {
+        expr = ieee_sqrt2tc(
+          s.type,
+          s.arguments[0],
+          symbol2tc(get_int32_type(), "c:@__ESBMC_rounding_mode"));
+        return;
+      }
+    }
+
     expr2tc fn = s.operand;
     std::vector<expr2tc> args = s.arguments;
     if (wrap_function_pointer_callee(fn, args))


### PR DESCRIPTION
> **Stacked on #6393 → #6390 → #6389** (same triage round; all touch
> `docs/roadmap/scope-v1k-adjuster.md`). Retarget as the stack merges.

Two independent `clang_c_adjust` mirrors for the `--python-irep2-adjust-only`
hop-off. Both are flag-gated: `python_adjust` is constructed only under the flag
(`python_language.cpp:299-303`), so the default pipeline is untouched.

## 1. `sqrt` → `ieee_sqrt` (fixes three divergences)

`sqrt5`'s counterexample is `result = -NAN`, and the GOTO diff isolates it to one
instruction:

```
legacy:  ASSIGN result = ieee_sqrt((double)x, __ESBMC_rounding_mode)
hop-off: FUNCTION_CALL: result = sqrt((double)x)
```

`python_math::handle_sqrt` emits a call to `c:@F@sqrt` whenever the argument is
not a foldable constant. `clang_c_adjust` rewrites that call to the `ieee_sqrt`
intrinsic (`clang_c_adjust_expr.cpp:1414-1423`); `python_adjust` did not, so the
hop-off ran the library model, which returns NaN.

Fixes **`sqrt5`**, **`math13`**, and **`cmath_polar_rect_semantics_success_07`** —
the last of which the roadmap had recorded as a standing *false alarm*. It was
not; it was this.

Note the guard: legacy matches the symbol's **base** name
(`to_symbol_expr(f_op).name()`) and applies the `py:` exclusion to the
*identifier*. `symbol2t` carries only the identifier, so the base name is
recovered as the segment after the last `@`. (A first attempt compared the full
identifier and silently never fired.)

## 2. `&array` → `&array[0]` at the node level (parity only)

`clang_c_adjust::adjust_address_of` (`clang_c_adjust_expr.cpp:743-754`) decays
unconditionally. #6363 added only the assignment-seam form, which never reaches
an `address_of` nested inside an aggregate literal — the OM raise sites build
`{ .message = &"math domain error" }` with a `char*` member, so the literal
carried a `char(*)[N]` and the member type disagreed with its initialiser.

**This flips no verdict in the sampled corpus.** It closes a structural parity
gap — the hop-off GOTO now matches legacy byte-for-byte at those sites — and is
presented as such, not as a divergence fix.

## Verification

- Two matched hop-off test pairs added
  (`python_irep2_adjust_only_sqrt_intrinsic{,_fail}`,
  `python_irep2_adjust_only_addrof_decay{,_fail}`); all four agree with the
  default path.
- `ctest -R 'regression/python/(python_irep2_adjust|sqrt|math1|cmath_polar|github_3012|div6|jpl|int_to_bytes|higher-order)'`:
  **71/71 pass**.
- Stride-12 census (366 tests, 12-way parallel against a pinned binary): no new
  divergences.

## Remaining

`github_3078_fail`, `github_4784_isnone_short_circuit_fail` (no verdict);
`github_3690`, `math_edge_frexp_success`, `github_4745_pep604_class_attr`
(legacy `SUCCESSFUL` → hop-off `FAILED`); plus `ternary_string_fail`,
`github_2934_2`, `none3`, `optional6` from the wider stride-6 run.
`math_edge_frexp_success` is `frexp` — the "one missing intrinsic lowering per
math builtin" shape may well repeat.