### PR TITLE
[util] Do not construct a std::string from an unset HOME

### DIFF
--- a/src/util/config/cmdline.cpp
+++ b/src/util/config/cmdline.cpp
@@ -193,10 +193,12 @@ std::string cmdlinet::expand_user(std::string const path) const
 {
   std::string result = std::string(path);
 
-  // Case ~
-  const std::optional<std::string> home_path = std::getenv(HOME_ENV_NAME);
+  // Case ~. Test the pointer, not an optional wrapping it: an unset variable
+  // yields nullptr, and std::optional<std::string> would construct the string
+  // from it before the guard runs, which is UB (#6238).
+  const char *home_path = std::getenv(HOME_ENV_NAME);
   if (!result.empty() && result[0] == '~' && home_path)
-    result.replace(0, 1, home_path.value());
+    result.replace(0, 1, home_path);
 
   return std::filesystem::absolute(result).string();
 }

--- a/unit/util/CMakeLists.txt
+++ b/unit/util/CMakeLists.txt
@@ -17,3 +17,4 @@ new_unit_test(migratetest "migrate.test.cpp" "util_esbmc")
 new_unit_test(arith_tools_test "arith_tools.test.cpp" "util_esbmc")
 # Running the fuzzer normally would overflow the /tmp with files.
 new_fast_fuzz_test(filesystemfuzz "filesystem.fuzz.cpp" "filesystem")
+new_unit_test(cmdlinetest "cmdline.test.cpp" "util_esbmc")

--- a/unit/util/cmdline.test.cpp
+++ b/unit/util/cmdline.test.cpp
@@ -7,8 +7,16 @@
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#  include <stdlib.h> // _putenv_s
+// Mirrors HOME_ENV_NAME in src/util/config/cmdline.cpp; keep the two in step.
+#  define HOME_ENV_NAME "USERPROFILE"
+#else
+#  define HOME_ENV_NAME "HOME"
+#endif
+
 // Reaching config-file location resolution is what matters here: parse()
-// expands the default "~/.config/esbmc.toml" before it can consult HOME.
+// expands the default config path before it can consult the home variable.
 // Built afresh per call: parse() hands each value_semantic to boost, which
 // takes ownership, so one table cannot serve two parses.
 static std::vector<group_opt_templ> make_test_options()
@@ -24,7 +32,24 @@ static std::vector<group_opt_templ> make_test_options()
 
 namespace
 {
-/// Restores HOME on scope exit so one section cannot leak into the next.
+/// Sets the home variable, or removes it from the environment when `value` is
+/// null.
+void put_home(const char *value)
+{
+#ifdef _WIN32
+  // The MSVC CRT has no setenv/unsetenv; _putenv_s removes a variable when
+  // given an empty value, and rejects a null one.
+  _putenv_s(HOME_ENV_NAME, value ? value : "");
+#else
+  if (value)
+    setenv(HOME_ENV_NAME, value, 1);
+  else
+    unsetenv(HOME_ENV_NAME);
+#endif
+}
+
+/// Restores the home variable on scope exit so one section cannot leak into
+/// the next.
 struct scoped_home
 {
   bool had_home;
@@ -32,31 +57,27 @@ struct scoped_home
 
   explicit scoped_home(const char *value)
   {
-    const char *current = std::getenv("HOME");
+    const char *current = std::getenv(HOME_ENV_NAME);
     had_home = current != nullptr;
     if (had_home)
       saved = current;
-    if (value)
-      setenv("HOME", value, 1);
-    else
-      unsetenv("HOME");
+    put_home(value);
   }
 
   ~scoped_home()
   {
-    if (had_home)
-      setenv("HOME", saved.c_str(), 1);
-    else
-      unsetenv("HOME");
+    put_home(had_home ? saved.c_str() : nullptr);
   }
 };
 } // namespace
 
-TEST_CASE("cmdline parses with HOME unset", "[core][util][cmdline]")
+TEST_CASE(
+  "cmdline parses with the home variable unset",
+  "[core][util][cmdline]")
 {
   const char *argv[] = {"esbmc", "main.c"};
 
-  SECTION("HOME absent from the environment")
+  SECTION("home variable absent from the environment")
   {
     // Constructing std::optional<std::string> from getenv's null return is UB
     // and aborted or crashed the process before any work was done (#6238).
@@ -68,7 +89,10 @@ TEST_CASE("cmdline parses with HOME unset", "[core][util][cmdline]")
     REQUIRE(cmdline.args[0] == "main.c");
   }
 
-  SECTION("HOME set but empty")
+#ifndef _WIN32
+  // Windows cannot hold an empty-but-set variable -- _putenv_s deletes one
+  // assigned "" -- so there this case would just repeat the one above.
+  SECTION("home variable set but empty")
   {
     scoped_home empty_home("");
     const std::vector<group_opt_templ> opts = make_test_options();
@@ -76,8 +100,9 @@ TEST_CASE("cmdline parses with HOME unset", "[core][util][cmdline]")
     REQUIRE_FALSE(cmdline.parse(2, argv, opts.data()));
     REQUIRE(cmdline.args[0] == "main.c");
   }
+#endif
 
-  SECTION("HOME set")
+  SECTION("home variable set")
   {
     scoped_home a_home("/tmp");
     const std::vector<group_opt_templ> opts = make_test_options();

--- a/unit/util/cmdline.test.cpp
+++ b/unit/util/cmdline.test.cpp
@@ -1,0 +1,88 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <util/config/cmdline.h>
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+// Reaching config-file location resolution is what matters here: parse()
+// expands the default "~/.config/esbmc.toml" before it can consult HOME.
+// Built afresh per call: parse() hands each value_semantic to boost, which
+// takes ownership, so one table cannot serve two parses.
+static std::vector<group_opt_templ> make_test_options()
+{
+  return {
+    {"Basic Usage",
+     {{"input-file",
+       boost::program_options::value<std::vector<std::string>>(),
+       "source file names"}}},
+    {"end", {{"", NULL, "end of options"}}},
+    {"Hidden Options", {{"", NULL, ""}}}};
+}
+
+namespace
+{
+/// Restores HOME on scope exit so one section cannot leak into the next.
+struct scoped_home
+{
+  bool had_home;
+  std::string saved;
+
+  explicit scoped_home(const char *value)
+  {
+    const char *current = std::getenv("HOME");
+    had_home = current != nullptr;
+    if (had_home)
+      saved = current;
+    if (value)
+      setenv("HOME", value, 1);
+    else
+      unsetenv("HOME");
+  }
+
+  ~scoped_home()
+  {
+    if (had_home)
+      setenv("HOME", saved.c_str(), 1);
+    else
+      unsetenv("HOME");
+  }
+};
+} // namespace
+
+TEST_CASE("cmdline parses with HOME unset", "[core][util][cmdline]")
+{
+  const char *argv[] = {"esbmc", "main.c"};
+
+  SECTION("HOME absent from the environment")
+  {
+    // Constructing std::optional<std::string> from getenv's null return is UB
+    // and aborted or crashed the process before any work was done (#6238).
+    scoped_home no_home(nullptr);
+    const std::vector<group_opt_templ> opts = make_test_options();
+    cmdlinet cmdline;
+    REQUIRE_FALSE(cmdline.parse(2, argv, opts.data()));
+    REQUIRE(cmdline.args.size() == 1);
+    REQUIRE(cmdline.args[0] == "main.c");
+  }
+
+  SECTION("HOME set but empty")
+  {
+    scoped_home empty_home("");
+    const std::vector<group_opt_templ> opts = make_test_options();
+    cmdlinet cmdline;
+    REQUIRE_FALSE(cmdline.parse(2, argv, opts.data()));
+    REQUIRE(cmdline.args[0] == "main.c");
+  }
+
+  SECTION("HOME set")
+  {
+    scoped_home a_home("/tmp");
+    const std::vector<group_opt_templ> opts = make_test_options();
+    cmdlinet cmdline;
+    REQUIRE_FALSE(cmdline.parse(2, argv, opts.data()));
+    REQUIRE(cmdline.args[0] == "main.c");
+  }
+}


### PR DESCRIPTION
`expand_user()` wrapped `getenv()`'s result in `std::optional<std::string>`,
whose converting constructor builds the string before the null guard on the
next line runs. With HOME unset every ESBMC invocation hit that UB while
resolving the default config path, throwing under libstdc++ and crashing
under libc++.

Fixes #6238.