### PR TITLE
[goto-programs] Stamp if2t locations on natively emitted statements

### DIFF
--- a/regression/python/github_4715_irep2_native_floordiv_loc_01/main.py
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_01/main.py
@@ -1,0 +1,10 @@
+def isqrt_like(n: int) -> int:
+    x: int = n
+    y: int = (x + 1) // 2
+    while y < x:
+        x = y
+        y = (x + n // x) // 2
+    return x
+
+
+assert isqrt_like(16) == 4

--- a/regression/python/github_4715_irep2_native_floordiv_loc_01/test.desc
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--goto-functions-only
+\* #location: \n\s*\* file: [^\n]*main\.py\n\s*\* line: 6\n\s*\* function: isqrt_like\n\s*\* column: 8

--- a/regression/python/github_4715_irep2_native_floordiv_loc_02/main.py
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_02/main.py
@@ -1,0 +1,10 @@
+def isqrt_like(n: int) -> int:
+    x: int = n
+    y: int = (x + 1) // 2
+    while y < x:
+        x = y
+        y = (x + n // x) // 2
+    return x
+
+
+assert isqrt_like(16) == 4

--- a/regression/python/github_4715_irep2_native_floordiv_loc_02/test.desc
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-irep2-native-body --goto-functions-only
+\* #location: \n\s*\* file: [^\n]*main\.py\n\s*\* line: 6\n\s*\* function: isqrt_like\n\s*\* column: 8

--- a/regression/python/github_4715_irep2_native_floordiv_loc_03/main.py
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_03/main.py
@@ -1,0 +1,5 @@
+def half_floor(n: int, d: int) -> int:
+    return (n + d // n) // 2
+
+
+assert half_floor(8, 4) == 4

--- a/regression/python/github_4715_irep2_native_floordiv_loc_03/test.desc
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--goto-functions-only
+\* #location: \n\s*\* file: [^\n]*main\.py\n\s*\* line: 2\n\s*\* function: half_floor\n\s*\* column: 4

--- a/regression/python/github_4715_irep2_native_floordiv_loc_04/main.py
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_04/main.py
@@ -1,0 +1,5 @@
+def half_floor(n: int, d: int) -> int:
+    return (n + d // n) // 2
+
+
+assert half_floor(8, 4) == 4

--- a/regression/python/github_4715_irep2_native_floordiv_loc_04/test.desc
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_04/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-irep2-native-body --goto-functions-only
+\* #location: \n\s*\* file: [^\n]*main\.py\n\s*\* line: 2\n\s*\* function: half_floor\n\s*\* column: 4

--- a/regression/python/github_4715_irep2_native_floordiv_loc_05/main.py
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_05/main.py
@@ -1,0 +1,9 @@
+def sink(v: int) -> int:
+    return v
+
+
+def run(n: int, d: int) -> None:
+    sink((n + d // n) // 2)
+
+
+run(8, 4)

--- a/regression/python/github_4715_irep2_native_floordiv_loc_05/test.desc
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_05/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--goto-functions-only
+\* #location: \n\s*\* file: [^\n]*main\.py\n\s*\* line: 6\n\s*\* function: run\n\s*\* column: 4

--- a/regression/python/github_4715_irep2_native_floordiv_loc_06/main.py
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_06/main.py
@@ -1,0 +1,9 @@
+def sink(v: int) -> int:
+    return v
+
+
+def run(n: int, d: int) -> None:
+    sink((n + d // n) // 2)
+
+
+run(8, 4)

--- a/regression/python/github_4715_irep2_native_floordiv_loc_06/test.desc
+++ b/regression/python/github_4715_irep2_native_floordiv_loc_06/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-irep2-native-body --goto-functions-only
+\* #location: \n\s*\* file: [^\n]*main\.py\n\s*\* line: 6\n\s*\* function: run\n\s*\* column: 4

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -172,6 +172,20 @@ static void stamp_if_locations(expr2tc &expr, const locationt &loc)
     [&loc](expr2tc &op) { stamp_if_locations(op, loc); });
 }
 
+// `code2` as the legacy path would have stored it: same node, except that any
+// ternary the round-trip would have had restore_value_locations stamp carries
+// `here`. Mirrors that helper's guard -- with no usable location it stamps
+// nothing rather than writing an empty one.
+static expr2tc with_if_locations(const expr2tc &code2, const locationt &here)
+{
+  if (here.get_file().empty())
+    return code2;
+
+  expr2tc stamped = code2;
+  stamp_if_locations(stamped, here);
+  return stamped;
+}
+
 // The location restore_value_locations would propagate into `code`'s value
 // operands: the statement's own when it has one, otherwise whatever the
 // enclosing statement passed down. An empty result means that helper's
@@ -435,11 +449,8 @@ bool goto_convert_functionst::convert_native_rec(
     // ternary — if2t's location field survives the round trip, so legacy keeps
     // what restore_value_locations stamped there and we must stamp it too.
     goto_programt::targett t = dest.add_instruction(ASSIGN);
-    expr2tc stamped = code2;
-    if (const locationt &here = effective_location(assign.location, inherited);
-        !here.get_file().empty())
-      stamp_if_locations(stamped, here);
-    t->code = stamped;
+    t->code =
+      with_if_locations(code2, effective_location(assign.location, inherited));
     t->location = assign.location;
     return true;
   }
@@ -523,7 +534,8 @@ bool goto_convert_functionst::convert_native_rec(
       return false;
 
     goto_programt::targett t = dest.add_instruction(OTHER);
-    t->code = code2;
+    t->code = with_if_locations(
+      code2, effective_location(expr_stmt.location, inherited));
     t->location = expr_stmt.location;
     return true;
   }
@@ -665,12 +677,14 @@ bool goto_convert_functionst::convert_native_rec(
       if (val.is_nil())
         return delegate_to_legacy();
       // The RETURN instruction convert_return emits is migrate_expr(code_returnt)
-      // located at the statement; migrate_expr drops the value-operand location
-      // restore_value_locations stamped, so it round-trips to code2 itself. Emit
+      // located at the statement; migrate_expr drops every value-operand
+      // location restore_value_locations stamped except a ternary's, so
+      // with_if_locations is what makes this round-trip to code2 itself. Emit
       // it directly, exactly as the assign/expression handlers do.
       goto_programt::targett r = dest.add_instruction();
       r->make_return();
-      r->code = code2;
+      r->code =
+        with_if_locations(code2, effective_location(ret.location, inherited));
       r->location = emitted_location(ret.location);
     }
     else if (val.is_not_nil() && val.type().id() != "empty")
@@ -1392,7 +1406,8 @@ bool goto_convert_functionst::convert_native_rec(
       return delegate_to_legacy();
 
     goto_programt::targett t = dest.add_instruction();
-    t->make_function_call(code2);
+    t->make_function_call(
+      with_if_locations(code2, effective_location(f.location, inherited)));
     t->location = f.location;
     return true;
   }

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -149,6 +149,29 @@ static void restore_value_locations(exprt &code, const locationt &inherited)
   }
 }
 
+// The IREP2 counterpart of stamp_value_locations. Value-level IREP2 carries no
+// source location with one exception: if2t has a `location` field, and
+// migrate_expr/migrate_expr_back both preserve it (migrate.cpp). So a ternary
+// is the one value operand on which the round-trip's restore_value_locations
+// stamping *survives* into the stored code -- which is why a natively emitted
+// statement has to reproduce it, or the two paths differ on any body containing
+// one (e.g. the correction term Python floor division lowers to).
+static void stamp_if_locations(expr2tc &expr, const locationt &loc)
+{
+  if (is_nil_expr(expr))
+    return;
+
+  if (is_if2t(expr))
+  {
+    if2t &ref = to_if2t(expr);
+    if (ref.location.is_nil() || ref.location.get_file().empty())
+      ref.location = loc;
+  }
+
+  expr.get()->Foreach_operand(
+    [&loc](expr2tc &op) { stamp_if_locations(op, loc); });
+}
+
 // The location restore_value_locations would propagate into `code`'s value
 // operands: the statement's own when it has one, otherwise whatever the
 // enclosing statement passed down. An empty result means that helper's
@@ -407,13 +430,16 @@ bool goto_convert_functionst::convert_native_rec(
       return delegate_to_legacy();
 
     // For side-effect-free operands the instruction convert_assign emits is
-    // migrate_expr(code_assignt(lhs, rhs)) located at the statement — which
-    // round-trips back to `code2` itself (migrate_expr drops the operand
-    // locations, so none of restore_value_locations' stamping survives in the
-    // stored code). Emit it directly, no round-trip, carrying the statement's
-    // own location, exactly as copy(new_assign, ASSIGN) would.
+    // migrate_expr(code_assignt(lhs, rhs)) located at the statement, which
+    // round-trips back to `code2` itself for every value operand except a
+    // ternary — if2t's location field survives the round trip, so legacy keeps
+    // what restore_value_locations stamped there and we must stamp it too.
     goto_programt::targett t = dest.add_instruction(ASSIGN);
-    t->code = code2;
+    expr2tc stamped = code2;
+    if (const locationt &here = effective_location(assign.location, inherited);
+        !here.get_file().empty())
+      stamp_if_locations(stamped, here);
+    t->code = stamped;
     t->location = assign.location;
     return true;
   }

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -676,11 +676,11 @@ bool goto_convert_functionst::convert_native_rec(
       // convert_return replaces a missing value with nondet
       if (val.is_nil())
         return delegate_to_legacy();
-      // The RETURN instruction convert_return emits is migrate_expr(code_returnt)
-      // located at the statement; migrate_expr drops every value-operand
-      // location restore_value_locations stamped except a ternary's, so
-      // with_if_locations is what makes this round-trip to code2 itself. Emit
-      // it directly, exactly as the assign/expression handlers do.
+      // The RETURN instruction convert_return emits is
+      // migrate_expr(code_returnt) located at the statement; migrate_expr drops
+      // every value-operand location restore_value_locations stamped except a
+      // ternary's, so with_if_locations is what makes this round-trip to code2
+      // itself. Emit it directly, exactly as the assign/expression handlers do.
       goto_programt::targett r = dest.add_instruction();
       r->make_return();
       r->code =


### PR DESCRIPTION
`if2t` is the only value-level IREP2 kind that carries a location, and `migrate_expr`/`migrate_expr_back` preserve it in both directions. So the legacy body round-trip keeps what `restore_value_locations` stamps on a ternary, while the native path left it nil — the emission sites' comments assumed `migrate_expr` drops all operand locations, which holds for every kind except this one.

Four native emission points can carry a nested ternary: assignment, return, a bare call, and an expression statement. All four are covered here via `with_if_locations`; `SKIP` and `GOTO` have no value operands.

Found by the Python A/B sweep in #6829: 24 of 379 sampled tests diverged on this. All are now byte-identical and the legacy arm is unchanged — the converter-side alternative is refuted in #6829 §21.7 because it moves legacy onto a worse location instead.

The six tests are A/B pairs covering the assignment, return and call shapes. Each native arm fails without the corresponding patch; each legacy arm passes with and without, pinning that the fix does not move legacy.