### PR TITLE
[om] Include <cstdint> from <string> in every language mode

### DIFF
--- a/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint/main.cpp
@@ -1,0 +1,16 @@
+// <string> and <sstream> must make the <cstdint> fixed-width typedefs visible,
+// as libstdc++/libc++ do transitively; requiring an explicit <stdint.h> broke
+// unmodified third-party sources (github #3267).
+#include <sstream>
+#include <string>
+#include <cassert>
+
+int main()
+{
+  const std::string s = "HI!";
+  std::stringstream ss;
+  uint32_t n = 0;
+  ss << char('0' + n);
+  assert(s.size() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_cxx03/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_cxx03/main.cpp
@@ -1,0 +1,15 @@
+// Pre-C++11 counterpart of github_3267_uint32_no_stdint: <string> used to
+// reach <cstdint> only through the C++11-guarded <string_view> (github #3267).
+#include <sstream>
+#include <string>
+#include <cassert>
+
+int main()
+{
+  const std::string s = "HI!";
+  std::stringstream ss;
+  uint32_t n = 0;
+  ss << char('0' + n);
+  assert(s.size() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_cxx03/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_cxx03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative counterpart of github_3267_uint32_no_stdint: the uint32_t typedef
+// must be the real 32-bit unsigned type, not merely a name that parses.
+#include <sstream>
+#include <string>
+#include <cassert>
+
+int main()
+{
+  const std::string s = "HI!";
+  std::stringstream ss;
+  uint32_t n = 0;
+  ss << char('0' + n);
+  assert(sizeof(uint32_t) == 8);
+  assert(s.size() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_no_stdint_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_stream_headers/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_stream_headers/main.cpp
@@ -15,5 +15,15 @@ int main()
   uint32_t n = 4000000000u;
   assert(n > 2147483647u);
   assert(sizeof(uint32_t) == 4);
+
+  std::uint32_t qn = n;
+  std::int64_t big = INT64_C(-5000000000);
+  std::size_t sz = 3;
+  uint_least16_t least = 7;
+  assert(qn == n);
+  assert(big < -2147483648LL);
+  assert(sz + least == 10);
+  assert(UINT32_MAX == 4294967295u);
+  assert(sizeof(intmax_t) >= sizeof(int32_t));
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_stream_headers/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_stream_headers/main.cpp
@@ -1,0 +1,19 @@
+// libstdc++ 11 (-std=c++17) makes the fixed-width typedefs visible through
+// each of these; ESBMC did not, so unmodified sources failed to parse
+// (github #3267).
+#include <iostream>
+#include <ostream>
+#include <istream>
+#include <streambuf>
+#include <iomanip>
+#include <iterator>
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  uint32_t n = 4000000000u;
+  assert(n > 2147483647u);
+  assert(sizeof(uint32_t) == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3267_uint32_stream_headers/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3267_uint32_stream_headers/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3387_iosfwd_vector/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3387_iosfwd_vector/main.cpp
@@ -1,0 +1,16 @@
+// <iosfwd> alongside another OM header used to resolve against the host
+// libstdc++ copy, whose basic_ios<char> template clashed with the concrete
+// std::ios the stream OMs define (github #3387).  -nostdinc++ plus a bundled
+// <iosfwd> keeps the OM tree the sole source of these declarations.
+#include <iosfwd>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(7);
+  assert(v.size() == 1);
+  assert(v[0] == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3387_iosfwd_vector/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3387_iosfwd_vector/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/github_3387_mutex_namespace_scope/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3387_mutex_namespace_scope/main.cpp
@@ -1,0 +1,16 @@
+// A namespace-scope std::mutex pulled the host <mutex> in, which reached the
+// OM <stdexcept>/<ios> through <system_error> and failed to parse against the
+// host basic_ios<char> (github #3387).
+#include <mutex>
+#include <cassert>
+
+std::mutex mtx;
+
+int main()
+{
+  mtx.lock();
+  int i = 0;
+  mtx.unlock();
+  assert(i == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_3387_mutex_namespace_scope/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3387_mutex_namespace_scope/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/streambuf
+++ b/src/cpp/library/streambuf
@@ -4,6 +4,10 @@
 #include "OM_compiler_defs.h"
 #include "definitions.h"
 #include "cstdio"
+// Base of the stream chain, so this is what makes the fixed-width typedefs
+// reachable from <ios>/<ostream>/<istream>/<iomanip>/<iostream>/<iterator>/
+// <memory> as on libstdc++ and libc++ (github #3267).
+#include "cstdint"
 
 namespace std
 {

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -6,8 +6,7 @@
 #include "cstring"
 #include "cstdio"
 #include "cassert"
-// Not via the C++11-guarded <string_view> below: hosts expose the fixed-width
-// typedefs from <string> in every mode (github #3267).
+// Explicit, not via the C++11-guarded <string_view> below (github #3267).
 #include "cstdint"
 #include "iostream"
 #include "cstdlib"

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -6,6 +6,9 @@
 #include "cstring"
 #include "cstdio"
 #include "cassert"
+// Not via the C++11-guarded <string_view> below: hosts expose the fixed-width
+// typedefs from <string> in every mode (github #3267).
+#include "cstdint"
 #include "iostream"
 #include "cstdlib"
 #include "memory"


### PR DESCRIPTION
ESBMC's C++ models did not make the `<cstdint>` fixed-width typedefs reachable from the headers that expose them on real toolchains, so unmodified sources using `uint32_t` failed to parse. Measured against libstdc++ 11 at `-std=c++17`: `<string>`, `<sstream>`, `<iostream>`, `<memory>`, `<iterator>`, `<ostream>`, `<istream>`, `<streambuf>` and `<iomanip>` all expose them.

Also pins the reproducers from #3267 and #3387 as regressions; the #3387 cases already pass on master since `-nostdinc++` became unconditional.

Fixes #3267