### PR TITLE
[regression] Pin the closure capture gap of #6256 and what already works

### DIFF
--- a/regression/python/github_6256_closure_capture/main.py
+++ b/regression/python/github_6256_closure_capture/main.py
@@ -1,0 +1,16 @@
+# A closure that escapes its defining scope: make_adder returns add, which
+# captures n. Calling it must yield 8. ESBMC currently leaves the call
+# unconstrained -- n is not bound -- so both `== 8` and `== 3` are refutable
+# (#6256). Same root cause as #6640: function values are static aliases, so
+# there is no environment to carry n out of make_adder.
+
+
+def make_adder(n):
+    def add(x):
+        return x + n
+
+    return add
+
+
+add5 = make_adder(5)
+assert add5(3) == 8

--- a/regression/python/github_6256_closure_capture/test.desc
+++ b/regression/python/github_6256_closure_capture/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6256_closure_no_capture/main.py
+++ b/regression/python/github_6256_closure_no_capture/main.py
@@ -1,0 +1,25 @@
+# The part of #6256 that already works: a nested function that escapes but
+# captures nothing, and one that captures but is called before escaping.
+# Pinning these keeps the closure fix honest -- it must not regress what the
+# frontend already models.
+
+
+def outer():
+    def inner(x):
+        return x + 1
+
+    return inner
+
+
+f = outer()
+assert f(3) == 4
+
+
+def applied(n):
+    def add(x):
+        return x + n
+
+    return add(3)
+
+
+assert applied(5) == 8

--- a/regression/python/github_6256_closure_no_capture/test.desc
+++ b/regression/python/github_6256_closure_no_capture/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
#6256 reads as a typing fault — its counterexample is `return_value$ == (double)8`. Measuring it instead:

| assertion on `make_adder(5)(3)` | verdict |
|---|---|
| `== 8` | FAILED |
| `== 3` (n treated as 0) | FAILED |
| `r == 8 or r != 8` | **SUCCESSFUL** |

Both concrete values are refutable while the tautology verifies, so the call is **entirely unconstrained** — the captured `n` is not bound at all, rather than bound and mis-typed. That places it with #6640 (function values are static aliases only): nothing carries an environment out of `make_adder`, so this needs closure objects rather than a fix to type inference.

Tests only:
- **KNOWNBUG** for the escaping closure, so it flips to CORE when that lands
- **CORE** for the two shapes that already work — a nested function that escapes capturing nothing, and one that captures but is called before escaping — so a closure implementation cannot regress them unnoticed

Both files exit 0 under CPython, and `scripts/check_python_tests.sh` passes.