### PR TITLE
[python] Report an ill-typed 'is' instead of aborting the solver

### DIFF
--- a/regression/python/is_ptr_vs_nonptr_diagnostic/main.py
+++ b/regression/python/is_ptr_vs_nonptr_diagnostic/main.py
@@ -1,0 +1,18 @@
+# An object popped from a deque comes back with an integer type, so comparing
+# it with the object by identity built an equality whose operands differ in
+# width -- every solver backend asserted on it. The construct is still
+# unsupported; it must report that rather than abort.
+from collections import deque as Queue
+
+
+class Node:
+    def __init__(self, v: int) -> None:
+        self.v = v
+
+
+q = Queue()
+a = Node(1)
+q.append(a)
+n = q.popleft()
+
+assert n is a

--- a/regression/python/is_ptr_vs_nonptr_diagnostic/test.desc
+++ b/regression/python/is_ptr_vs_nonptr_diagnostic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: 'is' between a pointer and a non-pointer

--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -632,6 +632,15 @@ expr2tc python_converter::build_is_equality(const exprt &lhs, const exprt &rhs)
     migrate_expr(rhs, rhs2);
   }
 
+  /* An object that lost its type through a container comes back as an
+   * integer, and comparing that with the object's pointer builds an equality
+   * every backend's mk_eq rejects on the width mismatch (#6640 territory).
+   * Say so here rather than abort in the solver. */
+  if (is_pointer_type(lhs2->type) != is_pointer_type(rhs2->type))
+    throw std::runtime_error(
+      "'is' between a pointer and a non-pointer: one operand lost its object "
+      "type, which ESBMC cannot compare by identity");
+
   return equality2tc(lhs2, rhs2);
 }
 


### PR DESCRIPTION
```python
q = Queue(); a = Node(1); q.append(a)
n = q.popleft()
assert n is a          # Assertion failed: get_data_width() == get_data_width()
```

An object popped from a container comes back typed as a 64-bit integer, so the
identity comparison built an equality whose operands differ in width. Every
backend rejects that -- z3 asserts at z3_conv.cpp:723, bitwuzla at
bitwuzla_conv.cpp:470 -- so the run died with no output at all.

This does not fix the typing: carrying object identity through a container needs
reference storage for non-empty classes, which is #6640/#4566. It stops the
abort and names the construct.

All 209 regression tests using `is`/`is not` pass; the guard runs only in
build_is_equality, so that is the whole affected set. The new test aborts on
master.
