### PR TITLE
[regression] Pin the plain malloc(0)-then-free shape of #6593

### DIFF
--- a/regression/esbmc/github_6593/main.c
+++ b/regression/esbmc/github_6593/main.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+
+/* Under --malloc-zero-is-null the constant-size fast path returned the NULL
+ * symbol without assigning it, so p kept an unconstrained value and free(p)
+ * was reported as an invalid free. Unlike github_5398 there is no assume
+ * here: this is the plain shape, where nothing constrains p but the call. */
+int main(void)
+{
+  void *p = malloc(0);
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/github_6593/test.desc
+++ b/regression/esbmc/github_6593/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_6593_fail/main.c
+++ b/regression/esbmc/github_6593_fail/main.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+
+int main(void)
+{
+  void *p = malloc(0);
+  free(p);
+
+  /* malloc(0) is NULL under this flag, so asserting otherwise must be
+   * reported -- if p were unconstrained again this would silently pass. */
+  __ESBMC_assert(p != 0, "malloc(0) is not NULL");
+  return 0;
+}

--- a/regression/esbmc/github_6593_fail/test.desc
+++ b/regression/esbmc/github_6593_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --malloc-zero-is-null
+^VERIFICATION FAILED$


### PR DESCRIPTION
**#6593 no longer reproduces** — #6793 fixed it along with #5398. Verified both directions against a pre-#6793 binary:

| | control (pre-#6793) | master |
|---|---|---|
| `--malloc-zero-is-null` | `invalid pointer freed`, FAILED | SUCCESSFUL |
| without the flag | SUCCESSFUL | SUCCESSFUL |

which is exactly the table in the issue.

The suite does not pin that shape, though. `github_5398` covers #5398's version — `malloc(0)`, *assume the result is non-null*, `free` — while #6593's is the plain one with nothing constraining the pointer, and that is the one that regressed: the destination kept an unconstrained value.

- the passing test **fails on the pre-#6793 binary** and passes now, so it pins the fix rather than the status quo
- the negative test pins that `malloc(0)` is NULL under the flag; it is mutation-checked by dropping the flag, which makes it fail

Tests only — no source change. **#6593 can be closed once this lands.**