### PR TITLE
[goto-symex] Compose schedule falsification with unwinding strategies

### DIFF
--- a/docs/roadmap/svcomp-6831-schedule-space-plan.md
+++ b/docs/roadmap/svcomp-6831-schedule-space-plan.md
@@ -348,9 +348,18 @@ and the pre-pass forces `--no-unwinding-assertions` (defaulting `--unwind` to 1
 when the run sets none) so a truncated loop yields fewer paths rather than a
 spurious unwinding-assertion failure. A violation found is therefore genuine
 whatever the strategy would have concluded, and finding none is not evidence,
-so the strategy afterwards runs untouched. Coverage runs skip the pre-pass:
-its rounds would fold into the reported figure and print one `[Coverage]` block
-per bound.
+so the strategy afterwards runs untouched.
+
+That argument only holds where a SAT round *means* a violation, which is
+narrower than it first appears and cost four wrong verdicts in review before it
+was pinned down. `--forward-condition` and `--inductive-step` read SAT as
+"unable to prove"; `--termination` inverts it further, since its markers make
+reaching an assert evidence that the loop terminates; a `--multi-property`
+round owns the property table and would report the truncated pre-pass as the
+whole result; and `--partial-loops` removes the very assumption the
+under-approximation rests on. The first four are rejected, `--partial-loops` is
+forced off for the pre-pass, and coverage runs skip it (its rounds would fold
+into the reported figure and print one `[Coverage]` block per bound).
 
 On `00_rwlock4` — the #6480 shape, a violation needing few switches stranded
 deep in unbounded DFS order — `--incremental-bmc` alone produced no verdict in

--- a/docs/roadmap/svcomp-6831-schedule-space-plan.md
+++ b/docs/roadmap/svcomp-6831-schedule-space-plan.md
@@ -332,6 +332,39 @@ not already guarantee it, W4 becomes a code change, not a configuration change.
 **Exit:** a measured score delta on the affected categories, and an explicit
 argument for why no `true` is emitted without exhaustive coverage.
 
+#### W4.1 — `--falsify-context-bound`, the composition (shipped, off by default)
+
+The wrapper cannot adopt `--incremental-context-bound`: it is rejected
+alongside `--incremental-bmc` (`driver.cpp:218`, #6480 — only one driver may own
+the outer loop) and the wrapper sends every concurrency task through
+`--incremental-bmc` (`esbmc-wrapper.py:315`). The two deepening loops do not
+compose because both own the *verdict*, not because they cannot run in sequence.
+
+`--falsify-context-bound N` gives up the half that collides. It deepens the
+context bound from 1 to N before the chosen strategy runs, under
+`suppress-bounded-success`, so it can only report a violation: each round
+under-approximates twice over — the context bound truncates the schedule space,
+and the pre-pass forces `--no-unwinding-assertions` (defaulting `--unwind` to 1
+when the run sets none) so a truncated loop yields fewer paths rather than a
+spurious unwinding-assertion failure. A violation found is therefore genuine
+whatever the strategy would have concluded, and finding none is not evidence,
+so the strategy afterwards runs untouched. Coverage runs skip the pre-pass:
+its rounds would fold into the reported figure and print one `[Coverage]` block
+per bound.
+
+On `00_rwlock4` — the #6480 shape, a violation needing few switches stranded
+deep in unbounded DFS order — `--incremental-bmc` alone produced no verdict in
+90 s, and `--incremental-bmc --falsify-context-bound 2` reported FAILED in
+1.1 s. `--k-induction --falsify-context-bound 2` behaves the same (1.2 s); both
+combinations were previously rejected outright.
+
+**Still open:** the adaptive policy. §W4's sweep says full deepening buys one
+stranded falsification in 40 unsafe tests and costs 18 proofs in 132 safe ones,
+so the wrapper change wants a *shallow* N (the stranded shapes are found at
+N ≤ 2 in ~1 s) rather than deepening to convergence — and that N, plus the
+resulting score delta on the concurrency categories, is what the exit above
+still asks for.
+
 ---
 
 ## 5. Sequencing

--- a/regression/esbmc-unix/github_6831_falsify_prepass/main.c
+++ b/regression/esbmc-unix/github_6831_falsify_prepass/main.c
@@ -1,0 +1,37 @@
+#include <pthread.h>
+#include <assert.h>
+#include <errno.h>
+
+pthread_rwlock_t lock;
+
+void *reader_thread(void *arg)
+{
+    int ret;
+    ret = pthread_rwlock_tryrdlock(&lock);
+    assert(ret == 0 || ret == EBUSY);
+    pthread_rwlock_unlock(&lock);
+    return NULL;
+}
+
+void *writer_thread(void *arg)
+{
+    int ret;
+    ret = pthread_rwlock_trywrlock(&lock);
+    assert(ret == 0 || ret == EBUSY);
+    ret = pthread_rwlock_trywrlock(&lock);
+    assert(ret == EBUSY);
+    ret = pthread_rwlock_tryrdlock(&lock);
+    pthread_rwlock_unlock(&lock);
+    return NULL;
+}
+
+int main()
+{
+    pthread_rwlock_init(&lock, NULL);
+    pthread_t t1, t2;
+    pthread_create(&t1, NULL, reader_thread, NULL);
+    pthread_create(&t2, NULL, writer_thread, NULL);
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+    return 0;
+}

--- a/regression/esbmc-unix/github_6831_falsify_prepass/test.desc
+++ b/regression/esbmc-unix/github_6831_falsify_prepass/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-por --incremental-bmc --falsify-context-bound 2
+^Falsifying with context bound 2$
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/github_6831_falsify_prepass_partial/main.c
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_partial/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int nondet_int();
+
+int main()
+{
+  int n = nondet_int();
+  __ESBMC_assume(n == 3);
+
+  int i = 0;
+  while (i < n)
+    i++;
+
+  assert(i == n);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6831_falsify_prepass_partial/test.desc
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_partial/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--partial-loops --falsify-context-bound 1
+^Falsifying with context bound 1$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6831_falsify_prepass_reject/main.c
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_reject/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int nondet_int();
+
+int main()
+{
+  int n = nondet_int();
+  __ESBMC_assume(n == 3);
+
+  int i = 0;
+  while (i < n)
+    i++;
+
+  assert(i == n);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6831_falsify_prepass_reject/test.desc
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_reject/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--multi-property --falsify-context-bound 1
+^ERROR: --falsify-context-bound cannot be combined with --multi-property$

--- a/regression/esbmc-unix/github_6831_falsify_prepass_restore/main.c
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_restore/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int nondet_int();
+
+int main()
+{
+  int n = nondet_int();
+  __ESBMC_assume(n == 5);
+
+  int i = 0;
+  while (i < n)
+    i++;
+
+  assert(i != 5);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6831_falsify_prepass_restore/test.desc
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_restore/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--falsify-context-bound 2
+^Falsifying with context bound 2$
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/github_6831_falsify_prepass_safe/main.c
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_safe/main.c
@@ -1,0 +1,30 @@
+#include <pthread.h>
+#include <assert.h>
+
+pthread_mutex_t m;
+int counter;
+
+void *worker(void *arg)
+{
+  pthread_mutex_lock(&m);
+  counter++;
+  assert(counter > 0);
+  pthread_mutex_unlock(&m);
+  return NULL;
+}
+
+int main()
+{
+  pthread_t t1, t2;
+
+  pthread_mutex_init(&m, NULL);
+  counter = 0;
+
+  pthread_create(&t1, NULL, worker, NULL);
+  pthread_create(&t2, NULL, worker, NULL);
+  pthread_join(t1, NULL);
+  pthread_join(t2, NULL);
+
+  assert(counter == 2);
+  return 0;
+}

--- a/regression/esbmc-unix/github_6831_falsify_prepass_safe/test.desc
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_safe/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--context-bound 2 --falsify-context-bound 3
+^Falsifying with context bound 3$
+Falsifying with context bound 1\n(?:(?!VERIFICATION SUCCESSFUL)[\s\S])*Falsifying with context bound 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_6831_falsify_prepass_sound/main.c
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_sound/main.c
@@ -1,0 +1,37 @@
+#include <pthread.h>
+#include <assert.h>
+#include <errno.h>
+
+pthread_rwlock_t lock;
+
+void *reader_thread(void *arg)
+{
+    int ret;
+    ret = pthread_rwlock_tryrdlock(&lock);
+    assert(ret == 0 || ret == EBUSY);
+    pthread_rwlock_unlock(&lock);
+    return NULL;
+}
+
+void *writer_thread(void *arg)
+{
+    int ret;
+    ret = pthread_rwlock_trywrlock(&lock);
+    assert(ret == 0 || ret == EBUSY);
+    ret = pthread_rwlock_trywrlock(&lock);
+    assert(ret == EBUSY);
+    ret = pthread_rwlock_tryrdlock(&lock);
+    pthread_rwlock_unlock(&lock);
+    return NULL;
+}
+
+int main()
+{
+    pthread_rwlock_init(&lock, NULL);
+    pthread_t t1, t2;
+    pthread_create(&t1, NULL, reader_thread, NULL);
+    pthread_create(&t2, NULL, writer_thread, NULL);
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+    return 0;
+}

--- a/regression/esbmc-unix/github_6831_falsify_prepass_sound/test.desc
+++ b/regression/esbmc-unix/github_6831_falsify_prepass_sound/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-por --context-bound 3 --falsify-context-bound 1
+^Falsifying with context bound 1$
+Falsifying with context bound 1\n(?:(?!VERIFICATION SUCCESSFUL)[\s\S])*VERIFICATION FAILED

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -83,6 +83,8 @@ protected:
     optionst &options,
     goto_functionst &goto_functions);
 
+  int run_chosen_strategy(optionst &options, goto_functionst &goto_functions);
+
   int doit_k_induction_parallel();
 
   tvt is_base_case_violated(

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -79,6 +79,10 @@ protected:
     optionst &options,
     goto_functionst &goto_functions);
 
+  bool falsify_with_bounded_schedules(
+    optionst &options,
+    goto_functionst &goto_functions);
+
   int doit_k_induction_parallel();
 
   tvt is_base_case_violated(

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -79,7 +79,7 @@ protected:
     optionst &options,
     goto_functionst &goto_functions);
 
-  bool falsify_with_bounded_schedules(
+  int falsify_with_bounded_schedules(
     optionst &options,
     goto_functionst &goto_functions);
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -561,6 +561,11 @@ const struct group_opt_templ all_cmd_options[] = {
     {"max-context-bound",
      boost::program_options::value<int>()->default_value(20)->value_name("nr"),
      "Highest context bound tried by --incremental-context-bound"},
+    {"falsify-context-bound",
+     boost::program_options::value<int>()->default_value(0)->value_name("nr"),
+     "Before the chosen strategy runs, look for a violation with the context "
+     "bound raised from 1 to nr; such a violation is genuine, no proof is "
+     "claimed, and the strategy still runs when none is found (0 = off)"},
     {"state-hashing", NULL, "Enable state-hashing, prunes duplicate states"},
     {"no-goto-merge",
      NULL,

--- a/src/esbmc/parseoptions/bmc_strategy.cpp
+++ b/src/esbmc/parseoptions/bmc_strategy.cpp
@@ -581,13 +581,44 @@ int esbmc_parseoptionst::do_context_bound_deepening(
 // context bound truncates the schedule space and the unwind bound truncates the
 // loops -- so a violation is genuine, while finding none is not evidence of
 // anything and is not reported. The chosen strategy then runs untouched.
-bool esbmc_parseoptionst::falsify_with_bounded_schedules(
+// Returns an exit code when the pre-pass concluded the run, or -1 to hand over
+// to the chosen strategy.
+int esbmc_parseoptionst::falsify_with_bounded_schedules(
   optionst &options,
   goto_functionst &goto_functions)
 {
   const int max_cb = atoi(options.get_option("falsify-context-bound").c_str());
-  if (max_cb < 1)
-    return false;
+  if (max_cb == 0)
+    return -1;
+
+  if (max_cb < 0)
+  {
+    log_error("--falsify-context-bound ({}) cannot be negative.", max_cb);
+    return 6;
+  }
+
+  // A round of the pre-pass is a base-case BMC run, so it composes only with a
+  // verdict read off the base case. Under --forward-condition / --inductive-step
+  // a SAT round means "unable to prove" rather than "violation"; --termination
+  // inverts it further, since its markers make reaching an assert evidence that
+  // the loop *does* terminate. A --multi-property round owns the property table
+  // and would report the truncated pre-pass as the whole result, and the two
+  // emission modes would dump their formulas once per bound.
+  for (const char *incompatible :
+       {"termination",
+        "forward-condition",
+        "inductive-step",
+        "multi-property",
+        "incremental-context-bound",
+        "show-vcc",
+        "smt-formula-only",
+        "smt-formula-too"})
+    if (options.get_bool_option(incompatible))
+    {
+      log_error(
+        "--falsify-context-bound cannot be combined with --{}", incompatible);
+      return 1;
+    }
 
   // Each round reaches its own set of claims and a coverage run reports the
   // union, so the pre-pass would print a [Coverage] block per bound and fold
@@ -595,27 +626,42 @@ bool esbmc_parseoptionst::falsify_with_bounded_schedules(
   if (is_coverage)
   {
     log_warning("--falsify-context-bound is ignored on a coverage run");
-    return false;
+    return -1;
   }
 
   const optionst::option_mapt saved = options.option_map;
 
   options.set_option("suppress-bounded-success", true);
   options.set_option("no-unwinding-assertions", true);
+  // Without this the forced unwind bound cuts loops with no constraint at all
+  // (symex_goto.cpp, loop_bound_exceeded), and paths that never satisfy the
+  // exit condition would flow on into the code after the loop -- which is an
+  // over-approximation, and would make a "violation" here not a violation.
+  options.set_option("partial-loops", false);
   if (options.get_option("unwind").empty())
     options.set_option("unwind", "1");
 
-  bool violated = false;
-  for (int cb = 1; cb <= max_cb && !violated; ++cb)
+  int result = -1;
+  for (int cb = 1; cb <= max_cb; ++cb)
   {
     options.set_option("context-bound", std::to_string(cb));
     bmct bmc(goto_functions, options, context);
     log_progress("Falsifying with context bound {}", cb);
-    violated = do_bmc(bmc) == P_SATISFIABLE;
+
+    const int res = do_bmc(bmc);
+    if (res == P_SATISFIABLE)
+    {
+      result = 1;
+      break;
+    }
+    // A solver failure says nothing about deeper bounds, and the strategy is
+    // entitled to its own attempt, so stop the pre-pass rather than deepen.
+    if (res != P_UNSATISFIABLE)
+      break;
   }
 
   options.option_map = saved;
-  return violated;
+  return result;
 }
 
 int esbmc_parseoptionst::do_bmc(bmct &bmc)

--- a/src/esbmc/parseoptions/bmc_strategy.cpp
+++ b/src/esbmc/parseoptions/bmc_strategy.cpp
@@ -573,6 +573,51 @@ int esbmc_parseoptionst::do_context_bound_deepening(
   return 0;
 }
 
+// Falsification-only pre-pass over a deepening context bound (issue #6831, W4).
+//
+// --incremental-context-bound cannot compose with the unwinding strategies
+// because both would own the verdict (driver.cpp, #6480). This composes by
+// giving up the half that collides: every round here under-approximates -- the
+// context bound truncates the schedule space and the unwind bound truncates the
+// loops -- so a violation is genuine, while finding none is not evidence of
+// anything and is not reported. The chosen strategy then runs untouched.
+bool esbmc_parseoptionst::falsify_with_bounded_schedules(
+  optionst &options,
+  goto_functionst &goto_functions)
+{
+  const int max_cb = atoi(options.get_option("falsify-context-bound").c_str());
+  if (max_cb < 1)
+    return false;
+
+  // Each round reaches its own set of claims and a coverage run reports the
+  // union, so the pre-pass would print a [Coverage] block per bound and fold
+  // its truncated rounds into the figure the strategy reports.
+  if (is_coverage)
+  {
+    log_warning("--falsify-context-bound is ignored on a coverage run");
+    return false;
+  }
+
+  const optionst::option_mapt saved = options.option_map;
+
+  options.set_option("suppress-bounded-success", true);
+  options.set_option("no-unwinding-assertions", true);
+  if (options.get_option("unwind").empty())
+    options.set_option("unwind", "1");
+
+  bool violated = false;
+  for (int cb = 1; cb <= max_cb && !violated; ++cb)
+  {
+    options.set_option("context-bound", std::to_string(cb));
+    bmct bmc(goto_functions, options, context);
+    log_progress("Falsifying with context bound {}", cb);
+    violated = do_bmc(bmc) == P_SATISFIABLE;
+  }
+
+  options.option_map = saved;
+  return violated;
+}
+
 int esbmc_parseoptionst::do_bmc(bmct &bmc)
 {
   log_progress("Starting Bounded Model Checking");

--- a/src/esbmc/parseoptions/bmc_strategy.cpp
+++ b/src/esbmc/parseoptions/bmc_strategy.cpp
@@ -598,8 +598,9 @@ int esbmc_parseoptionst::falsify_with_bounded_schedules(
   }
 
   // A round of the pre-pass is a base-case BMC run, so it composes only with a
-  // verdict read off the base case. Under --forward-condition / --inductive-step
-  // a SAT round means "unable to prove" rather than "violation"; --termination
+  // verdict read off the base case. Under --forward-condition or
+  // --inductive-step a SAT round means "unable to prove", not a violation;
+  // --termination
   // inverts it further, since its markers make reaching an assert evidence that
   // the loop *does* terminate. A --multi-property round owns the property table
   // and would report the truncated pre-pass as the whole result, and the two

--- a/src/esbmc/parseoptions/command_line_options.cpp
+++ b/src/esbmc/parseoptions/command_line_options.cpp
@@ -428,10 +428,6 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   else
     options.set_option("max-context-bound", 20);
 
-  if (cmdline.isset("falsify-context-bound"))
-    options.set_option(
-      "falsify-context-bound", cmdline.getval("falsify-context-bound"));
-
   if (cmdline.isset("deadlock-check"))
   {
     options.set_option("deadlock-check", true);

--- a/src/esbmc/parseoptions/command_line_options.cpp
+++ b/src/esbmc/parseoptions/command_line_options.cpp
@@ -428,6 +428,10 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   else
     options.set_option("max-context-bound", 20);
 
+  if (cmdline.isset("falsify-context-bound"))
+    options.set_option(
+      "falsify-context-bound", cmdline.getval("falsify-context-bound"));
+
   if (cmdline.isset("deadlock-check"))
   {
     options.set_option("deadlock-check", true);

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -410,7 +410,7 @@ int esbmc_parseoptionst::doit()
     return 0;
 
   // A violation found under a bounded schedule space is genuine whichever
-  // strategy owns the run, so this precedes the dispatch rather than joining it.
+  // strategy owns the run, so this precedes the dispatch rather than joins it.
   const int prepass = falsify_with_bounded_schedules(options, goto_functions);
   if (prepass >= 0)
     return prepass;

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -411,8 +411,9 @@ int esbmc_parseoptionst::doit()
 
   // A violation found under a bounded schedule space is genuine whichever
   // strategy owns the run, so this precedes the dispatch rather than joining it.
-  if (falsify_with_bounded_schedules(options, goto_functions))
-    return 1;
+  const int prepass = falsify_with_bounded_schedules(options, goto_functions);
+  if (prepass >= 0)
+    return prepass;
 
   // Now run one of the chosen strategies
   int res;

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -409,6 +409,11 @@ int esbmc_parseoptionst::doit()
   if (options.get_bool_option("skip-bmc"))
     return 0;
 
+  // A violation found under a bounded schedule space is genuine whichever
+  // strategy owns the run, so this precedes the dispatch rather than joining it.
+  if (falsify_with_bounded_schedules(options, goto_functions))
+    return 1;
+
   // Now run one of the chosen strategies
   int res;
   if (cmdline.isset("incremental-context-bound"))

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -110,6 +110,24 @@ extern "C"
 //    - Perform a single run of Bounded Model Checking and rely
 //      on the simplifier to determine the sufficient verification bound
 //      (see "do_bmc")
+int esbmc_parseoptionst::run_chosen_strategy(
+  optionst &options,
+  goto_functionst &goto_functions)
+{
+  if (cmdline.isset("incremental-context-bound"))
+    return do_context_bound_deepening(options, goto_functions);
+
+  if (
+    cmdline.isset("termination") || cmdline.isset("incremental-bmc") ||
+    cmdline.isset("falsification") || cmdline.isset("k-induction") ||
+    cmdline.isset("loop-invariant"))
+    return do_bmc_strategy(options, goto_functions);
+
+  // No strategy chosen: rely on the simplifier and the flags set through CMD.
+  bmct bmc(goto_functions, options, context);
+  return do_bmc(bmc);
+}
+
 int esbmc_parseoptionst::doit()
 {
   // Configure msg output
@@ -415,22 +433,7 @@ int esbmc_parseoptionst::doit()
   if (prepass >= 0)
     return prepass;
 
-  // Now run one of the chosen strategies
-  int res;
-  if (cmdline.isset("incremental-context-bound"))
-    res = do_context_bound_deepening(options, goto_functions);
-  else if (
-    cmdline.isset("termination") || cmdline.isset("incremental-bmc") ||
-    cmdline.isset("falsification") || cmdline.isset("k-induction") ||
-    cmdline.isset("loop-invariant"))
-    res = do_bmc_strategy(options, goto_functions);
-  else
-  {
-    // If no strategy is chosen, just rely on the simplifier
-    // and the flags set through CMD
-    bmct bmc(goto_functions, options, context);
-    res = do_bmc(bmc);
-  }
+  const int res = run_chosen_strategy(options, goto_functions);
 
   // Dead-code analysis is advisory: its probes are SAT for every live branch,
   // which do_bmc maps to a non-zero (FAILED) exit code. The findings are


### PR DESCRIPTION
`--incremental-context-bound` cannot run alongside `--incremental-bmc` or k-induction because both own the verdict (#6480), which left the SV-COMP wrapper — which sends every concurrency task through `--incremental-bmc` — unable to use it at all. `--falsify-context-bound N` gives up the half that collides: it deepens the context bound looking only for a violation, never claims a proof, and hands the run to the chosen strategy afterwards. Off by default.

On `00_rwlock4` `--incremental-bmc` alone reports nothing in 90 s; with `--falsify-context-bound 2` it reports FAILED in 1.1 s. The pre-pass is rejected under the phase-only modes, `--termination` and `--multi-property`, where a SAT round does not mean a violation, and forces `--partial-loops` off so the truncated loops stay an under-approximation.

Refs #6831.