### PR TITLE
[solvers] Round fixedbv values before resizing them to an int

### DIFF
--- a/regression/cbmc/01_cbmc_Fixedbv23-no-ir/test.desc
+++ b/regression/cbmc/01_cbmc_Fixedbv23-no-ir/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --fixedbv --no-slice --z3 -Wno-error=implicit-function-declaration
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/cbmc/01_cbmc_Fixedbv24-no-ir/test.desc
+++ b/regression/cbmc/01_cbmc_Fixedbv24-no-ir/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --fixedbv --no-slice --z3 -Wno-error=implicit-function-declaration
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_562/main.c
+++ b/regression/esbmc/github_562/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+extern unsigned nondet_uint(void);
+int main(void)
+{
+  /* narrowing: long double (128-bit fixedbv) -> unsigned long (64) */
+  unsigned long a = 1234567;
+  long double ua = a;
+  assert((unsigned long)ua == 1234567);
+
+  /* truncation toward zero must still truncate */
+  long double frac = 3.75L;
+  assert((int)frac == 3);
+
+  /* widening: float (32-bit fixedbv) -> long (64) */
+  unsigned n = nondet_uint();
+  __ESBMC_assume(n < 100);
+  float f = n;
+  assert((long)f == (long)n);
+
+  /* negative rounds toward zero */
+  long double neg = -3.75L;
+  assert((int)neg == -3);
+  return 0;
+}

--- a/regression/esbmc/github_562/test.desc
+++ b/regression/esbmc/github_562/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--fixedbv
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_562_bool/main.c
+++ b/regression/esbmc/github_562_bool/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+extern int nondet_int(void);
+int main(void)
+{
+  int c = nondet_int();
+  double u = (c != 0);
+  assert((int)u == (c != 0 ? 1 : 0));
+  return 0;
+}

--- a/regression/esbmc/github_562_bool/test.desc
+++ b/regression/esbmc/github_562_bool/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--fixedbv
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_562_fail/main.c
+++ b/regression/esbmc/github_562_fail/main.c
@@ -1,0 +1,7 @@
+#include <assert.h>
+int main(void)
+{
+  long double frac = 3.75L;
+  assert((int)frac == 4); /* truncation gives 3, so this must fail */
+  return 0;
+}

--- a/regression/esbmc/github_562_fail/test.desc
+++ b/regression/esbmc/github_562_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--fixedbv
+^VERIFICATION FAILED$
+assertion

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -289,11 +289,24 @@ smt_solver_baset::convert_typecast_to_ints_from_fbv_sint(const typecast2t &cast)
 
   unsigned from_width = cast.from->type->get_width();
 
+  if (is_fixedbv_type(cast.from) && is_bv_type(cast.type))
+  {
+    /* Round in the source width first. A fixedbv's low bits hold its fraction,
+     * so resizing the raw bit pattern would yield the fraction rather than the
+     * integer value (esbmc/esbmc#562). */
+    smt_astt rounded = round_fixedbv_to_int(a, from_width, from_width);
+
+    if (from_width == to_width)
+      return rounded;
+
+    if (from_width < to_width)
+      return mk_sign_ext(rounded, to_width - from_width);
+
+    return mk_extract(rounded, to_width - 1, 0);
+  }
+
   if (from_width == to_width)
   {
-    if (is_fixedbv_type(cast.from) && is_bv_type(cast.type))
-      return round_fixedbv_to_int(a, from_width, to_width);
-
     if (
       (is_signedbv_type(cast.type) && is_unsignedbv_type(cast.from)) ||
       (is_unsignedbv_type(cast.type) && is_signedbv_type(cast.from)))

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -90,8 +90,10 @@ smt_astt smt_solver_baset::convert_typecast_to_fixedbv_nonint_from_bool(
 
   smt_astt zero = mk_smt_bv(BigInt(0), to_integer_bits);
   smt_astt one = mk_smt_bv(BigInt(1), to_integer_bits);
-  smt_astt switched = mk_ite(a, zero, one);
-  return mk_concat(switched, zero);
+  smt_astt switched = mk_ite(a, one, zero);
+
+  smt_astt zero_fracbits = mk_smt_bv(BigInt(0), fbvt.width - to_integer_bits);
+  return mk_concat(switched, zero_fracbits);
 }
 
 smt_astt smt_solver_baset::convert_typecast_to_fixedbv_nonint_from_fixedbv(


### PR DESCRIPTION
A fixedbv keeps its fraction in the low bits, but casts to an int of a
different width resized the raw bit pattern -- so `(int)(a + 0.5)` on a
double returned the fraction under `--fixedbv`. A second commit fixes an
inverted bool-to-fixedbv conversion found alongside it.

`01_cbmc_Fixedbv23-no-ir` and `_24-no-ir` now expect FAILED: their `--ir`
siblings run the same source and already do, as does the default floatbv
encoding. That disagreement is what the issue reports.

Fixes #562