### PR TITLE
[test] Pin seven C++17/20/23 features the audit listed as broken

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4377_char8_t/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_char8_t/main.cpp
@@ -1,0 +1,16 @@
+// esbmc/esbmc#4377 (C++20): char8_t used to abort conversion with
+// "Unrecognized clang builtin type char8_t".
+#include <cassert>
+
+int main()
+{
+  char8_t c = u8'A';
+  assert(c == 65);
+  assert(sizeof(char8_t) == 1);
+
+  const char8_t *s = u8"AB";
+  assert(s[0] == 65);
+  assert(s[1] == 66);
+  assert(s[2] == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_char8_t/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_char8_t/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_char8_t_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_char8_t_fail/main.cpp
@@ -1,0 +1,16 @@
+// esbmc/esbmc#4377 negative control (C++20): char8_t used to abort conversion with
+// "Unrecognized clang builtin type char8_t".
+#include <cassert>
+
+int main()
+{
+  char8_t c = u8'A';
+  assert(c == 66);
+  assert(sizeof(char8_t) == 1);
+
+  const char8_t *s = u8"AB";
+  assert(s[0] == 65);
+  assert(s[1] == 66);
+  assert(s[2] == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_char8_t_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_char8_t_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++20
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20/main.cpp
@@ -1,0 +1,21 @@
+// esbmc/esbmc#4377 (C++20): aggregate class template argument deduction. The
+// audit filed this as a C++17 gap, but aggregate deduction guides are C++20
+// (P1816) -- clang rejects the same program at --std c++17. This pins the
+// C++20 behaviour, which is the one that must hold.
+#include <cassert>
+
+template <typename T>
+struct Box
+{
+  T t;
+};
+
+int main()
+{
+  Box b{42};
+  assert(b.t == 42);
+
+  Box c{'x'};
+  assert(c.t == 'x');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20_fail/main.cpp
@@ -1,0 +1,21 @@
+// esbmc/esbmc#4377 negative control (C++20): aggregate class template argument deduction. The
+// audit filed this as a C++17 gap, but aggregate deduction guides are C++20
+// (P1816) -- clang rejects the same program at --std c++17. This pins the
+// C++20 behaviour, which is the one that must hold.
+#include <cassert>
+
+template <typename T>
+struct Box
+{
+  T t;
+};
+
+int main()
+{
+  Box b{42};
+  assert(b.t == 43);
+
+  Box c{'x'};
+  assert(c.t == 'x');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_ctad_aggregate_cpp20_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++20
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4377_deducing_this/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_deducing_this/main.cpp
@@ -1,0 +1,27 @@
+// esbmc/esbmc#4377 (C++23): an explicit object parameter used to lower the
+// body's member access to a misaligned dereference, giving a spurious
+// counterexample on a deterministic program.
+#include <cassert>
+
+struct S
+{
+  int v = 7;
+  int get(this S const &self)
+  {
+    return self.v;
+  }
+  int doubled(this S const &self)
+  {
+    return self.v * 2;
+  }
+};
+
+int main()
+{
+  S s;
+  assert(s.get() == 7);
+  assert(s.doubled() == 14);
+  s.v = 21;
+  assert(s.get() == 21);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_deducing_this/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_deducing_this/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++23
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_deducing_this_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_deducing_this_fail/main.cpp
@@ -1,0 +1,27 @@
+// esbmc/esbmc#4377 negative control (C++23): an explicit object parameter used to lower the
+// body's member access to a misaligned dereference, giving a spurious
+// counterexample on a deterministic program.
+#include <cassert>
+
+struct S
+{
+  int v = 7;
+  int get(this S const &self)
+  {
+    return self.v;
+  }
+  int doubled(this S const &self)
+  {
+    return self.v * 2;
+  }
+};
+
+int main()
+{
+  S s;
+  assert(s.get() == 7);
+  assert(s.doubled() == 15);
+  s.v = 21;
+  assert(s.get() == 21);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_deducing_this_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_deducing_this_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++23
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4377_if_init_statement/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_if_init_statement/main.cpp
@@ -1,0 +1,26 @@
+// esbmc/esbmc#4377 (C++17): a variable declared in the init-statement of `if`
+// used to lose its initialiser and read as nondeterministic -- a spurious
+// counterexample on a deterministic program. Nothing pinned the fix.
+#include <cassert>
+
+int main()
+{
+  if (int x = 7; true)
+  {
+    assert(x == 7);
+  }
+
+  int taken = 0;
+  if (int y = 3; y > 2)
+    taken = y;
+  else
+    taken = -y;
+  assert(taken == 3);
+
+  if (int z = 1; z > 2)
+    taken = 0;
+  else
+    taken = z * 10;
+  assert(taken == 10);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_if_init_statement/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_if_init_statement/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_if_init_statement_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_if_init_statement_fail/main.cpp
@@ -1,0 +1,26 @@
+// esbmc/esbmc#4377 negative control (C++17): a variable declared in the init-statement of `if`
+// used to lose its initialiser and read as nondeterministic -- a spurious
+// counterexample on a deterministic program. Nothing pinned the fix.
+#include <cassert>
+
+int main()
+{
+  if (int x = 7; true)
+  {
+    assert(x == 8);
+  }
+
+  int taken = 0;
+  if (int y = 3; y > 2)
+    taken = y;
+  else
+    taken = -y;
+  assert(taken == 3);
+
+  if (int z = 1; z > 2)
+    taken = 0;
+  else
+    taken = z * 10;
+  assert(taken == 10);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_if_init_statement_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_if_init_statement_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init/main.cpp
@@ -1,0 +1,21 @@
+// esbmc/esbmc#4377 (C++20): parenthesised aggregate initialisation used to
+// abort with "Conversion of unsupported clang expr: CXXParenListInitExpr".
+#include <cassert>
+
+struct S
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  S s(1, 2);
+  assert(s.a == 1);
+  assert(s.b == 2);
+
+  S t(5);
+  assert(t.a == 5);
+  assert(t.b == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init_fail/main.cpp
@@ -1,0 +1,21 @@
+// esbmc/esbmc#4377 negative control (C++20): parenthesised aggregate initialisation used to
+// abort with "Conversion of unsupported clang expr: CXXParenListInitExpr".
+#include <cassert>
+
+struct S
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  S s(1, 2);
+  assert(s.a == 1);
+  assert(s.b == 2);
+
+  S t(5);
+  assert(t.a == 5);
+  assert(t.b == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_paren_aggregate_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++20
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4377_static_call_operator/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_static_call_operator/main.cpp
@@ -1,0 +1,20 @@
+// esbmc/esbmc#4377 (C++23): a static operator() used to lower its call site as
+// if it were a non-static member, passing the object as a hidden first
+// argument and clashing with the declared signature.
+#include <cassert>
+
+struct F
+{
+  static int operator()(int x)
+  {
+    return x + 1;
+  }
+};
+
+int main()
+{
+  F f;
+  assert(f(2) == 3);
+  assert(F{}(41) == 42);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_static_call_operator/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_static_call_operator/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++23
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_static_call_operator_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_static_call_operator_fail/main.cpp
@@ -1,0 +1,20 @@
+// esbmc/esbmc#4377 negative control (C++23): a static operator() used to lower its call site as
+// if it were a non-static member, passing the object as a hidden first
+// argument and clashing with the declared signature.
+#include <cassert>
+
+struct F
+{
+  static int operator()(int x)
+  {
+    return x + 1;
+  }
+};
+
+int main()
+{
+  F f;
+  assert(f(2) == 3);
+  assert(F{}(41) == 43);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_static_call_operator_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_static_call_operator_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++23
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4377_switch_init_statement/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_switch_init_statement/main.cpp
@@ -1,0 +1,28 @@
+// esbmc/esbmc#4377 (C++17): the `switch` init-statement form, the twin of the
+// `if` case in github_4377_if_init_statement.
+#include <cassert>
+
+int main()
+{
+  switch (int x = 7; 1)
+  {
+  case 1:
+    assert(x == 7);
+    break;
+  default:
+    assert(0);
+  }
+
+  int hit = 0;
+  switch (int sel = 2; sel)
+  {
+  case 1:
+    hit = 10;
+    break;
+  case 2:
+    hit = sel * 100;
+    break;
+  }
+  assert(hit == 200);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_switch_init_statement/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_switch_init_statement/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4377_switch_init_statement_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4377_switch_init_statement_fail/main.cpp
@@ -1,0 +1,28 @@
+// esbmc/esbmc#4377 negative control (C++17): the `switch` init-statement form, the twin of the
+// `if` case in github_4377_if_init_statement.
+#include <cassert>
+
+int main()
+{
+  switch (int x = 7; 1)
+  {
+  case 1:
+    assert(x == 7);
+    break;
+  default:
+    assert(0);
+  }
+
+  int hit = 0;
+  switch (int sel = 2; sel)
+  {
+  case 1:
+    hit = 10;
+    break;
+  case 2:
+    hit = sel * 100;
+    break;
+  }
+  assert(hit == 201);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4377_switch_init_statement_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4377_switch_init_statement_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$


### PR DESCRIPTION
Re-measuring the #4377 audit on 8.4.0 (it was taken on 8.2.0, master
`346082e0bf`) found most of it already fixed -- including both items it flagged
as *silent wrong results* -- and none of the seven had any regression coverage,
so nothing would catch a relapse.

Pinned here, each with a mutated `_fail` control that is shown to fail, and each
cross-checked against real `clang++` so the assertions are facts about C++ and
not about ESBMC:

| feature | std | audit's failure mode |
|---|---|---|
| `if` init-statement | C++17 | silent wrong result |
| `switch` init-statement | C++17 | silent wrong result |
| `char8_t` | C++20 | `Unrecognized clang builtin type char8_t` |
| parenthesised aggregate init | C++20 | unsupported `CXXParenListInitExpr` |
| aggregate CTAD | C++20 | see below |
| deducing `this` | C++23 | silent wrong result |
| static `operator()` | C++23 | argument type mismatch |

Aggregate CTAD is filed in the audit as a C++17 gap, but aggregate deduction
guides are C++20 (P1816): real `clang++` rejects the same reproducer at
`--std c++17` and accepts it at `--std c++20`, exactly as ESBMC does. It was
never a defect, so the test pins the C++20 behaviour, which is the one that has
to hold.

No source change -- this is coverage for behaviour that already works.

Refs #4377
