### PR TITLE
[regression] anchor a test's paths so they survive the runner's chdir

### DIFF
--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -424,7 +424,10 @@ class TestCase:
         assert os.path.exists(test_dir)
         assert os.path.exists(os.path.join(test_dir, "test.desc"))
         self.name = name
-        self.test_dir = test_dir
+        # A CHECK_JSON / CHECK_FILE / SEED_FILE test runs ESBMC in a private
+        # temporary cwd, where a test_dir relative to the invoking cwd no longer
+        # resolves. Anchor it here so every derived path survives the chdir.
+        self.test_dir = os.path.abspath(test_dir)
         self.test_args = None
         self.test_file = None
         self.test_mode = "CORE"

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -53,7 +53,8 @@ class CTest1(ParseTest):
     def _argument_list_checks(self, test_obj):
         argument_list = self.test_case.generate_run_argument_list("__test__")
         self.assertEqual(argument_list[0], "__test__")
-        self.assertEqual(argument_list[-1], "./esbmc-unix/00_bbuf_02/main.c")
+        self.assertEqual(argument_list[-1],
+                         os.path.abspath("./esbmc-unix/00_bbuf_02/main.c"))
         self.assertEqual(argument_list[1], "--unwind")
 
 
@@ -94,9 +95,11 @@ class CTest3(ParseTest):
 
     def _argument_list_checks(self, test_obj: TestCase):
         argument_list = self.test_case.generate_run_argument_list("__test__")
+        base = os.path.abspath("./esbmc-unix/00_account_01")
         expected = ['__test__',
-                    './esbmc-unix/00_account_01/account.c',
-                    '--no-slice', '--context-bound', '1', '--depth', '150', './esbmc-unix/00_account_01/test.c']
+                    os.path.join(base, 'account.c'),
+                    '--no-slice', '--context-bound', '1', '--depth', '150',
+                    os.path.join(base, 'test.c')]
         self.assertEqual(argument_list, expected, str(argument_list))
 
 
@@ -119,7 +122,8 @@ class CTest4(ParseTest):
     def _argument_list_checks(self, test_obj: TestCase):
         argument_list = self.test_case.generate_run_argument_list("__test__")
         expected = ['__test__',
-                    '--overflow-check', '--unwind', '3', '--32', './nonz3/29_exStbHwAcc/main.c']
+                    '--overflow-check', '--unwind', '3', '--32',
+                    os.path.abspath('./nonz3/29_exStbHwAcc/main.c')]
         self.assertEqual(argument_list, expected, str(argument_list))
 
 
@@ -130,8 +134,8 @@ class ToolTest1(CTest4):
         argument_list = self.test_case.generate_run_argument_list(
             "__tool_contains_spaces__ --param 1 __test__")
         expected = ['__tool_contains_spaces__ --param 1 __test__',
-                    '--overflow-check',
-                    '--unwind', '3', '--32', './nonz3/29_exStbHwAcc/main.c',]
+                    '--overflow-check', '--unwind', '3', '--32',
+                    os.path.abspath('./nonz3/29_exStbHwAcc/main.c')]
         self.assertEqual(argument_list, expected, str(argument_list))
 
 
@@ -142,9 +146,27 @@ class ToolTest2(CTest4):
         argument_list = self.test_case.generate_run_argument_list(
             '__tool_contains_no_spaces__', '--param', '1', '__test__')
         expected = ['__tool_contains_no_spaces__', '--param', '1', '__test__',
-                    '--overflow-check',
-                    '--unwind', '3', '--32', './nonz3/29_exStbHwAcc/main.c']
+                    '--overflow-check', '--unwind', '3', '--32',
+                    os.path.abspath('./nonz3/29_exStbHwAcc/main.c')]
         self.assertEqual(argument_list, expected, str(argument_list))
+
+
+class RelativeTestDirTest(unittest.TestCase):
+    """A CHECK_JSON / CHECK_FILE / SEED_FILE test runs ESBMC in a private
+    temporary cwd, so every path the runner hands ESBMC must be absolute
+    however the test directory was spelled (esbmc/esbmc#4331)."""
+
+    def test_paths_survive_a_chdir(self):
+        test_case = TestCase("./nonz3/29_exStbHwAcc", "29_exStbHwAcc")
+        source = test_case.generate_run_argument_list("__test__")[-1]
+        self.assertTrue(os.path.isabs(source), source)
+        with tempfile.TemporaryDirectory() as elsewhere:
+            cwd = os.getcwd()
+            try:
+                os.chdir(elsewhere)
+                self.assertTrue(os.path.exists(source), source)
+            finally:
+                os.chdir(cwd)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A `CHECK_JSON` / `CHECK_FILE` / `SEED_FILE` test runs ESBMC in a private temporary cwd, but `TestCase` kept `test_dir` exactly as spelled. Running such a test with a relative `--regression` path therefore made ESBMC fail to open its own source file. Absolutising `test_dir` once also makes a manual run agree with the CMake-driven one, which already passes absolute paths.

Adds a self-test that chdirs elsewhere and checks the source path still resolves; the existing expectations are rewritten against `os.path.abspath`.

Refs #4331