### PR TITLE
[goto-symex] Fold a printf operand that already has the target type

### DIFF
--- a/regression/esbmc/printf_no_simplify_const_arg/main.c
+++ b/regression/esbmc/printf_no_simplify_const_arg/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main()
+{
+  /* %02X of 0xAB is "AB" -- two characters -- whether the operand reaches the
+     formatter as a cast, as a propagated symbol, or as a bare literal. */
+  int a = printf("%02X", (unsigned)0xAB);
+  assert(a == 2);
+
+  unsigned v = 0xAB;
+  int b = printf("%02X", v);
+  assert(b == 2);
+
+  int c = printf("%02X", 0xAB);
+  assert(c == 2);
+}

--- a/regression/esbmc/printf_no_simplify_const_arg/test.desc
+++ b/regression/esbmc/printf_no_simplify_const_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/printf_no_simplify_const_arg_fail/main.c
+++ b/regression/esbmc/printf_no_simplify_const_arg_fail/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main()
+{
+  /* Non-vacuity control: the return value is pinned to the exact length, so
+     asserting the wrong length must fail rather than pass on a widened range. */
+  int a = printf("%02X", (unsigned)0xAB);
+  assert(a == 3);
+}

--- a/regression/esbmc/printf_no_simplify_const_arg_fail/test.desc
+++ b/regression/esbmc/printf_no_simplify_const_arg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-simplify
+^VERIFICATION FAILED$

--- a/regression/esbmc/printf_no_simplify_nondet_arg_fail/main.c
+++ b/regression/esbmc/printf_no_simplify_nondet_arg_fail/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdio.h>
+
+unsigned nondet_uint(void);
+
+int main()
+{
+  /* Over-pinning control: %02X of a genuinely unknown value spans 2..8
+     characters, so the return value must stay a range, not fold to a
+     constant. */
+  unsigned v = nondet_uint();
+  int r = printf("%02X", v);
+  assert(r == 2);
+}

--- a/regression/esbmc/printf_no_simplify_nondet_arg_fail/test.desc
+++ b/regression/esbmc/printf_no_simplify_nondet_arg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-simplify
+^VERIFICATION FAILED$

--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -9,10 +9,11 @@
 const expr2tc
 printf_formattert::make_type(const expr2tc &src, const type2tc &dest)
 {
-  if (src->type == dest)
-    return src;
-
-  expr2tc tmp = typecast2tc(dest, src);
+  // Callers test the result with is_constant_int2t, so fold on both paths --
+  // an operand already of the target type may be constant only after folding.
+  expr2tc tmp = src;
+  if (src->type != dest)
+    tmp = typecast2tc(dest, src);
   simplify(tmp);
   return tmp;
 }


### PR DESCRIPTION
make_type simplified only when it had to insert a typecast, so an operand
already of the conversion's type was returned unfolded and emit_int's
is_constant_int2t test failed. The conversion was then bounded by width
rather than by value — `%02X` of `(unsigned)0xAB` spanned [2,8] instead of 2 —
and printf's return value became a spurious range.

Default runs mask this because do_simplify folds the operand upstream, so it
surfaced only under `--no-simplify`. Closes four of the ten divergences
recorded as R16 in docs/roadmap/goto-symex-verification-plan.md.