### PR TITLE
[symex] Fix counterexample trace locations for function calls

### DIFF
--- a/regression/esbmc/function_return_location/main.c
+++ b/regression/esbmc/function_return_location/main.c
@@ -1,0 +1,12 @@
+int Foo(int F_a, int F_b)
+{
+  int F_res = F_a + F_b;
+  return F_res;
+}
+
+int main()
+{
+  int M_x, M_y, M_z;
+  M_z = Foo(M_x, M_y);
+  __ESBMC_assert(M_z == M_x + M_y + 1, "result");
+}

--- a/regression/esbmc/function_return_location/test.desc
+++ b/regression/esbmc/function_return_location/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--no-div-by-zero-check
+^VERIFICATION FAILED$
+State [0-9]+ file \S+main\.c line 10 column 3 function main thread 0\n-+\n  M_z =
+(?s)\A(?!.*line 4 column 3 function Foo.*\n.*\n.*M_z =)

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -267,7 +267,12 @@ void execution_statet::symex_step(reachability_treet &art)
     {
       expr2tc thecode = instruction.code, assign;
       if (make_return_assignment(assign, thecode))
+      {
+        auto saved_source = cur_state->source;
+        cur_state->source = cur_state->top().calling_location;
         goto_symext::symex_assign(assign);
+        cur_state->source = saved_source;
+      }
       symex_return(thecode);
       analyze_assign(assign);
     }

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -606,19 +606,21 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   frame.calling_location = cur_state->source;
   frame.entry_guard = cur_state->guard;
 
-  // assign arguments (goto_function.type is already IREP2)
-  frame.va_index = argument_assignments(
-    identifier, to_code_type(goto_function.type), arguments);
-  frame.va_cursor = frame.va_index;
-
   frame.end_of_function = --goto_function.body.instructions.end();
   frame.return_value = ret_value;
   frame.function_identifier = identifier;
   frame.hidden = goto_function.body.hide;
 
+  // Switch source into the callee before assigning arguments so that formal
+  // parameter assignments are attributed to the callee, not the call site.
   cur_state->source.is_set = true;
   cur_state->source.pc = goto_function.body.instructions.begin();
   cur_state->source.prog = &goto_function.body;
+
+  // assign arguments (goto_function.type is already IREP2)
+  frame.va_index = argument_assignments(
+    identifier, to_code_type(goto_function.type), arguments);
+  frame.va_cursor = frame.va_index;
 }
 
 // True if a function of type `candidate` may be called through a function

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -327,7 +327,10 @@ void goto_symext::symex_step(reachability_treet &art)
       expr2tc thecode = instruction.code, assign;
       if (make_return_assignment(assign, thecode))
       {
+        auto saved_source = cur_state->source;
+        cur_state->source = cur_state->top().calling_location;
         goto_symext::symex_assign(assign);
+        cur_state->source = saved_source;
       }
 
       symex_return(thecode);


### PR DESCRIPTION
Fix two location attribution bugs in the counterexample trace. First, the return value assignment was shown inside the callee instead of at the call site in the caller. Second, formal parameter assignments were shown at the call site instead of inside the callee. A regression test is added to pin the return value fix.