### PR TITLE
[om] Add invoke_result to <type_traits>

### DIFF
--- a/regression/esbmc-cpp/cpp/invoke_result/main.cpp
+++ b/regression/esbmc-cpp/cpp/invoke_result/main.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+#include <type_traits>
+
+static int takes_int(int);
+static char takes_two(int, long);
+
+struct Functor
+{
+  double operator()(int) const;
+};
+
+int main()
+{
+  // [meta.trans.other]: invoke_result is the type of the call expression.
+  static_assert(std::is_same<std::invoke_result_t<decltype(takes_int), int>,
+                             int>::value, "int");
+  static_assert(std::is_same<std::invoke_result_t<decltype(takes_two), int, long>,
+                             char>::value, "char");
+  static_assert(std::is_same<std::invoke_result_t<Functor, int>,
+                             double>::value, "double");
+
+  auto lam = [](int x) { return x + 1; };
+  static_assert(std::is_same<std::invoke_result_t<decltype(lam), int>,
+                             int>::value, "lambda");
+
+  // The struct form agrees with the alias.
+  static_assert(std::is_same<std::invoke_result<Functor, int>::type,
+                             double>::value, "struct form");
+
+  // SFINAE-friendly: no member `type` when the call is ill-formed, so this
+  // does not hard-error.
+  static_assert(!std::is_invocable<decltype(takes_int), const char *>::value,
+                "not invocable");
+
+  int v = 1;
+  assert(v == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/invoke_result/test.desc
+++ b/regression/esbmc-cpp/cpp/invoke_result/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17 --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/invoke_result_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/invoke_result_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <type_traits>
+
+struct Functor
+{
+  double operator()(int) const;
+};
+
+int main()
+{
+  // invoke_result_t<Functor, int> is double, so this comparison is false.
+  bool same = std::is_same<std::invoke_result_t<Functor, int>, int>::value;
+  assert(same);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/invoke_result_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/invoke_result_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17 --unwind 4
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -766,6 +766,36 @@ struct is_invocable_r : decltype(detail::test_invocable_r<R, F, Args...>(0))
 {
 };
 
+namespace detail
+{
+// SFINAE-friendly per [meta.trans.other]: no member `type` when the call is
+// ill-formed, so invoke_result can appear in a deduction context without
+// hard-erroring.
+template <class Void, class F, class... Args>
+struct invoke_result_impl
+{
+};
+
+template <class F, class... Args>
+struct invoke_result_impl<
+  void_t<decltype(declval<F>()(declval<Args>()...))>,
+  F,
+  Args...>
+{
+  using type = decltype(declval<F>()(declval<Args>()...));
+};
+} // namespace detail
+
+// invoke_result. Only the plain call form of INVOKE is modelled, matching
+// is_invocable above; pointer-to-member callables are out of scope.
+template <class F, class... Args>
+struct invoke_result : detail::invoke_result_impl<void, F, Args...>
+{
+};
+
+template <class F, class... Args>
+using invoke_result_t = typename invoke_result<F, Args...>::type;
+
 // is_convertible (simplified)
 namespace detail
 {


### PR DESCRIPTION
`is_invocable` and `is_invocable_r` were already modelled, but not the trait that reports *what the call returns*, so a header naming `invoke_result_t` failed to parse. It is 5 of 361 translation units in the #5868 self-verification measurement.

Built on the `declval` machinery already in the header, and made SFINAE-friendly per [meta.trans.other] — no member `type` when the call is ill-formed — so it can appear in a deduction context without hard-erroring. Only the plain call form of INVOKE is modelled, matching the existing `is_invocable`; pointer-to-member callables stay out of scope.

Verified: the passing test is a `PARSING ERROR` on a control binary and `SUCCESSFUL` here; its six `static_assert`s compile and hold under clang++; the `_fail` variant is mutation-checked; a 300-test differential over the C++ suites shows no other change.