### PR TITLE
[om] Model <shared_mutex> over the pthread rwlock model

### DIFF
--- a/regression/esbmc-cpp/cpp/shared_mutex_exclusive/main.cpp
+++ b/regression/esbmc-cpp/cpp/shared_mutex_exclusive/main.cpp
@@ -1,0 +1,28 @@
+#include <cassert>
+#include <pthread.h>
+#include <shared_mutex>
+
+std::shared_mutex m;
+int counter = 0;
+
+void *bump(void *arg)
+{
+  m.lock();
+  int local = counter;
+  counter = local + 1;
+  m.unlock();
+  return 0;
+}
+
+int main()
+{
+  pthread_t t;
+  pthread_create(&t, 0, bump, 0);
+  bump(0);
+  pthread_join(t, 0);
+
+  std::shared_lock<std::shared_mutex> reader(m);
+  assert(reader.owns_lock());
+  assert(counter == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/shared_mutex_exclusive/test.desc
+++ b/regression/esbmc-cpp/cpp/shared_mutex_exclusive/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/shared_mutex_shared_race_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/shared_mutex_shared_race_fail/main.cpp
@@ -1,0 +1,28 @@
+#include <cassert>
+#include <pthread.h>
+#include <shared_mutex>
+
+std::shared_mutex m;
+int counter = 0;
+
+void *bump(void *arg)
+{
+  m.lock_shared();
+  int local = counter;
+  counter = local + 1;
+  m.unlock_shared();
+  return 0;
+}
+
+int main()
+{
+  pthread_t t;
+  pthread_create(&t, 0, bump, 0);
+  bump(0);
+  pthread_join(t, 0);
+
+  std::shared_lock<std::shared_mutex> reader(m);
+  assert(reader.owns_lock());
+  assert(counter == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/shared_mutex_shared_race_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/shared_mutex_shared_race_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --context-bound 2
+^VERIFICATION FAILED$

--- a/src/cpp/library/shared_mutex
+++ b/src/cpp/library/shared_mutex
@@ -1,0 +1,173 @@
+#ifndef STL_SHARED_MUTEX
+#define STL_SHARED_MUTEX
+
+#include <mutex>
+#include <pthread.h>
+#include "OM_compiler_defs.h"
+
+// Model of <shared_mutex> over ESBMC's pthread rwlock model, so the C++
+// wrappers reach the same lock/unlock semantics -- including the deadlock
+// check -- that pthread_rwlock_* already implement. The lock-ownership tags
+// (defer_lock/try_to_lock/adopt_lock) come from <mutex>, as they do in the
+// standard headers.
+//
+// Not modelled: shared_timed_mutex's try_lock_for/_until and their shared
+// counterparts (ESBMC has no clock to block against).
+
+#if __cplusplus >= 201402L
+
+namespace std
+{
+class __shared_mutex_base
+{
+  pthread_rwlock_t __m;
+
+  __shared_mutex_base(const __shared_mutex_base &);
+  __shared_mutex_base &operator=(const __shared_mutex_base &);
+
+public:
+  __shared_mutex_base()
+  {
+    pthread_rwlock_init(&__m, OM_NULLPTR);
+  }
+
+  ~__shared_mutex_base()
+  {
+    pthread_rwlock_destroy(&__m);
+  }
+
+  void lock()
+  {
+    pthread_rwlock_wrlock(&__m);
+  }
+
+  bool try_lock()
+  {
+    return pthread_rwlock_trywrlock(&__m) == 0;
+  }
+
+  void unlock()
+  {
+    pthread_rwlock_unlock(&__m);
+  }
+
+  void lock_shared()
+  {
+    pthread_rwlock_rdlock(&__m);
+  }
+
+  bool try_lock_shared()
+  {
+    return pthread_rwlock_tryrdlock(&__m) == 0;
+  }
+
+  void unlock_shared()
+  {
+    pthread_rwlock_unlock(&__m);
+  }
+
+  typedef pthread_rwlock_t *native_handle_type;
+
+  native_handle_type native_handle()
+  {
+    return &__m;
+  }
+};
+
+class shared_timed_mutex : public __shared_mutex_base
+{
+};
+
+#  if __cplusplus >= 201703L
+class shared_mutex : public __shared_mutex_base
+{
+};
+#  endif
+
+template <class M>
+class shared_lock
+{
+  M *__m;
+  bool __owns;
+
+  shared_lock(const shared_lock &);
+  shared_lock &operator=(const shared_lock &);
+
+public:
+  typedef M mutex_type;
+
+  shared_lock() OM_NOEXCEPT : __m(OM_NULLPTR), __owns(false)
+  {
+  }
+
+  explicit shared_lock(M &m) : __m(&m), __owns(true)
+  {
+    __m->lock_shared();
+  }
+
+  shared_lock(M &m, defer_lock_t) OM_NOEXCEPT : __m(&m), __owns(false)
+  {
+  }
+
+  shared_lock(M &m, try_to_lock_t) : __m(&m), __owns(false)
+  {
+    __owns = __m->try_lock_shared();
+  }
+
+  shared_lock(M &m, adopt_lock_t) : __m(&m), __owns(true)
+  {
+  }
+
+  ~shared_lock()
+  {
+    if (__owns)
+      __m->unlock_shared();
+  }
+
+  void lock()
+  {
+    __m->lock_shared();
+    __owns = true;
+  }
+
+  bool try_lock()
+  {
+    __owns = __m->try_lock_shared();
+    return __owns;
+  }
+
+  void unlock()
+  {
+    __m->unlock_shared();
+    __owns = false;
+  }
+
+  M *release() OM_NOEXCEPT
+  {
+    M *r = __m;
+    __m = OM_NULLPTR;
+    __owns = false;
+    return r;
+  }
+
+  bool owns_lock() const OM_NOEXCEPT
+  {
+    return __owns;
+  }
+
+  operator bool() const OM_NOEXCEPT
+  {
+    return __owns;
+  }
+
+  M *mutex() const OM_NOEXCEPT
+  {
+    return __m;
+  }
+};
+
+} // namespace std
+
+#endif // __cplusplus >= 201402L
+
+#endif // STL_SHARED_MUTEX


### PR DESCRIPTION
`#include <shared_mutex>` was a parse error. That is WI-1 of the goto-symex
verification plan (§13.6), listed there as the highest-ratio item in the section
because it blocks including *any* ESBMC header in a harness.

`shared_mutex`, `shared_timed_mutex` and `shared_lock` are modelled on
`pthread_rwlock_*`, which ESBMC already models with a reader count and a
deadlock check, so the C++ wrappers inherit those rather than introducing a
second lock model. Not modelled, and commented as such: the timed
`try_lock_for`/`_until` members, since ESBMC has no clock to block against.

The two tests are a discriminating pair rather than two smoke tests — same
program, one lock call apart. `shared_mutex_exclusive` increments a counter
from two threads under `lock()` and proves it reaches 2;
`shared_mutex_shared_race_fail` swaps in `lock_shared()`, and the counterexample
is the lost update at `counter == 2`. A model that granted `lock_shared()`
exclusion would pass both.