### PR TITLE
[pointer-analysis] Store a whole float element without byte stitching

### DIFF
--- a/regression/floats-regression/github_6922/main.c
+++ b/regression/floats-regression/github_6922/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+/* The loop bound arrives as a parameter, so the index is symbolic and the
+ * store is not folded to a constant offset. A whole float element written
+ * through a symbolic index used to be decomposed into four byte updates;
+ * each byte round-tripped the element through fp.to_ieee_bv / to_fp, and
+ * SMT-LIB leaves the NaN pattern fp.to_ieee_bv returns unconstrained, so the
+ * value read back need not be the one stored. */
+static void st(const float *x, float *y, int n)
+{
+  int k;
+  for (k = 0; k < n - 1; k++)
+    y[k] = (x[k] < x[k + 1]) ? 7.5f : 2.5f;
+}
+
+int main(void)
+{
+  float x[2], y[1];
+  x[0] = 0.25f;
+  x[1] = 0.75f;
+  st(x, y, 2);
+  assert(y[0] == 7.5f); /* 0.25f < 0.75f */
+  return 0;
+}

--- a/regression/floats-regression/github_6922/test.desc
+++ b/regression/floats-regression/github_6922/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--32 --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats-regression/github_6922_fail/main.c
+++ b/regression/floats-regression/github_6922_fail/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+/* Negative twin: the store selects 7.5f, so asserting 2.5f must be reported.
+ * A store that yields an unconstrained value would let this through. */
+static void st(const float *x, float *y, int n)
+{
+  int k;
+  for (k = 0; k < n - 1; k++)
+    y[k] = (x[k] < x[k + 1]) ? 7.5f : 2.5f;
+}
+
+int main(void)
+{
+  float x[2], y[1];
+  x[0] = 0.25f;
+  x[1] = 0.75f;
+  st(x, y, 2);
+  assert(y[0] == 2.5f);
+  return 0;
+}

--- a/regression/floats-regression/github_6922_fail/test.desc
+++ b/regression/floats-regression/github_6922_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--32 --z3
+^VERIFICATION FAILED$

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1358,7 +1358,24 @@ void dereferencet::construct_from_array(
       !is_correctly_aligned && is_pointer_type(arr_subtype) &&
       alignment * 8 >= subtype_size)
       is_correctly_aligned = true;
-    overflows_boundaries = !is_correctly_aligned || deref_size > subtype_size;
+    /* A whole-element access needs no stitching. check_alignment() below
+     * asserts the offset lands on an element boundary, which is exactly the
+     * precondition index2tc needs, so an unproven alignment claim is a reason
+     * to *check*, not to decompose.
+     *
+     * Only floats are taken off the stitching path. Reassembling one costs a
+     * fp.to_ieee_bv / to_fp round trip per byte, and SMT-LIB leaves the NaN
+     * pattern fp.to_ieee_bv returns unconstrained -- so once an intermediate
+     * is NaN the solver may pick a different pattern each time and the value
+     * read back is not the one stored (esbmc/esbmc#6922). Integer subtypes
+     * keep the original condition: their stitching is exact, and weakening it
+     * would stop over-approximated alignments reaching check_alignment
+     * (regression/esbmc/align-deref_fail). */
+    const bool whole_element =
+      deref_size == subtype_size && is_floatbv_type(arr_subtype);
+    overflows_boundaries =
+      whole_element ? false
+                    : (!is_correctly_aligned || deref_size > subtype_size);
   }
 
   // No alignment guarantee: assert that it's correct.


### PR DESCRIPTION
A float written through a symbolic index was decomposed into four byte updates, because the value set only claimed 1-byte alignment. Each byte round-trips the element through `fp.to_ieee_bv` / `to_fp`, and SMT-LIB leaves the NaN pattern `fp.to_ieee_bv` returns unconstrained — so the value read back need not be the one stored. That is the false alarm in the issue.

The access is exactly one element wide (`deref_size == subtype_size`) and `check_alignment` is *already* emitted, asserting the offset lands on an element boundary — which is exactly the precondition `index2tc` needs. An unproven alignment claim is a reason to check, not to decompose. Scoped to float subtypes: integer stitching is exact, and weakening it would stop over-approximated alignments reaching `check_alignment` (`regression/esbmc/align-deref_fail`, which still fails as expected).

Measured: the reproducer flips FAILED → SUCCESSFUL under `--z3`; no verdict changes across 197 `esbmc`, 102 `floats` and 62 `floats-regression` tests in a control-vs-patched differential. The positive regression test fails on master and passes here.

Fixes #6922