### PR TITLE
[clang-frontend] Promote a boolean operand of unary - and ~

### DIFF
--- a/regression/esbmc/github_4078_unary_bool/main.c
+++ b/regression/esbmc/github_4078_unary_bool/main.c
@@ -1,0 +1,23 @@
+// C11 6.5.3.3: the operand of unary - and ~ undergoes integer promotion, so a
+// boolean one -- a comparison, || or && -- becomes int. The frontend left it
+// boolean, and the solver was then handed a boolean where it wanted a
+// bitvector: z3 reported "operator is applied to arguments of the wrong sort"
+// for ~ and "ast is not an expression" for -, two of the signatures listed in
+// issue #4078. Reduced from gcc.c-torture/execute/pr112581-1.c.
+int a, b;
+
+int main(void)
+{
+  __ESBMC_assert(~(a || b) == -1, "~0 is -1");
+  __ESBMC_assert(-(a || b) == 0, "-0 is 0");
+
+  __ESBMC_assert(~(1 || b) == -2, "~1 is -2");
+  __ESBMC_assert(-(1 || b) == -1, "-1 is -1");
+
+  __ESBMC_assert(~(a && b) == -1, "&& promotes too");
+  __ESBMC_assert(~(a < 1) == -2, "a comparison promotes too");
+
+  // The binary path already inserted the cast; keep it pinned alongside.
+  __ESBMC_assert((a || b) + 1 == 1, "binary operands were never affected");
+  return 0;
+}

--- a/regression/esbmc/github_4078_unary_bool/test.desc
+++ b/regression/esbmc/github_4078_unary_bool/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4078_unary_bool_fail/main.c
+++ b/regression/esbmc/github_4078_unary_bool_fail/main.c
@@ -1,0 +1,10 @@
+// Negative counterpart of github_4078_unary_bool: the promoted operand
+// carries its real value, so a claim contradicting it is refuted rather than
+// vacuously held (issue #4078).
+int a, b;
+
+int main(void)
+{
+  __ESBMC_assert(~(a || b) == 0, "must not hold");
+  return 0;
+}

--- a/regression/esbmc/github_4078_unary_bool_fail/test.desc
+++ b/regression/esbmc/github_4078_unary_bool_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -136,6 +136,18 @@ void clang_c_adjust::adjust_expr(exprt &expr)
     adjust_expr_unary_complex(expr);
     adjust_reference(expr);
   }
+  else if (expr.id() == "unary-" || expr.id() == "bitnot")
+  {
+    adjust_operands(expr);
+
+    // C11 6.5.3.3: the operand undergoes integer promotion, so a boolean one
+    // -- a comparison, || or && -- becomes int. Left boolean, it reaches the
+    // solver where a bitvector is wanted (issue #4078).
+    if (
+      expr.operands().size() == 1 && expr.op0().type().id() == "bool" &&
+      expr.type().id() != "bool")
+      gen_typecast(ns, expr.op0(), expr.type());
+  }
   else if (expr.id() == "shl" || expr.id() == "shr")
   {
     adjust_expr_shifts(expr);


### PR DESCRIPTION
C11 6.5.3.3 promotes the operand of unary minus and bitwise not, so a boolean one — a comparison, `||` or `&&` — becomes `int`. It was left boolean and reached the solver where a bitvector was wanted:

```c
int a, b;
b = ~(a || b);   // Z3 error: operator is applied to arguments of the wrong sort
b = -(a || b);   // Z3 error: ast is not an expression
b = (a || b) + 1; // fine — the binary path already casts
```

Those are two of the error signatures listed in #4078 (3 and 4 tests respectively). Reduced with creduce from `gcc.c-torture/execute/pr112581-1.c`, which now verifies.

Complex operands keep their existing arm. The new arm runs the same `adjust_operands` the generic `else` did before applying the cast — dropping that was what briefly broke `complex_arithmetic` and `llbmc_bitset-test` while developing this.

Tests assert exact values (`~0 == -1`, `~1 == -2`, `-0 == 0`, `-1 == -1`) so they cannot pass vacuously.