### PR TITLE
[ir-ieee] Preserve flushed negative zero sign metadata

### DIFF
--- a/regression/ir-ra/ra-div-rup-flush-preserves-own-signbit/main.c
+++ b/regression/ir-ra/ra-div-rup-flush-preserves-own-signbit/main.c
@@ -1,0 +1,21 @@
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF: negative tiny values flush to 0 */
+  double a = __VERIFIER_nondet_double();
+  double b = __VERIFIER_nondet_double();
+  __ESBMC_assume(a > 0.0 && a < 1e-162);
+  __ESBMC_assume(b > 0.5 && b < 1.5); /* symbolic, ordinary nonzero denominator */
+  double y = (-a) / b; /* the division itself, not one of its operands,
+                           produces the flushed negative zero */
+  /* encode_ieee_div wraps its subnormal-flush result in a further ite
+   * (to select the div-by-zero infinity case); the negative-zero
+   * predicate mk_subnormal_flush attaches must survive that wrapping so
+   * it is still visible on the division's own returned value. */
+  __ESBMC_assert(
+    __signbit(y) != 0,
+    "a division's own flushed result must still report a negative sign bit");
+  return 0;
+}

--- a/regression/ir-ra/ra-div-rup-flush-preserves-own-signbit/test.desc
+++ b/regression/ir-ra/ra-div-rup-flush-preserves-own-signbit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-mul-rup-flush-preserves-div-sign/main.c
+++ b/regression/ir-ra/ra-mul-rup-flush-preserves-div-sign/main.c
@@ -1,0 +1,19 @@
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF: negative tiny denom flushes to 0 */
+  double a = __VERIFIER_nondet_double();
+  __ESBMC_assume(a > 0.0 && a < 1e-162);
+  double denom = (-a) * a; /* flushes to zero under RUP; the true IEEE 754
+                               value at this point is -0.0 */
+  double z = 1.0 / denom;
+  /* IEEE 754: 1.0 / -0.0 == -infinity. This regression checks that
+   * IR-IEEE recovers the sign of a zero produced by flushing a negative
+   * value when selecting the sign of the infinity result. */
+  __ESBMC_assert(
+    z < 0.0,
+    "dividing by a zero flushed from a negative value must give -infinity");
+  return 0;
+}

--- a/regression/ir-ra/ra-mul-rup-flush-preserves-div-sign/test.desc
+++ b/regression/ir-ra/ra-mul-rup-flush-preserves-div-sign/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-mul-rup-flush-preserves-signbit/main.c
+++ b/regression/ir-ra/ra-mul-rup-flush-preserves-signbit/main.c
@@ -1,0 +1,19 @@
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF: negative tiny values flush to 0 */
+  double a = __VERIFIER_nondet_double();
+  __ESBMC_assume(a > 0.0 && a < 1e-162);
+  double y = (-a) * a; /* exact product is negative and strictly below
+                           min_subnormal in magnitude, so it flushes to
+                           zero under RUP */
+  /* IEEE 754 gives -0.0 here (sign bit set): a negative exact result that
+   * underflows keeps its sign even when rounded to zero. This regression
+   * checks that IR-IEEE preserves that sign through its side metadata. */
+  __ESBMC_assert(
+    __signbit(y) != 0,
+    "a negative result flushed to zero must still report a negative sign bit");
+  return 0;
+}

--- a/regression/ir-ra/ra-mul-rup-flush-preserves-signbit/test.desc
+++ b/regression/ir-ra/ra-mul-rup-flush-preserves-signbit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -71,6 +71,34 @@ void ir_ieee_convt::propagate_nan_pred(smt_astt lhs, smt_astt rhs)
     ir_ieee_nan_map[lhs] = it->second;
 }
 
+void ir_ieee_convt::store_neg_zero_pred(smt_astt t, smt_astt neg_zero_pred)
+{
+  ir_ieee_neg_zero_map[t] = neg_zero_pred;
+}
+
+smt_astt ir_ieee_convt::get_neg_zero_pred(smt_astt t) const
+{
+  auto it = ir_ieee_neg_zero_map.find(t);
+  return it != ir_ieee_neg_zero_map.end() ? it->second : nullptr;
+}
+
+void ir_ieee_convt::propagate_neg_zero_pred(smt_astt lhs, smt_astt rhs)
+{
+  auto it = ir_ieee_neg_zero_map.find(rhs);
+  if (it != ir_ieee_neg_zero_map.end())
+    ir_ieee_neg_zero_map[lhs] = it->second;
+}
+
+void ir_ieee_convt::propagate_neg_zero_through_ite(
+  smt_astt outer,
+  smt_astt inner,
+  smt_astt guard)
+{
+  smt_astt inner_neg_zero = get_neg_zero_pred(inner);
+  if (inner_neg_zero)
+    store_neg_zero_pred(outer, ctx->mk_and(guard, inner_neg_zero));
+}
+
 smt_astt ir_ieee_convt::combine_nan_preds(smt_astt a, smt_astt b) const
 {
   if (!a && !b)
@@ -631,8 +659,18 @@ smt_astt ir_ieee_convt::encode_ieee_div(const expr2tc &expr)
   }
 
   smt_astt sentinel = ctx->get_double_inf_sentinel();
+  // IEEE 754: the sign of x / +-0 is sign(x) XOR sign of the zero divisor.
+  // side2 is a bare real zero here (div_by_zero requires side2 == zero),
+  // which cannot carry its own sign, so the divisor's sign is recovered
+  // from its tracked negative-zero predicate (set only when side2 is the
+  // result of flushing a negative subnormal-range value); absent that
+  // predicate, side2 is treated as ordinary +0.0, matching prior behaviour.
+  smt_astt side1_neg = ctx->mk_lt(side1, zero);
+  smt_astt side2_neg_zero = get_neg_zero_pred(side2);
+  smt_astt result_neg =
+    side2_neg_zero ? ctx->mk_xor(side1_neg, side2_neg_zero) : side1_neg;
   smt_astt inf_result =
-    ctx->mk_ite(ctx->mk_lt(side1, zero), ctx->mk_sub(zero, sentinel), sentinel);
+    ctx->mk_ite(result_neg, ctx->mk_sub(zero, sentinel), sentinel);
   smt_astt real_result = ctx->mk_div(side1, side2);
   const expr2tc &rounding_mode = to_ieee_div2t(expr).rounding_mode;
 
@@ -701,12 +739,17 @@ smt_astt ir_ieee_convt::encode_ieee_div(const expr2tc &expr)
       combine_nan_preds(
         combine_nan_preds(get_nan_pred(side1), get_nan_pred(side2)),
         combine_nan_preds(zero_div_zero_nan, inf_div_inf_nan)));
+    // `a` is a further ite over `flushed`, not `flushed` itself.
+    propagate_neg_zero_through_ite(a, flushed, ctx->mk_not(div_by_zero));
     return a;
   }
 
   smt_astt ieee_result =
     ctx->apply_ieee754_semantics(real_result, fbv_type, nullptr, rounding_mode);
-  return ctx->mk_ite(div_by_zero, inf_result, ieee_result);
+  smt_astt result = ctx->mk_ite(div_by_zero, inf_result, ieee_result);
+  // `result` is a further ite over `ieee_result`, not `ieee_result` itself.
+  propagate_neg_zero_through_ite(result, ieee_result, ctx->mk_not(div_by_zero));
+  return result;
 }
 
 smt_astt ir_ieee_convt::encode_ieee_fma(const expr2tc &expr)

--- a/src/solvers/smt/fp/ir_ieee_conv.h
+++ b/src/solvers/smt/fp/ir_ieee_conv.h
@@ -96,6 +96,34 @@ public:
    *  mk_or(a, b) if both are set. */
   smt_astt combine_nan_preds(smt_astt a, smt_astt b) const;
 
+  /** Record that the SMT AST t is a real zero produced by flushing a
+   *  negative subnormal-range result (smt_solver_baset::mk_subnormal_flush).
+   *  neg_zero_pred is a boolean SMT term that is true iff t stands for
+   *  IEEE 754 -0.0. This tracks only the negative-zero case arising from
+   *  subnormal flushing, not general signed-zero semantics. */
+  void store_neg_zero_pred(smt_astt t, smt_astt neg_zero_pred);
+
+  /** Return the stored negative-zero predicate for t, or nullptr if t is
+   *  not known to be a flushed negative zero. */
+  smt_astt get_neg_zero_pred(smt_astt t) const;
+
+  /** Propagate a negative-zero predicate from rhs to lhs after an SSA
+   *  assignment. Called from smt_solver_baset::convert_assign alongside
+   *  propagate_interval and propagate_nan_pred. */
+  void propagate_neg_zero_pred(smt_astt lhs, smt_astt rhs);
+
+  /** Re-attach inner's negative-zero predicate (if any) to outer, guarded
+   *  by `guard` (the condition under which outer actually evaluates to
+   *  inner). Must be used whenever a term that may carry negative-zero
+   *  metadata is wrapped in a further SMT term such as an ite -- e.g.
+   *  encode_ieee_div's div-by-zero selection -- since the metadata map is
+   *  keyed by AST pointer and the wrapper is a different pointer from
+   *  inner, so a lookup on the wrapper alone would silently miss it. */
+  void propagate_neg_zero_through_ite(
+    smt_astt outer,
+    smt_astt inner,
+    smt_astt guard);
+
   /** Interval-lifted RNE enclosure helper.
    *  Input: exact real result and pre-computed interval endpoints [lo_r, hi_r].
    *  Returns {ra_lo, ra_hi} for storage in the interval map. */
@@ -145,6 +173,13 @@ private:
    *  true iff the value is NaN).  Only populated for sqrt results where
    *  the operand may be negative. */
   std::unordered_map<const smt_ast *, smt_astt> ir_ieee_nan_map;
+
+  /** Map from AST pointer to its negative-zero predicate (a boolean SMT
+   *  term that is true iff the value is a real zero produced by flushing
+   *  a negative subnormal-range result). Populated only by
+   *  smt_solver_baset::mk_subnormal_flush; an absent entry means that no
+   *  flushed-negative-zero metadata is recorded for the value. */
+  std::unordered_map<const smt_ast *, smt_astt> ir_ieee_neg_zero_map;
 
   /** Set of symbol names that have already received integer range assertions,
    *  preventing duplicate constraints for the same SSA variable. */

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -570,7 +570,17 @@ smt_astt smt_solver_baset::mk_subnormal_flush(
   else
     flush = mk_lt(abs_r, min_sub);
 
-  return mk_ite(flush, zero, r);
+  smt_astt result = mk_ite(flush, zero, r);
+
+  // Track when this flush produced IEEE 754 -0.0 rather than +0.0, so that
+  // sign-sensitive consumers (signbit, division by zero) can recover the
+  // sign that the bare real value 0 can no longer represent. This is
+  // recorded on `result` itself -- the term callers actually receive --
+  // not on the temporary `zero`/`flush` subterms, so it survives lookups
+  // keyed on the returned AST.
+  ir_ieee_api->store_neg_zero_pred(result, mk_and(flush, mk_lt(r, zero)));
+
+  return result;
 }
 
 smt_astt smt_solver_baset::get_double_inf_sentinel()
@@ -817,6 +827,13 @@ smt_astt smt_solver_baset::convert_signbit(const expr2tc &expr)
     // In integer/real encoding mode, floating-point values are represented as reals
     // We can't extract bits, so check the sign mathematically
     is_neg = mk_lt(value, mk_smt_real("0"));
+
+    // A value flushed to zero from a negative subnormal-range result is
+    // IEEE 754 -0.0, but the real zero it collapsed to carries no sign of
+    // its own; consult the tracked negative-zero predicate to recover it.
+    smt_astt neg_zero_pred = ir_ieee_api->get_neg_zero_pred(value);
+    if (neg_zero_pred)
+      is_neg = mk_or(is_neg, neg_zero_pred);
   }
   else
   {

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -381,6 +381,7 @@ smt_astt smt_solver_baset::convert_assign(const expr2tc &expr)
   // for compositional lifting.
   ir_ieee_api->propagate_interval(side1, side2);
   ir_ieee_api->propagate_nan_pred(side1, side2);
+  ir_ieee_api->propagate_neg_zero_pred(side1, side2);
 
   return side2;
 }


### PR DESCRIPTION
## Summary

This PR preserves the sign of IEEE-754 negative zero for subnormal results flushed to zero in the `--ir-ieee` encoding.

The previous underflow work intentionally approximated subnormal results using flush-to-zero (FTZ). While this preserved soundness, the sign of a negative subnormal was lost because the underlying real value became `0`, which cannot distinguish `+0.0` from `-0.0`.

This PR introduces lightweight negative-zero metadata for flushed results so that sign-sensitive operations can recover the correct IEEE-754 behaviour without changing the underlying real representation.

The change is limited to the `--ir-ieee` encoding and does not affect the existing `floatbv` encoding.

## Motivation

IEEE-754 distinguishes `+0.0` and `-0.0` even though they compare equal.

When a negative subnormal underflows and is flushed to zero, its sign must still be preserved. Without tracking this information, the `--ir-ieee` encoding loses the distinction because both values become the same real number (`0`).

This affects operations that observe the sign of zero, including:

- `signbit(-0.0)`, which must report a negative sign.
- Division by zero, where:
  - `1.0 / +0.0 == +∞`
  - `1.0 / -0.0 == -∞`

This PR restores those behaviours while keeping the existing FTZ approximation.

## Changes

- Introduce negative-zero metadata for values flushed to zero by `mk_subnormal_flush`.
- Propagate the metadata through SSA assignments alongside the existing interval and NaN metadata.
- Preserve the metadata when flushed results are wrapped by additional SMT expressions (such as `ite`).
- Update `signbit` to consult the tracked negative-zero metadata when the underlying real value is zero.
- Use the tracked sign when determining the sign of infinities produced by division by zero.
- Keep the implementation limited to negative zero produced by subnormal flushing; this PR does not implement general IEEE-754 signed-zero semantics.

## Regression Tests

Three new CORE regression tests were added under `regression/ir-ra/`:

- `ra-mul-rup-flush-preserves-signbit`
  - Checks that a negative result flushed to zero still reports a negative sign through `signbit()`.
  - Expected result: `VERIFICATION SUCCESSFUL`.

- `ra-mul-rup-flush-preserves-div-sign`
  - Checks that dividing by a zero produced by flushing a negative value yields negative infinity.
  - Expected result: `VERIFICATION SUCCESSFUL`.

- `ra-div-rup-flush-preserves-own-signbit`
  - Checks that a division whose own result is flushed to negative zero preserves its sign metadata even after the division encoding wraps the flushed result.
  - Expected result: `VERIFICATION SUCCESSFUL`.

## Testing

The new regression tests were run:

```bash
ctest --test-dir build -R "ra-.*flush-preserves" --output-on-failure
```

Result:

- 3/3 passed.

The full `ir-ra` regression suite was also run:

```bash
perl regression/test.pl \
  -c "$(realpath build/src/esbmc/esbmc)" \
  -p regression/ir-ra/*/
```

Result:

- 254 tests.
- All tests were successful.


## Notes

This PR intentionally has a narrow scope.

It preserves the sign of negative zero only for values produced by the existing subnormal flush-to-zero approximation.

It does **not** implement full IEEE-754 signed-zero semantics. In particular, it does not add signed-zero handling for operations such as `sqrt`, `copysign`, unary negation, or other floating-point operations that may create or propagate signed zeros independently of subnormal flushing.