### PR TITLE
[om] Make the C++98 container headers parse under --std c++03

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03/main.cpp
@@ -1,0 +1,52 @@
+// Pin issue #3387: the C++98 container headers must parse and verify under
+// --std c++03.  <vector> used nullptr and an unguarded variadic emplace_back,
+// <map> an unguarded initializer_list ctor, <stack>/<queue> `>>` where C++03
+// needs `> >`, and <typeinfo> spelled its what() overrides with a macro that
+// vanished in C++03 and so relaxed the base's throw() specification.
+// <list>, <map>, <queue> and <stack> all include <vector>, so they failed too.
+#include <cassert>
+#include <vector>
+#include <list>
+#include <map>
+#include <set>
+#include <deque>
+#include <stack>
+#include <queue>
+#include <typeinfo>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  assert(v.size() == 2 && v[0] == 1 && v[1] == 2);
+
+  std::list<int> l;
+  l.push_back(7);
+  assert(l.size() == 1 && l.front() == 7);
+
+  std::map<int, int> m;
+  m[3] = 30;
+  assert(m.size() == 1 && m[3] == 30);
+
+  std::set<int> s;
+  s.insert(5);
+  assert(s.size() == 1);
+
+  std::deque<int> d;
+  d.push_back(9);
+  assert(d.size() == 1 && d[0] == 9);
+
+  std::stack<int> st;
+  st.push(4);
+  assert(st.size() == 1 && st.top() == 4);
+
+  std::queue<int> q;
+  q.push(6);
+  assert(q.size() == 1 && q.front() == 6);
+
+  const std::type_info &ti = typeid(int);
+  assert(ti == typeid(int));
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative counterpart of github_3387_containers_c++03: the vector holds 2
+// elements, so the program is really verified rather than passing vacuously.
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  assert(v.size() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_containers_c++03_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -525,6 +525,7 @@ public:
     }
   }
 
+#if __cplusplus >= 201103L
   map(std::initializer_list<value_type> list)
   {
     this->_size = list.size();
@@ -535,6 +536,7 @@ public:
       this->_value[i] = (begin + i)->second;
     }
   }
+#endif
 
   T &operator[](const Key &x)
   {

--- a/src/cpp/library/queue
+++ b/src/cpp/library/queue
@@ -13,7 +13,7 @@ namespace std
 template <
   class T,
   class Container = vector<T>,
-  class Compare = less<typename Container::value_type>>
+  class Compare = less<typename Container::value_type> >
 class priority_queue
 {
   T buf[QUEUE_CAPACITY];
@@ -110,7 +110,7 @@ public:
   }
 };
 
-template <class T, class Container = deque<T>>
+template <class T, class Container = deque<T> >
 class queue
 {
   T buf[QUEUE_CAPACITY];

--- a/src/cpp/library/stack
+++ b/src/cpp/library/stack
@@ -10,7 +10,7 @@ namespace std
 #define STACK_CAPACITY 20
 
 // Forward declarations for specializations
-template <class T, class Container = deque<T>>
+template <class T, class Container = deque<T> >
 class stack;
 
 // Base template
@@ -88,7 +88,7 @@ public:
 
 // Specialization for list
 template <class T>
-class stack<T, list<T>>
+class stack<T, list<T> >
 {
   T buf[STACK_CAPACITY];
   size_t _top;
@@ -160,7 +160,7 @@ public:
 
 // Specialization for vector
 template <class T>
-class stack<T, vector<T>>
+class stack<T, vector<T> >
 {
   T buf[STACK_CAPACITY];
   size_t _top;
@@ -237,7 +237,7 @@ public:
 
 // Specialization for deque
 template <class T>
-class stack<T, deque<T>>
+class stack<T, deque<T> >
 {
   T buf[STACK_CAPACITY];
   size_t _top;

--- a/src/cpp/library/typeinfo
+++ b/src/cpp/library/typeinfo
@@ -44,28 +44,28 @@ public:
 
   // Pointer equality: two typeid results for the same type get the same
   // string literal address, so this is both fast and correct.
-  bool operator==(const type_info &arg) const noexcept
+  bool operator==(const type_info &arg) const _ESBMC_NOEXCEPT
   {
     return __name == arg.__name;
   }
 
-  bool operator!=(const type_info &arg) const noexcept
+  bool operator!=(const type_info &arg) const _ESBMC_NOEXCEPT
   {
     return __name != arg.__name;
   }
 
   // Returns the concrete string pointer set by CXXTypeidExprClass.
-  const char *name() const noexcept
+  const char *name() const _ESBMC_NOEXCEPT
   {
     return __name;
   }
 
-  size_t hash_code() const noexcept
+  size_t hash_code() const _ESBMC_NOEXCEPT
   {
     return (size_t)__name;
   }
 
-  bool before(const type_info &arg) const noexcept
+  bool before(const type_info &arg) const _ESBMC_NOEXCEPT
   {
     return (size_t)__name < (size_t)arg.__name;
   }
@@ -75,10 +75,10 @@ public:
 class bad_cast : public exception
 {
 public:
-  bad_cast() noexcept
+  bad_cast() _ESBMC_NOEXCEPT
   {
   }
-  virtual const char *what() const noexcept
+  virtual const char *what() const _ESBMC_NOEXCEPT
   {
     return "std::bad_cast";
   }
@@ -87,10 +87,10 @@ public:
 class bad_typeid : public exception
 {
 public:
-  bad_typeid() noexcept
+  bad_typeid() _ESBMC_NOEXCEPT
   {
   }
-  virtual const char *what() const noexcept
+  virtual const char *what() const _ESBMC_NOEXCEPT
   {
     return "std::bad_typeid";
   }

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -6,6 +6,7 @@
 #include <cstddef> // for size_t, ptrdiff_t
 #include <memory>
 #include "stdexcept"
+#include "OM_compiler_defs.h" // OM_NULLPTR
 
 #include <utility> /* std::move */
 #include <new>     /* placement-new */
@@ -35,9 +36,9 @@ public:
     }
     reverse_iterator()
     {
-      pointer = nullptr;
+      pointer = OM_NULLPTR;
       pos = -1;
-      vec_pos = nullptr;
+      vec_pos = OM_NULLPTR;
     }
     reverse_iterator &operator=(const reverse_iterator &i)
     {
@@ -165,7 +166,7 @@ public:
     }
 
     // Default constructor
-    const_reverse_iterator() : pointer(nullptr), pos(-1), vec_pos(nullptr)
+    const_reverse_iterator() : pointer(OM_NULLPTR), pos(-1), vec_pos(OM_NULLPTR)
     {
     }
 
@@ -337,10 +338,10 @@ public:
   // vector by value under --memory-leak-check remains unsupported.
   ~vector()
   {
-    if (buf != nullptr)
+    if (buf != OM_NULLPTR)
     {
       free(buf);
-      buf = nullptr;
+      buf = OM_NULLPTR;
       _size = 0;
       _capacity = 0;
     }
@@ -540,7 +541,7 @@ public:
     }
     else
     {
-      buffer.pointer = nullptr;
+      buffer.pointer = OM_NULLPTR;
       buffer.pos = -1;
     }
     buffer.vec_pos = buf;
@@ -558,7 +559,7 @@ public:
     }
     else
     {
-      buffer.pointer = nullptr;
+      buffer.pointer = OM_NULLPTR;
       buffer.pos = -1;
       buffer.vec_pos = buf;
     }
@@ -784,12 +785,14 @@ public:
     _size--;
   }
 
+#if __cplusplus >= 201103L
   template <class... Args>
   reference emplace_back(Args &&...args)
   {
     push_back(T(std::forward<Args>(args)...));
     return buf[_size - 1];
   }
+#endif
 
   // Non-binding request to reduce capacity; leaving the buffer as-is is a
   // conforming implementation and keeps capacity() >= size().


### PR DESCRIPTION
Refs #3387. Fourth of the language-mode header failures found by the
differential sweep (after #6455 `<compare>`, #6457 `<limits>` in C++11/14,
#6458 `<array>`/`<bit>`/`<span>`/`<expected>`).

## Root cause

`--std c++03` is a supported mode with 32 regression tests, but
`#include <vector>` did not parse in it — nor did `<list>`, `<map>`, `<queue>`
or `<stack>`, all of which include `<vector>`. Since the bundled headers
replace the host standard library (`-nostdinc++`), that makes the C++98
containers unusable in C++03.

Four independent C++11-isms had crept into C++98-era models:

1. **`<vector>`** — seven bare `nullptr` in the reverse-iterator constructors
   and the buffer bookkeeping (`vector:38: use of undeclared identifier
   'nullptr'`), and a variadic `emplace_back` using `std::forward` with no
   guard (`vector:791: no member named 'forward' in namespace 'std'`). The
   `initializer_list` constructor right above it *was* already guarded, so
   `emplace_back` was simply missed.
2. **`<map>`** — an unguarded `map(std::initializer_list<value_type>)`.
3. **`<queue>` / `<stack>`** — `less<typename Container::value_type>>`,
   `deque<T>>`, `vector<T>>`, `list<T>>`: C++11 allows the closing `>>`,
   C++03 requires `> >`.
4. **`<typeinfo>`** — its `what()` overrides were spelled `noexcept`, so in
   C++03 they had no exception specification while the base
   `std::exception::what()` (from `<exception>`) has `throw()`:
   *"exception specification of overriding function is more lax than base
   version"*.

Found by a differential sweep of every bundled header against host clang:
`clang++ -std=c++03 -fsyntax-only` accepts all of these.

## Fix

* `<vector>`: use `OM_NULLPTR` from `OM_compiler_defs.h` (the existing
  convention, already used by `valarray`, `atomic`, `type_traits`, ...) and
  wrap `emplace_back` in `#if __cplusplus >= 201103L`, matching the
  `initializer_list` constructor beside it.
* `<map>`: guard the `initializer_list` constructor the same way.
* `<queue>` / `<stack>`: insert the space — `> >`. Valid and identical in
  every mode.
* `<typeinfo>`: use `_ESBMC_NOEXCEPT`, which `<exception>` (already included
  here) defines as `noexcept` in C++11+ and `throw()` in C++03. Note
  `OM_NOEXCEPT` would be **wrong** here: it expands to *nothing* in C++03,
  which is exactly the "more lax than base" error. Worth remembering for any
  other override.

Every change is a no-op from C++11 on: `OM_NULLPTR` is `nullptr`,
`_ESBMC_NOEXCEPT` is `noexcept`, the guards never fire, and `> >` parses the
same. Only the C++03 path changes, and there it was a hard error.

## Result

All C++98-era headers now parse under `--std c++03`:

`vector list map set deque queue stack string bitset algorithm iterator
functional memory numeric utility exception stdexcept typeinfo new iostream
iomanip ios istream ostream sstream fstream streambuf locale complex valarray`

## Regression tests

Under `regression/esbmc-cpp/bug_fixes/`, following the existing
`github_4475_*_c++03` naming:

* `github_3387_containers_c++03` — exercises `vector`, `list`, `map`, `set`,
  `deque`, `stack`, `queue` and `typeid` together under `--std c++03`.
  SUCCESSFUL. **Reproduces pre-fix** (`vector:38:17: use of undeclared
  identifier 'nullptr'`). The identical program compiles and runs clean under
  `clang++ -std=c++03`.
* `github_3387_containers_c++03_fail` — asserts the wrong vector size; must
  stay FAILED, so the positive test cannot pass vacuously.

## Test suites

This touches the most heavily used container models, so coverage was broad:

* `esbmc-cpp/*` (C++, includes the `vector` / `list` / `map` / `set` /
  `deque` / `stack` / `queue` / `string` / `bug_fixes` / `try_catch` /
  `OM_sanity_checks` suites) — the 9 failures are identical to the master
  baseline built from the same tree (pre-existing macOS host-header
  breakage). The `vector_emplace_back*` tests pass, confirming the guarded
  `emplace_back` is unaffected in the default mode.
* `esbmc-cpp11 / 14 / 17 / 20` — pass, except
  `esbmc-cpp14/template/builtin-template*`, which use
  `--no-abstracted-cpp-includes` and fail in clang's header search on macOS
  before any of this is reached.

## Scope / follow-up

`<limits>` is the one remaining C++98 header broken under `--std c++03`: it is
written with `constexpr` throughout (512 occurrences) and needs a considered
`OM_CONSTEXPR` conversion, since in C++03 a `static constexpr double` member
cannot simply become `static const`. That is a change with real semantic
consequences for constant-expression usability, so it is deliberately left
out of this PR rather than bundled in.

The C++11/C++17/C++20 headers that are still hard errors under `--std c++03`
(`initializer_list`, `random`, `chrono`, `unordered_map`, `unordered_set`,
`any`, `optional`, `variant`, `string_view`, `filesystem`, `source_location`)
want the same "inert before their standard" guard applied in #6455/#6458, but
guarding them also changes their availability in C++11/C++14, so they need a
per-header check against existing tests first.
