### PR TITLE
[docs] Discharge the array scope's last two gates

### DIFF
--- a/docs/roadmap/scope-array-assignment-conversion.md
+++ b/docs/roadmap/scope-array-assignment-conversion.md
@@ -1,11 +1,14 @@
 # Scope — the array-typed assignment conversion
 
-> **Status: forward plan, opened 2026-08-03. Not started.**
+> **Status: Phase 1 shipped (#6700), Phase 2 gates discharged 2026-08-05 (§12).
+> The scope's own work is done; the flip it contributes to is not.**
 > `docs/roadmap/scope-coupled-arith-assign-conversion.md` §13.1 discharges every
 > gate that scope owns and closes with the flip blocked on **two mechanisms it
 > explicitly does not own**. This is the owner document for one of them. The
 > other — §9.4's "second mechanism" (`chained-comparison2_fail`, `lambda15`,
-> `precedence2`, `sum_tuple`) — still has none.
+> `precedence2`, `sum_tuple`) — is owned by
+> `scope-relational-float-reconciliation.md`, reopened at its §17 with one
+> witness clearing and nothing shipped.
 >
 > **Verification status of this document.** The tree reads in §3 were performed
 > against `master` on 2026-08-03. The GOTO diff and abort message in §2 are
@@ -219,3 +222,86 @@ a cast of a **pointer** to an **array** type, assigned to a `char[0]`-declared
 variable. §4's warning stands — the existing decay arm emits an `address_of`
 and cannot produce this — as does R1: getting the shape wrong risks the
 array/pointer mismatch at symex rename that the decay arms were added to fix.
+
+## 12. Phase 2 — the gates, discharged (2026-08-05)
+
+Phase 1 shipped as **#6700** (`c5efabb9c1`): an `is_constant_array2t`-guarded
+arm in `python_adjust`'s general assignment conversion that decays the literal
+to `&lit[0]` and casts that pointer to the target array type. That PR claimed
+G1, G2 and G3 and explicitly did **not** claim G4 or G5. Both are discharged
+here, and G1/G3 are re-measured on a wider slice.
+
+### 12.1 G5 — dual-solver agreement
+
+Both witnesses, `--python-irep2-adjust-only --incremental-bmc`:
+
+| witness | Bitwuzla | Z3 |
+|---|---|---|
+| `github_5571_tuple_str_annotation` | SUCCESSFUL | SUCCESSFUL |
+| `github_5571_fail` | FAILED | FAILED |
+
+### 12.2 G4 — the array/pointer mismatch has not returned
+
+G4 asks for the tests that pinned the symex-rename mismatch the decay arms were
+added to fix. #6363's commit message names five; all five agree with legacy
+under the hop-off, and none of them is the witness this scope fixed:
+
+| test | legacy | hop-off |
+|---|---|---|
+| `string-concat6` | SUCCESSFUL | SUCCESSFUL |
+| `string-concat11` | SUCCESSFUL | SUCCESSFUL |
+| `github_3090_4_fail` | FAILED | FAILED |
+| `string18` | SUCCESSFUL | SUCCESSFUL |
+| `string22_fail` | FAILED | FAILED |
+
+The 56 `python_irep2_adjust*` ctest cases — the suite that exercises the
+hop-off directly, including `python_irep2_adjust_only_array_assign{,_fail}`
+added by #6700 — pass 56/56.
+
+### 12.3 G1 and G3, re-measured wider
+
+- **G1**: 30-test hop-off-vs-legacy verdict parity over the array-carrying
+  families (`bytes*`, `str_*`, `concat*`, the three `github_5571` variants),
+  each replayed with its own `test.desc` flags. **30/30 agree**, positives and
+  `_fail` negatives alike.
+- **G2**: `neural-net_fail` (`--fixedbv`) reports FAILED on both paths — the
+  anti-masking gate re-confirmed against the shipped arm, not just the
+  experimental one.
+- **G3**: 317-test default-path ctest slice over the same families, 317/317
+  pass. This is assertion, not proof: `python_adjust` runs only under
+  `python_language.cpp:299`'s flag, so the default path cannot reach the arm.
+
+### 12.4 The shipped guard is narrower than the conversion permits
+
+The arm requires `is_constant_array2t(a.source)`, while
+`check_c_implicit_typecast` permits any array source into an array target of
+the same element type (`c_typecast.cpp:258-268`). The gap is a **non-constant**
+array source meeting a differently-typed array target.
+
+It has no witness. The same function contains one — `s = v` in the loop body —
+and both paths emit it bare, identically, because the types already agree:
+
+```
+legacy:   ASSIGN s=(signed char [16])(&{ 0 }[0]);   ASSIGN s=v;
+hop-off:  ASSIGN s=(signed char [16])(&{ 0 }[0]);   ASSIGN s=v;
+```
+
+Widening the guard to the full permission rule is therefore a change with no
+demonstrated benefit, which is the shape
+`scope-relational-float-reconciliation.md` §16.2 declined to ship. Left as
+recorded scope, not as work.
+
+### 12.5 A trap this re-measurement walked into
+
+§2's abort reproduces perfectly on a binary built before `c5efabb9c1` — the
+defect is fixed in the tree while the artefact still exhibits it. Re-deriving
+Phase 0's answer from that binary produced a patch that duplicated the shipped
+arm. **Check the binary's provenance against the fix commit, not just its
+mtime**, before treating a reproduction as evidence the defect is open.
+
+### 12.6 What this scope hands back
+
+`scope-coupled-arith-assign-conversion.md` Phase 3 owns the flip. Of its two
+blockers this one is now **cleared**; the other is
+`scope-relational-float-reconciliation.md` §17, where one of four witnesses
+clears and the widening that achieved it is still too broad to ship.


### PR DESCRIPTION
#6700 shipped Phase 1 of `scope-array-assignment-conversion.md` and claimed
G1/G2/G3, leaving G4 and G5 unclaimed and the scope document ending at Phase 0.

Both are now measured. G5: Bitwuzla and Z3 agree on each witness under the
hop-off. G4: the five tests #6363 names as pinning the symex-rename
array/pointer mismatch all still agree with legacy, and the 56
`python_irep2_adjust*` cases pass. G1/G3 re-measured wider — 30/30 hop-off
parity, 317/317 default-path.

Also recorded: the shipped guard is narrower than `check_c_implicit_typecast`
permits, and the gap has no witness.
