### PR TITLE
[om] Enable the unique_ptr destructors

### DIFF
--- a/regression/esbmc-cpp11/cpp/unique_ptr_dtor_conditional/main.cpp
+++ b/regression/esbmc-cpp11/cpp/unique_ptr_dtor_conditional/main.cpp
@@ -1,0 +1,22 @@
+// The shape that kept the destructor disabled: a class-typed conditional used
+// to destroy every branch temporary, so with ~unique_ptr present this reported
+// a false `invalid pointer freed`. It is the aws-sdk-cpp pattern the nullptr_t
+// constructor in src/cpp/library/memory exists to support.
+#include <memory>
+#include <cassert>
+#include <cstddef>
+
+int main()
+{
+  std::size_t n = 2;
+
+  std::unique_ptr<int> p = (n > 0) ? std::unique_ptr<int>(new int(5)) : nullptr;
+  assert(*p == 5);
+
+  std::unique_ptr<int[]> arr =
+    (n > 0) ? std::unique_ptr<int[]>(new int[n]) : nullptr;
+  arr[0] = 5;
+  assert(arr[0] == 5);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/unique_ptr_dtor_conditional/test.desc
+++ b/regression/esbmc-cpp11/cpp/unique_ptr_dtor_conditional/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/unique_ptr_dtor_frees/main.cpp
+++ b/regression/esbmc-cpp11/cpp/unique_ptr_dtor_frees/main.cpp
@@ -1,0 +1,62 @@
+// The unique_ptr models had no destructor: the scalar one was #if 0'd with a
+// "fix remove goto sideeffect" TODO, and the array specialisation simply lacked
+// one. The model therefore never freed, so --memory-leak-check reported a
+// spurious "forgotten memory" leak on correct RAII.
+#include <memory>
+#include <cassert>
+
+struct S
+{
+  int x;
+  S() : x(0)
+  {
+  }
+  S(int v) : x(v)
+  {
+  }
+};
+
+struct D
+{
+  void operator()(S *p) const
+  {
+    delete p;
+  }
+};
+
+int main()
+{
+  {
+    std::unique_ptr<S> p(new S(7));
+    assert(p->x == 7);
+  }
+
+  {
+    std::unique_ptr<S[]> a(new S[2]);
+    a[1].x = 2;
+    assert(a[1].x == 2);
+  }
+
+  {
+    std::unique_ptr<S, D> c(new S(4), D());
+    assert(c->x == 4);
+  }
+
+  {
+    // Moving must not leave both objects owning the pointer.
+    std::unique_ptr<S> m(new S(5));
+    std::unique_ptr<S> n = std::move(m);
+    assert(n->x == 5);
+    assert(m.get() == nullptr);
+  }
+
+  {
+    // release() hands ownership back: the caller frees, the model must not.
+    std::unique_ptr<S> r(new S(6));
+    S *raw = r.release();
+    assert(raw->x == 6);
+    delete raw;
+  }
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/unique_ptr_dtor_frees/test.desc
+++ b/regression/esbmc-cpp11/cpp/unique_ptr_dtor_frees/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/unique_ptr_dtor_uaf_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/unique_ptr_dtor_uaf_fail/main.cpp
@@ -1,0 +1,16 @@
+// Without a unique_ptr destructor the model never freed, so a genuine
+// use-after-free through a raw pointer outliving the unique_ptr was reported
+// SUCCESSFUL -- the unsound half of the same defect.
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  int *raw;
+  {
+    std::unique_ptr<int> p(new int(7));
+    raw = p.get();
+  }
+  assert(*raw == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/unique_ptr_dtor_uaf_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/unique_ptr_dtor_uaf_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$
+dereference failure

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -298,13 +298,15 @@ public:
     return *this;
   }
 
-#if 0
-  // TODO: fix remove goto sideeffect
+  /* Disabled until the class-typed conditional operator elided its temporaries:
+   * with a destructor present, the old lowering destroyed every branch
+   * temporary, so `cond ? unique_ptr<T>(new T) : nullptr` reported a false
+   * double free. Without one the model never frees, which reports a spurious
+   * leak on correct RAII and misses a real use-after-free. */
   ~unique_ptr()
   {
     deleter(ptr);
   }
-#endif
 
   T *operator->() const
   {
@@ -423,6 +425,11 @@ public:
     ptr = other.release();
     deleter = std::move(other.get_deleter());
     return *this;
+  }
+
+  ~unique_ptr()
+  {
+    deleter(ptr);
   }
 
   T &operator[](size_t i) const


### PR DESCRIPTION
**Stacked on #6401 — base is `fix/ternary-class-prvalue-elision`, not `master`.**
Merge #6401 first, or retarget this to master once it lands. The diff shown here
is one file; the parent commit is #6401's frontend fix.

No issue filed for this; it is the payoff of #6401 and clears a code TODO.

## Root cause

`src/cpp/library/memory` had no working destructor for `unique_ptr`: the scalar
one sat behind `#if 0 // TODO: fix remove goto sideeffect`, and the array
specialisation `unique_ptr<T[], D>` never had one at all. The model therefore
never freed, which produced two wrong verdicts — both measured, not inferred:

- **False positive.** `{ std::unique_ptr<int> p(new int(1)); }` under
  `--memory-leak-check` reported `dereference failure: forgotten memory`, i.e. a
  leak on the exact RAII the type exists to provide.
- **Unsound.** A genuine use-after-free through a raw pointer outliving the
  `unique_ptr` verified **SUCCESSFUL**. Missing a real bug is the worse half.

The TODO was accurate, not stale. I checked: enabling the destructor on master
makes ESBMC report a false `invalid pointer freed` on

```cpp
std::unique_ptr<T> p = cond ? std::unique_ptr<T>(new T) : nullptr;
```

because a class-typed conditional destroyed every branch temporary. That is the
aws-sdk-cpp shape the `nullptr_t` constructor in this header exists to support,
and #6401 fixes it — which is what makes this change safe now.

Worth stating plainly: the full `regression/esbmc-cpp*` suite does **not** catch
that regression. Only `github_6183` exercises a ternary with `unique_ptr`, and
only for `unique_ptr<int[]>`, so enabling just the scalar destructor produced a
completely green 2555-test run while the scalar ternary shape was broken. The
shapes below were probed by hand for that reason.

## Fix

Enable both destructors. The array specialisation gets the same `deleter(ptr)`
body as the scalar one; `default_delete<T[]>` already routes to `delete[]`.

## Tests

Under `regression/esbmc-cpp11/cpp/`:

- `unique_ptr_dtor_frees` — scalar, array, custom deleter, move, and `release()`
  (where the caller frees and the model must not), all under
  `--memory-leak-check`; SUCCESSFUL. Fails on master with a spurious leak.
- `unique_ptr_dtor_uaf_fail` — use-after-free through a raw pointer outliving the
  `unique_ptr`; FAILED, matched on `dereference failure`. Verifies SUCCESSFUL on
  master, so this test is the guard against the unsound direction.
- `unique_ptr_dtor_conditional` — the ternary shape, scalar and array, that kept
  the destructor disabled; SUCCESSFUL.

## Known limitation, unchanged by this PR

`std::unique_ptr<S[]> a(new S[2]{S(1), S(2)})` — array-new with a braced
initializer list of class objects — verifies FAILED. I confirmed it fails
identically with the destructors disabled, so it is pre-existing and out of
scope here; it is left out of the tests rather than papered over.

## Suites

Full `regression/esbmc-cpp*` (2560 tests): 9 failures, exactly the pre-existing
macOS/libc++ set, none new. All 21 existing `unique_ptr` / `make_unique` /
`github_3881` / `github_3887` / `github_6183` tests pass. clang-format clean.
