### PR TITLE
[goto-symex] Cut off after main returns under --deadlock-check

### DIFF
--- a/regression/esbmc-unix/01_cond_09/main.c
+++ b/regression/esbmc-unix/01_cond_09/main.c
@@ -43,5 +43,7 @@ int main()
   pthread_create(&t1, 0, thread1, 0);
   pthread_create(&t2, 0, thread2, 0);
 
-  return 0;  
+  /* Returning from main calls exit() and tears the workers down before they
+     can deadlock; pthread_exit keeps them alive (#6479). */
+  pthread_exit(0);
 }

--- a/regression/esbmc-unix/01_malloc_01/main.c
+++ b/regression/esbmc-unix/01_malloc_01/main.c
@@ -28,5 +28,7 @@ int main(void)
 //  assert(0);
   pthread_create(&id1, NULL, thread1, NULL);
   pthread_create(&id2, NULL, thread2, NULL);
-  return 0;
+  /* Returning from main calls exit() and tears the workers down before they
+     can deadlock; pthread_exit keeps them alive (#6479). */
+  pthread_exit(0);
 }

--- a/regression/esbmc-unix/github_6475_rdlock/main.c
+++ b/regression/esbmc-unix/github_6475_rdlock/main.c
@@ -29,5 +29,7 @@ int main(void)
   pthread_rwlock_init(&b, 0);
   pthread_create(&p1, 0, t1, 0);
   pthread_create(&p2, 0, t2, 0);
-  return 0;
+  /* Hand the process over to the workers: returning from main would call
+     exit() and tear them down before they can deadlock (#6479). */
+  pthread_exit(0);
 }

--- a/regression/esbmc-unix/github_6475_wrlock/main.c
+++ b/regression/esbmc-unix/github_6475_wrlock/main.c
@@ -29,5 +29,7 @@ int main(void)
   pthread_rwlock_init(&b, 0);
   pthread_create(&p1, 0, t1, 0);
   pthread_create(&p2, 0, t2, 0);
-  return 0;
+  /* Hand the process over to the workers: returning from main would call
+     exit() and tear them down before they can deadlock (#6479). */
+  pthread_exit(0);
 }

--- a/regression/esbmc-unix/github_6479-pthread-exit_fail/main.c
+++ b/regression/esbmc-unix/github_6479-pthread-exit_fail/main.c
@@ -1,0 +1,20 @@
+/* main hands the process over to its threads with pthread_exit, so the worker
+   really does outlive main and really does deadlock on the lock main holds. */
+#include <pthread.h>
+pthread_mutex_t m;
+
+void *w(void *p)
+{
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_lock(&m);
+  pthread_create(&a, 0, w, 0);
+  pthread_exit(0);
+}

--- a/regression/esbmc-unix/github_6479-pthread-exit_fail/test.desc
+++ b/regression/esbmc-unix/github_6479-pthread-exit_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 2 --deadlock-check
+^VERIFICATION FAILED$
+Deadlocked state in pthread_mutex_lock

--- a/regression/esbmc-unix/github_6479/main.c
+++ b/regression/esbmc-unix/github_6479/main.c
@@ -1,0 +1,20 @@
+/* main returns while holding m.  Returning from main calls exit(), the process
+   terminates, and the worker is torn down -- this is NOT a deadlock. */
+#include <pthread.h>
+pthread_mutex_t m;
+
+void *w(void *p)
+{
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_lock(&m);
+  pthread_create(&a, 0, w, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6479/test.desc
+++ b/regression/esbmc-unix/github_6479/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 2 --deadlock-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix2/01_pthread41/main.c
+++ b/regression/esbmc-unix2/01_pthread41/main.c
@@ -38,7 +38,7 @@ int main()
 
 //  pthread_join(a, NULL);
 //  pthread_join(b, NULL);
-
-  return 0;
+  /* Returning from main calls exit() and tears the workers down before they
+     can deadlock; pthread_exit keeps them alive (#6479). */
+  pthread_exit(0);
 }
-

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -227,15 +227,21 @@ void execution_statet::symex_step(reachability_treet &art)
     else if (
       (instruction.function == "c:@F@main" ||
        instruction.function == "c:@F@main#") &&
-      !options.get_bool_option("deadlock-check") &&
       !options.get_bool_option("memory-leak-check") &&
       !options.get_bool_option("termination"))
     {
       // check whether we reached the end of the main function and
-      // whether we are not checking for (local and global) deadlocks and memory leaks.
+      // whether we are not checking for memory leaks.
       // We should end the main thread to avoid exploring further interleavings
       // TODO: once we support at_exit, we should check this code
       // TODO: we should support verifying memory leaks in multi-threaded C programs.
+      //
+      // Returning from main is a call to exit(): the process terminates and
+      // every other thread is torn down (C11 5.1.2.2.3), so a thread still
+      // waiting on a lock main held is not deadlocked. This END_FUNCTION is
+      // reached only on a real return -- pthread_exit() ends in
+      // __ESBMC_assume(0) -- so a program whose threads outlive main via
+      // pthread_exit keeps being explored under --deadlock-check (#6479).
       //
       // Skipped under --termination: the strategy inserts an
       // `assert(false)` after the main() call in __ESBMC_main to


### PR DESCRIPTION
Returning from `main` is a call to `exit()`: the process terminates and every
other thread is torn down (C11 5.1.2.2.3), so a thread still waiting on a lock
`main` held is not deadlocked. The `END_FUNCTION` cut-off in
`execution_state.cpp` explicitly excluded `--deadlock-check`, so those threads
kept being scheduled and reported a deadlock that cannot happen at run time.

The `return` / `pthread_exit` distinction falls out for free: `pthread_exit`
ends in `__ESBMC_assume(0)`, so it never reaches this `END_FUNCTION`. Programs
whose threads legitimately outlive `main` keep being explored.

**Please look at the test changes.** Four existing tests relied on the old
behaviour -- their workers deadlock only after `main` returns without joining,
which is exactly the false positive this fixes:

- `esbmc-unix/github_6475_rdlock`, `esbmc-unix/github_6475_wrlock` (from #6490)
- `esbmc-unix/01_malloc_01`, `esbmc-unix2/01_pthread41` (legacy)

Each now calls `pthread_exit(0)` instead of `return 0`, which is how POSIX
expresses "these threads outlive main". All four still fail at the same site
with the same message, so the expected-output regexes are unchanged.

Two new tests cover both directions: the issue's reproducer is now SUCCESSFUL,
and the same program with `pthread_exit` still reports the deadlock.

Full `esbmc-unix` + `esbmc-unix2` sweep: 519/523, with only the four failures
that also fail on master on this platform (`04_valgrind`, `error`, `error2`,
`unsupported_extensions`).

Fixes #6479
