### PR TITLE
[om] Construct vector elements into raw storage instead of assigning

### DIFF
--- a/regression/esbmc-cpp/vector/github_6368/main.cpp
+++ b/regression/esbmc-cpp/vector/github_6368/main.cpp
@@ -1,0 +1,19 @@
+// Storing a non-trivial element must construct into the raw slot, not assign
+// into it: assignment runs the element's operator=, which frees the garbage
+// pointer an uninitialised slot holds.
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<std::vector<int>> v;
+  std::vector<int> row;
+  row.push_back(5);
+
+  v.push_back(row);
+
+  assert(v.size() == 1);
+  assert(v[0].size() == 1);
+  assert(v[0][0] == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/github_6368/test.desc
+++ b/regression/esbmc-cpp/vector/github_6368/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 main.cpp
---unwind 1
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/github_6368_fail/main.cpp
+++ b/regression/esbmc-cpp/vector/github_6368_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative twin of github_6368: the element must actually be stored, so a
+// wrong-value assertion has to be reported rather than passing vacuously.
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<std::vector<int>> v;
+  std::vector<int> row;
+  row.push_back(5);
+
+  v.push_back(row);
+
+  assert(v[0][0] == 6);
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/github_6368_fail/test.desc
+++ b/regression/esbmc-cpp/vector/github_6368_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/vector/github_6368_insert/main.cpp
+++ b/regression/esbmc-cpp/vector/github_6368_insert/main.cpp
@@ -1,0 +1,21 @@
+// The live/raw slot boundary is crossed by insert's shift as well as by
+// push_back, so the shift must construct into the one-past-the-end slot.
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<std::vector<int>> v;
+  std::vector<int> a;
+  a.push_back(7);
+  std::vector<int> b;
+  b.push_back(9);
+
+  v.push_back(a);
+  v.insert(v.begin(), b);
+
+  assert(v.size() == 2);
+  assert(v[0][0] == 9);
+  assert(v[1][0] == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/github_6368_insert/test.desc
+++ b/regression/esbmc-cpp/vector/github_6368_insert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -360,7 +360,8 @@ public:
     int n = 0;
     for (; t1 != t2; t1++)
     {
-      buf[n++] = *t1;
+      __construct_at(buf + n, *t1);
+      n++;
     }
     _size = n;
     _capacity = _size;
@@ -390,7 +391,7 @@ public:
     buf = static_cast<T *>(malloc(sizeof(T) * count));
     __ESBMC_assume(buf);
     for (int i = 0; i < count; i++)
-      buf[i] = *t++;
+      __construct_at(buf + i, *t++);
 
     _size = count;
     _capacity = _size;
@@ -402,7 +403,7 @@ public:
     __ESBMC_assume(buf);
     _size = n;
     for (int i = 0; i < n; i++)
-      buf[i] = x;
+      __construct_at(buf + i, x);
     _capacity = n;
   }
 
@@ -413,7 +414,7 @@ public:
     __ESBMC_assume(buf);
     _size = x._size;
     for (int i = 0; i < _size; i++)
-      buf[i] = x.buf[i];
+      __construct_at(buf + i, x.buf[i]);
     _capacity = _size;
   }
 
@@ -425,7 +426,7 @@ public:
     __ESBMC_assume(buf);
     _size = init.size();
     for (int i = 0; i < _size; i++)
-      buf[i] = *(init.begin() + i);
+      __construct_at(buf + i, *(init.begin() + i));
     _capacity = _size;
   }
 #endif
@@ -439,7 +440,7 @@ public:
       __ESBMC_assume(buf);
       _size = x._size;
       for (int i = 0; i < _size; i++)
-        buf[i] = x.buf[i];
+        __construct_at(buf + i, x.buf[i]);
       _capacity = _size;
     }
     return *this;
@@ -447,11 +448,13 @@ public:
 
   void assign(size_type n, const T &u)
   {
+    // realloc preserves the existing objects, so [0, min(_size, n)) stays live.
+    size_type live_end = _size < n ? _size : n;
     _size = n;
     buf = static_cast<T *>(realloc(buf, sizeof(T) * n));
     __ESBMC_assume(buf);
     for (int i = 0; i < n; i++)
-      buf[i] = u;
+      __put(i, u, live_end);
     _capacity = _size;
   }
 
@@ -468,7 +471,8 @@ public:
     int n = 0;
     for (; t1 != t2; t1++)
     {
-      buf[n++] = *t1;
+      __construct_at(buf + n, *t1);
+      n++;
     }
     _size = n;
     _capacity = _size;
@@ -489,17 +493,19 @@ public:
     }
 
     // Ensure we have enough capacity
+    size_type live_end = _size;
     if (count > _capacity)
     {
       free(buf);
       buf = static_cast<T *>(malloc(sizeof(T) * count));
       __ESBMC_assume(buf);
       _capacity = count;
+      live_end = 0;
     }
 
     // Copy elements
     for (size_type i = 0; i < count; i++)
-      buf[i] = t11[i];
+      __put(i, t11[i], live_end);
 
     _size = count;
   }
@@ -656,7 +662,7 @@ public:
 
     // Initialize new elements with the provided value
     for (unsigned int n = _size; n < sz; n++)
-      buf[n] = t;
+      __construct_at(buf + n, t);
 
     _size = sz;
   }
@@ -681,7 +687,7 @@ public:
 
       // copy over existing values
       for (int i = 0; i < _size; i++)
-        new_buf[i] = buf[i];
+        __construct_at(new_buf + i, buf[i]);
 
       free(buf); // free old memory
       buf = new_buf;
@@ -775,8 +781,8 @@ public:
       reserve(new_capacity);
     }
 
-    buf[_size] = x; // write element into slot
-    _size++;        // now bump size
+    __construct_at(buf + _size, x); // the slot is raw storage, so construct
+    _size++;                        // now bump size
   }
 
   void pop_back()
@@ -816,7 +822,7 @@ public:
 
       // Copy existing elements
       for (size_type i = 0; i < _size; i++)
-        new_buf[i] = buf[i];
+        __construct_at(new_buf + i, buf[i]);
 
       free(buf);
       buf = new_buf;
@@ -826,11 +832,12 @@ public:
     // one place. Backwards copy to avoid overwriting existing data.
     for (int i = (int)_size - 1; i >= (int)at; i--)
     {
-      buf[i + 1] = buf[i];
+      __put(i + 1, buf[i], _size);
     }
 
-    // And now install the new value.
-    buf[at] = x;
+    // And now install the new value: slot at is live unless it is the one
+    // past the last element, which the shift above left raw.
+    __put(at, x, _size);
     _size++;
     return buf + at;
   }
@@ -855,7 +862,7 @@ public:
 
     for (size_type i = 0; i < count; i++)
     {
-      temp_array[i] = *(first + i);
+      __construct_at(temp_array + i, *(first + i));
     }
 
     // Insert from the temporary array
@@ -889,7 +896,7 @@ public:
 
       // Copy existing elements
       for (size_type i = 0; i < _size; i++)
-        new_buf[i] = buf[i];
+        __construct_at(new_buf + i, buf[i]);
 
       free(buf);
       buf = new_buf;
@@ -900,12 +907,12 @@ public:
     // We need to move elements from [at, _size) to [at+count, _size+count)
     for (int i = (int)_size - 1; i >= (int)at; i--)
     {
-      buf[i + count] = buf[i];
+      __put(i + count, buf[i], _size);
     }
 
     // Insert the new values
     for (size_type i = 0; i < count; i++)
-      buf[at + i] = value;
+      __put(at + i, value, _size);
 
     _size += count;
     return buf + at;
@@ -986,6 +993,25 @@ private:
     return T();
   }
 
+  // Slots [0, _size) hold live objects; [_size, _capacity) is raw storage.
+  // A raw slot must be written by construction, never by assignment: T's
+  // operator= reads the destination as a live object, and for a T that owns
+  // heap memory (a nested container) it frees the garbage pointer the
+  // uninitialised slot happens to hold (issue #6368).
+  void __construct_at(T *p, const T &x)
+  {
+    new (static_cast<void *>(p)) T(x);
+  }
+
+  // Write x into slot i for a range that straddles the live/raw boundary.
+  void __put(size_type i, const T &x, size_type live_end)
+  {
+    if (i < live_end)
+      buf[i] = x;
+    else
+      __construct_at(buf + i, x);
+  }
+
   // Value-initialise slots [lo, hi) when T is default-constructible.
   // The non-default-constructible overload is selected for types whose
   // only constructor is user-provided (issue #2040), and is a no-op so
@@ -995,7 +1021,7 @@ private:
   __value_init_range(size_type lo, size_type hi)
   {
     for (size_type i = lo; i < hi; ++i)
-      buf[i] = U();
+      new (static_cast<void *>(buf + i)) U();
   }
   template <typename U = T>
   typename std::enable_if<!std::is_constructible<U>::value>::type


### PR DESCRIPTION
Fixes #6368. Unblocked by #6506, which fixed the placement-new false positive (#6464) that made this approach unshippable when the issue was last investigated.

## Root cause

`<vector>` allocated its backing store with `malloc` and wrote elements by assignment (`buf[_size] = x`). Assignment runs `T::operator=` against an uninitialised slot; for a `T` that owns heap memory that operator begins `free(buf)`, freeing the garbage pointer the raw slot holds. Hence `dereference failure: invalidated dynamic object` on `std::vector<std::vector<int>>`.

## Solution

Track the element-lifetime boundary: `[0, _size)` holds live objects, `[_size, _capacity)` is raw. Writes past the size construct via placement-new (`__construct_at`); writes within the live range keep assigning, so live elements are not leaked. Ranges that straddle the boundary — `insert`'s shift, `assign`'s realloc path — go through `__put(i, x, live_end)`. All write sites were audited.

`deque` and `list` were audited as the issue suggested: both use fixed arrays of live objects (`T buf[DEQUE_CAPACITY]`, `node _pool[]`) rather than raw storage, so this defect does not apply to them.

## Tests

`github_6368` (issue reproducer), `github_6368_fail` (negative twin), and `github_6368_insert` (insert's shift crossing the boundary). `github_2284_4` expected `FAILED` while pinning this very false positive — its program is clean under `clang++ -fsanitize=address,undefined`, so its expectation is corrected to `SUCCESSFUL`.

## Validation

`esbmc-cpp` tests are `THOROUGH`, which ctest skips on macOS, so the suites were run directly against separately-built master and patched binaries (confirmed to differ and to discriminate on the reproducer): `vector` 160/160 and `algorithm` 149/149 verdict-identical to master; the 35 vector-using tests across `cpp`/`deque`/`list`/`string`/`stack`/`bug_fixes`/`template`/`try_catch` all pass, with `github_2284_4` the only verdict change.

Known limitation: nested vectors do not converge under unbounded BMC (the copy-constructor loop unwinds indefinitely); bounded and incremental runs are fine. This was previously unreachable, since the nested case failed immediately.
