### PR TITLE
[CI] Fix stale comment on the codecov ignore list

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,9 @@ coverage:
   round: down
   range: "50...80"
 
-# Mirrors the lcov --remove filters in .github/workflows/coverage.yml
+# Codecov-side exclusions. The coverage jobs (pull_request.yml, push.yml) strip
+# only '/usr/*' and '*/build/*' via lcov --remove, so everything else is
+# filtered here rather than in the uploaded report.
 ignore:
   - "src/ansi-c/cpp/**"
   - "src/clang-c-frontend/headers/**"


### PR DESCRIPTION
The comment above `ignore:` points at `.github/workflows/coverage.yml`, which no longer exists. The coverage jobs live in `pull_request.yml` and `push.yml`, and their `lcov --remove` filters strip only `/usr/*` and `*/build/*` — so the globs listed here are Codecov-side exclusions rather than a mirror of the lcov filters.

Comment-only change; no behavioural effect on the uploaded report.