### PR TITLE
[python] Read an attribute off an operator result

### DIFF
--- a/regression/python/attr_on_operator_result/main.py
+++ b/regression/python/attr_on_operator_result/main.py
@@ -1,0 +1,26 @@
+# An attribute may be read straight off the value an operator produces, not
+# just off a name: `(a + b).x` used to abort with
+# "Unsupported Attribute value type: BinOp" while `c = a + b; c.x` worked.
+
+
+class V:
+    def __init__(self, x: int):
+        self.x = x
+
+    def __add__(self, o: "V") -> "V":
+        return V(self.x + o.x)
+
+    def __neg__(self) -> "V":
+        return V(-self.x)
+
+
+a = V(1)
+b = V(2)
+
+assert (a + b).x == 3
+assert (-a).x == -1
+assert (V(4) + V(5)).x == 9
+assert (a + b + a).x == 4
+
+c = a + b
+assert c.x == 3

--- a/regression/python/attr_on_operator_result/test.desc
+++ b/regression/python/attr_on_operator_result/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/attr_on_operator_result_fail/main.py
+++ b/regression/python/attr_on_operator_result_fail/main.py
@@ -1,0 +1,15 @@
+# The attribute carries the operator's real result, so asserting the wrong
+# value stays refutable.
+
+
+class V:
+    def __init__(self, x: int):
+        self.x = x
+
+    def __add__(self, o: "V") -> "V":
+        return V(self.x + o.x)
+
+
+a = V(1)
+b = V(2)
+assert (a + b).x == 4

--- a/regression/python/attr_on_operator_result_fail/test.desc
+++ b/regression/python/attr_on_operator_result_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/frontend_error_call_attr_fail/test.desc
+++ b/regression/python/frontend_error_call_attr_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
  --unwind 2
-ERROR: Cannot resolve attribute 'no_such_attr_zzz' on call result
+ERROR: Cannot resolve attribute 'no_such_attr_zzz' on Call result

--- a/regression/python/frontend_error_subscript_attr_fail/test.desc
+++ b/regression/python/frontend_error_subscript_attr_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
  --unwind 2
-ERROR: Cannot resolve attribute 'no_such_attr_zzz' on subscript result
+ERROR: Cannot resolve attribute 'no_such_attr_zzz' on Subscript result

--- a/regression/python/frontend_error_unsupported_value_fail/test.desc
+++ b/regression/python/frontend_error_unsupported_value_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
  --unwind 2
-ERROR: Unsupported Attribute value type: BinOp
+ERROR: Cannot resolve attribute 'no_such_attr_zzz' on BinOp result

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -458,6 +458,15 @@ exprt python_converter::get_named_expr(const nlohmann::json &element)
 
   return get_expr(target);
 }
+/// Node kinds whose value an attribute access may be applied to directly, as
+/// opposed to a plain name. Each converts to an object that
+/// resolve_member_on_base can look a member up on.
+static bool is_attribute_base_expression(const nlohmann::json &node_type)
+{
+  return node_type == "Subscript" || node_type == "Call" ||
+         node_type == "BinOp" || node_type == "UnaryOp";
+}
+
 
 exprt python_converter::get_expr(const nlohmann::json &element)
 {
@@ -856,9 +865,12 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       {
         var_name = element["value"]["id"].get<std::string>();
       }
-      else if (element["value"]["_type"] == "Subscript")
+      else if (is_attribute_base_expression(element["value"]["_type"]))
       {
-        // Attribute access on a subscript result, e.g. `d[key].attr`.
+        // Attribute access on the value an expression produces rather than on
+        // a name: `d[key].attr`, `C().attr`, `(a + b).attr`, `(-a).attr`. A
+        // named instance (`c = a + b; c.attr`) already works; this covers the
+        // unnamed case for every receiver we can convert to an object.
         exprt base_expr = get_expr(element["value"]);
         const std::string &attr_name = element["attr"].get<std::string>();
 
@@ -870,26 +882,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         }
 
         throw std::runtime_error(fmt::format(
-          "Cannot resolve attribute '{}' on subscript result", attr_name));
-      }
-      else if (element["value"]["_type"] == "Call")
-      {
-        // Attribute access on an inline call result, e.g. `C().attr`. Convert
-        // the call to its (materialised) instance and resolve the member on
-        // it, the same way `d[k].attr` is handled above. A named instance
-        // (`c = C(); c.attr`) already works; this covers the unnamed case.
-        exprt base_expr = get_expr(element["value"]);
-        const std::string &attr_name = element["attr"].get<std::string>();
-
-        exprt resolved = resolve_member_on_base(base_expr, attr_name);
-        if (!resolved.is_nil())
-        {
-          expr = resolved;
-          break;
-        }
-
-        throw std::runtime_error(fmt::format(
-          "Cannot resolve attribute '{}' on call result", attr_name));
+          "Cannot resolve attribute '{}' on {} result",
+          attr_name,
+          element["value"]["_type"].get<std::string>()));
       }
       else
       {

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -467,7 +467,6 @@ static bool is_attribute_base_expression(const nlohmann::json &node_type)
          node_type == "BinOp" || node_type == "UnaryOp";
 }
 
-
 exprt python_converter::get_expr(const nlohmann::json &element)
 {
   get_expr_depth_guard depth_guard(*this);


### PR DESCRIPTION
Attribute access dispatched on the receiver's AST node kind and knew only
`Name`, `Subscript` and `Call`, so

```python
assert (a + b).x == 3        # ERROR: Unsupported Attribute value type: BinOp
c = a + b; assert c.x == 3   # fine
```

failed on a program CPython accepts, purely because the receiver was spelled
inline. `UnaryOp` — `(-a).x` — was missing for the same reason.

The `Subscript` and `Call` arms were already identical apart from their error
string, so they collapse into one arm keyed on a small predicate that also
admits `BinOp` and `UnaryOp`. No new conversion logic: each of these already
converts to an object that `resolve_member_on_base` can look a member up on.

Found with a differential oracle against CPython, not from the tracker. Both
tests fail on master and pass here; the negative one keeps the attribute honest
by asserting the wrong value.
