### PR TITLE
[om] Model recursive and errorcheck mutex kinds

### DIFF
--- a/regression/esbmc-unix/01_malloc_08/main.c
+++ b/regression/esbmc-unix/01_malloc_08/main.c
@@ -12,33 +12,33 @@ pthread_cond_t *empty, *full;
 
 void * thread1(void * arg)
 {
-  pthread_mutex_lock(&m);
+  pthread_mutex_lock(m);
 
   while (num > 0) 
-    pthread_cond_wait(&empty, &m);
+    pthread_cond_wait(empty, m);
   
   num++;
 
-  pthread_mutex_unlock(&m);
-  pthread_cond_signal(&full);
+  pthread_mutex_unlock(m);
+  pthread_cond_signal(full);
 }
 
 
 void * thread2(void * arg)
 {
 #if 1
-  pthread_mutex_lock(&m);
+  pthread_mutex_lock(m);
 
   while (num == 0) 
-    pthread_cond_wait(&full, &m);
+    pthread_cond_wait(full, m);
 
 //this should cause a deadlock  
 //  num--;
   printf("consume ....\n");
 
-  pthread_mutex_unlock(&m);
+  pthread_mutex_unlock(m);
 
-  pthread_cond_signal(&empty);
+  pthread_cond_signal(empty);
 #endif
 }
 
@@ -53,9 +53,9 @@ int main()
   empty = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
   full = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
 
-  pthread_mutex_init(&m, 0);
-  pthread_cond_init(&empty, 0);
-  pthread_cond_init(&full, 0);
+  pthread_mutex_init(m, 0);
+  pthread_cond_init(empty, 0);
+  pthread_cond_init(full, 0);
   
   pthread_create(&t1, 0, thread1, 0);
 

--- a/regression/esbmc-unix/github_6477-errorcheck/main.c
+++ b/regression/esbmc-unix/github_6477-errorcheck/main.c
@@ -1,0 +1,23 @@
+/* PTHREAD_MUTEX_ERRORCHECK reports rather than blocks or traps: EDEADLK for a
+   relock by the owner, EPERM for an unlock by a thread that does not hold it. */
+#include <pthread.h>
+#include <errno.h>
+#include <assert.h>
+
+int main(void)
+{
+  pthread_mutex_t m;
+  pthread_mutexattr_t at;
+  int kind;
+  pthread_mutexattr_init(&at);
+  pthread_mutexattr_settype(&at, PTHREAD_MUTEX_ERRORCHECK);
+  pthread_mutexattr_gettype(&at, &kind);
+  assert(kind == PTHREAD_MUTEX_ERRORCHECK);
+  pthread_mutex_init(&m, &at);
+  assert(pthread_mutex_lock(&m) == 0);
+  assert(pthread_mutex_lock(&m) == EDEADLK);
+  assert(pthread_mutex_unlock(&m) == 0);
+  assert(pthread_mutex_unlock(&m) == EPERM);
+  pthread_mutex_destroy(&m);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6477-errorcheck/test.desc
+++ b/regression/esbmc-unix/github_6477-errorcheck/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6477/main.c
+++ b/regression/esbmc-unix/github_6477/main.c
@@ -1,0 +1,19 @@
+/* Re-locking a PTHREAD_MUTEX_RECURSIVE mutex from its owner is legal and does
+   not block, so this is not a deadlock. */
+#include <pthread.h>
+
+int main(void)
+{
+  pthread_mutex_t m;
+  pthread_mutexattr_t at;
+  pthread_mutexattr_init(&at);
+  pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&m, &at);
+  pthread_mutex_lock(&m);
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  pthread_mutex_unlock(&m);
+  pthread_mutex_destroy(&m);
+  pthread_mutexattr_destroy(&at);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6477/test.desc
+++ b/regression/esbmc-unix/github_6477/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6477_fail/main.c
+++ b/regression/esbmc-unix/github_6477_fail/main.c
@@ -1,0 +1,26 @@
+/* A recursive mutex stays held until the outermost unlock: the worker can
+   never acquire it, so the join really does deadlock. */
+#include <pthread.h>
+pthread_mutex_t m;
+
+void *w(void *p)
+{
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a;
+  pthread_mutexattr_t at;
+  pthread_mutexattr_init(&at);
+  pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&m, &at);
+  pthread_mutex_lock(&m);
+  pthread_mutex_lock(&m);
+  pthread_create(&a, 0, w, 0);
+  pthread_mutex_unlock(&m); /* still held at the outer level */
+  pthread_join(a, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6477_fail/test.desc
+++ b/regression/esbmc-unix/github_6477_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--deadlock-check --unwind 3
+^VERIFICATION FAILED$
+Deadlocked state in pthread_join

--- a/src/c2goto/headers/pthread.h
+++ b/src/c2goto/headers/pthread.h
@@ -51,12 +51,20 @@ typedef struct
   int __lock;
   /* Repurposed as this mutex's waiter count; see __ESBMC_mutex_waiters. */
   unsigned int __count;
+  /* Thread holding the mutex; only meaningful while __lock is 1. */
   int __owner;
+  /* PTHREAD_MUTEX_NORMAL / _RECURSIVE / _ERRORCHECK, from the attribute
+     passed to pthread_mutex_init. */
+  int __kind;
+  /* The owner's nesting depth, which only a recursive mutex takes above 1. */
+  unsigned int __depth;
 } pthread_mutex_t;
 
-/* Mutex initializer. */
-#define PTHREAD_MUTEX_INITIALIZER { 0, 0, 0, }
+/* Mutex initializer. PTHREAD_MUTEX_NORMAL is 0, so a statically initialised
+   mutex gets the default kind. */
+#define PTHREAD_MUTEX_INITIALIZER { 0, 0, 0, 0, 0, }
 
+/* __align holds the mutex kind; see __ESBMC_mutexattr_kind. */
 typedef union
 {
   int __align;

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -23,6 +23,9 @@ void __ESBMC_set_thread_internal_data(
 #define __ESBMC_mutex_lock_field(a) ((a).__lock)
 #define __ESBMC_mutex_waiters(a) ((a).__count)
 #define __ESBMC_mutex_owner_field(a) ((a).__owner)
+#define __ESBMC_mutex_kind_field(a) ((a).__kind)
+#define __ESBMC_mutex_depth_field(a) ((a).__depth)
+#define __ESBMC_mutexattr_kind(a) ((a).__align)
 #define __ESBMC_cond_lock_field(a) ((a).__lock)
 #define __ESBMC_cond_futex_field(a) ((a).__futex)
 #define __ESBMC_cond_nwaiters_field(a) ((a).__nwaiters)
@@ -415,9 +418,53 @@ __ESBMC_HIDE:;
 
 /************************* Mutex manipulation routines ************************/
 
-int pthread_mutex_init(
-  pthread_mutex_t *mutex,
-  const pthread_mutexattr_t *mutexattr)
+/* Set once a program asks for a mutex kind that has to know who the owner is.
+ * Every access to the owner, depth and kind fields below -- and to the
+ * attribute pointer in pthread_mutex_init -- is short-circuited by this flag,
+ * so a program that never calls pthread_mutexattr_settype keeps the plain
+ * boolean-lock model verbatim. That matters: symex resolves the may-null
+ * attribute pointer whenever pthread_mutex_init reads it, which poisons
+ * MPOR's dependency relation and tripled the interleavings explored on
+ * regression/esbmc-unix/github_6474 (3s -> 25s). */
+static _Bool __ESBMC_mutex_owner_tracking = 0;
+
+int pthread_mutexattr_init(pthread_mutexattr_t *attr)
+{
+__ESBMC_HIDE:;
+  __ESBMC_mutexattr_kind(*attr) = PTHREAD_MUTEX_DEFAULT;
+  return 0;
+}
+
+int pthread_mutexattr_destroy(pthread_mutexattr_t *attr)
+{
+__ESBMC_HIDE:;
+  return 0;
+}
+
+int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int kind)
+{
+__ESBMC_HIDE:;
+  if (
+    kind != PTHREAD_MUTEX_NORMAL && kind != PTHREAD_MUTEX_RECURSIVE &&
+    kind != PTHREAD_MUTEX_ERRORCHECK && kind != PTHREAD_MUTEX_ADAPTIVE_NP)
+    return EINVAL;
+  if (kind == PTHREAD_MUTEX_RECURSIVE || kind == PTHREAD_MUTEX_ERRORCHECK)
+    __ESBMC_mutex_owner_tracking = 1;
+  __ESBMC_mutexattr_kind(*attr) = kind;
+  return 0;
+}
+
+int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *kind)
+{
+__ESBMC_HIDE:;
+  *kind = __ESBMC_mutexattr_kind(*attr);
+  return 0;
+}
+
+/* Reset the state a mutex carries independently of its kind. Shared by
+ * pthread_mutex_init and the lazy PTHREAD_MUTEX_INITIALIZER path, which must
+ * not clobber a kind an earlier pthread_mutex_init recorded. */
+static void __ESBMC_mutex_clear(pthread_mutex_t *mutex)
 {
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
@@ -426,6 +473,21 @@ __ESBMC_HIDE:;
   __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
   __ESBMC_mutex_waiters(*mutex) = 0;
   __ESBMC_mutex_owner_field(*mutex) = 0;
+  __ESBMC_mutex_depth_field(*mutex) = 0;
+  __ESBMC_atomic_end();
+}
+
+int pthread_mutex_init(
+  pthread_mutex_t *mutex,
+  const pthread_mutexattr_t *mutexattr)
+{
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+  __ESBMC_mutex_clear(mutex);
+  int kind = PTHREAD_MUTEX_DEFAULT;
+  if (__ESBMC_mutex_owner_tracking && mutexattr)
+    kind = __ESBMC_mutexattr_kind(*mutexattr);
+  __ESBMC_mutex_kind_field(*mutex) = kind;
   __ESBMC_atomic_end();
   return 0;
 }
@@ -437,77 +499,156 @@ __ESBMC_HIDE:;
   // PTHREAD_MUTEX_INITIALIZER
   __ESBMC_atomic_begin();
   if (__ESBMC_mutex_lock_field(*mutex) == 0)
-    pthread_mutex_init(mutex, NULL);
+    __ESBMC_mutex_clear(mutex);
   __ESBMC_atomic_end();
   return 0;
 }
+
+/* Distinguished __ESBMC_mutex_relock result: the calling thread does not
+ * already hold the mutex, so the caller must take its normal path. */
+#define __ESBMC_MUTEX_NOT_HELD_BY_SELF (-1)
+
+/* Outcome of re-locking a mutex the calling thread already holds: 0 once the
+ * nesting depth has been bumped (PTHREAD_MUTEX_RECURSIVE), EDEADLK for
+ * PTHREAD_MUTEX_ERRORCHECK, and __ESBMC_MUTEX_NOT_HELD_BY_SELF otherwise --
+ * a PTHREAD_MUTEX_NORMAL relock really is a self-deadlock, so the caller
+ * models it as ordinary contention. */
+static int __ESBMC_mutex_relock(pthread_mutex_t *mutex)
+{
+__ESBMC_HIDE:;
+  if (
+    !__ESBMC_mutex_owner_tracking || __ESBMC_mutex_lock_field(*mutex) != 1 ||
+    __ESBMC_mutex_owner_field(*mutex) != (int)__ESBMC_get_thread_id())
+    return __ESBMC_MUTEX_NOT_HELD_BY_SELF;
+
+  int kind = __ESBMC_mutex_kind_field(*mutex);
+  if (kind == PTHREAD_MUTEX_ERRORCHECK)
+    return EDEADLK;
+  if (kind != PTHREAD_MUTEX_RECURSIVE)
+    return __ESBMC_MUTEX_NOT_HELD_BY_SELF;
+
+  __ESBMC_mutex_depth_field(*mutex)++;
+  return 0;
+}
+
+/* Record the acquisition so that a later relock can be attributed. */
+static void __ESBMC_mutex_acquire(pthread_mutex_t *mutex)
+{
+__ESBMC_HIDE:;
+  __ESBMC_mutex_lock_field(*mutex) = 1;
+  if (__ESBMC_mutex_owner_tracking)
+  {
+    __ESBMC_mutex_owner_field(*mutex) = (int)__ESBMC_get_thread_id();
+    __ESBMC_mutex_depth_field(*mutex) = 1;
+  }
+}
+
+/* Drop one nesting level. Returns whether the mutex is now free, in which
+ * case the caller is responsible for waking the threads blocked on it. */
+static _Bool __ESBMC_mutex_release(pthread_mutex_t *mutex)
+{
+__ESBMC_HIDE:;
+  if (__ESBMC_mutex_owner_tracking && __ESBMC_mutex_depth_field(*mutex) > 1)
+  {
+    __ESBMC_mutex_depth_field(*mutex)--;
+    return 0;
+  }
+  __ESBMC_mutex_lock_field(*mutex) = 0;
+  return 1;
+}
+
+/* An errorcheck mutex reports EPERM rather than trapping when the caller does
+ * not own it, which includes unlocking a mutex nobody holds. */
+static _Bool __ESBMC_mutex_unlock_denied(pthread_mutex_t *mutex)
+{
+__ESBMC_HIDE:;
+  return __ESBMC_mutex_owner_tracking &&
+         __ESBMC_mutex_kind_field(*mutex) == PTHREAD_MUTEX_ERRORCHECK &&
+         (__ESBMC_mutex_lock_field(*mutex) != 1 ||
+          __ESBMC_mutex_owner_field(*mutex) != (int)__ESBMC_get_thread_id());
+}
+
+/* Every routine below has exactly one __ESBMC_atomic_end on every path: symex
+ * decrements the atomic-nesting counter for an ATOMIC_END instruction without
+ * consulting the path guard, so returning early out of an atomic block tears
+ * that block down for the paths that did not take the early exit. */
 
 int pthread_mutex_lock_noassert(pthread_mutex_t *mutex)
 {
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
   pthread_mutex_initializer(mutex);
-  __ESBMC_assume(!__ESBMC_mutex_lock_field(*mutex));
-  __ESBMC_mutex_lock_field(*mutex) = 1;
+  int nested = __ESBMC_mutex_relock(mutex);
+  _Bool held_by_self = (nested != __ESBMC_MUTEX_NOT_HELD_BY_SELF);
+  if (!held_by_self)
+  {
+    __ESBMC_assume(!__ESBMC_mutex_lock_field(*mutex));
+    __ESBMC_mutex_acquire(mutex);
+  }
   __ESBMC_atomic_end();
-  return 0;
+  return held_by_self ? nested : 0;
 }
 
 int pthread_mutex_lock_nocheck(pthread_mutex_t *mutex)
 {
 __ESBMC_HIDE:;
-  __ESBMC_atomic_begin();
-  pthread_mutex_initializer(mutex);
-  __ESBMC_assume(!__ESBMC_mutex_lock_field(*mutex));
-  __ESBMC_mutex_lock_field(*mutex) = 1;
-  __ESBMC_atomic_end();
-  return 0;
+  return pthread_mutex_lock_noassert(mutex);
 }
 
 int pthread_mutex_unlock_noassert(pthread_mutex_t *mutex)
 {
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
-  __ESBMC_mutex_lock_field(*mutex) = 0;
+  _Bool denied = __ESBMC_mutex_unlock_denied(mutex);
+  if (!denied)
+    __ESBMC_mutex_release(mutex);
   __ESBMC_atomic_end();
-  return 0;
+  return denied ? EPERM : 0;
 }
 
 int pthread_mutex_unlock_nocheck(pthread_mutex_t *mutex)
 {
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
+  _Bool denied = __ESBMC_mutex_unlock_denied(mutex);
   __ESBMC_assert(
-    __ESBMC_mutex_lock_field(*mutex), "must hold lock upon unlock");
-  __ESBMC_mutex_lock_field(*mutex) = 0;
+    denied || __ESBMC_mutex_lock_field(*mutex), "must hold lock upon unlock");
+  if (!denied)
+    __ESBMC_mutex_release(mutex);
   __ESBMC_atomic_end();
-  return 0;
+  return denied ? EPERM : 0;
 }
 
 int pthread_mutex_lock_check(pthread_mutex_t *mutex)
 {
 __ESBMC_HIDE:;
-  _Bool unlocked = 1;
-
   __ESBMC_atomic_begin();
 
   pthread_mutex_initializer(mutex);
 
-  unlocked = (__ESBMC_mutex_lock_field(*mutex) == 0);
+  /* Re-locking a mutex we already own is only a deadlock for the default
+     kind; a recursive mutex nests and an errorcheck one reports EDEADLK. */
+  int nested = __ESBMC_mutex_relock(mutex);
+  _Bool held_by_self = (nested != __ESBMC_MUTEX_NOT_HELD_BY_SELF);
 
-  if (unlocked)
+  _Bool unlocked = held_by_self || (__ESBMC_mutex_lock_field(*mutex) == 0);
+
+  if (!held_by_self)
   {
-    __ESBMC_mutex_lock_field(*mutex) = 1;
-  }
-  else
-  {
-    // Deadlock foo
-    __ESBMC_mutex_waiters(*mutex)++;
-    __ESBMC_blocked_threads_count++;
-    // No more threads to run -> croak.
-    __ESBMC_assert(
-      __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
-      "Deadlocked state in pthread_mutex_lock");
+    if (unlocked)
+    {
+      __ESBMC_mutex_acquire(mutex);
+    }
+    else
+    {
+      // Deadlock foo
+      __ESBMC_mutex_waiters(*mutex)++;
+      __ESBMC_blocked_threads_count++;
+      // No more threads to run -> croak.
+      __ESBMC_assert(
+        __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
+        "Deadlocked state in pthread_mutex_lock");
+    }
   }
 
   // Switch away for deadlock detection and so forth...
@@ -516,20 +657,25 @@ __ESBMC_HIDE:;
   // ... but don't allow execution further if it was locked.
   __ESBMC_assume(unlocked);
 
-  return 0;
+  return held_by_self ? nested : 0;
 }
 
 int pthread_mutex_unlock_check(pthread_mutex_t *mutex)
 {
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
+  _Bool denied = __ESBMC_mutex_unlock_denied(mutex);
+
   __ESBMC_assert(
-    __ESBMC_mutex_lock_field(*mutex), "must hold lock upon unlock");
-  __ESBMC_mutex_lock_field(*mutex) = 0;
-  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
-  __ESBMC_mutex_waiters(*mutex) = 0;
+    denied || __ESBMC_mutex_lock_field(*mutex), "must hold lock upon unlock");
+
+  if (!denied && __ESBMC_mutex_release(mutex))
+  {
+    __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
+    __ESBMC_mutex_waiters(*mutex) = 0;
+  }
   __ESBMC_atomic_end();
-  return 0;
+  return denied ? EPERM : 0;
 }
 
 int pthread_mutex_trylock(pthread_mutex_t *mutex)
@@ -537,11 +683,21 @@ int pthread_mutex_trylock(pthread_mutex_t *mutex)
 __ESBMC_HIDE:;
   __ESBMC_atomic_begin();
 
-  int res = EBUSY;
+  /* A mutex the caller already owns nests when recursive; otherwise it is
+     busy -- trylock never reports EDEADLK. */
+  int res = __ESBMC_mutex_relock(mutex);
+  if (res != __ESBMC_MUTEX_NOT_HELD_BY_SELF)
+  {
+    if (res != 0)
+      res = EBUSY;
+    goto PTHREAD_MUTEX_TRYLOCK_END;
+  }
+
+  res = EBUSY;
   if (__ESBMC_mutex_lock_field(*mutex) != 0)
     goto PTHREAD_MUTEX_TRYLOCK_END;
 
-  pthread_mutex_lock(mutex);
+  __ESBMC_mutex_acquire(mutex);
   res = 0;
 
 PTHREAD_MUTEX_TRYLOCK_END:
@@ -951,11 +1107,7 @@ __ESBMC_HIDE:;
     _Bool _cancel = __ESBMC_pthread_cancel_requested[_ctid] &&
                     __ESBMC_pthread_cancelstate[_ctid] == PTHREAD_CANCEL_ENABLE;
     if (_cancel)
-    {
-      __ESBMC_mutex_lock_field(*mutex) = 0;
-      __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
-      __ESBMC_mutex_waiters(*mutex) = 0;
-    }
+      __ESBMC_mutex_clear(mutex);
     __ESBMC_atomic_end();
     if (_cancel)
       pthread_exit(PTHREAD_CANCELED);
@@ -967,10 +1119,10 @@ __ESBMC_HIDE:;
       __ESBMC_mutex_lock_field(*mutex),
       "caller must hold pthread mutex lock in pthread_cond_wait");
 
-  // Unlock mutex; register us as waiting on condvar; context switch
-  __ESBMC_mutex_lock_field(*mutex) = 0;
-  __ESBMC_release_blocked_threads(__ESBMC_mutex_waiters(*mutex));
-  __ESBMC_mutex_waiters(*mutex) = 0;
+  // Unlock mutex; register us as waiting on condvar; context switch.
+  // The mutex is dropped outright rather than by one nesting level: waiting
+  // on a recursive mutex is undefined behaviour (POSIX pthread_cond_wait).
+  __ESBMC_mutex_clear(mutex);
   __ESBMC_cond_lock_field(*cond) = 1;
 
   // Technically in the gap below, we are blocked. So mark ourselves thus. If


### PR DESCRIPTION
Fixes #6477.

`pthread_mutex_init` ignored its `pthread_mutexattr_t *` argument and `pthread_mutexattr_settype` had no operational model, so every mutex was treated as `PTHREAD_MUTEX_NORMAL`. Re-locking a `PTHREAD_MUTEX_RECURSIVE` mutex from its owner — legal, and non-blocking at run time — was reported as a deadlock.

## What changed

- `pthread_mutexattr_init` / `settype` / `gettype` / `destroy` are now modelled; `settype` rejects an unknown kind with `EINVAL`.
- `pthread_mutex_t` carries the kind and the owner's nesting depth, and the owner is recorded on acquisition. `PTHREAD_MUTEX_INITIALIZER` still yields `PTHREAD_MUTEX_NORMAL`, which is 0.
- A relock by the owner nests for `PTHREAD_MUTEX_RECURSIVE` and returns `EDEADLK` for `PTHREAD_MUTEX_ERRORCHECK`; a `PTHREAD_MUTEX_NORMAL` relock is still the self-deadlock it always was. `pthread_mutex_unlock` returns `EPERM` when an errorcheck mutex is unlocked by a thread that does not hold it. A recursive mutex stays held — and its waiters stay blocked — until the outermost unlock.
- `pthread_mutex_trylock` nests on a recursive mutex it already owns and reports `EBUSY` otherwise; it no longer routes through the unresolved `pthread_mutex_lock` symbol.
- All four lock/unlock variants (`_check`, `_nocheck`, `_noassert`) share the model, so the kinds behave the same under `--deadlock-check`, `--lock-order-check` and the default mode.

## Two things worth a reviewer's attention

**Single-exit atomic blocks.** Symex decrements the atomic-nesting counter for an `ATOMIC_END` instruction without consulting the path guard (`execution_state.cpp:259`), so an early `return` out of an atomic block tears that block down for the paths that did not take the early exit. A first cut used early returns and broke `pthread_create`'s atomic section, which let a spawned thread reach `pthread_trampoline` before its start data was set — a SIGSEGV in `intrinsic_get_thread_data`. Every routine here now has exactly one `__ESBMC_atomic_end` on every path; there is a comment saying so.

**Interleaving cost.** Reading the may-null attribute pointer in `pthread_mutex_init` makes symex resolve it, which poisons MPOR's dependency relation: `regression/esbmc-unix/github_6474` went from 617 interleavings / 3.2s to 1910 / 25s. Every access to the new fields and to the attribute pointer is therefore short-circuited by `__ESBMC_mutex_owner_tracking`, an internal flag only `pthread_mutexattr_settype` sets. A program that never asks for a mutex kind keeps the plain boolean-lock model verbatim — github_6474 is back to 617 / 3.2s, exactly master's numbers.

## Test changes

New: `github_6477` (the issue's reproducer, SUCCESSFUL), `github_6477_fail` (a recursive mutex still held at the outer level really does deadlock a joiner, FAILED), `github_6477-errorcheck` (`EDEADLK` / `EPERM` / `gettype` round-trip).

`01_malloc_08` passed `pthread_mutex_t **` and `pthread_cond_t **` to calls taking single pointers, so the model was reading the 8-byte pointer variable as the mutex object and any layout change perturbs it. Its types are corrected; the expected `VERIFICATION FAILED` verdict is unchanged, and it now runs in 0.6s instead of 1.6s. No other existing test was touched.

## Verification

`esbmc-unix` 341/341, `esbmc-unix2` 186/186, unit tests 592/592. `esbmc-unix/03_boundedBuffer` exceeds the harness's 120s cap both with this patch (1m49s) and on master (1m45s) — pre-existing and unrelated.