### PR TITLE
[docs] Document the chrono clocks, time_point and their limits

### DIFF
--- a/website/content/docs/c-cpp/limitations.md
+++ b/website/content/docs/c-cpp/limitations.md
@@ -74,6 +74,24 @@ call shape works.
   for verification tractability, so their performance characteristics and
   internal representations do not match a production standard library.
 
+## Time and clocks
+
+`system_clock::now()` and `steady_clock::now()` read a shared counter that
+advances by a non-negative nondeterministic step, so a reading is not wall-clock
+time and the gap between two readings is unconstrained. Checking a program
+against a particular instant needs an `__ESBMC_assume` on the value, and one
+whose correctness depends on how much real time passed cannot be checked at all.
+`system_clock::period` follows the target platform, so the range a `time_point`
+represents — and the point at which it saturates — differs between Linux, Apple
+and Windows.
+
+Calendar and time-zone facilities are absent: the C++20 types
+(`year_month_day`, `zoned_time`, `utc_clock`), the `chrono_literals` suffixes
+(`10ms`), and the `floor` / `ceil` / `round` / `abs` duration helpers.
+`std::this_thread::sleep_for` and `sleep_until` are absent too — ESBMC already
+interleaves at every step, so a sleep would not constrain the schedule it
+explores.
+
 ## Standard version
 
 The default is C++17. C++20 and C++23 features require an explicit `--std` — for

--- a/website/content/docs/c-cpp/limitations.md
+++ b/website/content/docs/c-cpp/limitations.md
@@ -85,12 +85,21 @@ whose correctness depends on how much real time passed cannot be checked at all.
 represents — and the point at which it saturates — differs between Linux, Apple
 and Windows.
 
+Because the counter is shared, `system_clock` is monotone too, even though its
+`is_steady` is false as the standard allows. A defect that needs the system
+clock to jump backwards — an NTP correction, an operator resetting the clock —
+is therefore outside what the model can produce.
+
 Calendar and time-zone facilities are absent: the C++20 types
 (`year_month_day`, `zoned_time`, `utc_clock`), the `chrono_literals` suffixes
 (`10ms`), and the `floor` / `ceil` / `round` / `abs` duration helpers.
 `std::this_thread::sleep_for` and `sleep_until` are absent too — ESBMC already
 interleaves at every step, so a sleep would not constrain the schedule it
 explores.
+
+`std::ratio` covers what `<chrono>` needs and no more: `ratio_add`,
+`ratio_subtract` and the comparison aliases (`ratio_equal`, `ratio_less`, …) are
+not declared, nor are the SI aliases outside `nano` / `micro` / `milli`.
 
 ## Standard version
 

--- a/website/content/docs/c-cpp/supported-features.md
+++ b/website/content/docs/c-cpp/supported-features.md
@@ -294,13 +294,15 @@ by regression tests under `regression/esbmc-cpp*`.
 
 `<chrono>` models `duration` over any `Rep` and `Period`, the `nanoseconds` …
 `hours` typedefs, `duration_cast`, and `time_point` with `time_point_cast`.
-Mixed-period arithmetic goes through `common_type`, so `seconds(1) +
-milliseconds(500)` is `milliseconds(1500)`, and the converting `duration`
-constructor is implicit only where the conversion cannot truncate
-([time.duration.cons] p2). `std::ratio` — reduced per [ratio.ratio] p1, with
-`ratio_multiply`, `ratio_divide` and the `nano` / `micro` / `milli` aliases — is
-declared by `<chrono>` itself, which also pulls in `<ctime>` for
-`system_clock::to_time_t` and `from_time_t`.
+Mixed-period arithmetic and comparison go through `common_type`, so
+`seconds(1) + milliseconds(500)` is `milliseconds(1500)`, and the converting
+`duration` constructor is implicit only where the conversion cannot truncate
+([time.duration.cons] p2). `duration::zero` / `min` / `max`, `time_point::min` /
+`max`, `treat_as_floating_point` and `duration_values` are there as well.
+`std::ratio` — reduced per [ratio.ratio] p1, with `ratio_multiply`,
+`ratio_divide` and the `nano` / `micro` / `milli` aliases — is declared by
+`<chrono>` itself, which also pulls in `<ctime>` for `system_clock::to_time_t`
+and `from_time_t`.
 
 `system_clock`, `steady_clock` and `high_resolution_clock` (an alias for
 `steady_clock`) share one tick counter that advances by a non-negative

--- a/website/content/docs/c-cpp/supported-features.md
+++ b/website/content/docs/c-cpp/supported-features.md
@@ -288,7 +288,28 @@ by regression tests under `regression/esbmc-cpp*`.
 | `<algorithm>` | Including the C++11 algorithms |
 | `<numeric>` | `iota`, `gcd`, `lcm`, `reduce` |
 | `<cmath>` | The floating-point classifiers `std::isnan`, `std::isinf`, `std::isfinite`, `std::isnormal` and `std::signbit` are re-declared as `std::` overloads lowered to ESBMC's native FP intrinsics |
-| `<complex>`, `<random>`, `<chrono>` | `<chrono>` covers durations |
+| `<complex>`, `<random>` | |
+
+### Time
+
+`<chrono>` models `duration` over any `Rep` and `Period`, the `nanoseconds` …
+`hours` typedefs, `duration_cast`, and `time_point` with `time_point_cast`.
+Mixed-period arithmetic goes through `common_type`, so `seconds(1) +
+milliseconds(500)` is `milliseconds(1500)`, and the converting `duration`
+constructor is implicit only where the conversion cannot truncate
+([time.duration.cons] p2). `std::ratio` — reduced per [ratio.ratio] p1, with
+`ratio_multiply`, `ratio_divide` and the `nano` / `micro` / `milli` aliases — is
+declared by `<chrono>` itself, which also pulls in `<ctime>` for
+`system_clock::to_time_t` and `from_time_t`.
+
+`system_clock`, `steady_clock` and `high_resolution_clock` (an alias for
+`steady_clock`) share one tick counter that advances by a non-negative
+nondeterministic step. A reading is therefore unconstrained rather than a fixed
+constant, while `steady_clock` still satisfies [time.clock.steady] — it never
+runs backwards between two `now()` calls. `system_clock::period` follows the
+target's standard library — nanoseconds on Linux, microseconds on Apple
+platforms, 100 ns on Windows — because the point at which the representation
+saturates is observable in verification.
 
 ### Concurrency
 
@@ -339,7 +360,9 @@ implementation, which is frequently intractable.
 `<cwctype>`, `<cfenv>`, `<cinttypes>`.
 
 Note that `<concepts>` being unmodelled does not affect the *language* feature —
-concepts and `requires` clauses are supported, as listed above.
+concepts and `requires` clauses are supported, as listed above. Likewise
+`<ratio>` is not includable, but `std::ratio` and its arithmetic aliases are
+declared by `<chrono>` — see [Time](#time).
 
 ## Current status
 


### PR DESCRIPTION
Gives `<chrono>` its own section covering durations, `time_point` and the three
clocks, and records what the nondeterministic clock model means for
verification: readings are unconstrained, and the shared counter makes
`system_clock` monotone as well, so a backwards clock jump is outside the model.
Also notes that `std::ratio` comes from `<chrono>` rather than an includable
`<ratio>`, and stops at the aliases `<chrono>` needs.

Follows #6985.