### PR TITLE
[om] Add the reverse range accessors to <iterator>

### DIFF
--- a/regression/esbmc-cpp/cpp/iterator_rbegin/main.cpp
+++ b/regression/esbmc-cpp/cpp/iterator_rbegin/main.cpp
@@ -1,0 +1,30 @@
+#include <cassert>
+#include <iterator>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+
+  // [iterator.range]: rbegin walks the container backwards.
+  assert(*std::rbegin(v) == 3);
+
+  int n = 0, sum = 0;
+  for (auto i = std::rbegin(v); i != std::rend(v); ++i)
+  {
+    sum += *i;
+    n++;
+  }
+  assert(n == 3);
+  assert(sum == 6);
+
+  assert(*std::crbegin(v) == 3);
+
+  const std::vector<int> &cv = v;
+  assert(*std::rbegin(cv) == 3);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/iterator_rbegin/test.desc
+++ b/regression/esbmc-cpp/cpp/iterator_rbegin/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/iterator_rbegin_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/iterator_rbegin_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <iterator>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+
+  // rbegin starts at the last element, which is 3.
+  assert(*std::rbegin(v) == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/iterator_rbegin_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/iterator_rbegin_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8
+^VERIFICATION FAILED$

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -502,6 +502,48 @@ constexpr T *end(T (&arr)[N]) noexcept
 #endif
 
 #if __cplusplus >= 201402L
+// [iterator.range]: the reverse range accessors, alongside cbegin/cend below.
+template <class C>
+constexpr auto rbegin(C &c) -> decltype(c.rbegin())
+{
+  return c.rbegin();
+}
+
+template <class C>
+constexpr auto rbegin(const C &c) -> decltype(c.rbegin())
+{
+  return c.rbegin();
+}
+
+template <class C>
+constexpr auto rend(C &c) -> decltype(c.rend())
+{
+  return c.rend();
+}
+
+template <class C>
+constexpr auto rend(const C &c) -> decltype(c.rend())
+{
+  return c.rend();
+}
+
+/* No array overloads: std::reverse_iterator is declaration-only in this model
+ * (no constructors, no definitions), so reverse_iterator<T*>(arr + N) has
+ * nothing to construct from. The container overloads above forward to the
+ * container's own rbegin, which is implemented. */
+
+template <class C>
+constexpr auto crbegin(const C &c) -> decltype(std::rbegin(c))
+{
+  return std::rbegin(c);
+}
+
+template <class C>
+constexpr auto crend(const C &c) -> decltype(std::rend(c))
+{
+  return std::rend(c);
+}
+
 template <class C>
 constexpr auto cbegin(const C &c) noexcept(noexcept(std::begin(c)))
   -> decltype(std::begin(c))


### PR DESCRIPTION
[iterator.range] pairs `rbegin`/`rend`/`crbegin`/`crend` with the `begin`/`end` the model already had. Without them `std::rbegin` does not resolve — 7 of ESBMC's own translation units stop there (#5868).

The container overloads forward to the container's own `rbegin`, which is implemented in `vector`, `string` and friends.

**The array overloads are deliberately absent.** `std::reverse_iterator` in this model is declaration-only — every member declared, none defined, and no constructor at all — so `reverse_iterator<T*>(arr + N)` has nothing to construct from. I tried it, got `no matching conversion for functional-style cast from 'int *' to 'reverse_iterator<int *>'`, and removed the overloads rather than paper over it with a shim. That shell is its own gap, worth noting for anyone relying on `std::reverse_iterator` directly.

Verified: the passing test is a `PARSING ERROR` on a control binary and `SUCCESSFUL` here; all assertions agree with clang++; the `_fail` variant is mutation-checked; a 300-test differential over the C++ suites shows no other change.