### PR TITLE
[cpp] Give pair its tuple protocol in <utility>

### DIFF
--- a/regression/esbmc-cpp11/pair_tuple_interface/main.cpp
+++ b/regression/esbmc-cpp11/pair_tuple_interface/main.cpp
@@ -1,0 +1,39 @@
+// [pair.astuple]: pair participates in the tuple protocol, so std::get,
+// tuple_size and tuple_element must work on it from <utility> alone --
+// <tuple> includes <utility>, not the other way round. Only tuple_element was
+// provided, and from the wrong header (issue #5868).
+#include <utility>
+
+int read_const(const std::pair<int, int> &p)
+{
+  return std::get<1>(p);
+}
+
+int main()
+{
+  __ESBMC_assert(
+    std::tuple_size<std::pair<int, char>>::value == 2, "a pair is a 2-tuple");
+
+  std::pair<int, int> p(7, 8);
+  __ESBMC_assert(std::get<0>(p) == 7 && std::get<1>(p) == 8, "get reads both");
+
+  // get returns a reference, so it writes through to the pair.
+  std::get<0>(p) = 9;
+  __ESBMC_assert(p.first == 9, "get writes through");
+  __ESBMC_assert(read_const(p) == 8, "and has a const overload");
+
+  std::pair<int, char> m(5, 'z');
+  std::tuple_element<1, std::pair<int, char>>::type c = std::get<1>(m);
+  __ESBMC_assert(c == 'z', "tuple_element names the second type");
+
+  // A structured binding calls get on an rvalue; without that overload the
+  // const one wins and the binding fails on the dropped const.
+  std::pair<int, int> q(1, 2);
+  auto [a, b] = q;
+  __ESBMC_assert(a == 1 && b == 2, "structured binding by value");
+
+  auto &[ra, rb] = q;
+  ra = 4;
+  __ESBMC_assert(q.first == 4, "structured binding by reference writes through");
+  return 0;
+}

--- a/regression/esbmc-cpp11/pair_tuple_interface/test.desc
+++ b/regression/esbmc-cpp11/pair_tuple_interface/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/pair_tuple_interface_fail/main.cpp
+++ b/regression/esbmc-cpp11/pair_tuple_interface_fail/main.cpp
@@ -1,0 +1,11 @@
+// Negative counterpart of pair_tuple_interface: get really reads the pair's
+// members, so a claim contradicting them is refuted rather than vacuously
+// held (issue #5868).
+#include <utility>
+
+int main()
+{
+  std::pair<int, int> p(7, 8);
+  __ESBMC_assert(std::get<0>(p) == 8, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp11/pair_tuple_interface_fail/test.desc
+++ b/regression/esbmc-cpp11/pair_tuple_interface_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 4
+^VERIFICATION FAILED$

--- a/src/cpp/library/tuple
+++ b/src/cpp/library/tuple
@@ -92,17 +92,8 @@ struct tuple_element<I, tuple<Head, Tail...>>
   using type = typename tuple_element<I - 1, tuple<Tail...>>::type;
 };
 
-// std::pair is a 2-tuple for tuple_element purposes ([pair.astuple]).
-template <typename T1, typename T2>
-struct tuple_element<0, std::pair<T1, T2>>
-{
-  using type = T1;
-};
-template <typename T1, typename T2>
-struct tuple_element<1, std::pair<T1, T2>>
-{
-  using type = T2;
-};
+// pair's tuple-protocol specialisations live in <utility>, which this header
+// includes: [pair.astuple] requires them to work without <tuple> (issue #5868).
 
 template <std::size_t I, typename Tuple>
 using tuple_element_t = typename tuple_element<I, Tuple>::type;

--- a/src/cpp/library/utility
+++ b/src/cpp/library/utility
@@ -292,6 +292,96 @@ using make_index_sequence = make_integer_sequence<size_t, _Np>;
 }
 #endif
 
+#if __cplusplus >= 201103L
+// [pair.astuple]: pair participates in the tuple protocol, so std::get,
+// tuple_size and tuple_element must work on it from <utility> alone -- <tuple>
+// includes this header, not the other way round, and <type_traits> includes it
+// too, so integral_constant is deliberately not used here (issue #5868).
+template <typename Tuple>
+struct tuple_size;
+
+template <std::size_t I, typename Tuple>
+struct tuple_element;
+
+template <typename T1, typename T2>
+struct tuple_size<pair<T1, T2>>
+{
+  static const std::size_t value = 2;
+};
+
+template <typename T1, typename T2>
+struct tuple_element<0, pair<T1, T2>>
+{
+  typedef T1 type;
+};
+
+template <typename T1, typename T2>
+struct tuple_element<1, pair<T1, T2>>
+{
+  typedef T2 type;
+};
+
+// Index dispatch, so get() selects the member by specialisation rather than
+// by casting between the two member types.
+template <std::size_t I>
+struct __pair_get;
+
+template <>
+struct __pair_get<0>
+{
+  template <typename T1, typename T2>
+  static OM_CONSTEXPR T1 &get(pair<T1, T2> &p)
+  {
+    return p.first;
+  }
+  template <typename T1, typename T2>
+  static OM_CONSTEXPR const T1 &get(const pair<T1, T2> &p)
+  {
+    return p.first;
+  }
+};
+
+template <>
+struct __pair_get<1>
+{
+  template <typename T1, typename T2>
+  static OM_CONSTEXPR T2 &get(pair<T1, T2> &p)
+  {
+    return p.second;
+  }
+  template <typename T1, typename T2>
+  static OM_CONSTEXPR const T2 &get(const pair<T1, T2> &p)
+  {
+    return p.second;
+  }
+};
+
+template <std::size_t I, typename T1, typename T2>
+OM_CONSTEXPR typename tuple_element<I, pair<T1, T2>>::type &get(pair<T1, T2> &p)
+{
+  return __pair_get<I>::get(p);
+}
+
+template <std::size_t I, typename T1, typename T2>
+OM_CONSTEXPR const typename tuple_element<I, pair<T1, T2>>::type &
+get(const pair<T1, T2> &p)
+{
+  return __pair_get<I>::get(p);
+}
+
+// The rvalue overload is not optional here: a structured binding calls get on
+// an rvalue, and without it the const lvalue overload wins and the binding
+// fails on the dropped const.
+template <std::size_t I, typename T1, typename T2>
+OM_CONSTEXPR typename tuple_element<I, pair<T1, T2>>::type &&
+get(pair<T1, T2> &&p)
+{
+  return static_cast<typename tuple_element<I, pair<T1, T2>>::type &&>(
+    __pair_get<I>::get(p));
+}
+
+#endif // __cplusplus >= 201103L
+
 } // namespace std
 
 #endif // ESBMC_UTILITY


### PR DESCRIPTION
[pair.astuple] requires `std::get`, `tuple_size` and `tuple_element` to work on a `pair` from `<utility>` alone — `<tuple>` includes `<utility>`, not the reverse. Only `tuple_element` was provided, and from `<tuple>`, so neither of these compiled:

```cpp
#include <utility>
std::tuple_size<std::pair<int,char>>::value;   // no member named 'tuple_size'
std::get<0>(p);                                // no member named 'get'
```

The `tuple_element` specialisations move from `<tuple>` to `<utility>` rather than being duplicated; `<tuple>` still sees them because it includes it.

**Two things testing caught that I would otherwise have shipped:**

- **The rvalue overload of `get` is not optional.** A structured binding calls `get` on an rvalue, so with only the lvalue overloads the *const* one wins and the binding fails on a dropped const. Adding `tuple_size<pair>` is what makes clang switch from its member-wise binding path to the tuple protocol — so this change is what first exercises `get` there, and `auto [a,b] = p;` regressed until the rvalue overload existed. It worked before this PR only because the protocol was incomplete.
- **The protocol is C++11 and up.** Unguarded, the specialisations broke six C++03 tests: that grammar rejects the nested `>>`, and C++03 has no `std::get` for pair to begin with.

Fourth of the actionable gaps in #5868. Tests cover reading both members, writing through the returned reference, the const overload, `tuple_element`, and structured bindings both by value and by reference — plus a negative variant.

899 C++ tests: 10 failures, all pre-existing. The 2 in cpp14/17/20 are pre-existing too — I confirmed both against a stashed build.