### PR TITLE
[jimple] Set the method body through symbolt's IREP2 value setter

### DIFF
--- a/src/jimple-frontend/AST/jimple_method.cpp
+++ b/src/jimple-frontend/AST/jimple_method.cpp
@@ -89,7 +89,7 @@ exprt jimple_method::to_exprt(
     method_type.make_ellipsis();
 
   added_symbol.set_type(method_type);
-  added_symbol.set_value(body->to_exprt(ctx, class_name, this->name));
+  added_symbol.set_value(body->to_code2t(ctx, class_name, this->name));
 
   return dummy;
 }

--- a/src/jimple-frontend/AST/jimple_method_body.h
+++ b/src/jimple-frontend/AST/jimple_method_body.h
@@ -2,6 +2,7 @@
 #define ESBMC_JIMPLE_METHOD_BODY_H
 
 #include <jimple-frontend/AST/jimple_ast.h>
+#include <util/irep/migrate.h>
 #include <util/irep/std_code.h>
 
 /**
@@ -17,6 +18,24 @@ public:
   {
     exprt dummy;
     return dummy;
+  }
+
+  /**
+   * @brief The IREP2 form of the body, for symbolt::set_value(const expr2tc &).
+   *
+   * K.1 of docs/roadmap/scope-jimple-irep2.md. The default migrates whatever
+   * to_exprt built, so a subclass that has not been converted yet keeps
+   * working; each override that lands removes one migration rather than adding
+   * one, which is why this migration runs from the seam downwards.
+   */
+  virtual expr2tc to_code2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name) const
+  {
+    expr2tc body;
+    migrate_expr(to_exprt(ctx, class_name, function_name), body);
+    return body;
   }
 };
 


### PR DESCRIPTION
First code step of Phase 5 (jimple → IREP2), K.1 of
`docs/roadmap/scope-jimple-irep2.md`.

`symbolt` already carries `set_value(const expr2tc &)` beside the legacy setter,
and jimple reaches that seam at exactly one line, so the method body can be
handed over as `expr2tc`. `to_code2t`'s default migrates whatever `to_exprt`
built, so every unconverted subclass keeps working and the one remaining
round-trip sits in a default that shrinks as statements and expressions convert —
rather than at each call site, which is what made a bottom-up first slice add
round-trips instead of removing them.

GOTO output is byte-identical across all 17 jimple tests, checked before and
after. Refs #4715.
