### PR TITLE
[jimple] Add the parallel to_expr2t hook and its first two users

### DIFF
--- a/src/jimple-frontend/AST/jimple_expr.cpp
+++ b/src/jimple-frontend/AST/jimple_expr.cpp
@@ -1,4 +1,5 @@
 #include <jimple-frontend/AST/jimple_expr.h>
+#include <irep2/irep2_expr.h>
 #include <util/arith/arith_tools.h>
 #include <util/lang/c_typecast.h>
 #include <util/lang/c_types.h>
@@ -20,6 +21,18 @@ exprt jimple_constant::to_exprt(
   return constant_exprt(
     integer2binary(as_number, 10), integer2string(as_number), int_type());
 };
+
+// The leaf of this frontend's expression tree: a literal with no context and no
+// operands, so it converts with nothing left to migrate. Matches what
+// migrate_expr makes of the constant_exprt above -- int_type() is signedbv, so
+// the IREP2 form is a constant_int2t of the same width.
+expr2tc jimple_constant::to_expr2t(
+  contextt &,
+  const std::string &,
+  const std::string &) const
+{
+  return constant_int2tc(migrate_type(int_type()), BigInt(std::stoi(value)));
+}
 
 void jimple_symbol::from_json(const json &j)
 {

--- a/src/jimple-frontend/AST/jimple_expr.h
+++ b/src/jimple-frontend/AST/jimple_expr.h
@@ -1,4 +1,5 @@
 #include <jimple-frontend/AST/jimple_ast.h>
+#include <util/irep/migrate.h>
 #include <jimple-frontend/AST/jimple_type.h>
 
 #pragma once
@@ -16,6 +17,25 @@ public:
     exprt val("at_identifier");
     return val;
   };
+
+  /**
+   * @brief The IREP2 form of this expression.
+   *
+   * The expression counterpart of jimple_method_field::to_code2t (K.4 of
+   * docs/roadmap/scope-jimple-irep2.md). A return type belongs to a virtual's
+   * signature, so the 27 to_exprt overrides cannot migrate one at a time;
+   * a parallel method can, with this default carrying whatever has not moved
+   * yet and shrinking as each override lands.
+   */
+  virtual expr2tc to_expr2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name) const
+  {
+    expr2tc e;
+    migrate_expr(to_exprt(ctx, class_name, function_name), e);
+    return e;
+  }
 
   /**
    * @brief Recursively explores and initializes a jimple_expression
@@ -63,6 +83,11 @@ public:
     value = v;
   }
   virtual exprt to_exprt(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name) const override;
+
+  virtual expr2tc to_expr2t(
     contextt &ctx,
     const std::string &class_name,
     const std::string &function_name) const override;

--- a/src/jimple-frontend/AST/jimple_statement.cpp
+++ b/src/jimple-frontend/AST/jimple_statement.cpp
@@ -231,6 +231,21 @@ exprt jimple_if::to_exprt(
   return if_expr;
 }
 
+// The first statement to reach an expression through to_expr2t. migrate_expr's
+// ifthenelse arm leaves else_case nil when the legacy node has only two
+// operands, which is the shape built above, so the else stays default.
+expr2tc jimple_if::to_code2t(
+  contextt &ctx,
+  const std::string &class_name,
+  const std::string &function_name,
+  const locationt &loc) const
+{
+  expr2tc condition = cond->to_expr2t(ctx, class_name, function_name);
+  expr2tc target = code_goto2tc(label);
+
+  return code_ifthenelse2tc(condition, target, expr2tc(), loc);
+}
+
 std::string jimple_assertion::to_string() const
 {
   std::ostringstream oss;

--- a/src/jimple-frontend/AST/jimple_statement.h
+++ b/src/jimple-frontend/AST/jimple_statement.h
@@ -171,6 +171,11 @@ public:
     contextt &ctx,
     const std::string &class_name,
     const std::string &function_name) const override;
+  virtual expr2tc to_code2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name,
+    const locationt &loc) const override;
   virtual std::string to_string() const override;
   virtual void from_json(const json &j) override;
 


### PR DESCRIPTION
K.4 of `docs/roadmap/scope-jimple-irep2.md`, stacked on #6855.

A return type belongs to a virtual's signature, so the 27 `to_exprt` overrides
cannot migrate one at a time — the choice is all of them or none. A parallel
`to_expr2t` can: its default carries whatever has not moved yet, and shrinks as
each override lands. That is the same shape as `to_code2t` in #6851, and it is
the technique the other four frontends will need too.

Two users ship with it so the hook is not dead code:

- **`jimple_constant`** — the leaf. Ranking all 27 overrides by size and
  entanglement put it first at 15 lines, no `ctx`, no operand surgery.
- **`jimple_if`** — the first statement to reach an expression through the hook.
  `migrate_expr`'s `ifthenelse` arm leaves `else_case` nil for a two-operand
  legacy node, which is the shape built here, so the else stays default.

That unblocks the rest of the statements: `invoke`, `return`, `assignment` and
`throw` were waiting on this hook, per #6854.

GOTO output is byte-identical across all 17 jimple tests. Refs #4715.
