### PR TITLE
[om] Add is_default_constructible, is_move_constructible/assignable

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_constructible_traits/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_constructible_traits/main.cpp
@@ -1,0 +1,38 @@
+#include <type_traits>
+
+struct plain
+{
+};
+struct no_default
+{
+  no_default(int)
+  {
+  }
+};
+struct no_move
+{
+  no_move(const no_move &)
+  {
+  }
+  no_move &operator=(const no_move &)
+  {
+    return *this;
+  }
+};
+
+int main()
+{
+  static_assert(std::is_default_constructible<plain>::value, "plain");
+  static_assert(std::is_default_constructible<int>::value, "int");
+  static_assert(!std::is_default_constructible<no_default>::value, "no_default");
+  static_assert(std::is_default_constructible_v<plain>, "_v alias");
+
+  static_assert(std::is_move_constructible<plain>::value, "move ctor");
+  static_assert(std::is_move_constructible<no_move>::value, "copy ctor serves");
+  static_assert(std::is_move_constructible_v<int>, "_v alias");
+
+  static_assert(std::is_move_assignable<plain>::value, "move assign");
+  static_assert(std::is_move_assignable_v<int>, "_v alias");
+  static_assert(!std::is_move_assignable<const int>::value, "const");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_constructible_traits/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_constructible_traits/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_constructible_traits_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_constructible_traits_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <type_traits>
+#include <cassert>
+
+struct no_default
+{
+  no_default(int)
+  {
+  }
+};
+
+int main()
+{
+  // no_default has no default constructor, so the trait is false.
+  assert(std::is_default_constructible<no_default>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_constructible_traits_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_constructible_traits_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -668,10 +668,33 @@ struct is_copy_assignable
 };
 
 template <class T>
+struct is_default_constructible : integral_constant<bool, __is_constructible(T)>
+{
+};
+
+template <class T>
 struct is_copy_constructible
   : integral_constant<
       bool,
       __is_constructible(T, typename add_lvalue_reference<const T>::type)>
+{
+};
+
+template <class T>
+struct is_move_constructible
+  : integral_constant<
+      bool,
+      __is_constructible(T, typename add_rvalue_reference<T>::type)>
+{
+};
+
+template <class T>
+struct is_move_assignable
+  : integral_constant<
+      bool,
+      __is_assignable(
+        typename add_lvalue_reference<T>::type,
+        typename add_rvalue_reference<T>::type)>
 {
 };
 
@@ -944,6 +967,13 @@ template <class T>
 inline constexpr bool is_copy_assignable_v = is_copy_assignable<T>::value;
 template <class T>
 inline constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
+template <class T>
+inline constexpr bool is_default_constructible_v =
+  is_default_constructible<T>::value;
+template <class T>
+inline constexpr bool is_move_constructible_v = is_move_constructible<T>::value;
+template <class T>
+inline constexpr bool is_move_assignable_v = is_move_assignable<T>::value;
 template <class T>
 inline constexpr bool is_destructible_v = is_destructible<T>::value;
 template <class T>


### PR DESCRIPTION
`<type_traits>` had `is_copy_constructible`, `is_copy_assignable`,
`is_assignable` and `is_destructible`, but not `is_default_constructible`,
`is_move_constructible` or `is_move_assignable`. `is_default_constructible` was
the first parse error in 11 of a 60-TU sample of ESBMC's own sources.

Each maps to the Clang builtin its siblings already use, naming the reference
type the standard's own definition names so a non-referenceable `T` answers
false rather than making the instantiation ill-formed. The `_v` aliases come
with them.

Refs #5868
