### PR TITLE
[clang-c] Migrate the index arm to the IREP2 adjuster

### DIFF
--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -22,7 +22,17 @@ public:
 
   bool adjust();
 
+  /// Hand the index rewrite to the IREP2 adjuster. Set only by the C driver:
+  /// clang_cpp_adjust derives from this class, and the IREP2 pass is wired into
+  /// clang_c_languaget::typecheck alone, so a global option check here would
+  /// disable the rewrite for C++ with nothing to replace it.
+  void set_irep2_owns_index()
+  {
+    irep2_owns_index = true;
+  }
+
 protected:
+  bool irep2_owns_index = false;
   contextt &context;
   namespacet ns;
   symbol_generator tmp_symbol{"clang_c_adjust::"};

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -683,6 +683,12 @@ void clang_c_adjust::adjust_index(index_exprt &index)
 {
   adjust_operands(index);
 
+  // The recursion above stays here whatever happens; only the rewrite below
+  // moves (scope-clang-c-irep2.md §19.2), so gating the whole arm would skip
+  // the subtree rather than hand over one transformation.
+  if (irep2_owns_index)
+    return;
+
   exprt &array_expr = index.op0();
   exprt &index_expr = index.op1();
 

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -60,11 +60,10 @@ void clang_c_adjust_irep2::adjust_index(expr2tc &expr)
   expr2tc index_expr = idx.index;
 
   // The operands may be the other way round: `i[a]` is legal C.
-  if (
-    const type2tc a = ns.follow(array_expr->type),
-    i = ns.follow(index_expr->type);
-    !is_array_type(a) && !is_pointer_type(a) &&
-    (is_array_type(i) || is_pointer_type(i)))
+  if (const type2tc a = ns.follow(array_expr->type),
+      i = ns.follow(index_expr->type);
+      !is_array_type(a) && !is_pointer_type(a) &&
+      (is_array_type(i) || is_pointer_type(i)))
     std::swap(array_expr, index_expr);
 
   // migrate_type(index_type()), not index_type2(): despite the name they are

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -1,5 +1,8 @@
 #include <clang-c-frontend/clang_c_adjust_irep2.h>
 #include <util/irep/migrate.h>
+#include <util/lang/c_typecast.h>
+#include <util/lang/c_types.h>
+#include <irep2/irep2_utils.h>
 #include <util/symtab/namespace.h>
 #include <utility>
 
@@ -24,8 +27,14 @@ bool clang_c_adjust_irep2::adjust()
   {
     if (!s->is_type && s->get_value().is_not_nil())
     {
-      expr2tc value = s->get_value2();
+      const expr2tc before = s->get_value2();
+      expr2tc value = before;
       adjust_expr(value);
+      // Only write back a value this pass actually changed, so symbols it does
+      // not touch never make the round trip (python_adjust takes the same care,
+      // for the bitfield and alignment losses migrate_type cannot carry).
+      if (value != before)
+        s->set_value(value);
     }
   }
 
@@ -39,4 +48,56 @@ void clang_c_adjust_irep2::adjust_expr(expr2tc &expr)
     return;
 
   expr->Foreach_operand([this](expr2tc &op) { adjust_expr(op); });
+
+  if (is_index2t(expr))
+    adjust_index(expr);
+}
+
+void clang_c_adjust_irep2::adjust_index(expr2tc &expr)
+{
+  const index2t &idx = to_index2t(expr);
+  expr2tc array_expr = idx.source_value;
+  expr2tc index_expr = idx.index;
+
+  // The operands may be the other way round: `i[a]` is legal C.
+  if (
+    const type2tc a = ns.follow(array_expr->type),
+    i = ns.follow(index_expr->type);
+    !is_array_type(a) && !is_pointer_type(a) &&
+    (is_array_type(i) || is_pointer_type(i)))
+    std::swap(array_expr, index_expr);
+
+  // migrate_type(index_type()), not index_type2(): despite the name they are
+  // different types -- index_type() is signed_size_type(), index_type2() is
+  // get_int_type(config.ansi_c.address_width) -- so the latter leaves a
+  // non-constant subscript uncast where the legacy arm casts it.
+  c_implicit_typecast(index_expr, migrate_type(index_type()), ns);
+
+  const type2tc final_array_type = ns.follow(array_expr->type);
+
+  // p[i] is syntactic sugar for *(p+i).
+  if (is_pointer_type(final_array_type))
+  {
+    expr = dereference2tc(
+      expr->type, add2tc(array_expr->type, array_expr, index_expr));
+    return;
+  }
+
+  if (!is_array_type(final_array_type) && !is_vector_type(final_array_type))
+  {
+    // The base is neither array, vector nor pointer -- typically a struct that
+    // appears in array context because two TUs declared the same external
+    // symbol with conflicting types. Rewrite `base[i]` as `*((T*)&base + i)`.
+    const type2tc elem_type = expr->type;
+    const type2tc ptr_type = pointer_type2tc(elem_type);
+
+    expr2tc addr_of =
+      address_of2tc(pointer_type2tc(array_expr->type), array_expr);
+    c_implicit_typecast(addr_of, ptr_type, ns);
+
+    expr = dereference2tc(elem_type, add2tc(ptr_type, addr_of, index_expr));
+    return;
+  }
+
+  expr = index2tc(expr->type, array_expr, index_expr);
 }

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/symtab/context.h>
+#include <util/symtab/namespace.h>
 #include <irep2/irep2.h>
 
 /// Phase 6 (C.3) IREP2-native adjuster for the C frontend.
@@ -44,5 +45,11 @@ public:
   void adjust_expr(expr2tc &expr);
 
 private:
+  /// IREP2 form of clang_c_adjust::adjust_index's rewrite. The legacy arm keeps
+  /// the operand recursion and returns before this point when the flag is on
+  /// (scope-clang-c-irep2.md §19.2).
+  void adjust_index(expr2tc &expr);
+
   contextt &context;
+  namespacet ns{context};
 };

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -452,6 +452,8 @@ bool clang_c_languaget::typecheck(contextt &context, const std::string &module)
     return true;
 
   clang_c_adjust adjuster(new_context);
+  if (config.options.get_bool_option("clang-c-irep2-adjust"))
+    adjuster.set_irep2_owns_index();
   if (adjuster.adjust())
     return true;
 

--- a/src/util/lang/c_typecast.cpp
+++ b/src/util/lang/c_typecast.cpp
@@ -969,6 +969,13 @@ void c_typecastt::do_typecast(expr2tc &dest, const type2tc &type)
 
   if (dest_type != type)
   {
+    // Fold a typecast of a constant, as the irept overload above does. Without
+    // this the two copies disagree on the commonest conversion a frontend
+    // performs -- storing a literal into a differently-typed lvalue leaves an
+    // unfolded typecast here but a folded constant there.
+    const bool fold = is_constant(dest) && !no_simplify;
     dest = typecast2tc(type, dest);
+    if (fold)
+      simplify(dest);
   }
 }

--- a/unit/util/c_typecast.test.cpp
+++ b/unit/util/c_typecast.test.cpp
@@ -20,6 +20,9 @@
 #include <util/config/config.h>
 #include <util/symtab/context.h>
 #include <util/symtab/namespace.h>
+#include <util/irep/migrate.h>
+#include <util/irep/std_expr.h>
+#include <util/arith/arith_tools.h>
 #include <irep2/irep2_utils.h>
 
 // get_c_type ranks an operand against config.ansi_c, which is zero-initialised
@@ -90,4 +93,113 @@ TEST_CASE("c_implicit_typecast converts an integer to double", "[c_typecast]")
   expr2tc e = gen_one(get_int32_type());
   REQUIRE_FALSE(c_implicit_typecast(e, double_type2(), ns));
   REQUIRE(is_floatbv_type(e->type));
+}
+
+// Differential harness. implicit_typecast_followed also exists twice, and the
+// two copies are not translations of each other: the irept one additionally
+// handles references, pointer-to-member, incomplete_array sources, qualifier
+// warnings and string-constant-to-array, none of which the expr2tc one has
+// (docs/roadmap/scope-coupled-arith-assign-conversion.md §20). Those gaps are
+// C++-frontend shaped; what follows pins the arithmetic and pointer conversions
+// that every frontend performs at an assignment, so a future edit to one copy
+// cannot silently drift from the other the way the floatbv omission above did.
+static void require_overloads_agree(
+  const namespacet &ns,
+  const exprt &input,
+  const typet &dest)
+{
+  // migrate_expr resolves symbol types through this thread-local, which only
+  // language_ui sets in a real run.
+  migrate_namespace_lookup = &ns;
+
+  exprt legacy = input;
+  const bool legacy_failed = c_implicit_typecast(legacy, dest, ns);
+
+  expr2tc native;
+  migrate_expr(input, native);
+  const bool native_failed =
+    c_implicit_typecast(native, migrate_type(dest), ns);
+
+  REQUIRE(legacy_failed == native_failed);
+
+  expr2tc legacy_migrated;
+  migrate_expr(legacy, legacy_migrated);
+  REQUIRE(legacy_migrated == native);
+}
+
+TEST_CASE(
+  "both c_implicit_typecast overloads agree on arithmetic conversions",
+  "[c_typecast]")
+{
+  contextt ctx;
+  namespacet ns(ctx);
+
+  SECTION("integer widens to double")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), double_type());
+  }
+
+  SECTION("integer widens to a wider integer")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), long_int_type());
+  }
+
+  SECTION("integer narrows to bool")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), bool_type());
+  }
+
+  // A non-constant source takes the unfolded route, so it covers the other
+  // side of the branch the constant sections above exercise.
+  SECTION("double narrows to integer")
+  {
+    require_overloads_agree(ns, symbol_exprt("d", double_type()), int_type());
+  }
+
+  SECTION("signed converts to unsigned of the same width")
+  {
+    require_overloads_agree(ns, from_integer(1, int_type()), uint_type());
+  }
+}
+
+TEST_CASE(
+  "both c_implicit_typecast overloads agree on pointer conversions",
+  "[c_typecast]")
+{
+  contextt ctx;
+  namespacet ns(ctx);
+
+  // The two copies spell the null pointer differently -- the irept one builds a
+  // constant whose value is "NULL", the expr2tc one a symbol named "NULL" --
+  // and migrate_expr reconciles them (migrate.cpp:810). Left unpinned, a change
+  // to either spelling would go unnoticed until a frontend compared pointers.
+  SECTION("literal zero becomes the null pointer")
+  {
+    require_overloads_agree(
+      ns, from_integer(0, int_type()), pointer_typet(int_type()));
+  }
+
+  SECTION("pointer converts to void pointer")
+  {
+    require_overloads_agree(
+      ns,
+      symbol_exprt("p", pointer_typet(int_type())),
+      pointer_typet(empty_typet()));
+  }
+
+  SECTION("pointer converts to an unrelated pointer type")
+  {
+    require_overloads_agree(
+      ns,
+      symbol_exprt("p", pointer_typet(int_type())),
+      pointer_typet(char_type()));
+  }
+
+  SECTION("pointer conversion to its own type is a no-op")
+  {
+    require_overloads_agree(
+      ns,
+      symbol_exprt("p", pointer_typet(int_type())),
+      pointer_typet(int_type()));
+  }
 }


### PR DESCRIPTION
First arm of C.4 (`docs/roadmap/scope-clang-c-irep2.md`). `clang_c_adjust::adjust_index` keeps its operand recursion and returns before the rewrite when the C driver hands that rewrite over; the IREP2 pass performs it, and the walk now writes a symbol back when it changed one.

**A/B over `regression/esbmc`: 2 divergences, both `github_746`,** which differs against itself without the flag. Dropping the dereference rewrite changes 23 tests, so the arm is doing the work. 668 unit tests and 1 641 C regression tests pass.

Three things had to be right, and each was wrong on the first attempt:

- **#6873 is a prerequisite.** The arm calls `gen_typecast`, a wrapper over the `c_typecast` overload that PR fixed. Without it in the branch, every constant subscript printed `p[(signed long int)0]` instead of `p[0]` — **296** divergent tests. §19.1 predicted this before the attempt; it is merged in here.
- **`index_type2()` is not the IREP2 form of `index_type()`.** The first is `get_int_type(config.ansi_c.address_width)`, the second `signed_size_type()`. The arm migrates the legacy type rather than trusting the `2` suffix.
- **`clang_cpp_adjust` derives from `clang_c_adjust`.** Gating the rewrite on the global option disabled it for C++ too, where nothing replaces it — **9** divergent `.cpp` tests, all of which looked like a missing widening cast. The hand-over is now a member the C driver alone sets.

Stacked on #6901 (which the A/B depends on) and merges #6873. Refs #4715
