### PR TITLE
[clang-c] Let a user's own abs definition win over the builtin

### DIFF
--- a/regression/esbmc-cpp/cpp/user_namespace_abs/main.cpp
+++ b/regression/esbmc-cpp/cpp/user_namespace_abs/main.cpp
@@ -1,0 +1,32 @@
+// `abs` inside a user namespace is an ordinary identifier, not libc's. It used
+// to be rewritten to the builtin `(x >= 0) ? x : -x` on the strength of its
+// name alone, so ESBMC verified the builtin and not this code (#6904).
+//
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <cassert>
+#include <cmath>
+
+namespace mylib
+{
+int abs(int x)
+{
+  return x < 0 ? 0 - x : x + 1;
+}
+
+double fabs(double x)
+{
+  return 0.0;
+}
+} // namespace mylib
+
+int main()
+{
+  assert(mylib::abs(5) == 6);
+  assert(mylib::abs(-5) == 5);
+  assert(mylib::fabs(-2.5) == 0.0);
+
+  // libc's own spellings keep the builtin lowering.
+  assert(std::abs(-7) == 7);
+  assert(std::fabs(-2.5) == 2.5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/user_namespace_abs/main.cpp
+++ b/regression/esbmc-cpp/cpp/user_namespace_abs/main.cpp
@@ -1,6 +1,7 @@
-// `abs` inside a user namespace is an ordinary identifier, not libc's. It used
-// to be rewritten to the builtin `(x >= 0) ? x : -x` on the strength of its
-// name alone, so ESBMC verified the builtin and not this code (#6904).
+// These names are ordinary identifiers outside libc's reserved set, so a
+// program may define them. do_special_functions matched a callee's base name
+// alone, so the definitions below were discarded and the builtins verified in
+// their place (#6904).
 //
 // Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
 #include <cassert>
@@ -17,6 +18,31 @@ double fabs(double x)
 {
   return 0.0;
 }
+
+bool isnan(double x)
+{
+  return true;
+}
+
+bool isinf(double x)
+{
+  return true;
+}
+
+bool isfinite(double x)
+{
+  return false;
+}
+
+bool isnormal(double x)
+{
+  return false;
+}
+
+bool signbit(double x)
+{
+  return true;
+}
 } // namespace mylib
 
 int main()
@@ -24,9 +50,14 @@ int main()
   assert(mylib::abs(5) == 6);
   assert(mylib::abs(-5) == 5);
   assert(mylib::fabs(-2.5) == 0.0);
+  assert(mylib::isnan(1.0) && mylib::isinf(1.0) && mylib::signbit(1.0));
+  assert(!mylib::isfinite(1.0) && !mylib::isnormal(1.0));
 
   // libc's own spellings keep the builtin lowering.
+  const double x = 1.0;
   assert(std::abs(-7) == 7);
   assert(std::fabs(-2.5) == 2.5);
+  assert(!std::isnan(x) && !std::isinf(x) && std::isfinite(x));
+  assert(std::isnormal(x) && !std::signbit(x));
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/user_namespace_abs/test.desc
+++ b/regression/esbmc-cpp/cpp/user_namespace_abs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/user_namespace_abs_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/user_namespace_abs_fail/main.cpp
@@ -1,0 +1,17 @@
+// The user's definition is what runs, so asserting the builtin's answer for it
+// must be refutable -- otherwise the test above would pass for the wrong reason.
+#include <cassert>
+
+namespace mylib
+{
+int abs(int x)
+{
+  return x < 0 ? 0 - x : x + 1;
+}
+} // namespace mylib
+
+int main()
+{
+  assert(mylib::abs(5) == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/user_namespace_abs_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/user_namespace_abs_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -74,6 +74,7 @@ public:
     if (config.set(cmdline))
       return 1;
     config.options.cmdline(cmdline);
+    config.options.set_option("building-c-library", true);
     set_verbosity_msg(VerbosityLevel::Result);
 
     if (!cmdline.isset("output"))

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -30,12 +30,14 @@ protected:
   /**
    * methods for symbol adjustment
    */
-  /// True when a call to one of the abs builtins may become an `abs` node: the
-  /// argument is arithmetic and the program does not define the callee itself.
-  /// See #6904.
-  bool lowers_to_abs_node(
-    const side_effect_expr_function_callt &expr,
-    const exprt &f_op) const;
+  /// True when the single argument is arithmetic, as the `abs` node requires.
+  bool has_single_arithmetic_argument(
+    const side_effect_expr_function_callt &expr) const;
+
+  /// True when a name-matched builtin lowering would discard a definition the
+  /// program supplies, in which case the definition wins. See #6904.
+  bool
+  shadows_user_definition(const irep_idt &identifier, const exprt &f_op) const;
 
   virtual void adjust_symbol(symbolt &symbol);
   void adjust_argc_argv(const symbolt &main_symbol);

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -30,6 +30,13 @@ protected:
   /**
    * methods for symbol adjustment
    */
+  /// True when a call to one of the abs builtins may become an `abs` node: the
+  /// argument is arithmetic and the program does not define the callee itself.
+  /// See #6904.
+  bool lowers_to_abs_node(
+    const side_effect_expr_function_callt &expr,
+    const exprt &f_op) const;
+
   virtual void adjust_symbol(symbolt &symbol);
   void adjust_argc_argv(const symbolt &main_symbol);
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1289,6 +1289,13 @@ bool clang_c_adjust::shadows_user_definition(
   if (!is_name_matched_builtin(identifier))
     return false;
 
+  /* c2goto compiles the operational models themselves, where libm/fabs.c and
+   * friends do define these names. Those definitions are the models, not a
+   * program's, so honouring them here would stop every call inside the models
+   * folding to its native node and blow the encoding up (#6904). */
+  if (config.options.get_bool_option("building-c-library"))
+    return false;
+
   const symbolt *s = context.find_symbol(to_symbol_expr(f_op).get_identifier());
   return s != nullptr && !s->get_value().is_nil();
 }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1252,22 +1252,45 @@ static inline bool is_abs_builtin_name(const irep_idt &identifier)
          compare_unscore_builtin(identifier, "fabs");
 }
 
-/// True when a call to one of the abs builtins may become an `abs` node. The
-/// argument must be arithmetic, since the node lowers to `(x >= 0) ? x : -x`,
-/// and the program must not supply the callee's body: matching on the name
-/// alone discarded a user's own definition and verified the builtin in its
-/// place -- `mylib::abs` is an identifier a program is free to reuse (#6904).
-/// Libc's `abs` is a bodiless declaration and <cmath>'s `std::abs` overloads
-/// forward to `::fabs`, so both still lower.
-bool clang_c_adjust::lowers_to_abs_node(
-  const side_effect_expr_function_callt &expr,
+/// The `abs` node lowers to `(x >= 0) ? x : -x`, which is ill-typed for
+/// anything else -- std::abs(complex) is why <complex> ships without it.
+bool clang_c_adjust::has_single_arithmetic_argument(
+  const side_effect_expr_function_callt &expr) const
+{
+  return expr.arguments().size() == 1 && is_number(expr.arguments()[0].type());
+}
+
+/// The lowerings in do_special_functions match a callee's base name, so a
+/// program that defines one of these names itself would have its body discarded
+/// and the builtin verified in its place (#6904). These are all spellings a
+/// program is free to reuse -- `mylib::abs`, `mylib::isinf` -- unlike the
+/// `__builtin_`-prefixed and CPROVER-prefixed entries, which are reserved.
+static inline bool is_name_matched_builtin(const irep_idt &identifier)
+{
+  return is_abs_builtin_name(identifier) ||
+         compare_unscore_builtin(identifier, "isnan") ||
+         compare_unscore_builtin(identifier, "isinf") ||
+         compare_unscore_builtin(identifier, "isnormal") ||
+         compare_unscore_builtin(identifier, "signbit") ||
+         compare_unscore_builtin(identifier, "isfinite") ||
+         compare_float_suffix(identifier, "finite") ||
+         compare_unscore_builtin(identifier, "finite") ||
+         compare_unscore_builtin(identifier, "inf") ||
+         compare_unscore_builtin(identifier, "huge_val");
+}
+
+/// True when lowering this call would throw away a definition the program
+/// supplies. Libc's own declarations are bodiless and the <cmath> overloads
+/// forward to their `__builtin_` spelling, so both still lower.
+bool clang_c_adjust::shadows_user_definition(
+  const irep_idt &identifier,
   const exprt &f_op) const
 {
-  if (expr.arguments().size() != 1 || !is_number(expr.arguments()[0].type()))
+  if (!is_name_matched_builtin(identifier))
     return false;
 
   const symbolt *s = context.find_symbol(to_symbol_expr(f_op).get_identifier());
-  return s == nullptr || s->get_value().is_nil();
+  return s != nullptr && !s->get_value().is_nil();
 }
 
 void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
@@ -1279,6 +1302,11 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
   if (f_op.is_symbol())
   {
     const irep_idt &identifier = to_symbol_expr(f_op).name();
+
+    // A definition the program supplies wins over every name-matched lowering
+    // below; see shadows_user_definition (#6904).
+    if (shadows_user_definition(identifier, f_op))
+      return;
 
     if (identifier == CPROVER_PREFIX "same_object")
     {
@@ -1376,7 +1404,7 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     }
     else if (is_abs_builtin_name(identifier))
     {
-      if (lowers_to_abs_node(expr, f_op))
+      if (has_single_arithmetic_argument(expr))
       {
         exprt abs_expr("abs", expr.type());
         abs_expr.operands() = expr.arguments();

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1252,6 +1252,24 @@ static inline bool is_abs_builtin_name(const irep_idt &identifier)
          compare_unscore_builtin(identifier, "fabs");
 }
 
+/// True when a call to one of the abs builtins may become an `abs` node. The
+/// argument must be arithmetic, since the node lowers to `(x >= 0) ? x : -x`,
+/// and the program must not supply the callee's body: matching on the name
+/// alone discarded a user's own definition and verified the builtin in its
+/// place -- `mylib::abs` is an identifier a program is free to reuse (#6904).
+/// Libc's `abs` is a bodiless declaration and <cmath>'s `std::abs` overloads
+/// forward to `::fabs`, so both still lower.
+bool clang_c_adjust::lowers_to_abs_node(
+  const side_effect_expr_function_callt &expr,
+  const exprt &f_op) const
+{
+  if (expr.arguments().size() != 1 || !is_number(expr.arguments()[0].type()))
+    return false;
+
+  const symbolt *s = context.find_symbol(to_symbol_expr(f_op).get_identifier());
+  return s == nullptr || s->get_value().is_nil();
+}
+
 void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
 {
   const exprt &f_op = expr.function();
@@ -1358,7 +1376,7 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     }
     else if (is_abs_builtin_name(identifier))
     {
-      if (expr.arguments().size() == 1 && is_number(expr.arguments()[0].type()))
+      if (lowers_to_abs_node(expr, f_op))
       {
         exprt abs_expr("abs", expr.type());
         abs_expr.operands() = expr.arguments();


### PR DESCRIPTION
`do_special_functions` rewrote a call into a builtin node on the strength of the
callee's **base name** alone. `mylib::abs`, `mylib::isinf` and friends are
ordinary identifiers a program is free to reuse, so their bodies were discarded
and the builtin verified in their place — wrong in both directions, since it can
invent a failure or mask a real one.

The rewrite now requires the callee to have no definition. Beyond the reported
`abs`/`labs`/`llabs`/`fabs*`, the audit the issue suggests found the same defect
in `isnan`, `isinf`, `isnormal`, `signbit`, `isfinite`/`finite`, `inf` and
`huge_val` — all five classifiers were confirmed broken and are fixed by the
same guard. The `__builtin_`- and CPROVER-prefixed spellings are reserved and
stay unguarded.

Libc's own declarations are bodiless and `<cmath>`'s `std::` overloads forward to
their `__builtin_` spelling, so both still lower. Differentials against master
moved only the new tests: 48 `abs`-bearing tests → 2, 77 classifier-bearing
tests → 1, and all 1681 `regression/esbmc` tests → 0. Both new tests are
adjudicated by clang++ with ASan and UBSan.

Fixes #6904.