### PR TITLE
[goto-programs] Locate global initializers in __ESBMC_main

### DIFF
--- a/docs/roadmap/spike-v1k-w1loc.md
+++ b/docs/roadmap/spike-v1k-w1loc.md
@@ -461,3 +461,58 @@ group. Further native-coverage gains are guard-fallback reductions (low value pe
 slice) — better weighed against the other open Part V workstreams (the V.3
 converter-construction residue, or the V.5 IREP2-native counterexample printer)
 than pursued mechanically.
+
+## Appendix E — the `__ESBMC_main` divergence is closed; legacy was the wrong one (2026-07-27)
+
+The two standing `esbmc-cpp` mismatches (`cpp_sum_class`, `cpp_sum_class_bug`),
+recorded on the #6177/#6179/#6231 rows as "upstream of Phase C entirely and needs
+its own investigation", are resolved. Repro, on plain master, flag-on vs flag-off:
+
+```
+int nondet_int();
+int A = nondet_int();
+int main() { return 0; }
+```
+
+```
+legacy:  // 9                                ASSIGN A=NONDET(signed int);
+native:  // 9 file t.cpp line 2 column 1     ASSIGN A=NONDET(signed int);
+```
+
+**The native path was right and the legacy path was losing the location.** The
+byte-identity gate had been treating the *correct* output as the deviation, which
+is why three rows recorded it as an unexplained native-side anomaly.
+
+**Cause — the same top-down early return #6179 encoded around.** `init_variable`
+stamps each global's initializing `code_assignt` with the symbol's location
+(`clang_c_main.cpp:25`), but `static_lifetime_init` collects them into a
+`code_blockt` with **no** location of its own. `restore_value_locations` computed
+`here` as "own location, else inherited", and on an empty `here` returned
+immediately — abandoning the entire subtree, including child statements that *do*
+carry locations. So the global's value operands were never stamped, and
+`nondet_int()` being side-effecting, `remove_sideeffects` read the emitted
+instruction's location off the bare operand and produced an unlocated `ASSIGN`.
+Every other initializer in `__ESBMC_main` is located because its operands come
+from OM sources that were stamped in their own function bodies.
+
+Fixed by descending into code children unconditionally and gating only the
+*value* stamping on having a location, so a located statement inside an unlocated
+block governs its own subtree — the invariant #6179 gave the native dispatcher,
+now also on the legacy path. The two paths are byte-identical on the repro.
+
+**Blast radius.** This is the default path for every frontend, and the change is
+monotone: it can only turn a blank location into the enclosing statement's, never
+alter an existing one. Measured — coverage suite 19/19 (the named failure mode
+this helper exists to prevent), a stride-12 `python` slice 378/378, and a
+stride-7 `regression/esbmc` slice 743 tests / 47 failures of which 44 are
+`esbmc-solidity` (no `solc` on this host). The three non-Solidity failures
+(`esbmc-unix/04_valgrind`, `esbmc/char32-lit-no-simp`,
+`esbmc-cpp/cpp/github_6200_fail`) were **control-run against a stashed rebuild
+and fail identically without the patch**; only `char32-lit-no-simp` was on the
+recorded macOS baseline, so that baseline should gain the other two.
+
+Regression: `regression/esbmc-cpp/cpp/global_init_location{,_fail}`. The positive
+test pins the location by regex and was confirmed to **fail on a pre-patch
+build** and pass after — a location fix is otherwise invisible to a verdict-only
+test. It must be a C++ test: C rejects a non-constant global initializer, so the
+shape cannot be written in the C suite at all.

--- a/regression/esbmc-cpp/cpp/global_init_location/main.cpp
+++ b/regression/esbmc-cpp/cpp/global_init_location/main.cpp
@@ -1,0 +1,12 @@
+/* A global initialized by a side-effecting call lowers, inside the synthesized
+ * __ESBMC_main body, to an ASSIGN whose location comes from
+ * restore_value_locations. That block is unlocated, so the walk used to abandon
+ * the whole subtree and the instruction came out with no location at all. */
+int nondet_int();
+
+int A = nondet_int();
+
+int main()
+{
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/global_init_location/test.desc
+++ b/regression/esbmc-cpp/cpp/global_init_location/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--goto-functions-only
+^\s*// \d+ file .*main\.cpp line 7 column 1$
+^\s*ASSIGN A=NONDET\(signed int\);$

--- a/regression/esbmc-cpp/cpp/global_init_location_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/global_init_location_fail/main.cpp
@@ -1,0 +1,11 @@
+/* Negative counterpart: the located global initializer must still be a real
+ * nondet assignment the solver can violate. */
+int nondet_int();
+
+int A = nondet_int();
+
+int main()
+{
+  __ESBMC_assert(A == 42, "global is not always 42");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/global_init_location_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/global_init_location_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -131,14 +131,20 @@ static void restore_value_locations(exprt &code, const locationt &inherited)
   const locationt &here =
     (own.is_not_nil() && !own.get_file().empty()) ? own : inherited;
 
-  if (here.get_file().empty())
-    return; // no location to propagate yet
+  // Keep descending even with nothing to propagate: a nested statement may
+  // carry its own location and govern its own subtree. __ESBMC_main's
+  // synthesised block is the case that matters -- static_lifetime_init builds
+  // an unlocated code_blockt whose child assignments are located from their
+  // symbols (clang_c_main.cpp:25), so returning here left every global
+  // initializer's value operands bare, and a side-effecting one
+  // (`int A = nondet_int();`) lowered to an unlocated ASSIGN.
+  const bool have_location = !here.get_file().empty();
 
   Forall_operands (it, code)
   {
     if (it->is_code())
       restore_value_locations(*it, here);
-    else
+    else if (have_location)
       stamp_value_locations(*it, here);
   }
 }


### PR DESCRIPTION
`static_lifetime_init` collects located assignments into a `code_blockt` with no
location of its own, and `restore_value_locations` returned as soon as the
enclosing node had no location — abandoning child statements that *do* carry one.
A global initialized by a side-effecting call (`int A = nondet_int();`) therefore
lowered to an `ASSIGN` with no location at all. Descend into code children
unconditionally and gate only the value stamping, matching the invariant #6179
gave the native path.

This closes the two standing `esbmc-cpp` mismatches
(`cpp_sum_class`, `cpp_sum_class_bug`) that `docs/roadmap/spike-v1k-w1loc.md`
recorded as needing their own investigation — the native path was right and
legacy was losing the location. The regression test pins the location by regex
and was confirmed to fail on a pre-patch build.