### PR TITLE
[om] Search from the position string::find was given

### DIFF
--- a/regression/esbmc-cpp/string/find_positions/main.cpp
+++ b/regression/esbmc-cpp/string/find_positions/main.cpp
@@ -1,0 +1,35 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s = "abcabc";
+
+  assert(s.find("abc") == 0);
+  assert(s.find("abc", 1) == 3);
+  assert(s.find("bc") == 1);
+  assert(s.find("zz") == std::string::npos);
+  assert(s.find('c') == 2);
+  assert(s.find('c', 3) == 5);
+  assert(s.find('z') == std::string::npos);
+
+  // An empty needle matches at pos whenever pos <= size().
+  assert(s.find("") == 0);
+  assert(s.find("", 2) == 2);
+  assert(s.find("", s.size()) == s.size());
+
+  // A start position past the end finds nothing; it is not an error.
+  assert(s.find("a", 99) == std::string::npos);
+  assert(s.find('a', 99) == std::string::npos);
+  assert(s.find("", 99) == std::string::npos);
+
+  // A needle longer than what remains cannot match.
+  assert(s.find("abcabcabc") == std::string::npos);
+  assert(s.find("abc", 5) == std::string::npos);
+
+  std::string t = "abc";
+  assert(s.find(t) == 0);
+  assert(s.find("abcXX", 0, 3) == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/find_positions/test.desc
+++ b/regression/esbmc-cpp/string/find_positions/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/find_positions_fail/main.cpp
+++ b/regression/esbmc-cpp/string/find_positions_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s = "abc";
+
+  // An empty needle matches at position 0, so this is not npos.
+  assert(s.find("") == std::string::npos);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/find_positions_fail/test.desc
+++ b/regression/esbmc-cpp/string/find_positions_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2039,17 +2039,36 @@ __ESBMC_HIDE:
   return *this;
 }
 
+/* [string.find]: the lowest xpos with pos <= xpos and xpos + nlen <= hlen at
+ * which the needle matches. An empty needle therefore matches at pos whenever
+ * pos <= hlen, and a pos past the end simply finds nothing -- neither is an
+ * error, which is why no assertion guards them. */
+static size_t __esbmc_string_find(
+  const char *hay,
+  size_t hlen,
+  const char *needle,
+  size_t nlen,
+  size_t pos)
+{
+__ESBMC_HIDE:
+  if (pos > hlen || nlen > hlen - pos)
+    return (size_t)-1;
+  for (size_t xpos = pos; xpos + nlen <= hlen; xpos++)
+  {
+    size_t i = 0;
+    while (i < nlen && hay[xpos + i] == needle[i])
+      i++;
+    if (i == nlen)
+      return xpos;
+  }
+  return (size_t)-1;
+}
+
 template <typename CharT, typename Traits, typename Alloc>
 size_t basic_string<CharT, Traits, Alloc>::find(char c, size_t pos) const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(pos < this->length(), "basic_string overflow");
-
-  for (size_t i = pos; i < this->length(); i++)
-    if (this->str[i] == c)
-      return i; // Return the index if character found
-
-  return npos; // Return npos if character not found
+  return __esbmc_string_find(this->str, this->length(), &c, 1, pos);
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -2058,41 +2077,9 @@ size_t basic_string<CharT, Traits, Alloc>::find(
   size_t pos) const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert((pos >= 0) && (pos < this->length()), "basic_string overflow");
   __ESBMC_assert(s.str != NULL, "The parameter must be different than NULL");
-  int len = this->length();
-  int lim = pos;
-  char s1[STRING_CAPACITY];
-  strcpy(s1, this->str);
-  int slen = s.length();
-  char s2[STRING_CAPACITY];
-  strcpy(s2, s.str);
-  pos = -1;
-  size_t i, j;
-
-  for (i = lim; i < len; i++)
-  {
-    for (j = 0; (j < slen) && ((i + j) < len); j++)
-    {
-      if (s1[i + j] != s2[j])
-      {
-        break;
-      }
-      else
-      {
-        if (pos == -1)
-        {
-          pos = i + j;
-        }
-      }
-    }
-    if (s2[j] == '\0')
-    {
-      return pos;
-    }
-  }
-
-  return -1;
+  return __esbmc_string_find(
+    this->str, this->length(), s.str, s.length(), pos);
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -2101,92 +2088,16 @@ basic_string<CharT, Traits, Alloc>::find(const char *s, size_t pos, size_t n)
   const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(
-    (pos >= 0) && (pos < this->length()) && ((pos + n) < this->length()) &&
-      (n > 0),
-    "basic_string overflow");
   __ESBMC_assert(s != NULL, "The parameter must be different than NULL");
-  size_t i, j;
-
-  int len = this->length();
-  int lim = pos;
-  char s1[STRING_CAPACITY];
-  strcpy(s1, this->str);
-
-  int slen = n;
-  char s2[STRING_CAPACITY];
-  for (i = 0; i < slen; i++)
-  {
-    s2[i] = s[i];
-  }
-  s2[i] = '\0';
-
-  pos = -1;
-
-  for (i = lim; i < len; i++)
-  {
-    for (j = 0; (j < slen) && ((i + j) < len); j++)
-    {
-      if (s1[i + j] != s2[j])
-      {
-        break;
-      }
-      else
-      {
-        if (pos == -1)
-        {
-          pos = i + j;
-        }
-      }
-    }
-    if (s2[j] == '\0')
-    {
-      return pos;
-    }
-  }
-
-  return -1;
+  return __esbmc_string_find(this->str, this->length(), s, n, pos);
 }
 
 template <typename CharT, typename Traits, typename Alloc>
 size_t basic_string<CharT, Traits, Alloc>::find(const char *s, size_t pos) const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert((pos >= 0) && (pos < this->length()), "basic_string overflow");
   __ESBMC_assert(s != NULL, "The parameter must be different than NULL");
-  int len = this->length();
-  int lim = pos;
-  char s1[STRING_CAPACITY];
-  strcpy(s1, this->str);
-  int slen = strlen(s);
-  char s2[STRING_CAPACITY];
-  strcpy(s2, s);
-  pos = -1;
-  size_t i, j;
-
-  for (i = lim; i < len; i++)
-  {
-    for (j = 0; (j < slen) && ((i + j) < len); j++)
-    {
-      if (s1[i + j] != s2[j])
-      {
-        break;
-      }
-      else
-      {
-        if (pos == -1)
-        {
-          pos = i + j;
-        }
-      }
-    }
-    if (s2[j] == '\0')
-    {
-      return pos;
-    }
-  }
-
-  return -1;
+  return __esbmc_string_find(this->str, this->length(), s, strlen(s), pos);
 }
 
 template <typename CharT, typename Traits, typename Alloc>


### PR DESCRIPTION
All four `find()` overloads asserted `pos < length()`, so searching from the end of a string was an *error* rather than a miss. The match loop also only recorded a position after comparing a character, so an empty needle — which compares none — returned npos:

```cpp
std::string s = "abc";
s.find("");        // npos, should be 0
s.find("", 2);     // npos, should be 2
s.find("a", 99);   // overflow assertion, should be npos
```

The counted overload additionally required `pos + n < length()`, rejecting a needle that ends exactly at the end of the string.

[string.find] asks for the lowest `xpos` with `pos <= xpos` and `xpos + n <= size()` at which the needle matches, and rejects no position outright. Every overload now routes through one helper that computes exactly that.

Found by differentially testing the C++ models against clang++. All 18 assertions in the new test hold under clang++ and failed before; a 320-test differential over the C++ suites shows no other change.

Touches `src/cpp/library/string` like #6837 and #6840, but a different region — those two are already verified to merge cleanly with each other.