### PR TITLE
[goto-symex] Discharge I9: a path merge never shrinks a value set

### DIFF
--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -592,12 +592,12 @@ discharge or an explicit, reviewed waiver.
 
 | Assumption used by | Statement | Discharged by |
 |---|---|---|
-| H-A1, H-A9 | The L2 `name_record` key is stable across `make_assignment`'s inner `rename` (I2) | H-B7 assertion on the real `level2t` |
+| H-A1, H-A9 | The L2 `name_record` key is stable across `make_assignment`'s inner `rename` (I2) | **Discharged**, §15 M9 (H-B7) — `renaming.test.cpp`'s "make_assignment publishes a fresh increasing L2 index" asserts the entry `coveredinbees` updated is the one keyed by the caller's key, over five successive publications |
 | H-A2 | `guard2tc::operator-=` satisfies `(g_cur ∨ g_mrg) → (diff ↔ g_mrg)` | **irep2 plan** H-A9/H-B4 — cross-document dependency |
 | H-A2 | Incoming merge guards may overlap (no disjointness assumed) | by construction (not assumed) |
-| H-A4 | Every `with2t` store the slicer elides has a `symbol2t` source and constant index | H-B7 counts the shapes reaching that branch |
-| H-A6 | `thread_last_reads/writes` contain *all* accesses of the last transition, including through pointers | H-B7 + `get_expr_globals` audit (**open risk**, R11) |
-| H-A8 | `push_ctx`/`pop_ctx` calls are balanced by the caller (`reachability_treet`) | H-B8 |
+| H-A4 | Every `with2t` store the slicer elides has a `symbol2t` source and constant index | **Discharged**, §15 M9 (H-B7) — `assumption_discharge.test.cpp` checks it on every elided store and censuses the excluded shapes; struct member stores are excluded by their `constant_string2t` field, which the census now pins |
+| H-A6 | `thread_last_reads/writes` contain *all* accesses of the last transition, including through pointers | **Refuted and fixed**, not discharged: R11 → **R18**, a one-level `get_expr_globals` resolution that lost a nested-dereference write, fixed by **#6550**. What holds post-fix is that pointer *chains* are followed; no harness asserts completeness for every access shape, so this row stays open in the weaker form |
+| H-A8 | `push_ctx`/`pop_ctx` calls are balanced by the caller (`reachability_treet`) | **Open**, scoped by §15 M9 (H-B7): the balance rests on the explicit `targ->push_ctx()` in `setup_for_new_explore` (`reachability_tree.cpp:339`, "Start with a depth of 1") pairing with `~dfs_execution_statet`'s pop, and only under `--smt-during-symex`. An unbalanced pop is UB, not a diagnostic — `runtime_encoded_equationt::pop_ctx` reads `scoped_end_points.back()` unchecked on a list the constructor leaves empty |
 | all Tier A | `nondet` solver answers are *sound* (no wrong TRUE/FALSE) | out of scope — solver backends are Tier D |
 
 ### 7.4 Tier C — whole-tool metamorphic oracles
@@ -813,11 +813,13 @@ and **R24** (bitfield padding under type punning), both since fixed, with seven 
 the eleven entries turning out to be wrong tests rather than defects — six of
 those fixed and retired.
 
-**M9 — The Tier-B remainder (0.5 wk).** H-B6, the one row §7.2 never scheduled
-under a milestone. **Closed, §15 M9.** I9 discharged on the real engine with no
-defect found; the entry records why the obvious mutant (deleting the union) is
-undetectable and the meaningful one (intersecting it) is caught. H-B7 remains,
-and is scoped by whatever §7.3 rows survive.
+**M9 — The Tier-B remainder (0.5 wk).** H-B6 and H-B7, the two rows §7.2 never
+scheduled under a milestone. **Closed, §15 M9.** I9 discharged on the real engine
+with no defect found; the entry records why the obvious mutant (deleting the
+union) is undetectable and the meaningful one (intersecting it) is caught. H-B7
+then closed three of §7.3's seven rows and sharpened the rest: two were already
+discharged elsewhere, one is refuted-and-fixed rather than discharged (R18), and
+**H-A8 is the one live residual**, carrying a stated UB consequence.
 
 Total ≈ 9 engineer-weeks for the verification track, plus ≈ 2 weeks for the
 ESBMC extension critical path (WI-1…WI-3, §13.6) running alongside it.
@@ -3548,6 +3550,65 @@ subsystem, not an I9 violation, and no case here constrains it.
 R9's three "sound over-approximation" claims remain open: H-B6 checks that a
 merge does not shrink the set, not that a *deliberate* narrowing elsewhere keeps
 only `unknown`/`invalid` entries, as §14 already records.
+
+### M9 (H-B7) — 2026-08-04, the assumption register audited
+
+H-B7 is not a harness so much as a pass over §7.3, whose rule is that a row may
+not be closed without a Tier-B discharge or a reviewed waiver. Seven rows; the
+audit closes three, and the interesting part is that only one of them needed new
+code.
+
+**Already discharged, cited rather than rebuilt.** The I2 key-stability row
+(H-A1/H-A9) is asserted by `renaming.test.cpp`'s "make_assignment publishes a
+fresh increasing L2 index", which checks that the entry `coveredinbees` updates
+is the one keyed by the caller's key across five successive publications — the
+row was written before that test existed and was never revisited. H-A2's
+overlap row was already marked "by construction".
+
+**New: H-A4's shape row**, in `unit/goto-symex/assumption_discharge.test.cpp`.
+The assumption reads "every `with2t` store the slicer elides has a `symbol2t`
+source and constant index", which the guard at `slice.cpp:249-254` makes true of
+whatever it admits — so the check that carries information is over the shapes it
+*excludes*, which is what §7.3 asked for. Four cases: the assumption checked on
+every elided store of a program where the elision demonstrably fires; a census
+showing symbolic-index stores never qualify; a control showing constant-index
+stores do; and the one worth keeping —
+
+> **A struct member store must never reach that branch.** `symex_assign` spells
+> it `s' == s WITH ["f" := v]` with a `constant_string2t` field
+> (`symex_assign.cpp:958-970`), so `is_constant_int2t(update_field)` excludes it
+> today. It matters because `index_reads`, the read-set the elision consults, is
+> populated *only* from `index2t` reads (`slice.cpp:104-118`): a member read is a
+> `member2t` and records nothing. A member store that qualified would find its
+> field "never read" and be dropped as dead. The unsoundness would arrive
+> through a change to how member updates are spelled — a change no one would
+> file under "slicer" — which is exactly the kind of coupling a register row is
+> for.
+
+An anti-vacuity guard earned its place while writing this: the first version of
+the elision program read the array through its return value, and every store was
+removed wholesale by `ignore` without the branch firing at all, so
+`REQUIRE(elided > 0)` failed rather than the case passing empty.
+
+**Sharpened, not closed.** H-A6's row cited R11 as an open risk; R11 became
+**R18** and was fixed by **#6550**, so the row is refuted-and-fixed rather than
+discharged — pointer chains are now followed, but no harness asserts
+completeness over every access shape, and the row stays open in that weaker
+form. H-A2's guard-algebra row remains a cross-document dependency on the irep2
+plan.
+
+**The live residual is H-A8**, and the audit gives it a consequence it did not
+have. The balance of `push_ctx`/`pop_ctx` rests on one explicit call —
+`targ->push_ctx()` at `reachability_tree.cpp:339`, commented "Start with a depth
+of 1" — pairing with `~dfs_execution_statet`'s pop, since the initial execution
+state is constructed rather than cloned and so has no push of its own. Both are
+conditional on `--smt-during-symex`. If that pairing ever breaks, the failure is
+not a diagnostic: `runtime_encoded_equationt::pop_ctx` takes
+`scoped_end_points.back()` unchecked, on a list its constructor leaves empty
+(`symex_target_equation.cpp:527-537, 596-609`). Checking this at Tier B needs a
+real `runtime_encoded_equationt` over a real `smt_convt` — §6.1's no-doubles rule
+forbids a counting subclass standing in for the equation — which is the next
+piece of work rather than a gap in this one.
 
 ---
 

--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -574,7 +574,7 @@ inspect the produced `symex_target_equationt`.
 | **H-B3** | **Slicer equisatisfiability** (P0, I11) | Build equation; clone; slice the clone; solve both per-claim with the real backend; assert identical per-claim verdicts on ≥ 30 small programs incl. arrays with symbolic indices. **Discharged by H-C1 instead, §15 M5 (H-A4/H-B3)**: 1328 corpus inputs at 0 divergences beats 30 programs; the per-claim residue moves to H-C7 | Slicer unsoundness on real formulas — the honest complement to H-A4 |
 | **H-B4** | **Renaming round-trip** (I3/I4) | For each `SSA_stept`, `get_original_name` of `lhs` equals the L0 symbol; `rename` is idempotent; the level never decreases along the step list | `fixup_renamed_type` / `rename_address` regressions |
 | **H-B5** | **Phi laws** (I8) | For 2-branch programs: the set of *program variables* receiving a phi == the set written by at least one arm; **zero** phi for untouched variables. **Corrected, §15 M4 (H-B5)**: this row originally said "written *differently* in both", which the code does not do — `phi_function` filters on the L2 index differing, not the value | Over- and under-generation of phi nodes |
-| **H-B6** | **Value-set merge monotonicity** (I9) | After `merge_value_sets`, assert the result ⊇ both inputs (using `value_sett` API) | An accidental intersection — a silent unsoundness |
+| **H-B6** | **Value-set merge monotonicity** (I9) | After `merge_value_sets`, assert the result ⊇ both inputs (using `value_sett` API). **Run, §15 M9: I9 discharged, no defect** — `unit/goto-symex/value_set_merge.test.cpp`; an *intersecting* `make_union` is caught by 3 of 5 cases, while *deleting* the union is caught by none, and cannot be | An accidental intersection — a silent unsoundness |
 | **H-B7** | **Assumption-discharge suite** (§6.1 rule 3) | For each Tier-A assumption in §7.3, an assertion on the real engine that it holds over the corpus | Over-constrained Tier-A proofs |
 | **H-B8** | **Incremental-equation parity** (I13) | Same program with and without `--smt-during-symex`; assert identical claim count and per-claim verdicts. **Run at Tier C instead, §15 M7: 1358 agreed, 3 diverged → R19**, a per-property false PASSED | `runtime_encoded_equationt` ctx-stack bugs |
 
@@ -812,6 +812,12 @@ inventory, and two of them produce **R22**. Triage of the resulting ten
 and **R24** (bitfield padding under type punning), both since fixed, with seven of
 the eleven entries turning out to be wrong tests rather than defects — six of
 those fixed and retired.
+
+**M9 — The Tier-B remainder (0.5 wk).** H-B6, the one row §7.2 never scheduled
+under a milestone. **Closed, §15 M9.** I9 discharged on the real engine with no
+defect found; the entry records why the obvious mutant (deleting the union) is
+undetectable and the meaningful one (intersecting it) is caught. H-B7 remains,
+and is scoped by whatever §7.3 rows survive.
 
 Total ≈ 9 engineer-weeks for the verification track, plus ≈ 2 weeks for the
 ESBMC extension critical path (WI-1…WI-3, §13.6) running alongside it.
@@ -3501,6 +3507,47 @@ discriminator isolating the trigger to writing the guard variable inside its own
 branch; proof the counterexample is real (`--data-races-check` reports the
 assertion itself); the exact divergent access and scheduling decision; and five
 eliminated mechanisms. All of it is in #6558 apart from this last round.
+
+### M9 (H-B6) — 2026-08-04, I9 discharged
+
+H-B6 was the last Tier-B row never run. `unit/goto-symex/value_set_merge.test.cpp`
+runs it on the real engine: three end-to-end programs whose joins give one global
+pointer two targets, plus two cases exercising `value_sett::make_union` directly.
+All five pass, and the assertions name the objects (`c:@a`, `c:@b`) rather than
+counting them — a global pointer's map already holds its zero-initialiser, so a
+cardinality of two is reached without any merge occurring, and an earlier
+count-based version of these cases passed without ever inspecting a target.
+
+**The verdict rests on separating two mutants, which is the substance of this
+entry.** Deleting the `make_union` call from `merge_value_sets` leaves all five
+cases green. Replacing it with an intersection fails three of them. Both mutants
+were built and run; the second is I9's actual content, so I9 is discharged and
+the surviving deletion mutant is not evidence against the harness.
+
+Why deletion cannot be caught here, from instrumenting the call on the
+`early_exit` program (an `if` arm leaving by its own `goto`, so the arms reach
+the join by different routes): the union arm runs three times and reports
+`changed == false` every time, and the `guard.is_false()` replacement arm above
+it — the only arm that can drop entries — is never taken. Guarded assignment
+*adds* to a pointer's object map rather than replacing it, and `cur_state`'s
+value set is never rewound when a branch is abandoned, so both targets are
+present before any join runs. The union is therefore redundant at every join
+reachable at this tier, and is load-bearing only against a future change making
+value sets path-sensitive. This also answers, negatively, the question the
+harness's first draft left open — that a shape whose arms diverge at the join
+would make the merge observable. `early_exit` is that shape, and it does not.
+
+**Not covered, and deliberately.** `make_union`'s `keepnew` parameter decides
+whether an entry present only in the source survives; `merge_value_sets` passes
+`true`, but `value_set_domaint::merge` — the static analysis, outside
+goto-symex — passes the caller's choice, and with `false` an entry that is
+neither a `value_set::dynamic_object` nor `value_set::return_value` is dropped
+(`value_set.cpp:133-149`). That is a documented asymmetry in a different
+subsystem, not an I9 violation, and no case here constrains it.
+
+R9's three "sound over-approximation" claims remain open: H-B6 checks that a
+merge does not shrink the set, not that a *deliberate* narrowing elsewhere keeps
+only `unknown`/`invalid` entries, as §14 already records.
 
 ---
 

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -9,3 +9,4 @@ new_unit_test(determinism-test "determinism.test.cpp" "test_goto_factory;symex;s
 new_unit_test(slice-test "slice.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(mpor-test "mpor.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(value-set-merge-test "value_set_merge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(assumption-discharge-test "assumption_discharge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -8,3 +8,4 @@ new_unit_test(symex-invariant-test "invariant.test.cpp" "test_goto_factory;symex
 new_unit_test(determinism-test "determinism.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(slice-test "slice.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(mpor-test "mpor.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(value-set-merge-test "value_set_merge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/assumption_discharge.test.cpp
+++ b/unit/goto-symex/assumption_discharge.test.cpp
@@ -1,0 +1,205 @@
+/*******************************************************************
+ Module: Discharging §7.3's assumption register on the real engine
+
+ H-B7 of docs/roadmap/goto-symex-verification-plan.md.
+
+ §7.3 records the assumptions the harnesses lean on but do not check. This file
+ takes the one row that names H-B7 as its sole discharge and is still open: the
+ slicer's dead-store elimination assumes every `with2t` store it elides has a
+ `symbol2t` source and a constant index. The row asks H-B7 to "count the shapes
+ reaching that branch", which is the useful form of the question -- the guard at
+ `slice.cpp:249-254` makes the assumption true of whatever it lets through, so
+ what matters is which shapes it *excludes*, and whether a shape that must never
+ be elided could start qualifying.
+
+ One such shape is a struct member store. `symex_assign` spells it
+ `s' == s WITH ["f" := v]` with a `constant_string2t` field
+ (`symex_assign.cpp:958-970`), while an array store carries a `constant_int2t`
+ index, and only the latter passes the guard. This matters because the read-set
+ the elision consults, `index_reads`, is populated exclusively from `index2t`
+ reads (`slice.cpp:104-118`): a member read is a `member2t` and records nothing.
+ A member store that reached the branch would therefore find its field "never
+ read" and be dropped as dead -- a silent unsoundness, in the missed-bug
+ direction, from a change no one would think of as touching the slicer.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <string>
+
+#include <goto-symex/slice.h>
+
+#include "symex_run.h"
+
+namespace
+{
+struct shape_census
+{
+  /// `with2t` stores passing the slicer's array-elision guard.
+  size_t qualifying = 0;
+  /// Stores whose update field names a struct member rather than an index.
+  size_t member_field = 0;
+  /// Everything else: a symbolic index, or a source that is not a symbol.
+  size_t other = 0;
+
+  size_t total() const
+  {
+    return qualifying + member_field + other;
+  }
+};
+
+/** The slicer's own guard, stated once (`slice.cpp:249-254`). */
+bool qualifies_for_elision(const expr2tc &rhs)
+{
+  if (!is_with2t(rhs))
+    return false;
+  const with2t &with = to_with2t(rhs);
+  return is_symbol2t(with.source_value) &&
+         is_constant_int2t(with.update_field) &&
+         !to_constant_int2t(with.update_field).value.is_negative();
+}
+
+shape_census census_of(const symex_target_equationt &eq)
+{
+  shape_census c;
+  for (const auto &step : eq.SSA_steps)
+  {
+    if (!step.is_assignment() || is_nil_expr(step.rhs) || !is_with2t(step.rhs))
+      continue;
+    if (qualifies_for_elision(step.rhs))
+      c.qualifying++;
+    else if (is_constant_string2t(to_with2t(step.rhs).update_field))
+      c.member_field++;
+    else
+      c.other++;
+  }
+  return c;
+}
+
+/** True if the slicer rewrote this store's encoding away from its rhs, i.e.
+ *  elided it. Same predicate as `slice.test.cpp`'s `store_elided`. */
+bool store_elided(const symex_target_equationt::SSA_stept &step)
+{
+  if (!step.is_assignment() || is_nil_expr(step.rhs) || is_nil_expr(step.cond))
+    return false;
+  if (!is_with2t(step.rhs))
+    return false;
+  return step.cond != expr2tc(equality2tc(step.lhs, step.rhs));
+}
+
+// Constant indices with one index read, so the other three stores are dead and
+// the elision branch has to fire. Reading through an assertion, not the return
+// value, keeps the array live: a returned expression is itself sliced away, and
+// then the stores go with `ignore` rather than reaching the branch at all.
+const char *dead_array_store = R"(
+int nondet_int(void);
+int main(void)
+{
+  int a[4];
+  a[0] = nondet_int();
+  a[1] = nondet_int();
+  a[2] = nondet_int();
+  a[3] = nondet_int();
+  __ESBMC_assert(a[1] != 424242, "read one index");
+  return 0;
+}
+)";
+
+// The same program indexed symbolically. No store qualifies, so none can be
+// elided -- the incompleteness the guard buys in exchange for soundness.
+const char *symbolic_index_store = R"(
+int nondet_int(void);
+int main(void)
+{
+  int a[4];
+  int i = nondet_int() & 3;
+  a[i] = nondet_int();
+  a[1] = 7;
+  return a[i];
+}
+)";
+
+// Member stores, including one to a field that is never read. If these ever
+// start qualifying, the never-read field is dropped and the assertion below
+// becomes reachable on a program whose value it still depends on.
+const char *member_store = R"(
+int nondet_int(void);
+struct s
+{
+  int read;
+  int unread;
+};
+int main(void)
+{
+  struct s v;
+  v.read = nondet_int();
+  v.unread = nondet_int();
+  return v.read;
+}
+)";
+} // namespace
+
+TEST_CASE(
+  "every store the slicer elides has a symbol source and a constant index",
+  "[symex][slice][assumptions]")
+{
+  symex_run::equation run(dead_array_store);
+  symex_target_equationt &eq = run.get();
+
+  symex_slicet slicer(run.options());
+  slicer.run(eq.SSA_steps);
+
+  size_t elided = 0;
+  for (const auto &step : eq.SSA_steps)
+    if (store_elided(step))
+    {
+      elided++;
+      // §7.3's assumption, checked rather than assumed.
+      REQUIRE(qualifies_for_elision(step.rhs));
+      REQUIRE(is_symbol2t(step.lhs));
+    }
+
+  // Anti-vacuity: the assumption holds for want of a subject if nothing was
+  // elided, and this program exists to make sure something is.
+  REQUIRE(elided > 0);
+}
+
+TEST_CASE(
+  "a struct member store never reaches the array-elision branch",
+  "[symex][slice][assumptions]")
+{
+  symex_run::equation run(member_store);
+  const shape_census c = census_of(run.get());
+
+  INFO(
+    "qualifying " << c.qualifying << ", member " << c.member_field << ", other "
+                  << c.other);
+  REQUIRE(c.member_field > 0);
+  REQUIRE(c.qualifying == 0);
+}
+
+TEST_CASE(
+  "a symbolic index disqualifies its store from elision",
+  "[symex][slice][assumptions]")
+{
+  symex_run::equation run(symbolic_index_store);
+  const shape_census c = census_of(run.get());
+
+  INFO(
+    "qualifying " << c.qualifying << ", member " << c.member_field << ", other "
+                  << c.other);
+  REQUIRE(c.total() > 0);
+  REQUIRE(c.other > 0);
+}
+
+TEST_CASE(
+  "constant-index stores do reach the branch",
+  "[symex][slice][assumptions]")
+{
+  // The control for the two exclusions above: the guard is not simply always
+  // false on the shapes symex produces.
+  symex_run::equation run(dead_array_store);
+  REQUIRE(census_of(run.get()).qualifying > 0);
+}

--- a/unit/goto-symex/value_set_merge.test.cpp
+++ b/unit/goto-symex/value_set_merge.test.cpp
@@ -1,0 +1,248 @@
+/*******************************************************************
+ Module: Value-set merge monotonicity on the real engine
+
+ Tier B of docs/roadmap/goto-symex-verification-plan.md (H-B6, I9).
+
+ §4.3's I9: merging two paths must *union* their points-to information. An
+ accidental intersection is silent -- the value set only feeds dereference
+ resolution, so a dropped target does not fail anywhere, it just stops being
+ considered, and every check on that object disappears with it. That is the
+ missed-bug direction with no diagnostic, which is why H-B6 asserts the
+ post-merge set contains both inputs rather than trusting `make_union`'s name.
+
+ **Mutation testing, and the two mutants it separates.** Deleting the
+ `make_union` call from `merge_value_sets` leaves every case green, including
+ `early_exit`, whose arms reach the join by different routes. Instrumenting the
+ call explains it: over that program the union arm runs three times and returns
+ `changed == false` every time, and the `guard.is_false()` replacement arm above
+ it is never taken at all. Guarded assignment *adds* to a pointer's object map
+ rather than replacing it, and `cur_state`'s value set is never rewound when a
+ branch is abandoned, so both targets are already present before any join runs.
+ Deleting the union is therefore an over-approximation of an
+ over-approximation -- it cannot lose a target, which is why no case detects it.
+
+ Replacing the union with an *intersection* is the mutant that matters, and it
+ is caught: three of the five cases fail. That is I9's actual content -- a merge
+ must not shrink the points-to set -- so these cases do discharge it, and the
+ surviving deletion mutant is not evidence against them.
+
+ The consequence for readers of `merge_value_sets`: its union is redundant at
+ every join reachable here, so it is load-bearing only against a future change
+ that makes value sets path-sensitive. Note also that `make_union`'s `keepnew`
+ parameter selects whether an entry present only in the source survives;
+ symex passes `true`, while the static `value_set_domaint::merge` does not.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <set>
+#include <string>
+#include <utility>
+
+#include <goto-symex/reachability_tree.h>
+#include <pointer-analysis/value_set.h>
+#include <util/symtab/namespace.h>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+class engine
+{
+public:
+  explicit engine(std::string src)
+    : source(std::move(src)),
+      prog(goto_factory::get_goto_functions(
+        source,
+        goto_factory::Architecture::BIT_64)),
+      ns(prog.context),
+      opts(goto_factory::get_default_options(
+        goto_factory::get_default_cmdline("test.c"))),
+      rt(
+        prog.functions,
+        ns,
+        opts,
+        std::make_shared<symex_target_equationt>(ns),
+        prog.context)
+  {
+    opts.set_option("unwind", "4");
+    rt.setup_for_new_explore();
+  }
+
+  void run()
+  {
+    REQUIRE(rt.get_next_formula().target != nullptr);
+  }
+
+  const value_sett &value_set()
+  {
+    return rt.get_cur_state().get_active_state().value_set;
+  }
+
+private:
+  std::string source;
+  program prog;
+  namespacet ns;
+  optionst opts;
+  reachability_treet rt;
+};
+
+/** Names of the objects the entry named exactly `id` may point to. The entry
+ *  match is exact and required to be unique: a substring match on "p" also
+ *  catches main's `$tmp::return_value$` temporaries, and a max over those
+ *  passes this test without ever inspecting the pointer.
+ *
+ *  The *targets* are returned by name rather than counted. A global pointer's
+ *  object map already holds its zero-initialiser before either arm runs, so a
+ *  cardinality of two is reached without any merge happening at all -- which is
+ *  what let the first version of these cases survive deleting `make_union`. */
+std::set<std::string> targets_of(const value_sett &vs, const std::string &id)
+{
+  size_t matches = 0;
+  std::set<std::string> targets;
+  for (const auto &entry : vs.values)
+    if (entry.second.identifier == id)
+    {
+      ++matches;
+      for (const auto &object : entry.second.object_map)
+      {
+        const expr2tc &o = value_sett::object_numbering[object.first];
+        targets.insert(
+          is_symbol2t(o) ? to_symbol2t(o).thename.as_string() : get_expr_id(o));
+      }
+    }
+  REQUIRE(matches == 1);
+  return targets;
+}
+
+bool points_to(const std::set<std::string> &targets, const std::string &object)
+{
+  for (const std::string &t : targets)
+    if (t.find(object) != std::string::npos)
+      return true;
+  return false;
+}
+
+// Two arms give one global pointer two different targets. `p` is a global so
+// its entry outlives main's frame, which is popped by the time run() returns.
+const char *two_arms = R"(
+int a, b;
+int *p;
+int nondet_int(void);
+int main(void)
+{
+  if (nondet_int())
+    p = &a;
+  else
+    p = &b;
+  return *p;
+}
+)";
+
+// Control: one arm leaves `p` untouched, so the merge must union the arm that
+// wrote it with the fall-through that did not. Losing either direction here is
+// the same defect as losing an arm above.
+const char *one_arm = R"(
+int a;
+int *p;
+int nondet_int(void);
+int main(void)
+{
+  p = 0;
+  if (nondet_int())
+    p = &a;
+  return p == 0 ? 0 : *p;
+}
+)";
+
+// A join whose arms arrive by different routes: one leaves the `if` by its own
+// jump, the other falls through. Included because it is the shape that *would*
+// distinguish a redundant union from a load-bearing one if value sets were
+// rewound on an abandoned branch -- they are not, see the header.
+const char *early_exit = R"(
+int a, b;
+int *p;
+int nondet_int(void);
+int main(void)
+{
+  if (nondet_int())
+  {
+    p = &a;
+    goto join;
+  }
+  p = &b;
+join:
+  return *p;
+}
+)";
+} // namespace
+
+TEST_CASE("a two-arm join keeps both arms' targets", "[symex][value-set]")
+{
+  engine e(two_arms);
+  e.run();
+
+  // Losing a name here is an arm dropped at the join: an intersection, not a
+  // union. Both &a and &b are reachable, so both must survive.
+  const std::set<std::string> targets = targets_of(e.value_set(), "c:@p");
+  REQUIRE(points_to(targets, "@a"));
+  REQUIRE(points_to(targets, "@b"));
+}
+
+TEST_CASE("a one-armed join keeps the fall-through value", "[symex][value-set]")
+{
+  engine e(one_arm);
+  e.run();
+
+  const std::set<std::string> targets = targets_of(e.value_set(), "c:@p");
+  REQUIRE(points_to(targets, "@a"));
+}
+
+TEST_CASE("a join whose arms diverge keeps both targets", "[symex][value-set]")
+{
+  engine e(early_exit);
+  e.run();
+
+  const std::set<std::string> targets = targets_of(e.value_set(), "c:@p");
+  REQUIRE(points_to(targets, "@a"));
+  REQUIRE(points_to(targets, "@b"));
+}
+
+TEST_CASE("make_union never shrinks the destination", "[symex][value-set]")
+{
+  engine e(two_arms);
+  e.run();
+
+  const value_sett &produced = e.value_set();
+
+  // Unioning with a copy of itself is the identity on a monotone merge; on an
+  // intersecting one it is the first thing to lose entries.
+  value_sett self = produced;
+  self.make_union(produced, true);
+
+  REQUIRE(self.values.size() >= produced.values.size());
+  for (const auto &entry : produced.values)
+  {
+    auto it = self.values.find(entry.first);
+    REQUIRE(it != self.values.end());
+    REQUIRE(it->second.object_map.size() >= entry.second.object_map.size());
+  }
+}
+
+TEST_CASE("make_union with an empty set loses nothing", "[symex][value-set]")
+{
+  engine e(two_arms);
+  e.run();
+
+  value_sett merged = e.value_set();
+  const size_t before = merged.values.size();
+  REQUIRE(before > 0);
+
+  value_sett empty = e.value_set();
+  empty.values.clear();
+  merged.make_union(empty, true);
+
+  REQUIRE(merged.values.size() == before);
+}


### PR DESCRIPTION
H-B6 was the last Tier-B row of the goto-symex verification plan never run. Five
cases on the real engine — three end-to-end, two on `value_sett::make_union`
directly — pin that a join keeps every arm's points-to targets.

An intersecting `make_union` fails three of them; deleting the union outright
fails none, because the value set is never rewound on an abandoned branch. §15 M9
records both mutants and the instrumentation behind that claim.