### PR TITLE
[docs] goto-symex verification plan: execute milestone M0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -208,6 +208,21 @@ jobs:
           cmakelint --config=.config/cmakelintrc "${files[@]}"
 
 
+  # Fail when a goto-symex verification harness no longer matches the source it
+  # transcribes (docs/roadmap/goto-symex-verification-plan.md §11.5).
+  symex-harness-drift:
+    name: Check goto-symex harness drift
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - name: Run drift check
+        run: python3 scripts/verification/symex/drift_check.py
+
+
   # Check project with YAPF
   python-style:
       name: Check Python code style (YAPF)

--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -6,7 +6,8 @@ SMT backend.
 **Verifier:** ESBMC itself (BMC + k-induction) on extracted kernels; Catch2
 property/differential tests on the real classes (`unit/goto-symex/`);
 whole-tool metamorphic oracles over `regression/`; sanitizers for the rest.
-**Status:** **M0 complete** (§15 verdict log); M1–M8 not yet executed. Except
+**Status:** **M0 complete, M1 partial** (§15 verdict log); M2–M8 not yet
+executed. §6.4 records the tier-ordering rule M1 produced. Except
 where §15 records a discharged result, every harness below is a *proposal* and
 nothing here asserts a proof. Findings R1–R12 remain *hypotheses with cited
 evidence*, not confirmed end-to-end bugs.
@@ -397,6 +398,35 @@ A forbidden-assumption list, enforced at review:
 - ✗ `assume(single thread)` in any harness whose property is claimed for
   concurrent runs.
 
+### 6.4 Tier B first — a rule learned from M1
+
+The tier table in §2.2 lists A before B, and M0/M1 read that as an ordering.
+It is not one. **Tier A proves things about a transcription; only Tier B and
+Tier C observe the shipped C++.** A Tier-A harness is therefore justified only
+when a property cannot be observed from outside the engine — and §15's M1 entry
+shows the cost of ignoring that: the moment H-A1's stub grew from an array index
+to the real `name_record` key behind a hash-probed map, it went from 163 VCCs
+and 4 s to 4371 VCCs and no verdict inside the plan's own 30 s budget. Fidelity
+to the real key and ESBMC-tractability pull in opposite directions, so a Tier-A
+harness faithful enough to be worth trusting is often one ESBMC cannot discharge.
+
+The rule for every remaining harness in §7:
+
+1. **Ask what the equation already shows.** Any property expressible over the
+   `symex_target_equationt` the engine actually produced — SSA well-formedness,
+   phi counts, slicer equisatisfiability, determinism — belongs in
+   `unit/goto-symex/`, with zero modelling and zero drift.
+2. **Then ask what a whole-tool oracle shows** (§7.4), for composition
+   properties over the 1400 `regression/esbmc` CORE inputs.
+3. **Only then write Tier A**, for internal decisions the equation does not
+   expose (the held-reference hazard of R3, a `previous_frame` precondition, an
+   MPOR independence relation), and keep the stub at the smallest fidelity the
+   property observes — a Tier-A harness that times out proves nothing at all.
+
+§11.3's acceptance criteria already say "timed out is never SUCCESSFUL". This
+section says the same thing one step earlier: prefer the tier that cannot time
+out, and cannot drift.
+
 ---
 
 ## 7. Proposed harnesses
@@ -680,6 +710,11 @@ Retires I1/I2/I16; produces the R3 and R7 verdicts. In parallel: **WI-3**
 (`initializer_list` / `iterator_traits` / `this_thread` / `aligned_storage`),
 which completes the parse path to `renaming.h`. *Artefact:* three Tier-A harness
 pairs + the R3 restructure PR if H-A9 confirms the hazard; WI-2/WI-3 merged.
+**Revised, §15 M1.** H-A1's Tier-A form was built and **rejected on
+tractability** — see §15 and the rule it produced in §6.4. I1/I10/P11 are
+instead discharged against the *real* `goto_symext` by H-B1
+(`unit/goto-symex/ssa_wellformed.test.cpp`). H-A9 and H-A7 remain open and are
+the next M1 work; both are re-scoped Tier-B-first per §6.4.
 
 **M2 — Isolated core algorithms: merging and bounding (1.5 wk).**
 H-A2 (the highest-value harness), H-A3, H-A5. Dual-solver mandatory.
@@ -737,7 +772,7 @@ regression/esbmc/symex_<area>_<nn>/           Tier A, passing — owns the kerne
     └── test.desc
 regression/esbmc/symex_<area>_<nn>_fail/      Tier A, anti-vacuity twin (§6.1 r5)
 regression/esbmc/symex_<area>_<nn>_probe/     Tier A, reachability probe (§6.1 r6)
-unit/goto-symex/<area>.test.cpp               Tier B  (wire in CMakeLists.txt)
+unit/goto-symex/<area>.test.cpp               Tier B — prefer this, see §6.4
 scripts/verification/symex/
     ├── oracle_slice_parity.sh                H-C1
     ├── oracle_simplify_parity.sh             H-C2
@@ -1052,6 +1087,70 @@ node ids. H-A1 (M1) subsumes it.
 **Carried into M1.** WI-1 (`<shared_mutex>`), WI-2 (`<type_traits>` completion)
 and D12 (issues G1–G8) were scheduled for M0 and are not started.
 
+### M1 — 2026-07-27
+
+**Result: I1, I10 and P11 discharged against the real engine.** Not by a
+transcription — by running the real `goto_symext` and validating the
+`symex_target_equationt` it produced.
+
+| Artefact | What it drives | Result |
+|---|---|---|
+| `unit/goto-symex/ssa_wellformed.test.cpp` (H-B1) | real `goto_factory` → real `reachability_treet` → real `goto_symext`, over straight-line, branching, nested-branch, unwound-loop, and call/recursion programs | 6 cases, 37 assertions, **pass**, 1.6 s |
+
+Properties checked on every produced equation:
+
+- **I1 / P8** — per `(base_name, l1_num, thread_num)`, the L2 index of each
+  definition strictly increases in equation order.
+- **I10 / P11** — no two assignment steps define the same SSA name. This is the
+  invariant `check_for_duplicate_assigns` exists for and never enforces (R5);
+  the validator is the enforcing version R5 asks for.
+- **P11** — no step reads an SSA name before the step defining it. A name never
+  defined in the equation is a free symbol and is correctly not a violation.
+
+Anti-vacuity: the last case takes an equation the engine produced, appends a
+copy of one of its own assignment steps, and requires the validator to report
+exactly one duplicate definition and one non-monotonic index. Without it the
+five passing cases would be indistinguishable from a validator that checks
+nothing.
+
+**One harness-side defect found and fixed, no engine defect.** The first run
+reported use-before-def on every first definition. Cause: for an assignment
+step, `symex_target_equationt::assignment` sets
+`SSA_step.cond = equality2tc(lhs, rhs)`, so reading `cond` on an assignment
+reports the definition as a use of itself. The reads of an assignment are in
+its `rhs`; `cond` is for assume/assert steps. Recorded because it is the exact
+failure mode a Tier-A transcription would have hidden — a stub has no `cond`
+field to get wrong.
+
+**Rejected: H-A1 as a Tier-A harness.** Built as specified in §7.1 — the full
+`name_record` key `(base_name, lev, l1_num, t_num)`, `hash` modelled as an
+arbitrary function of those fields so collisions stay possible, and a
+linear-probed map, at 3 assignments over a 16-key space. Measured:
+
+| Harness | VCCs | Wall | Verdict |
+|---|---|---|---|
+| `symex_ssa_00` (M0 template, array-indexed key) | 163 | 4 s | `SUCCESSFUL` |
+| H-A1 Tier-A (real `name_record` key, hash-probed map) | 4371 | **> 200 s** | none |
+| H-A1 `_fail` twin | 4368 | 108 s | `FAILED` |
+
+Rejected under §11.3 criterion 1 (no verdict) and the §11.2 budget (< 30 s per
+harness; the regression harness cap is a hard 120 s). Not committed. The green
+harness never returned, so it proves nothing — while the `_fail` twin returning
+`FAILED` in half the time is the shape you would expect: finding one violating
+trace is easy, proving none exists is not.
+
+The general lesson is written up as §6.4: raising a Tier-A stub's fidelity
+toward the real data structure raises its cost superlinearly, so the tier that
+verifies the shipped C++ is also the tier that scales. §6.4 reorders the
+remaining harness work accordingly.
+
+**Carried into the next M1 slice.** H-A9 (I2/R3, the `valuet &entry` reference
+held across `rename`) and H-A7 (I16/R7, `previous_frame` on a stack of size < 2)
+are unstarted and now Tier-B-first. R7's single call site,
+`symex_function.cpp::goto_symext::symex_function_call_code`, does
+`new_frame(...)` immediately before `previous_frame()`, so the precondition
+holds — but only because of an `assert` that is a no-op in release (R1). Also
+still open from M0: WI-1, WI-2, D12.
 ---
 
 ## Appendix A — Methodological basis

--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -6,9 +6,10 @@ SMT backend.
 **Verifier:** ESBMC itself (BMC + k-induction) on extracted kernels; Catch2
 property/differential tests on the real classes (`unit/goto-symex/`);
 whole-tool metamorphic oracles over `regression/`; sanitizers for the rest.
-**Status:** Plan / **not yet executed**. Every harness below is a *proposal*;
-nothing here asserts a proof has been discharged. Findings R1–R12 are
-*hypotheses with cited evidence*, not confirmed end-to-end bugs.
+**Status:** **M0 complete** (§15 verdict log); M1–M8 not yet executed. Except
+where §15 records a discharged result, every harness below is a *proposal* and
+nothing here asserts a proof. Findings R1–R12 remain *hypotheses with cited
+evidence*, not confirmed end-to-end bugs.
 **Audience:** An engineer who will implement the harnesses and run the
 verification tasks directly from this document.
 **Companion:** `docs/irep2-verification-plan.md` (branch
@@ -663,7 +664,7 @@ no milestone depends on a later one. The ESBMC extension work items (WI-1…WI-6
 §13.6) run **in parallel** with this track: no property claimed in §8 is blocked
 on them.
 
-**M0 — Infrastructure (0.5 wk).**
+**M0 — Infrastructure (0.5 wk). — DONE, see §15.**
 Re-enable `unit/goto-symex/CMakeLists.txt` (fix the `symex;solvers;
 gotoalgorithms;pointeranalysis;util_esbmc;langapi` link set). Stand up the
 `regression/esbmc/symex_*` harness skeleton + `test.desc` template. Land the
@@ -671,6 +672,8 @@ drift-check script. In parallel, start **WI-1** (`<shared_mutex>` operational
 model) and **WI-2** (`<type_traits>` completion), and file G1–G8 as issues (D12).
 *Artefact:* one green + one deliberately-red smoke harness proving the pipeline
 detects an injected bug; a building `unit/goto-symex` target; WI-1 merged.
+*Delivered:* the harness triple, the drift guard + its PR gate, and the
+`unit/goto-symex` target. WI-1/WI-2 and D12 remain open and move to M1.
 
 **M1 — Low-level kernels: SSA algebra (1 wk).** H-A1, H-A9, H-A7.
 Retires I1/I2/I16; produces the R3 and R7 verdicts. In parallel: **WI-3**
@@ -728,11 +731,12 @@ the plan and can be run opportunistically from M0.
 ### 11.1 Organisation and naming
 
 ```
-docs/roadmap/goto-symex-verification-plan.md  this document (+ verdict log, §9.2/§10)
-regression/esbmc/symex_<area>_<nn>/           Tier A, passing
+docs/roadmap/goto-symex-verification-plan.md  this document (+ verdict log, §15)
+regression/esbmc/symex_<area>_<nn>/           Tier A, passing — owns the kernel
     ├── symex_<area>_<nn>.c
     └── test.desc
-regression/esbmc/symex_<area>_<nn>_fail/      Tier A, anti-vacuity twin
+regression/esbmc/symex_<area>_<nn>_fail/      Tier A, anti-vacuity twin (§6.1 r5)
+regression/esbmc/symex_<area>_<nn>_probe/     Tier A, reachability probe (§6.1 r6)
 unit/goto-symex/<area>.test.cpp               Tier B  (wire in CMakeLists.txt)
 scripts/verification/symex/
     ├── oracle_slice_parity.sh                H-C1
@@ -745,7 +749,20 @@ scripts/verification/symex/
 ```
 
 `<area>` ∈ `{ssa, merge, mergequeue, slice, unwind, mpor, frame, eqctx,
-lookup, refalias}` — one area per harness family, matching §7.
+lookup, refalias}` — one area per harness family, matching §7. `<nn> = 00` is
+the M0 template.
+
+The `_fail` and `_probe` directories hold a one-line
+`#include "../symex_<area>_<nn>/symex_<area>_<nn>.c"` and select their variant
+with `-DSYMEX_HARNESS_PERTURB` / `-DSYMEX_HARNESS_PROBE` on `test.desc` line 3.
+The kernel therefore has exactly one copy: a twin cannot silently stop
+perturbing the code it is meant to perturb.
+
+Every harness citing `src/goto-symex` carries, in its header comment, one
+`SYMEX-HARNESS-TARGET: <path>::<symbol>` line per transcribed symbol and a
+`SYMEX-HARNESS-SHA256:` line holding the checksum of that symbol's definition.
+`drift_check.py` re-extracts and re-hashes each; `--update` refreshes them after
+a reviewed re-transcription.
 
 ### 11.2 CI integration
 
@@ -822,7 +839,7 @@ for what is claimed; a claim may not outlive its harness.
 | **D8** | Tier-C oracle scripts + scheduled workflow | `scripts/verification/symex/`, `.github/workflows/symex-oracles.yml` | M5, M7 |
 | **D9** | `SYMEX_INVARIANT` release-checked macro + promoted invariants + cost benchmark | `src/goto-symex/` | M3 |
 | **D10** | Fix PRs for confirmed findings (R2–R5, R7, R10 are tractable; R6/R8/R11 are investigations first) | code PRs, each with Mode-C proof where a branch changes | M1–M6 |
-| **D11** | Verdict log — per-harness result, ESBMC commit, solver versions, date — appended to this document | §9.2 / §10 | continuous |
+| **D11** | Verdict log — per-harness result, ESBMC commit, solver versions, date — appended to this document | §15 | continuous |
 | **D12** | Issues against ESBMC's C++ operational model, one per gap G1–G8 (§13.2), each with a reproducer and two regression tests | GitHub, label `clang-cpp-frontend` | M0 |
 | **D13** | ESBMC extension work items WI-1…WI-3 (`<shared_mutex>`, `<type_traits>` completion, `<compare>`/`std::unreachable`, `initializer_list`/`iterator_traits`/`this_thread`) | `src/cpp/library/`, `regression/esbmc-cpp*` | M0–M1 |
 | **D14** | Tier B′ pilot result (WI-4) — a harness including the real `renaming.h`, **or** a recorded negative result keeping Tier A | `unit/goto-symex/` or §13.3 | M4 |
@@ -994,6 +1011,46 @@ Stated plainly, to avoid over-claiming:
 7. **Absolute (unbounded) correctness of the engine.** Every Tier-A result is a
    proof at a bound, or a k-induction proof with convergence. Where convergence
    is not achieved, the result is reported as *bounded*, never as *proved*.
+
+---
+
+## 15. Verdict log (D11)
+
+Append-only. One row per discharged (or attempted) harness run, with the exact
+artefact it was run against. A row here is the *only* place this document claims
+a result; §7's harness descriptions remain proposals until they appear below.
+
+**Environment.** ESBMC 8.4.0, tree at `ecf26b5312`, `RelWithDebInfo` (`-DNDEBUG`
+present — see R1), Bitwuzla 0.9.0, Z3 4.13.3, Linux x86_64.
+
+### M0 — 2026-07-27
+
+| Artefact | Invocation | Verdict | Acceptance (§11.3) |
+|---|---|---|---|
+| `regression/esbmc/symex_ssa_00` | `--overflow-check --unsigned-overflow-check --memory-leak-check` | `VERIFICATION SUCCESSFUL` | 1 ✓ · 2 ✓ (45 of 163 VCCs remain) · 3 ✓ · 4 ✓ · 5 ✓ · 6 ✓ (Bitwuzla and Z3 agree) · 7 ✓ |
+| `regression/esbmc/symex_ssa_00_fail` | same + `-DSYMEX_HARNESS_PERTURB` | `VERIFICATION FAILED` at the `I1: L2 index advances by exactly one` claim | anti-vacuity twin for the row above |
+| `regression/esbmc/symex_ssa_00_probe` | same + `-DSYMEX_HARNESS_PROBE` | `VERIFICATION FAILED` at `reachability probe` | the harness body is reached |
+
+**Scope of the claim.** `symex_ssa_00` is the M0 *template*, not H-A1. It proves
+I1 for the counter algebra alone, over a 4-key map and a 4-assignment sequence,
+with the map modelled as a direct-indexed array. It does **not** yet model the
+`name_record` key, the `rename`-beneath-our-feet reference hazard (I2/R3), or
+node ids. H-A1 (M1) subsumes it.
+
+**Infrastructure delivered.**
+
+- `unit/goto-symex` builds and runs again (`intrinsic-utils-test`, 4 assertions).
+  The link failure was cvc5's exported target naming `cadical`/`picpoly`/
+  `picpolyxx` as bare `-l` flags with no search path: `src/esbmc/CMakeLists.txt`
+  carried a private `target_link_directories` workaround, so `esbmc` linked and
+  every other consumer of `solvers` did not. Moved onto `solvercvc5` as a
+  `PUBLIC` link directory, which fixes all consumers at once.
+- `scripts/verification/symex/drift_check.py` + a `pull_request.yml` gate.
+  Verified end-to-end: inserting one comment into `level2t::make_assignment`
+  turns the check red.
+
+**Carried into M1.** WI-1 (`<shared_mutex>`), WI-2 (`<type_traits>` completion)
+and D12 (issues G1–G8) were scheduled for M0 and are not started.
 
 ---
 

--- a/regression/esbmc/symex_ssa_00/symex_ssa_00.c
+++ b/regression/esbmc/symex_ssa_00/symex_ssa_00.c
@@ -1,0 +1,96 @@
+/*
+ * Tier-A harness template — docs/roadmap/goto-symex-verification-plan.md, M0.
+ *
+ * SYMEX-HARNESS-TARGET: src/goto-symex/renaming.cpp::renaming::level2t::make_assignment
+ * SYMEX-HARNESS-SHA256: ee23b753191f2cfbaab575c2d40aa016bea6752ac071792f8f53dc8069a5eecc
+ * SYMEX-HARNESS-TARGET: src/goto-symex/renaming.cpp::renaming::level2t::coveredinbees
+ * SYMEX-HARNESS-SHA256: a913ec311a854d4e6a99e6063d749c1e340a6c04a4156a106a6367262810c624
+ *
+ * Discharges (partially, at the smoke level): I1 / P4 / P8 / P12 — the L2
+ * counter published by make_assignment is fresh, strictly increasing per key,
+ * and never wraps.
+ *
+ * Assumptions (§6.1 rule 2 — each cites the symbol that establishes it):
+ *   key < MAP_CAP
+ *     src/goto-symex/renaming.h::renaming::level2t::name_record — the L2 key is
+ *     a value type over (base_name, rlevel, l1_num, t_num); the harness
+ *     enumerates a bounded key space, per §6.1 rule 4 (bound the shape).
+ *   before < UINT_MAX
+ *     src/goto-symex/renaming.cpp::renaming::level2t::coveredinbees — its
+ *     assert(entry.count <= count) is the engine-side statement that counts
+ *     only ever grow. Discharged by Tier B (H-B1) rather than assumed there.
+ *
+ * Variants — one source, selected by -D on test.desc line 3, so the twins
+ * cannot drift from the kernel they perturb:
+ *   (none)                  regression/esbmc/symex_ssa_00        SUCCESSFUL
+ *   SYMEX_HARNESS_PERTURB   regression/esbmc/symex_ssa_00_fail   FAILED (§6.1 r5)
+ *   SYMEX_HARNESS_PROBE     regression/esbmc/symex_ssa_00_probe  FAILED (§6.1 r6)
+ */
+
+#include <limits.h>
+
+#define MAP_CAP 4
+#define SEQ_LEN 4
+
+unsigned nondet_uint(void);
+
+/* renaming::level2t::valuet, reduced to the one field the property observes
+ * (§6.2 stub inventory: node ids, the propagated constant and the expression
+ * payload are not read by I1, and the latter is irep2's obligation). */
+struct valuet
+{
+  unsigned count;
+};
+
+static struct valuet current_names[MAP_CAP];
+
+/* renaming::level2t::make_assignment — the counter algebra only. */
+static unsigned make_assignment(unsigned key)
+{
+  struct valuet *entry = &current_names[key];
+#ifdef SYMEX_HARNESS_PERTURB
+  unsigned published = entry->count;
+#else
+  unsigned published = entry->count + 1;
+#endif
+  entry->count = published;
+  return published;
+}
+
+int main(void)
+{
+  unsigned keys[SEQ_LEN];
+  unsigned published[SEQ_LEN];
+
+  for (unsigned i = 0; i < MAP_CAP; i++)
+    current_names[i].count = 0;
+
+  for (unsigned i = 0; i < SEQ_LEN; i++)
+  {
+    unsigned key = nondet_uint();
+    __ESBMC_assume(key < MAP_CAP);
+
+    unsigned before = current_names[key].count;
+    __ESBMC_assume(before < UINT_MAX);
+
+    keys[i] = key;
+    published[i] = make_assignment(key);
+
+    __ESBMC_assert(
+      published[i] == before + 1, "I1: L2 index advances by exactly one");
+    __ESBMC_assert(
+      current_names[key].count == published[i],
+      "I1: the map holds the index just published");
+
+    for (unsigned j = 0; j < i; j++)
+      __ESBMC_assert(
+        keys[j] != key || published[j] != published[i],
+        "I1: a published (key, L2 index) pair is never republished");
+  }
+
+#ifdef SYMEX_HARNESS_PROBE
+  __ESBMC_assert(0, "reachability probe");
+#endif
+
+  return 0;
+}

--- a/regression/esbmc/symex_ssa_00/test.desc
+++ b/regression/esbmc/symex_ssa_00/test.desc
@@ -1,0 +1,4 @@
+CORE
+symex_ssa_00.c
+--overflow-check --unsigned-overflow-check --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/symex_ssa_00_fail/symex_ssa_00_fail.c
+++ b/regression/esbmc/symex_ssa_00_fail/symex_ssa_00_fail.c
@@ -1,0 +1,1 @@
+#include "../symex_ssa_00/symex_ssa_00.c"

--- a/regression/esbmc/symex_ssa_00_fail/test.desc
+++ b/regression/esbmc/symex_ssa_00_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+symex_ssa_00_fail.c
+-DSYMEX_HARNESS_PERTURB --overflow-check --unsigned-overflow-check --memory-leak-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/symex_ssa_00_probe/symex_ssa_00_probe.c
+++ b/regression/esbmc/symex_ssa_00_probe/symex_ssa_00_probe.c
@@ -1,0 +1,1 @@
+#include "../symex_ssa_00/symex_ssa_00.c"

--- a/regression/esbmc/symex_ssa_00_probe/test.desc
+++ b/regression/esbmc/symex_ssa_00_probe/test.desc
@@ -1,0 +1,4 @@
+CORE
+symex_ssa_00_probe.c
+-DSYMEX_HARNESS_PROBE --overflow-check --unsigned-overflow-check --memory-leak-check
+^VERIFICATION FAILED$

--- a/scripts/verification/symex/drift_check.py
+++ b/scripts/verification/symex/drift_check.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Transcription-drift guard for the goto-symex verification harnesses.
+
+A Tier-A harness (docs/roadmap/goto-symex-verification-plan.md §7.1) transcribes
+the logic of a `src/goto-symex` symbol into standalone C. The transcription is
+only as good as the day it was written: when the cited symbol changes, the
+harness silently stops proving anything about the shipped engine.
+
+Each harness therefore records the symbol it transcribes and a checksum of that
+symbol's current definition:
+
+    SYMEX-HARNESS-TARGET: src/goto-symex/renaming.cpp::renaming::level2t::make_assignment
+    SYMEX-HARNESS-SHA256: <64 hex digits>
+
+This script re-extracts every cited definition, re-hashes it, and fails when a
+checksum no longer matches — forcing the PR author to re-transcribe, widen the
+harness, or retire it (§11.5).
+
+    drift_check.py            check every harness, exit 1 on drift
+    drift_check.py --update   rewrite the recorded checksums
+"""
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+HARNESS_GLOBS = (
+    "regression/esbmc/symex_*/*.c",
+    "regression/esbmc/symex_*/*.cpp",
+    "unit/goto-symex/*.test.cpp",
+)
+
+TARGET_RE = re.compile(r"SYMEX-HARNESS-TARGET:\s*(\S+)")
+SHA_RE = re.compile(r"(SYMEX-HARNESS-SHA256:\s*)([0-9a-fA-F]{64})")
+PLACEHOLDER = "0" * 64
+
+
+class DriftError(Exception):
+    """A cited target cannot be resolved to exactly one definition."""
+
+
+def extract_definition(source: str, symbol: str) -> str:
+    """Return the text of `symbol`'s definition in `source`.
+
+    Finds the first occurrence of the symbol used as a definition — an
+    occurrence whose parameter list is followed by a body rather than a
+    semicolon — and returns from the start of the declaration through the
+    closing brace.
+    """
+    pattern = re.compile(r"(?<![\w:])" + re.escape(symbol) + r"\s*\(")
+    for match in pattern.finditer(source):
+        body_start = _find_body(source, match.end())
+        if body_start is None:
+            continue
+        start = _declaration_start(source, match.start())
+        end = _matching_brace(source, body_start)
+        return source[start:end + 1]
+    raise DriftError(f"no definition of '{symbol}' found")
+
+
+def _find_body(source: str, paren_start: int):
+    """Index of the `{` opening the body, or None if this is a declaration."""
+    depth = 1
+    i = paren_start
+    while i < len(source) and depth:
+        depth += {"(": 1, ")": -1}.get(source[i], 0)
+        i += 1
+    if depth:
+        return None
+    while i < len(source) and source[i] not in "{;":
+        i += 1
+    return i if i < len(source) and source[i] == "{" else None
+
+
+def _declaration_start(source: str, symbol_start: int) -> int:
+    """Index just past the previous statement.
+
+    Anchoring on the previous `;` or `}` rather than on the previous newline
+    keeps the return type, the template header and any doc comment inside the
+    hashed region, so a changed contract also trips the guard.
+    """
+    boundary = max(source.rfind(";", 0, symbol_start), source.rfind("}", 0, symbol_start))
+    return len(source) - len(source[boundary + 1:].lstrip())
+
+
+def _matching_brace(source: str, brace_start: int) -> int:
+    depth = 0
+    for i in range(brace_start, len(source)):
+        depth += {"{": 1, "}": -1}.get(source[i], 0)
+        if not depth:
+            return i
+    raise DriftError("unbalanced braces while extracting the definition")
+
+
+def region_digest(root: Path, target: str) -> str:
+    """sha256 of the definition cited by `<path>::<symbol>`."""
+    if "::" not in target:
+        raise DriftError(f"malformed target '{target}', expected <path>::<symbol>")
+    rel_path, symbol = target.split("::", 1)
+    path = root / rel_path
+    if not path.is_file():
+        raise DriftError(f"cited file '{rel_path}' does not exist")
+    definition = extract_definition(path.read_text(encoding="utf-8"), symbol)
+    normalised = "\n".join(line.rstrip() for line in definition.splitlines())
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+
+def check_harness(root: Path, harness: Path, update: bool) -> list:
+    """Verify (or refresh) one harness. Returns a list of problem strings."""
+    text = harness.read_text(encoding="utf-8")
+    targets = TARGET_RE.findall(text)
+    recorded = SHA_RE.findall(text)
+    rel = harness.relative_to(root)
+
+    if len(targets) != len(recorded):
+        return [f"{rel}: {len(targets)} TARGET line(s) but {len(recorded)} SHA256 line(s)"]
+
+    problems = []
+    digests = []
+    for target in targets:
+        try:
+            digests.append(region_digest(root, target))
+        except DriftError as err:
+            problems.append(f"{rel}: {err}")
+    if problems:
+        return problems
+
+    if update:
+        remaining = iter(digests)
+        harness.write_text(SHA_RE.sub(lambda m: m.group(1) + next(remaining), text),
+                           encoding="utf-8")
+        return []
+
+    for target, digest, (_, old) in zip(targets, digests, recorded):
+        if old.lower() != digest:
+            what = "unrecorded" if old == PLACEHOLDER else f"was {old[:12]}…"
+            problems.append(f"{rel}: '{target}' drifted ({what}, now {digest[:12]}…)")
+    return problems
+
+
+def main() -> int:
+    """Check (or refresh) every harness; return a process exit status."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--update",
+                        action="store_true",
+                        help="rewrite recorded checksums instead of failing on drift")
+    parser.add_argument("--root",
+                        type=Path,
+                        default=Path(__file__).resolve().parents[3],
+                        help="repository root (default: inferred from this script's location)")
+    args = parser.parse_args()
+
+    harnesses = [
+        p for glob in HARNESS_GLOBS for p in sorted(args.root.glob(glob))
+        if TARGET_RE.search(p.read_text(encoding="utf-8"))
+    ]
+    problems = []
+    for harness in harnesses:
+        problems += check_harness(args.root, harness, args.update)
+    checked = len(harnesses)
+
+    for problem in problems:
+        print(f"DRIFT: {problem}", file=sys.stderr)
+    verb = "refreshed" if args.update else "checked"
+    print(f"{verb} {checked} harness(es) citing src/goto-symex")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -57,9 +57,6 @@ target_include_directories(esbmc
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${Boost_INCLUDE_DIRS}
 )
-cmake_path(SET MY_MAGIC_PATH NORMALIZE "${cvc5_DIR}/../../")
-cmake_path(ABSOLUTE_PATH MY_MAGIC_PATH OUTPUT_VARIABLE CVC_LINK_DIR)
-message("Looking at ${CVC_LINK_DIR}")
 target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
                             ${LD_FRONTEND_TARGETS}
                             ${GOTO_CONTRACTOR_TARGETS} ${JIMPLE_FRONTEND_TARGETS}
@@ -85,5 +82,4 @@ elseif(MIMALLOC_TARGET)
   # malloc/operator new override wins.
   target_link_libraries(esbmc ${MIMALLOC_TARGET})
 endif()
-target_link_directories(esbmc PUBLIC "${CVC_LINK_DIR}")
 install(TARGETS esbmc DESTINATION bin)

--- a/src/solvers/cvc5/CMakeLists.txt
+++ b/src/solvers/cvc5/CMakeLists.txt
@@ -23,6 +23,12 @@ if(ENABLE_CVC5)
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(solvercvc5 PUBLIC fmt::fmt cvc5::cvc5)
 
+    # cvc5's exported target names its own dependencies (cadical, picpoly, ...)
+    # as bare -l flags, so every consumer needs cvc5's lib/ on the link path.
+    cmake_path(SET CVC5_LIB_PATH NORMALIZE "${cvc5_DIR}/../../")
+    cmake_path(ABSOLUTE_PATH CVC5_LIB_PATH OUTPUT_VARIABLE CVC5_LINK_DIR)
+    target_link_directories(solvercvc5 PUBLIC "${CVC5_LINK_DIR}")
+
     # Add to solver link
     target_link_libraries(solvers INTERFACE solvercvc5)
 

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -1,2 +1,2 @@
-new_unit_test(intrinsic-utils-test "intrinsic_utils.test.cpp" "symex;solvers;gotoalgorithms;pointeranalysis;util_esbmc;langapi")
+new_unit_test(intrinsic-utils-test "intrinsic_utils.test.cpp" "mode_table_obj;symex;solvers;gotoalgorithms;pointeranalysis;util_esbmc;langapi")
 new_unit_test(ssa-wellformed-test "ssa_wellformed.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -1,1 +1,2 @@
 new_unit_test(intrinsic-utils-test "intrinsic_utils.test.cpp" "symex;solvers;gotoalgorithms;pointeranalysis;util_esbmc;langapi")
+new_unit_test(ssa-wellformed-test "ssa_wellformed.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -1,4 +1,1 @@
-# Activate this on demand for now
-# Our current CMake is having some weird dependencies...
-# It makes no sense for this test to depend on solvers
-#new_unit_test(intrinsic-utils-test "intrinsic_utils.test.cpp" "symex;solvers;gotoalgorithms;pointeranalysis;util_esbmc;langapi")
+new_unit_test(intrinsic-utils-test "intrinsic_utils.test.cpp" "symex;solvers;gotoalgorithms;pointeranalysis;util_esbmc;langapi")

--- a/unit/goto-symex/intrinsic_utils.test.cpp
+++ b/unit/goto-symex/intrinsic_utils.test.cpp
@@ -15,8 +15,6 @@
 
 #include <goto-symex/goto_symex.h>
 
-const mode_table_et mode_table[] = {};
-
 SCENARIO("the memcpy generation can generate valid results", "[symex]")
 {
   auto primitive_test_case = [](

--- a/unit/goto-symex/ssa_wellformed.test.cpp
+++ b/unit/goto-symex/ssa_wellformed.test.cpp
@@ -1,0 +1,285 @@
+/*******************************************************************
+ Module: SSA well-formedness of equations produced by the real engine
+
+ Tier B of docs/roadmap/goto-symex-verification-plan.md (H-B1, milestone M1).
+
+ Unlike a Tier-A harness, nothing here is transcribed: `goto_factory` parses a
+ real C program, a real `reachability_treet` drives the real `goto_symext` over
+ it, and the assertions are made against the `symex_target_equationt` that comes
+ out. The properties are the ones §4.2 lists as unenforced in the shipped
+ binary:
+
+   I1  (P8)  per (base_name, L1, thread), the L2 index of each definition
+             strictly increases in equation order.
+   I10 (P11) no two assignment steps define the same SSA name. This is the
+             invariant `check_for_duplicate_assigns` was written for and never
+             enforces — it logs and returns (R5).
+   P11       no step reads an SSA name before the step that defines it.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include <goto-symex/reachability_tree.h>
+#include <goto-symex/symex_target_equation.h>
+#include <irep2/irep2_expr.h>
+#include <util/symtab/namespace.h>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+/** The identity of one SSA definition: everything but the L2 counter. */
+struct l2_keyt
+{
+  std::string base_name;
+  unsigned l1_num;
+  unsigned thread_num;
+
+  bool operator<(const l2_keyt &o) const
+  {
+    return std::tie(base_name, l1_num, thread_num) <
+           std::tie(o.base_name, o.l1_num, o.thread_num);
+  }
+};
+
+bool is_ssa_symbol(const expr2tc &e)
+{
+  if (!is_symbol2t(e))
+    return false;
+  const symbol_renaming_level lev = to_symbol2t(e).rlevel;
+  return lev == symbol_renaming_level::level2 ||
+         lev == symbol_renaming_level::level2_global;
+}
+
+l2_keyt key_of(const expr2tc &e)
+{
+  const symbol2t &s = to_symbol2t(e);
+  return {s.thename.as_string(), s.level1_num, s.thread_num};
+}
+
+void collect_ssa_reads(const expr2tc &e, std::set<std::string> &out)
+{
+  if (is_nil_expr(e))
+    return;
+  if (is_ssa_symbol(e))
+    out.insert(to_symbol2t(e).get_symbol_name());
+  e->foreach_operand(
+    [&out](const expr2tc &sub) { collect_ssa_reads(sub, out); });
+}
+
+/** Run the real engine over `src` and return the equation it produced. */
+std::shared_ptr<symex_target_equationt> symex_equation(std::string src)
+{
+  program prog =
+    goto_factory::get_goto_functions(src, goto_factory::Architecture::BIT_64);
+  REQUIRE(prog.functions.function_map.size() > 0);
+
+  namespacet ns(prog.context);
+  cmdlinet cmd = goto_factory::get_default_cmdline("test.c");
+  optionst opts = goto_factory::get_default_options(cmd);
+  opts.set_option("unwind", "4");
+
+  reachability_treet rt(
+    prog.functions,
+    ns,
+    opts,
+    std::make_shared<symex_target_equationt>(ns),
+    prog.context);
+  rt.setup_for_new_explore();
+
+  goto_symext::symex_resultt result = rt.get_next_formula();
+  auto eq = std::dynamic_pointer_cast<symex_target_equationt>(result.target);
+  REQUIRE(eq != nullptr);
+  REQUIRE(eq->SSA_steps.size() > 0);
+  return eq;
+}
+
+struct violationst
+{
+  std::vector<std::string> duplicate_definitions; // I10
+  std::vector<std::string> non_monotonic;         // I1
+  std::vector<std::string> use_before_def;        // P11
+};
+
+violationst validate(const symex_target_equationt &eq)
+{
+  violationst bad;
+
+  // Names defined anywhere in the equation. A read of a name that is never
+  // defined is a free symbol (nondet, argument, uninitialised global) and is
+  // not a use-before-def; only a read that *precedes* its definition is.
+  std::set<std::string> ever_defined;
+  for (const auto &step : eq.SSA_steps)
+    if (step.is_assignment() && is_ssa_symbol(step.lhs))
+      ever_defined.insert(to_symbol2t(step.lhs).get_symbol_name());
+
+  std::set<std::string> defined;
+  std::map<l2_keyt, unsigned> highest_index;
+
+  for (const auto &step : eq.SSA_steps)
+  {
+    // An assignment step's `cond` is equality2tc(lhs, rhs)
+    // (symex_target_equationt::assignment), so reading it here would report
+    // every definition as a use of itself. Its rhs carries the actual reads.
+    std::set<std::string> reads;
+    collect_ssa_reads(step.guard, reads);
+    if (step.is_assignment())
+      collect_ssa_reads(step.rhs, reads);
+    else
+      collect_ssa_reads(step.cond, reads);
+
+    for (const std::string &name : reads)
+      if (ever_defined.count(name) && !defined.count(name))
+        bad.use_before_def.push_back(name);
+
+    if (!step.is_assignment() || !is_ssa_symbol(step.lhs))
+      continue;
+
+    const symbol2t &lhs = to_symbol2t(step.lhs);
+    const std::string name = lhs.get_symbol_name();
+
+    if (!defined.insert(name).second)
+      bad.duplicate_definitions.push_back(name);
+
+    auto [it, fresh] = highest_index.emplace(key_of(step.lhs), lhs.level2_num);
+    if (!fresh)
+    {
+      if (lhs.level2_num <= it->second)
+        bad.non_monotonic.push_back(name);
+      it->second = lhs.level2_num;
+    }
+  }
+
+  return bad;
+}
+
+/** Every property at once, so a new program costs one line. */
+void require_well_formed(const std::string &src)
+{
+  const violationst bad = validate(*symex_equation(src));
+  CHECK(bad.duplicate_definitions.empty());
+  CHECK(bad.non_monotonic.empty());
+  CHECK(bad.use_before_def.empty());
+}
+} // namespace
+
+TEST_CASE("straight-line assignments produce well-formed SSA", "[symex][ssa]")
+{
+  require_well_formed(R"(
+int main(void)
+{
+  int x = 1;
+  int y = x + 2;
+  x = y * 3;
+  y = x - y;
+  return x + y;
+}
+)");
+}
+
+TEST_CASE("a branch and its join produce well-formed SSA", "[symex][ssa]")
+{
+  require_well_formed(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = 0, y = 0;
+  if (nondet_int() > 0)
+  {
+    x = 1;
+    y = x + 1;
+  }
+  else
+  {
+    x = 2;
+  }
+  return x + y;
+}
+)");
+}
+
+TEST_CASE(
+  "nested branches and a shared join produce well-formed SSA",
+  "[symex][ssa]")
+{
+  require_well_formed(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = 0;
+  if (nondet_int() > 0)
+  {
+    if (nondet_int() > 1)
+      x = 1;
+    else
+      x = 2;
+  }
+  else if (nondet_int() < -1)
+    x = 3;
+  return x;
+}
+)");
+}
+
+TEST_CASE("an unwound loop produces well-formed SSA", "[symex][ssa]")
+{
+  require_well_formed(R"(
+int main(void)
+{
+  int sum = 0;
+  for (int i = 0; i < 3; i++)
+    sum += i;
+  return sum;
+}
+)");
+}
+
+TEST_CASE(
+  "function calls and recursion produce well-formed SSA",
+  "[symex][ssa]")
+{
+  require_well_formed(R"(
+int add(int a, int b) { return a + b; }
+int fact(int n) { return n <= 1 ? 1 : n * fact(n - 1); }
+int main(void)
+{
+  int x = add(2, 3);
+  return add(x, fact(3));
+}
+)");
+}
+
+TEST_CASE("the validator is discriminating", "[symex][ssa]")
+{
+  // The three checks are only worth running if a violation would be seen.
+  // Re-defining an SSA name in an equation the engine produced must be caught;
+  // this is the check R5 says `check_for_duplicate_assigns` never performs.
+  auto eq = symex_equation(R"(
+int main(void)
+{
+  int x = 1;
+  x = x + 1;
+  return x;
+}
+)");
+
+  REQUIRE(validate(*eq).duplicate_definitions.empty());
+
+  auto assignment = std::find_if(
+    eq->SSA_steps.begin(), eq->SSA_steps.end(), [](const auto &step) {
+      return step.is_assignment() && is_ssa_symbol(step.lhs);
+    });
+  REQUIRE(assignment != eq->SSA_steps.end());
+
+  eq->SSA_steps.push_back(*assignment);
+  const violationst bad = validate(*eq);
+  CHECK(bad.duplicate_definitions.size() == 1);
+  CHECK(bad.non_monotonic.size() == 1);
+}


### PR DESCRIPTION
Executes **M0 — Infrastructure** of `docs/roadmap/goto-symex-verification-plan.md` (added in #6439). M0 builds nothing that proves the engine correct on its own; it builds the scaffolding M1–M8 all sit on, and proves that scaffolding detects an injected bug.

## What's here

**A working `unit/goto-symex` target.** The directory's `CMakeLists.txt` had been commented out with *"Our current CMake is having some weird dependencies"*. The actual cause: cvc5's exported CMake target names its own dependencies (`cadical`, `picpoly`, `picpolyxx`) as bare `-l` flags with no search path, and `src/esbmc/CMakeLists.txt` compensated with a private `target_link_directories`. So `esbmc` linked and every other consumer of `solvers` did not. Moving the link directory onto `solvercvc5` as `PUBLIC` fixes all consumers at once and lets the workaround go. `intrinsic-utils-test` now builds and passes (4 assertions).

**The Tier-A harness skeleton**, as a working template rather than a stub:

| Directory | Verdict | Role |
|---|---|---|
| `regression/esbmc/symex_ssa_00` | `SUCCESSFUL` | the kernel — I1, the L2 counter algebra of `level2t::make_assignment` |
| `regression/esbmc/symex_ssa_00_fail` | `FAILED` | anti-vacuity twin (plan §6.1 rule 5) — drops the `+1` |
| `regression/esbmc/symex_ssa_00_probe` | `FAILED` | reachability probe (§6.1 rule 6) — proves the body is reached |

The twins are one-line `#include`s of the kernel and select their variant with `-DSYMEX_HARNESS_PERTURB` / `-DSYMEX_HARNESS_PROBE` on `test.desc` line 3. One copy of the kernel exists, so a twin cannot silently stop perturbing the thing it perturbs.

**The transcription-drift guard**, `scripts/verification/symex/drift_check.py`, plus a `pull_request.yml` job. A Tier-A harness transcribes `src/goto-symex` logic into standalone C and is only as good as the day it was written; each harness records `SYMEX-HARNESS-TARGET: <path>::<symbol>` and a checksum of that symbol's definition. The script re-extracts each definition by brace-matching, re-hashes, and fails on mismatch. `--update` refreshes checksums after a reviewed re-transcription. Verified end-to-end: adding a single comment inside `level2t::make_assignment` turns the check red.

## Verification

Recorded in the plan's new §15 verdict log with the acceptance criteria of §11.3 discharged per row — including **dual-solver agreement** (Bitwuzla 0.9.0 and Z3 4.13.3 both `SUCCESSFUL` on the kernel) and non-vacuity (45 of 163 VCCs survive simplification).

The scope of the claim is stated honestly in §15: `symex_ssa_00` is the M0 *template*, not H-A1. It covers the counter algebra over a 4-key map and a 4-assignment sequence, and does not yet model the `name_record` key or the `rename`-beneath-our-feet reference hazard (I2/R3). H-A1 in M1 subsumes it.

## Testing

- `ctest -LE regression` — 550/550 pass, including the re-enabled `intrinsic-utils-test`.
- `ctest -R symex_ssa_00` — 3/3.
- A 250-test slice of the `esbmc` regression label — the only failure was `esbmc-unix/03_boundedBuffer`, a `THOROUGH` test that runs ~101 s and only exceeds the harness's 120 s cap under `-j4`; it passes serially and is unaffected by this change.
- `pylint` 10.00/10 and YAPF-clean on the new script.

## Carried forward

WI-1 (`<shared_mutex>`), WI-2 (`<type_traits>` completion) and D12 (issues G1–G8) were also scheduled for M0 and are untouched; §10 now records them as moving to M1.