### PR TITLE
[docs] goto-symex verification plan: M2 merge invariants at Tier B

### DIFF
--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -6,7 +6,7 @@ SMT backend.
 **Verifier:** ESBMC itself (BMC + k-induction) on extracted kernels; Catch2
 property/differential tests on the real classes (`unit/goto-symex/`);
 whole-tool metamorphic oracles over `regression/`; sanitizers for the rest.
-**Status:** **M0 and M1 complete** (§15 verdict log); M2–M8 not yet
+**Status:** **M0 and M1 complete, M2 partial** (§15 verdict log); M3–M8 not yet
 executed. §6.4 records the tier-ordering rule M1 produced. Except
 where §15 records a discharged result, every harness below is a *proposal* and
 nothing here asserts a proof. Findings R1–R12 remain *hypotheses with cited
@@ -722,6 +722,11 @@ plus a call-site argument. **M1 closed.**
 **M2 — Isolated core algorithms: merging and bounding (1.5 wk).**
 H-A2 (the highest-value harness), H-A3, H-A5. Dual-solver mandatory.
 *Artefact:* merge-soundness proof at arity 2 **and** 3; R2 `SYMEX_INVARIANT` PR.
+**Revised, §15 M2.** H-A2's and H-A3's obligations (I8, I6) are observable in the
+produced equation, so both are discharged at Tier B by
+`unit/goto-symex/merge.test.cpp` per §6.4 — no transcription, no dual-solver gate
+needed because no SMT query is involved. H-A5 is unstarted; R2's
+`SYMEX_INVARIANT` remains M3.
 
 **M3 — Release-mode enforcement (0.5 wk).** R1: introduce `SYMEX_INVARIANT`,
 promote the ~10 load-bearing asserts, measure the runtime cost on
@@ -1261,6 +1266,54 @@ WI-1, WI-2, D12. Next is **M2** (H-A2 merge-guard soundness, H-A3 merge-queue
 conservation, H-A5), which §6.4 requires be scoped Tier-B-first: `phi_function`
 and `merge_state_guards` are observable in the produced equation through phi
 assignment counts and step guards.
+### M2 (partial) — 2026-07-27
+
+**Result: I8 and I6 pinned against the real engine; R2's failure mode confirmed
+as unobserved on every shape tried.**
+
+| Artefact | What it drives | Result |
+|---|---|---|
+| `unit/goto-symex/merge.test.cpp` (H-A2 + H-A3) | real symex over two-armed, one-armed, nested, in-callee, early-return and in-loop branches | 7 cases, 31 assertions, **pass** |
+
+§4.3 ranks the merge machinery P0 — a lost path is a missed bug with no
+diagnostic — and both of its unenforced invariants turned out to be visible in
+the produced equation, so neither needed a transcription (§6.4).
+
+- **I8, emission** — a two-armed branch over nondet values produces exactly one
+  `ite` definition for the merged variable; a variable untouched in both arms
+  produces none; nested branches produce one per join; a branch in a 3×-unwound
+  loop produces at least one per iteration.
+- **I8, freshness** — the phi's L2 index is strictly greater than every index
+  previously defined for that key. A phi that reused one of its own inputs would
+  alias two distinct values under one SSA name, which is the I1/I10 violation
+  R3's stale-count scenario also produces.
+- **I8, one-armed merge** — for `if (c) x = …;` with no `else`, the emitted ite's
+  arms are distinct. This is the lost-behaviour direction: if the *pre-branch*
+  value were not one of the arms, the not-taken path would simply vanish from
+  the formula.
+- **I6 / R2** — after symex, every live frame's `merge_state_map` is empty. The
+  cases are chosen for where a snapshot could be orphaned: a branch inside a
+  callee (so the join and the `pop_frame` belong to the same frame), an early
+  `return` that jumps past a join, and a branch inside an unwound loop.
+
+Non-vacuity: the pending-merge count `REQUIRE`s a non-empty call stack before
+summing, so a zero cannot come from having examined nothing. Arm values are
+`nondet_int()` throughout — with constant arms, `simplify` folds the ite and the
+phi disappears, which would have made every emission assertion vacuous.
+
+**R2 is not retired by this.** These tests show the invariant holding on the
+shapes tried; R2 is that *nothing enforces it in the shipped binary*, since
+`pop_frame`'s `assert(merge_state_map.size() == 0)` is a no-op under NDEBUG.
+That remains true and remains M3's `SYMEX_INVARIANT` work. What the tests add is
+a durable regression: if a future change starts orphaning snapshots on any of
+these six shapes, this fails rather than silently dropping paths.
+
+**Still open in M2.** H-A5 (unwind bounding, `get_unwind` /
+`loop_bound_exceeded`) is unstarted. Note §11.3 and R12 both forbid pairing
+`--no-unwinding-assertions` with any reachability claim, so H-A5's Tier-C form
+(H-C6, unwind monotonicity: `FAILED` at `--unwind k` ⇒ `FAILED` at every
+`k' > k`) is the safer first cut and needs no oracle. Also still open from M0:
+WI-1, WI-2, D12.
 ---
 
 ## Appendix A — Methodological basis

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -2,3 +2,4 @@ new_unit_test(intrinsic-utils-test "intrinsic_utils.test.cpp" "symex;solvers;got
 new_unit_test(ssa-wellformed-test "ssa_wellformed.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(renaming-test "renaming.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(frame-lifecycle-test "frame_lifecycle.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(merge-test "merge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/merge.test.cpp
+++ b/unit/goto-symex/merge.test.cpp
@@ -1,0 +1,300 @@
+/*******************************************************************
+ Module: Path merging on the real engine
+
+ Tier B of docs/roadmap/goto-symex-verification-plan.md (H-A2 / H-A3, M2).
+
+ §4.3 ranks the merge machinery P0: a lost path is a missed bug with no
+ diagnostic anywhere. Two of its invariants are unenforced in the shipped
+ binary, and both are visible in the equation symex produces:
+
+   I8  (H-A2) `phi_function` emits an `ite` for a variable exactly when its L2
+       index differs between the two states, and the emitted definition is
+       fresh — it must not alias either value it selects between.
+   I6  (H-A3, finding R2) every `merge_statet` pushed at a join is consumed by
+       exactly one `merge_gotos`. `pop_frame` asserts the frame's
+       `merge_state_map` is empty; that assert is a no-op under NDEBUG, so in
+       the shipped binary a frame popped with pending merges drops those paths
+       silently.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <set>
+#include <string>
+
+#include <goto-symex/reachability_tree.h>
+#include <irep2/irep2_expr.h>
+#include <util/symtab/namespace.h>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+class engine
+{
+public:
+  explicit engine(std::string src)
+    : source(std::move(src)),
+      prog(goto_factory::get_goto_functions(
+        source,
+        goto_factory::Architecture::BIT_64)),
+      ns(prog.context),
+      opts(goto_factory::get_default_options(
+        goto_factory::get_default_cmdline("test.c"))),
+      rt(
+        prog.functions,
+        ns,
+        opts,
+        std::make_shared<symex_target_equationt>(ns),
+        prog.context)
+  {
+    opts.set_option("unwind", "4");
+    rt.setup_for_new_explore();
+  }
+
+  std::shared_ptr<symex_target_equationt> run()
+  {
+    auto eq = std::dynamic_pointer_cast<symex_target_equationt>(
+      rt.get_next_formula().target);
+    REQUIRE(eq != nullptr);
+    return eq;
+  }
+
+  /** Merge snapshots still pending on every live frame (I6 / R2). */
+  size_t pending_merges()
+  {
+    const auto &stack = rt.get_cur_state().get_active_state().call_stack;
+    // Guard against a vacuous zero: no frames would mean nothing was examined.
+    REQUIRE(!stack.empty());
+    size_t pending = 0;
+    for (const auto &frame : stack)
+      pending += frame.merge_state_map.size();
+    return pending;
+  }
+
+private:
+  std::string source;
+  program prog;
+  namespacet ns;
+  optionst opts;
+  reachability_treet rt;
+};
+
+bool is_ssa_symbol(const expr2tc &e)
+{
+  if (!is_symbol2t(e))
+    return false;
+  const symbol_renaming_level lev = to_symbol2t(e).rlevel;
+  return lev == symbol_renaming_level::level2 ||
+         lev == symbol_renaming_level::level2_global;
+}
+
+bool defines(const symex_target_equationt::SSA_stept &step, const char *var)
+{
+  return step.is_assignment() && is_ssa_symbol(step.lhs) &&
+         to_symbol2t(step.lhs).thename.as_string().find(var) !=
+           std::string::npos;
+}
+
+/** Assignments to `var` whose rhs is an ite — phi_function's output shape. */
+std::vector<const symex_target_equationt::SSA_stept *>
+phis_for(const symex_target_equationt &eq, const char *var)
+{
+  std::vector<const symex_target_equationt::SSA_stept *> found;
+  for (const auto &step : eq.SSA_steps)
+    if (defines(step, var) && !is_nil_expr(step.rhs) && is_if2t(step.rhs))
+      found.push_back(&step);
+  return found;
+}
+
+/** Highest L2 index defined for `var` strictly before `step`. */
+unsigned highest_index_before(
+  const symex_target_equationt &eq,
+  const char *var,
+  const symex_target_equationt::SSA_stept *step)
+{
+  unsigned highest = 0;
+  for (const auto &s : eq.SSA_steps)
+  {
+    if (&s == step)
+      break;
+    if (defines(s, var))
+      highest = std::max(highest, to_symbol2t(s.lhs).level2_num);
+  }
+  return highest;
+}
+} // namespace
+
+TEST_CASE("a two-armed branch merges into one fresh phi", "[symex][merge]")
+{
+  // Nondet arms so constant propagation cannot fold the selection away.
+  engine e(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = nondet_int();
+  if (nondet_int() > 0)
+    x = nondet_int();
+  else
+    x = nondet_int();
+  return x;
+}
+)");
+
+  auto eq = e.run();
+  const auto phis = phis_for(*eq, "@main@x");
+  REQUIRE(phis.size() == 1);
+
+  // I8 freshness: the phi must define a *new* SSA name, not reuse either of
+  // the values it selects between — reuse would alias two distinct values.
+  const unsigned phi_index = to_symbol2t(phis[0]->lhs).level2_num;
+  REQUIRE(phi_index > highest_index_before(*eq, "@main@x", phis[0]));
+
+  REQUIRE(e.pending_merges() == 0);
+}
+
+TEST_CASE("a one-armed branch still merges the untaken value", "[symex][merge]")
+{
+  // The lost-behaviour direction: if the else path's value were not one of the
+  // ite arms, the branch-not-taken case would vanish from the formula.
+  engine e(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = nondet_int();
+  if (nondet_int() > 0)
+    x = nondet_int();
+  return x;
+}
+)");
+
+  auto eq = e.run();
+  const auto phis = phis_for(*eq, "@main@x");
+  REQUIRE(phis.size() == 1);
+
+  const if2t &sel = to_if2t(phis[0]->rhs);
+  REQUIRE(sel.true_value != sel.false_value);
+  REQUIRE(e.pending_merges() == 0);
+}
+
+TEST_CASE("an untouched variable gets no phi", "[symex][merge]")
+{
+  // I8's filter chain: phi_function skips variables whose L2 index is equal in
+  // both states. A spurious phi here would be harmless but signals the
+  // "changed?" test is not doing its job.
+  engine e(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = nondet_int();
+  int untouched = nondet_int();
+  if (nondet_int() > 0)
+    x = nondet_int();
+  else
+    x = nondet_int();
+  return x + untouched;
+}
+)");
+
+  auto eq = e.run();
+  REQUIRE(phis_for(*eq, "@main@x").size() == 1);
+  REQUIRE(phis_for(*eq, "@main@untouched").empty());
+  REQUIRE(e.pending_merges() == 0);
+}
+
+TEST_CASE("nested branches merge at each join", "[symex][merge]")
+{
+  engine e(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = nondet_int();
+  if (nondet_int() > 0)
+  {
+    if (nondet_int() > 1)
+      x = nondet_int();
+    else
+      x = nondet_int();
+  }
+  else
+    x = nondet_int();
+  return x;
+}
+)");
+
+  auto eq = e.run();
+  // One join per branch construct.
+  REQUIRE(phis_for(*eq, "@main@x").size() == 2);
+  REQUIRE(e.pending_merges() == 0);
+}
+
+TEST_CASE(
+  "branches inside a called function leave no pending merge",
+  "[symex][merge]")
+{
+  // R2 is about a frame popped while its merge_state_map is non-empty. That
+  // needs a branch *inside a callee*, so the join and the pop belong to the
+  // same frame.
+  engine e(R"(
+int nondet_int(void);
+int pick(int a)
+{
+  int r = a;
+  if (nondet_int() > 0)
+    r = nondet_int();
+  else if (nondet_int() < 0)
+    r = nondet_int();
+  return r;
+}
+int main(void) { return pick(1) + pick(2); }
+)");
+
+  auto eq = e.run();
+  REQUIRE(!phis_for(*eq, "@pick@r").empty());
+  REQUIRE(e.pending_merges() == 0);
+}
+
+TEST_CASE("an early return leaves no pending merge", "[symex][merge]")
+{
+  // An early return jumps past the join, which is the shape most likely to
+  // orphan a snapshot in framet::merge_state_map.
+  engine e(R"(
+int nondet_int(void);
+int guarded(int a)
+{
+  if (a < 0)
+    return 0;
+  if (nondet_int() > 0)
+    return a + 1;
+  return a + 2;
+}
+int main(void) { return guarded(nondet_int()); }
+)");
+
+  auto eq = e.run();
+  REQUIRE(eq->SSA_steps.size() > 0);
+  REQUIRE(e.pending_merges() == 0);
+}
+
+TEST_CASE(
+  "a branch inside an unwound loop leaves no pending merge",
+  "[symex][merge]")
+{
+  engine e(R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = nondet_int();
+  for (int i = 0; i < 3; i++)
+    if (nondet_int() > 0)
+      x = nondet_int();
+  return x;
+}
+)");
+
+  auto eq = e.run();
+  REQUIRE(phis_for(*eq, "@main@x").size() >= 3);
+  REQUIRE(e.pending_merges() == 0);
+}


### PR DESCRIPTION
Stacked on #6450. Starts **M2** of `docs/roadmap/goto-symex-verification-plan.md` — H-A2 (which the plan calls "the highest-value harness") and H-A3.

§4.3 ranks the merge machinery **P0**: a lost path is a missed bug with no diagnostic anywhere. Both of its unenforced invariants turned out to be visible in the equation symex produces, so neither needed a transcription (§6.4).

`unit/goto-symex/merge.test.cpp` — 7 cases, 31 assertions, real symex over two-armed, one-armed, nested, in-callee, early-return and in-loop branches.

## I8 — `phi_function`'s emission and freshness

- **Emission** — a two-armed branch produces exactly one `ite` definition for the merged variable; a variable untouched in both arms produces none (I8's filter chain); nested branches produce one per join; a branch in a 3×-unwound loop produces at least one per iteration.
- **Freshness** — the phi's L2 index is strictly greater than every index previously defined for that key. A phi that reused one of its own inputs would alias two distinct values under one SSA name — the same I1/I10 violation R3's stale-count scenario produces.
- **The one-armed case** — for `if (c) x = …;` with no `else`, the emitted ite's arms must be distinct. This is the lost-behaviour direction: if the *pre-branch* value were not one of the arms, the not-taken path would simply vanish from the formula.

## I6 / R2 — no orphaned merge snapshot

After symex, every live frame's `merge_state_map` is empty. The cases are picked for where a snapshot could plausibly be orphaned:

- a branch **inside a callee**, so the join and the `pop_frame` belong to the same frame — this is exactly R2's shape;
- an **early `return`** that jumps past a join;
- a branch inside an **unwound loop**.

## Non-vacuity

Two things that would have made this suite pass while checking nothing, both closed:

- The pending-merge count `REQUIRE`s a non-empty call stack before summing, so a zero cannot come from having examined no frames.
- Arm values are `nondet_int()` throughout. With constant arms, `simplify` folds the ite away and the phi disappears — every emission assertion would have been vacuously satisfied by "no phi found".

## What this does *not* do

**R2 is not retired.** These tests show the invariant holding on the six shapes tried. R2 is that *nothing enforces it in the shipped binary* — `pop_frame`'s `assert(merge_state_map.size() == 0)` is a no-op under NDEBUG, so a frame popped with pending merges drops those paths silently and unboundedly. That remains true and remains M3's `SYMEX_INVARIANT` work. What this PR adds is the durable regression: if a future change starts orphaning snapshots on any of these shapes, this fails instead of silently losing paths.

No dual-solver gate here, because no SMT query is involved — these are assertions on the equation's structure, not verdicts.

## Testing

`ctest -LE regression` — 572/572 pass. clang-format clean, drift check clean.

## Still open in M2

H-A5 (unwind bounding — `get_unwind` / `loop_bound_exceeded`). Worth noting for whoever picks it up: §11.3 and R12 both forbid pairing `--no-unwinding-assertions` with any reachability claim, so H-A5's Tier-C form — **H-C6**, unwind monotonicity (`FAILED` at `--unwind k` ⇒ `FAILED` at every `k' > k`) — is the safer first cut and needs no oracle at all. Also still open from M0: WI-1, WI-2, D12.