### PR TITLE
[clang-cpp] Give a captureless lambda's function pointer a body

### DIFF
--- a/regression/esbmc-cpp11/github_4077_lambda_fn_ptr/main.cpp
+++ b/regression/esbmc-cpp11/github_4077_lambda_fn_ptr/main.cpp
@@ -1,0 +1,29 @@
+// A captureless lambda converts to a function pointer through an implicit
+// conversion operator that returns the closure's static invoker. Both are
+// implicit members, and both used to be skipped, so the conversion was
+// bodyless and yielded an invalid pointer; clang also leaves the invoker's
+// forwarding body to CodeGen, which never runs here (issue #4077).
+int g = 0;
+
+void run(void (*f)(int))
+{
+  f(5);
+}
+
+int main()
+{
+  void (*p)() = [] { g = 7; };
+  p();
+  __ESBMC_assert(g == 7, "the lambda body runs through the pointer");
+
+  int (*q)(int, int) = [](int a, int b) { return a * 10 + b; };
+  __ESBMC_assert(q(3, 4) == 34, "arguments and return value are forwarded");
+
+  run([](int v) { g = v * 2; });
+  __ESBMC_assert(g == 10, "converted at a call site too");
+
+  auto lam = [](int a) { return a + 1; };
+  int (*r)(int) = lam;
+  __ESBMC_assert(r(1) == lam(1), "pointer and closure calls agree");
+  return 0;
+}

--- a/regression/esbmc-cpp11/github_4077_lambda_fn_ptr/test.desc
+++ b/regression/esbmc-cpp11/github_4077_lambda_fn_ptr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/github_4077_lambda_fn_ptr_fail/main.cpp
+++ b/regression/esbmc-cpp11/github_4077_lambda_fn_ptr_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative counterpart of github_4077_lambda_fn_ptr: the call through the
+// pointer must carry the lambda's real effect, so a claim contradicting it is
+// refuted rather than vacuously held -- which is what a bodyless invoker
+// would have produced (issue #4077).
+int g = 0;
+
+int main()
+{
+  void (*p)() = [] { g = 7; };
+  p();
+  __ESBMC_assert(g == 0, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp11/github_4077_lambda_fn_ptr_fail/test.desc
+++ b/regression/esbmc-cpp11/github_4077_lambda_fn_ptr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 3
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -403,9 +403,13 @@ bool clang_cpp_convertert::get_method(
   // Copy assignment Operator/Move assignment Operator
   // A compiler-generated default ctor/dtor is considered implicit, but we have
   // to parse it.
+  // A captureless lambda's conversion-to-function-pointer operator and the
+  // static invoker it returns are implicit too, and skipping them left the
+  // conversion bodyless, so the pointer it yielded was invalid (issue #4077).
   if (
     md.isImplicit() && !is_ConstructorOrDestructor(md) &&
-    !is_CopyOrMoveOperator(md))
+    !is_CopyOrMoveOperator(md) && !md.isLambdaStaticInvoker() &&
+    !(md.getParent()->isLambda() && llvm::isa<clang::CXXConversionDecl>(md)))
     return false;
 
   if (clang_c_convertert::get_function(md, new_expr))
@@ -1985,11 +1989,80 @@ bool clang_cpp_convertert::build_destructor_chain(
   return false;
 }
 
+bool clang_cpp_convertert::build_lambda_static_invoker(
+  const clang::CXXMethodDecl &invoker,
+  exprt &new_expr)
+{
+  const clang::CXXRecordDecl *closure = invoker.getParent();
+  const clang::CXXMethodDecl *call_op = closure->getLambdaCallOperator();
+  if (call_op == nullptr)
+    return true;
+
+  typet closure_type;
+#if CLANG_VERSION_MAJOR >= 22
+  clang::QualType closure_qual_type =
+    closure->getASTContext().getCanonicalTagType(closure);
+  if (get_type(*closure_qual_type.getTypePtr(), closure_type))
+#else
+  if (get_type(*closure->getTypeForDecl(), closure_type))
+#endif
+    return true;
+
+  exprt callee;
+  if (get_decl_ref(*call_op, callee))
+    return true;
+
+  // The lambda is captureless -- that is the only way a static invoker is
+  // formed -- so the closure carries no state and a fresh one is as good as
+  // the original.
+  symbolt &obj = anon_symbol.new_symbol(context, closure_type, "lambda_self");
+  obj.lvalue = true;
+  obj.file_local = true;
+
+  side_effect_expr_function_callt call;
+  call.function() = callee;
+  call.type() = static_cast<const code_typet &>(callee.type()).return_type();
+  call.arguments().push_back(address_of_exprt(symbol_expr(obj)));
+  for (const auto *param : invoker.parameters())
+  {
+    exprt arg;
+    if (get_decl_ref(*param, arg))
+      return true;
+    call.arguments().push_back(arg);
+  }
+
+  code_blockt body;
+  body.copy_to_operands(code_declt(symbol_expr(obj)));
+  if (call.type().is_empty())
+  {
+    codet expr_stmt("expression");
+    expr_stmt.copy_to_operands(call);
+    body.move_to_operands(expr_stmt);
+  }
+  else
+  {
+    code_returnt ret;
+    ret.return_value() = call;
+    body.copy_to_operands(ret);
+  }
+
+  new_expr = body;
+  return false;
+}
+
 bool clang_cpp_convertert::get_function_body(
   const clang::FunctionDecl &fd,
   exprt &new_expr,
   const code_typet &ftype)
 {
+  // Clang leaves a lambda's static invoker bodyless in the AST -- the
+  // forwarding body is synthesised in CodeGen, which never runs here -- so a
+  // captureless lambda converted to a function pointer called into an empty
+  // function (issue #4077).
+  if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(&fd))
+    if (md->isLambdaStaticInvoker())
+      return build_lambda_static_invoker(*md, new_expr);
+
   // For implicit or explicitly-defaulted destructors, Clang does not
   // synthesise a body (hasBody() returns false), leaving symbol.value as nil.
   // Start with an empty block; the member/base destructor chain is appended

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -94,6 +94,12 @@ protected:
     exprt &new_expr,
     const code_typet &ftype) override;
 
+  /** Body for a lambda's static invoker: forward to the closure's
+   *  operator(). Clang synthesises this in CodeGen, so the AST has none. */
+  bool build_lambda_static_invoker(
+    const clang::CXXMethodDecl &invoker,
+    exprt &new_expr);
+
   /**
    *  Get function params for C++
    *  contains conversion routines specific to C++ class member functions


### PR DESCRIPTION
Converting a captureless lambda to a function pointer goes through two implicit members — the conversion operator, and the static invoker (`__invoke`) it returns. The implicit-method filter dropped both, so the conversion was bodyless and the pointer it produced was invalid: `f()` reported `dereference failure: invalid pointer`.

Clang additionally leaves the invoker's forwarding body to CodeGen, which never runs here, so it is synthesised: call the closure's `operator()` on a fresh closure object. That is exact rather than approximate, because a lambda only gains a static invoker when it captures nothing.

Found while triaging #4077. Worth noting that issue's headline complaint appears already resolved — none of its five named reproducers segfaults, and three of the four remaining non-clean results are merely under-bounded `--unwind 5` runs. `g++.dg/cpp0x/initlist117.C` was the one real defect left, and it now verifies.

Fixes #4077