### PR TITLE
[goto-symex] Track main-thread termination per state, not per search

### DIFF
--- a/regression/python/threading_thread_args_instance_safe/test.desc
+++ b/regression/python/threading_thread_args_instance_safe/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc
+--incremental-bmc --context-bound 2
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/threading_thread_increment_race_no_flag_fail/main.py
+++ b/regression/python/threading_thread_increment_race_no_flag_fail/main.py
@@ -5,9 +5,10 @@ import threading
 # where both threads read counter==0 before either writes leaves
 # counter==1, violating the assertion.
 #
-# Regression for #4584, exercising the ``--data-races-check`` path.
-# threading_thread_increment_race_no_flag_fail runs the same program
-# without that flag.
+# Regression for #4584, the plain path: no --data-races-check. That flag
+# used to be the only thing keeping interleaving generation alive once a
+# sibling schedule had run __ESBMC_main to completion, because the
+# reachability tree tracked that per search rather than per state.
 counter: int = 0
 
 

--- a/regression/python/threading_thread_increment_race_no_flag_fail/test.desc
+++ b/regression/python/threading_thread_increment_race_no_flag_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc --context-bound 2
+^VERIFICATION FAILED$
+^.*assertion.*$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -139,6 +139,7 @@ ignored_dirs=(
   "range19-fail"
   "ternary_symbolic"
   "threading_thread_increment_race_fail"
+  "threading_thread_increment_race_no_flag_fail"
   "threading_thread_race_fail"
   "threading_thread_subclass_race_fail"
   "threading_thread_subclass_run_assert_fail"

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -488,10 +488,16 @@ bool execution_statet::check_if_ileaves_blocked()
     // and to what thread.
     return true;
 
+  // Don't generate further interleavings since the __ESBMC_main thread has
+  // ended. Whether it has is a property of *this* state, not of the search:
+  // the reachability tree's own flag is set once and never cleared on
+  // backtracking, so a single branch running main to completion used to
+  // disable interleaving for every branch explored afterwards -- which is
+  // where the racy schedules live (#4584).
   if (
-    art1->main_thread_ended && !options.get_bool_option("deadlock-check") &&
+    !threads_state.empty() && threads_state[0].thread_ended &&
+    !options.get_bool_option("deadlock-check") &&
     !options.get_bool_option("data-races-check"))
-    // Don't generate further interleavings since __ESBMC_main thread has ended.
     return true;
 
   if (threads_state.size() < 2)


### PR DESCRIPTION
check_if_ileaves_blocked() consulted the reachability tree's
main_thread_ended flag, which is set when __ESBMC_main ends and is never
cleared on backtracking, so the first branch to run main to completion
disabled interleaving generation for every branch explored afterwards --
which is where the race-exposing schedules live.

Fixes #4584
