### PR TITLE
[python] Raise TypeError for len() on a class without __len__

### DIFF
--- a/regression/python/github_7085/main.py
+++ b/regression/python/github_7085/main.py
@@ -1,0 +1,23 @@
+class C:
+    def __init__(self) -> None:
+        self.i: int = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> int:
+        if self.i >= 3:
+            raise StopIteration
+        self.i = self.i + 1
+        return self.i
+
+
+def main():
+    n: int = 0
+    c = C()
+    for v in c:
+        n = n + 1
+    assert n == 3
+
+
+main()

--- a/regression/python/github_7085/test.desc
+++ b/regression/python/github_7085/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 6
+^  uncaught exception: TypeError$
+^VERIFICATION FAILED$

--- a/regression/python/github_7085_caught/main.py
+++ b/regression/python/github_7085_caught/main.py
@@ -1,0 +1,16 @@
+class C:
+    def __init__(self) -> None:
+        self.i: int = 0
+
+
+def main():
+    c = C()
+    caught: int = 0
+    try:
+        n: int = len(c)
+    except TypeError:
+        caught = 1
+    assert caught == 1
+
+
+main()

--- a/regression/python/github_7085_caught/test.desc
+++ b/regression/python/github_7085_caught/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7085_dead_loop_fail/main.py
+++ b/regression/python/github_7085_dead_loop_fail/main.py
@@ -1,0 +1,21 @@
+class C:
+    def __init__(self) -> None:
+        self.i: int = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> int:
+        if self.i >= 3:
+            raise StopIteration
+        self.i = self.i + 1
+        return self.i
+
+
+def main():
+    c = C()
+    for v in c:
+        assert False
+
+
+main()

--- a/regression/python/github_7085_dead_loop_fail/test.desc
+++ b/regression/python/github_7085_dead_loop_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 6
+^  uncaught exception: TypeError$
+^VERIFICATION FAILED$

--- a/regression/python/github_7085_dunder_len/main.py
+++ b/regression/python/github_7085_dunder_len/main.py
@@ -1,0 +1,14 @@
+class Box:
+    def __init__(self) -> None:
+        self.n: int = 7
+
+    def __len__(self) -> int:
+        return self.n
+
+
+def main():
+    b = Box()
+    assert len(b) == 7
+
+
+main()

--- a/regression/python/github_7085_dunder_len/test.desc
+++ b/regression/python/github_7085_dunder_len/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7085_dunder_len_fail/main.py
+++ b/regression/python/github_7085_dunder_len_fail/main.py
@@ -1,0 +1,14 @@
+class Box:
+    def __init__(self) -> None:
+        self.n: int = 7
+
+    def __len__(self) -> int:
+        return self.n
+
+
+def main():
+    b = Box()
+    assert len(b) == 8
+
+
+main()

--- a/regression/python/github_7085_dunder_len_fail/test.desc
+++ b/regression/python/github_7085_dunder_len_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 3
+^  assertion return_value\$___len__\$\d+ == 8$
+^VERIFICATION FAILED$

--- a/regression/python/github_7085_inherited_len/main.py
+++ b/regression/python/github_7085_inherited_len/main.py
@@ -1,0 +1,18 @@
+class Base:
+    def __init__(self) -> None:
+        self.n: int = 5
+
+    def __len__(self) -> int:
+        return self.n
+
+
+class Derived(Base):
+    pass
+
+
+def main():
+    d = Derived()
+    assert len(d) == 5
+
+
+main()

--- a/regression/python/github_7085_inherited_len/test.desc
+++ b/regression/python/github_7085_inherited_len/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7085_len_fail/main.py
+++ b/regression/python/github_7085_len_fail/main.py
@@ -1,0 +1,11 @@
+class C:
+    def __init__(self) -> None:
+        self.i: int = 0
+
+
+def main():
+    c = C()
+    assert len(c) == 0
+
+
+main()

--- a/regression/python/github_7085_len_fail/test.desc
+++ b/regression/python/github_7085_len_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 3
+^  uncaught exception: TypeError$
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_dunder.cpp
+++ b/src/python-frontend/converter/converter_dunder.cpp
@@ -59,12 +59,15 @@ symbolt *python_converter::find_dunder_method(
     return nullptr;
 
   symbol_id sid(file, class_name, dunder_name);
-  return find_symbol(sid.to_string());
+  if (symbolt *sym = find_symbol(sid.to_string()))
+    return sym;
+
+  return find_function_in_base_classes(
+    class_name, sid.to_string(), dunder_name, false);
 }
 
-bool python_converter::has_dunder_method(
-  const nlohmann::json &value_node,
-  const std::string &dunder_name)
+std::string
+python_converter::instance_class_name(const nlohmann::json &value_node)
 {
   std::string class_name = type_handler_.get_var_classname(value_node);
 
@@ -80,6 +83,15 @@ bool python_converter::has_dunder_method(
     if (func.is_object() && func.value("_type", "") == "Name")
       class_name = func.value("id", "");
   }
+
+  return class_name;
+}
+
+bool python_converter::has_dunder_method(
+  const nlohmann::json &value_node,
+  const std::string &dunder_name)
+{
+  const std::string class_name = instance_class_name(value_node);
 
   if (class_name.empty())
     return false;
@@ -214,6 +226,31 @@ bool python_converter::is_user_class_struct_type(const typet &t)
 bool python_converter::is_user_class_pointer(const typet &t)
 {
   return t.is_pointer() && is_user_class_struct_type(t.subtype());
+}
+
+bool python_converter::is_class_instance(const nlohmann::json &value_node)
+{
+  const std::string node_type = value_node.value("_type", "");
+  if (node_type == "Call")
+    return type_handler_.is_constructor_call(value_node);
+
+  if (node_type != "Name")
+    return false;
+
+  // The bound type decides, not the annotation's name: `a: List[int]` resolves
+  // to a class named List, but its struct is a model container that owns its
+  // own operator and length paths (#7085).
+  symbol_id sid(python_file(), current_classname(), current_function_name());
+  sid.set_object(value_node.value("id", ""));
+
+  symbolt *sym = find_symbol(sid.to_string());
+  if (!sym)
+    sym = find_symbol(sid.global_to_string());
+  if (!sym)
+    return false;
+
+  const typet &t = sym->get_type();
+  return is_user_class_pointer(t) || is_user_class_struct_type(t);
 }
 
 // move_symbol_to_context() only overwrites an existing symbol's type when

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -1,5 +1,6 @@
 #include <python-frontend/function_call/builder.h>
 #include <python-frontend/function_call/expr.h>
+#include <python-frontend/exception/python_exception_handler.h>
 #include <python-frontend/json_utils.h>
 #include <python-frontend/consteval/python_consteval.h>
 #include <python-frontend/python_converter.h>
@@ -330,6 +331,31 @@ bool python_converter::is_identity_function(
 
   return false;
 }
+
+exprt python_converter::get_len_on_class_instance(const nlohmann::json &element)
+{
+  if (
+    !element.contains("func") || !element["func"].is_object() ||
+    element["func"].value("_type", "") != "Name" ||
+    element["func"].value("id", "") != "len" || !element.contains("args") ||
+    !element["args"].is_array() || element["args"].size() != 1)
+    return nil_exprt();
+
+  const nlohmann::json &arg = element["args"][0];
+  if (has_dunder_method(arg, "__len__"))
+    return get_expr(
+      build_dunder_call(arg, "__len__", nlohmann::json::array(), element));
+
+  // Without a __len__ the builtin path measures the struct with strlen and
+  // reports 0, silently emptying any `for x in obj` bounded by len() (#7085).
+  const std::string cls = instance_class_name(arg);
+  if (!cls.empty() && is_class_instance(arg))
+    return get_exception_handler().gen_exception_raise(
+      "TypeError", "object of type '" + cls + "' has no len()");
+
+  return nil_exprt();
+}
+
 exprt python_converter::get_function_call(const nlohmann::json &element)
 {
   if (!element.contains("func") || element["_type"] != "Call")
@@ -1056,20 +1082,9 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
   }
 
-  // len(obj) where obj's class defines __len__: dispatch to obj.__len__().
-  // The builtin len path only recognises the model container types (list,
-  // tuple, dict, str/bytes), so a user-defined __len__ is otherwise ignored
-  // and len falls through to strlen over the struct — a wrong length.
-  if (
-    element.contains("func") && element["func"].is_object() &&
-    element["func"].value("_type", "") == "Name" &&
-    element["func"].value("id", "") == "len" && element.contains("args") &&
-    element["args"].is_array() && element["args"].size() == 1 &&
-    has_dunder_method(element["args"][0], "__len__"))
-  {
-    return get_expr(build_dunder_call(
-      element["args"][0], "__len__", nlohmann::json::array(), element));
-  }
+  if (exprt len_expr = get_len_on_class_instance(element);
+      len_expr.is_not_nil())
+    return len_expr;
 
   function_call_builder call_builder(*this, element);
   exprt call_expr = call_builder.build();

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -547,6 +547,11 @@ private:
 
   exprt get_function_call(const nlohmann::json &ast_block);
 
+  /// Lowers len(obj) when obj is a class instance -- dispatching to its
+  /// __len__, or raising TypeError as CPython does when it defines none.
+  /// Returns nil when @p element is not such a call.
+  exprt get_len_on_class_instance(const nlohmann::json &element);
+
   exprt get_block(
     const nlohmann::json &ast_block,
     bool is_function_body = false,
@@ -1281,6 +1286,14 @@ private:
   symbolt *find_dunder_method(
     const std::string &class_name,
     const std::string &dunder_name);
+
+  /// Class @p value_node is an instance of, or "" when it is not an instance.
+  /// Resolves both a bound name and a constructor temporary.
+  std::string instance_class_name(const nlohmann::json &value_node);
+
+  /// True when @p value_node denotes a user-defined class instance, as opposed
+  /// to a model container that merely resolves to a class name.
+  bool is_class_instance(const nlohmann::json &value_node);
   bool has_dunder_method(
     const nlohmann::json &value_node,
     const std::string &dunder_name);


### PR DESCRIPTION
`len()` on a class instance fell through to `strlen` over the struct and
reported 0, so a `for` loop the preprocessor lowers to an index loop bounded
by `len()` never ran, silently verifying a dead body. It now dispatches to an
inherited `__len__`, or raises `TypeError` as CPython does.

Fixes #7085
