### PR TITLE
[om] Make char_traits reachable outside <string>

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_char_traits/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits/main.cpp
@@ -1,0 +1,24 @@
+// esbmc/esbmc#5868: char_traits lived inside <string>, which includes
+// <string_view>, so <string_view> could not reach it and the stream OMs only
+// forward-declared it. Reaching a member from either header failed to parse.
+#include <cassert>
+#include <string_view>
+
+int main()
+{
+  typedef std::char_traits<char> T;
+  assert(T::length("abc") == 3);
+  assert(T::length("") == 0);
+  assert(T::eq('a', 'a'));
+  assert(!T::eq('a', 'b'));
+  assert(T::lt('a', 'b'));
+  assert(T::compare("abc", "abc", 3) == 0);
+  assert(T::compare("abc", "abd", 3) < 0);
+  assert(T::eof() == -1);
+  assert(T::to_int_type('a') == 97);
+  assert(T::to_char_type(97) == 'a');
+  assert(T::eq_int_type(T::eof(), T::eof()));
+  assert(T::not_eof(T::eof()) == 0);
+  assert(T::not_eof(5) == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_char_traits/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17 --unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_char_traits_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits_fail/main.cpp
@@ -1,0 +1,24 @@
+// esbmc/esbmc#5868 negative control: char_traits lived inside <string>, which includes
+// <string_view>, so <string_view> could not reach it and the stream OMs only
+// forward-declared it. Reaching a member from either header failed to parse.
+#include <cassert>
+#include <string_view>
+
+int main()
+{
+  typedef std::char_traits<char> T;
+  assert(T::length("abc") == 4);
+  assert(T::length("") == 0);
+  assert(T::eq('a', 'a'));
+  assert(!T::eq('a', 'b'));
+  assert(T::lt('a', 'b'));
+  assert(T::compare("abc", "abc", 3) == 0);
+  assert(T::compare("abc", "abd", 3) < 0);
+  assert(T::eof() == -1);
+  assert(T::to_int_type('a') == 97);
+  assert(T::to_char_type(97) == 'a');
+  assert(T::eq_int_type(T::eof(), T::eof()));
+  assert(T::not_eof(T::eof()) == 0);
+  assert(T::not_eof(5) == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_char_traits_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17 --unwind 6
+^VERIFICATION FAILED$

--- a/src/cpp/library/char_traits.h
+++ b/src/cpp/library/char_traits.h
@@ -1,0 +1,116 @@
+// std::char_traits, shared by the string, string_view and stream OMs.
+//
+// Lifted out of <string> unchanged. It lived there, but <string> includes
+// <string_view>, so <string_view> could not reach it, and the stream OMs and
+// <iterator> only ever forward-declared it to name it as a default template
+// argument. Any program that touched a member from those headers -- fmt and
+// boost lexical_cast do -- failed to parse. See #5868.
+//
+// The `Traits = char_traits<CharT>` defaults stay with the templates that
+// declare them; repeating one here would be a second default for the same
+// parameter.
+#pragma once
+
+#include <cstddef> /* size_t, ptrdiff_t */
+#include <cstdio>  /* EOF */
+#include <cstring> /* memcpy, memmove */
+
+#include "OM_compiler_defs.h"
+
+namespace std
+{
+template <class charT>
+struct char_traits
+{
+  typedef charT char_type;
+  typedef int int_type;
+  typedef std::ptrdiff_t off_type;
+  typedef std::size_t pos_type;
+
+  static void assign(char_type &c1, const char_type &c2) OM_NOEXCEPT
+  {
+    c1 = c2;
+  }
+
+  static char_type *assign(char_type *s, std::size_t n, char_type a)
+  {
+    for (std::size_t i = 0; i < n; ++i)
+      s[i] = a;
+    return s;
+  }
+
+  static bool eq(char_type c1, char_type c2) OM_NOEXCEPT
+  {
+    return c1 == c2;
+  }
+
+  static bool lt(char_type c1, char_type c2) OM_NOEXCEPT
+  {
+    return c1 < c2;
+  }
+
+  static int compare(const char_type *s1, const char_type *s2, std::size_t n)
+  {
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      if (lt(s1[i], s2[i]))
+        return -1;
+      if (lt(s2[i], s1[i]))
+        return 1;
+    }
+    return 0;
+  }
+
+  static std::size_t length(const char_type *s)
+  {
+    std::size_t i = 0;
+    while (!eq(s[i], char_type(0)))
+      ++i;
+    return i;
+  }
+
+  static const char_type *
+  find(const char_type *s, std::size_t n, const char_type &a)
+  {
+    for (std::size_t i = 0; i < n; ++i)
+      if (eq(s[i], a))
+        return s + i;
+    return OM_NULLPTR;
+  }
+
+  static char_type *move(char_type *dest, const char_type *src, std::size_t n)
+  {
+    return static_cast<char_type *>(memmove(dest, src, n * sizeof(charT)));
+  }
+
+  static char_type *copy(char_type *dest, const char_type *src, std::size_t n)
+  {
+    return static_cast<char_type *>(memcpy(dest, src, n * sizeof(charT)));
+  }
+
+  static int_type eof() OM_NOEXCEPT
+  {
+    return EOF;
+  }
+
+  static int_type to_int_type(char_type c) OM_NOEXCEPT
+  {
+    return static_cast<unsigned char>(c);
+  }
+
+  static char_type to_char_type(int_type c) OM_NOEXCEPT
+  {
+    return static_cast<char_type>(c);
+  }
+
+  static bool eq_int_type(int_type c1, int_type c2) OM_NOEXCEPT
+  {
+    return c1 == c2;
+  }
+
+  static int_type not_eof(int_type c) OM_NOEXCEPT
+  {
+    return (c == eof()) ? 0 : c;
+  }
+};
+} // namespace std

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -3,6 +3,7 @@
 
 #include "definitions.h"
 #include "OM_compiler_defs.h" // OM_NOEXCEPT
+#include "char_traits.h"
 #include "cstring"
 #include "cstdio"
 #include "cassert"
@@ -21,101 +22,6 @@ extern "C" void itoa(int value, char *str, int base);
 
 namespace std
 {
-template <class charT>
-struct char_traits
-{
-  typedef charT char_type;
-  typedef int int_type;
-  typedef std::ptrdiff_t off_type;
-  typedef std::size_t pos_type;
-
-  static void assign(char_type &c1, const char_type &c2) OM_NOEXCEPT
-  {
-    c1 = c2;
-  }
-
-  static char_type *assign(char_type *s, std::size_t n, char_type a)
-  {
-    for (std::size_t i = 0; i < n; ++i)
-      s[i] = a;
-    return s;
-  }
-
-  static bool eq(char_type c1, char_type c2) OM_NOEXCEPT
-  {
-    return c1 == c2;
-  }
-
-  static bool lt(char_type c1, char_type c2) OM_NOEXCEPT
-  {
-    return c1 < c2;
-  }
-
-  static int compare(const char_type *s1, const char_type *s2, std::size_t n)
-  {
-    for (std::size_t i = 0; i < n; ++i)
-    {
-      if (lt(s1[i], s2[i]))
-        return -1;
-      if (lt(s2[i], s1[i]))
-        return 1;
-    }
-    return 0;
-  }
-
-  static std::size_t length(const char_type *s)
-  {
-    std::size_t i = 0;
-    while (!eq(s[i], char_type(0)))
-      ++i;
-    return i;
-  }
-
-  static const char_type *
-  find(const char_type *s, std::size_t n, const char_type &a)
-  {
-    for (std::size_t i = 0; i < n; ++i)
-      if (eq(s[i], a))
-        return s + i;
-    return OM_NULLPTR;
-  }
-
-  static char_type *move(char_type *dest, const char_type *src, std::size_t n)
-  {
-    return static_cast<char_type *>(memmove(dest, src, n * sizeof(charT)));
-  }
-
-  static char_type *copy(char_type *dest, const char_type *src, std::size_t n)
-  {
-    return static_cast<char_type *>(memcpy(dest, src, n * sizeof(charT)));
-  }
-
-  static int_type eof() OM_NOEXCEPT
-  {
-    return EOF;
-  }
-
-  static int_type to_int_type(char_type c) OM_NOEXCEPT
-  {
-    return static_cast<unsigned char>(c);
-  }
-
-  static char_type to_char_type(int_type c) OM_NOEXCEPT
-  {
-    return static_cast<char_type>(c);
-  }
-
-  static bool eq_int_type(int_type c1, int_type c2) OM_NOEXCEPT
-  {
-    return c1 == c2;
-  }
-
-  static int_type not_eof(int_type c) OM_NOEXCEPT
-  {
-    return (c == eof()) ? 0 : c;
-  }
-};
-
 template <
   class CharT,
   class Traits = char_traits<CharT>,

--- a/src/cpp/library/string_view
+++ b/src/cpp/library/string_view
@@ -7,6 +7,7 @@
 #include <cstddef> /* size_t */
 #include <cstdint> /* SIZE_MAX */
 #include <cstring>
+#include "char_traits.h"
 /* Deliberately no <algorithm>: <string> includes this header, so pulling
  * <algorithm> in here would make std::for_each and friends visible to every
  * translation unit that includes <string>. Programs that define their own


### PR DESCRIPTION
`char_traits` was defined inside `<string>`. `<string>` includes `<string_view>`,
so `<string_view>` could not include it back, and the stream OMs and `<iterator>`
only forward-declared it to name it as a default template argument. Reaching a
member from any of those headers -- `Traits::length`, `Traits::eof`, as fmt and
boost `lexical_cast` do -- failed to parse.

The definition moves into `char_traits.h` **byte for byte** (verified against
master), so this is a visibility change and nothing else. `<string>` and
`<string_view>` include the new header; the `Traits = char_traits<CharT>`
defaults stay with the templates that already declare them, since a default
template argument may only be given once per translation unit.

Both tests fail to parse on an unpatched binary, and the passing one also runs
clean under real `clang++ -std=gnu++17`.

Found while reading the relocated code: `char_traits<char>::eq`/`lt` compare as
signed char, against [char.traits.specializations.char]. Filed as #7048 and
deliberately left alone here -- a behaviour change would make this relocation
unreviewable.

Refs #5868
