### PR TITLE
[om] Give allocator_traits rebind_alloc and the nothrow copy traits

### DIFF
--- a/regression/esbmc-cpp/cpp/allocator_traits_rebind/main.cpp
+++ b/regression/esbmc-cpp/cpp/allocator_traits_rebind/main.cpp
@@ -1,0 +1,35 @@
+// [allocator.traits.types]: allocator_traits exposes rebind_alloc/rebind_traits
+// and the propagate_on_container_* traits. boost multi_index builds its node
+// allocators through rebind_alloc, and src/util/symtab/context.h is a
+// multi_index container -- so without it no ESBMC header reaching the symbol
+// table parses. See #5868.
+#include <memory>
+#include <type_traits>
+#include <cassert>
+
+int main()
+{
+  typedef std::allocator<int> ai;
+  typedef std::allocator_traits<ai> t;
+
+  static_assert(
+    std::is_same<t::rebind_alloc<char>, std::allocator<char> >::value,
+    "rebind_alloc");
+  static_assert(
+    std::is_same<t::rebind_traits<char>::allocator_type, std::allocator<char> >::value,
+    "rebind_traits");
+  static_assert(std::is_same<t::void_pointer, void *>::value, "void_pointer");
+  static_assert(
+    std::is_same<t::const_void_pointer, const void *>::value,
+    "const_void_pointer");
+  static_assert(!t::propagate_on_container_swap::value, "pocs");
+  static_assert(!t::propagate_on_container_copy_assignment::value, "pocca");
+
+  ai a;
+  ai b = t::select_on_container_copy_construction(a);
+  int *p = t::allocate(b, 4);
+  t::construct(b, p, 7);
+  assert(p[0] == 7);
+  t::deallocate(b, p, 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/allocator_traits_rebind/test.desc
+++ b/regression/esbmc-cpp/cpp/allocator_traits_rebind/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/allocator_traits_rebind_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/allocator_traits_rebind_fail/main.cpp
@@ -1,0 +1,17 @@
+// Anti-vacuity twin of allocator_traits_rebind: a rebound allocator really
+// allocates its own value_type, so the storage it hands back holds what was
+// constructed into it.
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  typedef std::allocator_traits<std::allocator<int> > t;
+  t::rebind_alloc<char> ca;
+  typedef std::allocator_traits<t::rebind_alloc<char> > ct;
+  char *p = ct::allocate(ca, 4);
+  ct::construct(ca, p, 'x');
+  assert(p[0] == 'y');
+  ct::deallocate(ca, p, 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/allocator_traits_rebind_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/allocator_traits_rebind_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/type_traits_nothrow_copy/main.cpp
+++ b/regression/esbmc-cpp/cpp/type_traits_nothrow_copy/main.cpp
@@ -1,0 +1,30 @@
+// [meta.unary.prop]: the nothrow copy/destroy traits. boost's iterator_facade
+// names is_nothrow_copy_constructible, which the model did not have -- only the
+// move forms. See #5868.
+#include <type_traits>
+#include <cassert>
+
+struct thrower
+{
+  thrower(const thrower &);
+  thrower &operator=(const thrower &);
+  ~thrower();
+};
+
+struct plain
+{
+  int a;
+};
+
+int main()
+{
+  static_assert(std::is_nothrow_copy_constructible<int>::value, "int");
+  static_assert(std::is_nothrow_copy_constructible<plain>::value, "plain");
+  static_assert(!std::is_nothrow_copy_constructible<thrower>::value, "thrower");
+  static_assert(std::is_nothrow_copy_assignable<plain>::value, "assign");
+  static_assert(!std::is_nothrow_copy_assignable<thrower>::value, "assign2");
+  static_assert(std::is_nothrow_destructible<plain>::value, "dtor");
+  static_assert(std::is_nothrow_copy_constructible_v<int>, "v");
+  assert(1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/type_traits_nothrow_copy/test.desc
+++ b/regression/esbmc-cpp/cpp/type_traits_nothrow_copy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/type_traits_nothrow_copy_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/type_traits_nothrow_copy_fail/main.cpp
@@ -1,0 +1,15 @@
+// Anti-vacuity twin of type_traits_nothrow_copy: the trait distinguishes a
+// throwing copy from a trivial one, so claiming otherwise must fail.
+#include <type_traits>
+#include <cassert>
+
+struct thrower
+{
+  thrower(const thrower &);
+};
+
+int main()
+{
+  assert(std::is_nothrow_copy_constructible<thrower>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/type_traits_nothrow_copy_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/type_traits_nothrow_copy_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -184,8 +184,30 @@ struct allocator_traits
   typedef typename Alloc::value_type value_type;
   typedef value_type *pointer;
   typedef const value_type *const_pointer;
+  typedef void *void_pointer;
+  typedef const void *const_void_pointer;
   typedef size_t size_type;
   typedef ptrdiff_t difference_type;
+
+  /* [allocator.traits.types]: rebind_alloc is Alloc::rebind<T>::other when the
+   * allocator supplies one, which every allocator the models see does --
+   * std::allocator above, and boost multi_index's, which needs rebind_alloc to
+   * build its node allocators. The standard's fallback of rewriting the first
+   * template argument is not modelled. */
+  template <class T>
+  using rebind_alloc = typename Alloc::template rebind<T>::other;
+  template <class T>
+  using rebind_traits = allocator_traits<rebind_alloc<T> >;
+
+  typedef false_type propagate_on_container_copy_assignment;
+  typedef false_type propagate_on_container_move_assignment;
+  typedef false_type propagate_on_container_swap;
+  typedef true_type is_always_equal;
+
+  static Alloc select_on_container_copy_construction(const Alloc &a)
+  {
+    return a;
+  }
 
   static pointer allocate(Alloc &a, size_type n)
   {

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -689,6 +689,32 @@ struct is_nothrow_move_constructible
 };
 
 template <class T>
+struct is_nothrow_copy_constructible
+  : integral_constant<
+      bool,
+      __is_nothrow_constructible(
+        T,
+        typename add_lvalue_reference<const T>::type)>
+{
+};
+
+template <class T>
+struct is_nothrow_copy_assignable
+  : integral_constant<
+      bool,
+      __is_nothrow_assignable(
+        typename add_lvalue_reference<T>::type,
+        typename add_lvalue_reference<const T>::type)>
+{
+};
+
+template <class T>
+struct is_nothrow_destructible
+  : integral_constant<bool, __is_nothrow_destructible(T)>
+{
+};
+
+template <class T>
 struct is_nothrow_move_assignable
   : integral_constant<
       bool,
@@ -920,6 +946,15 @@ template <class T>
 inline constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
 template <class T>
 inline constexpr bool is_destructible_v = is_destructible<T>::value;
+template <class T>
+inline constexpr bool is_nothrow_copy_constructible_v =
+  is_nothrow_copy_constructible<T>::value;
+template <class T>
+inline constexpr bool is_nothrow_copy_assignable_v =
+  is_nothrow_copy_assignable<T>::value;
+template <class T>
+inline constexpr bool is_nothrow_destructible_v =
+  is_nothrow_destructible<T>::value;
 template <class T>
 inline constexpr bool is_nothrow_move_constructible_v =
   is_nothrow_move_constructible<T>::value;


### PR DESCRIPTION
The dominant remaining operational-model gap on the self-verification path, plus the
trait beside it. `allocator_traits::rebind_alloc` is how boost multi_index builds its
node allocators, and `src/util/symtab/context.h` is a multi_index container -- so
nothing reaching ESBMC's symbol table parsed, and the one missing member cascaded into
most of the errors left on `src/goto-symex/execution_state.cpp`.

`is_nothrow_copy_constructible` is named by boost's `iterator_facade`; the model had
only the move forms.

Part of #5868.
