### PR TITLE
[ir-ieee] Preserve sign metadata for negative zero constants

### DIFF
--- a/regression/ir-ra/ra-neg-zero-if-merge-lost-sign/main.c
+++ b/regression/ir-ra/ra-neg-zero-if-merge-lost-sign/main.c
@@ -1,0 +1,34 @@
+extern double __VERIFIER_nondet_double(void);
+extern int __VERIFIER_nondet_int(void);
+extern int __ESBMC_rounding_mode;
+
+int main(void)
+{
+  /* KNOWNBUG: pins a residual gap in negative-zero tracking that is
+   * distinct from, and not fixed by, the literal-constant work in this
+   * suite. z's two possible values (0.0 and -0.0) are assigned in
+   * separate branches of an `if`, so the SSA merge that combines them
+   * goes through the generic conditional/branch-merge machinery, not
+   * through mk_subnormal_flush or the constant-conversion path -- and
+   * that generic merge does not forward negative-zero metadata across
+   * the join. (The superficially similar ternary form `c ? -0.0 : 0.0`
+   * is NOT a counterexample to this: it happens to reach the right
+   * answer only because ESBMC's own constant folder treats +0.0 and
+   * -0.0 as interchangeable, per IEEE 754 ==, and arbitrarily keeps one
+   * branch's identity -- reordering the ternary's branches flips the
+   * result. Neither form is a soundly-handled merge.) */
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN, concrete */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.0);
+  int c = __VERIFIER_nondet_int();
+  double z = 0.0;
+  if (c)
+    z = -0.0;
+  double r = x / z;
+  /* IEEE 754: when c is true, z is -0.0 and r must be -infinity, so this
+   * assertion is false and should be reported as VERIFICATION FAILED.
+   * It currently is not: the lost merge metadata makes z's divisor sign
+   * look unconditionally positive, so r is (wrongly) always +infinity. */
+  __ESBMC_assert(r > 0.0, "if-merged -0.0 must still yield -infinity when divided into");
+  return 0;
+}

--- a/regression/ir-ra/ra-neg-zero-if-merge-lost-sign/test.desc
+++ b/regression/ir-ra/ra-neg-zero-if-merge-lost-sign/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-neg-zero-literal-div-sign-fail/main.c
+++ b/regression/ir-ra/ra-neg-zero-literal-div-sign-fail/main.c
@@ -1,0 +1,24 @@
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  /* Failing companion to ra-neg-zero-literal-div-sign: x is genuinely
+   * nondet, so the division cannot be resolved by ESBMC's own constant
+   * folder and must pass through the actual SMT encoding. */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.0);
+
+  double neg = x / (-0.0);
+
+  /* IEEE 754: positive / -0.0 == -infinity, so this assertion is false
+   * and must be reported as VERIFICATION FAILED. If the negative-zero
+   * metadata were ever dropped (e.g. a future change silently treats a
+   * literal -0.0 as +0.0), this assertion would incorrectly become
+   * true and the test would flip to VERIFICATION SUCCESSFUL -- catching
+   * the regression in the opposite direction from the passing
+   * companion. */
+  __ESBMC_assert(
+    neg > 0.0,
+    "dividing a positive value by literal -0.0 must not give +infinity");
+  return 0;
+}

--- a/regression/ir-ra/ra-neg-zero-literal-div-sign-fail/test.desc
+++ b/regression/ir-ra/ra-neg-zero-literal-div-sign-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-neg-zero-literal-div-sign/main.c
+++ b/regression/ir-ra/ra-neg-zero-literal-div-sign/main.c
@@ -1,0 +1,26 @@
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  /* x is genuinely nondet (not pinned to a specific value), so neither
+   * division below can be resolved by ESBMC's own constant folder --
+   * each is only decidable via the actual SMT encoding, which exercises
+   * the literal zero constants' tracked sign directly (no branching/
+   * merge is needed to reach them, so this stays isolated to the
+   * constant-conversion path). */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.0);
+
+  double neg = x / (-0.0);
+  double pos = x / 0.0;
+
+  /* IEEE 754: positive / -0.0 == -infinity, positive / +0.0 == +infinity.
+   * Checking both in the same program confirms that recording
+   * negative-zero metadata for the -0.0 literal does not also mark the
+   * ordinary +0.0 literal as negative. */
+  __ESBMC_assert(
+    neg < 0.0, "dividing a positive value by literal -0.0 must give -infinity");
+  __ESBMC_assert(
+    pos > 0.0, "dividing a positive value by literal +0.0 must give +infinity");
+  return 0;
+}

--- a/regression/ir-ra/ra-neg-zero-literal-div-sign/test.desc
+++ b/regression/ir-ra/ra-neg-zero-literal-div-sign/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-neg-zero-literal-signbit/main.c
+++ b/regression/ir-ra/ra-neg-zero-literal-signbit/main.c
@@ -1,0 +1,25 @@
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  /* IEEE 754: a literal -0.0 constant has its sign bit set, so
+   * signbit(-0.0) must be nonzero. q = x / z gives z a use beyond the
+   * signbit check itself; whether that is enough to keep z's conversion
+   * off ESBMC's own constant-folding path is build/platform dependent
+   * and not something this test asserts either way -- it only asserts
+   * the IEEE 754 semantic property.
+   *
+   * Use __builtin_signbit rather than <math.h>'s signbit: on some
+   * platforms (e.g. macOS) the latter expands to a libm inline that does
+   * its own bit-twiddling and never reaches convert_signbit, so a test
+   * written with signbit would silently fail to exercise this path. */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.0);
+  double z = -0.0;
+  double q = x / z;
+  (void)q;
+  __ESBMC_assert(
+    __builtin_signbit(z) != 0,
+    "a literal -0.0 constant must report a negative sign bit");
+  return 0;
+}

--- a/regression/ir-ra/ra-neg-zero-literal-signbit/test.desc
+++ b/regression/ir-ra/ra-neg-zero-literal-signbit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/ra-neg-zero-ternary-order-lost-sign/main.c
+++ b/regression/ir-ra/ra-neg-zero-ternary-order-lost-sign/main.c
@@ -1,0 +1,32 @@
+extern double __VERIFIER_nondet_double(void);
+extern int __VERIFIER_nondet_int(void);
+extern int __ESBMC_rounding_mode;
+
+int main(void)
+{
+  /* KNOWNBUG: companion to ra-neg-zero-if-merge-lost-sign, pinning the
+   * other branch order of the same underlying gap. z's two possible
+   * values (0.0 and -0.0) come from a C ternary rather than an if/else,
+   * but negative-zero metadata is still lost across the merge here: with
+   * this specific branch order, ESBMC's own constant folder (which
+   * treats +0.0 and -0.0 as interchangeable, per IEEE 754 ==) keeps the
+   * +0.0 branch's identity. Reversing the branch order
+   * (c ? -0.0 : 0.0, see ra-neg-zero-literal-div-sign's sibling
+   * investigation) happens to keep the -0.0 branch's identity instead
+   * and gives the correct answer by the same coincidence -- neither
+   * order is a soundly-handled merge. */
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN, concrete */
+  double x = __VERIFIER_nondet_double();
+  __ESBMC_assume(x > 0.0);
+  int c = __VERIFIER_nondet_int();
+  double z = c ? 0.0 : -0.0;
+  double r = x / z;
+  /* IEEE 754: when c is false, z is -0.0 and r must be -infinity, so
+   * this assertion is false and should be reported as VERIFICATION
+   * FAILED. It currently is not: the lost merge metadata makes z's
+   * divisor sign look unconditionally positive, so r is (wrongly)
+   * always +infinity. */
+  __ESBMC_assert(
+    r > 0.0, "ternary-merged -0.0 must still yield -infinity when divided into");
+  return 0;
+}

--- a/regression/ir-ra/ra-neg-zero-ternary-order-lost-sign/test.desc
+++ b/regression/ir-ra/ra-neg-zero-ternary-order-lost-sign/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/src/solvers/smt/fp/ir_ieee_conv.cpp
+++ b/src/solvers/smt/fp/ir_ieee_conv.cpp
@@ -662,9 +662,10 @@ smt_astt ir_ieee_convt::encode_ieee_div(const expr2tc &expr)
   // IEEE 754: the sign of x / +-0 is sign(x) XOR sign of the zero divisor.
   // side2 is a bare real zero here (div_by_zero requires side2 == zero),
   // which cannot carry its own sign, so the divisor's sign is recovered
-  // from its tracked negative-zero predicate (set only when side2 is the
-  // result of flushing a negative subnormal-range value); absent that
-  // predicate, side2 is treated as ordinary +0.0, matching prior behaviour.
+  // from its tracked negative-zero predicate (set when side2 is the
+  // result of flushing a negative subnormal-range value, or is itself a
+  // literal -0.0 constant); absent that predicate, side2 is treated as
+  // ordinary +0.0, matching prior behaviour.
   smt_astt side1_neg = ctx->mk_lt(side1, zero);
   smt_astt side2_neg_zero = get_neg_zero_pred(side2);
   smt_astt result_neg =

--- a/src/solvers/smt/fp/ir_ieee_conv.h
+++ b/src/solvers/smt/fp/ir_ieee_conv.h
@@ -96,20 +96,28 @@ public:
    *  mk_or(a, b) if both are set. */
   smt_astt combine_nan_preds(smt_astt a, smt_astt b) const;
 
-  /** Record that the SMT AST t is a real zero produced by flushing a
-   *  negative subnormal-range result (smt_solver_baset::mk_subnormal_flush).
-   *  neg_zero_pred is a boolean SMT term that is true iff t stands for
-   *  IEEE 754 -0.0. This tracks only the negative-zero case arising from
-   *  subnormal flushing, not general signed-zero semantics. */
+  /** Record a predicate that is true iff the SMT AST t represents
+   *  IEEE 754 -0.0. Such predicates originate when a negative
+   *  subnormal-range result is flushed to zero and when a literal
+   *  negative-zero float constant is converted, and may subsequently
+   *  be propagated through assignments or wrapper terms. This does not
+   *  implement general signed-zero semantics. */
   void store_neg_zero_pred(smt_astt t, smt_astt neg_zero_pred);
 
-  /** Return the stored negative-zero predicate for t, or nullptr if t is
-   *  not known to be a flushed negative zero. */
+  /** Return the stored negative-zero predicate for t, or nullptr if no
+   *  negative-zero metadata is recorded for t. */
   smt_astt get_neg_zero_pred(smt_astt t) const;
 
   /** Propagate a negative-zero predicate from rhs to lhs after an SSA
    *  assignment. Called from smt_solver_baset::convert_assign alongside
-   *  propagate_interval and propagate_nan_pred. */
+   *  propagate_interval and propagate_nan_pred.
+   *
+   *  One-way: if rhs carries no predicate, any existing entry already
+   *  recorded for lhs is left in place rather than cleared. This is
+   *  harmless under SSA, where each assignment gives lhs a fresh AST
+   *  with no prior entry of its own, but callers reusing an AST across
+   *  more than one assignment should not assume this clears stale
+   *  metadata. */
   void propagate_neg_zero_pred(smt_astt lhs, smt_astt rhs);
 
   /** Re-attach inner's negative-zero predicate (if any) to outer, guarded
@@ -175,10 +183,24 @@ private:
   std::unordered_map<const smt_ast *, smt_astt> ir_ieee_nan_map;
 
   /** Map from AST pointer to its negative-zero predicate (a boolean SMT
-   *  term that is true iff the value is a real zero produced by flushing
-   *  a negative subnormal-range result). Populated only by
-   *  smt_solver_baset::mk_subnormal_flush; an absent entry means that no
-   *  flushed-negative-zero metadata is recorded for the value. */
+   *  term that is true iff the value stands for IEEE 754 -0.0). Predicates
+   *  originate when a negative subnormal-range result is flushed to zero
+   *  (smt_solver_baset::mk_subnormal_flush) and when a literal
+   *  negative-zero float constant is converted
+   *  (smt_solver_baset::convert_terminal's constant_floatbv_id case), and
+   *  may subsequently be propagated through assignments or wrapper terms;
+   *  an absent entry means that no negative-zero metadata is recorded for
+   *  the value.
+   *
+   *  Lifetime: keyed on raw AST pointers and never pruned, but
+   *  smt_solver_baset::pop_ctx() deletes every AST created since the
+   *  matching push_ctx(). A pop can therefore leave both a key and its
+   *  stored predicate value dangling; a later lookup that hits such an
+   *  entry would hand a freed AST to a consumer. This exposure predates
+   *  this map (ir_ieee_nan_map above has the same shape and is subject
+   *  to the same limitation) and is not specific to negative-zero
+   *  tracking, but is noted here since this map's population grows with
+   *  every literal negative-zero constant converted. */
   std::unordered_map<const smt_ast *, smt_astt> ir_ieee_neg_zero_map;
 
   /** Set of symbol names that have already received integer range assertions,

--- a/src/solvers/smt/smt_fp_conv.cpp
+++ b/src/solvers/smt/smt_fp_conv.cpp
@@ -828,9 +828,10 @@ smt_astt smt_solver_baset::convert_signbit(const expr2tc &expr)
     // We can't extract bits, so check the sign mathematically
     is_neg = mk_lt(value, mk_smt_real("0"));
 
-    // A value flushed to zero from a negative subnormal-range result is
-    // IEEE 754 -0.0, but the real zero it collapsed to carries no sign of
-    // its own; consult the tracked negative-zero predicate to recover it.
+    // A value flushed to zero from a negative subnormal-range result, or
+    // a literal -0.0 constant, is IEEE 754 -0.0, but the real zero used
+    // to represent it carries no sign of its own; consult the tracked
+    // negative-zero predicate to recover it.
     smt_astt neg_zero_pred = ir_ieee_api->get_neg_zero_pred(value);
     if (neg_zero_pred)
       is_neg = mk_or(is_neg, neg_zero_pred);

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -2016,7 +2016,29 @@ smt_astt smt_solver_baset::convert_terminal(const expr2tc &expr)
     if (int_encoding)
     {
       if (thereal.value.is_zero())
+      {
+        // A literal -0.0 constant is a second source of IEEE 754 negative
+        // zero, alongside the subnormal-flush case handled by
+        // mk_subnormal_flush. Reuse the same neg_zero_pred side-channel
+        // rather than adding new tracking machinery -- but tag a fresh
+        // symbol constrained equal to zero, not the shared mk_smt_real("0")
+        // AST directly: nothing guarantees mk_smt_real returns a distinct
+        // pointer per call (see its declaration), so tagging the literal
+        // itself could let an ordinary +0.0 silently inherit this
+        // predicate if any backend ever memoises real constants by value.
+        // Mirrors the NaN branch below, which mints mk_fresh(...) for the
+        // same reason.
+        if (ir_ieee && thereal.value.get_sign())
+        {
+          smt_astt neg_zero_ast =
+            mk_fresh(mk_real_sort(), "ir_ieee::neg_zero_const::", nullptr);
+          smt_astt is_zero = mk_eq(neg_zero_ast, mk_smt_real("0"));
+          assert_ast(is_zero);
+          ir_ieee_api->store_neg_zero_pred(neg_zero_ast, is_zero);
+          return neg_zero_ast;
+        }
         return mk_smt_real("0");
+      }
       if (thereal.value.is_NaN())
       {
         if (ir_ieee)

--- a/src/solvers/smt/smt_solver.h
+++ b/src/solvers/smt/smt_solver.h
@@ -432,7 +432,16 @@ public:
    *         Tends to be one integer divided ('/') by another. After inspecting
    *         all other options, there are none that are good, this is a
    *         legitimate use of strings.
-   *  @return The newly created terminal smt_ast of this real. */
+   *  @return An SMT AST representing this real value.
+   *
+   *  No backend is required to return a distinct smt_ast * per call: a
+   *  backend that memoises real constants by value (a natural
+   *  optimisation) is free to hand back the same pointer for repeated
+   *  calls with the same str. Do not key identity-sensitive metadata
+   *  (e.g. AST-pointer-keyed side-channel maps) directly on the result of
+   *  this call unless the value is known to be one this call site
+   *  exclusively owns; mint a fresh symbol (mk_fresh) and constrain it
+   *  equal to the desired real value instead. */
   virtual smt_astt mk_smt_real(const std::string &str) = 0;
 
   // Returns SMT AST representing real zero


### PR DESCRIPTION
## Summary

This PR preserves the IEEE-754 sign of literal negative-zero floating-point constants in the `--ir-ieee` encoding.

In the integer/real encoding, both `+0.0` and `-0.0` have the same numerical SMT real value, `0`. Previously, converting a literal `-0.0` discarded its sign in the SMT representation, so sign-sensitive operations reaching the `--ir-ieee` encoding could not distinguish it from `+0.0`.

This PR extends the existing negative-zero metadata mechanism to literal `-0.0` constants while keeping the metadata attached to an identity-distinct SMT AST.

## Motivation

The previous negative-zero work introduced side metadata for negative zeros produced by subnormal flush-to-zero. Consumers such as division by zero and `signbit` can use that metadata to recover the sign that is absent from the underlying SMT real value.

Literal `-0.0` constants were still converted directly to an ordinary real zero:

```cpp
if (thereal.value.is_zero())
  return mk_smt_real("0");
```

As a result, operations that reached the SMT encoding could not distinguish a literal `-0.0` from `+0.0`.

For example, IEEE-754 requires:

```c
positive_value / -0.0 == -infinity
positive_value / +0.0 == +infinity
```

The negative-zero metadata map is keyed by SMT AST identity, so attaching metadata directly to `mk_smt_real("0")` would also rely on an unsafe assumption that repeated real constants always receive distinct wrapper ASTs. This PR avoids that dependency.

## Changes

- When converting a literal `-0.0`:
  - create a fresh real AST;
  - constrain that AST equal to real zero;
  - attach the existing negative-zero metadata to the fresh AST rather than to the ordinary `mk_smt_real("0")` constant.

- Reuse the zero-equality constraint as the negative-zero predicate rather than allocating a separate constant-true boolean AST.

- Leave ordinary `+0.0` constants untagged.

- Reuse the existing negative-zero metadata infrastructure without introducing a new tracking mechanism.

- Update the related documentation to clarify:
  - the current sources of negative-zero metadata;
  - that callers must not rely on `mk_smt_real` returning pointer-distinct ASTs for repeated constants;
  - the raw-AST-pointer lifetime limitation across `pop_ctx()`;
  - the one-way behaviour of assignment metadata propagation.

## Regression Tests

The existing literal division regression checks both zero signs using a symbolic positive numerator:

```c
double neg = x / (-0.0);
double pos = x / 0.0;

__ESBMC_assert(neg < 0.0, ...);
__ESBMC_assert(pos > 0.0, ...);
```

This verifies that a literal `-0.0` produces negative infinity while an ordinary `+0.0` does not accidentally acquire negative-zero metadata.

Additional coverage includes:

- `ra-neg-zero-literal-div-sign-fail`
  - failing companion for the literal negative-zero division case.

- `ra-neg-zero-literal-signbit`
  - covers the `__builtin_signbit` consumer for literal negative zero.

Two residual merge cases are also pinned as KNOWNBUG regressions:

- `ra-neg-zero-if-merge-lost-sign`
- `ra-neg-zero-ternary-order-lost-sign`

These document cases where negative-zero metadata is not yet propagated soundly through control-flow or conditional merges.

## Testing

The literal division regression and its failing companion pass with their expected verdicts.

The implementation was also tested with `z3_convt::mk_smt_real` temporarily memoised by string, reproducing the AST-sharing scenario identified during review. Under that setup, the `-0.0` and `+0.0` division results remained correctly distinguished.

The temporary memoisation change was reverted after testing.

The literal division regression was additionally checked with:

```text
--smt-symex-assert
--incremental-bmc
--multi-property
```

All three modes completed with `VERIFICATION SUCCESSFUL`.

Full `ir-ra` suite: 255/255 passed.

`regression/esbmc/github_2572`: passed.

`clang-format-11` and `git diff --check`: clean.

## Scope

This PR only adds direct literal negative-zero constants as another producer of the existing metadata.

It does not implement general IEEE-754 signed-zero semantics or sound propagation of negative-zero metadata through control-flow or conditional merges.

In particular, both statement-level `if` merges and conditional `?:` expressions still have cases where negative-zero sign metadata is lost or becomes branch-order dependent. These residual cases are documented by KNOWNBUG regressions and remain separate follow-up work.

The existing raw-AST-pointer metadata lifetime issue across `pop_ctx()` is also not addressed by this PR; it predates this change and affects other side metadata using the same representation.