### PR TITLE
[solver] State the assign-destination invariant both flatteners rely on

### DIFF
--- a/docs/roadmap/svcomp-6831-schedule-space-plan.md
+++ b/docs/roadmap/svcomp-6831-schedule-space-plan.md
@@ -755,12 +755,31 @@ all 273 are green. So are all 186 registered tests of `esbmc-unix2` (138 of them
 CORE). `github_6831_smt_during_symex_{crash,safe}` pin the FAILED and SUCCESSFUL
 verdicts on this path, and both segfault on the pre-fix binary.
 
-`array_ast::array_fields` does **not** need the same treatment, which is worth
-recording so it is not reopened: every site that writes it does so into an
-`array_ast` created in the same statement, so the fields never outlive their
-holder. The one copy-into-an-existing-object site, `convert_array_assign`
-(`array_conv.cpp:40`), relies on the same invariant the tuple `assign` path does
-— that an assign destination is current-level — and is unguarded today.
+#### W3.4 — The sibling hazard is latent, and the invariant behind it is measured
+
+`array_ast::array_fields` looks like the same bug waiting to happen: every site
+that writes it does so into an `array_ast` created in the same statement, except
+`convert_array_assign` (`array_conv.cpp:40`), which copies into a pre-existing
+destination — the exact shape of the tuple `assign` path. It also copies
+`base_array_id`, which indexes the containers `pop_array_ctx` resizes, so a
+stale destination would be an out-of-range index as well as a dangling pointer.
+
+Both sites rest on one unstated invariant: **an assign destination is
+current-level**. It holds because `convert_assign`'s LHS (`smt_solver.cpp:364`)
+is an SSA symbol, converted at the level its defining assignment is encoded at
+rather than fetched from a shallower cache. Measured rather than argued: a build
+instrumented to log every assign whose destination predates the current level
+found **zero** across 379 CORE concurrent tests under the wrapper's flags, and
+**zero** across all 2133 CORE tests that pass a flag implying a push/pop
+strategy, each run with its own `test.desc` flags.
+
+So the hazard is latent, not live, and no machinery is warranted at either site.
+What the patch leaves behind is the invariant itself, stated at both sites and
+asserted at the tuple one, so a future change to symbol caching trips an
+assertion in the Debug CI build rather than a segfault in competition. The
+tuple `assign` registration is kept as a defensive fallback and is triaged as
+such: it is correct under any input, costs one comparison, and the measurement
+above is evidence of unreachability rather than proof of it.
 
 ### W4 — Bound the schedule space in the SV-COMP strategy — **investigated, not a flag flip**
 

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -36,6 +36,12 @@ void array_convt::convert_array_assign(const array_ast *src, smt_astt sym)
   array_ast *destination = const_cast<array_ast *>(array_downcast(sym));
   const array_ast *source = src;
 
+  // Copying into a pre-existing destination is only safe while the destination
+  // is current-level: array_fields would otherwise outlive the ASTs it names
+  // once pop_ctx runs, and base_array_id would index the containers
+  // pop_array_ctx resizes. That invariant is the one tuple assign relies on too
+  // (smt_tuple_node_ast.cpp), and it held across 2133 CORE push/pop tests.
+
   // And copy across it's valuation
   destination->array_fields = source->array_fields;
   destination->base_array_id = source->base_array_id;

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
@@ -111,6 +111,14 @@ void tuple_node_smt_ast::assign(smt_solver_baset *ctx, smt_astt sym) const
 
   // Just copy across element data.
   destination->elements = elements;
+
+  // convert_assign's LHS is an SSA symbol converted at the level its defining
+  // assignment is encoded at, so the destination is expected to be
+  // current-level and this registration to be redundant -- measured over 2133
+  // CORE tests that push and pop, where it never fired. Kept because nothing
+  // enforces that invariant, and the cost of it breaking silently is the
+  // use-after-free this whole change is about.
+  assert(destination->creation_ctx_level == ctx->ctx_level);
   if (ctx->ctx_level > destination->creation_ctx_level)
     flat.note_elements_populated(destination);
 }


### PR DESCRIPTION
`convert_array_assign` copies `array_fields` and `base_array_id` into a
pre-existing destination — the same shape that made tuple elements dangle in
#7049, and with the extra hazard that `base_array_id` indexes containers
`pop_array_ctx` resizes.

Both sites are safe only while assign destinations are current-level, which
holds because `convert_assign`'s LHS is an SSA symbol converted at its defining
level. Measured, not assumed: an instrumented build found zero violations across
379 CORE concurrent tests under the wrapper's flags and zero across all 2133
CORE tests that pass a push/pop flag. So the hazard is latent and no machinery
is warranted — the patch records the invariant at both sites and asserts it at
the tuple one.

Stacked on #7049. Refs #6831.