### PR TITLE
[om] Add chrono time_point, clocks and duration arithmetic

### DIFF
--- a/regression/esbmc-cpp/cpp/github_6984_datetime/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_6984_datetime/main.cpp
@@ -1,0 +1,66 @@
+// github.com/esbmc/esbmc/issues/6984 — the aws-sdk-cpp Aws::Utils::DateTime
+// shape: a system_clock::time_point representation plus tm members, with
+// <chrono> as the only include.
+#include <chrono>
+#include <cassert>
+
+class DateTime
+{
+  std::chrono::system_clock::time_point m_time;
+
+public:
+  DateTime() = default;
+  explicit DateTime(std::chrono::system_clock::time_point t) : m_time(t) {}
+  explicit DateTime(int64_t millis)
+    : m_time(
+        std::chrono::system_clock::time_point(std::chrono::milliseconds(millis)))
+  {
+  }
+
+  int64_t Millis() const
+  {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+             m_time.time_since_epoch())
+      .count();
+  }
+
+  double SecondsWithMSPrecision() const
+  {
+    return static_cast<double>(Millis()) / 1000.0;
+  }
+
+  DateTime operator+(const std::chrono::milliseconds &d) const
+  {
+    return DateTime(m_time + d);
+  }
+
+  bool operator<(const DateTime &other) const
+  {
+    return m_time < other.m_time;
+  }
+
+  tm GetGmtStruct() const
+  {
+    tm t = {};
+    t.tm_year = 70;
+    return t;
+  }
+};
+
+int main()
+{
+  DateTime epoch;
+  assert(epoch.Millis() == 0);
+
+  DateTime d(1500);
+  assert(d.Millis() == 1500);
+  assert(d.SecondsWithMSPrecision() > 1.4);
+
+  DateTime later = d + std::chrono::milliseconds(500);
+  assert(later.Millis() == 2000);
+  assert(d < later);
+  assert(!(later < d));
+
+  assert(d.GetGmtStruct().tm_year == 70);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_6984_datetime/test.desc
+++ b/regression/esbmc-cpp/cpp/github_6984_datetime/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/github_6984_clock_nondet_fail/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_6984_clock_nondet_fail/main.cpp
@@ -1,0 +1,19 @@
+// github.com/esbmc/esbmc/issues/6984 — the clocks are nondeterministic, so a
+// reading is not pinned to the epoch and two readings need not differ.
+// Both assertions must be reachable failures, or the clock model is a
+// constant dressed up as a clock.
+#include <chrono>
+#include <cassert>
+
+using namespace std::chrono;
+
+int main()
+{
+  auto a = steady_clock::now();
+  assert(a.time_since_epoch().count() == 0);
+
+  auto b = steady_clock::now();
+  assert(b > a);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_6984_clock_nondet_fail/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_6984_clock_nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --unwind 2
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/cpp/github_6984_duration/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_6984_duration/main.cpp
@@ -1,0 +1,65 @@
+// github.com/esbmc/esbmc/issues/6984 — <chrono> duration converting
+// constructor and the arithmetic operators.
+#include <chrono>
+#include <cassert>
+
+using namespace std::chrono;
+
+int main()
+{
+  // [time.duration.cons] p2: implicit when the period ratio divides exactly.
+  nanoseconds ns = seconds(1);
+  assert(ns.count() == 1000000000LL);
+  milliseconds ms = minutes(2);
+  assert(ms.count() == 120000LL);
+
+  // [time.duration.nonmember]: mixed-period arithmetic goes through
+  // common_type, so the result carries the finer period.
+  auto mixed = seconds(1) + milliseconds(1);
+  assert(mixed.count() == 1001);
+  assert((seconds(1) - milliseconds(250)).count() == 750);
+
+  assert((seconds(2) * 3).count() == 6);
+  assert((3 * seconds(2)).count() == 6);
+  assert((seconds(6) / 2).count() == 3);
+  assert(seconds(6) / seconds(2) == 3);
+  assert((seconds(7) % 4).count() == 3);
+  assert((minutes(2) % seconds(50)).count() == 20);
+
+  // [time.duration.arithmetic]: unary and compound forms.
+  assert((-seconds(1)).count() == -1);
+  assert((+seconds(4)).count() == 4);
+
+  auto d = seconds(2);
+  d += seconds(1);
+  assert(d.count() == 3);
+  d -= seconds(1);
+  assert(d.count() == 2);
+  d *= 5;
+  assert(d.count() == 10);
+  d /= 4;
+  assert(d.count() == 2);
+  d %= seconds(3);
+  assert(d.count() == 2);
+  assert((++d).count() == 3);
+  assert((d--).count() == 3);
+  assert(d.count() == 2);
+
+  // Mixed-period comparison.
+  assert(seconds(1) == milliseconds(1000));
+  assert(milliseconds(1500) > seconds(1));
+  assert(microseconds(999) < milliseconds(1));
+
+  // [ratio.ratio] p1: num/den are reduced, and the sign lives on num.
+  static_assert(std::ratio<2, 4>::num == 1, "ratio num is reduced");
+  static_assert(std::ratio<2, 4>::den == 2, "ratio den is reduced");
+  static_assert(std::ratio<1, -2>::num == -1, "ratio sign is on num");
+  static_assert(std::ratio<1, -2>::den == 2, "ratio den is positive");
+
+  // Floating-point Rep may truncate, so its converting constructor is
+  // unconstrained.
+  duration<double> fs = milliseconds(1500);
+  assert(fs.count() > 1.4 && fs.count() < 1.6);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_6984_duration/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_6984_duration/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/github_6984_time_point/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_6984_time_point/main.cpp
@@ -1,0 +1,45 @@
+// github.com/esbmc/esbmc/issues/6984 — <chrono> time_point, time_point_cast
+// and the three clocks.
+#include <chrono>
+#include <cassert>
+#include <ctime>
+
+using namespace std::chrono;
+
+int main()
+{
+  time_point<system_clock> tp;
+  assert(tp.time_since_epoch().count() == 0);
+
+  system_clock::time_point epoch;
+  auto later = epoch + seconds(5);
+  assert(duration_cast<seconds>(later.time_since_epoch()).count() == 5);
+  assert(later > epoch);
+  assert(later - epoch == seconds(5));
+  assert(seconds(5) + epoch == later);
+  assert(later - seconds(5) == epoch);
+
+  auto t = epoch;
+  t += seconds(3);
+  assert(t - epoch == seconds(3));
+  t -= seconds(1);
+  assert(t - epoch == seconds(2));
+
+  assert(time_point_cast<seconds>(later).time_since_epoch().count() == 5);
+  assert(system_clock::to_time_t(later) == (std::time_t)5);
+  assert(system_clock::from_time_t(7) == epoch + seconds(7));
+
+  // [time.clock.steady]: readings never go backwards.
+  auto a = steady_clock::now();
+  auto b = steady_clock::now();
+  assert(b >= a);
+  assert((b - a).count() >= 0);
+
+  auto h = high_resolution_clock::now();
+  assert(h >= b);
+
+  static_assert(steady_clock::is_steady, "steady_clock is steady");
+  static_assert(!system_clock::is_steady, "system_clock is not steady");
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/github_6984_time_point/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_6984_time_point/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/chrono
+++ b/src/cpp/library/chrono
@@ -4,18 +4,50 @@
 #if __cplusplus >= 201103L
 
 #include "cstdint"
+#include "ctime"
 #include "limits"
+#include "type_traits"
+
+extern long long __esbmc_nondet_clock_step();
 
 namespace std
 {
 
+namespace detail
+{
+// A class template, not a recursive constexpr function: the latter is also
+// emitted as a callable body, and symex then unwinds it (and can trip a
+// recursion unwinding assertion) even though every use here is compile-time.
+template <intmax_t A, intmax_t B>
+struct static_gcd
+{
+  static constexpr intmax_t value = static_gcd<B, A % B>::value;
+};
+template <intmax_t A>
+struct static_gcd<A, 0>
+{
+  static constexpr intmax_t value = A < 0 ? -A : A;
+};
+} // namespace detail
+
 template <intmax_t Num, intmax_t Den = 1>
 struct ratio
 {
-  static constexpr intmax_t num = Num;
-  static constexpr intmax_t den = Den;
-  using type = ratio<Num, Den>;
+  static_assert(Den != 0, "ratio denominator must not be zero");
+  // [ratio.ratio] p1: num/den are reduced and the sign lives on num.
+  static constexpr intmax_t num =
+    (Den < 0 ? -Num : Num) / detail::static_gcd<Num, Den>::value;
+  static constexpr intmax_t den =
+    (Den < 0 ? -Den : Den) / detail::static_gcd<Num, Den>::value;
+  using type = ratio<num, den>;
 };
+
+template <class R1, class R2>
+using ratio_multiply =
+  typename ratio<R1::num * R2::num, R1::den * R2::den>::type;
+template <class R1, class R2>
+using ratio_divide =
+  typename ratio<R1::num * R2::den, R1::den * R2::num>::type;
 
 using nano = ratio<1, 1000000000>;
 using micro = ratio<1, 1000000>;
@@ -23,6 +55,32 @@ using milli = ratio<1, 1000>;
 
 namespace chrono
 {
+
+template <class Rep, class Period = std::ratio<1>>
+class duration;
+
+template <class Clock, class Duration>
+class time_point;
+
+namespace detail
+{
+template <class T>
+struct is_duration : std::false_type
+{
+};
+template <class Rep, class Period>
+struct is_duration<duration<Rep, Period>> : std::true_type
+{
+};
+} // namespace detail
+
+template <class ToDur, class Rep, class Period>
+constexpr ToDur duration_cast(const duration<Rep, Period> &d);
+
+template <class Rep>
+struct treat_as_floating_point : std::is_floating_point<Rep>
+{
+};
 
 template <class Rep>
 struct duration_values
@@ -40,7 +98,7 @@ struct duration_values
   }
 };
 
-template <class Rep, class Period = std::ratio<1>>
+template <class Rep, class Period>
 class duration
 {
   Rep rep_;
@@ -50,13 +108,95 @@ public:
   using period = Period;
 
   constexpr duration() noexcept : rep_(0) {}
-  constexpr explicit duration(const Rep &r) noexcept : rep_(r) {}
   constexpr duration(const duration &) noexcept = default;
   duration &operator=(const duration &) noexcept = default;
+
+  template <
+    class Rep2,
+    class = typename std::enable_if<
+      std::is_convertible<const Rep2 &, Rep>::value &&
+      (treat_as_floating_point<Rep>::value ||
+       !treat_as_floating_point<Rep2>::value)>::type>
+  constexpr explicit duration(const Rep2 &r) noexcept : rep_(static_cast<Rep>(r))
+  {
+  }
+
+  // [time.duration.cons] p2: implicit only when the conversion cannot
+  // truncate, i.e. the period ratio divides exactly (or Rep is floating point).
+  template <
+    class Rep2,
+    class Period2,
+    class = typename std::enable_if<
+      treat_as_floating_point<Rep>::value ||
+      (std::ratio_divide<Period2, Period>::den == 1 &&
+       !treat_as_floating_point<Rep2>::value)>::type>
+  constexpr duration(const duration<Rep2, Period2> &d)
+    : rep_(duration_cast<duration>(d).count())
+  {
+  }
 
   constexpr Rep count() const noexcept
   {
     return rep_;
+  }
+
+  constexpr duration operator+() const
+  {
+    return *this;
+  }
+  constexpr duration operator-() const
+  {
+    return duration(-rep_);
+  }
+
+  duration &operator++()
+  {
+    ++rep_;
+    return *this;
+  }
+  duration operator++(int)
+  {
+    return duration(rep_++);
+  }
+  duration &operator--()
+  {
+    --rep_;
+    return *this;
+  }
+  duration operator--(int)
+  {
+    return duration(rep_--);
+  }
+
+  duration &operator+=(const duration &d)
+  {
+    rep_ += d.count();
+    return *this;
+  }
+  duration &operator-=(const duration &d)
+  {
+    rep_ -= d.count();
+    return *this;
+  }
+  duration &operator*=(const Rep &r)
+  {
+    rep_ *= r;
+    return *this;
+  }
+  duration &operator/=(const Rep &r)
+  {
+    rep_ /= r;
+    return *this;
+  }
+  duration &operator%=(const Rep &r)
+  {
+    rep_ %= r;
+    return *this;
+  }
+  duration &operator%=(const duration &d)
+  {
+    rep_ %= d.count();
+    return *this;
   }
 
   static constexpr duration zero() noexcept
@@ -73,67 +213,182 @@ public:
   }
 };
 
-template <class Rep, class Period>
-constexpr duration<Rep, Period>
-operator+(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
-{
-  return duration<Rep, Period>(a.count() + b.count());
-}
-template <class Rep, class Period>
-constexpr duration<Rep, Period>
-operator-(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
-{
-  return duration<Rep, Period>(a.count() - b.count());
-}
+} // namespace chrono
 
-template <class Rep, class Period>
-constexpr bool
-operator==(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+// [time.traits.specializations]
+template <class Rep1, class Period1, class Rep2, class Period2>
+struct common_type<
+  chrono::duration<Rep1, Period1>,
+  chrono::duration<Rep2, Period2>>
 {
-  return a.count() == b.count();
-}
-template <class Rep, class Period>
-constexpr bool
-operator!=(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+  using type = chrono::duration<
+    typename common_type<Rep1, Rep2>::type,
+    ratio<
+      detail::static_gcd<Period1::num, Period2::num>::value,
+      (Period1::den /
+       detail::static_gcd<Period1::den, Period2::den>::value) *Period2::den>>;
+};
+
+template <class Clock, class Duration1, class Duration2>
+struct common_type<
+  chrono::time_point<Clock, Duration1>,
+  chrono::time_point<Clock, Duration2>>
 {
-  return !(a == b);
-}
-template <class Rep, class Period>
-constexpr bool
-operator<(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+  using type =
+    chrono::time_point<Clock, typename common_type<Duration1, Duration2>::type>;
+};
+
+namespace chrono
 {
-  return a.count() < b.count();
-}
-template <class Rep, class Period>
-constexpr bool
-operator<=(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
-{
-  return !(b < a);
-}
-template <class Rep, class Period>
-constexpr bool
-operator>(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
-{
-  return b < a;
-}
-template <class Rep, class Period>
-constexpr bool
-operator>=(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
-{
-  return !(a < b);
-}
 
 template <class ToDur, class Rep, class Period>
 constexpr ToDur duration_cast(const duration<Rep, Period> &d)
 {
   using ToRep = typename ToDur::rep;
-  using ToPeriod = typename ToDur::period;
-  // d.count() * (Period::num / Period::den) / (ToPeriod::num / ToPeriod::den)
-  // == d.count() * Period::num * ToPeriod::den
-  //               / (Period::den * ToPeriod::num)
+  using CF = std::ratio_divide<Period, typename ToDur::period>;
+  using CR = typename std::common_type<ToRep, Rep, intmax_t>::type;
   return ToDur(static_cast<ToRep>(
-    (static_cast<intmax_t>(d.count()) * Period::num * ToPeriod::den) /
-    (Period::den * ToPeriod::num)));
+    static_cast<CR>(d.count()) * static_cast<CR>(CF::num) /
+    static_cast<CR>(CF::den)));
+}
+
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr
+  typename std::common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::
+    type
+    operator+(
+      const duration<Rep1, Period1> &lhs,
+      const duration<Rep2, Period2> &rhs)
+{
+  using CD = typename std::
+    common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+  return CD(CD(lhs).count() + CD(rhs).count());
+}
+
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr
+  typename std::common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::
+    type
+    operator-(
+      const duration<Rep1, Period1> &lhs,
+      const duration<Rep2, Period2> &rhs)
+{
+  using CD = typename std::
+    common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+  return CD(CD(lhs).count() - CD(rhs).count());
+}
+
+namespace detail
+{
+// Absent ::type when either operand is a duration, so the scalar overloads
+// drop out by substitution failure. common_type must stay out of the return
+// type: common_type<Rep, duration> is a hard error, not a SFINAE-friendly one.
+template <
+  class R1,
+  class R2,
+  bool = !is_duration<R1>::value && !is_duration<R2>::value>
+struct scalar_common
+{
+};
+template <class R1, class R2>
+struct scalar_common<R1, R2, true>
+{
+  using type = typename std::common_type<R1, R2>::type;
+};
+} // namespace detail
+
+template <class Rep1, class Period, class Rep2>
+constexpr duration<typename detail::scalar_common<Rep1, Rep2>::type, Period>
+operator*(const duration<Rep1, Period> &d, const Rep2 &s)
+{
+  using CR = typename detail::scalar_common<Rep1, Rep2>::type;
+  return duration<CR, Period>(static_cast<CR>(d.count()) * static_cast<CR>(s));
+}
+
+template <class Rep1, class Rep2, class Period>
+constexpr duration<typename detail::scalar_common<Rep1, Rep2>::type, Period>
+operator*(const Rep1 &s, const duration<Rep2, Period> &d)
+{
+  return d * s;
+}
+
+template <class Rep1, class Period, class Rep2>
+constexpr duration<typename detail::scalar_common<Rep1, Rep2>::type, Period>
+operator/(const duration<Rep1, Period> &d, const Rep2 &s)
+{
+  using CR = typename detail::scalar_common<Rep1, Rep2>::type;
+  return duration<CR, Period>(static_cast<CR>(d.count()) / static_cast<CR>(s));
+}
+
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr typename std::common_type<Rep1, Rep2>::type
+operator/(const duration<Rep1, Period1> &lhs, const duration<Rep2, Period2> &rhs)
+{
+  using CD = typename std::
+    common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+  return CD(lhs).count() / CD(rhs).count();
+}
+
+template <class Rep1, class Period, class Rep2>
+constexpr duration<typename detail::scalar_common<Rep1, Rep2>::type, Period>
+operator%(const duration<Rep1, Period> &d, const Rep2 &s)
+{
+  using CR = typename detail::scalar_common<Rep1, Rep2>::type;
+  return duration<CR, Period>(static_cast<CR>(d.count()) % static_cast<CR>(s));
+}
+
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr
+  typename std::common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::
+    type
+    operator%(
+      const duration<Rep1, Period1> &lhs,
+      const duration<Rep2, Period2> &rhs)
+{
+  using CD = typename std::
+    common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+  return CD(CD(lhs).count() % CD(rhs).count());
+}
+
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr bool
+operator==(const duration<Rep1, Period1> &a, const duration<Rep2, Period2> &b)
+{
+  using CD = typename std::
+    common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+  return CD(a).count() == CD(b).count();
+}
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr bool
+operator!=(const duration<Rep1, Period1> &a, const duration<Rep2, Period2> &b)
+{
+  return !(a == b);
+}
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr bool
+operator<(const duration<Rep1, Period1> &a, const duration<Rep2, Period2> &b)
+{
+  using CD = typename std::
+    common_type<duration<Rep1, Period1>, duration<Rep2, Period2>>::type;
+  return CD(a).count() < CD(b).count();
+}
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr bool
+operator<=(const duration<Rep1, Period1> &a, const duration<Rep2, Period2> &b)
+{
+  return !(b < a);
+}
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr bool
+operator>(const duration<Rep1, Period1> &a, const duration<Rep2, Period2> &b)
+{
+  return b < a;
+}
+template <class Rep1, class Period1, class Rep2, class Period2>
+constexpr bool
+operator>=(const duration<Rep1, Period1> &a, const duration<Rep2, Period2> &b)
+{
+  return !(a < b);
 }
 
 using nanoseconds = duration<long long, nano>;
@@ -142,6 +397,223 @@ using milliseconds = duration<long long, milli>;
 using seconds = duration<long long>;
 using minutes = duration<long long, ratio<60>>;
 using hours = duration<long long, ratio<3600>>;
+
+template <class Clock, class Duration = typename Clock::duration>
+class time_point
+{
+  Duration d_;
+
+public:
+  using clock = Clock;
+  using duration = Duration;
+  using rep = typename Duration::rep;
+  using period = typename Duration::period;
+
+  constexpr time_point() : d_(Duration::zero()) {}
+  constexpr explicit time_point(const Duration &d) : d_(d) {}
+
+  template <class Duration2>
+  constexpr time_point(const time_point<Clock, Duration2> &t)
+    : d_(t.time_since_epoch())
+  {
+  }
+
+  constexpr Duration time_since_epoch() const
+  {
+    return d_;
+  }
+
+  time_point &operator+=(const Duration &d)
+  {
+    d_ += d;
+    return *this;
+  }
+  time_point &operator-=(const Duration &d)
+  {
+    d_ -= d;
+    return *this;
+  }
+
+  static constexpr time_point min()
+  {
+    return time_point(Duration::min());
+  }
+  static constexpr time_point max()
+  {
+    return time_point(Duration::max());
+  }
+};
+
+template <class ToDur, class Clock, class Duration>
+constexpr time_point<Clock, ToDur>
+time_point_cast(const time_point<Clock, Duration> &t)
+{
+  return time_point<Clock, ToDur>(duration_cast<ToDur>(t.time_since_epoch()));
+}
+
+template <class Clock, class Duration1, class Rep2, class Period2>
+constexpr time_point<
+  Clock,
+  typename std::common_type<Duration1, duration<Rep2, Period2>>::type>
+operator+(
+  const time_point<Clock, Duration1> &tp,
+  const duration<Rep2, Period2> &d)
+{
+  using CT = time_point<
+    Clock,
+    typename std::common_type<Duration1, duration<Rep2, Period2>>::type>;
+  return CT(tp.time_since_epoch() + d);
+}
+
+template <class Rep1, class Period1, class Clock, class Duration2>
+constexpr time_point<
+  Clock,
+  typename std::common_type<duration<Rep1, Period1>, Duration2>::type>
+operator+(
+  const duration<Rep1, Period1> &d,
+  const time_point<Clock, Duration2> &tp)
+{
+  return tp + d;
+}
+
+template <class Clock, class Duration1, class Rep2, class Period2>
+constexpr time_point<
+  Clock,
+  typename std::common_type<Duration1, duration<Rep2, Period2>>::type>
+operator-(
+  const time_point<Clock, Duration1> &tp,
+  const duration<Rep2, Period2> &d)
+{
+  using CT = time_point<
+    Clock,
+    typename std::common_type<Duration1, duration<Rep2, Period2>>::type>;
+  return CT(tp.time_since_epoch() - d);
+}
+
+template <class Clock, class Duration1, class Duration2>
+constexpr typename std::common_type<Duration1, Duration2>::type operator-(
+  const time_point<Clock, Duration1> &lhs,
+  const time_point<Clock, Duration2> &rhs)
+{
+  return lhs.time_since_epoch() - rhs.time_since_epoch();
+}
+
+template <class Clock, class Duration1, class Duration2>
+constexpr bool operator==(
+  const time_point<Clock, Duration1> &lhs,
+  const time_point<Clock, Duration2> &rhs)
+{
+  return lhs.time_since_epoch() == rhs.time_since_epoch();
+}
+template <class Clock, class Duration1, class Duration2>
+constexpr bool operator!=(
+  const time_point<Clock, Duration1> &lhs,
+  const time_point<Clock, Duration2> &rhs)
+{
+  return !(lhs == rhs);
+}
+template <class Clock, class Duration1, class Duration2>
+constexpr bool operator<(
+  const time_point<Clock, Duration1> &lhs,
+  const time_point<Clock, Duration2> &rhs)
+{
+  return lhs.time_since_epoch() < rhs.time_since_epoch();
+}
+template <class Clock, class Duration1, class Duration2>
+constexpr bool operator<=(
+  const time_point<Clock, Duration1> &lhs,
+  const time_point<Clock, Duration2> &rhs)
+{
+  return !(rhs < lhs);
+}
+template <class Clock, class Duration1, class Duration2>
+constexpr bool operator>(
+  const time_point<Clock, Duration1> &lhs,
+  const time_point<Clock, Duration2> &rhs)
+{
+  return rhs < lhs;
+}
+template <class Clock, class Duration1, class Duration2>
+constexpr bool operator>=(
+  const time_point<Clock, Duration1> &lhs,
+  const time_point<Clock, Duration2> &rhs)
+{
+  return !(lhs < rhs);
+}
+
+namespace detail
+{
+// The clocks share one monotone tick counter: a reading is nondeterministic
+// but never earlier than the previous one, so steady_clock's
+// [time.clock.steady] guarantee holds instead of time being free to run
+// backwards between two now() calls.
+inline long long &clock_ticks()
+{
+  static long long ticks = 0;
+  return ticks;
+}
+
+inline long long advance_clock()
+{
+  long long &t = clock_ticks();
+  long long step = __esbmc_nondet_clock_step();
+  __ESBMC_assume(step >= 0);
+  __ESBMC_assume(t <= std::numeric_limits<long long>::max() - step);
+  t += step;
+  return t;
+}
+} // namespace detail
+
+struct system_clock
+{
+  // [time.clock.system] leaves the period implementation-defined and the
+  // choice is observable in verification (int64 nanoseconds saturate ~292
+  // years past the epoch, microseconds ~294247), so follow the target's
+  // standard library rather than picking one for every platform.
+#if defined(_WIN32)
+  using period = std::ratio<1, 10000000>;
+#elif defined(__APPLE__)
+  using period = std::micro;
+#else
+  using period = std::nano;
+#endif
+  using rep = long long;
+  using duration = std::chrono::duration<rep, period>;
+  using time_point = std::chrono::time_point<system_clock, duration>;
+  static constexpr bool is_steady = false;
+
+  static time_point now() noexcept
+  {
+    return time_point(duration(detail::advance_clock()));
+  }
+
+  static std::time_t to_time_t(const time_point &t) noexcept
+  {
+    return static_cast<std::time_t>(
+      duration_cast<seconds>(t.time_since_epoch()).count());
+  }
+
+  static time_point from_time_t(std::time_t t) noexcept
+  {
+    return time_point(duration_cast<duration>(seconds(t)));
+  }
+};
+
+struct steady_clock
+{
+  using period = std::nano;
+  using rep = long long;
+  using duration = std::chrono::duration<rep, period>;
+  using time_point = std::chrono::time_point<steady_clock, duration>;
+  static constexpr bool is_steady = true;
+
+  static time_point now() noexcept
+  {
+    return time_point(duration(detail::advance_clock()));
+  }
+};
+
+using high_resolution_clock = steady_clock;
 
 } // namespace chrono
 } // namespace std


### PR DESCRIPTION
Adds `time_point`/`time_point_cast`, `system_clock`/`steady_clock`/`high_resolution_clock`, the exact-conversion `duration` constructor and the missing mixed-period, scalar, unary and compound operators; `ratio` now reduces per [ratio.ratio] p1 and `<chrono>` pulls in `<ctime>`.

`system_clock::period` follows the target standard library rather than a fixed choice, since the saturation point is observable in verification. `now()` reads a shared monotone nondeterministic counter, so `steady_clock` never runs backwards without pinning the clock to a constant.

Four regression tests, including a negative one that fails if the clocks become constants.

Fixes #6984.