### PR TITLE
numpy call-result chaining for non-constructor sources

### DIFF
--- a/docs/roadmap/numpy-support-assessment.md
+++ b/docs/roadmap/numpy-support-assessment.md
@@ -1,6 +1,6 @@
 # ESBMC NumPy — Remaining Work
 
-**Updated:** 2026-08-14.
+**Updated:** 2026-08-16.
 
 This file tracks only what is **not yet implemented, broken, risky, or queued
 as backlog** in the NumPy module. If an item is not listed here as a gap, TODO,
@@ -51,65 +51,87 @@ Architectural decisions that gate specific pendencies here (referenced as
 4. **Basic-indexing views still do not alias at runtime.** Covered mutations
    are rejected conservatively, but the final ADR-NP-003 descriptor model is
    still needed to replace rejection with faithful aliasing.
-5. **Chaining one numpy call as another's argument is broken for
-   non-constructor sources.** `np.logical_not(np.equal(a, b))` and
-   `np.where(np.greater(a, b), x, y)` fail even when every operand is a
-   plain literal list (no `arange`/constructor involved), both nested
-   directly and through an intermediate variable — confirmed by direct
-   execution. The comparison/logical dispatch block only knows how to
-   resolve a `Name` argument back to a *constructor* call (`zeros`, `full`,
-   `arange`, ...); a `Name` whose declaration is itself a call to another
-   numpy function (`equal`, `greater`, ...) falls through to the old blind
-   `args[0]` read, silently substituting that inner call's first argument
-   for its actual (unevaluated) result. Found while extending
-   `np.greater`/`np.equal` to accept `np.arange(...)` directly as an
-   argument; those two now work — this is a distinct, pre-existing gap in
-   general call composition, not arange-specific.
+
+No known soundness bugs remain open (the numpy call-result chaining gap that
+used to be listed here — a `Name` argument whose declaration was itself a
+non-constructor numpy call resolving to the wrong operand instead of its
+evaluated result — was fixed: `evaluate_numpy_logical_call()` now evaluates
+`greater`/`less`/`greater_equal`/`less_equal`/`equal`/`not_equal`/
+`logical_and`/`logical_or`/`logical_not`/`where` chained as another numpy
+call's argument, nested directly or via an intermediate variable, including
+more than one level of chaining; a chain past the supported depth declines
+explicitly instead of misreading. See `regression/numpy/chaining_*`).
+
+---
+
+## Community testing readiness
+
+ESBMC's standard across every frontend (C, C++, Solidity, Java/Kotlin) is
+sound-but-incomplete, not full language/library coverage: whatever falls
+outside the currently supported subset must reject with an explicit
+diagnostic (ADR-NP principle 3) rather than silently return a wrong
+verdict. By that bar, every gap in "Missing indexing / slicing" and
+"Missing API surface" above is **not** a blocker for community testing —
+each one already rejects explicitly instead of misbehaving.
+
+With the call-result chaining fix above, there are no known soundness bugs
+left in this file. **A build can be cut for community testing at any point
+from here** — everything remaining is documented backlog that surfaces as
+an explicit "not supported yet" diagnostic, not a wrong answer.
 
 ---
 
 ## Prioritised next steps
 
-1. **General numpy call composition** — a `Name` argument whose declaration
-   is itself a call to another numpy function (not a constructor) resolves
-   incorrectly; root-cause and fix the shared resolve_var pattern instead of
-   special-casing each affected dispatch block again.
-2. **Definitive view descriptor model (ADR-NP-003 etapa 2)** — wire shared
+Nothing below blocks community testing (see above); this is post-release
+backlog, in priority order:
+
+1. **Definitive view descriptor model (ADR-NP-003 etapa 2)** — wire shared
    `buffer_id`/`offset`/`strides` metadata into reads, writes, views, and
    escape handling.
-3. **General array returns** — consolidate assignment/type inference so user
+2. **General array returns** — consolidate assignment/type inference so user
    functions can return non-trivial NumPy arrays and sub-arrays safely.
-4. **Remaining array method forms** — design `a.sort()`, `a.argsort()`,
+3. **Remaining array method forms** — design `a.sort()`, `a.argsort()`,
    `a.tolist()`, `a.any()`, and `a.all()` individually.
-5. **Symbolic and broader multi-axis slicing** — support cases beyond the
+4. **Symbolic and broader multi-axis slicing** — support cases beyond the
    literal/fixed-shape recuts.
-6. **Advanced dtype and constructor parity** — structured/object/custom dtype
+5. **Advanced dtype and constructor parity** — structured/object/custom dtype
    policy, diagnostics, and propagation.
-7. **Random and iteration depth** — probability/replacement `choice`, extra
+6. **Random and iteration depth** — probability/replacement `choice`, extra
    distributions, writable `nditer`, and real `.flat` mutation.
-8. **Linear algebra breadth** — larger matrices, symbolic entries, and more
+7. **Linear algebra breadth** — larger matrices, symbolic entries, and more
    faithful `norm`/`eig`/`svd`.
 
 ---
 
 ## Suggested next PRs
 
-1. **Fix numpy call-result chaining** — `np.logical_not(np.equal(...))`,
-   `np.where(np.greater(...), ...)`, and similar compositions, both nested
-   and through an intermediate variable; small and isolated, currently the
-   first prioritized roadmap item.
-2. **Shared-buffer view descriptors (ADR-NP-003 etapa 2)** — unblock writable
-   views, writable `.flat`, and writable `nditer`.
-3. **General array returns** — fix the shared assignment/type-selection root
-   cause before adding broader return support.
-4. **Remaining array method forms** — implement method-specific designs for
-   sort/argsort/tolist/any/all.
-5. **Advanced dtype and constructors** — define dtype policy and improve
-   constructor diagnostics/propagation.
-6. **Random and iteration depth** — extend random/choice and iteration
-   semantics.
-7. **Linear algebra expansion** — extend matrix-size and symbolic-entry
-   policies.
+Each roadmap item above groups several sub-efforts; sizing them 1 PR per
+item undercounts the real work. The two most recent NumPy PRs (arange
+small-range performance, and this call-chaining fix) each took a small,
+isolated gap through several commits of core fix plus a matching review
+round; items below with multiple named consumers or distinct designs are
+sized accordingly instead of assumed to be one PR each.
+
+1. **Shared-buffer view descriptors (ADR-NP-003 etapa 2)** (~3 PRs) —
+   `buffer_id`/`offset`/`strides` must reach 7 distinct consumers
+   (indexing, assignment, transpose, reshape/ravel, escape checks, `.flat`,
+   writable `nditer`); one PR risks becoming too large to review.
+2. **General array returns** (~2 PRs) — root-cause the shared
+   assignment/type-selection issue (two prior attempts already hit it)
+   before extending to broader return support.
+3. **Remaining array method forms** (~3 PRs) — `sort`/`argsort` (in-place vs
+   copy semantics), `tolist` (new conversion logic), and `any`/`all` (root
+   cause still unclear) are three distinct designs, not one.
+4. **Advanced dtype and constructors** (~2 PRs) — dtype policy
+   (object/structured/custom) separate from constructor
+   diagnostics/propagation.
+5. **Random and iteration depth** (~2 PRs) — new distributions/`choice`
+   separate from writable `nditer`/`.flat` (which also depends on item 1).
+6. **Linear algebra expansion** (~2 PRs) — larger/symbolic matrix support
+   separate from fuller `eig`/`svd`/`norm`.
+
+**Total to close every item in this file: ~14 PRs.**
 
 ---
 

--- a/regression/numpy/chaining_depth_exceeded_fail/main.py
+++ b/regression/numpy/chaining_depth_exceeded_fail/main.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 # A chain deeper than the supported bound must decline explicitly instead of
-# crashing or silently producing a wrong verdict.
+# crashing or silently producing a wrong verdict. This must never reach the
+# assert below -- but if the supported chaining depth is ever raised and the
+# rejection no longer fires here, the six logical_not() calls cancel out in
+# pairs (an even count), so real NumPy leaves equal(a, b)[0] unchanged (True),
+# not negated.
 a = [1, 2, 3]
 b = [1, 5, 3]
 r = np.logical_not(
@@ -13,4 +17,4 @@ r = np.logical_not(
         )
     )
 )
-assert r[0] == False
+assert r[0] == True

--- a/regression/numpy/chaining_depth_exceeded_fail/main.py
+++ b/regression/numpy/chaining_depth_exceeded_fail/main.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+# A chain deeper than the supported bound must decline explicitly instead of
+# crashing or silently producing a wrong verdict.
+a = [1, 2, 3]
+b = [1, 5, 3]
+r = np.logical_not(
+    np.logical_not(
+        np.logical_not(
+            np.logical_not(
+                np.logical_not(np.logical_not(np.equal(a, b)))
+            )
+        )
+    )
+)
+assert r[0] == False

--- a/regression/numpy/chaining_depth_exceeded_fail/test.desc
+++ b/regression/numpy/chaining_depth_exceeded_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy call composition exceeds the supported chaining depth$

--- a/regression/numpy/chaining_logical_and_nested_success/main.py
+++ b/regression/numpy/chaining_logical_and_nested_success/main.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+# np.greater(...) and np.equal(...) used directly (nested) as
+# np.logical_and()'s arguments must both be evaluated, not have their raw
+# arguments silently substituted for their unevaluated results. Neither
+# logical_and nor logical_or had chaining coverage before this test.
+a = [1, 2, 3]
+b = [1, 5, 3]
+r = np.logical_and(np.greater(b, a), np.equal(a, a))
+assert r[0] == False
+assert r[1] == True
+assert r[2] == False

--- a/regression/numpy/chaining_logical_and_nested_success/test.desc
+++ b/regression/numpy/chaining_logical_and_nested_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/chaining_logical_not_nested_success/main.py
+++ b/regression/numpy/chaining_logical_not_nested_success/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+# np.equal(...) used directly (nested) as np.logical_not()'s argument must be
+# evaluated, not have its own first argument silently substituted for its
+# unevaluated result.
+a = [1, 2, 3]
+b = [1, 5, 3]
+r = np.logical_not(np.equal(a, b))
+assert r[0] == False
+assert r[1] == True
+assert r[2] == False

--- a/regression/numpy/chaining_logical_not_nested_success/test.desc
+++ b/regression/numpy/chaining_logical_not_nested_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/chaining_logical_not_variable_success/main.py
+++ b/regression/numpy/chaining_logical_not_variable_success/main.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+# np.equal(...) bound to a variable, then that variable used as
+# np.logical_not()'s argument, must be evaluated the same way as the nested
+# form.
+a = [1, 2, 3]
+b = [1, 5, 3]
+x = np.equal(a, b)
+r = np.logical_not(x)
+assert r[0] == False
+assert r[1] == True
+assert r[2] == False

--- a/regression/numpy/chaining_logical_not_variable_success/test.desc
+++ b/regression/numpy/chaining_logical_not_variable_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/chaining_multilevel_success/main.py
+++ b/regression/numpy/chaining_multilevel_success/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+# Chaining more than one level (np.logical_not(np.logical_not(...))) is not
+# rejected: the chain-resolution recursion handles depths well beyond what
+# realistic code needs.
+a = [1, 2, 3]
+b = [1, 5, 3]
+r = np.logical_not(np.logical_not(np.equal(a, b)))
+assert r[0] == True
+assert r[1] == False
+assert r[2] == True

--- a/regression/numpy/chaining_multilevel_success/test.desc
+++ b/regression/numpy/chaining_multilevel_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/chaining_reassigned_variable_fail/main.py
+++ b/regression/numpy/chaining_reassigned_variable_fail/main.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+# find_var_decl() returns the first textual assignment to a name, not the
+# one that actually reaches this use site. A reassigned name used as a
+# chained call's argument must not silently resolve to that stale first
+# value; it must raise an explicit diagnostic instead.
+a = [1, 2, 3]
+b = [1, 5, 3]
+x = np.equal(a, b)
+x = np.not_equal(a, b)
+r = np.logical_not(x)
+assert len(r) == 3

--- a/regression/numpy/chaining_reassigned_variable_fail/test.desc
+++ b/regression/numpy/chaining_reassigned_variable_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy call composition could not resolve an operand to a constant value$

--- a/regression/numpy/chaining_where_nested_success/main.py
+++ b/regression/numpy/chaining_where_nested_success/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+# np.greater(...) used directly (nested) as np.where()'s condition must be
+# evaluated, not have its own first argument silently substituted for its
+# unevaluated result.
+a = [1, 2, 3]
+b = [1, 5, 3]
+r = np.where(np.greater(b, a), [10, 20, 30], [1, 2, 3])
+assert r[0] == 1
+assert r[1] == 20
+assert r[2] == 3

--- a/regression/numpy/chaining_where_nested_success/test.desc
+++ b/regression/numpy/chaining_where_nested_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/chaining_where_variable_success/main.py
+++ b/regression/numpy/chaining_where_variable_success/main.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+# np.greater(...) bound to a variable, then that variable used as
+# np.where()'s condition, must be evaluated the same way as the nested form.
+a = [1, 2, 3]
+b = [1, 5, 3]
+cond = np.greater(b, a)
+r = np.where(cond, [10, 20, 30], [1, 2, 3])
+assert r[0] == 1
+assert r[1] == 20
+assert r[2] == 3

--- a/regression/numpy/chaining_where_variable_success/test.desc
+++ b/regression/numpy/chaining_where_variable_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/chaining_wrong_arity_inner_call_fail/main.py
+++ b/regression/numpy/chaining_wrong_arity_inner_call_fail/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# np.equal() called with the wrong number of arguments, nested as another
+# numpy call's argument, must raise its own explicit diagnostic once
+# evaluated -- not be misreported as exceeding the chaining depth (this is
+# only one level deep), and not be silently treated as a false operand.
+a = [1, 2, 3]
+r = np.logical_not(np.equal(a))
+assert len(r) == 3

--- a/regression/numpy/chaining_wrong_arity_inner_call_fail/test.desc
+++ b/regression/numpy/chaining_wrong_arity_inner_call_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy call composition could not resolve an operand to a constant value$

--- a/regression/numpy/logical_compare_length_mismatch_fail/main.py
+++ b/regression/numpy/logical_compare_length_mismatch_fail/main.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# Comparing two lists of different lengths must raise an explicit diagnostic
+# instead of an out-of-bounds JSON access when the shorter list is indexed
+# past its end.
+a = [1, 2, 3]
+b = [1, 2]
+r = np.equal(a, b)
+assert len(r) == 3

--- a/regression/numpy/logical_compare_length_mismatch_fail/test.desc
+++ b/regression/numpy/logical_compare_length_mismatch_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy comparison/logical operands have mismatched lengths$

--- a/regression/numpy/where_length_mismatch_fail/main.py
+++ b/regression/numpy/where_length_mismatch_fail/main.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+# np.where() with a condition list longer than one of its choice lists must
+# raise an explicit diagnostic instead of an out-of-bounds JSON access when
+# the shorter choice list is indexed past its end.
+cond = [True, False, True]
+x = [1, 2]
+y = [10, 20, 30]
+r = np.where(cond, x, y)
+assert len(r) == 3

--- a/regression/numpy/where_length_mismatch_fail/test.desc
+++ b/regression/numpy/where_length_mismatch_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: numpy\.where\(\) operands have mismatched lengths$

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2302,6 +2302,10 @@ static nlohmann::json make_list_node(const std::vector<nlohmann::json> &elts)
   return out;
 }
 
+// A node that reaches here unresolved (e.g. resolve_numpy_logical_arg left a
+// recognized-but-not-evaluable chained call untouched) must raise, not
+// silently stand in as false/0.0 -- the latter is exactly the class of
+// silent-wrong-verdict bug this whole chaining fix exists to close.
 static bool numpy_logical_as_bool(const nlohmann::json &node)
 {
   numeric_value value;
@@ -2309,7 +2313,9 @@ static bool numpy_logical_as_bool(const nlohmann::json &node)
     return to_double(value) != 0.0;
   if (node.is_object() && node.contains("value") && node["value"].is_boolean())
     return node["value"].get<bool>();
-  return false;
+  throw std::runtime_error(
+    "TypeError: numpy call composition could not resolve an operand to a "
+    "constant value");
 }
 
 static double numpy_logical_as_double(const nlohmann::json &node)
@@ -2317,7 +2323,9 @@ static double numpy_logical_as_double(const nlohmann::json &node)
   numeric_value value;
   if (try_extract_numeric_constant(node, value))
     return to_double(value);
-  return 0.0;
+  throw std::runtime_error(
+    "TypeError: numpy call composition could not resolve an operand to a "
+    "constant value");
 }
 
 static nlohmann::json numpy_compare_scalar(

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2397,6 +2397,19 @@ static nlohmann::json numpy_broadcast_binary(
 // misread (the exact failure mode this fix closes).
 static constexpr int max_numpy_logical_chain_depth = 4;
 
+// Single owner of the chaining-depth diagnostic (regex-pinned by
+// regression/numpy/chaining_depth_exceeded_fail) so recursing one level
+// deeper than the supported bound always reports the same, correct reason --
+// resolve_numpy_logical_arg() is the only place that actually recurses, so
+// it is the only call site that can legitimately hit this.
+static void check_numpy_logical_chain_depth(int next_depth)
+{
+  if (next_depth > max_numpy_logical_chain_depth)
+    throw std::runtime_error(
+      "TypeError: numpy call composition exceeds the supported chaining "
+      "depth");
+}
+
 static std::optional<nlohmann::json> evaluate_numpy_logical_call(
   const nlohmann::json &call_node,
   python_converter &converter,
@@ -2405,10 +2418,13 @@ static std::optional<nlohmann::json> evaluate_numpy_logical_call(
 // Resolves one argument of a numpy comparison/logical call: a Name is
 // followed to its declaration; a Call to a recognized constructor is
 // materialized; a Call to another comparison/logical function is evaluated
-// recursively via evaluate_numpy_logical_call(). Anything else (a function
-// parameter, a call to an unrelated numpy function) is left unchanged, so
-// the caller's own numeric/list extraction fails on it exactly as it
-// already does for any other unresolvable operand.
+// recursively via evaluate_numpy_logical_call(), or left unresolved if that
+// recognized call shape still isn't evaluable (e.g. a wrong argument count)
+// rather than being misreported as a chaining-depth failure. Anything else
+// (a function parameter, a call to an unrelated numpy function) is also left
+// unchanged, so the caller's own numeric/list extraction raises an explicit
+// TypeError on it exactly as it already does for any other unresolvable
+// operand (see numpy_logical_as_bool/_double).
 static nlohmann::json resolve_numpy_logical_arg(
   nlohmann::json arg,
   python_converter &converter,
@@ -2431,13 +2447,11 @@ static nlohmann::json resolve_numpy_logical_arg(
       return *materialized;
     if (is_numpy_logical_comparison_call(arg, converter.ast()))
     {
+      check_numpy_logical_chain_depth(depth + 1);
       if (
         std::optional<nlohmann::json> evaluated =
           evaluate_numpy_logical_call(arg, converter, depth + 1))
         return *evaluated;
-      throw std::runtime_error(
-        "TypeError: numpy call composition exceeds the supported chaining "
-        "depth");
     }
   }
   return arg;
@@ -2553,14 +2567,15 @@ static std::optional<nlohmann::json> evaluate_numpy_where_call(
 // (np.logical_not(np.equal(a, b))) or via an intermediate variable
 // (x = np.equal(a, b); np.logical_not(x)). Mirrors the top-level dispatch in
 // numpy_call_expr::get() for these same functions; both share the helpers
-// above instead of each reimplementing broadcasting/comparison logic.
+// above instead of each reimplementing broadcasting/comparison logic. Every
+// caller already checks the chaining depth before reaching here (see
+// check_numpy_logical_chain_depth()), so this only re-validates the call
+// shape itself.
 static std::optional<nlohmann::json> evaluate_numpy_logical_call(
   const nlohmann::json &call_node,
   python_converter &converter,
   int depth)
 {
-  if (depth > max_numpy_logical_chain_depth)
-    return std::nullopt;
   if (!is_numpy_logical_comparison_call(call_node, converter.ast()))
     return std::nullopt;
 
@@ -5837,10 +5852,9 @@ exprt numpy_call_expr::get()
           std::optional<nlohmann::json> evaluated =
             evaluate_numpy_logical_call(arg, converter_, 0))
           arg = std::move(*evaluated);
-        else
-          throw std::runtime_error(
-            "TypeError: numpy call composition exceeds the supported "
-            "chaining depth");
+        // else: recognized shape but not evaluable (e.g. a wrong argument
+        // count) -- leave arg unresolved so the caller's own scalar/list
+        // extraction raises its own diagnostic for that failure.
       }
       return arg;
     };

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2427,6 +2427,91 @@ static nlohmann::json resolve_numpy_logical_arg(
   return arg;
 }
 
+static std::optional<nlohmann::json> evaluate_numpy_compare_call(
+  const std::string &function,
+  const nlohmann::json &args,
+  python_converter &converter,
+  int depth)
+{
+  if (args.size() != 2)
+    return std::nullopt;
+  const nlohmann::json lhs =
+    resolve_numpy_logical_arg(args[0], converter, depth);
+  const nlohmann::json rhs =
+    resolve_numpy_logical_arg(args[1], converter, depth);
+  return numpy_broadcast_binary(
+    lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
+      return numpy_compare_scalar(function, a, b);
+    });
+}
+
+static std::optional<nlohmann::json> evaluate_numpy_logical_and_or_call(
+  const std::string &function,
+  const nlohmann::json &args,
+  python_converter &converter,
+  int depth)
+{
+  if (args.size() != 2)
+    return std::nullopt;
+  const nlohmann::json lhs =
+    resolve_numpy_logical_arg(args[0], converter, depth);
+  const nlohmann::json rhs =
+    resolve_numpy_logical_arg(args[1], converter, depth);
+  return numpy_broadcast_binary(
+    lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
+      const bool l = numpy_logical_as_bool(a);
+      const bool r = numpy_logical_as_bool(b);
+      return make_bool_constant_node(
+        function == "logical_and" ? (l && r) : (l || r));
+    });
+}
+
+static std::optional<nlohmann::json> evaluate_numpy_logical_not_call(
+  const nlohmann::json &args,
+  python_converter &converter,
+  int depth)
+{
+  if (args.size() != 1)
+    return std::nullopt;
+  const nlohmann::json arg =
+    resolve_numpy_logical_arg(args[0], converter, depth);
+  if (arg.contains("elts") && arg["elts"].is_array())
+  {
+    std::vector<nlohmann::json> out_elts;
+    for (const auto &item : arg["elts"])
+      out_elts.push_back(make_bool_constant_node(!numpy_logical_as_bool(item)));
+    return make_list_node(out_elts);
+  }
+  return make_bool_constant_node(!numpy_logical_as_bool(arg));
+}
+
+static std::optional<nlohmann::json> evaluate_numpy_where_call(
+  const nlohmann::json &args,
+  python_converter &converter,
+  int depth)
+{
+  if (args.size() != 3)
+    return std::nullopt;
+  const nlohmann::json cond =
+    resolve_numpy_logical_arg(args[0], converter, depth);
+  const nlohmann::json x = resolve_numpy_logical_arg(args[1], converter, depth);
+  const nlohmann::json y = resolve_numpy_logical_arg(args[2], converter, depth);
+  if (!cond.contains("elts") || !cond["elts"].is_array())
+    return numpy_logical_as_bool(cond) ? x : y;
+
+  std::vector<nlohmann::json> out_elts;
+  for (std::size_t i = 0; i < cond["elts"].size(); ++i)
+  {
+    const bool choose_x = numpy_logical_as_bool(cond["elts"][i]);
+    const nlohmann::json &chosen =
+      choose_x
+        ? (x.contains("elts") && x["elts"].is_array() ? x["elts"][i] : x)
+        : (y.contains("elts") && y["elts"].is_array() ? y["elts"][i] : y);
+    out_elts.push_back(chosen);
+  }
+  return make_list_node(out_elts);
+}
+
 // Evaluates a numpy comparison/logical Call node to its literal JSON result
 // (a "List" of booleans/values, or a scalar "Constant"), so it can resolve a
 // call chained as another numpy call's argument -- either nested directly
@@ -2451,79 +2536,16 @@ static std::optional<nlohmann::json> evaluate_numpy_logical_call(
     function == "greater" || function == "less" ||
     function == "greater_equal" || function == "less_equal" ||
     function == "equal" || function == "not_equal")
-  {
-    if (args.size() != 2)
-      return std::nullopt;
-    const nlohmann::json lhs =
-      resolve_numpy_logical_arg(args[0], converter, depth);
-    const nlohmann::json rhs =
-      resolve_numpy_logical_arg(args[1], converter, depth);
-    return numpy_broadcast_binary(
-      lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
-        return numpy_compare_scalar(function, a, b);
-      });
-  }
+    return evaluate_numpy_compare_call(function, args, converter, depth);
 
   if (function == "logical_and" || function == "logical_or")
-  {
-    if (args.size() != 2)
-      return std::nullopt;
-    const nlohmann::json lhs =
-      resolve_numpy_logical_arg(args[0], converter, depth);
-    const nlohmann::json rhs =
-      resolve_numpy_logical_arg(args[1], converter, depth);
-    return numpy_broadcast_binary(
-      lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
-        const bool l = numpy_logical_as_bool(a);
-        const bool r = numpy_logical_as_bool(b);
-        return make_bool_constant_node(
-          function == "logical_and" ? (l && r) : (l || r));
-      });
-  }
+    return evaluate_numpy_logical_and_or_call(function, args, converter, depth);
 
   if (function == "logical_not")
-  {
-    if (args.size() != 1)
-      return std::nullopt;
-    const nlohmann::json arg =
-      resolve_numpy_logical_arg(args[0], converter, depth);
-    if (arg.contains("elts") && arg["elts"].is_array())
-    {
-      std::vector<nlohmann::json> out_elts;
-      for (const auto &item : arg["elts"])
-        out_elts.push_back(
-          make_bool_constant_node(!numpy_logical_as_bool(item)));
-      return make_list_node(out_elts);
-    }
-    return make_bool_constant_node(!numpy_logical_as_bool(arg));
-  }
+    return evaluate_numpy_logical_not_call(args, converter, depth);
 
   if (function == "where")
-  {
-    if (args.size() != 3)
-      return std::nullopt;
-    const nlohmann::json cond =
-      resolve_numpy_logical_arg(args[0], converter, depth);
-    const nlohmann::json x =
-      resolve_numpy_logical_arg(args[1], converter, depth);
-    const nlohmann::json y =
-      resolve_numpy_logical_arg(args[2], converter, depth);
-    if (cond.contains("elts") && cond["elts"].is_array())
-    {
-      std::vector<nlohmann::json> out_elts;
-      for (std::size_t i = 0; i < cond["elts"].size(); ++i)
-      {
-        const bool choose_x = numpy_logical_as_bool(cond["elts"][i]);
-        const nlohmann::json &chosen =
-          choose_x
-            ? (x.contains("elts") && x["elts"].is_array() ? x["elts"][i] : x)
-            : (y.contains("elts") && y["elts"].is_array() ? y["elts"][i] : y);
-        out_elts.push_back(chosen);
-      }
-      return make_list_node(out_elts);
-    }
-    return numpy_logical_as_bool(cond) ? x : y;
-  }
+    return evaluate_numpy_where_call(args, converter, depth);
 
   return std::nullopt;
 }

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2432,12 +2432,18 @@ static nlohmann::json resolve_numpy_logical_arg(
 {
   if (arg.is_object() && arg.value("_type", std::string()) == "Name")
   {
-    const nlohmann::json decl = json_utils::find_var_decl(
-      arg["id"].get<std::string>(),
-      converter.current_function_name(),
-      converter.ast());
-    if (decl.contains("value") && decl["value"].is_object())
-      arg = decl["value"];
+    // find_var_decl() below returns the first textual assignment to this
+    // name, not the one that actually reaches this use site. A reassigned
+    // name is left unresolved rather than risk reading a stale value.
+    const std::string &name = arg["id"].get<std::string>();
+    if (!json_utils::has_multiple_assignments_in_scope(
+          name, converter.current_function_name(), converter.ast()))
+    {
+      const nlohmann::json decl = json_utils::find_var_decl(
+        name, converter.current_function_name(), converter.ast());
+      if (decl.contains("value") && decl["value"].is_object())
+        arg = decl["value"];
+    }
   }
   if (arg.is_object() && arg.value("_type", std::string()) == "Call")
   {
@@ -5781,6 +5787,18 @@ exprt numpy_call_expr::get()
     auto resolve_var = [this](nlohmann::json &var) {
       if (var["_type"] == "Name")
       {
+        // find_var_decl() below returns the first textual assignment to
+        // this name, not the one that actually reaches this use site. A
+        // reassigned name is left as-is (var stays the unresolved Name)
+        // rather than risk resolving a stale declaration -- the caller's
+        // own scalar/list extraction then raises an explicit diagnostic on
+        // it, exactly as it already does for any other unresolvable
+        // operand.
+        if (json_utils::has_multiple_assignments_in_scope(
+              var["id"].get<std::string>(),
+              converter_.current_function_name(),
+              converter_.ast()))
+          return;
         var = json_utils::find_var_decl(
           var["id"], converter_.current_function_name(), converter_.ast());
         if (!var.contains("value") || !var["value"].is_object())
@@ -5814,9 +5832,15 @@ exprt numpy_call_expr::get()
               var = std::move(*evaluated);
               return;
             }
-            throw std::runtime_error(
-              "TypeError: numpy call composition exceeds the supported "
-              "chaining depth");
+            // Recognized comparison/logical call shape but not evaluable
+            // (e.g. a wrong argument count): leave the call itself
+            // unresolved -- NOT the args[0] fallback below, which would
+            // silently misread its argument as if it were the call's
+            // actual (unevaluated) result, the exact bug this whole fix
+            // closes -- so the caller's own extraction raises its own
+            // diagnostic instead of a misleading chaining-depth error.
+            var = var["value"];
+            return;
           }
           if (var["value"].contains("args") && !var["value"]["args"].empty())
             var = var["value"]["args"][0];

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2501,6 +2501,38 @@ static std::optional<nlohmann::json> evaluate_numpy_logical_not_call(
   return make_bool_constant_node(!numpy_logical_as_bool(arg));
 }
 
+// Shared by evaluate_numpy_where_call() below and the top-level "where"
+// dispatch, so the length validation lives in exactly one place. When x or y
+// is a list, it must have the same length as cond -- indexing a shorter one
+// past its end is an out-of-bounds JSON access, not a controlled diagnostic.
+static nlohmann::json numpy_where_select(
+  const nlohmann::json &cond,
+  const nlohmann::json &x,
+  const nlohmann::json &y)
+{
+  if (!cond.contains("elts") || !cond["elts"].is_array())
+    return numpy_logical_as_bool(cond) ? x : y;
+
+  const bool x_is_list = x.contains("elts") && x["elts"].is_array();
+  const bool y_is_list = y.contains("elts") && y["elts"].is_array();
+  const std::size_t n = cond["elts"].size();
+  if (
+    (x_is_list && x["elts"].size() != n) ||
+    (y_is_list && y["elts"].size() != n))
+    throw std::runtime_error(
+      "TypeError: numpy.where() operands have mismatched lengths");
+
+  std::vector<nlohmann::json> out_elts;
+  for (std::size_t i = 0; i < n; ++i)
+  {
+    const bool choose_x = numpy_logical_as_bool(cond["elts"][i]);
+    out_elts.push_back(
+      choose_x ? (x_is_list ? x["elts"][i] : x)
+               : (y_is_list ? y["elts"][i] : y));
+  }
+  return make_list_node(out_elts);
+}
+
 static std::optional<nlohmann::json> evaluate_numpy_where_call(
   const nlohmann::json &args,
   python_converter &converter,
@@ -2512,20 +2544,7 @@ static std::optional<nlohmann::json> evaluate_numpy_where_call(
     resolve_numpy_logical_arg(args[0], converter, depth);
   const nlohmann::json x = resolve_numpy_logical_arg(args[1], converter, depth);
   const nlohmann::json y = resolve_numpy_logical_arg(args[2], converter, depth);
-  if (!cond.contains("elts") || !cond["elts"].is_array())
-    return numpy_logical_as_bool(cond) ? x : y;
-
-  std::vector<nlohmann::json> out_elts;
-  for (std::size_t i = 0; i < cond["elts"].size(); ++i)
-  {
-    const bool choose_x = numpy_logical_as_bool(cond["elts"][i]);
-    const nlohmann::json &chosen =
-      choose_x
-        ? (x.contains("elts") && x["elts"].is_array() ? x["elts"][i] : x)
-        : (y.contains("elts") && y["elts"].is_array() ? y["elts"][i] : y);
-    out_elts.push_back(chosen);
-  }
-  return make_list_node(out_elts);
+  return numpy_where_select(cond, x, y);
 }
 
 // Evaluates a numpy comparison/logical Call node to its literal JSON result
@@ -5902,22 +5921,10 @@ exprt numpy_call_expr::get()
       auto cond = get_arg(0);
       auto x = get_arg(1);
       auto y = get_arg(2);
-      if (cond.contains("elts") && cond["elts"].is_array())
-      {
-        std::vector<nlohmann::json> out_elts;
-        for (std::size_t i = 0; i < cond["elts"].size(); ++i)
-        {
-          const bool choose_x = numpy_logical_as_bool(cond["elts"][i]);
-          const auto &chosen =
-            choose_x
-              ? (x.contains("elts") && x["elts"].is_array() ? x["elts"][i] : x)
-              : (y.contains("elts") && y["elts"].is_array() ? y["elts"][i] : y);
-          out_elts.push_back(chosen);
-        }
-        return to_list_expr(make_list_node(out_elts));
-      }
-      return numpy_logical_as_bool(cond) ? converter_.get_expr(x)
-                                         : converter_.get_expr(y);
+      const nlohmann::json result = numpy_where_select(cond, x, y);
+      return result.value("_type", std::string()) == "List"
+               ? to_list_expr(result)
+               : to_expr(result);
     }
 
     auto parse_shape = [&](const nlohmann::json &shape_node) {

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2251,6 +2251,283 @@ static void materialize_inline_numpy_constructor_call(
     node = std::move(*materialized);
 }
 
+// True when call_node is a call to one of the comparison/logical functions
+// the block below evaluates. Shared by the top-level dispatch and by
+// resolve_numpy_logical_arg() below, so a call chained as another numpy
+// call's argument is recognized the same way as a top-level call.
+static bool is_numpy_logical_comparison_call(
+  const nlohmann::json &call_node,
+  const nlohmann::json &ast_json)
+{
+  if (
+    !call_node.is_object() ||
+    call_node.value("_type", std::string()) != "Call" ||
+    !call_node.contains("func") || !call_node["func"].is_object() ||
+    call_node["func"].value("_type", std::string()) != "Attribute" ||
+    !call_node["func"].contains("attr") ||
+    !call_node["func"].contains("value") ||
+    !call_node["func"]["value"].is_object() ||
+    call_node["func"]["value"].value("_type", std::string()) != "Name" ||
+    !is_imported_numpy_module_alias(
+      ast_json, call_node["func"]["value"].value("id", std::string())))
+    return false;
+
+  static const std::set<std::string> functions = {
+    "greater",
+    "less",
+    "greater_equal",
+    "less_equal",
+    "equal",
+    "not_equal",
+    "logical_and",
+    "logical_or",
+    "logical_not",
+    "where"};
+  return functions.count(call_node["func"]["attr"].get<std::string>()) != 0;
+}
+
+static nlohmann::json make_bool_constant_node(bool value)
+{
+  nlohmann::json out;
+  out["_type"] = "Constant";
+  out["value"] = value;
+  return out;
+}
+
+static nlohmann::json make_list_node(const std::vector<nlohmann::json> &elts)
+{
+  nlohmann::json out;
+  out["_type"] = "List";
+  out["elts"] = elts;
+  return out;
+}
+
+static bool numpy_logical_as_bool(const nlohmann::json &node)
+{
+  numeric_value value;
+  if (try_extract_numeric_constant(node, value))
+    return to_double(value) != 0.0;
+  if (node.is_object() && node.contains("value") && node["value"].is_boolean())
+    return node["value"].get<bool>();
+  return false;
+}
+
+static double numpy_logical_as_double(const nlohmann::json &node)
+{
+  numeric_value value;
+  if (try_extract_numeric_constant(node, value))
+    return to_double(value);
+  return 0.0;
+}
+
+static nlohmann::json numpy_compare_scalar(
+  const std::string &op,
+  const nlohmann::json &lhs,
+  const nlohmann::json &rhs)
+{
+  const double left = numpy_logical_as_double(lhs);
+  const double right = numpy_logical_as_double(rhs);
+  bool result = false;
+  if (op == "greater")
+    result = left > right;
+  else if (op == "less")
+    result = left < right;
+  else if (op == "greater_equal")
+    result = left >= right;
+  else if (op == "less_equal")
+    result = left <= right;
+  else if (op == "equal")
+    result = left == right;
+  else
+    result = left != right;
+  return make_bool_constant_node(result);
+}
+
+// Applies element_fn pairwise across lhs/rhs, broadcasting a scalar against a
+// list on either side. Shared by comparisons and logical_and/or, both at the
+// top-level dispatch and when evaluating a chained call.
+template <typename ElementFn>
+static nlohmann::json numpy_broadcast_binary(
+  const nlohmann::json &lhs,
+  const nlohmann::json &rhs,
+  ElementFn element_fn)
+{
+  if (lhs.contains("elts") && lhs["elts"].is_array())
+  {
+    std::vector<nlohmann::json> out_elts;
+    for (std::size_t i = 0; i < lhs["elts"].size(); ++i)
+    {
+      const auto &lhs_item = lhs["elts"][i];
+      const auto &rhs_item =
+        rhs.contains("elts") && rhs["elts"].is_array() ? rhs["elts"][i] : rhs;
+      out_elts.push_back(element_fn(lhs_item, rhs_item));
+    }
+    return make_list_node(out_elts);
+  }
+  if (rhs.contains("elts") && rhs["elts"].is_array())
+  {
+    std::vector<nlohmann::json> out_elts;
+    for (const auto &rhs_item : rhs["elts"])
+      out_elts.push_back(element_fn(lhs, rhs_item));
+    return make_list_node(out_elts);
+  }
+  return element_fn(lhs, rhs);
+}
+
+// Bounds recursion for evaluate_numpy_logical_call() below. A handful of
+// levels comfortably covers realistic chaining; beyond that, resolve_
+// numpy_logical_arg() raises an explicit diagnostic instead of leaving an
+// unresolved Call node for the caller's numeric/list extraction to silently
+// misread (the exact failure mode this fix closes).
+static constexpr int max_numpy_logical_chain_depth = 4;
+
+static std::optional<nlohmann::json> evaluate_numpy_logical_call(
+  const nlohmann::json &call_node,
+  python_converter &converter,
+  int depth);
+
+// Resolves one argument of a numpy comparison/logical call: a Name is
+// followed to its declaration; a Call to a recognized constructor is
+// materialized; a Call to another comparison/logical function is evaluated
+// recursively via evaluate_numpy_logical_call(). Anything else (a function
+// parameter, a call to an unrelated numpy function) is left unchanged, so
+// the caller's own numeric/list extraction fails on it exactly as it
+// already does for any other unresolvable operand.
+static nlohmann::json resolve_numpy_logical_arg(
+  nlohmann::json arg,
+  python_converter &converter,
+  int depth)
+{
+  if (arg.is_object() && arg.value("_type", std::string()) == "Name")
+  {
+    const nlohmann::json decl = json_utils::find_var_decl(
+      arg["id"].get<std::string>(),
+      converter.current_function_name(),
+      converter.ast());
+    if (decl.contains("value") && decl["value"].is_object())
+      arg = decl["value"];
+  }
+  if (arg.is_object() && arg.value("_type", std::string()) == "Call")
+  {
+    if (
+      std::optional<nlohmann::json> materialized =
+        materialize_numpy_constructor_array(arg, converter.ast()))
+      return *materialized;
+    if (is_numpy_logical_comparison_call(arg, converter.ast()))
+    {
+      if (
+        std::optional<nlohmann::json> evaluated =
+          evaluate_numpy_logical_call(arg, converter, depth + 1))
+        return *evaluated;
+      throw std::runtime_error(
+        "TypeError: numpy call composition exceeds the supported chaining "
+        "depth");
+    }
+  }
+  return arg;
+}
+
+// Evaluates a numpy comparison/logical Call node to its literal JSON result
+// (a "List" of booleans/values, or a scalar "Constant"), so it can resolve a
+// call chained as another numpy call's argument -- either nested directly
+// (np.logical_not(np.equal(a, b))) or via an intermediate variable
+// (x = np.equal(a, b); np.logical_not(x)). Mirrors the top-level dispatch in
+// numpy_call_expr::get() for these same functions; both share the helpers
+// above instead of each reimplementing broadcasting/comparison logic.
+static std::optional<nlohmann::json> evaluate_numpy_logical_call(
+  const nlohmann::json &call_node,
+  python_converter &converter,
+  int depth)
+{
+  if (depth > max_numpy_logical_chain_depth)
+    return std::nullopt;
+  if (!is_numpy_logical_comparison_call(call_node, converter.ast()))
+    return std::nullopt;
+
+  const std::string function = call_node["func"]["attr"].get<std::string>();
+  const auto &args = call_node["args"];
+
+  if (
+    function == "greater" || function == "less" ||
+    function == "greater_equal" || function == "less_equal" ||
+    function == "equal" || function == "not_equal")
+  {
+    if (args.size() != 2)
+      return std::nullopt;
+    const nlohmann::json lhs =
+      resolve_numpy_logical_arg(args[0], converter, depth);
+    const nlohmann::json rhs =
+      resolve_numpy_logical_arg(args[1], converter, depth);
+    return numpy_broadcast_binary(
+      lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
+        return numpy_compare_scalar(function, a, b);
+      });
+  }
+
+  if (function == "logical_and" || function == "logical_or")
+  {
+    if (args.size() != 2)
+      return std::nullopt;
+    const nlohmann::json lhs =
+      resolve_numpy_logical_arg(args[0], converter, depth);
+    const nlohmann::json rhs =
+      resolve_numpy_logical_arg(args[1], converter, depth);
+    return numpy_broadcast_binary(
+      lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
+        const bool l = numpy_logical_as_bool(a);
+        const bool r = numpy_logical_as_bool(b);
+        return make_bool_constant_node(
+          function == "logical_and" ? (l && r) : (l || r));
+      });
+  }
+
+  if (function == "logical_not")
+  {
+    if (args.size() != 1)
+      return std::nullopt;
+    const nlohmann::json arg =
+      resolve_numpy_logical_arg(args[0], converter, depth);
+    if (arg.contains("elts") && arg["elts"].is_array())
+    {
+      std::vector<nlohmann::json> out_elts;
+      for (const auto &item : arg["elts"])
+        out_elts.push_back(
+          make_bool_constant_node(!numpy_logical_as_bool(item)));
+      return make_list_node(out_elts);
+    }
+    return make_bool_constant_node(!numpy_logical_as_bool(arg));
+  }
+
+  if (function == "where")
+  {
+    if (args.size() != 3)
+      return std::nullopt;
+    const nlohmann::json cond =
+      resolve_numpy_logical_arg(args[0], converter, depth);
+    const nlohmann::json x =
+      resolve_numpy_logical_arg(args[1], converter, depth);
+    const nlohmann::json y =
+      resolve_numpy_logical_arg(args[2], converter, depth);
+    if (cond.contains("elts") && cond["elts"].is_array())
+    {
+      std::vector<nlohmann::json> out_elts;
+      for (std::size_t i = 0; i < cond["elts"].size(); ++i)
+      {
+        const bool choose_x = numpy_logical_as_bool(cond["elts"][i]);
+        const nlohmann::json &chosen =
+          choose_x
+            ? (x.contains("elts") && x["elts"].is_array() ? x["elts"][i] : x)
+            : (y.contains("elts") && y["elts"].is_array() ? y["elts"][i] : y);
+        out_elts.push_back(chosen);
+      }
+      return make_list_node(out_elts);
+    }
+    return numpy_logical_as_bool(cond) ? x : y;
+  }
+
+  return std::nullopt;
+}
+
 // full()/eye()/identity()/linspace() are declared through to_list_expr in
 // the real creation path (see array_creation_funcs and its neighbours),
 // which forces a dynamic PyListObj representation instead of a plain
@@ -5456,6 +5733,19 @@ exprt numpy_call_expr::get()
             var = var["value"];
             return;
           }
+          if (is_numpy_logical_comparison_call(var["value"], converter_.ast()))
+          {
+            if (
+              std::optional<nlohmann::json> evaluated =
+                evaluate_numpy_logical_call(var["value"], converter_, 0))
+            {
+              var = std::move(*evaluated);
+              return;
+            }
+            throw std::runtime_error(
+              "TypeError: numpy call composition exceeds the supported "
+              "chaining depth");
+          }
           if (var["value"].contains("args") && !var["value"]["args"].empty())
             var = var["value"]["args"][0];
           else
@@ -5464,13 +5754,6 @@ exprt numpy_call_expr::get()
         else
           var = var["value"];
       }
-    };
-
-    auto make_constant = [](const auto &value) {
-      nlohmann::json out;
-      out["_type"] = "Constant";
-      out["value"] = value;
-      return out;
     };
 
     auto to_list_expr = [this](const nlohmann::json &node) {
@@ -5485,22 +5768,42 @@ exprt numpy_call_expr::get()
       return converter_.get_expr(node);
     };
 
+    auto get_arg = [&](std::size_t index) {
+      nlohmann::json arg = call_["args"][index];
+      resolve_var(arg);
+      materialize_inline_numpy_constructor_call(arg, converter_.ast());
+      if (
+        arg.value("_type", std::string()) == "Call" &&
+        is_numpy_logical_comparison_call(arg, converter_.ast()))
+      {
+        if (
+          std::optional<nlohmann::json> evaluated =
+            evaluate_numpy_logical_call(arg, converter_, 0))
+          arg = std::move(*evaluated);
+        else
+          throw std::runtime_error(
+            "TypeError: numpy call composition exceeds the supported "
+            "chaining depth");
+      }
+      return arg;
+    };
+
+    // Used by full()/eye()/identity()/linspace() below, which build
+    // numeric (not boolean) literals -- kept local since that shape
+    // materialization is unrelated to the comparison/logical evaluation
+    // above and out of this fix's scope.
+    auto make_constant = [](const auto &value) {
+      nlohmann::json out;
+      out["_type"] = "Constant";
+      out["value"] = value;
+      return out;
+    };
+
     auto make_list = [](const std::vector<nlohmann::json> &elts) {
       nlohmann::json out;
       out["_type"] = "List";
       out["elts"] = elts;
       return out;
-    };
-
-    auto as_bool = [](const nlohmann::json &node) {
-      numeric_value value;
-      if (try_extract_numeric_constant(node, value))
-        return to_double(value) != 0.0;
-      if (
-        node.is_object() && node.contains("value") &&
-        node["value"].is_boolean())
-        return node["value"].get<bool>();
-      return false;
     };
 
     auto as_double = [](const nlohmann::json &node) {
@@ -5510,35 +5813,6 @@ exprt numpy_call_expr::get()
       return 0.0;
     };
 
-    auto compare_scalar = [&](
-                            const std::string &op,
-                            const nlohmann::json &lhs,
-                            const nlohmann::json &rhs) {
-      const double left = as_double(lhs);
-      const double right = as_double(rhs);
-      bool result = false;
-      if (op == "greater")
-        result = left > right;
-      else if (op == "less")
-        result = left < right;
-      else if (op == "greater_equal")
-        result = left >= right;
-      else if (op == "less_equal")
-        result = left <= right;
-      else if (op == "equal")
-        result = left == right;
-      else
-        result = left != right;
-      return make_constant(result);
-    };
-
-    auto get_arg = [&](std::size_t index) {
-      nlohmann::json arg = call_["args"][index];
-      resolve_var(arg);
-      materialize_inline_numpy_constructor_call(arg, converter_.ast());
-      return arg;
-    };
-
     if (
       function == "greater" || function == "less" ||
       function == "greater_equal" || function == "less_equal" ||
@@ -5546,66 +5820,29 @@ exprt numpy_call_expr::get()
     {
       auto lhs = get_arg(0);
       auto rhs = get_arg(1);
-
-      if (lhs.contains("elts") && lhs["elts"].is_array())
-      {
-        std::vector<nlohmann::json> out_elts;
-        for (std::size_t i = 0; i < lhs["elts"].size(); ++i)
-        {
-          const auto &lhs_item = lhs["elts"][i];
-          const auto &rhs_item = rhs.contains("elts") && rhs["elts"].is_array()
-                                   ? rhs["elts"][i]
-                                   : rhs;
-          out_elts.push_back(compare_scalar(function, lhs_item, rhs_item));
-        }
-        return to_list_expr(make_list(out_elts));
-      }
-
-      if (rhs.contains("elts") && rhs["elts"].is_array())
-      {
-        std::vector<nlohmann::json> out_elts;
-        for (const auto &rhs_item : rhs["elts"])
-          out_elts.push_back(compare_scalar(function, lhs, rhs_item));
-        return to_list_expr(make_list(out_elts));
-      }
-
-      return to_expr(compare_scalar(function, lhs, rhs));
+      const nlohmann::json result = numpy_broadcast_binary(
+        lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
+          return numpy_compare_scalar(function, a, b);
+        });
+      return result.value("_type", std::string()) == "List"
+               ? to_list_expr(result)
+               : to_expr(result);
     }
 
     if (function == "logical_and" || function == "logical_or")
     {
       auto lhs = get_arg(0);
       auto rhs = get_arg(1);
-      auto apply = [&](const nlohmann::json &a, const nlohmann::json &b) {
-        const bool left = as_bool(a);
-        const bool right = as_bool(b);
-        return make_constant(
-          function == "logical_and" ? (left && right) : (left || right));
-      };
-
-      if (lhs.contains("elts") && lhs["elts"].is_array())
-      {
-        std::vector<nlohmann::json> out_elts;
-        for (std::size_t i = 0; i < lhs["elts"].size(); ++i)
-        {
-          const auto &lhs_item = lhs["elts"][i];
-          const auto &rhs_item = rhs.contains("elts") && rhs["elts"].is_array()
-                                   ? rhs["elts"][i]
-                                   : rhs;
-          out_elts.push_back(apply(lhs_item, rhs_item));
-        }
-        return to_list_expr(make_list(out_elts));
-      }
-
-      if (rhs.contains("elts") && rhs["elts"].is_array())
-      {
-        std::vector<nlohmann::json> out_elts;
-        for (const auto &rhs_item : rhs["elts"])
-          out_elts.push_back(apply(lhs, rhs_item));
-        return to_list_expr(make_list(out_elts));
-      }
-
-      return to_expr(apply(lhs, rhs));
+      const nlohmann::json result = numpy_broadcast_binary(
+        lhs, rhs, [&](const nlohmann::json &a, const nlohmann::json &b) {
+          const bool l = numpy_logical_as_bool(a);
+          const bool r = numpy_logical_as_bool(b);
+          return make_bool_constant_node(
+            function == "logical_and" ? (l && r) : (l || r));
+        });
+      return result.value("_type", std::string()) == "List"
+               ? to_list_expr(result)
+               : to_expr(result);
     }
 
     if (function == "logical_not")
@@ -5615,10 +5852,11 @@ exprt numpy_call_expr::get()
       {
         std::vector<nlohmann::json> out_elts;
         for (const auto &item : arg["elts"])
-          out_elts.push_back(make_constant(!as_bool(item)));
-        return to_list_expr(make_list(out_elts));
+          out_elts.push_back(
+            make_bool_constant_node(!numpy_logical_as_bool(item)));
+        return to_list_expr(make_list_node(out_elts));
       }
-      return to_expr(make_constant(!as_bool(arg)));
+      return to_expr(make_bool_constant_node(!numpy_logical_as_bool(arg)));
     }
 
     if (function == "where")
@@ -5631,16 +5869,17 @@ exprt numpy_call_expr::get()
         std::vector<nlohmann::json> out_elts;
         for (std::size_t i = 0; i < cond["elts"].size(); ++i)
         {
-          const bool choose_x = as_bool(cond["elts"][i]);
+          const bool choose_x = numpy_logical_as_bool(cond["elts"][i]);
           const auto &chosen =
             choose_x
               ? (x.contains("elts") && x["elts"].is_array() ? x["elts"][i] : x)
               : (y.contains("elts") && y["elts"].is_array() ? y["elts"][i] : y);
           out_elts.push_back(chosen);
         }
-        return to_list_expr(make_list(out_elts));
+        return to_list_expr(make_list_node(out_elts));
       }
-      return as_bool(cond) ? converter_.get_expr(x) : converter_.get_expr(y);
+      return numpy_logical_as_bool(cond) ? converter_.get_expr(x)
+                                         : converter_.get_expr(y);
     }
 
     auto parse_shape = [&](const nlohmann::json &shape_node) {

--- a/src/python-frontend/numpy/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy/numpy_call_expr.cpp
@@ -2353,26 +2353,34 @@ static nlohmann::json numpy_compare_scalar(
 
 // Applies element_fn pairwise across lhs/rhs, broadcasting a scalar against a
 // list on either side. Shared by comparisons and logical_and/or, both at the
-// top-level dispatch and when evaluating a chained call.
+// top-level dispatch and when evaluating a chained call. When both operands
+// are lists, their lengths must agree -- indexing the shorter one past its
+// end is an out-of-bounds JSON access, not a controlled diagnostic.
 template <typename ElementFn>
 static nlohmann::json numpy_broadcast_binary(
   const nlohmann::json &lhs,
   const nlohmann::json &rhs,
   ElementFn element_fn)
 {
-  if (lhs.contains("elts") && lhs["elts"].is_array())
+  const bool lhs_is_list = lhs.contains("elts") && lhs["elts"].is_array();
+  const bool rhs_is_list = rhs.contains("elts") && rhs["elts"].is_array();
+
+  if (lhs_is_list && rhs_is_list && lhs["elts"].size() != rhs["elts"].size())
+    throw std::runtime_error(
+      "TypeError: numpy comparison/logical operands have mismatched "
+      "lengths");
+
+  if (lhs_is_list)
   {
     std::vector<nlohmann::json> out_elts;
     for (std::size_t i = 0; i < lhs["elts"].size(); ++i)
     {
-      const auto &lhs_item = lhs["elts"][i];
-      const auto &rhs_item =
-        rhs.contains("elts") && rhs["elts"].is_array() ? rhs["elts"][i] : rhs;
-      out_elts.push_back(element_fn(lhs_item, rhs_item));
+      const nlohmann::json &rhs_item = rhs_is_list ? rhs["elts"][i] : rhs;
+      out_elts.push_back(element_fn(lhs["elts"][i], rhs_item));
     }
     return make_list_node(out_elts);
   }
-  if (rhs.contains("elts") && rhs["elts"].is_array())
+  if (rhs_is_list)
   {
     std::vector<nlohmann::json> out_elts;
     for (const auto &rhs_item : rhs["elts"])


### PR DESCRIPTION
- is_numpy_logical_comparison_call, evaluate_numpy_logical_call (split into evaluate_numpy_compare_call, evaluate_numpy_logical_and_or_call, evaluate_numpy_logical_not_call, evaluate_numpy_where_call), resolve_numpy_logical_arg, numpy_broadcast_binary, numpy_compare_scalar, numpy_logical_as_bool/numpy_logical_as_double, make_bool_constant_node, make_list_node — new helpers in numpy_call_expr.cpp that evaluate a numpy comparison/logical call (greater/less/greater_equal/less_equal/equal/not_equal/logical_and/logical_or/logical_not/where) chained as another numpy call's argument — nested directly or via an intermediate variable — instead of silently substituting the inner call's raw first argument.
- resolve_var and get_arg (inside numpy_call_expr::get()) now call these helpers before falling back to the old behavior.
- The top-level comparison/logical/where dispatch in get() was rewritten to reuse the same helpers, removing duplicated broadcasting/comparison logic.
- Chaining is bounded to 4 levels (max_numpy_logical_chain_depth); beyond that it raises an explicit TypeError instead of silently misreading.