### PR TITLE
[clang-c] Migrate the member arm, relaxing member2t to admit its input

### DIFF
--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -26,13 +26,13 @@ public:
   /// clang_cpp_adjust derives from this class, and the IREP2 pass is wired into
   /// clang_c_languaget::typecheck alone, so a global option check here would
   /// disable the rewrite for C++ with nothing to replace it.
-  void set_irep2_owns_index()
+  void set_irep2_owns_arms()
   {
-    irep2_owns_index = true;
+    irep2_owns_arms = true;
   }
 
 protected:
-  bool irep2_owns_index = false;
+  bool irep2_owns_arms = false;
   contextt &context;
   namespacet ns;
   symbol_generator tmp_symbol{"clang_c_adjust::"};

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -414,6 +414,9 @@ void clang_c_adjust::adjust_member(member_exprt &expr)
 {
   adjust_operands(expr);
 
+  if (irep2_owns_arms)
+    return;
+
   exprt &base = expr.struct_op();
   if (base.type().is_pointer())
   {
@@ -686,7 +689,7 @@ void clang_c_adjust::adjust_index(index_exprt &index)
   // The recursion above stays here whatever happens; only the rewrite below
   // moves (scope-clang-c-irep2.md §19.2), so gating the whole arm would skip
   // the subtree rather than hand over one transformation.
-  if (irep2_owns_index)
+  if (irep2_owns_arms)
     return;
 
   exprt &array_expr = index.op0();

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -51,6 +51,26 @@ void clang_c_adjust_irep2::adjust_expr(expr2tc &expr)
 
   if (is_index2t(expr))
     adjust_index(expr);
+  else if (is_member2t(expr))
+    adjust_member(expr);
+}
+
+void clang_c_adjust_irep2::adjust_member(expr2tc &expr)
+{
+  const member2t &m = to_member2t(expr);
+  expr2tc base = m.source_value;
+
+  if (is_pointer_type(base->type))
+    base = dereference2tc(to_pointer_type(base->type).subtype, base);
+  else if (is_array_type(base->type))
+    base = index2tc(
+      to_array_type(base->type).subtype,
+      base,
+      gen_zero(migrate_type(index_type())));
+  else
+    return;
+
+  expr = member2tc(expr->type, base, m.member);
 }
 
 void clang_c_adjust_irep2::adjust_index(expr2tc &expr)

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -50,6 +50,10 @@ private:
   /// (scope-clang-c-irep2.md §19.2).
   void adjust_index(expr2tc &expr);
 
+  /// IREP2 form of clang_c_adjust::adjust_member's rewrite: reach through a
+  /// pointer base with a dereference, or an array base with a zero index.
+  void adjust_member(expr2tc &expr);
+
   contextt &context;
   namespacet ns{context};
 };

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -453,7 +453,7 @@ bool clang_c_languaget::typecheck(contextt &context, const std::string &module)
 
   clang_c_adjust adjuster(new_context);
   if (config.options.get_bool_option("clang-c-irep2-adjust"))
-    adjuster.set_irep2_owns_index();
+    adjuster.set_irep2_owns_arms();
   if (adjuster.adjust())
     return true;
 

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1580,15 +1580,27 @@ public:
        builds member2t pre-adjust (all go through migrate at goto-convert, which
        is post-adjust), so this disjunct is staged enabling infra, exercised
        once the V.1k converter/adjuster pilot lands. */
+    /* A `pointer_id` source is the same transient state index2t already
+       permits, and for the same reason: a legacy `member` over a pointer base
+       is what the C adjuster's adjust_member rewrites to
+       `member(dereference(base))`, so migrating a symbol value before that arm
+       has run hands one here. index2t's sibling comment names this pairing; the
+       relaxation had been applied there and not here. An `array_id` source is
+       the same thing for adjust_member other branch, which rewrites an array
+       base to `member(index(base, 0))`. */
     assert(
       source->type->type_id == type2t::struct_id ||
       source->type->type_id == type2t::union_id ||
       source->type->type_id == type2t::complex_id ||
-      source->type->type_id == type2t::symbol_id);
+      source->type->type_id == type2t::symbol_id ||
+      source->type->type_id == type2t::pointer_id ||
+      source->type->type_id == type2t::array_id);
     /* member must exist exactly once in the parent struct/union — only checkable
-       once the source type is resolved (skipped for the transient symbol case) */
+       once the source type is resolved (skipped for the transient cases) */
     assert(
       source->type->type_id == type2t::symbol_id ||
+      source->type->type_id == type2t::pointer_id ||
+      source->type->type_id == type2t::array_id ||
       struct_union_get_component_number(source->type, memb).has_value());
 #endif
   }

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1595,8 +1595,9 @@ public:
       source->type->type_id == type2t::symbol_id ||
       source->type->type_id == type2t::pointer_id ||
       source->type->type_id == type2t::array_id);
-    /* member must exist exactly once in the parent struct/union — only checkable
-       once the source type is resolved (skipped for the transient cases) */
+    /* member must exist exactly once in the parent struct/union — only
+       checkable once the source type is resolved (skipped for the transient
+       cases) */
     assert(
       source->type->type_id == type2t::symbol_id ||
       source->type->type_id == type2t::pointer_id ||


### PR DESCRIPTION
Migrates `clang_c_adjust::adjust_member`, which needed `member2t`'s construction invariant relaxed to admit its own input first.

**The invariant was half-relaxed already.** `index2t` permits a transient `pointer_id` source, documented as the V.1k two-phase invariant and naming the exact rewrite the adjuster performs (`p[i]` → `*(p+i)`). `member2t` carries the sibling comment ("see member2t above") and permits `symbol_id` but neither of the two states *its own* arm consumes:

- a **pointer** base, which `adjust_member` rewrites to `member(dereference(base))`;
- an **array** base, rewritten to `member(index(base, 0))`.

Migrating a symbol value before that arm has run hands both here, so both disjuncts are added, on the same rationale #6899 used for `constant_union2t`.

**Measured in three steps**, which is why both were needed:

| | A/B divergences |
|---|---|
| arm handed over, invariant untouched | 191 |
| with the `pointer_id` disjunct | 6 |
| with `array_id` as well | **2** — `github_746`, which differs against itself |

Dropping the dereference changes 187 tests, so the arm is live. 668/668 unit tests.

The hand-over flag is generalised from `set_irep2_owns_index` to `set_irep2_owns_arms`, since it now covers two arms.

Stacked on #6912. Refs #4715
