### PR TITLE
[goto-symex] Let malloc(0) return either NULL or a freeable object

### DIFF
--- a/regression/esbmc-unix/github_5395_calloc_zero_is_null_fail/main.c
+++ b/regression/esbmc-unix/github_5395_calloc_zero_is_null_fail/main.c
@@ -1,8 +1,8 @@
 // Regression for github #5395: calloc of a zero-sized request must track
-// malloc(0) under --malloc-zero-is-null too -- i.e. return NULL.  This
-// pins the option-respecting boundary: asserting the pointer is non-null
-// must FAIL here (the fix routes calloc(_,0) through malloc(0), which
-// returns NULL when --malloc-zero-is-null is set).
+// malloc(0) under --malloc-zero-is-null too.  This pins the option-respecting
+// boundary: asserting the pointer is non-null must FAIL here, because the fix
+// routes calloc(_,0) through malloc(0), whose NULL alternative the option
+// keeps reachable.
 #include <stdlib.h>
 
 void reach_error(void) {}
@@ -15,6 +15,6 @@ static void verifier_assert(int cond)
 int main(void)
 {
   void *p = calloc(1, 0);
-  verifier_assert(p != 0); // FAILS: calloc(1,0) is NULL under --malloc-zero-is-null
+  verifier_assert(p != 0); // FAILS: calloc(1,0) may be NULL under the option
   return 0;
 }

--- a/regression/esbmc/github_5398/main.c
+++ b/regression/esbmc/github_5398/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+extern void __VERIFIER_assume(int);
+
+int main(void)
+{
+  void *p = malloc(0);
+  __VERIFIER_assume((unsigned long)p != (unsigned long)0);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/github_5398/test.desc
+++ b/regression/esbmc/github_5398/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5398_access_fail/main.c
+++ b/regression/esbmc/github_5398_access_fail/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+extern void __VERIFIER_assume(int);
+
+int main(void)
+{
+  char *p = malloc(0);
+  __VERIFIER_assume((unsigned long)p != (unsigned long)0);
+  *p = 1;
+  return 0;
+}

--- a/regression/esbmc/github_5398_access_fail/test.desc
+++ b/regression/esbmc/github_5398_access_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null
+^VERIFICATION FAILED$
+^\s*dereference failure: array bounds violated: heap object$

--- a/regression/esbmc/github_5398_null_fail/main.c
+++ b/regression/esbmc/github_5398_null_fail/main.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+void reach_error(void)
+{
+  __ESBMC_assert(0, "NULL alternative of malloc(0) reached");
+}
+
+int main(void)
+{
+  void *p = malloc(0);
+  if ((unsigned long)p == (unsigned long)0)
+    reach_error();
+  return 0;
+}

--- a/regression/esbmc/github_5398_null_fail/test.desc
+++ b/regression/esbmc/github_5398_null_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null
+^VERIFICATION FAILED$
+^\s*NULL alternative of malloc\(0\) reached$

--- a/regression/esbmc/github_5398_nullderef_fail/main.c
+++ b/regression/esbmc/github_5398_nullderef_fail/main.c
@@ -1,0 +1,12 @@
+// The NULL alternative of malloc(0) must stay a genuine NULL pointer: the
+// allocation tracking arrays are indexed by the dynamic object, never by the
+// conditional result, or __ESBMC_alloc[NULL] is set and this deref is missed.
+#include <stdlib.h>
+
+int main(void)
+{
+  char *p = malloc(0);
+  if (p == 0)
+    *p = 1;
+  return 0;
+}

--- a/regression/esbmc/github_5398_nullderef_fail/test.desc
+++ b/regression/esbmc/github_5398_nullderef_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null
+^VERIFICATION FAILED$
+^\s*dereference failure: NULL pointer$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -782,7 +782,7 @@ const struct group_opt_templ all_cmd_options[] = {
      "Check if label is unreachable"},
     {"force-malloc-success", NULL, "Do not check for malloc/new failure"},
     {"force-realloc-success", NULL, "Do not check for realloc failure"},
-    {"malloc-zero-is-null", NULL, "Let malloc(0) return NULL"},
+    {"malloc-zero-is-null", NULL, "Also explore malloc(0) returning NULL"},
     {"max-symbolic-realloc-copy",
      boost::program_options::value<int>()->default_value(128)->value_name("nr"),
      "Set maximum number of elements to copy symbolically in realloc (default "

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -782,7 +782,7 @@ const struct group_opt_templ all_cmd_options[] = {
      "Check if label is unreachable"},
     {"force-malloc-success", NULL, "Do not check for malloc/new failure"},
     {"force-realloc-success", NULL, "Do not check for realloc failure"},
-    {"malloc-zero-is-null", NULL, "Force malloc(0) to return NULL"},
+    {"malloc-zero-is-null", NULL, "Let malloc(0) return NULL"},
     {"max-symbolic-realloc-copy",
      boost::program_options::value<int>()->default_value(128)->value_name("nr"),
      "Set maximum number of elements to copy symbolically in realloc (default "

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -623,11 +623,8 @@ expr2tc goto_symext::symex_mem(
     do_simplify(size);
     if (is_constant_int2t(size))
     {
-      uint64_t v = to_constant_int2t(size).value.to_uint64();
-      if (v == 1)
+      if (to_constant_int2t(size).value == 1)
         size_is_one = true;
-      else if (v == 0 && options.get_bool_option("malloc-zero-is-null"))
-        return symbol2tc(pointer_type2tc(type), "NULL");
     }
     else if (
       is_malloc && is_unsignedbv_type(size->type) &&
@@ -729,10 +726,24 @@ expr2tc goto_symext::symex_mem(
 
   if (options.get_bool_option("malloc-zero-is-null"))
   {
-    expr2tc null_sym = symbol2tc(rhs->type, "NULL");
-    expr2tc choice = greaterthan2tc(size, gen_long(size->type, 0));
-    alloc_guard.add(choice);
-    rhs = if2tc(rhs->type, choice, rhs, null_sym);
+    expr2tc nonzero = greaterthan2tc(size, gen_long(size->type, 0));
+    simplify(nonzero);
+
+    if (!is_true(nonzero))
+    {
+      // C17 7.22.3p1 leaves malloc(0) implementation-defined: NULL, or a
+      // pointer that may be freed but not used to access an object. Offer
+      // both -- forcing NULL makes the assume(p != NULL) that environment
+      // models emit after a zero-sized request unsatisfiable, pruning every
+      // execution under test (#5398).
+      expr2tc may_alloc = gen_nondet(get_bool_type());
+      replace_nondet(may_alloc);
+
+      expr2tc choice = or2tc(nonzero, may_alloc);
+      simplify(choice);
+      alloc_guard.add(choice);
+      rhs = if2tc(rhs->type, choice, rhs, symbol2tc(rhs->type, "NULL"));
+    }
   }
 
   if (!options.get_bool_option("force-malloc-success") && is_malloc)

--- a/website/content/docs/theory/memory-model.md
+++ b/website/content/docs/theory/memory-model.md
@@ -44,7 +44,9 @@ By default ESBMC also explores the possibility that an allocation *fails*
 flagged. This can be tuned:
 
 - `--force-malloc-success` — assume allocation never fails
-- `--malloc-zero-is-null` — model `malloc(0)` as returning `NULL`
+- `--malloc-zero-is-null` — let `malloc(0)` return `NULL`, as C17 7.22.3p1
+  permits; the non-`NULL` alternative stays reachable, and the object it yields
+  can be freed but not accessed
 
 ## Properties checked
 


### PR DESCRIPTION
Under `--malloc-zero-is-null` a constant zero size returned NULL early without
assigning it to the destination, so a later `free(p)` saw a stale pointer and
reported an invalid free — the SV-COMP false alarm in #5398. Both outcomes C17
7.22.3p1 permits are now offered, so an `assume(p != NULL)` no longer prunes
every execution.

Fixes #5398