### PR TITLE
[om] Order deques lexicographically and const-qualify comparators

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7149_const_relational/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7149_const_relational/main.cpp
@@ -1,0 +1,24 @@
+#include <deque>
+#include <map>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  const std::vector<int> v(3, 1), w(3, 1);
+  assert(v == w);
+  assert(!(v != w));
+
+  const std::deque<int> p, q;
+  assert(p == q);
+  assert(!(p != q));
+
+  std::multimap<int, int> a, b;
+  a.insert(std::pair<int, int>(1, 2));
+  b.insert(std::pair<int, int>(1, 2));
+  const std::multimap<int, int> &ca = a;
+  const std::multimap<int, int> &cb = b;
+  assert(ca == cb);
+  assert(!(ca != cb));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7149_const_relational/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7149_const_relational/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical/main.cpp
@@ -1,0 +1,16 @@
+#include <deque>
+#include <cassert>
+int main()
+{
+  std::deque<int> a;
+  a.push_back(2);
+  std::deque<int> b;
+  b.push_back(1);
+  b.push_back(3);
+  assert(!(a <= b));
+  assert(a > b);
+  assert(!(a < b));
+  assert(b < a);
+  assert(a >= b);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <deque>
+#include <cassert>
+
+int main()
+{
+  std::deque<int> a;
+  a.push_back(2);
+  std::deque<int> b;
+  b.push_back(1);
+  b.push_back(3);
+  // Ordering by size instead of lexicographically would make this hold.
+  assert(a <= b);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7149_deque_lexicographical_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -858,33 +858,51 @@ public:
   }
 
   // comparators:
-  bool operator==(const deque<T> &rhv)
+  bool operator==(const deque<T> &rhv) const
   {
     if (this->size() != rhv.size())
       return false;
-    int i = 0;
-    while (i != this->size())
-    {
+    for (size_type i = 0; i < this->size(); i++)
       if (this->at(i) != rhv[i])
         return false;
-      i++;
-    }
     return true;
   }
 
-  bool operator!=(const deque<T> &rhv)
+  bool operator!=(const deque<T> &rhv) const
   {
     return (!(*this == rhv));
   }
 
-  bool operator>=(const deque<T> &rhv)
+  /* [container.requirements]: the ordering is the lexicographical comparison
+   * of the two ranges, so the first differing element decides it and the
+   * lengths matter only when one range is a prefix of the other. Comparing
+   * sizes instead made {2} <= {1, 3}. */
+  bool operator<(const deque<T> &rhv) const
   {
-    return ((*this == rhv) || (this->size() > rhv.size()));
+    size_type n = this->size() < rhv.size() ? this->size() : rhv.size();
+    for (size_type i = 0; i < n; i++)
+    {
+      if ((*this)[i] < rhv[i])
+        return true;
+      if (rhv[i] < (*this)[i])
+        return false;
+    }
+    return this->size() < rhv.size();
   }
 
-  bool operator<=(const deque<T> &rhv)
+  bool operator>(const deque<T> &rhv) const
   {
-    return ((*this == rhv) || (this->size() < rhv.size()));
+    return rhv < *this;
+  }
+
+  bool operator>=(const deque<T> &rhv) const
+  {
+    return !(*this < rhv);
+  }
+
+  bool operator<=(const deque<T> &rhv) const
+  {
+    return !(rhv < *this);
   }
 
 private:

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -2259,7 +2259,7 @@ public:
   }
 #endif
 
-  bool operator==(multimap &y)
+  bool operator==(const multimap &y) const
   {
     if (this->_size != y._size)
       return false;
@@ -2271,7 +2271,7 @@ public:
     return true;
   }
 
-  bool operator!=(multimap &y)
+  bool operator!=(const multimap &y) const
   {
     if (this->_size != y._size)
       return true;

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -962,21 +962,17 @@ public:
   }
 
   // comparators:
-  bool operator==(const vector &rhv)
+  bool operator==(const vector &rhv) const
   {
     if (this->size() != rhv.size())
       return false;
-    int i = 0;
-    while (i != this->size())
-    {
+    for (size_type i = 0; i < this->size(); i++)
       if (this->at(i) != rhv[i])
         return false;
-      i++;
-    }
     return true;
   }
 
-  bool operator!=(const vector &rhv)
+  bool operator!=(const vector &rhv) const
   {
     return (!(*this == rhv));
   }


### PR DESCRIPTION
`deque`'s `operator<=`/`operator>=` compared sizes, so `{2} <= {1, 3}` held, and
it declared no `operator<`/`operator>` at all. `<vector>` had the same defect and
was already fixed; this reuses that implementation and its
[container.requirements] note.

`deque`'s, `vector`'s and `multimap`'s equality operators were also non-const
members, so none of them could be called on a const container. `multimap`'s pair
took its argument by non-const reference as well.

Fixes #7149
