### PR TITLE
[regression] escalate to SIGKILL even when the SIGTERM failed

### DIFF
--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -500,19 +500,23 @@ class Executor:
                 # Gracefully shut down the whole process group so
                 # grandchildren don't linger and starve the CI runner.
                 if os.name == "posix":
-                    # Best-effort: on macOS killpg can raise EPERM when the
-                    # group holds a process we can no longer signal, which
-                    # otherwise turns a tolerated timeout into a hard ERROR.
+                    # ESBMC does not necessarily die on SIGTERM, so the SIGKILL
+                    # escalation has to run even when the SIGTERM itself failed.
+                    # Sharing one try with the wait meant a killpg that raised
+                    # (on macOS it raises EPERM when the group holds a process
+                    # we can no longer signal) skipped the kill entirely and
+                    # left the group running.
                     try:
                         os.killpg(proc.pid, signal.SIGTERM)
+                    except OSError:
+                        pass
+                    try:
                         proc.wait(timeout=_TERM_GRACE)
                     except subprocess.TimeoutExpired:
                         try:
                             os.killpg(proc.pid, signal.SIGKILL)
                         except OSError:
                             pass
-                    except OSError:
-                        pass
                 else:
                     proc.kill()
                 stdout, stderr = proc.communicate()

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -169,5 +169,44 @@ class RelativeTestDirTest(unittest.TestCase):
                 os.chdir(cwd)
 
 
+class TimeoutReapsProcessGroupTest(unittest.TestCase):
+    """A timed-out run must leave nothing behind. ESBMC does not necessarily
+    die on SIGTERM -- orphans have been observed still running 34 hours after
+    their harness gave up -- so the cleanup has to escalate to SIGKILL."""
+
+    def test_sigterm_ignoring_child_is_reaped(self):
+        if os.name != "posix":
+            self.skipTest("process-group cleanup is posix-only")
+        with tempfile.TemporaryDirectory() as tmp:
+            # Stand-in for ESBMC: ignores SIGTERM, then sleeps past the timeout.
+            tool = os.path.join(tmp, "ignores_sigterm.py")
+            with open(tool, "w", encoding="utf-8") as f:
+                f.write(
+                    "import os, signal, sys, time\n"
+                    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+                    "sys.stderr.write('CHILDPID=' + str(os.getpid()) + '\\n')\n"
+                    "sys.stderr.flush()\n"
+                    "time.sleep(600)\n"
+                )
+            test_dir = os.path.join(tmp, "hangs")
+            os.mkdir(test_dir)
+            open(os.path.join(test_dir, "main.c"), "w").close()
+            with open(os.path.join(test_dir, "test.desc"), "w",
+                      encoding="utf-8") as f:
+                f.write("CORE\nmain.c\n\n^VERIFICATION SUCCESSFUL$\n")
+
+            executor = Executor("{} {}".format(sys.executable, tool))
+            executor.timeout = 2
+            stdout, stderr, _ = executor.run(TestCase(test_dir, "hangs"))
+
+            self.assertIsNone(stdout, "run should report a timeout")
+            marker = re.search(r"CHILDPID=(\d+)", stderr.decode())
+            self.assertIsNotNone(marker, stderr.decode())
+            child_pid = int(marker.group(1))
+            # A reaped pid may be recycled, but not within this test's lifetime.
+            with self.assertRaises(OSError):
+                os.kill(child_pid, 0)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Found while clearing a contended dev machine: five orphaned `esbmc` processes, each pinning ~99% of a core, aged 9h to **34h**, several with a live `timeout 25` / `timeout 120` parent. SIGTERM did nothing to them; only SIGKILL worked.

The timeout cleanup shared one `try` between the SIGTERM and the grace `wait`, so a `killpg` that raised — on macOS it raises EPERM when the group holds a process we can no longer signal, which is what the existing comment describes — fell into `except OSError: pass` and skipped the SIGKILL entirely, leaving the group running. Splitting them makes the escalation unconditional.

**On test coverage, stated plainly:** the added self-test drives `Executor.run` against a stand-in tool that ignores SIGTERM and sleeps past the timeout, and asserts the child is gone afterwards. I verified it **also passes against the unfixed code**, so it is a guard against regressing the escalation, not a discriminating test for this fix. The branch that actually differs is the EPERM path, which cannot be reached without mocking `killpg`, and this repo does not use mocks. The fix stands on inspection plus the field evidence above.