### PR TITLE
[om] Add a <system_error> model

### DIFF
--- a/regression/esbmc-cpp11/cpp/system_error_code/main.cpp
+++ b/regression/esbmc-cpp11/cpp/system_error_code/main.cpp
@@ -1,0 +1,37 @@
+// <system_error> was not bundled, so any program including it failed to parse
+// (github #5868 lists it among the missing headers). The category identity is
+// the load-bearing part: two codes with the same value but different categories
+// must not compare equal.
+#include <system_error>
+#include <cassert>
+#include <cstring>
+
+int main()
+{
+  std::error_code e;
+  assert(!e);
+  assert(e.value() == 0);
+
+  std::error_code f = std::make_error_code(std::errc::invalid_argument);
+  assert(f);
+  assert(f.value() == 22);
+  assert(f.category() == std::generic_category());
+  assert(std::strcmp(f.category().name(), "generic") == 0);
+
+  std::error_code g(22, std::system_category());
+  assert(g.value() == 22);
+  assert(g.category() != f.category());
+  assert(g != f); // same value, different category
+
+  std::error_code h(22, std::generic_category());
+  assert(h == f);
+
+  std::error_code i = std::errc::io_error; // implicit errc conversion
+  assert(i.value() == 5);
+
+  f.clear();
+  assert(!f);
+  assert(f.value() == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/system_error_code/test.desc
+++ b/regression/esbmc-cpp11/cpp/system_error_code/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/system_error_code_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/system_error_code_fail/main.cpp
@@ -1,0 +1,12 @@
+// Non-vacuity guard for system_error_code: codes from different categories
+// really are distinct, so asserting they are equal must FAIL.
+#include <system_error>
+#include <cassert>
+
+int main()
+{
+  std::error_code f(22, std::generic_category());
+  std::error_code g(22, std::system_category());
+  assert(f == g);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/system_error_code_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/system_error_code_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/system_error_throw/main.cpp
+++ b/regression/esbmc-cpp11/cpp/system_error_throw/main.cpp
@@ -1,0 +1,23 @@
+// std::system_error carries its code through a throw. --force-malloc-success is
+// needed because std::runtime_error's message storage allocates, and ESBMC
+// models malloc as able to fail: without the flag the escaping std::bad_alloc
+// masks the test, and a plain `throw std::runtime_error("x")` fails the same way
+// on master, independently of <system_error>.
+#include <system_error>
+#include <cassert>
+
+int main()
+{
+  try
+  {
+    throw std::system_error(std::make_error_code(std::errc::timed_out));
+  }
+  catch (const std::system_error &ex)
+  {
+    assert(ex.code().value() == 110);
+    assert(ex.code().category() == std::generic_category());
+    return 0;
+  }
+  assert(0); // the handler must run
+  return 1;
+}

--- a/regression/esbmc-cpp11/cpp/system_error_throw/test.desc
+++ b/regression/esbmc-cpp11/cpp/system_error_throw/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/system_error
+++ b/src/cpp/library/system_error
@@ -1,0 +1,174 @@
+#ifndef STL_SYSTEM_ERROR
+#define STL_SYSTEM_ERROR
+
+#include "stdexcept"
+#include "OM_compiler_defs.h"
+
+// Model of <system_error> (github #5868 lists it among the missing headers).
+// error_code carries a value and a category; the two standard categories are
+// distinct singletons so codes from different categories never compare equal.
+//
+// Not modelled: user-defined categories beyond deriving from error_category,
+// error_condition's equivalence mapping (default_error_condition returns a
+// condition with the same value and category), and message() strings, which
+// would need the string model for no verification benefit.
+
+#if __cplusplus >= 201103L
+
+namespace std
+{
+enum class errc
+{
+  operation_not_permitted = 1,
+  no_such_file_or_directory = 2,
+  no_such_process = 3,
+  interrupted = 4,
+  io_error = 5,
+  bad_file_descriptor = 9,
+  resource_unavailable_try_again = 11,
+  not_enough_memory = 12,
+  permission_denied = 13,
+  device_or_resource_busy = 16,
+  file_exists = 17,
+  invalid_argument = 22,
+  result_out_of_range = 34,
+  not_supported = 95,
+  timed_out = 110
+};
+
+class error_category
+{
+public:
+  virtual ~error_category()
+  {
+  }
+
+  virtual const char *name() const OM_NOEXCEPT = 0;
+
+  bool operator==(const error_category &o) const OM_NOEXCEPT
+  {
+    return this == &o;
+  }
+
+  bool operator!=(const error_category &o) const OM_NOEXCEPT
+  {
+    return this != &o;
+  }
+};
+
+class __generic_category : public error_category
+{
+public:
+  const char *name() const OM_NOEXCEPT
+  {
+    return "generic";
+  }
+};
+
+class __system_category : public error_category
+{
+public:
+  const char *name() const OM_NOEXCEPT
+  {
+    return "system";
+  }
+};
+
+inline const error_category &generic_category() OM_NOEXCEPT
+{
+  static __generic_category __c;
+  return __c;
+}
+
+inline const error_category &system_category() OM_NOEXCEPT
+{
+  static __system_category __c;
+  return __c;
+}
+
+class error_code
+{
+  int __v;
+  const error_category *__c;
+
+public:
+  error_code() OM_NOEXCEPT : __v(0), __c(&system_category())
+  {
+  }
+
+  error_code(int v, const error_category &c) OM_NOEXCEPT : __v(v), __c(&c)
+  {
+  }
+
+  error_code(errc e) OM_NOEXCEPT : __v((int)e), __c(&generic_category())
+  {
+  }
+
+  void assign(int v, const error_category &c) OM_NOEXCEPT
+  {
+    __v = v;
+    __c = &c;
+  }
+
+  void clear() OM_NOEXCEPT
+  {
+    __v = 0;
+    __c = &system_category();
+  }
+
+  int value() const OM_NOEXCEPT
+  {
+    return __v;
+  }
+
+  const error_category &category() const OM_NOEXCEPT
+  {
+    return *__c;
+  }
+
+  explicit operator bool() const OM_NOEXCEPT
+  {
+    return __v != 0;
+  }
+};
+
+inline bool operator==(const error_code &a, const error_code &b) OM_NOEXCEPT
+{
+  return a.value() == b.value() && a.category() == b.category();
+}
+
+inline bool operator!=(const error_code &a, const error_code &b) OM_NOEXCEPT
+{
+  return !(a == b);
+}
+
+inline error_code make_error_code(errc e) OM_NOEXCEPT
+{
+  return error_code((int)e, generic_category());
+}
+
+class system_error : public runtime_error
+{
+  error_code __ec;
+
+public:
+  system_error(error_code ec) : runtime_error("system_error"), __ec(ec)
+  {
+  }
+
+  system_error(error_code ec, const char *what_arg)
+    : runtime_error(what_arg), __ec(ec)
+  {
+  }
+
+  const error_code &code() const OM_NOEXCEPT
+  {
+    return __ec;
+  }
+};
+
+} // namespace std
+
+#endif // __cplusplus >= 201103L
+
+#endif // STL_SYSTEM_ERROR


### PR DESCRIPTION
Towards #5868, which lists `<system_error>` among the headers
`src/cpp/library/` does not bundle. Based on master, independent of the other
open PRs.

## Root cause

Not a defect but a gap: the C++ frontend resolves `#include <...>` only against
`src/cpp/library/`, so `#include <system_error>` is a hard parse error
(`fatal error: 'system_error' file not found`).

## Fix

`error_code` holds a value and a pointer to its category. The load-bearing part
is category *identity*: `generic_category()` and `system_category()` are
distinct singletons compared by address, so two codes with the same value but
different categories do not compare equal — which is what `error_code` is for
and the easiest thing to get wrong by modelling the category as a name string.

Covered: `errc` (the common POSIX values), `error_category` with the two
standard categories, `error_code` (construction from `errc` and from
value+category, `assign`, `clear`, `value`, `category`, `operator bool`,
`==`/`!=`), `make_error_code`, and `system_error` deriving from `runtime_error`
and carrying its code.

## Scope

Absent, with reasons: user-defined categories beyond deriving from
`error_category`; `error_condition`'s equivalence mapping; and `message()`
strings, which would pull in the string model for no verification benefit —
`name()` returns a literal instead.

## A pre-existing interaction worth knowing about

`system_error_throw` runs with `--force-malloc-success`. `std::runtime_error`'s
message storage allocates through `__refcnted_cstr`, and ESBMC models `malloc`
as able to fail, so an escaping `std::bad_alloc` masks the test otherwise. This
is **not** introduced here: `throw std::runtime_error("x")` caught by
`catch (const std::runtime_error &)` fails on master for exactly the same
reason. The test comment records this so the flag does not look arbitrary.

## Tests

Under `regression/esbmc-cpp11/cpp/`:

- `system_error_code` — default and explicit construction, `errc` conversion,
  `value`/`category`/`clear`/`operator bool`, `category().name()`, and the two
  same-value-different-category comparisons in both directions.
- `system_error_code_fail` — asserts two codes that differ only by category are
  equal; must FAIL, so the identity checks above are not vacuous.
- `system_error_throw` — the code survives a throw and reaches the handler.

## Suites

`regression/esbmc-cpp11` and all `try_catch` suites: 304 tests, 2 failures, both
`esbmc-solidity` (no `solc` on this host) and unrelated. `<system_error>` is
inert below C++11 and no OM header includes it, so only programs that include it
directly are affected. clang-format clean.
