### PR TITLE
[goto-symex] Key direct lock-array accesses per element too

### DIFF
--- a/regression/esbmc-unix/github_6480-disjoint/main.c
+++ b/regression/esbmc-unix/github_6480-disjoint/main.c
@@ -1,8 +1,10 @@
 /* The two threads hold different elements of the same lock array, so they
    share nothing and are independent. MPOR keyed every access on the base
    symbol `m`, which made them look dependent: 4973 interleavings here versus
-   732 for the same program written with two scalar mutexes. Refining a
-   constant offset into the key (#6480) brings this to 2780. */
+   732 for the same program written with two scalar mutexes. Keying on the
+   array element instead (#6480) brings this to 732 -- exact parity with the
+   scalar form, which is the point: how the locks are stored must not change
+   how much of the interleaving space has to be explored. */
 #include <pthread.h>
 pthread_mutex_t m[2];
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -9,6 +9,7 @@
 #include <util/lang/c_types.h>
 #include <util/config/config.h>
 #include <util/expr/expr_util.h>
+#include <util/expr/type_byte_size.h>
 #include <util/base/i2string.h>
 #include <irep2/irep2.h>
 #include <util/irep/migrate.h>
@@ -193,6 +194,21 @@ static bool is_pthread_sync_type(type2tc t)
   }
 
   return false;
+}
+
+/* Build the MPOR key for element `elem` of a lock array. Both the pointer
+ * path (which knows a byte offset) and a direct `m[i]` access (which knows an
+ * element index) funnel through here so the two produce the same key. */
+static expr2tc mpor_lock_array_key(const expr2tc &array, const BigInt &elem)
+{
+  const type2tc &subtype = to_array_type(array->type).subtype;
+  return index2tc(subtype, array, constant_int2tc(index_type2(), elem));
+}
+
+/* Is `e` an array of pthread sync objects that we key per element? */
+static bool is_lock_array(const expr2tc &e)
+{
+  return is_array_type(e->type) && is_pthread_sync_type(e->type);
 }
 
 /* Two MPOR keys conflict when they may name the same storage. A refined
@@ -877,10 +893,15 @@ void execution_statet::get_expr_globals(
            * unknown offset keeps the whole-array key, and
            * mpor_keys_may_alias pairs the refined and unrefined forms. */
           const expr2tc &off = to_object_descriptor2t(obj).offset;
-          if (
-            is_constant_int2t(off) && is_array_type(p->type) &&
-            is_pthread_sync_type(p->type))
-            p = index2tc(to_array_type(p->type).subtype, p, off);
+          if (is_constant_int2t(off) && is_lock_array(p))
+          {
+            /* The descriptor carries a byte offset; the key is an element
+             * index so that it matches the one a direct `m[i]` access
+             * builds. */
+            BigInt esize = type_byte_size(to_array_type(p->type).subtype, &ns);
+            if (esize > 0)
+              p = mpor_lock_array_key(p, to_constant_int2t(off).value / esize);
+          }
           /* Stop when the global symbol is found */
           if (point_to_global)
             break;
@@ -981,6 +1002,34 @@ void execution_statet::get_expr_globals(
     else
     {
       return;
+    }
+  }
+
+  /* A direct `m[i]` on a lock array: record the element. Falling through to
+   * the operand walk below would reach the bare array symbol and record the
+   * whole array, which re-conflates the elements the pointer path above took
+   * care to separate (#6480). */
+  if (is_index2t(expr))
+  {
+    const index2t &idx = to_index2t(expr);
+    if (is_symbol2t(idx.source_value) && is_lock_array(idx.source_value))
+    {
+      expr2tc src = idx.source_value;
+      get_active_state().get_original_name(src);
+      const symbolt *s = ns.lookup(to_symbol2t(src).thename);
+      expr2tc i = idx.index;
+      cur_state->rename(i);
+      simplify(i);
+      if (
+        s && (s->static_lifetime || s->get_type().is_dynamic_set()) &&
+        is_constant_int2t(i))
+      {
+        src = idx.source_value;
+        cur_state->top().level1.rename(src);
+        globals_list.insert(
+          mpor_lock_array_key(src, to_constant_int2t(i).value));
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
Partially addresses #6480. **Third in a stack** — #6514 → #6515 → this. It targets #6515's branch, so the diff here is just the last commit.

#6515 keyed the *pointer* path on the array element. That left a second path unrefined: `get_expr_globals`' generic operand walk descends into an `m[i]` expression, reaches the bare array symbol, and records the whole array — re-conflating exactly the elements the pointer path had just separated. Instrumenting the recorded keys shows it directly, one thread carrying both forms:

```
thr=1 kind=R viaptr=0 key=c:@m          <-- whole array, from the operand walk
thr=1 kind=W viaptr=1 key=IDX:c:@m[0]   <-- refined, from the pointer path
thr=2 kind=W viaptr=1 key=IDX:c:@m[12]
```

The two paths also disagreed about what the index *meant*: the object descriptor carries a **byte** offset, a direct access an **element** index, so `m[1]` was `[12]` one way and `[1]` the other. They could not have produced matching keys even where both fired.

This records the element for a direct access, and normalises the descriptor's byte offset by the element size so both paths agree.

## Result: the array/scalar gap closes exactly

| program (`--deadlock-check --unwind 2`) | master | #6514 | #6515 | this |
|---|---|---|---|---|
| disjoint array locks `m[0]`/`m[1]` | — | 4973 | 2780 | **732** |
| same, two scalar mutexes (control) | — | 732 | 732 | **732** |
| nested array locks | 34168 | 10358 | 6414 | **4764** |
| same, two scalar mutexes (control) | 4764 | 4764 | 4764 | **4764** |
| array locks, opposite orders | FAILED | FAILED | FAILED | **FAILED** |

Both array programs now explore exactly what their scalar equivalents do, which is the property worth having: how the locks happen to be stored should not change how much of the interleaving space has to be explored. Cumulatively the nested case is 34168 → 4764, 7.2×.

## Soundness

Unchanged from #6515 and re-checked here: only a constant index is refined, a symbolic one still keys on the whole array, and `mpor_keys_may_alias` pairs the refined and unrefined forms. The new branch additionally requires the array to be a genuine global (`static_lifetime` or dynamic) before keying per element, matching what the symbol path already demanded — without that a function-local lock array would have been recorded as shared.

## Scope — #6480 is still not fixed

The issue's own benchmark, loop-based dining philosophers, still does not converge: `phil2 --deadlock-check` fails to finish in 200s at both `--unwind 3` and `--unwind 4`. What this stack fixes is the array-vs-scalar penalty, which was one named contributor. The loop-based shape has others (the `for` loops in `main`, the `(void *)i` thread arguments). #6480 should stay open.

`esbmc-unix` 341/341, `esbmc-unix2` 186/186, `python/threading` 41/41, unit tests 592/592.