### PR TITLE
[ltl] Report the verdict in the result and distinguish absent prefixes

### DIFF
--- a/regression/ltl/basic-func/test.desc
+++ b/regression/ltl/basic-func/test.desc
@@ -1,5 +1,5 @@
 CORE
 test.c
 --ltl test.ba-2.c -DLTL_PREFIX_BOUND=10
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$
 ^Final lowest outcome: LTL_FAILING$

--- a/regression/ltl/basic/test.desc
+++ b/regression/ltl/basic/test.desc
@@ -1,5 +1,5 @@
 CORE
 test.c
 --ltl test.ba-2.c -DLTL_PREFIX_BOUND=10
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$
 ^Final lowest outcome: LTL_FAILING$

--- a/regression/ltl/uninstrumented-unknown/test.ba-2.c
+++ b/regression/ltl/uninstrumented-unknown/test.ba-2.c
@@ -1,0 +1,246 @@
+#if 0
+/* Precomputed transition data */
+States:
+label	id	final
+0	init	1
+1	T0_2	0
+
+Symbol table:
+id	symbol			cexpr
+0	_ltl2ba_cexpr_0_status	{ pressed }
+1	_ltl2ba_cexpr_1_status	{ charge > min }
+
+Stuttering:
+
+
+!{pressed}&!{charge > min}
+Transitions:
+1	1	
+0	1	
+
+Reachability:
+1	1	
+0	1	
+
+Accepting cycles: {0}
+Accepting states: {0}
+
+{pressed}&!{charge > min}
+Transitions:
+0	1	
+0	1	
+
+Reachability:
+0	1	
+0	1	
+
+Accepting cycles: {}
+Accepting states: {}
+
+!{pressed}&{charge > min}
+Transitions:
+1	1	
+1	1	
+
+Reachability:
+1	1	
+1	1	
+
+Accepting cycles: {0}
+Accepting states: {0,1}
+
+{pressed}&{charge > min}
+Transitions:
+1	1	
+1	1	
+
+Reachability:
+1	1	
+1	1	
+
+Accepting cycles: {0}
+Accepting states: {0,1}
+
+
+Optimistic transitions:
+1	1	
+1	1	
+Optimistic reachability:
+1	1	
+1	1	
+
+Accepting optimistic cycles: {0}
+Accepting optimistic states: {0,1}
+
+
+Pessimistic transitions:
+ 0: {1}
+ 1: {1}
+
+
+Pessimistic reachable:
+ 0: {1}
+ 1: {1}
+
+Accepting pessimistic cycles: {}
+Accepting pessimistic states: {}
+#endif
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+void __ESBMC_switch_to_monitor(void);
+void __ESBMC_switch_from_monitor(void);
+void __ESBMC_register_monitor(pthread_t t);
+void __ESBMC_really_atomic_begin();
+void __ESBMC_really_atomic_end();
+void __ESBMC_atomic_begin();
+void __ESBMC_atomic_end();
+void __ESBMC_assume(_Bool prop);
+void __ESBMC_kill_monitor();
+unsigned int nondet_uint();
+
+extern int pressed;
+extern int charge, min;
+
+char __ESBMC_property__ltl2ba_cexpr_0[] = "pressed";
+int _ltl2ba_cexpr_0_status(void) { return pressed; }
+char __ESBMC_property__ltl2ba_cexpr_1[] = "charge > min";
+int _ltl2ba_cexpr_1_status(void) { return charge > min; }
+
+typedef enum {
+	_ltl2ba_state_0,
+	_ltl2ba_state_1,
+} _ltl2ba_state;
+
+_ltl2ba_state _ltl2ba_statevar =_ltl2ba_state_0;
+
+unsigned int _ltl2ba_visited_states[2];
+
+void
+ltl2ba_fsm(bool state_stats, unsigned int num_iters)
+{
+	unsigned int choice;
+	unsigned int iters;
+	_Bool state_is_viable;
+
+	/* Original formula:
+	 * G({pressed} -> F {charge > min})
+	 */
+
+	for (iters = 0; iters < num_iters; iters++) {
+		choice = nondet_uint();
+
+		__ESBMC_atomic_begin();
+
+		switch(_ltl2ba_statevar) {
+		case _ltl2ba_state_0:
+			state_is_viable = (((!(pressed)) || ((charge > min))) || ((1)) || (((charge > min))) || ((false)));
+			if (choice == 0) {
+				__ESBMC_assume(((!(pressed)) || ((charge > min))));
+				_ltl2ba_statevar = _ltl2ba_state_0;
+			} else if (choice == 1) {
+				__ESBMC_assume(((1)));
+				_ltl2ba_statevar = _ltl2ba_state_1;
+			} else if (choice == 2) {
+				__ESBMC_assume((((charge > min))));
+				_ltl2ba_statevar = _ltl2ba_state_0;
+			} else {
+				__ESBMC_assume(0);
+			}
+			break;
+		case _ltl2ba_state_1:
+			state_is_viable = (((1)) || (((charge > min))) || ((false)));
+			if (choice == 0) {
+				__ESBMC_assume(((1)));
+				_ltl2ba_statevar = _ltl2ba_state_1;
+			} else if (choice == 1) {
+				__ESBMC_assume((((charge > min))));
+				_ltl2ba_statevar = _ltl2ba_state_0;
+			} else {
+				__ESBMC_assume(0);
+			}
+			break;
+		}
+		if (state_stats)
+			_ltl2ba_visited_states[_ltl2ba_statevar]++;
+
+		__ESBMC_atomic_end();
+		// __ESBMC_switch_from_monitor();
+	}
+
+	__ESBMC_assert(num_iters == iters, "Unwind bound on ltl2ba_fsm insufficient");
+
+	return;
+}
+
+#ifndef LTL_PREFIX_BOUND
+#define LTL_PREFIX_BOUND 2147483648
+#endif
+
+#define max(x,y) ((x) < (y) ? (y) : (x))
+
+void * ltl2ba_thread(void *dummy)
+{
+	ltl2ba_fsm(false, LTL_PREFIX_BOUND);
+	return 0;
+	(void)dummy;
+}
+
+void ltl2ba_start_monitor(void)
+{
+	pthread_t t;
+
+//	__ESBMC_atomic_begin();
+	pthread_create(&t, NULL, ltl2ba_thread, NULL);
+	__ESBMC_register_monitor(t);
+//	__ESBMC_atomic_end();
+
+	// __ESBMC_switch_to_monitor();
+}
+
+_Bool _ltl2ba_stutter_accept_table[4][2] = {
+{
+  true, false, 
+},
+{
+  false, false, 
+},
+{
+  true, true, 
+},
+{
+  true, true, 
+},
+};
+
+_Bool _ltl2ba_good_prefix_excluded_states[2] = {
+true, true, 
+};
+
+_Bool _ltl2ba_bad_prefix_states[2] = {
+false, false, 
+};
+
+unsigned int
+_ltl2ba_sym_to_idx(void)
+{
+	unsigned int idx = 0;
+	idx |= ((pressed)) ? 1 : 0;
+	idx |= ((charge > min)) ? 2 : 0;
+	return idx;
+}
+
+void
+ltl2ba_finish_monitor(void)
+{
+	__ESBMC_kill_monitor();
+
+	__ESBMC_assert(!_ltl2ba_bad_prefix_states[_ltl2ba_statevar],"LTL_BAD");
+
+	__ESBMC_assert(!_ltl2ba_stutter_accept_table[_ltl2ba_sym_to_idx()][_ltl2ba_statevar],"LTL_FAILING");
+
+	__ESBMC_assert(!_ltl2ba_good_prefix_excluded_states[_ltl2ba_statevar],"LTL_SUCCEEDING");
+
+	return;
+}

--- a/regression/ltl/uninstrumented-unknown/test.c
+++ b/regression/ltl/uninstrumented-unknown/test.c
@@ -1,0 +1,12 @@
+int pressed, charge, min;
+
+int main()
+{
+	charge = nondet_int();
+	min = nondet_int() % 1024;
+	for (int i = 0; i < 2; i++) {
+		pressed = nondet_int();
+		if (pressed)
+			charge = min + 1;
+	}
+}

--- a/regression/ltl/uninstrumented-unknown/test.desc
+++ b/regression/ltl/uninstrumented-unknown/test.desc
@@ -1,0 +1,5 @@
+CORE
+test.c
+--ltl test.ba-2.c -DLTL_PREFIX_BOUND=10 --k-induction
+^VERIFICATION UNKNOWN$
+^WARNING: No LTL outcome seen; the property was not checked$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -484,6 +484,10 @@ void bmct::report_trace(smt_resultt &res, const symex_target_equationt &eq)
     break;
 
   case P_SATISFIABLE:
+    // A verdict can be reached without a solver having been kept — no model to
+    // read, so there is no trace to build and dereferencing it would crash.
+    if (!runtime_solver)
+      break;
     if (!bs && show_cex)
     {
       error_trace(*runtime_solver, eq);
@@ -1528,7 +1532,7 @@ void bmct::report_result(smt_resultt &res)
         !options.get_bool_option("kind-violation-found") &&
         !(is && options.get_bool_option("disable-inductive-step")))
       {
-        if (vacuity_detected)
+        if (vacuity_detected || ltl_uninstrumented)
           report_unknown();
         else
           report_success();
@@ -1749,17 +1753,39 @@ smt_resultt bmct::run(std::shared_ptr<symex_target_equationt> &eq)
 
   if (options.get_bool_option("ltl"))
   {
-    // So, what was the lowest value ltl outcome that we saw?
+    // So, what was the lowest value ltl outcome that we saw? The lattice runs
+    // ⊥ < ⊥ᵖ < ⊤ᵖ < ⊤, and the two lower values say the property is violated
+    // on some prefix, so they have to reach the process result rather than
+    // only a log line.
     if (ltl_results_seen[ltl_res_bad])
+    {
       log_result("Final lowest outcome: LTL_BAD");
+      res = P_SATISFIABLE;
+    }
     else if (ltl_results_seen[ltl_res_failing])
+    {
       log_result("Final lowest outcome: LTL_FAILING");
+      res = P_SATISFIABLE;
+    }
     else if (ltl_results_seen[ltl_res_succeeding])
+    {
       log_result("Final lowest outcome: LTL_SUCCEEDING");
+      res = P_UNSATISFIABLE;
+    }
     else if (ltl_results_seen[ltl_res_good])
+    {
       log_result("Final lowest outcome: LTL_GOOD");
+      res = P_UNSATISFIABLE;
+    }
     else
-      log_warning("No LTL traces seen, apparently");
+    {
+      // No outcome at all: either nothing was instrumented, or symex never
+      // reached the monitor. Either way the property was not checked, which
+      // report_result turns into UNKNOWN.
+      log_warning("No LTL outcome seen; the property was not checked");
+      ltl_uninstrumented = true;
+      res = P_UNSATISFIABLE;
+    }
   }
 
   return interleaving_failed > 0 ? P_SATISFIABLE : res;
@@ -1997,6 +2023,11 @@ smt_resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
       int res = ltl_run_thread(*eq);
       if (res == -1)
         return P_SMTLIB;
+      if (res == ltl_res_uninstrumented)
+      {
+        ltl_uninstrumented = true;
+        return P_UNSATISFIABLE;
+      }
       if (res < 0)
         return P_ERROR;
       // Record that we've seen this outcome; later decide what the least
@@ -2080,7 +2111,7 @@ smt_resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
   }
 }
 
-int bmct::ltl_run_thread(symex_target_equationt &equation) const
+int bmct::ltl_run_thread(symex_target_equationt &equation)
 {
   /* LTL checking - first check for whether we have a negative prefix, then
    * the indeterminate ones. */
@@ -2094,6 +2125,8 @@ int bmct::ltl_run_thread(symex_target_equationt &equation) const
     Type{"LTL_SUCCEEDING", ltl_res_succeeding},
   };
 
+  size_t total_asserts = 0;
+
   for (const auto &[which, check] : seq)
   {
     size_t num_asserts = 0;
@@ -2106,14 +2139,18 @@ int bmct::ltl_run_thread(symex_target_equationt &equation) const
         if (SSA_step.comment != which)
           SSA_step.type = goto_trace_stept::SKIP;
         else
+        {
           num_asserts++;
+          total_asserts++;
+        }
       }
 
     smt_resultt solver_result = P_UNSATISFIABLE;
+    std::unique_ptr<smt_convt> smt_conv;
     log_status("Checking for {}", which);
     if (num_asserts != 0)
     {
-      std::unique_ptr<smt_convt> smt_conv(create_solver("", ns, options));
+      smt_conv.reset(create_solver("", ns, options));
       solver_result = run_decision_procedure(*smt_conv, equation);
       if (solver_result == P_SATISFIABLE)
         log_status("Found trace satisfying {}", which);
@@ -2134,6 +2171,10 @@ int bmct::ltl_run_thread(symex_target_equationt &equation) const
     switch (solver_result)
     {
     case P_SATISFIABLE:
+      // Hand the satisfying solver to the trace machinery: report_trace reads
+      // the model out of runtime_solver, which an LTL run otherwise never
+      // populates because it returns before the solver is created.
+      runtime_solver = std::move(smt_conv);
       return check;
     case P_ERROR:
       return -2;
@@ -2143,6 +2184,12 @@ int bmct::ltl_run_thread(symex_target_equationt &equation) const
       continue;
     }
   }
+
+  /* Every prefix assertion was absent rather than discharged, so this formula
+   * carries no monitor instrumentation and says nothing about the property.
+   * Reporting the top of the lattice here would claim a proof we never ran. */
+  if (total_asserts == 0)
+    return ltl_res_uninstrumented;
 
   /* Otherwise, we just got a good prefix. */
   return ltl_res_good;

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -44,6 +44,16 @@ public:
   };
   size_t ltl_results_seen[4];
 
+  /* ltl_run_thread returns an ltl_res, or one of these sentinels. Finding no
+   * prefix assertion at all is distinct from having proved every one of them
+   * unsatisfiable: the former says nothing about the property. */
+  static constexpr int ltl_res_uninstrumented = -3;
+
+  // Set when an LTL run found no prefix assertion to check, so no four-valued
+  // verdict is available; consulted by report_result to report UNKNOWN rather
+  // than the ⊤ that an absent assertion used to produce.
+  std::atomic<bool> ltl_uninstrumented{false};
+
   BigInt interleaving_number;
   BigInt interleaving_failed;
 
@@ -100,7 +110,9 @@ protected:
 
   smt_resultt run_thread(std::shared_ptr<symex_target_equationt> &eq);
 
-  int ltl_run_thread(symex_target_equationt &equation) const;
+  /* Not const: the solver that satisfied a prefix assertion is kept in
+   * runtime_solver so the verdict can be backed by a counterexample. */
+  int ltl_run_thread(symex_target_equationt &equation);
 
   /// \param truncated_loops how many loops exploration cut off at the
   ///   unwinding bound, carried in from the symex result rather than read back


### PR DESCRIPTION
ltl_run_thread could not tell a discharged prefix assertion from one it never
found, so an uninstrumented run — every --k-induction, --incremental-bmc,
--termination or small --unwind run — reported the top of the four-valued
lattice for a program that plainly fails. Return a distinct sentinel for that
and report UNKNOWN instead.

The verdict itself only ever reached a log line, so map it onto the process
result and keep the satisfying solver, which gives a failing run a non-zero exit
code and a counterexample. The two shipped tests that asserted SUCCESSFUL
regardless of verdict now assert the verdict they actually produce.

Fixes #6547
Fixes #6548
