### PR TITLE
[build] Enable -Werror on the macOS PR leg

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,7 +36,7 @@ jobs:
     name: arm64 darwin build
     with:
       operating-system: macos-latest
-      build-flags: '-b DebugOpt -c 21'
+      build-flags: '-b DebugOpt -c 21 -e ON'
       testing: true
 
   # Check project with clang-format. This job no longer auto-commits fixes:

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -29,6 +29,14 @@
 //                    subheaders. Include the ones we use.
 //
 // We use Boost.Process to run the Python interpreter in a separate process.
+//
+// v1's locale.hpp uses std::codecvt_utf8, deprecated in C++17. Boost is not
+// ours to fix and the include lists it with -I rather than -isystem (the
+// nlohmann pin needs that precedence, see ExternalDependencies.cmake), so
+// -Werror would stop on a third-party header. Silence it across the include
+// only.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #if defined(__APPLE__) || (BOOST_VERSION == 108700)
 #  include <boost/process/v1.hpp>
 namespace bp = boost::process::v1;
@@ -41,6 +49,7 @@ namespace bp = boost::process::v1;
 #  include <boost/process.hpp>
 namespace bp = boost::process;
 #endif
+#pragma GCC diagnostic pop
 
 namespace fs = boost::filesystem;
 

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -145,8 +145,10 @@ public:
   expr2tc tuple_get(const expr2tc &expr) override;
   expr2tc tuple_get(const type2tc &type, smt_astt a) override;
 
-  expr2tc
-  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+  expr2tc tuple_get_array_elem(
+    smt_astt array,
+    uint64_t index,
+    const type2tc &subtype) override;
 
   tvt get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;


### PR DESCRIPTION
The ubuntu and windows PR legs have built with `-e ON` for some time; macOS did not, so a warning introduced only on that toolchain could reach master unnoticed.

Compiling all 685 translation units with `-Werror` (all four optional frontends and five solvers enabled) turned up exactly one: `tuple_get_array_elem` in the Yices backend overrides without being marked `override`. Fixed here, and the leg now enforces it.

Fixes #1130