### PR TITLE
[goto-symex] Classify realloc's zero size regardless of --no-simplify

### DIFF
--- a/regression/esbmc/realloc_nonzero_no_simplify_fail/main.c
+++ b/regression/esbmc/realloc_nonzero_no_simplify_fail/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *p = malloc(4 * sizeof(int));
+  if (p == NULL)
+    return 0;
+
+  /* Over-classification control: a non-zero size must not take the
+     free-and-return-NULL path. */
+  int *q = realloc(p, 8 * sizeof(int));
+  assert(q == NULL);
+}

--- a/regression/esbmc/realloc_nonzero_no_simplify_fail/test.desc
+++ b/regression/esbmc/realloc_nonzero_no_simplify_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-simplify
+^VERIFICATION FAILED$

--- a/regression/esbmc/realloc_zero_no_simplify/main.c
+++ b/regression/esbmc/realloc_zero_no_simplify/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *p = malloc(4 * sizeof(int));
+  if (p == NULL)
+    return 0;
+
+  /* The zero-size classification must not depend on --no-simplify. */
+  int *q = realloc(p, 0);
+  assert(q == NULL);
+}

--- a/regression/esbmc/realloc_zero_no_simplify/test.desc
+++ b/regression/esbmc/realloc_zero_no_simplify/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -268,7 +268,9 @@ bool goto_symext::handle_realloc_zero_size(
 {
   expr2tc zero_size = gen_zero(realloc_size->type);
   expr2tc is_zero_size = equality2tc(realloc_size, zero_size);
-  do_simplify(is_zero_size);
+  // Classify unconditionally: --no-simplify selects a formula representation,
+  // it must not decide whether realloc(p, 0) frees p and returns NULL.
+  simplify(is_zero_size);
 
   if (is_true(is_zero_size))
   {


### PR DESCRIPTION
handle_realloc_zero_size tested the size with do_simplify, which is a no-op
under `--no-simplify`, so `realloc(p, 0)` did not take the free-and-return-NULL
path and the returned pointer was non-null.

#6660 already set this rule for the allocation-size checks 300 lines below, on
the same argument: the flag selects a formula representation, it must not decide
what the model does. Closes two more of the R16 divergences recorded in
docs/roadmap/goto-symex-verification-plan.md.