### PR TITLE
[goto-programs] Delegate ternary expression statements

### DIFF
--- a/regression/esbmc-cpp/cpp/native_expr_ternary_stmt/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_expr_ternary_stmt/main.cpp
@@ -1,0 +1,37 @@
+#include <cassert>
+
+int hits_a = 0;
+int hits_b = 0;
+
+int bump_a()
+{
+  ++hits_a;
+  return 1;
+}
+
+int bump_b()
+{
+  ++hits_b;
+  return 2;
+}
+
+// A top-level ternary in expression-statement position: convert_expression
+// peels it into convert_ifthenelse before remove_sideeffects runs, so the
+// dispatcher delegates the statement rather than failing the walk. Exactly one
+// arm must be evaluated, and the statements around it stay native.
+void pick(int x)
+{
+  x > 0 ? bump_a() : bump_b();
+}
+
+int main()
+{
+  pick(1);
+  assert(hits_a == 1);
+  assert(hits_b == 0);
+
+  pick(-1);
+  assert(hits_a == 1);
+  assert(hits_b == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/native_expr_ternary_stmt/test.desc
+++ b/regression/esbmc-cpp/cpp/native_expr_ternary_stmt/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/native_expr_ternary_stmt_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_expr_ternary_stmt_fail/main.cpp
@@ -1,0 +1,37 @@
+#include <cassert>
+
+int hits_a = 0;
+int hits_b = 0;
+
+int bump_a()
+{
+  ++hits_a;
+  return 1;
+}
+
+int bump_b()
+{
+  ++hits_b;
+  return 2;
+}
+
+// A top-level ternary in expression-statement position: convert_expression
+// peels it into convert_ifthenelse before remove_sideeffects runs, so the
+// dispatcher delegates the statement rather than failing the walk. Exactly one
+// arm must be evaluated, and the statements around it stay native.
+void pick(int x)
+{
+  x > 0 ? bump_a() : bump_b();
+}
+
+int main()
+{
+  pick(1);
+  assert(hits_a == 1);
+  assert(hits_b == 0);
+
+  pick(-1);
+  assert(hits_a == 1);
+  assert(hits_b == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/native_expr_ternary_stmt_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/native_expr_ternary_stmt_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$
+hits_b == 2

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -397,10 +397,18 @@ bool goto_convert_functionst::convert_native_rec(
 
     // Reproduce convert_expression() (goto_convert.cpp) verbatim on its
     // emitting branches. A top-level ternary is peeled unconditionally into
-    // convert_ifthenelse before remove_sideeffects runs; fall back on it.
+    // convert_ifthenelse before remove_sideeffects runs, and a nil operand has
+    // no native form; delegate the statement to convert_expression, which owns
+    // both, rather than failing the walk.
     exprt op = migrate_expr_back(expr_stmt.operand);
     if (op.is_nil() || op.id() == "if")
-      return false;
+    {
+      exprt stmt = migrate_expr_back(code2);
+      restore_value_locations(
+        stmt, effective_location(expr_stmt.location, inherited));
+      convert(to_code(stmt), dest);
+      return true;
+    }
 
     // convert_expression re-dispatches a code-typed operand straight through
     // the legacy convert(): the --irep2-bodies round-trip lowers an


### PR DESCRIPTION
Phase 1 of `docs/roadmap/frontends-to-irep2.md`. Master-based, independent of
#6668/#6671/#6672.

`convert_native_rec` failed the whole-function walk on an expression statement
whose operand is a top-level ternary (`convert_expression` peels it into
`convert_ifthenelse` before `remove_sideeffects` runs) or nil. Delegate the
statement to `convert_expression` instead — on the fallback path that same
function converted it anyway, so the emitted instructions are unchanged and the
statements around it keep converting natively.

100% of `code_expression` declines on a stride-10 `esbmc-cpp` census were this
one guard. Gates: A/B against `--no-irep2-native-body`, 0 divergences over 51
tests; `esbmc-cpp` 9/723 diff-identical to a control build; the new tests are
shown to reach the delegated site (5 hits vs 0 on a control test).