### PR TITLE
[test] Pin the diagnostic for a VLA in a structure

### DIFF
--- a/regression/esbmc/github_4086_vla_in_struct/main.c
+++ b/regression/esbmc/github_4086_vla_in_struct/main.c
@@ -1,0 +1,22 @@
+/* A variable-length array as a struct member is a GCC extension that clang
+   declines to implement -- its own diagnostic says the extension "will never
+   be supported" -- so ESBMC, whose frontend is clang, cannot parse it either.
+
+   That is a limitation rather than a defect, but the failure mode still
+   matters: it must stay a clean parse diagnostic and never become a crash.
+   This pins that (issue #4086). */
+void f(int n)
+{
+  struct S
+  {
+    int arr[n];
+  };
+  struct S s;
+  s.arr[0] = 42;
+}
+
+int main(void)
+{
+  f(3);
+  return 0;
+}

--- a/regression/esbmc/github_4086_vla_in_struct/test.desc
+++ b/regression/esbmc/github_4086_vla_in_struct/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^.*fields must have a constant size: 'variable length array in structure'
+^ERROR: PARSING ERROR$


### PR DESCRIPTION
A variable-length array as a struct member is a GCC extension that clang declines to implement — its own diagnostic says the extension "will never be supported" — so ESBMC, whose frontend is clang, cannot parse it either:

```
error: fields must have a constant size: 'variable length array in structure' extension will never be supported
ERROR: PARSING ERROR
```

**This adds no capability, and is not a fix for #4086.** ESBMC already behaves correctly here: a clean parse diagnostic and exit 6, no crash. What it adds is a guard on the failure *mode*, so this cannot silently regress into the SIGSEGV/SIGABRT category that #4076/#4077 were about.

On #4086 itself, the evidence says it is an upstream limitation rather than an ESBMC defect, which the issue already anticipates ("this may be acceptable to classify as a known limitation"). Closing it that way is a maintainer call, so I have not touched the issue — but this test makes the limitation explicit in the suite either way.

Supporting the extension would mean rewriting VLA-in-struct to an `alloca`-based layout ahead of the frontend, i.e. diverging from what clang accepts, for 16 tests.