### PR TITLE
[om] Give five containers a std::initializer_list constructor

### DIFF
--- a/regression/esbmc-cpp/cpp/container_init_list/main.cpp
+++ b/regression/esbmc-cpp/cpp/container_init_list/main.cpp
@@ -1,0 +1,18 @@
+#include <cassert>
+#include <deque>
+#include <list>
+#include <set>
+#include <forward_list>
+int main() {
+  std::deque<int> d{1,2,3};
+  assert(d.size()==3 && d[0]==1 && d[2]==3);
+  std::list<int> l{1,2,3};
+  assert(l.size()==3 && l.front()==1 && l.back()==3);
+  std::set<int> s{3,1,2};
+  assert(s.size()==3 && *s.begin()==1);
+  std::multiset<int> m{2,1,2};
+  assert(m.size()==3 && *m.begin()==1);
+  std::forward_list<int> f{1,2,3};
+  assert(f.front()==1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/container_init_list/test.desc
+++ b/regression/esbmc-cpp/cpp/container_init_list/test.desc
@@ -2,5 +2,3 @@ CORE
 main.cpp
 --unwind 8
 ^VERIFICATION SUCCESSFUL$
-^EXIT=0$
-^SIGNAL=0$

--- a/regression/esbmc-cpp/cpp/container_init_list/test.desc
+++ b/regression/esbmc-cpp/cpp/container_init_list/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/esbmc-cpp/cpp/container_init_list_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/container_init_list_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+#include <set>
+
+int main()
+{
+  // set is ordered and unique: {3,1,2,1} holds 1,2,3 and begins at 1.
+  std::set<int> s{3, 1, 2, 1};
+  assert(s.size() == 4);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/container_init_list_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/container_init_list_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$

--- a/regression/esbmc-cpp/cpp/container_init_list_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/container_init_list_fail/test.desc
@@ -2,5 +2,3 @@ CORE
 main.cpp
 --unwind 8
 ^VERIFICATION FAILED$
-^EXIT=10$
-^SIGNAL=0$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -3,6 +3,9 @@
 
 #include "iterator"
 #include "stdexcept"
+#if __cplusplus >= 201103L
+#  include <initializer_list>
+#endif
 
 #define DEQUE_CAPACITY 500
 
@@ -435,6 +438,14 @@ public:
     _size = 0;
     _capacity = 1;
   }
+
+#if __cplusplus >= 201103L
+  deque(std::initializer_list<T> init) : _size(0), _capacity(1)
+  {
+    for (const T *it = init.begin(); it != init.end(); ++it)
+      this->push_back(*it);
+  }
+#endif
 
   ~deque()
   {

--- a/src/cpp/library/forward_list
+++ b/src/cpp/library/forward_list
@@ -2,6 +2,9 @@
 #define __STL_FORWARD_LIST
 
 #include "definitions.h"
+#if __cplusplus >= 201103L
+#  include <initializer_list>
+#endif
 
 #define FORWARD_LIST_MAX_SIZE 20
 
@@ -100,6 +103,15 @@ public:
   forward_list() : _head(SENTINEL), _free(0)
   {
   }
+
+#if __cplusplus >= 201103L
+  /* Built back-to-front: push_front is the only O(1) insertion here. */
+  forward_list(std::initializer_list<T> init) : _head(SENTINEL), _free(0)
+  {
+    for (const T *it = init.end(); it != init.begin();)
+      this->push_front(*--it);
+  }
+#endif
 
   forward_list(size_type n, const T &value) : _head(SENTINEL), _free(0)
   {

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -4,6 +4,9 @@
 #include "definitions.h"
 #include "type_traits"
 #include "vector"
+#if __cplusplus >= 201103L
+#  include <initializer_list>
+#endif
 
 #define LIST_MAX_SIZE 20
 
@@ -262,6 +265,15 @@ public:
   {
     _init();
   }
+
+#if __cplusplus >= 201103L
+  list(std::initializer_list<value_type> init)
+  {
+    _init();
+    for (const value_type *it = init.begin(); it != init.end(); ++it)
+      this->push_back(*it);
+  }
+#endif
 
   list(size_type n, const value_type &value = value_type())
   {

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -9,6 +9,9 @@
 #include "iostream"
 #include "algorithm"
 #include "functional"
+#if __cplusplus >= 201103L
+#  include <initializer_list>
+#endif
 
 namespace std
 {
@@ -432,6 +435,14 @@ public:
   {
     _size = 0;
   }
+
+#if __cplusplus >= 201103L
+  multiset(std::initializer_list<value_type> init) : _size(0)
+  {
+    for (const value_type *it = init.begin(); it != init.end(); ++it)
+      this->insert(*it);
+  }
+#endif
 
   ~multiset()
   {
@@ -1174,6 +1185,14 @@ public:
   set() : _size(0), rule(Compare())
   {
   }
+
+#if __cplusplus >= 201103L
+  set(std::initializer_list<value_type> init) : _size(0), rule(Compare())
+  {
+    for (const value_type *it = init.begin(); it != init.end(); ++it)
+      this->insert(*it);
+  }
+#endif
 
   ~set()
   {


### PR DESCRIPTION
`vector` and `map` already had one, so brace-initialising any other container was not a wrong answer but a hard stop:

```cpp
std::set<int> s{3, 1, 2};   // ERROR: PARSING ERROR -- no viable constructor
```

The same held for `deque`, `list`, `multiset` and `forward_list`. Add the missing constructors, guarded on `__cplusplus` like the two that exist.

Found by differentially testing the C++ models against clang++. The passing test flips from PARSING ERROR to SUCCESSFUL against a control binary, clang++ agrees with both tests, and a 450-test differential over the C++ suites shows no other change.