### PR TITLE
[om] Compare const strings with <= and >=, per [string.cmp]

### DIFF
--- a/regression/esbmc-cpp/cpp/string_const_relational/main.cpp
+++ b/regression/esbmc-cpp/cpp/string_const_relational/main.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  const std::string a = "abc";
+  const std::string b = "abd";
+  std::string c = "abc";
+  std::string d = "abd";
+
+  assert(a < b);
+  assert(a <= b);
+  assert(b > a);
+  assert(b >= a);
+  assert(a <= a);
+  assert(a >= a);
+
+  assert(c < d);
+  assert(c <= d);
+  assert(d >= c);
+
+  assert(a <= "abd");
+  assert(a >= "abb");
+  assert("abb" <= a);
+  assert("abd" >= a);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/string_const_relational/test.desc
+++ b/regression/esbmc-cpp/cpp/string_const_relational/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/string_const_relational_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/string_const_relational_fail/main.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  const std::string a = "abc";
+  const std::string b = "abd";
+  std::string c = "abc";
+  std::string d = "abd";
+
+  assert(a < b);
+  assert(b <= a);
+  assert(b > a);
+  assert(b >= a);
+  assert(a <= a);
+  assert(a >= a);
+
+  assert(c < d);
+  assert(c <= d);
+  assert(d >= c);
+
+  assert(a <= "abd");
+  assert(a >= "abb");
+  assert("abb" <= a);
+  assert("abd" >= a);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/string_const_relational_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/string_const_relational_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -545,9 +545,9 @@ public:
   // operator==/!=), not members: a member operator>(const char*) would be
   // ambiguous with the free operator>(basic_string&, const char*) for s > "lit".
   bool operator>=(basic_string<CharT, Traits, Alloc> &a);
-  bool operator>=(const char *lhs);
+  bool operator>=(const char *lhs) const;
   bool operator<=(basic_string<CharT, Traits, Alloc> &a);
-  bool operator<=(const char *lhs);
+  bool operator<=(const char *lhs) const;
   basic_string<CharT, Traits, Alloc> &
   operator=(basic_string<CharT, Traits, Alloc> &str);
   basic_string<CharT, Traits, Alloc> &operator=(const char *s);
@@ -1342,6 +1342,36 @@ __ESBMC_HIDE:
   return (unsigned char)lhs.str[i] < (unsigned char)rhs.str[i];
 }
 
+// [string.cmp]: all six comparisons are non-member and take const&. The <= and
+// >= members below cover only non-const operands -- a non-template member wins
+// the tie against these templates -- so without these two, comparing a pair of
+// const strings does not compile.
+template <typename CharT, typename Traits, typename Alloc>
+bool operator<=(
+  const basic_string<CharT, Traits, Alloc> &lhs,
+  const basic_string<CharT, Traits, Alloc> &rhs)
+{
+__ESBMC_HIDE:
+  __ESBMC_assert(
+    lhs.str != NULL, "The first parameter must be different than NULL");
+  __ESBMC_assert(
+    rhs.str != NULL, "The second parameter must be different than NULL");
+  return strcmp(lhs.str, rhs.str) <= 0;
+}
+
+template <typename CharT, typename Traits, typename Alloc>
+bool operator>=(
+  const basic_string<CharT, Traits, Alloc> &lhs,
+  const basic_string<CharT, Traits, Alloc> &rhs)
+{
+__ESBMC_HIDE:
+  __ESBMC_assert(
+    lhs.str != NULL, "The first parameter must be different than NULL");
+  __ESBMC_assert(
+    rhs.str != NULL, "The second parameter must be different than NULL");
+  return strcmp(lhs.str, rhs.str) >= 0;
+}
+
 template <typename CharT, typename Traits, typename Alloc>
 bool operator>(const char *lhs, basic_string<CharT, Traits, Alloc> &rhs)
 {
@@ -1428,7 +1458,7 @@ __ESBMC_HIDE:
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-bool basic_string<CharT, Traits, Alloc>::operator>=(const char *lhs)
+bool basic_string<CharT, Traits, Alloc>::operator>=(const char *lhs) const
 {
 __ESBMC_HIDE:
   __ESBMC_assert(lhs != NULL, "The parameter must be different than NULL");
@@ -1461,7 +1491,7 @@ __ESBMC_HIDE:
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-bool basic_string<CharT, Traits, Alloc>::operator<=(const char *lhs)
+bool basic_string<CharT, Traits, Alloc>::operator<=(const char *lhs) const
 {
 __ESBMC_HIDE:
   __ESBMC_assert(lhs != NULL, "The parameter must be different than NULL");
@@ -1479,7 +1509,7 @@ __ESBMC_HIDE:
 // Free const char*-on-the-left overloads, so "lit" >= s / "lit" <= s resolve
 // (the member operators only cover s >= "lit" / s <= "lit").
 template <typename CharT, typename Traits, typename Alloc>
-bool operator>=(const char *lhs, basic_string<CharT, Traits, Alloc> &rhs)
+bool operator>=(const char *lhs, const basic_string<CharT, Traits, Alloc> &rhs)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(
@@ -1490,7 +1520,7 @@ __ESBMC_HIDE:
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-bool operator<=(const char *lhs, basic_string<CharT, Traits, Alloc> &rhs)
+bool operator<=(const char *lhs, const basic_string<CharT, Traits, Alloc> &rhs)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(


### PR DESCRIPTION
`<=` and `>=` between two `basic_string`s existed only as **non-const member
functions taking a non-const reference**, while `<` and `>` also have free
templates on `const&`. So `const std::string a, b; a <= b;` does not compile
today — which is exactly how `src/util/irep/irep_idt.h:123` and `:127` fail.
[string.cmp] specifies all six comparisons as non-member functions taking
`const&`.

**Added rather than replaced, deliberately.** The two members stay, so overload
resolution for non-const operands is unchanged: a non-template member wins the
tie against a function template, which is already how `<` and `>` behave with
both forms present. Adding mirrors that existing arrangement instead of
introducing a new one, and avoids the member-vs-free ambiguity this header has
been bitten by before. The `const char*` members also become `const`, and the
reversed free forms take `const&`, so the mixed comparisons work on a const
string in both directions.

The test asserts all six operators on const operands, the reflexive `a <= a` /
`a >= a` cases, the non-const forms, and the `const char*` forms both ways.
Verified discriminating: on a pre-change binary the same file fails to compile
with `invalid operands to binary expression` on each `<=`/`>=` line, while the
`<` and `>` lines compile.

It needs `--unwind 8`: unbounded, the comparison loop does not terminate — that
is pre-existing and applies equally to `<` on master, not something this change
introduces.

`esbmc-cpp/cpp` 703 pass (only `ch13_10`, the pre-existing ~105 s test, exceeds
the cap) and `esbmc-cpp11` 153/153.