### PR TITLE
[goto-symex] Only take the address of an lvalue for __ESBMC_old

### DIFF
--- a/regression/function_contract/github_6916_old_over_is_fresh/main.c
+++ b/regression/function_contract/github_6916_old_over_is_fresh/main.c
@@ -1,0 +1,21 @@
+/* github_6916_old_over_is_fresh:
+ * __ESBMC_old takes the address of its operand so that the pre-state value can
+ * be read back through it. That needs an lvalue. __ESBMC_is_fresh backs the
+ * object with an untyped byte array, so reading n->id through it lowers to a
+ * value reassembled from bytes, and its address reached the solver as
+ * address_of(bitcast(concat(...))), which convert_addr_of aborts on. */
+typedef struct { int id; int v; } Node;
+
+void helper(Node *n) {
+  __ESBMC_assigns(n->v);
+  __ESBMC_ensures(n->id == __ESBMC_old(n->id));
+  n->v = 1;
+}
+
+void f(Node *nodes) {
+  __ESBMC_requires(__ESBMC_is_fresh(nodes, sizeof(Node)));
+  __ESBMC_assigns(nodes[0].v);
+  __ESBMC_ensures(1);
+  helper(&nodes[0]);
+}
+int main(void) { return 0; }

--- a/regression/function_contract/github_6916_old_over_is_fresh/test.desc
+++ b/regression/function_contract/github_6916_old_over_is_fresh/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_6916_old_over_is_fresh_fail/main.c
+++ b/regression/function_contract/github_6916_old_over_is_fresh_fail/main.c
@@ -1,0 +1,17 @@
+/* github_6916_old_over_is_fresh_fail:
+ * The control for github_6916_old_over_is_fresh. Materialising the snapshotted
+ * value has to preserve it, not invent one, so a body that changes the field
+ * the ensures pins must still be rejected. Same shape as the pass case: the
+ * pointer is __ESBMC_is_fresh, so the snapshot is taken over an untyped byte
+ * allocation and goes through the same path. */
+typedef struct { int id; int v; } Node;
+
+void f(Node *nodes)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(nodes, sizeof(Node)));
+  __ESBMC_assigns(nodes[0].id, nodes[0].v);
+  __ESBMC_ensures(nodes[0].id == __ESBMC_old(nodes[0].id));
+  nodes[0].v = 1;
+  nodes[0].id = nodes[0].id + 1;   /* breaks the ensures */
+}
+int main(void) { return 0; }

--- a/regression/function_contract/github_6916_old_over_is_fresh_fail/test.desc
+++ b/regression/function_contract/github_6916_old_over_is_fresh_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --unwind 4
+^VERIFICATION FAILED$

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -958,6 +958,15 @@ protected:
     const bool hidden = false,
     const guard2tc &guard = guard2tc());
 
+  /** Give a value storage of its own, for __ESBMC_old.
+   *
+   *  Only an lvalue has an address, and dereference lowering can turn a read
+   *  through an untyped allocation into a value rebuilt from bytes. Snapshot
+   *  such a value into a symbol so the caller has something to point at.
+   *  @return A reference to the new storage, holding \p value.
+   */
+  expr2tc materialise_old_snapshot(const expr2tc &value, const guard2tc &guard);
+
   /** Recursively perform symex assign. @see symex_assign */
   void symex_assign_rec(
     const expr2tc &lhs,

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -13,6 +13,15 @@
 #include <util/irep/migrate.h>
 #include <util/irep/std_expr.h>
 
+/// Whether \p e denotes a place whose address can be taken. Dereference
+/// lowering can turn a member read through an untyped allocation into a value
+/// rebuilt from bytes, and that has no address.
+static bool is_lvalue(const expr2tc &e)
+{
+  return is_symbol2t(e) || is_member2t(e) || is_index2t(e) ||
+         is_dereference2t(e);
+}
+
 goto_symext::goto_symext(
   const namespacet &_ns,
   contextt &_new_context,
@@ -271,6 +280,18 @@ void goto_symext::handle_sideeffect(
     // modifies anything, so address_of(inner) gives the correct pre-state value.
     {
       expr2tc inner = effect.operand;
+
+      // Only an lvalue has an address. When the snapshotted expression reads
+      // through a pointer into an untyped allocation -- which is what
+      // __ESBMC_is_fresh produces, a byte array -- dereference lowering hands
+      // back a value reassembled from bytes rather than a place, and taking
+      // its address reaches the SMT layer as address_of(bitcast(concat(...)))
+      // and aborts there. Materialise the value into storage of its own and
+      // point at that instead: `*(T*)lhs` still reads the pre-state value,
+      // which is all the caller wants.
+      if (!is_lvalue(inner))
+        inner = materialise_old_snapshot(inner, guard);
+
       // address_of2tc(subtype, expr): subtype is T, result type is T*
       expr2tc addr = address_of2tc(inner->type, inner);
       // Cast to lhs type (void*)
@@ -320,6 +341,27 @@ bool goto_symext::handle_conditional(
   }
 
   return has_sideeffect;
+}
+
+/// Give \p value storage of its own and return a reference to it, so that the
+/// caller has something addressable holding the pre-state value.
+expr2tc goto_symext::materialise_old_snapshot(
+  const expr2tc &value,
+  const guard2tc &guard)
+{
+  static unsigned counter = 0;
+
+  symbolt symbol;
+  symbol.name = "old_snapshot_value_" + i2string(counter++);
+  symbol.id = "symex::" + id2string(symbol.name);
+  symbol.lvalue = true;
+  symbol.mode = "C";
+  symbol.set_type(ns.follow(migrate_type_back(value->type)));
+  new_context.add(symbol);
+
+  expr2tc place = symbol2tc(migrate_symbol_type(symbol), symbol.id);
+  symex_assign(code_assign2tc(place, value), true, guard);
+  return place;
 }
 
 void goto_symext::symex_assign(


### PR DESCRIPTION
Fixes #6916.

`__ESBMC_old` over a pointer that `__ESBMC_is_fresh` allocated aborts the solver:

```c
typedef struct { int id; int v; } Node;

void helper(Node *n) {
  __ESBMC_assigns(n->v);
  __ESBMC_ensures(n->id == __ESBMC_old(n->id));
  n->v = 1;
}

void f(Node *nodes) {
  __ESBMC_requires(__ESBMC_is_fresh(nodes, sizeof(Node)));
  __ESBMC_assigns(nodes[0].v);
  __ESBMC_ensures(1);
  helper(&nodes[0]);
}
```

`ERROR: Unrecognized address_of operand`, then `abort()`. Same under z3, boolector and bitwuzla.

## Cause

`symex_assign.cpp` takes the address of the snapshot's operand so that `*(T*)lhs` reads the pre-state value. That is sound when the operand is a place. `byte_malloc` allocates an `is_fresh` object with `char_type`, so it is `uint8[n]`; reading `n->id` through a `Node *` into it lowers to four byte reads concatenated back into an `int`. What reaches `convert_addr_of` is

```
address_of → bitcast → concat → concat → concat → index(dynamic_1_array[uint8×8], div(add(...)))
```

and its dispatch covers `index`, `member`, `symbol`, `constant_string`, `constant_array`, `if` and `typecast`, so it falls through to the abort at `smt_memspace.cpp:609`.

## Fix

Give the value storage of its own and point at that:

```cpp
if (!is_lvalue(inner))
  inner = materialise_old_snapshot(inner, guard);
```

`*(T*)lhs` still reads the pre-state value, so nothing downstream changes. Only the operand that had no address gains one. Where the operand already is an lvalue, which is every case that worked before, the path is untouched.

## Tests

`github_6916_old_over_is_fresh` is the reproducer. `github_6916_old_over_is_fresh_fail` is its control: materialising the value has to preserve the snapshot rather than invent one, so the same shape with a body that changes the pinned field must still be rejected. It is.

416/416 across `function_contract` and `loop-invariants`.

## Not #6483

The two look adjacent, and ESBMC prints a warning naming #6483 just before aborting. #6483's reproducer verifies correctly here, and on 8.2.0, so this is not that defect resurfacing. They share the "`is_fresh` heap-backs a struct pointer, plus `__ESBMC_old`" setting; #6483 records a missed violation, this one aborts.

## Why it mattered

It was the only thing stopping a hand-written reference contract in our benchmark set from verifying, and the contract cannot be written any other way — the parameter is dereferenced, so since #6484 it needs an extent, and stating one means `__ESBMC_is_fresh`. That suite goes from 61/62 to 62/62.