### PR TITLE
[om] Clamp substr and erase counts instead of asserting they fit

### DIFF
--- a/regression/esbmc-cpp/string/substr_erase_positions/main.cpp
+++ b/regression/esbmc-cpp/string/substr_erase_positions/main.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+#include <string>
+int main() {
+  std::string s = "hello";
+  assert(s.substr(1,3)=="ell");
+  assert(s.substr(1)=="ello");
+  assert(s.substr(1,std::string::npos)=="ello");
+  assert(s.substr(1,100)=="ello");
+  assert(s.substr(5).empty());
+  assert(s.substr(0)==s);
+
+  std::string a = "abcd"; a.erase(2);
+  assert(a=="ab");
+  std::string b = "abcd"; b.erase(1,2);
+  assert(b=="ad");
+  std::string c = "abcd"; c.erase(0);
+  assert(c.empty());
+  std::string e = "abcd"; e.erase(4);
+  assert(e=="abcd");
+  std::string g = "abcd"; g.erase(1,100);
+  assert(g=="a");
+  return 0;
+}

--- a/regression/esbmc-cpp/string/substr_erase_positions/test.desc
+++ b/regression/esbmc-cpp/string/substr_erase_positions/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/substr_erase_positions_fail/main.cpp
+++ b/regression/esbmc-cpp/string/substr_erase_positions_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s = "hello";
+
+  // substr clamps the count to size() - pos, so this yields "ello", not the
+  // five characters the assertion claims.
+  assert(s.substr(1, 100).size() == 5);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/substr_erase_positions_fail/test.desc
+++ b/regression/esbmc-cpp/string/substr_erase_positions_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -733,9 +733,8 @@ public:
     size_t pos = 0) const;
   size_t find_first_not_of(const char *s, size_t pos = 0) const;
   size_t find_first_not_of(char c, size_t pos = 0) const;
-  basic_string<CharT, Traits, Alloc> &erase(size_t pos, size_t n);
+  basic_string<CharT, Traits, Alloc> &erase(size_t pos = 0, size_t n = npos);
   basic_string<CharT, Traits, Alloc> &erase(size_t pos, size_t n, char *tmp);
-  basic_string<CharT, Traits, Alloc> &erase(size_t pos = 0);
   basic_string<CharT, Traits, Alloc> &erase(iterator it)
   {
     __ESBMC_assert(it.pos >= 0, "The parameter must be greater than zero");
@@ -1082,37 +1081,21 @@ public:
   size_t copy(char *s, size_t n, size_t pos = 0) const;
   const char *data() const;
 
-  basic_string<CharT, Traits, Alloc> substr(size_t pos, size_t n) const
+  /* [string.substr]: pos == size() is in range and yields the empty string;
+   * the count is min(n, size() - pos), so n is clamped rather than required
+   * to fit -- npos, the default, means "to the end". */
+  basic_string<CharT, Traits, Alloc>
+  substr(size_t pos = 0, size_t n = npos) const
   {
   __ESBMC_HIDE:
-    __ESBMC_assert(pos >= 0, "The first parameter must be greater than zero");
-    __ESBMC_assert(n >= 0, "The second parameter must be greater than zero");
-    int len = this->length();
-    __ESBMC_assert((pos < len) && ((pos + n) <= len), "basic_string overflow");
-    int i, k;
-    int lenOne = n + 1;
+    size_t len = this->length();
+    __ESBMC_assert(pos <= len, "basic_string::substr position out of range");
+    size_t rlen = n < (len - pos) ? n : (len - pos);
+    size_t k;
     char one[STRING_CAPACITY];
-    for (k = 0, i = pos; i < (pos + n); k++, i++)
+    for (k = 0; k < rlen; k++)
     {
-      one[k] = this->str[i];
-    }
-    one[k] = '\0';
-    basic_string<CharT, Traits, Alloc> tmp(one);
-    return tmp;
-  }
-
-  basic_string<CharT, Traits, Alloc> substr(size_t pos) const
-  {
-  __ESBMC_HIDE:
-    __ESBMC_assert(pos >= 0, "The first parameter must be greater than zero");
-    int i, k;
-    int len = this->length();
-    __ESBMC_assert(pos < len, "basic_string overflow");
-    int lenOne = len + 1;
-    char one[STRING_CAPACITY];
-    for (k = 0, i = pos; i < len; k++, i++)
-    {
-      one[k] = this->str[i];
+      one[k] = this->str[pos + k];
     }
     one[k] = '\0';
     basic_string<CharT, Traits, Alloc> tmp(one);
@@ -2410,67 +2393,18 @@ basic_string<CharT, Traits, Alloc> &
 basic_string<CharT, Traits, Alloc>::erase(size_t pos, size_t n)
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(
-    (pos < this->length()) && ((pos + n) <= this->length()), "overflow");
-  int i, k, len = this->length();
-  int lenOne = pos + 1;
-  char one[STRING_CAPACITY];
-  for (i = 0; i < pos; i++)
+  /* [string.erase]: out_of_range only if pos > size(); the count removed is
+   * min(n, size() - pos), so npos -- the default -- erases to the end. */
+  size_t len = this->length();
+  __ESBMC_assert(pos <= len, "basic_string::erase position out of range");
+  size_t xlen = n < (len - pos) ? n : (len - pos);
+  size_t i;
+  for (i = pos; i + xlen < len; i++)
   {
-    one[i] = this->str[i];
-  }
-  int lenTwo = (len - (pos + n)) + 1;
-  char two[STRING_CAPACITY];
-  for (k = 0, i = pos + n; i < len; i++, k++)
-  {
-    two[k] = this->str[i];
-  }
-  int totalLen = len - n;
-  this->_size = totalLen;
-  for (i = 0; i < lenOne - 1; i++)
-  {
-    this->str[i] = one[i];
-  }
-  for (k = 0; k < lenTwo - 1; k++, i++)
-  {
-    this->str[i] = two[k];
+    this->str[i] = this->str[i + xlen];
   }
   this->str[i] = '\0';
-  return *this;
-}
-
-template <typename CharT, typename Traits, typename Alloc>
-basic_string<CharT, Traits, Alloc> &
-basic_string<CharT, Traits, Alloc>::erase(size_t pos)
-{
-__ESBMC_HIDE:
-  int n = this->length() - 1;
-  __ESBMC_assert(
-    (pos < this->length()) && ((pos + n) <= this->length()), "overflow");
-  int i, k, len = this->length();
-  int lenOne = pos + 1;
-  char one[STRING_CAPACITY];
-  for (i = 0; i < pos; i++)
-  {
-    one[i] = this->str[i];
-  }
-  int lenTwo = (len - (pos + n)) + 1;
-  char two[STRING_CAPACITY];
-  for (k = 0, i = pos + n; i < len; i++, k++)
-  {
-    two[k] = this->str[i];
-  }
-  int totalLen = len - n;
-  this->_size = totalLen;
-  for (i = 0; i < lenOne - 1; i++)
-  {
-    this->str[i] = one[i];
-  }
-  for (k = 0; k < lenTwo - 1; k++, i++)
-  {
-    this->str[i] = two[k];
-  }
-  this->str[i] = '\0';
+  this->_size = len - xlen;
   return *this;
 }
 


### PR DESCRIPTION
Both treated `pos == size()` as out of range and required `pos + n <= size()`, but [string.substr] and [string.erase] admit `pos == size()` and act on only `min(n, size() - pos)` characters — `npos`, the default, means "to the end":

```cpp
std::string s = "hello";
s.substr(1, std::string::npos);   // overflow assertion, not "ello"
std::string a = "abcd"; a.erase(2);   // overflow assertion, not "ab"
```

`erase(pos)` also computed its count as `length() - 1` rather than `length() - pos`, so it asked to remove more characters than remained. Each pair of overloads folds into one defaulted definition, which is also the signature the standard gives.

Found by differentially testing the C++ models against clang++. The 11 assertions in the new test all hold under clang++ and all failed before; a 260-test differential over the C++ suites shows no other change.