### PR TITLE
[goto-programs] Skip race instrumentation that runs before any thread

### DIFF
--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -1,4 +1,5 @@
 #include <goto-programs/add_race_assertions.h>
+#include <functional>
 #include <goto-programs/remove_no_op.h>
 #include <goto-programs/rw_set.h>
 #include <pointer-analysis/value_sets.h>
@@ -365,6 +366,115 @@ static void collect_address_taken_functions(
 // that state. Such helpers stay fully instrumented -- they are over-, never
 // under-approximated -- so no race is hidden; the original false alarm simply
 // persists for that (rare) shape.
+/// Direct callees of @p body, plus every function whose address it takes (a
+/// function pointer may be called from anywhere, so counting it as a callee
+/// only ever over-approximates reachability).
+static void collect_callees(const goto_programt &body, std::set<irep_idt> &out)
+{
+  auto add_address_taken = [&out](const expr2tc &e) {
+    if (is_nil_expr(e))
+      return;
+    std::function<void(const expr2tc &)> rec = [&](const expr2tc &sub) {
+      if (is_nil_expr(sub))
+        return;
+      if (is_address_of2t(sub))
+      {
+        const expr2tc &ptr = to_address_of2t(sub).ptr_obj;
+        if (is_symbol2t(ptr))
+          out.insert(to_symbol2t(ptr).thename);
+      }
+      sub->foreach_operand(rec);
+    };
+    rec(e);
+  };
+
+  forall_goto_program_instructions (i_it, body)
+  {
+    if (i_it->is_function_call())
+    {
+      const code_function_call2t &call = to_code_function_call2t(i_it->code);
+      if (is_symbol2t(call.function))
+        out.insert(to_symbol2t(call.function).thename);
+    }
+    add_address_taken(i_it->code);
+    add_address_taken(i_it->guard);
+  }
+}
+
+static std::set<irep_idt>
+closure(const goto_functionst &goto_functions, const std::set<irep_idt> &seeds)
+{
+  std::set<irep_idt> seen;
+  std::vector<irep_idt> work(seeds.begin(), seeds.end());
+  while (!work.empty())
+  {
+    irep_idt f = work.back();
+    work.pop_back();
+    if (!seen.insert(f).second)
+      continue;
+    auto it = goto_functions.function_map.find(f);
+    if (it == goto_functions.function_map.end() || !it->second.body_available)
+      continue;
+    std::set<irep_idt> callees;
+    collect_callees(it->second.body, callees);
+    for (const irep_idt &c : callees)
+      if (!seen.count(c))
+        work.push_back(c);
+  }
+  return seen;
+}
+
+/// Functions that provably run before any thread exists.
+///
+/// __ESBMC_main performs the program's initialisation and then calls the entry
+/// point; only code reachable from the entry point ever creates a thread. So
+/// everything __ESBMC_main calls *before* its first spawn-reaching callee runs
+/// single-threaded, and those accesses cannot race with anything.
+///
+/// Worth suppressing rather than merely correct to suppress: each instrumented
+/// access costs a yield and two updates of the (infinite) race-flag array, and
+/// the Python frontend's generated `python_init` alone carries ~78 of them
+/// (github #6610). A function that also runs after the entry point is excluded,
+/// so this never hides an access that could race.
+static std::set<irep_idt>
+compute_pre_thread_functions(const goto_functionst &goto_functions)
+{
+  auto entry = goto_functions.function_map.find(goto_functions.main_id());
+  if (entry == goto_functions.function_map.end() ||
+      !entry->second.body_available)
+    return {};
+
+  // Callees of __ESBMC_main in program order, split at the first one from
+  // which a thread spawn is reachable -- that is the entry point.
+  std::vector<irep_idt> ordered;
+  forall_goto_program_instructions (i_it, entry->second.body)
+    if (i_it->is_function_call())
+    {
+      const code_function_call2t &call = to_code_function_call2t(i_it->code);
+      if (is_symbol2t(call.function))
+        ordered.push_back(to_symbol2t(call.function).thename);
+    }
+
+  std::set<irep_idt> before, after;
+  bool seen_spawner = false;
+  for (const irep_idt &callee : ordered)
+  {
+    const std::set<irep_idt> reach = closure(goto_functions, {callee});
+    if (!seen_spawner && reach.count("c:@F@__ESBMC_spawn_thread"))
+      seen_spawner = true;
+    (seen_spawner ? after : before).insert(callee);
+  }
+
+  if (!seen_spawner)
+    return {}; // single-threaded program: nothing to gain
+
+  std::set<irep_idt> pre = closure(goto_functions, before);
+  const std::set<irep_idt> post = closure(goto_functions, after);
+  for (const irep_idt &f : post)
+    pre.erase(f);
+  return pre;
+}
+
 static std::set<irep_idt>
 compute_always_atomic_functions(const goto_functionst &goto_functions)
 {
@@ -793,8 +903,10 @@ void add_race_assertions(contextt &context, goto_functionst &goto_functions)
   // global atomic lock, so its accesses can never race and must be instrumented
   // as atomic (issues #5133-#5135). This is an interprocedural property, so it
   // is computed once over the whole call graph before any body is instrumented.
-  const std::set<irep_idt> always_atomic =
+  std::set<irep_idt> always_atomic =
     compute_always_atomic_functions(goto_functions);
+  for (const irep_idt &f : compute_pre_thread_functions(goto_functions))
+    always_atomic.insert(f);
 
   Forall_goto_functions (f_it, goto_functions)
     if (f_it->first != goto_functions.main_id())

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -440,8 +440,8 @@ static std::set<irep_idt>
 compute_pre_thread_functions(const goto_functionst &goto_functions)
 {
   auto entry = goto_functions.function_map.find(goto_functions.main_id());
-  if (entry == goto_functions.function_map.end() ||
-      !entry->second.body_available)
+  if (
+    entry == goto_functions.function_map.end() || !entry->second.body_available)
     return {};
 
   // Callees of __ESBMC_main in program order, split at the first one from


### PR DESCRIPTION
`__ESBMC_main` initialises the program and then calls the entry point; only code reachable from the entry point creates a thread. Everything called before the first spawn-reaching callee therefore runs single-threaded and cannot race — yet each of its accesses still cost a yield and two updates of the infinite race-flag array.

That is ~78 sites in the Python frontend's generated `python_init`. Measured on #6610's reproducer at `--context-bound 4`: **19.2s → 3.8s**, verdict unchanged. C programs are unaffected (nothing runs before the entry point; guard count and timing identical).

A function that also runs after the entry point is excluded from the set, so no access that could race is hidden.

**This does not close #6610.** Its headline symptom — the unbounded run not terminating — persists: that is driven by the interleaving count (318 vs C's 28 at cb=4), which this does not address. Measurements are in https://github.com/esbmc/esbmc/issues/6610#issuecomment-5160491843.

Testing: 57/57 data-race tests, 186/186 `esbmc-unix2` pthread tests, 5/5 Python data-race tests.

One caveat: if an imported module spawned a thread at import time, `python_init` would reach `__ESBMC_spawn_thread` and be excluded — the sound path. I could not exercise it, because the frontend rejects Thread construction in an imported module ("start() reached without AST lowering").