### PR TITLE
[goto-symex] Retire a popped frame's L2 names instead of erasing them

### DIFF
--- a/regression/esbmc/double_assign_check_expired_write/main.c
+++ b/regression/esbmc/double_assign_check_expired_write/main.c
@@ -1,0 +1,15 @@
+// Minimal form of R14: a write through a pointer to a popped frame's local.
+// The local's L2 counter must survive frame teardown, so this write takes a
+// fresh index instead of re-issuing the one its declaration already defined.
+static int *dangle(void)
+{
+  int local = 42;
+  return &local;
+}
+
+int main(void)
+{
+  int *p = dangle();
+  *p = 7;
+  return 0;
+}

--- a/regression/esbmc/double_assign_check_expired_write/test.desc
+++ b/regression/esbmc/double_assign_check_expired_write/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--double-assign-check
+^VERIFICATION FAILED$
+^.*dereference failure: accessed expired variable pointer.*$

--- a/regression/esbmc/double_assign_check_local_array/main.c
+++ b/regression/esbmc/double_assign_check_local_array/main.c
@@ -1,7 +1,7 @@
 // Copy of regression/esbmc/github_286_3/main.c, run with --double-assign-check.
-// Pins R14: symex emits two definitions of ...@F@getNumbers2@numbers2?1!0&0#1,
-// violating I10. KNOWNBUG states the verdict this should produce; today the run
-// trips the invariant at bmc.cpp and aborts instead.
+// Pins R14: the write through the returned dangling pointer must take a fresh
+// L2 index rather than re-issue ...@F@getNumbers2@numbers2?1!0&0#1, which the
+// declaration of numbers2 already defined.
 
 int array[10];
 

--- a/regression/esbmc/double_assign_check_static_write/main.c
+++ b/regression/esbmc/double_assign_check_static_write/main.c
@@ -1,0 +1,18 @@
+// Discriminating sibling of double_assign_check_expired_write, one keyword
+// apart: a static has whole-program lifetime, so no frame teardown touches its
+// L2 record and the write through the returned pointer is well defined.
+#include <assert.h>
+
+static int *not_dangling(void)
+{
+  static int cell = 42;
+  return &cell;
+}
+
+int main(void)
+{
+  int *p = not_dangling();
+  *p = 7;
+  assert(*p == 7);
+  return 0;
+}

--- a/regression/esbmc/double_assign_check_static_write/test.desc
+++ b/regression/esbmc/double_assign_check_static_write/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --double-assign-check
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/renaming.h
+++ b/src/goto-symex/renaming.h
@@ -245,9 +245,19 @@ public:
     current_names.erase(name_record(to_symbol2t(symbol)));
   }
 
-  void remove(const name_record &rec)
+  /// Retire a name whose storage has gone out of scope. L1 names are never
+  /// reused (symex_decl draws from a monotone per-identifier counter), so a
+  /// popped frame's local can still be named -- through a dangling pointer --
+  /// after teardown. Erasing the record restarts the counter, letting such a
+  /// write re-issue an index the declaration already defined and so define one
+  /// SSA name twice (I10). Advancing past the last live index instead leaves
+  /// the current name undefined, which keeps a read of the expired storage
+  /// unconstrained exactly as erasure did.
+  void retire(const name_record &rec)
   {
-    current_names.erase(rec);
+    valuet &entry = current_names[rec];
+    ++entry.count;
+    entry.constant = expr2tc();
   }
 
   void get_original_name(expr2tc &expr) const override

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -963,7 +963,7 @@ void goto_symext::pop_frame()
   if (!cur_state->guard.is_false())
     cur_state->guard = frame.entry_guard;
 
-  // clear locals from L2 renaming
+  // retire locals from L2 renaming
   for (auto const &it : frame.local_variables)
   {
     // Python objects are garbage-collected (issue #4773): keep user class
@@ -984,7 +984,7 @@ void goto_symext::pop_frame()
     // Erase from level 1 propagation
     cur_state->value_set.erase(to_symbol2t(l1_sym).get_symbol_name());
 
-    cur_state->level2.remove(it);
+    cur_state->level2.retire(it);
 
     // Construct an l1 name on the fly - this is a temporary hack for when
     // the value set is storing things in a not-an-irep-idt form.


### PR DESCRIPTION
Erasing a local's level-2 record at frame teardown restarted its assignment counter, so a write through a dangling pointer to that storage re-issued an index the declaration had already defined — two constraints on one SSA name, unsatisfiable wherever they disagree, silently dropping that path. Advance the counter past the last live index instead, which leaves the current name undefined so reads of expired storage stay unconstrained as before.

Closes R14 of `docs/roadmap/goto-symex-verification-plan.md`; its pin `double_assign_check_local_array` moves KNOWNBUG → CORE, and a minimal discriminating pair (`double_assign_check_expired_write` / `double_assign_check_static_write`) is added one keyword apart.