### PR TITLE
[irep2] Let constant_union2t hold a transient by-name type

### DIFF
--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -492,7 +492,15 @@ public:
       datatype_members(members),
       init_field(std::move(if_))
   {
-    assert(is_union_type(type));
+    // A symbol_id type is permitted on the same terms constant_struct2t
+    // permits it above: a transient pre-resolution state. migrate_expr builds
+    // a union literal from `constant_union2tc(migrate_type(expr.type()), ...)`
+    // (migrate.cpp:923), and a frontend whose union tag is still by-name at
+    // that point yields symbol_type2t rather than union_type2t -- which aborted
+    // here for 12 of regression/esbmc's tests under --clang-c-irep2-adjust,
+    // while the identical shape passed for structs. The asymmetry was an
+    // oversight, not a rule: NDEBUG builds already construct these nodes.
+    assert(is_union_type(type) || type->type_id == type2t::symbol_id);
     // smt_conv.cpp's counterexample reconstruction intentionally builds unions
     //  with multiple members (see TODO in get_by_ast), so we can't check if the
     // union has at most 1 member initializer, with


### PR DESCRIPTION
`constant_struct2t` already permits a `symbol_id` type as "a transient pre-resolution state" — added deliberately so that migrating a constant aggregate before its tag is resolved does not abort. `constant_union2t`, whose own comment describes it as "almost the same as constant_struct2t", never got the same disjunct.

`migrate_expr` builds `constant_union2tc(migrate_type(expr.type()), ...)` (migrate.cpp:923), so a union whose tag is still by-name yields `symbol_type2t` and trips `assert(is_union_type(type))`. Reading every C symbol's IREP2 value under `--clang-c-irep2-adjust` (#6894) reaches it on **12 of the 1 686** tests in `regression/esbmc` — while the identical shape passes for structs.

The asymmetry looks like an oversight rather than a rule: the assertion is the only thing rejecting the shape, so NDEBUG builds already construct these nodes today.

**Verified:** non-zero exits with and without the flag are now 68 and 68 (was 73 / 85). 668/668 unit tests pass; 926 C regression tests pass before the local 5-minute cap, none failing.

Stacked on #6897. Refs #4715
