### PR TITLE
[test] Pin the unconstructed member-array element destruction

### DIFF
--- a/regression/esbmc-cpp/cpp/member_array_ctor_dtor_symmetry/main.cpp
+++ b/regression/esbmc-cpp/cpp/member_array_ctor_dtor_symmetry/main.cpp
@@ -1,0 +1,31 @@
+// Every element of a class-typed member array must be constructed before it is
+// destroyed. clang_cpp_convert.cpp bounds per-element construction at 8
+// elements but leaves destruction unbounded, so elements 8.. are destroyed
+// without ever having been constructed.
+#include <cassert>
+
+int marker;
+
+struct E
+{
+  int *p;
+  E()
+  {
+    p = &marker;
+  }
+  ~E()
+  {
+    assert(p == &marker);
+  }
+};
+
+struct H
+{
+  E buf[20];
+};
+
+int main()
+{
+  H h;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/member_array_ctor_dtor_symmetry/test.desc
+++ b/regression/esbmc-cpp/cpp/member_array_ctor_dtor_symmetry/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
See #6574. Adds only a pinning test — no behaviour change.

## Root cause

`clang_cpp_convert.cpp:2202` bounds per-element construction of class-typed member arrays at `max_unroll = 8`. Above the bound the fallback emits a single `array = ctor()`, which lowers to `ctor(&array)` and constructs element 0 only. Destruction is not bounded the same way, so elements 8.. are destroyed with uninitialised members.

The bound was a deliberate performance decision in #5877, which fixed the ≤8 case and recorded loop-based construction as future work. Choosing between the fix options is a maintainer trade-off (see #6574), so this PR only pins the defect.

## Test

`member_array_ctor_dtor_symmetry` uses a destructor that asserts its own object was constructed, so the failure is attributed at the destructor rather than surfacing indirectly as an invalid free. Verified to fail on master today (`VERIFICATION FAILED`) and clean under `clang++ -fsanitize=address,undefined`. Marked `KNOWNBUG`; it flips to `CORE` when #6574 is fixed.
