### PR TITLE
[test] Pin the ternary class-temporary over-destruction as KNOWNBUG

### DIFF
--- a/regression/esbmc-cpp/cpp/ternary_class_temporary_double_free/main.cpp
+++ b/regression/esbmc-cpp/cpp/ternary_class_temporary_double_free/main.cpp
@@ -1,0 +1,38 @@
+// KNOWNBUG: the same over-destruction turns into a double free once the class
+// owns a resource. This is why ~unique_ptr is disabled in src/cpp/library/memory
+// ("TODO: fix remove goto sideeffect"): re-enabling it makes ESBMC report a
+// false `invalid pointer freed` on
+//   std::unique_ptr<T> p = cond ? std::unique_ptr<T>(new T) : nullptr;
+// which is the aws-sdk-cpp shape the nullptr_t constructor there exists for.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <cassert>
+#include <cstddef>
+
+struct T
+{
+  int *p;
+  explicit T(int *q) : p(q)
+  {
+  }
+  T(std::nullptr_t) : p(nullptr)
+  {
+  }
+  T(T &&o) : p(o.p)
+  {
+    o.p = nullptr;
+  }
+  T(const T &) = delete;
+  ~T()
+  {
+    delete p;
+  }
+};
+
+int main()
+{
+  int n = 2;
+  T a = (n > 0) ? T(new int(5)) : nullptr;
+  assert(*a.p == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ternary_class_temporary_double_free/test.desc
+++ b/regression/esbmc-cpp/cpp/ternary_class_temporary_double_free/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ternary_class_temporary_dtor_count/main.cpp
+++ b/regression/esbmc-cpp/cpp/ternary_class_temporary_dtor_count/main.cpp
@@ -1,0 +1,39 @@
+// KNOWNBUG: a conditional operator with class-typed operands over-destroys.
+//
+// In C++17 `cond ? C(1) : C(2)` is a prvalue and `a` is initialised directly
+// from it ([dcl.init]/17.6.1, guaranteed elision), so exactly one C object
+// exists and exactly one destructor runs. ESBMC materialises a temporary per
+// branch plus a result temporary, assigns between them bitwise, and then
+// destroys all of them -- including the branch temporary that was never
+// constructed on the taken path. dtors ends up > 1.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <cassert>
+
+int dtors = 0;
+
+struct C
+{
+  int v;
+  explicit C(int x) : v(x)
+  {
+  }
+  C(const C &o) : v(o.v)
+  {
+  }
+  ~C()
+  {
+    ++dtors;
+  }
+};
+
+int main()
+{
+  int n = 2;
+  {
+    C a = (n > 0) ? C(1) : C(2);
+    assert(a.v == 1);
+  }
+  assert(dtors == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ternary_class_temporary_dtor_count/test.desc
+++ b/regression/esbmc-cpp/cpp/ternary_class_temporary_dtor_count/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Pins a newly-found C++ frontend defect as KNOWNBUG. **No issue exists yet** —
happy to file one; this PR carries the full analysis in the meantime. Tests
only, no behaviour change.

## The defect

A conditional operator with class-typed operands over-destroys. Minimal
reproducer, no dynamic memory:

```cpp
int dtors = 0;
struct C { int v; explicit C(int x):v(x){} C(const C&o):v(o.v){} ~C(){++dtors;} };
int n = 2;
{ C a = (n > 0) ? C(1) : C(2); assert(a.v == 1); }
assert(dtors == 1);   // ESBMC: VERIFICATION FAILED
```

C++17 makes `cond ? C(1) : C(2)` a prvalue and initialises `a` directly from it
([dcl.init]/17.6.1, guaranteed elision), so exactly one object exists and
exactly one destructor runs. Both reproducers exit 0 under
`clang++ -std=c++17 -fsanitize=address,undefined`, so the FAILED verdict is a
false positive, not a disputed reading of the standard.

## Root cause

`ConditionalOperatorClass` (`clang_c_convert.cpp:2600`) builds an `if_exprt`
whose operands are the two branches. Each class-typed branch has already been
lowered to a `temporary_object` side effect with its own scope-exit destructor.
`remove_sideeffects` (`goto_sideeffects.cpp:1298`) then declares a *third*
temporary and emits a plain `code_assignt` per branch into it. The resulting
GOTO:

```
FUNCTION_CALL:  T(&tmp$1, new_ptr$2)
ASSIGN tmp$4=tmp$1;          // bitwise, no copy/move constructor
...
ASSIGN a=tmp$4;              // bitwise again
FUNCTION_CALL:  ~T(&tmp$4)
FUNCTION_CALL:  ~T(&tmp$3)   // the *other* branch — never constructed here
FUNCTION_CALL:  ~T(&tmp$1)
FUNCTION_CALL:  ~T(&a)
```

Three problems: the move constructor is never called (so a move constructor's
`o.p = nullptr` never runs and every copy aliases), both branch temporaries are
destroyed unconditionally, and a redundant result temporary is destroyed too.

`MaterializeTemporaryExpr` in `clang_cpp_convert.cpp` already carries a fix for
the same shape one level down — *"Wrapping it in a second temporary_object would
construct one object and then copy it into another, leaving both with a
scope-exit destructor"* — so the ternary is the remaining hole in that pattern.

## Why this matters beyond the reproducer

It is the reason `~unique_ptr` is disabled in `src/cpp/library/memory` behind
`#if 0 // TODO: fix remove goto sideeffect`, and why the array specialisation
has no destructor at all. I confirmed that TODO is current, not stale: enabling
either destructor makes ESBMC report a false `invalid pointer freed` on

```cpp
std::unique_ptr<T> p = cond ? std::unique_ptr<T>(new T) : nullptr;
```

— the aws-sdk-cpp shape the `nullptr_t` constructor in that header exists to
support. Note the full `regression/esbmc-cpp*` suite does **not** catch the
scalar case (only `github_6183` exercises a ternary, and only for
`unique_ptr<int[]>`), so a green run is not evidence here.

Leaving the destructors disabled is not free either — both costs are measured:

- **False positive:** `--memory-leak-check` reports "forgotten memory" on
  `{ std::unique_ptr<int> p(new int(1)); }`, i.e. on correct RAII.
- **Unsound:** a genuine use-after-free through a raw pointer outliving the
  `unique_ptr` verifies SUCCESSFUL.

Fixing the conditional-operator lowering clears all of it at once.

## Tests

Both under `regression/esbmc-cpp/cpp/`, marked `KNOWNBUG` so they pass today and
get flagged for promotion to `CORE` when the frontend is fixed:

- `ternary_class_temporary_dtor_count` — counts destructor calls; isolates the
  over-destruction with no dynamic memory involved.
- `ternary_class_temporary_double_free` — the resource-owning shape, which is
  the one that blocks the `unique_ptr` destructors.

## Suites

Full `regression/esbmc-cpp*` (2557 tests): 9 failures, exactly the pre-existing
macOS/libc++ set, none new. clang-format clean.
