### PR TITLE
[esbmc] Keep the worker thread on the main malloc arena

### DIFF
--- a/src/esbmc/main.cpp
+++ b/src/esbmc/main.cpp
@@ -14,6 +14,30 @@
 #  define ESBMC_HAVE_CXXABI 1
 #endif
 
+#ifdef __GLIBC__
+#  include <cstring>
+#  include <malloc.h>
+
+/* glibc gives a non-main thread its own arena, so running the work on the
+ * thread below leaves symbolic execution, encoding and the solver allocating
+ * from a secondary one. Capping the process at a single arena puts them back on
+ * the main arena and is worth ~5% of wall clock, but only together with the
+ * malloc_trim() once GOTO creation is done (esbmc/esbmc#6831): the two are a
+ * pair, and the trim alone is a 3% regression.
+ *
+ * --parallel-solving is the exception, since it allocates from several threads
+ * at once and one arena would serialise them. It has to be read out of argv
+ * because a thread's arena is fixed at its first allocation, long before the
+ * options are parsed. */
+static bool wants_parallel_solving(int argc, const char **argv)
+{
+  for (int i = 1; i < argc; i++)
+    if (strcmp(argv[i], "--parallel-solving") == 0)
+      return true;
+  return false;
+}
+#endif
+
 // Name the exception being handled, for the catch-all arm. A `catch (const
 // std::exception &)` does not match when the throwing library was built against
 // a different C++ runtime than ESBMC -- the typeinfo pointers differ even
@@ -90,6 +114,11 @@ static void *run_main(void *arg)
 
 int main(int argc, const char **argv)
 {
+#ifdef __GLIBC__
+  if (!wants_parallel_solving(argc, argv))
+    mallopt(M_ARENA_MAX, 1);
+#endif
+
 #ifndef _WIN32
   pthread_attr_t attr;
   if (pthread_attr_init(&attr) == 0)

--- a/src/esbmc/parseoptions/goto_program.cpp
+++ b/src/esbmc/parseoptions/goto_program.cpp
@@ -16,6 +16,9 @@
 #include <util/base/filesystem.h>
 #include <csignal>
 #include <cstdlib>
+#ifdef __GLIBC__
+#  include <malloc.h>
+#endif
 #include <limits>
 #include <util/expr/expr_util.h>
 #include <iostream>
@@ -129,6 +132,14 @@ bool esbmc_parseoptionst::get_goto_program(
     log_status(
       "GOTO program creation time: {}s",
       time2string(create_stop - create_start));
+
+#ifdef __GLIBC__
+    /* Building the GOTO program allocates and frees the whole
+     * operational-model library, and with one arena (see main.cpp) those blocks
+     * are in the arena everything after this point allocates from. Handing them
+     * back here is what keeps encoding from paying for them (esbmc/esbmc#6831). */
+    malloc_trim(0);
+#endif
 
     fine_timet process_start = current_time();
     if (process_goto_program(options, goto_functions))

--- a/src/esbmc/parseoptions/goto_program.cpp
+++ b/src/esbmc/parseoptions/goto_program.cpp
@@ -137,7 +137,8 @@ bool esbmc_parseoptionst::get_goto_program(
     /* Building the GOTO program allocates and frees the whole
      * operational-model library, and with one arena (see main.cpp) those blocks
      * are in the arena everything after this point allocates from. Handing them
-     * back here is what keeps encoding from paying for them (esbmc/esbmc#6831). */
+     * back here is what keeps encoding from paying for them (esbmc/esbmc#6831).
+     */
     malloc_trim(0);
 #endif
 


### PR DESCRIPTION
Running the verification on a spawned thread (#6618) moved every allocation ESBMC makes onto a glibc secondary arena — the multiplicative term of #6831, which tipped 131 Juliet tasks past the 100 s limit. Capping the process at one arena, plus a `malloc_trim(0)` once GOTO creation is done, measures **×0.953 wall** on a 10 s task (IQR 0.007, 12 interleaved pairs) with every phase improving, and ×0.977 on a trivial program.

Neither half works alone: the arena cap alone is ×0.999 and the trim alone is a ×1.033 regression. `--parallel-solving` keeps several arenas, since it allocates from one thread per claim job.

Investigation and measurements: `docs/roadmap/svcomp-6831-fixed-cost-plan.md` (W0).

Fixes #6831