### PR TITLE
[om] Make <array> usable in C++11 and guard <bit>/<span>/<expected>

### DIFF
--- a/regression/esbmc-cpp11/cpp/github_3387_array_cxx11/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3387_array_cxx11/main.cpp
@@ -1,0 +1,26 @@
+// <array> is a C++11 header, but its relational operators were unconditionally
+// constexpr while looping, which a C++11 constexpr body may not do, so the
+// whole header failed to parse under --std c++11 (github #3387).
+#include <array>
+#include <cassert>
+
+int main()
+{
+  std::array<int, 3> a = {{1, 2, 3}};
+  std::array<int, 3> b = {{1, 2, 3}};
+  std::array<int, 3> c = {{1, 2, 4}};
+
+  assert(a == b);
+  assert(a != c);
+  assert(a < c);
+  assert(c > a);
+  assert(a <= b);
+  assert(a >= b);
+
+  assert(a.size() == 3);
+  assert(a.at(1) == 2);
+  a.fill(7);
+  assert(a[0] == 7 && a[2] == 7);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_3387_array_cxx11/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3387_array_cxx11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/github_3387_array_cxx11_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3387_array_cxx11_fail/main.cpp
@@ -1,0 +1,14 @@
+// Negative counterpart of github_3387_array_cxx11: the arrays differ in the
+// last element, so the equality must not hold.
+#include <array>
+#include <cassert>
+
+int main()
+{
+  std::array<int, 3> a = {{1, 2, 3}};
+  std::array<int, 3> c = {{1, 2, 4}};
+
+  assert(a == c);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_3387_array_cxx11_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3387_array_cxx11_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/github_3387_newer_headers_inert/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3387_newer_headers_inert/main.cpp
@@ -1,0 +1,16 @@
+// <bit> and <span> are C++20 headers and <expected> is C++23.  libstdc++ and
+// libc++ expand them to nothing in an older mode rather than erroring, so a
+// translation unit that includes them unconditionally still compiles; ESBMC's
+// models used to be unguarded and failed to parse (github #3387).
+#include <bit>
+#include <span>
+#include <expected>
+#include <array>
+#include <cassert>
+
+int main()
+{
+  std::array<int, 2> a = {{4, 5}};
+  assert(a[0] + a[1] == 9);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_3387_newer_headers_inert/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3387_newer_headers_inert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/array
+++ b/src/cpp/library/array
@@ -11,6 +11,15 @@
 #  define __ESBMC_ARRAY_CONSTEXPR_17
 #endif
 
+// The relational operators loop, which a C++11 constexpr function body may not
+// do; relaxed constexpr arrived in C++14. The standard only makes these
+// constexpr in C++20 anyway (github #3387).
+#if __cplusplus >= 201402L
+#  define __ESBMC_ARRAY_CONSTEXPR_14 constexpr
+#else
+#  define __ESBMC_ARRAY_CONSTEXPR_14
+#endif
+
 namespace std
 {
 #if __cplusplus >= 201103L
@@ -185,7 +194,8 @@ __ESBMC_ARRAY_CONSTEXPR_17 void swap(array<T, N> &a, array<T, N> &b) noexcept
 }
 
 template <typename T, std::size_t N>
-constexpr bool operator==(const array<T, N> &a, const array<T, N> &b)
+__ESBMC_ARRAY_CONSTEXPR_14 bool
+operator==(const array<T, N> &a, const array<T, N> &b)
 {
   for (std::size_t i = 0; i < N; ++i)
   {
@@ -196,13 +206,15 @@ constexpr bool operator==(const array<T, N> &a, const array<T, N> &b)
 }
 
 template <typename T, std::size_t N>
-constexpr bool operator!=(const array<T, N> &a, const array<T, N> &b)
+__ESBMC_ARRAY_CONSTEXPR_14 bool
+operator!=(const array<T, N> &a, const array<T, N> &b)
 {
   return !(a == b);
 }
 
 template <typename T, std::size_t N>
-constexpr bool operator<(const array<T, N> &a, const array<T, N> &b)
+__ESBMC_ARRAY_CONSTEXPR_14 bool
+operator<(const array<T, N> &a, const array<T, N> &b)
 {
   for (std::size_t i = 0; i < N; ++i)
   {
@@ -215,19 +227,22 @@ constexpr bool operator<(const array<T, N> &a, const array<T, N> &b)
 }
 
 template <typename T, std::size_t N>
-constexpr bool operator<=(const array<T, N> &a, const array<T, N> &b)
+__ESBMC_ARRAY_CONSTEXPR_14 bool
+operator<=(const array<T, N> &a, const array<T, N> &b)
 {
   return !(b < a);
 }
 
 template <typename T, std::size_t N>
-constexpr bool operator>(const array<T, N> &a, const array<T, N> &b)
+__ESBMC_ARRAY_CONSTEXPR_14 bool
+operator>(const array<T, N> &a, const array<T, N> &b)
 {
   return b < a;
 }
 
 template <typename T, std::size_t N>
-constexpr bool operator>=(const array<T, N> &a, const array<T, N> &b)
+__ESBMC_ARRAY_CONSTEXPR_14 bool
+operator>=(const array<T, N> &a, const array<T, N> &b)
 {
   return !(a < b);
 }

--- a/src/cpp/library/bit
+++ b/src/cpp/library/bit
@@ -4,6 +4,11 @@
 #include "cstdint"
 #include "type_traits"
 
+// C++20 header: libstdc++ and libc++ both expand it to nothing in an
+// older language mode rather than erroring, so a translation unit that
+// includes it unconditionally still compiles (github #3387).
+#if __cplusplus >= 202002L
+
 namespace std
 {
 
@@ -148,5 +153,7 @@ enum class endian
 };
 
 } // namespace std
+
+#endif // __cplusplus >= 202002L
 
 #endif

--- a/src/cpp/library/expected
+++ b/src/cpp/library/expected
@@ -17,6 +17,11 @@
 // monadic and_then / or_else / transform; in_place / unexpect tags;
 // and reference-typed expected<T&,E>.
 
+// C++23 header: libstdc++ and libc++ both expand it to nothing in an
+// older language mode rather than erroring, so a translation unit that
+// includes it unconditionally still compiles (github #3387).
+#if __cplusplus >= 202302L
+
 namespace std
 {
 
@@ -207,5 +212,7 @@ public:
 };
 
 } // namespace std
+
+#endif // __cplusplus >= 202302L
 
 #endif

--- a/src/cpp/library/span
+++ b/src/cpp/library/span
@@ -6,6 +6,11 @@
 #include "bit"      /* std::bit_cast (transitive, matches libc++/libstdc++) */
 #include "type_traits"
 
+// C++20 header: libstdc++ and libc++ both expand it to nothing in an
+// older language mode rather than erroring, so a translation unit that
+// includes it unconditionally still compiles (github #3387).
+#if __cplusplus >= 202002L
+
 namespace std
 {
 
@@ -134,3 +139,5 @@ template <class T>
 span(T *, T *) -> span<T>;
 
 } // namespace std
+
+#endif // __cplusplus >= 202002L


### PR DESCRIPTION
Refs #3387. Third of the language-mode header failures found by the
differential sweep (after #6455 for `<compare>` and #6457 for `<limits>`).

## Root cause

Two distinct defects, both surfacing as `ERROR: PARSING ERROR` from inside an
ESBMC temp directory. Because the bundled headers *replace* the host standard
library (`-nostdinc++`), a model that does not compile in a given language mode
makes that header unusable, even though host clang accepts the same program.

**1. `<array>` is a C++11 header that did not parse under `--std c++11.`**
Its relational operators were unconditionally `constexpr` while looping:

```cpp
template <typename T, std::size_t N>
constexpr bool operator==(const array<T, N> &a, const array<T, N> &b)
{
  for (std::size_t i = 0; i < N; ++i)   // array:190: statement not allowed
    ...                                 //            in constexpr function
}
```

A C++11 `constexpr` function body must be a single `return`; relaxed
`constexpr` only arrived in C++14. The file already had
`__ESBMC_ARRAY_CONSTEXPR_17` for the C++17-only members, but the relational
operators were missed. This also took `<span>` down with it, since `<span>`
includes `<array>`.

**2. `<bit>`, `<span>` (C++20) and `<expected>` (C++23) had no mode guard.**
Both real implementations expand these to nothing before their standard rather
than erroring, so a TU that includes one unconditionally still compiles in an
older mode. ESBMC's models were plain unguarded source and failed to parse.

Differentially confirmed — before this change, for `#include <H>` plus an
empty `main`:

| header | c++11 | c++14 | c++17 | c++20 | c++23 |
|---|---|---|---|---|---|
| `array` | **ERR** | OK | OK | OK | OK |
| `bit` | **ERR** | OK | OK | OK | OK |
| `span` | **ERR** | **ERR** | OK | OK | OK |
| `expected` | **ERR** | **ERR** | OK | OK | OK |

`clang++ -std=<mode> -fsyntax-only` accepts every one of these cells. After the
change ESBMC matches host clang in all 20.

## Fix

* `<array>`: add `__ESBMC_ARRAY_CONSTEXPR_14`, mirroring the existing
  `__ESBMC_ARRAY_CONSTEXPR_17`, and apply it to all six relational operators.
  Gating on C++14 rather than C++20 (where the standard actually makes them
  `constexpr`) is deliberate: it preserves today's C++14/17/20 behaviour
  exactly and only changes C++11, which was a hard error.
* `<bit>`, `<span>`: wrap in `#if __cplusplus >= 202002L`.
* `<expected>`: wrap in `#if __cplusplus >= 202302L`.

Guarding cannot regress existing users of these three headers: every test in
the tree that includes them already passes the matching `--std` (`c++20` for
`<bit>`/`<span>`, `c++23` for `<expected>`), and they all still pass.

The existing `constexpr`-`std::array` tests (`github_4269_constexpr_array`,
`github_4269_constexpr_array_at`) exercise `at()`/`operator[]` under
`__ESBMC_ARRAY_CONSTEXPR_17`, not the relational operators, so they are
unaffected.

## Regression tests

Under `regression/esbmc-cpp11/cpp/`, all with `--std c++11`:

* `github_3387_array_cxx11` — all six relational operators plus `size()`,
  `at()`, `fill()` and `operator[]`. SUCCESSFUL. **Reproduces pre-fix**
  (`array:190:3: statement not allowed in constexpr function`). The identical
  program compiles and runs clean under `clang++ -std=c++11`.
* `github_3387_array_cxx11_fail` — arrays that differ in the last element must
  not compare equal; must stay FAILED, so the positive test cannot pass
  vacuously.
* `github_3387_newer_headers_inert` — includes `<bit>`, `<span>` and
  `<expected>` together in C++11 and still uses `std::array`, checking the
  includes are inert rather than fatal *and* do not disturb the rest of the
  TU. SUCCESSFUL. **Reproduces pre-fix** (`bit:58:3`). Also cross-checked
  against host clang.

## Test suites

* `esbmc-cpp11 / 14 / 17 / 20` — pass, including the three new tests and every
  existing `<bit>` / `<span>` / `<expected>` test. The only failures are
  `esbmc-cpp14/template/builtin-template*`, which use
  `--no-abstracted-cpp-includes` and fail in clang's header search on macOS
  before any of this is reached.
* `esbmc-cpp/*` — the 9 failures are identical to the master baseline built
  from the same tree (pre-existing macOS host-header breakage). This suite
  includes the C++20 `<bit>` and `<span>` tests (`github_4191*`,
  `github_4247*`, `github_4270_span_*`), all of which pass.

`clang-format` 11 clean (the touched declarations were reflowed to 80 columns).

## Scope / follow-up

`--std c++03` is still broken for a larger set of headers — `<vector>`,
`<list>`, `<map>`, `<queue>`, `<stack>` use `nullptr`, and `<limits>` /
`<typeinfo>` use `constexpr`, all unguarded. That needs the `OM_CONSTEXPR` /
`OM_NULLPTR` treatment from `OM_compiler_defs.h` applied across the container
models and is left to a separate change.
