### PR TITLE
[goto-symex] Resolve an inline pointer-to-member

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member/main.cpp
@@ -1,0 +1,63 @@
+// `&C::m` written inline reaches symex as the address of a symbol named after
+// the member, while one stored in a pointer-to-member variable arrives as a
+// member_ref because renaming substitutes the variable's value. Only the
+// second was resolved, so every inline `.*` / `->*` aborted with
+// "pointer-to-member: constant propagation failed" (issue #6717).
+struct Foo
+{
+  int a;
+  int x;
+};
+
+struct Base
+{
+  int b;
+};
+struct Der : Base
+{
+  int d;
+};
+
+Foo &get(Foo &v)
+{
+  return v;
+}
+
+int main()
+{
+  Foo v;
+  v.a = 1;
+  v.x = 1;
+  v.*(&Foo::x) = 2;
+  __ESBMC_assert(v.x == 2 && v.a == 1, "writes the named member, not another");
+
+  Foo w;
+  w.x = 1;
+  Foo *p = &w;
+  p->*(&Foo::x) = 2;
+  __ESBMC_assert(w.x == 2, "->* through a pointer");
+
+  Foo r;
+  r.x = 1;
+  get(r).*(&Foo::x) = 2;
+  __ESBMC_assert(r.x == 2, ".* on a reference-returning call");
+
+  Foo s;
+  s.x = 7;
+  int read = s.*(&Foo::x);
+  __ESBMC_assert(read == 7, "reads as well as writes");
+
+  // Inherited members resolve through the nested base subobject.
+  Der o;
+  o.b = 1;
+  o.*(&Der::b) = 5;
+  __ESBMC_assert(o.b == 5, "inherited member via the base subobject");
+
+  // The spelling that already worked, kept pinned alongside.
+  Foo n;
+  n.x = 1;
+  int Foo::*pm = &Foo::x;
+  n.*pm = 2;
+  __ESBMC_assert(n.x == 2, "named pointer-to-member still resolves");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative counterpart of github_6717_inline_ptr_to_member: the resolved
+// member access carries the real write, so a claim contradicting it is
+// refuted rather than vacuously held (issue #6717).
+struct Foo
+{
+  int x;
+};
+
+int main()
+{
+  Foo v;
+  v.x = 1;
+  v.*(&Foo::x) = 2;
+  __ESBMC_assert(v.x == 1, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_inline_ptr_to_member_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2
+^VERIFICATION FAILED$

--- a/src/goto-symex/dynamic_allocation.cpp
+++ b/src/goto-symex/dynamic_allocation.cpp
@@ -191,6 +191,19 @@ void goto_symext::default_replace_dynamic_allocation(expr2tc &expr)
 
     cur_state->rename(member);
 
+    // `&C::m` written inline reaches here as the address of a symbol named
+    // after the member, whereas one that has gone through a pointer-to-member
+    // variable arrives as a member_ref because renaming substitutes the
+    // variable's value. Normalise the first spelling onto the second so both
+    // resolve through the same path (issue #6717).
+    if (is_address_of2t(member))
+    {
+      const expr2tc &inner = to_address_of2t(member).ptr_obj;
+      if (is_symbol2t(inner))
+        member =
+          member_ref2tc(member->type, to_symbol2t(inner).get_symbol_name());
+    }
+
     if (is_member_ref2t(member))
     {
       const member_ref2t &ref = to_member_ref2t(member);


### PR DESCRIPTION
`&C::m` written inline reaches symex as the address of a symbol named after the member, while one stored in a pointer-to-member variable arrives as a `member_ref` because renaming substitutes the variable's value. Only the second was handled, so **every** inline `.*` and `->*` aborted with `pointer-to-member: constant propagation failed`:

```cpp
struct Foo { int x; };
Foo v; v.x = 1;
v.*(&Foo::x) = 2;                 // aborted
int Foo::*pm = &Foo::x; v.*pm = 2; // worked
```

Normalising the inline spelling onto the `member_ref` form reuses the existing resolution unchanged, including its nested base-subobject path for inherited members.

Item 2 of #6717. Broader than that issue states: I had attributed it to the reference-returning call in `g++.dg/expr/cond18.C`, but the plain `v.*(&Foo::x)` fails identically — the call and the conditional were both incidental. `cond18.C` now verifies.

Tested across direct object, `->*` via pointer, reference-returning call, read as well as write, an inherited member through its base subobject, and member *selection* (writing `x` leaves `a` untouched), plus a negative variant so none of it can pass vacuously. The named-variable spelling is pinned alongside.

Independent of #6719 — with this branch alone, plain `.x` on a conditional still fails, so the two defects merely co-occur in `cond18.C`.

895 C++ tests: 10 failures, all pre-existing. C suite: 6, all pre-existing.