### PR TITLE
[om] Compare and order std::optional against a value

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_optional_value_compare/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_optional_value_compare/main.cpp
@@ -1,0 +1,25 @@
+#include <optional>
+#include <cassert>
+
+int main()
+{
+  std::optional<int> a(3);
+  std::optional<int> b(3);
+  std::optional<int> e;
+
+  // [optional.comp.with.t]: comparison against a value.
+  assert(a == 3);
+  assert(3 == a);
+  assert(a != 4);
+  assert(4 != a);
+  assert(!(e == 3));
+  assert(e != 3);
+
+  // [optional.relops] and the nullopt overloads must stay unambiguous.
+  assert(a == b);
+  assert(!(a != b));
+  assert(a != e);
+  assert(e == std::nullopt);
+  assert(a != std::nullopt);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_optional_value_compare/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_optional_value_compare/main.cpp
@@ -4,22 +4,40 @@
 int main()
 {
   std::optional<int> a(3);
-  std::optional<int> b(3);
+  std::optional<int> big(9);
   std::optional<int> e;
 
-  // [optional.comp.with.t]: comparison against a value.
-  assert(a == 3);
-  assert(3 == a);
-  assert(a != 4);
-  assert(4 != a);
-  assert(!(e == 3));
-  assert(e != 3);
+  // [optional.comp.with.t]: relational comparison against a value.
+  assert(a < 4);
+  assert(!(a < 3));
+  assert(a > 2);
+  assert(a <= 3);
+  assert(a >= 3);
+  assert(2 < a);
+  assert(4 > a);
 
-  // [optional.relops] and the nullopt overloads must stay unambiguous.
-  assert(a == b);
-  assert(!(a != b));
-  assert(a != e);
+  // A disengaged optional orders below every value.
+  assert(e < 0);
+  assert(!(e > 0));
+  assert(0 > e);
+
+  // [optional.relops]
+  assert(a < big);
+  assert(big > a);
+  assert(e < a);
+  assert(!(a < e));
+  assert(a <= a);
+  assert(a >= a);
+
+  // [optional.nullops]
+  assert(!(a < std::nullopt));
+  assert(std::nullopt < a);
+  assert(e <= std::nullopt);
+  assert(std::nullopt >= e);
+
+  // Equality must stay unambiguous.
+  assert(a == 3);
+  assert(a != big);
   assert(e == std::nullopt);
-  assert(a != std::nullopt);
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_5868_optional_value_compare/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_optional_value_compare/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_optional_value_compare_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_optional_value_compare_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <optional>
+#include <cassert>
+
+int main()
+{
+  std::optional<int> e;
+  // [optional.comp.with.t]: a disengaged optional compares unequal to any
+  // value, so this must be refuted.
+  assert(e == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_optional_value_compare_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_optional_value_compare_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/optional
+++ b/src/cpp/library/optional
@@ -157,6 +157,56 @@ constexpr bool operator!=(const optional<T> &a, const optional<T> &b)
   return !(a == b);
 }
 
+/* [optional.comp.with.t]: comparison against a value. The overloads have to
+ * exclude optional and nullopt_t themselves, or comparing two optionals -- or
+ * an optional against nullopt -- matches these just as exactly as the
+ * overloads above and is ambiguous. */
+namespace __optional_detail
+{
+template <class U>
+struct is_optional : false_type
+{
+};
+template <class U>
+struct is_optional<optional<U>> : true_type
+{
+};
+
+template <class U>
+struct is_value
+  : integral_constant<
+      bool,
+      !is_optional<typename decay<U>::type>::value &&
+        !is_same<typename decay<U>::type, nullopt_t>::value>
+{
+};
+} // namespace __optional_detail
+
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator==(const optional<T> &o, const U &v)
+{
+  return o.has_value() && *o == v;
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator==(const U &v, const optional<T> &o)
+{
+  return o.has_value() && v == *o;
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator!=(const optional<T> &o, const U &v)
+{
+  return !(o == v);
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator!=(const U &v, const optional<T> &o)
+{
+  return !(v == o);
+}
+
 } // namespace std
 
 #endif // __cplusplus >= 201103L

--- a/src/cpp/library/optional
+++ b/src/cpp/library/optional
@@ -207,6 +207,120 @@ operator!=(const U &v, const optional<T> &o)
   return !(v == o);
 }
 
+/* [optional.relops], [optional.nullops] and [optional.comp.with.t]: a
+ * disengaged optional orders below every value and below every engaged
+ * optional. */
+template <class T>
+constexpr bool operator<(const optional<T> &a, const optional<T> &b)
+{
+  return b.has_value() && (!a.has_value() || *a < *b);
+}
+template <class T>
+constexpr bool operator>(const optional<T> &a, const optional<T> &b)
+{
+  return b < a;
+}
+template <class T>
+constexpr bool operator<=(const optional<T> &a, const optional<T> &b)
+{
+  return !(b < a);
+}
+template <class T>
+constexpr bool operator>=(const optional<T> &a, const optional<T> &b)
+{
+  return !(a < b);
+}
+
+template <class T>
+constexpr bool operator<(const optional<T> &, nullopt_t) noexcept
+{
+  return false;
+}
+template <class T>
+constexpr bool operator<(nullopt_t, const optional<T> &o) noexcept
+{
+  return o.has_value();
+}
+template <class T>
+constexpr bool operator>(const optional<T> &o, nullopt_t) noexcept
+{
+  return o.has_value();
+}
+template <class T>
+constexpr bool operator>(nullopt_t, const optional<T> &) noexcept
+{
+  return false;
+}
+template <class T>
+constexpr bool operator<=(const optional<T> &o, nullopt_t) noexcept
+{
+  return !o.has_value();
+}
+template <class T>
+constexpr bool operator<=(nullopt_t, const optional<T> &) noexcept
+{
+  return true;
+}
+template <class T>
+constexpr bool operator>=(const optional<T> &, nullopt_t) noexcept
+{
+  return true;
+}
+template <class T>
+constexpr bool operator>=(nullopt_t, const optional<T> &o) noexcept
+{
+  return !o.has_value();
+}
+
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator<(const optional<T> &o, const U &v)
+{
+  return !o.has_value() || *o < v;
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator<(const U &v, const optional<T> &o)
+{
+  return o.has_value() && v < *o;
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator>(const optional<T> &o, const U &v)
+{
+  return v < o;
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator>(const U &v, const optional<T> &o)
+{
+  return o < v;
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator<=(const optional<T> &o, const U &v)
+{
+  return !(v < o);
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator<=(const U &v, const optional<T> &o)
+{
+  return !(o < v);
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator>=(const optional<T> &o, const U &v)
+{
+  return !(o < v);
+}
+template <class T, class U>
+constexpr typename enable_if<__optional_detail::is_value<U>::value, bool>::type
+operator>=(const U &v, const optional<T> &o)
+{
+  return !(v < o);
+}
+
 } // namespace std
 
 #endif // __cplusplus >= 201103L


### PR DESCRIPTION
`<optional>` compared against `nullopt_t` and against another `optional` for
equality only. It carried **no relational operators at all** — not against a
value, not against `nullopt`, and not between two optionals — so
`wrapped_interval.h`'s `result.upper < 0` on an `optional<BigInt>` did not
compile.

[optional.comp.with.t], [optional.relops] and [optional.nullops] add the value
comparisons and the orderings, with a disengaged optional ordering below every
value and below every engaged optional.

The value overloads have to exclude `optional` and `nullopt_t` themselves:
unconstrained, `operator==(const optional<T>&, const U&)` matches a two-optional
or an optional-against-nullopt comparison exactly as well as the existing
overloads, and every such comparison becomes ambiguous. The test covers those
cases specifically.

Verified against the site that motivated it: `memory_ops.cpp` no longer stops
on this error.

Refs #5868
