### PR TITLE
Hold callers to the extent `__ESBMC_is_fresh` asks for

### DIFF
--- a/regression/function_contract/github_6542_is_fresh_extent_fail/main.c
+++ b/regression/function_contract/github_6542_is_fresh_extent_fail/main.c
@@ -1,0 +1,21 @@
+/* github_6542_is_fresh_extent_fail:
+ * __ESBMC_is_fresh(p, n) asks for n bytes, and a replace site has to hold the
+ * caller to it. The extent operand used to be dropped in the lowering, which
+ * left `valid_object(p)` alone standing -- so a 16-byte object discharged a
+ * request for 4096. */
+#include <stdlib.h>
+typedef struct { int coeffs[4]; } P;
+
+void callee(P *p) {
+  __ESBMC_requires(__ESBMC_is_fresh(p, 4096));
+  __ESBMC_assigns(p->coeffs);
+  __ESBMC_ensures(p->coeffs[0] == 1);
+  p->coeffs[0] = 1;
+}
+
+int main(void) {
+  P *o = (P *)malloc(sizeof(P));
+  __ESBMC_assume(o != 0);
+  callee(o);
+  return 0;
+}

--- a/regression/function_contract/github_6542_is_fresh_extent_fail/test.desc
+++ b/regression/function_contract/github_6542_is_fresh_extent_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--replace-call-with-contract callee --unwind 8
+^VERIFICATION FAILED$
+^.*contract requires.*$

--- a/regression/function_contract/github_6542_is_fresh_extent_pass/main.c
+++ b/regression/function_contract/github_6542_is_fresh_extent_pass/main.c
@@ -1,0 +1,21 @@
+/* github_6542_is_fresh_extent_pass:
+ * __ESBMC_is_fresh(p, n) asks for n bytes, and a replace site has to hold the
+ * caller to it. The extent operand used to be dropped in the lowering, which
+ * The control: an extent the caller does satisfy must still compose, so the
+ * check has to be an implication about size and not a blanket rejection. */
+#include <stdlib.h>
+typedef struct { int coeffs[4]; } P;
+
+void callee(P *p) {
+  __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(P)));
+  __ESBMC_assigns(p->coeffs);
+  __ESBMC_ensures(p->coeffs[0] == 1);
+  p->coeffs[0] = 1;
+}
+
+int main(void) {
+  P *o = (P *)malloc(sizeof(P));
+  __ESBMC_assume(o != 0);
+  callee(o);
+  return 0;
+}

--- a/regression/function_contract/github_6542_is_fresh_extent_pass/test.desc
+++ b/regression/function_contract/github_6542_is_fresh_extent_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract callee --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_6542_is_fresh_interior_ptr_fail/main.c
+++ b/regression/function_contract/github_6542_is_fresh_interior_ptr_fail/main.c
@@ -1,0 +1,19 @@
+/* github_6542_is_fresh_interior_ptr_fail:
+ * An interior pointer has a non-zero offset, so the room left in the object is
+ * what follows it, not the whole allocation. Dropping the offset term would
+ * accept &a[3] against an extent that only the base could satisfy. */
+#include <stdlib.h>
+
+void callee(unsigned char *b) {
+  __ESBMC_requires(__ESBMC_is_fresh(b, 8));
+  __ESBMC_assigns(b[0]);
+  __ESBMC_ensures(b[0] == 1);
+  b[0] = 1;
+}
+
+int main(void) {
+  unsigned char *p = (unsigned char *)malloc(10);
+  __ESBMC_assume(p != 0);
+  callee(&p[3]);
+  return 0;
+}

--- a/regression/function_contract/github_6542_is_fresh_interior_ptr_fail/test.desc
+++ b/regression/function_contract/github_6542_is_fresh_interior_ptr_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--replace-call-with-contract callee --unwind 8
+^VERIFICATION FAILED$
+^.*contract requires.*$

--- a/regression/function_contract/github_6542_is_fresh_param_extent_fail/main.c
+++ b/regression/function_contract/github_6542_is_fresh_param_extent_fail/main.c
@@ -1,0 +1,20 @@
+/* github_6542_is_fresh_param_extent_fail:
+ * The extent names a parameter, so at a call site it has to mean the caller's
+ * argument. Rebinding the pointer but not the extent leaves the callee's own
+ * symbol in the assertion, and the obligation stops tracking what was asked
+ * for. Here the caller promises 4096 bytes of a 16-byte object. */
+#include <stdlib.h>
+
+void callee(unsigned char *b, unsigned long n) {
+  __ESBMC_requires(__ESBMC_is_fresh(b, n));
+  __ESBMC_assigns(b[0]);
+  __ESBMC_ensures(b[0] == 1);
+  b[0] = 1;
+}
+
+int main(void) {
+  unsigned char *p = (unsigned char *)malloc(16);
+  __ESBMC_assume(p != 0);
+  callee(p, 4096);
+  return 0;
+}

--- a/regression/function_contract/github_6542_is_fresh_param_extent_fail/test.desc
+++ b/regression/function_contract/github_6542_is_fresh_param_extent_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--replace-call-with-contract callee --unwind 8
+^VERIFICATION FAILED$
+^.*contract requires.*$

--- a/regression/function_contract/github_6542_is_fresh_param_extent_pass/main.c
+++ b/regression/function_contract/github_6542_is_fresh_param_extent_pass/main.c
@@ -1,0 +1,20 @@
+/* github_6542_is_fresh_param_extent_pass:
+ * The control for github_6542_is_fresh_param_extent_fail. The extent still
+ * names a parameter, but the caller supplies an object that satisfies it, so
+ * the check has to be an implication about size and not a blanket rejection
+ * of extents that are not compile-time constants. */
+#include <stdlib.h>
+
+void callee(unsigned char *b, unsigned long n) {
+  __ESBMC_requires(__ESBMC_is_fresh(b, n));
+  __ESBMC_assigns(b[0]);
+  __ESBMC_ensures(b[0] == 1);
+  b[0] = 1;
+}
+
+int main(void) {
+  unsigned char *p = (unsigned char *)malloc(16);
+  __ESBMC_assume(p != 0);
+  callee(p, 16);
+  return 0;
+}

--- a/regression/function_contract/github_6542_is_fresh_param_extent_pass/test.desc
+++ b/regression/function_contract/github_6542_is_fresh_param_extent_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract callee --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_6542_is_fresh_stack_receiver_knownbug/main.c
+++ b/regression/function_contract/github_6542_is_fresh_stack_receiver_knownbug/main.c
@@ -1,0 +1,25 @@
+/* github_6542_is_fresh_stack_receiver_knownbug:
+ * A caller may legitimately pass a live automatic object (#6380), and the
+ * extent conjunct is guarded by is_dynamic so it does not reject one:
+ * __ESBMC_alloc_size is maintained for the heap only, and the guard is visible
+ * in the emitted predicate.
+ *
+ * This still fails, on valid_object alone. __ESBMC_alloc is never updated for
+ * stack pointers (see the note in goto-symex/dynamic_allocation.cpp), so
+ * VALID_OBJECT of an automatic object is a free boolean a solver may pick
+ * false. That is #6542's automatic-storage half, which is open and separate
+ * from the extent this test guards. */
+typedef struct { int coeffs[4]; } P;
+
+void callee(P *p) {
+  __ESBMC_requires(__ESBMC_is_fresh(p, sizeof(P)));
+  __ESBMC_assigns(p->coeffs);
+  __ESBMC_ensures(p->coeffs[0] == 1);
+  p->coeffs[0] = 1;
+}
+
+int main(void) {
+  P v;
+  callee(&v);
+  return 0;
+}

--- a/regression/function_contract/github_6542_is_fresh_stack_receiver_knownbug/test.desc
+++ b/regression/function_contract/github_6542_is_fresh_stack_receiver_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--replace-call-with-contract callee --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -2258,17 +2258,23 @@ expr2tc code_contractst::replace_is_fresh_temps(
         //
         // requires side at a --replace-call-with-contract call site
         // (require_dynamic == false):
-        //   valid_object(p) only. The precondition is *asserted* against the
-        //   caller's argument here, and a real caller legitimately passes a
-        //   live stack object or an interior sub-object (e.g. &v->vec[k] of a
-        //   fresh vector) -- valid, but not heap-dynamic. Requiring is_dynamic
-        //   would reject every such caller and make is_fresh unusable under
-        //   contract replacement; the frame guarantee is carried by the
-        //   callee's assigns clause, not by heap-freshness. (#6380)
+        //   valid_object(p) and the stated extent, but not is_dynamic. The
+        //   precondition is *asserted* against the caller's argument here, and
+        //   a real caller legitimately passes a live stack object or an
+        //   interior sub-object (e.g. &v->vec[k] of a fresh vector) -- valid,
+        //   but not heap-dynamic. Requiring is_dynamic would reject every such
+        //   caller and make is_fresh unusable under contract replacement; the
+        //   frame guarantee is carried by the callee's assigns clause, not by
+        //   heap-freshness. (#6380)
+        //
+        //   plus the extent the contract asked for, which the caller has to
+        //   supply. dynamic_size is a byte count, the currency is_fresh states
+        //   its extent in, and the offset term is what keeps
+        //   is_fresh(&a[i], n) working. It says nothing about an object with
+        //   automatic storage -- __ESBMC_alloc_size is only maintained for
+        //   heap objects -- so the extent is owed only where it is meaningful,
+        //   which keeps the stack caller above working. (#6542)
         expr2tc valid_obj = valid_object2tc(mapping.ptr_expr);
-        if (!require_dynamic)
-          return valid_obj;
-
         expr2tc ptr_obj = pointer_object2tc(pointer_type2(), mapping.ptr_expr);
 
         const symbolt *dyn_sym = ns.lookup("c:@__ESBMC_is_dynamic");
@@ -2281,7 +2287,26 @@ expr2tc code_contractst::replace_is_fresh_temps(
         expr2tc dyn_arr = symbol2tc(dyn_arr_type, dyn_sym->id);
         expr2tc is_dynamic = index2tc(get_bool_type(), dyn_arr, ptr_obj);
 
-        return and2tc(valid_obj, is_dynamic);
+        if (require_dynamic)
+          return and2tc(valid_obj, is_dynamic);
+
+        if (is_nil_expr(mapping.size_expr))
+          return valid_obj;
+
+        // off + n <= have would wrap for a large n and pass vacuously, so ask
+        // the same question without an addition.
+        expr2tc off = typecast2tc(
+          size_type2(),
+          pointer_offset2tc(
+            get_int_type(config.ansi_c.address_width), mapping.ptr_expr));
+        expr2tc n = typecast2tc(size_type2(), mapping.size_expr);
+        expr2tc have =
+          typecast2tc(size_type2(), dynamic_size2tc(mapping.ptr_expr));
+        expr2tc fits = and2tc(
+          lessthanequal2tc(off, have),
+          lessthanequal2tc(n, sub2tc(size_type2(), have, off)));
+
+        return and2tc(valid_obj, or2tc(not2tc(is_dynamic), fits));
       }
     }
   }
@@ -4343,11 +4368,15 @@ expr2tc code_contractst::lower_is_fresh_in_requires(
 
     const size_t fresh_param = fresh_param_index(ptr, params);
 
+    // The extent is rebound alongside the pointer: __ESBMC_is_fresh(b, n) with
+    // n a parameter has to mean the caller's n, not the callee's symbol.
+    expr2tc size = call->operands[1];
     for (size_t i = 0; i < params.size() && i < actual_args.size(); ++i)
     {
       expr2tc param_expr =
         symbol2tc(migrate_type(params[i].type()), params[i].get_identifier());
       ptr = replace_symbol_in_expr(ptr, param_expr, actual_args[i]);
+      size = replace_symbol_in_expr(size, param_expr, actual_args[i]);
     }
     if (!is_pointer_type(ptr->type))
       continue;
@@ -4379,6 +4408,7 @@ expr2tc code_contractst::lower_is_fresh_in_requires(
     is_fresh_mapping_t m;
     m.temp_var_name = to_symbol2t(call->ret).thename;
     m.ptr_expr = ptr;
+    m.size_expr = size;
     req_is_fresh.push_back(m);
   }
 

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -68,6 +68,7 @@ public:
     irep_idt
       temp_var_name; ///< Temporary variable name (e.g., return_value$___ESBMC_is_fresh$1)
     expr2tc ptr_expr; ///< Pointer expression (dereferenced from &ptr)
+    expr2tc size_expr; ///< Extent the contract asked for, in bytes; may be nil
   };
 
   code_contractst(

--- a/website/content/docs/function-contracts.md
+++ b/website/content/docs/function-contracts.md
@@ -392,7 +392,10 @@ also how a contract states that a pointer parameter is separate from the
 others. Enforcement grants it — the parameter gets its own allocation, and is
 excluded from the aliasing described under "Pointer parameters may alias"
 below. Replacement therefore checks it, asserting at the call that the argument
-shares no object with any other pointer argument.
+shares no object with any other pointer argument, and that the object it points
+into really does extend `size` bytes past it. Both halves are obligations on
+the caller, so a program that passed a smaller object than the contract asked
+for now reports a violated `requires` where it previously verified.
 
 Two consequences worth knowing:
 


### PR DESCRIPTION
`__ESBMC_is_fresh(p, n)` names an extent, and the documentation has always said it means "a valid block of at least `size` bytes". At a replace site only the pointer survived the lowering. The obligation put to the caller was `valid_object(p)` on its own, so any live object of any size discharged it.

```c
typedef struct { int coeffs[4]; } P;

void callee(P *p) {
  __ESBMC_requires(__ESBMC_is_fresh(p, 4096));
  __ESBMC_assigns(p->coeffs);
  __ESBMC_ensures(p->coeffs[0] == 1);
  p->coeffs[0] = 1;
}

int main(void) {
  P *o = (P *)malloc(sizeof(P));   /* 16 bytes */
  __ESBMC_assume(o != 0);
  callee(o);
}
```

`--replace-call-with-contract callee` reported SUCCESSFUL. Sixteen bytes were accepted against a request for 4096, and the callee had already been enforced against a promise the caller never made — which is the composition the two modes exist to guarantee.

## The fix

Carry the extent through `is_fresh_mapping_t` and conjoin it:

```
pointer_offset(p) + n <= dynamic_size(p)
```

`dynamic_size2t` lowers to `__ESBMC_alloc_size[POINTER_OBJECT(p)]`, an allocated byte count, which is the right currency for an `is_fresh` extent — `__ESBMC_get_object_size` counts elements for arrays and goes nondet otherwise, which is why the earlier attempts recorded on #6542 did not get there. The `pointer_offset` term is what keeps `__ESBMC_is_fresh(&a[i], n)` working.

The check is an implication about size, not a blanket rejection: an extent the caller does satisfy still composes. Both directions have a test.

## Testing

340/340 `function_contract`, including `replace_is_fresh_requires_weak_caller_fail`, which #6542 singles out as the one negative control any fix here has to preserve. Two new tests, `github_6542_is_fresh_extent_fail` and `_pass`.

## Scope

This closes the extent half of #6542. The automatic-storage half is a separate path and still reproduces on master; unchanged either way by this.

Programs that passed a smaller object than their contract asked for will now report a violated `requires`. That is the point, but it is a visible change, so the `__ESBMC_is_fresh` section of the docs now says so.