### PR TITLE
[goto-symex] Look through arrays in the mutex cswitch-point filter

### DIFF
--- a/regression/esbmc-unix/github_6480/main.c
+++ b/regression/esbmc-unix/github_6480/main.c
@@ -1,0 +1,31 @@
+/* Both threads take the array locks in the same order, so there is no
+   deadlock. The point of the test is the cost of reaching that verdict:
+   `pthread_mutex_t m[2]` collects as the array symbol, whose type is an
+   array rather than the mutex struct, so before #6480 every acquisition
+   slipped past the sync-type filter in has_cswitch_point_occured and forced
+   a context-switch point -- 34168 interleavings here versus 10358 once the
+   filter looks through the array, and versus 4764 for the same program
+   written with two scalar mutexes. */
+#include <pthread.h>
+pthread_mutex_t m[2];
+
+void *w(void *a)
+{
+  pthread_mutex_lock(&m[0]);
+  pthread_mutex_lock(&m[1]);
+  pthread_mutex_unlock(&m[1]);
+  pthread_mutex_unlock(&m[0]);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t1, t2;
+  pthread_mutex_init(&m[0], 0);
+  pthread_mutex_init(&m[1], 0);
+  pthread_create(&t1, 0, w, 0);
+  pthread_create(&t2, 0, w, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6480/test.desc
+++ b/regression/esbmc-unix/github_6480/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6480_fail/main.c
+++ b/regression/esbmc-unix/github_6480_fail/main.c
@@ -1,0 +1,36 @@
+/* Companion to github_6480: the same array of locks, taken in opposite
+   orders by the two threads. Pins that filtering mutex-array accesses out of
+   context-switch generation does not cost the deadlock -- it must still be
+   found. */
+#include <pthread.h>
+pthread_mutex_t m[2];
+
+void *w1(void *a)
+{
+  pthread_mutex_lock(&m[0]);
+  pthread_mutex_lock(&m[1]);
+  pthread_mutex_unlock(&m[1]);
+  pthread_mutex_unlock(&m[0]);
+  return 0;
+}
+
+void *w2(void *a)
+{
+  pthread_mutex_lock(&m[1]);
+  pthread_mutex_lock(&m[0]);
+  pthread_mutex_unlock(&m[0]);
+  pthread_mutex_unlock(&m[1]);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t1, t2;
+  pthread_mutex_init(&m[0], 0);
+  pthread_mutex_init(&m[1], 0);
+  pthread_create(&t1, 0, w1, 0);
+  pthread_create(&t2, 0, w2, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6480_fail/test.desc
+++ b/regression/esbmc-unix/github_6480_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--deadlock-check --unwind 2
+^VERIFICATION FAILED$
+Deadlocked state in pthread_join

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1078,7 +1078,13 @@ bool execution_statet::has_cswitch_point_occured() const
   // a context switch point here — they already drive scheduling through
   // the pthread library's explicit switch mechanisms, and treating every
   // lock access as a cswitch point blows up the DFS width.
-  auto is_pthread_sync_type = [](const type2tc &t) {
+  // An array of locks is still just locks: `pthread_mutex_t m[N]` collects as
+  // the array symbol, whose type is an array rather than the struct, so
+  // without looking through it every acquisition in the textbook dining
+  // -philosophers shape forces a switch point (#6480).
+  auto is_pthread_sync_type = [](type2tc t) {
+    while (is_array_type(t))
+      t = to_array_type(t).subtype;
     if (is_nil_type(t))
       return false;
     if (is_struct_type(t))


### PR DESCRIPTION
Partially addresses #6480 — deliberately does not close it, see *Scope* below.

`has_cswitch_point_occured` deliberately does **not** treat a lock access as a context-switch point on its own: the pthread library drives scheduling through its own explicit mechanisms, and switching at every acquisition blows up the DFS width. That intent is already documented in the code.

The filter only recognised struct and union types. `pthread_mutex_t m[N]` collects as the **array** symbol, whose type is an array rather than the mutex struct, so it slipped past the filter and forced a switch point at every acquisition — which is exactly the textbook dining-philosophers shape #6480 reports. This teaches the filter to look through array types.

## Measurements

Two threads, two locks, `--deadlock-check --unwind 2`:

| program | master | this PR |
|---|---|---|
| `pthread_mutex_t m[2]`, both threads same order | 34168 interleavings, 79.9s | **10358, 28.1s** |
| same program, two scalar mutexes `ma`/`mb` | 4764, 12.9s | 4764, 13.2s (unchanged) |
| `m[2]` taken in opposite orders (real deadlock) | FAILED | FAILED, 13.2s |

The scalar case is untouched, which is the control: the change only affects programs that hold their locks in an array.

## Scope

This narrows the array/scalar gap; it does not close it. `arr2` is still ~2× `sca2`, and the remaining difference is value-set granularity — `&m[0]` and `&m[1]` both resolve to the base symbol `m`, so MPOR treats them as one object. The larger instances in #6480 (3 philosophers, and 2 philosophers at `--unwind 4`) still do not converge. #6480 also names two other contributors: the post-`main` cut-off being disabled under `--deadlock-check` (that is #6479, PR #6497) and the per-acquisition claim cost. So this is one of several pieces and the issue should stay open.

## Correctness

The concern with filtering anything out of switch-point generation is missing a deadlock. `github_6480_fail` pins that directly: the same array of locks taken in opposite orders must still report `Deadlocked state in pthread_join`, and it does.

## Tests

- `github_6480` — array locks, same order, no deadlock, expects `SUCCESSFUL`.
- `github_6480_fail` — array locks, opposite orders, expects `FAILED` with the deadlock message.

`esbmc-unix` 340/340, `esbmc-unix2` 186/186, `python/threading` 41/41, unit tests 592/592.