### PR TITLE
[om] Add the C++11 algorithms missing from <algorithm>

### DIFF
--- a/regression/esbmc-cpp/algorithm/cxx11_predicates/main.cpp
+++ b/regression/esbmc-cpp/algorithm/cxx11_predicates/main.cpp
@@ -1,0 +1,65 @@
+// The C++11 additions to <algorithm> were absent: all_of, any_of, none_of,
+// find_if_not, copy_if, is_partitioned, partition_point, minmax,
+// minmax_element, is_heap and is_heap_until. Naming any of them was a parse
+// error.
+//
+// The empty-range cases are the ones easy to get wrong: [alg.all.of] makes
+// all_of and none_of true on an empty range and any_of false. minmax_element
+// returns the FIRST smallest but the LAST largest.
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <algorithm>
+#include <utility>
+#include <cassert>
+static bool odd(int x)
+{
+  return x % 2 != 0;
+}
+static bool pos(int x)
+{
+  return x > 0;
+}
+int main()
+{
+  int v[6] = {1, 2, 3, 4, 5, 6};
+  assert(std::all_of(v, v + 6, pos));
+  assert(!std::all_of(v, v + 6, odd));
+  assert(std::any_of(v, v + 6, odd));
+  assert(!std::any_of(v, v + 6, [](int x) { return x > 100; }));
+  assert(std::none_of(v, v + 6, [](int x) { return x > 100; }));
+  assert(!std::none_of(v, v + 6, odd));
+
+  // empty range: all_of/none_of are true, any_of is false
+  assert(std::all_of(v, v, pos));
+  assert(std::none_of(v, v, pos));
+  assert(!std::any_of(v, v, pos));
+
+  assert(std::find_if_not(v, v + 6, odd) == v + 1);
+
+  int out[6];
+  int *e = std::copy_if(v, v + 6, out, odd);
+  assert(e == out + 3 && out[0] == 1 && out[1] == 3 && out[2] == 5);
+
+  int p[6] = {1, 3, 5, 2, 4, 6};
+  assert(std::is_partitioned(p, p + 6, odd));
+  assert(!std::is_partitioned(v, v + 6, odd));
+  assert(std::partition_point(p, p + 6, odd) == p + 3);
+
+  // minmax returns references, so the arguments must outlive the pair --
+  // binding it to literals would leave it dangling.
+  int lo = 4, hi = 2;
+  std::pair<const int &, const int &> mm = std::minmax(lo, hi);
+  assert(mm.first == 2 && mm.second == 4);
+
+  int d[5] = {3, 1, 4, 1, 5};
+  std::pair<int *, int *> me = std::minmax_element(d, d + 5);
+  assert(*me.first == 1 && *me.second == 5);
+  assert(me.first == d + 1); // the FIRST smallest
+
+  int h[5] = {5, 4, 3, 2, 1};
+  assert(std::is_heap(h, h + 5));
+  int nh[3] = {1, 2, 3};
+  assert(!std::is_heap(nh, nh + 3));
+  assert(std::is_heap_until(nh, nh + 3) == nh + 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/algorithm/cxx11_predicates/test.desc
+++ b/regression/esbmc-cpp/algorithm/cxx11_predicates/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 14
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/cxx11_predicates_fail/main.cpp
+++ b/regression/esbmc-cpp/algorithm/cxx11_predicates_fail/main.cpp
@@ -1,0 +1,16 @@
+// Non-vacuity guard for cxx11_predicates: all_of really inspects every element,
+// so a predicate that fails partway must make it false.
+#include <algorithm>
+#include <cassert>
+
+static bool odd(int x)
+{
+  return x % 2 != 0;
+}
+
+int main()
+{
+  int v[6] = {1, 2, 3, 4, 5, 6};
+  assert(std::all_of(v, v + 6, odd));
+  return 0;
+}

--- a/regression/esbmc-cpp/algorithm/cxx11_predicates_fail/test.desc
+++ b/regression/esbmc-cpp/algorithm/cxx11_predicates_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 10
+^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -2739,6 +2739,125 @@ bool prev_permutation(BidIt *first, BidIt *last)
 template <class BidIt, class Pr>
 bool prev_permutation(BidIt first, BidIt last, Pr pred);
 
+/* The C++11 additions to <algorithm>. Naming any of these was a parse error;
+ * they are all linear, matching the style of the algorithms already here. */
+#if __cplusplus >= 201103L
+template <class InIt, class Pr>
+bool all_of(InIt first, InIt last, Pr pred)
+{
+  for (; first != last; ++first)
+    if (!pred(*first))
+      return false;
+  return true;
+}
+
+template <class InIt, class Pr>
+bool any_of(InIt first, InIt last, Pr pred)
+{
+  for (; first != last; ++first)
+    if (pred(*first))
+      return true;
+  return false;
+}
+
+template <class InIt, class Pr>
+bool none_of(InIt first, InIt last, Pr pred)
+{
+  for (; first != last; ++first)
+    if (pred(*first))
+      return false;
+  return true;
+}
+
+template <class InIt, class Pr>
+InIt find_if_not(InIt first, InIt last, Pr pred)
+{
+  for (; first != last; ++first)
+    if (!pred(*first))
+      return first;
+  return last;
+}
+
+template <class InIt, class OutIt, class Pr>
+OutIt copy_if(InIt first, InIt last, OutIt dest, Pr pred)
+{
+  for (; first != last; ++first)
+    if (pred(*first))
+    {
+      *dest = *first;
+      ++dest;
+    }
+  return dest;
+}
+
+// [alg.partitions]: true for an empty range, and once the predicate fails no
+// later element may satisfy it.
+template <class InIt, class Pr>
+bool is_partitioned(InIt first, InIt last, Pr pred)
+{
+  for (; first != last; ++first)
+    if (!pred(*first))
+      break;
+  for (; first != last; ++first)
+    if (pred(*first))
+      return false;
+  return true;
+}
+
+template <class FwdIt, class Pr>
+FwdIt partition_point(FwdIt first, FwdIt last, Pr pred)
+{
+  for (; first != last; ++first)
+    if (!pred(*first))
+      return first;
+  return last;
+}
+
+// [alg.min.max]: minmax returns (b, a) when b < a, so the pair is stable for
+// equivalent values.
+template <class Ty>
+pair<const Ty &, const Ty &> minmax(const Ty &a, const Ty &b)
+{
+  return b < a ? pair<const Ty &, const Ty &>(b, a)
+               : pair<const Ty &, const Ty &>(a, b);
+}
+
+/* minmax_element: the first smallest but the LAST largest element, per
+ * [alg.min.max] -- hence the strict `<` for the minimum and the non-strict
+ * `>=` comparison for the maximum. */
+template <class FwdIt>
+pair<FwdIt, FwdIt> minmax_element(FwdIt first, FwdIt last)
+{
+  FwdIt mn = first, mx = first;
+  if (first == last)
+    return pair<FwdIt, FwdIt>(first, last);
+  for (FwdIt it = first; it != last; ++it)
+  {
+    if (*it < *mn)
+      mn = it;
+    if (!(*it < *mx))
+      mx = it;
+  }
+  return pair<FwdIt, FwdIt>(mn, mx);
+}
+
+template <class RanIt>
+RanIt is_heap_until(RanIt first, RanIt last)
+{
+  typename iterator_traits<RanIt>::difference_type n = last - first;
+  for (typename iterator_traits<RanIt>::difference_type i = 1; i < n; ++i)
+    if (first[(i - 1) / 2] < first[i])
+      return first + i;
+  return last;
+}
+
+template <class RanIt>
+bool is_heap(RanIt first, RanIt last)
+{
+  return is_heap_until(first, last) == last;
+}
+#endif // __cplusplus >= 201103L
+
 } // namespace std
 
 #endif


### PR DESCRIPTION
Continues the `<algorithm>` audit that produced #6434. No issue filed; happy to
file one. Based on master, independent of the other open PRs.

## The gap

```cpp
std::all_of(v, v + 6, pred);   // error: no member named 'all_of' in namespace 'std'
```

Eleven of the C++11 additions to `<algorithm>` are absent: `all_of`, `any_of`,
`none_of`, `find_if_not`, `copy_if`, `is_partitioned`, `partition_point`,
`minmax`, `minmax_element`, `is_heap` and `is_heap_until`. Naming any of them is
a parse error.

This is a missing feature rather than a wrong answer — it fails loudly — which
is why it is a separate change from #6434, where `upper_bound` was returning the
wrong iterator.

## Fix

All eleven, linear, matching the style of the algorithms already in the header
and guarded for C++11. Two details from [alg.min.max] worth calling out because
they are the easy things to get wrong:

- `minmax_element` returns the **first** smallest but the **last** largest, so
  the maximum uses a non-strict comparison while the minimum uses a strict one.
- `minmax(a, b)` returns `(b, a)` when `b < a`, so the result is stable for
  equivalent values.

`shuffle` is deliberately not included: it needs a uniform random bit generator,
which is a `<random>` concern rather than an `<algorithm>` one.

## Audit context

The rest of `<algorithm>` was probed in the same pass and is **correct**:
`rotate`, `swap_ranges`, `search`, `merge`, `partition`, `set_intersection`,
`set_union`, `includes`, `make_heap`/`pop_heap`, `partial_sort` and
`nth_element` all behave per the standard, on top of the core set already
confirmed in #6434.

## Tests

- `cxx11_predicates` — each of the eleven, including the empty-range cases that
  are easiest to get wrong ([alg.all.of] makes `all_of` and `none_of` true on an
  empty range and `any_of` false), `find_if_not` at the first failing element,
  `copy_if`'s returned end iterator, `partition_point` on a partitioned range,
  `minmax_element` returning the *first* smallest, and `is_heap_until` on a
  range that is not a heap.
- `cxx11_predicates_fail` — `all_of` with a predicate that fails partway; must
  FAIL.

Both were run under `clang++ -std=c++17 -fsanitize=address,undefined` first —
which caught a dangling reference in my own first draft of the test, where
`std::minmax(4, 2)` bound its result to temporaries that died at the end of the
full expression. The committed test uses named variables. (ESBMC reported that
draft SUCCESSFUL, so it did not detect the stack-use-after-scope; that is a
separate observation about lifetime checking, not something this PR changes.)

## Suites

`esbmc-cpp/algorithm`, `vector`, `list`, `set`, `map`, `deque` plus
`esbmc-cpp11`/`14`/`17`: 738 tests, 2 failures — both the known pre-existing
`esbmc-cpp14/template/builtin-template*` pair. `<algorithm>` still parses under
`--std c++03`.
