### PR TITLE
[goto-symex] Key MPOR on lock-array elements, not the whole array

### DIFF
--- a/regression/esbmc-unix/github_6480-disjoint/main.c
+++ b/regression/esbmc-unix/github_6480-disjoint/main.c
@@ -1,8 +1,10 @@
 /* The two threads hold different elements of the same lock array, so they
    share nothing and are independent. MPOR keyed every access on the base
    symbol `m`, which made them look dependent: 4973 interleavings here versus
-   732 for the same program written with two scalar mutexes. Refining a
-   constant offset into the key (#6480) brings this to 2780. */
+   732 for the same program written with two scalar mutexes. Keying on the
+   array element instead (#6480) brings this to 732 -- exact parity with the
+   scalar form, which is the point: how the locks are stored must not change
+   how much of the interleaving space has to be explored. */
 #include <pthread.h>
 pthread_mutex_t m[2];
 

--- a/regression/esbmc-unix/github_6480-disjoint/main.c
+++ b/regression/esbmc-unix/github_6480-disjoint/main.c
@@ -1,0 +1,33 @@
+/* The two threads hold different elements of the same lock array, so they
+   share nothing and are independent. MPOR keyed every access on the base
+   symbol `m`, which made them look dependent: 4973 interleavings here versus
+   732 for the same program written with two scalar mutexes. Refining a
+   constant offset into the key (#6480) brings this to 2780. */
+#include <pthread.h>
+pthread_mutex_t m[2];
+
+void *w1(void *a)
+{
+  pthread_mutex_lock(&m[0]);
+  pthread_mutex_unlock(&m[0]);
+  return 0;
+}
+
+void *w2(void *a)
+{
+  pthread_mutex_lock(&m[1]);
+  pthread_mutex_unlock(&m[1]);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t t1, t2;
+  pthread_mutex_init(&m[0], 0);
+  pthread_mutex_init(&m[1], 0);
+  pthread_create(&t1, 0, w1, 0);
+  pthread_create(&t2, 0, w2, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6480-disjoint/test.desc
+++ b/regression/esbmc-unix/github_6480-disjoint/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -9,6 +9,7 @@
 #include <util/lang/c_types.h>
 #include <util/config/config.h>
 #include <util/expr/expr_util.h>
+#include <util/expr/type_byte_size.h>
 #include <util/base/i2string.h>
 #include <irep2/irep2.h>
 #include <util/irep/migrate.h>
@@ -195,6 +196,21 @@ static bool is_pthread_sync_type(type2tc t)
   }
 
   return false;
+}
+
+/* Build the MPOR key for element `elem` of a lock array. Both the pointer
+ * path (which knows a byte offset) and a direct `m[i]` access (which knows an
+ * element index) funnel through here so the two produce the same key. */
+static expr2tc mpor_lock_array_key(const expr2tc &array, const BigInt &elem)
+{
+  const type2tc &subtype = to_array_type(array->type).subtype;
+  return index2tc(subtype, array, constant_int2tc(index_type2(), elem));
+}
+
+/* Is `e` an array of pthread sync objects that we key per element? */
+static bool is_lock_array(const expr2tc &e)
+{
+  return is_array_type(e->type) && is_pthread_sync_type(e->type);
 }
 
 /* Two MPOR keys conflict when they may name the same storage. A refined
@@ -886,10 +902,15 @@ void execution_statet::get_expr_globals(
            * unknown offset keeps the whole-array key, and
            * mpor_keys_may_alias pairs the refined and unrefined forms. */
           const expr2tc &off = to_object_descriptor2t(obj).offset;
-          if (
-            is_constant_int2t(off) && is_array_type(p->type) &&
-            is_pthread_sync_type(p->type))
-            p = index2tc(to_array_type(p->type).subtype, p, off);
+          if (is_constant_int2t(off) && is_lock_array(p))
+          {
+            /* The descriptor carries a byte offset; the key is an element
+             * index so that it matches the one a direct `m[i]` access
+             * builds. */
+            BigInt esize = type_byte_size(to_array_type(p->type).subtype, &ns);
+            if (esize > 0)
+              p = mpor_lock_array_key(p, to_constant_int2t(off).value / esize);
+          }
           /* Stop when the global symbol is found */
           if (point_to_global)
             break;
@@ -990,6 +1011,34 @@ void execution_statet::get_expr_globals(
     else
     {
       return;
+    }
+  }
+
+  /* A direct `m[i]` on a lock array: record the element. Falling through to
+   * the operand walk below would reach the bare array symbol and record the
+   * whole array, which re-conflates the elements the pointer path above took
+   * care to separate (#6480). */
+  if (is_index2t(expr))
+  {
+    const index2t &idx = to_index2t(expr);
+    if (is_symbol2t(idx.source_value) && is_lock_array(idx.source_value))
+    {
+      expr2tc src = idx.source_value;
+      get_active_state().get_original_name(src);
+      const symbolt *s = ns.lookup(to_symbol2t(src).thename);
+      expr2tc i = idx.index;
+      cur_state->rename(i);
+      simplify(i);
+      if (
+        s && (s->static_lifetime || s->get_type().is_dynamic_set()) &&
+        is_constant_int2t(i))
+      {
+        src = idx.source_value;
+        cur_state->top().level1.rename(src);
+        globals_list.insert(
+          mpor_lock_array_key(src, to_constant_int2t(i).value));
+        return;
+      }
     }
   }
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -168,6 +168,58 @@ void execution_statet::copy_derived_from(const execution_statet &ex)
   state_level2->owner = this;
 }
 
+/* Mutex / condition-var / rwlock / barrier / spinlock types, looking through
+ * arrays: `pthread_mutex_t m[N]` collects as the array symbol, whose type is
+ * an array rather than the struct (#6480). */
+static bool is_pthread_sync_type(type2tc t)
+{
+  while (is_array_type(t))
+    t = to_array_type(t).subtype;
+  if (is_nil_type(t))
+    return false;
+  if (is_struct_type(t))
+  {
+    const std::string &n = to_struct_type(t).name.as_string();
+    return n.find("pthread_mutex_t") != std::string::npos ||
+           n.find("pthread_cond_t") != std::string::npos ||
+           n.find("pthread_rwlock_t") != std::string::npos ||
+           n.find("pthread_barrier_t") != std::string::npos ||
+           n.find("pthread_spinlock_t") != std::string::npos;
+  }
+  if (is_union_type(t))
+  {
+    const std::string &n = to_union_type(t).name.as_string();
+    return n.find("pthread_mutex_t") != std::string::npos ||
+           n.find("pthread_cond_t") != std::string::npos ||
+           n.find("pthread_rwlock_t") != std::string::npos;
+  }
+
+  return false;
+}
+
+/* Two MPOR keys conflict when they may name the same storage. A refined
+ * lock-array key (index2t over the array symbol, see get_expr_globals) and the
+ * whole-array key for that same symbol may name the same element, so they must
+ * be treated as conflicting; two refined keys for distinct elements may not. */
+static bool mpor_keys_may_alias(const expr2tc &a, const expr2tc &b)
+{
+  if (a == b)
+    return true;
+  if (is_index2t(a) == is_index2t(b))
+    return false;
+  const expr2tc &base_a = is_index2t(a) ? to_index2t(a).source_value : a;
+  const expr2tc &base_b = is_index2t(b) ? to_index2t(b).source_value : b;
+  return base_a == base_b;
+}
+
+static bool mpor_set_conflicts(const std::set<expr2tc> &s, const expr2tc &key)
+{
+  for (const expr2tc &e : s)
+    if (mpor_keys_may_alias(e, key))
+      return true;
+  return false;
+}
+
 void execution_statet::symex_step(reachability_treet &art)
 {
   statet &state = get_active_state();
@@ -825,6 +877,19 @@ void execution_statet::get_expr_globals(
           point_to_global =
             s->static_lifetime || s->get_type().is_dynamic_set();
           p = to_object_descriptor2t(obj).object;
+          /* Distinguish the elements of a lock array. Both `&m[0]` and
+           * `&m[1]` resolve to the base symbol `m`, which makes MPOR treat
+           * every lock in the array as one object, so two threads holding
+           * different locks never come out independent -- 6.8x the
+           * interleavings of the same program written with scalar mutexes
+           * (#6480). Refine only a constant offset on a lock array; an
+           * unknown offset keeps the whole-array key, and
+           * mpor_keys_may_alias pairs the refined and unrefined forms. */
+          const expr2tc &off = to_object_descriptor2t(obj).offset;
+          if (
+            is_constant_int2t(off) && is_array_type(p->type) &&
+            is_pthread_sync_type(p->type))
+            p = index2tc(to_array_type(p->type).subtype, p, off);
           /* Stop when the global symbol is found */
           if (point_to_global)
             break;
@@ -946,24 +1011,18 @@ bool execution_statet::check_mpor_dependency(unsigned int j, unsigned int l)
   // don't intersect with this transitions write(s).
 
   // Double write intersection
-  for (std::set<expr2tc>::const_iterator it = thread_last_writes[j].begin();
-       it != thread_last_writes[j].end();
-       ++it)
-    if (thread_last_writes[l].find(*it) != thread_last_writes[l].end())
+  for (const expr2tc &it : thread_last_writes[j])
+    if (mpor_set_conflicts(thread_last_writes[l], it))
       return true;
 
   // This read what that wrote intersection
-  for (std::set<expr2tc>::const_iterator it = thread_last_reads[j].begin();
-       it != thread_last_reads[j].end();
-       ++it)
-    if (thread_last_writes[l].find(*it) != thread_last_writes[l].end())
+  for (const expr2tc &it : thread_last_reads[j])
+    if (mpor_set_conflicts(thread_last_writes[l], it))
       return true;
 
   // We wrote what that reads intersection
-  for (std::set<expr2tc>::const_iterator it = thread_last_writes[j].begin();
-       it != thread_last_writes[j].end();
-       ++it)
-    if (thread_last_reads[l].find(*it) != thread_last_reads[l].end())
+  for (const expr2tc &it : thread_last_writes[j])
+    if (mpor_set_conflicts(thread_last_reads[l], it))
       return true;
 
   // No check for read-read intersection, it doesn't affect anything
@@ -1087,35 +1146,6 @@ bool execution_statet::has_cswitch_point_occured() const
   // a context switch point here — they already drive scheduling through
   // the pthread library's explicit switch mechanisms, and treating every
   // lock access as a cswitch point blows up the DFS width.
-  // An array of locks is still just locks: `pthread_mutex_t m[N]` collects as
-  // the array symbol, whose type is an array rather than the struct, so
-  // without looking through it every acquisition in the textbook dining
-  // -philosophers shape forces a switch point (#6480).
-  auto is_pthread_sync_type = [](type2tc t) {
-    while (is_array_type(t))
-      t = to_array_type(t).subtype;
-    if (is_nil_type(t))
-      return false;
-    if (is_struct_type(t))
-    {
-      const std::string &n = to_struct_type(t).name.as_string();
-      return n.find("pthread_mutex_t") != std::string::npos ||
-             n.find("pthread_cond_t") != std::string::npos ||
-             n.find("pthread_rwlock_t") != std::string::npos ||
-             n.find("pthread_barrier_t") != std::string::npos ||
-             n.find("pthread_spinlock_t") != std::string::npos;
-    }
-    if (is_union_type(t))
-    {
-      const std::string &n = to_union_type(t).name.as_string();
-      return n.find("pthread_mutex_t") != std::string::npos ||
-             n.find("pthread_cond_t") != std::string::npos ||
-             n.find("pthread_rwlock_t") != std::string::npos;
-    }
-
-    return false;
-  };
-
   auto any_non_sync = [&](const std::set<expr2tc> &s) {
     for (const auto &e : s)
       if (!is_pthread_sync_type(e->type))


### PR DESCRIPTION
Partially addresses #6480. **Stacked on #6514** — review that one first; this PR targets its branch, so the diff here is just the second commit.

`get_expr_globals` resolves a lock pointer through the value set and keeps only `to_object_descriptor2t(obj).object`, discarding the offset. So `&m[0]` and `&m[1]` record the *same* MPOR key, and two threads holding different locks of one array never come out independent.

The clearest measurement is two threads that share nothing at all — one takes `m[0]`, the other `m[1]`:

| program (`--deadlock-check --unwind 2`) | #6514 | this PR |
|---|---|---|
| disjoint array locks `m[0]` / `m[1]` | 4973 interleavings | **2780** |
| same, two scalar mutexes (control) | 732 | 732 |
| nested array locks, same order | 10358 | **6414** |
| same, two scalar mutexes (control) | 4764 | 4764 |
| array locks, opposite orders | FAILED | FAILED |

Against master (before #6514) the nested case is 34168 → 6414, a 5.3× reduction.

## Soundness

This changes MPOR pruning, so the reasoning matters:

- Only a **constant** offset is folded into the key. An unknown or symbolic offset keeps the whole-array key, which is the conservative choice.
- `check_mpor_dependency` no longer uses exact set membership. It compares with `mpor_keys_may_alias`, so a refined key (`index2t` over the array symbol) and the whole-array key for that same symbol conflict. Without that, a thread indexing `m[k]` with symbolic `k` would have been treated as independent of a thread holding `m[0]` — unsound.
- Two refined keys for distinct elements do not conflict, which is the entire point.
- The refinement is scoped to pthread sync types, so no non-lock array changes granularity and the blast radius stays inside the lock model.

`index2t` keys are only ever produced by this refinement — every other insertion into `globals_list` is a `symbol2t` — so the may-alias predicate's case analysis is complete.

## Scope

Still partial: `disj_arr` at 2780 is 3.8× `disj_sca` at 732, so something beyond the key granularity still conflates array accesses, and the larger #6480 instances (3 philosophers) do not converge. The issue should stay open.

## Tests

`github_6480-disjoint` (new) exercises the refined-key path and expects `SUCCESSFUL`; `github_6480_fail` from #6514 pins that the opposite-order deadlock is still found.

I tried to add a symbolic-index test to pin the may-alias fallback directly, but it is not viable at CI scale: with nondet indices the whole-array fallback gives no pruning, so it does not converge in 200s, and `--context-bound 2` returns the wrong verdict at 111s. The fallback is exercised indirectly by the suites.

`esbmc-unix` 340/340, `esbmc-unix2` 186/186, `python/threading` 41/41, unit tests 592/592.