### PR TITLE
[om] Make ios_base::sync_with_stdio static and define it

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio/main.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include <cassert>
+int main()
+{
+  // [ios.base.sync]/2: the initial state is synchronised.
+  assert(std::ios_base::sync_with_stdio(false) == true);
+  // ... and each call reports the state the previous one installed.
+  assert(std::ios_base::sync_with_stdio(true) == false);
+  assert(std::ios_base::sync_with_stdio(true) == true);
+  // Reachable through a stream object too, and through std::ios.
+  assert(std::cout.sync_with_stdio(false) == true);
+  assert(std::ios::sync_with_stdio() == false);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio_fail/main.cpp
@@ -1,0 +1,12 @@
+// Negative counterpart of github_5868_sync_with_stdio: the returned state is
+// the real previous one, not a nondeterministic value, so a wrong claim about
+// it is refuted.
+#include <iostream>
+#include <cassert>
+
+int main()
+{
+  std::ios_base::sync_with_stdio(false);
+  assert(std::ios_base::sync_with_stdio(true) == true);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_sync_with_stdio_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -133,7 +133,11 @@ public:
   static int xalloc() throw();
 
   void register_callback(event_callback fn, int index);
-  bool sync_with_stdio(bool sync = true);
+
+  /* Held inverted so that zero-initialised storage means "synchronised",
+   * which is the initial state [ios.base.sync]/1 mandates. */
+  static bool __unsynced;
+  static bool sync_with_stdio(bool sync = true);
   class Init
   {
   public:
@@ -237,6 +241,16 @@ ios_base::setf(ios_base::fmtflags fmtfl, ios_base::fmtflags mask)
 void ios_base::unsetf(ios_base::fmtflags mask)
 {
   __flags &= ~mask;
+}
+
+/* [ios.base.sync]/2: returns the previous state, which starts out
+ * synchronised. The models write through the C stdio layer already, so the
+ * flag only has to be observable — there is no buffering to reconfigure. */
+bool ios_base::sync_with_stdio(bool sync)
+{
+  bool __old = !__unsynced;
+  __unsynced = !sync;
+  return __old;
 }
 
 streamsize ios_base::precision() const


### PR DESCRIPTION
Progresses #5868 — one more operational-model gap that turns ordinary C++ into
a hard frontend parse error.

## Root cause

`src/cpp/library/ios` declares

```cpp
bool sync_with_stdio(bool sync = true);
```

as a **non-static** member of `ios_base`, and never defines it. Two distinct
defects follow.

**1. The common idiom does not compile.** `[ios.base.sync]` specifies
`static bool sync_with_stdio(bool sync = true);`. Because the model drops the
`static`, the standard spelling is rejected outright:

```
$ printf '#include <iostream>\nint main(){ std::ios_base::sync_with_stdio(false); }\n' > s.cpp
$ esbmc s.cpp
s.cpp:4:18: error: call to non-static member function without an object argument
ERROR: PARSING ERROR
```

Host `clang++ -std=c++17 -fsyntax-only` accepts the same file. Since ESBMC
passes `-nostdinc++`, the OM is the only source of `<ios>`, so there is no
fallback — this is exactly the failure shape #5868 catalogues.

**2. Where it did parse, it returned nondet.** Reached through an object
(`std::cout.sync_with_stdio(false)`) the call bound to a declaration with no
body, which lowers to a call returning an unconstrained value — the
declaration-only defect shape previously fixed for `<string_view>` (#6421),
`<valarray>` (#6424) and `<ios>`'s `exceptions`/`copyfmt` (#6429). A silent
wrong answer, not a diagnostic.

## Solution

Make the member `static` and define it per `[ios.base.sync]/2` — return the
previous state, with the initial state synchronised.

The flag is stored **inverted** (`__unsynced`):

```cpp
static bool __unsynced;

bool ios_base::sync_with_stdio(bool sync)
{
  bool __old = !__unsynced;
  __unsynced = !sync;
  return __old;
}
```

A non-const `static bool` data member cannot carry an in-class initialiser in
C++03, and these headers must parse as C++03. Holding the value inverted makes
zero-initialised storage mean "synchronised", which is the initial state the
standard mandates, without needing one. The one-line comment in the header
records that.

The flag is observable but does not reconfigure anything: the stream models
already write straight through the C stdio layer, so there is no separate C++
buffer to detach. That is a faithful modelling choice — `sync_with_stdio` is a
performance knob whose only standard-visible effect is the returned previous
state.

## Tests

* `esbmc-cpp/cpp/github_5868_sync_with_stdio` — checks the initial state is
  synchronised, that each call reports the state the previous one installed,
  and that the function is reachable as `std::ios_base::`, `std::ios::` and
  through a stream object (`std::cout.sync_with_stdio`). The same program
  compiled with host `clang++ -std=c++17` runs and exits 0, so the expected
  values are the real library's, not invented.
* `esbmc-cpp/cpp/github_5868_sync_with_stdio_fail` — asserts a wrong previous
  state, to show the return value is the genuine one rather than a nondet
  value that satisfies any claim.

Also verified the positive test passes under `--std c++03`, since `<ios>` must
stay C++03-parseable.

```
ctest -R "github_5868"                                                        10/10
ctest -L "esbmc-cpp/cpp/|stream/|OM_sanity_checks/|string/|bug_fixes/|try_catch/"    1345, 11 fail
ctest -L "esbmc-cpp11|esbmc-cpp14|esbmc-cpp17|esbmc-cpp20"                    263, 3 fail
```

All 14 failures are pre-existing on this macOS host: 9 are the documented
`esbmc-cpp/cpp/` baseline, 2 are untracked local scratch tests not in the repo,
and the 3 in `esbmc-cpp11/14` were control-verified against a clean rebuild
(two of them fail on a host libc++ header-search error under
`--no-abstracted-cpp-includes`, which does not use the OM at all).

## Follow-up, deliberately not in this PR

`ios_base::imbue`, `ios_base::getloc`, `ios::imbue` and
`ios_base::register_callback` are still declaration-only, and nearly every
member of `<locale>` is too. Those all return nondet today. Fixing them
properly needs a real `<locale>` model — `getloc` returns a `locale` by value
and every `locale` constructor is itself declaration-only — which is a much
larger piece of work than this one-line API correction and does not belong in
the same change. `xalloc` is likewise declaration-only, and cannot be usefully
fixed on its own because the OM has no `iword`/`pword` to go with it.
