### PR TITLE
[docs] goto-symex verification plan: M1 at Tier B, on the real engine

### DIFF
--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -6,7 +6,8 @@ SMT backend.
 **Verifier:** ESBMC itself (BMC + k-induction) on extracted kernels; Catch2
 property/differential tests on the real classes (`unit/goto-symex/`);
 whole-tool metamorphic oracles over `regression/`; sanitizers for the rest.
-**Status:** **M0 complete** (§15 verdict log); M1–M8 not yet executed. Except
+**Status:** **M0 complete, M1 partial** (§15 verdict log); M2–M8 not yet
+executed. §6.4 records the tier-ordering rule M1 produced. Except
 where §15 records a discharged result, every harness below is a *proposal* and
 nothing here asserts a proof. Findings R1–R12 remain *hypotheses with cited
 evidence*, not confirmed end-to-end bugs.
@@ -397,6 +398,35 @@ A forbidden-assumption list, enforced at review:
 - ✗ `assume(single thread)` in any harness whose property is claimed for
   concurrent runs.
 
+### 6.4 Tier B first — a rule learned from M1
+
+The tier table in §2.2 lists A before B, and M0/M1 read that as an ordering.
+It is not one. **Tier A proves things about a transcription; only Tier B and
+Tier C observe the shipped C++.** A Tier-A harness is therefore justified only
+when a property cannot be observed from outside the engine — and §15's M1 entry
+shows the cost of ignoring that: the moment H-A1's stub grew from an array index
+to the real `name_record` key behind a hash-probed map, it went from 163 VCCs
+and 4 s to 4371 VCCs and no verdict inside the plan's own 30 s budget. Fidelity
+to the real key and ESBMC-tractability pull in opposite directions, so a Tier-A
+harness faithful enough to be worth trusting is often one ESBMC cannot discharge.
+
+The rule for every remaining harness in §7:
+
+1. **Ask what the equation already shows.** Any property expressible over the
+   `symex_target_equationt` the engine actually produced — SSA well-formedness,
+   phi counts, slicer equisatisfiability, determinism — belongs in
+   `unit/goto-symex/`, with zero modelling and zero drift.
+2. **Then ask what a whole-tool oracle shows** (§7.4), for composition
+   properties over the 1400 `regression/esbmc` CORE inputs.
+3. **Only then write Tier A**, for internal decisions the equation does not
+   expose (the held-reference hazard of R3, a `previous_frame` precondition, an
+   MPOR independence relation), and keep the stub at the smallest fidelity the
+   property observes — a Tier-A harness that times out proves nothing at all.
+
+§11.3's acceptance criteria already say "timed out is never SUCCESSFUL". This
+section says the same thing one step earlier: prefer the tier that cannot time
+out, and cannot drift.
+
 ---
 
 ## 7. Proposed harnesses
@@ -680,6 +710,11 @@ Retires I1/I2/I16; produces the R3 and R7 verdicts. In parallel: **WI-3**
 (`initializer_list` / `iterator_traits` / `this_thread` / `aligned_storage`),
 which completes the parse path to `renaming.h`. *Artefact:* three Tier-A harness
 pairs + the R3 restructure PR if H-A9 confirms the hazard; WI-2/WI-3 merged.
+**Revised, §15 M1.** H-A1's Tier-A form was built and **rejected on
+tractability** — see §15 and the rule it produced in §6.4. I1/I10/P11 are
+instead discharged against the *real* `goto_symext` by H-B1
+(`unit/goto-symex/ssa_wellformed.test.cpp`). H-A9 and H-A7 remain open and are
+the next M1 work; both are re-scoped Tier-B-first per §6.4.
 
 **M2 — Isolated core algorithms: merging and bounding (1.5 wk).**
 H-A2 (the highest-value harness), H-A3, H-A5. Dual-solver mandatory.
@@ -737,7 +772,7 @@ regression/esbmc/symex_<area>_<nn>/           Tier A, passing — owns the kerne
     └── test.desc
 regression/esbmc/symex_<area>_<nn>_fail/      Tier A, anti-vacuity twin (§6.1 r5)
 regression/esbmc/symex_<area>_<nn>_probe/     Tier A, reachability probe (§6.1 r6)
-unit/goto-symex/<area>.test.cpp               Tier B  (wire in CMakeLists.txt)
+unit/goto-symex/<area>.test.cpp               Tier B — prefer this, see §6.4
 scripts/verification/symex/
     ├── oracle_slice_parity.sh                H-C1
     ├── oracle_simplify_parity.sh             H-C2
@@ -1052,6 +1087,70 @@ node ids. H-A1 (M1) subsumes it.
 **Carried into M1.** WI-1 (`<shared_mutex>`), WI-2 (`<type_traits>` completion)
 and D12 (issues G1–G8) were scheduled for M0 and are not started.
 
+### M1 — 2026-07-27
+
+**Result: I1, I10 and P11 discharged against the real engine.** Not by a
+transcription — by running the real `goto_symext` and validating the
+`symex_target_equationt` it produced.
+
+| Artefact | What it drives | Result |
+|---|---|---|
+| `unit/goto-symex/ssa_wellformed.test.cpp` (H-B1) | real `goto_factory` → real `reachability_treet` → real `goto_symext`, over straight-line, branching, nested-branch, unwound-loop, and call/recursion programs | 6 cases, 37 assertions, **pass**, 1.6 s |
+
+Properties checked on every produced equation:
+
+- **I1 / P8** — per `(base_name, l1_num, thread_num)`, the L2 index of each
+  definition strictly increases in equation order.
+- **I10 / P11** — no two assignment steps define the same SSA name. This is the
+  invariant `check_for_duplicate_assigns` exists for and never enforces (R5);
+  the validator is the enforcing version R5 asks for.
+- **P11** — no step reads an SSA name before the step defining it. A name never
+  defined in the equation is a free symbol and is correctly not a violation.
+
+Anti-vacuity: the last case takes an equation the engine produced, appends a
+copy of one of its own assignment steps, and requires the validator to report
+exactly one duplicate definition and one non-monotonic index. Without it the
+five passing cases would be indistinguishable from a validator that checks
+nothing.
+
+**One harness-side defect found and fixed, no engine defect.** The first run
+reported use-before-def on every first definition. Cause: for an assignment
+step, `symex_target_equationt::assignment` sets
+`SSA_step.cond = equality2tc(lhs, rhs)`, so reading `cond` on an assignment
+reports the definition as a use of itself. The reads of an assignment are in
+its `rhs`; `cond` is for assume/assert steps. Recorded because it is the exact
+failure mode a Tier-A transcription would have hidden — a stub has no `cond`
+field to get wrong.
+
+**Rejected: H-A1 as a Tier-A harness.** Built as specified in §7.1 — the full
+`name_record` key `(base_name, lev, l1_num, t_num)`, `hash` modelled as an
+arbitrary function of those fields so collisions stay possible, and a
+linear-probed map, at 3 assignments over a 16-key space. Measured:
+
+| Harness | VCCs | Wall | Verdict |
+|---|---|---|---|
+| `symex_ssa_00` (M0 template, array-indexed key) | 163 | 4 s | `SUCCESSFUL` |
+| H-A1 Tier-A (real `name_record` key, hash-probed map) | 4371 | **> 200 s** | none |
+| H-A1 `_fail` twin | 4368 | 108 s | `FAILED` |
+
+Rejected under §11.3 criterion 1 (no verdict) and the §11.2 budget (< 30 s per
+harness; the regression harness cap is a hard 120 s). Not committed. The green
+harness never returned, so it proves nothing — while the `_fail` twin returning
+`FAILED` in half the time is the shape you would expect: finding one violating
+trace is easy, proving none exists is not.
+
+The general lesson is written up as §6.4: raising a Tier-A stub's fidelity
+toward the real data structure raises its cost superlinearly, so the tier that
+verifies the shipped C++ is also the tier that scales. §6.4 reorders the
+remaining harness work accordingly.
+
+**Carried into the next M1 slice.** H-A9 (I2/R3, the `valuet &entry` reference
+held across `rename`) and H-A7 (I16/R7, `previous_frame` on a stack of size < 2)
+are unstarted and now Tier-B-first. R7's single call site,
+`symex_function.cpp::goto_symext::symex_function_call_code`, does
+`new_frame(...)` immediately before `previous_frame()`, so the precondition
+holds — but only because of an `assert` that is a no-op in release (R1). Also
+still open from M0: WI-1, WI-2, D12.
 ---
 
 ## Appendix A — Methodological basis

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -1,1 +1,2 @@
 new_unit_test(intrinsic-utils-test "intrinsic_utils.test.cpp" "symex;solvers;gotoalgorithms;pointeranalysis;util_esbmc;langapi")
+new_unit_test(ssa-wellformed-test "ssa_wellformed.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/ssa_wellformed.test.cpp
+++ b/unit/goto-symex/ssa_wellformed.test.cpp
@@ -1,0 +1,285 @@
+/*******************************************************************
+ Module: SSA well-formedness of equations produced by the real engine
+
+ Tier B of docs/roadmap/goto-symex-verification-plan.md (H-B1, milestone M1).
+
+ Unlike a Tier-A harness, nothing here is transcribed: `goto_factory` parses a
+ real C program, a real `reachability_treet` drives the real `goto_symext` over
+ it, and the assertions are made against the `symex_target_equationt` that comes
+ out. The properties are the ones §4.2 lists as unenforced in the shipped
+ binary:
+
+   I1  (P8)  per (base_name, L1, thread), the L2 index of each definition
+             strictly increases in equation order.
+   I10 (P11) no two assignment steps define the same SSA name. This is the
+             invariant `check_for_duplicate_assigns` was written for and never
+             enforces — it logs and returns (R5).
+   P11       no step reads an SSA name before the step that defines it.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include <goto-symex/reachability_tree.h>
+#include <goto-symex/symex_target_equation.h>
+#include <irep2/irep2_expr.h>
+#include <util/symtab/namespace.h>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+/** The identity of one SSA definition: everything but the L2 counter. */
+struct l2_keyt
+{
+  std::string base_name;
+  unsigned l1_num;
+  unsigned thread_num;
+
+  bool operator<(const l2_keyt &o) const
+  {
+    return std::tie(base_name, l1_num, thread_num) <
+           std::tie(o.base_name, o.l1_num, o.thread_num);
+  }
+};
+
+bool is_ssa_symbol(const expr2tc &e)
+{
+  if (!is_symbol2t(e))
+    return false;
+  const symbol_renaming_level lev = to_symbol2t(e).rlevel;
+  return lev == symbol_renaming_level::level2 ||
+         lev == symbol_renaming_level::level2_global;
+}
+
+l2_keyt key_of(const expr2tc &e)
+{
+  const symbol2t &s = to_symbol2t(e);
+  return {s.thename.as_string(), s.level1_num, s.thread_num};
+}
+
+void collect_ssa_reads(const expr2tc &e, std::set<std::string> &out)
+{
+  if (is_nil_expr(e))
+    return;
+  if (is_ssa_symbol(e))
+    out.insert(to_symbol2t(e).get_symbol_name());
+  e->foreach_operand(
+    [&out](const expr2tc &sub) { collect_ssa_reads(sub, out); });
+}
+
+/** Run the real engine over `src` and return the equation it produced. */
+std::shared_ptr<symex_target_equationt> symex_equation(std::string src)
+{
+  program prog =
+    goto_factory::get_goto_functions(src, goto_factory::Architecture::BIT_64);
+  REQUIRE(prog.functions.function_map.size() > 0);
+
+  namespacet ns(prog.context);
+  cmdlinet cmd = goto_factory::get_default_cmdline("test.c");
+  optionst opts = goto_factory::get_default_options(cmd);
+  opts.set_option("unwind", "4");
+
+  reachability_treet rt(
+    prog.functions,
+    ns,
+    opts,
+    std::make_shared<symex_target_equationt>(ns),
+    prog.context);
+  rt.setup_for_new_explore();
+
+  goto_symext::symex_resultt result = rt.get_next_formula();
+  auto eq = std::dynamic_pointer_cast<symex_target_equationt>(result.target);
+  REQUIRE(eq != nullptr);
+  REQUIRE(eq->SSA_steps.size() > 0);
+  return eq;
+}
+
+struct violationst
+{
+  std::vector<std::string> duplicate_definitions; // I10
+  std::vector<std::string> non_monotonic;         // I1
+  std::vector<std::string> use_before_def;        // P11
+};
+
+violationst validate(const symex_target_equationt &eq)
+{
+  violationst bad;
+
+  // Names defined anywhere in the equation. A read of a name that is never
+  // defined is a free symbol (nondet, argument, uninitialised global) and is
+  // not a use-before-def; only a read that *precedes* its definition is.
+  std::set<std::string> ever_defined;
+  for (const auto &step : eq.SSA_steps)
+    if (step.is_assignment() && is_ssa_symbol(step.lhs))
+      ever_defined.insert(to_symbol2t(step.lhs).get_symbol_name());
+
+  std::set<std::string> defined;
+  std::map<l2_keyt, unsigned> highest_index;
+
+  for (const auto &step : eq.SSA_steps)
+  {
+    // An assignment step's `cond` is equality2tc(lhs, rhs)
+    // (symex_target_equationt::assignment), so reading it here would report
+    // every definition as a use of itself. Its rhs carries the actual reads.
+    std::set<std::string> reads;
+    collect_ssa_reads(step.guard, reads);
+    if (step.is_assignment())
+      collect_ssa_reads(step.rhs, reads);
+    else
+      collect_ssa_reads(step.cond, reads);
+
+    for (const std::string &name : reads)
+      if (ever_defined.count(name) && !defined.count(name))
+        bad.use_before_def.push_back(name);
+
+    if (!step.is_assignment() || !is_ssa_symbol(step.lhs))
+      continue;
+
+    const symbol2t &lhs = to_symbol2t(step.lhs);
+    const std::string name = lhs.get_symbol_name();
+
+    if (!defined.insert(name).second)
+      bad.duplicate_definitions.push_back(name);
+
+    auto [it, fresh] = highest_index.emplace(key_of(step.lhs), lhs.level2_num);
+    if (!fresh)
+    {
+      if (lhs.level2_num <= it->second)
+        bad.non_monotonic.push_back(name);
+      it->second = lhs.level2_num;
+    }
+  }
+
+  return bad;
+}
+
+/** Every property at once, so a new program costs one line. */
+void require_well_formed(const std::string &src)
+{
+  const violationst bad = validate(*symex_equation(src));
+  CHECK(bad.duplicate_definitions.empty());
+  CHECK(bad.non_monotonic.empty());
+  CHECK(bad.use_before_def.empty());
+}
+} // namespace
+
+TEST_CASE("straight-line assignments produce well-formed SSA", "[symex][ssa]")
+{
+  require_well_formed(R"(
+int main(void)
+{
+  int x = 1;
+  int y = x + 2;
+  x = y * 3;
+  y = x - y;
+  return x + y;
+}
+)");
+}
+
+TEST_CASE("a branch and its join produce well-formed SSA", "[symex][ssa]")
+{
+  require_well_formed(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = 0, y = 0;
+  if (nondet_int() > 0)
+  {
+    x = 1;
+    y = x + 1;
+  }
+  else
+  {
+    x = 2;
+  }
+  return x + y;
+}
+)");
+}
+
+TEST_CASE(
+  "nested branches and a shared join produce well-formed SSA",
+  "[symex][ssa]")
+{
+  require_well_formed(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = 0;
+  if (nondet_int() > 0)
+  {
+    if (nondet_int() > 1)
+      x = 1;
+    else
+      x = 2;
+  }
+  else if (nondet_int() < -1)
+    x = 3;
+  return x;
+}
+)");
+}
+
+TEST_CASE("an unwound loop produces well-formed SSA", "[symex][ssa]")
+{
+  require_well_formed(R"(
+int main(void)
+{
+  int sum = 0;
+  for (int i = 0; i < 3; i++)
+    sum += i;
+  return sum;
+}
+)");
+}
+
+TEST_CASE(
+  "function calls and recursion produce well-formed SSA",
+  "[symex][ssa]")
+{
+  require_well_formed(R"(
+int add(int a, int b) { return a + b; }
+int fact(int n) { return n <= 1 ? 1 : n * fact(n - 1); }
+int main(void)
+{
+  int x = add(2, 3);
+  return add(x, fact(3));
+}
+)");
+}
+
+TEST_CASE("the validator is discriminating", "[symex][ssa]")
+{
+  // The three checks are only worth running if a violation would be seen.
+  // Re-defining an SSA name in an equation the engine produced must be caught;
+  // this is the check R5 says `check_for_duplicate_assigns` never performs.
+  auto eq = symex_equation(R"(
+int main(void)
+{
+  int x = 1;
+  x = x + 1;
+  return x;
+}
+)");
+
+  REQUIRE(validate(*eq).duplicate_definitions.empty());
+
+  auto assignment = std::find_if(
+    eq->SSA_steps.begin(), eq->SSA_steps.end(), [](const auto &step) {
+      return step.is_assignment() && is_ssa_symbol(step.lhs);
+    });
+  REQUIRE(assignment != eq->SSA_steps.end());
+
+  eq->SSA_steps.push_back(*assignment);
+  const violationst bad = validate(*eq);
+  CHECK(bad.duplicate_definitions.size() == 1);
+  CHECK(bad.non_monotonic.size() == 1);
+}


### PR DESCRIPTION
Stacked on #6446 (M0). Executes the first slice of **M1** of `docs/roadmap/goto-symex-verification-plan.md` — and corrects the plan's tier ordering on the strength of a measurement.

## Verifying the real C++, not a copy

`unit/goto-symex/ssa_wellformed.test.cpp` runs the **actual engine**: `goto_factory` parses a real C program, a real `reachability_treet` drives the real `goto_symext`, and every assertion is made against the `symex_target_equationt` that comes out. Nothing is modelled or transcribed.

Three of the invariants §4.2 lists as unenforced in the shipped binary:

- **I1 / P8** — per `(base_name, l1_num, thread_num)`, the L2 index of each definition strictly increases in equation order.
- **I10 / P11** — no two assignment steps define the same SSA name. This is the invariant `check_for_duplicate_assigns` exists for and never enforces (finding **R5**: it logs and returns). The validator here is the enforcing version R5 asks for.
- **P11** — no step reads an SSA name before the step that defines it. A name never defined in the equation is a free symbol and correctly is not a violation.

Over straight-line, branching, nested-branch/shared-join, unwound-loop, and call/recursion programs: **6 cases, 37 assertions, 1.6 s.**

Anti-vacuity is a test, not a claim: the last case takes an equation the engine produced, appends a copy of one of its own assignment steps, and requires the validator to report exactly one duplicate definition and one non-monotonic index.

One defect was found and fixed — in the harness, not the engine. The first run flagged use-before-def on every first definition, because `symex_target_equationt::assignment` sets `SSA_step.cond = equality2tc(lhs, rhs)`, so reading `cond` on an assignment reports the definition as a use of itself. Worth recording: a Tier-A stub has no `cond` field to get wrong, so a transcription would have sailed past it.

## H-A1 as a Tier-A harness: built, measured, rejected

I built H-A1 exactly as §7.1 specifies — the full `name_record` key `(base_name, lev, l1_num, t_num)`, `hash` modelled as an arbitrary function of those fields so collisions stay possible, a linear-probed map, 3 assignments over a 16-key space:

| Harness | VCCs | Wall | Verdict |
|---|---|---|---|
| `symex_ssa_00` (M0 template, array-indexed key) | 163 | 4 s | `SUCCESSFUL` |
| H-A1 Tier-A (real `name_record` key, hash-probed map) | 4371 | **> 200 s** | none |
| H-A1 `_fail` twin | 4368 | 108 s | `FAILED` |

Rejected under §11.3 criterion 1 (no verdict) and the §11.2 budget (< 30 s/harness; the regression harness cap is a hard 120 s). Not committed — a green harness that never returns proves nothing, and the `_fail` twin finishing in half the time is the expected shape: finding one violating trace is easy, proving none exists is not.

## The rule that follows — new §6.4

Fidelity to the real data structure and ESBMC-tractability pull in opposite directions, so a Tier-A harness faithful enough to trust is often one ESBMC cannot discharge. §2.2 lists Tier A before Tier B; M0 and M1 read that as an ordering, and it is not one. §6.4 now states the actual priority — ask what the produced equation already shows (Tier B), then what a whole-tool oracle shows (Tier C), and write Tier A only for internal decisions the equation does not expose (R3's held reference, a `previous_frame` precondition, an MPOR relation). §10's M1 entry and §15 are updated to match.

## Testing

`ctest -LE regression` — 556/556 pass. clang-format clean.

## Still open in M1

H-A9 (I2/R3, the `valuet &entry` held across `rename`) and H-A7 (I16/R7, `previous_frame` on a stack of size < 2), both now Tier-B-first. Worth noting for R7: its single call site does `new_frame(...)` immediately before `previous_frame()`, so the precondition holds — but only via an `assert` that is a no-op in release (R1).