### PR TITLE
[ci] Give each process its own profraw so a killed test cannot void coverage

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -317,4 +317,7 @@ jobs:
           path: coverage.info
           retention-days: 5
       - name: Clean tmp files
+        # Also on failure: a cancelled or failed run otherwise leaves its
+        # profraw directory behind, and this runner's /tmp fills up.
+        if: always()
         run: rm -rf /tmp/esbmc*

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -284,14 +284,14 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies and build with coverage
         env:
-          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m.profraw"
+          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m_%p.profraw"
         run: ./scripts/build.sh -b Debug -k ON
       - name: Run tests
         env:
-          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m.profraw"
+          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m_%p.profraw"
         run: mkdir -p build/coverage && cd build/ && ctest -j32 --progress . || true
       - name: Merge coverage data
-        run: llvm-profdata merge -sparse /tmp/esbmc-coverage/*.profraw -o build/merged.profdata
+        run: llvm-profdata merge -sparse --failure-mode=warn /tmp/esbmc-coverage/*.profraw -o build/merged.profdata
       - name: Generate lcov coverage report
         run: |
           llvm-cov export -format=lcov \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,18 +28,18 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies and build with coverage
         env:
-          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m.profraw"
+          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m_%p.profraw"
         run: ./scripts/build.sh -b Debug -k ON
       - name: Run tests
         env:
-          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m.profraw"
+          LLVM_PROFILE_FILE: "/tmp/esbmc-coverage/coverage-%m_%p.profraw"
         # -I <shard>,,4 walks the suite with a stride of 4, so the shards
         # partition it exactly and interleave slow suites across all four.
         run: |
           mkdir -p build/coverage && cd build/ && \
           ctest -j4 --progress --timeout 600 -I ${{ matrix.shard }},,4 . || true
       - name: Merge coverage data
-        run: llvm-profdata merge -sparse /tmp/esbmc-coverage/*.profraw -o build/merged.profdata
+        run: llvm-profdata merge -sparse --failure-mode=warn /tmp/esbmc-coverage/*.profraw -o build/merged.profdata
       - name: Generate lcov coverage report
         run: |
           llvm-cov export -format=lcov \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,6 +59,11 @@ jobs:
           name: coverage-shard-${{ matrix.shard }}
           path: coverage.info
           retention-days: 1
+      - name: Clean tmp files
+        # Four shards each leave a profraw directory behind otherwise, and a
+        # run that fails before this point never cleans up at all.
+        if: always()
+        run: rm -rf /tmp/esbmc*
 
   upload:
     name: Upload coverage to Codecov


### PR DESCRIPTION
`LLVM_PROFILE_FILE` used `%m`, which pools every process into a single file per binary signature. The suite runs under `ctest ... || true` and kills tests on timeout; a process killed mid-write corrupts that shared file, and `llvm-profdata` then reports `no profile can be merged` and fails the job with the entire run lost (seen on #7097 after a 3h17m run).

Adding `%p` means a killed test loses only its own profile, and `--failure-mode=warn` lets the merge tolerate a bad input instead of discarding everything. Applied to both `pull_request.yml` and `push.yml`, which carried the same pattern.