### PR TITLE
[om] Give ostringstream the buffer its str() reports

### DIFF
--- a/regression/esbmc-cpp/cpp/ostringstream_str/main.cpp
+++ b/regression/esbmc-cpp/cpp/ostringstream_str/main.cpp
@@ -1,0 +1,42 @@
+#include <cassert>
+#include <sstream>
+#include <string>
+
+int main()
+{
+  std::ostringstream empty;
+  assert(empty.str().size() == 0);
+
+  std::ostringstream n;
+  n << 42;
+  assert(n.str() == "42");
+
+  std::ostringstream neg;
+  neg << -7;
+  assert(neg.str() == "-7");
+
+  std::ostringstream t;
+  t << "ab";
+  assert(t.str() == "ab");
+
+  std::ostringstream c;
+  c << 'z';
+  assert(c.str() == "z");
+
+  std::ostringstream b;
+  b << true;
+  assert(b.str() == "1");
+
+  std::ostringstream u;
+  u << 7u;
+  assert(u.str() == "7");
+
+  std::ostringstream seeded("xy");
+  assert(seeded.str() == "xy");
+
+  std::ostringstream set;
+  set.str("hello");
+  assert(set.str() == "hello");
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ostringstream_str/test.desc
+++ b/regression/esbmc-cpp/cpp/ostringstream_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ostringstream_str_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/ostringstream_str_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+#include <sstream>
+#include <string>
+
+int main()
+{
+  std::ostringstream o;
+  o << 42;
+
+  // The stream holds "42", not the empty string it starts as.
+  assert(o.str().size() == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ostringstream_str_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/ostringstream_str_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10
+^VERIFICATION FAILED$

--- a/src/cpp/library/sstream
+++ b/src/cpp/library/sstream
@@ -243,20 +243,108 @@ public:
   }
 };
 
+/* str() and the inserters were declared and never defined, so every use of an
+ * ostringstream produced a nondeterministic string. Back it with the same
+ * member stringstream uses, and give it the inserters that carry the common
+ * types. */
 class ostringstream : public ostream
 {
 public:
-  explicit ostringstream(openmode which = out)
+  string _string;
+
+  explicit ostringstream(openmode which = out) : ostream(), _string("")
   {
-    ostream();
   }
+
   explicit ostringstream(const string &str, openmode which = out)
+    : ostream(), _string(str)
   {
-    ostream();
   }
+
   stringbuf *rdbuf() const;
-  string str() const;
-  void str(const string &s);
+
+  string str() const
+  {
+    return _string;
+  }
+
+  void str(const string &s)
+  {
+    _string = s;
+  }
+
+  ostream &operator<<(const string &val)
+  {
+    _string.append(val.c_str());
+    return *this;
+  }
+
+  ostream &operator<<(const char *val)
+  {
+    _string.append(val);
+    return *this;
+  }
+
+  ostream &operator<<(char val)
+  {
+    char temp[2] = {val, '\0'};
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(bool val)
+  {
+    _string.append(val ? "1" : "0");
+    return *this;
+  }
+
+  ostream &operator<<(short val)
+  {
+    char temp[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(int val)
+  {
+    char temp[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(long val)
+  {
+    char temp[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(unsigned short val)
+  {
+    char temp[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(unsigned int val)
+  {
+    char temp[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(unsigned long val)
+  {
+    char temp[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
 };
 
 } // namespace std


### PR DESCRIPTION
`ostringstream` declared `str()`, the `str(string)` setter and `rdbuf()` and defined none of them, so a stream that had just been written to returned a **nondeterministic** string:

```cpp
std::ostringstream o;
o << 42;
assert(o.str() == "42");   // could fail; even o.str().size() == 0 on a fresh
                           // stream could fail
```

`stringstream` immediately above it in the same header already carries a `string` member and the inserters that append to it. `ostringstream` now does the same, for the types that reach it in practice: `string`, `const char*`, `char`, `bool`, and the signed/unsigned short/int/long family.

Found by differentially testing the C++ models against clang++. All 9 assertions in the new test hold under clang++ and failed before; a 340-test differential over the C++ suites shows no other change.

Scoped deliberately: `istringstream` and the extraction operators are the same kind of shell, but `>>` needs number parsing rather than appending, so it is left for its own patch rather than half-done here.