### PR TITLE
[goto-symex] Drop the write-only main_thread_ended flag

### DIFF
--- a/regression/esbmc/github_4634/main.c
+++ b/regression/esbmc/github_4634/main.c
@@ -11,7 +11,7 @@
 // constraint at globals only, so the intermediate schedule where the
 // thread is suspended between `A->next = new_node` and the splice
 // back-link was reported as a forgotten-memory violation whenever the
-// `main_thread_ended` throttle was bypassed (e.g. `--data-races-check`).
+// main-thread interleaving throttle was bypassed (e.g. `--data-races-check`).
 
 #include <pthread.h>
 #include <stdlib.h>

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -290,10 +290,7 @@ void execution_statet::symex_step(reachability_treet &art)
   {
   case END_FUNCTION:
     if (instruction.function == "__ESBMC_main")
-    {
       end_thread();
-      art1->main_thread_ended = true;
-    }
     else if (
       (instruction.function == "c:@F@main" ||
        instruction.function == "c:@F@main#") &&

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -34,7 +34,6 @@ reachability_treet::reachability_treet(
   schedule = options.get_bool_option("schedule");
   smt_during_symex = options.get_bool_option("smt-during-symex");
   por = !options.get_bool_option("no-por");
-  main_thread_ended = false;
   cs_bound_pruned = false;
   target_template = std::move(target);
 

--- a/src/goto-symex/reachability_tree.h
+++ b/src/goto-symex/reachability_tree.h
@@ -282,8 +282,6 @@ public:
   const namespacet &ns;
   /** Options that are enabled */
   optionst &options;
-  /** __ESBMC_main thread has ended */
-  bool main_thread_ended;
   /** --context-bound cut an available switch: the schedule space was truncated
    *  rather than exhausted (issue #6480). */
   bool cs_bound_pruned;


### PR DESCRIPTION
The unsound tree-global throttle #4635 reports was fixed in #6607, which moved the gate to per-state `threads_state[0].thread_ended`. That left `main_thread_ended` with one initialiser, one writer and no readers; remove it so nothing reaches for a tree-global throttle again.

Fixes #4635