### PR TITLE
[om] Const-qualify container iterator dereference

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref/main.cpp
@@ -1,0 +1,36 @@
+#include <list>
+#include <deque>
+#include <map>
+#include <set>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::list<int> l;
+  l.push_back(7);
+  const std::list<int>::iterator li = l.begin();
+  assert(*li == 7);
+
+  std::deque<int> d;
+  d.push_back(8);
+  const std::deque<int>::iterator di = d.begin();
+  assert(*di == 8);
+
+  std::vector<int> v;
+  v.push_back(9);
+  const std::vector<int>::iterator vi = v.begin();
+  assert(*vi == 9);
+
+  std::set<int> s;
+  s.insert(10);
+  const std::set<int>::iterator si = s.begin();
+  assert(*si == 10);
+
+  std::map<int, int> m;
+  m[1] = 11;
+  const std::map<int, int>::iterator mi = m.begin();
+  assert(mi->second == 11);
+  assert((*mi).first == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref_fail/main.cpp
@@ -1,0 +1,21 @@
+#include <deque>
+#include <cassert>
+
+struct box
+{
+  int v;
+};
+
+int main()
+{
+  std::deque<box> d;
+  box b;
+  b.v = 3;
+  d.push_back(b);
+
+  const std::deque<box> &cd = d;
+  std::deque<box>::const_iterator it = cd.begin();
+  // A nondet operator-> would leave this unfalsifiable; it must be refuted.
+  assert(it->v == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_const_iterator_deref_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_deque_const_iterator_arrow/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_deque_const_iterator_arrow/main.cpp
@@ -1,0 +1,23 @@
+#include <deque>
+#include <cassert>
+
+struct box
+{
+  int v;
+};
+
+int main()
+{
+  std::deque<box> d;
+  box b;
+  b.v = 3;
+  d.push_back(b);
+
+  const std::deque<box> &cd = d;
+  std::deque<box>::const_iterator it = cd.begin();
+  // operator-> was declared and never defined, so this returned a
+  // nondeterministic value that satisfied neither the property nor its negation.
+  assert(it->v == 3);
+  assert((*it).v == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_deque_const_iterator_arrow/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_deque_const_iterator_arrow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -49,12 +49,12 @@ public:
       return *this;
     }
 
-    T *operator->()
+    T *operator->() const
     {
       return pointer;
     }
 
-    T &operator*()
+    T &operator*() const
     {
       if (vec_pos != 0)
         return vec_pos[pos];
@@ -179,9 +179,15 @@ public:
       return *this;
     }
 
-    const T *operator->();
+    /* Declared and never defined: a declaration-only member converts as a call
+     * returning a nondeterministic value, so `it->m` satisfied neither the
+     * property nor its negation. */
+    const T *operator->() const
+    {
+      return &vec_pos[pos];
+    }
 
-    const T &operator*()
+    const T &operator*() const
     {
       return vec_pos[pos];
     }
@@ -286,12 +292,12 @@ public:
       return *this;
     }
 
-    T *operator->()
+    T *operator->() const
     {
       return pointer;
     }
 
-    T &operator*()
+    T &operator*() const
     {
       return *pointer;
     }

--- a/src/cpp/library/forward_list
+++ b/src/cpp/library/forward_list
@@ -108,11 +108,11 @@ public:
       return *this;
     }
 
-    reference operator*()
+    reference operator*() const
     {
       return owner->_storage.buf[idx].data;
     }
-    pointer operator->()
+    pointer operator->() const
     {
       return &owner->_storage.buf[idx].data;
     }

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -193,11 +193,11 @@ public:
       return *this;
     }
 
-    reference operator*()
+    reference operator*() const
     {
       return owner->_storage.buf[idx].data;
     }
-    pointer operator->()
+    pointer operator->() const
     {
       return &owner->_storage.buf[idx].data;
     }
@@ -257,11 +257,11 @@ public:
       return *this;
     }
 
-    reference operator*()
+    reference operator*() const
     {
       return owner->_storage.buf[idx].data;
     }
-    pointer operator->()
+    pointer operator->() const
     {
       return &owner->_storage.buf[idx].data;
     }

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -56,7 +56,7 @@ public:
   public:
     key_type *it_key;
     mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
 
     iterator(const iterator &x)
@@ -79,12 +79,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return this->it_pair;
     }
@@ -138,7 +138,7 @@ public:
   public:
     const key_type *it_key;
     const mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
 
     const_iterator(const const_iterator &x)
@@ -169,12 +169,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return this->it_pair;
     }
@@ -236,7 +236,7 @@ public:
   public:
     key_type *it_key;
     mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
     int *it_size;
 
@@ -262,12 +262,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return this->it_pair;
     }
@@ -359,7 +359,7 @@ public:
   public:
     const key_type *it_key;
     const mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
     const int *it_size;
 
@@ -394,12 +394,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return this->it_pair;
     }
@@ -1269,7 +1269,7 @@ public:
   public:
     key_type *it_key;
     mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
 
     iterator(const iterator &x)
@@ -1292,12 +1292,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return this->it_pair;
     }
@@ -1351,7 +1351,7 @@ public:
   public:
     const key_type *it_key;
     const mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
 
     const_iterator(const const_iterator &x)
@@ -1382,12 +1382,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return this->it_pair;
     }
@@ -1449,7 +1449,7 @@ public:
   public:
     key_type *it_key;
     mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
     int *it_size;
 
@@ -1475,12 +1475,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return this->it_pair;
     }
@@ -1572,7 +1572,7 @@ public:
   public:
     const key_type *it_key;
     const mapped_type *it_value;
-    value_type it_pair;
+    mutable value_type it_pair;
     int it_pos;
     const int *it_size;
 
@@ -1607,12 +1607,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &(this->it_pair);
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return this->it_pair;
     }

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -73,12 +73,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return base[pos];
     }
@@ -165,12 +165,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &base[pos];
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return base[pos];
     }
@@ -250,12 +250,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return base[pos];
     }
@@ -334,12 +334,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &base[pos];
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return base[pos];
     }
@@ -829,12 +829,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return base[pos];
     }
@@ -921,12 +921,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &base[pos];
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return base[pos];
     }
@@ -1005,12 +1005,12 @@ public:
       return *this;
     }
 
-    value_type *operator->()
+    value_type *operator->() const
     {
       return &base[pos];
     }
 
-    value_type &operator*()
+    value_type &operator*() const
     {
       return base[pos];
     }
@@ -1089,12 +1089,12 @@ public:
       return *this;
     }
 
-    const value_type *operator->()
+    const value_type *operator->() const
     {
       return &base[pos];
     }
 
-    const value_type &operator*()
+    const value_type &operator*() const
     {
       return base[pos];
     }


### PR DESCRIPTION
`operator*` and `operator->` were non-const members on `list`, `deque`, `map`,
`set` and `forward_list` iterators, so dereferencing a const iterator did not
compile. It was the first parse error in 20 of a 60-TU sample of ESBMC's own
sources (`const goto_programt::const_targett`). `<vector>` already had them
const.

Two consequences worth calling out:

- `map`'s iterators cache the `value_type` pair **by value**, so a const member
  could not hand out a modifiable reference to it. That cache is now `mutable`.
- `deque::const_iterator::operator->` was declared and never defined. A
  declaration-only member converts as a call returning a nondeterministic
  value, so `it->m` satisfied neither the property nor its negation. It now has
  a body, and `github_5868_deque_const_iterator_arrow` pins it.

Refs #5868
