### PR TITLE
[goto-symex] Scope --malloc-zero-is-null to malloc

### DIFF
--- a/regression/esbmc/github_5398_alloca/main.c
+++ b/regression/esbmc/github_5398_alloca/main.c
@@ -1,0 +1,10 @@
+// --malloc-zero-is-null is a statement about malloc: alloca has no NULL
+// alternative to explore, so a zero-sized frame allocation is unaffected.
+#include <stdlib.h>
+
+int main(void)
+{
+  void *p = __builtin_alloca(0);
+  __ESBMC_assert(p != 0, "alloca(0) is not NULL");
+  return 0;
+}

--- a/regression/esbmc/github_5398_alloca/test.desc
+++ b/regression/esbmc/github_5398_alloca/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--malloc-zero-is-null
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5398_leak_fail/main.c
+++ b/regression/esbmc/github_5398_leak_fail/main.c
@@ -1,0 +1,9 @@
+// The success arm of C17 7.22.3p1 yields an object that must still be freed,
+// so --memory-leak-check reports it exactly as it does without the option.
+#include <stdlib.h>
+
+int main(void)
+{
+  void *p = malloc(0);
+  return 0;
+}

--- a/regression/esbmc/github_5398_leak_fail/test.desc
+++ b/regression/esbmc/github_5398_leak_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null --memory-leak-check
+^VERIFICATION FAILED$
+^\s*dereference failure: forgotten memory: dynamic_1_array$

--- a/regression/esbmc/github_5398_symbolic_fail/main.c
+++ b/regression/esbmc/github_5398_symbolic_fail/main.c
@@ -1,0 +1,18 @@
+// With a symbolic size the guard stays a genuine disjunction rather than
+// folding away, so the zero-sized outcome must still be explored: writing
+// through the success arm is out of bounds when the request was for 0 bytes.
+#include <stdlib.h>
+
+extern unsigned long __VERIFIER_nondet_ulong(void);
+extern void __VERIFIER_assume(int);
+
+int main(void)
+{
+  unsigned long n = __VERIFIER_nondet_ulong();
+  __VERIFIER_assume(n <= 4);
+
+  char *p = malloc(n);
+  __VERIFIER_assume((unsigned long)p != (unsigned long)0);
+  p[0] = 1;
+  return 0;
+}

--- a/regression/esbmc/github_5398_symbolic_fail/test.desc
+++ b/regression/esbmc/github_5398_symbolic_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null
+^VERIFICATION FAILED$
+^\s*dereference failure: array bounds violated: heap object$

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -551,6 +551,33 @@ expr2tc goto_symext::symex_mem_inf(
   return to_address_of2t(rhs_addrof).ptr_obj;
 }
 
+void goto_symext::offer_malloc_zero_null(
+  const expr2tc &size,
+  expr2tc &rhs,
+  guard2tc &alloc_guard)
+{
+  if (!options.get_bool_option("malloc-zero-is-null"))
+    return;
+
+  expr2tc nonzero = greaterthan2tc(size, gen_long(size->type, 0));
+  simplify(nonzero);
+  if (is_true(nonzero))
+    return;
+
+  // C17 7.22.3p1 leaves malloc(0) implementation-defined: NULL, or a pointer
+  // that may be freed but not used to access an object. Offer both -- forcing
+  // NULL makes the assume(p != NULL) that environment models emit after a
+  // zero-sized request unsatisfiable, pruning every execution under test
+  // (#5398).
+  expr2tc may_alloc = gen_nondet(get_bool_type());
+  replace_nondet(may_alloc);
+
+  expr2tc choice = or2tc(nonzero, may_alloc);
+  simplify(choice);
+  alloc_guard.add(choice);
+  rhs = if2tc(rhs->type, choice, rhs, symbol2tc(rhs->type, "NULL"));
+}
+
 expr2tc goto_symext::symex_mem(
   const bool is_malloc,
   const expr2tc &lhs,
@@ -729,27 +756,8 @@ expr2tc goto_symext::symex_mem(
   }
 
   // alloca has no NULL outcome to explore: C17 7.22.3p1 is about malloc.
-  if (is_malloc && options.get_bool_option("malloc-zero-is-null"))
-  {
-    expr2tc nonzero = greaterthan2tc(size, gen_long(size->type, 0));
-    simplify(nonzero);
-
-    if (!is_true(nonzero))
-    {
-      // C17 7.22.3p1 leaves malloc(0) implementation-defined: NULL, or a
-      // pointer that may be freed but not used to access an object. Offer
-      // both -- forcing NULL makes the assume(p != NULL) that environment
-      // models emit after a zero-sized request unsatisfiable, pruning every
-      // execution under test (#5398).
-      expr2tc may_alloc = gen_nondet(get_bool_type());
-      replace_nondet(may_alloc);
-
-      expr2tc choice = or2tc(nonzero, may_alloc);
-      simplify(choice);
-      alloc_guard.add(choice);
-      rhs = if2tc(rhs->type, choice, rhs, symbol2tc(rhs->type, "NULL"));
-    }
-  }
+  if (is_malloc)
+    offer_malloc_zero_null(size, rhs, alloc_guard);
 
   if (!options.get_bool_option("force-malloc-success") && is_malloc)
   {

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -728,7 +728,8 @@ expr2tc goto_symext::symex_mem(
     ptr_rhs = rhs;
   }
 
-  if (options.get_bool_option("malloc-zero-is-null"))
+  // alloca has no NULL outcome to explore: C17 7.22.3p1 is about malloc.
+  if (is_malloc && options.get_bool_option("malloc-zero-is-null"))
   {
     expr2tc nonzero = greaterthan2tc(size, gen_long(size->type, 0));
     simplify(nonzero);

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -1212,6 +1212,12 @@ protected:
     const expr2tc &lhs,
     const sideeffect2t &code,
     const guard2tc &guard);
+  /** Offer both outcomes C17 7.22.3p1 permits for a zero-sized malloc,
+   *  under --malloc-zero-is-null. Widens @p alloc_guard and @p rhs. */
+  void offer_malloc_zero_null(
+    const expr2tc &size,
+    expr2tc &rhs,
+    guard2tc &alloc_guard);
   /** Wrapper around for infinite array allocation. */
   expr2tc symex_mem_inf(
     const expr2tc &lhs,


### PR DESCRIPTION
`--malloc-zero-is-null` ("Also explore malloc(0) returning NULL") applied its
NULL alternative to every `symex_mem` caller, so `alloca(0)` could return NULL
under it. C17 7.22.3p1 is about `malloc`; a frame allocation has no such
outcome. Follow-up to #6793, which fixed the malloc side of #5398.
