### PR TITLE
[util] Report a bad command line instead of a mangled type name

### DIFF
--- a/regression/esbmc/cmdline_repeated_option_fail/main.c
+++ b/regression/esbmc/cmdline_repeated_option_fail/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/esbmc/cmdline_repeated_option_fail/test.desc
+++ b/regression/esbmc/cmdline_repeated_option_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 2 --unwind 2
+Invalid command line: option .--unwind. cannot be specified more than once

--- a/regression/esbmc/github_5189_bad_option_value/test.desc
+++ b/regression/esbmc/github_5189_bad_option_value/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --unwind abc
-^ERROR: (uncaught exception \[|the argument )
+^ERROR: Invalid command line: the argument .+for option .--unwind. is invalid

--- a/src/util/config/cmdline.cpp
+++ b/src/util/config/cmdline.cpp
@@ -327,21 +327,22 @@ bool cmdlinet::parse(
         .run(),
       vm);
   }
-  catch (std::exception &e)
-  {
-    log_error("{}", e.what());
-    return true;
-  }
   // Boost throws program_options errors as boost::wrapexcept<...>, whose
   // typeinfo does not match this translation unit's std::exception across the
-  // library boundary, so the catch above misses them: they escaped to main's
-  // catch(...), and repeating any option (`--unwind 2 --unwind 2`) reached the
-  // user as a mangled boost::wrapexcept type name and nothing else. Catch the
-  // boost type directly, which keeps what() -- it names the offending option --
-  // and keep a catch-all behind it in case that match fails too.
+  // library boundary, so a catch(std::exception&) misses them: they escaped to
+  // main's catch(...), and repeating any option (`--unwind 2 --unwind 2`)
+  // reached the user as a mangled boost::wrapexcept type name and nothing
+  // else. Catching the boost type keeps what(), which names the offending
+  // option. It derives from std::exception, so it has to precede the handler
+  // below -- behind it the compiler reports it as already caught.
   catch (const boost::program_options::error &e)
   {
     log_error("Invalid command line: {}", e.what());
+    return true;
+  }
+  catch (std::exception &e)
+  {
+    log_error("{}", e.what());
     return true;
   }
   catch (...)

--- a/src/util/config/cmdline.cpp
+++ b/src/util/config/cmdline.cpp
@@ -332,6 +332,23 @@ bool cmdlinet::parse(
     log_error("{}", e.what());
     return true;
   }
+  // Boost throws program_options errors as boost::wrapexcept<...>, whose
+  // typeinfo does not match this translation unit's std::exception across the
+  // library boundary, so the catch above misses them: they escaped to main's
+  // catch(...), and repeating any option (`--unwind 2 --unwind 2`) reached the
+  // user as a mangled boost::wrapexcept type name and nothing else. Catch the
+  // boost type directly, which keeps what() -- it names the offending option --
+  // and keep a catch-all behind it in case that match fails too.
+  catch (const boost::program_options::error &e)
+  {
+    log_error("Invalid command line: {}", e.what());
+    return true;
+  }
+  catch (...)
+  {
+    log_error("Invalid command line");
+    return true;
+  }
 
   if (vm.count("input-file"))
     args = vm["input-file"].as<std::vector<std::string>>();


### PR DESCRIPTION
Boost throws `program_options` errors as `boost::wrapexcept<...>`, whose typeinfo
does not match `cmdline.cpp`'s `std::exception` across the library boundary, so
the existing catch missed them and they escaped to `main`'s `catch(...)`.
Repeating any option — `esbmc x.c --unwind 2 --unwind 2` — reached the user as a
mangled `boost::wrapexcept` type name and nothing else, with exit code 70.

Catching the boost type directly keeps `what()`, which names the offending
option, and a catch-all sits behind it. Exit code is now 64 (`EX_USAGE`).
`github_5189_bad_option_value`'s regex is updated to the improved message; it
still pins that nothing escapes.
