### PR TITLE
[om] Define ios::exceptions and ios::copyfmt

### DIFF
--- a/regression/esbmc-cpp/cpp/ios_copyfmt/main.cpp
+++ b/regression/esbmc-cpp/cpp/ios_copyfmt/main.cpp
@@ -1,0 +1,16 @@
+// ios::copyfmt was declared and never defined, so it returned a reference to
+// nothing and copied no state. [basic.ios.members]: it copies the formatting
+// state (flags, precision, width, fill, exception mask), not the buffer.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream a, b;
+  a.precision(7);
+  a.fill('*');
+  b.copyfmt(a);
+  assert(b.precision() == 7);
+  assert(b.fill() == '*');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ios_copyfmt/test.desc
+++ b/regression/esbmc-cpp/cpp/ios_copyfmt/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ios_default_state_knownbug/main.cpp
+++ b/regression/esbmc-cpp/cpp/ios_default_state_knownbug/main.cpp
@@ -1,12 +1,11 @@
 // KNOWNBUG: a freshly constructed stream's ios members are indeterminate.
 //
-// [ios.base.cons]/[basic.ios.cons]: a newly constructed stream has an empty
-// exception mask and a fill character of widen(' '). In this model neither
-// holds -- the values are *stable* but unconstrained, i.e. read from storage
-// whose initialiser never ran:
+// [basic.ios.cons]: a newly constructed stream has a fill character of
+// widen(' '). In this model it does not -- the value is *stable* but
+// unconstrained, i.e. read from storage whose initialiser never ran:
 //
-//   assert(os.exceptions() == os.exceptions());   // SUCCEEDS  (stable)
-//   assert(os.exceptions() == goodbit);           // FAILS     (uninitialised)
+//   assert(os.fill() == os.fill());   // SUCCEEDS  (stable)
+//   assert(os.fill() == ' ');         // FAILS     (uninitialised)
 //
 // So this is not a nondet-per-call return like the declaration-only defects;
 // ios::ios()'s member initialisation simply does not run for a stream built
@@ -16,9 +15,9 @@
 // construction works, so does a constructor body that calls its base
 // constructor as a discarded temporary (the `ostringstream(){ ostream(); }`
 // shape), and so does the combination with polymorphic classes -- each was
-// reproduced minimally and verified. ios_base's own state does run
-// (`os.good()` is correctly true), which is what makes this specific to the
-// ios level.
+// reproduced minimally and verified. ios_base's own state does run, which is
+// what makes this specific to the ios level -- and why the exception mask,
+// which lives in ios_base, is correctly goodbit here (ios_exceptions_mask).
 //
 // Setting a value first and reading it back works, which is what the
 // ios_exceptions_mask and ios_copyfmt tests assert.
@@ -28,7 +27,6 @@
 int main()
 {
   std::ostringstream os;
-  assert(os.exceptions() == std::ios_base::goodbit);
   assert(os.fill() == ' ');
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/ios_default_state_knownbug/main.cpp
+++ b/regression/esbmc-cpp/cpp/ios_default_state_knownbug/main.cpp
@@ -1,0 +1,34 @@
+// KNOWNBUG: a freshly constructed stream's ios members are indeterminate.
+//
+// [ios.base.cons]/[basic.ios.cons]: a newly constructed stream has an empty
+// exception mask and a fill character of widen(' '). In this model neither
+// holds -- the values are *stable* but unconstrained, i.e. read from storage
+// whose initialiser never ran:
+//
+//   assert(os.exceptions() == os.exceptions());   // SUCCEEDS  (stable)
+//   assert(os.exceptions() == goodbit);           // FAILS     (uninitialised)
+//
+// So this is not a nondet-per-call return like the declaration-only defects;
+// ios::ios()'s member initialisation simply does not run for a stream built
+// through the virtual ios base.
+//
+// Ruled out while narrowing, so as not to repeat the work: plain virtual-base
+// construction works, so does a constructor body that calls its base
+// constructor as a discarded temporary (the `ostringstream(){ ostream(); }`
+// shape), and so does the combination with polymorphic classes -- each was
+// reproduced minimally and verified. ios_base's own state does run
+// (`os.good()` is correctly true), which is what makes this specific to the
+// ios level.
+//
+// Setting a value first and reading it back works, which is what the
+// ios_exceptions_mask and ios_copyfmt tests assert.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream os;
+  assert(os.exceptions() == std::ios_base::goodbit);
+  assert(os.fill() == ' ');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ios_default_state_knownbug/test.desc
+++ b/regression/esbmc-cpp/cpp/ios_default_state_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ios_exceptions_mask/main.cpp
+++ b/regression/esbmc-cpp/cpp/ios_exceptions_mask/main.cpp
@@ -12,6 +12,8 @@
 int main()
 {
   std::ostringstream os;
+  // [ios.base.cons]: a new stream starts with an empty exception mask
+  assert(os.exceptions() == std::ios_base::goodbit);
   os.exceptions(std::ios_base::failbit);
   assert(os.exceptions() == std::ios_base::failbit);
   os.exceptions(std::ios_base::badbit);

--- a/regression/esbmc-cpp/cpp/ios_exceptions_mask/main.cpp
+++ b/regression/esbmc-cpp/cpp/ios_exceptions_mask/main.cpp
@@ -1,0 +1,20 @@
+// ios::exceptions() was declared and never defined, so it returned a
+// nondeterministic iostate: after os.exceptions(failbit), both
+// `exceptions() == failbit` and `exceptions() != failbit` FAILED.
+//
+// Note this models the mask as storage only. [ios.base] also has
+// exceptions(mask) throw when the stream state already matches the mask; OM
+// code cannot throw a catchable exception (see #6338), so that part is not
+// modelled -- but the mask itself is now determinate rather than garbage.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream os;
+  os.exceptions(std::ios_base::failbit);
+  assert(os.exceptions() == std::ios_base::failbit);
+  os.exceptions(std::ios_base::badbit);
+  assert(os.exceptions() == std::ios_base::badbit);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ios_exceptions_mask/test.desc
+++ b/regression/esbmc-cpp/cpp/ios_exceptions_mask/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ios_exceptions_mask_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/ios_exceptions_mask_fail/main.cpp
@@ -1,0 +1,13 @@
+// Non-vacuity guard for ios_exceptions_mask: the mask is really stored, so
+// asserting the wrong value must FAIL. Before the fix it was nondet and could
+// not discriminate.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream os;
+  os.exceptions(std::ios_base::failbit);
+  assert(os.exceptions() == std::ios_base::badbit);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ios_exceptions_mask_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/ios_exceptions_mask_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/ostream_format_state/main.cpp
+++ b/regression/esbmc-cpp/cpp/ostream_format_state/main.cpp
@@ -1,0 +1,40 @@
+// <ostream> declared its own width/fill/precision members. [ostream] has no
+// such members -- they belong to ios_base/ios -- and declaring them here hid
+// the inherited overload sets:
+//
+//   * cout.precision() did not resolve at all ("too few arguments"), because
+//     the void-returning one-argument ostream::precision hid both base
+//     overloads;
+//   * cout.precision(3) and cout.fill(c) bound to stubs whose bodies were
+//     commented out, so the setting was silently discarded;
+//   * ostream::width was declared and never defined, so it returned a
+//     nondeterministic value.
+//
+// Removing all four restores the inherited members, which are implemented.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream os;
+
+  // precision: the setter returns the previous value, the getter observes it
+  os.precision(3);
+  assert(os.precision() == 3);
+  std::streamsize prev = os.precision(5);
+  assert(prev == 3);
+  assert(os.precision() == 5);
+
+  // width
+  os.width(7);
+  assert(os.width() == 7);
+
+  // fill
+  os.fill('0');
+  assert(os.fill() == '0');
+  char oldfill = os.fill('x');
+  assert(oldfill == '0');
+  assert(os.fill() == 'x');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ostream_format_state/test.desc
+++ b/regression/esbmc-cpp/cpp/ostream_format_state/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ostream_format_state_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/ostream_format_state_fail/main.cpp
@@ -1,0 +1,13 @@
+// Non-vacuity guard for ostream_format_state: the setting is really stored, so
+// asserting the wrong value must FAIL. Before the fix the setter was a no-op
+// and width() was nondet, so this could not discriminate.
+#include <sstream>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream os;
+  os.precision(3);
+  assert(os.precision() == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ostream_format_state_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/ostream_format_state_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -158,7 +158,7 @@ public:
   typedef int streampos;
   typedef int streamoff;
 
-  ios() : __exception_mask(ios_base::goodbit)
+  ios()
   {
     ios_base();
   }
@@ -167,10 +167,6 @@ public:
   }
   mutable char __fill;
   streambuf *__streambuf;
-  /* Exception mask storage. exceptions() was declared and never defined, so it
-   * returned a nondeterministic iostate: `os.exceptions(failbit);
-   * os.exceptions() == failbit` satisfied neither itself nor its negation. */
-  iostate __exception_mask;
   bool operator!() const;
   operator void *() const;
   void clear(iostate state = ios_base::goodbit);
@@ -183,32 +179,12 @@ public:
   iostate rdstate() const;
   void setstate(iostate state);
 
-  // [basic.ios.members]: copies the formatting state, not the stream buffer or
-  // the error state.
-  ios &copyfmt(const ios &rhs)
-  {
-    __fill = rhs.__fill;
-    __exception_mask = rhs.__exception_mask;
-    ios_base::flags(rhs.flags());
-    ios_base::precision(rhs.precision());
-    ios_base::width(rhs.width());
-    return *this;
-  }
+  ios &copyfmt(const ios &rhs);
   char fill() const;
   char fill(char fillch);
 
-  /* Storage and accessor only: [ios.base] also has exceptions(mask) throw when
-   * the current state already matches the mask, which this model does not do --
-   * OM code cannot throw a catchable exception (see #6338). The mask itself is
-   * now determinate rather than nondeterministic. */
-  iostate exceptions() const
-  {
-    return __exception_mask;
-  }
-  void exceptions(iostate except)
-  {
-    __exception_mask = except;
-  }
+  iostate exceptions() const;
+  void exceptions(iostate except);
   locale imbue(const locale &loc);
   streambuf *rdbuf() const;
   streambuf *rdbuf(streambuf *sb);
@@ -219,6 +195,7 @@ public:
 ios_base::ios_base()
 {
   __streambuf_state = goodbit;
+  __exception = goodbit;
 }
 
 ios_base::fmtflags ios_base::flags() const
@@ -285,6 +262,39 @@ ios::iostate ios::rdstate() const
 void ios::setstate(ios::iostate state)
 {
   clear(__streambuf_state |= state);
+}
+
+/* Storage and accessor only: [ios.base] also has exceptions(mask) throw when
+ * the current state already matches the mask, which this model does not do --
+ * OM code cannot throw a catchable exception (see #6338). The mask itself is
+ * determinate rather than nondeterministic.
+ *
+ * The mask lives in ios_base::__exception rather than in an ios member, even
+ * though [basic.ios] puts it in basic_ios: an ios-level member of a stream
+ * built through the virtual ios base resolves to the wrong offset (#6430),
+ * which lands the write inside the vtable pointer and turns every access into
+ * byte-level pointer surgery -- Bitwuzla then needs gigabytes on what should
+ * be two trivial VCCs. */
+ios::iostate ios::exceptions() const
+{
+  return __exception;
+}
+
+void ios::exceptions(ios::iostate except)
+{
+  __exception = except;
+}
+
+// [basic.ios.members]: copies the formatting state, not the stream buffer or
+// the error state.
+ios &ios::copyfmt(const ios &rhs)
+{
+  __fill = rhs.__fill;
+  __exception = rhs.__exception;
+  flags(rhs.flags());
+  precision(rhs.precision());
+  width(rhs.width());
+  return *this;
 }
 
 bool ios::operator!() const

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -158,7 +158,7 @@ public:
   typedef int streampos;
   typedef int streamoff;
 
-  ios()
+  ios() : __exception_mask(ios_base::goodbit)
   {
     ios_base();
   }
@@ -167,6 +167,10 @@ public:
   }
   mutable char __fill;
   streambuf *__streambuf;
+  /* Exception mask storage. exceptions() was declared and never defined, so it
+   * returned a nondeterministic iostate: `os.exceptions(failbit);
+   * os.exceptions() == failbit` satisfied neither itself nor its negation. */
+  iostate __exception_mask;
   bool operator!() const;
   operator void *() const;
   void clear(iostate state = ios_base::goodbit);
@@ -179,12 +183,32 @@ public:
   iostate rdstate() const;
   void setstate(iostate state);
 
-  ios &copyfmt(const ios &rhs);
+  // [basic.ios.members]: copies the formatting state, not the stream buffer or
+  // the error state.
+  ios &copyfmt(const ios &rhs)
+  {
+    __fill = rhs.__fill;
+    __exception_mask = rhs.__exception_mask;
+    ios_base::flags(rhs.flags());
+    ios_base::precision(rhs.precision());
+    ios_base::width(rhs.width());
+    return *this;
+  }
   char fill() const;
   char fill(char fillch);
 
-  iostate exceptions() const;
-  void exceptions(iostate except);
+  /* Storage and accessor only: [ios.base] also has exceptions(mask) throw when
+   * the current state already matches the mask, which this model does not do --
+   * OM code cannot throw a catchable exception (see #6338). The mask itself is
+   * now determinate rather than nondeterministic. */
+  iostate exceptions() const
+  {
+    return __exception_mask;
+  }
+  void exceptions(iostate except)
+  {
+    __exception_mask = except;
+  }
   locale imbue(const locale &loc);
   streambuf *rdbuf() const;
   streambuf *rdbuf(streambuf *sb);

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -25,10 +25,14 @@ public:
   {
   }
 
-  streamsize width() const;
-  streamsize width(streamsize wide);
-  void fill(char c);
-  void precision(int p);
+  /* width/fill/precision are members of ios_base/ios, not of ostream
+   * ([ostream.formatted] lists no such members). Declaring them here hid the
+   * inherited overload sets: `cout.precision()` did not resolve at all, and
+   * `cout.precision(3)` / `cout.fill(c)` bound to void-returning stubs whose
+   * bodies were commented out, so the setting was silently discarded.
+   * ostream::width was declared and never defined, so it returned a
+   * nondeterministic value. Removing all four lets the inherited members
+   * through. */
   void put(char c);
   //	void write(char str[], size_t n);
   ostream &write(const char *s, streamsize n);
@@ -138,16 +142,6 @@ using basic_ostream = ostream;
 
 namespace std
 {
-void ostream::fill(char c)
-{
-  //		setfill(c);
-}
-
-void ostream::precision(int p)
-{
-  //		setprecision(p);
-}
-
 void ostream::put(char c)
 {
 }


### PR DESCRIPTION
**Stacked on #6427 — base is `fix/ostream-shadowing-members`, not `master`.**
The `copyfmt` test needs the `precision()`/`fill()` getters that #6427 unhides.
Merge #6427 first, or retarget once it lands.

Continues the stream-model audit (#6421 → #6424 → #6425 → #6427). No issue
filed; happy to file one.

## The defect

```cpp
std::ostringstream os;
os.exceptions(std::ios_base::failbit);
assert(os.exceptions() == std::ios_base::failbit);   // FAILED
assert(os.exceptions() != std::ios_base::failbit);   // ALSO FAILED
```

`ios::exceptions()` and `ios::copyfmt()` were declared and never defined, so the
mask read back as a nondeterministic `iostate` and `copyfmt` copied nothing
while returning a reference to nothing.

## Fix

Add the mask storage `__exception_mask` and define both accessors; give
`copyfmt` the [basic.ios.members] semantics — it copies the formatting state
(flags, precision, width, fill, exception mask), not the stream buffer or the
error state.

## Two limitations, stated rather than papered over

**1. The mask is storage only.** [ios.base] also has `exceptions(mask)` throw
when the stream state already matches the mask. OM code cannot throw a
catchable exception — the `<string>`/`<stdexcept>` include cycle and the
throw-analysis limitation recorded in #6338 — so that behaviour is not
modelled. The mask itself is now determinate rather than garbage, which is a
strict improvement, but a program relying on stream exceptions firing will not
see them.

**2. The *default* mask is not reliably `goodbit`**, and neither is the default
fill character. `ios::ios()`'s member initialisation does not run for a stream
built through the virtual `ios` base, so those members are read from storage
whose initialiser never executed. Crucially the values are **stable**, not
nondet-per-call — `assert(os.exceptions() == os.exceptions())` succeeds while
`assert(os.exceptions() == goodbit)` fails — which distinguishes this from the
declaration-only defects fixed in #6421/#6424/#6425. Set-then-get is correct,
which is what the tests assert.

This is **pre-existing** and not introduced here. I tried to reduce it and
could not, so rather than guess I pinned it as
`ios_default_state_knownbug` and recorded what was ruled out, each reproduced
minimally and verified working: plain virtual-base construction; a constructor
body that calls its base constructor as a discarded temporary (the
`ostringstream(){ ostream(); }` shape); and both combined with polymorphic
classes. `ios_base`'s own state *does* initialise — `os.good()` is correctly
true — which is what localises the gap to the `ios` level.

## Tests

- `ios_exceptions_mask` — set, read back, re-set with a different value.
- `ios_exceptions_mask_fail` — asserts the wrong mask; must FAIL. Before the fix
  it was nondet and could not discriminate.
- `ios_copyfmt` — `precision` and `fill` carried across by `copyfmt`.

The tests use `std::ostringstream` rather than `std::cout`, so they do not
depend on #6425.

## Suites

`esbmc-cpp/cpp` + `string` + `OM_sanity_checks`: 934 tests, 7 failures, all in
the known pre-existing macOS/libc++ set. `<ios>` still parses under
`--std c++03`.

## Audit status

A mechanical scan for the *other* shape found in #6427 — a derived class
redeclaring a base member name and hiding the whole overload set — reports ten
hits across the OM tree, and I checked each: eight are legitimate virtual
overrides (`what` on the exception hierarchy, `invoke` on `callable_wrapper`),
one is a regex artefact, and `ios::imbue` over `ios_base::imbue` is what the
standard actually specifies. So `<ostream>` was the only real instance; that
sweep is clean.
