### PR TITLE
[om] Fix stale blocked-thread counter and detect rwlock deadlocks

### DIFF
--- a/regression/esbmc-unix/github_6474/main.c
+++ b/regression/esbmc-unix/github_6474/main.c
@@ -1,0 +1,25 @@
+#include <pthread.h>
+pthread_mutex_t m1, m2;
+
+void *w(void *p)
+{
+  pthread_mutex_lock(&m2);
+  pthread_mutex_lock(&m1);
+  pthread_mutex_unlock(&m1);
+  pthread_mutex_unlock(&m2);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_mutex_init(&m1, 0);
+  pthread_mutex_init(&m2, 0);
+  pthread_mutex_lock(&m1);
+  pthread_create(&a, 0, w, 0);
+  pthread_create(&b, 0, w, 0);
+  pthread_mutex_unlock(&m1);
+  pthread_mutex_lock(&m2);
+  pthread_mutex_unlock(&m2);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6474/test.desc
+++ b/regression/esbmc-unix/github_6474/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --unwind 2 --context-bound 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6474_reinit/main.c
+++ b/regression/esbmc-unix/github_6474_reinit/main.c
@@ -1,0 +1,22 @@
+#include <pthread.h>
+
+static pthread_mutex_t m;
+
+static void *w(void *p)
+{
+  (void)p;
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_lock(&m);
+  pthread_create(&a, 0, w, 0);
+  pthread_mutex_init(&m, 0);
+  pthread_join(a, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6474_reinit/test.desc
+++ b/regression/esbmc-unix/github_6474_reinit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --context-bound 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6474_sem/main.c
+++ b/regression/esbmc-unix/github_6474_sem/main.c
@@ -1,0 +1,26 @@
+#include <pthread.h>
+#include <semaphore.h>
+
+static sem_t s;
+
+static void *worker(void *p)
+{
+  (void)p;
+  sem_wait(&s);
+  sem_post(&s);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t1, t2;
+  sem_init(&s, 0, 1);
+  sem_wait(&s);
+  pthread_create(&t1, 0, worker, 0);
+  pthread_create(&t2, 0, worker, 0);
+  sem_post(&s);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+  sem_destroy(&s);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6474_sem/test.desc
+++ b/regression/esbmc-unix/github_6474_sem/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --context-bound 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6475/main.c
+++ b/regression/esbmc-unix/github_6475/main.c
@@ -1,0 +1,32 @@
+#include <pthread.h>
+pthread_rwlock_t A, B;
+
+void *t1(void *p)
+{
+  pthread_rwlock_wrlock(&A);
+  pthread_rwlock_wrlock(&B);
+  pthread_rwlock_unlock(&B);
+  pthread_rwlock_unlock(&A);
+  return 0;
+}
+
+void *t2(void *p)
+{
+  pthread_rwlock_wrlock(&B);
+  pthread_rwlock_wrlock(&A);
+  pthread_rwlock_unlock(&A);
+  pthread_rwlock_unlock(&B);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_rwlock_init(&A, 0);
+  pthread_rwlock_init(&B, 0);
+  pthread_create(&a, 0, t1, 0);
+  pthread_create(&b, 0, t2, 0);
+  pthread_join(a, 0);
+  pthread_join(b, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6475/test.desc
+++ b/regression/esbmc-unix/github_6475/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--deadlock-check --unwind 4 --context-bound 4
+^VERIFICATION FAILED$
+^.*Deadlocked state.*$
+^  CWE: CWE-833$

--- a/regression/esbmc-unix/github_6475_rdlock/main.c
+++ b/regression/esbmc-unix/github_6475_rdlock/main.c
@@ -1,0 +1,33 @@
+#include <pthread.h>
+
+static pthread_rwlock_t a, b;
+
+static void *t1(void *p)
+{
+  (void)p;
+  pthread_rwlock_wrlock(&a);
+  pthread_rwlock_rdlock(&b);
+  pthread_rwlock_unlock(&b);
+  pthread_rwlock_unlock(&a);
+  return 0;
+}
+
+static void *t2(void *p)
+{
+  (void)p;
+  pthread_rwlock_wrlock(&b);
+  pthread_rwlock_rdlock(&a);
+  pthread_rwlock_unlock(&a);
+  pthread_rwlock_unlock(&b);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t p1, p2;
+  pthread_rwlock_init(&a, 0);
+  pthread_rwlock_init(&b, 0);
+  pthread_create(&p1, 0, t1, 0);
+  pthread_create(&p2, 0, t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6475_rdlock/test.desc
+++ b/regression/esbmc-unix/github_6475_rdlock/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--deadlock-check --unwind 4 --context-bound 4
+^VERIFICATION FAILED$
+^  Deadlocked state in pthread_rwlock_rdlock$
+^  CWE: CWE-833$

--- a/regression/esbmc-unix/github_6475_safe/main.c
+++ b/regression/esbmc-unix/github_6475_safe/main.c
@@ -1,0 +1,27 @@
+#include <pthread.h>
+
+static pthread_rwlock_t l;
+static int data;
+
+static void *reader(void *p)
+{
+  (void)p;
+  pthread_rwlock_rdlock(&l);
+  (void)data;
+  pthread_rwlock_unlock(&l);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t1, t2;
+  pthread_rwlock_init(&l, 0);
+  pthread_rwlock_wrlock(&l);
+  data = 1;
+  pthread_create(&t1, 0, reader, 0);
+  pthread_create(&t2, 0, reader, 0);
+  pthread_rwlock_unlock(&l);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6475_safe/test.desc
+++ b/regression/esbmc-unix/github_6475_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --unwind 4 --context-bound 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6475_wrlock/main.c
+++ b/regression/esbmc-unix/github_6475_wrlock/main.c
@@ -1,0 +1,33 @@
+#include <pthread.h>
+
+static pthread_rwlock_t a, b;
+
+static void *t1(void *p)
+{
+  (void)p;
+  pthread_rwlock_wrlock(&a);
+  pthread_rwlock_wrlock(&b);
+  pthread_rwlock_unlock(&b);
+  pthread_rwlock_unlock(&a);
+  return 0;
+}
+
+static void *t2(void *p)
+{
+  (void)p;
+  pthread_rwlock_wrlock(&b);
+  pthread_rwlock_wrlock(&a);
+  pthread_rwlock_unlock(&a);
+  pthread_rwlock_unlock(&b);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t p1, p2;
+  pthread_rwlock_init(&a, 0);
+  pthread_rwlock_init(&b, 0);
+  pthread_create(&p1, 0, t1, 0);
+  pthread_create(&p2, 0, t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6475_wrlock/test.desc
+++ b/regression/esbmc-unix/github_6475_wrlock/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--deadlock-check --unwind 4 --context-bound 4
+^VERIFICATION FAILED$
+^  Deadlocked state in pthread_rwlock_wrlock$
+^  CWE: CWE-833$

--- a/src/c2goto/headers/pthread.h
+++ b/src/c2goto/headers/pthread.h
@@ -49,6 +49,8 @@ typedef union pthread_attr_t
 typedef struct
 {
   int __lock;
+  /* Repurposed by the operational model as the number of threads currently
+     blocked on this mutex; see __ESBMC_mutex_waiters in pthread_lib.c. */
   unsigned int __count;
   int __owner;
 } pthread_mutex_t;

--- a/src/c2goto/headers/pthread.h
+++ b/src/c2goto/headers/pthread.h
@@ -49,8 +49,7 @@ typedef union pthread_attr_t
 typedef struct
 {
   int __lock;
-  /* Repurposed by the operational model as the number of threads currently
-     blocked on this mutex; see __ESBMC_mutex_waiters in pthread_lib.c. */
+  /* Repurposed as this mutex's waiter count; see __ESBMC_mutex_waiters. */
   unsigned int __count;
   int __owner;
 } pthread_mutex_t;
@@ -93,6 +92,8 @@ typedef int pthread_once_t;
 typedef struct {
   int __readers;
   int __writer;
+  /* Threads currently blocked on this lock; see __ESBMC_rwlock_waiters. */
+  unsigned int __waiters;
 } pthread_rwlock_t;
 
 /* Read-write lock initializer. */
@@ -564,8 +565,9 @@ extern int pthread_mutexattr_setrobust (pthread_mutexattr_t *__attr,
 #endif
 
 
-#if defined __USE_UNIX98 || defined __USE_XOPEN2K
-/* Functions for handling read-write locks.  */
+/* Functions for handling read-write locks. Unguarded because ESBMC defines
+   neither __USE_UNIX98 nor __USE_XOPEN2K, which would leave the
+   --deadlock-check -D renames with no prototype to rewrite.  */
 
 /* Initialize read-write lock RWLOCK using attributes ATTR, or use
    the default values if later is NULL.  */
@@ -631,7 +633,6 @@ extern int pthread_rwlockattr_getkind_np (__const pthread_rwlockattr_t *
 /* Set reader/write preference.  */
 extern int pthread_rwlockattr_setkind_np (pthread_rwlockattr_t *__attr,
 					  int __pref);
-#endif
 
 
 /* Functions for handling conditional variables.  */

--- a/src/c2goto/headers/semaphore.h
+++ b/src/c2goto/headers/semaphore.h
@@ -26,6 +26,8 @@ typedef struct
   int __lock;
   int __count;
   int __init;
+  /* Threads currently blocked on this semaphore; see __ESBMC_sem_waiters. */
+  unsigned int __waiters;
 } sem_t;
 
 /* Initialize semaphore object SEM to VALUE.  If PSHARED then share it

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -58,14 +58,9 @@ unsigned short int __ESBMC_num_threads_running = 0;
 unsigned short int __ESBMC_blocked_threads_count = 0;
 
 /* Cancels the blocked-count contributions of every thread waiting on one
- * object. Each was bumped together with that object's waiter count inside a
- * single atomic region, so the two are guarded by the same condition and
- * subtracting the count restores the global counter exactly.
- *
- * The clamp guards a modelling slip only: the pairing makes underflow
- * unreachable, but an unsigned short wrap to 65535 would silently disable
- * deadlock detection for the rest of the run, since 65535 is never equal to
- * __ESBMC_num_threads_running. */
+ * object. Waiter counts live in user-owned storage, so an uninitialised lock
+ * can feed an arbitrary value in here; clamping to 0 disables deadlock
+ * detection at this instant rather than for the rest of the run. */
 void __ESBMC_release_blocked_threads(unsigned int waiters)
 {
 __ESBMC_HIDE:;
@@ -421,6 +416,8 @@ int pthread_mutex_init(
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   __ESBMC_mutex_lock_field(*mutex) = 0;
+  // Re-initialising a contended mutex frees it, so release rather than drop.
+  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
   __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_mutex_owner_field(*mutex) = 0;
   __ESBMC_atomic_end();
@@ -564,8 +561,6 @@ __ESBMC_HIDE:;
 
   // It shall be safe to destroy an initialized mutex that is unlocked
   __ESBMC_mutex_lock_field(*mutex) = -1;
-  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
-  __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_atomic_end();
   return 0;
 }
@@ -596,6 +591,7 @@ __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   __ESBMC_rwlock_readers(lock) = 0;
   __ESBMC_rwlock_writer(lock) = 0;
+  __ESBMC_release_blocked_threads(__ESBMC_rwlock_waiters(lock));
   __ESBMC_rwlock_waiters(lock) = 0;
   __ESBMC_atomic_end();
   return 0;
@@ -678,10 +674,8 @@ __ESBMC_HIDE:;
   else if (__ESBMC_rwlock_readers(lock) > 0)
     __ESBMC_rwlock_readers(lock)--;
 
-  /* Only the _check acquisitions register waiters, so this is inert without
-   * --deadlock-check. A reader blocks only behind a writer and a writer
-   * excludes readers, so a fully free lock is exactly when every registered
-   * waiter could proceed. */
+  /* A reader blocks only behind a writer and a writer excludes readers, so a
+   * fully free lock is exactly when every registered waiter could proceed. */
   if (!__ESBMC_rwlock_writer(lock) && !__ESBMC_rwlock_readers(lock))
   {
     __ESBMC_release_blocked_threads(__ESBMC_rwlock_waiters(lock));
@@ -814,7 +808,7 @@ __ESBMC_HIDE:;
   if (assrt)
     __ESBMC_assert(
       __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
-      "Deadlocked state in pthread_mutex_lock");
+      "Deadlocked state in pthread_cond_wait");
 
   __ESBMC_atomic_end();
 

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -40,6 +40,10 @@ _Bool __ESBMC_pthread_thread_ended[1];
 __attribute__((annotate("__ESBMC_inf_size")))
 _Bool __ESBMC_pthread_thread_detach[1];
 
+/* Threads currently blocked in pthread_join waiting for thread[i] to end. */
+__attribute__((
+  annotate("__ESBMC_inf_size"))) unsigned int __ESBMC_pthread_join_waiters[1];
+
 __attribute__((
   annotate("__ESBMC_inf_size"))) void *__ESBMC_pthread_end_values[1];
 
@@ -226,6 +230,8 @@ __ESBMC_HIDE:;
   __ESBMC_pthread_end_values[threadid] = exit_val;
   __ESBMC_pthread_thread_ended[threadid] = 1;
   __ESBMC_num_threads_running--;
+  __ESBMC_release_blocked_threads(__ESBMC_pthread_join_waiters[threadid]);
+  __ESBMC_pthread_join_waiters[threadid] = 0;
   // A thread terminating during a search for a deadlock means there's no
   // deadlock or it can be found down a different path. Proof left as exercise
   // to the reader.
@@ -283,6 +289,8 @@ __ESBMC_HIDE:;
   __ESBMC_pthread_end_values[threadid] = retval;
   __ESBMC_pthread_thread_ended[threadid] = 1;
   __ESBMC_num_threads_running--;
+  __ESBMC_release_blocked_threads(__ESBMC_pthread_join_waiters[threadid]);
+  __ESBMC_pthread_join_waiters[threadid] = 0;
 
   // A thread terminating during a search for a deadlock means there's no
   // deadlock or it can be found down a different path. Proof left as exercise
@@ -363,6 +371,7 @@ __ESBMC_HIDE:;
   _Bool ended = __ESBMC_pthread_thread_ended[(int)thread];
   if (!ended)
   {
+    __ESBMC_pthread_join_waiters[(int)thread]++;
     __ESBMC_blocked_threads_count++;
     // If there are now no more threads unblocked, croak.
     __ESBMC_assert(

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -21,7 +21,7 @@ void __ESBMC_set_thread_internal_data(
   struct __pthread_start_data data);
 
 #define __ESBMC_mutex_lock_field(a) ((a).__lock)
-#define __ESBMC_mutex_count_field(a) ((a).__count)
+#define __ESBMC_mutex_waiters(a) ((a).__count)
 #define __ESBMC_mutex_owner_field(a) ((a).__owner)
 #define __ESBMC_cond_lock_field(a) ((a).__lock)
 #define __ESBMC_cond_futex_field(a) ((a).__futex)
@@ -51,6 +51,24 @@ static pthread_key_t __ESBMC_next_thread_key = 0;
 unsigned short int __ESBMC_num_total_threads = 0;
 unsigned short int __ESBMC_num_threads_running = 0;
 unsigned short int __ESBMC_blocked_threads_count = 0;
+
+/* Cancels the blocked-count contributions of every thread waiting on one
+ * object. Each was bumped together with that object's waiter count inside a
+ * single atomic region, so the two are guarded by the same condition and
+ * subtracting the count restores the global counter exactly.
+ *
+ * The clamp guards a modelling slip only: the pairing makes underflow
+ * unreachable, but an unsigned short wrap to 65535 would silently disable
+ * deadlock detection for the rest of the run, since 65535 is never equal to
+ * __ESBMC_num_threads_running. */
+void __ESBMC_release_blocked_threads(unsigned int waiters)
+{
+__ESBMC_HIDE:;
+  __ESBMC_blocked_threads_count =
+    (waiters >= (unsigned int)__ESBMC_blocked_threads_count)
+      ? 0
+      : (unsigned short int)(__ESBMC_blocked_threads_count - waiters);
+}
 
 /* Per-thread cancellation state. All default to 0:
  *   cancel_requested = false
@@ -393,7 +411,7 @@ int pthread_mutex_init(
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   __ESBMC_mutex_lock_field(*mutex) = 0;
-  __ESBMC_mutex_count_field(*mutex) = 0;
+  __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_mutex_owner_field(*mutex) = 0;
   __ESBMC_atomic_end();
   return 0;
@@ -471,6 +489,7 @@ __ESBMC_HIDE:;
   else
   {
     // Deadlock foo
+    __ESBMC_mutex_waiters(*mutex)++;
     __ESBMC_blocked_threads_count++;
     // No more threads to run -> croak.
     __ESBMC_assert(
@@ -494,6 +513,8 @@ __ESBMC_HIDE:;
   __ESBMC_assert(
     __ESBMC_mutex_lock_field(*mutex), "must hold lock upon unlock");
   __ESBMC_mutex_lock_field(*mutex) = 0;
+  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
+  __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_atomic_end();
   return 0;
 }
@@ -533,6 +554,8 @@ __ESBMC_HIDE:;
 
   // It shall be safe to destroy an initialized mutex that is unlocked
   __ESBMC_mutex_lock_field(*mutex) = -1;
+  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
+  __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_atomic_end();
   return 0;
 }
@@ -542,6 +565,8 @@ int pthread_mutex_destroy(pthread_mutex_t *mutex)
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   __ESBMC_mutex_lock_field(*mutex) = -1;
+  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
+  __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_atomic_end();
   return 0;
 }
@@ -683,7 +708,11 @@ __ESBMC_HIDE:;
     _Bool _cancel = __ESBMC_pthread_cancel_requested[_ctid] &&
                     __ESBMC_pthread_cancelstate[_ctid] == PTHREAD_CANCEL_ENABLE;
     if (_cancel)
+    {
       __ESBMC_mutex_lock_field(*mutex) = 0;
+      __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
+      __ESBMC_mutex_waiters(*mutex) = 0;
+    }
     __ESBMC_atomic_end();
     if (_cancel)
       pthread_exit(PTHREAD_CANCELED);
@@ -697,6 +726,8 @@ __ESBMC_HIDE:;
 
   // Unlock mutex; register us as waiting on condvar; context switch
   __ESBMC_mutex_lock_field(*mutex) = 0;
+  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
+  __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_cond_lock_field(*cond) = 1;
 
   // Technically in the gap below, we are blocked. So mark ourselves thus. If

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -28,6 +28,7 @@ void __ESBMC_set_thread_internal_data(
 #define __ESBMC_cond_nwaiters_field(a) ((a).__nwaiters)
 #define __ESBMC_rwlock_readers(a) ((a)->__readers)
 #define __ESBMC_rwlock_writer(a) ((a)->__writer)
+#define __ESBMC_rwlock_waiters(a) ((a)->__waiters)
 
 /* Global tracking data. Should all initialize to 0 / false */
 __attribute__((annotate("__ESBMC_inf_size")))
@@ -586,6 +587,7 @@ __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   __ESBMC_rwlock_readers(lock) = 0;
   __ESBMC_rwlock_writer(lock) = 0;
+  __ESBMC_rwlock_waiters(lock) = 0;
   __ESBMC_atomic_end();
   return 0;
 }
@@ -597,6 +599,33 @@ __ESBMC_HIDE:;
   __ESBMC_assume(!__ESBMC_rwlock_writer(lock));
   __ESBMC_rwlock_readers(lock)++;
   __ESBMC_atomic_end();
+  return 0;
+}
+
+int pthread_rwlock_rdlock_check(pthread_rwlock_t *lock)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+
+  _Bool acquired = !__ESBMC_rwlock_writer(lock);
+
+  if (acquired)
+  {
+    __ESBMC_rwlock_readers(lock)++;
+  }
+  else
+  {
+    __ESBMC_rwlock_waiters(lock)++;
+    __ESBMC_blocked_threads_count++;
+    __ESBMC_assert(
+      __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
+      "Deadlocked state in pthread_rwlock_rdlock");
+  }
+
+  __ESBMC_atomic_end();
+
+  __ESBMC_assume(acquired);
+
   return 0;
 }
 
@@ -639,6 +668,16 @@ __ESBMC_HIDE:;
     __ESBMC_rwlock_writer(lock) = 0;
   else if (__ESBMC_rwlock_readers(lock) > 0)
     __ESBMC_rwlock_readers(lock)--;
+
+  /* Only the _check acquisitions register waiters, so this is inert without
+   * --deadlock-check. A reader blocks only behind a writer and a writer
+   * excludes readers, so a fully free lock is exactly when every registered
+   * waiter could proceed. */
+  if (!__ESBMC_rwlock_writer(lock) && !__ESBMC_rwlock_readers(lock))
+  {
+    __ESBMC_release_blocked_threads(__ESBMC_rwlock_waiters(lock));
+    __ESBMC_rwlock_waiters(lock) = 0;
+  }
   __ESBMC_atomic_end();
   return 0;
 }
@@ -651,6 +690,34 @@ __ESBMC_HIDE:;
     !(__ESBMC_rwlock_writer(lock) || __ESBMC_rwlock_readers(lock)));
   __ESBMC_rwlock_writer(lock) = 1;
   __ESBMC_atomic_end();
+  return 0;
+}
+
+int pthread_rwlock_wrlock_check(pthread_rwlock_t *lock)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+
+  _Bool acquired =
+    !(__ESBMC_rwlock_writer(lock) || __ESBMC_rwlock_readers(lock));
+
+  if (acquired)
+  {
+    __ESBMC_rwlock_writer(lock) = 1;
+  }
+  else
+  {
+    __ESBMC_rwlock_waiters(lock)++;
+    __ESBMC_blocked_threads_count++;
+    __ESBMC_assert(
+      __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
+      "Deadlocked state in pthread_rwlock_wrlock");
+  }
+
+  __ESBMC_atomic_end();
+
+  __ESBMC_assume(acquired);
+
   return 0;
 }
 

--- a/src/c2goto/library/semaphore_lib.c
+++ b/src/c2goto/library/semaphore_lib.c
@@ -24,6 +24,8 @@ __ESBMC_HIDE:;
   __ESBMC_sem_lock_field(*__sem) = (__value == 0);
   __ESBMC_sem_count_field(*__sem) = __value;
   __ESBMC_sem_init_field(*__sem) = 1;
+  // Re-initialising a contended semaphore frees it: release, don't drop.
+  __ESBMC_release_blocked_threads(__ESBMC_sem_waiters(*__sem));
   __ESBMC_sem_waiters(*__sem) = 0;
   __ESBMC_atomic_end();
   return 0;

--- a/src/c2goto/library/semaphore_lib.c
+++ b/src/c2goto/library/semaphore_lib.c
@@ -5,10 +5,12 @@
 #define __ESBMC_sem_lock_field(a) ((a).__lock)
 #define __ESBMC_sem_count_field(a) ((a).__count)
 #define __ESBMC_sem_init_field(a) ((a).__init)
+#define __ESBMC_sem_waiters(a) ((a).__waiters)
 
 /* Declaration of external variables */
 extern unsigned short int __ESBMC_num_threads_running;
 extern unsigned short int __ESBMC_blocked_threads_count;
+extern void __ESBMC_release_blocked_threads(unsigned int waiters);
 
 /************************* Sem manipulation routines ************************/
 
@@ -22,6 +24,7 @@ __ESBMC_HIDE:;
   __ESBMC_sem_lock_field(*__sem) = (__value == 0);
   __ESBMC_sem_count_field(*__sem) = __value;
   __ESBMC_sem_init_field(*__sem) = 1;
+  __ESBMC_sem_waiters(*__sem) = 0;
   __ESBMC_atomic_end();
   return 0;
 }
@@ -54,11 +57,12 @@ __ESBMC_HIDE:;
   else
   {
     // Deadlock foo
+    __ESBMC_sem_waiters(*__sem)++;
     __ESBMC_blocked_threads_count++;
     // No more threads to run -> croak.
     __ESBMC_assert(
       __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
-      "Deadlocked state in pthread_mutex_lock");
+      "Deadlocked state in sem_wait");
   }
   __ESBMC_atomic_end();
 
@@ -86,7 +90,11 @@ __ESBMC_HIDE:;
   sem_init_check(__sem);
   __ESBMC_sem_count_field(*__sem) += 1;
   if (__ESBMC_sem_count_field(*__sem))
+  {
     __ESBMC_sem_lock_field(*__sem) = 0;
+    __ESBMC_release_blocked_threads(__ESBMC_sem_waiters(*__sem));
+    __ESBMC_sem_waiters(*__sem) = 0;
+  }
   __ESBMC_atomic_end();
   return 0;
 }
@@ -96,6 +104,8 @@ int sem_destroy(sem_t *__sem)
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   __ESBMC_sem_lock_field(*__sem) = -1;
+  __ESBMC_release_blocked_threads(__ESBMC_sem_waiters(*__sem));
+  __ESBMC_sem_waiters(*__sem) = 0;
   __ESBMC_atomic_end();
   return 0;
 }

--- a/src/clang-c-frontend/c_preprocess.cpp
+++ b/src/clang-c-frontend/c_preprocess.cpp
@@ -318,6 +318,8 @@ int configure_and_run_cpp(
     record_define("pthread_mutex_unlock=pthread_mutex_unlock_check");
     record_define("pthread_cond_wait=pthread_cond_wait_check");
     record_define("pthread_join=pthread_join_switch");
+    record_define("pthread_rwlock_rdlock=pthread_rwlock_rdlock_check");
+    record_define("pthread_rwlock_wrlock=pthread_rwlock_wrlock_check");
   }
   else if (config.options.get_bool_option("lock-order-check"))
   {

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -87,6 +87,12 @@ void clang_c_languaget::build_compiler_args(
       "-Dpthread_mutex_unlock=pthread_mutex_unlock_check");
     compiler_args.emplace_back("-Dpthread_cond_wait=pthread_cond_wait_check");
     compiler_args.emplace_back("-Dsem_wait=sem_wait_check");
+    // Only the blocking acquisitions need renaming: pthread_rwlock_unlock's
+    // waiter release is inert when nothing registered a waiter.
+    compiler_args.emplace_back(
+      "-Dpthread_rwlock_rdlock=pthread_rwlock_rdlock_check");
+    compiler_args.emplace_back(
+      "-Dpthread_rwlock_wrlock=pthread_rwlock_wrlock_check");
   }
   else if (config.options.get_bool_option("lock-order-check"))
   {


### PR DESCRIPTION
`__ESBMC_blocked_threads_count` was incremented on every failed acquisition but almost never decremented, so `--deadlock-check` reported deadlocks in deadlock-free programs. Separately, `pthread_rwlock_rdlock`/`wrlock` blocked with a bare `__ESBMC_assume` and no accounting at all, so real rwlock deadlocks were reported as SUCCESSFUL.

Threads now register as waiters on the object they block on, and whoever releases that object cancels their contribution. Adds `pthread_rwlock_{rd,wr}lock_check` and selects them from the `deadlock-check` arm of both `-D` rewrite lists; the rwlock prototypes had to be un-guarded, since ESBMC defines neither `__USE_UNIX98` nor `__USE_XOPEN2K` and the renames had no prototype to rewrite.

Fixes #6474. Fixes #6475.

### Notes for reviewers

* The Python model (`threading.Lock`, `__pyt_join`/`__pyt_terminate`) has the identical counter defect and is deliberately **not** fixed here, since it would destabilise `regression/python/github_4581`. Tracked in #6489.
* The join release (8f7875b) has no discriminating test. Its commit message says the pre-existing `assume(blocked == 0)` at thread exit "masks" it, which is imprecise: the release runs *before* that assume, so it does change which traces survive, but no test I could construct detects the difference. It is included because #6474 names `pthread_join_switch` as one of the four unbalanced increment sites, and weakening an assume can only add traces, never introduce a false positive.
* `pthread_mutex_trylock` and `pthread_cond_wait`'s mutex re-acquire remain unaccounted for: the clib is built without `--deadlock-check`, so both freeze to `pthread_mutex_lock_noassert`. Pre-existing and out of scope.

### Tests

Seven new tests under `regression/esbmc-unix/`: `github_6474` (the #6474 reproducer), `github_6474_sem`, `github_6474_reinit`, `github_6475` (the #6475 reproducer), `github_6475_wrlock`, `github_6475_rdlock`, `github_6475_safe`.

Each `--context-bound` was chosen by building a control with the release stubbed out and picking the smallest bound at which the test genuinely fails unpatched — at `--context-bound 2` both `github_6474` and `github_6474_sem` pass even with the fix disabled, so they would have been non-discriminating.