### PR TITLE
[om] Give unordered_map and unordered_set their Allocator parameter

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param/main.cpp
@@ -1,0 +1,30 @@
+#include <unordered_map>
+#include <unordered_set>
+#include <memory>
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  // [unord.map.overview] / [unord.set.overview]: five and four parameters.
+  std::unordered_map<
+    int, int, std::hash<int>, std::equal_to<int>,
+    std::allocator<std::pair<const int, int>>> m;
+  m[1] = 10;
+  assert(m[1] == 10);
+  assert(m.size() == 1);
+
+  std::unordered_set<
+    int, std::hash<int>, std::equal_to<int>, std::allocator<int>> s;
+  s.insert(4);
+  assert(s.count(4) == 1);
+
+  // The defaults must still work.
+  std::unordered_map<int, int> dm;
+  dm[3] = 30;
+  assert(dm[3] == 30);
+  std::unordered_set<int> ds;
+  ds.insert(6);
+  assert(ds.count(6) == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <unordered_set>
+#include <memory>
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  std::unordered_set<
+    int, std::hash<int>, std::equal_to<int>, std::allocator<int>> s;
+  s.insert(4);
+  // A set holds one copy of an equivalent key.
+  assert(s.count(4) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_allocator_param_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/unordered_map
+++ b/src/cpp/library/unordered_map
@@ -5,6 +5,7 @@
 #if __cplusplus >= 201103L
 
 #include <utility>
+#include <memory> /* std::allocator, for the Allocator parameter */
 
 namespace std {
 
@@ -29,8 +30,12 @@ struct esbmc_um_equal_to {
 };
 
 // Forward declaration
-template<typename Key, typename Value, typename Hash = esbmc_um_hash<Key>, 
-         typename KeyEqual = esbmc_um_equal_to<Key>>
+// [unord.map.overview]: the Allocator parameter completes the signature. The
+// fixed array below does the allocating, so it is carried for the signature and
+// the allocator_type typedef only.
+template<typename Key, typename Value, typename Hash = esbmc_um_hash<Key>,
+         typename KeyEqual = esbmc_um_equal_to<Key>,
+         typename Allocator = allocator<std::pair<const Key, Value>>>
 class unordered_map;
 
 // Iterator for unordered_map
@@ -152,7 +157,8 @@ public:
 };
 
 // Simple unordered_map implementation using fixed-size array
-template<typename Key, typename Value, typename Hash, typename KeyEqual>
+template<typename Key, typename Value, typename Hash, typename KeyEqual,
+         typename Allocator>
 class unordered_map {
 public:
     // Type definitions
@@ -162,6 +168,7 @@ public:
     typedef std::pair<Key, Value> value_type;
     typedef Hash hasher;
     typedef KeyEqual key_equal;
+    typedef Allocator allocator_type;
     typedef value_type& reference;
     typedef const value_type& const_reference;
     typedef value_type* pointer;

--- a/src/cpp/library/unordered_set
+++ b/src/cpp/library/unordered_set
@@ -5,6 +5,7 @@
 #if __cplusplus >= 201103L
 
 #include <utility>
+#include <memory> /* std::allocator, for the Allocator parameter */
 
 namespace std {
 
@@ -29,8 +30,12 @@ struct esbmc_equal_to {
 };
 
 // Forward declaration
-template<typename Key, typename Hash = esbmc_hash<Key>, 
-         typename KeyEqual = esbmc_equal_to<Key>>
+// [unord.set.overview]: the Allocator parameter completes the signature. The
+// fixed array below does the allocating, so it is carried for the signature and
+// the allocator_type typedef only.
+template<typename Key, typename Hash = esbmc_hash<Key>,
+         typename KeyEqual = esbmc_equal_to<Key>,
+         typename Allocator = allocator<Key>>
 class unordered_set;
 
 // Simple array-based implementation - much simpler than hash table
@@ -91,7 +96,7 @@ public:
 };
 
 // Simple unordered_set implementation using fixed-size array
-template<typename Key, typename Hash, typename KeyEqual>
+template<typename Key, typename Hash, typename KeyEqual, typename Allocator>
 class unordered_set {
 public:
     // Type definitions
@@ -99,6 +104,7 @@ public:
     typedef Key value_type;
     typedef Hash hasher;
     typedef KeyEqual key_equal;
+    typedef Allocator allocator_type;
     typedef value_type& reference;
     typedef const value_type& const_reference;
     typedef value_type* pointer;


### PR DESCRIPTION
`unordered_map` and `unordered_set` both stopped at `KeyEqual`, so naming the
allocator failed with `too many template arguments for class template
'unordered_map'`. It was the first parse error in 11 of a 60-TU sample of
ESBMC's own sources — the unordered counterpart of the same gap #7163 fixes in
`map`/`set`.

The fixed arrays behind these containers do the allocating, so the parameter is
carried for the signature and the `allocator_type` typedef only.

`unordered_multiset` needs the same parameter, but it only exists on #7156's
branch, so it is handled there rather than here.

Refs #5868
