### PR TITLE
[python] Keep a scope's global declarations across a nested def

### DIFF
--- a/regression/python/github_6669/main.py
+++ b/regression/python/github_6669/main.py
@@ -1,0 +1,27 @@
+class Adder:
+    def __init__(self, amount: int) -> None:
+        self.amount: int = amount
+
+
+obj: Adder = None
+
+
+def reader() -> None:
+    global obj
+    assert obj.amount == 1
+
+
+def outer() -> None:
+    global obj
+
+    # Converting this nested def used to clear the enclosing scope's `global`
+    # declarations, so the assignment below bound a local instead.
+    def bump(a: int) -> int:
+        return a + 1
+
+    obj = Adder(1)
+    assert bump(1) == 2
+    reader()
+
+
+outer()

--- a/regression/python/github_6669/test.desc
+++ b/regression/python/github_6669/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6669_fail/main.py
+++ b/regression/python/github_6669_fail/main.py
@@ -1,0 +1,27 @@
+class Adder:
+    def __init__(self, amount: int) -> None:
+        self.amount: int = amount
+
+
+obj: Adder = None
+
+
+def reader() -> None:
+    global obj
+    assert obj.amount == 2
+
+
+def outer() -> None:
+    global obj
+
+    # Converting this nested def used to clear the enclosing scope's `global`
+    # declarations, so the assignment below bound a local instead.
+    def bump(a: int) -> int:
+        return a + 1
+
+    obj = Adder(1)
+    assert bump(1) == 2
+    reader()
+
+
+outer()

--- a/regression/python/github_6669_fail/test.desc
+++ b/regression/python/github_6669_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_6669_nested_shadow/main.py
+++ b/regression/python/github_6669_nested_shadow/main.py
@@ -1,0 +1,20 @@
+count: int = 0
+
+
+def outer() -> None:
+    global count
+
+    def helper() -> int:
+        # A `global` in the nested scope must not leak out to the enclosing
+        # one, and must not survive past this def either.
+        global count
+        count = count + 10
+        return count
+
+    count = 1
+    assert helper() == 11
+    count = count + 1
+
+
+outer()
+assert count == 12

--- a/regression/python/github_6669_nested_shadow/test.desc
+++ b/regression/python/github_6669_nested_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -5557,9 +5557,18 @@ exprt python_converter::get_block(
     }
     case StatementType::FUNC_DEFINITION:
     {
+      // A nested def is converted in the middle of its enclosing function, so
+      // save and restore rather than clear: the inner body's own `global`
+      // declarations must not outlive it, and the enclosing scope's must
+      // survive it. Clearing dropped the enclosing `global x`, after which
+      // every later `x = ...` in the outer body bound a fresh local and the
+      // module global kept its initial value (#6669). At module scope the
+      // saved state is empty, so this matches the previous behaviour.
+      std::vector<std::string> saved_globals = global_declarations;
+      std::vector<std::string> saved_loads = local_loads;
       get_function_definition(element);
-      global_declarations.clear();
-      local_loads.clear();
+      global_declarations = std::move(saved_globals);
+      local_loads = std::move(saved_loads);
       break;
     }
     case StatementType::RETURN:


### PR DESCRIPTION
Converting a nested `def` cleared `global_declarations`, which belongs to the enclosing scope. Every `x = ...` after the nested def then bound a fresh local, so the module global kept its initial value and a later read saw it unwritten — a NULL dereference reported on a correct program.

Save and restore around the nested definition instead. At module scope the saved state is empty, so top-level defs behave exactly as before.

Fixes #6669.