### PR TITLE
[python] Refuse a called lambda parameter instead of crashing

### DIFF
--- a/regression/python/github_7074-ok/main.py
+++ b/regression/python/github_7074-ok/main.py
@@ -1,0 +1,11 @@
+def apply(g, v: int) -> int:
+    return g(v)
+
+
+def main():
+    n: int = 10
+    inc = lambda x: x + n
+    assert apply(inc, 5) == 15
+
+
+main()

--- a/regression/python/github_7074-ok/test.desc
+++ b/regression/python/github_7074-ok/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7074-ok_fail/main.py
+++ b/regression/python/github_7074-ok_fail/main.py
@@ -1,0 +1,11 @@
+def apply(g, v: int) -> int:
+    return g(v)
+
+
+def main():
+    n: int = 10
+    inc = lambda x: x + n
+    assert apply(inc, 5) == 16
+
+
+main()

--- a/regression/python/github_7074-ok_fail/test.desc
+++ b/regression/python/github_7074-ok_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/github_7074/main.py
+++ b/regression/python/github_7074/main.py
@@ -1,0 +1,7 @@
+def main():
+    apply = lambda g, v: g(v)
+    inc = lambda x: x + 1
+    assert apply(inc, 5) == 6
+
+
+main()

--- a/regression/python/github_7074/test.desc
+++ b/regression/python/github_7074/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: calling the lambda parameter 'g' is not supported: higher-order lambda parameters have no inferred signature$

--- a/src/python-frontend/lambda/python_lambda.cpp
+++ b/src/python-frontend/lambda/python_lambda.cpp
@@ -139,6 +139,19 @@ static bool is_param_used_as_callee(
   return false;
 }
 
+static void refuse_called_lambda_parameter(
+  const nlohmann::json &body_node,
+  const std::string &arg_name)
+{
+  if (!is_param_used_as_callee(body_node, arg_name))
+    return;
+
+  throw std::runtime_error(
+    "calling the lambda parameter '" + arg_name +
+    "' is not supported: higher-order lambda parameters have no inferred "
+    "signature");
+}
+
 typet python_lambda::infer_lambda_return_type(
   [[maybe_unused]] const nlohmann::json &body_node)
 {
@@ -248,11 +261,7 @@ void python_lambda::process_lambda_parameters(
   {
     std::string arg_name = arg["arg"].get<std::string>();
 
-    if (is_param_used_as_callee(body_node, arg_name))
-      throw std::runtime_error(
-        "calling the lambda parameter '" + arg_name +
-        "' is not supported: higher-order lambda parameters have no inferred "
-        "signature");
+    refuse_called_lambda_parameter(body_node, arg_name);
 
     // Determine parameter type from annotation or infer from usage
     typet param_type = double_type();

--- a/src/python-frontend/lambda/python_lambda.cpp
+++ b/src/python-frontend/lambda/python_lambda.cpp
@@ -104,6 +104,41 @@ static bool is_param_used_as_string(
   return false;
 }
 
+// True when `param_name` appears in callee position anywhere in the body.
+// Parameters are typed `double` below, so lowering such a call would build a
+// call through a non-code operand and hand the solver an ill-sorted term
+// (esbmc/esbmc#7074).
+static bool is_param_used_as_callee(
+  const nlohmann::json &node,
+  const std::string &param_name)
+{
+  if (node.is_array())
+  {
+    for (const auto &child : node)
+      if (is_param_used_as_callee(child, param_name))
+        return true;
+    return false;
+  }
+
+  if (!node.is_object())
+    return false;
+
+  if (node.value("_type", "") == "Call" && node.contains("func"))
+  {
+    const auto &callee = node["func"];
+    if (
+      callee.is_object() && callee.value("_type", "") == "Name" &&
+      callee.value("id", "") == param_name)
+      return true;
+  }
+
+  for (const auto &entry : node.items())
+    if (is_param_used_as_callee(entry.value(), param_name))
+      return true;
+
+  return false;
+}
+
 typet python_lambda::infer_lambda_return_type(
   [[maybe_unused]] const nlohmann::json &body_node)
 {
@@ -212,6 +247,12 @@ void python_lambda::process_lambda_parameters(
   for (const auto &arg : args_node["args"])
   {
     std::string arg_name = arg["arg"].get<std::string>();
+
+    if (is_param_used_as_callee(body_node, arg_name))
+      throw std::runtime_error(
+        "calling the lambda parameter '" + arg_name +
+        "' is not supported: higher-order lambda parameters have no inferred "
+        "signature");
 
     // Determine parameter type from annotation or infer from usage
     typet param_type = double_type();


### PR DESCRIPTION
Lambda parameters are typed `double` unless annotated `str` or used in string concatenation, so a body that calls one built a call through a non-code operand and handed the solver an ill-sorted term — Bitwuzla died on an `extract` with `upper < lower` (core dump), Z3 on an unexpected FP sort.

Detect the callee use at conversion time and refuse cleanly, matching how the frontend reports every other unsupported construct. Higher-order lambdas are already documented as unsupported in the frontend README; this makes the behaviour match that contract instead of crashing.

Three regression tests: the refusal, plus a passing/failing pair passing a lambda to a `def` — the neighbouring shape that must keep working.

Fixes #7074