### PR TITLE
[python] Give dynamically-typed variables a verdict on is/== compares

### DIFF
--- a/regression/python/dynamic_type_eq_tagged/main.py
+++ b/regression/python/dynamic_type_eq_tagged/main.py
@@ -1,0 +1,11 @@
+# Comparing two tagged variables directly. Both branches give the pair equal
+# values, so `x == y` holds on either path. Issue #7075.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+    y = 1
+else:
+    x = "ab"
+    y = "ab"
+assert x == y

--- a/regression/python/dynamic_type_eq_tagged/test.desc
+++ b/regression/python/dynamic_type_eq_tagged/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_eq_tagged_bound_fail/main.py
+++ b/regression/python/dynamic_type_eq_tagged_bound_fail/main.py
@@ -1,0 +1,11 @@
+# A tagged str past the byte compare's modelled bound is reported, not
+# silently answered. CPython prints True here; ESBMC refuses to claim it.
+
+cond = nondet_bool()
+if cond:
+    x = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    y = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+else:
+    x = 1
+    y = 1
+assert x == y

--- a/regression/python/dynamic_type_eq_tagged_bound_fail/test.desc
+++ b/regression/python/dynamic_type_eq_tagged_bound_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*tagged str exceeds the modelled bound.*$

--- a/regression/python/dynamic_type_eq_tagged_crosstype/main.py
+++ b/regression/python/dynamic_type_eq_tagged_crosstype/main.py
@@ -1,0 +1,11 @@
+# The two tagged operands hold different Python types on either path. Python
+# compares across types as unequal rather than coercing.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+    y = "a"
+else:
+    x = "a"
+    y = 1
+assert x != y

--- a/regression/python/dynamic_type_eq_tagged_crosstype/test.desc
+++ b/regression/python/dynamic_type_eq_tagged_crosstype/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_eq_tagged_num_fail/main.py
+++ b/regression/python/dynamic_type_eq_tagged_num_fail/main.py
@@ -1,0 +1,11 @@
+# The numeric arm of the tagged-vs-tagged compare, isolated: the pair is equal
+# on the str path, so only a wrong numeric compare could make this hold.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+    y = 2
+else:
+    x = "ab"
+    y = "ab"
+assert x == y

--- a/regression/python/dynamic_type_eq_tagged_num_fail/test.desc
+++ b/regression/python/dynamic_type_eq_tagged_num_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*assertion return_value.*python_scalar_eq_obj.*$

--- a/regression/python/dynamic_type_eq_tagged_size/main.py
+++ b/regression/python/dynamic_type_eq_tagged_size/main.py
@@ -1,0 +1,12 @@
+# Two tagged strings of different lengths, the longer on the left and holding
+# an embedded NUL. Without the length check the byte compare would run past
+# the end of the shorter payload instead of stopping.
+
+cond = nondet_bool()
+if cond:
+    x = "a\x00b"
+    y = "a"
+else:
+    x = 1
+    y = 2
+assert x != y

--- a/regression/python/dynamic_type_eq_tagged_size/test.desc
+++ b/regression/python/dynamic_type_eq_tagged_size/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_eq_tagged_str_fail/main.py
+++ b/regression/python/dynamic_type_eq_tagged_str_fail/main.py
@@ -1,0 +1,11 @@
+# The str arm, isolated: the pair is equal on the numeric path, so only a
+# wrong byte compare could make this hold.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+    y = 1
+else:
+    x = "ab"
+    y = "ac"
+assert x == y

--- a/regression/python/dynamic_type_eq_tagged_str_fail/test.desc
+++ b/regression/python/dynamic_type_eq_tagged_str_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*assertion return_value.*python_scalar_eq_obj.*$

--- a/regression/python/dynamic_type_is_call_unsupported/main.py
+++ b/regression/python/dynamic_type_is_call_unsupported/main.py
@@ -1,0 +1,13 @@
+# `is` against a call is refused rather than folded to a constant: folding
+# would discard the call, and with it the exception it raises.
+
+def f():
+    raise ValueError("boom")
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+r = x is f()
+assert True

--- a/regression/python/dynamic_type_is_call_unsupported/test.desc
+++ b/regression/python/dynamic_type_is_call_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: operator 'Is' on a dynamically-typed variable is not yet supported$

--- a/regression/python/dynamic_type_is_none/main.py
+++ b/regression/python/dynamic_type_is_none/main.py
@@ -1,0 +1,9 @@
+# A tagged variable only ever holds a number or a string, so `is None` is
+# False on every path. Issue #7075: this used to abort the frontend.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+assert x is not None

--- a/regression/python/dynamic_type_is_none/test.desc
+++ b/regression/python/dynamic_type_is_none/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_is_none_fail/main.py
+++ b/regression/python/dynamic_type_is_none_fail/main.py
@@ -1,0 +1,9 @@
+# The identity check is genuinely evaluated, not folded away: asserting the
+# wrong direction is detected.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+assert x is None

--- a/regression/python/dynamic_type_is_none_fail/test.desc
+++ b/regression/python/dynamic_type_is_none_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*assertion 0$

--- a/src/c2goto/library/python/scalar.c
+++ b/src/c2goto/library/python/scalar.c
@@ -58,6 +58,39 @@ __ESBMC_HIDE:;
   return *(const long long *)tagged->value == value;
 }
 
+// Tagged-vs-tagged equality. Dispatching on `type_id` before any byte compare
+// keeps the numeric arm at a fixed width, so only two tagged strings reach
+// the byte loop below, which the numeric case would otherwise pay for too.
+int __python_scalar_eq_obj(
+  const PyObject *a,
+  const PyObject *b,
+  size_t num_type_id)
+{
+__ESBMC_HIDE:;
+  // Python compares across types as unequal rather than coercing.
+  if (a->type_id != b->type_id)
+    return 0;
+  if (a->type_id == num_type_id)
+    return *(const long long *)a->value == *(const long long *)b->value;
+  if (a->size != b->size)
+    return 0;
+  // `.size` is only known at runtime, so memcmp's loop bound would be
+  // symbolic and never unwind to completion; a compile-time bound keeps this
+  // loop finite. Do not "simplify" it back to memcmp. `.size` counts the
+  // trailing NUL, so the limit here is 255 characters -- one below the length
+  // bound __python_strnlen_bounded applies.
+  __ESBMC_assert(
+    a->size <= ESBMC_PY_STRNLEN_BOUND, "tagged str exceeds the modelled bound");
+  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
+  {
+    if (i >= a->size)
+      break;
+    if (((const uint8_t *)a->value)[i] != ((const uint8_t *)b->value)[i])
+      return 0;
+  }
+  return 1;
+}
+
 int __python_scalar_eq_str(
   const PyObject *tagged,
   size_t type_id,

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -899,6 +899,44 @@ bool python_converter::needs_zero_division_guard(
          !in_contract_clause_;
 }
 
+
+/// A tagged-scalar operand needs runtime dispatch instead of any of the
+/// static-type-driven paths, none of which know how to handle a PyObject-shaped
+/// operand.
+exprt python_converter::handle_tagged_scalar_binop(
+  const std::string &op,
+  const exprt &lhs,
+  const exprt &rhs,
+  const nlohmann::json &left,
+  const nlohmann::json &right,
+  const nlohmann::json &element)
+{
+  if (op == "Eq" || op == "NotEq")
+    return dynamic_type_handler_.handle_comparison(op, lhs, rhs);
+  if (op == "Add" || op == "Sub" || op == "Div")
+    return dynamic_type_handler_.handle_arithmetic(
+      op, lhs, rhs, get_location_from_decl(element));
+
+  // Tagging only ever stores a number or a string (get_var_assign rejects every
+  // other rvalue), so a tagged operand is never None. Only a literal None folds:
+  // any other operand may carry side effects that get_expr has not emitted yet,
+  // and returning a constant would discard them.
+  if (op == "Is" || op == "IsNot")
+  {
+    const auto &other =
+      type_handler_.is_tagged_scalar_type(lhs.type()) ? right : left;
+    if (
+      other.value("_type", "") == "Constant" && other.contains("value") &&
+      other["value"].is_null())
+      return migrate_expr_back(
+        op == "IsNot" ? gen_true_expr() : gen_false_expr());
+  }
+
+  throw std::runtime_error(
+    "operator '" + op +
+    "' on a dynamically-typed variable is not yet supported");
+}
+
 exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 {
   // Extract left and right operands from AST
@@ -933,36 +971,10 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     op = element["ops"][0]["_type"].get<std::string>();
   assert(!op.empty());
 
-  // A tagged-scalar operand needs runtime dispatch instead of any of the
-  // static-type-driven paths below, none of which know how to handle a
-  // PyObject-shaped operand.
   if (
     type_handler_.is_tagged_scalar_type(lhs.type()) ||
     type_handler_.is_tagged_scalar_type(rhs.type()))
-  {
-    if (op == "Eq" || op == "NotEq")
-      return dynamic_type_handler_.handle_comparison(op, lhs, rhs);
-    if (op == "Add" || op == "Sub" || op == "Div")
-      return dynamic_type_handler_.handle_arithmetic(
-        op, lhs, rhs, get_location_from_decl(element));
-    // Tagging only ever stores a number or a string (get_var_assign rejects
-    // every other rvalue), so a tagged operand is never None. Only a literal
-    // None folds: any other operand may carry side effects that get_expr has
-    // not emitted yet, and returning a constant would discard them.
-    if (op == "Is" || op == "IsNot")
-    {
-      const auto &other =
-        type_handler_.is_tagged_scalar_type(lhs.type()) ? right : left;
-      if (
-        other.value("_type", "") == "Constant" && other.contains("value") &&
-        other["value"].is_null())
-        return migrate_expr_back(
-          op == "IsNot" ? gen_true_expr() : gen_false_expr());
-    }
-    throw std::runtime_error(
-      "operator '" + op +
-      "' on a dynamically-typed variable is not yet supported");
-  }
+    return handle_tagged_scalar_binop(op, lhs, rhs, left, right, element);
 
   // Handle type identity checks (e.g., y is int, x is str)
   exprt type_identity_result =

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -899,7 +899,6 @@ bool python_converter::needs_zero_division_guard(
          !in_contract_clause_;
 }
 
-
 /// A tagged-scalar operand needs runtime dispatch instead of any of the
 /// static-type-driven paths, none of which know how to handle a PyObject-shaped
 /// operand.
@@ -918,9 +917,9 @@ exprt python_converter::handle_tagged_scalar_binop(
       op, lhs, rhs, get_location_from_decl(element));
 
   // Tagging only ever stores a number or a string (get_var_assign rejects every
-  // other rvalue), so a tagged operand is never None. Only a literal None folds:
-  // any other operand may carry side effects that get_expr has not emitted yet,
-  // and returning a constant would discard them.
+  // other rvalue), so a tagged operand is never None. Only a literal None
+  // folds: any other operand may carry side effects that get_expr has not
+  // emitted yet, and returning a constant would discard them.
   if (op == "Is" || op == "IsNot")
   {
     const auto &other =

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -945,6 +945,20 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     if (op == "Add" || op == "Sub" || op == "Div")
       return dynamic_type_handler_.handle_arithmetic(
         op, lhs, rhs, get_location_from_decl(element));
+    // Tagging only ever stores a number or a string (get_var_assign rejects
+    // every other rvalue), so a tagged operand is never None. Only a literal
+    // None folds: any other operand may carry side effects that get_expr has
+    // not emitted yet, and returning a constant would discard them.
+    if (op == "Is" || op == "IsNot")
+    {
+      const auto &other =
+        type_handler_.is_tagged_scalar_type(lhs.type()) ? right : left;
+      if (
+        other.value("_type", "") == "Constant" && other.contains("value") &&
+        other["value"].is_null())
+        return migrate_expr_back(
+          op == "IsNot" ? gen_true_expr() : gen_false_expr());
+    }
     throw std::runtime_error(
       "operator '" + op +
       "' on a dynamically-typed variable is not yet supported");

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -363,16 +363,20 @@ exprt dynamic_type_handler::handle_comparison(
   const bool lhs_tagged = type_handler_.is_tagged_scalar_type(lhs.type());
   const bool rhs_tagged = type_handler_.is_tagged_scalar_type(rhs.type());
 
-  // A tagged-vs-tagged compare needs a size known only at runtime (each
-  // operand's `.size` field), so the byte-compare's memcmp fallback can't
-  // unwind to termination even though the real value is always tiny.
-  // Comparing against a literal doesn't have this problem, since its size is
-  // a compile-time constant. Refuse cleanly rather than risk a
-  // non-terminating run.
   if (lhs_tagged && rhs_tagged)
-    throw std::runtime_error(
-      "comparing two dynamically-typed variables directly is not yet "
-      "supported");
+  {
+    const symbolt *eq_obj_func =
+      converter_.symbol_table().find_symbol("c:@F@__python_scalar_eq_obj");
+    assert(eq_obj_func && "__python_scalar_eq_obj not found in symbol table");
+    exprt call = build_call_expr(
+      *eq_obj_func,
+      int_type(),
+      {build_address_of(lhs),
+       build_address_of(rhs),
+       type_handler_.tagged_scalar_type_id(long_long_int_type())});
+    exprt equal = build_equal(call, from_integer(1, int_type()));
+    return op == "NotEq" ? build_not(equal) : equal;
+  }
 
   exprt result =
     lhs_tagged ? build_eq_literal(lhs, rhs) : build_eq_literal(rhs, lhs);
@@ -518,7 +522,8 @@ exprt dynamic_type_handler::handle_arithmetic(
   const bool lhs_tagged = type_handler_.is_tagged_scalar_type(lhs.type());
   const bool rhs_tagged = type_handler_.is_tagged_scalar_type(rhs.type());
 
-  // Same runtime-size concern as handle_comparison's tagged-vs-tagged case.
+  // Equality can settle a type_id mismatch without knowing either type;
+  // arithmetic cannot, since it needs the concrete type to pick an operation.
   if (lhs_tagged && rhs_tagged)
     throw std::runtime_error(
       "'" + op +

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1092,6 +1092,17 @@ private:
     const nlohmann::json &left,
     const nlohmann::json &right);
 
+  /// Runtime dispatch for a tagged-scalar (PyObject-shaped) operand, which none
+  /// of the static-type-driven paths can handle. Throws for an operator this
+  /// mode does not model.
+  exprt handle_tagged_scalar_binop(
+    const std::string &op,
+    const exprt &lhs,
+    const exprt &rhs,
+    const nlohmann::json &left,
+    const nlohmann::json &right,
+    const nlohmann::json &element);
+
   /**
    * @brief Converts function calls in binary operands to side effects.
    * @param lhs Left operand expression (may be modified).


### PR DESCRIPTION
`x is None` and `==` between two tagged variables each threw `std::runtime_error`, so a single dynamically-typed variable aborted the whole run.

The identity check folds against a literal `None` only — a tagged variable never holds one, and folding a computed operand would drop its side effects. Equality dispatches on `.type_id`, keeping the numeric arm fixed-width and the str arm under a compile-time bound rather than a memcmp over the runtime `.size`.

Refs #7075 — assigning a container to a tagged variable is still refused, so the issue stays open.