### PR TITLE
[om] Guard <compare> so it is includable before C++20

### DIFF
--- a/regression/esbmc-cpp/cpp/github_3387_compare_default_std/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3387_compare_default_std/main.cpp
@@ -1,0 +1,13 @@
+// <compare> is a C++20 header, but libstdc++ and libc++ both let a translation
+// unit include it unconditionally in an older mode, where it expands to
+// nothing.  ESBMC's model used to be unguarded, so this program failed to parse
+// under the default language mode (github #3387).
+#include <compare>
+#include <cassert>
+
+int main()
+{
+  int a = 1, b = 2;
+  assert(a < b);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3387_compare_default_std/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3387_compare_default_std/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20/main.cpp
@@ -1,0 +1,15 @@
+// Including <compare> in C++17 must be a no-op rather than a parse error, and
+// must not disturb the rest of the translation unit (github #3387).
+#include <compare>
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(3);
+  v.push_back(1);
+  assert(v.size() == 2);
+  assert(v[0] > v[1]);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20_fail/main.cpp
@@ -1,0 +1,14 @@
+// Negative counterpart of github_3387_compare_pre_cxx20: the translation unit
+// is really verified after the <compare> include, not silently skipped.
+#include <compare>
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(3);
+  v.push_back(1);
+  assert(v[0] < v[1]);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_3387_compare_pre_cxx20_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/compare
+++ b/src/cpp/library/compare
@@ -9,6 +9,12 @@
 // The signed-char value layout matches the one libc++ and libstdc++ use,
 // which is also what Clang's compiler hooks for default <=> assume.
 
+// Everything below needs consteval, operator<=> and defaulted comparisons.
+// libstdc++ and libc++ both make this header expand to nothing before C++20
+// rather than erroring, so a translation unit that includes it unconditionally
+// still compiles in an older mode; match that (github #3387).
+#if __cplusplus >= 202002L
+
 namespace std
 {
 
@@ -311,5 +317,7 @@ constexpr bool is_gteq(partial_ordering c) noexcept
 }
 
 } // namespace std
+
+#endif // __cplusplus >= 202002L
 
 #endif


### PR DESCRIPTION
Refs #3387.

## Root cause

`src/cpp/library/compare` is a C++20-only model (`consteval`, `operator<=>`,
defaulted `operator==`) with no language-mode guard. Because ESBMC's bundled
headers *replace* the host standard library (`-nostdinc++`), any translation
unit that includes `<compare>` in a pre-C++20 mode hit a hard parse error:

```
compare:22:3: error: unknown type name 'consteval'; did you mean 'constexpr'?
compare:96:3: error: friends can only be classes or functions
ERROR: PARSING ERROR
```

This fires under **ESBMC's default language mode**, so it needs no flags to
reproduce. It went unnoticed because every existing `<compare>` test lives in
`regression/esbmc-cpp20/cpp/` and passes `--std c++20` explicitly.

Both real implementations expand `<compare>` to nothing before C++20 rather
than erroring (libstdc++ guards on `__cplusplus > 201703L`), so a TU that
includes it unconditionally still compiles in an older mode. Confirmed
differentially: `clang++ -std=c++03/11/14/17 -fsyntax-only` accepts the same
program that ESBMC rejected.

## Fix

Wrap the header body in `#if __cplusplus >= 202002L`, matching the guard
convention already used across the OM tree (`array`, `type_traits`, ...).
C++20 behaviour is untouched: preprocessing the header with `-std=c++20`
before and after the change yields byte-identical output, so this cannot
affect any existing C++20 result.

## Regression tests

* `esbmc-cpp/cpp/github_3387_compare_default_std` — the user-facing symptom:
  `#include <compare>` with **no** `--std` flag. SUCCESSFUL.
* `esbmc-cpp17/cpp/github_3387_compare_pre_cxx20` — include under
  `--std c++17` alongside `<vector>`; verifies the include is inert and does
  not disturb the rest of the TU. SUCCESSFUL.
* `esbmc-cpp17/cpp/github_3387_compare_pre_cxx20_fail` — negative counterpart,
  so the positive test cannot pass vacuously. FAILED.

All three were confirmed to reproduce `ERROR: PARSING ERROR` on a binary
rebuilt from the unfixed header, and to pass after the fix.

## Test suites

* `esbmc-cpp20/cpp` — 44/44 pass (no C++20 regression).
* `esbmc-cpp17/cpp` — 44/44 pass, including the two new tests.

## Scope / follow-up

This closes the `<compare>` instance only, not all of #3387. A differential
sweep of every bundled header against host clang shows further mode-guarding
gaps that ESBMC rejects and the real library accepts — notably `<limits>` and
`<chrono>` under `--std c++11`/`c++14`, and ~22 headers under `--std c++03`.
Those are separable and will be handled in follow-up PRs.