### PR TITLE
[docs] Fix mutex macro names and the libltl2ba commit link

### DIFF
--- a/website/content/docs/theory/LTL.md
+++ b/website/content/docs/theory/LTL.md
@@ -37,7 +37,7 @@ the implementation diverges from [1].
 | Monitor prefix bound | `-DLTL_PREFIX_BOUND=N`, **required in practice** (default is 2³¹) |
 | Other properties in the same run | **None** — safety and unwinding assertions are masked |
 | Regression coverage | 13 `CORE` tests in `regression/ltl/`, run on Linux, macOS and Windows |
-| Minimum translator version | libltl2ba `master` at [`b810033`](https://github.com/esbmc/libltl2ba/commit/b81003333) or later ([libltl2ba#4](https://github.com/esbmc/libltl2ba/pull/4)) — **later than the v2.1 tag** |
+| Minimum translator version | libltl2ba `master` at [`b810033`](https://github.com/esbmc/libltl2ba/commit/b81003333b5cf2505aeeee1df9355bd97b586ad7) or later ([libltl2ba#4](https://github.com/esbmc/libltl2ba/pull/4)) — **later than the v2.1 tag** |
 
 ## The four-valued verdict
 
@@ -247,7 +247,7 @@ re-checked with different maskings.
 ## Limitations
 
 > **Note**: Everything below was reproduced against ESBMC 8.4.0 paired with
-> libltl2ba at [`b810033`](https://github.com/esbmc/libltl2ba/commit/b81003333).
+> libltl2ba at [`b810033`](https://github.com/esbmc/libltl2ba/commit/b81003333b5cf2505aeeee1df9355bd97b586ad7).
 > The `--ltl` path has no dedicated issue label.
 
 ### Violations were missed *(fixed in 8.4.0)*

--- a/website/content/docs/theory/concurrency.md
+++ b/website/content/docs/theory/concurrency.md
@@ -111,7 +111,7 @@ rather than the host implementation. On the POSIX side that model covers:
 
 | Primitive | Notes |
 |---|---|
-| Mutexes | `PTHREAD_MUTEX_NORMAL`, `RECURSIVE` and `ERRORCHECK`, selected through `pthread_mutexattr_settype`. A recursive re-lock by the owner is not a deadlock; an error-checking one returns `EDEADLK` |
+| Mutexes | `PTHREAD_MUTEX_NORMAL`, `PTHREAD_MUTEX_RECURSIVE` and `PTHREAD_MUTEX_ERRORCHECK`, selected through `pthread_mutexattr_settype`. A recursive re-lock by the owner is not a deadlock; an error-checking one returns `EDEADLK` |
 | Read/write locks | `pthread_rwlock_rdlock` / `wrlock` participate in the wait graph, so a genuine rwlock deadlock is reported |
 | Barriers | `pthread_barrier_init` / `wait` / `destroy`, with waiter accounting |
 | Spinlocks | `pthread_spin_lock` / `trylock` / `unlock` |


### PR DESCRIPTION
Follow-up to the review on #6730. The mutex kind table abbreviated
`PTHREAD_MUTEX_RECURSIVE`/`PTHREAD_MUTEX_ERRORCHECK` to bare `RECURSIVE`/`ERRORCHECK`,
which are not copy-pastable constants; both names are confirmed against
`src/c2goto/library/pthread_lib.c`.

The two libltl2ba links displayed `b810033` but targeted `b81003333`. Both prefixes
resolve (HTTP 200), so nothing was broken, but the targets now carry the full SHA.