### PR TITLE
[util] Classify floatbv in the IREP2 get_c_type overload

### DIFF
--- a/regression/python/float_int_arith_reconcile/main.py
+++ b/regression/python/float_int_arith_reconcile/main.py
@@ -1,0 +1,14 @@
+# Exercises c_implicit_typecast_arithmetic through python_math's floor-div and
+# modulo reconciliation with one float and one integer operand. The IREP2
+# get_c_type overload used to classify floatbv as OTHER, which outranks every
+# arithmetic kind and made the helper convert neither operand.
+x = 7.0
+assert x // 2 == 3.0
+assert x % 2 == 1.0
+
+y = 7
+assert y // 2.0 == 3.0
+assert y % 2.0 == 1.0
+
+z = -7.0
+assert z // 2 == -4.0

--- a/regression/python/float_int_arith_reconcile/test.desc
+++ b/regression/python/float_int_arith_reconcile/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_int_arith_reconcile_fail/main.py
+++ b/regression/python/float_int_arith_reconcile_fail/main.py
@@ -1,0 +1,14 @@
+# Exercises c_implicit_typecast_arithmetic through python_math's floor-div and
+# modulo reconciliation with one float and one integer operand. The IREP2
+# get_c_type overload used to classify floatbv as OTHER, which outranks every
+# arithmetic kind and made the helper convert neither operand.
+x = 7.0
+assert x // 2 == 3.0
+assert x % 2 == 1.0
+
+y = 7
+assert y // 2.0 == 3.0
+assert y % 2.0 == 1.0
+
+z = -7.0
+assert z // 2 == -3.0

--- a/regression/python/float_int_arith_reconcile_fail/test.desc
+++ b/regression/python/float_int_arith_reconcile_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/util/lang/c_typecast.cpp
+++ b/src/util/lang/c_typecast.cpp
@@ -395,9 +395,16 @@ c_typecastt::c_typet c_typecastt::get_c_type(const type2tc &type)
   }
   else if (is_bool_type(type))
     return BOOL;
-  else if (is_fixedbv_type(type))
+  else if (is_fixedbv_type(type) || is_floatbv_type(type))
   {
-    unsigned width = to_fixedbv_type(type).width;
+    // The legacy typet overload above classifies "floatbv" and "fixedbv"
+    // together; this one only ever handled fixedbv, so every floatbv fell
+    // through to OTHER. OTHER outranks every arithmetic kind, so
+    // implicit_typecast_arithmetic promoted both operands to a type its switch
+    // has no case for and silently converted neither -- making the whole
+    // helper a no-op on any expr2tc pair with a floating-point operand.
+    unsigned width = is_fixedbv_type(type) ? to_fixedbv_type(type).width
+                                           : to_floatbv_type(type).get_width();
     if (width <= config.ansi_c.single_width)
       return SINGLE;
     else if (width <= config.ansi_c.double_width)


### PR DESCRIPTION
The legacy `typet` overload of `get_c_type` classifies `"floatbv"` and
`"fixedbv"` together (`c_typecast.cpp`); the `expr2tc` overload only ever
handled `fixedbv`, so **every `floatbv` fell through to `OTHER`**. `OTHER`
outranks every arithmetic kind in `c_typet`, so
`implicit_typecast_arithmetic` computed `max_type = OTHER`, called the
single-operand conversion whose switch has no `OTHER` case, and converted
neither operand — making `c_implicit_typecast_arithmetic` a **silent no-op on
any `expr2tc` pair with a floating-point operand**.

**How it was found.** Probing `python_adjust`'s comparison arm while chasing
`lambda15`'s `mk_eq` abort: the arm fires on `floatbv == bool`, and the operand
types are byte-identical before and after the helper call. Not an inference —
the probe prints both.

**Blast radius.** Five call sites, all in the Python frontend
(`python_adjust`, `python_math`, `list_comprehension`, `list_mutation`,
`python_set`, `builtins`), four of them on the **default** path, not behind the
`--python-irep2-adjust-only` flag.

**Gates.** Python suite stride sample: 489 tests, 1 failure
(`github_3719_4-nondet`), and a control build with this file reverted **fails it
identically** — pre-existing. `neural-net_fail` still reports FAILED, which is
the anti-masking gate a widened conversion broke once before
(`scope-coupled-arith-assign-conversion.md` §9.3), and
`python_irep2_adjust_only_binary_arith` still passes.

**Honest framing:** no verdict changed in the sample. This removes a latent
no-op rather than fixing an observed wrong verdict — but it is a prerequisite
for any float reconciliation on the IREP2 path, and the helper is currently
lying to five callers. The tests guard the floor-div/modulo path that reaches it
with mixed float/int operands.
