### PR TITLE
[svcomp] Drop the inert --floatbv flag from the wrapper

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -235,7 +235,7 @@ esbmc_path = "./esbmc "
 # as a no-op, emits physical line numbers for witnesses, and avoids malloc/free
 # in the fopen/fclose models.
 esbmc_dargs = "--sv-comp --no-div-by-zero-check --force-malloc-success --force-realloc-success --state-hashing --add-symex-value-sets "
-esbmc_dargs += "--no-align-check --k-step 2 --floatbv --unlimited-k-steps "
+esbmc_dargs += "--no-align-check --k-step 2 --unlimited-k-steps "
 
 # <https://github.com/esbmc/esbmc/pull/1190#issuecomment-1637047028>
 esbmc_dargs += "--no-vla-size-check "


### PR DESCRIPTION
`--floatbv` has been ESBMC's default float encoding since 9f96e947ed (2018) and no code reads the option: the frontend keys off `--fixedbv` and the solver picks its FP encoding from `--fp2bv` plus backend support. Its only live effect is the conflict check against `--fixedbv`, which the wrapper never passes.

Verified by dry-run: across all 80 command lines the wrapper generates (5 property files x 4 strategies x 2 architectures x concurrency on/off), the sole textual delta is the removed flag, and an end-to-end run under the full wrapper flags gives byte-identical output with and without it.