### PR TITLE
[bmc] Scope per-claim solves on the shared runtime solver

### DIFF
--- a/regression/esbmc/github_6540/main.c
+++ b/regression/esbmc/github_6540/main.c
@@ -1,0 +1,9 @@
+int nondet_int(void);
+
+int main(void)
+{
+  int x = nondet_int();
+  __ESBMC_assert(x != 42, "may fail");
+  __ESBMC_assert(x >= 0 || x < 0, "holds");
+  return 0;
+}

--- a/regression/esbmc/github_6540/test.desc
+++ b/regression/esbmc/github_6540/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--multi-property --smt-during-symex
+may fail.*FAILED|FAILED.*may fail
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_6540_all_pass/main.c
+++ b/regression/esbmc/github_6540_all_pass/main.c
@@ -1,0 +1,9 @@
+int nondet_int(void);
+
+int main(void)
+{
+  int x = nondet_int();
+  __ESBMC_assert(x >= 0 || x < 0, "holds one");
+  __ESBMC_assert(x == x, "holds two");
+  return 0;
+}

--- a/regression/esbmc/github_6540_all_pass/test.desc
+++ b/regression/esbmc/github_6540_all_pass/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--multi-property --smt-during-symex
+2 passed
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_6540_last/main.c
+++ b/regression/esbmc/github_6540_last/main.c
@@ -1,0 +1,9 @@
+int nondet_int(void);
+
+int main(void)
+{
+  int x = nondet_int();
+  __ESBMC_assert(x >= 0 || x < 0, "holds");
+  __ESBMC_assert(x != 42, "may fail");
+  return 0;
+}

--- a/regression/esbmc/github_6540_last/test.desc
+++ b/regression/esbmc/github_6540_last/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--multi-property --smt-during-symex
+may fail.*FAILED|FAILED.*may fail
+^VERIFICATION FAILED$

--- a/regression/python/constants-fail/test.desc
+++ b/regression/python/constants-fail/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.py
 --multi-property
-
-SIZE == .*?9(?:\n.*)*X == 15(?:\n.*)*VERIFICATION FAILED
-
+SIZE == .*?9
+X == 15
+^VERIFICATION FAILED$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -2204,7 +2204,10 @@ smt_resultt bmct::multi_property_check(
   // Initial values
   smt_resultt final_result = P_UNSATISFIABLE;
   std::mutex result_mutex;
-  std::unordered_set<size_t> jobs;
+  // Solved in claim order: an unordered container would make the per-claim
+  // solve order — and which claim a shared-solver bug lands on — vary by
+  // standard library.
+  std::vector<size_t> jobs;
 
   // For coverage info
   auto &reached_claims = symex->goto_functions.reached_claims;
@@ -2288,7 +2291,7 @@ smt_resultt bmct::multi_property_check(
 
   // TODO: This is the place to check a cache
   for (size_t i = 1; i <= remaining_claims; i++)
-    jobs.emplace(i);
+    jobs.push_back(i);
 
   /* This is a JOB that will:
    * 1. Generate a solver instance for a specific claim (@parameter i)

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -2423,6 +2423,26 @@ smt_resultt bmct::multi_property_check(
       solver_ptr = new_solver.get();
     }
 
+    // --smt-during-symex shares one persistent solver across every claim.
+    // Scope this claim's re-encoded formula in a context frame; without it
+    // the negated assertion stays asserted forever, and once one claim's
+    // negation is unsatisfiable every later claim solves UNSAT and is
+    // misreported as PASSED (issue #6540).
+    struct solver_ctx_framet
+    {
+      smt_convt *conv;
+      explicit solver_ctx_framet(smt_convt *c) : conv(c)
+      {
+        if (conv)
+          conv->push_ctx();
+      }
+      ~solver_ctx_framet()
+      {
+        if (conv)
+          conv->pop_ctx();
+      }
+    } ctx_frame(new_solver ? nullptr : solver_ptr);
+
     // Store solver name initially but not again
     std::call_once(solver_stats.name_flag, [&]() {
       solver_stats.name = solver_ptr->solver_text();


### PR DESCRIPTION
Under `--multi-property --smt-during-symex` each claim's job re-encodes its
sliced equation — negated assertion included — into the persistent runtime
solver with no context frame, so once one claim's negation is unsatisfiable
every later claim is misreported as PASSED. Wrap each claim's encode/solve in
a push/pop context frame, and solve claims in deterministic claim order so the
regression pins discriminate on every standard library. Also resolves the
`--smt-during-symex` verdict divergence on github_1408, github_1890_1 and
github_2629.

Fixes #6540