### PR TITLE
[c2goto] Register bundled models through the filesystem singleton

### DIFF
--- a/src/c2goto/cprover_libc_sources.cpp
+++ b/src/c2goto/cprover_libc_sources.cpp
@@ -61,23 +61,27 @@ void register_bundled_libc()
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_musl + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_musl + "/" #__VA_ARGS__, body, size);
 #include <libmusl.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_musl + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_musl + "/" #__VA_ARGS__, body, size);
 #include <libmuslhdr.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_cpp + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_cpp + "/" #__VA_ARGS__, body, size);
 #include <libcpp.h>
 #undef ESBMC_FLAIL
 
 #ifdef ENABLE_PYTHON_FRONTEND
 #  define ESBMC_FLAIL(body, size, ...)                                         \
-    fs.add_bundled(vfs_python + "/" #__VA_ARGS__, body, size);
+    file_operations::filesystemt::get().add_bundled(                           \
+      vfs_python + "/" #__VA_ARGS__, body, size);
 #  include <libpython.h>
 #  include <libpythonhdr.h>
 #  undef ESBMC_FLAIL
@@ -85,7 +89,8 @@ void register_bundled_libc()
 
 #ifdef ENABLE_SOLIDITY_FRONTEND
 #  define ESBMC_FLAIL(body, size, ...)                                         \
-    fs.add_bundled(vfs_solidity + "/" #__VA_ARGS__, body, size);
+    file_operations::filesystemt::get().add_bundled(                           \
+      vfs_solidity + "/" #__VA_ARGS__, body, size);
 #  include <libsolidity.h>
 #  include <libsolidityhdr.h>
 #  undef ESBMC_FLAIL


### PR DESCRIPTION
Master does not compile. #6766 added five `ESBMC_FLAIL` blocks in `register_bundled_libc()` that call `fs.add_bundled(...)`, but `fs` is never declared; the three pre-existing blocks spell out `file_operations::filesystemt::get()` instead. Those five now use the same fully-qualified call.

Binding a local `filesystemt &fs` and using it from every block was the first attempt and reads better, but it does not survive static analysis: the flail headers are generated at build time, so an analyser that cannot resolve `#include <libmusl.h>` never sees the macro bodies that use the reference and reports it unused. Codacy flagged exactly that. Spelling the singleton out keeps the analysers quiet and matches what the file already did.

Verified with a clean `ninja -C build esbmc` (Python frontend on) on a tree that failed to compile before the change.