### PR TITLE
[contracts] Frame the array the clause named

### DIFF
--- a/regression/function_contract/github_7010_assigns_element_not_widened/main.c
+++ b/regression/function_contract/github_7010_assigns_element_not_widened/main.c
@@ -1,0 +1,22 @@
+// Widening the decay must not widen an element the source really did name.
+// `__ESBMC_assigns(a[0])` still frames one element, so the caller keeps the
+// rest, which is the whole point of a precise assigns clause.
+#include <assert.h>
+
+int a[4];
+
+void f(void)
+{
+  __ESBMC_assigns(a[0]);
+  __ESBMC_ensures(a[0] == 1);
+  a[0] = 1;
+}
+
+int main(void)
+{
+  a[1] = 20;
+  f();
+  assert(a[0] == 1);
+  assert(a[1] == 20); /* outside the frame, so it survives the call */
+  return 0;
+}

--- a/regression/function_contract/github_7010_assigns_element_not_widened/test.desc
+++ b/regression/function_contract/github_7010_assigns_element_not_widened/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract "*" --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_7010_assigns_struct_member_array_fail/main.c
+++ b/regression/function_contract/github_7010_assigns_struct_member_array_fail/main.c
@@ -1,0 +1,29 @@
+// The struct-member form, which is what an elementwise polynomial update looks
+// like. `__ESBMC_assigns(p->coeffs)` decays the same way a bare array does.
+#include <assert.h>
+
+typedef struct
+{
+  int coeffs[4];
+} poly;
+
+void f(poly *p)
+{
+  __ESBMC_assigns(p->coeffs);
+  __ESBMC_ensures(
+    p->coeffs[0] == 1 && p->coeffs[1] == 1 && p->coeffs[2] == 1 &&
+    p->coeffs[3] == 1);
+  for (int i = 0; i < 4; i++)
+    p->coeffs[i] = 1;
+}
+
+int main(void)
+{
+  poly q;
+  for (int i = 0; i < 4; i++)
+    q.coeffs[i] = 0;
+  f(&q);
+  assert(q.coeffs[3] == 1); /* holds under the contract */
+  assert(0);                /* reachable */
+  return 0;
+}

--- a/regression/function_contract/github_7010_assigns_struct_member_array_fail/test.desc
+++ b/regression/function_contract/github_7010_assigns_struct_member_array_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract "*" --unwind 8
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_7010_assigns_whole_array_distinct_fail/main.c
+++ b/regression/function_contract/github_7010_assigns_whole_array_distinct_fail/main.c
@@ -1,0 +1,22 @@
+// The whole-array havoc has to leave the elements independent. ARRAY_OF(NONDET)
+// ties them to one value, so an ensures naming two different values had no
+// post-state to land in and the path died before reaching the assert.
+#include <assert.h>
+
+int a[4];
+
+void f(void)
+{
+  __ESBMC_assigns(a);
+  __ESBMC_ensures(a[0] == 1 && a[1] == 2);
+  a[0] = 1;
+  a[1] = 2;
+}
+
+int main(void)
+{
+  f();
+  assert(a[0] == 1 && a[1] == 2); /* holds under the contract */
+  assert(0);                      /* reachable */
+  return 0;
+}

--- a/regression/function_contract/github_7010_assigns_whole_array_distinct_fail/test.desc
+++ b/regression/function_contract/github_7010_assigns_whole_array_distinct_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract "*" --unwind 8
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_7010_assigns_whole_array_fail/main.c
+++ b/regression/function_contract/github_7010_assigns_whole_array_fail/main.c
@@ -1,0 +1,23 @@
+// `__ESBMC_assigns(a)` reached the havoc as `a[0]`, because `&a` is `&a[0]` by
+// then and an element the source named looks exactly the same. Every other
+// element kept its pre-call value, so the ensures below was `assume false` and
+// the reachable assert(0) went unreported.
+#include <assert.h>
+
+int a[4];
+
+void f(void)
+{
+  __ESBMC_assigns(a);
+  __ESBMC_ensures(a[0] == 1 && a[1] == 1 && a[2] == 1 && a[3] == 1);
+  for (int i = 0; i < 4; i++)
+    a[i] = 1;
+}
+
+int main(void)
+{
+  f();
+  assert(a[3] == 1); /* holds under the contract */
+  assert(0);         /* reachable, so the only correct answer is FAILED */
+  return 0;
+}

--- a/regression/function_contract/github_7010_assigns_whole_array_fail/test.desc
+++ b/regression/function_contract/github_7010_assigns_whole_array_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract "*" --unwind 8
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_7010_enforce_whole_array/main.c
+++ b/regression/function_contract/github_7010_enforce_whole_array/main.c
@@ -1,0 +1,16 @@
+// The enforce side read the same clause as `a[0]` and so asserted the whole
+// array unchanged, reporting a frame violation against a body that writes only
+// what its own clause names.
+int a[4];
+
+void f(void)
+{
+  __ESBMC_assigns(a);
+  __ESBMC_ensures(a[1] == 1);
+  a[1] = 1;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/function_contract/github_7010_enforce_whole_array/test.desc
+++ b/regression/function_contract/github_7010_enforce_whole_array/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function f --enforce-contract f --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1228,6 +1228,37 @@ void clang_c_adjust::adjust_side_effect_function_call(
   do_special_functions(expr);
 }
 
+// The expression a chain of typecasts wraps, which is where the address the
+// caller wrote actually sits.
+static exprt *strip_typecasts(exprt &e)
+{
+  exprt *p = &e;
+  while (p->id() == "typecast" && p->operands().size() == 1)
+    p = &p->op0();
+  return p;
+}
+
+static bool is_address_of_array(exprt &arg, const namespacet &ns)
+{
+  const exprt *addr = strip_typecasts(arg);
+  return addr->is_address_of() && addr->operands().size() == 1 &&
+         is_array_like(ns.follow(addr->op0().type()));
+}
+
+// Undo the `&a` -> `&a[0]` rewrite adjust_address_of applies to every array.
+static void restore_array_lvalue(exprt &arg)
+{
+  exprt *addr = strip_typecasts(arg);
+  if (
+    !addr->is_address_of() || addr->operands().size() != 1 ||
+    !addr->op0().is_index() || addr->op0().operands().size() != 2)
+    return;
+
+  exprt array = addr->op0().op0();
+  addr->type() = pointer_typet(array.type());
+  addr->op0().swap(array);
+}
+
 void clang_c_adjust::adjust_function_call_arguments(
   side_effect_expr_function_callt &expr)
 {
@@ -1236,10 +1267,24 @@ void clang_c_adjust::adjust_function_call_arguments(
   exprt::operandst &arguments = expr.arguments();
   const code_typet::argumentst &argument_types = code_type.arguments();
 
+  // An assigns clause names an lvalue, and array-to-pointer decay is the one
+  // conversion that loses which lvalue it was: adjust_address_of rewrites `&a`
+  // to `&a[0]`, after which the clause is indistinguishable from one that
+  // named the first element, and the frame silently shrinks to it (#7010).
+  // Keep the pointer-to-array `&a` C already gave us for this callee alone.
+  const bool keeps_array_lvalues =
+    f_op.is_symbol() && f_op.identifier() == "c:@F@__ESBMC_assigns_impl";
+
   for (unsigned i = 0; i < arguments.size(); i++)
   {
     exprt &op = arguments[i];
+    const bool was_array_lvalue =
+      keeps_array_lvalues && is_address_of_array(op, ns);
+
     adjust_expr(op);
+
+    if (was_array_lvalue)
+      restore_array_lvalue(op);
 
     if (i < argument_types.size())
     {

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -869,6 +869,18 @@ bool goto_convertt::drop_inactive_contract_clause(bool is_clause) const
   return is_clause && !options.contracts_enabled();
 }
 
+// The assigns marker is an assignment, so symex reads its right-hand side. A
+// whole array read through a pointer is the one rvalue dereference refuses to
+// build (pointer-analysis/dereference.cpp), so carry an array target by
+// address; the contracts layer strips it back off. A frame target is a place,
+// and its address is the part that matters.
+static exprt assigns_marker_operand(const exprt &target)
+{
+  if (!target.type().is_array())
+    return target;
+  return address_of_exprt(target);
+}
+
 void goto_convertt::do_function_call_symbol(
   const exprt &lhs,
   const exprt &function,
@@ -1140,6 +1152,8 @@ void goto_convertt::do_function_call_symbol(
 
       log_debug(
         "builtin_functions", "  Assigns target {}: {}", i, actual_arg.pretty());
+
+      actual_arg = assigns_marker_operand(actual_arg);
 
       // Create a sideeffect expression to mark this as an assigns target
       // Type is inherited from the actual argument (after stripping typecast)

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -948,6 +948,23 @@ static bool declares_frame_condition(
 // Helper function to unwrap array-to-pointer decay in assigns targets
 // In C, when an array is passed to a function, it decays to &arr[0].
 // This function detects this pattern and returns the original array.
+// Whether reaching \p e goes through a pointer, which is what decides whether
+// an array-typed place can be written in one assignment.
+static bool reaches_through_pointer(const expr2tc &e)
+{
+  if (is_nil_expr(e))
+    return false;
+  if (is_dereference2t(e))
+    return true;
+
+  bool found = false;
+  e->foreach_operand([&found](const expr2tc &op) {
+    if (reaches_through_pointer(op))
+      found = true;
+  });
+  return found;
+}
+
 static expr2tc unwrap_array_decay(const expr2tc &expr)
 {
   // Pattern: address_of(index(array, 0))
@@ -1007,6 +1024,13 @@ code_contractst::extract_assigns_from_body(const goto_programt &function_body)
         // Unwrap array-to-pointer decay: &arr[0] -> arr
         // This happens when an array is passed to __ESBMC_assigns()
         target_expr = unwrap_array_decay(target_expr);
+
+        // An array target travels as its address, so the marker instruction
+        // does not read the array itself. Recover the place it names.
+        if (
+          is_address_of2t(target_expr) &&
+          is_array_type(to_address_of2t(target_expr).ptr_obj->type))
+          target_expr = to_address_of2t(target_expr).ptr_obj;
 
         log_debug("contracts", "  Found assigns target expression");
         assigns_targets.push_back(target_expr);
@@ -4605,6 +4629,46 @@ expr2tc code_contractst::lower_is_fresh_in_requires(
   return requires_clause;
 }
 
+// An array frame target reached through a pointer cannot be assigned in one go:
+// dereference refuses to build an array-typed lvalue (dereference.cpp:1103).
+// Write the elements instead -- same post-state, more instructions. Returns
+// whether the target was of that shape and so is now dealt with.
+static bool havoc_pointed_to_array(
+  const expr2tc &target,
+  const locationt &call_location,
+  goto_programt &replacement)
+{
+  if (!is_array_type(target->type) || !reaches_through_pointer(target))
+    return false;
+
+  const array_type2t &at = to_array_type(target->type);
+  if (!is_constant_int2t(at.array_size))
+  {
+    // A symbolic extent has no element count to write out, so the frame cannot
+    // be havocked at all. Saying so beats a silent partial havoc.
+    log_warning(
+      "__ESBMC_assigns: array of unknown size reached through a pointer is "
+      "not havocked; the caller keeps its pre-call value");
+    return true;
+  }
+
+  const BigInt &n = to_constant_int2t(at.array_size).value;
+  for (BigInt k = 0; k < n; k += 1)
+  {
+    expr2tc elem =
+      index2tc(at.subtype, target, constant_int2tc(at.array_size->type, k));
+    goto_programt::targett e = replacement.add_instruction(ASSIGN);
+    e->code = code_assign2tc(elem, gen_nondet(at.subtype));
+    e->location = call_location;
+    e->location.comment("contract havoc assigns");
+  }
+  log_debug(
+    "contracts",
+    "Havoc'd {} elements of a pointed-to array assigns target",
+    integer2string(n));
+  return true;
+}
+
 void code_contractst::generate_replacement_at_call(
   const symbolt &function_symbol,
   const goto_programt &function_body,
@@ -4776,20 +4840,16 @@ void code_contractst::generate_replacement_at_call(
         is_pointer_type(instantiated_target))
         continue;
 
-      // Generate nondeterministic value and create assignment
-      // Special handling for array types: use ARRAY_OF(NONDET) construction
-      expr2tc rhs;
-      if (is_array_type(instantiated_target->type))
-      {
-        // For arrays, generate ARRAY_OF(nondet_element)
-        const array_type2t &arr_type = to_array_type(instantiated_target->type);
-        expr2tc nondet_elem = gen_nondet(arr_type.subtype);
-        rhs = constant_array_of2tc(instantiated_target->type, nondet_elem);
-      }
-      else
-      {
-        rhs = gen_nondet(instantiated_target->type);
-      }
+      if (havoc_pointed_to_array(
+            instantiated_target, call_location, replacement))
+        continue;
+
+      // One nondet of the target's own type, arrays included. ARRAY_OF ties
+      // every element to a single nondet, so a callee that leaves its elements
+      // holding different values has no post-state the havoc can express and
+      // the ensures ASSUME kills the path (#7010). This is what the loop
+      // invariant havoc has always done.
+      expr2tc rhs = gen_nondet(instantiated_target->type);
 
       goto_programt::targett t = replacement.add_instruction(ASSIGN);
       t->code = code_assign2tc(instantiated_target, rhs);


### PR DESCRIPTION
Fixes #7010.

## Symptom

`__ESBMC_assigns` naming an array frames only element `[0]`. Every other
element keeps its pre-call value, so the clause does not cover what it
names.

```c
int a[4];
void f(void)
{
  __ESBMC_assigns(a);
  __ESBMC_ensures(a[0] == 1 && a[1] == 1 && a[2] == 1 && a[3] == 1);
  for (int i = 0; i < 4; i++) a[i] = 1;
}
int main(void) { f(); assert(0); return 0; }
```

```
$ esbmc repro.c --replace-call-with-contract "*"
VERIFICATION SUCCESSFUL      # wrong: assert(0) is reachable
```

Both directions are wrong. Where the `ensures` constrains the un-havocked
elements the assumption is unsatisfiable, the path dies and a reachable
assertion goes unreported. Where it does not, the caller keeps stale
values past `[0]` while believing the callee's writes were modelled.

The enforce side has the same root cause, recorded separately as
`assigns_global_arr_elem_knownbug`: the frame enforcer snapshots `a` but
reads the clause as `a[0]`, so a body writing only what its own clause
names is reported as a frame violation.

## Cause

`clang_c_adjust_expr.cpp` rewrites `&array` to `&array[0]` for every
address-of an array. By the time the clause is lowered:

```
__ESBMC_assigns(a)      ->  address_of(index(a,0))
__ESBMC_assigns(a[0])   ->  address_of(index(a,0))
```

The same expression. `unwrap_array_decay` was written to undo this, but
`builtin_functions.cpp` strips the `address_of` first, so it never
matches and never fires.

Nothing downstream can recover the distinction, because the information
is gone before it gets there.

## Fix

**Do not decay the argument, for this callee only.** The pointer-to-array
`&a` that C already gives us is kept for `__ESBMC_assigns_impl`. An
assigns clause names an lvalue, and array-to-pointer decay is the one
conversion that loses which lvalue it was.

Marking the synthesised `[0]` and reading the mark later does not work: a
`#` comment is dropped by the irep2 round trip in `remove_sideeffects`
(`goto_sideeffects.cpp`), and irep2 has nowhere to keep an extra field on
`index2t` either. Confirmed with temporary probes — the mark survives to
the end of `adjust` and is gone at goto conversion.

**Carry an array target by address.** The clause leaves an
`ASSIGN tmp = sideeffect(assigns_target, X)` marker, and symex reads `X`.
A whole array read through a pointer is what
`pointer-analysis/dereference.cpp` refuses to build, so the target
travels as `&X` and the contracts layer strips it back off. A frame
target is a place; its address is the part that matters.

**Havoc the array with one nondet of its own type.** `ARRAY_OF(NONDET)`
ties every element to a single value, so `__ESBMC_ensures(a[0] == 1 &&
a[1] == 2)` had no post-state to land in even once the target was widened.
`goto_loop_invariant.cpp` has always used a plain `gen_nondet`; the array
special case in contracts was the deviation.

**Write the elements one at a time when the array is reached through a
pointer**, since that is the same wall as above. Same post-state, more
instructions — `mlk_poly`'s `coeffs[256]` becomes 256 assignments, still
far cheaper than inlining the callee's loop. A symbolic extent has no
element count to write out, so nothing is havocked and a warning says so
rather than leaving a silent partial frame.

The enforce side needs no separate change: once the target is the array
symbol, `frame_enforcert`'s `var == direct` matches and the spurious
assertion is not emitted.

## Scope

Multi-dimensional arrays are consistent — decay applies once, so
`__ESBMC_assigns(m)` frames all of `int m[3][4]` and
`__ESBMC_assigns(m[0])` frames that row. Pointer forms are untouched:
`__ESBMC_assigns(p)`, `*p` and `p[0]` never enter the decay branch.

Not addressed: `__ESBMC_assigns(global[i])` with a symbolic index, a
different mechanism, still `assigns_global_arr_elem_knownbug`.

## Tests

Five new, in `regression/function_contract/`. On unmodified master four
are red and go green with the patch; `assigns_element_not_widened` is
green on both, being the guard against over-widening rather than a
red-green case.

| test | master | patched |
|---|---|---|
| `github_7010_assigns_whole_array_fail` | FAIL | pass |
| `github_7010_assigns_whole_array_distinct_fail` | FAIL | pass |
| `github_7010_assigns_struct_member_array_fail` | FAIL | pass |
| `github_7010_enforce_whole_array` | FAIL | pass |
| `github_7010_assigns_element_not_widened` | pass | pass |

`regression/function_contract` is 366/366, `github_4220` included: it
was failing on the older base this branch sat on and passes on current
master.

Wider sweep, rebased onto master at 4622c3b267: a uniform sample of the
core C suite (295 of 1769, every sixth test) and of the C++ suite (259
of 777, every third) is clean. Sampled rather than exhaustive — the full
`esbmc` label does not finish inside this repo's five-minute cap. The
blast radius outside contracts is nil by construction: the frontend
change is guarded on the callee being `__ESBMC_assigns_impl`, and the
`builtin_functions` change only reshapes an array-typed assigns marker.

Worth noting for review: `assigns_entire_array_pass` and
`assigns_entire_array_fail` passed **vacuously** before this change — the
first one's `ensures` is unsatisfiable under the broken havoc, so the
path died and the run was reported successful. They still pass, now for
the stated reason.

## Complexity

Each of the three sites keeps its work in a named helper
(`assigns_marker_operand`, `havoc_pointed_to_array`,
`is_address_of_array` / `restore_array_lvalue`), so none of
`do_function_call_symbol`, `generate_replacement_at_call` or
`adjust_function_call_arguments` gains cyclomatic complexity and the
gate is green.
