### PR TITLE
[c2goto] Link CBMC memory primitives only where referenced

### DIFF
--- a/regression/esbmc/cprover_memory_primitives/main.c
+++ b/regression/esbmc/cprover_memory_primitives/main.c
@@ -1,0 +1,16 @@
+/* The bodies of these primitives are linked only when a program refers to
+ * them (#6831), so this test is what keeps a referenced one reaching symex. */
+#include <stdlib.h>
+
+int main(void)
+{
+  int a, b;
+  char *p = malloc(8);
+  if (!p)
+    return 0;
+  __ESBMC_assert(!__CPROVER_same_object(&a, &b), "distinct objects differ");
+  __ESBMC_assert(__CPROVER_OBJECT_SIZE(p) == 8, "malloc(8) is 8 bytes");
+  __ESBMC_assert(__CPROVER_r_ok(p, 8), "the whole allocation is readable");
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cprover_memory_primitives/test.desc
+++ b/regression/esbmc/cprover_memory_primitives/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cprover_memory_primitives_fail/main.c
+++ b/regression/esbmc/cprover_memory_primitives_fail/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int main(void)
+{
+  char *p = malloc(8);
+  if (!p)
+    return 0;
+  __ESBMC_assert(__CPROVER_OBJECT_SIZE(p) == 16, "wrong size on purpose");
+  free(p);
+  return 0;
+}

--- a/regression/esbmc/cprover_memory_primitives_fail/test.desc
+++ b/regression/esbmc/cprover_memory_primitives_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-check
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -445,6 +445,28 @@ static std::unordered_set<std::string> program_references(const contextt &ctx)
   return referenced;
 }
 
+/// Whether a library symbol belongs in the context handed to the rest of the
+/// run. `bundled_wholesale` frontends (Python, Solidity) filter upstream, so
+/// everything their blob carries is kept; for the rest a symbol is a library
+/// body the program declared and left empty, minus the memory primitives it
+/// never mentions.
+static bool store_library_symbol(
+  const contextt &context,
+  const symbolt &s,
+  bool bundled_wholesale,
+  const std::unordered_set<std::string> &referenced)
+{
+  if (bundled_wholesale)
+    return true;
+
+  const symbolt *symbol = context.find_symbol(s.id);
+  if (symbol == nullptr || !symbol->get_value().is_nil())
+    return false;
+
+  return !is_cbmc_memory_primitive(s) ||
+         referenced.find(id2string(s.id)) != referenced.end();
+}
+
 static void ingest_symbol(
   irep_idt name,
   std::multimap<irep_idt, irep_idt> &deps,
@@ -594,30 +616,23 @@ void add_cprover_library(contextt &context, const languaget *language)
   // Solidity: uses dedicated sol64 binary → ALL symbols in new_ctx, no whitelist.
   bool uses_whitelist = language && language->id() == "python";
 
+  const bool bundled_wholesale = is_solidity || uses_whitelist;
+
   const std::unordered_set<std::string> referenced =
-    (is_solidity || uses_whitelist) ? std::unordered_set<std::string>()
-                                    : program_references(context);
+    bundled_wholesale ? std::unordered_set<std::string>()
+                      : program_references(context);
 
   new_ctx.foreach_operand([&context,
                            &store_ctx,
                            &symbol_deps,
                            &to_include,
-                           &is_solidity,
-                           &uses_whitelist,
+                           bundled_wholesale,
                            &referenced](const symbolt &s) {
-    const symbolt *symbol = context.find_symbol(s.id);
-    if (
-      (is_solidity || uses_whitelist) ||
-      (symbol != nullptr && symbol->get_value().is_nil()))
-    {
-      if (
-        !is_solidity && !uses_whitelist && is_cbmc_memory_primitive(s) &&
-        referenced.find(id2string(s.id)) == referenced.end())
-        return;
+    if (!store_library_symbol(context, s, bundled_wholesale, referenced))
+      return;
 
-      store_ctx.add(s);
-      ingest_symbol(s.id, symbol_deps, to_include);
-    }
+    store_ctx.add(s);
+    ingest_symbol(s.id, symbol_deps, to_include);
   });
 
   /* Now iterate through the dependencies that we know we want to add (due to ingest_symbol filter)

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -405,6 +405,46 @@ static void generate_symbol_deps(
   }
 }
 
+/* Linked only when the program actually mentions one of them. Every other
+ * library body arrives because the program declared it and left it empty, but
+ * esbmc_intrinsics.h is force-included, so these ten are "declared" in every
+ * translation unit and would otherwise be linked into programs that never call
+ * them -- ten function bodies to goto-convert, slice and encode, worth ~4% of
+ * wall clock on a 10 s task (esbmc/esbmc#6831). No operational model calls
+ * them; they exist so CBMC sources verify unchanged. */
+static bool is_cbmc_memory_primitive(const symbolt &s)
+{
+  static const std::unordered_set<std::string> names = {
+    "__CPROVER_POINTER_OBJECT",
+    "__CPROVER_POINTER_OFFSET",
+    "__CPROVER_same_object",
+    "__CPROVER_OBJECT_SIZE",
+    "__CPROVER_DYNAMIC_OBJECT",
+    "__CPROVER_LIVE_OBJECT",
+    "__CPROVER_WRITEABLE_OBJECT",
+    "__CPROVER_r_ok",
+    "__CPROVER_w_ok",
+    "__CPROVER_rw_ok"};
+  return names.find(id2string(s.get_function_name())) != names.end();
+}
+
+/// Names the program's own symbols refer to, including through their types.
+/// A function whose address is taken counts as referenced, since the reference
+/// appears in the value that takes it.
+static std::unordered_set<std::string> program_references(const contextt &ctx)
+{
+  std::multimap<irep_idt, irep_idt> deps;
+  ctx.foreach_operand([&deps](const symbolt &s) {
+    generate_symbol_deps(s.id, s.get_value(), deps);
+    generate_symbol_deps(s.id, s.get_type(), deps);
+  });
+
+  std::unordered_set<std::string> referenced;
+  for (const auto &dep : deps)
+    referenced.insert(id2string(dep.second));
+  return referenced;
+}
+
 static void ingest_symbol(
   irep_idt name,
   std::multimap<irep_idt, irep_idt> &deps,
@@ -554,17 +594,27 @@ void add_cprover_library(contextt &context, const languaget *language)
   // Solidity: uses dedicated sol64 binary → ALL symbols in new_ctx, no whitelist.
   bool uses_whitelist = language && language->id() == "python";
 
+  const std::unordered_set<std::string> referenced =
+    (is_solidity || uses_whitelist) ? std::unordered_set<std::string>()
+                                    : program_references(context);
+
   new_ctx.foreach_operand([&context,
                            &store_ctx,
                            &symbol_deps,
                            &to_include,
                            &is_solidity,
-                           &uses_whitelist](const symbolt &s) {
+                           &uses_whitelist,
+                           &referenced](const symbolt &s) {
     const symbolt *symbol = context.find_symbol(s.id);
     if (
       (is_solidity || uses_whitelist) ||
       (symbol != nullptr && symbol->get_value().is_nil()))
     {
+      if (
+        !is_solidity && !uses_whitelist && is_cbmc_memory_primitive(s) &&
+        referenced.find(id2string(s.id)) == referenced.end())
+        return;
+
       store_ctx.add(s);
       ingest_symbol(s.id, symbol_deps, to_include);
     }


### PR DESCRIPTION
`esbmc_intrinsics.h` is force-included, so every C program "declares" the ten `__CPROVER_*` memory primitives, and `add_cprover_library()`'s rule for the C path — declared here with an empty value, so link the body — pulled all ten into programs that never call them. `int main(void){return 0;}` had **16 function bodies where 6 belong**.

They now require a reference in the program's own symbols (a taken address counts). A trivial program is back to 6; one calling `__CPROVER_same_object` gets 7.

Measured with 20 interleaved pairs on an idle host: **×0.994** wall on master, **×0.975** on a build carrying #7051 and #7058, mostly in encoding. The value is less in the number than in the mechanism — every intrinsic added to that header currently costs every task, which is the silent-regrowth pattern #6831 is about.

Two regression tests: one asserting a referenced primitive still reaches symex and holds, one negative.

Regressions: 61 core C, 80 unix, 120 C++, 150 Python, all green.