### PR TITLE
[solver] Widen #6794's scope: the tuple flattener, not bitwuzla

### DIFF
--- a/regression/bitwuzla/github_6794_reflexive_array_eq/main.c
+++ b/regression/bitwuzla/github_6794_reflexive_array_eq/main.c
@@ -1,8 +1,8 @@
 /* array_conv encodes an array equality index-by-index, so a frame check that
  * compares an array against its own snapshot -- the same array id at the same
  * update level -- indexed a valuation vector that is empty whenever no select
- * was ever applied to that array, and aborted (#6794). Bitwuzla only: Z3
- * carries arrays natively and never enters array_conv. */
+ * was ever applied to that array, and aborted (#6794). Reached via the tuple
+ * flattener, so every backend registering no tuple_api takes this path. */
 #include <stdint.h>
 #include <stddef.h>
 #define N 8

--- a/regression/bitwuzla/github_6794_reflexive_array_eq_fail/test.desc
+++ b/regression/bitwuzla/github_6794_reflexive_array_eq_fail/test.desc
@@ -2,3 +2,4 @@ CORE
 main.c
 --bitwuzla --enforce-contract add --function add --unwind 9
 ^VERIFICATION FAILED$
+^.*not in assigns clause$

--- a/regression/z3/github_6794_tuple_flattener_array_eq/main.c
+++ b/regression/z3/github_6794_tuple_flattener_array_eq/main.c
@@ -1,0 +1,20 @@
+/* Companion to regression/bitwuzla/github_6794_reflexive_array_eq, pinning the
+ * same fix on a z3-only build. array_conv is reached through the TUPLE
+ * flattener: a backend registering no tuple_api gets smt_tuple_node_flattener,
+ * which owns an array_convt. z3 does register one, so --tuple-node-flattener is
+ * what puts this path back in reach here (#6794). */
+#include <stdint.h>
+#include <stddef.h>
+#define N 8
+typedef struct
+{
+  int16_t coeffs[N];
+} poly;
+void add(poly *r, const poly *b)
+{
+  __ESBMC_requires(r != NULL && b != NULL);
+  __ESBMC_assigns(r->coeffs);
+  __ESBMC_ensures(1);
+  for (unsigned i = 0; i < N; i++)
+    r->coeffs[i] = (int16_t)(r->coeffs[i] + b->coeffs[i]);
+}

--- a/regression/z3/github_6794_tuple_flattener_array_eq/test.desc
+++ b/regression/z3/github_6794_tuple_flattener_array_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --tuple-node-flattener --enforce-contract add --function add --unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -451,8 +451,14 @@ array_convt::encode_array_equality(const array_ast *a1, const array_ast *a2)
   // Record an equality between two arrays at this point in time. To be
   // implemented at constraint time.
 
-  /* Reflexivity: recording it instead indexes a valuation vector that is empty
-   * whenever no select was ever applied to that array (#6794). */
+  /* Both operands are resolved through array_valuation[id][update], so this
+   * pair is the identity of an array state, and only an unbounded array
+   * carries one -- a bounded one leaves both fields unset. */
+  assert(is_unbounded_array(a1->sort) && is_unbounded_array(a2->sort));
+
+  /* Same id and update level: the element-wise encoding would compare a
+   * valuation vector with itself, and that vector is empty when the array was
+   * never selected (#6794). */
   if (
     a1->base_array_id == a2->base_array_id &&
     a1->array_update_num == a2->array_update_num)


### PR DESCRIPTION
Follow-up to #6801, which merged before this correction reached the branch.

`array_conv` is reached through `smt_tuple_node_flattener`, which a backend gets when it registers no `tuple_api`; z3 and yices do, so the other six take that path. #6801 recorded the cause as bitwuzla's array handling, which is wrong and would misdirect anyone triaging the same abort under cvc5 or boolector.

Adds a `--z3 --tuple-node-flattener` regression so a z3-only build still pins the fix, pins the `_fail` test's property text, and asserts the unbounded-array invariant the id/update pair relies on. All three tests fail with the guard neutralised.
