### PR TITLE
[test] Pin the undetected dangling reference to a temporary as KNOWNBUG

### DIFF
--- a/regression/esbmc-cpp/cpp/dangling_temporary_ref/main.cpp
+++ b/regression/esbmc-cpp/cpp/dangling_temporary_ref/main.cpp
@@ -1,0 +1,43 @@
+// KNOWNBUG: a reference to a temporary that has already died is not detected --
+// ESBMC reports SUCCESSFUL where the read is a genuine use-after-lifetime.
+//
+// [class.temporary]/4: the temporaries created for the arguments are destroyed
+// at the end of the full-expression, and [class.temporary]/6 does NOT extend
+// their lifetime here because the reference binds to the function's *return*
+// value, not directly to a temporary. clang++ -fsanitize=address aborts on this
+// program; ESBMC verifies it.
+//
+// The GOTO shows why: the argument temporaries are declared in main's scope and
+// never marked dead, so they outlive the full expression.
+//
+//     DECL signed int tmp$1;  ASSIGN tmp$1=4;
+//     DECL signed int tmp$2;  ASSIGN tmp$2=2;
+//     FUNCTION_CALL: return_value$_pick$3=pick(&tmp$1, &tmp$2)
+//     ASSIGN r=return_value$_pick$3;
+//     -- no DEAD tmp$1 / DEAD tmp$2 here --
+//
+// This is the shape std::min/std::max/std::minmax produce, so it is a common
+// real-world dangling-reference bug.
+//
+// CAUTION for whoever fixes it: emitting DEAD for every argument temporary at
+// the end of the full expression would be wrong. A temporary bound *directly*
+// to a reference does have its lifetime extended ([class.temporary]/6) --
+// see temporary_lifetime_extension, which must keep verifying.
+//
+// Detection does work for the neighbouring shapes; both of these are correctly
+// reported as failures today, which is what localises the gap:
+//   * a pointer to a block-scope local read after the block ends;
+//   * a function returning a reference to its own local.
+#include <cassert>
+
+static const int &pick(const int &a, const int &b)
+{
+  return a < b ? a : b;
+}
+
+int main()
+{
+  const int &r = pick(4, 2);
+  assert(r == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dangling_temporary_ref/test.desc
+++ b/regression/esbmc-cpp/cpp/dangling_temporary_ref/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/temporary_lifetime_extension/main.cpp
+++ b/regression/esbmc-cpp/cpp/temporary_lifetime_extension/main.cpp
@@ -1,0 +1,25 @@
+// Companion to dangling_temporary_ref: a temporary bound DIRECTLY to a
+// const reference has its lifetime extended to that of the reference
+// ([class.temporary]/6), so these reads are valid and must keep verifying.
+// A fix for the dangling case that simply kills every temporary at the end of
+// the full expression would break this.
+#include <cassert>
+
+struct S
+{
+  int v;
+  ~S()
+  {
+  }
+};
+
+int main()
+{
+  const int &r = 4;
+  assert(r == 4);
+
+  const S &s = S{7};
+  assert(s.v == 7);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/temporary_lifetime_extension/test.desc
+++ b/regression/esbmc-cpp/cpp/temporary_lifetime_extension/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
A missed bug — ESBMC reports SUCCESSFUL on a program that reads a dead
temporary. Tests only, no behaviour change. No issue filed; happy to file one,
and this is the category that most warrants it.

## The defect

```cpp
static const int &pick(const int &a, const int &b) { return a < b ? a : b; }

const int &r = pick(4, 2);   // the argument temporaries die at the ';'
assert(r == 2);              // reads a dead object
```

**ESBMC: VERIFICATION SUCCESSFUL. `clang++ -fsanitize=address`: aborts.**

[class.temporary]/4 destroys the argument temporaries at the end of the
full-expression, and /6 does *not* extend their lifetime here, because the
reference binds to the function's **return value** rather than directly to a
temporary.

## Root cause, from the GOTO

```
DECL signed int tmp$1;  ASSIGN tmp$1=4;
DECL signed int tmp$2;  ASSIGN tmp$2=2;
FUNCTION_CALL: return_value$_pick$3=pick(&tmp$1, &tmp$2)
ASSIGN r=return_value$_pick$3;
        <- no DEAD tmp$1 / DEAD tmp$2
```

The argument temporaries are declared in the caller's scope and never marked
dead, so they remain live to the end of `main` and the read is of a live object.

## How I found it, and why it matters

This surfaced while writing tests for #6435: my first draft used
`std::minmax(4, 2)` and read the pair afterwards. ASan aborted; ESBMC did not.
That is exactly the shape `std::min`, `std::max` and `std::minmax` produce, so it
is one of the more common real-world dangling-reference bugs — and the one
category of defect where a verifier being wrong is worst, since it reports
success on broken code.

## Detection is *not* broken in general

Both neighbouring shapes are correctly reported as failures today, which is what
localises the gap rather than leaving it as "lifetimes are unsound":

- a pointer to a block-scope local, read after the block ends → FAILED;
- a function returning a reference to its own local → FAILED.

## Caution for whoever fixes this

The obvious fix — emit `DEAD` for every argument temporary at the end of the
full expression — **would be wrong**. A temporary bound *directly* to a const
reference does have its lifetime extended ([class.temporary]/6):

```cpp
const int &r = 4;      // valid, r is usable
const S   &s = S{7};   // valid
```

Both verify today and must keep verifying. They ship as
`temporary_lifetime_extension` (`CORE`) alongside the `KNOWNBUG`, so a fix that
overshoots is caught immediately rather than trading one wrong answer for
another.

This is also adjacent to the discarded-temporary work in #6076, which added
end-of-full-expression destruction for the `result_is_used == false` case; here
the result *is* used, which is why those temporaries stay alive.

## Tests

- `dangling_temporary_ref` — `KNOWNBUG`, expecting `VERIFICATION FAILED`. It
  passes today (the harness expects the wrong verdict) and will be flagged for
  promotion to `CORE` when the lifetime is modelled.
- `temporary_lifetime_extension` — `CORE`, the two extension cases above.

## Suites

`regression/esbmc-cpp/cpp/`: 635 tests, 7 failures, all in the known
pre-existing macOS/libc++ set. The change is additive test-only.
