### PR TITLE
[python] Bind the alias of an aliased module import

### DIFF
--- a/regression/numpy/github_6296_alias/main.py
+++ b/regression/numpy/github_6296_alias/main.py
@@ -1,0 +1,5 @@
+# The reported form: an aliased numpy attribute (#6296).
+import numpy as np
+
+assert np.pi > 3.14
+assert np.pi < 3.15

--- a/regression/numpy/github_6296_alias/test.desc
+++ b/regression/numpy/github_6296_alias/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6296/main.py
+++ b/regression/python/github_6296/main.py
@@ -1,0 +1,16 @@
+# An aliased module attribute must resolve like the unaliased one (#6296).
+import math as m
+import math
+
+assert m.pi > 3.14
+assert m.pi < 3.15
+assert math.pi > 3.14
+
+
+def normalise(angle: float) -> float:
+    while angle >= 2 * m.pi:
+        angle -= 2 * m.pi
+    return angle
+
+
+assert normalise(1.0) == 1.0

--- a/regression/python/github_6296/test.desc
+++ b/regression/python/github_6296/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6296_fail/main.py
+++ b/regression/python/github_6296_fail/main.py
@@ -1,0 +1,3 @@
+import math as m
+
+assert m.pi > 4.0

--- a/regression/python/github_6296_fail/test.desc
+++ b/regression/python/github_6296_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -246,6 +246,30 @@ static std::string import_module_name(const nlohmann::json &node)
   return node["names"][0]["name"].get<std::string>();
 }
 
+// `import numpy as np` binds the alias, not the module name, so a lookup of
+// `np` misses and the attribute access aborts as an undefined variable
+// (#6296). Register the alias against the same file. Only the first name is
+// considered, matching import_module_name: an `import a as x, b as y` node
+// resolves to `a`, so binding `y` to it would be wrong. ImportFrom's names are
+// imported members rather than module aliases, and are excluded.
+void python_converter::register_import_alias(
+  const nlohmann::json &import_node,
+  const std::string &module_file)
+{
+  if (import_node["_type"] != "Import" || !import_node.contains("names"))
+    return;
+
+  const nlohmann::json &names = import_node["names"];
+  if (!names.is_array() || names.empty())
+    return;
+
+  const nlohmann::json &first = names[0];
+  if (!first.contains("asname") || first["asname"].is_null())
+    return;
+
+  imported_modules.emplace(first["asname"].get<std::string>(), module_file);
+}
+
 bool python_converter::import_module_into_block(
   const nlohmann::json &import_node,
   module_locator &locator,
@@ -253,8 +277,15 @@ bool python_converter::import_module_into_block(
 {
   const std::string module_name = import_module_name(import_node);
 
-  if (imported_modules.find(module_name) != imported_modules.end())
+  auto already = imported_modules.find(module_name);
+  if (already != imported_modules.end())
+  {
+    // Already converted, but this import node may bind an alias the earlier
+    // one did not -- a model importing `math` for its own use leaves a later
+    // `import math as m` with no binding for `m` (#6296).
+    register_import_alias(import_node, already->second);
     return true;
+  }
 
   // pre_collect_module_asts populates the pool before any import runs.
   // A miss here means the same module_locator could not open the file.
@@ -265,6 +296,7 @@ bool python_converter::import_module_into_block(
 
   current_python_file = nested_module_json["filename"].get<std::string>();
   imported_modules.emplace(module_name, current_python_file);
+  register_import_alias(import_node, current_python_file);
 
   // Process nested imports first.
   process_module_imports(nested_module_json, locator, block);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -668,6 +668,12 @@ private:
     module_locator &locator,
     code_blockt &code);
 
+  /// Binds an `import <mod> as <alias>` alias to the module's file, so the
+  /// alias resolves like the module name does (#6296).
+  void register_import_alias(
+    const nlohmann::json &import_node,
+    const std::string &module_file);
+
   /// Converts every module-level and function-local Import/ImportFrom
   /// statement in the current AST, appending the resulting code to
   /// `all_imports_block`. Shared by both the whole-module conversion path


### PR DESCRIPTION
`imported_modules` is keyed by the module name, so `import numpy as np` left
`np` unbound and any attribute access through it aborted as an undefined
variable (exit 134). Register the alias against the same file, on both the
freshly converted and the already-imported paths — a model that imports
`math` for its own use would otherwise leave a later `import math as m`
without `m`.

Fixes #6296.