### PR TITLE
[regression] Pin Bitwuzla on an alternating forall/exists

### DIFF
--- a/regression/bitwuzla/quantifiers-alternating/main.c
+++ b/regression/bitwuzla/quantifiers-alternating/main.c
@@ -1,0 +1,12 @@
+// Bitwuzla used to time out on a genuine forall/exists *alternation* -- exists
+// nested inside forall -- while Z3 discharged it immediately (#4033). The
+// neighbouring quantifiers-hello only asserts the two quantifiers separately,
+// which is the easy case, so pin the alternation itself.
+int main()
+{
+  int a, b;
+  __ESBMC_assert(
+    __ESBMC_forall(&a, __ESBMC_exists(&b, b == a + 1)),
+    "for every a there exists b = a+1");
+  return 0;
+}

--- a/regression/bitwuzla/quantifiers-alternating/test.desc
+++ b/regression/bitwuzla/quantifiers-alternating/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--bitwuzla
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
#4033 reported Bitwuzla timing out on `forall a. exists b. b == a+1` while Z3 solved it instantly. It now solves immediately on Bitwuzla 0.9.0, but nothing pinned it — `quantifiers-hello` asserts the two quantifiers separately, which never exercises the alternation.

Closes #4033.