### PR TITLE
[om] Fix upper_bound, which scanned backwards and returned the wrong iterator

### DIFF
--- a/regression/esbmc-cpp/algorithm/upper_bound_semantics/main.cpp
+++ b/regression/esbmc-cpp/algorithm/upper_bound_semantics/main.cpp
@@ -1,0 +1,45 @@
+// upper_bound was scanning BACKWARDS from last-1 and returning the last
+// position satisfying `val <= *it`, instead of [upper.bound]'s first position
+// satisfying `val < *it`. On a sorted {1,2,3,4,5,6} it answered
+// upper_bound(3) == &6 rather than &4 -- deterministically wrong, not
+// nondeterministic, which is why it looked plausible and survived.
+//
+// lower_bound's comparator overload additionally tested
+// `comp(val, *it) || val == *it`, requiring Ty to have operator== which
+// [lower.bound] does not; a comparator-only type would not compile.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <algorithm>
+#include <utility>
+#include <cassert>
+static bool gt(int a, int b)
+{
+  return a > b;
+}
+int main()
+{
+  int v[7] = {1, 2, 3, 3, 3, 5, 6};
+
+  // [lower.bound] / [upper.bound] around a run of equal values
+  assert(std::lower_bound(v, v + 7, 3) == v + 2);
+  assert(std::upper_bound(v, v + 7, 3) == v + 5);
+
+  // value absent: both point at the first greater element
+  assert(std::lower_bound(v, v + 7, 4) == v + 5);
+  assert(std::upper_bound(v, v + 7, 4) == v + 5);
+
+  // below the range / above the range
+  assert(std::lower_bound(v, v + 7, 0) == v);
+  assert(std::upper_bound(v, v + 7, 0) == v);
+  assert(std::lower_bound(v, v + 7, 9) == v + 7);
+  assert(std::upper_bound(v, v + 7, 9) == v + 7);
+
+  std::pair<int *, int *> r = std::equal_range(v, v + 7, 3);
+  assert(r.first == v + 2 && r.second == v + 5);
+
+  // comparator overloads on a descending range
+  int d[5] = {9, 7, 5, 3, 1};
+  assert(std::lower_bound(d, d + 5, 5, gt) == d + 2);
+  assert(std::upper_bound(d, d + 5, 5, gt) == d + 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/algorithm/upper_bound_semantics/test.desc
+++ b/regression/esbmc-cpp/algorithm/upper_bound_semantics/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 14
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/upper_bound_semantics_fail/main.cpp
+++ b/regression/esbmc-cpp/algorithm/upper_bound_semantics_fail/main.cpp
@@ -1,0 +1,11 @@
+// Non-vacuity guard: upper_bound really returns the first element greater than
+// the value, so the old (backwards-scan) answer must FAIL.
+#include <algorithm>
+#include <cassert>
+
+int main()
+{
+  int v[6] = {1, 2, 3, 4, 5, 6};
+  assert(std::upper_bound(v, v + 6, 3) == v + 5); // the pre-fix answer
+  return 0;
+}

--- a/regression/esbmc-cpp/algorithm/upper_bound_semantics_fail/test.desc
+++ b/regression/esbmc-cpp/algorithm/upper_bound_semantics_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 10
+^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -1414,26 +1414,31 @@ FwdIt lower_bound(FwdIt first, FwdIt last, const Ty &val)
 template <class FwdIt, class Ty, class Pr>
 FwdIt lower_bound(FwdIt first, FwdIt last, const Ty &val, Pr pred)
 {
+  /* [lower.bound]: the first it with !comp(*it, val). The previous form,
+   * comp(val, *it) || val == *it, also required Ty to have operator==, which
+   * the standard does not — a comparator-only type would not compile. */
   while (first != last)
   {
-    if (pred(val, *first) || val == *first)
+    if (!pred(*first, val))
       return first;
-    else
-      first++;
+    ++first;
   }
-  return first;
+  return last;
 }
 
 template <class FwdIt, class Ty>
 FwdIt upper_bound(FwdIt first, FwdIt last, const Ty &val)
 {
-  last--;
+  /* [upper.bound]: the FIRST iterator it in [first, last) with val < *it.
+   * The previous version scanned BACKWARDS from last-1 and returned the last
+   * position satisfying val <= *it, so on a sorted {1,2,3,4,5,6} it answered
+   * upper_bound(3) == &6 instead of &4 -- deterministically wrong rather than
+   * nondeterministic, which is why it looked plausible. */
   while (first != last)
   {
-    if (val <= *last)
-      return last;
-    else
-      last--;
+    if (val < *first)
+      return first;
+    ++first;
   }
   return last;
 }
@@ -1441,14 +1446,12 @@ FwdIt upper_bound(FwdIt first, FwdIt last, const Ty &val)
 template <class FwdIt, class Ty, class Pr>
 FwdIt upper_bound(FwdIt first, FwdIt last, const Ty &val, Pr pred)
 {
-  last--;
+  // [upper.bound]: the first it with comp(val, *it).
   while (first != last)
   {
-    // Return the iterator _before_ the predicate becomes true.
-    if (!pred(val, *last))
-      return ++last;
-    else
-      last--;
+    if (pred(val, *first))
+      return first;
+    ++first;
   }
   return last;
 }


### PR DESCRIPTION
Found by an assert-based audit of `<algorithm>`. No issue filed; happy to file
one. Based on master, independent of the other open PRs.

## The defect

```cpp
int v[6] = {1, 2, 3, 4, 5, 6};
assert(std::upper_bound(v, v + 6, 3) == v + 3);   // VERIFICATION FAILED
```

[upper.bound] specifies the **first** iterator `it` in `[first, last)` with
`val < *it`. The implementation scanned **backwards** from `last - 1` and
returned the last position satisfying `val <= *it`:

```cpp
last--;
while (first != last) {
  if (val <= *last) return last;
  else last--;
}
```

On the sorted range above it answers `&6` instead of `&4`. This is
*deterministically* wrong rather than nondeterministic, which is why it looked
plausible and survived — a caller gets a real iterator into the range, just the
wrong one, and `equal_range` inherits the error since it is built on
`upper_bound`.

`lower_bound` is correct; I checked it separately rather than assuming, and the
test covers both so the pair cannot silently diverge again.

## Also fixed: an unnecessary requirement in lower_bound's comparator overload

It tested `comp(val, *it) || val == *it`. [lower.bound] says the first `it` with
`!comp(*it, val)` — the `||` form additionally requires `Ty` to have
`operator==`, so a comparator-only type would fail to compile. Changed to the
standard form, which also removes that requirement.

## Audit context

The rest of `<algorithm>` was probed in the same pass and is **correct**:
`min`/`max`, `min_element`/`max_element`, `count`, `find`, `sort`,
`binary_search`, `copy`, `equal`, `reverse`, `fill`, `is_sorted`, `transform`,
`unique` and `remove` all behave per the standard.

Separately, `all_of`, `any_of` and `none_of` ([alg.all.of] and neighbours) are
**absent** from the header — naming any of them is a parse error. That is a
missing feature rather than a wrong answer, so it is left for its own change
rather than folded in here.

## Tests

- `upper_bound_semantics` — `lower_bound`/`upper_bound` around a run of equal
  values, for a value absent from the range, below and above the whole range,
  `equal_range`, and both comparator overloads on a descending range. Exits 0
  under `clang++ -std=c++17 -fsanitize=address,undefined`.
- `upper_bound_semantics_fail` — asserts the pre-fix answer (`v + 5`); must
  FAIL, so the test pins the specific defect rather than just exercising the
  function.

## Suites

`esbmc-cpp/algorithm`, `vector`, `list`, `set`, `map` and `deque`: 554 tests,
all pass — the associative containers matter here because they use these
functions internally. The clang-format complaint in `src/cpp/library/algorithm`
is pre-existing, confirmed against the parent commit.
