### PR TITLE
[jimple] Build a return statement natively

### DIFF
--- a/src/jimple-frontend/AST/jimple_statement.cpp
+++ b/src/jimple-frontend/AST/jimple_statement.cpp
@@ -52,6 +52,21 @@ exprt jimple_return::to_exprt(
   return ret_expr;
 }
 
+expr2tc jimple_return::to_code2t(
+  contextt &ctx,
+  const std::string &class_name,
+  const std::string &function_name,
+  const locationt &loc) const
+{
+  // code_returnt always carries one operand, nil when there is no value, and
+  // migrate_expr maps that nil to a null expr2tc.
+  expr2tc value;
+  if (expr)
+    value = expr->to_expr2t(ctx, class_name, function_name);
+
+  return code_return2tc(value, loc);
+}
+
 std::string jimple_return::to_string() const
 {
   return "Return: (Nothing)";

--- a/src/jimple-frontend/AST/jimple_statement.h
+++ b/src/jimple-frontend/AST/jimple_statement.h
@@ -69,6 +69,13 @@ class jimple_return : public jimple_statement
     contextt &ctx,
     const std::string &class_name,
     const std::string &function_name) const override;
+
+  virtual expr2tc to_code2t(
+    contextt &ctx,
+    const std::string &class_name,
+    const std::string &function_name,
+    const locationt &loc) const override;
+
   virtual std::string to_string() const override;
   virtual void from_json(const json &j) override;
   std::shared_ptr<jimple_expr> expr;


### PR DESCRIPTION
Migrates `jimple_return` to `to_code2t`.

`code_returnt` always holds exactly one operand — nil when there is no return value — so `migrate_expr` recurses into it unconditionally and maps that nil to a null `expr2tc`. The override reproduces this by passing a default-constructed `expr2tc` rather than an operand that does not exist.

All 17 jimple tests byte-identical against the pre-patch binary. Two mutants separate the branches: replacing the statement with a skip changes all 17 (every test reaches the override), dropping only the value changes 10 (10 tests take the value path, 7 the valueless one).

Stacked on #6865. Refs #4715