### PR TITLE
[c++] Give a template instantiation's lambda its own closure type

### DIFF
--- a/regression/esbmc-cpp17/cpp/github_6969/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_6969/main.cpp
@@ -1,0 +1,19 @@
+extern "C" void __ESBMC_assert(bool, const char *);
+
+/* A lambda inside a function template is a distinct closure type in every
+ * instantiation. Naming the closure after its source location alone made all
+ * three collide, so only the first instantiation got an operator() body and
+ * the rest returned nondet. */
+template <typename T> static int f(int v)
+{
+  auto g = [](int x) { return x > 0 ? 10 : 20; };
+  return g(v);
+}
+
+int main()
+{
+  __ESBMC_assert(f<int>(1) == 10, "int instantiation");
+  __ESBMC_assert(f<long>(1) == 10, "long instantiation");
+  __ESBMC_assert(f<char>(-1) == 20, "char instantiation");
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_6969/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_6969/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++17 --multi-property
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_6969_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_6969_fail/main.cpp
@@ -1,0 +1,16 @@
+extern "C" void __ESBMC_assert(bool, const char *);
+
+/* The negative twin: a bodyless closure returns nondet, which satisfies any
+ * assertion the solver likes. This one is false in every instantiation, so a
+ * regression back to nondet returns would let it pass. */
+template <typename T> static int f(int v)
+{
+  auto g = [](int x) { return x > 0 ? 10 : 20; };
+  return g(v);
+}
+
+int main()
+{
+  __ESBMC_assert(f<long>(1) == 20, "long instantiation is 10, not 20");
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_6969_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_6969_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++17
+
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -4890,6 +4890,24 @@ void clang_c_convertert::get_decl_name(
                                        location_begin.column().as_string();
       std::string kind_name = rd.getKindName().str();
       name = kind_name + " __anon_" + kind_name + "_at_" + location_begin_str;
+
+      /* A lambda closure declared inside a function template is a distinct
+       * type in every instantiation, but file/line/column are shared by all
+       * of them, so the name above collides. get_struct_union_class() then
+       * finds the first instantiation's symbol already present and returns
+       * early, leaving the later instantiations' operator() with no body --
+       * symex assigns a nondet return and the verdict is silently wrong
+       * (esbmc/esbmc#6969). Qualify with the enclosing specialisation, which
+       * is what clang's own USRs for the closure's methods already carry. */
+      const auto *parent =
+        llvm::dyn_cast_or_null<clang::FunctionDecl>(rd.getDeclContext());
+      if (parent && parent->getTemplateSpecializationArgs())
+      {
+        std::string parent_name, parent_id;
+        get_decl_name(*parent, parent_name, parent_id);
+        name += "_" + parent_id;
+      }
+
       std::replace(name.begin(), name.end(), '.', '_');
     }
     else if (


### PR DESCRIPTION
An anonymous record is named after file/function/line/column, so the lambda inside a function template got the *same* name in every instantiation. `get_struct_union_class()` then found the first instantiation's symbol already present and returned early, leaving later instantiations' `operator()` with no body — symex assigned a nondet return and the verdict was silently wrong.

Qualifying the name with the enclosing specialisation fixes it; that is what clang's own USRs for the closure's *methods* already carry, which is why the call sites and the single emitted definition disagreed.

The issue's reproducer goes from 2 of 3 assertions wrongly FAILED to all PASSED, and the GOTO now carries three `operator()` bodies instead of one. No verdict changes across 199 tests in `esbmc-cpp`, `esbmc-cpp11` and `esbmc-cpp17` (control-vs-patched differential). The positive regression test fails on master and passes here; its negative twin passes on both, since a nondet return makes an assertion fail rather than hold.

Fixes #6969