### PR TITLE
[build] Build the Solidity model with IEEE floats

### DIFF
--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -276,9 +276,13 @@ function(mangle_clib output)
       endforeach()
       file(WRITE ${sol64_unified_c} "${sol64_unified_body}")
 
+      # No --fixedbv here: the contract under verification, the default clib and
+      # the solver encoding all run floats as IEEE, so building the models with
+      # the legacy fixed-point fallback gives the same C type two incompatible
+      # representations either side of the model boundary (#6898).
       add_custom_command(OUTPUT ${sol64_goto}
         COMMAND c2goto ${multiarch_flags} ${OS_C2GOTO_FLAGS}
-                ${sol64_unified_c} --64 --fixedbv -D__ESBMC_FIXEDBV
+                ${sol64_unified_c} --64
                 --output ${sol64_goto}
         DEPENDS c2goto ${c2goto_solidity_files} ${c2goto_header_files}
                 ${sol64_unified_c}


### PR DESCRIPTION
Reported by @mikhailramalho. `sol64.goto` was compiled with `--fixedbv -D__ESBMC_FIXEDBV` while the contract under verification, the default clib and the solver encoding all run floats as IEEE.

The models declare no floats of their own, but the amalgamated TU includes `<stdlib.h>`, whose `atof`/`strtof`/`strtod`/`strtold` arrive fixedbv-typed. Compiling that TU both ways with `c2goto` emits a `fixedbv` type entry under the current flags and `floatbv` without them. `-D__ESBMC_FIXEDBV` gates only `libm/sqrt.c`, which this TU does not include.

No regression test: this is a build-configuration change with no host-observable behaviour. macOS/ARM64 takes the empty-stub arm, so the edited command cannot run locally — the Solidity suite in PR CI (Linux, `ENABLE_SOLIDITY_FRONTEND=On`) is what exercises it, and is the check to watch here.

Fixes #6898