### PR TITLE
[goto-programs] Delegate the non-native assignment shapes

### DIFF
--- a/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+#include <vector>
+
+// Exercises the assignment shape the census observed at this handler: an rhs
+// that is a side-effecting expression, reached through the container
+// operational models. Delegating the statement to convert_assign must preserve
+// the stored values and the size.
+int main()
+{
+  std::vector<int> v;
+  v.push_back(3);
+  v.push_back(4);
+
+  int first = v[0];
+  int second = v[1];
+
+  assert(v.size() == 2);
+  assert(first == 3);
+  assert(second == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs/test.desc
+++ b/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs_fail/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+#include <vector>
+
+// Exercises the assignment shape the census observed at this handler: an rhs
+// that is a side-effecting expression, reached through the container
+// operational models. Delegating the statement to convert_assign must preserve
+// the stored values and the size.
+int main()
+{
+  std::vector<int> v;
+  v.push_back(3);
+  v.push_back(4);
+
+  int first = v[0];
+  int second = v[1];
+
+  assert(v.size() == 2);
+  assert(first == 3);
+  assert(second == 9);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/native_assign_sideeffect_rhs_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$
+second == 9

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -317,9 +317,23 @@ bool goto_convert_functionst::convert_native_rec(
   if (is_code_assign2t(code2))
   {
     const code_assign2t &assign = to_code_assign2t(code2);
+
+    // Every shape below that this handler does not emit natively is delegated
+    // to convert_assign, which owns the side-effect lowering, the ternary peel
+    // and the convert_assign_atomic dispatch. On the fallback path that same
+    // function converted the statement anyway, so the instructions are
+    // unchanged; delegating keeps the rest of the function native.
+    auto delegate_to_legacy = [&]() {
+      exprt op = migrate_expr_back(code2);
+      restore_value_locations(
+        op, effective_location(assign.location, inherited));
+      convert(to_code(op), dest);
+      return true;
+    };
+
     exprt lhs = migrate_expr_back(assign.target);
     if (has_sideeffect(lhs) || lhs.id() == "if")
-      return false;
+      return delegate_to_legacy();
 
     // convert_assign()'s function-call special case (goto_convert.cpp)
     // dispatches a call-valued rhs straight to do_function_call(), bypassing
@@ -343,10 +357,10 @@ bool goto_convert_functionst::convert_native_rec(
     {
       const sideeffect2t &se = to_sideeffect2t(assign.source);
       if (has_sideeffect(se.operand))
-        return false;
+        return delegate_to_legacy();
       for (const expr2tc &arg : se.arguments)
         if (has_sideeffect(arg))
-          return false;
+          return delegate_to_legacy();
 
       exprt function_legacy = migrate_expr_back(se.operand);
       exprt::operandst args_legacy;
@@ -377,7 +391,7 @@ bool goto_convert_functionst::convert_native_rec(
     if (
       has_sideeffect(rhs) || rhs.id() == "if" || rhs.type().is_code() ||
       is_atomic_symbol(lhs, ns) || has_atomic_read(rhs, ns))
-      return false;
+      return delegate_to_legacy();
 
     // For side-effect-free operands the instruction convert_assign emits is
     // migrate_expr(code_assignt(lhs, rhs)) located at the statement — which


### PR DESCRIPTION
Phase 1 of `docs/roadmap/frontends-to-irep2.md`. Master-based, independent of
the other dispatcher PRs.

`convert_native_rec` failed the whole-function walk on an assignment with a
side-effecting or ternary lhs, a call-valued rhs with side-effecting callee or
arguments, or — the only shape the census observed — a side-effecting rhs, a
code-typed rhs, or a C11 `_Atomic` operand. All four now delegate to
`convert_assign`, which owns the side-effect lowering, the ternary peel and the
`convert_assign_atomic` dispatch.

100% of `code_assign` declines were the generic rhs guard. Gates: A/B against
`--no-irep2-native-body`, 0 divergences over 51 tests; `esbmc-cpp` 9/723
diff-identical to control; core C 5/1623, all pre-existing. The regression test
is shown to reach the delegated site (4 hits under a probe) — two earlier
candidate programs did not, so a passing test alone was not taken as evidence.