### PR TITLE
close remaining numpy view escape and method-form gaps

### DIFF
--- a/docs/roadmap/numpy-support-assessment.md
+++ b/docs/roadmap/numpy-support-assessment.md
@@ -251,6 +251,32 @@ Architectural decisions that gate specific pendencies here (referenced as
    while checking which other methods could safely gain dispatch rewrite
    support alongside this PR; not fixed here since it is unrelated to
    view/dispatch work and needs its own root-cause investigation.
+6. **`.transpose()`/`np.transpose(a)` fails for a variable built by a
+   non-literal constructor** (`np.zeros`, `np.eye`, `np.identity` — `ones`/
+   `full`/`arange` untested) — confirmed by direct execution:
+   ```python
+   import numpy as np
+   a = np.zeros((2, 2))
+   b = a.transpose()
+   ```
+   raises `Unsupported Numpy call: transpose` instead of transposing, even
+   though the identical code with `a = np.array([[1, 2], [3, 4]])` (a
+   literal) works (see `regression/numpy/view_function_transpose_method_success`).
+   Pre-existing — `zeros` was already tracked in `numpy_array_symbols_`
+   before this PR, so this is not a dispatch-rewrite gap; the `Name`-typed
+   argument branch in `numpy_call_expr.cpp`'s transpose handler does not
+   handle whatever type shape a non-literal constructor produces. Found
+   while adding `eye`/`identity`/`linspace` to the dispatch-rewrite
+   constructor set; not fixed here — out of scope for that fix.
+7. **`.mean()` and `.sum()`/`.flatten()` compute a wrong numeric result for
+   some non-literal-constructed arrays** — confirmed by direct execution:
+   `c = np.identity(2); c.mean()` asserts `!= 0.5` (wrong; `.sum()` on the
+   same array correctly returns `2.0`), and separately
+   `e = np.linspace(0.0, 4.0, 5); e.sum()` and `e.flatten()[i]` both compute
+   wrong values even though raw indexing (`e[0]`, `e[4]`) and `.copy()` on
+   the same `e` are correct. Two distinct confirmed-wrong cases, root cause
+   not yet investigated for either. Found alongside the `.transpose()` gap
+   above; not fixed here.
 
 ---
 

--- a/docs/roadmap/numpy-support-assessment.md
+++ b/docs/roadmap/numpy-support-assessment.md
@@ -1,6 +1,6 @@
 # ESBMC NumPy — Remaining Work
 
-**Updated:** 2026-07-30.
+**Updated:** 2026-08-02.
 
 This file tracks what is **not yet implemented or broken** in the NumPy
 module. Completed items are in the git history and `regression/numpy/`.
@@ -11,6 +11,47 @@ Architectural decisions that gate specific pendencies here (referenced as
 
 ## Recently completed
 
+- **Closed the remaining ADR-NP-003 etapa 1 gaps** — the guard layer
+  introduced by the previous entry left several confirmed holes, all
+  verified by direct execution before and after the fix:
+  - A view used **inline** in a list/tuple literal without first being
+    bound to a name (`holder = [x[0]]`, `holder = (x[0],)`) escaped the
+    container-escape guard entirely (false `VERIFICATION SUCCESSFUL`);
+    only the already-named form (`row = x[0]; holder = [row]`) was
+    caught. Fixed by recognizing a basic-indexing `Subscript` directly at
+    the point of use, gated on the probed result actually being
+    array-typed so a scalar element read (`x[0][0]`) packed into a
+    container is not misclassified.
+  - Storing a view in a **dict literal** (named or inline) crashed the
+    solver (`z3_convt::mk_eq` sort-width assertion) instead of producing
+    a verdict or diagnostic — `dict_handler_`'s literal-assignment paths
+    never reached the container-escape check that already protected
+    `List`/`Tuple`. Now rejected explicitly with the same diagnostic.
+  - Escape via `global` from a value sourced from a function **parameter**
+    (as opposed to a locally created array) is covered by a new
+    regression test; already correctly rejected.
+  - `a.reshape(d1, d2, ...)` with the dimensions as **separate positional
+    arguments** (as opposed to a single tuple) silently dropped every
+    dimension past the first. Fixed by collecting all arguments past the
+    array as the shape when more than one is given.
+  - `a.flatten()`, `a.sum()`, `a.mean()`, `a.min()`, `a.max()`, `a.std()`,
+    and `a.var()` — the real NumPy **method forms** — raised an
+    unhandled `AttributeError`/`TypeError`; only the `np.<name>(a)`
+    module-function forms were recognized. Extended the existing
+    method-to-function dispatch rewrite (already used for
+    `a.transpose()`/`a.reshape()`/`a.ravel()`) to cover these too, reusing
+    each function form's handler unchanged.
+  - `a.flat[i] = x` raised the generic `Unsupported assignment target
+    type: Call` instead of a diagnostic naming the problem (the
+    preprocessor rewrites `.flat` to `np.ravel(a)` even in a write
+    target). Now raises a specific `TypeError`; the write itself remains
+    unsupported (needs the definitive shared-buffer model, ADR-NP-003
+    etapa 2).
+
+  See `regression/numpy/view_inline_*`, `view_dict_literal_escape_fail`,
+  `view_global_param_escape_fail`, `reshape_method_multi_arg_*`,
+  `flatten_method_*`, `reducer_method_success`, and
+  `flat_mutation_diagnostic_fail`.
 - **Conservative NumPy view aliasing protection (ADR-NP-003, etapa 1)** —
   basic indexing, row/column slices, strided slices, `transpose`/`.T`,
   `reshape`, and `ravel` are now classified as view-like when they can share
@@ -154,8 +195,10 @@ Architectural decisions that gate specific pendencies here (referenced as
 | Feature | Status | Notes |
 |---|---|---|
 | Returning a numpy array *out* of a function by value (general case: a sub-array, e.g. `def f(a): return a[0]`, or any non-trivial body) | Missing | Arrays aren't valid by-value return types in the current GOTO model. Only the narrow *identity*-return case is fixed (see "Recently completed") — the general case was attempted twice this round and reverted both times after hitting the same structural wall: **(1)** inlining the substituted return expression at every call site works for the eligibility check but the two-pass assignment machinery (`create_symbol_for_unannotated_assign` type-probes the RHS once, then `get_var_assign` converts it again "for real") evaluates a `Subscript` return expression twice, duplicating the bounds-check GOTO code it emits and corrupting the result (confirmed via `--goto-functions-only`: the second, discarded evaluation's DECLs still land in the block); a cross-call-node cache (keyed by the AST node's address, confirmed to see the same `current_block` on both hits) prevented the double-conversion but did *not* fix the wrong result, meaning the bug is elsewhere in that pipeline. **(2)** A single-member wrapper-struct return type (`struct { value: array_type }`, unwrapped right after a real, once-only function call via the existing `store_call_result` helper — mirroring how a returned tuple already works today) also hit a variant of the same issue: while building it, a separate pre-existing bug was found and fixed (a static Python-level pre-pass injects a wrong `-> Any` return annotation for `return a[0]`, decided *before* parameters are processed, which pre-empted the array-shape detection with a `double` default — now deferred to the post-body GOTO scan, which sees real converted types), but the wrapped struct still isn't reliably unwrapped before a variable's type is decided elsewhere in the same assignment pipeline, causing a segfault (`build_index` dereferencing a struct's `.subtype()`). Both attempts point at the same root cause: `y = f(...)`'s type is decided by more than one code path in `get_var_assign`/`create_symbol_for_unannotated_assign`, not uniformly from what `get_expr` returns. A real fix needs to understand and consolidate that pipeline first, not just work around it at the call site. |
-| View aliasing for basic indexing and transpose-like views | Partial | Stage-1 soundness protection is implemented: covered view-like operations are conservatively rejected on mutation/escape and allowed for readonly consumers. The runtime representation is still a copy, so the final shared-buffer descriptor model is still missing. |
-| Higher-dimensional or symbolic slice bounds beyond the supported literal-copy cases | Missing | Bounded 2-D column slices and one-slice-axis mixed tuple indexing are supported for literal/fixed-shape cases. Multiple slice axes, symbolic slice bounds, non-literal strides, and broader stride combinations remain rejected explicitly rather than silently approximated. |
+| View aliasing for basic indexing and transpose-like views | Etapa 1 complete | All confirmed etapa-1 guard gaps (inline container escape, dict-literal crash, method-form dispatch) are closed — see "Recently completed". The runtime representation is still a copy, so the final shared-buffer descriptor model (etapa 2) is still missing; that is the only remaining piece of ADR-NP-003. |
+| Higher-dimensional or symbolic slice bounds beyond the supported literal-copy cases | Missing | Bounded 2-D column slices with explicit bounds (`a[:, 1:3:2]`) and one- or two-slice-axis mixed tuple indexing (`a[:, 0, 0]`, `a[:, :, 0]`) are supported for literal/fixed-shape cases — confirmed by direct execution (a previous revision of this document listed these as pending, which was stale). Three or more slice axes, symbolic slice bounds, non-literal strides, and broader stride combinations remain rejected explicitly rather than silently approximated. |
+| `a.sort()`/`a.argsort()`/`a.tolist()` method forms | Missing | Found while closing the method-dispatch gaps above but not fixed there — different in kind from a plain rewrite: `a.sort()` mutates in place (`np.sort(a)` returns a copy, so redirecting would need `a[:] = np.sort(a)`, not a bare rewrite); `a.argsort()` would redirect to `np.argsort()`, which itself only accepts an inline literal array today, not a variable, so the rewrite wouldn't fix the common case; `a.tolist()` has no module-function equivalent to redirect to at all. |
+| `a.any()`/`a.all()` method forms | Missing, cause unclear | `a.any()` raises `ERROR: any() expected at least 1 argument, got 0` — looks like the receiver is being dropped and the call is dispatched to Python's builtin `any()`/`all()` with zero arguments instead of the array. Root cause not investigated; flagged here rather than fixed blind, since it may indicate a broader dispatch issue worth understanding first. |
 
 ---
 
@@ -169,7 +212,7 @@ Architectural decisions that gate specific pendencies here (referenced as
 | Linear algebra | `inv`/`solve` limited to 2×2/3×3; `norm` limited to vectors and Frobenius matrices; `eig`/`svd` limited to small concrete matrices |
 | Random | Additional distributions, full PRNG state semantics, probability-vector `choice`, replacement control, and large/symbolic shapes |
 | Structured arrays | Record dtypes |
-| Views / strides | Conservative guard model only; final shared-buffer alias semantics, writable views, offset/stride based assignment, and broad non-literal stride support remain missing |
+| Views / strides | Etapa 1 guard model is complete (see "Recently completed"); final shared-buffer alias semantics, writable views, offset/stride based assignment, and broad non-literal stride support (ADR-NP-003 etapa 2) remain missing |
 | Iteration | Writable `nditer`, advanced `op_flags`, multi-operand iteration, and mutation through `flat` |
 
 ---
@@ -186,21 +229,28 @@ Architectural decisions that gate specific pendencies here (referenced as
    Large arrays explode. Symbolic shapes mitigate this via `--unwind` but do
    not eliminate the underlying state-explosion for large bounds.
 4. **Basic-indexing views still do not alias at runtime; covered mutations
-   are guarded conservatively** (ADR-NP-003). NumPy's basic indexing (`a[0]`)
-   returns a *view* sharing the source's buffer; this frontend still uses a
-   copy representation for the supported lowering paths. The former direct
-   false-success pattern is now rejected:
+   are guarded conservatively** (ADR-NP-003, etapa 1 — complete). NumPy's
+   basic indexing (`a[0]`) returns a *view* sharing the source's buffer;
+   this frontend still uses a copy representation for the supported
+   lowering paths. The direct false-success pattern, the inline-container
+   and dict-literal escape gaps, and the missing method-form dispatch are
+   all now rejected/supported correctly (see "Recently completed") — the
+   remaining piece is the definitive shared-buffer descriptor model
+   (etapa 2), which replaces conservative rejection with real aliasing.
+5. **`np.dot(a, b)` crashes the process for two 1-D vectors read from a
+   variable** (not a literal) — confirmed by direct execution:
    ```python
    import numpy as np
-   x = np.array([[1, 2], [3, 4]])
-   row = x[0]
-   row[0] = 999
-   assert x[0][0] == 1  # rejected until writable shared-buffer views exist
+   a = np.array([1, 2, 3])
+   b = np.array([4, 5, 6])
+   np.dot(a, b)
    ```
-   The remaining risk is coverage breadth: any view-like operation not yet
-   classified must be added to the guard layer or migrated directly to the
-   definitive descriptor-based alias model before writable semantics can be
-   considered sound.
+   aborts (core dump) during GOTO conversion instead of producing a
+   verdict. `a.dot(b)` (method form) does not crash — it raises an
+   explicit `TypeError`, so it is merely unsupported, not unsound. Found
+   while checking which other methods could safely gain dispatch rewrite
+   support alongside this PR; not fixed here since it is unrelated to
+   view/dispatch work and needs its own root-cause investigation.
 
 ---
 
@@ -214,12 +264,16 @@ No remaining KNOWNBUG in the targeted `dot6`/`dot7`/`transpose2`/
 
 ## Prioritised next steps
 
-1. **Definitive view descriptor model** — replace the current conservative
-   guard-over-copy approach with shared `ndarray_descriptor`
-   buffer_id/offset/stride metadata in indexing, assignment, transpose,
-   reshape/ravel, and escape checks. This is the path to writable views that
-   alias like NumPy instead of being rejected.
-2. **NumPy arrays as function return values, general case** — only the
+1. **`np.dot(a, b)` crash with two variable-sourced 1-D vectors** — see
+   "Soundness concerns" #5. Highest priority: it is a process crash, not
+   merely a missing feature or a conservative rejection.
+2. **Definitive view descriptor model (ADR-NP-003 etapa 2)** — replace the
+   current conservative guard-over-copy approach with shared
+   `ndarray_descriptor` buffer_id/offset/stride metadata in indexing,
+   assignment, transpose, reshape/ravel, and escape checks. This is the
+   path to writable views that alias like NumPy instead of being rejected.
+   Etapa 1 (the guard layer) is complete — see "Recently completed".
+3. **NumPy arrays as function return values, general case** — only the
    narrow identity-return pattern (a single-parameter function whose entire
    body is `return <that param>`) is fixed; a sub-array return
    (`def f(a): return a[0]`), a function with more than one parameter, or
@@ -234,39 +288,57 @@ No remaining KNOWNBUG in the targeted `dot6`/`dot7`/`transpose2`/
    needs to understand and consolidate that pipeline first, rather than
    work around it purely at the call site or the callee's return
    statement.
-3. **Strided column slice combined with explicit bounds** (`a[:, 1:3:2]`) —
-   currently rejected explicitly; the bare-step form (`a[:, ::step]`) is
-   supported. Would need the result width resolved from runtime bounds
-   instead of the array's static shape.
-4. **Multiple slice axes or symbolic bounds mixed with integer indices in
-   one tuple** (`a[:, :, 0]`, `a[i:j, 0, 0]`) — literal bounded one-axis
-   mixed tuple slices are supported; broader symbolic/multi-axis forms stay
-   rejected explicitly.
-5. **Advanced dtype and constructor parity** — object/structured/custom
-   dtype support remains intentionally rejected in the new creation helpers.
-6. **Random and iterator follow-up** — extend beyond the initial nondet
+4. **`a.sort()`/`a.argsort()`/`a.tolist()`/`a.any()`/`a.all()` method
+   forms** — see the "Missing indexing / slicing" table above; each needs
+   its own design (in-place mutation semantics, extending `np.argsort()`
+   to variables first, a new array-to-list conversion, or root-causing the
+   `any()`/`all()` zero-argument dispatch bug) rather than the plain
+   rewrite used for the method forms closed in this round.
+5. **Multiple slice axes or symbolic bounds mixed with integer indices in
+   one tuple** (`a[:, :, :, 0]` on 4-D+, `a[i:j, 0, 0]`) — literal bounded
+   one- and two-slice-axis mixed tuple slices (`a[:, 0, 0]`, `a[:, :, 0]`)
+   and the bounded strided column slice (`a[:, 1:3:2]`) are already
+   supported (confirmed by direct execution — the previous revision of
+   this document listed both as still pending, which was stale); broader
+   symbolic/multi-axis forms beyond those stay rejected explicitly.
+6. **Advanced dtype and constructor parity** — object/structured/custom
+   dtype support remains intentionally rejected in the new creation
+   helpers; the basic case (`dtype=float` in `np.array`) already works.
+7. **Random and iterator follow-up** — extend beyond the initial nondet
    random/choice recut to probability vectors, replacement semantics,
-   additional distributions, writable `nditer`, and mutation through `flat`.
-7. **Linear algebra breadth** — larger matrices, symbolic matrix entries,
+   additional distributions, writable `nditer`, and mutation through `flat`
+   (needs etapa 2 first, since `.flat`'s current rewrite target,
+   `np.ravel(a)`, is a copy).
+8. **Linear algebra breadth** — larger matrices (`det`/`inv` explicitly cap
+   at 3×3 today, confirmed by direct execution — generalizing needs a
+   symbolic cofactor-expansion/Gauss-elimination algorithm, not a bug fix),
+   symbolic matrix entries,
    additional `norm` axes/orders, and more faithful `eig`/`svd` semantics.
 
 ## Suggested next PRs
 
-1. **Shared-buffer view descriptors** — connect `ndarray_descriptor`
-   buffer/offset/stride metadata to basic indexing, transpose, assignment,
-   and escape checks so supported writable views alias correctly instead of
-   being rejected conservatively.
-2. **General array returns** — consolidate the assignment/type inference
+1. **Fix the `np.dot` variable-vector crash** — small, isolated, high
+   priority (process crash, not a soundness/feature gap).
+2. **Shared-buffer view descriptors (ADR-NP-003 etapa 2)** — connect
+   `ndarray_descriptor` buffer/offset/stride metadata to basic indexing,
+   transpose, assignment, and escape checks so supported writable views
+   alias correctly instead of being rejected conservatively. Also unblocks
+   writable `.flat`/`nditer`.
+3. **General array returns** — consolidate the assignment/type inference
    pipeline so user functions can return non-trivial NumPy arrays and
    sub-arrays without double conversion or wrapper-type confusion.
-3. **Advanced dtype and constructors** — structured/object dtype policy,
+4. **Remaining array method forms** — `a.sort()` (in-place semantics),
+   `a.argsort()` (needs `np.argsort()` to accept a variable first),
+   `a.tolist()` (new conversion, no function-form equivalent), and
+   `a.any()`/`a.all()` (root-cause the zero-argument dispatch bug first).
+5. **Advanced dtype and constructors** — structured/object dtype policy,
    constructor diagnostics, and dtype propagation for creation/sort/stat
    helpers.
-4. **Random and iteration depth** — PRNG-state decisions, remaining
+6. **Random and iteration depth** — PRNG-state decisions, remaining
    distributions, probability/replacement `choice`, writable `nditer`, and
    `flat` assignment semantics.
-5. **Linear algebra expansion** — matrix-size strategy, symbolic-entry
-   policy, and additional `norm`/`eig`/`svd` coverage.
+7. **Linear algebra expansion** — matrix-size strategy (`det`/`inv` beyond
+   3×3), symbolic-entry policy, and additional `norm`/`eig`/`svd` coverage.
 
 ### Out of scope
 - True SMT-array scalability — `array_typet` already lowers to SMT

--- a/regression/numpy/dispatch_rewrite_eye_identity_linspace_success/main.py
+++ b/regression/numpy/dispatch_rewrite_eye_identity_linspace_success/main.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+# np.eye/identity/linspace results were not tracked in numpy_array_symbols_,
+# so a method call on one (e.g. a.sum()) silently stopped being rewritten
+# into the np.sum(a) dispatch form instead of raising a diagnostic.
+a = np.eye(2)
+s = a.sum()
+assert s == 2.0
+
+c = np.identity(3)
+s2 = c.sum()
+assert s2 == 3.0
+
+e = np.linspace(0.0, 4.0, 5)
+g = e.copy()
+assert g[0] == 0.0
+assert g[4] == 4.0

--- a/regression/numpy/dispatch_rewrite_eye_identity_linspace_success/test.desc
+++ b/regression/numpy/dispatch_rewrite_eye_identity_linspace_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/flat_mutation_diagnostic_fail/main.py
+++ b/regression/numpy/flat_mutation_diagnostic_fail/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.array([[1, 2], [3, 4]])
+a.flat[0] = 99

--- a/regression/numpy/flat_mutation_diagnostic_fail/test.desc
+++ b/regression/numpy/flat_mutation_diagnostic_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: mutation through .flat is not supported

--- a/regression/numpy/flatten_method_1d_success/main.py
+++ b/regression/numpy/flatten_method_1d_success/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+a = np.array([1, 2, 3, 4])
+b = a.flatten()
+
+assert b[0] == 1
+assert b[1] == 2
+assert b[2] == 3
+assert b[3] == 4

--- a/regression/numpy/flatten_method_1d_success/test.desc
+++ b/regression/numpy/flatten_method_1d_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/flatten_method_2d_independent_edge/main.py
+++ b/regression/numpy/flatten_method_2d_independent_edge/main.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+a = np.array([[1, 2], [3, 4]])
+b = a.flatten()
+b[0] = 99
+
+assert a[0][0] == 1
+assert b[0] == 99

--- a/regression/numpy/flatten_method_2d_independent_edge/test.desc
+++ b/regression/numpy/flatten_method_2d_independent_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ravel_method_non_numpy_receiver_fail/main.py
+++ b/regression/numpy/ravel_method_non_numpy_receiver_fail/main.py
@@ -1,0 +1,16 @@
+class Buffer:
+    def __init__(self):
+        self.data = [1, 2, 3]
+
+    def ravel(self):
+        return self.data
+
+
+# A user class with its own ravel() method is unrelated to numpy's .flat.
+# Writing through its result is still unsupported (Buffer.ravel() returns a
+# fresh reference, not something extract_target_name can resolve to a
+# symbol), but it must not be reported as the numpy-specific .flat
+# diagnostic, which only applies to a numpy-sourced receiver.
+b = Buffer()
+b.ravel()[0] = 99
+assert b.data[0] == 99

--- a/regression/numpy/ravel_method_non_numpy_receiver_fail/test.desc
+++ b/regression/numpy/ravel_method_non_numpy_receiver_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: Unsupported assignment target type: Call

--- a/regression/numpy/reducer_method_success/main.py
+++ b/regression/numpy/reducer_method_success/main.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+a = np.array([1.0, 2.0, 3.0])
+
+s = a.sum()
+m = a.mean()
+mn = a.min()
+mx = a.max()
+sd = a.std()
+vr = a.var()
+
+assert s == 6.0
+assert m == 2.0
+assert mn == 1.0
+assert mx == 3.0
+assert sd >= 0.0
+assert vr >= 0.0

--- a/regression/numpy/reducer_method_success/main.py
+++ b/regression/numpy/reducer_method_success/main.py
@@ -13,5 +13,7 @@ assert s == 6.0
 assert m == 2.0
 assert mn == 1.0
 assert mx == 3.0
-assert sd >= 0.0
-assert vr >= 0.0
+# var = mean((x - mean)^2) = ((1-2)^2 + (2-2)^2 + (3-2)^2) / 3 = 2/3
+assert vr > 0.6666 and vr < 0.6667
+# std = sqrt(var) = sqrt(2/3)
+assert sd > 0.8164 and sd < 0.8165

--- a/regression/numpy/reducer_method_success/test.desc
+++ b/regression/numpy/reducer_method_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/reshape_method_multi_arg_incompatible_fail/main.py
+++ b/regression/numpy/reshape_method_multi_arg_incompatible_fail/main.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+a = np.array([1, 2, 3, 4])
+b = a.reshape(2, 3)

--- a/regression/numpy/reshape_method_multi_arg_incompatible_fail/test.desc
+++ b/regression/numpy/reshape_method_multi_arg_incompatible_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: ValueError: cannot reshape array of size 4 into shape \(2, 3\)$

--- a/regression/numpy/reshape_method_multi_arg_negative_edge/main.py
+++ b/regression/numpy/reshape_method_multi_arg_negative_edge/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+a = np.array([1, 2, 3, 4])
+b = a.reshape(-1, 2)
+
+assert b[0][0] == 1
+assert b[1][1] == 4

--- a/regression/numpy/reshape_method_multi_arg_negative_edge/test.desc
+++ b/regression/numpy/reshape_method_multi_arg_negative_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/reshape_method_multi_arg_success/main.py
+++ b/regression/numpy/reshape_method_multi_arg_success/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+a = np.array([1, 2, 3, 4])
+b = a.reshape(2, 2)
+
+assert b[0][0] == 1
+assert b[0][1] == 2
+assert b[1][0] == 3
+assert b[1][1] == 4

--- a/regression/numpy/reshape_method_multi_arg_success/test.desc
+++ b/regression/numpy/reshape_method_multi_arg_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/reshape_module_form_split_dim_fail/main.py
+++ b/regression/numpy/reshape_module_form_split_dim_fail/main.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+# numpy.reshape(a, newshape, order='C') has no split-dimension form: a third
+# positional argument is `order`, not another dimension. Only the method
+# form a.reshape(d1, d2, ...) accepts dimensions split across arguments.
+a = np.array([1, 2, 3, 4, 5, 6])
+b = np.reshape(a, 2, 3)
+assert b[0][0] == 1

--- a/regression/numpy/reshape_module_form_split_dim_fail/test.desc
+++ b/regression/numpy/reshape_module_form_split_dim_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy\.reshape\(\) does not accept dimensions as separate positional arguments

--- a/regression/numpy/view_dict_literal_annotated_escape_fail/main.py
+++ b/regression/numpy/view_dict_literal_annotated_escape_fail/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+x = np.array([[1, 2], [3, 4]])
+holder: dict = {"row": x[0]}
+holder["row"][0] = 999
+
+assert x[0][0] == 1

--- a/regression/numpy/view_dict_literal_annotated_escape_fail/test.desc
+++ b/regression/numpy/view_dict_literal_annotated_escape_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: storing a copied numpy view in a container is not supported

--- a/regression/numpy/view_dict_literal_escape_fail/main.py
+++ b/regression/numpy/view_dict_literal_escape_fail/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+x = np.array([[1, 2], [3, 4]])
+holder = {"row": x[0]}
+holder["row"][0] = 999
+
+assert x[0][0] == 1

--- a/regression/numpy/view_dict_literal_escape_fail/test.desc
+++ b/regression/numpy/view_dict_literal_escape_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: storing a copied numpy view in a container is not supported

--- a/regression/numpy/view_global_param_escape_fail/main.py
+++ b/regression/numpy/view_global_param_escape_fail/main.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+g = None
+
+
+def leak(a):
+    global g
+    g = a[0]
+
+
+x = np.array([[1, 2], [3, 4]])
+leak(x)
+g[0] = 999
+
+assert x[0][0] == 1

--- a/regression/numpy/view_global_param_escape_fail/test.desc
+++ b/regression/numpy/view_global_param_escape_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: TypeError: storing a copied numpy view in a global variable is not supported
+^ERROR: TypeError: storing a copied numpy view in a global is not supported

--- a/regression/numpy/view_global_param_escape_fail/test.desc
+++ b/regression/numpy/view_global_param_escape_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: storing a copied numpy view in a global variable is not supported

--- a/regression/numpy/view_inline_list_escape_fail/main.py
+++ b/regression/numpy/view_inline_list_escape_fail/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+x = np.array([[1, 2], [3, 4]])
+holder = [x[0]]
+holder[0][0] = 999
+
+assert x[0][0] == 1

--- a/regression/numpy/view_inline_list_escape_fail/test.desc
+++ b/regression/numpy/view_inline_list_escape_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: storing a copied numpy view in a container is not supported

--- a/regression/numpy/view_inline_list_read_success/main.py
+++ b/regression/numpy/view_inline_list_read_success/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+x = np.array([[1, 2], [3, 4]])
+holder = [x[0][0]]
+
+assert holder[0] == 1
+assert x[0][0] == 1

--- a/regression/numpy/view_inline_list_read_success/test.desc
+++ b/regression/numpy/view_inline_list_read_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/view_inline_tuple_escape_edge/main.py
+++ b/regression/numpy/view_inline_tuple_escape_edge/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+x = np.array([[1, 2], [3, 4]])
+holder = (x[0],)
+holder[0][0] = 999
+
+assert x[0][0] == 1

--- a/regression/numpy/view_inline_tuple_escape_edge/test.desc
+++ b/regression/numpy/view_inline_tuple_escape_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: storing a copied numpy view in a container is not supported

--- a/regression/numpy/view_param_local_read_success/main.py
+++ b/regression/numpy/view_param_local_read_success/main.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+
+def read_local(a):
+    row = a[0]
+    assert row[0] == 1
+    assert row[1] == 2
+
+
+x = np.array([[1, 2], [3, 4]])
+read_local(x)
+assert x[0][0] == 1

--- a/regression/numpy/view_param_local_read_success/test.desc
+++ b/regression/numpy/view_param_local_read_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1316,7 +1316,21 @@ bool python_converter::contains_copied_numpy_view_name(
 
   if (node.is_object())
   {
-    if (node.value("_type", "") == "Name" && node.contains("id"))
+    const std::string node_type = node.value("_type", "");
+
+    // A comprehension/generator always builds a brand-new list/set/dict, so
+    // it cannot itself be a numpy view; and its element/key/value
+    // expressions reference the comprehension's own loop variable(s), which
+    // are not registered as real symbols outside of the comprehension's own
+    // conversion (handle_comprehension/_lower_listcomp) — probing a
+    // Subscript inside one here (e.g. `x[j]` for `for j in ...`) would look
+    // up `j` before it exists and abort the conversion.
+    if (
+      node_type == "GeneratorExp" || node_type == "ListComp" ||
+      node_type == "SetComp" || node_type == "DictComp")
+      return false;
+
+    if (node_type == "Name" && node.contains("id"))
     {
       const std::string id =
         resolve_name_symbol_id(node["id"].get<std::string>());
@@ -1334,17 +1348,31 @@ bool python_converter::contains_copied_numpy_view_name(
     // matches a plain scalar element read (x[0][0]), which is not a view,
     // so confirm the expression is actually array-typed before treating
     // it as an escape.
+    //
+    // The probe itself is not free of side effects either: a bounds-checked
+    // subscript (list index, when `--no-bounds-check` is not set) emits a
+    // size lookup and an IndexError-raise guard into current_block. This
+    // function can be reached while walking an AST subtree that has not
+    // been selected for evaluation yet (e.g. the untaken branch of a
+    // ternary, still being probed by contains_copied_numpy_view_name before
+    // get_conditional_stm's own short-circuit guard is built), so those
+    // instructions must not leak into the real block. Redirect them into a
+    // throwaway block for the duration of the probe.
     if (
       is_basic_numpy_view_subscript(node) &&
       !root_name_from_subscript(node["value"]).empty())
     {
+      code_blockt scratch_block;
+      code_blockt *saved_block = current_block;
+      current_block = &scratch_block;
       exprt probe = get_expr(node);
+      current_block = saved_block;
       if (!contains_cpp_throw(probe) && probe.type().is_array())
         return true;
     }
 
     if (
-      node.value("_type", "") == "Subscript" && node.contains("value") &&
+      node_type == "Subscript" && node.contains("value") &&
       node.contains("slice") && !json_contains_slice_node(node["slice"]) &&
       contains_copied_numpy_view_name(node["value"]))
       return contains_copied_numpy_view_name(node["slice"]);

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1240,7 +1240,8 @@ bool python_converter::is_numpy_array_constructor_expr(
     return false;
 
   static const std::set<std::string> constructors = {
-    "array", "zeros", "ones", "full", "empty", "arange"};
+    "array", "zeros", "ones", "full", "empty", "arange", "eye", "identity",
+    "linspace"};
   return constructors.count(node["func"].value("attr", "")) != 0;
 }
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -2580,6 +2580,19 @@ python_converter::extract_target_name(const nlohmann::json &target) const
     // Recurse through nested Subscripts (e.g. board[0][0] = x) to reach the
     // root container's Name/Attribute, which carries the symbol id.
     return extract_target_name(target["value"]);
+  else if (
+    target_type == "Call" && target.contains("func") &&
+    target["func"].is_object() &&
+    target["func"].value("_type", "") == "Attribute" &&
+    target["func"].value("attr", "") == "ravel")
+    // a.flat[i] = x: the preprocessor rewrites every .flat read, including
+    // the one implicit in this assignment's target, to np.ravel(a) — so the
+    // target here is really Subscript(value=Call(ravel(a))), which has no
+    // symbol id to extract. np.ravel(a)[i] = x written directly hits the
+    // same shape and is equally unsupported for the same reason (ravel's
+    // result is a copy, not a writable view of a).
+    throw std::runtime_error(
+      "TypeError: mutation through .flat is not supported");
 
   throw std::runtime_error(
     "Unsupported assignment target type: " + target_type.get<std::string>());

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3781,6 +3781,13 @@ void python_converter::get_var_assign(
           call_node["args"].push_back(arg);
       call_node["keywords"] =
         ast_node["value"].value("keywords", nlohmann::json::array());
+      // numpy.reshape(a, newshape, order='C') has no split-dimension form
+      // (a third positional argument is `order`, not another dimension);
+      // only the method form a.reshape(d1, d2, ...) is equivalent to
+      // a.reshape((d1, d2, ...)). Mark this rewrite so the reshape handler
+      // can tell the two shapes apart and reject a genuine
+      // np.reshape(a, 2, 3) call instead of silently accepting it.
+      call_node["_numpy_method_form"] = true;
       copy_location_fields_from_decl(ast_node["value"], call_node);
       copy_location_fields_from_decl(ast_node["value"], call_node["func"]);
       effective_ast_node["value"] = call_node;

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1365,7 +1365,16 @@ bool python_converter::contains_copied_numpy_view_name(
       code_blockt scratch_block;
       code_blockt *saved_block = current_block;
       current_block = &scratch_block;
-      exprt probe = get_expr(node);
+      exprt probe;
+      try
+      {
+        probe = get_expr(node);
+      }
+      catch (...)
+      {
+        current_block = saved_block;
+        throw;
+      }
       current_block = saved_block;
       if (!contains_cpp_throw(probe) && probe.type().is_array())
         return true;

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1093,7 +1093,8 @@ exprt python_converter::get_rhs_with_dict_resolution(
     dict_expr, ast_node["value"]["slice"], target_type);
 }
 
-std::string python_converter::resolve_name_symbol_id(const std::string &name)
+std::string
+python_converter::resolve_name_symbol_id(const std::string &name) const
 {
   symbol_id sid = create_symbol_id();
   sid.set_object(name);
@@ -2630,6 +2631,41 @@ bool python_converter::is_global_variable(const symbol_id &sid) const
   return false;
 }
 
+bool python_converter::is_numpy_ravel_receiver(
+  const nlohmann::json &ravel_call) const
+{
+  if (!ravel_call["func"].contains("value"))
+    return false;
+
+  const nlohmann::json &func_value = ravel_call["func"]["value"];
+  const bool is_module_form =
+    func_value.is_object() && func_value.value("_type", "") == "Name" &&
+    is_imported_numpy_module_alias(*ast_json, func_value.value("id", ""));
+
+  // np.ravel(a): the array is the call's first argument (this is the shape
+  // the preprocessor's .flat rewrite always produces). a.ravel(): the array
+  // is the Attribute's own receiver.
+  nlohmann::json receiver;
+  if (is_module_form)
+  {
+    if (
+      ravel_call.contains("args") && ravel_call["args"].is_array() &&
+      !ravel_call["args"].empty())
+      receiver = ravel_call["args"][0];
+  }
+  else
+    receiver = func_value;
+
+  const std::string receiver_name = root_name_from_subscript(receiver);
+  if (receiver_name.empty())
+    return false;
+
+  const std::string receiver_id = resolve_name_symbol_id(receiver_name);
+  return !receiver_id.empty() &&
+         (numpy_array_symbols_.count(receiver_id) != 0 ||
+          numpy_view_copy_sources_.count(receiver_id) != 0);
+}
+
 std::string
 python_converter::extract_target_name(const nlohmann::json &target) const
 {
@@ -2647,13 +2683,16 @@ python_converter::extract_target_name(const nlohmann::json &target) const
     target_type == "Call" && target.contains("func") &&
     target["func"].is_object() &&
     target["func"].value("_type", "") == "Attribute" &&
-    target["func"].value("attr", "") == "ravel")
+    target["func"].value("attr", "") == "ravel" &&
+    is_numpy_ravel_receiver(target))
     // a.flat[i] = x: the preprocessor rewrites every .flat read, including
     // the one implicit in this assignment's target, to np.ravel(a) — so the
     // target here is really Subscript(value=Call(ravel(a))), which has no
     // symbol id to extract. np.ravel(a)[i] = x written directly hits the
     // same shape and is equally unsupported for the same reason (ravel's
-    // result is a copy, not a writable view of a).
+    // result is a copy, not a writable view of a). Gated on the receiver
+    // actually being a tracked numpy array/view so an unrelated class with
+    // its own ravel() method does not get this numpy-specific diagnostic.
     throw std::runtime_error(
       "TypeError: mutation through .flat is not supported");
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1323,6 +1323,26 @@ bool python_converter::contains_copied_numpy_view_name(
       return !id.empty() && numpy_view_copy_sources_.count(id) != 0;
     }
 
+    // An inline basic-indexing view used directly as a container literal
+    // element (x[0]) escapes just as much as one already bound to a name
+    // first — what makes it escape is the container literal, not whether
+    // an intermediate variable was involved. Scoped to the Subscript form
+    // only (not `.T`/`transpose`/`reshape`/`ravel` Call forms): probing
+    // those via get_expr here would convert them a second time, and
+    // unlike a plain index-into-a-symbol, their conversion is not free of
+    // side effects on converter state. The same Subscript AST shape also
+    // matches a plain scalar element read (x[0][0]), which is not a view,
+    // so confirm the expression is actually array-typed before treating
+    // it as an escape.
+    if (
+      is_basic_numpy_view_subscript(node) &&
+      !root_name_from_subscript(node["value"]).empty())
+    {
+      exprt probe = get_expr(node);
+      if (!contains_cpp_throw(probe) && probe.type().is_array())
+        return true;
+    }
+
     if (
       node.value("_type", "") == "Subscript" && node.contains("value") &&
       node.contains("slice") && !json_contains_slice_node(node["slice"]) &&

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3634,6 +3634,14 @@ void python_converter::get_var_assign(
       !base_is_imported_module &&
       (method_name == "transpose" || method_name == "reshape" ||
        method_name == "ravel");
+    // flatten() is copy-like, not view-like (see is_numpy_view_copy_expr,
+    // which deliberately excludes it), but the method form still needs the
+    // same np.flatten(a, ...)-shaped rewrite below to dispatch to the
+    // existing numpy.flatten() handler — the only form that method-call
+    // dispatch resolves through here at all is the function-call shape.
+    const bool supported_dispatch_rewrite_method =
+      supported_view_method ||
+      (!base_is_imported_module && method_name == "flatten");
     const std::string method_base_id =
       method_base_name.empty() ? std::string()
                                : resolve_name_symbol_id(method_base_name);
@@ -3645,7 +3653,7 @@ void python_converter::get_var_assign(
     {
       effective_ast_node["value"] = ast_node["value"]["func"]["value"];
     }
-    else if (supported_view_method)
+    else if (supported_dispatch_rewrite_method)
     {
       std::string numpy_alias = "np";
       for (const auto &entry : imported_modules)

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1241,7 +1241,14 @@ bool python_converter::is_numpy_array_constructor_expr(
     return false;
 
   static const std::set<std::string> constructors = {
-    "array", "zeros", "ones", "full", "empty", "arange", "eye", "identity",
+    "array",
+    "zeros",
+    "ones",
+    "full",
+    "empty",
+    "arange",
+    "eye",
+    "identity",
     "linspace"};
   return constructors.count(node["func"].value("attr", "")) != 0;
 }

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3634,14 +3634,18 @@ void python_converter::get_var_assign(
       !base_is_imported_module &&
       (method_name == "transpose" || method_name == "reshape" ||
        method_name == "ravel");
-    // flatten() is copy-like, not view-like (see is_numpy_view_copy_expr,
-    // which deliberately excludes it), but the method form still needs the
-    // same np.flatten(a, ...)-shaped rewrite below to dispatch to the
-    // existing numpy.flatten() handler — the only form that method-call
-    // dispatch resolves through here at all is the function-call shape.
+    // flatten()/sum()/mean()/min()/max()/std()/var() are not view-like (see
+    // is_numpy_view_copy_expr, which deliberately excludes them), but the
+    // method form still needs the same np.<name>(a, ...)-shaped rewrite
+    // below to dispatch to the existing np.<name>() handler — the only form
+    // that method-call dispatch resolves through here at all is the
+    // function-call shape.
+    static const std::set<std::string> other_dispatch_rewrite_methods = {
+      "flatten", "sum", "mean", "min", "max", "std", "var"};
     const bool supported_dispatch_rewrite_method =
       supported_view_method ||
-      (!base_is_imported_module && method_name == "flatten");
+      (!base_is_imported_module &&
+       other_dispatch_rewrite_methods.count(method_name) != 0);
     const std::string method_base_id =
       method_base_name.empty() ? std::string()
                                : resolve_name_symbol_id(method_base_name);

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1504,6 +1504,31 @@ void python_converter::reject_numpy_view_identity_query(
   }
 }
 
+// dict_handler_ intercepts a Dict-literal assignment before the generic
+// List/Tuple/Dict escape check further down the caller ever runs, so a
+// copied-view escape into a dict literal (named or inline, e.g.
+// {"row": x[0]}) has to be caught here too, or the view ends up embedded in
+// the dict's runtime representation in a way that crashes SMT encoding
+// instead of producing a diagnostic (mismatched sort widths in
+// z3_convt::mk_eq).
+void python_converter::reject_copied_numpy_view_in_container(
+  const nlohmann::json &ast_node,
+  const std::set<std::string> &container_types)
+{
+  if (!ast_node.contains("value") || !ast_node["value"].is_object())
+    return;
+
+  const nlohmann::json &value_node = ast_node["value"];
+  if (
+    container_types.count(value_node.value("_type", "")) == 0 ||
+    !contains_copied_numpy_view_name(value_node))
+    return;
+
+  throw std::runtime_error(
+    "TypeError: storing a copied numpy view in a container is not "
+    "supported");
+}
+
 std::optional<nlohmann::json> python_converter::select_return_value_for_call(
   const nlohmann::json &call_node) const
 {
@@ -3476,20 +3501,7 @@ void python_converter::get_var_assign(
     // Create LHS expression
     lhs = create_lhs_expression(target, lhs_symbol, location_begin);
 
-    // A dict literal containing a copied numpy view (named or inline, e.g.
-    // {"row": x[0]}) is handled entirely by dict_handler_ below, which
-    // never routes through the generic List/Tuple/Dict escape check further
-    // down this function (dict_handler_ returns before reaching it) — so it
-    // has to be caught here too, or the view ends up embedded in the dict's
-    // runtime representation in a way that crashes SMT encoding instead of
-    // producing a diagnostic (mismatched sort widths in z3_convt::mk_eq).
-    if (
-      ast_node.contains("value") && ast_node["value"].is_object() &&
-      ast_node["value"].value("_type", "") == "Dict" &&
-      contains_copied_numpy_view_name(ast_node["value"]))
-      throw std::runtime_error(
-        "TypeError: storing a copied numpy view in a container is not "
-        "supported");
+    reject_copied_numpy_view_in_container(ast_node, {"Dict"});
 
     // Handle dict literal assignment specially - after LHS is created
     if (dict_handler_->handle_literal_assignment_check(*this, ast_node, lhs))
@@ -3521,16 +3533,7 @@ void python_converter::get_var_assign(
 
     bool is_global = is_global_variable(sid);
 
-    // Same reasoning as the annotated-assignment dict check above: this
-    // path also hands off to dict_handler_ before the generic container
-    // escape check further down ever runs.
-    if (
-      ast_node.contains("value") && ast_node["value"].is_object() &&
-      ast_node["value"].value("_type", "") == "Dict" &&
-      contains_copied_numpy_view_name(ast_node["value"]))
-      throw std::runtime_error(
-        "TypeError: storing a copied numpy view in a container is not "
-        "supported");
+    reject_copied_numpy_view_in_container(ast_node, {"Dict"});
 
     // Handle unannotated dict literal assignment
     if (
@@ -3615,17 +3618,7 @@ void python_converter::get_var_assign(
   current_lhs = &lhs;
   is_converting_lhs = false;
 
-  if (
-    ast_node.contains("value") && ast_node["value"].is_object() &&
-    (ast_node["value"].value("_type", "") == "List" ||
-     ast_node["value"].value("_type", "") == "Tuple" ||
-     ast_node["value"].value("_type", "") == "Dict") &&
-    contains_copied_numpy_view_name(ast_node["value"]))
-  {
-    throw std::runtime_error(
-      "TypeError: storing a copied numpy view in a container is not "
-      "supported");
-  }
+  reject_copied_numpy_view_in_container(ast_node, {"List", "Tuple", "Dict"});
 
   // Get RHS
   nlohmann::json effective_ast_node = ast_node;

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3425,6 +3425,21 @@ void python_converter::get_var_assign(
     // Create LHS expression
     lhs = create_lhs_expression(target, lhs_symbol, location_begin);
 
+    // A dict literal containing a copied numpy view (named or inline, e.g.
+    // {"row": x[0]}) is handled entirely by dict_handler_ below, which
+    // never routes through the generic List/Tuple/Dict escape check further
+    // down this function (dict_handler_ returns before reaching it) — so it
+    // has to be caught here too, or the view ends up embedded in the dict's
+    // runtime representation in a way that crashes SMT encoding instead of
+    // producing a diagnostic (mismatched sort widths in z3_convt::mk_eq).
+    if (
+      ast_node.contains("value") && ast_node["value"].is_object() &&
+      ast_node["value"].value("_type", "") == "Dict" &&
+      contains_copied_numpy_view_name(ast_node["value"]))
+      throw std::runtime_error(
+        "TypeError: storing a copied numpy view in a container is not "
+        "supported");
+
     // Handle dict literal assignment specially - after LHS is created
     if (dict_handler_->handle_literal_assignment_check(*this, ast_node, lhs))
     {
@@ -3454,6 +3469,17 @@ void python_converter::get_var_assign(
     lhs_symbol = symbol_table_.find_symbol(sid.to_string());
 
     bool is_global = is_global_variable(sid);
+
+    // Same reasoning as the annotated-assignment dict check above: this
+    // path also hands off to dict_handler_ before the generic container
+    // escape check further down ever runs.
+    if (
+      ast_node.contains("value") && ast_node["value"].is_object() &&
+      ast_node["value"].value("_type", "") == "Dict" &&
+      contains_copied_numpy_view_name(ast_node["value"]))
+      throw std::runtime_error(
+        "TypeError: storing a copied numpy view in a container is not "
+        "supported");
 
     // Handle unannotated dict literal assignment
     if (

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3671,8 +3671,19 @@ void python_converter::get_var_assign(
     const bool base_is_imported_module =
       method_base_name == "np" || method_base_name == "numpy" ||
       (!method_base_name.empty() && is_imported_module(method_base_name));
+    const std::string method_base_id =
+      method_base_name.empty() ? std::string()
+                               : resolve_name_symbol_id(method_base_name);
+    // A method name like sum()/max()/min() is not exclusive to numpy (e.g.
+    // Decimal.max(), a plain module-level function called through an
+    // aliased import); only rewrite when the receiver is actually a
+    // tracked numpy array, matching the check already used for copy()
+    // below.
+    const bool method_base_is_numpy_array =
+      !method_base_id.empty() &&
+      numpy_array_symbols_.count(method_base_id) != 0;
     const bool supported_view_method =
-      !base_is_imported_module &&
+      !base_is_imported_module && method_base_is_numpy_array &&
       (method_name == "transpose" || method_name == "reshape" ||
        method_name == "ravel");
     // flatten()/sum()/mean()/min()/max()/std()/var() are not view-like (see
@@ -3685,15 +3696,11 @@ void python_converter::get_var_assign(
       "flatten", "sum", "mean", "min", "max", "std", "var"};
     const bool supported_dispatch_rewrite_method =
       supported_view_method ||
-      (!base_is_imported_module &&
+      (!base_is_imported_module && method_base_is_numpy_array &&
        other_dispatch_rewrite_methods.count(method_name) != 0);
-    const std::string method_base_id =
-      method_base_name.empty() ? std::string()
-                               : resolve_name_symbol_id(method_base_name);
-    const bool supported_copy_method =
-      !base_is_imported_module && method_name == "copy" &&
-      !method_base_id.empty() &&
-      numpy_array_symbols_.count(method_base_id) != 0;
+    const bool supported_copy_method = !base_is_imported_module &&
+                                       method_name == "copy" &&
+                                       method_base_is_numpy_array;
     if (supported_copy_method)
     {
       effective_ast_node["value"] = ast_node["value"]["func"]["value"];

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -5936,7 +5936,18 @@ exprt numpy_call_expr::get()
       // (a.reshape(d1, d2, ...)), equivalent to a.reshape((d1, d2, ...)).
       // Only reachable here (not the single-tuple-arg branch above) because
       // a single dimension can't be split into more than one argument, so
-      // more than one argument past the array itself always means this form.
+      // more than one argument past the array itself always means this
+      // form -- for the method-form rewrite. A genuine module-function call
+      // numpy.reshape(a, 2, 3) has no such form: numpy's real signature is
+      // reshape(a, newshape, order='C'), so the third positional argument
+      // is `order`, not another dimension. Reject that case explicitly
+      // instead of silently reinterpreting it as split dimensions.
+      if (!call_.value("_numpy_method_form", false))
+        throw std::runtime_error(
+          "TypeError: numpy.reshape() does not accept dimensions as "
+          "separate positional arguments; pass a tuple, or use the "
+          "a.reshape(d1, d2, ...) method form");
+
       for (std::size_t i = 1; i < call_["args"].size(); ++i)
       {
         int64_t d = parse_reshape_dim(call_["args"][i]);

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -5930,6 +5930,22 @@ exprt numpy_call_expr::get()
         raw_shape.push_back(d);
       }
     }
+    else if (call_["args"].size() > 2)
+    {
+      // Method form with each dimension as its own positional argument
+      // (a.reshape(d1, d2, ...)), equivalent to a.reshape((d1, d2, ...)).
+      // Only reachable here (not the single-tuple-arg branch above) because
+      // a single dimension can't be split into more than one argument, so
+      // more than one argument past the array itself always means this form.
+      for (std::size_t i = 1; i < call_["args"].size(); ++i)
+      {
+        int64_t d = parse_reshape_dim(call_["args"][i]);
+        if (d == INT64_MIN)
+          throw std::runtime_error(
+            "TypeError: numpy.reshape() shape must contain concrete integers");
+        raw_shape.push_back(d);
+      }
+    }
     else
     {
       int64_t d = parse_reshape_dim(shape_arg);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -863,6 +863,10 @@ private:
 
   void reject_numpy_view_identity_query(const nlohmann::json &node);
 
+  void reject_copied_numpy_view_in_container(
+    const nlohmann::json &ast_node,
+    const std::set<std::string> &container_types);
+
   std::optional<nlohmann::json>
   select_return_value_for_call(const nlohmann::json &call_node) const;
 

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -842,7 +842,7 @@ private:
     const nlohmann::json &ast_node,
     const typet &current_type);
 
-  std::string resolve_name_symbol_id(const std::string &name);
+  std::string resolve_name_symbol_id(const std::string &name) const;
 
   std::string root_name_from_subscript(const nlohmann::json &node) const;
 
@@ -866,6 +866,8 @@ private:
   void reject_copied_numpy_view_in_container(
     const nlohmann::json &ast_node,
     const std::set<std::string> &container_types);
+
+  bool is_numpy_ravel_receiver(const nlohmann::json &ravel_call) const;
 
   std::optional<nlohmann::json>
   select_return_value_for_call(const nlohmann::json &call_node) const;


### PR DESCRIPTION
- view used inline in a list/tuple literal without a named binding (`holder = [x[0]]`) escaped detection entirely; only the already-named form (`row = x[0]; holder = [row]`) was caught.
- Fixes a real process crash: storing a view in a `dict` literal (named or inline) aborted the SMT solver (`z3_conv.cpp` `mk_eq` width-mismatch) instead of producing a diagnostic — `dict_handler_`'s literal-assignment paths never reached the container-escape check that already protected `List`/`Tuple`.
- Adds a regression test confirming escape via `global` from a function-parameter-sourced view (as opposed to a locally created one) is already correctly rejected.
- Fixes `a.reshape(d1, d2, ...)` (dimensions as separate positional arguments): it silently dropped every dimension past the first; only the tuple-shape form worked.
- Adds the real NumPy method forms `a.flatten()`, `a.sum()`, `a.mean()`, `a.min()`, `a.max()`, `a.std()`, `a.var()` — previously unhandled `AttributeError`/`TypeError` — by extending the existing method-to-function dispatch rewrite already used for `a.transpose()`/`a.reshape()`/`a.ravel()`.
- Gives `a.flat[i] = x` a specific diagnostic (`TypeError: mutation through .flat is not supported`) instead of the generic `Unsupported assignment target type: Call`; the write itself remains unsupported 