### PR TITLE
[clang-c] Convert boolean operands natively under the IREP2 hop-off

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -2679,3 +2679,54 @@ Next: `and takes boolean operands only` -- `migrate.cpp:1118` asserting because
 the boolean arms have not run. §58.1 showed those arms' type write is dead for C
 (the converter already emits bool), so the assert is firing on operands, not on
 the node: worth reducing before assuming which.
+
+## 78. The boolean arms port after all -- in this shape
+
+§58 withdrew `adjust_expr_binary_boolean` and `adjust_expr_unary_boolean`
+because the *dispatch-point round trip* was quadratic on `&&` chains. That was
+an objection to the shape, not the arm. Under `-only` the walk migrates a symbol
+once and never round-trips per node, so the same arm goes in without the cost,
+and their live half -- the operand conversion, §58.1 -- is now native.
+
+This is the first evidence that `-only` absorbs work the other two shapes
+rejected, which is a point in favour of §60.3's third route beyond its being the
+last one standing.
+
+### 78.1 The reduction took three attempts
+
+The error is `goto_convert`'s short-circuit lowering rejecting a non-boolean
+operand (`goto_sideeffects.cpp:1267`), so a bare `x && f()` looks like it should
+fail. It does not, and neither does the same condition in an `if`. What fails:
+
+```c
+int foo(int x) { return 1; }
+int main(void) { int il; for (il = 0; foo(il) && il < 2; ++il) {} return 0; }
+```
+
+A call on the **left** of `&&`, in a **`for`** condition. Fixing this from the
+error message alone would have meant patching against a case that could not be
+triggered -- and the message names the check, not the shape that reaches it.
+
+### 78.2 Gate
+
+Default path byte-identical (0 of 2 809); shadow mode unchanged at 2, both the
+§62 VLA defect. `regression/esbmc/irep2_only_boolean_operands` pins the fix by
+the `(_Bool)` cast on the call result; disabling the conversion makes ESBMC abort
+and fails it.
+
+The first `test.desc` regex was written from a guess at the lowering and did not
+match: the condition becomes
+`IF !((_Bool)return_value$_foo$1 ? il < 2 ? 1 : 0 : 0)`, a ternary. Read the
+output before writing the pattern.
+
+## 79. Status
+
+Sampled `-only` errors: **12, of which 10 are the pre-existing parse failures**
+(§72.1) -- so **2 real**: one `sizeof` arity, one `do_function_call` member
+callee. `llvm/sizeof` and `llvm/struct_method` are the two tests.
+
+Next: the `sizeof` arity error. `migrate.cpp:783` aborts on a one-operand
+`sizeof`, which `adjust_sizeof` fills for VLAs -- and §55.5 already found that
+arm blocked on exactly this, from the other direction. That makes it a migration
+ordering question like §72's `shr`, not a port: check whether the converter can
+supply the value operand before assuming the arm must.

--- a/regression/esbmc/irep2_only_boolean_operands/main.c
+++ b/regression/esbmc/irep2_only_boolean_operands/main.c
@@ -1,0 +1,9 @@
+int foo(int x) { return 1; }
+int main(void)
+{
+  int il;
+  for (il = 0; foo(il) && il < 2; ++il)
+  {
+  }
+  return 0;
+}

--- a/regression/esbmc/irep2_only_boolean_operands/test.desc
+++ b/regression/esbmc/irep2_only_boolean_operands/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--goto-functions-only --clang-c-irep2-adjust-only
+IF !\(\(_Bool\)return_value\$_foo\$1 \?

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -56,6 +56,17 @@ void clang_c_adjust_irep2::adjust_expr(expr2tc &expr)
   else if (
     sole_adjuster && (is_code_function_call2t(expr) || is_sideeffect2t(expr)))
     declare_implicit_callee(expr);
+
+  if (sole_adjuster && (is_and2t(expr) || is_or2t(expr) || is_not2t(expr)))
+    adjust_boolean_operands(expr);
+}
+
+void clang_c_adjust_irep2::adjust_boolean_operands(expr2tc &expr)
+{
+  expr->Foreach_operand([this](expr2tc &op) {
+    if (!is_nil_expr(op) && !is_bool_type(op->type))
+      c_implicit_typecast(op, get_bool_type(), ns);
+  });
 }
 
 void clang_c_adjust_irep2::declare_implicit_callee(const expr2tc &expr)

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -66,6 +66,13 @@ private:
   /// rewrite, so it ports independently of the rest of that arm (§70).
   void declare_implicit_callee(const expr2tc &expr);
 
+  /// IREP2 form of clang_c_adjust::adjust_expr_{unary,binary}_boolean's live
+  /// half. Their type write is dead for C (§58.1); the operand conversion is
+  /// not -- goto_convert's short-circuit lowering rejects a non-boolean operand
+  /// outright. Portable here, unlike §58's dispatch-point shape, because this
+  /// walk migrates once and does not round-trip per node (§78).
+  void adjust_boolean_operands(expr2tc &expr);
+
   contextt &context;
   const bool sole_adjuster;
   namespacet ns{context};


### PR DESCRIPTION
§58 withdrew `adjust_expr_binary_boolean` and `adjust_expr_unary_boolean` because
the *dispatch-point round trip* was quadratic on `&&` chains. That was an
objection to the shape, not the arm. Under `-only` the walk migrates a symbol
once and never round-trips per node, so the same arm goes in without the cost,
and their live half — the operand conversion (§58.1) — is now native.

First evidence that `-only` absorbs work the other two shapes rejected, which is
a point in favour of §60.3's third route beyond its being the last one standing.

**The reduction took three attempts.** The error is `goto_convert`'s
short-circuit lowering rejecting a non-boolean operand
(`goto_sideeffects.cpp:1267`), so a bare `x && f()` looks like it should fail. It
does not, and neither does the same condition in an `if`. What fails:

```c
int foo(int x) { return 1; }
int main(void) { int il; for (il = 0; foo(il) && il < 2; ++il) {} return 0; }
```

A call on the **left** of `&&`, in a **`for`** condition. The message names the
check, not the shape that reaches it — fixing from the message alone would have
meant patching against a case I could not trigger.

**Gate.** Default path byte-identical (**0 of 2 809**); shadow mode unchanged at
**2**, both the §62 VLA defect. `regression/esbmc/irep2_only_boolean_operands`
pins the fix by the `(_Bool)` cast on the call result, and disabling the
conversion makes ESBMC abort and fails it. Gated on sole ownership, since the
legacy arm does the same work in shadow mode.

Sampled `-only` errors now **12, of which 10 are pre-existing parse failures** —
2 real ones left. `cstd` 142/142. Stacked on #7004. Refs #4715