### PR TITLE
[goto-symex] Make --no-propagation disable constant propagation

### DIFF
--- a/regression/esbmc/no_propagation_01/main.c
+++ b/regression/esbmc/no_propagation_01/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int x = 42;
+  int y = x + 1;
+  __ESBMC_assert(y == 43, "y is 43");
+  return 0;
+}

--- a/regression/esbmc/no_propagation_01/test.desc
+++ b/regression/esbmc/no_propagation_01/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^Generated 1 VCC\(s\), 0 remaining after simplification
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_propagation_02/main.c
+++ b/regression/esbmc/no_propagation_02/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int x = 42;
+  int y = x + 1;
+  __ESBMC_assert(y == 43, "y is 43");
+  return 0;
+}

--- a/regression/esbmc/no_propagation_02/test.desc
+++ b/regression/esbmc/no_propagation_02/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-propagation
+^Generated 1 VCC\(s\), 1 remaining after simplification
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_propagation_03_unsafe/main.c
+++ b/regression/esbmc/no_propagation_03_unsafe/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int a[4];
+  int i = 3;
+  int j = i + 1;
+  a[j] = 0;
+  return 0;
+}

--- a/regression/esbmc/no_propagation_03_unsafe/test.desc
+++ b/regression/esbmc/no_propagation_03_unsafe/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-propagation
+^Generated 2 VCC\(s\), 2 remaining after simplification
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -914,7 +914,10 @@ const struct group_opt_templ all_cmd_options[] = {
      "Configure time limit, integer followed by {s,m,h}"},
     {"enable-core-dump", NULL, "Do not disable core dump output"},
     {"no-simplify", NULL, "Do not simplify any expression"},
-    {"no-propagation", NULL, "Disable constant propagation"},
+    {"no-propagation",
+     NULL,
+     "Disable constant propagation (unsupported with concurrency: the pthread "
+     "model requires constant thread ids)"},
     {"gcse",
      NULL,
      "Adds intermediate variables to precompute common sub-expressions between "

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -55,7 +55,11 @@ execution_statet::execution_statet(
   const goto_programt *goto_program = &(it->second.body);
 
   // Initialize initial thread state
-  goto_symex_statet state(*state_level2, global_value_set, ns);
+  goto_symex_statet state(
+    *state_level2,
+    global_value_set,
+    ns,
+    options.get_bool_option("no-propagation"));
   state.initialize(
     (*goto_program).instructions.begin(),
     (*goto_program).instructions.end(),
@@ -665,7 +669,11 @@ void execution_statet::execute_guard()
 
 unsigned int execution_statet::add_thread(const goto_programt *prog)
 {
-  goto_symex_statet new_state(*state_level2, global_value_set, ns);
+  goto_symex_statet new_state(
+    *state_level2,
+    global_value_set,
+    ns,
+    options.get_bool_option("no-propagation"));
   new_state.initialize(
     prog->instructions.begin(),
     prog->instructions.end(),

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -43,6 +43,7 @@ execution_statet::execution_statet(
   symex_trace = options.get_bool_option("symex-trace");
   smt_during_symex = options.get_bool_option("smt-during-symex");
   smt_thread_guard = options.get_bool_option("smt-thread-guard");
+  no_propagation = options.get_bool_option("no-propagation");
 
   goto_functionst::function_mapt::const_iterator it =
     goto_functions.function_map.find("__ESBMC_main");
@@ -55,11 +56,7 @@ execution_statet::execution_statet(
   const goto_programt *goto_program = &(it->second.body);
 
   // Initialize initial thread state
-  goto_symex_statet state(
-    *state_level2,
-    global_value_set,
-    ns,
-    options.get_bool_option("no-propagation"));
+  goto_symex_statet state(*state_level2, global_value_set, ns, no_propagation);
   state.initialize(
     (*goto_program).instructions.begin(),
     (*goto_program).instructions.end(),
@@ -158,6 +155,7 @@ void execution_statet::copy_derived_from(const execution_statet &ex)
   symex_trace = ex.symex_trace;
   smt_during_symex = ex.smt_during_symex;
   smt_thread_guard = ex.smt_thread_guard;
+  no_propagation = ex.no_propagation;
 
   CS_number = ex.CS_number;
 
@@ -670,10 +668,7 @@ void execution_statet::execute_guard()
 unsigned int execution_statet::add_thread(const goto_programt *prog)
 {
   goto_symex_statet new_state(
-    *state_level2,
-    global_value_set,
-    ns,
-    options.get_bool_option("no-propagation"));
+    *state_level2, global_value_set, ns, no_propagation);
   new_state.initialize(
     prog->instructions.begin(),
     prog->instructions.end(),

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -635,6 +635,10 @@ protected:
   /** Are we evaluating the thread guard in the SMT solver during context
    *  switching? */
   bool smt_thread_guard;
+  /** Was constant propagation disabled with --no-propagation? Seeds every
+   *  thread's goto_symex_statet, so the option is looked up once per run
+   *  rather than once per thread creation. */
+  bool no_propagation;
 
   /** Copy execution_statet's own scheduling fields from `ex`. The base
    *  goto_symext slice is left untouched (the copy constructor's

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -1298,8 +1298,6 @@ protected:
    *  --no-interval-symex-guard); assertion pruning via --interval-symex-assert
    *  discharges claims proven TRUE. */
   std::optional<interval_domaint> interval_domain_state;
-  /** Whether constant propagation is to be enabled. */
-  bool constant_propagation;
   /** Namespace we're working in. */
   const namespacet &ns;
   /** Context we're working with */

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -13,8 +13,9 @@
 goto_symex_statet::goto_symex_statet(
   renaming::level2t &l2,
   value_sett &vs,
-  const namespacet &_ns)
-  : level2(l2), value_set(vs), ns(_ns)
+  const namespacet &_ns,
+  bool no_propagation)
+  : no_propagation(no_propagation), level2(l2), value_set(vs), ns(_ns)
 {
   use_value_set = true;
   num_instructions = 0;
@@ -44,6 +45,7 @@ goto_symex_statet &goto_symex_statet::operator=(const goto_symex_statet &state)
   loop_iterations = state.loop_iterations;
   function_unwind = state.function_unwind;
   use_value_set = state.use_value_set;
+  no_propagation = state.no_propagation;
   call_stack = state.call_stack;
   witness_segs = state.witness_segs;
   cur_seg = state.cur_seg;
@@ -97,6 +99,9 @@ static bool type_has_constant_size(const type2tc &type)
 
 bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
 {
+  if (no_propagation)
+    return false;
+
   if (is_array_type(expr))
   {
     array_type2t arr = to_array_type(expr->type);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -45,11 +45,13 @@ public:
    *  and value set / pointer tracking situations.
    *  @param l2 Global L2 state reference.
    *  @param vs Global value set reference.
+   *  @param no_propagation Value of --no-propagation, from the live optionst.
    */
   goto_symex_statet(
     renaming::level2t &l2,
     value_sett &vs,
-    const namespacet &_ns);
+    const namespacet &_ns,
+    bool no_propagation);
 
   /**
    *  Copy constructor.
@@ -459,6 +461,10 @@ public:
 
   /** Flag saying whether to maintain pointer value set tracking. */
   bool use_value_set;
+  /** Flag saying constant propagation was disabled with --no-propagation.
+   *  Cached because constant_propagation() runs on every assignment and
+   *  get_bool_option does a string-keyed map lookup. */
+  bool no_propagation = false;
   /** Reference to global l2 state. */
   renaming::level2t &level2;
   /** Reference to global pointer tracking state. */

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -26,7 +26,6 @@ goto_symext::goto_symext(
     remaining_claims(0),
     simplified_claims(0),
     max_unwind(options.get_option("unwind").c_str()),
-    constant_propagation(!options.get_bool_option("no-propagation")),
     ns(_ns),
     new_context(_new_context),
     goto_functions(_goto_functions),
@@ -180,7 +179,6 @@ goto_symext &goto_symext::operator=(const goto_symext &sym)
   unwind_func_set = sym.unwind_func_set;
   loop_id_to_func_index = sym.loop_id_to_func_index;
   max_unwind = sym.max_unwind;
-  constant_propagation = sym.constant_propagation;
   total_claims = sym.total_claims;
   remaining_claims = sym.remaining_claims;
   simplified_claims = sym.simplified_claims;


### PR DESCRIPTION
`--no-propagation` has been inert since 148700569a (2019): it set `goto_symext::constant_propagation`, a bool nothing ever read, so the flag silently changed nothing.
Take it from the live `optionst` at state construction and bail out of `goto_symex_statet::constant_propagation()` — reading `config.options` would miss it, since that is a snapshot taken before `process_goto_program` mutates the options, which is exactly how the commented-out `set_option("no-propagation", true)` at `process_goto_program.cpp:540` would have been dropped.
This restores the flag as an oracle for correctness that must not depend on propagation; #6464 was found with it, and #6470 discusses why that oracle was needed.
Three tests: two pinning that the flag changes the SSA without changing the verdict, one that a real bug is still caught under it.
