### PR TITLE
[goto-programs] Name the location when an assert description is not literal

### DIFF
--- a/regression/esbmc/assert_desc_not_literal/main.c
+++ b/regression/esbmc/assert_desc_not_literal/main.c
@@ -1,0 +1,17 @@
+// An __ESBMC_assert whose description is a runtime pointer rather than a string
+// literal used to abort the whole run out of get_string_constant. Only the
+// assertion's description is read from there, so it degrades to a warning and
+// verification proceeds. #1557
+int nondet_int(void);
+
+static void checked(const char *why, int ok)
+{
+  __ESBMC_assert(ok, why);
+}
+
+int main(void)
+{
+  int x = nondet_int();
+  checked("x equals itself", x == x);
+  return 0;
+}

--- a/regression/esbmc/assert_desc_not_literal/test.desc
+++ b/regression/esbmc/assert_desc_not_literal/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^WARNING: assertion description at .* is not a string literal; reporting the guard instead$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/assert_desc_not_literal_fail/main.c
+++ b/regression/esbmc/assert_desc_not_literal_fail/main.c
@@ -1,0 +1,15 @@
+// The assertion is still checked when its description is not a literal, and
+// the report falls back to the guard rather than an empty message. #1557
+int nondet_int(void);
+
+static void checked(const char *why, int ok)
+{
+  __ESBMC_assert(ok, why);
+}
+
+int main(void)
+{
+  int x = nondet_int();
+  checked("x must be positive", x > 0);
+  return 0;
+}

--- a/regression/esbmc/assert_desc_not_literal_fail/test.desc
+++ b/regression/esbmc/assert_desc_not_literal_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^  assertion \(_Bool\)ok$
+^VERIFICATION FAILED$

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -46,7 +46,16 @@ static void get_string_constant(const exprt &expr, std::string &the_string)
     !expr.is_address_of() || expr.operands().size() != 1 ||
     !expr.op0().is_index() || expr.op0().operands().size() != 2)
   {
-    log_warning("expected string constant, but got:\n{}", expr);
+    // Only the assertion's description is read from here, so a message built
+    // at runtime is not an error: the caller falls back to printing the guard.
+    // Name the location rather than dumping the expression tree — the dump was
+    // pages of irep for a benign case, and it is the source line the user needs
+    // (#1557).
+    const locationt &loc = expr.find_location();
+    log_warning(
+      "assertion description at {} is not a string literal; reporting the "
+      "guard instead",
+      loc.is_nil() ? std::string("unknown location") : loc.as_string());
     return;
   }
 


### PR DESCRIPTION
Reported by @mikhailramalho. Checking #1557 against master first: the abort it reports is **already gone** — `get_string_constant` warns and returns, and the caller falls back to reporting the guard, so a runtime-built description now verifies fine. Nothing pinned that, though, and the warning still dumped the whole irep tree for a benign case.

This replaces the dump with one line naming the source location, which is what identifies the offending call site, and adds the regression coverage the graceful path never had.

Note on the tests: `assert_desc_not_literal` fails without this change (it matches the new message); `assert_desc_not_literal_fail` passes either way by design — it locks in the already-fixed behaviour so the abort cannot come back.

Part of #1557