### PR TITLE
[om] Add the transparent operation functors to <functional>

### DIFF
--- a/regression/esbmc-cpp17/cpp/github_5868_transparent_functors/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_5868_transparent_functors/main.cpp
@@ -1,0 +1,40 @@
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  // Transparent comparators compare at the operands' own types: binding
+  // std::less<> to std::less<int> truncates both sides and answers wrongly.
+  assert(std::less<>()(0.5, 0.7) == true);
+  assert(std::greater<>()(0.7, 0.5) == true);
+  assert(std::less_equal<>()(0.5, 0.5) == true);
+  assert(std::greater_equal<>()(0.7, 0.5) == true);
+  assert(std::equal_to<>()(0.5, 0.5) == true);
+  assert(std::not_equal_to<>()(0.5, 0.7) == true);
+
+  // ... and combine at their own types, rather than in int.
+  assert(std::plus<>()(1.5, 2.25) == 3.75);
+  assert(std::minus<>()(2.5, 0.25) == 2.25);
+  assert(std::multiplies<>()(1.5, 2.0) == 3.0);
+  assert(std::divides<>()(5.0, 2.0) == 2.5);
+  assert(std::modulus<>()(7, 4) == 3);
+  assert(std::negate<>()(0.5) == -0.5);
+
+  assert(std::logical_and<>()(true, false) == false);
+  assert(std::logical_or<>()(true, false) == true);
+  assert(std::logical_not<>()(false) == true);
+
+  assert(std::bit_and<>()(6, 3) == 2);
+  assert(std::bit_or<>()(6, 3) == 7);
+  assert(std::bit_xor<>()(6, 3) == 5);
+  assert(std::bit_not<>()(0) == -1);
+
+  // Pointer comparison is what motivated is_transparent: less<int> cannot do
+  // it at all. Same array, so the relational comparison is well defined.
+  int a[2] = {1, 2};
+  assert(std::less<>()(&a[0], &a[1]) == true);
+
+  // Heterogeneous operands.
+  assert(std::less<>()(1, 2.5) == true);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_5868_transparent_functors/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_5868_transparent_functors/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_5868_transparent_functors_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_5868_transparent_functors_fail/main.cpp
@@ -1,0 +1,11 @@
+// Negative counterpart of github_5868_transparent_functors: std::less<> really
+// compares at the operands' own types, so the truncating answer std::less<int>
+// used to give (0.5 < 0.7 == false) is now refuted.
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  assert(std::less<>()(0.5, 0.7) == false);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_5868_transparent_functors_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_5868_transparent_functors_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -492,8 +492,21 @@ struct binary_function
   typedef Result result_type;
 };
 
+/* [functional.syn]: from C++14 the operation functors default to void, and
+ * <void> is a transparent specialisation that compares/combines its operands
+ * at their own types. Older modes keep the concrete default this model has
+ * always used, so existing c++03/c++11 uses of e.g. `std::less<>` still work.
+ */
+#if __cplusplus >= 201402L
+#  define OM_FN_DEFAULT void
+#  define OM_FN_DEFAULT_BOOL void
+#else
+#  define OM_FN_DEFAULT int
+#  define OM_FN_DEFAULT_BOOL bool
+#endif
+
 // Arithmetic Operations
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct plus
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -502,7 +515,7 @@ struct plus
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct minus
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -511,7 +524,7 @@ struct minus
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct multiplies
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -520,7 +533,7 @@ struct multiplies
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct divides
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -529,7 +542,7 @@ struct divides
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct modulus
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -538,7 +551,7 @@ struct modulus
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct negate
 {
   OM_CONSTEXPR T operator()(const T &a) const
@@ -548,7 +561,7 @@ struct negate
 };
 
 // Comparison Operations
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct equal_to
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -557,7 +570,7 @@ struct equal_to
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct not_equal_to
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -566,7 +579,7 @@ struct not_equal_to
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct greater
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -575,7 +588,7 @@ struct greater
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct less
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -584,7 +597,7 @@ struct less
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct greater_equal
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -593,7 +606,7 @@ struct greater_equal
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct less_equal
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -603,7 +616,7 @@ struct less_equal
 };
 
 // Logical Operations
-template <typename T = bool>
+template <typename T = OM_FN_DEFAULT_BOOL>
 struct logical_and
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -612,7 +625,7 @@ struct logical_and
   }
 };
 
-template <typename T = bool>
+template <typename T = OM_FN_DEFAULT_BOOL>
 struct logical_or
 {
   OM_CONSTEXPR bool operator()(const T &a, const T &b) const
@@ -621,7 +634,7 @@ struct logical_or
   }
 };
 
-template <typename T = bool>
+template <typename T = OM_FN_DEFAULT_BOOL>
 struct logical_not
 {
   OM_CONSTEXPR bool operator()(const T &a) const
@@ -631,7 +644,7 @@ struct logical_not
 };
 
 // Bitwise Operations
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct bit_and
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -640,7 +653,7 @@ struct bit_and
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct bit_or
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -649,7 +662,7 @@ struct bit_or
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct bit_xor
 {
   OM_CONSTEXPR T operator()(const T &a, const T &b) const
@@ -658,7 +671,7 @@ struct bit_xor
   }
 };
 
-template <typename T = int>
+template <typename T = OM_FN_DEFAULT>
 struct bit_not
 {
   OM_CONSTEXPR T operator()(const T &a) const
@@ -666,6 +679,239 @@ struct bit_not
     return ~a;
   }
 };
+
+#if __cplusplus >= 201402L
+/* Transparent specialisations [functional.syn]. is_transparent is what
+ * enables heterogeneous lookup in the associative containers. */
+
+template <>
+struct plus<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) + ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) + ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct minus<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) - ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) - ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct multiplies<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) * ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) * ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct divides<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) / ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) / ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct modulus<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) % ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) % ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct equal_to<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) == ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) == ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct not_equal_to<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) != ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) != ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct greater<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) > ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) > ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct less<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) < ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) < ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct greater_equal<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) >= ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) >= ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct less_equal<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) <= ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) <= ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct logical_and<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) && ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) && ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct logical_or<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) || ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) || ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct bit_and<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) & ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) & ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct bit_or<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) | ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) | ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct bit_xor<void>
+{
+  typedef void is_transparent;
+  template <typename T, typename U>
+  OM_CONSTEXPR auto operator()(T &&a, U &&b) const
+    -> decltype(::std::forward<T>(a) ^ ::std::forward<U>(b))
+  {
+    return ::std::forward<T>(a) ^ ::std::forward<U>(b);
+  }
+};
+
+template <>
+struct negate<void>
+{
+  typedef void is_transparent;
+  template <typename T>
+  OM_CONSTEXPR auto operator()(T &&a) const
+    -> decltype(-::std::forward<T>(a))
+  {
+    return -::std::forward<T>(a);
+  }
+};
+
+template <>
+struct logical_not<void>
+{
+  typedef void is_transparent;
+  template <typename T>
+  OM_CONSTEXPR auto operator()(T &&a) const
+    -> decltype(!::std::forward<T>(a))
+  {
+    return !::std::forward<T>(a);
+  }
+};
+
+template <>
+struct bit_not<void>
+{
+  typedef void is_transparent;
+  template <typename T>
+  OM_CONSTEXPR auto operator()(T &&a) const
+    -> decltype(~::std::forward<T>(a))
+  {
+    return ~::std::forward<T>(a);
+  }
+};
+#endif // __cplusplus >= 201402L
 
 #if __cplusplus >= 201103L
 // Simplified std::invoke model.


### PR DESCRIPTION
Progresses #5868, gap 7 ("Incomplete `<type_traits>`/`<tuple>`/`<functional>`
… no transparent `less<void>` specialization").

## Root cause

`src/cpp/library/functional` declares all 19 operation functors as

```cpp
template <typename T = int>     // `= bool` for logical_and/or/not
struct less
{
  OM_CONSTEXPR bool operator()(const T &a, const T &b) const { return a < b; }
};
```

`[functional.syn]` says the default is `void`, and that `<void>` is a
**transparent** specialisation whose `operator()` is a template comparing the
operands at their own types. Neither is present here, and the consequences go
past "feature missing":

**1. Silent wrong answers.** `std::less<>` binds `std::less<int>`, so both
operands are converted to `int` first:

```cpp
assert(std::less<>()(0.5, 0.7) == true);   // ESBMC on master: VERIFICATION FAILED
```

Both sides truncate to `0`, `0 < 0` is false, and the assertion is reported as
violated. The same program built with host `clang++ -std=c++17` runs and exits
0. `std::plus<>()(1.5, 2.25)` likewise returned `3`, not `3.75`. This is the
worst shape a model defect can take — no diagnostic, just a wrong verdict on a
correct program.

**2. Hard parse errors on the motivating use case.** Pointer comparison, which
is exactly what transparent comparators exist for, does not compile at all:

```
error: no matching function for call to object of type 'std::less<>'
note: candidate function not viable: no known conversion from 'int *' to 'const int'
```

**3. No `is_transparent`.** That typedef is what enables heterogeneous lookup in
the associative containers, so nothing could opt into it.

## Solution

Follow `[functional.syn]`: default the template parameter to `void` from C++14
on, and add the 19 `<void>` specialisations, each with `is_transparent` and a
member template `operator()` returning `decltype(std::forward<T>(a) OP
std::forward<U>(b))`.

The default is switched through a macro rather than changed outright:

```cpp
#if __cplusplus >= 201402L
#  define OM_FN_DEFAULT void
#  define OM_FN_DEFAULT_BOOL void
#else
#  define OM_FN_DEFAULT int
#  define OM_FN_DEFAULT_BOOL bool
#endif
```

Transparent comparators are a C++14 feature, so the `<void>` specialisations
have to be gated anyway. Gating the default alongside them means a c++03 or
c++11 translation unit that writes `std::less<>` — relying on the model's
historical non-standard `int` default — keeps working instead of turning into
a fresh parse error. That is the conservative choice: this PR removes wrong
answers without withdrawing anything that previously worked.

Trailing return types are used rather than `decltype(auto)` so the header stays
parseable in C++11, matching the existing `std::invoke` model in the same file.

## Tests

* `esbmc-cpp17/cpp/github_5868_transparent_functors` — exercises all 19
  transparent specialisations: the six comparisons on `double` operands (where
  the `int` binding gave the wrong answer), the arithmetic ones on values with
  fractional parts, the logical and bitwise ones, pointer comparison within one
  array (same-object, so the relational comparison is well defined), and a
  heterogeneous `less<>()(1, 2.5)`. Compiled and run with host
  `clang++ -std=c++17`: exits 0, so every expected value is the real library's.
* `esbmc-cpp17/cpp/github_5868_transparent_functors_fail` — asserts
  `std::less<>()(0.5, 0.7) == false`, i.e. exactly the wrong answer master
  produced, and expects `VERIFICATION FAILED`.

Control-verified: with `src/cpp/library/functional` reverted and the binary
rebuilt, the positive test does not pass — it stops at
`ERROR: PARSING ERROR` on the pointer comparison — and the standalone
`std::less<>()(0.5, 0.7) == true` check reports `VERIFICATION FAILED`.

The positive test also verifies SUCCESSFUL under `--std c++14` and
`--std c++20`, and a separate probe confirms `--std c++03` and `--std c++11`
still parse and still resolve `std::less<>`, `std::greater<int>`,
`std::plus<int>` and `std::logical_and<bool>` as before.

```
ctest -R "github_5868_transparent"                                        2/2
ctest -L "esbmc-cpp/cpp/|algorithm/|map/|set/|multimap/|multiset/|priority_queue/|OM_sanity_checks/|bug_fixes/|functional/"   1242, 9 fail
ctest -L "esbmc-cpp11|esbmc-cpp14|esbmc-cpp17|esbmc-cpp20"                265, 3 fail
ctest -L "esbmc-cpp/string/|vector/|list/|deque/|try_catch/"              711, 2 fail
```

All 14 failures are pre-existing on this macOS host: 9 are the documented
`esbmc-cpp/cpp/` baseline, 2 are untracked local scratch tests not in the repo,
and the 3 in `esbmc-cpp11/14` were control-verified against a clean rebuild
(two fail on a host libc++ header-search error under
`--no-abstracted-cpp-includes`, which does not use the OM at all).

## Follow-up

The rest of gap 7 — `is_base_of`/`is_class`/`is_union`/`is_polymorphic` and the
C++14 `_t` aliases in `<type_traits>`, and `tuple_element_t` — was already
addressed by #6412; the transparent comparators were the piece left over. The
associative containers do not yet act on `is_transparent` (no heterogeneous
lookup overloads), which is a separate change.
