### PR TITLE
[cpp] Model <typeindex>

### DIFF
--- a/regression/esbmc-cpp/cpp/typeindex_model/main.cpp
+++ b/regression/esbmc-cpp/cpp/typeindex_model/main.cpp
@@ -1,0 +1,35 @@
+// Model for <typeindex>. std::type_index wraps a `const type_info &` so a type
+// can key an associative container; the ordering is required to be consistent
+// within a run but not stable across runs ([type.index]), which is what the
+// underlying type_info model already provides.
+//
+// Missing entirely before, and the largest single header blocking ESBMC's own
+// translation units from parsing (issue #5868).
+#include <typeindex>
+
+int main()
+{
+  std::type_index i1(typeid(int));
+  std::type_index i2(typeid(int));
+  std::type_index c(typeid(char));
+
+  __ESBMC_assert(i1 == i2, "the same type compares equal");
+  __ESBMC_assert(!(i1 != i2), "and not unequal");
+  __ESBMC_assert(i1 != c, "different types compare unequal");
+
+  // A strict weak ordering: irreflexive, and antisymmetric across a pair.
+  __ESBMC_assert(!(i1 < i1), "irreflexive");
+  __ESBMC_assert((i1 < c) != (c < i1), "antisymmetric");
+
+  // The relational operators agree with each other.
+  __ESBMC_assert((i1 < c) == (c > i1), "< and > agree");
+  __ESBMC_assert((i1 <= i2) && (i1 >= i2), "equal compares both <= and >=");
+
+  // hash is consistent with equality, which is what container use relies on.
+  std::hash<std::type_index> h;
+  __ESBMC_assert(h(i1) == h(i2), "equal keys hash equal");
+  __ESBMC_assert(i1.hash_code() == i2.hash_code(), "hash_code agrees");
+
+  __ESBMC_assert(i1.name() == i2.name(), "name is the shared type-name string");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/typeindex_model/test.desc
+++ b/regression/esbmc-cpp/cpp/typeindex_model/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/typeindex_model_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/typeindex_model_fail/main.cpp
@@ -1,0 +1,12 @@
+// Negative counterpart of typeindex_model: distinct types really are
+// distinguished, so a claim that they compare equal is refuted rather than
+// vacuously held (issue #5868).
+#include <typeindex>
+
+int main()
+{
+  std::type_index i(typeid(int));
+  std::type_index c(typeid(char));
+  __ESBMC_assert(i == c, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/typeindex_model_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/typeindex_model_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/typeindex
+++ b/src/cpp/library/typeindex
@@ -1,0 +1,84 @@
+// ESBMC model for <typeindex>
+//
+// std::type_index is a thin, copyable wrapper over a `const type_info &` so
+// that a type can be used as a key in an associative container. Everything it
+// needs is already provided by the <typeinfo> model: equality is pointer
+// comparison on the type-name string, and `before` orders by that same
+// pointer, so the ordering is consistent within a run without being stable
+// across runs -- exactly the guarantee the standard gives ([type.index]).
+//
+// It was the single largest remaining blocker to parsing ESBMC's own sources
+// (issue #5868).
+
+#ifndef ESBMC_TYPEINDEX
+#define ESBMC_TYPEINDEX
+
+#include <cstddef>
+#include <functional> // std::hash, for the specialisation below
+#include <typeinfo>
+
+namespace std
+{
+
+class type_index
+{
+  const type_info *__t;
+
+public:
+  type_index(const type_info &t) _ESBMC_NOEXCEPT : __t(&t)
+  {
+  }
+
+  bool operator==(const type_index &o) const _ESBMC_NOEXCEPT
+  {
+    return *__t == *o.__t;
+  }
+
+  bool operator!=(const type_index &o) const _ESBMC_NOEXCEPT
+  {
+    return *__t != *o.__t;
+  }
+
+  bool operator<(const type_index &o) const _ESBMC_NOEXCEPT
+  {
+    return __t->before(*o.__t);
+  }
+
+  bool operator<=(const type_index &o) const _ESBMC_NOEXCEPT
+  {
+    return !o.__t->before(*__t);
+  }
+
+  bool operator>(const type_index &o) const _ESBMC_NOEXCEPT
+  {
+    return o.__t->before(*__t);
+  }
+
+  bool operator>=(const type_index &o) const _ESBMC_NOEXCEPT
+  {
+    return !__t->before(*o.__t);
+  }
+
+  size_t hash_code() const _ESBMC_NOEXCEPT
+  {
+    return __t->hash_code();
+  }
+
+  const char *name() const _ESBMC_NOEXCEPT
+  {
+    return __t->name();
+  }
+};
+
+template <>
+struct hash<type_index>
+{
+  size_t operator()(type_index t) const
+  {
+    return t.hash_code();
+  }
+};
+
+} // namespace std
+
+#endif


### PR DESCRIPTION
`std::type_index` wraps a `const type_info &` so a type can key an associative container. Everything it needs the `<typeinfo>` model already provides: equality is pointer comparison on the type-name string, and `before` orders by that same pointer — consistent within a run without being stable across runs, which is exactly the guarantee [type.index] gives.

One of the actionable gaps in #5868, which explicitly intends its gaps to be split out. Re-measuring that study on a 60-TU sample of ESBMC's own sources, `<typeindex>` was the **largest single remaining blocker at 22 TUs** — and it is the smallest of the remaining headers to model.

I verified the header is not itself introducing errors: on a TU it unblocks, **zero** diagnostics originate from `typeindex`. Those TUs now fail further in, on pre-existing second-layer gaps (`tuple_size`, `monostate`, `error_condition`) — the Tier-2 layer that study anticipated.

Tests assert the properties container use actually relies on — equality, a strict weak ordering (irreflexive, antisymmetric, and the relational operators agreeing), and hash consistent with equality — plus a negative variant so none of it can pass vacuously.

897 C++ regression tests: 10 failures, all pre-existing.