### PR TITLE
[goto-symex] Add --closed-world-fnptr for calls with no target

### DIFF
--- a/regression/esbmc/github_604/main.c
+++ b/regression/esbmc/github_604/main.c
@@ -1,0 +1,13 @@
+typedef int func();
+
+/* No definition, and no address-taken function of this signature anywhere in
+ * the program: the call through f has no candidate target. */
+func *fun();
+
+int main()
+{
+  func *f = fun();
+  int x = f ? f() : 0;
+  __ESBMC_assert(!x, "x is 0 unless an unknown callee supplied a value");
+  return 0;
+}

--- a/regression/esbmc/github_604/test.desc
+++ b/regression/esbmc/github_604/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--closed-world-fnptr
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_604_fail/main.c
+++ b/regression/esbmc/github_604_fail/main.c
@@ -1,0 +1,13 @@
+typedef int func();
+
+/* No definition, and no address-taken function of this signature anywhere in
+ * the program: the call through f has no candidate target. */
+func *fun();
+
+int main()
+{
+  func *f = fun();
+  int x = f ? f() : 0;
+  __ESBMC_assert(!x, "x is 0 unless an unknown callee supplied a value");
+  return 0;
+}

--- a/regression/esbmc/github_604_fail/test.desc
+++ b/regression/esbmc/github_604_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -427,6 +427,10 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "Disable the removal of NO-OP instructions in GOTO programs"},
     {"partial-loops", NULL, "Permit paths with partial loops"},
+    {"closed-world-fnptr",
+     NULL,
+     "Treat a function-pointer call with no compatible target as unreachable "
+     "rather than assuming an external definition may supply one"},
     {"no-slice", NULL, "Do not remove unused equations"},
     {"multi-fail-fast",
      boost::program_options::value<int>()->value_name("n"),

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -182,8 +182,14 @@ protected:
    *  if-then-else list of concrete references that it might point at.
    *  @param expr Expression to eliminate dereferences from.
    *  @param mode The dereference mode.
+   *  @param block_assertions Suppress the pointer-safety claims this
+   *         dereference would otherwise record. Only for probing what a
+   *         pointer may designate before deciding whether the access happens.
    */
-  void dereference(expr2tc &expr, dereferencet::modet mode);
+  void dereference(
+    expr2tc &expr,
+    dereferencet::modet mode,
+    bool block_assertions = false);
 
   // symex
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -214,11 +214,16 @@ bool symex_dereference_statet::is_live_variable(const expr2tc &symbol)
   return false;
 }
 
-void goto_symext::dereference(expr2tc &expr, dereferencet::modet mode)
+void goto_symext::dereference(
+  expr2tc &expr,
+  dereferencet::modet mode,
+  bool block_assertions)
 {
   symex_dereference_statet symex_dereference_state(*this, *cur_state);
 
   dereferencet dereference(ns, new_context, options, symex_dereference_state);
+  if (block_assertions)
+    dereference.set_block_assertions();
 
   // needs to be renamed to level 1
   assert(!cur_state->call_stack.empty());

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -666,6 +666,18 @@ static bool function_is_type_compatible(
   return true;
 }
 
+// Whether a dereferenced function pointer designates anything callable: the
+// two failed-symbol spellings mean the value-set had nothing to offer.
+static bool has_call_target(const expr2tc &expr)
+{
+  if (!is_symbol2t(expr))
+    return true;
+
+  const std::string &name = to_symbol2t(expr).thename.as_string();
+  return !has_prefix(name, "symex::invalid_object") &&
+         name.find("$object") == std::string::npos;
+}
+
 static std::list<std::pair<guard2tc, expr2tc>>
 get_function_list(const expr2tc &expr)
 {
@@ -742,6 +754,29 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
 
   // Generate a list of functions to call. We'll then proceed to call them,
   // and will later on merge them.
+  // Closed world: the program we were given is all there is, so a call with no
+  // compatible target cannot happen and its path is dead. Decide that on a
+  // throwaway copy with the pointer-safety claims suppressed -- the real
+  // dereference below records an invalid-pointer claim before we would
+  // otherwise learn there is no target, condemning the path first
+  // (esbmc/esbmc#604). When a target does exist nothing is skipped: we fall
+  // through to the unmodified path and its claims.
+  if (options.get_bool_option("closed-world-fnptr"))
+  {
+    expr2tc probe = call.function;
+    dereference(probe, dereferencet::READ, true);
+    if (!has_call_target(probe))
+    {
+      log_status(
+        "No target candidate for function call {}; assuming unreachable "
+        "(--closed-world-fnptr)",
+        from_expr(ns, "", call.function));
+      assume(gen_false_expr());
+      cur_state->source.pc++;
+      return;
+    }
+  }
+
   expr2tc func_ptr = call.function;
   dereference(func_ptr, dereferencet::READ);
 
@@ -758,6 +793,12 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
     log_status(
       "No target candidate for function call {}",
       from_expr(ns, "", call.function));
+    // Open world by default: the definition may live in a translation unit we
+    // were not given, so the call is skipped and its result left havoc'd.
+    // Under --closed-world-fnptr the whole program is assumed present, so no
+    // such call can happen and the path is dead (esbmc/esbmc#604).
+    if (options.get_bool_option("closed-world-fnptr"))
+      assume(gen_false_expr());
     cur_state->source.pc++;
     return;
   }
@@ -862,7 +903,13 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
   cur_state->top().orig_func_ptr_call = expr;
 
   if (!run_next_function_ptr_target(true))
+  {
+    // Same rationale as the failed-symbol case above: an empty target list
+    // means no compatible definition was found in what we were given.
+    if (options.get_bool_option("closed-world-fnptr"))
+      assume(gen_false_expr());
     cur_state->source.pc++;
+  }
 }
 
 bool goto_symext::run_next_function_ptr_target(bool first)


### PR DESCRIPTION
ESBMC assumes an open world: a call through a function pointer with no compatible target may still be supplied by a translation unit we were not given, so the call is skipped and its result left havoc'd. CBMC assumes a closed world and makes that path infeasible. #604 asks for the latter — added as an opt-in flag, so no existing verdict changes.

Ordering is the subtle part: `dereference(func_ptr, READ)` records an invalid-pointer claim *before* the code can know there is no target, so simply assuming false afterwards leaves the path already condemned. Instead the flag probes a throwaway copy with the pointer claims suppressed, and only kills the path when that shows no target. When a target does exist we fall through to the unmodified path and all of its claims — verified by identical `--show-claims` counts with the flag on and off.

Fixes #604