### PR TITLE
[python] Size a dict literal with the dict handler, not strlen

### DIFF
--- a/regression/python/len_of_dict_literal/main.py
+++ b/regression/python/len_of_dict_literal/main.py
@@ -1,0 +1,16 @@
+# len() of a dict literal used to fall through to strlen over the dict struct
+# and report a wrong size. A dict bound to a name was never affected: it
+# reaches the dict-aware path by type. List and tuple literals were already
+# routed correctly.
+
+assert len({"a": 1, "b": 2}) == 2
+assert len({"a": 1}) == 1
+assert len({}) == 0
+
+d = {"a": 1, "b": 2}
+assert len(d) == 2
+
+assert len(dict(a=1, b=2)) == 2
+assert len([1, 2, 3]) == 3
+assert len((1, 2)) == 2
+assert len("abc") == 3

--- a/regression/python/len_of_dict_literal/test.desc
+++ b/regression/python/len_of_dict_literal/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/len_of_dict_literal_fail/main.py
+++ b/regression/python/len_of_dict_literal_fail/main.py
@@ -1,0 +1,2 @@
+# The literal holds two entries, so its length is 2.
+assert len({"a": 1, "b": 2}) == 3

--- a/regression/python/len_of_dict_literal_fail/test.desc
+++ b/regression/python/len_of_dict_literal_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -142,8 +142,7 @@ bool function_call_builder::is_len_call(const symbol_id &function_id) const
 
 /// True when @p arg is `name[...]` whose slice node is of kind @p slice_kind
 /// and whose base is a plain Name; the caller then tests that name's type.
-static bool
-is_name_subscript(const nlohmann::json &arg, const char *slice_kind)
+static bool is_name_subscript(const nlohmann::json &arg, const char *slice_kind)
 {
   return arg["_type"] == "Subscript" && arg.contains("slice") &&
          arg["slice"].is_object() &&

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -426,6 +426,18 @@ symbol_id function_call_builder::build_function_id() const
     }
     else if (arg["_type"] == "List")
       func_name = kGetObjectSize;
+    else if (arg["_type"] == "Dict")
+    {
+      // len({"a": 1}) -- a dict literal is dict-typed just as dict(...) is,
+      // so it needs the same size handler. Without this it fell to strlen over
+      // the dict struct and reported a wrong size; a dict bound to a name was
+      // never affected, because it reaches the dict-aware path by type.
+      func_name = "__ESBMC_len_dict";
+      function_id.clear();
+      function_id.set_prefix("esbmc:");
+      function_id.set_function(func_name);
+      return function_id;
+    }
     else if (
       arg["_type"] == "Subscript" && arg.contains("slice") &&
       arg["slice"].is_object() && arg["slice"].value("_type", "") == "Slice" &&

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -140,6 +140,18 @@ bool function_call_builder::is_len_call(const symbol_id &function_id) const
   return func_name == kGetObjectSize || func_name == kStrlen;
 }
 
+/// True when @p arg is `name[...]` whose slice node is of kind @p slice_kind
+/// and whose base is a plain Name; the caller then tests that name's type.
+static bool
+is_name_subscript(const nlohmann::json &arg, const char *slice_kind)
+{
+  return arg["_type"] == "Subscript" && arg.contains("slice") &&
+         arg["slice"].is_object() &&
+         arg["slice"].value("_type", "") == slice_kind &&
+         arg.contains("value") && arg["value"].is_object() &&
+         arg["value"].value("_type", "") == "Name";
+}
+
 symbol_id function_call_builder::build_function_id() const
 {
   const std::string &python_file = converter_.python_file();
@@ -439,10 +451,7 @@ symbol_id function_call_builder::build_function_id() const
       return function_id;
     }
     else if (
-      arg["_type"] == "Subscript" && arg.contains("slice") &&
-      arg["slice"].is_object() && arg["slice"].value("_type", "") == "Slice" &&
-      arg.contains("value") && arg["value"].is_object() &&
-      arg["value"].value("_type", "") == "Name" &&
+      is_name_subscript(arg, "Slice") &&
       th.get_var_type(arg["value"]["id"].get<std::string>()) == "bytes")
     {
       // Inline len(b[a:b]) where b is bytes: the slice is a wide-int array, so
@@ -452,10 +461,7 @@ symbol_id function_call_builder::build_function_id() const
       func_name = kGetObjectSize;
     }
     else if (
-      arg["_type"] == "Subscript" && arg.contains("slice") &&
-      arg["slice"].is_object() && arg["slice"].value("_type", "") == "List" &&
-      arg.contains("value") && arg["value"].is_object() &&
-      arg["value"].value("_type", "") == "Name" &&
+      is_name_subscript(arg, "List") &&
       th.get_var_type(arg["value"]["id"].get<std::string>()) != "str")
     {
       // len(a[[0, 2]]): fancy indexing always selects multiple elements into


### PR DESCRIPTION
```python
assert len({"a": 1, "b": 2}) == 2     # FAILED
```

`len()` routes its argument by syntactic kind: a `List` literal and the `range()`, `set()` and `dict()` calls each get a size handler, and everything else falls to `strlen`. A **`Dict` literal had no case**, so it ran `strlen` over the dict struct.

What hid it is that only the literal form is affected:

| expression | before |
|---|---|
| `len({"a": 1, "b": 2})` | wrong size |
| `d = {...}; len(d)` | correct — reaches the dict-aware path by type |
| `len(dict(a=1, b=2))` | correct — the `dict()` call already had a case |
| `len([1, 2, 3])`, `len((1, 2))` | correct |

Found while testing #6892, where it surfaced as an unrelated-looking failure in a combined test; it reproduces identically without that change, so it is fixed here on its own.

Verified against CPython for two-entry, one-entry and empty literals, with the named-dict, `dict(...)`, list, tuple and str forms unchanged. 24 dict tests pass; three `NORESULT`s are identical on a control binary (slow, not regressions). This replaces the KNOWNBUG that #6892 adds for the same shape — that pin should be dropped when this lands.