### PR TITLE
[om] Model is_fundamental and tuple_size_v

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_is_fundamental/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_fundamental/main.cpp
@@ -1,0 +1,39 @@
+// esbmc/esbmc#5868: <type_traits> had no is_fundamental, which fmt's format.h
+// reaches for. Fundamental types are the arithmetic types, cv void and cv
+// std::nullptr_t ([basic.types.general], [meta.unary.comp] Table 53).
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+
+struct s
+{
+  int x;
+};
+enum e
+{
+  a
+};
+
+int main()
+{
+  static_assert(std::is_fundamental<int>::value, "");
+  static_assert(std::is_fundamental<const double>::value, "");
+  static_assert(std::is_fundamental<volatile char>::value, "");
+  static_assert(std::is_fundamental<void>::value, "");
+  static_assert(std::is_fundamental<const void>::value, "");
+  static_assert(std::is_fundamental<std::nullptr_t>::value, "");
+  static_assert(std::is_fundamental_v<bool>, "");
+
+  static_assert(!std::is_fundamental<int *>::value, "");
+  static_assert(!std::is_fundamental<int &>::value, "");
+  static_assert(!std::is_fundamental<int[4]>::value, "");
+  static_assert(!std::is_fundamental<s>::value, "");
+  static_assert(!std::is_fundamental<e>::value, "");
+
+  static_assert(std::is_null_pointer_v<std::nullptr_t>, "");
+  static_assert(!std::is_null_pointer_v<void *>, "");
+
+  assert(std::is_fundamental<int>::value);
+  assert(!std::is_fundamental<s>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_fundamental/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_fundamental/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_is_fundamental_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_fundamental_fail/main.cpp
@@ -1,0 +1,39 @@
+// esbmc/esbmc#5868 negative control: <type_traits> had no is_fundamental, which fmt's format.h
+// reaches for. Fundamental types are the arithmetic types, cv void and cv
+// std::nullptr_t ([basic.types.general], [meta.unary.comp] Table 53).
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+
+struct s
+{
+  int x;
+};
+enum e
+{
+  a
+};
+
+int main()
+{
+  static_assert(std::is_fundamental<int>::value, "");
+  static_assert(std::is_fundamental<const double>::value, "");
+  static_assert(std::is_fundamental<volatile char>::value, "");
+  static_assert(std::is_fundamental<void>::value, "");
+  static_assert(std::is_fundamental<const void>::value, "");
+  static_assert(std::is_fundamental<std::nullptr_t>::value, "");
+  static_assert(std::is_fundamental_v<bool>, "");
+
+  static_assert(!std::is_fundamental<int *>::value, "");
+  static_assert(!std::is_fundamental<int &>::value, "");
+  static_assert(!std::is_fundamental<int[4]>::value, "");
+  static_assert(!std::is_fundamental<s>::value, "");
+  static_assert(!std::is_fundamental<e>::value, "");
+
+  static_assert(std::is_null_pointer_v<std::nullptr_t>, "");
+  static_assert(!std::is_null_pointer_v<void *>, "");
+
+  assert(std::is_fundamental<int>::value);
+  assert(std::is_fundamental<s>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_fundamental_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_fundamental_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_tuple_size_v/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_tuple_size_v/main.cpp
@@ -1,0 +1,17 @@
+// esbmc/esbmc#5868: <tuple> modelled tuple_size but not the C++17 tuple_size_v
+// variable template, which ESBMC's own irep2.h uses.
+#include <cassert>
+#include <tuple>
+
+int main()
+{
+  static_assert(std::tuple_size_v<std::tuple<>> == 0, "");
+  static_assert(std::tuple_size_v<std::tuple<int>> == 1, "");
+  static_assert(std::tuple_size_v<std::tuple<int, char, double>> == 3, "");
+  static_assert(
+    std::tuple_size_v<std::tuple<int, char>> == std::tuple_size<std::tuple<int, char>>::value,
+    "");
+
+  assert((std::tuple_size_v<std::tuple<int, char, double>> == 3));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_tuple_size_v/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_tuple_size_v/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_tuple_size_v_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_tuple_size_v_fail/main.cpp
@@ -1,0 +1,17 @@
+// esbmc/esbmc#5868 negative control: <tuple> modelled tuple_size but not the C++17 tuple_size_v
+// variable template, which ESBMC's own irep2.h uses.
+#include <cassert>
+#include <tuple>
+
+int main()
+{
+  static_assert(std::tuple_size_v<std::tuple<>> == 0, "");
+  static_assert(std::tuple_size_v<std::tuple<int>> == 1, "");
+  static_assert(std::tuple_size_v<std::tuple<int, char, double>> == 3, "");
+  static_assert(
+    std::tuple_size_v<std::tuple<int, char>> == std::tuple_size<std::tuple<int, char>>::value,
+    "");
+
+  assert((std::tuple_size_v<std::tuple<int, char, double>> == 4));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_tuple_size_v_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_tuple_size_v_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/tuple
+++ b/src/cpp/library/tuple
@@ -107,6 +107,11 @@ struct tuple_size<tuple<Types...>>
 {
 };
 
+#if __cplusplus >= 201703L
+template <typename Tuple>
+inline constexpr std::size_t tuple_size_v = tuple_size<Tuple>::value;
+#endif
+
 template <std::size_t I, typename... Types>
 constexpr typename tuple_element<I, tuple<Types...>>::type &
 get(tuple<Types...> &t) noexcept

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -403,6 +403,28 @@ struct is_void : is_same<void, typename remove_cv<T>::type>
 {
 };
 
+// is_null_pointer
+#if __cplusplus >= 201103L
+template <class T>
+struct is_null_pointer
+  : is_same<decltype(nullptr), typename remove_cv<T>::type>
+{
+};
+#endif
+
+// is_fundamental: arithmetic types, cv void and cv std::nullptr_t
+// ([basic.types.general], [meta.unary.comp]).
+template <class T>
+struct is_fundamental : integral_constant<
+                          bool,
+                          is_arithmetic<T>::value || is_void<T>::value
+#if __cplusplus >= 201103L
+                            || is_null_pointer<T>::value
+#endif
+                          >
+{
+};
+
 // is_pointer
 template <class T>
 struct is_pointer : false_type
@@ -839,6 +861,10 @@ template <class T>
 inline constexpr bool is_function_v = is_function<T>::value;
 template <class T>
 inline constexpr size_t alignment_of_v = alignment_of<T>::value;
+template <class T>
+inline constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
+template <class T>
+inline constexpr bool is_fundamental_v = is_fundamental<T>::value;
 template <class T>
 inline constexpr bool is_integral_v = is_integral<T>::value;
 template <class T>


### PR DESCRIPTION
Two of the model gaps that stop ESBMC parsing its own sources: `irep2.h`
reaches for `std::tuple_size_v` (4 diagnostics) and fmt's `format.h` for
`std::is_fundamental` (3), and neither existed.

`is_fundamental` follows [basic.types.general] / [meta.unary.comp] Table 53 --
the arithmetic types, cv `void` and cv `std::nullptr_t` -- with `is_null_pointer`
added as its prerequisite. The `nullptr_t` arm is behind an additive
`>= 201103L` guard, so C++03 keeps the correct pre-`nullptr` answer; checked
SUCCESSFUL in c++03/11/14/17/20.

Both passing tests also compile clean under real `clang++ -std=gnu++17`, and
both fail to parse on an unpatched binary, so they discriminate.

Refs #5868
