### PR TITLE
[goto-programs] Locate an unlocated expression statement from its parent

### DIFF
--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -464,14 +464,21 @@ bool goto_convert_functionst::convert_native_rec(
       return true;
     }
 
-    // The OTHER carries the statement location directly; without a usable one
-    // the legacy path would instead locate it at an enclosing block.
-    if (expr_stmt.location.is_nil() || expr_stmt.location.get_file().empty())
+    // The OTHER carries the statement location directly. When the statement has
+    // none, fall back on the enclosing statement's -- which is what `inherited`
+    // threads down for the side-effect branch above, and where the legacy path
+    // locates it anyway. Python's converter emits synthetic statements
+    // (operational-model calls, desugared constructs) with no location of their
+    // own, and declining them was ~87 % of that corpus's genuine declines
+    // (docs/roadmap/frontends-to-irep2.md §13). Still decline when even the
+    // inherited location is unusable: there is then nothing to locate it at.
+    const locationt &here = effective_location(expr_stmt.location, inherited);
+    if (here.is_nil() || here.get_file().empty())
       return false;
 
     goto_programt::targett t = dest.add_instruction(OTHER);
     t->code = code2;
-    t->location = expr_stmt.location;
+    t->location = here;
     return true;
   }
 


### PR DESCRIPTION
Phase 1 of `docs/roadmap/frontends-to-irep2.md`, targeting the site #6691
measured as **~87 % of the Python corpus's genuine dispatcher declines**.

**Draft: the byte-identity gate is incomplete — see below.**

`convert_native_rec` declined any expression statement whose own location is nil
or file-less, because the `OTHER` instruction carries that location directly.
Python's converter emits synthetic statements (operational-model calls,
desugared constructs) with no location of their own, so this dominated that
corpus while being almost absent from C and C++ — which is why eight patches
tuned on C++ never touched it.

The fix uses `effective_location()`, which the side-effect branch *directly
above* already threads `inherited` for, and which resolves to the enclosing
statement's location — where the legacy path locates it anyway. It still
declines when even the inherited location is unusable.

**Gates.**
- Python suite: 9 tests sampled, 8 pass; the one failure
  (`github_3719_4-nondet`) was proven pre-existing against a control build
  earlier in this series. This change is on the **default** path
  (`--irep2-native-body` is default-on), so the suite tests it directly.
- **Outstanding: the `--goto-functions-only` byte-identity A/B.** This is a
  *location* change, and location fidelity is the entire subject of the W1-loc
  work, so verdict parity is not a sufficient gate for it. The dev machine was
  contended (load 8→16) and each Python test spawns the parser subprocess, so
  the A/B could not complete. Draft until it does.

**A harness finding worth recording**, because it defeats the normalization rule
in §7 of that roadmap: the first A/B divergence was `__file__`, which encodes the
**randomized temp directory as decimal character codes** in a char array —
`esbmc-python-astgen-07f2-…` vs `…-c929-…`. Path-based normalization cannot
match it. Any Python A/B must drop `ASSIGN __file__=` lines as well as
normalizing paths.

No discriminating regression test is offered: the change converts statements
that previously fell back, with no expected verdict difference. The gate is the
A/B, which is why it is outstanding rather than substituted for.
