### PR TITLE
[regression] Pin the schedule-space size a reduction is expected to cut

### DIFF
--- a/regression/esbmc-unix/interleaving_count_no_por/main.c
+++ b/regression/esbmc-unix/interleaving_count_no_por/main.c
@@ -1,0 +1,32 @@
+#include <pthread.h>
+
+/* Two threads whose accesses to x and y conflict in both directions, so the
+ * schedule space is large enough for the partial-order reduction to matter,
+ * and small enough to enumerate in about a second.
+ *
+ * main returns without joining, so interleavings are still generated after
+ * its thread has ended -- the case #4584 was about. */
+
+static int x, y;
+
+static void *ta(void *arg)
+{
+  x = 1;
+  y = x + 1;
+  return 0;
+}
+
+static void *tb(void *arg)
+{
+  y = 2;
+  x = y + 1;
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_create(&a, 0, ta, 0);
+  pthread_create(&b, 0, tb, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/interleaving_count_no_por/test.desc
+++ b/regression/esbmc-unix/interleaving_count_no_por/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 3 --context-bound 3 --all-runs --no-por
+^Number of generated interleavings: 57$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/interleaving_count_por/main.c
+++ b/regression/esbmc-unix/interleaving_count_por/main.c
@@ -1,0 +1,32 @@
+#include <pthread.h>
+
+/* Two threads whose accesses to x and y conflict in both directions, so the
+ * schedule space is large enough for the partial-order reduction to matter,
+ * and small enough to enumerate in about a second.
+ *
+ * main returns without joining, so interleavings are still generated after
+ * its thread has ended -- the case #4584 was about. */
+
+static int x, y;
+
+static void *ta(void *arg)
+{
+  x = 1;
+  y = x + 1;
+  return 0;
+}
+
+static void *tb(void *arg)
+{
+  y = 2;
+  x = y + 1;
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_create(&a, 0, ta, 0);
+  pthread_create(&b, 0, tb, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/interleaving_count_por/test.desc
+++ b/regression/esbmc-unix/interleaving_count_por/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 3 --context-bound 3 --all-runs
+^Number of generated interleavings: 38$
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Groundwork for #6831.

#6607 restored interleaving generation after main's thread ends. That is a soundness fix and must stay, but it multiplied the schedule space: 240 `pthread-wmm` tasks that answered in a median of **1.7s** now exceed the 100s limit, and 287 of the 291 lost concurrency tasks are `true`, so they need the exhaustive search to get cheaper rather than to stop early.

Nothing in the suite measures schedule-space size, so a change of that kind stays invisible until a competition run days later. These two tests pin the interleaving count on a two-thread program small enough to enumerate in about a second, once with the reduction and once with `--no-por` (38 vs 57), so both the absolute size and the reduction's share of it are ratcheted.

Deterministic across repeated runs, ~0.9s each. Each was mutation-checked: swapping the reduction setting while leaving the expected count alone makes the test fail, so neither is green-only.

This measures the mechanism; it is not a reproducer of #6607 itself — that shape needs a larger program than belongs in the fast suite.