### PR TITLE
[build] Bump the pinned vcpkg past the pruned msys2-runtime

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,11 @@ jobs:
       run: |
         vcpkg.exe update
         cd C:/vcpkg
-        git.exe checkout 2025.03.19
+        # MSYS2 prunes old packages from every mirror, so a vcpkg release only
+        # stays usable while the msys2-runtime it names is still published.
+        # 2025.03.19 asked for msys2-runtime-3.5.4-2, which now 404s on all of
+        # them and fails every Windows configure; this release asks for 3.6.5-1.
+        git.exe checkout 2026.07.29
         .\bootstrap-vcpkg.bat
     - name: Make git use LF only
       run: |


### PR DESCRIPTION
Windows configure fails on every PR: vcpkg 2025.03.19 asks for `msys2-runtime-3.5.4-2`, which MSYS2 has pruned and now 404s on all five mirrors. Re-running cannot help.

vcpkg 2026.07.29 asks for `3.6.5-1`, which is still published (verified: 3.5.4-2 → HTTP 404, 3.6.5-1 → HTTP 200).

Only CI can validate this, as the failure is Windows-only.