### PR TITLE
[contracts] Accept either call in the nested-clause diagnostic

### DIFF
--- a/regression/function_contract/clause_call_nested/test.desc
+++ b/regression/function_contract/clause_call_nested/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --enforce-contract f --function f
-^ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@inner', whose result the clause cannot name outside the function body$
+^ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@(inner|outer)', whose result the clause cannot name outside the function body$


### PR DESCRIPTION
clause_call_nested pins which call the walk names for `outer(inner(x))`, and that is not stable. The same ubuntu leg produced `inner` on one run (#6970) and `outer` on another (#6982) with src/goto-programs/contracts unchanged since #6944, so either name is flaky.

Accept both until the traversal is made deterministic. My earlier #6980 swapped the expectation from `outer` to `inner` on a single local measurement; that was treating a flake as a fixed value, and this supersedes it.

Refs #6944