### PR TITLE
[scripts] Stop the CPython gate skipping tests that only mention an intrinsic

### DIFF
--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -27,6 +27,9 @@ ignored_dirs=(
   "cover5"
   "concurrency_fail"
   "threading_thread_skip_join_fail"
+  # A data race does not manifest deterministically under CPython, so the
+  # _fail expectation (non-zero exit) cannot be checked there.
+  "threading_thread_increment_race_no_flag_fail"
   "convert-byte-update2"
   "constants"
   "decimal"
@@ -207,7 +210,12 @@ for dir in */; do
   # NameError under direct execution and can only be validated via ESBMC.
   # Detecting them by content means an intrinsic-using test no longer needs a
   # manual ignore-list entry (e.g. github_5104, github_5105).
-  if grep -qE '__ESBMC|__VERIFIER_|nondet_' "$dir/main.py"; then
+  #
+  # Comments are stripped first: a test that only *mentions* an intrinsic while
+  # calling none is plain Python, and matching the mention skipped it silently
+  # -- 22 tests were being reported as "expected" without ever being run.
+  if sed 's/#.*//' "$dir/main.py" |
+    grep -qE '__ESBMC|__VERIFIER_|nondet_'; then
     echo "🚫 IGNORED: $dir (uses ESBMC intrinsics, not runnable under CPython)"
     continue
   fi


### PR DESCRIPTION
**Master-based**, independent of the clang-c hop-off stack.

`check_python_tests.sh` decides whether a test can run under CPython by grepping `main.py` for `__ESBMC|__VERIFIER_|nondet_`. It greps the **whole file, comments included**, so a plain-Python test that merely names an intrinsic in a comment was reported ignored and never run:

```
# before
🚫 IGNORED: dict_eq_int_float (uses ESBMC intrinsics, not runnable under CPython)
✅ All tests behaved as expected.        <- having run nothing

# after
✅ dict_eq_int_float: executed successfully (exit 0)
```

**22 tests** matched only on a comment. Strip comments before matching and **18** become genuinely checked (the other 4 are still skipped: three carry `nondet` in the directory name, which the existing name rule catches). All 18 pass; the full gate is green end to end.

One needs an explicit entry rather than an accidental one: `threading_thread_increment_race_no_flag_fail` expects a non-zero exit, but a data race does not manifest deterministically under CPython — added to `ignored_dirs` with that reason.

Found while adding a test in #7095, where my own new test was silently skipped for the same reason.

Part of #4715.