### PR TITLE
[clang-frontend] Inject the intrinsic prelude before forced includes

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_include_file_prelude/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_include_file_prelude/main.cpp
@@ -1,0 +1,10 @@
+// github #5868 gap 5: the intrinsic prelude was appended to clang's predefines
+// buffer *after* the `#include` lines that --include-file generates, so a forced
+// header reaching ESBMC's own models failed with `use of undeclared identifier
+// 'nondet_uint'`. main.cpp itself needs nothing special -- the whole point is
+// that the forced header is processed before the intrinsics are in scope.
+int main()
+{
+  assert(helper() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_include_file_prelude/pch.hpp
+++ b/regression/esbmc-cpp/cpp/github_5868_include_file_prelude/pch.hpp
@@ -1,0 +1,10 @@
+// Forced header that reaches ESBMC's stream models (which use nondet_*) and
+// uses an ESBMC intrinsic directly.
+#include <iostream>
+#include <cassert>
+
+static int helper()
+{
+  __ESBMC_assume(1);
+  return 3;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_include_file_prelude/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_include_file_prelude/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --include-file pch.hpp --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_include_file_prelude_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_include_file_prelude_fail/main.cpp
@@ -1,0 +1,8 @@
+// github #5868 gap 5, negative direction: the forced header is really compiled
+// and its helper really returns 3, so a wrong expectation must FAIL. Otherwise
+// the positive test could pass without the header contributing anything.
+int main()
+{
+  assert(helper() == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_include_file_prelude_fail/pch.hpp
+++ b/regression/esbmc-cpp/cpp/github_5868_include_file_prelude_fail/pch.hpp
@@ -1,0 +1,10 @@
+// Forced header that reaches ESBMC's stream models (which use nondet_*) and
+// uses an ESBMC intrinsic directly.
+#include <iostream>
+#include <cassert>
+
+static int helper()
+{
+  __ESBMC_assume(1);
+  return 3;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_include_file_prelude_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_include_file_prelude_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --include-file pch.hpp --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_5868_include_file_prelude/main.c
+++ b/regression/esbmc/github_5868_include_file_prelude/main.c
@@ -1,0 +1,8 @@
+/* github #5868 gap 5: the intrinsic prelude was appended to clang's predefines
+   buffer after the `#include` lines --include-file generates. esbmc_action.h is
+   shared by the C and C++ frontends, so the C path needs the same guard. */
+int main()
+{
+  assert(helper() == 3);
+  return 0;
+}

--- a/regression/esbmc/github_5868_include_file_prelude/pch.h
+++ b/regression/esbmc/github_5868_include_file_prelude/pch.h
@@ -1,0 +1,9 @@
+/* Forced header that reaches ESBMC's own models and uses an intrinsic. */
+#include <stdio.h>
+#include <assert.h>
+
+static int helper(void)
+{
+  __ESBMC_assume(1);
+  return 3;
+}

--- a/regression/esbmc/github_5868_include_file_prelude/test.desc
+++ b/regression/esbmc/github_5868_include_file_prelude/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--include-file pch.h --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/AST/esbmc_action.h
+++ b/src/clang-c-frontend/AST/esbmc_action.h
@@ -26,7 +26,19 @@ public:
     clang::Preprocessor &PP = CI.getPreprocessor();
 
     std::string s = PP.getPredefines();
-    s += intrinsics;
+
+    /* clang appends each -include / --include-file as an `#include` line at the
+     * end of the predefines buffer. Such a header can transitively reach ESBMC's
+     * own models, which use nondet_* / __ESBMC_*, so appending the intrinsics
+     * after it leaves them undeclared at that point. Put them before the first
+     * forced include instead -- still after the builtin #defines the intrinsics
+     * rely on (github #5868). */
+    const std::string first_include = "\n#include ";
+    size_t pos = s.find(first_include);
+    if (pos == std::string::npos)
+      s += intrinsics;
+    else
+      s.insert(pos + 1, intrinsics + "\n");
     PP.setPredefines(s);
 
     return true;


### PR DESCRIPTION
Towards #5868 — closes gap 5. The issue is an umbrella and should stay open for
the rest (notably the `shared_ptr` family, gap 4).

Separate from #6397, which fixes model gaps 2/3/6b; this one is a frontend
defect, not a missing model.

## Root cause

`esbmc_action::BeginSourceFileAction` **appends** the intrinsic prelude
(`nondet_*`, `__ESBMC_*`) to clang's predefines buffer. clang emits each
`--include-file` / `-include` header as an `#include` line in that same buffer,
earlier. So when a forced header transitively pulls in ESBMC's own models —
`src/cpp/library/istream` uses `nondet_uint` at :20/:28/:268, `nondet_bool` at
:212, `nondet_char` at :214, and `ostream:175` uses `__ESBMC_assert` — the
prelude is not yet in scope:

```sh
printf '#include <iostream>\n' > pch.h
printf 'int main(){return 0;}\n' > m.cpp
esbmc m.cpp --include-file pch.h --std=c++17
# istream:20:17: error: use of undeclared identifier 'nondet_uint'
```

This makes `--include-file` unusable with any header touching the stream models
— which is what a CMake PCH (`cmake_pch.hxx`) typically is, and why #5868
measured ~172 TUs blocked on it. It does **not** reproduce for a plain in-body
`#include <iostream>`, which is why it went unnoticed.

Not documented in the issue and confirmed here: the **C frontend is affected
too**, since it shares `esbmc_action`. The equivalent C reproducer fails
identically, so the regression tests cover both frontends.

## Fix

Insert the prelude before the first forced `#include` in the predefines buffer
rather than after it — still after the builtin `#define`s the prelude depends on
(`__UINTPTR_TYPE__`, `__SIZE_TYPE__`, …). When there is no forced include, the
`npos` branch appends exactly as before, so every invocation without
`--include-file` builds a byte-identical buffer and behaviour is unchanged.

The first `\n#include ` in the buffer is unambiguous: predefines are one
`#define` per line and a macro body cannot contain a newline, so no `#define`
can produce that sequence.

Checked and unaffected: diagnostics inside a forced header still carry that
header's own file and line (`./bad_pch.h:1:14: error: expected expression`), so
the prelude's `# 1 "esbmc_intrinsics.h" 1` line marker does not bleed into them.
Multiple `--include-file` arguments work — inserting before the *first* covers
all of them. Intrinsics can now also be used directly inside a forced header,
which previously could not work at all.

## Tests

- `regression/esbmc-cpp/cpp/github_5868_include_file_prelude` — forced header
  includes `<iostream>` (reaching the models) *and* calls `__ESBMC_assume`
  directly; SUCCESSFUL.
- `regression/esbmc-cpp/cpp/github_5868_include_file_prelude_fail` — same forced
  header, wrong expected value; FAILED, so the header is really compiled and
  contributing rather than the positive test passing for free.
- `regression/esbmc/github_5868_include_file_prelude` — the C-frontend
  equivalent, guarding the shared `esbmc_action` path.

All three FAIL on unpatched master and pass after.

## Suites

`regression/esbmc`, `regression/esbmc-cpp*` and `regression/goto-coverage`
together: 4069 tests, 17 failures. All 17 were verified failing on an unpatched
build of the same tree — the nine known macOS/libc++ C++ ones, plus
`bitvector_02/03`, `char16-lit`, `char32-lit` (and their `-no-simp` variants)
and `github_1537-{assume,no-assume}`. None of those eight uses
`--include-file`, so they take the unchanged `npos` branch; that they fail
identically before and after was confirmed by running them against a stashed
build rather than assumed.
