### PR TITLE
[om] Remove ostream's width/fill/precision, which hid the inherited members

### DIFF
--- a/regression/esbmc-cpp/cpp/ostream_format_state/main.cpp
+++ b/regression/esbmc-cpp/cpp/ostream_format_state/main.cpp
@@ -1,0 +1,40 @@
+// <ostream> declared its own width/fill/precision members. [ostream] has no
+// such members -- they belong to ios_base/ios -- and declaring them here hid
+// the inherited overload sets:
+//
+//   * cout.precision() did not resolve at all ("too few arguments"), because
+//     the void-returning one-argument ostream::precision hid both base
+//     overloads;
+//   * cout.precision(3) and cout.fill(c) bound to stubs whose bodies were
+//     commented out, so the setting was silently discarded;
+//   * ostream::width was declared and never defined, so it returned a
+//     nondeterministic value.
+//
+// Removing all four restores the inherited members, which are implemented.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream os;
+
+  // precision: the setter returns the previous value, the getter observes it
+  os.precision(3);
+  assert(os.precision() == 3);
+  std::streamsize prev = os.precision(5);
+  assert(prev == 3);
+  assert(os.precision() == 5);
+
+  // width
+  os.width(7);
+  assert(os.width() == 7);
+
+  // fill
+  os.fill('0');
+  assert(os.fill() == '0');
+  char oldfill = os.fill('x');
+  assert(oldfill == '0');
+  assert(os.fill() == 'x');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ostream_format_state/test.desc
+++ b/regression/esbmc-cpp/cpp/ostream_format_state/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ostream_format_state_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/ostream_format_state_fail/main.cpp
@@ -1,0 +1,13 @@
+// Non-vacuity guard for ostream_format_state: the setting is really stored, so
+// asserting the wrong value must FAIL. Before the fix the setter was a no-op
+// and width() was nondet, so this could not discriminate.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream os;
+  os.precision(3);
+  assert(os.precision() == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ostream_format_state_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/ostream_format_state_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -25,10 +25,14 @@ public:
   {
   }
 
-  streamsize width() const;
-  streamsize width(streamsize wide);
-  void fill(char c);
-  void precision(int p);
+  /* width/fill/precision are members of ios_base/ios, not of ostream
+   * ([ostream.formatted] lists no such members). Declaring them here hid the
+   * inherited overload sets: `cout.precision()` did not resolve at all, and
+   * `cout.precision(3)` / `cout.fill(c)` bound to void-returning stubs whose
+   * bodies were commented out, so the setting was silently discarded.
+   * ostream::width was declared and never defined, so it returned a
+   * nondeterministic value. Removing all four lets the inherited members
+   * through. */
   void put(char c);
   //	void write(char str[], size_t n);
   ostream &write(const char *s, streamsize n);
@@ -138,16 +142,6 @@ using basic_ostream = ostream;
 
 namespace std
 {
-void ostream::fill(char c)
-{
-  //		setfill(c);
-}
-
-void ostream::precision(int p)
-{
-  //		setprecision(p);
-}
-
 void ostream::put(char c)
 {
 }


### PR DESCRIPTION
Found while probing the remaining declaration-only members in the stream models
(after #6425). No issue filed; happy to file one. Based on master, independent
of the other open PRs.

## The defect

```cpp
std::cout.precision(3);
std::streamsize p = std::cout.precision();
// error: too few arguments to function call, expected 1, have 0
// error: cannot initialize 'std::streamsize' with an rvalue of type 'void'
```

`<ostream>` declared **its own** `width`, `fill` and `precision` members.
[ostream] has no such members — they belong to `ios_base`/`ios` — and declaring
them in the derived class hid the inherited overload sets entirely. Three
distinct consequences:

1. **`cout.precision()` did not resolve at all.** The one-argument
   `void ostream::precision(int)` hid both `ios_base::precision` overloads, so
   the getter was simply unavailable.
2. **`cout.precision(3)` and `cout.fill(c)` silently discarded the setting.**
   Their definitions were stubs with the real work commented out:
   `void ostream::fill(char c) { //  setfill(c); }`.
3. **`ostream::width` was declared and never defined**, so it returned a
   nondeterministic value — `os.width(5); os.width() == 5` satisfied neither
   itself nor its negation.

The inherited `ios_base::precision`/`width` and `ios::fill` are all properly
implemented, storing to `__precision`/`__width`/`__fill`. They were simply
unreachable.

## Fix

Remove all four declarations and the two stub definitions. Nothing replaces
them: the inherited members are correct and become visible again.

This is a source-compatible change for callers. `cout.precision(3)` previously
returned `void` and now returns the previous `streamsize`; `cout.fill('0')`
previously returned `void` and now returns the previous `char`. Discarding a
return value is fine, so existing code keeps compiling — and code that could not
compile before (the getters) now can.

## Tests

- `ostream_format_state` — `precision`, `width` and `fill` each set, read back,
  and re-set to confirm the setter returns the *previous* value. Exits 0 under
  `clang++ -std=c++17 -fsanitize=address,undefined`.
- `ostream_format_state_fail` — asserts a wrong precision; must FAIL. Before the
  fix this could not discriminate at all, since the setter was a no-op and
  `width()` was nondet.

The tests use `std::ostringstream` rather than `std::cout` deliberately, so they
verify independently of #6425 (which defines the standard stream objects).

## Suites

`<ostream>` is included by `<iostream>`, `<sstream>`, `<fstream>` and
`<iterator>`, so this was run wide: `esbmc-cpp/cpp` + `string` +
`OM_sanity_checks` + `vector` + `algorithm` — 1236 tests, 7 failures, all in the
known pre-existing macOS/libc++ set; `esbmc-cpp11`/`14`/`17` plus the
`fstream`/`sstream`/`iostream` tests — 184 tests, 2 failures, both the known
`builtin-template*` pair. No new failures. `<ostream>` still parses under
`--std c++03`, and the clang-format complaint in the file is pre-existing
(confirmed against the parent commit).
