### PR TITLE
[ld] Fix graphical LD resolver soundness and add a correctness oracle

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -78,6 +78,24 @@ engines:
       # siblings.
       - 'unit/python-frontend/**'
 
+      # Developer build and test tooling, run by hand or from CI against a
+      # checkout — never shipped, and never fed untrusted input. Driving
+      # another program IS the job of these scripts (esbmc for
+      # ld_resolver_oracle.py, csmith and a compiler for run_csmith.py,
+      # gcov for cov-report.py), so B404 "consider implications of the
+      # subprocess module" and B603 "subprocess call - check for execution
+      # of untrusted input" fire on every one of them. B603 in particular
+      # fires on the *recommended* form: a fixed argv list with no shell.
+      # B311 likewise flags the seeded PRNG that ld_resolver_oracle.py
+      # needs precisely because a failing case must be reproducible from
+      # its seed alone; a cryptographic generator would defeat that.
+      # Bandit's own `# nosec` markers are not honoured by Codacy and
+      # patterns cannot be disabled in this file, so the path is excluded
+      # instead. This mirrors the global 'regression/**' exclusion above,
+      # which already covers the identical findings in
+      # regression/testing_tool.py.
+      - 'scripts/**'
+
   cppcheck:
     enabled: true
     exclude_paths:

--- a/docs/roadmap/safe-ld-implementation-plan.md
+++ b/docs/roadmap/safe-ld-implementation-plan.md
@@ -869,6 +869,34 @@ is the only gate on the front-end.
 - **Counter reset from a contact chain** is diagnosed and left unconnected;
   only a reset pin wired to a variable is modelled.
 
+### Validation beyond the regression suite
+
+`scripts/ld_resolver_oracle.py` is a randomised **structural** oracle for the
+graphical resolver. It generates random PLCopen networks, derives each one's
+power-flow formula from the ladder algebra independently of the resolver, and
+asserts through ESBMC that the coil is equivalent to that formula (both
+implications, so an undriven coil fails rather than passing vacuously). It is not
+a differential test against a previous resolver, which would bless a bug present
+in both. Two shapes are generated: `sp` (series-parallel, what a vendor tool
+draws) and `dag` (layered, each node fed by a random subset of the previous
+layer — not series-parallel, so it is what checks that path enumeration and the
+per-node recurrence agree by distributivity).
+
+This exists because the graphical corpus is only two real programs
+(`stairs_light`, `water_control`), which is thin cover for changing the resolver.
+Current state: **101 generated programs pass** (69 `sp` at depths 3–5, 32 `dag`
+up to 4 layers x 3 wide). Run it before and after any resolver change:
+
+```sh
+python3 scripts/ld_resolver_oracle.py 30 4 sp        # series-parallel
+python3 scripts/ld_resolver_oracle.py 20 3 dag 4 3   # re-convergent DAG
+```
+
+It does not yet cover function blocks on a rung path, edge contacts, feedback
+variables, or Set/Reset coils — those are still covered only by `stairs_light`
+and the driver tests, and extending the oracle to them is a prerequisite for
+trusting a resolver rewrite.
+
 ### Suggested next increments
 
 1. Run the M1 review of `docs/safe-ld-sos-semantics.md` and close its §10 items.

--- a/docs/roadmap/safe-ld-implementation-plan.md
+++ b/docs/roadmap/safe-ld-implementation-plan.md
@@ -3,14 +3,14 @@
 **Status:** PLANNING — WP2 largely implemented (skeleton #5280, property pipeline #5289, ld-verify runner + fault injection #5294, industrial benchmarks #5427, user-FB/REAL/watchdog #5620, graphical-LD soundness fixes + WP1 SOS spec)  
 **Project:** APP113435 — ESBMC-PLC (EPSRC Standard Research Grant)  
 **Tracking:** umbrella issue TBD  
-**Date:** 2026-06-09 (status refreshed 2026-07-24)
+**Date:** 2026-06-09 (status refreshed 2026-07-30)
 
 > **Implementation note.** The boolean/combinational Tier-1 subset, the
 > integer-arithmetic constructs (TON/TOF/TP timers, CTU/CTD counters, and the
 > `response` property), and — beyond the original Tier-1 scope — user-defined
 > function-block bodies, REAL/analog process variables, and an optional
 > scan-watchdog all now lower to GOTO IR and verify end-to-end (see §10). The
-> suite under `regression/ld/` has grown to 23 CTest cases, plus 10 for the
+> suite under `regression/ld/` has grown to 25 CTest cases, plus 10 for the
 > `ld-verify` runner, and CI now actually runs them. All four curated
 > benchmarks have validated verdicts and are wired as regression tests. The WP1
 > SOS specification exists as `docs/safe-ld-sos-semantics.md`; its independent
@@ -572,7 +572,7 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 | T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280); extended with user-FB-body and REAL/analog parsing (#5620) |
 | T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | boolean subset + timers/counters/`response` all lower and verify (#5289); ST→`codet` FB-body translator + numeric↔Boolean coercion (#5620); graphical resolver now models FB blocks, edge contacts, parallel-path OR and network feedback; all four benchmark verdicts validated (§10) |
 | T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired + JSON report (#5289); `ld-verify` runner implemented, driving `esbmc` (#5294); `--ld-fault-injection`, `--ld-sound-mode`, `--ld-scan-watchdog`/`--ld-scan-budget` driver flags added (#5294, #5620) |
-| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 23 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
+| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 25 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
 
 **Success criteria (WP2):**
 - **Correctness:** ≥95% of benchmark programs translated to GOTO IR with semantic
@@ -777,6 +777,12 @@ prose in §3 is not mistaken for delivered functionality.
   also re-encoded so that `Q` starts false rather than reading an un-run timer's
   `ET` as an expired interval. PLCopen `<initialValue>` is now parsed; before,
   every declared preset silently read as zero.
+- **Unmodellable rung paths are rejected, not dropped.** The graphical resolver
+  used to skip any rail-to-coil path it could not model and, when a block's
+  output drove a coil without a power-flow edge reaching it, emitted no rung and
+  no diagnostic at all — leaving the coil at its initial value and passing
+  properties over it vacuously. Both now raise
+  `UnsupportedConstruct(name, tier=2)` per §7, naming the offending block.
 - **Benchmark verdicts validated.** `conveyor_sequencing` and
   `emergency_shutdown` are wired as regression tests. The ESD violation proved
   to be a true positive — its reset rung does not gate on the manual trip being
@@ -784,7 +790,7 @@ prose in §3 is not mistaken for delivered functionality.
   pinned as `esd_manual_reset_fail`, with the corrected program as
   `emergency_shutdown_safe`. The conveyor's failure was a `response` property
   whose bound ignored a free `Stop_Button` input, plus the unparsed preset.
-- **Regression suite `regression/ld/`** now holds **23 CTest cases** (guarded by
+- **Regression suite `regression/ld/`** now holds **25 CTest cases** (guarded by
   `ENABLE_LD_FRONTEND`, with the `benchmarks/` dataset excluded from CTest —
   `regression/CMakeLists.txt`), covering all five property kinds plus
   fault-injection, user-FB, watchdog, REAL-arithmetic, and the `stairs_light` /
@@ -812,7 +818,7 @@ requests as well as pushes touching `src/ld-frontend/`, `tools/ld-verify/`,
 `regression/ld/` or `unit/ld-frontend/`:
 
 - `regression-ld` builds with `BUILD_TESTING=On` / `ENABLE_REGRESSION=On` and
-  runs `regression/ld/` (23 cases), the `ld-verify` runner suite (10 cases) and
+  runs `regression/ld/` (25 cases), the `ld-verify` runner suite (10 cases) and
   the three LD unit binaries.
 - `build-linux-amd64` builds the release binary, smoke-tests that it advertises
   `--ld-props`, and publishes it as an artifact.
@@ -835,17 +841,23 @@ is the only gate on the front-end.
 - **Graphical path enumeration is exponential.** The resolver enumerates every
   simple rail-to-sink path; a vendor export with many parallel branches would
   blow up. No path-count guard yet.
-- **Arithmetic and unknown blocks on a rung path** are still diagnosed and
-  dropped rather than modelled, so a program using one verifies over strictly
-  less behaviour. Only timers and counters are resolved on graphical paths.
+- **Arithmetic and unknown blocks on a rung path** are still not modelled —
+  only timers and counters are resolved on graphical paths — but they are now
+  a hard `UnsupportedConstruct(name, tier=2)` error rather than a dropped path,
+  so a program using one is rejected instead of verifying over strictly less
+  behaviour. Previously such a block was not even diagnosed: because step 3
+  only makes `IN`/`CU`/`CD` into power-flow edges, a block like `GT` driving a
+  coil got no incoming edge, `paths_to` returned nothing, and the coil was left
+  unassigned — a `VERIFICATION SUCCESSFUL` verdict on a program whose rung had
+  silently vanished (`graphical_unsupported_block_fail` pins this).
 - **Counter reset from a contact chain** is diagnosed and left unconnected;
   only a reset pin wired to a variable is modelled.
 
 ### Suggested next increments
 
 1. Run the M1 review of `docs/safe-ld-sos-semantics.md` and close its §10 items.
-2. Model arithmetic/unknown blocks on graphical rung paths, or make the
-   diagnostic an error rather than a dropped path, so a silently weaker model
-   is not possible.
-3. Add a path-count guard to the graphical resolver.
-4. Widen or guard the timer/counter integer arithmetic.
+2. Add a path-count guard to the graphical resolver.
+3. Widen or guard the timer/counter integer arithmetic.
+4. Model arithmetic/unknown blocks on graphical rung paths, so the programs now
+   rejected under item 2 of the previous list can be verified rather than
+   refused.

--- a/docs/roadmap/safe-ld-implementation-plan.md
+++ b/docs/roadmap/safe-ld-implementation-plan.md
@@ -10,7 +10,7 @@
 > `response` property), and — beyond the original Tier-1 scope — user-defined
 > function-block bodies, REAL/analog process variables, and an optional
 > scan-watchdog all now lower to GOTO IR and verify end-to-end (see §10). The
-> suite under `regression/ld/` has grown to 25 CTest cases, plus 10 for the
+> suite under `regression/ld/` has grown to 26 CTest cases, plus 10 for the
 > `ld-verify` runner, and CI now actually runs them. All four curated
 > benchmarks have validated verdicts and are wired as regression tests. The WP1
 > SOS specification exists as `docs/safe-ld-sos-semantics.md`; its independent
@@ -572,7 +572,7 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 | T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280); extended with user-FB-body and REAL/analog parsing (#5620) |
 | T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | boolean subset + timers/counters/`response` all lower and verify (#5289); ST→`codet` FB-body translator + numeric↔Boolean coercion (#5620); graphical resolver now models FB blocks, edge contacts, parallel-path OR and network feedback; all four benchmark verdicts validated (§10) |
 | T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired + JSON report (#5289); `ld-verify` runner implemented, driving `esbmc` (#5294); `--ld-fault-injection`, `--ld-sound-mode`, `--ld-scan-watchdog`/`--ld-scan-budget` driver flags added (#5294, #5620) |
-| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 25 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
+| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 26 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
 
 **Success criteria (WP2):**
 - **Correctness:** ≥95% of benchmark programs translated to GOTO IR with semantic
@@ -790,7 +790,7 @@ prose in §3 is not mistaken for delivered functionality.
   pinned as `esd_manual_reset_fail`, with the corrected program as
   `emergency_shutdown_safe`. The conveyor's failure was a `response` property
   whose bound ignored a free `Stop_Button` input, plus the unparsed preset.
-- **Regression suite `regression/ld/`** now holds **25 CTest cases** (guarded by
+- **Regression suite `regression/ld/`** now holds **26 CTest cases** (guarded by
   `ENABLE_LD_FRONTEND`, with the `benchmarks/` dataset excluded from CTest —
   `regression/CMakeLists.txt`), covering all five property kinds plus
   fault-injection, user-FB, watchdog, REAL-arithmetic, and the `stairs_light` /
@@ -818,7 +818,7 @@ requests as well as pushes touching `src/ld-frontend/`, `tools/ld-verify/`,
 `regression/ld/` or `unit/ld-frontend/`:
 
 - `regression-ld` builds with `BUILD_TESTING=On` / `ENABLE_REGRESSION=On` and
-  runs `regression/ld/` (25 cases), the `ld-verify` runner suite (10 cases) and
+  runs `regression/ld/` (26 cases), the `ld-verify` runner suite (10 cases) and
   the three LD unit binaries.
 - `build-linux-amd64` builds the release binary, smoke-tests that it advertises
   `--ld-props`, and publishes it as an artifact.
@@ -838,9 +838,18 @@ is the only gate on the front-end.
 - **Timer/counter integer width.** The arithmetic uses `int_type()` with no
   overflow guard; very long-running counters could wrap. Not exercised by the
   current bounded tests.
-- **Graphical path enumeration is exponential.** The resolver enumerates every
-  simple rail-to-sink path; a vendor export with many parallel branches would
-  blow up. No path-count guard yet.
+- **Graphical path enumeration is exponential — now bounded, but not fixed.**
+  The resolver enumerates every simple rail-to-sink path, so cost grows as 2^N
+  in re-convergent parallel branches. It is now bounded at 100000 search steps
+  (~5000x the widest benchmark network, which peaks at 20), and exceeding the
+  bound is a hard error rather than a truncated path set. **The bound only makes
+  the blowup diagnosable; the algorithm is still exponential.** Measured: a
+  network of 18 fully-connected 2-wide stages — just 36 contacts — costs 112 s
+  of GOTO-creation time unguarded, versus 0.15 s to reject
+  (`graphical_path_explosion_fail`). 36 contacts is far below the 1000 rungs the
+  WP2 performance criterion targets at <5 s, so **that criterion is not merely
+  unmeasured, it is unreachable for re-convergent graphical networks** until the
+  enumeration is replaced by per-node power-flow accumulation, which is linear.
 - **Arithmetic and unknown blocks on a rung path** are still not modelled —
   only timers and counters are resolved on graphical paths — but they are now
   a hard `UnsupportedConstruct(name, tier=2)` error rather than a dropped path,
@@ -856,8 +865,10 @@ is the only gate on the front-end.
 ### Suggested next increments
 
 1. Run the M1 review of `docs/safe-ld-sos-semantics.md` and close its §10 items.
-2. Add a path-count guard to the graphical resolver.
+2. Replace rail-to-sink path enumeration with per-node power-flow accumulation.
+   The step bound now rejects wide networks instead of hanging, but a linear
+   resolver would verify them instead — and is what the WP2 <5 s / 1000-rung
+   criterion requires.
 3. Widen or guard the timer/counter integer arithmetic.
-4. Model arithmetic/unknown blocks on graphical rung paths, so the programs now
-   rejected under item 2 of the previous list can be verified rather than
-   refused.
+4. Model arithmetic/unknown blocks on graphical rung paths, so the programs
+   rejected as `UnsupportedConstruct` can be verified rather than refused.

--- a/docs/roadmap/safe-ld-implementation-plan.md
+++ b/docs/roadmap/safe-ld-implementation-plan.md
@@ -10,7 +10,7 @@
 > `response` property), and — beyond the original Tier-1 scope — user-defined
 > function-block bodies, REAL/analog process variables, and an optional
 > scan-watchdog all now lower to GOTO IR and verify end-to-end (see §10). The
-> suite under `regression/ld/` has grown to 26 CTest cases, plus 10 for the
+> suite under `regression/ld/` has grown to 28 CTest cases, plus 10 for the
 > `ld-verify` runner, and CI now actually runs them. All four curated
 > benchmarks have validated verdicts and are wired as regression tests. The WP1
 > SOS specification exists as `docs/safe-ld-sos-semantics.md`; its independent
@@ -572,7 +572,7 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 | T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280); extended with user-FB-body and REAL/analog parsing (#5620) |
 | T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | boolean subset + timers/counters/`response` all lower and verify (#5289); ST→`codet` FB-body translator + numeric↔Boolean coercion (#5620); graphical resolver now models FB blocks, edge contacts, parallel-path OR and network feedback; all four benchmark verdicts validated (§10) |
 | T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired + JSON report (#5289); `ld-verify` runner implemented, driving `esbmc` (#5294); `--ld-fault-injection`, `--ld-sound-mode`, `--ld-scan-watchdog`/`--ld-scan-budget` driver flags added (#5294, #5620) |
-| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 26 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
+| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 28 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
 
 **Success criteria (WP2):**
 - **Correctness:** ≥95% of benchmark programs translated to GOTO IR with semantic
@@ -790,7 +790,7 @@ prose in §3 is not mistaken for delivered functionality.
   pinned as `esd_manual_reset_fail`, with the corrected program as
   `emergency_shutdown_safe`. The conveyor's failure was a `response` property
   whose bound ignored a free `Stop_Button` input, plus the unparsed preset.
-- **Regression suite `regression/ld/`** now holds **26 CTest cases** (guarded by
+- **Regression suite `regression/ld/`** now holds **28 CTest cases** (guarded by
   `ENABLE_LD_FRONTEND`, with the `benchmarks/` dataset excluded from CTest —
   `regression/CMakeLists.txt`), covering all five property kinds plus
   fault-injection, user-FB, watchdog, REAL-arithmetic, and the `stairs_light` /
@@ -818,7 +818,7 @@ requests as well as pushes touching `src/ld-frontend/`, `tools/ld-verify/`,
 `regression/ld/` or `unit/ld-frontend/`:
 
 - `regression-ld` builds with `BUILD_TESTING=On` / `ENABLE_REGRESSION=On` and
-  runs `regression/ld/` (26 cases), the `ld-verify` runner suite (10 cases) and
+  runs `regression/ld/` (28 cases), the `ld-verify` runner suite (10 cases) and
   the three LD unit binaries.
 - `build-linux-amd64` builds the release binary, smoke-tests that it advertises
   `--ld-props`, and publishes it as an artifact.
@@ -835,9 +835,16 @@ is the only gate on the front-end.
   reset dominance, and the scope of the feedback rule).
 - **WRITE_OUTPUTS** is not modelled as a distinct step; output coils are plain
   variable assignments (sufficient for the current property checks).
-- **Timer/counter integer width.** The arithmetic uses `int_type()` with no
-  overflow guard; very long-running counters could wrap. Not exercised by the
-  current bounded tests.
+- **Timer/counter integer width — now saturating.** CTU/CTD saturate CV at the
+  configured integer type's bound and TON bounds ET by PT, so neither wraps.
+  Before this, `CV + 1` on a counter at INTmax was reachable undefined behaviour
+  (`--overflow-check` reports `arithmetic overflow on add`) and the wrap dropped
+  Q back to false, losing violations; `counter_saturate_at_max` pins it, and
+  `counter_counts_fail` pins that the bound does not stop the counter counting.
+  Whether IEC saturates CV at the type bound or at PV is recorded as open item 4
+  for the M1 review in `docs/safe-ld-sos-semantics.md` §10 — the two agree on Q
+  and differ only above the preset, and the type bound is the over-approximating
+  (so non-hiding) choice.
 - **Graphical path enumeration is exponential — now bounded, but not fixed.**
   The resolver enumerates every simple rail-to-sink path, so cost grows as 2^N
   in re-convergent parallel branches. It is now bounded at 100000 search steps
@@ -869,6 +876,5 @@ is the only gate on the front-end.
    The step bound now rejects wide networks instead of hanging, but a linear
    resolver would verify them instead — and is what the WP2 <5 s / 1000-rung
    criterion requires.
-3. Widen or guard the timer/counter integer arithmetic.
-4. Model arithmetic/unknown blocks on graphical rung paths, so the programs
+3. Model arithmetic/unknown blocks on graphical rung paths, so the programs
    rejected as `UnsupportedConstruct` can be verified rather than refused.

--- a/docs/roadmap/safe-ld-implementation-plan.md
+++ b/docs/roadmap/safe-ld-implementation-plan.md
@@ -10,7 +10,7 @@
 > `response` property), and — beyond the original Tier-1 scope — user-defined
 > function-block bodies, REAL/analog process variables, and an optional
 > scan-watchdog all now lower to GOTO IR and verify end-to-end (see §10). The
-> suite under `regression/ld/` has grown to 28 CTest cases, plus 10 for the
+> suite under `regression/ld/` has grown to 33 CTest cases, plus 10 for the
 > `ld-verify` runner, and CI now actually runs them. All four curated
 > benchmarks have validated verdicts and are wired as regression tests. The WP1
 > SOS specification exists as `docs/safe-ld-sos-semantics.md`; its independent
@@ -572,7 +572,7 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 | T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280); extended with user-FB-body and REAL/analog parsing (#5620) |
 | T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | boolean subset + timers/counters/`response` all lower and verify (#5289); ST→`codet` FB-body translator + numeric↔Boolean coercion (#5620); graphical resolver now models FB blocks, edge contacts, parallel-path OR and network feedback; all four benchmark verdicts validated (§10) |
 | T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired + JSON report (#5289); `ld-verify` runner implemented, driving `esbmc` (#5294); `--ld-fault-injection`, `--ld-sound-mode`, `--ld-scan-watchdog`/`--ld-scan-budget` driver flags added (#5294, #5620) |
-| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 28 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
+| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 33 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
 
 **Success criteria (WP2):**
 - **Correctness:** ≥95% of benchmark programs translated to GOTO IR with semantic
@@ -790,7 +790,7 @@ prose in §3 is not mistaken for delivered functionality.
   pinned as `esd_manual_reset_fail`, with the corrected program as
   `emergency_shutdown_safe`. The conveyor's failure was a `response` property
   whose bound ignored a free `Stop_Button` input, plus the unparsed preset.
-- **Regression suite `regression/ld/`** now holds **28 CTest cases** (guarded by
+- **Regression suite `regression/ld/`** now holds **33 CTest cases** (guarded by
   `ENABLE_LD_FRONTEND`, with the `benchmarks/` dataset excluded from CTest —
   `regression/CMakeLists.txt`), covering all five property kinds plus
   fault-injection, user-FB, watchdog, REAL-arithmetic, and the `stairs_light` /
@@ -818,7 +818,7 @@ requests as well as pushes touching `src/ld-frontend/`, `tools/ld-verify/`,
 `regression/ld/` or `unit/ld-frontend/`:
 
 - `regression-ld` builds with `BUILD_TESTING=On` / `ENABLE_REGRESSION=On` and
-  runs `regression/ld/` (28 cases), the `ld-verify` runner suite (10 cases) and
+  runs `regression/ld/` (33 cases), the `ld-verify` runner suite (10 cases) and
   the three LD unit binaries.
 - `build-linux-amd64` builds the release binary, smoke-tests that it advertises
   `--ld-props`, and publishes it as an artifact.
@@ -868,6 +868,17 @@ is the only gate on the front-end.
   silently vanished (`graphical_unsupported_block_fail` pins this).
 - **Counter reset from a contact chain** is diagnosed and left unconnected;
   only a reset pin wired to a variable is modelled.
+- **Non-numeric presets used to terminate the process.** `literal_to_ticks`
+  converted with `std::stoll` and relied on catching `std::invalid_argument`, but
+  the catch did not fire: a block data pin wired to a named variable via
+  `<inVariable>`, or an unparsable `<initialValue>`, aborted ESBMC with an
+  uncaught exception. Both of the callers' fallback paths — the identifier
+  reference in `resolve_data_pin` and the "unrecognised initial value" warning in
+  `parse_var_decl` — were therefore unreachable. It now validates with `strtoll`
+  and errno instead of converting and catching; `ld_preset_named_pin_safe` and
+  `graphical_timer_path_fail` pin the two paths. Why the handler was skipped is
+  not established, so the same convert-and-catch pattern elsewhere in ESBMC
+  (~20 `std::sto*` call sites, several on user input) should not be assumed safe.
 
 ### Validation beyond the regression suite
 
@@ -892,10 +903,27 @@ python3 scripts/ld_resolver_oracle.py 30 4 sp        # series-parallel
 python3 scripts/ld_resolver_oracle.py 20 3 dag 4 3   # re-convergent DAG
 ```
 
-It does not yet cover function blocks on a rung path, edge contacts, feedback
-variables, or Set/Reset coils — those are still covered only by `stairs_light`
-and the driver tests, and extending the oracle to them is a prerequisite for
-trusting a resolver rewrite.
+The oracle cannot be extended to stateful constructs, and this is a property of
+the property language rather than an omission: the edge/feedback shadow update is
+emitted *before* the scan-boundary assertion, so a previous-scan value is not
+observable where properties are checked (`__edge_prev_a == a` there), and the
+expression grammar has no temporal operators. So `q <=> f(inputs, prev)` is not
+expressible.
+
+Stateful constructs are therefore pinned by **discriminating reachability
+tests** instead: a state that is reachable under the intended semantics and
+provably unreachable under the plausible wrong one. `edge_rising_fail` /
+`edge_falling_fail` assert that `a && !q` / `!a && q` are reachable, and
+`edge_level_safe` proves both unreachable for a plain contact — so a resolver
+that ignored the `edge` attribute again (as one did before #6378) flips all
+three. `graphical_timer_path_fail` does the same for a timer on a graphical rung
+path, which the enumerating resolver handles by cutting the path at the block and
+resuming from its Q pin.
+
+Still thin: Set/Reset coils and multi-coil networks are covered only inside the
+whole-program benchmarks (`esd`, `stairs_light`, `water_control`), and the
+textual-`<rung>` tests (`counter_*`, `function_blocks_*`, `userfb_*`) bypass the
+graphical resolver entirely, so they are not cover for it.
 
 ### Suggested next increments
 

--- a/docs/roadmap/safe-ld-implementation-plan.md
+++ b/docs/roadmap/safe-ld-implementation-plan.md
@@ -10,7 +10,7 @@
 > `response` property), and — beyond the original Tier-1 scope — user-defined
 > function-block bodies, REAL/analog process variables, and an optional
 > scan-watchdog all now lower to GOTO IR and verify end-to-end (see §10). The
-> suite under `regression/ld/` has grown to 36 CTest cases, plus 10 for the
+> suite under `regression/ld/` has grown to 37 CTest cases, plus 10 for the
 > `ld-verify` runner, and CI now actually runs them. All four curated
 > benchmarks have validated verdicts and are wired as regression tests. The WP1
 > SOS specification exists as `docs/safe-ld-sos-semantics.md`; its independent
@@ -572,7 +572,7 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 | T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280); extended with user-FB-body and REAL/analog parsing (#5620) |
 | T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | boolean subset + timers/counters/`response` all lower and verify (#5289); ST→`codet` FB-body translator + numeric↔Boolean coercion (#5620); graphical resolver now models FB blocks, edge contacts, parallel-path OR and network feedback; all four benchmark verdicts validated (§10) |
 | T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired + JSON report (#5289); `ld-verify` runner implemented, driving `esbmc` (#5294); `--ld-fault-injection`, `--ld-sound-mode`, `--ld-scan-watchdog`/`--ld-scan-budget` driver flags added (#5294, #5620) |
-| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 36 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
+| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 37 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
 
 **Success criteria (WP2):**
 - **Correctness:** ≥95% of benchmark programs translated to GOTO IR with semantic
@@ -790,7 +790,7 @@ prose in §3 is not mistaken for delivered functionality.
   pinned as `esd_manual_reset_fail`, with the corrected program as
   `emergency_shutdown_safe`. The conveyor's failure was a `response` property
   whose bound ignored a free `Stop_Button` input, plus the unparsed preset.
-- **Regression suite `regression/ld/`** now holds **36 CTest cases** (guarded by
+- **Regression suite `regression/ld/`** now holds **37 CTest cases** (guarded by
   `ENABLE_LD_FRONTEND`, with the `benchmarks/` dataset excluded from CTest —
   `regression/CMakeLists.txt`), covering all five property kinds plus
   fault-injection, user-FB, watchdog, REAL-arithmetic, and the `stairs_light` /
@@ -818,7 +818,7 @@ requests as well as pushes touching `src/ld-frontend/`, `tools/ld-verify/`,
 `regression/ld/` or `unit/ld-frontend/`:
 
 - `regression-ld` builds with `BUILD_TESTING=On` / `ENABLE_REGRESSION=On` and
-  runs `regression/ld/` (36 cases), the `ld-verify` runner suite (10 cases) and
+  runs `regression/ld/` (37 cases), the `ld-verify` runner suite (10 cases) and
   the three LD unit binaries.
 - `build-linux-amd64` builds the release binary, smoke-tests that it advertises
   `--ld-props`, and publishes it as an artifact.
@@ -929,10 +929,21 @@ passing trivially; `graphical_multi_coil_safe` gives two coils different power
 flows from one shared prefix, so a resolver handing both the same flow fails one
 of the two invariants.
 
+`graphical_feedback_snapshot_fail` closes the last one, the entry-snapshot rule
+(§6.3 / IEC 61131-3 §4.1.3): `m` is written by the first rung and read by the
+second, and the GOTO shows `m__prev = m` emitted before any rung, so the reader
+sees the entry value and the scan in which `a` rises leaves `q` off. Reading `m`
+immediately would make `q` track `a` and the state unreachable.
+
 Note the textual-`<rung>` tests (`counter_*`, `function_blocks_*`, `userfb_*`)
-bypass the graphical resolver entirely and are not cover for it. What remains
-uncovered for the resolver is the feedback entry-snapshot rule (§6.3), exercised
-only by `stairs_light`.
+bypass the graphical resolver entirely and are not cover for it.
+
+**Together the oracle and these tests are the intended safety net for replacing
+the resolver** (next increment 2): 101 generated programs for the combinational
+algebra, plus one discriminating test per stateful construct — edge rising and
+falling with a level complement, a timer on a rung path, set-coil latching, sink
+emission order, multi-coil sub-network sharing, and the feedback snapshot — plus
+the undriven-sink and unsupported-block rejections and the enumeration bound.
 
 ### Suggested next increments
 

--- a/docs/roadmap/safe-ld-implementation-plan.md
+++ b/docs/roadmap/safe-ld-implementation-plan.md
@@ -10,7 +10,7 @@
 > `response` property), and — beyond the original Tier-1 scope — user-defined
 > function-block bodies, REAL/analog process variables, and an optional
 > scan-watchdog all now lower to GOTO IR and verify end-to-end (see §10). The
-> suite under `regression/ld/` has grown to 33 CTest cases, plus 10 for the
+> suite under `regression/ld/` has grown to 36 CTest cases, plus 10 for the
 > `ld-verify` runner, and CI now actually runs them. All four curated
 > benchmarks have validated verdicts and are wired as regression tests. The WP1
 > SOS specification exists as `docs/safe-ld-sos-semantics.md`; its independent
@@ -572,7 +572,7 @@ all 20 programs pass semantic review; spec reviewed against IEC 61508 §7.
 | T2.1 Parser & Semantic Analyser | PLCopen XML parser; AST; type checker; SOS consistency check | M3 (Month 6): parser handles all WP1 SOS constructs | skeleton landed (#5280); extended with user-FB-body and REAL/analog parsing (#5620) |
 | T2.2 GOTO IR Generator & Property Encoder | LdIR; `ld_converter` (irep2); YAML parser; property encoder (`code_assertt`) | M4 (Month 9): IR generator correct on all benchmark programs | boolean subset + timers/counters/`response` all lower and verify (#5289); ST→`codet` FB-body translator + numeric↔Boolean coercion (#5620); graphical resolver now models FB blocks, edge contacts, parallel-path OR and network feedback; all four benchmark verdicts validated (§10) |
 | T2.3 ESBMC Integration & ld-verify | `ld_languaget`; CMake wiring; ld-verify CLI; JSON report | M5 (Month 12): end-to-end pipeline ready | `--ld-props` wired + JSON report (#5289); `ld-verify` runner implemented, driving `esbmc` (#5294); `--ld-fault-injection`, `--ld-sound-mode`, `--ld-scan-watchdog`/`--ld-scan-budget` driver flags added (#5294, #5620) |
-| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 33 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
+| T2.4 Test Suite (TDD, >90% coverage) | Unit tests per component; integration tests; fault-injection tests | tracked per task; coverage measured with gcov | 3 unit suites + 36 driver regression tests (incl. fault-injection, user-FB, watchdog, REAL arithmetic) + 10 `ld-verify` runner tests, all run by CI; line-coverage target not yet measured |
 
 **Success criteria (WP2):**
 - **Correctness:** ≥95% of benchmark programs translated to GOTO IR with semantic
@@ -790,7 +790,7 @@ prose in §3 is not mistaken for delivered functionality.
   pinned as `esd_manual_reset_fail`, with the corrected program as
   `emergency_shutdown_safe`. The conveyor's failure was a `response` property
   whose bound ignored a free `Stop_Button` input, plus the unparsed preset.
-- **Regression suite `regression/ld/`** now holds **33 CTest cases** (guarded by
+- **Regression suite `regression/ld/`** now holds **36 CTest cases** (guarded by
   `ENABLE_LD_FRONTEND`, with the `benchmarks/` dataset excluded from CTest —
   `regression/CMakeLists.txt`), covering all five property kinds plus
   fault-injection, user-FB, watchdog, REAL-arithmetic, and the `stairs_light` /
@@ -818,7 +818,7 @@ requests as well as pushes touching `src/ld-frontend/`, `tools/ld-verify/`,
 `regression/ld/` or `unit/ld-frontend/`:
 
 - `regression-ld` builds with `BUILD_TESTING=On` / `ENABLE_REGRESSION=On` and
-  runs `regression/ld/` (33 cases), the `ld-verify` runner suite (10 cases) and
+  runs `regression/ld/` (36 cases), the `ld-verify` runner suite (10 cases) and
   the three LD unit binaries.
 - `build-linux-amd64` builds the release binary, smoke-tests that it advertises
   `--ld-props`, and publishes it as an artifact.
@@ -920,10 +920,19 @@ three. `graphical_timer_path_fail` does the same for a timer on a graphical rung
 path, which the enumerating resolver handles by cutting the path at the block and
 resuming from its Q pin.
 
-Still thin: Set/Reset coils and multi-coil networks are covered only inside the
-whole-program benchmarks (`esd`, `stairs_light`, `water_control`), and the
-textual-`<rung>` tests (`counter_*`, `function_blocks_*`, `userfb_*`) bypass the
-graphical resolver entirely, so they are not cover for it.
+Set/Reset coils and multi-coil networks are pinned the same way:
+`graphical_set_latch_fail` shows a set coil holding on with no path energised (an
+output coil cannot); `graphical_set_reset_order_safe` proves the reset drawn
+below the set wins within a scan, and **reversing the two `rightPowerRail`
+connections flips it to FAILED**, so it pins sink emission order rather than
+passing trivially; `graphical_multi_coil_safe` gives two coils different power
+flows from one shared prefix, so a resolver handing both the same flow fails one
+of the two invariants.
+
+Note the textual-`<rung>` tests (`counter_*`, `function_blocks_*`, `userfb_*`)
+bypass the graphical resolver entirely and are not cover for it. What remains
+uncovered for the resolver is the feedback entry-snapshot rule (§6.3), exercised
+only by `stairs_light`.
 
 ### Suggested next increments
 

--- a/docs/safe-ld-sos-semantics.md
+++ b/docs/safe-ld-sos-semantics.md
@@ -215,14 +215,24 @@ enable pin and `PT`, `ET`, `Q` its preset, elapsed count and output.
 ### 5.2 TON — on-delay
 
 ```
-        IN = tt                                    IN = ff
-  ─────────────────────────────────────    ────────────────────────────  [TON]
-   σ' = σ[ET ↦ σ(ET)+1]                     σ' = σ[ET ↦ 0]
-   σ'' = σ'[Q ↦ (σ'(ET) ≥ σ(PT))]           σ'' = σ'[Q ↦ ff]
+    IN = tt, σ(ET) < σ(PT)              IN = tt, σ(ET) ≥ σ(PT)
+  ─────────────────────────────    ─────────────────────────────  [TON]
+   σ' = σ[ET ↦ σ(ET)+1]             σ' = σ
+
+                    IN = ff
+              ────────────────────────────  [TON-RESET]
+               σ' = σ[ET ↦ 0], σ'' = σ'[Q ↦ ff]
+
+              σ'' = σ'[Q ↦ (σ'(ET) ≥ σ(PT))]   (IN = tt)
 ```
 
 Equivalently `Q := IN ∧ ET ≥ PT`. Conjoining `IN` matters at `PT = 0`, where
 a TON must follow its enable directly rather than latch on.
+
+ET is bounded above by PT (IEC 61131-3 §2.5.2.3.2 gives ET the range 0..PT), so
+the count stops once the interval is up. An unbounded ET would rise on every
+scan IN holds and eventually overflow its machine width, which is undefined
+behaviour and wraps ET negative so that Q drops back to ff.
 
 ### 5.3 TOF — off-delay
 
@@ -258,14 +268,14 @@ is retriggerable only after its pulse has completed.
 ### 5.5 CTU / CTD — counters
 
 ```
-   σ(CU) = tt, π(CU) = ff                      σ(R) = tt
-  ──────────────────────────  [CTU]      ───────────────────────  [CTU-RESET]
-   σ' = σ[CV ↦ σ(CV)+1]                    σ' = σ[CV ↦ 0]
+   σ(CU) = tt, π(CU) = ff, σ(CV) < INTmax        σ(R) = tt
+  ─────────────────────────────────────  [CTU]  ───────────────────  [CTU-RESET]
+   σ' = σ[CV ↦ σ(CV)+1]                          σ' = σ[CV ↦ 0]
 
                     σ'' = σ'[Q ↦ (σ'(CV) ≥ σ(PV))]
 
-   σ(CD) = tt, π(CD) = ff
-  ──────────────────────────  [CTD]      σ'' = σ'[Q ↦ (σ'(CV) ≤ 0)]
+   σ(CD) = tt, π(CD) = ff, σ(CV) > INTmin
+  ─────────────────────────────────────  [CTD]  σ'' = σ'[Q ↦ (σ'(CV) ≤ 0)]
    σ' = σ[CV ↦ σ(CV)−1]
 ```
 
@@ -399,8 +409,11 @@ time or documented as an approximation.
 - **Counter reset from a contact chain.** [CTU-RESET] takes R from a variable.
   A reset pin driven by a contact chain in a graphical body is diagnosed and
   left unconnected rather than silently approximated.
-- **Integer width.** CV and ET are machine integers with no overflow guard; a
-  counter run past its width wraps rather than saturating.
+- **Integer width.** CV and ET are machine integers of the configured width.
+  Both saturate rather than wrap: CV at INTmax/INTmin, ET at PT. Saturating at
+  the type bound rather than at PV over-approximates CV above the preset, which
+  can raise a false alarm but cannot hide a violation; see the open item in §10
+  on which bound IEC intends.
 - **Non-timer, non-counter blocks on a rung path.** A path through an
   arithmetic or unknown block is diagnosed and dropped rather than modelled,
   so a program using one verifies over strictly less behaviour. User-defined
@@ -439,3 +452,8 @@ to raise in it:
 3. §6.3 applies the entry-snapshot rule to all feedback variables of a
    network. IEC 61131-3 §4.1.3 states it for feedback paths specifically;
    confirm the two coincide for LD bodies, or narrow the rule.
+4. §5.5 saturates CV at the integer type's bound. Secondary sources render the
+   normative CTU body with both `CV < PVmax` (the type bound, as here) and
+   `CV < PV` (the preset); confirm which IEC 61131-3 §2.5.2.3.3 specifies. The
+   two agree on Q for every reachable state and differ only in CV's value above
+   the preset, so this changes no verdict that does not read CV directly.

--- a/regression/ld/counter_counts_fail/counter.ld
+++ b/regression/ld/counter_counts_fail/counter.ld
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-07-30"/>
+  <contentHeader name="CounterSaturate"/>
+  <types/><instances/>
+  <pous>
+    <pou name="CounterSaturate" pouType="program">
+      <interface>
+        <inputVars>
+          <variable name="Up"><type><BOOL/></type></variable>
+        </inputVars>
+        <localVars>
+          <variable name="PV"><type><INT/></type><initialValue><simpleValue value="2"/></initialValue></variable>
+          <variable name="CVu"><type><INT/></type><initialValue><simpleValue value="0"/></initialValue></variable>
+        </localVars>
+        <outputVars>
+          <variable name="CUQ"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <rung localId="1"><block typeName="CTU" instanceName="cu1"><variable formalParameter="CU">Up</variable><variable formalParameter="PV">PV</variable><variable formalParameter="Q">CUQ</variable><variable formalParameter="CV">CVu</variable></block></rung>
+        </LD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/counter_counts_fail/props.yaml
+++ b/regression/ld/counter_counts_fail/props.yaml
@@ -1,0 +1,9 @@
+properties:
+
+  # Companion to counter_saturate_at_max: the saturation bound must not stop the
+  # counter from counting at all. Two rising edges reach PV=2, so this invariant
+  # is genuinely violated — a bound computed as 0 would leave it holding.
+  - id: P1
+    kind: invariant
+    expression: "!CUQ"
+    description: "The counter never reaches its preset"

--- a/regression/ld/counter_counts_fail/test.desc
+++ b/regression/ld/counter_counts_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+counter.ld
+--ld-props props.yaml --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/ld/counter_saturate_at_max/counter.ld
+++ b/regression/ld/counter_saturate_at_max/counter.ld
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-07-30"/>
+  <contentHeader name="CounterSaturate"/>
+  <types/><instances/>
+  <pous>
+    <pou name="CounterSaturate" pouType="program">
+      <interface>
+        <inputVars>
+          <variable name="Up"><type><BOOL/></type></variable>
+        </inputVars>
+        <localVars>
+          <variable name="PV"><type><INT/></type><initialValue><simpleValue value="3"/></initialValue></variable>
+          <variable name="CVu"><type><INT/></type><initialValue><simpleValue value="2147483647"/></initialValue></variable>
+        </localVars>
+        <outputVars>
+          <variable name="CUQ"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <rung localId="1"><block typeName="CTU" instanceName="cu1"><variable formalParameter="CU">Up</variable><variable formalParameter="PV">PV</variable><variable formalParameter="Q">CUQ</variable><variable formalParameter="CV">CVu</variable></block></rung>
+        </LD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/counter_saturate_at_max/props.yaml
+++ b/regression/ld/counter_saturate_at_max/props.yaml
@@ -1,0 +1,10 @@
+properties:
+
+  # CV starts at the INT maximum, as a retained counter value would after a long
+  # run. An unsaturated CV+1 overflows on the first rising edge, which is UB and
+  # wraps CV negative so that Q drops back to false. With saturation neither the
+  # overflow VCC nor P1 is violated, so no counterexample is found.
+  - id: P1
+    kind: invariant
+    expression: "CUQ"
+    description: "A counter at its maximum stays at or above any preset"

--- a/regression/ld/counter_saturate_at_max/test.desc
+++ b/regression/ld/counter_saturate_at_max/test.desc
@@ -1,0 +1,4 @@
+CORE
+counter.ld
+--ld-props props.yaml --incremental-bmc --overflow-check
+^VERIFICATION UNKNOWN$

--- a/regression/ld/edge_falling_fail/edge.ld
+++ b/regression/ld/edge_falling_fail/edge.ld
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="edge" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="edge"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="edge" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="40">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false" edge="falling">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <coil localId="4" width="20" height="20" negated="false">
+          <position x="200" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="40">
+          <position x="250" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="edge"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/edge_falling_fail/props.yaml
+++ b/regression/ld/edge_falling_fail/props.yaml
@@ -1,0 +1,10 @@
+properties:
+
+  # A falling-edge contact energises the coil on the scan its operand goes low,
+  # so the coil is on while the operand reads low. Unreachable under level
+  # sensing (edge_level_safe).
+  - id: P1
+    kind: reachability
+    expression: "!a && q"
+    description: "Coil energised while its operand reads low"
+    justification: "Only transition sensing can energise a coil while its operand is low"

--- a/regression/ld/edge_falling_fail/test.desc
+++ b/regression/ld/edge_falling_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+edge.ld
+--ld-props props.yaml --incremental-bmc --unwind 4
+^VERIFICATION FAILED$

--- a/regression/ld/edge_level_safe/edge.ld
+++ b/regression/ld/edge_level_safe/edge.ld
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="edge" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="edge"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="edge" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="40">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <coil localId="4" width="20" height="20" negated="false">
+          <position x="200" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="40">
+          <position x="250" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="edge"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/edge_level_safe/props.yaml
+++ b/regression/ld/edge_level_safe/props.yaml
@@ -1,0 +1,17 @@
+properties:
+
+  # The complement of edge_rising_fail / edge_falling_fail: with a plain contact
+  # the coil tracks its operand within the scan, so both transition-only states
+  # are provably unreachable. Together the three tests pin the distinction
+  # between level and transition sensing rather than just one side of it.
+  - id: P1
+    kind: reachability
+    expression: "a && !q"
+    description: "Operand held with the coil dropped is unreachable under level sensing"
+    justification: "Complement of edge_rising_fail; a plain contact drives the coil every scan"
+
+  - id: P2
+    kind: reachability
+    expression: "!a && q"
+    description: "Coil on with the operand low is unreachable under level sensing"
+    justification: "Complement of edge_falling_fail; a plain contact drives the coil every scan"

--- a/regression/ld/edge_level_safe/test.desc
+++ b/regression/ld/edge_level_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+edge.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/edge_rising_fail/edge.ld
+++ b/regression/ld/edge_rising_fail/edge.ld
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="edge" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="edge"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="edge" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="40">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false" edge="rising">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <coil localId="4" width="20" height="20" negated="false">
+          <position x="200" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="40">
+          <position x="250" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="edge"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/edge_rising_fail/props.yaml
+++ b/regression/ld/edge_rising_fail/props.yaml
@@ -1,0 +1,11 @@
+properties:
+
+  # A rising-edge contact energises the coil only on the scan its operand goes
+  # high, so the operand can still be held while the coil has already dropped.
+  # A resolver that ignored the edge attribute would make q track a, and this
+  # state would be unreachable (edge_level_safe proves exactly that).
+  - id: P1
+    kind: reachability
+    expression: "a && !q"
+    description: "Operand still held while the coil has dropped"
+    justification: "Only transition sensing can leave the coil off while its operand is high"

--- a/regression/ld/edge_rising_fail/test.desc
+++ b/regression/ld/edge_rising_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+edge.ld
+--ld-props props.yaml --incremental-bmc --unwind 4
+^VERIFICATION FAILED$

--- a/regression/ld/graphical_contact_driven_safe/alarm.ld
+++ b/regression/ld/graphical_contact_driven_safe/alarm.ld
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="contact_driven">
+    <coordinateInfo>
+      <ld>
+        <scaling x="10" y="10"/>
+      </ld>
+    </coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="alarm_control" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="level_high" address="%IX0.0">
+              <type>
+                <BOOL/>
+              </type>
+            </variable>
+            <variable name="inhibit" address="%IX0.1">
+              <type>
+                <BOOL/>
+              </type>
+            </variable>
+            <variable name="alarm" address="%QX0.0">
+              <type>
+                <BOOL/>
+              </type>
+            </variable>
+          </localVars>
+        </interface>
+        <body>
+          <LD>
+            <leftPowerRail localId="1" width="10" height="40">
+              <position x="30" y="20"/>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="20"/>
+              </connectionPointOut>
+            </leftPowerRail>
+            <rightPowerRail localId="2" width="10" height="40">
+              <position x="410" y="20"/>
+              <connectionPointIn>
+                <relPosition x="0" y="20"/>
+                <connection refLocalId="6"/>
+              </connectionPointIn>
+            </rightPowerRail>
+            <contact localId="3" width="20" height="20" negated="false">
+              <position x="90" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1"/>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="20" y="10"/>
+              </connectionPointOut>
+              <variable>level_high</variable>
+            </contact>
+            <contact localId="4" width="20" height="20" negated="true">
+              <position x="180" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="3"/>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="20" y="10"/>
+              </connectionPointOut>
+              <variable>inhibit</variable>
+            </contact>
+            <coil localId="6" width="20" height="20" negated="false">
+              <position x="330" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="4"/>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="20" y="10"/>
+              </connectionPointOut>
+              <variable>alarm</variable>
+            </coil>
+          </LD>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances>
+    <configurations>
+      <configuration name="config">
+        <resource name="res">
+          <task name="main" interval="T#10ms" priority="0">
+            <pouInstance name="inst" typeName="alarm_control"/>
+          </task>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+</project>

--- a/regression/ld/graphical_contact_driven_safe/props.yaml
+++ b/regression/ld/graphical_contact_driven_safe/props.yaml
@@ -1,0 +1,10 @@
+properties:
+
+  # The coil is driven by a modellable contact chain, so the resolver must emit
+  # the rung rather than reject it. P1 pins the coil in both directions, so an
+  # undriven coil (which holds its initial false) violates the second conjunct
+  # instead of passing vacuously.
+  - id: P1
+    kind: invariant
+    expression: "(!alarm || (level_high && !inhibit)) && (alarm || !level_high || inhibit)"
+    description: "Alarm is energised exactly when the level is high and not inhibited"

--- a/regression/ld/graphical_contact_driven_safe/test.desc
+++ b/regression/ld/graphical_contact_driven_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+alarm.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/graphical_feedback_snapshot_fail/fb.ld
+++ b/regression/ld/graphical_feedback_snapshot_fail/fb.ld
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="feedback"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="feedback" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="m"><type><BOOL/></type></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="80">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+          <connectionPointOut><relPosition x="10" y="50"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <coil localId="5" width="20" height="20" negated="false">
+          <position x="140" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>m</variable>
+        </coil>
+        <contact localId="4" width="20" height="20" negated="false">
+          <position x="60" y="50"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>m</variable>
+        </contact>
+        <coil localId="6" width="20" height="20" negated="false">
+          <position x="140" y="50"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="80">
+          <position x="220" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="5"/></connectionPointIn>
+          <connectionPointIn><relPosition x="0" y="50"/><connection refLocalId="6"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="feedback"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/graphical_feedback_snapshot_fail/props.yaml
+++ b/regression/ld/graphical_feedback_snapshot_fail/props.yaml
@@ -1,0 +1,12 @@
+properties:
+
+  # m is written by the first rung and read by the second, so IEC 61131-3 §4.1.3
+  # has the read take m's value at network entry, not the value the first rung
+  # just wrote. The scan in which a first goes high therefore sets m but leaves q
+  # off. Reading m immediately instead would make q track a and this state
+  # unreachable.
+  - id: P1
+    kind: reachability
+    expression: "m && !q"
+    description: "Intermediate coil set while the coil reading it is still off"
+    justification: "Only an entry snapshot of a feedback variable can delay the read by one scan"

--- a/regression/ld/graphical_feedback_snapshot_fail/test.desc
+++ b/regression/ld/graphical_feedback_snapshot_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+fb.ld
+--ld-props props.yaml --incremental-bmc --unwind 4
+^VERIFICATION FAILED$

--- a/regression/ld/graphical_multi_coil_safe/multi.ld
+++ b/regression/ld/graphical_multi_coil_safe/multi.ld
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="multi"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="multi" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="b" address="%IX0.1"><type><BOOL/></type></variable>
+        <variable name="q1" address="%QX0.0"><type><BOOL/></type></variable>
+        <variable name="q2" address="%QX0.1"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="80">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <contact localId="4" width="20" height="20" negated="false">
+          <position x="110" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>b</variable>
+        </contact>
+        <coil localId="5" width="20" height="20" negated="false">
+          <position x="170" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q1</variable>
+        </coil>
+        <coil localId="6" width="20" height="20" negated="false">
+          <position x="170" y="50"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q2</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="80">
+          <position x="240" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="5"/></connectionPointIn>
+          <connectionPointIn><relPosition x="0" y="50"/><connection refLocalId="6"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="multi"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/graphical_multi_coil_safe/props.yaml
+++ b/regression/ld/graphical_multi_coil_safe/props.yaml
@@ -1,0 +1,15 @@
+properties:
+
+  # Two coils share the contact on a, but q1 sits behind a further contact on b.
+  # Each coil must get its own power flow from the shared node rather than both
+  # taking the longer or the shorter one. Both implications are asserted, so a
+  # coil left undriven fails rather than passing vacuously.
+  - id: P1
+    kind: invariant
+    expression: "(!q1 || (a && b)) && (q1 || !a || !b)"
+    description: "The far coil follows the whole chain"
+
+  - id: P2
+    kind: invariant
+    expression: "(!q2 || a) && (q2 || !a)"
+    description: "The near coil follows only the shared prefix"

--- a/regression/ld/graphical_multi_coil_safe/test.desc
+++ b/regression/ld/graphical_multi_coil_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+multi.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/graphical_path_explosion_fail/props.yaml
+++ b/regression/ld/graphical_path_explosion_fail/props.yaml
@@ -1,0 +1,9 @@
+properties:
+
+  # The network is 18 fully-connected 2-wide stages, so 2**18 simple paths reach
+  # the coil. The resolver must hit its enumeration bound and reject the program
+  # rather than run out of memory or truncate the path set.
+  - id: P1
+    kind: invariant
+    expression: "!out"
+    description: "Coil never energises"

--- a/regression/ld/graphical_path_explosion_fail/test.desc
+++ b/regression/ld/graphical_path_explosion_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+wide.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: graphical LD: network feeding localId \d+ has too many parallel paths to enumerate \(limit 100000 steps\)$
+^ERROR: PARSING ERROR$

--- a/regression/ld/graphical_path_explosion_fail/wide.ld
+++ b/regression/ld/graphical_path_explosion_fail/wide.ld
@@ -1,0 +1,441 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="path_explosion">
+    <coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="wide_net" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="c0_0" address="%IX0.0"><type><BOOL/></type></variable>
+            <variable name="c0_1" address="%IX0.1"><type><BOOL/></type></variable>
+            <variable name="c1_0" address="%IX1.0"><type><BOOL/></type></variable>
+            <variable name="c1_1" address="%IX1.1"><type><BOOL/></type></variable>
+            <variable name="c2_0" address="%IX2.0"><type><BOOL/></type></variable>
+            <variable name="c2_1" address="%IX2.1"><type><BOOL/></type></variable>
+            <variable name="c3_0" address="%IX3.0"><type><BOOL/></type></variable>
+            <variable name="c3_1" address="%IX3.1"><type><BOOL/></type></variable>
+            <variable name="c4_0" address="%IX4.0"><type><BOOL/></type></variable>
+            <variable name="c4_1" address="%IX4.1"><type><BOOL/></type></variable>
+            <variable name="c5_0" address="%IX5.0"><type><BOOL/></type></variable>
+            <variable name="c5_1" address="%IX5.1"><type><BOOL/></type></variable>
+            <variable name="c6_0" address="%IX6.0"><type><BOOL/></type></variable>
+            <variable name="c6_1" address="%IX6.1"><type><BOOL/></type></variable>
+            <variable name="c7_0" address="%IX7.0"><type><BOOL/></type></variable>
+            <variable name="c7_1" address="%IX7.1"><type><BOOL/></type></variable>
+            <variable name="c8_0" address="%IX8.0"><type><BOOL/></type></variable>
+            <variable name="c8_1" address="%IX8.1"><type><BOOL/></type></variable>
+            <variable name="c9_0" address="%IX9.0"><type><BOOL/></type></variable>
+            <variable name="c9_1" address="%IX9.1"><type><BOOL/></type></variable>
+            <variable name="c10_0" address="%IX10.0"><type><BOOL/></type></variable>
+            <variable name="c10_1" address="%IX10.1"><type><BOOL/></type></variable>
+            <variable name="c11_0" address="%IX11.0"><type><BOOL/></type></variable>
+            <variable name="c11_1" address="%IX11.1"><type><BOOL/></type></variable>
+            <variable name="c12_0" address="%IX12.0"><type><BOOL/></type></variable>
+            <variable name="c12_1" address="%IX12.1"><type><BOOL/></type></variable>
+            <variable name="c13_0" address="%IX13.0"><type><BOOL/></type></variable>
+            <variable name="c13_1" address="%IX13.1"><type><BOOL/></type></variable>
+            <variable name="c14_0" address="%IX14.0"><type><BOOL/></type></variable>
+            <variable name="c14_1" address="%IX14.1"><type><BOOL/></type></variable>
+            <variable name="c15_0" address="%IX15.0"><type><BOOL/></type></variable>
+            <variable name="c15_1" address="%IX15.1"><type><BOOL/></type></variable>
+            <variable name="c16_0" address="%IX16.0"><type><BOOL/></type></variable>
+            <variable name="c16_1" address="%IX16.1"><type><BOOL/></type></variable>
+            <variable name="c17_0" address="%IX17.0"><type><BOOL/></type></variable>
+            <variable name="c17_1" address="%IX17.1"><type><BOOL/></type></variable>
+            <variable name="out" address="%QX0.0"><type><BOOL/></type></variable>
+          </localVars>
+        </interface>
+        <body>
+          <LD>
+            <leftPowerRail localId="1" width="10" height="40">
+              <position x="30" y="20"/>
+              <connectionPointOut><relPosition x="10" y="20"/></connectionPointOut>
+            </leftPowerRail>
+            <contact localId="10" width="20" height="20" negated="false">
+              <position x="60" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c0_0</variable>
+            </contact>
+            <contact localId="11" width="20" height="20" negated="false">
+              <position x="60" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="1"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c0_1</variable>
+            </contact>
+            <contact localId="12" width="20" height="20" negated="false">
+              <position x="100" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="10"/>
+                <connection refLocalId="11"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c1_0</variable>
+            </contact>
+            <contact localId="13" width="20" height="20" negated="false">
+              <position x="100" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="10"/>
+                <connection refLocalId="11"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c1_1</variable>
+            </contact>
+            <contact localId="14" width="20" height="20" negated="false">
+              <position x="140" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="12"/>
+                <connection refLocalId="13"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c2_0</variable>
+            </contact>
+            <contact localId="15" width="20" height="20" negated="false">
+              <position x="140" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="12"/>
+                <connection refLocalId="13"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c2_1</variable>
+            </contact>
+            <contact localId="16" width="20" height="20" negated="false">
+              <position x="180" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="14"/>
+                <connection refLocalId="15"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c3_0</variable>
+            </contact>
+            <contact localId="17" width="20" height="20" negated="false">
+              <position x="180" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="14"/>
+                <connection refLocalId="15"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c3_1</variable>
+            </contact>
+            <contact localId="18" width="20" height="20" negated="false">
+              <position x="220" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="16"/>
+                <connection refLocalId="17"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c4_0</variable>
+            </contact>
+            <contact localId="19" width="20" height="20" negated="false">
+              <position x="220" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="16"/>
+                <connection refLocalId="17"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c4_1</variable>
+            </contact>
+            <contact localId="20" width="20" height="20" negated="false">
+              <position x="260" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="18"/>
+                <connection refLocalId="19"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c5_0</variable>
+            </contact>
+            <contact localId="21" width="20" height="20" negated="false">
+              <position x="260" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="18"/>
+                <connection refLocalId="19"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c5_1</variable>
+            </contact>
+            <contact localId="22" width="20" height="20" negated="false">
+              <position x="300" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="20"/>
+                <connection refLocalId="21"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c6_0</variable>
+            </contact>
+            <contact localId="23" width="20" height="20" negated="false">
+              <position x="300" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="20"/>
+                <connection refLocalId="21"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c6_1</variable>
+            </contact>
+            <contact localId="24" width="20" height="20" negated="false">
+              <position x="340" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="22"/>
+                <connection refLocalId="23"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c7_0</variable>
+            </contact>
+            <contact localId="25" width="20" height="20" negated="false">
+              <position x="340" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="22"/>
+                <connection refLocalId="23"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c7_1</variable>
+            </contact>
+            <contact localId="26" width="20" height="20" negated="false">
+              <position x="380" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="24"/>
+                <connection refLocalId="25"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c8_0</variable>
+            </contact>
+            <contact localId="27" width="20" height="20" negated="false">
+              <position x="380" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="24"/>
+                <connection refLocalId="25"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c8_1</variable>
+            </contact>
+            <contact localId="28" width="20" height="20" negated="false">
+              <position x="420" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="26"/>
+                <connection refLocalId="27"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c9_0</variable>
+            </contact>
+            <contact localId="29" width="20" height="20" negated="false">
+              <position x="420" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="26"/>
+                <connection refLocalId="27"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c9_1</variable>
+            </contact>
+            <contact localId="30" width="20" height="20" negated="false">
+              <position x="460" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="28"/>
+                <connection refLocalId="29"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c10_0</variable>
+            </contact>
+            <contact localId="31" width="20" height="20" negated="false">
+              <position x="460" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="28"/>
+                <connection refLocalId="29"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c10_1</variable>
+            </contact>
+            <contact localId="32" width="20" height="20" negated="false">
+              <position x="500" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="30"/>
+                <connection refLocalId="31"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c11_0</variable>
+            </contact>
+            <contact localId="33" width="20" height="20" negated="false">
+              <position x="500" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="30"/>
+                <connection refLocalId="31"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c11_1</variable>
+            </contact>
+            <contact localId="34" width="20" height="20" negated="false">
+              <position x="540" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="32"/>
+                <connection refLocalId="33"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c12_0</variable>
+            </contact>
+            <contact localId="35" width="20" height="20" negated="false">
+              <position x="540" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="32"/>
+                <connection refLocalId="33"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c12_1</variable>
+            </contact>
+            <contact localId="36" width="20" height="20" negated="false">
+              <position x="580" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="34"/>
+                <connection refLocalId="35"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c13_0</variable>
+            </contact>
+            <contact localId="37" width="20" height="20" negated="false">
+              <position x="580" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="34"/>
+                <connection refLocalId="35"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c13_1</variable>
+            </contact>
+            <contact localId="38" width="20" height="20" negated="false">
+              <position x="620" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="36"/>
+                <connection refLocalId="37"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c14_0</variable>
+            </contact>
+            <contact localId="39" width="20" height="20" negated="false">
+              <position x="620" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="36"/>
+                <connection refLocalId="37"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c14_1</variable>
+            </contact>
+            <contact localId="40" width="20" height="20" negated="false">
+              <position x="660" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="38"/>
+                <connection refLocalId="39"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c15_0</variable>
+            </contact>
+            <contact localId="41" width="20" height="20" negated="false">
+              <position x="660" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="38"/>
+                <connection refLocalId="39"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c15_1</variable>
+            </contact>
+            <contact localId="42" width="20" height="20" negated="false">
+              <position x="700" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="40"/>
+                <connection refLocalId="41"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c16_0</variable>
+            </contact>
+            <contact localId="43" width="20" height="20" negated="false">
+              <position x="700" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="40"/>
+                <connection refLocalId="41"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c16_1</variable>
+            </contact>
+            <contact localId="44" width="20" height="20" negated="false">
+              <position x="740" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="42"/>
+                <connection refLocalId="43"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c17_0</variable>
+            </contact>
+            <contact localId="45" width="20" height="20" negated="false">
+              <position x="740" y="40"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="42"/>
+                <connection refLocalId="43"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>c17_1</variable>
+            </contact>
+            <coil localId="46" width="20" height="20" negated="false">
+              <position x="780" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="44"/>
+                <connection refLocalId="45"/>
+              </connectionPointIn>
+              <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+              <variable>out</variable>
+            </coil>
+            <rightPowerRail localId="2" width="10" height="40">
+              <position x="900" y="20"/>
+              <connectionPointIn>
+                <relPosition x="0" y="20"/>
+                <connection refLocalId="46"/>
+              </connectionPointIn>
+            </rightPowerRail>
+          </LD>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances><configurations><configuration name="config"><resource name="res">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="inst" typeName="wide_net"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/graphical_set_latch_fail/latch.ld
+++ b/regression/ld/graphical_set_latch_fail/latch.ld
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="latch"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="latch" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="b" address="%IX0.1"><type><BOOL/></type></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="80">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+          <connectionPointOut><relPosition x="10" y="50"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <contact localId="4" width="20" height="20" negated="false">
+          <position x="60" y="50"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>b</variable>
+        </contact>
+        <coil localId="5" width="20" height="20" negated="false" storage="set">
+          <position x="140" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <coil localId="6" width="20" height="20" negated="false" storage="reset">
+          <position x="140" y="50"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="80">
+          <position x="220" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="5"/></connectionPointIn>
+          <connectionPointIn><relPosition x="0" y="50"/><connection refLocalId="6"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="latch"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/graphical_set_latch_fail/props.yaml
+++ b/regression/ld/graphical_set_latch_fail/props.yaml
@@ -1,0 +1,11 @@
+properties:
+
+  # A set coil latches: once energised it stays on after its path drops. So the
+  # state "set path low but coil still on" is reachable. Under plain output-coil
+  # semantics the coil would track its path and this state would be unreachable
+  # (edge_level_safe proves exactly that shape unreachable for an output coil).
+  - id: P1
+    kind: reachability
+    expression: "!a && !b && q"
+    description: "Coil still latched after both its set and reset paths went low"
+    justification: "Only a retentive set coil can hold the coil on with no path energised"

--- a/regression/ld/graphical_set_latch_fail/test.desc
+++ b/regression/ld/graphical_set_latch_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+latch.ld
+--ld-props props.yaml --incremental-bmc --unwind 4
+^VERIFICATION FAILED$

--- a/regression/ld/graphical_set_reset_order_safe/latch.ld
+++ b/regression/ld/graphical_set_reset_order_safe/latch.ld
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="latch"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="latch" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="b" address="%IX0.1"><type><BOOL/></type></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="80">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+          <connectionPointOut><relPosition x="10" y="50"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <contact localId="4" width="20" height="20" negated="false">
+          <position x="60" y="50"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>b</variable>
+        </contact>
+        <coil localId="5" width="20" height="20" negated="false" storage="set">
+          <position x="140" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <coil localId="6" width="20" height="20" negated="false" storage="reset">
+          <position x="140" y="50"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="80">
+          <position x="220" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="5"/></connectionPointIn>
+          <connectionPointIn><relPosition x="0" y="50"/><connection refLocalId="6"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="latch"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/graphical_set_reset_order_safe/props.yaml
+++ b/regression/ld/graphical_set_reset_order_safe/props.yaml
@@ -1,0 +1,11 @@
+properties:
+
+  # The set coil is drawn above the reset coil, so the resolver must emit it
+  # first and the reset must win within a scan (IEC 61131-3 evaluates a network
+  # in drawing order, and the later assignment stands). A resolver that emitted
+  # sinks in an arbitrary order, or that let two sinks on one variable share a
+  # power-flow accumulator, would break this.
+  - id: P1
+    kind: invariant
+    expression: "!b || !q"
+    description: "The reset path always wins in the scan it is energised"

--- a/regression/ld/graphical_set_reset_order_safe/test.desc
+++ b/regression/ld/graphical_set_reset_order_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+latch.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/graphical_timer_path_fail/props.yaml
+++ b/regression/ld/graphical_timer_path_fail/props.yaml
@@ -1,0 +1,11 @@
+properties:
+
+  # A TON on a graphical rung path must delay the coil: the enable can be held
+  # while the coil is still off, because the timer has not yet reached PT. A
+  # resolver that wired the coil straight to the contact (dropping the block from
+  # the path) would make q track a, and this state would be unreachable.
+  - id: P1
+    kind: reachability
+    expression: "a && !q"
+    description: "Enable held while the on-delay has not yet elapsed"
+    justification: "Only an on-delay timer on the path can hold the coil off while its enable is high"

--- a/regression/ld/graphical_timer_path_fail/test.desc
+++ b/regression/ld/graphical_timer_path_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+timer.ld
+--ld-props props.yaml --incremental-bmc --unwind 4
+^VERIFICATION FAILED$

--- a/regression/ld/graphical_timer_path_fail/timer.ld
+++ b/regression/ld/graphical_timer_path_fail/timer.ld
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="timer_path"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="timer_path" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="PT"><type><INT/></type><initialValue><simpleValue value="2"/></initialValue></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <leftPowerRail localId="1" width="10" height="40">
+          <position x="10" y="10"/>
+          <connectionPointOut><relPosition x="10" y="10"/></connectionPointOut>
+        </leftPowerRail>
+        <contact localId="3" width="20" height="20" negated="false">
+          <position x="60" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="1"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>a</variable>
+        </contact>
+        <inVariable localId="6" width="40" height="20" negated="false">
+          <position x="100" y="50"/>
+          <connectionPointOut><relPosition x="40" y="10"/></connectionPointOut>
+          <expression>PT</expression>
+        </inVariable>
+        <block localId="5" width="60" height="40" typeName="TON" instanceName="T0">
+          <position x="140" y="10"/>
+          <inputVariables>
+            <variable formalParameter="IN">
+              <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="3"/></connectionPointIn>
+            </variable>
+            <variable formalParameter="PT">
+              <connectionPointIn><relPosition x="0" y="30"/><connection refLocalId="6"/></connectionPointIn>
+            </variable>
+          </inputVariables>
+          <inOutVariables/>
+          <outputVariables>
+            <variable formalParameter="Q"><connectionPointOut><relPosition x="60" y="10"/></connectionPointOut></variable>
+          </outputVariables>
+        </block>
+        <coil localId="4" width="20" height="20" negated="false">
+          <position x="240" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="5"/></connectionPointIn>
+          <connectionPointOut><relPosition x="20" y="10"/></connectionPointOut>
+          <variable>q</variable>
+        </coil>
+        <rightPowerRail localId="2" width="10" height="40">
+          <position x="300" y="10"/>
+          <connectionPointIn><relPosition x="0" y="10"/><connection refLocalId="4"/></connectionPointIn>
+        </rightPowerRail>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="timer_path"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/graphical_unsupported_block_fail/alarm.ld
+++ b/regression/ld/graphical_unsupported_block_fail/alarm.ld
@@ -1,0 +1,118 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="unsupported_block">
+    <coordinateInfo>
+      <ld>
+        <scaling x="10" y="10"/>
+      </ld>
+    </coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="alarm_control" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="level" address="%IW0.0">
+              <type>
+                <INT/>
+              </type>
+            </variable>
+            <variable name="limit">
+              <type>
+                <INT/>
+              </type>
+              <initialValue>
+                <simpleValue value="5"/>
+              </initialValue>
+            </variable>
+            <variable name="alarm" address="%QX0.0">
+              <type>
+                <BOOL/>
+              </type>
+            </variable>
+          </localVars>
+        </interface>
+        <body>
+          <LD>
+            <leftPowerRail localId="1" width="10" height="40">
+              <position x="30" y="20"/>
+              <connectionPointOut formalParameter="">
+                <relPosition x="10" y="20"/>
+              </connectionPointOut>
+            </leftPowerRail>
+            <rightPowerRail localId="2" width="10" height="40">
+              <position x="410" y="20"/>
+              <connectionPointIn>
+                <relPosition x="0" y="20"/>
+                <connection refLocalId="6"/>
+              </connectionPointIn>
+            </rightPowerRail>
+            <inVariable localId="4" width="60" height="20" negated="false">
+              <position x="80" y="10"/>
+              <connectionPointOut>
+                <relPosition x="60" y="10"/>
+              </connectionPointOut>
+              <expression>level</expression>
+            </inVariable>
+            <inVariable localId="5" width="60" height="20" negated="false">
+              <position x="80" y="40"/>
+              <connectionPointOut>
+                <relPosition x="60" y="10"/>
+              </connectionPointOut>
+              <expression>limit</expression>
+            </inVariable>
+            <block localId="3" width="60" height="40" typeName="GT" instanceName="GT0">
+              <position x="180" y="10"/>
+              <inputVariables>
+                <variable formalParameter="IN1">
+                  <connectionPointIn>
+                    <relPosition x="0" y="10"/>
+                    <connection refLocalId="4"/>
+                  </connectionPointIn>
+                </variable>
+                <variable formalParameter="IN2">
+                  <connectionPointIn>
+                    <relPosition x="0" y="30"/>
+                    <connection refLocalId="5"/>
+                  </connectionPointIn>
+                </variable>
+              </inputVariables>
+              <inOutVariables/>
+              <outputVariables>
+                <variable formalParameter="OUT">
+                  <connectionPointOut>
+                    <relPosition x="60" y="10"/>
+                  </connectionPointOut>
+                </variable>
+              </outputVariables>
+            </block>
+            <coil localId="6" width="20" height="20" negated="false">
+              <position x="330" y="10"/>
+              <connectionPointIn>
+                <relPosition x="0" y="10"/>
+                <connection refLocalId="3"/>
+              </connectionPointIn>
+              <connectionPointOut>
+                <relPosition x="20" y="10"/>
+              </connectionPointOut>
+              <variable>alarm</variable>
+            </coil>
+          </LD>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances>
+    <configurations>
+      <configuration name="config">
+        <resource name="res">
+          <task name="main" interval="T#10ms" priority="0">
+            <pouInstance name="inst" typeName="alarm_control"/>
+          </task>
+        </resource>
+      </configuration>
+    </configurations>
+  </instances>
+</project>

--- a/regression/ld/graphical_unsupported_block_fail/props.yaml
+++ b/regression/ld/graphical_unsupported_block_fail/props.yaml
@@ -1,0 +1,10 @@
+properties:
+
+  # The alarm coil is driven by a GT comparison block, which the graphical
+  # resolver does not model. The real program violates this invariant whenever
+  # the havoc'd level input exceeds limit, so a SUCCESSFUL verdict here means
+  # the resolver silently dropped the rung and verified a weaker program.
+  - id: P1
+    kind: invariant
+    expression: "!alarm"
+    description: "Alarm coil never energises"

--- a/regression/ld/graphical_unsupported_block_fail/test.desc
+++ b/regression/ld/graphical_unsupported_block_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+alarm.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: UnsupportedConstruct\(GT, tier=2\)$
+^ERROR: PARSING ERROR$

--- a/regression/ld/ld_preset_named_pin_safe/preset.ld
+++ b/regression/ld/ld_preset_named_pin_safe/preset.ld
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="ESBMC" productName="regression" productVersion="1" creationDateTime="2026-07-30T00:00:00"/>
+  <contentHeader name="preset"><coordinateInfo><ld><scaling x="10" y="10"/></ld></coordinateInfo></contentHeader>
+  <types><dataTypes/><pous>
+    <pou name="preset" pouType="program">
+      <interface><localVars>
+        <variable name="a" address="%IX0.0"><type><BOOL/></type></variable>
+        <variable name="PV"><type><INT/></type><initialValue><simpleValue value="notanumber"/></initialValue></variable>
+        <variable name="q" address="%QX0.0"><type><BOOL/></type></variable>
+      </localVars></interface>
+      <body><LD>
+        <rung localId="1"><contact variable="a"/><coil variable="q"/></rung>
+      </LD></body>
+    </pou>
+  </pous></types>
+  <instances><configurations><configuration name="c"><resource name="r">
+    <task name="main" interval="T#10ms" priority="0"><pouInstance name="p" typeName="preset"/></task>
+  </resource></configuration></configurations></instances>
+</project>

--- a/regression/ld/ld_preset_named_pin_safe/props.yaml
+++ b/regression/ld/ld_preset_named_pin_safe/props.yaml
@@ -1,0 +1,10 @@
+properties:
+
+  # The unparsable initial value must be diagnosed and defaulted, not crash the
+  # process. literal_to_ticks relied on catching std::stoll's std::invalid_
+  # argument, which never reached a handler, so this file used to terminate
+  # ESBMC and the warning branch below it was unreachable.
+  - id: P1
+    kind: invariant
+    expression: "!q || a"
+    description: "The coil follows its contact within the scan"

--- a/regression/ld/ld_preset_named_pin_safe/test.desc
+++ b/regression/ld/ld_preset_named_pin_safe/test.desc
@@ -1,0 +1,5 @@
+CORE
+preset.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^warning: LD: variable 'PV' has an unrecognised initial value 'notanumber'; using 0\.$
+^VERIFICATION SUCCESSFUL$

--- a/scripts/ld_resolver_oracle.py
+++ b/scripts/ld_resolver_oracle.py
@@ -19,6 +19,13 @@ itself. Two network shapes are generated:
        that enumerates rail-to-coil paths computes the distributed form
        instead, so this mode is what checks distributivity.
 
+Stateful constructs (edge contacts, feedback variables, function blocks,
+set/reset coils) are out of scope by construction: the shadow update is emitted
+before the scan-boundary assertion, so a previous-scan value is not observable
+where properties are checked, and the property grammar has no temporal
+operators. Those are pinned by the discriminating reachability tests under
+regression/ld/ instead.
+
 Usage:
   scripts/ld_resolver_oracle.py [seeds] [depth] [sp|dag] [layers] [width]
 
@@ -32,6 +39,16 @@ import subprocess
 import sys
 
 ESBMC = os.environ.get("ESBMC", "build/src/esbmc/esbmc")
+RAIL_LID = 1
+RIGHT_RAIL_LID = 2
+
+
+def _join_or(parts):
+    """OR a list of formulas, parenthesising only when there is more than one."""
+    if len(parts) == 1:
+        return parts[0]
+    joined = " || ".join(parts)
+    return f"({joined})"
 
 
 class Network:
@@ -44,15 +61,17 @@ class Network:
         self.nodes = []
 
     def new_lid(self):
+        """Allocate the next unused PLCopen localId."""
         self.lid += 1
         return self.lid
 
     def contact(self, preds):
-        var = "i%d" % self.rng.randrange(self.nvars)
-        neg = self.rng.random() < 0.35
+        """Append one contact fed by preds; return its (localId, condition)."""
+        var = f"i{self.rng.randrange(self.nvars)}"
+        negated = self.rng.random() < 0.35
         lid = self.new_lid()
-        self.nodes.append((lid, var, neg, list(preds)))
-        return lid, ("!%s" % var) if neg else var
+        self.nodes.append((lid, var, negated, list(preds)))
+        return lid, (f"!{var}" if negated else var)
 
     def series_parallel(self, preds, depth):
         """Compose series (AND) and parallel (OR) groups; return (exits, expr)."""
@@ -62,51 +81,39 @@ class Network:
         if self.rng.random() < 0.5:
             exits_a, expr_a = self.series_parallel(preds, depth - 1)
             exits_b, expr_b = self.series_parallel(exits_a, depth - 1)
-            return exits_b, "(%s && %s)" % (expr_a, expr_b)
+            return exits_b, f"({expr_a} && {expr_b})"
         exits_a, expr_a = self.series_parallel(preds, depth - 1)
         exits_b, expr_b = self.series_parallel(preds, depth - 1)
-        return exits_a + exits_b, "(%s || %s)" % (expr_a, expr_b)
+        return exits_a + exits_b, f"({expr_a} || {expr_b})"
 
     def layered_dag(self, layers, width):
         """Build a layered DAG; return (exit ids, power-flow formula)."""
         rail = "TRUE"
-        prev = [(1, rail)]
+        prev = [(RAIL_LID, rail)]
         for _ in range(layers):
             cur = []
             for _ in range(width):
-                chosen = self.rng.sample(
-                    prev, self.rng.randrange(1, len(prev) + 1))
+                chosen = self.rng.sample(prev,
+                                         self.rng.randrange(1, len(prev) + 1))
                 lid, cond = self.contact([p[0] for p in chosen])
                 feeds = [p[1] for p in chosen]
                 if rail in feeds:
                     expr = cond  # energised straight from the rail
                 else:
-                    joined = feeds[0] if len(feeds) == 1 \
-                        else "(" + " || ".join(feeds) + ")"
-                    expr = "(%s && %s)" % (joined, cond)
+                    expr = f"({_join_or(feeds)} && {cond})"
                 cur.append((lid, expr))
             prev = cur
-        parts = [p[1] for p in prev]
-        top = parts[0] if len(parts) == 1 else "(" + " || ".join(parts) + ")"
-        return [p[0] for p in prev], top
+        return [p[0] for p in prev], _join_or([p[1] for p in prev])
 
 
-def emit(seed, cfg):
-    """Return (ld_xml, props_yaml, formula) for one generated network."""
-    nvars = cfg["nvars"]
-    net = Network(random.Random(seed), nvars)
-    if cfg["mode"] == "dag":
-        exits, expr = net.layered_dag(cfg["layers"], cfg["width"])
-    else:
-        exits, expr = net.series_parallel([1], cfg["depth"])
-    coil = net.new_lid()
-
-    out = [
+def _interface_xml(seed, nvars):
+    """Project header through the end of the variable declarations."""
+    lines = [
         "<?xml version='1.0' encoding='utf-8'?>",
         '<project xmlns="http://www.plcopen.org/xml/tc6_0201">',
         '  <fileHeader companyName="ESBMC" productName="ld-oracle"'
         ' productVersion="1" creationDateTime="2026-07-30T00:00:00"/>',
-        '  <contentHeader name="gen%d">' % seed,
+        f'  <contentHeader name="gen{seed}">',
         '    <coordinateInfo><ld><scaling x="10" y="10"/></ld>'
         '</coordinateInfo>',
         '  </contentHeader>',
@@ -114,50 +121,69 @@ def emit(seed, cfg):
         '      <pou name="gen" pouType="program">',
         '        <interface><localVars>',
     ]
-    for v in range(nvars):
-        out.append('          <variable name="i%d" address="%%IX0.%d">'
-                   '<type><BOOL/></type></variable>' % (v, v))
-    out += [
+    for var in range(nvars):
+        lines.append(f'          <variable name="i{var}" address="%IX0.{var}">'
+                     '<type><BOOL/></type></variable>')
+    lines += [
         '          <variable name="q" address="%QX0.0">'
         '<type><BOOL/></type></variable>',
         '        </localVars></interface>',
         '        <body><LD>',
-        '          <leftPowerRail localId="1" width="10" height="40">',
+        f'          <leftPowerRail localId="{RAIL_LID}" width="10" '
+        'height="40">',
         '            <position x="10" y="10"/>',
         '            <connectionPointOut><relPosition x="10" y="10"/>'
         '</connectionPointOut>',
         '          </leftPowerRail>',
     ]
-    for (lid, var, neg, preds) in net.nodes:
-        out.append('          <contact localId="%d" width="20" height="20"'
-                   ' negated="%s">' % (lid, "true" if neg else "false"))
-        out.append('            <position x="%d" y="10"/>' % (40 + 30 * lid))
-        out.append('            <connectionPointIn>')
-        out.append('              <relPosition x="0" y="10"/>')
-        for p in preds:
-            out.append('              <connection refLocalId="%d"/>' % p)
-        out.append('            </connectionPointIn>')
-        out.append('            <connectionPointOut>'
-                   '<relPosition x="20" y="10"/></connectionPointOut>')
-        out.append('            <variable>%s</variable>' % var)
-        out.append('          </contact>')
-    out.append('          <coil localId="%d" width="20" height="20"'
-               ' negated="false">' % coil)
-    out.append('            <position x="900" y="10"/>')
-    out.append('            <connectionPointIn>')
-    out.append('              <relPosition x="0" y="10"/>')
-    for e in exits:
-        out.append('              <connection refLocalId="%d"/>' % e)
-    out.append('            </connectionPointIn>')
-    out.append('            <connectionPointOut><relPosition x="20" y="10"/>'
-               '</connectionPointOut>')
-    out.append('            <variable>q</variable>')
-    out.append('          </coil>')
-    out += [
-        '          <rightPowerRail localId="2" width="10" height="40">',
+    return lines
+
+
+def _contact_xml(node):
+    """One <contact> element, wired to each of its predecessors."""
+    lid, var, negated, preds = node
+    negated_attr = "true" if negated else "false"
+    lines = [
+        f'          <contact localId="{lid}" width="20" height="20"'
+        f' negated="{negated_attr}">',
+        f'            <position x="{40 + 30 * lid}" y="10"/>',
+        '            <connectionPointIn>',
+        '              <relPosition x="0" y="10"/>',
+    ]
+    for pred in preds:
+        lines.append(f'              <connection refLocalId="{pred}"/>')
+    lines += [
+        '            </connectionPointIn>',
+        '            <connectionPointOut><relPosition x="20" y="10"/>'
+        '</connectionPointOut>',
+        f'            <variable>{var}</variable>',
+        '          </contact>',
+    ]
+    return lines
+
+
+def _sink_xml(coil, exits):
+    """The output coil, its incoming connections, and the closing elements."""
+    lines = [
+        f'          <coil localId="{coil}" width="20" height="20"'
+        ' negated="false">',
+        '            <position x="900" y="10"/>',
+        '            <connectionPointIn>',
+        '              <relPosition x="0" y="10"/>',
+    ]
+    for exit_lid in exits:
+        lines.append(f'              <connection refLocalId="{exit_lid}"/>')
+    lines += [
+        '            </connectionPointIn>',
+        '            <connectionPointOut><relPosition x="20" y="10"/>'
+        '</connectionPointOut>',
+        '            <variable>q</variable>',
+        '          </coil>',
+        f'          <rightPowerRail localId="{RIGHT_RAIL_LID}" width="10"'
+        ' height="40">',
         '            <position x="950" y="10"/>',
         '            <connectionPointIn><relPosition x="0" y="10"/>'
-        '<connection refLocalId="%d"/></connectionPointIn>' % coil,
+        f'<connection refLocalId="{coil}"/></connectionPointIn>',
         '          </rightPowerRail>',
         '        </LD></body>',
         '      </pou>',
@@ -169,25 +195,40 @@ def emit(seed, cfg):
         '  </resource></configuration></configurations></instances>',
         '</project>',
     ]
+    return lines
+
+
+def emit(seed, cfg):
+    """Return (ld_xml, props_yaml, formula) for one generated network."""
+    net = Network(random.Random(seed), cfg["nvars"])
+    if cfg["mode"] == "dag":
+        exits, expr = net.layered_dag(cfg["layers"], cfg["width"])
+    else:
+        exits, expr = net.series_parallel([RAIL_LID], cfg["depth"])
+
+    lines = _interface_xml(seed, cfg["nvars"])
+    for node in net.nodes:
+        lines += _contact_xml(node)
+    lines += _sink_xml(net.new_lid(), exits)
 
     # Both implications, so an undriven coil (stuck false) fails the second one
     # rather than passing vacuously.
-    props = ('properties:\n'
-             '  - id: P1\n'
-             '    kind: invariant\n'
-             '    expression: "(!q || %s) && (q || !(%s))"\n'
-             '    description: "coil equals its power flow"\n' % (expr, expr))
-    return "\n".join(out) + "\n", props, expr
+    props = ("properties:\n"
+             "  - id: P1\n"
+             "    kind: invariant\n"
+             f'    expression: "(!q || {expr}) && (q || !({expr}))"\n'
+             '    description: "coil equals its power flow"\n')
+    return "\n".join(lines) + "\n", props, expr
 
 
 def verdict_of(output):
     """Extract ESBMC's verdict word, or an ERROR: line if there is none."""
-    for v in ("VERIFICATION SUCCESSFUL", "VERIFICATION FAILED",
-              "VERIFICATION UNKNOWN"):
-        if v in output:
-            return v.split()[-1]
-    last = output.strip().splitlines()
-    return "ERROR:" + (last[-1] if last else "<no output>")
+    for verdict in ("VERIFICATION SUCCESSFUL", "VERIFICATION FAILED",
+                    "VERIFICATION UNKNOWN"):
+        if verdict in output:
+            return verdict.split()[-1]
+    tail = output.strip().splitlines()
+    return "ERROR:" + (tail[-1] if tail else "<no output>")
 
 
 def run_one(seed, tmpdir, cfg, timeout=60):
@@ -195,33 +236,51 @@ def run_one(seed, tmpdir, cfg, timeout=60):
     xml, props, expr = emit(seed, cfg)
     ld_path = os.path.join(tmpdir, "oracle.ld")
     props_path = os.path.join(tmpdir, "oracle.yaml")
-    with open(ld_path, "w", encoding="utf-8") as f:
-        f.write(xml)
-    with open(props_path, "w", encoding="utf-8") as f:
-        f.write(props)
+    with open(ld_path, "w", encoding="utf-8") as handle:
+        handle.write(xml)
+    with open(props_path, "w", encoding="utf-8") as handle:
+        handle.write(props)
     try:
         # ESBMC splits output across stdout and stderr; merge or the verdict
         # line is missed.
         proc = subprocess.run(
-            [ESBMC, ld_path, "--ld-props", props_path,
-             "--k-induction", "--max-k-step", "4"],
-            capture_output=True, text=True, timeout=timeout, check=False)
+            [ESBMC, ld_path, "--ld-props", props_path, "--k-induction",
+             "--max-k-step", "4"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False)
         return verdict_of(proc.stdout + proc.stderr), expr, xml, props
     except subprocess.TimeoutExpired:
         return "TIMEOUT", expr, xml, props
 
 
+def _save_failure(seed, xml, props):
+    """Write a failing case to fail_seed<N>/ and return the directory name."""
+    outdir = f"fail_seed{seed}"
+    os.makedirs(outdir, exist_ok=True)
+    with open(os.path.join(outdir, "oracle.ld"), "w",
+              encoding="utf-8") as handle:
+        handle.write(xml)
+    with open(os.path.join(outdir, "oracle.yaml"), "w",
+              encoding="utf-8") as handle:
+        handle.write(props)
+    return outdir
+
+
 def main():
     """Generate and verify a batch of networks; return 1 if any failed."""
-    seeds = int(sys.argv[1]) if len(sys.argv) > 1 else 30
-    depth = int(sys.argv[2]) if len(sys.argv) > 2 else 3
-    mode = sys.argv[3] if len(sys.argv) > 3 else "sp"
-    layers = int(sys.argv[4]) if len(sys.argv) > 4 else 3
-    width = int(sys.argv[5]) if len(sys.argv) > 5 else 2
-
-    cfg = {"nvars": 3, "depth": depth, "mode": mode,
-           "layers": layers, "width": width}
+    argv = sys.argv[1:]
+    seeds = int(argv[0]) if argv else 30
+    cfg = {
+        "nvars": 3,
+        "depth": int(argv[1]) if len(argv) > 1 else 3,
+        "mode": argv[2] if len(argv) > 2 else "sp",
+        "layers": int(argv[3]) if len(argv) > 3 else 3,
+        "width": int(argv[4]) if len(argv) > 4 else 2,
+    }
     tmpdir = os.environ.get("TMPDIR", "/tmp")
+
     tally = {}
     failures = []
     for seed in range(seeds):
@@ -230,19 +289,11 @@ def main():
         if got != "SUCCESSFUL":
             failures.append((seed, got, expr, xml, props))
 
-    print("seeds=%d mode=%s depth=%d layers=%d width=%d -> %s"
-          % (seeds, mode, depth, layers, width, tally))
+    print(f"seeds={seeds} mode={cfg['mode']} depth={cfg['depth']} "
+          f"layers={cfg['layers']} width={cfg['width']} -> {tally}")
     for (seed, got, expr, xml, props) in failures[:4]:
-        print("\n--- seed %d: %s\n    formula: %s" % (seed, got, expr))
-        outdir = "fail_seed%d" % seed
-        os.makedirs(outdir, exist_ok=True)
-        with open(os.path.join(outdir, "oracle.ld"), "w",
-                  encoding="utf-8") as f:
-            f.write(xml)
-        with open(os.path.join(outdir, "oracle.yaml"), "w",
-                  encoding="utf-8") as f:
-            f.write(props)
-        print("    saved to %s/" % outdir)
+        print(f"\n--- seed {seed}: {got}\n    formula: {expr}")
+        print(f"    saved to {_save_failure(seed, xml, props)}/")
     return 1 if failures else 0
 
 

--- a/scripts/ld_resolver_oracle.py
+++ b/scripts/ld_resolver_oracle.py
@@ -35,8 +35,10 @@ fail_seed<N>/ directory for inspection.
 """
 import os
 import random
-import subprocess
+# Runs the esbmc binary; the argv list is built here and no shell is involved.
+import subprocess  # nosec B404
 import sys
+import tempfile
 
 ESBMC = os.environ.get("ESBMC", "build/src/esbmc/esbmc")
 RAIL_LID = 1
@@ -200,7 +202,9 @@ def _sink_xml(coil, exits):
 
 def emit(seed, cfg):
     """Return (ld_xml, props_yaml, formula) for one generated network."""
-    net = Network(random.Random(seed), cfg["nvars"])
+    # A seeded PRNG is the point: a failing case must be reproducible from its
+    # seed alone. Nothing here is security-relevant.
+    net = Network(random.Random(seed), cfg["nvars"])  # nosec B311
     if cfg["mode"] == "dag":
         exits, expr = net.layered_dag(cfg["layers"], cfg["width"])
     else:
@@ -243,7 +247,8 @@ def run_one(seed, tmpdir, cfg, timeout=60):
     try:
         # ESBMC splits output across stdout and stderr; merge or the verdict
         # line is missed.
-        proc = subprocess.run(
+        # Fixed argv, no shell, and both paths are generated above.
+        proc = subprocess.run(  # nosec B603
             [ESBMC, ld_path, "--ld-props", props_path, "--k-induction",
              "--max-k-step", "4"],
             capture_output=True,
@@ -279,15 +284,16 @@ def main():
         "layers": int(argv[3]) if len(argv) > 3 else 3,
         "width": int(argv[4]) if len(argv) > 4 else 2,
     }
-    tmpdir = os.environ.get("TMPDIR", "/tmp")
-
     tally = {}
     failures = []
-    for seed in range(seeds):
-        got, expr, xml, props = run_one(seed, tmpdir, cfg)
-        tally[got] = tally.get(got, 0) + 1
-        if got != "SUCCESSFUL":
-            failures.append((seed, got, expr, xml, props))
+    # A private directory per run: the generated files reuse one name, so two
+    # concurrent runs sharing $TMPDIR would overwrite each other's input.
+    with tempfile.TemporaryDirectory(prefix="ld-oracle-") as tmpdir:
+        for seed in range(seeds):
+            got, expr, xml, props = run_one(seed, tmpdir, cfg)
+            tally[got] = tally.get(got, 0) + 1
+            if got != "SUCCESSFUL":
+                failures.append((seed, got, expr, xml, props))
 
     print(f"seeds={seeds} mode={cfg['mode']} depth={cfg['depth']} "
           f"layers={cfg['layers']} width={cfg['width']} -> {tally}")

--- a/scripts/ld_resolver_oracle.py
+++ b/scripts/ld_resolver_oracle.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Randomised correctness oracle for the ESBMC-PLC graphical LD resolver.
+
+The resolver in src/ld-frontend/parser/plcopen_xml_parser.cpp turns a graphical
+PLCopen LD body into rungs. Only two real graphical programs exist under
+regression/ld/benchmarks/, which is thin cover for changes to it. This script
+generates random networks, derives each one's power-flow formula independently
+of the resolver, and asserts through ESBMC that the coil equals that formula.
+
+The oracle is structural, not differential: it does not compare one resolver
+against another (which would bless a shared bug) but against the ladder algebra
+itself. Two network shapes are generated:
+
+  sp   series-parallel, the shape a vendor tool draws: series = AND, parallel
+       = OR.
+  dag  layered, each node taking a random non-empty subset of the previous
+       layer. Not series-parallel, so the formula comes from the per-node
+       recurrence pf(n) = (OR over preds p of pf(p)) AND cond(n). A resolver
+       that enumerates rail-to-coil paths computes the distributed form
+       instead, so this mode is what checks distributivity.
+
+Usage:
+  scripts/ld_resolver_oracle.py [seeds] [depth] [sp|dag] [layers] [width]
+
+ESBMC is taken from $ESBMC, else build/src/esbmc/esbmc. Exits non-zero if any
+generated program does not verify, leaving the offending case in a
+fail_seed<N>/ directory for inspection.
+"""
+import os
+import random
+import subprocess
+import sys
+
+ESBMC = os.environ.get("ESBMC", "build/src/esbmc/esbmc")
+
+
+class Network:
+    """Accumulates contact nodes as (localId, var, negated, predecessor ids)."""
+
+    def __init__(self, rng, nvars):
+        self.rng = rng
+        self.nvars = nvars
+        self.lid = 10
+        self.nodes = []
+
+    def new_lid(self):
+        self.lid += 1
+        return self.lid
+
+    def contact(self, preds):
+        var = "i%d" % self.rng.randrange(self.nvars)
+        neg = self.rng.random() < 0.35
+        lid = self.new_lid()
+        self.nodes.append((lid, var, neg, list(preds)))
+        return lid, ("!%s" % var) if neg else var
+
+    def series_parallel(self, preds, depth):
+        """Compose series (AND) and parallel (OR) groups; return (exits, expr)."""
+        if depth <= 0 or self.rng.random() < 0.3:
+            lid, expr = self.contact(preds)
+            return [lid], expr
+        if self.rng.random() < 0.5:
+            exits_a, expr_a = self.series_parallel(preds, depth - 1)
+            exits_b, expr_b = self.series_parallel(exits_a, depth - 1)
+            return exits_b, "(%s && %s)" % (expr_a, expr_b)
+        exits_a, expr_a = self.series_parallel(preds, depth - 1)
+        exits_b, expr_b = self.series_parallel(preds, depth - 1)
+        return exits_a + exits_b, "(%s || %s)" % (expr_a, expr_b)
+
+    def layered_dag(self, layers, width):
+        """Build a layered DAG; return (exit ids, power-flow formula)."""
+        rail = "TRUE"
+        prev = [(1, rail)]
+        for _ in range(layers):
+            cur = []
+            for _ in range(width):
+                chosen = self.rng.sample(
+                    prev, self.rng.randrange(1, len(prev) + 1))
+                lid, cond = self.contact([p[0] for p in chosen])
+                feeds = [p[1] for p in chosen]
+                if rail in feeds:
+                    expr = cond  # energised straight from the rail
+                else:
+                    joined = feeds[0] if len(feeds) == 1 \
+                        else "(" + " || ".join(feeds) + ")"
+                    expr = "(%s && %s)" % (joined, cond)
+                cur.append((lid, expr))
+            prev = cur
+        parts = [p[1] for p in prev]
+        top = parts[0] if len(parts) == 1 else "(" + " || ".join(parts) + ")"
+        return [p[0] for p in prev], top
+
+
+def emit(seed, cfg):
+    """Return (ld_xml, props_yaml, formula) for one generated network."""
+    nvars = cfg["nvars"]
+    net = Network(random.Random(seed), nvars)
+    if cfg["mode"] == "dag":
+        exits, expr = net.layered_dag(cfg["layers"], cfg["width"])
+    else:
+        exits, expr = net.series_parallel([1], cfg["depth"])
+    coil = net.new_lid()
+
+    out = [
+        "<?xml version='1.0' encoding='utf-8'?>",
+        '<project xmlns="http://www.plcopen.org/xml/tc6_0201">',
+        '  <fileHeader companyName="ESBMC" productName="ld-oracle"'
+        ' productVersion="1" creationDateTime="2026-07-30T00:00:00"/>',
+        '  <contentHeader name="gen%d">' % seed,
+        '    <coordinateInfo><ld><scaling x="10" y="10"/></ld>'
+        '</coordinateInfo>',
+        '  </contentHeader>',
+        '  <types><dataTypes/><pous>',
+        '      <pou name="gen" pouType="program">',
+        '        <interface><localVars>',
+    ]
+    for v in range(nvars):
+        out.append('          <variable name="i%d" address="%%IX0.%d">'
+                   '<type><BOOL/></type></variable>' % (v, v))
+    out += [
+        '          <variable name="q" address="%QX0.0">'
+        '<type><BOOL/></type></variable>',
+        '        </localVars></interface>',
+        '        <body><LD>',
+        '          <leftPowerRail localId="1" width="10" height="40">',
+        '            <position x="10" y="10"/>',
+        '            <connectionPointOut><relPosition x="10" y="10"/>'
+        '</connectionPointOut>',
+        '          </leftPowerRail>',
+    ]
+    for (lid, var, neg, preds) in net.nodes:
+        out.append('          <contact localId="%d" width="20" height="20"'
+                   ' negated="%s">' % (lid, "true" if neg else "false"))
+        out.append('            <position x="%d" y="10"/>' % (40 + 30 * lid))
+        out.append('            <connectionPointIn>')
+        out.append('              <relPosition x="0" y="10"/>')
+        for p in preds:
+            out.append('              <connection refLocalId="%d"/>' % p)
+        out.append('            </connectionPointIn>')
+        out.append('            <connectionPointOut>'
+                   '<relPosition x="20" y="10"/></connectionPointOut>')
+        out.append('            <variable>%s</variable>' % var)
+        out.append('          </contact>')
+    out.append('          <coil localId="%d" width="20" height="20"'
+               ' negated="false">' % coil)
+    out.append('            <position x="900" y="10"/>')
+    out.append('            <connectionPointIn>')
+    out.append('              <relPosition x="0" y="10"/>')
+    for e in exits:
+        out.append('              <connection refLocalId="%d"/>' % e)
+    out.append('            </connectionPointIn>')
+    out.append('            <connectionPointOut><relPosition x="20" y="10"/>'
+               '</connectionPointOut>')
+    out.append('            <variable>q</variable>')
+    out.append('          </coil>')
+    out += [
+        '          <rightPowerRail localId="2" width="10" height="40">',
+        '            <position x="950" y="10"/>',
+        '            <connectionPointIn><relPosition x="0" y="10"/>'
+        '<connection refLocalId="%d"/></connectionPointIn>' % coil,
+        '          </rightPowerRail>',
+        '        </LD></body>',
+        '      </pou>',
+        '  </pous></types>',
+        '  <instances><configurations><configuration name="c">'
+        '<resource name="r">',
+        '    <task name="main" interval="T#10ms" priority="0">'
+        '<pouInstance name="p" typeName="gen"/></task>',
+        '  </resource></configuration></configurations></instances>',
+        '</project>',
+    ]
+
+    # Both implications, so an undriven coil (stuck false) fails the second one
+    # rather than passing vacuously.
+    props = ('properties:\n'
+             '  - id: P1\n'
+             '    kind: invariant\n'
+             '    expression: "(!q || %s) && (q || !(%s))"\n'
+             '    description: "coil equals its power flow"\n' % (expr, expr))
+    return "\n".join(out) + "\n", props, expr
+
+
+def verdict_of(output):
+    """Extract ESBMC's verdict word, or an ERROR: line if there is none."""
+    for v in ("VERIFICATION SUCCESSFUL", "VERIFICATION FAILED",
+              "VERIFICATION UNKNOWN"):
+        if v in output:
+            return v.split()[-1]
+    last = output.strip().splitlines()
+    return "ERROR:" + (last[-1] if last else "<no output>")
+
+
+def run_one(seed, tmpdir, cfg, timeout=60):
+    """Generate one network, verify it, and return (verdict, formula, files)."""
+    xml, props, expr = emit(seed, cfg)
+    ld_path = os.path.join(tmpdir, "oracle.ld")
+    props_path = os.path.join(tmpdir, "oracle.yaml")
+    with open(ld_path, "w", encoding="utf-8") as f:
+        f.write(xml)
+    with open(props_path, "w", encoding="utf-8") as f:
+        f.write(props)
+    try:
+        # ESBMC splits output across stdout and stderr; merge or the verdict
+        # line is missed.
+        proc = subprocess.run(
+            [ESBMC, ld_path, "--ld-props", props_path,
+             "--k-induction", "--max-k-step", "4"],
+            capture_output=True, text=True, timeout=timeout, check=False)
+        return verdict_of(proc.stdout + proc.stderr), expr, xml, props
+    except subprocess.TimeoutExpired:
+        return "TIMEOUT", expr, xml, props
+
+
+def main():
+    """Generate and verify a batch of networks; return 1 if any failed."""
+    seeds = int(sys.argv[1]) if len(sys.argv) > 1 else 30
+    depth = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+    mode = sys.argv[3] if len(sys.argv) > 3 else "sp"
+    layers = int(sys.argv[4]) if len(sys.argv) > 4 else 3
+    width = int(sys.argv[5]) if len(sys.argv) > 5 else 2
+
+    cfg = {"nvars": 3, "depth": depth, "mode": mode,
+           "layers": layers, "width": width}
+    tmpdir = os.environ.get("TMPDIR", "/tmp")
+    tally = {}
+    failures = []
+    for seed in range(seeds):
+        got, expr, xml, props = run_one(seed, tmpdir, cfg)
+        tally[got] = tally.get(got, 0) + 1
+        if got != "SUCCESSFUL":
+            failures.append((seed, got, expr, xml, props))
+
+    print("seeds=%d mode=%s depth=%d layers=%d width=%d -> %s"
+          % (seeds, mode, depth, layers, width, tally))
+    for (seed, got, expr, xml, props) in failures[:4]:
+        print("\n--- seed %d: %s\n    formula: %s" % (seed, got, expr))
+        outdir = "fail_seed%d" % seed
+        os.makedirs(outdir, exist_ok=True)
+        with open(os.path.join(outdir, "oracle.ld"), "w",
+                  encoding="utf-8") as f:
+            f.write(xml)
+        with open(os.path.join(outdir, "oracle.yaml"), "w",
+                  encoding="utf-8") as f:
+            f.write(props)
+        print("    saved to %s/" % outdir)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ld_resolver_oracle.py
+++ b/scripts/ld_resolver_oracle.py
@@ -35,7 +35,6 @@ fail_seed<N>/ directory for inspection.
 """
 import os
 import random
-# Runs the esbmc binary; the argv list is built here and no shell is involved.
 import subprocess  # nosec B404
 import sys
 import tempfile
@@ -202,8 +201,6 @@ def _sink_xml(coil, exits):
 
 def emit(seed, cfg):
     """Return (ld_xml, props_yaml, formula) for one generated network."""
-    # A seeded PRNG is the point: a failing case must be reproducible from its
-    # seed alone. Nothing here is security-relevant.
     net = Network(random.Random(seed), cfg["nvars"])  # nosec B311
     if cfg["mode"] == "dag":
         exits, expr = net.layered_dag(cfg["layers"], cfg["width"])
@@ -247,7 +244,6 @@ def run_one(seed, tmpdir, cfg, timeout=60):
     try:
         # ESBMC splits output across stdout and stderr; merge or the verdict
         # line is missed.
-        # Fixed argv, no shell, and both paths are generated above.
         proc = subprocess.run(  # nosec B603
             [ESBMC, ld_path, "--ld-props", props_path, "--k-induction",
              "--max-k-step", "4"],

--- a/src/ld-frontend/ir_gen/ld_converter.cpp
+++ b/src/ld-frontend/ir_gen/ld_converter.cpp
@@ -48,6 +48,18 @@ exprt ld_converter::int_const(long long value) const
   return from_integer(BigInt(value), int32_t_());
 }
 
+// Saturation bounds for CV, taken from the configured integer width rather than
+// assumed to be 32-bit.
+exprt ld_converter::int_max() const
+{
+  return to_signedbv_type(int32_t_()).largest_expr();
+}
+
+exprt ld_converter::int_min() const
+{
+  return to_signedbv_type(int32_t_()).smallest_expr();
+}
+
 static std::string ld_name(const std::string &var)
 {
   return "ld::" + var;
@@ -278,7 +290,12 @@ codet ld_converter::translate_timer(const LdIRNode &n)
   exprt in_val = bool_value_of(in_sym);
   exprt q_val = bool_value_of(q_sym);
 
-  auto advance_et =
+  // IEC 61131-3 §2.5.2.3.2 bounds ET by PT, so the count stops once the
+  // interval is up. Without the bound ET rises every scan IN holds and
+  // eventually overflows, which is UB and flips Q back to false.
+  code_ifthenelset advance_et;
+  advance_et.cond() = binary_relation_exprt(et_sym, "<", pt_sym);
+  advance_et.then_case() =
     code_assignt(et_sym, make_arith(exprt::plus, et_sym, one, int32_t_()));
   auto q_while_pending =
     code_assignt(q_sym, binary_relation_exprt(et_sym, "<", pt_sym));
@@ -363,7 +380,9 @@ codet ld_converter::translate_counter(const LdIRNode &n)
       declare_bool_shadow(ld_name("__ctr_prev_" + n.ctr_instance));
 
     code_ifthenelset cu_step;
-    cu_step.cond() = and_exprt(cu, not_exprt(cu_prev));
+    cu_step.cond() = and_exprt(
+      and_exprt(cu, not_exprt(cu_prev)),
+      binary_relation_exprt(cv, "<", int_max()));
     cu_step.then_case() =
       code_assignt(cv, make_arith(exprt::plus, cv, one, int32_t_()));
     blk.copy_to_operands(cu_step);
@@ -396,7 +415,9 @@ codet ld_converter::translate_counter(const LdIRNode &n)
       declare_bool_shadow(ld_name("__ctr_prev_" + n.ctr_instance));
 
     code_ifthenelset cd_step;
-    cd_step.cond() = and_exprt(cd, not_exprt(cd_prev));
+    cd_step.cond() = and_exprt(
+      and_exprt(cd, not_exprt(cd_prev)),
+      binary_relation_exprt(cv, ">", int_min()));
     cd_step.then_case() =
       code_assignt(cv, make_arith(exprt::plus, cv, neg_one, int32_t_()));
     blk.copy_to_operands(cd_step);

--- a/src/ld-frontend/ir_gen/ld_converter.h
+++ b/src/ld-frontend/ir_gen/ld_converter.h
@@ -48,6 +48,8 @@ private:
   typet int32_t_() const;
   typet type_of_kind(VarKind kind) const; // IEC 61131-3 type -> ESBMC typet
   exprt int_const(long long value) const;
+  exprt int_max() const;
+  exprt int_min() const;
 
   symbol_exprt declare_variable(const VarDecl &v);
   symbol_exprt declare_bool_shadow(const std::string &id);

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -1,5 +1,6 @@
 #include <ld-frontend/parser/plcopen_xml_parser.h>
 #include <pugixml.hpp>
+#include <algorithm>
 #include <cassert>
 #include <cctype>
 #include <cstdlib>
@@ -688,7 +689,6 @@ static bool parse_graphical_ld(
   // Convert one path into its contact chain.  A path that runs through a
   // function block is cut at the last block on it and restarted from that
   // block's output pin, which the block's own rung has already assigned.
-  // Returns false if the path contains an element that cannot be modelled.
   auto path_contacts =
     [&](const std::vector<int> &path, std::vector<RungElement> &out) {
       size_t start = 0;
@@ -705,21 +705,17 @@ static bool parse_graphical_ld(
         const GNode &g = nodes.at(path[i]);
         if (g.tag == "leftPowerRail")
           continue;
+        // Dropping the path would verify a program in which this branch never
+        // energises its coil, which hides violations instead of reporting them.
         if (g.tag != "contact")
-        {
-          std::cerr << "warning: graphical LD: rung path contains "
-                    << "unsupported element '" << g.tag << "'"
-                    << (g.var.empty() ? "" : " (var=" + g.var + ")")
-                    << " — skipping path to avoid an unsound model.\n";
-          return false;
-        }
+          throw UnsupportedConstructError(
+            g.tag + (g.var.empty() ? "" : " (var=" + g.var + ")"), 2);
         out.push_back(make_contact(sensed_name(g.var), g.negated, g.edge));
       }
 
       if (!resume_pin.empty())
         out.insert(
           out.begin(), make_contact(resume_pin, false, ContactEdge::None));
-      return true;
     };
 
   // Emit the rungs driving one sink from its incoming paths.  Parallel paths
@@ -728,17 +724,31 @@ static bool parse_graphical_ld(
   // path needs no accumulator and drives the sink directly.
   auto emit_sink = [&](
                      const std::vector<std::vector<int>> &paths,
+                     int sink_id,
                      const std::string &target,
                      CoilKind kind) {
+    // No rail-to-sink path means nothing would ever assign the sink, so it
+    // would hold its initial value for every scan and any property over it
+    // would pass vacuously. A block driving the sink whose enable pin is not
+    // one of enable_pins (step 3) gets no incoming edge and lands here, so
+    // report that block rather than the sink itself.
+    if (paths.empty())
+    {
+      for (const auto &[lid, g] : nodes)
+        if (
+          g.tag == "block" &&
+          std::find(g.feeds.begin(), g.feeds.end(), sink_id) != g.feeds.end())
+          throw UnsupportedConstructError(g.type_name, 2);
+      throw UnsupportedConstructError("undriven sink " + target, 2);
+    }
+
     std::vector<std::vector<RungElement>> chains;
     for (const auto &p : paths)
     {
       std::vector<RungElement> elems;
-      if (path_contacts(p, elems))
-        chains.push_back(std::move(elems));
+      path_contacts(p, elems);
+      chains.push_back(std::move(elems));
     }
-    if (chains.empty())
-      return;
 
     if (chains.size() == 1)
     {
@@ -808,7 +818,7 @@ static bool parse_graphical_ld(
     const char *enable = is_timer ? "IN" : (kind == FBKind::CTU ? "CU" : "CD");
     const std::string enable_var =
       synth_var(pin_name(block_id, enable), VarKind::BOOL, true, 0);
-    emit_sink(paths, enable_var, CoilKind::Output);
+    emit_sink(paths, block_id, enable_var, CoilKind::Output);
 
     RungElement e;
     e.loc = loc;
@@ -898,7 +908,7 @@ static bool parse_graphical_ld(
       kind = CoilKind::Set;
     else if (g.storage == "reset")
       kind = CoilKind::Reset;
-    emit_sink(paths, g.var, kind);
+    emit_sink(paths, coil, g.var, kind);
   }
 
   // Blocks whose outputs drive nothing still advance their internal state

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -2,6 +2,7 @@
 #include <pugixml.hpp>
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <cctype>
 #include <cstdlib>
 #include <iostream>
@@ -388,19 +389,18 @@ literal_to_ticks(const std::string &text, unsigned interval_ms, long long &out)
     return true;
   }
 
-  try
-  {
-    size_t consumed = 0;
-    const long long v = std::stoll(text, &consumed);
-    if (consumed == 0)
-      return false;
-    out = v;
-    return true;
-  }
-  catch (const std::exception &)
-  {
+  // Validate rather than convert-and-catch. A non-numeric preset — a data pin
+  // wired to a named variable, or an unparsable <initialValue> — used to
+  // terminate the process on std::stoll's std::invalid_argument despite the
+  // catch that was here, leaving both callers' fallback paths unreachable.
+  // Parsers should not route ordinary "not a number" input through exceptions.
+  errno = 0;
+  char *end = nullptr;
+  const long long v = std::strtoll(text.c_str(), &end, 10);
+  if (end == text.c_str() || errno == ERANGE)
     return false;
-  }
+  out = v;
+  return true;
 }
 
 // The FB type table is shared between the textual rung parser and the

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -533,9 +533,14 @@ static bool parse_graphical_ld(
   // Step 4: enumerate simple paths from every leftPowerRail to a target.
   // The returned paths exclude the rail and the target itself.
   //
-  // NOTE: the number of simple paths is exponential in the number of parallel
-  // branches. This is tractable for the graphical LD programs evaluated here;
-  // larger vendor exports may need a path-count guard.
+  // The search is exponential in the number of parallel branches, so it is
+  // bounded. Exceeding the bound is an error rather than a truncated
+  // enumeration: dropping paths would silently weaken the model the same way
+  // an unmodellable path used to. The bound is ~5000x the widest network in
+  // the benchmark set (stairs_light peaks at 20 steps), so it is only
+  // reachable by an export far wider than anything drawn by hand.
+  static constexpr unsigned long max_path_search_steps = 100000;
+
   std::vector<int> left_rails;
   for (auto &[lid, g] : nodes)
     if (g.tag == "leftPowerRail")
@@ -545,7 +550,13 @@ static bool parse_graphical_ld(
     std::vector<std::vector<int>> found;
     std::vector<int> path;
     std::set<int> visited;
+    unsigned long steps = 0;
     std::function<void(int)> dfs = [&](int cur) {
+      if (++steps > max_path_search_steps)
+        throw LdParseError(
+          "graphical LD: network feeding localId " + std::to_string(target) +
+          " has too many parallel paths to enumerate (limit " +
+          std::to_string(max_path_search_steps) + " steps)");
       if (cur == target)
       {
         found.push_back(path);

--- a/unit/ld-frontend/test_ir_gen.cpp
+++ b/unit/ld-frontend/test_ir_gen.cpp
@@ -3,12 +3,18 @@
 
 #include <ld-frontend/ir/ld_ir.h>
 #include <ld-frontend/ir_gen/ld_converter.h>
+#include <util/config/config.h>
 #include <util/symtab/context.h>
 #include <util/irep/std_code.h>
 #include <util/irep/std_expr.h>
 
 static LdIR make_empty_ir()
 {
+  // int_type() reads config.ansi_c.int_width, which this binary never sets. A
+  // zero-width integer type makes the counters' saturation bounds underflow
+  // their width to a 2^32-bit exponent.
+  config.ansi_c.set_data_model(configt::LP64);
+
   LdIR ir;
   ir.source_file = "<test>";
   return ir;


### PR DESCRIPTION
The graphical LD resolver dropped rung paths it could not model, enumerated
rail-to-sink paths exponentially, wrapped counter and timer arithmetic, and
aborted on a non-numeric preset. Fix all four, and update the SOS specification
where it had specified the unguarded counter increment.

Adds scripts/ld_resolver_oracle.py, a randomised structural oracle that derives
each generated network's power-flow formula independently of the resolver, plus
one discriminating test per stateful construct. regression/ld/ goes 23 to 37.
