### PR TITLE
[docs] Census floats; the ieee_* promotion gap was a false positive

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -3339,3 +3339,66 @@ Next, in order:
    retires both arms' declines together. The work is reproducing the
    temporary's name -- `<file>:<line>$complex$`, `file_local`, module-tagged --
    closely enough that `c_link` renames it the same way across TUs.
+
+## 103. The `floats` suite censused — and the `ieee_*` gap does not exist
+
+`floats` is the second of §101's uncensused suites: **97 of 102 differ**. By
+cause, over the first 50:
+
+| cause | tests | owner |
+|---|---:|---|
+| name-matched builtins (`fabs`, `inf`, ...) | 25 | #7088 |
+| `migrate_expr` renaming warning | 18 | #7093 |
+| `assert` base name | 18 | #7087 |
+| boolean cast on a condition | 4 | #7099 |
+| array-to-pointer decay | 3 | #7098 |
+| `for`-init hoist | 1 | #7105 |
+
+**Every cause is owned.** Like `cstd` (§102), the suite is denser in the same
+things rather than differently affected.
+
+### 103.1 A cause that was not there
+
+A first pass tagged 2 tests as an `ieee_*` promotion gap — the
+`adjust_float_arith` arm §104.2 deferred — on the strength of `IEEE_ADD` and
+friends appearing in the default symbol table and not under `-only`. The arm was
+written to close it. It fires **zero** times, and the tag was a false positive.
+
+Measured directly:
+
+```c
+double a = nondet_double(), b = nondet_double();
+double c = a + b;
+```
+
+`double c=IEEE_ADD(a, b);` on the default path **and** under `-only` on an
+unmodified baseline. The promotion is already there without the legacy arm.
+
+The two tagged tests are `Float-no-simp8`/`9`, and their `IEEE_*` lines sit
+inside **libm model functions absent from the `-only` symbol table altogether** —
+the same "1066 vs 1067 symbols" seen in §102's `cstd` samples. An unlowered
+builtin call (#7088) changes which operational-model functions get linked, so
+whole model bodies appear or disappear. The tag matched a consequence of a cause
+already owned, in a function that is not the program's.
+
+The arm was deleted rather than shipped. It would have been an arm with no
+witness, which is what §94.1 and §102.2 both declined to do.
+
+### 103.2 A dead-code candidate
+
+That measurement says something about the legacy pass, not just the port: if a
+float `+` is already an `ieee_add` before `clang_c_adjust` runs — which is what
+`-only` on an unmodified baseline demonstrates, since it never calls
+`adjust_float_arith` — then **`adjust_float_arith`'s scalar path is dead on the C
+frontend**. Its vector branch may not be; the arm explicitly handles a
+vector-of-float and returns before attaching a rounding mode.
+
+That makes it a candidate for the dead-code process rather than for porting:
+`CLAUDE.md`'s C-Dead sub-mode, with the vector case checked separately. Recorded
+here rather than acted on, because deleting a legacy arm needs its own proof and
+is not this scope's business.
+
+### 103.3 Suites remaining
+
+`esbmc-unix` (438) is the last of §101's list. On the evidence of `cstd` and
+`floats`, expect the same four owned causes and no new ones.


### PR DESCRIPTION
**Master-based**, docs only. (Note master does not currently build — see #7111 — so this was measured on master+#7111.)

`floats` is the second of §101's uncensused suites: **97 of 102 differ**, and **every cause is owned by an open PR** — 25 name-matched builtins (#7088), 18 warning (#7093), 18 `assert` (#7087), 4 bool cast (#7099), 3 array decay (#7098), 1 for-init hoist (#7105). Like `cstd`, denser in the same things rather than differently affected.

**The part worth reading is a cause that turned out not to exist.** A first pass tagged 2 tests as the `ieee_*` promotion gap — the `adjust_float_arith` arm §104.2 deferred — and I wrote the arm to close it. **It fires zero times.** Measured directly:

```c
double c = a + b;   // double c=IEEE_ADD(a, b);  on BOTH paths
```

The promotion is already there under `-only` on an unmodified baseline, which never calls `adjust_float_arith`. The two tagged tests' `IEEE_*` lines sit inside **libm model functions absent from the `-only` symbol table altogether** — an unlowered builtin (#7088) changes which operational models get linked, so whole model bodies appear or disappear. My tag matched a consequence of an owned cause, in a function that isn't the program's.

**I deleted the arm rather than ship it.** An arm with no witness is what §94.1 and §102.2 both declined to ship, and it would have been the third.

**A by-product worth someone's attention (§103.2):** if a float `+` is already `ieee_add` before `clang_c_adjust` runs, then `adjust_float_arith`'s **scalar path is dead on the C frontend**. Its vector branch may not be. That is a candidate for `CLAUDE.md`'s C-Dead process, not for porting — recorded, not acted on, since deleting a legacy arm needs its own proof.

`esbmc-unix` (438) is the last uncensused suite; expect the same four owned causes.

Part of #4715.