### PR TITLE
[contracts] reject __ESBMC_is_fresh on a non-pointer object

### DIFF
--- a/regression/function_contract/is_fresh_addr_array_local_fail/main.c
+++ b/regression/function_contract/is_fresh_addr_array_local_fail/main.c
@@ -1,0 +1,10 @@
+void f(void)
+{
+  int a[10];
+  __ESBMC_requires(__ESBMC_is_fresh(&a, sizeof(a)));
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/is_fresh_addr_array_local_fail/test.desc
+++ b/regression/function_contract/is_fresh_addr_array_local_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --no-pointer-check --unwind 4
+^ERROR: __ESBMC_is_fresh needs a pointer it can point at fresh storage

--- a/regression/function_contract/is_fresh_addr_ptr_local_pass/main.c
+++ b/regression/function_contract/is_fresh_addr_ptr_local_pass/main.c
@@ -1,0 +1,15 @@
+typedef struct
+{
+  int coeffs[4];
+} P;
+
+void f(void)
+{
+  P *v;
+  __ESBMC_requires(__ESBMC_is_fresh(&v, sizeof(P)));
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/is_fresh_addr_ptr_local_pass/test.desc
+++ b/regression/function_contract/is_fresh_addr_ptr_local_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --no-pointer-check --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/is_fresh_addr_scalar_local_fail/main.c
+++ b/regression/function_contract/is_fresh_addr_scalar_local_fail/main.c
@@ -1,0 +1,10 @@
+void f(void)
+{
+  int x;
+  __ESBMC_requires(__ESBMC_is_fresh(&x, sizeof(int)));
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/is_fresh_addr_scalar_local_fail/test.desc
+++ b/regression/function_contract/is_fresh_addr_scalar_local_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --no-pointer-check --unwind 4
+^ERROR: __ESBMC_is_fresh needs a pointer it can point at fresh storage

--- a/regression/function_contract/is_fresh_addr_struct_local_fail/main.c
+++ b/regression/function_contract/is_fresh_addr_struct_local_fail/main.c
@@ -1,0 +1,15 @@
+typedef struct
+{
+  int coeffs[4];
+} P;
+
+void f(void)
+{
+  P v;
+  __ESBMC_requires(__ESBMC_is_fresh(&v, sizeof(P)));
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/is_fresh_addr_struct_local_fail/test.desc
+++ b/regression/function_contract/is_fresh_addr_struct_local_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --no-pointer-check --unwind 4
+^ERROR: __ESBMC_is_fresh needs a pointer it can point at fresh storage

--- a/regression/function_contract/is_fresh_array_param_pass/main.c
+++ b/regression/function_contract/is_fresh_array_param_pass/main.c
@@ -1,0 +1,9 @@
+void f(int a[10])
+{
+  __ESBMC_requires(__ESBMC_is_fresh(a, 10 * sizeof(int)));
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/is_fresh_array_param_pass/test.desc
+++ b/regression/function_contract/is_fresh_array_param_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --no-pointer-check --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -1138,19 +1138,36 @@ goto_programt code_contractst::generate_checking_wrapper(
     // to *p.  Earlier revisions had a "fallback" else branch that emitted
     // *p = malloc(...), which dereferenced an uninitialised p and tripped
     // alignment / pointer-validity checks before the body even ran.
+    // Peeling the address-of is only sound when what it wraps is itself a
+    // pointer.  For &obj with obj a struct or scalar, the peel would assign
+    // the malloc result into obj: value-set analysis then walks a pointer as
+    // if it were a struct and aborts (#6469), and for a scalar obj the
+    // assignment silently clobbers it and the contract means nothing.
+    // An address_of is itself pointer-typed, so it has to be matched before
+    // the bare-pointer case or it falls through to an unassignable lvalue.
     expr2tc ptr_var;
+    bool assignable = true;
     if (is_address_of2t(stripped))
     {
-      // &var → assign to var (peel the address-of).
-      ptr_var = to_address_of2t(stripped).ptr_obj;
+      const expr2tc &obj = to_address_of2t(stripped).ptr_obj;
+      assignable = is_pointer_type(obj->type);
+      ptr_var = obj;
     }
     else
     {
-      // Bare pointer expression — assign directly to it.
-      assert(
-        is_pointer_type(stripped->type) &&
-        "__ESBMC_is_fresh first argument must be pointer-typed");
+      assignable = is_pointer_type(stripped->type);
       ptr_var = stripped;
+    }
+
+    if (!assignable)
+    {
+      log_error(
+        "__ESBMC_is_fresh needs a pointer it can point at fresh storage, but "
+        "the contract of '{}' gives it the address of a non-pointer object. "
+        "Take that object as a pointer parameter, or allocate it with malloc "
+        "and pass the pointer.",
+        id2string(original_func.name));
+      abort();
     }
 
     // A plain symbol lvalue is independent of any harness setup — allocate now.


### PR DESCRIPTION
Fixes #6469, reported by @adilanwar2399.

`__ESBMC_is_fresh(EXPR, n)` lowers to "allocate n bytes and assign the result into EXPR". Recovering the assignment target peeled an `address_of` unconditionally:

```cpp
if (is_address_of2t(stripped))
  ptr_var = to_address_of2t(stripped).ptr_obj;   // &var -> var
```

That is only coherent when the peeled object is itself a pointer. When it is not, the malloc result is assigned into the object, and the resulting instruction is type-incoherent:

```
ASSIGN v = MALLOC(unsigned char, ...)     // v is a struct, not a pointer
ASSUME v != (struct mlk_poly)NULL
```

Two symptoms follow from the one defect:

- **struct object — abort.** `value_sett::assign` decomposes the struct-typed lhs into components, `make_member` pushes through the typecast `symex_mem` inserted at `memory_alloc.cpp:705`, lands on the `u8*` operand and throws:

  ```
  irep2: struct_union_members() called on incompatible type (type_id = pointer)
  ```

  Backtrace: `symex_mem` → `symex_assign_symbol` → `value_sett::assign` → `value_sett::make_member` (`value_set.cpp:1546`).

- **scalar object — silent.** Not reported in the issue, found while reducing it. `__ESBMC_is_fresh(&x, sizeof(int))` with `int x` reports `VERIFICATION SUCCESSFUL`, because value-set never decomposes a scalar. The lowering is the same nonsense (`ASSIGN x = MALLOC(...)`), it just clobbers `x` and makes the contract vacuous instead of crashing. This is the more dangerous half.

Behaviour across the argument forms, before and after:

| form | before | after |
|---|---|---|
| `is_fresh(p, n)`, `p` a `T *` param | SUCCESSFUL | unchanged |
| `is_fresh(p, n)`, `p` a `T **` param | SUCCESSFUL | unchanged |
| `is_fresh(&p, n)`, `p` a `T *` local | SUCCESSFUL | unchanged |
| `is_fresh(&v, n)`, `v` a struct local | **abort** | diagnosed |
| `is_fresh(&x, n)`, `x` an `int` local | **silently vacuous** | diagnosed |

## The fix

`address_of` is itself pointer-typed, so testing `is_pointer_type(stripped->type)` does not distinguish the two cases; the `address_of` shape has to be matched first and its operand checked. Both shapes were nominally guarded by an `assert`, but `NDEBUG` compiles those out, so release builds diagnosed neither. Replaced with a real check using this file's existing `log_error` + `abort()` idiom (`contracts.cpp:182`, `:205`, `:1992`).

The message points at the two supported ways to say what the reporter wanted:

```
ERROR: __ESBMC_is_fresh needs a pointer it can point at fresh storage, but the
contract of 'f' gives it the address of a non-pointer object. Take that object
as a pointer parameter, or allocate it with malloc and pass the pointer.
```

Both are already confirmed to work in the issue.

## Tests

- `is_fresh_addr_struct_local_fail` — the reporter's reduction, was an abort
- `is_fresh_addr_scalar_local_fail` — the silent variant, was a false SUCCESSFUL
- `is_fresh_addr_ptr_local_pass` — guard: `&p` with `p` a pointer local must keep working, since that peel is the legitimate one

Red before the patch (abort / false pass / pass), green after. `function_contract` and `loop-invariants` are 365/365.

## Not addressed

`value_sett::make_member` asserts `is_struct_type(type) || is_union_type(type)` and then pushes through typecasts without re-checking the operand, so any other producer of such a cast crashes the same way in a release build. This patch removes the only producer I know of rather than hardening `make_member`; hardening it is a reasonable follow-up but is a change to shared analysis code and does not belong in a contracts fix.
