### PR TITLE
[c2goto] map CBMC's memory primitives onto ESBMC's memory model

### DIFF
--- a/regression/esbmc/github_2457-assume/main.c
+++ b/regression/esbmc/github_2457-assume/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdlib.h>
+
+/* Each assumption below is false under the real memory model, so main is
+   unreachable. Were the __CPROVER_* primitives havoc'd, every assumption would
+   be satisfiable and the assert(0) reachable. */
+int main()
+{
+  char a[4];
+  char *d = malloc(8);
+  __ESBMC_assume(__CPROVER_r_ok(a, 8));
+  __ESBMC_assume(__CPROVER_w_ok(a + 3, 2));
+  __ESBMC_assume(__CPROVER_OBJECT_SIZE(a) != 4);
+  __ESBMC_assume(__CPROVER_DYNAMIC_OBJECT(a));
+  __ESBMC_assume(!__CPROVER_same_object(a, a + 1));
+  __ESBMC_assume(!__CPROVER_DYNAMIC_OBJECT(d));
+  assert(0);
+  return 0;
+}

--- a/regression/esbmc/github_2457-assume/test.desc
+++ b/regression/esbmc/github_2457-assume/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --no-pointer-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2457/main.c
+++ b/regression/esbmc/github_2457/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdlib.h>
+int main() {
+  char a[4];
+  assert(__CPROVER_r_ok(a, 4));
+  assert(!__CPROVER_r_ok(a, 8));
+  assert(__CPROVER_r_ok(a + 2, 2));
+  assert(!__CPROVER_r_ok(a + 2, 3));
+  assert(!__CPROVER_r_ok((void *)0, 1));
+  assert(__CPROVER_OBJECT_SIZE(a) == 4);
+  assert(__CPROVER_OBJECT_SIZE((void *)0) == 0);
+  assert(__CPROVER_same_object(a, a + 1));
+  assert(__CPROVER_POINTER_OFFSET(a + 3) == 3);
+  assert(!__CPROVER_DYNAMIC_OBJECT(a));
+  assert(__CPROVER_LIVE_OBJECT(a));
+  char *d = malloc(8);
+  assert(__CPROVER_DYNAMIC_OBJECT(d));
+  assert(__CPROVER_w_ok(d, 8));
+  assert(!__CPROVER_rw_ok(d, 9));
+  free(d);
+  assert(!__CPROVER_LIVE_OBJECT(d));
+  assert(!__CPROVER_r_ok(d, 1));
+  return 0;
+}

--- a/regression/esbmc/github_2457/test.desc
+++ b/regression/esbmc/github_2457/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --no-pointer-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2457_fail/main.c
+++ b/regression/esbmc/github_2457_fail/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main()
+{
+  char a[4];
+  assert(__CPROVER_rw_ok(a, 8));
+  return 0;
+}

--- a/regression/esbmc/github_2457_fail/test.desc
+++ b/regression/esbmc/github_2457_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/builtin_libs.c
+++ b/src/c2goto/library/builtin_libs.c
@@ -250,3 +250,73 @@ __attribute__((annotate("__ESBMC_inf_size"))) _Bool __ESBMC_is_dynamic[1];
 
 __attribute__((annotate("__ESBMC_inf_size")))
 __SIZE_TYPE__ __ESBMC_alloc_size[1];
+
+/* CBMC memory primitives, mapped onto ESBMC's memory model (esbmc/esbmc#2457).
+ * Declared in esbmc_intrinsics.h; the semantics reproduced here are CBMC's
+ * doc/cprover-manual/memory-primitives.md. */
+
+__SIZE_TYPE__ __CPROVER_POINTER_OBJECT(const void *p)
+{
+  return __ESBMC_POINTER_OBJECT(p);
+}
+
+__PTRDIFF_TYPE__ __CPROVER_POINTER_OFFSET(const void *p)
+{
+  return __ESBMC_POINTER_OFFSET(p);
+}
+
+_Bool __CPROVER_same_object(const void *p, const void *q)
+{
+  return __ESBMC_same_object(p, q);
+}
+
+__SIZE_TYPE__ __CPROVER_OBJECT_SIZE(const void *p)
+{
+  return p == 0 ? 0 : __ESBMC_get_object_size(p);
+}
+
+_Bool __CPROVER_DYNAMIC_OBJECT(const void *p)
+{
+  return p != 0 && __ESBMC_is_dynamic[__ESBMC_POINTER_OBJECT(p)];
+}
+
+/* __ESBMC_alloc tracks dynamic allocation only: it stays false for a live
+ * static or automatic object, so liveness may only be read off it for objects
+ * __ESBMC_is_dynamic flags. */
+_Bool __CPROVER_LIVE_OBJECT(const void *p)
+{
+  if (p == 0)
+    return 0;
+  __UINTPTR_TYPE__ object = __ESBMC_POINTER_OBJECT(p);
+  return !__ESBMC_is_dynamic[object] || __ESBMC_alloc[object];
+}
+
+_Bool __CPROVER_WRITEABLE_OBJECT(const void *p)
+{
+  return __CPROVER_LIVE_OBJECT(p);
+}
+
+_Bool __CPROVER_r_ok(const void *p, __SIZE_TYPE__ size)
+{
+  if (!__CPROVER_LIVE_OBJECT(p))
+    return 0;
+  __PTRDIFF_TYPE__ offset = __ESBMC_POINTER_OFFSET(p);
+  if (offset < 0)
+    return 0;
+  __SIZE_TYPE__ object_size = __ESBMC_get_object_size(p);
+  if ((__SIZE_TYPE__)offset > object_size)
+    return 0;
+  return size <= object_size - (__SIZE_TYPE__)offset;
+}
+
+/* CBMC's memory is uniformly readable and writeable, so w_ok and rw_ok
+ * coincide with r_ok. */
+_Bool __CPROVER_w_ok(const void *p, __SIZE_TYPE__ size)
+{
+  return __CPROVER_r_ok(p, size);
+}
+
+_Bool __CPROVER_rw_ok(const void *p, __SIZE_TYPE__ size)
+{
+  return __CPROVER_r_ok(p, size);
+}

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -507,6 +507,21 @@ extern __SIZE_TYPE__ __ESBMC_alloc_size[1];
 // Get object size
 __SIZE_TYPE__ __ESBMC_get_object_size(const void *);
 
+/* CBMC memory primitives (esbmc/esbmc#2457). Without these declarations the
+ * names are implicitly declared as int-returning functions and havoc'd, so a
+ * program written against CBMC verifies against nondet rather than against the
+ * memory model. Bodies live in src/c2goto/library/builtin_libs.c. */
+__SIZE_TYPE__ __CPROVER_POINTER_OBJECT(const void *);
+__PTRDIFF_TYPE__ __CPROVER_POINTER_OFFSET(const void *);
+_Bool __CPROVER_same_object(const void *, const void *);
+__SIZE_TYPE__ __CPROVER_OBJECT_SIZE(const void *);
+_Bool __CPROVER_DYNAMIC_OBJECT(const void *);
+_Bool __CPROVER_LIVE_OBJECT(const void *);
+_Bool __CPROVER_WRITEABLE_OBJECT(const void *);
+_Bool __CPROVER_r_ok(const void *, __SIZE_TYPE__);
+_Bool __CPROVER_w_ok(const void *, __SIZE_TYPE__);
+_Bool __CPROVER_rw_ok(const void *, __SIZE_TYPE__);
+
 // Contract predicate: indicates that a pointer points to freshly allocated memory
 // Signature: __ESBMC_is_fresh(p, size)
 // - p: The pointer itself, passed bare. const so that const-qualified pointer

--- a/unit/goto-programs/atomicity_check.test.cpp
+++ b/unit/goto-programs/atomicity_check.test.cpp
@@ -4,43 +4,44 @@
 #include "../testing-utils/goto_factory.h"
 #include <goto-programs/goto_atomicity_check.h>
 
-/// Returns true iff @p id names a user-defined function (not an ESBMC runtime
-/// or C library function).  User functions have IDs of the form c:@F@name
-/// where name does not begin with __ or come from a library source file.
-static bool is_user_function(const irep_idt &id)
+/// Path suffix of the file goto_factory writes the code under test to: its
+/// default test_name, under a fresh temporary directory.
+static const std::string test_file = "/test.c";
+
+/// Returns true iff @p instr came from the code under test rather than from a
+/// linked library.  Selecting on the source file rather than on the symbol name
+/// matters: the C library is always linked, several of its functions do touch
+/// globals and so are legitimately instrumented, and naming them is a moving
+/// target -- __ESBMC_*, __VERIFIER_* and __CPROVER_* all appear there today.
+static bool is_under_test(const goto_programt::instructiont &instr)
 {
-  const std::string &s = id.as_string();
-  return s.rfind("c:@F@", 0) == 0 && s.find("__ESBMC") == std::string::npos &&
-         s.find("__VERIFIER") == std::string::npos;
+  const std::string &f = instr.location.get_file().as_string();
+  return f.size() >= test_file.size() &&
+         f.compare(f.size() - test_file.size(), test_file.size(), test_file) ==
+           0;
 }
 
 /// Counts ASSERT instructions whose property tag is "atomicity"
-/// in user-defined functions only (excludes runtime/library functions).
+/// in the code under test only (excludes runtime/library functions).
 static unsigned count_atomicity_asserts(const goto_functionst &functions)
 {
   unsigned n = 0;
   for (const auto &kv : functions.function_map)
-  {
-    if (!is_user_function(kv.first))
-      continue;
     for (const auto &instr : kv.second.body.instructions)
-      if (instr.is_assert() && instr.location.property() == "atomicity")
+      if (
+        instr.is_assert() && instr.location.property() == "atomicity" &&
+        is_under_test(instr))
         n++;
-  }
   return n;
 }
 
-/// Returns true iff any user-defined function body contains an ATOMIC_BEGIN.
+/// Returns true iff the code under test contains an ATOMIC_BEGIN.
 static bool has_atomic_begin(const goto_functionst &functions)
 {
   for (const auto &kv : functions.function_map)
-  {
-    if (!is_user_function(kv.first))
-      continue;
     for (const auto &instr : kv.second.body.instructions)
-      if (instr.is_atomic_begin())
+      if (instr.is_atomic_begin() && is_under_test(instr))
         return true;
-  }
   return false;
 }
 


### PR DESCRIPTION
`__CPROVER_r_ok`, `__CPROVER_OBJECT_SIZE` and friends were undeclared, so ESBMC implicitly declared and havoc'd them — a program written against CBMC was verified against nondet rather than against the memory model. They are now declared in `esbmc_intrinsics.h` with bodies over `__ESBMC_POINTER_OBJECT`, `__ESBMC_POINTER_OFFSET`, `__ESBMC_get_object_size` and the allocation arrays.

Covers `POINTER_OBJECT`, `POINTER_OFFSET`, `same_object`, `OBJECT_SIZE`, `DYNAMIC_OBJECT`, `LIVE_OBJECT`, `WRITEABLE_OBJECT`, `r_ok`, `w_ok` and `rw_ok`. The goto-binary transcoder still lowers CBMC's `r_ok`/`w_ok`/`rw_ok` expression ids to `true` (`migrate.cpp`), which the `goto-transcoder/r_ok_false` and `cbmc_w_ok_false` KNOWNBUGs pin; that path is untouched here.

Fixes #2457