### PR TITLE
[solver] Report Bitwuzla's unevaluatable booleans instead of aborting

### DIFF
--- a/regression/bitwuzla/github_7063/main.c
+++ b/regression/bitwuzla/github_7063/main.c
@@ -1,0 +1,20 @@
+#define SIZE 3
+typedef char data_t;
+typedef int idx_t;
+
+int main()
+{
+  idx_t idx;
+  data_t vec[SIZE];
+  idx_t idx_vfy;
+
+  idx = 0;
+  __ESBMC_loop_invariant(
+    __ESBMC_forall(&idx_vfy, !(idx_vfy == 1) || (vec[idx_vfy] == 17)));
+
+  while (idx < SIZE - 1)
+  {
+    vec[idx] = 3;
+    ++idx;
+  }
+}

--- a/regression/bitwuzla/github_7063/test.desc
+++ b/regression/bitwuzla/github_7063/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--multi-property --loop-invariant-check --bitwuzla
+^VERIFICATION FAILED$
+^Violated property:$
+^✗ FAILED: 'loop invariant base case at file .*main\.c line 15 column 3 function main'$
+^Properties: 4 verified ✓ 1 passed, ✗ 3 failed$
+\A(?![\s\S]*Can't get boolean value)[\s\S]*\Z

--- a/regression/bitwuzla/github_7063_holds/main.c
+++ b/regression/bitwuzla/github_7063_holds/main.c
@@ -1,0 +1,22 @@
+#define SIZE 3
+typedef char data_t;
+typedef int idx_t;
+
+int main()
+{
+  idx_t idx;
+  data_t vec[SIZE];
+  idx_t idx_vfy;
+
+  idx = 0;
+  __ESBMC_loop_invariant(
+    0 <= idx && idx <= SIZE - 1 &&
+    __ESBMC_forall(
+      &idx_vfy, !(0 <= idx_vfy && idx_vfy < idx) || (vec[idx_vfy] == 3)));
+
+  while (idx < SIZE - 1)
+  {
+    vec[idx] = 3;
+    ++idx;
+  }
+}

--- a/regression/bitwuzla/github_7063_holds/test.desc
+++ b/regression/bitwuzla/github_7063_holds/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--multi-property --loop-invariant-check --bitwuzla
+^VERIFICATION SUCCESSFUL$
+^Properties: 4 verified ✓ 4 passed$

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -1,5 +1,4 @@
 #include <bitwuzla_conv.h>
-#include <cstring>
 #include <cstdio>
 
 #define new_ast new_solver_ast<bitw_smt_ast>
@@ -699,19 +698,18 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 tvt bitwuzla_convt::get_bool(smt_astt a)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
+  BitwuzlaTerm value = bitwuzla_get_value(bitw, ast->a);
 
-  const char *result =
-    bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
-
-  assert(result != NULL && "Bitwuzla returned null bv value string");
-
-  if (!strcmp(result, "true"))
+  if (bitwuzla_term_is_true(value))
     return tvt(true);
-  if (!strcmp(result, "false"))
+  if (bitwuzla_term_is_false(value))
     return tvt(false);
 
-  log_error("Can't get boolean value from Bitwuzla: {}", result);
-  abort();
+  // Bitwuzla returns the query term unchanged when evaluating it would need a
+  // quantifier it never registered, so there is no ground value here (#7063).
+  log_debug(
+    "solver", "Bitwuzla returned no boolean value; term is unevaluatable");
+  return tvt(tvt::TV_UNKNOWN);
 }
 
 BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)


### PR DESCRIPTION
`bitwuzla_get_value` returns the query term unchanged when evaluating it would
need a quantifier the solver never registered, so `get_bool`'s string comparison
fell through to `abort()` and the run produced no verdict at all. Return
`TV_UNKNOWN` instead, matching how the Z3 backend already handles this case
(#6191); `get_by_ast` maps it to the established "no value" signal.

Tests: `github_7063` (issue reproducer, fails without the patch) and
`github_7063_holds` (provable invariant, guards the SUCCESSFUL direction).

Fixes #7063