### PR TITLE
[clang-cpp] Report a throw in a class-typed conditional

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6717_throw_conditional_ok/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_throw_conditional_ok/main.cpp
@@ -1,0 +1,30 @@
+// The shapes either side of the rejection in
+// github_6717_throw_conditional_reject: a scalar conditional never
+// materialises, so a throw branch is fine there, and a class-typed
+// conditional without a throw was never affected (issue #6717).
+struct S
+{
+  int v;
+  S(int p) : v(p)
+  {
+  }
+};
+
+int scalar(int x)
+{
+  return x ? throw 1 : 5;
+}
+
+S pick(bool c)
+{
+  S a(1), b(2);
+  return c ? a : b;
+}
+
+int main()
+{
+  __ESBMC_assert(scalar(0) == 5, "throw in a scalar conditional");
+  __ESBMC_assert(pick(true).v == 1, "class conditional without a throw");
+  __ESBMC_assert(pick(false).v == 2, "and its other branch");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_throw_conditional_ok/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_throw_conditional_ok/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_6717_throw_conditional_reject/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6717_throw_conditional_reject/main.cpp
@@ -1,0 +1,29 @@
+// C++ [expr.cond]/2: a throw-expression operand contributes no value. A
+// class-typed conditional is materialised by taking the address of each
+// branch, which for the throw is meaningless -- it used to abort inside the
+// solver with an "Unrecognized address_of operand" irep dump. Report it at
+// the frontend instead, until the branch is lowered to a statement
+// (issue #6717, from g++.dg/expr/cond16.C).
+struct S
+{
+  const char *s;
+  S(const char *p) : s(p)
+  {
+  }
+  bool empty() const
+  {
+    return !s;
+  }
+};
+
+S foo()
+{
+  S s("foo");
+  return s.empty() ? throw "empty" : s;
+}
+
+int main()
+{
+  foo();
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6717_throw_conditional_reject/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6717_throw_conditional_reject/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+
+^ERROR: ESBMC currently does not support a throw-expression in a class-typed conditional$
+\A(?![\s\S]*Unrecognized address_of operand)[\s\S]*\Z

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1079,6 +1079,26 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     const clang::ConditionalOperator &ternary =
       static_cast<const clang::ConditionalOperator &>(stmt);
 
+    // C++ [expr.cond]/2: a throw-expression operand contributes no value, so
+    // the branch has to become a statement rather than something the
+    // conditional's result is built from. Materialising a class-typed
+    // conditional takes the address of each branch, which for the throw is
+    // meaningless and used to abort inside the solver with an irep dump
+    // (issue #6717). Scalar conditionals never materialise, so they are
+    // unaffected and keep working.
+    if (
+      ternary.getType()->isRecordType() &&
+      (llvm::isa<clang::CXXThrowExpr>(
+         ternary.getTrueExpr()->IgnoreParenImpCasts()) ||
+       llvm::isa<clang::CXXThrowExpr>(
+         ternary.getFalseExpr()->IgnoreParenImpCasts())))
+    {
+      log_error(
+        "ESBMC currently does not support a throw-expression in a "
+        "class-typed conditional");
+      return true;
+    }
+
     bool elided = false;
     if (get_conditional_class_prvalue(ternary, new_expr, elided))
       return true;


### PR DESCRIPTION
C++ [expr.cond]/2 gives a throw-expression operand no value — the conditional's type comes from the other operand, and the throw branch simply throws. ESBMC typed it as the *thrown object* instead, so materialising a class-typed conditional took the address of the throw and aborted inside the solver:

```
ERROR: Unrecognized address_of operand:
address_of
* pointer_obj : cpp_throw
```

**This is a diagnostic improvement, not a semantic fix**, and I want to be explicit about that. Doing it properly means lowering the throw branch to a statement, which the expression converter cannot express; I tried simply retyping the branch to the conditional's type and it still took the address. So this rejects the construct at the frontend (exit 6, clear message) rather than aborting in the solver with an irep dump — the "ESBMC shouldn't crash" complaint behind several of these audit issues.

Item 3 of #6717, from `g++.dg/expr/cond16.C`, which now exits cleanly instead of SIGABRT.

Scoped tightly: scalar conditionals never materialise, so `x ? throw 1 : 5` keeps verifying, as does a class-typed conditional without a throw. Both are pinned in `github_6717_throw_conditional_ok` so the rejection cannot widen unnoticed, and the reject test also asserts the old irep dump is gone.

895 C++ tests: 10 failures, all pre-existing.