### PR TITLE
[c2goto] Load the Python models from their own blob

### DIFF
--- a/docs/roadmap/svcomp-6831-fixed-cost-plan.md
+++ b/docs/roadmap/svcomp-6831-fixed-cost-plan.md
@@ -1,7 +1,8 @@
 # Plan — the per-task cost every SV-COMP run pays (issue #6831, cause 2)
 
-**Status:** in progress. W3 (both reader wins) and W4 (the cost is reported and
-pinned) are shipped; W0, W1, W2 and W5 are still plan only.
+**Status:** W0 closed (the term is a glibc secondary arena, not the library);
+W1 in review, W3 and W4 shipped; W2 and W5 still plan only. Against the
+window's fast endpoint the oracle is back to ×0.999 from ×1.070 — see §9.
 **Owner issue:** [#6831](https://github.com/esbmc/esbmc/issues/6831), *cause 2 —
 a general slowdown tipping tasks already at the limit*, ~198 of 489 lost tasks,
 led by 131 `Juliet_Test` no-overflow tasks at a median of 99.1 s of a 100 s
@@ -562,3 +563,26 @@ used, superlinearly in its size, with 24 % of it Python models a C task can
 never call — but that fixed cost is not what lost the 131 Juliet tasks sitting
 at 99 s of a 100 s limit, so attribute the 3.5 % multiplicative term first (W0)
 and only then stop paying for models nobody asked for (W1–W4).
+
+**Outcome.** The multiplicative term was a glibc secondary arena, created the
+moment the run moved onto a worker thread; the fixed term was the blob, and
+neither was what the issue supposed. All three fixes together, 20 pairs on an
+idle host against the window's fast endpoint:
+
+| metric | `978a007e73` | with #7051 + #7058 + #7060 | B/A |
+|---|---|---|---|
+| wall | 9.794 s | 9.224 s | **0.999** |
+| GOTO creation | 0.308 s | 0.200 s | **0.670** |
+| symex | 0.748 s | 0.784 s | 1.065 |
+| encoding | 4.182 s | 4.042 s | 0.995 |
+| solving | 2.150 s | 1.965 s | 0.990 |
+
+**×1.070 → ×0.999: the regression is closed on this oracle**, and GOTO creation
+is a third faster than it was before the regression rather than merely
+restored. `symex` is the one phase still above parity; at ×1.065 of a 0.75 s
+phase it is ~50 ms of a 9.2 s run, and wall does not see it.
+
+The caveat that matters for the 131 tasks: this is ESBMC-bound time. A task
+that spends its 99 s inside the solver gains nothing from any of it (§W0's
+solver-bound workload measured ×0.994), so the score should be re-measured
+rather than predicted from these ratios.

--- a/docs/roadmap/svcomp-6831-fixed-cost-plan.md
+++ b/docs/roadmap/svcomp-6831-fixed-cost-plan.md
@@ -336,20 +336,36 @@ added — `POINTER_OBJECT`, `POINTER_OFFSET`, `same_object`, `OBJECT_SIZE`,
 `DYNAMIC_OBJECT`, `LIVE_OBJECT`, `WRITEABLE_OBJECT`, `r_ok`, `w_ok`, `rw_ok` —
 linked with bodies into every C program, none of which calls them.
 
-Deleting them from `builtin_libs.c` and re-measuring against the same build:
+Deleting them from `builtin_libs.c` and re-measuring against the same build,
+**20 pairs on an idle host** (a first pass at 12 pairs under load said ×0.958
+and ×0.920; those numbers were too generous and are corrected here):
 
 | metric | master+both | minus the ten | B/A |
 |---|---|---|---|
-| wall | 9.662 s | 9.421 s | **0.958** |
-| encoding | 4.386 s | 4.059 s | **0.920** |
-| symex | 0.794 s | 0.806 s | 1.021 |
+| wall | 9.782 s | 9.625 s | **0.975** |
+| encoding | 4.467 s | 4.212 s | **0.936** |
+| symex | 0.790 s | 0.786 s | 0.999 |
+
+On plain `master`, the same removal via the shipped filter is worth only
+×0.994 (20 pairs). So the ten bodies cost **0.6–2.5 % depending on what else
+the build carries** — real, concentrated in encoding, and an order of magnitude
+short of "the rest of the regression".
 
 **This contradicts W0's hypothesis-2 probe above**, which ran the same deletion,
 found `Symex completed in` unchanged, and concluded "#6708 contributes nothing
 to the multiplicative term". That reading was right about symex and wrong about
 the total: unreferenced bodies cost nothing to *execute* and plenty to *encode*.
 The probe measured the one phase where the effect could not appear. Corrected:
-**#6708 is worth ~4 % on this oracle, and it is the rest of the regression.**
+**#6708 is worth 0.6–2.5 % here, in encoding — real, but not the rest of the
+regression.** The first version of this section claimed ~4 %, from 12 pairs on
+a host at load average 33; 20 pairs on an idle host do not support it. Both
+that claim and the probe it corrected failed the same way, in opposite
+directions, and the fix for both is the same: measure the phase the mechanism
+predicts, with enough pairs, on a quiet machine.
+
+**So the regression's remaining ~2–3 points are still unattributed.** What is
+ruled out: the library as a whole (`--no-library` A/B), the arena (#7051), the
+blob size (#7058), and now these ten bodies at the scale first claimed.
 
 The fix is not to remove the primitives — a program that uses them needs them.
 It is to stop linking bodies nothing references. They arrive because

--- a/docs/roadmap/svcomp-6831-fixed-cost-plan.md
+++ b/docs/roadmap/svcomp-6831-fixed-cost-plan.md
@@ -325,11 +325,41 @@ in the arena; W1 makes that load smaller, so there is less left to trim. They
 are not additive, and anyone re-measuring one of them after the other lands
 should expect a smaller number than this plan quotes for it in isolation.
 
-What remains — ~4 points in symex and encoding, with the counts identical — is
-not the library and not the arena. It is the same "accumulated creep" the
-bisect saw at commits 23 (×1.020), 35 (×1.015) and 37 (×1.034), and finding it
-means bisecting again with a stopping rule tuned to a 1–2 % effect, which needs
-more pairs per step than the ×1.07 hunt did.
+#### The residue is ten model bodies nothing calls — and §4 W0 got this wrong
+
+The ~4 points left after both fixes are **entirely library-mediated**: the same
+A/B under `--no-library` is ×0.994. So they are not code layout and not creep.
+
+A trivial C program's GOTO program holds **6 function bodies on `978a007e73`
+and 16 on master**. The ten are exactly the `__CPROVER_*` primitives #6708
+added — `POINTER_OBJECT`, `POINTER_OFFSET`, `same_object`, `OBJECT_SIZE`,
+`DYNAMIC_OBJECT`, `LIVE_OBJECT`, `WRITEABLE_OBJECT`, `r_ok`, `w_ok`, `rw_ok` —
+linked with bodies into every C program, none of which calls them.
+
+Deleting them from `builtin_libs.c` and re-measuring against the same build:
+
+| metric | master+both | minus the ten | B/A |
+|---|---|---|---|
+| wall | 9.662 s | 9.421 s | **0.958** |
+| encoding | 4.386 s | 4.059 s | **0.920** |
+| symex | 0.794 s | 0.806 s | 1.021 |
+
+**This contradicts W0's hypothesis-2 probe above**, which ran the same deletion,
+found `Symex completed in` unchanged, and concluded "#6708 contributes nothing
+to the multiplicative term". That reading was right about symex and wrong about
+the total: unreferenced bodies cost nothing to *execute* and plenty to *encode*.
+The probe measured the one phase where the effect could not appear. Corrected:
+**#6708 is worth ~4 % on this oracle, and it is the rest of the regression.**
+
+The fix is not to remove the primitives — a program that uses them needs them.
+It is to stop linking bodies nothing references. They arrive because
+`esbmc_intrinsics.h` is force-included, so the context holds a nil-valued
+declaration for each, and `add_cprover_library()`'s rule for the C path is
+"declared here, empty value → link the body". Every intrinsic in that header
+is therefore linked into every program whether or not it is mentioned. Options,
+cheapest first: drop function bodies with no callers after goto-conversion;
+or make the closure demand a reference rather than a declaration. Either is a
+change to shared linking behaviour, so G1 applies in full.
 
 ### W2 — Make the blob indexable, so loading is O(used) not O(total)
 

--- a/docs/roadmap/svcomp-6831-fixed-cost-plan.md
+++ b/docs/roadmap/svcomp-6831-fixed-cost-plan.md
@@ -1,8 +1,9 @@
 # Plan — the per-task cost every SV-COMP run pays (issue #6831, cause 2)
 
 **Status:** W0 closed (the term is a glibc secondary arena, not the library);
-W1 in review, W3 and W4 shipped; W2 and W5 still plan only. Against the
-window's fast endpoint the oracle is back to ×0.999 from ×1.070 — see §9.
+W1, W3, W4 and W5 shipped or in review; W2 closed unbuilt, its premise refuted
+by measurement. Against the window's fast endpoint the oracle is back to
+×0.999 from ×1.070 — see §9.
 **Owner issue:** [#6831](https://github.com/esbmc/esbmc/issues/6831), *cause 2 —
 a general slowdown tipping tasks already at the limit*, ~198 of 489 lost tasks,
 led by 131 `Juliet_Test` no-overflow tasks at a median of 99.1 s of a 100 s
@@ -400,6 +401,37 @@ committing to the design — if shared ireps dominate, the win collapses), and
 every consumer of the format (`c2goto`, `--binary`, goto binary round-trips)
 must move together. W1 delivers a large fraction of the win with none of this
 risk, which is why it is sequenced first.
+
+**Measured, and the risk is realised. Do not build this as sketched.**
+A throwaway probe in `reference_convert()` charges every byte of the stream to
+the record that owns it (a record's span minus the spans of records nested
+inside it), reading `clib64_fp` for `int main(void){return 0;}`:
+
+| | |
+|---|---|
+| distinct ireps (the pool) | **101,027** |
+| back-references to them | 209,803 |
+| bytes owned by distinct ireps | **3,363,256** |
+| bytes in the stream | 3,378,683 |
+
+**The pool is 99.5 % of the blob.** Two thirds of all irep slots are shared, so
+the sharing is real and load-bearing — but what is left once you factor it out
+is 15 KB of framing, not a set of substantial per-symbol records. Step 2 of the
+sketch, "read the index and the pool eagerly, deserialise a symbol record on
+first lookup", therefore reads 99.5 % of the bytes before it has done anything,
+and there is no version of it that is O(used).
+
+The alternative — self-contained records that duplicate whatever they share —
+is a size trade, not a free one: with 209,803 of 310,830 slots being repeats,
+independent records would inflate the blob severalfold, and §2.4 shows per-symbol
+cost *rising* with blob size. That is the wrong direction.
+
+**Recommendation: close W2.** What it was for is now largely delivered by other
+means — W1 removed 30 % of the bytes for C tasks and W3.1 made the remaining
+read ×0.805 — and §9 shows the fixed cost already a third below where the
+regression started. If loading ever needs to be sublinear again, the question
+to reopen is not indexing but whether the *frontend* can avoid asking for
+symbols it will not use.
 
 **Exit:** trivial-program library time proportional to symbols kept (≈100), not
 symbols present (3,847); `esbmc --binary` round-trip regressions pass.

--- a/docs/roadmap/svcomp-6831-fixed-cost-plan.md
+++ b/docs/roadmap/svcomp-6831-fixed-cost-plan.md
@@ -298,7 +298,38 @@ Two things this cost that the sketch above did not anticipate:
 
 **Not done here:** the `libm` half (1,002 symbols, 26 %), which needs the same
 treatment behind `ENABLE_LIBM` and is a bigger question — unlike the Python
-models, libm is reachable from ordinary C.
+models, libm is reachable from ordinary C, so it cannot be keyed off the
+frontend and a wrong answer drops a model a task needed. That is a G1
+soundness risk rather than a performance one.
+
+#### Both fixes together, against the fast endpoint
+
+`master` + #7051 + #7058 built in the bisect's build directory, 12 pairs on the
+oracle, library loaded:
+
+| metric | `978a007e73` | master+both | B/A |
+|---|---|---|---|
+| wall | 9.272 s | 10.398 s | **1.039** |
+| GOTO creation | 0.293 s | 0.210 s | **0.690** |
+| symex | 0.744 s | 0.782 s | 1.072 |
+| encoding | 4.069 s | 4.617 s | 1.081 |
+| solving | 2.026 s | 2.171 s | 1.012 |
+
+**×1.070 → ×1.039: about half the regression recovered**, and GOTO creation is
+now 31 % *below* the 2026-08-01 baseline rather than merely restored.
+
+The residue is symex and encoding, and the shortfall against what the parts
+predicted (×1.070 × ×0.953 ≈ ×1.02) is itself informative: **the two fixes
+overlap**. The arena fix's value came from trimming what the library load left
+in the arena; W1 makes that load smaller, so there is less left to trim. They
+are not additive, and anyone re-measuring one of them after the other lands
+should expect a smaller number than this plan quotes for it in isolation.
+
+What remains — ~4 points in symex and encoding, with the counts identical — is
+not the library and not the arena. It is the same "accumulated creep" the
+bisect saw at commits 23 (×1.020), 35 (×1.015) and 37 (×1.034), and finding it
+means bisecting again with a stopping rule tuned to a 1–2 % effect, which needs
+more pairs per step than the ×1.07 hunt did.
 
 ### W2 — Make the blob indexable, so loading is O(used) not O(total)
 

--- a/docs/roadmap/svcomp-6831-fixed-cost-plan.md
+++ b/docs/roadmap/svcomp-6831-fixed-cost-plan.md
@@ -268,6 +268,38 @@ at read time cannot beat not shipping the bytes down that path at all.
 **Exit:** a C task's deserialise+deps time down by ≥24 % (more, per §2.4), no
 verdict change in any suite, and Python/Solidity/C++ regressions unchanged.
 
+**Shipped as [#7058](https://github.com/esbmc/esbmc/pull/7058)** (Python half;
+`libm` not attempted). `py64` and `py64_fp` are built the way `sol64` is, and
+`clib64_fp.goto` drops from 3,369,011 to 2,348,422 bytes — **−30 %**.
+Interleaved A/B against the same build without the split:
+
+| program | wall | GOTO creation |
+|---|---|---|
+| `int main(void){return 0;}` (14 pairs) | 0.760 | **0.720** |
+| trivial Python (12 pairs) | 0.959 | **0.960** |
+
+**Exit met, and G2's worry did not materialise**: the plan expected Python to
+be flat at best, since it now reads two blobs, and it gains 4 %.
+
+Two things this cost that the sketch above did not anticipate:
+
+- **The split is not self-contained, so read order became load-bearing.**
+  `sol64` holds only Solidity symbols; the Python models call libc, libm and
+  the pthread helpers. `contextt::add` silently rejects duplicates, so clib is
+  read *first* (its definitions win) and a nil declaration carried by the
+  models' headers is dropped when clib holds the body in `ignored_ctx` — adding
+  it would shadow the definition the dependency closure then cannot reach. Get
+  that order backwards and libc bodies silently become declarations: a verdict
+  change, not a crash, which is what G1 exists to catch.
+- **Measurement discipline decided the outcome.** Single runs on a loaded host
+  said the split made C 45 % *slower* and Python 2.2× slower. Interleaved on
+  the same host at the same moment: ×0.72 and ×0.96. The numbers that looked
+  like a reason to revert were an artefact of a load average of 33.
+
+**Not done here:** the `libm` half (1,002 symbols, 26 %), which needs the same
+treatment behind `ENABLE_LIBM` and is a bigger question — unlike the Python
+models, libm is reachable from ordinary C.
+
 ### W2 — Make the blob indexable, so loading is O(used) not O(total)
 
 The end state the issue asks for: seek to the symbols a task needs. Today this

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -235,6 +235,36 @@ function(mangle_clib output)
            MACRO ESBMC_FLAIL
            ACC_HEADERS_INTO ${CMAKE_CURRENT_BINARY_DIR}/libpython.h)
 
+    # Build the Python operational models as their own goto binaries, the way
+    # sol64 is built, so a C or C++ run does not deserialise them (#6831). Two
+    # float encodings, matching the clib64/clib64_fp pair the runtime selects
+    # between; the Python frontend is 64-bit only, so there is no 32-bit pair.
+    set(py64_configs py64 py64_fp)
+    set(py64_flags_py64 --fixedbv -D__ESBMC_FIXEDBV)
+    set(py64_flags_py64_fp --floatbv)
+    foreach(py_cfg ${py64_configs})
+      set(py_goto "${CMAKE_CURRENT_BINARY_DIR}/${py_cfg}.goto")
+      set(py_c "${CMAKE_CURRENT_BINARY_DIR}/${py_cfg}.c")
+      add_custom_command(OUTPUT ${py_goto}
+        COMMAND c2goto ${multiarch_flags} ${OS_C2GOTO_FLAGS}
+                ${c2goto_python_files} --64 ${py64_flags_${py_cfg}}
+                --output ${py_goto}
+        DEPENDS c2goto ${c2goto_python_files} ${c2goto_header_files}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Generating Python model ${py_goto}"
+        VERBATIM
+      )
+      add_custom_command(OUTPUT ${py_c}
+        COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/flail.py
+                -o ${py_c} ${py_goto}
+        DEPENDS ${py_goto} ${CMAKE_SOURCE_DIR}/scripts/flail.py
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Converting Python model ${py_goto} to data"
+        VERBATIM
+      )
+      list(APPEND result ${py_c})
+    endforeach()
+
     list(APPEND result
       ${CMAKE_CURRENT_BINARY_DIR}/libpython.c
       ${CMAKE_CURRENT_BINARY_DIR}/libpython.h)

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -171,16 +171,13 @@ function(mangle_clib output)
       list(APPEND inputs_c ${c2goto_libm_files})
     endif()
 
-    # Python models are built as a separate pair of goto binaries (py64,
-    # py64_fp) below, NOT mixed into clib, so a C or C++ run does not
-    # deserialise them (#6831).
-
     # C++ operational models (esbmc/esbmc#5298): compiled by the C++ frontend
     # registered in c2goto and serialized into the clib alongside the C models.
     list(APPEND inputs_c ${c2goto_cpp_files})
 
-    # Solidity models are built as a separate goto binary (sol64.goto),
-    # NOT mixed into clib64, for faster runtime loading.
+    # Python (py64) and Solidity (sol64) models are built as their own goto
+    # binaries, NOT mixed into clib, so a run of one language does not
+    # deserialise the others' models (#6831).
 
     if(ESBMC_CHERI_CLANG)
       list(APPEND in_flags -I "${cheri_compressed_cap_SOURCE_DIR}")

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -171,9 +171,9 @@ function(mangle_clib output)
       list(APPEND inputs_c ${c2goto_libm_files})
     endif()
 
-    if(ENABLE_PYTHON_FRONTEND)
-      list(APPEND inputs_c ${c2goto_python_files})
-    endif()
+    # Python models are built as a separate pair of goto binaries (py64,
+    # py64_fp) below, NOT mixed into clib, so a C or C++ run does not
+    # deserialise them (#6831).
 
     # C++ operational models (esbmc/esbmc#5298): compiled by the C++ frontend
     # registered in c2goto and serialized into the clib alongside the C models.
@@ -192,7 +192,7 @@ function(mangle_clib output)
     # Convert a list of C operational models (e.g. *.c) into a single goto binary file (e.g. clib32.goto) at CMake build time
     add_custom_command(OUTPUT ${out_goto}
       COMMAND ${run_c2goto}
-      DEPENDS c2goto ${c2goto_library_files} ${c2goto_libm_files} ${c2goto_header_files} ${c2goto_python_files} ${c2goto_cpp_files}
+      DEPENDS c2goto ${c2goto_library_files} ${c2goto_libm_files} ${c2goto_header_files} ${c2goto_cpp_files}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Generating libc model ${out_goto}"
       VERBATIM

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -56,6 +56,13 @@ extern "C"
   extern const uint8_t sol64_buf[];
   extern const unsigned int sol64_buf_size;
 #endif
+
+#ifdef ENABLE_PYTHON_FRONTEND
+  extern const uint8_t py64_buf[];
+  extern const unsigned int py64_buf_size;
+  extern const uint8_t py64_fp_buf[];
+  extern const unsigned int py64_fp_buf_size;
+#endif
 }
 
 namespace
@@ -456,6 +463,32 @@ static bool select_solidity_blob(
 }
 #endif
 
+#ifdef ENABLE_PYTHON_FRONTEND
+/// Merge the Python operational models into what was read from clib. py64
+/// holds only the models, so it is read whole; the libc, libm and pthread
+/// symbols they call stay in clib (`python_c_extern_deps`) and are reached
+/// through the dependency closure below. A declaration the models' headers
+/// carry must not shadow the clib definition of the same name, which the
+/// closure would then have no way to add.
+static void read_python_blob(contextt &new_ctx, contextt &ignored_ctx)
+{
+  const bool floatbv = !config.ansi_c.use_fixed_for_float;
+  const uint8_t *start = floatbv ? py64_fp_buf : py64_buf;
+  unsigned int size = floatbv ? py64_fp_buf_size : py64_buf_size;
+
+  contextt py_ctx, py_ignored;
+  goto_binary_reader py_reader;
+  if (py_reader.read_goto_binary_array(start, size, py_ctx, py_ignored))
+    abort();
+
+  py_ctx.foreach_operand([&new_ctx, &ignored_ctx](const symbolt &s) {
+    if (s.get_value().is_nil() && ignored_ctx.find_symbol(s.id))
+      return;
+    new_ctx.add(s);
+  });
+}
+#endif
+
 struct library_load_report
 {
   bool is_solidity;
@@ -531,7 +564,8 @@ void add_cprover_library(contextt &context, const languaget *language)
 
   goto_binary_reader goto_reader;
 
-  if (language && language->id() == "python")
+  const bool is_python = language && language->id() == "python";
+  if (is_python)
     goto_reader.set_functions_to_read(python_c_models);
 
   const uint8_t *lib_start = clib->start;
@@ -553,6 +587,11 @@ void add_cprover_library(contextt &context, const languaget *language)
   if (goto_reader.read_goto_binary_array(
         lib_start, lib_size, new_ctx, ignored_ctx))
     abort();
+
+#ifdef ENABLE_PYTHON_FRONTEND
+  if (is_python)
+    read_python_blob(new_ctx, ignored_ctx);
+#endif
   fine_timet read_stop = current_time();
 
   // Traverse symbols and get dependencies from both their nested types and values
@@ -589,7 +628,7 @@ void add_cprover_library(contextt &context, const languaget *language)
   // Determine whether this language uses a whitelist-based loading strategy.
   // Python: uses whitelist with clib64 → symbols split between new_ctx/ignored_ctx.
   // Solidity: uses dedicated sol64 binary → ALL symbols in new_ctx, no whitelist.
-  bool uses_whitelist = language && language->id() == "python";
+  bool uses_whitelist = is_python;
 
   new_ctx.foreach_operand([&context,
                            &store_ctx,

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -464,14 +464,15 @@ static bool select_solidity_blob(
 #endif
 
 #ifdef ENABLE_PYTHON_FRONTEND
-/// Merge the Python operational models into what was read from clib. py64
-/// holds only the models, so it is read whole; the libc, libm and pthread
-/// symbols they call stay in clib (`python_c_extern_deps`) and are reached
-/// through the dependency closure below. A declaration the models' headers
-/// carry must not shadow the clib definition of the same name, which the
-/// closure would then have no way to add.
+/// Merge the Python operational models into what was already read from clib.
+/// py64 holds only the models, so it is read whole; the libc, libm and pthread
+/// symbols they call stay in clib and are reached through the dependency
+/// closure below. Hence the skip: a declaration the models' headers carry must
+/// not displace the clib definition of that name, which the closure has no way
+/// to add once the id is taken.
 static void read_python_blob(contextt &new_ctx, contextt &ignored_ctx)
 {
+  // 64-bit only, as sol64 is; the pair is the two float encodings.
   const bool floatbv = !config.ansi_c.use_fixed_for_float;
   const uint8_t *start = floatbv ? py64_fp_buf : py64_buf;
   unsigned int size = floatbv ? py64_fp_buf_size : py64_buf_size;

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -463,15 +463,20 @@ static bool select_solidity_blob(
 }
 #endif
 
-#ifdef ENABLE_PYTHON_FRONTEND
 /// Merge the Python operational models into what was already read from clib.
 /// py64 holds only the models, so it is read whole; the libc, libm and pthread
 /// symbols they call stay in clib and are reached through the dependency
 /// closure below. Hence the skip: a declaration the models' headers carry must
 /// not displace the clib definition of that name, which the closure has no way
 /// to add once the id is taken.
-static void read_python_blob(contextt &new_ctx, contextt &ignored_ctx)
+/// No-op for every other language, as select_solidity_blob is.
+static void
+read_python_blob(bool is_python, contextt &new_ctx, contextt &ignored_ctx)
 {
+#ifdef ENABLE_PYTHON_FRONTEND
+  if (!is_python)
+    return;
+
   // 64-bit only, as sol64 is; the pair is the two float encodings.
   const bool floatbv = !config.ansi_c.use_fixed_for_float;
   const uint8_t *start = floatbv ? py64_fp_buf : py64_buf;
@@ -487,8 +492,12 @@ static void read_python_blob(contextt &new_ctx, contextt &ignored_ctx)
       return;
     new_ctx.add(s);
   });
-}
+#else
+  (void)is_python;
+  (void)new_ctx;
+  (void)ignored_ctx;
 #endif
+}
 
 struct library_load_report
 {
@@ -589,10 +598,7 @@ void add_cprover_library(contextt &context, const languaget *language)
         lib_start, lib_size, new_ctx, ignored_ctx))
     abort();
 
-#ifdef ENABLE_PYTHON_FRONTEND
-  if (is_python)
-    read_python_blob(new_ctx, ignored_ctx);
-#endif
+  read_python_blob(is_python, new_ctx, ignored_ctx);
   fine_timet read_stop = current_time();
 
   // Traverse symbols and get dependencies from both their nested types and values


### PR DESCRIPTION
A C or C++ run deserialised 911 Python-only symbols on every invocation, ~30% of the operational-model blob. They now build as their own goto binaries (`py64`, `py64_fp`), the way `sol64` already does, and only a Python run reads them.

`clib64_fp.goto` drops from 3,369,011 to 2,348,422 bytes. Interleaved A/B against the same build without the split: **GOTO creation ×0.720** on a trivial C program (×0.760 wall), and **×0.960** on a trivial Python one — both frontends gain.

Unlike `sol64` the split is not self-contained: the Python models call libc, libm and the pthread helpers, so clib is read first and a nil declaration the models carry is dropped when clib holds the body, rather than shadowing it.

Regressions: 2,000 Python, 61 core C, 150 C++, all green.

Investigation and measurements: `docs/roadmap/svcomp-6831-fixed-cost-plan.md` (W1).