### PR TITLE
[om] Make <complex> usable

### DIFF
--- a/regression/esbmc-cpp/cpp/complex_arithmetic/main.cpp
+++ b/regression/esbmc-cpp/cpp/complex_arithmetic/main.cpp
@@ -1,0 +1,67 @@
+// <complex> was a skeleton that could not be used at all: every member sat in
+// the default-private section of `class complex`, no member or operator had a
+// definition, and the comparison operators were declared to return complex<T>
+// instead of bool. `std::complex<double> a(3.0, 4.0);` did not compile.
+//
+// All values here are exactly representable, so the floating-point equalities
+// are safe to assert.
+#include <complex>
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  std::complex<double> a(3.0, 4.0);
+  assert(a.real() == 3.0);
+  assert(a.imag() == 4.0);
+
+  std::complex<double> b(1.0, 2.0);
+
+  std::complex<double> s = a + b;
+  assert(s.real() == 4.0 && s.imag() == 6.0);
+
+  std::complex<double> d = a - b;
+  assert(d.real() == 2.0 && d.imag() == 2.0);
+
+  // (3+4i)(1+2i) = -5+10i
+  std::complex<double> m = a * b;
+  assert(m.real() == -5.0 && m.imag() == 10.0);
+
+  // (3+4i)/(1+2i) = (11-2i)/5
+  std::complex<double> q = a / b;
+  assert(q.real() == 2.2 && q.imag() == -0.4);
+
+  std::complex<double> n = -a;
+  assert(n.real() == -3.0 && n.imag() == -4.0);
+
+  assert(std::norm(a) == 25.0);
+  assert(sqrt(std::norm(a)) == 5.0); // std::abs(complex) aborts ESBMC, see
+                                     // std_abs_class_overload
+
+  std::complex<double> c = std::conj(a);
+  assert(c.real() == 3.0 && c.imag() == -4.0);
+
+  assert(std::real(a) == 3.0);
+  assert(std::imag(a) == 4.0);
+
+  // [complex.ops]: comparisons yield bool
+  assert(a == std::complex<double>(3.0, 4.0));
+  assert(a != b);
+
+  std::complex<double> e(3.0, 4.0);
+  e += b;
+  assert(e.real() == 4.0 && e.imag() == 6.0);
+  e -= b;
+  assert(e == a);
+  e *= 2.0;
+  assert(e.real() == 6.0 && e.imag() == 8.0);
+  e /= 2.0;
+  assert(e == a);
+
+  std::complex<double> f = a; // copy
+  assert(f == a);
+  f.real(9.0);
+  assert(a.real() == 3.0); // the copy is independent
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/complex_arithmetic/test.desc
+++ b/regression/esbmc-cpp/cpp/complex_arithmetic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/complex_arithmetic_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/complex_arithmetic_fail/main.cpp
@@ -1,0 +1,12 @@
+// Non-vacuity guard for complex_arithmetic: the multiplication really computes,
+// so a wrong expectation must FAIL.
+#include <complex>
+#include <cassert>
+
+int main()
+{
+  std::complex<double> a(3.0, 4.0), b(1.0, 2.0);
+  std::complex<double> m = a * b;
+  assert(m.real() == 5.0); // the real part is -5.0
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/complex_arithmetic_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/complex_arithmetic_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/std_abs_class_overload/main.cpp
+++ b/regression/esbmc-cpp/cpp/std_abs_class_overload/main.cpp
@@ -1,0 +1,34 @@
+// KNOWNBUG: overloading the name `abs` for a class type makes ESBMC abort with
+// an internal assertion:
+//
+//   Assertion failed: (type->type_id == trueval->type->type_id),
+//   function if2t, file irep2_expr.h, line 809
+//
+// The identical body under any other name converts and verifies fine, so the
+// trigger is the name `abs` rather than the arithmetic. This is why <complex>
+// does not provide std::abs(complex) -- shipping it would ship a crash.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <cmath>
+#include <cassert>
+
+namespace std
+{
+struct Mag
+{
+  double v;
+};
+
+double abs(const Mag &m)
+{
+  return sqrt(m.v * m.v);
+}
+} // namespace std
+
+int main()
+{
+  std::Mag m;
+  m.v = -5.0;
+  assert(std::abs(m) == 5.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/std_abs_class_overload/test.desc
+++ b/regression/esbmc-cpp/cpp/std_abs_class_overload/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/complex
+++ b/src/cpp/library/complex
@@ -1,136 +1,277 @@
 #ifndef __STL_COMPLEX
 #define __STL_COMPLEX
 
-#include "iostream"
+#include "cmath"
+
+// Model of <complex>. The previous version of this header was a skeleton that
+// could not be used at all: every member sat in the default-private section of
+// `class complex`, none of the members or operators had a definition, and the
+// comparison operators were declared to return complex<T> rather than bool.
+//
+// Not modelled: the transcendental functions (exp/log/pow/sqrt/sin/cos/...),
+// polar/arg, and the stream inserters. Those are left out rather than declared
+// without a definition -- a declaration-only member converts to a nondet call,
+// which would silently produce wrong values instead of a diagnostic.
+//
+// abs(complex) is also absent, but for a different reason: overloading the name
+// `abs` for a class type makes ESBMC abort with an internal assertion
+// (irep2_expr.h `if2t`: type->type_id == trueval->type->type_id). The identical
+// body under any other name converts fine, so the trigger is the name, not the
+// arithmetic. See regression/esbmc-cpp/cpp/std_abs_class_overload for the
+// reduced case; use sqrt(norm(z)) meanwhile.
 
 namespace std
 {
-
 template <class T>
 class complex
 {
+  T __re;
+  T __im;
+
+public:
   typedef T value_type;
 
-  complex(const T &re = T(), const T &im = T());
-  complex(const complex &cmplx);
-  template <class X>
-  complex(const complex<X> &cmplx);
-  T imag() const;
-  T real() const;
-  complex<T> &operator=(const T &val);
-  complex<T> &operator+=(const T &val);
-  complex<T> &operator-=(const T &val);
-  complex<T> &operator*=(const T &val);
-  complex<T> &operator/=(const T &val);
+  complex(const T &re = T(), const T &im = T()) : __re(re), __im(im)
+  {
+  }
 
-  complex &operator=(const complex &rhs);
+  complex(const complex &o) : __re(o.__re), __im(o.__im)
+  {
+  }
 
   template <class X>
-  complex<T> &operator=(const complex<X> &rhs);
-  template <class X>
-  complex<T> &operator+=(const complex<X> &rhs);
-  template <class X>
-  complex<T> &operator-=(const complex<X> &rhs);
-  template <class X>
-  complex<T> &operator*=(const complex<X> &rhs);
-  template <class X>
-  complex<T> &operator/=(const complex<X> &rhs);
+  complex(const complex<X> &o) : __re(o.real()), __im(o.imag())
+  {
+  }
+
+  T real() const
+  {
+    return __re;
+  }
+
+  T imag() const
+  {
+    return __im;
+  }
+
+  void real(T v)
+  {
+    __re = v;
+  }
+
+  void imag(T v)
+  {
+    __im = v;
+  }
+
+  complex &operator=(const complex &o)
+  {
+    __re = o.__re;
+    __im = o.__im;
+    return *this;
+  }
+
+  complex &operator=(const T &v)
+  {
+    __re = v;
+    __im = T();
+    return *this;
+  }
+
+  complex &operator+=(const T &v)
+  {
+    __re += v;
+    return *this;
+  }
+
+  complex &operator-=(const T &v)
+  {
+    __re -= v;
+    return *this;
+  }
+
+  complex &operator*=(const T &v)
+  {
+    __re *= v;
+    __im *= v;
+    return *this;
+  }
+
+  complex &operator/=(const T &v)
+  {
+    __re /= v;
+    __im /= v;
+    return *this;
+  }
+
+  complex &operator+=(const complex &o)
+  {
+    __re += o.__re;
+    __im += o.__im;
+    return *this;
+  }
+
+  complex &operator-=(const complex &o)
+  {
+    __re -= o.__re;
+    __im -= o.__im;
+    return *this;
+  }
+
+  complex &operator*=(const complex &o)
+  {
+    T r = __re * o.__re - __im * o.__im;
+    T i = __re * o.__im + __im * o.__re;
+    __re = r;
+    __im = i;
+    return *this;
+  }
+
+  complex &operator/=(const complex &o)
+  {
+    T d = o.__re * o.__re + o.__im * o.__im;
+    T r = (__re * o.__re + __im * o.__im) / d;
+    T i = (__im * o.__re - __re * o.__im) / d;
+    __re = r;
+    __im = i;
+    return *this;
+  }
 };
 
 template <class T>
-complex<T> operator+(const complex<T> &lhs, const complex<T> &rhs);
+complex<T> operator+(const complex<T> &a, const complex<T> &b)
+{
+  return complex<T>(a.real() + b.real(), a.imag() + b.imag());
+}
 template <class T>
-complex<T> operator+(const complex<T> &lhs, const T &val);
+complex<T> operator+(const complex<T> &a, const T &v)
+{
+  return complex<T>(a.real() + v, a.imag());
+}
 template <class T>
-complex<T> operator+(const T &val, const complex<T> &rhs);
+complex<T> operator+(const T &v, const complex<T> &a)
+{
+  return complex<T>(v + a.real(), a.imag());
+}
 
 template <class T>
-complex<T> operator-(const complex<T> &lhs, const complex<T> &rhs);
+complex<T> operator-(const complex<T> &a, const complex<T> &b)
+{
+  return complex<T>(a.real() - b.real(), a.imag() - b.imag());
+}
 template <class T>
-complex<T> operator-(const complex<T> &lhs, const T &val);
+complex<T> operator-(const complex<T> &a, const T &v)
+{
+  return complex<T>(a.real() - v, a.imag());
+}
 template <class T>
-complex<T> operator-(const T &val, const complex<T> &rhs);
+complex<T> operator-(const T &v, const complex<T> &a)
+{
+  return complex<T>(v - a.real(), -a.imag());
+}
 
 template <class T>
-complex<T> operator*(const complex<T> &lhs, const complex<T> &rhs);
+complex<T> operator*(const complex<T> &a, const complex<T> &b)
+{
+  return complex<T>(
+    a.real() * b.real() - a.imag() * b.imag(),
+    a.real() * b.imag() + a.imag() * b.real());
+}
 template <class T>
-complex<T> operator*(const complex<T> &lhs, const T &val);
+complex<T> operator*(const complex<T> &a, const T &v)
+{
+  return complex<T>(a.real() * v, a.imag() * v);
+}
 template <class T>
-complex<T> operator*(const T &val, const complex<T> &rhs);
+complex<T> operator*(const T &v, const complex<T> &a)
+{
+  return complex<T>(v * a.real(), v * a.imag());
+}
 
 template <class T>
-complex<T> operator/(const complex<T> &lhs, const complex<T> &rhs);
+complex<T> operator/(const complex<T> &a, const complex<T> &b)
+{
+  T d = b.real() * b.real() + b.imag() * b.imag();
+  return complex<T>(
+    (a.real() * b.real() + a.imag() * b.imag()) / d,
+    (a.imag() * b.real() - a.real() * b.imag()) / d);
+}
 template <class T>
-complex<T> operator/(const complex<T> &lhs, const T &val);
+complex<T> operator/(const complex<T> &a, const T &v)
+{
+  return complex<T>(a.real() / v, a.imag() / v);
+}
 template <class T>
-complex<T> operator/(const T &val, const complex<T> &rhs);
+complex<T> operator/(const T &v, const complex<T> &a)
+{
+  return complex<T>(v, T()) / a;
+}
 
 template <class T>
-complex<T> operator+(const complex<T> &rhs);
+complex<T> operator+(const complex<T> &a)
+{
+  return a;
+}
 template <class T>
-complex<T> operator-(const complex<T> &rhs);
+complex<T> operator-(const complex<T> &a)
+{
+  return complex<T>(-a.real(), -a.imag());
+}
+
+// [complex.ops]: the comparisons yield bool. The previous declarations returned
+// complex<T>, which no conforming program could use.
+template <class T>
+bool operator==(const complex<T> &a, const complex<T> &b)
+{
+  return a.real() == b.real() && a.imag() == b.imag();
+}
+template <class T>
+bool operator==(const complex<T> &a, const T &v)
+{
+  return a.real() == v && a.imag() == T();
+}
+template <class T>
+bool operator==(const T &v, const complex<T> &a)
+{
+  return v == a.real() && a.imag() == T();
+}
 
 template <class T>
-complex<T> operator==(const complex<T> &lhs, const complex<T> &rhs);
+bool operator!=(const complex<T> &a, const complex<T> &b)
+{
+  return !(a == b);
+}
 template <class T>
-complex<T> operator==(const complex<T> &lhs, const T &val);
+bool operator!=(const complex<T> &a, const T &v)
+{
+  return !(a == v);
+}
 template <class T>
-complex<T> operator==(const T &val, const complex<T> &rhs);
+bool operator!=(const T &v, const complex<T> &a)
+{
+  return !(v == a);
+}
 
 template <class T>
-complex<T> operator!=(const complex<T> &lhs, const complex<T> &rhs);
+T real(const complex<T> &a)
+{
+  return a.real();
+}
 template <class T>
-complex<T> operator!=(const complex<T> &lhs, const T &val);
+T imag(const complex<T> &a)
+{
+  return a.imag();
+}
 template <class T>
-complex<T> operator!=(const T &val, const complex<T> &rhs);
-
+T norm(const complex<T> &a)
+{
+  return a.real() * a.real() + a.imag() * a.imag();
+}
 template <class T>
-istream &operator>>(istream &istr, complex<T> &rhs);
-template <class T>
-ostream &operator<<(ostream &ostr, const complex<T> &rhs);
-
-template <class T>
-T real(const complex<T> &x);
-template <class T>
-T imag(const complex<T> &x);
-template <class T>
-T abs(const complex<T> &x);
-template <class T>
-T arg(const complex<T> &x);
-template <class T>
-T norm(const complex<T> &x);
-template <class T>
-complex<T> conj(const complex<T> &x);
-template <class T>
-complex<T> polar(const T &rho, const T &theta = 0);
-template <class T>
-complex<T> cos(const complex<T> &x);
-template <class T>
-complex<T> cosh(const complex<T> &x);
-template <class T>
-complex<T> exp(const complex<T> &x);
-template <class T>
-complex<T> log(const complex<T> &x);
-template <class T>
-complex<T> log10(const complex<T> &x);
-template <class T>
-complex<T> pow(const complex<T> &x, int y);
-template <class T>
-complex<T> pow(const complex<T> &x, const complex<T> &y);
-template <class T>
-complex<T> pow(const complex<T> &x, const T &y);
-template <class T>
-complex<T> pow(const T &x, const complex<T> &y);
-template <class T>
-complex<T> sin(const complex<T> &x);
-template <class T>
-complex<T> sinh(const complex<T> &x);
-template <class T>
-complex<T> sqrt(const complex<T> &x);
-template <class T>
-complex<T> tan(const complex<T> &x);
-template <class T>
-complex<T> tanh(const complex<T> &x);
+complex<T> conj(const complex<T> &a)
+{
+  return complex<T>(a.real(), -a.imag());
+}
 
 } // namespace std
 


### PR DESCRIPTION
Found by continuing the audit of models that had not been audited before. No
issue filed; happy to file one — the `abs` crash in particular deserves it.
Based on master, independent of the other open PRs.

## The defect

```cpp
std::complex<double> a(3.0, 4.0);
// error: calling a private constructor of class 'std::complex<double>'
// error: 'real' is a private member of 'std::complex<double>'
```

`<complex>` was a skeleton that could not be used at all:

1. The class is declared `class complex { ... }` with **no `public:`**, so every
   member — constructors, `real`, `imag`, every compound assignment — is
   private.
2. **No member or free operator had a definition.** Only declarations.
3. `operator==` and `operator!=` were declared to return **`complex<T>`**
   instead of `bool`, contradicting [complex.ops].

Point 1 at least fails loudly. Point 2 is the one to be careful about: a
declaration-only member converts to a nondet call, so "fixing" the access
without adding bodies would have turned a compile error into silently wrong
values.

## Fix

Implement the arithmetic core with real definitions: storage and constructors,
`real`/`imag` (both accessor and setter forms), all compound assignments with
scalar and complex operands, binary `+ - * /` in all three operand
combinations, unary `+ -`, `==`/`!=` returning `bool`, and the free `real`,
`imag`, `norm`, `conj`.

Division uses the conjugate form `(a·c̄)/|b|²` rather than a naive quotient, and
`operator/=` computes both components before storing either, so the first
assignment cannot corrupt the second.

## Why `abs(complex)` is not here

Overloading the name `abs` for a class type makes ESBMC **abort**:

```
Assertion failed: (type->type_id == trueval->type->type_id),
function if2t, file irep2_expr.h, line 809
```

I isolated this carefully: `sqrt` alone is fine, `sqrt` inside a template is
fine, `sqrt(std::norm(a))` written inline in `main` is fine, and the **identical
body under any other name** verifies. Only the name `abs` triggers it. So this
is an ESBMC frontend bug, not a defect in the header, and shipping
`std::abs(complex)` would ship a crash. `sqrt(norm(z))` is the workaround, and
the header says so.

The reduced case is pinned as `std_abs_class_overload` (KNOWNBUG, ~20 lines, no
`<complex>` involved), so the crash is tracked and the test flips to `CORE`
when it is fixed. It exits 0 under
`clang++ -std=c++17 -fsanitize=address,undefined`.

Also not modelled, deliberately: the transcendental functions, `polar`/`arg`,
and the stream inserters — omitted rather than declared without definitions, for
the reason in point 2 above.

## Tests

- `complex_arithmetic` — construction, accessors and setters, all four binary
  operations against hand-computed results, unary minus, `norm`, `conj`, free
  `real`/`imag`, both comparisons, all four compound assignments, and copy
  independence. Every value is exactly representable, so the floating-point
  equalities are safe to assert.
- `complex_arithmetic_fail` — a wrong multiplication result must FAIL.
- `std_abs_class_overload` — the crash pin described above.

## Suites

`regression/esbmc-cpp/cpp/`: 636 tests, 7 failures, all in the known
pre-existing macOS/libc++ set (`github_2242_*`, `github_3897_collision`,
`github_6200_fail`, `github_6227_fail`, `github_6229_fail`, `utility2_fail`) —
none new. `<complex>` still parses under `--std c++03`, and no OM header
includes it, so only programs including it directly are affected.
clang-format clean.
