### PR TITLE
[ci] Report the cyclomatic complexity a PR introduces

### DIFF
--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -1,0 +1,120 @@
+name: Complexity
+
+# Measures the cyclomatic complexity a pull request introduces and reports it on
+# the PR. The metric is *modified* CCN (a switch counts as one decision point),
+# and the check is a delta, not an absolute: ESBMC's median function sits at CCN
+# 3 but ~11% are above 15, so a repo-wide gate would be permanently red and would
+# only ever nag about AST dispatch tables nobody intends to refactor. The rules
+# and partitioning are documented in scripts/complexity/ccn_report.py.
+#
+# Files the PR touches under `regression/` and `unit/` are measured and reported
+# but never gated: a creduce-reduced witness is supposed to be pathological.
+#
+# Bring-up note: `continue-on-error: true` mirrors sanitizers.yml — this runs
+# advisory-only while the artifacts accumulate enough merged-PR data to
+# calibrate the thresholds in ccn_report.py. A follow-up PR drops the flag,
+# adds .config/complexity-allow.txt for deliberate exceptions, and promotes the
+# job to a required check. That PR must also run the *base* branch's copy of
+# ccn_report.py: the script is checked out from the PR head, so while it is
+# advisory a PR may edit its own thresholds, which a required check cannot allow.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Weekly whole-tree snapshot on master, to chart the trend.
+    - cron: "0 4 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  complexity:
+    name: Cyclomatic complexity
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout PR head (not the merge ref)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      # Pinned: an unpinned parser is an unpinned metric.
+      - name: Install lizard
+        run: pip install lizard==1.23.0
+
+      - name: Self-test the report script
+        run: python3 scripts/complexity/test_ccn_report.py
+
+      - name: Report complexity introduced by this PR
+        if: ${{ github.event_name == 'pull_request' }}
+        # base_ref goes through the environment, not string interpolation: a
+        # refname may contain shell metacharacters.
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          base=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "merge base: $base"
+          python3 scripts/complexity/ccn_report.py \
+            --base "$base" --gate \
+            --json complexity.json --markdown complexity.md
+
+      - name: Snapshot the whole tree
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          python3 scripts/complexity/ccn_report.py --snapshot \
+            --json complexity.json --markdown complexity.md
+
+      # Always available, including on fork PRs whose token cannot comment.
+      # Guarded on the file: when an earlier step dies there is no report, and
+      # three more red steps would only bury the real error.
+      - name: Publish to the job summary
+        if: ${{ always() && hashFiles('complexity.md') != '' }}
+        run: cat complexity.md >> "$GITHUB_STEP_SUMMARY"
+
+      # The calibration input for promoting this job to a required check.
+      - name: Upload the full report
+        if: ${{ always() && hashFiles('complexity.md') != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: complexity-${{ github.run_number }}
+          path: |
+            complexity.json
+            complexity.md
+          retention-days: 30
+
+      - name: Comment on the PR
+        # Forks get a read-only token; the job summary above is their report.
+        if: ${{ always() && github.event_name == 'pull_request' &&
+                hashFiles('complexity.md') != '' &&
+                github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            // Update one comment rather than posting per push: unlike the
+            // code-style check this is advisory, so repeated comments are spam.
+            const marker = '<!-- esbmc-complexity-report -->';
+            const body = marker + '\n' + fs.readFileSync('complexity.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments, { owner, repo, issue_number });
+            const mine = comments.find(c => c.body && c.body.includes(marker));
+            if (mine) {
+              await github.rest.issues.updateComment(
+                { owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment(
+                { owner, repo, issue_number, body });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Regression test format (`test.desc`): line 1 is `CORE`/`KNOWNBUG`/`FUTURE`/`THOR
 - Always run the project's test suite. If tests fail, fix the failures before committing — never commit broken or untested code.
 - **Regression suite cap.** When running the full regression suite, cap the run at **5 minutes** (300000 ms) — pass the timeout to the `Bash` tool's `timeout` parameter, or wrap the invocation with `timeout 5m …`. If the suite cannot complete in 5 minutes, narrow the scope (e.g. run only the affected subset) or ask the user before extending the limit.
 - **Lint and typecheck.** Run lint and typecheckers and fix any errors. For Python code, use `pylint`. For C++ code, ensure clang-format compliance (CI enforces this).
+- **Cyclomatic complexity.** `python3 scripts/complexity/ccn_report.py --gate` reports what the branch adds against its merge base, the same check the Complexity workflow runs on the PR (needs `pip install lizard==1.23.0`). It is advisory while the thresholds are being calibrated.
 
 ## Branching
 

--- a/scripts/complexity/ccn_report.py
+++ b/scripts/complexity/ccn_report.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Cyclomatic-complexity report and ratchet for ESBMC pull requests.
+
+ESBMC's median function has a CCN of 3, but ~11% sit above 15 and the top of the
+list is hand-rolled AST dispatch (`migrate_expr`, `convert_ast_node`,
+`clang_c_convertert::get_expr`). A repo-wide absolute gate would therefore be
+permanently red and would only ever nag about jump tables nobody intends to
+refactor. This script gates on what a *pull request changes* instead.
+
+Two rules, both evaluated between the merge base and the PR head:
+
+  R1 new-or-worsened  A function the PR adds lands above its partition's
+                      threshold, or an existing function's CCN increases and
+                      ends above it. Merely touching a file that already
+                      contains a 300-CCN dispatcher is not a violation, and a
+                      function that moves or gains a parameter is matched by
+                      name rather than being read as newly introduced.
+  R2 budget ratchet   The per-partition count of over-threshold functions may
+                      not increase. Catches the growth R1's per-function
+                      matching cannot see, such as one big function replaced
+                      by several renamed ones that are each still too complex.
+
+Complexity is *modified* CCN (lizard's `modified` extension): a switch/match
+with N arms counts as one decision point, not N. Note that this cannot collapse
+a hand-rolled `if (x == A) ... if (x == B) ...` chain, which is why some
+dispatchers stay high; that is the metric working, not a misconfiguration.
+
+Sources are split into four partitions so that `regression/` — 565k LOC of
+deliberately pathological creduce and csmith output — is reported but never
+gated. See PARTITIONS / THRESHOLDS below.
+
+    ccn_report.py                        # working tree vs merge base with master
+    ccn_report.py --base <rev> --gate    # exit 1 on any R1/R2 violation
+    ccn_report.py --snapshot             # whole-tree ranking, no comparison
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+try:
+    import lizard
+except ImportError:  # pragma: no cover - install guidance is the whole message
+    sys.exit("error: lizard is not installed (pip install lizard==1.23.0)")
+
+# The gated partitions live entirely under these roots. `unit/` and
+# `regression/` are deliberately absent: R2 never counts them, and walking 565k
+# LOC of creduce output on both revisions costs minutes for a report nobody
+# gates on, so the `tests` partition is analysed only on the files a PR touches.
+ROOTS = ("src", "scripts")
+
+# Vendored or third-party trees. The first three mirror the clang-format job in
+# .github/workflows/pull_request.yml; ast2json is the vendored Python parser.
+EXCLUDED = (
+    "src/ansi-c/cpp/",
+    "src/clang-c-frontend/headers/",
+    "src/c2goto/library/libm/musl/",
+    "src/python-frontend/libs/",
+)
+
+C_EXTS = (".c", ".cpp", ".cc", ".h", ".hpp", ".hh")
+OM_PREFIXES = ("src/c2goto/library/", "src/cpp/library/")
+PY_PREFIXES = ("src/python-frontend/", "scripts/")
+TEST_PREFIXES = ("unit/", "regression/")
+
+# A partition with a threshold is gated; `tests` has none and stays advisory.
+# `om` is looser because the hand-written C models are branchy by design.
+THRESHOLDS = {"core": 15, "python": 15, "om": 25}
+PARTITIONS = ("core", "python", "om", "tests")
+
+# Rising-but-tolerable functions are worth showing; a brand-new CCN-2 accessor
+# is not. Only report the advisory tail from here up.
+ADVISORY_FLOOR = 8
+
+
+def partition_for(rel):
+    """Return the partition owning `rel`, or None when out of scope."""
+    if rel.startswith(EXCLUDED):
+        return None
+    ext = os.path.splitext(rel)[1]
+    if rel.startswith(TEST_PREFIXES):
+        return "tests" if ext in C_EXTS or ext == ".py" else None
+    if ext == ".py":
+        return "python" if rel.startswith(PY_PREFIXES) else None
+    if ext not in C_EXTS:
+        return None
+    if rel.startswith(OM_PREFIXES):
+        return "om"
+    return "core" if rel.startswith("src/") else None
+
+
+def _record(part, rel, fn):
+    return {
+        "partition": part,
+        "path": rel,
+        "name": fn.name,
+        "long_name": fn.long_name,
+        "ccn": fn.cyclomatic_complexity,
+        "nloc": fn.nloc,
+        "params": fn.parameter_count,
+        "line": fn.start_line,
+    }
+
+
+def _absorb(out, part, rel, functions):
+    for fn in functions:
+        key = (part, rel, fn.long_name)
+        prev = out.get(key)
+        # Same signature twice in one file (macro expansion, #if arms): keep the
+        # worst, so a violation cannot hide behind its twin.
+        if prev is None or fn.cyclomatic_complexity > prev["ccn"]:
+            out[key] = _record(part, rel, fn)
+
+
+def collect(root, strict=False, threads=None, tracked=None):
+    """Map (partition, path, long_name) -> record for every function under root.
+
+    threads > 1 makes lizard fork a process pool, which on spawn platforms
+    requires the calling module to be import-safe; pass threads=1 from callers
+    that are not main-guarded.
+
+    `tracked` restricts the walk to git's view of the revision. Without it the
+    head side would analyse build droppings an in-tree cmake leaves under src/
+    while the base worktree is clean, inventing violations out of nothing.
+    """
+    root = Path(root).resolve()
+    paths = [str(root / r) for r in ROOTS if (root / r).is_dir()]
+    exts = lizard.get_extensions([] if strict else ["modified"])
+    excludes = ["*/" + e + "*" for e in EXCLUDED]
+
+    out = {}
+    for info in lizard.analyze(
+            paths,
+            exclude_pattern=excludes,
+            threads=threads or os.cpu_count() or 4,
+            exts=exts,
+    ):
+        rel = os.path.relpath(info.filename, root)
+        part = partition_for(rel)
+        if part is None or (tracked is not None and rel not in tracked):
+            continue
+        _absorb(out, part, rel, info.function_list)
+    return out
+
+
+def collect_files(root, rels, strict=False):
+    """collect(), restricted to an explicit set of repo-relative paths."""
+    root = Path(root).resolve()
+    analyzer = lizard.FileAnalyzer(lizard.get_extensions([] if strict else ["modified"]))
+    out = {}
+    for rel in sorted(rels):
+        part = partition_for(rel)
+        path = root / rel
+        if part is None or not path.is_file():
+            continue
+        _absorb(out, part, rel, analyzer(str(path)).function_list)
+    return out
+
+
+def git(repo, *args):
+    """Run git in `repo`, exiting with git's own message on failure."""
+    done = subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True, check=False)
+    if done.returncode:
+        sys.exit(f"error: git {' '.join(args)}: {done.stderr.strip()}")
+    return done.stdout.strip()
+
+
+def changed_tests(repo, base_rev, head_rev=None):
+    """`tests`-partition files touched between the revisions (or the worktree)."""
+    spec = [base_rev, head_rev] if head_rev else [base_rev]
+    names = git(repo, "diff", "--name-only", "--diff-filter=d", *spec).split("\n")
+    return [n for n in names if n and partition_for(n) == "tests"]
+
+
+def tracked_files(root):
+    """The repo-relative paths git knows about under `root`."""
+    return set(git(root, "ls-files").split("\n"))
+
+
+def analyse(root, extra_files=(), threads=None, tracked=None):
+    """Gated partitions across the tree, plus the named advisory `tests` files."""
+    records = collect(root, threads=threads, tracked=tracked)
+    records.update(collect_files(root, extra_files))
+    return records
+
+
+def worktree_analyse(repo, rev, extra_files=()):
+    """Analyse `rev` in a throwaway worktree so the checkout is left alone.
+
+    Only the paths the analysis reads are checked out; a full checkout of
+    regression/ dominates the runtime and none of it is needed.
+    """
+    with tempfile.TemporaryDirectory(prefix="esbmc-ccn-") as tmp:
+        tree = os.path.join(tmp, "tree")
+        git(repo, "worktree", "add", "--detach", "--no-checkout", "--quiet", tree, rev)
+        try:
+            wanted = set(ROOTS) | {os.path.dirname(f) for f in extra_files}
+            git(tree, "sparse-checkout", "set", *sorted(wanted))
+            git(tree, "checkout", "--quiet")
+            return analyse(tree, extra_files)
+        finally:
+            subprocess.run(["git", "-C", repo, "worktree", "remove", "--force", tree], check=False)
+            subprocess.run(["git", "-C", repo, "worktree", "prune"], check=False)
+
+
+def over_threshold(rec):
+    """True when `rec` sits above its partition's gate (None = ungated)."""
+    limit = THRESHOLDS.get(rec["partition"])
+    return limit is not None and rec["ccn"] > limit
+
+
+def _prior_ccn(base, by_name, key, rec):
+    """The CCN this function had at base, tolerating a move or a re-signature.
+
+    The exact key is (partition, path, long_name), so `git mv` and any parameter
+    change re-key a function and would otherwise read as newly introduced --
+    which would fail the gate on exactly the refactors it exists to encourage.
+    Fall back to the *worst* same-named function in the partition: if complexity
+    that high already existed under this name, the PR did not introduce it.
+    """
+    if key in base:
+        return base[key]["ccn"]
+    candidates = by_name.get((rec["partition"], rec["name"]))
+    return max(candidates) if candidates else None
+
+
+def compare(base, head):
+    """Apply R1 and R2, returning (violations, advisory, per-partition budget)."""
+    by_name = {}
+    for rec in base.values():
+        by_name.setdefault((rec["partition"], rec["name"]), []).append(rec["ccn"])
+
+    violations, advisory = [], []
+    for key, rec in head.items():
+        before = _prior_ccn(base, by_name, key, rec)
+        if before is not None and rec["ccn"] <= before:
+            continue
+        row = dict(rec, before=before)
+        if over_threshold(rec):
+            violations.append(row)
+        elif rec["ccn"] >= ADVISORY_FLOOR:
+            advisory.append(row)
+
+    counts_before = Counter(r["partition"] for r in base.values() if over_threshold(r))
+    counts_after = Counter(r["partition"] for r in head.values() if over_threshold(r))
+    budget = {
+        p: {
+            "before": counts_before[p],
+            "after": counts_after[p]
+        }
+        for p in PARTITIONS if counts_before[p] or counts_after[p]
+    }
+    return violations, advisory, budget
+
+
+def budget_regressions(budget):
+    """Partitions whose over-threshold population grew (rule R2)."""
+    return {p: d for p, d in budget.items() if d["after"] > d["before"]}
+
+
+def _table(rows, header, cell):
+    lines = ["| " + " | ".join(header) + " |", "|" + "---|" * len(header)]
+    return lines + ["| " + " | ".join(cell(r)) + " |" for r in rows]
+
+
+def render(violations, advisory, budget, strict_ccn=None):
+    """Render the PR report as markdown."""
+    strict_ccn = strict_ccn or {}
+    thresholds = ", ".join(f"`{p}` > {t}" for p, t in sorted(THRESHOLDS.items()))
+    md = [
+        "## Cyclomatic complexity",
+        "",
+        f"Modified CCN, so a switch counts as one decision point. Gated: "
+        f"{thresholds}. `tests` (unit/, regression/) is reported, never gated.",
+        "",
+    ]
+    if not violations and not budget_regressions(budget):
+        md += ["No function this PR adds or worsens exceeds its threshold.", ""]
+
+    def row(r):
+        before = "new" if r["before"] is None else str(r["before"])
+        strict = strict_ccn.get((r["partition"], r["path"], r["long_name"]))
+        return [
+            f"`{r['name']}`",
+            f"{r['path']}:{r['line']}",
+            r["partition"],
+            f"{before} → **{r['ccn']}**",
+            str(strict) if strict is not None else "—",
+        ]
+
+    header = ["function", "location", "partition", "CCN", "strict"]
+    if violations:
+        md += [f"### Over threshold ({len(violations)})", ""]
+        md += _table(sorted(violations, key=lambda r: -r["ccn"]), header, row) + [""]
+    if advisory:
+        shown = sorted(advisory, key=lambda r: -r["ccn"])[:50]
+        md += [
+            f"<details><summary>Below threshold but rising "
+            f"({len(advisory)})</summary>",
+            "",
+        ]
+        md += _table(shown, header, row) + ["", "</details>", ""]
+    if budget:
+        md += ["### Functions over threshold, repo-wide", ""]
+        md += _table(
+            sorted(budget.items()),
+            ["partition", "before", "after", "Δ"],
+            lambda kv: [
+                kv[0],
+                str(kv[1]["before"]),
+                str(kv[1]["after"]),
+                f"{kv[1]['after'] - kv[1]['before']:+d}",
+            ],
+        ) + [""]
+    return "\n".join(md)
+
+
+def render_snapshot(records):
+    """Render the whole-tree distribution and worst offenders as markdown."""
+    ranked = sorted(records.values(), key=lambda r: -r["ccn"])
+    ccns = sorted(r["ccn"] for r in ranked)
+    n = len(ccns)
+    if not n:
+        return "## Cyclomatic complexity snapshot\n\nNo functions found."
+    md = [
+        "## Cyclomatic complexity snapshot",
+        "",
+        f"{n} functions across the gated partitions ({', '.join(sorted(THRESHOLDS))}); "
+        "modified CCN.",
+        "",
+    ]
+    md += _table(
+        [(t, sum(1 for c in ccns if c > t)) for t in (10, 15, 20, 25, 30, 50, 100)],
+        ["CCN >", "functions", "share"],
+        lambda kv: [str(kv[0]), str(kv[1]), f"{100 * kv[1] / n:.1f}%"],
+    )
+    md += [
+        "",
+        f"median {ccns[n // 2]}, p90 {ccns[int(0.9 * n)]}, p99 {ccns[int(0.99 * n)]}",
+        "",
+        "### Top 25",
+        "",
+    ]
+    md += _table(
+        ranked[:25],
+        ["CCN", "function", "location", "partition"],
+        lambda r: [
+            str(r["ccn"]),
+            f"`{r['name']}`",
+            f"{r['path']}:{r['line']}",
+            r["partition"],
+        ],
+    )
+    return "\n".join(md)
+
+
+def run_diff(repo, args):
+    """Compare the two revisions; return (markdown, report, failed)."""
+    base_rev = args.base or git(repo, "merge-base", "origin/master", "HEAD")
+    tests = changed_tests(repo, base_rev, args.head)
+    base = worktree_analyse(repo, base_rev, tests)
+    head = (worktree_analyse(repo, args.head, tests)
+            if args.head else analyse(repo, tests, tracked=tracked_files(repo)))
+
+    # A checkout that half-materialised yields no functions, hence no
+    # violations, hence a green gate reading "nothing exceeds its threshold".
+    # Same for a file lizard fails to parse on one side only: it reports the
+    # failure on stderr and returns an empty function list. Refuse to report on
+    # a head that lost a meaningful share of the base's functions.
+    if len(head) * 2 < len(base):
+        sys.exit(f"error: analysed {len(head)} functions at head vs {len(base)} at "
+                 f"base -- the checkout looks incomplete, refusing to report")
+
+    violations, advisory, budget = compare(base, head)
+
+    # Strict McCabe is context only, so pay for it on the flagged files. It
+    # reads the checkout, so it is only meaningful when the checkout is head.
+    strict_ccn = {}
+    if not args.head:
+        strict_ccn = {
+            k: r["ccn"]
+            for k, r in collect_files(repo, {r["path"]
+                                             for r in violations}, strict=True).items()
+        }
+    report = {
+        "mode": "diff",
+        "base": base_rev,
+        "head": args.head or "worktree",
+        "thresholds": THRESHOLDS,
+        "violations": violations,
+        "advisory": advisory,
+        "budget": budget,
+    }
+    failed = bool(violations) or bool(budget_regressions(budget))
+    return render(violations, advisory, budget, strict_ccn), report, failed
+
+
+def run_snapshot(repo):
+    """Rank the gated partitions; return (markdown, report, failed)."""
+    records = analyse(repo, tracked=tracked_files(repo))
+    ranked = sorted(records.values(), key=lambda r: -r["ccn"])
+    return render_snapshot(records), {"mode": "snapshot", "functions": ranked}, False
+
+
+def main(argv=None):
+    """Entry point; returns the process exit status."""
+    ap = argparse.ArgumentParser(
+        description="Cyclomatic-complexity report and ratchet for ESBMC PRs.")
+    ap.add_argument("--repo", default=".", help="repository root")
+    ap.add_argument("--base", help="base revision (default: merge base with master)")
+    ap.add_argument("--head", help="head revision (default: the working tree)")
+    ap.add_argument("--snapshot", action="store_true", help="rank the whole tree")
+    ap.add_argument("--gate", action="store_true", help="exit 1 on a violation")
+    ap.add_argument("--json", dest="json_out", help="write the full report here")
+    ap.add_argument("--markdown", dest="md_out", help="write the summary here")
+    args = ap.parse_args(argv)
+
+    repo = os.path.abspath(args.repo)
+    markdown, report, failed = (run_snapshot(repo) if args.snapshot else run_diff(repo, args))
+
+    if args.md_out:
+        Path(args.md_out).write_text(markdown, encoding="utf-8")
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=1), encoding="utf-8")
+    print(markdown)
+
+    if failed and args.gate:
+        print("::error::complexity gate: see the table above", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/complexity/test_ccn_report.py
+++ b/scripts/complexity/test_ccn_report.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-test for ccn_report.py. Run: python3 scripts/complexity/test_ccn_report.py
+
+Each case is built from the fixture pair in testdata/{before,after}, which is a
+miniature of the repo layout (src/, regression/) so partitioning is exercised
+too rather than stubbed.
+"""
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+# pylint: disable=wrong-import-position
+import ccn_report as ccn  # noqa: E402
+
+DATA = HERE / "testdata"
+FAILURES = []
+
+
+def check(condition, message):
+    """Record `message` when `condition` does not hold."""
+    if not condition:
+        FAILURES.append(message)
+
+
+def test_partitioning():
+    """Every path lands in the partition its gate depends on."""
+    cases = {
+        "src/goto-symex/symex_main.cpp": "core",
+        "src/util/irep/migrate.h": "core",
+        "src/c2goto/library/string.c": "om",
+        "src/cpp/library/vector": None,
+        "src/python-frontend/models/esbmc.py": "python",
+        "src/python-frontend/libs/ast2json/ast2json.py": None,
+        "src/c2goto/library/libm/musl/exp.c": None,
+        "src/ansi-c/cpp/cpp.cpp": None,
+        "regression/esbmc/github_1/main.c": "tests",
+        "unit/goto-symex/renaming.test.cpp": "tests",
+        "docs/roadmap/plan.md": None,
+        "scripts/complexity/ccn_report.py": "python",
+    }
+    for path, expected in cases.items():
+        got = ccn.partition_for(path)
+        check(got == expected, f"partition_for({path}) = {got}, want {expected}")
+
+
+def test_modified_ccn_collapses_switch():
+    """The `modified` extension must collapse a wide switch to one branch."""
+    key = ("core", "src/dispatch.cpp", "dispatch( int k)")
+    lax = ccn.collect_files(DATA / "before", ["src/dispatch.cpp"])
+    strict = ccn.collect_files(DATA / "before", ["src/dispatch.cpp"], strict=True)
+    check(key in lax and key in strict, f"dispatch not found: {sorted(lax)}")
+    if key in lax and key in strict:
+        check(
+            lax[key]["ccn"] < strict[key]["ccn"] // 2,
+            f"switch not collapsed: modified {lax[key]['ccn']} vs "
+            f"strict {strict[key]['ccn']}",
+        )
+
+
+# What changed_tests() would return for this fixture pair: the advisory files
+# are analysed by name, exactly as production does, not by walking regression/.
+TOUCHED_TESTS = ["regression/esbmc/witness/main.c"]
+
+
+def test_rules():
+    """R1/R2 fire on the fixture pair, and only where they should."""
+    base = ccn.analyse(DATA / "before", TOUCHED_TESTS, threads=1)
+    head = ccn.analyse(DATA / "after", TOUCHED_TESTS, threads=1)
+    violations, advisory, budget = ccn.compare(base, head)
+    check(
+        any(a["name"] == "nasty_reduced_witness" for a in advisory),
+        "the touched regression file should still reach the advisory list",
+    )
+    flagged = {(v["name"], v["partition"]) for v in violations}
+
+    check(
+        ("worsened", "core") in flagged,
+        "R1 missed a function whose CCN rose above the threshold",
+    )
+    check(
+        ("added", "core") in flagged,
+        "R1 missed a newly added over-threshold function",
+    )
+    check(
+        ("dispatch", "core") not in flagged,
+        "an untouched over-threshold dispatcher must not be flagged",
+    )
+    check(
+        ("nasty_reduced_witness", "tests") not in flagged,
+        "regression/ is advisory: it must never produce a violation",
+    )
+    check(
+        any(a["name"] == "grew_a_little" for a in advisory),
+        "a rising but below-threshold function belongs in the advisory list",
+    )
+    check(
+        not any(a["name"] == "tiny" for a in advisory),
+        f"a rise below ADVISORY_FLOOR ({ccn.ADVISORY_FLOOR}) is noise, not signal",
+    )
+    check(
+        ccn.budget_regressions(budget).get("core", {}).get("after", 0) > 0,
+        f"R2 should record a core budget increase, got {budget}",
+    )
+    # `om` is looser than `core`: the same CCN must not trip it.
+    check(
+        ("model_strcmp", "om") not in flagged,
+        "om threshold (25) should tolerate a CCN that core (15) rejects",
+    )
+    # Moved file + new parameter + lower CCN: neither the path nor the
+    # long_name survives, so only the name fallback keeps this off the gate.
+    check(
+        ("relocated", "core") not in flagged,
+        "a function that moved and lost complexity must not read as new",
+    )
+
+
+def test_clean_pr_is_silent():
+    """A PR that changes nothing produces no violation and says so."""
+    base = ccn.analyse(DATA / "before", TOUCHED_TESTS, threads=1)
+    violations, _, budget = ccn.compare(base, base)
+    check(not violations, "comparing a tree with itself must yield no violations")
+    check(not ccn.budget_regressions(budget), "self-comparison must not ratchet")
+    check(
+        "No function this PR adds or worsens" in ccn.render(violations, [], budget),
+        "the clean report should say so explicitly",
+    )
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_"):
+            fn()
+    for failure in FAILURES:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    print(f"{len(FAILURES)} failure(s)")
+    sys.exit(1 if FAILURES else 0)

--- a/scripts/complexity/testdata/after/regression/esbmc/witness/main.c
+++ b/scripts/complexity/testdata/after/regression/esbmc/witness/main.c
@@ -1,0 +1,128 @@
+// Fixture for scripts/complexity/test_ccn_report.py. Not built.
+// The `before`/`after` pair stands in for a PR's merge base and head.
+
+int nasty_reduced_witness(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  if (a == 9)
+    r++;
+  if (a == 10)
+    r++;
+  if (a == 11)
+    r++;
+  if (a == 12)
+    r++;
+  if (a == 13)
+    r++;
+  if (a == 14)
+    r++;
+  if (a == 15)
+    r++;
+  if (a == 16)
+    r++;
+  if (a == 17)
+    r++;
+  if (a == 18)
+    r++;
+  if (a == 19)
+    r++;
+  if (a == 20)
+    r++;
+  if (a == 21)
+    r++;
+  if (a == 22)
+    r++;
+  if (a == 23)
+    r++;
+  if (a == 24)
+    r++;
+  if (a == 25)
+    r++;
+  if (a == 26)
+    r++;
+  if (a == 27)
+    r++;
+  if (a == 28)
+    r++;
+  if (a == 29)
+    r++;
+  if (a == 30)
+    r++;
+  if (a == 31)
+    r++;
+  if (a == 32)
+    r++;
+  if (a == 33)
+    r++;
+  if (a == 34)
+    r++;
+  if (a == 35)
+    r++;
+  if (a == 36)
+    r++;
+  if (a == 37)
+    r++;
+  if (a == 38)
+    r++;
+  if (a == 39)
+    r++;
+  if (a == 40)
+    r++;
+  if (a == 41)
+    r++;
+  if (a == 42)
+    r++;
+  if (a == 43)
+    r++;
+  if (a == 44)
+    r++;
+  if (a == 45)
+    r++;
+  if (a == 46)
+    r++;
+  if (a == 47)
+    r++;
+  if (a == 48)
+    r++;
+  if (a == 49)
+    r++;
+  if (a == 50)
+    r++;
+  if (a == 51)
+    r++;
+  if (a == 52)
+    r++;
+  if (a == 53)
+    r++;
+  if (a == 54)
+    r++;
+  if (a == 55)
+    r++;
+  if (a == 56)
+    r++;
+  if (a == 57)
+    r++;
+  if (a == 58)
+    r++;
+  if (a == 59)
+    r++;
+  return r;
+}

--- a/scripts/complexity/testdata/after/src/c2goto/library/model.c
+++ b/scripts/complexity/testdata/after/src/c2goto/library/model.c
@@ -1,0 +1,46 @@
+/* Fixture for scripts/complexity/test_ccn_report.py. Not built.
+/* The `before`/`after` pair stands in for a PR's merge base and head. */
+
+int model_strcmp(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  if (a == 9)
+    r++;
+  if (a == 10)
+    r++;
+  if (a == 11)
+    r++;
+  if (a == 12)
+    r++;
+  if (a == 13)
+    r++;
+  if (a == 14)
+    r++;
+  if (a == 15)
+    r++;
+  if (a == 16)
+    r++;
+  if (a == 17)
+    r++;
+  if (a == 18)
+    r++;
+  return r;
+}

--- a/scripts/complexity/testdata/after/src/dispatch.cpp
+++ b/scripts/complexity/testdata/after/src/dispatch.cpp
@@ -1,0 +1,91 @@
+// Fixture for scripts/complexity/test_ccn_report.py. Not built.
+// The `before`/`after` pair stands in for a PR's merge base and head.
+
+int dispatch(int k)
+{
+  switch (k)
+  {
+  case 0:
+    return 0 * 2;
+  case 1:
+    return 1 * 2;
+  case 2:
+    return 2 * 2;
+  case 3:
+    return 3 * 2;
+  case 4:
+    return 4 * 2;
+  case 5:
+    return 5 * 2;
+  case 6:
+    return 6 * 2;
+  case 7:
+    return 7 * 2;
+  case 8:
+    return 8 * 2;
+  case 9:
+    return 9 * 2;
+  case 10:
+    return 10 * 2;
+  case 11:
+    return 11 * 2;
+  case 12:
+    return 12 * 2;
+  case 13:
+    return 13 * 2;
+  case 14:
+    return 14 * 2;
+  case 15:
+    return 15 * 2;
+  case 16:
+    return 16 * 2;
+  case 17:
+    return 17 * 2;
+  case 18:
+    return 18 * 2;
+  case 19:
+    return 19 * 2;
+  case 20:
+    return 20 * 2;
+  case 21:
+    return 21 * 2;
+  case 22:
+    return 22 * 2;
+  case 23:
+    return 23 * 2;
+  case 24:
+    return 24 * 2;
+  case 25:
+    return 25 * 2;
+  case 26:
+    return 26 * 2;
+  case 27:
+    return 27 * 2;
+  case 28:
+    return 28 * 2;
+  case 29:
+    return 29 * 2;
+  case 30:
+    return 30 * 2;
+  case 31:
+    return 31 * 2;
+  case 32:
+    return 32 * 2;
+  case 33:
+    return 33 * 2;
+  case 34:
+    return 34 * 2;
+  case 35:
+    return 35 * 2;
+  case 36:
+    return 36 * 2;
+  case 37:
+    return 37 * 2;
+  case 38:
+    return 38 * 2;
+  case 39:
+    return 39 * 2;
+  default:
+    return -1;
+  }
+}

--- a/scripts/complexity/testdata/after/src/funcs.cpp
+++ b/scripts/complexity/testdata/after/src/funcs.cpp
@@ -1,0 +1,124 @@
+// Fixture for scripts/complexity/test_ccn_report.py. Not built.
+// The `before`/`after` pair stands in for a PR's merge base and head.
+
+int worsened(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  if (a == 9)
+    r++;
+  if (a == 10)
+    r++;
+  if (a == 11)
+    r++;
+  if (a == 12)
+    r++;
+  if (a == 13)
+    r++;
+  if (a == 14)
+    r++;
+  if (a == 15)
+    r++;
+  if (a == 16)
+    r++;
+  if (a == 17)
+    r++;
+  return r;
+}
+
+int grew_a_little(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  return r;
+}
+
+int tiny(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  return r;
+}
+
+int added(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  if (a == 9)
+    r++;
+  if (a == 10)
+    r++;
+  if (a == 11)
+    r++;
+  if (a == 12)
+    r++;
+  if (a == 13)
+    r++;
+  if (a == 14)
+    r++;
+  if (a == 15)
+    r++;
+  if (a == 16)
+    r++;
+  if (a == 17)
+    r++;
+  if (a == 18)
+    r++;
+  if (a == 19)
+    r++;
+  return r;
+}

--- a/scripts/complexity/testdata/after/src/new_home.cpp
+++ b/scripts/complexity/testdata/after/src/new_home.cpp
@@ -1,0 +1,42 @@
+// Fixture for scripts/complexity/test_ccn_report.py. Not built.
+// The `before`/`after` pair stands in for a PR's merge base and head.
+
+int relocated(int a, int mode)
+{
+  int r = mode;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  if (a == 9)
+    r++;
+  if (a == 10)
+    r++;
+  if (a == 11)
+    r++;
+  if (a == 12)
+    r++;
+  if (a == 13)
+    r++;
+  if (a == 14)
+    r++;
+  if (a == 15)
+    r++;
+  if (a == 16)
+    r++;
+  return r;
+}

--- a/scripts/complexity/testdata/before/src/dispatch.cpp
+++ b/scripts/complexity/testdata/before/src/dispatch.cpp
@@ -1,0 +1,91 @@
+// Fixture for scripts/complexity/test_ccn_report.py. Not built.
+// The `before`/`after` pair stands in for a PR's merge base and head.
+
+int dispatch(int k)
+{
+  switch (k)
+  {
+  case 0:
+    return 0 * 2;
+  case 1:
+    return 1 * 2;
+  case 2:
+    return 2 * 2;
+  case 3:
+    return 3 * 2;
+  case 4:
+    return 4 * 2;
+  case 5:
+    return 5 * 2;
+  case 6:
+    return 6 * 2;
+  case 7:
+    return 7 * 2;
+  case 8:
+    return 8 * 2;
+  case 9:
+    return 9 * 2;
+  case 10:
+    return 10 * 2;
+  case 11:
+    return 11 * 2;
+  case 12:
+    return 12 * 2;
+  case 13:
+    return 13 * 2;
+  case 14:
+    return 14 * 2;
+  case 15:
+    return 15 * 2;
+  case 16:
+    return 16 * 2;
+  case 17:
+    return 17 * 2;
+  case 18:
+    return 18 * 2;
+  case 19:
+    return 19 * 2;
+  case 20:
+    return 20 * 2;
+  case 21:
+    return 21 * 2;
+  case 22:
+    return 22 * 2;
+  case 23:
+    return 23 * 2;
+  case 24:
+    return 24 * 2;
+  case 25:
+    return 25 * 2;
+  case 26:
+    return 26 * 2;
+  case 27:
+    return 27 * 2;
+  case 28:
+    return 28 * 2;
+  case 29:
+    return 29 * 2;
+  case 30:
+    return 30 * 2;
+  case 31:
+    return 31 * 2;
+  case 32:
+    return 32 * 2;
+  case 33:
+    return 33 * 2;
+  case 34:
+    return 34 * 2;
+  case 35:
+    return 35 * 2;
+  case 36:
+    return 36 * 2;
+  case 37:
+    return 37 * 2;
+  case 38:
+    return 38 * 2;
+  case 39:
+    return 39 * 2;
+  default:
+    return -1;
+  }
+}

--- a/scripts/complexity/testdata/before/src/funcs.cpp
+++ b/scripts/complexity/testdata/before/src/funcs.cpp
@@ -1,0 +1,48 @@
+// Fixture for scripts/complexity/test_ccn_report.py. Not built.
+// The `before`/`after` pair stands in for a PR's merge base and head.
+
+int worsened(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  if (a == 9)
+    r++;
+  if (a == 10)
+    r++;
+  return r;
+}
+
+int grew_a_little(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  return r;
+}
+
+int tiny(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  return r;
+}

--- a/scripts/complexity/testdata/before/src/old_home.cpp
+++ b/scripts/complexity/testdata/before/src/old_home.cpp
@@ -1,0 +1,48 @@
+// Fixture for scripts/complexity/test_ccn_report.py. Not built.
+// The `before`/`after` pair stands in for a PR's merge base and head.
+
+int relocated(int a)
+{
+  int r = 0;
+  if (a == 0)
+    r++;
+  if (a == 1)
+    r++;
+  if (a == 2)
+    r++;
+  if (a == 3)
+    r++;
+  if (a == 4)
+    r++;
+  if (a == 5)
+    r++;
+  if (a == 6)
+    r++;
+  if (a == 7)
+    r++;
+  if (a == 8)
+    r++;
+  if (a == 9)
+    r++;
+  if (a == 10)
+    r++;
+  if (a == 11)
+    r++;
+  if (a == 12)
+    r++;
+  if (a == 13)
+    r++;
+  if (a == 14)
+    r++;
+  if (a == 15)
+    r++;
+  if (a == 16)
+    r++;
+  if (a == 17)
+    r++;
+  if (a == 18)
+    r++;
+  if (a == 19)
+    r++;
+  return r;
+}


### PR DESCRIPTION
Adds an advisory Complexity workflow driving lizard's modified CCN (a switch
counts as one decision point) over the merge-base/head delta, so a PR is judged
on the complexity it adds rather than on ESBMC's existing distribution, where
~11% of functions already exceed 15.

Gated partitions are core/python (>15) and the C operational models (>25); files
touched under `unit/` and `regression/` are reported only. The job runs with
`continue-on-error` while its artifacts accumulate the data needed to calibrate
the thresholds before it becomes a required check.