### PR TITLE
[test] Make two pinned reproducers target-independent

### DIFF
--- a/regression/esbmc/github_1932/main.c
+++ b/regression/esbmc/github_1932/main.c
@@ -1,9 +1,14 @@
 #include <assert.h>
+#include <stdint.h>
+
+/* The issue's reproducer casts through `unsigned long`, which is pointer-sized
+ * only on LP64. On LLP64 (Windows) it is 32 bits, so the guard truncates and
+ * does not imply a null pointer -- see github_1932_lossy_cast_fail. `uintptr_t`
+ * is pointer-sized on every target, which is what the reproducer meant. */
 
 int main(int argc, char **argv) {
-  if ((unsigned long)argv[0] == (unsigned long)0) {
+  if ((uintptr_t)argv[0] == (uintptr_t)0) {
     assert(argv[0] == 0);
   }
   return 0;
 }
-

--- a/regression/esbmc/github_1932_lossy_cast_fail/main.c
+++ b/regression/esbmc/github_1932_lossy_cast_fail/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+/* The mirror of github_1932: a cast to an integer narrower than a pointer
+ * loses the high bits, so a zero result does not imply a null pointer and the
+ * assertion must not be provable. Pins that the pointer/integer round-trip is
+ * not treated as lossless regardless of the cast's width. */
+
+int main(int argc, char **argv) {
+  if ((unsigned int)argv[0] == (unsigned int)0) {
+    assert(argv[0] == 0);
+  }
+  return 0;
+}

--- a/regression/esbmc/github_1932_lossy_cast_fail/test.desc
+++ b/regression/esbmc/github_1932_lossy_cast_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^.*assertion argv\[0\] == 0.*$

--- a/regression/esbmc/github_2163/main.c
+++ b/regression/esbmc/github_2163/main.c
@@ -3,8 +3,12 @@
 
  int main () {
  
-   int x ;
-   int y ;
+   /* The issue's reproducer reads uninitialised locals, which is undefined
+      behaviour and is not modelled as nondeterministic on every target -- on
+      LLP64/Windows the assumes below become infeasible and the assertion is
+      reported UNREACHED. nondet_int() states the intent portably. */
+   int x = nondet_int();
+   int y = nondet_int();
    
    __ESBMC_assume (x < 100);
    __ESBMC_assume (x > 0);

--- a/regression/esbmc/github_2163/main.c
+++ b/regression/esbmc/github_2163/main.c
@@ -1,25 +1,31 @@
 // example.c
-#include <assert.h>
 
- int main () {
- 
-   /* The issue's reproducer reads uninitialised locals, which is undefined
-      behaviour and is not modelled as nondeterministic on every target -- on
-      LLP64/Windows the assumes below become infeasible and the assertion is
-      reported UNREACHED. nondet_int() states the intent portably. */
-   int x = nondet_int();
-   int y = nondet_int();
-   
-   __ESBMC_assume (x < 100);
-   __ESBMC_assume (x > 0);
-   
-   __ESBMC_assume (y < 100);
-   __ESBMC_assume (y > 0);
-   
-   int c = x + y;
-  
-  __ESBMC_assume (c < 100);
-  assert(c < 100); 
-  
+/* Two departures from the issue's verbatim reproducer, both for portability:
+ *
+ * - It read uninitialised locals, which is undefined behaviour; nondet_int()
+ *   states the "arbitrary value" intent directly.
+ * - It used assert(). MSVC's assert.h puts the failure path under !(cond), so
+ *   with `__ESBMC_assume(c < 100)` right above it that path is unsatisfiable
+ *   and coverage correctly reports the assertion UNREACHED -- a different
+ *   answer from the same source on Linux/macOS, where assert() lowers to an
+ *   unconditional check. __ESBMC_assert is unconditional on every target.
+ */
+
+int main()
+{
+  int x = nondet_int();
+  int y = nondet_int();
+
+  __ESBMC_assume(x < 100);
+  __ESBMC_assume(x > 0);
+
+  __ESBMC_assume(y < 100);
+  __ESBMC_assume(y > 0);
+
+  int c = x + y;
+
+  __ESBMC_assume(c < 100);
+  __ESBMC_assert(c < 100, "c < 100");
+
   return c;
 }

--- a/regression/esbmc/github_2163/test.desc
+++ b/regression/esbmc/github_2163/test.desc
@@ -2,5 +2,5 @@ CORE
 main.c
 --assertion-coverage-claims
 Assertion Instances Coverage: 100%
-REACHED: 'assertion c < 100
+: REACHED$
 ^COVERAGE ANALYSIS COMPLETE$


### PR DESCRIPTION
`github_1932` and `github_2163` fail the Windows leg on master, so every open PR inherits a red build. Both landed with #6954, whose own Windows leg failed on exactly these two.

Neither is an ESBMC regression — each reproducer depends on something that differs by target:

- **`github_1932`** casts a pointer through `unsigned long`, which is pointer-sized only on LP64. On LLP64 the cast truncates, so `(unsigned long)p == 0` does not imply `p == 0` and `VERIFICATION FAILED` is the correct verdict there. Cast through `uintptr_t`, which is pointer-sized everywhere and is what the reproducer meant. The truncating case is now pinned deliberately by `github_1932_lossy_cast_fail`.
- **`github_2163`** used `assert()`. MSVC's `assert.h` puts the failure path under `!(cond)`, and with `__ESBMC_assume(c < 100)` directly above it that path is unsatisfiable — so coverage correctly reports the assertion UNREACHED, a different answer from the same source on Linux/macOS where `assert()` lowers to an unconditional check. Reproduced on Linux/macOS by emulating the expansion. `__ESBMC_assert` is unconditional on every target. The reproducer also read uninitialised locals, which is undefined behaviour; `nondet_int()` states the intent directly.

Both still pin what their issues were about — the pointer/integer round-trip, and `--assertion-coverage-claims` reporting the assertion reached.

While anchoring the expectation: the old `REACHED: 'assertion c < 100` regex also matches the `UNREACHED:` line, so it did not discriminate on its own. It is now `: REACHED$`, checked against both a reachable and an unreachable run.
