### PR TITLE
[test] Solve harness_queue_fifo with z3 instead of bitwuzla

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -614,26 +614,3 @@ foreach(_t IN LISTS _very_slow_regression_tests)
         )
     endif()
 endforeach()
-
-# testing_tool caps each test with setrlimit(RLIMIT_AS) -- a *virtual* address
-# space limit, which for a solver runs well above its resident set. Linux only:
-# macOS rejects RLIMIT_AS, so these tests only hit the ceiling on the Linux
-# runners. Raise the ceiling for the few tests that legitimately map more than
-# the default, rather than lifting the global budget and losing the signal on
-# every other test.
-math(EXPR ESBMC_REGRESS_MEMORY_LIMIT_HIGH "${ESBMC_REGRESS_MEMORY_LIMIT} * 2")
-set(_memory_hungry_regression_tests
-    # queue.Queue is list-backed, so get() unwinds __ESBMC_list_pop and the
-    # bit-vector query Bitwuzla builds maps past the 8 GiB default while its
-    # resident set stays near 4.3 GiB. Reproduced on ubuntu-24.04 across six
-    # unrelated PRs, always within 0.1% of the same figure -- the signature of a
-    # fixed ceiling being hit, not of a machine running out of memory.
-    "regression/python/harness_queue_fifo"
-)
-foreach(_t IN LISTS _memory_hungry_regression_tests)
-    if(TEST ${_t})
-        set_tests_properties(${_t} PROPERTIES
-          ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT_HIGH}"
-        )
-    endif()
-endforeach()

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -614,3 +614,26 @@ foreach(_t IN LISTS _very_slow_regression_tests)
         )
     endif()
 endforeach()
+
+# testing_tool caps each test with setrlimit(RLIMIT_AS) -- a *virtual* address
+# space limit, which for a solver runs well above its resident set. Linux only:
+# macOS rejects RLIMIT_AS, so these tests only hit the ceiling on the Linux
+# runners. Raise the ceiling for the few tests that legitimately map more than
+# the default, rather than lifting the global budget and losing the signal on
+# every other test.
+math(EXPR ESBMC_REGRESS_MEMORY_LIMIT_HIGH "${ESBMC_REGRESS_MEMORY_LIMIT} * 2")
+set(_memory_hungry_regression_tests
+    # queue.Queue is list-backed, so get() unwinds __ESBMC_list_pop and the
+    # bit-vector query Bitwuzla builds maps past the 8 GiB default while its
+    # resident set stays near 4.3 GiB. Reproduced on ubuntu-24.04 across six
+    # unrelated PRs, always within 0.1% of the same figure -- the signature of a
+    # fixed ceiling being hit, not of a machine running out of memory.
+    "regression/python/harness_queue_fifo"
+)
+foreach(_t IN LISTS _memory_hungry_regression_tests)
+    if(TEST ${_t})
+        set_tests_properties(${_t} PROPERTIES
+          ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT_HIGH}"
+        )
+    endif()
+endforeach()

--- a/regression/python/harness_queue_fifo/test.desc
+++ b/regression/python/harness_queue_fifo/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3 --no-standard-checks
+--unwind 3 --no-standard-checks --z3
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The `harness_queue_fifo` regression test fails the required Ubuntu check on unrelated PRs (nine hits so far: #6346, #6353, #6355, #6378, #6388, #6390, #6392, #6393, #6397, #6398) with `ERROR: Out of memory` from the solver.

The trigger is `regression/testing_tool.py:388`, which applies `setrlimit(RLIMIT_AS)` from `ESBMC_REGRESS_MEMORY_LIMIT`. macOS rejects `RLIMIT_AS` (the call sits under `except (ValueError, OSError): pass`), so the ceiling only exists on Linux — which is why the test passes everywhere else.

**Raising the ceiling does not fix it.** This PR first doubled the budget to 16 GiB; the run then consumed **8.13 GiB** and still aborted, against **4.13 GiB** under the old 8 GiB cap. Consumption tracked the budget, so bitwuzla is not short of a fixed amount — its demand on this query is effectively unbounded on x86-64. That commit is reverted here.

For contrast the identical query costs **0.17 GiB and ~4s** on aarch64 macOS, so this is an x86-64 backend blowup rather than a test that is genuinely too big.

Pin the test to z3, which solves it locally in ~2s with the correct `VERIFICATION SUCCESSFUL`. Coverage of this harness is retained; only the backend changes for this one test.