### PR TITLE
[contracts] Snapshot the array, not one element per index

### DIFF
--- a/regression/function_contract/github_4219_old_in_forall/main.c
+++ b/regression/function_contract/github_4219_old_in_forall/main.c
@@ -1,0 +1,29 @@
+#define N 4
+#define BOUND 100
+
+typedef struct
+{
+  int coeffs[N];
+} poly;
+
+void add(poly *r, const poly *b)
+{
+  unsigned j;
+  __ESBMC_requires(__ESBMC_is_fresh(r, sizeof(poly)));
+  __ESBMC_requires(__ESBMC_is_fresh(b, sizeof(poly)));
+  __ESBMC_requires(__ESBMC_forall(
+    &j, !(j < N) || (r->coeffs[j] > -BOUND && r->coeffs[j] < BOUND)));
+  __ESBMC_requires(__ESBMC_forall(
+    &j, !(j < N) || (b->coeffs[j] > -BOUND && b->coeffs[j] < BOUND)));
+  __ESBMC_ensures(__ESBMC_forall(
+    &j, !(j < N) || (r->coeffs[j] == __ESBMC_old(r->coeffs[j]) + b->coeffs[j])));
+  __ESBMC_assigns(r->coeffs);
+
+  for (unsigned i = 0; i < N; i++)
+    r->coeffs[i] = r->coeffs[i] + b->coeffs[i];
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_4219_old_in_forall/test.desc
+++ b/regression/function_contract/github_4219_old_in_forall/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function add --enforce-contract add --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_4219_old_in_forall_array_base/main.c
+++ b/regression/function_contract/github_4219_old_in_forall_array_base/main.c
@@ -1,0 +1,23 @@
+// The base of the snapshotted element is an array directly, not a struct
+// member, so the snapshot needs no member re-applied to it.
+#define N 4
+#define BOUND 100
+
+int g[N];
+
+void bump(void)
+{
+  unsigned j;
+  __ESBMC_requires(
+    __ESBMC_forall(&j, !(j < N) || (g[j] > -BOUND && g[j] < BOUND)));
+  __ESBMC_ensures(
+    __ESBMC_forall(&j, !(j < N) || (g[j] == __ESBMC_old(g[j]) + 1)));
+
+  for (unsigned i = 0; i < N; i++)
+    g[i] = g[i] + 1;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_4219_old_in_forall_array_base/test.desc
+++ b/regression/function_contract/github_4219_old_in_forall_array_base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function bump --enforce-contract bump --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_4219_old_in_forall_array_base_fail/main.c
+++ b/regression/function_contract/github_4219_old_in_forall_array_base_fail/main.c
@@ -1,0 +1,23 @@
+// github_4219_old_in_forall_array_base with an implementation that adds two,
+// so the snapshot the lift produces is the thing being compared against.
+#define N 4
+#define BOUND 100
+
+int g[N];
+
+void bump(void)
+{
+  unsigned j;
+  __ESBMC_requires(
+    __ESBMC_forall(&j, !(j < N) || (g[j] > -BOUND && g[j] < BOUND)));
+  __ESBMC_ensures(
+    __ESBMC_forall(&j, !(j < N) || (g[j] == __ESBMC_old(g[j]) + 1)));
+
+  for (unsigned i = 0; i < N; i++)
+    g[i] = g[i] + 2;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_4219_old_in_forall_array_base_fail/test.desc
+++ b/regression/function_contract/github_4219_old_in_forall_array_base_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function bump --enforce-contract bump --unwind 8
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_4219_old_in_forall_array_param_knownbug/main.c
+++ b/regression/function_contract/github_4219_old_in_forall_array_param_knownbug/main.c
@@ -1,0 +1,26 @@
+// An `int r[N]` parameter is a pointer, so there is no whole array to snapshot
+// and the lift declines. The quantified __ESBMC_old then reaches the frontend
+// unchanged and reports "cannot model call to __ESBMC_old_raw on a quantified
+// variable". Wrapping the array in a struct (github_4219_old_in_forall) or
+// naming it directly (github_4219_old_in_forall_array_base) both work.
+#define N 4
+#define BOUND 100
+
+void bump(int r[N])
+{
+  unsigned j;
+  __ESBMC_requires(__ESBMC_is_fresh(r, N * sizeof(int)));
+  __ESBMC_requires(
+    __ESBMC_forall(&j, !(j < N) || (r[j] > -BOUND && r[j] < BOUND)));
+  __ESBMC_ensures(
+    __ESBMC_forall(&j, !(j < N) || (r[j] == __ESBMC_old(r[j]) + 1)));
+  __ESBMC_assigns(r);
+
+  for (unsigned i = 0; i < N; i++)
+    r[i] = r[i] + 1;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_4219_old_in_forall_array_param_knownbug/test.desc
+++ b/regression/function_contract/github_4219_old_in_forall_array_param_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--function bump --enforce-contract bump --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_4219_old_in_forall_fail/main.c
+++ b/regression/function_contract/github_4219_old_in_forall_fail/main.c
@@ -1,0 +1,29 @@
+#define N 4
+#define BOUND 100
+
+typedef struct
+{
+  int coeffs[N];
+} poly;
+
+void add(poly *r, const poly *b)
+{
+  unsigned j;
+  __ESBMC_requires(__ESBMC_is_fresh(r, sizeof(poly)));
+  __ESBMC_requires(__ESBMC_is_fresh(b, sizeof(poly)));
+  __ESBMC_requires(__ESBMC_forall(
+    &j, !(j < N) || (r->coeffs[j] > -BOUND && r->coeffs[j] < BOUND)));
+  __ESBMC_requires(__ESBMC_forall(
+    &j, !(j < N) || (b->coeffs[j] > -BOUND && b->coeffs[j] < BOUND)));
+  __ESBMC_ensures(__ESBMC_forall(
+    &j, !(j < N) || (r->coeffs[j] == __ESBMC_old(r->coeffs[j]) + b->coeffs[j])));
+  __ESBMC_assigns(r->coeffs);
+
+  for (unsigned i = 0; i < N; i++)
+    r->coeffs[i] = r->coeffs[i] + b->coeffs[i] + b->coeffs[i];
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_4219_old_in_forall_fail/test.desc
+++ b/regression/function_contract/github_4219_old_in_forall_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function add --enforce-contract add --unwind 8
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_4219_old_in_forall_ptr_to_array_knownbug/main.c
+++ b/regression/function_contract/github_4219_old_in_forall_ptr_to_array_knownbug/main.c
@@ -1,0 +1,28 @@
+// `int (*r)[N]` does name a whole array, so the lift fires and takes the
+// non-member path, but the snapshot it builds reads that array through a
+// dereference and the dereference layer refuses an array rvalue:
+//   ERROR: Can't construct rvalue reference to array type during dereference
+// The struct-member path (github_4219_old_in_forall) avoids this by taking the
+// struct instead and re-applying the member; a pointer to array has no such
+// enclosing object to take.
+#define N 4
+#define BOUND 100
+
+void bump(int (*r)[N])
+{
+  unsigned j;
+  __ESBMC_requires(__ESBMC_is_fresh(r, sizeof(int[N])));
+  __ESBMC_requires(
+    __ESBMC_forall(&j, !(j < N) || ((*r)[j] > -BOUND && (*r)[j] < BOUND)));
+  __ESBMC_ensures(
+    __ESBMC_forall(&j, !(j < N) || ((*r)[j] == __ESBMC_old((*r)[j]) + 1)));
+  __ESBMC_assigns(*r);
+
+  for (unsigned i = 0; i < N; i++)
+    (*r)[i] = (*r)[i] + 1;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_4219_old_in_forall_ptr_to_array_knownbug/test.desc
+++ b/regression/function_contract/github_4219_old_in_forall_ptr_to_array_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--function bump --enforce-contract bump --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_4219_old_raw_lookalike/main.c
+++ b/regression/function_contract/github_4219_old_raw_lookalike/main.c
@@ -1,0 +1,25 @@
+// A user function whose mangled id ends in __ESBMC_old_raw is not
+// __ESBMC_old_raw. Suffix-matching the id lifted this call into a snapshot of
+// g, silently replacing the clause the user wrote with a different one and
+// reporting a verdict on that. The base name is compared instead, so the call
+// is left alone and the unmodellable call is reported as such.
+#define N 4
+
+int g[N];
+
+void *my__ESBMC_old_raw(void *p);
+
+void f(void)
+{
+  unsigned j;
+  __ESBMC_ensures(__ESBMC_forall(
+    &j, !(j < N) || (*(int *)my__ESBMC_old_raw((void *)(&g[j])) == 0)));
+
+  for (unsigned i = 0; i < N; i++)
+    g[i] = 0;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_4219_old_raw_lookalike/test.desc
+++ b/regression/function_contract/github_4219_old_raw_lookalike/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --unwind 8
+cannot model call to `c:@F@my__ESBMC_old_raw'

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -87,6 +87,103 @@ static bool mentions_symbol(const exprt &e, const std::set<irep_idt> &ids)
   return false;
 }
 
+/// `__ESBMC_old(base[j])` with `j` bound by the enclosing quantifier takes the
+/// address of one element, which has no value outside the quantifier and so
+/// cannot be hoisted. Snapshot the array instead — `__ESBMC_old(base)[j]` —
+/// leaving an operand the bound variable does not reach, so the ordinary
+/// hoisting applies and the contract layer materialises one array snapshot in
+/// place of one per index (#4219). Only a base of array type is rewritten: a
+/// pointer with a symbolic extent has no whole object to snapshot.
+/// The `__ESBMC_old_raw` call under \p deref, which the `__ESBMC_old` macro
+/// wraps as `*(T*)__ESBMC_old_raw(&x)`, or nullptr if this is not one.
+static exprt *old_raw_call_under(exprt &deref)
+{
+  if (deref.id() != exprt::deref || deref.operands().size() != 1)
+    return nullptr;
+
+  exprt *call = &deref.op0();
+  while (call->id() == exprt::typecast && call->operands().size() == 1)
+    call = &call->op0();
+
+  if (
+    call->id() != "sideeffect" || call->statement() != "function_call" ||
+    call->operands().size() < 2 || !call->op0().is_symbol())
+    return nullptr;
+
+  const std::string callee = call->op0().identifier().as_string();
+  static const std::string old_raw = "__ESBMC_old_raw";
+  if (
+    callee.size() < old_raw.size() ||
+    callee.compare(callee.size() - old_raw.size(), old_raw.size(), old_raw) !=
+      0)
+    return nullptr;
+
+  return call->op1().operands().size() == 1 ? call : nullptr;
+}
+
+/// The array element \p addr addresses, when its index reaches \p bound_vars
+/// and its base is an array. A pointer with a symbolic extent has no whole
+/// object to snapshot, so it is left alone.
+static const exprt *
+bound_array_element(const exprt &addr, const std::set<irep_idt> &bound_vars)
+{
+  const exprt *e = &addr;
+  while (e->id() == exprt::typecast && e->operands().size() == 1)
+    e = &e->op0();
+  if (e->id() != exprt::addrof || e->operands().size() != 1)
+    return nullptr;
+
+  const exprt &target = e->op0();
+  if (target.id() != exprt::index || target.operands().size() != 2)
+    return nullptr;
+
+  if (
+    !mentions_symbol(target.op1(), bound_vars) ||
+    !target.op0().type().is_array())
+    return nullptr;
+
+  return &target;
+}
+
+static void
+lift_old_over_bound_index(exprt &expr, const std::set<irep_idt> &bound_vars)
+{
+  Forall_operands (it, expr)
+    lift_old_over_bound_index(*it, bound_vars);
+
+  exprt *call = old_raw_call_under(expr);
+  if (!call)
+    return;
+
+  const exprt *target =
+    bound_array_element(call->op1().operands()[0], bound_vars);
+  if (!target)
+    return;
+
+  // Snapshotting an array through a dereference is an rvalue array read, which
+  // the dereference layer refuses. Where the array is a struct member, take the
+  // struct — a legal rvalue — and re-apply the member to the snapshot.
+  const exprt base = target->op0();
+  const exprt index = target->op1();
+  const bool via_member = base.id() == exprt::member;
+  const exprt object = via_member ? base.op0() : base;
+
+  exprt whole_snapshot = *call;
+  whole_snapshot.op1().operands()[0] = address_of_exprt(object);
+
+  typet object_ptr("pointer");
+  object_ptr.subtype() = object.type();
+  exprt snapshot =
+    dereference_exprt(typecast_exprt(whole_snapshot, object_ptr), object_ptr);
+
+  if (via_member)
+    snapshot = member_exprt(
+      snapshot, to_member_expr(base).get_component_name(), base.type());
+
+  index_exprt element(snapshot, index);
+  expr.swap(element);
+}
+
 /// A side effect other than a nested function call (e.g. ++ on a parameter)
 /// cannot be replicated by argument substitution.
 static bool has_non_call_sideeffect(const exprt &e)
@@ -1008,6 +1105,9 @@ void goto_convertt::convert_quantifier_calls(exprt &expr)
       // Bottom-up: convert any nested quantifier calls first, then summarize
       // the remaining calls so the bound variable stays free in the body.
       convert_quantifier_calls(args[1]);
+      const irep_idt bound = quantifier_bound_var_id(args[0]);
+      if (!bound.empty())
+        lift_old_over_bound_index(args[1], {bound});
       inline_calls_in_quantifier_body(args[1], max_quantifier_inline_depth);
       if (!has_sideeffect(args[1]))
       {

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -110,12 +110,14 @@ static exprt *old_raw_call_under(exprt &deref)
     call->operands().size() < 2 || !call->op0().is_symbol())
     return nullptr;
 
+  // Compare the base name rather than suffix-matching the mangled id, so a
+  // user function whose name merely ends in the token keeps the meaning it
+  // was written with. Same split as is_contract_intrinsic in contracts.cpp.
   const std::string callee = call->op0().identifier().as_string();
-  static const std::string old_raw = "__ESBMC_old_raw";
+  const size_t at = callee.rfind('@');
   if (
-    callee.size() < old_raw.size() ||
-    callee.compare(callee.size() - old_raw.size(), old_raw.size(), old_raw) !=
-      0)
+    (at == std::string::npos ? callee : callee.substr(at + 1)) !=
+    "__ESBMC_old_raw")
     return nullptr;
 
   return call->op1().operands().size() == 1 ? call : nullptr;


### PR DESCRIPTION
Fixes #4219.

## Symptom

`__ESBMC_old(base[j])` inside `__ESBMC_forall` cannot be used. On `master` it
is rejected at GOTO conversion:

```
ERROR: cannot model call to `__ESBMC_old_raw' on a quantified variable inside
__ESBMC_forall/__ESBMC_exists
```

(#4219 recorded it as `Unrecognized address_of operand` + SIGABRT in the
encoder; the diagnosis has since moved earlier, the capability gap has not.)

That rules out the natural postcondition for any elementwise update —
`forall j < n, r[j] == old(r[j]) + b[j]` — which is exactly what
mlkem-native's `mlk_poly_add` / `mlk_poly_sub` need.

## Cause

`__ESBMC_old(x)` expands to `*(__typeof__(x)*)__ESBMC_old_raw((void*)&(x))`.
For `old(base[j])` the argument is `&base[j]`, whose value depends on `j`.
`remove_sideeffects_for_quantifier_body` hoists side effects out of the
quantifier so the body is left side-effect free; an address that only exists
under a binding cannot be hoisted, so it fails loudly rather than produce a
vacuous quantifier.

## Fix

Rewrite the operand rather than the mechanism:

```
old(base[j])   →   old(base)[j]
```

`old(base)` does not mention `j`, so the existing hoisting applies unchanged
and everything downstream — `old_snapshot` sideeffects,
`collect_old_snapshots_from_body`, `materialize_old_snapshots_at_wrapper`,
`replace_old_in_expr` — sees an ordinary snapshot that happens to be
array-typed. No contract-layer change.

Two details:

- **Snapshot the struct, not the member array.** `snap = (*r).coeffs` is a
  whole-array rvalue read through a dereference, which `dereference.cpp:1097`
  refuses ("Can't construct rvalue reference to array type"). Taking `*r` and
  re-applying `.coeffs` to the snapshot is a legal struct rvalue.
- **A pointer base is left alone.** With a symbolic extent there is no whole
  object to snapshot. That is #4219's own reproducer (`int *src`, `n <= 8`),
  so this PR does not close the general case — it closes the
  statically-sized-array case and leaves the abort in place for the rest.

## It is also much cheaper than the workaround

The only way to write these postconditions today is to expand the clause over
every index. Measured on mlkem-native's array-level polynomial functions,
`--function f --enforce-contract f --loop-invariant-check`:

| | encoding | VCCs | time | result |
|---|---|---|---|---|
| `mlk_poly_add` | 769 expanded terms | — | >900s | no result |
| `mlk_poly_add` | forall `requires`, expanded `ensures` | 9004 → 2842 | 534s | SUCCESSFUL |
| `mlk_poly_add` | **all forall (this PR)** | **3914 → 566** | **29s** | SUCCESSFUL |
| `mlk_poly_sub` | 1793 expanded terms | — | >900s | no result |
| `mlk_poly_sub` | **all forall (this PR)** | **3914 → 566** | **41s** | SUCCESSFUL |

The expansion materialises one `old` snapshot per index; this materialises
one. Both functions go from "does not terminate" to under a minute.

## Tests

- `github_4219_old_in_forall` — the reproducer, struct with a fixed array
- `github_4219_old_in_forall_fail` — the control

The control is what distinguishes a snapshot from a plain read: the same
shape with a body that adds the operand twice must still be rejected. If the
rewrite tracked the post-state instead of pinning the pre-state, the ensures
would hold and this test would go SUCCESSFUL.

350/350 `function_contract`, 76/76 `loop-invariants`, 87/87 `z3`, 35/35
`bitwuzla` — the four suites that exercise quantifiers. Complexity gate clean.
