### PR TITLE
[c++] Bind the operands of a defaulted friend comparison

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6578/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578/main.cpp
@@ -1,0 +1,30 @@
+// A defaulted comparison declared as a friend takes both operands as
+// parameters. Leaving them unnamed made the synthesised body compare unbound
+// operands, so every == returned true.
+#include <cassert>
+
+struct P
+{
+  int v;
+  friend bool operator==(P, P) = default;
+};
+
+struct Q
+{
+  int a;
+  char b;
+  bool c;
+  friend bool operator==(Q, Q) = default;
+};
+
+int main()
+{
+  P a{1}, b{2};
+  assert(a == a);
+  assert(!(a == b));
+
+  Q x{1, 'z', true}, y{1, 'z', true}, z{1, 'z', false};
+  assert(x == y);
+  assert(!(x == z));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6578_compare/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578_compare/main.cpp
@@ -1,0 +1,12 @@
+// The bundled comparison categories declare the defaulted friend form, so
+// equality between category values exercised the same defect.
+#include <compare>
+#include <cassert>
+
+int main()
+{
+  assert(std::strong_ordering::less == std::strong_ordering::less);
+  assert(!(std::strong_ordering::less == std::strong_ordering::greater));
+  assert(!(std::partial_ordering::unordered == std::partial_ordering::less));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578_compare/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578_compare/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6578_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative twin: the operands really are compared, so an equality that is
+// false must be reported rather than passing vacuously.
+#include <cassert>
+
+struct P
+{
+  int v;
+  friend bool operator==(P, P) = default;
+};
+
+int main()
+{
+  P a{1}, b{2};
+  assert(a == b);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6578_spaceship/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578_spaceship/main.cpp
@@ -1,0 +1,22 @@
+// The same unbound-operand defect reached defaulted operator<=> declared as a
+// friend, which aborted in member2t rather than returning a wrong answer.
+#include <compare>
+#include <cassert>
+
+struct S
+{
+  int v;
+  friend auto operator<=>(S, S) = default;
+  friend bool operator==(S, S) = default;
+};
+
+int main()
+{
+  S a{1}, b{2};
+  assert((a <=> b) < 0);
+  assert((b <=> a) > 0);
+  assert((a <=> a) == 0);
+  assert(a < b);
+  assert(!(b < a));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578_spaceship/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578_spaceship/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2549,28 +2549,39 @@ void clang_cpp_convertert::name_param_and_continue(
   assert(id.empty() && name.empty());
 
   const clang::DeclContext *dcxt = pd.getParentFunctionOrMethod();
-  if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(dcxt))
+  /* Every implicit or explicitly-defaulted function gets a compiler-synthesised
+   * body that refers to its parameter, so the parameter needs a name even
+   * though the declaration leaves it unnamed. Testing isImplicit() alone left
+   * `= default` assignment and comparison operators — which are defaulted but
+   * not implicit — with an unnamed parameter, so their synthesised body read
+   * from an unbound operand (github #4377). Matching CXXMethodDecl alone left
+   * the same hole for a defaulted comparison declared as a friend, which is a
+   * plain FunctionDecl taking both operands as parameters (github #6578). */
+  const auto *fd = llvm::dyn_cast_or_null<clang::FunctionDecl>(dcxt);
+  if (!fd || !(fd->isImplicit() || fd->isDefaulted()))
+    return;
+
+  get_decl_name(*fd, name, id);
+
+  // name would be just `ref` and id would be "<cpyctor_id>::ref"
+  name = name + "::" + constref_suffix;
+  id = id + "::" + constref_suffix;
+
+  /* A defaulted friend comparison takes two unnamed parameters, which the
+   * suffix above would give the same symbol; disambiguate by position, as the
+   * named-parameter path in get_decl_name already does. */
+  if (fd->getNumParams() > 1)
   {
-    /* Every implicit or explicitly-defaulted method gets a compiler-synthesised
-     * body that refers to its parameter, so the parameter needs a name even
-     * though the declaration leaves it unnamed. Testing isImplicit() alone left
-     * `= default` assignment and comparison operators — which are defaulted but
-     * not implicit — with an unnamed parameter, so their synthesised body read
-     * from an unbound operand (github #4377). */
-    if (md->isImplicit() || md->isDefaulted())
-    {
-      get_decl_name(*md, name, id);
-
-      // name would be just `ref` and id would be "<cpyctor_id>::ref"
-      name = name + "::" + constref_suffix;
-      id = id + "::" + constref_suffix;
-
-      // sync param name
-      param.cmt_base_name(name);
-      param.identifier(id);
-      param.name(name);
-    }
+    const std::string index_suffix =
+      "::" + std::to_string(pd.getFunctionScopeIndex());
+    name += index_suffix;
+    id += index_suffix;
   }
+
+  // sync param name
+  param.cmt_base_name(name);
+  param.identifier(id);
+  param.name(name);
 }
 
 template <typename SpecializationDecl>


### PR DESCRIPTION
Fixes #6578.

## Root cause

`name_param_and_continue` names the unnamed parameters of implicit and defaulted functions so their compiler-synthesised bodies have something to bind to. It matched only `llvm::dyn_cast<clang::CXXMethodDecl>`.

A defaulted comparison declared as a **friend** is a plain `FunctionDecl` that takes *both* operands as parameters, so it never matched and both operands were left unbound. The synthesised body came out as

```
operator== (c:@F@operator==#$@S@P#S0_#):
        RETURN: .v == .v
```

— two member accesses with no base object, which is trivially true. Hence `a == b` for distinct values returned true with no diagnostic. The three-way form did not even get that far: it aborted in `member2t` (`irep2_expr.h:1569`).

This is the case left over from #6196, which fixed the `CXXMethodDecl` half of the same defect.

## Solution

Match `FunctionDecl` — which also covers `CXXMethodDecl`, so the path fixed by #6196 is unchanged — and disambiguate by `getFunctionScopeIndex()` when the function has more than one parameter, mirroring what the named-parameter path in `get_decl_name` already does for the same reason. Single-parameter cases (copy constructor, copy assignment) keep their existing symbol names exactly, since the index suffix is applied only when `getNumParams() > 1`.

The body now binds correctly:

```
        RETURN: operator==::ref::0.v == operator==::ref::1.v
```

## Tests

Four tests, each verified to discriminate against master:

| test | master | patched |
|---|---|---|
| `github_6578` — by-value friend `==`, one- and three-member structs | `member2t` abort | SUCCESSFUL |
| `github_6578_fail` — negative twin | SUCCESSFUL (wrong) | FAILED |
| `github_6578_compare` — `<compare>` category equality | FAILED | SUCCESSFUL |
| `github_6578_spaceship` — defaulted friend `operator<=>` | `member2t` abort | SUCCESSFUL |

The `<=>` case was not in the issue: the same unbound-operand defect reaches defaulted three-way comparison, where it aborts rather than returning a wrong answer. It is covered here because it is the same root cause. All four programs are clean under host `clang++ -std=c++20`, and multi-member memberwise equality (differing only in the last member) agrees with clang.

## Validation

`esbmc-cpp` tests are `THOROUGH`, which ctest skips on macOS, so suites were run directly against separately-built master and patched binaries (confirmed to differ and to discriminate on the reproducer).

**988 tests, zero differences**: `cpp` 688, `try_catch` 172, `inheritance` 85, `template` 29, `destructors` 14.

## Follow-up

This unblocks the remaining `<compare>` work for #4377: floating-point `<=>` additionally needs `std::partial_ordering` collapsed to a single member (clang rejects the two-member form) and an `unordered` branch in the `cmp_three_way` SMT lowering, which currently reports NaN as `greater`. Held on a separate branch pending this fix, since landing it earlier would have traded a parse error for a silent wrong result.
