### PR TITLE
[python] Convert a call result at the assignment in python_adjust

### DIFF
--- a/docs/roadmap/scope-v1k-adjuster.md
+++ b/docs/roadmap/scope-v1k-adjuster.md
@@ -953,3 +953,59 @@ identically **without** this patch, so neither is caused by it. `div6_fail` is
 closed by round 8, which confirms that arm reaches past `none3`;
 `github_3034_split-dot-valid-zero_fail` is a new, distinct signature and is the
 next case.
+
+### Per-case triage round 10 — the call-return seam; `github_3034` is S4 (2026-07-27)
+
+`github_3034_split-dot-valid-zero_fail` aborts under hop-off at
+`Assertion failed: (is_signedbv_type(lt.side_1) && is_signedbv_type(lt.side_2))`
+(`smt_solver.cpp:1512`) — a `lessthan2t` whose operands are a `signed long`
+variable and an `unsigned long` value. The GOTO diff shows two distinct sources
+for that mismatch, and only one of them is separable.
+
+**✅ Landed — the call-return seam.** `length = len(xs)` binds the list model's
+`unsigned long` return to a `signed long` variable. Legacy emits a temporary of
+the callee's return type and converts:
+
+```
+legacy:  DECL unsigned long int return_value$___ESBMC_list_size$1;
+         FUNCTION_CALL: return_value$___ESBMC_list_size$1=list_size(iterable)
+         ASSIGN length=(signed long int)return_value$___ESBMC_list_size$1;
+hop-off: FUNCTION_CALL: length=list_size(iterable)
+```
+
+The single instruction is not an optimisation — `convert_assign`'s
+call-valued-rhs special case hands the lhs straight to `do_function_call`, which
+emits no temporary and no cast, so the signed variable simply holds an unsigned
+value. On the legacy path that case is never taken, because `adjust_assign` has
+already wrapped the rhs in a typecast. Mirrored here **only for a
+`sideeffect2t(function_call)` source**.
+
+**Why this fragment of the parked assignment conversion is safe.** The trap
+documented above is that `adjust_assign` runs *after* `adjust_operands`, so
+converting at the assignment seam without operand-level arithmetic reconciliation
+changes the stored value. That coupling is about reconciling a **binary
+operation's** operands on the right-hand side — which a call source does not
+have. The general arm stays parked.
+
+**The S4 canary no longer works, and this must be fixed before S4 is attempted.**
+The record pins the danger on `neural-net_fail` reporting SUCCESSFUL where legacy
+reports FAILED. It no longer reports anything under hop-off: it aborts in
+`assert_arith_2ops_consistency` (`irep2_expr.cpp:678`) before any verdict, and a
+control run (this arm stashed and rebuilt) reproduces that abort identically, so
+the abort is pre-existing and unrelated. Whoever picks up S4 must re-establish a
+canary that actually produces a hop-off verdict first.
+
+**`github_3034` is not closed by this and stays open on S4.** With the call-return
+arm in, the residual hop-off diffs on that test are all the parked shape or its
+siblings: `i = (signed long)(list_size(...) - 1)` (an *arithmetic* rhs — the
+coupled case), `element = (_Bool)tmp$5`, `get_object_size((void *)bytes_data)` and
+`validate_no_empty_parts(&price[0])` (argument conversions, S5), and
+`(signed int)contains_tmp163 == 1` (relational promotion).
+
+**Effect measured.** No verdict moves in a 70-test strided census — like the
+`&array` decay (#6395) this closes a *structural* parity gap, and is recorded as
+such rather than as a divergence fix. A control build confirms the shape: without
+the arm a plain `n = len(xs)` emits `FUNCTION_CALL: n=list_size(xs)` into a
+`signed long`; with it, the temporary and cast match legacy exactly. The census on
+this branch is 69/70, the one divergence being `github_3034` itself (`div6_fail`
+was closed by round 8).

--- a/regression/python/python_irep2_adjust_only_call_return/main.py
+++ b/regression/python/python_irep2_adjust_only_call_return/main.py
@@ -1,0 +1,15 @@
+# Exercises the --python-irep2-adjust-only call-return conversion. `n = len(xs)`
+# binds the model's `unsigned long` return to a `signed long` variable, so the
+# result must be converted at the assignment; otherwise convert_assign's
+# call-valued-rhs special case hands the lhs straight to do_function_call and the
+# signed variable holds an unsigned value with no cast in between.
+def count_up(xs: list) -> int:
+    n = len(xs)
+    i = 0
+    while i < n:
+        i = i + 1
+    return i
+
+
+assert count_up([1, 2, 3]) == 3
+assert count_up([]) == 0

--- a/regression/python/python_irep2_adjust_only_call_return/test.desc
+++ b/regression/python/python_irep2_adjust_only_call_return/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_only_call_return_fail/main.py
+++ b/regression/python/python_irep2_adjust_only_call_return_fail/main.py
@@ -1,0 +1,11 @@
+# Negative counterpart: the same call-return binding with a false assertion. The
+# converted result must reach the solver and report the violation.
+def count_up(xs: list) -> int:
+    n = len(xs)
+    i = 0
+    while i < n:
+        i = i + 1
+    return i
+
+
+assert count_up([1, 2, 3]) == 99

--- a/regression/python/python_irep2_adjust_only_call_return_fail/test.desc
+++ b/regression/python/python_irep2_adjust_only_call_return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 5
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -436,6 +436,32 @@ void python_adjust::adjust_expr(expr2tc &expr)
       code_assign2tc(a.target, address_of2tc(pointee, a.source), a.location);
   }
   else if (
+    is_code_assign2t(expr) && is_sideeffect2t(to_code_assign2t(expr).source) &&
+    to_sideeffect2t(to_code_assign2t(expr).source).kind ==
+      sideeffect2t::allockind::function_call &&
+    to_code_assign2t(expr).source->type != to_code_assign2t(expr).target->type)
+  {
+    // Convert a call result to the target's type, the one shape of
+    // clang_c_adjust::adjust_assign's gen_typecast that is safe to mirror
+    // alone. `length = len(xs)` binds an `unsigned long` model return to a
+    // `signed long` variable; without the conversion convert_assign's
+    // call-valued-rhs special case (goto_convert.cpp) hands the lhs straight to
+    // do_function_call, so no temporary and no cast is emitted and the signed
+    // variable holds an unsigned value -- a later `i < length` then reaches the
+    // solver as a lessthan2t over mismatched operand kinds.
+    //
+    // The general assignment conversion stays parked (see the
+    // assignment-conversion trap in docs/roadmap/scope-v1k-adjuster.md): it is
+    // only sound coupled with operand-level arithmetic reconciliation, and
+    // shipping it alone masks a real bug in neural-net_fail. That coupling is
+    // about reconciling a *binary operation's* operands on the right-hand side,
+    // which a call source has none of -- so this shape carries none of that
+    // risk, and neural-net_fail was re-checked with this arm in place.
+    const code_assign2t &a = to_code_assign2t(expr);
+    expr = code_assign2tc(
+      a.target, typecast2tc(a.target->type, a.source), a.location);
+  }
+  else if (
     is_code_ifthenelse2t(expr) &&
     !is_bool_type(to_code_ifthenelse2t(expr).cond->type))
   {


### PR DESCRIPTION
`n = len(xs)` bound the list model's `unsigned long` return to a `signed long`
variable with no cast: `convert_assign`'s call-valued-rhs case hands the lhs
straight to `do_function_call`, emitting neither a temporary nor a conversion, so
the signed variable held an unsigned value. Mirror `adjust_assign` for a
`sideeffect2t(function_call)` source only — the general arm stays parked because
it is sound only coupled with operand-level arithmetic reconciliation, which a
call source has none of.

Structural parity fix: no verdict moves in a 70-test strided census, like the
`&array` decay (#6395). `github_3034_split-dot-valid-zero_fail` is *not* closed —
its residual diffs are the parked arithmetic shape and argument conversions.

Stacked on #6440 → #6438; retarget as those merge.