### PR TITLE
[python] Pin both shapes of calling a callable held in a list

### DIFF
--- a/regression/python/callable_class_field/main.py
+++ b/regression/python/callable_class_field/main.py
@@ -1,12 +1,13 @@
-# Storing callables in a class instance field, as opposed to a module-level
-# variable (which callable3 and friends already cover). This is the last of
-# the four features regression/python/concurrency_fail waits on (#4566) --
-# threading.Thread subclassing, queue.Queue and random.choice over a filtered
-# list all work now.
+# Calling a callable that was stored in a list. Storing one works -- drop the
+# call below and this verifies -- so the gap is the indirect call through the
+# element, not the container (#6640).
 #
-# ESBMC currently aborts rather than reporting anything: the list element type
-# comes out as empty/void, so dereferencet::construct_from_array asks it for a
-# width and the symbolic_type_excp escapes uncaught.
+# The two shapes fail differently, and only this one is a crash: through an
+# instance field ESBMC aborts on to_code_type's `type.id() == typet::t_code`,
+# while through a module-level list it reports `got invalid code for function
+# ...$list_elem$` and exits (callable_module_list pins that one). callable3
+# covers neither: it stores a callable in a module-level *variable* and then
+# calls a different function directly.
 from typing import List, Callable
 
 

--- a/regression/python/callable_module_list/main.py
+++ b/regression/python/callable_module_list/main.py
@@ -1,0 +1,16 @@
+# The module-level counterpart of callable_class_field: calling a callable held
+# in a list element. This shape reports `got invalid code for function
+# ...$list_elem$` and exits rather than aborting, so it pins the reachable half
+# of #6640 -- if the abort in callable_class_field is ever turned into a
+# diagnostic, both shapes should end up here.
+from typing import List, Callable
+
+
+def cb(x: int) -> int:
+    return x + 1
+
+
+fns: List[Callable[[int], int]] = []
+fns.append(cb)
+
+assert fns[0](1) == 2

--- a/regression/python/callable_module_list/test.desc
+++ b/regression/python/callable_module_list/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Storing a callable in a list already works, so the gap is the indirect call
through the element. The two shapes fail differently -- an instance field aborts
on to_code_type's type assertion, a module-level list reports invalid code and
exits -- and only the first was covered, under a comment describing a failure
that no longer happens.

Tracks #6640
