### PR TITLE
[regression] Accept both clang spellings of the thrown type name

### DIFF
--- a/regression/esbmc-cpp/string/github_6338_at_uncaught_fail/test.desc
+++ b/regression/esbmc-cpp/string/github_6338_at_uncaught_fail/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --std c++17 --incremental-bmc
 ^VERIFICATION FAILED$
-^\s*uncaught exception: class std::out_of_range$
+^\s*uncaught exception: std::out_of_range$

--- a/regression/esbmc-cpp/string/github_6338_at_uncaught_fail/test.desc
+++ b/regression/esbmc-cpp/string/github_6338_at_uncaught_fail/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --std c++17 --incremental-bmc
 ^VERIFICATION FAILED$
-^\s*uncaught exception: std::out_of_range$
+^\s*uncaught exception: (class )?std::out_of_range$


### PR DESCRIPTION
The uncaught-exception verdict names the thrown type from its tag symbol, and
`get_decl_name` prepends clang's record kind only from clang 22 on (fcfdf1afc2).
The same throw therefore reads `std::out_of_range` under clang 21 and
`class std::out_of_range` under clang 22, so pinning either spelling fails on the
other. Make the record kind optional instead.

Refs #6338