### PR TITLE
[contracts] reject unknown function names in contract flags

### DIFF
--- a/regression/function_contract/contract_fn_name_all_no_annotation/main.c
+++ b/regression/function_contract/contract_fn_name_all_no_annotation/main.c
@@ -1,0 +1,10 @@
+int f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value > x);
+  return x + 1;
+}
+
+int main(void)
+{
+  return f(1) - 2;
+}

--- a/regression/function_contract/contract_fn_name_all_no_annotation/test.desc
+++ b/regression/function_contract/contract_fn_name_all_no_annotation/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--enforce-all-contracts
+^ERROR: --enforce-all-contracts: no function carries the __ESBMC_contract annotation$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_comma/main.c
+++ b/regression/function_contract/contract_fn_name_comma/main.c
@@ -1,0 +1,19 @@
+int f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int g(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int main(void)
+{
+  int a = f(3);
+  int b = g(3);
+  __ESBMC_assert(b == 3, "true of g's body, not of g's contract");
+  return a - a;
+}

--- a/regression/function_contract/contract_fn_name_comma/test.desc
+++ b/regression/function_contract/contract_fn_name_comma/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract f,g
+^ERROR: --replace-call-with-contract: no function named 'f,g' \(names are not comma-separated; repeat the flag once per function, or use "\*"\)$

--- a/regression/function_contract/contract_fn_name_comma/test.desc
+++ b/regression/function_contract/contract_fn_name_comma/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --replace-call-with-contract f,g
-^ERROR: --replace-call-with-contract: cannot use 'f,g': no function of that name \(names are not comma-separated; repeat the flag once per function, or use "\*"\)$
+^ERROR: --replace-call-with-contract: cannot use 'f,g': no function of that name has a body here \(names are not comma-separated; repeat the flag once per function, or use "\*"\)$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_comma/test.desc
+++ b/regression/function_contract/contract_fn_name_comma/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --replace-call-with-contract f,g
-^ERROR: --replace-call-with-contract: no function named 'f,g' \(names are not comma-separated; repeat the flag once per function, or use "\*"\)$
+^ERROR: --replace-call-with-contract: cannot use 'f,g': no function of that name \(names are not comma-separated; repeat the flag once per function, or use "\*"\)$

--- a/regression/function_contract/contract_fn_name_cpp_paramspp/main.cpp
+++ b/regression/function_contract/contract_fn_name_cpp_paramspp/main.cpp
@@ -1,0 +1,12 @@
+int fst(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int main()
+{
+  int b = fst(3);
+  __ESBMC_assert(b == 3, "true of the body, not of the contract");
+  return 0;
+}

--- a/regression/function_contract/contract_fn_name_cpp_paramspp/test.desc
+++ b/regression/function_contract/contract_fn_name_cpp_paramspp/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--replace-call-with-contract fst
+^ERROR: --replace-call-with-contract: cannot use 'fst': no function of that name has a body here$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_enforce_unknown/main.c
+++ b/regression/function_contract/contract_fn_name_enforce_unknown/main.c
@@ -1,0 +1,19 @@
+int f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int g(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int main(void)
+{
+  int a = f(3);
+  int b = g(3);
+  __ESBMC_assert(b == 3, "true of g's body, not of g's contract");
+  return a - a;
+}

--- a/regression/function_contract/contract_fn_name_enforce_unknown/test.desc
+++ b/regression/function_contract/contract_fn_name_enforce_unknown/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enforce-contract no_such_function --function f
+^ERROR: --enforce-contract: no function named 'no_such_function'$

--- a/regression/function_contract/contract_fn_name_enforce_unknown/test.desc
+++ b/regression/function_contract/contract_fn_name_enforce_unknown/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --enforce-contract no_such_function --function f
-^ERROR: --enforce-contract: no function named 'no_such_function'$
+^ERROR: --enforce-contract: cannot use 'no_such_function': no function of that name$

--- a/regression/function_contract/contract_fn_name_enforce_unknown/test.desc
+++ b/regression/function_contract/contract_fn_name_enforce_unknown/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --enforce-contract no_such_function --function f
-^ERROR: --enforce-contract: cannot use 'no_such_function': no function of that name$
+^ERROR: --enforce-contract: cannot use 'no_such_function': no function of that name, or the name is ambiguous$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_no_body/main.c
+++ b/regression/function_contract/contract_fn_name_no_body/main.c
@@ -1,0 +1,12 @@
+int extern_fn(int x);
+
+int f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int main(void)
+{
+  return f(3) - 3;
+}

--- a/regression/function_contract/contract_fn_name_no_body/main.c
+++ b/regression/function_contract/contract_fn_name_no_body/main.c
@@ -1,3 +1,5 @@
+/* extern_fn is declared, has no body here, and IS called: the flag must be
+   rejected because the body is absent, not because nothing calls it. */
 int extern_fn(int x);
 
 int f(int x)
@@ -8,5 +10,5 @@ int f(int x)
 
 int main(void)
 {
-  return f(3) - 3;
+  return f(3) + extern_fn(1) - 3;
 }

--- a/regression/function_contract/contract_fn_name_no_body/test.desc
+++ b/regression/function_contract/contract_fn_name_no_body/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract extern_fn
+^ERROR: --replace-call-with-contract: cannot use 'extern_fn': that function is declared but has no body here$

--- a/regression/function_contract/contract_fn_name_no_body/test.desc
+++ b/regression/function_contract/contract_fn_name_no_body/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --replace-call-with-contract extern_fn
-^ERROR: --replace-call-with-contract: cannot use 'extern_fn': that function is declared but has no body here$
+^ERROR: --replace-call-with-contract: cannot use 'extern_fn': no function of that name has a body here$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_no_contract/main.c
+++ b/regression/function_contract/contract_fn_name_no_contract/main.c
@@ -1,0 +1,15 @@
+int plain(int x)
+{
+  return x + 1;
+}
+
+int f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int main(void)
+{
+  return f(3) - plain(2);
+}

--- a/regression/function_contract/contract_fn_name_no_contract/test.desc
+++ b/regression/function_contract/contract_fn_name_no_contract/test.desc
@@ -2,3 +2,4 @@ CORE
 main.c
 --replace-call-with-contract plain
 ^ERROR: --replace-call-with-contract: cannot use 'plain': that function declares no contract clauses$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_no_contract/test.desc
+++ b/regression/function_contract/contract_fn_name_no_contract/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract plain
+^ERROR: --replace-call-with-contract: cannot use 'plain': that function declares no contract clauses$

--- a/regression/function_contract/contract_fn_name_repeated/main.c
+++ b/regression/function_contract/contract_fn_name_repeated/main.c
@@ -1,0 +1,19 @@
+int f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int g(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int main(void)
+{
+  int a = f(3);
+  int b = g(3);
+  __ESBMC_assert(b == 3, "true of g's body, not of g's contract");
+  return a - a;
+}

--- a/regression/function_contract/contract_fn_name_repeated/test.desc
+++ b/regression/function_contract/contract_fn_name_repeated/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract f --replace-call-with-contract g
+^VERIFICATION FAILED$

--- a/regression/function_contract/contract_fn_name_repeated/test.desc
+++ b/regression/function_contract/contract_fn_name_repeated/test.desc
@@ -2,3 +2,4 @@ CORE
 main.c
 --replace-call-with-contract f --replace-call-with-contract g
 ^VERIFICATION FAILED$
+^Replacing calls with contracts for 2 function\(s\)$

--- a/regression/function_contract/contract_fn_name_star_no_contract/main.c
+++ b/regression/function_contract/contract_fn_name_star_no_contract/main.c
@@ -1,0 +1,9 @@
+int plain(int x)
+{
+  return x + 1;
+}
+
+int main(void)
+{
+  return plain(2) - 3;
+}

--- a/regression/function_contract/contract_fn_name_star_no_contract/test.desc
+++ b/regression/function_contract/contract_fn_name_star_no_contract/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--replace-call-with-contract "*"
+^ERROR: --replace-call-with-contract: no function with a contract to act on$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_unknown/main.c
+++ b/regression/function_contract/contract_fn_name_unknown/main.c
@@ -1,0 +1,19 @@
+int f(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int g(int x)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return x > 0 ? x : 0;
+}
+
+int main(void)
+{
+  int a = f(3);
+  int b = g(3);
+  __ESBMC_assert(b == 3, "true of g's body, not of g's contract");
+  return a - a;
+}

--- a/regression/function_contract/contract_fn_name_unknown/test.desc
+++ b/regression/function_contract/contract_fn_name_unknown/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --replace-call-with-contract no_such_function
-^ERROR: --replace-call-with-contract: cannot use 'no_such_function': no function of that name$
+^ERROR: --replace-call-with-contract: cannot use 'no_such_function': no function of that name has a body here$
+\A(?!(.|\n)*VERIFICATION)

--- a/regression/function_contract/contract_fn_name_unknown/test.desc
+++ b/regression/function_contract/contract_fn_name_unknown/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --replace-call-with-contract no_such_function
-^ERROR: --replace-call-with-contract: no function named 'no_such_function'$
+^ERROR: --replace-call-with-contract: cannot use 'no_such_function': no function of that name$

--- a/regression/function_contract/contract_fn_name_unknown/test.desc
+++ b/regression/function_contract/contract_fn_name_unknown/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract no_such_function
+^ERROR: --replace-call-with-contract: no function named 'no_such_function'$

--- a/regression/function_contract/ring_enforce_process_messages/test.desc
+++ b/regression/function_contract/ring_enforce_process_messages/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --enforce-contract process_messages_at_time --replace-call-with-contract source_reaction_in --replace-call-with-contract node_reaction --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/ring_enforce_process_messages/test.desc
+++ b/regression/function_contract/ring_enforce_process_messages/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --enforce-contract process_messages_at_time --replace-call-with-contract source_reaction_in --replace-call-with-contract node_reaction --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/ring_loop_with_contract/test.desc
+++ b/regression/loop-invariants/ring_loop_with_contract/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --loop-invariant --replace-call-with-contract source_startup --replace-call-with-contract source_reaction_start --replace-call-with-contract source_reaction_in --replace-call-with-contract node_reaction --replace-call-with-contract process_messages_at_time --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/ring_loop_with_contract/test.desc
+++ b/regression/loop-invariants/ring_loop_with_contract/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --loop-invariant --replace-call-with-contract source_startup --replace-call-with-contract source_reaction_start --replace-call-with-contract source_reaction_in --replace-call-with-contract node_reaction --replace-call-with-contract process_messages_at_time --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -65,7 +65,8 @@ protected:
   /// \param has_enforce Whether to enforce contracts
   /// \param has_enforce_all Whether to enforce contracts for all annotated functions
   /// \param has_replace_all Whether to replace calls for all annotated functions
-  void process_function_contracts(
+  /// \return True on a usage error (e.g. a named function does not exist)
+  bool process_function_contracts(
     goto_functionst &goto_functions,
     bool has_replace,
     bool has_enforce,

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -65,7 +65,7 @@ protected:
   /// \param has_enforce Whether to enforce contracts
   /// \param has_enforce_all Whether to enforce contracts for all annotated functions
   /// \param has_replace_all Whether to replace calls for all annotated functions
-  /// \return True on a usage error (e.g. a named function does not exist)
+  /// \return True on a usage error, e.g. a named function that nothing acted on
   bool process_function_contracts(
     goto_functionst &goto_functions,
     bool has_replace,

--- a/src/esbmc/parseoptions/function_contracts.cpp
+++ b/src/esbmc/parseoptions/function_contracts.cpp
@@ -8,8 +8,8 @@
 #include <set>
 #include <string>
 
-// Process function contracts if enabled
-void esbmc_parseoptionst::process_function_contracts(
+// Process function contracts if enabled. Returns true on a usage error.
+bool esbmc_parseoptionst::process_function_contracts(
   goto_functionst &goto_functions,
   bool has_replace,
   bool has_enforce,
@@ -59,32 +59,51 @@ void esbmc_parseoptionst::process_function_contracts(
       return result;
     };
 
-  // Lambda function to process function list (handles "*" wildcard)
-  auto process_function_list = [&collect_functions_with_contracts](
-                                 const std::list<std::string> &func_list) {
-    std::set<std::string> result;
-    for (const auto &func : func_list)
-    {
-      if (func == "*")
+  // Lambda function to process function list (handles "*" wildcard).
+  // An unresolvable name is a usage error rather than a warning: these options
+  // decide *what* gets verified, so silently skipping one leaves ESBMC
+  // verifying something other than what was asked and still reporting a
+  // verdict for it. Sets ok=false on the first bad name.
+  bool ok = true;
+  auto process_function_list =
+    [&collect_functions_with_contracts, &contracts, &ok](
+      const std::list<std::string> &func_list, const char *opt) {
+      std::set<std::string> result;
+      for (const auto &func : func_list)
       {
-        // "*" means all functions with contracts
-        result = collect_functions_with_contracts();
-        break; // "*" means all, so we can break after collecting
-      }
-      else
-      {
+        if (func == "*")
+        {
+          // "*" means all functions with contracts
+          return collect_functions_with_contracts();
+        }
+
+        if (contracts.find_function_symbol(func) == nullptr)
+        {
+          log_error(
+            "--{}: no function named '{}'{}",
+            opt,
+            func,
+            func.find(',') != std::string::npos
+              ? " (names are not comma-separated; repeat the flag once per "
+                "function, or use \"*\")"
+              : "");
+          ok = false;
+          return std::set<std::string>();
+        }
         result.insert(func);
       }
-    }
-    return result;
-  };
+      return result;
+    };
 
   // Process enforce-contract option
   if (has_enforce)
   {
     const std::list<std::string> &enforce_list =
       cmdline.get_values("enforce-contract");
-    std::set<std::string> to_enforce = process_function_list(enforce_list);
+    std::set<std::string> to_enforce =
+      process_function_list(enforce_list, "enforce-contract");
+    if (!ok)
+      return true;
 
     if (!to_enforce.empty())
     {
@@ -104,14 +123,13 @@ void esbmc_parseoptionst::process_function_contracts(
   {
     const std::list<std::string> &replace_list =
       cmdline.get_values("replace-call-with-contract");
-    std::set<std::string> to_replace = process_function_list(replace_list);
+    std::set<std::string> to_replace =
+      process_function_list(replace_list, "replace-call-with-contract");
+    if (!ok)
+      return true;
 
     if (!to_replace.empty())
-    {
-      log_status(
-        "Replacing calls with contracts for {} function(s)", to_replace.size());
       contracts.replace_calls(to_replace);
-    }
   }
 
   // Lambda to collect ONLY functions with __ESBMC_contract annotation
@@ -157,4 +175,6 @@ void esbmc_parseoptionst::process_function_contracts(
       contracts.replace_calls(to_replace);
     }
   }
+
+  return false;
 }

--- a/src/esbmc/parseoptions/function_contracts.cpp
+++ b/src/esbmc/parseoptions/function_contracts.cpp
@@ -59,14 +59,32 @@ bool esbmc_parseoptionst::process_function_contracts(
       return result;
     };
 
-  // Lambda function to process function list (handles "*" wildcard).
-  // An unresolvable name is a usage error rather than a warning: these options
-  // decide *what* gets verified, so silently skipping one leaves ESBMC
-  // verifying something other than what was asked and still reporting a
-  // verdict for it. Sets ok=false on the first bad name.
+  // Reject a name these options cannot act on, and say which way it failed.
+  // All three ways -- unresolvable, no body, no contract -- reach the same
+  // place: nothing is enforced or replaced, yet a verdict is still printed for
+  // a run that is not the one that was asked for. Returns the reason, or an
+  // empty string when the name is usable.
+  auto unusable_because = [&contracts,
+                           &goto_functions](const std::string &func) {
+    const symbolt *sym = contracts.find_function_symbol(func);
+    if (sym == nullptr)
+      return std::string("no function of that name");
+
+    auto it = goto_functions.function_map.find(sym->id);
+    if (it == goto_functions.function_map.end() || !it->second.body_available)
+      return std::string("that function is declared but has no body here");
+
+    if (
+      !contracts.has_contracts(it->second.body) &&
+      !contracts.is_annotated_contract_function(*sym))
+      return std::string("that function declares no contract clauses");
+
+    return std::string();
+  };
+
   bool ok = true;
   auto process_function_list =
-    [&collect_functions_with_contracts, &contracts, &ok](
+    [&collect_functions_with_contracts, &unusable_because, &ok](
       const std::list<std::string> &func_list, const char *opt) {
       std::set<std::string> result;
       for (const auto &func : func_list)
@@ -77,12 +95,14 @@ bool esbmc_parseoptionst::process_function_contracts(
           return collect_functions_with_contracts();
         }
 
-        if (contracts.find_function_symbol(func) == nullptr)
+        std::string reason = unusable_because(func);
+        if (!reason.empty())
         {
           log_error(
-            "--{}: no function named '{}'{}",
+            "--{}: cannot use '{}': {}{}",
             opt,
             func,
+            reason,
             func.find(',') != std::string::npos
               ? " (names are not comma-separated; repeat the flag once per "
                 "function, or use \"*\")"

--- a/src/esbmc/parseoptions/function_contracts.cpp
+++ b/src/esbmc/parseoptions/function_contracts.cpp
@@ -8,7 +8,7 @@
 #include <set>
 #include <string>
 
-// Process function contracts if enabled. Returns true on a usage error.
+// Process function contracts if enabled
 bool esbmc_parseoptionst::process_function_contracts(
   goto_functionst &goto_functions,
   bool has_replace,
@@ -59,99 +59,6 @@ bool esbmc_parseoptionst::process_function_contracts(
       return result;
     };
 
-  // Reject a name these options cannot act on, and say which way it failed.
-  // All three ways -- unresolvable, no body, no contract -- reach the same
-  // place: nothing is enforced or replaced, yet a verdict is still printed for
-  // a run that is not the one that was asked for. Returns the reason, or an
-  // empty string when the name is usable.
-  auto unusable_because = [&contracts,
-                           &goto_functions](const std::string &func) {
-    const symbolt *sym = contracts.find_function_symbol(func);
-    if (sym == nullptr)
-      return std::string("no function of that name");
-
-    auto it = goto_functions.function_map.find(sym->id);
-    if (it == goto_functions.function_map.end() || !it->second.body_available)
-      return std::string("that function is declared but has no body here");
-
-    if (
-      !contracts.has_contracts(it->second.body) &&
-      !contracts.is_annotated_contract_function(*sym))
-      return std::string("that function declares no contract clauses");
-
-    return std::string();
-  };
-
-  bool ok = true;
-  auto process_function_list =
-    [&collect_functions_with_contracts, &unusable_because, &ok](
-      const std::list<std::string> &func_list, const char *opt) {
-      std::set<std::string> result;
-      for (const auto &func : func_list)
-      {
-        if (func == "*")
-        {
-          // "*" means all functions with contracts
-          return collect_functions_with_contracts();
-        }
-
-        std::string reason = unusable_because(func);
-        if (!reason.empty())
-        {
-          log_error(
-            "--{}: cannot use '{}': {}{}",
-            opt,
-            func,
-            reason,
-            func.find(',') != std::string::npos
-              ? " (names are not comma-separated; repeat the flag once per "
-                "function, or use \"*\")"
-              : "");
-          ok = false;
-          return std::set<std::string>();
-        }
-        result.insert(func);
-      }
-      return result;
-    };
-
-  // Process enforce-contract option
-  if (has_enforce)
-  {
-    const std::list<std::string> &enforce_list =
-      cmdline.get_values("enforce-contract");
-    std::set<std::string> to_enforce =
-      process_function_list(enforce_list, "enforce-contract");
-    if (!ok)
-      return true;
-
-    if (!to_enforce.empty())
-    {
-      log_status("Enforcing contracts for {} function(s)", to_enforce.size());
-      // Pass --function entry point so the enforce wrapper allocates fresh
-      // backing storage for pointer params (harness receives nil args).
-      std::string entry_function =
-        cmdline.isset("function") ? cmdline.getval("function") : "";
-      // Assigns compliance check is always enabled: without it, functions can
-      // lie about their assigns clause, causing false VERIFICATION SUCCESSFUL.
-      contracts.enforce_contracts(to_enforce, entry_function, true);
-    }
-  }
-
-  // Process replace-call-with-contract option
-  if (has_replace)
-  {
-    const std::list<std::string> &replace_list =
-      cmdline.get_values("replace-call-with-contract");
-    std::set<std::string> to_replace =
-      process_function_list(replace_list, "replace-call-with-contract");
-    if (!ok)
-      return true;
-
-    if (!to_replace.empty())
-      contracts.replace_calls(to_replace);
-  }
-
   // Lambda to collect ONLY functions with __ESBMC_contract annotation
   auto collect_annotated_contract_functions =
     [&contracts, &goto_functions, &ctx]() {
@@ -170,31 +77,137 @@ bool esbmc_parseoptionst::process_function_contracts(
       return result;
     };
 
-  // Process --enforce-all-contracts
-  if (has_enforce_all)
-  {
-    std::set<std::string> to_enforce = collect_annotated_contract_functions();
-    if (!to_enforce.empty())
+  // Lambda function to process function list (handles "*" wildcard).
+  // \p named receives the names the user spelled out; "*" leaves it empty and
+  // discards any name spelled alongside it. Those names cannot be checked
+  // individually once "*" is in play: the wildcard resolves to full symbol IDs
+  // while the user spells short names, so comparing the two would reject every
+  // legitimate spelling. A misspelling next to "*" is therefore not diagnosed.
+  auto process_function_list = [&collect_functions_with_contracts](
+                                 const std::list<std::string> &func_list,
+                                 std::set<std::string> &named) {
+    std::set<std::string> result;
+    for (const auto &func : func_list)
     {
-      log_status(
-        "Enforcing annotated contracts for {} function(s)", to_enforce.size());
-      std::string entry_function =
-        cmdline.isset("function") ? cmdline.getval("function") : "";
-      contracts.enforce_contracts(to_enforce, entry_function, true);
+      if (func == "*")
+      {
+        // "*" means all functions with contracts
+        named.clear();
+        return collect_functions_with_contracts();
+      }
+      result.insert(func);
+      named.insert(func);
     }
-  }
+    return result;
+  };
 
-  // Process --replace-all-contracts
-  if (has_replace_all)
-  {
-    std::set<std::string> to_replace = collect_annotated_contract_functions();
-    if (!to_replace.empty())
+  // Reject a name no pass can act on, and treat selecting nothing at all as an
+  // error too. The reason comes from code_contractst::diagnose_contract_target,
+  // which is where both passes' eligibility rules live, so this cannot drift
+  // from what they will do -- and it is asked per option, because the two rules
+  // genuinely differ (a C++ id with parameters satisfies enforce and not
+  // replace).
+  auto check = [&contracts](
+                 const char *opt,
+                 const std::set<std::string> &named,
+                 const std::set<std::string> &resolved,
+                 bool for_replace,
+                 const char *nothing_selected) {
+    if (named.empty())
     {
-      log_status(
-        "Replacing annotated calls for {} function(s)", to_replace.size());
-      contracts.replace_calls(to_replace);
+      if (!resolved.empty())
+        return false;
+      log_error("--{}: {}", opt, nothing_selected);
+      return true;
     }
-  }
+
+    bool failed = false;
+    for (const auto &name : named)
+    {
+      std::string reason =
+        contracts.diagnose_contract_target(name, for_replace);
+      if (reason.empty())
+        continue;
+      log_error(
+        "--{}: cannot use '{}': {}{}",
+        opt,
+        name,
+        reason,
+        name.find(',') != std::string::npos
+          ? " (names are not comma-separated; repeat the flag once per "
+            "function, or use \"*\")"
+          : "");
+      failed = true;
+    }
+    return failed;
+  };
+
+  // Resolve every requested list first and validate all of them before any
+  // pass runs. enforce_contracts rewrites the functions it acts on into
+  // wrappers that carry no contract, so a check made afterwards would call a
+  // name that was used unusable, and would reject
+  // `--enforce-contract f --replace-call-with-contract "*"`, which is how four
+  // existing tests enforce one function and abstract the rest.
+  std::set<std::string> enforce_named, replace_named;
+  std::set<std::string> to_enforce, to_replace, annotated;
+
+  if (has_enforce)
+    to_enforce = process_function_list(
+      cmdline.get_values("enforce-contract"), enforce_named);
+  if (has_replace)
+    to_replace = process_function_list(
+      cmdline.get_values("replace-call-with-contract"), replace_named);
+  if (has_enforce_all || has_replace_all)
+    annotated = collect_annotated_contract_functions();
+
+  static const char *const no_contract =
+    "no function with a contract to act on";
+  static const char *const no_annotation =
+    "no function carries the __ESBMC_contract annotation";
+
+  bool failed = false;
+  if (has_enforce)
+    failed |=
+      check("enforce-contract", enforce_named, to_enforce, false, no_contract);
+  if (has_replace)
+    failed |= check(
+      "replace-call-with-contract",
+      replace_named,
+      to_replace,
+      true,
+      no_contract);
+  if (has_enforce_all)
+    failed |=
+      check("enforce-all-contracts", {}, annotated, false, no_annotation);
+  if (has_replace_all)
+    failed |=
+      check("replace-all-contracts", {}, annotated, true, no_annotation);
+
+  if (failed)
+    return true;
+
+  // Pass --function entry point so the enforce wrapper allocates fresh backing
+  // storage for pointer params (harness receives nil args).
+  const std::string entry_function =
+    cmdline.isset("function") ? cmdline.getval("function") : "";
+
+  // Assigns compliance check is always enabled: without it, functions can lie
+  // about their assigns clause, causing false VERIFICATION SUCCESSFUL.
+  if (has_enforce)
+    log_status(
+      "Enforcing contracts for {} function(s)",
+      contracts.enforce_contracts(to_enforce, entry_function, true).size());
+
+  if (has_replace)
+    contracts.replace_calls(to_replace);
+
+  if (has_enforce_all)
+    log_status(
+      "Enforcing annotated contracts for {} function(s)",
+      contracts.enforce_contracts(annotated, entry_function, true).size());
+
+  if (has_replace_all)
+    contracts.replace_calls(annotated);
 
   return false;
 }

--- a/src/esbmc/parseoptions/process_goto_program.cpp
+++ b/src/esbmc/parseoptions/process_goto_program.cpp
@@ -446,13 +446,15 @@ bool esbmc_parseoptionst::process_goto_program(
     bool has_replace = cmdline.isset("replace-call-with-contract");
     bool has_enforce_all = cmdline.isset("enforce-all-contracts");
     bool has_replace_all = cmdline.isset("replace-all-contracts");
-    if (has_enforce || has_replace || has_enforce_all || has_replace_all)
+    if (
+      (has_enforce || has_replace || has_enforce_all || has_replace_all) &&
       process_function_contracts(
         goto_functions,
         has_replace,
         has_enforce,
         has_enforce_all,
-        has_replace_all);
+        has_replace_all))
+      return true;
 
     // add re-evaluations of monitored properties
     add_property_monitors(goto_functions, ns);

--- a/src/esbmc/parseoptions/process_goto_program.cpp
+++ b/src/esbmc/parseoptions/process_goto_program.cpp
@@ -446,15 +446,16 @@ bool esbmc_parseoptionst::process_goto_program(
     bool has_replace = cmdline.isset("replace-call-with-contract");
     bool has_enforce_all = cmdline.isset("enforce-all-contracts");
     bool has_replace_all = cmdline.isset("replace-all-contracts");
-    if (
-      (has_enforce || has_replace || has_enforce_all || has_replace_all) &&
-      process_function_contracts(
-        goto_functions,
-        has_replace,
-        has_enforce,
-        has_enforce_all,
-        has_replace_all))
-      return true;
+    if (has_enforce || has_replace || has_enforce_all || has_replace_all)
+    {
+      if (process_function_contracts(
+            goto_functions,
+            has_replace,
+            has_enforce,
+            has_enforce_all,
+            has_replace_all))
+        return true;
+    }
 
     // add re-evaluations of monitored properties
     add_property_monitors(goto_functions, ns);

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -892,11 +892,12 @@ void code_contractst::havoc_static_globals(
   });
 }
 
-void code_contractst::enforce_contracts(
+std::set<std::string> code_contractst::enforce_contracts(
   const std::set<std::string> &to_enforce,
   const std::string &entry_function,
   bool check_assigns_compliance)
 {
+  std::set<std::string> enforced;
   for (const auto &function_name : to_enforce)
   {
     // Skip compiler-generated functions (destructors, constructors, exception handlers)
@@ -910,7 +911,9 @@ void code_contractst::enforce_contracts(
     symbolt *func_sym = find_function_symbol(function_name);
     if (func_sym == nullptr)
     {
-      log_warning("Function {} not found", function_name);
+      // Not necessarily absent: find_function_symbol also returns nullptr for
+      // an ambiguous short name, and logs which candidates it found.
+      log_warning("Could not resolve {} to a single function", function_name);
       continue;
     }
 
@@ -1144,9 +1147,11 @@ void code_contractst::enforce_contracts(
     goto_functions.function_map[original_id] = new_func;
 
     log_status("Enforced contract for function {}", function_name);
+    enforced.insert(function_name);
   }
 
   goto_functions.update();
+  return enforced;
 }
 
 /// Build `malloc(size_bytes)` typed as u8*, so the allocation is exactly
@@ -3728,11 +3733,52 @@ bool code_contractst::is_annotated_contract_function(
   return func_sym.get_type().get_bool("#annotated_contract");
 }
 
+std::string code_contractst::diagnose_contract_target(
+  const std::string &function_name,
+  bool for_replace)
+{
+  if (for_replace)
+  {
+    // Mirror replace_calls' selection below: a body-available function whose
+    // goto key matches the pattern, carrying a contract or the annotation.
+    bool any_match = false;
+    forall_goto_functions (it, goto_functions)
+    {
+      if (!it->second.body_available)
+        continue;
+      if (!matches_replace_pattern(id2string(it->first), {function_name}))
+        continue;
+      any_match = true;
+      symbolt *sym = context.find_symbol(it->first);
+      if (
+        has_contracts(it->second.body) ||
+        (sym && is_annotated_contract_function(*sym)))
+        return std::string();
+    }
+    return any_match ? "that function declares no contract clauses"
+                     : "no function of that name has a body here";
+  }
+
+  // Mirror enforce_contracts' gates.
+  if (is_compiler_generated(function_name))
+    return "that name is compiler-generated";
+
+  const symbolt *sym = find_function_symbol(function_name);
+  if (sym == nullptr)
+    return "no function of that name, or the name is ambiguous";
+
+  auto it = goto_functions.function_map.find(sym->id);
+  if (it == goto_functions.function_map.end() || !it->second.body_available)
+    return "that function is declared but has no body here";
+
+  if (!has_contracts(it->second.body) && !is_annotated_contract_function(*sym))
+    return "that function declares no contract clauses";
+
+  return std::string();
+}
+
 void code_contractst::replace_calls(const std::set<std::string> &to_replace)
 {
-  log_status(
-    "Replacing calls with contracts for {} function(s)", to_replace.size());
-
   // Build a map of function names to their symbols, bodies, and IDs for quick lookup
   // Key: function name (e.g., "increment")
   // Value: (symbol pointer, body pointer, function ID in goto_functions)
@@ -3778,6 +3824,10 @@ void code_contractst::replace_calls(const std::set<std::string> &to_replace)
 
   for (const auto &f : replaceable_funcs)
     log_debug("contracts", "  Replaceable: {}", f);
+
+  log_status(
+    "Replacing calls with contracts for {} function(s)",
+    replaceable_funcs.size());
 
   // Track functions to delete after replacement
   std::set<irep_idt> functions_to_delete;

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -83,7 +83,9 @@ public:
   ///        When non-empty AND matches the function being enforced, the wrapper
   ///        allocates fresh backing storage for all pointer parameters so that
   ///        the harness-generated nil args become valid dereferenceable objects.
-  void enforce_contracts(
+  /// \return The subset of \p to_enforce that was actually enforced. A name
+  ///         absent from the result named nothing this pass could act on.
+  std::set<std::string> enforce_contracts(
     const std::set<std::string> &to_enforce,
     const std::string &entry_function = "",
     bool check_assigns_compliance = false);
@@ -172,10 +174,23 @@ public:
   /// \return True if the function should be skipped (destructor, __cxa_*, etc.)
   bool is_compiler_generated(const std::string &function_name) const;
 
-  /// \brief Find function symbol
-  /// \param function_name Function name (can be full ID or simple name)
-  /// \return Pointer to function symbol, or nullptr if not found
-  symbolt *find_function_symbol(const std::string &function_name);
+  /// \brief Say why \p function_name cannot be used by a contract flag.
+  ///
+  /// The eligibility rules differ between the two passes and always have:
+  /// enforce_contracts resolves a name through find_function_symbol, while
+  /// replace_calls selects through matches_replace_pattern, which is why a
+  /// C++ id with parameters satisfies one and not the other. This method is
+  /// the single place both rules live, so a caller can ask the same question
+  /// the pass will ask, and get the same answer.
+  ///
+  /// Call it before any pass runs: enforce_contracts rewrites the functions it
+  /// acts on into wrappers that carry no contract, so asking afterwards
+  /// reports a name that was used as unusable.
+  ///
+  /// \param for_replace Ask replace_calls' rule rather than enforce's
+  /// \return The reason, or an empty string when the name is usable
+  std::string
+  diagnose_contract_target(const std::string &function_name, bool for_replace);
 
 private:
   goto_functionst &goto_functions;
@@ -197,6 +212,11 @@ private:
   /// and produce the spurious "array bounds violated" of #5314, so prefer a
   /// recorded extent whenever one exists.
   static constexpr size_t WITNESS_IDX_FALLBACK_ELEMS = 100;
+
+  /// \brief Find function symbol
+  /// \param function_name Function name (can be full ID or simple name)
+  /// \return Pointer to function symbol, or nullptr if not found
+  symbolt *find_function_symbol(const std::string &function_name);
 
   /// \brief Rename function
   /// \param old_id Original function ID

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -172,6 +172,11 @@ public:
   /// \return True if the function should be skipped (destructor, __cxa_*, etc.)
   bool is_compiler_generated(const std::string &function_name) const;
 
+  /// \brief Find function symbol
+  /// \param function_name Function name (can be full ID or simple name)
+  /// \return Pointer to function symbol, or nullptr if not found
+  symbolt *find_function_symbol(const std::string &function_name);
+
 private:
   goto_functionst &goto_functions;
   contextt &context;
@@ -192,11 +197,6 @@ private:
   /// and produce the spurious "array bounds violated" of #5314, so prefer a
   /// recorded extent whenever one exists.
   static constexpr size_t WITNESS_IDX_FALLBACK_ELEMS = 100;
-
-  /// \brief Find function symbol
-  /// \param function_name Function name (can be full ID or simple name)
-  /// \return Pointer to function symbol, or nullptr if not found
-  symbolt *find_function_symbol(const std::string &function_name);
 
   /// \brief Rename function
   /// \param old_id Original function ID


### PR DESCRIPTION
## The problem

Every contract flag silently accepted a name it could not act on, did nothing, and still printed a verdict. `esbmc x.c --replace-call-with-contract typo` reported `VERIFICATION SUCCESSFUL` for a run that verified the program with no contract applied at all. The same held for a name with no body, a name with no contract, a comma-separated list, a C++ id with parameters, `"*"` on a file whose contract macros did not survive preprocessing, and both `--*-all-contracts` flags.

Fixes #6498.

## The change

One eligibility rule, `code_contractst::diagnose_contract_target`, asked once for every flag **before any pass runs**.

It is asked per option, because the two passes' rules genuinely differ and always have: `enforce_contracts` resolves through `find_function_symbol`, `replace_calls` selects through `matches_replace_pattern`. A C++ free function `int fst(int)` has the id `c:@F@fst#I#`, whose tail after the last `@` with one trailing `#` stripped is `fst#I`, not `fst` — so it satisfies enforce and not replace. That divergence is why #6498 stayed open for C++ after the first attempt here, and asking the right rule per option is what closes it.

Checking before any pass runs is not a style preference. `enforce_contracts` rewrites the functions it acts on into wrappers that carry no contract, so a check made afterwards calls a name that *was* used unusable. It rejects `--enforce-contract f --replace-call-with-contract "*"` — the shape four existing tests use — and rejects two valid spellings of one function.

Also here:

- `replace_calls` reports the count it acted on rather than the count requested, and emits that line once instead of twice. `contract_fn_name_repeated` can then assert it and mean something.
- The diagnostics no longer contradict each other on an ambiguous C++ name: the cause is reported by the code that knows it, and the caller's line does not restate a different one.
- `find_function_symbol` stays private.

## Behaviour

```
$ esbmc x.c --replace-call-with-contract typo
ERROR: --replace-call-with-contract: cannot use 'typo': no function of that name has a body here

$ esbmc x.c --replace-call-with-contract f,g
ERROR: --replace-call-with-contract: cannot use 'f,g': no function of that name has a body here (names are not comma-separated; repeat the flag once per function, or use "*")

$ esbmc x.cpp --replace-call-with-contract fst        # int fst(int)
ERROR: --replace-call-with-contract: cannot use 'fst': no function of that name has a body here

$ esbmc nc.c --replace-call-with-contract "*"         # no contracts in the file
ERROR: --replace-call-with-contract: no function with a contract to act on

$ esbmc x.c --enforce-all-contracts                   # contracts, but none annotated
ERROR: --enforce-all-contracts: no function carries the __ESBMC_contract annotation
```

No verdict is printed in any of these, and the exit status is 6.

## Tests

Nine under `regression/function_contract/`: `contract_fn_name_unknown`, `_comma`, `_enforce_unknown`, `_no_body`, `_no_contract`, `_repeated`, `_star_no_contract`, `_all_no_annotation`, and `_cpp_paramspp`, the last pinning the C++ case above. Each error test asserts the exact message **and** `\A(?!(.|\n)*VERIFICATION)`, so a run that prints the error and then goes on to a verdict fails the test — the runner does not consult the exit status, so the absence of a verdict has to be asserted positively.

`ctest -L function_contract` 314/314, `ctest -L loop-invariants` 73/73.

## Known and deliberate

- **A misspelling next to `"*"` is not diagnosed.** `--replace-call-with-contract typo --replace-call-with-contract "*"` runs without complaint, in either order. The wildcard resolves to full symbol ids while users spell short names, so the two cannot be compared without rejecting every legitimate spelling.
- **A name whose only contract is `__ESBMC_assigns()` is now rejected** rather than silently ignored. `has_contracts` does not recognise `contract::assigns_empty`, although `contracts.cpp` handles that comment elsewhere, so an empty frame condition has never actually worked. Surfacing it is an improvement over silence; making it work is a separate change and I will file it.
- **A name that resolves to a contracted function with no call site is accepted.** Replacing calls where there are none is not a usage error, and erroring would break `"*"` over a file with unreachable code.
