### PR TITLE
[docs] Open the all-frontends IREP2 migration roadmap

### DIFF
--- a/docs/roadmap/frontends-to-irep2.md
+++ b/docs/roadmap/frontends-to-irep2.md
@@ -1,0 +1,294 @@
+# Roadmap — all frontends → IREP2-native construction
+
+> **Status: forward plan, opened 2026-08-03. This document reverses standing
+> decisions by owner direction.**
+> Part I's B1 ("frontends stay legacy"), Part III §14's Solidity close-out, and
+> Part V's V.1a/V.2/V.6 closures all concluded that migrating frontend
+> *construction* to IREP2 was not worth its cost. The project goal is now full
+> frontend migration, so those conclusions are reopened as **decisions, not
+> discoveries** — the arguments behind them were sound and are answered here
+> (§5), not ignored.
+>
+> Parent record: `irep2-migration.md`. Sibling scopes:
+> `scope-coupled-arith-assign-conversion.md`, `scope-v2-w3-attribute-carriage.md`,
+> `scope-v1k-adjuster.md`.
+
+## 1. The goal, as a measurable bar
+
+Per frontend `F` in {clang-c, clang-cpp, python, solidity, jimple}:
+
+| # | Bar | Command |
+|---|---|---|
+| B-1 | Legacy type mentions → ~0, modulo enumerated boundary glue | `git grep -P '\b([A-Za-z_]*(exprt\|typet\|codet)\|irept)\b' -- src/F-frontend` |
+| B-2 | Symbol-table writes carry IREP2 values only | `grep -rn 'set_type(\|set_value(' src/F-frontend \| grep -vc 2tc` → 0 |
+| B-3 | Bodies reach `goto_convert` with no `migrate_*` back-hop | native dispatcher coverage = 100 %, round-trip deleted |
+| B-4 | No `#`-attribute escape hatch into a shared pass | W3 removed, not merely seamed |
+
+B-1/B-2 are frontend-local. **B-3 and B-4 are shared** — they are one repo-wide
+job each, not five. That asymmetry is the whole shape of this program: do the
+two shared jobs once, then the five frontends become largely mechanical.
+
+## 2. Baseline census (measured 2026-08-03, `f14cd73ff8`)
+
+| frontend | legacy mentions | IREP2 (`*2tc`) | LOC | construction state |
+|---|---:|---:|---:|---|
+| python | 5 547 | 806 | 79 282 | partially native (Part V) |
+| clang-c | 971 | 49 | 13 783 | legacy + isolated IREP2 |
+| clang-cpp | 626 | **0** | 7 394 | fully legacy |
+| solidity | 1 420 | **0** | 23 589 | fully legacy |
+| jimple | 176 | **0** | 3 259 | fully legacy |
+
+The three zeros are real: those frontends construct no IREP2 node at all and
+rely entirely on `migrate_expr`/`migrate_type` at the symbol-table seam. Note
+jimple's 176 is small because the frontend is small, not because it is nearly
+done — normalise by LOC before reading these as effort.
+
+## 3. The W1 wall is stale — this is the finding that makes the program tractable
+
+`irep2-migration.md` §V.1's wall table states:
+
+> **W1 (P1)** — IREP2 has the flat goto-level code kinds … but **no structured
+> CF kinds** (`ifthenelse`/`while`/`for`/`switch`/`break`/`continue`/`label`).
+
+**That is no longer true and has not been since #5265** ("V.4.0: add structured
+control-flow code kinds"). `src/irep2/expr_kinds.inc:129-139` defines
+`code_ifthenelse2t`, `code_while2t`, `code_dowhile2t`, `code_for2t`,
+`code_switch2t`, `code_break2t`, `code_continue2t`, `code_label2t`,
+`code_switch_case2t`, `code_assert2t`, `code_assume2t`. They have forward and
+back `migrate` arms (`src/util/irep/migrate.cpp`), and `goto_convert` consumes
+them natively via `convert_native_rec`
+(`goto-programs/goto_convert_functions.cpp:254`), with a **per-function**
+fallback to the legacy round-trip for unsupported shapes — currently ≈78.7 % of
+functions native on the `esbmc-cpp` census.
+
+The consequence is large. Every prior "frontends stay legacy" argument rested
+partly on W1: a frontend *could not* build a body natively because the
+representation for `if`/`while`/`switch` did not exist. It exists. What remains
+of W1 is not a representation gap but **dispatcher coverage** — a finite,
+enumerable list of shapes `convert_native_rec` returns `false` on. That is
+ordinary work with a measurable completion criterion, not an architectural wall.
+
+**Action:** §V.1's W1 row must be corrected in the parent document (§9 below).
+Any planning that still treats W1 as "IREP2 cannot represent structured CF" is
+working from a stale premise.
+
+## 4. The four walls, re-grounded at `f14cd73ff8`
+
+| Wall | Original statement | State now | Remaining work |
+|---|---|---|---|
+| W1 | no structured CF kinds in IREP2 | **dissolved as stated** (§3) | drive `convert_native_rec` to 100 %, then delete the round-trip |
+| W2 | `member2t`/`index2t` assert a resolved source | **dissolved as a construction blocker**, with a standing obligation | the relaxation is repo-wide, but it is conditional — see below |
+| W3 | `#cpp_type`/`#member_name`/`#cformat` read off legacy nodes by shared passes | **seamed, not removed** (Option D, #6569/#6570) | carriage — §5, the one genuine design problem left |
+| W4 | counterexample printer consumes the attributes | untouched, deferred | falls out of W3 if W3 is solved by a typed field |
+
+Two of four walls are gone, one is reduced to a coverage exercise, and one is a
+real design problem. That is a materially better starting position than the
+Part V close-out implies.
+
+**W2's obligation, stated because it is a per-frontend cost.** The relaxation
+(`irep2_expr.h:1549-1570`) permits a `symbol_id` source **only as a transient
+pre-resolution state**, and the comment is explicit that "the adjuster MUST
+follow it to a struct before symex" — the strong invariant is re-enforced
+post-adjust, not dropped. So the *representation* is repo-wide, but the
+*obligation* is not: every frontend that builds `member2t`/`index2t` before type
+resolution needs a resolve pass of its own, or must reuse one. Python's is
+`python_adjust`. Budget one per frontend in Phases 5-9, and note that the assert
+is `#ifndef NDEBUG` — an unresolved source will pass a `RelWithDebInfo` build
+silently and fail in symex, which is gate G4's reason for existing.
+
+## 5. The one real wall — value-carried metadata (W3 and Solidity's Q-S1)
+
+### 5.1 Why the recorded closures are right about the mechanism
+
+Part III §14 (Q-S1) and `scope-v2-w3-attribute-carriage.md` §3 independently
+established the same fact, and it is not in dispute: **these attributes are read
+off transient type values with no symbol in scope.** `cpp_expr2string.cpp:138`
+reads the type currently being printed, reached recursively through
+`convert(src.subtype())`. `solidity_convert_decl.cpp` reads `get_sol_type(t)`
+off a local `typet t` before any symbol exists. A side table keyed by symbol id
+— §V.2's prescribed design — cannot serve either. That finding stands.
+
+The options considered, and their recorded verdicts:
+
+| Option | Carries with the value? | Recorded verdict |
+|---|---|---|
+| A — symbol-keyed side table | no | not viable (Q-S1) |
+| B — value-bundled wrapper over `type2tc` | yes | viable, rejected on cost; recreates attribute flexibility |
+| C — extend `type2t` with a spelling field | yes | rejected: "pushes presentation concerns into the verifier IR" |
+| D — encapsulate writers, leave carriage legacy | n/a | **taken**; does not move B-4 |
+
+### 5.2 Option F — a closed typed field, which is not Option C
+
+Both rejections of B and C rest on the same objection: *do not reinstate the
+open, string-keyed attribute flexibility IREP2 abolished.* That objection is
+correct against a generic map. It does **not** apply to a closed enum, and two
+measurements say a closed enum suffices:
+
+- **Solidity's classification is already a closed `enum class`** —
+  `SolType` at `solidity-frontend/solidity_grammar.h:484`. It is stringified
+  only to cross the `irept` boundary. Restoring it to a typed field removes a
+  serialization step rather than adding an escape hatch.
+- **`#cpp_type`'s value domain is the C type-keyword set** — the writers emit
+  `"bool"`, `"signed_char"`, `"unsigned_char"`, `"void"` and a `c_type` variable
+  drawn from the same finite vocabulary. It is an enum wearing a string.
+
+So the third option the record never separated out:
+
+> **Option F.** Add a **closed, typed, optional** classification field to the
+> specific `type2t` kinds that need it — not a generic attribute map, not a
+> wrapper struct. `enum class c_spelling` on the integer/float kinds;
+> `enum class sol_class` on the kinds Solidity tags. Absent by default, ignored
+> by every solver backend, exhaustively switchable.
+
+**Why this is legitimate where C was not.** C was framed as pushing
+*presentation* concerns into the verifier IR, and for `cpp_expr2string` and
+`goto2c/expr2c` that framing is right. But it is incomplete:
+`clang_cpp_adjust_expr.cpp:582` uses `#cpp_type` to **build exception type ids
+for catch matching**. That is semantics, not presentation — a C++ program's
+observable behaviour depends on it. Metadata that catch-matching depends on
+belongs in the typed IR by the migration's own governing rule that verification
+correctness outranks implementation convenience. The presentation readers then
+ride along for free.
+
+**The honest price**, which must not be glossed: IREP2's type system stops being
+purely structural. Two types identical in width and signedness may now differ in
+a spelling field. Every equality, hashing and canonicalisation path over
+`type2t` must decide whether the field participates — and the answer is almost
+certainly **no** (it must not, or `long` and `long long` stop unifying in the
+solver and verdicts change). That asymmetry is a sharp edge and needs an
+explicit invariant plus a test that pins it.
+
+**Option F is a spike before it is a plan** (Phase 0 below). If the equality
+asymmetry proves unmanageable, fall back to Option B for Solidity only and
+accept that B-4 closes for C/C++ but not Solidity.
+
+## 6. Phased program
+
+Ordered by dependency. Phases 1 and 2 are shared and unlock everything else;
+5-9 are per-frontend and parallelisable once 1 and 2 land.
+
+### Phase 0 — Option F spike (gate for the whole B-4 half)
+Prototype `enum class c_spelling` on `signedbv_type2t`/`unsignedbv_type2t`.
+Answer three questions and stop: does the field participate in `type2t`
+equality/hash (expected: no)? Does exception catch-matching still work off the
+typed field? Does the whole `esbmc-cpp` suite hold verdict **and
+counterexample-text** parity? Deliverable: a go/no-go with measurements.
+*Accept:* a recorded answer either way. A no-go re-routes §5.2 to Option B, it
+does not stall the program — Phases 1, 3-9 are independent of B-4.
+
+### Phase 1 — drive `convert_native_rec` to 100 % (closes W1, shared)
+Instrument the dispatcher to log every `(kind, shape)` it declines, run the full
+corpus, and work the resulting histogram down. This is the highest-value phase:
+it is mechanical, measurable, benefits all five frontends at once, and its
+completion criterion is a number reaching zero.
+*Accept:* 0 fallbacks corpus-wide; then delete the round-trip and the fallback
+path in the same PR that proves it unreachable.
+
+### Phase 2 — W3 carriage removal (closes B-4, shared)
+Only if Phase 0 says go. Land `c_spelling`/`sol_class` as typed fields, repoint
+the four readers, delete the `irept` accessors. Option D already gave one
+repoint-point per attribute, so this is now a small diff at a single seam — the
+work Option D was explicitly designed to make cheap.
+
+### Phase 3 — finish the Python flip
+Phases 2-3 of `scope-coupled-arith-assign-conversion.md`, plus the two ownerless
+mechanisms that block it (§9.4's second mechanism; the array-typecast class of
+§14). Each needs its own scope doc. Python is the pathfinder: it is the only
+frontend with construction experience, so its remaining defects are the ones the
+other four will hit.
+
+### Phase 4 — extract the reusable construction kit
+Before touching a second frontend, factor what Python learned into shared
+helpers: the width-reconciliation idiom (`c_implicit_typecast_arithmetic` on
+`expr2tc`), the resolved-source `ns.follow` pattern, the operand-surgery recipe.
+Without this, four frontends re-derive the same lessons at four times the cost.
+
+### Phases 5-9 — per-frontend migration, in this order
+**5. jimple** (176 mentions, 3 259 LOC) — smallest surface, no operational-model
+complication, lowest blast radius. The pathfinder for the kit.
+**6. clang-c** (971, already 49 IREP2) — has a partial head start.
+**7. clang-cpp** (626) — small but highest semantic density; owns catch-matching
+and `clang_cpp_adjust`, which every other frontend's output passes through.
+**8. solidity** (1 420) — gated on Phase 2's `sol_class` outcome. If Phase 0 said
+no-go, this is where the program's scope is formally cut.
+**9. python** (5 547) — largest, and deliberately last so it inherits every
+lesson, exactly as §V.1 reframed it.
+
+Each of 5-9 opens its own `scope-<frontend>-irep2.md` at start, following the
+established scope-doc pattern: census, phased decomposition, gates, risks.
+
+## 7. Gates (every phase)
+
+| # | Gate |
+|---|---|
+| G1 | Verdict parity on the affected suites, dual-solver (Bitwuzla + Z3) |
+| G2 | Counterexample **text** parity — asserted verbatim by `test.desc` regexes; W3/W4 readers make this load-bearing |
+| G3 | `--goto-functions-only` A/B, normalised per the recorded harness rules (§8) |
+| G4 | Asserts-on (`DebugOpt`) build — `assert_*_consistency` is `#ifndef NDEBUG` and a `RelWithDebInfo` build compiles it out; ill-formed IR passed every local gate once already |
+| G5 | `esbmc-solidity` rides **Linux CI** — macOS has no `solc` and stubbed `sol64` models |
+
+**Inherited harness rules — non-optional.** Every census on this track has been
+invalidated at least once by harness artifacts. Reuse them verbatim:
+
+1. Normalise the whole temp-path segment (`s@/esbmc[-._][^/ ]*@/TMPD@g`), not
+   individual prefixes — four spellings exist; partial normalisation reports
+   ~90 % false divergence.
+2. Strip timing lines (`completed in:|time:|Runtime|Elapsed`) — 46 false
+   divergences out of 106 from `0.000s` vs `0.001s` alone.
+3. Exclude or serialize `--k-induction-parallel` tests — UNSTABLE against
+   themselves.
+4. Skip tests whose `test.desc` already passes the flag under test — boost
+   throws `multiple_occurrences`.
+5. Minimum-size guard (`< 200 bytes → SKIP`) — two collapsed error lines
+   otherwise count as a match.
+6. Sample dense and unbiased; stride-20 missed a 0.5 % defect rate entirely.
+7. **When a divergence survives, run the baseline against itself before
+   attributing it to the patch.** That control is what settled `cpp_sum_class`.
+8. **Probe the invariant you depend on, not a proxy for it**, and prove the probe
+   fires on known-bad input before trusting a zero. A probe measuring a narrower
+   condition than its invariant reported "0 firings" for a violation that CI then
+   caught.
+
+## 8. Risks
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | Option F's spelling field leaks into `type2t` equality and silently changes verdicts | Phase 0 answers this first; explicit invariant + a pinning test |
+| R2 | Five frontends re-derive Python's lessons independently | Phase 4 exists solely to prevent this; do not start Phase 5 before it |
+| R3 | Partial migration is tracked as progress | B-1..B-4 are all-or-nothing per frontend, as V.5's deferral argument established: migrating 10 of ~159 kinds removes **zero** back-hops |
+| R4 | Solidity's metadata proves genuinely open, not enum-shaped | Cut scope to four frontends; record it, do not let it stall the rest |
+| R5 | The program stalls mid-way, leaving frontends in a worse hybrid state than pure legacy | Each phase is independently valuable and independently revertible; Phase 1 alone is a net win even if nothing else lands |
+
+## 9. What this reverses, and required parent-document edits
+
+Three recorded conclusions are superseded **by decision**:
+
+- **B1** (Part I, "frontends stay legacy") — reopened.
+- **Part III §14** ("the Solidity frontend stays legacy by design") — reopened,
+  conditional on Phase 0.
+- **Part V's V.1a/V.2/V.6 closures** — reopened; V.2's blocker is now Option F,
+  not the refuted Option A.
+
+And one is superseded **by fact**, independent of the goal change:
+
+- **§V.1's W1 row is stale** (§3). It should be corrected regardless of whether
+  this program is prosecuted, because it misstates the tree.
+
+## 10. Honest sizing
+
+No total estimate is given, deliberately — the Part V record shows what happens
+when a multi-phase program is sized before its keystone spike returns. What can
+be sized:
+
+| item | estimate | confidence |
+|---|---|---|
+| Phase 0 spike | days | high — bounded, one question |
+| Phase 1 (dispatcher to 100 %) | weeks | medium — histogram is measurable but its tail is unknown until instrumented |
+| Phase 2 (W3 removal, post-Option D) | days | high — one seam, four readers |
+| Phases 5-9 | unknown until Phase 4 | low — Phase 5 (jimple) is the calibration run |
+
+**The recommended first action is Phase 1, not Phase 0.** It is independent of
+the Option F question, benefits all five frontends whether or not the rest of
+the program proceeds, and its output — the declined-shape histogram — is the
+single most informative artefact available about how far frontend construction
+actually is from native.

--- a/docs/roadmap/irep2-migration.md
+++ b/docs/roadmap/irep2-migration.md
@@ -13,6 +13,16 @@ consolidated into this retrospective once everything landed. The
 commit log (`git log --all --grep "B2\\|IREP2\\|esbmc/esbmc#4715"`)
 preserves every per-stage plan and decision rationale.
 
+> **Reopened 2026-08-03 — see `docs/roadmap/frontends-to-irep2.md`.** The
+> project goal is now full IREP2 migration of *all five frontends*. That
+> supersedes B1 ("frontends stay legacy", Part I §"What is not changing"),
+> Part III §14's Solidity close-out, and Part V's V.1a/V.2/V.6 closures — by
+> **decision**, not because their arguments were wrong. This document remains
+> the record of what was done and why each boundary was originally drawn; the
+> forward plan for crossing them lives in the new roadmap. One correction there
+> is independent of the goal change: **§V.1's W1 row was stale** and is fixed
+> in place below.
+
 ## Headline
 
 `symbolt::type` and `symbolt::value` are now stored as `type2tc` /
@@ -1492,6 +1502,15 @@ attribute flexibility IREP2 removed, for no verifier-core benefit. The
 frontend → `type2tc` migration therefore remains, as in B1, **out of
 scope**; the durable boundary stays the `migrate_*` seam at goto-convert,
 and the Solidity frontend stays legacy by design.
+
+> **Reopened 2026-08-03.** Q-S1's mechanism finding stands — the reads are
+> value-carried, so a side table cannot serve them. What this section did not
+> separate out is a **third** option between the wrapper and a generic
+> attribute map: `SolType` is already a closed `enum class`
+> (`solidity_grammar.h:484`), so a *closed typed field* on the relevant
+> `type2t` kinds carries the classification with the value without reinstating
+> string-keyed flexibility. See `docs/roadmap/frontends-to-irep2.md` §5.2
+> (Option F), which is gated on a spike, not assumed.
 
 ---
 
@@ -3105,7 +3124,7 @@ here) sit **outside** `src/python-frontend`:
 
 | Wall | Statement | Anchor (re-verify) | Owner |
 |---|---|---|---|
-| **W1 (P1)** | IREP2 has the **flat goto-level** code kinds (`code_block`/`assign`/`decl`/`return`/`goto`/`skip`/`dead`/`free`/`expression`) but **no structured CF kinds** (`ifthenelse`/`while`/`for`/`switch`/`break`/`continue`/`label`); `goto_convert` reads the body as **legacy** `codet`. | `grep 'IREP2_EXPR(code' src/irep2/expr_kinds.inc`; `goto_convert_functions.cpp:116` | shared (all frontends) |
+| **W1 (P1)** | ~~IREP2 has the flat goto-level code kinds but **no structured CF kinds** (`ifthenelse`/`while`/`for`/`switch`/`break`/`continue`/`label`); `goto_convert` reads the body as legacy `codet`.~~ **STALE as stated — corrected 2026-08-03.** The structured kinds were added by #5265 and live at `expr_kinds.inc:129-139` with forward/back `migrate` arms; `goto_convert` consumes them natively via `convert_native_rec` (`goto_convert_functions.cpp:254`) with a per-function fallback, ≈78.7 % native. What remains of W1 is **dispatcher coverage**, not a representation gap. | `grep 'IREP2_EXPR(code' src/irep2/expr_kinds.inc`; `goto_convert_functions.cpp:254` | shared (all frontends) |
 | **W2 (P2 / F-P10 / F-P11)** | `member2t`/`index2t` assert a **resolved** struct/array source (`irep2_expr.h:1502`/`:1576`); the converter runs **before** `clang_cpp_adjust` follows `symbol`-typed bases; `migrate_expr` recurses into the assert (§16.1). | §16, §16.1 | shared (`clang_cpp_adjust`) |
 | **W3 (F-P5)** | `#cpp_type`/`#member_name`/`#cformat` are read off **legacy** nodes by `clang_cpp_adjust_expr.cpp:464`, `cpp_expr2string.cpp:138-140`, `goto2c/expr2c.cpp:169-174`. | §15.2 | shared |
 | **W4** | The counterexample C/C++ printer consumes `#cpp_type`/`#cformat` (Part II 2.7, "out of scope"). | Part II §2.7 | shared |
@@ -5304,3 +5323,11 @@ Two items, both sized and neither speculative:
 V.5 is closed rather than pending — see its scope doc. With those recorded, the
 V-track has no undocumented residue: every remaining item has a named owner
 document, a sized cost, and a stated reason it was not taken.
+
+> **Superseded 2026-08-03 as the program's stopping point.** The V-track closed
+> Part V; it did not close the migration, and the project goal is now full
+> frontend migration. `docs/roadmap/frontends-to-irep2.md` takes V.1a, V.2 and
+> V.6 forward as part of a five-frontend program, re-grounds the four walls
+> against the tree (two are dissolved, one is a coverage exercise, one is a
+> real design problem), and re-routes V.2 to Option F. Python's remaining
+> items above are unchanged and become that program's Phase 3.


### PR DESCRIPTION
The project goal is now full IREP2 migration of all five frontends, which
reverses B1, Part III §14 and Part V's V.1a/V.2/V.6 closures by decision.

Adds `docs/roadmap/frontends-to-irep2.md` and re-grounds the four walls
against the tree: W1 is stale (structured CF kinds landed in #5265, and
`goto_convert` consumes them natively), W2 is dissolved with a per-frontend
resolve obligation, W3 is the one real design problem left, and Solidity's
closed `SolType` enum admits a typed-field option Q-S1 never separated out.
Docs only.