### PR TITLE
[goto-symex] Cover the HTML counterexample report

### DIFF
--- a/regression/esbmc/html_report_c/main.c
+++ b/regression/esbmc/html_report_c/main.c
@@ -1,0 +1,10 @@
+int nondet_int();
+
+int main()
+{
+  int x = nondet_int();
+  __ESBMC_assume(x > 0 && x < 10);
+  int y = x + 1;
+  __ESBMC_assert(y > 100, "y must exceed one hundred");
+  return 0;
+}

--- a/regression/esbmc/html_report_c/main.c
+++ b/regression/esbmc/html_report_c/main.c
@@ -6,5 +6,6 @@ int main()
   __ESBMC_assume(x > 0 && x < 10);
   int y = x + 1;
   __ESBMC_assert(y > 100, "y must exceed one hundred");
+  int from = 0;
   return 0;
 }

--- a/regression/esbmc/html_report_c/test.desc
+++ b/regression/esbmc/html_report_c/test.desc
@@ -5,16 +5,19 @@ main.c
 ^VERIFICATION FAILED$
 CHECK_FILE report-1.html contains <!doctype html><html><head><title>ESBMC report</title>
 CHECK_FILE report-1.html contains <h3>Bug Summary</h3><table class="simpletable">
-CHECK_FILE report-1.html contains <td class="rowname">File:</td><td>/[^<]*html_report_c/main\.c</td>
+CHECK_FILE report-1.html contains <td class="rowname">File:</td><td>[^<]*html_report_c[\\/]main\.c</td>
 CHECK_FILE report-1.html contains <a href="#EndPath">function main, line 8, column 3</a><br />Y must exceed one hundred
-CHECK_FILE report-1.html contains esbmc --[^<]*--generate-html-report=1
-CHECK_FILE report-1.html contains <div id=File1><h4 class=FileName>/[^<]*html_report_c/main\.c</h4>
+CHECK_FILE report-1.html contains esbmc [^<]*--generate-html-report=1
+CHECK_FILE report-1.html contains <div id=File1><h4 class=FileName>[^<]*html_report_c[\\/]main\.c</h4>
 CHECK_FILE report-1.html contains <table class="code" data-fileid="1">
-CHECK_FILE report-1.html contains <tr class="codeline" data-linenumber="1">
+CHECK_FILE report-1.html contains data-linenumber="1"><td class="num" id="LN1">1</td><td class="line"><span class='keyword'>int</span> nondet_int\(\);
 CHECK_FILE report-1.html contains <span class='keyword'>int</span>
-CHECK_FILE report-1.html absent <span class='keyword'>def</span>
+CHECK_FILE report-1.html absent <span class='keyword'>from</span>
 CHECK_FILE report-1.html contains <td>y = [0-9]+</td>
 CHECK_FILE report-1.html contains Assumption restriction
 CHECK_FILE report-1.html contains class="PathIndex PathIndexControl">[0-9]+</div>
-CHECK_FILE report-1.html contains class="PathIndex PathIndexEvent">[0-9]+</div>
+CHECK_FILE report-1.html contains <div id="Path[0-9]+" class="msg msgEvent"
 CHECK_FILE report-1.html contains <div id="EndPath" class="msg msgEvent"
+CHECK_FILE report-1.html contains var relevant_lines = \{"1": \{
+CHECK_FILE report-1.html contains "8": 1
+CHECK_FILE report-1.html contains </table><hr class=divider></body></html>

--- a/regression/esbmc/html_report_c/test.desc
+++ b/regression/esbmc/html_report_c/test.desc
@@ -3,21 +3,23 @@ main.c
 --generate-html-report
 ^Generating HTML report for trace: 1$
 ^VERIFICATION FAILED$
-CHECK_FILE report-1.html contains <!doctype html><html><head><title>ESBMC report</title>
-CHECK_FILE report-1.html contains <h3>Bug Summary</h3><table class="simpletable">
-CHECK_FILE report-1.html contains <td class="rowname">File:</td><td>[^<]*html_report_c[\\/]main\.c</td>
-CHECK_FILE report-1.html contains <a href="#EndPath">function main, line 8, column 3</a><br />Y must exceed one hundred
+CHECK_FILE report-1.html contains <!doctype html>\s*<html>\s*<head>
+CHECK_FILE report-1.html contains <title>ESBMC report</title>
+CHECK_FILE report-1.html contains <h3>Bug Summary</h3>\s*<table class=["']simpletable["']>
+CHECK_FILE report-1.html contains <td class=["']rowname["']>File:</td>\s*<td>[^<]*html_report_c[\\/]main\.c</td>
+CHECK_FILE report-1.html contains <a href=["']#EndPath["']>function main, line 8, column 3</a>\s*<br />Y must exceed one hundred
 CHECK_FILE report-1.html contains esbmc [^<]*--generate-html-report=1
-CHECK_FILE report-1.html contains <div id=File1><h4 class=FileName>[^<]*html_report_c[\\/]main\.c</h4>
-CHECK_FILE report-1.html contains <table class="code" data-fileid="1">
-CHECK_FILE report-1.html contains data-linenumber="1"><td class="num" id="LN1">1</td><td class="line"><span class='keyword'>int</span> nondet_int\(\);
-CHECK_FILE report-1.html contains <span class='keyword'>int</span>
-CHECK_FILE report-1.html absent <span class='keyword'>from</span>
+CHECK_FILE report-1.html contains <div id=["']?File1["']?>\s*<h4 class=["']?FileName["']?>[^<]*html_report_c[\\/]main\.c</h4>
+CHECK_FILE report-1.html contains <table class=["']code["'] data-fileid=["']1["']>
+CHECK_FILE report-1.html contains data-linenumber=["']1["']>\s*<td class=["']num["'] id=["']LN1["']>1</td>\s*<td class=["']line["']><span class=["']keyword["']>int</span> nondet_int\(\);
+CHECK_FILE report-1.html contains <span class=["']keyword["']>int</span>
+CHECK_FILE report-1.html absent <span class=["']keyword["']>from</span>
 CHECK_FILE report-1.html contains <td>y = [0-9]+</td>
 CHECK_FILE report-1.html contains Assumption restriction
-CHECK_FILE report-1.html contains class="PathIndex PathIndexControl">[0-9]+</div>
-CHECK_FILE report-1.html contains <div id="Path[0-9]+" class="msg msgEvent"
-CHECK_FILE report-1.html contains <div id="EndPath" class="msg msgEvent"
+CHECK_FILE report-1.html contains class=["']PathIndex PathIndexControl["']>[0-9]+</div>
+CHECK_FILE report-1.html contains <div id=["']Path[0-9]+["'] class=["']msg msgEvent["']
+CHECK_FILE report-1.html contains <div id=["']EndPath["'] class=["']msg msgEvent["']
 CHECK_FILE report-1.html contains var relevant_lines = \{"1": \{
 CHECK_FILE report-1.html contains "8": 1
-CHECK_FILE report-1.html contains </table><hr class=divider></body></html>
+CHECK_FILE report-1.html contains </table>\s*<hr class=["']?divider["']?>
+CHECK_FILE report-1.html contains </body>\s*</html>

--- a/regression/esbmc/html_report_c/test.desc
+++ b/regression/esbmc/html_report_c/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+--generate-html-report
+^Generating HTML report for trace: 1$
+^VERIFICATION FAILED$
+CHECK_FILE report-1.html contains <!doctype html><html><head><title>ESBMC report</title>
+CHECK_FILE report-1.html contains <h3>Bug Summary</h3><table class="simpletable">
+CHECK_FILE report-1.html contains <td class="rowname">File:</td><td>/[^<]*html_report_c/main\.c</td>
+CHECK_FILE report-1.html contains <a href="#EndPath">function main, line 8, column 3</a><br />Y must exceed one hundred
+CHECK_FILE report-1.html contains esbmc --[^<]*--generate-html-report=1
+CHECK_FILE report-1.html contains <div id=File1><h4 class=FileName>/[^<]*html_report_c/main\.c</h4>
+CHECK_FILE report-1.html contains <table class="code" data-fileid="1">
+CHECK_FILE report-1.html contains <tr class="codeline" data-linenumber="1">
+CHECK_FILE report-1.html contains <span class='keyword'>int</span>
+CHECK_FILE report-1.html absent <span class='keyword'>def</span>
+CHECK_FILE report-1.html contains <td>y = [0-9]+</td>
+CHECK_FILE report-1.html contains Assumption restriction
+CHECK_FILE report-1.html contains class="PathIndex PathIndexControl">[0-9]+</div>
+CHECK_FILE report-1.html contains class="PathIndex PathIndexEvent">[0-9]+</div>
+CHECK_FILE report-1.html contains <div id="EndPath" class="msg msgEvent"

--- a/regression/python/html_report_python_fail/main.py
+++ b/regression/python/html_report_python_fail/main.py
@@ -4,4 +4,6 @@ def double(n: int) -> int:
 
 x: int = double(3)
 assert x > 10
+# Keep a line below the violation: html.cpp renders a trace step at source
+# line L only when the file has more than L lines (off-by-one at html.cpp:649).
 y: int = x + 1

--- a/regression/python/html_report_python_fail/main.py
+++ b/regression/python/html_report_python_fail/main.py
@@ -1,0 +1,7 @@
+def double(n: int) -> int:
+    return n * 2
+
+
+x: int = double(3)
+assert x > 10
+y: int = x + 1

--- a/regression/python/html_report_python_fail/test.desc
+++ b/regression/python/html_report_python_fail/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.py
+--generate-html-report
+^Generating HTML report for trace: 1$
+^VERIFICATION FAILED$
+CHECK_FILE report-1.html contains <h3>Bug Summary</h3><table class="simpletable">
+CHECK_FILE report-1.html contains <div id=File1><h4 class=FileName>/[^<]*html_report_python_fail/main\.py</h4>
+CHECK_FILE report-1.html contains <span class='keyword'>def</span>
+CHECK_FILE report-1.html contains <span class='keyword'>return</span>
+CHECK_FILE report-1.html contains <span class='keyword'>assert</span>
+CHECK_FILE report-1.html absent <span class='keyword'>int</span>
+CHECK_FILE report-1.html contains <div id="EndPath" class="msg msgEvent"

--- a/regression/python/html_report_python_fail/test.desc
+++ b/regression/python/html_report_python_fail/test.desc
@@ -3,10 +3,10 @@ main.py
 --generate-html-report
 ^Generating HTML report for trace: 1$
 ^VERIFICATION FAILED$
-CHECK_FILE report-1.html contains <h3>Bug Summary</h3><table class="simpletable">
-CHECK_FILE report-1.html contains <div id=File1><h4 class=FileName>/[^<]*html_report_python_fail/main\.py</h4>
-CHECK_FILE report-1.html contains <span class='keyword'>def</span>
-CHECK_FILE report-1.html contains <span class='keyword'>return</span>
-CHECK_FILE report-1.html contains <span class='keyword'>assert</span>
-CHECK_FILE report-1.html absent <span class='keyword'>int</span>
-CHECK_FILE report-1.html contains <div id="EndPath" class="msg msgEvent"
+CHECK_FILE report-1.html contains <h3>Bug Summary</h3>\s*<table class=["']simpletable["']>
+CHECK_FILE report-1.html contains <div id=["']?File1["']?>\s*<h4 class=["']?FileName["']?>[^<]*html_report_python_fail[\\/]main\.py</h4>
+CHECK_FILE report-1.html contains <span class=["']keyword["']>def</span>
+CHECK_FILE report-1.html contains <span class=["']keyword["']>return</span>
+CHECK_FILE report-1.html contains <span class=["']keyword["']>assert</span>
+CHECK_FILE report-1.html absent <span class=["']keyword["']>int</span>
+CHECK_FILE report-1.html contains <div id=["']EndPath["'] class=["']msg msgEvent["']


### PR DESCRIPTION
`src/goto-symex/html.cpp` is 0/354 lines in the current Codecov report: no regression test anywhere passes `--generate-html-report`. This adds one C and one Python test that generate a report and assert on its contents, covering report generation, language detection and all three trace-step renderers.

Both are `CORE`, so they run in the coverage build (`build.sh -k ON` implies `CORE_REGRESSION_ONLY`). The assertions pin report structure rather than step-to-line association; the latter is currently wrong (off-by-one at `html.cpp:649`) and is fixed separately.