### PR TITLE
[svcomp] Report the tasks a few percent of runtime would flip

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -169,6 +169,15 @@ jobs:
           ESBMC_OPTS: ${{ inputs.options }}
       - name: Show summary (ESBMC)
         run: tail $HOME/esbmc-output/*results*.txt
+      - name: Show the marginal band (ESBMC)
+        # Tasks finishing within 5% of the limit flip on any timing change, in
+        # either direction, and read as a regression in the score when they do
+        # (esbmc/esbmc#6831). Report them next to the summary so a score move
+        # can be attributed without re-running the set.
+        continue-on-error: true
+        run: |
+          python3 ./esbmc-src/scripts/competitions/svcomp/marginal_timeouts.py \
+            $HOME/esbmc-output/*results*.xml.bz2
       - name: Save logs
         if: ${{ inputs.output != '' }}
         run: cp $HOME/output.zip $HOME/${{ inputs.output }}

--- a/scripts/competitions/svcomp/marginal_timeouts.py
+++ b/scripts/competitions/svcomp/marginal_timeouts.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Report how many SV-COMP tasks finished close enough to the limit to flip.
+
+A run's score moves for two reasons: ESBMC got better or worse at something, or
+tasks sitting a hair under the time limit crossed it. The second is not a
+regression, but it looks exactly like one in the summary -- issue #6831 spent a
+week distinguishing them for 131 Juliet tasks whose median runtime was 99.1 s of
+a 100 s limit.
+
+This reads BenchExec's per-run XML and splits the outcome into what a few
+percent of runtime can and cannot change:
+
+  * marginal wins    -- correct, but within <margin> of the limit; a slowdown
+                        of that size loses them
+  * marginal losses  -- timed out, but a speedup of that size would recover
+                        them (only visible when the run records how long the
+                        task actually took)
+  * safe             -- everything else, which no plausible timing change moves
+
+Usage:
+    marginal_timeouts.py results.xml.bz2 [more.xml ...] [--margin 5]
+"""
+
+import argparse
+import bz2
+import sys
+import xml.etree.ElementTree as ET
+
+
+def parse_seconds(value):
+    """BenchExec writes times as '12.345678901s'."""
+    if not value:
+        return None
+    try:
+        return float(value.rstrip("s"))
+    except ValueError:
+        return None
+
+
+def load(path):
+    opener = bz2.open if path.endswith(".bz2") else open
+    with opener(path, "rb") as handle:
+        return ET.parse(handle).getroot()
+
+
+def limit_of(result, override):
+    if override:
+        return override
+    # BenchExec records the budget on the result element; cputime is what the
+    # limit applies to, so prefer it and fall back to the wall clock one.
+    for attribute in ("cpuTimelimit", "timelimit", "walltimelimit"):
+        seconds = parse_seconds(result.get(attribute))
+        if seconds:
+            return seconds
+    return None
+
+
+def classify(result, limit, margin):
+    """Split one result file's runs into marginal wins, marginal losses, safe."""
+    threshold = limit * (1.0 - margin / 100.0)
+    wins, losses, safe = [], [], 0
+
+    for run in result.iter("run"):
+        columns = {c.get("title"): c.get("value") for c in run.findall("column")}
+        status = columns.get("status", "")
+        cputime = parse_seconds(columns.get("cputime"))
+        name = run.get("name") or run.get("files") or "?"
+
+        if status.startswith("TIMEOUT"):
+            losses.append((name, cputime))
+        elif cputime is not None and cputime >= threshold:
+            wins.append((name, cputime))
+        else:
+            safe += 1
+
+    return wins, losses, safe
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("results", nargs="+", help="BenchExec results XML (.xml or .xml.bz2)")
+    parser.add_argument("--margin", type=float, default=5.0,
+                        help="percent of the limit that counts as marginal (default: 5)")
+    parser.add_argument("--limit", type=float, help="time limit in seconds, if not in the XML")
+    parser.add_argument("--list", action="store_true", help="name every marginal task")
+    opts = parser.parse_args()
+
+    total_wins, total_losses, total_safe = [], [], 0
+    for path in opts.results:
+        result = load(path)
+        limit = limit_of(result, opts.limit)
+        if limit is None:
+            print(f"{path}: no time limit recorded; pass --limit", file=sys.stderr)
+            return 2
+        wins, losses, safe = classify(result, limit, opts.margin)
+        total_wins += wins
+        total_losses += losses
+        total_safe += safe
+        print(f"{path}: limit {limit:g}s, marginal band {limit * (1 - opts.margin / 100):g}-{limit:g}s")
+
+    print(f"\nmarginal wins   {len(total_wins):>6}  correct, but a {opts.margin:g}% slowdown loses them")
+    print(f"marginal losses {len(total_losses):>6}  timed out")
+    print(f"safe            {total_safe:>6}")
+
+    if opts.list:
+        print()
+        for name, cputime in sorted(total_wins, key=lambda w: -(w[1] or 0)):
+            print(f"  {cputime:>8.1f}s  {name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/competitions/svcomp/marginal_timeouts.py
+++ b/scripts/competitions/svcomp/marginal_timeouts.py
@@ -38,12 +38,14 @@ def parse_seconds(value):
 
 
 def load(path):
+    """Read a BenchExec result file, transparently un-bzipping it."""
     opener = bz2.open if path.endswith(".bz2") else open
     with opener(path, "rb") as handle:
         return ET.parse(handle).getroot()
 
 
 def limit_of(result, override):
+    """The run's time budget in seconds: the override, else what BenchExec recorded."""
     if override:
         return override
     # BenchExec records the budget on the result element; cputime is what the
@@ -77,6 +79,7 @@ def classify(result, limit, margin):
 
 
 def main():
+    """Print the marginal band for every result file named on the command line."""
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("results", nargs="+", help="BenchExec results XML (.xml or .xml.bz2)")

--- a/scripts/competitions/svcomp/marginal_timeouts.py
+++ b/scripts/competitions/svcomp/marginal_timeouts.py
@@ -24,7 +24,7 @@ Usage:
 import argparse
 import bz2
 import sys
-import xml.etree.ElementTree as ET
+from xml.etree import ElementTree
 
 
 def parse_seconds(value):
@@ -41,7 +41,7 @@ def load(path):
     """Read a BenchExec result file, transparently un-bzipping it."""
     opener = bz2.open if path.endswith(".bz2") else open
     with opener(path, "rb") as handle:
-        return ET.parse(handle).getroot()
+        return ElementTree.parse(handle).getroot()
 
 
 def limit_of(result, override):

--- a/scripts/competitions/svcomp/test_marginal_timeouts.py
+++ b/scripts/competitions/svcomp/test_marginal_timeouts.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Self-test. Run: python3 scripts/competitions/svcomp/test_marginal_timeouts.py"""
+
+import unittest
+import xml.etree.ElementTree as ET
+
+import marginal_timeouts
+
+# Shaped like BenchExec 3.x output: one <run> per task, times as '12.3s'.
+RESULT_XML = """<?xml version="1.0"?>
+<result benchmarkname="esbmc" cpuTimelimit="100.0s" walltimelimit="120.0s">
+  <run name="ok_fast.c" files="[ok_fast.c]">
+    <column title="status" value="true"/>
+    <column title="cputime" value="3.140000000s"/>
+  </run>
+  <run name="ok_marginal.c" files="[ok_marginal.c]">
+    <column title="status" value="true"/>
+    <column title="cputime" value="99.100000000s"/>
+  </run>
+  <run name="ok_just_inside.c" files="[ok_just_inside.c]">
+    <column title="status" value="false(unreach-call)"/>
+    <column title="cputime" value="95.000000000s"/>
+  </run>
+  <run name="lost.c" files="[lost.c]">
+    <column title="status" value="TIMEOUT"/>
+    <column title="cputime" value="100.200000000s"/>
+  </run>
+</result>
+"""
+
+
+class TestClassify(unittest.TestCase):
+    def setUp(self):
+        self.result = ET.fromstring(RESULT_XML)
+
+    def test_marginal_band_is_inclusive_at_the_threshold(self):
+        wins, losses, safe = marginal_timeouts.classify(self.result, 100.0, 5.0)
+        self.assertEqual([name for name, _ in wins], ["ok_marginal.c", "ok_just_inside.c"])
+        self.assertEqual([name for name, _ in losses], ["lost.c"])
+        self.assertEqual(safe, 1)
+
+    def test_a_narrower_margin_keeps_fewer_tasks(self):
+        wins, _, safe = marginal_timeouts.classify(self.result, 100.0, 1.0)
+        self.assertEqual([name for name, _ in wins], ["ok_marginal.c"])
+        self.assertEqual(safe, 2)
+
+    def test_limit_comes_from_the_cpu_budget(self):
+        self.assertEqual(marginal_timeouts.limit_of(self.result, None), 100.0)
+        self.assertEqual(marginal_timeouts.limit_of(self.result, 30.0), 30.0)
+
+
+class TestParseSeconds(unittest.TestCase):
+    def test_strips_the_unit(self):
+        self.assertEqual(marginal_timeouts.parse_seconds("12.5s"), 12.5)
+
+    def test_missing_or_unparseable_is_none(self):
+        self.assertIsNone(marginal_timeouts.parse_seconds(None))
+        self.assertIsNone(marginal_timeouts.parse_seconds(""))
+        self.assertIsNone(marginal_timeouts.parse_seconds("-"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/competitions/svcomp/test_marginal_timeouts.py
+++ b/scripts/competitions/svcomp/test_marginal_timeouts.py
@@ -2,7 +2,7 @@
 """Self-test. Run: python3 scripts/competitions/svcomp/test_marginal_timeouts.py"""
 
 import unittest
-import xml.etree.ElementTree as ET
+from xml.etree import ElementTree
 
 import marginal_timeouts
 
@@ -31,7 +31,7 @@ RESULT_XML = """<?xml version="1.0"?>
 
 class TestClassify(unittest.TestCase):
     def setUp(self):
-        self.result = ET.fromstring(RESULT_XML)
+        self.result = ElementTree.fromstring(RESULT_XML)
 
     def test_marginal_band_is_inclusive_at_the_threshold(self):
         wins, losses, safe = marginal_timeouts.classify(self.result, 100.0, 5.0)


### PR DESCRIPTION
131 Juliet tasks ran at a median of **99.1 s of a 100 s limit**. Any change costing a few percent lost them; any change saving a few percent wins them back. In the score alone that is indistinguishable from ESBMC getting better or worse at verification — #6831 spent a week telling the two apart.

The benchexec workflow now prints, next to the existing summary, how many correct tasks finished inside the last 5% of the limit and how many timed out:

```
marginal wins       2  correct, but a 5% slowdown loses them
marginal losses     1  timed out
safe                1
```

`--list` names them, `--margin` widens the band. The step is `continue-on-error` — a reporting aid must never fail a benchmark run. Ships with a dependency-free self-test over a captured BenchExec XML shape.

Part of the #6831 cause-2 fixed-cost plan (W5).