### PR TITLE
[c++] Support floating-point three-way comparison

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4377_float_spaceship/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_float_spaceship/main.cpp
@@ -1,0 +1,36 @@
+// Floating-point <=> yields std::partial_ordering, whose fourth result is
+// `unordered` when either operand is NaN ([expr.spaceship]/4).
+#include <compare>
+#include <cassert>
+
+int main()
+{
+  double a = 1.0, b = 2.0, c = 1.0;
+  double nan = 0.0 / 0.0;
+
+  auto lt = a <=> b;
+  assert(lt < 0 && !(lt > 0) && !(lt == 0));
+
+  auto eq = a <=> c;
+  assert(eq == 0 && eq <= 0 && eq >= 0);
+
+  auto gt = b <=> a;
+  assert(gt > 0 && !(gt < 0));
+
+  // every relational comparison against 0 is false for unordered
+  auto un = nan <=> a;
+  assert(!(un < 0));
+  assert(!(un > 0));
+  assert(!(un == 0));
+  assert(!(un <= 0));
+  assert(!(un >= 0));
+  assert(un == std::partial_ordering::unordered);
+  assert(!(un == std::partial_ordering::less));
+
+  // category conversions
+  std::partial_ordering ps = std::strong_ordering::less;
+  assert(ps < 0);
+  std::partial_ordering pw = std::weak_ordering::greater;
+  assert(pw > 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_float_spaceship/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_float_spaceship/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_float_spaceship_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_float_spaceship_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative twin: NaN <=> x is unordered, so claiming it is greater must be
+// reported. Guards against the lowering falling through to `greater`.
+#include <compare>
+#include <cassert>
+
+int main()
+{
+  double a = 1.0;
+  double nan = 0.0 / 0.0;
+  auto un = nan <=> a;
+  assert(un > 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_float_spaceship_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_float_spaceship_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6578/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578/main.cpp
@@ -1,0 +1,30 @@
+// A defaulted comparison declared as a friend takes both operands as
+// parameters. Leaving them unnamed made the synthesised body compare unbound
+// operands, so every == returned true.
+#include <cassert>
+
+struct P
+{
+  int v;
+  friend bool operator==(P, P) = default;
+};
+
+struct Q
+{
+  int a;
+  char b;
+  bool c;
+  friend bool operator==(Q, Q) = default;
+};
+
+int main()
+{
+  P a{1}, b{2};
+  assert(a == a);
+  assert(!(a == b));
+
+  Q x{1, 'z', true}, y{1, 'z', true}, z{1, 'z', false};
+  assert(x == y);
+  assert(!(x == z));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6578_compare/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578_compare/main.cpp
@@ -1,0 +1,12 @@
+// The bundled comparison categories declare the defaulted friend form, so
+// equality between category values exercised the same defect.
+#include <compare>
+#include <cassert>
+
+int main()
+{
+  assert(std::strong_ordering::less == std::strong_ordering::less);
+  assert(!(std::strong_ordering::less == std::strong_ordering::greater));
+  assert(!(std::partial_ordering::unordered == std::partial_ordering::less));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578_compare/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578_compare/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6578_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative twin: the operands really are compared, so an equality that is
+// false must be reported rather than passing vacuously.
+#include <cassert>
+
+struct P
+{
+  int v;
+  friend bool operator==(P, P) = default;
+};
+
+int main()
+{
+  P a{1}, b{2};
+  assert(a == b);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6578_spaceship/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6578_spaceship/main.cpp
@@ -1,0 +1,22 @@
+// The same unbound-operand defect reached defaulted operator<=> declared as a
+// friend, which aborted in member2t rather than returning a wrong answer.
+#include <compare>
+#include <cassert>
+
+struct S
+{
+  int v;
+  friend auto operator<=>(S, S) = default;
+  friend bool operator==(S, S) = default;
+};
+
+int main()
+{
+  S a{1}, b{2};
+  assert((a <=> b) < 0);
+  assert((b <=> a) > 0);
+  assert((a <=> a) == 0);
+  assert(a < b);
+  assert(!(b < a));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6578_spaceship/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6578_spaceship/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2549,28 +2549,39 @@ void clang_cpp_convertert::name_param_and_continue(
   assert(id.empty() && name.empty());
 
   const clang::DeclContext *dcxt = pd.getParentFunctionOrMethod();
-  if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(dcxt))
+  /* Every implicit or explicitly-defaulted function gets a compiler-synthesised
+   * body that refers to its parameter, so the parameter needs a name even
+   * though the declaration leaves it unnamed. Testing isImplicit() alone left
+   * `= default` assignment and comparison operators — which are defaulted but
+   * not implicit — with an unnamed parameter, so their synthesised body read
+   * from an unbound operand (github #4377). Matching CXXMethodDecl alone left
+   * the same hole for a defaulted comparison declared as a friend, which is a
+   * plain FunctionDecl taking both operands as parameters (github #6578). */
+  const auto *fd = llvm::dyn_cast_or_null<clang::FunctionDecl>(dcxt);
+  if (!fd || !(fd->isImplicit() || fd->isDefaulted()))
+    return;
+
+  get_decl_name(*fd, name, id);
+
+  // name would be just `ref` and id would be "<cpyctor_id>::ref"
+  name = name + "::" + constref_suffix;
+  id = id + "::" + constref_suffix;
+
+  /* A defaulted friend comparison takes two unnamed parameters, which the
+   * suffix above would give the same symbol; disambiguate by position, as the
+   * named-parameter path in get_decl_name already does. */
+  if (fd->getNumParams() > 1)
   {
-    /* Every implicit or explicitly-defaulted method gets a compiler-synthesised
-     * body that refers to its parameter, so the parameter needs a name even
-     * though the declaration leaves it unnamed. Testing isImplicit() alone left
-     * `= default` assignment and comparison operators — which are defaulted but
-     * not implicit — with an unnamed parameter, so their synthesised body read
-     * from an unbound operand (github #4377). */
-    if (md->isImplicit() || md->isDefaulted())
-    {
-      get_decl_name(*md, name, id);
-
-      // name would be just `ref` and id would be "<cpyctor_id>::ref"
-      name = name + "::" + constref_suffix;
-      id = id + "::" + constref_suffix;
-
-      // sync param name
-      param.cmt_base_name(name);
-      param.identifier(id);
-      param.name(name);
-    }
+    const std::string index_suffix =
+      "::" + std::to_string(pd.getFunctionScopeIndex());
+    name += index_suffix;
+    id += index_suffix;
   }
+
+  // sync param name
+  param.cmt_base_name(name);
+  param.identifier(id);
+  param.name(name);
 }
 
 template <typename SpecializationDecl>

--- a/src/cpp/library/compare
+++ b/src/cpp/library/compare
@@ -35,12 +35,22 @@ struct __zero_cmp
 
 class partial_ordering
 {
-  signed char __value_;
-  bool __is_ordered_;
+  // Clang's comparison-category hooks require exactly one member of integral
+  // type, so "unordered" is folded into the value instead of being carried in
+  // a second flag; with two members the compiler rejects every floating-point
+  // <=> with "the type does not have the expected form". -127 is the spelling
+  // libc++ uses.
+  static constexpr signed char __unordered_value_ = -127;
 
-  constexpr explicit partial_ordering(signed char v, bool o) noexcept
-    : __value_(v), __is_ordered_(o)
+  signed char __value_;
+
+  constexpr explicit partial_ordering(signed char v) noexcept : __value_(v)
   {
+  }
+
+  constexpr bool __is_ordered() const noexcept
+  {
+    return __value_ != __unordered_value_;
   }
 
 public:
@@ -55,47 +65,47 @@ public:
   friend constexpr bool
   operator==(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
   {
-    return v.__is_ordered_ && v.__value_ == 0;
+    return v.__is_ordered() && v.__value_ == 0;
   }
   friend constexpr bool
   operator<(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
   {
-    return v.__is_ordered_ && v.__value_ < 0;
+    return v.__is_ordered() && v.__value_ < 0;
   }
   friend constexpr bool
   operator>(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
   {
-    return v.__is_ordered_ && v.__value_ > 0;
+    return v.__is_ordered() && v.__value_ > 0;
   }
   friend constexpr bool
   operator<=(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
   {
-    return v.__is_ordered_ && v.__value_ <= 0;
+    return v.__is_ordered() && v.__value_ <= 0;
   }
   friend constexpr bool
   operator>=(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
   {
-    return v.__is_ordered_ && v.__value_ >= 0;
+    return v.__is_ordered() && v.__value_ >= 0;
   }
   friend constexpr bool
   operator<(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
   {
-    return v.__is_ordered_ && 0 < v.__value_;
+    return v.__is_ordered() && 0 < v.__value_;
   }
   friend constexpr bool
   operator>(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
   {
-    return v.__is_ordered_ && 0 > v.__value_;
+    return v.__is_ordered() && 0 > v.__value_;
   }
   friend constexpr bool
   operator<=(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
   {
-    return v.__is_ordered_ && 0 <= v.__value_;
+    return v.__is_ordered() && 0 <= v.__value_;
   }
   friend constexpr bool
   operator>=(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
   {
-    return v.__is_ordered_ && 0 >= v.__value_;
+    return v.__is_ordered() && 0 >= v.__value_;
   }
 
   friend constexpr partial_ordering
@@ -106,13 +116,14 @@ public:
   friend constexpr partial_ordering
   operator<=>(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
   {
-    return partial_ordering(-v.__value_, v.__is_ordered_);
+    return v.__is_ordered() ? partial_ordering(-v.__value_) : v;
   }
 };
-inline constexpr partial_ordering partial_ordering::less{-1, true};
-inline constexpr partial_ordering partial_ordering::equivalent{0, true};
-inline constexpr partial_ordering partial_ordering::greater{1, true};
-inline constexpr partial_ordering partial_ordering::unordered{0, false};
+inline constexpr partial_ordering partial_ordering::less{-1};
+inline constexpr partial_ordering partial_ordering::equivalent{0};
+inline constexpr partial_ordering partial_ordering::greater{1};
+inline constexpr partial_ordering partial_ordering::unordered{
+  partial_ordering::__unordered_value_};
 
 class weak_ordering
 {

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -1478,6 +1478,24 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
     expr2tc inner = if2tc(
       cw.type, eq, make_cmp_value(cw.type, 0), make_cmp_value(cw.type, 1));
     expr2tc outer = if2tc(cw.type, lt, make_cmp_value(cw.type, -1), inner);
+
+    // Floating-point operands yield std::partial_ordering, whose fourth
+    // result is `unordered` when either operand is NaN ([expr.spaceship]/4).
+    // Without this the NaN case falls through the chain above and is reported
+    // as `greater`. The sentinel must agree with std::partial_ordering's
+    // representation in src/cpp/library/compare, which follows libc++.
+    if (is_floatbv_type(cw.side_1) || is_floatbv_type(cw.side_2))
+    {
+      constexpr int partial_ordering_unordered = -127;
+      expr2tc gt = greaterthan2tc(cw.side_1, cw.side_2);
+      expr2tc ordered = or2tc(lt, or2tc(eq, gt));
+      outer = if2tc(
+        cw.type,
+        ordered,
+        outer,
+        make_cmp_value(cw.type, partial_ordering_unordered));
+    }
+
     a = convert_ast(outer);
     break;
   }


### PR DESCRIPTION
Clears the floating-point `<=>` item from #4377.

> **Stacked on #6579** — base is `fix/6578-defaulted-eq-byvalue`, not `master`. The comparison categories declare their `operator==` as a defaulted friend, so without #6579 category equality is wrong and this change would trade a parse error for a silent wrong answer. Please merge #6579 first.

## Root cause

Two defects, the second hidden behind the first.

**1. `std::partial_ordering` had two members.** Clang's comparison-category hooks require exactly one member of integral type, so every floating-point `<=>` was rejected outright:

```
error: standard library implementation of 'std::partial_ordering' is not
supported; the type does not have the expected form
```

`strong_ordering` and `weak_ordering` already had one member and were unaffected.

**2. The `cmp_three_way` lowering has no unordered case.** `smt_solver.cpp` lowers `a <=> b` to a three-way ITE chain (`<` → -1, `==` → 0, else → 1). With a NaN operand both `<` and `==` are false, so it fell through to **`greater`**. This only became reachable once (1) was fixed, and it is a silent wrong result rather than a diagnostic.

## Solution

Fold `unordered` into the value using libc++'s `-127` sentinel and add a private `__is_ordered()`, then add a fourth branch to the lowering for floating-point operands, guarded on `lt || eq || gt`.

The sentinel is necessarily duplicated between `src/cpp/library/compare` and `smt_solver.cpp` — the solver has no visibility of the operational model's representation. Both sites carry cross-referencing comments.

Collapsing to one member also removes a latent trap: `make_cmp_value` sets member 0 and zeroes the rest, so under the two-member layout `make_cmp_value(t, 0)` produced `{0, 0}` — *unordered*, not *equivalent*.

## Tests

- `github_4377_float_spaceship` — `less`/`equivalent`/`greater`, all five relational comparisons against 0 false for `unordered`, reversed operands, and `strong_ordering`/`weak_ordering` → `partial_ordering` conversions.
- `github_4377_float_spaceship_fail` — asserts `un > 0` for a NaN operand, which must be reported. This is the specific guard against defect 2 regressing.

Both are clean under host `clang++ -std=c++20`. The positive test is a parse error on `master` **and** on this PR's base, so it discriminates on this change alone.

## Validation

`esbmc-cpp` tests are `THOROUGH`, which ctest skips on macOS, so suites were run directly against separately-built base and patched binaries.

**788 tests, zero differences** against the base branch: `esbmc-cpp/cpp` 691 and `floats` 97. The floats suite matters here because `cmp_three_way` is on the path for every `<=>`.

## Not addressed

The remaining #4377 items are unrelated to this one: `<ranges>`, `<coroutine>`, `<format>` and `<print>` are missing headers, and modules needs `-fmodules-ts` plumbed into the embedded clang.
