### PR TITLE
[goto-symex] Check MPOR's dependency chain points forward in time

### DIFF
--- a/docs/roadmap/goto-symex-verification-plan.md
+++ b/docs/roadmap/goto-symex-verification-plan.md
@@ -22,9 +22,10 @@ disabled block is superseded; and R29 — found by M9's own access-shape census 
 is a **new High-severity false SUCCESSFUL**, partly fixed, with its residual
 traced out of this subsystem into `src/pointer-analysis`.
 
-**Still open:** R6's soundness witness (mechanism observed, verdict never
-flipped), R29's two bare-struct-member shapes, and the pre-existing R16/R19–R27
-rows §9.2 records individually.
+**Still open:** R29's two bare-struct-member shapes and the pre-existing
+R16/R19–R27 rows §9.2 records individually. R6 got its witness and its fix
+(#6785); A6.4, carried since M6, is discharged by the run-order invariant the
+engine now checks in release.
 **Audience:** An engineer who will implement the harnesses and run the
 verification tasks directly from this document.
 **Companion:** `docs/irep2-verification-plan.md` (branch
@@ -801,10 +802,10 @@ relation proof + POR/state-hashing parity report + an R11 verdict.
 R18**: a confirmed default-configuration false SUCCESSFUL where POR prunes a race
 reached through a nested dereference. A6.2 is refuted by that counterexample at
 Tier B — the specced Tier-A model would have passed it. A6.1 and A6.3 discharged
-by inspection. **Carried forward: A6.4** (the active-row reset in
-`calculate_mpor_constraints`) **and R6**, whose unproven step is now pinned to the
-bisimilarity comment at `reachability_tree.cpp:420` with a stated witness
-requirement.
+by inspection. Both rows M6 carried forward are now closed: **R6** got its
+witness and its fix (#6785, §15 M9), and **A6.4** — the active-row reset in
+`calculate_mpor_constraints` — is discharged by the run-order invariant the
+engine now checks in release (§15 M6 (A6.4)).
 
 **M7 — End-to-end scenarios and regression pinning (1 wk).** H-C2, H-C3, H-C5,
 H-C6, H-C7 wired as a scheduled CI job; H-B8. *Artefact:* the oracle job + a
@@ -4920,6 +4921,90 @@ paywalled — or a witness constructed against the reset the way R6's was
 constructed against the fingerprint. The second is now a known-workable
 technique rather than a hope, which is the one thing this session changed about
 A6.4's prospects.
+
+---
+
+### M6 (A6.4) — 2026-08-12, the reset is checked rather than argued
+
+A6.4 has been the one row with no verdict since M6: `calculate_mpor_constraints`
+resets the active thread's row to −1, that reset is the only operation in the
+chain update which *removes* relations, and a removed relation is the direction
+that costs interleavings. M9's POR leg (1409 agreed, 0 diverged) deliberately
+did not close it, for the reason R6 had already demonstrated: a pruning defect
+only moves a verdict when the pruned state is on the path to the *only* buggy
+interleaving.
+
+**The reset is sound, and the argument is one line once the invariant is written
+down.** DCij asserts a dependency chain from Ti's last transition to Tj's, and a
+chain follows execution order, so DCij = 1 requires Ti's last transition to
+precede Tj's. The transition just taken is the newest in the run. Every entry in
+the active thread's row bar the diagonal therefore asserts a chain leaving the
+newest transition for an older one, which no run contains. The reset is not an
+optimisation that might drop something — it is what keeps the matrix's own
+meaning true, and it clears **exactly** the set the ordering forbids: all of row
+`a` bar the diagonal, no more.
+
+That is also the completeness half, which is what "removes relations" was really
+asking. Nothing recoverable is lost, because the row is rebuilt forward: when a
+later thread Tm runs, the column update writes DCjm from any DCjl already set,
+so chains out of the active thread's *new* transition are recorded as they arise
+rather than carried over. With the addition half already settled in M6 — the
+two-hop step is MPOR's recurrence, and the `res == 0` non-overwrite only ever
+keeps an extra 1, which loses reduction rather than interleavings — A6.4's
+"preserves transitive closure" has a verdict in both directions.
+
+**Written down, the invariant is a comparison, so it ships.** The engine now
+carries `thread_last_transition`, the run-order ordinal of each thread's last
+completed transition, advanced where the chain is advanced. Three checks run on
+every transition, inside the loop already walking the threads, under
+`SYMEX_INVARIANT` and so in the `-DNDEBUG` binary (R1, M3):
+
+| Check | What it pins |
+|---|---|
+| `new_dep_chain[j][a] != 1 ∨ ord[j] < ord[a]` | no chain into the newest transition starts after it — covers the `res == 0` path, which keeps a 1 recorded against an *older* transition of the active thread |
+| `new_dep_chain[a][j] != 1 ∨ ord[a] < ord[j]` | no chain leaves the newest transition — this is the reset |
+| `(DCjj == 1) ⇔ ord[j] ≠ 0` | the diagonal means "has run", the precondition the un-run guard reads |
+
+Only the active thread's row and column change meaning when it takes a
+transition; every other entry keeps both its endpoints. So checking those two is
+checking the inductive step, at O(T) per transition inside a body already doing
+O(T²).
+
+**It discriminates.** Deleting the reset — the one-line mutant A6.4 is about —
+trips the row check on the first concurrent program tried,
+`regression/esbmc/19_time_var_mutex_true-unreach-call` under its own flags:
+
+```
+ERROR: goto-symex invariant violated in calculate_mpor_constraints
+  condition: new_dep_chain[active_thread][j] != 1 ||
+             thread_last_transition[active_thread] < thread_last_transition[j]
+  MPOR dependency chain leaves the newest transition
+```
+
+and fails `unit/goto-symex/mpor.test.cpp`, which re-checks the same property
+from outside the engine on every interleaving of a two-writer program — `9 < 4`,
+a chain recorded backwards. Both legs were green immediately before and after
+the mutation, on the same tree.
+
+**Anti-vacuity.** The unit test counts explorations in which some thread took a
+second transition, since only there does the reset have anything to clear, and
+requires that count to be non-zero: 1471 assertions over 49 interleavings. The
+corpus leg is every CORE/THOROUGH test in
+`regression/{esbmc,esbmc-unix,esbmc-unix2}` that creates a thread, run under its
+own flags — **481 tests, 0 violations** (462 to a verdict, 18 to a 30 s cap, 2
+without a source file). The cap does not hide anything: the check runs on every
+transition from the first, so a capped run is a run that took thousands of
+transitions without tripping it.
+
+**What this does not claim.** The runtime check enforces the direction the reset
+*establishes* — no chain pointing backwards. The other direction, that no true
+chain is lost, has no runtime witness, because a dropped entry leaves no trace
+in the matrix; it rests on the ordering argument above. The two are the same
+fact seen twice: the entries cleared are precisely the entries the ordering
+forbids.
+
+**A6.4 closed.** With it, the row §15 M9 named as the last one carrying no
+verdict has one.
 
 ---
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1,5 +1,6 @@
 #include <goto-symex/execution_state.h>
 #include <goto-symex/reachability_tree.h>
+#include <goto-symex/symex_invariant.h>
 #include <langapi/language_ui.h>
 #include <langapi/languages.h>
 #include <langapi/mode.h>
@@ -95,6 +96,8 @@ execution_statet::execution_statet(
   // One thread with one dependency relation.
   dependency_chain.emplace_back();
   dependency_chain.back().push_back(0);
+  thread_last_transition.push_back(0);
+  transition_ordinal = 0;
   mpor_says_no = false;
 
   cswitch_forced = false;
@@ -163,6 +166,8 @@ void execution_statet::copy_derived_from(const execution_statet &ex)
   thread_last_reads = ex.thread_last_reads;
   thread_last_writes = ex.thread_last_writes;
   dependency_chain = ex.dependency_chain;
+  thread_last_transition = ex.thread_last_transition;
+  transition_ordinal = ex.transition_ordinal;
   mpor_says_no = ex.mpor_says_no;
   cswitch_forced = ex.cswitch_forced;
 
@@ -862,6 +867,7 @@ unsigned int execution_statet::add_thread(const goto_programt *prog)
   dependency_chain.emplace_back();
   for (unsigned int i = 0; i < dependency_chain.size(); i++)
     dependency_chain.back().push_back(0);
+  thread_last_transition.push_back(0);
 
   // While we've recorded the new thread as starting in the designated program,
   // it might not run immediately, thus must have it's path preserved:
@@ -1286,6 +1292,9 @@ void execution_statet::calculate_mpor_constraints()
   //  about progress later.
   std::vector<std::vector<int>> new_dep_chain = dependency_chain;
 
+  // The transition just taken is the newest in the run.
+  thread_last_transition[active_thread] = ++transition_ordinal;
+
   // Start new dependency chain for this thread. Default to there being no
   // relation.
   for (unsigned int i = 0; i < new_dep_chain.size(); i++)
@@ -1300,6 +1309,12 @@ void execution_statet::calculate_mpor_constraints()
   {
     if (j == active_thread)
       continue;
+
+    // The diagonal is what the un-run test below reads, and it is only a
+    // "has this thread run" flag because nothing else ever writes it.
+    SYMEX_INVARIANT(
+      (dependency_chain[j][j] == 1) == (thread_last_transition[j] != 0),
+      "MPOR chain diagonal disagrees with whether the thread has run");
 
     // MPOR's rule is DCjj(k) == 0 -- "Tj has not run" -- not DCji(k) == 0. The
     // two differ for a thread created after Tj last ran: its column is padded
@@ -1336,6 +1351,22 @@ void execution_statet::calculate_mpor_constraints()
       if (res != 0)
         new_dep_chain[j][active_thread] = res;
     }
+
+    // The inductive step of A6.4: every 1 in the chain points forward in run
+    // order. Only the active thread's row and column change meaning when it
+    // takes a transition -- every other entry keeps both its endpoints -- so
+    // checking those two is checking the step. The column covers the res == 0
+    // path, which keeps a 1 recorded against an older transition of the active
+    // thread; the row covers the reset above, without which the chain would
+    // claim a dependency leaving the newest transition in the run.
+    SYMEX_INVARIANT(
+      new_dep_chain[j][active_thread] != 1 ||
+        thread_last_transition[j] < thread_last_transition[active_thread],
+      "MPOR dependency chain runs backwards in time");
+    SYMEX_INVARIANT(
+      new_dep_chain[active_thread][j] != 1 ||
+        thread_last_transition[active_thread] < thread_last_transition[j],
+      "MPOR dependency chain leaves the newest transition");
   }
 
   // For /all other relations/, just propagate the dependency it already has.

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1275,6 +1275,30 @@ bool execution_statet::check_mpor_dependency(unsigned int j, unsigned int l)
     thread_last_writes[l]);
 }
 
+/// The inductive step of A6.4: every 1 in the chain points forward in run
+/// order. Only the active thread's row and column change meaning when it takes
+/// a transition -- every other entry keeps both its endpoints -- so checking
+/// those two is checking the step.
+static void check_chain_points_forward(
+  const std::vector<std::vector<int>> &chain,
+  const std::vector<unsigned int> &last_transition,
+  unsigned int active_thread,
+  unsigned int j)
+{
+  // The column covers the res == 0 path, which keeps a 1 recorded against an
+  // older transition of the active thread; the row covers the active-row reset,
+  // without which the chain would claim a dependency leaving the newest
+  // transition in the run.
+  SYMEX_INVARIANT(
+    chain[j][active_thread] != 1 ||
+      last_transition[j] < last_transition[active_thread],
+    "MPOR dependency chain runs backwards in time");
+  SYMEX_INVARIANT(
+    chain[active_thread][j] != 1 ||
+      last_transition[active_thread] < last_transition[j],
+    "MPOR dependency chain leaves the newest transition");
+}
+
 void execution_statet::calculate_mpor_constraints()
 {
   // Primary bit of MPOR logic - to be executed at the end of a transition to
@@ -1352,21 +1376,8 @@ void execution_statet::calculate_mpor_constraints()
         new_dep_chain[j][active_thread] = res;
     }
 
-    // The inductive step of A6.4: every 1 in the chain points forward in run
-    // order. Only the active thread's row and column change meaning when it
-    // takes a transition -- every other entry keeps both its endpoints -- so
-    // checking those two is checking the step. The column covers the res == 0
-    // path, which keeps a 1 recorded against an older transition of the active
-    // thread; the row covers the reset above, without which the chain would
-    // claim a dependency leaving the newest transition in the run.
-    SYMEX_INVARIANT(
-      new_dep_chain[j][active_thread] != 1 ||
-        thread_last_transition[j] < thread_last_transition[active_thread],
-      "MPOR dependency chain runs backwards in time");
-    SYMEX_INVARIANT(
-      new_dep_chain[active_thread][j] != 1 ||
-        thread_last_transition[active_thread] < thread_last_transition[j],
-      "MPOR dependency chain leaves the newest transition");
+    check_chain_points_forward(
+      new_dep_chain, thread_last_transition, active_thread, j);
   }
 
   // For /all other relations/, just propagate the dependency it already has.

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -549,6 +549,12 @@ public:
     return dependency_chain;
   }
 
+  /** Read-only accessor for the chain's run order, for the A6.4 harness. */
+  const std::vector<unsigned int> &get_thread_last_transition() const
+  {
+    return thread_last_transition;
+  }
+
   /** Accessor method for cswitch_forced. Sets it to true. */
   void force_cswitch()
   {
@@ -699,6 +705,14 @@ protected:
   /** Dependancy chain for POR calculations. In mpor paper, DCij elements map
    *  to dependency_chain[i][j] here. */
   std::vector<std::vector<int>> dependency_chain;
+  /** Run-order ordinal of each thread's last completed transition; 0 for a
+   *  thread that has not run. Only advanced where the chain is maintained,
+   *  which is why it is the chain's own notion of time rather than CS_number.
+   *  DCij asserts a chain from Ti's last transition to Tj's, so every 1 must
+   *  point forward in this order (A6.4). */
+  std::vector<unsigned int> thread_last_transition;
+  /** Ordinal issued to the next completed transition. */
+  unsigned int transition_ordinal;
   /** MPOR scheduling outcome. If we've just taken a transition that MPOR
    *  rejects, this becomes true. For various reasons, we can't tell whether or
    *  not MPOR rejects a transition in advance. */

--- a/unit/goto-symex/mpor.test.cpp
+++ b/unit/goto-symex/mpor.test.cpp
@@ -11,9 +11,12 @@
 
  The reset is faithful: DCil records a chain from the last transition of Tl to
  Ti's, and the transition just taken is the latest in the run, so no chain can
- leave it. What is *not* a transcription of the recurrence is the guard on the
- un-run case, which tests the column entry DCja where MPOR tests the diagonal
- DCjj; that equivalence is a property of the run and is asserted in the engine.
+ leave it. That argument is now the engine's own invariant -- every 1 in the
+ chain points forward in the run order the engine records alongside it -- and
+ this file re-checks it from outside, on the chain a real exploration produces.
+ What is *not* a transcription of the recurrence is the guard on the un-run
+ case, which tests the column entry DCja where MPOR tests the diagonal DCjj;
+ that equivalence is a property of the run and is asserted in the engine.
  This file pins the chain's shape after every interleaving of a real concurrent
  program. It does *not* discriminate the un-run guard itself: reverting that
  guard leaves every assertion here green, and the interleaving count unchanged
@@ -24,6 +27,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -57,10 +61,18 @@ public:
     rt.setup_for_new_explore();
   }
 
-  const std::vector<std::vector<int>> &run_one_interleaving()
+  struct chaint
+  {
+    const std::vector<std::vector<int>> &dc;
+    const std::vector<unsigned int> &order;
+  };
+
+  chaint run_one_interleaving()
   {
     rt.get_next_formula();
-    return rt.get_cur_state().get_dependency_chain();
+    return {
+      rt.get_cur_state().get_dependency_chain(),
+      rt.get_cur_state().get_thread_last_transition()};
   }
 
   bool more_interleavings()
@@ -84,16 +96,31 @@ struct census
   unsigned run_threads = 0;
   unsigned chains = 0;
   unsigned no_relation = 0;
+  unsigned rows_reset_after_running = 0;
 };
 
-void check_chain(const std::vector<std::vector<int>> &dc, census &seen)
+void check_chain(const engine::chaint &c, census &seen)
 {
+  const std::vector<std::vector<int>> &dc = c.dc;
   const size_t n = dc.size();
   REQUIRE(n >= 2);
+  REQUIRE(c.order.size() == n);
+
+  // A6.4 from outside the engine: a chain into Tj's last transition can only
+  // start at one that preceded it. The reset of the active row is what keeps
+  // this true, so a run where some thread took a second transition after a
+  // chain out of it was recorded is a run where the reset had work to do --
+  // counted below, since without it the property is unobservable.
+  unsigned latest = 0;
+  for (size_t j = 0; j < n; j++)
+    latest = std::max(latest, c.order[j]);
+  if (latest > n)
+    seen.rows_reset_after_running++;
 
   for (size_t j = 0; j < n; j++)
   {
     REQUIRE(dc[j].size() == n);
+    REQUIRE((dc[j][j] == 1) == (c.order[j] != 0));
 
     bool row_all_zero = true;
     for (size_t l = 0; l < n; l++)
@@ -105,7 +132,10 @@ void check_chain(const std::vector<std::vector<int>> &dc, census &seen)
       if (j == l)
         continue;
       if (dc[j][l] == 1)
+      {
+        REQUIRE(c.order[j] < c.order[l]);
         seen.chains++;
+      }
       else if (dc[j][l] == -1)
         seen.no_relation++;
     }
@@ -172,4 +202,5 @@ TEST_CASE(
   REQUIRE(seen.run_threads > 0);
   REQUIRE(seen.chains > 0);
   REQUIRE(seen.no_relation > 0);
+  REQUIRE(seen.rows_reset_after_running > 0);
 }


### PR DESCRIPTION
DCij records a dependency chain from Ti's last transition to Tj's, so every 1 must point forward in run order. Resetting the active thread's row is what keeps that true once its transition becomes the newest in the run — it clears exactly the entries the ordering forbids.

Record that order alongside the chain and check it under `SYMEX_INVARIANT`, so deleting the reset fails in the release binary instead of silently costing interleavings. Discharges A6.4, the last row of the goto-symex verification plan carrying no verdict.