### PR TITLE
[om] Add string->string_view conversion, hash<string_view> and fstream string overloads

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_fstream_cxx03/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_fstream_cxx03/main.cpp
@@ -1,0 +1,17 @@
+// github #5868 gap 6, C++03 guard: the std::string overloads added to the
+// fstream models are C++11 ([fstream.cons]) and use delegating constructors,
+// which do not parse under --std c++03. No existing test included <fstream>
+// under C++03, so nothing would have caught the header becoming unusable there.
+#include <fstream>
+#include <string>
+
+int main()
+{
+  std::ifstream i("f.txt");
+  i.close();
+  std::ofstream o("f.txt");
+  o.close();
+  std::fstream f("f.txt");
+  f.close();
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_fstream_cxx03/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_fstream_cxx03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_fstream_string/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_fstream_string/main.cpp
@@ -1,0 +1,29 @@
+// github #5868 gap 6: the fstream models declared only const char* constructors
+// and open(), so the C++11 std::string overloads did not exist -- ESBMC's own
+// src/python-frontend/json_utils.h hits this with `std::ifstream f(path)`.
+#include <fstream>
+#include <string>
+
+int main()
+{
+  const std::string p = "f.txt";
+
+  std::ofstream o(p);
+  o.close();
+  std::ifstream i(p);
+  i.close();
+  std::fstream f(p);
+  f.close();
+
+  std::ifstream j;
+  j.open(p);
+  j.close();
+  std::ofstream k;
+  k.open(p);
+  k.close();
+  std::fstream g;
+  g.open(p);
+  g.close();
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_fstream_string/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_fstream_string/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_view_hash/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_view_hash/main.cpp
@@ -1,0 +1,31 @@
+// github #5868 gaps 2/3: std::string had no conversion to std::string_view, and
+// std::hash<std::string_view> bound the deleted primary template. [string.view.hash]
+// requires a view's hash to equal the corresponding string's, so both must use
+// the same scheme.
+#include <string>
+#include <string_view>
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  std::string s = "hello";
+
+  // [string.accessors]: operator basic_string_view
+  std::string_view v = s;
+  assert(v.size() == 5);
+  assert(v[0] == 'h');
+  assert(v.data() == s.c_str());
+
+  assert(std::hash<std::string_view>{}(v) == std::hash<std::string>{}(s));
+
+  std::string_view w("hello");
+  assert(std::hash<std::string_view>{}(w) == std::hash<std::string>{}(s));
+
+  std::string other = "world";
+  assert(
+    std::hash<std::string_view>{}(std::string_view(other)) !=
+    std::hash<std::string_view>{}(v));
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_view_hash/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_view_hash/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_view_hash_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_view_hash_fail/main.cpp
@@ -1,0 +1,14 @@
+// github #5868, negative direction: the string -> string_view conversion must
+// carry the real length, so a wrong expected size has to be caught. Without
+// this the checks in github_5868_string_view_hash could pass vacuously.
+#include <string>
+#include <string_view>
+#include <cassert>
+
+int main()
+{
+  std::string s = "hello";
+  std::string_view v = s;
+  assert(v.size() == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_view_hash_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_view_hash_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/fstream
+++ b/src/cpp/library/fstream
@@ -58,11 +58,27 @@ class fstream : public istream, public ostream
 public:
   fstream();
   explicit fstream(const char *filename, openmode mode = in | out);
+#if __cplusplus >= 201103L
+  // [fstream.cons]: the std::string overloads are C++11; they also use
+  // delegating constructors, which do not parse under --std c++03.
+  explicit fstream(const string &filename, openmode mode = in | out)
+    : fstream(filename.c_str(), mode)
+  {
+  }
+#endif
   filebuf *rdbuf() const;
   bool is_open();
   void open(
     const char *filename,
     ios_base::openmode mode = ios_base::in | ios_base::out);
+#if __cplusplus >= 201103L
+  void open(
+    const string &filename,
+    ios_base::openmode mode = ios_base::in | ios_base::out)
+  {
+    open(filename.c_str(), mode);
+  }
+#endif
   void close();
 
   //private:
@@ -77,9 +93,23 @@ public:
   explicit ofstream(
     const char *filename,
     ios_base::openmode mode = ios_base::out);
+#if __cplusplus >= 201103L
+  explicit ofstream(
+    const string &filename,
+    ios_base::openmode mode = ios_base::out)
+    : ofstream(filename.c_str(), mode)
+  {
+  }
+#endif
   filebuf *rdbuf() const;
   bool is_open();
   void open(const char *filename, ios_base::openmode mode = ios_base::out);
+#if __cplusplus >= 201103L
+  void open(const string &filename, ios_base::openmode mode = ios_base::out)
+  {
+    open(filename.c_str(), mode);
+  }
+#endif
   void close();
 
   //private:
@@ -94,9 +124,23 @@ public:
   explicit ifstream(
     const char *filename,
     ios_base::openmode mode = ios_base::in);
+#if __cplusplus >= 201103L
+  explicit ifstream(
+    const string &filename,
+    ios_base::openmode mode = ios_base::in)
+    : ifstream(filename.c_str(), mode)
+  {
+  }
+#endif
   filebuf *rdbuf() const;
   bool is_open();
   void open(const char *filename, ios_base::openmode mode = ios_base::in);
+#if __cplusplus >= 201103L
+  void open(const string &filename, ios_base::openmode mode = ios_base::in)
+  {
+    open(filename.c_str(), mode);
+  }
+#endif
   void close();
 
   inline bool operator&&(bool other);

--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -11,6 +11,7 @@
 #  include <cstdint> // for uint32_t, uint64_t
 #  include <cmath>   // for INFINITY
 #  include <string>  // for std::string
+#  include <string_view> // for std::string_view
 #endif
 
 namespace std
@@ -449,6 +450,28 @@ struct hash<::std::string>
     // Use c_str() to access characters in a const-compatible way
     const char *str = key.c_str();
     for (size_t i = 0; i < key.length(); ++i)
+    {
+      hash_value = hash_value * prime +
+                   static_cast<size_t>(static_cast<unsigned char>(str[i]));
+    }
+
+    return __esbmc_deterministic_hash(hash_value);
+  }
+};
+
+// Specialization for std::string_view. [string.view.hash] requires the hash of
+// a string view to equal the hash of the corresponding string, so this must use
+// the same scheme as hash<std::string> above.
+template <>
+struct hash<::std::string_view>
+{
+  size_t operator()(::std::string_view key) const
+  {
+    size_t hash_value = 0;
+    const size_t prime = 31;
+
+    const char *str = key.data();
+    for (size_t i = 0; i < key.size(); ++i)
     {
       hash_value = hash_value * prime +
                    static_cast<size_t>(static_cast<unsigned char>(str[i]));

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -9,6 +9,9 @@
 #include "iostream"
 #include "cstdlib"
 #include "memory"
+#if __cplusplus >= 201103L
+#  include "string_view" // string_view itself is C++11-only syntax
+#endif
 
 #define STRING_CAPACITY 128
 
@@ -1164,6 +1167,17 @@ public:
     *this = temp;
     return *this;
   }
+
+#if __cplusplus >= 201103L
+  /* [string.accessors]: `constexpr operator basic_string_view<charT, traits>()
+   * const noexcept`. The model's string_view is char-only, so this is
+   * well-formed exactly for basic_string<char>; instantiating it for wstring
+   * is ill-formed, as the conversion is in the real library too. */
+  operator string_view() const OM_NOEXCEPT
+  {
+    return string_view(c_str(), size());
+  }
+#endif
 
 private:
 };

--- a/src/cpp/library/string_view
+++ b/src/cpp/library/string_view
@@ -4,10 +4,22 @@
 #include <cstddef> /* size_t */
 #include <cstdint> /* SIZE_MAX */
 #include <cstring>
-#include <algorithm> /* std::swap, std::min */
+/* Deliberately no <algorithm>: <string> includes this header, so pulling
+ * <algorithm> in here would make std::for_each and friends visible to every
+ * translation unit that includes <string>. Programs that define their own
+ * for_each/count/... alongside `using namespace std;` then fail to compile with
+ * an ambiguous call. The two helpers needed are trivial, so they are local. */
 
 namespace std
 {
+namespace __sv_detail
+{
+inline size_t min(size_t a, size_t b)
+{
+  return a < b ? a : b;
+}
+} // namespace __sv_detail
+
 class string_view
 {
   const char *str;
@@ -55,25 +67,28 @@ public:
   void remove_suffix(size_t n) { len -= n; }
   void swap(string_view &sv) noexcept
   {
-    using std::swap;
-    swap(str, sv.str);
-    swap(len, sv.len);
+    const char *s = str;
+    size_t l = len;
+    str = sv.str;
+    len = sv.len;
+    sv.str = s;
+    sv.len = l;
   }
 
   // Operations
   size_t copy(char *dest, size_t count, size_t pos = 0) const
   {
-    size_t n = std::min(count, len - pos);
+    size_t n = __sv_detail::min(count, len - pos);
     memcpy(dest, str + pos, n);
     return n;
   }
   string_view substr(size_t pos = 0, size_t count = npos) const
   {
-    return { str + pos, std::min(count, len - pos) };
+    return { str + pos, __sv_detail::min(count, len - pos) };
   }
   int compare(string_view sv) const noexcept
   {
-    int r = memcmp(str, sv.str, std::min(len, sv.len));
+    int r = memcmp(str, sv.str, __sv_detail::min(len, sv.len));
     if (r)
       return r;
     if (len < sv.len)


### PR DESCRIPTION
Towards #5868 — closes gaps 2 (the string_view half), 3 and 6b of that study.
The issue is an umbrella and should stay open for the rest.

## Root cause

ESBMC's C++ frontend forces `-nostdinc++` and resolves `#include <...>` only
against `src/cpp/library/`, so every incomplete model is a hard parse error.
Three such gaps, each verified still live on current master before touching
anything:

1. **`std::string` → `std::string_view`** — `basic_string` had no
   `operator basic_string_view` ([string.accessors]), so `std::string_view v = s;`
   gave *no viable conversion*. #5868 counts this in 57 TUs.
2. **`std::hash<std::string_view>`** — `<functional>` specialises `hash` for
   integrals, pointers and `std::string`, but not `string_view`, so
   `std::hash<std::string_view>{}` selected the primary template's
   `operator() = delete`. ESBMC's own `src/util/string_pool.h:21` does exactly
   this; ~41 TUs.
3. **`fstream` `std::string` overloads** — `ifstream`/`ofstream`/`fstream`
   declared only `const char *` constructors and `open()`, so
   `std::ifstream f(path)` with a `std::string` path failed to compile. ESBMC's
   own `src/python-frontend/json_utils.h:100` does exactly this; ~17 TUs.

Several other gaps from the study are **already fixed on master** and are not
touched here: `<iosfwd>`, the `std::string` member typedefs, and the const
`operator[]` all parse now, and the concurrency headers of gap 1 are #6394.

## Fix

`hash<string_view>` reuses the polynomial-rolling scheme of `hash<std::string>`
verbatim rather than inventing one. That is not a stylistic choice:
[string.view.hash] requires "the hash value of a string view object is equal to
the hash value of the corresponding string object", so the two specialisations
must agree, and the test asserts it.

The conversion is placed on `basic_string` as `operator string_view()`, matching
[string.accessors], rather than as a converting constructor on `string_view`.
That direction also keeps the include graph acyclic: `string` → `string_view`
(a leaf), and `functional` → `string` → `string_view`. The model's `string_view`
is char-only, so the operator is well-formed exactly for `basic_string<char>`;
instantiating it for `wstring` is ill-formed, as it is in the real library.
The `wstring` tests (`github_6063*`) are unaffected.

## The C++03 trap

All three additions are C++11 features, and the `fstream` overloads use
delegating constructors. Left unguarded they made `<fstream>` **fail to parse
under `--std c++03`** — and the regression suite did not catch it, because no
existing test includes `<fstream>` in C++03 mode. The unguarded `<string_view>`
include in `<string>` did break three C++03 tests
(`type_traits_cxx03`, `type_traits_cxx03_fail`, `try_catch/ch13_3`), which is
what prompted checking `<fstream>` by hand rather than trusting the green run.
Everything added is now behind `#if __cplusplus >= 201103L`, and
`github_5868_fstream_cxx03` closes the coverage hole so this cannot regress
silently again.

## Tests

Under `regression/esbmc-cpp/cpp/`:

- `github_5868_string_view_hash` — the conversion carries the right data
  pointer and length, and `hash<string_view>` agrees with `hash<string>` for
  equal contents (both from a converted string and from a literal view), and
  differs for different contents.
- `github_5868_string_view_hash_fail` — a wrong expected length must FAIL, so
  the checks above are not vacuous.
- `github_5868_fstream_string` — all six new overloads: `std::string`
  constructors and `open()` on `ifstream`, `ofstream` and `fstream`.
- `github_5868_fstream_cxx03` — `<fstream>` still parses under `--std c++03`.

## Suites

Full `regression/esbmc-cpp*` (2559 tests): 9 failures, exactly the same nine
pre-existing macOS/libc++ ones the unpatched tree produces, none new. The three
C++03 tests broken by the first cut of this change pass again.
