### PR TITLE
[contracts] Name the first call the program reaches

### DIFF
--- a/regression/function_contract/clause_call_nested/test.desc
+++ b/regression/function_contract/clause_call_nested/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --enforce-contract f --function f
-^ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@(inner|outer)', whose result the clause cannot name outside the function body$
+^ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@inner', whose result the clause cannot name outside the function body$

--- a/regression/function_contract/clause_call_nested_three/main.c
+++ b/regression/function_contract/clause_call_nested_three/main.c
@@ -1,0 +1,30 @@
+// clause_call_nested with a third level. The data dependency fixes the order
+// the calls are reached in, so the diagnostic has one right answer; with three
+// candidates an ordering that is not the program's is unlikely to agree with it
+// by chance.
+int innermost(int x)
+{
+  return x;
+}
+int middle(int x)
+{
+  return x;
+}
+int outermost(int x)
+{
+  return x;
+}
+
+int f(int x)
+{
+  __ESBMC_requires(outermost(middle(innermost(x))) > 100);
+  __ESBMC_ensures(__ESBMC_return_value > 100);
+  return x;
+}
+
+int main(void)
+{
+  int n;
+  __ESBMC_assume(n > 200);
+  return f(n);
+}

--- a/regression/function_contract/clause_call_nested_three/test.desc
+++ b/regression/function_contract/clause_call_nested_three/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enforce-contract f --function f
+^ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@innermost', whose result the clause cannot name outside the function body$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -422,10 +422,19 @@ std::string code_contractst::clause_call_callee(const goto_programt &body) const
   if (referenced.empty())
     return std::string();
 
-  for (const goto_programt::const_targett &call_it :
-       select_clause_calls(referenced, declared_in(body), body))
-    return id2string(
-      to_symbol2t(to_code_function_call2t(call_it->code).function).thename);
+  // The set is ordered by instruction address, not by position: operator< on a
+  // const_targett is `&*i1 < &*i2` (goto_program.cpp) and instructiont lives in
+  // a std::list, so its first element is whichever node the allocator placed
+  // lowest. With two eligible calls that names an arbitrary one of them, and a
+  // different one on a build whose heap is laid out differently. Walk the body
+  // for the first call the program reaches instead.
+  const std::set<goto_programt::const_targett> selected =
+    select_clause_calls(referenced, declared_in(body), body);
+
+  forall_goto_program_instructions (it, body)
+    if (selected.count(it))
+      return id2string(
+        to_symbol2t(to_code_function_call2t(it->code).function).thename);
 
   return std::string();
 }


### PR DESCRIPTION
Makes the traversal deterministic, which is what #7000 said it was waiting for.

`clause_call_callee` returned the first element of a `std::set<goto_programt::const_targett>`, and the comparator for those is an address compare:

```cpp
// src/goto-programs/goto_program.cpp:215
bool operator<(const goto_programt::const_targett i1,
               const goto_programt::const_targett i2)
{
  const goto_programt::instructiont &_i1 = *i1;
  const goto_programt::instructiont &_i2 = *i2;
  return &_i1 < &_i2;
}
```

`instructiont` lives in a `std::list`, so each one is separately allocated and "first" means "lowest heap address". With more than one eligible call the diagnostic names an arbitrary one of them.

### The reproducer is one environment variable

Same binary, same input, unmodified master, no rebuild:

```
$ esbmc --enforce-contract f --function f regression/function_contract/clause_call_nested/main.c
ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@inner', ...

$ MALLOC_MMAP_THRESHOLD_=1024 esbmc --enforce-contract f --function f <same file>
ERROR: --enforce-contract: cannot use 'f': a contract clause calls 'c:@F@outer', ...
```

`GLIBC_TUNABLES=glibc.malloc.tcache_count=0` flips it the same way; `MALLOC_ARENA_MAX=1` flips the three-call case. Nothing about the program under verification changes. That is the same effect as #6970 and #6982 disagreeing on one ubuntu leg — the runner's heap differs run to run, and the walk follows the heap.

### The fix

Walk the body and report the first call in it. That is the order #6944 describes ("the first call the walk reaches"). Membership is all the set was ever used for here, so it stays a set; only the choice of which element to report changes.

`clause_call_nested` goes back to asserting `c:@F@inner` instead of accepting either, since there is now one answer.

### Test

`clause_call_nested_three` nests one level deeper. The data dependency fixes the order the calls are reached in, so the diagnostic has one right answer, and with three candidates an ordering that is not the program's is unlikely to agree with it by chance. On master it names `c:@F@outermost` in a plain environment where the dependency says `c:@F@innermost`, so it is red-green rather than a determinism claim.

Both tests hold across every allocator setting I could flip the old behaviour with: `MALLOC_ARENA_MAX` 1 and 8, `MALLOC_MMAP_THRESHOLD_` 1024 and 1G, `MALLOC_TOP_PAD_`, `MALLOC_TRIM_THRESHOLD_`, `MALLOC_PERTURB_`, `glibc.malloc.tcache_count=0`.

`regression/function_contract` is 353/354, `github_4220` being the one failure. That one fails identically on unmodified master (`dereference failure: array bounds violated: heap object` where the `.desc` wants `contract ensures`), so it is not from this change. Complexity gate is clean.

### Not touched

`contracts.cpp` (`instructions_to_remove`) and `remove_unreachable.cpp` hold target sets with the same comparator. Both use them for membership only, so neither is wrong today, but the order they carry is not the one it looks like.