### PR TITLE
[om] Declare std::allocate_shared in the <memory> operational model

### DIFF
--- a/regression/esbmc-cpp11/cpp/allocate_shared_allocator_calls/main.cpp
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_allocator_calls/main.cpp
@@ -1,0 +1,55 @@
+// github #6488, KNOWNBUG: pins the one thing the allocate_shared model gets
+// wrong. [util.smartptr.shared.create] requires the object's storage to come
+// from the supplied allocator, so g_allocs is 1 here -- g++ builds this and it
+// exits 0. ESBMC's <memory> routes allocate_shared through `new` instead
+// (shared_ptr releases with `delete`, so allocator-supplied malloc'd storage
+// would report a deallocation-operator mismatch), so allocate() is never
+// called, g_allocs stays 0, and ESBMC reports FAILED.
+//
+// This is the unsound direction: the same gap lets ESBMC *prove*
+// `g_allocs == 0`, a property false of every conforming implementation. Flip
+// this test to CORE when allocators are modelled for real.
+#include <memory>
+#include <cassert>
+#include <cstdlib>
+
+static int g_allocs = 0;
+
+template <typename T>
+struct CountingAlloc
+{
+  typedef T value_type;
+  CountingAlloc()
+  {
+  }
+  template <typename U>
+  CountingAlloc(const CountingAlloc<U> &)
+  {
+  }
+  T *allocate(size_t n)
+  {
+    ++g_allocs;
+    return (T *)malloc(n * sizeof(T));
+  }
+  void deallocate(T *p, size_t)
+  {
+    free(p);
+  }
+};
+
+struct S
+{
+  int x;
+  S(int v) : x(v)
+  {
+  }
+};
+
+int main()
+{
+  CountingAlloc<S> a;
+  std::shared_ptr<S> p = std::allocate_shared<S, CountingAlloc<S>>(a, 7);
+  assert(p->x == 7);
+  assert(g_allocs == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/allocate_shared_allocator_calls/test.desc
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_allocator_calls/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/allocate_shared_basic/main.cpp
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_basic/main.cpp
@@ -1,0 +1,38 @@
+// github #6488: allocate_shared forwards its arguments to T's constructor and
+// hands the result to the same reference-counted shared_ptr make_shared uses,
+// so the object is released when the last owner dies. The allocator argument
+// is accepted but not modelled.
+#include <memory>
+#include <cassert>
+
+struct S
+{
+  int x;
+  int y;
+  S(int a, int b) : x(a), y(b)
+  {
+  }
+};
+
+int main()
+{
+  std::allocator<S> alloc;
+
+  std::shared_ptr<S> p = std::allocate_shared<S, std::allocator<S>>(alloc, 3, 4);
+  assert(p->x == 3);
+  assert(p->y == 4);
+  assert(p.use_count() == 1);
+
+  {
+    std::shared_ptr<S> q = p;
+    assert(q.use_count() == 2);
+    assert(q.get() == p.get());
+  }
+  assert(p.use_count() == 1); // the copy released its share
+
+  std::shared_ptr<int> n =
+    std::allocate_shared<int, std::allocator<int>>(std::allocator<int>());
+  assert(*n == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/allocate_shared_basic/main.cpp
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_basic/main.cpp
@@ -1,9 +1,10 @@
 // github #6488: allocate_shared forwards its arguments to T's constructor and
 // hands the result to the same reference-counted shared_ptr make_shared uses,
 // so the object is released when the last owner dies. The allocator argument
-// is accepted but not modelled.
+// is accepted but not modelled -- see allocate_shared_allocator_calls.
 #include <memory>
 #include <cassert>
+#include <cstdlib>
 
 struct S
 {
@@ -11,6 +12,29 @@ struct S
   int y;
   S(int a, int b) : x(a), y(b)
   {
+  }
+};
+
+// The reason allocate_shared exists: a user-defined allocator, which is what
+// real callers pass, with A deduced rather than spelled out.
+template <typename T>
+struct MyAlloc
+{
+  typedef T value_type;
+  MyAlloc()
+  {
+  }
+  template <typename U>
+  MyAlloc(const MyAlloc<U> &)
+  {
+  }
+  T *allocate(size_t n)
+  {
+    return (T *)malloc(n * sizeof(T));
+  }
+  void deallocate(T *p, size_t)
+  {
+    free(p);
   }
 };
 
@@ -29,6 +53,11 @@ int main()
     assert(q.get() == p.get());
   }
   assert(p.use_count() == 1); // the copy released its share
+
+  std::shared_ptr<S> d = std::allocate_shared<S>(MyAlloc<S>(), 5, 6);
+  assert(d->x == 5);
+  assert(d->y == 6);
+  assert(d.use_count() == 1);
 
   std::shared_ptr<int> n =
     std::allocate_shared<int, std::allocator<int>>(std::allocator<int>());

--- a/regression/esbmc-cpp11/cpp/allocate_shared_basic/test.desc
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/allocate_shared_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_fail/main.cpp
@@ -1,0 +1,21 @@
+// github #6488: the negative side of allocate_shared_basic -- the constructor
+// arguments really are forwarded, so a claim about the wrong value is refuted
+// rather than vacuously proved.
+#include <memory>
+#include <cassert>
+
+struct S
+{
+  int x;
+  S(int v) : x(v)
+  {
+  }
+};
+
+int main()
+{
+  std::shared_ptr<S> p =
+    std::allocate_shared<S, std::allocator<S>>(std::allocator<S>(), 3);
+  assert(p->x == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/allocate_shared_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/allocate_shared_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_fail/test.desc
@@ -2,3 +2,4 @@ CORE
 main.cpp
 --std c++11
 ^VERIFICATION FAILED$
+assertion p->x == 4

--- a/regression/esbmc-cpp11/cpp/allocate_shared_uninstantiated/main.cpp
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_uninstantiated/main.cpp
@@ -1,0 +1,16 @@
+// github #6488: <memory> declared make_shared but not allocate_shared, so
+// merely *naming* it made clang parse the `<` as less-than and reject the
+// translation unit -- even from a function template that is never
+// instantiated, which no harness can work around.
+#include <memory>
+
+template <typename T>
+std::shared_ptr<T> MakeShared(const std::allocator<T> &alloc)
+{
+  return std::allocate_shared<T, std::allocator<T>>(alloc);
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/allocate_shared_uninstantiated/test.desc
+++ b/regression/esbmc-cpp11/cpp/allocate_shared_uninstantiated/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -867,6 +867,18 @@ shared_ptr<T> make_shared(Args &&...args)
 {
   return shared_ptr<T>(new T(std::forward<Args>(args)...));
 }
+
+/* The allocator is deliberately not modelled: storage comes from the same
+ * `new` make_shared uses, because shared_ptr's release path is `delete __p`.
+ * So a custom allocator's allocate/deallocate/construct are never called, and
+ * this model cannot answer questions *about* an allocator -- only about code
+ * that happens to use one (github #6488). The array forms added in C++20 are
+ * not declared. */
+template <class T, class A, class... Args>
+shared_ptr<T> allocate_shared(const A &, Args &&...args)
+{
+  return make_shared<T>(std::forward<Args>(args)...);
+}
 #endif
 
 #if 0

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -868,13 +868,19 @@ shared_ptr<T> make_shared(Args &&...args)
   return shared_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-/* The allocator is deliberately not modelled: storage comes from the same
- * `new` make_shared uses, because shared_ptr's release path is `delete __p`.
- * So a custom allocator's allocate/deallocate/construct are never called, and
- * this model cannot answer questions *about* an allocator -- only about code
- * that happens to use one (github #6488). The array forms added in C++20 are
- * not declared. */
-template <class T, class A, class... Args>
+/* The allocator is deliberately not modelled, and the two halves cannot be
+ * coupled as they stand: allocator::allocate hands out malloc'd storage while
+ * shared_ptr releases with `delete __p`, so routing through the allocator
+ * makes every use report "Mismatched memory deallocation operators". Storage
+ * therefore comes from the same `new` make_shared uses, a custom allocator's
+ * allocate/deallocate/construct are never called, and this model cannot
+ * answer questions *about* an allocator -- only about code that happens to
+ * use one. allocate_shared_allocator_calls pins that divergence (github
+ * #6488). The array forms added in C++20 are not declared.
+ * `typename A::value_type` ([allocator.requirements]) stops A deducing to a
+ * constructor argument when the allocator is omitted altogether, which would
+ * otherwise silently swallow it. */
+template <class T, class A, class... Args, class = typename A::value_type>
 shared_ptr<T> allocate_shared(const A &, Args &&...args)
 {
   return make_shared<T>(std::forward<Args>(args)...);


### PR DESCRIPTION
Fixes #6488.

## Root cause

`src/cpp/library/memory` gained a real reference-counted `shared_ptr`/`weak_ptr`/`make_shared` in #6403, but never declared `std::allocate_shared`.

The interesting part is *how* the absence fails. With no declaration in scope, `std::allocate_shared` is not a template-name, so clang parses the `<` as less-than and the template argument as a value expression. That yields two diagnostics:

```
error: no member named 'allocate_shared' in namespace 'std'
error: 'T' does not refer to a value
```

The second one fires while **parsing the template definition**, before any instantiation. So a function template that merely *names* `allocate_shared` and is never instantiated is enough to take out the whole translation unit. That is the difference between this and an ordinary missing-member gap: a missing member that is only ever *called* fails at the call site, which a harness can route around; this one fails on inclusion, which nothing can avoid short of a shim.

Where it bites in practice: `aws-cpp-sdk-core`'s `Aws::MakeShared` (`AWSAllocator.h`) is such a template. Merely including the header stopped the run, so Base64/hex codec verification could not start.

## Solution

Declare and define `allocate_shared` next to `make_shared`, with the signature from **[util.smartptr.shared.create] (20.4.2.2.7)**:

```cpp
template <class T, class A, class... Args>
shared_ptr<T> allocate_shared(const A &, Args &&...args)
{
  return make_shared<T>(std::forward<Args>(args)...);
}
```

This is option (2) from the issue. Rationale for choosing it over option (3) (allocator-aware allocation): the OM's `shared_ptr::__release()` releases with `delete __p`, so the storage a `shared_ptr` owns **must** come from `new`. Routing `allocate_shared` through `alloc.allocate()` — which is `malloc` in the OM's `std::allocator` — would pair a `malloc` with a `delete`. Modelling the allocator properly therefore requires giving `shared_ptr` a deleter first, which is a much larger change with real regression risk, and is not needed to unblock the reported case.

### Documented limitation

The allocator argument is accepted and ignored, and the code says so:

> The allocator is deliberately not modelled: storage comes from the same `new` make_shared uses, because shared_ptr's release path is `delete __p`. So a custom allocator's allocate/deallocate/construct are never called, and this model cannot answer questions *about* an allocator — only about code that happens to use one.

This model is sound for code that merely *uses* an allocator; it cannot be used to verify a claim about an allocator's own behaviour (e.g. counting `allocate` calls). The array forms added in C++20 (`allocate_shared<T[]>`, `allocate_shared_for_overwrite`) are likewise not declared — a follow-up if anything needs them.

## Regression tests

Three new tests under `regression/esbmc-cpp11/cpp/`, following the naming of the existing `shared_ptr_*` / `unique_ptr_*` family:

| Test | Flags | Expected | What it pins |
|---|---|---|---|
| `allocate_shared_uninstantiated` | `--std c++11` | `SUCCESSFUL` | The issue's exact reproducer: a never-instantiated function template naming `allocate_shared` no longer fails the parse. |
| `allocate_shared_basic` | `--std c++11 --memory-leak-check` | `SUCCESSFUL` | Constructor arguments are forwarded, `use_count` transfers to and from a copy, and the object is released when the last owner dies. |
| `allocate_shared_fail` | `--std c++11` | `FAILED` | The negative side: a wrong claim about a forwarded constructor argument is refuted, not vacuously proved. |

The passing tests were checked for vacuity rather than assumed:

- Mutating `assert(p.use_count() == 1)` to `== 2` flips `allocate_shared_basic` to `VERIFICATION FAILED`, so the ownership assertions are live.
- A raw leaking `new` under the same `--std c++11 --memory-leak-check` reports `VERIFICATION FAILED`, so the leak check is active in this configuration and the `SUCCESSFUL` verdict genuinely pins release.

## Test suites

Run against this branch:

| Suite | Result |
|---|---|
| `esbmc-cpp11/cpp` | **60/60 pass** (including the 3 new tests) |
| `esbmc-cpp/OM_sanity_checks` + `esbmc-cpp/template` + `esbmc-cpp11/template` + `esbmc-cpp11/new-delete` | **97/97 pass** |
| `esbmc-cpp/cpp` | **664/665 pass** |

The one `esbmc-cpp/cpp` failure is `ch13_10`, which passes on its own (103.4 s against the harness's hard 120 s cap) and fails only under `-j4` load. It is the known timeout artifact, it does not include `<memory>`, and it is unrelated to this change.

## Follow-up (not in this PR)

The same parse-level failure mode still applies to other names absent from `src/cpp/library/memory`: `static_pointer_cast`, `dynamic_pointer_cast`, `const_pointer_cast`, `enable_shared_from_this`, `owner_less`, and the `uninitialized_*` family. Confirmed for `static_pointer_cast` — an uninstantiated template naming it produces the identical `'T' does not refer to a value` parse error. Kept out of this PR to stay one-issue-per-PR.

---

## Update — review follow-up (commit 2)

Two findings from a review pass on the first commit, both verified with runnable probes before acting on them.

**1. `A` was unconstrained, so the model accepted a program g++ rejects.** With `A` deduced from any first argument, `std::allocate_shared<S>(3, 4, 5)` deduced `A = int`, silently swallowed the first constructor argument, and reported `VERIFICATION SUCCESSFUL`; `g++ -std=c++17` rejects the same line. Requiring `typename A::value_type` — which [allocator.requirements] demands of every conforming allocator — makes the model reject it too (`error: no matching function for call to 'allocate_shared'`), without rejecting anything legal.

**2. The unmodelled allocator is unsound in the false-negative direction, and only a comment was tracking it.** A counting allocator makes this concrete:

```cpp
static int g_allocs = 0;   // CountingAlloc<T>::allocate does ++g_allocs
std::shared_ptr<S> p = std::allocate_shared<S, CountingAlloc<S>>(a, 7);
assert(g_allocs == 1);     // g++ builds this and it exits 0
```

[util.smartptr.shared.create] requires the storage to come from the supplied allocator, so `g_allocs == 1`. ESBMC reports `FAILED`; worse, the mirror-image assertion `g_allocs == 0` — false of every conforming implementation — is *proved*. That is a real gap, not merely a documented simplification, so it is now machine-tracked by a fourth test, `allocate_shared_allocator_calls` (`KNOWNBUG`, expecting `SUCCESSFUL`), which flips to `CORE` the day allocators are modelled for real. The header comment now also records *why* the halves cannot simply be coupled: `allocator::allocate` hands out `malloc`'d storage while `shared_ptr` releases with `delete __p`, so routing through the allocator reports `Mismatched memory deallocation operators` on every use.

`allocate_shared_basic` additionally now covers the spelling real callers use — a user-defined allocator with `A` deduced, `std::allocate_shared<S>(MyAlloc<S>(), 5, 6)` — which nothing pinned before.

Re-run after these changes: `esbmc-cpp11/cpp` **61/61 pass**, `esbmc-cpp/OM_sanity_checks` + `esbmc-cpp11/new-delete` + `esbmc-cpp11/template` **68/68 pass**.
