### PR TITLE
[solver] widen array index domain to fit one-past-end index (#6399)

### DIFF
--- a/regression/function_contract/is_fresh_loopinv_poweroftwo_fail/main.c
+++ b/regression/function_contract/is_fresh_loopinv_poweroftwo_fail/main.c
@@ -1,0 +1,30 @@
+/* is_fresh_loopinv_poweroftwo_fail (issue #6399):
+ * Negative control for is_fresh_loopinv_poweroftwo_pass. The loop only touches
+ * vec[0..2], so vec[3] is left havoc'd (nondet) and the ensures over all four
+ * elements must FAIL. Confirms the #6399 fix (a wider array index domain) does
+ * not make the power-of-two case vacuously verify.
+ */
+typedef struct { int x; } Elem;
+typedef struct { Elem vec[4]; } Vec;
+
+void touch(Elem *e)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(e, sizeof(Elem)));
+  __ESBMC_ensures(e->x == 0);
+  __ESBMC_assigns(e->x);
+  e->x = 0;
+}
+
+void touch_all(Vec *v)
+{
+  unsigned k, j;
+  __ESBMC_requires(__ESBMC_is_fresh(v, sizeof(Vec)));
+  __ESBMC_assigns(v->vec);
+  __ESBMC_ensures(__ESBMC_forall(&j, !(j < 4) || v->vec[j].x == 0));
+
+  __ESBMC_loop_invariant(k <= 3 && __ESBMC_forall(&j, !(j < k) || v->vec[j].x == 0));
+  for (k = 0; k < 3; k++)
+    touch(&v->vec[k]);
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/is_fresh_loopinv_poweroftwo_fail/test.desc
+++ b/regression/function_contract/is_fresh_loopinv_poweroftwo_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function touch_all --enforce-contract touch_all --no-pointer-check --unwind 8 --loop-invariant-check --z3 --replace-call-with-contract touch
+^VERIFICATION FAILED$

--- a/regression/function_contract/is_fresh_loopinv_poweroftwo_pass/main.c
+++ b/regression/function_contract/is_fresh_loopinv_poweroftwo_pass/main.c
@@ -1,0 +1,37 @@
+/* is_fresh_loopinv_poweroftwo_pass (issue #6399):
+ * A wrapper loops K times over an __ESBMC_is_fresh struct, calling an
+ * is_fresh-guarded callee (replaced via --replace-call-with-contract) per
+ * element, with its own loop cut by __ESBMC_loop_invariant. This used to
+ * report a false VERIFICATION FAILED whenever sizeof(Vec) was a power of two
+ * (K = 1,2,4,8,16 -> 4,8,16,32,64 bytes). size_to_bit_width() gave an
+ * n-element array ceil(log2(n)) index bits, which for a power-of-two n is
+ * exactly log2(n): the one-past-the-end index n was then unrepresentable and
+ * wrapped to 0, aliasing element 0. Every other size had a spare bit, hence
+ * the parity. The domain is now wide enough to hold n itself.
+ * sizeof(Vec) = 4*4 = 16 (power of two) here, the historically-failing shape.
+ * The contract is genuinely true.
+ */
+typedef struct { int x; } Elem;
+typedef struct { Elem vec[4]; } Vec;
+
+void touch(Elem *e)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(e, sizeof(Elem)));
+  __ESBMC_ensures(e->x == 0);
+  __ESBMC_assigns(e->x);
+  e->x = 0;
+}
+
+void touch_all(Vec *v)
+{
+  unsigned k, j;
+  __ESBMC_requires(__ESBMC_is_fresh(v, sizeof(Vec)));
+  __ESBMC_assigns(v->vec);
+  __ESBMC_ensures(__ESBMC_forall(&j, !(j < 4) || v->vec[j].x == 0));
+
+  __ESBMC_loop_invariant(k <= 4 && __ESBMC_forall(&j, !(j < k) || v->vec[j].x == 0));
+  for (k = 0; k < 4; k++)
+    touch(&v->vec[k]);
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/is_fresh_loopinv_poweroftwo_pass/test.desc
+++ b/regression/function_contract/is_fresh_loopinv_poweroftwo_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function touch_all --enforce-contract touch_all --no-pointer-check --unwind 8 --loop-invariant-check --z3 --replace-call-with-contract touch
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_fail/main.c
+++ b/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_fail/main.c
@@ -1,0 +1,27 @@
+/* is_fresh_loopinv_scalar_poweroftwo_fail (issue #6399):
+ * Negative control for is_fresh_loopinv_scalar_poweroftwo_pass. The loop only
+ * touches v[0..2], so v[3] stays havoc'd and the ensures over all four
+ * elements must FAIL -- the widened index domain must not make the
+ * power-of-two case vacuously verify.
+ */
+void touch(int *e)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(e, sizeof(int)));
+  __ESBMC_ensures(*e == 0);
+  __ESBMC_assigns(*e);
+  *e = 0;
+}
+
+void touch_all(int *v)
+{
+  unsigned k, j;
+  __ESBMC_requires(__ESBMC_is_fresh(v, 4 * sizeof(int)));
+  __ESBMC_assigns(*v);
+  __ESBMC_ensures(__ESBMC_forall(&j, !(j < 4) || v[j] == 0));
+
+  __ESBMC_loop_invariant(k <= 3 && __ESBMC_forall(&j, !(j < k) || v[j] == 0));
+  for (k = 0; k < 3; k++)
+    touch(&v[k]);
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_fail/test.desc
+++ b/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function touch_all --enforce-contract touch_all --no-pointer-check --unwind 8 --loop-invariant-check --z3 --replace-call-with-contract touch
+^VERIFICATION FAILED$

--- a/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_pass/main.c
+++ b/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_pass/main.c
@@ -1,0 +1,30 @@
+/* is_fresh_loopinv_scalar_poweroftwo_pass (issue #6399):
+ * The scalar-pointee counterpart of is_fresh_loopinv_poweroftwo_pass. The
+ * fresh object is a plain int buffer, so nothing here is a struct: 16 bytes
+ * (2^4) used to report a false VERIFICATION FAILED while 20 bytes verified,
+ * the same power-of-two parity coming from the array index domain being one
+ * bit too narrow to hold the one-past-the-end index. Kept as a separate test
+ * because a contract-side fix that retypes aggregate is_fresh objects cannot
+ * reach this shape -- only widening the domain does.
+ */
+void touch(int *e)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(e, sizeof(int)));
+  __ESBMC_ensures(*e == 0);
+  __ESBMC_assigns(*e);
+  *e = 0;
+}
+
+void touch_all(int *v)
+{
+  unsigned k, j;
+  __ESBMC_requires(__ESBMC_is_fresh(v, 4 * sizeof(int)));
+  __ESBMC_assigns(*v);
+  __ESBMC_ensures(__ESBMC_forall(&j, !(j < 4) || v[j] == 0));
+
+  __ESBMC_loop_invariant(k <= 4 && __ESBMC_forall(&j, !(j < k) || v[j] == 0));
+  for (k = 0; k < 4; k++)
+    touch(&v[k]);
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_pass/test.desc
+++ b/regression/function_contract/is_fresh_loopinv_scalar_poweroftwo_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function touch_all --enforce-contract touch_all --no-pointer-check --unwind 8 --loop-invariant-check --z3 --replace-call-with-contract touch
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -2521,9 +2521,11 @@ static unsigned long size_to_bit_width(unsigned long sz)
   uint64_t domwidth = 2;
   unsigned int dombits = 1;
 
-  // Shift domwidth up until it's either larger or equal to sz, or we risk
-  // overflowing.
-  while (domwidth != 0x8000000000000000ULL && domwidth < sz)
+  // Shift domwidth up until it is strictly larger than sz, or we risk
+  // overflowing. Strictly larger, not just equal: sz itself is the
+  // one-past-the-end index, a valid pointer value in C, and a domain that
+  // cannot represent it wraps it to 0 and aliases element 0 (#6399).
+  while (domwidth != 0x8000000000000000ULL && domwidth <= sz)
   {
     domwidth <<= 1;
     dombits++;


### PR DESCRIPTION
Fixes #6399.

### Symptom

`__ESBMC_is_fresh` + `--loop-invariant-check` + `--replace-call-with-contract`
reported a false `VERIFICATION FAILED` whenever the fresh object's byte size
was a power of two, and verified at every other size. The report framed this as
a trip-count parity; decoupling element size from element count shows it is a
parity on the object's **byte size**.

### Root cause

`size_to_bit_width()` (`src/solvers/smt/smt_solver.cpp`) sizes an array's index
domain:

```cpp
while (domwidth != 0x8000000000000000ULL && domwidth < sz) { domwidth <<= 1; dombits++; }
```

An `n`-element array gets `ceil(log2(n))` bits. For `n` a power of two that is
*exactly* `log2(n)`: the domain represents `0..n-1` and cannot represent `n`
itself. But `n` is the one-past-the-end index — a valid pointer value in C, and
one that contract replacement plus a cut loop does construct. It wraps to `0`
and aliases element 0, so the re-established invariant stops connecting to the
`ensures`.

Every non-power-of-two size takes one more iteration of the shift loop and ends
up with a spare bit. That is the entire parity.

### Fix

`<` becomes `<=`, so the domain is wide enough to hold `n`. It widens
power-of-two sizes only; every other size already had the extra bit, so nothing
else changes.

### Evidence

A/B on a single binary, one character apart, `contracts.cpp` untouched:

| shape | `sizeof` | `< sz` | `<= sz` |
|---|---|---|---|
| aggregate, K=1 | 4 (2²) | FAILED | SUCCESSFUL |
| aggregate, K=2 | 8 (2³) | FAILED | SUCCESSFUL |
| aggregate, K=3 | 12 | SUCCESSFUL | SUCCESSFUL |
| aggregate, K=4 | 16 (2⁴) | FAILED | SUCCESSFUL |
| aggregate, K=8 | 32 (2⁵) | FAILED | SUCCESSFUL |
| aggregate, K=16 | 64 (2⁶) | FAILED | SUCCESSFUL |
| **scalar `int*`** | 16 (2⁴) | FAILED | SUCCESSFUL |
| scalar `int*` | 20 | SUCCESSFUL | SUCCESSFUL |
| negative control | 16 (2⁴) | FAILED | **FAILED** |

The negative controls still fail, so the power-of-two cases are not becoming
vacuous.

Solve time is flat across sizes afterwards (0.23–0.55s for 128–512 byte
objects); the previous run showed no such regularity.

### Tests

- `is_fresh_loopinv_poweroftwo_{pass,fail}` — aggregate shape, the reporter's.
- `is_fresh_loopinv_scalar_poweroftwo_{pass,fail}` — plain `int` buffer.

The scalar pair is the point of the second commit on this PR's history: the
first approach taken here was a contract-side workaround that retyped aggregate
`is_fresh` allocations, and as @lucasccordeiro showed in review, that cannot
reach a plain `int` buffer. Chasing why led to the domain width. The contract
change is gone; `contracts.cpp` is untouched.

### Scope and risk

The change is global — it affects the index domain of every constant-size
array, not just contract code. Two risks seemed worth closing before asking
anyone to merge it.

**Does a wider domain miss out-of-bounds accesses?** No. The worry was that if
the bounds assertion were emitted *after* the index is cast to the domain
width, then under the old code an index of `16` into `int a[16]` would wrap to
`0` and the overflow would have been silently missed — a false negative, and a
far worse bug than the one being fixed. Measured on both builds, out-of-bounds
writes are caught identically and in-bounds writes still verify:

| | `< sz` | `<= sz` |
|---|---|---|
| `int a[16]` (2⁴), out-of-bounds write | FAILED | FAILED |
| `int a[20]`, out-of-bounds write | FAILED | FAILED |
| `int a[16]`, in-bounds write | SUCCESSFUL | SUCCESSFUL |

So the old behaviour was wrong only in the direction of false positives, and
this PR is a false-positive fix, not a soundness fix. (The likely reason is
that the assertion precedes the cast, but that is an inference from the
behaviour above — I did not confirm it in the code.)

**What does the extra bit cost?** An array filled by a loop, then read at a
symbolic index, `--unwind N+1`:

| N | 2ⁿ? | `< sz` | `<= sz` | Δ |
|---|---|---|---|---|
| 128 | yes | 0.095s | 0.117s | +23% |
| 200 | no | 0.260s | 0.291s | +12% |
| 256 | yes | 0.665s | 0.723s | +8.7% |
| 500 | no | 5.183s | 5.949s | +15% |
| 512 | yes | 5.904s | 6.325s | +7.1% |
| 1000 | no | 53.394s | 58.757s | +10% |
| 1024 | yes | 56.474s | 61.916s | +9.6% |

Read this carefully: the non-power-of-two rows are sizes whose domain width is
*unchanged* by this patch, and they move by the same 10–15%. The deltas are
therefore dominated by run-to-run noise, and the real cost of the extra bit
sits below that noise floor. Single runs, not medians — the honest summary is
"no measurable regression, bounded above by ~10%", and the scaling behaviour is
unchanged (both builds grow with the unwind count, not the index width).

**Regression runs on this branch**, 3314 tests, all green: `esbmc/` 1524/1524
(full label, not sampled), the array-heavy labels `cbmc/` + `cstd/` + `floats/`
+ `k-induction/` + `llvm/` + `csmith/` + `bitwuzla/` + `esbmc-cpp/cpp/` 1395,
`function_contract` 291/291, memory suites 104/104. The `bitwuzla/` label
passing matters here: it shows the parity was not a Z3 artefact.

**What I do not claim.** Plain `malloc` plus a cut loop, with no contracts
involved, does **not** reproduce the original failure. So the narrow domain is
the enabling condition rather than the whole causal chain — the contract path
additionally has to construct the one-past-the-end index. The domain arithmetic
and the A/B above are solid; I have not traced which step builds that index,
and I would rather say so than imply a complete story.
