### PR TITLE
[solvers] Build against Yices 2.7

### DIFF
--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -18,6 +18,14 @@
 #  define yices_bvor yices_bvor2
 #endif
 
+// Yices 2.7 likewise renamed the smt_status_t enumerators with a YICES_ prefix,
+// keeping no aliases for the old spelling (yices_types.h).
+
+#if __YICES_VERSION > 2 || (__YICES_VERSION == 2 && __YICES_VERSION_MAJOR >= 7)
+#  define STATUS_SAT YICES_STATUS_SAT
+#  define STATUS_UNSAT YICES_STATUS_UNSAT
+#endif
+
 #define new_ast new_solver_ast<yices_smt_ast>
 
 smt_solver_baset *create_new_yices_solver(


### PR DESCRIPTION
Yices 2.7 renamed the `smt_status_t` enumerators with a `YICES_` prefix and
kept no aliases, so `yices_conv.cpp` no longer compiled against it -- which is
what Homebrew's `yices2` formula now ships.

Maps the two names ESBMC uses, guarded by the same version macros as the
existing 2.3 API-rename block just above.
