### PR TITLE
[clang-frontend] Colourize clang AST dumps

### DIFF
--- a/regression/esbmc/github_746/main.c
+++ b/regression/esbmc/github_746/main.c
@@ -1,3 +1,7 @@
+/* THOROUGH, i.e. Linux-only: on Windows LLVM's prepare_colors() refuses colour
+   for any stream that is not a console (Process::ColorNeedsFlush()), and the
+   dump goes through a raw_os_ostream, so the escapes never appear there.
+   github_746_nocolor pins the absence case on every platform. */
 int main(void)
 {
   void *p = &&lbl;   /* indirect goto: unsupported, triggers an AST dump */

--- a/regression/esbmc/github_746/main.c
+++ b/regression/esbmc/github_746/main.c
@@ -1,0 +1,7 @@
+int main(void)
+{
+  void *p = &&lbl;   /* indirect goto: unsupported, triggers an AST dump */
+lbl:
+  goto *p;
+  return 0;
+}

--- a/regression/esbmc/github_746/test.desc
+++ b/regression/esbmc/github_746/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.c
 --color always
 ^.*CONVERSION ERROR$

--- a/regression/esbmc/github_746/test.desc
+++ b/regression/esbmc/github_746/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--color always
+^.*CONVERSION ERROR$
+\x1b\[0;1;35mIndirectGotoStmt

--- a/regression/esbmc/github_746_nocolor/main.c
+++ b/regression/esbmc/github_746_nocolor/main.c
@@ -1,0 +1,7 @@
+int main(void)
+{
+  void *p = &&lbl;   /* indirect goto: unsupported, triggers an AST dump */
+lbl:
+  goto *p;
+  return 0;
+}

--- a/regression/esbmc/github_746_nocolor/test.desc
+++ b/regression/esbmc/github_746_nocolor/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--color never
+^.*CONVERSION ERROR$
+\A(?!(?s:.)*\x1b\[0;1;35m)

--- a/src/clang-c-frontend/CMakeLists.txt
+++ b/src/clang-c-frontend/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(clangcfrontend_stuff clang_c_language.cpp clang_c_convert.cpp
             clang_c_main.cpp clang_c_adjust_expr.cpp typecast.cpp clang_c_adjust_code.cpp
             clang_c_convert_literals.cpp clang_headers.cpp padding.cpp
             clang_c_adjust_polymorphic_functions.cpp nested_func_transform.cpp
-            clang_c_lexer.cpp)
+            clang_c_lexer.cpp clang_ast_dump.cpp)
 target_include_directories(clangcfrontend_stuff
     PRIVATE ${CMAKE_BINARY_DIR}/src
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/clang-c-frontend/clang_ast_dump.cpp
+++ b/src/clang-c-frontend/clang_ast_dump.cpp
@@ -1,0 +1,18 @@
+#include <clang-c-frontend/clang_ast_dump.h>
+
+#include <clang/AST/ASTContext.h>
+#include <clang/Basic/Diagnostic.h>
+#include <llvm/Support/raw_ostream.h>
+#include <util/config/config.h>
+
+void enable_ast_dump_colors(llvm::raw_ostream &os, clang::ASTContext &ctx)
+{
+  /* command_line_options.cpp resolves --color (auto honours isatty on stderr)
+   * before the frontend runs. The dump lands in a std::string that the logger
+   * may write anywhere, so an unconditional opt-in would leak escapes into
+   * redirected output. */
+  const bool colored = config.options.get_bool_option("color");
+
+  os.enable_colors(colored);
+  ctx.getDiagnostics().setShowColors(colored);
+}

--- a/src/clang-c-frontend/clang_ast_dump.h
+++ b/src/clang-c-frontend/clang_ast_dump.h
@@ -1,0 +1,23 @@
+#ifndef CLANG_C_FRONTEND_CLANG_AST_DUMP_H
+#define CLANG_C_FRONTEND_CLANG_AST_DUMP_H
+
+namespace clang
+{
+class ASTContext;
+}
+namespace llvm
+{
+class raw_ostream;
+}
+
+/// Opt @p os into clang's coloured AST dumps, honouring `--color`.
+///
+/// Two independent gates suppress the colour that `--parse-tree-*` already
+/// gets (esbmc/esbmc#746): `Decl::dump` builds its ASTDumper from
+/// `ASTContext::getDiagnostics().getShowColors()`, and `raw_ostream` refuses
+/// to emit escapes to a stream that is not a terminal -- which the
+/// `raw_os_ostream` wrappers around `std::ostringstream` never are. Open both,
+/// or neither.
+void enable_ast_dump_colors(llvm::raw_ostream &os, clang::ASTContext &ctx);
+
+#endif

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -14,6 +14,7 @@ CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <clang/Index/USRGeneration.h>
 #include <clang/Frontend/ASTUnit.h>
 #include <llvm/Support/raw_os_ostream.h>
+#include <clang-c-frontend/clang_ast_dump.h>
 CC_DIAGNOSTIC_POP()
 
 #include <ac_config.h>
@@ -294,6 +295,7 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
   default:
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
 
     ross << "unrecognized / unimplemented clang declaration "
          << decl.getDeclKindName() << "\n";
@@ -1448,6 +1450,7 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
   default:
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     ross << "Conversion of unsupported clang type: \"";
     ross << the_type.getTypeClassName() << "\n";
     the_type.dump(ross, *ASTContext);
@@ -1877,6 +1880,7 @@ bool clang_c_convertert::get_builtin_type(
   {
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
 
     ross << "Unrecognized clang builtin type "
          << bt.getName(clang::PrintingPolicy(clang::LangOptions())).str()
@@ -1920,6 +1924,7 @@ bool clang_c_convertert::get_bitfield_type(
     log_error("Clang could not calculate bitfield width");
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     fd.getBitWidth()->dump(ross, *ASTContext);
     ross.flush();
     log_error("{}", oss.str());
@@ -3380,6 +3385,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       log_error("ESBMC currently does not support indirect gotos");
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
       stmt.dump(ross, *ASTContext);
       ross.flush();
       log_error("{}", oss.str());
@@ -3417,6 +3423,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
       ross << "ESBMC could not find the parent scope for "
            << "the following return statement:"
            << "\n";
@@ -3507,6 +3514,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
       ross << "Conversion of unsupported value-dependent type-trait expr: \"";
       ross << stmt.getStmtClassName() << "\" to expression"
            << "\n";
@@ -3671,6 +3679,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
   {
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     ross << "Conversion of unsupported clang expr: \"";
     ross << stmt.getStmtClassName() << "\" to expression"
          << "\n";
@@ -3750,6 +3759,7 @@ bool clang_c_convertert::get_decl_ref(const clang::Decl &d, exprt &new_expr)
 
   std::ostringstream oss;
   llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
   ross << "Conversion of unsupported clang decl ref: \"";
   ross << d.getDeclKindName() << "\" to expression"
        << "\n";
@@ -4017,6 +4027,7 @@ bool clang_c_convertert::get_cast_expr(
   {
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     ross << "Conversion of unsupported clang cast operator: \"";
     ross << cast.getCastKindName() << "\" to expression"
          << "\n";
@@ -4101,6 +4112,7 @@ bool clang_c_convertert::get_unary_operator_expr(
   {
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     ross << "Conversion of unsupported clang unary operator: \"";
     ross << clang::UnaryOperator::getOpcodeStr(uniop.getOpcode()).str()
          << "\" to expression"
@@ -4305,6 +4317,7 @@ bool clang_c_convertert::get_compound_assign_expr(
   {
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     ross << "Conversion of unsupported clang binary operator: \"";
     ross << compop.getOpcodeStr().str() << "\" to expression"
          << "\n";
@@ -4478,6 +4491,7 @@ bool clang_c_convertert::get_atomic_expr(
     log_error("Unknown Atomic expression");
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     atm.dump(ross, *ASTContext);
     ross.flush();
     log_error("{}", oss.str());
@@ -4750,6 +4764,7 @@ void clang_c_convertert::get_decl_name(
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
       nd.dump(ross);
       ross.flush();
       log_error("Declaration has an empty name:\n{}", oss.str());
@@ -4767,6 +4782,7 @@ void clang_c_convertert::get_decl_name(
   // Otherwise, abort
   std::ostringstream oss;
   llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
   ross << "Unable to generate the USR for:\n";
   nd.dump(ross);
   ross.flush();
@@ -5181,6 +5197,7 @@ bool clang_c_convertert::get_APValue_expr(
     log_error("Unsupported APValue expression");
     std::ostringstream oss;
     llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
     value.dump(ross, *ASTContext);
     ross.flush();
     log_error("{}", oss.str());

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3385,7 +3385,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       log_error("ESBMC currently does not support indirect gotos");
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+      enable_ast_dump_colors(ross, *ASTContext);
       stmt.dump(ross, *ASTContext);
       ross.flush();
       log_error("{}", oss.str());
@@ -3423,7 +3423,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+      enable_ast_dump_colors(ross, *ASTContext);
       ross << "ESBMC could not find the parent scope for "
            << "the following return statement:"
            << "\n";
@@ -3514,7 +3514,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+      enable_ast_dump_colors(ross, *ASTContext);
       ross << "Conversion of unsupported value-dependent type-trait expr: \"";
       ross << stmt.getStmtClassName() << "\" to expression"
            << "\n";
@@ -3759,7 +3759,7 @@ bool clang_c_convertert::get_decl_ref(const clang::Decl &d, exprt &new_expr)
 
   std::ostringstream oss;
   llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+  enable_ast_dump_colors(ross, *ASTContext);
   ross << "Conversion of unsupported clang decl ref: \"";
   ross << d.getDeclKindName() << "\" to expression"
        << "\n";
@@ -4764,7 +4764,7 @@ void clang_c_convertert::get_decl_name(
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+      enable_ast_dump_colors(ross, *ASTContext);
       nd.dump(ross);
       ross.flush();
       log_error("Declaration has an empty name:\n{}", oss.str());
@@ -4782,7 +4782,7 @@ void clang_c_convertert::get_decl_name(
   // Otherwise, abort
   std::ostringstream oss;
   llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+  enable_ast_dump_colors(ross, *ASTContext);
   ross << "Unable to generate the USR for:\n";
   nd.dump(ross);
   ross.flush();

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -266,7 +266,7 @@ void clang_cpp_convertert::get_decl_name(
   // Otherwise, abort
   std::ostringstream oss;
   llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+  enable_ast_dump_colors(ross, *ASTContext);
   ross << "Unable to generate the USR for:\n";
   nd.dump(ross);
   ross.flush();
@@ -1208,7 +1208,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
-    enable_ast_dump_colors(ross, *ASTContext);
+      enable_ast_dump_colors(ross, *ASTContext);
       ross << "Conversion of unsupported value-dependent size-of-pack expr: \"";
       ross << stmt.getStmtClassName() << "\" to expression"
            << "\n";

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -18,6 +18,7 @@ CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/Support/raw_os_ostream.h>
+#include <clang-c-frontend/clang_ast_dump.h>
 CC_DIAGNOSTIC_POP()
 
 #include <clang-cpp-frontend/clang_cpp_convert.h>
@@ -265,6 +266,7 @@ void clang_cpp_convertert::get_decl_name(
   // Otherwise, abort
   std::ostringstream oss;
   llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
   ross << "Unable to generate the USR for:\n";
   nd.dump(ross);
   ross.flush();
@@ -1206,6 +1208,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     {
       std::ostringstream oss;
       llvm::raw_os_ostream ross(oss);
+    enable_ast_dump_colors(ross, *ASTContext);
       ross << "Conversion of unsupported value-dependent size-of-pack expr: \"";
       ross << stmt.getStmtClassName() << "\" to expression"
            << "\n";


### PR DESCRIPTION
The AST dumps printed on unsupported constructs were always plain, while
`--parse-tree-*` output is coloured. Two gates suppress them: `Decl::dump`
builds its `ASTDumper` from `ASTContext`'s `getShowColors()`, and `raw_ostream`
refuses escapes to a non-terminal -- which the `raw_os_ostream` wrappers around
`std::ostringstream` never are.

Open both from the already-resolved `--color` option, so redirected output stays
clean: `never` and `auto`-when-piped emit no escapes, `always` gets clang's node
colours.

Fixes #746
