### PR TITLE
[om] Let list and forward_list hold an incomplete element type

### DIFF
--- a/regression/esbmc-cpp/list/list_incomplete_element_type/main.cpp
+++ b/regression/esbmc-cpp/list/list_incomplete_element_type/main.cpp
@@ -1,0 +1,30 @@
+// [container.requirements.general] (N4510, adopted for C++17) requires vector,
+// list and forward_list -- and only those three -- to accept an incomplete
+// element type. The models held their storage in by-value member arrays, which
+// need the element complete at instantiation, so the recursive member that
+// tree-shaped code declares did not parse. Contrast #7029: map is *not* obliged
+// to accept one, and libstdc++ doing so is a QoI extension.
+#include <list>
+#include <forward_list>
+#include <vector>
+#include <cassert>
+
+struct tree_node
+{
+  std::vector<tree_node> vec_kids;
+  std::list<tree_node> list_kids;
+  std::forward_list<tree_node> flist_kids;
+  int id;
+};
+
+int main()
+{
+  tree_node n;
+  n.id = 7;
+  assert(n.id == 7);
+  assert(n.vec_kids.empty());
+  assert(n.list_kids.empty());
+  assert(n.flist_kids.empty());
+  assert(n.list_kids.size() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/list/list_incomplete_element_type/test.desc
+++ b/regression/esbmc-cpp/list/list_incomplete_element_type/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_incomplete_element_type_fail/main.cpp
+++ b/regression/esbmc-cpp/list/list_incomplete_element_type_fail/main.cpp
@@ -1,0 +1,19 @@
+// Anti-vacuity twin of list_incomplete_element_type: the containers still hold
+// elements once the type is complete, so a wrong claim about one must fail.
+#include <list>
+#include <cassert>
+
+struct tree_node
+{
+  std::list<tree_node> kids;
+  int id;
+};
+
+int main()
+{
+  std::list<int> l;
+  l.push_back(1);
+  l.push_back(2);
+  assert(l.size() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/list/list_incomplete_element_type_fail/test.desc
+++ b/regression/esbmc-cpp/list/list_incomplete_element_type_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/src/cpp/library/forward_list
+++ b/src/cpp/library/forward_list
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include "definitions.h"
+#include "type_traits"
 #if __cplusplus >= 201103L
 #  include <initializer_list>
 #endif
@@ -20,6 +21,38 @@ namespace std
 // std::forward_list deliberately has no size(); mutation is expressed
 // relative to the *preceding* position, which is what before_begin and the
 // _after operations are for.
+
+// Mirrors __om_list_pool in <list>; forward_list has its own capacity.
+template <class node_t, bool complete>
+struct __om_fwd_pool;
+
+template <class node_t>
+struct __om_fwd_pool<node_t, true>
+{
+  node_t buf[FORWARD_LIST_MAX_SIZE];
+  void allocate()
+  {
+  }
+  void release()
+  {
+  }
+};
+
+template <class node_t>
+struct __om_fwd_pool<node_t, false>
+{
+  node_t *buf;
+  void allocate()
+  {
+    buf = static_cast<node_t *>(malloc(sizeof(node_t) * FORWARD_LIST_MAX_SIZE));
+    __ESBMC_assume(buf);
+  }
+  void release()
+  {
+    free(buf);
+  }
+};
+
 template <class T>
 class forward_list
 {
@@ -43,11 +76,13 @@ public:
     size_type next_idx;
   };
 
-  // Held behind a pointer, not as a by-value array: an array member requires
-  // the element type to be complete at instantiation.
-  // [container.requirements.general] (N4510) requires vector, list and
-  // forward_list to accept an incomplete element type.
-  node *_pool;
+  // [container.requirements.general] (N4510) requires forward_list to accept an
+  // incomplete element type, which a by-value `node _storage.buf[N]` member rules out.
+  // Only the complete specialisation of __om_fwd_pool names that array. The
+  // array is kept for the complete case because routing every access through a
+  // heap object costs symex enough to time the list suite out; see the same
+  // shape in <list>.
+  __om_fwd_pool<node, __om_list_complete<T>::value> _storage;
   size_type _head;
   size_type _free;
 
@@ -75,16 +110,16 @@ public:
 
     reference operator*()
     {
-      return owner->_pool[idx].data;
+      return owner->_storage.buf[idx].data;
     }
     pointer operator->()
     {
-      return &owner->_pool[idx].data;
+      return &owner->_storage.buf[idx].data;
     }
 
     iterator &operator++()
     {
-      idx = (idx == BEFORE_BEGIN) ? owner->_head : owner->_pool[idx].next_idx;
+      idx = (idx == BEFORE_BEGIN) ? owner->_head : owner->_storage.buf[idx].next_idx;
       return *this;
     }
     iterator operator++(int)
@@ -108,8 +143,7 @@ public:
 
   void __om_allocate()
   {
-    _pool = static_cast<node *>(malloc(sizeof(node) * FORWARD_LIST_MAX_SIZE));
-    __ESBMC_assume(_pool);
+    _storage.allocate();
   }
 
   forward_list() : _head(SENTINEL), _free(0)
@@ -119,7 +153,7 @@ public:
 
   ~forward_list()
   {
-    free(_pool);
+    _storage.release();
   }
 
 #if __cplusplus >= 201103L
@@ -146,7 +180,7 @@ public:
   {
     __om_allocate();
     for (size_type i = 0; i < x._free; i++)
-      _pool[i] = x._pool[i];
+      _storage.buf[i] = x._storage.buf[i];
   }
 
   forward_list<T> &operator=(const forward_list<T> &x)
@@ -156,7 +190,7 @@ public:
       _head = x._head;
       _free = x._free;
       for (size_type i = 0; i < x._free; i++)
-        _pool[i] = x._pool[i];
+        _storage.buf[i] = x._storage.buf[i];
     }
     return *this;
   }
@@ -173,11 +207,11 @@ public:
 
   reference front()
   {
-    return _pool[_head].data;
+    return _storage.buf[_head].data;
   }
   const_reference front() const
   {
-    return _pool[_head].data;
+    return _storage.buf[_head].data;
   }
 
   iterator before_begin()
@@ -198,15 +232,15 @@ public:
     __ESBMC_assert(
       _free < FORWARD_LIST_MAX_SIZE, "forward_list exceeded its bounded pool");
     size_type slot = _free++;
-    _pool[slot].data = value;
-    _pool[slot].next_idx = _head;
+    _storage.buf[slot].data = value;
+    _storage.buf[slot].next_idx = _head;
     _head = slot;
   }
 
   void pop_front()
   {
     __ESBMC_assert(_head != SENTINEL, "pop_front on an empty forward_list");
-    _head = _pool[_head].next_idx;
+    _head = _storage.buf[_head].next_idx;
   }
 
   void clear()
@@ -222,17 +256,17 @@ public:
     __ESBMC_assert(
       _free < FORWARD_LIST_MAX_SIZE, "forward_list exceeded its bounded pool");
     size_type slot = _free++;
-    _pool[slot].data = value;
+    _storage.buf[slot].data = value;
 
     if (pos.idx == BEFORE_BEGIN)
     {
-      _pool[slot].next_idx = _head;
+      _storage.buf[slot].next_idx = _head;
       _head = slot;
     }
     else
     {
-      _pool[slot].next_idx = _pool[pos.idx].next_idx;
-      _pool[pos.idx].next_idx = slot;
+      _storage.buf[slot].next_idx = _storage.buf[pos.idx].next_idx;
+      _storage.buf[pos.idx].next_idx = slot;
     }
     return iterator(this, slot);
   }
@@ -241,14 +275,14 @@ public:
   // follows it.
   iterator erase_after(iterator pos)
   {
-    size_type victim = (pos.idx == BEFORE_BEGIN) ? _head : _pool[pos.idx].next_idx;
+    size_type victim = (pos.idx == BEFORE_BEGIN) ? _head : _storage.buf[pos.idx].next_idx;
     __ESBMC_assert(victim != SENTINEL, "erase_after past the end");
 
-    size_type after = _pool[victim].next_idx;
+    size_type after = _storage.buf[victim].next_idx;
     if (pos.idx == BEFORE_BEGIN)
       _head = after;
     else
-      _pool[pos.idx].next_idx = after;
+      _storage.buf[pos.idx].next_idx = after;
     return iterator(this, after);
   }
 };

--- a/src/cpp/library/forward_list
+++ b/src/cpp/library/forward_list
@@ -1,6 +1,8 @@
 #ifndef __STL_FORWARD_LIST
 #define __STL_FORWARD_LIST
 
+#include <stdlib.h>
+
 #include "definitions.h"
 #if __cplusplus >= 201103L
 #  include <initializer_list>
@@ -41,7 +43,11 @@ public:
     size_type next_idx;
   };
 
-  node _pool[FORWARD_LIST_MAX_SIZE];
+  // Held behind a pointer, not as a by-value array: an array member requires
+  // the element type to be complete at instantiation.
+  // [container.requirements.general] (N4510) requires vector, list and
+  // forward_list to accept an incomplete element type.
+  node *_pool;
   size_type _head;
   size_type _free;
 
@@ -100,14 +106,27 @@ public:
 
   typedef iterator const_iterator;
 
+  void __om_allocate()
+  {
+    _pool = static_cast<node *>(malloc(sizeof(node) * FORWARD_LIST_MAX_SIZE));
+    __ESBMC_assume(_pool);
+  }
+
   forward_list() : _head(SENTINEL), _free(0)
   {
+    __om_allocate();
+  }
+
+  ~forward_list()
+  {
+    free(_pool);
   }
 
 #if __cplusplus >= 201103L
   /* Built back-to-front: push_front is the only O(1) insertion here. */
   forward_list(std::initializer_list<T> init) : _head(SENTINEL), _free(0)
   {
+    __om_allocate();
     for (const T *it = init.end(); it != init.begin();)
       this->push_front(*--it);
   }
@@ -115,6 +134,7 @@ public:
 
   forward_list(size_type n, const T &value) : _head(SENTINEL), _free(0)
   {
+    __om_allocate();
     for (size_type i = 0; i < n; i++)
       push_front(value);
   }
@@ -124,6 +144,7 @@ public:
   // rather than to the contents, on every pass-by-value.
   forward_list(const forward_list<T> &x) : _head(x._head), _free(x._free)
   {
+    __om_allocate();
     for (size_type i = 0; i < x._free; i++)
       _pool[i] = x._pool[i];
   }

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -14,6 +14,39 @@
 
 namespace std
 {
+
+// Only this specialisation names node[LIST_MAX_SIZE], so the incomplete case
+// never forms an array of an incomplete type.
+template <class node_t, bool complete>
+struct __om_list_pool;
+
+template <class node_t>
+struct __om_list_pool<node_t, true>
+{
+  node_t buf[LIST_MAX_SIZE];
+  void allocate()
+  {
+  }
+  void release()
+  {
+  }
+};
+
+template <class node_t>
+struct __om_list_pool<node_t, false>
+{
+  node_t *buf;
+  void allocate()
+  {
+    buf = static_cast<node_t *>(malloc(sizeof(node_t) * LIST_MAX_SIZE));
+    __ESBMC_assume(buf);
+  }
+  void release()
+  {
+    free(buf);
+  }
+};
+
 template <class T>
 class list
 {
@@ -43,13 +76,17 @@ public:
     size_type next_idx;
   };
 
-  // Held behind a pointer, not as a by-value array: an array member requires
-  // the element type to be complete at instantiation, which rules out the
-  // recursive list<Node> member that tree-shaped code declares.
-  // [container.requirements.general] (N4510) requires vector, list and
-  // forward_list to accept an incomplete element type. See #7029 for the same
-  // fix on map, which is *not* obliged to accept one.
-  node *_pool;
+  // [container.requirements.general] (N4510) requires list and forward_list to
+  // accept an incomplete element type, which a by-value `node _storage.buf[N]` member
+  // rules out: it completes `node`, and so `T`, at instantiation. Only the
+  // complete specialisation of __om_list_pool ever names that array, so the
+  // recursive list<Node> member tree-shaped code declares still instantiates.
+  //
+  // The array is kept for the complete case because the indirection is not
+  // free here: routing every `_storage.buf[i]` through a heap object costs symex
+  // enough to push list_sort-4 from ~5s to over the 120s cap. See #7029 for the
+  // same completeness fix on map, which is *not* obliged to accept one.
+  __om_list_pool<node, __om_list_complete<T>::value> _storage;
   size_type _sentinel_prev;
   size_type _sentinel_next;
   // Monotonic high-water mark for the pool. erase does not reclaim
@@ -59,8 +96,7 @@ public:
 
   void __om_allocate()
   {
-    _pool = static_cast<node *>(malloc(sizeof(node) * LIST_MAX_SIZE));
-    __ESBMC_assume(_pool);
+    _storage.allocate();
   }
 
   void _init()
@@ -76,7 +112,7 @@ public:
     __ESBMC_assert(_next_free < LIST_MAX_SIZE, "list capacity exceeded");
     size_type idx = _next_free;
     ++_next_free;
-    _pool[idx].data = x;
+    _storage.buf[idx].data = x;
     return idx;
   }
 
@@ -86,37 +122,37 @@ public:
   {
     if (pos_idx == SENTINEL)
     {
-      _pool[n_idx].prev_idx = _sentinel_prev;
-      _pool[n_idx].next_idx = SENTINEL;
+      _storage.buf[n_idx].prev_idx = _sentinel_prev;
+      _storage.buf[n_idx].next_idx = SENTINEL;
       if (_sentinel_prev != SENTINEL)
-        _pool[_sentinel_prev].next_idx = n_idx;
+        _storage.buf[_sentinel_prev].next_idx = n_idx;
       else
         _sentinel_next = n_idx;
       _sentinel_prev = n_idx;
     }
     else
     {
-      size_type prev = _pool[pos_idx].prev_idx;
-      _pool[n_idx].prev_idx = prev;
-      _pool[n_idx].next_idx = pos_idx;
+      size_type prev = _storage.buf[pos_idx].prev_idx;
+      _storage.buf[n_idx].prev_idx = prev;
+      _storage.buf[n_idx].next_idx = pos_idx;
       if (prev != SENTINEL)
-        _pool[prev].next_idx = n_idx;
+        _storage.buf[prev].next_idx = n_idx;
       else
         _sentinel_next = n_idx;
-      _pool[pos_idx].prev_idx = n_idx;
+      _storage.buf[pos_idx].prev_idx = n_idx;
     }
   }
 
   void _unlink(size_type n_idx)
   {
-    size_type p = _pool[n_idx].prev_idx;
-    size_type nx = _pool[n_idx].next_idx;
+    size_type p = _storage.buf[n_idx].prev_idx;
+    size_type nx = _storage.buf[n_idx].next_idx;
     if (p != SENTINEL)
-      _pool[p].next_idx = nx;
+      _storage.buf[p].next_idx = nx;
     else
       _sentinel_next = nx;
     if (nx != SENTINEL)
-      _pool[nx].prev_idx = p;
+      _storage.buf[nx].prev_idx = p;
     else
       _sentinel_prev = p;
   }
@@ -125,14 +161,14 @@ public:
   {
     if (idx == SENTINEL)
       return SENTINEL;
-    return _pool[idx].next_idx;
+    return _storage.buf[idx].next_idx;
   }
 
   size_type _prev_idx(size_type idx) const
   {
     if (idx == SENTINEL)
       return _sentinel_prev;
-    return _pool[idx].prev_idx;
+    return _storage.buf[idx].prev_idx;
   }
 
   class iterator
@@ -159,11 +195,11 @@ public:
 
     reference operator*()
     {
-      return owner->_pool[idx].data;
+      return owner->_storage.buf[idx].data;
     }
     pointer operator->()
     {
-      return &owner->_pool[idx].data;
+      return &owner->_storage.buf[idx].data;
     }
 
     iterator &operator++()
@@ -223,11 +259,11 @@ public:
 
     reference operator*()
     {
-      return owner->_pool[idx].data;
+      return owner->_storage.buf[idx].data;
     }
     pointer operator->()
     {
-      return &owner->_pool[idx].data;
+      return &owner->_storage.buf[idx].data;
     }
 
     reverse_iterator &operator++()
@@ -318,7 +354,7 @@ public:
   // Bulk pool copy bounded by x._next_free (the high-water mark — slots
   // at indices >= _next_free have never been allocated and are
   // unreachable through prev/next links). Copying by index instead of
-  // walking the linked list via x._pool[i].next_idx lets ESBMC unroll
+  // walking the linked list via x._storage.buf[i].next_idx lets ESBMC unroll
   // with a concrete index bound: under a low --unwind the loop
   // terminates naturally at x._next_free, instead of speculatively
   // unrolling to --unwind with a fresh LIST_MAX_SIZE-way case split per
@@ -331,7 +367,7 @@ public:
     _next_free = x._next_free;
     _size = x._size;
     for (size_type i = 0; i < x._next_free; i++)
-      _pool[i] = x._pool[i];
+      _storage.buf[i] = x._storage.buf[i];
   }
 
   list<T> &operator=(const list<T> &x)
@@ -343,14 +379,14 @@ public:
       _next_free = x._next_free;
       _size = x._size;
       for (size_type i = 0; i < x._next_free; i++)
-        _pool[i] = x._pool[i];
+        _storage.buf[i] = x._storage.buf[i];
     }
     return *this;
   }
 
   ~list()
   {
-    free(_pool);
+    _storage.release();
   }
 
   typedef iterator const_iterator;
@@ -439,20 +475,20 @@ public:
 
   reference front()
   {
-    return _pool[_sentinel_next].data;
+    return _storage.buf[_sentinel_next].data;
   }
   const_reference front() const
   {
-    return _pool[_sentinel_next].data;
+    return _storage.buf[_sentinel_next].data;
   }
 
   reference back()
   {
-    return _pool[_sentinel_prev].data;
+    return _storage.buf[_sentinel_prev].data;
   }
   const_reference back() const
   {
-    return _pool[_sentinel_prev].data;
+    return _storage.buf[_sentinel_prev].data;
   }
 
   void resize(size_type sz, value_type c = value_type())
@@ -532,7 +568,7 @@ public:
 
   iterator erase(iterator position)
   {
-    size_type nx = _pool[position.idx].next_idx;
+    size_type nx = _storage.buf[position.idx].next_idx;
     _unlink(position.idx);
     --_size;
     return iterator(this, nx);
@@ -797,10 +833,10 @@ public:
     // Swap prev/next of every node, then swap sentinel ends.
     for (size_type i = _sentinel_next; i != SENTINEL;)
     {
-      size_type nx = _pool[i].next_idx;
-      size_type p = _pool[i].prev_idx;
-      _pool[i].prev_idx = nx;
-      _pool[i].next_idx = p;
+      size_type nx = _storage.buf[i].next_idx;
+      size_type p = _storage.buf[i].prev_idx;
+      _storage.buf[i].prev_idx = nx;
+      _storage.buf[i].next_idx = p;
       i = nx;
     }
     size_type tmp = _sentinel_prev;
@@ -841,10 +877,10 @@ bool operator==(const list<int> &x, const list<int> &y)
   {
     if (ix == list<int>::SENTINEL)
       return iy == list<int>::SENTINEL;
-    if (x._pool[ix].data != y._pool[iy].data)
+    if (x._storage.buf[ix].data != y._storage.buf[iy].data)
       return false;
-    ix = x._pool[ix].next_idx;
-    iy = y._pool[iy].next_idx;
+    ix = x._storage.buf[ix].next_idx;
+    iy = y._storage.buf[iy].next_idx;
   }
   return true;
 }
@@ -864,10 +900,10 @@ bool operator==(const list<double> &x, const list<double> &y)
   {
     if (ix == list<double>::SENTINEL)
       return iy == list<double>::SENTINEL;
-    if (x._pool[ix].data != y._pool[iy].data)
+    if (x._storage.buf[ix].data != y._storage.buf[iy].data)
       return false;
-    ix = x._pool[ix].next_idx;
-    iy = y._pool[iy].next_idx;
+    ix = x._storage.buf[ix].next_idx;
+    iy = y._storage.buf[iy].next_idx;
   }
   return true;
 }

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -1,6 +1,8 @@
 #ifndef __STL_LIST
 #define __STL_LIST
 
+#include <stdlib.h>
+
 #include "definitions.h"
 #include "type_traits"
 #include "vector"
@@ -41,13 +43,25 @@ public:
     size_type next_idx;
   };
 
-  node _pool[LIST_MAX_SIZE];
+  // Held behind a pointer, not as a by-value array: an array member requires
+  // the element type to be complete at instantiation, which rules out the
+  // recursive list<Node> member that tree-shaped code declares.
+  // [container.requirements.general] (N4510) requires vector, list and
+  // forward_list to accept an incomplete element type. See #7029 for the same
+  // fix on map, which is *not* obliged to accept one.
+  node *_pool;
   size_type _sentinel_prev;
   size_type _sentinel_next;
   // Monotonic high-water mark for the pool. erase does not reclaim
   // slots; total alloc per list instance is bounded by LIST_MAX_SIZE.
   size_type _next_free;
   size_type _size;
+
+  void __om_allocate()
+  {
+    _pool = static_cast<node *>(malloc(sizeof(node) * LIST_MAX_SIZE));
+    __ESBMC_assume(_pool);
+  }
 
   void _init()
   {
@@ -263,12 +277,14 @@ public:
 
   list()
   {
+    __om_allocate();
     _init();
   }
 
 #if __cplusplus >= 201103L
   list(std::initializer_list<value_type> init)
   {
+    __om_allocate();
     _init();
     for (const value_type *it = init.begin(); it != init.end(); ++it)
       this->push_back(*it);
@@ -277,6 +293,7 @@ public:
 
   list(size_type n, const value_type &value = value_type())
   {
+    __om_allocate();
     _init();
     for (size_type i = 0; i < n; i++)
       push_back(value);
@@ -284,6 +301,7 @@ public:
 
   list(value_type *t1, value_type *t2)
   {
+    __om_allocate();
     _init();
     for (value_type *p = t1; p != t2; ++p)
       push_back(*p);
@@ -291,6 +309,7 @@ public:
 
   list(iterator first, iterator last)
   {
+    __om_allocate();
     _init();
     for (iterator it = first; it != last; ++it)
       push_back(*it);
@@ -306,6 +325,7 @@ public:
   // step on the symbolic next_idx.
   list(const list<T> &x)
   {
+    __om_allocate();
     _sentinel_prev = x._sentinel_prev;
     _sentinel_next = x._sentinel_next;
     _next_free = x._next_free;
@@ -330,6 +350,7 @@ public:
 
   ~list()
   {
+    free(_pool);
   }
 
   typedef iterator const_iterator;

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -1011,6 +1011,28 @@ using aligned_storage_t = typename aligned_storage<Len, Align>::type;
 
 #endif // __cplusplus >= 201103L
 
+
+// void_t over a value, so sizeof(T) can be used as the SFINAE probe.
+template <__SIZE_TYPE__>
+struct __om_list_void
+{
+  typedef void type;
+};
+
+// True when T is complete here. A member array of an incomplete type is
+// ill-formed, so a container's pool shape has to be chosen on this.
+template <class T, class = void>
+struct __om_list_complete
+{
+  static const bool value = false;
+};
+
+template <class T>
+struct __om_list_complete<T, typename __om_list_void<sizeof(T)>::type>
+{
+  static const bool value = true;
+};
+
 } // namespace std
 
 #endif // ESBMC_TYPE_TRAITS


### PR DESCRIPTION
[container.requirements.general] (N4510, adopted for C++17) requires `vector`, `list` and
`forward_list` -- and only those three -- to accept an incomplete element type. Both
models held their nodes in by-value member arrays, which need the element complete at
instantiation, so a recursive `list<Node>` member did not parse. `goto_programt::instructiont`
and `xmlt` are two such members in ESBMC's own headers.

The pools now sit behind pointers allocated per constructor, the same shape #7029 used for
`map` -- with the difference that `map` is *not* obliged to accept an incomplete
`mapped_type` (libstdc++ doing so is a QoI extension), whereas these three are.

Part of #5868.
