### PR TITLE
[util] Create temporary files exclusively, not by name

### DIFF
--- a/src/ld-frontend/verify/ld_verify.cpp
+++ b/src/ld-frontend/verify/ld_verify.cpp
@@ -231,8 +231,10 @@ LdVerifyResult LdVerifyRunner::run(const LdVerifyOptions &opts)
         "could not determine the temporary directory: " + ec.message();
       return r;
     }
-    // unique_path guarantees a fresh name, so the plain copy_file overload
-    // suffices (no overwrite option needed).
+    // unique_path() only invents a name, it does not reserve one. What stops a
+    // file planted at that path in the meantime from being clobbered is
+    // copy_file()'s default: without overwrite_existing it creates the target
+    // exclusively and fails with EEXIST. Do not "simplify" that away.
     temp_ld = tmp_dir / fs::unique_path("ld-verify-%%%%-%%%%.ld");
     fs::copy_file(input, temp_ld, ec);
     if (ec)

--- a/src/util/base/filesystem.cpp
+++ b/src/util/base/filesystem.cpp
@@ -4,9 +4,15 @@
 #include <fstream>
 #include <vector>
 
-#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#  include <io.h>
+#else
 #  include <csignal>
 #  include <sys/types.h>
+#  include <unistd.h>
 #endif
 
 using namespace file_operations;
@@ -124,6 +130,34 @@ FILE *tmp_file::file() noexcept
   return _file;
 }
 
+/* unique_path() only invents a name; it does not stake a claim on it. Opening
+ * that name with fopen() would happily follow a symlink planted there in the
+ * meantime and truncate whatever it points at (CWE-377). O_EXCL fails instead,
+ * which makes the caller's loop pick a new name. 0600 also stops the temporary
+ * from being world-readable, which fopen()'s 0666 & ~umask allowed. */
+static FILE *fopen_exclusive(const std::string &path, const char *mode)
+{
+#ifdef _WIN32
+  int fd =
+    _open(path.c_str(), _O_CREAT | _O_EXCL | _O_RDWR, _S_IREAD | _S_IWRITE);
+#else
+  int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+#endif
+  if (fd < 0)
+    return NULL;
+
+#ifdef _WIN32
+  FILE *f = _fdopen(fd, mode);
+  if (!f)
+    _close(fd);
+#else
+  FILE *f = fdopen(fd, mode);
+  if (!f)
+    close(fd);
+#endif
+  return f;
+}
+
 template <typename F>
 static inline std::string with_unique_tmp_path(F &&f, const std::string &format)
 {
@@ -142,7 +176,7 @@ file_operations::create_tmp_file(const std::string &format, const char *mode)
   FILE *r = NULL;
   std::string path = with_unique_tmp_path(
     [&r, mode](auto path) {
-      r = fopen(path.string().c_str(), mode);
+      r = fopen_exclusive(path.string(), mode);
       return r;
     },
     format);
@@ -161,30 +195,13 @@ tmp_path file_operations::create_tmp_dir(const std::string &format)
 const std::string
 file_operations::get_unique_tmp_path(const std::string &format)
 {
-  // Get the temp file dir
-  const boost::filesystem::path tmp_path =
-    boost::filesystem::temp_directory_path();
-
-  // Define the pattern for the name
-  const std::string pattern = (tmp_path / format.c_str()).string();
-  boost::filesystem::path path;
-
-  // Try to get a name that is not used already e.g. esbmc.0000-0000
-  do
-  {
-    path = boost::filesystem::unique_path(pattern);
-  } while (
-    boost::filesystem::exists(path)); // TODO: This may cause infinite loop
-
-  // If path folders doesn't exist, create then
-  boost::filesystem::create_directories(path);
-  if (!boost::filesystem::is_directory(path))
-  {
-    assert(!"Can't create temporary directory");
-    abort();
-  }
-
-  return path.string();
+  // create_directory() reports whether *this* call created the directory, so
+  // testing its result claims the name atomically. Testing exists() first and
+  // creating afterwards left a window in which another process could take the
+  // name between the two calls.
+  return with_unique_tmp_path(
+    [](const auto &path) { return boost::filesystem::create_directory(path); },
+    format);
 }
 
 void file_operations::create_path_and_write(

--- a/src/util/base/filesystem.h
+++ b/src/util/base/filesystem.h
@@ -88,6 +88,10 @@ public:
  * In Linux, running this function with "esbmc-%%%%" will
  * return a string such as "/tmp/esbmc-0001" or "/tmp/esbmc-8787".
  *
+ * The directory is created before the path is returned, so the name is the
+ * caller's for as long as it keeps it. Unlike create_tmp_dir() the result is
+ * not registered for cleanup: the caller owns removal.
+ *
  * This function does not have guarantee that will finish
  * and can be run forever until it sees an available spot.
  *
@@ -95,6 +99,8 @@ public:
  */
 const std::string get_unique_tmp_path(const std::string &format);
 
+/** The file is created exclusively and with 0600 permissions, so it is never
+ *  a pre-existing path (or a symlink to one) that this would clobber. */
 tmp_file create_tmp_file(
   const std::string &format = "esbmc.%%%%-%%%%-%%%%",
   const char *mode = "w+");

--- a/unit/util/filesystem.test.cpp
+++ b/unit/util/filesystem.test.cpp
@@ -8,6 +8,8 @@ Author: Rafael Sá Menezes
 #include <catch2/catch.hpp>
 #include <util/base/filesystem.h>
 #include <boost/filesystem.hpp>
+#include <fstream>
+#include <cstdlib>
 
 TEST_CASE(
   "tmp path should be unique between two runs",
@@ -86,3 +88,76 @@ TEST_CASE(
   }
   REQUIRE(!boost::filesystem::exists(path));
 }
+
+TEST_CASE(
+  "tmp file is created exclusively, not opened by name",
+  "[core][util][filesystem]")
+{
+  // unique_path() only invents a name; it does not stake a claim on it.
+  // Creating the file with fopen() therefore opened whatever already sat at
+  // that path -- including a symlink planted between the two steps -- and
+  // truncated it (CWE-377). Opening with O_EXCL|0600 instead is observable:
+  // the temporary is not group/world accessible.
+  auto file = file_operations::create_tmp_file("esbmc-test-%%%%");
+  const std::string path = file.path();
+  REQUIRE(boost::filesystem::is_regular_file(path));
+  REQUIRE(
+    !boost::filesystem::is_symlink(boost::filesystem::symlink_status(path)));
+
+#ifndef _WIN32
+  using boost::filesystem::perms;
+  const perms p = boost::filesystem::status(path).permissions();
+  REQUIRE((p & (perms::group_all | perms::others_all)) == perms::no_perms);
+#endif
+}
+
+#ifndef _WIN32
+TEST_CASE(
+  "an already-taken tmp name is never clobbered",
+  "[core][util][filesystem]")
+{
+  // A single '%' expands to one hex digit, so the format below has exactly 16
+  // candidate names. Occupy 15 of them and the only name create_tmp_file() can
+  // take is the sixteenth -- so the outcome is deterministic, and any run that
+  // truncates a sentinel or returns an occupied name is a regression. fopen()
+  // took the first name it drew, clobbering a sentinel 15 times out of 16.
+  namespace fs = boost::filesystem;
+  auto dir = file_operations::create_tmp_dir("esbmc-test-excl-%%%%");
+
+  // create_tmp_file() resolves the temp directory per call, so TMPDIR confines
+  // this test to `dir` and keeps it off the shared /tmp.
+  const char *saved = getenv("TMPDIR");
+  const std::string old_tmpdir = saved ? saved : "";
+  setenv("TMPDIR", dir.path().c_str(), 1);
+
+  const std::string free_name = "esbmc-test-slot-a";
+  for (const char *d = "0123456789abcdef"; *d; ++d)
+  {
+    const fs::path occupied =
+      fs::path(dir.path()) / ("esbmc-test-slot-" + std::string(1, *d));
+    if (occupied.filename().string() == free_name)
+      continue;
+    std::ofstream(occupied.string()) << "sentinel";
+  }
+  REQUIRE(!fs::exists(fs::path(dir.path()) / free_name));
+
+  {
+    auto taken = file_operations::create_tmp_file("esbmc-test-slot-%");
+    REQUIRE(fs::path(taken.path()).filename().string() == free_name);
+  }
+
+  for (const char *d = "0123456789abcdef"; *d; ++d)
+  {
+    const fs::path occupied =
+      fs::path(dir.path()) / ("esbmc-test-slot-" + std::string(1, *d));
+    if (occupied.filename().string() == free_name)
+      continue;
+    REQUIRE(fs::file_size(occupied) == 8);
+  }
+
+  if (saved)
+    setenv("TMPDIR", old_tmpdir.c_str(), 1);
+  else
+    unsetenv("TMPDIR");
+}
+#endif


### PR DESCRIPTION
Boost's `unique_path()` only invents a name, it does not reserve one, so creating the file with `fopen()` adopted whatever already sat at that path — including a symlink planted in between — and truncated it (CWE-377). The temporaries were world-readable too. `get_unique_tmp_path()` had the same window between `exists()` and `create_directories()`.

Both now claim the name atomically. Unit tests cover it: on the unpatched code they fail with permissions `044` and by taking an occupied slot, truncating its sentinel.

Refs #1862 — this is the `unique_path()` race @fbrausse asked to fix first; the `flock(2)` half is untouched.