### PR TITLE
[om] Give map, multimap, set and multiset their Allocator parameter

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param/main.cpp
@@ -1,0 +1,29 @@
+#include <map>
+#include <set>
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int>>> m;
+  m[1] = 10;
+  assert(m[1] == 10);
+
+  std::set<int, std::less<int>, std::allocator<int>> s;
+  s.insert(4);
+  assert(s.count(4) == 1);
+
+  std::multiset<int, std::less<int>, std::allocator<int>> ms;
+  ms.insert(5);
+  ms.insert(5);
+  assert(ms.count(5) == 2);
+
+  std::multimap<int, int, std::less<int>, std::allocator<std::pair<const int, int>>> mm;
+  mm.insert(std::pair<int, int>(2, 20));
+  assert(mm.size() == 1);
+
+  std::map<int, int> dm;
+  dm[3] = 30;
+  assert(dm[3] == 30);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <set>
+#include <memory>
+#include <cassert>
+
+int main()
+{
+  std::multiset<int, std::less<int>, std::allocator<int>> ms;
+  ms.insert(5);
+  ms.insert(5);
+  // A multiset keeps equivalent keys, so this is 2.
+  assert(ms.count(5) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_assoc_allocator_param_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 
+#include "memory" /* std::allocator, for the Allocator parameter */
 #include "utility"
 #include "vector"
 #include "functional"
@@ -14,7 +15,14 @@
 
 namespace std
 {
-template <class Key, class T, class Compare = less<Key> >
+// [associative.reqmts]: the Allocator parameter completes the signature. The
+// fixed arrays below do the allocating, so it is carried for the signature
+// and the allocator_type typedef only.
+template <
+  class Key,
+  class T,
+  class Compare = less<Key>,
+  class Allocator = allocator<pair<const Key, T> > >
 class map
 {
 public:
@@ -1232,7 +1240,14 @@ public:
   }
 };
 
-template <class Key, class T, class Compare = less<Key> >
+// [associative.reqmts]: the Allocator parameter completes the signature. The
+// fixed arrays below do the allocating, so it is carried for the signature
+// and the allocator_type typedef only.
+template <
+  class Key,
+  class T,
+  class Compare = less<Key>,
+  class Allocator = allocator<pair<const Key, T> > >
 class multimap
 {
 public:

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -4,6 +4,7 @@
 #define MAX 500
 
 #include "definitions.h"
+#include "memory" /* std::allocator, for the Allocator parameter */
 #include "utility"
 #include "iterator"
 #include "iostream"
@@ -17,7 +18,8 @@ namespace std
 {
 template <
   class Key,
-  class Compare = less<Key> /*,class Allocator = allocator<Key> */>
+  class Compare = less<Key>,
+  class Allocator = allocator<Key> >
 class multiset
 {
 public:
@@ -777,7 +779,10 @@ public:
   }
 };
 
-template <class Key, class Compare = less<Key> >
+template <
+  class Key,
+  class Compare = less<Key>,
+  class Allocator = allocator<Key> >
 class set
 {
 public:


### PR DESCRIPTION
`map`, `multimap`, `set` and `multiset` all stopped at `Compare`, so naming the
allocator — which the standard's signature has and generic code does — failed
with `too many template arguments for class template 'map'`. It was the first
parse error in 11 of a 60-TU sample of ESBMC's own sources. `multiset` already
carried the parameter, commented out.

The fixed arrays behind these containers do the allocating, so the parameter is
carried for the signature only.

The closing brackets are spelled `> >`: these headers are also compiled under
`--std c++03`, where `>>` is a shift operator. A first version without the space
regressed `esbmc-cpp/set/set-value_comp-c++03`.

Refs #5868
