### PR TITLE
[om] Fix basic_string size, resize and max_size

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7138/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7138/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s("abc");
+
+  // [string.capacity]: size() returns size_type, an unsigned integer type, so
+  // the subtraction wraps instead of going negative.
+  assert(s.size() - 5 > 0);
+  assert(s.size() == s.length());
+
+  std::string e;
+  assert(e.size() - 1 > 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7138/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7138/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7139/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s("abc");
+
+  // [string.capacity]: n == 0 is in range; it erases every element.
+  s.resize(0);
+  assert(s.size() == 0);
+  assert(s.empty());
+  assert(s.c_str()[0] == '\0');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7139_2/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_2/main.cpp
@@ -10,12 +10,14 @@ int main()
   assert(s.size() == 5);
   assert(s[3] == '\0');
   assert(s[4] == '\0');
+  assert(s[0] == 'a' && s[1] == 'b' && s[2] == 'c');
 
   std::string t("ab");
   t.resize(4, 'x');
   assert(t.size() == 4);
   assert(t[2] == 'x');
   assert(t[3] == 'x');
+  assert(t == "abxx");
 
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_7139_2/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_2/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  // [string.capacity]: resize(n) is equivalent to resize(n, charT()), so the
+  // appended positions are null characters, not whatever the buffer held.
+  std::string s("abc");
+  s.resize(5);
+  assert(s.size() == 5);
+  assert(s[3] == '\0');
+  assert(s[4] == '\0');
+
+  std::string t("ab");
+  t.resize(4, 'x');
+  assert(t.size() == 4);
+  assert(t[2] == 'x');
+  assert(t[3] == 'x');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139_2/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7139_3/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_3/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s("abcde");
+
+  // [string.capacity]: n <= size() erases the last size() - n elements, and
+  // [string.accessors] makes c_str() a null-terminated array of size() chars.
+  s.resize(2);
+  assert(s.size() == 2);
+  assert(s[0] == 'a');
+  assert(s[1] == 'b');
+  assert(s.c_str()[2] == '\0');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139_3/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7139_4/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_4/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s("abcde");
+
+  // [string.accessors]: c_str() is a null-terminated array of size() chars, so
+  // shrinking has to move the terminator down to n.
+  s.resize(2, 'x');
+  assert(s.size() == 2);
+  assert(s.c_str()[2] == '\0');
+  assert(s == "ab");
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139_4/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7139_5/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_5/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  // n == capacity() is the largest resize this fixed-capacity model admits;
+  // the terminator at str[n] must still land inside the buffer.
+  std::string s;
+  s.resize(127);
+  assert(s.size() == 127);
+  assert(s.c_str()[127] == '\0');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139_5/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 130
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7139_6/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_6/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  // Deliberately unbounded: the grow loop has to converge on its own, without
+  // --unwind or --incremental-bmc bounding it.
+  std::string s("abc");
+  s.resize(5);
+  assert(s.size() == 5);
+  assert(s[4] == '\0');
+
+  std::string t("abc");
+  t.resize(5, 'x');
+  assert(t.size() == 5);
+  assert(t[4] == 'x');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139_6/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7139_cap_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_cap_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <string>
+
+int main()
+{
+  // One past capacity(): the guard must reject this rather than write the
+  // terminator out of bounds.
+  std::string s;
+  s.resize(128);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139_cap_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139_cap_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--incremental-bmc
+^\s+file .* function resize$
+^\s+String capacity exceeded$
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_7139_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7139_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <string>
+
+int main()
+{
+  std::string s("abc");
+
+  // The operational model backs every string with a STRING_CAPACITY buffer, so
+  // a resize past it is out of range rather than a reallocation.
+  s.resize(200);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7139_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7139_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--incremental-bmc
+^\s+file .* function resize$
+^\s+String capacity exceeded$
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_7140/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7140/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s("abc");
+
+  // [string.require]: size() <= max_size() holds after every operation, and
+  // capacity() cannot exceed max_size() either.
+  assert(s.max_size() >= s.size());
+  assert(s.max_size() >= s.capacity());
+
+  std::string e;
+  assert(e.max_size() > 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7140/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7140/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -623,7 +623,7 @@ public:
   void resize(size_t n);
   size_t capacity() const;
   size_t max_size() const;
-  int size() const;
+  size_t size() const;
   size_t rfind(basic_string<CharT, Traits, Alloc> &s, size_t pos = npos) const;
   size_t rfind(const char *s, size_t pos = npos) const;
   size_t rfind(char *s) const;
@@ -1656,15 +1656,16 @@ size_t basic_string<CharT, Traits, Alloc>::capacity() const
   return STRING_CAPACITY - 1;
 }
 
+// [string.require] keeps size() <= max_size() invariant across every
+// operation, so an unconstrained value here is not a sound over-approximation.
 template <typename CharT, typename Traits, typename Alloc>
 size_t basic_string<CharT, Traits, Alloc>::max_size() const
 {
-  int nondet;
-  return nondet;
+  return STRING_CAPACITY - 1;
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-int basic_string<CharT, Traits, Alloc>::size() const
+size_t basic_string<CharT, Traits, Alloc>::size() const
 {
   return this->_size;
 }
@@ -1673,34 +1674,20 @@ template <typename CharT, typename Traits, typename Alloc>
 void basic_string<CharT, Traits, Alloc>::resize(size_t n)
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(n > 0, "The parameter must be greater than zero");
-  int num = this->_size, i;
-  char tmp[STRING_CAPACITY];
-  for (i = 0; i < n; i++)
-  {
-    tmp[i] = this->str[i];
-  }
-  tmp[i] = '\0';
-  this->_size = n;
-  for (i = 0; i < n; i++)
-    this->str[i] = tmp[i];
-  this->str[i] = '\0';
+  this->resize(n, CharT());
 }
 
+// [string.accessors]: c_str() is terminated at size(), so a shrink moves the
+// terminator down to n instead of leaving it at the old size.
 template <typename CharT, typename Traits, typename Alloc>
 void basic_string<CharT, Traits, Alloc>::resize(size_t n, char c)
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(n > 0, "The parameter must be greater than zero");
-  int num, i;
-  num = this->length();
-  basic_string<CharT, Traits, Alloc> tmp(this->str);
-  this->_size = n;
-  for (i = 0; i < num; i++)
-    this->str[i] = tmp.str[i];
-  for (i = num; i < (this->_size); i++)
+  __ESBMC_assert(n < STRING_CAPACITY, "String capacity exceeded");
+  for (size_t i = this->_size; i < n; i++)
     this->str[i] = c;
-  this->str[i] = '\0';
+  this->_size = n;
+  this->str[n] = '\0';
 }
 
 template <typename CharT, typename Traits, typename Alloc>

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1684,8 +1684,13 @@ void basic_string<CharT, Traits, Alloc>::resize(size_t n, char c)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(n < STRING_CAPACITY, "String capacity exceeded");
-  for (size_t i = this->_size; i < n; i++)
-    this->str[i] = c;
+  // Iterate from 0 rather than from _size: a size_t index starting at the
+  // symbolic old size wraps past the i < n test, so the loop never converges
+  // unless the caller bounds it with --unwind or --incremental-bmc.
+  size_t old_size = this->_size;
+  for (size_t i = 0; i < n; i++)
+    if (i >= old_size)
+      this->str[i] = c;
   this->_size = n;
   this->str[n] = '\0';
 }


### PR DESCRIPTION
size() returned int, losing the unsigned wrap [string.capacity] requires, and
max_size() returned an unconstrained nondet that could fall below size().
resize() rejected n == 0, and the two-arg overload grew with uninitialised
bytes and left the terminator at the old size when shrinking, so
resize(2, 'x') on "abcde" reported size() == 2 with c_str() == "abcde".

Fixes #7138
Fixes #7139
Fixes #7140