### PR TITLE
[om] Stop the variant converting ctor from hijacking copies

### DIFF
--- a/regression/esbmc-cpp17/cpp/variant_copy/main.cpp
+++ b/regression/esbmc-cpp17/cpp/variant_copy/main.cpp
@@ -1,0 +1,36 @@
+// Copying a variant used to lose the active alternative. The converting
+// constructor template was unconstrained, so for a non-const lvalue it beat the
+// implicit copy constructor; __assign then matched no alternative and left the
+// target at index 0 with an empty slot -- a silent wrong answer.
+// [variant.ctor]/13 requires that constructor not to participate when the
+// argument is the variant itself.
+#include <variant>
+#include <cassert>
+
+int main()
+{
+  std::variant<int, double> v = 2.5;
+  assert(v.index() == 1);
+
+  std::variant<int, double> w = v; // copy construction
+  assert(w.index() == 1);
+  assert(std::get<double>(w) == 2.5);
+  assert(std::holds_alternative<double>(w));
+
+  std::variant<int, double> x = 7;
+  assert(x.index() == 0);
+  x = w; // copy assignment
+  assert(x.index() == 1);
+  assert(std::get<double>(x) == 2.5);
+
+  std::variant<int, double> y = std::move(w); // move construction
+  assert(y.index() == 1);
+  assert(std::get<double>(y) == 2.5);
+
+  // A converting assignment still selects the matching alternative.
+  y = 3;
+  assert(y.index() == 0);
+  assert(std::get<int>(y) == 3);
+
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/variant_copy/test.desc
+++ b/regression/esbmc-cpp17/cpp/variant_copy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/variant_copy_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/variant_copy_fail/main.cpp
@@ -1,0 +1,12 @@
+// Non-vacuity guard for variant_copy: the copy really carries the alternative,
+// so expecting the wrong index must FAIL.
+#include <variant>
+#include <cassert>
+
+int main()
+{
+  std::variant<int, double> v = 2.5;
+  std::variant<int, double> w = v;
+  assert(w.index() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/variant_copy_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/variant_copy_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/variant
+++ b/src/cpp/library/variant
@@ -79,6 +79,11 @@ struct __at_or_char<3, T0, T1, T2, T3, Ts...>
   using type = T3;
 };
 
+template <class>
+struct __dependent_false : false_type
+{
+};
+
 } // namespace __variant_detail
 
 template <class... Types>
@@ -101,13 +106,26 @@ public:
   {
   }
 
-  template <class T>
+  /* [variant.ctor]/13 and [variant.assign]/11: the converting constructor and
+   * assignment shall not participate in overload resolution when the argument
+   * is the variant itself. Unconstrained, they are a better match than the
+   * implicit copy operations for a non-const lvalue, so `variant w = v;` went
+   * through __assign, matched no alternative, and left w with index 0 and an
+   * empty slot -- a silent wrong answer rather than a diagnostic. Constrained
+   * out, the implicit copy/move operations do the correct memberwise copy. */
+  template <
+    class T,
+    class = typename enable_if<
+      !is_same<typename decay<T>::type, variant>::value>::type>
   constexpr variant(T &&v) : __idx_(0), __s0_(), __s1_(), __s2_(), __s3_()
   {
     __assign(std::forward<T>(v));
   }
 
-  template <class T>
+  template <
+    class T,
+    class = typename enable_if<
+      !is_same<typename decay<T>::type, variant>::value>::type>
   variant &operator=(T &&v)
   {
     __assign(std::forward<T>(v));
@@ -155,6 +173,14 @@ private:
     {
       __idx_ = 3;
       __s3_ = std::forward<T>(v);
+    }
+    else
+    {
+      // Falling through used to leave the variant silently untouched.
+      static_assert(
+        __variant_detail::__dependent_false<D>::value,
+        "this <variant> OM requires the assigned type to match an alternative "
+        "exactly; no converting selection is modelled");
     }
   }
 };


### PR DESCRIPTION
Found by an assert-based audit of the `<variant>` model, not from an issue —
happy to file one for the record. Silent-wrong-answer class.

## The defect

```cpp
std::variant<int, double> v = 2.5;   // index 1
std::variant<int, double> w = v;     // copy
assert(w.index() == 1);              // VERIFICATION FAILED
```

The copy silently loses the active alternative: `w` ends up at index 0 with an
empty slot. No error, no warning. The same program runs clean under
`clang++ -std=c++17 -fsanitize=address,undefined`, so the verdict was false.

## Root cause

`variant`'s converting constructor and assignment were unconstrained templates:

```cpp
template <class T> constexpr variant(T &&v) : __idx_(0), ... { __assign(...); }
template <class T> variant &operator=(T &&v)                 { __assign(...); }
```

For a **non-const lvalue** argument, `T&&` deduces to `variant&` — an exact
match — while the implicitly declared copy constructor takes `const variant&`
and needs a qualification conversion. The template therefore wins overload
resolution, and `__assign` compares `decay_t<T>` (= `variant<int,double>`)
against each alternative type, matches none, falls out of the `if constexpr`
chain, and returns having written nothing. `__idx_` keeps the `0` from the
mem-initialiser.

[variant.ctor]/13 and [variant.assign]/11 require exactly this constructor and
assignment not to participate in overload resolution when the argument is the
variant itself, which is what prevents the hijack in a conforming library.

## Fix

Constrain both with
`enable_if<!is_same<decay_t<T>, variant>::value>`, so the implicit copy/move
operations take over and do the correct memberwise copy of `__idx_` and the
slots. No new copy operations are written — a constructor *template* is never a
copy constructor, so the implicit ones were there all along, just outranked.

Additionally, `__assign`'s fall-through — the branch that silently did nothing —
is now a `static_assert`. An unmatched type becomes a compile error instead of a
wrong answer, which closes the whole family rather than this one instance.

## Blast radius

The C++ frontend resolves `#include <...>` only against `src/cpp/library/`, and
**no OM header includes `<variant>`**, so only programs that include it directly
can be affected. That is exactly five regression tests, all in
`regression/esbmc-cpp17/cpp/`.

## Tests

- `variant_copy` — copy construction, copy assignment and move construction all
  preserve index and value, and a converting assignment still selects the
  matching alternative.
- `variant_copy_fail` — expects the wrong index; must FAIL.

Both **fail on the parent commit** and pass with the fix. Note the `_fail` test
discriminates in the opposite direction: before the fix the copy really did land
on index 0, so its assertion *held* and the test did not get its expected
FAILED. The three pre-existing `github_4377_variant*` tests pass either way.

## Suites

`regression/esbmc-cpp17` (38 tests, the suite containing every `<variant>` user)
100% pass. clang-format clean.

A full `regression/esbmc-cpp*` run is not reported here: on this host the suite
does not complete — individual container tests were still running after 990s
each under contention — so any failure count from it would be timeout noise
rather than evidence. The blast-radius argument above is the substantive
justification, and CI will run the full suite.
