### PR TITLE
[python] Reconcile mismatched-signedness relational operands

### DIFF
--- a/docs/roadmap/scope-v1k-adjuster.md
+++ b/docs/roadmap/scope-v1k-adjuster.md
@@ -1045,3 +1045,64 @@ store.
 Census after this round: **69/70** on the strided sample, the single divergence
 being `github_3034_split-dot-valid-zero_fail`, which is the parked S4 work
 (round 10).
+
+### Per-case triage round 12 — the relational signedness abort (2026-07-28)
+
+**Re-measure first, as always.** Round 11's two open items shrank to one before any
+triage: `github_3690` is **closed** (legacy and hop-off both SUCCESSFUL, and its
+`_fail` sibling both FAILED) — #6445 did what it claimed and the entry was stale.
+
+**✅ FIXED — `github_3034_split-dot-valid-zero` and its `_fail` sibling.** These are
+the tests round 10 parked on S4, and **the recorded diagnosis was wrong**. The
+residual is not the list of promotions round 10 enumerated; hop-off does not reach
+a verdict at all. It aborts in the solver:
+
+```
+Assertion failed: (is_signedbv_type(lt.side_1) && is_signedbv_type(lt.side_2)),
+  function convert_ast_node, file smt_solver.cpp, line 1512.
+```
+
+`smt_convt::convert_ast_node`'s `lessthan` case dispatches on *both* sides being
+floatbv, *both* fixedbv, *both* unsignedbv, or — in the final `else` — *both*
+signedbv. An ordering relation whose operands disagree in signedness matches no
+arm and trips the assert. `while i < len(parts)` produces exactly that: the loop
+variable is a Python int (`signed long`) and the list model's `list_size` returns
+`unsigned long`. The whole GOTO diff for the enclosing function was **one cast**:
+
+```
+legacy:  IF !((unsigned long int)i < return_value$___ESBMC_list_size$1) THEN GOTO 3
+hop-off: IF !(i < return_value$___ESBMC_list_size$1) THEN GOTO 3
+```
+
+`clang_c_adjust::adjust_expr_rel` reconciles the two operands with
+`gen_typecast_arithmetic`; `python_adjust` had no relational arm at all, so the
+node reached the SMT layer unreconciled.
+
+**Why this is not the rejected "gap-2" arm.** Running `gen_typecast_arithmetic` on
+*every* relational node was tried in round 3 and rejected: it diverges corpus-wide
+from clang's promotions over the OM bodies (~7500 diff lines on `builtin2` alone),
+for a purely cosmetic gain. This arm is gated on the **signedness mismatch** — the
+one shape that is not encodable at all. A same-signedness width promotion
+(`char` vs `int`, gap-2's target) is encodable and stays untouched, so none of
+that traffic is re-admitted. The arm also calls
+`c_implicit_typecast_arithmetic`'s **`expr2tc` overload**, so there is no migrate
+round-trip and gap-2's first negative result — an operand picking up a spurious
+wrap because its migrated type does not compare equal to itself — cannot arise by
+construction. It is the same helper `python_math`'s floor-div/modulo
+reconciliation uses (#5725).
+
+**Relation to the parked S4 trap.** S4's danger is mirroring `adjust_assign`
+*without* operand-level arithmetic reconciliation, which makes `neural-net_fail`
+report SUCCESSFUL where legacy correctly FAILS. This arm is the reconciliation
+half, and only for relationals: it changes no stored value, it makes an otherwise
+unencodable node encodable, and its output is byte-identical to what legacy
+already emits. The masking direction is the assignment half, which stays parked.
+The S4 canary is still broken (round 10) and must still be re-established before
+the assignment half is attempted.
+
+**C-Live discharged by probe, not argument.** Both new tests *abort* on a control
+build with the arm reverted and rebuilt, and pass with it — the arm is live, not
+dead instrumentation. Idempotent: after one application both operands share a
+signedness, so the gate cannot re-fire.
+
+Tests: `regression/python/python_irep2_adjust_only_rel_signedness{,_fail}`.

--- a/regression/python/python_irep2_adjust_only_rel_signedness/main.py
+++ b/regression/python/python_irep2_adjust_only_rel_signedness/main.py
@@ -1,0 +1,15 @@
+def count_parts(text: str) -> int:
+    parts = text.split(".")
+    i = 0
+    seen = 0
+    while i < len(parts):
+        seen += 1
+        i += 1
+    return seen
+
+
+def main() -> None:
+    assert count_parts("0.00") == 2
+
+
+main()

--- a/regression/python/python_irep2_adjust_only_rel_signedness/test.desc
+++ b/regression/python/python_irep2_adjust_only_rel_signedness/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_only_rel_signedness_fail/main.py
+++ b/regression/python/python_irep2_adjust_only_rel_signedness_fail/main.py
@@ -1,0 +1,15 @@
+def count_parts(text: str) -> int:
+    parts = text.split(".")
+    i = 0
+    seen = 0
+    while i < len(parts):
+        seen += 1
+        i += 1
+    return seen
+
+
+def main() -> None:
+    assert count_parts("0.00") == 3
+
+
+main()

--- a/regression/python/python_irep2_adjust_only_rel_signedness_fail/test.desc
+++ b/regression/python/python_irep2_adjust_only_rel_signedness_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --unwind 5
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -1,6 +1,7 @@
 #include <python-frontend/python_adjust.h>
 
 #include <clang-c-frontend/padding.h>
+#include <util/lang/c_typecast.h>
 #include <irep2/irep2_utils.h>
 #include <util/lang/c_types.h>
 #include <util/message/message.h>
@@ -349,6 +350,44 @@ void python_adjust::adjust_expr(expr2tc &expr)
     // has pointer type -- otherwise reaches the SMT layer as a negation of a
     // non-boolean sort and trips bitwuzla's mk_not assert. not2t is immutable.
     expr = not2tc(typecast2tc(get_bool_type(), to_not2t(expr).value));
+  }
+  else if (
+    is_lessthan2t(expr) || is_lessthanequal2t(expr) || is_greaterthan2t(expr) ||
+    is_greaterthanequal2t(expr))
+  {
+    // clang_c_adjust::adjust_expr_rel reconciles the two operands with
+    // gen_typecast_arithmetic (the usual arithmetic conversions). Mirrored only
+    // for the shape the SMT layer cannot encode: an ordering relation whose
+    // operands disagree in signedness, which smt_convt::convert_ast_node has no
+    // arm for and aborts on (smt_solver.cpp:1512 -- it dispatches on *both*
+    // sides being unsigned or *both* signed). `while i < len(parts)` is the
+    // canonical source: the loop variable is a Python int (signed long) and the
+    // list model returns unsigned long, so hop-off reaches the solver with
+    // `i < list_size(...)` unreconciled and never produces a verdict.
+    //
+    // Deliberately not the general relational mirror: running
+    // gen_typecast_arithmetic on *every* relational node was tried and rejected
+    // (docs/roadmap/scope-v1k-adjuster.md, "gap-2") because it diverges
+    // corpus-wide from clang's promotions over the OM bodies. The
+    // signedness-mismatch gate excludes that traffic -- a same-signedness
+    // width promotion (char vs int) is encodable and stays untouched -- and
+    // leaves only nodes that are otherwise a hard abort.
+    std::vector<expr2tc *> ops;
+    expr->Foreach_operand([&ops](expr2tc &op) { ops.push_back(&op); });
+
+    if (
+      ops.size() == 2 && is_bv_type((*ops[0])->type) &&
+      is_bv_type((*ops[1])->type) &&
+      is_signedbv_type((*ops[0])->type) != is_signedbv_type((*ops[1])->type))
+    {
+      // The expr2tc overload, not the legacy exprt one clang_c_adjust calls:
+      // same usual-arithmetic-conversion rule with no migrate round-trip, so an
+      // operand cannot pick up a spurious wrap from a type that fails to compare
+      // equal to itself after migration -- the first of the two "gap-2"
+      // negative results. Same helper python_math's floor-div/modulo width
+      // reconciliation uses (#5725).
+      c_implicit_typecast_arithmetic(*ops[0], *ops[1], ns);
+    }
   }
   else if (
     is_typecast2t(expr) && is_pointer_type(expr->type) &&


### PR DESCRIPTION
An ordering relation whose operands disagree in signedness matches no arm in
`smt_convt::convert_ast_node` and trips its assert (`smt_solver.cpp:1512`), so
`while i < len(xs)` -- a signed long index against the list model's unsigned long
-- produced no verdict at all under `--python-irep2-adjust-only`. Mirror
`clang_c_adjust::adjust_expr_rel` for that shape only; the general relational
mirror stays rejected (`docs/roadmap/scope-v1k-adjuster.md`, "gap-2").

Closes `github_3034_split-dot-valid-zero{,_fail}` on the hop-off path, whose
round-10 diagnosis (a list of residual promotions, filed under parked S4 work)
was wrong -- the whole GOTO diff for the function was one missing cast.

Census: 154 tests, 0 divergences. C-Live discharged by control build (both new
tests abort pre-patch, pass post-patch).