### PR TITLE
[clang-frontend] Rewrite four more builtins to the modelled names

### DIFF
--- a/regression/esbmc/builtin_mem_rewrites/main.c
+++ b/regression/esbmc/builtin_mem_rewrites/main.c
@@ -1,0 +1,30 @@
+// Clang's __builtin_ forms of the string/allocation functions are rewritten to
+// the names ESBMC models. memset, memcmp, strncpy and calloc were missing from
+// that list, so each was left unmodelled and its effect went nondet -- a
+// __builtin_memset'd struct kept garbage fields, which surfaced as a spurious
+// "dereference failure: invalid pointer" on
+// gcc.c-torture/execute/20000815-1.c.
+struct S
+{
+  int a;
+  int b;
+};
+
+int main(void)
+{
+  struct S e;
+  __builtin_memset(&e, 0, sizeof(e));
+  __ESBMC_assert(e.a == 0 && e.b == 0, "__builtin_memset zeroes the struct");
+
+  char x[4] = "abc", y[4] = "abc";
+  __ESBMC_assert(__builtin_memcmp(x, y, 4) == 0, "__builtin_memcmp compares");
+
+  char d[8];
+  __builtin_strncpy(d, "hi", 3);
+  __ESBMC_assert(d[0] == 'h' && d[2] == '\0', "__builtin_strncpy copies");
+
+  int *p = __builtin_calloc(2, sizeof(int));
+  if (p)
+    __ESBMC_assert(p[0] == 0 && p[1] == 0, "__builtin_calloc zeroes");
+  return 0;
+}

--- a/regression/esbmc/builtin_mem_rewrites/test.desc
+++ b/regression/esbmc/builtin_mem_rewrites/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/builtin_mem_rewrites_fail/main.c
+++ b/regression/esbmc/builtin_mem_rewrites_fail/main.c
@@ -1,0 +1,17 @@
+// Negative counterpart of builtin_mem_rewrites: the rewritten builtin has the
+// real effect, so a claim contradicting it is refuted rather than vacuously
+// held -- which is what the unmodelled, nondet version would have allowed.
+struct S
+{
+  int a;
+  int b;
+};
+
+int main(void)
+{
+  struct S e;
+  e.a = 5;
+  __builtin_memset(&e, 0, sizeof(e));
+  __ESBMC_assert(e.a == 5, "must not hold");
+  return 0;
+}

--- a/regression/esbmc/builtin_mem_rewrites_fail/test.desc
+++ b/regression/esbmc/builtin_mem_rewrites_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 12
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3844,9 +3844,13 @@ void clang_c_convertert::rewrite_builtin_ref(
 {
   static const std::list<std::string> builtins_to_rewrite = {
     "__builtin_malloc",
+    "__builtin_calloc",
     "__builtin_memcpy",
     "__builtin_memmove",
+    "__builtin_memset",
+    "__builtin_memcmp",
     "__builtin_strcpy",
+    "__builtin_strncpy",
     "__builtin_strcmp",
     "__builtin_free",
     "__builtin_strlen",


### PR DESCRIPTION
`rewrite_builtin_ref` maps clang's `__builtin_` forms onto the names ESBMC models, but `memset`, `memcmp`, `strncpy` and `calloc` were missing. Each was therefore left unmodelled and its effect went nondet — a `__builtin_memset`'d struct kept garbage fields, while plain `memset()` passes.

Clang emits these forms routinely, so this is a false-positive generator on ordinary code. It surfaced as a spurious `dereference failure: invalid pointer` on `gcc.c-torture/execute/20000815-1.c`, found while sweeping the reproducer sets behind #4076/#4077. Each target was checked to be genuinely modelled under its plain name before being added.

Note a rewritten call now runs the modelled loop, so `__builtin_memset` over a large object needs an adequate `--unwind`.