### PR TITLE
[python] Raise TypeError for item assignment on a string

### DIFF
--- a/regression/python/str_item_assign_typeerror/main.py
+++ b/regression/python/str_item_assign_typeerror/main.py
@@ -1,0 +1,13 @@
+# Assigning through a string subscript is a TypeError: strings are immutable.
+# Caught here rather than updating the char array with a whole string value,
+# which tripped with2t::assert_consistency and aborted.
+s = "hello"
+
+try:
+    s[0] = "H"
+    caught = False
+except TypeError:
+    caught = True
+
+assert caught
+assert s == "hello"

--- a/regression/python/str_item_assign_typeerror/test.desc
+++ b/regression/python/str_item_assign_typeerror/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-immutable-fail/test.desc
+++ b/regression/python/string-immutable-fail/test.desc
@@ -1,4 +1,5 @@
-KNOWNBUG
+CORE
 main.py
 
 ^VERIFICATION FAILED$
+uncaught exception: TypeError

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1732,6 +1732,28 @@ bool python_converter::return_value_uses_call_argument(
          return_value.contains("value") && is_param_name(return_value["value"]);
 }
 
+/// Item assignment on an immutable container is a TypeError. A string that is
+/// not intercepted here updates its char array with a whole string value, which
+/// trips with2t::assert_consistency and aborts instead of reporting anything.
+bool python_converter::reject_immutable_item_assignment(
+  const typet &container_type,
+  codet &target_block)
+{
+  const char *kind = tuple_handler_->is_tuple_type(container_type) ? "tuple"
+                     : type_utils::is_string_type(container_type)  ? "str"
+                                                                   : nullptr;
+  if (!kind)
+    return false;
+
+  exprt raise = get_exception_handler().gen_exception_raise(
+    "TypeError",
+    std::string("'") + kind + "' object does not support item assignment");
+  codet throw_code("expression");
+  throw_code.operands().push_back(raise);
+  target_block.copy_to_operands(throw_code);
+  return true;
+}
+
 void python_converter::reject_unsafe_numpy_view_target(
   const nlohmann::json &target)
 {
@@ -3271,16 +3293,8 @@ void python_converter::get_var_assign(
     exprt container_expr = get_expr(target["value"]);
     typet container_type = container_expr.type();
 
-    // Tuple subscript assignment: tuples are immutable, raise TypeError
-    if (tuple_handler_->is_tuple_type(container_type))
-    {
-      exprt raise = get_exception_handler().gen_exception_raise(
-        "TypeError", "'tuple' object does not support item assignment");
-      codet throw_code("expression");
-      throw_code.operands().push_back(raise);
-      target_block.copy_to_operands(throw_code);
+    if (reject_immutable_item_assignment(container_type, target_block))
       return;
-    }
 
     // Handle object subscript assignment via __setitem__:
     //   obj[key] = value  ->  obj.__setitem__(key, value)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -900,6 +900,12 @@ private:
 
   void reject_unsafe_numpy_view_target(const nlohmann::json &target);
 
+  /// Raise Python's TypeError for item assignment on an immutable container,
+  /// reporting whether `container_type` is one.
+  bool reject_immutable_item_assignment(
+    const typet &container_type,
+    codet &target_block);
+
   void record_numpy_view_copy(const exprt &lhs, const nlohmann::json &rhs_node);
 
   void clear_numpy_view_copy(const exprt &lhs);


### PR DESCRIPTION
`s[0] = "H"` updated the char array with a whole string value, so
with2t::assert_consistency aborted on the element type mismatch and ESBMC
reported nothing at all. Strings are immutable, so raise the TypeError tuples
already raise, from a helper shared by both.

regression/python/string-immutable-fail expected VERIFICATION FAILED and now
gets it, so it moves from KNOWNBUG to CORE and also matches the reason.
