### PR TITLE
[python] Let a constructor temporary's own method win over the dict one

### DIFF
--- a/regression/python/method_on_constructor_temporary/main.py
+++ b/regression/python/method_on_constructor_temporary/main.py
@@ -1,0 +1,42 @@
+# A method called on a constructor temporary. When its name collides with a
+# dict or list method the call used to be claimed by the container handler,
+# which then failed looking the class up as a dict variable. A non-colliding
+# name (value) never came through that path, and a named receiver resolves its
+# type, so only this shape was affected.
+
+
+class C:
+    def get(self):
+        return 7
+
+    def pop(self):
+        return 8
+
+    def update(self):
+        return 9
+
+    def clear(self):
+        return 10
+
+    def value(self):
+        return 11
+
+
+assert C().get() == 7
+assert C().pop() == 8
+assert C().update() == 9
+assert C().clear() == 10
+assert C().value() == 11
+
+# A named receiver keeps working.
+c = C()
+assert c.get() == 7
+
+# Real containers still reach their own methods.
+d = {"a": 1}
+assert d.get("a") == 1
+assert d.get("z", 9) == 9
+
+v = [1, 2]
+assert v.pop() == 2
+assert len(v) == 1

--- a/regression/python/method_on_constructor_temporary/test.desc
+++ b/regression/python/method_on_constructor_temporary/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/method_on_constructor_temporary_fail/main.py
+++ b/regression/python/method_on_constructor_temporary_fail/main.py
@@ -1,0 +1,7 @@
+class C:
+    def get(self):
+        return 7
+
+
+# C().get() calls the class's own method, which returns 7.
+assert C().get() == 8

--- a/regression/python/method_on_constructor_temporary_fail/test.desc
+++ b/regression/python/method_on_constructor_temporary_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -1887,6 +1887,13 @@ bool function_call_expr::receiver_is_non_dict_object() const
     return !cls.empty() && cls != "__python_dict__";
   }
 
+  // A constructor call as the receiver (`C().get()`) is a class instance, so
+  // the class's own method must win over the same-named dict method. Without
+  // this the dict handler claims the call and then fails looking `C` up as a
+  // dict variable. Only the name collides -- `C().value()` never came here.
+  if (node_type_of(recv) == "Call")
+    return type_handler_.is_constructor_call(recv);
+
   if (recv["_type"] != "Name" || !recv.contains("id"))
     return false;
 


### PR DESCRIPTION
```python
class C:
    def get(self):
        return 7

assert C().get() == 7     # ERROR: Dictionary variable not found: C
```

`is_dict_method_call` already defers to instance dispatch when the receiver resolves to a non-dict object — its comment says so explicitly — but `receiver_is_non_dict_object` only inspected `Name` and `Attribute` receivers. A **constructor call** receiver fell through as "not a non-dict object", so the dict handler claimed the call and then failed looking `C` up as a dict variable.

The failure depends entirely on the *name*:

| call | before |
|---|---|
| `C().value()` | works — never reached this path |
| `C().get()` / `C().pop()` | `Dictionary variable not found: C` |
| `c.get()` via a named receiver | works — the receiver resolves its type |

Found by differentially testing the Python frontend against CPython.

Verified: `get`, `pop`, `update` and `clear` on a constructor temporary all agree with CPython now; real `dict.get`, a dict *literal*'s `.get`, and `list.pop` are unchanged; 40 tests using those four method names pass.

One scare worth recording: `del_list_slice` looked like a regression until I re-ran it — it needs ~14s of BMC and my harness timeout was too tight. It passes with a realistic one, and on the control.