### PR TITLE
[cpp] Bind a reference parameter to the selected conditional arm

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param/main.cpp
@@ -1,0 +1,33 @@
+// A conditional whose arms are lvalues is an lvalue ([expr.cond]), so binding a
+// reference *parameter* to it must designate the selected arm.  The copy
+// constructor takes `const P &`, so `P r = c ? a : b;` binds one, and the
+// address the frontend synthesises for that binding used to cover neither arm
+// (github #6291 fixed only the source-level `&`).
+#include <cassert>
+
+struct P
+{
+  int v;
+};
+
+int by_ref(const P &x)
+{
+  return x.v;
+}
+
+int main()
+{
+  P a{1}, b{2};
+  int c = 0;
+
+  P copy_init = (c < 1) ? a : b;
+  assert(copy_init.v == 1);
+
+  P assigned;
+  assigned = (c < 1) ? a : b;
+  assert(assigned.v == 1);
+
+  assert(by_ref((c < 1) ? a : b) == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param_fail/main.cpp
@@ -1,0 +1,20 @@
+// Negative counterpart: the condition selects `b`, so the copy holds 2 and the
+// assertion must be violated.  Distributing the address over the arms must not
+// make the wrong arm satisfiable.
+#include <cassert>
+
+struct P
+{
+  int v;
+};
+
+int main()
+{
+  P a{1}, b{2};
+  int c = 5;
+
+  P copy_init = (c < 1) ? a : b;
+  assert(copy_init.v == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_param_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_shapes/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_shapes/main.cpp
@@ -1,0 +1,54 @@
+// Further shapes of the same binding, to keep the address-of distribution from
+// being narrowed later: a nested conditional (the distribution has to recurse),
+// arms that are struct members or array elements, and a scalar conditional,
+// which shows the defect was never specific to class types.
+#include <cassert>
+
+int nondet_int();
+
+struct P
+{
+  int v;
+};
+
+struct H
+{
+  P p, q;
+};
+
+void bump(P &x)
+{
+  x.v += 10;
+}
+
+void bump_int(int &x)
+{
+  x += 10;
+}
+
+int main()
+{
+  P a{1}, b{2}, c{3};
+  int i = 2;
+  bump(i < 1 ? a : (i < 3 ? b : c));
+  assert(a.v == 1 && b.v == 12 && c.v == 3);
+
+  H h;
+  h.p.v = 1;
+  h.q.v = 2;
+  bump(i < 1 ? h.p : h.q);
+  assert(h.p.v == 1 && h.q.v == 12);
+
+  P arr[2];
+  arr[0].v = 1;
+  arr[1].v = 2;
+  int n = nondet_int();
+  bump(n < 1 ? arr[0] : arr[1]);
+  assert((arr[0].v == 11 && arr[1].v == 2) || (arr[0].v == 1 && arr[1].v == 12));
+
+  int s = 1, t = 2;
+  bump_int(i < 1 ? s : t);
+  assert(s == 1 && t == 12);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_shapes/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_shapes/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write/main.cpp
@@ -1,0 +1,33 @@
+// Writing through a reference parameter bound to a conditional lvalue must hit
+// exactly the selected arm.  Before the fix the concrete case below bumped `b`
+// instead of `a`.  The nondeterministic case additionally pins that the bound
+// reference aliases one arm rather than both.
+#include <cassert>
+
+int nondet_int();
+
+struct P
+{
+  int v;
+};
+
+void bump(P &x)
+{
+  x.v += 10;
+}
+
+int main()
+{
+  P a{1}, b{2};
+  int c = 0;
+  bump((c < 1) ? a : b);
+  assert(a.v == 11);
+  assert(b.v == 2);
+
+  P p{1}, q{2};
+  int n = nondet_int();
+  bump((n < 1) ? p : q);
+  assert((p.v == 11 && q.v == 2) || (p.v == 1 && q.v == 12));
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write_fail/main.cpp
@@ -1,0 +1,28 @@
+// Negative counterpart of github_6291_conditional_ref_write: with the condition
+// nondeterministic, `b` is not always the arm that gets bumped, so pinning the
+// write to one specific arm must fail.  Guards against a fix that makes the
+// bound reference alias both arms at once.
+#include <cassert>
+
+int nondet_int();
+
+struct P
+{
+  int v;
+};
+
+void bump(P &x)
+{
+  x.v += 10;
+}
+
+int main()
+{
+  P a{1}, b{2};
+  int c = nondet_int();
+
+  bump((c < 1) ? a : b);
+  assert(b.v == 12);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6291_conditional_ref_write_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/util/lang/c_typecast.cpp
+++ b/src/util/lang/c_typecast.cpp
@@ -594,6 +594,30 @@ void c_typecastt::implicit_typecast(expr2tc &expr, const type2tc &type)
   implicit_typecast_followed(expr, src_type, dest_type);
 }
 
+/// Build the pointer that models a reference bound to \p expr.
+///
+/// A conditional whose arms are lvalues is itself an lvalue ([expr.cond]), so
+/// the address has to be taken per arm: `&(c ? a : b)` is `c ? &a : &b`. Left
+/// as `address_of(if(...))` the pointer analysis resolves neither arm and the
+/// bound reference silently designates the wrong object (#6291, #3387).
+static void take_reference_address(exprt &expr)
+{
+  if (
+    expr.id() == "if" && expr.operands().size() == 3 &&
+    expr.op1().type() == expr.op2().type())
+  {
+    take_reference_address(expr.op1());
+    take_reference_address(expr.op2());
+    expr.type() = expr.op1().type();
+    return;
+  }
+
+  address_of_exprt addr(expr);
+  addr.location() = expr.location();
+  addr.type().set("#reference", true);
+  expr.swap(addr);
+}
+
 void c_typecastt::implicit_typecast_followed(
   exprt &expr,
   const typet &src_type,
@@ -620,10 +644,7 @@ void c_typecastt::implicit_typecast_followed(
       src_type != dest_type &&
       !expr.is_address_of()) // TODO: remove this condition
     {
-      address_of_exprt addr(expr);
-      addr.location() = expr.location();
-      addr.type().set("#reference", true);
-      expr.swap(addr);
+      take_reference_address(expr);
     }
     else
     {


### PR DESCRIPTION
Completes #6291, which fixed only part of the problem.

## Symptom

ESBMC reports a spurious `VERIFICATION FAILED` on trivial, well-formed C++:

```cpp
#include <cassert>
struct P { int v; };
int main() {
  P a{1}, b{2};
  int c = 0;
  P r = (c < 1) ? a : b;   // c<1 is true -> copies a
  assert(r.v == 1);        // VERIFICATION FAILED
}
```

Worse than a false alarm, it is a wrong-object bug: writing through the
binding hits the *other* arm. With `void bump(P &x){ x.v += 10; }` and
`bump((c < 1) ? a : b)`, `b` is bumped instead of `a`. The counterexample
shows the copy constructor storing `{ .v=2 }`, i.e. the false arm.

## Root cause

A conditional whose arms are lvalues is itself an lvalue ([expr.cond]), so a
reference may bind to it. ESBMC models references as pointers, so the binding
becomes `address_of(if(cond, a, b))` — a single address that designates
neither arm, which the pointer analysis cannot resolve.

#6291 fixed this by distributing the address over the arms in
`clang_c_adjust::adjust_address_of` — `&(c ? a : b)` becomes `c ? &a : &b`.
That covers a **source-level** address-of only. The reference bindings the
frontend *synthesises* are built by `c_typecastt::implicit_typecast_followed`
(`src/util/lang/c_typecast.cpp`), which runs **after** `adjust_expr` and
constructs `address_of_exprt` directly, so it never reaches that distribution.

That is why the surviving cases are exactly the synthesised ones:

| form | before |
|---|---|
| `P *p = &((c<1)?a:b);` | correct (source-level address-of) |
| `P &r = (c<1)?a:b;` | correct |
| `P r = (c<1)?a:b;` (copy ctor taking `const P&`) | **wrong** |
| `r = (c<1)?a:b;` (`operator=`) | **wrong** |
| `f((c<1)?a:b)` (reference parameter) | **wrong** |

It is not C++-specific plumbing: `c_typecast.cpp` is shared, and the same
function already special-cases `if` for array-to-pointer decay a few lines
down — the reference branch simply lacked the equivalent.

Found while auditing `<compare>`: `std::is_lt(a <=> b)` returned the wrong
answer because `strong_ordering::operator partial_ordering()` returns
`v < 0 ? partial_ordering::less : partial_ordering::greater`, and that
class-typed conditional was mis-bound. So this silently corrupted results in
the shipped operational models too.

## Fix

Factor the reference-address construction into `take_reference_address()` and
recurse into the arms of a conditional, so the binding designates the selected
arm. Non-`if` expressions take exactly the previous path (same `address_of`,
same `#reference` flag), and recursion handles nested conditionals. The guard
requires both arms to have the same type, matching `adjust_address_of`.

## Regression tests

Under `regression/esbmc-cpp/cpp/`, all in the default language mode:

* `github_6291_conditional_ref_param` — copy-init, `operator=` and a
  reference parameter through a conditional. SUCCESSFUL. **Reproduces
  pre-fix** (FAILED).
* `github_6291_conditional_ref_write` — writes through a reference parameter
  bound to a conditional: concrete condition (`a` bumped, `b` untouched) plus
  a nondeterministic condition asserting exactly one arm changed.
  SUCCESSFUL. **Reproduces pre-fix** (FAILED — it bumped the wrong object).
* `github_6291_conditional_ref_param_fail` — condition selects the other arm;
  must stay FAILED, so the fix cannot make the wrong arm satisfiable.
* `github_6291_conditional_ref_write_fail` — nondeterministic condition
  pinning the write to one specific arm; must stay FAILED, so the reference
  cannot alias both arms at once.

* `github_6291_conditional_ref_shapes` — a nested conditional (which
  exercises the recursion in the distribution), arms that are struct members
  or array elements, and a scalar conditional showing the defect was never
  specific to class types. SUCCESSFUL. **Reproduces pre-fix** (FAILED).

The two `_fail` tests are deliberately guards rather than reproducers: they
already passed before the fix, and they are what keeps the fix from being
over-permissive.

## Test suites

Because `c_typecast.cpp` is shared by all frontends, both large suites were
run against a **master baseline built from the same tree**, and the failure
sets diffed:

* `regression/esbmc` (C) — 1544 tests, 8 failures, **identical to the master
  baseline** (pre-existing: `bitvector_02/03`, `char16/32-lit*`,
  `github_1537-*`).
* `esbmc-cpp/*` (C++) — the 9 failures reproduce identically on the master
  baseline (pre-existing macOS host-header breakage).
* `esbmc-cpp11 / 14 / 17 / 20` — pass, except `esbmc-cpp14/template/builtin-template*`,
  which uses `--no-abstracted-cpp-includes` and fails in clang's header search
  on macOS before any typecast code runs.

`clang-format` 11 clean.
