### PR TITLE
[om] Define valarray's declared-but-missing members

### DIFF
--- a/regression/esbmc-cpp/cpp/valarray_members/main.cpp
+++ b/regression/esbmc-cpp/cpp/valarray_members/main.cpp
@@ -1,0 +1,50 @@
+// valarray::max, min, shift, cshift and both apply overloads were DECLARED but
+// never DEFINED, so each call returned a nondeterministic value: on {5,2,9,2},
+// `a.max()` satisfied neither `== 9` nor `!= 9`. Silent wrong answers rather
+// than a diagnostic.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <valarray>
+#include <cassert>
+
+int twice(int x)
+{
+  return 2 * x;
+}
+
+int main()
+{
+  std::valarray<int> a(4);
+  a[0] = 5;
+  a[1] = 2;
+  a[2] = 9;
+  a[3] = 2;
+
+  assert(a.max() == 9);
+  assert(a.min() == 2);
+  assert(a.sum() == 18);
+  assert(a.size() == 4);
+
+  // shift: positive moves toward the front, vacated slots are value-initialised
+  std::valarray<int> s = a.shift(1);
+  assert(s[0] == 2 && s[1] == 9 && s[2] == 2 && s[3] == 0);
+
+  std::valarray<int> s2 = a.shift(-1);
+  assert(s2[0] == 0 && s2[1] == 5 && s2[2] == 2 && s2[3] == 9);
+
+  // cshift: rotates, nothing is lost
+  std::valarray<int> c = a.cshift(1);
+  assert(c[0] == 2 && c[1] == 9 && c[2] == 2 && c[3] == 5);
+
+  std::valarray<int> c2 = a.cshift(-1);
+  assert(c2[0] == 2 && c2[1] == 5 && c2[2] == 2 && c2[3] == 9);
+
+  // a full rotation is the identity
+  std::valarray<int> c3 = a.cshift(4);
+  assert(c3[0] == 5 && c3[1] == 2 && c3[2] == 9 && c3[3] == 2);
+
+  std::valarray<int> ap = a.apply(twice);
+  assert(ap[0] == 10 && ap[2] == 18);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/valarray_members/test.desc
+++ b/regression/esbmc-cpp/cpp/valarray_members/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/valarray_members_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/valarray_members_fail/main.cpp
@@ -1,0 +1,15 @@
+// Non-vacuity guard for valarray_members: max() really computes, so asserting
+// the wrong maximum must FAIL. Before the fix this failed too -- but so did the
+// positive form, which is the tell-tale of a nondet return.
+#include <valarray>
+#include <cassert>
+
+int main()
+{
+  std::valarray<int> a(3);
+  a[0] = 5;
+  a[1] = 2;
+  a[2] = 9;
+  assert(a.max() == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/valarray_members_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/valarray_members_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 6
+^VERIFICATION FAILED$

--- a/src/cpp/library/valarray
+++ b/src/cpp/library/valarray
@@ -2,7 +2,10 @@
 #define STL_VALARRAY
 
 #include "definitions.h"
-#include <initializer_list>
+#include "OM_compiler_defs.h" // OM_NULLPTR
+#if __cplusplus >= 201103L
+#  include <initializer_list>
+#endif
 
 namespace std
 {
@@ -49,7 +52,7 @@ private:
   size_t _ndim;
 
 public:
-  gslice() : _start(0), _lengths(nullptr), _strides(nullptr), _ndim(0)
+  gslice() : _start(0), _lengths(OM_NULLPTR), _strides(OM_NULLPTR), _ndim(0)
   {
   }
   gslice(
@@ -221,7 +224,7 @@ private:
 
 public:
   // Constructors
-  valarray() : _data(nullptr), _size(0)
+  valarray() : _data(OM_NULLPTR), _size(0)
   {
   }
 
@@ -261,6 +264,7 @@ public:
     }
   }
 
+#if __cplusplus >= 201103L
   // C++11 initializer list constructor
   valarray(std::initializer_list<T> il) : _size(il.size())
   {
@@ -271,6 +275,7 @@ public:
       _data[i] = *it;
     }
   }
+#endif
 
   valarray(const slice_array<T> &sub) : _size(sub._size)
   {
@@ -444,11 +449,62 @@ public:
   valarray<T> &operator>>=(const T &val);
 
   // Member functions
-  valarray<T> apply(T func(T)) const;
-  valarray<T> apply(T func(const T &)) const;
-  valarray<T> cshift(int n) const;
-  T max() const;
-  T min() const;
+  valarray<T> apply(T func(T)) const
+  {
+    valarray<T> r(_size);
+    for (size_t i = 0; i < _size; ++i)
+      r[i] = func(_data[i]);
+    return r;
+  }
+
+  valarray<T> apply(T func(const T &)) const
+  {
+    valarray<T> r(_size);
+    for (size_t i = 0; i < _size; ++i)
+      r[i] = func(_data[i]);
+    return r;
+  }
+
+  /* [valarray.members]: cshift rotates, shift fills the vacated positions with
+   * a value-initialised T; a positive n moves elements toward the front. These
+   * five were declared and never defined, so every call returned a
+   * nondeterministic value -- `a.max()` satisfied neither `== 9` nor `!= 9`. */
+  valarray<T> cshift(int n) const
+  {
+    valarray<T> r(_size);
+    if (_size == 0)
+      return r;
+    for (size_t i = 0; i < _size; ++i)
+    {
+      long long k = (long long)i + (long long)n;
+      long long m = (long long)_size;
+      k %= m;
+      if (k < 0)
+        k += m;
+      r[i] = _data[(size_t)k];
+    }
+    return r;
+  }
+
+  T max() const
+  {
+    __ESBMC_assert(_size > 0, "valarray::max on an empty valarray");
+    T m = _data[0];
+    for (size_t i = 1; i < _size; ++i)
+      if (m < _data[i])
+        m = _data[i];
+    return m;
+  }
+
+  T min() const
+  {
+    __ESBMC_assert(_size > 0, "valarray::min on an empty valarray");
+    T m = _data[0];
+    for (size_t i = 1; i < _size; ++i)
+      if (_data[i] < m)
+        m = _data[i];
+    return m;
+  }
 
   // Assignment operators
   valarray<T> &operator=(const valarray<T> &x)
@@ -585,7 +641,16 @@ public:
   indirect_array<T> operator[](const valarray<size_t> &ind);
 
   void resize(size_t sz, T c = T());
-  valarray<T> shift(int n) const;
+  valarray<T> shift(int n) const
+  {
+    valarray<T> r(_size);
+    for (size_t i = 0; i < _size; ++i)
+    {
+      long long k = (long long)i + (long long)n;
+      r[i] = (k >= 0 && k < (long long)_size) ? _data[(size_t)k] : T();
+    }
+    return r;
+  }
 
   size_t size() const
   {


### PR DESCRIPTION
Second instance of the declaration-only defect fixed for `<string_view>` in
#6421, found by the same scan. No issue filed; happy to file one. Based on
master, independent of the other open PRs.

## The defect — a silent wrong answer

```cpp
std::valarray<int> a(3);
a[0] = 5; a[1] = 2; a[2] = 9;
assert(a.max() == 9);   // VERIFICATION FAILED
assert(a.max() != 9);   // ALSO VERIFICATION FAILED
```

`max`, `min`, `shift`, `cshift` and both `apply` overloads were **declared and
never defined**, so each call converted to one returning an unconstrained value.
Both a property and its negation fail — the signature of a nondet return.

The rest of the header (`sum`, `size`, `operator[]`, the arithmetic operators)
is properly defined and behaves correctly, which is why nothing looked wrong
from the outside.

## Fix

Definitions for all six, following [valarray.members]:

- `shift(n)` fills the vacated positions with a value-initialised `T`;
  `cshift(n)` rotates so nothing is lost. Positive `n` moves elements toward the
  front in both cases, and the index arithmetic is done in `long long` so a
  negative shift cannot wrap through `size_t`.
- `max`/`min` assert non-emptiness — [valarray.members] leaves it undefined, and
  an assert reports the violation rather than reading `_data[0]` of an empty
  array.

## Also: the header could not be used under C++03 at all

While testing I found `<valarray>` includes `<initializer_list>`
**unconditionally** and uses `nullptr`, so `--std c++03` produced 11 parse
errors — 7 of them from `<initializer_list>`, which has no `__cplusplus` guards
at all and is a C++11 header.

Guarding the include and its constructor, and switching two `nullptr` uses to
`OM_NULLPTR`, takes `<valarray>` from 11 C++03 errors to **0**. I checked the
`<initializer_list>` errors are pre-existing and independent by compiling that
header alone.

## Tests

- `valarray_members` — `max`/`min`/`sum` on a set with a duplicate minimum;
  `shift` in both directions including the value-initialised fill; `cshift` in
  both directions plus a full rotation as the identity; and `apply`. Exits 0
  under `clang++ -std=c++17 -fsanitize=address,undefined`.
- `valarray_members_fail` — a wrong maximum must FAIL. As with #6421, this test
  also failed before the fix — but so did its positive counterpart, which is
  exactly the tell-tale being fixed.

## Suites

All 12 `valarray`-matching tests pass, including the pre-existing
`valarray2`/`3`/`4` and `OM_sanity_checks/valarray`. No OM header includes
`<valarray>`, so only programs including it directly are affected.
clang-format clean.

Remaining from the same scan, not in this PR: `locale`, `ios` and `streambuf`
also have undefined members. Each is a large surface and deserves its own
change.
