### PR TITLE
[contracts] Enforce a contract that is only __ESBMC_assigns()

### DIFF
--- a/regression/function_contract/assigns_empty_only/main.c
+++ b/regression/function_contract/assigns_empty_only/main.c
@@ -1,0 +1,17 @@
+int g;
+
+/* An empty frame condition is the whole contract: pure writes nothing
+   outside its own locals (GitHub #6555). */
+int pure(int x)
+{
+  __ESBMC_assigns();
+  return x + 1;
+}
+
+int main(void)
+{
+  g = 7;
+  __ESBMC_assert(pure(1) == 2, "pure returns x + 1");
+  __ESBMC_assert(g == 7, "pure leaves g alone");
+  return 0;
+}

--- a/regression/function_contract/assigns_empty_only/test.desc
+++ b/regression/function_contract/assigns_empty_only/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enforce-contract pure
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/assigns_empty_only_fail/main.c
+++ b/regression/function_contract/assigns_empty_only_fail/main.c
@@ -1,0 +1,15 @@
+int g;
+
+/* Declares an empty frame condition but writes a global: the assigns
+   compliance check must catch it (GitHub #6555). */
+int impure(int x)
+{
+  __ESBMC_assigns();
+  g = x;
+  return x + 1;
+}
+
+int main(void)
+{
+  return impure(1) - 2;
+}

--- a/regression/function_contract/assigns_empty_only_fail/test.desc
+++ b/regression/function_contract/assigns_empty_only_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--enforce-contract impure
+^VERIFICATION FAILED$
+assigns compliance: c:@g not in assigns clause

--- a/regression/function_contract/assigns_empty_replace/main.c
+++ b/regression/function_contract/assigns_empty_replace/main.c
@@ -1,0 +1,17 @@
+int g;
+
+/* Assigns-only contract, no requires/ensures: replacing the call must still
+   honour the empty frame condition and leave g alone (GitHub #6555). */
+int pure(int x)
+{
+  __ESBMC_assigns();
+  return x + 1;
+}
+
+int main(void)
+{
+  g = 3;
+  pure(1);
+  __ESBMC_assert(g == 3, "replaced call writes nothing");
+  return 0;
+}

--- a/regression/function_contract/assigns_empty_replace/test.desc
+++ b/regression/function_contract/assigns_empty_replace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract pure
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -962,7 +962,10 @@ std::set<std::string> code_contractst::enforce_contracts(
     // deserve enforcement: the assigns compliance check is the contract.
     std::vector<expr2tc> assigns_targets_early =
       extract_assigns_from_body(original_body_copy);
-    bool has_assigns = !assigns_targets_early.empty();
+    // An explicit __ESBMC_assigns() yields no targets but is still a frame
+    // condition -- the strongest one, naming nothing (#6555).
+    bool has_assigns = !assigns_targets_early.empty() ||
+                       has_empty_assigns_marker(original_body_copy);
 
     // For annotated functions without explicit contracts, use default true/true
     // This allows the function to be processed with default contract semantics.
@@ -1187,6 +1190,13 @@ goto_programt code_contractst::generate_checking_wrapper(
 {
   goto_programt wrapper;
   locationt location = original_func.location;
+
+  // A declared frame condition, whether or not it names any target. An
+  // explicit __ESBMC_assigns() names nothing, which enforce_frame_rule reads
+  // as "every snapshotted global must be unchanged" -- the check that makes
+  // the empty clause mean anything (#6555).
+  const bool declares_frame =
+    !assigns_targets.empty() || has_empty_assigns_marker(original_body);
 
   // Note: Here is the design, enforce_contracts mode does NOT havoc
   // parameters or globals. The wrapper is called by actual callers, so we
@@ -1468,7 +1478,7 @@ goto_programt code_contractst::generate_checking_wrapper(
   std::vector<ptr_deref_snapshot_t> ptr_deref_snaps;
   std::vector<arr_elem_snapshot_t> arr_elem_snaps;
   frame_enforcert::classified_assignst classified_assigns;
-  if (check_assigns_compliance && !assigns_targets.empty())
+  if (check_assigns_compliance && declares_frame)
   {
     std::string func_name = id2string(original_func.name);
 
@@ -1679,7 +1689,7 @@ goto_programt code_contractst::generate_checking_wrapper(
   }
 
   // 3c. Assert assigns compliance (after function call, before ensures)
-  if (check_assigns_compliance && !assigns_targets.empty())
+  if (check_assigns_compliance && declares_frame)
   {
     log_debug(
       "contracts",
@@ -3661,6 +3671,12 @@ expr2tc code_contractst::normalize_ensures_guard_for_return_value(
 
 bool code_contractst::has_contracts(const goto_programt &function_body) const
 {
+  // __ESBMC_assigns() lowers to an ASSERT marker, not an ASSUME, so the comment
+  // scan below cannot see it. An empty frame condition is a whole contract on
+  // its own: it states the function writes nothing outside its locals (#6555).
+  if (has_empty_assigns_marker(function_body))
+    return true;
+
   // Quick check: scan for contract markers without extracting full clauses
   forall_goto_program_instructions (it, function_body)
   {

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -706,6 +706,17 @@ static bool has_empty_assigns_marker(const goto_programt &function_body)
   return false;
 }
 
+// A frame condition is declared whether or not it names any target: an
+// explicit __ESBMC_assigns() names nothing, which enforce_frame_rule reads as
+// "every snapshotted global must be unchanged" -- the check that makes the
+// empty clause mean anything (#6555).
+static bool declares_frame_condition(
+  const std::vector<expr2tc> &assigns_targets,
+  const goto_programt &function_body)
+{
+  return !assigns_targets.empty() || has_empty_assigns_marker(function_body);
+}
+
 // Helper function to unwrap array-to-pointer decay in assigns targets
 // In C, when an array is passed to a function, it decays to &arr[0].
 // This function detects this pattern and returns the original array.
@@ -962,10 +973,8 @@ std::set<std::string> code_contractst::enforce_contracts(
     // deserve enforcement: the assigns compliance check is the contract.
     std::vector<expr2tc> assigns_targets_early =
       extract_assigns_from_body(original_body_copy);
-    // An explicit __ESBMC_assigns() yields no targets but is still a frame
-    // condition -- the strongest one, naming nothing (#6555).
-    bool has_assigns = !assigns_targets_early.empty() ||
-                       has_empty_assigns_marker(original_body_copy);
+    bool has_assigns =
+      declares_frame_condition(assigns_targets_early, original_body_copy);
 
     // For annotated functions without explicit contracts, use default true/true
     // This allows the function to be processed with default contract semantics.
@@ -1191,12 +1200,8 @@ goto_programt code_contractst::generate_checking_wrapper(
   goto_programt wrapper;
   locationt location = original_func.location;
 
-  // A declared frame condition, whether or not it names any target. An
-  // explicit __ESBMC_assigns() names nothing, which enforce_frame_rule reads
-  // as "every snapshotted global must be unchanged" -- the check that makes
-  // the empty clause mean anything (#6555).
   const bool declares_frame =
-    !assigns_targets.empty() || has_empty_assigns_marker(original_body);
+    declares_frame_condition(assigns_targets, original_body);
 
   // Note: Here is the design, enforce_contracts mode does NOT havoc
   // parameters or globals. The wrapper is called by actual callers, so we


### PR DESCRIPTION
`__ESBMC_assigns()` lowers to an ASSERT marker, which `has_contracts` did not
recognise, so a function whose whole contract is an empty frame condition
looked contract-free. Two later gates keyed off a non-empty target list and
skipped it as well, leaving the check vacuous once the clause was seen.

Route the explicit-empty marker through all three. `enforce_frame_rule`
already reads an empty target set as "every snapshotted global unchanged",
which is what the clause states.

Fixes #6555.