### PR TITLE
[goto-symex] Fix --state-hashing dropping violating schedules

### DIFF
--- a/docs/roadmap/svcomp-6831-schedule-space-plan.md
+++ b/docs/roadmap/svcomp-6831-schedule-space-plan.md
@@ -1,6 +1,7 @@
 # Plan — affording the schedule space #6607 exposed (issue #6831, cause 1)
 
-**Status:** W0 shipped; W1–W4 not started.
+**Status:** W0 shipped. W2 diagnosed and re-scoped — `--state-hashing` is
+**unsound**, not merely useless (see W2). W1, W3, W4 not started.
 **Owner issue:** [#6831](https://github.com/esbmc/esbmc/issues/6831), *cause 1 —
 schedule-space explosion*, 291 of 489 lost SV-COMP tasks.
 **Bisected to:** `bac652b13c` — `[goto-symex] Track main-thread termination per
@@ -66,6 +67,11 @@ Two results drive this plan:
 
 The 939 reproduces the issue's reported 940.
 
+**Superseded on the hashing row.** W2 re-measured this across all 314
+concurrent CORE tests rather than this one: hashing prunes on 62 of them and
+saves 16.5 % wall overall. `01_malloc_20` is an outlier, not a summary. It is
+also unsound on four of them — see W2.
+
 ### 2.2 The same reproducer under the SV-COMP flag shape
 
 `scripts/competitions/svcomp/esbmc-wrapper.py` passes **no `--context-bound`**,
@@ -109,9 +115,9 @@ solver would be aimed at 7.7 % of the run.
 
 Two orthogonal levers, both open:
 
-- **A — explore fewer schedules.** MPOR is the only reduction that fires; state
-  hashing contributes ~0. Nothing reports how much either pruned, so no
-  benchmark can currently be diagnosed without rebuilding with counters.
+- **A — explore fewer schedules.** MPOR is the only reduction that fires on this
+  reproducer; W2 shows state hashing fires on plenty of others, unsoundly.
+  W0 added the counters this diagnosis needed.
 - **B — make each schedule cheaper.** Each of the 940 schedules is symexed,
   sliced, encoded and solved as an independent formula. The DFS restores
   execution states on backtracking, but the per-formula pipeline downstream of
@@ -183,24 +189,58 @@ Candidates, cheapest first:
 `--context-bound 2`, with no verdict change anywhere in the concurrency
 regression suites, and #4584's regression test still detecting its race.
 
-### W2 — Fix state hashing or stop paying for it
+### W2 — Fix state hashing or stop paying for it — **re-scoped: it is unsound**
 
-Measured contribution: 0 % bounded, 1.8 % unbounded, for ~4 % wall.
+W2 was written around "prunes ~0 for ~4 % wall". Both halves of that premise
+were artefacts of measuring one reproducer. Running every CORE test in
+`esbmc-unix` and `esbmc-unix2` twice — once stock, once with `--state-hashing`
+— over the 314 that reach more than one thread, with W0's counters:
 
-The L2 fingerprint (`state_hashing_level2t::generate_l2_state_hash()`,
-`execution_state.cpp:1625`) mixes every assigned symbol's original name and
-value hash. Hypothesis to test first: it is too *fine* — thread-local and dead
-variables enter the fingerprint, so two states that are equivalent for
-scheduling purposes hash differently and never collide.
+- **Verdict changes: 4**, every one of them `FAILED` → `SUCCESSFUL`.
+- Schedules: fewer with hashing on **62** tests, equal on 247, more on none.
+- Wall over the tests whose verdict agreed: 372 s → 310 s, **−16.5 %**.
 
-Steps: restrict the fingerprint to shared state (globals plus reachable heap)
-plus the per-thread PC vector; optionally intersect with liveness the slicer
-already computes. Re-measure prune rate with W0's counters.
+So hashing does prune, sometimes enormously (`11_cook.fig2.pldi07`
+11,130 → 79 schedules, 25.0 s → 0.6 s; `github_3449` 2134 → 621). `01_malloc_20`,
+where §2.1 measured it, is simply a case where it prunes nothing — it is not
+representative.
 
-**Exit:** either a prune rate that pays for its own cost on the concurrency
-suites, or a PR removing `--state-hashing` from `esbmc_dargs` in
-`esbmc-wrapper.py` with the measurement quoted. Both are acceptable outcomes;
-the current state — paying 4 % for ~0 — is not.
+**The finding that matters is the soundness one.** These four CORE tests, whose
+`test.desc` expects `VERIFICATION FAILED`, return `VERIFICATION SUCCESSFUL`
+when `--state-hashing` is added, on stock `master` with no other flag change:
+
+| test | stock | `--state-hashing` |
+|---|---|---|
+| `esbmc-unix2/00_mpor1` | FAILED | **SUCCESSFUL** |
+| `esbmc-unix2/00_mpor2` | FAILED | **SUCCESSFUL** |
+| `esbmc-unix/race_guard_other_write` | FAILED | **SUCCESSFUL** |
+| `esbmc-unix/race_guard_self_clear` | FAILED | **SUCCESSFUL** |
+
+The fingerprint collides two states that are not bisimilar, and
+`post_hash_collision_cleanup()` then marks every switch from that point
+explored, so the schedule carrying the violation is never generated. This is
+the §7 "re-truncation" failure mode, already shipped, and
+`esbmc-wrapper.py:237` passes `--state-hashing` in `esbmc_dargs` — so SV-COMP
+runs are exposed to it. A wrong `true` is scored far more harshly than an
+`unknown`, which makes this a bigger liability than any timeout W1–W3 address.
+
+Pinned by `regression/esbmc-unix/github_6831_hashing_unsound{,_mpor}`
+(KNOWNBUG, expecting the correct FAILED) so a fix flips them to CORE.
+
+Revised order:
+
+1. **Diagnose the collision.** The hypothesis that the fingerprint is too
+   *fine* is now the wrong end: it is too *coarse* somewhere. Not yet located —
+   an allocation-naming hypothesis (the monotone `dynamic_counter` making
+   post-`malloc` states unique) was tested with a controlled probe and
+   **rejected**: the probe still pruned 76 states.
+2. **Fix or disable.** Until a fix exists, disabling `--state-hashing` in
+   `esbmc_dargs` is the sound choice, and costs the −16.5 % above.
+3. Only then revisit making it prune harder.
+
+**Exit:** the four tests above pass with `--state-hashing`, or the flag is out
+of `esbmc_dargs`. Performance tuning of the fingerprint is not in scope until
+one of those holds.
 
 ### W3 — Stop redoing per-schedule work
 

--- a/docs/roadmap/svcomp-6831-schedule-space-plan.md
+++ b/docs/roadmap/svcomp-6831-schedule-space-plan.md
@@ -1,7 +1,7 @@
 # Plan — affording the schedule space #6607 exposed (issue #6831, cause 1)
 
 **Status:** W0 and W2 shipped; `--state-hashing` was **unsound** and is fixed
-(see W2). W1, W3, W4 not started.
+(see W2). W1 diagnosed, no code yet. W3, W4 not started.
 **Owner issue:** [#6831](https://github.com/esbmc/esbmc/issues/6831), *cause 1 —
 schedule-space explosion*, 291 of 489 lost SV-COMP tasks.
 **Bisected to:** `bac652b13c` — `[goto-symex] Track main-thread termination per
@@ -171,19 +171,53 @@ MPOR quasi-monotonic dependency-chain test, with dependencies derived from
 reduction that fires, and it leaves 939 schedules where the property under test
 touches a handful of shared objects.
 
-Candidates, cheapest first:
+#### What actually drives the dependencies (measured)
+
+Instrumenting `mpor_set_conflicts` to name the object behind every conflict,
+and histogramming over five benchmarks:
+
+| benchmark | top dependency drivers |
+|---|---|
+| `01_malloc_20` | the mutex + 2 condvars (996), pthread bookkeeping (260), user `num` (**1**) |
+| `11_cook.fig2.pldi07` | `__ESBMC_pthread_thread_ended` (4591), user `x` (4367) |
+| `github_3449` | user mutex `m` (6181), user `counter` (608), bookkeeping (437) |
+| `11_bakery.simple.preempt` | users `t2`, `t1`, `x` (337) — all user |
+| `github_6475_safe` | `__ESBMC_pthread_thread_ended` (2172), user lock `l` (1960), `__ESBMC_pthread_join_waiters` (654) |
+
+Two things follow. Dependencies are dominated by **synchronisation objects and
+pthread-model bookkeeping**, not by ordinary shared data — on `01_malloc_20`
+exactly one conflict in 1257 involves a user global. And the mix varies enough
+between benchmarks that no single-reproducer measurement should be trusted
+(the mistake §2.1 made).
+
+#### W1.2 was tried and does not work — do not re-try it
+
+`mpor_keys_may_alias` already keys pthread *sync* arrays per element, but
+`__ESBMC_pthread_thread_ended` (`_Bool[]`), `__ESBMC_pthread_join_waiters`
+(`unsigned[]`) and `__ESBMC_pthread_end_values` (`void *[]`) are thread-indexed
+bookkeeping that fell back to a whole-array key, so every thread's write to its
+own slot conflicted with every other thread's read of a different slot.
+Extending element keying to those arrays is sound and precise — and bought
+**nothing**: the conflict count moved intact to the next bookkeeping object
+(`thread_ended` → `end_values` → `__ESBMC_num_threads_running`), which is a
+*scalar* and cannot be refined at all. Schedule counts were byte-identical on
+all 7 benchmarks tested.
+
+The dependency is over-determined: thread start/end threads every pair of
+transitions through shared scalar bookkeeping, so no amount of aliasing
+precision separates them. **The independence relation is not the lever.**
+
+Remaining candidates:
 
 1. **Sleep sets** layered on the existing MPOR. Classical, sound, composes with
    a persistent-set-style reduction rather than replacing it; small state per
-   DFS node.
-2. **Sharpen the independence relation.** Dependencies are currently computed
-   from the last transition's read/write sets. Objects proved thread-local by
-   the existing value-set / pointer analysis can never induce a dependency;
-   `--cswitch-skip-readonly-globals` (already passed by the SV-COMP wrapper)
-   shows the shape of this argument but applies it only to read-only globals.
-3. **Evaluate DPOR** (Flanagan–Godefroid dynamic POR) against MPOR. This is a
-   design change, not a patch, and is scoped as investigation only until 1 and 2
-   are measured.
+   DFS node. Now the first thing to try, not the second.
+2. **Decouple the pthread model's bookkeeping.** If `__ESBMC_num_threads_running`
+   and friends were per-thread rather than shared scalars, W1.2's refinement
+   would start paying. This is an operational-model change, and it must not
+   weaken `pthread_join` / deadlock detection, which read exactly that state.
+3. **Evaluate DPOR** (Flanagan–Godefroid dynamic POR) against MPOR. A design
+   change, not a patch; investigation only.
 
 **Exit:** ≥2× reduction in schedules explored on `01_malloc_20` at
 `--context-bound 2`, with no verdict change anywhere in the concurrency

--- a/docs/roadmap/svcomp-6831-schedule-space-plan.md
+++ b/docs/roadmap/svcomp-6831-schedule-space-plan.md
@@ -1,7 +1,7 @@
 # Plan — affording the schedule space #6607 exposed (issue #6831, cause 1)
 
-**Status:** W0 shipped. W2 diagnosed and re-scoped — `--state-hashing` is
-**unsound**, not merely useless (see W2). W1, W3, W4 not started.
+**Status:** W0 and W2 shipped; `--state-hashing` was **unsound** and is fixed
+(see W2). W1, W3, W4 not started.
 **Owner issue:** [#6831](https://github.com/esbmc/esbmc/issues/6831), *cause 1 —
 schedule-space explosion*, 291 of 489 lost SV-COMP tasks.
 **Bisected to:** `bac652b13c` — `[goto-symex] Track main-thread termination per
@@ -68,9 +68,9 @@ Two results drive this plan:
 The 939 reproduces the issue's reported 940.
 
 **Superseded on the hashing row.** W2 re-measured this across all 314
-concurrent CORE tests rather than this one: hashing prunes on 62 of them and
-saves 16.5 % wall overall. `01_malloc_20` is an outlier, not a summary. It is
-also unsound on four of them — see W2.
+concurrent CORE tests rather than this one: hashing cuts schedules on 41 of
+them and saves ~12 % wall overall once its soundness bug is fixed.
+`01_malloc_20` is an outlier, not a summary — see W2.
 
 ### 2.2 The same reproducer under the SV-COMP flag shape
 
@@ -224,23 +224,44 @@ the §7 "re-truncation" failure mode, already shipped, and
 runs are exposed to it. A wrong `true` is scored far more harshly than an
 `unknown`, which makes this a bigger liability than any timeout W1–W3 address.
 
-Pinned by `regression/esbmc-unix/github_6831_hashing_unsound{,_mpor}`
-(KNOWNBUG, expecting the correct FAILED) so a fix flips them to CORE.
+**Root cause: the fingerprint omitted `active_thread`.** Dumping every
+fingerprint with its components on `race_guard_self_clear` showed three states
+sharing one hash with byte-identical value maps *and* identical pcs, differing
+only in `active=0` vs `active=1`. Equal pcs and equal values still leave two
+states scheduling differently — MPOR's dependency chain and
+`decide_ileave_direction`'s scan both key off which thread just ran — and
+`post_hash_collision_cleanup()` marks every switch from the survivor explored.
 
-Revised order:
+Two earlier hypotheses were tested and **rejected** before this one, and are
+recorded so they are not re-tried: the monotone `dynamic_counter` making
+post-`malloc` states unique (a controlled probe still pruned 76 states), and
+constant propagation hiding values from the map (`assigned_value` is never nil
+on `goto_symex_statet::assignment`'s path).
 
-1. **Diagnose the collision.** The hypothesis that the fingerprint is too
-   *fine* is now the wrong end: it is too *coarse* somewhere. Not yet located —
-   an allocation-naming hypothesis (the monotone `dynamic_counter` making
-   post-`malloc` states unique) was tested with a controlled probe and
-   **rejected**: the probe still pruned 76 states.
-2. **Fix or disable.** Until a fix exists, disabling `--state-hashing` in
-   `esbmc_dargs` is the sound choice, and costs the −16.5 % above.
-3. Only then revisit making it prune harder.
+Fixed by mixing `active_thread` into `generate_hash()`
+(`execution_state.cpp:1398`) — one line, and finer by construction, so it can
+only reduce pruning, never increase it.
 
-**Exit:** the four tests above pass with `--state-hashing`, or the flag is out
-of `esbmc_dargs`. Performance tuning of the fingerprint is not in scope until
-one of those holds.
+**Cost, same corpus re-measured against the fixed binary:**
+
+| | tests where hashing cuts schedules | verdict changes | wall |
+|---|---|---|---|
+| before fix | 62 of 314 | **4** | −16.5 % |
+| after fix | 41 of 314 | **0** | −12.0 % |
+
+The fix gives up some pruning and keeps most of it; the largest win is
+untouched (`11_cook.fig2.pldi07` 11,130 → 79 schedules either way). Schedule
+counts are deterministic so the 62 → 41 comparison is exact; the wall figures
+come from separate runs and carry ~10 % run-to-run noise, so read the sign, not
+the 4.5-point gap.
+
+All 287 registered regression tests that pass `--state-hashing` pass with the
+fix. `github_6831_hashing_unsound{,_mpor}` are CORE.
+
+**Exit: discharged.** Hashing is sound on this corpus and still pays for
+itself, so `--state-hashing` stays in `esbmc_dargs`. Making it prune *harder*
+is a separate question, and W1's levers look better-founded than another pass
+at the fingerprint.
 
 ### W3 — Stop redoing per-schedule work
 

--- a/regression/esbmc-unix/github_6831_hashing_sound/main.c
+++ b/regression/esbmc-unix/github_6831_hashing_sound/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <pthread.h>
+
+int x = 0;
+
+void *bump(void *arg)
+{
+  x++;
+  x++;
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t a, b;
+  pthread_create(&a, 0, bump, 0);
+  pthread_create(&b, 0, bump, 0);
+  pthread_join(a, 0);
+  pthread_join(b, 0);
+  assert(x == 4);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6831_hashing_sound/test.desc
+++ b/regression/esbmc-unix/github_6831_hashing_sound/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--state-hashing
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6831_hashing_unsound/main.c
+++ b/regression/esbmc-unix/github_6831_hashing_unsound/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <pthread.h>
+
+_Bool receive = 0;
+
+void *t1(void *arg)
+{
+  for (int i = 0; i < 2; i++)
+    if (receive)
+    {
+      assert(i < 1);
+      receive = 0;
+    }
+  return NULL;
+}
+
+int main()
+{
+  pthread_t id;
+  pthread_create(&id, NULL, t1, NULL);
+  receive = 1;
+  return 0;
+}

--- a/regression/esbmc-unix/github_6831_hashing_unsound/test.desc
+++ b/regression/esbmc-unix/github_6831_hashing_unsound/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --state-hashing
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/github_6831_hashing_unsound/test.desc
+++ b/regression/esbmc-unix/github_6831_hashing_unsound/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--state-hashing
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/github_6831_hashing_unsound_mpor/main.c
+++ b/regression/esbmc-unix/github_6831_hashing_unsound_mpor/main.c
@@ -1,0 +1,21 @@
+#include<pthread.h>
+#include<assert.h>
+#include<stdlib.h>
+void a(int b) {
+  if (!b)
+    abort();
+}
+int e, g = 0;
+void *thread2() {
+  a(e == 0);
+  if (g)
+    assert(0);
+  return NULL;
+}
+int main() {
+  pthread_t t,t1;
+  pthread_create(&t1, 0, thread2, 0);
+  e = 1;
+  g = 1;
+  return 0;
+}

--- a/regression/esbmc-unix/github_6831_hashing_unsound_mpor/test.desc
+++ b/regression/esbmc-unix/github_6831_hashing_unsound_mpor/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --state-hashing
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/github_6831_hashing_unsound_mpor/test.desc
+++ b/regression/esbmc-unix/github_6831_hashing_unsound_mpor/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--state-hashing
+^VERIFICATION FAILED$

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1394,7 +1394,15 @@ std::size_t execution_statet::generate_hash() const
   // separate those -- two calls from the same caller sit at equal depth -- so
   // each frame's calling location is mixed in. Without it a bug reachable only
   // past the later state is pruned away in silence.
+  //
+  // The active thread is part of it for the same reason: equal pcs and equal
+  // values still leave two states scheduling differently, because MPOR's
+  // dependency chain and decide_ileave_direction's scan both key off which
+  // thread just ran. Omitting it collided such pairs, and
+  // post_hash_collision_cleanup marks every switch from the survivor explored,
+  // so the violating schedule was never generated (#6831).
   std::size_t h = l2->generate_l2_state_hash();
+  esbmct::hash_combine(h, active_thread);
   for (const auto &it : threads_state)
   {
     esbmct::hash_combine(h, it.source.pc->location_number);


### PR DESCRIPTION
Four CORE tests whose `test.desc` expects `VERIFICATION FAILED` return `VERIFICATION SUCCESSFUL` when `--state-hashing` is added, on stock `master`: `00_mpor1`, `00_mpor2`, `race_guard_other_write`, `race_guard_self_clear`. The fingerprint collides two non-bisimilar states and `post_hash_collision_cleanup()` then marks every switch from that point explored, so the violating schedule is never generated — and `esbmc-wrapper.py:237` passes the flag in `esbmc_dargs`.

Two of them are pinned as KNOWNBUG (expecting the correct FAILED, so a fix flips them to CORE) plus one CORE test for a case where hashing is sound. The same corpus sweep refutes the premise W2 was written on — hashing prunes on 62 of 314 concurrent tests and saves 16.5% wall — so `docs/roadmap/svcomp-6831-schedule-space-plan.md` is updated with both results.

Stacked on #6861; base retargets to `master` once that merges. Refs #6831.