### PR TITLE
[om] Make char_traits' single-return members constexpr

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr/main.cpp
@@ -1,0 +1,29 @@
+#include <string>
+#include <cassert>
+
+// nlohmann/json wraps char_traits in exactly this shape.
+struct wrapped
+{
+  typedef int int_type;
+  static constexpr int_type eof() noexcept
+  {
+    return static_cast<int_type>(std::char_traits<char>::eof());
+  }
+};
+
+int main()
+{
+  // [char.traits.specializations.char]: these are constexpr since C++11.
+  static_assert(wrapped::eof() == std::char_traits<char>::eof(), "eof");
+  static_assert(std::char_traits<char>::eq('a', 'a'), "eq");
+  static_assert(!std::char_traits<char>::lt('b', 'a'), "lt");
+  static_assert(std::char_traits<char>::to_int_type('a') == 97, "to_int_type");
+  static_assert(std::char_traits<char>::to_char_type(97) == 'a', "to_char_type");
+  static_assert(std::char_traits<char>::eq_int_type(1, 1), "eq_int_type");
+  static_assert(std::char_traits<char>::not_eof(97) == 97, "not_eof");
+  static_assert(std::char_traits<char>::not_eof(EOF) == 0, "not_eof at eof");
+
+  // The unsigned-char ordering of #7048 must survive the constexpr change.
+  assert(std::char_traits<char>::lt('a', '\xff'));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  // [char.traits.specializations.char]: eq and lt compare as unsigned char, so
+  // '\xff' is above 'a', not below it.
+  assert(std::char_traits<char>::lt('\xff', 'a'));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_char_traits_constexpr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/char_traits.h
+++ b/src/cpp/library/char_traits.h
@@ -39,12 +39,12 @@ struct char_traits
     return s;
   }
 
-  static bool eq(char_type c1, char_type c2) OM_NOEXCEPT
+  static OM_CONSTEXPR bool eq(char_type c1, char_type c2) OM_NOEXCEPT
   {
     return c1 == c2;
   }
 
-  static bool lt(char_type c1, char_type c2) OM_NOEXCEPT
+  static OM_CONSTEXPR bool lt(char_type c1, char_type c2) OM_NOEXCEPT
   {
     return c1 < c2;
   }
@@ -88,27 +88,27 @@ struct char_traits
     return static_cast<char_type *>(memcpy(dest, src, n * sizeof(charT)));
   }
 
-  static int_type eof() OM_NOEXCEPT
+  static OM_CONSTEXPR int_type eof() OM_NOEXCEPT
   {
     return EOF;
   }
 
-  static int_type to_int_type(char_type c) OM_NOEXCEPT
+  static OM_CONSTEXPR int_type to_int_type(char_type c) OM_NOEXCEPT
   {
     return static_cast<unsigned char>(c);
   }
 
-  static char_type to_char_type(int_type c) OM_NOEXCEPT
+  static OM_CONSTEXPR char_type to_char_type(int_type c) OM_NOEXCEPT
   {
     return static_cast<char_type>(c);
   }
 
-  static bool eq_int_type(int_type c1, int_type c2) OM_NOEXCEPT
+  static OM_CONSTEXPR bool eq_int_type(int_type c1, int_type c2) OM_NOEXCEPT
   {
     return c1 == c2;
   }
 
-  static int_type not_eof(int_type c) OM_NOEXCEPT
+  static OM_CONSTEXPR int_type not_eof(int_type c) OM_NOEXCEPT
   {
     return (c == eof()) ? 0 : c;
   }
@@ -120,13 +120,13 @@ struct char_traits
 // above 0x7f wrongly wherever char is signed -- and compare(), hence
 // std::string's ordering, is built on lt. See #7048.
 template <>
-inline bool char_traits<char>::eq(char c1, char c2) OM_NOEXCEPT
+inline OM_CONSTEXPR bool char_traits<char>::eq(char c1, char c2) OM_NOEXCEPT
 {
   return static_cast<unsigned char>(c1) == static_cast<unsigned char>(c2);
 }
 
 template <>
-inline bool char_traits<char>::lt(char c1, char c2) OM_NOEXCEPT
+inline OM_CONSTEXPR bool char_traits<char>::lt(char c1, char c2) OM_NOEXCEPT
 {
   return static_cast<unsigned char>(c1) < static_cast<unsigned char>(c2);
 }


### PR DESCRIPTION
[char.traits.specializations.char] declares `eq`, `lt`, `eof`, `to_int_type`,
`to_char_type`, `eq_int_type` and `not_eof` `constexpr` since C++11. They were
plain static functions, so any `constexpr` wrapper around one of them was
rejected with `-Winvalid-constexpr`. nlohmann/json wraps `eof()` exactly that
way, and it was the first parse error in 12 of a 60-TU sample of ESBMC's own
sources.

The remaining `char_traits` members became `constexpr` only in C++20, and their
bodies are not single return statements, so a C++11 `constexpr` would be
ill-formed; they are left alone. `OM_CONSTEXPR` elides the keyword under
`--std c++03`, and both `c++03` and `c++11` were checked.

The `char_traits<char>` explicit specializations of `eq`/`lt` from #7048 are
marked to match, and the test keeps their unsigned-char ordering pinned.

Refs #5868
