### PR TITLE
[python] Make the higher-order closure tests assert their result

### DIFF
--- a/regression/python/higher-order3/main.py
+++ b/regression/python/higher-order3/main.py
@@ -3,5 +3,8 @@ def make_multiplier(k):
         return x * k
     return mul
 
+
 times3 = make_multiplier(3)
-times3(4)   # 12
+# Once the closure escapes make_multiplier, mul still reads k from the dead
+# enclosing frame, so the product is unconstrained (#6256).
+assert times3(4) == 12

--- a/regression/python/higher-order3/test.desc
+++ b/regression/python/higher-order3/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --unwind 1
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/higher-order3_1/main.py
+++ b/regression/python/higher-order3_1/main.py
@@ -5,5 +5,7 @@ def make_multiplier(k):
 
 
 times3 = make_multiplier(3)
-times3(4)
-times3(5)
+# Two calls through the same escaped closure: both read k from the dead
+# enclosing frame, so neither product is constrained (#6256).
+assert times3(4) == 12
+assert times3(5) == 15

--- a/regression/python/higher-order3_1/test.desc
+++ b/regression/python/higher-order3_1/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --unwind 1
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Both called the escaped closure and discarded the value, so they passed with
closures entirely broken. Asserting the product exposes that mul still reads k
from the dead enclosing frame, so both are marked KNOWNBUG until closures carry
their captured environment.

Tracks #6256
