### PR TITLE
[python] Annotate a for-loop over a constructor call with its class

### DIFF
--- a/regression/python/github_7083_sequence/main.py
+++ b/regression/python/github_7083_sequence/main.py
@@ -1,0 +1,21 @@
+class Seq:
+    def __init__(self) -> None:
+        self.n: int = 3
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, i: int) -> int:
+        if i >= self.n:
+            raise IndexError
+        return i * 2
+
+
+def main() -> None:
+    total: int = 0
+    for v in Seq():
+        total += v
+    assert total == 6
+
+
+main()

--- a/regression/python/github_7083_sequence/test.desc
+++ b/regression/python/github_7083_sequence/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7083_sequence_fail/main.py
+++ b/regression/python/github_7083_sequence_fail/main.py
@@ -1,0 +1,21 @@
+class Seq:
+    def __init__(self) -> None:
+        self.n: int = 3
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, i: int) -> int:
+        if i >= self.n:
+            raise IndexError
+        return i * 2
+
+
+def main() -> None:
+    total: int = 0
+    for v in Seq():
+        total += v
+    assert total == 7
+
+
+main()

--- a/regression/python/github_7083_sequence_fail/test.desc
+++ b/regression/python/github_7083_sequence_fail/test.desc
@@ -2,4 +2,3 @@ CORE
 main.py
 --unwind 6
 ^VERIFICATION FAILED$
-^\s*uncaught exception: TypeError$

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -407,7 +407,7 @@ ESBMC-Python provides an optional strict type-checking mode that enforces type c
 
 The current version of ESBMC-Python has the following limitations:
 
-- `for` loops over a user-defined iterable (a class implementing `__iter__`) are not supported. Iteration is supported over `range()`, list and tuple literals and variables, strings, dictionary views (`keys()`/`values()`/`items()`) and generator functions, as well as the `enumerate()`, `zip()` and `reversed()` builtins, nested loops, and the `for`/`else` form.
+- `for` loops over a user-defined iterable (a class implementing `__iter__`) are not supported; a class implementing the sequence protocol (`__len__` and `__getitem__`) is, and a class implementing neither raises `TypeError` as CPython does. Iteration is supported over `range()`, list and tuple literals and variables, strings, dictionary views (`keys()`/`values()`/`items()`) and generator functions, as well as the `enumerate()`, `zip()` and `reversed()` builtins, nested loops, and the `for`/`else` form.
 - List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, `remove()`, and `copy()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
 - Dictionary support is partial: the supported operations are literals, subscript access/assignment, `del`, `in`/`not in`, equality, iteration over `keys()`/`values()`/`items()`, `update()`, `get()`, `setdefault()`, `pop()`, and `popitem()`. Other methods (e.g., `copy()`) are not yet implemented.

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -2089,6 +2089,10 @@ class LoopMixin:
                 slice=ast.Name(id="Any", ctx=ast.Load()),
                 ctx=ast.Load(),
             )
+        # Any other annotation binds the constructor's __ESBMC_new_object
+        # result to a non-pointer lvalue (#7083).
+        elif annotation_id in getattr(self, "module_class_names", set()):
+            iter_annotation = ast.Name(id=annotation_id, ctx=ast.Load())
         else:
             # Use 'Any' instead of bare 'list' to avoid misinterpreting the
             # container type as the element type in the C++ converter,

--- a/src/python-frontend/preprocessor/type_inference_mixin.py
+++ b/src/python-frontend/preprocessor/type_inference_mixin.py
@@ -283,6 +283,11 @@ class TypeInferenceMixin:
         if (isinstance(iterable, ast.Call) and isinstance(iterable.func, ast.Name)
                 and iterable.func.id == "str"):
             return "str"
+        # `for v in C()`: naming the class keeps the "list" fallback from
+        # applying the list OM to a class instance (#7083).
+        instance_class = self._element_instance_class(iterable)
+        if instance_class:
+            return instance_class
         return "list"
 
     @staticmethod


### PR DESCRIPTION
`for v in C()` annotated the iteration temporary as a list and then constructed a class instance into it, so the constructor's `__ESBMC_new_object` result was bound to a non-pointer lvalue and symex aborted.

Naming the class instead routes the loop through the same `len()`/subscript lowering the variable-bound `c = C(); for v in c` form already uses: a class with `__len__`/`__getitem__` now verifies, and one with neither raises `TypeError` as CPython does.

Fixes #7083