### PR TITLE
[om] Order vectors lexicographically rather than by size

### DIFF
--- a/regression/esbmc-cpp/vector/relational_lexicographic/main.cpp
+++ b/regression/esbmc-cpp/vector/relational_lexicographic/main.cpp
@@ -1,0 +1,37 @@
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  // The first differing element decides, whatever the lengths.
+  std::vector<int> a{2}, b{1, 3};
+  assert(a > b);
+  assert(a >= b);
+  assert(!(a < b));
+  assert(!(a <= b));
+
+  // A prefix is less than the range that extends it.
+  std::vector<int> p{1, 2}, q{1, 2, 3};
+  assert(p < q);
+  assert(p <= q);
+  assert(q > p);
+  assert(!(p > q));
+
+  // Equal ranges compare equal on both non-strict orderings.
+  std::vector<int> e{1, 2}, f{1, 2};
+  assert(e <= f);
+  assert(e >= f);
+  assert(!(e < f));
+  assert(!(e > f));
+
+  // Empty is less than anything non-empty.
+  std::vector<int> z, o{0};
+  assert(z < o);
+  assert(!(o < z));
+
+  std::vector<int> c{1, 2}, d{1, 3};
+  assert(c < d);
+  assert(d > c);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/relational_lexicographic/test.desc
+++ b/regression/esbmc-cpp/vector/relational_lexicographic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/relational_lexicographic_fail/main.cpp
+++ b/regression/esbmc-cpp/vector/relational_lexicographic_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> a{2}, b{1, 3};
+
+  // Ordering is lexicographic, not by size: 2 > 1 makes a the greater range
+  // even though it is the shorter one.
+  assert(a < b);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/relational_lexicographic_fail/test.desc
+++ b/regression/esbmc-cpp/vector/relational_lexicographic_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -973,14 +973,36 @@ public:
     return (!(*this == rhv));
   }
 
-  bool operator>=(const vector &rhv)
+  /* [container.requirements]: the ordering is the lexicographical comparison
+   * of the two ranges, so the first differing element decides it and the
+   * lengths matter only when one range is a prefix of the other. Comparing
+   * sizes instead made {2} < {1,3}. */
+  bool operator<(const vector &rhv) const
   {
-    return ((*this == rhv) || (this->size() > rhv.size()));
+    size_type n = this->size() < rhv.size() ? this->size() : rhv.size();
+    for (size_type i = 0; i < n; i++)
+    {
+      if ((*this)[i] < rhv[i])
+        return true;
+      if (rhv[i] < (*this)[i])
+        return false;
+    }
+    return this->size() < rhv.size();
   }
 
-  bool operator<=(const vector &rhv)
+  bool operator>(const vector &rhv) const
   {
-    return ((*this == rhv) || (this->size() < rhv.size()));
+    return rhv < *this;
+  }
+
+  bool operator>=(const vector &rhv) const
+  {
+    return !(*this < rhv);
+  }
+
+  bool operator<=(const vector &rhv) const
+  {
+    return !(rhv < *this);
   }
 
 private:


### PR DESCRIPTION
`operator<=` and `operator>=` decided on **size** once the ranges were unequal:

```cpp
bool operator>=(const vector &rhv)
{ return ((*this == rhv) || (this->size() > rhv.size())); }
```

so `{2} >= {1,3}` was false although `2 > 1` settles it at the first element. `operator<` and `operator>` were missing outright, making `a < b` a `PARSING ERROR`.

[container.requirements] defines the ordering as the lexicographical comparison of the two ranges — the first differing element decides, and the lengths matter only when one range is a prefix of the other. Implement that in `operator<` and derive the other three from it.

Found by differentially testing the C++ models against clang++. The 16 assertions in the new test all hold under clang++; a 300-test differential over the C++ suites shows no other change.

Touches the same file as #6846 but a different region — I test-merged that pair and both PRs' tests pass on the merged tree.