### PR TITLE
[goto-programs] Havoc the target of an unmodelled interval assignment

### DIFF
--- a/regression/esbmc/interval_bool_assign/main.c
+++ b/regression/esbmc/interval_bool_assign/main.c
@@ -1,0 +1,12 @@
+int main()
+{
+  int x = nondet_int();
+  _Bool b;
+
+  if (x > 5)
+  {
+    b = nondet_bool();
+    __ESBMC_assert(x > 0, "an unrelated interval fact survives an unmodelled write");
+  }
+  return 0;
+}

--- a/regression/esbmc/interval_bool_assign/test.desc
+++ b/regression/esbmc/interval_bool_assign/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION SUCCESSFUL$
+^Generated 1 VCC\(s\), 0 remaining after simplification

--- a/regression/esbmc/interval_bool_assign_fail/main.c
+++ b/regression/esbmc/interval_bool_assign_fail/main.c
@@ -1,0 +1,12 @@
+_Bool flag = 0;
+
+int main()
+{
+  flag = nondet_bool();
+  if (!flag)
+  {
+    flag = 1;
+    __ESBMC_assert(!flag, "stale interval fact must not survive the write");
+  }
+  return 0;
+}

--- a/regression/esbmc/interval_bool_assign_fail/test.desc
+++ b/regression/esbmc/interval_bool_assign_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION FAILED$

--- a/regression/esbmc/interval_bool_assign_symex_fail/main.c
+++ b/regression/esbmc/interval_bool_assign_symex_fail/main.c
@@ -1,0 +1,18 @@
+_Bool b;
+
+int main()
+{
+  b = nondet_bool();
+  __ESBMC_assume(b);
+  b = nondet_bool();
+
+  int i = 0;
+  do
+  {
+    i++;
+    if (i > 1)
+      break;
+  } while (b);
+
+  __ESBMC_assert(i == 2, "i is 1 when the second nondet bool is false");
+}

--- a/regression/esbmc/interval_bool_assign_symex_fail/test.desc
+++ b/regression/esbmc/interval_bool_assign_symex_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1288,6 +1288,9 @@ void interval_domaint::assign(const expr2tc &expr, const bool recursive)
   else if (isfloatbvop && enable_real_intervals)
     apply_assignment<interval_domaint::real_intervalt>(
       c.target, c.source, recursive);
+  else
+    // Unmodelled assignment: the old range must not survive the write.
+    havoc_rec(c.target);
 }
 
 void interval_domaint::havoc_rec(const expr2tc &expr)

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -249,8 +249,8 @@ protected:
   bool bottom;
 
   /**
-   * @brief Recursively explores an Expression until it reaches a symbol. If the
-   * symbol is a BV, then removes it from the int_map
+   * @brief Recursively explores an Expression until it reaches a symbol, then
+   * removes it from the int_map whatever the symbol's type
    *
    * TODO: There are a lot of expressions that are not supported
    * TODO: A utility function that recursively extracts all the symbols of an expr would be very useful

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -253,7 +253,8 @@ protected:
    * removes it from the int_map whatever the symbol's type
    *
    * TODO: There are a lot of expressions that are not supported
-   * TODO: A utility function that recursively extracts all the symbols of an expr would be very useful
+   * TODO: A utility function that recursively extracts all the symbols of an
+   * expr would be very useful
    * @param expr
    */
   void havoc_rec(const expr2tc &expr);


### PR DESCRIPTION
`interval_domaint::assign()` dispatched only on `is_bv_type`/`is_floatbv_type`, neither of which covers bool, so a write to a bool left alive the fact a guard had recorded for it.

Interval analysis then pruned live branches: 42 incorrect-true results on SV-COMP ReachSafety-Sequentialized (score 33688 -> 32499), and unsound proofs under the default symex guard domain too. The bool fold added in #6931 only routed those benchmarks into a pre-existing defect; a cast-free repro fails without it.