### PR TITLE
[python] Correct the stale range()-only iteration limitation

### DIFF
--- a/regression/python/github_7077_iteration/main.py
+++ b/regression/python/github_7077_iteration/main.py
@@ -1,0 +1,68 @@
+def gen():
+    yield 1
+    yield 2
+
+
+class Acc:
+    def __init__(self) -> None:
+        self.t: int = 0
+
+
+def main():
+    t: int = 0
+
+    for v in range(1, 4):
+        t = t + v
+    assert t == 6
+
+    for v in [10, 20]:
+        t = t + v
+    assert t == 36
+
+    xs = [1, 2, 3]
+    for v in xs:
+        t = t + v
+    assert t == 42
+
+    for v in (4, 5):
+        t = t + v
+    assert t == 51
+
+    for ch in "abc":
+        t = t + 1
+    assert t == 54
+
+    d = {"a": 1, "b": 2}
+    for k in d.keys():
+        t = t + d[k]
+    assert t == 57
+
+    for i, v in enumerate([100, 200]):
+        t = t + i + v
+    assert t == 358
+
+    for a, b in zip([1, 2], [10, 20]):
+        t = t + a * b
+    assert t == 408
+
+    for v in reversed([1, 2, 3]):
+        t = t * 10 + v
+    assert t == 408321
+
+    for v in gen():
+        t = t + v
+    assert t == 408324
+
+    for a in [1, 2]:
+        for b in [10, 20]:
+            t = t + a * b
+    assert t == 408414
+
+    for v in [7]:
+        t = t + v
+    else:
+        t = t + 1
+    assert t == 408422
+
+
+main()

--- a/regression/python/github_7077_iteration/test.desc
+++ b/regression/python/github_7077_iteration/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7077_iteration_fail/main.py
+++ b/regression/python/github_7077_iteration_fail/main.py
@@ -1,0 +1,68 @@
+def gen():
+    yield 1
+    yield 2
+
+
+class Acc:
+    def __init__(self) -> None:
+        self.t: int = 0
+
+
+def main():
+    t: int = 0
+
+    for v in range(1, 4):
+        t = t + v
+    assert t == 6
+
+    for v in [10, 20]:
+        t = t + v
+    assert t == 36
+
+    xs = [1, 2, 3]
+    for v in xs:
+        t = t + v
+    assert t == 42
+
+    for v in (4, 5):
+        t = t + v
+    assert t == 51
+
+    for ch in "abc":
+        t = t + 1
+    assert t == 54
+
+    d = {"a": 1, "b": 2}
+    for k in d.keys():
+        t = t + d[k]
+    assert t == 57
+
+    for i, v in enumerate([100, 200]):
+        t = t + i + v
+    assert t == 358
+
+    for a, b in zip([1, 2], [10, 20]):
+        t = t + a * b
+    assert t == 408
+
+    for v in reversed([1, 2, 3]):
+        t = t * 10 + v
+    assert t == 408321
+
+    for v in gen():
+        t = t + v
+    assert t == 408324
+
+    for a in [1, 2]:
+        for b in [10, 20]:
+            t = t + a * b
+    assert t == 408414
+
+    for v in [7]:
+        t = t + v
+    else:
+        t = t + 1
+    assert t == 4242
+
+
+main()

--- a/regression/python/github_7077_iteration_fail/test.desc
+++ b/regression/python/github_7077_iteration_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -407,7 +407,7 @@ ESBMC-Python provides an optional strict type-checking mode that enforces type c
 
 The current version of ESBMC-Python has the following limitations:
 
-- Only `for` loops using the `range()` function are supported.
+- `for` loops over a user-defined iterable (a class implementing `__iter__`) are not supported. Iteration is supported over `range()`, list and tuple literals and variables, strings, dictionary views (`keys()`/`values()`/`items()`) and generator functions, as well as the `enumerate()`, `zip()` and `reversed()` builtins, nested loops, and the `for`/`else` form.
 - List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, `remove()`, and `copy()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
 - Dictionary support is partial: the supported operations are literals, subscript access/assignment, `del`, `in`/`not in`, equality, iteration over `keys()`/`values()`/`items()`, `update()`, `get()`, `setdefault()`, `pop()`, and `popitem()`. Other methods (e.g., `copy()`) are not yet implemented.


### PR DESCRIPTION
The *Limitations* list opened with "Only `for` loops using the `range()` function are supported." That has not been true for some time.

Every other iteration shape I tested verifies correctly, and each was mutation-checked — the expected value was replaced with a wrong one and every mutant returned `VERIFICATION FAILED`, so the passes are genuine rather than vacuous:

| Shape | Verdict | Mutant |
|---|---|---|
| `range()` | SUCCESSFUL | FAILED |
| list literal / list variable | SUCCESSFUL | FAILED |
| tuple | SUCCESSFUL | FAILED |
| string | SUCCESSFUL | FAILED |
| `dict.keys()` | SUCCESSFUL | FAILED |
| `enumerate()` / `zip()` / `reversed()` | SUCCESSFUL | FAILED |
| generator function | SUCCESSFUL | FAILED |
| nested loops | SUCCESSFUL | FAILED |
| `for`/`else` | SUCCESSFUL | FAILED |

The one shape that genuinely fails is a class implementing `__iter__`, so the limitation is restated in those terms rather than deleted.

A regression test exercising all eleven supported shapes in one program (plus its failing counterpart) locks the corrected claim in, so it cannot drift again without a test going red.

Worth a separate look, not fixed here: iterating a user-defined `__iter__` reports `ERROR: NameError: name 'iterator' is not defined`, which is a confusing diagnostic for an unsupported construct rather than a clean refusal.

Fixes #7077