### PR TITLE
[goto-symex] Pin the schedule count #6831's bisect used

### DIFF
--- a/docs/roadmap/svcomp-6831-schedule-space-plan.md
+++ b/docs/roadmap/svcomp-6831-schedule-space-plan.md
@@ -6,7 +6,7 @@
 schedule-space explosion*, 291 of 489 lost SV-COMP tasks.
 **Bisected to:** `bac652b13c` — `[goto-symex] Track main-thread termination per
 state, not per search` (#6607), which fixes #4584.
-**Last updated:** 2026-08-09.
+**Last updated:** 2026-08-11.
 
 **Measurement environment.** All numbers below were measured on an x86_64 Linux
 host against `build/src/esbmc/esbmc`, ESBMC 8.4.0, built from `19db2adc96`
@@ -356,10 +356,14 @@ re-introduce exactly the unsoundness #6607 removed. Each must discharge:
 - **G2 — #4584 still caught.** The regression test #6607 added still detects its
   race. A reduction that silently re-truncates the search will pass G1 and fail
   only here.
-- **G3 — schedule count pinned.** A regression test asserting the interleaving
-  count on `01_malloc_20` at `--context-bound 2`, so a future truncation is a
-  test failure rather than a score movement noticed a release later. This is the
-  oracle the issue's bisect used; it should be in the tree.
+- **G3 — schedule count pinned. Discharged.** Both `01_malloc_20` at
+  `--context-bound 2` (the oracle the bisect used, 940 schedules / 296 MPOR,
+  THOROUGH) and a CORE variant `github_6831_schedule_count` at `--unwind 1`
+  (262 / 95, 4 s so it runs in PR CI) now assert their counters, so a future
+  truncation is a test failure rather than a score movement noticed a release
+  later. Re-introducing #6607's search-global `main_thread_ended` collapses them
+  to 66 / 15 and 14 / 3 respectively — measured, not assumed, so the pin is
+  known to discriminate the exact regression §7 is about.
 - **G4 — dual-solver agreement.** Bitwuzla and Z3 agree on the changed set.
 - **G5 — measured, not asserted.** Every claimed reduction quoted with W0's
   counters, before and after, naming the configuration.

--- a/regression/esbmc-unix/01_malloc_20/test.desc
+++ b/regression/esbmc-unix/01_malloc_20/test.desc
@@ -2,3 +2,4 @@ THOROUGH
 main.c
 --no-unwinding-assertions --unwind 3 --context-bound 2 --force-malloc-success --memory-leak-check
 ^VERIFICATION SUCCESSFUL$
+^Schedule reduction: peak_threads 3, schedules_explored 940, pruned_by_mpor 296, pruned_by_hash 0

--- a/regression/esbmc-unix/github_6831_schedule_count/main.c
+++ b/regression/esbmc-unix/github_6831_schedule_count/main.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#define N 2
+
+int  num;
+pthread_mutex_t *m;
+pthread_cond_t *empty, *full;
+
+void *thread1(void * arg)
+{
+  int i;
+
+  i = 0;
+  while (i < N){
+    pthread_mutex_lock(m);
+    while (num > 0) 
+      pthread_cond_wait(empty, m);
+    
+    num++;
+
+    printf ("produce ....%d\n", i);
+    pthread_mutex_unlock(m);
+
+    pthread_cond_signal(full);
+
+    i++;
+  }
+}
+
+
+void *thread2(void *arg)
+{
+  int j;
+
+  j = 0;
+  while (j < N){
+    pthread_mutex_lock(m);
+    while (num == 0) 
+      pthread_cond_wait(full, m);
+
+    num--;
+    printf("consume ....%d\n",j);
+    pthread_mutex_unlock(m);
+    
+    pthread_cond_signal(empty);
+    j++;    
+  }
+}
+
+
+int main()
+{
+  pthread_t  t1, t2;
+
+  num = 0;
+
+  m = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+  empty = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
+  full = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
+
+  if (m==NULL || empty==NULL || full==NULL)
+    exit(0);
+
+  pthread_mutex_init(m, 0);
+  pthread_cond_init(empty, 0);
+  pthread_cond_init(full, 0);
+  
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+
+  free(m);
+  free(empty);
+  free(full);
+
+  return 0;
+  
+}

--- a/regression/esbmc-unix/github_6831_schedule_count/test.desc
+++ b/regression/esbmc-unix/github_6831_schedule_count/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-unwinding-assertions --unwind 1 --context-bound 2 --force-malloc-success --memory-leak-check
+^VERIFICATION SUCCESSFUL$
+^Schedule reduction: peak_threads 3, schedules_explored 262, pruned_by_mpor 95, pruned_by_hash 0


### PR DESCRIPTION
Gate G3 of the schedule-space plan asked for the interleaving count on `01_malloc_20` to be a test rather than a number in a document. Pins it on the THOROUGH original (940 schedules, 296 MPOR-pruned) and adds a 4 s CORE variant at `--unwind 1` (262 / 95) so PR CI carries the oracle too.

Re-introducing #6607's search-global `main_thread_ended` collapses the two counts to 66 and 14, so the pin discriminates the re-truncation regression it exists for. Bitwuzla and Z3 agree on the counters.

Refs #6831.