### PR TITLE
[clang-cpp-frontend] Zero-init trivial value-init mem-initializers

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4243_mem_init/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4243_mem_init/main.cpp
@@ -1,0 +1,18 @@
+#include <array>
+#include <cstdint>
+
+struct B
+{
+  std::array<std::uint32_t, 8> bitmap_;
+  B() : bitmap_() {} // parenthesized value-init in a ctor mem-initializer
+};
+
+int main()
+{
+  B x;
+  for (std::size_t i = 0; i < x.bitmap_.size(); ++i)
+    __ESBMC_assert(
+      x.bitmap_[i] == 0,
+      "value-init must zero-initialise std::array members");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4243_mem_init/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4243_mem_init/main.cpp
@@ -4,7 +4,31 @@
 struct B
 {
   std::array<std::uint32_t, 8> bitmap_;
-  B() : bitmap_() {} // parenthesized value-init in a ctor mem-initializer
+  B() : bitmap_()
+  {
+  } // parenthesized value-init in a ctor mem-initializer
+};
+
+struct M
+{
+  std::uint32_t v;
+  M() : v(7)
+  {
+  } // user-provided default ctor: must keep the call path
+};
+
+struct W
+{
+  M m; // implicit, non-trivial default ctor: must keep the call path
+};
+
+struct U
+{
+  M m;
+  W w;
+  U() : m(), w()
+  {
+  } // parenthesized mem-initializers must still call
 };
 
 int main()
@@ -12,7 +36,10 @@ int main()
   B x;
   for (std::size_t i = 0; i < x.bitmap_.size(); ++i)
     __ESBMC_assert(
-      x.bitmap_[i] == 0,
-      "value-init must zero-initialise std::array members");
+      x.bitmap_[i] == 0, "value-init must zero-initialise std::array members");
+
+  U u;
+  __ESBMC_assert(u.m.v == 7, "user-provided ctor still runs");
+  __ESBMC_assert(u.w.m.v == 7, "non-trivial implicit ctor still runs");
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_4243_mem_init/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4243_mem_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4243_mem_init_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4243_mem_init_fail/main.cpp
@@ -1,17 +1,21 @@
+// Counterpart of github_4243_mem_init: the mem-initializer zeroes the
+// elements, but an explicit write in the ctor body must win over that
+// zero-init.
 #include <array>
 #include <cstdint>
 
 struct B
 {
   std::array<std::uint32_t, 8> bitmap_;
-  B() : bitmap_() {}
+  B() : bitmap_()
+  {
+    bitmap_[0] = 7;
+  }
 };
 
 int main()
 {
   B x;
-  __ESBMC_assert(
-    x.bitmap_[0] != 0,
-    "value-init must zero-initialise std::array members");
+  __ESBMC_assert(x.bitmap_[0] == 0, "explicit write must not be zeroed");
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_4243_mem_init_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4243_mem_init_fail/main.cpp
@@ -1,0 +1,17 @@
+#include <array>
+#include <cstdint>
+
+struct B
+{
+  std::array<std::uint32_t, 8> bitmap_;
+  B() : bitmap_() {}
+};
+
+int main()
+{
+  B x;
+  __ESBMC_assert(
+    x.bitmap_[0] != 0,
+    "value-init must zero-initialise std::array members");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4243_mem_init_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4243_mem_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -32,6 +32,7 @@ CC_DIAGNOSTIC_POP()
 #include <util/lang/c_types.h>
 #include <util/lang/exception_specification.h>
 #include <util/expr/string_constant.h>
+#include <util/expr/symbolic_types.h>
 #include <util/symtab/base_subobject.h>
 
 clang_cpp_convertert::clang_cpp_convertert(
@@ -2329,7 +2330,22 @@ bool clang_cpp_convertert::get_function_body(
 
         exprt rhs;
         rhs.set("#member_init", 1);
-        if (get_expr(*init->getInit(), rhs))
+
+        /* `m()` in a mem-initializer value-initializes m. For a class type
+         * whose default ctor is trivial (thus not user-provided) this is
+         * exactly zero-initialization, [dcl.init.general]/8; and the implicit
+         * ctor has no GOTO body, so emitting the call would havoc m and leave
+         * it nondeterministic (#4243). */
+        const auto *ctor_expr =
+          llvm::dyn_cast<clang::CXXConstructExpr>(init->getInit());
+        if (
+          ctor_expr && ctor_expr->requiresZeroInitialization() &&
+          ctor_expr->getConstructor() &&
+          ctor_expr->getConstructor()->isTrivial())
+          /* member.type() may be a symbolic tag; resolve it so gen_zero
+           * walks the real struct/array. */
+          rhs = gen_zero(get_complete_type(member.type(), ns));
+        else if (get_expr(*init->getInit(), rhs))
           return true;
 
         /* We can't assign to arrays, dereference() will choke. */

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2141,6 +2141,25 @@ bool clang_cpp_convertert::build_lambda_static_invoker(
   return false;
 }
 
+bool clang_cpp_convertert::get_member_initializer(
+  const clang::Expr &init,
+  const typet &member_type,
+  exprt &rhs)
+{
+  const auto *ctor_expr = llvm::dyn_cast<clang::CXXConstructExpr>(&init);
+  if (
+    ctor_expr && zero_initialises(init) && ctor_expr->getConstructor() &&
+    ctor_expr->getConstructor()->isTrivial())
+  {
+    // member_type may be a symbolic tag; resolve it so gen_zero walks the
+    // real struct/array.
+    rhs = gen_zero(get_complete_type(member_type, ns));
+    return false;
+  }
+
+  return get_expr(init, rhs);
+}
+
 bool clang_cpp_convertert::get_function_body(
   const clang::FunctionDecl &fd,
   exprt &new_expr,
@@ -2336,16 +2355,7 @@ bool clang_cpp_convertert::get_function_body(
          * exactly zero-initialization, [dcl.init.general]/8; and the implicit
          * ctor has no GOTO body, so emitting the call would havoc m and leave
          * it nondeterministic (#4243). */
-        const auto *ctor_expr =
-          llvm::dyn_cast<clang::CXXConstructExpr>(init->getInit());
-        if (
-          ctor_expr && ctor_expr->requiresZeroInitialization() &&
-          ctor_expr->getConstructor() &&
-          ctor_expr->getConstructor()->isTrivial())
-          /* member.type() may be a symbolic tag; resolve it so gen_zero
-           * walks the real struct/array. */
-          rhs = gen_zero(get_complete_type(member.type(), ns));
-        else if (get_expr(*init->getInit(), rhs))
+        if (get_member_initializer(*init->getInit(), member.type(), rhs))
           return true;
 
         /* We can't assign to arrays, dereference() will choke. */

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -93,6 +93,10 @@ protected:
     const clang::FunctionDecl &fd,
     exprt &new_expr,
     const code_typet &ftype) override;
+  bool get_member_initializer(
+    const clang::Expr &init,
+    const typet &member_type,
+    exprt &rhs);
 
   /** Body for a lambda's static invoker: forward to the closure's
    *  operator(). Clang synthesises this in CodeGen, so the AST has none. */


### PR DESCRIPTION
## Description

When you write `B() : bitmap_()`, the frontend turns it into a call to `array#`, a constructor that was never actually generated. Symex hits a function with no body, warns, and skips it. Nothing ever writes the zeroes and the array contents stay random. `std::array<int,4> buf{}` was already fixed by #4244: that form just becomes the constant `{0,0,0,0}` directly. The two spellings go through different code, though, and the constructor one never got the same fix.

```cpp
struct B
{
  std::array<std::uint32_t, 8> bitmap_;
  B() : bitmap_() {}
};

int main()
{
  B x;
  __ESBMC_assert(x.bitmap_[0] == 0, "elements must be zero"); // FAILED on master
}
```

## Change

In `get_function_body`, where ctor member initializers get converted, if the initializer is a `CXXConstructExpr` that value-initializes a member whose default ctor is trivial, we now assign a zero constant straight to the member instead of emitting the call. For a trivial default constructor that's exactly equivalent. It isn't user-provided, has no vptrs to set and no members to construct, so zeroing is all the call would ever have done. This matches the standard's value-initialization rule ([dcl.init.general]/8): a class type whose default ctor is neither user-provided nor deleted is zero-initialized. Copy/move inits and every ctor that has a real body still take the old path unchanged.

## Validation

- New regressions: `github_4243_mem_init` / `_fail` twin.

Refs #4243.
