### PR TITLE
[regression] Pin the data-race verdicts recovered since #2928

### DIFF
--- a/regression/esbmc-unix/github_2928_escape_norace/main.c
+++ b/regression/esbmc-unix/github_2928_escape_norace/main.c
@@ -1,0 +1,29 @@
+/* No-race control for github_2928_escape_rc: identical shape -- main's stack
+   local escapes to the spawned thread -- except both sides take the same
+   mutex, so the accesses are ordered and no race exists. Pairs with that test
+   so recognising an escaped stack local as shared cannot degrade into
+   reporting a race on every such access. */
+#include <pthread.h>
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg)
+{
+  int *p = (int *)arg;
+  pthread_mutex_lock(&mutex);
+  (*p)++;
+  pthread_mutex_unlock(&mutex);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t id;
+  int i = 0;
+  pthread_create(&id, 0, t_fun, (void *)&i);
+  pthread_mutex_lock(&mutex);
+  i++;
+  pthread_mutex_unlock(&mutex);
+  pthread_join(id, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/github_2928_escape_norace/test.desc
+++ b/regression/esbmc-unix/github_2928_escape_norace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--32 --sv-comp --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --smt-symex-guard --cswitch-skip-readonly-globals --no-pointer-check --no-bounds-check --data-races-check-only --no-assertions --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_2928_escape_rc/main.c
+++ b/regression/esbmc-unix/github_2928_escape_rc/main.c
@@ -1,0 +1,31 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2005-2021 University of Tartu & Technische Universität München
+//
+// SPDX-License-Identifier: MIT
+
+#include <pthread.h>
+#include <stdio.h>
+
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  int *p = (int *) arg;
+  pthread_mutex_lock(&mutex1);
+  (*p)++; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  int i;
+  pthread_create(&id, NULL, t_fun, (void *) &i);
+  pthread_mutex_lock(&mutex2);
+  i++; // RACE!
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/regression/esbmc-unix/github_2928_escape_rc/test.desc
+++ b/regression/esbmc-unix/github_2928_escape_rc/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--32 --sv-comp --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --smt-symex-guard --cswitch-skip-readonly-globals --no-pointer-check --no-bounds-check --data-races-check-only --no-assertions --incremental-bmc
+^VERIFICATION FAILED$
+^.*data race.*$

--- a/regression/esbmc-unix/github_2928_funptr_rc/main.c
+++ b/regression/esbmc-unix/github_2928_funptr_rc/main.c
@@ -1,0 +1,35 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2005-2021 University of Tartu & Technische Universität München
+//
+// SPDX-License-Identifier: MIT
+
+#include <pthread.h>
+#include <stdio.h>
+
+
+int f1() { return 4; }
+int f2() { return 5; }
+
+int (*fp)() = f1;
+
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&mutex1);
+  fp = f2; // RACE!
+  pthread_mutex_unlock(&mutex1);
+  return NULL;
+}
+
+int main(void) {
+  pthread_t id;
+  pthread_create(&id, NULL, t_fun, NULL);
+  pthread_mutex_lock(&mutex2);
+  fp();  // RACE!
+  pthread_mutex_unlock(&mutex2);
+  pthread_join (id, NULL);
+  return 0;
+}

--- a/regression/esbmc-unix/github_2928_funptr_rc/test.desc
+++ b/regression/esbmc-unix/github_2928_funptr_rc/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--32 --sv-comp --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --smt-symex-guard --cswitch-skip-readonly-globals --no-pointer-check --no-bounds-check --data-races-check-only --no-assertions --incremental-bmc
+^VERIFICATION FAILED$
+^.*data race.*$

--- a/regression/esbmc-unix/github_2928_qw2004_2/main.c
+++ b/regression/esbmc-unix/github_2928_qw2004_2/main.c
@@ -1,0 +1,80 @@
+// Source: Shaz Qadeer, Dinghao Wu: "KISS: Keep It Simple and Sequential",
+// PLDI 2004
+// Simplified to remove heap accesses
+
+#include <pthread.h>
+#include "assert.h"
+
+volatile int stoppingFlag;
+volatile int pendingIo;
+volatile int stoppingEvent;
+volatile int stopped;
+
+int BCSP_IoIncrement() {
+    __VERIFIER_atomic_begin();
+    int lsf = stoppingFlag;
+    __VERIFIER_atomic_end();
+    if (lsf) {
+	return -1;
+    } else {
+    __VERIFIER_atomic_begin();
+    int lp = pendingIo;
+    __VERIFIER_atomic_end();
+    __VERIFIER_atomic_begin();
+    pendingIo = lp + 1;
+    __VERIFIER_atomic_end();
+    }
+    return 0;
+}
+
+int dec() {
+    __VERIFIER_atomic_begin();
+    pendingIo--;
+    int tmp = pendingIo;
+    __VERIFIER_atomic_end();
+    return tmp;
+}
+
+void BCSP_IoDecrement() {
+    int pending;
+    pending = dec();
+    if (pending == 0) {
+    __VERIFIER_atomic_begin();
+	stoppingEvent = 1;
+    __VERIFIER_atomic_end();
+    }
+}
+
+void* BCSP_PnpAdd(void* arg) {
+    int status;
+    status = BCSP_IoIncrement();
+    if (status == 0) {
+	__VERIFIER_assert(!stopped);
+    }
+    BCSP_IoDecrement();
+    return 0;
+}
+
+void* BCSP_PnpStop(void* arg) {
+    __VERIFIER_atomic_begin();
+    stoppingFlag = 1;
+    __VERIFIER_atomic_end();
+    BCSP_IoDecrement();
+    __VERIFIER_atomic_begin();
+    int lse = stoppingEvent;
+    __VERIFIER_atomic_end();
+    assume_abort_if_not(lse);
+    stopped = 1;
+    return 0;
+}
+
+int main() {
+    pthread_t t;
+    pendingIo = 1;
+    stoppingFlag = 0;
+    stoppingEvent = 0;
+    stopped = 0;
+    pthread_create(&t, 0, BCSP_PnpStop, 0);
+    BCSP_PnpAdd(0);
+    return 0;
+}

--- a/regression/esbmc-unix/github_2928_qw2004_2/test.desc
+++ b/regression/esbmc-unix/github_2928_qw2004_2/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--32 --sv-comp --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets --smt-symex-guard --cswitch-skip-readonly-globals --no-pointer-check --no-bounds-check --data-races-check-only --no-assertions --incremental-bmc
+^VERIFICATION FAILED$
+^.*data race.*$


### PR DESCRIPTION
#2928 still lists four unresolved data-race benchmarks. Three are reproducible
off an x86 host, and all three now give the expected verdict:

| benchmark | ground truth | verdict |
|---|---|---|
| `goblint-regression/04-mutex_45-escape_rc` | race | FALSE |
| `goblint-regression/04-mutex_50-funptr_rc` | race | FALSE |
| `pthread-lit/qw2004-2` | race | FALSE |

`goblint-regression/06-symbeq_07-tricky_address2` also gives the expected TRUE,
but takes ~60s locally, too close to the CI cap to add. The remaining entry is
an LDV task that needs an x86 host to parse.

Adds the three as regression tests, plus a no-race twin of the escaped-local
case so recognising an escaped stack local as shared cannot degrade into
reporting a race on every such access. All four run in under 3s combined.

Relates to #2928
