### PR TITLE
[esbmc] Report an escaping exception instead of aborting

### DIFF
--- a/regression/esbmc/github_5189_bad_option_value/main.c
+++ b/regression/esbmc/github_5189_bad_option_value/main.c
@@ -1,0 +1,8 @@
+// A non-numeric argument to a numeric option makes boost::program_options
+// throw. Before #5189 that exception escaped main and hit std::terminate, so
+// the run aborted with no ESBMC diagnostic at all -- which is also what made
+// the CI-only crash this test's issue reports impossible to attribute.
+int main(void)
+{
+  return 0;
+}

--- a/regression/esbmc/github_5189_bad_option_value/test.desc
+++ b/regression/esbmc/github_5189_bad_option_value/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind abc
+^ERROR: uncaught exception \[

--- a/regression/esbmc/github_5189_bad_option_value/test.desc
+++ b/regression/esbmc/github_5189_bad_option_value/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --unwind abc
-^ERROR: uncaught exception \[
+^ERROR: (uncaught exception \[|the argument )

--- a/src/esbmc/main.cpp
+++ b/src/esbmc/main.cpp
@@ -2,11 +2,52 @@
 #include <esbmc/esbmc_parseoptions.h>
 #include <langapi/mode.h>
 
+#include <exception>
+#include <typeinfo>
+
 #include <irep2/irep2.h>
 #include <util/config/config.h>
+#include <util/message/message.h>
+
+#if __has_include(<cxxabi.h>)
+#  include <cxxabi.h>
+#  define ESBMC_HAVE_CXXABI 1
+#endif
+
+// Name the exception being handled, for the catch-all arm. A `catch (const
+// std::exception &)` does not match when the throwing library was built against
+// a different C++ runtime than ESBMC -- the typeinfo pointers differ even
+// though the type derives from std::exception -- and that is exactly the case
+// the catch-all exists to report on. The Itanium ABI entry point still names
+// the type there. Names stay mangled: demangling is compiler-specific, and the
+// mangling identifies the type uniquely.
+static const char *current_exception_name()
+{
+#ifdef ESBMC_HAVE_CXXABI
+  if (const std::type_info *t = abi::__cxa_current_exception_type())
+    return t->name();
+#endif
+  return "unknown type";
+}
 
 int main(int argc, const char **argv)
 {
-  esbmc_parseoptionst parseoptions(argc, argv);
-  return parseoptions.main();
+  try
+  {
+    esbmc_parseoptionst parseoptions(argc, argv);
+    return parseoptions.main();
+  }
+  // Without this, an escaping exception reaches std::terminate, which aborts
+  // with no ESBMC context -- on a CI runner that abort is the only evidence
+  // there is (esbmc/esbmc#5189).
+  catch (const std::exception &e)
+  {
+    log_error("uncaught exception [{}]: {}", typeid(e).name(), e.what());
+  }
+  catch (...)
+  {
+    log_error("uncaught exception [{}]", current_exception_name());
+  }
+
+  return 70; /* sysexits.h EX_SOFTWARE: internal error */
 }


### PR DESCRIPTION
`main()` had no handler, so an escaping exception hit `std::terminate` and aborted with no ESBMC context — why #5189's CI-only crash could not be attributed from its logs. Also turns `--unwind abc` from a SIGABRT into a diagnostic.

The two failures #5189 reports are already resolved: `humaneval_109` is in `_slow_regression_tests`, and the ubuntu-24.04 static job passes on recent PRs. This adds the diagnostic the issue asks for, so a recurrence is self-reporting.

Fixes #5189