### PR TITLE
[witness] Say up front that the witness list is truncated

### DIFF
--- a/regression/esbmc/github_4309-cap/test.desc
+++ b/regression/esbmc/github_4309-cap/test.desc
@@ -4,3 +4,4 @@ main.c
 ^VERIFICATION FAILED$
 Witness 1 of 1
 --max-witnesses cap reached
+^  NOTE: --max-witnesses cap reached; more witnesses may exist\.$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -625,6 +625,12 @@ void bmct::report_multi_property_trace(
   oss << (reachability_trace ? "\n[Reachability traces - "
                              : "\n[Counterexamples - ")
       << witnesses.size() << " witnesses]\n\n";
+  // Say up front that this is a truncated enumeration. The same fact reaches
+  // the Summary footer below, but that sits after every witness block -- tens
+  // of kilobytes on a real program -- so a reader can easily act on a partial
+  // list without realising it (#4311).
+  if (stop_reason == enumeration_stop_reasont::CapHit)
+    oss << "  NOTE: --max-witnesses cap reached; more witnesses may exist.\n\n";
   for (size_t i = 0; i < witnesses.size(); ++i)
   {
     const witness_recordt &w = witnesses[i];


### PR DESCRIPTION
The `--max-witnesses cap reached` stop reason only reaches the Summary footer, which sits after every witness block — tens of kilobytes on a real program — so a reader can act on a partial list without noticing it is partial. It now also appears immediately under the header.

One bullet of #4311; the rest (diff rendering, state cap, `--full-traces`, ASCII glyph fallback) is untouched, so the issue stays open.