### PR TITLE
[regression] Pin deadlock-check precision on disjoint critical sections

### DIFF
--- a/regression/esbmc-unix/github_6474_disjoint/main.c
+++ b/regression/esbmc-unix/github_6474_disjoint/main.c
@@ -1,0 +1,42 @@
+/* Deadlock-free: t1 releases m before it ever wants n, so no thread holds one
+   mutex while waiting for the other and no wait-for cycle exists. The two
+   critical sections are disjoint rather than nested, which is what separates
+   this from github_6474_disjoint_fail.
+
+   Counting blocked threads reports this as deadlocked if a blocked thread's
+   contribution outlives the unlock that released it: the blocked count then
+   reaches the running count and the assertion fires on a program that cannot
+   deadlock. Cancelling a mutex's waiters at unlock time (#6474) is what keeps
+   this SUCCESSFUL. */
+#include <pthread.h>
+pthread_mutex_t m, n;
+
+void *t1(void *a)
+{
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  pthread_mutex_lock(&n);
+  pthread_mutex_unlock(&n);
+  return 0;
+}
+
+void *t2(void *a)
+{
+  pthread_mutex_lock(&n);
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  pthread_mutex_unlock(&n);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_init(&n, 0);
+  pthread_create(&a, 0, t1, 0);
+  pthread_create(&b, 0, t2, 0);
+  pthread_join(a, 0);
+  pthread_join(b, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6474_disjoint/test.desc
+++ b/regression/esbmc-unix/github_6474_disjoint/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--deadlock-check --unwind 2 --context-bound 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6474_disjoint_fail/main.c
+++ b/regression/esbmc-unix/github_6474_disjoint_fail/main.c
@@ -1,0 +1,37 @@
+/* The nested counterpart of github_6474_disjoint: t1 holds m while waiting for
+   n and t2 holds n while waiting for m, so a wait-for cycle does exist and the
+   deadlock must still be reported. Pairs with that test so cancelling waiters
+   at unlock time cannot be tightened into missing real deadlocks. */
+#include <pthread.h>
+
+pthread_mutex_t m, n;
+
+void *t1(void *a)
+{
+  pthread_mutex_lock(&m);
+  pthread_mutex_lock(&n);
+  pthread_mutex_unlock(&n);
+  pthread_mutex_unlock(&m);
+  return 0;
+}
+
+void *t2(void *a)
+{
+  pthread_mutex_lock(&n);
+  pthread_mutex_lock(&m);
+  pthread_mutex_unlock(&m);
+  pthread_mutex_unlock(&n);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_mutex_init(&m, 0);
+  pthread_mutex_init(&n, 0);
+  pthread_create(&a, 0, t1, 0);
+  pthread_create(&b, 0, t2, 0);
+  pthread_join(a, 0);
+  pthread_join(b, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6474_disjoint_fail/test.desc
+++ b/regression/esbmc-unix/github_6474_disjoint_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--deadlock-check --unwind 2 --context-bound 3
+^VERIFICATION FAILED$
+^.*Deadlocked state.*$


### PR DESCRIPTION
Two threads that take the same pair of mutexes in opposite orders deadlock only
when the critical sections nest. The disjoint shape -- one thread releases the
first mutex before it ever wants the second -- has no wait-for cycle, but a
blocked-thread counter reports it as deadlocked if a waiter's contribution
outlives the unlock that released it.

Adds both shapes: the disjoint one must stay SUCCESSFUL, the nested one must
still report the deadlock, so the waiter cancellation added for #6474 cannot be
tightened into missing real deadlocks. Neither shape was covered -- the existing
github_6474 case has two identical workers plus a main-held mutex.

Relates to #6474
