### PR TITLE
[python] Let a non-str receiver keep its own join()

### DIFF
--- a/regression/python/queue_join/main.py
+++ b/regression/python/queue_join/main.py
@@ -1,0 +1,22 @@
+# Queue.join() takes no arguments, but every attribute call is offered to the
+# string handler first, and its str.join arm used to throw on any arity other
+# than one instead of declining. The receiver never reached instance dispatch.
+# Each put() is matched by a task_done() so join() returns under CPython too.
+import queue
+from queue import Queue
+
+a: Queue = Queue()
+a.put(7)
+a.task_done()
+a.join()
+assert a.qsize() == 1
+
+# Same call through a dotted annotation.
+b: queue.Queue = queue.Queue()
+b.put(8)
+b.task_done()
+b.join()
+assert b.qsize() == 1
+
+# str.join is unaffected.
+assert ",".join(["x", "y"]) == "x,y"

--- a/regression/python/queue_join/test.desc
+++ b/regression/python/queue_join/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -1145,9 +1145,14 @@ std::optional<exprt> dispatch_decode_join_method(
 
   if (method_name == "join")
   {
-    ensure_allowed_keywords(method_name, keyword_values, {});
+    // str.join takes exactly one iterable, so any other arity is not a string
+    // method at all. Decline instead of throwing, or an object with its own
+    // join() -- queue.Queue.join(), threading's Thread.join() -- never reaches
+    // instance dispatch, because every attribute call is offered to the string
+    // handler first (#6639).
     if (args.size() != 1)
-      throw std::runtime_error("join() takes exactly one argument");
+      return std::nullopt;
+    ensure_allowed_keywords(method_name, keyword_values, {});
     return self.handle_str_join(call_json);
   }
 


### PR DESCRIPTION
Every attribute call is offered to the string handler first, and its `str.join` arm threw on any arity other than one instead of declining — so `queue.Queue.join()` died with "join() takes exactly one argument" before instance dispatch saw it. `str.join` always takes exactly one iterable, so any other arity is not a string method.

Found while narrowing #6639; independent of the annotation form, so it is not that issue's defect.