### PR TITLE
[test] Pin std::string::at not throwing as KNOWNBUG

### DIFF
--- a/regression/esbmc-cpp/string/github_6338_at_throws/main.cpp
+++ b/regression/esbmc-cpp/string/github_6338_at_throws/main.cpp
@@ -1,0 +1,53 @@
+// KNOWNBUG (github #6338): std::string::at does not throw std::out_of_range.
+//
+// src/cpp/library/string still carries a pre-try-catch placeholder in
+// basic_string::at -- `__ESBMC_assert(0, ...)` where the throw should be -- so
+// correct exception-handling code is reported as VERIFICATION FAILED.
+// std::vector::at throws correctly, which is the control below.
+//
+// The fix is blocked on a <string>/<stdexcept> include cycle: <stdexcept>
+// includes <string> solely for the `const std::string &` constructor overloads
+// of its exception classes, so out_of_range is incomplete at the point
+// basic_string::at is parsed and a direct throw does not compile. Routing the
+// throw through a helper compiles but defeats ESBMC's throw analysis, which
+// only marks a function as throwing when the throw is directly in its body --
+// that would make an *uncaught* string::at OOB verify SUCCESSFUL, which is
+// unsound and worse than the current assert. See the issue for both directions.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include <cassert>
+
+int main()
+{
+  // Control: vector::at throws and the handler runs.
+  std::vector<int> v;
+  v.push_back(1);
+  bool caught_vector = false;
+  try
+  {
+    v.at(5);
+  }
+  catch (const std::out_of_range &)
+  {
+    caught_vector = true;
+  }
+  assert(caught_vector);
+
+  // string::at should behave the same way.
+  std::string s = "ab";
+  bool caught_string = false;
+  try
+  {
+    s.at(5);
+  }
+  catch (const std::out_of_range &)
+  {
+    caught_string = true;
+  }
+  assert(caught_string);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/github_6338_at_throws/test.desc
+++ b/regression/esbmc-cpp/string/github_6338_at_throws/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Towards #6338. Tests only, no behaviour change — the fix is blocked, and this
records the gap in the suite with a control so it cannot be quietly forgotten.

## The defect (re-verified on current master)

```cpp
std::string s = "ab";
try { s.at(5); }
catch (const std::out_of_range &) { /* should run */ }
```

`basic_string::at` still carries a pre-try-catch placeholder in
`src/cpp/library/string` — `__ESBMC_assert(0, ...)` where the throw belongs — so
correct exception-handling code is reported as **VERIFICATION FAILED**. Per
[string.access], `at` throws `std::out_of_range` when `pos >= size()`.

`std::vector::at` throws correctly, and the test asserts that first. That makes
the pin precise: the gap is specific to `<string>`, not to ESBMC's exception
handling.

The reproducer exits 0 under `clang++ -std=c++17 -fsanitize=address,undefined`.

## Why this is a pin and not a fix

I re-investigated both directions the issue records, and sharpened *why* the
obvious one does not work:

`<stdexcept>` includes `<string>` **solely** for the `const std::string &`
constructor overloads of its exception classes — every one of them also has a
`const char *` overload, and nothing else in the header needs `std::string`.
That single dependency is what makes `out_of_range` incomplete at the point
`basic_string::at` is parsed, so a direct `throw` does not compile.

Breaking it cleanly is harder than it looks:

- Dropping the `const std::string &` constructors would break the cycle, and the
  blast radius inside the suite is nil — exactly one test throws any of these
  types and it passes a string literal. But removing standard constructors is a
  user-visible API regression that this issue does not call for.
- Keeping them as constrained templates would work around the incompleteness,
  but an unconstrained-or-loosely-constrained `template <class S> C(const S &)`
  is precisely the copy-constructor-hijacking shape that had to be fixed in
  `variant` (#6407) and `any` (#6408). Deliberately introducing another is not a
  trade worth making.
- Routing the throw through a helper compiles in every include order and a
  handler does catch it — but ESBMC's throw analysis only marks a function as
  throwing when the `throw` is directly in its body, so an *uncaught*
  `string::at` OOB would verify **SUCCESSFUL**. That is unsound and strictly
  worse than today's assert, so it must not be shipped.

A real fix therefore needs either `<stdexcept>` made independent of `<string>`
without losing its API, or throw-analysis that propagates through a helper
(which ties into #5125). Both are their own piece of work.

## Tests

`regression/esbmc-cpp/string/github_6338_at_throws`, marked `KNOWNBUG` so it
passes today and the harness flags it for promotion to `CORE` the moment
`string::at` throws.

## Suites

`regression/esbmc-cpp/string/` and all `try_catch` suites: 413 tests, 2
failures, both `esbmc-solidity` (no `solc` on this host) and unrelated. The
change is additive test-only, so no model or frontend behaviour moves.
clang-format clean.
