### PR TITLE
[contracts] reconstruct conditional ensures instead of picking an arm

### DIFF
--- a/regression/function_contract/github_6499_ternary_old_fail/main.c
+++ b/regression/function_contract/github_6499_ternary_old_fail/main.c
@@ -1,0 +1,15 @@
+int g;
+
+void f(int c)
+{
+  __ESBMC_requires(c == 1);
+  __ESBMC_assigns(g);
+  /* c is 1, so the then-arm applies. It is FALSE: g becomes 0, not 99.
+     The else-arm is a tautology. A correct reconstruction must FAIL. */
+  __ESBMC_ensures(
+    c ? (g == 99 && __ESBMC_old(g) == __ESBMC_old(g))
+      : (__ESBMC_old(g) == __ESBMC_old(g)));
+  g = 0;
+}
+
+int main(void) { return 0; }

--- a/regression/function_contract/github_6499_ternary_old_fail/test.desc
+++ b/regression/function_contract/github_6499_ternary_old_fail/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--function f --enforce-contract f
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_6499_ternary_old_fail/test.desc
+++ b/regression/function_contract/github_6499_ternary_old_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --function f --enforce-contract f
 ^VERIFICATION FAILED$

--- a/regression/function_contract/replace_ternary_ensures_knownbug/main.c
+++ b/regression/function_contract/replace_ternary_ensures_knownbug/main.c
@@ -1,10 +1,7 @@
-/* replace_ternary_ensures_knownbug (issue #6298):
- * The recursive flattening only descends &&/|| trees, not a ternary (?:)
- * ensures. A ternary is lowered soundly (the unsound-if-passed t==1 case is
- * correctly rejected) but imprecisely: the else-branch old() constraints are
- * not recovered, so this correct program is spuriously rejected. The desired
- * result is VERIFICATION SUCCESSFUL; until ternary ensures are flattened it is
- * absent (VERIFICATION FAILED), so this is pinned KNOWNBUG.
+/* replace_ternary_ensures (issue #6298, fixed by #6499):
+ * A ternary ensures used to be reconstructed as its else-arm alone, so the
+ * then-arm and the guard were lost and this correct program was spuriously
+ * rejected. Reconstructing the conditional recovers both arms.
  */
 #include <stddef.h>
 

--- a/regression/function_contract/replace_ternary_ensures_knownbug/test.desc
+++ b/regression/function_contract/replace_ternary_ensures_knownbug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --replace-call-with-contract f
 ^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/ring_enforce_process_messages/test.desc
+++ b/regression/function_contract/ring_enforce_process_messages/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---enforce-contract process_messages_at_time --replace-call-with-contract "source_reaction_in,node_reaction" --no-align-check
+--enforce-contract process_messages_at_time --replace-call-with-contract source_reaction_in --replace-call-with-contract node_reaction --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/ring_loop_with_contract/test.desc
+++ b/regression/loop-invariants/ring_loop_with_contract/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---loop-invariant --replace-call-with-contract "source_startup,source_reaction_start,source_reaction_in,node_reaction,process_messages_at_time" --no-align-check
+--loop-invariant --replace-call-with-contract source_startup --replace-call-with-contract source_reaction_start --replace-call-with-contract source_reaction_in --replace-call-with-contract node_reaction --replace-call-with-contract process_messages_at_time --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -309,6 +309,153 @@ static std::vector<var_assignment_info> find_all_assignments(
   return assignments;
 }
 
+/// Reconstruct the value a temporary holds at \p use, by walking forward over
+/// the region between its declaration and \p use and tracking the path
+/// condition under which each assignment reaches that point.
+///
+/// Clang lowers a conditional whose arms contain calls -- in an ensures clause
+/// that means __ESBMC_old -- into a temporary written on both arms:
+///
+///     ASSIGN v = NONDET
+///     IF !G THEN GOTO L
+///     ASSIGN v = <then>
+///     GOTO M
+///   L:
+///     ASSIGN v = <else>
+///   M: <use of v>
+///
+/// Picking one assignment loses the guard and the other arm, which yields an
+/// ensures that is neither what was written nor a safe approximation of it: it
+/// can be stronger (a false failure) or weaker (a false VERIFICATION
+/// SUCCESSFUL). See #6499. Folding the reaching assignments back into an
+/// if-then-else recovers the clause exactly.
+///
+/// \return The reconstructed value, or nil when the region is not a
+///         forward-only DAG. Nil means "cannot reconstruct", never "no value":
+///         callers must diagnose rather than fall back to a guess.
+static expr2tc reconstruct_conditional_value(
+  const irep_idt &var_name,
+  const goto_programt &body,
+  const goto_programt::const_targett &use)
+{
+  // Region start: the variable's declaration, or the start of the body.
+  goto_programt::const_targett start = body.instructions.begin();
+  for (goto_programt::const_targett it = use; it != body.instructions.begin();)
+  {
+    --it;
+    if (it->is_decl() && is_code_decl2t(it->code))
+      if (to_code_decl2t(it->code).value == var_name)
+      {
+        start = it;
+        break;
+      }
+  }
+
+  // Index the region so branch targets can be ordered against it.
+  std::vector<goto_programt::const_targett> region;
+  std::map<const goto_programt::instructiont *, size_t> index;
+  for (goto_programt::const_targett it = start; it != use; ++it)
+  {
+    index[&*it] = region.size();
+    region.push_back(it);
+  }
+  index[&*use] = region.size();
+  region.push_back(use);
+
+  // (path condition, value) pairs reaching each point. A nil value means the
+  // variable is not yet assigned on that path. Paths carrying the same value
+  // are merged on arrival: without that the list doubles at every branch, and
+  // a clause with a handful of nested conditionals exhausts memory.
+  std::vector<std::vector<std::pair<expr2tc, expr2tc>>> reaching(region.size());
+  auto push = [&reaching](size_t at, const expr2tc &pc, const expr2tc &val) {
+    for (auto &e : reaching[at])
+      if (e.second == val)
+      {
+        e.first = or2tc(e.first, pc);
+        return true;
+      }
+    // A clause needing more distinct values than this is beyond what a linear
+    // fold should be trusted with; the caller diagnoses rather than guesses.
+    if (reaching[at].size() >= 32)
+      return false;
+    reaching[at].emplace_back(pc, val);
+    return true;
+  };
+  reaching[0].emplace_back(gen_true_expr(), expr2tc());
+
+  for (size_t i = 0; i + 1 < region.size(); ++i)
+  {
+    if (reaching[i].empty())
+      continue;
+
+    goto_programt::const_targett it = region[i];
+
+    // An assignment to the variable replaces the value on every path here.
+    std::vector<std::pair<expr2tc, expr2tc>> out = reaching[i];
+    if (it->is_assign() && is_code_assign2t(it->code))
+    {
+      const code_assign2t &a = to_code_assign2t(it->code);
+      if (is_symbol2t(a.target) && to_symbol2t(a.target).thename == var_name)
+      {
+        // Expand the right-hand side once, here, so the two arms of the
+        // if-then-else below share it. Leaving it to the caller re-expands
+        // every nested temporary once per arm, and the clause grows
+        // exponentially in its nesting depth.
+        expr2tc v = inline_temporary_variables(a.source, body, it);
+        for (auto &p : out)
+          p.second = v;
+      }
+    }
+
+    if (!it->is_goto())
+    {
+      for (auto &p : out)
+        if (!push(i + 1, p.first, p.second))
+          return expr2tc();
+      continue;
+    }
+
+    // Only forward branches with a single in-region target are handled. A
+    // backwards branch is a loop, which this linear fold cannot express.
+    if (it->is_backwards_goto() || it->targets.size() != 1)
+      return expr2tc();
+    auto tgt = index.find(&*it->targets.front());
+    if (tgt == index.end() || tgt->second <= i)
+      return expr2tc();
+
+    bool unconditional =
+      is_constant_bool2t(it->guard) && to_constant_bool2t(it->guard).is_true();
+    for (auto &p : out)
+    {
+      if (unconditional)
+      {
+        if (!push(tgt->second, p.first, p.second))
+          return expr2tc();
+        continue;
+      }
+      expr2tc g = inline_temporary_variables(it->guard, body, it);
+      if (
+        !push(tgt->second, and2tc(p.first, g), p.second) ||
+        !push(i + 1, and2tc(p.first, not2tc(g)), p.second))
+        return expr2tc();
+    }
+  }
+
+  // Fold the paths that define the variable into nested if-then-elses.
+  expr2tc result;
+  for (const auto &p : reaching.back())
+  {
+    if (is_nil_expr(p.second))
+      continue;
+    expr2tc guard = p.first;
+    simplify(guard);
+    result = is_nil_expr(result)
+               ? p.second
+               : if2tc(p.second->type, guard, p.second, result);
+  }
+  return result;
+}
+
 // Helper function to inline temporary variables generated by Clang for short-circuit evaluation
 // When ensures contains complex expressions like (a && b) || (c && d) with __ESBMC_old calls,
 // Clang generates control flow with temporary variables (tmp$1, tmp$2, etc).
@@ -391,9 +538,22 @@ static expr2tc inline_temporary_variables(
       //   tmp$7 = 1           (when first branch succeeds - short circuit)
       //   tmp$7 = tmp$6 ? 1:0 (when first branch fails, use second branch result)
       //
-      // We need to find the meaningful assignment that captures the full expression.
-      // Skip: NONDET (initialization), constants 0/1 (short-circuit markers)
-      // Keep: expressions that reference other temporaries (these capture the logic)
+      // Fold the assignments back into an if-then-else under the guards that
+      // select them, rather than choosing one and discarding the rest (#6499).
+      expr2tc folded = reconstruct_conditional_value(
+        sym.thename, function_body, assume_location);
+      if (!is_nil_expr(folded))
+        return folded;
+
+      // Reconstruction failed, so any value chosen here would be a guess that
+      // is neither the written clause nor a safe approximation of it.
+      log_error(
+        "cannot reconstruct the contract clause holding '{}': its control flow "
+        "is not a forward-only region. Rewrite the clause without a "
+        "conditional or short-circuit operator around __ESBMC_old.",
+        sym_name);
+      abort();
+
       expr2tc best_value;
       goto_programt::const_targett best_location =
         function_body.instructions.end();


### PR DESCRIPTION
Fixes #6499.

## What was wrong

`inline_temporary_variables` (`contracts.cpp:320`) resolved a temporary with several assignments by walking `find_all_assignments`, skipping the `NONDET` initialiser and the constant 0/1 short-circuit markers, then taking the **first of the rest** and breaking.

Clang lowers a conditional whose arms contain calls into a temporary written on both arms. In an `ensures` clause the call that triggers this is `__ESBMC_old`:

```
ASSIGN tmp$11 = NONDET
IF !<guard> THEN GOTO 1
ASSIGN tmp$11 = <then-value>
GOTO 6
1: ASSIGN tmp$11 = <else-value>
6: <use>
```

`find_all_assignments` scans **backwards** with no control-flow awareness, so the first non-trivial assignment it meets is always the else-arm. A ternary `ensures` was therefore replaced by its else branch and the guard discarded. `var_assignment_info` even reserves a `condition` field for this, filled in as `expr2tc(); // Will be filled later if needed` and never populated.

The result is neither the written clause nor a safe approximation of it, so it errs in both directions:

- else-arm stronger than the clause: false failure. That is how this surfaced, on `ring_enforce_process_messages`.
- else-arm weaker: the clause goes vacuous and a violated contract passes. That is the reproducer:

```c
int g;
void f(int c)
{
  __ESBMC_requires(c == 1);
  __ESBMC_assigns(g);
  __ESBMC_ensures(
    c ? (g == 99 && __ESBMC_old(g) == __ESBMC_old(g))
      : (__ESBMC_old(g) == __ESBMC_old(g)));
  g = 0;
}
```

`c` is 1, so the then-arm applies and it is false. Before: `VERIFICATION SUCCESSFUL`, asserting `old_snapshot_f_wrapper_0 == old_snapshot_f_wrapper_0`. After: `VERIFICATION FAILED`.

A ternary with plain arms was always fine, because Clang keeps it as a conditional expression and never introduces the temporary. Adding `&&` or `||` is not enough either. It takes a call in an arm, which is why #6298's fix did not reach this and why it survived: the shape needs a conditional *and* `old()`.

## The fix

`reconstruct_conditional_value` walks the region between the temporary's declaration and its use, tracks the path condition under which each assignment reaches that use, and folds them into an if-then-else.

Two things were necessary and I only found the second by measuring:

- **Paths carrying the same value merge on arrival.** Enumerating them doubles the state at every branch; `ring_enforce_process_messages` has enough nesting to exhaust memory.
- **Right-hand sides are expanded where they are read, not by the caller.** Otherwise both arms re-expand the nested temporaries independently and the clause grows exponentially in its nesting depth. My first attempt did the expansion in the caller and segfaulted inside `expr2t::simplify`, walking the result.

Reconstruction handles forward-only regions. A backwards branch, an out-of-region target or more than 32 distinct values returns nil, which is reported rather than falling back to a guess. Guessing is what this PR removes.

## Tests

- `github_6499_ternary_old_fail` — the false-success reproducer above, `CORE`.
- `replace_ternary_ensures_knownbug` — **pinned `KNOWNBUG` since #6298 for exactly this gap** ("the recursive flattening only descends `&&`/`||` trees, not a ternary"). It now passes, and is promoted to `CORE`. An independently written test that was parked for this deficiency is the strongest check available that the fix is the right one.
- `ring_enforce_process_messages` and `ring_loop_with_contract` — restored from the comma-separated argument, which silently replaced nothing (#6498), to the repeated-flag form they were written for. Both verify.

27 tests across `function_contract` and `loop-invariants` pair a conditional or short-circuit `ensures` with `__ESBMC_old`, so they all take the rewritten path. `function_contract` + `loop-invariants` 363/363, unit tests 584/584.

Note `or_ensures_vacuous_pass` still passes and should: its vacuity is genuine `||` semantics, with the left disjunct implied by the `requires`, not this defect.

## Interaction with #6502

#6502 demotes the two ring tests to `KNOWNBUG` against this issue, because correcting their syntax there makes them fail. This removes the cause, so they are restored to `CORE` here. Whichever merges second will conflict on those two `test.desc` files; the resolution is the version in this PR.
