### PR TITLE
[om] Define strtoul/strtoull/strtod/strtold and complete <string>'s sto*

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_string_conversions/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_conversions/main.cpp
@@ -1,0 +1,29 @@
+// [string.conversions]: <string> shipped only stoi and stof, and both ignored
+// the `pos` out-parameter (github #5868).
+#include <string>
+#include <cassert>
+
+int main()
+{
+  assert(std::stoi("42") == 42);
+  assert(std::stoi("-7") == -7);
+  assert(std::stoi("ff", 0, 16) == 255);
+  assert(std::stol("1234") == 1234L);
+  assert(std::stoul("40000") == 40000UL);
+  assert(std::stoll("-1234") == -1234LL);
+  assert(std::stoull("500") == 500ULL);
+
+  assert(std::stof("2.5") == 2.5f);
+  assert(std::stod("2.5") == 2.5);
+  assert(std::stold("3") == 3.0L);
+
+  // pos receives the index of the first unconverted character.
+  size_t p = 0;
+  assert(std::stoi("42abc", &p) == 42);
+  assert(p == 2);
+
+  p = 0;
+  assert(std::stol("  17rest", &p) == 17L);
+  assert(p == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_conversions/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_conversions/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_conversions_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_conversions_fail/main.cpp
@@ -1,0 +1,12 @@
+// Negative counterpart of github_5868_string_conversions: `pos` really is
+// written, so a wrong claim about it is refuted rather than vacuously true.
+#include <string>
+#include <cassert>
+
+int main()
+{
+  size_t p = 0;
+  assert(std::stoi("42abc", &p) == 42);
+  assert(p == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_conversions_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_conversions_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_5868_strto/main.c
+++ b/regression/esbmc/github_5868_strto/main.c
@@ -1,0 +1,34 @@
+/* strtoul, strtoull, strtod and strtold were declared in stdlib.h but never
+ * defined, so they returned an unconstrained value (github #5868). */
+#include <stdlib.h>
+#include <limits.h>
+#include <assert.h>
+
+int main()
+{
+  char *e;
+
+  assert(strtoul("42", &e, 10) == 42UL);
+  assert(*e == 0);
+  assert(strtoul("ff", &e, 16) == 255UL);
+  assert(strtoul("0x1f", &e, 0) == 31UL);
+  /* C99 7.22.1.4p5: a leading '-' is negated in the return type. */
+  assert(strtoul("-1", &e, 10) == ULONG_MAX);
+
+  assert(strtoull("42", &e, 10) == 42ULL);
+  assert(strtoull("18446744073709551615", &e, 10) == ULLONG_MAX);
+
+  assert(strtod("2.5", &e) == 2.5);
+  assert(*e == 0);
+  assert(strtod("-4.25", &e) == -4.25);
+  assert(strtod("  7", &e) == 7.0);
+
+  assert(strtold("3", &e) == 3.0L);
+
+  /* endptr points at the first unconverted character. */
+  assert(strtoul("42abc", &e, 10) == 42UL);
+  assert(*e == 'a');
+  assert(strtod("2.5xyz", &e) == 2.5);
+  assert(*e == 'x');
+  return 0;
+}

--- a/regression/esbmc/github_5868_strto/test.desc
+++ b/regression/esbmc/github_5868_strto/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5868_strto_fail/main.c
+++ b/regression/esbmc/github_5868_strto_fail/main.c
@@ -1,0 +1,12 @@
+/* Negative counterpart of github_5868_strto: the new definitions compute a
+   real value rather than returning an unconstrained one, so a wrong claim is
+   refuted instead of being satisfiable. */
+#include <stdlib.h>
+#include <assert.h>
+
+int main()
+{
+  char *e;
+  assert(strtod("2.5", &e) == 3.5);
+  return 0;
+}

--- a/regression/esbmc/github_5868_strto_fail/test.desc
+++ b/regression/esbmc/github_5868_strto_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -173,74 +173,142 @@ STRTOL_DEF(strtoll, long long int, LLONG)
 
 #undef STRTOL_DEF
 
-float strtof(const char *str, char **endptr)
-{
-__ESBMC_HIDE:;
-  float result = 0.0f;
-  int sign = 1;
-  float decimal_factor = 0.1f;
-
-  while (isspace(*str))
-    str++;
-
-  if (*str == '-')
-  {
-    sign = -1;
-    str++;
-  }
-  else if (*str == '+')
-  {
-    str++;
-  }
-
-  while (isdigit(*str))
-  {
-    result = result * 10 + (*str - '0');
-    str++;
-  }
-
-  if (*str == '.')
-  {
-    str++;
-    while (isdigit(*str))
-    {
-      result += (*str - '0') * decimal_factor;
-      decimal_factor /= 10;
-      str++;
-    }
-  }
-
-  if (*str == 'e' || *str == 'E')
-  {
-    str++;
-    int exp_sign = 1;
-    if (*str == '-')
-    {
-      exp_sign = -1;
-      str++;
-    }
-    else if (*str == '+')
-    {
-      str++;
-    }
-
-    int exponent = 0;
-    while (isdigit(*str))
-    {
-      exponent = exponent * 10 + (*str - '0');
-      str++;
-    }
-
-    result *= pow(10, exp_sign * exponent);
+/* Same shape as STRTOL_DEF, but C99 7.22.1.4p5 has the unsigned conversions
+ * negate a leading '-' in the return type rather than clamping, and there is
+ * no TYPE_MIN to saturate towards. */
+#define STRTOUL_DEF(name, type, TYPE)                                          \
+  type name(const char *str, char **endptr, int base)                          \
+  {                                                                            \
+  __ESBMC_HIDE:;                                                               \
+    type result = 0;                                                           \
+    int negate = 0;                                                            \
+                                                                               \
+    while (isspace(*str))                                                      \
+      str++;                                                                   \
+                                                                               \
+    if (*str == '-')                                                           \
+    {                                                                          \
+      negate = 1;                                                              \
+      str++;                                                                   \
+    }                                                                          \
+    else if (*str == '+')                                                      \
+      str++;                                                                   \
+                                                                               \
+    if (base == 0)                                                             \
+    {                                                                          \
+      if (*str == '0')                                                         \
+      {                                                                        \
+        base = 8;                                                              \
+        if (tolower(str[1]) == 'x')                                            \
+        {                                                                      \
+          base = 16;                                                           \
+          str += 2;                                                            \
+        }                                                                      \
+        else                                                                   \
+          str++;                                                               \
+      }                                                                        \
+      else                                                                     \
+        base = 10;                                                             \
+    }                                                                          \
+    else if (base == 16 && *str == '0' && tolower(str[1]) == 'x')              \
+      str += 2;                                                                \
+                                                                               \
+    while (isdigit(*str) || (base == 16 && isxdigit(*str)))                    \
+    {                                                                          \
+      int digit = isdigit(*str) ? *str - '0' : tolower(*str) - 'a' + 10;       \
+      if (result > (TYPE##_MAX - digit) / base)                                \
+        return TYPE##_MAX;                                                     \
+      result = result * base + digit;                                          \
+      str++;                                                                   \
+    }                                                                          \
+                                                                               \
+    if (endptr != NULL)                                                        \
+      *endptr = (char *)str;                                                   \
+                                                                               \
+    return negate ? (type)0 - result : result;                                 \
   }
 
-  result *= sign;
+STRTOUL_DEF(strtoul, unsigned long int, ULONG)
+STRTOUL_DEF(strtoull, unsigned long long int, ULLONG)
 
-  if (endptr != NULL)
-    *endptr = (char *)str;
+#undef STRTOUL_DEF
 
-  return result;
-}
+/* strtod and strtold were declared in stdlib.h but never defined, so they
+ * returned an unconstrained value (and an unconstrained endptr). Share the
+ * strtof body rather than duplicating it three times. The digit-by-digit
+ * accumulation is approximate for values that are not exactly representable,
+ * which is the accuracy strtof already had. */
+#define STRTOF_DEF(name, type, one_tenth)                                      \
+  type name(const char *str, char **endptr)                                    \
+  {                                                                            \
+  __ESBMC_HIDE:;                                                               \
+    type result = 0;                                                           \
+    int sign = 1;                                                              \
+    type decimal_factor = one_tenth;                                           \
+                                                                               \
+    while (isspace(*str))                                                      \
+      str++;                                                                   \
+                                                                               \
+    if (*str == '-')                                                           \
+    {                                                                          \
+      sign = -1;                                                               \
+      str++;                                                                   \
+    }                                                                          \
+    else if (*str == '+')                                                      \
+      str++;                                                                   \
+                                                                               \
+    while (isdigit(*str))                                                      \
+    {                                                                          \
+      result = result * 10 + (*str - '0');                                     \
+      str++;                                                                   \
+    }                                                                          \
+                                                                               \
+    if (*str == '.')                                                           \
+    {                                                                          \
+      str++;                                                                   \
+      while (isdigit(*str))                                                    \
+      {                                                                        \
+        result += (*str - '0') * decimal_factor;                               \
+        decimal_factor /= 10;                                                  \
+        str++;                                                                 \
+      }                                                                        \
+    }                                                                          \
+                                                                               \
+    if (*str == 'e' || *str == 'E')                                            \
+    {                                                                          \
+      str++;                                                                   \
+      int exp_sign = 1;                                                        \
+      if (*str == '-')                                                         \
+      {                                                                        \
+        exp_sign = -1;                                                         \
+        str++;                                                                 \
+      }                                                                        \
+      else if (*str == '+')                                                    \
+        str++;                                                                 \
+                                                                               \
+      int exponent = 0;                                                        \
+      while (isdigit(*str))                                                    \
+      {                                                                        \
+        exponent = exponent * 10 + (*str - '0');                               \
+        str++;                                                                 \
+      }                                                                        \
+                                                                               \
+      result *= pow(10, exp_sign * exponent);                                  \
+    }                                                                          \
+                                                                               \
+    result *= sign;                                                            \
+                                                                               \
+    if (endptr != NULL)                                                        \
+      *endptr = (char *)str;                                                   \
+                                                                               \
+    return result;                                                             \
+  }
+
+STRTOF_DEF(strtof, float, 0.1f)
+STRTOF_DEF(strtod, double, 0.1)
+STRTOF_DEF(strtold, long double, 0.1L)
+
+#undef STRTOF_DEF
 
 /* one plus the numeric value, rest is zero */
 static const unsigned char get_atoi_map(unsigned char pos)

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -3427,29 +3427,49 @@ std::string to_string(long double value)
   return string(buffer);
 }
 
-int stoi(const std::string &str, size_t *pos = 0, int base = 10)
-{
-  const char *c_str = str.c_str();
+/* [string.conversions]. Only stoi and stof were modelled, and both ignored
+ * `pos`, which must receive the index of the first unconverted character.
+ *
+ * The standard has these throw invalid_argument when no conversion happens;
+ * OM code cannot throw a catchable exception (#6338), so the model asserts.
+ * Out-of-range values are not diagnosed: the underlying strto* saturate, and
+ * adding the check would raise new claims on programs that verify today. */
+#define OM_STOI(fn, type, cfn)                                                 \
+  inline type fn(const std::string &str, size_t *pos = 0, int base = 10)       \
+  {                                                                            \
+    const char *c_str = str.c_str();                                           \
+    char *endptr;                                                              \
+    type result = static_cast<type>(cfn(c_str, &endptr, base));                \
+    __ESBMC_assert(endptr != c_str, "No digits in input string");              \
+    if (pos != 0)                                                              \
+      *pos = static_cast<size_t>(endptr - c_str);                              \
+    return result;                                                             \
+  }
 
-  char *endptr;
-  long result = std::strtol(c_str, &endptr, base);
+#define OM_STOF(fn, type, cfn)                                                 \
+  inline type fn(const std::string &str, size_t *pos = 0)                      \
+  {                                                                            \
+    const char *c_str = str.c_str();                                           \
+    char *endptr;                                                              \
+    type result = cfn(c_str, &endptr);                                         \
+    __ESBMC_assert(endptr != c_str, "No digits in input string");              \
+    if (pos != 0)                                                              \
+      *pos = static_cast<size_t>(endptr - c_str);                              \
+    return result;                                                             \
+  }
 
-  __ESBMC_assert(endptr != c_str, "No digits in input string");
+OM_STOI(stoi, int, std::strtol)
+OM_STOI(stol, long, std::strtol)
+OM_STOI(stoul, unsigned long, std::strtoul)
+OM_STOI(stoll, long long, std::strtoll)
+OM_STOI(stoull, unsigned long long, std::strtoull)
 
-  return static_cast<int>(result);
-}
+OM_STOF(stof, float, std::strtof)
+OM_STOF(stod, double, std::strtod)
+OM_STOF(stold, long double, std::strtold)
 
-float stof(const std::string &str, size_t *pos = 0)
-{
-  const char *c_str = str.c_str();
-
-  char *endptr;
-  float result = std::strtof(c_str, &endptr);
-
-  __ESBMC_assert(endptr != c_str, "No digits in input string");
-
-  return result;
-}
+#undef OM_STOI
+#undef OM_STOF
 
 } // namespace std
 #endif


### PR DESCRIPTION
Progresses #5868. One feature — the numeric string conversions — that was
broken at both layers, so both are fixed here; the C fix alone would be
untestable from C++ and the C++ fix alone would sit on unmodelled primitives.

## Root cause

**Layer 1, `src/c2goto/library/stdlib.c`.** `strtoul`, `strtoull`, `strtod`
and `strtold` are *declared* in `src/c2goto/headers/stdlib.h` but never
defined. A declared-with-no-body function lowers to a call returning an
unconstrained value, so both the result and `*endptr` were nondet:

```c
char *e;
assert(strtoul("42", &e, 10) == 42UL);    // VERIFICATION FAILED on master
assert(strtod("2.5", &e) == 2.5);         // VERIFICATION FAILED on master
```

Their siblings `strtol`, `strtoll` and `strtof` *are* modelled, which is why
this went unnoticed — the gap is invisible unless you probe each one.

**Layer 2, `src/cpp/library/string`.** `[string.conversions]` specifies eight
functions; the model had two, `stoi` and `stof`, so `std::stol`, `std::stoul`,
`std::stoll`, `std::stoull`, `std::stod` and `std::stold` were hard parse
errors (`no member named 'stol' in namespace 'std'`). Worse, the two that did
exist accepted a `size_t *pos` and **silently discarded it**, where
`[string.conversions]/2` requires it to receive the index of the first
unconverted character:

```cpp
size_t p = 0;
std::stoi("42abc", &p);
assert(p == 2);        // VERIFICATION FAILED on master — p was never written
```

That is a silent wrong answer, not a missing feature.

Found by a differential battery: small self-contained TUs asserting facts the
real library guarantees, compiled and **run** with host `clang++`/`clang` for
ground truth, then re-run under ESBMC.

## Solution

**C layer.** No new algorithm — generalise what is already there.

* `STRTOUL_DEF`, alongside the existing `STRTOL_DEF`. It is a separate macro
  rather than a reuse because the unsigned conversions differ in two ways:
  C99 7.22.1.4p5 has a leading `-` *negated in the return type* rather than
  clamped, and there is no `ULONG_MIN` to saturate towards, so overflow
  saturates to `TYPE_MAX` only.
* `STRTOF_DEF` — the existing `strtof` body, macro-ised over the type and the
  `0.1` literal, then instantiated for `float`, `double` and `long double`.
  `strtof` itself now comes from the macro, so there is one body instead of
  three copies.

**C++ layer.** `OM_STOI`/`OM_STOF` generate the eight functions over the
now-complete C primitives, each writing `*pos` when it is non-null.

### Deliberate limitations, unchanged from before

* `[string.conversions]` has these throw `invalid_argument`/`out_of_range`.
  OM code cannot throw a catchable exception (#6338), so the model keeps the
  existing `__ESBMC_assert(endptr != c_str, "No digits in input string")` and
  does **not** add a range check — `strtol` and friends saturate, and a new
  claim would fire on programs that verify today.
* The digit-by-digit float accumulation is approximate for values that are not
  exactly representable. That is the accuracy `strtof` already had and it now
  applies uniformly. It shows up at `long double`: ESBMC models it as extended
  precision, where `2.0L + 5*0.1L != 2.5L` even in plain arithmetic, so the
  tests assert on integral values for `stold`/`strtold` and on exactly
  representable ones (`2.5`, `-4.25`) elsewhere.

## Tests

* `esbmc/github_5868_strto` — C level: `strtoul` in bases 10/16/0, the
  `strtoul("-1") == ULONG_MAX` negation rule, `strtoull` at `ULLONG_MAX`,
  `strtod` on positive, negative and leading-whitespace input, `strtold`, and
  `endptr` placement on trailing garbage for both an integer and a float.
* `esbmc/github_5868_strto_fail` — asserts `strtod("2.5", &e) == 3.5`,
  expecting `VERIFICATION FAILED`. On master this same claim is *satisfiable*
  because the return value is unconstrained, so it pins exactly the defect.
* `esbmc-cpp/cpp/github_5868_string_conversions` — all eight `sto*`, including
  base-16 `stoi`, and `pos` after both `stoi("42abc")` and a
  leading-whitespace `stol("  17rest")` (where `pos` is 4, not 6 — the skipped
  whitespace counts).
* `esbmc-cpp/cpp/github_5868_string_conversions_fail` — asserts the wrong
  `pos`, expecting `VERIFICATION FAILED`.

Both positive programs were compiled and **run** with the host toolchain and
exit 0, so every expected value is the real library's. The C++ one also
verifies SUCCESSFUL under `--std c++03`, `c++11`, `c++17` and `c++20`. It runs
in ~24 s locally; I trimmed the operand magnitudes to keep it clear of CI's
120 s cap.

```
ctest -R "github_5868_strto|github_5868_string_conv"                     4/4
ctest -L "esbmc/"                                                        1564, 8 fail
ctest -L "esbmc-unix/|esbmc-unix2/|k-induction/|goto-transcoder/|cstd/"  953, 5 fail
ctest -L "esbmc-cpp/string/|cpp/|bug_fixes/|OM_sanity_checks/"           1106, 11 fail
ctest -R "<the 41 tests that use strtol/strtod/atof/...>"                41/41
```

Since this touches the C library that every C test links, I ran the whole
`regression/esbmc` suite: the 8 failures are exactly the documented macOS
baseline (`bitvector_02/03`, `char16/32-lit` ×4, `github_1537-assume/-no-assume`)
and no more. The others are also pre-existing and environmental:
`esbmc-unix/04_valgrind` and `goto-transcoder/cbmc_fpclassify` are documented;
`esbmc-unix/error` and `error2` need glibc's `error.h`, which macOS lacks; and
`esbmc-unix/unsupported_extensions` pulls x86-only `mmintrin.h` on aarch64. The
11 C++ failures are the 9-test `esbmc-cpp/cpp/` baseline plus 2 untracked local
scratch tests not in the repo.

I also ran, as a targeted check, every one of the 41 tests in the tree that
mention `strtol`/`strtoul`/`strtod`/`atof`/`stoi` — all pass.

## Follow-up

`std::to_string(double)` is separately wrong: it calls `itoa(value, buffer, 10)`,
so `std::to_string(2.5)` yields `"2"` rather than `"2.500000"`. Fixing it needs
float-to-decimal formatting in the model — ESBMC's `sprintf("%f", 2.5)` does not
produce `"2.500000"` either — which is a larger change than this one and is
left out deliberately rather than bodged.
