### PR TITLE
[om] Stop the any converting ctor from hijacking copies

### DIFF
--- a/regression/esbmc-cpp17/cpp/any_copy/main.cpp
+++ b/regression/esbmc-cpp17/cpp/any_copy/main.cpp
@@ -1,0 +1,25 @@
+// Copying an any used to wrap it instead of copying the held object. The
+// converting constructor template was unconstrained, so for a non-const lvalue
+// it beat any(const any&) and stored an `any` inside the `any`. [any.cons]/6
+// requires that constructor not to participate when decay_t<T> is any itself.
+#include <any>
+#include <cassert>
+
+int main()
+{
+  std::any a = 5;
+  assert(a.has_value());
+  assert(std::any_cast<int>(a) == 5);
+
+  std::any b = a; // copy construction from a non-const lvalue
+  assert(b.has_value());
+  assert(std::any_cast<int>(b) == 5);
+
+  std::any c;
+  assert(!c.has_value());
+  c = b; // copy assignment
+  assert(c.has_value());
+  assert(std::any_cast<int>(c) == 5);
+
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/any_copy/test.desc
+++ b/regression/esbmc-cpp17/cpp/any_copy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/any_copy_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/any_copy_fail/main.cpp
@@ -1,0 +1,12 @@
+// Non-vacuity guard for any_copy: the copy really carries the held value, so a
+// wrong expectation must FAIL.
+#include <any>
+#include <cassert>
+
+int main()
+{
+  std::any a = 5;
+  std::any b = a;
+  assert(std::any_cast<int>(b) == 6);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/any_copy_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/any_copy_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/any
+++ b/src/cpp/library/any
@@ -34,7 +34,14 @@ public:
 
   constexpr any() noexcept = default;
 
-  template <class T>
+  /* [any.cons]/6: this constructor participates only when decay_t<T> is not
+   * any itself. Unconstrained it is a better match than any(const any&) for a
+   * non-const lvalue, so `any b = a;` stored an any inside the any instead of
+   * copying the held object. */
+  template <
+    class T,
+    class = typename enable_if<!is_same<typename decay<T>::type, any>::value>::
+      type>
   any(T &&v)
   {
     using D = typename decay<T>::type;


### PR DESCRIPTION
Second instance of the defect fixed for `<variant>` in #6407, found by auditing
the rest of that family. No issue filed; happy to file one.

## The defect

```cpp
std::any a = 5;
std::any b = a;                       // copy from a non-const lvalue
assert(std::any_cast<int>(b) == 5);
```

Before the fix this produces **no verdict at all** — symex does not terminate
(killed at 300s). After, it verifies in about a second.

## Root cause

`any`'s converting constructor was an unconstrained template:

```cpp
template <class T> any(T &&v) { __ptr_ = new typename decay<T>::type(...); ... }
```

For a non-const lvalue, `T&&` deduces to `any&` — an exact match — while
`any(const any&)` needs a qualification conversion, so the template wins. It
then heap-allocates an `any` *inside* the `any`, and the nested type-erasure
(each layer holding `__deleter_`/`__copier_` function pointers) is what symex
fails to get through.

This is visible in the GOTO without needing the solver. Before, four
constructors are instantiated:

```
any#&&$@N@std@S@any#            move
any#&1$@N@std@S@any#            copy
any<#&$@N@std@S@any>#S0_#       <-- the template with T = any&, doing new any(...)
any<#I>#&&I#                    the template with T = int
```

After, the `T = any&` instantiation is gone and the copy routes to
`any(const any&)`.

[any.cons]/6 requires this constructor not to participate in overload
resolution when `decay_t<T>` is `any`, which is exactly what prevents the
hijack in a conforming library.

## Fix

Constrain it with `enable_if<!is_same<decay_t<T>, any>::value>`. No copy
constructor is added — a constructor *template* is never a copy constructor, so
the implicit one was always there, just outranked.

## The rest of the family

Audited at the same time, so this is not a one-off patch:

- `variant` — same defect, fixed in #6407 (silent wrong answer there: the copy
  landed on index 0).
- `expected` — **already correctly constrained**
  (`!is_same<decay_t<U>, expected>::value` on its converting constructor);
  confirmed at the GOTO level that only the copy constructor and the `T = int`
  instantiation appear. No change needed.
- `optional` — has no converting constructor template at all (its `template
  <class U>` is `value_or`), and passed a full behavioural audit separately.

## Blast radius

The C++ frontend resolves `#include <...>` only against `src/cpp/library/`, and
**no OM header includes `<any>`**, so only programs that include it directly are
affected — three pre-existing tests, all in `regression/esbmc-cpp17/cpp/`.

## Tests

- `any_copy` — copy construction and copy assignment both carry the held value.
- `any_copy_fail` — a wrong expected value must FAIL, so the above is not
  vacuous.

## Suites

`regression/esbmc-cpp17` (38 tests, the suite containing every `<any>` user)
100% pass, including the three pre-existing `github_4377_any*` tests.
clang-format clean.

A full `regression/esbmc-cpp*` run is not reported: this host cannot complete it
(individual container tests still running after 990s under contention), so any
count from it would be timeout noise. The blast-radius argument above is the
substantive justification and CI runs the full suite.
