### PR TITLE
[jimple] Build a binary operation natively, with a fallback

### DIFF
--- a/src/jimple-frontend/AST/jimple_expr.cpp
+++ b/src/jimple-frontend/AST/jimple_expr.cpp
@@ -199,6 +199,40 @@ exprt jimple_binop::to_exprt(
     rhs->to_exprt(ctx, class_name, function_name));
 };
 
+// The operator reaches to_exprt as a legacy irep id -- gen_binary builds
+// exprt(binop, ...) -- so the usable set is whatever migrate_expr maps, not
+// whatever the Jimple producer emits. The corpus uses six: ==, +, notequal, -,
+// >= and >, with from_json rewriting == to = beforehand. Anything else falls
+// through to the base default and takes exactly the path it takes today, so an
+// operator this switch does not know cannot silently build the wrong node.
+expr2tc jimple_binop::to_expr2t(
+  contextt &ctx,
+  const std::string &class_name,
+  const std::string &function_name) const
+{
+  expr2tc l = lhs->to_expr2t(ctx, class_name, function_name);
+  expr2tc r = rhs->to_expr2t(ctx, class_name, function_name);
+
+  // gen_binary gives the node the lhs type; the relational kinds force bool
+  // themselves, which is what migrate_expr produces for them too.
+  const type2tc &t = l->type;
+
+  if (binop == "+")
+    return add2tc(t, l, r);
+  if (binop == "-")
+    return sub2tc(t, l, r);
+  if (binop == "=")
+    return equality2tc(l, r);
+  if (binop == "notequal")
+    return notequal2tc(l, r);
+  if (binop == ">")
+    return greaterthan2tc(l, r);
+  if (binop == ">=")
+    return greaterthanequal2tc(l, r);
+
+  return jimple_expr::to_expr2t(ctx, class_name, function_name);
+}
+
 void jimple_cast::from_json(const json &j)
 {
   jimple_type type;

--- a/src/jimple-frontend/AST/jimple_expr.h
+++ b/src/jimple-frontend/AST/jimple_expr.h
@@ -152,6 +152,11 @@ public:
     const std::string &class_name,
     const std::string &function_name) const override;
 
+  virtual expr2tc to_expr2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name) const override;
+
   std::string binop;
   std::shared_ptr<jimple_expr> lhs;
   std::shared_ptr<jimple_expr> rhs;


### PR DESCRIPTION
Completes the expression side of K.4 for the operators the corpus uses, stacked
on #6858.

`gen_binary` hands `to_exprt` a legacy irep id, so the usable operator set is
whatever `migrate_expr` maps — not whatever the Jimple producer emits, which is
what made this look open-ended. Measured over the corpus, six appear: `==`, `+`,
`notequal`, `-`, `>=`, `>`, with `from_json` rewriting `==` to `=` first.
`notequal` is a word rather than a symbol and would be missed silently by a
mapping written from the C operator set.

Anything the switch does not know **falls through to the base default**, so an
unrecognised operator takes exactly the path it takes today rather than building
the wrong node. That is what makes a partial mapping safe against a 17-test
corpus: the tests need only show the mapped operators are mapped correctly,
because the unmapped ones are unchanged by construction.

One limitation worth knowing at review time: only the **relational** operators
are reached so far. `+` and `-` appear in assignments, which still convert
through `to_exprt`, so those arms are inert until `jimple_assignment` migrates.
Checked rather than assumed — mutating the `+` arm changes no output, mutating
`>` does.

GOTO output is byte-identical across all 17 jimple tests. Refs #4715.
