### PR TITLE
[om] Add iota, gcd, lcm and reduce to <numeric>

### DIFF
--- a/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota/main.cpp
+++ b/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota/main.cpp
@@ -1,0 +1,41 @@
+// <numeric> shipped accumulate/inner_product/partial_sum/adjacent_difference
+// but not iota (C++11) or gcd/lcm/reduce (C++17), so naming them failed with
+// "no member named 'gcd' in namespace 'std'".
+//
+// The sign and zero cases are the load-bearing part: [numeric.ops.gcd] and
+// [numeric.ops.lcm] are defined on the absolute values, gcd(0,0) is 0, and lcm
+// is 0 if either operand is 0.
+#include <numeric>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  assert(std::gcd(12, 18) == 6);
+  assert(std::gcd(17, 5) == 1);
+  assert(std::gcd(0, 0) == 0);
+  assert(std::gcd(0, 5) == 5);
+  assert(std::gcd(5, 0) == 5);
+  assert(std::gcd(-12, 18) == 6);
+  assert(std::gcd(12, -18) == 6);
+  assert(std::gcd(-12, -18) == 6);
+
+  assert(std::lcm(4, 6) == 12);
+  assert(std::lcm(21, 6) == 42);
+  assert(std::lcm(0, 5) == 0);
+  assert(std::lcm(5, 0) == 0);
+  assert(std::lcm(-4, 6) == 12);
+  assert(std::lcm(4, -6) == 12);
+
+  std::vector<int> v(3);
+  std::iota(v.begin(), v.end(), 1);
+  assert(v[0] == 1 && v[1] == 2 && v[2] == 3);
+
+  assert(std::reduce(v.begin(), v.end(), 0) == 6);
+  assert(std::reduce(v.begin(), v.end(), 10) == 16);
+
+  // still present, unchanged
+  assert(std::accumulate(v.begin(), v.end(), 0) == 6);
+
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota/test.desc
+++ b/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota_fail/main.cpp
@@ -1,0 +1,10 @@
+// Non-vacuity guard for numeric_gcd_lcm_iota: gcd really computes, so a wrong
+// expectation must FAIL.
+#include <numeric>
+#include <cassert>
+
+int main()
+{
+  assert(std::gcd(12, 18) == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/numeric_gcd_lcm_iota_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/numeric
+++ b/src/cpp/library/numeric
@@ -117,6 +117,69 @@ OutputIterator partial_sum(
   return result;
 }
 
+#if __cplusplus >= 201103L
+// [numeric.iota]
+template <class ForwardIterator, class T>
+void iota(ForwardIterator first, ForwardIterator last, T value)
+{
+  for (; first != last; ++first, ++value)
+    *first = value;
+}
+#endif
+
+#if __cplusplus >= 201703L
+/* [numeric.ops.gcd] / [numeric.ops.lcm]: both are defined on the *absolute*
+ * values, and gcd(0,0) is 0. lcm is written as (|m| / gcd) * |n| so the
+ * division happens before the multiplication, which keeps the intermediate
+ * inside the result type. */
+template <class M, class N>
+constexpr auto gcd(M m, N n) -> decltype(m + n)
+{
+  /* [numeric.ops.gcd] returns common_type_t<M,N>; both operands are required to
+   * be integer types, for which decltype(m + n) is that same type under the
+   * usual arithmetic conversions -- and it does not require <type_traits>. */
+  typedef decltype(m + n) R;
+  R a = m < 0 ? (R)-(R)m : (R)m;
+  R b = n < 0 ? (R)-(R)n : (R)n;
+  while (b != 0)
+  {
+    R t = a % b;
+    a = b;
+    b = t;
+  }
+  return a;
+}
+
+template <class M, class N>
+constexpr auto lcm(M m, N n) -> decltype(m + n)
+{
+  typedef decltype(m + n) R;
+  if (m == 0 || n == 0)
+    return 0;
+  R a = m < 0 ? (R)-(R)m : (R)m;
+  R b = n < 0 ? (R)-(R)n : (R)n;
+  return (a / gcd(a, b)) * b;
+}
+
+// [numeric.ops.reduce]: accumulate with an unspecified order; the model folds
+// left, which is a valid order and keeps the result deterministic.
+template <class InputIterator, class T>
+T reduce(InputIterator first, InputIterator last, T init)
+{
+  for (; first != last; ++first)
+    init = init + *first;
+  return init;
+}
+
+template <class InputIterator, class T, class BinaryOperation>
+T reduce(InputIterator first, InputIterator last, T init, BinaryOperation op)
+{
+  for (; first != last; ++first)
+    init = op(init, *first);
+  return init;
+}
+#endif
+
 } // namespace std
 
 #endif


### PR DESCRIPTION
Found by an API/soundness audit of the models that had not been audited before.
No issue filed; happy to file one. Based on master, independent of the other
open PRs.

## The gap

```cpp
std::gcd(12, 18);   // error: no member named 'gcd' in namespace 'std'
```

`<numeric>` ships `accumulate`, `inner_product`, `partial_sum` and
`adjacent_difference`, but not `iota` (C++11) or `gcd`/`lcm`/`reduce` (C++17),
so naming any of them is a parse error. I probed each algorithm individually
rather than assuming which were present.

## Fix

`iota` and `reduce` are straightforward. `gcd`/`lcm` follow
[numeric.ops.gcd]/[numeric.ops.lcm] precisely, and the details matter:

- both are defined on the **absolute values** of the operands, so
  `gcd(-12, 18) == 6`;
- `gcd(0, 0) == 0`, and `gcd(n, 0) == |n|`;
- `lcm` is 0 if **either** operand is 0;
- `lcm` divides before multiplying — `(|m| / gcd) * |n|` — so the intermediate
  stays inside the result type rather than overflowing on the way.

The standard specifies the return type as `common_type_t<M, N>`. This header
does not include `<type_traits>`, and adding that dependency would couple
`<numeric>` to it for one typedef, so the return type is spelled
`decltype(m + n)` via a trailing return type. For the integer types `gcd`/`lcm`
are defined on, the usual arithmetic conversions make that the same type.
(`common_type` itself is one of the things #6412 adds; this PR deliberately does
not depend on that branch.)

`reduce` folds left. The standard leaves the order unspecified, and a fixed
order keeps the result deterministic, which is what a verifier wants.

## Audit context

Also checked in the same pass and **clean**, so no changes for them:

- **`<limits>`** — `numeric_limits` `max`/`min`/`is_signed`/`is_integer`/`digits`
  for `char`, `short`, `int`, `long`, `long long` and their unsigned forms, each
  cross-checked against the corresponding `<climits>` macro. Getting these wrong
  would silently corrupt every overflow check, so it was worth confirming.
- **`std::pair`** — construction, `make_pair`, all six comparisons, copy
  independence, assignment and `swap`.
- **`<numeric>`'s existing four algorithms** — `accumulate` (both forms),
  `inner_product`, `partial_sum`, `adjacent_difference`.

## Tests

- `numeric_gcd_lcm_iota` — every sign combination for `gcd` and `lcm`, both
  zero cases for each, a coprime pair, `iota`, both `reduce` forms, and
  `accumulate` to confirm the pre-existing algorithms still work.
- `numeric_gcd_lcm_iota_fail` — a wrong `gcd` expectation must FAIL, so the
  above is not vacuous.

## Suites

`regression/esbmc-cpp17` and the `algorithm` suite: 183 tests, all pass.
`<numeric>` still parses under `--std c++03` (everything added is guarded), and
no OM header includes `<numeric>`, so only programs that include it directly are
affected.

The one clang-format complaint in `src/cpp/library/numeric` is pre-existing —
line 7, `namespace std {` — and is unchanged by this PR.
