### PR TITLE
[util] Fold constant typecasts in the IREP2 c_typecast overload

### DIFF
--- a/src/util/lang/c_typecast.cpp
+++ b/src/util/lang/c_typecast.cpp
@@ -969,6 +969,13 @@ void c_typecastt::do_typecast(expr2tc &dest, const type2tc &type)
 
   if (dest_type != type)
   {
+    // Fold a typecast of a constant, as the irept overload above does. Without
+    // this the two copies disagree on the commonest conversion a frontend
+    // performs -- storing a literal into a differently-typed lvalue leaves an
+    // unfolded typecast here but a folded constant there.
+    const bool fold = is_constant(dest) && !no_simplify;
     dest = typecast2tc(type, dest);
+    if (fold)
+      simplify(dest);
   }
 }

--- a/unit/util/c_typecast.test.cpp
+++ b/unit/util/c_typecast.test.cpp
@@ -20,6 +20,9 @@
 #include <util/config/config.h>
 #include <util/symtab/context.h>
 #include <util/symtab/namespace.h>
+#include <util/irep/migrate.h>
+#include <util/irep/std_expr.h>
+#include <util/arith/arith_tools.h>
 #include <irep2/irep2_utils.h>
 
 // get_c_type ranks an operand against config.ansi_c, which is zero-initialised
@@ -90,4 +93,113 @@ TEST_CASE("c_implicit_typecast converts an integer to double", "[c_typecast]")
   expr2tc e = gen_one(get_int32_type());
   REQUIRE_FALSE(c_implicit_typecast(e, double_type2(), ns));
   REQUIRE(is_floatbv_type(e->type));
+}
+
+// Differential harness. implicit_typecast_followed also exists twice, and the
+// two copies are not translations of each other: the irept one additionally
+// handles references, pointer-to-member, incomplete_array sources, qualifier
+// warnings and string-constant-to-array, none of which the expr2tc one has
+// (docs/roadmap/scope-coupled-arith-assign-conversion.md §20). Those gaps are
+// C++-frontend shaped; what follows pins the arithmetic and pointer conversions
+// that every frontend performs at an assignment, so a future edit to one copy
+// cannot silently drift from the other the way the floatbv omission above did.
+static void require_overloads_agree(
+  const namespacet &ns,
+  const exprt &input,
+  const typet &dest)
+{
+  // migrate_expr resolves symbol types through this thread-local, which only
+  // language_ui sets in a real run.
+  migrate_namespace_lookup = &ns;
+
+  exprt legacy = input;
+  const bool legacy_failed = c_implicit_typecast(legacy, dest, ns);
+
+  expr2tc native;
+  migrate_expr(input, native);
+  const bool native_failed =
+    c_implicit_typecast(native, migrate_type(dest), ns);
+
+  REQUIRE(legacy_failed == native_failed);
+
+  expr2tc legacy_migrated;
+  migrate_expr(legacy, legacy_migrated);
+  REQUIRE(legacy_migrated == native);
+}
+
+TEST_CASE(
+  "both c_implicit_typecast overloads agree on arithmetic conversions",
+  "[c_typecast]")
+{
+  contextt ctx;
+  namespacet ns(ctx);
+
+  SECTION("integer widens to double")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), double_type());
+  }
+
+  SECTION("integer widens to a wider integer")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), long_int_type());
+  }
+
+  SECTION("integer narrows to bool")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), bool_type());
+  }
+
+  // A non-constant source takes the unfolded route, so it covers the other
+  // side of the branch the constant sections above exercise.
+  SECTION("double narrows to integer")
+  {
+    require_overloads_agree(ns, symbol_exprt("d", double_type()), int_type());
+  }
+
+  SECTION("signed converts to unsigned of the same width")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), uint_type());
+  }
+}
+
+TEST_CASE(
+  "both c_implicit_typecast overloads agree on pointer conversions",
+  "[c_typecast]")
+{
+  contextt ctx;
+  namespacet ns(ctx);
+
+  // The two copies spell the null pointer differently -- the irept one builds a
+  // constant whose value is "NULL", the expr2tc one a symbol named "NULL" --
+  // and migrate_expr reconciles them (migrate.cpp:810). Left unpinned, a change
+  // to either spelling would go unnoticed until a frontend compared pointers.
+  SECTION("literal zero becomes the null pointer")
+  {
+    require_overloads_agree(
+      ns, from_integer(0, int_type()), pointer_typet(int_type()));
+  }
+
+  SECTION("pointer converts to void pointer")
+  {
+    require_overloads_agree(
+      ns,
+      symbol_exprt("p", pointer_typet(int_type())),
+      pointer_typet(empty_typet()));
+  }
+
+  SECTION("pointer converts to an unrelated pointer type")
+  {
+    require_overloads_agree(
+      ns,
+      symbol_exprt("p", pointer_typet(int_type())),
+      pointer_typet(char_type()));
+  }
+
+  SECTION("pointer conversion to its own type is a no-op")
+  {
+    require_overloads_agree(
+      ns,
+      symbol_exprt("p", pointer_typet(int_type())),
+      pointer_typet(int_type()));
+  }
 }


### PR DESCRIPTION
`c_typecastt::do_typecast` exists twice, written independently. The irept copy wraps the expression and then folds when the operand is constant; the expr2tc copy only wrapped:

```cpp
// irept
dest.make_typecast(type);
if (dest.op0().is_constant() && !no_simplify) { migrate -> simplify -> back; }

// expr2tc, before this PR
dest = typecast2tc(type, dest);
```

So storing a literal into a differently-typed lvalue produced a folded constant on one path and an unfolded `typecast` node on the other — the commonest conversion any frontend performs at an assignment. `int 1` to `int64` gave `constant_int 1:signedbv64` legacy, `typecast(constant_int 1:signedbv32)` native.

This is the second divergence found between these two copies, after the `floatbv` omission in `check_c_implicit_typecast` that this test file already documents, so the fix comes with a differential harness: both overloads run over the arithmetic and pointer conversions and the migrated results must be equal. The pointer sections also pin the two spellings of the null pointer, which `migrate_expr` reconciles.

Verified: 670/670 unit tests, 69/69 Python float tests, 103/103 interval and cast C tests, and 1841 core regression tests with no failures (the full core suite exceeds the local 5-minute cap; CI covers the rest).

Refs #4715
