### PR TITLE
[om] Declare <cctype>, <ctime> and <clocale> names in namespace std

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_c_headers_std/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_c_headers_std/main.cpp
@@ -1,0 +1,41 @@
+// [cctype.syn]/[ctime.syn]/[clocale.syn] put these names in namespace std; the
+// models only delegated to the C header, so std::isdigit and friends did not
+// resolve even though ::isdigit did (github #5868).
+#include <cctype>
+#include <ctime>
+#include <clocale>
+#include <cassert>
+
+int main()
+{
+  assert(std::isdigit('5'));
+  assert(!std::isdigit('a'));
+  assert(std::isalpha('a'));
+  assert(std::isalnum('5'));
+  assert(std::isupper('A'));
+  assert(!std::isupper('a'));
+  assert(std::islower('a'));
+  assert(std::isspace(' '));
+  assert(!std::isspace('x'));
+  assert(std::isxdigit('f'));
+  assert(std::ispunct('!'));
+  assert(std::isprint('a'));
+  assert(!std::iscntrl('a'));
+  assert(std::isgraph('a'));
+  assert(std::tolower('A') == 'a');
+  assert(std::toupper('a') == 'A');
+
+  std::time_t t = std::time(0);
+  (void)t;
+  std::clock_t c = std::clock();
+  (void)c;
+  std::tm bt;
+  (void)bt;
+  assert(std::difftime(20, 8) == 12.0);
+
+  const char *l = std::setlocale(LC_ALL, "C");
+  (void)l;
+  std::lconv *lc = std::localeconv();
+  (void)lc;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_c_headers_std/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_c_headers_std/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_c_headers_std_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_c_headers_std_fail/main.cpp
@@ -1,0 +1,11 @@
+// Negative counterpart of github_5868_c_headers_std: the std:: names alias the
+// real C functions rather than returning an unconstrained value, so a wrong
+// claim about them is refuted.
+#include <cctype>
+#include <cassert>
+
+int main()
+{
+  assert(std::isdigit('a'));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_c_headers_std_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_c_headers_std_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/cctype
+++ b/src/cpp/library/cctype
@@ -1,1 +1,22 @@
+#pragma once
+
 #include <ctype.h>
+
+// [cctype.syn]: <cctype> declares the C character classification functions in
+// namespace std. Mirrors the cstring/cstdlib models.
+namespace std
+{
+using ::isalnum;
+using ::isalpha;
+using ::iscntrl;
+using ::isdigit;
+using ::isgraph;
+using ::islower;
+using ::isprint;
+using ::ispunct;
+using ::isspace;
+using ::isupper;
+using ::isxdigit;
+using ::tolower;
+using ::toupper;
+} // namespace std

--- a/src/cpp/library/clocale
+++ b/src/cpp/library/clocale
@@ -1,1 +1,12 @@
+#pragma once
+
 #include <locale.h>
+
+// [clocale.syn]: <clocale> declares the C locale facilities in namespace std.
+// Mirrors the cstring/cstdlib models.
+namespace std
+{
+using ::lconv;
+using ::localeconv;
+using ::setlocale;
+} // namespace std

--- a/src/cpp/library/ctime
+++ b/src/cpp/library/ctime
@@ -1,1 +1,23 @@
+#pragma once
+
 #include <time.h>
+
+// [ctime.syn]: <ctime> declares the C time facilities in namespace std.
+// Mirrors the cstring/cstdlib models.
+namespace std
+{
+using ::clock_t;
+using ::size_t;
+using ::time_t;
+using ::tm;
+
+using ::asctime;
+using ::clock;
+using ::ctime;
+using ::difftime;
+using ::gmtime;
+using ::localtime;
+using ::mktime;
+using ::strftime;
+using ::time;
+} // namespace std


### PR DESCRIPTION
Progresses #5868 — three more operational-model gaps that turn ordinary C++
into a hard frontend parse error.

## Root cause

`src/cpp/library/cctype`, `ctime` and `clocale` were each a **single line**:

```c
#include <ctype.h>
```

That satisfies `#include <cctype>`, but it only introduces the names at global
scope. `[cctype.syn]`, `[ctime.syn]` and `[clocale.syn]` require them inside
`namespace std`, so every std-qualified use failed:

```
$ printf '#include <cctype>\nint main(){ return std::isdigit(53); }\n' > c.cpp
$ esbmc c.cpp
c.cpp:2:20: error: use of undeclared identifier 'std'
ERROR: PARSING ERROR
```

Host `clang++ -std=c++17` accepts all three headers' std-qualified names, and
ESBMC passes `-nostdinc++`, so there is no fallback. `std::isdigit` /
`std::isspace` / `std::tolower` are everyday C++.

The sibling models already do this correctly — `<cstring>` and `<cstdlib>`
both carry a `namespace std { using ::…; }` block (`<cstring>`'s was added for
#6063) — so these three were simply left behind.

Found by a differential battery: small self-contained TUs asserting facts the
real library guarantees, compiled and **run** with host `clang++` for ground
truth, then re-run under ESBMC. A case where the host exits 0 but ESBMC does
not report SUCCESSFUL is a candidate model defect.

## Solution

Add the using-declarations, following the `<cstring>` model exactly.

* `<cctype>` — the 13 classification/conversion functions
  (`isalnum`, `isalpha`, `iscntrl`, `isdigit`, `isgraph`, `islower`,
  `isprint`, `ispunct`, `isspace`, `isupper`, `isxdigit`, `tolower`,
  `toupper`).
* `<ctime>` — `clock_t`, `size_t`, `time_t`, `tm`, plus `asctime`, `clock`,
  `ctime`, `difftime`, `gmtime`, `localtime`, `mktime`, `strftime`, `time`.
* `<clocale>` — `lconv`, `localeconv`, `setlocale`.

These are pure using-declarations: nothing is re-implemented, so the
std-qualified name and the `::`-qualified one denote the same entity and are
modelled identically. `isblank` is left out because ESBMC's `ctype.h` does not
declare it, and `using ::isblank;` would then fail to compile.

`<csignal>` has the same missing-`namespace std` shape but is **not** in this
PR: it does not merely delegate, it defines its own global `signal`/`raise`
with a non-standard signature (`void signal(...)` rather than returning the
previous handler) and has no `sig_atomic_t`. Correcting it is a behavioural
change to the model, not a scoping fix, so it belongs in its own change.

## Tests

* `esbmc-cpp/cpp/github_5868_c_headers_std` — exercises all 13 `<cctype>`
  functions with both a true and a false case where the classification is
  interesting (`isdigit('5')` / `!isdigit('a')`, `isupper('A')` /
  `!isupper('a')`, `isspace(' ')` / `!isspace('x')`), the `<ctime>` types and
  `difftime`, and `<clocale>`'s `setlocale`/`localeconv`. The identical
  program compiled and run with host `clang++ -std=c++17` exits 0, so the
  expected classifications are the real library's.
* `esbmc-cpp/cpp/github_5868_c_headers_std_fail` — asserts `std::isdigit('a')`
  and expects `VERIFICATION FAILED`, showing the alias reaches the real
  function rather than returning an unconstrained value that would satisfy any
  claim.

The positive test verifies SUCCESSFUL under `--std c++03`, `c++11`, `c++17`
and `c++20` — these headers have to stay parseable in every mode.

```
ctest -R "github_5868_c_headers"                                                 2/2
ctest -L "esbmc-cpp/cpp/|OM_sanity_checks/|bug_fixes/|string/|try_catch/|stream/"  1344, 11 fail
ctest -L "esbmc-cpp11|esbmc-cpp14|esbmc-cpp17|esbmc-cpp20"                       263, 3 fail
ctest -L "esbmc-cpp/unix/|inheritance/|polymorphism/|template/|algorithm/"       264/264
```

All 14 failures are pre-existing on this macOS host: 9 are the documented
`esbmc-cpp/cpp/` baseline, 2 are untracked local scratch tests not in the repo,
and the 3 in `esbmc-cpp11/14` were control-verified against a clean rebuild
(two fail on a host libc++ header-search error under
`--no-abstracted-cpp-includes`, which does not use the OM at all).
