### PR TITLE
[goto-programs] Delegate static, code-typed and array declarations

### DIFF
--- a/regression/esbmc-cpp/cpp/native_decl_array_static/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_decl_array_static/main.cpp
@@ -1,0 +1,42 @@
+#include <cassert>
+
+int dtor_runs = 0;
+
+struct Guard
+{
+  ~Guard()
+  {
+    ++dtor_runs;
+  }
+};
+
+static int counter = 7;
+
+// The three declaration shapes this handler delegates to convert_decl rather
+// than reproducing natively: a static-lifetime symbol, an array (conservatively
+// excluded because it may be a VLA), and a destructible type. Each must still
+// declare, initialise and destroy exactly as the legacy body path does, while
+// the statements around them convert natively.
+int sum_array(int n)
+{
+  Guard g;
+  int values[4] = {1, 2, 3, 4};
+  int total = 0;
+  for (int i = 0; i < 4; ++i)
+    total += values[i];
+  return total + n;
+}
+
+int main()
+{
+  assert(counter == 7);
+  counter = 9;
+  assert(counter == 9);
+
+  assert(sum_array(0) == 10);
+  assert(dtor_runs == 1);
+
+  assert(sum_array(5) == 15);
+  assert(dtor_runs == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/native_decl_array_static/test.desc
+++ b/regression/esbmc-cpp/cpp/native_decl_array_static/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/native_decl_array_static_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_decl_array_static_fail/main.cpp
@@ -1,0 +1,45 @@
+#include <cassert>
+
+int dtor_runs = 0;
+
+struct Guard
+{
+  ~Guard()
+  {
+    ++dtor_runs;
+  }
+};
+
+static int counter = 7;
+
+// _fail variant: dtor_runs is 2, so this must fail rather than pass
+// vacuously -- it pins that delegated declarations do not duplicate or skip
+// the scope-exit destructor.
+// The three declaration shapes this handler delegates to convert_decl rather
+// than reproducing natively: a static-lifetime symbol, an array (conservatively
+// excluded because it may be a VLA), and a destructible type. Each must still
+// declare, initialise and destroy exactly as the legacy body path does, while
+// the statements around them convert natively.
+int sum_array(int n)
+{
+  Guard g;
+  int values[4] = {1, 2, 3, 4};
+  int total = 0;
+  for (int i = 0; i < 4; ++i)
+    total += values[i];
+  return total + n;
+}
+
+int main()
+{
+  assert(counter == 7);
+  counter = 9;
+  assert(counter == 9);
+
+  assert(sum_array(0) == 10);
+  assert(dtor_runs == 1);
+
+  assert(sum_array(5) == 15);
+  assert(dtor_runs == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/native_decl_array_static_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/native_decl_array_static_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$
+dtor_runs == 3

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -489,8 +489,8 @@ bool goto_convert_functionst::convert_native_rec(
     //    generator — exclude all arrays conservatively.
     // A destructible type or an initializer needing lowering is delegated the
     // same way just below; everything else is convert_decl's plain path
-    // (a DECL, an optional side-effect-free ASSIGN, and one scope-exit code_dead)
-    // reproduced natively after that.
+    // (a DECL, an optional side-effect-free ASSIGN, and one scope-exit
+    // code_dead) reproduced natively after that.
     if (
       s->static_lifetime || s->get_type().is_code() || s->get_type().is_array())
       return delegate_to_legacy();

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -475,18 +475,25 @@ bool goto_convert_functionst::convert_native_rec(
     if (s == nullptr)
       return false;
 
-    // Fall back on the two convert_decl shapes this handler neither reproduces
-    // natively nor delegates, so flag-on stays byte-identical:
+    auto delegate_to_legacy = [&]() {
+      exprt op = migrate_expr_back(code2);
+      restore_value_locations(op, effective_location(decl.location, inherited));
+      convert(to_code(op), dest);
+      return true;
+    };
+
+    // Delegate the two convert_decl shapes this handler does not reproduce
+    // natively:
     //  - a static-lifetime or code-typed symbol is a no-op SKIP,
     //  - an array type may be a VLA needing rewrite_vla_decl / a dynamic-size
     //    generator — exclude all arrays conservatively.
-    // A destructible type or an initializer needing lowering is delegated to
-    // convert_decl just below; everything else is convert_decl's plain path
+    // A destructible type or an initializer needing lowering is delegated the
+    // same way just below; everything else is convert_decl's plain path
     // (a DECL, an optional side-effect-free ASSIGN, and one scope-exit code_dead)
     // reproduced natively after that.
     if (
       s->static_lifetime || s->get_type().is_code() || s->get_type().is_array())
-      return false;
+      return delegate_to_legacy();
 
     exprt initializer = is_nil_expr(decl.init) ? static_cast<exprt>(nil_exprt())
                                                : migrate_expr_back(decl.init);
@@ -515,12 +522,7 @@ bool goto_convert_functionst::convert_native_rec(
       (initializer.is_not_nil() &&
        (has_sideeffect(initializer) || initializer.id() == "if"));
     if (needs_convert_decl)
-    {
-      exprt op = migrate_expr_back(code2);
-      restore_value_locations(op, effective_location(decl.location, inherited));
-      convert(to_code(op), dest);
-      return true;
-    }
+      return delegate_to_legacy();
 
     // Emit exactly as convert_decl does: copy() migrates the freshly-built
     // legacy node, so the DECL/ASSIGN instructions match byte-for-byte. Build the


### PR DESCRIPTION
Phase 1 of `docs/roadmap/frontends-to-irep2.md`. Independent of #6668/#6671 —
a different handler, based on master rather than stacked.

`convert_native_rec` failed the whole-function walk on a declaration whose
symbol is static-lifetime or code-typed (`convert_decl` emits a no-op SKIP), or
whose type is an array (conservatively excluded because it may be a VLA). The
handler already delegated the destructible and lowered-initializer shapes to
`convert_decl`; this routes these through the same lambda, so only the
declaration converts legacy-side and the rest of the function stays native.

100% of `code_decl` declines on a stride-10 `esbmc-cpp` census were this one
guard. Gates: `--goto-functions-only` A/B against `--no-irep2-native-body`,
0 divergences over 51 tests; `esbmc-cpp` 9/723 and core C 5/1623 failure sets
each verified independent of the patch.