### PR TITLE
[om] Make <limits> parse under --std c++03

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03/main.cpp
@@ -1,0 +1,28 @@
+#include <limits>
+#include <cassert>
+#include <climits>
+#include <cfloat>
+
+int main()
+{
+  assert(std::numeric_limits<int>::is_specialized);
+  assert(std::numeric_limits<int>::is_signed);
+  assert(std::numeric_limits<int>::is_integer);
+  assert(std::numeric_limits<int>::digits == 31);
+  assert(std::numeric_limits<int>::min() == INT_MIN);
+  assert(std::numeric_limits<int>::max() == INT_MAX);
+  assert(std::numeric_limits<unsigned>::min() == 0u);
+  assert(std::numeric_limits<unsigned>::max() == UINT_MAX);
+  assert(!std::numeric_limits<unsigned>::is_signed);
+  assert(std::numeric_limits<char>::is_specialized);
+  assert(std::numeric_limits<double>::is_iec559);
+  assert(std::numeric_limits<double>::has_infinity);
+  assert(!std::numeric_limits<double>::is_integer);
+  assert(std::numeric_limits<double>::radix == FLT_RADIX);
+  assert(std::numeric_limits<double>::max() == DBL_MAX);
+  assert(std::numeric_limits<float>::epsilon() == FLT_EPSILON);
+  assert(std::numeric_limits<float>::round_style == std::round_to_nearest);
+  assert(std::numeric_limits<long>::max() == LONG_MAX);
+  assert(std::numeric_limits<short>::min() == SHRT_MIN);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <limits>
+#include <cassert>
+#include <climits>
+
+// Negative counterpart of github_3387_limits_c++03: confirms the C++03
+// numeric_limits members carry their real values rather than being vacuously
+// true, by asserting a wrong one.
+
+int main()
+{
+  assert(std::numeric_limits<int>::digits == 30);
+  assert(std::numeric_limits<int>::max() == INT_MAX);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_3387_limits_c++03_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/OM_compiler_defs.h
+++ b/src/cpp/library/OM_compiler_defs.h
@@ -18,3 +18,12 @@
 #  define OM_NOEXCEPT
 #  define OM_NULLPTR 0
 #endif
+
+// A static data member with an in-class initialiser. OM_CONSTEXPR alone is not
+// enough: eliding `constexpr` would leave a non-const member, which C++03 does
+// not let you initialise in-class. Only valid for integral and enum types.
+#if __cplusplus >= 201103L
+#  define OM_STATIC_CONSTANT static constexpr
+#else
+#  define OM_STATIC_CONSTANT static const
+#endif

--- a/src/cpp/library/limits
+++ b/src/cpp/library/limits
@@ -3,6 +3,7 @@
 
 #include <climits>
 #include <cfloat>
+#include "OM_compiler_defs.h" // OM_CONSTEXPR, OM_NOEXCEPT, OM_STATIC_CONSTANT
 
 namespace std
 {
@@ -28,39 +29,39 @@ template <class T>
 class numeric_limits
 {
 public:
-  static constexpr bool is_specialized = false;
-  static constexpr bool is_signed = false;
-  static constexpr bool is_integer = false;
-  static constexpr bool is_exact = false;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = false;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = 0;
-  static constexpr int digits10 = 0;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 0;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = false;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = false;
+  OM_STATIC_CONSTANT bool is_signed = false;
+  OM_STATIC_CONSTANT bool is_integer = false;
+  OM_STATIC_CONSTANT bool is_exact = false;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = false;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = 0;
+  OM_STATIC_CONSTANT int digits10 = 0;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 0;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = false;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr T min() noexcept { return T(); }
-  static constexpr T lowest() noexcept { return T(); }
-  static constexpr T max() noexcept { return T(); }
-  static constexpr T epsilon() noexcept { return T(); }
-  static constexpr T round_error() noexcept { return T(); }
-  static constexpr T infinity() noexcept { return T(); }
-  static constexpr T quiet_NaN() noexcept { return T(); }
-  static constexpr T signaling_NaN() noexcept { return T(); }
-  static constexpr T denorm_min() noexcept { return T(); }
+  static OM_CONSTEXPR T min() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T lowest() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T max() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T epsilon() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T round_error() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T infinity() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T quiet_NaN() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T signaling_NaN() OM_NOEXCEPT { return T(); }
+  static OM_CONSTEXPR T denorm_min() OM_NOEXCEPT { return T(); }
 };
 
 // bool
@@ -68,39 +69,39 @@ template <>
 class numeric_limits<bool>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = false;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = 1;
-  static constexpr int digits10 = 0;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = false;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = false;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = 1;
+  OM_STATIC_CONSTANT int digits10 = 0;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = false;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr bool min() noexcept { return false; }
-  static constexpr bool lowest() noexcept { return false; }
-  static constexpr bool max() noexcept { return true; }
-  static constexpr bool epsilon() noexcept { return false; }
-  static constexpr bool round_error() noexcept { return false; }
-  static constexpr bool infinity() noexcept { return false; }
-  static constexpr bool quiet_NaN() noexcept { return false; }
-  static constexpr bool signaling_NaN() noexcept { return false; }
-  static constexpr bool denorm_min() noexcept { return false; }
+  static OM_CONSTEXPR bool min() OM_NOEXCEPT { return false; }
+  static OM_CONSTEXPR bool lowest() OM_NOEXCEPT { return false; }
+  static OM_CONSTEXPR bool max() OM_NOEXCEPT { return true; }
+  static OM_CONSTEXPR bool epsilon() OM_NOEXCEPT { return false; }
+  static OM_CONSTEXPR bool round_error() OM_NOEXCEPT { return false; }
+  static OM_CONSTEXPR bool infinity() OM_NOEXCEPT { return false; }
+  static OM_CONSTEXPR bool quiet_NaN() OM_NOEXCEPT { return false; }
+  static OM_CONSTEXPR bool signaling_NaN() OM_NOEXCEPT { return false; }
+  static OM_CONSTEXPR bool denorm_min() OM_NOEXCEPT { return false; }
 };
 
 // char
@@ -108,39 +109,39 @@ template <>
 class numeric_limits<char>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = (CHAR_MIN < 0);
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = (CHAR_MIN == 0);
-  static constexpr int digits = (CHAR_MIN < 0) ? CHAR_BIT - 1 : CHAR_BIT;
-  static constexpr int digits10 = digits * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = (CHAR_MIN < 0);
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = (CHAR_MIN == 0);
+  OM_STATIC_CONSTANT int digits = (CHAR_MIN < 0) ? CHAR_BIT - 1 : CHAR_BIT;
+  OM_STATIC_CONSTANT int digits10 = digits * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr char min() noexcept { return CHAR_MIN; }
-  static constexpr char lowest() noexcept { return CHAR_MIN; }
-  static constexpr char max() noexcept { return CHAR_MAX; }
-  static constexpr char epsilon() noexcept { return 0; }
-  static constexpr char round_error() noexcept { return 0; }
-  static constexpr char infinity() noexcept { return 0; }
-  static constexpr char quiet_NaN() noexcept { return 0; }
-  static constexpr char signaling_NaN() noexcept { return 0; }
-  static constexpr char denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR char min() OM_NOEXCEPT { return CHAR_MIN; }
+  static OM_CONSTEXPR char lowest() OM_NOEXCEPT { return CHAR_MIN; }
+  static OM_CONSTEXPR char max() OM_NOEXCEPT { return CHAR_MAX; }
+  static OM_CONSTEXPR char epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR char round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR char infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR char quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR char signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR char denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // signed char
@@ -148,39 +149,39 @@ template <>
 class numeric_limits<signed char>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = CHAR_BIT - 1;
-  static constexpr int digits10 = (CHAR_BIT - 1) * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = CHAR_BIT - 1;
+  OM_STATIC_CONSTANT int digits10 = (CHAR_BIT - 1) * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr signed char min() noexcept { return SCHAR_MIN; }
-  static constexpr signed char lowest() noexcept { return SCHAR_MIN; }
-  static constexpr signed char max() noexcept { return SCHAR_MAX; }
-  static constexpr signed char epsilon() noexcept { return 0; }
-  static constexpr signed char round_error() noexcept { return 0; }
-  static constexpr signed char infinity() noexcept { return 0; }
-  static constexpr signed char quiet_NaN() noexcept { return 0; }
-  static constexpr signed char signaling_NaN() noexcept { return 0; }
-  static constexpr signed char denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR signed char min() OM_NOEXCEPT { return SCHAR_MIN; }
+  static OM_CONSTEXPR signed char lowest() OM_NOEXCEPT { return SCHAR_MIN; }
+  static OM_CONSTEXPR signed char max() OM_NOEXCEPT { return SCHAR_MAX; }
+  static OM_CONSTEXPR signed char epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR signed char round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR signed char infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR signed char quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR signed char signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR signed char denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // unsigned char
@@ -188,39 +189,39 @@ template <>
 class numeric_limits<unsigned char>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = false;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = true;
-  static constexpr int digits = CHAR_BIT;
-  static constexpr int digits10 = CHAR_BIT * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = false;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = true;
+  OM_STATIC_CONSTANT int digits = CHAR_BIT;
+  OM_STATIC_CONSTANT int digits10 = CHAR_BIT * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr unsigned char min() noexcept { return 0; }
-  static constexpr unsigned char lowest() noexcept { return 0; }
-  static constexpr unsigned char max() noexcept { return UCHAR_MAX; }
-  static constexpr unsigned char epsilon() noexcept { return 0; }
-  static constexpr unsigned char round_error() noexcept { return 0; }
-  static constexpr unsigned char infinity() noexcept { return 0; }
-  static constexpr unsigned char quiet_NaN() noexcept { return 0; }
-  static constexpr unsigned char signaling_NaN() noexcept { return 0; }
-  static constexpr unsigned char denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR unsigned char min() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned char lowest() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned char max() OM_NOEXCEPT { return UCHAR_MAX; }
+  static OM_CONSTEXPR unsigned char epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned char round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned char infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned char quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned char signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned char denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // short
@@ -228,39 +229,39 @@ template <>
 class numeric_limits<short>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = sizeof(short) * CHAR_BIT - 1;
-  static constexpr int digits10 = (sizeof(short) * CHAR_BIT - 1) * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = sizeof(short) * CHAR_BIT - 1;
+  OM_STATIC_CONSTANT int digits10 = (sizeof(short) * CHAR_BIT - 1) * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr short min() noexcept { return SHRT_MIN; }
-  static constexpr short lowest() noexcept { return SHRT_MIN; }
-  static constexpr short max() noexcept { return SHRT_MAX; }
-  static constexpr short epsilon() noexcept { return 0; }
-  static constexpr short round_error() noexcept { return 0; }
-  static constexpr short infinity() noexcept { return 0; }
-  static constexpr short quiet_NaN() noexcept { return 0; }
-  static constexpr short signaling_NaN() noexcept { return 0; }
-  static constexpr short denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR short min() OM_NOEXCEPT { return SHRT_MIN; }
+  static OM_CONSTEXPR short lowest() OM_NOEXCEPT { return SHRT_MIN; }
+  static OM_CONSTEXPR short max() OM_NOEXCEPT { return SHRT_MAX; }
+  static OM_CONSTEXPR short epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR short round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR short infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR short quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR short signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR short denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // unsigned short
@@ -268,39 +269,39 @@ template <>
 class numeric_limits<unsigned short>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = false;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = true;
-  static constexpr int digits = sizeof(unsigned short) * CHAR_BIT;
-  static constexpr int digits10 = sizeof(unsigned short) * CHAR_BIT * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = false;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = true;
+  OM_STATIC_CONSTANT int digits = sizeof(unsigned short) * CHAR_BIT;
+  OM_STATIC_CONSTANT int digits10 = sizeof(unsigned short) * CHAR_BIT * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr unsigned short min() noexcept { return 0; }
-  static constexpr unsigned short lowest() noexcept { return 0; }
-  static constexpr unsigned short max() noexcept { return USHRT_MAX; }
-  static constexpr unsigned short epsilon() noexcept { return 0; }
-  static constexpr unsigned short round_error() noexcept { return 0; }
-  static constexpr unsigned short infinity() noexcept { return 0; }
-  static constexpr unsigned short quiet_NaN() noexcept { return 0; }
-  static constexpr unsigned short signaling_NaN() noexcept { return 0; }
-  static constexpr unsigned short denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR unsigned short min() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned short lowest() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned short max() OM_NOEXCEPT { return USHRT_MAX; }
+  static OM_CONSTEXPR unsigned short epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned short round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned short infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned short quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned short signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned short denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // int
@@ -308,39 +309,39 @@ template <>
 class numeric_limits<int>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = sizeof(int) * CHAR_BIT - 1;
-  static constexpr int digits10 = (sizeof(int) * CHAR_BIT - 1) * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = sizeof(int) * CHAR_BIT - 1;
+  OM_STATIC_CONSTANT int digits10 = (sizeof(int) * CHAR_BIT - 1) * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr int min() noexcept { return INT_MIN; }
-  static constexpr int lowest() noexcept { return INT_MIN; }
-  static constexpr int max() noexcept { return INT_MAX; }
-  static constexpr int epsilon() noexcept { return 0; }
-  static constexpr int round_error() noexcept { return 0; }
-  static constexpr int infinity() noexcept { return 0; }
-  static constexpr int quiet_NaN() noexcept { return 0; }
-  static constexpr int signaling_NaN() noexcept { return 0; }
-  static constexpr int denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR int min() OM_NOEXCEPT { return INT_MIN; }
+  static OM_CONSTEXPR int lowest() OM_NOEXCEPT { return INT_MIN; }
+  static OM_CONSTEXPR int max() OM_NOEXCEPT { return INT_MAX; }
+  static OM_CONSTEXPR int epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR int round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR int infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR int quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR int signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR int denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // unsigned int
@@ -348,39 +349,39 @@ template <>
 class numeric_limits<unsigned int>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = false;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = true;
-  static constexpr int digits = sizeof(unsigned int) * CHAR_BIT;
-  static constexpr int digits10 = sizeof(unsigned int) * CHAR_BIT * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = false;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = true;
+  OM_STATIC_CONSTANT int digits = sizeof(unsigned int) * CHAR_BIT;
+  OM_STATIC_CONSTANT int digits10 = sizeof(unsigned int) * CHAR_BIT * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr unsigned int min() noexcept { return 0; }
-  static constexpr unsigned int lowest() noexcept { return 0; }
-  static constexpr unsigned int max() noexcept { return UINT_MAX; }
-  static constexpr unsigned int epsilon() noexcept { return 0; }
-  static constexpr unsigned int round_error() noexcept { return 0; }
-  static constexpr unsigned int infinity() noexcept { return 0; }
-  static constexpr unsigned int quiet_NaN() noexcept { return 0; }
-  static constexpr unsigned int signaling_NaN() noexcept { return 0; }
-  static constexpr unsigned int denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR unsigned int min() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned int lowest() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned int max() OM_NOEXCEPT { return UINT_MAX; }
+  static OM_CONSTEXPR unsigned int epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned int round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned int infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned int quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned int signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned int denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // long
@@ -388,39 +389,39 @@ template <>
 class numeric_limits<long>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = sizeof(long) * CHAR_BIT - 1;
-  static constexpr int digits10 = (sizeof(long) * CHAR_BIT - 1) * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = sizeof(long) * CHAR_BIT - 1;
+  OM_STATIC_CONSTANT int digits10 = (sizeof(long) * CHAR_BIT - 1) * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr long min() noexcept { return LONG_MIN; }
-  static constexpr long lowest() noexcept { return LONG_MIN; }
-  static constexpr long max() noexcept { return LONG_MAX; }
-  static constexpr long epsilon() noexcept { return 0; }
-  static constexpr long round_error() noexcept { return 0; }
-  static constexpr long infinity() noexcept { return 0; }
-  static constexpr long quiet_NaN() noexcept { return 0; }
-  static constexpr long signaling_NaN() noexcept { return 0; }
-  static constexpr long denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR long min() OM_NOEXCEPT { return LONG_MIN; }
+  static OM_CONSTEXPR long lowest() OM_NOEXCEPT { return LONG_MIN; }
+  static OM_CONSTEXPR long max() OM_NOEXCEPT { return LONG_MAX; }
+  static OM_CONSTEXPR long epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // unsigned long
@@ -428,39 +429,39 @@ template <>
 class numeric_limits<unsigned long>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = false;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = true;
-  static constexpr int digits = sizeof(unsigned long) * CHAR_BIT;
-  static constexpr int digits10 = sizeof(unsigned long) * CHAR_BIT * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = false;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = true;
+  OM_STATIC_CONSTANT int digits = sizeof(unsigned long) * CHAR_BIT;
+  OM_STATIC_CONSTANT int digits10 = sizeof(unsigned long) * CHAR_BIT * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr unsigned long min() noexcept { return 0; }
-  static constexpr unsigned long lowest() noexcept { return 0; }
-  static constexpr unsigned long max() noexcept { return ULONG_MAX; }
-  static constexpr unsigned long epsilon() noexcept { return 0; }
-  static constexpr unsigned long round_error() noexcept { return 0; }
-  static constexpr unsigned long infinity() noexcept { return 0; }
-  static constexpr unsigned long quiet_NaN() noexcept { return 0; }
-  static constexpr unsigned long signaling_NaN() noexcept { return 0; }
-  static constexpr unsigned long denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR unsigned long min() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long lowest() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long max() OM_NOEXCEPT { return ULONG_MAX; }
+  static OM_CONSTEXPR unsigned long epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // long long
@@ -468,39 +469,39 @@ template <>
 class numeric_limits<long long>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = sizeof(long long) * CHAR_BIT - 1;
-  static constexpr int digits10 = (sizeof(long long) * CHAR_BIT - 1) * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = sizeof(long long) * CHAR_BIT - 1;
+  OM_STATIC_CONSTANT int digits10 = (sizeof(long long) * CHAR_BIT - 1) * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr long long min() noexcept { return LLONG_MIN; }
-  static constexpr long long lowest() noexcept { return LLONG_MIN; }
-  static constexpr long long max() noexcept { return LLONG_MAX; }
-  static constexpr long long epsilon() noexcept { return 0; }
-  static constexpr long long round_error() noexcept { return 0; }
-  static constexpr long long infinity() noexcept { return 0; }
-  static constexpr long long quiet_NaN() noexcept { return 0; }
-  static constexpr long long signaling_NaN() noexcept { return 0; }
-  static constexpr long long denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR long long min() OM_NOEXCEPT { return LLONG_MIN; }
+  static OM_CONSTEXPR long long lowest() OM_NOEXCEPT { return LLONG_MIN; }
+  static OM_CONSTEXPR long long max() OM_NOEXCEPT { return LLONG_MAX; }
+  static OM_CONSTEXPR long long epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long long round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long long infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long long quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long long signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR long long denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // unsigned long long
@@ -508,39 +509,39 @@ template <>
 class numeric_limits<unsigned long long>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = false;
-  static constexpr bool is_integer = true;
-  static constexpr bool is_exact = true;
-  static constexpr bool has_infinity = false;
-  static constexpr bool has_quiet_NaN = false;
-  static constexpr bool has_signaling_NaN = false;
-  static constexpr float_denorm_style has_denorm = denorm_absent;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_toward_zero;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = true;
-  static constexpr int digits = sizeof(unsigned long long) * CHAR_BIT;
-  static constexpr int digits10 = sizeof(unsigned long long) * CHAR_BIT * 3 / 10;
-  static constexpr int max_digits10 = 0;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = 0;
-  static constexpr int min_exponent10 = 0;
-  static constexpr int max_exponent = 0;
-  static constexpr int max_exponent10 = 0;
-  static constexpr bool traps = true;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = false;
+  OM_STATIC_CONSTANT bool is_integer = true;
+  OM_STATIC_CONSTANT bool is_exact = true;
+  OM_STATIC_CONSTANT bool has_infinity = false;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = false;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = false;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_absent;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_toward_zero;
+  OM_STATIC_CONSTANT bool is_iec559 = false;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = true;
+  OM_STATIC_CONSTANT int digits = sizeof(unsigned long long) * CHAR_BIT;
+  OM_STATIC_CONSTANT int digits10 = sizeof(unsigned long long) * CHAR_BIT * 3 / 10;
+  OM_STATIC_CONSTANT int max_digits10 = 0;
+  OM_STATIC_CONSTANT int radix = 2;
+  OM_STATIC_CONSTANT int min_exponent = 0;
+  OM_STATIC_CONSTANT int min_exponent10 = 0;
+  OM_STATIC_CONSTANT int max_exponent = 0;
+  OM_STATIC_CONSTANT int max_exponent10 = 0;
+  OM_STATIC_CONSTANT bool traps = true;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr unsigned long long min() noexcept { return 0; }
-  static constexpr unsigned long long lowest() noexcept { return 0; }
-  static constexpr unsigned long long max() noexcept { return ULLONG_MAX; }
-  static constexpr unsigned long long epsilon() noexcept { return 0; }
-  static constexpr unsigned long long round_error() noexcept { return 0; }
-  static constexpr unsigned long long infinity() noexcept { return 0; }
-  static constexpr unsigned long long quiet_NaN() noexcept { return 0; }
-  static constexpr unsigned long long signaling_NaN() noexcept { return 0; }
-  static constexpr unsigned long long denorm_min() noexcept { return 0; }
+  static OM_CONSTEXPR unsigned long long min() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long long lowest() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long long max() OM_NOEXCEPT { return ULLONG_MAX; }
+  static OM_CONSTEXPR unsigned long long epsilon() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long long round_error() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long long infinity() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long long quiet_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long long signaling_NaN() OM_NOEXCEPT { return 0; }
+  static OM_CONSTEXPR unsigned long long denorm_min() OM_NOEXCEPT { return 0; }
 };
 
 // float
@@ -548,39 +549,39 @@ template <>
 class numeric_limits<float>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = false;
-  static constexpr bool is_exact = false;
-  static constexpr bool has_infinity = true;
-  static constexpr bool has_quiet_NaN = true;
-  static constexpr bool has_signaling_NaN = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_to_nearest;
-  static constexpr bool is_iec559 = true;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = FLT_MANT_DIG;
-  static constexpr int digits10 = FLT_DIG;
-  static constexpr int max_digits10 = __FLT_DECIMAL_DIG__;
-  static constexpr int radix = FLT_RADIX;
-  static constexpr int min_exponent = FLT_MIN_EXP;
-  static constexpr int min_exponent10 = FLT_MIN_10_EXP;
-  static constexpr int max_exponent = FLT_MAX_EXP;
-  static constexpr int max_exponent10 = FLT_MAX_10_EXP;
-  static constexpr bool traps = false;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = false;
+  OM_STATIC_CONSTANT bool is_exact = false;
+  OM_STATIC_CONSTANT bool has_infinity = true;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = true;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = true;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_present;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_to_nearest;
+  OM_STATIC_CONSTANT bool is_iec559 = true;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = FLT_MANT_DIG;
+  OM_STATIC_CONSTANT int digits10 = FLT_DIG;
+  OM_STATIC_CONSTANT int max_digits10 = __FLT_DECIMAL_DIG__;
+  OM_STATIC_CONSTANT int radix = FLT_RADIX;
+  OM_STATIC_CONSTANT int min_exponent = FLT_MIN_EXP;
+  OM_STATIC_CONSTANT int min_exponent10 = FLT_MIN_10_EXP;
+  OM_STATIC_CONSTANT int max_exponent = FLT_MAX_EXP;
+  OM_STATIC_CONSTANT int max_exponent10 = FLT_MAX_10_EXP;
+  OM_STATIC_CONSTANT bool traps = false;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr float min() noexcept { return FLT_MIN; }
-  static constexpr float lowest() noexcept { return -FLT_MAX; }
-  static constexpr float max() noexcept { return FLT_MAX; }
-  static constexpr float epsilon() noexcept { return FLT_EPSILON; }
-  static constexpr float round_error() noexcept { return 0.5F; }
-  static constexpr float infinity() noexcept { return __builtin_huge_valf(); }
-  static constexpr float quiet_NaN() noexcept { return __builtin_nanf(""); }
-  static constexpr float signaling_NaN() noexcept { return __builtin_nansf(""); }
-  static constexpr float denorm_min() noexcept { return __FLT_DENORM_MIN__; }
+  static OM_CONSTEXPR float min() OM_NOEXCEPT { return FLT_MIN; }
+  static OM_CONSTEXPR float lowest() OM_NOEXCEPT { return -FLT_MAX; }
+  static OM_CONSTEXPR float max() OM_NOEXCEPT { return FLT_MAX; }
+  static OM_CONSTEXPR float epsilon() OM_NOEXCEPT { return FLT_EPSILON; }
+  static OM_CONSTEXPR float round_error() OM_NOEXCEPT { return 0.5F; }
+  static OM_CONSTEXPR float infinity() OM_NOEXCEPT { return __builtin_huge_valf(); }
+  static OM_CONSTEXPR float quiet_NaN() OM_NOEXCEPT { return __builtin_nanf(""); }
+  static OM_CONSTEXPR float signaling_NaN() OM_NOEXCEPT { return __builtin_nansf(""); }
+  static OM_CONSTEXPR float denorm_min() OM_NOEXCEPT { return __FLT_DENORM_MIN__; }
 };
 
 // double
@@ -588,39 +589,39 @@ template <>
 class numeric_limits<double>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = false;
-  static constexpr bool is_exact = false;
-  static constexpr bool has_infinity = true;
-  static constexpr bool has_quiet_NaN = true;
-  static constexpr bool has_signaling_NaN = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_to_nearest;
-  static constexpr bool is_iec559 = true;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = DBL_MANT_DIG;
-  static constexpr int digits10 = DBL_DIG;
-  static constexpr int max_digits10 = __DBL_DECIMAL_DIG__;
-  static constexpr int radix = FLT_RADIX;
-  static constexpr int min_exponent = DBL_MIN_EXP;
-  static constexpr int min_exponent10 = DBL_MIN_10_EXP;
-  static constexpr int max_exponent = DBL_MAX_EXP;
-  static constexpr int max_exponent10 = DBL_MAX_10_EXP;
-  static constexpr bool traps = false;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = false;
+  OM_STATIC_CONSTANT bool is_exact = false;
+  OM_STATIC_CONSTANT bool has_infinity = true;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = true;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = true;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_present;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_to_nearest;
+  OM_STATIC_CONSTANT bool is_iec559 = true;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = DBL_MANT_DIG;
+  OM_STATIC_CONSTANT int digits10 = DBL_DIG;
+  OM_STATIC_CONSTANT int max_digits10 = __DBL_DECIMAL_DIG__;
+  OM_STATIC_CONSTANT int radix = FLT_RADIX;
+  OM_STATIC_CONSTANT int min_exponent = DBL_MIN_EXP;
+  OM_STATIC_CONSTANT int min_exponent10 = DBL_MIN_10_EXP;
+  OM_STATIC_CONSTANT int max_exponent = DBL_MAX_EXP;
+  OM_STATIC_CONSTANT int max_exponent10 = DBL_MAX_10_EXP;
+  OM_STATIC_CONSTANT bool traps = false;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr double min() noexcept { return DBL_MIN; }
-  static constexpr double lowest() noexcept { return -DBL_MAX; }
-  static constexpr double max() noexcept { return DBL_MAX; }
-  static constexpr double epsilon() noexcept { return DBL_EPSILON; }
-  static constexpr double round_error() noexcept { return 0.5; }
-  static constexpr double infinity() noexcept { return __builtin_huge_val(); }
-  static constexpr double quiet_NaN() noexcept { return __builtin_nan(""); }
-  static constexpr double signaling_NaN() noexcept { return __builtin_nans(""); }
-  static constexpr double denorm_min() noexcept { return __DBL_DENORM_MIN__; }
+  static OM_CONSTEXPR double min() OM_NOEXCEPT { return DBL_MIN; }
+  static OM_CONSTEXPR double lowest() OM_NOEXCEPT { return -DBL_MAX; }
+  static OM_CONSTEXPR double max() OM_NOEXCEPT { return DBL_MAX; }
+  static OM_CONSTEXPR double epsilon() OM_NOEXCEPT { return DBL_EPSILON; }
+  static OM_CONSTEXPR double round_error() OM_NOEXCEPT { return 0.5; }
+  static OM_CONSTEXPR double infinity() OM_NOEXCEPT { return __builtin_huge_val(); }
+  static OM_CONSTEXPR double quiet_NaN() OM_NOEXCEPT { return __builtin_nan(""); }
+  static OM_CONSTEXPR double signaling_NaN() OM_NOEXCEPT { return __builtin_nans(""); }
+  static OM_CONSTEXPR double denorm_min() OM_NOEXCEPT { return __DBL_DENORM_MIN__; }
 };
 
 // long double
@@ -628,39 +629,39 @@ template <>
 class numeric_limits<long double>
 {
 public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = false;
-  static constexpr bool is_exact = false;
-  static constexpr bool has_infinity = true;
-  static constexpr bool has_quiet_NaN = true;
-  static constexpr bool has_signaling_NaN = true;
-  static constexpr float_denorm_style has_denorm = denorm_present;
-  static constexpr bool has_denorm_loss = false;
-  static constexpr float_round_style round_style = round_to_nearest;
-  static constexpr bool is_iec559 = true;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = LDBL_MANT_DIG;
-  static constexpr int digits10 = LDBL_DIG;
-  static constexpr int max_digits10 = __LDBL_DECIMAL_DIG__;
-  static constexpr int radix = FLT_RADIX;
-  static constexpr int min_exponent = LDBL_MIN_EXP;
-  static constexpr int min_exponent10 = LDBL_MIN_10_EXP;
-  static constexpr int max_exponent = LDBL_MAX_EXP;
-  static constexpr int max_exponent10 = LDBL_MAX_10_EXP;
-  static constexpr bool traps = false;
-  static constexpr bool tinyness_before = false;
+  OM_STATIC_CONSTANT bool is_specialized = true;
+  OM_STATIC_CONSTANT bool is_signed = true;
+  OM_STATIC_CONSTANT bool is_integer = false;
+  OM_STATIC_CONSTANT bool is_exact = false;
+  OM_STATIC_CONSTANT bool has_infinity = true;
+  OM_STATIC_CONSTANT bool has_quiet_NaN = true;
+  OM_STATIC_CONSTANT bool has_signaling_NaN = true;
+  OM_STATIC_CONSTANT float_denorm_style has_denorm = denorm_present;
+  OM_STATIC_CONSTANT bool has_denorm_loss = false;
+  OM_STATIC_CONSTANT float_round_style round_style = round_to_nearest;
+  OM_STATIC_CONSTANT bool is_iec559 = true;
+  OM_STATIC_CONSTANT bool is_bounded = true;
+  OM_STATIC_CONSTANT bool is_modulo = false;
+  OM_STATIC_CONSTANT int digits = LDBL_MANT_DIG;
+  OM_STATIC_CONSTANT int digits10 = LDBL_DIG;
+  OM_STATIC_CONSTANT int max_digits10 = __LDBL_DECIMAL_DIG__;
+  OM_STATIC_CONSTANT int radix = FLT_RADIX;
+  OM_STATIC_CONSTANT int min_exponent = LDBL_MIN_EXP;
+  OM_STATIC_CONSTANT int min_exponent10 = LDBL_MIN_10_EXP;
+  OM_STATIC_CONSTANT int max_exponent = LDBL_MAX_EXP;
+  OM_STATIC_CONSTANT int max_exponent10 = LDBL_MAX_10_EXP;
+  OM_STATIC_CONSTANT bool traps = false;
+  OM_STATIC_CONSTANT bool tinyness_before = false;
 
-  static constexpr long double min() noexcept { return LDBL_MIN; }
-  static constexpr long double lowest() noexcept { return -LDBL_MAX; }
-  static constexpr long double max() noexcept { return LDBL_MAX; }
-  static constexpr long double epsilon() noexcept { return LDBL_EPSILON; }
-  static constexpr long double round_error() noexcept { return 0.5L; }
-  static constexpr long double infinity() noexcept { return __builtin_huge_vall(); }
-  static constexpr long double quiet_NaN() noexcept { return __builtin_nanl(""); }
-  static constexpr long double signaling_NaN() noexcept { return __builtin_nansl(""); }
-  static constexpr long double denorm_min() noexcept { return __LDBL_DENORM_MIN__; }
+  static OM_CONSTEXPR long double min() OM_NOEXCEPT { return LDBL_MIN; }
+  static OM_CONSTEXPR long double lowest() OM_NOEXCEPT { return -LDBL_MAX; }
+  static OM_CONSTEXPR long double max() OM_NOEXCEPT { return LDBL_MAX; }
+  static OM_CONSTEXPR long double epsilon() OM_NOEXCEPT { return LDBL_EPSILON; }
+  static OM_CONSTEXPR long double round_error() OM_NOEXCEPT { return 0.5L; }
+  static OM_CONSTEXPR long double infinity() OM_NOEXCEPT { return __builtin_huge_vall(); }
+  static OM_CONSTEXPR long double quiet_NaN() OM_NOEXCEPT { return __builtin_nanl(""); }
+  static OM_CONSTEXPR long double signaling_NaN() OM_NOEXCEPT { return __builtin_nansl(""); }
+  static OM_CONSTEXPR long double denorm_min() OM_NOEXCEPT { return __LDBL_DENORM_MIN__; }
 };
 
 } // namespace std


### PR DESCRIPTION
Progresses #3387 (C++ library conflicts). Continues the header language-mode
audit started in #6455 / #6457 / #6458 / #6459.

## Root cause

`<limits>` is a C++98 header, but ESBMC's operational model spells every
`numeric_limits` member `static constexpr`:

```cpp
static constexpr bool is_specialized = false;
static constexpr T min() noexcept { return T(); }
```

Under `--std c++03` Clang rejects the file outright (`unknown type name
'constexpr'`, 512 occurrences). ESBMC passes `-nostdinc++`, so the OM is the
*only* source of `<limits>` — the header is not merely degraded in that mode,
it is unusable, and anything reaching it transitively fails too (`<chrono>`
failed solely through this path).

Differential audit against the host toolchain, one TU per header, all five
modes:

| mode | `#include <limits>` host clang++ | ESBMC before | ESBMC after |
|---|---|---|---|
| c++03 | OK | **PARSING ERROR** | OK |
| c++11/14/17/20 | OK | OK | OK |

## Solution

Route the `constexpr`/`noexcept` uses through the existing `OM_CONSTEXPR` /
`OM_NOEXCEPT` macros from `OM_compiler_defs.h`, and add one new macro for the
static data members:

```cpp
#if __cplusplus >= 201103L
#  define OM_STATIC_CONSTANT static constexpr
#else
#  define OM_STATIC_CONSTANT static const
#endif
```

`OM_CONSTEXPR` alone is not sufficient for the data members: eliding
`constexpr` would leave a plain non-const static member, which C++03 does not
permit an in-class initialiser on. `static const` is the correct C++03
spelling and is what libstdc++'s own C++03 `<limits>` uses. It is valid here
because every `numeric_limits` data member is integral or enum typed
(`bool`, `int`, `float_round_style`, `float_denorm_style`) — verified by
grep; the floating-point values are all *functions* (`min()`, `epsilon()`, …),
which keep the `OM_CONSTEXPR` treatment.

Behaviour in C++11 and later is byte-identical: the macros expand to exactly
what was written before.

### Limitation

As before this patch, the members have no out-of-class definitions, so
odr-using one (e.g. binding it to a `const&`) is unsupported. That is
unchanged by this PR, not introduced by it.

## Tests

New `esbmc-cpp/bug_fixes/github_3387_limits_c++03{,_fail}`, run with
`--std c++03 --incremental-bmc`, checking `is_specialized`/`is_signed`/
`is_integer`/`digits`/`radix`/`round_style`, `min()`/`max()`/`epsilon()` for
`int`, `unsigned`, `char`, `short`, `long`, `float` and `double` against the
`<climits>`/`<cfloat>` macros. The `_fail` variant asserts a deliberately
wrong `digits` to show the members carry real values rather than being
vacuously true.

The positive test also passes on the host toolchain
(`clang++ -std=c++03`), and under ESBMC in `--std c++11`, `c++17`, `c++20`
and the default mode.

```
ctest -R "github_3387|OM_sanity_checks/(limits|climit|cfloat)"
100% tests passed, 0 tests failed out of 16

ctest -L "esbmc-cpp/bug_fixes/|esbmc-cpp/try_catch/|esbmc-cpp/string/"   # no new failures
ctest -L "esbmc-cpp11|esbmc-cpp14|esbmc-cpp17|esbmc-cpp20"               # 260/263
ctest -L "esbmc-cpp/OM_sanity_checks/|esbmc-cpp/cpp/"                    # 724/733
```

The 3 + 9 failures are pre-existing on this macOS host. The three
`esbmc-cpp11/14` ones were control-verified: with the two changed files
reverted and the binary rebuilt, `allocate_shared_fail`,
`builtin-template` and `builtin-template-fail` fail identically (the latter
two on a host libc++ header-search error, under
`--no-abstracted-cpp-includes`, which does not use the OM at all).

## Follow-up

`<chrono>`, `<random>`, `<unordered_map>`, `<unordered_set>`,
`<initializer_list>`, `<any>`, `<optional>`, `<variant>`, `<string_view>`,
`<filesystem>` and `<source_location>` still fail to parse under
`--std c++03`. Those are genuinely post-C++03 headers, so the fix is the
mode guard libstdc++/libc++ use (expand to nothing), not a macro rewrite —
handled separately.