### PR TITLE
[goto-symex] Make --unwindsetname actually select a loop (H-A5, M2)

### DIFF
--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -683,6 +683,7 @@ this document** — each is a prioritised target for the cited harness.
 | **R9** | **Low–Medium (approximation direction unproven)** | Three documented "sound over-approximation" claims are unproven: value-set filtering after a pointer havoc (`symex_assign.cpp:~550-570`), the non-scalar uninterpreted-function fallback (`symex_function.cpp:~410-430`), and the function-pointer target enumeration over an over-approximated value set (`symex_function.cpp:~766`). Each *argues* the direction in a comment; none is checked. | cited lines | H-B6 + H-C1/H-C3 | For each, state the claim as a checkable predicate and add a Tier-B assertion (e.g. filtered set ⊆ original **and** the dropped entries are `unknown`/`invalid` only). |
 | **R10** | **Low (latent UB)** | `renaming::level2t::name_record`'s `name_record() = default` leaves `lev`, `l1_num`, `t_num` **and the derived `hash`** indeterminate (contrast `level1t::name_record`, which initialises `base_name("")`). No current default-construction site was found, but a future one (`std::optional`, map default-insert, array of records) would read indeterminate memory in `compare`/`hash`. | `renaming.h:143-214` | MSan (Tier D) + a `static_assert`-style unit check | Add default member initialisers; near-zero cost. |
 | **R11** | **Open question (concurrency soundness)** | MPOR's independence decision consumes `thread_last_reads`/`thread_last_writes`, populated via `get_expr_globals`, which resolves pointer operands through the *current* value set. If a write through a pointer whose value set is incomplete (or whose entry is `unknown`) is missed, the dependency is missed and an interleaving is dropped — **unsound**. `get_expr_globals` also early-returns entirely under `--data-races-check-only`. | `execution_statet::get_expr_globals`, `check_mpor_dependency`; `reachability_treet::ever_written_globals`/`address_taken_globals` | H-A6 (relation) + **H-C4** (end-to-end) | Determine whether an `unknown` value-set entry forces a conservative dependency; if not, that is a concrete unsoundness to fix. Highest-uncertainty item in this plan. |
+| **R13** | **Medium (silent under-verification) — confirmed and fixed, §15 M2 (cont.)** | **`--unwindsetname` never matched a loop.** `unwind_func_set` was keyed by `user_name_to_usr(name)`, which appends a `#` terminator (clang's C++ USR spelling), while `loop_id_to_func_index` was keyed by the goto function-map id, which for a C function is `c:@F@f` with no terminator. The `count(unwind_key)` in `get_unwind` therefore always missed and the global `--unwind` silently won, so a user raising the bound for one function got the lower global bound and a verdict covering less than they asked for. A second defect in the same option: the `name:index:bound` field split scanned left-to-right, so the documented USR form (`c:@F@f#:0:11`) split inside the `c:` prefix. Neither was caught because all five `unwindsetname` regression tests ran without a global `--unwind` and so passed vacuously. | `goto_symext::goto_symext`, `symex_assign.cpp:66-120`; `get_unwind`, `symex_goto.cpp:525`; `user_name_to_usr`, `usr_utils.cpp:29` | `unit/goto-symex/unwind.test.cpp` (Tier B, discharged) | Fixed: both sides now key on the name `--show-loops` prints (`usr_to_user_name`), and the field split scans from the right. Three non-vacuous regression tests added; `unwindsetname_03_priority` corrected to the loop number the program actually has. |
 | **R12** | **Info (bounded by design)** | With `--no-unwinding-assertions`, `loop_bound_exceeded` emits an *assumption* that truncates the path; a `VERIFICATION SUCCESSFUL` then covers only the truncated prefix. This is intended BMC behaviour, but the repo has already been bitten by it in *verification harnesses* (`CLAUDE.md` bans pairing it with reachability checks). | `goto_symext::loop_bound_exceeded`, `symex_goto.cpp:497-523` | H-A5 | No code change; encode as an acceptance criterion (§11.3) so no harness in this plan ever uses that flag. |
 
 ---
@@ -725,7 +726,8 @@ H-A2 (the highest-value harness), H-A3, H-A5. Dual-solver mandatory.
 **Revised, §15 M2.** H-A2's and H-A3's obligations (I8, I6) are observable in the
 produced equation, so both are discharged at Tier B by
 `unit/goto-symex/merge.test.cpp` per §6.4 — no transcription, no dual-solver gate
-needed because no SMT query is involved. H-A5 is unstarted; R2's
+needed because no SMT query is involved. H-A5 is likewise Tier B
+(`unit/goto-symex/unwind.test.cpp`) and found R13. **M2 closed**; R2's
 `SYMEX_INVARIANT` remains M3.
 
 **M3 — Release-mode enforcement (0.5 wk).** R1: introduce `SYMEX_INVARIANT`,
@@ -1309,11 +1311,56 @@ a durable regression: if a future change starts orphaning snapshots on any of
 these six shapes, this fails rather than silently dropping paths.
 
 **Still open in M2.** H-A5 (unwind bounding, `get_unwind` /
-`loop_bound_exceeded`) is unstarted. Note §11.3 and R12 both forbid pairing
-`--no-unwinding-assertions` with any reachability claim, so H-A5's Tier-C form
-(H-C6, unwind monotonicity: `FAILED` at `--unwind k` ⇒ `FAILED` at every
-`k' > k`) is the safer first cut and needs no oracle. Also still open from M0:
-WI-1, WI-2, D12.
+`loop_bound_exceeded`). Also still open from M0: WI-1, WI-2, D12.
+
+### M2 (cont.) — 2026-07-28, M2 closed
+
+**Result: H-A5 discharged at Tier B — and it found a live bug (R13).**
+
+| Artefact | What it drives | Result |
+|---|---|---|
+| `unit/goto-symex/unwind.test.cpp` (H-A5) | real symex under `--unwind`, `--unwindsetname`, `--unwindset`, `--no-unwinding-assertions`, `--partial-loops` | 8 cases, 39 assertions, **pass** |
+
+Both targets are observable from outside the engine, so §6.4 puts them at Tier B:
+`get_unwind`'s decision is the *number of loop-body assignments* in the equation,
+and `loop_bound_exceeded`'s three arms are which step it appends. No case makes a
+reachability claim, so R12 and §11.3 are respected by construction.
+
+- **A5.1, precedence** — the three bounds are given distinct values (global 5,
+  function-specific 3, loop-specific 2) so that a precedence swap lands on a
+  different iteration count rather than an equal one. The loop id passed to
+  `--unwindset` is read out of the built GOTO program, not assumed.
+- **A5.2, `0` means unbounded** — a loop-specific `0` exempts one loop from a
+  global `--unwind 2`, and the loop then runs to its natural exhaustion. Its
+  non-vacuity twin drops only the exemption and gets truncation back.
+- **A5.3, exactly one arm** — `--no-unwinding-assertions` must trade the claim
+  for an assumption *together*: the unwinding-assertion count goes 1 → 0 while
+  the assume count goes n → n+1, at an unchanged iteration count.
+  `--partial-loops` moves neither.
+- **A5.4, guard strengthening** — with a condition still true at the bound, the
+  `¬cond` that `loop_bound_exceeded` adds is `false`, so the code after the loop
+  becomes unreachable and is not emitted. Under `--partial-loops` — the one arm
+  that skips the `guard.add` — the same post-loop assignment *is* emitted. That
+  difference is the guard strengthening, observed rather than modelled.
+
+**R13, found by writing A5.1.** The function-specific arm of `get_unwind`'s
+precedence chain was dead: `unwind_func_set` was keyed by
+`user_name_to_usr(name)`, which appends clang's C++ USR `#` terminator, and
+`loop_id_to_func_index` by the goto function-map id, which for a C function has
+none. Every `--unwindsetname` lookup missed and the global `--unwind` silently
+won. The five existing `unwindsetname` regression tests all passed vacuously:
+none set a global `--unwind`, so all of them verify identically whether the
+option works or is ignored. Both sides now key on the name `--show-loops`
+prints, and the `name:index:bound` split scans from the right so a USR name's
+own `c:` prefix no longer splits the field.
+
+This is the plan's premise landing for the first time on a shipped-binary
+defect: the harness was written to state A5.1, not to hunt for a bug, and the
+bug fell out of stating it.
+
+**M2 is closed.** H-A2/H-A3 (§15 M2) and H-A5 are discharged at Tier B, all
+three without a transcription. Still open from M0: WI-1, WI-2, D12. Next is
+**M3** (R1: `SYMEX_INVARIANT`), which R2 and R7 both wait on.
 ---
 
 ## Appendix A — Methodological basis

--- a/regression/esbmc/unwindsetname_03_priority/main.c
+++ b/regression/esbmc/unwindsetname_03_priority/main.c
@@ -9,7 +9,7 @@ void test_priority() {
 
   __ESBMC_assume(limit == 10);
 
-  // This is loop 1
+  // Loop 3 globally: --show-loops numbers the two C library loops first
   for (i = 0; i < limit; i++) {
     sum += i;
   }

--- a/regression/esbmc/unwindsetname_03_priority/test.desc
+++ b/regression/esbmc/unwindsetname_03_priority/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
---unwindsetname test_priority:0:4 --unwindset 1:11 --z3
+--unwindsetname test_priority:0:4 --unwindset 3:11 --z3
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/unwindsetname_07_overrides_global/main.c
+++ b/regression/esbmc/unwindsetname_07_overrides_global/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+void compute_sum(void)
+{
+  int sum = 0;
+  for (int i = 0; i < 10; i++)
+    sum += i;
+  assert(sum == 45);
+}
+
+int main(void)
+{
+  compute_sum();
+  return 0;
+}

--- a/regression/esbmc/unwindsetname_07_overrides_global/test.desc
+++ b/regression/esbmc/unwindsetname_07_overrides_global/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 3 --unwindsetname compute_sum:0:11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/unwindsetname_08_lowers_global/main.c
+++ b/regression/esbmc/unwindsetname_08_lowers_global/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+void compute_sum(void)
+{
+  int sum = 0;
+  for (int i = 0; i < 10; i++)
+    sum += i;
+  assert(sum == 45);
+}
+
+int main(void)
+{
+  compute_sum();
+  return 0;
+}

--- a/regression/esbmc/unwindsetname_08_lowers_global/test.desc
+++ b/regression/esbmc/unwindsetname_08_lowers_global/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 20 --unwindsetname compute_sum:0:3
+^  unwinding assertion loop \d+$
+^VERIFICATION FAILED$

--- a/regression/esbmc/unwindsetname_09_usr_effective/main.c
+++ b/regression/esbmc/unwindsetname_09_usr_effective/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+void compute_sum(void)
+{
+  int sum = 0;
+  for (int i = 0; i < 10; i++)
+    sum += i;
+  assert(sum == 45);
+}
+
+int main(void)
+{
+  compute_sum();
+  return 0;
+}

--- a/regression/esbmc/unwindsetname_09_usr_effective/test.desc
+++ b/regression/esbmc/unwindsetname_09_usr_effective/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 3 --unwindsetname c:@F@compute_sum#:0:11
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -74,25 +74,31 @@ goto_symext::goto_symext(
       std::string val = func_set.substr(
         start, comma == std::string::npos ? std::string::npos : comma - start);
 
-      // Parse name:index:bound format
-      std::string::size_type first_colon = val.find(":");
-      std::string::size_type second_colon = first_colon != std::string::npos
-                                              ? val.find(":", first_colon + 1)
-                                              : std::string::npos;
+      // Parse name:index:bound from the right: only the last two fields are
+      // fixed, and a USR name is itself colon-prefixed (`c:@F@f#`).
+      std::string::size_type bound_colon = val.rfind(":");
+      std::string::size_type index_colon =
+        bound_colon == std::string::npos || bound_colon == 0
+          ? std::string::npos
+          : val.rfind(":", bound_colon - 1);
 
-      if (first_colon != std::string::npos && second_colon != std::string::npos)
+      if (index_colon != std::string::npos)
       {
-        std::string user_name = val.substr(0, first_colon);
+        std::string user_name = val.substr(0, index_colon);
         unsigned loop_index = atoi(
-          val.substr(first_colon + 1, second_colon - first_colon - 1).c_str());
-        BigInt bound(val.substr(second_colon + 1).c_str());
+          val.substr(index_colon + 1, bound_colon - index_colon - 1).c_str());
+        BigInt bound(val.substr(bound_colon + 1).c_str());
 
-        // Convert user syntax to internal USR format with trailing #
-        std::string usr_name = user_name_to_usr(user_name);
+        // Key on the name --show-loops prints. A user name cannot be turned
+        // back into a function id: ESBMC ids follow clang's USR spelling, so a
+        // C function is `c:@F@f` while a C++ one carries its parameter
+        // mangling (`c:@F@f#i#`). Normalising the id down to the user name is
+        // the only direction that matches both.
+        std::string key_name = usr_to_user_name(user_name);
 
         // Only add valid entries (must have function name)
-        if (!usr_name.empty())
-          unwind_func_set[std::make_pair(usr_name, loop_index)] = bound;
+        if (!key_name.empty())
+          unwind_func_set[std::make_pair(key_name, loop_index)] = bound;
       }
 
       if (comma == std::string::npos)
@@ -110,8 +116,8 @@ goto_symext::goto_symext(
     {
       if (instruction.is_backwards_goto())
       {
-        loop_id_to_func_index[instruction.loop_number] =
-          std::make_pair(func_pair.first.as_string(), loop_index);
+        loop_id_to_func_index[instruction.loop_number] = std::make_pair(
+          usr_to_user_name(func_pair.first.as_string()), loop_index);
         loop_index++;
 
         // Handle #pragma unroll annotations

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -3,3 +3,4 @@ new_unit_test(ssa-wellformed-test "ssa_wellformed.test.cpp" "test_goto_factory;s
 new_unit_test(renaming-test "renaming.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(frame-lifecycle-test "frame_lifecycle.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(merge-test "merge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(unwind-test "unwind.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/unwind.test.cpp
+++ b/unit/goto-symex/unwind.test.cpp
@@ -1,0 +1,278 @@
+/*******************************************************************
+ Module: Unwind bounding on the real engine
+
+ Tier B of docs/roadmap/goto-symex-verification-plan.md (H-A5, M2).
+
+ `get_unwind` decides *when* a loop stops unwinding and `loop_bound_exceeded`
+ decides *what the truncation means* (symex_goto.cpp:497,525). Both are P1: a
+ bound applied to the wrong loop silently verifies less than the user asked
+ for, and a truncation that fails to strengthen the state guard would let the
+ code after the loop run on a path the loop never reached.
+
+ §11.3 and R12 forbid pairing `--no-unwinding-assertions` with a reachability
+ claim, so none of these cases makes one: every assertion here is a count or a
+ presence check over the equation symex produced.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <string>
+
+#include <goto-programs/goto_functions.h>
+#include <goto-symex/reachability_tree.h>
+#include <irep2/irep2_expr.h>
+#include <util/symtab/namespace.h>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+/** A loop whose condition constant-folds, run under an explicit bound. */
+const char *const long_loop = R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = nondet_int();
+  int i = 0;
+  while (i < 100)
+  {
+    x = nondet_int();
+    i = i + 1;
+  }
+  int after = nondet_int();
+  return x + after;
+}
+)";
+
+/** The same shape, but exhausted after three iterations. */
+const char *const short_loop = R"(
+int nondet_int(void);
+int main(void)
+{
+  int x = nondet_int();
+  int i = 0;
+  while (i < 3)
+  {
+    x = nondet_int();
+    i = i + 1;
+  }
+  return x;
+}
+)";
+
+class engine
+{
+public:
+  explicit engine(std::string src)
+    : source(std::move(src)),
+      prog(goto_factory::get_goto_functions(
+        source,
+        goto_factory::Architecture::BIT_64)),
+      ns(prog.context),
+      opts(goto_factory::get_default_options(
+        goto_factory::get_default_cmdline("test.c"))),
+      rt(
+        prog.functions,
+        ns,
+        opts,
+        std::make_shared<symex_target_equationt>(ns),
+        prog.context)
+  {
+  }
+
+  /** Options must be set before run(): goto_symext reads them in its ctor. */
+  engine &with(const std::string &key, const std::string &value)
+  {
+    opts.set_option(key, value);
+    return *this;
+  }
+
+  /** The id `--unwindset` keys on, read from the program rather than assumed. */
+  unsigned main_loop_number() const
+  {
+    for (const auto &[name, func] : prog.functions.function_map)
+    {
+      if (name.as_string().find("@F@main") == std::string::npos)
+        continue;
+      for (const auto &insn : func.body.instructions)
+        if (insn.is_backwards_goto())
+          return insn.loop_number;
+    }
+    FAIL("main has no loop");
+    return 0;
+  }
+
+  std::shared_ptr<symex_target_equationt> run()
+  {
+    rt.setup_for_new_explore();
+    auto eq = std::dynamic_pointer_cast<symex_target_equationt>(
+      rt.get_next_formula().target);
+    REQUIRE(eq != nullptr);
+    return eq;
+  }
+
+private:
+  std::string source;
+  program prog;
+  namespacet ns;
+  optionst opts;
+  reachability_treet rt;
+};
+
+size_t assignments_to(const symex_target_equationt &eq, const char *var)
+{
+  size_t found = 0;
+  for (const auto &step : eq.SSA_steps)
+    if (
+      step.is_assignment() && is_symbol2t(step.lhs) &&
+      to_symbol2t(step.lhs).thename.as_string().find(var) != std::string::npos)
+      ++found;
+  return found;
+}
+
+/** Body executions: `x` is written exactly once per iteration, plus its init. */
+size_t iterations(const symex_target_equationt &eq)
+{
+  const size_t writes = assignments_to(eq, "@main@x");
+  REQUIRE(writes >= 1);
+  return writes - 1;
+}
+
+size_t unwinding_assertions(const symex_target_equationt &eq)
+{
+  size_t found = 0;
+  for (const auto &step : eq.SSA_steps)
+    if (
+      step.is_assert() &&
+      step.comment.as_string().rfind("unwinding assertion loop", 0) == 0)
+      ++found;
+  return found;
+}
+
+size_t assumptions(const symex_target_equationt &eq)
+{
+  size_t found = 0;
+  for (const auto &step : eq.SSA_steps)
+    if (step.is_assume())
+      ++found;
+  return found;
+}
+} // namespace
+
+TEST_CASE("the global bound stops the loop and claims the truncation")
+{
+  engine e(long_loop);
+  e.with("unwind", "5");
+
+  auto eq = e.run();
+  REQUIRE(iterations(*eq) == 5);
+  REQUIRE(unwinding_assertions(*eq) == 1);
+}
+
+TEST_CASE("a function-specific bound overrides the global one")
+{
+  // A5.1, first half: unwind_func_set is consulted before max_unwind is used.
+  engine e(long_loop);
+  e.with("unwind", "5").with("unwindsetname", "main:0:3");
+
+  auto eq = e.run();
+  REQUIRE(iterations(*eq) == 3);
+  REQUIRE(unwinding_assertions(*eq) == 1);
+}
+
+TEST_CASE("a loop-specific bound overrides the function-specific one")
+{
+  // A5.1, second half. All three bounds are distinct, so a precedence swap
+  // lands on a different count rather than an equal one.
+  engine e(long_loop);
+  const std::string id = std::to_string(e.main_loop_number());
+  e.with("unwind", "5")
+    .with("unwindsetname", "main:0:3")
+    .with("unwindset", id + ":2");
+
+  auto eq = e.run();
+  REQUIRE(iterations(*eq) == 2);
+  REQUIRE(unwinding_assertions(*eq) == 1);
+}
+
+TEST_CASE("a zero bound means unbounded, not zero iterations")
+{
+  // A5.2: `this_loop_max_unwind != 0` gates the whole comparison, so a
+  // loop-specific 0 is the documented way to exempt one loop from --unwind.
+  engine e(short_loop);
+  const std::string id = std::to_string(e.main_loop_number());
+  e.with("unwind", "2").with("unwindset", id + ":0");
+
+  auto eq = e.run();
+  REQUIRE(iterations(*eq) == 3);
+  REQUIRE(unwinding_assertions(*eq) == 0);
+}
+
+TEST_CASE("the same loop truncates when the exemption is dropped")
+{
+  // Non-vacuity twin of the case above: three iterations there is the loop
+  // running to exhaustion, not the bound being ignored for another reason.
+  engine e(short_loop);
+  e.with("unwind", "2");
+
+  auto eq = e.run();
+  REQUIRE(iterations(*eq) == 2);
+  REQUIRE(unwinding_assertions(*eq) == 1);
+}
+
+// Case names must not start with `--`: Catch2 registers them as CLI tokens.
+TEST_CASE("no-unwinding-assertions trades the claim for an assumption")
+{
+  // A5.3: exactly one of the three arms of loop_bound_exceeded is taken. The
+  // assumption arm is reachable *only* under no_unwinding_assertions, so the
+  // claim disappearing and an assumption appearing must happen together.
+  engine base(long_loop);
+  base.with("unwind", "3");
+  auto claimed = base.run();
+
+  engine assumed_e(long_loop);
+  assumed_e.with("unwind", "3").with("no-unwinding-assertions", "1");
+  auto assumed = assumed_e.run();
+
+  REQUIRE(unwinding_assertions(*claimed) == 1);
+  REQUIRE(unwinding_assertions(*assumed) == 0);
+  REQUIRE(assumptions(*assumed) == assumptions(*claimed) + 1);
+  REQUIRE(iterations(*assumed) == iterations(*claimed));
+}
+
+TEST_CASE("partial-loops takes neither arm")
+{
+  // A5.3, third arm: loop_bound_exceeded returns before emitting anything.
+  engine base(long_loop);
+  base.with("unwind", "3");
+  auto claimed = base.run();
+
+  engine partial_e(long_loop);
+  partial_e.with("unwind", "3").with("partial-loops", "1");
+  auto partial = partial_e.run();
+
+  REQUIRE(unwinding_assertions(*partial) == 0);
+  REQUIRE(assumptions(*partial) == assumptions(*claimed));
+  REQUIRE(iterations(*partial) == iterations(*claimed));
+}
+
+TEST_CASE("truncation strengthens the state guard by the negated condition")
+{
+  // A5.4. `i < 100` is still true at the bound, so the ¬cond that
+  // loop_bound_exceeded adds is false and everything after the loop becomes
+  // unreachable. Under --partial-loops that guard is never added, and the
+  // post-loop code is emitted — which is the whole reason partial loops are
+  // unsound for reachability. The difference *is* the guard strengthening.
+  engine base(long_loop);
+  base.with("unwind", "3");
+  auto claimed = base.run();
+
+  engine partial_e(long_loop);
+  partial_e.with("unwind", "3").with("partial-loops", "1");
+  auto partial = partial_e.run();
+
+  REQUIRE(assignments_to(*claimed, "@main@after") == 0);
+  REQUIRE(assignments_to(*partial, "@main@after") == 1);
+}


### PR DESCRIPTION
Resumes `docs/roadmap/goto-symex-verification-plan.md` at **H-A5** (unwind-bound selection and truncation semantics), the last open harness in milestone M2 — and the harness found a live bug.

## The bug (plan finding R13)

`--unwindsetname f:0:N` never matched a loop. `unwind_func_set` was keyed by `user_name_to_usr(name)`, which appends clang's C++ USR `#` terminator, while `loop_id_to_func_index` was keyed by the goto function-map id, which for a C function carries none. Every `count(unwind_key)` in `get_unwind` missed, so the per-function bound was silently dropped and the global `--unwind` won:

```
$ esbmc main.c --unwind 20 --unwindsetname compute_sum:0:3   # before
... 10 iterations   (the bound was ignored)
$ esbmc main.c --unwind 20 --unwindsetname compute_sum:0:3   # after
... 3 iterations
```

A user raising the bound for one hot function got the lower global bound instead, and a `VERIFICATION SUCCESSFUL` covering less than they asked for.

A second defect in the same option: the `name:index:bound` split scanned left-to-right, so the documented USR spelling (`c:@F@f#:0:11`, which `unwindsetname_usr_passthrough` passes) split inside the `c:` prefix. Both sides now key on the name `--show-loops` prints (`usr_to_user_name`), which is the only normalisation that matches for both C (`c:@F@f`) and C++ (`c:@F@f#i#`) ids, and the field split scans from the right.

## Why no test caught it

All five existing `unwindsetname` tests run without a global `--unwind`, so the effective bound is unbounded either way — every one passes whether the option works or is ignored. Replaced with three non-vacuous tests (a bound that must *raise* above the global, one that must *lower* below it and fail, and the USR form). `unwindsetname_03_priority` also named loop 1 while its loop is number 3 — the two C library loops are numbered first — so its `--unwindset` never applied either; corrected, and it now genuinely exercises loop-specific > function-specific.

## The harness

`unit/goto-symex/unwind.test.cpp`, 8 cases / 39 assertions, Tier B per §6.4 — `get_unwind`'s decision is the loop-body assignment count in the equation and `loop_bound_exceeded`'s arms are which step it appends, so neither needs a transcription:

- **A5.1** precedence, with all three bounds distinct so a swap lands on a different count; the loop id is read out of the built GOTO program rather than assumed.
- **A5.2** a loop-specific `0` exempts one loop from the global bound, plus the twin that drops only the exemption and gets truncation back.
- **A5.3** the claim/assumption/no-op arms are mutually exclusive: `--no-unwinding-assertions` moves the unwinding-assertion count 1 → 0 *and* the assume count n → n+1 at an unchanged iteration count; `--partial-loops` moves neither.
- **A5.4** the state guard is strengthened by `¬cond`: the post-loop code is unreachable and unemitted under a bound, but emitted under `--partial-loops` — the one arm that skips the `guard.add`.

No case makes a reachability claim, so §11.3 and R12's ban on pairing `--no-unwinding-assertions` with one is respected by construction.

## Testing

- `ctest -LE regression` — 581/581 pass.
- `ctest -R "unwind|unroll|pragma"` — 53/53 pass, including all 6 pre-existing `unwindsetname` tests.

## Note for review

`user_name_to_usr` now has no caller in `src/`. It is left in place: it correctly implements clang's C++ USR spelling and is covered by `unit/util/usr_utils.test.cpp`; the defect was using it as a lookup key against ESBMC's function-map ids, not the function itself. Happy to remove it (and its tests) if preferred.

M2 is closed by this — H-A2, H-A3 and H-A5 are all discharged at Tier B. Next is M3 (R1's release-mode `SYMEX_INVARIANT`), which R2 and R7 both wait on.