### PR TITLE
[om] Add list::emplace_back, emplace_front and emplace

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_list_emplace/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_list_emplace/main.cpp
@@ -1,0 +1,41 @@
+#include <list>
+#include <cassert>
+
+struct point
+{
+  int x;
+  int y;
+  point() : x(0), y(0)
+  {
+  }
+  point(int a, int b) : x(a), y(b)
+  {
+  }
+};
+
+int main()
+{
+  std::list<point> l;
+  point &b = l.emplace_back(1, 2);
+  assert(b.x == 1 && b.y == 2);
+  assert(l.size() == 1);
+  assert(l.back().x == 1);
+
+  point &f = l.emplace_front(3, 4);
+  assert(f.x == 3);
+  assert(l.size() == 2);
+  assert(l.front().y == 4);
+  assert(l.back().x == 1);
+
+  std::list<int> n;
+  n.emplace_back(5);
+  n.emplace(n.begin(), 6);
+  assert(n.size() == 2);
+  assert(n.front() == 6);
+  assert(n.back() == 5);
+
+  // The returned reference aliases the element.
+  n.emplace_back(7) = 8;
+  assert(n.back() == 8);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_list_emplace/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_list_emplace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_list_emplace_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_list_emplace_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <list>
+#include <cassert>
+
+int main()
+{
+  std::list<int> l;
+  l.emplace_back(5);
+  l.emplace_front(6);
+  // emplace_front puts the element at the front, not the back.
+  assert(l.back() == 6);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_list_emplace_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_list_emplace_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -8,6 +8,7 @@
 #include "vector"
 #if __cplusplus >= 201103L
 #  include <initializer_list>
+#  include <utility> /* std::forward */
 #endif
 
 #define LIST_MAX_SIZE 20
@@ -512,6 +513,28 @@ public:
     _link_before(i, _sentinel_next);
     ++_size;
   }
+
+#if __cplusplus >= 201103L
+  template <class... Args>
+  reference emplace_back(Args &&...args)
+  {
+    push_back(value_type(std::forward<Args>(args)...));
+    return back();
+  }
+
+  template <class... Args>
+  reference emplace_front(Args &&...args)
+  {
+    push_front(value_type(std::forward<Args>(args)...));
+    return front();
+  }
+
+  template <class... Args>
+  iterator emplace(iterator position, Args &&...args)
+  {
+    return insert(position, value_type(std::forward<Args>(args)...));
+  }
+#endif
 
   void pop_back()
   {


### PR DESCRIPTION
`<list>` had no `emplace_back`, `emplace_front` or `emplace`, which made
`emplace_back` the first parse error in 21 of a 60-TU sample of ESBMC's own
sources (`std::list<goto_programt::instructiont>`, `std::list<xmlt>`). They
forward to the corresponding `push_back`/`push_front`/`insert`, matching how
`<vector>` already models `emplace_back`.

Note that the model still requires a default-constructible element type — the
node pool is a fixed array — so this does not extend `list` to the
emplace-only types the standard allows. That limitation is unchanged and
pre-existing.

Refs #5868
