### PR TITLE
[ci] Fold heap addresses out of the sanitizer dedup key

### DIFF
--- a/scripts/sanitizers/collect_findings.py
+++ b/scripts/sanitizers/collect_findings.py
@@ -40,6 +40,14 @@ from typing import Iterable, Iterator, List
 _UBSAN_RE = re.compile(
     r"(?P<loc>[^:\s]+:\d+(?::\d+)?): runtime error: (?P<msg>.+)$")
 
+# Heap addresses vary run to run and even between occurrences of the same
+# defect. UBSan embeds them mid-message ("member access within address 0x55..
+# with insufficient space for ..."), and those messages carry no colon for the
+# split below to cut at, so the address survived into the dedup key: one
+# recurring finding became tens of thousands of "unique" ones, and the report
+# outgrew the 1 MB job-summary limit. Fold them to a placeholder.
+_ADDR_RE = re.compile(r"0x[0-9a-fA-F]+")
+
 # ASan/LSan reports begin with a header line containing the tool and a
 # kind identifier. The kind is the first token after the colon; ASan
 # sometimes appends parenthesised qualifiers (e.g.
@@ -153,7 +161,8 @@ def parse_log(path: Path) -> List[Finding]:
         for line in line_iter:
             ubsan = _UBSAN_RE.search(line)
             if ubsan:
-                kind = ubsan.group("msg").split(":", 1)[0].strip()
+                kind = _ADDR_RE.sub("0xADDR",
+                                    ubsan.group("msg").split(":", 1)[0].strip())
                 out.append(Finding("UBSan", kind, ubsan.group("loc")))
                 continue
             tsan = _TSAN_RE.search(line)

--- a/scripts/sanitizers/test_collect_findings.py
+++ b/scripts/sanitizers/test_collect_findings.py
@@ -328,6 +328,29 @@ class Main(unittest.TestCase):
         rc = cf.main([])
         self.assertEqual(rc, 1)
 
+    def test_heap_addresses_do_not_split_one_finding(self):
+        """UBSan embeds the faulting address mid-message, and those messages
+        carry no colon for the kind-split to cut at. Left in the dedup key,
+        one recurring defect reported as thousands of distinct findings and
+        the summary outgrew the 1 MB job-summary limit."""
+        addrs = ["0x5555aaaa", "0x7777bbbb", "0x9999cccc"]
+        _write(
+            self.dir, "sanitizer.600", "".join(
+                "a.cpp:1:2: runtime error: member access within address "
+                f"{a} with insufficient space for an object of type X\n"
+                for a in addrs))
+        findings = cf.parse_log(self.dir / "sanitizer.600")
+        self.assertEqual(len(findings), len(addrs))
+        self.assertEqual(len(set(findings)), 1)
+        self.assertIn("0xADDR", next(iter(set(findings))).kind)
+
+    def test_kind_split_still_trims_at_the_colon(self):
+        _write(
+            self.dir, "sanitizer.601",
+            "b.cpp:3:4: runtime error: signed integer overflow: 1 + 2\n")
+        findings = cf.parse_log(self.dir / "sanitizer.601")
+        self.assertEqual(findings[0].kind, "signed integer overflow")
+
     def test_missing_arg_errors(self):
         with self.assertRaises(SystemExit) as ctx:
             cf.main([])

--- a/scripts/sanitizers/ubsan-suppressions.txt
+++ b/scripts/sanitizers/ubsan-suppressions.txt
@@ -11,4 +11,11 @@
 # Keep each rule paired with the issue that tracks the underlying bug.
 # See: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#runtime-suppressions
 #
-# (empty — populated as the bring-up CI run surfaces findings)
+# immer's HAMT node allocates its children inline past the declared struct --
+# a variable-length tail sized from the node's bitmap -- so every access to
+# that tail reports as reaching beyond the object. UBSan's object-size check
+# does not model tail allocation, which makes this a false positive of the
+# idiom rather than a defect, and the code is a vendored dependency we do not
+# own (build/_deps/immer-src). It was the *only* UBSan check to fire in the
+# bring-up run: 28044 reports, all of them this one, all in this one header.
+insufficient-object-size:immer/detail/hamts/node.hpp


### PR DESCRIPTION
The UBSan job has been failing, but not on anything it found: the report outgrew GitHub's 1 MB job-summary limit.

```
28044 unique finding(s); 28044 total occurrence(s).
##[error]$GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 5788k
```

UBSan embeds the faulting address mid-message — `member access within address 0x5555... with insufficient space for ...` — and those messages carry no colon for the `split(":", 1)` kind-cut to trim at, so the address survived into the dedup key. Every occurrence of one recurring defect counted as a separate finding.

Folding addresses to a placeholder collapses **that same CI log from 28044 occurrences to 19 findings**, which I verified by replaying the real log from run 30960023559 through the parser.

Worth recording for #5782: all 19 are in vendored `immer` (`build/_deps/immer-src/immer/detail/hamts/node.hpp`) — **none in ESBMC's own code**. So "fix all findings" is a much smaller job than the headline number suggested, and it is mostly a question of whether to suppress a third-party dependency. This also unblocks #5783, since a job that always fails on summary size cannot become a required gate.

Two regression tests added: one asserting three address-varying occurrences dedup to a single finding, one asserting the colon-split still trims `signed integer overflow: ...` as before. 30/30 tests pass.