### PR TITLE
[scripts] Order Finding so equal sanitizer counts can be sorted

### DIFF
--- a/scripts/sanitizers/collect_findings.py
+++ b/scripts/sanitizers/collect_findings.py
@@ -65,9 +65,14 @@ _FRAME_RE = re.compile(
     r"(?:\s+(?P<loc>\S+:\d+(?::\d+)?))?")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class Finding:
-    """Single sanitizer finding (already comparable; used as dedup key)."""
+    """Single sanitizer finding; used as a dedup key and sorted for display.
+
+    ``order`` is what makes the count tie-break in render_markdown work: frozen
+    alone gives __eq__/__hash__ but no ordering, so two findings with the same
+    count made sorted() fall through to comparing Finding objects and raise.
+    """
     tool: str
     kind: str
     location: str

--- a/scripts/sanitizers/test_collect_findings.py
+++ b/scripts/sanitizers/test_collect_findings.py
@@ -249,6 +249,16 @@ class Render(unittest.TestCase):
         once_pos = out.index("| 1 | ASan |")
         self.assertLess(many_pos, once_pos)
 
+    def test_equal_counts_tie_break(self):
+        # Equal counts make sorted() fall through to comparing Finding objects.
+        # Frozen dataclasses are hashable but not ordered, so without
+        # order=True this raised TypeError instead of rendering.
+        b = cf.Finding("UBSan", "shift", "src/b.cc:1")
+        a = cf.Finding("ASan", "heap-buffer-overflow", "src/a.cc:1")
+        out = cf.render_markdown([b, a])
+        self.assertLess(
+            out.index("| 1 | ASan |"), out.index("| 1 | UBSan |"))
+
 
 class WriteSummary(unittest.TestCase):
     """write_summary appends to $GITHUB_STEP_SUMMARY when set."""


### PR DESCRIPTION
`render_markdown` sorts by `(-count, finding)`, so two findings seen the same number of times fall through to comparing `Finding` objects. `frozen=True` gives `__eq__`/`__hash__` — enough to be a `Counter` key — but no ordering, so `collect_findings.py` died with `TypeError: '<' not supported between instances of 'Finding' and 'Finding'` instead of writing the summary.

`order=True` makes the tie-break deterministic on (tool, kind, location), matching the table's column order.

The existing `test_sort_descending_then_lex` only used differing counts, so it never reached the tie-break — hence the miss. Added a case with equal counts, which reproduces the crash on master.