### PR TITLE
[test] Cover consteval and C++23 deducing this

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -255,6 +255,9 @@ set(REGRESSIONS_CPP17 esbmc-cpp17/cpp
 # list of C++20 test suites
 set(REGRESSIONS_CPP20 esbmc-cpp20/cpp)
 
+# list of C++23 test suites
+set(REGRESSIONS_CPP23 esbmc-cpp23/cpp)
+
 # enable test case geeneration
 set(TEST_GENERATION witnesses/test_case_generation)
 
@@ -286,6 +289,7 @@ if(APPLE)
                     ${REGRESSIONS_CPP14}
                     ${REGRESSIONS_CPP17}
                     ${REGRESSIONS_CPP20}
+                    ${REGRESSIONS_CPP23}
                     extensions
                     ${REGRESSIONS_CHERI}
                     ${REGRESSIONS_PYTHON}
@@ -350,6 +354,7 @@ else()
                     ${REGRESSIONS_SMTLIB}
                     ${REGRESSIONS_Z3}
                     incremental-smt
+                    ${REGRESSIONS_CPP23}
                     ${REGRESSIONS_CPP20}
                     ${REGRESSIONS_CPP17}
                     ${REGRESSIONS_CPP14}

--- a/regression/esbmc-cpp20/cpp/github_4084_consteval/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4084_consteval/main.cpp
@@ -1,0 +1,26 @@
+// C++20 consteval. Issue #4084 reported consteval and concepts as
+// unsupported, but the failure was clang rejecting the source for want of a
+// C++20 mode. Concepts already have coverage in github_4190_concept_combo;
+// this pins the consteval half.
+consteval int sq(int x)
+{
+  return x * x;
+}
+
+template <typename T>
+concept Num = requires(T a) { a + a; };
+
+template <Num T>
+T twice(T v)
+{
+  return v + v;
+}
+
+int main()
+{
+  constexpr int k = sq(5);
+  static_assert(k == 25);
+  __ESBMC_assert(k == 25, "consteval result reaches the model");
+  __ESBMC_assert(twice(3) == 6, "concept-constrained template instantiates");
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4084_consteval/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4084_consteval/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4084_consteval_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4084_consteval_fail/main.cpp
@@ -1,0 +1,14 @@
+// Negative counterpart of github_4084_consteval: the consteval result must
+// reach the model as its real value, so a contradicting claim is refuted
+// rather than vacuously held (issue #4084).
+consteval int sq(int x)
+{
+  return x * x;
+}
+
+int main()
+{
+  constexpr int k = sq(5);
+  __ESBMC_assert(k == 26, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4084_consteval_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4084_consteval_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp23/cpp/github_4085_deducing_this/main.cpp
+++ b/regression/esbmc-cpp23/cpp/github_4085_deducing_this/main.cpp
@@ -1,0 +1,36 @@
+// C++23 explicit object parameters ("deducing this"). Issue #4085 reported
+// these as unsupported, but the failure was `explicit object parameters are
+// incompatible with C++ standards before C++2b` -- clang rejecting the source
+// because no C++23 mode was requested. Under --std c++23 each form converts.
+struct S
+{
+  int v;
+  int by_val(this S self)
+  {
+    return self.v + 1;
+  }
+  int by_ref(this S &self)
+  {
+    return self.v + 2;
+  }
+  int by_cref(this const S &self)
+  {
+    return self.v + 3;
+  }
+};
+
+int main()
+{
+  S s{10};
+  __ESBMC_assert(s.by_val() == 11, "explicit object parameter by value");
+  __ESBMC_assert(s.by_ref() == 12, "explicit object parameter by reference");
+  __ESBMC_assert(s.by_cref() == 13, "explicit object parameter by const ref");
+
+  // The recursive-lambda idiom deducing this was introduced for.
+  int n = 5;
+  auto f = [n](this auto const &self, int k) -> int {
+    return k <= 0 ? n : self(k - 1);
+  };
+  __ESBMC_assert(f(3) == 5, "recursive lambda via deducing this");
+  return 0;
+}

--- a/regression/esbmc-cpp23/cpp/github_4085_deducing_this/test.desc
+++ b/regression/esbmc-cpp23/cpp/github_4085_deducing_this/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp23/cpp/github_4085_deducing_this_fail/main.cpp
+++ b/regression/esbmc-cpp23/cpp/github_4085_deducing_this_fail/main.cpp
@@ -1,0 +1,18 @@
+// Negative counterpart of github_4085_deducing_this: the explicit object
+// parameter must carry the real object through, so a claim contradicting it
+// is refuted rather than vacuously held (issue #4085).
+struct S
+{
+  int v;
+  int by_ref(this S &self)
+  {
+    return self.v + 2;
+  }
+};
+
+int main()
+{
+  S s{10};
+  __ESBMC_assert(s.by_ref() == 99, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp23/cpp/github_4085_deducing_this_fail/test.desc
+++ b/regression/esbmc-cpp23/cpp/github_4085_deducing_this_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23
+^VERIFICATION FAILED$


### PR DESCRIPTION
Both features were reported unsupported, but the failures quoted in the issues are clang rejecting the source for want of a C++20 / C++23 mode (`explicit object parameters are incompatible with C++ standards before C++2b`) rather than a conversion gap. Under the right `--std` each converts and verifies.

Pin the working behaviour so it cannot regress silently, and add the C++23 suite the deducing-this tests need. Structured bindings (#4082) already have coverage in `github_4377_structured_binding`, and concepts in `github_4190_concept_combo`, so neither is duplicated here.

Fixes #4084
Fixes #4085