### PR TITLE
[cpp] Model <forward_list>

### DIFF
--- a/regression/esbmc-cpp/cpp/forward_list_model/main.cpp
+++ b/regression/esbmc-cpp/cpp/forward_list_model/main.cpp
@@ -1,0 +1,70 @@
+// Model for <forward_list>, which was missing entirely (issue #5868).
+//
+// A singly-linked list over a fixed pool with index links rather than
+// pointers, so the structure survives a copy -- a self-referential pointer
+// would dangle into the source object. std::forward_list deliberately has no
+// size(), and expresses mutation relative to the *preceding* position, which
+// is what before_begin and the _after operations are for.
+#include <forward_list>
+
+int main()
+{
+  std::forward_list<int> l;
+  __ESBMC_assert(l.empty(), "a default-constructed list is empty");
+
+  l.push_front(3);
+  l.push_front(2);
+  l.push_front(1);
+  __ESBMC_assert(!l.empty(), "no longer empty");
+  __ESBMC_assert(l.front() == 1, "push_front puts the newest at the front");
+
+  // Traversal reaches every element, in push order reversed.
+  int seen[3];
+  int n = 0;
+  for (std::forward_list<int>::iterator it = l.begin(); it != l.end(); ++it)
+    seen[n++] = *it;
+  __ESBMC_assert(n == 3, "iteration visits every element exactly once");
+  __ESBMC_assert(
+    seen[0] == 1 && seen[1] == 2 && seen[2] == 3, "and in the right order");
+
+  l.pop_front();
+  __ESBMC_assert(l.front() == 2, "pop_front removes the front");
+
+  // insert_after places the element *after* the given position, and
+  // before_begin() addresses the position preceding the first element.
+  std::forward_list<int> m;
+  m.push_front(3);
+  m.push_front(1);
+  m.insert_after(m.begin(), 2);
+  std::forward_list<int>::iterator second = m.begin();
+  ++second;
+  __ESBMC_assert(m.front() == 1, "insert_after leaves the head alone");
+  __ESBMC_assert(*second == 2, "and places the element after it");
+
+  m.insert_after(m.before_begin(), 0);
+  __ESBMC_assert(m.front() == 0, "before_begin inserts at the head");
+
+  // erase_after removes the element following the position, and returns the
+  // one after that.
+  std::forward_list<int>::iterator after = m.erase_after(m.begin());
+  __ESBMC_assert(m.front() == 0, "erase_after leaves the position itself");
+  __ESBMC_assert(*after == 2, "and returns the element that follows");
+
+  // A copy is independent of its source: the index links must not alias back
+  // into the original's pool.
+  std::forward_list<int> a;
+  a.push_front(1);
+  std::forward_list<int> b = a;
+  b.push_front(2);
+  __ESBMC_assert(a.front() == 1, "the source is unchanged by a copy's push");
+  __ESBMC_assert(b.front() == 2, "and the copy has its own front");
+
+  std::forward_list<int> c;
+  c = a;
+  c.push_front(9);
+  __ESBMC_assert(a.front() == 1, "assignment is independent too");
+
+  l.clear();
+  __ESBMC_assert(l.empty(), "clear empties the list");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/forward_list_model/test.desc
+++ b/regression/esbmc-cpp/cpp/forward_list_model/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/forward_list_model_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/forward_list_model_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative counterpart of forward_list_model: the container really holds the
+// elements pushed into it, so a claim contradicting the traversal order is
+// refuted rather than vacuously held (issue #5868).
+#include <forward_list>
+
+int main()
+{
+  std::forward_list<int> l;
+  l.push_front(2);
+  l.push_front(1);
+  __ESBMC_assert(l.front() == 2, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/forward_list_model_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/forward_list_model_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/forward_list
+++ b/src/cpp/library/forward_list
@@ -1,0 +1,224 @@
+#ifndef __STL_FORWARD_LIST
+#define __STL_FORWARD_LIST
+
+#include "definitions.h"
+
+#define FORWARD_LIST_MAX_SIZE 20
+
+namespace std
+{
+// Singly-linked list over a fixed pool, with index links rather than
+// pointers so the structure survives a copy: a self-referential pointer
+// would dangle into the source object. SENTINEL is "off the end", i.e. a
+// null next or end().
+//
+// std::forward_list deliberately has no size(); mutation is expressed
+// relative to the *preceding* position, which is what before_begin and the
+// _after operations are for.
+template <class T>
+class forward_list
+{
+public:
+  typedef T value_type;
+  typedef T &reference;
+  typedef const T &const_reference;
+  typedef T *pointer;
+  typedef const T *const_pointer;
+  typedef unsigned int size_type;
+  typedef int difference_type;
+
+  static const size_type SENTINEL = FORWARD_LIST_MAX_SIZE;
+  // One slot past the pool stands for before_begin(): advancing from it
+  // yields the head, and nothing dereferences it.
+  static const size_type BEFORE_BEGIN = FORWARD_LIST_MAX_SIZE + 1;
+
+  struct node
+  {
+    T data;
+    size_type next_idx;
+  };
+
+  node _pool[FORWARD_LIST_MAX_SIZE];
+  size_type _head;
+  size_type _free;
+
+  class iterator
+  {
+  public:
+    forward_list<T> *owner;
+    size_type idx;
+
+    iterator() : owner(NULL), idx(SENTINEL)
+    {
+    }
+    iterator(forward_list<T> *o, size_type i) : owner(o), idx(i)
+    {
+    }
+    iterator(const iterator &x) : owner(x.owner), idx(x.idx)
+    {
+    }
+    iterator &operator=(const iterator &x)
+    {
+      owner = x.owner;
+      idx = x.idx;
+      return *this;
+    }
+
+    reference operator*()
+    {
+      return owner->_pool[idx].data;
+    }
+    pointer operator->()
+    {
+      return &owner->_pool[idx].data;
+    }
+
+    iterator &operator++()
+    {
+      idx = (idx == BEFORE_BEGIN) ? owner->_head : owner->_pool[idx].next_idx;
+      return *this;
+    }
+    iterator operator++(int)
+    {
+      iterator tmp(*this);
+      ++(*this);
+      return tmp;
+    }
+
+    bool operator==(const iterator &x) const
+    {
+      return idx == x.idx;
+    }
+    bool operator!=(const iterator &x) const
+    {
+      return idx != x.idx;
+    }
+  };
+
+  typedef iterator const_iterator;
+
+  forward_list() : _head(SENTINEL), _free(0)
+  {
+  }
+
+  forward_list(size_type n, const T &value) : _head(SENTINEL), _free(0)
+  {
+    for (size_type i = 0; i < n; i++)
+      push_front(value);
+  }
+
+  // Copy only the slots in use, as the list model does. The implicit copy
+  // would duplicate the whole fixed pool -- work proportional to the bound
+  // rather than to the contents, on every pass-by-value.
+  forward_list(const forward_list<T> &x) : _head(x._head), _free(x._free)
+  {
+    for (size_type i = 0; i < x._free; i++)
+      _pool[i] = x._pool[i];
+  }
+
+  forward_list<T> &operator=(const forward_list<T> &x)
+  {
+    if (this != &x)
+    {
+      _head = x._head;
+      _free = x._free;
+      for (size_type i = 0; i < x._free; i++)
+        _pool[i] = x._pool[i];
+    }
+    return *this;
+  }
+
+  bool empty() const
+  {
+    return _head == SENTINEL;
+  }
+
+  size_type max_size() const
+  {
+    return FORWARD_LIST_MAX_SIZE;
+  }
+
+  reference front()
+  {
+    return _pool[_head].data;
+  }
+  const_reference front() const
+  {
+    return _pool[_head].data;
+  }
+
+  iterator before_begin()
+  {
+    return iterator(this, BEFORE_BEGIN);
+  }
+  iterator begin()
+  {
+    return iterator(this, _head);
+  }
+  iterator end()
+  {
+    return iterator(this, SENTINEL);
+  }
+
+  void push_front(const T &value)
+  {
+    __ESBMC_assert(
+      _free < FORWARD_LIST_MAX_SIZE, "forward_list exceeded its bounded pool");
+    size_type slot = _free++;
+    _pool[slot].data = value;
+    _pool[slot].next_idx = _head;
+    _head = slot;
+  }
+
+  void pop_front()
+  {
+    __ESBMC_assert(_head != SENTINEL, "pop_front on an empty forward_list");
+    _head = _pool[_head].next_idx;
+  }
+
+  void clear()
+  {
+    _head = SENTINEL;
+    _free = 0;
+  }
+
+  // Insert after `pos` and return an iterator to the new element, per
+  // [forward.list.modifiers].
+  iterator insert_after(iterator pos, const T &value)
+  {
+    __ESBMC_assert(
+      _free < FORWARD_LIST_MAX_SIZE, "forward_list exceeded its bounded pool");
+    size_type slot = _free++;
+    _pool[slot].data = value;
+
+    if (pos.idx == BEFORE_BEGIN)
+    {
+      _pool[slot].next_idx = _head;
+      _head = slot;
+    }
+    else
+    {
+      _pool[slot].next_idx = _pool[pos.idx].next_idx;
+      _pool[pos.idx].next_idx = slot;
+    }
+    return iterator(this, slot);
+  }
+
+  // Erase the element after `pos` and return an iterator to the one that
+  // follows it.
+  iterator erase_after(iterator pos)
+  {
+    size_type victim = (pos.idx == BEFORE_BEGIN) ? _head : _pool[pos.idx].next_idx;
+    __ESBMC_assert(victim != SENTINEL, "erase_after past the end");
+
+    size_type after = _pool[victim].next_idx;
+    if (pos.idx == BEFORE_BEGIN)
+      _head = after;
+    else
+      _pool[pos.idx].next_idx = after;
+    return iterator(this, after);
+  }
+};
+} // namespace std
+
+#endif


### PR DESCRIPTION
`<forward_list>` was missing entirely, so any program including it failed to parse. This adds a singly-linked list over a fixed pool, following the existing `list` model: index links rather than pointers, so the structure survives a copy — a self-referential pointer would dangle into the source object.

The interface follows the standard's shape: no `size()`, and mutation expressed relative to the *preceding* position, which is what `before_begin()` and the `_after` operations are for.

**The copy constructor and assignment are explicit, and that is load-bearing.** Without them the implicit ones copy the whole fixed pool rather than the slots in use — work proportional to the bound, on every pass-by-value. In testing that did not merely cost time: copying a `forward_list` **hung the frontend**, because the whole-pool copy goes through the array-of-class path that #6723 fixes. `std::list` already avoids this by copying only `_next_free` entries; this does the same, and copy independence then verifies. Worth knowing for whoever models the next container.

Third of the actionable gaps in #5868, which intends its gaps to be split out. It was 5 TUs in my re-measurement of that study. ESBMC's own sources never name `forward_list` — they reach it transitively — so I wrote a real bounded model rather than a stub that compiles: a container that parses but misbehaves is a worse trap than one that is absent.

Tests cover traversal order, `insert_after` / `erase_after` / `before_begin` placement and return values, `pop_front`, `clear`, and copy *and* assignment independence, plus a negative variant so none of it passes vacuously. The model also asserts on pool exhaustion and on `pop_front` of an empty list rather than corrupting silently.

901 C++ regression tests: 10 failures, all pre-existing.