### PR TITLE
[python] Lower requires/ensures clauses in the Python frontend

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -202,6 +202,7 @@ if(ENABLE_PYTHON_FRONTEND)
     set(REGRESSIONS_HUMANEVAL humaneval)
     set(REGRESSIONS_QUIXBUGS quixbugs)
     set(REGRESSIONS_PYTHON_COVERAGE python-coverage)
+    set(REGRESSIONS_PYTHON_CONTRACTS python-contracts)
     set(REGRESSIONS_AI_GENERATED_CODE ai-generated-code)
 endif()
 
@@ -315,6 +316,7 @@ if(APPLE)
                     ${REGRESSIONS_HUMANEVAL}
                     ${REGRESSIONS_QUIXBUGS}
                     ${REGRESSIONS_PYTHON_COVERAGE}
+                    ${REGRESSIONS_PYTHON_CONTRACTS}
                     ${REGRESSIONS_AI_GENERATED_CODE}
                     ${REGRESSIONS_LD}
                     ${TEST_GENERATION}
@@ -389,6 +391,7 @@ else()
                     ${REGRESSIONS_HUMANEVAL}
                     ${REGRESSIONS_QUIXBUGS}
                     ${REGRESSIONS_PYTHON_COVERAGE}
+                    ${REGRESSIONS_PYTHON_CONTRACTS}
                     ${REGRESSIONS_AI_GENERATED_CODE}
                     ${REGRESSIONS_LD}
                     ${TEST_GENERATION}

--- a/regression/python-contracts/clause_arity_fail/main.py
+++ b/regression/python-contracts/clause_arity_fail/main.py
@@ -1,0 +1,9 @@
+def h(x: int) -> int:
+    __ESBMC_requires(x > 0, x < 10)
+    return x
+
+def main() -> None:
+    y: int = h(5)
+    assert y == 5
+
+main()

--- a/regression/python-contracts/clause_arity_fail/test.desc
+++ b/regression/python-contracts/clause_arity_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract h
+^ERROR: __ESBMC_requires at line 2 takes exactly one argument, got 2

--- a/regression/python-contracts/clause_call_fail/main.py
+++ b/regression/python-contracts/clause_call_fail/main.py
@@ -1,0 +1,11 @@
+def size(l: list) -> int:
+    __ESBMC_requires(len(l) > 0)
+    __ESBMC_ensures(__ESBMC_return_value >= 0)
+    return len(l)
+
+def main() -> None:
+    a = [7, 8]
+    v: int = size(a)
+    assert v == 2
+
+main()

--- a/regression/python-contracts/clause_call_fail/test.desc
+++ b/regression/python-contracts/clause_call_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract size
+^ERROR: __ESBMC_requires clause at line 2 contains a function call

--- a/regression/python-contracts/clause_genexp_fail/main.py
+++ b/regression/python-contracts/clause_genexp_fail/main.py
@@ -1,0 +1,11 @@
+def allpos(l: list, n: int) -> int:
+    __ESBMC_requires(all(x > 0 for x in l))
+    __ESBMC_ensures(__ESBMC_return_value == n)
+    return n
+
+def main() -> None:
+    a = [1, 2]
+    v: int = allpos(a, 5)
+    assert v == 5
+
+main()

--- a/regression/python-contracts/clause_genexp_fail/test.desc
+++ b/regression/python-contracts/clause_genexp_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract allpos
+^ERROR: __ESBMC_requires clause at line 2 contains a function call

--- a/regression/python-contracts/clause_return_value_in_requires_fail/main.py
+++ b/regression/python-contracts/clause_return_value_in_requires_fail/main.py
@@ -1,0 +1,9 @@
+def k(x: int) -> int:
+    __ESBMC_requires(__ESBMC_return_value > 0)
+    return x
+
+def main() -> None:
+    y: int = k(5)
+    assert y == 5
+
+main()

--- a/regression/python-contracts/clause_return_value_in_requires_fail/test.desc
+++ b/regression/python-contracts/clause_return_value_in_requires_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract k
+^ERROR: __ESBMC_requires clause at line 2 references __ESBMC_return_value; a precondition cannot mention the return value$

--- a/regression/python-contracts/clause_return_value_none_fail/main.py
+++ b/regression/python-contracts/clause_return_value_none_fail/main.py
@@ -1,0 +1,9 @@
+def g(x: int) -> None:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > 0)
+    return None
+
+def main() -> None:
+    g(1)
+
+main()

--- a/regression/python-contracts/clause_return_value_none_fail/test.desc
+++ b/regression/python-contracts/clause_return_value_none_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract g
+^ERROR: __ESBMC_ensures clause at line 3 references __ESBMC_return_value, but 'g' returns None$

--- a/regression/python-contracts/clause_subscript_fail/main.py
+++ b/regression/python-contracts/clause_subscript_fail/main.py
@@ -1,0 +1,11 @@
+def first(l: list) -> int:
+    __ESBMC_requires(True)
+    __ESBMC_ensures(__ESBMC_return_value == l[0])
+    return l[0]
+
+def main() -> None:
+    a = [7, 8]
+    v: int = first(a)
+    assert v == 7
+
+main()

--- a/regression/python-contracts/clause_subscript_fail/test.desc
+++ b/regression/python-contracts/clause_subscript_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract first
+^ERROR: __ESBMC_ensures clause at line 3 contains a subscript

--- a/regression/python-contracts/clause_untyped_fail/main.py
+++ b/regression/python-contracts/clause_untyped_fail/main.py
@@ -1,0 +1,9 @@
+def pick(o) -> int:
+    __ESBMC_requires(o > 0)
+    __ESBMC_ensures(__ESBMC_return_value == 1)
+    return 1
+
+def main() -> None:
+    assert True
+
+main()

--- a/regression/python-contracts/clause_untyped_fail/test.desc
+++ b/regression/python-contracts/clause_untyped_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract pick
+^ERROR: __ESBMC_requires clause at line 2 references .o., whose type could not be determined

--- a/regression/python-contracts/clause_walrus_fail/main.py
+++ b/regression/python-contracts/clause_walrus_fail/main.py
@@ -1,0 +1,10 @@
+def w(n: int) -> int:
+    __ESBMC_requires((m := n) > 0)
+    __ESBMC_ensures(__ESBMC_return_value == n)
+    return n
+
+def main() -> None:
+    v: int = w(5)
+    assert v == 5
+
+main()

--- a/regression/python-contracts/clause_walrus_fail/test.desc
+++ b/regression/python-contracts/clause_walrus_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract w
+^ERROR: __ESBMC_requires clause at line 2 contains an assignment expression

--- a/regression/python-contracts/clauses_inert/main.py
+++ b/regression/python-contracts/clauses_inert/main.py
@@ -1,0 +1,10 @@
+def double(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > x)
+    return 2 * x
+
+def main() -> None:
+    y: int = double(5)
+    assert y == 10
+
+main()

--- a/regression/python-contracts/clauses_inert/test.desc
+++ b/regression/python-contracts/clauses_inert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/clauses_inert_masking_fail/main.py
+++ b/regression/python-contracts/clauses_inert_masking_fail/main.py
@@ -1,0 +1,9 @@
+def f(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    return 100 // x
+
+def main() -> None:
+    n: int = nondet_int()
+    y: int = f(n)
+
+main()

--- a/regression/python-contracts/clauses_inert_masking_fail/test.desc
+++ b/regression/python-contracts/clauses_inert_masking_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python-contracts/enforce_bool/main.py
+++ b/regression/python-contracts/enforce_bool/main.py
@@ -1,0 +1,10 @@
+def neg(b: bool) -> bool:
+    __ESBMC_requires(b or not b)
+    __ESBMC_ensures(__ESBMC_return_value != b)
+    return not b
+
+def main() -> None:
+    c: bool = neg(True)
+    assert c == False
+
+main()

--- a/regression/python-contracts/enforce_bool/test.desc
+++ b/regression/python-contracts/enforce_bool/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract neg
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/enforce_bool_fail/main.py
+++ b/regression/python-contracts/enforce_bool_fail/main.py
@@ -1,0 +1,10 @@
+def neg(b: bool) -> bool:
+    __ESBMC_requires(b or not b)
+    __ESBMC_ensures(__ESBMC_return_value != b)
+    return b
+
+def main() -> None:
+    c: bool = neg(True)
+    assert c == True
+
+main()

--- a/regression/python-contracts/enforce_bool_fail/test.desc
+++ b/regression/python-contracts/enforce_bool_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--enforce-contract neg
+^  contract ensures$
+^VERIFICATION FAILED$

--- a/regression/python-contracts/enforce_float/main.py
+++ b/regression/python-contracts/enforce_float/main.py
@@ -1,0 +1,10 @@
+def half(x: float) -> float:
+    __ESBMC_requires(x > 0.0)
+    __ESBMC_ensures(__ESBMC_return_value < x)
+    return x / 2.0
+
+def main() -> None:
+    z: float = half(4.0)
+    assert z < 4.0
+
+main()

--- a/regression/python-contracts/enforce_float/test.desc
+++ b/regression/python-contracts/enforce_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract half
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/enforce_float_fail/main.py
+++ b/regression/python-contracts/enforce_float_fail/main.py
@@ -1,0 +1,10 @@
+def half(x: float) -> float:
+    __ESBMC_requires(x > 0.0)
+    __ESBMC_ensures(__ESBMC_return_value < x)
+    return x * 2.0
+
+def main() -> None:
+    z: float = half(4.0)
+    assert z > 4.0
+
+main()

--- a/regression/python-contracts/enforce_float_fail/test.desc
+++ b/regression/python-contracts/enforce_float_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--enforce-contract half
+^  contract ensures$
+^VERIFICATION FAILED$

--- a/regression/python-contracts/enforce_int/main.py
+++ b/regression/python-contracts/enforce_int/main.py
@@ -1,0 +1,10 @@
+def double(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > x)
+    return 2 * x
+
+def main() -> None:
+    y: int = double(5)
+    assert y == 10
+
+main()

--- a/regression/python-contracts/enforce_int/test.desc
+++ b/regression/python-contracts/enforce_int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract double
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/enforce_int_fail/main.py
+++ b/regression/python-contracts/enforce_int_fail/main.py
@@ -1,0 +1,10 @@
+def double(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > x)
+    return 0 - x
+
+def main() -> None:
+    y: int = double(5)
+    assert y == -5
+
+main()

--- a/regression/python-contracts/enforce_int_fail/test.desc
+++ b/regression/python-contracts/enforce_int_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--enforce-contract double
+^  contract ensures$
+^VERIFICATION FAILED$

--- a/regression/python-contracts/replace_int/main.py
+++ b/regression/python-contracts/replace_int/main.py
@@ -1,0 +1,10 @@
+def double(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > x)
+    return 2 * x
+
+def main() -> None:
+    y: int = double(5)
+    assert y > 5
+
+main()

--- a/regression/python-contracts/replace_int/test.desc
+++ b/regression/python-contracts/replace_int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--replace-call-with-contract double
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/replace_int_requires_fail/main.py
+++ b/regression/python-contracts/replace_int_requires_fail/main.py
@@ -1,0 +1,10 @@
+def double(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > x)
+    return 2 * x
+
+def main() -> None:
+    y: int = double(-5)
+    assert y > -5
+
+main()

--- a/regression/python-contracts/replace_int_requires_fail/test.desc
+++ b/regression/python-contracts/replace_int_requires_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--replace-call-with-contract double
+^  contract requires$
+^VERIFICATION FAILED$

--- a/regression/python-contracts/replace_int_vacuity_fail/main.py
+++ b/regression/python-contracts/replace_int_vacuity_fail/main.py
@@ -1,0 +1,10 @@
+def double(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > x)
+    return 2 * x
+
+def main() -> None:
+    y: int = double(5)
+    assert y == 10
+
+main()

--- a/regression/python-contracts/replace_int_vacuity_fail/test.desc
+++ b/regression/python-contracts/replace_int_vacuity_fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
 --replace-call-with-contract double
+^  assertion y == 10$
 ^VERIFICATION FAILED$

--- a/regression/python-contracts/replace_int_vacuity_fail/test.desc
+++ b/regression/python-contracts/replace_int_vacuity_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--replace-call-with-contract double
+^VERIFICATION FAILED$

--- a/regression/python-contracts/typed_container_param/main.py
+++ b/regression/python-contracts/typed_container_param/main.py
@@ -1,0 +1,11 @@
+def take(l: list, n: int) -> int:
+    __ESBMC_requires(n > 0)
+    __ESBMC_ensures(__ESBMC_return_value == n)
+    return n
+
+def main() -> None:
+    a = [7, 8, 9]
+    v: int = take(a, 3)
+    assert v == 3
+
+main()

--- a/regression/python-contracts/typed_container_param/test.desc
+++ b/regression/python-contracts/typed_container_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract take
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/typed_container_param_fail/main.py
+++ b/regression/python-contracts/typed_container_param_fail/main.py
@@ -1,0 +1,11 @@
+def take(l: list, n: int) -> int:
+    __ESBMC_requires(n > 0)
+    __ESBMC_ensures(__ESBMC_return_value == n + 1)
+    return n
+
+def main() -> None:
+    a = [7, 8, 9]
+    v: int = take(a, 3)
+    assert v == 3
+
+main()

--- a/regression/python-contracts/typed_container_param_fail/test.desc
+++ b/regression/python-contracts/typed_container_param_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--enforce-contract take
+^  contract ensures$
+^VERIFICATION FAILED$

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -864,6 +864,14 @@ static void emit_va_marker_call(
   t->location = function.location();
 }
 
+static bool contracts_enabled(const optionst &options)
+{
+  return !options.get_option("enforce-contract").empty() ||
+         !options.get_option("replace-call-with-contract").empty() ||
+         options.get_bool_option("enforce-all-contracts") ||
+         options.get_bool_option("replace-all-contracts");
+}
+
 void goto_convertt::do_function_call_symbol(
   const exprt &lhs,
   const exprt &function,
@@ -935,6 +943,14 @@ void goto_convertt::do_function_call_symbol(
       "Found __ESBMC_assigns call with {} arguments",
       arguments.size());
   }
+
+  // A contract clause states nothing outside contract mode. goto_sideeffects
+  // already drops it, but only for clauses that arrive as a side-effect
+  // expression; the Python frontend emits a direct FUNCTION_CALL, which never
+  // reaches that strip, so a live `requires` would be assumed and mask real
+  // bugs in the function it annotates.
+  if ((is_requires || is_ensures) && !contracts_enabled(options))
+    return;
 
   if (is_assume || is_assert || is_loop_invariant || is_requires || is_ensures)
   {

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -864,12 +864,9 @@ static void emit_va_marker_call(
   t->location = function.location();
 }
 
-static bool contracts_enabled(const optionst &options)
+bool goto_convertt::drop_inactive_contract_clause(bool is_clause) const
 {
-  return !options.get_option("enforce-contract").empty() ||
-         !options.get_option("replace-call-with-contract").empty() ||
-         options.get_bool_option("enforce-all-contracts") ||
-         options.get_bool_option("replace-all-contracts");
+  return is_clause && !options.contracts_enabled();
 }
 
 void goto_convertt::do_function_call_symbol(
@@ -933,6 +930,7 @@ void goto_convertt::do_function_call_symbol(
   bool is_loop_invariant = (base_name == "__ESBMC_loop_invariant");
   bool is_requires = (base_name == "__ESBMC_requires");
   bool is_ensures = (base_name == "__ESBMC_ensures");
+  bool is_clause = is_requires || is_ensures;
   bool is_assigns = (base_name == "__ESBMC_assigns");
 
   // Debug: log if we see assigns
@@ -949,10 +947,10 @@ void goto_convertt::do_function_call_symbol(
   // expression; the Python frontend emits a direct FUNCTION_CALL, which never
   // reaches that strip, so a live `requires` would be assumed and mask real
   // bugs in the function it annotates.
-  if ((is_requires || is_ensures) && !contracts_enabled(options))
+  if (drop_inactive_contract_clause(is_clause))
     return;
 
-  if (is_assume || is_assert || is_loop_invariant || is_requires || is_ensures)
+  if (is_assume || is_assert || is_loop_invariant || is_clause)
   {
     if (arguments.size() != 1)
     {
@@ -962,7 +960,7 @@ void goto_convertt::do_function_call_symbol(
 
     if (
       options.get_bool_option("no-assertions") && !is_assume &&
-      !is_loop_invariant && !is_requires && !is_ensures)
+      !is_loop_invariant && !is_clause)
       return;
 
     // Rafael's invariant merging: combine consecutive
@@ -995,7 +993,7 @@ void goto_convertt::do_function_call_symbol(
     else
     {
       // For contract functions, generate ASSUME instructions with special markers
-      if (is_requires || is_ensures)
+      if (is_clause)
       {
         t = dest.add_instruction(ASSUME);
         t->guard = guard;

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -166,6 +166,11 @@ protected:
     const exprt::operandst &arguments,
     goto_programt &dest);
 
+  /// True when a contract clause should be dropped: no contract mode is
+  /// active, so the clause states nothing. Split out so the clause handling
+  /// adds no branching to do_function_call_symbol.
+  bool drop_inactive_contract_clause(bool is_clause) const;
+
   virtual void do_function_call_symbol(
     const exprt &lhs,
     const exprt &function,

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -1492,11 +1492,7 @@ void goto_convertt::remove_sideeffects(
       // they have zero effect on the GOTO program (no FUNCTION_CALL step, no
       // side-effect processing of the argument).  The declarations remain in
       // the unconditional intrinsics section so annotated files still compile.
-      if (
-        fsym && options.get_option("enforce-contract").empty() &&
-        options.get_option("replace-call-with-contract").empty() &&
-        !options.get_bool_option("enforce-all-contracts") &&
-        !options.get_bool_option("replace-all-contracts"))
+      if (fsym && !options.contracts_enabled())
       {
         const std::string &fname = id2string(fsym->name);
         if (

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -501,6 +501,23 @@ symbolt *python_converter::contract_return_value_symbol(
   return add_symbol_and_get_ptr(ret_symbol);
 }
 
+/// The "variable is not defined" diagnostic for a Name that resolved to no
+/// symbol, naming the enclosing function when the reference is inside one.
+static std::string undefined_variable_message(
+  const std::string &var_name,
+  const std::string &func_name,
+  const locationt &location)
+{
+  std::ostringstream error_msg;
+  error_msg << "Variable '" << var_name << "' is not defined";
+  if (!func_name.empty())
+    error_msg << " in function '" << func_name << "'";
+  if (!location.get_line().empty())
+    error_msg << " at line " << location.get_line();
+  error_msg << ".";
+  return error_msg.str();
+}
+
 exprt python_converter::get_expr(const nlohmann::json &element)
 {
   get_expr_depth_guard depth_guard(*this);
@@ -1047,27 +1064,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           break;
         }
 
-        locationt location = get_location_from_decl(element);
-        std::ostringstream error_msg;
-        if (!current_func_name_.empty())
-        {
-          // Variable referenced inside a function
-          error_msg << "Variable '" << var_name
-                    << "' is not defined in function '" << current_func_name_
-                    << "'";
-          if (!location.get_line().empty())
-            error_msg << " at line " << location.get_line();
-          error_msg << ".";
-        }
-        else
-        {
-          // Variable referenced at global scope
-          error_msg << "Variable '" << var_name << "' is not defined";
-          if (!location.get_line().empty())
-            error_msg << " at line " << location.get_line();
-          error_msg << ".";
-        }
-        throw std::runtime_error(error_msg.str());
+        throw std::runtime_error(undefined_variable_message(
+          var_name, current_func_name_, get_location_from_decl(element)));
       }
     }
 

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1007,6 +1007,30 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             break;
           }
         }
+        // __ESBMC_return_value names the returned value inside an
+        // __ESBMC_ensures clause. The contracts pass rewrites it to the real
+        // return value, so the frontend only has to give it the enclosing
+        // function's return type for the clause to type-check.
+        if (var_name == "__ESBMC_return_value" && !current_func_name_.empty())
+        {
+          symbol_id ret_sid = create_symbol_id();
+          symbolt *func_symbol = find_symbol(ret_sid.to_string());
+          if (func_symbol && func_symbol->get_type().is_code())
+          {
+            ret_sid.set_object(var_name);
+            symbolt ret_symbol = create_symbol(
+              current_python_file,
+              var_name,
+              ret_sid.to_string(),
+              get_location_from_decl(element),
+              to_code_type(func_symbol->get_type()).return_type());
+            ret_symbol.lvalue = true;
+            ret_symbol.file_local = true;
+            expr = symbol_expr(*add_symbol_and_get_ptr(ret_symbol));
+            break;
+          }
+        }
+
         locationt location = get_location_from_decl(element);
         std::ostringstream error_msg;
         if (!current_func_name_.empty())

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1015,7 +1015,15 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         {
           symbol_id ret_sid = create_symbol_id();
           symbolt *func_symbol = find_symbol(ret_sid.to_string());
-          if (func_symbol && func_symbol->get_type().is_code())
+          // A None-returning function has no value to name, and an
+          // empty-typed symbol crashes the encoder rather than failing here.
+          const typet ret_type =
+            func_symbol && func_symbol->get_type().is_code()
+              ? to_code_type(func_symbol->get_type()).return_type()
+              : typet();
+          if (
+            ret_type.is_not_nil() && ret_type != none_type() &&
+            ret_type.id() != "empty")
           {
             ret_sid.set_object(var_name);
             symbolt ret_symbol = create_symbol(
@@ -1023,7 +1031,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
               var_name,
               ret_sid.to_string(),
               get_location_from_decl(element),
-              to_code_type(func_symbol->get_type()).return_type());
+              ret_type);
             ret_symbol.lvalue = true;
             ret_symbol.file_local = true;
             expr = symbol_expr(*add_symbol_and_get_ptr(ret_symbol));

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -467,6 +467,40 @@ static bool is_attribute_base_expression(const nlohmann::json &node_type)
          node_type == "BinOp" || node_type == "UnaryOp";
 }
 
+/// The symbol `__ESBMC_return_value` names inside an `__ESBMC_ensures` clause,
+/// or null when the name is something else or the enclosing function returns
+/// nothing. The contracts pass rewrites it to the real return value, so the
+/// frontend only has to give it the enclosing function's return type for the
+/// clause to type-check.
+symbolt *python_converter::contract_return_value_symbol(
+  const std::string &var_name,
+  const nlohmann::json &element)
+{
+  if (var_name != "__ESBMC_return_value" || current_func_name_.empty())
+    return nullptr;
+
+  symbol_id ret_sid = create_symbol_id();
+  symbolt *func_symbol = find_symbol(ret_sid.to_string());
+  // A None-returning function has no value to name, and an empty-typed symbol
+  // crashes the encoder rather than failing here.
+  const typet ret_type = func_symbol && func_symbol->get_type().is_code()
+                           ? to_code_type(func_symbol->get_type()).return_type()
+                           : typet();
+  if (returns_no_value(ret_type))
+    return nullptr;
+
+  ret_sid.set_object(var_name);
+  symbolt ret_symbol = create_symbol(
+    current_python_file,
+    var_name,
+    ret_sid.to_string(),
+    get_location_from_decl(element),
+    ret_type);
+  ret_symbol.lvalue = true;
+  ret_symbol.file_local = true;
+  return add_symbol_and_get_ptr(ret_symbol);
+}
+
 exprt python_converter::get_expr(const nlohmann::json &element)
 {
   get_expr_depth_guard depth_guard(*this);
@@ -1007,36 +1041,10 @@ exprt python_converter::get_expr(const nlohmann::json &element)
             break;
           }
         }
-        // __ESBMC_return_value names the returned value inside an
-        // __ESBMC_ensures clause. The contracts pass rewrites it to the real
-        // return value, so the frontend only has to give it the enclosing
-        // function's return type for the clause to type-check.
-        if (var_name == "__ESBMC_return_value" && !current_func_name_.empty())
+        if (symbolt *rv = contract_return_value_symbol(var_name, element))
         {
-          symbol_id ret_sid = create_symbol_id();
-          symbolt *func_symbol = find_symbol(ret_sid.to_string());
-          // A None-returning function has no value to name, and an
-          // empty-typed symbol crashes the encoder rather than failing here.
-          const typet ret_type =
-            func_symbol && func_symbol->get_type().is_code()
-              ? to_code_type(func_symbol->get_type()).return_type()
-              : typet();
-          if (
-            ret_type.is_not_nil() && ret_type != none_type() &&
-            ret_type.id() != "empty")
-          {
-            ret_sid.set_object(var_name);
-            symbolt ret_symbol = create_symbol(
-              current_python_file,
-              var_name,
-              ret_sid.to_string(),
-              get_location_from_decl(element),
-              ret_type);
-            ret_symbol.lvalue = true;
-            ret_symbol.file_local = true;
-            expr = symbol_expr(*add_symbol_and_get_ptr(ret_symbol));
-            break;
-          }
+          expr = symbol_expr(*rv);
+          break;
         }
 
         locationt location = get_location_from_decl(element);

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -78,6 +78,8 @@ const std::string kEsbmcAssert = "__ESBMC_assert";
 const std::string kEsbmcUnreachable = "__ESBMC_unreachable";
 const std::string kLoopInvariant = "__loop_invariant";
 const std::string kEsbmcLoopInvariant = "__ESBMC_loop_invariant";
+const std::string kEsbmcRequires = "__ESBMC_requires";
+const std::string kEsbmcEnsures = "__ESBMC_ensures";
 const std::string kEsbmcCover = "__ESBMC_cover";
 const std::string kEsbmcAtomicBegin = "__ESBMC_atomic_begin";
 const std::string kEsbmcAtomicEnd = "__ESBMC_atomic_end";
@@ -1137,8 +1139,14 @@ exprt function_call_builder::build() const
     }
   }
 
-  // Add loop invariant symbol to symbol table
-  if (function_id.get_function() == kEsbmcLoopInvariant)
+  // Loop invariants and function-contract clauses share one shape: a bodiless
+  // `void f(bool)` whose call goto_convert lowers into a LOOP_INVARIANT or a
+  // marked ASSUME. The symbol must stay valueless: builtin_functions.cpp
+  // routes any callee carrying a body to a plain FUNCTION_CALL instead.
+  if (
+    function_id.get_function() == kEsbmcLoopInvariant ||
+    function_id.get_function() == kEsbmcRequires ||
+    function_id.get_function() == kEsbmcEnsures)
   {
     const auto &symbol_table = converter_.symbol_table();
     const std::string &func_symbol_id = function_id.to_string();

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -9,6 +9,7 @@
 #include <python-frontend/type/type_utils.h>
 #include <util/arith/arith_tools.h>
 #include <util/lang/c_types.h>
+#include <util/lang/python_types.h>
 #include <util/message/message.h>
 #include <util/irep/std_expr.h>
 #include <python-frontend/python_expr_builder.h>
@@ -89,6 +90,59 @@ const std::string kPytJoin = "__pyt_join";
 const std::string kPytTerminate = "__pyt_terminate";
 const std::string kPyLockBlockAndCheck = "__ESBMC_pylock_block_and_check";
 const std::string kPyLockReleaseWaiters = "__pyt_lock_release_waiters";
+
+// A contract clause is lowered into one ASSUME/ASSERT, so its argument has to
+// survive as a pure expression. Three Python constructs do not: a call binds
+// to an SSA temporary that the contract wrapper never declares, so the clause
+// silently becomes nondeterministic; a subscript expands into a bounds-check
+// branch, which collapses the clause to a constant; and a parameter whose type
+// could not be inferred is a `void *`, so `o > 0` compares a pointer rather
+// than the value the source reads as. Reject all three instead of verifying a
+// different property than the one written. A parameter whose type *is* known,
+// including a list or str, stays allowed.
+void function_call_builder::check_contract_clause(
+  const nlohmann::json &node,
+  const std::string &clause) const
+{
+  if (!node.is_object())
+  {
+    if (node.is_array())
+      for (const auto &child : node)
+        check_contract_clause(child, clause);
+    return;
+  }
+
+  const std::string node_type = node.value("_type", "");
+
+  if (node_type == "Call" || node_type == "Subscript")
+    throw std::runtime_error(fmt::format(
+      "{} clause at line {} contains {}; a contract clause must be a pure "
+      "expression",
+      clause,
+      node.value("lineno", 0),
+      node_type == "Call" ? "a function call" : "a subscript"));
+
+  if (node_type == "Name")
+  {
+    symbol_id sid(
+      converter_.python_file(),
+      converter_.current_classname(),
+      converter_.current_function_name());
+    sid.set_object(node.value("id", ""));
+
+    const symbolt *sym = converter_.symbol_table().find_symbol(sid.to_string());
+    if (sym && sym->get_type() == any_type())
+      throw std::runtime_error(fmt::format(
+        "{} clause at line {} references '{}', whose type could not be "
+        "determined; annotate the parameter so the clause constrains its value",
+        clause,
+        node.value("lineno", 0),
+        node.value("id", "")));
+  }
+
+  for (const auto &child : node)
+    check_contract_clause(child, clause);
+}
 
 function_call_builder::function_call_builder(
   python_converter &converter,
@@ -1138,6 +1192,11 @@ exprt function_call_builder::build() const
       converter_.add_symbol(symbol);
     }
   }
+
+  if (
+    function_id.get_function() == kEsbmcRequires ||
+    function_id.get_function() == kEsbmcEnsures)
+    check_contract_clause(call_["args"], function_id.get_function());
 
   // Loop invariants and function-contract clauses share one shape: a bodiless
   // `void f(bool)` whose call goto_convert lowers into a LOOP_INVARIANT or a

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -142,17 +142,16 @@ void function_call_builder::check_contract_call(
 // should fail loudly instead of lowering into something else. Denying only
 // Call and Subscript let comprehensions and the walrus operator through.
 // Operator and context nodes carry their own `_type`, so they are listed too.
+// `In` / `NotIn` are absent because they are container operations.
 static bool is_pure_clause_node(const std::string &node_type)
 {
   static const std::set<std::string> pure = {
-    "Name",  "Constant", "BoolOp", "UnaryOp", "BinOp",    "Compare",
-    "IfExp", "Attribute", "Load",
-    "And",   "Or",       "Not",    "UAdd",    "USub",     "Invert",
-    "Add",   "Sub",      "Mult",   "Div",     "FloorDiv", "Mod",
-    "Pow",   "LShift",   "RShift", "BitOr",   "BitXor",   "BitAnd",
-    // `in` / `not in` are container operations and stay out
-    "Eq",    "NotEq",    "Lt",     "LtE",     "Gt",       "GtE",
-    "Is",    "IsNot"};
+    "Name",  "Constant",  "BoolOp", "UnaryOp", "BinOp",  "Compare",
+    "IfExp", "Attribute", "Load",   "And",     "Or",     "Not",
+    "UAdd",  "USub",      "Invert", "Add",     "Sub",    "Mult",
+    "Div",   "FloorDiv",  "Mod",    "Pow",     "LShift", "RShift",
+    "BitOr", "BitXor",    "BitAnd", "Eq",      "NotEq",  "Lt",
+    "LtE",   "Gt",        "GtE",    "Is",      "IsNot"};
   return pure.count(node_type) != 0;
 }
 

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -81,6 +81,7 @@ const std::string kLoopInvariant = "__loop_invariant";
 const std::string kEsbmcLoopInvariant = "__ESBMC_loop_invariant";
 const std::string kEsbmcRequires = "__ESBMC_requires";
 const std::string kEsbmcEnsures = "__ESBMC_ensures";
+const std::string kEsbmcReturnValue = "__ESBMC_return_value";
 const std::string kEsbmcCover = "__ESBMC_cover";
 const std::string kEsbmcAtomicBegin = "__ESBMC_atomic_begin";
 const std::string kEsbmcAtomicEnd = "__ESBMC_atomic_end";
@@ -90,6 +91,47 @@ const std::string kPytJoin = "__pyt_join";
 const std::string kPytTerminate = "__pyt_terminate";
 const std::string kPyLockBlockAndCheck = "__ESBMC_pylock_block_and_check";
 const std::string kPyLockReleaseWaiters = "__pyt_lock_release_waiters";
+
+// True when the enclosing function yields nothing an ensures clause could
+// name: `-> None`, no annotation, or no enclosing function at all.
+static bool returns_no_value(const typet &t)
+{
+  return t.is_nil() || t == none_type() || t.id() == "empty";
+}
+
+typet function_call_builder::enclosing_return_type() const
+{
+  symbol_id sid(
+    converter_.python_file(),
+    converter_.current_classname(),
+    converter_.current_function_name());
+
+  const symbolt *sym = converter_.symbol_table().find_symbol(sid.to_string());
+  if (!sym || !sym->get_type().is_code())
+    return typet();
+
+  return to_code_type(sym->get_type()).return_type();
+}
+
+void function_call_builder::check_contract_call(
+  const symbol_id &function_id) const
+{
+  const std::string &clause = function_id.get_function();
+  if (clause != kEsbmcRequires && clause != kEsbmcEnsures)
+    return;
+
+  // goto_convert aborts on any other arity, so reject it here where the user
+  // still gets a line number and a suggestion.
+  if (call_["args"].size() != 1)
+    throw std::runtime_error(fmt::format(
+      "{} at line {} takes exactly one argument, got {}; combine conditions "
+      "with 'and'",
+      clause,
+      call_.value("lineno", 0),
+      call_["args"].size()));
+
+  check_contract_clause(call_["args"], clause);
+}
 
 // A contract clause is lowered into one ASSUME/ASSERT, so its argument has to
 // survive as a pure expression. Three Python constructs do not: a call binds
@@ -115,20 +157,49 @@ void function_call_builder::check_contract_clause(
   const std::string node_type = node.value("_type", "");
 
   if (node_type == "Call" || node_type == "Subscript")
+  {
+    const bool is_call = node_type == "Call";
+    const std::string callee =
+      is_call ? node["func"].value("id", "") : std::string();
     throw std::runtime_error(fmt::format(
       "{} clause at line {} contains {}; a contract clause must be a pure "
-      "expression",
+      "expression{}",
       clause,
       node.value("lineno", 0),
-      node_type == "Call" ? "a function call" : "a subscript"));
+      is_call ? "a function call" : "a subscript",
+      callee.rfind("__ESBMC_", 0) == 0
+        ? fmt::format(" ({} is not supported in Python clauses yet)", callee)
+        : ""));
+  }
 
   if (node_type == "Name")
   {
+    const std::string name = node.value("id", "");
+
+    if (name == kEsbmcReturnValue)
+    {
+      if (clause == kEsbmcRequires)
+        throw std::runtime_error(fmt::format(
+          "{} clause at line {} references {}; a precondition cannot mention "
+          "the return value",
+          clause,
+          node.value("lineno", 0),
+          kEsbmcReturnValue));
+
+      if (returns_no_value(enclosing_return_type()))
+        throw std::runtime_error(fmt::format(
+          "{} clause at line {} references {}, but '{}' returns None",
+          clause,
+          node.value("lineno", 0),
+          kEsbmcReturnValue,
+          converter_.current_function_name()));
+    }
+
     symbol_id sid(
       converter_.python_file(),
       converter_.current_classname(),
       converter_.current_function_name());
-    sid.set_object(node.value("id", ""));
+    sid.set_object(name);
 
     const symbolt *sym = converter_.symbol_table().find_symbol(sid.to_string());
     if (sym && sym->get_type() == any_type())
@@ -137,7 +208,7 @@ void function_call_builder::check_contract_clause(
         "determined; annotate the parameter so the clause constrains its value",
         clause,
         node.value("lineno", 0),
-        node.value("id", "")));
+        name));
   }
 
   for (const auto &child : node)
@@ -1193,10 +1264,7 @@ exprt function_call_builder::build() const
     }
   }
 
-  if (
-    function_id.get_function() == kEsbmcRequires ||
-    function_id.get_function() == kEsbmcEnsures)
-    check_contract_clause(call_["args"], function_id.get_function());
+  check_contract_call(function_id);
 
   // Loop invariants and function-contract clauses share one shape: a bodiless
   // `void f(bool)` whose call goto_convert lowers into a LOOP_INVARIANT or a

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -16,6 +16,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <optional>
+#include <set>
 
 using namespace python_expr;
 
@@ -92,13 +93,6 @@ const std::string kPytTerminate = "__pyt_terminate";
 const std::string kPyLockBlockAndCheck = "__ESBMC_pylock_block_and_check";
 const std::string kPyLockReleaseWaiters = "__pyt_lock_release_waiters";
 
-// True when the enclosing function yields nothing an ensures clause could
-// name: `-> None`, no annotation, or no enclosing function at all.
-static bool returns_no_value(const typet &t)
-{
-  return t.is_nil() || t == none_type() || t.id() == "empty";
-}
-
 typet function_call_builder::enclosing_return_type() const
 {
   symbol_id sid(
@@ -111,6 +105,15 @@ typet function_call_builder::enclosing_return_type() const
     return typet();
 
   return to_code_type(sym->get_type()).return_type();
+}
+
+// Loop invariants and function-contract clauses share one shape: a bodiless
+// `void f(bool)` whose call goto_convert lowers into a LOOP_INVARIANT or a
+// marked ASSUME.
+static bool needs_bool_intrinsic_symbol(const std::string &name)
+{
+  return name == kEsbmcLoopInvariant || name == kEsbmcRequires ||
+         name == kEsbmcEnsures;
 }
 
 void function_call_builder::check_contract_call(
@@ -131,6 +134,87 @@ void function_call_builder::check_contract_call(
       call_["args"].size()));
 
   check_contract_clause(call_["args"], clause);
+}
+
+// Node kinds a clause may contain. An allow-list rather than a deny-list: the
+// clause becomes one ASSUME/ASSERT, so anything needing a temporary, a branch
+// or an iteration does not survive it, and a construct nobody enumerated
+// should fail loudly instead of lowering into something else. Denying only
+// Call and Subscript let comprehensions and the walrus operator through.
+// Operator and context nodes carry their own `_type`, so they are listed too.
+static bool is_pure_clause_node(const std::string &node_type)
+{
+  static const std::set<std::string> pure = {
+    "Name",  "Constant", "BoolOp", "UnaryOp", "BinOp",    "Compare",
+    "IfExp", "Attribute", "Load",
+    "And",   "Or",       "Not",    "UAdd",    "USub",     "Invert",
+    "Add",   "Sub",      "Mult",   "Div",     "FloorDiv", "Mod",
+    "Pow",   "LShift",   "RShift", "BitOr",   "BitXor",   "BitAnd",
+    // `in` / `not in` are container operations and stay out
+    "Eq",    "NotEq",    "Lt",     "LtE",     "Gt",       "GtE",
+    "Is",    "IsNot"};
+  return pure.count(node_type) != 0;
+}
+
+/// Names the Python construct rather than the AST spelling where they differ.
+static std::string describe_clause_node(const std::string &node_type)
+{
+  if (node_type == "Call")
+    return "a function call";
+  if (node_type == "Subscript")
+    return "a subscript";
+  if (node_type == "NamedExpr")
+    return "an assignment expression";
+  if (
+    node_type == "ListComp" || node_type == "SetComp" ||
+    node_type == "DictComp" || node_type == "GeneratorExp")
+    return "a comprehension";
+  return "a " + node_type + " expression";
+}
+
+void function_call_builder::check_clause_name(
+  const nlohmann::json &node,
+  const std::string &clause) const
+{
+  const std::string name = node.value("id", "");
+
+  if (name == kEsbmcReturnValue)
+  {
+    if (clause == kEsbmcRequires)
+      throw std::runtime_error(fmt::format(
+        "{} clause at line {} references {}; a precondition cannot mention "
+        "the return value",
+        clause,
+        node.value("lineno", 0),
+        kEsbmcReturnValue));
+
+    if (returns_no_value(enclosing_return_type()))
+      throw std::runtime_error(fmt::format(
+        "{} clause at line {} references {}, but '{}' returns None",
+        clause,
+        node.value("lineno", 0),
+        kEsbmcReturnValue,
+        converter_.current_function_name()));
+  }
+
+  symbol_id sid(
+    converter_.python_file(),
+    converter_.current_classname(),
+    converter_.current_function_name());
+  sid.set_object(name);
+
+  // A clause may also name a module-level global, which is not in the
+  // function's scope.
+  const symbolt *sym = converter_.symbol_table().find_symbol(sid.to_string());
+  if (!sym)
+    sym = converter_.symbol_table().find_symbol(sid.global_to_string());
+  if (sym && sym->get_type() == any_type())
+    throw std::runtime_error(fmt::format(
+      "{} clause at line {} references '{}', whose type could not be "
+      "determined; annotate the parameter so the clause constrains its value",
+      clause,
+      node.value("lineno", 0),
+      name));
 }
 
 // A contract clause is lowered into one ASSUME/ASSERT, so its argument has to
@@ -156,60 +240,23 @@ void function_call_builder::check_contract_clause(
 
   const std::string node_type = node.value("_type", "");
 
-  if (node_type == "Call" || node_type == "Subscript")
+  if (!node_type.empty() && !is_pure_clause_node(node_type))
   {
-    const bool is_call = node_type == "Call";
     const std::string callee =
-      is_call ? node["func"].value("id", "") : std::string();
+      node_type == "Call" ? node["func"].value("id", "") : std::string();
     throw std::runtime_error(fmt::format(
       "{} clause at line {} contains {}; a contract clause must be a pure "
       "expression{}",
       clause,
       node.value("lineno", 0),
-      is_call ? "a function call" : "a subscript",
+      describe_clause_node(node_type),
       callee.rfind("__ESBMC_", 0) == 0
         ? fmt::format(" ({} is not supported in Python clauses yet)", callee)
         : ""));
   }
 
   if (node_type == "Name")
-  {
-    const std::string name = node.value("id", "");
-
-    if (name == kEsbmcReturnValue)
-    {
-      if (clause == kEsbmcRequires)
-        throw std::runtime_error(fmt::format(
-          "{} clause at line {} references {}; a precondition cannot mention "
-          "the return value",
-          clause,
-          node.value("lineno", 0),
-          kEsbmcReturnValue));
-
-      if (returns_no_value(enclosing_return_type()))
-        throw std::runtime_error(fmt::format(
-          "{} clause at line {} references {}, but '{}' returns None",
-          clause,
-          node.value("lineno", 0),
-          kEsbmcReturnValue,
-          converter_.current_function_name()));
-    }
-
-    symbol_id sid(
-      converter_.python_file(),
-      converter_.current_classname(),
-      converter_.current_function_name());
-    sid.set_object(name);
-
-    const symbolt *sym = converter_.symbol_table().find_symbol(sid.to_string());
-    if (sym && sym->get_type() == any_type())
-      throw std::runtime_error(fmt::format(
-        "{} clause at line {} references '{}', whose type could not be "
-        "determined; annotate the parameter so the clause constrains its value",
-        clause,
-        node.value("lineno", 0),
-        name));
-  }
+    check_clause_name(node, clause);
 
   for (const auto &child : node)
     check_contract_clause(child, clause);
@@ -1270,10 +1317,7 @@ exprt function_call_builder::build() const
   // `void f(bool)` whose call goto_convert lowers into a LOOP_INVARIANT or a
   // marked ASSUME. The symbol must stay valueless: builtin_functions.cpp
   // routes any callee carrying a body to a plain FUNCTION_CALL instead.
-  if (
-    function_id.get_function() == kEsbmcLoopInvariant ||
-    function_id.get_function() == kEsbmcRequires ||
-    function_id.get_function() == kEsbmcEnsures)
+  if (needs_bool_intrinsic_symbol(function_id.get_function()))
   {
     const auto &symbol_table = converter_.symbol_table();
     const std::string &func_symbol_id = function_id.to_string();

--- a/src/python-frontend/function_call/builder.h
+++ b/src/python-frontend/function_call/builder.h
@@ -58,12 +58,24 @@ public:
 
 private:
   /*
+   * Validates a call to __ESBMC_requires / __ESBMC_ensures; a no-op for any
+   * other callee.
+   */
+  void check_contract_call(const symbol_id &function_id) const;
+
+  /*
    * Rejects a contract clause that does not lower to a pure expression.
    * Throws with a diagnostic naming the offending construct.
    */
   void check_contract_clause(
     const nlohmann::json &node,
     const std::string &clause) const;
+
+  /*
+   * Return type of the function currently being converted; nil when there is
+   * no enclosing function.
+   */
+  typet enclosing_return_type() const;
 
   python_converter &converter_;
   const nlohmann::json &call_;

--- a/src/python-frontend/function_call/builder.h
+++ b/src/python-frontend/function_call/builder.h
@@ -67,6 +67,14 @@ private:
    * Rejects a contract clause that does not lower to a pure expression.
    * Throws with a diagnostic naming the offending construct.
    */
+  /*
+   * Rejects a name a clause may not mention: the return value in a
+   * precondition or in a None-returning function, or a value whose type
+   * could not be determined.
+   */
+  void check_clause_name(const nlohmann::json &node, const std::string &clause)
+    const;
+
   void check_contract_clause(
     const nlohmann::json &node,
     const std::string &clause) const;

--- a/src/python-frontend/function_call/builder.h
+++ b/src/python-frontend/function_call/builder.h
@@ -57,6 +57,14 @@ public:
   bool is_numpy_call(const symbol_id &function_id) const;
 
 private:
+  /*
+   * Rejects a contract clause that does not lower to a pure expression.
+   * Throws with a diagnostic naming the offending construct.
+   */
+  void check_contract_clause(
+    const nlohmann::json &node,
+    const std::string &clause) const;
+
   python_converter &converter_;
   const nlohmann::json &call_;
 };

--- a/src/python-frontend/parser/typecheck.py
+++ b/src/python-frontend/parser/typecheck.py
@@ -21,11 +21,8 @@ _INTRINSIC_UNDEFINED = re.compile(
     r' is not defined')
 
 
-def _run_mypy_module(filename: str, cache_dir: str) -> tuple[int, str] | None:
-    """Run mypy through ``mypy.api`` when importable."""
-    if mypy_api is None:
-        return None
-
+def _run_mypy_module(filename: str, cache_dir: str) -> tuple[int, str]:
+    """Run mypy through ``mypy.api``."""
     report, errors, exit_status = mypy_api.run(  # pylint: disable=c-extension-no-member
         ["--strict", "--cache-dir", cache_dir, filename])
     return int(exit_status), f"{report}{errors}"
@@ -33,7 +30,13 @@ def _run_mypy_module(filename: str, cache_dir: str) -> tuple[int, str] | None:
 
 def _without_intrinsic_diagnostics(exit_status: int, report: str) -> tuple[int, str]:
     """Drop undefined-name diagnostics for ESBMC's injected globals."""
-    kept = [line for line in report.splitlines() if not _INTRINSIC_UNDEFINED.search(line)]
+    lines = report.splitlines()
+    kept = [line for line in lines if not _INTRINSIC_UNDEFINED.search(line)]
+    # Nothing suppressed: pass the report through untouched, so a mypy failure
+    # that formats without a ": error:" line (a missing file, an internal
+    # error) still reaches the caller.
+    if len(kept) == len(lines):
+        return exit_status, report
     if not any(": error:" in line for line in kept):
         return 0, ""
     return exit_status, "\n".join(line for line in kept if not line.startswith("Found "))
@@ -45,7 +48,4 @@ def run_mypy_strict(filename: str) -> tuple[int, str]:
         return 0, ""
 
     with tempfile.TemporaryDirectory(prefix="esbmc-mypy-cache-") as cache_dir:
-        module_result = _run_mypy_module(filename, cache_dir)
-        if module_result is None:
-            return 0, ""
-        return _without_intrinsic_diagnostics(*module_result)
+        return _without_intrinsic_diagnostics(*_run_mypy_module(filename, cache_dir))

--- a/src/python-frontend/parser/typecheck.py
+++ b/src/python-frontend/parser/typecheck.py
@@ -12,13 +12,45 @@ except ImportError:  # pragma: no cover - environment-dependent
 
 __all__ = ["run_mypy_strict"]
 
-# Verification intrinsics (__ESBMC_assume, nondet_int, __ESBMC_requires, ...)
-# are supplied by the frontend rather than declared in the source, so mypy
-# reports every use as undefined. Suppress only those; a name-defined error
-# for a name the user actually mistyped still reaches the report.
-_INTRINSIC_UNDEFINED = re.compile(
-    r'error: Name "(__ESBMC_\w+|__VERIFIER_\w+|nondet_\w+|__loop_invariant)"'
-    r' is not defined')
+# Verification intrinsics are supplied by the frontend rather than declared in
+# the source, so mypy reports every use as undefined. Matched by exact name: a
+# prefix wildcard would also swallow a misspelling such as `__ESBMC_assme`,
+# which is the very thing the report should still show.
+_INTRINSICS = (
+    "__ESBMC_assume",
+    "__ESBMC_assert",
+    "__ESBMC_requires",
+    "__ESBMC_ensures",
+    "__ESBMC_return_value",
+    "__ESBMC_old",
+    "__ESBMC_assigns",
+    "__ESBMC_is_fresh",
+    "__ESBMC_forall",
+    "__ESBMC_exists",
+    "__ESBMC_unreachable",
+    "__ESBMC_cover",
+    "__ESBMC_loop_invariant",
+    "__loop_invariant",
+    "__ESBMC_atomic_begin",
+    "__ESBMC_atomic_end",
+    "__VERIFIER_assume",
+    "__VERIFIER_error",
+    "nondet_int",
+    "nondet_uint",
+    "nondet_long",
+    "nondet_ulong",
+    "nondet_short",
+    "nondet_ushort",
+    "nondet_char",
+    "nondet_uchar",
+    "nondet_float",
+    "nondet_double",
+    "nondet_bool",
+    "nondet_str",
+    "nondet_size",
+)
+_INTRINSIC_UNDEFINED = re.compile(r'error: Name "(?:%s)" is not defined' %
+                                  "|".join(re.escape(name) for name in _INTRINSICS))
 
 
 def _run_mypy_module(filename: str, cache_dir: str) -> tuple[int, str]:

--- a/src/python-frontend/parser/typecheck.py
+++ b/src/python-frontend/parser/typecheck.py
@@ -49,8 +49,9 @@ _INTRINSICS = (
     "nondet_str",
     "nondet_size",
 )
-_INTRINSIC_UNDEFINED = re.compile(r'error: Name "(?:%s)" is not defined' %
-                                  "|".join(re.escape(name) for name in _INTRINSICS))
+_INTRINSIC_UNDEFINED = re.compile('error: Name "(?:' +
+                                  "|".join(re.escape(name)
+                                           for name in _INTRINSICS) + ')" is not defined')
 
 
 def _run_mypy_module(filename: str, cache_dir: str) -> tuple[int, str]:

--- a/src/python-frontend/parser/typecheck.py
+++ b/src/python-frontend/parser/typecheck.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import tempfile
 
 try:
@@ -10,6 +11,14 @@ except ImportError:  # pragma: no cover - environment-dependent
     mypy_api = None
 
 __all__ = ["run_mypy_strict"]
+
+# Verification intrinsics (__ESBMC_assume, nondet_int, __ESBMC_requires, ...)
+# are supplied by the frontend rather than declared in the source, so mypy
+# reports every use as undefined. Suppress only those; a name-defined error
+# for a name the user actually mistyped still reaches the report.
+_INTRINSIC_UNDEFINED = re.compile(
+    r'error: Name "(__ESBMC_\w+|__VERIFIER_\w+|nondet_\w+|__loop_invariant)"'
+    r' is not defined')
 
 
 def _run_mypy_module(filename: str, cache_dir: str) -> tuple[int, str] | None:
@@ -22,6 +31,14 @@ def _run_mypy_module(filename: str, cache_dir: str) -> tuple[int, str] | None:
     return int(exit_status), f"{report}{errors}"
 
 
+def _without_intrinsic_diagnostics(exit_status: int, report: str) -> tuple[int, str]:
+    """Drop undefined-name diagnostics for ESBMC's injected globals."""
+    kept = [line for line in report.splitlines() if not _INTRINSIC_UNDEFINED.search(line)]
+    if not any(": error:" in line for line in kept):
+        return 0, ""
+    return exit_status, "\n".join(line for line in kept if not line.startswith("Found "))
+
+
 def run_mypy_strict(filename: str) -> tuple[int, str]:
     """Run mypy in strict mode when the Python module is available."""
     if mypy_api is None:
@@ -29,6 +46,6 @@ def run_mypy_strict(filename: str) -> tuple[int, str]:
 
     with tempfile.TemporaryDirectory(prefix="esbmc-mypy-cache-") as cache_dir:
         module_result = _run_mypy_module(filename, cache_dir)
-        if module_result is not None:
-            return module_result
-        return 0, ""
+        if module_result is None:
+            return 0, ""
+        return _without_intrinsic_diagnostics(*module_result)

--- a/src/python-frontend/preprocessor/generator_mixin.py
+++ b/src/python-frontend/preprocessor/generator_mixin.py
@@ -10,6 +10,14 @@ import copy
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 import sys
 
+CONTRACT_CLAUSES = ("__ESBMC_requires", "__ESBMC_ensures")
+
+
+def _is_contract_clause_call(expr):
+    """True for a call to a contract clause intrinsic."""
+    return (isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name)
+            and expr.func.id in CONTRACT_CLAUSES)
+
 
 class GeneratorMixin:
 
@@ -903,7 +911,11 @@ class GeneratorMixin:
         Returns (prefix_stmts, new_expr, result_type) where result_type
         is inferred from the transformed root expression.
         """
-        if expr is None:
+        if expr is None or _is_contract_clause_call(expr):
+            # A contract clause is lowered into a single assumption or
+            # assertion, so hoisting part of it into the body would leave the
+            # clause naming a temporary the contract wrapper never declares.
+            # Leave it as written; the frontend's clause check rejects by name.
             return [], expr, "Any"
         lowerer = self._ListCompExpressionLowerer(self)
         new_expr = lowerer.visit(expr)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -100,6 +100,12 @@ public:
   {
     return *ast_json;
   }
+  /// \brief Symbol for __ESBMC_return_value in an ensures clause, null when
+  ///   the name is something else or the function returns nothing.
+  symbolt *contract_return_value_symbol(
+    const std::string &var_name,
+    const nlohmann::json &element);
+
   exprt get_expr(const nlohmann::json &element);
 
   /**

--- a/src/util/config/options.cpp
+++ b/src/util/config/options.cpp
@@ -73,3 +73,11 @@ bool optionst::is_kind() const
   return get_bool_option("k-induction") ||
          get_bool_option("k-induction-parallel");
 }
+
+bool optionst::contracts_enabled() const
+{
+  return !get_option("enforce-contract").empty() ||
+         !get_option("replace-call-with-contract").empty() ||
+         get_bool_option("enforce-all-contracts") ||
+         get_bool_option("replace-all-contracts");
+}

--- a/src/util/config/options.h
+++ b/src/util/config/options.h
@@ -24,6 +24,11 @@ public:
   void cmdline(cmdlinet &cmds);
 
   bool is_kind() const;
+
+  /// \brief Whether any function-contract mode is active. Contract clauses
+  ///   state nothing outside these modes and are dropped, which two separate
+  ///   lowering paths need to agree on.
+  bool contracts_enabled() const;
 };
 
 #endif

--- a/src/util/lang/python_types.cpp
+++ b/src/util/lang/python_types.cpp
@@ -13,6 +13,11 @@ typet any_type()
   return pointer_typet(empty_typet()); // void*
 }
 
+bool returns_no_value(const typet &t)
+{
+  return t.is_nil() || t == none_type() || t.id() == "empty";
+}
+
 void set_python_aggregate_kind(typet &type, const irep_idt &kind)
 {
   type.set(PYTHON_AGGREGATE_ATTR, kind);

--- a/src/util/lang/python_types.h
+++ b/src/util/lang/python_types.h
@@ -8,6 +8,11 @@ typet none_type();
 
 typet any_type();
 
+// True when a function yields nothing a postcondition could name: `-> None`,
+// no annotation, or no enclosing function at all. Shared so the clause check
+// and the __ESBMC_return_value lowering cannot disagree about what None means.
+bool returns_no_value(const typet &t);
+
 // Classification of Python "internal model aggregate" struct types.
 //
 // The Python frontend lowers a handful of built-in container/union types to

--- a/unit/python-frontend/test_typecheck_intrinsics.py
+++ b/unit/python-frontend/test_typecheck_intrinsics.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PARSER_DIR = os.path.join(ROOT, "src", "python-frontend", "parser")
+
+if PARSER_DIR not in sys.path:
+    sys.path.insert(0, PARSER_DIR)
+
+# pylint: disable=wrong-import-position
+from typecheck import _without_intrinsic_diagnostics
+
+
+def test_intrinsic_only_report_is_dropped():
+    report = ('main.py:2: error: Name "__ESBMC_requires" is not defined'
+              '  [name-defined]\n'
+              'main.py:3: error: Name "__ESBMC_return_value" is not defined'
+              '  [name-defined]\n'
+              'main.py:4: error: Name "nondet_int" is not defined'
+              '  [name-defined]\n'
+              'Found 3 errors in 1 file (checked 1 source file)\n')
+
+    assert _without_intrinsic_diagnostics(1, report) == (0, "")
+
+
+def test_user_typo_survives_alongside_intrinsics():
+    report = ('main.py:2: error: Name "__ESBMC_ensures" is not defined'
+              '  [name-defined]\n'
+              'main.py:3: error: Name "typo_name" is not defined'
+              '  [name-defined]\n'
+              'Found 2 errors in 1 file (checked 1 source file)\n')
+
+    status, kept = _without_intrinsic_diagnostics(1, report)
+
+    assert status == 1
+    assert "typo_name" in kept
+    assert "__ESBMC_ensures" not in kept
+
+
+def test_non_name_errors_are_untouched():
+    report = ('main.py:2: error: Incompatible return value type'
+              '  [return-value]\n'
+              'Found 1 error in 1 file (checked 1 source file)\n')
+
+    status, kept = _without_intrinsic_diagnostics(1, report)
+
+    assert status == 1
+    assert "Incompatible return value type" in kept

--- a/unit/python-frontend/test_typecheck_intrinsics.py
+++ b/unit/python-frontend/test_typecheck_intrinsics.py
@@ -23,17 +23,21 @@ def test_intrinsic_only_report_is_dropped():
     assert _without_intrinsic_diagnostics(1, report) == (0, "")
 
 
-def test_user_typo_survives_alongside_intrinsics():
+def test_misspelled_intrinsic_still_reaches_the_report():
+    """The real gap: a name that looks like an intrinsic but is not one."""
     report = ('main.py:2: error: Name "__ESBMC_ensures" is not defined'
               '  [name-defined]\n'
-              'main.py:3: error: Name "typo_name" is not defined'
+              'main.py:3: error: Name "__ESBMC_assme" is not defined'
               '  [name-defined]\n'
-              'Found 2 errors in 1 file (checked 1 source file)\n')
+              'main.py:4: error: Name "nondet_intt" is not defined'
+              '  [name-defined]\n'
+              'Found 3 errors in 1 file (checked 1 source file)\n')
 
     status, kept = _without_intrinsic_diagnostics(1, report)
 
     assert status == 1
-    assert "typo_name" in kept
+    assert "__ESBMC_assme" in kept
+    assert "nondet_intt" in kept
     assert "__ESBMC_ensures" not in kept
 
 

--- a/unit/python-frontend/test_typecheck_intrinsics.py
+++ b/unit/python-frontend/test_typecheck_intrinsics.py
@@ -37,6 +37,12 @@ def test_user_typo_survives_alongside_intrinsics():
     assert "__ESBMC_ensures" not in kept
 
 
+def test_mypy_failure_without_error_lines_is_preserved():
+    report = "mypy: can't read file 'missing.py': No such file or directory\n"
+
+    assert _without_intrinsic_diagnostics(2, report) == (2, report)
+
+
 def test_non_name_errors_are_untouched():
     report = ('main.py:2: error: Incompatible return value type'
               '  [return-value]\n'


### PR DESCRIPTION
Function contracts were C/C++ only. A Python `__ESBMC_requires` call either hit the undefined-function stub, or, once declared as a Python `def`, reached `builtin_functions.cpp` as a callee carrying a body, which short-circuits to a plain `FUNCTION_CALL` before the clause lowering at `builtin_functions.cpp:906` can run. Both contract modes then rejected every Python function:

```
$ esbmc main.py --enforce-contract double
ERROR: --enforce-contract: cannot use 'double': that function declares no contract clauses
```

The error was never "unknown function `double`". `code_contractst::find_function_symbol` already resolved the Python symbol by short name; only clause detection failed.

Two commits: make clauses work, then stop the cases that do not work from passing silently.

## 1. Lower the clauses

Two frontend edits, ~30 lines. `src/goto-programs/contracts/contracts.cpp` is unchanged.

- `function_call/builder.cpp`: register `__ESBMC_requires` and `__ESBMC_ensures` as bodiless `void f(bool)` symbols. Folded into the existing `__ESBMC_loop_invariant` registration, since all three want the same shape: a valueless symbol whose call `goto_convert` lowers into a `LOOP_INVARIANT` or a marked `ASSUME`.
- `converter/converter_expr.cpp`: resolve `__ESBMC_return_value` to a symbol typed from the enclosing function's return annotation. The contracts pass then rewrites it to the real return value, exactly as it does for C.

Inertness under plain BMC came for free: the clause drop in `goto_sideeffects.cpp` keys on `fsym->name`. `--replace-call-with-contract` likewise needed nothing beyond the registration.

```python
def double(x: int) -> int:
    __ESBMC_requires(x > 0)
    __ESBMC_ensures(__ESBMC_return_value > x)
    return 2 * x
```

```
Violated property:
  contract ensures
  return_value > x
```

## 2. Reject clauses that do not lower to an expression

A clause becomes one ASSUME/ASSERT, so its argument has to survive as a pure expression. Three Python constructs do not, and each one silently verified a different property than the one written:

| construct | what was actually verified |
| --- | --- |
| a call, e.g. `__ESBMC_requires(len(l) > 0)` | `ASSUME <SSA temp> > 0`, where the temp is declared in the *original body* and is free in the wrapper. The precondition became arbitrary. |
| a subscript, e.g. `__ESBMC_ensures(rv == l[0])` | `ASSERT 0`. A guaranteed false positive. |
| a parameter whose type could not be inferred | `o > 0` on a `void *` compares a pointer, not the value the source reads as. |

All three now fail with a diagnostic naming the construct and the line:

```
ERROR: __ESBMC_requires clause at line 2 contains a function call; a contract clause must be a pure expression
ERROR: __ESBMC_ensures clause at line 3 contains a subscript; a contract clause must be a pure expression
ERROR: __ESBMC_requires clause at line 2 references 'o', whose type could not be determined; annotate the parameter so the clause constrains its value
```

The discriminator is the **clause expression, not the parameter type**. A `list` or `str` parameter is fine as long as the clause itself is pure, which the `typed_container_param` test pins down:

```python
def take(l: list, n: int) -> int:      # list parameter, allowed
    __ESBMC_requires(n > 0)
    __ESBMC_ensures(__ESBMC_return_value == n)
```

An unannotated parameter is likewise allowed when the frontend inferred its type from a call site; it is rejected only when the type really is `void *`.

`__ESBMC_old` is not implemented yet and is a call, so it now reports the pure-expression diagnostic rather than "Unsupported function".

## 3. Stop mypy reporting ESBMC intrinsics as undefined

Pre-existing and not specific to contracts: the frontend supplies `__ESBMC_assume`, `nondet_int` and friends, so `mypy --strict` flagged every use. A three-line file printed five `name-defined` errors before this. Those diagnostics are now filtered out. A name the user actually mistyped still reaches the report, and non-name diagnostics are untouched.

## Tests

New `regression/python-contracts` suite with its own ctest label, 15 tests, all passing. Every positive is paired with a mutation that must fail, so none of the greens can be vacuous.

| test | expected |
| --- | --- |
| `enforce_int` / `_fail` | SUCCESSFUL / FAILED on `contract ensures` |
| `enforce_float` / `_fail` | SUCCESSFUL / FAILED on `contract ensures` |
| `enforce_bool` / `_fail` | SUCCESSFUL / FAILED on `contract ensures` |
| `replace_int` | SUCCESSFUL |
| `replace_int_requires_fail` | FAILED on `contract requires` at the call site |
| `replace_int_vacuity_fail` | FAILED |
| `clauses_inert` | SUCCESSFUL with no contract flag |
| `clause_call_fail` | the call diagnostic |
| `clause_subscript_fail` | the subscript diagnostic |
| `clause_untyped_fail` | the untyped-parameter diagnostic |
| `typed_container_param` / `_fail` | SUCCESSFUL / FAILED, list parameter with a pure clause |

`replace_int_vacuity_fail` is the soundness control: the caller asserts `y == 10`, which `ensures(return_value > x)` does not entail, so the replacement must not prove it. This is the #6212 / #6542 failure class, caught cheaply rather than after the fact.

Three unit tests in `unit/python-frontend/test_typecheck_intrinsics.py` cover the mypy filter, including that a genuine typo survives it.

Also run: the five existing `regression/python` tests that assert on undefined-name output, the loop-invariant tests, and two ~85-test samples spread across the `python` suite. All passing. `git clang-format` against `origin/master` is clean under clang-format-11, and `yapf` is clean on the Python changes.

Complexity gate: `check_contract_clause` is new at CCN 11, its strict limit. `get_expr` 283 → 287 and `function_call_builder::build` 64 → 66, both already over threshold before this change and both still under their strict limits.

## Not in this PR

- `__ESBMC_old`, which needs a frontend-side snapshot since Python has no address-of
- `__ESBMC_assigns` and any frame reasoning
- a separation predicate for aliased containers
- methods and `self`, `--enforce-all-contracts`
- exceptional postconditions

These are P1.3 onward in #6938, and the container work there will hit the same extent and aliasing questions the #6485 umbrella tracks for C.

Refs #6938
