### PR TITLE
[om] Give std::array its required iterator/const_iterator typedefs

### DIFF
--- a/regression/esbmc-cpp17/cpp/array_iterator_typedefs/main.cpp
+++ b/regression/esbmc-cpp17/cpp/array_iterator_typedefs/main.cpp
@@ -1,0 +1,33 @@
+// [array.overview] requires std::array to provide iterator and const_iterator
+// member types. The model defined pointer/const_pointer and built
+// reverse_iterator on them, but never named iterator/const_iterator, so generic
+// code spelling std::array<T,N>::iterator failed with "no type named
+// 'iterator'". begin()/end() already return pointer, so the typedefs just give
+// those the names the standard requires.
+//
+// --unwind is needed only because an iterator loop over an OM container has no
+// statically-visible bound; that is a separate, pre-existing property shared
+// with std::vector and is not what this test is about.
+#include <array>
+#include <cassert>
+#include <iterator>
+int main()
+{
+  std::array<int, 3> a = {1, 2, 3};
+  std::array<int, 3>::iterator it = a.begin();
+  assert(*it == 1);
+  ++it;
+  assert(*it == 2);
+
+  std::array<int, 3>::const_iterator ci = a.cbegin();
+  assert(*ci == 1);
+
+  const std::array<int, 3> &c = a;
+  std::array<int, 3>::const_iterator ci2 = c.begin();
+  assert(*ci2 == 1);
+
+  // value_type via the iterator, the shape generic code uses
+  std::iterator_traits<std::array<int, 3>::iterator>::value_type v = *a.begin();
+  assert(v == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/array_iterator_typedefs/test.desc
+++ b/regression/esbmc-cpp17/cpp/array_iterator_typedefs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/array
+++ b/src/cpp/library/array
@@ -24,6 +24,11 @@ struct array
   typedef const value_type &const_reference;
   typedef value_type *pointer;
   typedef const value_type *const_pointer;
+  /* [array.overview]: iterator and const_iterator are required member types.
+   * begin()/end() already return pointer, and reverse_iterator below is built
+   * on pointer, so these are the matching names generic code asks for. */
+  typedef pointer iterator;
+  typedef const_pointer const_iterator;
   typedef std::reverse_iterator<pointer> reverse_iterator;
   typedef std::reverse_iterator<const_pointer> const_reverse_iterator;
 


### PR DESCRIPTION
Found by a soundness/API audit of the `<array>` and `<bitset>` models. No issue
filed; happy to file one. Based on master, independent of the other open PRs.

## The defect

```cpp
std::array<int, 3>::iterator it = a.begin();
// error: no type named 'iterator' in 'std::array<int, 3>'
```

[array.overview] requires `std::array` to provide `iterator` and
`const_iterator` member types. The model defines `value_type`, `size_type`,
`difference_type`, `reference`, `const_reference`, `pointer`, `const_pointer`,
`reverse_iterator` and `const_reverse_iterator` — but never names `iterator` or
`const_iterator`. Any generic code that spells `Container::iterator`, or that
goes through `std::iterator_traits<Container::iterator>`, fails to compile.

## Fix

`begin()`/`end()` already return `pointer`, and `reverse_iterator` is already
`std::reverse_iterator<pointer>`, so the two typedefs just give what is already
there the names the standard requires. Purely additive: no existing declaration
changes, so nothing that compiled before can behave differently.

## Audit context

This came out of checking the models that had not been audited before.

- **`<bitset>` — clean.** `set`/`reset`/`flip`/`test`/`count`/`any`/`none`/
  `all`/`size`/`to_ulong`, the `unsigned long` constructor, and the
  whole-bitset `set()`/`reset()` forms all behave correctly.
- **`<array>` — sound where it compiles.** Indexing, `at`, `front`/`back`,
  `data`, `fill`, `size`, equality/inequality and copy independence all hold;
  the only defect found is the missing typedefs fixed here.

## A separate, pre-existing property this test has to work around

An iterator loop or a range-for over an OM container has no statically visible
bound, so ESBMC unwinds it indefinitely: `for (int x : a) s += x;` over a
**fixed-size** `std::array<int,3>` does not terminate without `--unwind`, and
`std::vector` behaves the same way. With `--unwind 5` it verifies immediately.

That is not introduced here and is not what this PR fixes — the test carries
`--unwind 5` and says so in a comment. It is worth its own issue: for an array
whose size is a compile-time constant, the bound ought to be visible. I have
deliberately not touched `end()` to chase it, because the existing notes on the
string model record that naively changing `end()` regresses several append/
assign tests.

## Tests

`regression/esbmc-cpp17/cpp/array_iterator_typedefs` — `iterator` and
`const_iterator` named directly, `const_iterator` obtained from both `cbegin()`
and a `const` array's `begin()`, and `std::iterator_traits<...>::value_type`,
which is the shape generic code actually uses. Each is dereferenced and checked,
so the test is not merely a compile gate.

## Suites

`regression/esbmc-cpp17` (37), the `array` and `vector` suites (160) and the
`span` suite (16 — `<span>` is the only OM header that includes `<array>`, so it
is the entire blast radius) all pass. `<array>` still parses under `--std c++03`.
clang-format clean.
