### PR TITLE
[clang-frontend] Emit nothing for a GNU local-label declaration

### DIFF
--- a/regression/esbmc/github_4076_gnu_local_label/main.c
+++ b/regression/esbmc/github_4076_gnu_local_label/main.c
@@ -1,9 +1,30 @@
 // GNU local labels. `__label__ l;` only scopes the name -- the label is placed
 // by its statement -- but the declaration used to convert to an expression,
 // and a DeclStmt's operands must be statements, so goto-convert aborted on
-// "label". Reduced from gcc.c-torture/execute/930406-1.c (issue #4076).
+// "label". Reduced from gcc.c-torture/execute/930406-1.c and 980526-1.c, both
+// of which this fixes (issue #4076).
+
+// 980526-1.c's shape: a static jump table over two local labels, indexed at
+// run time -- the interpreter idiom the extension exists for.
+static int dispatch(int x)
+{
+  __label__ lbl1;
+  __label__ lbl2;
+  static void *jtab[2];
+  jtab[0] = &&lbl1;
+  jtab[1] = &&lbl2;
+  goto *jtab[x];
+lbl1:
+  return 1;
+lbl2:
+  return 2;
+}
+
 int main(void)
 {
+  __ESBMC_assert(dispatch(0) == 1, "jump table selects the first label");
+  __ESBMC_assert(dispatch(1) == 2, "jump table selects the second label");
+
   int x = 1;
 
   ({

--- a/regression/esbmc/github_4076_gnu_local_label/main.c
+++ b/regression/esbmc/github_4076_gnu_local_label/main.c
@@ -1,0 +1,31 @@
+// GNU local labels. `__label__ l;` only scopes the name -- the label is placed
+// by its statement -- but the declaration used to convert to an expression,
+// and a DeclStmt's operands must be statements, so goto-convert aborted on
+// "label". Reduced from gcc.c-torture/execute/930406-1.c (issue #4076).
+int main(void)
+{
+  int x = 1;
+
+  ({
+    __label__ mylabel;
+  mylabel:
+    x++;
+    if (x != 3)
+      goto mylabel;
+  });
+
+  __ESBMC_assert(x == 3, "the local-label loop runs to completion");
+
+  // A local label also has an address, and jumping through it must agree.
+  int hops = 0;
+  {
+    __label__ again;
+    void *target = &&again;
+  again:
+    hops++;
+    if (hops < 2)
+      goto *target;
+  }
+  __ESBMC_assert(hops == 2, "computed goto to a local label");
+  return 0;
+}

--- a/regression/esbmc/github_4076_gnu_local_label/test.desc
+++ b/regression/esbmc/github_4076_gnu_local_label/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4076_gnu_local_label_fail/main.c
+++ b/regression/esbmc/github_4076_gnu_local_label_fail/main.c
@@ -1,0 +1,18 @@
+// Negative counterpart of github_4076_gnu_local_label: the loop through the
+// local label really does run, so a claim that it does not is refuted rather
+// than vacuously held (issue #4076).
+int main(void)
+{
+  int x = 1;
+
+  ({
+    __label__ mylabel;
+  mylabel:
+    x++;
+    if (x != 3)
+      goto mylabel;
+  });
+
+  __ESBMC_assert(x == 2, "must not hold");
+  return 0;
+}

--- a/regression/esbmc/github_4076_gnu_local_label_fail/test.desc
+++ b/regression/esbmc/github_4076_gnu_local_label_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 5
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -104,18 +104,13 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
 
   switch (decl.getKind())
   {
-  // Label declaration
+  // GNU local label: `__label__ l;` only scopes the name, and the label
+  // itself is placed by the LabelStmt, so the declaration emits nothing. It
+  // reaches here inside a DeclStmt, whose operands must be statements --
+  // yielding an expression made goto-convert abort on "label" (issue #4076).
   case clang::Decl::Label:
-  {
-    const clang::LabelDecl &ld = static_cast<const clang::LabelDecl &>(decl);
-
-    exprt label("label", empty_typet());
-    label.identifier(ld.getName().str());
-    label.cmt_base_name(ld.getName().str());
-
-    new_expr = label;
+    new_expr = code_skipt();
     break;
-  }
 
   // Declaration of variables
   case clang::Decl::Var:


### PR DESCRIPTION
`__label__ l;` only scopes the name — the label itself is placed by its statement — but the declaration converted to an *expression*, and a DeclStmt's operands must be statements, so goto-convert aborted on "label". Emit a skip instead.

This is the SIGABRT in `gcc.c-torture/execute/930406-1.c`, cited in #4076. The other four reproducers named there already verify, so that issue's "102 test cases" count looks stale.

Fixes #4076