### PR TITLE
[clang-cpp] Copy an array member through its element constructor

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6717_array_member_copy/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_array_member_copy/main.cpp
@@ -1,0 +1,52 @@
+// Copying a class that holds an array of class type goes through clang's
+// ArrayInitLoopExpr, whose sub-expression is the element's copy constructor
+// rather than the indexed read a scalar element yields. The frontend cast it
+// to an index anyway, walked off the end of the expression and segfaulted
+// during conversion. Reduced from g++.dg/init/array37.C and init/array4.C
+// (issue #6717).
+struct A
+{
+  int i;
+};
+
+struct B
+{
+  A ar[3];
+};
+
+int check(B x)
+{
+  return x.ar[1].i;
+}
+
+struct C
+{
+  A ar[2];
+  C()
+  {
+  }
+  C(const C &) = default;
+};
+
+int main()
+{
+  B b;
+  b.ar[0].i = 7;
+  b.ar[1].i = 8;
+  b.ar[2].i = 9;
+
+  B b2(b);
+  __ESBMC_assert(
+    b2.ar[0].i == 7 && b2.ar[1].i == 8 && b2.ar[2].i == 9,
+    "every element is copied, not just the first");
+
+  // Passing by value takes the same path.
+  __ESBMC_assert(check(b) == 8, "by-value parameter copies the array");
+
+  // So does an explicitly defaulted copy constructor.
+  C c;
+  c.ar[1].i = 4;
+  C c2(c);
+  __ESBMC_assert(c2.ar[1].i == 4, "defaulted copy constructor");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_array_member_copy/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_array_member_copy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6717_array_member_copy_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_array_member_copy_fail/main.cpp
@@ -1,0 +1,21 @@
+// Negative counterpart of github_6717_array_member_copy: the copy carries the
+// real element values, so a claim contradicting one is refuted rather than
+// vacuously held (issue #6717).
+struct A
+{
+  int i;
+};
+
+struct B
+{
+  A ar[3];
+};
+
+int main()
+{
+  B b;
+  b.ar[0].i = 7;
+  B b2(b);
+  __ESBMC_assert(b2.ar[0].i == 8, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_array_member_copy_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_array_member_copy_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 3
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1592,11 +1592,39 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (get_expr(*aile.getSubExpr(), init))
       return true;
 
-    index_exprt ind = to_index_expr(init);
-
     const llvm::APInt &Int = aile.getArraySize();
     std::size_t size = Int.getSExtValue();
     exprt inits("constant", common.type());
+
+    // A class-typed element copies through its copy constructor, so the
+    // sub-expression is a CXXConstructExpr rather than the indexed read a
+    // scalar element yields. Casting it to an index walked off the end of the
+    // expression and crashed the frontend (issue #6717). A trivial
+    // constructor copies the representation and nothing else, so the
+    // element-wise read below says the same thing.
+    if (!init.is_index())
+    {
+      const auto *ctor = llvm::dyn_cast<clang::CXXConstructExpr>(
+        aile.getSubExpr()->IgnoreImplicit());
+      if (!ctor || !ctor->getConstructor()->isTrivial())
+      {
+        log_error(
+          "ESBMC currently does not support an array copy whose element "
+          "constructor is non-trivial");
+        return true;
+      }
+
+      const typet &elem_t = common.type().subtype();
+      for (std::size_t i = 0; i < size; ++i)
+        inits.copy_to_operands(
+          index_exprt(common, from_integer(i, index_type()), elem_t));
+
+      new_expr = inits;
+      break;
+    }
+
+    index_exprt ind = to_index_expr(init);
+
     // { ref->arr[0], ref->arr[1], ... ,ref->arr[i]}
     for (std::size_t i = 0; i < size; ++i)
     {


### PR DESCRIPTION
Copying a class that holds an array of class type goes through clang's `ArrayInitLoopExpr`, whose sub-expression is the element's **copy constructor** rather than the indexed read a scalar element yields. The handler cast it to an index regardless:

```cpp
index_exprt ind = to_index_expr(init);   // init is a CXXConstructExpr
```

which walked off the end of the expression and segfaulted in `irept::detatch` during conversion:

```cpp
struct A { int i; };
struct B { A ar[3]; };
int main() { B b; B b2(b); }   // SIGSEGV
```

Read the elements directly when the element constructor is trivial — that copies the representation and nothing else, so it says the same thing — and report the non-trivial case rather than crashing on it.

Items 4 and 5 of #6717, reduced from `g++.dg/init/array37.C`. `init/array4.C` also stops crashing: its `std::string` elements have a non-trivial copy constructor, so it now exits cleanly on the new diagnostic instead of SIGSEGV.

Three corrections to what that issue originally said, all from measurement: it is **size-independent** (`A ar[1]` crashed identically, so not stack exhaustion from the 10x20x30 extent I had blamed), `virtual` is irrelevant, and the two tests are one defect rather than two.

Tested for element-wise fidelity (all three elements, not just the first), by-value parameters, an explicitly defaulted copy constructor, and a negative variant so none of it passes vacuously. 895 C++ tests: 10 failures, all pre-existing.