### PR TITLE
[goto-symex] Test MPOR's un-run case on the diagonal, as the recurrence does

### DIFF
--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1225,7 +1225,11 @@ void execution_statet::calculate_mpor_constraints()
     if (j == active_thread)
       continue;
 
-    if (dependency_chain[j][active_thread] == 0)
+    // MPOR's rule is DCjj(k) == 0 -- "Tj has not run" -- not DCji(k) == 0. The
+    // two differ for a thread created after Tj last ran: its column is padded
+    // with 0, so testing it would skip the dependency below and drop the chain
+    // onto the new thread's first transition (A6.4).
+    if (dependency_chain[j][j] == 0)
     {
       // This thread hasn't been run; continue not having been run.
       new_dep_chain[j][active_thread] = 0;

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -489,6 +489,12 @@ public:
     return mpor_says_no;
   }
 
+  /** Read-only accessor for the MPOR dependency chain, for the A6.4 harness. */
+  const std::vector<std::vector<int>> &get_dependency_chain() const
+  {
+    return dependency_chain;
+  }
+
   /** Accessor method for cswitch_forced. Sets it to true. */
   void force_cswitch()
   {

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -7,3 +7,4 @@ new_unit_test(unwind-test "unwind.test.cpp" "test_goto_factory;symex;solvers;got
 new_unit_test(symex-invariant-test "invariant.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(determinism-test "determinism.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(slice-test "slice.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(mpor-test "mpor.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/mpor.test.cpp
+++ b/unit/goto-symex/mpor.test.cpp
@@ -1,0 +1,175 @@
+/*******************************************************************
+ Module: The MPOR dependency chain on the real engine
+
+ Tier B of docs/roadmap/goto-symex-verification-plan.md (H-A6's A6.4, M6).
+
+ `calculate_mpor_constraints` implements the recurrence of Kahlon, Wang and
+ Gupta's monotonic partial order reduction. Of its five rules, the one that
+ *removes* relations is the reset of the active thread's row, and A6.4 asks
+ whether that reset can lose a chain the reduction later needs -- a lost chain
+ blocks a transition, which drops interleavings with no diagnostic.
+
+ The reset is faithful: DCil records a chain from the last transition of Tl to
+ Ti's, and the transition just taken is the latest in the run, so no chain can
+ leave it. What is *not* a transcription of the recurrence is the guard on the
+ un-run case, which tests the column entry DCja where MPOR tests the diagonal
+ DCjj; that equivalence is a property of the run and is asserted in the engine.
+ This file pins the chain's shape after every interleaving of a real concurrent
+ program. It does *not* discriminate the un-run guard itself: reverting that
+ guard leaves every assertion here green, and the interleaving count unchanged
+ at 49, so the shape is what it pins and nothing more.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <string>
+#include <vector>
+
+#include <goto-symex/reachability_tree.h>
+#include <goto-symex/symex_target_equation.h>
+#include <util/symtab/namespace.h>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+class engine
+{
+public:
+  explicit engine(std::string src)
+    : source(std::move(src)),
+      prog(goto_factory::get_goto_functions(
+        source,
+        goto_factory::Architecture::BIT_64)),
+      ns(prog.context),
+      opts(goto_factory::get_default_options(
+        goto_factory::get_default_cmdline("test.c"))),
+      rt(
+        prog.functions,
+        ns,
+        opts,
+        std::make_shared<symex_target_equationt>(ns),
+        prog.context)
+  {
+    REQUIRE(prog.functions.function_map.size() > 0);
+    rt.setup_for_new_explore();
+  }
+
+  const std::vector<std::vector<int>> &run_one_interleaving()
+  {
+    rt.get_next_formula();
+    return rt.get_cur_state().get_dependency_chain();
+  }
+
+  bool more_interleavings()
+  {
+    return rt.setup_next_formula();
+  }
+
+private:
+  std::string source;
+  program prog;
+  namespacet ns;
+  optionst opts;
+  reachability_treet rt;
+};
+
+/// Chain shapes observed across an exploration, so a check cannot pass by
+/// never meeting the case it describes.
+struct census
+{
+  unsigned interleavings = 0;
+  unsigned run_threads = 0;
+  unsigned chains = 0;
+  unsigned no_relation = 0;
+};
+
+void check_chain(const std::vector<std::vector<int>> &dc, census &seen)
+{
+  const size_t n = dc.size();
+  REQUIRE(n >= 2);
+
+  for (size_t j = 0; j < n; j++)
+  {
+    REQUIRE(dc[j].size() == n);
+
+    bool row_all_zero = true;
+    for (size_t l = 0; l < n; l++)
+    {
+      REQUIRE(dc[j][l] >= -1);
+      REQUIRE(dc[j][l] <= 1);
+      row_all_zero &= dc[j][l] == 0;
+
+      if (j == l)
+        continue;
+      if (dc[j][l] == 1)
+        seen.chains++;
+      else if (dc[j][l] == -1)
+        seen.no_relation++;
+    }
+
+    // The diagonal is the run marker: a thread that has taken a transition
+    // depends on itself, and one that has not has no relation to anything.
+    // The converse of the second half does not hold -- a run thread's row
+    // carries 0 in the column of any thread created after it last ran, which
+    // is why the un-run test upstream has to be the diagonal.
+    REQUIRE((dc[j][j] == 0 || dc[j][j] == 1));
+    if (dc[j][j] == 0)
+      REQUIRE(row_all_zero);
+    else
+      seen.run_threads++;
+  }
+}
+
+const char *TWO_WRITERS = R"(
+#include <pthread.h>
+
+int g;
+int h;
+
+void *writer(void *arg)
+{
+  g = 1;
+  h = g;
+  return 0;
+}
+
+void *reader(void *arg)
+{
+  h = 2;
+  g = h;
+  return 0;
+}
+
+int main()
+{
+  pthread_t a, b;
+  pthread_create(&a, 0, writer, 0);
+  pthread_create(&b, 0, reader, 0);
+  return 0;
+}
+)";
+} // namespace
+
+TEST_CASE(
+  "the MPOR dependency chain keeps its shape across an exploration",
+  "[goto-symex][mpor]")
+{
+  engine e(TWO_WRITERS);
+  census seen;
+
+  do
+  {
+    check_chain(e.run_one_interleaving(), seen);
+    seen.interleavings++;
+  } while (seen.interleavings < 64 && e.more_interleavings());
+
+  // Anti-vacuity: the exploration has to have reached the shapes the checks
+  // above discriminate between, or they hold for want of a subject.
+  REQUIRE(seen.interleavings >= 2);
+  REQUIRE(seen.run_threads > 0);
+  REQUIRE(seen.chains > 0);
+  REQUIRE(seen.no_relation > 0);
+}


### PR DESCRIPTION
A6.4 of the goto-symex verification plan asks whether the `dependency_chain`
update in `calculate_mpor_constraints` can lose a relation. It can, though not
where the plan suspected: MPOR guards its un-run case on `DCjj` — "Tj has not
run yet" — while we guard it on `DCji`. The two disagree for a thread created
after `Tj` last ran, because thread creation pads every existing row with 0 in
the new column, so the dependency between `Tj`'s last transition and the new
thread's first one is skipped instead of computed.

Evidence and its limits, so the change is not oversold:

- an invariant asserting the two guards coincide fires on an ordinary
  two-thread program, which is what identified the divergence;
- no behavioural difference has been observed. The probe program explores 49
  interleavings either way, and the concurrency regression subset (`race`,
  `mpor`, `pthread`, `cswitch`, `deadlock`, `circular`) is green apart from
  `01_pthread60`, which is the known 120 s-cap timeout — 105.2 s standalone
  here, matching its pre-patch profile;
- the direction is the safe one: the guard only ever adds chains, and a chain
  makes `can_run` more permissive, so no interleaving can be lost by it.

The unit test pins the chain's shape after every interleaving. It does not
discriminate the guard — reverting the guard leaves it green — and its header
says so rather than implying coverage it lacks.