### PR TITLE
[clang-c] Add an inert IREP2 adjuster walk behind a flag

### DIFF
--- a/src/clang-c-frontend/CMakeLists.txt
+++ b/src/clang-c-frontend/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(clangcfrontend_stuff clang_c_language.cpp clang_c_convert.cpp
             clang_c_main.cpp clang_c_adjust_expr.cpp typecast.cpp clang_c_adjust_code.cpp
             clang_c_convert_literals.cpp clang_headers.cpp padding.cpp
             clang_c_adjust_polymorphic_functions.cpp nested_func_transform.cpp
-            clang_c_lexer.cpp clang_ast_dump.cpp)
+            clang_c_lexer.cpp clang_ast_dump.cpp clang_c_adjust_irep2.cpp)
 target_include_directories(clangcfrontend_stuff
     PRIVATE ${CMAKE_BINARY_DIR}/src
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -1,0 +1,29 @@
+#include <clang-c-frontend/clang_c_adjust_irep2.h>
+
+bool clang_c_adjust_irep2::adjust()
+{
+  // Hash-table iterators are not stable across mutation, so snapshot the
+  // symbol pointers first (mirrors clang_c_adjust::adjust()).
+  std::vector<symbolt *> symbol_list;
+  context.Foreach_operand_in_order(
+    [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
+
+  for (symbolt *s : symbol_list)
+  {
+    if (!s->is_type && s->get_value().is_not_nil())
+    {
+      expr2tc value = s->get_value2();
+      adjust_expr(value);
+    }
+  }
+
+  return false;
+}
+
+void clang_c_adjust_irep2::adjust_expr(expr2tc &expr)
+{
+  if (is_nil_expr(expr))
+    return;
+
+  expr->Foreach_operand([this](expr2tc &op) { adjust_expr(op); });
+}

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <util/symtab/context.h>
+#include <irep2/irep2.h>
+
+/// Phase 6 (C.3) IREP2-native adjuster for the C frontend.
+///
+/// The eventual replacement for `clang_c_adjust`, following the shape
+/// `python_adjust` established (docs/roadmap/scope-clang-c-irep2.md §6): an
+/// in-place recursive walk over `expr2tc` rather than the converter's
+/// out-parameter seam.
+///
+/// At this stage the walk is deliberately **read-only**: it reads each code
+/// symbol's IREP2 value and recurses, and never writes one back. That keeps the
+/// pass inert by construction rather than by argument -- there is no write path
+/// to be wrong -- while still exercising `migrate_expr` over every construct the
+/// C corpus contains, since `symbolt::get_value2()` migrates the legacy value on
+/// demand. A construct that cannot migrate aborts here instead of much later.
+///
+/// Read-only also side-steps the round-trip losses `python_adjust` documents
+/// (a bitfield's `#bitfield` flag, an explicit alignment attribute): those only
+/// matter to a write-back, and C headers are exactly the place they occur.
+class clang_c_adjust_irep2
+{
+public:
+  explicit clang_c_adjust_irep2(contextt &_context) : context(_context)
+  {
+  }
+
+  /// Walk every code symbol's IREP2 value. Returns false; there is no failure
+  /// mode yet, and the signature matches `clang_c_adjust::adjust()` so the
+  /// driver can call either.
+  bool adjust();
+
+  void adjust_expr(expr2tc &expr);
+
+private:
+  contextt &context;
+};

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -13,9 +13,10 @@
 /// At this stage the walk is deliberately **read-only**: it reads each code
 /// symbol's IREP2 value and recurses, and never writes one back. That keeps the
 /// pass inert by construction rather than by argument -- there is no write path
-/// to be wrong -- while still exercising `migrate_expr` over every construct the
-/// C corpus contains, since `symbolt::get_value2()` migrates the legacy value on
-/// demand. A construct that cannot migrate aborts here instead of much later.
+/// to be wrong -- while still exercising `migrate_expr` over every construct
+/// the C corpus contains, since `symbolt::get_value2()` migrates the legacy
+/// value on demand. A construct that cannot migrate aborts here instead of much
+/// later.
 ///
 /// Read-only also side-steps the round-trip losses `python_adjust` documents
 /// (a bitfield's `#bitfield` flag, an explicit alignment attribute): those only

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -1,4 +1,5 @@
 #include <util/base/compiler_defs.h>
+#include <clang-c-frontend/clang_c_adjust_irep2.h>
 CC_DIAGNOSTIC_PUSH()
 CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <clang/Frontend/ASTUnit.h>
@@ -453,6 +454,17 @@ bool clang_c_languaget::typecheck(contextt &context, const std::string &module)
   clang_c_adjust adjuster(new_context);
   if (adjuster.adjust())
     return true;
+
+  // Phase 6 C.3: shadow the legacy pass with the IREP2-native walk. Read-only,
+  // so flag-on and flag-off are byte-identical by construction; what the flag
+  // buys is migrating every value in the corpus through get_value2(), which
+  // aborts on a construct migrate_expr cannot represent.
+  if (config.options.get_bool_option("clang-c-irep2-adjust"))
+  {
+    clang_c_adjust_irep2 irep2_adjuster(new_context);
+    if (irep2_adjuster.adjust())
+      return true;
+  }
 
   return c_link(context, new_context, module);
 }

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -207,6 +207,10 @@ const struct group_opt_templ all_cmd_options[] = {
      {"python-list-compare-depth",
       boost::program_options::value<int>()->default_value(4)->value_name("nr"),
       "Set maximum nesting depth for Python list comparison (default is 4)"},
+     {"clang-c-irep2-adjust",
+      NULL,
+      "Run the IREP2-native C adjuster alongside the legacy adjust pass "
+      "(Phase 6 migration; experimental, default off)"},
      {"python-irep2-adjust",
       NULL,
       "Run the IREP2-native Python adjuster alongside the legacy adjust pass "


### PR DESCRIPTION
Phase 6 C.3 of `docs/roadmap/scope-clang-c-irep2.md` — the first executable step of the clang-c migration.

`clang_c_adjust_irep2` walks each code symbol's IREP2 value and recurses via `Foreach_operand`, behind `--clang-c-irep2-adjust` (default off). It never writes a symbol back.

> **Correction (2026-08-10).** An earlier version of this description claimed the walk was inert — "no new failures" and "no content divergence, the 17 remaining are baseline nondeterminism". Both claims were wrong, and the errors are worth naming because they are the ones this project's own harness rules warn about:
>
> - The "no new failures" figure came from the **first 300 tests alphabetically**, which contain no `to_union_*` and no `github_9*`. Parent §7 harness rule 6 says sample dense and unbiased; a prefix is neither. Measured over all 1 686: **73 non-zero exits flag-off, 85 flag-on — 12 new crashes.**
> - The "baseline nondeterminism" control stripped only the migrate warnings, **not** the temp paths and timing lines that the real A/B normalises. Re-run with the same normaliser, **1 of 13** differs against itself, not nine of ten. So the content divergences are real, not noise.

**What the walk actually found.** It aborts on:

```
Assertion failed: (is_union_type(type)), function constant_union2t, irep2_expr.h:495
```

`migrate_expr`'s union arm does `constant_union2tc(migrate_type(expr.type()), ...)`, and at this point the union's type is still a by-name tag, so `migrate_type` yields `symbol_type2t` rather than `union_type2t`.

That is the transient-by-name-aggregate hazard `python_adjust` documents — and the reason this PR placed the walk *after* `clang_c_adjust` was precisely to avoid it, on the assumption inherited from Python that a post-adjust walk sees resolved types. **For C that assumption does not hold**, which is the substantive Phase 6 finding here and the thing C.4 must solve before it can lean on this seam.

The flag is experimental and default-off, so the crash is reachable only by opting in. It is left unguarded deliberately: suppressing it would hide the one defect the walk exists to surface.

Refs #4715
