### PR TITLE
[python] Fold sorted() over tuples carrying a string

### DIFF
--- a/regression/python/sorted_tuple_str_component/main.py
+++ b/regression/python/sorted_tuple_str_component/main.py
@@ -1,0 +1,18 @@
+# Sorting by a string key, where string order differs from insertion order.
+v = sorted([("pear", 1), ("apple", 2), ("fig", 3)])
+assert v[0][0] == "apple"
+assert v[1][0] == "fig"
+assert v[2][0] == "pear"
+assert v[0][1] == 2
+
+# Tie on the first component: the second decides.
+w = sorted([("a", 2), ("a", 1)])
+assert w[0][1] == 1 and w[1][1] == 2
+
+# Integer first component still orders numerically, not lexically.
+u = sorted([(10, "x"), (9, "y")])
+assert u[0][0] == 9 and u[1][0] == 10
+
+# reverse= still applies.
+r = sorted([(1, "a"), (2, "b")], reverse=True)
+assert r[0][0] == 2

--- a/regression/python/sorted_tuple_str_component/test.desc
+++ b/regression/python/sorted_tuple_str_component/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted_tuple_str_component_fail/main.py
+++ b/regression/python/sorted_tuple_str_component_fail/main.py
@@ -1,0 +1,4 @@
+v = sorted([("pear", 1), ("apple", 2)])
+
+# "apple" sorts before "pear", so the first row is the apple one.
+assert v[0][0] == "pear"

--- a/regression/python/sorted_tuple_str_component_fail/test.desc
+++ b/regression/python/sorted_tuple_str_component_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4197,9 +4197,63 @@ std::optional<exprt> function_call_expr::fold_sorted_constant_tuples(
     return false;
   };
 
+  // A Python str component is a char array, so its constant form is an array
+  // of character constants. Reading it lets a tuple carrying a string be
+  // folded here instead of falling through to the runtime sort model, which
+  // retypes elements as int (#6883).
+  std::function<bool(const exprt &, std::string &)> eval_const_str =
+    [&](const exprt &e, std::string &out) -> bool {
+    if (e.is_symbol())
+    {
+      const symbolt *sym = converter_.find_symbol(e.identifier().as_string());
+      return sym && eval_const_str(sym->get_value(), out);
+    }
+    if (e.id() == "typecast" && e.operands().size() == 1)
+      return eval_const_str(e.op0(), out);
+    if (!e.type().is_array())
+      return false;
+    const typet &elt = e.type().subtype();
+    const bool byte_elt =
+      (elt.is_signedbv() && to_signedbv_type(elt).get_width() == 8) ||
+      (elt.is_unsignedbv() && to_unsignedbv_type(elt).get_width() == 8);
+    if (!byte_elt || e.operands().empty())
+      return false;
+    out.clear();
+    for (const exprt &c : e.operands())
+    {
+      if (!c.is_constant())
+        return false;
+      BigInt v =
+        binary2integer(to_constant_expr(c).value().c_str(), c.type().is_signedbv());
+      if (v == 0)
+        break;
+      out.push_back(static_cast<char>(v.to_int64()));
+    }
+    return true;
+  };
+
+  // One tuple component: an integer or a string. Python orders tuples
+  // lexicographically and refuses to compare an int with a str, so a column
+  // that mixes the two makes the whole list unfoldable here.
+  struct comp_key
+  {
+    bool is_str = false;
+    BigInt i;
+    std::string s;
+
+    bool operator<(const comp_key &o) const
+    {
+      return is_str ? s < o.s : i < o.i;
+    }
+    bool operator==(const comp_key &o) const
+    {
+      return is_str == o.is_str && (is_str ? s == o.s : i == o.i);
+    }
+  };
+
   struct sortable_tuple
   {
-    std::vector<BigInt> key;
+    std::vector<comp_key> key;
     size_t pos;
   };
   std::vector<sortable_tuple> telems;
@@ -4234,16 +4288,33 @@ std::optional<exprt> function_call_expr::fold_sorted_constant_tuples(
       all_constant_tuples = false;
       break;
     }
-    std::vector<BigInt> key;
+    std::vector<comp_key> key;
     for (const auto &comp : val.operands())
     {
+      comp_key k;
       BigInt v;
-      if (!eval_const_int(comp, v))
+      std::string t;
+      if (eval_const_int(comp, v))
+        k.i = v;
+      else if (eval_const_str(comp, t))
+      {
+        k.is_str = true;
+        k.s = t;
+      }
+      else
       {
         all_constant_tuples = false;
         break;
       }
-      key.push_back(v);
+      // Python raises TypeError comparing int with str, so a column that is
+      // not uniformly one or the other must not be folded.
+      if (!telems.empty() && key.size() < telems[0].key.size() &&
+          telems[0].key[key.size()].is_str != k.is_str)
+      {
+        all_constant_tuples = false;
+        break;
+      }
+      key.push_back(k);
     }
     if (!all_constant_tuples)
       break;
@@ -4273,8 +4344,19 @@ std::optional<exprt> function_call_expr::fold_sorted_constant_tuples(
       tup["_type"] = "Tuple";
       tup["elts"] = nlohmann::json::array();
       converter_.copy_location_fields_from_decl(call_, tup);
-      for (const BigInt &v : te.key)
+      for (const comp_key &ck : te.key)
       {
+        if (ck.is_str)
+        {
+          nlohmann::json scst;
+          scst["_type"] = "Constant";
+          scst["value"] = ck.s;
+          scst["kind"] = nullptr;
+          converter_.copy_location_fields_from_decl(call_, scst);
+          tup["elts"].push_back(scst);
+          continue;
+        }
+        const BigInt &v = ck.i;
         // Mirror the parser's literal shape: a negative integer is
         // UnaryOp(USub, Constant(|v|)), not Constant(-v). A bare
         // negative Constant nested in a tuple takes a slow conversion

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4157,6 +4157,72 @@ std::optional<exprt> function_call_expr::fold_sorted_int_list(
   return std::nullopt;
 }
 
+/// Fold a constant integer component, following symbols, unary minus and
+/// widening typecasts.
+bool function_call_expr::eval_const_int(const exprt &e, BigInt &out) const
+{
+  if (
+    e.is_constant() &&
+    (e.type().is_signedbv() || e.type().is_unsignedbv() || e.is_boolean()))
+  {
+    out = binary2integer(
+      to_constant_expr(e).value().c_str(), e.type().is_signedbv());
+    return true;
+  }
+  if (e.is_symbol())
+  {
+    const symbolt *s = converter_.find_symbol(e.identifier().as_string());
+    return s && eval_const_int(s->get_value(), out);
+  }
+  // A negative literal reaches here as unary-minus over a constant
+  // (the parser emits UnaryOp(USub, Constant(n))); a widened literal
+  // as a typecast. Fold both.
+  if (e.id() == "unary-" && e.operands().size() == 1)
+  {
+    if (!eval_const_int(e.op0(), out))
+      return false;
+    out = -out;
+    return true;
+  }
+  if (e.id() == "typecast" && e.operands().size() == 1)
+    return eval_const_int(e.op0(), out);
+  return false;
+}
+
+/// Fold a constant str component. A Python str is a char array, so its
+/// constant form is an array of character constants (#6883).
+bool function_call_expr::eval_const_str(const exprt &e, std::string &out)
+  const
+{
+  if (e.is_symbol())
+  {
+    const symbolt *sym = converter_.find_symbol(e.identifier().as_string());
+    return sym && eval_const_str(sym->get_value(), out);
+  }
+  if (e.id() == "typecast" && e.operands().size() == 1)
+    return eval_const_str(e.op0(), out);
+  if (!e.type().is_array())
+    return false;
+  const typet &elt = e.type().subtype();
+  const bool byte_elt =
+    (elt.is_signedbv() && to_signedbv_type(elt).get_width() == 8) ||
+    (elt.is_unsignedbv() && to_unsignedbv_type(elt).get_width() == 8);
+  if (!byte_elt || e.operands().empty())
+    return false;
+  out.clear();
+  for (const exprt &c : e.operands())
+  {
+    if (!c.is_constant())
+      return false;
+    BigInt v = binary2integer(
+      to_constant_expr(c).value().c_str(), c.type().is_signedbv());
+    if (v == 0)
+      break;
+    out.push_back(static_cast<char>(v.to_int64()));
+  }
+  return true;
+}
+
 std::optional<exprt> function_call_expr::fold_sorted_constant_tuples(
   const std::string &list_id,
   size_t map_size,
@@ -4167,70 +4233,11 @@ std::optional<exprt> function_call_expr::fold_sorted_constant_tuples(
   // elements as int; sort here at convert time and rebuild a list of
   // tuple literals so the element type is preserved and verification is
   // cheap. Symbolic tuple lists fall through (still unsupported).
-  std::function<bool(const exprt &, BigInt &)> eval_const_int =
-    [&](const exprt &e, BigInt &out) -> bool {
-    if (
-      e.is_constant() &&
-      (e.type().is_signedbv() || e.type().is_unsignedbv() || e.is_boolean()))
-    {
-      out = binary2integer(
-        to_constant_expr(e).value().c_str(), e.type().is_signedbv());
-      return true;
-    }
-    if (e.is_symbol())
-    {
-      const symbolt *s = converter_.find_symbol(e.identifier().as_string());
-      return s && eval_const_int(s->get_value(), out);
-    }
-    // A negative literal reaches here as unary-minus over a constant
-    // (the parser emits UnaryOp(USub, Constant(n))); a widened literal
-    // as a typecast. Fold both.
-    if (e.id() == "unary-" && e.operands().size() == 1)
-    {
-      if (!eval_const_int(e.op0(), out))
-        return false;
-      out = -out;
-      return true;
-    }
-    if (e.id() == "typecast" && e.operands().size() == 1)
-      return eval_const_int(e.op0(), out);
-    return false;
-  };
 
   // A Python str component is a char array, so its constant form is an array
   // of character constants. Reading it lets a tuple carrying a string be
   // folded here instead of falling through to the runtime sort model, which
   // retypes elements as int (#6883).
-  std::function<bool(const exprt &, std::string &)> eval_const_str =
-    [&](const exprt &e, std::string &out) -> bool {
-    if (e.is_symbol())
-    {
-      const symbolt *sym = converter_.find_symbol(e.identifier().as_string());
-      return sym && eval_const_str(sym->get_value(), out);
-    }
-    if (e.id() == "typecast" && e.operands().size() == 1)
-      return eval_const_str(e.op0(), out);
-    if (!e.type().is_array())
-      return false;
-    const typet &elt = e.type().subtype();
-    const bool byte_elt =
-      (elt.is_signedbv() && to_signedbv_type(elt).get_width() == 8) ||
-      (elt.is_unsignedbv() && to_unsignedbv_type(elt).get_width() == 8);
-    if (!byte_elt || e.operands().empty())
-      return false;
-    out.clear();
-    for (const exprt &c : e.operands())
-    {
-      if (!c.is_constant())
-        return false;
-      BigInt v =
-        binary2integer(to_constant_expr(c).value().c_str(), c.type().is_signedbv());
-      if (v == 0)
-        break;
-      out.push_back(static_cast<char>(v.to_int64()));
-    }
-    return true;
-  };
 
   // One tuple component: an integer or a string. Python orders tuples
   // lexicographically and refuses to compare an int with a str, so a column

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4191,8 +4191,7 @@ bool function_call_expr::eval_const_int(const exprt &e, BigInt &out) const
 
 /// Fold a constant str component. A Python str is a char array, so its
 /// constant form is an array of character constants (#6883).
-bool function_call_expr::eval_const_str(const exprt &e, std::string &out)
-  const
+bool function_call_expr::eval_const_str(const exprt &e, std::string &out) const
 {
   if (e.is_symbol())
   {
@@ -4234,14 +4233,8 @@ std::optional<exprt> function_call_expr::fold_sorted_constant_tuples(
   // tuple literals so the element type is preserved and verification is
   // cheap. Symbolic tuple lists fall through (still unsupported).
 
-  // A Python str component is a char array, so its constant form is an array
-  // of character constants. Reading it lets a tuple carrying a string be
-  // folded here instead of falling through to the runtime sort model, which
-  // retypes elements as int (#6883).
-
-  // One tuple component: an integer or a string. Python orders tuples
-  // lexicographically and refuses to compare an int with a str, so a column
-  // that mixes the two makes the whole list unfoldable here.
+  // One tuple component: an integer or a string, ordered as Python orders
+  // tuples, lexicographically component by component.
   struct comp_key
   {
     bool is_str = false;
@@ -4315,8 +4308,9 @@ std::optional<exprt> function_call_expr::fold_sorted_constant_tuples(
       }
       // Python raises TypeError comparing int with str, so a column that is
       // not uniformly one or the other must not be folded.
-      if (!telems.empty() && key.size() < telems[0].key.size() &&
-          telems[0].key[key.size()].is_str != k.is_str)
+      if (
+        !telems.empty() && key.size() < telems[0].key.size() &&
+        telems[0].key[key.size()].is_str != k.is_str)
       {
         all_constant_tuples = false;
         break;

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -50,6 +50,13 @@ public:
 private:
   friend class function_call_expr_test_access;
 
+  /// Fold a constant integer component of a tuple being sorted at convert
+  /// time; follows symbols, unary minus and widening typecasts.
+  bool eval_const_int(const exprt &e, BigInt &out) const;
+
+  /// Fold a constant str component of such a tuple (#6883).
+  bool eval_const_str(const exprt &e, std::string &out) const;
+
   /*
   * Check if the current function call is to math.comb() function
   * Returns true if this is a call to math.comb


### PR DESCRIPTION
```python
v = sorted([(2, "b"), (1, "a")])
assert v[0][0] == 1     # ERROR: TypeError: 'int' object is not subscriptable
```

`fold_sorted_constant_tuples` read components with `eval_const_int` only, so a tuple holding a string fell past it onto the runtime tuple-sort model — which, as that fold's own comment says, *retypes elements as int*. Indexing the result then failed. Integer tuples folded fine, and the same list unsorted indexed fine, which is why this looked like a typing fault.

The fix reads a constant `str` component too (a `str` is a char array here) and keys on either kind, comparing lexicographically as Python does. **A column that mixes int and str is deliberately left unfolded** — Python raises `TypeError` comparing them, and `sorted_mixed_key_fail` pins that diagnostic; folding it would have replaced a correct error with a made-up order.

Found by differentially testing the Python frontend against CPython. Verified beyond the reproducer: ordering by a string key, tie-breaking on the second component, integer components still ordering numerically rather than lexically, and `reverse=` — all agreeing with CPython and all failing on a control binary. The five existing tuple-sort tests still pass, `sorted_mixed_key_fail` included.

Supersedes the `sorted` half of #6883, whose KNOWNBUG for this shape I am dropping there.