### PR TITLE
[build] Decouple sanitizers from CMAKE_BUILD_TYPE

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -548,7 +548,9 @@ $0 [-OPTS] [deps] [build] [install]
 Options [defaults]:
   -h         display this help message
   -b BTYPE   set cmake build type to BTYPE [RelWithDebInfo]
-  -s STYPE   enable sanitizer STYPE and compile with clang [disabled]
+  -s STYPE   enable sanitizer STYPE (asan/tsan/lsan/msan/ubsan, or the
+             clang spellings address/thread/leak/memory/undefined; comma-
+             separated for several) and compile with clang [disabled]
   -e ON|OFF  enable/disable -Werror [OFF]
   -r ON|OFF  enable/disable 'benchbringup' [OFF]
   -d         enable debug output for this script and c2goto
@@ -585,7 +587,7 @@ while getopts "hb:s:e:r:dS:c:CB:x:k:" flag; do
       BASE_ARGS+=("-DCMAKE_BUILD_TYPE=${OPTARG}")
       ;;
     s)
-      BASE_ARGS+=("-DSANITIZER_TYPE=${OPTARG}")
+      BASE_ARGS+=("-DENABLE_SANITIZERS=${OPTARG}")
       COMPILER_ENV=(CC=clang CXX=clang++)
       ;;
     e)

--- a/scripts/cmake/BuildStatic.cmake
+++ b/scripts/cmake/BuildStatic.cmake
@@ -2,7 +2,7 @@
 
 message(STATUS "ESBMC will be built in static mode")
 if(NOT APPLE)
-    if(CMAKE_BUILD_TYPE STREQUAL "Sanitizer")
+    if(ESBMC_SANITIZERS_ENABLED)
         # Sanitizer runtimes (ASan especially) cannot be fully statically
         # linked: -static drops the dynamic section that libclang_rt.asan
         # needs, producing "undefined reference to _DYNAMIC" at link time.

--- a/scripts/cmake/Sanitizers.cmake
+++ b/scripts/cmake/Sanitizers.cmake
@@ -2,37 +2,94 @@
 
 # Inspired on http://www.stablecoder.ca/2018/02/01/analyzer-build-types.html
 
+# Instrumentation only: -O and -g belong to CMAKE_BUILD_TYPE, so that any build
+# type can be sanitized rather than only the dedicated one (esbmc/esbmc#1380).
+# -fsanitize-recover=address makes findings recoverable so that, combined with
+# halt_on_error=0, the process continues past a report instead of aborting. That
+# is required for the build-time c2goto invocations to survive bundled-clang
+# findings (see sanitizers.yml) and lets one esbmc run surface several findings.
+set(SANITIZER_FLAGS_address
+    "-fsanitize=address -fsanitize-recover=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer")
+set(SANITIZER_FLAGS_thread "-fsanitize=thread")
+set(SANITIZER_FLAGS_leak "-fsanitize=leak -fno-omit-frame-pointer")
+set(SANITIZER_FLAGS_memory
+    "-fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer")
+set(SANITIZER_FLAGS_undefined "-fsanitize=undefined -fno-sanitize=vptr")
+
+set(SANITIZER_KNOWN address thread leak memory undefined)
+
+# The clang -fsanitize= spellings are the canonical ones; the *SAN names are
+# kept because SANITIZER_TYPE and `build.sh -s` have always used them.
+set(SANITIZER_ALIAS_asan address)
+set(SANITIZER_ALIAS_tsan thread)
+set(SANITIZER_ALIAS_lsan leak)
+set(SANITIZER_ALIAS_msan memory)
+set(SANITIZER_ALIAS_ubsan undefined)
+
+set(ENABLE_SANITIZERS "" CACHE STRING
+    "Sanitizers to instrument with, independent of CMAKE_BUILD_TYPE; comma- or semicolon-separated, from: ${SANITIZER_KNOWN}")
+
 if(CMAKE_BUILD_TYPE STREQUAL "Sanitizer")
     message(STATUS "Sanitizer Mode")
-    set(SANITIZER_TYPE "ASAN" CACHE
-            STRING "Choose the sanitizer to use.")
-
+    set(SANITIZER_TYPE "ASAN" CACHE STRING "Choose the sanitizer to use.")
     set_property(CACHE SANITIZER_TYPE PROPERTY STRINGS
             "TSAN" "ASAN" "LSAN" "MSAN" "UBSAN")
-
-    # ThreadSanitizer
-    set(TSAN_FLAGS "-fsanitize=thread -g -O1")
-    # AddressSanitizer.  -fsanitize-recover=address makes findings recoverable
-    # so that, combined with halt_on_error=0, the process continues past a
-    # report instead of aborting.  This is required for the build-time c2goto
-    # invocations to survive bundled-clang findings (see sanitizers.yml) and
-    # lets a single esbmc run surface more than one runtime finding.
-    set(ASAN_FLAGS "-fsanitize=address -fsanitize-recover=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1")
-    # LeakSanitizer
-    set(LSAN_FLAGS "-fsanitize=leak -fno-omit-frame-pointer -g -O1")
-    # MemorySanitizer
-    set(MSAN_FLAGS "-fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -O2")
-    # UndefinedBehaviour
-    set(UBSAN_FLAGS "-fsanitize=undefined -fno-sanitize=vptr")
-
-    set(CMAKE_C_FLAGS_SANITIZER
-            "${${SANITIZER_TYPE}_FLAGS}" CACHE
-            STRING "C flags for sanitizer." FORCE)
-    set(CMAKE_CXX_FLAGS_SANITIZER
-            "${${SANITIZER_TYPE}_FLAGS}"
-            CACHE STRING "C++ flags for sanitizer." FORCE)
 else()
     unset(SANITIZER_TYPE CACHE)
+endif()
+
+# ENABLE_SANITIZERS wins; SANITIZER_TYPE is the pre-#1380 spelling and only
+# applies to the dedicated build type.
+set(sanitizer_requested "${ENABLE_SANITIZERS}")
+if(NOT sanitizer_requested AND CMAKE_BUILD_TYPE STREQUAL "Sanitizer")
+    set(sanitizer_requested "${SANITIZER_TYPE}")
+endif()
+
+set(sanitizer_list "")
+string(REPLACE "," ";" sanitizer_requested "${sanitizer_requested}")
+foreach(sanitizer IN LISTS sanitizer_requested)
+    string(TOLOWER "${sanitizer}" sanitizer)
+    if(DEFINED SANITIZER_ALIAS_${sanitizer})
+        set(sanitizer "${SANITIZER_ALIAS_${sanitizer}}")
+    endif()
+    if(NOT sanitizer IN_LIST SANITIZER_KNOWN)
+        message(FATAL_ERROR
+                "Unknown sanitizer '${sanitizer}'; expected one of: ${SANITIZER_KNOWN}")
+    endif()
+    list(APPEND sanitizer_list "${sanitizer}")
+endforeach()
+list(REMOVE_DUPLICATES sanitizer_list)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Sanitizer")
+    # The build type now carries only optimization and debug info; MSan keeps
+    # the higher level it always had, to bound origin-tracking cost.
+    set(sanitizer_opt "-g -O1")
+    if("memory" IN_LIST sanitizer_list)
+        set(sanitizer_opt "-g -O2")
+    endif()
+
+    set(CMAKE_C_FLAGS_SANITIZER "${sanitizer_opt}" CACHE
+            STRING "C flags for sanitizer." FORCE)
+    set(CMAKE_CXX_FLAGS_SANITIZER "${sanitizer_opt}" CACHE
+            STRING "C++ flags for sanitizer." FORCE)
+else()
     unset(CMAKE_C_FLAGS_SANITIZER CACHE)
     unset(CMAKE_CXX_FLAGS_SANITIZER CACHE)
 endif()
+
+if(sanitizer_list)
+    set(sanitizer_flags "")
+    foreach(sanitizer IN LISTS sanitizer_list)
+        string(APPEND sanitizer_flags " ${SANITIZER_FLAGS_${sanitizer}}")
+    endforeach()
+
+    message(STATUS "Sanitizers enabled: ${sanitizer_list}")
+
+    separate_arguments(sanitizer_flag_list UNIX_COMMAND "${sanitizer_flags}")
+    add_compile_options(${sanitizer_flag_list})
+    add_link_options(${sanitizer_flag_list})
+endif()
+
+# BuildStatic keys off this to skip -static, which drops the dynamic section the
+# sanitizer runtimes need.
+set(ESBMC_SANITIZERS_ENABLED "${sanitizer_list}")


### PR DESCRIPTION
Sanitizer flags only applied under `CMAKE_BUILD_TYPE=Sanitizer`, and each
carried its own `-O`/`-g`, so a sanitized `RelWithDebInfo` was impossible and
`build.sh -s ASAN` without `-b Sanitizer` was a silent no-op.

`ENABLE_SANITIZERS` now takes a list and instruments any build type, with the
optimization level left to the build type. `SANITIZER_TYPE` and the dedicated
build type keep working: all four CI configurations reproduce their previous
flags exactly.

Fixes #1380
