### PR TITLE
[om] Define is_convertible by copy-initialization, not static_cast

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit/main.cpp
@@ -1,0 +1,33 @@
+#include <type_traits>
+
+struct target
+{
+};
+struct explicit_src
+{
+  explicit operator target() const;
+};
+struct implicit_src
+{
+  operator target() const;
+};
+
+int main()
+{
+  static_assert(
+    !std::is_convertible<explicit_src, target>::value,
+    "an explicit operator is not an implicit conversion");
+  static_assert(
+    !std::is_convertible<const explicit_src &, target>::value,
+    "same through a const reference");
+  static_assert(
+    std::is_convertible<implicit_src, target>::value,
+    "a non-explicit operator still converts");
+
+  static_assert(std::is_convertible<int, long>::value, "arithmetic");
+  static_assert(!std::is_convertible<int, target>::value, "unrelated");
+  static_assert(std::is_convertible<void, void>::value, "[meta.rel]: void");
+  static_assert(!std::is_convertible<void, int>::value, "[meta.rel]: void");
+  static_assert(!std::is_convertible<int, int[3]>::value, "[meta.rel]: array");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit_fail/main.cpp
@@ -1,0 +1,20 @@
+#include <type_traits>
+#include <cassert>
+
+struct target
+{
+};
+struct explicit_src
+{
+  explicit operator target() const
+  {
+    return target();
+  }
+};
+
+int main()
+{
+  // [meta.rel] makes this false; asserting the pre-fix answer must fail.
+  assert((std::is_convertible<explicit_src, target>::value));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_convertible_explicit_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -844,17 +844,40 @@ struct invoke_result : detail::invoke_result_impl<void, F, Args...>
 template <class F, class... Args>
 using invoke_result_t = typename invoke_result<F, Args...>::type;
 
-// is_convertible (simplified)
+// is_convertible
 namespace detail
 {
+// [meta.rel]: the trait is defined by copy-initialising the return value of
+// `To test() { return declval<From>(); }`, so passing by value is the test --
+// a static_cast here would also accept an `explicit` conversion operator.
+template <class To>
+auto test_convertible_dest(To) -> void;
+
 template <class From, class To>
-auto test_convertible(int) -> decltype(static_cast<To>(declval<From>()), true_type{});
+auto test_convertible(int)
+  -> decltype(test_convertible_dest<To>(declval<From>()), true_type{});
 template <class From, class To>
 false_type test_convertible(...);
+
+template <class From, class To>
+struct is_convertible_impl : decltype(test_convertible<From, To>(0))
+{
+};
+
+// [meta.rel]: when To is a function or array type, or From is void, the result
+// is is_void<To> -- the by-value probe above cannot be formed for those.
+template <class From, class To>
+struct is_convertible_base
+  : conditional<
+      is_void<From>::value || is_function<To>::value || is_array<To>::value,
+      is_void<To>,
+      is_convertible_impl<From, To>>::type
+{
+};
 } // namespace detail
 
 template <class From, class To>
-struct is_convertible : decltype(detail::test_convertible<From, To>(0))
+struct is_convertible : detail::is_convertible_base<From, To>
 {
 };
 


### PR DESCRIPTION
The probe was `static_cast<To>(declval<From>())`, which is an explicit
conversion, so a type whose only path to `To` is an `explicit operator To()`
reported convertible. [meta.rel] defines the trait by copy-initializing a `To`
return value, so a by-value probe is the test, plus the void / function / array
special cases.

This is what made fmt's two `fstring` constructors ambiguous: `FMT_COMPILE_STRING`
derives from `compile_string` *and* declares an `explicit` conversion to
`basic_string_view`, so both candidates stayed viable. On a 60-TU sample of
ESBMC's own sources the ambiguity was the first error in 31 files; it is now
absent from all of them.

Refs #5868
