### PR TITLE
[test] Pin the placement-new false positive under incremental BMC

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6464_placement_new_bmc/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6464_placement_new_bmc/main.cpp
@@ -1,0 +1,64 @@
+// github #6464 (control): the same program under plain BMC, where ESBMC gets
+// it right. The --incremental-bmc / --k-induction variant is pinned as a
+// KNOWNBUG next door; this test keeps the working mode from regressing while
+// that one is fixed. Clean under clang++ -std=c++17 -fsanitize=address,undefined.
+//
+// Two ingredients are needed, both bisected on the issue: the placement-new
+// itself (any plain assignment through the same address is fine, including via
+// a void* round-trip across a function boundary), and a second malloc on a
+// guarded path -- here grow(), which is never executed.
+//
+// This blocks #6368: constructing vector elements with placement-new is the
+// right fix there, but it would make every growable std::vector<T> report a
+// spurious failure in these two modes.
+#include <new>
+#include <cstdlib>
+
+struct Elem
+{
+  char a[8];
+};
+
+struct Holder
+{
+  Elem *buf;
+  int n;
+  int cap;
+
+  Holder()
+  {
+    buf = (Elem *)malloc(sizeof(Elem) * 10);
+    if (!buf)
+      abort();
+    n = 0;
+    cap = 10;
+  }
+
+  // Never executed below (n is 0, cap is 10), but its presence is what makes
+  // the placement-new in add() report a spurious out-of-bounds heap write.
+  void grow()
+  {
+    Elem *nb = (Elem *)malloc(sizeof(Elem) * 20);
+    if (!nb)
+      abort();
+    buf = nb;
+    cap = 20;
+  }
+
+  void add(const Elem &x)
+  {
+    if (n == cap)
+      grow();
+    new (buf + n) Elem(x);
+    n++;
+  }
+};
+
+int main()
+{
+  Holder h;
+  Elem e;
+  e.a[0] = 1;
+  h.add(e);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6464_placement_new_bmc/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6464_placement_new_bmc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 4 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/main.cpp
@@ -1,0 +1,64 @@
+// KNOWNBUG (github #6464): placement-new into malloc'd storage is reported as
+// an out-of-bounds heap write under --incremental-bmc and --k-induction, while
+// plain BMC (default, and every explicit --unwind N) proves the same program
+// safe. Clean under clang++ -std=c++17 -fsanitize=address,undefined.
+//
+// Two ingredients are needed, both bisected on the issue: the placement-new
+// itself (any plain assignment through the same address is fine, including via
+// a void* round-trip across a function boundary), and a second malloc on a
+// guarded path -- here grow(), which is never executed.
+//
+// This blocks #6368: constructing vector elements with placement-new is the
+// right fix there, but it would make every growable std::vector<T> report a
+// spurious failure in these two modes.
+#include <new>
+#include <cstdlib>
+
+struct Elem
+{
+  char a[8];
+};
+
+struct Holder
+{
+  Elem *buf;
+  int n;
+  int cap;
+
+  Holder()
+  {
+    buf = (Elem *)malloc(sizeof(Elem) * 10);
+    if (!buf)
+      abort();
+    n = 0;
+    cap = 10;
+  }
+
+  // Never executed below (n is 0, cap is 10), but its presence is what makes
+  // the placement-new in add() report a spurious out-of-bounds heap write.
+  void grow()
+  {
+    Elem *nb = (Elem *)malloc(sizeof(Elem) * 20);
+    if (!nb)
+      abort();
+    buf = nb;
+    cap = 20;
+  }
+
+  void add(const Elem &x)
+  {
+    if (n == cap)
+      grow();
+    new (buf + n) Elem(x);
+    n++;
+  }
+};
+
+int main()
+{
+  Holder h;
+  Elem e;
+  e.a[0] = 1;
+  h.add(e);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Refs #6464. Blocks #6368.

## Root cause

`src/clang-cpp-frontend/clang_cpp_convert.cpp:836-899` lowers placement-new to `comma(<ctor call retargeted at *(T *)place>, (T *)place)`, so the constructor's `this` is the placement address:

```
FUNCTION_CALL: Elem(&(*( struct Elem *)((void *)(buf + n))), &(*x))
OTHER (struct Elem *)((void *)(buf + n));
```

The dereference check raised inside that constructor loses the precise value-set of the address, so it degenerates to "must be in bounds for every dynamic object in scope":

```
guard => !SAME-OBJECT(this, &dynamic_1_array) || <size/validity of dynamic_1_array>
```

Introducing a second `malloc` — even on a guarded path that is never taken — is then enough to make it unprovable, and `--incremental-bmc` / `--k-induction` report `dereference failure: array bounds violated: heap object`. Plain BMC (default, and every explicit `--unwind N`) proves the same program safe.

Both ingredients were bisected:

- **placement-new is required.** `buf[n] = x`, `*(buf + n) = x`, `*(Elem *)((void *)(buf + n)) = x`, and a free function `f(Elem *p, const Elem &x) { *p = x; }` called either as `f(buf + n, x)` or as `f((Elem *)((void *)(buf + n)), x)` all verify. A `void *` round-trip across a function boundary is therefore not the trigger — the generated constructor call is.
- **A second `malloc` on a guarded path is required.** Emptying `grow()` or replacing its body with `cap = m;` makes the verdict `SUCCESSFUL`. Removing only `free(buf)` from it does not.

Not involved: element size (reproduces from `char a[8]` to `char a[132]`), the second allocation's size (a fixed `sizeof(Elem) * 1000` still fails), and `__ESBMC_assume`-ing either size.

## What this PR does

Tests only — no behaviour change. The defect is in the dereference/value-set handling of the constructor call that placement-new generates, which is a separate fix from the reproducer.

## Tests

- `esbmc-cpp/cpp/github_6464_placement_new_incremental` — `KNOWNBUG`, `--std c++17 --incremental-bmc`, expects `VERIFICATION SUCCESSFUL`. Flips to a pass once the defect is fixed.
- `esbmc-cpp/cpp/github_6464_placement_new_bmc` — `CORE`, `--std c++17 --unwind 4 --no-unwinding-assertions`, expects `VERIFICATION SUCCESSFUL`. Keeps the mode that currently gets it right from regressing while the KNOWNBUG is open.

Both sources are self-contained, use no ESBMC intrinsics, and exit 0 under `clang++ -std=c++17 -fsanitize=address,undefined`.

`ctest -R github_6464` passes 2/2. Full `esbmc-cpp/cpp` is unchanged at 657/664, with the same 7 pre-existing macOS failures as `master`.

## Why it matters

This blocks #6368. Constructing `std::vector` elements with placement-new instead of assigning into raw storage is the correct and fast fix there, but with this defect it would make every growable `std::vector<T>` — including `std::vector<std::string>` — report a spurious `VERIFICATION FAILED` in these two modes. The alternative of zeroing raw slots before assigning avoids the imprecision but is prohibitively slow. Details recorded on #6368.