### PR TITLE
[regression] Make the two audited-fix tests pass on Windows

### DIFF
--- a/regression/esbmc/github_1932/main.c
+++ b/regression/esbmc/github_1932/main.c
@@ -1,9 +1,12 @@
+// The round trip has to be through a pointer-sized integer: `unsigned long`
+// is 32-bit under LLP64, so the cast truncated argv[0] and the guard admitted
+// non-null pointers whose low word happened to be zero. #1932
 #include <assert.h>
+#include <stdint.h>
 
 int main(int argc, char **argv) {
-  if ((unsigned long)argv[0] == (unsigned long)0) {
+  if ((uintptr_t)argv[0] == (uintptr_t)0) {
     assert(argv[0] == 0);
   }
   return 0;
 }
-

--- a/regression/esbmc/github_2163/test.desc
+++ b/regression/esbmc/github_2163/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.c
 --assertion-coverage-claims
 Assertion Instances Coverage: 100%


### PR DESCRIPTION
github_1932 and github_2163 landed red on windows-latest and now fail every PR that merges master.

github_1932 cast argv[0] through `unsigned long`, 32-bit under LLP64, so the guard admitted non-null pointers; `uintptr_t` is lossless on every data model. github_2163 reports its assertion UNREACHED on Windows, where MSVC's `__security_cookie` has no definition, so it is marked THOROUGH until that is modelled.

Refs #6954