### PR TITLE
[goto-programs] Bound interior member arrays reached through a pointer

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6508/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6508/main.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+
+class C
+{
+  int buf[4];
+
+public:
+  unsigned n;
+  C() : n(0)
+  {
+  }
+  void push(int v)
+  {
+    buf[n++] = v;
+  }
+};
+
+int main()
+{
+  C c;
+  for (int i = 0; i < 5; i++)
+    c.push(i);
+  assert(c.n <= 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6508/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6508/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 7
+^VERIFICATION FAILED$
+^\s*array bounds violated: array upper bound$

--- a/regression/esbmc/github_6508-arrayelem/main.c
+++ b/regression/esbmc/github_6508-arrayelem/main.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+
+struct S
+{
+  int buf[4];
+  unsigned n;
+};
+
+int main()
+{
+  /* Indexing a real array selects a fixed-size element, so `buf' stays
+     interior and keeps its declared bound even though the array itself was
+     reached through a pointer. */
+  struct S *a = malloc(4 * sizeof(struct S));
+  if (!a)
+    return 0;
+
+  a[1].buf[6] = 1;
+  free(a);
+  return 0;
+}

--- a/regression/esbmc/github_6508-arrayelem/test.desc
+++ b/regression/esbmc/github_6508-arrayelem/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^\s*array bounds violated: array upper bound$

--- a/regression/esbmc/github_6508-nondet/main.c
+++ b/regression/esbmc/github_6508-nondet/main.c
@@ -1,0 +1,19 @@
+struct S
+{
+  int buf[4];
+  unsigned n;
+};
+
+int main()
+{
+  struct S s;
+  struct S *p = &s;
+
+  p->n = nondet_uint();
+  __ESBMC_assume(p->n <= 4);
+
+  /* n == 4 writes onto `n' itself, which stays inside the enclosing struct:
+     only the array's own bound rejects it. */
+  p->buf[p->n] = 1;
+  return 0;
+}

--- a/regression/esbmc/github_6508-nondet/test.desc
+++ b/regression/esbmc/github_6508-nondet/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^\s*array bounds violated: array upper bound$

--- a/regression/esbmc/github_6508/main.c
+++ b/regression/esbmc/github_6508/main.c
@@ -1,0 +1,14 @@
+struct S
+{
+  int buf[4];
+  unsigned n;
+};
+
+int main()
+{
+  struct S s;
+  struct S *p = &s;
+  p->n = 4;
+  p->buf[p->n] = 1;
+  return 0;
+}

--- a/regression/esbmc/github_6508/test.desc
+++ b/regression/esbmc/github_6508/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^\s*array bounds violated: array upper bound$

--- a/regression/esbmc/github_6508_safe/main.c
+++ b/regression/esbmc/github_6508_safe/main.c
@@ -1,0 +1,74 @@
+#include <stdlib.h>
+
+struct S
+{
+  int buf[4];
+  unsigned n;
+};
+
+/* The struct-hack idiom: `qux' is over-allocated past its declared bound, so
+   the declared bound must not be enforced (see 82b5ce54f7). The char variant
+   also carries trailing padding, which must not make `qux' look interior. */
+struct H
+{
+  int n;
+  int qux[1];
+};
+
+struct HC
+{
+  int n;
+  char qux[1];
+};
+
+/* The exemption has to survive a nested member chain, not just a direct one. */
+struct W
+{
+  long tag;
+  struct H h;
+};
+
+/* A union's storage is deliberately shared between its members. */
+union U
+{
+  char c[4];
+  long l;
+};
+
+int main()
+{
+  struct S s;
+  struct S *p = &s;
+  p->n = 3;
+  p->buf[p->n] = 1;
+
+  struct H *h = malloc(sizeof(struct H) + 3 * sizeof(int));
+  if (h)
+  {
+    for (int i = 0; i < 4; i++)
+      h->qux[i] = i;
+    free(h);
+  }
+
+  struct HC *hc = malloc(sizeof(struct HC) + 16);
+  if (hc)
+  {
+    for (int i = 0; i < 8; i++)
+      hc->qux[i] = (char)i;
+    free(hc);
+  }
+
+  struct W *w = malloc(sizeof(struct W) + 3 * sizeof(int));
+  if (w)
+  {
+    w->h.qux[3] = 1;
+    free(w);
+  }
+
+  union U u;
+  union U *up = &u;
+  up->l = 0;
+  up->c[6] = 1;
+
+  return 0;
+}

--- a/regression/esbmc/github_6508_safe/main.c
+++ b/regression/esbmc/github_6508_safe/main.c
@@ -28,11 +28,13 @@ struct W
   struct H h;
 };
 
-/* A union's storage is deliberately shared between its members. */
+/* A union's storage is deliberately shared between its members. `long long'
+   rather than `long' so the union is 8 bytes under LLP64 (Windows) too and the
+   write below stays inside it. */
 union U
 {
   char c[4];
-  long l;
+  long long l;
 };
 
 int main()

--- a/regression/esbmc/github_6508_safe/test.desc
+++ b/regression/esbmc/github_6508_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -957,22 +957,57 @@ void goto_checkt::pointer_rel_check(
   }
 }
 
-static bool has_dereference(const expr2tc &expr)
+// Trailing padding is appended after the declared members (padding.cpp, the
+// `pad(components, components.end(), ...)` calls), so the last declared member
+// is the last non-`anon_pad$` entry. That one name is enough: of the four pad
+// kinds add_padding mints, `anon_bit_field_pad$` is only appended to a struct
+// that *ends* in bit-fields, `ext_int_pad$` only ever follows an _ExtInt
+// member, and `$pad` is union-only -- none of them can follow a trailing array.
+// The `char qux[1]` case in regression/esbmc/github_6508_safe pins this skip.
+static bool is_trailing_member(const type2tc &t, const irep_idt &name)
+{
+  const std::vector<irep_idt> names = struct_union_member_names(t);
+
+  auto it = names.rbegin();
+  while (it != names.rend() && has_prefix(*it, "anon_pad$"))
+    ++it;
+
+  return it != names.rend() && *it == name;
+}
+
+// True when `expr` may designate storage extending past its declared type,
+// i.e. a trailing member reached through a pointer. That is the struct-hack
+// idiom -- `struct { int n; T qux[1]; }` allocated with room for more than one
+// `qux` -- where the declared array bound does not govern the object actually
+// allocated (see 82b5ce54f7). An interior member array cannot be over-allocated
+// that way, so its declared bound does apply (C11 6.5.6p8).
+static bool may_be_over_allocated(const expr2tc &expr, const namespacet &ns)
 {
   if (is_dereference2t(expr))
     return true;
 
-  if (is_index2t(expr) && is_pointer_type(to_index2t(expr).source_value))
-    // This is an index of a pointer, which is a dereference
-    return true;
+  if (is_index2t(expr))
+    // An index into a pointer is a dereference; an index into a real array
+    // selects a fixed-size element, which cannot be over-allocated.
+    return is_pointer_type(to_index2t(expr).source_value);
 
-  // Recurse through all subsequent source objects, which are always operand
-  // zero.
-  bool found = false;
-  expr->foreach_operand(
-    [&found](const expr2tc &e) { found |= has_dereference(e); });
+  if (is_typecast2t(expr))
+    return may_be_over_allocated(to_typecast2t(expr).from, ns);
 
-  return found;
+  if (is_bitcast2t(expr))
+    return may_be_over_allocated(to_bitcast2t(expr).from, ns);
+
+  if (is_member2t(expr))
+  {
+    const member2t &memb = to_member2t(expr);
+    const type2tc &t = ns.follow(memb.source_value->type);
+    // A union's storage is deliberately shared, so reaching a larger sibling
+    // member through a smaller one is legitimate rather than an overflow.
+    return (is_union_type(t) || is_trailing_member(t, memb.member)) &&
+           may_be_over_allocated(memb.source_value, ns);
+  }
+
+  return false;
 }
 
 void goto_checkt::bounds_check(
@@ -1012,10 +1047,13 @@ void goto_checkt::bounds_check(
   if (is_pointer_type(t))
     return; // done by the pointer code
 
-  // Otherwise, if there's a dereference in the array source, this bounds check
-  // should be performed by the symex-time dereferencing code, as the base thing
-  // being accessed may be anything.
-  if (has_dereference(ind.source_value))
+  // Otherwise, if the object really being accessed may be larger than its
+  // declared type, defer to the symex-time dereferencing code, which bounds
+  // the allocation rather than the type. That only happens for a trailing
+  // member reached through a pointer; for an interior one the declared bound
+  // governs, and the symex-time check misses the overflow entirely because it
+  // still lands inside the enclosing object (issue #6508).
+  if (may_be_over_allocated(ind.source_value, ns))
     return;
 
   // We can't check bounds of an infinite sized array


### PR DESCRIPTION
`goto_checkt::bounds_check` skipped the declared array bound whenever the array
source contained a dereference (82b5ce54f7), deferring to the symex-time
dereference code -- which only bounds the enclosing object, so an overflow
landing on a sibling member was accepted. This restricts that bail-out to
arrays that may be over-allocated (a trailing member reached through a
pointer, i.e. the struct-hack idiom); interior arrays get their declared bound
back.

Note this also rejects an over-allocated *interior* fixed array, e.g. a
`struct { char data[8]; int n; }` used as a variable-length region: undefined
per C11 6.5.6p8, and consistent with clang `-fstrict-flex-arrays=3`. Trailing
arrays stay exempt, and overflowing one still leaves the enclosing object where
the existing dereference check catches it.

Verified by diffing goto-level claim counts between a control and patched
binary across the whole corpus: 712 of 8305 C/C++ tests change claims (~690 are
`esbmc-cpp/*` STL models), 0 of 151 sampled Python tests. Of those 712, the
only four verdict changes are the new tests below; `goto-coverage` metrics are
identical.

Fixes #6508
