### PR TITLE
[om] Add the free range-access functions size, empty and data

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_iterator_range_access/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_range_access/main.cpp
@@ -1,0 +1,26 @@
+#include <iterator>
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  // [iterator.range]
+  int a[4] = {1, 2, 3, 4};
+  assert(std::size(a) == 4);
+  assert(!std::empty(a));
+  assert(std::data(a) == &a[0]);
+  static_assert(std::size(a) == 4, "size of an array is constexpr");
+
+  std::vector<int> v;
+  assert(std::size(v) == 0);
+  assert(std::empty(v));
+  v.push_back(7);
+  assert(std::size(v) == 1);
+  assert(!std::empty(v));
+  assert(*std::data(v) == 7);
+
+  const std::vector<int> &cv = v;
+  assert(std::size(cv) == 1);
+  assert(*std::data(cv) == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_iterator_range_access/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_range_access/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_iterator_range_access_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_range_access_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <iterator>
+#include <cassert>
+
+int main()
+{
+  int a[4] = {1, 2, 3, 4};
+  // [iterator.range]: size() on an array is its extent, not its first element.
+  assert(std::size(a) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_iterator_range_access_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_iterator_range_access_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -136,6 +136,48 @@ BidirectionalIterator prev(BidirectionalIterator i, ptrdiff_t n = 1)
 }
 #endif
 
+#if __cplusplus >= 201703L
+/* [iterator.range]: the free range-access functions. size() on a raw array is
+ * the one that generic code cannot express any other way. */
+template <class C>
+constexpr auto size(const C &c) -> decltype(c.size())
+{
+  return c.size();
+}
+template <class T, size_t N>
+constexpr size_t size(const T (&)[N]) noexcept
+{
+  return N;
+}
+
+template <class C>
+constexpr auto empty(const C &c) -> decltype(c.empty())
+{
+  return c.empty();
+}
+template <class T, size_t N>
+constexpr bool empty(const T (&)[N]) noexcept
+{
+  return false;
+}
+
+template <class C>
+constexpr auto data(C &c) -> decltype(c.data())
+{
+  return c.data();
+}
+template <class C>
+constexpr auto data(const C &c) -> decltype(c.data())
+{
+  return c.data();
+}
+template <class T, size_t N>
+constexpr T *data(T (&array)[N]) noexcept
+{
+  return array;
+}
+#endif
+
 template <class Container>
 class back_insert_iterator
   : public iterator<output_iterator_tag, void, void, void, void>


### PR DESCRIPTION
`<iterator>` had none of the free range-access functions, so `std::size` did not
compile. The array overload is the one generic code cannot express any other
way, and it is `constexpr`, so it works in a constant expression.

Guarded for C++17, where [iterator.range] adds them; `c++03`, `c++11` and
`c++14` are untouched and were each checked, after two earlier PRs in this
series regressed the `*_cxx03` tests.

Note that `std::max` and `std::toupper` also appeared once each in the census,
but both already resolve — those entries are different contexts and are not
addressed here.

Refs #5868
