### PR TITLE
[om] Import the C99 math functions into namespace std

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_cmath_c99/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_c99/main.cpp
@@ -1,0 +1,28 @@
+// [cmath.syn] requires the C99 additions to be visible in namespace std; the
+// model only pulled in the C89 set, so std::fmin and friends did not resolve
+// even though ::fmin did (github #5868).
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  assert(std::fmin(1.0, 2.0) == 1.0);
+  assert(std::fmax(1.0, 2.0) == 2.0);
+  assert(std::fmin(1.0f, 2.0f) == 1.0f);
+  assert(std::fmax(1.0L, 2.0L) == 2.0L);
+  assert(std::fdim(5.0, 3.0) == 2.0);
+  assert(std::fdim(3.0, 5.0) == 0.0);
+  assert(std::hypot(3.0, 4.0) == 5.0);
+  assert(std::copysign(2.0, -1.0) == -2.0);
+  assert(std::remainder(5.0, 2.0) == 1.0);
+  assert(std::nextafter(1.0, 2.0) > 1.0);
+  assert(std::log2(8.0) == 3.0);
+  assert(std::expm1(0.0) == 0.0);
+  assert(std::log1p(0.0) == 0.0);
+  assert(std::asinh(0.0) == 0.0);
+  assert(std::acosh(1.0) == 0.0);
+  assert(std::atanh(0.0) == 0.0);
+  assert(std::nearbyint(2.5) == 2.0);
+  assert(std::rint(3.5) == 4.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_cmath_c99/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_c99/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_cmath_c99_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_c99_fail/main.cpp
@@ -1,0 +1,11 @@
+// Negative counterpart of github_5868_cmath_c99: the newly visible std::
+// overloads forward to the real models rather than returning an unconstrained
+// value, so a wrong claim about them is refuted.
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  assert(std::fmin(1.0, 2.0) == 2.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_cmath_c99_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_c99_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -102,6 +102,30 @@ CIMPORT1(sqrt)
 CIMPORT2(fmod)
 CIMPORT1(round)
 
+/* [cmath.syn]: the C99 additions. math.h already declares the f/d/l triples,
+ * so these only have to be pulled into namespace std. */
+CIMPORT1(cbrt)
+CIMPORT1(exp2)
+CIMPORT1(expm1)
+CIMPORT1(log1p)
+CIMPORT1(log2)
+CIMPORT1(asinh)
+CIMPORT1(acosh)
+CIMPORT1(atanh)
+CIMPORT1(erf)
+CIMPORT1(erfc)
+CIMPORT1(tgamma)
+CIMPORT1(lgamma)
+CIMPORT1(nearbyint)
+CIMPORT1(rint)
+CIMPORT2(fmin)
+CIMPORT2(fmax)
+CIMPORT2(fdim)
+CIMPORT2(hypot)
+CIMPORT2(copysign)
+CIMPORT2(remainder)
+CIMPORT2(nextafter)
+
 using ::pow;
 #if !defined(__MATHCALL_VEC)
 using ::powf;


### PR DESCRIPTION
Progresses #5868 — another operational-model gap that makes ordinary C++ a
hard frontend parse error.

## Root cause

`src/cpp/library/cmath` imports names into `namespace std` with two macros,
`CIMPORT1` (unary) and `CIMPORT2` (binary), which pull in the `::name`,
`::namef` and `::namel` triple and add the `float`/`long double` overloads. It
applies them to the **C89** set only — `acos … sqrt`, `fmod`, `round`, `pow`,
`frexp`, `ldexp`, `modf` and the classifiers.

Everything C99 added is therefore missing from `std`, while being perfectly
available unqualified:

```
$ printf '#include <cmath>\nint main(){ return std::fmin(1.0,2.0)==1.0; }\n' > m.cpp
$ esbmc m.cpp
m.cpp:2:26: error: no member named 'fmin' in namespace 'std'; did you mean simply 'fmin'?
ERROR: PARSING ERROR
```

`[cmath.syn]` requires all of them in `std`. Host `clang++ -std=c++17` accepts
the same file, and since ESBMC passes `-nostdinc++` there is no fallback.

Found by a differential battery: small self-contained TUs asserting facts the
real library guarantees, compiled and **run** with host `clang++` for ground
truth, then re-run under ESBMC. A case where the host exits 0 but ESBMC does
not report SUCCESSFUL is a candidate model defect.

## Solution

Apply the existing macros to the 22 C99 additions. No new mechanism, and no
change to any name that already resolved:

* `CIMPORT1`: `cbrt`, `exp2`, `expm1`, `log1p`, `log2`, `asinh`, `acosh`,
  `atanh`, `erf`, `erfc`, `tgamma`, `lgamma`, `nearbyint`, `rint`
* `CIMPORT2`: `fmin`, `fmax`, `fdim`, `hypot`, `copysign`, `remainder`,
  `nextafter`

I verified up front that ESBMC's `math.h` really declares all three of
`namef`/`name`/`namel` for each — otherwise the `using ::namef;` inside the
macro would itself fail to compile.

### What this does and does not change

Making a name visible in `std` does not alter how it is *modelled*. I
classified each new name by running `assert(f(x)==k)` and `assert(!(f(x)==k))`
as C programs against the unqualified function, which separates "modelled" from
"returns an unconstrained value":

* **Modelled exactly** — `fmin`, `fmax`, `fdim`, `hypot`, `copysign`,
  `remainder`, `nextafter`, `log2`, `expm1`, `log1p`, `asinh`, `acosh`,
  `atanh`, `nearbyint`, `rint`. These are what the regression test asserts on.
* **Declared but not modelled, so nondet** — `cbrt`, `erf`, `erfc`, `tgamma`,
  `lgamma`. Pre-existing: `::cbrt(8.0)` is equally nondet today. Exposing them
  in `std` puts C++ on a par with C rather than leaving a parse error, and an
  unmodelled library call returning nondet is the usual sound
  over-approximation.
* **Modelled but inexact** — `exp2(3.0)` yields `0x401FFFFFFFFFFFD7`, not
  exactly `8.0`, because `src/c2goto/library/libm/exp.c` routes it through the
  `expm1` series. Also pre-existing and unaffected by this PR; I left it out of
  the test rather than baking the imprecise value in, and it deserves its own
  look at the libm model.

## Tests

* `esbmc-cpp/cpp/github_5868_cmath_c99` — asserts exact values for the 15
  properly-modelled additions, including the `float` and `long double`
  overloads the macros generate (`std::fmin(1.0f,2.0f)`,
  `std::fmax(1.0L,2.0L)`) and both branches of `fdim`. The identical program
  compiled and run with host `clang++ -std=c++17` exits 0, so every expected
  value is the real library's rather than invented.
* `esbmc-cpp/cpp/github_5868_cmath_c99_fail` — asserts
  `std::fmin(1.0,2.0) == 2.0` and expects `VERIFICATION FAILED`, showing the
  new overloads forward to the real models instead of returning an
  unconstrained value that would satisfy any claim.

The positive test also verifies SUCCESSFUL under `--std c++03`, `c++11`,
`c++17` and `c++20` — `<cmath>` has to stay parseable in every mode.

```
ctest -R "github_5868_cmath"                                           2/2
ctest -L "esbmc-cpp/cpp/|OM_sanity_checks/|bug_fixes/|floats"          1017, 11 fail
```

All 11 are pre-existing on this macOS host: 9 are the documented
`esbmc-cpp/cpp/` baseline, and `floats/isinf_ir_ieee` and `floats/underflow8`
were control-verified — with `src/cpp/library/cmath` reverted and the binary
rebuilt, both still fail.
