### PR TITLE
[docs] Record multiplicative object recovery as a known limitation

### DIFF
--- a/docs/design/pointer-integer-provenance.md
+++ b/docs/design/pointer-integer-provenance.md
@@ -1,0 +1,74 @@
+# Object recovery through integer arithmetic
+
+ESBMC models a pointer as an (object, offset) pair. An integer holds no object,
+so every `uintptr_t` round trip has to be re-associated with an object before the
+resulting pointer can be dereferenced. `value_sett::get_value_set_rec` does that
+for `add2t`/`sub2t`: one operand names objects, the other is treated as a byte
+displacement, and each object is carried across with its offset updated.
+
+Nothing does it for `mul2t`. A multiplied address falls through to the bottom of
+`get_value_set_rec` and is recorded as `unknown`, so
+
+```c
+uintptr_t u = (uintptr_t)&s;
+u *= 2;
+u -= (uintptr_t)&s;   /* u == (uintptr_t)&s again */
+*(int *)u = 3;
+```
+
+reports a spurious violation, and so do `regression/esbmc/github_426_2`,
+`github_426_3` and `github_426_4` (esbmc/esbmc#6545). `github_426_2` only ever
+multiplies an `offsetof`, but `offsetof` expands to `(size_t)&((S *)0)->y` and is
+address-derived like any other address.
+
+This is the noisy direction — a spurious counterexample, not a missed bug.
+
+## Why the obvious fix is unsound
+
+The tempting one-line change is to treat an operand whose value set contains
+nothing but `unknown` as the integer side of the arithmetic, so the subtraction
+above recovers `s` from its other operand. It does make all four tests pass, and
+it survives the whole regression suite.
+
+It is still wrong. `unknown` is the top element of the lattice — *may be any
+object, including one we have not named* — not *is an integer*. Removing it makes
+the points-to set exhaustive, and `dereference.cpp` emits the
+`dereference failure: invalid pointer` property **only** for `unknown`/`invalid`
+entries. Narrowing the set therefore deletes the property outright:
+
+```c
+char a[64], b[64];
+unsigned long u = nondet_ulong();
+char *p = (char *)(u * 8 - (uintptr_t)&a[0]);
+if ((uintptr_t)p == (uintptr_t)&b[0]) {
+  *p = 3;
+  assert(b[0] == 0);      /* proved, on a path where p == &b[0] */
+}
+```
+
+The branch is reachable, ESBMC's own model puts `p` at `&b[0]`, the write
+executes — and the assertion is proved. The surviving bounds and alignment checks
+apply to the fabricated object `a`, not to wherever `p` actually points, so they
+catch nothing here. Trading a spurious counterexample for a false proof is the
+wrong direction for a verifier.
+
+`regression/esbmc/ptr_int_mul_unknown_alias` and `ptr_int_mul_unknown_wild` pin
+both witnesses.
+
+## What a real fix needs
+
+Either of:
+
+- **Provenance as a linear form.** Represent an address-derived value as a
+  combination of object bases with coefficients, so `2*&s - &s` reduces to
+  `1*&s` and recovers offset 0 exactly. This is a model extension, not a local
+  change: every consumer of `object_mapt` would have to understand coefficients.
+
+- **An address-range obligation at the dereference.** Recover the object as
+  above, but make the recovery a proof obligation rather than an assumption:
+  claim `(uintptr_t)p >= (uintptr_t)&obj && (uintptr_t)p < (uintptr_t)&obj +
+  sizeof(obj)` wherever the object came from a discarded `unknown`. That
+  discharges the round trip and rejects both witnesses above.
+
+Until one of them lands, recovering object identity through a multiplicative term
+is a known limitation and the three `github_426_*` tests stay `KNOWNBUG`.

--- a/regression/esbmc/github_426_2/main.c
+++ b/regression/esbmc/github_426_2/main.c
@@ -1,3 +1,5 @@
+// Known limitation, recorded with the reason the obvious fix is unsound in
+// docs/design/pointer-integer-provenance.md (esbmc/esbmc#6545).
 
 #include <stdint.h>
 #include <assert.h>

--- a/regression/esbmc/github_426_3/main.c
+++ b/regression/esbmc/github_426_3/main.c
@@ -1,3 +1,5 @@
+// Known limitation, recorded with the reason the obvious fix is unsound in
+// docs/design/pointer-integer-provenance.md (esbmc/esbmc#6545).
 
 #include <stdint.h>
 #include <assert.h>

--- a/regression/esbmc/github_426_4/main.c
+++ b/regression/esbmc/github_426_4/main.c
@@ -1,3 +1,5 @@
+// Known limitation, recorded with the reason the obvious fix is unsound in
+// docs/design/pointer-integer-provenance.md (esbmc/esbmc#6545).
 
 #include <stdint.h>
 #include <assert.h>

--- a/regression/esbmc/ptr_int_mul_unknown_alias/main.c
+++ b/regression/esbmc/ptr_int_mul_unknown_alias/main.c
@@ -1,0 +1,23 @@
+#include <stdint.h>
+#include <assert.h>
+
+unsigned long nondet_ulong(void);
+
+char a[64], b[64];
+
+int main(void)
+{
+  // A multiplication leaves the value set holding nothing but `unknown`, and
+  // the subtraction must not be allowed to recover `a` from the other operand:
+  // on this path the pointer is exactly &b[0], so the write clobbers b.
+  // Treating a top value set as the integer side of the arithmetic would drop
+  // the invalid-pointer property and prove this assertion (#6545).
+  unsigned long u = nondet_ulong();
+  char *p = (char *)(u * 8 - (uintptr_t)&a[0]);
+  if ((uintptr_t)p == (uintptr_t)&b[0])
+  {
+    *p = 3;
+    assert(b[0] == 0);
+  }
+  return 0;
+}

--- a/regression/esbmc/ptr_int_mul_unknown_alias/test.desc
+++ b/regression/esbmc/ptr_int_mul_unknown_alias/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^.*dereference failure: invalid pointer$

--- a/regression/esbmc/ptr_int_mul_unknown_wild/main.c
+++ b/regression/esbmc/ptr_int_mul_unknown_wild/main.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <assert.h>
+
+unsigned long nondet_ulong(void);
+
+char a[64];
+char c = 0;
+
+int main(void)
+{
+  // Same guard as ptr_int_mul_unknown_alias, for a pointer that names no
+  // object at all: its numeric value is below 64, so it is wild (#6545).
+  unsigned long u = nondet_ulong();
+  char *p = (char *)(u * 8 - (uintptr_t)&a[0]);
+  if ((uintptr_t)p < 64)
+  {
+    *p = 3;
+    assert(c == 0);
+  }
+  return 0;
+}

--- a/regression/esbmc/ptr_int_mul_unknown_wild/test.desc
+++ b/regression/esbmc/ptr_int_mul_unknown_wild/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^.*dereference failure: invalid pointer$

--- a/regression/esbmc/ptr_int_multiply_roundtrip/main.c
+++ b/regression/esbmc/ptr_int_multiply_roundtrip/main.c
@@ -6,8 +6,10 @@ int main(void)
   struct S { int x; int y; int z; } s = {.x = 1};
   uintptr_t u = (uintptr_t)&s;
   // Multiplying an address-derived integer loses object identity, so the
-  // reconstructed pointer is rejected and this reports FAILED (#6545). The
-  // additive round-trip in ptr_int_additive_roundtrip is tracked.
+  // reconstructed pointer is rejected and this reports FAILED. Known
+  // limitation; docs/design/pointer-integer-provenance.md records why the
+  // obvious fix is unsound (#6545). The additive round-trip in
+  // ptr_int_additive_roundtrip is tracked.
   u *= 2;
   u -= (uintptr_t)&s;
   int *p = (int *)u;


### PR DESCRIPTION
The narrow fix for #6545 — treating an only-`unknown` operand as the integer side of the arithmetic — makes all four affected tests pass and survives the suite, but it deletes the invalid-pointer property and yields a false proof. Records the decision #6545 asks for, with the two witnesses pinned as tests.

Fixes #6545