### PR TITLE
[c2goto] Bind the filesystem the FLAIL macros register into

### DIFF
--- a/src/c2goto/cprover_libc_sources.cpp
+++ b/src/c2goto/cprover_libc_sources.cpp
@@ -42,21 +42,20 @@ void register_bundled_libc()
     return;
   done = true;
 
+  file_operations::filesystemt &fs = file_operations::filesystemt::get();
+
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  file_operations::filesystemt::get().add_bundled(                             \
-    vfs_headers + "/" #__VA_ARGS__, body, size);
+  fs.add_bundled(vfs_headers + "/" #__VA_ARGS__, body, size);
 #include <headers/libc_hdr.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  file_operations::filesystemt::get().add_bundled(                             \
-    vfs_library + "/" #__VA_ARGS__, body, size);
+  fs.add_bundled(vfs_library + "/" #__VA_ARGS__, body, size);
 #include <libc.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  file_operations::filesystemt::get().add_bundled(                             \
-    vfs_libm + "/" #__VA_ARGS__, body, size);
+  fs.add_bundled(vfs_libm + "/" #__VA_ARGS__, body, size);
 #include <libm.h>
 #undef ESBMC_FLAIL
 


### PR DESCRIPTION
Fixes #7112. `master` at `2284cf241d` does not compile.

```
FAILED: src/c2goto/CMakeFiles/c2goto.dir/cprover_libc_sources.cpp.o
src/c2goto/cprover_libc_sources.cpp:64:3: error: 'fs' was not declared in this scope; did you mean 'ffs'?
   64 |   fs.add_bundled(vfs_musl + "/" #__VA_ARGS__, body, size);
```

`register_bundled_libc` uses `fs` in five `ESBMC_FLAIL` expansions and nothing declares it. #6766 added those five; the three blocks that predate it spell `file_operations::filesystemt::get().add_bundled(...)` out in full.

Bind it once at the top of the function and let every block use it, rather than leaving two spellings of the same call in one function.

## Checks

- builds clean
- `regression/function_contract` and `regression/python-contracts` 457/457
- runtime sanity, since compiling is not evidence the models are still mounted: a C file reaching `memset` and `fabs`, and a Python file reaching the list model, both verify

Worth a look at why CI did not catch this -- every build job should have.
