### PR TITLE
[clang-c] Emit lshr/ashr at conversion instead of an untyped shr

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -2502,3 +2502,68 @@ Metric under `--clang-c-irep2-adjust-only`: **1 808 of 2 809 diverge**, of which
 Next: the remaining 304. `shr` (64 tests) and `builtin_va_arg` (6) are
 `adjust_expr_shifts` and `adjust_builtin_va_arg` (§68.2); the rest need the same
 reduce-then-classify treatment this section applied.
+
+## 72. `shr` shows the hop-off's ordering is not universally satisfiable
+
+§71 put the shift arm next: `shr` is 64 of the tests still erroring under
+`-only`, and 10 of the 14 real errors in the §70 sample. It does not port, and
+the reason is about the `-only` architecture rather than the arm.
+
+### 72.1 The 10 `PARSING ERROR`s are not ours
+
+First, §68.3's unattributed row, resolved: all 10 fail flag-off as well. They are
+pre-existing parse failures, not `-only` failures, and they should be subtracted
+from every error count in §68-§71. The sample's 24 errors are 14.
+
+### 72.2 IREP2 has no untyped shift, and the choice needs the promotion
+
+`clang_c_adjust::adjust_expr_shifts` promotes both operands
+(`gen_typecast_arithmetic`) and *then* reads `op0.type()` to pick `lshr` for
+unsigned or `ashr` for signed. IREP2 has `lshr2t`, `ashr2t` and `shl2t` and no
+signedness-agnostic `shr`, so a raw `shr` is not representable: migration must
+make the arm's choice.
+
+It cannot make it correctly. `-only` migrates a symbol's whole value up front,
+before any native arm runs, so the only type available is the **unpromoted**
+one, and promotion changes it:
+
+```c
+unsigned char x = 200;
+int y = x >> 1;      // flag-off: ASSIGN y=(signed int)x >> 1
+```
+
+`x` is `unsignedbv` before promotion and `signedbv` after, so a migration-time
+decision picks `lshr` where the arm picks `ashr`. For a promoted `unsigned char`
+the two agree numerically -- the promoted value cannot be negative -- so this is
+a byte-identity failure rather than a wrong answer. Byte-identity is the gate.
+
+### 72.3 What this bounds
+
+The hop-off's order is *migrate, then adjust natively*. That is only satisfiable
+when every construct's IREP2 form is determined **before** adjustment. `shr` is
+the first proof that it is not: its node kind is a *result* of adjustment.
+
+So teaching `migrate_expr` about `shr` is not the fix -- it would have to
+duplicate the promotion to be right, which is the arm. The resolutions are:
+
+1. **Decide earlier.** Have the converter emit `ashr`/`lshr` directly; it knows
+   the operand types and C11 6.5.7p3's promotion rule. This changes flag-off
+   output and needs its own A/B, but it removes the construct from the adjuster
+   entirely.
+2. **Adjust before migrating**, i.e. keep the legacy pass -- which is what
+   shadow mode already does, and what `-only` exists to stop doing.
+3. **Construct natively end to end** (C.2), where no migration boundary exists
+   and the question does not arise.
+
+Only (1) and (3) make progress. (1) is a small, self-contained change and is the
+next step; (3) is the phase's actual goal and this is evidence for taking the
+converter, not the adjuster, as its vehicle.
+
+## 73. Status
+
+Metric under `--clang-c-irep2-adjust-only`: 1 808 of 2 809 diverge; **304 error,
+of which the pre-existing parse failures (§72.1) are not ours**. Shadow mode: 2,
+both the §62 VLA defect.
+
+Next: §72.3 option 1 -- emit `ashr`/`lshr` from the converter -- measured
+flag-off first, since it moves output on the default path.

--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -2567,3 +2567,67 @@ both the §62 VLA defect.
 
 Next: §72.3 option 1 -- emit `ashr`/`lshr` from the converter -- measured
 flag-off first, since it moves output on the default path.
+
+## 74. The shift kind, decided at conversion
+
+§72.3 left two viable routes for `shr`; this takes option 1. `clang_c_convert`
+now emits `lshr` or `ashr` directly instead of a signedness-agnostic `shr`.
+
+### 74.1 Why the converter can decide and migration cannot
+
+Clang has already applied the integer promotion by the time the converter sees
+the node, and records it as an `ImplicitCastExpr <IntegralCast>`:
+
+```
+BinaryOperator 'int' '>>'
+|-ImplicitCastExpr 'int' <IntegralCast>
+| `-ImplicitCastExpr 'unsigned char' <LValueToRValue>
+`-IntegerLiteral 'int' 1
+```
+
+C11 6.5.7p3 gives the result the type of the *promoted* left operand, so the
+node's own type is exactly the signedness `adjust_expr_shifts` computes. One
+ternary, no promotion logic duplicated -- which is the difference from teaching
+`migrate_expr` the same trick (§72.2), where only the unpromoted type exists.
+
+### 74.2 The A/B caught a dispatcher bug
+
+`clang_c_adjust::adjust_expr` routes to the shift arm on
+`id() == "shl" || id() == "shr"`. Emitting the typed ids moved those nodes out
+of its reach, so the arm stopped running -- and the two things it does besides
+choosing the kind, `gen_typecast_arithmetic` on both operands and
+`expr.type() = op0.type()`, sit *outside* the `shr` branch and apply to every
+shift. One default-path divergence (`esbmc/github_323`) and 46 bytes of missing
+casts. The fix is both halves: emit the typed id **and** route it.
+
+Generalises: moving a decision earlier can silently detach a node from a
+dispatcher keyed on the old spelling. Grep for the id being replaced is part of
+the change, not a follow-up.
+
+### 74.3 The gate cannot see this change
+
+`c_expr2string` prints `ashr` and `lshr` identically as `>>`, so flipping the
+kind produces a byte-identical dump. The clean A/B (0 of 2 809 on the default
+path) says the surrounding structure is unchanged and **nothing** about the
+choice -- §39.1's fourth row, met for the first time in this phase.
+
+So the gate is a semantic test: for `a >= 0x80000000`, `a >> 1 < 0x80000000`
+holds under a logical shift and fails under an arithmetic one. Nondeterministic
+input, so it cannot be constant-folded. `regression/esbmc/shift_kind_unsigned`,
+mutation-checked -- flipping the ternary fails it.
+
+The typedef case is covered there too: `t` resolves for integer typedefs, so
+`u32 >> 1` picks `lshr`. That was a live risk, since the arm follows the type
+(`ns.follow(op0.type())`) and the converter does not.
+
+## 75. Status
+
+`shr` no longer errors under `-only` (64 tests). Default path byte-identical.
+Remaining sampled `-only` errors: 4 `assign_shr`, 2 `and takes boolean operands
+only`, 1 `sizeof` arity, 1 `do_function_call` member callee -- plus 10
+pre-existing parse failures that are not ours (§72.1).
+
+Next: `assign_shr`, the same class one level up. `adjust_side_effect_assignment`
+picks `assign_lshr`/`assign_ashr` from the **unpromoted** LHS type, which the
+converter also has, so option 1 applies again -- with its own default-path A/B
+and its own semantic test, since the printer is blind here too.

--- a/regression/esbmc/shift_kind_unsigned/main.c
+++ b/regression/esbmc/shift_kind_unsigned/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+typedef unsigned int u32;
+unsigned int nondet_uint(void);
+int main(void)
+{
+  u32 a = nondet_uint();
+  __ESBMC_assume(a >= 0x80000000u);
+  /* logical shift: a>>1 <= 0x7FFFFFFF.  arithmetic shift would give >=0xC0000000 */
+  assert((a >> 1) < 0x80000000u);
+  u32 c = a;
+  c >>= 1;
+  assert(c < 0x80000000u);
+  return 0;
+}

--- a/regression/esbmc/shift_kind_unsigned/test.desc
+++ b/regression/esbmc/shift_kind_unsigned/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -76,6 +76,14 @@ void clang_c_adjust::adjust_symbol(symbolt &symbol)
   }
 }
 
+/// The four shift ids the adjuster handles together: the C-level `shl`/`shr`
+/// the parser still emits, and the signed/unsigned `ashr`/`lshr` this
+/// conversion now produces.
+static bool is_shift_id(const irep_idt &id)
+{
+  return id == "shl" || id == "shr" || id == "ashr" || id == "lshr";
+}
+
 void clang_c_adjust::adjust_expr(exprt &expr)
 {
   adjust_type(expr.type());
@@ -150,9 +158,7 @@ void clang_c_adjust::adjust_expr(exprt &expr)
       expr.type().id() != "bool")
       gen_typecast(ns, expr.op0(), expr.type());
   }
-  else if (
-    expr.id() == "shl" || expr.id() == "shr" || expr.id() == "ashr" ||
-    expr.id() == "lshr")
+  else if (is_shift_id(expr.id()))
   {
     adjust_expr_shifts(expr);
   }
@@ -440,9 +446,7 @@ void clang_c_adjust::adjust_member(member_exprt &expr)
 
 void clang_c_adjust::adjust_expr_shifts(exprt &expr)
 {
-  assert(
-    expr.id() == "shr" || expr.id() == "shl" || expr.id() == "ashr" ||
-    expr.id() == "lshr");
+  assert(is_shift_id(expr.id()));
 
   adjust_operands(expr);
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -150,7 +150,9 @@ void clang_c_adjust::adjust_expr(exprt &expr)
       expr.type().id() != "bool")
       gen_typecast(ns, expr.op0(), expr.type());
   }
-  else if (expr.id() == "shl" || expr.id() == "shr")
+  else if (
+    expr.id() == "shl" || expr.id() == "shr" || expr.id() == "ashr" ||
+    expr.id() == "lshr")
   {
     adjust_expr_shifts(expr);
   }
@@ -438,7 +440,9 @@ void clang_c_adjust::adjust_member(member_exprt &expr)
 
 void clang_c_adjust::adjust_expr_shifts(exprt &expr)
 {
-  assert(expr.id() == "shr" || expr.id() == "shl");
+  assert(
+    expr.id() == "shr" || expr.id() == "shl" || expr.id() == "ashr" ||
+    expr.id() == "lshr");
 
   adjust_operands(expr);
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -4334,7 +4334,12 @@ bool clang_c_convertert::get_binary_operator_expr(
     break;
 
   case clang::BO_Shr:
-    new_expr = exprt("shr", t);
+    // C11 6.5.7p3: the operands are promoted and the result has the type of
+    // the promoted left operand, which is `t`. IREP2 has no signedness-
+    // agnostic shift, and the choice cannot be made after conversion without
+    // redoing that promotion (scope-clang-c-irep2.md §72), so make it here
+    // where clang has already applied it.
+    new_expr = exprt(t.id() == "unsignedbv" ? "lshr" : "ashr", t);
     break;
 
   case clang::BO_Rem:


### PR DESCRIPTION
§72.3 left two viable routes for `shr`; this takes option 1. `clang_c_convert`
now emits `lshr`/`ashr` directly instead of a signedness-agnostic `shr`.

**Why the converter can decide and migration cannot.** Clang has already applied
the integer promotion and records it as an `ImplicitCastExpr <IntegralCast>`, and
C11 6.5.7p3 gives the result the type of the *promoted* left operand — so the
node's own type is exactly the signedness `adjust_expr_shifts` computes. One
ternary, no promotion logic duplicated, which is the difference from teaching
`migrate_expr` the same trick (§72.2) where only the unpromoted type exists.

**The A/B caught a dispatcher bug.** `adjust_expr` routes to the shift arm on
`id() == "shl" || id() == "shr"`, so emitting the typed ids moved those nodes out
of its reach and the arm stopped running — losing `gen_typecast_arithmetic` on
both operands and `expr.type() = op0.type()`, which sit *outside* the `shr`
branch. One default-path divergence (`esbmc/github_323`), 46 bytes of missing
casts. Fixed by routing the new ids as well. Generalises: moving a decision
earlier can silently detach a node from a dispatcher keyed on the old spelling.

**The gate cannot see this change.** `c_expr2string` prints both kinds as `>>`,
so flipping the choice yields a byte-identical dump — §39.1's fourth row. The
clean A/B (**0 of 2 809** on the default path) says the surrounding structure is
unchanged and nothing about the choice. So the gate is semantic: for
`a >= 0x80000000`, `a >> 1 < 0x80000000` holds under a logical shift and fails
under an arithmetic one, with nondeterministic input so it cannot be folded.
`regression/esbmc/shift_kind_unsigned` is mutation-checked — flipping the ternary
fails it. The typedef case is covered too, which was a live risk since the arm
follows the type and the converter does not.

`shr` no longer errors under `-only` (64 tests). `cstd` 142/142,
`clang_builtins|llvm|floats` 215/215. Stacked on #7002. Refs #4715