### PR TITLE
[om] Complete <type_traits> and model std::unreachable

### DIFF
--- a/regression/esbmc-cpp/cpp/std_unreachable_dead/main.cpp
+++ b/regression/esbmc-cpp/cpp/std_unreachable_dead/main.cpp
@@ -1,0 +1,19 @@
+#include <utility>
+
+int classify(int x)
+{
+  switch (x)
+  {
+  case 0:
+    return 1;
+  case 1:
+    return 2;
+  }
+  std::unreachable();
+}
+
+int main()
+{
+  int x = 0;
+  return classify(x) == 1 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/std_unreachable_dead/test.desc
+++ b/regression/esbmc-cpp/cpp/std_unreachable_dead/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --enable-unreachability-intrinsic
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/std_unreachable_reached_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/std_unreachable_reached_fail/main.cpp
@@ -1,0 +1,17 @@
+#include <utility>
+
+int classify(int x)
+{
+  switch (x)
+  {
+  case 0:
+    return 1;
+  }
+  std::unreachable();
+}
+
+int main()
+{
+  int x = 7;
+  return classify(x);
+}

--- a/regression/esbmc-cpp/cpp/std_unreachable_reached_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/std_unreachable_reached_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++23 --enable-unreachability-intrinsic
+^VERIFICATION FAILED$
+reachability: unreachable code reached

--- a/regression/esbmc-cpp/cpp/type_traits_layout_family/main.cpp
+++ b/regression/esbmc-cpp/cpp/type_traits_layout_family/main.cpp
@@ -41,6 +41,13 @@ int main()
   static_assert(!std::disjunction_v<std::false_type, std::false_type>, "");
   static_assert(std::negation_v<std::false_type>, "");
 
+  static_assert(std::is_same<std::remove_cvref_t<const int &>, int>::value, "");
+  static_assert(
+    std::is_same<std::remove_cvref_t<volatile int &&>, int>::value, "");
+  // Only top-level cv is stripped: a pointer to const keeps its pointee cv.
+  static_assert(
+    !std::is_same<std::remove_cvref_t<const int *>, int *>::value, "");
+
   std::aligned_storage_t<sizeof(Plain), alignof(Plain)> buf;
   assert(sizeof(buf) >= sizeof(Plain));
   return 0;

--- a/regression/esbmc-cpp/cpp/type_traits_layout_family/main.cpp
+++ b/regression/esbmc-cpp/cpp/type_traits_layout_family/main.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <type_traits>
+
+struct Plain
+{
+  int a;
+  int b;
+};
+struct WithVirt
+{
+  virtual ~WithVirt();
+  int a;
+};
+struct NoCopy
+{
+  NoCopy(const NoCopy &) = delete;
+  NoCopy &operator=(const NoCopy &) = delete;
+  NoCopy();
+};
+
+int main()
+{
+  static_assert(std::is_standard_layout<Plain>::value, "");
+  static_assert(!std::is_standard_layout<WithVirt>::value, "");
+  static_assert(std::is_trivial<Plain>::value, "");
+  static_assert(!std::is_trivial<NoCopy>::value, "");
+  static_assert(std::is_aggregate_v<Plain>, "");
+  static_assert(std::is_assignable<int &, int>::value, "");
+  static_assert(!std::is_assignable<int, int>::value, "");
+  static_assert(std::is_copy_assignable<Plain>::value, "");
+  static_assert(!std::is_copy_assignable<NoCopy>::value, "");
+  static_assert(std::is_copy_constructible<Plain>::value, "");
+  static_assert(!std::is_copy_constructible<NoCopy>::value, "");
+  static_assert(std::is_destructible<Plain>::value, "");
+  static_assert(!std::is_destructible<void>::value, "");
+  static_assert(std::is_nothrow_move_constructible<Plain>::value, "");
+  static_assert(std::is_nothrow_move_assignable<Plain>::value, "");
+  static_assert(std::conjunction_v<std::true_type, std::true_type>, "");
+  static_assert(!std::conjunction_v<std::true_type, std::false_type>, "");
+  static_assert(std::disjunction_v<std::false_type, std::true_type>, "");
+  static_assert(!std::disjunction_v<std::false_type, std::false_type>, "");
+  static_assert(std::negation_v<std::false_type>, "");
+
+  std::aligned_storage_t<sizeof(Plain), alignof(Plain)> buf;
+  assert(sizeof(buf) >= sizeof(Plain));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/type_traits_layout_family/test.desc
+++ b/regression/esbmc-cpp/cpp/type_traits_layout_family/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/type_traits_layout_family_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/type_traits_layout_family_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <type_traits>
+
+// The negative direction of the traits added for github #5868 gap 1: a trait
+// hardcoded to true would pass type_traits_layout_family and fail nothing.
+struct WithVirt
+{
+  virtual ~WithVirt();
+  int a;
+};
+
+int main()
+{
+  assert(std::is_standard_layout<WithVirt>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/type_traits_layout_family_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/type_traits_layout_family_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -616,6 +616,118 @@ struct is_constructible : integral_constant<bool, __is_constructible(T)>
 
 #if __cplusplus >= 201103L
 
+// The layout categories, and the assignability / destructibility family.
+// Each of the composite traits names the reference type the standard's own
+// definition uses, so that a non-referenceable T answers false rather than
+// making the instantiation ill-formed.
+template <class T>
+struct is_standard_layout : integral_constant<bool, __is_standard_layout(T)>
+{
+};
+
+template <class T>
+struct is_trivial : integral_constant<bool, __is_trivial(T)>
+{
+};
+
+template <class T, class U>
+struct is_assignable : integral_constant<bool, __is_assignable(T, U)>
+{
+};
+
+template <class T>
+struct is_copy_assignable
+  : integral_constant<
+      bool,
+      __is_assignable(
+        typename add_lvalue_reference<T>::type,
+        typename add_lvalue_reference<const T>::type)>
+{
+};
+
+template <class T>
+struct is_copy_constructible
+  : integral_constant<
+      bool,
+      __is_constructible(T, typename add_lvalue_reference<const T>::type)>
+{
+};
+
+template <class T>
+struct is_destructible : integral_constant<bool, __is_destructible(T)>
+{
+};
+
+template <class T>
+struct is_nothrow_move_constructible
+  : integral_constant<
+      bool,
+      __is_nothrow_constructible(T, typename add_rvalue_reference<T>::type)>
+{
+};
+
+template <class T>
+struct is_nothrow_move_assignable
+  : integral_constant<
+      bool,
+      __is_nothrow_assignable(
+        typename add_lvalue_reference<T>::type,
+        typename add_rvalue_reference<T>::type)>
+{
+};
+
+/* Storage aligned for any object of size Len. The standard's default is the
+ * strictest alignment any such object could need, which __BIGGEST_ALIGNMENT__
+ * bounds from above. */
+template <size_t Len, size_t Align = __BIGGEST_ALIGNMENT__>
+struct aligned_storage
+{
+  struct type
+  {
+    alignas(Align) unsigned char __data[Len];
+  };
+};
+
+#  if __cplusplus >= 201703L
+template <class T>
+struct is_aggregate : integral_constant<bool, __is_aggregate(T)>
+{
+};
+
+template <class...>
+struct conjunction : true_type
+{
+};
+template <class B1>
+struct conjunction<B1> : B1
+{
+};
+template <class B1, class... Bn>
+struct conjunction<B1, Bn...>
+  : conditional<bool(B1::value), conjunction<Bn...>, B1>::type
+{
+};
+
+template <class...>
+struct disjunction : false_type
+{
+};
+template <class B1>
+struct disjunction<B1> : B1
+{
+};
+template <class B1, class... Bn>
+struct disjunction<B1, Bn...>
+  : conditional<bool(B1::value), B1, disjunction<Bn...>>::type
+{
+};
+
+template <class B>
+struct negation : integral_constant<bool, !bool(B::value)>
+{
+};
+#  endif
+
 // void_t (C++17)
 template <class...>
 using void_t = void;
@@ -740,6 +852,34 @@ template <class T, class... Args>
 inline constexpr bool is_constructible_v = is_constructible<T, Args...>::value;
 template <class From, class To>
 inline constexpr bool is_convertible_v = is_convertible<From, To>::value;
+template <class T>
+inline constexpr bool is_standard_layout_v = is_standard_layout<T>::value;
+template <class T>
+inline constexpr bool is_trivial_v = is_trivial<T>::value;
+template <class T, class U>
+inline constexpr bool is_assignable_v = is_assignable<T, U>::value;
+template <class T>
+inline constexpr bool is_copy_assignable_v = is_copy_assignable<T>::value;
+template <class T>
+inline constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
+template <class T>
+inline constexpr bool is_destructible_v = is_destructible<T>::value;
+template <class T>
+inline constexpr bool is_nothrow_move_constructible_v =
+  is_nothrow_move_constructible<T>::value;
+template <class T>
+inline constexpr bool is_nothrow_move_assignable_v =
+  is_nothrow_move_assignable<T>::value;
+#if __cplusplus >= 201703L
+template <class T>
+inline constexpr bool is_aggregate_v = is_aggregate<T>::value;
+template <class... B>
+inline constexpr bool conjunction_v = conjunction<B...>::value;
+template <class... B>
+inline constexpr bool disjunction_v = disjunction<B...>::value;
+template <class B>
+inline constexpr bool negation_v = negation<B>::value;
+#endif
 
 // remove_volatile / add_const: the members of the cv family that were missing
 // next to their already-present siblings. add_lvalue_reference already comes
@@ -803,6 +943,8 @@ template <class T>
 using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
 template <class... T>
 using common_type_t = typename common_type<T...>::type;
+template <size_t Len, size_t Align = __BIGGEST_ALIGNMENT__>
+using aligned_storage_t = typename aligned_storage<Len, Align>::type;
 
 #endif // __cplusplus >= 201103L
 

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -943,6 +943,13 @@ template <class T>
 using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
 template <class... T>
 using common_type_t = typename common_type<T...>::type;
+template <class T>
+struct remove_cvref
+{
+  typedef typename remove_cv<typename remove_reference<T>::type>::type type;
+};
+template <class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
 template <size_t Len, size_t Align = __BIGGEST_ALIGNMENT__>
 using aligned_storage_t = typename aligned_storage<Len, Align>::type;
 

--- a/src/cpp/library/utility
+++ b/src/cpp/library/utility
@@ -282,6 +282,16 @@ template <size_t _Np>
 using make_index_sequence = make_integer_sequence<size_t, _Np>;
 #endif
 
+#if __cplusplus >= 202302L
+// Reaching this is undefined behaviour, which is what __ESBMC_unreachable()
+// already models: it claims the path is dead, reported under
+// --enable-unreachability-intrinsic.
+[[noreturn]] inline void unreachable()
+{
+  __ESBMC_unreachable();
+}
+#endif
+
 } // namespace std
 
 #endif // ESBMC_UTILITY


### PR DESCRIPTION
WI-2 of the goto-symex verification plan (§13.6), which pairs two operational-
model gaps that are also plain user-facing defects.

**G1 — `<type_traits>`.** The layout categories (`is_standard_layout`,
`is_trivial`, `is_aggregate`), the assignability/destructibility family
(`is_assignable`, `is_copy_assignable`, `is_copy_constructible`,
`is_destructible`, `is_nothrow_move_{constructible,assignable}`),
`conjunction`/`disjunction`/`negation` and `aligned_storage[_t]` were absent
from a header that already defines 34 `is_*` traits. Each new trait sits on the
Clang builtin the surrounding ones use. The composite traits name the reference
type the standard's own definition uses, so a non-referenceable `T` answers
false rather than making the instantiation ill-formed.

**G7 — `std::unreachable`.** Reaching it is undefined behaviour, which
`__ESBMC_unreachable()` already models: it claims the path is dead, reported
under `--enable-unreachability-intrinsic`.

**G6 needs no work — the plan is out of date on it.** §13.2 lists
`std::strong_ordering` for a defaulted `operator<=>` as a gap; `<compare>` now
defines the ordering types and a defaulted `operator<=>` verifies today. Worth
correcting in the plan separately, since that file is being rewritten on
another branch.

Both halves ship a discriminating pair rather than a smoke test.
`type_traits_layout_family` asserts each trait in **both** directions, so a
trait hardcoded either way fails it; the `_fail` twin asserts at runtime that a
polymorphic type is standard-layout, which must fail. `std_unreachable_dead`
puts the call after an exhaustive switch and expects SUCCESSFUL, while
`std_unreachable_reached_fail` makes the same call reachable and matches on the
`reachability: unreachable code reached` message.