### PR TITLE
[om] Add is_member_object_pointer and is_member_function_pointer

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits/main.cpp
@@ -1,0 +1,32 @@
+#include <type_traits>
+
+struct S
+{
+  int data;
+  void fn();
+  int cfn() const;
+};
+
+int main()
+{
+  // [meta.unary.cat]: a pointer to member is object-or-function, never both.
+  static_assert(std::is_member_object_pointer<int S::*>::value, "data ptr");
+  static_assert(!std::is_member_function_pointer<int S::*>::value, "data ptr");
+
+  static_assert(std::is_member_function_pointer<void (S::*)()>::value, "fn ptr");
+  static_assert(!std::is_member_object_pointer<void (S::*)()>::value, "fn ptr");
+  static_assert(
+    std::is_member_function_pointer<int (S::*)() const>::value, "const fn ptr");
+
+  static_assert(!std::is_member_object_pointer<int>::value, "plain int");
+  static_assert(!std::is_member_function_pointer<int>::value, "plain int");
+  static_assert(!std::is_member_object_pointer<int *>::value, "plain pointer");
+
+  // cv-qualified member pointers still classify.
+  static_assert(
+    std::is_member_object_pointer<int S::*const>::value, "const data ptr");
+
+  static_assert(std::is_member_object_pointer_v<int S::*>, "_v alias");
+  static_assert(std::is_member_function_pointer_v<void (S::*)()>, "_v alias");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <type_traits>
+#include <cassert>
+
+struct S
+{
+  void fn();
+};
+
+int main()
+{
+  // [meta.unary.cat]: a pointer to member function is not an object pointer.
+  assert((std::is_member_object_pointer<void (S::*)()>::value));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_member_pointer_traits_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -459,6 +459,35 @@ struct is_function : integral_constant<bool, __is_function(T)>
 {
 };
 
+/* [meta.unary.cat]: a pointer to member is one or the other -- the pointee of a
+ * pointer to member function is a function type. Defined here rather than
+ * beside is_member_pointer because it needs is_function above. */
+namespace detail
+{
+template <class T>
+struct is_member_function_pointer_base : false_type
+{
+};
+template <class T, class U>
+struct is_member_function_pointer_base<T U::*> : is_function<T>
+{
+};
+} // namespace detail
+
+template <class T>
+struct is_member_function_pointer
+  : detail::is_member_function_pointer_base<typename remove_cv<T>::type>
+{
+};
+
+template <class T>
+struct is_member_object_pointer
+  : integral_constant<
+      bool,
+      is_member_pointer<T>::value && !is_member_function_pointer<T>::value>
+{
+};
+
 #if __cplusplus >= 201103L
 // alignment_of
 template <class T>
@@ -914,6 +943,12 @@ template <class T>
 inline constexpr bool is_volatile_v = is_volatile<T>::value;
 template <class T>
 inline constexpr bool is_member_pointer_v = is_member_pointer<T>::value;
+template <class T>
+inline constexpr bool is_member_function_pointer_v =
+  is_member_function_pointer<T>::value;
+template <class T>
+inline constexpr bool is_member_object_pointer_v =
+  is_member_object_pointer<T>::value;
 template <class Base, class Derived>
 inline constexpr bool is_base_of_v = is_base_of<Base, Derived>::value;
 template <class T>


### PR DESCRIPTION
`<type_traits>` had `is_member_pointer` but neither of the two categories
[meta.unary.cat] splits it into, so boost's type dispatch did not compile.

They sit after `is_function` rather than beside `is_member_pointer`, because the
pointee of a pointer to member function *is* a function type — that is how the
two are told apart, and `is_function` is defined further down the file.

Both are unguarded: `is_function` is a Clang builtin valid pre-C++11, and the
definitions avoid C++11-only syntax, so `--std c++03` keeps working.

Refs #5868
