### PR TITLE
[jimple] Build a goto statement natively

### DIFF
--- a/src/jimple-frontend/AST/jimple_method.cpp
+++ b/src/jimple-frontend/AST/jimple_method.cpp
@@ -89,7 +89,7 @@ exprt jimple_method::to_exprt(
     method_type.make_ellipsis();
 
   added_symbol.set_type(method_type);
-  added_symbol.set_value(body->to_exprt(ctx, class_name, this->name));
+  added_symbol.set_value(body->to_code2t(ctx, class_name, this->name));
 
   return dummy;
 }

--- a/src/jimple-frontend/AST/jimple_method_body.cpp
+++ b/src/jimple-frontend/AST/jimple_method_body.cpp
@@ -1,9 +1,46 @@
 #include <jimple-frontend/AST/jimple_method_body.h>
+#include <irep2/irep2_expr.h>
 #include <jimple-frontend/AST/jimple_declaration.h>
 #include <jimple-frontend/AST/jimple_statement.h>
 #include <memory>
 #include <util/irep/std_code.h>
 #include <util/expr/expr_util.h>
+
+// The IREP2 twin of to_exprt below (K.2 of
+// docs/roadmap/scope-jimple-irep2.md). migrate_expr's block arm additionally
+// splices a child whose legacy statement is "decl-block"; this frontend never
+// builds one -- its statements are decl, assign, block, function_call, goto,
+// label, return and skip -- so there is nothing to reproduce here.
+expr2tc jimple_full_method_body::to_code2t(
+  contextt &ctx,
+  const std::string &class_name,
+  const std::string &function_name) const
+{
+  std::vector<expr2tc> ops;
+  ops.reserve(this->members.size());
+
+  for (auto const &stmt : this->members)
+  {
+    auto l = jimple_ast::get_location(class_name, function_name);
+    if (stmt->line_location != -1)
+      l.set_line(stmt->line_location);
+
+    ops.push_back(stmt->to_code2t(ctx, class_name, function_name, l));
+  }
+
+  // migrate_expr reads the legacy block's location through the *const*
+  // accessor, so an unlocated block migrates with a nil location, not the
+  // default-constructed empty one -- the nil-vs-empty distinction of #6176.
+  // A default here renders as a blank location where the round-trip renders
+  // "no location". This frontend never locates the block itself.
+  // Both locations must be nil, not default-constructed: migrate_expr reads
+  // them off the legacy block through the *const* accessors, so an unlocated
+  // block migrates nil where a default renders blank -- the nil-vs-empty
+  // distinction of #6176. end_location is the one that shows: goto_convert
+  // gives END_FUNCTION that location. This frontend locates neither.
+  const locationt &nil = static_cast<const locationt &>(get_nil_irep());
+  return code_block2tc(ops, nil, nil);
+}
 
 exprt jimple_full_method_body::to_exprt(
   contextt &ctx,

--- a/src/jimple-frontend/AST/jimple_method_body.h
+++ b/src/jimple-frontend/AST/jimple_method_body.h
@@ -2,6 +2,7 @@
 #define ESBMC_JIMPLE_METHOD_BODY_H
 
 #include <jimple-frontend/AST/jimple_ast.h>
+#include <util/irep/migrate.h>
 #include <util/irep/std_code.h>
 
 /**
@@ -17,6 +18,24 @@ public:
   {
     exprt dummy;
     return dummy;
+  }
+
+  /**
+   * @brief The IREP2 form of the body, for symbolt::set_value(const expr2tc &).
+   *
+   * K.1 of docs/roadmap/scope-jimple-irep2.md. The default migrates whatever
+   * to_exprt built, so a subclass that has not been converted yet keeps
+   * working; each override that lands removes one migration rather than adding
+   * one, which is why this migration runs from the seam downwards.
+   */
+  virtual expr2tc to_code2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name) const
+  {
+    expr2tc body;
+    migrate_expr(to_exprt(ctx, class_name, function_name), body);
+    return body;
   }
 };
 

--- a/src/jimple-frontend/AST/jimple_method_body.h
+++ b/src/jimple-frontend/AST/jimple_method_body.h
@@ -53,6 +53,29 @@ public:
     code_skipt dummy;
     return dummy;
   }
+
+  /**
+   * @brief The IREP2 form of this statement, located at @p loc.
+   *
+   * K.2 of docs/roadmap/scope-jimple-irep2.md. The location is a parameter
+   * rather than something the caller stamps afterwards: a code_*2t holds it in
+   * a non-reflected field, so it has to be set while the node is still a legacy
+   * exprt. As in jimple_method_body, the default migrates whatever to_exprt
+   * built, so each override that lands removes a migration instead of adding
+   * one.
+   */
+  virtual expr2tc to_code2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name,
+    const locationt &loc) const
+  {
+    exprt e = to_exprt(ctx, class_name, function_name);
+    e.location() = loc;
+    expr2tc stmt;
+    migrate_expr(e, stmt);
+    return stmt;
+  }
 };
 
 /**
@@ -75,6 +98,11 @@ public:
   virtual void from_json(const json &j) override;
   virtual std::string to_string() const override;
   virtual exprt to_exprt(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name) const override;
+
+  virtual expr2tc to_code2t(
     contextt &ctx,
     const std::string &class_name,
     const std::string &function_name) const override;

--- a/src/jimple-frontend/AST/jimple_statement.cpp
+++ b/src/jimple-frontend/AST/jimple_statement.cpp
@@ -2,6 +2,7 @@
 #include <util/irep/std_expr.h>
 #include <util/irep/std_types.h>
 #include <jimple-frontend/AST/jimple_statement.h>
+#include <irep2/irep2_expr.h>
 #include <util/arith/arith_tools.h>
 #include "util/lang/c_typecast.h"
 
@@ -109,6 +110,19 @@ exprt jimple_goto::to_exprt(
   code_gotot code_goto;
   code_goto.set_destination(label);
   return code_goto;
+}
+
+// K.3 of docs/roadmap/scope-jimple-irep2.md: the first statement to build its
+// IREP2 form directly rather than through the base's migrating default. Matches
+// migrate_expr's goto arm, which reads the destination off the legacy node's
+// "destination" field -- what set_destination writes above.
+expr2tc jimple_goto::to_code2t(
+  contextt &,
+  const std::string &,
+  const std::string &,
+  const locationt &loc) const
+{
+  return code_goto2tc(label, loc);
 }
 
 void jimple_label::from_json(const json &j)

--- a/src/jimple-frontend/AST/jimple_statement.h
+++ b/src/jimple-frontend/AST/jimple_statement.h
@@ -109,6 +109,12 @@ public:
     const std::string &class_name,
     const std::string &function_name) const override;
 
+  virtual expr2tc to_code2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name,
+    const locationt &loc) const override;
+
   std::string label;
 };
 


### PR DESCRIPTION
K.3 of `docs/roadmap/scope-jimple-irep2.md`, stacked on #6853.

`jimple_goto` carries only a label, so it builds its `code_goto2t` directly
instead of going through the base's migrating default.

The measurement that shaped the slice: of the nine statement classes, four hold
no `jimple_expr` operand (`goto`, `identity`, `label`, `assertion`) and five do
(`invoke`, `return`, `assignment`, `if`, `throw`). Migrating one of the latter
now would build its code node natively but migrate each operand separately —
trading one round-trip for several, which is the same shape that made a
bottom-up first slice wrong. So K.3 splits along that line and the
operand-bearing statements wait for the expression hook.

`jimple_identity` and `jimple_assertion` are nominally operand-free but build
legacy `symbol_expr`/argument lists, so they have the same problem one level
down; `jimple_label`'s body already has `to_code2t` and is the next clean one.

GOTO output is byte-identical across all 17 jimple tests. Refs #4715.
