### PR TITLE
[clang-cpp] Keep an lvalue conditional a reference

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary/main.cpp
@@ -1,0 +1,45 @@
+// An lvalue conditional denotes an object, not a copy of one. The frontend
+// typed the `if` from clang's getType(), which drops the reference, so both
+// branches were dereferenced into a temporary and the assignment landed on
+// that copy -- leaving the original untouched and the claim below reported as
+// violated. Reduced from g++.dg/expr/cond18.C (issue #6717).
+struct Foo
+{
+  int x;
+};
+
+Foo &get(Foo &v)
+{
+  return v;
+}
+
+int main()
+{
+  bool c = true;
+
+  Foo v;
+  v.x = 1;
+  (c ? get(v) : get(v)).x = 2;
+  __ESBMC_assert(v.x == 2, "the write reaches the referenced object");
+
+  // The condition still selects: only the taken branch's object is written.
+  Foo a, b;
+  a.x = 1;
+  b.x = 1;
+  bool f = false;
+  (f ? get(a) : get(b)).x = 2;
+  __ESBMC_assert(b.x == 2 && a.x == 1, "the false branch writes b, not a");
+
+  // Object- and scalar-typed conditionals were never affected; keep them
+  // pinned so the reference case cannot be fixed at their expense.
+  Foo p, q;
+  p.x = 1;
+  q.x = 1;
+  (c ? p : q).x = 2;
+  __ESBMC_assert(p.x == 2, "object conditional still assigns through");
+
+  int i = 1, j = 1;
+  (c ? i : j) = 2;
+  __ESBMC_assert(i == 2, "scalar conditional still assigns through");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary_fail/main.cpp
@@ -1,0 +1,23 @@
+// Negative counterpart of github_6717_lvalue_ternary: the write really does
+// reach the referenced object, so a claim that it did not -- which is exactly
+// what the old copy-to-temporary lowering made true -- is refuted (issue
+// #6717).
+struct Foo
+{
+  int x;
+};
+
+Foo &get(Foo &v)
+{
+  return v;
+}
+
+int main()
+{
+  bool c = true;
+  Foo v;
+  v.x = 1;
+  (c ? get(v) : get(v)).x = 2;
+  __ESBMC_assert(v.x == 1, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_lvalue_ternary_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1084,6 +1084,21 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       return true;
     if (!elided && clang_c_convertert::get_expr(stmt, new_expr))
       return true;
+
+    // An lvalue conditional denotes an object, not a copy of one. The C path
+    // types the `if` from getType(), which drops the reference, so both
+    // branches were dereferenced into a temporary and an assignment through
+    // the conditional left the original untouched (issue #6717).
+    if (
+      !elided && ternary.isLValue() && new_expr.id() == "if" &&
+      new_expr.operands().size() == 3 &&
+      (is_reference(new_expr.op1().type()) ||
+       is_reference(new_expr.op2().type())))
+    {
+      typet ref = reference_typet();
+      ref.subtype() = new_expr.type();
+      new_expr.type() = ref;
+    }
     break;
   }
 


### PR DESCRIPTION
An lvalue conditional denotes an object, not a copy of one. The C path types the `if` from clang's `getType()`, which drops the reference, so a conditional over reference-returning calls had both branches dereferenced into a temporary:

```
DECL struct Foo tmp$3;
ASSIGN tmp$3 = *return_value$_get$1;   // copies out of the reference
ASSIGN tmp$3.x = 2;                    // writes to the copy
```

So the assignment never reached the original, and ESBMC reported a violation on valid C++:

```cpp
struct Foo { int x; };
Foo &get(Foo &v) { return v; }
(c ? get(v) : get(v)).x = 2;
assert(v.x == 2);   // holds; was VERIFICATION FAILED
```

Give the `if` a reference type when the conditional is an lvalue *and* its branches are references — object- and scalar-typed conditionals already worked and are left alone, which the test pins alongside the fixed case.

Item 1 of #6717, reduced from `g++.dg/expr/cond18.C`. That test now advances to the separate pointer-to-member defect (item 2), which this does not address. The sibling shape over reference *variables* (`(c ? ra : rb).x = 2`) still aborts and remains open in the issue.

895 C++ regression tests: 10 failures, all pre-existing.