### PR TITLE
[ci] Run the repo-stats job on a runner that has Docker

### DIFF
--- a/.github/workflows/esbmc-stats.yml
+++ b/.github/workflows/esbmc-stats.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   j1:
     name: repostats-for-robota-core
-    runs-on: ubuntu-slim
+    # github-repo-stats is a Docker container action, and ubuntu-slim is itself
+    # a container with no Docker daemon to build it against.
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # The repositories to generate reports for.


### PR DESCRIPTION
`github-repo-stats` is a Docker container action, and `ubuntu-slim` is itself a container with no daemon at `/var/run/docker.sock`, so the build failed three times and the job gave up.

Every scheduled run has failed since `ubuntu-slim` landed in #4690 on 2026-05-22. This is the only `ubuntu-slim` job using a container action — the others use JavaScript actions, which run natively — and `pages.yml` already runs one on `ubuntu-latest`.
