### PR TITLE
[python] recover a callable member's signature from the assigned parameter

### DIFF
--- a/regression/python/github_6640/main.py
+++ b/regression/python/github_6640/main.py
@@ -1,0 +1,14 @@
+from typing import Callable
+
+
+def act(x: int) -> int:
+    return x + 1
+
+
+class Holder:
+    def __init__(self, fn: Callable[[int], int]) -> None:
+        self.fn = fn
+
+
+h = Holder(act)
+assert h.fn(1) == 2

--- a/regression/python/github_6640/test.desc
+++ b/regression/python/github_6640/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6640_attribute_error_fail/main.py
+++ b/regression/python/github_6640_attribute_error_fail/main.py
@@ -1,0 +1,7 @@
+class Holder:
+    def __init__(self, v: int) -> None:
+        self.v = v
+
+
+h = Holder(1)
+assert h.missing(1) == 2

--- a/regression/python/github_6640_attribute_error_fail/test.desc
+++ b/regression/python/github_6640_attribute_error_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_6640_fail/main.py
+++ b/regression/python/github_6640_fail/main.py
@@ -1,0 +1,14 @@
+from typing import Callable
+
+
+def act(x: int) -> int:
+    return x + 1
+
+
+class Holder:
+    def __init__(self, fn: Callable[[int], int]) -> None:
+        self.fn = fn
+
+
+h = Holder(act)
+assert h.fn(1) == 3

--- a/regression/python/github_6640_fail/test.desc
+++ b/regression/python/github_6640_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -599,6 +599,38 @@ void python_converter::get_attributes_from_self(
     }
   }
 
+  auto is_callable_annotation = [](const nlohmann::json &annotation) {
+    return annotation.is_object() &&
+           annotation.value("_type", "") == "Subscript" &&
+           annotation.contains("value") && annotation["value"].is_object() &&
+           annotation["value"].value("id", "") == "Callable";
+  };
+
+  // Carry the signature when it is spelled: `Callable[[A, B], R]` parses as
+  // Subscript(slice=Tuple([List([A, B]), R])). A member typed `R (*)(A, B)`
+  // lets a call through it recover the return type; the bare pointer would
+  // leave the result nondet. Anything else (bare `Callable`, or an unspelled
+  // signature) keeps the generic function pointer.
+  auto callable_member_type =
+    [&](const nlohmann::json &annotation, const nlohmann::json &stmt) -> typet {
+    code_typet fn_type;
+    fn_type.return_type() = empty_typet();
+    const auto &slice = annotation["slice"];
+    if (
+      slice.is_object() && slice.value("_type", "") == "Tuple" &&
+      slice.contains("elts") && slice["elts"].size() == 2 &&
+      slice["elts"][0].value("_type", "") == "List")
+    {
+      for (const auto &arg : slice["elts"][0]["elts"])
+        fn_type.arguments().push_back(
+          code_typet::argumentt(get_type_from_annotation(arg, stmt)));
+      fn_type.return_type() = get_type_from_annotation(slice["elts"][1], stmt);
+    }
+    return fn_type.return_type().is_nil()
+             ? type_handler_.get_typet(std::string("Callable"))
+             : gen_pointer_type(fn_type);
+  };
+
   for (const auto &stmt : method_body)
   {
     if (
@@ -646,42 +678,9 @@ void python_converter::get_attributes_from_self(
         // `Callable[...]` is resolved on a different path that the pointer
         // form breaks (regression/python/callable4), so the mapping stays
         // local to members.
-        const bool member_is_callable =
-          stmt["annotation"]["_type"] == "Subscript" &&
-          stmt["annotation"].contains("value") &&
-          stmt["annotation"]["value"].is_object() &&
-          stmt["annotation"]["value"].contains("id") &&
-          stmt["annotation"]["value"]["id"] == "Callable";
-
-        typet type;
-        if (member_is_callable)
-        {
-          // Carry the signature when it is spelled: `Callable[[A, B], R]`
-          // parses as Subscript(slice=Tuple([List([A, B]), R])). A member
-          // typed `R (*)(A, B)` lets a call through it recover the return
-          // type; the bare pointer would leave the result nondet. Anything
-          // else (bare `Callable`, `Callable[..., R]`) keeps the generic
-          // function pointer.
-          code_typet fn_type;
-          fn_type.return_type() = empty_typet();
-          const auto &slice = stmt["annotation"]["slice"];
-          if (
-            slice.is_object() && slice.value("_type", "") == "Tuple" &&
-            slice.contains("elts") && slice["elts"].size() == 2 &&
-            slice["elts"][0].value("_type", "") == "List")
-          {
-            for (const auto &arg : slice["elts"][0]["elts"])
-              fn_type.arguments().push_back(
-                code_typet::argumentt(get_type_from_annotation(arg, stmt)));
-            fn_type.return_type() =
-              get_type_from_annotation(slice["elts"][1], stmt);
-          }
-          type = fn_type.return_type().is_nil()
-                   ? type_handler_.get_typet(std::string("Callable"))
-                   : gen_pointer_type(fn_type);
-        }
-        else
-          type = get_type_from_annotation(stmt["annotation"], stmt);
+        typet type = is_callable_annotation(stmt["annotation"])
+                       ? callable_member_type(stmt["annotation"], stmt)
+                       : get_type_from_annotation(stmt["annotation"], stmt);
         if (type.is_nil() || type.is_empty())
         {
           log_warning(
@@ -825,6 +824,21 @@ void python_converter::get_attributes_from_self(
           rhs_is_aliased_name && type.id() == "symbol" &&
           json_utils::is_class(annotated_type, *ast_json))
           type = gen_pointer_type(type);
+
+        // A bare `Callable` is what the annotation pass infers for an
+        // unannotated `self.fn = fn`; the signature is lost because the
+        // inference carries a type *name*. Recover it from the parameter the
+        // RHS names, so a call through the member resolves rather than being
+        // reported as an AttributeError (esbmc/esbmc#6640).
+        if (annotated_type == "Callable" && rhs_is_aliased_name)
+        {
+          auto param =
+            param_annotations.find(stmt["value"].value("id", std::string()));
+          if (
+            param != param_annotations.end() &&
+            is_callable_annotation(param->second))
+            type = callable_member_type(param->second, stmt);
+        }
       }
 
       if (!clazz.has_component(attr_name))
@@ -848,6 +862,7 @@ void python_converter::get_attributes_from_self(
       // A member is initialized with something that might be not annotated
       typet type = any_type();
       const std::string &attr_name = stmt["targets"][0]["attr"];
+
       if (!clazz.has_component(attr_name))
       {
         struct_typet::componentt comp = python_frontend::build_component(


### PR DESCRIPTION
`self.fn = fn` carries no annotation, so the annotation pass rewrites it into an AnnAssign holding a bare `Callable` *name* — the signature is lost because the inference carries a type name. The member became a generic `void (*)()`, and a call through it resolved to no method and was reported as a spurious `AttributeError`. It now takes the spelled signature from the parameter the RHS names, which is what the explicitly annotated `self.fn: Callable[[int], int] = fn` spelling already produced.

This is the instance-field case of #6640 — the symptom recorded in #4566 and the publish/subscribe idiom `regression/python/concurrency_fail` waits on. A callable chosen at runtime and `List[Callable]` are the architectural half and stay unsupported, so the issue is not closed.

Three tests: the fixed case, a wrong-expected-value control proving the call really evaluates, and a genuinely missing attribute that must still report the error.

Refs #6640