### PR TITLE
[om] Fix inverted pthread_mutex_destroy_check assertions

### DIFF
--- a/regression/esbmc-unix/github_6476-double-destroy_fail/main.c
+++ b/regression/esbmc-unix/github_6476-double-destroy_fail/main.c
@@ -1,0 +1,10 @@
+#include <pthread.h>
+
+int main(void)
+{
+  pthread_mutex_t m;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_destroy(&m);
+  pthread_mutex_destroy(&m);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6476-double-destroy_fail/test.desc
+++ b/regression/esbmc-unix/github_6476-double-destroy_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 4 --lock-order-check
+^VERIFICATION FAILED$
+attempt to destroy a previously destroyed mutex

--- a/regression/esbmc-unix/github_6476/main.c
+++ b/regression/esbmc-unix/github_6476/main.c
@@ -1,0 +1,11 @@
+#include <pthread.h>
+
+int main(void)
+{
+  pthread_mutex_t m;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  pthread_mutex_destroy(&m);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6476/test.desc
+++ b/regression/esbmc-unix/github_6476/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4 --lock-order-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6476_fail/main.c
+++ b/regression/esbmc-unix/github_6476_fail/main.c
@@ -1,0 +1,10 @@
+#include <pthread.h>
+
+int main(void)
+{
+  pthread_mutex_t m;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_lock(&m);
+  pthread_mutex_destroy(&m);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6476_fail/test.desc
+++ b/regression/esbmc-unix/github_6476_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 4 --lock-order-check
+^VERIFICATION FAILED$
+attempt to destroy a locked mutex

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -551,15 +551,13 @@ int pthread_mutex_destroy_check(pthread_mutex_t *mutex)
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   __ESBMC_assert(
-    __ESBMC_mutex_lock_field(*mutex) != 0, "attempt to destroy a locked mutex");
-  // Attempting to destroy a locked mutex results in undefined behavior.
-  __ESBMC_assert(
-    __ESBMC_mutex_lock_field(*mutex) == 1, "attempt to destroy a locked mutex");
-  __ESBMC_assert(
     __ESBMC_mutex_lock_field(*mutex) != -1,
     "attempt to destroy a previously destroyed mutex");
+  // 0 = unlocked, 1 = locked, -1 = destroyed. Destroying a locked mutex is
+  // undefined behaviour; only an initialised, unlocked mutex may be destroyed.
+  __ESBMC_assert(
+    __ESBMC_mutex_lock_field(*mutex) == 0, "attempt to destroy a locked mutex");
 
-  // It shall be safe to destroy an initialized mutex that is unlocked
   __ESBMC_mutex_lock_field(*mutex) = -1;
   __ESBMC_atomic_end();
   return 0;


### PR DESCRIPTION
The lock field encodes 0 = unlocked, 1 = locked, -1 = destroyed, but
`pthread_mutex_destroy_check` asserted `field != 0` and `field == 1`, so
destroying an unlocked mutex (legal) was reported as UB while destroying a
locked one (UB) passed silently. Replace both with a single `field == 0` and
order it after the double-destroy check so the more specific message wins.

Three regression tests under `regression/esbmc-unix/` cover the legal, locked
and double-destroy cases; all three fail on the unpatched binary.

Fixes #6476