### PR TITLE
[om] Add the missing type_traits classification traits and _t aliases

### DIFF
--- a/regression/esbmc-cpp17/cpp/github_5868_type_traits/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_5868_type_traits/main.cpp
@@ -1,0 +1,80 @@
+// github #5868 gap 7: <type_traits> was missing several classification traits
+// and most of the C++14 _t aliases, and <tuple> had tuple_element but no
+// tuple_element_t. TMP-heavy headers (llvm/ADT, fmt) name these, so their
+// absence blocks the ~24-TU clang-frontend family from parsing.
+//
+// Everything here is compile-time: the value of the test is that it compiles.
+#include <type_traits>
+#include <tuple>
+#include <utility>
+#include <cassert>
+
+struct A
+{
+};
+struct B : A
+{
+};
+union U
+{
+  int i;
+};
+struct P
+{
+  virtual ~P()
+  {
+  }
+};
+struct Abstract
+{
+  virtual void f() = 0;
+};
+struct Final final
+{
+};
+
+static_assert(std::is_base_of<A, B>::value, "is_base_of");
+static_assert(std::is_class<A>::value, "is_class");
+static_assert(std::is_union<U>::value, "is_union");
+static_assert(!std::is_union<A>::value, "is_union negative");
+static_assert(std::is_polymorphic<P>::value, "is_polymorphic");
+static_assert(std::is_abstract<Abstract>::value, "is_abstract");
+static_assert(!std::is_abstract<A>::value, "is_abstract negative");
+static_assert(std::is_empty<A>::value, "is_empty");
+static_assert(!std::is_empty<P>::value, "is_empty negative");
+static_assert(std::is_final<Final>::value, "is_final");
+static_assert(!std::is_final<A>::value, "is_final negative");
+static_assert(std::is_member_pointer<int A::*>::value, "is_member_pointer");
+
+static_assert(std::is_same<std::remove_const_t<const int>, int>::value, "1");
+static_assert(
+  std::is_same<std::remove_volatile_t<volatile int>, int>::value,
+  "2");
+static_assert(std::is_same<std::remove_pointer_t<int *>, int>::value, "3");
+static_assert(std::is_same<std::add_const_t<int>, const int>::value, "4");
+static_assert(std::is_same<std::add_pointer_t<int>, int *>::value, "5");
+static_assert(
+  std::is_same<std::add_lvalue_reference_t<int>, int &>::value,
+  "6");
+static_assert(std::is_same<std::common_type_t<int, long>, long>::value, "7");
+static_assert(
+  std::is_same<std::remove_cv_t<const volatile int>, int>::value,
+  "8");
+
+static_assert(
+  std::is_same<std::tuple_element_t<0, std::tuple<int, char>>, int>::value,
+  "9");
+static_assert(
+  std::is_same<std::tuple_element_t<1, std::tuple<int, char>>, char>::value,
+  "10");
+static_assert(
+  std::is_same<std::tuple_element_t<1, std::pair<int, char>>, char>::value,
+  "11");
+
+int main()
+{
+  // One runtime check so the test is not purely a compile gate.
+  std::tuple_element_t<0, std::tuple<int, char>> v = 7;
+  assert(v == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_5868_type_traits/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_5868_type_traits/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/tuple
+++ b/src/cpp/library/tuple
@@ -92,6 +92,21 @@ struct tuple_element<I, tuple<Head, Tail...>>
   using type = typename tuple_element<I - 1, tuple<Tail...>>::type;
 };
 
+// std::pair is a 2-tuple for tuple_element purposes ([pair.astuple]).
+template <typename T1, typename T2>
+struct tuple_element<0, std::pair<T1, T2>>
+{
+  using type = T1;
+};
+template <typename T1, typename T2>
+struct tuple_element<1, std::pair<T1, T2>>
+{
+  using type = T2;
+};
+
+template <std::size_t I, typename Tuple>
+using tuple_element_t = typename tuple_element<I, Tuple>::type;
+
 template <typename Tuple>
 struct tuple_size;
 

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -313,6 +313,30 @@ struct is_polymorphic : integral_constant<bool, __is_polymorphic(T)>
 {
 };
 
+// is_union
+template <class T>
+struct is_union : integral_constant<bool, __is_union(T)>
+{
+};
+
+// is_abstract
+template <class T>
+struct is_abstract : integral_constant<bool, __is_abstract(T)>
+{
+};
+
+// is_empty
+template <class T>
+struct is_empty : integral_constant<bool, __is_empty(T)>
+{
+};
+
+// is_final
+template <class T>
+struct is_final : integral_constant<bool, __is_final(T)>
+{
+};
+
 // is_trivially_default_constructible
 template <class T>
 struct is_trivially_default_constructible
@@ -716,6 +740,69 @@ template <class T, class... Args>
 inline constexpr bool is_constructible_v = is_constructible<T, Args...>::value;
 template <class From, class To>
 inline constexpr bool is_convertible_v = is_convertible<From, To>::value;
+
+// remove_volatile / add_const: the members of the cv family that were missing
+// next to their already-present siblings. add_lvalue_reference already comes
+// from <utility>, which this header includes.
+template <class T>
+struct remove_volatile
+{
+  typedef T type;
+};
+template <class T>
+struct remove_volatile<volatile T>
+{
+  typedef T type;
+};
+
+template <class T>
+struct add_const
+{
+  typedef const T type;
+};
+
+// common_type: enough of [meta.trans.other] for the two-type case TMP-heavy
+// headers use; the variadic form folds left as the standard specifies.
+template <class... T>
+struct common_type;
+
+template <class T>
+struct common_type<T>
+{
+  typedef typename decay<T>::type type;
+};
+
+template <class T, class U>
+struct common_type<T, U>
+{
+  typedef typename decay<decltype(
+    true ? declval<T>() : declval<U>())>::type type;
+};
+
+template <class T, class U, class... V>
+struct common_type<T, U, V...>
+{
+  typedef typename common_type<typename common_type<T, U>::type, V...>::type
+    type;
+};
+
+/* The C++14 _t aliases. These are compile-time only: they add no runtime
+ * semantics, they just let TMP-heavy headers name the transformations they
+ * already rely on (github #5868 gap 7). */
+template <class T>
+using remove_const_t = typename remove_const<T>::type;
+template <class T>
+using remove_volatile_t = typename remove_volatile<T>::type;
+template <class T>
+using remove_pointer_t = typename remove_pointer<T>::type;
+template <class T>
+using add_const_t = typename add_const<T>::type;
+template <class T>
+using add_pointer_t = typename add_pointer<T>::type;
+template <class T>
+using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
+template <class... T>
+using common_type_t = typename common_type<T...>::type;
 
 #endif // __cplusplus >= 201103L
 


### PR DESCRIPTION
Towards #5868 — gap 7, partially. Based on master, independent of the other
open PRs.

## Root cause

`src/cpp/library/type_traits` and `tuple` are missing pieces that TMP-heavy
headers name directly, so those headers fail to parse. I re-probed each item on
current master rather than working from the issue's list, since parts of it have
been fixed since it was written:

| | state on master |
|---|---|
| `is_base_of`, `is_class`, `is_polymorphic`, `is_member_pointer` | already present |
| `is_union`, `is_abstract`, `is_empty`, `is_final` | **missing** |
| `remove_cv_t`, `remove_reference_t`, `decay_t`, `conditional_t`, `enable_if_t`, `underlying_type_t`, `make_signed_t`, `make_unsigned_t`, `remove_extent_t` | already present |
| `remove_const_t`, `remove_volatile_t`, `remove_pointer_t`, `add_const_t`, `add_pointer_t`, `add_lvalue_reference_t`, `common_type_t` | **missing** |
| `tuple_element` | present |
| `tuple_element_t` | **missing** |

`remove_volatile`, `add_const` and `common_type` were missing as base traits
too, not just as aliases. `add_lvalue_reference` already exists in `<utility>`,
which `<type_traits>` includes, so only the alias was needed — defining it again
here is a redefinition error, which is how I found it.

## Fix

The four classification traits use the Clang builtins, matching how
`is_class`/`is_polymorphic` are already written in this header. `common_type`
follows [meta.trans.other]: `decay` of the conditional-operator result, folding
left for the variadic case. The rest are the straightforward aliases.

**Everything here is additive.** No existing declaration is modified, so nothing
that compiled before can behave differently — the change can only turn a parse
error into a working translation unit.

## Deliberately not included: transparent comparators

Gap 7 also asks for `std::less<>` and friends. I implemented it and then backed
it out, because making `std::less<>` transparent requires changing the *default
template argument* of six comparators in `<functional>` from `int` to `void`
(the C++14 default). That modifies existing declarations in a header included by
`<tuple>`, `<map>`, `<set>` and more — a genuinely wide blast radius, and the
one part of this work that could regress something.

I could not validate it on this host: the container suites take 700–1000 s per
test under contention and the run does not complete. Rather than ship a
wide-radius header change on narrow evidence — which is exactly how the
`<string>` → `<algorithm>` regression in #6397 happened — it is left for a
separate change that can be validated properly. The `less<void>` specialisations
alone are useless without the default change, so none of it is here.

## Tests

`regression/esbmc-cpp17/cpp/github_5868_type_traits` — every trait with a
positive *and* negative `static_assert` where the negative is meaningful
(`is_union<A>`, `is_abstract<A>`, `is_empty<P>`, `is_final<A>`), every alias
checked with `is_same`, `tuple_element_t` on both `tuple` and `pair`, plus one
runtime assertion so the test is not purely a compile gate.

## Suites

`regression/esbmc-cpp17` (37 tests) and the tuple/map/set suites (115 tests) all
pass. `<type_traits>` and `<tuple>` still parse under `--std c++03`.
clang-format clean.
