### PR TITLE
[python] Keep a clause from planting a statement

### DIFF
--- a/regression/python-contracts/clause_div_enforce/main.py
+++ b/regression/python-contracts/clause_div_enforce/main.py
@@ -1,0 +1,9 @@
+def safe(d: int) -> int:
+    __ESBMC_requires(100 // d > 0)
+    return 1
+
+def main() -> None:
+    x: int = nondet_int()
+    assert safe(x) == 1
+
+main()

--- a/regression/python-contracts/clause_div_enforce/test.desc
+++ b/regression/python-contracts/clause_div_enforce/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--enforce-contract safe
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/clause_div_inert/main.py
+++ b/regression/python-contracts/clause_div_inert/main.py
@@ -1,0 +1,9 @@
+def safe(d: int) -> int:
+    __ESBMC_requires(100 // d > 0)
+    return 1
+
+def main() -> None:
+    x: int = nondet_int()
+    assert safe(x) == 1
+
+main()

--- a/regression/python-contracts/clause_div_inert/test.desc
+++ b/regression/python-contracts/clause_div_inert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python-contracts/clause_div_inert_body_fail/main.py
+++ b/regression/python-contracts/clause_div_inert_body_fail/main.py
@@ -1,0 +1,9 @@
+def f(x: int) -> int:
+    __ESBMC_requires(100 // x > 0)
+    return 100 // x
+
+def main() -> None:
+    n: int = nondet_int()
+    y: int = f(n)
+
+main()

--- a/regression/python-contracts/clause_div_inert_body_fail/test.desc
+++ b/regression/python-contracts/clause_div_inert_body_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/loop_invariant_div_inert/main.py
+++ b/regression/python/loop_invariant_div_inert/main.py
@@ -1,0 +1,9 @@
+def main() -> None:
+    d: int = nondet_int()
+    i: int = 0
+    while i < 3:
+        __ESBMC_loop_invariant(100 // d > 0)
+        i = i + 1
+    assert i == 3
+
+main()

--- a/regression/python/loop_invariant_div_inert/test.desc
+++ b/regression/python/loop_invariant_div_inert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -932,6 +932,35 @@ exprt python_converter::handle_tagged_scalar_comparison(
   return op == "NotEq" ? python_expr::build_not(result) : result;
 }
 
+// Python raises a *catchable* ZeroDivisionError when the divisor of /, //, or
+// % is zero (for both int and float operands, unlike C/IEEE). Model it as a
+// guarded exception raise -- the same mechanism list indexing uses for
+// IndexError -- so that `try: x / 0 except ZeroDivisionError: ...` is treated
+// as SAFE while a bare division by zero propagates and fails. The built-in
+// C-level div-by-zero assertion cannot express this: it fires regardless of
+// the surrounding try/except, so caught divisions were wrongly reported.
+//
+// The guard is a statement planted into the enclosing block, so it is emitted
+// only where the division is really code-generated in its execution context:
+// not for a lambda body converted at its definition, not during the discarded
+// type-probe pass over an assignment RHS, and not inside a clause, which is a
+// specification rather than code.
+bool python_converter::needs_zero_division_guard(
+  const std::string &op,
+  const exprt &rhs) const
+{
+  if (op != "Div" && op != "FloorDiv" && op != "Mod")
+    return false;
+
+  if (
+    !rhs.type().is_signedbv() && !rhs.type().is_unsignedbv() &&
+    !rhs.type().is_floatbv())
+    return false;
+
+  return !converting_lambda_body_ && !in_rhs_type_probe_ &&
+         !in_contract_clause_;
+}
+
 exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 {
   // Extract left and right operands from AST
@@ -1602,18 +1631,7 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
         "values");
   }
 
-  // Python raises a *catchable* ZeroDivisionError when the divisor of /, //, or
-  // % is zero (for both int and float operands, unlike C/IEEE). Model it as a
-  // guarded exception raise — the same mechanism list indexing uses for
-  // IndexError — so that `try: x / 0 except ZeroDivisionError: ...` is treated
-  // as SAFE while a bare division by zero propagates and fails. The built-in
-  // C-level div-by-zero assertion cannot express this: it fires regardless of
-  // the surrounding try/except, so caught divisions were wrongly reported.
-  if (
-    (op == "Div" || op == "FloorDiv" || op == "Mod") &&
-    (rhs.type().is_signedbv() || rhs.type().is_unsignedbv() ||
-     rhs.type().is_floatbv()) &&
-    !converting_lambda_body_ && !in_rhs_type_probe_)
+  if (needs_zero_division_guard(op, rhs))
   {
     // The divisor is referenced by both the zero-check guard and the division
     // itself. If it carries a side effect (a call, or a nondet) it would be

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -1378,6 +1378,10 @@ exprt function_call_builder::build() const
     return numpy_call.get();
   }
 
+  const bool saved = converter_.enter_contract_clause(
+    needs_bool_intrinsic_symbol(function_id.get_function()));
   function_call_expr call_expr(function_id, call_, converter_);
-  return call_expr.get();
+  exprt result = call_expr.get();
+  converter_.restore_contract_clause(saved);
+  return result;
 }

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -294,6 +294,17 @@ public:
   python_typechecking &get_typechecker();
   const python_typechecking &get_typechecker() const;
 
+  /// Enters a contract clause or loop invariant, staying entered when already
+  /// inside one. Returns the previous state for @ref restore_contract_clause.
+  bool enter_contract_clause(bool entering)
+  {
+    return std::exchange(in_contract_clause_, in_contract_clause_ || entering);
+  }
+  void restore_contract_clause(bool saved)
+  {
+    in_contract_clause_ = saved;
+  }
+
 private:
   friend class complex_handler;
   friend class function_call_expr;
@@ -1345,6 +1356,14 @@ private:
   // and evaluate a side-effecting divisor an extra time).
   bool converting_lambda_body_ = false;
   bool in_rhs_type_probe_ = false;
+  // A clause is a specification, not code: converting one must not plant a
+  // statement into the enclosing block. The guard did, so annotating a file
+  // changed its verification result with contracts switched off, and a `//` in
+  // a loop invariant raised inside the loop body. C emits nothing from a
+  // clause either.
+  bool in_contract_clause_ = false;
+
+  bool needs_zero_division_guard(const std::string &op, const exprt &rhs) const;
   // Set by resolve_any_subscript_array_type when it adopts an array type for
   // an Any-annotated `row = a[i]`-style assignment. The RHS in that case is a
   // raw index/slice expression rather than an already-materialized array


### PR DESCRIPTION
Fixes #7034.

## Symptom

A `/`, `//` or `%` inside a contract clause or a loop invariant emitted the
ZeroDivisionError guard into the enclosing block. The guard is a *statement*
planted with `add_instruction`, not part of the clause expression, so it
survived even where the clause itself was dropped — a specification became
code.

With no contract flag, annotating a file changed its verification result:

```python
def safe(d: int) -> int:
    __ESBMC_requires(100 // d > 0)
    return 1

def main() -> None:
    x: int = nondet_int()
    assert safe(x) == 1

main()
```

```
$ esbmc repro.py
VERIFICATION FAILED — uncaught exception: ZeroDivisionError

$ esbmc repro.py          # with the __ESBMC_requires line deleted
VERIFICATION SUCCESSFUL
```

`regression/python-contracts/clauses_inert` exists to forbid exactly this;
it did not cover a clause containing a division. A `//` in a loop invariant
had the same shape, raising inside the loop body.

C is inert here in both modes, so the two frontends disagreed on whether
annotating a program may change its result.

## Fix

Suppress the guard while a clause is converted, alongside the two contexts it
already skips: a lambda body converted at its definition (operands still
unbound) and the discarded type-probe pass over an assignment RHS. All three
are places where the division is not really code-generated in its execution
context.

The flag is entered in `function_call_builder::build` for the callees
`needs_bool_intrinsic_symbol` already names — `__ESBMC_requires`,
`__ESBMC_ensures` and `__ESBMC_loop_invariant` — and restored afterwards, so a
division in the *body* still raises normally.

The guard's condition moves into `needs_zero_division_guard`, which leaves
`get_binary_operator_expr` seven decision points lighter than it was and keeps
the complexity gate green.

## Tests

Four new. The two marked red-green were checked by stashing the patch and
rebuilding, not assumed.

| test | master | patched | |
|---|---|---|---|
| `python-contracts/clause_div_inert` | FAILED | SUCCESSFUL | red-green |
| `python/loop_invariant_div_inert` | FAILED | SUCCESSFUL | red-green |
| `python-contracts/clause_div_inert_body_fail` | FAILED | FAILED | control: a division in the body must still raise, so an over-broad suppression is caught |
| `python-contracts/clause_div_enforce` | SUCCESSFUL | SUCCESSFUL | control: `--enforce-contract` unaffected, matching C |

`python-contracts` is 40/40. In `python`, the 171 tests whose `main.py`
contains `//`, `%`, `divmod`, `ZeroDivision`, a loop invariant or a contract
clause all pass — scoped that way rather than run whole, since the full suite
does not finish inside this repo's five-minute cap.
