### PR TITLE
[c++] Value-initialise the elements of new T[n]()

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6588/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6588/main.cpp
@@ -1,0 +1,22 @@
+#include <cassert>
+
+int nondet_int();
+
+int main()
+{
+  int *p = new int[4]();
+  assert(p[0] == 0 && p[3] == 0);
+  delete[] p;
+
+  int n = nondet_int();
+  __ESBMC_assume(n > 0 && n < 4);
+  int *q = new int[n]();
+  assert(q[0] == 0);
+  delete[] q;
+
+  int *r = new int[2]{};
+  assert(r[0] == 0 && r[1] == 0);
+  delete[] r;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6588/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6588/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6588_aggregate/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6588_aggregate/main.cpp
@@ -1,0 +1,39 @@
+#include <cassert>
+
+struct S
+{
+  int a;
+  int b;
+};
+
+struct U
+{
+  int a;
+  U() = default;
+};
+
+struct T
+{
+  int a;
+  T()
+  {
+    a = 7;
+  }
+};
+
+int main()
+{
+  S *s = new S[2]();
+  assert(s[0].a == 0 && s[0].b == 0 && s[1].a == 0 && s[1].b == 0);
+  delete[] s;
+
+  U *u = new U[2]();
+  assert(u[0].a == 0 && u[1].a == 0);
+  delete[] u;
+
+  T *t = new T[3]();
+  assert(t[0].a == 7 && t[2].a == 7);
+  delete[] t;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6588_aggregate/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6588_aggregate/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6588_ctor_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6588_ctor_fail/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+
+struct T
+{
+  int a;
+  T()
+  {
+    a = 7;
+  }
+};
+
+int main()
+{
+  // [dcl.init]/8: a class with a user-provided default constructor is
+  // value-initialised by calling that constructor, with no prior zeroing --
+  // the braced spelling must not be zero-filled on top of it.
+  T *t = new T[2]{};
+  assert(t[0].a == 0);
+  delete[] t;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6588_ctor_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6588_ctor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6588_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6588_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+
+int main()
+{
+  // [dcl.init]/7: the non-parenthesised form default-initialises, which leaves
+  // a scalar element indeterminate -- the zero must not be assumed here.
+  int *p = new int[4];
+  assert(p[0] == 0);
+  delete[] p;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6588_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6588_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_6588_multidim_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6588_multidim_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+
+int main()
+{
+  // An array element type is left indeterminate rather than zero-filled;
+  // this must still produce a verdict rather than an internal error.
+  int(*a)[3] = new int[2][3]();
+  assert(a[0][0] == 0);
+  delete[] a;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6588_multidim_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6588_multidim_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -618,6 +618,38 @@ static const clang::FunctionDecl *resolve_deallocation_function(
   return nullptr;
 }
 
+// Does this new-expression initializer value-initialise the allocated elements?
+// Clang spells the same request three ways: an ImplicitValueInitExpr for a
+// scalar element, an InitListExpr with no explicit initialiser for the braced
+// form, and, for a class element, a CXXConstructExpr carrying the zeroing flag
+// (set exactly when the constructor is not user-provided, so the elements are
+// zero-initialised before it runs).
+static bool zero_initialises(const clang::Expr &init)
+{
+  if (llvm::isa<clang::ImplicitValueInitExpr>(init))
+    return true;
+
+  if (const auto *ile = llvm::dyn_cast<clang::InitListExpr>(&init))
+  {
+    // A list with explicit initialisers zero-fills only the tail; modelling
+    // that needs the leading values too, which this does not supply.
+    if (ile->getNumInits() != 0)
+      return false;
+
+    // For an array new the per-element request is the filler, not an init, so
+    // a filler running a user-provided constructor must not be zeroed on top.
+    if (const clang::Expr *filler = ile->getArrayFiller())
+      return zero_initialises(*filler);
+
+    return true;
+  }
+
+  if (const auto *ce = llvm::dyn_cast<clang::CXXConstructExpr>(&init))
+    return ce->requiresZeroInitialization();
+
+  return false;
+}
+
 bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 {
   locationt location;
@@ -976,6 +1008,16 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
         return true;
       new_expr.add("alloc_function") = alloc_function;
     }
+
+    // [expr.new]/24: `new T[n]()` and `new T[n]{}` value-initialise every
+    // element, which zero-initialises whatever the element constructor -- if
+    // there is one at all -- does not write itself. Plain `new T[n]`
+    // default-initialises and correctly leaves a scalar element indeterminate,
+    // so the two forms must be told apart here (github #6588).
+    if (
+      ne.isArray() && ne.hasInitializer() &&
+      zero_initialises(*ne.getInitializer()))
+      new_expr.set("zero_initialized", true);
 
     if (ne.hasInitializer())
     {

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -548,6 +548,48 @@ static exprt *find_cpp_new_constructor(exprt &e)
   return nullptr;
 }
 
+// Zero the elements a value-initialising `new T[n]()` just allocated:
+//
+//   for (size_type i = 0; i < n; ++i)
+//     *(lhs + i) = <zero of T>;
+//
+// An assignment loop rather than a memset call: n need not be a compile-time
+// constant, and __ESBMC_memset falls back to a library body that is only linked
+// when the program itself calls memset.
+void goto_convertt::cpp_new_zero_fill(
+  const exprt &lhs,
+  const exprt &rhs,
+  const exprt &elem_count,
+  goto_programt &dest)
+{
+  const typet &subtype = ns.follow(rhs.type().subtype());
+
+  symbol_exprt index(new_tmp_symbol(size_type()).id, size_type());
+
+  // Pointer arithmetic on lhs, for the reason spelled out at the element
+  // constructor loop below: &lhs[i] does not survive symex.
+  plus_exprt element_addr(lhs, index);
+  element_addr.type() = lhs.type();
+
+  exprt element("dereference", subtype);
+  element.copy_to_operands(element_addr);
+
+  code_assignt body(element, gen_zero(subtype));
+  body.location() = rhs.find_location();
+
+  plus_exprt next(index, from_integer(1, size_type()));
+  next.type() = size_type();
+
+  code_fort loop;
+  loop.init() = code_assignt(index, from_integer(0, size_type()));
+  loop.cond() = binary_relation_exprt(index, "<", elem_count);
+  loop.iter() = code_assignt(index, next);
+  loop.body() = body;
+  loop.location() = rhs.find_location();
+
+  convert(loop, dest);
+}
+
 void goto_convertt::cpp_new_initializer(
   const exprt &lhs,
   const exprt &rhs,
@@ -608,6 +650,18 @@ void goto_convertt::cpp_new_initializer(
   {
     if (rhs.statement() == "cpp_new[]")
     {
+      // The parenthesised and braced-empty forms value-initialise, which zeroes
+      // every element the constructor -- if any -- does not write itself
+      // ([expr.new]/24, github #6588). The frontend flags exactly those forms,
+      // so plain `new T[n]` keeps its indeterminate elements.
+      // An array element type (`new T[n][m]()`) is skipped: symex rejects a
+      // dereference yielding an array, and leaving those elements
+      // indeterminate stays sound.
+      if (
+        rhs.get_bool("zero_initialized") &&
+        !ns.follow(rhs.type().subtype()).is_array())
+        cpp_new_zero_fill(lhs, rhs, elem_count, dest);
+
       // Construct every element: what the scalar arm below does once, done for
       // each element of the allocated array. Leaving this unimplemented meant
       // `new T[n]` ran no constructor at all, so members initialised by T's
@@ -617,12 +671,6 @@ void goto_convertt::cpp_new_initializer(
       //
       //   for (size_type i = 0; i < n; ++i)
       //     <element constructor, with `this` = lhs + i>
-      //
-      // Only when there is a constructor to run. `new int[n]` has none, and
-      // the scalar arm's zero-fill is not worth an n-iteration loop: it would
-      // both change the existing behaviour (the array form has always left
-      // such elements nondeterministic) and, for a symbolic n, cost far more
-      // than it buys.
       exprt *ctor = find_cpp_new_constructor(initializer);
       if (ctor == nullptr)
         return;

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -146,6 +146,12 @@ protected:
     const exprt &elem_count,
     goto_programt &dest);
 
+  void cpp_new_zero_fill(
+    const exprt &lhs,
+    const exprt &rhs,
+    const exprt &elem_count,
+    goto_programt &dest);
+
   //
   // function calls
   //

--- a/src/util/irep/migrate.cpp
+++ b/src/util/irep/migrate.cpp
@@ -1952,6 +1952,14 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
         migrate_expr(alloc_function, fn);
         args.push_back(fn);
       }
+
+      // Value-initialisation of the elements (github #6588) rides in
+      // arguments[2], for the same reason as the two slots above.
+      if (expr.get_bool("zero_initialized"))
+      {
+        args.resize(2);
+        args.push_back(gen_true_expr());
+      }
     }
     else if (
       expr.statement() == "malloc" || expr.statement() == "realloc" ||
@@ -3796,12 +3804,15 @@ exprt migrate_expr_back(const expr2tc &ref)
       ref2.kind == sideeffect2t::allockind::cpp_new_arr)
     {
       // cpp_new has no operands in source form (size lives in the size field,
-      // handled below; the initializer, if any, is carried in arguments[0],
-      // and a replaced operator new in arguments[1]).
+      // handled below; the initializer, if any, is carried in arguments[0], a
+      // replaced operator new in arguments[1], and the value-initialisation
+      // marker in arguments[2]).
       if (!ref2.arguments.empty() && !is_nil_expr(ref2.arguments[0]))
         theexpr.initializer(migrate_expr_back(ref2.arguments[0]));
       if (ref2.arguments.size() > 1 && !is_nil_expr(ref2.arguments[1]))
         theexpr.add("alloc_function") = migrate_expr_back(ref2.arguments[1]);
+      if (ref2.arguments.size() > 2 && !is_nil_expr(ref2.arguments[2]))
+        theexpr.set("zero_initialized", true);
     }
     else
     {


### PR DESCRIPTION
`new T[n]()` and `new T[n]{}` value-initialise every element per [expr.new]/24; ESBMC left them indeterminate, so correct code got a spurious violation. The frontend now flags exactly those forms and goto-convert zero-fills ahead of the element constructor, while plain `new T[n]` keeps its indeterminate elements.

Fixes #6588