### PR TITLE
[python] Drain the blocked-thread counter on Lock.release and join

### DIFF
--- a/regression/python/github_6489/main.py
+++ b/regression/python/github_6489/main.py
@@ -1,0 +1,24 @@
+# Python translation of regression/esbmc-unix/github_6474/main.c: deadlock-free.
+import threading
+
+m1 = threading.Lock()
+m2 = threading.Lock()
+
+
+def w() -> None:
+    m2.acquire()
+    m1.acquire()
+    m1.release()
+    m2.release()
+
+
+a = threading.Thread(target=w)
+b = threading.Thread(target=w)
+m1.acquire()
+a.start()
+b.start()
+m1.release()
+m2.acquire()
+m2.release()
+a.join()
+b.join()

--- a/regression/python/github_6489/test.desc
+++ b/regression/python/github_6489/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2 --deadlock-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6489_deadlock/main.py
+++ b/regression/python/github_6489_deadlock/main.py
@@ -1,0 +1,31 @@
+# The drain added for #6489 must not mask a genuine deadlock: main releases m0
+# first (running the drain), and only then do the workers deadlock on m1/m2.
+import threading
+
+m0 = threading.Lock()
+m1 = threading.Lock()
+m2 = threading.Lock()
+
+
+def t1() -> None:
+    m1.acquire()
+    m2.acquire()
+    m2.release()
+    m1.release()
+
+
+def t2() -> None:
+    m2.acquire()
+    m1.acquire()
+    m1.release()
+    m2.release()
+
+
+m0.acquire()
+m0.release()
+a = threading.Thread(target=t1)
+b = threading.Thread(target=t2)
+a.start()
+b.start()
+a.join()
+b.join()

--- a/regression/python/github_6489_deadlock/test.desc
+++ b/regression/python/github_6489_deadlock/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 2 --deadlock-check
+^VERIFICATION FAILED$
+^.*Deadlocked state.*$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -180,6 +180,7 @@ const static std::vector<std::string> python_c_extern_deps = {
   "__pyt_init_tid",
   "__pyt_join",
   "__pyt_terminate",
+  "__pyt_lock_release_waiters",
   "__ESBMC_pthread_start_main_hook",
   "__ESBMC_pthread_end_main_hook",
   "__ESBMC_pylock_block_and_check"};

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -1099,6 +1099,8 @@ __ESBMC_HIDE:;
   pthread_t threadid = __ESBMC_get_thread_id();
   __ESBMC_pthread_thread_ended[threadid] = 1;
   __ESBMC_num_threads_running--;
+  __ESBMC_release_blocked_threads(__ESBMC_pthread_join_waiters[threadid]);
+  __ESBMC_pthread_join_waiters[threadid] = 0;
   // ``pthread_trampoline`` additionally assumes
   // ``__ESBMC_blocked_threads_count == 0`` to prune deadlocked
   // schedules from its own path; we deliberately omit that assume
@@ -1119,6 +1121,9 @@ __ESBMC_HIDE:;
   _Bool ended = __ESBMC_pthread_thread_ended[(int)thread];
   if (!ended)
   {
+    // Register as a waiter so __pyt_terminate can cancel this bump; without
+    // it the counter saturates and every later block looks like a deadlock.
+    __ESBMC_pthread_join_waiters[(int)thread]++;
     __ESBMC_blocked_threads_count++;
     // Deadlock if every running thread is now blocked.
     __ESBMC_assert(
@@ -1155,4 +1160,17 @@ __ESBMC_HIDE:;
   __ESBMC_assert(
     __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
     "Deadlocked state in threading.Lock.acquire");
+}
+
+/* Drains a threading.Lock's waiter count, called from ``Lock.release`` in
+ * models/threading_deadlock.py. Mirrors what pthread_mutex_unlock_check does
+ * with __ESBMC_mutex_waiters: without it the bumps made by
+ * __ESBMC_pylock_block_and_check accumulate and a later, unrelated block reads
+ * as a deadlock (#6489). Named __pyt_* rather than __ESBMC_* because symex
+ * intercepts the latter prefix in run_intrinsic and would never run this body.
+ */
+void __pyt_lock_release_waiters(unsigned int waiters)
+{
+__ESBMC_HIDE:;
+  __ESBMC_release_blocked_threads(waiters);
 }

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -1163,11 +1163,12 @@ __ESBMC_HIDE:;
 }
 
 /* Drains a threading.Lock's waiter count, called from ``Lock.release`` in
- * models/threading_deadlock.py. Mirrors what pthread_mutex_unlock_check does
- * with __ESBMC_mutex_waiters: without it the bumps made by
- * __ESBMC_pylock_block_and_check accumulate and a later, unrelated block reads
- * as a deadlock (#6489). Named __pyt_* rather than __ESBMC_* because symex
- * intercepts the latter prefix in run_intrinsic and would never run this body.
+ * ``models/threading_deadlock.py``. Mirrors what ``pthread_mutex_unlock_check``
+ * does with ``__ESBMC_mutex_waiters``: without it the bumps made by
+ * ``__ESBMC_pylock_block_and_check`` accumulate and a later, unrelated block
+ * reads as a deadlock (#6489). Named ``__pyt_*`` rather than ``__ESBMC_*``
+ * because symex intercepts the latter prefix in ``run_intrinsic`` and would
+ * never run this body.
  */
 void __pyt_lock_release_waiters(unsigned int waiters)
 {

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -77,6 +77,7 @@ const std::string kPytInitTid = "__pyt_init_tid";
 const std::string kPytJoin = "__pyt_join";
 const std::string kPytTerminate = "__pyt_terminate";
 const std::string kPyLockBlockAndCheck = "__ESBMC_pylock_block_and_check";
+const std::string kPyLockReleaseWaiters = "__pyt_lock_release_waiters";
 
 function_call_builder::function_call_builder(
   python_converter &converter,
@@ -1023,12 +1024,14 @@ exprt function_call_builder::build() const
     const bool is_join = func_name == kPytJoin;
     const bool is_terminate = func_name == kPytTerminate;
     const bool is_lock_block = func_name == kPyLockBlockAndCheck;
-    if (is_init_tid || is_join || is_terminate || is_lock_block)
+    const bool is_lock_release = func_name == kPyLockReleaseWaiters;
+    if (is_init_tid || is_join || is_terminate || is_lock_block ||
+        is_lock_release)
     {
       auto &symbol_table = converter_.symbol_table();
       locationt location = converter_.get_location_from_decl(call_);
 
-      const bool takes_uint_arg = is_init_tid || is_join;
+      const bool takes_uint_arg = is_init_tid || is_join || is_lock_release;
 
       code_typet fn_type;
       fn_type.return_type() = empty_typet();

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -1025,8 +1025,9 @@ exprt function_call_builder::build() const
     const bool is_terminate = func_name == kPytTerminate;
     const bool is_lock_block = func_name == kPyLockBlockAndCheck;
     const bool is_lock_release = func_name == kPyLockReleaseWaiters;
-    if (is_init_tid || is_join || is_terminate || is_lock_block ||
-        is_lock_release)
+    if (
+      is_init_tid || is_join || is_terminate || is_lock_block ||
+      is_lock_release)
     {
       auto &symbol_table = converter_.symbol_table();
       locationt location = converter_.get_location_from_decl(call_);

--- a/src/python-frontend/models/threading_deadlock.py
+++ b/src/python-frontend/models/threading_deadlock.py
@@ -18,7 +18,9 @@ is where the predicate fires.
 The release path mirrors ``pthread_mutex_unlock_check``: assert the
 lock was held before clearing the field, so a release-without-acquire
 bug is caught under the same flag whose job it is to find concurrency
-errors.
+errors, then drain the waiters this lock registered. Without that drain
+the global counter saturates and a later, unrelated block reads as a
+deadlock (#6489).
 """
 # pylint: disable=unused-argument,unnecessary-pass,undefined-variable,function-redefined
 
@@ -28,6 +30,7 @@ class Lock:
 
     def __init__(self) -> None:
         self._locked: int = 0
+        self._waiters: int = 0
 
     def acquire(self) -> None:
         """Block until the lock is free, then mark it held.
@@ -44,6 +47,7 @@ class Lock:
         if unlocked:
             self._locked = 1
         else:
+            self._waiters = self._waiters + 1
             __ESBMC_pylock_block_and_check()
         __ESBMC_atomic_end()
         __ESBMC_assume(unlocked)
@@ -59,6 +63,8 @@ class Lock:
         __ESBMC_atomic_begin()
         assert self._locked == 1, "must hold lock upon unlock"  # nosec B101
         self._locked = 0
+        __pyt_lock_release_waiters(self._waiters)
+        self._waiters = 0
         __ESBMC_atomic_end()
 
 

--- a/src/python-frontend/python_annotation/annotation_intrinsics.cpp
+++ b/src/python-frontend/python_annotation/annotation_intrinsics.cpp
@@ -82,6 +82,7 @@ const std::map<std::string, std::string> &builtin_functions()
     {"__pyt_join", "NoneType"},
     {"__pyt_terminate", "NoneType"},
     {"__ESBMC_pylock_block_and_check", "NoneType"},
+    {"__pyt_lock_release_waiters", "NoneType"},
 
     // Execution functions
     {"eval", "Any"},


### PR DESCRIPTION
`threading.Lock.acquire` and `__pyt_join` bumped `__ESBMC_blocked_threads_count`
on their blocked branches, but nothing ever cancelled those bumps. The counter
saturated, so a later, unrelated block read as a deadlock -- the Python mirror
of the C-side defect fixed in #6490.

Mirrors the C model on both paths:

- `Lock` gains a `_waiters` count, bumped alongside
  `__ESBMC_pylock_block_and_check()` and drained in `release()` through a new
  `__pyt_lock_release_waiters` intrinsic, exactly as
  `pthread_mutex_unlock_check` drains `__ESBMC_mutex_waiters`.
- `__pyt_join` registers in `__ESBMC_pthread_join_waiters[]` and
  `__pyt_terminate` releases them, matching `pthread_join_switch` /
  `pthread_trampoline`.

The new helper is deliberately named `__pyt_*` rather than `__ESBMC_*`:
`run_intrinsic` (`symex_main.cpp`) intercepts every `c:@F@__ESBMC` call and
would never execute the body. `__ESBMC_pylock_block_and_check` only works
because it has an explicit escape-hatch entry there.

Tests:

- `regression/python/github_6489` -- the issue's reproducer (a Python
  translation of `esbmc-unix/github_6474`, deadlock-free). Confirmed to fail
  on a rebuilt unpatched binary and pass with the fix.
- `regression/python/github_6489_deadlock` -- a genuine deadlock that occurs
  *after* a release has run the drain, guarding against the drain
  over-releasing and masking real deadlocks. Passes both before and after by
  design; it is a regression guard, not a discriminator.

All 48 `regression/python` threading/lock/deadlock tests pass, including the
`github_4581*` cases the issue flagged as at risk, plus the C-side
`cwe_deadlock` / `github_6474` / `github_6475` group. `scripts/check_python_tests.sh`
passes on both new tests; pylint rates the model 10.00/10.

Fixes #6489
