### PR TITLE
[om] Compare map's const iterators by position, not by the cached pair

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq/main.cpp
@@ -1,0 +1,27 @@
+#include <map>
+#include <cassert>
+
+// A mapped type with no operator== -- exactly what goto_functiont is.
+struct payload
+{
+  int v;
+  payload() : v(0)
+  {
+  }
+  payload(int x) : v(x)
+  {
+  }
+};
+
+int main()
+{
+  std::map<int, payload> m;
+  m[1] = payload(10);
+
+  // Comparing const_iterators must not require mapped_type to be comparable.
+  const std::map<int, payload> &cm = m;
+  assert(cm.find(1) != cm.end());
+  assert(cm.find(9) == cm.end());
+  assert(cm.begin() != cm.end());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq_fail/main.cpp
@@ -1,0 +1,23 @@
+#include <map>
+#include <cassert>
+
+struct payload
+{
+  int v;
+  payload() : v(0)
+  {
+  }
+  payload(int x) : v(x)
+  {
+  }
+};
+
+int main()
+{
+  std::map<int, payload> m;
+  m[1] = payload(10);
+  const std::map<int, payload> &cm = m;
+  // A key that is not present compares equal to end().
+  assert(cm.find(9) != cm.end());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_map_const_iterator_eq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -211,23 +211,14 @@ public:
 
     bool operator==(const const_iterator &it) const
     {
-      if (this->it_pos == it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first == it.it_pair.first) &&
-        (this->it_pair.second == it.it_pair.second))
-        return true;
-      return false;
+      // Position, not the cached pair: comparing it_pair needs mapped_type
+      // to be equality-comparable, and end() fills it from an uninitialised
+      // slot. Matches the non-const twins (github #6354).
+      return this->it_pos == it.it_pos && this->it_key == it.it_key;
     }
     bool operator!=(const const_iterator &it) const
     {
-      if (this->it_pos != it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first != it.it_pair.first) &&
-        (this->it_pair.second != it.it_pair.second))
-        return true;
-      return false;
+      return !(*this == it);
     }
   };
 
@@ -478,23 +469,14 @@ public:
 
     bool operator==(const const_reverse_iterator &it) const
     {
-      if (this->it_pos == it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first == it.it_pair.first) &&
-        (this->it_pair.second == it.it_pair.second))
-        return true;
-      return false;
+      // Position, not the cached pair: comparing it_pair needs mapped_type
+      // to be equality-comparable, and end() fills it from an uninitialised
+      // slot. Matches the non-const twins (github #6354).
+      return this->it_pos == it.it_pos && this->it_key == it.it_key;
     }
     bool operator!=(const const_reverse_iterator &it) const
     {
-      if (this->it_pos != it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first != it.it_pair.first) &&
-        (this->it_pair.second != it.it_pair.second))
-        return true;
-      return false;
+      return !(*this == it);
     }
   };
 
@@ -1424,23 +1406,14 @@ public:
 
     bool operator==(const const_iterator &it) const
     {
-      if (this->it_pos == it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first == it.it_pair.first) &&
-        (this->it_pair.second == it.it_pair.second))
-        return true;
-      return false;
+      // Position, not the cached pair: comparing it_pair needs mapped_type
+      // to be equality-comparable, and end() fills it from an uninitialised
+      // slot. Matches the non-const twins (github #6354).
+      return this->it_pos == it.it_pos && this->it_key == it.it_key;
     }
     bool operator!=(const const_iterator &it) const
     {
-      if (this->it_pos != it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first != it.it_pair.first) &&
-        (this->it_pair.second != it.it_pair.second))
-        return true;
-      return false;
+      return !(*this == it);
     }
   };
 
@@ -1691,23 +1664,14 @@ public:
 
     bool operator==(const const_reverse_iterator &it) const
     {
-      if (this->it_pos == it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first == it.it_pair.first) &&
-        (this->it_pair.second == it.it_pair.second))
-        return true;
-      return false;
+      // Position, not the cached pair: comparing it_pair needs mapped_type
+      // to be equality-comparable, and end() fills it from an uninitialised
+      // slot. Matches the non-const twins (github #6354).
+      return this->it_pos == it.it_pos && this->it_key == it.it_key;
     }
     bool operator!=(const const_reverse_iterator &it) const
     {
-      if (this->it_pos != it.it_pos)
-        return true;
-      if (
-        (this->it_pair.first != it.it_pair.first) &&
-        (this->it_pair.second != it.it_pair.second))
-        return true;
-      return false;
+      return !(*this == it);
     }
   };
 


### PR DESCRIPTION
`map`'s `iterator` and `reverse_iterator` were changed to compare **position**
for #6354 — the cached `it_pair` is filled from an uninitialised slot at
`end()`, which made `find(k) != end()` unreliable. Their `const` twins kept the
pair comparison.

That has a second consequence the original fix did not mention: comparing two
`const_iterator`s required `mapped_type` to be equality-comparable. So

```cpp
forall_goto_functions (f_it, goto_functions)   // map<irep_idt, goto_functiont>
```

did not compile — `goto_functiont` has no `operator!=`:

```
map:236: error: invalid operands to binary expression
  ('goto_functiont' and 'goto_functiont')
note: in instantiation of 'const_iterator::operator!=' requested here
```

All four const variants (`const_iterator` and `const_reverse_iterator`, in both
`map` and `multimap`) now compare position, matching their non-const twins.

Refs #5868
