### PR TITLE
[om] Model shared_ptr, weak_ptr and make_shared

### DIFF
--- a/regression/esbmc-cpp11/cpp/shared_ptr_basic/main.cpp
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_basic/main.cpp
@@ -1,0 +1,99 @@
+// github #5868 gap 4: <memory> modelled allocator/unique_ptr/make_unique but
+// never declared shared_ptr, so any use failed with "no template named
+// 'shared_ptr' in namespace 'std'". 40 of ESBMC's own source files use it.
+#include <memory>
+#include <cassert>
+
+struct S
+{
+  int x;
+  S(int v) : x(v)
+  {
+  }
+};
+
+struct B
+{
+  virtual ~B()
+  {
+  }
+  int b;
+  B() : b(1)
+  {
+  }
+};
+struct D : B
+{
+  int d;
+  D() : d(2)
+  {
+  }
+};
+
+int main()
+{
+  {
+    std::shared_ptr<S> a(new S(7));
+    assert(a->x == 7);
+    assert(a.use_count() == 1);
+    assert(a.unique());
+    {
+      std::shared_ptr<S> b = a;
+      assert(a.use_count() == 2);
+      assert(b.get() == a.get());
+      assert(a == b);
+    }
+    assert(a.use_count() == 1); // the copy released its share
+  }
+
+  {
+    std::shared_ptr<S> e;
+    assert(!e);
+    assert(e.use_count() == 0);
+    assert(e == nullptr);
+  }
+
+  {
+    std::shared_ptr<S> m = std::make_shared<S>(9);
+    assert(m->x == 9);
+    assert(m.use_count() == 1);
+  }
+
+  {
+    std::shared_ptr<S> a(new S(4));
+    std::shared_ptr<S> b = std::move(a);
+    assert(a.get() == nullptr);
+    assert(b->x == 4);
+    assert(b.use_count() == 1);
+  }
+
+  {
+    // assignment releases the old object
+    std::shared_ptr<S> a(new S(5));
+    std::shared_ptr<S> b(new S(6));
+    a = b;
+    assert(a->x == 6);
+    assert(b.use_count() == 2);
+  }
+
+  {
+    std::shared_ptr<S> a(new S(8));
+    a.reset();
+    assert(!a);
+    a.reset(new S(10));
+    assert(a->x == 10);
+    std::shared_ptr<S> b;
+    a.swap(b);
+    assert(!a);
+    assert(b->x == 10);
+  }
+
+  {
+    std::shared_ptr<D> d(new D());
+    std::shared_ptr<B> b = d; // Derived* -> Base*
+    assert(b->b == 1);
+    assert(d.use_count() == 2);
+  }
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/shared_ptr_basic/test.desc
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/shared_ptr_uaf_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_uaf_fail/main.cpp
@@ -1,0 +1,15 @@
+// The last shared owner must really free: a raw pointer outliving it is a
+// use-after-free, and a model that never freed would report SUCCESSFUL.
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  int *raw;
+  {
+    std::shared_ptr<int> a(new int(7));
+    raw = a.get();
+  }
+  assert(*raw == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/shared_ptr_uaf_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_uaf_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$
+dereference failure

--- a/regression/esbmc-cpp11/cpp/shared_ptr_use_count_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_use_count_fail/main.cpp
@@ -1,0 +1,12 @@
+// A copy really shares ownership, so use_count() must be 2 here. Without this
+// the counting checks in shared_ptr_basic could pass vacuously.
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  std::shared_ptr<int> a(new int(1));
+  std::shared_ptr<int> b = a;
+  assert(a.use_count() == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/shared_ptr_use_count_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_use_count_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/shared_ptr_weak/main.cpp
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_weak/main.cpp
@@ -1,0 +1,35 @@
+// github #5868 gap 4: weak_ptr must observe the pointee's death while keeping
+// the control block alive, which is what the second (weak) count is for.
+#include <memory>
+#include <cassert>
+
+struct S
+{
+  int x;
+  S(int v) : x(v)
+  {
+  }
+};
+
+int main()
+{
+  std::weak_ptr<S> w;
+  assert(w.expired());
+
+  {
+    std::shared_ptr<S> a(new S(3));
+    w = a;
+    assert(!w.expired());
+    assert(w.use_count() == 1);
+
+    std::shared_ptr<S> l = w.lock();
+    assert(l.get() == a.get());
+    assert(a.use_count() == 2); // lock() took a share
+  }
+
+  assert(w.expired());
+  assert(w.use_count() == 0);
+  assert(w.lock() == nullptr);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/shared_ptr_weak/test.desc
+++ b/regression/esbmc-cpp11/cpp/shared_ptr_weak/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -571,6 +571,297 @@ unique_ptr<T> make_unique(size_t n)
 }
 #endif
 
+#if __cplusplus >= 201103L
+/* Model of shared_ptr/weak_ptr (github #5868 gap 4) using the usual two-count
+ * control block: __scount owns the pointee, __wcount owns the control block and
+ * is held collectively by the shared owners as a single count. That is what
+ * makes weak_ptr::expired() observable after the last shared owner dies while
+ * the control block is still alive. */
+struct __sp_control
+{
+  long __scount;
+  long __wcount;
+};
+
+template <class T>
+class weak_ptr;
+
+template <class T>
+class shared_ptr
+{
+  T *__p;
+  __sp_control *__c;
+
+  template <class U>
+  friend class shared_ptr;
+  template <class U>
+  friend class weak_ptr;
+
+  void __retain() noexcept
+  {
+    if (__c)
+      ++__c->__scount;
+  }
+
+  void __release() noexcept
+  {
+    if (!__c)
+      return;
+    if (--__c->__scount == 0)
+    {
+      delete __p;
+      __p = nullptr;
+      if (--__c->__wcount == 0)
+        delete __c;
+    }
+    __c = nullptr;
+  }
+
+public:
+  typedef T element_type;
+
+  constexpr shared_ptr() noexcept : __p(nullptr), __c(nullptr)
+  {
+  }
+
+  constexpr shared_ptr(nullptr_t) noexcept : __p(nullptr), __c(nullptr)
+  {
+  }
+
+  explicit shared_ptr(T *p) : __p(p), __c(new __sp_control)
+  {
+    __c->__scount = 1;
+    __c->__wcount = 1;
+  }
+
+  shared_ptr(const shared_ptr &o) noexcept : __p(o.__p), __c(o.__c)
+  {
+    __retain();
+  }
+
+  shared_ptr(shared_ptr &&o) noexcept : __p(o.__p), __c(o.__c)
+  {
+    o.__p = nullptr;
+    o.__c = nullptr;
+  }
+
+  // Derived* -> Base* aliasing conversion.
+  template <class U>
+  shared_ptr(const shared_ptr<U> &o) noexcept : __p(o.__p), __c(o.__c)
+  {
+    __retain();
+  }
+
+  ~shared_ptr()
+  {
+    __release();
+  }
+
+  shared_ptr &operator=(const shared_ptr &o) noexcept
+  {
+    if (this != &o)
+    {
+      __release();
+      __p = o.__p;
+      __c = o.__c;
+      __retain();
+    }
+    return *this;
+  }
+
+  shared_ptr &operator=(shared_ptr &&o) noexcept
+  {
+    if (this != &o)
+    {
+      __release();
+      __p = o.__p;
+      __c = o.__c;
+      o.__p = nullptr;
+      o.__c = nullptr;
+    }
+    return *this;
+  }
+
+  void reset() noexcept
+  {
+    __release();
+  }
+
+  void reset(T *p)
+  {
+    __release();
+    __p = p;
+    __c = new __sp_control;
+    __c->__scount = 1;
+    __c->__wcount = 1;
+  }
+
+  void swap(shared_ptr &o) noexcept
+  {
+    T *p = __p;
+    __sp_control *c = __c;
+    __p = o.__p;
+    __c = o.__c;
+    o.__p = p;
+    o.__c = c;
+  }
+
+  T *get() const noexcept
+  {
+    return __p;
+  }
+
+  T &operator*() const
+  {
+    return *__p;
+  }
+
+  T *operator->() const
+  {
+    return __p;
+  }
+
+  long use_count() const noexcept
+  {
+    return __c ? __c->__scount : 0;
+  }
+
+  bool unique() const noexcept
+  {
+    return use_count() == 1;
+  }
+
+  explicit operator bool() const noexcept
+  {
+    return __p != nullptr;
+  }
+};
+
+template <class T, class U>
+bool operator==(const shared_ptr<T> &a, const shared_ptr<U> &b) noexcept
+{
+  return a.get() == b.get();
+}
+
+template <class T, class U>
+bool operator!=(const shared_ptr<T> &a, const shared_ptr<U> &b) noexcept
+{
+  return a.get() != b.get();
+}
+
+template <class T>
+bool operator==(const shared_ptr<T> &a, nullptr_t) noexcept
+{
+  return a.get() == nullptr;
+}
+
+template <class T>
+bool operator!=(const shared_ptr<T> &a, nullptr_t) noexcept
+{
+  return a.get() != nullptr;
+}
+
+template <class T>
+class weak_ptr
+{
+  T *__p;
+  __sp_control *__c;
+
+  template <class U>
+  friend class weak_ptr;
+
+  void __retain() noexcept
+  {
+    if (__c)
+      ++__c->__wcount;
+  }
+
+  void __release() noexcept
+  {
+    if (__c && --__c->__wcount == 0)
+      delete __c;
+    __c = nullptr;
+    __p = nullptr;
+  }
+
+public:
+  typedef T element_type;
+
+  constexpr weak_ptr() noexcept : __p(nullptr), __c(nullptr)
+  {
+  }
+
+  weak_ptr(const weak_ptr &o) noexcept : __p(o.__p), __c(o.__c)
+  {
+    __retain();
+  }
+
+  weak_ptr(const shared_ptr<T> &o) noexcept : __p(o.__p), __c(o.__c)
+  {
+    __retain();
+  }
+
+  ~weak_ptr()
+  {
+    __release();
+  }
+
+  weak_ptr &operator=(const weak_ptr &o) noexcept
+  {
+    if (this != &o)
+    {
+      __release();
+      __p = o.__p;
+      __c = o.__c;
+      __retain();
+    }
+    return *this;
+  }
+
+  weak_ptr &operator=(const shared_ptr<T> &o) noexcept
+  {
+    __release();
+    __p = o.__p;
+    __c = o.__c;
+    __retain();
+    return *this;
+  }
+
+  void reset() noexcept
+  {
+    __release();
+  }
+
+  long use_count() const noexcept
+  {
+    return __c ? __c->__scount : 0;
+  }
+
+  bool expired() const noexcept
+  {
+    return use_count() == 0;
+  }
+
+  shared_ptr<T> lock() const noexcept
+  {
+    shared_ptr<T> r;
+    if (!expired())
+    {
+      r.__p = __p;
+      r.__c = __c;
+      ++__c->__scount;
+    }
+    return r;
+  }
+};
+
+template <class T, class... Args>
+shared_ptr<T> make_shared(Args &&...args)
+{
+  return shared_ptr<T>(new T(std::forward<Args>(args)...));
+}
+#endif
+
 #if 0
 template <class OutputIterator, class T>
 class raw_storage_iterator :


### PR DESCRIPTION
Towards #5868 — closes gap 4, the largest remaining item in that study.
**Stacked on #6401 — base is `fix/ternary-class-prvalue-elision`, not `master`.**
Independent of #6402; both sit on the same parent.

## Root cause

Not a defect but a gap: `src/cpp/library/memory` models
`allocator`/`auto_ptr`/`unique_ptr`/`make_unique` but never declares
`shared_ptr`, `weak_ptr` or `make_shared`. Because the model satisfies
`#include <memory>`, any use resolves against it and fails with
`no template named 'shared_ptr' in namespace 'std'`. #5868 counts 40 of ESBMC's
own source files using the family directly — `esbmc/bmc.{h,cpp}`,
`goto-programs/goto_cfg.*`, `goto_contractor.cpp`, `goto_k_induction.cpp`,
`abstract-interpretation/*`, `goto-symex/symex_assign.cpp` and more — plus
transitive includers.

## Fix

The usual two-count control block: the shared count owns the pointee, the weak
count owns the control block and is held collectively by the shared owners as a
single count. That second count is what makes `weak_ptr::expired()` observable
after the last shared owner dies while the control block is still alive — a
single counter cannot express it.

Covered: `shared_ptr` (construction from raw pointer / `nullptr` / copy / move /
`Derived*`→`Base*`, assignment, `reset`, `swap`, `get`, `*`, `->`, `use_count`,
`unique`, `operator bool`, comparisons), `weak_ptr` (construction from
`shared_ptr`, assignment, `expired`, `use_count`, `lock`, `reset`), and
`make_shared`.

### Why this needs #6401

`shared_ptr` is only useful with a working destructor, and until #6401 a
class-typed conditional destroyed every branch temporary — so
`shared_ptr<T> p = cond ? shared_ptr<T>(new T) : nullptr;` would have been a
false double free. The ternary shape is checked directly and verifies clean on
this base.

### A platform trap worth recording

The control-block members were first named `__shared` / `__weak`. `__weak` is a
reserved ARC ownership qualifier in clang on Apple targets, so `<memory>` failed
to parse there with `expected unqualified-id` — while being perfectly fine on
Linux. Renamed to `__scount` / `__wcount`.

## Scope

`enable_shared_from_this` is **not** included. It requires the `shared_ptr`
constructor to detect the base and seed its weak reference, which needs
`is_base_of` plumbing this model does not have; shipping a stub that silently
did nothing would be worse than a clear compile error. `shared_ptr<T[]>`,
`allocate_shared`, `static_pointer_cast`/`dynamic_pointer_cast` and
`owner_before` are likewise absent. #5868 stays open for these.

## Tests

Under `regression/esbmc-cpp11/cpp/`:

- `shared_ptr_basic` — ownership counting across copy/move/assignment/reset/swap,
  `make_shared`, empty and `Derived`→`Base`, all under `--memory-leak-check` so
  the control block and pointee must both be freed.
- `shared_ptr_weak` — `expired()` before, during and after the owner's lifetime;
  `lock()` takes a share while alive and yields null after expiry.
- `shared_ptr_uaf_fail` — a raw pointer outliving the last owner; FAILED on
  `dereference failure`. A model that never freed would report SUCCESSFUL, so
  this is the guard that the destructor really runs.
- `shared_ptr_use_count_fail` — a wrong `use_count()` expectation must FAIL, so
  the counting checks above are not vacuous.

## Suites

Full `regression/esbmc-cpp*` (2561 tests): 9 failures, exactly the pre-existing
macOS/libc++ set, none new. `<memory>` still parses under `--std c++03` (the
whole addition is behind `#if __cplusplus >= 201103L`). clang-format clean.
