### PR TITLE
[python] Pin the Any return type lost through an assignment

### DIFF
--- a/regression/python/github_2848-direct-call/main.py
+++ b/regression/python/github_2848-direct-call/main.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+def pick(c: bool) -> Any:
+    if c:
+        return 10
+    return "ten"
+
+
+def main() -> None:
+    # Control for github_2848: asserting on the call directly already works,
+    # which locates the defect in the assignment path rather than in the
+    # return-type inference itself.
+    assert pick(False) == "ten"
+
+
+main()

--- a/regression/python/github_2848-direct-call/test.desc
+++ b/regression/python/github_2848-direct-call/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2848-via-variable/main.py
+++ b/regression/python/github_2848-via-variable/main.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+
+def pick(c: bool) -> Any:
+    if c:
+        return 10
+    return "ten"
+
+
+def main() -> None:
+    # The call site resolves the Any return correctly (see the
+    # -direct-call sibling), but binding it to a variable loses that: the
+    # variable takes the first return literal's type instead, so the
+    # assertion is reported violated even though CPython accepts this.
+    v = pick(False)
+    assert v == "ten"
+
+
+main()

--- a/regression/python/github_2848-via-variable/test.desc
+++ b/regression/python/github_2848-via-variable/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
A reproducer for #2848, narrowed and pinned. Not a fix.

```python
def pick(c: bool) -> Any:
    if c:
        return 10
    return "ten"

v = pick(False)
assert v == "ten"     # VERIFICATION FAILED, reported as `1 == 3` shapes
```

CPython accepts this. ESBMC resolves the `Any` return to the *first* return literal, so `v` is typed int.

The narrowing is the useful part: **asserting on the call directly already works.** `assert pick(False) == "ten"` verifies, because `infer_any_return_from_call`'s `bool_constant` resolves a parameter `Name` through the matching call argument and picks the right branch. Only the assignment path loses it. That places the defect in how an unannotated assignment types its target, not in the `Any` inference itself — narrower than the issue's framing, which proposes reworking this at the symex level.

Two tests: `github_2848-via-variable` (KNOWNBUG, the defect) and `github_2848-direct-call` (CORE, the control that locates it). Both run clean under CPython via `scripts/check_python_tests.sh`; the whole `github_2848*` family is 10/10 under ctest.

I did not attempt the fix: the target path is `create_symbol_for_unannotated_assign`, which calls `get_expr()` before the real processing, and I would rather hand over a pinned boundary than guess at it.

Refs #2848