### PR TITLE
[contracts] Record why __ESBMC_old declines two array shapes

### DIFF
--- a/regression/function_contract/github_4219_old_in_forall_array_param_knownbug/main.c
+++ b/regression/function_contract/github_4219_old_in_forall_array_param_knownbug/main.c
@@ -1,8 +1,17 @@
-// An `int r[N]` parameter is a pointer, so there is no whole array to snapshot
-// and the lift declines. The quantified __ESBMC_old then reaches the frontend
-// unchanged and reports "cannot model call to __ESBMC_old_raw on a quantified
-// variable". Wrapping the array in a struct (github_4219_old_in_forall) or
-// naming it directly (github_4219_old_in_forall_array_base) both work.
+// An `int r[N]` parameter is a pointer, so `bound_array_element` finds no
+// array-typed base and the lift declines before it starts. The quantified
+// __ESBMC_old then reaches the frontend unchanged and reports "cannot model
+// call to __ESBMC_old_raw on a quantified variable".
+//
+// The lift is right to decline. A quantified index cannot be snapshotted one
+// element at a time -- the snapshot is taken once, before the body runs, while
+// j still ranges -- so the whole region has to be copied and indexed after. For
+// a pointer parameter that region is reached through the pointer and its extent
+// lives in the `is_fresh` clause, which the lift never sees.
+//
+// Wrapping the array in a struct (github_4219_old_in_forall) or naming it
+// directly (github_4219_old_in_forall_array_base) both work, because both give
+// the snapshot a named object whose address resolves.
 #define N 4
 #define BOUND 100
 

--- a/regression/function_contract/github_4219_old_in_forall_ptr_to_array_knownbug/main.c
+++ b/regression/function_contract/github_4219_old_in_forall_ptr_to_array_knownbug/main.c
@@ -1,10 +1,30 @@
-// `int (*r)[N]` does name a whole array, so the lift fires and takes the
-// non-member path, but the snapshot it builds reads that array through a
-// dereference and the dereference layer refuses an array rvalue:
+// `int (*r)[N]` does name a whole array, so the lift fires, and it takes the
+// same route a directly named global array takes -- both reach
+// lift_old_over_bound_index with an array-typed object and build
+// `dereference(typecast(__ESBMC_old_raw(&object), int (*)[N]))`. The named
+// global verifies; this one reports
 //   ERROR: Can't construct rvalue reference to array type during dereference
-// The struct-member path (github_4219_old_in_forall) avoids this by taking the
-// struct instead and re-applying the member; a pointer to array has no such
-// enclosing object to take.
+//
+// So reading the snapshot back as an array rvalue is not what fails: the global
+// does that too. The two differ only in what `&object` is. For the global it is
+// the address of a named object; here `object` is `*r`, so it is `&*r`, an
+// address computed through a pointer, and the dereference layer cannot
+// construct the array rvalue for it. Confirmed by instrumenting the lift:
+//   named global   object.id=symbol       object.type=array   SUCCESSFUL
+//   pointer to arr object.id=dereference  object.type=array   the error above
+//
+// Two ways round it were tried and both trade the error for a crash, so the
+// shape is pinned rather than half-fixed:
+//   - snapshot through the pointer and index the element type, `((int *)snap)[j]`:
+//     assertion `!is_scalar_type(expr)' in
+//     dereferencet::dereference_expr_nonscalar (dereference.cpp:529)
+//   - the same with explicit pointer arithmetic, `*((int *)snap + j)`:
+//     assertion in assert_arith_2ops_consistency (irep2_expr.cpp:673), the
+//     index needing a width the construction does not give it
+//
+// What this needs is for the snapshot to be taken of a pointed-to region rather
+// than of a named object; see github_4219_old_in_forall_array_param_knownbug,
+// which needs the same thing for a different reason.
 #define N 4
 #define BOUND 100
 


### PR DESCRIPTION
Refs #7057. **Documentation only — no behaviour change, no source file outside `regression/` is touched.**

I tried to fix both shapes, could not, and this records what blocks them so the
next reader does not start where I did. Both KNOWNBUG tests said what the error
was; neither said why it cannot be fixed where it appears — and my first attempt
at writing that down was wrong, which is the more useful half of this PR.

## Why the lift exists at all

A quantified index cannot be snapshotted one element at a time. The snapshot is
taken once, before the body runs, while `j` still ranges over the quantifier, so
`__ESBMC_old(r[j])` has to become *"copy the whole region now, index it by `j`
later"*. That rewrite is `lift_old_over_bound_index`, and it needs an object to
copy.

## `int (*r)[N]` — and the correction

My first reading was that reading the snapshot back as an array rvalue is what
fails, and that the struct-member path avoids it by copying the enclosing
struct. **That is wrong.** Instrumenting the lift shows a directly named global
array takes the same route and builds the same array rvalue read:

| test | `object.id` | `object.type` | result |
|---|---|---|---|
| `github_4219_old_in_forall_array_base` | `symbol` | `array` | VERIFICATION SUCCESSFUL |
| `github_4219_old_in_forall_ptr_to_array_knownbug` | `dereference` | `array` | `Can't construct rvalue reference to array type during dereference` |

Both reach the same line and build
`dereference(typecast(__ESBMC_old_raw(&object), int (*)[N]))`. So the array
rvalue is not the problem: the global does it too and verifies.

The two differ in one thing — what `&object` is. For the global it is the
address of a named object. Here `object` is `*r`, so it is `&*r`, an address
computed through a pointer, and the dereference layer cannot construct the
rvalue for it.

Two ways round it, both of which trade the error for a crash:

| attempt | result |
|---|---|
| snapshot through the pointer, index the element type: `((int *)snap)[j]` | `Assertion !is_scalar_type(expr)` in `dereferencet::dereference_expr_nonscalar`, dereference.cpp:529 |
| the same with explicit pointer arithmetic: `*((int *)snap + j)` | assertion in `assert_arith_2ops_consistency`, irep2_expr.cpp:673 — the index needs a width the construction does not give it |

By the second I was guessing at IR construction details, so I stopped.

## `int r[N]` — the lift declines, and correctly

`bound_array_element` requires an array-typed base and a decayed parameter is a
pointer, so the lift never starts. Forcing it would be wrong rather than merely
awkward: the region to copy is reached through the pointer and its extent lives
in the `__ESBMC_is_fresh` clause, which the lift never sees.

## The common cause

Both shapes need the snapshot to be taken of a **pointed-to region** rather than
of a named object — the extent being what `__ESBMC_is_fresh` already states.
That capability does not exist, and adding it is the actual fix; anything done
inside `lift_old_over_bound_index` works around its absence.

#7057 is re-scoped to say so.

## Verification

`function_contract` 369/369 — both tests stay KNOWNBUG and stay red for the
reasons now written down.
