### PR TITLE
[om] Make allocator_traits work with a minimal allocator

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_minimal_allocator/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_minimal_allocator/main.cpp
@@ -1,0 +1,45 @@
+#include <memory>
+#include <cassert>
+#include <cstdlib>
+
+// [allocator.requirements] requires only these three members.
+template <class T>
+struct minimal_alloc
+{
+  typedef T value_type;
+  T *allocate(std::size_t n)
+  {
+    return static_cast<T *>(malloc(sizeof(T) * n));
+  }
+  void deallocate(T *p, std::size_t)
+  {
+    free(p);
+  }
+};
+
+int main()
+{
+  typedef std::allocator_traits<minimal_alloc<int>> tr;
+  minimal_alloc<int> a;
+
+  assert(tr::max_size(a) == std::size_t(-1) / sizeof(int));
+
+  int *p = tr::allocate(a, 1);
+  if (p == NULL)
+    return 0;
+  tr::construct(a, p, 42);
+  assert(*p == 42);
+  tr::destroy(a, p);
+  tr::deallocate(a, p, 1);
+
+  // An allocator that does supply the members keeps using them.
+  std::allocator<int> sa;
+  int *q = std::allocator_traits<std::allocator<int>>::allocate(sa, 1);
+  if (q == NULL)
+    return 0;
+  std::allocator_traits<std::allocator<int>>::construct(sa, q, 7);
+  assert(*q == 7);
+  std::allocator_traits<std::allocator<int>>::destroy(sa, q);
+  std::allocator_traits<std::allocator<int>>::deallocate(sa, q, 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_minimal_allocator/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_minimal_allocator/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_minimal_allocator_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_minimal_allocator_fail/main.cpp
@@ -1,0 +1,30 @@
+#include <memory>
+#include <cassert>
+#include <cstdlib>
+
+template <class T>
+struct minimal_alloc
+{
+  typedef T value_type;
+  T *allocate(std::size_t n)
+  {
+    return static_cast<T *>(malloc(sizeof(T) * n));
+  }
+  void deallocate(T *p, std::size_t)
+  {
+    free(p);
+  }
+};
+
+int main()
+{
+  typedef std::allocator_traits<minimal_alloc<int>> tr;
+  minimal_alloc<int> a;
+  int *p = tr::allocate(a, 1);
+  if (p == NULL)
+    return 1;
+  tr::construct(a, p, 42);
+  // construct copy-initialises from the argument, so this is 42, not 0.
+  assert(*p == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_minimal_allocator_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_minimal_allocator_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback/main.cpp
@@ -1,0 +1,26 @@
+#include <memory>
+#include <type_traits>
+
+// An allocator that supplies no rebind member, as fmt::detail::allocator does.
+template <class T>
+struct plain_alloc
+{
+  typedef T value_type;
+  T *allocate(std::size_t n);
+  void deallocate(T *p, std::size_t n);
+};
+
+int main()
+{
+  typedef std::allocator_traits<plain_alloc<int>>::rebind_alloc<char> rebound;
+  static_assert(
+    std::is_same<rebound, plain_alloc<char>>::value,
+    "[allocator.traits.types]: rebind_alloc rewrites the first argument");
+  // An allocator that does supply rebind must keep working.
+  static_assert(
+    std::is_same<
+      std::allocator_traits<std::allocator<int>>::rebind_alloc<char>,
+      std::allocator<char>>::value,
+    "std::allocator's own rebind still wins");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback_fail/main.cpp
@@ -1,0 +1,19 @@
+#include <memory>
+#include <type_traits>
+#include <cassert>
+
+template <class T>
+struct plain_alloc
+{
+  typedef T value_type;
+  T *allocate(std::size_t n);
+  void deallocate(T *p, std::size_t n);
+};
+
+int main()
+{
+  typedef std::allocator_traits<plain_alloc<int>>::rebind_alloc<char> rebound;
+  // Rebinding rewrites the element type, so this is plain_alloc<char>.
+  assert((std::is_same<rebound, plain_alloc<int>>::value));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_rebind_alloc_fallback_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -207,6 +207,107 @@ struct rebind_alloc<
 {
   using type = typename Alloc::template rebind<T>::other;
 };
+
+/* [allocator.requirements] requires only value_type, allocate and deallocate of
+ * an allocator; [allocator.traits.members] supplies the rest when the allocator
+ * omits it. fmt's own allocator omits all three below.
+ *
+ * These are static members of class templates rather than free function
+ * templates, which do not get a GOTO body in OM headers (github #6063). */
+template <class Alloc, class = void>
+struct has_max_size : false_type
+{
+};
+template <class Alloc>
+struct has_max_size<Alloc, void_t<decltype(declval<const Alloc &>().max_size())>>
+  : true_type
+{
+};
+
+template <class Alloc, class T, bool = has_max_size<Alloc>::value>
+struct max_size_of
+{
+  static size_t get(const Alloc &a)
+  {
+    return a.max_size();
+  }
+};
+template <class Alloc, class T>
+struct max_size_of<Alloc, T, false>
+{
+  static size_t get(const Alloc &)
+  {
+    return size_t(-1) / sizeof(T);
+  }
+};
+
+template <class Alloc, class T, class = void>
+struct has_construct : false_type
+{
+};
+template <class Alloc, class T>
+struct has_construct<
+  Alloc,
+  T,
+  void_t<
+    decltype(declval<Alloc &>().construct(declval<T *>(), declval<const T &>()))>>
+  : true_type
+{
+};
+
+template <class Alloc, class T, bool = has_construct<Alloc, T>::value>
+struct construct_with
+{
+  static void copy(Alloc &a, T *p, const T &v)
+  {
+    a.construct(p, v);
+  }
+  static void value(Alloc &a, T *p)
+  {
+    a.construct(p);
+  }
+};
+template <class Alloc, class T>
+struct construct_with<Alloc, T, false>
+{
+  static void copy(Alloc &, T *p, const T &v)
+  {
+    ::new (static_cast<void *>(p)) T(v);
+  }
+  static void value(Alloc &, T *p)
+  {
+    ::new (static_cast<void *>(p)) T();
+  }
+};
+
+template <class Alloc, class T, class = void>
+struct has_destroy : false_type
+{
+};
+template <class Alloc, class T>
+struct has_destroy<
+  Alloc,
+  T,
+  void_t<decltype(declval<Alloc &>().destroy(declval<T *>()))>> : true_type
+{
+};
+
+template <class Alloc, class T, bool = has_destroy<Alloc, T>::value>
+struct destroy_with
+{
+  static void run(Alloc &a, T *p)
+  {
+    a.destroy(p);
+  }
+};
+template <class Alloc, class T>
+struct destroy_with<Alloc, T, false>
+{
+  static void run(Alloc &, T *p)
+  {
+    p->~T();
+  }
+};
 } // namespace __alloc_detail
 
 // Minimal allocator_traits (github #6063): delegates to the allocator's own
@@ -251,22 +352,22 @@ struct allocator_traits
 
   static void construct(Alloc &a, pointer p, const value_type &v)
   {
-    a.construct(p, v);
+    __alloc_detail::construct_with<Alloc, value_type>::copy(a, p, v);
   }
 
   static void construct(Alloc &a, pointer p)
   {
-    a.construct(p);
+    __alloc_detail::construct_with<Alloc, value_type>::value(a, p);
   }
 
   static void destroy(Alloc &a, pointer p)
   {
-    a.destroy(p);
+    __alloc_detail::destroy_with<Alloc, value_type>::run(a, p);
   }
 
   static size_type max_size(const Alloc &a)
   {
-    return a.max_size();
+    return __alloc_detail::max_size_of<Alloc, value_type>::get(a);
   }
 };
 #endif

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -174,6 +174,41 @@ struct default_delete
 };
 
 #if __cplusplus >= 201103L
+namespace __alloc_detail
+{
+/* [allocator.traits.types]: rebind_alloc<T> is Alloc::rebind<T>::other when
+ * that qualified-id is valid, and otherwise Alloc<T, Args...> for an Alloc
+ * spelled Alloc<U, Args...>. fmt's own allocator supplies no rebind member and
+ * needs the second form. */
+template <class Alloc, class T>
+struct replace_first_arg;
+
+template <
+  template <class, class...>
+  class Alloc,
+  class U,
+  class... Args,
+  class T>
+struct replace_first_arg<Alloc<U, Args...>, T>
+{
+  using type = Alloc<T, Args...>;
+};
+
+template <class Alloc, class T, class = void>
+struct rebind_alloc : replace_first_arg<Alloc, T>
+{
+};
+
+template <class Alloc, class T>
+struct rebind_alloc<
+  Alloc,
+  T,
+  void_t<typename Alloc::template rebind<T>::other>>
+{
+  using type = typename Alloc::template rebind<T>::other;
+};
+} // namespace __alloc_detail
+
 // Minimal allocator_traits (github #6063): delegates to the allocator's own
 // members. Static member functions of class templates convert to GOTO
 // correctly (unlike free-function templates in OM headers).
@@ -189,13 +224,8 @@ struct allocator_traits
   typedef size_t size_type;
   typedef ptrdiff_t difference_type;
 
-  /* [allocator.traits.types]: rebind_alloc is Alloc::rebind<T>::other when the
-   * allocator supplies one, which every allocator the models see does --
-   * std::allocator above, and boost multi_index's, which needs rebind_alloc to
-   * build its node allocators. The standard's fallback of rewriting the first
-   * template argument is not modelled. */
   template <class T>
-  using rebind_alloc = typename Alloc::template rebind<T>::other;
+  using rebind_alloc = typename __alloc_detail::rebind_alloc<Alloc, T>::type;
   template <class T>
   using rebind_traits = allocator_traits<rebind_alloc<T> >;
 


### PR DESCRIPTION
`allocator_traits` delegated to the allocator unconditionally, so an allocator
supplying only the members [allocator.requirements] mandates — `value_type`,
`allocate`, `deallocate` — did not work through the traits at all. fmt's own
allocator is exactly that shape, and it accounted for the first parse error in
23 TUs of a 60-TU sample of ESBMC's own sources (11 on `rebind`, 12 on
`max_size`).

[allocator.traits] supplies each of these when the allocator omits it:

- `rebind_alloc<T>` rewrites the first template argument, `Alloc<U, Args...>`
  to `Alloc<T, Args...>`.
- `max_size(a)` is `numeric_limits<size_type>::max() / sizeof(value_type)`.
- `construct(a, p, v)` is placement-new.
- `destroy(a, p)` is `p->~T()`.

Allocators that do supply these, `std::allocator` included, keep using their own.

Refs #5868
