### PR TITLE
[om] Model std::promise and std::future over ESBMC's pthread model

### DIFF
--- a/regression/esbmc-cpp11/cpp/future_promise/main.cpp
+++ b/regression/esbmc-cpp11/cpp/future_promise/main.cpp
@@ -1,0 +1,29 @@
+// github #6319: the promise/future half of <future>, over ESBMC's pthread
+// model. The producer thread publishes under the state's mutex and broadcasts;
+// future::get() waits on the condvar, so the value is observed only after the
+// producer sets it -- a model that did not synchronise would read the
+// uninitialised state and fail this assertion.
+//
+// --no-unwinding-assertions follows the repo convention for a condvar wait
+// (see regression/esbmc-unix/01_cond_10): ESBMC's condvar model admits an
+// unbounded run of spurious wake-ups, so the wait loop has no finite unwind
+// bound. future_promise_fail runs the same program under the same flags and
+// must FAIL, which is what shows the assertion is still reached.
+#include <future>
+#include <thread>
+#include <cassert>
+std::promise<int> p;
+void producer()
+{
+  p.set_value(42);
+}
+int main()
+{
+  std::future<int> f = p.get_future();
+  assert(f.valid());
+  std::thread t(producer);
+  int v = f.get();
+  assert(v == 42);
+  t.join();
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/future_promise/test.desc
+++ b/regression/esbmc-cpp11/cpp/future_promise/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 2 --no-unwinding-assertions --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/future_promise_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/future_promise_fail/main.cpp
@@ -1,0 +1,21 @@
+// github #6319, negative direction: future_promise with the expected value
+// changed, under identical flags. It must FAIL, so the positive test is not
+// vacuously discharged by the truncated wait loop.
+#include <future>
+#include <thread>
+#include <cassert>
+std::promise<int> p;
+void producer()
+{
+  p.set_value(42);
+}
+int main()
+{
+  std::future<int> f = p.get_future();
+  assert(f.valid());
+  std::thread t(producer);
+  int v = f.get();
+  assert(v == 43);
+  t.join();
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/future_promise_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/future_promise_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 2 --no-unwinding-assertions --context-bound 2
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/future_promise_same_thread/main.cpp
+++ b/regression/esbmc-cpp11/cpp/future_promise_same_thread/main.cpp
@@ -1,0 +1,15 @@
+// github #6319: promise/future used within a single thread -- get_future(),
+// valid(), and a set_value() that has already happened, so no waiting occurs.
+#include <future>
+#include <cassert>
+int main()
+{
+  std::future<int> e;
+  assert(!e.valid());
+  std::promise<int> p;
+  std::future<int> f = p.get_future();
+  assert(f.valid());
+  p.set_value(7); // same thread: no waiting needed
+  assert(f.get() == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/future_promise_same_thread/test.desc
+++ b/regression/esbmc-cpp11/cpp/future_promise_same_thread/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 2 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/future
+++ b/src/cpp/library/future
@@ -1,0 +1,122 @@
+#ifndef STL_FUTURE
+#define STL_FUTURE
+
+#include <pthread.h>
+#include <mutex>
+#include <condition_variable>
+#include "OM_compiler_defs.h"
+
+// Model of the promise/future half of <future> (github #6319) over ESBMC's
+// pthread model, so a value published by one thread and consumed by another
+// goes through the same lock/wait machinery the rest of the concurrency models
+// use.
+//
+// Not modelled: std::async and packaged_task (both need to launch a callable
+// returning a value, which the <thread> model's function-pointer constructors
+// cannot express), shared_future, exception propagation through
+// set_exception, and the timed waits -- ESBMC has no clock.
+
+#if __cplusplus >= 201103L
+
+namespace std
+{
+template <class T>
+struct __future_state
+{
+  T __v;
+  bool __ready;
+  pthread_mutex_t __m;
+  pthread_cond_t __c;
+};
+
+template <class T>
+class future
+{
+  __future_state<T> *__s;
+
+  template <class U>
+  friend class promise;
+
+  future(const future &);
+  future &operator=(const future &);
+
+public:
+  future() OM_NOEXCEPT : __s(OM_NULLPTR)
+  {
+  }
+
+  future(future &&o) OM_NOEXCEPT : __s(o.__s)
+  {
+    o.__s = OM_NULLPTR;
+  }
+
+  future &operator=(future &&o) OM_NOEXCEPT
+  {
+    __s = o.__s;
+    o.__s = OM_NULLPTR;
+    return *this;
+  }
+
+  bool valid() const OM_NOEXCEPT
+  {
+    return __s != OM_NULLPTR;
+  }
+
+  void wait() const
+  {
+    pthread_mutex_lock(&__s->__m);
+    while (!__s->__ready)
+      pthread_cond_wait(&__s->__c, &__s->__m);
+    pthread_mutex_unlock(&__s->__m);
+  }
+
+  T get()
+  {
+    wait();
+    return __s->__v;
+  }
+};
+
+template <class T>
+class promise
+{
+  __future_state<T> *__s;
+
+  promise(const promise &);
+  promise &operator=(const promise &);
+
+public:
+  promise() : __s(new __future_state<T>)
+  {
+    __s->__ready = false;
+    pthread_mutex_init(&__s->__m, OM_NULLPTR);
+    pthread_cond_init(&__s->__c, OM_NULLPTR);
+  }
+
+  promise(promise &&o) OM_NOEXCEPT : __s(o.__s)
+  {
+    o.__s = OM_NULLPTR;
+  }
+
+  future<T> get_future()
+  {
+    future<T> f;
+    f.__s = __s;
+    return f;
+  }
+
+  void set_value(const T &v)
+  {
+    pthread_mutex_lock(&__s->__m);
+    __s->__v = v;
+    __s->__ready = true;
+    pthread_cond_broadcast(&__s->__c);
+    pthread_mutex_unlock(&__s->__m);
+  }
+};
+
+} // namespace std
+
+#endif // __cplusplus >= 201103L
+
+#endif // STL_FUTURE


### PR DESCRIPTION
Towards #6319 — adds the last of the concurrency headers that issue names.
`<thread>`, `<mutex>` and `<condition_variable>` landed in #6394; this is
`<future>`. Based on master, independent of the other open PRs.

## Root cause

Not a defect but a gap: `src/cpp/library/` bundles no `<future>`, so
`#include <future>` fails at parse time. #6319 lists it alongside the other
concurrency headers.

## Fix

`promise<T>` and `future<T>` share a heap-allocated state carrying the value, a
ready flag, a `pthread_mutex_t` and a `pthread_cond_t`. `set_value` publishes
under the lock and broadcasts; `future::get()` waits on the condvar and then
reads. Reusing the pthread model rather than inventing a second synchronisation
mechanism means the existing lock and deadlock checks apply unchanged.

Covered: `promise` (default and move construction, `get_future`, `set_value`),
`future` (default and move construction, `valid`, `wait`, `get`).

## Scope

Deliberately absent, with reasons rather than for convenience:

- **`std::async` and `packaged_task`** — both launch a callable that returns a
  value. The `<thread>` model takes function pointers, because a trampoline
  would have to be a function template whose body the frontend does not convert
  in an OM header (#6394 explains this at length); the thread would silently
  never run. Neither is expressible without that, so they are omitted rather
  than stubbed.
- **`shared_future`**, **`set_exception`**, and the timed waits
  (`wait_for`/`wait_until`) — no clock, and no exception propagation through the
  shared state.

#6319 should stay open for these.

## Tests

Under `regression/esbmc-cpp11/cpp/`:

- `future_promise` — a producer thread publishes 42 and the main thread reads it
  through `future::get()`. The state is heap-allocated and uninitialised, so a
  model that did not actually synchronise would read nondet and fail this
  assertion; it is what shows the wait is real.
- `future_promise_fail` — the same program with the expected value changed;
  FAILED under identical flags, so the positive test is not vacuously discharged
  by the truncated wait loop.
- `future_promise_same_thread` — `get_future`/`valid`/`set_value` with no
  waiting, so the non-concurrent API surface is covered separately from the
  interleaving cost.

The two-thread pair carries `--unwind 2 --no-unwinding-assertions
--context-bound 2`, the repo convention for a condvar wait
(`regression/esbmc-unix/01_cond_10`): ESBMC's condvar model admits an unbounded
run of spurious wake-ups, so the wait loop has no finite unwind bound. Because a
truncated loop can hide a vacuous SUCCESSFUL, the `_fail` companion runs under
exactly the same flags. The positive test takes ~11 s, well inside CI's 120 s
cap.

## Suites

`regression/esbmc-cpp11` (138 tests, including the `github_6319_*` tests from
#6394) 100% pass. `<future>` is inert below C++11 and no OM header includes it,
so nothing outside programs that include it directly can be affected.
clang-format clean.
