### PR TITLE
[python] Pin the callable-in-class-field crash blocking #4566

### DIFF
--- a/regression/python/callable_class_field/main.py
+++ b/regression/python/callable_class_field/main.py
@@ -1,0 +1,27 @@
+# Storing callables in a class instance field, as opposed to a module-level
+# variable (which callable3 and friends already cover). This is the last of
+# the four features regression/python/concurrency_fail waits on (#4566) --
+# threading.Thread subclassing, queue.Queue and random.choice over a filtered
+# list all work now.
+#
+# ESBMC currently aborts rather than reporting anything: the list element type
+# comes out as empty/void, so dereferencet::construct_from_array asks it for a
+# width and the symbolic_type_excp escapes uncaught.
+from typing import List, Callable
+
+
+def cb(x: int) -> int:
+    return x + 1
+
+
+class Holder:
+    def __init__(self) -> None:
+        self.fns: List[Callable[[int], int]] = []
+
+    def add(self, f: Callable[[int], int]) -> None:
+        self.fns.append(f)
+
+
+h = Holder()
+h.add(cb)
+assert h.fns[0](1) == 2

--- a/regression/python/callable_class_field/test.desc
+++ b/regression/python/callable_class_field/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Re #4566 — status update plus a test for the one remaining blocker. Does not close the issue.

#4566 parks `regression/python/concurrency_fail` as `KNOWNBUG` behind four frontend features. I probed each in isolation, with a negative control on every one so a passing result cannot be vacuous:

| dependency | verdict | negative control |
|---|---|---|
| `threading.Thread` subclassing + `start`/`join`/`run` | works | flips to FAILED |
| `queue.Queue` `put`/`get` | works | flips to FAILED |
| `random.choice` over a runtime-filtered list | works | flips to FAILED |
| callable stored in a class instance field | **aborts** | — |

Three of the four have landed since the issue was filed. All three are already covered elsewhere in the suite (`threading_thread_*`, `queue_fifo`, `github_4355`), so this PR adds no redundant tests for them.

## The remaining blocker aborts rather than reporting

```
$ esbmc main.py --incremental-bmc
terminate called after throwing an instance of 'type2t::symbolic_type_excp'
```

The list element type comes out as empty/void, so `dereferencet::construct_from_array` calls `type_byte_size_bits` on it, `empty_type2t::get_width()` throws, and nothing catches it:

```
#1  empty_type2t::get_width ()                 irep2_type.cpp:186
#2  dereferencet::construct_from_array (...)
#3  dereferencet::build_reference_to (...)     dereference.cpp:824
#7  goto_symext::symex_function_call_deref (...) symex_function.cpp:746
```

The existing `callable*` tests all bind a callable to a *module-level* variable (`h: Callable[[int], int] = f`); none puts one in a class instance field, which is why nothing pinned this. Added as `KNOWNBUG` — it flips to `CORE` once the frontend gives the field a function-pointer type.

## What I did not do

I did not rework the reproducer to use module-level functions, which #4566 lists as a possible path. That would make the test pass without the feature existing, and `concurrency_fail` would still be blocked.

I also have not filed the abort as its own issue. It is arguably distinct from #4566 — an uncaught exception in pointer-analysis is a defect whatever the frontend does, and turning it into a diagnostic is a separate, smaller change than typing the field. Happy to file it if you want it tracked separately.