### PR TITLE
[bmc] label a multi-witness block with the k that produced it

### DIFF
--- a/regression/esbmc/github_4309-large/test.desc
+++ b/regression/esbmc/github_4309-large/test.desc
@@ -4,4 +4,4 @@ main.c
 ^VERIFICATION FAILED$
 \[Counterexamples - 2 witnesses\]
 --max-witnesses cap reached
-^  │    \.\.\. [0-9]+ earlier states omitted \(--full-traces to show them\) \.\.\.$
+^  (│|\|)    \.\.\. [0-9]+ earlier states omitted \(--full-traces to show them\) \.\.\.$

--- a/regression/esbmc/github_4311-ascii/main.c
+++ b/regression/esbmc/github_4311-ascii/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int main(void)
+{
+  int x;
+  if (x > 0)
+    x--;
+  else
+    x++;
+  assert(x != 0);
+  return 0;
+}

--- a/regression/esbmc/github_4311-ascii/test.desc
+++ b/regression/esbmc/github_4311-ascii/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--all-witnesses --ascii-report
+^VERIFICATION FAILED$
+^  \+- Witness 1 of [0-9]+ -+$
+^  \|  Inputs : \[0\] = -?[0-9]+$
+^  \+-+$

--- a/regression/esbmc/github_4314-plain-bmc/main.c
+++ b/regression/esbmc/github_4314-plain-bmc/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+extern int nondet_int(void);
+
+/* The assertion is violable at several unwindings, so an incremental run
+   enumerates witnesses at more than one k. Without the bound in the header
+   the blocks are indistinguishable from a repeat of the same one. */
+int main()
+{
+  int n = nondet_int();
+  __ESBMC_assume(n >= 0 && n <= 12);
+  int s = 0;
+  for (int i = 0; i < n; i++)
+    s += 1;
+  assert(s != 2 && s != 3);
+  return 0;
+}

--- a/regression/esbmc/github_4314-plain-bmc/test.desc
+++ b/regression/esbmc/github_4314-plain-bmc/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--all-witnesses --max-witnesses 2 --unwind 14 --no-unwinding-assertions
+^VERIFICATION FAILED$
+\[Counterexamples - [0-9]+ witnesses\]

--- a/regression/esbmc/github_4314/main.c
+++ b/regression/esbmc/github_4314/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+extern int nondet_int(void);
+
+/* The assertion is violable at several unwindings, so an incremental run
+   enumerates witnesses at more than one k. Without the bound in the header
+   the blocks are indistinguishable from a repeat of the same one. */
+int main()
+{
+  int n = nondet_int();
+  __ESBMC_assume(n >= 0 && n <= 12);
+  int s = 0;
+  for (int i = 0; i < n; i++)
+    s += 1;
+  assert(s != 2 && s != 3);
+  return 0;
+}

--- a/regression/esbmc/github_4314/test.desc
+++ b/regression/esbmc/github_4314/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--incremental-bmc --all-witnesses --keep-verified-claims --max-witnesses 2
+^VERIFICATION FAILED$
+\[Counterexamples - [0-9]+ witnesses at k = 3\]
+\[Counterexamples - [0-9]+ witnesses at k = 4\]

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1,5 +1,8 @@
 #include <csignal>
 #include <memory>
+#ifdef _WIN32
+#  include <windows.h>
+#endif
 #include <sys/types.h>
 #include <algorithm>
 #include <cctype>
@@ -573,15 +576,18 @@ namespace
 {
 /// True when the multi-witness report must avoid box-drawing glyphs. A console
 /// that is not reading UTF-8 renders them as mojibake on every line of the
-/// report (esbmc/esbmc#4311); Windows' default cp1252 console is the common
-/// case, and a POSIX shell in a non-UTF-8 locale the other. An unset locale is
-/// treated as UTF-8 so the common CI shape keeps the richer output.
+/// report (esbmc/esbmc#4311). On Windows the console's code page is queried;
+/// on POSIX the locale environment is read. An unset locale is treated as
+/// UTF-8 so the common CI shape keeps the richer output.
 bool ascii_report(const optionst &options)
 {
   if (options.get_bool_option("ascii-report"))
     return true;
 #ifdef _WIN32
-  return true;
+  // A Windows console is cp1252 by default but can be switched to UTF-8
+  // (`chcp 65001`), so ask it rather than assuming: assuming would also cost
+  // the richer output on a console that renders it correctly.
+  return GetConsoleOutputCP() != CP_UTF8;
 #else
   for (const char *var : {"LC_ALL", "LC_CTYPE", "LANG"})
   {

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -2,6 +2,8 @@
 #include <memory>
 #include <sys/types.h>
 #include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <thread>
 #include <chrono>
 
@@ -569,6 +571,34 @@ void bmct::clear_verified_claims_in_goto(
 
 namespace
 {
+/// True when the multi-witness report must avoid box-drawing glyphs. A console
+/// that is not reading UTF-8 renders them as mojibake on every line of the
+/// report (esbmc/esbmc#4311); Windows' default cp1252 console is the common
+/// case, and a POSIX shell in a non-UTF-8 locale the other. An unset locale is
+/// treated as UTF-8 so the common CI shape keeps the richer output.
+bool ascii_report(const optionst &options)
+{
+  if (options.get_bool_option("ascii-report"))
+    return true;
+#ifdef _WIN32
+  return true;
+#else
+  for (const char *var : {"LC_ALL", "LC_CTYPE", "LANG"})
+  {
+    const char *val = std::getenv(var);
+    if (!val || !*val)
+      continue;
+    std::string v(val);
+    std::transform(v.begin(), v.end(), v.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
+    return v.find("utf-8") == std::string::npos &&
+           v.find("utf8") == std::string::npos;
+  }
+  return false;
+#endif
+}
+
 /// States nearest the failure are the ones that explain it; the rest is
 /// prologue repeated almost verbatim across every witness (#4311). Keep the
 /// last @p keep of them and replace what precedes with a count, so the reader
@@ -721,12 +751,24 @@ void bmct::report_multi_property_trace(
       oss << "\n";
     }
   }
+  // Box-drawing glyphs are mojibake'd by a console that is not reading UTF-8
+  // -- Windows' default cp1252 above all -- which at N witnesses corrupts
+  // every line of the report (esbmc/esbmc#4311).
+  const bool ascii = ascii_report(options);
+  const std::string bar = ascii ? "|" : "│";
+  const std::string head_open = ascii ? "  +- " : "  ┌─ ";
+  const std::string head_fill =
+    ascii ? " -----------------------------" : " ─────────────────────────────";
+  const std::string foot =
+    ascii ? "  +---------------------------------------------\n\n"
+          : "  └──────────────────────────────────────────────\n\n";
+
   for (size_t i = 0; i < witnesses.size(); ++i)
   {
     const witness_recordt &w = witnesses[i];
-    oss << "  ┌─ Witness " << (i + 1) << " of " << witnesses.size()
-        << " ─────────────────────────────\n";
-    oss << "  │  Inputs : ";
+    oss << head_open << "Witness " << (i + 1) << " of " << witnesses.size()
+        << head_fill << "\n";
+    oss << "  " << bar << "  Inputs : ";
     if (w.nondet_inputs.empty())
     {
       oss << "(none)\n";
@@ -746,7 +788,7 @@ void bmct::report_multi_property_trace(
       }
       oss << "\n";
     }
-    oss << "  │  Trace  :\n";
+    oss << "  " << bar << "  Trace  :\n";
     {
       std::ostringstream tr;
       show_goto_trace(tr, ns, w.trace, reachability_trace);
@@ -756,16 +798,17 @@ void bmct::report_multi_property_trace(
         s = keep_last_trace_states(s, kMaxReportedStates);
       std::string indented;
       indented.reserve(s.size() + 8);
-      indented += "  │    ";
+      const std::string lead = "  " + bar + "    ";
+      indented += lead;
       for (char c : s)
       {
         indented += c;
         if (c == '\n')
-          indented += "  │    ";
+          indented += lead;
       }
       oss << indented << "\n";
     }
-    oss << "  └──────────────────────────────────────────────\n\n";
+    oss << foot;
   }
 
   oss << "Summary: " << witnesses.size()

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -664,7 +664,17 @@ void bmct::report_multi_property_trace(
   // tracked separately (#4311).
   oss << (reachability_trace ? "\n[Reachability traces - "
                              : "\n[Counterexamples - ")
-      << witnesses.size() << " witnesses]\n\n";
+      << witnesses.size() << " witnesses";
+  // An incremental run already enumerates at every failing k, not just the
+  // first, so without the bound a reader cannot tell which unwinding produced
+  // a block -- or that two blocks are different unwindings rather than a
+  // repeat (esbmc/esbmc#4314). Plain BMC has one bound, where this is noise.
+  if (options.get_bool_option("incremental-bmc"))
+  {
+    const std::string k = options.get_option("unwind");
+    oss << " at k = " << (k.empty() ? "0" : k);
+  }
+  oss << "]\n\n";
   // Say up front that this is a truncated enumeration. The same fact reaches
   // the Summary footer below, but that sits after every witness block -- tens
   // of kilobytes on a real program -- so a reader can easily act on a partial

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -352,7 +352,11 @@ const struct group_opt_templ all_cmd_options[] = {
     {"full-traces",
      NULL,
      "Print every trace state in the multi-witness report instead of the "
-     "states closest to the failure. Only meaningful with --all-witnesses."}}},
+     "states closest to the failure. Only meaningful with --all-witnesses."},
+    {"ascii-report",
+     NULL,
+     "Draw the multi-witness report with ASCII instead of box-drawing "
+     "characters. Detected automatically from the locale; this forces it."}}},
   {"Output",
    {{"output-goto",
      boost::program_options::value<std::string>(),


### PR DESCRIPTION
#4314 proposes either (1) enumerating witnesses at every SAT k under `--incremental-bmc`, or (2) an opt-in `--all-k-witnesses` flag to do so, and recommends (2).

**Option 1 is already the behaviour.** `--all-witnesses` auto-enables `--multi-property`, which suppresses the early `return 1` in the incremental arm of `do_bmc_strategy`, so the loop already continues past the first failing k. Verified on unpatched master: k=3 reports witnesses and `VERIFICATION FAILED`, then the run proceeds to k=4. So a new flag would gate behaviour that is already on, and the cost the flag was meant to bound is already being paid.

What is actually missing is the tagging the issue asks for. A stacked report renders several `[Counterexamples - N witnesses]` blocks with nothing distinguishing them, so a reader cannot tell which unwinding produced one — or that two blocks are different unwindings rather than a repeat. This names the bound in the header.

The label is scoped to incremental runs; plain BMC has one bound, where it would be noise. That also leaves the ten existing `--all-witnesses` tests byte-unchanged — none of them use `--incremental-bmc`.

Two tests: `github_4314` pins labelled blocks at two different k (the stacked report needs `--keep-verified-claims`, since a failed claim is otherwise not re-checked at later k), and `github_4314-plain-bmc` is the control pinning the unlabelled header under plain BMC.

Refs #4314 — the report-scaling half of that cluster is #4311 and is untouched here.


---

**Note:** this branch currently also carries a second, unrelated commit (`b5e2748186`, the ASCII fallback for the multi-witness report, `Refs #4311`). That was a branching error on my part; it belongs in its own PR and will be split out.
