### PR TITLE
[om] Make the kernel spin_lock model block instead of failing

### DIFF
--- a/regression/linux/kernel_spin_lock_held_past_limit/test.c
+++ b/regression/linux/kernel_spin_lock_held_past_limit/test.c
@@ -1,3 +1,8 @@
+/* The kernel's spin_lock() blocks and has no failure path (esbmc/esbmc#1332),
+   so holding the lock past the model's old SPIN_LIMIT must not lose thread 2's
+   increment. This program was kernel_race_condition_spinlock_fail, which
+   expected FAILED precisely because the old model gave up after SPIN_LIMIT
+   retries -- behaviour the kernel does not have. */
 #include <ubuntu20.04/kernel_5.15.0-76/include/linux/spinlock.h>
 #include <assert.h>
 #include <pthread.h>
@@ -8,7 +13,7 @@ spinlock_t lock;
 void* exceed_spin_limit(void* arg) {
    if(spin_lock(&lock))
    {
-    for(int i=0; i<(SPIN_LIMIT+30); i++) { } // delay release to mock the failure of thread2 acquiring the lock.
+    for(int i=0; i<(SPIN_LIMIT+30); i++) { } // hold the lock past the old retry bound
     shared_counter++;
     spin_unlock(&lock);
    }

--- a/regression/linux/kernel_spin_lock_held_past_limit/test.desc
+++ b/regression/linux/kernel_spin_lock_held_past_limit/test.desc
@@ -1,0 +1,4 @@
+CORE
+test.c
+--unwind 400 --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/linux/kernel_spin_lock_unlocked_fail/test.c
+++ b/regression/linux/kernel_spin_lock_unlocked_fail/test.c
@@ -1,0 +1,29 @@
+#include <ubuntu20.04/kernel_5.15.0-76/include/linux/spinlock.h>
+#include <assert.h>
+#include <pthread.h>
+
+/* Control for kernel_spin_lock_blocks: drop the lock and the increments race,
+   so the same assertion must be reachable. Keeps the pair discriminating -- a
+   spin_lock that never excluded anything would pass both. */
+int shared_counter = 0;
+spinlock_t lock;
+#define MAX_THREADS 2
+
+void *increment(void *arg)
+{
+  int local = shared_counter;
+  shared_counter = local + 1;
+  return NULL;
+}
+
+int main()
+{
+  pthread_t thread1, thread2;
+  spin_lock_init(&lock);
+  pthread_create(&thread1, NULL, increment, NULL);
+  pthread_create(&thread2, NULL, increment, NULL);
+  pthread_join(thread1, NULL);
+  pthread_join(thread2, NULL);
+  assert(shared_counter == MAX_THREADS);
+  return 0;
+}

--- a/regression/linux/kernel_spin_lock_unlocked_fail/test.desc
+++ b/regression/linux/kernel_spin_lock_unlocked_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 test.c
---unwind 400 --context-bound 2 
+--unwind 400 --context-bound 2
 ^VERIFICATION FAILED$

--- a/src/c2goto/library/kernel.c
+++ b/src/c2goto/library/kernel.c
@@ -133,21 +133,17 @@ bool spin_lock(spinlock_t *lock)
 __ESBMC_HIDE:;
   __ESBMC_assert(lock != NULL, "The lock is null, verfication failed");
 
-  int retries = 0;
-  while (retries < SPIN_LIMIT)
-  {
-    __ESBMC_atomic_begin();
-    if (lock->locked == false)
-    {
-      lock->locked = true;
-      __ESBMC_atomic_end();
-      return true;
-    }
-    __ESBMC_atomic_end();
-    retries++;
-  }
+  /* The kernel's spin_lock() spins until it holds the lock and has no failure
+     path -- only spin_trylock() may fail (esbmc/esbmc#1332). Block the same way
+     pthread_mutex_lock_noassert does rather than giving up after a bounded
+     number of retries. The bool result is retained for source compatibility and
+     is always true. */
+  __ESBMC_atomic_begin();
+  __ESBMC_assume(lock->locked == false);
+  lock->locked = true;
+  __ESBMC_atomic_end();
 
-  return false;
+  return true;
 }
 
 void spin_unlock(spinlock_t *lock)


### PR DESCRIPTION
The kernel's `spin_lock()` spins until it holds the lock and has no failure
path -- only `spin_trylock()` may fail. The model gave up after `SPIN_LIMIT`
retries and returned false, so a lock held a little too long silently lost the
caller's critical section.

Block the way `pthread_mutex_lock_noassert` already does. The `bool` result is
kept for source compatibility and is always true.

`kernel_race_condition_spinlock_fail` existed only to exercise that failure
path, so it becomes `kernel_spin_lock_held_past_limit` with the verdict flipped:
the same program is FAILED before this change and SUCCESSFUL after. A lock-free
control pins the other direction.

Fixes #1332
