### PR TITLE
[om] Make string::end() one past the last character

### DIFF
--- a/regression/esbmc-cpp/string/iterator_end_half_open/main.cpp
+++ b/regression/esbmc-cpp/string/iterator_end_half_open/main.cpp
@@ -1,0 +1,40 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s = "abc";
+
+  // Every character is visited exactly once.
+  int n = 0, count = 0;
+  for (std::string::iterator i = s.begin(); i != s.end(); ++i)
+  {
+    n += *i;
+    count++;
+  }
+  assert(count == 3);
+  assert(n == 'a' + 'b' + 'c');
+
+  // Range-for is the same traversal.
+  int m = 0;
+  for (char c : s)
+    m += c;
+  assert(m == n);
+
+  // An empty string iterates zero times.
+  std::string e;
+  int k = 0;
+  for (std::string::iterator i = e.begin(); i != e.end(); ++i)
+    k++;
+  assert(k == 0);
+  assert(e.begin() == e.end());
+
+  // A one-character string iterates once.
+  std::string one = "z";
+  int j = 0;
+  for (std::string::iterator i = one.begin(); i != one.end(); ++i)
+    j++;
+  assert(j == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/iterator_end_half_open/test.desc
+++ b/regression/esbmc-cpp/string/iterator_end_half_open/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/iterator_end_half_open_fail/main.cpp
+++ b/regression/esbmc-cpp/string/iterator_end_half_open_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s = "abc";
+
+  int count = 0;
+  for (std::string::iterator i = s.begin(); i != s.end(); ++i)
+    count++;
+
+  // end() is one past the last character, so all three are visited.
+  assert(count == 2);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/iterator_end_half_open_fail/test.desc
+++ b/regression/esbmc-cpp/string/iterator_end_half_open_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -654,8 +654,9 @@ public:
     int pos = one.pos;
     int n = two.pos, i, k;
     __ESBMC_assert(s != NULL, "The parameter must be different than NULL");
-    this->_size = n - pos + 1;
-    for (k = 0, i = pos; i <= n; i++, k++)
+    /* [one, two) -- two is not itself copied. */
+    this->_size = n - pos;
+    for (k = 0, i = pos; i < n; i++, k++)
       this->str[k] = s[i];
     this->str[k] = '\0';
     return *this;
@@ -675,9 +676,8 @@ public:
     int pos = one.pos;
     int n = two.pos;
     __ESBMC_assert(pos >= 0, "basic_string overflow");
-    __ESBMC_assert(pos < sLen, "basic_string overflow");
+    __ESBMC_assert(pos <= sLen, "basic_string overflow");
     __ESBMC_assert(n <= sLen, "basic_string overflow");
-    __ESBMC_assert(n > 0, "basic_string overflow");
     __ESBMC_assert(s != NULL, "The parameter must be different than NULL");
     if ((pos > sLen) || (pos > n))
     {
@@ -687,7 +687,8 @@ public:
     }
 
     int totalLength = this->size();
-    totalLength += (n - pos + 1);
+    /* [one, two) -- two is not itself appended. */
+    totalLength += (n - pos);
     int i, j, k;
     basic_string<CharT, Traits, Alloc> result;
     for (i = 0; i < this->_size; i++)
@@ -778,7 +779,8 @@ public:
     int i, k, len = this->length();
     __ESBMC_assert(
       end.pos <= len, "The second parameter must be less than zero");
-    int n = (end.pos - begin.pos) + 1;
+    /* [begin, end) -- end is not itself erased. */
+    int n = end.pos - begin.pos;
     __ESBMC_assert(pos < len, "overflow");
     int lenOne = pos + 1;
     char one[STRING_CAPACITY];
@@ -961,27 +963,13 @@ public:
     }
     int len = this->length(), i, k;
     int sLen = n;
-    __ESBMC_assert(pos1 < len, "overflow");
-    if (pos1 == (len - 1))
-    {
-      char one[STRING_CAPACITY];
-      for (i = 0; i < len; i++)
-      {
-        one[i] = this->str[i];
-      }
-      int totalLen = len + n;
-      this->_size = totalLen;
-      for (i = 0; i < len; i++)
-      {
-        this->str[i] = one[i];
-      }
-      for (; i < totalLen; i++)
-      {
-        this->str[i] = c;
-      }
-      this->str[i] = '\0';
-      return *this;
-    }
+    /* Inserting at end() is legal, so pos1 may equal len. The general path
+     * below copies [0, pos1), then the new characters, then [pos1, len) --
+     * which appends when that tail is empty. The special case that stood here
+     * appended whenever pos1 was len - 1, compensating for end() reporting the
+     * last character rather than one past it; with end() corrected it would
+     * wrongly append an insert aimed before the final character. */
+    __ESBMC_assert(pos1 <= len, "overflow");
     int lenOne = pos1 + 1;
     char one[STRING_CAPACITY];
     for (i = 0; i < pos1; i++)
@@ -1025,27 +1013,13 @@ public:
     }
     int len = this->length(), i, k;
     int sLen = n;
-    __ESBMC_assert(pos1 < len, "overflow");
-    if (pos1 == (len - 1))
-    {
-      char one[STRING_CAPACITY];
-      for (i = 0; i < len; i++)
-      {
-        one[i] = this->str[i];
-      }
-      int totalLen = len + n;
-      this->_size = totalLen;
-      for (i = 0; i < len; i++)
-      {
-        this->str[i] = one[i];
-      }
-      for (; i < totalLen; i++)
-      {
-        this->str[i] = c;
-      }
-      this->str[i] = '\0';
-      return *this;
-    }
+    /* Inserting at end() is legal, so pos1 may equal len. The general path
+     * below copies [0, pos1), then the new characters, then [pos1, len) --
+     * which appends when that tail is empty. The special case that stood here
+     * appended whenever pos1 was len - 1, compensating for end() reporting the
+     * last character rather than one past it; with end() corrected it would
+     * wrongly append an insert aimed before the final character. */
+    __ESBMC_assert(pos1 <= len, "overflow");
     int lenOne = pos1 + 1;
     char one[STRING_CAPACITY];
     for (i = 0; i < pos1; i++)
@@ -1110,8 +1084,15 @@ public:
 
   basic_string<CharT, Traits, Alloc>::iterator end() const
   {
-    basic_string<CharT, Traits, Alloc>::iterator end(const_cast<char *>(this->str));
-    end.pos = this->length() - 1;
+    /* One past the last character, so [begin(), end()) covers every element
+     * and begin() == end() on an empty string. Stopping at length() - 1 left
+     * the last character unvisited, and on an empty string gave pos == -1,
+     * which begin() never reaches. */
+    size_t len = this->length();
+    basic_string<CharT, Traits, Alloc>::iterator end(
+      const_cast<char *>(this->str));
+    end.pointer = const_cast<char *>(this->str) + len;
+    end.pos = len;
     return end;
   }
   template <class T>
@@ -2520,8 +2501,11 @@ basic_string<CharT, Traits, Alloc> &basic_string<CharT, Traits, Alloc>::replace(
 {
 __ESBMC_HIDE:
   __ESBMC_assert(str.str != NULL, "The parameter must be different than NULL");
+  /* [i1, i2). The +1 that stood here compensated for end() reporting the last
+   * character rather than one past it; the char* overloads below never had
+   * it, so the two disagreed by one whenever end() was involved. */
   int tmp_one = i1.pos;
-  int tmp_two = i2.pos + 1;
+  int tmp_two = i2.pos;
   int tmp = tmp_two - tmp_one;
   this->erase(tmp_one, tmp);
   this->insert(tmp_one, str.str);
@@ -2568,8 +2552,9 @@ basic_string<CharT, Traits, Alloc> &basic_string<CharT, Traits, Alloc>::replace(
   char c)
 {
 __ESBMC_HIDE:
+  /* [i1, i2) -- i2 is not itself replaced. */
   int tmp_one = i1.pos;
-  int tmp_two = i2.pos + 1;
+  int tmp_two = i2.pos;
   int tmpk = tmp_two - tmp_one;
   this->erase(tmp_one, tmpk);
   int k;


### PR DESCRIPTION
`end()` returned an iterator at `length() - 1`:

```cpp
std::string s = "abc";
int n = 0;
for (auto i = s.begin(); i != s.end(); ++i) n++;   // n == 2, not 3
```

An empty string was worse — `begin()` sat at 0 and `end()` at `-1`, and `operator!=` compares only `pos`, so it never terminated.

**Six places were built around that convention and move with it:** `assign`, `append` and `erase` over an iterator pair; `replace(i1, i2, string)`; `replace(i1, i2, n, c)`; and both `insert` overloads, whose "append when `pos == len - 1`" branch existed only to make `insert(end(), ...)` land at the end. The general insert path already appends when the tail it copies is empty, so that branch is removed rather than shifted.

Worth noting the `char*` `replace` overloads already treated the range as half-open, so they disagreed with their `string` sibling by one whenever `end()` was involved. They agree now.

Verification — this one needed more than the usual, because a 420-test sampled differential **missed three of the regressions**:
- full `esbmc-cpp/string` suite, all **249** tests: only `string_clear_pop_resize{,_fail}` fail, and they fail identically on a control binary (untracked WIP dirs, not repo tests)
- 663/663 unit tests
- 420-test differential: no change beyond my own already-merged #6837/#6838
- new test's assertions all hold under clang++; `_fail` variant mutation-checks the count