### PR TITLE
Conclude the IREP2 roadmap; convert bodies natively by default

### DIFF
--- a/docs/roadmap/irep2-migration.md
+++ b/docs/roadmap/irep2-migration.md
@@ -3931,9 +3931,9 @@ The S-list frames S3 as "reproduce the pointer-deref / `p[i]`→`*(p+i)` / index
 typecast steps for the pointer-backed Python container/instance sources"
 (mirroring `clang_c_adjust::adjust_index`/`adjust_member`). A code audit shows
 that framing is a **legacy-`exprt` view that does not carry over to IREP2** — the
-Key-implementation-insight of `irep2-keystone-implementation-plan.md` (§"most of
-`clang_cpp_adjust`'s completion must happen at converter construction") is right,
-and this pins it for the index/member surface specifically:
+keystone plan's key implementation insight, that most of `clang_cpp_adjust`'s
+completion must happen at converter construction rather than in a post-pass, is
+right, and this pins it for the index/member surface specifically:
 
 - **`index2t`/`member2t` cannot hold a pointer source.** The construction asserts
   permit only array/vector (`index2t`, `irep2_expr.h:1646`) or struct/union

--- a/docs/roadmap/irep2-migration.md
+++ b/docs/roadmap/irep2-migration.md
@@ -3030,7 +3030,13 @@ so the body-seam back-migration disappears. Active work moves there.
 
 # Part V — Python frontend → **100 % IREP2** (the deep-pin program)
 
-> **Status: in progress.** Phase V.4 (IREP2-native bodies through
+> **Status: concluded — see §V.7** for the per-phase close-out and the measured
+> §V.1 bar. V.1k and V.4 (with its W1-loc successor) are done and default-on;
+> V.5 is deliberately deferred; V.1a, V.2 and V.6 are not started and are
+> recorded there with their reasons. The in-flight narrative below is kept as
+> the execution record.
+>
+> **Status while in flight: in progress.** Phase V.4 (IREP2-native bodies through
 > `goto_convert`) has landed V.4.0→V.4.3 across all frontends; **V.4.4a
 > flipped the flag on by default** (full-corpus verdict-parity sweep clean —
 > Bitwuzla + Z3; Python, C, C++ at every standard, floats, cstd, CUDA,
@@ -5165,3 +5171,86 @@ at the seam by design.** If the initiative *is* greenlit, **Phase V.1k
 (resolve-then-build) is the mandatory first spike** — it is the keystone, its
 proof obligation (RV2) is the highest-value question to settle, and every other
 converter phase is blocked on it.
+
+## V.7 Part V close-out (2026-07-29)
+
+Recorded in the §15.1 spirit: the plan sections above are the forward plan, and
+this is what the program actually reached. §V.6's recommendation — "unless ESBMC
+commits to the repo-wide initiative, the defensible target remains Part IV's" —
+was answered by *partially* committing: the two keystones were prosecuted to
+completion, and the remaining phases are closed with a recorded reason rather
+than left implicitly open.
+
+### Per-phase final status
+
+| Phase | Removes | Status | Where it is recorded |
+|---|---|---|---|
+| V.0 | — | **done** | harness/census tooling in use by every row below |
+| V.1k | W2 | **done** | the relaxed `member2t`/`index2t` construction assert (round 3 breakthrough), then every width-hazard and deferred-operand site in the converter migrated — the working plan that tracked those sites was deleted once drained; §"V.3 close-out (2026-07-04)" is the surviving record |
+| V.1k (b) adjuster | — | **structurally done, flip blocked** | `docs/roadmap/scope-v1k-adjuster.md` §"Flip gate (2026-07-29)" |
+| V.1a | — | **not started** | type builders still `lower_to_seam`; blocked on V.2 by the dependency graph in §V.3 |
+| V.2 | W3 | **not started** | the three legacy `#cpp_type`/`#member_name`/`#cformat` consumers are unchanged |
+| V.3 | — | **done for converter expression construction; bar #1/#2 not met** | §"V.3 close-out (2026-07-04)"; the residue is type/symbol-write surface, not expressions |
+| V.4 | W1 | **done** | V.4.0→V.4.4b landed; the deeper W1 removal reopened and completed as W1-loc, now default-on |
+| V.5 | W4 | **deferred, concluded** | see "Why V.5 is deferred" below — this is now the only record; its scope doc was deleted |
+| V.6 | — | **not reached** | requires V.1a + V.2 |
+
+### Why V.5 is deferred
+
+The counterexample printer (`c_expr2stringt` / `cpp_expr2stringt`, reached via
+`from_expr`) is the lowest-value Part V item, and the reasoning is worth keeping
+even though its scope document has been deleted:
+
+- **The value is all-or-nothing.** The only gain is deleting the
+  `migrate_expr_back` in `from_expr` (`language_util.h:18-24`) — a cleanliness
+  win on a path that runs once per reported counterexample, not a hot path. That
+  back-hop cannot go until **every** kind `convert_rec` can receive is handled
+  natively, because one fall-through re-introduces it. Migrating 10 of the ~159
+  kinds removes **zero** back-hops.
+- **The gate is strict per-kind byte-identity.** Counterexample text is asserted
+  verbatim by `test.desc` regexes, and the symbol *shorthand* machinery
+  (`id_shorthand` / `get_shorthands`) is expression-global, so even a bare symbol
+  is not a local rewrite.
+- **It duplicates a large surface** across two classes until the legacy printer
+  can be deleted, which needs every frontend's `from_expr` users migrated first.
+
+If it is ever taken, the only sound shape is a native `expr2string(ns, id,
+expr2tc)` that falls back to `migrate_expr_back` + the legacy printer for
+unmigrated kinds, gated on byte-identical output over the whole suite, migrated
+in dependency order (constants → symbols-with-shorthand → unary/binary with
+precedence → aggregates), with the fallback kept until the reachable-kind census
+is exhausted. Partial migration must **not** be tracked as progress.
+
+### The §V.1 acceptance bar, measured
+
+Re-run at this revision, the bar stands as follows. These are the honest
+numbers; the converter's *expression* surface being IREP2-native is not the same
+thing as the bar being met, and the two were easy to conflate while the work was
+in flight.
+
+| # | Bar | Measured | Met? |
+|---|---|---|---|
+| 1 | `git grep -P '\b([A-Za-z_]*(exprt\|typet\|codet)\|irept)\b' -- src/python-frontend` → ~0 | **5 495** | no |
+| 2 | `grep -rn 'set_type(\|set_value(' src/python-frontend \| grep -vc 2tc` → 0 | **100** | no |
+| 3 | bodies reach `goto_convert` with no `migrate_*` back-hop | native dispatcher is default-on; unsupported constructs still fall back to the round-trip (≈78.7 % of functions native on the `esbmc-cpp` census) | partially |
+| 4 | no `#`-attribute legacy escape hatch into a shared pass | W3 intact | no |
+
+Bar #3 is the one the program moved decisively: the round-trip is no longer
+*load-bearing for location fidelity* (the W1-loc result), so what remains is
+per-shape dispatcher coverage rather than a fidelity impossibility.
+
+### What is left, and why it is left
+
+Two items, both sized and neither speculative:
+
+1. **The coupled arithmetic-conversion effort** (operand-level reconciliation,
+   then the assignment conversion) — the sole remaining blocker on the
+   `python_adjust` flip. `scope-v1k-adjuster.md` sizes it as multi-PR and proves
+   that shipping either half alone is unsound.
+2. **V.2/W3 attribute carriage**, which V.1a and V.6 both depend on. Untouched;
+   the highest shared blast radius left in the program (`clang_cpp_adjust_expr`,
+   `cpp_expr2string`, `goto2c/expr2c` serve C++ and Solidity too).
+
+V.5 is closed rather than pending — see its scope doc. With those recorded, the
+V-track has no undocumented residue: every remaining item has a named owner
+document, a sized cost, and a stated reason it was not taken.

--- a/docs/roadmap/scope-v1k-adjuster.md
+++ b/docs/roadmap/scope-v1k-adjuster.md
@@ -3,6 +3,16 @@
 **Program:** Part V of `docs/roadmap/irep2-migration.md` (IREP2-native frontend→goto, #4715).
 **Question this scopes:** is the whole-body "resolve-then-build" adjuster the right
 next step to close the V.3 residue, and if so, what exactly does it own?
+**Status (2026-07-29): CONCLUDED as a scope — Goal A shipped, Goal B blocked on
+one named prerequisite.** Converter-construction 100 % (Goal A) is complete
+(#6323). The `python_adjust` flip (Goal B) is **not** taken: a denser,
+unbiased whole-corpus census refuted round 16's "no remaining verified
+divergence" and traced every genuine divergence to the single
+assignment/operand-conversion coupling this document already sized as multi-PR
+work. `--python-irep2-adjust-only` therefore stays default-off. See
+§"Flip gate (2026-07-29)" for the measurement and the remaining-work table; the
+narrative below is the execution record.
+
 **Status (updated 2026-07-23):** §5.1's Spike-1 conclusion ("adjuster
 unnecessary; finish inline") held *for Goal A* — **converter-construction 100%
 is now complete**: every arithmetic/relational/member/index node the Python
@@ -1222,6 +1232,109 @@ census** (the stride-20 sample is exhausted), plus deciding what to do about
 `nondet_string`: either implement it — which would make the six CORE `-fail`
 tests above assert something — or re-mark those tests, which currently pass
 regardless of the behaviour they name.
+### Flip gate (2026-07-29) — the denser census refutes the flip; the blocker is the assignment-conversion coupling
+
+Round 16 closed with "the next honest step is a **denser census** (the stride-20
+sample is exhausted)". That census was run, each test executed twice on one
+pinned binary — default (legacy `clang_cpp_adjust`) vs
+`--python-irep2-adjust-only` — with the `test.desc` flags replayed verbatim and
+a 90 s per-run cap, over two samples:
+
+| sample | tests | hop-off regressions |
+|---|---:|---:|
+| directory-order prefix (biased; kept only because it is what first surfaced the mechanism) | 672 | 2 |
+| every 4th directory (unbiased, 5× denser than the exhausted stride-20) | 1 108 | **6** |
+
+The strided run breaks down as 1 062 matches and 46 divergences, of which 31 are
+*both*-paths-no-verdict (pre-existing, not attributable to the adjuster), 9 are a
+harness artifact — those tests already carry `--python-irep2-adjust-only` in
+their own `test.desc`, so adding it again makes boost throw
+`multiple_occurrences`; any census on this track must skip tests that already
+pass the flag — and **6 are genuine**:
+
+| test | legacy | hop-off |
+|---|---|---|
+| `github_4344` | SUCCESSFUL | SIGSEGV |
+| `github_5571_fail` | FAILED | abort |
+| `github_5571_tuple_str_annotation` | SUCCESSFUL | abort |
+| `lambda15` | SUCCESSFUL | abort |
+| `precedence2` | SUCCESSFUL | FAILED (the false alarm this document already documents) |
+| `sum_tuple` | SUCCESSFUL | FAILED |
+
+`sum_tuple`'s own header comment names its subject as "Python's int->float
+promotion" — i.e. the sixth case corroborates the mechanism rather than adding a
+seventh.
+
+**Result: the flip is NOT ready, and round 16's "no remaining verified
+divergence" does not survive the denser sample** — it was an artifact of the
+stride-20 sample being too sparse (6 in 1 108 is ≈0.5 %, which a 220-test sample
+can easily miss entirely).
+
+Throughout, "hop-off regression" means legacy produces a verdict and hop-off
+does not, or produces a different one. Cases where *both* paths fail to produce
+a verdict — differing only in which signal, `rc=134` abort vs `rc=139` segfault
+— are pre-existing and not attributable to the adjuster; they are counted
+separately above.
+
+**Every genuine regression in both samples is the same defect, and it is the one
+this document already named.** They are not new per-case stragglers for another
+triage round — they are the *documented* "assignment-conversion trap" above,
+observed in a more severe form than that section recorded. The prefix sample's
+two are the clearest witnesses:
+
+| test | legacy | hop-off | mechanism |
+|---|---|---|---|
+| `builtin_all_nonliteral` | SUCCESSFUL | **SIGSEGV** in `smt_solver_baset::convert_assign` (`smt_solver.cpp:366`, `side2->assign(this, side1)`) | assignment conversion dropped |
+| `chained-comparison2_fail` | FAILED | **Bitwuzla abort**: "terms with mismatching sort at indices 0 and 1" | same |
+
+`builtin_all_nonliteral` pins the mechanism exactly. Normalising the
+`--goto-functions-only` dumps (strip timings, the docstring `OTHER` the hop-off
+elides, and instruction renumbering) leaves **one** substantive line:
+
+```
+legacy:   5: ASSIGN element=(_Bool)tmp$5;
+hop-off:  5: ASSIGN element=tmp$5;
+```
+
+The `_Bool`-typed target is assigned an unconverted integer. `python_adjust`
+never applies `adjust_assign`'s `gen_typecast(ns, code.op1(), code.op0().type())`,
+so the ill-typed assignment survives goto-conversion and symex and reaches the
+solver, where the destination AST is not the sort the source expects.
+`chained-comparison2_fail` is the same fault one layer up: `x` is retyped to
+float mid-function, and the chained comparison mixes sorts.
+
+**Why this changes the flip decision rather than adding a fix.** The "do not
+mirror `adjust_assign` alone" section above already proved that adding the
+assignment conversion by itself is *unsound*: it makes `neural-net_fail` report
+SUCCESSFUL where legacy correctly reports FAILED — masking a real bug. The
+sound fix is the coupled one that section sizes: operand-level arithmetic
+reconciliation (a faithful `adjust_expr_binary_arithmetic`, ~114 lines with
+complex promotion, `ieee_*` mapping for `floatbv`, and side-effect binding)
+landing **first**, with its own parity gate, and the assignment conversion on
+top. That is explicitly "a multi-PR effort in its own right".
+
+The new information is severity, not direction: the gap was recorded as a
+*false-alarm* class (`precedence2`), so it read as tolerable for an
+experimental flag. It is not — the same missing conversion crashes the solver
+outright, which is why the flag stays **default-off** and the flip does not
+ship with the W1-loc one.
+
+**Status of this scope, concluded.** Goal A (converter-construction 100 %) is
+complete and shipped. Goal B (the `clang_cpp_adjust` replacement) has all its
+*structural* work done — every blocker this document enumerated is closed or
+refuted — and is gated on exactly one remaining, named, sized prerequisite:
+
+| item | state |
+|---|---|
+| S1/S2 type + aggregate completion, exception ids, call rewrite, S4 width reconcile | landed |
+| S5 arg casts, `bases` carriage, S3 member/index at scale | closed / refuted (round 16) |
+| **operand-level arithmetic reconciliation + assignment conversion (coupled)** | **the only remaining blocker; multi-PR, not started** |
+| the flip itself (`python_adjust` as sole adjuster, default-on) | blocked on the row above |
+
+Next owner: take the coupled conversion effort as its own scope, then re-run
+this whole-corpus census as the flip gate. Do not re-triage per case — the
+census now names the single mechanism.
+
 ### Per-case triage round 14 — array decay at the call-argument seam (2026-07-28)
 
 **A strided whole-corpus census is now the frontier finder.** With round 11's open

--- a/docs/roadmap/spike-v1k-w1loc.md
+++ b/docs/roadmap/spike-v1k-w1loc.md
@@ -2,10 +2,14 @@
 
 **Program:** repo-wide "IREP2-native frontend→goto pipeline" (the Part V umbrella, #4715).
 **This issue:** the mandatory first spike. Read-only investigation + one throw-away prototype.
-**Owner:** TBD. **Status:** Phases A+B executed (2026-07-05) — **D3 selected (go),
-D1 ruled out; W1-loc refuted as a *fidelity* wall** (the barrier is native-
-dispatcher implementation cost, not location correctness). Phase C prototype is
-the next step. See Appendices A & B. **Refs:** #4715, Part V of
+**Owner:** TBD. **Status (2026-07-29): CONCLUDED — all four deliverables
+produced, native path default-on.** Phases A+B selected **D3** and refuted
+W1-loc as a *fidelity* wall (the barrier was native-dispatcher implementation
+cost, not location correctness); Phase C grew the dispatcher one `code_*2t` kind
+at a time until the reachable ladder was drained (Appendix D); Phase D's
+byte-identity gate is discharged and `--irep2-native-body` is now the **default**,
+with `--no-irep2-native-body` retained as the diagnostic escape hatch
+(Appendix F). See Appendices A–F. **Refs:** #4715, Part V of
 `docs/roadmap/irep2-migration.md`.
 
 ---
@@ -516,3 +520,80 @@ test pins the location by regex and was confirmed to **fail on a pre-patch
 build** and pass after — a location fix is otherwise invisible to a verdict-only
 test. It must be a C++ test: C rejects a non-constant global initializer, so the
 shape cannot be written in the C suite at all.
+
+## Appendix F — Phase D discharged; the native path is the default (2026-07-29)
+
+Deliverable (4). The spike's remaining step was never another `code_*2t` kind —
+Appendix D established the reachable ladder was drained — but the **flip**: the
+dispatcher was still behind a default-off `--irep2-native-body`, so the §5 gates
+were being discharged on a path no user ran. `--irep2-native-body` is now a
+deprecated no-op, the native dispatcher is the default, and
+**`--no-irep2-native-body`** is the escape hatch that restores the whole-body
+legacy round-trip.
+
+**Gate 1 — byte-identical GOTO (the §5 gate that matters here).** A strided
+sample of every 3rd directory in `regression/{esbmc,cbmc,esbmc-cpp/cpp}` —
+**832 tests** — comparing `--goto-functions-only` default vs
+`--no-irep2-native-body`:
+
+| outcome | n | |
+|---|---:|---|
+| byte-identical | **820** | |
+| not runnable on this host | 10 | `--boolector` / `--k-induction --boolector` etc. not built here; reported as SKIP, never counted as a match |
+| unstable against themselves | 2 | `cpp_sum_class_bug`, `cpp_queue_pop_bug` — see the control below |
+| **attributable divergences** | **0** | |
+
+The two unstable tests both run `--k-induction-parallel`, which forks children
+that share the parent's stderr; the captured output interleaves and garbles
+(`ConvertingConverting`, a `WARNING:` line spliced into a `DECL` line). A
+**control run comparing each path against itself** — same flags twice, native
+vs native and opt-out vs opt-out — is UNSTABLE in both configurations, so the
+difference reproduces without any dispatcher change and is not attributable.
+`--k-induction-parallel` tests must be excluded from, or serialized in, any
+byte-identity sweep on this track.
+
+**Gate 2 — the native path is actually taken (C-Live).** Temporary
+instrumentation at the dispatch (added, measured, reverted) on a body mixing
+decl / expression-assignment / `for` / `switch` / `if-else` / `return`:
+
+```
+default:                (nothing for classify — converted natively)
+                        PROBE_FALLBACK optout=0 c:@F@main
+--no-irep2-native-body: PROBE_FALLBACK optout=1 c:@F@classify
+                        PROBE_FALLBACK optout=1 c:@F@main
+```
+
+So the native branch is live with no flag, and the opt-out branch is live too —
+both arms of the new condition discharged, not just assumed. (`main` falls back
+in both: its `assert(classify(0) == 4)` has a result-used call in the guard, an
+existing guard fallback, not a missing kind.)
+
+**Gate 3 — verdicts.** `-R github_4715` 104/108, unit suite 584/584. The 4
+failures are `esbmc-solidity` and **fail identically on unmodified master**
+(no `solc` on this host).
+
+**Sweep methodology — four normalization gaps this run added.** Each first
+presented as a "divergence" and none was one. Recording them because every
+prior row in this table under-normalized at least once, and the failure mode is
+always "a real-looking mismatch that is really the harness":
+
+1. The C++ header tmpdir is `esbmc-cpp-headers-<hex>-<hex>-<hex>` — a narrower
+   regex than the documented one misses it (49 false mismatches).
+2. Generated nested-function filenames carry a **two**-group hex,
+   `esbmc-nested.<hex>-<hex>.c` — the three-group rule misses it (5 false
+   mismatches, the whole `gcc_nested_func_*` cluster).
+3. `Interval Analysis time:` is a **third** timing line beyond the two already
+   documented (1 false mismatch).
+4. A `test.desc` that already contains `--goto-functions-only` gets it twice and
+   boost throws `multiple_occurrences`, collapsing the capture to one error
+   line. **Both** sides collapse identically, so without a minimum-size guard
+   this counts as a *match* — the same class of false zero as the withdrawn
+   stderr figure. A `< 200 bytes → SKIP` guard catches it.
+
+**What this closes and what it does not.** The spike is concluded: D3 was
+selected, implemented, proven byte-identical, and is now the default. What
+remains is **not** spike work — it is the ≈21 % of functions that still take a
+*guard* fallback (Appendix D finding 2: side-effecting conditions the coverage
+options touch, array/VLA decls, atomic or code-typed operands), each a
+shape-by-shape slice with diminishing value. The round-trip therefore still
+exists as a fallback and cannot be deleted; §V.1 bar #3 is advanced, not met.

--- a/regression/esbmc/github_4715_irep2_native_body_default_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_default_01/main.c
@@ -1,0 +1,35 @@
+// The IREP2-native goto_convert dispatcher is the default since the W1-loc
+// keystone concluded (esbmc/esbmc#4715): this body converts natively with no
+// flag on the command line. It mixes the kinds the native ladder covers —
+// decl, expression-statement assignment, for, if/else, switch, return — so a
+// regression that silently reverted the default would still verify, but the
+// companion _optout_ test pins that both paths agree.
+#include <assert.h>
+
+int classify(int n)
+{
+  int acc = 0;
+  for (int i = 0; i < 3; i++)
+    acc += i;
+
+  switch (n)
+  {
+  case 0:
+    acc = acc + 1;
+    break;
+  default:
+    acc = acc - 1;
+  }
+
+  if (acc > 0)
+    return acc;
+  else
+    return 0;
+}
+
+int main(void)
+{
+  assert(classify(0) == 4);
+  assert(classify(7) == 2);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_default_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_default_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_default_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_default_01_fail/main.c
@@ -1,0 +1,32 @@
+// Negative twin of github_4715_irep2_native_body_default_01: the same natively
+// converted body, with an assertion the computation violates. Pins that the
+// default native path still reports the violation rather than verifying
+// vacuously.
+#include <assert.h>
+
+int classify(int n)
+{
+  int acc = 0;
+  for (int i = 0; i < 3; i++)
+    acc += i;
+
+  switch (n)
+  {
+  case 0:
+    acc = acc + 1;
+    break;
+  default:
+    acc = acc - 1;
+  }
+
+  if (acc > 0)
+    return acc;
+  else
+    return 0;
+}
+
+int main(void)
+{
+  assert(classify(0) == 5);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_default_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_default_01_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_optout_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_optout_01/main.c
@@ -1,0 +1,34 @@
+// --no-irep2-native-body is the escape hatch that restores the whole-body
+// legacy round-trip (esbmc/esbmc#4715). Same body as
+// github_4715_irep2_native_body_default_01; the two tests together pin that
+// opting out changes no verdict, which is the property the byte-identity gate
+// asserts at GOTO level.
+#include <assert.h>
+
+int classify(int n)
+{
+  int acc = 0;
+  for (int i = 0; i < 3; i++)
+    acc += i;
+
+  switch (n)
+  {
+  case 0:
+    acc = acc + 1;
+    break;
+  default:
+    acc = acc - 1;
+  }
+
+  if (acc > 0)
+    return acc;
+  else
+    return 0;
+}
+
+int main(void)
+{
+  assert(classify(0) == 4);
+  assert(classify(7) == 2);
+  return 0;
+}

--- a/regression/esbmc/github_4715_irep2_native_body_optout_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_optout_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4 --no-irep2-native-body
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -963,13 +963,17 @@ const struct group_opt_templ all_cmd_options[] = {
      "bypass and the --no-irep2-bodies escape hatch have been removed."},
     {"irep2-native-body",
      NULL,
-     "Experimental, default off (W1-loc spike Phase C, esbmc/esbmc#4715). "
-     "Route function bodies to an IREP2-native goto_convert that consumes "
-     "code_*2t directly and inherits the statement location onto value "
-     "operands at consumption, skipping the whole-body legacy round-trip. "
-     "Grown one statement kind at a time; any body containing an unsupported "
-     "construct falls back to the round-trip path, so flag-on is byte-"
-     "identical to flag-off until the native path is complete."}}},
+     "Deprecated no-op (accepted for backward compatibility). Function bodies "
+     "are routed to the IREP2-native goto_convert by default since the W1-loc "
+     "keystone concluded; --no-irep2-native-body opts out."},
+    {"no-irep2-native-body",
+     NULL,
+     "Convert function bodies through the whole-body legacy round-trip "
+     "instead of the IREP2-native goto_convert (esbmc/esbmc#4715). The native "
+     "path consumes code_*2t directly and inherits the statement location "
+     "onto value operands at consumption; a body containing an unsupported "
+     "construct falls back to the round-trip either way, so this is a "
+     "diagnostic escape hatch, not a semantic switch."}}},
   {"end", {{"", NULL, "End of options"}}},
   {"Hidden Options",
    {{"depth", boost::program_options::value<int>(), "Instruction"},

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -1447,14 +1447,15 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   targets.has_return_value =
     to_code_type(f.type).ret_type->type_id != type2t::empty_id;
 
-  // W1-loc spike Phase C (esbmc/esbmc#4715): --irep2-native-body routes the
-  // body through the IREP2-native dispatcher, which consumes code_*2t directly
-  // (no whole-body legacy round-trip) and inherits statement locations onto
-  // value operands. Until every kind in this body is supported it returns
-  // false and we fall back to goto_convert_rec on the round-tripped `code`, so
-  // flag-on is byte-identical to flag-off. `code`/`end_location` above are
-  // still computed from the round-trip; the native path only replaces the
-  // body-instruction dispatch.
+  // W1-loc keystone (esbmc/esbmc#4715): the body goes through the IREP2-native
+  // dispatcher, which consumes code_*2t directly (no whole-body legacy
+  // round-trip) and inherits statement locations onto value operands. Until
+  // every kind in this body is supported it returns false and we fall back to
+  // goto_convert_rec on the round-tripped `code`, so the native path is
+  // byte-identical to the round-trip. `code`/`end_location` above are still
+  // computed from the round-trip; the native path only replaces the
+  // body-instruction dispatch. --no-irep2-native-body forces the round-trip
+  // for diagnosis.
   //
   // A native attempt that reaches a side-effecting code_while2t condition or
   // a code_assign2t with a function-call rhs (below) calls the shared
@@ -1472,7 +1473,7 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   unsigned tmp_counter_before = tmp_symbol.counter;
   irep_idt context_mark_before = context.mark();
   targetst targets_before = targets;
-  if (!(options.get_bool_option("irep2-native-body") &&
+  if (!(!options.get_bool_option("no-irep2-native-body") &&
         try_convert_body_native(symbol.get_value2(), f.body)))
   {
     tmp_symbol.counter = tmp_counter_before;

--- a/src/goto-programs/goto_convert_functions.h
+++ b/src/goto-programs/goto_convert_functions.h
@@ -63,8 +63,8 @@ protected:
   // locations byte-identically). Returns true iff every statement kind in
   // `body2` is supported by the native dispatcher; returns false — leaving
   // `dest` untouched — the moment it meets an unsupported kind, so the caller
-  // falls back to `goto_convert_rec` and flag-on stays byte-identical to
-  // flag-off until the native path is complete. Gated on --irep2-native-body.
+  // falls back to `goto_convert_rec` and the native path stays byte-identical
+  // to the round-trip. Default on; --no-irep2-native-body forces the fallback.
   bool try_convert_body_native(const expr2tc &body2, goto_programt &dest);
 
   // Consume one IREP2 statement `code2` natively, appending to `dest`. Returns

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -290,12 +290,12 @@ bool python_languaget::typecheck(contextt &context, const std::string &)
 
   // V.4 hop-off: with --python-irep2-adjust-only the IREP2-native adjuster
   // *replaces* clang_cpp_adjust on the Python path (the B.5 "sole adjuster"
-  // milestone, gated behind a default-off flag). A 2026-07-24 corrected census
-  // over regression/python (228/228 on the a-b prefix, 290/291 on an unbiased
-  // strided whole-corpus sample) showed verdict parity with the legacy pass and
-  // zero wrong verdicts; docs/scope-v1k-adjuster.md records the method. The one
-  // known non-parity case (boolop-len-or) is a load-dependent solver-time
-  // timeout, not a type-resolution defect, so the hop-off stays experimental.
+  // milestone, gated behind a default-off flag). It stays default-off: a
+  // whole-corpus legacy-vs-hop-off census (2026-07-29) found the missing
+  // assignment/operand conversion documented in docs/roadmap/scope-v1k-adjuster.md
+  // ("the assignment-conversion trap") reaches the solver as an ill-typed term
+  // and crashes it, so the flip waits on the coupled arithmetic-reconciliation
+  // effort that section sizes.
   if (config.options.get_bool_option("python-irep2-adjust-only"))
   {
     python_adjust py_adjuster(context);

--- a/src/util/symtab/context.h
+++ b/src/util/symtab/context.h
@@ -121,7 +121,7 @@ public:
 
   /// Id of the most-recently-added symbol, or a nil id if the table is empty.
   /// Pair with erase_since() to roll back a speculative batch of add() calls
-  /// (e.g. a discarded --irep2-native-body attempt, esbmc/esbmc#4715) in
+  /// (e.g. a discarded IREP2-native goto_convert attempt, esbmc/esbmc#4715) in
   /// O(k) for k symbols undone, instead of an O(n) scan of the whole table.
   irep_idt mark() const;
 


### PR DESCRIPTION
Concludes the five IREP2 roadmap plans under `docs/roadmap/` and lands the one
piece of remaining implementation whose gate passes: the IREP2-native
`goto_convert` becomes the default, with `--no-irep2-native-body` as the escape
hatch and `--irep2-native-body` kept as a deprecated no-op.

Gated on a strided 832-test byte-identity sweep (0 attributable divergences),
C-Live instrumentation proving both branches reachable, and a 966-test
cross-suite ctest sample whose 89 failures match unmodified master exactly.

The `python_adjust` flip is deliberately **not** taken: a denser unbiased census
(1108 tests) found six genuine regressions, all the documented
assignment-conversion coupling, which crashes the solver rather than merely
raising a false alarm. That flag stays default-off and the docs record the
measurement and the remaining prerequisite.

Refs #4715