### PR TITLE
[contracts] give a fresh object an initial version

### DIFF
--- a/regression/function_contract/github_6797_is_fresh_initial_version_pass/main.c
+++ b/regression/function_contract/github_6797_is_fresh_initial_version_pass/main.c
@@ -1,0 +1,19 @@
+/* github_6797_is_fresh_initial_version_pass:
+ * __ESBMC_is_fresh allocated the object without ever writing through the
+ * pointer, so it had no level-2 version. symex skips the phi at a join for
+ * such an object, leaving the branch's version current on both sides, so the
+ * conditional write below escaped its guard and the precondition on t->p was
+ * lost. The branch cannot be taken under v == t->m, so t->p keeps the value
+ * the requires clause gave it and the ensures holds. */
+typedef struct { int m; int p; } T;
+
+void f(T *t, int v)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(t, sizeof(T)));
+  __ESBMC_requires(t->p == 0);
+  __ESBMC_requires(v == t->m);
+  __ESBMC_assigns(t->p);
+  __ESBMC_ensures(t->p == 0);
+  if (v != t->m) { t->p = 1; }
+}
+int main(void) { return 0; }

--- a/regression/function_contract/github_6797_is_fresh_initial_version_pass/test.desc
+++ b/regression/function_contract/github_6797_is_fresh_initial_version_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_6797_is_fresh_no_precondition_fail/main.c
+++ b/regression/function_contract/github_6797_is_fresh_no_precondition_fail/main.c
@@ -1,0 +1,16 @@
+/* github_6797_is_fresh_no_precondition_fail:
+ * The control for github_6797_is_fresh_initial_version_pass. With no requires
+ * establishing t->p, nothing makes the ensures hold on the path where the
+ * branch is not taken, so it must still be rejected. Giving the object an
+ * initial version must fix the lost precondition, not invent one. */
+typedef struct { int m; int p; } T;
+
+void f(T *t, int v)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(t, sizeof(T)));
+  __ESBMC_requires(v == t->m);
+  __ESBMC_assigns(t->p);
+  __ESBMC_ensures(t->p == 0);
+  if (v != t->m) { t->p = 1; }
+}
+int main(void) { return 0; }

--- a/regression/function_contract/github_6797_is_fresh_no_precondition_fail/test.desc
+++ b/regression/function_contract/github_6797_is_fresh_no_precondition_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function f --enforce-contract f --unwind 6
+^VERIFICATION FAILED$
+^.*contract ensures.*$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -1305,6 +1305,10 @@ goto_programt code_contractst::generate_checking_wrapper(
       assume_nn->guard = notequal2tc(ptr_var, gen_zero(ptr_var->type));
       assume_nn->location = location;
       assume_nn->location.comment("__ESBMC_is_fresh: pointer is non-null");
+
+      // Must follow the non-null assume, or this writes through a pointer
+      // symex may still believe is NULL.
+      emit_is_fresh_initial_version(wrapper, ptr_var, size_expr, location);
     };
 
   // is_fresh pointers whose lvalue reads through another pointer — e.g. a
@@ -4521,6 +4525,36 @@ void code_contractst::add_pointer_validity_assumptions(
 
   warn_unstated_extents(func, location, nondet_extent);
   warn_assumed_struct_extents(func, location, assumed_one_element);
+}
+
+void code_contractst::emit_is_fresh_initial_version(
+  goto_programt &wrapper,
+  const expr2tc &ptr_var,
+  const expr2tc &size_expr,
+  const locationt &location)
+{
+  // A symbolic extent may be zero, which would make the write below the
+  // out-of-bounds access the harness exists to avoid. Those contracts keep
+  // the old behaviour, so #6798 survives for them.
+  expr2tc extent = size_expr;
+  simplify(extent);
+  if (!is_constant_int2t(extent) || to_constant_int2t(extent).value <= 0)
+    return;
+
+  // One byte, self-assigned. symex skips the phi at a join for an object with
+  // no level-2 version, so a write on one side of a branch stays current on
+  // both and a precondition on the object's contents is lost (#6798). Versions
+  // are per object rather than per location, so touching a single byte is
+  // enough and the cost does not grow with the extent; a self-assignment
+  // rather than a havoc means no value changes.
+  expr2tc byte = dereference2tc(
+    get_uint8_type(), typecast2tc(pointer_type2tc(get_uint8_type()), ptr_var));
+
+  auto init_inst = wrapper.add_instruction(ASSIGN);
+  init_inst->code = code_assign2tc(byte, byte);
+  init_inst->location = location;
+  init_inst->location.comment(
+    "__ESBMC_is_fresh: give the fresh object an initial version");
 }
 
 void code_contractst::emit_struct_stack_backing(

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -629,6 +629,19 @@ private:
   bool
   param_extent_is_observable(const symbolt &func, const irep_idt &param) const;
 
+  /// \brief Give a freshly allocated object a level-2 version.
+  ///
+  /// symex skips the phi at a join for an object that has none, so a write on
+  /// one side of a branch stays current on both and a precondition on the
+  /// object's contents is silently lost (#6798). One self-assigned byte is
+  /// enough, since versions are per object rather than per location, and it
+  /// changes no value. Skipped for a symbolic extent, which may be zero.
+  void emit_is_fresh_initial_version(
+    goto_programt &wrapper,
+    const expr2tc &ptr_var,
+    const expr2tc &size_expr,
+    const locationt &location);
+
   /// \brief Back a struct/union pointer param with one stack-allocated element.
   ///
   /// This is the normative statement of the #6483 carve-out; other sites point


### PR DESCRIPTION
Works around #6797. Independent of #6796 — this applies to `master` on its own, and the two can land in either order.

`__ESBMC_is_fresh(p, n)` allocates the object and never writes through the pointer, so it has no level-2 version. `phi_function` skips such an object at a join, so a write on one side of a branch stays current on both: the write escapes its guard, and a precondition constraining the object's contents is lost.

```c
typedef struct { int m; int p; } T;

void f(T *t, int v)
{
  __ESBMC_requires(__ESBMC_is_fresh(t, sizeof(T)));
  __ESBMC_requires(t->p == 0);
  __ESBMC_requires(v == t->m);
  __ESBMC_assigns(t->p);
  __ESBMC_ensures(t->p == 0);
  if (v != t->m) { t->p = 1; }   /* unreachable under the requires */
}
```

| how the pointer's validity is stated | before | after |
| --- | --- | --- |
| `__ESBMC_is_fresh(t, sizeof(T))` | **FAILED** | SUCCESSFUL |
| `t != 0`, nothing else changed | SUCCESSFUL | SUCCESSFUL |

The branch cannot be taken under `v == t->m`, so `t->p` keeps the value the requires clause gave it. The `t != 0` path was never affected, because it is backed by a `DECL` and therefore has a version.

## The change

One self-assigned byte, emitted after the non-null assume:

```c
expr2tc byte = dereference2tc(
  get_uint8_type(), typecast2tc(pointer_type2tc(get_uint8_type()), ptr_var));
init_inst->code = code_assign2tc(byte, byte);
```

Three properties worth stating, because I got each of them wrong in an earlier attempt:

- **One byte is enough.** Versions are per object symbol, not per location, so touching any byte gives the whole object a version. Verified: a conditional write to `t->q` is fixed by touching `t->m`, and in an array case a conditional write to `a[5]` is fixed by touching `a[0]`.
- **It is therefore O(1) in the extent.** A 2048-byte pointee costs the same as a 4-byte one. `regression/loop-invariants/quantified_array_invariant`, whose pointee is `struct { int16_t e[1024]; }` and which exists to show that cost stays independent of N, runs in 0.28s. Writing the whole pointee instead made that test take 446s, which is what made me look for the cheaper form.
- **A self-assignment, not a havoc.** It supplies a version without changing a value, so it cannot mask anything. It has to follow the non-null assume, or it writes through a pointer symex may still believe is NULL.

Skipped when the extent is symbolic, since it may be zero and the write would then be the out-of-bounds access the harness exists to avoid. `enforce_tlv_mid_pass` (`is_fresh(&buf, buf_len)`) and `cpp_is_fresh_member_pass` are the cases in the tree; both keep the old behaviour, so #6798 survives for them.

## This is a workaround, and the real defect is worse

The underlying bug is `phi_function` in `src/goto-symex/symex_goto.cpp` skipping objects with no prior level-2 record. It is not contract-specific. Filed as #6798 with a four-line reproducer using plain `malloc` and no contract syntax at all, which reports `VERIFICATION SUCCESSFUL` for a property that is false. It reproduces on 7.11.0, 8.0.0, 8.2.0 and master.

I tried fixing it there. It works, and `regression/function_contract` plus `regression/loop-invariants` stay green, but `humaneval_152` goes from 763 MB to 7.75 GB peak and dies on the harness's 8 GB limit. ESBMC has no field-sensitive merging, so every dynamic object gets a whole-byte-array ITE at every join. That needs design work rather than a two-line change, and the measurements are recorded on #6798 so whoever takes it does not repeat them.

So this PR does not claim to fix #6798. It makes `__ESBMC_is_fresh` usable in the meantime, at the cost of one instruction per allocation.

## Tests

`github_6797_is_fresh_initial_version_pass` is the reproducer. `github_6797_is_fresh_no_precondition_fail` is its control: with no requires establishing `t->p`, nothing makes the ensures hold and it must still be rejected — the fix has to restore a lost precondition, not invent one.

397/397 pass across `function_contract` and `loop-invariants`.
