### PR TITLE
chore: clang-format enable comment wrapping

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -84,7 +84,7 @@ MaxEmptyLinesToKeep: '1'
 NamespaceIndentation: None
 PenaltyBreakString: 10000
 PointerAlignment: Right
-ReflowComments: 'false'
+ReflowComments: 'true'
 SortIncludes: 'false'
 SpaceAfterCStyleCast: 'false'
 SpaceBeforeAssignmentOperators: 'true'


### PR DESCRIPTION
This enables comment wrapping, no idea why it was disabled. In general it's a good idea.