### PR TITLE
[om] Define string_view's declared-but-missing search members

### DIFF
--- a/regression/esbmc-cpp17/cpp/string_view_search/main.cpp
+++ b/regression/esbmc-cpp17/cpp/string_view_search/main.cpp
@@ -1,0 +1,40 @@
+// string_view::at, starts_with, ends_with, find, find_first_of and
+// find_first_not_of were DECLARED but never DEFINED. A declaration-only member
+// converts to a call returning a nondeterministic value, so on "hello" both
+// `assert(v.starts_with("he"))` and `assert(!v.starts_with("he"))` FAILED --
+// a silent wrong answer rather than a diagnostic.
+//
+// Verified against clang++ -std=c++20 -fsanitize=address,undefined: exits 0.
+#include <string_view>
+#include <cassert>
+int main()
+{
+  std::string_view v("hello world");
+  std::string_view he("he"), ld("ld"), xx("xx"), wo("wo"), empty("");
+
+  assert(v.starts_with(he));
+  assert(!v.starts_with(ld));
+  assert(v.ends_with(ld));
+  assert(!v.ends_with(he));
+  assert(v.starts_with(empty));
+  assert(v.ends_with(empty));
+
+  assert(v.find(wo) == 6);
+  assert(v.find(he) == 0);
+  assert(v.find(xx) == std::string_view::npos);
+  assert(v.find(wo, 7) == std::string_view::npos);
+
+  std::string_view vowels("aeiou");
+  assert(v.find_first_of(vowels) == 1);                      // 'e' in "hello"
+  assert(v.find_first_not_of(std::string_view("hel")) == 4); // 'o'
+
+  // a needle longer than the haystack
+  std::string_view longer("hello world!!");
+  assert(!v.starts_with(longer));
+  assert(!v.ends_with(longer));
+  assert(v.find(longer) == std::string_view::npos);
+
+  assert(v.at(0) == 'h');
+  assert(v.at(10) == 'd');
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/string_view_search/test.desc
+++ b/regression/esbmc-cpp17/cpp/string_view_search/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 16
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/string_view_search_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/string_view_search_fail/main.cpp
@@ -1,0 +1,13 @@
+// Non-vacuity guard for string_view_search: starts_with really computes, so
+// asserting the negation of a true result must FAIL. Before the fix this test
+// also failed -- but so did its positive counterpart, which is the tell-tale
+// of a nondet return.
+#include <string_view>
+#include <cassert>
+
+int main()
+{
+  std::string_view v("hello");
+  assert(!v.starts_with(std::string_view("he")));
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/string_view_search_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/string_view_search_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/string_view
+++ b/src/cpp/library/string_view
@@ -45,7 +45,15 @@ public:
 
   // Element access
   const char &operator[](size_t pos) const { return str[pos]; }
-  const char &at(size_t pos) const;
+  const char &at(size_t pos) const
+  {
+    /* [string.view.access]: at() throws out_of_range for pos >= size(). The
+     * exception is not modelled here (see #6338 for why <string> cannot throw
+     * either), so the precondition is asserted instead -- which at least
+     * reports the violation rather than reading out of bounds. */
+    __ESBMC_assert(pos < len, "string_view::at: pos out of range");
+    return str[pos];
+  }
   const char &front() const { return *str; }
   const char &back() const { return str[len-1]; }
   const char *data() const noexcept { return str; }
@@ -82,11 +90,59 @@ public:
       return +1;
     return 0;
   }
-  bool starts_with(string_view sv) const;
-  bool ends_with(string_view sv) const;
-  size_t find(string_view sv, size_t pos = 0) const;
-  size_t find_first_of(string_view sv, size_t pos = 0) const;
-  size_t find_first_not_of(string_view sv, size_t pos = 0) const;
+  /* These five were declared and never defined. A declaration-only member is
+   * converted as a call returning a nondeterministic value, so
+   * `sv.starts_with(x)` satisfied neither the property nor its negation --
+   * a silent wrong answer rather than a diagnostic. */
+  bool starts_with(string_view sv) const
+  {
+    if (sv.len > len)
+      return false;
+    return memcmp(str, sv.str, sv.len) == 0;
+  }
+
+  bool ends_with(string_view sv) const
+  {
+    if (sv.len > len)
+      return false;
+    return memcmp(str + (len - sv.len), sv.str, sv.len) == 0;
+  }
+
+  size_t find(string_view sv, size_t pos = 0) const
+  {
+    if (sv.len > len)
+      return npos;
+    for (size_t i = pos; i + sv.len <= len; ++i)
+      if (memcmp(str + i, sv.str, sv.len) == 0)
+        return i;
+    return npos;
+  }
+
+  size_t find_first_of(string_view sv, size_t pos = 0) const
+  {
+    for (size_t i = pos; i < len; ++i)
+      for (size_t j = 0; j < sv.len; ++j)
+        if (str[i] == sv.str[j])
+          return i;
+    return npos;
+  }
+
+  size_t find_first_not_of(string_view sv, size_t pos = 0) const
+  {
+    for (size_t i = pos; i < len; ++i)
+    {
+      bool found = false;
+      for (size_t j = 0; j < sv.len; ++j)
+        if (str[i] == sv.str[j])
+        {
+          found = true;
+          break;
+        }
+      if (!found)
+        return i;
+    }
+    return npos;
+  }
 
   // Non-member functions
   friend bool operator==(string_view lhs, string_view rhs) { return lhs.compare(rhs) == 0; }


### PR DESCRIPTION
Found by scanning for the *other* half of what made `<complex>` unusable
(#6419): members declared with no definition. No issue filed; happy to file one.
Based on master, independent of the other open PRs.

## The defect — a silent wrong answer

```cpp
std::string_view v("hello");
assert(v.starts_with(std::string_view("he")));   // VERIFICATION FAILED
assert(!v.starts_with(std::string_view("he")));  // VERIFICATION FAILED
```

**Both** the property and its negation fail. That is the signature of a
nondeterministic return: `starts_with`, `ends_with`, `find`, `find_first_of`,
`find_first_not_of` and `at` were **declared and never defined** in
`src/cpp/library/string_view`, and a declaration-only member converts to a call
yielding an unconstrained value.

This is worse than a missing feature. A program using these gets a spurious
counterexample, and — depending on how the result is used — a nondet value can
just as easily satisfy an assertion and mask a real defect. Everything else in
the header (`size`, `operator[]`, `compare`, `substr`, the comparison
operators) is properly defined, so nothing about using `string_view` looked
suspicious.

## Fix

Definitions for all six. `find` scans for the needle, the two `find_first_*`
walk the character set, and `starts_with`/`ends_with` guard the
needle-longer-than-haystack case before comparing. `at()` asserts its
precondition rather than throwing: `<string>` cannot throw `out_of_range`
either, for the include-cycle reason recorded in #6338, so an assert at least
reports the violation instead of reading out of bounds.

## How this was found

`<complex>` turned out to be unusable in two independent ways — everything
private (fixed in #6419, and a scan for that shape found `iterator_traits` in
#6420) and everything declaration-only. This PR comes from scanning for the
second shape. That detector is much noisier than the first, so I did not treat
its output as a defect list: I used it to shortlist candidates and then
confirmed each by running a program, which is how the `assert(X)` **and**
`assert(!X)` both-fail signature turned up.

Other headers the scan flagged (`valarray`, `locale`, `ios`, `streambuf`) do
have genuinely undefined members, but they are large surfaces that deserve their
own change rather than being folded in here.

## Tests

- `string_view_search` — `starts_with`/`ends_with` including the empty needle
  and a needle longer than the haystack, `find` hitting at 0, mid-string, and
  missing, `find` with a start offset past the match, `find_first_of` and
  `find_first_not_of`, and `at` at both ends. Exits 0 under
  `clang++ -std=c++20 -fsanitize=address,undefined`.
- `string_view_search_fail` — asserts the negation of a true `starts_with`;
  must FAIL. Note this test also failed *before* the fix — but so did its
  positive counterpart, which is precisely the tell-tale being fixed.

## Suites

`regression/esbmc-cpp17` and `esbmc-cpp/string/`: 276 tests, all pass. No OM
header includes `<string_view>` on master, so only programs including it
directly are affected. The one clang-format complaint in the file is
pre-existing (line 30, the default constructor), confirmed by stashing the
change.
