### PR TITLE
[goto-symex] Report how the exploration spent its schedules

### DIFF
--- a/regression/esbmc-unix/schedule_prune_counters/main.c
+++ b/regression/esbmc-unix/schedule_prune_counters/main.c
@@ -1,0 +1,29 @@
+#include <pthread.h>
+
+/* Two threads whose accesses to x and y conflict in both directions, so the
+ * reduction has something to prune and the counters have something to report.
+ * main returns without joining, so schedules continue past its thread ending. */
+
+static int x, y;
+
+static void *ta(void *arg)
+{
+  x = 1;
+  y = x + 1;
+  return 0;
+}
+
+static void *tb(void *arg)
+{
+  y = 2;
+  x = y + 1;
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_create(&a, 0, ta, 0);
+  pthread_create(&b, 0, tb, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/schedule_prune_counters/test.desc
+++ b/regression/esbmc-unix/schedule_prune_counters/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 3 --context-bound 3
+^Schedules explored: 38 \(pruned by MPOR: 36, by state hashing: 0\)$
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1623,6 +1623,28 @@ void bmct::report_coverage_verbose(
   }
 }
 
+/* What the exploration spent its schedules on. Reading a reduction's
+ * contribution off a single run is what makes a prune rate measurable over a
+ * benchmark set, rather than by re-running with each knob toggled (#6831). */
+void bmct::report_schedule_stats()
+{
+  if (!symex)
+    return;
+
+  const auto &stats = symex->get_schedule_stats();
+
+  /* Silent on a program that never had a schedule to choose: one explored
+   * schedule and nothing pruned is just a sequential run. */
+  if (stats.explored <= 1 && !stats.pruned_by_mpor && !stats.pruned_by_hash)
+    return;
+
+  log_status(
+    "Schedules explored: {} (pruned by MPOR: {}, by state hashing: {})",
+    stats.explored,
+    stats.pruned_by_mpor,
+    stats.pruned_by_hash);
+}
+
 void bmct::report_result(smt_resultt &res)
 {
   // k-induction prints its own messages
@@ -1731,6 +1753,11 @@ void bmct::report_result(smt_resultt &res)
     log_status("Number of generated interleavings: {}", interleaving_number);
     log_status("Number of failed interleavings: {}", interleaving_failed);
   }
+
+  /* What the exploration spent its schedules on. Reading a reduction's
+   * contribution off a single run is what makes a prune rate measurable over a
+   * benchmark set, rather than by re-running with each knob toggled (#6831). */
+  report_schedule_stats();
 }
 
 smt_resultt bmct::start_bmc()

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -109,6 +109,10 @@ protected:
 
   virtual void report_result(smt_resultt &res);
 
+  /** Report how the exploration spent its schedules, for programs that had
+   *  more than one to choose from. */
+  void report_schedule_stats();
+
   virtual void
   bidirectional_search(smt_convt &smt_conv, const symex_target_equationt &eq);
 

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -769,6 +769,7 @@ goto_symext::symex_resultt reachability_treet::get_next_formula()
     {
       if (check_for_hash_collision())
       {
+        ++schedule_stats.pruned_by_hash;
         post_hash_collision_cleanup();
         break;
       }
@@ -784,6 +785,7 @@ goto_symext::symex_resultt reachability_treet::get_next_formula()
         // This transition is pruned by MPOR. If we already recorded its state
         // hash above, drop it again so the seen set reflects the state explored
         // before this transition rather than the pruned state.
+        ++schedule_stats.pruned_by_mpor;
         if (state_hashing)
           remove_hash_collision_entry();
         break;
@@ -811,6 +813,7 @@ goto_symext::symex_resultt reachability_treet::get_next_formula()
     cur_frame_it->state->add_memory_leak_checks();
 
   has_complete_formula = false;
+  ++schedule_stats.explored;
 
   return get_cur_state().get_symex_result();
 }

--- a/src/goto-symex/reachability_tree.h
+++ b/src/goto-symex/reachability_tree.h
@@ -286,6 +286,24 @@ public:
    *  rather than exhausted (issue #6480). */
   bool cs_bound_pruned;
 
+  /** How the exploration spent its schedules. Reported at the end of a run so
+   *  a reduction's contribution can be read off one verification instead of
+   *  re-running with each knob toggled (issue #6831). */
+  struct schedule_statisticst
+  {
+    unsigned long explored = 0;
+    unsigned long pruned_by_mpor = 0;
+    unsigned long pruned_by_hash = 0;
+  };
+  schedule_statisticst schedule_stats;
+
+public:
+  /** Read-only accessor for the schedule statistics, for run reporting. */
+  const schedule_statisticst &get_schedule_stats() const
+  {
+    return schedule_stats;
+  }
+
 protected:
   struct scheduler_framet
   {


### PR DESCRIPTION
Implements **W0** of the plan in #6844, which states it lands first because W1 and W2 are not assessable without it. Groundwork for #6831 cause 1.

Nothing today reports how many schedules a run explored or how many each reduction pruned, so measuring a reduction's contribution means re-running the whole verification with each knob toggled — which does not scale to a benchmark set.

```
Schedules explored: 940 (pruned by MPOR: 296, by state hashing: 0)
```

That single line reproduces the finding #6844 §2.1 needed four runs to establish: MPOR prunes, state hashing prunes nothing. Silent for programs that never had a schedule to choose, so sequential runs are unaffected.

No behaviour change — counters and one `log_status`.

- 663/663 unit tests pass (the gate my own #6809 failure showed is the one that matters for symex changes)
- the new test is mutation-checked: adding `--no-por` while leaving the expected counts alone makes it fail
- re-measured #6844 §2.1 on current master (`8ffb84b24d`, which includes #6793): 940 / 940 / 1171 / 1155 — within one of the plan's figures, so its numbers can be acted on as they stand