### PR TITLE
[python] Truth-test an object through __bool__ in not and assert

### DIFF
--- a/regression/python/not_calls_bool_dunder/main.py
+++ b/regression/python/not_calls_bool_dunder/main.py
@@ -1,0 +1,32 @@
+# `not obj` is a truth test and must go through the class's __bool__, as `if`,
+# `while`, a ternary and bool() already did. It used to cast the object
+# straight to bool instead, so `not b` was false for an object __bool__ calls
+# false.
+
+
+class Falsy:
+    def __bool__(self) -> bool:
+        return False
+
+
+class Truthy:
+    def __bool__(self) -> bool:
+        return True
+
+
+f = Falsy()
+t = Truthy()
+
+assert not f
+assert not not t
+
+# The contexts that already worked must keep working.
+r = 1 if f else 2
+assert r == 2
+
+n = 0
+if t:
+    n = 1
+assert n == 1
+
+assert bool(f) is False

--- a/regression/python/not_calls_bool_dunder/test.desc
+++ b/regression/python/not_calls_bool_dunder/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/not_calls_bool_dunder_fail/main.py
+++ b/regression/python/not_calls_bool_dunder_fail/main.py
@@ -1,0 +1,10 @@
+# __bool__ decides the answer, so asserting the opposite stays refutable.
+
+
+class Falsy:
+    def __bool__(self) -> bool:
+        return False
+
+
+f = Falsy()
+assert f

--- a/regression/python/not_calls_bool_dunder_fail/test.desc
+++ b/regression/python/not_calls_bool_dunder_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -4637,9 +4637,7 @@ exprt python_converter::apply_bool_dunder_for_not(
   return op == "Not" ? apply_bool_dunder(operand, location) : operand;
 }
 
-exprt python_converter::apply_bool_dunder(
-  exprt cond,
-  const locationt &location)
+exprt python_converter::apply_bool_dunder(exprt cond, const locationt &location)
 {
   typet value_type = ns.follow(cond.type());
   if (value_type.is_pointer())
@@ -4667,8 +4665,7 @@ exprt python_converter::apply_bool_dunder(
   bool_call.function() = symbol_expr(*bool_method);
   bool_call.type() = to_code_type(bool_method->get_type()).return_type();
   bool_call.location() = location;
-  bool_call.arguments().push_back(
-    object_is_ptr ? cond : gen_address_of(cond));
+  bool_call.arguments().push_back(object_is_ptr ? cond : gen_address_of(cond));
 
   exprt result = store_call_result(bool_call, location, "cond_bool");
   result.location() = location;

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -4622,6 +4622,59 @@ python_converter::scalar_tag_candidates(const nlohmann::json &if_node)
   return candidates;
 }
 
+/// Truth-testing an object calls its __bool__ when the class defines one. The
+/// caller has already resolved @p value_type to the struct behind @p cond
+/// (following a pointer if need be); a non-struct or a class without the dunder
+/// comes back unchanged.
+/// `not obj` is a truth test, so it dispatches __bool__ exactly as `if obj:`
+/// does. Kept as its own entry point so the unary-operator conversion stays a
+/// single statement.
+exprt python_converter::apply_bool_dunder_for_not(
+  const std::string &op,
+  exprt operand,
+  const locationt &location)
+{
+  return op == "Not" ? apply_bool_dunder(operand, location) : operand;
+}
+
+exprt python_converter::apply_bool_dunder(
+  exprt cond,
+  const locationt &location)
+{
+  typet value_type = ns.follow(cond.type());
+  if (value_type.is_pointer())
+    value_type = ns.follow(value_type.subtype());
+  if (!value_type.is_struct())
+    return cond;
+
+  const std::string class_name =
+    extract_class_name_from_tag(to_struct_type(value_type).tag().as_string());
+  if (class_name.empty())
+    return cond;
+
+  symbolt *bool_method = find_dunder_method(class_name, "__bool__");
+  if (!bool_method)
+    return cond;
+
+  // __bool__ expects self by reference. A migrated instance is already a
+  // `Class*` pointer (pass it through); a by-value struct must be a named
+  // object whose address we take.
+  const bool object_is_ptr = cond.type().is_pointer();
+  if (!object_is_ptr && !cond.is_symbol())
+    cond = store_call_result(cond, location, "cond_obj");
+
+  side_effect_expr_function_callt bool_call;
+  bool_call.function() = symbol_expr(*bool_method);
+  bool_call.type() = to_code_type(bool_method->get_type()).return_type();
+  bool_call.location() = location;
+  bool_call.arguments().push_back(
+    object_is_ptr ? cond : gen_address_of(cond));
+
+  exprt result = store_call_result(bool_call, location, "cond_bool");
+  result.location() = location;
+  return result;
+}
+
 exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
 {
   // A walrus in a `while` test re-evaluates every iteration, but get_named_expr
@@ -4980,35 +5033,7 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
         value_type = ns.follow(value_type.subtype());
 
       // Objects in conditions are converted with __bool__() when available.
-      if (value_type.is_struct())
-      {
-        if (const std::string class_name = extract_class_name_from_tag(
-              to_struct_type(value_type).tag().as_string());
-            !class_name.empty())
-        {
-          if (symbolt *bool_method = find_dunder_method(class_name, "__bool__"))
-          {
-            exprt bool_object = cond;
-            // __bool__ expects self by reference. A migrated instance is
-            // already a `Class*` pointer (pass it through); a by-value struct
-            // must be a named object whose address we take.
-            const bool object_is_ptr = bool_object.type().is_pointer();
-            if (!object_is_ptr && !bool_object.is_symbol())
-              bool_object =
-                store_call_result(bool_object, location, "cond_obj");
-            const code_typet &method_type =
-              to_code_type(bool_method->get_type());
-            side_effect_expr_function_callt bool_call;
-            bool_call.function() = symbol_expr(*bool_method);
-            bool_call.type() = method_type.return_type();
-            bool_call.location() = location;
-            bool_call.arguments().push_back(
-              object_is_ptr ? bool_object : gen_address_of(bool_object));
-            cond = store_call_result(bool_call, location, "cond_bool");
-            cond.location() = location;
-          }
-        }
-      }
+      cond = apply_bool_dunder(cond, location);
 
       typet list_type = type_handler_.get_list_type();
       // Python treats lists in conditions by their size, for example:
@@ -5767,6 +5792,10 @@ exprt python_converter::get_block(
 
       current_element_type = bool_type();
       exprt test = get_expr(element["test"]);
+      // An object asserted directly is truth-tested like any condition, so a
+      // class with __bool__ decides the answer. Without this `assert obj` cast
+      // the object to bool and passed whatever the dunder said.
+      test = apply_bool_dunder(test, get_location_from_decl(element));
       if (test.statement() == "cpp-throw")
       {
         test.location() = get_location_from_decl(element);

--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -200,6 +200,12 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
   // frontend) so it is well-formed IR: migrate_expr asserts that `not`/`and`/
   // `or` nodes are bool-typed, and consumers that migrate eagerly (e.g.
   // build_typecast) would otherwise abort before the C adjuster normalises it.
+  // `not obj` is a truth test like `if obj:`, so it goes through the class's
+  // __bool__ where there is one; without it the operand was cast straight to
+  // bool and the dunder never ran.
+  unary_sub = apply_bool_dunder_for_not(
+    op, unary_sub, get_location_from_decl(element));
+
   const typet result_type = (op == "Not") ? bool_type() : type;
   const std::string op_id = python_frontend::map_operator(op, result_type);
 

--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -203,8 +203,8 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
   // `not obj` is a truth test like `if obj:`, so it goes through the class's
   // __bool__ where there is one; without it the operand was cast straight to
   // bool and the dunder never ran.
-  unary_sub = apply_bool_dunder_for_not(
-    op, unary_sub, get_location_from_decl(element));
+  unary_sub =
+    apply_bool_dunder_for_not(op, unary_sub, get_location_from_decl(element));
 
   const typet result_type = (op == "Not") ? bool_type() : type;
   const std::string op_id = python_frontend::map_operator(op, result_type);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1232,6 +1232,15 @@ private:
 
   static std::string op_to_dunder(const std::string &op);
   static std::string op_to_rdunder(const std::string &op);
+  /// Rewrite @p cond into a call to its class's __bool__ when there is one.
+  exprt apply_bool_dunder(exprt cond, const locationt &location);
+
+  /// apply_bool_dunder for the `not` operator; a no-op for any other @p op.
+  exprt apply_bool_dunder_for_not(
+    const std::string &op,
+    exprt operand,
+    const locationt &location);
+
   symbolt *find_dunder_method(
     const std::string &class_name,
     const std::string &dunder_name);


### PR DESCRIPTION
`if obj:`, `while obj:`, a ternary and `bool(obj)` all called the class's
`__bool__`. Two other truth-test contexts did not:

```python
class Falsy:
    def __bool__(self) -> bool:
        return False

f = Falsy()
assert not f     # VERIFICATION FAILED on master -- false alarm
assert f         # VERIFICATION SUCCESSFUL on master -- CPython raises
```

The second is the serious one: master **proves an assertion CPython rejects**, so
it is a missed bug rather than a spurious one. Both fell out of the same cause —
the operand was cast straight to bool and the dunder never ran.

The dispatch was written inline in `get_conditional_stm`; it moves into
`apply_bool_dunder`, which now follows the pointer itself, and both new sites call
it. A thin `apply_bool_dunder_for_not` keeps the unary-operator conversion a
single statement so its complexity does not rise.

Found with a differential oracle against CPython, not from the tracker. The
positive test also re-checks the four contexts that already worked, so a future
change cannot fix one by breaking another; the negative test is the unsound case
and flips SUCCESSFUL to FAILED.
