### PR TITLE
[solver] Fall back to nlsat when the smt tactic gives up on reals

### DIFF
--- a/regression/floats/ir_nonlinear_nlsat/main.c
+++ b/regression/floats/ir_nonlinear_nlsat/main.c
@@ -1,0 +1,20 @@
+/* Companion to ir_nonlinear_nlsat_fail: the same nonlinear goal with the NaN
+ * operands assumed away, so the equality holds and the nonlinear fallback must
+ * not manufacture a counterexample. */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = nondet_float();
+  float y = nondet_float();
+  float z = x * y;
+  float w = z * z;
+
+  __ESBMC_assume(z == z && w == w);
+
+  assert(w == z * z);
+  return 0;
+}

--- a/regression/floats/ir_nonlinear_nlsat/test.desc
+++ b/regression/floats/ir_nonlinear_nlsat/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/ir_nonlinear_nlsat_fail/main.c
+++ b/regression/floats/ir_nonlinear_nlsat_fail/main.c
@@ -1,0 +1,19 @@
+/* A nested product of unbounded floats under directed rounding: nonlinear in
+ * the reals the integer/real encoding uses, so Z3's `smt` tactic alone reports
+ * "incomplete (theory arithmetic)" and no verdict is reached at all.
+ * The violation is a NaN operand, for which the equality is false. */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = nondet_float();
+  float y = nondet_float();
+  float z = x * y;
+  float w = z * z;
+
+  assert(w == z * z);
+  return 0;
+}

--- a/regression/floats/ir_nonlinear_nlsat_fail/test.desc
+++ b/regression/floats/ir_nonlinear_nlsat_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3
+^VERIFICATION FAILED$

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -50,8 +50,16 @@ z3_convt::z3_convt(const namespacet &_ns, const optionst &_options)
     array_iface(true, true),
     fp_convt(this),
     z3_ctx(),
+    /* `smt` is incomplete for nonlinear real arithmetic, which the
+     * integer/real encoding (--ir) produces from a float multiplication, and
+     * the relevancy=0 below makes it give up rather than grind: it reports
+     * "incomplete (theory arithmetic)", which reaches the user as "SMT solver
+     * failed" with no verdict. Fall back to the complete NRA procedure, which
+     * declines any goal outside QF_NRA and leaves the result unknown exactly
+     * as before. */
     solver((z3::tactic(z3_ctx, "simplify") & z3::tactic(z3_ctx, "solve-eqs") &
-            z3::tactic(z3_ctx, "simplify") & z3::tactic(z3_ctx, "smt"))
+            z3::tactic(z3_ctx, "simplify") &
+            (z3::tactic(z3_ctx, "smt") | z3::tactic(z3_ctx, "qfnra-nlsat")))
              .mk_solver())
 {
   z3::params p(z3_ctx);


### PR DESCRIPTION
Z3's `smt` tactic is incomplete for nonlinear real arithmetic and the `relevancy=0` ESBMC sets makes it abandon such a goal rather than grind, so a float multiplication under the integer/real encoding reached the user as `ERROR: SMT solver failed` with no verdict. Composing the chain with `qfnra-nlsat` through `or-else` only runs the fallback where `smt` already failed, and it declines any goal outside QF_NRA, leaving unknown exactly as before.

This repairs two CORE tests already in the tree that fail on master — `floats/underflow8` and `ir-ra/ra-interval-lift-mul-rup-both-tracked-single` — and adds a discriminating pair. Swept all 540 `--ir` tests against a master control binary: those two flip to passing, nothing regresses, and wall-clock is unchanged (2m44s vs 2m49s).