### PR TITLE
[om] Add visit to <variant>

### DIFF
--- a/regression/esbmc-cpp17/cpp/variant_visit/main.cpp
+++ b/regression/esbmc-cpp17/cpp/variant_visit/main.cpp
@@ -1,0 +1,61 @@
+// std::visit calls the visitor on the alternative the variant currently holds.
+// Verified against clang++ -std=c++17 -fsanitize=address,undefined: exits 0.
+#include <cassert>
+#include <variant>
+
+struct ToInt
+{
+  int operator()(int x) const
+  {
+    return x;
+  }
+  int operator()(double d) const
+  {
+    return (int)d + 100;
+  }
+  int operator()(char c) const
+  {
+    return (int)c + 1000;
+  }
+};
+
+static int calls = 0;
+
+struct Counting
+{
+  void operator()(int)
+  {
+    calls++;
+  }
+  void operator()(double)
+  {
+    calls++;
+  }
+};
+
+int main()
+{
+  std::variant<int, double, char> v;
+
+  v = 5;
+  assert(std::visit(ToInt(), v) == 5);
+  v = 2.5;
+  assert(std::visit(ToInt(), v) == 102);
+  v = 'a';
+  assert(std::visit(ToInt(), v) == 1097);
+
+  const std::variant<int, double, char> &cv = v;
+  assert(std::visit(ToInt(), cv) == 1097);
+
+  // Two alternatives: the storage's surplus slots must not be instantiated.
+  std::variant<int, double> w = 7;
+  assert(std::visit(ToInt(), w) == 7);
+
+  // A void visitor runs exactly once per visit, on every alternative.
+  std::variant<int, double> u = 1;
+  std::visit(Counting(), u);
+  u = 2.0;
+  std::visit(Counting(), u);
+  assert(calls == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/variant_visit/test.desc
+++ b/regression/esbmc-cpp17/cpp/variant_visit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/variant_visit_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/variant_visit_fail/main.cpp
@@ -1,0 +1,23 @@
+// visit dispatches on the alternative actually held, so asserting the answer
+// for a different one stays refutable.
+#include <cassert>
+#include <variant>
+
+struct ToInt
+{
+  int operator()(int x) const
+  {
+    return x;
+  }
+  int operator()(double d) const
+  {
+    return (int)d + 100;
+  }
+};
+
+int main()
+{
+  std::variant<int, double> v = 2.5;
+  assert(std::visit(ToInt(), v) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/variant_visit_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/variant_visit_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/variant
+++ b/src/cpp/library/variant
@@ -12,9 +12,9 @@
 // types via a flat discriminator + per-alternative member, which is wider
 // than a real tagged union but observably equivalent for verification and
 // avoids the constexpr/APValue::Union path that ESBMC's converter does
-// not yet handle.  Per [variant] in N4861/P0088.  Out-of-scope: visit()
-// returning non-void, in_place_type construction past the fourth
-// alternative, and emplace().
+// not yet handle.  Per [variant] in N4861/P0088.  Out-of-scope: visiting
+// more than one variant at once, in_place_type construction past the
+// fourth alternative, and emplace().
 
 namespace std
 {
@@ -300,6 +300,55 @@ get_if(const variant<Types...> *v) noexcept
     return &v->__s2_;
   else
     return &v->__s3_;
+}
+
+// [variant.visit]: call the visitor on the currently held alternative.
+//
+// The dispatch is hand-unrolled to match the storage, and each arm is gated on
+// `sizeof...(Types)`: the four slots are padded with `char` for a variant of
+// fewer alternatives, and instantiating the visitor on a padding slot would not
+// compile. Testing the highest index first leaves alternative 0 as the fall
+// through, so the visitor is called exactly once on every path -- a chain that
+// ended with a second `f(get<0>(v))` would run a visitor's side effects twice
+// on a valueless variant.
+//
+// The result type is the visitor's result on alternative 0; [variant.visit]
+// requires the same type for every alternative, so any other arm converts to
+// it. Out of scope, as elsewhere in this header: visiting more than one variant
+// at a time, and throwing bad_variant_access for a valueless variant (which
+// reads as alternative 0 here).
+template <class F, class... Types>
+constexpr auto visit(F &&f, variant<Types...> &v)
+  -> decltype(f(get<0>(v)))
+{
+  const size_t __i = v.index();
+  if constexpr (sizeof...(Types) > 3)
+    if (__i == 3)
+      return f(get<3>(v));
+  if constexpr (sizeof...(Types) > 2)
+    if (__i == 2)
+      return f(get<2>(v));
+  if constexpr (sizeof...(Types) > 1)
+    if (__i == 1)
+      return f(get<1>(v));
+  return f(get<0>(v));
+}
+
+template <class F, class... Types>
+constexpr auto visit(F &&f, const variant<Types...> &v)
+  -> decltype(f(get<0>(v)))
+{
+  const size_t __i = v.index();
+  if constexpr (sizeof...(Types) > 3)
+    if (__i == 3)
+      return f(get<3>(v));
+  if constexpr (sizeof...(Types) > 2)
+    if (__i == 2)
+      return f(get<2>(v));
+  if constexpr (sizeof...(Types) > 1)
+    if (__i == 1)
+      return f(get<1>(v));
+  return f(get<0>(v));
 }
 
 } // namespace std


### PR DESCRIPTION
`visit` was listed as out of scope in `<variant>`, and it is the second-largest
blocker to verifying ESBMC with itself: 93 of ESBMC's own 361 translation units
stop at `no member named 'visit'` (#5868).

The dispatch is hand-unrolled to match the existing four-slot storage, in the
same style as `get<I>` and `get_if` above it. Each arm is gated on
`sizeof...(Types)`, because a variant of fewer alternatives pads the surplus
slots with `char` and instantiating the visitor on one would not compile.
Testing the highest index first leaves alternative 0 as the fall-through, so the
visitor runs **exactly once** on every path — a chain ending in a second
`f(get<0>(v))` would run a visitor's side effects twice on a valueless variant.
The regression test pins that with a counting visitor.

The result type is the visitor's result on alternative 0; [variant.visit]
requires a common type across alternatives, so any other arm converts to it.
Still out of scope, consistent with the rest of the header: visiting more than
one variant at once, and throwing `bad_variant_access` for a valueless variant
(which reads as alternative 0 here). The header comment is updated to say so.

**Measured effect, stated precisely.** Re-running the self-verification census
before and after, the 93 TUs that reported `no member named 'visit'` now report
`no member named 'placeholders'` instead — so `visit` is genuinely no longer
their blocker, but they are multi-blocker TUs and the converted count is
unchanged at 17/361. `std::placeholders` becomes the joint-second blocker.

Both tests are adjudicated by clang++ (the positive one also under ASan and
UBSan); they fail on master and pass here, and the five existing `variant` tests
are unaffected. 663/663 unit tests pass.
