### PR TITLE
[regression] Probe frontend capabilities with the tool under test

### DIFF
--- a/regression/esbmc/bitvector_02/test.desc
+++ b/regression/esbmc/bitvector_02/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 
+REQUIRES bitint_wide
 ^VERIFICATION FAILED$

--- a/regression/esbmc/bitvector_03/test.desc
+++ b/regression/esbmc/bitvector_03/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 
+REQUIRES bitint_wide
 ^VERIFICATION FAILED$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -221,13 +221,50 @@ SEED_FILE_KEYWORD = "SEED_FILE"
 # is a hard error instead of a test that quietly stops running.
 REQUIRES_KEYWORD = "REQUIRES"
 
-KNOWN_CAPABILITIES = {
+STATIC_CAPABILITIES = {
     # <uchar.h> is present. Not in the C standard library on macOS.
     "uchar_h",
     # The 32-bit target (--32) is usable: multi-arch headers exist and the
     # frontend's type model matches them. See issue #1400.
     "arch32",
 }
+
+# Capabilities of the frontend itself, which the build system cannot answer:
+# CMake would have to probe with the *build* compiler, whose target need not
+# match the one ESBMC's Clang is configured for -- a probe that disagreed would
+# silently skip tests on hosts that actually support them. Ask the tool under
+# test instead, by parsing a snippet that exercises the feature.
+DYNAMIC_CAPABILITY_PROBES = {
+    # Clang caps _BitInt/_ExtInt width per target (128 bits on aarch64-darwin,
+    # far higher on x86_64-linux), so this cannot be answered statically.
+    "bitint_wide": "int main() { _BitInt(1000) x = 0; return (int)x; }\n",
+}
+
+KNOWN_CAPABILITIES = STATIC_CAPABILITIES | set(DYNAMIC_CAPABILITY_PROBES)
+
+
+def _probe_capability(name, executor_path):
+    """Ask the tool under test whether it supports `name`.
+
+    Parsing is enough -- every dynamic capability is a frontend question -- and
+    it keeps the probe far cheaper than a verification run. An unparseable
+    snippet, a crash, or a hang all mean "not supported", so the test is
+    skipped rather than failing for a reason that is not about the test.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        source = os.path.join(tmp_dir, "probe.c")
+        with open(source, "w") as fp:
+            fp.write(DYNAMIC_CAPABILITY_PROBES[name])
+        try:
+            completed = subprocess.run(
+                shlex.split(executor_path) + ["--parse-tree-only", source],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=120,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+    return b"PARSING ERROR" not in completed.stdout
 
 
 def _is_requires_line(stripped):
@@ -644,13 +681,19 @@ def gen_one_test(
     test_case = TestCase(os.path.join(base_dir, test), test)
     if test_case.test_mode not in modes:
         exit(10)
-    # No --capabilities at all means the caller did not probe: run the test and
-    # let it fail loudly rather than silently dropping coverage.
-    if capabilities is not None:
-        missing = [c for c in test_case.requires if c not in capabilities]
-        if missing:
-            print(f"SKIP: {test} requires {', '.join(missing)}")
-            exit(10)
+    missing = []
+    for capability in test_case.requires:
+        if capability in DYNAMIC_CAPABILITY_PROBES:
+            if not _probe_capability(capability, executor_path):
+                missing.append(capability)
+        # No --capabilities at all means the caller did not probe the static
+        # ones: run the test and let it fail loudly rather than silently
+        # dropping coverage.
+        elif capabilities is not None and capability not in capabilities:
+            missing.append(capability)
+    if missing:
+        print(f"SKIP: {test} requires {', '.join(missing)}")
+        exit(10)
     test_func = _add_test(test_case, executor)
     setattr(RegressionBase, "test_{0}".format(test_case.name), test_func)
 
@@ -726,11 +769,13 @@ def _arg_parsing():
         capabilities = {
             c for c in re.split(r"[,;\s]+", main_args.capabilities.strip()) if c
         }
-        unknown = capabilities - KNOWN_CAPABILITIES
+        # Only the static ones: the dynamic capabilities are the tool's own
+        # answer, so accepting them here would let the build override it.
+        unknown = capabilities - STATIC_CAPABILITIES
         assert not unknown, (
             f"--capabilities names unknown capability "
             f"{', '.join(sorted(unknown))}; known names are "
-            f"{', '.join(sorted(KNOWN_CAPABILITIES))}"
+            f"{', '.join(sorted(STATIC_CAPABILITIES))}"
         )
 
     gen_one_test(


### PR DESCRIPTION
`REQUIRES` so far only answered questions the build system could settle. Whether the frontend accepts a wide `_BitInt` cannot be settled there: CMake would have to probe with the *build* compiler, whose target need not match the one ESBMC's Clang is configured for — and a probe that disagreed would silently skip tests on hosts that do support them, which is worse than the failure it replaces.

Adds dynamic capabilities, answered by parsing a snippet with the tool under test itself, and uses one to gate `bitvector_02`/`bitvector_03`: they need `_BitInt(1000)`, which Clang caps at 128 bits on aarch64-darwin but allows on x86_64-linux. Those two are the last environment-driven false failures I could account for locally.

Verified both directions: with the real 1000-bit probe the tests skip here, and with the probe narrowed to a width this target does support they run again — so the gate keys on the probe result, not merely on the tag.

Refs #1400