### PR TITLE
[om] Model ostream insertion and template the string streams

### DIFF
--- a/regression/esbmc-cpp/cpp/fnptr_nothrow_no_branches/main.cpp
+++ b/regression/esbmc-cpp/cpp/fnptr_nothrow_no_branches/main.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+// No function that may throw has its address taken, so the virtual dispatch
+// inside <ostream> must not make main possibly-throwing: a program that only
+// writes to cout carries no exception-propagation branch.
+int main()
+{
+  int x = 1;
+  std::cout << x;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/fnptr_nothrow_no_branches/test.desc
+++ b/regression/esbmc-cpp/cpp/fnptr_nothrow_no_branches/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--branch-coverage --unwind 3 --no-unwinding-assertions
+^Branches : 0$
+^Branch Coverage: N/A \(no branches\)$
+^COVERAGE ANALYSIS COMPLETE$

--- a/regression/esbmc-cpp/cpp/fnptr_throw_propagates/main.cpp
+++ b/regression/esbmc-cpp/cpp/fnptr_throw_propagates/main.cpp
@@ -1,0 +1,35 @@
+#include <cassert>
+
+struct E
+{
+};
+
+static void boom()
+{
+  throw E();
+}
+static void safe()
+{
+}
+
+int main()
+{
+  int nd;
+  void (*f)() = nd ? &boom : &safe;
+
+  bool caught = false;
+  try
+  {
+    f();
+  }
+  catch (E &)
+  {
+    caught = true;
+  }
+
+  // boom() is address-taken and throws, so the call through f must still
+  // propagate: the may-throw analysis may not drop an indirect call whose
+  // possible targets include a throwing function.
+  assert(!caught);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/fnptr_throw_propagates/test.desc
+++ b/regression/esbmc-cpp/cpp/fnptr_throw_propagates/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/ios_default_state_knownbug/test.desc
+++ b/regression/esbmc-cpp/cpp/ios_default_state_knownbug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --std c++17
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ostringstream_str/test.desc
+++ b/regression/esbmc-cpp/cpp/ostringstream_str/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10
+--unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/github_7016_basefield/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7016_basefield/main.cpp
@@ -1,0 +1,24 @@
+#include <sstream>
+#include <iomanip>
+#include <cstring>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream h;
+  h << std::hex << 255;
+  assert(strcmp(h.str().c_str(), "ff") == 0);
+
+  std::ostringstream o;
+  o << std::oct << 8;
+  assert(strcmp(o.str().c_str(), "10") == 0);
+
+  std::ostringstream n;
+  n << std::hex << -1;
+  assert(strcmp(n.str().c_str(), "ffffffff") == 0);
+
+  std::ostringstream b;
+  b << std::setbase(16) << std::uppercase << 255;
+  assert(strcmp(b.str().c_str(), "FF") == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7016_basefield/test.desc
+++ b/regression/esbmc-cpp/stream/github_7016_basefield/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 16 --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/github_7016_hex_width/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7016_hex_width/main.cpp
@@ -1,0 +1,15 @@
+#include <sstream>
+#include <cstring>
+#include <cassert>
+int main() {
+  // [ostream.inserters.arithmetic]: a negative value in a non-decimal base
+  // goes through the same-width unsigned type.
+  std::ostringstream s;
+  s << std::hex << (short)-1;
+  assert(strcmp(s.str().c_str(), "ffff") == 0);
+
+  std::ostringstream l;
+  l << std::hex << (long long)-1;
+  assert(strcmp(l.str().c_str(), "ffffffffffffffff") == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7016_hex_width/test.desc
+++ b/regression/esbmc-cpp/stream/github_7016_hex_width/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 24 --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/github_7016_manipulators/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7016_manipulators/main.cpp
@@ -1,0 +1,20 @@
+#include <sstream>
+#include <iomanip>
+#include <cstring>
+#include <cassert>
+
+int main()
+{
+  std::ostringstream ss;
+  ss << std::setw(4) << 7;
+  assert(strcmp(ss.str().c_str(), "   7") == 0);
+
+  std::ostringstream fs;
+  fs << std::setfill('0') << std::setw(3) << 42;
+  assert(strcmp(fs.str().c_str(), "042") == 0);
+
+  std::ostringstream ls;
+  ls << std::left << std::setw(3) << 5;
+  assert(strcmp(ls.str().c_str(), "5  ") == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7016_manipulators/test.desc
+++ b/regression/esbmc-cpp/stream/github_7016_manipulators/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12 --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/github_7016_manipulators_fail/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7016_manipulators_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <sstream>
+#include <iomanip>
+#include <cassert>
+
+// Pins github #7016: the pre-fix model discarded every insertion reached
+// through an ostream&, so this empty-output claim held.
+int main()
+{
+  std::ostringstream ss;
+  ss << std::setw(4) << 7;
+  assert(ss.str().size() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7016_manipulators_fail/test.desc
+++ b/regression/esbmc-cpp/stream/github_7016_manipulators_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 12 --timeout 120
+^  assertion ss\.str\(\)\.size\(\) == 0$
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/stream/github_7016_ostream_ref/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7016_ostream_ref/main.cpp
@@ -1,0 +1,24 @@
+#include <sstream>
+#include <ostream>
+#include <cstring>
+#include <cassert>
+
+struct Point
+{
+  int x, y;
+};
+
+std::ostream &operator<<(std::ostream &o, const Point &p)
+{
+  o << p.x << "," << p.y;
+  return o;
+}
+
+int main()
+{
+  std::ostringstream ss;
+  Point p = {3, 4};
+  ss << p;
+  assert(strcmp(ss.str().c_str(), "3,4") == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7016_ostream_ref/test.desc
+++ b/regression/esbmc-cpp/stream/github_7016_ostream_ref/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12 --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/github_7016_ostream_ref_helper/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7016_ostream_ref_helper/main.cpp
@@ -1,0 +1,17 @@
+#include <sstream>
+#include <ostream>
+#include <cstring>
+#include <cassert>
+
+static void emit(std::ostream &o)
+{
+  o << "id=" << 12;
+}
+
+int main()
+{
+  std::ostringstream hs;
+  emit(hs);
+  assert(strcmp(hs.str().c_str(), "id=12") == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7016_ostream_ref_helper/test.desc
+++ b/regression/esbmc-cpp/stream/github_7016_ostream_ref_helper/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12 --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/github_7016_setw_negative/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7016_setw_negative/main.cpp
@@ -1,0 +1,13 @@
+#include <sstream>
+#include <iomanip>
+#include <cstring>
+#include <cassert>
+// [ios.base]: a negative width is well-formed and means "no padding". The
+// model's streamsize is unsigned, so it has to clamp rather than wrap.
+int main()
+{
+  std::ostringstream s;
+  s << std::setw(-1) << 5;
+  assert(strcmp(s.str().c_str(), "5") == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7016_setw_negative/test.desc
+++ b/regression/esbmc-cpp/stream/github_7016_setw_negative/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12 --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/github_7017_basic_stringstream/main.cpp
+++ b/regression/esbmc-cpp/stream/github_7017_basic_stringstream/main.cpp
@@ -1,0 +1,35 @@
+#include <sstream>
+#include <cstring>
+#include <cassert>
+
+template <class T>
+struct MyAlloc
+{
+  typedef T value_type;
+  MyAlloc()
+  {
+  }
+  template <class U>
+  MyAlloc(const MyAlloc<U> &)
+  {
+  }
+  T *allocate(size_t n)
+  {
+    return (T *)::operator new(n * sizeof(T));
+  }
+  void deallocate(T *p, size_t)
+  {
+    ::operator delete(p);
+  }
+};
+
+typedef std::basic_stringstream<char, std::char_traits<char>, MyAlloc<char> >
+  Stream;
+
+int main()
+{
+  Stream ss;
+  ss << "n=" << 42;
+  assert(strcmp(ss.str().c_str(), "n=42") == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/github_7017_basic_stringstream/test.desc
+++ b/regression/esbmc-cpp/stream/github_7017_basic_stringstream/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12 --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/definitions.h
+++ b/src/cpp/library/definitions.h
@@ -19,8 +19,28 @@ typedef __int64 streamsize;
 typedef unsigned int streamsize;
 #endif
 
+/* The <iomanip> manipulators are implementation-defined types; the model
+ * funnels all of them through this one, tagged with which setting to apply
+ * when it reaches a stream (github #7016). */
 class smanip
 {
+public:
+  enum kind
+  {
+    _setiosflags,
+    _resetiosflags,
+    _setbase,
+    _setfill,
+    _setprecision,
+    _setw
+  };
+
+  int _kind;
+  long _arg;
+
+  smanip(kind k, long a) : _kind(k), _arg(a)
+  {
+  }
 };
 
 #define _SIZE_T_DEFINED

--- a/src/cpp/library/fstream
+++ b/src/cpp/library/fstream
@@ -53,7 +53,11 @@ private:
   ios::streampos _filepos = 0;
 };
 
-class fstream : public istream, public ostream
+/* ostream first: a virtual call through a non-first base that itself derives
+ * virtually dereferences a bad vtable pointer (github #7025), and every
+ * formatted insertion dispatches through ostream. iostream already orders the
+ * bases this way. */
+class fstream : public ostream, public istream
 {
 public:
   fstream();

--- a/src/cpp/library/iomanip
+++ b/src/cpp/library/iomanip
@@ -8,12 +8,35 @@ namespace std
 {
 //Parameterized manipulators
 
-smanip setiosflags(ios_base::fmtflags mask);
-smanip resetiosflags(ios_base::fmtflags mask);
-smanip setbase(int base);
-smanip setfill(char c);
-smanip setprecision(int n);
-smanip setw(int n);
+inline smanip setiosflags(ios_base::fmtflags mask)
+{
+  return smanip(smanip::_setiosflags, mask);
+}
+
+inline smanip resetiosflags(ios_base::fmtflags mask)
+{
+  return smanip(smanip::_resetiosflags, mask);
+}
+
+inline smanip setbase(int base)
+{
+  return smanip(smanip::_setbase, base);
+}
+
+inline smanip setfill(char c)
+{
+  return smanip(smanip::_setfill, c);
+}
+
+inline smanip setprecision(int n)
+{
+  return smanip(smanip::_setprecision, n);
+}
+
+inline smanip setw(int n)
+{
+  return smanip(smanip::_setw, n);
+}
 
 } // namespace std
 

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -164,7 +164,7 @@ public:
 
   ios()
   {
-    ios_base();
+    __fill = ' ';
   }
   virtual ~ios()
   {
@@ -209,11 +209,17 @@ ios_base::ios_base()
 {
   __streambuf_state = goodbit;
   __exception = goodbit;
+  // [ios.base.cons]: width starts at 0, precision at 6.
+  __width = 0;
+  __precision = 6;
 }
 
+/* Caveat: __flags is `static`, so format state is shared between every
+ * stream -- `cout << hex` changes the base a later ostringstream formats in.
+ * Making it a member of the virtual ios_base base costs ~15x in symex. */
 ios_base::fmtflags ios_base::flags() const
 {
-  return (bool)__flags;
+  return __flags;
 }
 
 ios_base::fmtflags ios_base::flags(ios_base::fmtflags fmtfl)

--- a/src/cpp/library/iosfwd
+++ b/src/cpp/library/iosfwd
@@ -5,11 +5,12 @@
 //
 // ESBMC forces -nostdinc++ and resolves #include <...> only against this
 // bundled OM tree, so <iosfwd> must exist here for TUs that include it to
-// parse.  The stream OMs define *concrete* (non-template) classes rather than
+// parse.  Most stream OMs are *concrete* (non-template) classes rather than
 // the standard basic_*<charT> templates with typedefs, so these forward
 // declarations name those concrete classes directly.  Using the standard
 // "template <...> class basic_ostream; typedef basic_ostream<char> ostream;"
-// form would redefine e.g. ostream and break <ostream>.
+// form would redefine e.g. ostream and break <ostream>.  The <sstream>
+// classes are the exception -- they really are templates (github #7017).
 
 namespace std
 {
@@ -23,10 +24,37 @@ class filebuf;
 class ifstream;
 class ofstream;
 class fstream;
-class stringbuf;
-class istringstream;
-class ostringstream;
-class stringstream;
+
+template <class CharT>
+struct char_traits;
+template <class T>
+class allocator;
+
+template <
+  class CharT,
+  class Traits = char_traits<CharT>,
+  class Alloc = allocator<CharT> >
+class basic_stringbuf;
+template <
+  class CharT,
+  class Traits = char_traits<CharT>,
+  class Alloc = allocator<CharT> >
+class basic_istringstream;
+template <
+  class CharT,
+  class Traits = char_traits<CharT>,
+  class Alloc = allocator<CharT> >
+class basic_ostringstream;
+template <
+  class CharT,
+  class Traits = char_traits<CharT>,
+  class Alloc = allocator<CharT> >
+class basic_stringstream;
+
+typedef basic_stringbuf<char> stringbuf;
+typedef basic_istringstream<char> istringstream;
+typedef basic_ostringstream<char> ostringstream;
+typedef basic_stringstream<char> stringstream;
 } // namespace std
 
 #endif

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -344,9 +344,16 @@ public:
     : out_stream(&s), delim(delimiter)
   {
   }
-  ostream_iterator(ostream_iterator<T, charT, traits> &x); /* :
-			out_stream(x.out_stream), delim(x.delim) {
-	}*/
+  /* Needs a body for the same reason ostream's own constructors do: an
+   * undefined one leaves out_stream unconstrained, and std::copy takes the
+   * iterator by value -- an insertion through the copy then dispatches on a
+   * vtable pointer no value set can pin down, surfacing as "No target
+   * candidate" and a bogus invalid-pointer violation on a safe program.
+   * [ostream.iterator.cons] declares the parameter const. */
+  ostream_iterator(const ostream_iterator<T, charT, traits> &x)
+    : out_stream(x.out_stream), delim(x.delim)
+  {
+  }
   ~ostream_iterator()
   {
   }

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -3,8 +3,12 @@
 
 #include "ios"
 #include "definitions.h"
-//#include "iomanip"
-//#include "cstring"
+#include "cstring"
+
+/* Widest field a stream can hold. Matches STRING_CAPACITY in <string>, which
+ * is what ostringstream::str() has to fit the result into. */
+#define OSTREAM_CAPACITY 128
+#define OSTREAM_NUM_SIZE 24
 
 namespace std
 {
@@ -14,7 +18,16 @@ class ostream : virtual public ios
   typedef int streamoff;
 
 public:
-  explicit ostream(streambuf *sb);
+  /* Both constructors need a body: an undefined one leaves the object -- its
+   * vtable pointer included -- unconstructed, and the first insertion then
+   * dereferences a bad pointer through the sink dispatch below. */
+  explicit ostream(streambuf *sb)
+  {
+    _filesize = nondet_uint();
+    _filepos = 0;
+    __streambuf = sb;
+  }
+
   ostream()
   {
     _filesize = nondet_uint();
@@ -25,23 +38,15 @@ public:
   {
   }
 
-  /* width/fill/precision are members of ios_base/ios, not of ostream
-   * ([ostream.formatted] lists no such members). Declaring them here hid the
-   * inherited overload sets: `cout.precision()` did not resolve at all, and
-   * `cout.precision(3)` / `cout.fill(c)` bound to void-returning stubs whose
-   * bodies were commented out, so the setting was silently discarded.
-   * ostream::width was declared and never defined, so it returned a
-   * nondeterministic value. Removing all four lets the inherited members
-   * through. */
+  /* width/fill/precision stay inherited: [ostream.formatted] gives ostream no
+   * such members, and redeclaring them here hides the ios_base overload
+   * sets. */
   void put(char c);
-  //	void write(char str[], size_t n);
   ostream &write(const char *s, streamsize n);
   streampos tellp();                                    //model
   ostream &seekp(streampos pos);                        //model
   ostream &seekp(streamoff off, ios_base::seekdir dir); //model
   ostream &flush();
-  ios_base::fmtflags flags() const;
-  ios_base::fmtflags flags(ios_base::fmtflags fmtfl);
 
   class sentry
   {
@@ -57,73 +62,152 @@ public:
   ostream &operator=(const ostream &); // disabled
   static streamsize _filesize;
   static ios::streampos _filepos;
+
+  /* The character sink the inserters below feed. It hangs off the base, so
+   * that a chain whose static type is ostream& -- a manipulator, a
+   * user-defined inserter, any helper taking ostream& -- still reaches the
+   * derived stream's buffer, which is what github #7016 was about. cout & co.
+   * inherit the discarding default.
+   *
+   * Virtual rather than a `bool _sink` data member tested in place: symex
+   * resolves the dispatch from the object's dynamic type and drops the append
+   * path outright, whereas a flag stops constant-folding as soon as any
+   * unrelated pointer write (a std::string operation, say) widens the value
+   * set -- the appends then cost one --incremental-bmc k step per character.
+   * Appends take an explicit length for the same reason: strlen() over a
+   * 128-byte buffer is a loop no unwind bound folds away.
+   *
+   * _discard() also consumes width(): [ostream.formatted.reqmts] has a
+   * formatted insertion reset it whether or not anything is buffered. */
+  virtual bool _discard()
+  {
+    width(0);
+    return true;
+  }
+  virtual void _sink_write(const char *s, streamsize n)
+  {
+  }
+  virtual void _sink_fill(char c, streamsize n)
+  {
+  }
+
+  void _put_field(const char *s, streamsize n);
+  int _base() const;
+  /* `bytes` is sizeof the source type: [ostream.inserters.arithmetic] routes a
+   * signed value through the *same-width* unsigned type when the base is not
+   * decimal, so `<< hex << -1` is width-sensitive ("ffffffff" for int). */
+  void _put_num(long long val, unsigned bytes);
+  void _put_unum(unsigned long long val);
+  void _put_double(double val);
+  void _apply(const smanip &m);
 };
 //ios::streampos ostream::_filepos = 0;
 
 // Ostream shift output operators: these are explicitly enumerated by the
-// spec, and thus we can't template them, or crazy things happen. Until
-// someone knows how much of this to model, just discard the data for now.
+// spec, and thus we can't template them, or crazy things happen.
 
 inline ostream &operator<<(ostream &o, bool val)
 {
+  if (o.flags() & ios_base::boolalpha)
+    o._put_field(val ? "true" : "false", val ? 4 : 5);
+  else
+    o._put_field(val ? "1" : "0", 1);
+  return o;
+}
+inline ostream &operator<<(ostream &o, char val)
+{
+  char s[2] = {val, '\0'};
+  o._put_field(s, 1);
+  return o;
+}
+inline ostream &operator<<(ostream &o, signed char val)
+{
+  return o << (char)val;
+}
+inline ostream &operator<<(ostream &o, unsigned char val)
+{
+  return o << (char)val;
+}
+inline ostream &operator<<(ostream &o, const char *val)
+{
+  // strlen() is a loop; keep it off the path of a stream that discards.
+  if (!o._discard())
+    o._put_field(val, strlen(val));
   return o;
 }
 inline ostream &operator<<(ostream &o, short val)
 {
+  o._put_num(val, sizeof(short));
   return o;
 }
 inline ostream &operator<<(ostream &o, unsigned short val)
 {
+  o._put_unum(val);
   return o;
 }
 inline ostream &operator<<(ostream &o, int val)
 {
+  o._put_num(val, sizeof(int));
   return o;
 }
 inline ostream &operator<<(ostream &o, unsigned int val)
 {
+  o._put_unum(val);
   return o;
 }
 #if defined(__clang__) ||                                                      \
   __WORDSIZE == 64 // Is the same type as 'int' otherwise.
 inline ostream &operator<<(ostream &o, long val)
 {
+  o._put_num(val, sizeof(long));
   return o;
 }
 inline ostream &operator<<(ostream &o, unsigned long val)
 {
+  o._put_unum(val);
   return o;
 }
 #endif
 inline ostream &operator<<(ostream &o, long long val)
 {
+  o._put_num(val, sizeof(long long));
   return o;
 }
 inline ostream &operator<<(ostream &o, unsigned long long val)
 {
+  o._put_unum(val);
   return o;
 }
 inline ostream &operator<<(ostream &o, float val)
 {
+  o._put_double(val);
   return o;
 }
 inline ostream &operator<<(ostream &o, double val)
 {
+  o._put_double(val);
   return o;
 }
 #if defined(__clang__)
 // Identical to double under ESBMC.
 inline ostream &operator<<(ostream &o, long double val)
 {
+  o._put_double((double)val);
   return o;
 }
 #endif
+inline ostream &operator<<(ostream &o, const void *val)
+{
+  o._put_unum((unsigned long long)val);
+  return o;
+}
 inline ostream &operator<<(ostream &o, void *val)
 {
-  return o;
+  return o << (const void *)val;
 }
 inline ostream &operator<<(ostream &o, const smanip &val)
 {
+  o._apply(val);
   return o;
 }
 
@@ -142,14 +226,229 @@ using basic_ostream = ostream;
 
 namespace std
 {
+/* [ostream.formatted.reqmts]: a formatted insertion pads to width() with
+ * fill() and then resets width() to 0. */
+void ostream::_put_field(const char *s, streamsize n)
+{
+  if (_discard())
+    return;
+
+  streamsize w = width();
+  width(0);
+  streamsize pad = (n < w) ? w - n : 0;
+
+  if (flags() & ios_base::left)
+  {
+    _sink_write(s, n);
+    _sink_fill(fill(), pad);
+  }
+  else
+  {
+    _sink_fill(fill(), pad);
+    _sink_write(s, n);
+  }
+}
+
+// The converters return the number of characters written, so that no caller
+// has to strlen() the result back.
+int _ostream_utoa_base(unsigned long long v, int base, bool upper, char *s)
+{
+  char rev[OSTREAM_NUM_SIZE];
+  int n = 0;
+  do
+  {
+    int d = (int)(v % (unsigned long long)base);
+    rev[n++] = (char)(d < 10 ? '0' + d : (upper ? 'A' : 'a') + (d - 10));
+    v /= (unsigned long long)base;
+  } while (v != 0);
+
+  int i = 0;
+  while (n > 0)
+    s[i++] = rev[--n];
+  s[i] = '\0';
+  return i;
+}
+
+int _ostream_utoa(unsigned long long v, char *s)
+{
+  return _ostream_utoa_base(v, 10, false, s);
+}
+
+int _ostream_itoa(long long val, char *s)
+{
+  if (val >= 0)
+    return _ostream_utoa((unsigned long long)val, s);
+
+  s[0] = '-';
+  // Negating in unsigned avoids the overflow on LLONG_MIN.
+  return 1 + _ostream_utoa(0ULL - (unsigned long long)val, s + 1);
+}
+
+int ostream::_base() const
+{
+  fmtflags b = flags() & ios_base::basefield;
+  if (b == ios_base::hex)
+    return 16;
+  if (b == ios_base::oct)
+    return 8;
+  return 10;
+}
+
+void ostream::_put_num(long long val, unsigned bytes)
+{
+  if (_discard())
+    return;
+
+  char buf[OSTREAM_NUM_SIZE + 1];
+  int base = _base();
+  if (base == 10)
+  {
+    _put_field(buf, _ostream_itoa(val, buf));
+    return;
+  }
+
+  // Reinterpret in the same-width unsigned type, without shifting by the full
+  // width (undefined when bytes == sizeof(long long)).
+  unsigned long long u = (unsigned long long)val;
+  if (bytes < sizeof(unsigned long long))
+    u &= (1ULL << (bytes * 8)) - 1ULL;
+  _put_field(
+    buf, _ostream_utoa_base(u, base, (flags() & ios_base::uppercase) != 0, buf));
+}
+
+void ostream::_put_unum(unsigned long long val)
+{
+  if (_discard())
+    return;
+
+  char buf[OSTREAM_NUM_SIZE];
+  _put_field(
+    buf,
+    _ostream_utoa_base(
+      val, _base(), (flags() & ios_base::uppercase) != 0, buf));
+}
+
+/* %g-like formatting to `sig` significant digits, with trailing zeros and a
+ * trailing '.' stripped to match the iostream default. Long double maps to
+ * double under ESBMC. Deviations from %g a caller can observe: the integer
+ * part must fit in `int`; a leading "0." counts against `sig`; there is no
+ * switch to exponent notation; and NaN/infinity are not handled. Each digit
+ * emitted costs one loop iteration, so a program printing wide values needs a
+ * matching --unwind. */
+int _ostream_dtoa(double val, int sig, char *out)
+{
+  int len = 0;
+  if (val < 0)
+  {
+    out[len++] = '-';
+    val = -val;
+  }
+  int ipart = (int)val;
+  int idigits = _ostream_utoa((unsigned long long)ipart, out + len);
+
+  // A double carries no more than 17 significant decimal digits, and 10^prec
+  // has to stay inside long long.
+  if (sig > 15)
+    sig = 15;
+  // Ternary, not `if (prec < 0) prec = 0;`. With `--unwind 10`
+  // (no `--incremental-bmc`) ESBMC's interval domain widens `prec`
+  // through the if-clamp and produces a false positive on a later
+  // `len` invariant; the ternary is opaque to that widening. Verified
+  // against regression/esbmc-cpp/stream/sstream_str_{char,double,float}
+  // (issue #4401).
+  int prec = (idigits < sig) ? (sig - idigits) : 0;
+
+  char fbuf[OSTREAM_NUM_SIZE];
+  int flen = 0;
+  if (prec > 0)
+  {
+    double fpart = val - (double)ipart;
+    long long mult = 1;
+    for (int i = 0; i < prec; i++)
+      mult *= 10;
+    long long fint = (long long)(fpart * (double)mult + 0.5);
+
+    // Half-up rounding can produce fint == mult (e.g. fpart = 0.999999,
+    // mult = 1e6). Promote the carry into ipart and re-emit so the
+    // leading digit is not silently dropped from the fractional buffer.
+    if (fint >= mult)
+    {
+      ipart++;
+      idigits = _ostream_utoa((unsigned long long)ipart, out + len);
+      fint = 0;
+    }
+
+    flen = prec;
+    for (int j = prec; j > 0; fint /= 10)
+      fbuf[--j] = (char)('0' + (int)(fint % 10));
+    while (flen > 0 && fbuf[flen - 1] == '0')
+      flen--;
+  }
+
+  len += idigits;
+  if (flen > 0)
+  {
+    out[len++] = '.';
+    for (int i = 0; i < flen; i++)
+      out[len++] = fbuf[i];
+  }
+  out[len] = '\0';
+  return len;
+}
+
+void ostream::_put_double(double val)
+{
+  if (_discard())
+    return;
+
+  char buf[OSTREAM_CAPACITY];
+  _put_field(buf, _ostream_dtoa(val, (int)precision(), buf));
+}
+
+/* Only width and fill reach the output; the remaining settings are recorded
+ * so that a later flags()/precision() query answers consistently. */
+void ostream::_apply(const smanip &m)
+{
+  switch (m._kind)
+  {
+  case smanip::_setw:
+    // streamsize is unsigned here, and setw(-1) is well-formed and means "no
+    // padding" ([ios.base]); assigning it raw would ask for a 4e9-wide field.
+    width(m._arg > 0 ? (streamsize)m._arg : 0);
+    break;
+  case smanip::_setfill:
+    fill((char)m._arg);
+    break;
+  case smanip::_setprecision:
+    precision(m._arg > 0 ? (streamsize)m._arg : 0);
+    break;
+  case smanip::_setbase:
+    setf(
+      m._arg == 8 ? ios_base::oct : (m._arg == 16 ? ios_base::hex
+                                                  : ios_base::dec),
+      ios_base::basefield);
+    break;
+  case smanip::_setiosflags:
+    setf(m._arg);
+    break;
+  case smanip::_resetiosflags:
+    unsetf(m._arg);
+    break;
+  }
+}
+
+// [ostream.unformatted]: no padding, and width() is left alone.
 void ostream::put(char c)
 {
+  char s[2] = {c, '\0'};
+  _sink_write(s, 1);
 }
 
 //	void ostream::write(char str[], size_t n)
 ostream &ostream::write(const char *s, streamsize n)
 {
   _filepos = n;
+  _sink_write(s, n);
   return *this;
 }
 
@@ -193,14 +492,18 @@ inline ostream &flush(ostream &os)
   return os.flush();
 }
 
-inline ostream& boolalpha(ostream& os) 
-{
-  return os;
-}
-
 inline ostream &operator<<(ostream &o, ostream& (*manip)(ostream&))
 {
   return manip(o);
+}
+
+/* [ostream.manip] also reaches the ios_base manipulators -- left, right, hex,
+ * boolalpha and the rest, declared in <ios> as ios_base&(*)(ios_base&).
+ * Without this overload they convert to `const void*` and print a pointer. */
+inline ostream &operator<<(ostream &o, ios_base &(*manip)(ios_base &))
+{
+  manip(o);
+  return o;
 }
 
 } // namespace std

--- a/src/cpp/library/sstream
+++ b/src/cpp/library/sstream
@@ -1,349 +1,264 @@
 #ifndef STL_SSTREAM
 #define STL_SSTREAM
 
+#include "iosfwd"
 #include "streambuf"
 #include "definitions.h"
 #include "ostream"
+#include "istream"
 #include "ios"
 #include "string"
+#include "memory"
 #include "cstdio"
 #include "cstdlib"
-
-#ifdef _WIN64
-#define NUM_SIZE 20
-#else
-#define NUM_SIZE 20
-#endif
-#define DEC 10
-
-/* TODO: this is not part of <sstream> */
-extern "C" void itoa(int value, char *str, int base);
+#include "cstring"
 
 namespace std
 {
-class stringbuf : public streambuf
+/* The string streams used to be plain classes bound to std::string, so any
+ * instantiation over a non-default allocator failed to parse (github #7017).
+ * basic_ostringstream overrides the ostream sink, which is what makes an
+ * insertion through an ostream& reach the stream (github #7016). */
+template <class CharT, class Traits, class Alloc>
+class basic_stringbuf : public streambuf
 {
 public:
-  explicit stringbuf(ios_base::openmode which = ios_base::in | ios_base::out);
-  explicit stringbuf(
-    const string &str,
+  typedef basic_string<CharT, Traits, Alloc> string_type;
+
+  explicit basic_stringbuf(
     ios_base::openmode which = ios_base::in | ios_base::out);
-  void str(const string &s);
-  string str() const;
+  explicit basic_stringbuf(
+    const string_type &str,
+    ios_base::openmode which = ios_base::in | ios_base::out);
+  void str(const string_type &s);
+  string_type str() const;
 };
 
-class istringstream : public istream
+template <class CharT, class Traits, class Alloc>
+class basic_istringstream : public istream
 {
 public:
-  explicit istringstream(openmode which = ios_base::in)
+  typedef basic_string<CharT, Traits, Alloc> string_type;
+
+  explicit basic_istringstream(ios_base::openmode which = ios_base::in)
+    : istream()
   {
-    istream();
   }
-  explicit istringstream(const string &str, openmode which = ios_base::in)
+  explicit basic_istringstream(
+    const string_type &str,
+    ios_base::openmode which = ios_base::in)
+    : istream()
   {
-    istream();
   }
-  stringbuf *rdbuf() const;
-  string str() const;
-  void str(const string &s);
+  basic_stringbuf<CharT, Traits, Alloc> *rdbuf() const;
+  string_type str() const;
+  void str(const string_type &s);
 };
 
-class stringstream : public istream, public ostream
+template <class CharT, class Traits, class Alloc>
+class basic_ostringstream : public ostream
 {
 public:
-  string _string;
-  explicit stringstream(openmode which = ios_base::out | ios_base::in)
-    : istream(), ostream(), _string("")
+  typedef basic_string<CharT, Traits, Alloc> string_type;
+
+  streamsize _len;
+  char _buf[OSTREAM_CAPACITY];
+
+  explicit basic_ostringstream(ios_base::openmode which = ios_base::out)
+    : ostream(), _len(0)
   {
   }
 
-  explicit stringstream(
-    const string &str,
-    openmode which = ios_base::out | ios_base::in)
-    : istream(), ostream(), _string("")
+  explicit basic_ostringstream(
+    const string_type &str,
+    ios_base::openmode which = ios_base::out)
+    : ostream(), _len(0)
+  {
+    _sink_write(str.c_str(), str.size());
+  }
+
+  virtual bool _discard()
+  {
+    return false;
+  }
+
+  virtual void _sink_write(const char *s, streamsize n)
+  {
+    __ESBMC_assert(_len + n < OSTREAM_CAPACITY, "ostream capacity exceeded");
+    memcpy(_buf + _len, s, n);
+    _len += n;
+  }
+
+  virtual void _sink_fill(char c, streamsize n)
+  {
+    __ESBMC_assert(_len + n < OSTREAM_CAPACITY, "ostream capacity exceeded");
+    memset(_buf + _len, c, n);
+    _len += n;
+  }
+
+  basic_stringbuf<CharT, Traits, Alloc> *rdbuf() const;
+
+  string_type str() const
+  {
+    return string_type(_buf, _len);
+  }
+
+  void str(const string_type &s)
+  {
+    _len = 0;
+    _sink_write(s.c_str(), s.size());
+  }
+};
+
+/* Unlike the other three, this one keeps its own buffer and its own inserters
+ * instead of overriding the ostream sink: it derives from both stream classes,
+ * and a member reached through `this` in that layout resolves to the wrong
+ * offset (github #7025) -- _len read inside an inherited _sink_write() yields
+ * another field's bytes. Members of the complete object are safe, so the
+ * inserters return the derived type to keep a chain off the base; insertion
+ * through an explicit ostream& still does not reach a stringstream
+ * (github #7016). ostream comes first so that such an insertion at least
+ * discards rather than dispatching through a bad vtable pointer. Fold this
+ * back into the base once #7025 is fixed. */
+template <class CharT, class Traits, class Alloc>
+class basic_stringstream : public ostream, public istream
+{
+public:
+  typedef basic_string<CharT, Traits, Alloc> string_type;
+
+  string_type _sbuf;
+
+  explicit basic_stringstream(
+    ios_base::openmode which = ios_base::out | ios_base::in)
+    : ostream(), istream(), _sbuf("")
   {
   }
 
-  stringbuf *rdbuf() const;
-
-  string str() const
+  explicit basic_stringstream(
+    const string_type &str,
+    ios_base::openmode which = ios_base::out | ios_base::in)
+    : ostream(), istream(), _sbuf(str)
   {
-    return _string;
   }
 
-  ostream &operator<<(const string &val)
+  basic_stringbuf<CharT, Traits, Alloc> *rdbuf() const;
+
+  string_type str() const
   {
-    _string.append(val.c_str());
+    return _sbuf;
+  }
+
+  void str(const string_type &s)
+  {
+    _sbuf = s;
+  }
+
+  basic_stringstream &operator<<(const string_type &val)
+  {
+    _sbuf.append(val.c_str());
     return *this;
   }
 
-  ostream &operator<<(bool val)
+  basic_stringstream &operator<<(const char *val)
   {
-    if (val)
-      _string.append("1");
-    else
-      _string.append("0");
+    _sbuf.append(val);
     return *this;
   }
 
-  ostream &operator<<(void* val)
+  basic_stringstream &operator<<(char val)
   {
-    char temp[NUM_SIZE];
-    // Convert pointer to string representation (hexadecimal)
-    // For simplicity, just convert the pointer value to decimal
-    itoa(reinterpret_cast<unsigned long long>(val), temp, DEC);
-    _string.append(temp);
+    _sbuf.append(&val, 1);
     return *this;
   }
 
-  ostream &operator<<(short val)
+  basic_stringstream &operator<<(signed char val)
   {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
+    return *this << (char)val;
+  }
+
+  basic_stringstream &operator<<(unsigned char val)
+  {
+    return *this << (char)val;
+  }
+
+  basic_stringstream &operator<<(bool val)
+  {
+    _sbuf.append(val ? "1" : "0");
     return *this;
   }
 
-  ostream &operator<<(int val)
+  basic_stringstream &operator<<(short val)
   {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
+    return *this << (long long)val;
+  }
+
+  basic_stringstream &operator<<(int val)
+  {
+    return *this << (long long)val;
+  }
+
+  basic_stringstream &operator<<(long val)
+  {
+    return *this << (long long)val;
+  }
+
+  basic_stringstream &operator<<(long long val)
+  {
+    char temp[OSTREAM_NUM_SIZE + 1];
+    _ostream_itoa(val, temp);
+    _sbuf.append(temp);
     return *this;
   }
 
-  ostream &operator<<(long val)
+  basic_stringstream &operator<<(unsigned short val)
   {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
+    return *this << (unsigned long long)val;
+  }
+
+  basic_stringstream &operator<<(unsigned int val)
+  {
+    return *this << (unsigned long long)val;
+  }
+
+  basic_stringstream &operator<<(unsigned long val)
+  {
+    return *this << (unsigned long long)val;
+  }
+
+  basic_stringstream &operator<<(unsigned long long val)
+  {
+    char temp[OSTREAM_NUM_SIZE];
+    _ostream_utoa(val, temp);
+    _sbuf.append(temp);
     return *this;
   }
 
-  ostream &operator<<(unsigned short val)
+  basic_stringstream &operator<<(const void *val)
   {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
+    return *this << (unsigned long long)val;
+  }
+
+  basic_stringstream &operator<<(void *val)
+  {
+    return *this << (const void *)val;
+  }
+
+  basic_stringstream &operator<<(double val)
+  {
+    char temp[OSTREAM_CAPACITY];
+    _ostream_dtoa(val, 6, temp);
+    _sbuf.append(temp);
     return *this;
   }
 
-  ostream &operator<<(unsigned int val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
-  }
-
-  ostream &operator<<(unsigned long val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
-  }
-
-  // Default-precision (6 significant digits) %g-like formatting, with trailing
-  // zeros and a trailing '.' stripped to match iostream defaults. Negative
-  // values get a leading '-'; the integer part fits in `int` (sufficient for
-  // the regression tests). Long double maps to double under ESBMC.
-  ostream &operator<<(double val)
-  {
-    char buf[NUM_SIZE];
-    if (val < 0)
-    {
-      _string.append("-");
-      val = -val;
-    }
-    int ipart = (int)val;
-    itoa(ipart, buf, DEC);
-    int len = strlen(buf);
-
-    // Ternary, not `if (prec < 0) prec = 0;`. With `--unwind 10`
-    // (no `--incremental-bmc`) ESBMC's interval domain widens `prec`
-    // through the if-clamp and produces a false positive on a later
-    // `len` invariant; the ternary is opaque to that widening. Verified
-    // against regression/esbmc-cpp/stream/sstream_str_{char,double,float}
-    // (issue #4401).
-    int prec = (len < 6) ? (6 - len) : 0;
-    if (prec > 0)
-    {
-      double fpart = val - (double)ipart;
-      long mult = 1;
-      for (int i = 0; i < prec; i++)
-        mult *= DEC;
-      long fint = (long)(fpart * (double)mult + 0.5);
-
-      // Half-up rounding can produce fint == mult (e.g. fpart = 0.999999,
-      // mult = 1e6). Promote the carry into ipart and re-emit so the
-      // leading digit is not silently dropped from the fractional buffer.
-      if (fint >= mult)
-      {
-        ipart++;
-        itoa(ipart, buf, DEC);
-        len = strlen(buf);
-        fint = 0;
-      }
-
-      char fbuf[NUM_SIZE];
-      int j = prec;
-      fbuf[j] = '\0';
-      while (j > 0)
-      {
-        fbuf[--j] = '0' + (int)(fint % 10);
-        fint /= 10;
-      }
-      int flen = prec;
-      while (flen > 0 && fbuf[flen - 1] == '0')
-        fbuf[--flen] = '\0';
-      if (flen > 0)
-      {
-        buf[len++] = '.';
-        buf[len] = '\0';
-        strcat(buf, fbuf);
-      }
-    }
-    _string.append(buf);
-    return *this;
-  }
-
-  ostream &operator<<(float val)
+  basic_stringstream &operator<<(float val)
   {
     return *this << (double)val;
   }
 
-  ostream &operator<<(long double val)
+  basic_stringstream &operator<<(long double val)
   {
     return *this << (double)val;
-  }
-
-  ostream &operator<<(char val)
-  {
-    _string.append(&val, 1);
-    return *this;
-  }
-
-  ostream &operator<<(signed char val)
-  {
-    _string.append(reinterpret_cast<const char *>(&val), 1);
-    return *this;
-  }
-
-  ostream &operator<<(unsigned char val)
-  {
-    _string.append(reinterpret_cast<const char *>(&val), 1);
-    return *this;
-  }
-
-  ostream &operator<<(const char *val)
-  {
-    _string.append(val);
-    return *this;
-  }
-};
-
-/* str() and the inserters were declared and never defined, so every use of an
- * ostringstream produced a nondeterministic string. Back it with the same
- * member stringstream uses, and give it the inserters that carry the common
- * types. */
-class ostringstream : public ostream
-{
-public:
-  string _string;
-
-  explicit ostringstream(openmode which = out) : ostream(), _string("")
-  {
-  }
-
-  explicit ostringstream(const string &str, openmode which = out)
-    : ostream(), _string(str)
-  {
-  }
-
-  stringbuf *rdbuf() const;
-
-  string str() const
-  {
-    return _string;
-  }
-
-  void str(const string &s)
-  {
-    _string = s;
-  }
-
-  ostream &operator<<(const string &val)
-  {
-    _string.append(val.c_str());
-    return *this;
-  }
-
-  ostream &operator<<(const char *val)
-  {
-    _string.append(val);
-    return *this;
-  }
-
-  ostream &operator<<(char val)
-  {
-    char temp[2] = {val, '\0'};
-    _string.append(temp);
-    return *this;
-  }
-
-  ostream &operator<<(bool val)
-  {
-    _string.append(val ? "1" : "0");
-    return *this;
-  }
-
-  ostream &operator<<(short val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
-  }
-
-  ostream &operator<<(int val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
-  }
-
-  ostream &operator<<(long val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
-  }
-
-  ostream &operator<<(unsigned short val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
-  }
-
-  ostream &operator<<(unsigned int val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
-  }
-
-  ostream &operator<<(unsigned long val)
-  {
-    char temp[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    return *this;
   }
 };
 

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1244,8 +1244,11 @@ __ESBMC_HIDE:
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-inline ostream &operator<<(ostream &o, basic_string<CharT, Traits, Alloc>)
+inline ostream &
+operator<<(ostream &o, const basic_string<CharT, Traits, Alloc> &s)
 {
+  if (!o._discard())
+    o._put_field(s.c_str(), s.size());
   return o;
 }
 

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <goto-programs/remove_exceptions.h>
 #include <goto-programs/exception_typeid.h>
 #include <goto-programs/exception_globals.h>
@@ -111,7 +112,7 @@ public:
 
     track_uncaught_ = program_reads_uncaught(goto_functions);
 
-    may_throw = compute_may_throw(goto_functions);
+    may_throw = compute_may_throw(goto_functions, context);
 
     // Single scan: teach the registry any exception hierarchy that lives only in
     // THROW exception_lists (the Python frontend's classes have no `tag-`
@@ -578,10 +579,55 @@ private:
 
   // ---- may-throw analysis ------------------------------------------------
 
-  static std::set<irep_idt> compute_may_throw(const goto_functionst &gf)
+  /// Every function whose address the program takes, whether in a function
+  /// body or in a static initialiser -- a virtual table is the latter. A call
+  /// through a pointer can only land on one of these, so it needs exception
+  /// propagation only when one of them may throw. Treating *every* indirect
+  /// call as possibly-throwing instead costs a branch at each one: a C++
+  /// program whose only indirect calls are the virtual sink of <ostream> then
+  /// grows exception-propagation branches around every `cout << x`.
+  static std::set<irep_idt>
+  collect_address_taken(const goto_functionst &gf, const contextt &context)
   {
-    std::set<irep_idt> may;
-    std::map<irep_idt, std::set<irep_idt>> callees;
+    std::set<irep_idt> taken;
+
+    std::function<void(const expr2tc &)> scan = [&](const expr2tc &e) {
+      if (is_nil_expr(e))
+        return;
+      if (is_address_of2t(e))
+      {
+        const expr2tc &obj = to_address_of2t(e).ptr_obj;
+        if (is_symbol2t(obj) && is_code_type(obj->type))
+          taken.insert(to_symbol2t(obj).thename);
+      }
+      e->foreach_operand(scan);
+    };
+
+    for (const auto &fn : gf.function_map)
+      if (fn.second.body_available)
+        for (const auto &ins : fn.second.body.instructions)
+        {
+          scan(ins.code);
+          scan(ins.guard);
+        }
+
+    // Virtual tables live in the symbol table, not in any body: without this
+    // the set would miss every virtual method and the result would be unsound.
+    context.foreach_operand(
+      [&scan](const symbolt &s) { scan(s.get_value2()); });
+
+    return taken;
+  }
+
+  /// Seeds the may-throw fixpoint: \p may gets the functions that raise
+  /// directly, \p callees the direct call graph, \p indirect_callers the
+  /// functions that call through a pointer.
+  static void collect_may_throw_seeds(
+    const goto_functionst &gf,
+    std::set<irep_idt> &may,
+    std::map<irep_idt, std::set<irep_idt>> &callees,
+    std::set<irep_idt> &indirect_callers)
+  {
     for (const auto &fn : gf.function_map)
     {
       if (!fn.second.body_available)
@@ -593,21 +639,37 @@ private:
         else if (ins.type == FUNCTION_CALL)
         {
           const code_function_call2t &c = to_code_function_call2t(ins.code);
-          if (is_symbol2t(c.function))
+          if (!is_symbol2t(c.function))
           {
-            const irep_idt callee = to_symbol2t(c.function).thename;
-            if (
-              id2string(callee).find("__ESBMC_rethrow_exception_raw") !=
-              std::string::npos)
-              may.insert(fn.first);
-            else
-              callees[fn.first].insert(callee);
+            indirect_callers.insert(fn.first);
+            continue;
           }
+          const irep_idt callee = to_symbol2t(c.function).thename;
+          if (
+            id2string(callee).find("__ESBMC_rethrow_exception_raw") !=
+            std::string::npos)
+            may.insert(fn.first);
           else
-            may.insert(fn.first); // indirect call: callee may throw
+            callees[fn.first].insert(callee);
         }
       }
     }
+  }
+
+  static std::set<irep_idt>
+  compute_may_throw(const goto_functionst &gf, const contextt &context)
+  {
+    const std::set<irep_idt> address_taken = collect_address_taken(gf, context);
+
+    std::set<irep_idt> may;
+    std::set<irep_idt> indirect_callers;
+    std::map<irep_idt, std::set<irep_idt>> callees;
+    collect_may_throw_seeds(gf, may, callees, indirect_callers);
+
+    // An indirect call reaches only an address-taken function, so it forces
+    // exception propagation on its caller exactly when one of those may throw.
+    // That is a fixpoint of its own: resolving it can put a new function in
+    // `may`, which may in turn be address-taken.
     for (bool changed = true; changed;)
     {
       changed = false;
@@ -620,6 +682,16 @@ private:
               changed = true;
               break;
             }
+
+      if (!indirect_callers.empty())
+        for (const irep_idt &fn : address_taken)
+          if (may.count(fn))
+          {
+            for (const irep_idt &caller : indirect_callers)
+              changed |= may.insert(caller).second;
+            indirect_callers.clear();
+            break;
+          }
     }
     return may;
   }


### PR DESCRIPTION
Every ostream inserter discarded its value and `<iomanip>`'s manipulators were
declared but never defined, so `setw`/`setfill`/`hex` had no effect; the string
streams were plain classes, so instantiating one over a custom allocator did not
parse. Make them templates and give `ostream` a virtual sink that
`basic_ostringstream` overrides, so a chain typed `ostream&` reaches the buffer.

Fixes #7016. Fixes #7017.
