### PR TITLE
[pointer-analysis] Handle a conditional assignment target in VSA

### DIFF
--- a/regression/python/gcse_vsa_ite_target/main.py
+++ b/regression/python/gcse_vsa_ite_target/main.py
@@ -1,0 +1,6 @@
+# VSA aborted on every Python program -- the always-linked operational model
+# lowers an assignment whose target is a conditional, which value_sett::assign_rec
+# had no case for -- so --gcse and every other points-to consumer silently lost
+# its data. Any program at all exercises it.
+x: int = 1
+assert x == 1

--- a/regression/python/gcse_vsa_ite_target/test.desc
+++ b/regression/python/gcse_vsa_ite_target/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--gcse
+^VERIFICATION SUCCESSFUL$
+\A(?![\s\S]*Unable to compute VSA)[\s\S]*\Z

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1389,6 +1389,16 @@ void value_sett::assign_rec(
   {
     assign_rec(to_byte_extract2t(lhs).source_value, values_rhs, suffix, true);
   }
+  else if (is_if2t(lhs))
+  {
+    // A conditional assignment target: which arm receives the value is not
+    // known here, so update both weakly. Killing either would drop a value the
+    // other branch can still hold. Without this the whole analysis aborts, so
+    // every consumer loses its points-to data on any program that lowers an
+    // assignment this way (github #6610).
+    assign_rec(to_if2t(lhs).true_value, values_rhs, suffix, true);
+    assign_rec(to_if2t(lhs).false_value, values_rhs, suffix, true);
+  }
   else
   {
     log_error("[VSA] assign NYI: `{}'", get_expr_id(lhs));


### PR DESCRIPTION
`value_sett::assign_rec` had no case for an `if2t` on the left-hand side, so it threw `vsa_not_implemented_exception` and the whole analysis was discarded. The operational model linked into every Python program lowers an assignment that way, so VSA aborted on **every** Python input — `x: int = 1` is enough — and each consumer silently fell back to no points-to data.

Both arms are updated weakly: which one receives the value is unknown there, and killing either would drop a value the other can still hold.

Prerequisite for #6610, whose fix needs points-to information to decide which dereferenced accesses can actually race.