### PR TITLE
[om] Step advance and distance without random access

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional/main.cpp
@@ -1,0 +1,36 @@
+#include <list>
+#include <vector>
+#include <iterator>
+#include <cassert>
+
+int main()
+{
+  // [iterator.operations]: a bidirectional iterator has no operator+, so
+  // advance has to step with ++ and --.
+  std::list<int> l;
+  l.push_back(1);
+  l.push_back(2);
+  l.push_back(3);
+
+  std::list<int>::iterator it = l.begin();
+  std::advance(it, 2);
+  assert(*it == 3);
+  std::advance(it, -1);
+  assert(*it == 2);
+  std::advance(it, 0);
+  assert(*it == 2);
+
+  assert(*std::next(l.begin()) == 2);
+  assert(*std::prev(l.end()) == 3);
+
+  // Random access keeps the i + n path.
+  std::vector<int> v;
+  v.push_back(4);
+  v.push_back(5);
+  v.push_back(6);
+  std::vector<int>::iterator vi = v.begin();
+  std::advance(vi, 2);
+  assert(*vi == 6);
+  assert(*std::next(v.begin()) == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <list>
+#include <iterator>
+#include <cassert>
+
+int main()
+{
+  std::list<double> l;
+  l.push_back(1.0);
+  l.push_back(2.0);
+  l.push_back(3.0);
+  std::list<double>::iterator it = l.begin();
+  std::advance(it, 2);
+  // advance(it, 2) lands on the third element, not the second.
+  assert(*it == 2.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_advance_bidirectional_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -4,6 +4,7 @@
 #include "iostream"
 #include "streambuf"
 #include "utility"
+#include "type_traits" /* void_t, declval, for the advance/distance dispatch */
 
 namespace std
 {
@@ -96,6 +97,95 @@ struct iterator_traits<const T *>
  * `== 3` nor `!= 3` on a three-element range -- and an advance() that left
  * the iterator where it was. The bodies below are the ones <algorithm> had;
  * <algorithm> includes this header, so its own callers are unaffected. */
+/* [iterator.operations]: advance and distance are specified per iterator
+ * category -- only a random access iterator supports i + n and first < last.
+ * A bidirectional iterator such as std::list's has to step with ++ and --.
+ *
+ * The category is detected by whether `i + n` is well-formed rather than by
+ * iterator_traits<It>::iterator_category, because the container iterators this
+ * header has to serve do not all carry the traits typedefs -- the same reason
+ * the parameter below is a ptrdiff_t.
+ *
+ * The detection needs void_t and declval, so the C++03 path keeps the original
+ * random-access-only bodies rather than losing advance and distance entirely. */
+#if __cplusplus >= 201103L
+namespace __iter_detail
+{
+template <class It, class = void>
+struct has_plus : false_type
+{
+};
+template <class It>
+struct has_plus<It, void_t<decltype(declval<It>() + declval<ptrdiff_t>())>>
+  : true_type
+{
+};
+
+template <class It, bool = has_plus<It>::value>
+struct advance_by
+{
+  static void run(It &i, ptrdiff_t n)
+  {
+    i = i + n;
+  }
+};
+template <class It>
+struct advance_by<It, false>
+{
+  static void run(It &i, ptrdiff_t n)
+  {
+    for (; n > 0; --n)
+      ++i;
+    for (; n < 0; ++n)
+      --i;
+  }
+};
+
+template <class It, bool = has_plus<It>::value>
+struct distance_between
+{
+  static int run(It first, It last)
+  {
+    int i = 0;
+    int koef = first < last ? 1 : -1;
+    It pilgrim = first < last ? first : last;
+    while (pilgrim != last)
+    {
+      pilgrim = pilgrim + koef;
+      i++;
+    }
+    return i;
+  }
+};
+template <class It>
+struct distance_between<It, false>
+{
+  // Only the forward direction is defined for a non-random-access range.
+  static int run(It first, It last)
+  {
+    int i = 0;
+    while (first != last)
+    {
+      ++first;
+      i++;
+    }
+    return i;
+  }
+};
+} // namespace __iter_detail
+
+template <class InputIterator, class Distance>
+void advance(InputIterator &i, Distance n)
+{
+  __iter_detail::advance_by<InputIterator>::run(i, n);
+}
+
+template <class InputIterator>
+int distance(InputIterator first, InputIterator last)
+{
+  return __iter_detail::distance_between<InputIterator>::run(first, last);
+}
+#else
 template <class InputIterator, class Distance>
 void advance(InputIterator &i, Distance n)
 {
@@ -115,6 +205,7 @@ int distance(InputIterator first, InputIterator last)
   }
   return i;
 }
+#endif
 
 #if __cplusplus >= 201103L
 /* [iterator.operations]/3,6. The parameter type is spelled ptrdiff_t rather


### PR DESCRIPTION
`advance` was `i = i + n` and `distance` compared `first < last`, so both
required a **random access** iterator. `std::next` on a `std::list` iterator
therefore failed to compile:

```
iterator:102: error: invalid operands to binary expression
  ('std::list<goto_programt::instructiont>::iterator' and 'long')
note: in instantiation of 'std::next<...>' requested here
goto_program.h:586: const auto next = std::next(target);
```

That is ESBMC's own `goto_program.h`, so it reached a large share of the
self-verification sample.

The category is detected by whether `i + n` is well-formed rather than by
`iterator_traits<It>::iterator_category`, because the container iterators this
header serves do not all carry the traits typedefs — the same reason the
parameter is a `ptrdiff_t`. The detection needs `void_t` and `declval`, so the
**C++03 path keeps the original bodies unchanged**; an unguarded first version
broke six `*_cxx03` tests.

`distance` on a non-random-access range now compiles, but note it is as slow to
execute as it already is for vectors on master — `std::distance` on a
`std::vector` times out on unpatched master too. The tests therefore cover
`advance`/`next`/`prev`.

Refs #5868
