### PR TITLE
[om] Return the straddling element from map's bound scans, not end()

### DIFF
--- a/regression/esbmc-cpp/cpp/map_bound_miss/main.cpp
+++ b/regression/esbmc-cpp/cpp/map_bound_miss/main.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+#include <map>
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  m[3] = 30;
+  m[5] = 50;
+
+  // Miss: the first key not less than / greater than the argument.
+  assert(m.lower_bound(2)->first == 3);
+  assert(m.upper_bound(2)->first == 3);
+  assert(m.lower_bound(0)->first == 1);
+  assert(m.upper_bound(0)->first == 1);
+
+  // Hit: lower_bound stops on the key, upper_bound steps past it.
+  assert(m.lower_bound(3)->first == 3);
+  assert(m.upper_bound(3)->first == 5);
+
+  // Past the last key.
+  assert(m.lower_bound(9) == m.end());
+  assert(m.upper_bound(9) == m.end());
+
+  assert(m.lower_bound(2)->second == 30);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/map_bound_miss/test.desc
+++ b/regression/esbmc-cpp/cpp/map_bound_miss/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/map_bound_miss_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/map_bound_miss_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+#include <map>
+
+int main()
+{
+  std::map<int, int> m;
+  m[1] = 10;
+  m[3] = 30;
+
+  // lower_bound(2) is the element with key 3, not the end of the map.
+  assert(m.lower_bound(2) == m.end());
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/map_bound_miss_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/map_bound_miss_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -1136,7 +1136,9 @@ public:
         }
         if (key_compare()((Key &)x, this->_key[i]))
         {
-          return this->end();
+          /* First key greater than x: for both bounds that key is the
+           * answer, not the end of the map ([map.ops]). */
+          return it;
         }
         it++;
       }
@@ -1163,7 +1165,9 @@ public:
         }
         if (key_compare()((Key &)x, this->_key[i]))
         {
-          return this->end();
+          /* First key greater than x: for both bounds that key is the
+           * answer, not the end of the map ([map.ops]). */
+          return it;
         }
         it++;
       }
@@ -2136,7 +2140,9 @@ public:
         }
         if (key_compare()((Key &)x, this->_key[i]))
         {
-          return this->end();
+          /* First key greater than x: for both bounds that key is the
+           * answer, not the end of the map ([map.ops]). */
+          return it;
         }
         it++;
       }
@@ -2162,7 +2168,9 @@ public:
         }
         if (key_compare()((Key &)x, this->_key[i]))
         {
-          return this->end();
+          /* First key greater than x: for both bounds that key is the
+           * answer, not the end of the map ([map.ops]). */
+          return it;
         }
         it++;
       }


### PR DESCRIPTION
`lower_bound` and `upper_bound` walk the keys in order and stop at the first one greater than the argument — and then returned `end()`. That key is precisely what [map.ops] asks for:

```cpp
std::map<int,int> m; m[1]=10; m[3]=30;
m.lower_bound(2);   // reported end(), should be the element at key 3
m.upper_bound(2);   // likewise
```

Only an exact hit was found; every miss looked like "no such key". All four scans carried the same line (`map` and `multimap`, both bounds). `set` already got this right, so it is untouched.

Found by differentially testing the C++ models against clang++. The 10 assertions in the new test all hold under clang++ and all failed before; a 280-test differential over the C++ suites shows no other change.