### PR TITLE
[python] Stop a class defined inside a method segfaulting the builder

### DIFF
--- a/regression/python/class_in_method_no_segv/main.py
+++ b/regression/python/class_in_method_no_segv/main.py
@@ -1,0 +1,12 @@
+# A class defined inside a method is not supported, but it must not crash:
+# the class builder dereferenced the missing method symbol and segfaulted.
+# The method stays callable, so the verdict below is still decided.
+class Outer:
+    def m(self) -> int:
+        class Inner:
+            pass
+
+        return 1
+
+
+assert Outer().m() == 1

--- a/regression/python/class_in_method_no_segv/test.desc
+++ b/regression/python/class_in_method_no_segv/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/class_in_method_no_segv_fail/main.py
+++ b/regression/python/class_in_method_no_segv_fail/main.py
@@ -1,0 +1,12 @@
+# A class defined inside a method is not supported, but it must not crash:
+# the class builder dereferenced the missing method symbol and segfaulted.
+# The method stays callable, so the verdict below is still decided.
+class Outer:
+    def m(self) -> int:
+        class Inner:
+            pass
+
+        return 1
+
+
+assert Outer().m() == 999

--- a/regression/python/class_in_method_no_segv_fail/test.desc
+++ b/regression/python/class_in_method_no_segv_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/class/python_class_builder.cpp
+++ b/src/python-frontend/class/python_class_builder.cpp
@@ -42,6 +42,41 @@ symbolt *python_class_builder::ensure_sym(const std::string &name)
 
 /* Handles inheritance: collects user-defined base classes and
  * merges their components (fields) into the derived struct type. */
+/// Add the converted method \p sid to \p st's method table, reporting whether
+/// it could be. get_function_definition does not always leave a symbol behind
+/// -- a method whose body defines a class is not converted -- and
+/// dereferencing that miss segfaulted, since the recovery here only ever
+/// caught exceptions. Such a method stays callable directly; it is only absent
+/// from the table, so dispatch through it may not resolve.
+bool python_class_builder::register_method(
+  struct_typet &st,
+  const symbol_id &sid)
+{
+  const std::string id = sid.to_string();
+  symbolt *method_symbol = conv_.symbol_table_.find_symbol(id);
+  if (!method_symbol)
+  {
+    log_warning(
+      "{}: no symbol after conversion, so it is missing from the class's "
+      "method table; a class defined inside a method is not supported",
+      id);
+    return false;
+  }
+
+  try
+  {
+    exprt me = symbol_expr(*method_symbol);
+    st.methods().emplace_back(me.name(), me.type());
+  }
+  catch (const std::exception &e)
+  {
+    log_error("Exception creating symbol_expr for {}: {}", id, e.what());
+    return false;
+  }
+
+  return true;
+}
+
 bool python_class_builder::get_bases(struct_typet &st)
 {
   bool has_ud = false;
@@ -110,20 +145,8 @@ void python_class_builder::get_members(
       symbol_id method_sid = conv_.create_symbol_id();
       conv_.current_func_name_ = saved_func_for_lookup;
 
-      symbolt *method_symbol =
-        conv_.symbol_table_.find_symbol(method_sid.to_string());
-
-      try
+      if (!register_method(st, method_sid))
       {
-        exprt me = symbol_expr(*method_symbol);
-        st.methods().emplace_back(me.name(), me.type());
-      }
-      catch (const std::exception &e)
-      {
-        log_error(
-          "Exception creating symbol_expr for {}: {}",
-          method_sid.to_string(),
-          e.what());
         conv_.current_func_name_ = saved_func_name;
         continue;
       }

--- a/src/python-frontend/class/python_class_builder.h
+++ b/src/python-frontend/class/python_class_builder.h
@@ -8,6 +8,8 @@ class codet;
 class symbolt;
 class struct_typet;
 
+class symbol_id;
+
 class python_class_builder
 {
 public:
@@ -30,6 +32,11 @@ private:
   symbolt *ensure_sym(const std::string &name);
 
   bool get_bases(struct_typet &st);
+
+  /// Add the converted method \p sid to \p st's method table, reporting
+  /// whether it could be. A method that was not converted has no symbol, and
+  /// dereferencing that miss used to segfault.
+  bool register_method(struct_typet &st, const symbol_id &sid);
 
   void get_members(struct_typet &st, codet &out, bool has_ud_base);
 


### PR DESCRIPTION
```python
class Outer:
    def m(self) -> int:
        class Inner:
            pass
        return 1

assert Outer().m() == 1        # Segmentation fault: 11
```

get_function_definition does not always leave a symbol behind -- a method whose
body defines a class is not converted -- and the class builder dereferenced that
miss. The try/catch beside it only ever caught exceptions, so a null was a
segfault rather than the recovery the author intended.

The same class in a plain function verifies fine, so the trigger is method scope
specifically.

Method-scope classes remain unsupported; this only stops the crash. The method
stays callable, so both regression tests decide a real verdict -- the _fail one
asserts a false value and fails. Both segfault on master.
