### PR TITLE
[python] Rewrite nondet_string tests onto the nondet_str builtin

### DIFF
--- a/regression/python/string-char-symbolic-fail/main.py
+++ b/regression/python/string-char-symbolic-fail/main.py
@@ -1,4 +1,4 @@
 
-s = nondet_string(3)
+s = nondet_str()
 c = s[0]  # caractere não determinístico
 assert c == "a"  # FALHA - não sabemos o valor

--- a/regression/python/string-char-symbolic-fail/test.desc
+++ b/regression/python/string-char-symbolic-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 4 --unwind 5
+main\.py line 4 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-char-symbolic-success/main.py
+++ b/regression/python/string-char-symbolic-success/main.py
@@ -1,6 +1,6 @@
 
-s = nondet_string(3)
-assume(s == "abc")
+s = nondet_str()
+__ESBMC_assume(s == "abc")
 c1 = s[0]
 assert c1 == "a"
 c2 = s[1]

--- a/regression/python/string-char-symbolic-success/test.desc
+++ b/regression/python/string-char-symbolic-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 4 --unwind 5
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-assume-success/main.py
+++ b/regression/python/string-nondet-assume-success/main.py
@@ -1,5 +1,5 @@
 
-s = nondet_string(5)
-assume(s == "hello")
+s = nondet_str()
+__ESBMC_assume(s == "hello")
 assert s == "hello"
 assert len(s) == 5

--- a/regression/python/string-nondet-assume-success/test.desc
+++ b/regression/python/string-nondet-assume-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 6 --unwind 7
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-basic-fail/main.py
+++ b/regression/python/string-nondet-basic-fail/main.py
@@ -1,3 +1,3 @@
 
-s = nondet_string(5)
+s = nondet_str()
 assert s == "hello"  # FALHA

--- a/regression/python/string-nondet-basic-fail/test.desc
+++ b/regression/python/string-nondet-basic-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 6 --unwind 7
+main\.py line 3 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-compare-fail/main.py
+++ b/regression/python/string-nondet-compare-fail/main.py
@@ -1,3 +1,3 @@
 
-s = nondet_string(4)
+s = nondet_str()
 assert s != "test"  # FALHA - pode ser "test"

--- a/regression/python/string-nondet-compare-fail/test.desc
+++ b/regression/python/string-nondet-compare-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 5 --unwind 6
+main\.py line 3 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-compare-success/main.py
+++ b/regression/python/string-nondet-compare-success/main.py
@@ -1,5 +1,5 @@
 
-s = nondet_string(4)
-assume(s != "test")
+s = nondet_str()
+__ESBMC_assume(s != "test")
 assert s != "test"
 # s pode ser qualquer coisa menos "test"

--- a/regression/python/string-nondet-compare-success/test.desc
+++ b/regression/python/string-nondet-compare-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 5 --unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-concat-fail/main.py
+++ b/regression/python/string-nondet-concat-fail/main.py
@@ -1,4 +1,4 @@
 
-s = nondet_string(3)
+s = nondet_str()
 result = s + "def"
 assert result == "abcdef"  # FALHA - s é não determinístico

--- a/regression/python/string-nondet-concat-fail/test.desc
+++ b/regression/python/string-nondet-concat-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 4 --unwind 5
+main\.py line 4 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-concat-success/main.py
+++ b/regression/python/string-nondet-concat-success/main.py
@@ -1,6 +1,6 @@
 
-s = nondet_string(3)
-assume(s == "abc")
+s = nondet_str()
+__ESBMC_assume(s == "abc")
 result = s + "def"
 assert result == "abcdef"
 assert len(result) == 6

--- a/regression/python/string-nondet-concat-success/test.desc
+++ b/regression/python/string-nondet-concat-success/test.desc
@@ -1,4 +1,4 @@
 FUTURE
 main.py
-
+--nondet-str-length 4 --unwind 5
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-double-fail/main.py
+++ b/regression/python/string-nondet-double-fail/main.py
@@ -1,4 +1,4 @@
 
-s1 = nondet_string(3)
-s2 = nondet_string(3)
+s1 = nondet_str()
+s2 = nondet_str()
 assert s1 == s2  # FALHA

--- a/regression/python/string-nondet-double-fail/test.desc
+++ b/regression/python/string-nondet-double-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 4 --unwind 5
+main\.py line 4 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-double-success/main.py
+++ b/regression/python/string-nondet-double-success/main.py
@@ -1,7 +1,7 @@
 
-s1 = nondet_string(3)
-s2 = nondet_string(3)
-assume(s1 == "abc")
-assume(s2 == "abc")
+s1 = nondet_str()
+s2 = nondet_str()
+__ESBMC_assume(s1 == "abc")
+__ESBMC_assume(s2 == "abc")
 assert s1 == s2
 assert s1 == "abc"

--- a/regression/python/string-nondet-double-success/test.desc
+++ b/regression/python/string-nondet-double-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 4 --unwind 5
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-empty-success/main.py
+++ b/regression/python/string-nondet-empty-success/main.py
@@ -1,5 +1,5 @@
 
-s = nondet_string(0)
+s = nondet_str()
 assert len(s) == 0
 assert s == ""
 result = s + "test"

--- a/regression/python/string-nondet-empty-success/test.desc
+++ b/regression/python/string-nondet-empty-success/test.desc
@@ -1,4 +1,4 @@
 FUTURE
 main.py
-
+--nondet-str-length 1 --unwind 2
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-in-embedded-null-empty-success/main.py
+++ b/regression/python/string-nondet-in-embedded-null-empty-success/main.py
@@ -1,5 +1,5 @@
-s = nondet_string(4)
-assume(s == "a\0b")
+s = nondet_str()
+__ESBMC_assume(s == "a\0b")
 
 assert "" in s
 assert "a\0b" in s

--- a/regression/python/string-nondet-in-embedded-null-empty-success/test.desc
+++ b/regression/python/string-nondet-in-embedded-null-empty-success/test.desc
@@ -1,4 +1,4 @@
 FUTURE
 main.py
-
+--nondet-str-length 5 --unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-in-embedded-null-longer-fail/main.py
+++ b/regression/python/string-nondet-in-embedded-null-longer-fail/main.py
@@ -1,4 +1,4 @@
-s = nondet_string(4)
-assume(s == "a\0b")
+s = nondet_str()
+__ESBMC_assume(s == "a\0b")
 
 assert "a\0bc" in s

--- a/regression/python/string-nondet-in-embedded-null-longer-fail/test.desc
+++ b/regression/python/string-nondet-in-embedded-null-longer-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 5 --unwind 6
+main\.py line 4 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-in-embedded-null-success/main.py
+++ b/regression/python/string-nondet-in-embedded-null-success/main.py
@@ -1,5 +1,5 @@
-s = nondet_string(4)
-assume(s == "a\0b")
+s = nondet_str()
+__ESBMC_assume(s == "a\0b")
 
 assert "\0b" in s
 assert "a\0" in s

--- a/regression/python/string-nondet-in-embedded-null-success/test.desc
+++ b/regression/python/string-nondet-in-embedded-null-success/test.desc
@@ -1,4 +1,4 @@
 FUTURE
 main.py
-
+--nondet-str-length 5 --unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-in-fail/main.py
+++ b/regression/python/string-nondet-in-fail/main.py
@@ -1,3 +1,3 @@
 
-s = nondet_string(10)
+s = nondet_str()
 assert "test" in s  # FALHA - não sabemos o conteúdo

--- a/regression/python/string-nondet-in-fail/test.desc
+++ b/regression/python/string-nondet-in-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 11 --unwind 12
+main\.py line 3 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-in-success/main.py
+++ b/regression/python/string-nondet-in-success/main.py
@@ -1,6 +1,6 @@
 
-s = nondet_string(11)
-assume(s == "hello world")
+s = nondet_str()
+__ESBMC_assume(s == "hello world")
 assert "world" in s
 assert "hello" in s
 assert "xyz" not in s

--- a/regression/python/string-nondet-in-success/test.desc
+++ b/regression/python/string-nondet-in-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 12 --unwind 13
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-index-fail/main.py
+++ b/regression/python/string-nondet-index-fail/main.py
@@ -1,4 +1,4 @@
 
-s = nondet_string(5)
+s = nondet_str()
 c = s[0]
 assert c == "h"  # FALHA - valor não determinístico

--- a/regression/python/string-nondet-index-fail/test.desc
+++ b/regression/python/string-nondet-index-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 6 --unwind 7
+main\.py line 4 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-index-success/main.py
+++ b/regression/python/string-nondet-index-success/main.py
@@ -1,6 +1,6 @@
 
-s = nondet_string(5)
-assume(s == "hello")
+s = nondet_str()
+__ESBMC_assume(s == "hello")
 assert s[0] == "h"
 assert s[1] == "e"
 assert s[-1] == "o"

--- a/regression/python/string-nondet-index-success/test.desc
+++ b/regression/python/string-nondet-index-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 6 --unwind 7
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-length-success/main.py
+++ b/regression/python/string-nondet-length-success/main.py
@@ -1,3 +1,4 @@
 
-s = nondet_string(10)
+s = nondet_str()
+__ESBMC_assume(len(s) == 10)
 assert len(s) == 10

--- a/regression/python/string-nondet-length-success/test.desc
+++ b/regression/python/string-nondet-length-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 11 --unwind 12
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-methods-fail/main.py
+++ b/regression/python/string-nondet-methods-fail/main.py
@@ -1,4 +1,4 @@
 
-s = nondet_string(5)
+s = nondet_str()
 upper = s.upper()
 assert upper == "HELLO"  # FALHA

--- a/regression/python/string-nondet-methods-fail/test.desc
+++ b/regression/python/string-nondet-methods-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 6 --unwind 7
+main\.py line 4 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-methods-success/main.py
+++ b/regression/python/string-nondet-methods-success/main.py
@@ -1,6 +1,6 @@
 
-s = nondet_string(5)
-assume(s == "hello")
+s = nondet_str()
+__ESBMC_assume(s == "hello")
 upper = s.upper()
 assert upper == "HELLO"
 assert len(upper) == 5

--- a/regression/python/string-nondet-methods-success/test.desc
+++ b/regression/python/string-nondet-methods-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 6 --unwind 7
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-nondet-slice-fail/main.py
+++ b/regression/python/string-nondet-slice-fail/main.py
@@ -1,4 +1,4 @@
 
-s = nondet_string(6)
+s = nondet_str()
 sub = s[0:3]
 assert sub == "hel"  # FALHA - não sabemos o conteúdo

--- a/regression/python/string-nondet-slice-fail/test.desc
+++ b/regression/python/string-nondet-slice-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
-
+--nondet-str-length 7 --unwind 8
+main\.py line 4 column 0
 ^VERIFICATION FAILED$

--- a/regression/python/string-nondet-slice-success/main.py
+++ b/regression/python/string-nondet-slice-success/main.py
@@ -1,6 +1,6 @@
 
-s = nondet_string(6)
-assume(s == "Python")
+s = nondet_str()
+__ESBMC_assume(s == "Python")
 sub1 = s[0:3]
 assert sub1 == "Pyt"
 sub2 = s[3:6]

--- a/regression/python/string-nondet-slice-success/test.desc
+++ b/regression/python/string-nondet-slice-success/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.py
-
+--nondet-str-length 7 --unwind 8
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
nondet_string(n) was never implemented — every call collapsed to
assert(false), so six CORE *_fail tests passed for the wrong reason
(issue #6473). Standardize on nondet_str(): rewrite the 23 string-nondet
tests with explicit --nondet-str-length/--unwind flags, pin each *_fail
desc to the violated assertion's source line, and promote nine FUTURE
success tests verified non-vacuous to CORE; four stay FUTURE for
genuinely unsupported behaviors.

Fixes #6473