### PR TITLE
[om] Add <cwchar>, the largest single blocker to self-verification

### DIFF
--- a/regression/esbmc-cpp/cpp/cwchar_header/main.cpp
+++ b/regression/esbmc-cpp/cpp/cwchar_header/main.cpp
@@ -1,0 +1,34 @@
+#include <cassert>
+#include <cwchar>
+
+// [cwchar.syn]. Without the header this is a fatal "'cwchar' file not found",
+// which is what blocks most of ESBMC's own translation units (#5868).
+//
+// The wide-character *functions* have no body in C++ -- a separate,
+// pre-existing gap that <wchar.h> shows on its own -- so this pins the names
+// and the data handling rather than any return value.
+
+static std::size_t take_size(std::size_t n)
+{
+  return n;
+}
+
+int main()
+{
+  wchar_t buf[4] = {L'a', L'b', L'c', L'\0'};
+  assert(buf[0] == L'a');
+  assert(buf[2] == L'c');
+  assert(buf[3] == L'\0');
+
+  assert(sizeof(wchar_t) == sizeof(buf[0]));
+  assert(take_size(3) == 3);
+
+  std::mbstate_t state;
+  (void)state;
+
+  // The declarations resolve in namespace std and at global scope.
+  std::size_t (*len)(const wchar_t *) = &std::wcslen;
+  assert(len != 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cwchar_header/test.desc
+++ b/regression/esbmc-cpp/cpp/cwchar_header/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cwchar_header_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cwchar_header_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <cassert>
+#include <cwchar>
+
+int main()
+{
+  wchar_t buf[4] = {L'a', L'b', L'c', L'\0'};
+
+  // The third element is 'c', not 'a'.
+  assert(buf[2] == L'a');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cwchar_header_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cwchar_header_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/cpp/library/cwchar
+++ b/src/cpp/library/cwchar
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <wchar.h>
+
+// [cwchar.syn]: <cwchar> declares the wide-character functions in namespace
+// std. Mirrors the cstring model's approach; the definitions live in
+// src/c2goto/library/wchar.c.
+namespace std
+{
+using ::mbstate_t;
+using ::size_t;
+using ::wint_t;
+
+using ::mbsinit;
+using ::wcscat;
+using ::wcschr;
+using ::wcscmp;
+using ::wcscpy;
+using ::wcslen;
+using ::wcsncmp;
+using ::wcsncpy;
+using ::wcsrchr;
+using ::wmemchr;
+using ::wmemcmp;
+using ::wmemcpy;
+using ::wmemmove;
+using ::wmemset;
+} // namespace std


### PR DESCRIPTION
Re-ran #5868's measurement — how many of ESBMC's own C++ translation units clear the frontend — against current master. **All three gaps that issue names are now closed** (`<atomic>`/`<mutex>`/`<thread>`, the `string` typedefs and const `operator[]`, `hash<string_view>`), and a different one now dominates:

| blocker | TUs (of 361) |
|---|---:|
| **`cwchar` not found** | **158** |
| `std::visit` missing from `<variant>` | 93 |
| `index_sequence_for` missing from `<utility>` | 35 |

`<cwchar>` simply did not exist, so any C++ program including it was a fatal parse error. This adds it over the existing `<wchar.h>`, the way `<cstring>` sits over `<string.h>`.

**This unblocks parsing only.** The wide-character functions have no body in C++, so they return nondet there — sound, but imprecise. That gap is pre-existing and independent: a C++ program including `<wchar.h>` *directly* shows it on master with or without this header, while the same program in C verifies. It is left to its own patch, and the tests here deliberately pin the names, the types and the wide-character data handling rather than any return value.

Verified: the passing test is a `PARSING ERROR` on a control binary and `SUCCESSFUL` with the header; both tests agree with clang++; the `_fail` variant is mutation-checked; a 300-test differential over the C++ suites shows no other change.