### PR TITLE
[build] Make master coverage reach Codecov again

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,14 +1,17 @@
-name: Master Push
+name: Master Coverage
 on:
-  push:
-    branches: [master]
+  # Nightly, not per-push: the run takes hours, and every push to master shared
+  # one `cancel-in-progress` concurrency group, so a later push killed it. 97 of
+  # the last 100 runs were cancelled and master went 8 days with no report.
+  schedule:
+    - cron: '0 2 * * *'
   # Lets the sharded pipeline be re-run against a known commit, so its total
   # can be compared with a previous unsharded run rather than assumed correct.
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   coverage:
@@ -58,7 +61,7 @@ jobs:
           retention-days: 1
 
   upload:
-    name: Build and upload coverage to Codecov
+    name: Upload coverage to Codecov
     runs-on: ubuntu-24.04
     # Every shard must succeed: a missing shard would publish a partial figure
     # as the repo total, which reads as a coverage regression.
@@ -72,7 +75,11 @@ jobs:
         with:
           pattern: coverage-shard-*
           path: shards
-      - name: Combine shard coverage
+      # Not uploaded -- this is the combined line total #6799 left open, to be
+      # read from the log and compared against the last good unsharded run
+      # (76.4%, 138,698 of 181,616 lines).
+      - name: Report combined line total
+        continue-on-error: true
         run: |
           args=()
           for f in shards/*/coverage.info; do args+=(-a "$f"); done
@@ -80,9 +87,15 @@ jobs:
           # lcov treats as an error when aggregating tracefiles.
           lcov --ignore-errors inconsistent --ignore-errors corrupt \
                --ignore-errors empty "${args[@]}" \
-               --output-file coverage.info
+               --output-file combined.info
+      # Upload the shards themselves and let Codecov merge them: the two runs
+      # that ever reached this step both uploaded an lcov-combined tracefile and
+      # both came back `state: error` with no report, while every unsharded run
+      # before them processed. Server-side merge is Codecov's own path for
+      # matrix builds and drops the step that correlates with the failures.
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.info
+          disable_search: true
+          files: shards/coverage-shard-1/coverage.info,shards/coverage-shard-2/coverage.info,shards/coverage-shard-3/coverage.info,shards/coverage-shard-4/coverage.info


### PR DESCRIPTION
The Codecov badge reads "unknown" because master has had no coverage report
since 2026-07-31. Two causes: every push shared one `cancel-in-progress`
concurrency group, so a later push killed the multi-hour run (97 of the last
100 were cancelled); and the two runs that did finish uploaded an
lcov-combined tracefile that Codecov failed to process (`state: error`,
`report: null`), where every unsharded run before them processed fine.

Run nightly instead of per-push, and upload the four shard tracefiles for
Codecov to merge server-side. Verify after merge with `workflow_dispatch`.
