### PR TITLE
[cpp] Add std::monostate to the variant model

### DIFF
--- a/regression/esbmc-cpp17/cpp/monostate_model/main.cpp
+++ b/regression/esbmc-cpp17/cpp/monostate_model/main.cpp
@@ -1,0 +1,32 @@
+// [variant.monostate]: a unit type, so a variant whose first alternative is
+// not default-constructible can still be default-constructed. The variant
+// model listed it as out of scope (issue #5868).
+#include <variant>
+
+int main()
+{
+  std::monostate a, b;
+  __ESBMC_assert(a == b, "all monostate values compare equal");
+  __ESBMC_assert(!(a != b), "and none unequal");
+  __ESBMC_assert(!(a < b) && !(a > b), "neither orders before the other");
+  __ESBMC_assert(a <= b && a >= b, "and both are <= and >=");
+
+  std::variant<std::monostate, int> v;
+  __ESBMC_assert(v.index() == 0, "a variant defaults to monostate");
+  __ESBMC_assert(
+    std::holds_alternative<std::monostate>(v), "and holds it");
+
+  v = 3;
+  __ESBMC_assert(v.index() == 1, "assignment moves the discriminator");
+  __ESBMC_assert(std::get<int>(v) == 3, "and stores the value");
+  __ESBMC_assert(
+    !std::holds_alternative<std::monostate>(v), "no longer the unit type");
+
+  // Note: monostate's other classic use -- letting a variant whose first
+  // alternative is not default-constructible still be default-constructed --
+  // is not reachable here. The model gives each alternative its own member
+  // and value-initialises all of them, so every alternative must be
+  // default-constructible regardless. That is a property of the flat-member
+  // design the header documents, not of monostate.
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/monostate_model/test.desc
+++ b/regression/esbmc-cpp17/cpp/monostate_model/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/monostate_model_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/monostate_model_fail/main.cpp
@@ -1,0 +1,12 @@
+// Negative counterpart of monostate_model: the variant really tracks which
+// alternative it holds, so a claim contradicting the discriminator is refuted
+// rather than vacuously held (issue #5868).
+#include <variant>
+
+int main()
+{
+  std::variant<std::monostate, int> v;
+  v = 3;
+  __ESBMC_assert(v.index() == 0, "must not hold");
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/monostate_model_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/monostate_model_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --unwind 4
+^VERIFICATION FAILED$

--- a/src/cpp/library/variant
+++ b/src/cpp/library/variant
@@ -13,13 +13,45 @@
 // than a real tagged union but observably equivalent for verification and
 // avoids the constexpr/APValue::Union path that ESBMC's converter does
 // not yet handle.  Per [variant] in N4861/P0088.  Out-of-scope: visit()
-// returning non-void, monostate, in_place_type construction past the
-// fourth alternative, and emplace().
+// returning non-void, in_place_type construction past the fourth
+// alternative, and emplace().
 
 namespace std
 {
 
 inline constexpr size_t variant_npos = static_cast<size_t>(-1);
+
+// [variant.monostate]: a unit type, so that a variant whose first alternative
+// is not default-constructible can still be default-constructed. All values
+// compare equal, which is what [variant.monostate.relops] specifies.
+struct monostate
+{
+};
+
+constexpr bool operator==(monostate, monostate) noexcept
+{
+  return true;
+}
+constexpr bool operator!=(monostate, monostate) noexcept
+{
+  return false;
+}
+constexpr bool operator<(monostate, monostate) noexcept
+{
+  return false;
+}
+constexpr bool operator>(monostate, monostate) noexcept
+{
+  return false;
+}
+constexpr bool operator<=(monostate, monostate) noexcept
+{
+  return true;
+}
+constexpr bool operator>=(monostate, monostate) noexcept
+{
+  return true;
+}
 
 namespace __variant_detail
 {


### PR DESCRIPTION
[variant.monostate] specifies a unit type whose values all compare equal. The model listed it as out of scope, so `variant<monostate, T>` — the usual way to spell an empty alternative — did not compile:

```
error: no type named 'monostate' in namespace 'std'
```

Fifth of the actionable gaps in #5868, and one of the second-layer symbols my re-measurement of that study surfaced.

**One caveat, which the test records rather than hides.** monostate's other classic use — letting a variant whose first alternative is *not* default-constructible still be default-constructed — is **not** unlocked by this. The model gives each alternative its own member and value-initialises all of them, so every alternative must be default-constructible regardless of which one is active. My first draft of the test asserted that case and failed; that is a property of the flat-member design the header documents, and lifting it means real storage (a union or an aligned buffer), which is a separate piece of work.

Tests cover the relational operators [variant.monostate.relops], defaulting to the monostate alternative, `holds_alternative`, and that the discriminator moves on assignment — plus a negative variant so none of it passes vacuously.

901 C++ and 119 cpp14/17/20 tests: 10 and 2 failures respectively, all pre-existing.