### PR TITLE
[python] Split tuple-from-list so it stops flapping on macOS CI

### DIFF
--- a/regression/python/tuple-from-list-access/main.py
+++ b/regression/python/tuple-from-list-access/main.py
@@ -1,0 +1,13 @@
+# Split from tuple-from-list: len, subscript, and iteration over a tuple
+# built from a list.
+
+u = tuple([4, 5, 6])
+assert len(u) == 3
+assert u[0] == 4
+assert u[2] == 6
+total = 0
+for x in u:
+    total = total + x
+assert total == 15
+
+print("ok")

--- a/regression/python/tuple-from-list-access/test.desc
+++ b/regression/python/tuple-from-list-access/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple-from-list-copy/main.py
+++ b/regression/python/tuple-from-list-copy/main.py
@@ -1,0 +1,22 @@
+# Split from tuple-from-list: tuple-of-tuple identity and the snapshot
+# semantics of tuple() over a list.
+
+# tuple of a tuple is the tuple itself (CPython identity)
+t = tuple((1, 2))
+assert t == (1, 2)
+
+# tuple of a tuple-returning call
+def pair():
+    return (1, 2)
+
+assert tuple(pair()) == (1, 2)
+
+# tuple() copies: mutating the source list afterwards must not show
+# through the tuple (CPython snapshot semantics)
+src = [1, 2]
+snap = tuple(src)
+src[0] = 9
+assert snap[0] == 1
+assert src[0] == 9
+
+print("ok")

--- a/regression/python/tuple-from-list-copy/test.desc
+++ b/regression/python/tuple-from-list-copy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple-from-list/main.py
+++ b/regression/python/tuple-from-list/main.py
@@ -1,6 +1,8 @@
-# tuple(iterable) over lists and tuples. The tuple is modelled as the
-# underlying sequence object, so equality, len(), subscript, and iteration
-# route through the list machinery (#4807, humaneval_33 pattern).
+# tuple(iterable) over lists. The tuple is modelled as the underlying
+# sequence object, so equality routes through the list machinery (#4807,
+# humaneval_33 pattern). Copy semantics live in tuple-from-list-copy and
+# len/subscript/iteration in tuple-from-list-access; verifying all three in
+# one program lands at ~85s on the macOS arm64 runner against a 120s cap.
 
 def ident(l: list):
     l = list(l)
@@ -16,33 +18,5 @@ assert tuple(a) == tuple(a)
 # tuple of a list-returning call (the humaneval_33 assertion shape)
 assert tuple(ident([1, 2, 3])) == tuple(ident([1, 2, 3]))
 assert tuple(ident([4, 5, 6]))[0] == 4
-
-# tuple of a tuple is the tuple itself (CPython identity)
-t = tuple((1, 2))
-assert t == (1, 2)
-
-# tuple of a tuple-returning call
-def pair():
-    return (1, 2)
-
-assert tuple(pair()) == (1, 2)
-
-# tuple() copies: mutating the source list afterwards must not show
-# through the tuple (CPython snapshot semantics)
-src = [1, 2]
-snap = tuple(src)
-src[0] = 9
-assert snap[0] == 1
-assert src[0] == 9
-
-# len, subscript, and iteration over a tuple built from a list
-u = tuple([4, 5, 6])
-assert len(u) == 3
-assert u[0] == 4
-assert u[2] == 6
-total = 0
-for x in u:
-    total = total + x
-assert total == 15
 
 print("ok")


### PR DESCRIPTION
`regression/python/tuple-from-list` verified construction, copy semantics,
len/subscript and iteration in a single program. It lands at 75-86s against the
120s per-test cap on the macOS arm64 runner and timed out at 120.47s in #6468's
run, which does not touch its code path.

Split into three tests. Worst single test drops from 19.7s to 6.2s locally
(6.2 / 1.2 / 1.4 vs 19.7); the `tuple-from-list_fail` companion is unchanged and
still the negative case. Preferred over a `_slow_regression_tests` 2x-budget
entry because it cuts the real cost rather than widening the cap.