### PR TITLE
[python] Convert an array-typed assignment in python_adjust

### DIFF
--- a/regression/python/python_irep2_adjust_only_array_assign/main.py
+++ b/regression/python/python_irep2_adjust_only_array_assign/main.py
@@ -1,0 +1,12 @@
+# A char[1] string literal assigned to a variable carrying the #5571
+# fixed-width tuple-string representation. Under --python-irep2-adjust-only the
+# assignment reached the solver unconverted and symex synthesised an
+# array-to-array typecast that convert_typecast has no arm for.
+def f(pairs: list[tuple[str, str]]) -> str:
+    s = ""
+    for u, v in pairs:
+        s = v
+    return s
+
+
+assert f([("A", "B")]) == "B"

--- a/regression/python/python_irep2_adjust_only_array_assign/test.desc
+++ b/regression/python/python_irep2_adjust_only_array_assign/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_only_array_assign_fail/main.py
+++ b/regression/python/python_irep2_adjust_only_array_assign_fail/main.py
@@ -1,0 +1,12 @@
+# A char[1] string literal assigned to a variable carrying the #5571
+# fixed-width tuple-string representation. Under --python-irep2-adjust-only the
+# assignment reached the solver unconverted and symex synthesised an
+# array-to-array typecast that convert_typecast has no arm for.
+def f(pairs: list[tuple[str, str]]) -> str:
+    s = ""
+    for u, v in pairs:
+        s = v
+    return s
+
+
+assert f([("A", "B")]) == "A"

--- a/regression/python/python_irep2_adjust_only_array_assign_fail/test.desc
+++ b/regression/python/python_irep2_adjust_only_array_assign_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -616,6 +616,30 @@ void python_adjust::adjust_expr(expr2tc &expr)
       if (source != a.source)
         expr = code_assign2tc(a.target, source, a.location);
     }
+    else if (
+      is_array_type(a.target->type) && is_array_type(a.source->type) &&
+      is_constant_array2t(a.source))
+    {
+      // An array-typed source into an array-typed target, which every arm above
+      // declines because they all guard on a pointer target. `s = ""` where `s`
+      // carries the #5571 fixed-width tuple-string representation assigns a
+      // char[1] literal to a char[16]; the hop-off leaves the bare
+      // constant_array, and symex then synthesises the array-to-array typecast
+      // that convert_typecast has no arm for.
+      //
+      // Reproduce legacy's two steps at this seam -- decay the literal to
+      // &lit[0], then cast that pointer to the target array type -- which is
+      // the shape clang_c_adjust emits and the only one the working default
+      // path produces. Phase 1 of
+      // docs/roadmap/scope-array-assignment-conversion.md; its Phase 0
+      // established that the conversion is the defect, not the literal or the
+      // char[0] declaration that every passing variant also carries.
+      const type2tc &elem = to_array_type(a.source->type).subtype;
+      expr2tc decayed = address_of2tc(
+        elem, index2tc(elem, a.source, gen_zero(index_type2())));
+      expr = code_assign2tc(
+        a.target, typecast2tc(a.target->type, decayed), a.location);
+    }
   }
   else if (
     is_code_ifthenelse2t(expr) &&

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -635,8 +635,8 @@ void python_adjust::adjust_expr(expr2tc &expr)
       // established that the conversion is the defect, not the literal or the
       // char[0] declaration that every passing variant also carries.
       const type2tc &elem = to_array_type(a.source->type).subtype;
-      expr2tc decayed = address_of2tc(
-        elem, index2tc(elem, a.source, gen_zero(index_type2())));
+      expr2tc decayed =
+        address_of2tc(elem, index2tc(elem, a.source, gen_zero(index_type2())));
       expr = code_assign2tc(
         a.target, typecast2tc(a.target->type, decayed), a.location);
     }


### PR DESCRIPTION
Phase 1 of `docs/roadmap/scope-array-assignment-conversion.md`, implementing the
layer its Phase 0 (#6699) selected. This clears **one of the two mechanisms
blocking the `python_adjust` flip**.

`s = ""` where `s` carries the #5571 fixed-width tuple-string representation
assigns a `char[1]` literal to a `char[16]`. Every existing arm declines it —
the array-to-pointer decay arm and the Phase 2 assignment arm both guard on a
**pointer** target, while this needs an **array** target. The hop-off left the
bare `constant_array`, and symex then synthesised the array-to-array typecast
`convert_typecast` has no arm for: `ERROR: Typecast for unexpected type`.

The arm reproduces legacy's two steps at the seam — decay the literal to
`&lit[0]`, then cast that pointer to the target array type — which is the shape
`clang_c_adjust` emits and the only one the working default path produces.

**Gates.**
- **G1: both witnesses now match legacy** under `--python-irep2-adjust-only`.
  `github_5571_tuple_str_annotation` SUCCESSFUL, `github_5571_fail` FAILED —
  clearing both tests the coupled-arith scope re-homed out of its own G3 (§13.1).
- **G2 (anti-masking) holds:** `neural-net_fail` still reports FAILED. This is
  the gate a conversion added at an assignment seam broke once before (that
  scope's §9.3), so it is not optional.
- **G3 default path:** unaffected by construction — `python_adjust` runs only
  under `--python-irep2-adjust[-only]`, both default-off
  (`python_language.cpp:299,330`). Asserted anyway: 314-test default-path slice
  clean. (One reported failure,
  `threading_thread_subclass_func_scope_unsupported`, is a stale ctest
  registration — the directory was removed by #6666.)
- Hop-off vs legacy verdict parity: **9/9** on an unbiased slice.

**Not claimed:** G5 dual-solver, and the whole-corpus census. Those are the
coupled scope's Phase 3 gates, not this one's.

The other blocker — the §9.4 "second mechanism" — is separately established as
**not fixable in the frontend** (#6685 §16), so the flip still needs that work
before Phase 3.
