### PR TITLE
[esbmc] Report external symbols that have no definition

### DIFF
--- a/regression/esbmc/github_1424/main.c
+++ b/regression/esbmc/github_1424/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int defined_global = 5;
+int tentative_global;        /* tentative definition, not extern */
+extern int undefined_extern; /* no definition anywhere: havoc'd */
+
+int main(void)
+{
+  assert(defined_global == 5);
+  assert(tentative_global == 0);
+  return 0;
+}

--- a/regression/esbmc/github_1424/test.desc
+++ b/regression/esbmc/github_1424/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$
+no definition for external symbol undefined_extern declared at file .*main\.c line 5
+\A(?!(?s:.)*external symbol defined_global)
+\A(?!(?s:.)*external symbol tentative_global)

--- a/regression/esbmc/github_1424_fail/main.c
+++ b/regression/esbmc/github_1424_fail/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+extern int undefined_extern;
+
+int main(void)
+{
+  assert(undefined_extern == 0);
+  return 0;
+}

--- a/regression/esbmc/github_1424_fail/test.desc
+++ b/regression/esbmc/github_1424_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION FAILED$
+no definition for external symbol undefined_extern declared at file .*main\.c line 3

--- a/src/esbmc/parseoptions/goto_program.cpp
+++ b/src/esbmc/parseoptions/goto_program.cpp
@@ -493,9 +493,9 @@ static void warn_undefined_external_symbols(const contextt &context)
   });
 
   std::sort(
-    undefined.begin(),
-    undefined.end(),
-    [](const symbolt *a, const symbolt *b) { return a->id < b->id; });
+    undefined.begin(), undefined.end(), [](const symbolt *a, const symbolt *b) {
+      return a->id < b->id;
+    });
 
   for (const symbolt *s : undefined)
     log_warning(

--- a/src/esbmc/parseoptions/goto_program.cpp
+++ b/src/esbmc/parseoptions/goto_program.cpp
@@ -479,6 +479,31 @@ bool esbmc_parseoptionst::synthesize_cprover_additions(
   return failed;
 }
 
+/* A call to a bodyless function is reported ("no body for function", see
+ * symex_function.cpp), but an undefined external variable was silently havoc'd,
+ * leaving no trace that the run covered less than the user believed
+ * (esbmc/esbmc#1424). c_link clears is_extern once a definition is linked in,
+ * so what survives final() is exactly the undefined set. */
+static void warn_undefined_external_symbols(const contextt &context)
+{
+  std::vector<const symbolt *> undefined;
+  context.foreach_operand([&undefined](const symbolt &s) {
+    if (s.is_extern && !s.is_type && !s.get_type().is_code())
+      undefined.push_back(&s);
+  });
+
+  std::sort(
+    undefined.begin(),
+    undefined.end(),
+    [](const symbolt *a, const symbolt *b) { return a->id < b->id; });
+
+  for (const symbolt *s : undefined)
+    log_warning(
+      "no definition for external symbol {} declared at {}",
+      s->name,
+      s->location);
+}
+
 // This method creates a GOTO program by parsing the input program files.
 //
 // \param options - options to be passed to the program parser,
@@ -507,6 +532,8 @@ bool esbmc_parseoptionst::parse_goto_program(
       return true;
     if (final())
       return true;
+
+    warn_undefined_external_symbols(context);
 
     // we no longer need any parse trees or language files
     clear_parse();


### PR DESCRIPTION
A call to a bodyless function is reported, but an undefined external
variable was silently havoc'd, so a run could cover far less than the
user believed with nothing in the log to say so.

`c_link` clears `is_extern` once a definition is linked in, so what
survives `final()` is exactly the undefined set -- an empty program
reports nothing, and defined and tentative globals are not flagged.

Fixes #1424
