### PR TITLE
[regression] Pin recursion with a multi-valued symbolic argument

### DIFF
--- a/regression/esbmc/github_5387/main.c
+++ b/regression/esbmc/github_5387/main.c
@@ -1,0 +1,20 @@
+/* A recursive call whose argument is symbolic over more than one value once
+ * made the path after the call vacuous, so this false assertion was reported
+ * SUCCESSFUL. f(n) is 1 for both admitted values, never 999. */
+extern int nondet_int(void);
+
+int f(int n)
+{
+  if (n <= 1)
+    return n;
+  return f(n - 1);
+}
+
+int main(void)
+{
+  int n = nondet_int();
+  __ESBMC_assume(n == 2 || n == 3);
+  int r = f(n);
+  __ESBMC_assert(r == 999, "r is 1, never 999");
+  return r;
+}

--- a/regression/esbmc/github_5387/test.desc
+++ b/regression/esbmc/github_5387/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 24
+^VERIFICATION FAILED$
+r is 1, never 999

--- a/regression/esbmc/github_5387_value/main.c
+++ b/regression/esbmc/github_5387_value/main.c
@@ -1,0 +1,21 @@
+/* Companion to github_5387. The bug made the post-call path vacuous, which
+ * discharges *any* assertion placed there -- so both this true assertion and
+ * the false one next door reported SUCCESSFUL. Pinning both directions is what
+ * distinguishes a vacuous continuation from a correctly evaluated one. */
+extern int nondet_int(void);
+
+int f(int n)
+{
+  if (n <= 1)
+    return n;
+  return f(n - 1);
+}
+
+int main(void)
+{
+  int n = nondet_int();
+  __ESBMC_assume(n == 2 || n == 3);
+  int r = f(n);
+  __ESBMC_assert(r == 1, "f returns 1 for both admitted values");
+  return r;
+}

--- a/regression/esbmc/github_5387_value/test.desc
+++ b/regression/esbmc/github_5387_value/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 24
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The post-call path was once treated as vacuous, discharging any assertion placed
after the call. The defect no longer reproduces on master, so this pins both
directions: the false assertion must fail and the true one must hold, which a
vacuous continuation could not distinguish.

Fixes #5387
