### PR TITLE
[c2goto] Restore the filesystem handle the VFS flail blocks use

### DIFF
--- a/regression/esbmc/clib_source_from_vfs/main.c
+++ b/regression/esbmc/clib_source_from_vfs/main.c
@@ -1,0 +1,7 @@
+#include <math.h>
+
+int main()
+{
+  float f = 1.0f;
+  return cosf(f) > 0.0f ? 0 : 1;
+}

--- a/regression/esbmc/clib_source_from_vfs/test.desc
+++ b/regression/esbmc/clib_source_from_vfs/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--goto-functions-only
+file ([A-Za-z]:)?/esbmc-vfs/libc/library/libm/musl/__cosdf\.c line \d+
+file ([A-Za-z]:)?/esbmc-vfs/libc/library/libm/pow\.c line \d+

--- a/regression/esbmc/clib_source_from_vfs_ce/main.c
+++ b/regression/esbmc/clib_source_from_vfs_ce/main.c
@@ -1,0 +1,9 @@
+#include <string.h>
+
+int main()
+{
+  char a[4];
+  char b[4];
+  memcpy(a, b, 8);
+  return a[0];
+}

--- a/regression/esbmc/clib_source_from_vfs_ce/test.desc
+++ b/regression/esbmc/clib_source_from_vfs_ce/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--incremental-bmc
+file ([A-Za-z]:)?/esbmc-vfs/libc/library/string\.c line \d+ column \d+ function memcpy
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_libc_sources.cpp
+++ b/src/c2goto/cprover_libc_sources.cpp
@@ -42,41 +42,46 @@ void register_bundled_libc()
     return;
   done = true;
 
-  file_operations::filesystemt &fs = file_operations::filesystemt::get();
-
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_headers + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_headers + "/" #__VA_ARGS__, body, size);
 #include <headers/libc_hdr.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_library + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_library + "/" #__VA_ARGS__, body, size);
 #include <libc.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_libm + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_libm + "/" #__VA_ARGS__, body, size);
 #include <libm.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_musl + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_musl + "/" #__VA_ARGS__, body, size);
 #include <libmusl.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_musl + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_musl + "/" #__VA_ARGS__, body, size);
 #include <libmuslhdr.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  fs.add_bundled(vfs_cpp + "/" #__VA_ARGS__, body, size);
+  file_operations::filesystemt::get().add_bundled(                             \
+    vfs_cpp + "/" #__VA_ARGS__, body, size);
 #include <libcpp.h>
 #undef ESBMC_FLAIL
 
 #ifdef ENABLE_PYTHON_FRONTEND
 #  define ESBMC_FLAIL(body, size, ...)                                         \
-    fs.add_bundled(vfs_python + "/" #__VA_ARGS__, body, size);
+    file_operations::filesystemt::get().add_bundled(                           \
+      vfs_python + "/" #__VA_ARGS__, body, size);
 #  include <libpython.h>
 #  include <libpythonhdr.h>
 #  undef ESBMC_FLAIL
@@ -84,7 +89,8 @@ void register_bundled_libc()
 
 #ifdef ENABLE_SOLIDITY_FRONTEND
 #  define ESBMC_FLAIL(body, size, ...)                                         \
-    fs.add_bundled(vfs_solidity + "/" #__VA_ARGS__, body, size);
+    file_operations::filesystemt::get().add_bundled(                           \
+      vfs_solidity + "/" #__VA_ARGS__, body, size);
 #  include <libsolidity.h>
 #  include <libsolidityhdr.h>
 #  undef ESBMC_FLAIL

--- a/src/c2goto/cprover_libc_sources.cpp
+++ b/src/c2goto/cprover_libc_sources.cpp
@@ -42,21 +42,20 @@ void register_bundled_libc()
     return;
   done = true;
 
+  file_operations::filesystemt &fs = file_operations::filesystemt::get();
+
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  file_operations::filesystemt::get().add_bundled(                             \
-    vfs_headers + "/" #__VA_ARGS__, body, size);
+  fs.add_bundled(vfs_headers + "/" #__VA_ARGS__, body, size);
 #include <headers/libc_hdr.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  file_operations::filesystemt::get().add_bundled(                             \
-    vfs_library + "/" #__VA_ARGS__, body, size);
+  fs.add_bundled(vfs_library + "/" #__VA_ARGS__, body, size);
 #include <libc.h>
 #undef ESBMC_FLAIL
 
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  file_operations::filesystemt::get().add_bundled(                             \
-    vfs_libm + "/" #__VA_ARGS__, body, size);
+  fs.add_bundled(vfs_libm + "/" #__VA_ARGS__, body, size);
 #include <libm.h>
 #undef ESBMC_FLAIL
 


### PR DESCRIPTION
PR #6766 added five ESBMC_FLAIL blocks calling `fs.add_bundled()` without the
declaration of `fs`, so master has not compiled since — each macro expands once
per bundled file, so one missing declaration becomes hundreds of errors.
Binds the singleton once, and lands the `clib_source_from_vfs` test #6766 promised.