### PR TITLE
[om] Add std::unordered_multiset

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_unordered_multiset/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_multiset/main.cpp
@@ -1,0 +1,35 @@
+#include <unordered_set>
+#include <cassert>
+
+int main()
+{
+  std::unordered_multiset<int> m;
+  m.insert(1);
+  m.insert(1);
+  m.insert(2);
+
+  // [unord.multiset]: equivalent keys are all kept.
+  assert(m.size() == 3);
+  assert(m.count(1) == 2);
+  assert(m.count(2) == 1);
+  assert(m.count(3) == 0);
+  assert(!m.empty());
+
+  // erase(k) removes every equivalent key.
+  assert(m.erase(1) == 2);
+  assert(m.size() == 1);
+  assert(m.count(1) == 0);
+  assert(m.count(2) == 1);
+
+  assert(m.find(2) != m.end());
+  assert(m.find(9) == m.end());
+
+  int total = 0;
+  for (std::unordered_multiset<int>::iterator it = m.begin(); it != m.end(); ++it)
+    total += *it;
+  assert(total == 2);
+
+  m.clear();
+  assert(m.empty());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_multiset/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_multiset/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_alloc/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_alloc/main.cpp
@@ -1,0 +1,22 @@
+#include <unordered_set>
+#include <memory>
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  // [unord.multiset.overview]: four parameters.
+  std::unordered_multiset<
+    int, std::hash<int>, std::equal_to<int>, std::allocator<int>> m;
+  m.insert(1);
+  m.insert(1);
+  assert(m.count(1) == 2);
+  assert(m.size() == 2);
+
+  // The defaults must still work.
+  std::unordered_multiset<int> d;
+  d.insert(5);
+  d.insert(5);
+  assert(d.count(5) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_alloc/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_alloc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <unordered_set>
+#include <cassert>
+
+int main()
+{
+  std::unordered_multiset<int> m;
+  m.insert(1);
+  m.insert(1);
+  // [unord.multiset] keeps equivalent keys, so this is 2, not the 1 a
+  // uniquing container would report.
+  assert(m.count(1) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_multiset_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/unordered_set
+++ b/src/cpp/library/unordered_set
@@ -5,6 +5,7 @@
 #if __cplusplus >= 201103L
 
 #include <utility>
+#include <memory> /* std::allocator, for the Allocator parameter */
 
 namespace std {
 
@@ -410,13 +411,15 @@ public:
 // [unord.multiset]: same storage as unordered_set, but insert never rejects an
 // equivalent key, so find/count/equal_range have to scan for every match.
 template<typename Key, typename Hash = esbmc_hash<Key>,
-         typename KeyEqual = esbmc_equal_to<Key>>
+         typename KeyEqual = esbmc_equal_to<Key>,
+         typename Allocator = allocator<Key>>
 class unordered_multiset {
 public:
     typedef Key key_type;
     typedef Key value_type;
     typedef Hash hasher;
     typedef KeyEqual key_equal;
+    typedef Allocator allocator_type;
     typedef value_type& reference;
     typedef const value_type& const_reference;
     typedef value_type* pointer;

--- a/src/cpp/library/unordered_set
+++ b/src/cpp/library/unordered_set
@@ -407,6 +407,157 @@ public:
     }
 };
 
+// [unord.multiset]: same storage as unordered_set, but insert never rejects an
+// equivalent key, so find/count/equal_range have to scan for every match.
+template<typename Key, typename Hash = esbmc_hash<Key>,
+         typename KeyEqual = esbmc_equal_to<Key>>
+class unordered_multiset {
+public:
+    typedef Key key_type;
+    typedef Key value_type;
+    typedef Hash hasher;
+    typedef KeyEqual key_equal;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+    typedef value_type* pointer;
+    typedef const value_type* const_pointer;
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
+
+    typedef esbmc_unordered_set_iterator<Key, Hash, KeyEqual> iterator;
+    typedef esbmc_unordered_set_iterator<Key, Hash, KeyEqual> const_iterator;
+
+private:
+    // 64 slots keeps the inline data_ array small, for the reason <unordered_map>
+    // records: with std::string's inline buffer, 1024 slots made one container
+    // ~140KB and solver encodings timed out.
+    static const size_t MAX_SIZE = 64;
+    Key data_[MAX_SIZE];
+    size_type size_;
+    hasher hash_function_;
+    key_equal equal_function_;
+
+    size_type find_index(const Key& key) const {
+        for (size_type i = 0; i < size_; ++i) {
+            if (equal_function_(data_[i], key)) {
+                return i;
+            }
+        }
+        return MAX_SIZE;
+    }
+
+public:
+    unordered_multiset() : size_(0) {}
+
+    ~unordered_multiset() { size_ = 0; }
+
+    explicit unordered_multiset(size_type /*bucket_count*/) : size_(0) {}
+
+    template<typename InputIterator>
+    unordered_multiset(InputIterator first, InputIterator last) : size_(0) {
+        insert(first, last);
+    }
+
+    unordered_multiset(const unordered_multiset& other)
+        : size_(other.size_), hash_function_(other.hash_function_),
+          equal_function_(other.equal_function_) {
+        for (size_type i = 0; i < size_; ++i) {
+            data_[i] = other.data_[i];
+        }
+    }
+
+    unordered_multiset& operator=(const unordered_multiset& other) {
+        if (this != &other) {
+            size_ = other.size_;
+            hash_function_ = other.hash_function_;
+            equal_function_ = other.equal_function_;
+            for (size_type i = 0; i < size_; ++i) {
+                data_[i] = other.data_[i];
+            }
+        }
+        return *this;
+    }
+
+    iterator begin() const { return iterator(data_, 0, size_); }
+    iterator end() const { return iterator(data_, size_, size_); }
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
+
+    bool empty() const { return size_ == 0; }
+    size_type size() const { return size_; }
+    size_type max_size() const { return MAX_SIZE; }
+
+    // Unlike unordered_set::insert, an equivalent key is always added, so this
+    // returns a plain iterator rather than a pair.
+    iterator insert(const value_type& value) {
+        __ESBMC_assert(size_ < MAX_SIZE, "unordered_multiset capacity exceeded");
+        data_[size_] = value;
+        ++size_;
+        return iterator(data_, size_ - 1, size_);
+    }
+
+    template<typename InputIterator>
+    void insert(InputIterator first, InputIterator last) {
+        for (InputIterator it = first; it != last; ++it) {
+            insert(*it);
+        }
+    }
+
+    template<typename... Args>
+    iterator emplace(Args&&... args) {
+        return insert(value_type(std::forward<Args>(args)...));
+    }
+
+    // [unord.multiset] erase(k) removes every equivalent key.
+    size_type erase(const key_type& key) {
+        size_type removed = 0;
+        size_type out = 0;
+        for (size_type i = 0; i < size_; ++i) {
+            if (equal_function_(data_[i], key)) {
+                ++removed;
+            } else {
+                data_[out] = data_[i];
+                ++out;
+            }
+        }
+        size_ = out;
+        return removed;
+    }
+
+    void clear() { size_ = 0; }
+
+    iterator find(const key_type& key) const {
+        size_type idx = find_index(key);
+        if (idx == MAX_SIZE) {
+            return end();
+        }
+        return iterator(data_, idx, size_);
+    }
+
+    size_type count(const key_type& key) const {
+        size_type n = 0;
+        for (size_type i = 0; i < size_; ++i) {
+            if (equal_function_(data_[i], key)) {
+                ++n;
+            }
+        }
+        return n;
+    }
+
+    bool contains(const key_type& key) const {
+        return find_index(key) != MAX_SIZE;
+    }
+
+    void swap(unordered_multiset& other) {
+        unordered_multiset tmp = *this;
+        *this = other;
+        other = tmp;
+    }
+
+    hasher hash_function() const { return hash_function_; }
+    key_equal key_eq() const { return equal_function_; }
+};
+
 } // namespace std
 
 #endif // __cplusplus >= 201103L


### PR DESCRIPTION
`<unordered_set>` modelled only `unordered_set`, so `std::unordered_multiset`
was the first parse error in 16 of a 60-TU sample of ESBMC's own sources —
`goto_functions.h` declares `static std::unordered_multiset<std::string>
reached_mul_claims`, and it is included very widely.

The new class reuses `unordered_set`'s array storage and iterator. The
[unord.multiset] differences are that `insert` never rejects an equivalent key
and returns a plain iterator rather than a pair, and `erase(k)` removes every
match and returns how many. It carries the `Allocator` parameter
[unord.multiset.overview] specifies, matching #7167 for the other two.

Its capacity is 64, the bound `<unordered_map>` already documents ("with
std::string's inline buffer, 1024 slots made one map ~140KB and solver
encodings timed out"), rather than `unordered_set`'s 1024.

Two limitations left alone, both pre-existing and neither introduced here:

- Executing operations on a **string-keyed** unordered container still times
  out — `unordered_set<std::string>` and `unordered_map<std::string, int>` both
  do so on master today. Declaring one parses, which is what the 16 TUs need.
- `unordered_set` itself still has the 1024 bound.

Refs #5868
