### PR TITLE
[python] Bound dict_eq_int_float instead of searching for the bound

### DIFF
--- a/regression/python/dict_eq_int_float/test.desc
+++ b/regression/python/dict_eq_int_float/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc
+--unwind 3
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
--incremental-bmc took 215s against CI's 120s per-test cap, so this test failed
on unrelated PRs by luck (seen twice on #6808). --unwind 3 reaches the same
verdict in 66s -- 57s under ctest -- with unwinding assertions still enabled, so
SUCCESSFUL means the bound is sufficient rather than merely unexplored.

--unwind 2 fails, so 3 is the smallest sufficient bound, not an arbitrary cut.
All six assertions are unchanged.
