### PR TITLE
[om] Add index_sequence_for to <utility>

### DIFF
--- a/regression/esbmc-cpp/cpp/index_sequence_for/main.cpp
+++ b/regression/esbmc-cpp/cpp/index_sequence_for/main.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+#include <utility>
+
+template <class... T>
+static constexpr std::size_t width(std::index_sequence_for<T...>)
+{
+  return sizeof...(T);
+}
+
+int main()
+{
+  // [intseq.general]: index_sequence_for<T...> is make_index_sequence<sizeof...(T)>.
+  std::index_sequence_for<int, char, long> three;
+  assert(three.size() == 3);
+
+  std::index_sequence_for<> none;
+  assert(none.size() == 0);
+
+  std::index_sequence_for<int> one;
+  assert(one.size() == 1);
+
+  // It really is the same type as the sequence it aliases.
+  std::make_index_sequence<3> made = three;
+  assert(made.size() == 3);
+
+  assert((width<int, char>(std::index_sequence_for<int, char>())) == 2);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/index_sequence_for/test.desc
+++ b/regression/esbmc-cpp/cpp/index_sequence_for/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/index_sequence_for_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/index_sequence_for_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <cassert>
+#include <utility>
+
+int main()
+{
+  std::index_sequence_for<int, char, long> s;
+
+  // The sequence has one index per type, so its size is 3.
+  assert(s.size() == 2);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/index_sequence_for_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/index_sequence_for_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/cpp/library/utility
+++ b/src/cpp/library/utility
@@ -280,6 +280,10 @@ using make_integer_sequence =
 
 template <size_t _Np>
 using make_index_sequence = make_integer_sequence<size_t, _Np>;
+
+// [intseq.general]: index_sequence_for<T...> is make_index_sequence<sizeof...(T)>.
+template <class... T>
+using index_sequence_for = make_index_sequence<sizeof...(T)>;
 #endif
 
 #if __cplusplus >= 202302L


### PR DESCRIPTION
[intseq.general] specifies `index_sequence_for<T...>` as `make_index_sequence<sizeof...(T)>`. The model already had `integer_sequence`, `index_sequence`, `make_integer_sequence` and `make_index_sequence` — just not this alias, so any header using it failed to parse.

It is the third-largest blocker in the #5868 self-verification measurement, at **35 of 361** translation units.

Verified: the passing test is a `PARSING ERROR` on a control binary and `SUCCESSFUL` with the alias; all five assertions agree with clang++; the `_fail` variant is mutation-checked; a 300-test differential over the C++ suites shows no other change.