### PR TITLE
[om] Place the nth element where nth_element promises to put it

### DIFF
--- a/regression/esbmc-cpp/algorithm/nth_element_postcondition/main.cpp
+++ b/regression/esbmc-cpp/algorithm/nth_element_postcondition/main.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+#include <vector>
+#include <algorithm>
+
+int main()
+{
+  std::vector<int> v{3, 1, 2};
+  std::nth_element(v.begin(), v.begin() + 1, v.end());
+  // Sorted order is {1,2,3}, so the middle element must be 2.
+  assert(v[1] == 2);
+  // Everything before nth compares no greater; everything after, no less.
+  assert(!(v[1] < v[0]));
+  assert(!(v[2] < v[1]));
+
+  std::vector<int> w{5, 4, 3, 2, 1};
+  std::nth_element(w.begin(), w.begin() + 2, w.end());
+  assert(w[2] == 3);
+
+  std::vector<int> d{1, 3, 2};
+  std::nth_element(d.begin(), d.begin() + 1, d.end(),
+                   [](int a, int b) { return a > b; });
+  assert(d[1] == 2);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/algorithm/nth_element_postcondition/test.desc
+++ b/regression/esbmc-cpp/algorithm/nth_element_postcondition/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/nth_element_postcondition_fail/main.cpp
+++ b/regression/esbmc-cpp/algorithm/nth_element_postcondition_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+#include <vector>
+#include <algorithm>
+
+int main()
+{
+  std::vector<int> v{3, 1, 2};
+  std::nth_element(v.begin(), v.begin() + 1, v.end());
+
+  // The middle element of {1,2,3} is 2, not 3.
+  assert(v[1] == 3);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/algorithm/nth_element_postcondition_fail/test.desc
+++ b/regression/esbmc-cpp/algorithm/nth_element_postcondition_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -1318,52 +1318,25 @@ RanIt partial_sort_copy(
   return pilgrim2;
 }
 
+/* [alg.nth.element]: the element at nth ends up where it would be if the
+ * range were sorted, and nothing before nth compares greater than it.
+ * Sorting the whole range establishes that. It also fixes one of the
+ * permutations the standard leaves unspecified, so a program reading the
+ * order of the *other* elements sees more than it is entitled to. */
 template <class RanIt>
 void nth_element(RanIt first, RanIt nth, RanIt last)
 {
-  RanIt pilgrim, pos;
-  swap(*first, *nth);
-  nth = first;
-  for (pilgrim = first + 1; pilgrim < last; pilgrim++)
-  {
-    if (*pilgrim < *nth)
-    {
-      swap(*pilgrim, *nth);
-      nth = pilgrim;
-      while (nth != first)
-      {
-        pos = nth - 1;
-        if (!(*nth < *pos))
-          break;
-        swap(*nth, *pos);
-        nth = pos;
-      }
-    }
-  }
+  if (nth == last)
+    return;
+  sort(first, last);
 }
 
 template <class RanIt, class Pr>
 void nth_element(RanIt first, RanIt nth, RanIt last, Pr pred)
 {
-  RanIt pilgrim, pos;
-  swap(*first, *nth);
-  nth = first;
-  for (pilgrim = first + 1; pilgrim < last; pilgrim++)
-  {
-    if (pred(*pilgrim, *nth))
-    {
-      swap(*pilgrim, *nth);
-      nth = pilgrim;
-      while (nth != first)
-      {
-        pos = nth - 1;
-        if (!pred(*nth, *pos))
-          break;
-        swap(*nth, *pos);
-        nth = pos;
-      }
-    }
-  }
+  if (nth == last)
+    return;
+  sort(first, last, pred);
 }
 
 template <class FwdIt, class Ty>


### PR DESCRIPTION
`nth` is a by-value parameter, and the model reassigned it to `first` right after the initial swap — so the caller's target position was discarded and the partial sort that followed ran against the wrong pivot:

```cpp
std::vector<int> v{3,1,2};
std::nth_element(v.begin(), v.begin()+1, v.end());
assert(v[1] == 2);   // left 3 in the middle
```

Sorting the range establishes [alg.nth.element]'s postcondition directly — the element at `nth` is the one sorted order puts there, and the range is partitioned around it. That also fixes one of the permutations the standard leaves unspecified, which is noted in a comment: a program reading the order of the *other* elements sees more than it is entitled to. The previous model was equally deterministic and simply wrong.

Found by differentially testing the C++ models against clang++. All assertions in the new test hold under clang++ and failed before; a 300-test differential over the C++ suites shows no other change.