### PR TITLE
[python] Do not treat a module's own name as an import

### DIFF
--- a/regression/python/module_self_name/main.py
+++ b/regression/python/module_self_name/main.py
@@ -1,0 +1,10 @@
+# A module never imports itself, so a variable may carry the module's own name.
+# is_imported_module fell back to "does a module of this name exist on disk",
+# and the file being converted always does, so the receiver resolved to the
+# module and no method call on it dispatched (#6639).
+import queue
+
+main: queue.Queue = queue.Queue()
+main.put(7)
+x = main.get()
+assert x == 7

--- a/regression/python/module_self_name/test.desc
+++ b/regression/python/module_self_name/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_symbols.cpp
+++ b/src/python-frontend/converter/converter_symbols.cpp
@@ -1,5 +1,6 @@
 #include <python-frontend/json_utils.h>
 #include <python-frontend/python_converter.h>
+#include <filesystem>
 #include <python-frontend/symbol_id.h>
 #include <util/arith/arith_tools.h>
 #include <util/message/message.h>
@@ -372,7 +373,22 @@ bool python_converter::is_imported_module(const std::string &module_name) const
   if (imported_modules.find(module_name) != imported_modules.end())
     return true;
 
+  // A module never imports itself, so its own name is not a module reference
+  // inside it and a variable may legitimately carry that name. The fallback
+  // below only asks whether a module of this name exists on disk, and the file
+  // being converted always does -- so without this, `foo` in foo.py resolves to
+  // the module and every method call on it fails to dispatch (#6639).
+  if (module_name == current_module_name())
+    return false;
+
   return json_utils::is_module(module_name, *ast_json);
+}
+
+/// Stem of the file being converted, i.e. the module name it would be imported
+/// under.
+std::string python_converter::current_module_name() const
+{
+  return std::filesystem::path(current_python_file).stem().string();
 }
 
 symbolt &python_converter::create_tmp_symbol(

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -231,6 +231,7 @@ public:
   symbolt *find_symbol(const std::string &symbol_id) const;
 
   bool is_imported_module(const std::string &module_name) const;
+  std::string current_module_name() const;
 
   const std::string
   get_imported_module_path(const std::string &module_name) const


### PR DESCRIPTION
`is_imported_module` falls back to asking whether a module of that name exists in the AST output directory, and the file being converted always does. So a variable carrying the module's own name — `foo` in `foo.py` — resolved to the module, and every method call on it failed to dispatch: the receiver never typed, so `get` fell through to the dict handler and asked for a dictionary key.

A module never imports itself, so its own name is excluded from that fallback. The same program under any other filename already verified.

Fixes #6639