### PR TITLE
[docs] Correct the #sol claim and scope the two open roadmap items

### DIFF
--- a/docs/roadmap/irep2-migration.md
+++ b/docs/roadmap/irep2-migration.md
@@ -1375,10 +1375,28 @@ read through a single typed accessor on `solidity_convertert`
 | [#4959](https://github.com/esbmc/esbmc/pull/4959) | `#sol_data_loc` | 3 set / 0 read |
 
 (`#sol_type` was already encapsulated pre-plan via `get_sol_type` /
-`set_sol_type`.) After the pass, raw `"#sol` access outside the accessor
-bodies is gone; the Solidity type-metadata surface sits behind ~10 typed
-seams that a future migration can repoint **in one place each**, rather
-than at the dozens of scattered call sites that existed before. Every PR
+`set_sol_type`.) After the pass, raw `"#sol` access is gone **for every
+attribute in the table above**; the Solidity type-metadata surface sits behind
+~10 typed seams that a future migration can repoint **in one place each**,
+rather than at the dozens of scattered call sites that existed before.
+
+**Correction (2026-07-30) — the pass was per-attribute, not exhaustive.** An
+earlier revision of this section claimed raw `"#sol` access outside the
+accessor bodies was *gone*, unqualified. It is not: two attributes were never
+in scope of the five PRs above and still have raw writes.
+
+| site | attribute | added |
+|---|---|---|
+| `solidity_convert_modifier.cpp:92` | `#sol_tuple_id` | 2026-04-06 |
+| `solidity_convert_stmt.cpp:122` | `#sol_unchecked` | 2026-05-05 |
+
+Both predate the pass's conclusion (2026-05-30), so these are attributes the
+pass never covered — not regressions against it. Re-derive with
+`git grep -n '"#sol' -- src/solidity-frontend`: 24 hits, 21 of them the
+accessor bodies in `solidity_convert.h`, 2 the raw writes above, 1 a comment.
+Anyone resuming Part III should fold these two into the accessor set first, so
+the "one repoint-point per attribute" property the milestone claims actually
+holds for the whole `#sol_*` surface. Every PR
 was a behaviour-preserving mechanical no-op (same key, same value,
 same storage); verdict validation ran on Linux CI, since the
 `esbmc-solidity` suite cannot run on macOS (the `sol64` operational models
@@ -4419,6 +4437,16 @@ straight into the symbol table via `set_type(type2tc)` rather than
 no legacy `typet`; symbol types are IREP2 at write; verdict + text unchanged.
 
 ### Phase V.2 — IREP2-native attribute carriage (removes W3)
+
+> **Superseded (2026-07-30) — read
+> `docs/roadmap/scope-v2-w3-attribute-carriage.md` before acting on this
+> paragraph.** The symbol-keyed companion below cannot serve any of the
+> consumers: every W3 read is off a transient type *value*, with no symbol in
+> hand — the same Q-S1 wall Part III §14 hit for `#sol_*`, recorded there after
+> this text was written and never propagated here. The consumer list is also
+> incomplete (four reader sites, not three) and `#cformat` has no external
+> consumer at all.
+
 Move `#cpp_type`/`#member_name`/`#cformat` off `irept` onto a **typed IREP2
 companion keyed by symbol id** (the §5.1 pattern — *not* a generic string-map,
 which re-introduces the escape hatch IREP2 abolished). Teach the three external
@@ -5245,11 +5273,19 @@ Two items, both sized and neither speculative:
 
 1. **The coupled arithmetic-conversion effort** (operand-level reconciliation,
    then the assignment conversion) — the sole remaining blocker on the
-   `python_adjust` flip. `scope-v1k-adjuster.md` sizes it as multi-PR and proves
-   that shipping either half alone is unsound.
+   `python_adjust` flip. `scope-v1k-adjuster.md` proves that shipping either
+   half alone is unsound. Owner document:
+   `docs/roadmap/scope-coupled-arith-assign-conversion.md`, which re-sizes it
+   at 3 PRs (down from "multi-PR effort") on the finding that the
+   usual-arithmetic-conversion engine already has native `expr2tc` overloads
+   that `python_adjust` already calls.
 2. **V.2/W3 attribute carriage**, which V.1a and V.6 both depend on. Untouched;
    the highest shared blast radius left in the program (`clang_cpp_adjust_expr`,
-   `cpp_expr2string`, `goto2c/expr2c` serve C++ and Solidity too).
+   `cpp_expr2string`, `goto2c/expr2c` serve C++ and Solidity too — and a fourth
+   reader, `clang_cpp_adjust_code_gen`, that §V.2 does not name). Owner
+   document: `docs/roadmap/scope-v2-w3-attribute-carriage.md`, which finds
+   §V.2's prescribed design refuted by Part III's own Q-S1 argument and
+   recommends re-scoping.
 
 V.5 is closed rather than pending — see its scope doc. With those recorded, the
 V-track has no undocumented residue: every remaining item has a named owner

--- a/docs/roadmap/scope-coupled-arith-assign-conversion.md
+++ b/docs/roadmap/scope-coupled-arith-assign-conversion.md
@@ -1,0 +1,242 @@
+# Scope — the coupled arithmetic + assignment conversion (the `python_adjust` flip blocker)
+
+> **Status: not started.** This document exists because
+> `docs/roadmap/scope-v1k-adjuster.md` §"Flip gate (2026-07-29)" closes that
+> scope with exactly one remaining prerequisite and hands it off: *"Next owner:
+> take the coupled conversion effort as its own scope, then re-run this
+> whole-corpus census as the flip gate."* This is that scope.
+>
+> It is a **forward plan**, not a record of work. Nothing below has landed.
+
+## 1. What this unblocks, and what it does not
+
+`python_adjust` is the IREP2-native replacement for the legacy
+`clang_cpp_adjust` pass on the Python path. It is complete enough to run as the
+sole adjuster behind `--python-irep2-adjust-only` (`src/esbmc/options.cpp:214`,
+experimental, default off), and every *structural* gap the adjuster scope
+enumerated is closed or refuted.
+
+The flip to default-on is blocked on one defect class. Clearing it:
+
+- **unblocks** the `python_adjust` flip (`--python-irep2-adjust-only` becomes
+  the default; the legacy `clang_cpp_adjust` hop on the Python path goes away);
+- **does not** advance §V.1 bars #1, #2 or #4 — those are V.2/W3 and the
+  symbol-write boundary, tracked elsewhere;
+- **does not** touch C or C++, which keep using `clang_c_adjust` /
+  `clang_cpp_adjust` unchanged. The blast radius is the Python suite only.
+
+## 2. The defect, restated precisely
+
+From the flip-gate census (1 108 tests, every 4th directory): 6 genuine
+regressions, all one mechanism. The witness is `builtin_all_nonliteral`, whose
+normalized `--goto-functions-only` dumps differ in exactly one line:
+
+```
+legacy:   5: ASSIGN element=(_Bool)tmp$5;
+hop-off:  5: ASSIGN element=tmp$5;
+```
+
+A `_Bool`-typed target receives an unconverted integer. The ill-typed
+assignment survives goto-conversion and symex and reaches the solver, where the
+destination AST is not the sort the source expects — SIGSEGV in
+`smt_solver_baset::convert_assign` (`smt_solver.cpp:366`), or a Bitwuzla
+"terms with mismatching sort" abort. This is a **crash class, not a
+false-alarm class**; that severity finding is what moved the flag from
+"tolerable for an experimental flag" to "does not ship".
+
+**Why the obvious fix is unsafe.** `clang_c_adjust::adjust_assign`
+(`clang_c_adjust_code.cpp:175-181`) is two statements:
+
+```cpp
+adjust_operands(code);
+gen_typecast(ns, code.op1(), code.op0().type());
+```
+
+Mirroring only the second line in `python_adjust` fixes `precedence2` **and
+makes `neural-net_fail` (`--fixedbv`) report SUCCESSFUL where legacy correctly
+reports FAILED** — it masks a real bug. The reason is the first line:
+`adjust_operands` has already recursively applied the usual arithmetic
+conversions to the right-hand side. Converting only at the assignment seam,
+over operands that were never reconciled, changes the stored value. The two
+halves are only sound **together**.
+
+## 3. Sizing correction — the conversion engine is already IREP2-native
+
+The adjuster scope sized the operand half as "mirroring
+`clang_c_adjust::adjust_expr_binary_arithmetic` (~114 lines) … a multi-PR
+effort in its own right". That estimate treats the whole legacy function as
+work to be re-implemented. A re-audit of the tree (2026-07-30) finds two
+reasons it is an over-estimate, and one reason it is an under-estimate.
+
+### 3.1 `c_typecastt` already has full `expr2tc` overloads
+
+The usual-arithmetic-conversion engine does **not** need building. Every
+routine the legacy path uses already has a native IREP2 sibling, and they are
+exported as free functions:
+
+| legacy entry point | IREP2 sibling | location |
+|---|---|---|
+| `c_implicit_typecast(exprt&, typet, ns)` | `c_implicit_typecast(expr2tc&, const type2tc&, ns)` | `c_typecast.h:33` |
+| `c_implicit_typecast_arithmetic(exprt&, exprt&, ns)` | `c_implicit_typecast_arithmetic(expr2tc&, expr2tc&, ns)` | `c_typecast.h:43` |
+| `implicit_typecast_followed(exprt&, …)` | `implicit_typecast_followed(expr2tc&, …)` | `c_typecast.cpp:784` |
+| `get_c_type(const typet&)` | `get_c_type(const type2tc&)` | `c_typecast.cpp:364` |
+| `do_typecast(exprt&, const typet&)` | `do_typecast(expr2tc&, const type2tc&)` | `c_typecast.cpp:947` |
+
+These are not stubs — `implicit_typecast_arithmetic(expr2tc&, c_typet)`
+(`c_typecast.cpp:490-565`) implements the full promotion ladder including the
+array→pointer decay case.
+
+**They are already in use on the Python path.** `python_adjust.cpp:428` calls
+the `expr2tc` arithmetic overload today, and so do `python_math.cpp:47`,
+`list_comprehension.cpp:299`, `list_mutation.cpp:981`, `python_set.cpp:180,252`
+and `builtins.cpp:1490`. So the engine is native, exercised, and no
+`migrate_expr` round-trip is involved.
+
+What is narrow is the **guard**, not the engine. `python_adjust.cpp:421-429`
+fires only when the node has exactly 2 operands, *both* are `bv`, and their
+signedness differs — the round-13 relational fix (#6462). Arithmetic binops and
+assignments have **no arm at all**: `adjust_expr`'s dispatch
+(`python_adjust.cpp:247-767`) handles `member2t`, `index2t`, `dereference2t`,
+`if2t`, `not2t`, `constant_struct2t`, `code_function_call2t` and
+`code_cpp_throw2t`, and nothing else.
+
+### 3.2 The complex branch is very likely unreachable on the Python path
+
+Of the 114 lines in `adjust_expr_binary_arithmetic`
+(`clang_c_adjust_expr.cpp:428-541`), **lines 435-522 (~88) are the complex
+branch** — promotion to `{val, 0}`, component-wise lowering, the `ieee_*`
+remap, and `bind_sideeffect_operands`. The scalar path is lines 524-540: follow
+both operand types, one `gen_typecast_arithmetic` call, adopt the result type
+if both operands agree and are numeric, then `adjust_float_arith`.
+
+The Python converter **already lowers complex arithmetic itself**, before the
+adjuster ever runs: `math/complex_handler.cpp:98-110` builds `ieee_mul2tc` /
+`ieee_add2tc` over `.real` / `.imag` `member2tc` accesses directly, carrying
+`symbol2tc(get_int32_type(), "c:@__ESBMC_rounding_mode")` as the rounding mode
+(`complex_handler.cpp:92`). If no `complex_type2t`-typed binary operation
+survives into `python_adjust`, ~88 of the 114 lines are not this scope's work.
+
+**This is a hypothesis with a named discharge, not a finding.** It must be
+verified before it is used to size anything — see gate G0 in §5.
+
+### 3.3 The under-estimate — `adjust_float_arith` is not an id rewrite in IREP2
+
+`clang_c_adjust::adjust_float_arith` works by **mutating the node's id in
+place** (`expr.id("ieee_add")`) and then setting a `rounding_mode` sub-irep.
+Neither operation exists in IREP2: `add2t` and `ieee_add2t` are distinct
+classes (`src/irep2/expr_kinds.inc:58`), nodes are immutable, and the rounding
+mode is a constructor **operand**, not an attribute. The IREP2 arm must
+therefore *rebuild* the node — `ieee_add2tc(type, lhs, rhs, rm)` — rather than
+retype it, and must source `rm` the same way the converter already does
+(`c:@__ESBMC_rounding_mode`), or the goto output will not be byte-identical.
+
+The legacy function also carries a `// BUG: setting rounding_mode breaks
+migration` comment and an early return for vector types. Do not port the bug;
+do check whether the vector arm is reachable from Python at all (it likely is
+not — the same census as G0 answers it).
+
+### 3.4 Revised sizing
+
+| half | estimate | basis |
+|---|---|---|
+| operand-level reconciliation | **1 PR**, ~40-60 lines | scalar path only (§3.2), engine already native (§3.1), node rebuild instead of id rewrite (§3.3) |
+| assignment conversion | **1 PR**, ~15-25 lines | `c_implicit_typecast(expr2tc&, type2tc, ns)` at a new `code_assign2t` arm |
+| flip + census | **1 PR** | re-run the §6 gate |
+
+So **3 PRs, not "multi-PR effort" in the open-ended sense** — *conditional on
+G0*. If G0 shows complex or vector binops do reach `python_adjust`, the operand
+half reverts to roughly the original estimate and gains a fourth PR.
+
+## 4. Phased decomposition
+
+Strictly ordered. The ordering is the soundness argument from §2, not a
+preference.
+
+### Phase 0 — the reachability census (no code change)
+
+Discharge G0. Instrument `python_adjust::adjust_expr` to log the `type_id` and
+`expr_id` of every binary arithmetic node it sees, run the whole `python`
+suite, and tabulate. Deliverable: a table of reachable operand type kinds.
+Revert the instrumentation.
+
+### Phase 1 — operand-level arithmetic reconciliation
+
+Add the binary-arithmetic arm to `adjust_expr`, covering the kinds Phase 0
+found reachable. Widen the `python_adjust.cpp:421` guard from
+"both-bv-different-signedness" to the usual arithmetic conversions, rebuilding
+`ieee_*` nodes per §3.3.
+
+**Ships alone.** It must, because it has its own parity gate and because
+shipping it *with* Phase 2 would leave no way to attribute a regression to one
+half. Landing it alone is safe in the direction that matters: it adds
+conversions the legacy path also performs, so it moves the hop-off *toward*
+legacy, and the assignment seam stays as under-converted as it is today.
+
+### Phase 2 — the assignment conversion
+
+Add the `code_assign2t` arm calling
+`c_implicit_typecast(source, target->type, ns)`. Only after Phase 1 has landed
+and passed its gate.
+
+**The `neural-net_fail` check is the acceptance test for this phase**, not a
+regression to notice later. It must report FAILED.
+
+### Phase 3 — the flip
+
+Make `python_adjust` the sole adjuster; `--python-irep2-adjust-only` becomes
+the default with an opt-out, mirroring how the W1-loc keystone shipped
+(`--irep2-native-body` → deprecated no-op, `--no-irep2-native-body` the escape
+hatch, `src/esbmc/options.cpp:964-975`).
+
+## 5. Gates
+
+| # | Gate | Discharged by |
+|---|---|---|
+| **G0** | The reachable operand-kind census exists, and the complex/vector claim in §3.2 is confirmed or refuted | Phase 0 |
+| G1 | `builtin_all_nonliteral` and `chained-comparison2_fail` produce legacy-identical verdicts under the hop-off | Phase 2 |
+| G2 | **`neural-net_fail` (`--fixedbv`) reports FAILED** | Phase 2 — the anti-masking gate |
+| G3 | All 6 flip-gate regressions clear: `github_4344`, `github_5571_fail`, `github_5571_tuple_str_annotation`, `lambda15`, `precedence2`, `sum_tuple` | Phase 2 |
+| G4 | Whole-corpus census re-run, 0 attributable divergences | Phase 3 |
+| G5 | Dual-solver agreement (Bitwuzla + Z3) on the corpus | Phase 3 |
+
+**Census methodology — inherited, non-optional.** Both prior censuses on this
+track were first invalidated by harness artifacts. Reuse the recorded rules:
+
+1. **Skip tests whose `test.desc` already passes the flag** — adding it twice
+   makes boost throw `multiple_occurrences` (9 false divergences in the
+   flip-gate run).
+2. **Count both-paths-no-verdict separately** — differing only in `rc=134` vs
+   `rc=139` is pre-existing, not attributable.
+3. **Exclude or serialize `--k-induction-parallel` tests** — forked children
+   share stderr and the capture garbles; it is UNSTABLE against itself.
+4. **Minimum-size guard on captured output** (`< 200 bytes → SKIP`) — both
+   sides collapsing to one error line otherwise counts as a *match*.
+5. Sample **unbiased and dense**: stride-20 missed a 0.5 % defect rate
+   entirely. Directory-order prefixes are biased.
+
+## 6. Risks
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | Phase 1 lands and Phase 2 never does, leaving the hop-off half-converted indefinitely | Phase 1 is verdict-neutral-or-better by construction; the flag stays default-off until G2-G4 |
+| R2 | The conversions change goto bytes for tests that currently pass, on the *default* path | They cannot — `python_adjust` runs only under `--python-irep2-adjust-only` until Phase 3 |
+| R3 | G0 refutes §3.2 and the effort triples | Phase 0 is deliberately first and cheap; re-size before committing to Phase 1 |
+| R4 | Another masking case exists that `neural-net_fail` does not represent | G3 + G5; and prefer `_fail` tests when sampling — a masked bug only shows on a test that should FAIL |
+
+## 7. Non-goals
+
+- Touching `clang_c_adjust` / `clang_cpp_adjust`, or the C and C++ paths.
+- The remaining `python_adjust` per-case divergences — the flip-gate census
+  established there are none left outside this mechanism. **Do not re-triage
+  per case**; the census names the single mechanism.
+- V.1a, V.2/W3, V.5, V.6 — different scopes, see
+  `docs/roadmap/irep2-migration.md` §V.7 and
+  `docs/roadmap/scope-v2-w3-attribute-carriage.md`.
+- §V.1 bars #1/#2/#4. This scope moves none of them.
+
+## 8. One-line summary
+
+The engine is already IREP2-native and already called from `python_adjust`;
+what is missing is a binary-arithmetic arm and an assignment arm, which are
+unsound apart and must land in that order — sized at 3 PRs conditional on a
+cheap reachability census that could shrink the first one by ~88 lines.

--- a/docs/roadmap/scope-v1k-adjuster.md
+++ b/docs/roadmap/scope-v1k-adjuster.md
@@ -1335,6 +1335,20 @@ Next owner: take the coupled conversion effort as its own scope, then re-run
 this whole-corpus census as the flip gate. Do not re-triage per case — the
 census now names the single mechanism.
 
+**That scope now exists: `docs/roadmap/scope-coupled-arith-assign-conversion.md`
+(2026-07-30).** It carries the census methodology above forward as a
+non-optional gate, and re-sizes the effort at **3 PRs** rather than the
+open-ended "multi-PR effort in its own right" this section estimated. The
+re-sizing rests on two findings this document did not have: the
+usual-arithmetic-conversion engine already has complete `expr2tc` overloads
+(`c_typecast.h:33,43`) which `python_adjust.cpp:428` already calls — so only
+the *guard* is narrow, not the engine — and ~88 of
+`adjust_expr_binary_arithmetic`'s 114 lines are the complex branch, which the
+Python converter appears to pre-lower itself (`math/complex_handler.cpp:98-110`
+builds `ieee_*2tc` over `.real`/`.imag` directly). That second finding is a
+hypothesis with a named discharge, not a result; the new scope gates on it
+(G0) before any code is written.
+
 ### Per-case triage round 14 — array decay at the call-argument seam (2026-07-28)
 
 **A strided whole-corpus census is now the frontier finder.** With round 11's open

--- a/docs/roadmap/scope-v2-w3-attribute-carriage.md
+++ b/docs/roadmap/scope-v2-w3-attribute-carriage.md
@@ -1,0 +1,183 @@
+# Scope — V.2 / W3 IREP2-native attribute carriage
+
+> **Status: not started, and this document recommends re-scoping before it is.**
+> `docs/roadmap/irep2-migration.md` §V.7 lists V.2/W3 as one of two remaining
+> items — *"Untouched; the highest shared blast radius left in the program"* —
+> and V.1a and V.6 both depend on it. This scope re-grounds §V.2 against the
+> tree (2026-07-30) and finds that **the design §V.2 prescribes is refuted by an
+> argument Part III already recorded and never propagated forward.**
+>
+> A forward plan, not a record of work. Nothing below has landed.
+
+## 1. What §V.2 asks for
+
+Verbatim (`irep2-migration.md:4421-4428`):
+
+> Move `#cpp_type`/`#member_name`/`#cformat` off `irept` onto a **typed IREP2
+> companion keyed by symbol id** (the §5.1 pattern — *not* a generic string-map,
+> which re-introduces the escape hatch IREP2 abolished). Teach the three
+> external consumers (`clang_cpp_adjust_expr`, `cpp_expr2string`,
+> `goto2c/expr2c`) to read the IREP2 form.
+
+Two of that paragraph's load-bearing claims do not survive contact with the
+tree: the consumer count, and the keying.
+
+## 2. The consumer census (re-derived)
+
+`git grep -c '#cpp_type' -- src` and siblings. **Reads**, classified by hand —
+the raw counts include writes, accessor bodies and comments:
+
+| reader | attribute | what it does |
+|---|---|---|
+| `clang-cpp-frontend/clang_cpp_adjust_expr.cpp:582` | `#cpp_type` | builds exception type ids for catch matching |
+| `util/lang/cpp_expr2string.cpp:138,140` | `#cpp_type` | counterexample type spelling (`signed char`, …) |
+| `goto2c/expr2c.cpp:174` | `#cpp_type` | distinguishes same-width types (`long` vs `long long`) when emitting C |
+| `clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp:51,200` | `#member_name` | ctor member lookup + symbol-name construction |
+
+**Correction to §V.2: there are four reader sites, not three.**
+`clang_cpp_adjust_code_gen.cpp` is a real consumer and is not in §V.2's list.
+It is also the *only* `#member_name` reader, which matters because it makes
+`#member_name` separable from `#cpp_type` (§5).
+
+Two further corrections:
+
+- **`#cformat` has no external consumer at all.** Its only non-frontend
+  presence is the `irept::cformat()` accessor itself (`util/irep/irep.cpp`,
+  `util/irep/std_expr.h`), which Phase 4.1 already routed Python through. Its
+  remaining writers are Solidity (`solidity_convert_type.cpp:2`,
+  `solidity_convert_literals.cpp:1`). Bundling it with the other two overstates
+  the work.
+- `goto-programs/exception_typeid.h` matches a `#cpp_type` grep but the hit is
+  a **comment**, not a read. It is not a consumer.
+
+### 2.1 The writer side is four frontends, not one
+
+§V.2 sits in Part V (Python), but the attributes are written by four frontends
+at very different levels of encapsulation:
+
+| frontend | encapsulation state |
+|---|---|
+| Python | **encapsulated** — Phase 4.1 routed all access through `type_utils::{set,get}_cpp_type` / `{set,remove}_member_name` (`type_utils.h`); raw access is the accessor bodies only |
+| Solidity | **partial** — Phase 3.1 encapsulated the `#sol_*` family, but `#cpp_type` (`solidity_convert_type.cpp:7`, `solidity_convert.cpp:1`, `solidity_convert_literals.cpp:1`) and `#member_name` (7 sites across 5 files) were never in scope |
+| clang-cpp | **raw** — `clang_cpp_convert.cpp:3`, `clang_cpp_convert.h:1` write `#member_name` directly |
+| clang-c | **raw** — `clang_c_convert.cpp:1891` writes `#cpp_type` |
+
+So a Python-scoped V.2 cannot remove the attributes: three other frontends keep
+writing them, and the four readers keep reading them. **V.2 is only meaningful
+as a repo-wide change**, which is why §V.7 correctly calls it the highest
+shared blast radius left.
+
+## 3. The decisive finding — §V.2's keying is already refuted
+
+§V.2 prescribes "a typed IREP2 companion **keyed by symbol id**". Part III
+§14's Q-S1 investigated exactly that design for Solidity's `#sol_*` and killed
+it:
+
+> the reads are **value-carried, not symbol-reachable** … ~40 of the ~43 read
+> sites read off a transient `typet` value or an expression's `.type()` — with
+> **no associated symbol at read time**.
+
+**Every W3 reader has the same shape.** Verified by reading each site:
+
+- `cpp_expr2string.cpp:138` — `src` is the type currently being printed,
+  reached *recursively* (`convert(src.subtype())`). There is no symbol; worse,
+  the metadata must survive subtype traversal.
+- `goto2c/expr2c.cpp:174` — `src` is a type being named; the read is guarded on
+  `width % 8 == 0`, i.e. it is a property of the type value.
+- `clang_cpp_adjust_expr.cpp:582` — `type` is a catch parameter type in the
+  middle of id construction.
+- `clang_cpp_adjust_code_gen.cpp:51` — `ctor_type.get("#member_name")` is read
+  off a value and then *used* as a lookup key; the symbol is the result, not
+  the context.
+
+A symbol-keyed side table cannot serve any of them. Part III's conclusion
+transfers verbatim: **the metadata must travel with the value**, so only a
+value-bundled companion can carry it — and that companion "re-introduces the
+attribute flexibility IREP2 removed, for no verifier-core benefit".
+
+This is not a new discovery. It is Part III's finding, which was recorded in
+Part III and never propagated to §V.2 — the plan text predates it. §V.2 as
+written should be treated as **superseded**.
+
+## 4. Why this also re-validates B1
+
+Part III §14 closed with the Solidity frontend staying legacy "by design",
+citing B1. The same argument applied to W3 lands in the same place, and for a
+sharper reason: `#cpp_type` exists precisely to carry information IREP2's
+closed type system **deliberately discards** — the source-level *spelling* of a
+type. `long` and `long long` are the same `signedbv_type2t` at the same width;
+that is not a gap in IREP2, it is the normalization IREP2 was built to perform.
+`goto2c/expr2c.cpp:160-173` says so in its own comment.
+
+The three `#cpp_type` readers are, without exception, **presentation** consumers
+— counterexample text, generated C, and exception-id strings. None is verifier
+core. Removing W3 buys no soundness and no round-trip.
+
+## 5. Options, and the recommendation
+
+| # | Option | Cost | Verdict |
+|---|---|---|---|
+| A | Symbol-keyed IREP2 companion (as §V.2 specifies) | — | **Not viable.** §3 |
+| B | Value-bundled companion wrapping `type2tc` | high | Viable but re-creates attribute flexibility; rejected on the same cost/benefit as Part III §14 |
+| C | Extend `type2t` with a spelling field | medium | Explicitly rejected upstream ("extending `type2t` (rejected)", Part III §14) — and it would push presentation concerns into the verifier IR |
+| D | **Encapsulate the remaining raw writers; leave carriage legacy** | low (2-3 PRs) | **Recommended.** §5.1 |
+| E | Do nothing | zero | Defensible, but leaves four frontends writing raw ireps with no repoint-point |
+
+### 5.1 Option D — what it actually is
+
+Both Part III and Part IV independently converged on the same end state:
+*encapsulate the attribute behind one typed seam per frontend, leave the
+storage legacy.* Python is already there (Phase 4.1); Solidity is there for
+`#sol_*` (Phase 3.1). Option D finishes the pattern for the attributes and
+frontends that were never in scope:
+
+1. **clang-cpp `#member_name`** (`clang_cpp_convert.cpp`, `.h`) — 4 sites
+   behind a typed accessor. Pairs with the single reader at
+   `clang_cpp_adjust_code_gen.cpp:51,200`, so `#member_name` becomes fully
+   seamed end-to-end in one PR.
+2. **Solidity `#cpp_type` + `#member_name`** — the sites Phase 3.1 skipped,
+   plus the two `#sol_*` stragglers `irep2-migration.md` §14's correction names
+   (`#sol_tuple_id`, `#sol_unchecked`).
+3. **clang-c `#cpp_type`** (`clang_c_convert.cpp:1891`) — one site.
+
+This delivers the only property V.2 was actually going to buy — *one
+repoint-point per attribute per frontend* — at a small fraction of the cost,
+and it leaves B/C available should the cost/benefit ever change. It is a
+behaviour-preserving mechanical no-op per PR, gated exactly as Phase 3.1 was.
+
+**What Option D does not do:** it does not remove W3, so it does **not**
+unblock §V.1 bar #4, and it does not unblock V.1a or V.6. Those stay blocked,
+now with a recorded reason rather than an unexamined plan. That is the honest
+trade and it should be stated in any PR that takes this option.
+
+## 6. Gates (for Option D)
+
+| # | Gate |
+|---|---|
+| G1 | Per PR: same key, same value, same storage — a mechanical no-op |
+| G2 | Verdict parity on **`esbmc-cpp`, `esbmc-solidity` and `python`** — these consumers serve C++ and Solidity too, so a Python-only gate is insufficient |
+| G3 | Counterexample **text** parity, not just verdicts — `cpp_expr2string` is a reader, so its output is asserted verbatim by `test.desc` regexes |
+| G4 | `goto2c` output parity on the `goto2c` suite |
+| G5 | Raw-access census after each PR: `git grep -n '#cpp_type\|#member_name\|#cformat' -- src/<frontend>` returns accessor bodies only |
+
+**Environment caveat.** `esbmc-solidity` needs `solc` and cannot run on macOS
+(`sol64` operational models are stubbed empty — `_BitInt(256)` is unavailable on
+Apple aarch64). Gate G2 must run on Linux CI. This bit Phase 3.1 and is
+recorded in `irep2-migration.md` §14.
+
+## 7. Risks
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | Option D is mistaken for progress toward removing W3 | Say so explicitly in each PR body; §V.7 bar #4 stays "no" |
+| R2 | An accessor changes the value's spelling or default | G1: byte-identical key and value; mechanical no-op only |
+| R3 | A reader is missed and keeps raw-reading | G5 census is repo-wide, not frontend-scoped |
+| R4 | Someone revives Option A from the stale §V.2 text | §3 of this document; `irep2-migration.md` §V.2 should link here |
+
+## 8. One-line summary
+
+§V.2's symbol-keyed companion cannot work — all four W3 readers read off
+transient type *values*, the same Q-S1 wall Part III hit — so the honest choice
+is the low-cost encapsulation pass that Parts III and IV both converged on,
+with W3 removal declined on a recorded rationale rather than left implicitly
+open.


### PR DESCRIPTION
Audits the three IREP2 roadmap documents against the tree and records what it found. Docs only — no code changes.

## 1. One inaccurate claim, corrected

Part III §14 stated that after the Phase 3.1 encapsulation pass, raw `"#sol` access outside the accessor bodies was *gone*, unqualified. It is not: `#sol_tuple_id` (`solidity_convert_modifier.cpp:92`) and `#sol_unchecked` (`solidity_convert_stmt.cpp:122`) still have raw writes. Both predate the pass's conclusion, so they are attributes it never covered rather than regressions against it. The claim is now scoped to the attributes in its own table, with the re-derivation command and a note for whoever resumes Part III.

Everything else in all three documents re-derived correctly, including all four §V.1 acceptance-bar measurements.

## 2. Owner documents for the two open items

§V.7 promises that "every remaining item has a named owner document, a sized cost, and a stated reason it was not taken." Two items had the reason but not the document. Both new scopes are grounded in the code rather than in the roadmap's prose, and each turned up something that changes the plan.

### `scope-coupled-arith-assign-conversion.md`

The sole blocker on the `python_adjust` flip. The adjuster scope sized it as "a multi-PR effort in its own right" on the assumption that `adjust_expr_binary_arithmetic` must be re-implemented. Two findings re-size it:

- **The conversion engine is already IREP2-native.** `c_typecastt` has complete `expr2tc` overloads (`c_typecast.h:33,43`, implementations at `c_typecast.cpp:490,589,875,947`), and `python_adjust.cpp:428` already calls one — along with six other Python sites. What is narrow is the *guard* (both-`bv`, differing signedness), not the engine. Arithmetic binops and assignments have no arm at all.
- **~88 of the 114 legacy lines are the complex branch**, which the Python converter appears to pre-lower itself (`math/complex_handler.cpp:98-110` builds `ieee_*2tc` over `.real`/`.imag` directly). This is flagged as a hypothesis with a named discharge (gate G0), not a result.

Working the other way: `adjust_float_arith` mutates the node id in place, which is impossible in IREP2 — `add2t` and `ieee_add2t` are distinct classes and the rounding mode is a constructor operand — so the arm must rebuild rather than retype.

Net: **3 PRs conditional on G0**. The scope carries forward the anti-masking gate (`neural-net_fail` must report FAILED) and all five census-methodology rules, since both prior censuses on this track were first invalidated by harness artifacts.

### `scope-v2-w3-attribute-carriage.md`

§V.2 prescribes "a typed IREP2 companion **keyed by symbol id**". Reading all four consumer sites shows every W3 read is off a transient type *value* with no symbol in hand — `cpp_expr2string.cpp:138` reads recursively through `src.subtype()`. That is exactly the Q-S1 wall Part III §14 hit for `#sol_*`, found *after* the §V.2 text was written and never propagated forward. §V.2 is marked superseded with a pointer.

Three further corrections: there are **four** reader sites, not three (`clang_cpp_adjust_code_gen.cpp:51,200` is unnamed); `#cformat` has **no** external consumer at all; and the writers span four frontends at different encapsulation levels, so a Python-scoped V.2 cannot remove anything.

The recommendation is the low-cost encapsulation pass Parts III and IV both independently converged on, stating plainly that it does **not** remove W3 — bar #4, V.1a and V.6 stay blocked, with a recorded reason instead of an unexamined plan.

## Testing

Docs only; no build or test impact. The claims are cited to file:line and were verified against the tree at `b368becda0`.