### PR TITLE
[pointer-analysis] Add the same-object guard to byte-array bounds

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/main.cpp
@@ -1,0 +1,55 @@
+// github #6464: placement-new into malloc'd storage was reported as an
+// out-of-bounds heap write under --incremental-bmc and --k-induction, but only
+// when a second malloc sits on a guarded path. Clean under clang++ -std=c++17
+// -fsanitize=address,undefined.
+#include <new>
+#include <cstdlib>
+
+struct Elem
+{
+  char a[8];
+};
+
+struct Holder
+{
+  Elem *buf;
+  int n;
+  int cap;
+
+  Holder()
+  {
+    buf = (Elem *)malloc(sizeof(Elem) * 10);
+    if (!buf)
+      abort();
+    n = 0;
+    cap = 10;
+  }
+
+  // Never executed (n is 0, cap is 10); its mere presence is what triggered
+  // the false positive.
+  void grow()
+  {
+    Elem *nb = (Elem *)malloc(sizeof(Elem) * 20);
+    if (!nb)
+      abort();
+    buf = nb;
+    cap = 20;
+  }
+
+  void add(const Elem &x)
+  {
+    if (n == cap)
+      grow();
+    new (buf + n) Elem(x);
+    n++;
+  }
+};
+
+int main()
+{
+  Holder h;
+  Elem e;
+  e.a[0] = 1;
+  h.add(e);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6464_placement_new_incremental/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_6464_merged_pointer_bounds/main.c
+++ b/regression/esbmc/github_6464_merged_pointer_bounds/main.c
@@ -1,0 +1,36 @@
+// github #6464: the bounds check for a pointer reconstructed from a byte array
+// was emitted without the caller's same-object guard, so a second heap object
+// reachable only on a never-taken branch made the access unprovable. Clean
+// under clang -fsanitize=address,undefined.
+//
+// --no-propagation is load-bearing: with propagation on, the merge folds away
+// before the check is built and the defect is invisible. Do not drop the flag.
+#include <stdlib.h>
+
+struct Elem
+{
+  char a[8];
+};
+
+int main()
+{
+  struct Elem *buf;
+  int n = 0, cap = 10;
+
+  buf = (struct Elem *)malloc(sizeof(struct Elem) * 10);
+  if (!buf)
+    abort();
+
+  if (n == cap) // never taken
+  {
+    struct Elem *nb = (struct Elem *)malloc(sizeof(struct Elem) * 20);
+    if (!nb)
+      abort();
+    buf = nb;
+  }
+
+  struct Elem e;
+  e.a[0] = 1;
+  *(buf + n) = e;
+  return 0;
+}

--- a/regression/esbmc/github_6464_merged_pointer_bounds/test.desc
+++ b/regression/esbmc/github_6464_merged_pointer_bounds/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-propagation
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_6464_merged_pointer_bounds_fail/main.c
+++ b/regression/esbmc/github_6464_merged_pointer_bounds_fail/main.c
@@ -1,0 +1,35 @@
+// github #6464 (negative): the branch *is* taken and the write really is out of
+// bounds of the object the pointer ends up at (aborts under
+// clang -fsanitize=address). This pins end-to-end detection over the same
+// merged-pointer shape as the positive tests; the claim it trips comes from
+// bounds_check via build_reference_to, not from the guarded site itself.
+#include <stdlib.h>
+
+struct Elem
+{
+  char a[8];
+};
+
+int main()
+{
+  struct Elem *buf;
+  int n = 0, cap = 0;
+
+  buf = (struct Elem *)malloc(sizeof(struct Elem) * 10);
+  if (!buf)
+    abort();
+
+  if (n == cap) // taken
+  {
+    struct Elem *nb = (struct Elem *)malloc(sizeof(struct Elem) * 1);
+    if (!nb)
+      abort();
+    buf = nb;
+    n = 5;
+  }
+
+  struct Elem e;
+  e.a[0] = 1;
+  *(buf + n) = e;
+  return 0;
+}

--- a/regression/esbmc/github_6464_merged_pointer_bounds_fail/test.desc
+++ b/regression/esbmc/github_6464_merged_pointer_bounds_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-propagation
+^VERIFICATION FAILED$
+^.*dereference failure: array bounds violated: heap object$

--- a/regression/esbmc/github_6464_struct_field_pointer/main.c
+++ b/regression/esbmc/github_6464_struct_field_pointer/main.c
@@ -1,0 +1,41 @@
+// github #6464: same defect reached through a pointer held in a struct field,
+// which --incremental-bmc exposes because it does not constant-propagate WITH
+// chains. Clean under clang -fsanitize=address,undefined.
+#include <stdlib.h>
+
+struct Elem
+{
+  char a[8];
+};
+
+struct Holder
+{
+  struct Elem *buf;
+  int n;
+  int cap;
+};
+
+int main()
+{
+  struct Holder h;
+
+  h.buf = (struct Elem *)malloc(sizeof(struct Elem) * 10);
+  if (!h.buf)
+    abort();
+  h.n = 0;
+  h.cap = 10;
+
+  if (h.n == h.cap) // never taken
+  {
+    struct Elem *nb = (struct Elem *)malloc(sizeof(struct Elem) * 20);
+    if (!nb)
+      abort();
+    h.buf = nb;
+    h.cap = 20;
+  }
+
+  struct Elem e;
+  e.a[0] = 1;
+  *(h.buf + h.n) = e;
+  return 0;
+}

--- a/regression/esbmc/github_6464_struct_field_pointer/test.desc
+++ b/regression/esbmc/github_6464_struct_field_pointer/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_propagation_01/main.c
+++ b/regression/esbmc/no_propagation_01/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int x = 42;
+  int y = x + 1;
+  __ESBMC_assert(y == 43, "y is 43");
+  return 0;
+}

--- a/regression/esbmc/no_propagation_01/test.desc
+++ b/regression/esbmc/no_propagation_01/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^Generated 1 VCC\(s\), 0 remaining after simplification
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_propagation_02/main.c
+++ b/regression/esbmc/no_propagation_02/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int x = 42;
+  int y = x + 1;
+  __ESBMC_assert(y == 43, "y is 43");
+  return 0;
+}

--- a/regression/esbmc/no_propagation_02/test.desc
+++ b/regression/esbmc/no_propagation_02/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-propagation
+^Generated 1 VCC\(s\), 1 remaining after simplification
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_propagation_03_unsafe/main.c
+++ b/regression/esbmc/no_propagation_03_unsafe/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int a[4];
+  int i = 3;
+  int j = i + 1;
+  a[j] = 0;
+  return 0;
+}

--- a/regression/esbmc/no_propagation_03_unsafe/test.desc
+++ b/regression/esbmc/no_propagation_03_unsafe/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-propagation
+^Generated 2 VCC\(s\), 2 remaining after simplification
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -914,7 +914,10 @@ const struct group_opt_templ all_cmd_options[] = {
      "Configure time limit, integer followed by {s,m,h}"},
     {"enable-core-dump", NULL, "Do not disable core dump output"},
     {"no-simplify", NULL, "Do not simplify any expression"},
-    {"no-propagation", NULL, "Disable constant propagation"},
+    {"no-propagation",
+     NULL,
+     "Disable constant propagation (unsupported with concurrency: the pthread "
+     "model requires constant thread ids)"},
     {"gcse",
      NULL,
      "Adds intermediate variables to precompute common sub-expressions between "

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -55,7 +55,11 @@ execution_statet::execution_statet(
   const goto_programt *goto_program = &(it->second.body);
 
   // Initialize initial thread state
-  goto_symex_statet state(*state_level2, global_value_set, ns);
+  goto_symex_statet state(
+    *state_level2,
+    global_value_set,
+    ns,
+    options.get_bool_option("no-propagation"));
   state.initialize(
     (*goto_program).instructions.begin(),
     (*goto_program).instructions.end(),
@@ -665,7 +669,11 @@ void execution_statet::execute_guard()
 
 unsigned int execution_statet::add_thread(const goto_programt *prog)
 {
-  goto_symex_statet new_state(*state_level2, global_value_set, ns);
+  goto_symex_statet new_state(
+    *state_level2,
+    global_value_set,
+    ns,
+    options.get_bool_option("no-propagation"));
   new_state.initialize(
     prog->instructions.begin(),
     prog->instructions.end(),

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -43,6 +43,7 @@ execution_statet::execution_statet(
   symex_trace = options.get_bool_option("symex-trace");
   smt_during_symex = options.get_bool_option("smt-during-symex");
   smt_thread_guard = options.get_bool_option("smt-thread-guard");
+  no_propagation = options.get_bool_option("no-propagation");
 
   goto_functionst::function_mapt::const_iterator it =
     goto_functions.function_map.find("__ESBMC_main");
@@ -55,11 +56,7 @@ execution_statet::execution_statet(
   const goto_programt *goto_program = &(it->second.body);
 
   // Initialize initial thread state
-  goto_symex_statet state(
-    *state_level2,
-    global_value_set,
-    ns,
-    options.get_bool_option("no-propagation"));
+  goto_symex_statet state(*state_level2, global_value_set, ns, no_propagation);
   state.initialize(
     (*goto_program).instructions.begin(),
     (*goto_program).instructions.end(),
@@ -158,6 +155,7 @@ void execution_statet::copy_derived_from(const execution_statet &ex)
   symex_trace = ex.symex_trace;
   smt_during_symex = ex.smt_during_symex;
   smt_thread_guard = ex.smt_thread_guard;
+  no_propagation = ex.no_propagation;
 
   CS_number = ex.CS_number;
 
@@ -670,10 +668,7 @@ void execution_statet::execute_guard()
 unsigned int execution_statet::add_thread(const goto_programt *prog)
 {
   goto_symex_statet new_state(
-    *state_level2,
-    global_value_set,
-    ns,
-    options.get_bool_option("no-propagation"));
+    *state_level2, global_value_set, ns, no_propagation);
   new_state.initialize(
     prog->instructions.begin(),
     prog->instructions.end(),

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -635,6 +635,10 @@ protected:
   /** Are we evaluating the thread guard in the SMT solver during context
    *  switching? */
   bool smt_thread_guard;
+  /** Was constant propagation disabled with --no-propagation? Seeds every
+   *  thread's goto_symex_statet, so the option is looked up once per run
+   *  rather than once per thread creation. */
+  bool no_propagation;
 
   /** Copy execution_statet's own scheduling fields from `ex`. The base
    *  goto_symext slice is left untouched (the copy constructor's

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -1298,8 +1298,6 @@ protected:
    *  --no-interval-symex-guard); assertion pruning via --interval-symex-assert
    *  discharges claims proven TRUE. */
   std::optional<interval_domaint> interval_domain_state;
-  /** Whether constant propagation is to be enabled. */
-  bool constant_propagation;
   /** Namespace we're working in. */
   const namespacet &ns;
   /** Context we're working with */

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -13,8 +13,9 @@
 goto_symex_statet::goto_symex_statet(
   renaming::level2t &l2,
   value_sett &vs,
-  const namespacet &_ns)
-  : level2(l2), value_set(vs), ns(_ns)
+  const namespacet &_ns,
+  bool no_propagation)
+  : no_propagation(no_propagation), level2(l2), value_set(vs), ns(_ns)
 {
   use_value_set = true;
   num_instructions = 0;
@@ -44,6 +45,7 @@ goto_symex_statet &goto_symex_statet::operator=(const goto_symex_statet &state)
   loop_iterations = state.loop_iterations;
   function_unwind = state.function_unwind;
   use_value_set = state.use_value_set;
+  no_propagation = state.no_propagation;
   call_stack = state.call_stack;
   witness_segs = state.witness_segs;
   cur_seg = state.cur_seg;
@@ -97,6 +99,9 @@ static bool type_has_constant_size(const type2tc &type)
 
 bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
 {
+  if (no_propagation)
+    return false;
+
   if (is_array_type(expr))
   {
     array_type2t arr = to_array_type(expr->type);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -45,11 +45,13 @@ public:
    *  and value set / pointer tracking situations.
    *  @param l2 Global L2 state reference.
    *  @param vs Global value set reference.
+   *  @param no_propagation Value of --no-propagation, from the live optionst.
    */
   goto_symex_statet(
     renaming::level2t &l2,
     value_sett &vs,
-    const namespacet &_ns);
+    const namespacet &_ns,
+    bool no_propagation);
 
   /**
    *  Copy constructor.
@@ -459,6 +461,10 @@ public:
 
   /** Flag saying whether to maintain pointer value set tracking. */
   bool use_value_set;
+  /** Flag saying constant propagation was disabled with --no-propagation.
+   *  Cached because constant_propagation() runs on every assignment and
+   *  get_bool_option does a string-keyed map lookup. */
+  bool no_propagation = false;
   /** Reference to global l2 state. */
   renaming::level2t &level2;
   /** Reference to global pointer tracking state. */

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -26,7 +26,6 @@ goto_symext::goto_symext(
     remaining_claims(0),
     simplified_claims(0),
     max_unwind(options.get_option("unwind").c_str()),
-    constant_propagation(!options.get_bool_option("no-propagation")),
     ns(_ns),
     new_context(_new_context),
     goto_functions(_goto_functions),
@@ -180,7 +179,6 @@ goto_symext &goto_symext::operator=(const goto_symext &sym)
   unwind_func_set = sym.unwind_func_set;
   loop_id_to_func_index = sym.loop_id_to_func_index;
   max_unwind = sym.max_unwind;
-  constant_propagation = sym.constant_propagation;
   total_claims = sym.total_claims;
   remaining_claims = sym.remaining_claims;
   simplified_claims = sym.simplified_claims;

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1858,7 +1858,7 @@ void dereferencet::construct_struct_ref_from_dyn_offset(
   std::list<std::pair<expr2tc, expr2tc>> resolved_list;
 
   construct_struct_ref_from_dyn_offs_rec(
-    value, offs, type, gen_true_expr(), mode, resolved_list);
+    value, offs, type, guard, gen_true_expr(), mode, resolved_list);
 
   if (resolved_list.size() == 0)
   {
@@ -1901,6 +1901,7 @@ void dereferencet::construct_struct_ref_from_dyn_offs_rec(
   const expr2tc &value,
   const expr2tc &offs,
   const type2tc &type,
+  const guard2tc &guard,
   const expr2tc &accuml_guard,
   modet mode,
   std::list<std::pair<expr2tc, expr2tc>> &output)
@@ -1945,7 +1946,7 @@ void dereferencet::construct_struct_ref_from_dyn_offs_rec(
     simplify(range_guard);
 
     construct_struct_ref_from_dyn_offs_rec(
-      index, new_offset, type, range_guard, mode, output);
+      index, new_offset, type, guard, range_guard, mode, output);
     return;
   }
 
@@ -1993,7 +1994,7 @@ void dereferencet::construct_struct_ref_from_dyn_offs_rec(
 
       simplify(new_offset);
       construct_struct_ref_from_dyn_offs_rec(
-        memb, new_offset, type, range_guard, mode, output);
+        memb, new_offset, type, guard, range_guard, mode, output);
       i++;
     }
     return;
@@ -2027,7 +2028,7 @@ void dereferencet::construct_struct_ref_from_dyn_offs_rec(
       expr2tc memb = member2tc(it, value, union_type.member_names[i]);
 
       construct_struct_ref_from_dyn_offs_rec(
-        memb, offs, type, accuml_guard, mode, output);
+        memb, offs, type, guard, accuml_guard, mode, output);
       i++;
     }
     return;
@@ -2039,7 +2040,7 @@ void dereferencet::construct_struct_ref_from_dyn_offs_rec(
   {
     // This is a byte array. We can reconstruct a structure from this, if
     // we don't overflow bounds. Start by encoding an assertion.
-    guard2tc tmp;
+    guard2tc tmp(guard);
     tmp.add(accuml_guard);
 
     // Only encode a bounds check if we're directly accessing an array symbol:

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -550,6 +550,7 @@ private:
     const expr2tc &value,
     const expr2tc &offs,
     const type2tc &type,
+    const guard2tc &guard,
     const expr2tc &accuml_guard,
     modet mode,
     std::list<std::pair<expr2tc, expr2tc>> &output);


### PR DESCRIPTION
`construct_struct_ref_from_dyn_offset` seeded its recursion with a true guard and the byte-array arm built a fresh empty one, so the bounds check lost both the path guard and the same-object guard that `build_reference_to` had already put on the sibling check at `dereference.cpp:810`; each value-set target's claim then had to hold for every dynamic object at once, and a second `malloc` on a never-taken branch was enough to report a spurious heap out-of-bounds.
This is the real cause of #6464 and supersedes the constant-propagation workaround in #6470 — that PR's own C++ placement-new test passes here without any propagation change.
Verified across plain BMC / `--incremental-bmc` / `--k-induction`, each with and without `--no-propagation` (18/18), plus six negative programs agreeing with ASan; every regression suite matches a master build on the same machine.
Stacked on #6505, which the propagation-independence test needs. Fixes #6464.
