### PR TITLE
[docs] Complete the Phase 6 census: no unowned cause remains

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -3339,3 +3339,59 @@ Next, in order:
    retires both arms' declines together. The work is reproducing the
    temporary's name -- `<file>:<line>$complex$`, `file_local`, module-tagged --
    closely enough that `c_link` renames it the same way across TUs.
+
+## 104. All four C suites censused — and no unowned cause remains
+
+`esbmc-unix` is the last of §101's list. **53 of 60 sampled tests differ**, and
+after correcting three tag rules (see below) every cause is owned. That closes
+the census:
+
+| suite | differing | dominant cause |
+|---|---|---|
+| `regression/esbmc` | 78 of 120 (65 %) | `__builtin_expect` — 37 (#7086) |
+| `cstd` | 134 of 142 (94 %) | warning 34 (#7093), `assert` 34 (#7087) |
+| `floats` | 97 of 102 (95 %) | name-matched builtins — 25 (#7088) |
+| `esbmc-unix` | 53 of 60 (88 %) | **padding — 46 (#7100)** |
+
+**Across all four, every measured divergence is owned by an open PR.** There is
+no adjuster arm left to write for the censused C corpus. §101 said that of one
+suite; it now holds for the corpus §1.2 prices.
+
+### 104.1 The dominant cause differs per suite, which changes the priorities
+
+This is the useful result, and it is not visible from any single suite.
+`#7100` (struct/union padding) accounts for 9 tests in `regression/esbmc` and
+**46 of 53** in `esbmc-unix`: the unix headers are dense in padded unions
+(`pthread_attr_t` is a union of a `char[36]` and a `long`, whose
+`union_pad#` is missing under the flag). A reviewer sizing these PRs from
+`regression/esbmc` alone would rank #7100 sixth; on the corpus it is first or
+second.
+
+Likewise #7088 barely registers in `regression/esbmc` and is the top cause in
+`floats`, where `fabs`/`inf` are everywhere.
+
+### 104.2 Three tag rules were wrong
+
+Recorded because the same rules will be reused:
+
+- `union_pad#` is a padding token that `anon_pad` does not match — unions pad
+  under a different name.
+- `&f` for a function designator (#7092) needs its own rule; it is not a
+  by-name pattern like the others.
+- `&"lit"[0]` versus `"lit"` is the string-literal half of the decay class
+  (#7098), and reads as a quoted-string difference rather than an index.
+
+Each initially produced an UNTAGGED test that looked like a new cause. §98.2 and
+§104.3 already record that symptom-tagging misattributes; this adds that it also
+*over*-reports, and the fix is to read every untagged residue rather than trust
+the tally.
+
+### 104.3 What is left, and it is not an arm
+
+- **Landing the PRs.** §99 gives the order and the two non-mechanical conflicts.
+  Master additionally does not build at 2284cf241d (#7111).
+- **W3/W4**, coupled per §102.2 and needing a design decision, not a port.
+- **`goto_convert`**, for §98's residual `DEAD` questions.
+- **`adjust_type` beyond padding** and **`adjust_float_arith`'s vector branch**,
+  both witnessless so far; §103.2 argues the latter's scalar path is dead
+  legacy code rather than unported work.


### PR DESCRIPTION
**Master-based**, docs only. Measured on master+#7111, since master does not build at 2284cf241d.

`esbmc-unix` is the last of §101's uncensused suites. That closes the census over the corpus §1.2 prices:

| suite | differing | dominant cause |
|---|---|---|
| `regression/esbmc` | 78 of 120 (65%) | `__builtin_expect` — 37 (#7086) |
| `cstd` | 134 of 142 (94%) | warning 34 (#7093), `assert` 34 (#7087) |
| `floats` | 97 of 102 (95%) | name-matched builtins — 25 (#7088) |
| `esbmc-unix` | 53 of 60 (88%) | **padding — 46 (#7100)** |

**Across all four, every measured divergence is owned by an open PR. There is no adjuster arm left to write for the censused C corpus.**

**The result worth acting on (§104.1): the dominant cause differs per suite, so sizing these PRs from one suite ranks them wrongly.** #7100 (struct/union padding) is 9 tests in `regression/esbmc` and **46 of 53** in `esbmc-unix` — the unix headers are dense in padded unions (`pthread_attr_t`'s `union_pad#` is simply missing under the flag). Judged on `regression/esbmc` it looks sixth; on the corpus it is first or second. #7088 is similar: negligible in `regression/esbmc`, top cause in `floats`.

§104.2 records three of my own tag rules that were wrong — `union_pad#` (unions pad under a different token than `anon_pad`), `&f` for a function designator, and `&"lit"[0]` vs `"lit"`. Each produced an UNTAGGED test that looked like a new cause. The lesson already recorded is that symptom-tagging misattributes; this adds that it also over-reports, and the fix is to read every untagged residue rather than trust the tally.

What is left is not an arm: landing the PRs (§99's order; #7111 first), the coupled W3/W4 design decision (§102.2), `goto_convert` for §98's residual `DEAD`, and two witnessless items — one of which (§103.2) looks like dead legacy code rather than unported work.

Part of #4715.