### PR TITLE
[contracts] Name the value a replaced call returns

### DIFF
--- a/regression/function_contract/github_7009_discarded_result_fail/main.c
+++ b/regression/function_contract/github_7009_discarded_result_fail/main.c
@@ -1,0 +1,17 @@
+/* A dropped result still needs naming. The ensures is assumed either way, and
+ * with nothing to rewrite __ESBMC_return_value to it was assumed over a symbol
+ * no instruction defines, which took the reachable assertion below with it. */
+#include <assert.h>
+
+int g(void)
+{
+  __ESBMC_ensures(__ESBMC_return_value == 1);
+  return 1;
+}
+
+int main(void)
+{
+  g();
+  assert(0);
+  return 0;
+}

--- a/regression/function_contract/github_7009_discarded_result_fail/test.desc
+++ b/regression/function_contract/github_7009_discarded_result_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract g
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_7009_ensures_assigned_return_fail/main.c
+++ b/regression/function_contract/github_7009_ensures_assigned_return_fail/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int f(void)
+{
+  __ESBMC_ensures(__ESBMC_return_value == 1);
+  return 1;
+}
+
+int main(void)
+{
+  int r = 200;
+  r = f();
+  assert(0);
+  return 0;
+}

--- a/regression/function_contract/github_7009_ensures_assigned_return_fail/test.desc
+++ b/regression/function_contract/github_7009_ensures_assigned_return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract "*"
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_7009_ensures_init_return/main.c
+++ b/regression/function_contract/github_7009_ensures_init_return/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int f(void)
+{
+  __ESBMC_ensures(__ESBMC_return_value == 1);
+  return 1;
+}
+
+int main(void)
+{
+  int r = f();
+  assert(r == 1);
+  return 0;
+}

--- a/regression/function_contract/github_7009_ensures_init_return/test.desc
+++ b/regression/function_contract/github_7009_ensures_init_return/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract "*"
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_7009_ensures_stale_value_fail/main.c
+++ b/regression/function_contract/github_7009_ensures_stale_value_fail/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+int f(void)
+{
+  __ESBMC_ensures(__ESBMC_return_value >= 0);
+  return 7;
+}
+
+int main(void)
+{
+  int r = 200;
+  r = f();
+  /* The contract permits any non-negative result, so the caller cannot know
+     the value is still 200. Reported SUCCESSFUL while the return value was
+     never havocked (#7009). */
+  assert(r == 200);
+  return 0;
+}

--- a/regression/function_contract/github_7009_ensures_stale_value_fail/test.desc
+++ b/regression/function_contract/github_7009_ensures_stale_value_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract "*"
+^VERIFICATION FAILED$

--- a/regression/function_contract/github_7009_pointer_result_knownbug/main.c
+++ b/regression/function_contract/github_7009_pointer_result_knownbug/main.c
@@ -1,0 +1,27 @@
+/* The result is the only definition of what the call returns, so it is a fresh
+ * nondet. For a pointer that leaves it without a value set: `p == &a` is proved
+ * from the ensures, but the write through p does not reach a.
+ *
+ * Leaving the result undeclared instead is what #7009 was: the ensures would be
+ * assumed about the caller's stale pointer, `p == &a` would be assume-false and
+ * everything after the call would pass vacuously. A reported failure is the
+ * safe direction of the two, and unlike the other it is visible. */
+int a;
+
+int *pick(int c)
+{
+  __ESBMC_requires(c == 0);
+  __ESBMC_ensures(__ESBMC_return_value == &a);
+
+  return &a;
+}
+
+int main(void)
+{
+  int *p = 0;
+  p = pick(0);
+  __ESBMC_assert(p == &a, "pointer equality holds");
+  *p = 5;
+  __ESBMC_assert(a == 5, "the write through p reaches a");
+  return 0;
+}

--- a/regression/function_contract/github_7009_pointer_result_knownbug/test.desc
+++ b/regression/function_contract/github_7009_pointer_result_knownbug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--replace-call-with-contract pick
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_7009_self_assigned_arg/main.c
+++ b/regression/function_contract/github_7009_self_assigned_arg/main.c
@@ -1,0 +1,19 @@
+/* The positive half of github_7009_self_assigned_arg_fail: what the contract
+ * does imply about the same call still holds, so the result is written back
+ * rather than merely left unconstrained. */
+#include <assert.h>
+
+int f(int x)
+{
+  __ESBMC_requires(x > 0);
+  __ESBMC_ensures(__ESBMC_return_value == x + 1);
+  return x + 1;
+}
+
+int main(void)
+{
+  int r = 5;
+  r = f(r);
+  assert(r == 6);
+  return 0;
+}

--- a/regression/function_contract/github_7009_self_assigned_arg/test.desc
+++ b/regression/function_contract/github_7009_self_assigned_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract f
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_7009_self_assigned_arg_fail/main.c
+++ b/regression/function_contract/github_7009_self_assigned_arg_fail/main.c
@@ -1,0 +1,19 @@
+/* The result overwrites the variable the ensures was instantiated with, so a
+ * havoc of that place in situ makes the clause read `r == r + 1` and the path
+ * dies. The caller then proves anything, including this. */
+#include <assert.h>
+
+int f(int x)
+{
+  __ESBMC_requires(x > 0);
+  __ESBMC_ensures(__ESBMC_return_value == x + 1);
+  return x + 1;
+}
+
+int main(void)
+{
+  int r = 5;
+  r = f(r);
+  assert(r == 5);
+  return 0;
+}

--- a/regression/function_contract/github_7009_self_assigned_arg_fail/test.desc
+++ b/regression/function_contract/github_7009_self_assigned_arg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract f
+^VERIFICATION FAILED$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -2578,35 +2578,37 @@ bool code_contractst::is_old_call(const expr2tc &expr) const
   return false;
 }
 
+// A fresh lvalue of \p type registered under \p name.
+//
+// Note: symbolt uses IRep1 (typet) while we work with IRep2 (type2tc). This is
+// ESBMC's architecture: the symbol table is IRep1-based for global state, while
+// modern code (GOTO programs, contracts) uses IRep2 for local logic. Set the
+// symbol's IREP2 type directly via the migrate-layer chokepoint;
+// set_symbol_type stores the cache authoritatively and derives the legacy field
+// via migrate_type_back exactly once (esbmc/esbmc#4715, B2 S4b).
+expr2tc code_contractst::declare_local_symbol(
+  const std::string &name,
+  const type2tc &type) const
+{
+  symbolt symbol;
+  symbol.name = name;
+  symbol.id = name;
+  set_symbol_type(symbol, type);
+  symbol.lvalue = true;
+  symbol.static_lifetime = false;
+  symbol.file_local = false;
+
+  return symbol2tc(type, context.move_symbol_to_context(symbol)->id);
+}
+
 expr2tc code_contractst::create_snapshot_variable(
   const expr2tc &expr,
   const std::string &func_name,
   size_t index) const
 {
-  // Generate unique snapshot variable name
-  std::string snapshot_name =
-    "__ESBMC_old_snapshot_" + func_name + "_" + std::to_string(index);
-
-  // Create symbol and add to symbol table
-  // Note: symbolt uses IRep1 (typet) while we work with IRep2 (type2tc).
-  // This is ESBMC's architecture: Symbol Table is IRep1-based for global state,
-  // while modern code (GOTO programs, contracts) uses IRep2 for local logic.
-  // Set the symbol's IREP2 type directly via the migrate-layer chokepoint;
-  // set_symbol_type stores the cache authoritatively and derives the legacy
-  // field via migrate_type_back exactly once (esbmc/esbmc#4715, B2 S4b).
-  symbolt snapshot_symbol;
-  snapshot_symbol.name = snapshot_name;
-  snapshot_symbol.id = snapshot_name;
-  set_symbol_type(snapshot_symbol, expr->type);
-  snapshot_symbol.lvalue = true;
-  snapshot_symbol.static_lifetime = false;
-  snapshot_symbol.file_local = false;
-
-  // Add to context (symbol table)
-  symbolt *added = context.move_symbol_to_context(snapshot_symbol);
-
-  // Return symbol expression (IRep2)
-  return symbol2tc(expr->type, added->id);
+  return declare_local_symbol(
+    "__ESBMC_old_snapshot_" + func_name + "_" + std::to_string(index),
+    expr->type);
 }
 
 expr2tc code_contractst::replace_old_in_expr(
@@ -4710,6 +4712,77 @@ static bool havoc_pointed_to_array(
   return true;
 }
 
+// The value the removed body would have returned: a fresh unconstrained one,
+// which is what `__ESBMC_return_value` is rewritten to.
+//
+// The caller's own lvalue cannot play that part. The ensures is instantiated
+// with the caller's argument expressions, so for `r = f(r)` it would carry `r`
+// on both sides and the ASSUME would read `r == r + 1` -- `assume false`, the
+// path dies, and a reachable assertion after the call goes unreported (#7009).
+// Naming the result separately keeps the arguments at their pre-call values
+// for as long as the clause speaks about them; the caller's place is written
+// once, after (§4.b).
+//
+// A discarded result still needs one. The ensures is assumed either way, and
+// with nothing to rewrite `__ESBMC_return_value` to it was assumed over a
+// symbol no instruction defines.
+expr2tc code_contractst::declare_call_result(
+  const symbolt &function_symbol,
+  const expr2tc &ret_val,
+  const locationt &call_location,
+  goto_programt &replacement) const
+{
+  type2tc result_type;
+  if (!is_nil_expr(ret_val))
+    result_type = ret_val->type;
+  else if (function_symbol.get_type().is_code())
+    result_type =
+      migrate_type(to_code_type(function_symbol.get_type()).return_type());
+
+  // A void function returns nothing for a clause to name.
+  if (is_nil_type(result_type) || is_empty_type(result_type))
+    return expr2tc();
+
+  // Unlike the three havoc sites, this one does not skip a pointer under
+  // --add-symex-value-sets. They leave existing state alone; this one is the
+  // result's only definition, and omitting it puts the ensures back over the
+  // caller's stale value. A pointer result therefore carries no value set, so
+  // a write through it is lost (github_7009_pointer_result_knownbug).
+  static size_t counter = 0;
+  expr2tc result = declare_local_symbol(
+    "__ESBMC_return_value$" + std::to_string(counter++), result_type);
+
+  goto_programt::targett decl = replacement.add_instruction(DECL);
+  decl->code = code_decl2tc(result_type, to_symbol2t(result).thename);
+  decl->location = call_location;
+  decl->location.comment("contract call result declaration");
+
+  goto_programt::targett assign = replacement.add_instruction(ASSIGN);
+  assign->code = code_assign2tc(result, gen_nondet(result_type));
+  assign->location = call_location;
+  assign->location.comment("contract call result");
+
+  return result;
+}
+
+// The caller's place takes the result only once the ensures has been assumed:
+// until then the arguments the clause was instantiated with must still hold
+// their pre-call values, and one of them can be that very place.
+static void write_back_call_result(
+  const expr2tc &ret_val,
+  const expr2tc &call_result,
+  const locationt &call_location,
+  goto_programt &replacement)
+{
+  if (is_nil_expr(ret_val) || is_nil_expr(call_result))
+    return;
+
+  goto_programt::targett t = replacement.add_instruction(ASSIGN);
+  t->code = code_assign2tc(ret_val, call_result);
+  t->location = call_location;
+  t->location.comment("contract call result written back");
+}
+
 void code_contractst::generate_replacement_at_call(
   const symbolt &function_symbol,
   const goto_programt &function_body,
@@ -4993,9 +5066,13 @@ void code_contractst::generate_replacement_at_call(
     }
   }
 
+  // 2.5. Name the value the removed body would have returned.
+  expr2tc call_result =
+    declare_call_result(function_symbol, ret_val, call_location, replacement);
+
   // 3. Normalize ensures guard: replace return_value, fix types, normalize floating-point
   expr2tc ensures_guard =
-    normalize_ensures_guard_for_return_value(ensures_clause, ret_val);
+    normalize_ensures_guard_for_return_value(ensures_clause, call_result);
 
   // 3.b Replace __ESBMC_old() occurrences in ensures using call-site snapshots
   if (!callsite_snapshots.empty() && !is_nil_expr(ensures_guard))
@@ -5016,6 +5093,9 @@ void code_contractst::generate_replacement_at_call(
   // 4. Assume ensures clause (assume postcondition at call site)
   add_contract_clause(
     ensures_guard, ASSUME, "contract ensures", "contract ensures");
+
+  // 4.b The caller's place takes the result only now.
+  write_back_call_result(ret_val, call_result, call_location, replacement);
 
   // Replace the call with the replacement code.
   //

--- a/src/goto-programs/contracts/contracts.h
+++ b/src/goto-programs/contracts/contracts.h
@@ -266,6 +266,22 @@ private:
     const std::vector<expr2tc> &assigns_targets = {},
     bool check_assigns_compliance = false);
 
+  /// \brief A fresh lvalue symbol of \p type registered under \p name
+  expr2tc
+  declare_local_symbol(const std::string &name, const type2tc &type) const;
+
+  /// \brief Declare and havoc the value a replaced call returns
+  /// \param function_symbol Function symbol being called
+  /// \param ret_val Place the call assigns to, nil when the result is dropped
+  /// \param call_location Location to give the emitted instructions
+  /// \param replacement Program the declaration and havoc are appended to
+  /// \return The result symbol, nil for a function returning nothing
+  expr2tc declare_call_result(
+    const symbolt &function_symbol,
+    const expr2tc &ret_val,
+    const locationt &call_location,
+    goto_programt &replacement) const;
+
   /// \brief Generate replacement code at function call site
   /// \param function_symbol Function symbol being called
   /// \param function_body Function body (to extract contracts from)


### PR DESCRIPTION
Fixes #7009.

## Symptom

`__ESBMC_return_value` was rewritten to the caller's own lvalue, which
`--replace-call-with-contract` never wrote, so the `ensures` was assumed about
the value that lvalue held *before* the call.

```c
int f(void) { __ESBMC_ensures(__ESBMC_return_value == 1); return 1; }

int main(void)
{
	int r = 200;
	r = f();
	assert(0);       /* reachable, so the only correct answer is FAILED */
	return 0;
}
```

```
$ esbmc repro.c --replace-call-with-contract "*"
VERIFICATION SUCCESSFUL      # wrong, and silent
```

`r` is still 200, so `ASSUME r == 1` is `assume false`: the path dies and the
reachable assertion is never reported. A false negative — it does not turn a
passing table red, it makes a failing one look green.

Where the stale value happens to satisfy the contract the path survives and the
caller simply keeps it. Writing the same call as an initialiser was already
correct, so whether the contract was honoured depended on how the call site was
spelled.

## Fix

Havocking the caller's place in situ is not enough, and the first version of
this PR did exactly that. The clause is instantiated with the caller's
*argument expressions*, so `r = f(r)` carried `r` on both sides and the ASSUME
read `r == r + 1` — the same `assume false`, now for a different reason.

The result gets a name of its own, and the caller's place is written once the
clause has been assumed:

```
DECL signed int return_value$0;
ASSIGN return_value$0=NONDET(signed int);
ASSUME return_value$0 == r + 1
ASSIGN r=return_value$0;
```

A discarded result needs the same name. The ensures is assumed either way, and
with nothing to rewrite `__ESBMC_return_value` to it was assumed over a symbol
no instruction defines, which took a reachable assertion with it. That was a
second false negative sitting next to the first, also present on master.

`create_snapshot_variable` and the new declaration share
`declare_local_symbol` rather than repeating the symbol setup, and the
write-back is its own helper, so `generate_replacement_at_call` gains no
cyclomatic complexity.

## Known limitation, pinned rather than hidden

A pointer result carries no value set, so a contract pinning it to an object
proves the equality and then loses writes through it
(`github_7009_pointer_result_knownbug`). This is not a contracts defect: the
same failure reproduces with no contract flag at all, from a plain
`__ESBMC_assume(tmp == &a)` — filed as **#7066** against goto-symex.

Omitting the declaration for pointers is not an option: that puts the `ensures`
back over the caller's stale value, which is the false negative this PR
removes. A reported failure is the safe direction of the two, and unlike the
other it is visible.

## Tests

Six, in `regression/function_contract/`. Every red-green pair was checked by
building master first, not assumed.

| test | master | patched | |
|---|---|---|---|
| `github_7009_ensures_assigned_return_fail` | SUCCESSFUL | FAILED | red-green |
| `github_7009_ensures_stale_value_fail` | SUCCESSFUL | FAILED | red-green |
| `github_7009_self_assigned_arg_fail` | SUCCESSFUL | FAILED | red-green; `r = f(r)` |
| `github_7009_discarded_result_fail` | SUCCESSFUL | FAILED | red-green; result dropped |
| `github_7009_self_assigned_arg` | SUCCESSFUL | SUCCESSFUL | control: the result is written back, not merely left unconstrained |
| `github_7009_ensures_init_return` | SUCCESSFUL | SUCCESSFUL | control: the initialiser form that already worked, so an over-havoc is caught |
| `github_7009_pointer_result_knownbug` | — | KNOWNBUG | #7066 |

`function_contract` 380/380, `loop-invariants` 76/76, `python-contracts` 55/55
— the three suites whose `.desc` files pass `--replace-call-with-contract`.
Nothing outside those paths can reach the change; it lives in
`generate_replacement_at_call`.
