### PR TITLE
[python] Resolve an annotation naming an OM function to its return type

### DIFF
--- a/regression/python/collections_annotation/main.py
+++ b/regression/python/collections_annotation/main.py
@@ -1,0 +1,23 @@
+# deque / defaultdict / OrderedDict are classes in Python but the operational
+# model implements them as functions, so an annotation naming one used to be
+# rejected with "NameError: name 'deque' is not defined". The annotation now
+# resolves to the function's declared return type.
+import collections
+from collections import deque, OrderedDict
+
+a: collections.deque = collections.deque()
+a.append(3)
+assert len(a) == 1
+
+b: deque = deque()
+b.append(4)
+b.append(5)
+assert len(b) == 2
+
+c: collections.defaultdict = collections.defaultdict(int)
+c["k"] = 1
+assert c["k"] == 1
+
+d: OrderedDict = OrderedDict()
+d["k"] = 2
+assert d["k"] == 2

--- a/regression/python/collections_annotation/test.desc
+++ b/regression/python/collections_annotation/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -762,4 +762,59 @@ bool has_overload_decorator(const JsonType &func_node)
   return false;
 }
 
+/// The declared return-type name of a function `name` defined in a module this
+/// AST imports, or "" if there is none. Some operational models implement what
+/// Python calls a class as a function (collections.deque -> list[int]), and
+/// such a name is still legal in an annotation; resolving it to the return type
+/// is what makes `d: collections.deque` usable (#6639). Only imported modules
+/// are scanned, so a user function never shadows a type name this way.
+template <typename JsonType>
+std::string
+imported_function_return_type(const std::string &name, const JsonType &ast_json)
+{
+  if (!ast_json.contains("ast_output_dir") || !ast_json.contains("body"))
+    return "";
+
+  const std::string output_dir =
+    ast_json["ast_output_dir"].template get<std::string>();
+
+  auto lookup = [&](const std::string &module_name) -> std::string {
+    std::ifstream f(output_dir + "/" + dotted_to_path(module_name) + ".json");
+    if (!f.is_open())
+      return "";
+    JsonType module_json;
+    f >> module_json;
+    if (!module_json.contains("body"))
+      return "";
+    JsonType fn = try_find_function(module_json["body"], name);
+    if (fn.empty() || !fn.contains("returns") || fn["returns"].is_null())
+      return "";
+    return get_annotation_type_name(fn["returns"]);
+  };
+
+  for (const auto &obj : ast_json["body"])
+  {
+    if (obj["_type"] == "ImportFrom")
+    {
+      if (obj["module"].is_null())
+        continue;
+      const std::string r = lookup(obj["module"].template get<std::string>());
+      if (!r.empty())
+        return r;
+    }
+    else if (obj["_type"] == "Import")
+    {
+      for (const auto &imported : obj["names"])
+      {
+        const std::string r =
+          lookup(imported["name"].template get<std::string>());
+        if (!r.empty())
+          return r;
+      }
+    }
+  }
+
+  return "";
+}
+
 } // namespace json_utils

--- a/src/python-frontend/type/type_handler.cpp
+++ b/src/python-frontend/type/type_handler.cpp
@@ -715,6 +715,18 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     }
   }
 
+  // An operational model may implement what Python calls a class as a function
+  // (collections.deque -> list[int], defaultdict/OrderedDict -> dict). The name
+  // is still a legal annotation, so resolve it to the declared return type
+  // rather than rejecting it (#6639).
+  if (!is_defined)
+  {
+    const std::string ret =
+      json_utils::imported_function_return_type(ast_type, converter_.ast());
+    if (!ret.empty() && ret != ast_type)
+      return get_typet(ret, type_size);
+  }
+
   // If still not found, it's a NameError
   if (!is_defined)
   {


### PR DESCRIPTION
`deque`, `defaultdict` and `OrderedDict` are classes in Python, but the collections model implements them as functions returning list/dict, so annotating with one was rejected with "NameError: name 'deque' is not defined" — in both the dotted and from-import spelling, while the unannotated binding verified. Such a name now resolves to the function's declared return type.

Documented under #6639 as an adjacent defect; independent of the annotation form, so it is not that issue's bug.