### PR TITLE
[regression] Skip the libm VFS test where the host math.h shadows it

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -80,6 +80,13 @@ if(ESBMC_BUNDLE_LIBC)
     list(APPEND ESBMC_TEST_CAPABILITIES bundled_libc)
 endif()
 
+# The bundled musl libm is only reached where the host's own <math.h> does not
+# shadow it. On Windows the UCRT headers declare cosf/pow themselves, so no
+# /esbmc-vfs libm source ever enters the goto program.
+if(NOT WIN32)
+    list(APPEND ESBMC_TEST_CAPABILITIES bundled_libm)
+endif()
+
 string(REPLACE ";" "," ESBMC_TEST_CAPABILITIES_ARG "${ESBMC_TEST_CAPABILITIES}")
 message(STATUS "Regression capabilities: ${ESBMC_TEST_CAPABILITIES_ARG}")
 

--- a/regression/esbmc/clib_source_from_vfs/test.desc
+++ b/regression/esbmc/clib_source_from_vfs/test.desc
@@ -1,5 +1,6 @@
 CORE
 main.c
 --goto-functions-only
+REQUIRES bundled_libm
 file ([A-Za-z]:)?/esbmc-vfs/libc/library/libm/musl/__cosdf\.c line \d+
 file ([A-Za-z]:)?/esbmc-vfs/libc/library/libm/pow\.c line \d+

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -231,6 +231,9 @@ STATIC_CAPABILITIES = {
     # ESBMC_BUNDLE_LIBC=OFF it is parsed from sources instead, and anything
     # measuring the blob has nothing to measure.
     "bundled_libc",
+    # The bundled musl libm is reached rather than shadowed by the host's own
+    # <math.h>. Not so on Windows, where the UCRT declares cosf/pow itself.
+    "bundled_libm",
 }
 
 # Capabilities of the frontend itself, which the build system cannot answer:


### PR DESCRIPTION
`clib_source_from_vfs` asserts `cosf` and `pow` resolve to bundled musl sources under `/esbmc-vfs`. On Windows the UCRT declares them itself, so no libm source reaches the goto program and the test fails for a reason unrelated to ESBMC — reddening the Windows job on every open PR since #7123.

Gate it on a `bundled_libm` capability, the mechanism issue #1400 established for host-dependent tests. Verified both ways: the test still runs and passes where the capability is present, and reports `SKIP` rather than failing where it is absent. The sibling `clib_source_from_vfs_ce` passes on Windows and is left ungated.