### PR TITLE
[clang-frontend] Test a condition variable through its bool conversion

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4078_cond_decl/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4078_cond_decl/main.cpp
@@ -1,0 +1,44 @@
+// A condition that declares a variable of class type is tested through the
+// variable's conversion to bool. The frontend used to take the declaration
+// itself as the condition, which discarded that conversion and handed the
+// solver a struct where a boolean was required (issue #4078).
+struct c
+{
+  int a;
+  c(int x) : a(x)
+  {
+  }
+  operator bool()
+  {
+    return a != 0;
+  }
+};
+
+int k = 3;
+
+int main()
+{
+  int hit = 0;
+  if (c b = 0)
+    hit = 1;
+  __ESBMC_assert(hit == 0, "a zero-valued condition variable is false");
+
+  if (c b = 1)
+    hit = 2;
+  __ESBMC_assert(hit == 2, "a non-zero condition variable is true");
+
+  // The variable is rebuilt each iteration, so the loop sees k decrease.
+  int n = 0;
+  while (c b = k)
+  {
+    n++;
+    k--;
+  }
+  __ESBMC_assert(n == 3, "while re-evaluates the declaration each iteration");
+
+  int m = 0;
+  for (int j = 3; c b = j; j--)
+    m++;
+  __ESBMC_assert(m == 3, "for re-evaluates the declaration each iteration");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4078_cond_decl/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4078_cond_decl/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4078_cond_decl_continue/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4078_cond_decl_continue/main.cpp
@@ -1,0 +1,28 @@
+// The declaration and its bool test live in the loop body, but the loop stays
+// a for-loop so continue still reaches the increment. If continue jumped to
+// the re-declaration instead, j would never decrease and the loop would not
+// terminate (issue #4078).
+struct c
+{
+  int a;
+  c(int x) : a(x)
+  {
+  }
+  operator bool()
+  {
+    return a != 0;
+  }
+};
+
+int main()
+{
+  int n = 0;
+  for (int j = 3; c b = j; j--)
+  {
+    if (j == 2)
+      continue;
+    n++;
+  }
+  __ESBMC_assert(n == 2, "continue runs the increment and skips one body");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4078_cond_decl_continue/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4078_cond_decl_continue/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4078_cond_decl_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4078_cond_decl_fail/main.cpp
@@ -1,0 +1,23 @@
+// Negative counterpart of github_4078_cond_decl: the condition variable's
+// conversion to bool must carry its real value, so a claim contradicting it
+// is refuted rather than vacuously held (issue #4078).
+struct c
+{
+  int a;
+  c(int x) : a(x)
+  {
+  }
+  operator bool()
+  {
+    return a != 0;
+  }
+};
+
+int main()
+{
+  int hit = 0;
+  if (c b = 1)
+    hit = 1;
+  __ESBMC_assert(hit == 0, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4078_cond_decl_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4078_cond_decl_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3162,12 +3162,12 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       break;
     }
 
-    const clang::Stmt *cond_expr = ifstmt.getConditionVariableDeclStmt();
-    if (cond_expr == nullptr)
-      cond_expr = ifstmt.getCond();
-
+    // A condition that declares a variable keeps the declaration in
+    // getConditionVariableDeclStmt() and the contextual conversion to bool in
+    // getCond(). Taking the declaration as the condition drops the
+    // conversion, handing the backend a class-typed condition (issue #4078).
     exprt cond;
-    if (get_expr(*cond_expr, cond))
+    if (get_expr(*ifstmt.getCond(), cond))
       return true;
 
     exprt then;
@@ -3191,18 +3191,34 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       if_expr.copy_to_operands(else_expr);
     }
 
-    // C++17 init-statement: `if (init; cond)`. Wrap the init and the
-    // resulting if in a block so the init's side-effects (in particular,
-    // the initialiser of any variable declared there) are emitted.
+    // C++17 init-statement: `if (init; cond)`, and a condition that declares
+    // a variable: `if (T v = e)`. Both put statements before the branch, so
+    // wrap them and the resulting if in a block; the init runs first.
+    code_blockt block;
+    bool needs_block = false;
+
     if (const clang::Stmt *init_stmt = ifstmt.getInit())
     {
       exprt init;
       if (get_expr(*init_stmt, init))
         return true;
       convert_expression_to_code(init);
-
-      code_blockt block;
       block.move_to_operands(init);
+      needs_block = true;
+    }
+
+    if (const clang::Stmt *cond_decl = ifstmt.getConditionVariableDeclStmt())
+    {
+      exprt decl;
+      if (get_expr(*cond_decl, decl))
+        return true;
+      convert_expression_to_code(decl);
+      block.move_to_operands(decl);
+      needs_block = true;
+    }
+
+    if (needs_block)
+    {
       block.copy_to_operands(if_expr);
       new_expr = block;
     }
@@ -3258,12 +3274,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     const clang::WhileStmt &while_stmt =
       static_cast<const clang::WhileStmt &>(stmt);
 
-    const clang::Stmt *cond_expr = while_stmt.getConditionVariableDeclStmt();
-    if (cond_expr == nullptr)
-      cond_expr = while_stmt.getCond();
-
     exprt cond;
-    if (get_expr(*cond_expr, cond))
+    if (get_expr(*while_stmt.getCond(), cond))
       return true;
 
     codet body = code_skipt();
@@ -3273,8 +3285,36 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     convert_expression_to_code(body);
 
     code_whilet code_while;
-    code_while.cond() = cond;
-    code_while.body() = body;
+
+    // `while (T v = e)` declares v afresh on every iteration and tests its
+    // conversion to bool, so the declaration belongs at the top of the body
+    // -- which is also where continue lands -- rather than in the condition,
+    // where it would displace the conversion (issue #4078).
+    if (
+      const clang::Stmt *cond_decl = while_stmt.getConditionVariableDeclStmt())
+    {
+      exprt decl;
+      if (get_expr(*cond_decl, decl))
+        return true;
+      convert_expression_to_code(decl);
+
+      code_ifthenelset leave;
+      leave.cond() = gen_not(cond);
+      leave.then_case() = code_breakt();
+
+      code_blockt guarded;
+      guarded.move_to_operands(decl);
+      guarded.copy_to_operands(leave);
+      guarded.copy_to_operands(body);
+
+      code_while.cond() = true_exprt();
+      code_while.body() = guarded;
+    }
+    else
+    {
+      code_while.cond() = cond;
+      code_while.body() = body;
+    }
 
     new_expr = code_while;
     break;
@@ -3319,13 +3359,10 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
         return true;
 
     convert_expression_to_code(init);
-    const clang::Stmt *cond_expr = for_stmt.getConditionVariableDeclStmt();
-    if (cond_expr == nullptr)
-      cond_expr = for_stmt.getCond();
 
     exprt cond = true_exprt();
-    if (cond_expr)
-      if (get_expr(*cond_expr, cond))
+    if (const clang::Stmt *c = for_stmt.getCond())
+      if (get_expr(*c, cond))
         return true;
 
     codet inc = code_skipt();
@@ -3348,6 +3385,32 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     code_for.cond() = cond;
     code_for.iter() = inc;
     code_for.body() = body;
+
+    // `for (a; T v = e; b)` re-declares v each iteration. Moving the
+    // declaration and the test into the body keeps the loop a code_fort, so
+    // continue still reaches the increment (goto_convertt::convert_for sets
+    // the continue target there) while v is rebuilt on every pass -- putting
+    // the declaration in the condition would drop its conversion to bool,
+    // and putting it in the init would evaluate it once (issue #4078).
+    if (const clang::Stmt *cond_decl = for_stmt.getConditionVariableDeclStmt())
+    {
+      exprt decl;
+      if (get_expr(*cond_decl, decl))
+        return true;
+      convert_expression_to_code(decl);
+
+      code_ifthenelset leave;
+      leave.cond() = gen_not(cond);
+      leave.then_case() = code_breakt();
+
+      code_blockt guarded;
+      guarded.move_to_operands(decl);
+      guarded.copy_to_operands(leave);
+      guarded.copy_to_operands(body);
+
+      code_for.cond() = true_exprt();
+      code_for.body() = guarded;
+    }
 
     new_expr = code_for;
     break;


### PR DESCRIPTION
`if`/`while`/`for` took `getConditionVariableDeclStmt()` as the condition whenever one was present, discarding the `getCond()` expression that carries the contextual conversion to `bool`. A class-typed condition variable then reached the backend unconverted — z3 rejects it as `Sorts |struct_type_struct c| and Bool are incompatible`, and bitwuzla silently drops it.

Emit the declaration ahead of the branch, and inside the loop body for the two loops so it is rebuilt on every iteration. The for-loop deliberately stays a `code_fort` rather than folding into a `while`, because `goto_convertt::convert_for` points `continue` at the increment.

Two notes beyond the issue text: this was never `for`-specific (`if` and `while` were equally broken, just silently), and three of the four cited reproducers already pass on master, so the "18 programs" count is stale.

Fixes #4078