### PR TITLE
[symex] Answer "unknown" for __builtin_object_size on a dynamic array

### DIFF
--- a/regression/esbmc/builtin_object_size_vla/main.c
+++ b/regression/esbmc/builtin_object_size_vla/main.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+unsigned int nondet_uint();
+
+/* __builtin_object_size on a VLA. The array has no compile-time size, so
+   type_byte_size() cannot produce one and throws; GCC answers "unknown" for
+   exactly these objects. Letting the exception escape aborted the run with
+   array_type2t::dyn_sized_array_excp before symex reached any property. */
+int main()
+{
+  unsigned int n = nondet_uint();
+  __ESBMC_assume(n >= 1 && n <= 8);
+
+  char vla[n];
+  vla[0] = 'x';
+
+  /* Type 0 is the "maximum size" query, so an unknown answer is a large
+     value rather than zero. */
+  __ESBMC_assume(__builtin_object_size(vla, 0) != 0);
+  /* Type 2 is the "minimum size" query, whose unknown answer is zero. */
+  assert(__builtin_object_size(vla, 2) == 0);
+
+  assert(vla[0] == 'x');
+  return 0;
+}

--- a/regression/esbmc/builtin_object_size_vla/test.desc
+++ b/regression/esbmc/builtin_object_size_vla/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-vla-size-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/builtin_object_size_vla_fail/main.c
+++ b/regression/esbmc/builtin_object_size_vla_fail/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+unsigned int nondet_uint();
+
+/* The companion to builtin_object_size_vla: a fixed-size array still gets a
+   real answer, so the unknown-size fallback has not swallowed the ordinary
+   case. Asserting the wrong size must fail. */
+int main()
+{
+  unsigned int n = nondet_uint();
+  __ESBMC_assume(n >= 1 && n <= 8);
+
+  char fixed[16];
+  char vla[n];
+  vla[0] = 'x';
+
+  assert(__builtin_object_size(fixed, 0) == 16);
+  /* Wrong on purpose: the object is 16 bytes, not 8. */
+  assert(__builtin_object_size(fixed, 0) == 8);
+  return 0;
+}

--- a/regression/esbmc/builtin_object_size_vla_fail/test.desc
+++ b/regression/esbmc/builtin_object_size_vla_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-vla-size-check
+^VERIFICATION FAILED$

--- a/src/goto-symex/builtin_functions/object_size.cpp
+++ b/src/goto-symex/builtin_functions/object_size.cpp
@@ -118,38 +118,52 @@ void goto_symext::intrinsic_builtin_object_size(
     // Note: type_byte_size returns the allocated object size, not just the sum
     // of fields. For structs/unions this includes alignment and padding, which
     // matches GCC's __builtin_object_size semantics.
-    BigInt total_size = type_byte_size(addressed_type);
-
-    if (consider_offset)
+    //
+    // A VLA or otherwise dynamically sized array has no compile-time size, so
+    // type_byte_size() throws rather than returning one. That is not an error
+    // here: GCC's __builtin_object_size answers "unknown" for exactly these
+    // objects, which is the fallback this function already computes when it
+    // cannot identify the object at all. Letting the exception escape instead
+    // aborts the run.
+    try
     {
-      // Type 1 or 3: calculate remaining bytes from offset
-      expr2tc offset_expr = pointer_offset2tc(get_int64_type(), ptr);
-      cur_state->rename(offset_expr);
-      do_simplify(offset_expr);
+      BigInt total_size = type_byte_size(addressed_type);
 
-      if (is_constant_int2t(offset_expr))
+      if (consider_offset)
       {
-        BigInt offset = to_constant_int2t(offset_expr).value;
-        BigInt remaining =
-          (total_size > offset) ? (total_size - offset) : BigInt(0);
-        obj_size = constant_int2tc(size_type2(), remaining);
+        // Type 1 or 3: calculate remaining bytes from offset
+        expr2tc offset_expr = pointer_offset2tc(get_int64_type(), ptr);
+        cur_state->rename(offset_expr);
+        do_simplify(offset_expr);
+
+        if (is_constant_int2t(offset_expr))
+        {
+          BigInt offset = to_constant_int2t(offset_expr).value;
+          BigInt remaining =
+            (total_size > offset) ? (total_size - offset) : BigInt(0);
+          obj_size = constant_int2tc(size_type2(), remaining);
+        }
+        else
+        {
+          // Offset is symbolic - can't determine remaining size statically
+          const expr2tc total_size_expr =
+            constant_int2tc(get_int64_type(), total_size);
+          obj_size = if2tc(
+            size_type2(),
+            greaterthan2tc(total_size_expr, offset_expr),
+            sub2tc(size_type2(), total_size_expr, offset_expr),
+            gen_zero(size_type2()));
+        }
       }
       else
       {
-        // Offset is symbolic - can't determine remaining size statically
-        const expr2tc total_size_expr =
-          constant_int2tc(get_int64_type(), total_size);
-        obj_size = if2tc(
-          size_type2(),
-          greaterthan2tc(total_size_expr, offset_expr),
-          sub2tc(size_type2(), total_size_expr, offset_expr),
-          gen_zero(size_type2()));
+        // Type 0 or 2: return full object size of the addressed object
+        obj_size = constant_int2tc(size_type2(), total_size);
       }
     }
-    else
+    catch (const array_type2t::array_size_excp &)
     {
-      // Type 0 or 2: return full object size of the addressed object
-      obj_size = constant_int2tc(size_type2(), total_size);
+      obj_size = create_fallback_size(use_zero_for_unknown);
     }
   }
 


### PR DESCRIPTION
## Problem

`intrinsic_builtin_object_size()` calls `type_byte_size()` on the addressed
type without guarding it. A VLA — or any dynamically sized array — has no
compile-time size, so `type_byte_size()` throws
`array_type2t::dyn_sized_array_excp` rather than returning one, and nothing
catches it. The run aborts:

```
terminate called after throwing an instance of 'array_type2t::dyn_sized_array_excp'
  what():  Sizeof nondeterministically sized array encountered
```

before symbolic execution reaches any property.

Minimal reproducer:

```c
unsigned int nondet_uint();
int main() {
  unsigned int n = nondet_uint();
  __ESBMC_assume(n >= 1 && n <= 8);
  char vla[n];
  __ESBMC_assume(__builtin_object_size(vla, 0) != 0);
  return 0;
}
```

```
$ esbmc vla.c --no-vla-size-check
Starting Bounded Model Checking
terminate called after throwing an instance of 'array_type2t::dyn_sized_array_excp'
```

## Fix

GCC answers "unknown" for exactly these objects, and this function **already
computes that answer** — `create_fallback_size()` is what it uses when the
underlying object cannot be identified at all. The throwing call is simply not
inside the block that routes to it.

Moving the `type_byte_size()` call (and the size arithmetic that depends on it)
into a `try` block, with `catch (const array_type2t::array_size_excp &)`
producing the existing fallback, makes a dynamic array take the same path as an
unidentifiable object: `2^(word_size-1)-1` for types 0/1, zero for types 2/3.

Catching the `array_size_excp` base covers `inf_sized_array_excp` too, which
`type_byte_size()` can also throw.

## Tests

- `regression/esbmc/builtin_object_size_vla` — the VLA case, now
  `VERIFICATION SUCCESSFUL`. Checks both the type-0 query (unknown ⇒ large) and
  the type-2 query (unknown ⇒ zero).
- `regression/esbmc/builtin_object_size_vla_fail` — asserts a deliberately
  wrong size for a *fixed*-size array, so the fallback is shown not to have
  swallowed the ordinary case.

I checked the passing test against an unpatched build: it aborts. It guards the
fix rather than passing incidentally.

## Provenance

Reduced from `regression/esbmc-unix/instrumented_nohup_comb_overflow`, where
this crash was masked by an unrelated false positive in the shl overflow check
(#6684) that terminated symex earlier. The two changes are independent — this
one reproduces on current `master` with the VLA reproducer above, which
involves no shifts — and that test is unaffected by this PR (still `CORE`,
still passing, 4.5 s).
