### PR TITLE
[om] Model pthread barriers and spinlocks

### DIFF
--- a/regression/esbmc-unix/github_6478-spinlock/main.c
+++ b/regression/esbmc-unix/github_6478-spinlock/main.c
@@ -1,0 +1,26 @@
+#include <pthread.h>
+#include <assert.h>
+pthread_spinlock_t sl;
+int shared = 0;
+
+void *t(void *p)
+{
+  pthread_spin_lock(&sl);
+  shared++;
+  pthread_spin_unlock(&sl);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a;
+  pthread_spin_init(&sl, 0);
+  pthread_create(&a, 0, t, 0);
+  pthread_spin_lock(&sl);
+  shared++;
+  pthread_spin_unlock(&sl);
+  pthread_join(a, 0);
+  assert(shared == 2);
+  pthread_spin_destroy(&sl);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6478-spinlock/test.desc
+++ b/regression/esbmc-unix/github_6478-spinlock/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4 --deadlock-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6478-spinlock_fail/main.c
+++ b/regression/esbmc-unix/github_6478-spinlock_fail/main.c
@@ -1,0 +1,10 @@
+/* Self-deadlock: a spinlock is not recursive. */
+#include <pthread.h>
+pthread_spinlock_t sl;
+int main(void)
+{
+  pthread_spin_init(&sl, 0);
+  pthread_spin_lock(&sl);
+  pthread_spin_lock(&sl);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6478-spinlock_fail/test.desc
+++ b/regression/esbmc-unix/github_6478-spinlock_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 4 --deadlock-check
+^VERIFICATION FAILED$
+Deadlocked state in pthread_spin_lock

--- a/regression/esbmc-unix/github_6478/main.c
+++ b/regression/esbmc-unix/github_6478/main.c
@@ -1,0 +1,23 @@
+/* The barrier orders the write in the worker before the read in main. */
+#include <pthread.h>
+#include <assert.h>
+pthread_barrier_t bar;
+int shared = 0;
+
+void *t(void *p)
+{
+  shared = 42;
+  pthread_barrier_wait(&bar);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a;
+  pthread_barrier_init(&bar, 0, 2);
+  pthread_create(&a, 0, t, 0);
+  pthread_barrier_wait(&bar);
+  assert(shared == 42);
+  pthread_join(a, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6478/test.desc
+++ b/regression/esbmc-unix/github_6478/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4 --deadlock-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6478_fail/main.c
+++ b/regression/esbmc-unix/github_6478_fail/main.c
@@ -1,0 +1,16 @@
+/* Barrier of 3, but only 2 threads ever arrive: a real deadlock. */
+#include <pthread.h>
+pthread_barrier_t bar;
+
+void *t(void *p) { pthread_barrier_wait(&bar); return 0; }
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_barrier_init(&bar, 0, 3);
+  pthread_create(&a, 0, t, 0);
+  pthread_create(&b, 0, t, 0);
+  pthread_join(a, 0);
+  pthread_join(b, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6478_fail/test.desc
+++ b/regression/esbmc-unix/github_6478_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 4 --deadlock-check
+^VERIFICATION FAILED$
+Deadlocked state in

--- a/src/c2goto/headers/pthread.h
+++ b/src/c2goto/headers/pthread.h
@@ -106,23 +106,33 @@ typedef union
 //#endif
 
 
-#ifdef __USE_XOPEN2K
-/* POSIX spinlock data type.  */
-typedef volatile int pthread_spinlock_t;
+/* Always exposed: ESBMC never defines __USE_XOPEN2K, so guarding these made
+   barriers and spinlocks unusable outright (#6478). */
+/* POSIX spinlock data type. Both fields are ESBMC bookkeeping: __lock holds
+   the state and __waiters the blocked-thread count, as for pthread_mutex_t. */
+typedef struct
+{
+  int __lock;
+  unsigned int __waiters;
+} pthread_spinlock_t;
 
 
 /* POSIX barriers data type.  The structure of the type is
    deliberately not exposed.  */
-typedef union
+typedef struct
 {
-  long int __align;
+  unsigned int __count;
+  unsigned int __arrived;
+  /* Bumped every time the barrier opens, so a waiter can tell that the
+     round it arrived in has completed. */
+  unsigned int __generation;
+  unsigned int __waiters;
 } pthread_barrier_t;
 
 typedef union
 {
   int __align;
 } pthread_barrierattr_t;
-#endif
 
 struct sched_param
 {
@@ -256,12 +266,10 @@ enum
 #define PTHREAD_ONCE_INIT 0
 
 
-#ifdef __USE_XOPEN2K
 /* Value returned by 'pthread_barrier_wait' for one of the threads after
    the required number of threads have called this function.
    -1 is distinct from 0 and all errno constants */
-# define PTHREAD_BARRIER_SERIAL_THREAD -1
-#endif
+#define PTHREAD_BARRIER_SERIAL_THREAD -1
 
 
 /* Create a new thread, starting with execution of START-ROUTINE
@@ -701,7 +709,7 @@ extern int pthread_condattr_setclock (pthread_condattr_t *__attr,
 #endif
 
 
-#ifdef __USE_XOPEN2K
+/* Always exposed; see the type definitions above. */
 /* Functions to handle spinlocks.  */
 
 /* Initialize the spinlock LOCK.  If PSHARED is nonzero the spinlock can
@@ -750,7 +758,6 @@ extern int pthread_barrierattr_getpshared (__const pthread_barrierattr_t *
 /* Set the process-shared flag of the barrier attribute ATTR.  */
 extern int pthread_barrierattr_setpshared (pthread_barrierattr_t *__attr,
 					   int __pshared);
-#endif
 
 
 /* Functions for handling thread-specific data.  */

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -29,6 +29,12 @@ void __ESBMC_set_thread_internal_data(
 #define __ESBMC_rwlock_readers(a) ((a)->__readers)
 #define __ESBMC_rwlock_writer(a) ((a)->__writer)
 #define __ESBMC_rwlock_waiters(a) ((a)->__waiters)
+#define __ESBMC_barrier_count(a) ((a)->__count)
+#define __ESBMC_barrier_arrived(a) ((a)->__arrived)
+#define __ESBMC_barrier_generation(a) ((a)->__generation)
+#define __ESBMC_barrier_waiters(a) ((a)->__waiters)
+#define __ESBMC_spin_lock_field(a) ((a)->__lock)
+#define __ESBMC_spin_waiters(a) ((a)->__waiters)
 
 /* Global tracking data. Should all initialize to 0 / false */
 __attribute__((annotate("__ESBMC_inf_size")))
@@ -721,6 +727,175 @@ __ESBMC_HIDE:;
 
   __ESBMC_assume(acquired);
 
+  return 0;
+}
+
+/************************ barrier mainpulation routines ***********************/
+
+int pthread_barrierattr_init(pthread_barrierattr_t *attr)
+{
+  return 0;
+}
+
+int pthread_barrierattr_destroy(pthread_barrierattr_t *attr)
+{
+  return 0;
+}
+
+int pthread_barrierattr_getpshared(
+  const pthread_barrierattr_t *attr,
+  int *pshared)
+{
+__ESBMC_HIDE:;
+  *pshared = PTHREAD_PROCESS_PRIVATE;
+  return 0;
+}
+
+int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared)
+{
+  return 0;
+}
+
+int pthread_barrier_init(
+  pthread_barrier_t *barrier,
+  const pthread_barrierattr_t *attr,
+  unsigned int count)
+{
+__ESBMC_HIDE:;
+  if (count == 0)
+    return EINVAL;
+
+  __ESBMC_atomic_begin();
+  __ESBMC_barrier_count(barrier) = count;
+  __ESBMC_barrier_arrived(barrier) = 0;
+  __ESBMC_barrier_generation(barrier) = 0;
+  __ESBMC_release_blocked_threads(__ESBMC_barrier_waiters(barrier));
+  __ESBMC_barrier_waiters(barrier) = 0;
+  __ESBMC_atomic_end();
+  return 0;
+}
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+  __ESBMC_assert(
+    __ESBMC_barrier_arrived(barrier) == 0,
+    "attempt to destroy a barrier with waiting threads");
+  __ESBMC_barrier_count(barrier) = 0;
+  __ESBMC_atomic_end();
+  return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+
+  unsigned int generation = __ESBMC_barrier_generation(barrier);
+  int res = 0;
+
+  __ESBMC_barrier_arrived(barrier)++;
+
+  if (__ESBMC_barrier_arrived(barrier) == __ESBMC_barrier_count(barrier))
+  {
+    // Last to arrive: open the barrier and let this round's waiters through.
+    __ESBMC_barrier_arrived(barrier) = 0;
+    __ESBMC_barrier_generation(barrier)++;
+    __ESBMC_release_blocked_threads(__ESBMC_barrier_waiters(barrier));
+    __ESBMC_barrier_waiters(barrier) = 0;
+    res = PTHREAD_BARRIER_SERIAL_THREAD;
+  }
+  else
+  {
+    __ESBMC_barrier_waiters(barrier)++;
+    __ESBMC_blocked_threads_count++;
+    __ESBMC_assert(
+      __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
+      "Deadlocked state in pthread_barrier_wait");
+  }
+
+  __ESBMC_atomic_end();
+
+  // Only schedules in which this thread's round has since completed continue.
+  __ESBMC_assume(__ESBMC_barrier_generation(barrier) != generation);
+
+  return res;
+}
+
+/*********************** spinlock mainpulation routines ***********************/
+
+int pthread_spin_init(pthread_spinlock_t *lock, int pshared)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+  __ESBMC_spin_lock_field(lock) = 0;
+  __ESBMC_release_blocked_threads(__ESBMC_spin_waiters(lock));
+  __ESBMC_spin_waiters(lock) = 0;
+  __ESBMC_atomic_end();
+  return 0;
+}
+
+int pthread_spin_destroy(pthread_spinlock_t *lock)
+{
+  return 0;
+}
+
+int pthread_spin_lock(pthread_spinlock_t *lock)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+
+  _Bool acquired = (__ESBMC_spin_lock_field(lock) == 0);
+
+  if (acquired)
+  {
+    __ESBMC_spin_lock_field(lock) = 1;
+  }
+  else
+  {
+    // A spinning thread never yields, so every thread spinning at once is a
+    // deadlock exactly as it is for a blocking mutex.
+    __ESBMC_spin_waiters(lock)++;
+    __ESBMC_blocked_threads_count++;
+    __ESBMC_assert(
+      __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
+      "Deadlocked state in pthread_spin_lock");
+  }
+
+  __ESBMC_atomic_end();
+
+  __ESBMC_assume(acquired);
+
+  return 0;
+}
+
+int pthread_spin_trylock(pthread_spinlock_t *lock)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+
+  int res = EBUSY;
+  if (__ESBMC_spin_lock_field(lock) == 0)
+  {
+    __ESBMC_spin_lock_field(lock) = 1;
+    res = 0;
+  }
+
+  __ESBMC_atomic_end();
+  return res;
+}
+
+int pthread_spin_unlock(pthread_spinlock_t *lock)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+  __ESBMC_assert(
+    __ESBMC_spin_lock_field(lock), "must hold spinlock upon unlock");
+  __ESBMC_spin_lock_field(lock) = 0;
+  __ESBMC_release_blocked_threads(__ESBMC_spin_waiters(lock));
+  __ESBMC_spin_waiters(lock) = 0;
+  __ESBMC_atomic_end();
   return 0;
 }
 


### PR DESCRIPTION
`pthread_barrier_t` and `pthread_spinlock_t` sat behind `#ifdef __USE_XOPEN2K`,
which ESBMC never defines, so any program using them failed to parse, and there
was no operational model for `pthread_barrier_wait` / `pthread_spin_lock` even
if the types had been visible.

Expose both — as was already done for the rwlock block just above — and add
models that reuse the waiter-count and `__ESBMC_blocked_threads_count`
accounting of `pthread_mutex_lock_check`. The barrier carries a generation
counter so a waiter resumes only on schedules where its round has completed,
which is what gives the barrier its ordering guarantee.

Four regression tests under `regression/esbmc-unix/` cover a satisfied barrier
with a cross-thread ordering assertion, an under-subscribed barrier deadlock,
spinlock mutual exclusion, and a spinlock self-deadlock. All four fail on the
unpatched binary.

Fixes #6478