### PR TITLE
[util] Hold a BSD lock on our temporary paths

### DIFF
--- a/src/util/base/filesystem.cpp
+++ b/src/util/base/filesystem.cpp
@@ -11,11 +11,47 @@
 #  include <io.h>
 #else
 #  include <csignal>
+#  include <sys/file.h>
 #  include <sys/types.h>
 #  include <unistd.h>
 #endif
 
 using namespace file_operations;
+
+/* systemd-tmpfiles ages /tmp by wall-clock time, so a verification run that
+ * outlives the configured age -- or merely spans a suspend or a clock jump --
+ * can have its temporaries unlinked from under it. It takes a shared BSD lock
+ * on each directory it descends into and skips anything already locked, along
+ * with everything below it, which applications are explicitly invited to use to
+ * exclude a subtree (systemd.io/TEMPORARY_DIRECTORIES). Hold such a lock for as
+ * long as we own the path. Best effort: filesystems that do not implement
+ * flock() simply leave us unlocked, exactly as before. */
+static int lock_tmp_path([[maybe_unused]] const std::string &path)
+{
+#ifdef _WIN32
+  return -1;
+#else
+  int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
+    return -1;
+
+  if (flock(fd, LOCK_SH | LOCK_NB))
+  {
+    close(fd);
+    return -1;
+  }
+  return fd;
+#endif
+}
+
+static void unlock_tmp_path(int &fd)
+{
+#ifndef _WIN32
+  if (fd >= 0)
+    close(fd); /* releases the lock */
+#endif
+  fd = -1;
+}
 
 static std::vector<std::string> registered_tmp_paths;
 static std::vector<long> registered_pgroups;
@@ -57,18 +93,28 @@ void file_operations::kill_registered_pgroups()
 }
 
 tmp_path::tmp_path(std::string path, bool keep)
-  : _path(std::move(path)), _keep(keep)
+  : _path(std::move(path)), _lock_fd(lock_tmp_path(_path)), _keep(keep)
 {
   assert(boost::filesystem::exists(_path));
 }
 
-tmp_path::tmp_path(tmp_path &&o) : tmp_path(std::move(o._path), o._keep)
+tmp_path::tmp_path(tmp_path &&o)
+  : _path(std::move(o._path)), _lock_fd(o._lock_fd), _keep(o._keep)
 {
+  /* Take over the lock rather than re-acquiring it: a second flock() on the
+   * same path from this process would silently succeed and leave the original
+   * descriptor leaked. */
+  o._lock_fd = -1;
   o._keep = true;
 }
 
 tmp_path::~tmp_path()
 {
+  /* Drop the lock whether or not we remove the path: keeping the descriptor
+   * open past our ownership would pin the inode and keep excluding it from
+   * ageing forever. */
+  unlock_tmp_path(_lock_fd);
+
   if (_keep)
     return;
   // Best-effort cleanup: the path may already be gone. create_tmp_dir() also

--- a/src/util/base/filesystem.h
+++ b/src/util/base/filesystem.h
@@ -23,6 +23,9 @@ namespace file_operations
 class tmp_path
 {
   std::string _path;
+  /** Descriptor holding a BSD lock on the path; -1 when unlocked. Held for as
+   *  long as this object owns the path, so systemd-tmpfiles skips it. */
+  int _lock_fd = -1;
 
 protected:
   bool _keep = true;
@@ -42,6 +45,7 @@ public:
     using std::swap;
     swap(a._path, b._path);
     swap(a._keep, b._keep);
+    swap(a._lock_fd, b._lock_fd);
   }
 
   const std::string &path() const noexcept;

--- a/unit/util/filesystem.test.cpp
+++ b/unit/util/filesystem.test.cpp
@@ -8,6 +8,11 @@ Author: Rafael Sá Menezes
 #include <catch2/catch.hpp>
 #include <util/base/filesystem.h>
 #include <boost/filesystem.hpp>
+#ifndef _WIN32
+#  include <fcntl.h>
+#  include <sys/file.h>
+#  include <unistd.h>
+#endif
 #include <fstream>
 #include <cstdlib>
 
@@ -159,5 +164,69 @@ TEST_CASE(
     setenv("TMPDIR", old_tmpdir.c_str(), 1);
   else
     unsetenv("TMPDIR");
+}
+#endif
+
+#ifndef _WIN32
+// Returns true iff an exclusive BSD lock can be taken on `path`, i.e. nobody
+// currently holds one. flock() conflicts across open file descriptions, so this
+// sees the lock tmp_path holds even though we are the same process.
+static bool can_lock_exclusively(const std::string &path)
+{
+  int fd = open(path.c_str(), O_RDONLY);
+  REQUIRE(fd >= 0);
+  bool free_to_lock = flock(fd, LOCK_EX | LOCK_NB) == 0;
+  if (free_to_lock)
+    flock(fd, LOCK_UN);
+  close(fd);
+  return free_to_lock;
+}
+
+TEST_CASE(
+  "a temporary directory is flocked against systemd-tmpfiles",
+  "[core][util][filesystem]")
+{
+  // systemd-tmpfiles ages /tmp by wall-clock time and would happily unlink a
+  // long run's temporaries; it skips any path holding a BSD lock. Without the
+  // lock this path would be lockable, so the check discriminates.
+  std::string path;
+  {
+    auto dir = file_operations::create_tmp_dir("esbmc-test-lock-%%%%");
+    path = dir.path();
+    REQUIRE(!can_lock_exclusively(path));
+  }
+  REQUIRE(!boost::filesystem::exists(path));
+}
+
+TEST_CASE(
+  "the temporary lock is released once the path is given up",
+  "[core][util][filesystem]")
+{
+  // Keeping the descriptor open past our ownership would pin the inode and
+  // exclude it from ageing for the rest of the process's life.
+  std::string path;
+  {
+    auto dir = file_operations::create_tmp_dir("esbmc-test-lock-%%%%");
+    path = dir.path();
+    dir.keep(true);
+  }
+  REQUIRE(boost::filesystem::exists(path));
+  REQUIRE(can_lock_exclusively(path));
+  boost::filesystem::remove_all(path);
+}
+
+TEST_CASE("moving a temporary path moves its lock", "[core][util][filesystem]")
+{
+  // The move must hand the descriptor over, not re-acquire: a second flock()
+  // from this process would succeed and leak the original descriptor.
+  std::string path;
+  {
+    auto dir = file_operations::create_tmp_dir("esbmc-test-lock-%%%%");
+    path = dir.path();
+    auto moved = std::move(dir);
+    REQUIRE(moved.path() == path);
+    REQUIRE(!can_lock_exclusively(path));
+  }
+  REQUIRE(!boost::filesystem::exists(path));
 }
 #endif


### PR DESCRIPTION
systemd-tmpfiles ages `/tmp` by wall-clock time, so a verification run that outlives the configured age — or merely spans a suspend or a clock jump — can have its temporaries unlinked from under it. It takes a shared BSD lock on each directory it descends into and skips anything already locked along with everything below it, which applications are [explicitly invited](https://systemd.io/TEMPORARY_DIRECTORIES/) to use to exclude a subtree.

`tmp_path` now holds such a lock for as long as it owns the path, and drops it on destruction so the inode is not pinned afterwards. The move constructor hands the descriptor over rather than re-acquiring, since a second `flock()` from the same process would succeed and leak the original.

Best effort: filesystems without `flock()` are left exactly as before, and it compiles out on Windows. Two of the three new unit tests fail on master without this change.

This completes the issue: #6643 fixed the `unique_path()` race @fbrausse asked to address first.

Fixes #1862