### PR TITLE
[test] Pin virtual-base construction at the wrong address as KNOWNBUG

### DIFF
--- a/regression/esbmc-cpp/inheritance/virtual_base_with_base/main.cpp
+++ b/regression/esbmc-cpp/inheritance/virtual_base_with_base/main.cpp
@@ -1,0 +1,55 @@
+// KNOWNBUG: a virtual base whose own base has state is constructed at the
+// wrong address, so nothing in that subobject is initialised.
+//
+// The GOTO for Mid's constructor shows the cause:
+//
+//     FUNCTION_CALL:  Base((struct Base *)this)
+//
+// `this` (a Mid*) is cast straight to Base* with no virtual-base offset
+// adjustment. Under virtual inheritance the Base subobject is not at offset 0,
+// so Base's constructor -- and transitively Root's -- writes to the wrong
+// place and both members read back as unconstrained values.
+//
+// Narrowed from the stream models, where it makes a freshly constructed
+// std::ostream's ios state indeterminate (ostream : virtual public ios,
+// ios : public ios_base): std::ios on its own is fine, std::ostream is not.
+// See regression/esbmc-cpp/cpp/ios_default_state_knownbug.
+//
+// The trigger is precisely "virtual base that itself has a base":
+//   * with no grandparent (Base has no base of its own) it works;
+//   * with the inheritance made non-virtual it works;
+//   * virtual destructors are irrelevant -- it fails with and without them.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <cassert>
+
+struct Root
+{
+  int r;
+  Root() : r(1)
+  {
+  }
+};
+
+struct Base : public Root
+{
+  int v;
+  Base() : v(7)
+  {
+  }
+};
+
+struct Mid : virtual public Base
+{
+  Mid()
+  {
+  }
+};
+
+int main()
+{
+  Mid x;
+  assert(x.r == 1);
+  assert(x.v == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/virtual_base_with_base/test.desc
+++ b/regression/esbmc-cpp/inheritance/virtual_base_with_base/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/virtual_base_without_base/main.cpp
+++ b/regression/esbmc-cpp/inheritance/virtual_base_without_base/main.cpp
@@ -1,0 +1,25 @@
+// Control for virtual_base_with_base: the same shape, but the virtual base has
+// no base of its own. This one works, which is what isolates the trigger.
+#include <cassert>
+
+struct Base
+{
+  int v;
+  Base() : v(7)
+  {
+  }
+};
+
+struct Mid : virtual public Base
+{
+  Mid()
+  {
+  }
+};
+
+int main()
+{
+  Mid x;
+  assert(x.v == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/virtual_base_without_base/test.desc
+++ b/regression/esbmc-cpp/inheritance/virtual_base_without_base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Root cause of the indeterminate stream state pinned in #6429, narrowed to a
12-line reproducer with no library headers involved. Tests only, no behaviour
change. No issue filed; happy to file one — this one probably deserves it.

## The defect

```cpp
struct Root { int r; Root() : r(1) {} };
struct Base : public Root { int v; Base() : v(7) {} };
struct Mid  : virtual public Base { Mid() {} };

Mid x;
assert(x.r == 1);   // VERIFICATION FAILED
assert(x.v == 7);   // VERIFICATION FAILED
```

Both members read back as unconstrained values: **nothing in the virtual base
subobject is initialised**. The reproducer exits 0 under
`clang++ -std=c++17 -fsanitize=address,undefined`.

## Root cause: two base-layout models meeting at a seam

The GOTO shows both models side by side. `Base` — which has only a non-virtual
base — uses the **nested subobject** model:

```
Base (...):
        FUNCTION_CALL:  Root(&this->@base@tag-struct Root)
        ASSIGN this->v=7;
```

`Mid` has a virtual base, so `get_base_components_methods` takes the
`has_virtual_bases` branch and keeps the **legacy flattened layout** for the
whole hierarchy, and `#base_subobject` is deliberately not set for a virtual
base (`if (!init->isBaseVirtual())`). Its constructor therefore emits:

```
Mid (...):
        FUNCTION_CALL:  Base((struct Base *)this)
```

So `Base::Base` writes through a `Base *` whose layout is *nested*
(`@base@Root`, then `v`), while the storage it is handed is `Mid`'s *flattened*
layout (`Root`'s and `Base`'s members pulled in directly, no `@base@`
component). The two representations disagree, and the bare cast reinterprets
one as the other — so neither `r` nor `v` lands where the reader looks.

This is not an oversight in the constructor code. It is the seam between the
nested model, which now covers non-virtual bases, and the flattened model still
used whenever a virtual base is present. The code says so:

> Legacy flattened layout. A shared virtual base must appear exactly once in the
> most-derived object, which per-path nested subobjects cannot express yet (P5).
> See #1866, #3894.

Note the multiple-inheritance half of this **is now fixed** — `struct AP : A, P`
with members in both bases verifies correctly on master, and
`inheritance/mi_base_subobject_layout` is `CORE` and passing. What remains is
the virtual-base path, which is exactly what #3894 tracks.

## Why this matters beyond the reproducer

It explains the stream defect I pinned in #6429. `std::ostream` is
`virtual public ios`, and `ios` is `public ios_base` — exactly this shape. So a
freshly constructed `std::ostream` has indeterminate `ios` state, while
`std::ios` constructed directly is fine. I confirmed both:
`std::ios x; x.exceptions() == goodbit` verifies; `std::ostream x;` does not.

Because the values are *stable* rather than nondeterministic per call, this is
easy to mistake for correct behaviour in a test that sets a field before reading
it — which is why it survived.

## The trigger, narrowed

Each of these was reproduced minimally and checked, so the next person does not
repeat the work:

| variation | result |
|---|---|
| virtual base **with** a base of its own | **fails** |
| virtual base with no base of its own | passes |
| same hierarchy, inheritance made non-virtual | passes |
| with / without virtual destructors | fails either way — irrelevant |
| base constructor called as a discarded temporary in the body | passes |

## Tests

- `virtual_base_with_base` — the reproducer, `KNOWNBUG`, so it passes today and
  the harness flags it for promotion to `CORE` when the offset adjustment is
  fixed.
- `virtual_base_without_base` — the control, `CORE`. It is what makes the pin
  precise: without it the KNOWNBUG could be read as "virtual inheritance is
  broken", which is not the case.

## Suites

`esbmc-cpp/inheritance`, `inheritance_bringup` and `polymorphism_bringup`: 145
tests, all pass. The change is additive test-only.
