### PR TITLE
[docs] Add August 2026 development update to the website

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -3,8 +3,10 @@ title: ESBMC
 toc: false
 ---
 
-{{< callout type="important" icon="sparkles" >}} **NEW:** We have rewritten and
-cleaned up the docs, read more [here](/news/docs-page-improvement).
+{{< callout type="important" icon="sparkles" >}} **NEW:** Around 80 pull
+requests landed in early August — Python function contracts, a user-facing
+`esbmc.h`, concurrency soundness fixes and more. Read the
+[development update](/news/development-update-august-2026).
 {{< /callout >}}
 
 {{< cards >}}

--- a/website/content/docs/c-cpp/supported-features.md
+++ b/website/content/docs/c-cpp/supported-features.md
@@ -156,6 +156,9 @@ case. See [Limitations](./limitations#constructor-and-destructor-ordering).
 - A captureless lambda converted to a function pointer produces a *callable*
   pointer: both the conversion operator and the static invoker behind it get a
   body, so `int (*f)(int) = [](int x){ return x + 1; }; f(2);` runs
+- A lambda inside a template instantiation gets its own closure type per
+  instantiation, so two instantiations of the same function template do not
+  share (and corrupt) one capture layout
 
 ### Templates
 
@@ -245,7 +248,7 @@ by regression tests under `regression/esbmc-cpp*`.
 | `<unordered_map>`, `<unordered_set>` | |
 | `<array>` | `iterator` / `const_iterator` typedefs; usable in C++11 |
 | `<queue>`, `<stack>`, `<bitset>` | Includes `std::priority_queue` |
-| `<iterator>` | `iterator_traits` and the iterator tags; `advance`, `distance`, `next`, `prev` |
+| `<iterator>` | `iterator_traits` and the iterator tags; `advance`, `distance`, `next`, `prev`; the range accessors including the reverse forms `rbegin` / `rend` / `crbegin` / `crend` |
 | `<valarray>` | |
 
 `std::multimap` and `std::multiset` track `std::map` and `std::set`, including
@@ -258,19 +261,19 @@ by regression tests under `regression/esbmc-cpp*`.
 | `<string>` | `(const char*, size_t)` range and fill constructors; length-aware `operator<`/`operator>`/`operator<=`/`operator>=` including free overloads against `const char*`; `const` `substr(pos, n)`; C++20 `starts_with`/`ends_with`; `at` throws `std::out_of_range`; the full `sto*` family (`stoi`, `stol`, `stoll`, `stoul`, `stoull`, `stof`, `stod`, `stold`) |
 | `<string_view>` | Search members, `string` → `string_view` conversion, `hash<string_view>` |
 | `<iostream>`, `<istream>`, `<ostream>`, `<ios>`, `<iosfwd>` | Standard stream objects, `ios::widen`/`narrow`, `ios::exceptions`, `ios::copyfmt` |
-| `<sstream>`, `<fstream>`, `<streambuf>`, `<iomanip>` | |
+| `<sstream>`, `<fstream>`, `<streambuf>`, `<iomanip>` | `ostringstream` accumulates into the buffer its `str()` reports |
 | `<locale>` | |
 
 ### Utilities and type support
 
 | Header | Notes |
 | --- | --- |
-| `<type_traits>` | Classification traits and the `_t` / `_v` forms, including `is_trivial`, `is_standard_layout`, `is_aggregate`, `is_assignable` and the copy/move/destructible variants, `remove_cvref`, `aligned_storage`, and the logical traits `conjunction` / `disjunction` / `negation` |
-| `<utility>` | Including C++23 `std::unreachable` |
+| `<type_traits>` | Classification traits and the `_t` / `_v` forms, including `is_trivial`, `is_standard_layout`, `is_aggregate`, `is_assignable` and the copy/move/destructible variants, `remove_cvref`, `aligned_storage`, `invoke_result`, and the logical traits `conjunction` / `disjunction` / `negation` |
+| `<utility>` | Including `index_sequence_for` and C++23 `std::unreachable` |
 | `<functional>`, `<memory>`, `<initializer_list>` | `<functional>` has the transparent operation functors (`plus<>`, `less<>`, …); `<memory>` has `std::allocate_shared` and a correct default-constructed `unique_ptr` |
 | `<tuple>` | `std::tie`, `std::ignore`, structured binding over a tuple |
 | `<optional>` | `emplace`, `swap`, `std::make_optional` |
-| `<variant>`, `<any>` | The converting constructor does not hijack copies |
+| `<variant>`, `<any>` | `std::visit` calls the visitor on the currently held alternative; the converting constructor does not hijack copies |
 | `<expected>` | C++23 |
 | `<compare>` | Includable before C++20 |
 | `<source_location>`, `<span>`, `<bit>` | C++20 |
@@ -301,7 +304,8 @@ modelled on the same basis, and `<atomic>` is modelled with atomic sections.
 
 `<cassert>`, `<cctype>`, `<cerrno>`, `<cfloat>`, `<ciso646>`, `<climits>`,
 `<clocale>`, `<cmath>`, `<csetjmp>`, `<csignal>`, `<cstdarg>`, `<cstddef>`,
-`<cstdint>`, `<cstdio>`, `<cstdlib>`, `<cstring>` and `<ctime>` are available.
+`<cstdint>`, `<cstdio>`, `<cstdlib>`, `<cstring>`, `<ctime>` and `<cwchar>`
+are available.
 
 Their names are declared in namespace `std` as the standard requires, not only
 in the global namespace: `std::isalpha`, `std::tolower`, `std::time`,
@@ -332,7 +336,7 @@ implementation, which is frequently intractable.
 `<coroutine>`, `<charconv>`, `<numbers>`, `<ratio>`, `<typeindex>`,
 `<barrier>`, `<latch>`, `<semaphore>`, `<stop_token>`,
 `<syncstream>`, `<execution>`, `<memory_resource>`, `<scoped_allocator>`,
-`<cwchar>`, `<cwctype>`, `<cfenv>`, `<cinttypes>`.
+`<cwctype>`, `<cfenv>`, `<cinttypes>`.
 
 Note that `<concepts>` being unmodelled does not affect the *language* feature —
 concepts and `requires` clauses are supported, as listed above.

--- a/website/content/docs/constructs.md
+++ b/website/content/docs/constructs.md
@@ -15,6 +15,38 @@ you're planning to verify your code with only ESBMC.
 
 SV-COMP Document: https://sv-comp.sosy-lab.org/2025/rules.php {{< /callout >}}
 
+## The `esbmc.h` Header
+
+ESBMC installs an `esbmc.h` header alongside the binary. Including it gives the
+intrinsics unprefixed names, which is the supported surface for hand-written
+harnesses and stubs:
+
+| Macro                       | Expands to                  |
+| --------------------------- | --------------------------- |
+| `ESBMC_assume(cond)`        | `__ESBMC_assume`            |
+| `ESBMC_assert(cond, msg)`   | `__ESBMC_assert`            |
+| `ESBMC_alloca(size)`        | `__ESBMC_alloca`            |
+| `ESBMC_same_object(p, q)`   | `__ESBMC_same_object`       |
+| `ESBMC_unreachable()`       | `__ESBMC_unreachable`       |
+| `ESBMC_unroll(n)`           | `__ESBMC_unroll`            |
+| `ESBMC_atomic_begin()` / `ESBMC_atomic_end()` | `__ESBMC_atomic_begin` / `__ESBMC_atomic_end` |
+| `ESBMC_yield()`             | `__ESBMC_yield`             |
+
+Every ESBMC run defines `__ESBMC_execution`, and the header refuses to compile
+without it — so a harness that includes `esbmc.h` is a hard error under any
+ordinary compiler instead of silently building with the intrinsics undefined.
+
+```c
+#include <esbmc.h>
+
+int main() {
+    unsigned int x = nondet_uint();
+    ESBMC_assume(x < 5);
+    ESBMC_assert(x < 10, "X needs to be less than 10.");
+    return 0;
+}
+```
+
 ## Non-Deterministic Functions
 
 `nondet_X()` where `X` is a primitive C data type. This will mark the variable

--- a/website/content/docs/function-contracts.md
+++ b/website/content/docs/function-contracts.md
@@ -463,6 +463,33 @@ every function that has at least one contract clause, whether annotated or not.
 `--enforce-all-contracts` and `--replace-all-contracts` match only annotated
 functions.
 
+## Contracts in Python
+
+The Python frontend lowers `__ESBMC_requires` / `__ESBMC_ensures` clauses too,
+so `--enforce-contract` and `--replace-call-with-contract` work on Python
+functions:
+
+```python
+def double(x: int) -> int:
+    __ESBMC_requires(x > 0)
+    __ESBMC_ensures(__ESBMC_return_value > x)
+    return 2 * x
+```
+
+```bash
+esbmc main.py --enforce-contract double
+```
+
+`__ESBMC_return_value` takes its type from the function's return annotation.
+Clauses are inert under a plain BMC run, exactly as in C.
+
+A clause the lowering cannot express is rejected with a diagnostic naming the
+clause and line — a function call or subscript inside the condition, a
+reference whose type cannot be determined, `__ESBMC_return_value` inside
+`requires` or on a function annotated `-> None` — rather than being silently
+dropped. `__ESBMC_old`, `__ESBMC_assigns`, and the quantified forms are not yet
+available in Python.
+
 ## Quick reference
 
 | Construct                       | Where                  | Purpose                               |

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -50,6 +50,8 @@ This page is a reference of all Python language constructs, data structures, and
 - **Explicit base-class `__init__`**: unbound parent-constructor calls of the form `Base.__init__(self, ...)` (the pre-`super()` idiom) are dispatched to the base constructor with `self` bound correctly
 - **`@staticmethod` and `@classmethod`**: receiver binding is taken from the method's decorator list rather than guessed from the first parameter's name. A `@staticmethod` receives no implicit receiver (so `M.twice(6)` binds `6` to the first real parameter), and a `@classmethod`'s `cls` parameter is typed against the enclosing class, so `cls.<attr>` resolves
 - **`@property` getters**: reading a `@property`-decorated attribute (`obj.area`) invokes the decorated getter method rather than looking up a struct field; inherited properties resolve through the base class
+- **`__bool__` truth-testing**: a class's `__bool__` is called in every truth context — `if obj:`, `while obj:`, ternaries, `bool(obj)`, and also `not obj` and a bare `assert obj`, so `assert falsy_obj` fails exactly as CPython raises
+- **Constructor temporaries**: calling a method directly on a fresh instance (`C().get()`) works without binding the instance to a name first — `__init__` runs on the temporary, its own methods win over same-named ones from other classes, and dunder methods (e.g. `C() == x`, `len(C())`) dispatch on it
 - **Classes as first-class values**: a class name passed as a bare value (`register(Twist)`) — the class object itself, not an instance — is modelled as an opaque placeholder for inert uses (storing/forwarding the class), while normal construction through the name (`Twist()`) is unaffected
 - **Class-method defaults**: `Name` defaults referencing `ESBMC_default_*` helpers are hoisted past the enclosing `ClassDef` so they remain visible at call sites
 
@@ -296,6 +298,16 @@ t1.start(); t2.start(); t1.join(); t2.join()
 
 `esbmc race.py --incremental-bmc --data-races-check` reports `W/W data race on py:race.py@shared` and `VERIFICATION FAILED`.
 
+## Function Contracts
+
+`__ESBMC_requires` / `__ESBMC_ensures` clauses at the top of a function body
+are lowered for `--enforce-contract` and `--replace-call-with-contract`, with
+`__ESBMC_return_value` typed from the return annotation; the clauses are inert
+under a plain BMC run. Malformed clauses (calls or subscripts inside the
+condition, untypeable references, `__ESBMC_return_value` in `requires` or on a
+`-> None` function) are rejected with a named diagnostic. See
+[Function Contracts](/docs/function-contracts#contracts-in-python).
+
 ## Cover Properties and Reachability
 
 `__ESBMC_cover(cond)` checks whether a condition is satisfiable at a given program point (inverted assertion semantics: a counterexample means the condition *is* reachable).
@@ -506,7 +518,7 @@ Partial executable support for list-backed arrays, element-wise arithmetic, sele
 
 **Shape manipulation**: `np.reshape(a, shape)` (2-D and 3-D targets; an incompatible element count is rejected), `np.flatten(a)` / `np.ravel(a)` (row-major 1-D view), `np.squeeze(a)` (drop unit-length axes; a non-unit axis is rejected), `np.stack([a, b, ...])` (join arrays along a new leading axis, e.g. 1-D → 2-D), `np.concatenate([a, b, ...])` (join along the existing axis), and `a.astype(dtype)` (dtype conversion; `astype` to a complex dtype is rejected)
 
-**Reductions**: `np.sum(a)`, `np.prod(a)`, `np.min(a)`, `np.max(a)`, `np.mean(a)`, `np.argmin(a)`, `np.argmax(a)` over list-backed arrays
+**Reductions**: `np.sum(a)`, `np.prod(a)`, `np.min(a)`, `np.max(a)`, `np.mean(a)`, `np.std(a)`, `np.var(a)`, `np.argmin(a)`, `np.argmax(a)` over list-backed arrays. The reductions, `transpose` and `flatten` accept arrays built by any constructor (`zeros`, `ones`, `full`, `eye`, `identity`, `linspace`, `arange`), not only `np.array(<literal>)`. The method spellings (`a.sum()`, `a.min()`, `a.prod()`, `a.transpose()`, `a.flatten()`, …) are rewritten to the module form in any expression context — e.g. `assert a.min() == 0` — not just on the right-hand side of an assignment
 
 **Comparison and logical ufuncs**: `np.greater`, `np.greater_equal`, `np.less`, `np.less_equal`, `np.equal`, `np.not_equal`, `np.logical_and`, `np.logical_or`, `np.logical_not`, and `np.where(cond, a, b)` (element-wise select; also the scalar-condition form `np.where(False, 1, 2)`)
 

--- a/website/content/docs/theory/concurrency.md
+++ b/website/content/docs/theory/concurrency.md
@@ -21,8 +21,19 @@ state.
 The number of interleavings grows combinatorially with the number of threads
 and operations — for *n* threads performing *k₁, …, kₙ* operations it is the
 multinomial coefficient `(k₁ + … + kₙ)! / (k₁! ⋯ kₙ!)` — so ESBMC controls the
-explosion in three complementary ways: bounding context switches [2],
-partial-order reduction [3], and state hashing.
+explosion in complementary ways: bounding context switches [2], partial-order
+reduction [3], state hashing, and sleep sets.
+
+At the end of a run ESBMC reports how the exploration spent its schedules and
+what each reduction pruned, so a reduction's contribution can be measured
+without re-running with each knob toggled:
+
+```
+Schedules explored: 940 (pruned by MPOR: 296, by state hashing: 0)
+```
+
+The line is omitted for sequential programs, which never have a schedule to
+choose.
 
 ## Bounding the context switches
 
@@ -78,10 +89,26 @@ esbmc file.c --state-hashing
 
 State hashing records a fingerprint of each explored state and skips
 re-exploring states already seen, pruning duplicate work across interleavings.
+The fingerprint includes which thread is active, so two states that differ only
+in the scheduled thread are explored separately rather than conflated.
 
 By default ESBMC stops at the first interleaving that violates a property; pass
 `--all-runs` to keep checking the remaining interleavings even after a bug is
 found.
+
+## Sleep sets
+
+```sh
+esbmc file.c --sleep-sets --no-por
+```
+
+`--sleep-sets` (experimental, off by default) adds a classic sleep-set
+reduction on top of the DFS: once a thread's subtree at a decision node is
+exhausted, the thread is skipped at sibling nodes until something dependent on
+it has run. It only fires where the search is exhaustive, so pair it with
+`--no-por` and no context bound; it is ignored under `--schedule`,
+`--direct-interleavings`, `--interactive-ileaves` and
+`--data-races-check-only`.
 
 ## Atomic blocks
 

--- a/website/content/news/development-update-august-2026.md
+++ b/website/content/news/development-update-august-2026.md
@@ -9,7 +9,7 @@ tags:
   - OpenSource
 ---
 
-🚀 Development on ESBMC has been moving fast: around 80 pull requests were
+Development on ESBMC has been moving fast: around 80 pull requests were
 merged into `master` in the first two weeks of August alone. Here are the
 highlights.
 

--- a/website/content/news/development-update-august-2026.md
+++ b/website/content/news/development-update-august-2026.md
@@ -1,0 +1,113 @@
+---
+title: "Development Update: August 2026"
+date: 2026-08-13T20:30:00+01:00
+draft: false
+tags:
+  - ESBMC
+  - FormalVerification
+  - ModelChecking
+  - OpenSource
+---
+
+🚀 Development on ESBMC has been moving fast: around 80 pull requests were
+merged into `master` in the first two weeks of August alone. Here are the
+highlights.
+
+**A user-facing `esbmc.h` header.**
+[#6932](https://github.com/esbmc/esbmc/pull/6932) ships `include/esbmc.h`,
+installed alongside the binary, which exposes the verification intrinsics under
+unprefixed names — `ESBMC_assume`, `ESBMC_assert`, `ESBMC_nondet_int`, and
+friends. Including the header under any other compiler is a hard error, so
+verification harnesses cannot silently compile to no-ops.
+
+**Function contracts come to Python.**
+[#6940](https://github.com/esbmc/esbmc/pull/6940) lowers `__ESBMC_requires` /
+`__ESBMC_ensures` clauses in the Python frontend, so `--enforce-contract` and
+`--replace-call-with-contract` now work on Python functions, with
+`__ESBMC_return_value` typed from the function's return annotation. On the
+C/C++ side, `__ESBMC_old` now insists on an lvalue
+([#6917](https://github.com/esbmc/esbmc/pull/6917)), `__ESBMC_is_fresh`
+callers are held to the extent they asked for
+([#6919](https://github.com/esbmc/esbmc/pull/6919)), and contract-clause
+misuse is diagnosed instead of silently lifted
+([#6944](https://github.com/esbmc/esbmc/pull/6944),
+[#6980](https://github.com/esbmc/esbmc/pull/6980)).
+
+**Sounder, leaner concurrency exploration.**
+[#6911](https://github.com/esbmc/esbmc/pull/6911) fixes a `--state-hashing`
+soundness bug that collided states differing only in the active thread — four
+regression tests return to their expected FAILED verdicts — and introduces
+optional sleep sets (`--sleep-sets`) plus per-run counters reporting what each
+schedule reduction prunes. [#6968](https://github.com/esbmc/esbmc/pull/6968)
+tightens MPOR by checking its dependency chain points forward in time, and
+[#6939](https://github.com/esbmc/esbmc/pull/6939) /
+[#6947](https://github.com/esbmc/esbmc/pull/6947) compose schedule
+falsification with unwinding strategies for faster bug-finding on concurrent
+benchmarks.
+
+**Memory layout faithful to the ABI.**
+The C frontend now honours `#pragma pack` when laying out struct members
+([#6955](https://github.com/esbmc/esbmc/pull/6955)), declaration alignment
+survives type-symbol squashing
+([#6956](https://github.com/esbmc/esbmc/pull/6956)), and the SMT backends give
+non-packed objects the ABI's fundamental alignment
+([#6957](https://github.com/esbmc/esbmc/pull/6957)). The pointer analysis also
+stores whole floating-point elements directly instead of stitching bytes
+([#6977](https://github.com/esbmc/esbmc/pull/6977)).
+
+**More compiler builtins modelled.**
+`__builtin_ffs/ffsl/ffsll`
+([#6943](https://github.com/esbmc/esbmc/pull/6943),
+[#6946](https://github.com/esbmc/esbmc/pull/6946)) and
+`__builtin_clzg/ctzg` together with the `ctz` family
+([#6928](https://github.com/esbmc/esbmc/pull/6928)) are now understood by
+symbolic execution, and a user's own `abs` definition wins over the builtin
+([#6906](https://github.com/esbmc/esbmc/pull/6906)).
+
+**Python frontend.**
+NumPy support grows substantially:
+[#6909](https://github.com/esbmc/esbmc/pull/6909) extends `dot`, `transpose`,
+`flatten`, `sum`, `mean`, `min`, `max`, `prod`, `std` and `var` to arrays built
+by any constructor (`zeros`, `ones`, `full`, `eye`, `identity`, `linspace`,
+`arange`), in both module and method form. Objects are now truth-tested through
+`__bool__` in `not` and `assert`
+([#6915](https://github.com/esbmc/esbmc/pull/6915)), and constructor
+temporaries run `__init__` and dispatch their own methods correctly
+([#6890](https://github.com/esbmc/esbmc/pull/6890),
+[#6892](https://github.com/esbmc/esbmc/pull/6892),
+[#6903](https://github.com/esbmc/esbmc/pull/6903)).
+
+**C++ operational models.**
+New coverage includes `<cwchar>` — the largest single blocker to
+self-verification ([#6869](https://github.com/esbmc/esbmc/pull/6869)) —
+`std::visit` ([#6918](https://github.com/esbmc/esbmc/pull/6918)),
+`std::invoke_result` ([#6874](https://github.com/esbmc/esbmc/pull/6874)),
+reverse range accessors ([#6872](https://github.com/esbmc/esbmc/pull/6872))
+and `ostringstream` buffering fixes
+([#6864](https://github.com/esbmc/esbmc/pull/6864)). Lambdas inside template
+instantiations now get their own closure type
+([#6976](https://github.com/esbmc/esbmc/pull/6976)).
+
+**Java/Kotlin frontend modernisation.**
+A sustained series of about twenty pull requests
+([#6851](https://github.com/esbmc/esbmc/pull/6851)–[#6891](https://github.com/esbmc/esbmc/pull/6891))
+migrates the Jimple frontend to build statements and expressions natively in
+ESBMC's IREP2 representation — assignments, gotos, invocations, allocations,
+array accesses and more — shedding a whole legacy conversion layer.
+
+**Robustness.**
+Deeply nested expressions are now reported as a graceful error instead of
+crashing the process with stack exhaustion
+([#6910](https://github.com/esbmc/esbmc/pull/6910),
+[#6974](https://github.com/esbmc/esbmc/pull/6974)), a `malloc` whose result is
+discarded still allocates — so leak checking sees it
+([#6937](https://github.com/esbmc/esbmc/pull/6937)) — and the expression
+simplifier gained missing peephole identities and an unsigned-negation
+modulus fix ([#6931](https://github.com/esbmc/esbmc/pull/6931),
+[#6933](https://github.com/esbmc/esbmc/pull/6933),
+[#6975](https://github.com/esbmc/esbmc/pull/6975)).
+
+As always, the full list is in the
+[commit history](https://github.com/esbmc/esbmc/commits/master/) — and if you
+hit a bug or a missing feature, we would love an
+[issue report](https://github.com/esbmc/esbmc/issues).


### PR DESCRIPTION
Summarise the ~80 PRs merged in early August as a news post: Python
function contracts, the user-facing esbmc.h, concurrency soundness fixes,
ABI-faithful layout, builtins, OM and Jimple work. Point the front-page
callout at the new post. Site builds cleanly with Hugo 0.154.5.