### PR TITLE
[om] Add basic_string::clear and forward_list's Allocator parameter

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_string_clear_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_clear_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("abc");
+  s.clear();
+  // clear() erases every character, so size() is 0.
+  assert(s.size() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_clear_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_clear_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_string_clear_forward_list_alloc/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_clear_forward_list_alloc/main.cpp
@@ -1,0 +1,28 @@
+#include <string>
+#include <forward_list>
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  std::string s("abc");
+  assert(s.size() == 3);
+  s.clear();
+  assert(s.size() == 0);
+  assert(s.empty());
+
+  std::string t("hello");
+  t.clear();
+  assert(t.length() == 0);
+
+  // [forward.list.overview]: forward_list takes an Allocator parameter.
+  std::forward_list<int, std::allocator<int>> f;
+  f.push_front(1);
+  f.push_front(2);
+  assert(f.front() == 2);
+
+  std::forward_list<int> g;
+  g.push_front(7);
+  assert(g.front() == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_clear_forward_list_alloc/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_clear_forward_list_alloc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/forward_list
+++ b/src/cpp/library/forward_list
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include "definitions.h"
+#include "memory" /* std::allocator, for the Allocator parameter */
 #include "type_traits"
 #if __cplusplus >= 201103L
 #  include <initializer_list>
@@ -53,11 +54,14 @@ struct __om_fwd_pool<node_t, false>
   }
 };
 
-template <class T>
+// [forward.list.overview] gives forward_list an Allocator parameter. The pool
+// below does the allocating, so it is carried for the signature only.
+template <class T, class Allocator = allocator<T>>
 class forward_list
 {
 public:
   typedef T value_type;
+  typedef Allocator allocator_type;
   typedef T &reference;
   typedef const T &const_reference;
   typedef T *pointer;

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -474,6 +474,7 @@ public:
   char front() const;
   char back() const;
   bool empty() const;
+  void clear();
   size_t length() const;
   int compare(const basic_string<CharT, Traits, Alloc> &s) const;
   int compare(const char *s) const;
@@ -1401,6 +1402,13 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     rhs.str != NULL, "The second parameter must be different than NULL");
   return strcmp(lhs, rhs.str) <= 0;
+}
+
+template <typename CharT, typename Traits, typename Alloc>
+void basic_string<CharT, Traits, Alloc>::clear()
+{
+  this->_size = 0;
+  this->str[0] = '\0';
 }
 
 template <typename CharT, typename Traits, typename Alloc>


### PR DESCRIPTION
Two small gaps the self-verification census turned up, both on the current
master:

- `basic_string` had no `clear()` at all — the first parse error in 10 of a
  60-TU sample of ESBMC's own sources.
- `forward_list` was declared with only its element parameter, so
  `std::forward_list<T, A>` did not compile — the first parse error in 11 more.
  [forward.list.overview] gives it an `Allocator` parameter; the pool does the
  allocating here, so it is carried for the signature and the `allocator_type`
  typedef only.

Refs #5868
