### PR TITLE
[om] Define div, ldiv and lldiv

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_std_div/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_std_div/main.cpp
@@ -1,0 +1,18 @@
+#include <cstdlib>
+#include <cassert>
+
+int main()
+{
+  std::div_t d = std::div(7, 2);
+  assert(d.quot == 3);
+  assert(d.rem == 1);
+
+  std::ldiv_t l = std::ldiv(-9L, 4L);
+  assert(l.quot == -2L);
+  assert(l.rem == -1L);
+
+  std::lldiv_t ll = std::lldiv(9LL, 4LL);
+  assert(ll.quot == 2LL);
+  assert(ll.rem == 1LL);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_std_div/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_std_div/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5868_div/main.c
+++ b/regression/esbmc/github_5868_div/main.c
@@ -1,0 +1,32 @@
+/* C99 7.20.6.2: div, ldiv and lldiv were declared in stdlib.h but never
+   defined, so both members of the returned struct were unconstrained
+   (github #5868). */
+#include <stdlib.h>
+#include <assert.h>
+
+int main()
+{
+  div_t d = div(7, 2);
+  assert(d.quot == 3);
+  assert(d.rem == 1);
+
+  /* Truncation is toward zero, so a negative numerator gives a negative
+     remainder and quot*denom + rem == numer still holds. */
+  div_t n = div(-7, 2);
+  assert(n.quot == -3);
+  assert(n.rem == -1);
+  assert(n.quot * 2 + n.rem == -7);
+
+  div_t e = div(6, 3);
+  assert(e.quot == 2);
+  assert(e.rem == 0);
+
+  ldiv_t l = ldiv(-9L, 4L);
+  assert(l.quot == -2L);
+  assert(l.rem == -1L);
+
+  lldiv_t ll = lldiv(9LL, 4LL);
+  assert(ll.quot == 2LL);
+  assert(ll.rem == 1LL);
+  return 0;
+}

--- a/regression/esbmc/github_5868_div/test.desc
+++ b/regression/esbmc/github_5868_div/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5868_div_fail/main.c
+++ b/regression/esbmc/github_5868_div_fail/main.c
@@ -1,0 +1,11 @@
+/* Negative counterpart of github_5868_div: the members now carry real values
+   rather than being unconstrained, so a wrong claim is refuted. */
+#include <stdlib.h>
+#include <assert.h>
+
+int main()
+{
+  div_t d = div(7, 2);
+  assert(d.quot == 4);
+  return 0;
+}

--- a/regression/esbmc/github_5868_div_fail/test.desc
+++ b/regression/esbmc/github_5868_div_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/headers/stdlib.h
+++ b/src/c2goto/headers/stdlib.h
@@ -53,7 +53,7 @@ long int labs(long int n);
 
 ldiv_t ldiv(long int numerator, long int denominator);
 
-lldiv_t lldiv(long int numerator, long int denominator);
+lldiv_t lldiv(long long int numerator, long long int denominator);
 
 int mblen(const char * pmb, size_t max);
 

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -111,6 +111,26 @@ __ESBMC_HIDE:;
   return res;
 }
 
+/* C99 7.20.6.2: div, ldiv and lldiv were declared in stdlib.h but never
+ * defined, so both members of the returned struct were unconstrained. C's
+ * integer division already truncates toward zero, which is exactly the
+ * rounding the standard specifies, so quot*denom + rem == numer holds. */
+#define DIV_DEF(name, result_type, type)                                       \
+  result_type name(type numerator, type denominator)                           \
+  {                                                                            \
+  __ESBMC_HIDE:;                                                               \
+    result_type result;                                                        \
+    result.quot = numerator / denominator;                                     \
+    result.rem = numerator % denominator;                                      \
+    return result;                                                             \
+  }
+
+DIV_DEF(div, div_t, int)
+DIV_DEF(ldiv, ldiv_t, long int)
+DIV_DEF(lldiv, lldiv_t, long long int)
+
+#undef DIV_DEF
+
 #define STRTOL_DEF(name, type, TYPE)                                           \
   type name(const char *str, char **endptr, int base)                          \
   {                                                                            \


### PR DESCRIPTION
Progresses #5868.

## Root cause

`src/c2goto/headers/stdlib.h` declares `div`, `ldiv` and `lldiv`, and
`src/cpp/library/cstdlib` dutifully re-exports all three plus `div_t`,
`ldiv_t` and `lldiv_t` into `namespace std`. But `src/c2goto/library/stdlib.c`
never defines any of them, so the call lowers to one returning an
unconstrained struct:

```c
div_t d = div(7, 2);
assert(d.quot == 3);   // VERIFICATION FAILED
assert(d.quot != 3);   // ALSO VERIFICATION FAILED
```

Both directions failing is the signature of a nondet return — not a missing
feature (which fails to compile) and not a wrong implementation (which fails
one way consistently). Everything around them is fine: `abs`, `labs`, `atoi`
and `atol` all verify, which is why this was easy to miss.

There is a second, smaller defect alongside it. `lldiv` was declared

```c
lldiv_t lldiv(long int numerator, long int denominator);
```

taking `long` parameters while returning `lldiv_t`, so on an LP64 target a
`long long` argument outside the `long` range would be silently truncated
before the division.

Found by a differential battery: small self-contained TUs asserting facts the
real library guarantees, compiled and **run** with host `clang`/`clang++` for
ground truth, then re-run under ESBMC. Nine of the ten cases in this round
passed — the containers, algorithms, `<bitset>`, `<memory>` and `<limits>` are
in good shape — and `div` was the one that did not.

## Solution

Define the three via a `DIV_DEF` macro, matching the `STRTOL_DEF` idiom
already in the file, and widen `lldiv`'s parameters to `long long int`.

C99 7.20.6.2 requires the quotient to be "the integer of lesser magnitude that
is nearest to the algebraic quotient", i.e. truncation toward zero, with
`quot * denom + rem == numer`. C's own `/` and `%` have exactly that rounding
(C99 6.5.5p6), so the bodies are a direct `numerator / denominator` and
`numerator % denominator` — no sign fixup needed, and none that could drift
from the language semantics ESBMC already models.

Widening `lldiv`'s parameters cannot break a caller: every argument that was
accepted before still converts.

## Tests

* `esbmc/github_5868_div` — `div(7, 2)`, the exact-division case `div(6, 3)`,
  and `div(-7, 2)` to pin truncation toward zero (`quot == -3`, `rem == -1`,
  not the floor-division `-4`/`1`), including the
  `quot * denom + rem == numer` identity the standard guarantees. Plus `ldiv`
  on a negative numerator and `lldiv`.
* `esbmc/github_5868_div_fail` — asserts `div(7, 2).quot == 4`, expecting
  `VERIFICATION FAILED`. On master that claim is *satisfiable* because the
  member is unconstrained, so this pins the defect directly.
* `esbmc-cpp/cpp/github_5868_std_div` — the `std::`-qualified spellings
  through `<cstdlib>`, run at `--std c++03`; also verified SUCCESSFUL under
  `c++11`, `c++17` and `c++20`.

Both positive programs were compiled and **run** with the host toolchain and
exit 0, so the expected values are the real library's.

```
ctest -R "github_5868_div|github_5868_std_div"                          3/3
ctest -L "esbmc/"                                                       1564, 8 fail
ctest -L "esbmc-unix/|esbmc-unix2/|cstd/|goto-transcoder/|k-induction/" 953, 5 fail
ctest -L "esbmc-cpp/cpp/|OM_sanity_checks/|bug_fixes/"                  862, 9 fail
```

Since this touches the C library every C test links against, I ran the whole
`regression/esbmc` suite: the 8 failures are exactly the documented macOS
baseline (`bitvector_02/03`, `char16/32-lit` ×4,
`github_1537-assume`/`-no-assume`) and no more. The rest are also pre-existing
and environmental — `esbmc-unix/04_valgrind` and
`goto-transcoder/cbmc_fpclassify` are documented, `esbmc-unix/error` and
`error2` need glibc's `error.h` which macOS lacks, and
`esbmc-unix/unsupported_extensions` pulls x86-only `mmintrin.h` on aarch64 —
and the 9 C++ ones are the documented `esbmc-cpp/cpp/` baseline.
