### PR TITLE
[cpp] Pin the virtual-base non-first-base member offset bug

### DIFF
--- a/docs/design/cpp-multiple-inheritance-subobjects.md
+++ b/docs/design/cpp-multiple-inheritance-subobjects.md
@@ -207,6 +207,25 @@ changes) before the next.
   returns.
 * **P5 — virtual bases.** Shared virtual-base subobject via an indirection
   (vbase pointer), building on the #938 most-derived-init work.
+  * **Symptom now pinned:** `regression/esbmc-cpp/inheritance/`
+    `github_7025_vbase_nonfirst_member` (KNOWNBUG) plus the two
+    `github_7025_vbase_first_base{,_fail}` controls. Under the flattened
+    layout a class whose virtual base is *not* at offset 0 lays its own
+    fields out differently from the enclosing class, so a write through the
+    base's `this` and a read through the derived object disagree — silently,
+    since only the non-first-base ordering triggers it (#7025).
+  * **Spike result (single-path virtual bases are not a shortcut):** nesting
+    a virtual base that is reachable on exactly one path — keeping the flat
+    layout only for genuinely shared ones — fixes #7025 and promotes
+    `virtual_base_with_base`, but two further migrations fall out and the
+    second is the blocker. (a) Clang elides the intermediate base specifiers
+    from a cast path that crosses a virtual base, so `get_cast_expr` must
+    resolve a *chain* of `@base@` hops per specifier, not one. (b) The C++
+    stream OM (`ostream`/`istream : virtual ios`, `ios : ios_base`) then
+    reaches `ios_base` fields through member expressions that never pass
+    through `get_cast_expr` at all, and those still assume the flat layout.
+    P5 has to migrate them together; a layout flip on its own does not
+    converge.
 
 ## 6. Validation strategy
 

--- a/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base/main.cpp
@@ -1,0 +1,33 @@
+// Control for github_7025_vbase_nonfirst_member: the same hierarchy with the
+// virtual base at offset 0 (B declared first). This shape already resolves
+// correctly, so it pins that the working case stays working.
+#include <cassert>
+
+struct V
+{
+  int v;
+};
+struct A
+{
+  int a;
+};
+struct B : virtual V
+{
+  char buf[8];
+  void put(char c)
+  {
+    buf[0] = c;
+  }
+};
+struct D : B, A
+{
+};
+
+int main()
+{
+  D d;
+  d.buf[0] = 'x';
+  d.put('A');
+  assert(d.buf[0] == 'A');
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base_fail/main.cpp
@@ -1,0 +1,33 @@
+// Control for github_7025_vbase_nonfirst_member: the same hierarchy with the
+// virtual base at offset 0 (B declared first). Negative variant: the byte written by
+// B::put must no longer hold the pre-call value.
+#include <cassert>
+
+struct V
+{
+  int v;
+};
+struct A
+{
+  int a;
+};
+struct B : virtual V
+{
+  char buf[8];
+  void put(char c)
+  {
+    buf[0] = c;
+  }
+};
+struct D : B, A
+{
+};
+
+int main()
+{
+  D d;
+  d.buf[0] = 'x';
+  d.put('A');
+  assert(d.buf[0] == 'x');
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_7025_vbase_first_base_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/github_7025_vbase_nonfirst_member/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_7025_vbase_nonfirst_member/main.cpp
@@ -1,0 +1,33 @@
+// esbmc/esbmc#7025: a class with a virtual base resolves its own members to the
+// wrong offset when it is a non-first base and the access goes through `this`.
+// The write in B::put and the read through `d` must land on the same bytes.
+#include <cassert>
+
+struct V
+{
+  int v;
+};
+struct A
+{
+  int a;
+};
+struct B : virtual V
+{
+  char buf[8];
+  void put(char c)
+  {
+    buf[0] = c;
+  }
+};
+struct D : A, B
+{
+};
+
+int main()
+{
+  D d;
+  d.buf[0] = 'x';
+  d.put('A');
+  assert(d.buf[0] == 'A');
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_7025_vbase_nonfirst_member/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_7025_vbase_nonfirst_member/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 2 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
A class with a virtual base lays its own fields out differently from an
enclosing class that holds it as a non-first base, so a write through the
base's `this` and a read through the derived object land on different bytes.

Adds the KNOWNBUG reproducer plus the two offset-0 controls, and records in
the P5 plan why flipping single-path virtual bases to nested subobjects does
not converge on its own.

Refs #7025
