### PR TITLE
[clang-frontend] Support GCC computed goto

### DIFF
--- a/regression/esbmc-cpp11/github_4083-nested/main.cpp
+++ b/regression/esbmc-cpp11/github_4083-nested/main.cpp
@@ -1,0 +1,24 @@
+// A lambda's call operator is converted while the enclosing body is still
+// mid-conversion. The address-taken label set is per-function state, so the
+// nested conversion must stack it rather than reset it -- otherwise main's
+// later `&&A` resolves against the lambda's (empty) set and the whole
+// function fails to convert (issue #4083).
+int main()
+{
+  void *p[2];
+  int r = 0;
+  auto inner = [](int v) { return v + 3; };
+  r = inner(4);
+  p[0] = &&A;
+  p[1] = &&B;
+  goto *p[1];
+A:
+  r += 1;
+  goto END;
+B:
+  r += 2;
+  goto END;
+END:
+  __ESBMC_assert(r == 9, "lambda conversion preserves the outer label set");
+  return 0;
+}

--- a/regression/esbmc-cpp11/github_4083-nested/test.desc
+++ b/regression/esbmc-cpp11/github_4083-nested/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4083-dup-address/main.c
+++ b/regression/esbmc/github_4083-dup-address/main.c
@@ -1,0 +1,13 @@
+// Taking one label's address twice must yield one value: the number a label
+// gets is its first position in the function's address-taken set, not its
+// per-occurrence position. Pins that `&&L` is a stable value rather than a
+// fresh one per mention (issue #4083).
+int main(void)
+{
+  void *a = &&L;
+  void *b = &&L;
+  __ESBMC_assert(a == b, "one label, one address");
+  goto *a;
+L:
+  return 0;
+}

--- a/regression/esbmc/github_4083-dup-address/test.desc
+++ b/regression/esbmc/github_4083-dup-address/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4083-invalid-target/main.c
+++ b/regression/esbmc/github_4083-invalid-target/main.c
@@ -1,0 +1,12 @@
+// Jumping to a value that is not any label's address is undefined behaviour.
+// The dispatch chain is exhaustive over the address-taken labels, so the
+// trailing assertion is what reports it instead of silently falling through
+// to the next statement (issue #4083).
+int main()
+{
+  void *p = (void *)0;
+  void *unused[] = {&&L1};
+  goto *p;
+L1:
+  return 0;
+}

--- a/regression/esbmc/github_4083-invalid-target/test.desc
+++ b/regression/esbmc/github_4083-invalid-target/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_4083-nondet/main.c
+++ b/regression/esbmc/github_4083-nondet/main.c
@@ -1,0 +1,23 @@
+// A symbolic index selects the target, so both labels must stay reachable:
+// the dispatch chain has to branch rather than collapse onto one label
+// (issue #4083). github_4083-invalid-target pins the other side, that a
+// target matching no label is caught.
+int nondet_int();
+
+int main()
+{
+  void *labels[] = {&&L1, &&L2};
+  int i = nondet_int();
+  __ESBMC_assume(i >= 0 && i < 2);
+  int x = 0;
+  goto *labels[i];
+L1:
+  x = 1;
+  goto END;
+L2:
+  x = 2;
+  goto END;
+END:
+  __ESBMC_assert(x == 1 || x == 2, "reaches exactly one of the two labels");
+  return 0;
+}

--- a/regression/esbmc/github_4083-nondet/test.desc
+++ b/regression/esbmc/github_4083-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4083/main.c
+++ b/regression/esbmc/github_4083/main.c
@@ -1,0 +1,18 @@
+// GCC computed goto: `&&L` takes a label's address and `goto *p` jumps to it.
+// The dispatch must land on the label the pointer names -- here labels[1],
+// i.e. L2 (issue #4083).
+int main()
+{
+  void *labels[] = {&&L1, &&L2};
+  int x = 0;
+  goto *labels[1];
+L1:
+  x = 1;
+  goto END;
+L2:
+  x = 2;
+  goto END;
+END:
+  __ESBMC_assert(x == 2, "computed goto lands on L2");
+  return 0;
+}

--- a/regression/esbmc/github_4083/test.desc
+++ b/regression/esbmc/github_4083/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4083_fail/main.c
+++ b/regression/esbmc/github_4083_fail/main.c
@@ -1,0 +1,19 @@
+// Negative counterpart of github_4083: the target is labels[1] (L2), so a
+// claim that execution reaches L1 must be refuted rather than vacuously held
+// -- this is what fails if the dispatch chain picks the wrong label or falls
+// through (issue #4083).
+int main()
+{
+  void *labels[] = {&&L1, &&L2};
+  int x = 0;
+  goto *labels[1];
+L1:
+  x = 1;
+  goto END;
+L2:
+  x = 2;
+  goto END;
+END:
+  __ESBMC_assert(x == 1, "must not reach L1");
+  return 0;
+}

--- a/regression/esbmc/github_4083_fail/test.desc
+++ b/regression/esbmc/github_4083_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_746/main.c
+++ b/regression/esbmc/github_746/main.c
@@ -1,11 +1,15 @@
 /* THOROUGH, i.e. Linux-only: on Windows LLVM's prepare_colors() refuses colour
    for any stream that is not a console (Process::ColorNeedsFlush()), and the
    dump goes through a raw_os_ostream, so the escapes never appear there.
-   github_746_nocolor pins the absence case on every platform. */
+   github_746_nocolor pins the absence case on every platform.
+
+   The construct is incidental -- it only has to be one the frontend cannot
+   convert, so that it dumps the clang AST. It was an indirect goto until that
+   became supported (issue #4083). */
+_Atomic int a;
+
 int main(void)
 {
-  void *p = &&lbl;   /* indirect goto: unsupported, triggers an AST dump */
-lbl:
-  goto *p;
+  __c11_atomic_fetch_nand(&a, 1, 0);
   return 0;
 }

--- a/regression/esbmc/github_746/test.desc
+++ b/regression/esbmc/github_746/test.desc
@@ -2,4 +2,4 @@ THOROUGH
 main.c
 --color always
 ^.*CONVERSION ERROR$
-\x1b\[0;1;35mIndirectGotoStmt
+\x1b\[0;1;35mAtomicExpr

--- a/regression/esbmc/github_746_nocolor/main.c
+++ b/regression/esbmc/github_746_nocolor/main.c
@@ -1,7 +1,10 @@
+/* Pins that the clang AST dump the frontend emits for an unsupported
+   construct honours --color never. The construct is incidental -- it was an
+   indirect goto until that became supported (issue #4083). */
+_Atomic int a;
+
 int main(void)
 {
-  void *p = &&lbl;   /* indirect goto: unsupported, triggers an AST dump */
-lbl:
-  goto *p;
+  __c11_atomic_fetch_nand(&a, 1, 0);
   return 0;
 }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -7,6 +7,7 @@ CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <clang/AST/ExprCXX.h> /* clang::TypeTraitExpr */
 #include <clang/AST/ParentMapContext.h>
 #include <clang/AST/RecordLayout.h>
+#include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/AST/QualTypeNames.h>
 #include <clang/AST/Type.h>
 #include <clang/Basic/Version.inc>
@@ -812,6 +813,44 @@ bool clang_c_convertert::get_function(
   return false;
 }
 
+namespace
+{
+class addr_label_collectort
+  : public clang::RecursiveASTVisitor<addr_label_collectort>
+{
+public:
+  explicit addr_label_collectort(std::vector<const clang::LabelDecl *> &labels)
+    : labels(labels)
+  {
+  }
+
+  bool VisitAddrLabelExpr(clang::AddrLabelExpr *e)
+  {
+    if (std::find(labels.begin(), labels.end(), e->getLabel()) == labels.end())
+      labels.push_back(e->getLabel());
+    return true;
+  }
+
+private:
+  std::vector<const clang::LabelDecl *> &labels;
+};
+} // namespace
+
+/// The value standing for the address of the `index`-th address-taken label.
+static exprt label_address(std::size_t index)
+{
+  const BigInt id(index + 1);
+  return constant_exprt(
+    integer2binary(id, bv_width(size_type())), integer2string(id), size_type());
+}
+
+void clang_c_convertert::collect_address_taken_labels(const clang::Stmt &body)
+{
+  address_taken_labels.clear();
+  addr_label_collectort(address_taken_labels)
+    .TraverseStmt(const_cast<clang::Stmt *>(&body));
+}
+
 bool clang_c_convertert::get_function_body(
   const clang::FunctionDecl &fd,
   exprt &new_expr,
@@ -820,8 +859,18 @@ bool clang_c_convertert::get_function_body(
   if (!fd.hasBody())
     return false;
 
+  // A nested body -- a lambda's call operator, a local class method -- is
+  // converted while the enclosing body is still mid-conversion, so the label
+  // set has to be stacked rather than merely reset: clearing it would leave
+  // the enclosing function's later `&&L` with nothing to resolve against.
+  std::vector<const clang::LabelDecl *> outer_labels;
+  outer_labels.swap(address_taken_labels);
+  collect_address_taken_labels(*fd.getBody());
+
   exprt body_exprt;
-  if (get_expr(*fd.getBody(), body_exprt))
+  const bool failed = get_expr(*fd.getBody(), body_exprt);
+  address_taken_labels.swap(outer_labels);
+  if (failed)
     return true; // return true if failing to parse function body
 
   new_expr = body_exprt;
@@ -2534,11 +2583,24 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     const clang::AddrLabelExpr &addrlabelExpr =
       static_cast<const clang::AddrLabelExpr &>(stmt);
 
-    exprt label;
-    if (get_decl(*addrlabelExpr.getLabel(), label))
+    auto it = std::find(
+      address_taken_labels.begin(),
+      address_taken_labels.end(),
+      addrlabelExpr.getLabel());
+    if (it == address_taken_labels.end())
+    {
+      log_error(
+        "address taken of label '{}' outside a converted function body",
+        addrlabelExpr.getLabel()->getName().str());
+      return true;
+    }
+
+    typet t;
+    if (get_type(addrlabelExpr.getType(), t))
       return true;
 
-    new_expr = address_of_exprt(label);
+    new_expr = typecast_exprt(
+      label_address(std::distance(address_taken_labels.begin(), it)), t);
     break;
   }
 
@@ -3382,23 +3444,30 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     }
     else
     {
-      log_error("ESBMC currently does not support indirect gotos");
-      std::ostringstream oss;
-      llvm::raw_os_ostream ross(oss);
-      enable_ast_dump_colors(ross, *ASTContext);
-      stmt.dump(ross, *ASTContext);
-      ross.flush();
-      log_error("{}", oss.str());
-      return true;
-
       exprt target;
       if (get_expr(*goto_stmt.getTarget(), target))
         return true;
 
-      codet code_goto("gcc_goto");
-      code_goto.copy_to_operands(target);
+      // Dispatch over every address-taken label. A label address is the only
+      // value the target can legally hold, so the chain is exhaustive; the
+      // trailing assertion catches the programs where it is not.
+      code_blockt dispatch;
+      for (std::size_t i = 0; i < address_taken_labels.size(); ++i)
+      {
+        code_ifthenelset branch;
+        branch.cond() = equality_exprt(
+          target, typecast_exprt(label_address(i), target.type()));
+        branch.then_case() =
+          code_gotot(address_taken_labels[i]->getName().str());
+        dispatch.copy_to_operands(branch);
+      }
 
-      new_expr = code_goto;
+      code_assertt unreached{false_exprt()};
+      get_start_location_from_stmt(stmt, unreached.location());
+      unreached.location().comment("invalid computed goto target");
+      dispatch.copy_to_operands(unreached);
+
+      new_expr = dispatch;
     }
 
     break;

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -18,6 +18,7 @@ class ASTContext;
 class SourceManager;
 class FunctionDecl;
 class Decl;
+class LabelDecl;
 class VarDecl;
 class ParmVarDecl;
 class RecordDecl;
@@ -121,6 +122,17 @@ protected:
   clang::SourceManager *sm;
 
   const clang::FunctionDecl *current_functionDecl;
+
+  /** Address-taken labels of the function being converted, in the order the
+   *  addresses appear. A label has no storage, so `&&L` lowers to its 1-based
+   *  position cast to a pointer and `goto *p` to an equality chain over those
+   *  positions. Collected up front because a label's address may be taken
+   *  after the indirect goto that jumps to it. A vector, not a map keyed on
+   *  the decl: pointer order varies per run, and the chain it emits has to be
+   *  reproducible (GCC computed goto, issue #4083). */
+  std::vector<const clang::LabelDecl *> address_taken_labels;
+
+  void collect_address_taken_labels(const clang::Stmt &body);
 
   bool convert_builtin_types();
   virtual bool convert_top_level_decl();


### PR DESCRIPTION
`&&L` produced an `address_of` over a label expression that did not survive to symex, and `goto *p` errored out unless clang could constant-fold the target, which it almost never can.

Number the address-taken labels of each function and lower `&&L` to its number, `goto *p` to an equality chain over them, and an unmatched target to an assertion. The label set is stacked across nested bodies, since a lambda's call operator is converted while the enclosing body is still mid-conversion.

Note that a function with several dispatch sites needs `--unwind`: each site can branch to every address-taken label, so the CFG becomes cyclic even for straight-line code.

Fixes #4083