### PR TITLE
[symex] Don't allocate *strp on the asprintf failure path

### DIFF
--- a/regression/esbmc/github_6966/main.c
+++ b/regression/esbmc/github_6966/main.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int __VERIFIER_nondet_int(void);
+
+/* Mirrors busybox bb_verror_msg: a runtime format string leaves the return
+   value unbounded, so the asprintf failure path is reachable. POSIX leaves
+   *strp undefined on failure, so returning without freeing is correct and
+   must not be reported as a leak. */
+static void log_msg(const char *fmt)
+{
+  char *msg;
+  int used = asprintf(&msg, fmt, 1);
+  if (used < 0)
+    return;
+  free(msg);
+}
+
+int main(void)
+{
+  const char *fmt = __VERIFIER_nondet_int() ? "%d" : "x%d";
+  log_msg(fmt);
+  return 0;
+}

--- a/regression/esbmc/github_6966/test.desc
+++ b/regression/esbmc/github_6966/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --malloc-zero-is-null --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_6966_discarded/main.c
+++ b/regression/esbmc/github_6966_discarded/main.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int __VERIFIER_nondet_int(void);
+
+/* Discarding the asprintf result leaves no return lvalue to guard the
+   allocation with, so the buffer is allocated unconditionally and the caller
+   owns it on every path (#6966). */
+int main(void)
+{
+  const char *fmt = __VERIFIER_nondet_int() ? "%d" : "x%d";
+  char *msg;
+  asprintf(&msg, fmt, 1);
+  free(msg);
+  return 0;
+}

--- a/regression/esbmc/github_6966_discarded/test.desc
+++ b/regression/esbmc/github_6966_discarded/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --malloc-zero-is-null --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_6966_fail/main.c
+++ b/regression/esbmc/github_6966_fail/main.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int __VERIFIER_nondet_int(void);
+
+/* The success path still owns the buffer: dropping it is a genuine leak and
+   must stay detected after the failure path stopped allocating (#6966). */
+int main(void)
+{
+  const char *fmt = __VERIFIER_nondet_int() ? "%d" : "x%d";
+  char *msg;
+  int used = asprintf(&msg, fmt, 1);
+  if (used < 0)
+    return 0;
+  return 0;
+}

--- a/regression/esbmc/github_6966_fail/test.desc
+++ b/regression/esbmc/github_6966_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --malloc-zero-is-null --incremental-bmc
+^VERIFICATION FAILED$
+^\s*dereference failure: forgotten memory: dynamic_1_value$

--- a/src/goto-symex/builtin_functions/io.cpp
+++ b/src/goto-symex/builtin_functions/io.cpp
@@ -410,6 +410,11 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     args.push_back(tmp);
   });
 
+  // The value assigned to the return lvalue, nil when the result is discarded.
+  // Needed below to keep the asprintf/vasprintf *strp allocation off the
+  // failure path.
+  expr2tc retval;
+
   if (!is_nil_expr(lhs))
   {
     // get the return value from code_printf2tc
@@ -511,14 +516,12 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     //    >1 GB formatted string — infeasible in practice. Tightening further
     //    would risk masking real overflows; see also GitHub #4976-#4979.
     const bool sound_bound = format_is_constant && printf_formatter.bounded;
-    const bool is_allocating = new_rhs.kind == printf_kindt::ASPRINTF ||
-                               new_rhs.kind == printf_kindt::VASPRINTF;
     if (
       sound_bound && printf_formatter.min_outlen == printf_formatter.max_outlen)
     {
-      symex_assign(code_assign2tc(
-        lhs,
-        constant_int2tc(int_type2(), BigInt(printf_formatter.max_outlen))));
+      retval =
+        constant_int2tc(int_type2(), BigInt(printf_formatter.max_outlen));
+      symex_assign(code_assign2tc(lhs, retval));
     }
     else
     {
@@ -530,6 +533,7 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
         type2tc(),
         sideeffect2t::allockind::nondet);
       replace_nondet(nondet);
+      retval = nondet;
       if (sound_bound)
       {
         expr2tc lo =
@@ -563,6 +567,15 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
   // should be aware of this limitation.
   if (is_allocating && !is_nil_expr(strp) && is_pointer_type(strp->type))
   {
+    // Only the success path allocates. POSIX leaves *strp undefined when the
+    // call fails, so the caller owns nothing and correctly returns without
+    // freeing; allocating unconditionally orphans the buffer on that path and
+    // trips --memory-leak-check (GitHub #6966). The guard reaches the object's
+    // allocation guard via symex_mem, so the leak check is scoped too.
+    guard2tc alloc_guard;
+    if (!is_nil_expr(retval))
+      alloc_guard.add(greaterthanequal2tc(retval, gen_zero(retval->type)));
+
     // Derive char * from strp's declared type (char **) so the dereference
     // width matches what the value-set analysis and SMT encoding expect.
     type2tc char_ptr_type = to_pointer_type(strp->type).subtype;
@@ -574,7 +587,7 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
       std::vector<expr2tc>(),
       char_type2(),
       sideeffect2t::allockind::malloc);
-    symex_assign(code_assign2tc(deref_strp, malloc_se));
+    symex_assign(code_assign2tc(deref_strp, malloc_se), false, alloc_guard);
   }
 
   target->output(


### PR DESCRIPTION
`symex_printf` allocated the asprintf/vasprintf output buffer unconditionally while assuming the return value into `[-1, INT_MAX/2]`, so the solver could pick the `-1` failure value on a path that had nonetheless allocated. POSIX leaves `*strp` undefined on failure, so a correct caller returns without freeing and the buffer was reported as forgotten memory.

Guards the allocation on a non-negative return; the guard reaches the object's allocation guard via `symex_mem`, so the leak check is scoped too. Three regression tests cover the failure path, the success path (still a genuine leak) and the discarded-result path.

Fixes #6966.