### PR TITLE
[goto-symex] Audit the assumption register: close three rows, sharpen four

### DIFF
--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -592,12 +592,12 @@ discharge or an explicit, reviewed waiver.
 
 | Assumption used by | Statement | Discharged by |
 |---|---|---|
-| H-A1, H-A9 | The L2 `name_record` key is stable across `make_assignment`'s inner `rename` (I2) | H-B7 assertion on the real `level2t` |
+| H-A1, H-A9 | The L2 `name_record` key is stable across `make_assignment`'s inner `rename` (I2) | **Discharged**, §15 M9 (H-B7) — `renaming.test.cpp`'s "make_assignment publishes a fresh increasing L2 index" asserts the entry `coveredinbees` updated is the one keyed by the caller's key, over five successive publications |
 | H-A2 | `guard2tc::operator-=` satisfies `(g_cur ∨ g_mrg) → (diff ↔ g_mrg)` | **irep2 plan** H-A9/H-B4 — cross-document dependency |
 | H-A2 | Incoming merge guards may overlap (no disjointness assumed) | by construction (not assumed) |
-| H-A4 | Every `with2t` store the slicer elides has a `symbol2t` source and constant index | H-B7 counts the shapes reaching that branch |
-| H-A6 | `thread_last_reads/writes` contain *all* accesses of the last transition, including through pointers | H-B7 + `get_expr_globals` audit (**open risk**, R11) |
-| H-A8 | `push_ctx`/`pop_ctx` calls are balanced by the caller (`reachability_treet`) | H-B8 |
+| H-A4 | Every `with2t` store the slicer elides has a `symbol2t` source and constant index | **Discharged**, §15 M9 (H-B7) — `assumption_discharge.test.cpp` checks it on every elided store and censuses the excluded shapes; struct member stores are excluded by their `constant_string2t` field, which the census now pins |
+| H-A6 | `thread_last_reads/writes` contain *all* accesses of the last transition, including through pointers | **Refuted and fixed**, not discharged: R11 → **R18**, a one-level `get_expr_globals` resolution that lost a nested-dereference write, fixed by **#6550**. What holds post-fix is that pointer *chains* are followed; no harness asserts completeness for every access shape, so this row stays open in the weaker form |
+| H-A8 | `push_ctx`/`pop_ctx` calls are balanced by the caller (`reachability_treet`) | **Open**, scoped by §15 M9 (H-B7): the balance rests on the explicit `targ->push_ctx()` in `setup_for_new_explore` (`reachability_tree.cpp:339`, "Start with a depth of 1") pairing with `~dfs_execution_statet`'s pop, and only under `--smt-during-symex`. An unbalanced pop is UB, not a diagnostic — `runtime_encoded_equationt::pop_ctx` reads `scoped_end_points.back()` unchecked on a list the constructor leaves empty |
 | all Tier A | `nondet` solver answers are *sound* (no wrong TRUE/FALSE) | out of scope — solver backends are Tier D |
 
 ### 7.4 Tier C — whole-tool metamorphic oracles
@@ -813,11 +813,13 @@ and **R24** (bitfield padding under type punning), both since fixed, with seven 
 the eleven entries turning out to be wrong tests rather than defects — six of
 those fixed and retired.
 
-**M9 — The Tier-B remainder (0.5 wk).** H-B6, the one row §7.2 never scheduled
-under a milestone. **Closed, §15 M9.** I9 discharged on the real engine with no
-defect found; the entry records why the obvious mutant (deleting the union) is
-undetectable and the meaningful one (intersecting it) is caught. H-B7 remains,
-and is scoped by whatever §7.3 rows survive.
+**M9 — The Tier-B remainder (0.5 wk).** H-B6 and H-B7, the two rows §7.2 never
+scheduled under a milestone. **Closed, §15 M9.** I9 discharged on the real engine
+with no defect found; the entry records why the obvious mutant (deleting the
+union) is undetectable and the meaningful one (intersecting it) is caught. H-B7
+then closed three of §7.3's seven rows and sharpened the rest: two were already
+discharged elsewhere, one is refuted-and-fixed rather than discharged (R18), and
+**H-A8 is the one live residual**, carrying a stated UB consequence.
 
 Total ≈ 9 engineer-weeks for the verification track, plus ≈ 2 weeks for the
 ESBMC extension critical path (WI-1…WI-3, §13.6) running alongside it.
@@ -3548,6 +3550,65 @@ subsystem, not an I9 violation, and no case here constrains it.
 R9's three "sound over-approximation" claims remain open: H-B6 checks that a
 merge does not shrink the set, not that a *deliberate* narrowing elsewhere keeps
 only `unknown`/`invalid` entries, as §14 already records.
+
+### M9 (H-B7) — 2026-08-04, the assumption register audited
+
+H-B7 is not a harness so much as a pass over §7.3, whose rule is that a row may
+not be closed without a Tier-B discharge or a reviewed waiver. Seven rows; the
+audit closes three, and the interesting part is that only one of them needed new
+code.
+
+**Already discharged, cited rather than rebuilt.** The I2 key-stability row
+(H-A1/H-A9) is asserted by `renaming.test.cpp`'s "make_assignment publishes a
+fresh increasing L2 index", which checks that the entry `coveredinbees` updates
+is the one keyed by the caller's key across five successive publications — the
+row was written before that test existed and was never revisited. H-A2's
+overlap row was already marked "by construction".
+
+**New: H-A4's shape row**, in `unit/goto-symex/assumption_discharge.test.cpp`.
+The assumption reads "every `with2t` store the slicer elides has a `symbol2t`
+source and constant index", which the guard at `slice.cpp:249-254` makes true of
+whatever it admits — so the check that carries information is over the shapes it
+*excludes*, which is what §7.3 asked for. Four cases: the assumption checked on
+every elided store of a program where the elision demonstrably fires; a census
+showing symbolic-index stores never qualify; a control showing constant-index
+stores do; and the one worth keeping —
+
+> **A struct member store must never reach that branch.** `symex_assign` spells
+> it `s' == s WITH ["f" := v]` with a `constant_string2t` field
+> (`symex_assign.cpp:958-970`), so `is_constant_int2t(update_field)` excludes it
+> today. It matters because `index_reads`, the read-set the elision consults, is
+> populated *only* from `index2t` reads (`slice.cpp:104-118`): a member read is a
+> `member2t` and records nothing. A member store that qualified would find its
+> field "never read" and be dropped as dead. The unsoundness would arrive
+> through a change to how member updates are spelled — a change no one would
+> file under "slicer" — which is exactly the kind of coupling a register row is
+> for.
+
+An anti-vacuity guard earned its place while writing this: the first version of
+the elision program read the array through its return value, and every store was
+removed wholesale by `ignore` without the branch firing at all, so
+`REQUIRE(elided > 0)` failed rather than the case passing empty.
+
+**Sharpened, not closed.** H-A6's row cited R11 as an open risk; R11 became
+**R18** and was fixed by **#6550**, so the row is refuted-and-fixed rather than
+discharged — pointer chains are now followed, but no harness asserts
+completeness over every access shape, and the row stays open in that weaker
+form. H-A2's guard-algebra row remains a cross-document dependency on the irep2
+plan.
+
+**The live residual is H-A8**, and the audit gives it a consequence it did not
+have. The balance of `push_ctx`/`pop_ctx` rests on one explicit call —
+`targ->push_ctx()` at `reachability_tree.cpp:339`, commented "Start with a depth
+of 1" — pairing with `~dfs_execution_statet`'s pop, since the initial execution
+state is constructed rather than cloned and so has no push of its own. Both are
+conditional on `--smt-during-symex`. If that pairing ever breaks, the failure is
+not a diagnostic: `runtime_encoded_equationt::pop_ctx` takes
+`scoped_end_points.back()` unchecked, on a list its constructor leaves empty
+(`symex_target_equation.cpp:527-537, 596-609`). Checking this at Tier B needs a
+real `runtime_encoded_equationt` over a real `smt_convt` — §6.1's no-doubles rule
+forbids a counting subclass standing in for the equation — which is the next
+piece of work rather than a gap in this one.
 
 ---
 

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -9,3 +9,4 @@ new_unit_test(determinism-test "determinism.test.cpp" "test_goto_factory;symex;s
 new_unit_test(slice-test "slice.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(mpor-test "mpor.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(value-set-merge-test "value_set_merge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(assumption-discharge-test "assumption_discharge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/assumption_discharge.test.cpp
+++ b/unit/goto-symex/assumption_discharge.test.cpp
@@ -1,0 +1,205 @@
+/*******************************************************************
+ Module: Discharging §7.3's assumption register on the real engine
+
+ H-B7 of docs/roadmap/goto-symex-verification-plan.md.
+
+ §7.3 records the assumptions the harnesses lean on but do not check. This file
+ takes the one row that names H-B7 as its sole discharge and is still open: the
+ slicer's dead-store elimination assumes every `with2t` store it elides has a
+ `symbol2t` source and a constant index. The row asks H-B7 to "count the shapes
+ reaching that branch", which is the useful form of the question -- the guard at
+ `slice.cpp:249-254` makes the assumption true of whatever it lets through, so
+ what matters is which shapes it *excludes*, and whether a shape that must never
+ be elided could start qualifying.
+
+ One such shape is a struct member store. `symex_assign` spells it
+ `s' == s WITH ["f" := v]` with a `constant_string2t` field
+ (`symex_assign.cpp:958-970`), while an array store carries a `constant_int2t`
+ index, and only the latter passes the guard. This matters because the read-set
+ the elision consults, `index_reads`, is populated exclusively from `index2t`
+ reads (`slice.cpp:104-118`): a member read is a `member2t` and records nothing.
+ A member store that reached the branch would therefore find its field "never
+ read" and be dropped as dead -- a silent unsoundness, in the missed-bug
+ direction, from a change no one would think of as touching the slicer.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <string>
+
+#include <goto-symex/slice.h>
+
+#include "symex_run.h"
+
+namespace
+{
+struct shape_census
+{
+  /// `with2t` stores passing the slicer's array-elision guard.
+  size_t qualifying = 0;
+  /// Stores whose update field names a struct member rather than an index.
+  size_t member_field = 0;
+  /// Everything else: a symbolic index, or a source that is not a symbol.
+  size_t other = 0;
+
+  size_t total() const
+  {
+    return qualifying + member_field + other;
+  }
+};
+
+/** The slicer's own guard, stated once (`slice.cpp:249-254`). */
+bool qualifies_for_elision(const expr2tc &rhs)
+{
+  if (!is_with2t(rhs))
+    return false;
+  const with2t &with = to_with2t(rhs);
+  return is_symbol2t(with.source_value) &&
+         is_constant_int2t(with.update_field) &&
+         !to_constant_int2t(with.update_field).value.is_negative();
+}
+
+shape_census census_of(const symex_target_equationt &eq)
+{
+  shape_census c;
+  for (const auto &step : eq.SSA_steps)
+  {
+    if (!step.is_assignment() || is_nil_expr(step.rhs) || !is_with2t(step.rhs))
+      continue;
+    if (qualifies_for_elision(step.rhs))
+      c.qualifying++;
+    else if (is_constant_string2t(to_with2t(step.rhs).update_field))
+      c.member_field++;
+    else
+      c.other++;
+  }
+  return c;
+}
+
+/** True if the slicer rewrote this store's encoding away from its rhs, i.e.
+ *  elided it. Same predicate as `slice.test.cpp`'s `store_elided`. */
+bool store_elided(const symex_target_equationt::SSA_stept &step)
+{
+  if (!step.is_assignment() || is_nil_expr(step.rhs) || is_nil_expr(step.cond))
+    return false;
+  if (!is_with2t(step.rhs))
+    return false;
+  return step.cond != expr2tc(equality2tc(step.lhs, step.rhs));
+}
+
+// Constant indices with one index read, so the other three stores are dead and
+// the elision branch has to fire. Reading through an assertion, not the return
+// value, keeps the array live: a returned expression is itself sliced away, and
+// then the stores go with `ignore` rather than reaching the branch at all.
+const char *dead_array_store = R"(
+int nondet_int(void);
+int main(void)
+{
+  int a[4];
+  a[0] = nondet_int();
+  a[1] = nondet_int();
+  a[2] = nondet_int();
+  a[3] = nondet_int();
+  __ESBMC_assert(a[1] != 424242, "read one index");
+  return 0;
+}
+)";
+
+// The same program indexed symbolically. No store qualifies, so none can be
+// elided -- the incompleteness the guard buys in exchange for soundness.
+const char *symbolic_index_store = R"(
+int nondet_int(void);
+int main(void)
+{
+  int a[4];
+  int i = nondet_int() & 3;
+  a[i] = nondet_int();
+  a[1] = 7;
+  return a[i];
+}
+)";
+
+// Member stores, including one to a field that is never read. If these ever
+// start qualifying, the never-read field is dropped and the assertion below
+// becomes reachable on a program whose value it still depends on.
+const char *member_store = R"(
+int nondet_int(void);
+struct s
+{
+  int read;
+  int unread;
+};
+int main(void)
+{
+  struct s v;
+  v.read = nondet_int();
+  v.unread = nondet_int();
+  return v.read;
+}
+)";
+} // namespace
+
+TEST_CASE(
+  "every store the slicer elides has a symbol source and a constant index",
+  "[symex][slice][assumptions]")
+{
+  symex_run::equation run(dead_array_store);
+  symex_target_equationt &eq = run.get();
+
+  symex_slicet slicer(run.options());
+  slicer.run(eq.SSA_steps);
+
+  size_t elided = 0;
+  for (const auto &step : eq.SSA_steps)
+    if (store_elided(step))
+    {
+      elided++;
+      // §7.3's assumption, checked rather than assumed.
+      REQUIRE(qualifies_for_elision(step.rhs));
+      REQUIRE(is_symbol2t(step.lhs));
+    }
+
+  // Anti-vacuity: the assumption holds for want of a subject if nothing was
+  // elided, and this program exists to make sure something is.
+  REQUIRE(elided > 0);
+}
+
+TEST_CASE(
+  "a struct member store never reaches the array-elision branch",
+  "[symex][slice][assumptions]")
+{
+  symex_run::equation run(member_store);
+  const shape_census c = census_of(run.get());
+
+  INFO(
+    "qualifying " << c.qualifying << ", member " << c.member_field << ", other "
+                  << c.other);
+  REQUIRE(c.member_field > 0);
+  REQUIRE(c.qualifying == 0);
+}
+
+TEST_CASE(
+  "a symbolic index disqualifies its store from elision",
+  "[symex][slice][assumptions]")
+{
+  symex_run::equation run(symbolic_index_store);
+  const shape_census c = census_of(run.get());
+
+  INFO(
+    "qualifying " << c.qualifying << ", member " << c.member_field << ", other "
+                  << c.other);
+  REQUIRE(c.total() > 0);
+  REQUIRE(c.other > 0);
+}
+
+TEST_CASE(
+  "constant-index stores do reach the branch",
+  "[symex][slice][assumptions]")
+{
+  // The control for the two exclusions above: the guard is not simply always
+  // false on the shapes symex produces.
+  symex_run::equation run(dead_array_store);
+  REQUIRE(census_of(run.get()).qualifying > 0);
+}


### PR DESCRIPTION
Stacked on #6714 — review the top commit only; it retargets to master once #6714 merges.

H-B7 is a pass over the verification plan's §7.3 register, whose rule is that no
row closes without a Tier-B discharge or a reviewed waiver. Three close; only one
needed new code.

The new suite's load-bearing case is that a struct member store must never reach
the slicer's array-elision branch. It is excluded today only because member
updates carry a `constant_string2t` field, while `index_reads` is populated
solely from `index2t` reads — so a member store that qualified would find its
field never read and be dropped as dead. H-A8 is left as the one live residual.