### PR TITLE
[build] Run a platform-sensitive test set on the macOS leg

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -76,11 +76,16 @@ jobs:
         # when tests set TIMEOUT via set_tests_properties (regression/CMakeLists.txt),
         # so we override the cache variable that feeds it and reconfigure.
         cmake -DESBMC_REGRESS_TIMEOUT=120 .
-        # macOS PR: only the python/ suite (anchored — excludes python-intensive
-        # and python-coverage, which already run on Linux). The Python frontend is
-        # the one part of ESBMC whose toolchain materially differs across OSes
-        # (Homebrew Python, stdlib paths); the rest of the regression suite is
-        # platform-portable and covered by the Linux PR job.
+        # macOS PR: the python/ suite (anchored — excludes python-intensive
+        # and python-coverage, which already run on Linux), plus the
+        # platform-sensitive set. The Python frontend is the one part of ESBMC
+        # whose toolchain materially differs across OSes (Homebrew Python,
+        # stdlib paths); the rest of the regression suite is platform-portable
+        # and covered by the Linux PR job. The exception is behaviour that is
+        # genuinely OS-specific — resource limits, threading, signals, memory
+        # mapping, filesystem semantics — which passes on Linux and fails on
+        # macOS with no signal from CI (#6619). Tests covering that opt in via
+        # ESBMC_PLATFORM_SENSITIVE_TESTS in regression/CMakeLists.txt.
         # On PR Linux, skip python-intensive to keep fast feedback.
         # On other systems/events (push, dispatch), run everything.
         #
@@ -89,10 +94,10 @@ jobs:
         # peaks ~8GB, map/multimap _string_class-2_bug ~3GB each). Under -j4 on a
         # 16GB runner these can align and exhaust RAM, ending the job with a
         # "runner received a shutdown signal" (OOM). Run the Linux legs with -j2
-        # to bound peak concurrent memory. The macOS leg runs only the light
-        # python/ suite and keeps -j4.
+        # to bound peak concurrent memory. The macOS leg runs the light python/
+        # suite plus a handful of platform-sensitive tests, and keeps -j4.
         if [[ "${{ inputs.operating-system }}" =~ ^macos ]]; then
-          ctest -j4 --output-on-failure --progress -L '^python/$'
+          ctest -j4 --output-on-failure --progress -L '^python/$|^platform-sensitive$'
         elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
           ctest -j2 --output-on-failure --progress -LE python-intensive .
         else

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -79,6 +79,19 @@ endif()
 string(REPLACE ";" "," ESBMC_TEST_CAPABILITIES_ARG "${ESBMC_TEST_CAPABILITIES}")
 message(STATUS "Regression capabilities: ${ESBMC_TEST_CAPABILITIES_ARG}")
 
+# Tests covering behaviour that is genuinely OS-specific -- resource limits,
+# threading, signals, memory mapping, filesystem semantics -- named as
+# "<folder>/<test>". The macOS CI leg runs only the python/ suite, so without
+# this a change of that kind passes on Linux and fails on macOS with no signal
+# from CI; #6617 was fixed twice for exactly that reason. These carry the
+# platform-sensitive label, which the macOS leg also selects (#6619).
+set(ESBMC_PLATFORM_SENSITIVE_TESTS
+    # Deep expression nesting: needs the large-stack thread main.cpp spawns,
+    # since raising RLIMIT_STACK does not grow the main thread's stack on
+    # macOS even though setrlimit reports success (#6618).
+    esbmc/deep_binary_chain_pass
+    esbmc/deep_binary_chain_fail)
+
 # An optional 5th argument names a backend to run the suite under. The tool
 # string is shlex-split by testing_tool.py, so the extra option rides along with
 # the binary; --default-solver only applies when the test itself names no
@@ -92,6 +105,9 @@ function(add_esbmc_regression_test folder modes test)
         set(test_name "${test_name}[${solver}]")
         set(tool "${ESBMC_BIN} --default-solver=${solver}")
         set(extra_labels ";cross-backend;cross-backend/${solver}")
+    endif()
+    if("${folder}/${test}" IN_LIST ESBMC_PLATFORM_SENSITIVE_TESTS)
+        string(APPEND extra_labels ";platform-sensitive")
     endif()
     add_test(NAME ${test_name}
              COMMAND ${Python_EXECUTABLE} ${ESBMC_REGRESSION_TOOL}


### PR DESCRIPTION
The macOS leg runs only the `python/` suite, so behaviour that is genuinely
OS-specific — resource limits, threading, signals, memory mapping, filesystem
semantics — passes on Linux and fails on macOS with no signal from CI. #6617
was fixed twice for that reason. Tests covering such behaviour now opt into a
`platform-sensitive` label that the macOS leg also selects.

Fixes #6619.