### PR TITLE
[goto-programs] Delegate side-effect returns instead of failing the walk

### DIFF
--- a/regression/esbmc-cpp/cpp/native_return_sideeffect/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_return_sideeffect/main.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+
+int dtor_runs = 0;
+
+struct Guard
+{
+  ~Guard()
+  {
+    ++dtor_runs;
+  }
+};
+
+int side_effect(int x)
+{
+  return x + 1;
+}
+
+// A side-effect return (a call) inside a scope holding a destructor: the
+// dispatcher delegates this statement to convert_return while converting the
+// rest of the function natively. The destructor must still run exactly once.
+int f(int x)
+{
+  Guard g;
+  return side_effect(x);
+}
+
+int main()
+{
+  int r = f(41);
+  assert(r == 42);
+  assert(dtor_runs == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/native_return_sideeffect/test.desc
+++ b/regression/esbmc-cpp/cpp/native_return_sideeffect/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/native_return_sideeffect_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_return_sideeffect_fail/main.cpp
@@ -1,0 +1,32 @@
+#include <cassert>
+
+int dtor_runs = 0;
+
+struct Guard
+{
+  ~Guard()
+  {
+    ++dtor_runs;
+  }
+};
+
+int side_effect(int x)
+{
+  return x + 1;
+}
+
+int f(int x)
+{
+  Guard g;
+  return side_effect(x);
+}
+
+int main()
+{
+  int r = f(41);
+  // The destructor runs exactly once, so this must fail rather than be
+  // vacuously true: it pins that the delegated return does not skip or
+  // duplicate the scope-exit unwind.
+  assert(dtor_runs == 2);
+  return r - 42;
+}

--- a/regression/esbmc-cpp/cpp/native_return_sideeffect_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/native_return_sideeffect_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$
+dtor_runs == 2

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -571,20 +571,20 @@ bool goto_convert_functionst::convert_native_rec(
     // A void function returning a value is a C/C++ constraint violation the
     // frontend rejects, so it never reaches here; only a valueless void return
     // does, which correctly emits just the end-of-function goto below.
-    // When the destructor stack holds a destructor FUNCTION_CALL, convert_return
-    // runs an unwind-before-RETURN (C++ [stmt.return]: capture the value into a
-    // temp, run the destructors, then return the temp; a constant value takes a
-    // simpler sub-path). Reproducing that natively would allocate a
-    // $tmp::tmp$ temp from the shared tmp_symbol counter -- the byte-identity
-    // hazard this dispatcher avoids -- so delegate the whole return statement to
-    // the legacy convert()/convert_return rather than fall back the entire
-    // function. convert_return leaves the destructor stack unchanged (its unwind
-    // is non-destructive and any return-temp entries are resized away) and emits
-    // a trailing unconditional goto, so the enclosing block handler's
-    // unreachable guard skips the scope-exit unwind and no destructor runs
-    // twice. Any temp it allocates is covered by convert_function's
-    // snapshot/restore on a later fallback; restore the value-operand locations
-    // first as the legacy body round-trip does.
+    // When the destructor stack holds a destructor FUNCTION_CALL,
+    // convert_return runs an unwind-before-RETURN (C++ [stmt.return]: capture
+    // the value into a temp, run the destructors, then return the temp; a
+    // constant value takes a simpler sub-path). Reproducing that natively would
+    // allocate a $tmp::tmp$ temp from the shared tmp_symbol counter -- the
+    // byte-identity hazard this dispatcher avoids -- so delegate the whole
+    // return statement to the legacy convert()/convert_return rather than fall
+    // back the entire function. convert_return leaves the destructor stack
+    // unchanged (its unwind is non-destructive and any return-temp entries are
+    // resized away) and emits a trailing unconditional goto, so the enclosing
+    // block handler's unreachable guard skips the scope-exit unwind and no
+    // destructor runs twice. Any temp it allocates is covered by
+    // convert_function's snapshot/restore on a later fallback; restore the
+    // value-operand locations first as the legacy body round-trip does.
     // Delegate every shape convert_return transforms statement-locally instead
     // of failing the walk: convert_return owns the lowering, and delegating one
     // statement leaves the rest of the function native.

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -562,7 +562,7 @@ bool goto_convert_functionst::convert_native_rec(
     // convert_return (goto_convert.cpp) emits, for the plain case, a RETURN
     // instruction (only when the function returns a value) followed by an
     // unconditional GOTO to the end-of-function target. Reproduce that exactly,
-    // and fall back on every shape convert_return transforms, deciding with the
+    // and delegate every shape convert_return transforms, deciding with the
     // same predicates on a throwaway legacy view of the return value:
     //  - a side-effect value (remove_sideeffects lowers it into extra instrs),
     //  - a cpp-throw return value (converted as a statement, no RETURN),
@@ -585,27 +585,32 @@ bool goto_convert_functionst::convert_native_rec(
     // twice. Any temp it allocates is covered by convert_function's
     // snapshot/restore on a later fallback; restore the value-operand locations
     // first as the legacy body round-trip does.
+    // Delegate every shape convert_return transforms statement-locally instead
+    // of failing the walk: convert_return owns the lowering, and delegating one
+    // statement leaves the rest of the function native.
+    auto delegate_to_legacy = [&]() {
+      exprt op = migrate_expr_back(code2);
+      restore_value_locations(op, effective_location(ret.location, inherited));
+      convert(to_code(op), dest);
+      return true;
+    };
+
     for (const codet &d : targets.destructor_stack)
       if (d.get_statement() == "function_call")
-      {
-        exprt op = migrate_expr_back(code2);
-        restore_value_locations(
-          op, effective_location(ret.location, inherited));
-        convert(to_code(op), dest);
-        return true;
-      }
+        return delegate_to_legacy();
 
     exprt val = is_nil_expr(ret.operand) ? static_cast<exprt>(nil_exprt())
                                          : migrate_expr_back(ret.operand);
     if (
       val.is_not_nil() &&
       (has_sideeffect(val) || val.is_code() || val.id() == "if"))
-      return false;
+      return delegate_to_legacy();
 
     if (targets.has_return_value)
     {
+      // convert_return replaces a missing value with nondet
       if (val.is_nil())
-        return false; // convert_return replaces a missing value with nondet
+        return delegate_to_legacy();
       // The RETURN instruction convert_return emits is migrate_expr(code_returnt)
       // located at the statement; migrate_expr drops the value-operand location
       // restore_value_locations stamped, so it round-trips to code2 itself. Emit


### PR DESCRIPTION
Phase 1 of `docs/roadmap/frontends-to-irep2.md` — drive `convert_native_rec`
toward full coverage.

`convert_native_rec` failed the whole-function walk on any return whose value
has a side-effect (`return f(x);`, the commonest shape in C++). `convert_return`
already had a statement-local delegation route for the destructor-unwind case;
this reuses it for the remaining three shapes, so only the return converts
legacy-side and the rest of the function stays native.

Declines over a stride-4 `esbmc-cpp` census fall 28243 → 8528, `code_return` to
zero. Gates: byte-identical `--goto-functions-only` A/B (native vs
`--no-irep2-native-body`) over 118 tests, 0 divergences; `esbmc-cpp` 712/721 and
core C 1615/1618 with every failure reproduced on a control build or the legacy
path.