### PR TITLE
[om] Fix <limits> under --std c++11 and c++14

### DIFF
--- a/regression/esbmc-cpp11/cpp/github_3387_chrono_cxx11/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3387_chrono_cxx11/main.cpp
@@ -1,0 +1,13 @@
+// <chrono> includes <limits>, so it was collateral damage of the same
+// pre-C++17 parse failure (github #3387).
+#include <chrono>
+#include <cassert>
+
+int main()
+{
+  std::chrono::seconds s(3);
+  std::chrono::milliseconds ms = std::chrono::duration_cast<
+    std::chrono::milliseconds>(s);
+  assert(ms.count() == 3000);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_3387_chrono_cxx11/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3387_chrono_cxx11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11/main.cpp
@@ -1,0 +1,27 @@
+// <limits> used FLT_DECIMAL_DIG / FLT_TRUE_MIN and friends, which <float.h>
+// only exposes from C11 / C++17 on, so the header failed to parse under
+// --std c++11 and c++14 (github #3387).  The values asserted here match the
+// host standard library.
+#include <limits>
+#include <cassert>
+
+int main()
+{
+  assert(std::numeric_limits<float>::max_digits10 == 9);
+  assert(std::numeric_limits<double>::max_digits10 == 17);
+
+  assert(std::numeric_limits<float>::denorm_min() > 0.0F);
+  assert(
+    std::numeric_limits<float>::denorm_min() <
+    std::numeric_limits<float>::min());
+  assert(std::numeric_limits<double>::denorm_min() > 0.0);
+  assert(
+    std::numeric_limits<double>::denorm_min() <
+    std::numeric_limits<double>::min());
+
+  assert(std::numeric_limits<float>::digits == 24);
+  assert(std::numeric_limits<double>::digits == 53);
+  assert(std::numeric_limits<int>::is_specialized);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11_fail/main.cpp
@@ -1,0 +1,10 @@
+// Negative counterpart of github_3387_limits_cxx11: max_digits10 for float is
+// 9, not 8, so the program is really verified rather than passing vacuously.
+#include <limits>
+#include <cassert>
+
+int main()
+{
+  assert(std::numeric_limits<float>::max_digits10 == 8);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3387_limits_cxx11_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/limits
+++ b/src/cpp/library/limits
@@ -563,7 +563,7 @@ public:
   static constexpr bool is_modulo = false;
   static constexpr int digits = FLT_MANT_DIG;
   static constexpr int digits10 = FLT_DIG;
-  static constexpr int max_digits10 = FLT_DECIMAL_DIG;
+  static constexpr int max_digits10 = __FLT_DECIMAL_DIG__;
   static constexpr int radix = FLT_RADIX;
   static constexpr int min_exponent = FLT_MIN_EXP;
   static constexpr int min_exponent10 = FLT_MIN_10_EXP;
@@ -580,7 +580,7 @@ public:
   static constexpr float infinity() noexcept { return __builtin_huge_valf(); }
   static constexpr float quiet_NaN() noexcept { return __builtin_nanf(""); }
   static constexpr float signaling_NaN() noexcept { return __builtin_nansf(""); }
-  static constexpr float denorm_min() noexcept { return FLT_TRUE_MIN; }
+  static constexpr float denorm_min() noexcept { return __FLT_DENORM_MIN__; }
 };
 
 // double
@@ -603,7 +603,7 @@ public:
   static constexpr bool is_modulo = false;
   static constexpr int digits = DBL_MANT_DIG;
   static constexpr int digits10 = DBL_DIG;
-  static constexpr int max_digits10 = DBL_DECIMAL_DIG;
+  static constexpr int max_digits10 = __DBL_DECIMAL_DIG__;
   static constexpr int radix = FLT_RADIX;
   static constexpr int min_exponent = DBL_MIN_EXP;
   static constexpr int min_exponent10 = DBL_MIN_10_EXP;
@@ -620,7 +620,7 @@ public:
   static constexpr double infinity() noexcept { return __builtin_huge_val(); }
   static constexpr double quiet_NaN() noexcept { return __builtin_nan(""); }
   static constexpr double signaling_NaN() noexcept { return __builtin_nans(""); }
-  static constexpr double denorm_min() noexcept { return DBL_TRUE_MIN; }
+  static constexpr double denorm_min() noexcept { return __DBL_DENORM_MIN__; }
 };
 
 // long double
@@ -643,7 +643,7 @@ public:
   static constexpr bool is_modulo = false;
   static constexpr int digits = LDBL_MANT_DIG;
   static constexpr int digits10 = LDBL_DIG;
-  static constexpr int max_digits10 = LDBL_DECIMAL_DIG;
+  static constexpr int max_digits10 = __LDBL_DECIMAL_DIG__;
   static constexpr int radix = FLT_RADIX;
   static constexpr int min_exponent = LDBL_MIN_EXP;
   static constexpr int min_exponent10 = LDBL_MIN_10_EXP;
@@ -660,7 +660,7 @@ public:
   static constexpr long double infinity() noexcept { return __builtin_huge_vall(); }
   static constexpr long double quiet_NaN() noexcept { return __builtin_nanl(""); }
   static constexpr long double signaling_NaN() noexcept { return __builtin_nansl(""); }
-  static constexpr long double denorm_min() noexcept { return LDBL_TRUE_MIN; }
+  static constexpr long double denorm_min() noexcept { return __LDBL_DENORM_MIN__; }
 };
 
 } // namespace std


### PR DESCRIPTION
Refs #3387.

## Root cause

`src/cpp/library/limits` spells three of the `numeric_limits` members with
macros from `<float.h>`:

```cpp
static constexpr int   max_digits10 = FLT_DECIMAL_DIG;
static constexpr float denorm_min() noexcept { return FLT_TRUE_MIN; }
```

`FLT_DECIMAL_DIG` and `FLT_TRUE_MIN` (and the `DBL_`/`LDBL_` variants) were
added to `<float.h>` by C11, and clang's `float.h` guards them on
`__STDC_VERSION__ >= 201112L || __cplusplus >= 201703L`. ESBMC ships no
`float.h` of its own, so under `--std c++11` and `--std c++14` the macros are
simply not declared and the header fails to parse:

```
limits:566:39: error: use of undeclared identifier 'FLT_DECIMAL_DIG'
limits:566:24: error: declaration of constexpr static data member 'max_digits10' requires an initializer
limits:583:57: error: use of undeclared identifier 'FLT_TRUE_MIN'
ERROR: PARSING ERROR
```

`<limits>` is a C++98 header, so this breaks two mainstream language modes, and
it takes `<chrono>` down with it since `<chrono>` includes `<limits>`. It went
unnoticed because the default mode is C++17, where the macros are visible.

Found by a differential sweep of every bundled header against host clang with
the real standard library: `clang++ -std=c++11 -fsyntax-only` accepts the same
programs ESBMC rejected.

## Fix

Use the compiler's predefined `__FLT_DECIMAL_DIG__` / `__FLT_DENORM_MIN__` (and
the `DBL_`/`LDBL_` variants) instead. Clang predefines these in **every**
language mode, and this is exactly what libc++'s own `<limits>` does.

The substitution is value-preserving — `FLT_DECIMAL_DIG == __FLT_DECIMAL_DIG__`
and `FLT_TRUE_MIN == __FLT_DENORM_MIN__` (the C11 "minimum positive value
including subnormals" *is* the denormal minimum). Verified by `static_assert`
on all six pairs against the host `<float.h>`, and by asserting the resulting
`numeric_limits` values in the tests below, which pass identically under host
clang and ESBMC.

## Regression tests

Under `regression/esbmc-cpp11/cpp/`, all with `--std c++11`:

* `github_3387_limits_cxx11` — asserts `max_digits10` is 9 / 17 for
  float / double, that `denorm_min()` is positive and below `min()` for both,
  and `digits` is 24 / 53. SUCCESSFUL. Cross-checked: the identical program
  compiles and runs clean under `clang++ -std=c++11` with the real libc++.
* `github_3387_chrono_cxx11` — a `duration_cast` from seconds to
  milliseconds, covering the collateral `<chrono>` breakage. SUCCESSFUL.
  Also cross-checked against host clang.
* `github_3387_limits_cxx11_fail` — asserts `max_digits10 == 8`; must stay
  FAILED, so the positive test cannot pass vacuously.

All three were confirmed to reproduce `ERROR: PARSING ERROR` on a binary
rebuilt from the unfixed header.

## Test suites

* `esbmc-cpp11 / 14 / 17 / 20` — pass, including the three new tests. The only
  failures are `esbmc-cpp14/template/builtin-template*`, which use
  `--no-abstracted-cpp-includes` and fail in clang's header search on macOS
  before any of this code is reached.
* `esbmc-cpp/*` — the 9 failures are identical to the master baseline built
  from the same tree (pre-existing macOS host-header breakage).
* `floats` / `floats-regression` — the 2 failures (`isinf_ir_ieee`,
  `underflow8`) are C tests (`main.c`) that never include the C++ `<limits>`
  model, so they are structurally unrelated; pre-existing macOS FP breakage.

## Scope / follow-up

`--std c++03` remains broken for `<limits>`, but for an unrelated reason — the
header is written with `constexpr` throughout and needs the `OM_CONSTEXPR`
treatment from `OM_compiler_defs.h`. That is part of a larger C++03 gap
(~22 headers, including `<vector>` and `<typeinfo>`, which use `nullptr` and
other C++11 syntax unguarded) and is left to a separate change.
