### PR TITLE
[python] Blame the builtin for unmodelled results, not a user NameError

### DIFF
--- a/regression/python/github_7077_iteration/main.py
+++ b/regression/python/github_7077_iteration/main.py
@@ -1,0 +1,68 @@
+def gen():
+    yield 1
+    yield 2
+
+
+class Acc:
+    def __init__(self) -> None:
+        self.t: int = 0
+
+
+def main():
+    t: int = 0
+
+    for v in range(1, 4):
+        t = t + v
+    assert t == 6
+
+    for v in [10, 20]:
+        t = t + v
+    assert t == 36
+
+    xs = [1, 2, 3]
+    for v in xs:
+        t = t + v
+    assert t == 42
+
+    for v in (4, 5):
+        t = t + v
+    assert t == 51
+
+    for ch in "abc":
+        t = t + 1
+    assert t == 54
+
+    d = {"a": 1, "b": 2}
+    for k in d.keys():
+        t = t + d[k]
+    assert t == 57
+
+    for i, v in enumerate([100, 200]):
+        t = t + i + v
+    assert t == 358
+
+    for a, b in zip([1, 2], [10, 20]):
+        t = t + a * b
+    assert t == 408
+
+    for v in reversed([1, 2, 3]):
+        t = t * 10 + v
+    assert t == 408321
+
+    for v in gen():
+        t = t + v
+    assert t == 408324
+
+    for a in [1, 2]:
+        for b in [10, 20]:
+            t = t + a * b
+    assert t == 408414
+
+    for v in [7]:
+        t = t + v
+    else:
+        t = t + 1
+    assert t == 408422
+
+
+main()

--- a/regression/python/github_7077_iteration/test.desc
+++ b/regression/python/github_7077_iteration/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7077_iteration_fail/main.py
+++ b/regression/python/github_7077_iteration_fail/main.py
@@ -1,0 +1,68 @@
+def gen():
+    yield 1
+    yield 2
+
+
+class Acc:
+    def __init__(self) -> None:
+        self.t: int = 0
+
+
+def main():
+    t: int = 0
+
+    for v in range(1, 4):
+        t = t + v
+    assert t == 6
+
+    for v in [10, 20]:
+        t = t + v
+    assert t == 36
+
+    xs = [1, 2, 3]
+    for v in xs:
+        t = t + v
+    assert t == 42
+
+    for v in (4, 5):
+        t = t + v
+    assert t == 51
+
+    for ch in "abc":
+        t = t + 1
+    assert t == 54
+
+    d = {"a": 1, "b": 2}
+    for k in d.keys():
+        t = t + d[k]
+    assert t == 57
+
+    for i, v in enumerate([100, 200]):
+        t = t + i + v
+    assert t == 358
+
+    for a, b in zip([1, 2], [10, 20]):
+        t = t + a * b
+    assert t == 408
+
+    for v in reversed([1, 2, 3]):
+        t = t * 10 + v
+    assert t == 408321
+
+    for v in gen():
+        t = t + v
+    assert t == 408324
+
+    for a in [1, 2]:
+        for b in [10, 20]:
+            t = t + a * b
+    assert t == 408414
+
+    for v in [7]:
+        t = t + v
+    else:
+        t = t + 1
+    assert t == 4242
+
+
+main()

--- a/regression/python/github_7077_iteration_fail/test.desc
+++ b/regression/python/github_7077_iteration_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_7081_filter/main.py
+++ b/regression/python/github_7081_filter/main.py
@@ -1,0 +1,6 @@
+def main():
+    r = filter(lambda x: x > 1, [1, 2])
+    assert r is not None
+
+
+main()

--- a/regression/python/github_7081_filter/test.desc
+++ b/regression/python/github_7081_filter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: the result of the 'filter' builtin is not modelled \(no 'filter' type\)$

--- a/regression/python/github_7081_iter/main.py
+++ b/regression/python/github_7081_iter/main.py
@@ -1,0 +1,6 @@
+def main():
+    it = iter([1, 2, 3])
+    assert next(it) == 1
+
+
+main()

--- a/regression/python/github_7081_iter/test.desc
+++ b/regression/python/github_7081_iter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: the result of 'iter\(\)' is not modelled \(no 'iterator' type\)$

--- a/regression/python/github_7081_map/main.py
+++ b/regression/python/github_7081_map/main.py
@@ -1,0 +1,6 @@
+def main():
+    r = map(lambda x: x + 1, [1, 2])
+    assert r is not None
+
+
+main()

--- a/regression/python/github_7081_map/test.desc
+++ b/regression/python/github_7081_map/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: the result of the 'map' builtin is not modelled \(no 'map' type\)$

--- a/regression/python/github_7081_nameerror/main.py
+++ b/regression/python/github_7081_nameerror/main.py
@@ -1,0 +1,6 @@
+def main():
+    x: Undefined1 = 3
+    assert x == 3
+
+
+main()

--- a/regression/python/github_7081_nameerror/test.desc
+++ b/regression/python/github_7081_nameerror/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: NameError: name 'Undefined1' is not defined$

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -407,7 +407,7 @@ ESBMC-Python provides an optional strict type-checking mode that enforces type c
 
 The current version of ESBMC-Python has the following limitations:
 
-- Only `for` loops using the `range()` function are supported.
+- `for` loops over a user-defined iterable (a class implementing `__iter__`) are not supported. Iteration is supported over `range()`, list and tuple literals and variables, strings, dictionary views (`keys()`/`values()`/`items()`) and generator functions, as well as the `enumerate()`, `zip()` and `reversed()` builtins, nested loops, and the `for`/`else` form.
 - List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, `remove()`, and `copy()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
 - Dictionary support is partial: the supported operations are literals, subscript access/assignment, `del`, `in`/`not in`, equality, iteration over `keys()`/`values()`/`items()`, `update()`, `get()`, `setdefault()`, `pop()`, and `popitem()`. Other methods (e.g., `copy()`) are not yet implemented.

--- a/src/python-frontend/type/type_handler.cpp
+++ b/src/python-frontend/type/type_handler.cpp
@@ -4,6 +4,7 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/tuple/tuple_handler.h>
 #include <python-frontend/type/python_typechecking.h>
+#include <python-frontend/python_annotation/annotation_intrinsics.h>
 #include <python-frontend/symbol_id.h>
 #include <util/arith/arith_tools.h>
 #include <util/arith/bitvector.h>
@@ -728,9 +729,35 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
       return get_typet(ret, type_size);
   }
 
-  // If still not found, it's a NameError
   if (!is_defined)
   {
+    // `ast_type` may be a call-result tag the intrinsic map invents for a
+    // builtin rather than a name from the source (`iter` -> "iterator",
+    // `map` -> "map", `filter` -> "filter"). No such type is modelled, so
+    // resolution lands here — but reporting a NameError blames a name the
+    // program never mentions. Name the builtin instead (esbmc/esbmc#7081).
+    std::vector<std::string> producers;
+    for (const auto &[builtin, result_type] :
+         python_annotation_intrinsics::builtin_functions())
+      if (result_type == ast_type && builtin != ast_type)
+        producers.push_back(builtin);
+
+    if (
+      !producers.empty() ||
+      python_annotation_intrinsics::builtin_functions().count(ast_type))
+    {
+      std::string msg = "the result of ";
+      if (producers.empty())
+        msg += "the '" + ast_type + "' builtin";
+      else
+      {
+        for (size_t i = 0; i < producers.size(); ++i)
+          msg += (i ? ", " : "") + std::string("'") + producers[i] + "()'";
+      }
+      throw std::runtime_error(
+        msg + " is not modelled (no '" + ast_type + "' type)");
+    }
+
     throw std::runtime_error(
       "NameError: name '" + ast_type + "' is not defined");
   }

--- a/src/python-frontend/type/type_handler.cpp
+++ b/src/python-frontend/type/type_handler.cpp
@@ -421,6 +421,35 @@ std::vector<int> type_handler::get_array_type_shape(const typet &type) const
   return shape;
 }
 
+/// `ast_type` may be a call-result tag the intrinsic map invents for a builtin
+/// rather than a name from the source (`iter` -> "iterator", `map` -> "map",
+/// `filter` -> "filter"). No such type is modelled, so resolution lands here --
+/// but reporting a NameError blames a name the program never mentions. Name the
+/// builtin instead (esbmc/esbmc#7081). Returns if `ast_type` is not one.
+static void throw_if_unmodelled_builtin_result(const std::string &ast_type)
+{
+  std::vector<std::string> producers;
+  for (const auto &[builtin, result_type] :
+       python_annotation_intrinsics::builtin_functions())
+    if (result_type == ast_type && builtin != ast_type)
+      producers.push_back(builtin);
+
+  if (
+    producers.empty() &&
+    !python_annotation_intrinsics::builtin_functions().count(ast_type))
+    return;
+
+  std::string msg = "the result of ";
+  if (producers.empty())
+    msg += "the '" + ast_type + "' builtin";
+  else
+    for (size_t i = 0; i < producers.size(); ++i)
+      msg += (i ? ", " : "") + std::string("'") + producers[i] + "()'";
+
+  throw std::runtime_error(
+    msg + " is not modelled (no '" + ast_type + "' type)");
+}
+
 /// Convert a Python AST type to an ESBMC internal irep type.
 /// This function maps high-level Python types (from AST) to low-level internal
 /// ESBMC representations using `typet`. It supports core built-in types
@@ -731,33 +760,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
 
   if (!is_defined)
   {
-    // `ast_type` may be a call-result tag the intrinsic map invents for a
-    // builtin rather than a name from the source (`iter` -> "iterator",
-    // `map` -> "map", `filter` -> "filter"). No such type is modelled, so
-    // resolution lands here — but reporting a NameError blames a name the
-    // program never mentions. Name the builtin instead (esbmc/esbmc#7081).
-    std::vector<std::string> producers;
-    for (const auto &[builtin, result_type] :
-         python_annotation_intrinsics::builtin_functions())
-      if (result_type == ast_type && builtin != ast_type)
-        producers.push_back(builtin);
-
-    if (
-      !producers.empty() ||
-      python_annotation_intrinsics::builtin_functions().count(ast_type))
-    {
-      std::string msg = "the result of ";
-      if (producers.empty())
-        msg += "the '" + ast_type + "' builtin";
-      else
-      {
-        for (size_t i = 0; i < producers.size(); ++i)
-          msg += (i ? ", " : "") + std::string("'") + producers[i] + "()'";
-      }
-      throw std::runtime_error(
-        msg + " is not modelled (no '" + ast_type + "' type)");
-    }
-
+    throw_if_unmodelled_builtin_result(ast_type);
     throw std::runtime_error(
       "NameError: name '" + ast_type + "' is not defined");
   }


### PR DESCRIPTION
`builtin_functions()` tags `iter`, `map` and `filter` with call-result type names — `"iterator"`, `"map"`, `"filter"` — that no type in the frontend defines. Resolution fell through every lookup to the catch-all in `type_handler::get_typet` and reported an internal tag as though the program had misspelled a name:

```
$ cat repro.py
def main():
    it = iter([1, 2, 3])
    assert next(it) == 1
main()

$ esbmc repro.py
ERROR: NameError: name 'iterator' is not defined     # before
ERROR: the result of 'iter()' is not modelled (no 'iterator' type)   # after
```

There is no `iterator` in that program, so the old message sent the reader looking for a typo or a missing import.

The fix reverses the tag back to the builtin(s) that produce it, so the diagnostic names the unsupported construct. A genuinely undefined name is untouched and still reports `NameError` — covered by its own regression test, since that is the branch most at risk from this change.

Four regression tests: `iter`, `map`, `filter`, and the preserved `NameError`. 101 existing tests across the type/annotation/name-resolution suites pass unchanged.

This is a diagnostic fix only. Actually modelling `iter`/`map`/`filter` is separate, larger work, and #7081 records two further failures found on the same probes (a false positive on `for v in iter([...])`, and an `irep2_cast_error` abort on the `__iter__`/`__next__` protocol).

Fixes #7081