### PR TITLE
[om] Template allocator_traits' construct and destroy on the pointee

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_allocator_construct_crosstype/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_allocator_construct_crosstype/main.cpp
@@ -1,0 +1,47 @@
+#include <memory>
+#include <cassert>
+#include <cstdlib>
+
+struct node
+{
+  int payload;
+};
+
+template <class T>
+struct minimal_alloc
+{
+  typedef T value_type;
+  T *allocate(std::size_t n)
+  {
+    return static_cast<T *>(malloc(sizeof(T) * n));
+  }
+  void deallocate(T *p, std::size_t)
+  {
+    free(p);
+  }
+};
+
+int main()
+{
+  // [allocator.traits.members]: construct/destroy are templates on the pointee,
+  // so a traits instantiated on a node allocator can build an int -- the shape
+  // boost multi_index uses.
+  typedef std::allocator_traits<minimal_alloc<node>> tr;
+  minimal_alloc<node> a;
+
+  int *p = static_cast<int *>(malloc(sizeof(int)));
+  if (p == NULL)
+    return 0;
+  tr::construct(a, p, 42);
+  assert(*p == 42);
+  tr::destroy(a, p);
+  free(p);
+
+  node *q = tr::allocate(a, 1);
+  if (q == NULL)
+    return 0;
+  tr::construct(a, q);
+  tr::destroy(a, q);
+  tr::deallocate(a, q, 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_allocator_construct_crosstype/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_allocator_construct_crosstype/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -258,25 +258,19 @@ struct has_construct<
 template <class Alloc, class T, bool = has_construct<Alloc, T>::value>
 struct construct_with
 {
-  static void copy(Alloc &a, T *p, const T &v)
+  template <class... Args>
+  static void run(Alloc &a, T *p, Args &&...args)
   {
-    a.construct(p, v);
-  }
-  static void value(Alloc &a, T *p)
-  {
-    a.construct(p);
+    a.construct(p, std::forward<Args>(args)...);
   }
 };
 template <class Alloc, class T>
 struct construct_with<Alloc, T, false>
 {
-  static void copy(Alloc &, T *p, const T &v)
+  template <class... Args>
+  static void run(Alloc &, T *p, Args &&...args)
   {
-    ::new (static_cast<void *>(p)) T(v);
-  }
-  static void value(Alloc &, T *p)
-  {
-    ::new (static_cast<void *>(p)) T();
+    ::new (static_cast<void *>(p)) T(std::forward<Args>(args)...);
   }
 };
 
@@ -350,19 +344,21 @@ struct allocator_traits
     a.deallocate(p, n);
   }
 
-  static void construct(Alloc &a, pointer p, const value_type &v)
+  /* [allocator.traits.members]: construct and destroy are templates on the
+   * pointee, not on the allocator's own value_type. boost multi_index relies on
+   * that -- it destroys a symbolt through a traits instantiated on its node
+   * allocator, so a `pointer` parameter rejects the call. */
+  template <class T, class... Args>
+  static void construct(Alloc &a, T *p, Args &&...args)
   {
-    __alloc_detail::construct_with<Alloc, value_type>::copy(a, p, v);
+    __alloc_detail::construct_with<Alloc, T>::run(
+      a, p, std::forward<Args>(args)...);
   }
 
-  static void construct(Alloc &a, pointer p)
+  template <class T>
+  static void destroy(Alloc &a, T *p)
   {
-    __alloc_detail::construct_with<Alloc, value_type>::value(a, p);
-  }
-
-  static void destroy(Alloc &a, pointer p)
-  {
-    __alloc_detail::destroy_with<Alloc, value_type>::run(a, p);
+    __alloc_detail::destroy_with<Alloc, T>::run(a, p);
   }
 
   static size_type max_size(const Alloc &a)


### PR DESCRIPTION
[allocator.traits.members] declares `construct` and `destroy` as templates on
the pointed-to type:

```cpp
template<class T, class... Args> static void construct(Alloc&, T* p, Args&&...);
template<class T>                static void destroy(Alloc&, T* p);
```

They took a `pointer` — the allocator's own `value_type*` — so a traits
instantiated on one type could not construct or destroy another. boost
multi_index relies on exactly that: it destroys a `symbolt` through a traits
instantiated on its node allocator, and `util/symtab/context.h` puts that in
ESBMC's own include graph.

```
boost/multi_index_container.hpp:672: error: cannot initialize a parameter of
type 'pointer' (aka 'hashed_index_node<...>*') with an rvalue of type 'symbolt*'
```

It was the first parse error in 15 of a 60-TU sample of ESBMC's own sources.

Follows #7152, which is now merged.

Refs #5868
