### PR TITLE
[docs] Sync website with user-facing changes since #6107

### DIFF
--- a/website/content/docs/c-cpp/ESBMC-Cpp-Support.md
+++ b/website/content/docs/c-cpp/ESBMC-Cpp-Support.md
@@ -73,6 +73,128 @@ The standard given is the one the test exercises (`--std`).
 - `std::vector::at` throws `std::out_of_range` instead of asserting (`try-catch_vector_02_bug`); `std::bad_cast` / `std::bad_typeid` derive from `std::exception` with a virtual `what()`
 - Concurrent exceptions: the exception-state globals are thread-local, so each thread raises, catches, and clears its own in-flight exception independently — concurrently-throwing programs are lowered directly rather than rejected (`lower-exceptions_concurrent`). A pthread start routine reached through a computed pointer (or also called directly) cannot get a sound per-function uncaught-escape check and is declined as unsupported; declining is sound — it never validates a buggy program (`lower-exceptions_concurrent_dualuse`)
 
+# Operational models vs. host headers
+
+By default ESBMC compiles C++ with `-nostdinc++`, so `#include <vector>` resolves
+to ESBMC's own operational model (OM) rather than the host standard library. Two
+flags change that:
+
+- `--no-abstracted-cpp-includes` — do not include the abstract C++ operational
+  models at all.
+- `--mix-cpp-host-headers` — keep the host system headers visible *alongside* the
+  OMs, so an `#include` not covered by the bundled models falls through to the
+  host header. Names defined by both (`char_traits`, `istream`, …) can then
+  produce ambiguity errors, so this is opt-in.
+
+# Standard-library coverage (2026-07 update)
+
+The following are covered by passing regression tests under `regression/esbmc-cpp*`.
+
+**Newly modelled headers**
+
+- `<atomic>` ([#6129](https://github.com/esbmc/esbmc/pull/6129))
+- `<thread>`, `<mutex>` and `<condition_variable>`, lowered onto ESBMC's pthread
+  model so interleaving exploration, deadlock and race detection apply
+  ([#6394](https://github.com/esbmc/esbmc/pull/6394)); `std::promise` /
+  `std::future` on the same basis ([#6411](https://github.com/esbmc/esbmc/pull/6411))
+- `<system_error>` ([#6414](https://github.com/esbmc/esbmc/pull/6414)),
+  `<iosfwd>` ([#6417](https://github.com/esbmc/esbmc/pull/6417)), and `<complex>`,
+  which is now usable ([#6419](https://github.com/esbmc/esbmc/pull/6419))
+
+**Completed existing headers**
+
+- `<algorithm>` — the C++11 algorithms that were missing
+  ([#6435](https://github.com/esbmc/esbmc/pull/6435)); `upper_bound` scanned
+  backwards and returned the wrong iterator
+  ([#6434](https://github.com/esbmc/esbmc/pull/6434))
+- `<numeric>` — `iota`, `gcd`, `lcm`, `reduce`
+  ([#6418](https://github.com/esbmc/esbmc/pull/6418))
+- `<type_traits>` — the classification traits and `_t` aliases
+  ([#6412](https://github.com/esbmc/esbmc/pull/6412))
+- `<iterator>` — `iterator_traits` is now accessible and the iterator tags are
+  present ([#6420](https://github.com/esbmc/esbmc/pull/6420))
+- `<array>` — the required `iterator`/`const_iterator` typedefs
+  ([#6416](https://github.com/esbmc/esbmc/pull/6416))
+- `std::string_view` — the declared-but-missing search members
+  ([#6421](https://github.com/esbmc/esbmc/pull/6421)), plus `string` →
+  `string_view` conversion, `hash<string_view>` and the `fstream` string
+  overloads ([#6397](https://github.com/esbmc/esbmc/pull/6397))
+- `std::valarray` — the declared-but-missing members
+  ([#6424](https://github.com/esbmc/esbmc/pull/6424))
+- Streams — the standard stream objects (`std::cout` and friends) and
+  `ios::widen`/`narrow` ([#6425](https://github.com/esbmc/esbmc/pull/6425)),
+  `ios::exceptions` and `ios::copyfmt`
+  ([#6429](https://github.com/esbmc/esbmc/pull/6429)); `ostream`'s own
+  `width`/`fill`/`precision` were hiding the inherited members and are gone
+  ([#6427](https://github.com/esbmc/esbmc/pull/6427))
+- `std::variant` and `std::any` — the converting constructor no longer hijacks
+  copies ([#6407](https://github.com/esbmc/esbmc/pull/6407),
+  [#6408](https://github.com/esbmc/esbmc/pull/6408))
+- `std::optional` — `emplace`, `swap`, `std::make_optional`
+  ([#6346](https://github.com/esbmc/esbmc/pull/6346))
+- `<tuple>` — `std::tie` and `std::ignore`
+  ([#6344](https://github.com/esbmc/esbmc/pull/6344)); structured binding over a
+  `std::tuple` ([#6342](https://github.com/esbmc/esbmc/pull/6342))
+
+**Containers: const-correctness and the C++11/20 API**
+
+- `std::vector` — the destructor now frees its buffer
+  ([#6232](https://github.com/esbmc/esbmc/pull/6232)), plus `data()`,
+  `emplace_back`, `shrink_to_fit` and `cbegin`/`cend`
+- `std::list` — const `front`/`back`/`rbegin`/`rend`, and `cbegin`/`cend`
+- `std::deque` — const iteration and corrected iterator operators
+- `std::map`/`std::multimap` — a const `at` overload, `count` taking
+  `const key_type&`, const forward and reverse iteration, `emplace`,
+  `try_emplace`, `insert_or_assign`, and iterator equality so
+  `find(k) != end()` behaves
+- `std::set`/`std::multiset` — const-correct const iterators and `emplace`
+- C++20 `contains` on `map`/`multimap`/`set`/`multiset`, and `cbegin`/`cend`
+  across `deque`/`set`/`multiset`/`map`/`multimap`
+
+**`std::string`**
+
+- The `(const char*, size_t)` range constructor and the fill constructor
+  (whose parameters were reversed) are fixed
+- `operator<` / `operator>` are length-aware and available as free non-member
+  overloads against `const char*`
+- `substr(pos, n)` is `const`; C++20 `starts_with` / `ends_with` are available
+- `at` throws a catchable `std::out_of_range` instead of asserting
+  ([#6463](https://github.com/esbmc/esbmc/pull/6463))
+
+**Standard-version guards.** `<compare>` is includable before C++20, `<bit>`,
+`<span>` and `<expected>` are guarded, `<array>` is usable in C++11, `<limits>`
+works under `--std c++11` and `c++14`, and the C++98 container headers parse
+under `--std c++03`.
+
+# Language and frontend fixes (2026-07 update)
+
+- **Placement new** is modelled, including the form without an initializer
+  ([#6133](https://github.com/esbmc/esbmc/pull/6133),
+  [#6195](https://github.com/esbmc/esbmc/pull/6195))
+- **Virtual dispatch through a non-arrow member expression** — `(*p).f()` and
+  `ref.f()` now dispatch virtually
+  ([#6272](https://github.com/esbmc/esbmc/pull/6272))
+- **`delete`** dispatches through the virtual destructor slot
+  ([#6202](https://github.com/esbmc/esbmc/pull/6202)), and deleting through a
+  base subobject whose destructor is not virtual is rejected
+  ([#6285](https://github.com/esbmc/esbmc/pull/6285))
+- **Multiple inheritance** — nested base subobjects, `dynamic_cast<T*>`
+  re-offsetting across bases, override thunks keyed by each base's virtual name
+  and adjusted by the indirect base's cumulative offset, and catch-by-base
+  binding re-offset for MI thrown types
+- **`typeid`** on a polymorphic glvalue reports the dynamic type
+  ([#6392](https://github.com/esbmc/esbmc/pull/6392)), and the `type_info` name
+  string is NUL-terminated
+- **Virtual bases** are initialised only in the most-derived constructor
+  ([#6159](https://github.com/esbmc/esbmc/pull/6159))
+- **Conditional operators** — address-of distributes over a conditional lvalue,
+  class-typed conditionals elide their temporaries, and a reference parameter
+  binds to the selected arm
+- **Dynamic exception specifications** — `unexpected` / `bad_exception` recovery
+  ([#6240](https://github.com/esbmc/esbmc/pull/6240)); an aggregate-thrown
+  exception gets a symbol-consistent type id
+  ([#6303](https://github.com/esbmc/esbmc/pull/6303))
+
 # Features WIP:
 - Fixing our OMs for STL libraries
    * See guidelines: https://github.com/esbmc/esbmc/wiki/Guidelines-for-Fixing-Operational-Models-(OM)-in-ESBMC

--- a/website/content/docs/constructs.md
+++ b/website/content/docs/constructs.md
@@ -232,6 +232,36 @@ Run with a supported solver:
 esbmc file.c --z3
 ```
 
+### Calls, branches and loops inside a quantifier body
+
+A quantifier body may call a function. ESBMC inlines the callee *under* the
+binder, so the bound variable stays free:
+
+```c
+_Bool eq(int a, int b) { return a == b; }
+
+int main() {
+  int var;
+  __ESBMC_assert(__ESBMC_forall(&var, eq(var, 6)), "not valid for every var");
+}
+```
+
+Beyond a single `return`, a callee built from local declarations, assignments,
+`if`/`else`, and loops with a **statically constant** trip count is summarized
+into one side-effect-free expression — so a counting or accumulating helper can
+appear under `__ESBMC_forall`/`__ESBMC_exists` directly.
+
+Summarization is bounded by the size of the resulting expression rather than by
+the iteration count, because a branch merge inside an unrolled loop can double
+the summary on every iteration. The cap is
+`--max-quantifier-summary-nodes NR` (default 20000); raise it if a legitimate
+body is rejected for size.
+
+Shapes that cannot be summarized soundly — data-dependent trip counts, pointer
+writes, `break`, `switch`, recursion — are **rejected with a diagnostic naming
+the cause**, not silently hoisted out of the binder (which would freeze the
+bound variable and make the quantifier vacuous).
+
 ### Limitations
 
 - Supported solvers are Z3 and CVC5 (no SMT-LIB support).

--- a/website/content/docs/ld/limitations.md
+++ b/website/content/docs/ld/limitations.md
@@ -10,7 +10,15 @@ supported and the known restrictions.
 ## Supported constructs
 
 - **Contacts and coils** — normally-open and normally-closed contacts; output,
-  Set, and Reset coils.
+  Set, and Reset coils. Contacts carrying `edge="rising"` / `edge="falling"`
+  (and the vendor spellings `positive`/`negative`, `R`/`P`, `F`/`N`) are sensed
+  against a previous-scan shadow rather than treated as level contacts.
+- **Rung topology** — parallel paths that reach the same coil are OR-ed, not
+  overwritten by the last branch, and network feedback is snapshotted per scan
+  as required by IEC 61131-3 §4.1.3. A rung path that passes through a function
+  block resolves the block into synthesised pins instead of being dropped.
+- **Declared initial values** — `<initialValue>` on a variable declaration is
+  parsed, so declared presets no longer read as zero.
 - **Timers** — `TON` (on-delay) and `TOF` (off-delay), with their retained
   `ET`/`Q` state evaluated per scan. `TP` (pulse) blocks are accepted but
   currently simplified to `TON` semantics — see Restrictions below.

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -126,6 +126,12 @@ weight: 4
 - Core built-in exception types are supported, but not all Python standard library exceptions; custom exception hierarchies with complex inheritance patterns may not be fully handled.
 - `try`/`finally` is supported (including bare `try`/`finally`), but two shapes are refused at parse time rather than lowered unsoundly: a non-empty `else` clause on the `try` (a pre-existing gap — `orelse` is silently dropped today), and a `return`/`break`/`continue` that escapes the `try`, an `except` handler, or the `finally` body (it would bypass the appended `finally`).
 
+## Methods Without an Operational Model
+
+- A method call whose receiver class cannot be resolved — most commonly a method invoked directly on a **container literal**, e.g. `{1}.isdisjoint({2})` or `[1].foobar()` — evaluates to a **nondeterministic value**, so neither the assertion nor its negation can be discharged and both report `VERIFICATION FAILED`. This is deliberate: the previous fallback returned a null (falsy) value, which *proved* the negation of any such call. Binding the receiver to a name first (`s = {1}` … `s.isdisjoint({2})`) gets the modelled semantics.
+- An attribute assigned from a method whose return type is not the enclosing class, then used as a receiver (`self.pub = self.make_publisher()` followed by `self.pub.publish(...)`), degrades to `Unsupported function 'publish' is reached` / `VERIFICATION FAILED` rather than resolving the call.
+- `self.attr = self.method()` types `attr` by the **enclosing** class and does not perform virtual dispatch, so a subclass override is ignored and a valid polymorphic program can be reported as a false `VERIFICATION FAILED` (pinned as a KNOWNBUG in `regression/python/github_6242_override`).
+
 ## Class Attributes
 
 - Type inference for class attributes requires values with clear, determinable types; complex expressions may require explicit type annotations.

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -26,7 +26,7 @@ This page is a reference of all Python language constructs, data structures, and
 
 - **Function definitions**: Parameters, return values, and calls
 - **Variadic parameters**: `*args` syntax for variable-length positional argument lists
-- **Type annotations**: Basic types (`int`, `float`, `bool`, `str`), `Any`, `Union[T1, T2]`, PEP 604 `T1 | T2` syntax (including `T | None` on class attributes)
+- **Type annotations**: Basic types (`int`, `float`, `bool`, `str`), `Any`, `Union[T1, T2]`, PEP 604 `T1 | T2` syntax (including `T | None` on class attributes), subscripted forms (`list[int]`), **string forward references** (`node: 'Foo'`) and **dotted** annotations (`node: pkg.mod.Robot`, resolved on the last component). An annotation that cannot be resolved degrades to a clean error rather than a crash
 - **Union types**: Both `Union[int, bool]` and `int | bool` syntax are supported, including chained unions with multiple members
 - **Type widening**: ESBMC selects the widest type from Union members using the hierarchy `float > int > bool`
 - **Any type**: When a function is annotated `-> Any`, ESBMC infers the actual return type by analyzing return statements in the function body; supports `int`, `float`, `bool`, and expressions evaluating to those types
@@ -47,6 +47,7 @@ This page is a reference of all Python language constructs, data structures, and
 - **Inheritance**: Single and multi-level inheritance; verification of scenarios involving overridden methods
 - **`super()` calls**: `super().__init__(...)` and other `super().method(...)` calls, enabling verification of polymorphic behavior and parent-constructor side effects
 - **Explicit base-class `__init__`**: unbound parent-constructor calls of the form `Base.__init__(self, ...)` (the pre-`super()` idiom) are dispatched to the base constructor with `self` bound correctly
+- **`@staticmethod` and `@classmethod`**: receiver binding is taken from the method's decorator list rather than guessed from the first parameter's name. A `@staticmethod` receives no implicit receiver (so `M.twice(6)` binds `6` to the first real parameter), and a `@classmethod`'s `cls` parameter is typed against the enclosing class, so `cls.<attr>` resolves
 - **`@property` getters**: reading a `@property`-decorated attribute (`obj.area`) invokes the decorated getter method rather than looking up a struct field; inherited properties resolve through the base class
 - **Classes as first-class values**: a class name passed as a bare value (`register(Twist)`) — the class object itself, not an instance — is modelled as an opaque placeholder for inert uses (storing/forwarding the class), while normal construction through the name (`Twist()`) is unaffected
 - **Class-method defaults**: `Name` defaults referencing `ESBMC_default_*` helpers are hoisted past the enclosing `ClassDef` so they remain visible at call sites
@@ -62,6 +63,7 @@ This page is a reference of all Python language constructs, data structures, and
 - Empty and literal f-strings: `f""`, `f"Just a string"`
 - F-string concatenation with other strings
 - IEEE 754–compliant 32-bit and 64-bit float-to-string conversion
+- **Shortest-repr floats**: `str()`, `repr()`, f-string interpolation and empty-`{}` `format()` share one renderer that reproduces CPython's `repr` — a whole value below `1e16` renders as `N.0`, everything else uses the fewest significant digits that read back as the same `double`, with the same fixed/exponential cut-over. So `str(0.1 + 0.2)` is `"0.30000000000000004"`, `str(1e-5)` is `"1e-05"` and `repr(0.1234567)` is exact, where a previous release degraded these to a nondeterministic string (which made a correct assertion report a spurious `VERIFICATION FAILED`)
 
 ## Data Structures
 
@@ -81,7 +83,7 @@ This page is a reference of all Python language constructs, data structures, and
 - `in` operator: Membership testing (`2 in [1, 2, 3]`), including membership of a user-class instance by identity (`obj in [obj]`)
 - `del l[i]`: Remove the element at a constant index; `del l[i:j]` removes a slice
 - **Slice assignment**: `l[i:j] = src` and the extended form `l[i:j:k] = src`, including grow/shrink replacement (step 1), step > 1 (CPython requires matching lengths), and negative step (`l[::-1] = src`)
-- `+` operator: List concatenation (`[1,2] + [3,4]`)
+- `+` operator: List concatenation (`[1,2] + [3,4]`). A definite non-list right operand (`[1,2] + 3`, `[1,2] + "x"`) raises a catchable `TypeError`, matching CPython's `can only concatenate list (not "int") to list`; an unknown/`Any`-typed operand is left alone rather than misfiring on imprecise typing
 - **Repetition**: `lst * n` with both literal and variable lists
 - **Nested lists**: Method calls on subscripted elements (e.g., `nested[i].append(v)`)
 - **Typed instance attributes**: `self.attr: List[T]` instance attributes with full method support
@@ -198,6 +200,8 @@ Byte sequences and integer class methods:
 - **Numeric-tower properties** — `int.numerator` / `int.denominator` (an `int` is the ratio `n/1`), `int.real` / `int.imag`, and `float.real` / `float.imag`. `float.numerator` / `float.denominator` and these properties on a `bool` deliberately raise a clean `AttributeError` (CPython's `float` is not a `Rational`).
 - **`float.is_integer()`** — constant-folds on a literal float receiver (e.g. `(2.0).is_integer()` → `True`), evaluated as `isfinite(d) && d == trunc(d)` to match CPython
 - **`float.as_integer_ratio()` / `int.as_integer_ratio()`** — folds a numeric literal to its exact `(numerator, denominator)` pair in lowest terms (`(2.5).as_integer_ratio()` → `(5, 2)`, `(5).as_integer_ratio()` → `(5, 1)`, `(-2.5)` → `(-5, 2)`), including the exact dyadic ratio of a non-representable decimal (`(0.1).as_integer_ratio()`); the folded tuple unpacks (`n, d = (1.5).as_integer_ratio()`)
+- **`float.hex()`** — folds a literal float receiver to CPython's exact hexadecimal string (`(3.5).hex()` → `"0x1.c000000000000p+1"`), including negative and subnormal magnitudes and the special `-0.0` / `0.0` spellings. A `Name` receiver is not folded
+- **`float.fromhex(s)`** — the exact inverse over a **constant string**, matched against the strict C99 hex-float grammar `[sign]0x<hex>[.<hex>]p[sign]<dec>` that `float.hex()` emits, so the `hex → fromhex` round trip is exact. CPython's lenient spellings (no `0x` prefix, missing `p` exponent, `inf`/`nan`, out-of-range input) are rejected rather than folded
 - **`str.encode()` / `bytes.decode()`** — standalone constant-folded conversions over **ASCII** data (`s.encode()` → byte array of ordinals, `b.decode()` → string of byte values); a non-ASCII / multi-byte character falls through to a clean error, matching CPython's `UnicodeDecodeError`. The round-trip form `s.encode().decode()` is also supported.
 
 ## Error Handling
@@ -211,6 +215,7 @@ Byte sequences and integer class methods:
 
 **Built-in exception hierarchy**:
 - `BaseException` → `Exception` → `AssertionError`, `ValueError`, `TypeError`, `IndexError`, `KeyError`, `ZeroDivisionError`, `ImportError`
+- `BaseException` → `KeyboardInterrupt` (raisable and catchable; like `BaseException` itself, its `__init__` takes a required argument)
 - `OSError` → `FileNotFoundError`, `FileExistsError`, `PermissionError`
 
 Exception instances expose a message attribute and support `__str__()`.
@@ -287,6 +292,8 @@ The `--strict-types` flag enables type compatibility validation for function arg
 
 - **`__name__`**: Set to `"__main__"` when run directly; set to the module name when imported. Enables `if __name__ == "__main__":` idioms.
 - **Imports**: Standard `import` and `from ... import ...` styles validated at verification time. Module-level and function-local imports are also processed when verifying a single function with `--function`, so calls through imported modules (including operational models such as `math` and `random`) resolve there too
+- **Multiple files on the command line**: `esbmc a.py b.py` converts each file as its own translation unit of the same program — its own imports, its own global pre-registration, its own `__name__`/`__file__` — and appends each into `python_user_main`, mirroring how the C frontend merges several `.c` files. (Earlier releases kept only the last file, so a violated assertion in `a.py` silently dropped out of verification.)
+- **Relative imports**: `from .module import X` resolves as before. The no-module forms `from . import X` and `from .. import X` are treated as *unresolved* — the importing module still converts and verifies — instead of aborting
 - **Local bindings shadow imported modules**: When a name is both an imported module and a local binding (e.g. a parameter `node` while `from node import Node` is in scope), attribute access such as `node.value` resolves to the local binding, following Python's LEGB rule, rather than to a module member.
 - **Selective imports preserve module-level constants**: `from M import f, C` retains plain `Assign` bindings such as `INT_BOUND = 1024` in addition to `AnnAssign` ones. Tuple-unpacking targets are treated atomically.
 - **Parser package layout**: The Python parser ships as a package under `src/python-frontend/parser/` (entrypoint `parser/__main__.py`, public facade `parser/__init__.py`, import resolution in `parser/import_resolver.py`). The resolver emits deterministic, review-friendly diagnostics for missing modules, cyclic imports, and relative-import rewrites.
@@ -299,7 +306,7 @@ The `--strict-types` flag enables type compatibility validation for function arg
 | `int`, `float`, `bool`, `chr`, `ord`, `str`, `repr`, `hex`, `oct`, `bin`, `ascii` | Type conversions and representations. `bin`, `hex`, and `oct` accept non-literal integer arguments: a compile-time-foldable expression (e.g. `bin(round(3.0))`) folds to the exact literal, while a genuinely symbolic operand (a function parameter or variable) lowers to a runtime operational model (`__python_int_to_{bin,hex,oct}`) producing the correctly prefixed string (`0b`/`0x`/`0o`, a leading `-` for negatives, lowercase hex digits); a non-integer argument still raises `TypeError`. `bin` is `LLONG_MIN`-safe; `ascii` emits `\xNN`/`\uNNNN`/`\UNNNNNNNN` escapes for non-ASCII codepoints. |
 | `pow(b, e)` | Shares the `**` operator lowering (integer, float, bool operands) |
 | `pow(b, e, m)` | 3-argument modular exponentiation: exact `BigInt` for constant integer operands; symbolic operands raise an unsupported diagnostic rather than emit unsound floating-point modulo |
-| `format(value[, spec])` | Builtin formatting (distinct from the `str.format()` method). Constant-folds a literal integer with a bare presentation-type spec (`'d'`/`'x'`/`'X'`/`'o'`/`'b'` or empty) — `format(255, "x")` → `"ff"` (no `0x`/`0o`/`0b` prefix, leading `-` for negatives, `LLONG_MIN`-safe) — and a constant string with the default spec to itself. Width/alignment/precision specs, float values, and variable arguments raise a clean error rather than a wrong fold |
+| `format(value[, spec])` | Builtin formatting (distinct from the `str.format()` method). Constant-folds a literal integer with a bare presentation-type spec (`'d'`/`'x'`/`'X'`/`'o'`/`'b'` or empty) — `format(255, "x")` → `"ff"` (no `0x`/`0o`/`0b` prefix, leading `-` for negatives, `LLONG_MIN`-safe) — and a constant string with the default spec to itself. A **typeless float spec** (no presentation type) is folded too: width, alignment, sign and zero-padding (`format(1.5, "10")`, `format(-1.5, "08")`, `format(1.5, "=+10")`) render the digits through the shared shortest-repr renderer and then pad, and `,`/`_` grouping groups the integer part by 3 as CPython does (`format(1234.5, ",")` → `"1,234.5"`). Combinations that are *not* modelled — typeless precision (`format(1.5, ".2")`), grouping with an explicit float type (`",.1f"`), grouping plus zero/`=` padding (`"08,"`) — and variable arguments raise a clean error rather than a wrong fold |
 | `callable(obj)`, `issubclass(cls, base)` | Resolved at compile time from the symbol table and AST class hierarchy |
 | `len` | Works on lists, sets, strings, tuples |
 | `range` | Used in `for` loops |

--- a/website/content/docs/usage.md
+++ b/website/content/docs/usage.md
@@ -502,9 +502,18 @@ continues until all bugs are found. Relevant options:
 
 - `--multi-property` — verify all claims of the current bound (also activates `--no-remove-unreachable`).
 - `--multi-fail-fast N` — stop after the first `N` violations.
+- `--multi-property-interleavings N` — for concurrent programs, keep exploring thread interleavings after a violation until `N` consecutive ones reach a verdict on no new property (default 100, must be positive).
 - `--keep-verified-claims` — do not skip verified claims (assertions inside a loop body are then re-verified during unwinding).
 - `--all-witnesses` — after a property is violated, enumerate further inputs that also violate it (implies `--multi-property`; see below).
 - `--max-witnesses N` — cap witnesses per property (default 16; 0 = unlimited).
+
+Verdicts accumulate across the whole run and each property is reported exactly
+once at the end, with *failed* dominating *unknown* dominating *passed* — so a
+property discharged under one schedule and violated under another is reported as
+violated rather than printing contradictory lines. For a concurrent program,
+exploration continues past the first violation until
+`--multi-property-interleavings` consecutive interleavings decide nothing new; a
+run that stops early states that its report is partial.
 
 ### Enumerating all violating inputs
 
@@ -580,6 +589,22 @@ dynamic-symbolic-execution test generation (KLEE, DART, SAGE), which varies the
 path condition to maximise coverage; `--all-witnesses` instead fixes the failure
 path and enumerates input vectors on it.
 
+## Suppressing assertions inside the operational models
+
+```sh
+esbmc file.c --no-library-assertions
+```
+
+ESBMC's operational models assert their own API preconditions (for example
+`"Sem is not initialized"`). `--no-library-assertions` drops those claims while
+keeping every assertion in the program under verification — useful when a model
+precondition is deliberately violated in code you do not own.
+
+It hides genuine API misuse the models report, so it is off by default. It also
+leaves the checks ESBMC *generates* inside model code (those are controlled by
+`--no-standard-checks`), renumbers `--claim` indices, and is unsupported for
+Python.
+
 ## Supported SMT backends {#smt-backends}
 
 ESBMC integrates several SMT solvers directly via their APIs, and on Unix can
@@ -622,3 +647,12 @@ shell, so it can include options or chain commands (the tools must be on
 - `cvc5 -L smt2 -m`
 
 Remember to quote the `CMD` string when invoking ESBMC.
+
+### Symmetry breaking
+
+Symmetric formulas — most often a running maximum or minimum folded over an
+uninitialised array — make the backend solver enumerate equivalent case splits.
+ESBMC recognises those max/min folds and asserts the redundant bounds they imply
+before solving, which cuts the search. This is **on by default**; pass
+`--no-symmetry-breaking` to disable it if the extra constraints hurt on a
+particular benchmark.


### PR DESCRIPTION
Documents the five user-facing CLI flags added since the last website sync (`--no-library-assertions`, `--mix-cpp-host-headers`, `--no-symmetry-breaking`, `--multi-property-interleavings`, `--max-quantifier-summary-nodes`), the function/loop summarization now allowed inside quantifier bodies, the 2026-07 batch of C++ operational-model and frontend work, the Python float-repr / decorator / multi-file / import fixes, and the graphical Ladder Diagram constructs from #6378.

Also corrects the now-stale claim that Python's `format()` rejects every float spec — #6249/#6250 made typeless float specs and `,`/`_` grouping fold correctly.

Hugo builds clean; 565 unit tests and the 22 regression tests backing the documented claims pass. Substantive claims were spot-checked against a rebuilt binary rather than inferred from commit messages.
