### PR TITLE
[goto-symex] Mark a thread explored when the switch is taken

### DIFF
--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -464,6 +464,8 @@ void reachability_treet::create_next_state()
 
   if (next_thread_id != ex_state.threads_state.size())
   {
+    get_cur_scheduler_frame().mark_explored(next_thread_id);
+
     auto new_state = ex_state.clone();
     exploration_frames.push_back({new_state, scheduler_framet{}});
 
@@ -683,10 +685,13 @@ void reachability_treet::mark_active_thread_explored()
   get_cur_scheduler_frame().mark_explored(get_cur_state().active_thread);
 }
 
+// Pure: whether tid is still an unexplored, runnable switch target on this
+// frame. Marking it explored is create_next_state's job, once the switch is
+// actually taken -- deciding is not the same as going, and get_next_formula
+// can bail between the two (#4482).
 bool reachability_treet::dfs_explore_thread(unsigned int tid)
 {
-  scheduler_framet &frame = get_cur_scheduler_frame();
-  if (frame.is_explored(tid))
+  if (get_cur_scheduler_frame().is_explored(tid))
     return false;
 
   if (get_cur_state().threads_state.at(tid).call_stack.empty())
@@ -695,7 +700,6 @@ bool reachability_treet::dfs_explore_thread(unsigned int tid)
   if (get_cur_state().threads_state.at(tid).thread_ended)
     return false;
 
-  frame.mark_explored(tid);
   return true;
 }
 


### PR DESCRIPTION
dfs_explore_thread() doubled as the "can we schedule tid?" predicate and
as the point that marked tid explored, but get_next_formula() can bail
between deciding and switching. The mark then survived on a thread never
visited. Move it to create_next_state(), where the switch is committed.

Measured over 12 pthread benchmarks under --unwind 5 --context-bound 5:
the bail fires 3028 times either way, leaving a stale explored mark on
all 3028 before and none after.

Fixes #4482
