### PR TITLE
[python] Locate a bare expression statement at its source line

### DIFF
--- a/regression/python/docstring_located/main.py
+++ b/regression/python/docstring_located/main.py
@@ -1,0 +1,22 @@
+"""Module docstring: a bare string-literal statement.
+
+It lowers to a decayed string literal carrying no location of its own, which
+the native body dispatcher declined -- forcing the enclosing function back to
+the legacy body path.
+"""
+
+
+def annotated(x: int) -> int:
+    """Function docstring, same shape."""
+    y = x + 1
+    return y
+
+
+def two_statements(x: int) -> int:
+    """Docstring followed by real work, so the fallback would be observable."""
+    "a second bare string-literal statement"
+    return annotated(x) + 1
+
+
+assert annotated(1) == 2
+assert two_statements(1) == 3

--- a/regression/python/docstring_located/test.desc
+++ b/regression/python/docstring_located/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/docstring_located_fail/main.py
+++ b/regression/python/docstring_located_fail/main.py
@@ -1,0 +1,22 @@
+"""Module docstring: a bare string-literal statement.
+
+It lowers to a decayed string literal carrying no location of its own, which
+the native body dispatcher declined -- forcing the enclosing function back to
+the legacy body path.
+"""
+
+
+def annotated(x: int) -> int:
+    """Function docstring, same shape."""
+    y = x + 1
+    return y
+
+
+def two_statements(x: int) -> int:
+    """Docstring followed by real work, so the fallback would be observable."""
+    "a second bare string-literal statement"
+    return annotated(x) + 1
+
+
+assert annotated(1) == 2
+assert two_statements(1) == 4

--- a/regression/python/docstring_located_fail/test.desc
+++ b/regression/python/docstring_located_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -5771,7 +5771,16 @@ exprt python_converter::get_block(
         // body dispatcher declines an unlocated expression statement, and that
         // was ~87 % of the Python corpus's genuine declines
         // (docs/roadmap/frontends-to-irep2.md §13).
-        code_stmt.location() = get_location_from_decl(element);
+        //
+        // Fill in only when the statement has no usable location of its own.
+        // Assigning unconditionally clobbers one that is already set, and a
+        // locationt carries more than a position: __ESBMC_assert's message
+        // rides in its comment field, so overwriting it turns a modelled
+        // rejection ("Counter.most_common is not modelled") into a bare
+        // "assertion 0".
+        const locationt &here = code_stmt.location();
+        if (here.is_nil() || here.get_file().empty())
+          code_stmt.location() = get_location_from_decl(element);
         block.move_to_operands(code_stmt);
       }
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -5765,6 +5765,13 @@ exprt python_converter::get_block(
       if (expr != empty)
       {
         codet code_stmt = convert_expression_to_code(expr);
+        // Every sibling statement handler stamps this; EXPR did not, so a bare
+        // expression statement -- most commonly a docstring, which lowers to a
+        // decayed string literal -- reached goto-convert unlocated. The native
+        // body dispatcher declines an unlocated expression statement, and that
+        // was ~87 % of the Python corpus's genuine declines
+        // (docs/roadmap/frontends-to-irep2.md §13).
+        code_stmt.location() = get_location_from_decl(element);
         block.move_to_operands(code_stmt);
       }
 


### PR DESCRIPTION
Phase 1 of `docs/roadmap/frontends-to-irep2.md`, fixing the site #6691 measured
as **~87 % of the Python corpus's genuine dispatcher declines**.

`get_block()`'s `EXPR` arm was the one statement handler that never stamped a
location — every sibling calls `get_location_from_decl`. So a bare expression
statement reached goto-convert unlocated, and `convert_native_rec` declines
those because the `OTHER` instruction carries that location directly. Each one
forced its **enclosing function** back to the legacy body path.

The statements are almost all **docstrings**: a bare string literal lowers to a
decayed string constant, which is why the probe showed the declined operands as
`address_of(index(constant_array …))` with character codes.

**Effect:** `casting31` goes from **31 unlocated declines to 0**, and the
GOTO dump has **0** unlocated `OTHER` instructions where it previously had them.

**Gates.**
- Python suite: **369 passed / 1 failed**, the failure being
  `github_3719_4-nondet` — proven pre-existing against a control build earlier
  in this series. This is a converter change on the **default** path, so the
  suite tests it head-on.
- `--goto-functions-only` A/B against `--no-irep2-native-body`: **byte-identical
  on all three decline-heavy tests** (`casting31`, `dict_del7`,
  `complex_runtime_success_08`).
- The fix is shown to fire **before** the A/B was trusted — 31 → 0 under a
  probe. #6692 (now superseded) is the cautionary case: its A/B was also
  byte-identical, vacuously, because that change never executed. A no-op scores
  perfectly on byte-identity.

Supersedes #6692, which should be closed unmerged; #6693 records why it was
inert.

The new tests pin a module docstring, a function docstring, and a second bare
string-literal statement followed by real work, so a regression to the fallback
path would be observable.
