### PR TITLE
[om] Give istream extraction an unconstrained result

### DIFF
--- a/regression/esbmc-cpp/cpp/istream_extract_havocs/main.cpp
+++ b/regression/esbmc-cpp/cpp/istream_extract_havocs/main.cpp
@@ -1,0 +1,17 @@
+// The operand is unconstrained, not unusable: properties that hold for every
+// input still verify, and the stream stays in a usable state.
+#include <iostream>
+#include <cassert>
+
+int main()
+{
+  int i = 0;
+  std::cin >> i;
+  if (i > 0)
+    assert(i >= 1);
+
+  unsigned u = 0;
+  std::cin >> u;
+  assert(u >= 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/istream_extract_havocs/test.desc
+++ b/regression/esbmc-cpp/cpp/istream_extract_havocs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/istream_extract_havocs_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/istream_extract_havocs_fail/main.cpp
@@ -1,0 +1,19 @@
+// Extraction has no input to read, so the operand must come back
+// unconstrained. Leaving it at its prior value proved this assertion, which
+// real input refutes -- a missed bug, not a spurious alarm.
+#include <iostream>
+#include <cassert>
+
+int main()
+{
+  int i = 7;
+  double d = 2.5;
+  long long q = 9;
+
+  std::cin >> i;
+  std::cin >> d;
+  std::cin >> q;
+
+  assert(i == 7 && d == 2.5 && q == 9);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/istream_extract_havocs_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/istream_extract_havocs_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/istream
+++ b/src/cpp/library/istream
@@ -5,6 +5,25 @@
 #include "definitions.h"
 #include "cstdio"
 
+// Extraction has no input to read, so it yields an unconstrained value of the
+// target type. Leaving the operand at its prior value proved properties that
+// real input refutes -- `int v = 7; cin >> v; assert(v == 7);` succeeded.
+extern bool nondet_bool();
+extern char nondet_char();
+extern signed char nondet_schar();
+extern unsigned char nondet_uchar();
+extern short nondet_short();
+extern unsigned short nondet_ushort();
+extern int nondet_int();
+extern unsigned int nondet_uint();
+extern long nondet_long();
+extern unsigned long nondet_ulong();
+extern long long nondet_llong();
+extern unsigned long long nondet_ullong();
+extern float nondet_float();
+extern double nondet_double();
+extern long double nondet_ldouble();
+
 namespace std
 {
 class istream : virtual public ios
@@ -88,52 +107,62 @@ istream &operator>>(istream &is, bool &val)
   {
     boolalpha(is);
   }
+  val = nondet_bool();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, char &val)
 {
+  val = nondet_char();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, signed char &val)
 {
+  val = nondet_schar();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, unsigned char &val)
 {
+  val = nondet_uchar();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, short &val)
 {
+  val = nondet_short();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, unsigned short &val)
 {
+  val = nondet_ushort();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, int &val)
 {
+  val = nondet_int();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, unsigned int &val)
 {
+  val = nondet_uint();
   is._gcount = 0;
   return is;
 }
 #if defined(__clang__) || __WORDSIZE == 64
 istream &operator>>(istream &is, long &val)
 {
+  val = nondet_long();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, unsigned long &val)
 {
+  val = nondet_ulong();
   is._gcount = 0;
   return is;
 }
@@ -141,28 +170,33 @@ istream &operator>>(istream &is, unsigned long &val)
 #if __cplusplus >= 201103L
 istream &operator>>(istream &is, long long &val)
 {
+  val = nondet_llong();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, unsigned long long &val)
 {
+  val = nondet_ullong();
   is._gcount = 0;
   return is;
 }
 #endif
 istream &operator>>(istream &is, float &val)
 {
+  val = nondet_float();
   is._gcount = 0;
   return is;
 }
 istream &operator>>(istream &is, double &val)
 {
+  val = nondet_double();
   is._gcount = 0;
   return is;
 }
 #if defined(__clang__)
 istream &operator>>(istream &is, long double &val)
 {
+  val = nondet_ldouble();
   is._gcount = 0;
   return is;
 }


### PR DESCRIPTION
Every arithmetic `operator>>(istream&, T&)` only zeroed `_gcount` and never wrote
its operand, so a variable kept whatever it held before the read:

```cpp
int v = 7;
std::cin >> v;
assert(v == 7);   // VERIFICATION SUCCESSFUL on master
```

Any input refutes that, so it is a missed bug rather than a spurious alarm. The
same held for `double`, `long long` and the rest.

Each arithmetic overload now yields a nondeterministic value of the target type.
That is a sound over-approximation of the standard behaviour: since C++11
formatted input assigns either the parsed value or `0` on failure ([istream.formatted.arithmetic]),
and pre-C++11 leaves the operand unmodified on failure — havoc covers all three.

A differential over the 261 stream-bearing tests in `regression/esbmc-cpp*`,
`esbmc-unix*` and `esbmc-old` moved **nothing** (the one apparent move,
`string/traits1`, takes ~50s on both binaries and only exceeded the sweep timeout
under parallel load). 663/663 unit tests pass. The negative test fails on master
and passes here; the positive one guards that ordinary input-independent
properties still verify.

Note this does not close the `istringstream("42") >> v` parsing gap — extraction
from a string buffer is still unmodelled, and stays a separate limitation.