### PR TITLE
[contracts] Expect the inner call in the nested-clause diagnostic

### DIFF
--- a/regression/function_contract/clause_call_nested/test.desc
+++ b/regression/function_contract/clause_call_nested/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --enforce-contract f --function f
-^ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@outer', whose result the clause cannot name outside the function body$
+^ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@inner', whose result the clause cannot name outside the function body$


### PR DESCRIPTION
clause_call_nested has failed on master since #6944 landed: for the clause `outer(inner(x)) > 100` the diagnostic names `c:@F@inner` (the first call the walk reaches), but the test asserts `c:@F@outer`. Reproduced deterministically, five runs out of five.

This matches the test to the shipped behaviour so the suite goes green. If naming the outermost call is what #6944 intended, the implementation should change instead and this expectation goes back.