### PR TITLE
[om] Make iterator_traits accessible and add the missing iterator tags

### DIFF
--- a/regression/esbmc-cpp/cpp/iterator_traits_tags/main.cpp
+++ b/regression/esbmc-cpp/cpp/iterator_traits_tags/main.cpp
@@ -1,0 +1,63 @@
+// Two defects in <iterator>:
+//
+// 1. [iterator.traits] specifies iterator_traits as a struct, but it was
+//    declared `class` with no access specifier, so all five member typedefs
+//    were private. iterator_traits<It>::value_type on any class-type iterator
+//    failed with "'value_type' is a private member"; only the T*
+//    specialisation, already a struct, worked.
+// 2. [iterator.tags] defines five categories. forward_iterator_tag and
+//    bidirectional_iterator_tag did not exist, and random_access_iterator_tag
+//    derived from nothing, so tag dispatch could not select an overload.
+#include <iterator>
+#include <cstddef>
+#include <cassert>
+#include <type_traits>
+
+struct MyIt
+{
+  typedef std::ptrdiff_t difference_type;
+  typedef int value_type;
+  typedef int *pointer;
+  typedef int &reference;
+  typedef std::forward_iterator_tag iterator_category;
+};
+
+// tag dispatch must pick the more specialised overload
+int which(std::input_iterator_tag)
+{
+  return 1;
+}
+int which(std::forward_iterator_tag)
+{
+  return 2;
+}
+int which(std::bidirectional_iterator_tag)
+{
+  return 3;
+}
+int which(std::random_access_iterator_tag)
+{
+  return 4;
+}
+
+int main()
+{
+  std::iterator_traits<MyIt>::value_type v = 7;
+  assert(v == 7);
+  assert((std::is_same<std::iterator_traits<MyIt>::pointer, int *>::value));
+  assert((std::is_same<std::iterator_traits<int *>::value_type, int>::value));
+
+  assert(which(std::iterator_traits<MyIt>::iterator_category()) == 2);
+  assert(which(std::iterator_traits<int *>::iterator_category()) == 4);
+
+  // [iterator.tags] inheritance
+  assert((std::is_base_of<std::input_iterator_tag, std::forward_iterator_tag>::
+            value));
+  assert((std::is_base_of<
+          std::forward_iterator_tag,
+          std::bidirectional_iterator_tag>::value));
+  assert((std::is_base_of<
+          std::bidirectional_iterator_tag,
+          std::random_access_iterator_tag>::value));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/iterator_traits_tags/test.desc
+++ b/regression/esbmc-cpp/cpp/iterator_traits_tags/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/iterator_traits_tags_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/iterator_traits_tags_fail/main.cpp
@@ -1,0 +1,19 @@
+// Non-vacuity guard for iterator_traits_tags: tag dispatch really resolves to
+// the most derived overload, so expecting the wrong one must FAIL.
+#include <iterator>
+#include <cassert>
+
+int which(std::input_iterator_tag)
+{
+  return 1;
+}
+int which(std::random_access_iterator_tag)
+{
+  return 4;
+}
+
+int main()
+{
+  assert(which(std::iterator_traits<int *>::iterator_category()) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/iterator_traits_tags_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/iterator_traits_tags_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -26,23 +26,41 @@ public:
   typedef Category iterator_category;
 };
 
+/* [iterator.tags]: the five categories, with the inheritance the standard
+ * specifies. forward_ and bidirectional_ were missing, and random_access_ did
+ * not derive from anything, so tag dispatch could not select an overload. */
 ///  Marking input iterators.
-class input_iterator_tag
+struct input_iterator_tag
 {
 };
 
 ///  Marking output iterators.
-class output_iterator_tag
+struct output_iterator_tag
+{
+};
+
+///  Marking forward iterators.
+struct forward_iterator_tag : public input_iterator_tag
+{
+};
+
+///  Marking bidirectional iterators.
+struct bidirectional_iterator_tag : public forward_iterator_tag
 {
 };
 
 // Marking random iterators
-class random_access_iterator_tag
+struct random_access_iterator_tag : public bidirectional_iterator_tag
 {
 };
 
+/* [iterator.traits] specifies iterator_traits as a struct. Declared as a
+ * class with no access specifier, all five member typedefs were private, so
+ * iterator_traits<It>::value_type on any class-type iterator failed with
+ * "'value_type' is a private member". Only the T* specialisation below --
+ * already a struct -- worked. */
 template <class Iterator>
-class iterator_traits
+struct iterator_traits
 {
   typedef typename Iterator::difference_type difference_type;
   typedef typename Iterator::value_type value_type;


### PR DESCRIPTION
Found by a mechanical scan for the defect shape that made `<complex>` unusable
(#6419): a `class` definition whose body never says `public:`. No issue filed;
happy to file one. Based on master, independent of the other open PRs.

## The defects

**1. `iterator_traits` was entirely private.**

```cpp
std::iterator_traits<MyIt>::value_type v;
// error: 'value_type' is a private member of 'std::iterator_traits<MyIt>'
```

[iterator.traits] specifies `iterator_traits` as a **struct**. It was declared
`class` with no access specifier, so all five member typedefs
(`difference_type`, `value_type`, `pointer`, `reference`,
`iterator_category`) were private. Only the `T *` specialisation — already a
`struct` — worked, which is why the defect survived: pointer iterators are the
common case in this codebase, so nothing exercised the primary template.

**2. Two of the five iterator category tags did not exist.**

[iterator.tags] defines five. `<iterator>` had `input_iterator_tag`,
`output_iterator_tag` and `random_access_iterator_tag`, but no
`forward_iterator_tag` or `bidirectional_iterator_tag` — naming either was a
parse error. Worse, `random_access_iterator_tag` derived from nothing, so tag
dispatch could not work at all: with overloads on `input_iterator_tag` and
`random_access_iterator_tag`, a random-access iterator matched neither by
derivation.

## Fix

`iterator_traits` becomes a `struct`, and the tags gain the two missing types
plus the inheritance the standard specifies —
`forward : input`, `bidirectional : forward`, `random_access : bidirectional`.

## How this was found

`<complex>` (#6419) turned out to be all-private, so I scanned every header in
`src/cpp/library/` for the same shape rather than waiting to trip over the next
one. Getting the scanner right mattered: my first version matched `class` inside
`template <class T>` parameter lists and produced 150 false positives, and my
second required `{` on the same line as the class head — which silently missed
`<complex>` itself. I only trusted the third version once it reported `complex`,
the instance I already knew about. It reports exactly two headers, and this PR
fixes the other one.

## Behaviour change worth noting

Making `random_access_iterator_tag` derive from `bidirectional_iterator_tag` is
a real change to overload resolution: a random-access iterator now matches a
`bidirectional_iterator_tag` overload where previously it matched nothing. That
is what the standard requires and what makes tag dispatch work, but it is not
purely additive, which is why the suites below were run wide.

## Tests

- `iterator_traits_tags` — the traits typedefs on a class-type iterator and on
  `int *`, checked with `is_same`; tag dispatch selecting the most derived
  overload for both a forward and a random-access iterator; and the three
  `is_base_of` relations from [iterator.tags].
- `iterator_traits_tags_fail` — expects tag dispatch to pick the *less* derived
  overload; must FAIL, so the dispatch checks are not vacuous.

## Suites

Eight OM headers include `<iterator>` (`array`, `algorithm`, `bitset`, `deque`,
`locale`, `memory`, `numeric`, `set`), so this was run wide:
`algorithm`/`vector`/`list`/`deque`/`set`/`map` plus `esbmc-cpp17` — 588 tests,
all pass; `string`/`bitset`/`stack`/`queue`/`priority_queue`/`OM_sanity_checks`
plus `esbmc-cpp11`/`esbmc-cpp14` — 497 tests, 2 failures, both
`esbmc-cpp14/template/builtin-template*`, which are in the known pre-existing
macOS set.

`<iterator>` still parses under `--std c++03`. The one clang-format complaint in
the file is pre-existing (a `template <...>` line ~200 lines from these edits),
confirmed by stashing the change.
