### PR TITLE
[om] Add std::reference_wrapper, ref/cref and is_object

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_is_object/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_object/main.cpp
@@ -1,0 +1,15 @@
+#include <type_traits>
+#include <cassert>
+struct S {};
+int main()
+{
+  static_assert(std::is_object<int>::value, "int is an object type");
+  static_assert(std::is_object<S>::value, "class is an object type");
+  static_assert(std::is_object<int *>::value, "pointer is an object type");
+  static_assert(std::is_object<int[3]>::value, "array is an object type");
+  static_assert(!std::is_object<void>::value, "void is not");
+  static_assert(!std::is_object<int &>::value, "reference is not");
+  static_assert(!std::is_object<int()>::value, "function is not");
+  static_assert(std::is_object_v<int>, "_v alias");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_object/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_object/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_reference_wrapper/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_reference_wrapper/main.cpp
@@ -1,0 +1,18 @@
+#include <functional>
+#include <cassert>
+int main()
+{
+  int n = 3;
+  std::reference_wrapper<int> r = std::ref(n);
+  r.get() = 7;
+  assert(n == 7);
+
+  int m = r;
+  assert(m == 7);
+
+  std::reference_wrapper<const int> c = std::cref(n);
+  assert(c.get() == 7);
+  n = 9;
+  assert(c.get() == 9);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_reference_wrapper/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_reference_wrapper/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  int n = 3;
+  std::reference_wrapper<int> r = std::ref(n);
+  // The wrapper aliases n, so writing through it is visible in n.
+  r.get() = 7;
+  assert(n == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_tuple/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_tuple/main.cpp
@@ -1,0 +1,12 @@
+#include <tuple>
+#include <functional>
+#include <cassert>
+int main()
+{
+  int n = 1;
+  auto t = std::make_tuple(std::ref(n), 2);
+  std::get<0>(t) = 5;
+  assert(n == 5);
+  assert(std::get<1>(t) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_tuple/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_reference_wrapper_tuple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -19,6 +19,62 @@ namespace std
 
 #if __cplusplus >= 201103L
 
+// [refwrap]: a CopyConstructible, CopyAssignable wrapper around a reference.
+// The rvalue overloads of ref/cref are deleted so that binding a temporary is a
+// diagnostic rather than a dangling wrapper.
+template <class T>
+class reference_wrapper
+{
+  T *ptr;
+
+public:
+  typedef T type;
+
+  reference_wrapper(T &t) noexcept : ptr(&t)
+  {
+  }
+
+  operator T &() const noexcept
+  {
+    return *ptr;
+  }
+
+  T &get() const noexcept
+  {
+    return *ptr;
+  }
+};
+
+template <class T>
+reference_wrapper<T> ref(T &t) noexcept
+{
+  return reference_wrapper<T>(t);
+}
+
+template <class T>
+reference_wrapper<T> ref(reference_wrapper<T> t) noexcept
+{
+  return t;
+}
+
+template <class T>
+void ref(const T &&) = delete;
+
+template <class T>
+reference_wrapper<const T> cref(const T &t) noexcept
+{
+  return reference_wrapper<const T>(t);
+}
+
+template <class T>
+reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept
+{
+  return reference_wrapper<const T>(t.get());
+}
+
+template <class T>
+void cref(const T &&) = delete;
+
 // Base class for callable objects
 class callable_base
 {

--- a/src/cpp/library/tuple
+++ b/src/cpp/library/tuple
@@ -214,29 +214,6 @@ constexpr bool operator>=(const tuple<T1...> &lhs, const tuple<T2...> &rhs)
   return !(lhs < rhs);
 }
 
-// Minimal reference_wrapper needed by unwrap_refwrapper below.
-// The full implementation lives in <functional>; this stub is sufficient
-// for make_tuple to strip reference_wrapper<T> → T& at compile time.
-template <class T>
-class reference_wrapper
-{
-  T *ptr_;
-
-public:
-  using type = T;
-  reference_wrapper(T &ref) noexcept : ptr_(&ref)
-  {
-  }
-  operator T &() const noexcept
-  {
-    return *ptr_;
-  }
-  T &get() const noexcept
-  {
-    return *ptr_;
-  }
-};
-
 template <class T>
 struct unwrap_refwrapper
 {

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -494,6 +494,16 @@ struct is_reference : integral_constant<bool, is_lvalue_reference<T>::value ||
 {
 };
 
+// [meta.unary.comp]: an object type is any type that is not a function type,
+// not a reference type, and not cv void.
+template <class T>
+struct is_object
+  : integral_constant<
+      bool,
+      !is_function<T>::value && !is_reference<T>::value && !is_void<T>::value>
+{
+};
+
 // make_unsigned
 template <class T>
 struct make_unsigned;
@@ -908,6 +918,8 @@ inline constexpr bool is_trivially_copyable_v =
   is_trivially_copyable<T>::value;
 template <class T>
 inline constexpr bool is_class_v = is_class<T>::value;
+template <class T>
+inline constexpr bool is_object_v = is_object<T>::value;
 template <class T>
 inline constexpr bool is_polymorphic_v = is_polymorphic<T>::value;
 template <class T>


### PR DESCRIPTION
`<functional>` had no `reference_wrapper` at all, so `std::cref` was the first
parse error in 13 of a 60-TU sample of ESBMC's own sources, and `is_object`
was missing from `<type_traits>` in 4 more. `<tuple>` carried a private copy of
`reference_wrapper` for `unwrap_refwrapper`; it now shares the one definition.

Refs #5868
