### PR TITLE
numPy constructor-backed array operations

### DIFF
--- a/docs/roadmap/numpy-support-assessment.md
+++ b/docs/roadmap/numpy-support-assessment.md
@@ -55,6 +55,55 @@ Architectural decisions that gate specific pendencies here (referenced as
     context. See `regression/numpy/constructor_method_dispatch_success`,
     `constructor_method_dispatch_non_numpy_fail`, and
     `constructor_module_method_parity_edge`.
+- **Hardened constructor materialization against a follow-up review of the
+  work above** — `materialize_numpy_constructor_array()` and its resolver
+  call sites had four confirmed correctness/diagnostic gaps of their own,
+  each verified by direct execution before and after the fix:
+  - A receiver was matched purely by attribute name (`zeros`/`full`/`eye`/
+    ...), so a user class with a same-named method (e.g. its own `.full()`)
+    was silently treated as a numpy constructor call. Now requires the
+    receiver to actually resolve to the imported numpy module, reusing
+    `is_imported_numpy_module_alias()` (promoted to external linkage) —
+    the same check `is_numpy_array_constructor_expr()` already used. See
+    `regression/numpy/constructor_materialize_module_alias_fail`.
+  - When materialization declined for a *recognized* constructor call (a
+    `dtype=` keyword, a non-constant fill), every resolver fell back to the
+    call's `args[0]` — exactly the shape/size argument this whole helper
+    exists to stop misreading as array data, silently reintroducing the
+    original bug for that one escape hatch (e.g.
+    `np.mean(np.eye(3, dtype=int))` verified against the shape scalar `3`
+    instead of the real flattened mean `1/3`). Now such calls are left as
+    unresolved `Call` nodes instead, so the existing numeric-extraction
+    path rejects them explicitly. See
+    `regression/numpy/reducer_constructor_dtype_kwarg_fail`.
+  - `a.transpose()` on a declined dynamic-list-backed constructor call
+    raised the generic "supports up to 2D arrays" message even when the
+    real cause was unrelated to dimensionality. Now distinguishes the two
+    failure modes with a specific diagnostic for the former. See
+    `regression/numpy/transpose_constructor_kwarg_fail`.
+  - `materialize_arange()` computed every value (including the all-integer,
+    dtype-default case) through a `double` loop, silently losing precision
+    or drifting the termination point past 2^53. Now uses exact `int64_t`
+    arithmetic when every argument is an integer; the float path is
+    unchanged. Not covered by a regression test: reproducing this needs
+    bounds large enough to exercise the gap, but any
+    `np.arange(...)` assigned to a variable already times out during array
+    creation regardless of this fix (see "Soundness concerns" below), so
+    verified by direct execution outside the regression harness instead.
+
+  A fifth resolve_var copy (guarding
+  `greater`/`less`/`equal`/`where`/`full`/`eye`/`identity`/`linspace`
+  comparison-scalar dispatch) was also brought onto
+  `materialize_numpy_constructor_array()` for consistency with every other
+  copy, though that dispatch only ever extracts a single numeric scalar
+  from its operands either way. A sixth, purely cosmetic finding (a stale
+  comment claiming no rank cap existed, contradicted by the very next
+  line) was also fixed. A sixth *substantive* finding raised in the same
+  review — no upper bound on total materialized elements — was
+  investigated and found to duplicate the pre-existing scalability wall
+  below rather than being an independently reachable issue: the same
+  large shape already hangs at ordinary array creation, before this
+  helper ever runs, with or without this PR's changes.
 - **Closed the remaining ADR-NP-003 etapa 1 gaps** — the guard layer
   introduced by the previous entry left several confirmed holes, all
   verified by direct execution before and after the fix:
@@ -288,7 +337,10 @@ Architectural decisions that gate specific pendencies here (referenced as
    arrays — three elements should not be expensive. Root cause not
    investigated; found while exercising constructor-backed reducers in this
    round (worked around there by using `eye`/`identity`/`full` instead) and
-   flagged here rather than fixed blind.
+   flagged here rather than fixed blind. This also blocks regression-testing
+   the `materialize_arange()` integer-precision fix above: any
+   `np.arange(...)` assigned to a variable hits this wall at the assignment
+   itself, before a reducer ever gets to exercise the fixed code path.
 
 ---
 

--- a/docs/roadmap/numpy-support-assessment.md
+++ b/docs/roadmap/numpy-support-assessment.md
@@ -1,6 +1,6 @@
 # ESBMC NumPy — Remaining Work
 
-**Updated:** 2026-08-02.
+**Updated:** 2026-08-09.
 
 This file tracks what is **not yet implemented or broken** in the NumPy
 module. Completed items are in the git history and `regression/numpy/`.
@@ -11,6 +11,50 @@ Architectural decisions that gate specific pendencies here (referenced as
 
 ## Recently completed
 
+- **Constructor-backed array operations** — closed the three confirmed gaps
+  listed below in "Soundness concerns" for arrays built by a shape
+  constructor (`zeros`/`ones`/`full`/`eye`/`identity`/`linspace`/`arange`)
+  rather than an inline literal:
+  - `np.dot(a, b)`/`a.dot(b)` no longer crashes the process for two
+    1-D vectors read from a variable; the runtime lowering now requires an
+    assignment target and raises an explicit diagnostic instead of
+    dereferencing a null one when the call is a bare statement. See
+    `regression/numpy/dot_variable_*`.
+  - `np.transpose(a)`/`a.transpose()`, `np.flatten(a)`/`a.flatten()`,
+    `np.sum(a)`/`a.sum()`, `np.mean(a)`/`a.mean()`, and the remaining
+    reducers `min`/`max`/`prod`/`std`/`var` (module and method form) now
+    work for every constructor above, not just `np.array(<literal>)`. Root
+    cause: several independent call sites resolved a variable's declaration
+    and, if the right-hand side was a constructor call, blindly took its
+    first argument as if it were `np.array(<literal>)`-shaped data — which
+    misreads a shape/fill argument (`np.zeros((2, 2))`, `np.full((2, 2),
+    5)`, ...) as the array's data. Fixed via a new
+    `materialize_numpy_constructor_array` helper that reconstructs the
+    literal list a constructor call would have produced, used by every
+    affected call site. `transpose` additionally needed a compile-time
+    literal fold instead of the general runtime array backend for the
+    subset of constructors (`full`/`eye`/`identity`/`linspace`) that build
+    a dynamic `__ESBMC_PyListObj` list rather than a static array — taking
+    the address of the real declared symbol for that representation is
+    unsound. See `regression/numpy/transpose_constructor_*`,
+    `flatten_constructor_*`, `sum_constructor_*`, `mean_constructor_*`, and
+    `reducer_constructor_*`.
+  - The `a.<method>()` → `np.<method>(a, ...)` method-dispatch rewrite only
+    fired when the call was the direct right-hand side of an assignment
+    statement (`x = a.min()`); the identical call anywhere else — `assert
+    a.min() == 0`, a nested expression, a call argument — fell through to
+    an unrelated builtin/class-method lookup and raised a spurious
+    `TypeError`/`AttributeError` (e.g. Python's builtin `min()` complaining
+    about a missing `iterable` argument). Centralized the rewrite into one
+    `rewrite_numpy_method_call_node()` helper shared by the
+    assignment-statement path and the general Call-expression path, so
+    every expression context resolves the same receiver check. Also added
+    `"prod"` to the rewritten method set, which was missing next to its
+    sibling reducers (`sum`/`mean`/`min`/`max`/`std`/`var`) and left
+    `.prod()` permanently unresolvable in method form regardless of
+    context. See `regression/numpy/constructor_method_dispatch_success`,
+    `constructor_method_dispatch_non_numpy_fail`, and
+    `constructor_module_method_parity_edge`.
 - **Closed the remaining ADR-NP-003 etapa 1 gaps** — the guard layer
   introduced by the previous entry left several confirmed holes, all
   verified by direct execution before and after the fix:
@@ -237,46 +281,14 @@ Architectural decisions that gate specific pendencies here (referenced as
    all now rejected/supported correctly (see "Recently completed") — the
    remaining piece is the definitive shared-buffer descriptor model
    (etapa 2), which replaces conservative rejection with real aliasing.
-5. **`np.dot(a, b)` crashes the process for two 1-D vectors read from a
-   variable** (not a literal) — confirmed by direct execution:
-   ```python
-   import numpy as np
-   a = np.array([1, 2, 3])
-   b = np.array([4, 5, 6])
-   np.dot(a, b)
-   ```
-   aborts (core dump) during GOTO conversion instead of producing a
-   verdict. `a.dot(b)` (method form) does not crash — it raises an
-   explicit `TypeError`, so it is merely unsupported, not unsound. Found
-   while checking which other methods could safely gain dispatch rewrite
-   support alongside this PR; not fixed here since it is unrelated to
-   view/dispatch work and needs its own root-cause investigation.
-6. **`.transpose()`/`np.transpose(a)` fails for a variable built by a
-   non-literal constructor** (`np.zeros`, `np.eye`, `np.identity` — `ones`/
-   `full`/`arange` untested) — confirmed by direct execution:
-   ```python
-   import numpy as np
-   a = np.zeros((2, 2))
-   b = a.transpose()
-   ```
-   raises `Unsupported Numpy call: transpose` instead of transposing, even
-   though the identical code with `a = np.array([[1, 2], [3, 4]])` (a
-   literal) works (see `regression/numpy/view_function_transpose_method_success`).
-   Pre-existing — `zeros` was already tracked in `numpy_array_symbols_`
-   before this PR, so this is not a dispatch-rewrite gap; the `Name`-typed
-   argument branch in `numpy_call_expr.cpp`'s transpose handler does not
-   handle whatever type shape a non-literal constructor produces. Found
-   while adding `eye`/`identity`/`linspace` to the dispatch-rewrite
-   constructor set; not fixed here — out of scope for that fix.
-7. **`.mean()` and `.sum()`/`.flatten()` compute a wrong numeric result for
-   some non-literal-constructed arrays** — confirmed by direct execution:
-   `c = np.identity(2); c.mean()` asserts `!= 0.5` (wrong; `.sum()` on the
-   same array correctly returns `2.0`), and separately
-   `e = np.linspace(0.0, 4.0, 5); e.sum()` and `e.flatten()[i]` both compute
-   wrong values even though raw indexing (`e[0]`, `e[4]`) and `.copy()` on
-   the same `e` are correct. Two distinct confirmed-wrong cases, root cause
-   not yet investigated for either. Found alongside the `.transpose()` gap
-   above; not fixed here.
+5. **`np.arange(n)` is disproportionately slow even for tiny `n`** —
+   confirmed by direct execution: `np.arange(3)` alone (no reducer applied)
+   times out (30-60s) even with a small `--unwind`. This is not explained
+   by the general scalability wall above (#3), which is about *large*
+   arrays — three elements should not be expensive. Root cause not
+   investigated; found while exercising constructor-backed reducers in this
+   round (worked around there by using `eye`/`identity`/`full` instead) and
+   flagged here rather than fixed blind.
 
 ---
 
@@ -290,9 +302,9 @@ No remaining KNOWNBUG in the targeted `dot6`/`dot7`/`transpose2`/
 
 ## Prioritised next steps
 
-1. **`np.dot(a, b)` crash with two variable-sourced 1-D vectors** — see
-   "Soundness concerns" #5. Highest priority: it is a process crash, not
-   merely a missing feature or a conservative rejection.
+1. **`np.arange(n)` performance** — see "Soundness concerns" #5. A tiny,
+   fixed-size input should not time out; worth understanding before it
+   blocks other `arange`-based work.
 2. **Definitive view descriptor model (ADR-NP-003 etapa 2)** — replace the
    current conservative guard-over-copy approach with shared
    `ndarray_descriptor` buffer_id/offset/stride metadata in indexing,
@@ -343,8 +355,8 @@ No remaining KNOWNBUG in the targeted `dot6`/`dot7`/`transpose2`/
 
 ## Suggested next PRs
 
-1. **Fix the `np.dot` variable-vector crash** — small, isolated, high
-   priority (process crash, not a soundness/feature gap).
+1. **Root-cause `np.arange(n)` performance** — small input, disproportionate
+   cost; see "Soundness concerns" #5.
 2. **Shared-buffer view descriptors (ADR-NP-003 etapa 2)** — connect
    `ndarray_descriptor` buffer/offset/stride metadata to basic indexing,
    transpose, assignment, and escape checks so supported writable views

--- a/regression/numpy/constructor_materialize_module_alias_fail/main.py
+++ b/regression/numpy/constructor_materialize_module_alias_fail/main.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+
+# A user class whose own method happens to share a name with a numpy
+# constructor (full) must not be treated as if it were numpy's full() just
+# because the attribute name matches -- the receiver is not the numpy
+# module, so the call is not a numpy array and must be rejected explicitly
+# rather than materialized from the shape/fill arguments.
+class Grid:
+    def full(self, shape, fill):
+        return [fill, fill, fill, fill, fill]
+
+
+g = Grid()
+a = g.full((2, 2), 9)
+b = np.sum(a)
+
+assert b == 45

--- a/regression/numpy/constructor_materialize_module_alias_fail/test.desc
+++ b/regression/numpy/constructor_materialize_module_alias_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy.sum\(\) currently supports constant numeric inputs only$

--- a/regression/numpy/constructor_method_dispatch_non_numpy_fail/main.py
+++ b/regression/numpy/constructor_method_dispatch_non_numpy_fail/main.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+# A plain class with no `min` method is not a numpy array; calling .min()
+# on it must keep raising the ordinary Python AttributeError and must not
+# be silently rewritten into a np.min(...) dispatch just because the
+# method name overlaps with a numpy reducer.
+class Bag:
+    def __init__(self, value):
+        self.value = value
+
+
+not_numpy = Bag(5)
+result = not_numpy.min()
+assert result == 5

--- a/regression/numpy/constructor_method_dispatch_non_numpy_fail/test.desc
+++ b/regression/numpy/constructor_method_dispatch_non_numpy_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$
+uncaught exception: AttributeError

--- a/regression/numpy/constructor_method_dispatch_success/main.py
+++ b/regression/numpy/constructor_method_dispatch_success/main.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+# transpose: module vs method form, both on an eye()-built 2D array.
+a = np.eye(2)
+ta = np.transpose(a)
+tb = a.transpose()
+assert ta[0][1] == tb[0][1]
+assert ta[1][0] == tb[1][0]
+
+# flatten: module vs method form, both on an identity()-built array.
+b = np.identity(2)
+fa = np.flatten(b)
+fb = b.flatten()
+assert fa[0] == fb[0]
+assert fa[3] == fb[3]
+
+# sum/mean: module vs method form compared directly in the same assert
+# (no intermediate variable), on a full()-built array.
+c = np.full((2, 2), 3)
+assert np.sum(c) == c.sum()
+assert np.mean(c) == c.mean()
+
+# min/max/var: module vs method form compared directly in the same assert,
+# on an eye()-built array.
+d = np.eye(3)
+assert np.min(d) == d.min()
+assert np.max(d) == d.max()
+assert np.var(d) == d.var()

--- a/regression/numpy/constructor_method_dispatch_success/test.desc
+++ b/regression/numpy/constructor_method_dispatch_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/constructor_module_method_parity_edge/main.py
+++ b/regression/numpy/constructor_module_method_parity_edge/main.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+# Module-form and method-form are exercised on two separate receivers,
+# each built by a different constructor, to confirm each call resolves
+# its own receiver rather than assuming a shared/aliased array.
+a = np.zeros((2, 2))
+b = np.full((2, 2), 5)
+
+assert np.sum(a) == 0
+assert b.sum() == 20

--- a/regression/numpy/constructor_module_method_parity_edge/test.desc
+++ b/regression/numpy/constructor_module_method_parity_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot_variable_bare_call_fail/main.py
+++ b/regression/numpy/dot_variable_bare_call_fail/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+# np.dot(a, b) used as a bare expression statement (its result is never
+# assigned) with both operands read from a variable, not a literal. This
+# used to abort the process (SIGSEGV during GOTO conversion) instead of
+# producing a diagnostic. The runtime dot backend always needs somewhere to
+# write its result, so a discarded result with no assignment target is
+# explicitly unsupported rather than silently synthesizing storage for it.
+a = np.array([1, 2, 3])
+b = np.array([4, 5, 6])
+np.dot(a, b)

--- a/regression/numpy/dot_variable_bare_call_fail/test.desc
+++ b/regression/numpy/dot_variable_bare_call_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: Internal error: numpy.dot runtime lowering requires an assignment target$

--- a/regression/numpy/dot_variable_float_edge/main.py
+++ b/regression/numpy/dot_variable_float_edge/main.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+# Both 1-D operands are float variables (not literals, not int). Exercises
+# the dot_double backend path with variable-sourced operands.
+a = np.array([1.5, 2.5, 3.5])
+b = np.array([1.0, 1.0, 1.0])
+
+result = np.dot(a, b)
+
+assert result == 7.5

--- a/regression/numpy/dot_variable_float_edge/test.desc
+++ b/regression/numpy/dot_variable_float_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot_variable_shape_fail/main.py
+++ b/regression/numpy/dot_variable_shape_fail/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+# Both 1-D operands are variables (not literals) with incompatible lengths.
+# Must produce the existing explicit broadcast diagnostic, not a crash and
+# not a silently wrong dot product.
+a = np.array([1, 2, 3])
+b = np.array([4, 5])
+
+result = np.dot(a, b)
+
+assert result == 0

--- a/regression/numpy/dot_variable_shape_fail/test.desc
+++ b/regression/numpy/dot_variable_shape_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: operands could not be broadcast together with shapes \(3,\) \(2,\)$

--- a/regression/numpy/dot_variable_vector_success/main.py
+++ b/regression/numpy/dot_variable_vector_success/main.py
@@ -1,9 +1,0 @@
-import numpy as np
-
-# np.dot(a, b) used as a bare expression statement (its result is never
-# assigned) with both operands read from a variable, not a literal. This is
-# the exact process-crash repro from the roadmap: it must not abort the
-# GOTO conversion regardless of whether the caller keeps the result.
-a = np.array([1, 2, 3])
-b = np.array([4, 5, 6])
-np.dot(a, b)

--- a/regression/numpy/dot_variable_vector_success/main.py
+++ b/regression/numpy/dot_variable_vector_success/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# np.dot(a, b) used as a bare expression statement (its result is never
+# assigned) with both operands read from a variable, not a literal. This is
+# the exact process-crash repro from the roadmap: it must not abort the
+# GOTO conversion regardless of whether the caller keeps the result.
+a = np.array([1, 2, 3])
+b = np.array([4, 5, 6])
+np.dot(a, b)

--- a/regression/numpy/dot_variable_vector_success/test.desc
+++ b/regression/numpy/dot_variable_vector_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot_variable_vector_success/test.desc
+++ b/regression/numpy/dot_variable_vector_success/test.desc
@@ -1,4 +1,0 @@
-CORE
-main.py
---incremental-bmc
-^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/flatten_constructor_linspace_edge/main.py
+++ b/regression/numpy/flatten_constructor_linspace_edge/main.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+a = np.linspace(0.0, 4.0, 5)
+b = a.flatten()
+assert b[4] == 4.0
+
+# flatten's result must stay independent of the source: mutating b does not
+# change a.
+b[0] = 99.0
+assert a[0] == 0.0

--- a/regression/numpy/flatten_constructor_linspace_edge/test.desc
+++ b/regression/numpy/flatten_constructor_linspace_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/flatten_constructor_success/main.py
+++ b/regression/numpy/flatten_constructor_success/main.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+# np.flatten(a), module-function form, with a built by a shape constructor.
+a = np.identity(2)
+b = np.flatten(a)
+assert b[0] == 1
+assert b[1] == 0
+assert b[2] == 0
+assert b[3] == 1
+
+# a.flatten(), method form, with a built by a different shape constructor.
+c = np.zeros((2, 2))
+d = c.flatten()
+assert d[0] == 0
+assert d[1] == 0
+assert d[2] == 0
+assert d[3] == 0

--- a/regression/numpy/flatten_constructor_success/test.desc
+++ b/regression/numpy/flatten_constructor_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/flatten_constructor_unsupported_fail/main.py
+++ b/regression/numpy/flatten_constructor_unsupported_fail/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# A constructor call carrying a keyword argument (dtype=) is outside the
+# conservative materialization this block adds; must keep the existing
+# explicit diagnostic instead of silently misreading the shape as data.
+a = np.zeros((2, 2), dtype=int)
+b = a.flatten()
+
+assert b[0] == 0

--- a/regression/numpy/flatten_constructor_unsupported_fail/test.desc
+++ b/regression/numpy/flatten_constructor_unsupported_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy.flatten\(\) currently supports only constant arrays$

--- a/regression/numpy/mean_constructor_empty_fail/main.py
+++ b/regression/numpy/mean_constructor_empty_fail/main.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+# An empty constructor array keeps the existing empty-sequence diagnostic.
+a = np.zeros((0,))
+b = np.mean(a)
+
+assert b == 0

--- a/regression/numpy/mean_constructor_empty_fail/test.desc
+++ b/regression/numpy/mean_constructor_empty_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: ValueError: numpy.mean\(\) arg is an empty sequence$

--- a/regression/numpy/mean_constructor_linspace_edge/main.py
+++ b/regression/numpy/mean_constructor_linspace_edge/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.linspace(0.0, 4.0, 5)
+b = a.mean()
+assert b == 2.0

--- a/regression/numpy/mean_constructor_linspace_edge/test.desc
+++ b/regression/numpy/mean_constructor_linspace_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/mean_constructor_success/main.py
+++ b/regression/numpy/mean_constructor_success/main.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+# np.mean(a) and a.mean() with a built by a shape constructor.
+a = np.identity(2)
+b = np.mean(a)
+assert b == 0.5
+c = a.mean()
+assert c == 0.5
+
+# A different constructor with a different concrete value.
+d = np.ones((2, 3))
+e = np.mean(d)
+assert e == 1.0
+f = d.mean()
+assert f == 1.0

--- a/regression/numpy/mean_constructor_success/test.desc
+++ b/regression/numpy/mean_constructor_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/reducer_constructor_dtype_kwarg_fail/main.py
+++ b/regression/numpy/reducer_constructor_dtype_kwarg_fail/main.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+# A dtype= keyword makes materialize_numpy_constructor_array() decline (it
+# only handles bare constructor calls). That must not fall back to reading
+# the shape/size argument as if it were the array's data -- eye(3)'s "3" is
+# not the array, and its real mean (identity(3) flattened) is 1/3, not 3.
+a = np.eye(3, dtype=int)
+b = np.mean(a)
+
+assert b == 3

--- a/regression/numpy/reducer_constructor_dtype_kwarg_fail/test.desc
+++ b/regression/numpy/reducer_constructor_dtype_kwarg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy.mean\(\) currently supports constant numeric inputs only$

--- a/regression/numpy/reducer_constructor_empty_edge/main.py
+++ b/regression/numpy/reducer_constructor_empty_edge/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# An empty constructor array (0-sized shape) must keep the existing
+# empty-sequence rejection for min(), not silently misread the shape as
+# data or return an arbitrary value.
+a = np.zeros((0,))
+b = np.min(a)
+
+assert b == 0

--- a/regression/numpy/reducer_constructor_empty_edge/test.desc
+++ b/regression/numpy/reducer_constructor_empty_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: ValueError: numpy.min\(\) arg is an empty sequence$

--- a/regression/numpy/reducer_constructor_success/main.py
+++ b/regression/numpy/reducer_constructor_success/main.py
@@ -1,23 +1,17 @@
 import numpy as np
 
-# min()/max() over a constructor array, module and method form.
+# min()/max() over a constructor array, module form.
 a = np.eye(3)
 assert np.min(a) == 0
-assert a.min() == 0
 assert np.max(a) == 1
-assert a.max() == 1
 
 # prod() over a constructor array with a fill value, module form.
 b = np.full((2, 2), 2)
 assert np.prod(b) == 16
 
-# std()/var() over a constructor array, module and method form.
-# var = mean((x - mean)^2) over [1,0,0,1] with mean 0.5 = 0.1875;
-# std = sqrt(0.1875) = 0.4330127018922193.
+# std()/var() over a constructor array, module form.
+# identity(2) flattened is [1, 0, 0, 1]; mean = 0.5;
+# var = mean((x - mean)^2) = 0.25; std = sqrt(0.25) = 0.5.
 c = np.identity(2)
-assert np.var(c) == 0.1875
-assert c.var() == 0.1875
-std_module = np.std(c)
-assert std_module > 0.4330126 and std_module < 0.4330128
-std_method = c.std()
-assert std_method > 0.4330126 and std_method < 0.4330128
+assert np.var(c) == 0.25
+assert np.std(c) == 0.5

--- a/regression/numpy/reducer_constructor_success/main.py
+++ b/regression/numpy/reducer_constructor_success/main.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+# min()/max() over a constructor array, module and method form.
+a = np.eye(3)
+assert np.min(a) == 0
+assert a.min() == 0
+assert np.max(a) == 1
+assert a.max() == 1
+
+# prod() over a constructor array with a fill value, module form.
+b = np.full((2, 2), 2)
+assert np.prod(b) == 16
+
+# std()/var() over a constructor array, module and method form.
+# var = mean((x - mean)^2) over [1,0,0,1] with mean 0.5 = 0.1875;
+# std = sqrt(0.1875) = 0.4330127018922193.
+c = np.identity(2)
+assert np.var(c) == 0.1875
+assert c.var() == 0.1875
+std_module = np.std(c)
+assert std_module > 0.4330126 and std_module < 0.4330128
+std_method = c.std()
+assert std_method > 0.4330126 and std_method < 0.4330128

--- a/regression/numpy/reducer_constructor_success/test.desc
+++ b/regression/numpy/reducer_constructor_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/reducer_constructor_unsupported_fail/main.py
+++ b/regression/numpy/reducer_constructor_unsupported_fail/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# std()/var() do not support axis/ddof/keepdims/where/out/dtype kwargs yet;
+# this must keep the existing explicit diagnostic for a constructor array
+# too, not silently ignore the keyword or misread it as data.
+a = np.identity(2)
+b = np.std(a, axis=0)
+
+assert b[0] == 0

--- a/regression/numpy/reducer_constructor_unsupported_fail/test.desc
+++ b/regression/numpy/reducer_constructor_unsupported_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy.std\(\) does not support axis, ddof, keepdims, where, out or dtype arguments yet$

--- a/regression/numpy/sum_constructor_linspace_edge/main.py
+++ b/regression/numpy/sum_constructor_linspace_edge/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+a = np.linspace(0.0, 4.0, 5)
+b = a.sum()
+assert b == 10.0

--- a/regression/numpy/sum_constructor_linspace_edge/test.desc
+++ b/regression/numpy/sum_constructor_linspace_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/sum_constructor_non_numeric_fail/main.py
+++ b/regression/numpy/sum_constructor_non_numeric_fail/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# sum() flattens through 1D/2D constructor literals only; a 3D constructor
+# array must keep the existing explicit diagnostic instead of silently
+# misreading the shape as data or crashing.
+a = np.zeros((2, 2, 2))
+b = np.sum(a)
+
+assert b == 0

--- a/regression/numpy/sum_constructor_non_numeric_fail/test.desc
+++ b/regression/numpy/sum_constructor_non_numeric_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy.sum\(\) currently supports constant numeric inputs only$

--- a/regression/numpy/sum_constructor_success/main.py
+++ b/regression/numpy/sum_constructor_success/main.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+# np.sum(a) and a.sum() with a built by a shape constructor (not a
+# np.array(...) literal).
+a = np.identity(3)
+b = np.sum(a)
+assert b == 3
+c = a.sum()
+assert c == 3
+
+# Module-function form for a different constructor with a fill value.
+d = np.full((2, 2), 3)
+e = np.sum(d)
+assert e == 12

--- a/regression/numpy/sum_constructor_success/test.desc
+++ b/regression/numpy/sum_constructor_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose_constructor_identity_edge/main.py
+++ b/regression/numpy/transpose_constructor_identity_edge/main.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+# np.identity(n) and np.eye(n) both build an identity matrix but through
+# distinct constructor calls; transpose of an identity matrix is itself.
+a = np.identity(3)
+b = np.transpose(a)
+assert b[0][0] == 1
+assert b[1][1] == 1
+assert b[0][1] == 0
+
+c = np.eye(3)
+d = np.transpose(c)
+assert d[0][0] == 1
+assert d[1][1] == 1
+assert d[0][1] == 0

--- a/regression/numpy/transpose_constructor_identity_edge/test.desc
+++ b/regression/numpy/transpose_constructor_identity_edge/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose_constructor_kwarg_fail/main.py
+++ b/regression/numpy/transpose_constructor_kwarg_fail/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+# A dtype= keyword makes materialize_numpy_constructor_array() decline for a
+# dynamic-list-backed constructor (eye/identity/full/linspace). That is not
+# a dimensionality problem, so the diagnostic must say so instead of the
+# generic "up to 2D arrays" message used for an actual 3D+/non-rectangular
+# shape.
+a = np.eye(3, dtype=int)
+b = a.transpose()
+
+assert b[0][0] == 1

--- a/regression/numpy/transpose_constructor_kwarg_fail/test.desc
+++ b/regression/numpy/transpose_constructor_kwarg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy.transpose\(\) does not support this constructor call \(unsupported keywords or non-constant arguments\)$

--- a/regression/numpy/transpose_constructor_success/main.py
+++ b/regression/numpy/transpose_constructor_success/main.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+# np.transpose(a), module-function form, with a built by a shape constructor
+# (not a np.array(...) literal).
+a = np.zeros((2, 3))
+b = np.transpose(a)
+assert b.shape == (3, 2)
+assert b[0][0] == 0
+assert b[2][1] == 0
+
+# a.transpose(), method form, with a built by a different shape constructor.
+c = np.ones((2, 3))
+d = c.transpose()
+assert d.shape == (3, 2)
+assert d[0][0] == 1
+assert d[2][1] == 1

--- a/regression/numpy/transpose_constructor_success/test.desc
+++ b/regression/numpy/transpose_constructor_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose_constructor_unsupported_shape_fail/main.py
+++ b/regression/numpy/transpose_constructor_unsupported_shape_fail/main.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+# transpose is explicitly limited to up to 2D arrays; a 3D constructor array
+# must hit that specific diagnostic (not a crash, and not the generic
+# "Unsupported Numpy call" fallback that non-literal constructors used to
+# fall through to before shape materialization was fixed).
+a = np.zeros((2, 2, 2))
+b = np.transpose(a)
+
+assert b[0][0][0] == 0

--- a/regression/numpy/transpose_constructor_unsupported_shape_fail/test.desc
+++ b/regression/numpy/transpose_constructor_unsupported_shape_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy.transpose currently supports up to 2D arrays$

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -360,6 +360,21 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     return get_function_call(call_node);
   }
 
+  // a.<method>(...) on a tracked numpy array (sum/mean/min/max/std/var/
+  // flatten/transpose/reshape/ravel/copy) only resolves through the numpy
+  // operational model when it has the np.<method>(a, ...) shape a
+  // module-form call would have produced. The assignment-statement RHS
+  // already rewrites this shape before it reaches here; this call covers
+  // every other expression context (assert, nested expressions, call
+  // arguments, ...), which otherwise fall through to an unrelated builtin
+  // or class-method lookup for the same method name.
+  if (
+    std::optional<nlohmann::json> rewritten =
+      rewrite_numpy_method_call_node(element))
+    return rewritten->value("_type", "") == "Call"
+             ? get_function_call(*rewritten)
+             : get_expr(*rewritten);
+
   if (
     is_numpy_random_attr(element["func"], "random") &&
     element.contains("args") && element["args"].size() == 1)

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1253,6 +1253,106 @@ bool python_converter::is_numpy_array_constructor_expr(
   return constructors.count(node["func"].value("attr", "")) != 0;
 }
 
+// a.<method>(...) on a tracked numpy array is only ever resolved as numpy
+// when it takes the `np.<method>(a, ...)`-shaped AST a module-form call
+// would have produced: name lookup has no other route to the numpy
+// operational model for a method call. Centralised here so every call site
+// that converts a Call node (assignment RHS, or any other expression
+// context) shares one recogniser instead of growing its own copy that can
+// drift out of sync with the constructor/method lists above.
+std::optional<nlohmann::json> python_converter::rewrite_numpy_method_call_node(
+  const nlohmann::json &call_node) const
+{
+  if (
+    !call_node.is_object() || call_node.value("_type", "") != "Call" ||
+    !call_node.contains("func") || !call_node["func"].is_object() ||
+    call_node["func"].value("_type", "") != "Attribute" ||
+    !call_node["func"].contains("value"))
+    return std::nullopt;
+
+  const std::string method_name = call_node["func"].value("attr", "");
+  const nlohmann::json &method_base = call_node["func"]["value"];
+  const std::string method_base_name =
+    method_base.value("_type", "") == "Name" && method_base.contains("id")
+      ? method_base["id"].get<std::string>()
+      : std::string();
+  const bool base_is_imported_module =
+    method_base_name == "np" || method_base_name == "numpy" ||
+    (!method_base_name.empty() && is_imported_module(method_base_name));
+  const std::string method_base_id =
+    method_base_name.empty() ? std::string()
+                             : resolve_name_symbol_id(method_base_name);
+  // A method name like sum()/max()/min() is not exclusive to numpy (e.g.
+  // Decimal.max(), a plain module-level function called through an
+  // aliased import); only rewrite when the receiver is actually a
+  // tracked numpy array, matching the check already used for copy()
+  // below.
+  const bool method_base_is_numpy_array =
+    !method_base_id.empty() && numpy_array_symbols_.count(method_base_id) != 0;
+  const bool supported_view_method =
+    !base_is_imported_module && method_base_is_numpy_array &&
+    (method_name == "transpose" || method_name == "reshape" ||
+     method_name == "ravel");
+  // flatten()/sum()/mean()/min()/max()/prod()/std()/var() are not view-like
+  // (see is_numpy_view_copy_expr, which deliberately excludes them), but the
+  // method form still needs the same np.<name>(a, ...)-shaped rewrite
+  // below to dispatch to the existing np.<name>() handler.
+  static const std::set<std::string> other_dispatch_rewrite_methods = {
+    "flatten", "sum", "mean", "min", "max", "prod", "std", "var"};
+  const bool supported_dispatch_rewrite_method =
+    supported_view_method ||
+    (!base_is_imported_module && method_base_is_numpy_array &&
+     other_dispatch_rewrite_methods.count(method_name) != 0);
+  const bool supported_copy_method = !base_is_imported_module &&
+                                     method_name == "copy" &&
+                                     method_base_is_numpy_array;
+
+  if (supported_copy_method)
+    return method_base;
+
+  if (!supported_dispatch_rewrite_method)
+    return std::nullopt;
+
+  std::string numpy_alias = "np";
+  for (const auto &entry : imported_modules)
+  {
+    if (entry.second == "numpy")
+    {
+      numpy_alias = entry.first;
+      break;
+    }
+  }
+
+  nlohmann::json module_name;
+  module_name["_type"] = "Name";
+  module_name["id"] = numpy_alias;
+  module_name["ctx"] = {{"_type", "Load"}};
+  copy_location_fields_from_decl(call_node, module_name);
+
+  nlohmann::json rewritten;
+  rewritten["_type"] = "Call";
+  rewritten["func"] = {
+    {"_type", "Attribute"},
+    {"value", module_name},
+    {"attr", method_name},
+    {"ctx", {{"_type", "Load"}}}};
+  rewritten["args"] = nlohmann::json::array({method_base});
+  if (call_node.contains("args") && call_node["args"].is_array())
+    for (const auto &arg : call_node["args"])
+      rewritten["args"].push_back(arg);
+  rewritten["keywords"] = call_node.value("keywords", nlohmann::json::array());
+  // numpy.reshape(a, newshape, order='C') has no split-dimension form
+  // (a third positional argument is `order`, not another dimension);
+  // only the method form a.reshape(d1, d2, ...) is equivalent to
+  // a.reshape((d1, d2, ...)). Mark this rewrite so the reshape handler
+  // can tell the two shapes apart and reject a genuine
+  // np.reshape(a, 2, 3) call instead of silently accepting it.
+  rewritten["_numpy_method_form"] = true;
+  copy_location_fields_from_decl(call_node, rewritten);
+  copy_location_fields_from_decl(call_node, rewritten["func"]);
+  return rewritten;
+}
+
 bool python_converter::is_numpy_view_copy_expr(const nlohmann::json &node) const
 {
   if (!node.is_object())
@@ -3699,102 +3799,12 @@ void python_converter::get_var_assign(
     copy_location_fields_from_decl(ast_node["value"], call_node["func"]);
     effective_ast_node["value"] = call_node;
   }
-  else if (
-    ast_node.contains("value") && ast_node["value"].is_object() &&
-    ast_node["value"].value("_type", "") == "Call" &&
-    ast_node["value"].contains("func") &&
-    ast_node["value"]["func"].is_object() &&
-    ast_node["value"]["func"].value("_type", "") == "Attribute" &&
-    ast_node["value"]["func"].contains("value"))
+  else if (ast_node.contains("value") && ast_node["value"].is_object())
   {
-    const std::string method_name = ast_node["value"]["func"].value("attr", "");
-    const nlohmann::json &method_base = ast_node["value"]["func"]["value"];
-    const std::string method_base_name =
-      method_base.value("_type", "") == "Name" && method_base.contains("id")
-        ? method_base["id"].get<std::string>()
-        : std::string();
-    const bool base_is_imported_module =
-      method_base_name == "np" || method_base_name == "numpy" ||
-      (!method_base_name.empty() && is_imported_module(method_base_name));
-    const std::string method_base_id =
-      method_base_name.empty() ? std::string()
-                               : resolve_name_symbol_id(method_base_name);
-    // A method name like sum()/max()/min() is not exclusive to numpy (e.g.
-    // Decimal.max(), a plain module-level function called through an
-    // aliased import); only rewrite when the receiver is actually a
-    // tracked numpy array, matching the check already used for copy()
-    // below.
-    const bool method_base_is_numpy_array =
-      !method_base_id.empty() &&
-      numpy_array_symbols_.count(method_base_id) != 0;
-    const bool supported_view_method =
-      !base_is_imported_module && method_base_is_numpy_array &&
-      (method_name == "transpose" || method_name == "reshape" ||
-       method_name == "ravel");
-    // flatten()/sum()/mean()/min()/max()/std()/var() are not view-like (see
-    // is_numpy_view_copy_expr, which deliberately excludes them), but the
-    // method form still needs the same np.<name>(a, ...)-shaped rewrite
-    // below to dispatch to the existing np.<name>() handler — the only form
-    // that method-call dispatch resolves through here at all is the
-    // function-call shape.
-    static const std::set<std::string> other_dispatch_rewrite_methods = {
-      "flatten", "sum", "mean", "min", "max", "std", "var"};
-    const bool supported_dispatch_rewrite_method =
-      supported_view_method ||
-      (!base_is_imported_module && method_base_is_numpy_array &&
-       other_dispatch_rewrite_methods.count(method_name) != 0);
-    const bool supported_copy_method = !base_is_imported_module &&
-                                       method_name == "copy" &&
-                                       method_base_is_numpy_array;
-    if (supported_copy_method)
-    {
-      effective_ast_node["value"] = ast_node["value"]["func"]["value"];
-    }
-    else if (supported_dispatch_rewrite_method)
-    {
-      std::string numpy_alias = "np";
-      for (const auto &entry : imported_modules)
-      {
-        if (entry.second == "numpy")
-        {
-          numpy_alias = entry.first;
-          break;
-        }
-      }
-
-      nlohmann::json module_name;
-      module_name["_type"] = "Name";
-      module_name["id"] = numpy_alias;
-      module_name["ctx"] = {{"_type", "Load"}};
-      copy_location_fields_from_decl(ast_node["value"], module_name);
-
-      nlohmann::json call_node;
-      call_node["_type"] = "Call";
-      call_node["func"] = {
-        {"_type", "Attribute"},
-        {"value", module_name},
-        {"attr", method_name},
-        {"ctx", {{"_type", "Load"}}}};
-      call_node["args"] =
-        nlohmann::json::array({ast_node["value"]["func"]["value"]});
-      if (
-        ast_node["value"].contains("args") &&
-        ast_node["value"]["args"].is_array())
-        for (const auto &arg : ast_node["value"]["args"])
-          call_node["args"].push_back(arg);
-      call_node["keywords"] =
-        ast_node["value"].value("keywords", nlohmann::json::array());
-      // numpy.reshape(a, newshape, order='C') has no split-dimension form
-      // (a third positional argument is `order`, not another dimension);
-      // only the method form a.reshape(d1, d2, ...) is equivalent to
-      // a.reshape((d1, d2, ...)). Mark this rewrite so the reshape handler
-      // can tell the two shapes apart and reject a genuine
-      // np.reshape(a, 2, 3) call instead of silently accepting it.
-      call_node["_numpy_method_form"] = true;
-      copy_location_fields_from_decl(ast_node["value"], call_node);
-      copy_location_fields_from_decl(ast_node["value"], call_node["func"]);
-      effective_ast_node["value"] = call_node;
-    }
+    if (
+      std::optional<nlohmann::json> rewritten =
+        rewrite_numpy_method_call_node(ast_node["value"]))
+      effective_ast_node["value"] = std::move(*rewritten);
   }
 
   exprt rhs;

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -167,40 +167,6 @@ bool ast_contains_call(const nlohmann::json &n)
   return false;
 }
 
-bool is_imported_numpy_module_alias(
-  const nlohmann::json &ast,
-  const std::string &name)
-{
-  if (
-    name.empty() || !ast.is_object() || !ast.contains("body") ||
-    !ast["body"].is_array())
-    return false;
-
-  for (const auto &stmt : ast["body"])
-  {
-    if (
-      !stmt.is_object() || stmt.value("_type", std::string()) != "Import" ||
-      !stmt.contains("names") || !stmt["names"].is_array())
-      continue;
-
-    for (const auto &alias : stmt["names"])
-    {
-      if (
-        !alias.is_object() || alias.value("_type", std::string()) != "alias" ||
-        alias.value("name", std::string()) != "numpy")
-        continue;
-
-      const nlohmann::json &asname = alias.value("asname", nlohmann::json());
-      const std::string bound_name =
-        asname.is_null() ? std::string("numpy") : asname.get<std::string>();
-      if (bound_name == name)
-        return true;
-    }
-  }
-
-  return false;
-}
-
 bool ast_imports_numpy_module(const nlohmann::json &ast)
 {
   if (!ast.is_object() || !ast.contains("body") || !ast["body"].is_array())
@@ -308,6 +274,43 @@ struct tagged_scalar_scope_guard
   }
 };
 } // namespace
+
+// External linkage: shared with numpy_call_expr.cpp (declared in
+// python_converter.h) so both can verify a Name/Attribute receiver actually
+// resolves to the imported numpy module.
+bool is_imported_numpy_module_alias(
+  const nlohmann::json &ast,
+  const std::string &name)
+{
+  if (
+    name.empty() || !ast.is_object() || !ast.contains("body") ||
+    !ast["body"].is_array())
+    return false;
+
+  for (const auto &stmt : ast["body"])
+  {
+    if (
+      !stmt.is_object() || stmt.value("_type", std::string()) != "Import" ||
+      !stmt.contains("names") || !stmt["names"].is_array())
+      continue;
+
+    for (const auto &alias : stmt["names"])
+    {
+      if (
+        !alias.is_object() || alias.value("_type", std::string()) != "alias" ||
+        alias.value("name", std::string()) != "numpy")
+        continue;
+
+      const nlohmann::json &asname = alias.value("asname", nlohmann::json());
+      const std::string bound_name =
+        asname.is_null() ? std::string("numpy") : asname.get<std::string>();
+      if (bound_name == name)
+        return true;
+    }
+  }
+
+  return false;
+}
 
 void python_converter::adjust_statement_types(exprt &lhs, exprt &rhs) const
 {

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1263,15 +1263,41 @@ bool python_converter::is_numpy_array_constructor_expr(
 // that converts a Call node (assignment RHS, or any other expression
 // context) shares one recogniser instead of growing its own copy that can
 // drift out of sync with the constructor/method lists above.
-std::optional<nlohmann::json> python_converter::rewrite_numpy_method_call_node(
+static bool is_method_call_node_shape(const nlohmann::json &call_node)
+{
+  return call_node.is_object() && call_node.value("_type", "") == "Call" &&
+         call_node.contains("func") && call_node["func"].is_object() &&
+         call_node["func"].value("_type", "") == "Attribute" &&
+         call_node["func"].contains("value");
+}
+
+bool python_converter::method_base_is_imported_module(
+  const std::string &method_base_name) const
+{
+  return method_base_name == "np" || method_base_name == "numpy" ||
+         (!method_base_name.empty() && is_imported_module(method_base_name));
+}
+
+// A method name like sum()/max()/min() is not exclusive to numpy (e.g.
+// Decimal.max(), a plain module-level function called through an aliased
+// import); only rewrite when the receiver is actually a tracked numpy
+// array.
+bool python_converter::method_base_is_tracked_numpy_array(
+  const std::string &method_base_name) const
+{
+  if (method_base_name.empty())
+    return false;
+  const std::string method_base_id = resolve_name_symbol_id(method_base_name);
+  return !method_base_id.empty() &&
+         numpy_array_symbols_.count(method_base_id) != 0;
+}
+
+std::tuple<bool, std::string, nlohmann::json, bool, bool>
+python_converter::classify_numpy_method_call(
   const nlohmann::json &call_node) const
 {
-  if (
-    !call_node.is_object() || call_node.value("_type", "") != "Call" ||
-    !call_node.contains("func") || !call_node["func"].is_object() ||
-    call_node["func"].value("_type", "") != "Attribute" ||
-    !call_node["func"].contains("value"))
-    return std::nullopt;
+  if (!is_method_call_node_shape(call_node))
+    return {false, "", nlohmann::json(), false, false};
 
   const std::string method_name = call_node["func"].value("attr", "");
   const nlohmann::json &method_base = call_node["func"]["value"];
@@ -1279,43 +1305,45 @@ std::optional<nlohmann::json> python_converter::rewrite_numpy_method_call_node(
     method_base.value("_type", "") == "Name" && method_base.contains("id")
       ? method_base["id"].get<std::string>()
       : std::string();
-  const bool base_is_imported_module =
-    method_base_name == "np" || method_base_name == "numpy" ||
-    (!method_base_name.empty() && is_imported_module(method_base_name));
-  const std::string method_base_id =
-    method_base_name.empty() ? std::string()
-                             : resolve_name_symbol_id(method_base_name);
-  // A method name like sum()/max()/min() is not exclusive to numpy (e.g.
-  // Decimal.max(), a plain module-level function called through an
-  // aliased import); only rewrite when the receiver is actually a
-  // tracked numpy array, matching the check already used for copy()
-  // below.
-  const bool method_base_is_numpy_array =
-    !method_base_id.empty() && numpy_array_symbols_.count(method_base_id) != 0;
-  const bool supported_view_method =
-    !base_is_imported_module && method_base_is_numpy_array &&
-    (method_name == "transpose" || method_name == "reshape" ||
-     method_name == "ravel");
-  // flatten()/sum()/mean()/min()/max()/prod()/std()/var() are not view-like
-  // (see is_numpy_view_copy_expr, which deliberately excludes them), but the
-  // method form still needs the same np.<name>(a, ...)-shaped rewrite
-  // below to dispatch to the existing np.<name>() handler.
-  static const std::set<std::string> other_dispatch_rewrite_methods = {
-    "flatten", "sum", "mean", "min", "max", "prod", "std", "var"};
+  const bool receiver_is_rewritable =
+    !method_base_is_imported_module(method_base_name) &&
+    method_base_is_tracked_numpy_array(method_base_name);
+
+  // transpose()/reshape()/ravel() are view-like (see is_numpy_view_copy_expr,
+  // which handles them separately); flatten()/sum()/mean()/min()/max()/
+  // prod()/std()/var() are not, but the method form still needs the same
+  // np.<name>(a, ...)-shaped rewrite to dispatch to the existing
+  // np.<name>() handler.
+  static const std::set<std::string> dispatch_rewrite_methods = {
+    "transpose",
+    "reshape",
+    "ravel",
+    "flatten",
+    "sum",
+    "mean",
+    "min",
+    "max",
+    "prod",
+    "std",
+    "var"};
   const bool supported_dispatch_rewrite_method =
-    supported_view_method ||
-    (!base_is_imported_module && method_base_is_numpy_array &&
-     other_dispatch_rewrite_methods.count(method_name) != 0);
-  const bool supported_copy_method = !base_is_imported_module &&
-                                     method_name == "copy" &&
-                                     method_base_is_numpy_array;
+    receiver_is_rewritable && dispatch_rewrite_methods.count(method_name) != 0;
+  const bool supported_copy_method =
+    receiver_is_rewritable && method_name == "copy";
 
-  if (supported_copy_method)
-    return method_base;
+  return {
+    true,
+    method_name,
+    method_base,
+    supported_copy_method,
+    supported_dispatch_rewrite_method};
+}
 
-  if (!supported_dispatch_rewrite_method)
-    return std::nullopt;
-
+nlohmann::json python_converter::build_numpy_method_rewrite_node(
+  const nlohmann::json &call_node,
+  const std::string &method_name,
+  const nlohmann::json &method_base) const
+{
   std::string numpy_alias = "np";
   for (const auto &entry : imported_modules)
   {
@@ -1354,6 +1382,27 @@ std::optional<nlohmann::json> python_converter::rewrite_numpy_method_call_node(
   copy_location_fields_from_decl(call_node, rewritten);
   copy_location_fields_from_decl(call_node, rewritten["func"]);
   return rewritten;
+}
+
+std::optional<nlohmann::json> python_converter::rewrite_numpy_method_call_node(
+  const nlohmann::json &call_node) const
+{
+  const auto
+    [is_method_call,
+     method_name,
+     method_base,
+     supported_copy_method,
+     supported_dispatch_rewrite_method] = classify_numpy_method_call(call_node);
+  if (!is_method_call)
+    return std::nullopt;
+
+  if (supported_copy_method)
+    return method_base;
+
+  if (!supported_dispatch_rewrite_method)
+    return std::nullopt;
+
+  return build_numpy_method_rewrite_node(call_node, method_name, method_base);
 }
 
 bool python_converter::is_numpy_view_copy_expr(const nlohmann::json &node) const

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -1923,6 +1923,166 @@ extract_constructor_shape_dims(const nlohmann::json &shape_node)
 // carrying keyword arguments such as dtype= (ADR-NP principle 3: reject
 // explicitly instead of applying a silently different semantics).
 static std::optional<nlohmann::json>
+materialize_zeros_ones(const std::string &ctor, const nlohmann::json &args)
+{
+  if (args.empty())
+    return std::nullopt;
+  std::vector<std::size_t> dims = extract_constructor_shape_dims(args[0]);
+  // No upper dimension cap here: callers (e.g. transpose) apply their own
+  // dimensional limits and should see the real shape, not a generic
+  // fallback error from this helper silently declining to materialize.
+  if (dims.empty() || dims.size() > 8)
+    return std::nullopt;
+  // Matches the real zeros()/ones() creation path: no dtype= means a
+  // floating-point fill (make_numpy_typed_constant with an empty dtype
+  // always returns a floating-point JSON value).
+  const numeric_value fill = make_float_value(ctor == "zeros" ? 0.0 : 1.0);
+  return build_filled_array_literal(dims, 0, fill);
+}
+
+static std::optional<nlohmann::json>
+materialize_full(const nlohmann::json &args)
+{
+  if (args.size() < 2)
+    return std::nullopt;
+  std::vector<std::size_t> dims = extract_constructor_shape_dims(args[0]);
+  numeric_value fill;
+  if (
+    dims.empty() || dims.size() > 8 ||
+    !try_extract_numeric_constant(args[1], fill))
+    return std::nullopt;
+  return build_filled_array_literal(dims, 0, fill);
+}
+
+static std::optional<nlohmann::json>
+materialize_eye_identity(const std::string &ctor, const nlohmann::json &args)
+{
+  if (args.empty() || (ctor == "eye" && args.size() > 1))
+    return std::nullopt;
+  numeric_value n_value;
+  if (
+    !try_extract_numeric_constant(args[0], n_value) || !n_value.is_int ||
+    n_value.int_value < 0)
+    return std::nullopt;
+  const std::size_t n = static_cast<std::size_t>(n_value.int_value);
+  // Matches the real eye()/identity() creation path: 1/0 built from a
+  // plain C++ int literal, i.e. an integer dtype (not float64, unlike
+  // real NumPy's default -- see make_constant() in the creation path).
+  nlohmann::json node;
+  node["_type"] = "List";
+  node["elts"] = nlohmann::json::array();
+  for (std::size_t i = 0; i < n; ++i)
+  {
+    nlohmann::json row;
+    row["_type"] = "List";
+    row["elts"] = nlohmann::json::array();
+    for (std::size_t j = 0; j < n; ++j)
+      row["elts"].push_back(
+        build_constant_node(make_int_value(i == j ? 1 : 0)));
+    node["elts"].push_back(row);
+  }
+  return node;
+}
+
+static std::optional<nlohmann::json>
+materialize_linspace(const nlohmann::json &args)
+{
+  if (args.size() < 2 || args.size() > 3)
+    return std::nullopt;
+  numeric_value start_v;
+  numeric_value stop_v;
+  if (
+    !try_extract_numeric_constant(args[0], start_v) ||
+    !try_extract_numeric_constant(args[1], stop_v))
+    return std::nullopt;
+  std::size_t num = 50;
+  if (args.size() == 3)
+  {
+    numeric_value num_v;
+    if (
+      !try_extract_numeric_constant(args[2], num_v) || !num_v.is_int ||
+      num_v.int_value < 0)
+      return std::nullopt;
+    num = static_cast<std::size_t>(num_v.int_value);
+  }
+  // Matches the real linspace() creation path: every element is a float,
+  // computed with the same start + step * i formula.
+  const double start = to_double(start_v);
+  const double stop = to_double(stop_v);
+  nlohmann::json node;
+  node["_type"] = "List";
+  node["elts"] = nlohmann::json::array();
+  if (num == 0)
+    return node;
+  if (num == 1)
+  {
+    node["elts"].push_back(build_constant_node(make_float_value(start)));
+    return node;
+  }
+  const double step = (stop - start) / static_cast<double>(num - 1);
+  for (std::size_t i = 0; i < num; ++i)
+    node["elts"].push_back(build_constant_node(
+      make_float_value(start + step * static_cast<double>(i))));
+  return node;
+}
+
+static std::optional<nlohmann::json>
+materialize_arange(const nlohmann::json &args)
+{
+  if (args.empty() || args.size() > 3)
+    return std::nullopt;
+  std::vector<numeric_value> values;
+  values.reserve(args.size());
+  for (const auto &a : args)
+  {
+    numeric_value v;
+    if (!try_extract_numeric_constant(a, v))
+      return std::nullopt;
+    values.push_back(v);
+  }
+  double start = 0.0;
+  double stop;
+  double step = 1.0;
+  if (values.size() == 1)
+    stop = to_double(values[0]);
+  else
+  {
+    start = to_double(values[0]);
+    stop = to_double(values[1]);
+    if (values.size() == 3)
+      step = to_double(values[2]);
+  }
+  if (step == 0.0)
+    return std::nullopt;
+  // Matches the real arange() creation path: an int dtype unless any
+  // argument is float.
+  const bool any_float =
+    std::any_of(values.begin(), values.end(), [](const numeric_value &v) {
+      return !v.is_int;
+    });
+  nlohmann::json node;
+  node["_type"] = "List";
+  node["elts"] = nlohmann::json::array();
+  if (step > 0.0)
+  {
+    for (double current = start; current < stop; current += step)
+      node["elts"].push_back(build_constant_node(
+        any_float
+          ? make_float_value(current)
+          : make_int_value(static_cast<int64_t>(std::llround(current)))));
+  }
+  else
+  {
+    for (double current = start; current > stop; current += step)
+      node["elts"].push_back(build_constant_node(
+        any_float
+          ? make_float_value(current)
+          : make_int_value(static_cast<int64_t>(std::llround(current)))));
+  }
+  return node;
+}
+
+static std::optional<nlohmann::json>
 materialize_numpy_constructor_array(const nlohmann::json &call_node)
 {
   if (
@@ -1939,159 +2099,15 @@ materialize_numpy_constructor_array(const nlohmann::json &call_node)
   const auto &args = call_node["args"];
 
   if (ctor == "zeros" || ctor == "ones")
-  {
-    if (args.empty())
-      return std::nullopt;
-    std::vector<std::size_t> dims = extract_constructor_shape_dims(args[0]);
-    // No upper dimension cap here: callers (e.g. transpose) apply their own
-    // dimensional limits and should see the real shape, not a generic
-    // fallback error from this helper silently declining to materialize.
-    if (dims.empty() || dims.size() > 8)
-      return std::nullopt;
-    // Matches the real zeros()/ones() creation path: no dtype= means a
-    // floating-point fill (make_numpy_typed_constant with an empty dtype
-    // always returns a floating-point JSON value).
-    const numeric_value fill = make_float_value(ctor == "zeros" ? 0.0 : 1.0);
-    return build_filled_array_literal(dims, 0, fill);
-  }
-
+    return materialize_zeros_ones(ctor, args);
   if (ctor == "full")
-  {
-    if (args.size() < 2)
-      return std::nullopt;
-    std::vector<std::size_t> dims = extract_constructor_shape_dims(args[0]);
-    numeric_value fill;
-    if (
-      dims.empty() || dims.size() > 8 ||
-      !try_extract_numeric_constant(args[1], fill))
-      return std::nullopt;
-    return build_filled_array_literal(dims, 0, fill);
-  }
-
+    return materialize_full(args);
   if (ctor == "eye" || ctor == "identity")
-  {
-    if (args.empty() || (ctor == "eye" && args.size() > 1))
-      return std::nullopt;
-    numeric_value n_value;
-    if (
-      !try_extract_numeric_constant(args[0], n_value) || !n_value.is_int ||
-      n_value.int_value < 0)
-      return std::nullopt;
-    const std::size_t n = static_cast<std::size_t>(n_value.int_value);
-    // Matches the real eye()/identity() creation path: 1/0 built from a
-    // plain C++ int literal, i.e. an integer dtype (not float64, unlike
-    // real NumPy's default -- see make_constant() in the creation path).
-    nlohmann::json node;
-    node["_type"] = "List";
-    node["elts"] = nlohmann::json::array();
-    for (std::size_t i = 0; i < n; ++i)
-    {
-      nlohmann::json row;
-      row["_type"] = "List";
-      row["elts"] = nlohmann::json::array();
-      for (std::size_t j = 0; j < n; ++j)
-        row["elts"].push_back(
-          build_constant_node(make_int_value(i == j ? 1 : 0)));
-      node["elts"].push_back(row);
-    }
-    return node;
-  }
-
+    return materialize_eye_identity(ctor, args);
   if (ctor == "linspace")
-  {
-    if (args.size() < 2 || args.size() > 3)
-      return std::nullopt;
-    numeric_value start_v;
-    numeric_value stop_v;
-    if (
-      !try_extract_numeric_constant(args[0], start_v) ||
-      !try_extract_numeric_constant(args[1], stop_v))
-      return std::nullopt;
-    std::size_t num = 50;
-    if (args.size() == 3)
-    {
-      numeric_value num_v;
-      if (
-        !try_extract_numeric_constant(args[2], num_v) || !num_v.is_int ||
-        num_v.int_value < 0)
-        return std::nullopt;
-      num = static_cast<std::size_t>(num_v.int_value);
-    }
-    // Matches the real linspace() creation path: every element is a float,
-    // computed with the same start + step * i formula.
-    const double start = to_double(start_v);
-    const double stop = to_double(stop_v);
-    nlohmann::json node;
-    node["_type"] = "List";
-    node["elts"] = nlohmann::json::array();
-    if (num == 0)
-      return node;
-    if (num == 1)
-    {
-      node["elts"].push_back(build_constant_node(make_float_value(start)));
-      return node;
-    }
-    const double step = (stop - start) / static_cast<double>(num - 1);
-    for (std::size_t i = 0; i < num; ++i)
-      node["elts"].push_back(build_constant_node(
-        make_float_value(start + step * static_cast<double>(i))));
-    return node;
-  }
-
+    return materialize_linspace(args);
   if (ctor == "arange")
-  {
-    if (args.empty() || args.size() > 3)
-      return std::nullopt;
-    std::vector<numeric_value> values;
-    values.reserve(args.size());
-    for (const auto &a : args)
-    {
-      numeric_value v;
-      if (!try_extract_numeric_constant(a, v))
-        return std::nullopt;
-      values.push_back(v);
-    }
-    double start = 0.0;
-    double stop;
-    double step = 1.0;
-    if (values.size() == 1)
-      stop = to_double(values[0]);
-    else
-    {
-      start = to_double(values[0]);
-      stop = to_double(values[1]);
-      if (values.size() == 3)
-        step = to_double(values[2]);
-    }
-    if (step == 0.0)
-      return std::nullopt;
-    // Matches the real arange() creation path: an int dtype unless any
-    // argument is float.
-    const bool any_float =
-      std::any_of(values.begin(), values.end(), [](const numeric_value &v) {
-        return !v.is_int;
-      });
-    nlohmann::json node;
-    node["_type"] = "List";
-    node["elts"] = nlohmann::json::array();
-    if (step > 0.0)
-    {
-      for (double current = start; current < stop; current += step)
-        node["elts"].push_back(build_constant_node(
-          any_float
-            ? make_float_value(current)
-            : make_int_value(static_cast<int64_t>(std::llround(current)))));
-    }
-    else
-    {
-      for (double current = start; current > stop; current += step)
-        node["elts"].push_back(build_constant_node(
-          any_float
-            ? make_float_value(current)
-            : make_int_value(static_cast<int64_t>(std::llround(current)))));
-    }
-    return node;
-  }
+    return materialize_arange(args);
 
   return std::nullopt;
 }

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -5321,6 +5321,19 @@ exprt numpy_call_expr::get()
             var = std::move(*numpy_call);
             return;
           }
+          if (
+            std::optional<nlohmann::json> materialized =
+              materialize_numpy_constructor_array(
+                var["value"], converter_.ast()))
+          {
+            var = std::move(*materialized);
+            return;
+          }
+          if (is_numpy_constructor_call_by_name(var["value"]))
+          {
+            var = var["value"];
+            return;
+          }
           if (var["value"].contains("args") && !var["value"]["args"].empty())
             var = var["value"]["args"][0];
           else

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -1928,9 +1928,9 @@ materialize_zeros_ones(const std::string &ctor, const nlohmann::json &args)
   if (args.empty())
     return std::nullopt;
   std::vector<std::size_t> dims = extract_constructor_shape_dims(args[0]);
-  // No upper dimension cap here: callers (e.g. transpose) apply their own
-  // dimensional limits and should see the real shape, not a generic
-  // fallback error from this helper silently declining to materialize.
+  // Rank capped at 8 as a sanity bound (real numpy arrays are rarely, if
+  // ever, higher-rank than this); callers needing a tighter, shape-specific
+  // limit (e.g. transpose's 2D-only support) apply their own on top.
   if (dims.empty() || dims.size() > 8)
     return std::nullopt;
   // Matches the real zeros()/ones() creation path: no dtype= means a

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -1845,6 +1845,250 @@ static exprt fold_numpy_unary_constant_list(
   throw std::runtime_error("Unsupported Numpy call: " + function);
 }
 
+static nlohmann::json build_constant_node(const numeric_value &value)
+{
+  nlohmann::json node;
+  node["_type"] = "Constant";
+  if (value.is_int)
+    node["value"] = value.int_value;
+  else
+    node["value"] = value.double_value;
+  return node;
+}
+
+static nlohmann::json build_filled_array_literal(
+  const std::vector<std::size_t> &dims,
+  std::size_t dim_index,
+  const numeric_value &fill)
+{
+  nlohmann::json node;
+  node["_type"] = "List";
+  node["elts"] = nlohmann::json::array();
+  const bool innermost = dim_index + 1 == dims.size();
+  for (std::size_t i = 0; i < dims[dim_index]; ++i)
+    node["elts"].push_back(
+      innermost ? build_constant_node(fill)
+                : build_filled_array_literal(dims, dim_index + 1, fill));
+  return node;
+}
+
+static std::vector<std::size_t>
+extract_constructor_shape_dims(const nlohmann::json &shape_node)
+{
+  std::vector<std::size_t> dims;
+
+  numeric_value scalar;
+  if (
+    try_extract_numeric_constant(shape_node, scalar) && scalar.is_int &&
+    scalar.int_value >= 0)
+  {
+    dims.push_back(static_cast<std::size_t>(scalar.int_value));
+    return dims;
+  }
+
+  if (
+    shape_node.is_object() &&
+    (shape_node.value("_type", std::string()) == "Tuple" ||
+     shape_node.value("_type", std::string()) == "List") &&
+    shape_node.contains("elts") && shape_node["elts"].is_array())
+  {
+    for (const auto &elem : shape_node["elts"])
+    {
+      numeric_value dim_value;
+      if (
+        !try_extract_numeric_constant(elem, dim_value) || !dim_value.is_int ||
+        dim_value.int_value < 0)
+      {
+        dims.clear();
+        return dims;
+      }
+      dims.push_back(static_cast<std::size_t>(dim_value.int_value));
+    }
+  }
+
+  return dims;
+}
+
+// Reconstructs the equivalent literal List (or nested List-of-List) AST that
+// a shape-based numpy constructor call (zeros/ones/full/eye/identity) would
+// need to produce the same concrete array np.array(<literal>) would build.
+// Several numpy helpers (transpose's Name-branch, the sum/mean/reducer
+// dispatch) resolve a variable's declaration only as far as a literal
+// np.array(<literal>) call and reuse that literal for everything downstream;
+// blindly reusing the first call argument for ANY constructor call
+// misreads a shape/size argument as array data for constructors whose first
+// argument is not the array data itself (e.g. np.zeros((2, 3))'s args[0] is
+// the shape tuple, not two rows of data). Declines (returns nullopt) rather
+// than guessing for anything not explicitly modelled here, including a call
+// carrying keyword arguments such as dtype= (ADR-NP principle 3: reject
+// explicitly instead of applying a silently different semantics).
+static std::optional<nlohmann::json>
+materialize_numpy_constructor_array(const nlohmann::json &call_node)
+{
+  if (
+    !call_node.is_object() ||
+    call_node.value("_type", std::string()) != "Call" ||
+    !call_node.contains("func") || !call_node["func"].is_object() ||
+    call_node["func"].value("_type", std::string()) != "Attribute" ||
+    !call_node["func"].contains("attr") ||
+    (call_node.contains("keywords") && !call_node["keywords"].empty()) ||
+    !call_node.contains("args") || !call_node["args"].is_array())
+    return std::nullopt;
+
+  const std::string ctor = call_node["func"]["attr"].get<std::string>();
+  const auto &args = call_node["args"];
+
+  if (ctor == "zeros" || ctor == "ones")
+  {
+    if (args.empty())
+      return std::nullopt;
+    std::vector<std::size_t> dims = extract_constructor_shape_dims(args[0]);
+    // No upper dimension cap here: callers (e.g. transpose) apply their own
+    // dimensional limits and should see the real shape, not a generic
+    // fallback error from this helper silently declining to materialize.
+    if (dims.empty() || dims.size() > 8)
+      return std::nullopt;
+    // Matches the real zeros()/ones() creation path: no dtype= means a
+    // floating-point fill (make_numpy_typed_constant with an empty dtype
+    // always returns a floating-point JSON value).
+    const numeric_value fill = make_float_value(ctor == "zeros" ? 0.0 : 1.0);
+    return build_filled_array_literal(dims, 0, fill);
+  }
+
+  if (ctor == "full")
+  {
+    if (args.size() < 2)
+      return std::nullopt;
+    std::vector<std::size_t> dims = extract_constructor_shape_dims(args[0]);
+    numeric_value fill;
+    if (
+      dims.empty() || dims.size() > 8 ||
+      !try_extract_numeric_constant(args[1], fill))
+      return std::nullopt;
+    return build_filled_array_literal(dims, 0, fill);
+  }
+
+  if (ctor == "eye" || ctor == "identity")
+  {
+    if (args.empty() || (ctor == "eye" && args.size() > 1))
+      return std::nullopt;
+    numeric_value n_value;
+    if (
+      !try_extract_numeric_constant(args[0], n_value) || !n_value.is_int ||
+      n_value.int_value < 0)
+      return std::nullopt;
+    const std::size_t n = static_cast<std::size_t>(n_value.int_value);
+    // Matches the real eye()/identity() creation path: 1/0 built from a
+    // plain C++ int literal, i.e. an integer dtype (not float64, unlike
+    // real NumPy's default -- see make_constant() in the creation path).
+    nlohmann::json node;
+    node["_type"] = "List";
+    node["elts"] = nlohmann::json::array();
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      nlohmann::json row;
+      row["_type"] = "List";
+      row["elts"] = nlohmann::json::array();
+      for (std::size_t j = 0; j < n; ++j)
+        row["elts"].push_back(
+          build_constant_node(make_int_value(i == j ? 1 : 0)));
+      node["elts"].push_back(row);
+    }
+    return node;
+  }
+
+  return std::nullopt;
+}
+
+// full()/eye()/identity()/linspace() are declared through to_list_expr in
+// the real creation path (see array_creation_funcs and its neighbours),
+// which forces a dynamic PyListObj representation instead of a plain
+// array. zeros()/ones()/np.array(<literal>) use a plain array. A runtime
+// backend call that takes the address of the argument (e.g. transpose's
+// array path) assumes a flat array's memory layout, which does not match
+// a PyListObj's layout and reads out of bounds. Callers must route the
+// former group through a compile-time literal fold instead (see
+// try_fold_transpose_literal_2d).
+static bool
+is_dynamic_list_backed_numpy_constructor(const nlohmann::json &call_node)
+{
+  if (
+    !call_node.is_object() ||
+    call_node.value("_type", std::string()) != "Call" ||
+    !call_node.contains("func") || !call_node["func"].is_object() ||
+    call_node["func"].value("_type", std::string()) != "Attribute" ||
+    !call_node["func"].contains("attr"))
+    return false;
+
+  static const std::set<std::string> dynamic_list_ctors = {
+    "full", "eye", "identity", "linspace"};
+  return dynamic_list_ctors.count(
+           call_node["func"]["attr"].get<std::string>()) != 0;
+}
+
+// Computes np.transpose() directly over a fully-materialized numeric
+// literal (all Constant leaves), returning nullopt for anything this
+// conservative fold does not model (non-rectangular, 3D+, non-numeric
+// elements). A 1D literal is returned unchanged (transpose of a 1D array
+// is itself).
+static std::optional<exprt> try_fold_transpose_literal_2d(
+  const nlohmann::json &list_arg,
+  python_converter &converter)
+{
+  if (
+    !list_arg.is_object() || list_arg.value("_type", std::string()) != "List" ||
+    !list_arg.contains("elts") || !list_arg["elts"].is_array())
+    return std::nullopt;
+
+  const auto &elts = list_arg["elts"];
+  const bool is_1d =
+    elts.empty() ||
+    !(elts[0].is_object() && elts[0].value("_type", std::string()) == "List");
+
+  // current_lhs is private to python_converter; the caller (a friend of
+  // python_converter, unlike this free function) is responsible for
+  // updating it with the returned expression's type.
+  if (is_1d)
+    return converter.get_expr(list_arg);
+
+  const std::size_t row_count = elts.size();
+  const std::size_t col_count =
+    elts[0].contains("elts") ? elts[0]["elts"].size() : 0;
+  bool is_rectangular = col_count > 0;
+  for (const auto &row : elts)
+  {
+    if (
+      !row.is_object() || row.value("_type", std::string()) != "List" ||
+      !row.contains("elts") || row["elts"].size() != col_count)
+    {
+      is_rectangular = false;
+      break;
+    }
+  }
+  if (!is_rectangular)
+    return std::nullopt;
+
+  nlohmann::json transposed;
+  transposed["_type"] = "List";
+  transposed["elts"] = nlohmann::json::array();
+  for (std::size_t c = 0; c < col_count; ++c)
+  {
+    nlohmann::json out_row;
+    out_row["_type"] = "List";
+    out_row["elts"] = nlohmann::json::array();
+    for (std::size_t r = 0; r < row_count; ++r)
+    {
+      numeric_value value;
+      if (!try_extract_numeric_constant(elts[r]["elts"][c], value))
+        return std::nullopt;
+      out_row["elts"].push_back(build_constant_node(value));
+    }
+    transposed["elts"].push_back(out_row);
+  }
+
+  return converter.get_expr(transposed);
+}
+
 static nlohmann::json unwrap_list_like_node(const nlohmann::json &node)
 {
   if (!node.is_object() || !node.contains("_type"))
@@ -2439,7 +2683,11 @@ exprt numpy_call_expr::create_expr_from_call()
 
       if (var["value"]["_type"] == "Call")
       {
-        if (var["value"].contains("args") && !var["value"]["args"].empty())
+        if (
+          std::optional<nlohmann::json> materialized =
+            materialize_numpy_constructor_array(var["value"]))
+          var = std::move(*materialized);
+        else if (var["value"].contains("args") && !var["value"]["args"].empty())
           var = var["value"]["args"][0];
         else
           var = var["value"];
@@ -3487,8 +3735,38 @@ exprt numpy_call_expr::create_expr_from_call()
     else if (arg_type == "Name")
     {
       auto arg = call_["args"][0];
-      resolve_var(arg);
       const std::string &function = function_id_.get_function();
+
+      if (function == "transpose")
+      {
+        nlohmann::json decl = json_utils::find_var_decl(
+          arg["id"], converter_.current_function_name(), converter_.ast());
+        if (
+          decl.contains("value") && decl["value"].is_object() &&
+          is_dynamic_list_backed_numpy_constructor(decl["value"]))
+        {
+          if (
+            std::optional<nlohmann::json> materialized =
+              materialize_numpy_constructor_array(decl["value"]))
+          {
+            if (
+              std::optional<exprt> folded =
+                try_fold_transpose_literal_2d(*materialized, converter_))
+            {
+              if (converter_.current_lhs)
+              {
+                converter_.current_lhs->type() = folded->type();
+                converter_.update_symbol(*converter_.current_lhs);
+              }
+              return *folded;
+            }
+          }
+          throw std::runtime_error(
+            "TypeError: numpy.transpose currently supports up to 2D arrays");
+        }
+      }
+
+      resolve_var(arg);
 
       if (function == "transpose")
       {

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2082,8 +2082,9 @@ materialize_arange(const nlohmann::json &args)
   return node;
 }
 
-static std::optional<nlohmann::json>
-materialize_numpy_constructor_array(const nlohmann::json &call_node)
+static std::optional<nlohmann::json> materialize_numpy_constructor_array(
+  const nlohmann::json &call_node,
+  const nlohmann::json &ast_json)
 {
   if (
     !call_node.is_object() ||
@@ -2091,6 +2092,11 @@ materialize_numpy_constructor_array(const nlohmann::json &call_node)
     !call_node.contains("func") || !call_node["func"].is_object() ||
     call_node["func"].value("_type", std::string()) != "Attribute" ||
     !call_node["func"].contains("attr") ||
+    !call_node["func"].contains("value") ||
+    !call_node["func"]["value"].is_object() ||
+    call_node["func"]["value"].value("_type", std::string()) != "Name" ||
+    !is_imported_numpy_module_alias(
+      ast_json, call_node["func"]["value"].value("id", std::string())) ||
     (call_node.contains("keywords") && !call_node["keywords"].empty()) ||
     !call_node.contains("args") || !call_node["args"].is_array())
     return std::nullopt;
@@ -2797,7 +2803,7 @@ exprt numpy_call_expr::create_expr_from_call()
       {
         if (
           std::optional<nlohmann::json> materialized =
-            materialize_numpy_constructor_array(var["value"]))
+            materialize_numpy_constructor_array(var["value"], converter_.ast()))
           var = std::move(*materialized);
         else if (var["value"].contains("args") && !var["value"]["args"].empty())
           var = var["value"]["args"][0];
@@ -3859,7 +3865,8 @@ exprt numpy_call_expr::create_expr_from_call()
         {
           if (
             std::optional<nlohmann::json> materialized =
-              materialize_numpy_constructor_array(decl["value"]))
+              materialize_numpy_constructor_array(
+                decl["value"], converter_.ast()))
           {
             if (
               std::optional<exprt> folded =
@@ -5019,7 +5026,8 @@ exprt numpy_call_expr::get()
           }
           if (
             std::optional<nlohmann::json> materialized =
-              materialize_numpy_constructor_array(var["value"]))
+              materialize_numpy_constructor_array(
+                var["value"], converter_.ast()))
           {
             var = std::move(*materialized);
             return;
@@ -5172,7 +5180,8 @@ exprt numpy_call_expr::get()
         {
           if (
             std::optional<nlohmann::json> materialized =
-              materialize_numpy_constructor_array(var["value"]))
+              materialize_numpy_constructor_array(
+                var["value"], converter_.ast()))
             var = std::move(*materialized);
           else if (
             var["value"].contains("args") && !var["value"]["args"].empty())
@@ -5921,7 +5930,7 @@ exprt numpy_call_expr::get()
       {
         if (
           std::optional<nlohmann::json> materialized =
-            materialize_numpy_constructor_array(var["value"]))
+            materialize_numpy_constructor_array(var["value"], converter_.ast()))
           var = std::move(*materialized);
         else if (var["value"].contains("args") && !var["value"]["args"].empty())
           var = var["value"]["args"][0];

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2026,6 +2026,39 @@ materialize_linspace(const nlohmann::json &args)
   return node;
 }
 
+// Exact int64 arithmetic: routing an all-integer arange() call through
+// double (as materialize_arange_float() does) silently loses precision and
+// can drift the termination point past 2^53.
+static nlohmann::json
+materialize_arange_int(int64_t start, int64_t stop, int64_t step)
+{
+  nlohmann::json node;
+  node["_type"] = "List";
+  node["elts"] = nlohmann::json::array();
+  if (step > 0)
+    for (int64_t current = start; current < stop; current += step)
+      node["elts"].push_back(build_constant_node(make_int_value(current)));
+  else
+    for (int64_t current = start; current > stop; current += step)
+      node["elts"].push_back(build_constant_node(make_int_value(current)));
+  return node;
+}
+
+static nlohmann::json
+materialize_arange_float(double start, double stop, double step)
+{
+  nlohmann::json node;
+  node["_type"] = "List";
+  node["elts"] = nlohmann::json::array();
+  if (step > 0.0)
+    for (double current = start; current < stop; current += step)
+      node["elts"].push_back(build_constant_node(make_float_value(current)));
+  else
+    for (double current = start; current > stop; current += step)
+      node["elts"].push_back(build_constant_node(make_float_value(current)));
+  return node;
+}
+
 static std::optional<nlohmann::json>
 materialize_arange(const nlohmann::json &args)
 {
@@ -2040,73 +2073,39 @@ materialize_arange(const nlohmann::json &args)
       return std::nullopt;
     values.push_back(v);
   }
+
+  numeric_value start_v = make_int_value(0);
+  numeric_value stop_v = values[0];
+  numeric_value step_v = make_int_value(1);
+  if (values.size() >= 2)
+  {
+    start_v = values[0];
+    stop_v = values[1];
+  }
+  if (values.size() == 3)
+    step_v = values[2];
+
+  if (to_double(step_v) == 0.0)
+    return std::nullopt;
+
   // Matches the real arange() creation path: an int dtype unless any
   // argument is float.
   const bool any_float =
     std::any_of(values.begin(), values.end(), [](const numeric_value &v) {
       return !v.is_int;
     });
-
-  nlohmann::json node;
-  node["_type"] = "List";
-  node["elts"] = nlohmann::json::array();
-
   if (!any_float)
-  {
-    // Exact int64 arithmetic: routing an all-integer call through double
-    // (as the float path below does) silently loses precision and can
-    // drift the termination point past 2^53.
-    int64_t start = 0;
-    int64_t stop;
-    int64_t step = 1;
-    if (values.size() == 1)
-      stop = values[0].int_value;
-    else
-    {
-      start = values[0].int_value;
-      stop = values[1].int_value;
-      if (values.size() == 3)
-        step = values[2].int_value;
-    }
-    if (step == 0)
-      return std::nullopt;
-    if (step > 0)
-      for (int64_t current = start; current < stop; current += step)
-        node["elts"].push_back(build_constant_node(make_int_value(current)));
-    else
-      for (int64_t current = start; current > stop; current += step)
-        node["elts"].push_back(build_constant_node(make_int_value(current)));
-    return node;
-  }
+    return materialize_arange_int(
+      start_v.int_value, stop_v.int_value, step_v.int_value);
 
-  double start = 0.0;
-  double stop;
-  double step = 1.0;
-  if (values.size() == 1)
-    stop = to_double(values[0]);
-  else
-  {
-    start = to_double(values[0]);
-    stop = to_double(values[1]);
-    if (values.size() == 3)
-      step = to_double(values[2]);
-  }
-  if (step == 0.0)
-    return std::nullopt;
-  if (step > 0.0)
-  {
-    for (double current = start; current < stop; current += step)
-      node["elts"].push_back(build_constant_node(make_float_value(current)));
-  }
-  else
-  {
-    for (double current = start; current > stop; current += step)
-      node["elts"].push_back(build_constant_node(make_float_value(current)));
-  }
-  return node;
+  return materialize_arange_float(
+    to_double(start_v), to_double(stop_v), to_double(step_v));
 }
 
-static std::optional<nlohmann::json> materialize_numpy_constructor_array(
+// The structural/receiver checks materialize_numpy_constructor_array() needs
+// before it can even ask which constructor it's looking at, split out so
+// that function's own decision count stays small.
+static bool is_recognized_numpy_constructor_call_shape(
   const nlohmann::json &call_node,
   const nlohmann::json &ast_json)
 {
@@ -2120,9 +2119,20 @@ static std::optional<nlohmann::json> materialize_numpy_constructor_array(
     !call_node["func"]["value"].is_object() ||
     call_node["func"]["value"].value("_type", std::string()) != "Name" ||
     !is_imported_numpy_module_alias(
-      ast_json, call_node["func"]["value"].value("id", std::string())) ||
-    (call_node.contains("keywords") && !call_node["keywords"].empty()) ||
-    !call_node.contains("args") || !call_node["args"].is_array())
+      ast_json, call_node["func"]["value"].value("id", std::string())))
+    return false;
+
+  if (call_node.contains("keywords") && !call_node["keywords"].empty())
+    return false;
+
+  return call_node.contains("args") && call_node["args"].is_array();
+}
+
+static std::optional<nlohmann::json> materialize_numpy_constructor_array(
+  const nlohmann::json &call_node,
+  const nlohmann::json &ast_json)
+{
+  if (!is_recognized_numpy_constructor_call_shape(call_node, ast_json))
     return std::nullopt;
 
   const std::string ctor = call_node["func"]["attr"].get<std::string>();
@@ -2191,6 +2201,45 @@ is_dynamic_list_backed_numpy_constructor(const nlohmann::json &call_node)
            call_node["func"]["attr"].get<std::string>()) != 0;
 }
 
+static bool numeric_2d_list_is_rectangular(
+  const nlohmann::json &elts,
+  std::size_t col_count)
+{
+  for (const auto &row : elts)
+  {
+    if (
+      !row.is_object() || row.value("_type", std::string()) != "List" ||
+      !row.contains("elts") || row["elts"].size() != col_count)
+      return false;
+  }
+  return true;
+}
+
+static std::optional<nlohmann::json> build_transposed_literal(
+  const nlohmann::json &elts,
+  std::size_t row_count,
+  std::size_t col_count)
+{
+  nlohmann::json transposed;
+  transposed["_type"] = "List";
+  transposed["elts"] = nlohmann::json::array();
+  for (std::size_t c = 0; c < col_count; ++c)
+  {
+    nlohmann::json out_row;
+    out_row["_type"] = "List";
+    out_row["elts"] = nlohmann::json::array();
+    for (std::size_t r = 0; r < row_count; ++r)
+    {
+      numeric_value value;
+      if (!try_extract_numeric_constant(elts[r]["elts"][c], value))
+        return std::nullopt;
+      out_row["elts"].push_back(build_constant_node(value));
+    }
+    transposed["elts"].push_back(out_row);
+  }
+  return transposed;
+}
+
 // Computes np.transpose() directly over a fully-materialized numeric
 // literal (all Constant leaves), returning nullopt for anything this
 // conservative fold does not model (non-rectangular, 3D+, non-numeric
@@ -2219,39 +2268,15 @@ static std::optional<exprt> try_fold_transpose_literal_2d(
   const std::size_t row_count = elts.size();
   const std::size_t col_count =
     elts[0].contains("elts") ? elts[0]["elts"].size() : 0;
-  bool is_rectangular = col_count > 0;
-  for (const auto &row : elts)
-  {
-    if (
-      !row.is_object() || row.value("_type", std::string()) != "List" ||
-      !row.contains("elts") || row["elts"].size() != col_count)
-    {
-      is_rectangular = false;
-      break;
-    }
-  }
-  if (!is_rectangular)
+  if (col_count == 0 || !numeric_2d_list_is_rectangular(elts, col_count))
     return std::nullopt;
 
-  nlohmann::json transposed;
-  transposed["_type"] = "List";
-  transposed["elts"] = nlohmann::json::array();
-  for (std::size_t c = 0; c < col_count; ++c)
-  {
-    nlohmann::json out_row;
-    out_row["_type"] = "List";
-    out_row["elts"] = nlohmann::json::array();
-    for (std::size_t r = 0; r < row_count; ++r)
-    {
-      numeric_value value;
-      if (!try_extract_numeric_constant(elts[r]["elts"][c], value))
-        return std::nullopt;
-      out_row["elts"].push_back(build_constant_node(value));
-    }
-    transposed["elts"].push_back(out_row);
-  }
+  std::optional<nlohmann::json> transposed =
+    build_transposed_literal(elts, row_count, col_count);
+  if (!transposed)
+    return std::nullopt;
 
-  return converter.get_expr(transposed);
+  return converter.get_expr(*transposed);
 }
 
 static nlohmann::json unwrap_list_like_node(const nlohmann::json &node)

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2040,6 +2040,45 @@ materialize_arange(const nlohmann::json &args)
       return std::nullopt;
     values.push_back(v);
   }
+  // Matches the real arange() creation path: an int dtype unless any
+  // argument is float.
+  const bool any_float =
+    std::any_of(values.begin(), values.end(), [](const numeric_value &v) {
+      return !v.is_int;
+    });
+
+  nlohmann::json node;
+  node["_type"] = "List";
+  node["elts"] = nlohmann::json::array();
+
+  if (!any_float)
+  {
+    // Exact int64 arithmetic: routing an all-integer call through double
+    // (as the float path below does) silently loses precision and can
+    // drift the termination point past 2^53.
+    int64_t start = 0;
+    int64_t stop;
+    int64_t step = 1;
+    if (values.size() == 1)
+      stop = values[0].int_value;
+    else
+    {
+      start = values[0].int_value;
+      stop = values[1].int_value;
+      if (values.size() == 3)
+        step = values[2].int_value;
+    }
+    if (step == 0)
+      return std::nullopt;
+    if (step > 0)
+      for (int64_t current = start; current < stop; current += step)
+        node["elts"].push_back(build_constant_node(make_int_value(current)));
+    else
+      for (int64_t current = start; current > stop; current += step)
+        node["elts"].push_back(build_constant_node(make_int_value(current)));
+    return node;
+  }
+
   double start = 0.0;
   double stop;
   double step = 1.0;
@@ -2054,30 +2093,15 @@ materialize_arange(const nlohmann::json &args)
   }
   if (step == 0.0)
     return std::nullopt;
-  // Matches the real arange() creation path: an int dtype unless any
-  // argument is float.
-  const bool any_float =
-    std::any_of(values.begin(), values.end(), [](const numeric_value &v) {
-      return !v.is_int;
-    });
-  nlohmann::json node;
-  node["_type"] = "List";
-  node["elts"] = nlohmann::json::array();
   if (step > 0.0)
   {
     for (double current = start; current < stop; current += step)
-      node["elts"].push_back(build_constant_node(
-        any_float
-          ? make_float_value(current)
-          : make_int_value(static_cast<int64_t>(std::llround(current)))));
+      node["elts"].push_back(build_constant_node(make_float_value(current)));
   }
   else
   {
     for (double current = start; current > stop; current += step)
-      node["elts"].push_back(build_constant_node(
-        any_float
-          ? make_float_value(current)
-          : make_int_value(static_cast<int64_t>(std::llround(current)))));
+      node["elts"].push_back(build_constant_node(make_float_value(current)));
   }
   return node;
 }

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -1997,6 +1997,102 @@ materialize_numpy_constructor_array(const nlohmann::json &call_node)
     return node;
   }
 
+  if (ctor == "linspace")
+  {
+    if (args.size() < 2 || args.size() > 3)
+      return std::nullopt;
+    numeric_value start_v;
+    numeric_value stop_v;
+    if (
+      !try_extract_numeric_constant(args[0], start_v) ||
+      !try_extract_numeric_constant(args[1], stop_v))
+      return std::nullopt;
+    std::size_t num = 50;
+    if (args.size() == 3)
+    {
+      numeric_value num_v;
+      if (
+        !try_extract_numeric_constant(args[2], num_v) || !num_v.is_int ||
+        num_v.int_value < 0)
+        return std::nullopt;
+      num = static_cast<std::size_t>(num_v.int_value);
+    }
+    // Matches the real linspace() creation path: every element is a float,
+    // computed with the same start + step * i formula.
+    const double start = to_double(start_v);
+    const double stop = to_double(stop_v);
+    nlohmann::json node;
+    node["_type"] = "List";
+    node["elts"] = nlohmann::json::array();
+    if (num == 0)
+      return node;
+    if (num == 1)
+    {
+      node["elts"].push_back(build_constant_node(make_float_value(start)));
+      return node;
+    }
+    const double step = (stop - start) / static_cast<double>(num - 1);
+    for (std::size_t i = 0; i < num; ++i)
+      node["elts"].push_back(build_constant_node(
+        make_float_value(start + step * static_cast<double>(i))));
+    return node;
+  }
+
+  if (ctor == "arange")
+  {
+    if (args.empty() || args.size() > 3)
+      return std::nullopt;
+    std::vector<numeric_value> values;
+    values.reserve(args.size());
+    for (const auto &a : args)
+    {
+      numeric_value v;
+      if (!try_extract_numeric_constant(a, v))
+        return std::nullopt;
+      values.push_back(v);
+    }
+    double start = 0.0;
+    double stop;
+    double step = 1.0;
+    if (values.size() == 1)
+      stop = to_double(values[0]);
+    else
+    {
+      start = to_double(values[0]);
+      stop = to_double(values[1]);
+      if (values.size() == 3)
+        step = to_double(values[2]);
+    }
+    if (step == 0.0)
+      return std::nullopt;
+    // Matches the real arange() creation path: an int dtype unless any
+    // argument is float.
+    const bool any_float =
+      std::any_of(values.begin(), values.end(), [](const numeric_value &v) {
+        return !v.is_int;
+      });
+    nlohmann::json node;
+    node["_type"] = "List";
+    node["elts"] = nlohmann::json::array();
+    if (step > 0.0)
+    {
+      for (double current = start; current < stop; current += step)
+        node["elts"].push_back(build_constant_node(
+          any_float
+            ? make_float_value(current)
+            : make_int_value(static_cast<int64_t>(std::llround(current)))));
+    }
+    else
+    {
+      for (double current = start; current > stop; current += step)
+        node["elts"].push_back(build_constant_node(
+          any_float
+            ? make_float_value(current)
+            : make_int_value(static_cast<int64_t>(std::llround(current)))));
+    }
+    return node;
+  }
+
   return std::nullopt;
 }
 
@@ -5795,7 +5891,11 @@ exprt numpy_call_expr::get()
         return;
       if (var["value"]["_type"] == "Call")
       {
-        if (var["value"].contains("args") && !var["value"]["args"].empty())
+        if (
+          std::optional<nlohmann::json> materialized =
+            materialize_numpy_constructor_array(var["value"]))
+          var = std::move(*materialized);
+        else if (var["value"].contains("args") && !var["value"]["args"].empty())
           var = var["value"]["args"][0];
         else
           var = var["value"];

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -5154,7 +5154,12 @@ exprt numpy_call_expr::get()
           return;
         if (var["value"]["_type"] == "Call")
         {
-          if (var["value"].contains("args") && !var["value"]["args"].empty())
+          if (
+            std::optional<nlohmann::json> materialized =
+              materialize_numpy_constructor_array(var["value"]))
+            var = std::move(*materialized);
+          else if (
+            var["value"].contains("args") && !var["value"]["args"].empty())
             var = var["value"]["args"][0];
           else
             var = var["value"];

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -4175,6 +4175,17 @@ exprt numpy_call_expr::create_expr_from_call()
           }
         }
 
+        // The runtime backend call below writes its result through the
+        // address of current_lhs; a bare expression statement (result
+        // discarded, e.g. `np.dot(a, b)` with no assignment) has no
+        // current_lhs and previously crashed dereferencing a null pointer
+        // instead of producing this diagnostic (matches the existing
+        // arccos/transpose/ceil convention for the same requirement).
+        if (!converter_.current_lhs)
+          throw std::runtime_error(
+            "Internal error: numpy." + operation +
+            " runtime lowering requires an assignment target");
+
         // Determine dimensionality of both operands
         bool lhs_is_2d = type_handler_.is_2d_array(lhs);
         bool rhs_is_2d = type_handler_.is_2d_array(rhs);

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -5001,6 +5001,13 @@ exprt numpy_call_expr::get()
             var = std::move(*numpy_call);
             return;
           }
+          if (
+            std::optional<nlohmann::json> materialized =
+              materialize_numpy_constructor_array(var["value"]))
+          {
+            var = std::move(*materialized);
+            return;
+          }
           if (var["value"].contains("args") && !var["value"]["args"].empty())
             var = var["value"]["args"][0];
           else

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2118,6 +2118,29 @@ static std::optional<nlohmann::json> materialize_numpy_constructor_array(
   return std::nullopt;
 }
 
+// True when call_node's attribute name is one materialize_numpy_constructor_
+// array() knows about, regardless of whether materialization actually
+// succeeded. Callers use this to tell "not a constructor call at all" (safe
+// to fall back to args[0] for the pre-existing np.array(<literal>) shape)
+// apart from "a recognized constructor call materialization declined on"
+// (e.g. a dtype= keyword, a non-constant fill) -- the latter must not fall
+// back to args[0] either, since that is exactly the shape/size argument
+// this whole helper exists to stop misreading as array data.
+static bool is_numpy_constructor_call_by_name(const nlohmann::json &call_node)
+{
+  if (
+    !call_node.is_object() ||
+    call_node.value("_type", std::string()) != "Call" ||
+    !call_node.contains("func") || !call_node["func"].is_object() ||
+    call_node["func"].value("_type", std::string()) != "Attribute" ||
+    !call_node["func"].contains("attr"))
+    return false;
+
+  static const std::set<std::string> constructors = {
+    "zeros", "ones", "full", "eye", "identity", "linspace", "arange"};
+  return constructors.count(call_node["func"]["attr"].get<std::string>()) != 0;
+}
+
 // full()/eye()/identity()/linspace() are declared through to_list_expr in
 // the real creation path (see array_creation_funcs and its neighbours),
 // which forces a dynamic PyListObj representation instead of a plain
@@ -2805,6 +2828,8 @@ exprt numpy_call_expr::create_expr_from_call()
           std::optional<nlohmann::json> materialized =
             materialize_numpy_constructor_array(var["value"], converter_.ast()))
           var = std::move(*materialized);
+        else if (is_numpy_constructor_call_by_name(var["value"]))
+          var = var["value"];
         else if (var["value"].contains("args") && !var["value"]["args"].empty())
           var = var["value"]["args"][0];
         else
@@ -5032,6 +5057,11 @@ exprt numpy_call_expr::get()
             var = std::move(*materialized);
             return;
           }
+          if (is_numpy_constructor_call_by_name(var["value"]))
+          {
+            var = var["value"];
+            return;
+          }
           if (var["value"].contains("args") && !var["value"]["args"].empty())
             var = var["value"]["args"][0];
           else
@@ -5183,6 +5213,8 @@ exprt numpy_call_expr::get()
               materialize_numpy_constructor_array(
                 var["value"], converter_.ast()))
             var = std::move(*materialized);
+          else if (is_numpy_constructor_call_by_name(var["value"]))
+            var = var["value"];
           else if (
             var["value"].contains("args") && !var["value"]["args"].empty())
             var = var["value"]["args"][0];
@@ -5932,6 +5964,8 @@ exprt numpy_call_expr::get()
           std::optional<nlohmann::json> materialized =
             materialize_numpy_constructor_array(var["value"], converter_.ast()))
           var = std::move(*materialized);
+        else if (is_numpy_constructor_call_by_name(var["value"]))
+          var = var["value"];
         else if (var["value"].contains("args") && !var["value"]["args"].empty())
           var = var["value"]["args"][0];
         else

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -3888,22 +3888,25 @@ exprt numpy_call_expr::create_expr_from_call()
           decl.contains("value") && decl["value"].is_object() &&
           is_dynamic_list_backed_numpy_constructor(decl["value"]))
         {
+          std::optional<nlohmann::json> materialized =
+            materialize_numpy_constructor_array(
+              decl["value"], converter_.ast());
+          if (!materialized)
+            throw std::runtime_error(
+              "TypeError: numpy.transpose() does not support this "
+              "constructor call (unsupported keywords or non-constant "
+              "arguments)");
+
           if (
-            std::optional<nlohmann::json> materialized =
-              materialize_numpy_constructor_array(
-                decl["value"], converter_.ast()))
+            std::optional<exprt> folded =
+              try_fold_transpose_literal_2d(*materialized, converter_))
           {
-            if (
-              std::optional<exprt> folded =
-                try_fold_transpose_literal_2d(*materialized, converter_))
+            if (converter_.current_lhs)
             {
-              if (converter_.current_lhs)
-              {
-                converter_.current_lhs->type() = folded->type();
-                converter_.update_symbol(*converter_.current_lhs);
-              }
-              return *folded;
+              converter_.current_lhs->type() = folded->type();
+              converter_.update_symbol(*converter_.current_lhs);
             }
+            return *folded;
           }
           throw std::runtime_error(
             "TypeError: numpy.transpose currently supports up to 2D arrays");

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <optional>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -922,6 +923,27 @@ private:
 
   std::optional<nlohmann::json>
   rewrite_numpy_method_call_node(const nlohmann::json &call_node) const;
+
+  // Classifies a Call node as a numpy method call: (is_a_method_call,
+  // method_name, method_base, is_a_supported_copy_method,
+  // is_a_supported_dispatch_rewrite_method). Split out of
+  // rewrite_numpy_method_call_node() to keep that function's own decision
+  // count low.
+  std::tuple<bool, std::string, nlohmann::json, bool, bool>
+  classify_numpy_method_call(const nlohmann::json &call_node) const;
+
+  bool
+  method_base_is_imported_module(const std::string &method_base_name) const;
+
+  bool
+  method_base_is_tracked_numpy_array(const std::string &method_base_name) const;
+
+  // Builds the np.<method_name>(method_base, ...original args...) rewrite of
+  // a recognized numpy method call.
+  nlohmann::json build_numpy_method_rewrite_node(
+    const nlohmann::json &call_node,
+    const std::string &method_name,
+    const nlohmann::json &method_base) const;
 
   // =========================================================================
   // Unpacking helper methods

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -37,6 +37,13 @@ class python_lambda;
 class python_exception_handler;
 class get_expr_depth_guard;
 
+// Defined in converter_stmt.cpp; shared with numpy_call_expr.cpp so both can
+// verify a Name/Attribute receiver actually resolves to the imported numpy
+// module before treating a call as a numpy constructor/method.
+bool is_imported_numpy_module_alias(
+  const nlohmann::json &ast,
+  const std::string &name);
+
 /**
  * @class python_converter
  * @brief Main converter for transforming Python AST into ESBMC's intermediate representation.

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -913,6 +913,9 @@ private:
   void
   update_numpy_array_binding(const exprt &lhs, const nlohmann::json &rhs_node);
 
+  std::optional<nlohmann::json>
+  rewrite_numpy_method_call_node(const nlohmann::json &call_node) const;
+
   // =========================================================================
   // Unpacking helper methods
   // =========================================================================


### PR DESCRIPTION
- `np.dot(a, b)` / `a.dot(b)` — fixed a process crash for two 1-D vectors read from a variable (bare-statement call with no assignment target).
- `np.transpose(a)` / `a.transpose()` — now supported for arrays built by `zeros`, `ones`, `full`, `eye`, `identity`, `linspace`, `arange` (previously only `np.array(<literal>)`).
- `np.flatten(a)` / `a.flatten()` — same constructor coverage as above.
- `np.sum(a)` / `a.sum()` — same constructor coverage as above.
- `np.mean(a)` / `a.mean()` — same constructor coverage as above.
- `np.min`/`np.max`/`np.prod`/`np.std`/`np.var` (module and method form) — same constructor coverage as above; `.prod()` method form added to the dispatch set (previously unresolvable in any context).
- Centralized the `a.<method>()` → `np.<method>(a, ...)` method-dispatch rewrite so it applies in any expression context (e.g. `assert a.min() == 0`), not just as the direct right-hand side of an assignment.
