### PR TITLE
[python] Reconcile bool and float/int comparison operands in python_adjust

### DIFF
--- a/regression/python/python_irep2_adjust_only_cmp_mixed/main.py
+++ b/regression/python/python_irep2_adjust_only_cmp_mixed/main.py
@@ -1,0 +1,12 @@
+# Two comparison shapes that reached the solver unreconciled under
+# --python-irep2-adjust-only: `x is True` builds floatbv == bool (bitwuzla
+# mk_eq sort-width abort), and a chained comparison against integer bounds
+# builds lessthanequal over floatbv and signedbv (convert_ast_node signedbv
+# assertion).
+is_even = lambda x: x % 2 == 0
+assert is_even(4) is True
+assert is_even(5) is False
+
+between = lambda x: 0 <= x <= 10
+assert between(5) is True
+assert between(-1) is False

--- a/regression/python/python_irep2_adjust_only_cmp_mixed/test.desc
+++ b/regression/python/python_irep2_adjust_only_cmp_mixed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_irep2_adjust_only_cmp_mixed_fail/main.py
+++ b/regression/python/python_irep2_adjust_only_cmp_mixed_fail/main.py
@@ -1,0 +1,12 @@
+# Two comparison shapes that reached the solver unreconciled under
+# --python-irep2-adjust-only: `x is True` builds floatbv == bool (bitwuzla
+# mk_eq sort-width abort), and a chained comparison against integer bounds
+# builds lessthanequal over floatbv and signedbv (convert_ast_node signedbv
+# assertion).
+is_even = lambda x: x % 2 == 0
+assert is_even(4) is True
+assert is_even(5) is False
+
+between = lambda x: 0 <= x <= 10
+assert between(5) is True
+assert between(-1) is True

--- a/regression/python/python_irep2_adjust_only_cmp_mixed_fail/test.desc
+++ b/regression/python/python_irep2_adjust_only_cmp_mixed_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--python-irep2-adjust-only
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_adjust.cpp
+++ b/src/python-frontend/python_adjust.cpp
@@ -379,6 +379,29 @@ void python_adjust::adjust_expr(expr2tc &expr)
     // non-boolean sort and trips bitwuzla's mk_not assert. not2t is immutable.
     expr = not2tc(typecast2tc(get_bool_type(), to_not2t(expr).value));
   }
+  else if (is_equality2t(expr) || is_notequal2t(expr))
+  {
+    // Python's `x is True` builds `floatbv == bool`, which reaches bitwuzla's
+    // mk_eq with 64- and 1-bit sorts and aborts. Legacy routes == and !=
+    // through adjust_expr_rel, whose gen_typecast_arithmetic promotes the
+    // Boolean;
+    // python_adjust had no equality arm at all, so nothing did. Restricted to a
+    // Boolean paired with a number: the only shape measured to reach here
+    // unreconciled (docs/roadmap/scope-relational-float-reconciliation.md
+    // §15, §17). A wider rule would re-open gap-2.
+    std::vector<expr2tc *> ops;
+    expr->Foreach_operand([&ops](expr2tc &op) { ops.push_back(&op); });
+
+    auto number = [](const type2tc &t) {
+      return is_bv_type(t) || is_floatbv_type(t) || is_fixedbv_type(t);
+    };
+
+    if (
+      ops.size() == 2 &&
+      ((is_bool_type((*ops[0])->type) && number((*ops[1])->type)) ||
+       (number((*ops[0])->type) && is_bool_type((*ops[1])->type))))
+      c_implicit_typecast_arithmetic(*ops[0], *ops[1], ns);
+  }
   else if (
     is_lessthan2t(expr) || is_lessthanequal2t(expr) || is_greaterthan2t(expr) ||
     is_greaterthanequal2t(expr))
@@ -403,10 +426,24 @@ void python_adjust::adjust_expr(expr2tc &expr)
     std::vector<expr2tc *> ops;
     expr->Foreach_operand([&ops](expr2tc &op) { ops.push_back(&op); });
 
+    // The second admission: one side floating point, the other an integer.
+    // `0 <= x <= 10` with a float `x` trips convert_ast_node's signedbv
+    // assertion. Deliberately NOT a same-kind width promotion (char vs int):
+    // that is the traffic gap-2 showed diverges corpus-wide over the
+    // operational-model bodies. §12's census measured the mixed float/integer
+    // traffic there as empty -- 1296 comparison nodes, zero mixed pairs -- so
+    // this admits exactly what that census covered and nothing more.
+    const bool float_int_mix =
+      ops.size() == 2 &&
+      ((is_floatbv_type((*ops[0])->type) && is_bv_type((*ops[1])->type)) ||
+       (is_bv_type((*ops[0])->type) && is_floatbv_type((*ops[1])->type)));
+
     if (
-      ops.size() == 2 && is_bv_type((*ops[0])->type) &&
-      is_bv_type((*ops[1])->type) &&
-      is_signedbv_type((*ops[0])->type) != is_signedbv_type((*ops[1])->type))
+      (ops.size() == 2 && is_bv_type((*ops[0])->type) &&
+       is_bv_type((*ops[1])->type) &&
+       is_signedbv_type((*ops[0])->type) !=
+         is_signedbv_type((*ops[1])->type)) ||
+      float_int_mix)
     {
       // The expr2tc overload, not the legacy exprt one clang_c_adjust calls:
       // same usual-arithmetic-conversion rule with no migrate round-trip, so an


### PR DESCRIPTION
Implements what #6701's §17 established, narrowed to the traffic §12 actually
measured. **One gate is still outstanding — see Gates.**

Two shapes reached the solver unreconciled under `--python-irep2-adjust-only`:

| shape | abort |
|---|---|
| `x is True` → `floatbv == bool` | bitwuzla `mk_eq`, 64- vs 1-bit sort mismatch |
| `0 <= x <= 10` with float `x` → `lessthanequal(floatbv, signedbv)` | `convert_ast_node:1563` signedbv assertion |

`python_adjust` had **no equality arm at all**, and its ordering arm admitted
only `bv`/`bv` pairs of differing signedness. This adds an equality arm
restricted to a Boolean paired with a number, and admits a float/integer pair in
the ordering arm.

**Deliberately not a same-kind width promotion** (char vs int). That is exactly
gap-2's traffic — the shape that made the general relational mirror diverge
corpus-wide over the operational-model bodies — and §12's census measured the
*mixed float/integer* traffic there as **empty**: 1296 comparison nodes, zero
mixed pairs. The rule admits what that census covered and nothing more.

**Gates.**
- `lambda15` now matches legacy under the hop-off (**SUCCESSFUL**) — the first
  of the §9.4 "second mechanism" witnesses to clear.
- **G2 anti-masking holds:** `neural-net_fail` (`--fixedbv`) still FAILED. A
  widened conversion is the shape that broke this gate once before.
- No regression on previously-passing hop-off tests sampled (`casting31`,
  `dict_del7`, `complex_runtime_success_08`, `github_5571`).
- Default path unaffected by construction: `python_adjust` runs only under
  `--python-irep2-adjust[-only]`, both default-off.
- `precedence2`, `sum_tuple`, `chained-comparison2_fail` still fail — unchanged,
  not regressed. They are the remaining three witnesses.

**Outstanding: the full gap-2 verdict-parity sweep** (hop-off vs legacy over a
corpus slice). Each test needs two runs and the dev machine has been contended
all session; the sweep timed out repeatedly. Ready for review while this
completes; it is being re-run now and the result will be posted here. Given the
rule is gated behind a default-off experimental flag, the blast radius of being
wrong is bounded — but that is a reason to gate it properly, not to skip it.

