### PR TITLE
[python] Cast any non-code pointer callee to a function pointer

### DIFF
--- a/regression/python/github_6640_runtime_callable/main.py
+++ b/regression/python/github_6640_runtime_callable/main.py
@@ -1,0 +1,21 @@
+# A callable returned by a function without a return annotation: the frontend
+# types the value None (bool*), so the indirect call needs the generic
+# function-pointer cast the adjuster relies on. Without it ESBMC aborted on
+# to_code_type's `type.id() == typet::t_code` (#6640).
+def inc(m: int) -> int:
+    return m + 1
+
+
+def century(m: int) -> int:
+    return m + 100
+
+
+def pick(c: bool):
+    return inc if c else century
+
+
+first = pick(True)
+assert first(1) == 2
+
+second = pick(False)
+assert second(1) == 101

--- a/regression/python/github_6640_runtime_callable/test.desc
+++ b/regression/python/github_6640_runtime_callable/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6640_runtime_callable_fail/main.py
+++ b/regression/python/github_6640_runtime_callable_fail/main.py
@@ -1,0 +1,17 @@
+# The call must dispatch to the callable that was actually selected, not to
+# whichever name the frontend saw first: pick(False) is century, so expecting
+# inc's result has to be refuted (#6640).
+def inc(m: int) -> int:
+    return m + 1
+
+
+def century(m: int) -> int:
+    return m + 100
+
+
+def pick(c: bool):
+    return inc if c else century
+
+
+chosen = pick(False)
+assert chosen(1) == 2

--- a/regression/python/github_6640_runtime_callable_fail/test.desc
+++ b/regression/python/github_6640_runtime_callable_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -772,13 +772,16 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       call.location() = get_location_from_decl(element);
 
       // The function pointer itself, not dereferenced.
-      // For Any-typed (void*) parameters, cast to a generic function pointer
-      // so that the adjuster can dereference it to a code type (it calls
-      // to_code_type on the dereferenced subtype, which would fail on void).
+      // Any pointer whose pointee is not code needs the cast to a generic
+      // function pointer: the adjuster dereferences the callee and calls
+      // to_code_type on the result, which asserts on anything else. Any-typed
+      // (void*) parameters get here, and so does a callable returned by an
+      // unannotated function, which the frontend types None, i.e. bool*
+      // (#6640).
       // V.3: build the function-pointer reference (and the generic-pointer
       // cast the adjuster relies on) in IREP2; both are over a clean symbol.
       exprt func_ptr_expr = python_expr::build_symbol(*var_symbol);
-      if (var_symbol->get_type() == any_type())
+      if (!var_symbol->get_type().subtype().is_code())
         func_ptr_expr = python_expr::build_typecast(
           func_ptr_expr, gen_pointer_type(code_typet()));
       call.function() = func_ptr_expr;


### PR DESCRIPTION
An indirect call through a name whose symbol is a pointer got the generic function-pointer cast only when the symbol was Any-typed (`void*`). A callable returned by a function without a return annotation is typed None (`bool*`) instead, so the cast was skipped and the adjuster's `to_code_type` on the dereferenced callee aborted ESBMC.

Widening the test to any non-code pointee also makes the call dispatch to the callable that was actually selected — the two new tests pin both branches, and the `_fail` one is refuted for the other callable's result.

The remaining #6640 shapes (`List[Callable]` elements, and a callable chosen under a nondeterministic condition) are unaffected, so this is a step rather than a close.

Part of #6640.