### PR TITLE
[build] re-derive the version ID on every build

### DIFF
--- a/scripts/buildidobj.py
+++ b/scripts/buildidobj.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys, os
+import re  # For comparing build IDs
 import shutil  # For git
 import subprocess  # For git
 from datetime import datetime  # For date
@@ -74,17 +75,41 @@ class BuildObj:
         return True
 
     @staticmethod
+    def format_id() -> str:
+        line = (f'{BuildObj.STR_ESBMC_BUILT_FROM} {BuildObj.get_last_hash()} '
+                f'{BuildObj.get_datetime()} {BuildObj.STR_BY} '
+                f'{BuildObj.get_username()}{BuildObj.STR_AT}'
+                f'{BuildObj.get_hostname()}')
+        if BuildObj.is_dirty_tree():
+            line += f' {BuildObj.STR_DIRTY}'
+        return line
+
+    @staticmethod
+    def without_datetime(line: str) -> str:
+        return re.sub(r'\d{4}-\d{2}-\d{2} [\d:.]+ ', '', line)
+
+    @staticmethod
+    def describes_same_build(output, line) -> bool:
+        """The build system re-runs this on every build so the ID cannot go
+        stale. Rewriting unconditionally would then relink the whole binary
+        every time, so report when the only difference is the timestamp."""
+        # errors='replace' rather than a narrower except: a file written by an
+        # older revision carries the locale encoding, and a decode failure here
+        # would abort the build. Mangled text simply reads as a different ID.
+        try:
+            with open(output, encoding='utf-8', errors='replace') as f:
+                old = f.read()
+        except OSError:
+            return False
+        return BuildObj.without_datetime(old) == BuildObj.without_datetime(line)
+
+    @staticmethod
     def run(output):
-        with open(output, 'w') as f:
-            f.write(f'{BuildObj.STR_ESBMC_BUILT_FROM} ')
-            f.write(f'{BuildObj.get_last_hash()} ')
-            f.write(f'{BuildObj.get_datetime()} ')
-            f.write(f'{BuildObj.STR_BY} ')
-            f.write(f'{BuildObj.get_username()}')
-            f.write(f'{BuildObj.STR_AT}')
-            f.write(f'{BuildObj.get_hostname()}')
-            if BuildObj.is_dirty_tree():
-                f.write(f' {BuildObj.STR_DIRTY}')
+        line = BuildObj.format_id()
+        if BuildObj.describes_same_build(output, line):
+            return
+        with open(output, 'w', encoding='utf-8') as f:
+            f.write(line)
 
 
 def main():

--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -27,8 +27,15 @@ if(ENABLE_JIMPLE_FRONTEND)
   set(JIMPLE_FRONTEND_TARGETS jimple)
 endif()
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.txt
+# A custom target always runs, so the version ID is re-derived on every build
+# rather than once when the build tree is configured, which is what made
+# --git-hash report the configure-time commit instead of the compiled one.
+# buildidobj.py leaves the file untouched when only its timestamp would change,
+# so the flail rule below, and the relink after it, still only fire when the ID
+# actually changes.
+add_custom_target(esbmc_buildid
   COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/buildidobj.py ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.txt
+  BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.txt
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating ESBMC version ID"
   VERBATIM
@@ -36,7 +43,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.txt
 set(BUILD_ID_OBJ_OUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.txt)
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c
   COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/flail.py -o ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c ${BUILD_ID_OBJ_OUT}
-  DEPENDS  ${BUILD_ID_OBJ_OUT} ${CMAKE_SOURCE_DIR}/scripts/flail.py
+  DEPENDS  ${BUILD_ID_OBJ_OUT} ${CMAKE_SOURCE_DIR}/scripts/flail.py esbmc_buildid
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Flailing build ID object"
   VERBATIM


### PR DESCRIPTION
Fixes #6615.

## What

`--git-hash` reported the commit the build tree was **configured** at rather than the one compiled in, because the rule generating the version ID declared no `DEPENDS` and its output already existed, so ninja ran it once and never again.

On the tree this was found on, a binary linked 2026-07-30 from `2b84f2a8ec` reported `ef23805e29` dated 2026-04-20, a commit that is not even an ancestor of the one built.

## How

- `buildidobj-rerun` is added as a second output and is never created, so the rule stays permanently out of date and re-runs every build.
- Rewriting the file every build would relink the whole binary every build, since `buildidobj.c` depends on it. So `buildidobj.py` now compares against the existing file with the timestamp removed, and returns without writing when only the timestamp would differ. The timestamp's meaning becomes "when the version ID last changed", which is also more useful than "when it was last relinked".
- The rule now also declares `DEPENDS` on `buildidobj.py` itself.

The emitted string format is unchanged.

## Testing

Verified in an isolated CMake project with the same generator that the sentinel output does force a re-run on every build, and that a downstream rule consuming the file does **not** re-run while the content is unchanged (this is what keeps the relink cost at zero).

Against this repository:

| check | result |
| --- | --- |
| generated ninja edge | `buildidobj.txt` and `buildidobj-rerun` both declared as outputs, `DEPENDS` on the script |
| output format vs `master` | byte-identical once the timestamp is removed |
| refreshing the stale file in-place | `ef23805e29 2026-04-20` becomes `f0979a428a 2026-08-01 (dirty tree)` |
| repeated runs, nothing changed | file untouched, mtime unchanged, so no relink |
| ID changed under it | rewritten with the correct sha |
| `yapf --style .style.yapf` | clean |

No test is added: this is build-system behaviour, `regression/`'s `test.desc` format does not apply to it, and `unit/` currently hosts only the Python frontend's model tests. Happy to add coverage if you would like it somewhere.
