### PR TITLE
[concurrency] Pin the triangular-2 soundness fix with tests

### DIFF
--- a/regression/esbmc-unix/github_2775-safe/main.c
+++ b/regression/esbmc-unix/github_2775-safe/main.c
@@ -1,0 +1,56 @@
+/* Companion to github_2775: the same program with a limit the two threads
+   cannot reach in NUM steps, so the ERROR label is genuinely unreachable.
+   Pins the other direction -- the search must not report a bug here, and the
+   label really is in the goto program (github_2775 reaches it). */
+#include <pthread.h>
+
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
+
+extern void abort(void);
+#include <assert.h>
+void reach_error() { assert(0); }
+
+int i = 3, j = 6;
+
+#define NUM 5
+#define LIMIT (2*NUM+60)
+
+void *t1(void *arg) {
+  for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
+    i = j + 1;
+    __VERIFIER_atomic_end();
+  }
+  pthread_exit(NULL);
+}
+
+void *t2(void *arg) {
+  for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
+    j = i + 1;
+    __VERIFIER_atomic_end();
+  }
+  pthread_exit(NULL);
+}
+
+int main(int argc, char **argv) {
+  pthread_t id1, id2;
+
+  pthread_create(&id1, NULL, t1, NULL);
+  pthread_create(&id2, NULL, t2, NULL);
+
+  __VERIFIER_atomic_begin();
+  int condI = i >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: {reach_error();abort();}
+  }
+
+  return 0;
+}

--- a/regression/esbmc-unix/github_2775-safe/test.desc
+++ b/regression/esbmc-unix/github_2775-safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--state-hashing --k-step 2 --unlimited-k-steps --64 --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_2775/main.c
+++ b/regression/esbmc-unix/github_2775/main.c
@@ -1,0 +1,58 @@
+/* SV-COMP pthread/triangular-2.c (sv-benchmarks, Apache-2.0).
+
+   Alternating t1 and t2 drives j to 2*NUM+6, so the ERROR label is
+   reachable and the expected verdict is FAILED. ESBMC used to answer
+   SUCCESSFUL here (#2775). --state-hashing is what keeps the interleaving
+   search tractable; without it this does not converge. */
+#include <pthread.h>
+
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
+
+extern void abort(void);
+#include <assert.h>
+void reach_error() { assert(0); }
+
+int i = 3, j = 6;
+
+#define NUM 5
+#define LIMIT (2*NUM+6)
+
+void *t1(void *arg) {
+  for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
+    i = j + 1;
+    __VERIFIER_atomic_end();
+  }
+  pthread_exit(NULL);
+}
+
+void *t2(void *arg) {
+  for (int k = 0; k < NUM; k++) {
+    __VERIFIER_atomic_begin();
+    j = i + 1;
+    __VERIFIER_atomic_end();
+  }
+  pthread_exit(NULL);
+}
+
+int main(int argc, char **argv) {
+  pthread_t id1, id2;
+
+  pthread_create(&id1, NULL, t1, NULL);
+  pthread_create(&id2, NULL, t2, NULL);
+
+  __VERIFIER_atomic_begin();
+  int condI = i >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  __VERIFIER_atomic_begin();
+  int condJ = j >= LIMIT;
+  __VERIFIER_atomic_end();
+
+  if (condI || condJ) {
+    ERROR: {reach_error();abort();}
+  }
+
+  return 0;
+}

--- a/regression/esbmc-unix/github_2775/test.desc
+++ b/regression/esbmc-unix/github_2775/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--state-hashing --k-step 2 --unlimited-k-steps --64 --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes #2775.

#2775 reported `VERIFICATION SUCCESSFUL` for SV-COMP's `pthread/triangular-2.c`, whose `ERROR` label is reachable — alternating `t1` and `t2` from `i=3, j=6` gives `i=15, j=16`, and `LIMIT` is `2*NUM+6 = 16`, so `condJ` holds.

**Master already answers `FAILED`** on the issue's exact command line, stably across five runs, and the counterexample reaches the label. What master does not have is any coverage of it, so nothing stops the verdict silently flipping back. This PR adds that coverage rather than a code change.

## Tests

- `github_2775` — the SV-COMP reproducer verbatim, expects `VERIFICATION FAILED` (9.8s).
- `github_2775-safe` — the same program with `LIMIT` raised to `2*NUM+60`, out of reach in `NUM` steps, expects `VERIFICATION SUCCESSFUL` (26.9s).

The pair matters for more than symmetry: `--error-label` reports `SUCCESSFUL` silently when the label is absent from the goto program, so a lone passing test would be indistinguishable from a vacuous one. `github_2775` reaching the label is what makes `github_2775-safe`'s verdict meaningful.

`--state-hashing` is the flag that makes this converge — with the rest of the SV-COMP flag set but without it, neither direction finishes in 200s. That is noted in the test sources so a future reader does not trim it.

## Verification

`esbmc-unix` 341/341 with the 4 new tests registered. No source changes.

## Note on #2661

While checking the neighbouring issue I found #2661 (`data race detected on the wrong line`) is also already fixed — the race is reported against `c:@balance` at the right line, and under `--multi-property` exactly one claim fails, the real one. It is already pinned by `regression/esbmc-unix/github_2661`, added in #2926. It can be closed; no test is needed and none is added here.