### PR TITLE
[python] Lower *args for a def nested inside another function

### DIFF
--- a/regression/python/github_6800/main.py
+++ b/regression/python/github_6800/main.py
@@ -1,0 +1,42 @@
+def outer():
+    def inner(*rest):
+        return len(rest)
+
+    return inner(1, 2, 3)
+
+
+def closes_over_a_local():
+    base = 10
+
+    def helper(*rest):
+        return base + len(rest)
+
+    return helper(1, 2, 3)
+
+
+def keeps_fixed_parameters():
+    def helper(x, *rest):
+        return x + len(rest)
+
+    return helper(5, 1, 2)
+
+
+def sibling_of_a_same_named_nested_def():
+    def helper(*rest):
+        return len(rest) * 100
+
+    return helper(7, 8, 9)
+
+
+def called_at_two_arities():
+    def helper(*rest):
+        return len(rest)
+
+    return helper(1) + helper(2, 3, 4)
+
+
+assert outer() == 3
+assert called_at_two_arities() == 4
+assert closes_over_a_local() == 13
+assert keeps_fixed_parameters() == 7
+assert sibling_of_a_same_named_nested_def() == 300

--- a/regression/python/github_6800/test.desc
+++ b/regression/python/github_6800/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6800_fail/main.py
+++ b/regression/python/github_6800_fail/main.py
@@ -1,0 +1,10 @@
+def outer():
+    base = 10
+
+    def inner(*rest):
+        return base + len(rest)
+
+    return inner(1, 2, 3)
+
+
+assert outer() == 12

--- a/regression/python/github_6800_fail/test.desc
+++ b/regression/python/github_6800_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -1491,6 +1491,7 @@ class CoreVisitorsMixin:
         self._assignment_call_origins.clear()
         saved_eq_only = set(self._eq_only_items_view_targets)
         self._eq_only_items_view_targets = self._scan_eq_only_items_view_targets(node.body)
+        saved_vararg_defs = self._enter_vararg_scope(node)
         try:
             node = self._rewrite_humaneval_20_none_sentinel(node)
 
@@ -1527,3 +1528,4 @@ class CoreVisitorsMixin:
             self.variable_annotations = saved_var_anns
             self._assignment_call_origins = saved_call_origins
             self._eq_only_items_view_targets = saved_eq_only
+            self._exit_vararg_scope(node, saved_vararg_defs)

--- a/src/python-frontend/preprocessor/preprocessor_state_mixin.py
+++ b/src/python-frontend/preprocessor/preprocessor_state_mixin.py
@@ -21,6 +21,9 @@ class PreprocessorStateMixin:
         self._vararg_module_defs = set()
         self._vararg_specializations = {}
         self._vararg_dropped_defs = set()
+        self._vararg_scope_stack = []
+        self._vararg_def_owners = {}
+        self._vararg_owner_specs = {}
         self.listcomp_counter = 0
         self.variable_annotations = {}
         self.function_return_annotations = {}

--- a/src/python-frontend/preprocessor/vararg_mixin.py
+++ b/src/python-frontend/preprocessor/vararg_mixin.py
@@ -7,15 +7,36 @@ import copy
 class VarargMixin:
 
     def _scan_module_vararg_defs(self, node):
-        """Mark the variadic defs that live directly in the module body.
-
-        Specializations are injected at module level, so only a def at that
-        level can be copied: a nested one would lose the scope it closes over.
-        """
+        """Mark the variadic defs that live directly in the module body."""
         self._vararg_module_defs = {
             id(stmt)
             for stmt in node.body if isinstance(stmt, ast.FunctionDef) and stmt.args.vararg
         }
+
+    def _enter_vararg_scope(self, node):
+        """Open the scope of `node`, returning the def table to restore on exit.
+
+        A variadic def nested in `node` is visible only while that scope is
+        open, so a sibling function cannot resolve a call against it.
+        """
+        self._vararg_scope_stack.append(node)
+        return dict(self._vararg_func_defs)
+
+    def _exit_vararg_scope(self, node, saved_func_defs):
+        # Keyed by the def that was pushed: a visitor may hand back a rewritten
+        # node, and ownership was recorded against the original.
+        scope = self._vararg_scope_stack.pop()
+        own_entry = self._vararg_func_defs.get(scope.name)
+        self._vararg_func_defs = saved_func_defs
+        # Only the defs nested inside `scope` go out of scope here; `scope`
+        # itself binds its own name in the scope that encloses it.
+        if own_entry is scope:
+            self._vararg_func_defs[scope.name] = scope
+        self._inject_vararg_specializations(node, id(scope))
+
+    def _enclosing_vararg_scope(self):
+        """The def enclosing the one being visited, which is itself on top."""
+        return self._vararg_scope_stack[-2] if len(self._vararg_scope_stack) > 1 else None
 
     def _record_vararg_function(self, node, qualified_name):
         if node.args.vararg:
@@ -23,8 +44,13 @@ class VarargMixin:
             # Registered only once visited, since a specialization is a copy of
             # the body as the converter will see it -- an unvisited body still
             # holds constructs (`for`, comprehensions) with no lowering there.
-            if id(node) in self._vararg_module_defs:
+            # A specialization takes the place of the def it copies, so only a
+            # def that is a statement of its own scope's body has somewhere to go.
+            owner = self._enclosing_vararg_scope()
+            if (any(stmt is node for stmt in owner.body)
+                    if owner is not None else id(node) in self._vararg_module_defs):
                 self._vararg_func_defs[node.name] = node
+                self._vararg_def_owners[id(node)] = owner
         else:
             self.functionVarargs.discard(qualified_name)
             self._vararg_func_defs.pop(qualified_name, None)
@@ -64,11 +90,18 @@ class VarargMixin:
         if not self._is_specializable_vararg_call(node, func_def):
             return
 
+        owner = self._vararg_def_owners.get(id(func_def))
         extra = len(node.args) - len(func_def.args.args)
-        spec_name = f"{func_def.name}__esbmc_va{extra}"
+        # The owner prefix keeps same-named defs nested in different functions
+        # from sharing one specialization, which lives in only one of them.
+        prefix = f"{owner.name}__" if owner is not None else ""
+        spec_name = f"{prefix}{func_def.name}__esbmc_va{extra}"
         if spec_name not in self._vararg_specializations:
             self._vararg_specializations[spec_name] = self._build_vararg_specialization(
                 func_def, spec_name, extra)
+            owner_key = id(owner) if owner is not None else None
+            owned = self._vararg_owner_specs.setdefault(owner_key, {})
+            owned.setdefault(id(func_def), []).append(spec_name)
         node.func = ast.Name(id=spec_name, ctx=ast.Load())
         self._vararg_dropped_defs.add(id(func_def))
         ast.fix_missing_locations(node)
@@ -90,21 +123,35 @@ class VarargMixin:
         ast.fix_missing_locations(spec)
         return spec
 
-    def _inject_vararg_specializations(self, node):
-        if not self._vararg_dropped_defs:
+    def _inject_vararg_specializations(self, node, owner_key=None):
+        """Put the specializations owned by `node` where their originals sat.
+
+        A nested def is copied into the function that encloses it rather than
+        into the module, so the copy keeps the scope it closes over, and it
+        takes the original's position so the names it reads are already bound
+        there (#6800).
+        """
+        specs_by_source = self._vararg_owner_specs.pop(owner_key, None)
+        if not specs_by_source:
             return
-        specializations = list(self._vararg_specializations.values())
-        survivors = [stmt for stmt in node.body if id(stmt) not in self._vararg_dropped_defs]
-        # A variadic def is dead only once every reference to it has been
-        # rewritten; a call this pass cannot lower (`*` unpacking, an alias, a
-        # caller in another module) must keep the original, so the frontend
-        # reports the unsupported construct rather than a call to a function
-        # that no longer exists.
-        node.body = [
-            stmt for stmt in node.body if id(stmt) not in self._vararg_dropped_defs
-            or self._name_is_used(survivors + specializations, stmt.name)
+        specializations = [
+            self._vararg_specializations[name] for names in specs_by_source.values()
+            for name in names
         ]
         for spec in specializations:
             self.ensure_all_locations(spec)
             ast.fix_missing_locations(spec)
-        node.body = specializations + node.body
+        survivors = [stmt for stmt in node.body if id(stmt) not in self._vararg_dropped_defs]
+        body = []
+        for stmt in node.body:
+            body.extend(self._vararg_specializations[name]
+                        for name in specs_by_source.get(id(stmt), ()))
+            # A variadic def is dead only once every reference to it has been
+            # rewritten; a call this pass cannot lower (`*` unpacking, an alias,
+            # a caller in another module) must keep the original, so the
+            # frontend reports the unsupported construct rather than a call to a
+            # function that no longer exists.
+            if (id(stmt) not in self._vararg_dropped_defs
+                    or self._name_is_used(survivors + specializations, stmt.name)):
+                body.append(stmt)
+        node.body = body


### PR DESCRIPTION
The specialization pass only registered variadic defs from the module body, so
a nested one reached the converter unlowered and was rejected. Track the scope
each variadic def belongs to and put its fixed-arity copy where the original
sat, so the copy keeps both the scope and the bindings it reads.

Fixes #6800