### PR TITLE
[goto-programs] Drop the unused result_is_used parameter

### DIFF
--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -125,10 +125,7 @@ protected:
   remove_function_call(exprt &expr, goto_programt &dest, bool result_is_used);
   void remove_cpp_new(exprt &expr, goto_programt &dest, bool result_is_used);
   void remove_cpp_delete(exprt &expr, goto_programt &dest);
-  void remove_temporary_object(
-    exprt &expr,
-    goto_programt &dest,
-    bool result_is_used);
+  void remove_temporary_object(exprt &expr, goto_programt &dest);
   void remove_statement_expression(
     exprt &expr,
     goto_programt &dest,

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -1630,7 +1630,7 @@ void goto_convertt::remove_sideeffects(
     else if (statement == "temporary_object")
     {
       const locationt location = expr.find_location();
-      remove_temporary_object(expr, dest, result_is_used);
+      remove_temporary_object(expr, dest);
 
       // A discarded temporary dies at the end of its full expression
       // (C++ [class.temporary]/4, github #6076), not at block exit: emit
@@ -2287,10 +2287,7 @@ void goto_convertt::remove_cpp_delete(exprt &expr, goto_programt &dest)
   expr.make_nil();
 }
 
-void goto_convertt::remove_temporary_object(
-  exprt &expr,
-  goto_programt &dest,
-  bool result_is_used)
+void goto_convertt::remove_temporary_object(exprt &expr, goto_programt &dest)
 {
   if (expr.operands().size() != 1 && expr.operands().size() != 0)
     throw "temporary_object takes 0 or 1 operands";


### PR DESCRIPTION
remove_temporary_object never read `result_is_used` — the end-of-full-expression destructor logic it once gated now lives in the caller in `remove_sideeffects`, which tests the flag itself. Dropping the dead parameter silences a `-Wunused-parameter` warning and matches the 2-arg shape of its sibling `remove_cpp_delete`.

Signature-only cleanup: the parameter was never read, so the generated GOTO is unchanged by construction. No new tests — the changed lines are already exercised by the existing temporary-object suite (`github_6075/6076/6077` ± `_fail`, `github_4715_irep2_bodies_temp_dtor_*`, `reference_temporary_single_dtor`), which passes along with the 51 goto/symex/migrate unit tests.