### PR TITLE
[om] Move advance/distance into <iterator> and add next/prev

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_iterator_ops/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_ops/main.cpp
@@ -1,0 +1,28 @@
+// [iterator.synopsis] puts advance and distance in <iterator>, but the
+// definitions lived in <algorithm> while <iterator> only declared them. A TU
+// that included <iterator> without <algorithm> got a distance() returning an
+// unconstrained value and an advance() that did nothing (github #5868).
+#include <iterator>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+
+  assert(std::distance(v.begin(), v.end()) == 3);
+  assert(std::distance(v.begin(), v.begin()) == 0);
+
+  std::vector<int>::iterator i = v.begin();
+  std::advance(i, 2);
+  assert(*i == 3);
+  std::advance(i, -1);
+  assert(*i == 2);
+
+  int a[4] = {5, 6, 7, 8};
+  assert(std::distance(a, a + 4) == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_iterator_ops/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_ops/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_iterator_ops_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_ops_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative counterpart of github_5868_iterator_ops: distance() now computes a
+// real length instead of returning an unconstrained value, so a wrong claim is
+// refuted rather than being satisfiable.
+#include <iterator>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+  assert(std::distance(v.begin(), v.end()) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_iterator_ops_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_ops_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/github_5868_iterator_next_prev/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_5868_iterator_next_prev/main.cpp
@@ -1,0 +1,28 @@
+// std::next and std::prev ([iterator.operations]/3,6) were missing from the
+// <iterator> model entirely (github #5868).
+#include <iterator>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+
+  assert(*std::next(v.begin()) == 2);
+  assert(*std::next(v.begin(), 2) == 3);
+  assert(std::next(v.begin(), 3) == v.end());
+  assert(*std::prev(v.end()) == 3);
+  assert(*std::prev(v.end(), 2) == 2);
+
+  // next/prev take the iterator by value: the argument must not move.
+  std::vector<int>::iterator i = v.begin();
+  (void)std::next(i, 2);
+  assert(*i == 1);
+
+  int a[4] = {5, 6, 7, 8};
+  assert(*std::next(a, 3) == 8);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_5868_iterator_next_prev/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_5868_iterator_next_prev/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -465,26 +465,6 @@ FwdIt1 search(FwdIt1 first1, FwdIt1 last1, FwdIt2 first2, FwdIt2 last2, Pr pred)
   return last1;
 }
 
-template <class InputIterator, class Distance>
-void advance(InputIterator &i, Distance n)
-{
-  i = i + n;
-}
-
-template <class InputIterator>
-int distance(InputIterator first, InputIterator last)
-{
-  int i = 0;
-  int koef = first < last ? 1 : -1;
-  InputIterator pilgrim = first < last ? first : last;
-  while (pilgrim != last)
-  {
-    pilgrim = pilgrim + koef;
-    i++;
-  }
-  return i;
-}
-
 template <class FwdIt, class Diff, class Ty>
 FwdIt search_n(FwdIt first, FwdIt last, Diff count, const Ty &value)
 {

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -89,12 +89,52 @@ struct iterator_traits<const T *>
   typedef random_access_iterator_tag iterator_category;
 };
 
+/* [iterator.synopsis] puts advance and distance here, but the definitions
+ * lived in <algorithm> while <iterator> carried declarations with no body.
+ * A translation unit that included <iterator> without <algorithm> therefore
+ * got a distance() returning an unconstrained value -- it satisfied neither
+ * `== 3` nor `!= 3` on a three-element range -- and an advance() that left
+ * the iterator where it was. The bodies below are the ones <algorithm> had;
+ * <algorithm> includes this header, so its own callers are unaffected. */
 template <class InputIterator, class Distance>
-void advance(InputIterator &i, Distance n);
+void advance(InputIterator &i, Distance n)
+{
+  i = i + n;
+}
 
 template <class InputIterator>
-typename iterator_traits<InputIterator>::difference_type
-distance(InputIterator first, InputIterator last);
+int distance(InputIterator first, InputIterator last)
+{
+  int i = 0;
+  int koef = first < last ? 1 : -1;
+  InputIterator pilgrim = first < last ? first : last;
+  while (pilgrim != last)
+  {
+    pilgrim = pilgrim + koef;
+    i++;
+  }
+  return i;
+}
+
+#if __cplusplus >= 201103L
+/* [iterator.operations]/3,6. The parameter type is spelled ptrdiff_t rather
+ * than iterator_traits<It>::difference_type so that these stay usable with the
+ * container iterators that do not carry the traits typedefs -- the same reason
+ * distance above returns int. */
+template <class ForwardIterator>
+ForwardIterator next(ForwardIterator i, ptrdiff_t n = 1)
+{
+  advance(i, n);
+  return i;
+}
+
+template <class BidirectionalIterator>
+BidirectionalIterator prev(BidirectionalIterator i, ptrdiff_t n = 1)
+{
+  advance(i, -n);
+  return i;
+}
+#endif
 
 template <class Container>
 class back_insert_iterator


### PR DESCRIPTION
Progresses #5868.

## Root cause

`[iterator.synopsis]` puts `std::advance` and `std::distance` in `<iterator>`.
ESBMC's models put the *definitions* in `<algorithm>` and left `<iterator>`
with declarations that have no body:

```cpp
// src/cpp/library/iterator
template <class InputIterator, class Distance>
void advance(InputIterator &i, Distance n);          // no definition

template <class InputIterator>
typename iterator_traits<InputIterator>::difference_type
distance(InputIterator first, InputIterator last);   // no definition
```

A declared-with-no-body function lowers to a call returning an unconstrained
value, so a translation unit that included `<iterator>` without `<algorithm>`
silently got nonsense:

```cpp
std::vector<int> v;  // {1, 2, 3}
assert(std::distance(v.begin(), v.end()) == 3);   // VERIFICATION FAILED
assert(std::distance(v.begin(), v.end()) != 3);   // ALSO VERIFICATION FAILED
```

Both directions failing is the signature of a nondet return — neither a
missing feature (which fails to compile) nor a wrong implementation (which
fails one way consistently). `std::advance` had the matching symptom: the
iterator simply did not move.

The declarations also could not be *made* into definitions in place, because
that would collide with `<algorithm>`'s — a TU including both would get
"redefinition of 'advance'".

`std::next` and `std::prev` were absent altogether.

Found by a differential battery: small self-contained TUs asserting facts the
real library guarantees, compiled and **run** with host `clang++` for ground
truth, then re-run under ESBMC.

## Solution

Move the two bodies from `<algorithm>` into `<iterator>`, where the standard
puts them, and add `next`/`prev` next to them. `<algorithm>` already
`#include`s `<iterator>`, so everything that reaches them through
`<algorithm>` — including `<algorithm>`'s own internal calls in
`binary_search` and `sort` — sees exactly the same definitions as before.

The bodies are moved **verbatim**. That is deliberate: it makes the change a
pure relocation for every caller that worked before, so the only behavioural
delta is that `<iterator>`-only TUs stop getting nondet. `next`/`prev` are
guarded at C++11, which is when they were introduced.

### Inherited limitation, not introduced here

The moved `distance` returns `int` and uses `first < last`, and `advance` uses
`i = i + n`; both therefore require a random-access iterator. That is why
`std::distance` on a `std::list` iterator does not compile — it did not
compile before this PR either, for the same reason, and the declaration's
`iterator_traits<It>::difference_type` return type would have failed on those
iterators anyway since the container models do not carry the traits typedefs.
Making these work for bidirectional and input iterators means tag dispatch,
which in turn means adding the five `iterator_traits` typedefs to every
container iterator — a much larger change, left for separate work.

`next`/`prev` take `ptrdiff_t` rather than
`iterator_traits<It>::difference_type` for the same reason: spelling it the
standard way would make them unusable with exactly the iterators that lack the
typedefs.

## Tests

* `esbmc-cpp/cpp/github_5868_iterator_ops` — `<iterator>` only, no
  `<algorithm>`: `distance` over a 3-element range and over an empty one,
  `advance` forwards and backwards, and `distance` on a raw array.
* `esbmc-cpp/cpp/github_5868_iterator_ops_fail` — asserts `distance == 2` on
  the same 3-element range.
* `esbmc-cpp11/cpp/github_5868_iterator_next_prev` — `next`/`prev` with and
  without an explicit count, `next(begin, 3) == end()`, both on a vector and a
  raw array, plus a check that the argument iterator is taken by value and
  does not move.

Both positive programs were compiled and **run** with host `clang++`
(`-std=c++03` and `-std=c++11` respectively) and exit 0, so the expected
values are the real library's.

Control-verified against a rebuild with `src/cpp/library/{iterator,algorithm}`
reverted: `github_5868_iterator_ops` fails (the `distance == 3` claim is not
provable) and `github_5868_iterator_next_prev` fails with
`no member named 'next' in namespace 'std'`. Note that
`github_5868_iterator_ops_fail` *passes* on the unpatched build too — with a
nondet return, `distance == 2` is satisfiable — so it is the positive test
that establishes determinism; the pair together pins the value at exactly 3.

```
ctest -R "github_5868_iterator"                                                3/3
ctest -L "esbmc-cpp/algorithm/|vector/|list/|deque/|set/|map/|multiset/|multimap/|priority_queue/|queue/|stack/"   690/690
ctest -L "esbmc-cpp/cpp/|string/|bug_fixes/|OM_sanity_checks/|stream/|try_catch/"   1342, 11 fail
ctest -L "esbmc-cpp11|esbmc-cpp14|esbmc-cpp17|esbmc-cpp20"                     263, 3 fail
```

The container and algorithm suites — the ones that actually exercise
`advance`/`distance` — are fully green at 690/690. All 14 other failures are
pre-existing on this macOS host: 9 are the documented `esbmc-cpp/cpp/`
baseline, 2 are untracked local scratch tests not in the repo, and the 3 in
`esbmc-cpp11/14` were control-verified against a clean rebuild (two fail on a
host libc++ header-search error under `--no-abstracted-cpp-includes`, which
does not use the OM at all).
