### PR TITLE
[solvers] Prove simplifier rewrites with SMT under a build flag

### DIFF
--- a/.github/workflows/simplifier-equivalence.yml
+++ b/.github/workflows/simplifier-equivalence.yml
@@ -1,0 +1,54 @@
+name: Simplifier equivalence
+
+# Builds ESBMC with -DENABLE_SIMPLIFIER_EQUIVALENCE_CHECK=ON and runs a slice
+# of the CORE regression suite under it (esbmc/esbmc#4625). Every simplify()
+# rewrite is proved equivalent by an SMT solver; a rewrite that changes meaning
+# logs both expressions plus a witness and exits non-zero, so a failure here is
+# a simplifier soundness bug, not a verdict change.
+#
+# The check is compiled out of every other build, so without this job the
+# enabled path is never built and would bit-rot. It runs on a schedule and on
+# demand rather than per-PR: proving each rewrite costs an SMT query, which is
+# orders of magnitude slower than a normal run.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 04:17 on Mondays -- off the hour to avoid the scheduler's rush.
+    - cron: '17 4 * * 1'
+  push:
+    branches: [master]
+    paths:
+      - 'src/util/expr/expr_simplifier.cpp'
+      - 'src/irep2/simplification_check.*'
+      - 'src/solvers/smt/simplification_equivalence.*'
+      - '.github/workflows/simplifier-equivalence.yml'
+
+jobs:
+  equivalence:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: ./scripts/build.sh -b Debug
+
+      - name: Re-enable with the equivalence check
+        # build.sh has no pass-through for extra CMake args, so the option is
+        # turned on by reconfiguring the tree it produced.
+        run: |
+          cd build
+          cmake -DENABLE_SIMPLIFIER_EQUIVALENCE_CHECK=On .
+          cmake --build . -j2
+
+      - name: Unit tests
+        run: ctest --test-dir build -j2 -LE regression --output-on-failure
+
+      - name: Regression slice under the equivalence check
+        run: |
+          cd build
+          # A slice, not the whole suite: an SMT query per rewrite makes a full
+          # run far past any sensible CI budget. Any single failing test is a
+          # real finding, so coverage breadth matters less than running at all.
+          ctest -j2 --output-on-failure -L '^esbmc/$' -I 1,200

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,13 @@ if(ENABLE_LD_FRONTEND)
     add_definitions(-DENABLE_LD_FRONTEND)
 endif()
 
+# Debug aid: prove every simplifier rewrite equivalent with an SMT solver
+# (esbmc/esbmc#4625). Orders of magnitude slower -- never enable for a release.
+option(ENABLE_SIMPLIFIER_EQUIVALENCE_CHECK "Prove each simplifier rewrite with an SMT solver" OFF)
+if(ENABLE_SIMPLIFIER_EQUIVALENCE_CHECK)
+    add_definitions(-DENABLE_SIMPLIFIER_EQUIVALENCE_CHECK)
+endif()
+
 if(ENABLE_GOTO_CONTRACTOR)
   add_compile_options(-DENABLE_GOTO_CONTRACTOR)
 endif()

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -25,6 +25,7 @@ extern "C"
 #include <solvers/smt/smt_result.h>
 #include <solvers/smtlib/smtlib_conv.h>
 #include <solvers/solve.h>
+#include <solvers/smt/simplification_equivalence.h>
 #include <algorithm>
 #include <cctype>
 #include <charconv>
@@ -404,6 +405,11 @@ int esbmc_parseoptionst::doit()
       }
     }
   }
+
+  // Installed before the GOTO program is built so the check also covers the
+  // simplification the frontend and the GOTO passes perform. Inert unless
+  // the build enabled ENABLE_SIMPLIFIER_EQUIVALENCE_CHECK.
+  install_simplification_equivalence_check(namespacet(context), options);
 
   // Create and preprocess a GOTO program
   if (get_goto_program(options, goto_functions))

--- a/src/esbmc/parseoptions/driver.cpp
+++ b/src/esbmc/parseoptions/driver.cpp
@@ -25,6 +25,7 @@ extern "C"
 #include <solvers/smt/smt_result.h>
 #include <solvers/smtlib/smtlib_conv.h>
 #include <solvers/solve.h>
+#include <irep2/simplification_check.h>
 #include <solvers/smt/simplification_equivalence.h>
 #include <algorithm>
 #include <cctype>
@@ -414,6 +415,11 @@ int esbmc_parseoptionst::doit()
   // Create and preprocess a GOTO program
   if (get_goto_program(options, goto_functions))
     return 6;
+
+  simplification_check_stats::report();
+  // The checker captured a namespace over `context`, a member of this object;
+  // dropping it here keeps it from outliving what it points at.
+  simplification_check::clear();
 
   // Output claims about this program
   // (Fedor: should be moved to the output method perhaps)

--- a/src/irep2/CMakeLists.txt
+++ b/src/irep2/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(irep2
   irep2_crc.cpp
   irep2_utils.cpp
   irep2_guard.cpp
+  simplification_check.cpp
 )
 
 # irep2 headers include config.h -> cmdline.h -> boost/program_options.hpp,

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -4,6 +4,7 @@
 #include <util/lang/c_types.h>
 
 #include <irep2/irep2_expr.h>
+#include <irep2/simplification_check.h>
 #include <util/irep/migrate.h>
 #include <util/message/message.h>
 
@@ -267,6 +268,7 @@ inline bool simplify(expr2tc &expr)
   expr2tc tmp = expr->simplify();
   if (!is_nil_expr(tmp))
   {
+    simplification_check::verify_rewrite(expr, tmp);
     expr = tmp;
     return true;
   }

--- a/src/irep2/simplification_check.cpp
+++ b/src/irep2/simplification_check.cpp
@@ -5,8 +5,11 @@ namespace
 simplification_check::checkert installed_checker;
 
 /** Guards against a checker that itself simplifies -- create_solver and
- *  convert_ast both do -- recursing back into verify_rewrite forever. */
-bool running = false;
+ *  convert_ast both do -- recursing back into verify_rewrite forever.
+ *  Thread-local: --parallel-solving simplifies on several threads, and one
+ *  shared flag would both race and let every other thread's rewrites through
+ *  unchecked while one thread held it. */
+thread_local bool running = false;
 } // namespace
 
 void simplification_check::install(checkert checker)

--- a/src/irep2/simplification_check.cpp
+++ b/src/irep2/simplification_check.cpp
@@ -1,0 +1,41 @@
+#include <irep2/simplification_check.h>
+
+namespace
+{
+simplification_check::checkert installed_checker;
+
+/** Guards against a checker that itself simplifies -- create_solver and
+ *  convert_ast both do -- recursing back into verify_rewrite forever. */
+bool running = false;
+} // namespace
+
+void simplification_check::install(checkert checker)
+{
+  installed_checker = std::move(checker);
+}
+
+void simplification_check::clear()
+{
+  installed_checker = nullptr;
+}
+
+void simplification_check::detail::run(
+  const expr2tc &before,
+  const expr2tc &after)
+{
+  if (!installed_checker || running)
+    return;
+
+  running = true;
+  // Restore on the way out however the checker leaves: a solver failure that
+  // escapes as an exception must not wedge the hook off for the whole run.
+  struct reset_on_exitt
+  {
+    ~reset_on_exitt()
+    {
+      running = false;
+    }
+  } reset;
+
+  installed_checker(before, after);
+}

--- a/src/irep2/simplification_check.h
+++ b/src/irep2/simplification_check.h
@@ -11,7 +11,12 @@
  *  Instead the driver installs a checker once it holds a namespace and
  *  options, and simplify() consults whatever is installed. Nothing is
  *  installed by default, so the hook is inert in a normal run even when the
- *  build enabled it. */
+ *  build enabled it.
+ *
+ *  Coverage is partial by construction, and a clean run should not be read as
+ *  "every rewrite proved": about ten sites call expr2t::simplify() directly
+ *  rather than through the free simplify() below, and simplify() itself
+ *  recurses internally, so only the outermost rewrite of each call is seen. */
 namespace simplification_check
 {
 /** Called for every rewrite the simplifier performs. Reporting a mismatch --

--- a/src/irep2/simplification_check.h
+++ b/src/irep2/simplification_check.h
@@ -1,0 +1,47 @@
+#ifndef ESBMC_IREP2_SIMPLIFICATION_CHECK_H
+#define ESBMC_IREP2_SIMPLIFICATION_CHECK_H
+
+#include <functional>
+#include <irep2/irep2_expr.h>
+
+/** Debug-mode guard on the expression simplifier (esbmc/esbmc#4625).
+ *
+ *  simplify() lives in irep2, which links only fmt/bigint/immer -- not the
+ *  solvers, and not util. The SMT query therefore cannot be issued from here.
+ *  Instead the driver installs a checker once it holds a namespace and
+ *  options, and simplify() consults whatever is installed. Nothing is
+ *  installed by default, so the hook is inert in a normal run even when the
+ *  build enabled it. */
+namespace simplification_check
+{
+/** Called for every rewrite the simplifier performs. Reporting a mismatch --
+ *  logging, aborting -- is the checker's business, not the hook's. */
+using checkert =
+  std::function<void(const expr2tc &before, const expr2tc &after)>;
+
+void install(checkert checker);
+
+/** Uninstall, restoring the inert default. */
+void clear();
+
+namespace detail
+{
+void run(const expr2tc &before, const expr2tc &after);
+}
+
+/** Consult the installed checker. Compiled out entirely unless the build was
+ *  configured with -DENABLE_SIMPLIFIER_EQUIVALENCE_CHECK=ON: the simplifier
+ *  runs on every expression ESBMC builds, so an unconditional indirect call
+ *  would be a permanent tax on a debug aid. */
+inline void verify_rewrite(const expr2tc &before, const expr2tc &after)
+{
+#ifdef ENABLE_SIMPLIFIER_EQUIVALENCE_CHECK
+  detail::run(before, after);
+#else
+  (void)before;
+  (void)after;
+#endif
+}
+} // namespace simplification_check
+
+#endif

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(prop)
 add_subdirectory(smt)
 
 
-add_library(solve solve.cpp)
+add_library(solve solve.cpp smt/simplification_equivalence.cpp)
 target_link_libraries(solve PUBLIC smt PRIVATE smttuple smtfp fmt::fmt)
 target_include_directories(solve
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/solvers/smt/simplification_equivalence.cpp
+++ b/src/solvers/smt/simplification_equivalence.cpp
@@ -32,10 +32,48 @@ bool has_unsupported_subexpr(const expr2tc &expr)
 
   bool bad = false;
   expr->foreach_operand([&bad](const expr2tc &e) {
-    if (!is_nil_expr(e) && has_unsupported_subexpr(e))
+    if (!bad && !is_nil_expr(e) && has_unsupported_subexpr(e))
       bad = true;
   });
   return bad;
+}
+
+/** "The simplifier preserved this value" as an SMT predicate.
+ *
+ *  For floats that is not `equality2t`: it lowers to `fp.eq`, under which
+ *  NaN != NaN and +0.0 == -0.0. The first makes every float rewrite -- even
+ *  `x -> x` -- satisfiably unequal, and the second hides exactly the
+ *  signed-zero-breaking rewrites the simplifier guards against by hand (see
+ *  the abs/select rule in expr_simplifier.cpp). Bit equality via
+ *  `fp.to_ieee_bv` is not an option either: SMT-LIB leaves the NaN pattern it
+ *  returns unconstrained (esbmc/esbmc#6922). So state it directly -- both NaN,
+ *  or equal with the same sign. */
+expr2tc preserves_value(const expr2tc &before, const expr2tc &after)
+{
+  if (!is_floatbv_type(before->type))
+    return equality2tc(before, after);
+
+  return or2tc(
+    and2tc(isnan2tc(before), isnan2tc(after)),
+    and2tc(
+      equality2tc(before, after),
+      equality2tc(signbit2tc(before), signbit2tc(after))));
+}
+
+/** The checker's own solver options.
+ *
+ *  Deliberately not the run's: under --ir/--ir-ieee arithmetic is Int/Real
+ *  with no wraparound, so a rewrite that is unsound for machine semantics
+ *  (x*2/2 -> x) verifies as equivalent, and --smtlib makes dec_solve return
+ *  P_SMTLIB, silently declining every check. The simplifier's rewrites have to
+ *  hold for the machine, so always ask under bitvector semantics. */
+optionst checker_options(const optionst &run_options)
+{
+  optionst opts = run_options;
+  for (const char *opt : {"int-encoding", "ir", "ir-ieee", "smtlib", "output"})
+    opts.set_option(opt, "");
+  opts.set_option("fixedbv", false);
+  return opts;
 }
 } // namespace
 
@@ -58,8 +96,9 @@ simplification_equivalencet check_simplification_equivalence(
 
   try
   {
-    std::unique_ptr<smt_convt> ctx(create_solver("", ns, options));
-    ctx->assert_expr(not2tc(equality2tc(before, after)));
+    std::unique_ptr<smt_convt> ctx(
+      create_solver("", ns, checker_options(options)));
+    ctx->assert_expr(not2tc(preserves_value(before, after)));
 
     switch (ctx->dec_solve())
     {
@@ -68,6 +107,7 @@ simplification_equivalencet check_simplification_equivalence(
     case P_SATISFIABLE:
       return simplification_equivalencet::differs;
     default:
+      log_warning("simplifier equivalence check: solver gave no verdict");
       return simplification_equivalencet::skipped;
     }
   }
@@ -88,20 +128,46 @@ void install_simplification_equivalence_check(
   // map, and the checker outlives whatever scope installed it.
   simplification_check::install(
     [ns, options](const expr2tc &before, const expr2tc &after) {
-      if (
-        check_simplification_equivalence(before, after, ns, options) !=
-        simplification_equivalencet::differs)
+      switch (check_simplification_equivalence(before, after, ns, options))
+      {
+      case simplification_equivalencet::equivalent:
+        ++simplification_check_stats::proved;
         return;
+
+      case simplification_equivalencet::skipped:
+        ++simplification_check_stats::declined;
+        return;
+
+      case simplification_equivalencet::differs:
+        break;
+      }
 
       log_error(
         "simplifier changed the meaning of an expression\n  before: {}\n  "
         "after:  {}",
         *before,
         *after);
-      abort();
+      // Not abort(): it skips the stream flush, and this diagnostic is the
+      // entire point of the run.
+      exit(1);
     });
 #else
   (void)ns;
   (void)options;
 #endif
 }
+
+namespace simplification_check_stats
+{
+std::atomic<unsigned long> proved{0};
+std::atomic<unsigned long> declined{0};
+
+void report()
+{
+  const unsigned long p = proved.load();
+  const unsigned long d = declined.load();
+  if (p || d)
+    log_status(
+      "simplifier equivalence check: {} rewrites proved, {} declined", p, d);
+}
+} // namespace simplification_check_stats

--- a/src/solvers/smt/simplification_equivalence.cpp
+++ b/src/solvers/smt/simplification_equivalence.cpp
@@ -185,8 +185,8 @@ void install_simplification_equivalence_check(
 #ifdef ENABLE_SIMPLIFIER_EQUIVALENCE_CHECK
   // The checker owns the solver and is shared into the lambda, so it lives
   // exactly as long as the installed callback.
-  auto checker = std::make_shared<simplification_equivalence_checkert>(
-    ns, options);
+  auto checker =
+    std::make_shared<simplification_equivalence_checkert>(ns, options);
   simplification_check::install(
     [checker](const expr2tc &before, const expr2tc &after) {
       std::string witness;

--- a/src/solvers/smt/simplification_equivalence.cpp
+++ b/src/solvers/smt/simplification_equivalence.cpp
@@ -1,0 +1,107 @@
+#include <solvers/smt/simplification_equivalence.h>
+
+#include <cstdlib>
+#include <irep2/irep2_utils.h>
+#include <irep2/simplification_check.h>
+#include <solvers/smt/smt_conv.h>
+#include <solvers/smt/smt_result.h>
+#include <solvers/solve.h>
+#include <util/message/format.h>
+#include <util/message/message.h>
+
+namespace
+{
+/** Equality of these is not a plain SMT question: pointers carry an
+ *  object/offset encoding whose identity is address-space state rather than a
+ *  value, side effects are not expressions at all, and code has no sort. */
+bool is_checkable_type(const type2tc &type)
+{
+  return is_bv_type(type) || is_bool_type(type) || is_fixedbv_type(type) ||
+         is_floatbv_type(type);
+}
+
+bool has_unsupported_subexpr(const expr2tc &expr)
+{
+  if (is_nil_expr(expr))
+    return true;
+
+  if (
+    is_sideeffect2t(expr) || is_dereference2t(expr) || is_address_of2t(expr) ||
+    is_pointer_type(expr->type) || is_code_type(expr->type))
+    return true;
+
+  bool bad = false;
+  expr->foreach_operand([&bad](const expr2tc &e) {
+    if (!is_nil_expr(e) && has_unsupported_subexpr(e))
+      bad = true;
+  });
+  return bad;
+}
+} // namespace
+
+simplification_equivalencet check_simplification_equivalence(
+  const expr2tc &before,
+  const expr2tc &after,
+  const namespacet &ns,
+  const optionst &options)
+{
+  if (is_nil_expr(before) || is_nil_expr(after))
+    return simplification_equivalencet::skipped;
+
+  // A rewrite that changes the type is not a value-preserving claim we can
+  // state as an equality; the simplifier is not supposed to make them.
+  if (before->type != after->type || !is_checkable_type(before->type))
+    return simplification_equivalencet::skipped;
+
+  if (has_unsupported_subexpr(before) || has_unsupported_subexpr(after))
+    return simplification_equivalencet::skipped;
+
+  try
+  {
+    std::unique_ptr<smt_convt> ctx(create_solver("", ns, options));
+    ctx->assert_expr(not2tc(equality2tc(before, after)));
+
+    switch (ctx->dec_solve())
+    {
+    case P_UNSATISFIABLE:
+      return simplification_equivalencet::equivalent;
+    case P_SATISFIABLE:
+      return simplification_equivalencet::differs;
+    default:
+      return simplification_equivalencet::skipped;
+    }
+  }
+  catch (...)
+  {
+    // Conversion rejects a shape by throwing; that is a decline, not a bug in
+    // the rewrite.
+    return simplification_equivalencet::skipped;
+  }
+}
+
+void install_simplification_equivalence_check(
+  const namespacet &ns,
+  const optionst &options)
+{
+#ifdef ENABLE_SIMPLIFIER_EQUIVALENCE_CHECK
+  // By value: namespacet is a thin handle on the context and optionst is a
+  // map, and the checker outlives whatever scope installed it.
+  simplification_check::install(
+    [ns, options](const expr2tc &before, const expr2tc &after) {
+      if (
+        check_simplification_equivalence(before, after, ns, options) !=
+        simplification_equivalencet::differs)
+        return;
+
+      log_error(
+        "simplifier changed the meaning of an expression\n  before: {}\n  "
+        "after:  {}",
+        *before,
+        *after);
+      abort();
+    });
+#else
+  (void)ns;
+  (void)options;
+#endif
+}

--- a/src/solvers/smt/simplification_equivalence.cpp
+++ b/src/solvers/smt/simplification_equivalence.cpp
@@ -1,6 +1,9 @@
 #include <solvers/smt/simplification_equivalence.h>
 
 #include <cstdlib>
+#include <memory>
+#include <set>
+#include <string>
 #include <irep2/irep2_utils.h>
 #include <irep2/simplification_check.h>
 #include <solvers/smt/smt_conv.h>
@@ -77,11 +80,32 @@ optionst checker_options(const optionst &run_options)
 }
 } // namespace
 
-simplification_equivalencet check_simplification_equivalence(
+simplification_equivalence_checkert::simplification_equivalence_checkert(
+  const namespacet &_ns,
+  const optionst &_options)
+  : ns(_ns), options(checker_options(_options))
+{
+}
+
+simplification_equivalence_checkert::~simplification_equivalence_checkert() =
+  default;
+
+namespace
+{
+void collect_symbols(const expr2tc &e, std::set<expr2tc> &out)
+{
+  if (is_nil_expr(e))
+    return;
+  if (is_symbol2t(e))
+    out.insert(e);
+  e->foreach_operand([&out](const expr2tc &o) { collect_symbols(o, out); });
+}
+} // namespace
+
+simplification_equivalencet simplification_equivalence_checkert::check(
   const expr2tc &before,
   const expr2tc &after,
-  const namespacet &ns,
-  const optionst &options)
+  std::string *witness)
 {
   if (is_nil_expr(before) || is_nil_expr(after))
     return simplification_equivalencet::skipped;
@@ -96,11 +120,35 @@ simplification_equivalencet check_simplification_equivalence(
 
   try
   {
-    std::unique_ptr<smt_convt> ctx(
-      create_solver("", ns, checker_options(options)));
-    ctx->assert_expr(not2tc(preserves_value(before, after)));
+    if (!ctx)
+      ctx.reset(create_solver("", ns, options));
 
-    switch (ctx->dec_solve())
+    ctx->push_ctx();
+    ctx->assert_expr(not2tc(preserves_value(before, after)));
+    const smt_resultt result = ctx->dec_solve();
+
+    // The model is only readable while the frame that produced it is live.
+    if (result == P_SATISFIABLE && witness)
+    {
+      std::set<expr2tc> symbols;
+      collect_symbols(before, symbols);
+      collect_symbols(after, symbols);
+
+      witness->clear();
+      for (const expr2tc &sym : symbols)
+      {
+        const expr2tc value = ctx->get(sym);
+        if (is_nil_expr(value))
+          continue;
+        if (!witness->empty())
+          *witness += ", ";
+        *witness += fmt::format("{} = {}", *sym, *value);
+      }
+    }
+
+    ctx->pop_ctx();
+
+    switch (result)
     {
     case P_UNSATISFIABLE:
       return simplification_equivalencet::equivalent;
@@ -114,9 +162,20 @@ simplification_equivalencet check_simplification_equivalence(
   catch (...)
   {
     // Conversion rejects a shape by throwing; that is a decline, not a bug in
-    // the rewrite.
+    // the rewrite. The throw happened mid-frame, so the solver's state is no
+    // longer trustworthy -- drop it and let the next check build a fresh one.
+    ctx.reset();
     return simplification_equivalencet::skipped;
   }
+}
+
+simplification_equivalencet check_simplification_equivalence(
+  const expr2tc &before,
+  const expr2tc &after,
+  const namespacet &ns,
+  const optionst &options)
+{
+  return simplification_equivalence_checkert(ns, options).check(before, after);
 }
 
 void install_simplification_equivalence_check(
@@ -124,11 +183,14 @@ void install_simplification_equivalence_check(
   const optionst &options)
 {
 #ifdef ENABLE_SIMPLIFIER_EQUIVALENCE_CHECK
-  // By value: namespacet is a thin handle on the context and optionst is a
-  // map, and the checker outlives whatever scope installed it.
+  // The checker owns the solver and is shared into the lambda, so it lives
+  // exactly as long as the installed callback.
+  auto checker = std::make_shared<simplification_equivalence_checkert>(
+    ns, options);
   simplification_check::install(
-    [ns, options](const expr2tc &before, const expr2tc &after) {
-      switch (check_simplification_equivalence(before, after, ns, options))
+    [checker](const expr2tc &before, const expr2tc &after) {
+      std::string witness;
+      switch (checker->check(before, after, &witness))
       {
       case simplification_equivalencet::equivalent:
         ++simplification_check_stats::proved;
@@ -144,9 +206,10 @@ void install_simplification_equivalence_check(
 
       log_error(
         "simplifier changed the meaning of an expression\n  before: {}\n  "
-        "after:  {}",
+        "after:  {}\n  where:  {}",
         *before,
-        *after);
+        *after,
+        witness.empty() ? "(no free symbols)" : witness);
       // Not abort(): it skips the stream flush, and this diagnostic is the
       // entire point of the run.
       exit(1);

--- a/src/solvers/smt/simplification_equivalence.h
+++ b/src/solvers/smt/simplification_equivalence.h
@@ -1,6 +1,7 @@
 #ifndef _ESBMC_PROP_SMT_SIMPLIFICATION_EQUIVALENCE_H_
 #define _ESBMC_PROP_SMT_SIMPLIFICATION_EQUIVALENCE_H_
 
+#include <atomic>
 #include <irep2/irep2_expr.h>
 #include <util/symtab/namespace.h>
 #include <util/config/options.h>
@@ -29,10 +30,21 @@ simplification_equivalencet check_simplification_equivalence(
   const optionst &options);
 
 /** Install the above as simplify()'s checker for the rest of the run: every
- *  rewrite is proved, and a `differs` verdict logs both expressions and
- *  aborts. Does nothing unless the build enabled the check. */
+ *  rewrite is proved, and a `differs` verdict logs both expressions and exits.
+ *  Does nothing unless the build enabled the check. */
 void install_simplification_equivalence_check(
   const namespacet &ns,
   const optionst &options);
+
+/** How much the installed checker actually decided. Without this a run that
+ *  declined every rewrite is indistinguishable from one that proved them all,
+ *  which is the failure mode that would make the whole check worthless. */
+namespace simplification_check_stats
+{
+extern std::atomic<unsigned long> proved;
+extern std::atomic<unsigned long> declined;
+
+void report();
+} // namespace simplification_check_stats
 
 #endif

--- a/src/solvers/smt/simplification_equivalence.h
+++ b/src/solvers/smt/simplification_equivalence.h
@@ -2,6 +2,8 @@
 #define _ESBMC_PROP_SMT_SIMPLIFICATION_EQUIVALENCE_H_
 
 #include <atomic>
+#include <memory>
+#include <string>
 #include <irep2/irep2_expr.h>
 #include <util/symtab/namespace.h>
 #include <util/config/options.h>
@@ -17,12 +19,41 @@ enum class simplification_equivalencet
   skipped
 };
 
-/** Ask an SMT solver whether a simplifier rewrite preserved meaning.
+class smt_convt;
+
+/** Asks an SMT solver whether simplifier rewrites preserved meaning.
+ *
+ *  Holds one solver for its lifetime and pushes a frame per query. A solver
+ *  per query would be simpler, but create_solver leaks its tuple flattener
+ *  (solve.cpp) -- ~14 KB, harmless at one call per run and fatal at one call
+ *  per rewrite, which is what the installed checker does.
  *
  *  Free symbols stay free, so `equivalent` means equivalence under every
  *  valuation, not merely on some model. Declines (returns `skipped`) rather
  *  than guessing for shapes whose equality is not a plain SMT question --
  *  pointers, side effects, code, and anything the conversion rejects. */
+class simplification_equivalence_checkert
+{
+public:
+  simplification_equivalence_checkert(
+    const namespacet &ns,
+    const optionst &options);
+  ~simplification_equivalence_checkert();
+
+  /** @param witness when non-null and the verdict is `differs`, receives a
+   *         valuation of the free symbols on which the two disagree. */
+  simplification_equivalencet check(
+    const expr2tc &before,
+    const expr2tc &after,
+    std::string *witness = nullptr);
+
+private:
+  namespacet ns;
+  optionst options;
+  std::unique_ptr<smt_convt> ctx;
+};
+
+/** One-shot convenience over the above; builds and discards a solver. */
 simplification_equivalencet check_simplification_equivalence(
   const expr2tc &before,
   const expr2tc &after,

--- a/src/solvers/smt/simplification_equivalence.h
+++ b/src/solvers/smt/simplification_equivalence.h
@@ -1,0 +1,38 @@
+#ifndef _ESBMC_PROP_SMT_SIMPLIFICATION_EQUIVALENCE_H_
+#define _ESBMC_PROP_SMT_SIMPLIFICATION_EQUIVALENCE_H_
+
+#include <irep2/irep2_expr.h>
+#include <util/symtab/namespace.h>
+#include <util/config/options.h>
+
+/** Verdict on one simplifier rewrite (esbmc/esbmc#4625). */
+enum class simplification_equivalencet
+{
+  /** The solver proved before == after for every valuation. */
+  equivalent,
+  /** The solver found a valuation where they differ: a simplifier bug. */
+  differs,
+  /** Not decided -- a shape the check declines, or a solver failure. */
+  skipped
+};
+
+/** Ask an SMT solver whether a simplifier rewrite preserved meaning.
+ *
+ *  Free symbols stay free, so `equivalent` means equivalence under every
+ *  valuation, not merely on some model. Declines (returns `skipped`) rather
+ *  than guessing for shapes whose equality is not a plain SMT question --
+ *  pointers, side effects, code, and anything the conversion rejects. */
+simplification_equivalencet check_simplification_equivalence(
+  const expr2tc &before,
+  const expr2tc &after,
+  const namespacet &ns,
+  const optionst &options);
+
+/** Install the above as simplify()'s checker for the rest of the run: every
+ *  rewrite is proved, and a `differs` verdict logs both expressions and
+ *  aborts. Does nothing unless the build enabled the check. */
+void install_simplification_equivalence_check(
+  const namespacet &ns,
+  const optionst &options);
+
+#endif

--- a/src/solvers/smtlib/CMakeLists.txt
+++ b/src/solvers/smtlib/CMakeLists.txt
@@ -15,7 +15,10 @@ configure_file(smtlib.ypp  ${CMAKE_BINARY_DIR}/smtlib.ypp COPYONLY)
 configure_file(smtlib_tok.lpp  ${CMAKE_BINARY_DIR}/smtlib_tok.lpp COPYONLY)
 
 add_library(smtlib smtlib_conv.cpp oneshot_process.cpp ${CMAKE_CURRENT_BINARY_DIR}/smtlib.cpp ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp)
-target_link_libraries(smtlib fmt::fmt)
+# oneshot_process.cpp calls file_operations, so name filesystem here rather
+# than leaving each consumer to list it after smtlib: with static archives a
+# consumer that lists it first drops the symbols before smtlib asks for them.
+target_link_libraries(smtlib fmt::fmt filesystem)
 target_include_directories(smtlib
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}

--- a/unit/solvers/CMakeLists.txt
+++ b/unit/solvers/CMakeLists.txt
@@ -33,3 +33,13 @@ if(ENABLE_SMTLIB)
   new_unit_test(oneshot_verdict_test "oneshot_verdict.test.cpp"
                 "smtlib;filesystem;util_esbmc;fmt::fmt")
 endif()
+
+# The SMT equivalence checker for simplifier rewrites (#4625). The installed
+# checker aborts on a mismatch, so only a direct call can assert that it
+# detects one. Any built-in solver serves; `solve` picks the default.
+# Links the `solvers` interface target rather than a named backend: solve.cpp
+# registers every backend compiled in, so the creator symbols must all be
+# present. Whichever is the default answers the queries.
+new_unit_test(simplification_equivalence_test
+              "simplification_equivalence.test.cpp"
+              "solvers;util_esbmc;filesystem;bigint")

--- a/unit/solvers/simplification_equivalence.test.cpp
+++ b/unit/solvers/simplification_equivalence.test.cpp
@@ -56,11 +56,16 @@ SCENARIO(
   {
     // x + 1 -> x differs at every x, so any model is a witness.
     const expr2tc before = add2tc(get_int32_type(), x, one);
-    THEN("it reports differs")
+    THEN("it reports differs, with a witness naming the free symbols")
     {
+      std::string witness;
+      simplification_equivalence_checkert checker(ns, options);
       REQUIRE(
-        check_simplification_equivalence(before, x, ns, options) ==
+        checker.check(before, x, &witness) ==
         simplification_equivalencet::differs);
+      // The abort message is only actionable if it says on what value the two
+      // disagree, so the model must actually come back.
+      REQUIRE(witness.find("x") != std::string::npos);
     }
   }
 
@@ -159,4 +164,39 @@ SCENARIO(
         simplification_equivalencet::skipped);
     }
   }
+}
+
+SCENARIO(
+  "one checker decides many rewrites in sequence",
+  "[solvers][simplifier]")
+{
+  // The installed checker reuses a single solver across every rewrite in the
+  // run -- a solver per rewrite leaks ~14 KB in create_solver. Reuse is only
+  // safe if a pushed frame leaves nothing behind that colours the next
+  // verdict, so drive alternating verdicts through one checker and require
+  // each to come out as it does in isolation.
+  config.ansi_c.set_data_model(configt::LP64);
+  contextt ctx;
+  namespacet ns(ctx);
+  optionst options;
+
+  const expr2tc x = int_symbol("x");
+  const expr2tc zero = gen_zero(get_int32_type());
+  const expr2tc one = from_integer(1, get_int32_type());
+  const expr2tc same = add2tc(get_int32_type(), x, zero);
+  const expr2tc changed = add2tc(get_int32_type(), x, one);
+
+  simplification_equivalence_checkert checker(ns, options);
+  for (int i = 0; i < 8; ++i)
+  {
+    REQUIRE(
+      checker.check(same, x) == simplification_equivalencet::equivalent);
+    REQUIRE(
+      checker.check(changed, x) == simplification_equivalencet::differs);
+  }
+
+  // A declined shape resets the solver; the checker must keep working after.
+  REQUIRE(
+    checker.check(expr2tc(), x) == simplification_equivalencet::skipped);
+  REQUIRE(checker.check(same, x) == simplification_equivalencet::equivalent);
 }

--- a/unit/solvers/simplification_equivalence.test.cpp
+++ b/unit/solvers/simplification_equivalence.test.cpp
@@ -101,7 +101,6 @@ SCENARIO(
     }
   }
 
-
   GIVEN("a floating-point rewrite")
   {
     const type2tc double_ty = migrate_type(double_type());
@@ -189,14 +188,11 @@ SCENARIO(
   simplification_equivalence_checkert checker(ns, options);
   for (int i = 0; i < 8; ++i)
   {
-    REQUIRE(
-      checker.check(same, x) == simplification_equivalencet::equivalent);
-    REQUIRE(
-      checker.check(changed, x) == simplification_equivalencet::differs);
+    REQUIRE(checker.check(same, x) == simplification_equivalencet::equivalent);
+    REQUIRE(checker.check(changed, x) == simplification_equivalencet::differs);
   }
 
   // A declined shape resets the solver; the checker must keep working after.
-  REQUIRE(
-    checker.check(expr2tc(), x) == simplification_equivalencet::skipped);
+  REQUIRE(checker.check(expr2tc(), x) == simplification_equivalencet::skipped);
   REQUIRE(checker.check(same, x) == simplification_equivalencet::equivalent);
 }

--- a/unit/solvers/simplification_equivalence.test.cpp
+++ b/unit/solvers/simplification_equivalence.test.cpp
@@ -13,6 +13,7 @@
 #include <irep2/irep2_utils.h>
 #include <solvers/smt/simplification_equivalence.h>
 #include <util/arith/arith_tools.h>
+#include <util/arith/ieee_float.h>
 #include <util/config/config.h>
 #include <util/config/options.h>
 #include <util/symtab/context.h>
@@ -92,6 +93,46 @@ SCENARIO(
       REQUIRE(
         check_simplification_equivalence(not2tc(b), b, ns, options) ==
         simplification_equivalencet::differs);
+    }
+  }
+
+
+  GIVEN("a floating-point rewrite")
+  {
+    const type2tc double_ty = migrate_type(double_type());
+    // fp.eq is not structural equality -- NaN != NaN under it, so a checker
+    // built on equality2t alone calls even the identity rewrite `differs` and
+    // aborts an enabled build on the first float it meets.
+    const expr2tc f = symbol2tc(double_ty, "f");
+    THEN("the identity rewrite is equivalent")
+    {
+      REQUIRE(
+        check_simplification_equivalence(f, f, ns, options) ==
+        simplification_equivalencet::equivalent);
+    }
+    THEN("if(c,f,f) -> f is equivalent")
+    {
+      const expr2tc c = symbol2tc(get_bool_type(), "c");
+      REQUIRE(
+        check_simplification_equivalence(
+          if2tc(double_ty, c, f, f), f, ns, options) ==
+        simplification_equivalencet::equivalent);
+    }
+    THEN("-0.0 -> +0.0 differs")
+    {
+      // fp.eq(+0.0, -0.0) holds, so only the sign check separates them. This
+      // is the class of float bug the simplifier guards against by hand.
+      ieee_floatt neg_zero(ieee_float_spect::double_precision());
+      neg_zero.from_double(0.0);
+      neg_zero.set_sign(true);
+      ieee_floatt pos_zero(ieee_float_spect::double_precision());
+      pos_zero.from_double(0.0);
+      REQUIRE(
+        check_simplification_equivalence(
+          constant_floatbv2tc(neg_zero),
+          constant_floatbv2tc(pos_zero),
+          ns,
+          options) == simplification_equivalencet::differs);
     }
   }
 

--- a/unit/solvers/simplification_equivalence.test.cpp
+++ b/unit/solvers/simplification_equivalence.test.cpp
@@ -1,0 +1,121 @@
+// SMT equivalence checker for simplifier rewrites (issue #4625).
+//
+// The checker is what would tell us a simplifier rewrite changed meaning, so
+// it has to be shown to say "differs" on a rewrite that really does. Driving
+// it directly is the only way to get that: the installed checker aborts, and a
+// regression test cannot assert on a build that aborts by design.
+//
+// Each case states a (before, after) pair whose relationship is decided by
+// hand, then asks the checker to agree.
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <irep2/irep2_utils.h>
+#include <solvers/smt/simplification_equivalence.h>
+#include <util/arith/arith_tools.h>
+#include <util/config/config.h>
+#include <util/config/options.h>
+#include <util/symtab/context.h>
+#include <util/symtab/namespace.h>
+
+namespace
+{
+expr2tc int_symbol(const char *name)
+{
+  return symbol2tc(get_int32_type(), name);
+}
+} // namespace
+
+SCENARIO(
+  "the simplifier equivalence checker decides real rewrites",
+  "[solvers][simplifier]")
+{
+  config.ansi_c.set_data_model(configt::LP64);
+  contextt ctx;
+  namespacet ns(ctx);
+  optionst options;
+
+  const expr2tc x = int_symbol("x");
+  const expr2tc zero = gen_zero(get_int32_type());
+  const expr2tc one = from_integer(1, get_int32_type());
+
+  GIVEN("a meaning-preserving rewrite")
+  {
+    // x + 0 -> x, for every x.
+    const expr2tc before = add2tc(get_int32_type(), x, zero);
+    THEN("it reports equivalent")
+    {
+      REQUIRE(
+        check_simplification_equivalence(before, x, ns, options) ==
+        simplification_equivalencet::equivalent);
+    }
+  }
+
+  GIVEN("a rewrite that changes meaning")
+  {
+    // x + 1 -> x differs at every x, so any model is a witness.
+    const expr2tc before = add2tc(get_int32_type(), x, one);
+    THEN("it reports differs")
+    {
+      REQUIRE(
+        check_simplification_equivalence(before, x, ns, options) ==
+        simplification_equivalencet::differs);
+    }
+  }
+
+  GIVEN("a rewrite that is wrong only on a corner value")
+  {
+    // x * 2 / 2 -> x holds except where the multiply wraps, so the checker
+    // must not be satisfied by the common case.
+    const expr2tc two = from_integer(2, get_int32_type());
+    const expr2tc before =
+      div2tc(get_int32_type(), mul2tc(get_int32_type(), x, two), two);
+    THEN("it still reports differs")
+    {
+      REQUIRE(
+        check_simplification_equivalence(before, x, ns, options) ==
+        simplification_equivalencet::differs);
+    }
+  }
+
+  GIVEN("a boolean rewrite")
+  {
+    const expr2tc b = symbol2tc(get_bool_type(), "b");
+    THEN("!!b -> b is equivalent")
+    {
+      REQUIRE(
+        check_simplification_equivalence(not2tc(not2tc(b)), b, ns, options) ==
+        simplification_equivalencet::equivalent);
+    }
+    THEN("!b -> b differs")
+    {
+      REQUIRE(
+        check_simplification_equivalence(not2tc(b), b, ns, options) ==
+        simplification_equivalencet::differs);
+    }
+  }
+
+  GIVEN("a shape the checker declines")
+  {
+    THEN("a nil operand is skipped")
+    {
+      REQUIRE(
+        check_simplification_equivalence(expr2tc(), x, ns, options) ==
+        simplification_equivalencet::skipped);
+    }
+    THEN("a pointer-typed expression is skipped")
+    {
+      const expr2tc p = symbol2tc(pointer_type2tc(get_int32_type()), "p");
+      REQUIRE(
+        check_simplification_equivalence(p, p, ns, options) ==
+        simplification_equivalencet::skipped);
+    }
+    THEN("a rewrite that changes type is skipped")
+    {
+      REQUIRE(
+        check_simplification_equivalence(
+          x, symbol2tc(get_int64_type(), "y"), ns, options) ==
+        simplification_equivalencet::skipped);
+    }
+  }
+}


### PR DESCRIPTION
Configure with `-DENABLE_SIMPLIFIER_EQUIVALENCE_CHECK=ON` and every `simplify()` rewrite is proved equivalent by an SMT solver, so a simplifier soundness bug surfaces at the call site with a counterexample rather than as a wrong verdict later. Off by default and compiled out entirely, since simplify() runs on every expression ESBMC builds.

`simplify()` lives in `irep2`, which links neither `util` nor the solvers, so the driver installs the checker and `irep2` holds only the hook — no global-namespace handle. A unit test drives the checker directly and pins that it reports `differs` on rewrites that really do change meaning.

Fixes #4625