### PR TITLE
[goto-symex] Give a fresh dynamic object an L2 record at allocation

### DIFF
--- a/regression/esbmc/github_6798/main.c
+++ b/regression/esbmc/github_6798/main.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+
+typedef struct
+{
+  int p;
+} T;
+
+int main(void)
+{
+  T *t = malloc(sizeof(T));
+  if (!t)
+    return 0;
+
+  int v = nondet_int();
+  if (v != 0)
+  {
+    t->p = 1;
+  }
+
+  /* Nothing writes t->p when v == 0, so this must not be provable. */
+  __ESBMC_assert(t->p == 1, "conditionally written heap object");
+  free(t);
+  return 0;
+}

--- a/regression/esbmc/github_6798/test.desc
+++ b/regression/esbmc/github_6798/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 4
+^VERIFICATION FAILED$
+conditionally written heap object

--- a/regression/esbmc/github_6798_ok/main.c
+++ b/regression/esbmc/github_6798_ok/main.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+
+typedef struct
+{
+  int p;
+} T;
+
+int main(void)
+{
+  T *t = malloc(sizeof(T));
+  if (!t)
+    return 0;
+
+  t->p = 1;
+
+  int v = nondet_int();
+  if (v != 0)
+  {
+    t->p = 2;
+  }
+
+  /* The join must keep both versions reachable, not just the branch's. */
+  __ESBMC_assert(t->p == 1 || t->p == 2, "both join arms survive");
+
+  int w = nondet_int();
+  if (w != 0)
+  {
+    t->p = 3;
+  }
+  else
+  {
+    t->p = 3;
+  }
+  __ESBMC_assert(t->p == 3, "written on every path");
+
+  free(t);
+  return 0;
+}

--- a/regression/esbmc/github_6798_ok/test.desc
+++ b/regression/esbmc/github_6798_ok/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_6797/main.c
+++ b/regression/function_contract/github_6797/main.c
@@ -1,0 +1,26 @@
+typedef struct
+{
+  int m;
+  int p;
+} T;
+
+void f(T *t, int v)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(t, sizeof(T)));
+  __ESBMC_requires(t->p == 0);
+  __ESBMC_requires(v == t->m);
+  __ESBMC_assigns(t->p);
+  __ESBMC_ensures(t->p == 0);
+
+  /* Unreachable under the requires clauses, so t->p keeps the value they
+     gave it. The join must not drop that value on the not-taken arm. */
+  if (v != t->m)
+  {
+    t->p = 1;
+  }
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_6797/test.desc
+++ b/regression/function_contract/github_6797/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -691,6 +691,13 @@ expr2tc goto_symext::symex_mem(
 
   new_context.add(symbol);
 
+  // Without a record at the branch point phi_function skips this object, so a
+  // write inside a branch would apply on both paths (#6798).
+  expr2tc dyn_l1_sym = symbol2tc(get_empty_type(), symbol.id);
+  cur_state->top().level1.get_ident_name(dyn_l1_sym);
+  cur_state->level2.declare(
+    renaming::level2t::name_record(to_symbol2t(dyn_l1_sym)));
+
   type2tc new_type = migrate_symbol_type(symbol);
 
   type2tc rhs_type;

--- a/src/goto-symex/renaming.h
+++ b/src/goto-symex/renaming.h
@@ -270,6 +270,16 @@ public:
     entry.constant = expr2tc();
   }
 
+  /// Record `rec` at its initial version. phi_function merges only names that
+  /// already had a record when the branch was taken, so storage first written
+  /// inside a branch would otherwise keep that branch's version on both paths
+  /// (#6798). get_ident_name numbers a count-0 record exactly as it numbers an
+  /// absent one, so declaring costs no SSA renumbering.
+  void declare(const name_record &rec)
+  {
+    current_names.emplace(rec, valuet());
+  }
+
   void get_original_name(expr2tc &expr) const override
   {
     renaming_levelt::get_original_name(expr, symbol_renaming_level::level1);


### PR DESCRIPTION
phi_function merges only names that already had a level2 record when the branch
was taken. A dynamic object has none until something writes it, so an object
first written inside a branch kept that branch's version on both paths and
ESBMC proved false properties.

Fixes #6798
Fixes #6797
