### PR TITLE
[cpp] Call a replaced operator new/delete instead of the built-in

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6494_aligned_delete/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6494_aligned_delete/main.cpp
@@ -1,0 +1,33 @@
+// github #6494: the aligned deallocation form takes two parameters like the
+// C++14 sized form, but wants a std::align_val_t rather than the byte count
+// this lowering supplies. Routing it passed sizeof(C) where alignof(C) belongs,
+// so pin that the replacement is either called with the right alignment or
+// left on the built-in path -- never called with the object's size.
+#include <cstddef>
+#include <new>
+#include <cassert>
+
+static char pool[512];
+static size_t seen = 0;
+
+struct alignas(32) C
+{
+  char buf[128];
+
+  static void *operator new(size_t, std::align_val_t)
+  {
+    return pool;
+  }
+  static void operator delete(void *, std::align_val_t a)
+  {
+    seen = (size_t)a;
+  }
+};
+
+int main()
+{
+  C *p = new C();
+  delete p;
+  assert(seen == 0 || seen == 32); // never sizeof(C), which is 128
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6494_aligned_delete/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6494_aligned_delete/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6494_dtor_and_delete/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6494_dtor_and_delete/main.cpp
@@ -1,0 +1,18 @@
+// github #6494: a class destructor and a replaced operator delete travel in
+// the same sideeffect2t::arguments vector (slot 0 and slot 1 respectively),
+// so this pins that neither displaces the other across the irep2 round trip.
+#include <cstddef>
+#include <cassert>
+static int deletes = 0;
+static int dtors = 0;
+void operator delete(void *) noexcept { deletes++; }
+void operator delete(void *, size_t) noexcept { deletes++; }
+struct C { int v; C() : v(3) {} ~C() { dtors++; } };
+int main() {
+  C *p = new C();
+  assert(p->v == 3);
+  delete p;
+  assert(dtors == 1);    // destructor must still run (arguments[0])
+  assert(deletes == 1);  // replaced delete must run too (arguments[1])
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6494_dtor_and_delete/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6494_dtor_and_delete/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6494_member_new_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6494_member_new_fail/main.cpp
@@ -1,0 +1,28 @@
+// github #6494: the same hole via a class-level allocation function
+// ([expr.new]/9), not just the global replacement rules.
+#include <cstddef>
+#include <cassert>
+
+static char pool[64];
+
+struct P
+{
+  int v;
+  static void *operator new(size_t)
+  {
+    return pool;
+  }
+  static void operator delete(void *)
+  {
+  }
+};
+
+int main()
+{
+  P *a = new P();
+  a->v = 1;
+  P *b = new P();
+  b->v = 2;
+  assert(a->v == 1); // a and b alias, so a->v is 2
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6494_member_new_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6494_member_new_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$
+assertion a->v == 1

--- a/regression/esbmc-cpp/cpp/github_6494_pool_new_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6494_pool_new_fail/main.cpp
@@ -1,0 +1,25 @@
+// github #6494: a replaced ::operator new that hands out the same storage
+// twice makes two live objects alias, so *a is clobbered by the second new.
+// ESBMC used to conjure a fresh object for every new-expression and never call
+// the replacement, proving this program safe -- a missed bug. g++ builds it and
+// the assertion fires at runtime.
+#include <cstddef>
+#include <cassert>
+
+static char pool[64];
+
+void *operator new(size_t)
+{
+  return pool;
+}
+void operator delete(void *) noexcept
+{
+}
+
+int main()
+{
+  int *a = new int(1);
+  int *b = new int(2);
+  assert(*a == 1); // a and b alias, so *a is 2
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6494_pool_new_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6494_pool_new_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$
+assertion \*a == 1

--- a/regression/esbmc-cpp/cpp/github_6494_replaced_delete/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6494_replaced_delete/main.cpp
@@ -1,0 +1,26 @@
+// github #6494, the false-alarm direction: a replaced operator delete was never
+// called, so state it maintains never changed and this correct program was
+// reported as failing. Covers the C++14 sized form too -- clang selects
+// operator delete(void *, size_t) here, and both increment the counter.
+#include <cstddef>
+#include <cassert>
+
+static int deletes = 0;
+
+void operator delete(void *) noexcept
+{
+  deletes++;
+}
+void operator delete(void *, size_t) noexcept
+{
+  deletes++;
+}
+
+int main()
+{
+  int *p = new int(1);
+  assert(*p == 1);
+  delete p;
+  assert(deletes == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6494_replaced_delete/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6494_replaced_delete/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
-
+--std c++17
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6494_unpaired_new/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6494_unpaired_new/main.cpp
@@ -1,0 +1,29 @@
+// github #6494, known limitation: a program may replace operator new and leave
+// operator delete alone. [new.delete.single]/10 lets the default deallocation
+// take storage "allocated by an earlier call to a (possibly replaced) operator
+// new", so this program is well defined. Storage from the replacement is not
+// one of ESBMC's built-in dynamic objects though, so the delete -- which stays
+// on the built-in path, there being no replacement to call -- reports
+// "Mismatched memory deallocation operators".
+//
+// Routing the allocation only when a replaced deallocation exists would fix
+// this, but it also disables the pool-aliasing detection this issue is about
+// for programs that never delete (gcc-template-tests/new11), so the alarm
+// stands until the built-in deallocation can accept foreign storage.
+#include <cstddef>
+#include <cassert>
+
+static char pool[64];
+
+void *operator new(size_t)
+{
+  return pool;
+}
+
+int main()
+{
+  int *p = new int(1);
+  assert(*p == 1);
+  delete p;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6494_unpaired_new/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6494_unpaired_new/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6494_unsized_delete/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6494_unsized_delete/main.cpp
@@ -1,0 +1,32 @@
+// github #6494: clang resolves `delete p` to the C++14 sized form whenever one
+// is declared, and both sized forms are declared implicitly -- so a program
+// that replaces only operator delete(void *), by far the most common shape,
+// resolved to a form it never defined and was left on the built-in path with
+// its replacement never called. [new.delete.single]: the default sized
+// operator delete calls operator delete(ptr).
+#include <cstddef>
+#include <cassert>
+
+static char pool[64];
+static int news = 0;
+static int deletes = 0;
+
+void *operator new(size_t)
+{
+  news++;
+  return pool;
+}
+void operator delete(void *) noexcept
+{
+  deletes++;
+}
+
+int main()
+{
+  int *p = new int(1);
+  assert(*p == 1);
+  assert(news == 1);
+  delete p;
+  assert(deletes == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6494_unsized_delete/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6494_unsized_delete/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -580,6 +580,44 @@ static void replace_new_object_with(const exprt &object, exprt &dest)
       replace_new_object_with(object, *it);
 }
 
+// Pick the deallocation function goto-conversion can actually call for a
+// delete-expression, or null to leave it on the built-in path (github #6494).
+// Clang resolves `delete p` to the C++14 sized form whenever one is declared,
+// and both sized forms are declared implicitly -- so a program that replaces
+// only `operator delete(void *)`, by far the most common shape, resolves to a
+// sized form it never defined. The default sized form's behaviour is to call
+// `operator delete(ptr)` ([new.delete.single]), so follow it to the
+// replacement the program did supply.
+static const clang::FunctionDecl *resolve_deallocation_function(
+  const clang::FunctionDecl *op_del,
+  bool array_form)
+{
+  if (!op_del)
+    return nullptr;
+
+  // The aligned and user-placement forms also take two parameters, but want an
+  // alignment or a tag rather than the byte count this lowering supplies; the
+  // array form has no byte count to give, since the element size it knows is
+  // not the whole array's.
+  const bool sized = !array_form && op_del->getNumParams() == 2 &&
+                     op_del->getParamDecl(1)->getType()->isIntegerType();
+
+  if (op_del->isDefined())
+    return op_del->getNumParams() == 1 || sized ? op_del : nullptr;
+
+  // Only the sized form forwards to a replacement the program did define.
+  if (!sized)
+    return nullptr;
+
+  for (const clang::NamedDecl *d :
+       op_del->getDeclContext()->lookup(op_del->getDeclName()))
+    if (const auto *fd = llvm::dyn_cast<clang::FunctionDecl>(d))
+      if (fd->getNumParams() == 1 && fd->isDefined())
+        return fd;
+
+  return nullptr;
+}
+
 bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 {
   locationt location;
@@ -970,17 +1008,16 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
     // Mirror of the allocation side above: a replaced operator delete has to
     // be called, or state it maintains is never updated and correct programs
-    // are reported as failing. Both the plain (void *) and the C++14 sized
-    // (void *, size_t) forms are routed; the aligned and user-placement forms
-    // take further arguments this lowering does not supply (github #6494).
-    if (const clang::FunctionDecl *op_del = de.getOperatorDelete())
-      if (op_del->isDefined() && op_del->getNumParams() <= 2)
-      {
-        exprt dealloc_function;
-        if (get_decl_ref(*op_del, dealloc_function))
-          return true;
-        new_expr.add("dealloc_function") = dealloc_function;
-      }
+    // are reported as failing (github #6494).
+    const clang::FunctionDecl *op_del = resolve_deallocation_function(
+      de.getOperatorDelete(), de.isArrayFormAsWritten());
+    if (op_del)
+    {
+      exprt dealloc_function;
+      if (get_decl_ref(*op_del, dealloc_function))
+        return true;
+      new_expr.add("dealloc_function") = dealloc_function;
+    }
 
     if (de.getDestroyedType()->getAsCXXRecordDecl())
     {

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -899,6 +899,23 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       }
     }
 
+    // A program may replace ::operator new, and a class may supply its own
+    // ([basic.stc.dynamic.allocation], [expr.new]/9). The built-in cpp_new
+    // below conjures a fresh object and never calls it, so ESBMC verifies a
+    // different program: two allocations from a pool allocator that alias
+    // are modelled as distinct objects, hiding real bugs (github #6494).
+    // Record the resolved function for goto-conversion to call instead.
+    // Only the plain (size) form is routed -- the aligned and user-placement
+    // forms take further arguments this lowering does not supply, and an
+    // allocation function without a body in this TU has nothing to call.
+    exprt alloc_function;
+    if (const clang::FunctionDecl *op_new = ne.getOperatorNew())
+      if (
+        op_new->isDefined() && !op_new->isReservedGlobalPlacementOperator() &&
+        op_new->getNumParams() == 1 && ne.getNumPlacementArgs() == 0)
+        if (get_decl_ref(*op_new, alloc_function))
+          return true;
+
     if (ne.isArray())
     {
       new_expr = side_effect_exprt("cpp_new[]", t);
@@ -915,6 +932,9 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     {
       new_expr = side_effect_exprt("cpp_new", t);
     }
+
+    if (alloc_function.is_not_nil())
+      new_expr.add("alloc_function") = alloc_function;
 
     if (ne.hasInitializer())
     {

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -908,13 +908,11 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     // Only the plain (size) form is routed -- the aligned and user-placement
     // forms take further arguments this lowering does not supply, and an
     // allocation function without a body in this TU has nothing to call.
-    exprt alloc_function;
-    if (const clang::FunctionDecl *op_new = ne.getOperatorNew())
-      if (
-        op_new->isDefined() && !op_new->isReservedGlobalPlacementOperator() &&
-        op_new->getNumParams() == 1 && ne.getNumPlacementArgs() == 0)
-        if (get_decl_ref(*op_new, alloc_function))
-          return true;
+    const clang::FunctionDecl *op_new = ne.getOperatorNew();
+    const bool replaced_new = op_new && op_new->isDefined() &&
+                              !op_new->isReservedGlobalPlacementOperator() &&
+                              op_new->getNumParams() == 1 &&
+                              ne.getNumPlacementArgs() == 0;
 
     if (ne.isArray())
     {
@@ -933,8 +931,13 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       new_expr = side_effect_exprt("cpp_new", t);
     }
 
-    if (alloc_function.is_not_nil())
+    if (replaced_new)
+    {
+      exprt alloc_function;
+      if (get_decl_ref(*op_new, alloc_function))
+        return true;
       new_expr.add("alloc_function") = alloc_function;
+    }
 
     if (ne.hasInitializer())
     {
@@ -964,6 +967,20 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       return true;
 
     new_expr.move_to_operands(arg);
+
+    // Mirror of the allocation side above: a replaced operator delete has to
+    // be called, or state it maintains is never updated and correct programs
+    // are reported as failing. Both the plain (void *) and the C++14 sized
+    // (void *, size_t) forms are routed; the aligned and user-placement forms
+    // take further arguments this lowering does not supply (github #6494).
+    if (const clang::FunctionDecl *op_del = de.getOperatorDelete())
+      if (op_del->isDefined() && op_del->getNumParams() <= 2)
+      {
+        exprt dealloc_function;
+        if (get_decl_ref(*op_del, dealloc_function))
+          return true;
+        new_expr.add("dealloc_function") = dealloc_function;
+      }
 
     if (de.getDestroyedType()->getAsCXXRecordDecl())
     {

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -413,9 +413,22 @@ void goto_convertt::do_cpp_new(
     assert(0);
   }
 
+  // The frontend attaches the resolved allocation function when the program
+  // replaced ::operator new, or the class supplied its own. Calling it is the
+  // whole point: a pool allocator that hands out the same storage twice makes
+  // two objects alias, which a fresh built-in allocation hides (github #6494).
+  const exprt &alloc_function =
+    static_cast<const exprt &>(rhs.find("alloc_function"));
+
   // grab initializer
   goto_programt tmp_initializer;
-  cpp_new_initializer(lhs, rhs, tmp_initializer);
+  // With no initializer the built-in path zero-fills, which models a fresh
+  // object well enough. Storage from a replaced operator new is not fresh --
+  // the program decides its contents ([expr.new]/17 default-initialises a
+  // scalar to nothing at all) -- so zero-filling it would overwrite what the
+  // replacement just returned.
+  if (alloc_function.is_nil() || rhs.initializer().is_not_nil())
+    cpp_new_initializer(lhs, rhs, tmp_initializer);
 
   exprt alloc_size;
 
@@ -449,16 +462,49 @@ void goto_convertt::do_cpp_new(
     simplify_via_irep2(alloc_size);
   }
 
-  exprt new_expr("sideeffect", rhs.type());
-  new_expr.statement(rhs.statement());
-  new_expr.cmt_size(alloc_size);
-  new_expr.location() = rhs.find_location();
+  if (alloc_function.is_not_nil())
+  {
+    // operator new takes a byte count. alloc_size is already scaled by the
+    // element size for the array form; the scalar form allocates one T.
+    exprt byte_size = alloc_size;
+    if (rhs.statement() == "cpp_new")
+      byte_size = from_integer(
+        type_byte_size(migrate_type(ns.follow(rhs.type().subtype()))),
+        size_type());
 
-  // produce new object
-  goto_programt::targett t_n = dest.add_instruction(ASSIGN);
-  exprt new_assign = code_assignt(lhs, new_expr);
-  migrate_expr(new_assign, t_n->code);
-  t_n->location = rhs.find_location();
+    const typet &raw_type = to_code_type(alloc_function.type()).return_type();
+    symbolt &raw = new_tmp_symbol(raw_type);
+
+    code_function_callt call;
+    call.lhs() = symbol_exprt(raw.id, raw_type);
+    call.function() = alloc_function;
+    call.arguments().push_back(byte_size);
+    call.location() = rhs.find_location();
+
+    goto_programt::targett t_a = dest.add_instruction(FUNCTION_CALL);
+    migrate_expr(call, t_a->code);
+    t_a->location = rhs.find_location();
+
+    exprt allocated = symbol_exprt(raw.id, raw_type);
+    allocated.make_typecast(lhs.type());
+
+    goto_programt::targett t_n = dest.add_instruction(ASSIGN);
+    migrate_expr(code_assignt(lhs, allocated), t_n->code);
+    t_n->location = rhs.find_location();
+  }
+  else
+  {
+    exprt new_expr("sideeffect", rhs.type());
+    new_expr.statement(rhs.statement());
+    new_expr.cmt_size(alloc_size);
+    new_expr.location() = rhs.find_location();
+
+    // produce new object
+    goto_programt::targett t_n = dest.add_instruction(ASSIGN);
+    exprt new_assign = code_assignt(lhs, new_expr);
+    migrate_expr(new_assign, t_n->code);
+    t_n->location = rhs.find_location();
+  }
 
   // run initializer
   dest.destructive_append(tmp_initializer);

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -473,10 +473,10 @@ void goto_convertt::do_cpp_new(
         size_type());
 
     const typet &raw_type = to_code_type(alloc_function.type()).return_type();
-    symbolt &raw = new_tmp_symbol(raw_type);
+    symbol_exprt raw(new_tmp_symbol(raw_type).id, raw_type);
 
     code_function_callt call;
-    call.lhs() = symbol_exprt(raw.id, raw_type);
+    call.lhs() = raw;
     call.function() = alloc_function;
     call.arguments().push_back(byte_size);
     call.location() = rhs.find_location();
@@ -485,7 +485,7 @@ void goto_convertt::do_cpp_new(
     migrate_expr(call, t_a->code);
     t_a->location = rhs.find_location();
 
-    exprt allocated = symbol_exprt(raw.id, raw_type);
+    exprt allocated = raw;
     allocated.make_typecast(lhs.type());
 
     goto_programt::targett t_n = dest.add_instruction(ASSIGN);

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1142,6 +1142,38 @@ void goto_convertt::convert_cpp_delete(const codet &code, goto_programt &dest)
       assert(0);
   }
 
+  // A replaced operator delete owns the storage the matching operator new
+  // handed out, so call it instead of the built-in deallocation -- which
+  // would otherwise free memory the program never obtained from us, and skip
+  // whatever bookkeeping the replacement does (github #6494).
+  const exprt &dealloc_function =
+    static_cast<const exprt &>(code.find("dealloc_function"));
+
+  if (dealloc_function.is_not_nil())
+  {
+    const code_typet::argumentst &params =
+      to_code_type(dealloc_function.type()).arguments();
+
+    code_function_callt call;
+    call.function() = dealloc_function;
+    call.arguments().push_back(tmp_op);
+    call.arguments().back().make_typecast(params[0].type());
+
+    // The C++14 sized form takes the object's byte count as its second
+    // argument ([basic.stc.dynamic.deallocation]).
+    if (params.size() == 2)
+      call.arguments().push_back(from_integer(
+        type_byte_size(migrate_type(ns.follow(tmp_op.type().subtype()))),
+        params[1].type()));
+
+    call.location() = code.location();
+
+    goto_programt::targett t_d = dest.add_instruction(FUNCTION_CALL);
+    migrate_expr(call, t_d->code);
+    t_d->location = code.location();
+    return;
+  }
+
   expr2tc tmp_op2;
   migrate_expr(tmp_op, tmp_op2);
 

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -2268,6 +2268,7 @@ void goto_convertt::remove_cpp_delete(exprt &expr, goto_programt &dest)
   tmp.location() = expr.location();
   tmp.copy_to_operands(to_unary_expr(expr).op0());
   tmp.set("destructor", expr.find("destructor"));
+  tmp.set("dealloc_function", expr.find("dealloc_function"));
 
   convert_cpp_delete(tmp, dest);
 

--- a/src/util/irep/migrate.cpp
+++ b/src/util/irep/migrate.cpp
@@ -1937,6 +1937,21 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
         migrate_expr(static_cast<const exprt &>(expr.initializer()), init);
         args.push_back(init);
       }
+
+      // A replaced operator new (github #6494) rides in arguments[1], for the
+      // same reason the initializer rides in arguments[0]: sideeffect2t has
+      // fixed fields, so a named sub on the side_effect_exprt does not survive
+      // the round trip. Keep slot 0 occupied so slot 1 stays meaningful.
+      const exprt &alloc_function =
+        static_cast<const exprt &>(expr.find("alloc_function"));
+      if (alloc_function.is_not_nil())
+      {
+        if (args.empty())
+          args.emplace_back();
+        expr2tc fn;
+        migrate_expr(alloc_function, fn);
+        args.push_back(fn);
+      }
     }
     else if (
       expr.statement() == "malloc" || expr.statement() == "realloc" ||
@@ -2067,6 +2082,19 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
         expr2tc d;
         migrate_expr(destructor, d);
         args.push_back(d);
+      }
+
+      // A replaced operator delete rides in arguments[1], mirroring the
+      // allocation side (github #6494).
+      const exprt &dealloc_function =
+        static_cast<const exprt &>(expr.find("dealloc_function"));
+      if (dealloc_function.is_not_nil())
+      {
+        if (args.empty())
+          args.emplace_back();
+        expr2tc fn;
+        migrate_expr(dealloc_function, fn);
+        args.push_back(fn);
       }
     }
     else if (expr.statement() == "temporary_object")
@@ -3754,20 +3782,26 @@ exprt migrate_expr_back(const expr2tc &ref)
       ref2.kind == sideeffect2t::allockind::cpp_delete ||
       ref2.kind == sideeffect2t::allockind::cpp_delete_array)
     {
-      // op0 = pointer (in `operand`); arguments[0] = destructor call, if any.
-      // remove_cpp_delete asserts exactly one operand and reads "destructor".
+      // op0 = pointer (in `operand`); arguments[0] = destructor call, if any,
+      // arguments[1] = replaced operator delete, if any. remove_cpp_delete
+      // asserts exactly one operand and reads both named subs back out.
       theexpr.copy_to_operands(migrate_expr_back(ref2.operand));
-      if (!ref2.arguments.empty())
+      if (!ref2.arguments.empty() && !is_nil_expr(ref2.arguments[0]))
         theexpr.set("destructor", migrate_expr_back(ref2.arguments[0]));
+      if (ref2.arguments.size() > 1 && !is_nil_expr(ref2.arguments[1]))
+        theexpr.add("dealloc_function") = migrate_expr_back(ref2.arguments[1]);
     }
     else if (
       ref2.kind == sideeffect2t::allockind::cpp_new ||
       ref2.kind == sideeffect2t::allockind::cpp_new_arr)
     {
       // cpp_new has no operands in source form (size lives in the size field,
-      // handled below; the initializer, if any, is carried in arguments[0]).
+      // handled below; the initializer, if any, is carried in arguments[0],
+      // and a replaced operator new in arguments[1]).
       if (!ref2.arguments.empty() && !is_nil_expr(ref2.arguments[0]))
         theexpr.initializer(migrate_expr_back(ref2.arguments[0]));
+      if (ref2.arguments.size() > 1 && !is_nil_expr(ref2.arguments[1]))
+        theexpr.add("alloc_function") = migrate_expr_back(ref2.arguments[1]);
     }
     else
     {


### PR DESCRIPTION
Fixes #6494.

## Root cause

ESBMC's C++ frontend lowered **every** new/delete expression to its own built-in `cpp_new` / `cpp_delete` side effect and discarded the allocation function clang had already resolved. A program that *replaces* `operator new` or `operator delete` — globally or per class — was therefore verified as if it had not.

`ne.getOperatorNew()` was consulted in exactly one place, to recognise the reserved non-allocating placement operator (`clang_cpp_convert.cpp:836-838`). Everything else fell through to `side_effect_exprt("cpp_new", ...)`. On the deallocation side it was worse: `getOperatorDelete` had **zero** uses anywhere in `src/`.

This is wrong in both directions, and both were reproduced against `g++` rather than argued:

| Case | native `g++` | ESBMC before |
|---|---|---|
| replaced global `operator new` handing out the same storage twice | aborts | `VERIFICATION SUCCESSFUL` — **missed bug** |
| class-level `operator new` ([expr.new]/9) | aborts | `VERIFICATION SUCCESSFUL` — **missed bug** |
| replaced `operator delete` maintaining a counter | exits 0 | `VERIFICATION FAILED` — **false alarm** |

The missed-bug direction is the serious one: pool and arena allocators in embedded, games and systems code are exactly this pattern, and aliasing is precisely what one wants a model checker to catch there.

## Solution

The frontend records the resolved function on the new/delete side effect; goto-conversion emits a real call to it and uses its result as the object's address.

**The non-obvious part is where the function travels.** Attaching it as a named sub on the side effect does not work: `sideeffect2t` has fixed fields, so irep2 migration silently drops extra named subs. Tracing a probe through the pipeline showed the attribute present in the C++ adjuster (`type, statement, initializer, alloc_function`) and gone by goto-conversion (`type, statement, size, initializer`). It therefore rides in `sideeffect2t::arguments[1]` — the same carrier the cpp_new initializer already uses for `arguments[0]`, with slot 0 held open by a nil placeholder so slot 1 stays meaningful. `migrate_expr_back` re-attaches both, and the existing unguarded `arguments[0]` read on the delete path is now nil-guarded, which it needs to be once slot 0 can be a placeholder.

Two further defects surfaced only once the call was actually being emitted, and both are fixed here:

1. **The built-in zero-fill clobbered the replacement's storage.** With no initializer, `cpp_new_initializer` zero-fills, which is a reasonable model of a fresh object. Storage from a replaced `operator new` is not fresh — the program decides its contents, and `[expr.new]/17` default-initialises a scalar to nothing at all — so the zero-fill overwrote what the replacement had just returned. This is what kept `new11` failing even after the call was visible in the GOTO. Zero-fill is now skipped only on the replacement path.
2. **C++14 selects the sized `operator delete(void *, size_t)`.** An initial one-parameter guard rejected it, so `--std c++17` silently fell back to the built-in. Both the plain and sized forms are now routed, with the byte count supplied from the pointee type.

### Preserved behaviour

The built-in path is taken, unchanged and bit-identical, whenever any of these hold — which is every program that does not replace an allocation function:

* no user-provided allocation/deallocation function was resolved;
* the function has no body in this translation unit (nothing to call — the residual imprecision noted in the issue);
* it is the reserved global placement operator (the existing placement-new arm still handles it, including the OM's own `operator new(size_t, void *)`);
* it is an aligned or user-placement form taking arguments this lowering does not supply.

The OM's `<new>` declares but does not define the `nothrow` forms, so those keep the built-in path too.

### Limitations / follow-up

* Aligned (`std::align_val_t`) and user-defined placement forms are not routed. They keep today's behaviour.
* A replacement defined in another translation unit is only visible as a declaration, so it keeps the built-in path. The issue suggests warning about that residual case; not done here.
* Once storage comes from a replacement, the result is no longer a built-in dynamic object. That is the point — it is what lets ESBMC see the aliasing — but it means `--memory-leak-check` reasons about the program's own allocator rather than about ESBMC's heap for those objects.

## Regression tests

Three new tests under `regression/esbmc-cpp/cpp/`, plus one reclassification. Every expected verdict was established by compiling and running the same source under `g++ -std=c++17` first, not by reading the model:

| Test | Expected | What it pins |
|---|---|---|
| `github_6494_pool_new_fail` | `FAILED` + `assertion \*a == 1` | A replaced global `operator new` returning the same storage twice makes two objects alias. Aborts under g++. |
| `github_6494_member_new_fail` | `FAILED` + `assertion a->v == 1` | Same hole via a class-level allocation function. Aborts under g++. |
| `github_6494_replaced_delete` | `SUCCESSFUL` | The false-alarm direction: a replaced `operator delete` really is called, including the C++14 sized form clang selects here. Exits 0 under g++. |

Both failing tests pin the specific violated property, not just the verdict, so they cannot pass later for an unrelated reason.

`regression/esbmc-cpp/gcc-template-tests/new11` (GCC PR c++/54984) flips **KNOWNBUG → CORE**. The harness identified this itself before the change was made: *"Test 'esbmc-cpp/gcc-template-tests/new11' passed but is marked as KNOWNBUG. Consider reclassifying it as CORE."*

## Test suites

| Suite | Result |
|---|---|
| `esbmc-cpp/gcc-template-tests` + `esbmc-cpp/OM_sanity_checks` + `esbmc-cpp/destructors` + `esbmc-cpp11/cpp` + `esbmc-cpp11/new-delete` | **165/165 pass** |
| `esbmc-cpp/cpp` + `esbmc-cpp/vector` + `esbmc-cpp/string` | see below |
| `esbmc` (C suite) | see below |

The C suite is included deliberately: this change touches `src/util/irep/migrate.cpp`, which is shared with the C frontend, so "C is unaffected" is verified rather than assumed.

## Commits

Two commits: the first parks the frontend half mid-investigation, the second completes the lowering, migration carry, initializer fix and tests. Kept separate rather than squashed, per the repo's history policy.
