### PR TITLE
[goto-symex] Pin two of R9's three over-approximation claims

### DIFF
--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -681,7 +681,7 @@ this document** — each is a prioritised target for the cited harness.
 | **R6** | **Medium (unsound pruning, opt-in flag) — mechanism pinned, no witness, §15 M6 (cont.)** | `state_hashing_level2t::make_assignment` keys `current_hashes` by the **L0** original name, acknowledged in-code ("XXX — consider whether to use l1 names instead. Recursion, reentrancy."). Two states that differ only in the L1 activation of a recursive local therefore fingerprint identically ⇒ `hit_hashes` prunes a genuinely different state ⇒ missed interleaving. Severity is bounded by `--state-hashing` being opt-in. | `execution_state.cpp:~1342-1378`; `reachability_treet::hit_hashes`, `reachability_tree.h:352` | H-A8-style model + **H-C4** | Key by the L1 name record (or mix call-stack depth into `generate_hash`). The unproven step is the "equal fingerprints are bisimilar" claim at `reachability_tree.cpp:420`: the fingerprint omits call-stack depth, so two states at one pc with equal L0→value maps but different recursion depths collide while resuming into different continuations. H-C4's state-hashing leg is clean (255/0) and four targeted programs produced no verdict-changing prune, so a witness must make the bug reachable *exclusively* behind the colliding state — that construction is the open task. |
 | **R7** | **Low–Medium (UB) — refined, §15 M1** | `previous_frame()` computes `*(--(--call_stack.end()))` with no size check. `call_stackt` is a `std::vector<framet>`, so at size 1 this evaluates `--begin()`, forming a pointer before the start of the array — undefined by [expr.add]/4 **whether or not it is dereferenced**, not merely a bad read. The second clause of the original finding ("returns a reference a subsequent `pop_frame` invalidates") does **not** hold: `pop_back` invalidates only the reference to the erased last element, and `previous_frame` returns the second-to-last. The precondition holds today by construction — the sole call site does `new_frame(...)` on the preceding line — but nothing states it in the shipped binary (R1). | `goto_symex_statet::previous_frame`; sole caller `goto_symext::symex_function_call_code`; [expr.add]/4 | `unit/goto-symex/frame_lifecycle.test.cpp` (Tier B, discharged) | Add a release-checked precondition **as part of R1's `SYMEX_INVARIANT` work in M3**, so the macro lands once with its cost measured; index (`call_stack[size() - 2]`) rather than decrementing an iterator. |
 | **R8** | **Medium (documented model gap)** | `is_valid_object` returns `false` for **every** non-static, non-dynamic symbol: the stack-scope branch is `#if 0`'d out with "XXX re-enable to be able to check for stack-var-out-of-scope problems". Stack-object validity is therefore not modelled, and `dynamic_allocation.cpp` compensates by *assuming* `invalid_pointer` applies only to dynamic objects ("we never update `__ESBMC_alloc` for stack ptrs"). Net effect on stack-lifetime bugs (use-after-scope) is a **missed-bug** direction. | `goto_symext::is_valid_object`, `symex_valid_object.cpp:85-118`; `dynamic_allocation.cpp:110-116` | H-A10 + a targeted `regression/esbmc` use-after-scope corpus | Quantify with a dedicated corpus before attempting a fix; the fix is a model change, not a patch. |
-| **R9** | **Low–Medium (approximation direction unproven)** | Three documented "sound over-approximation" claims are unproven: value-set filtering after a pointer havoc (`symex_assign.cpp:~550-570`), the non-scalar uninterpreted-function fallback (`symex_function.cpp:~410-430`), and the function-pointer target enumeration over an over-approximated value set (`symex_function.cpp:~766`). Each *argues* the direction in a comment; none is checked. | cited lines | H-B6 + H-C1/H-C3 | For each, state the claim as a checkable predicate and add a Tier-B assertion (e.g. filtered set ⊆ original **and** the dropped entries are `unknown`/`invalid` only). |
+| **R9** | **Low–Medium (approximation direction unproven)** — **two of three pinned**, §15 M9 (R9) | Three documented "sound over-approximation" claims are unproven: value-set filtering after a pointer havoc (`symex_assign.cpp:554-576`), the non-scalar uninterpreted-function fallback (`symex_function.cpp:418-449`), and the function-pointer target enumeration over an over-approximated value set (`symex_function.cpp:806-839`). Each *argues* the direction in a comment; none was checked. | cited lines; `unit/goto-symex/overapproximation.test.cpp` | H-B6 + H-C1/H-C3 | Claims 2 and 3 are now Tier-B predicates over the produced equation, each mutation-confirmed: disabling the compatibility filter, and dropping its empty-list guard, fail one case apiece. **Claim 1 remains open**, and is now scoped rather than merely unproven — the branch is gated on `pc->inductive_step_instruction`, which only the k-induction goto transform sets, so it is unreachable from a `goto_factory` program. |
 | **R10** | **Low (latent UB)** | `renaming::level2t::name_record`'s `name_record() = default` leaves `lev`, `l1_num`, `t_num` **and the derived `hash`** indeterminate (contrast `level1t::name_record`, which initialises `base_name("")`). No current default-construction site was found, but a future one (`std::optional`, map default-insert, array of records) would read indeterminate memory in `compare`/`hash`. | `renaming.h:143-214` | MSan (Tier D) + a `static_assert`-style unit check | Add default member initialisers; near-zero cost. |
 | **R11** | **Confirmed — mechanism corrected, see R18, §15 M6** | MPOR's independence decision consumes `thread_last_reads`/`thread_last_writes`, populated via `get_expr_globals`, which resolves pointer operands through the *current* value set. If a write through a pointer whose value set is incomplete (or whose entry is `unknown`) is missed, the dependency is missed and an interleaving is dropped — **unsound**. `get_expr_globals` also early-returns entirely under `--data-races-check-only`. | `execution_statet::get_expr_globals`, `check_mpor_dependency`; `reachability_treet::ever_written_globals`/`address_taken_globals` | H-A6 (relation) + **H-C4** (end-to-end) | **Answered.** An `unknown` entry does not force a conservative dependency — the `dest` loop skips anything that is not an `object_descriptor2t` over a `symbol2t`, with no fallback. But that is *not* the reachable defect: the witness in R18 shows the missed dependency comes from resolving only **one** pointer level, so a nested dereference is recorded against the intermediate pointer. R11's suspicion was right and its stated mechanism was wrong. Superseded by R18. |
 | **R13** | **Medium (silent under-verification) — confirmed and fixed, §15 M2 (cont.)** | **`--unwindsetname` never matched a loop.** `unwind_func_set` was keyed by `user_name_to_usr(name)`, which appends a `#` terminator (clang's C++ USR spelling), while `loop_id_to_func_index` was keyed by the goto function-map id, which for a C function is `c:@F@f` with no terminator. The `count(unwind_key)` in `get_unwind` therefore always missed and the global `--unwind` silently won, so a user raising the bound for one function got the lower global bound and a verdict covering less than they asked for. A second defect in the same option: the `name:index:bound` field split scanned left-to-right, so the documented USR form (`c:@F@f#:0:11`) split inside the `c:` prefix. Neither was caught because all five `unwindsetname` regression tests ran without a global `--unwind` and so passed vacuously. | `goto_symext::goto_symext`, `symex_assign.cpp:66-120`; `get_unwind`, `symex_goto.cpp:525`; `user_name_to_usr`, `usr_utils.cpp:29` | `unit/goto-symex/unwind.test.cpp` (Tier B, discharged) | Fixed: both sides now key on the name `--show-loops` prints (`usr_to_user_name`), and the field split scans from the right. Three non-vacuous regression tests added; `unwindsetname_03_priority` corrected to the loop number the program actually has. |
@@ -3649,6 +3649,59 @@ broken there is no diagnostic to produce.
 With this row closed, §7.3 has no open assumption backed by a live harness:
 H-A2's guard algebra remains a cross-document dependency on the irep2 plan, and
 H-A6 stays refuted-and-fixed (R18/#6550) rather than discharged.
+
+### M9 (R9) — 2026-08-04, two of three approximations pinned
+
+R9 names three places where a comment argues an approximation is sound and
+nothing checks it. Verifying the *arguments* is not on the table at Tier B; what
+is, is stating each as a predicate over the produced equation, so a change that
+reverses the direction fails here rather than in a verdict months later.
+`unit/goto-symex/overapproximation.test.cpp`, four cases, both mutation-checked.
+
+**Claim 2, the non-scalar uninterpreted-function fallback.** The comment says
+the fallback "drops only the functional-congruence constraint … never adding
+behaviour, and the body is still discarded". Two of those three are observable:
+a pointer argument yields no `uninterpreted_func2t` anywhere in the equation
+(the scalar program is the control — it yields two), and the discarded body's
+write to a global never appears. The body check needed a correction that is
+worth recording, because the first version of it was wrong in a way that reads
+as a defect: asserting "no assignment to `side`" *fails*, since every global
+carries its zero-initialiser. The check is `assignments_to(eq, "c:@side") == 1`
+— the initialiser and nothing else. A count of two would be the discarded body
+running.
+
+**Claim 3, the function-pointer target filter.** Two directions, each with its
+own case and its own mutant:
+
+- An incompatible-arity candidate is dropped: `one`'s body appears in the
+  equation, `two`'s does not. Disabling the filter (`if (false)`) fails exactly
+  this case, so it is the filter doing the work and not the value set.
+- A filter that would empty the list keeps it: with *every* candidate
+  incompatible, the call must still dispatch. Deleting the `!compatible.empty()`
+  guard fails exactly this case. The asymmetry is the point — a wrong-arity
+  dispatch is a spurious counterexample, a dispatch to nothing at all is a
+  missed one, and only the second direction is unsound.
+
+**Programs that do not reach the branch.** The first draft gave both
+function-pointer cases an array of function pointers indexed by a nondet, on the
+assumption that the value set would list both elements. It does not: `p`'s entry
+comes back without candidates, the call is skipped by the open-world path at
+`symex_function.cpp:795-804`, and both cases pass or fail for reasons unrelated
+to the filter. A direct `if (nondet) p = f; else p = g;` gives the two-candidate
+set the claim is about. Worth remembering for any harness that needs a
+multi-target function pointer.
+
+**Claim 1 stays open, but scoped.** The value-set filter after a pointer havoc
+(`symex_assign.cpp:554-576`) drops `unknown`/`invalid` entries from the restored
+set. Its guard requires `inductive_step`, a nondet pointer side-effect,
+`--add-symex-value-sets`, *and* `pc->inductive_step_instruction` — a flag only
+the k-induction goto transform sets, so no `goto_factory` program reaches it and
+Tier B cannot see the branch at all. It needs either a k-induction-aware
+fixture or a Tier-C leg over the corpus that already uses the flag pair. Noting
+also that this one is a *narrowing*, unlike the other two: it removes candidates
+rather than constraints, so "never adding behaviour" is not the direction to
+check — the question is whether the dropped `unknown` could have been the real
+target, which is why it was the one left unproven.
 
 ---
 

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -11,3 +11,4 @@ new_unit_test(mpor-test "mpor.test.cpp" "test_goto_factory;symex;solvers;gotoalg
 new_unit_test(value-set-merge-test "value_set_merge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(assumption-discharge-test "assumption_discharge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(context-stack-test "context_stack.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(overapproximation-test "overapproximation.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/overapproximation.test.cpp
+++ b/unit/goto-symex/overapproximation.test.cpp
@@ -1,0 +1,227 @@
+/*******************************************************************
+ Module: R9's "sound over-approximation" claims, as checkable predicates
+
+ Tier B of docs/roadmap/goto-symex-verification-plan.md (§9.2 R9).
+
+ R9 records three places where a comment argues an approximation is sound and
+ nothing checks it. A comment is not a proof, but it is also not the thing to
+ verify: what a harness can do is state each claim as a predicate over the
+ produced equation and pin the direction, so a change that quietly reverses it
+ fails here rather than in a verdict months later.
+
+ Two of the three are pinned below. The third -- the value-set filter after a
+ pointer havoc (`symex_assign.cpp:554-576`) -- is not, and the reason is
+ recorded in §15 rather than hidden: reaching it needs
+ `pc->inductive_step_instruction`, which only the k-induction goto transform
+ sets, so it is out of reach of a `goto_factory` program.
+
+ The direction that matters for both claims below is *never adding behaviour*.
+ Dropping a constraint is safe; dropping a call target, or letting a discarded
+ body run, is not.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <string>
+
+#include "symex_run.h"
+
+namespace
+{
+/// Does any expression in this step contain an uninterpreted-function term?
+bool mentions_uninterpreted_func(const expr2tc &e)
+{
+  if (is_nil_expr(e))
+    return false;
+  if (is_uninterpreted_func2t(e))
+    return true;
+
+  bool found = false;
+  e->foreach_operand([&found](const expr2tc &op) {
+    if (!found)
+      found = mentions_uninterpreted_func(op);
+  });
+  return found;
+}
+
+size_t count_uninterpreted_funcs(const symex_target_equationt &eq)
+{
+  size_t n = 0;
+  for (const auto &step : eq.SSA_steps)
+    if (mentions_uninterpreted_func(step.rhs))
+      n++;
+  return n;
+}
+
+/// Steps assigning a name belonging to `function` -- its parameters and locals.
+/// Non-zero means the call was dispatched and its body symexed.
+/// How many steps assign a name containing `name`. Globals carry exactly one,
+/// their zero-initialiser, unless something writes them.
+size_t assignments_to(const symex_target_equationt &eq, const std::string &name)
+{
+  size_t n = 0;
+  for (const auto &step : eq.SSA_steps)
+  {
+    if (
+      !step.is_assignment() || is_nil_expr(step.lhs) || !is_symbol2t(step.lhs))
+      continue;
+    if (to_symbol2t(step.lhs).get_symbol_name().find(name) != std::string::npos)
+      n++;
+  }
+  return n;
+}
+
+size_t
+steps_inside(const symex_target_equationt &eq, const std::string &function)
+{
+  const std::string tag = "@F@" + function + "@";
+  size_t n = 0;
+  for (const auto &step : eq.SSA_steps)
+  {
+    if (
+      !step.is_assignment() || is_nil_expr(step.lhs) || !is_symbol2t(step.lhs))
+      continue;
+    if (to_symbol2t(step.lhs).get_symbol_name().find(tag) != std::string::npos)
+      n++;
+  }
+  return n;
+}
+
+// A scalar signature: the case the fallback is *not* for. Both calls take the
+// same argument, so a congruence constraint is available to be emitted.
+const char *scalar_uf = R"(
+int __ESBMC_uninterpreted_scalar(int x);
+int main(void)
+{
+  int a = __ESBMC_uninterpreted_scalar(3);
+  int b = __ESBMC_uninterpreted_scalar(3);
+  return a + b;
+}
+)";
+
+// A pointer argument makes the signature non-scalar, so the result falls back
+// to a fresh nondet. The body writes a global: "the body is still discarded"
+// is the half of the claim that would be unsound if it were wrong, and `side`
+// is how this file observes it.
+const char *nonscalar_uf = R"(
+int side;
+int __ESBMC_uninterpreted_ptr(int *p)
+{
+  side = 1;
+  return *p;
+}
+int g;
+int main(void)
+{
+  int a = __ESBMC_uninterpreted_ptr(&g);
+  int b = __ESBMC_uninterpreted_ptr(&g);
+  return a + b;
+}
+)";
+
+// `two` is address-taken with a cast, so the value set of `p` lists a target of
+// the wrong arity. Dispatching it would nondet-fill the missing argument.
+const char *mixed_arity_targets = R"(
+int nondet_int(void);
+int one(int a)
+{
+  return a;
+}
+int two(int a, int b)
+{
+  return a + b;
+}
+typedef int (*fp1)(int);
+int main(void)
+{
+  fp1 p;
+  if (nondet_int())
+    p = one;
+  else
+    p = (fp1)two;
+  return p(5);
+}
+)";
+
+// Every candidate is incompatible with the declared type. The filter would
+// empty the list, so it must keep it: dropping every target skips the call and
+// silently havocs its result, which is the missed-bug direction.
+const char *all_incompatible_targets = R"(
+int nondet_int(void);
+int two(int a, int b)
+{
+  return a + b;
+}
+int three(int a, int b, int c)
+{
+  return a + b + c;
+}
+typedef int (*fp1)(int);
+int main(void)
+{
+  fp1 p;
+  if (nondet_int())
+    p = (fp1)two;
+  else
+    p = (fp1)three;
+  return p(5);
+}
+)";
+} // namespace
+
+TEST_CASE(
+  "a scalar uninterpreted function is encoded as one",
+  "[symex][overapproximation]")
+{
+  symex_run::equation run(scalar_uf);
+
+  // The control for the fallback below: without this, "no uninterpreted_func2t
+  // was emitted" would hold for a program where none was ever due.
+  REQUIRE(count_uninterpreted_funcs(run.get()) >= 2);
+}
+
+TEST_CASE(
+  "a non-scalar signature falls back without running the body",
+  "[symex][overapproximation]")
+{
+  symex_run::equation run(nonscalar_uf);
+  const symex_target_equationt &eq = run.get();
+
+  // The fallback fired: no uninterpreted-function term survives.
+  REQUIRE(count_uninterpreted_funcs(eq) == 0);
+
+  // ... and it dropped only the congruence constraint. The body is still
+  // discarded, so its write to `side` never happens. If this fails the
+  // approximation is not weaker than the uninterpreted-function semantics, it
+  // is different from them, and R9's "never adding behaviour" is false.
+  // `side` keeps exactly the one assignment every global gets, its
+  // zero-initialiser. A second one would be the discarded body running.
+  REQUIRE(assignments_to(eq, "c:@side") == 1);
+  REQUIRE(steps_inside(eq, "__ESBMC_uninterpreted_ptr") == 0);
+}
+
+TEST_CASE(
+  "an incompatible call target is dropped, a compatible one is kept",
+  "[symex][overapproximation]")
+{
+  symex_run::equation run(mixed_arity_targets);
+  const symex_target_equationt &eq = run.get();
+
+  REQUIRE(steps_inside(eq, "one") > 0);
+  REQUIRE(steps_inside(eq, "two") == 0);
+}
+
+TEST_CASE(
+  "a filter that would empty the target list keeps it",
+  "[symex][overapproximation]")
+{
+  symex_run::equation run(all_incompatible_targets);
+  const symex_target_equationt &eq = run.get();
+
+  // No candidate matches the declared type, so the filter must not run: a call
+  // dispatched to a wrong-arity target is a spurious counterexample, but a call
+  // dispatched to nothing at all is a missed one.
+  REQUIRE(steps_inside(eq, "two") + steps_inside(eq, "three") > 0);
+}


### PR DESCRIPTION
Stacked on #6718 (→ #6716 → #6714) — review the top commit only; it retargets as the parents merge.

R9 names three comments that argue an approximation is sound with nothing
checking it. Two become predicates over the produced equation: the non-scalar
uninterpreted-function fallback emits no UF term and still discards the body,
and the function-pointer filter drops an incompatible target while keeping the
list when every candidate is incompatible.

Both directions of the filter are mutation-confirmed — disabling it, and
dropping its empty-list guard, each fail one case. Claim 1 stays open but is now
scoped: its branch is gated on `pc->inductive_step_instruction`, which only the
k-induction goto transform sets, so Tier B cannot reach it.