### PR TITLE
[python] Raise TypeError for len() of a non-sized object

### DIFF
--- a/regression/python/github_6261/main.py
+++ b/regression/python/github_6261/main.py
@@ -1,0 +1,9 @@
+# len() on an object with no __len__ raises TypeError (GitHub #6261).
+n = 5
+caught = False
+try:
+    y = len(n)
+except TypeError:
+    caught = True
+
+assert caught

--- a/regression/python/github_6261/test.desc
+++ b/regression/python/github_6261/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6261_fail/main.py
+++ b/regression/python/github_6261_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    n = 5
+    y = len(n)
+
+
+main()

--- a/regression/python/github_6261_fail/test.desc
+++ b/regression/python/github_6261_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$
+uncaught exception: TypeError

--- a/regression/python/github_6261_sized/main.py
+++ b/regression/python/github_6261_sized/main.py
@@ -1,0 +1,11 @@
+lst = [1, 2, 3]
+d = {"a": 1}
+t = (1, 2)
+s = "abcd"
+
+assert len(lst) == 3
+assert len(d) == 1
+assert len(t) == 2
+assert len(s) == 4
+assert len(s[0]) == 1
+assert len(range(5)) == 5

--- a/regression/python/github_6261_sized/test.desc
+++ b/regression/python/github_6261_sized/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -62,6 +62,14 @@ static bool is_pylist_object_type(const typet &type, const namespacet &ns)
   return try_get_pylist_struct_type(type, ns).has_value();
 }
 
+/// Python types that define no __len__. Named rather than tested inline so the
+/// len() lowering stays one decision point wide.
+static bool is_unsized_python_type(const std::string &python_type)
+{
+  return python_type == "int" || python_type == "float" ||
+         python_type == "bool" || python_type == "complex";
+}
+
 const std::string kGetObjectSize = "__ESBMC_get_object_size";
 const std::string kStrlen = "strlen";
 const std::string kEsbmcAssume = "__ESBMC_assume";
@@ -764,9 +772,7 @@ exprt function_call_builder::build() const
       // int, and refusing on that alone would reject a real str/list.
       const std::string arg_py_type =
         converter_.get_type_handler().get_operand_type(call_["args"][0]);
-      if (
-        arg_py_type == "int" || arg_py_type == "float" ||
-        arg_py_type == "bool" || arg_py_type == "complex")
+      if (is_unsized_python_type(arg_py_type))
         return converter_.get_exception_handler().gen_exception_raise(
           "TypeError", "object of type '" + arg_py_type + "' has no len()");
 

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -722,19 +722,6 @@ exprt function_call_builder::build() const
   symbol_id function_id = build_function_id();
   if (is_len_call(function_id) && !call_["args"].empty())
   {
-    // An int/float/bool/complex operand defines no __len__, so CPython raises
-    // TypeError. Decide that from the Python type: the integer fast path below
-    // answers 1, which is right for a single character (also a bitvector here)
-    // but silently wrong for a number (#6261). An unknown or empty type keeps
-    // the existing lowering rather than inventing an exception.
-    const std::string arg_py_type =
-      converter_.get_type_handler().get_operand_type(call_["args"][0]);
-    if (
-      arg_py_type == "int" || arg_py_type == "float" || arg_py_type == "bool" ||
-      arg_py_type == "complex")
-      return converter_.get_exception_handler().gen_exception_raise(
-        "TypeError", "object of type '" + arg_py_type + "' has no len()");
-
     exprt arg_expr = converter_.get_expr(call_["args"][0]);
 
     // If len() argument is a list-typed symbol, force list-size semantics.
@@ -768,7 +755,23 @@ exprt function_call_builder::build() const
     }
 
     if (arg_expr.type().is_signedbv() || arg_expr.type().is_unsignedbv())
+    {
+      // A single character reaches here too and does have length 1, so tell the
+      // two apart by the Python type. A number defines no __len__, and CPython
+      // raises TypeError rather than answering 1 (#6261). Anything the
+      // annotator could not type keeps the historical answer: get_operand_type
+      // reports a BinOp as its left operand's type, so `3 * "x,"` looks like an
+      // int, and refusing on that alone would reject a real str/list.
+      const std::string arg_py_type =
+        converter_.get_type_handler().get_operand_type(call_["args"][0]);
+      if (
+        arg_py_type == "int" || arg_py_type == "float" ||
+        arg_py_type == "bool" || arg_py_type == "complex")
+        return converter_.get_exception_handler().gen_exception_raise(
+          "TypeError", "object of type '" + arg_py_type + "' has no len()");
+
       return from_integer(1, long_long_int_type());
+    }
 
     typet len_arg_type = converter_.ns.follow(arg_expr.type());
     if (len_arg_type.is_array() && len_arg_type.subtype() != char_type())

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -1,4 +1,5 @@
 #include <python-frontend/function_call/builder.h>
+#include <python-frontend/exception/python_exception_handler.h>
 #include <python-frontend/function_call/expr.h>
 #include <python-frontend/json_utils.h>
 #include <python-frontend/numpy/numpy_call_expr.h>
@@ -721,6 +722,19 @@ exprt function_call_builder::build() const
   symbol_id function_id = build_function_id();
   if (is_len_call(function_id) && !call_["args"].empty())
   {
+    // An int/float/bool/complex operand defines no __len__, so CPython raises
+    // TypeError. Decide that from the Python type: the integer fast path below
+    // answers 1, which is right for a single character (also a bitvector here)
+    // but silently wrong for a number (#6261). An unknown or empty type keeps
+    // the existing lowering rather than inventing an exception.
+    const std::string arg_py_type =
+      converter_.get_type_handler().get_operand_type(call_["args"][0]);
+    if (
+      arg_py_type == "int" || arg_py_type == "float" || arg_py_type == "bool" ||
+      arg_py_type == "complex")
+      return converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", "object of type '" + arg_py_type + "' has no len()");
+
     exprt arg_expr = converter_.get_expr(call_["args"][0]);
 
     // If len() argument is a list-typed symbol, force list-size semantics.

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -717,6 +717,24 @@ symbol_id function_call_builder::build_function_id() const
   return function_id;
 }
 
+exprt function_call_builder::len_of_bitvector_operand(
+  const nlohmann::json &arg) const
+{
+  // A single character also lowers to a bitvector and does have length 1, so
+  // tell the two apart by the Python type. Anything the annotator could not
+  // type keeps the historical answer: get_operand_type reports a BinOp as its
+  // left operand's type, so `3 * "x,"` looks like an int, and refusing on that
+  // alone would reject a real str/list.
+  const std::string arg_py_type =
+    converter_.get_type_handler().get_operand_type(arg);
+
+  if (is_unsized_python_type(arg_py_type))
+    return converter_.get_exception_handler().gen_exception_raise(
+      "TypeError", "object of type '" + arg_py_type + "' has no len()");
+
+  return from_integer(1, long_long_int_type());
+}
+
 exprt function_call_builder::build() const
 {
   if (call_["func"]["_type"] == "Attribute")
@@ -763,21 +781,7 @@ exprt function_call_builder::build() const
     }
 
     if (arg_expr.type().is_signedbv() || arg_expr.type().is_unsignedbv())
-    {
-      // A single character reaches here too and does have length 1, so tell the
-      // two apart by the Python type. A number defines no __len__, and CPython
-      // raises TypeError rather than answering 1 (#6261). Anything the
-      // annotator could not type keeps the historical answer: get_operand_type
-      // reports a BinOp as its left operand's type, so `3 * "x,"` looks like an
-      // int, and refusing on that alone would reject a real str/list.
-      const std::string arg_py_type =
-        converter_.get_type_handler().get_operand_type(call_["args"][0]);
-      if (is_unsized_python_type(arg_py_type))
-        return converter_.get_exception_handler().gen_exception_raise(
-          "TypeError", "object of type '" + arg_py_type + "' has no len()");
-
-      return from_integer(1, long_long_int_type());
-    }
+      return len_of_bitvector_operand(call_["args"][0]);
 
     typet len_arg_type = converter_.ns.follow(arg_expr.type());
     if (len_arg_type.is_array() && len_arg_type.subtype() != char_type())

--- a/src/python-frontend/function_call/builder.h
+++ b/src/python-frontend/function_call/builder.h
@@ -46,6 +46,12 @@ public:
   bool is_len_call(const symbol_id &function_id) const;
 
   /*
+   * len() of an operand that lowered to a bitvector: length 1 for a single
+   * character, TypeError for a number, which defines no __len__ (#6261).
+   */
+  exprt len_of_bitvector_operand(const nlohmann::json &arg) const;
+
+  /*
    * Checks if a NumPy function is being invoked.
    */
   bool is_numpy_call(const symbol_id &function_id) const;


### PR DESCRIPTION
The len lowering short-circuits any integer-typed operand to the constant 1,
so `len(5)` produced no VCC and verified vacuously. Keep that fast path — a
single character is a bitvector too, and `len(s[0]) == 1` depends on it — but
gate it on the Python type, raising `TypeError` for int/float/bool/complex as
CPython does. An unknown type keeps the existing lowering.

Fixes #6261.