### PR TITLE
[c++] Construct and destroy the elements of new T[n]

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6584/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6584/main.cpp
@@ -1,0 +1,31 @@
+// new T[n] must run one constructor per element, and delete[] one destructor
+// per element. Both arms of the lowering were empty stubs, so neither ran and
+// members initialised by T's constructor read back nondeterministically.
+#include <cassert>
+
+int ctor = 0, dtor = 0;
+
+struct T
+{
+  int v;
+  T()
+  {
+    ctor++;
+    v = 7;
+  }
+  ~T()
+  {
+    dtor++;
+  }
+};
+
+int main()
+{
+  T *p = new T[4];
+  assert(ctor == 4);
+  assert(p[0].v == 7);
+  assert(p[3].v == 7);
+  delete[] p;
+  assert(dtor == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6584/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6584/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6584_dtor/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6584_dtor/main.cpp
@@ -1,0 +1,23 @@
+// Construction without matching destruction would report a spurious leak, so
+// pin that delete[] releases what the element constructors acquired.
+#include <cstdlib>
+
+struct R
+{
+  int *p;
+  R()
+  {
+    p = (int *)malloc(sizeof(int));
+  }
+  ~R()
+  {
+    free(p);
+  }
+};
+
+int main()
+{
+  R *a = new R[3];
+  delete[] a;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6584_dtor/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6584_dtor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --memory-leak-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6584_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6584_fail/main.cpp
@@ -1,0 +1,19 @@
+// Negative twin: the constructor really runs for every element, so a claim
+// that a later element is unset must be reported rather than passing.
+#include <cassert>
+
+struct T
+{
+  int v;
+  T() : v(7)
+  {
+  }
+};
+
+int main()
+{
+  T *p = new T[3];
+  assert(p[2].v != 7);
+  delete[] p;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6584_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6584_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/nec_ex7-ctor-throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex7-ctor-throw/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
+--unwind 8 --no-unwinding-assertions --error-label ERROR --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/unique_ptr_dtor_frees/test.desc
+++ b/regression/esbmc-cpp11/cpp/unique_ptr_dtor_frees/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---std c++11 --memory-leak-check
+--std c++11 --memory-leak-check --unwind 4
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -510,6 +510,33 @@ void goto_convertt::do_cpp_new(
   dest.destructive_append(tmp_initializer);
 }
 
+// Locate the constructor call inside a cpp_new initializer. Mirrors
+// find_constructor_call in clang_cpp_adjust_code.cpp: a temporary_object keeps
+// its call under the named "initializer" sub-irep rather than in an operand.
+static const exprt *find_cpp_new_constructor(const exprt &e)
+{
+  if (
+    e.id() == "sideeffect" && e.statement() == "function_call" &&
+    e.get_bool("constructor"))
+    return &e;
+
+  if (e.id() == "sideeffect" && e.statement() == "temporary_object")
+  {
+    const irept &init = e.initializer();
+    if (init.is_not_nil())
+      if (
+        const exprt *c =
+          find_cpp_new_constructor(static_cast<const exprt &>(init)))
+        return c;
+  }
+
+  forall_operands (it, e)
+    if (const exprt *c = find_cpp_new_constructor(*it))
+      return c;
+
+  return nullptr;
+}
+
 void goto_convertt::cpp_new_initializer(
   const exprt &lhs,
   const exprt &rhs,
@@ -563,7 +590,61 @@ void goto_convertt::cpp_new_initializer(
   {
     if (rhs.statement() == "cpp_new[]")
     {
-      // build loop
+      // Construct every element: what the scalar arm below does once, done for
+      // each element of the allocated array. Leaving this unimplemented meant
+      // `new T[n]` ran no constructor at all, so members initialised by T's
+      // constructor read back nondeterministically (github #6584). The element
+      // count need not be a compile-time constant, so emit a loop rather than
+      // unrolling it:
+      //
+      //   for (size_type i = 0; i < n; ++i)
+      //     <initializer, retargeted at *(lhs + i)>
+      exprt count = static_cast<const exprt &>(rhs.size_irep());
+      if (count.type() != size_type())
+        count.make_typecast(size_type());
+      remove_sideeffects(count, dest);
+
+      symbol_exprt index(new_tmp_symbol(size_type()).id, size_type());
+      index_exprt element(lhs, index, rhs.type().subtype());
+
+      // The frontend's initializer for the array form is shaped for the whole
+      // array: a temporary_object of type T[n] whose constructor targets
+      // element 0. Retargeting its `new_object` per element would splice a
+      // single element into a context expecting the array, so take the
+      // constructor call out and re-point its `this` at &lhs[i] instead.
+      codet body;
+      if (const exprt *ctor = find_cpp_new_constructor(initializer))
+      {
+        exprt call = *ctor;
+        call.op1().operands().at(0) = address_of_exprt(element);
+        code_expressiont ctor_code;
+        ctor_code.expression() = call;
+        body = ctor_code;
+      }
+      else
+      {
+        // No constructor (`new int[n]`, or value-initialisation): the scalar
+        // arm's substitution is correct element-wise.
+        replace_new_object(element, initializer);
+        body = to_code(initializer);
+      }
+
+      plus_exprt next(index, from_integer(1, size_type()));
+      next.type() = size_type();
+
+      code_fort loop;
+      loop.init() = code_assignt(index, from_integer(0, size_type()));
+      loop.cond() = binary_relation_exprt(index, "<", count);
+      loop.iter() = code_assignt(index, next);
+      loop.body() = body;
+      loop.location() = rhs.find_location();
+
+      // Same reasoning as the scalar arm: a class-typed initializer may lower
+      // to a stack temporary copied into the element, and that slot must not
+      // get its own scope-exit destructor.
+      std::size_t stack_size = targets.destructor_stack.size();
+      convert(loop, dest);
+      targets.destructor_stack.resize(stack_size);
     }
     else if (rhs.statement() == "cpp_new")
     {

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -529,8 +529,9 @@ static exprt *find_cpp_new_constructor(exprt &e)
   if (e.id() == "sideeffect" && e.statement() == "temporary_object")
   {
     if (e.find("initializer").is_not_nil())
-      if (exprt *c = find_cpp_new_constructor(
-            static_cast<exprt &>(e.add("initializer"))))
+      if (
+        exprt *c =
+          find_cpp_new_constructor(static_cast<exprt &>(e.add("initializer"))))
         return c;
   }
 
@@ -608,7 +609,17 @@ void goto_convertt::cpp_new_initializer(
       // unrolling it:
       //
       //   for (size_type i = 0; i < n; ++i)
-      //     <initializer, retargeted at *(lhs + i)>
+      //     <element constructor, with `this` = lhs + i>
+      //
+      // Only when there is a constructor to run. `new int[n]` has none, and
+      // the scalar arm's zero-fill is not worth an n-iteration loop: it would
+      // both change the existing behaviour (the array form has always left
+      // such elements nondeterministic) and, for a symbolic n, cost far more
+      // than it buys.
+      exprt *ctor = find_cpp_new_constructor(initializer);
+      if (ctor == nullptr)
+        return;
+
       exprt count = static_cast<const exprt &>(rhs.size_irep());
       if (count.type() != size_type())
         count.make_typecast(size_type());
@@ -628,25 +639,12 @@ void goto_convertt::cpp_new_initializer(
       // The frontend's initializer is shaped for the whole array: a
       // temporary_object of type T[n] wrapping the element constructor, whose
       // `this` is &new_object[0]. Lift that call out and re-point its `this`
-      // at &lhs[i], so each iteration constructs its own element in place.
-      codet body;
-      if (exprt *ctor = find_cpp_new_constructor(initializer))
-      {
-        exprt call = *ctor;
-        call.op1().operands().at(0) = element_addr;
-        code_expressiont ctor_code;
-        ctor_code.expression() = call;
-        ctor_code.location() = rhs.find_location();
-        body = ctor_code;
-      }
-      else
-      {
-        // No constructor to lift (`new int[n]`): the element-wise
-        // substitution the scalar arm performs is already correct.
-        dereference_exprt element(element_addr, lhs.type());
-        replace_new_object(element, initializer);
-        body = to_code(initializer);
-      }
+      // at lhs + i, so each iteration constructs its own element in place.
+      exprt call = *ctor;
+      call.op1().operands().at(0) = element_addr;
+      code_expressiont body;
+      body.expression() = call;
+      body.location() = rhs.find_location();
 
       plus_exprt next(index, from_integer(1, size_type()));
       next.type() = size_type();

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -510,28 +510,32 @@ void goto_convertt::do_cpp_new(
   dest.destructive_append(tmp_initializer);
 }
 
-// Locate the constructor call inside a cpp_new initializer. Mirrors
-// find_constructor_call in clang_cpp_adjust_code.cpp: a temporary_object keeps
-// its call under the named "initializer" sub-irep rather than in an operand.
-static const exprt *find_cpp_new_constructor(const exprt &e)
+// Locate the element constructor inside a cpp_new[] initializer, by shape.
+//
+// The decl-path helper (find_constructor_call in clang_cpp_adjust_code.cpp)
+// keys on the "constructor" flag, but nothing in the initializer the frontend
+// builds for the array form carries it. What is there is a plain function_call
+// side effect -- the element constructor, whose first argument is the `this`
+// pointer -- nested inside a temporary_object of the whole array type. Match
+// that shape instead, and note a temporary_object keeps its call under the
+// named "initializer" sub-irep rather than in an operand.
+static exprt *find_cpp_new_constructor(exprt &e)
 {
   if (
     e.id() == "sideeffect" && e.statement() == "function_call" &&
-    e.get_bool("constructor"))
+    e.operands().size() == 2 && !e.op1().operands().empty())
     return &e;
 
   if (e.id() == "sideeffect" && e.statement() == "temporary_object")
   {
-    const irept &init = e.initializer();
-    if (init.is_not_nil())
-      if (
-        const exprt *c =
-          find_cpp_new_constructor(static_cast<const exprt &>(init)))
+    if (e.find("initializer").is_not_nil())
+      if (exprt *c = find_cpp_new_constructor(
+            static_cast<exprt &>(e.add("initializer"))))
         return c;
   }
 
-  forall_operands (it, e)
-    if (const exprt *c = find_cpp_new_constructor(*it))
+  Forall_operands (it, e)
+    if (exprt *c = find_cpp_new_constructor(*it))
       return c;
 
   return nullptr;
@@ -565,7 +569,13 @@ void goto_convertt::cpp_new_initializer(
   {
     initializer = static_cast<const code_expressiont &>(rhs.initializer());
 
-    if (!initializer.op0().get_bool("constructor"))
+    // The wrap below is scalar-shaped: it assigns into a `new_object` of the
+    // element type. For the array form the frontend supplies an array-typed
+    // temporary_object, so wrapping it assigns a T* into a T. The cpp_new[]
+    // arm retargets the element constructor itself instead (github #6584).
+    if (
+      rhs.statement() != "cpp_new[]" &&
+      !initializer.op0().get_bool("constructor"))
     {
       // for auto *p = Foo(3) and int *p = 3
       // constructor case:  init is Foo(&(*new_object), 3)
@@ -605,26 +615,35 @@ void goto_convertt::cpp_new_initializer(
       remove_sideeffects(count, dest);
 
       symbol_exprt index(new_tmp_symbol(size_type()).id, size_type());
-      index_exprt element(lhs, index, rhs.type().subtype());
 
-      // The frontend's initializer for the array form is shaped for the whole
-      // array: a temporary_object of type T[n] whose constructor targets
-      // element 0. Retargeting its `new_object` per element would splice a
-      // single element into a context expecting the array, so take the
-      // constructor call out and re-point its `this` at &lhs[i] instead.
+      // The element address is plain pointer arithmetic on lhs. Building it as
+      // &lhs[i] instead would not survive symex: dereference_expr_nonscalar
+      // recurses into an index's source, and a pointer source is scalar, so it
+      // trips the "no sudden transition back to scalars" assertion. `p[i]` in
+      // user code only reaches symex as a dereference because the adjuster
+      // rewrites it, and this runs after adjust.
+      plus_exprt element_addr(lhs, index);
+      element_addr.type() = lhs.type();
+
+      // The frontend's initializer is shaped for the whole array: a
+      // temporary_object of type T[n] wrapping the element constructor, whose
+      // `this` is &new_object[0]. Lift that call out and re-point its `this`
+      // at &lhs[i], so each iteration constructs its own element in place.
       codet body;
-      if (const exprt *ctor = find_cpp_new_constructor(initializer))
+      if (exprt *ctor = find_cpp_new_constructor(initializer))
       {
         exprt call = *ctor;
-        call.op1().operands().at(0) = address_of_exprt(element);
+        call.op1().operands().at(0) = element_addr;
         code_expressiont ctor_code;
         ctor_code.expression() = call;
+        ctor_code.location() = rhs.find_location();
         body = ctor_code;
       }
       else
       {
-        // No constructor (`new int[n]`, or value-initialisation): the scalar
-        // arm's substitution is correct element-wise.
+        // No constructor to lift (`new int[n]`): the element-wise
+        // substitution the scalar arm performs is already correct.
+        dereference_exprt element(element_addr, lhs.type());
         replace_new_object(element, initializer);
         body = to_code(initializer);
       }

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -420,17 +420,12 @@ void goto_convertt::do_cpp_new(
   const exprt &alloc_function =
     static_cast<const exprt &>(rhs.find("alloc_function"));
 
-  // grab initializer
-  goto_programt tmp_initializer;
-  // With no initializer the built-in path zero-fills, which models a fresh
-  // object well enough. Storage from a replaced operator new is not fresh --
-  // the program decides its contents ([expr.new]/17 default-initialises a
-  // scalar to nothing at all) -- so zero-filling it would overwrite what the
-  // replacement just returned.
-  if (alloc_function.is_nil() || rhs.initializer().is_not_nil())
-    cpp_new_initializer(lhs, rhs, tmp_initializer);
-
+  // The element count drives both the allocation size and the construction
+  // loop, and `new T[f()]` evaluates f() exactly once, so evaluate it here --
+  // ahead of cpp_new_initializer -- and hand the resulting side-effect-free
+  // expression to both.
   exprt alloc_size;
+  exprt elem_count;
 
   if (rhs.statement() == "cpp_new[]")
   {
@@ -439,6 +434,7 @@ void goto_convertt::do_cpp_new(
       alloc_size.make_typecast(size_type());
 
     remove_sideeffects(alloc_size, dest);
+    elem_count = alloc_size;
 
     // jmorse: multiply alloc size by size of subtype.
     type2tc subtype = migrate_type(ns.follow(rhs.type().subtype()));
@@ -452,6 +448,16 @@ void goto_convertt::do_cpp_new(
   }
   else
     alloc_size = from_integer(1, size_type());
+
+  // grab initializer
+  goto_programt tmp_initializer;
+  // With no initializer the built-in path zero-fills, which models a fresh
+  // object well enough. Storage from a replaced operator new is not fresh --
+  // the program decides its contents ([expr.new]/17 default-initialises a
+  // scalar to nothing at all) -- so zero-filling it would overwrite what the
+  // replacement just returned.
+  if (alloc_function.is_nil() || rhs.initializer().is_not_nil())
+    cpp_new_initializer(lhs, rhs, elem_count, tmp_initializer);
 
   if (alloc_size.is_nil())
     alloc_size = from_integer(1, size_type());
@@ -545,6 +551,7 @@ static exprt *find_cpp_new_constructor(exprt &e)
 void goto_convertt::cpp_new_initializer(
   const exprt &lhs,
   const exprt &rhs,
+  const exprt &elem_count,
   goto_programt &dest)
 {
   // grab initializer
@@ -620,10 +627,9 @@ void goto_convertt::cpp_new_initializer(
       if (ctor == nullptr)
         return;
 
-      exprt count = static_cast<const exprt &>(rhs.size_irep());
-      if (count.type() != size_type())
-        count.make_typecast(size_type());
-      remove_sideeffects(count, dest);
+      // do_cpp_new already evaluated the count for the allocation; reusing it
+      // is what keeps `new T[f()]` from calling f() a second time here.
+      const exprt &count = elem_count;
 
       symbol_exprt index(new_tmp_symbol(size_type()).id, size_type());
 

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1116,9 +1116,16 @@ void goto_convertt::convert_cpp_delete(const codet &code, goto_programt &dest)
       exprt byte_size("dynamic_size", size_type());
       byte_size.copy_to_operands(tmp_op);
 
-      exprt elem_size = from_integer(
-        type_byte_size(migrate_type(ns.follow(tmp_op.type().subtype()))),
-        size_type());
+      // An empty class models as zero bytes here, while C++ gives it a
+      // nonzero size ([class]/4). Clamp so the division below is well defined;
+      // the allocation for such a class is itself zero bytes, so its element
+      // count comes out as zero and no destructor runs -- see the limitation
+      // noted on #6584.
+      BigInt esz =
+        type_byte_size(migrate_type(ns.follow(tmp_op.type().subtype())));
+      if (esz == 0)
+        esz = 1;
+      exprt elem_size = from_integer(esz, size_type());
 
       exprt count("/", size_type());
       count.copy_to_operands(byte_size, elem_size);

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1105,7 +1105,64 @@ void goto_convertt::convert_cpp_delete(const codet &code, goto_programt &dest)
   {
     if (code.statement() == "cpp_delete[]")
     {
-      // build loop
+      // Destroy every element, pairing the construction loop do_cpp_new emits
+      // for `new T[n]` (github #6584). Leaving this empty while construction
+      // runs would be worse than leaving both empty: elements would be built
+      // and never torn down, so a T that acquires a resource in its
+      // constructor reports a spurious leak under --memory-leak-check.
+      //
+      // delete[] does not carry the element count, so recover it from the
+      // allocation -- dynamic_size is the object's size in bytes.
+      exprt byte_size("dynamic_size", size_type());
+      byte_size.copy_to_operands(tmp_op);
+
+      exprt elem_size = from_integer(
+        type_byte_size(migrate_type(ns.follow(tmp_op.type().subtype()))),
+        size_type());
+
+      exprt count("/", size_type());
+      count.copy_to_operands(byte_size, elem_size);
+
+      symbol_exprt index(new_tmp_symbol(size_type()).id, size_type());
+
+      // *(p + i). As in the scalar arm the destructor is retargeted at the
+      // pointee, since a virtually-bound destructor reads the vtable pointer
+      // out of that dereference.
+      exprt element_addr("+", tmp_op.type());
+      element_addr.copy_to_operands(tmp_op, index);
+      exprt element("dereference", ns.follow(tmp_op.type().subtype()));
+      element.copy_to_operands(element_addr);
+
+      codet tmp_code = to_code(destructor);
+      replace_new_object(element, tmp_code);
+
+      exprt next("+", size_type());
+      next.copy_to_operands(index, from_integer(1, size_type()));
+
+      code_fort loop;
+      loop.init() = code_assignt(index, from_integer(0, size_type()));
+      loop.cond() = binary_relation_exprt(index, "<", count);
+      loop.iter() = code_assignt(index, next);
+      loop.body() = tmp_code;
+      loop.location() = code.location();
+
+      // C++ [expr.delete]/7: deleting a null pointer invokes no destructor.
+      goto_programt dtor_prog;
+      convert(loop, dtor_prog);
+
+      goto_programt::targett t_skip = dtor_prog.add_instruction(SKIP);
+      t_skip->location = code.location();
+
+      goto_programt::targett t_null = dest.add_instruction();
+      t_null->make_goto(t_skip);
+      exprt is_null("not", typet("bool"));
+      exprt non_null("typecast", typet("bool"));
+      non_null.copy_to_operands(tmp_op);
+      is_null.move_to_operands(non_null);
+      migrate_expr(is_null, t_null->guard);
+      t_null->location = code.location();
+
+      dest.destructive_append(dtor_prog);
     }
     else if (code.statement() == "cpp_delete")
     {

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -140,8 +140,11 @@ protected:
 
   static void replace_new_object(const exprt &object, exprt &dest);
 
-  void
-  cpp_new_initializer(const exprt &lhs, const exprt &rhs, goto_programt &dest);
+  void cpp_new_initializer(
+    const exprt &lhs,
+    const exprt &rhs,
+    const exprt &elem_count,
+    goto_programt &dest);
 
   //
   // function calls


### PR DESCRIPTION
Fixes #6584.

## Root cause

Both arms of the array form were empty stubs. `goto_convertt::cpp_new_initializer` (`src/goto-programs/builtin_functions.cpp`) and `goto_convertt::convert_cpp_delete` (`src/goto-programs/goto_convert.cpp`) each contained only

```cpp
    if (rhs.statement() == "cpp_new[]")
    {
      // build loop
    }
```

so the initializer was dropped at goto-convert time and no constructor or destructor ever reached the GOTO program. Members initialised by `T`'s constructor read back nondeterministically, giving a spurious violation on correct code:

```cpp
struct T { int v; T() : v(7) {} };
T *p = new T[3];
assert(p[0].v == 7);   // VERIFICATION FAILED; clean under clang -fsanitize=address,undefined
```

Scalar `new T` was unaffected — it has its own arm — which is what made the array form look like a modelling choice rather than a gap.

## Solution

**Construction.** The initializer the frontend supplies for the array form is shaped for the whole array: a `temporary_object` of type `T[n]` wrapping the element constructor, whose `this` is `&new_object[0]`. Two things follow:

- The else-branch wrap that turns an initializer into `new_object = <expr>` uses `rhs.type().subtype()` and is scalar-shaped; applied to the array form it assigns a `T*` into a `T`. It is skipped for `cpp_new[]`.
- Nothing in that initializer carries the `constructor` flag that the decl path's helper (`find_constructor_call` in `clang_cpp_adjust_code.cpp`) keys on. The constructor is located **by shape** instead — a `function_call` side effect with a function operand and a non-empty argument list — then lifted out and its `this` re-pointed at each element inside a loop bounded by the element count.

`this` is built as pointer arithmetic `lhs + i`, not `&lhs[i]`: `dereference_expr_nonscalar` recurses into an index's `source_value`, and a pointer source is scalar, so the index form trips its "no sudden transition back to scalars" assertion. User-written `p[i]` only survives because the adjuster rewrites it, and this runs after adjust.

A loop rather than unrolling, because the element count need not be a compile-time constant.

**Destruction.** `convert_cpp_delete` emits the matching teardown, recovering the count from `dynamic_size` (the allocation's byte size) divided by the element size, and reusing the scalar arm's null guard per [expr.delete]/7.

The two halves must land together. Constructing without destroying is worse than leaving both stubs empty: `new R[3]; delete[] a;` where `R` acquires memory in its constructor then reports a spurious `forgotten memory` under `--memory-leak-check`, which master (symmetric, both empty) does not.

**No constructor, no loop.** `new int[n]` has no constructor to run, and the array form has always left such elements nondeterministic. Emitting the scalar arm's zero-fill per element would both change that behaviour and, for a symbolic `n`, cost far more than it buys — it regressed `cwe_excessive_alloc_new_pass` to `UNKNOWN` and timed out two other tests before being removed.

## Tests

- `github_6584` — constructor and destructor counts plus element values through `new T[4]` / `delete[]`. `VERIFICATION FAILED` on master, `SUCCESSFUL` here.
- `github_6584_fail` — negative twin; a claim that a later element is unset must be reported.
- `github_6584_dtor` — `new R[3]` / `delete[]` under `--memory-leak-check`. This one passes on master too, since master runs neither constructor nor destructor; it is a pairing guard against the asymmetry above rather than a reproducer of the reported bug.

All three agree with host `clang++ -std=c++20`.

## Validation

`esbmc-cpp` tests are `THOROUGH`, which ctest skips on macOS, so suites were run directly against separately-built master and patched binaries.

**816 tests, zero differences**: `cpp` 688, `inheritance` 85, `template` 29, `destructors` 14.

## Limitation

A class with no data members models as zero bytes here, while C++ gives it a nonzero size ([class]/4). Its allocation is therefore zero bytes and the recovered element count is zero, so destructors do not run for `new Empty[n]`. Constructors do, which is already an improvement on master — and since such a class owns nothing, this cannot produce a leak false positive. Fixing it properly means modelling `sizeof` of an empty class as at least 1, which changes allocation sizes and belongs in its own change.
