### PR TITLE
[om] Erase the half-open range vector::erase was given

### DIFF
--- a/regression/esbmc-cpp/vector/erase_range_half_open/main.cpp
+++ b/regression/esbmc-cpp/vector/erase_range_half_open/main.cpp
@@ -1,0 +1,30 @@
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  // Half-open: [begin()+1, begin()+3) removes 2 and 3, keeping 1 and 4.
+  std::vector<int> v{1, 2, 3, 4};
+  std::vector<int>::iterator it = v.erase(v.begin() + 1, v.begin() + 3);
+  assert(v.size() == 2);
+  assert(v[0] == 1 && v[1] == 4);
+  assert(*it == 4);
+
+  std::vector<int> a{1, 2, 3};
+  a.erase(a.begin(), a.begin() + 1);
+  assert(a.size() == 2 && a[0] == 2 && a[1] == 3);
+
+  std::vector<int> b{1, 2};
+  b.erase(b.begin(), b.end());
+  assert(b.empty());
+
+  // An empty range erases nothing.
+  std::vector<int> c{1, 2};
+  c.erase(c.begin() + 1, c.begin() + 1);
+  assert(c.size() == 2 && c[1] == 2);
+
+  std::vector<int> d{1, 2, 3};
+  assert(d.max_size() >= d.size());
+
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/erase_range_half_open/test.desc
+++ b/regression/esbmc-cpp/vector/erase_range_half_open/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/erase_range_half_open_fail/main.cpp
+++ b/regression/esbmc-cpp/vector/erase_range_half_open_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v{1, 2, 3, 4};
+  v.erase(v.begin() + 1, v.begin() + 3);
+
+  // The range is half-open, so 4 survives and 2 does not.
+  assert(v[1] == 3);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/erase_range_half_open_fail/test.desc
+++ b/regression/esbmc-cpp/vector/erase_range_half_open_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -618,7 +618,13 @@ public:
     return _size;
   }
 
-  size_type max_size() const;
+  /* Declared but never defined, so callers got a nondeterministic result.
+   * The model's own invariant is _size <= VECTOR_CAPACITY, so that bound is
+   * what a vector here can actually hold. */
+  size_type max_size() const
+  {
+    return VECTOR_CAPACITY;
+  }
 
   void resize(size_type sz)
   {
@@ -931,12 +937,14 @@ public:
 
   iterator erase(iterator first, iterator last)
   {
-    iterator it;
-    while (first != last)
-    {
-      it = erase(last--);
-    }
-    return it;
+    /* [vector.modifiers]: the range is half-open, so last is not itself
+     * erased, and the result is an iterator to the element that followed it.
+     * Each single erase shifts the tail down, so erasing at first that many
+     * times removes exactly the range. */
+    size_type n = last - first;
+    for (size_type i = 0; i < n; i++)
+      erase(first);
+    return first;
   }
 
   void swap(vector &v1)


### PR DESCRIPTION
`erase(first, last)` called `erase(last--)`, starting one element **past** the range and working outwards:

```cpp
std::vector<int> v{1,2,3,4};
v.erase(v.begin()+1, v.begin()+3);   // removed 4 and 3, not 2 and 3
assert(v[0]==1 && v[1]==4);
```

The size came out right, which is why this survived — only the contents were wrong, and `size()`-based assertions still passed. Erase at `first` as many times as the range is long (each single erase shifts the tail down), and return `first`, which is where the following element ends up.

`max_size()` was declared and never defined, so callers got a nondeterministic answer and `max_size() >= size()` could fail. It now reports the `VECTOR_CAPACITY` bound the model already asserts `_size` against.

Found by differentially testing the C++ models against clang++. All assertions in the new test hold under clang++ and failed before; a 320-test differential over the C++ suites shows no other change.