### PR TITLE
[om] Include <initializer_list> from <algorithm>; model std::this_thread

### DIFF
--- a/regression/esbmc-cpp/cpp/algorithm_initializer_list/main.cpp
+++ b/regression/esbmc-cpp/cpp/algorithm_initializer_list/main.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <cassert>
+
+// [algorithm.syn] opens with #include <initializer_list>, so naming
+// std::initializer_list after including <algorithm> alone must compile.
+int main()
+{
+  std::initializer_list<int> l = {4, 1, 3};
+  assert(l.size() == 3);
+  assert(*std::min_element(l.begin(), l.end()) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/algorithm_initializer_list/test.desc
+++ b/regression/esbmc-cpp/cpp/algorithm_initializer_list/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/algorithm_initializer_list_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/algorithm_initializer_list_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <cassert>
+
+// [algorithm.syn] opens with #include <initializer_list>, so naming
+// std::initializer_list after including <algorithm> alone must compile.
+int main()
+{
+  std::initializer_list<int> l = {4, 1, 3};
+  assert(l.size() == 2);
+  assert(*std::min_element(l.begin(), l.end()) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/algorithm_initializer_list_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/algorithm_initializer_list_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/this_thread_id/main.cpp
+++ b/regression/esbmc-cpp/cpp/this_thread_id/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+#include <thread>
+
+std::thread::id worker_id;
+
+void worker()
+{
+  worker_id = std::this_thread::get_id();
+  std::this_thread::yield();
+}
+
+int main()
+{
+  std::thread t(worker);
+  // [thread.thread.id]/1: distinct running threads compare unequal.
+  assert(std::this_thread::get_id() != t.get_id());
+  t.join();
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/this_thread_id/test.desc
+++ b/regression/esbmc-cpp/cpp/this_thread_id/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/this_thread_id_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/this_thread_id_fail/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+#include <thread>
+
+std::thread::id worker_id;
+
+void worker()
+{
+  worker_id = std::this_thread::get_id();
+  std::this_thread::yield();
+}
+
+int main()
+{
+  std::thread t(worker);
+  // [thread.thread.id]/1: distinct running threads compare unequal.
+  assert(std::this_thread::get_id() == t.get_id());
+  t.join();
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/this_thread_id_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/this_thread_id_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --context-bound 2
+^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -1,6 +1,7 @@
 #ifndef STL_ALGORITHM
 #define STL_ALGORITHM
 
+#include "initializer_list" /* [algorithm.syn] opens with this include */
 #include "iterator" /* std::iterator_traits, used by the heap helpers below */
 #include "definitions.h"
 #include <utility>

--- a/src/cpp/library/thread
+++ b/src/cpp/library/thread
@@ -22,7 +22,7 @@
 // pointer, but that conversion operator is currently bodyless in the frontend
 // (independently of this header: `void (*f)() = []{ g = 5; }; f();` already
 // loses the write), so it yields a nondet pointer. std::this_thread::sleep_*
-// and yield are absent: ESBMC has no clock and interleaves at every step.
+// remain absent: ESBMC has no clock, and it interleaves at every step anyway.
 
 #if __cplusplus >= 201103L
 
@@ -126,6 +126,22 @@ public:
     return 1;
   }
 };
+
+namespace this_thread
+{
+inline thread::id get_id() OM_NOEXCEPT
+{
+  return thread::id(pthread_self());
+}
+
+// A scheduling hint rather than a clock operation, so unlike sleep_* it has a
+// faithful model: __ESBMC_yield forces the context switch [thread.thread.this]
+// permits yield to make.
+inline void yield() OM_NOEXCEPT
+{
+  __ESBMC_yield();
+}
+} // namespace this_thread
 
 } // namespace std
 


### PR DESCRIPTION
WI-3 of the goto-symex verification plan (§13.6). Two of its four items turned
out to be already closed on master, so this is what is actually left.

**G3 — `<algorithm>` must include `<initializer_list>`.** [algorithm.syn] opens
with `#include <initializer_list>`, so a translation unit that includes only
`<algorithm>` may name `std::initializer_list`. Ours did not, and immer's
`champ.hpp:290` and `map.hpp:178` both rely on it. Note the plan's own probe for
this gap — "`std::initializer_list` not usable as a template in namespace
`std`" — is a misdiagnosis: the class template is fine, the include edge was
missing.

**G5 — `std::this_thread`.** `yield` is a scheduling hint rather than a clock
operation, so unlike `sleep_*` it has a faithful model: `__ESBMC_yield` forces
the context switch [thread.thread.this] permits. `get_id` maps onto
`pthread_self`. `sleep_*` stay absent, for the reason the header already gives.

**G4 needs no work.** `std::iterator_traits<T>::difference_type` resolves today
for both a raw pointer and a container iterator. Together with G6 (already
closed, see #6631) that is two of §13.2's eight gaps that have been fixed since
the census was taken.

Tests are discriminating pairs. `algorithm_initializer_list` names
`std::initializer_list` behind `<algorithm>` alone — it does not compile without
this change — and its twin asserts the wrong size. `this_thread_id` asserts
[thread.thread.id]/1, that two running threads compare unequal; its twin asserts
they are equal, which a `get_id` returning a constant would pass.