### PR TITLE
[util] Seam #member_name behind a typed irept accessor

### DIFF
--- a/docs/roadmap/irep2-migration.md
+++ b/docs/roadmap/irep2-migration.md
@@ -5279,13 +5279,17 @@ Two items, both sized and neither speculative:
    at 3 PRs (down from "multi-PR effort") on the finding that the
    usual-arithmetic-conversion engine already has native `expr2tc` overloads
    that `python_adjust` already calls.
-2. **V.2/W3 attribute carriage**, which V.1a and V.6 both depend on. Untouched;
-   the highest shared blast radius left in the program (`clang_cpp_adjust_expr`,
+2. **V.2/W3 attribute carriage**, which V.1a and V.6 both depend on. The
+   highest shared blast radius left in the program (`clang_cpp_adjust_expr`,
    `cpp_expr2string`, `goto2c/expr2c` serve C++ and Solidity too — and a fourth
    reader, `clang_cpp_adjust_code_gen`, that §V.2 does not name). Owner
    document: `docs/roadmap/scope-v2-w3-attribute-carriage.md`, which finds
    §V.2's prescribed design refuted by Part III's own Q-S1 argument and
-   recommends re-scoping.
+   re-scopes to Option D (encapsulate the raw writers; decline W3 removal on a
+   recorded rationale). **Step 1 of 3 has landed** — `#member_name` is seamed
+   end-to-end behind `irept::member_name()`. Solidity's writers and clang-c's
+   `#cpp_type` remain. Option D deliberately does **not** move bar #4, so V.1a
+   and V.6 stay blocked.
 
 V.5 is closed rather than pending — see its scope doc. With those recorded, the
 V-track has no undocumented residue: every remaining item has a named owner

--- a/docs/roadmap/scope-v2-w3-attribute-carriage.md
+++ b/docs/roadmap/scope-v2-w3-attribute-carriage.md
@@ -1,6 +1,6 @@
 # Scope — V.2 / W3 IREP2-native attribute carriage
 
-> **Status: not started, and this document recommends re-scoping before it is.**
+> **Status: re-scoped to Option D; step 1 of 3 landed (2026-07-31, §9).**
 > `docs/roadmap/irep2-migration.md` §V.7 lists V.2/W3 as one of two remaining
 > items — *"Untouched; the highest shared blast radius left in the program"* —
 > and V.1a and V.6 both depend on it. This scope re-grounds §V.2 against the
@@ -134,7 +134,7 @@ frontends that were never in scope:
 1. **clang-cpp `#member_name`** (`clang_cpp_convert.cpp`, `.h`) — 4 sites
    behind a typed accessor. Pairs with the single reader at
    `clang_cpp_adjust_code_gen.cpp:51,200`, so `#member_name` becomes fully
-   seamed end-to-end in one PR.
+   seamed end-to-end in one PR. **DONE — §9.**
 2. **Solidity `#cpp_type` + `#member_name`** — the sites Phase 3.1 skipped,
    plus the two `#sol_*` stragglers `irep2-migration.md` §14's correction names
    (`#sol_tuple_id`, `#sol_unchecked`).
@@ -181,3 +181,51 @@ transient type *values*, the same Q-S1 wall Part III hit — so the honest choic
 is the low-cost encapsulation pass that Parts III and IV both converged on,
 with W3 removal declined on a recorded rationale rather than left implicitly
 open.
+
+## 9. Option D step 1 — what landed (2026-07-31)
+
+`#member_name` is now seamed end-to-end: both clang-cpp writers
+(`clang_cpp_convert.cpp:2762,2831`), both readers
+(`clang_cpp_adjust_code_gen.cpp:51,200`), and the Python frontend's existing
+`type_utils` accessors all go through one place.
+
+**One shared seam, not one per frontend — a deliberate departure from §5.1.**
+The accessor is `irept::member_name()` / `member_name(val)` /
+`remove_member_name()`, keyed by an interned `a_member_name`, alongside the
+`irept::cformat()` pair that already treats this attribute family exactly this
+way (`irep.h:478`). Two reasons the shared form is strictly better here:
+
+- **The reader is shared.** `clang_cpp_adjust_code_gen` reads what clang-cpp,
+  Solidity *and* Python write. A per-frontend seam would still leave the key
+  literal in three writer headers plus the reader — four repoint-points for one
+  attribute, which is not what §5.1 was trying to buy.
+- **It matches the codebase's own convention**, so step 2 (Solidity) becomes
+  seven one-line call-site edits with no new accessor to design.
+
+After this step the only live `#member_name` key literal in the tree is
+`irep.cpp:508`. The remaining `git grep` hits in `src/clang-cpp-frontend` and
+`src/python-frontend` are comments.
+
+### 9.1 Gates
+
+| # | Result |
+|---|---|
+| G1 | **Discharged.** `--goto-functions-only` A/B against master over all 582 runnable `esbmc-cpp/cpp` tests: 2 raw divergences, both non-attributable — `ch19_1` embeds a wall-clock timestamp in a string literal, `cpp_sum_class` differs only in stdout/stderr interleaving of a progress line |
+| G2 | **Discharged** for `esbmc-cpp` (676/685; the 9 failures reproduce identically on the master binary) and `python` (375/375 on a stride-4 slice). `esbmc-solidity` is untouched by this step and is macOS-blocked — it rides CI |
+| G3 | Not applicable to this step: `cpp_expr2string` reads `#cpp_type`, not `#member_name` |
+| G4 | Not applicable: `goto2c/expr2c` reads `#cpp_type` |
+| G5 | **Discharged** for clang-cpp and Python (comments only). Solidity's 7 writers are step 2 |
+
+**Harness note for step 2.** Both A/B censuses on this track were first invalidated
+by randomized temp directories embedded in the GOTO dump, in four spellings —
+`esbmc.XXXX-`, `esbmc_XXXX-`, `esbmc-cpp-headers-`, `esbmc-headers-` — plus
+`esbmc-python-astgen-` on the Python side. Normalize the whole path segment
+(`s@/esbmc[-._][^/ ]*@/TMPD@g`), not individual prefixes, or the run reports
+~90 % false divergence.
+
+### 9.2 What this does not do
+
+Unchanged from §5.1's honest trade, restated because it is easy to lose: this
+does **not** remove W3. §V.1 bar #4 stays "no", and V.1a and V.6 stay blocked.
+What it buys is one repoint-point for `#member_name` if carriage is ever
+revisited — and §3's argument that it should not be is unaffected.

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -48,7 +48,7 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
 
   // get the class' type where this ctor is declared
   const symbolt *ctor_class_symb =
-    namespacet(context).lookup(ctor_type.get("#member_name"));
+    namespacet(context).lookup(ctor_type.member_name());
   assert(ctor_class_symb);
   // get the `components` vector from this class' type
   const struct_typet::componentst &components =
@@ -197,7 +197,7 @@ exprt clang_cpp_adjust::gen_vptr_init_rhs(
 
   // get the corresponding vtable variable symbol
   std::string vtable_var_id = comp.type().subtype().identifier().as_string() +
-                              "@" + ctor_type.get("#member_name").as_string();
+                              "@" + ctor_type.member_name().as_string();
   const symbolt *vtable_var_symb = namespacet(context).lookup(vtable_var_id);
   assert(vtable_var_symb);
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2759,7 +2759,7 @@ bool clang_cpp_convertert::annotate_class_field(
     return true;
   }
   std::string parent_class_id = tag_prefix + type.tag().as_string();
-  comp.type().set("#member_name", parent_class_id);
+  comp.type().member_name(parent_class_id);
 
   // set access in component
   if (annotate_class_field_access(field, comp))
@@ -2828,7 +2828,7 @@ bool clang_cpp_convertert::annotate_class_method(
   // versions don't).
   std::string parent_class_name, parent_class_id;
   get_decl_name(*cxxmdd.getParent(), parent_class_name, parent_class_id);
-  component_type.set("#member_name", parent_class_id);
+  component_type.member_name(parent_class_id);
 
   // annotate ctor and dtor
   if (is_ConstructorOrDestructor(cxxmdd))

--- a/src/python-frontend/type/type_utils.h
+++ b/src/python-frontend/type/type_utils.h
@@ -184,12 +184,12 @@ public:
 
   static void set_member_name(typet &t, const irep_idt &value)
   {
-    t.set("#member_name", value);
+    t.member_name(value);
   }
 
   static void remove_member_name(typet &t)
   {
-    t.remove("#member_name");
+    t.remove_member_name();
   }
 
   static bool is_char_type(const typet &t)

--- a/src/util/irep/irep.cpp
+++ b/src/util/irep/irep.cpp
@@ -505,6 +505,7 @@ const irep_idt irept::a_cmt_base_name = irep_idt("#base_name");
 const irep_idt irept::a_id_class = irep_idt("#id_class");
 const irep_idt irept::a_cmt_identifier = irep_idt("#identifier");
 const irep_idt irept::a_cformat = irep_idt("#cformat");
+const irep_idt irept::a_member_name = irep_idt("#member_name");
 const irep_idt irept::a_cmt_width = irep_idt("#width");
 const irep_idt irept::a_axiom = irep_idt("axiom");
 const irep_idt irept::a_cmt_constant = irep_idt("#constant");

--- a/src/util/irep/irep.h
+++ b/src/util/irep/irep.h
@@ -480,6 +480,16 @@ public:
     return get(a_cformat);
   }
 
+  /// Owning class tag of a member function type, e.g. `tag-MyClass`.
+  /// Written by the clang-cpp, Solidity and Python frontends; read by
+  /// clang_cpp_adjust_code_gen to locate a constructor's class symbol.
+  /// Carriage stays on the legacy irep — see
+  /// docs/roadmap/scope-v2-w3-attribute-carriage.md.
+  inline const irep_idt &member_name() const
+  {
+    return get(a_member_name);
+  }
+
   inline const irep_idt &cmt_width() const
   {
     return get(a_cmt_width);
@@ -718,6 +728,16 @@ public:
   inline void cformat(const irep_idt val)
   {
     set(a_cformat, val);
+  }
+
+  inline void member_name(const irep_idt val)
+  {
+    set(a_member_name, val);
+  }
+
+  inline void remove_member_name()
+  {
+    remove(a_member_name);
   }
 
   inline void flavor(const irep_idt val)
@@ -1252,6 +1272,7 @@ public:
   static const irep_idt a_pretty_name, a_property, a_size, a_integer_bits, a_to;
   static const irep_idt a_failed_symbol, a_dynamic, a_cmt_base_name, a_id_class;
   static const irep_idt a_cmt_identifier, a_cformat, a_cmt_width, a_axiom;
+  static const irep_idt a_member_name;
   static const irep_idt a_cmt_constant, a_default;
   static const irep_idt a_ellipsis, a_explicit, a_file_local;
   static const irep_idt a_hex_or_oct, a_hide, a_implicit, a_incomplete;


### PR DESCRIPTION
Option D step 1 of `docs/roadmap/scope-v2-w3-attribute-carriage.md`: route the
clang-cpp writers and both readers, plus the Python frontend's existing
`type_utils` accessors, through `irept::member_name()` — alongside the
`cformat()` pair that already treats this attribute family the same way.

Mechanical no-op: a `--goto-functions-only` A/B against master over all 582
runnable `esbmc-cpp/cpp` tests shows no attributable divergence. This does not
remove W3 — §V.1 bar #4 is unmoved, and Solidity's writers are step 2.
