### PR TITLE
[om] Add is_scalar and map's const ordered lookups

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup/main.cpp
@@ -1,0 +1,28 @@
+#include <type_traits>
+#include <map>
+#include <cassert>
+
+struct S
+{
+  int m;
+};
+
+int main()
+{
+  // [meta.unary.comp]
+  static_assert(std::is_scalar<int>::value, "arithmetic");
+  static_assert(std::is_scalar<int *>::value, "pointer");
+  static_assert(std::is_scalar<int S::*>::value, "member pointer");
+  static_assert(std::is_scalar<const double>::value, "cv-qualified");
+  static_assert(!std::is_scalar<S>::value, "class");
+  static_assert(!std::is_scalar<int &>::value, "reference");
+  static_assert(std::is_scalar_v<int>, "_v alias");
+
+  // [associative.reqmts]: the ordered lookups have const overloads.
+  std::map<int, int> m;
+  m[2] = 20;
+  const std::map<int, int> &cm = m;
+  assert(cm.lower_bound(2) != cm.end());
+  assert(cm.upper_bound(2) == cm.end());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <map>
+#include <cassert>
+
+int main()
+{
+  std::map<int, int> m;
+  m[2] = 20;
+  const std::map<int, int> &cm = m;
+  // upper_bound(2) is past the last element, so it is end().
+  assert(cm.upper_bound(2) != cm.end());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_scalar_const_lookup_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -1142,6 +1142,24 @@ public:
   }
 #endif
 
+  /* [associative.reqmts]: the ordered lookups have const overloads. The
+   * non-const bodies below only read, so the const ones delegate. */
+  const_iterator lower_bound(const key_type &x) const
+  {
+    return const_cast<map *>(this)->lower_bound(x);
+  }
+
+  const_iterator upper_bound(const key_type &x) const
+  {
+    return const_cast<map *>(this)->upper_bound(x);
+  }
+
+  pair<const_iterator, const_iterator> equal_range(const key_type &k) const
+  {
+    pair<iterator, iterator> r = const_cast<map *>(this)->equal_range(k);
+    return pair<const_iterator, const_iterator>(r.first, r.second);
+  }
+
   iterator lower_bound(const key_type &x)
   {
     unsigned int s = this->_size;

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -496,6 +496,17 @@ struct is_reference : integral_constant<bool, is_lvalue_reference<T>::value ||
 
 // [meta.unary.comp]: an object type is any type that is not a function type,
 // not a reference type, and not cv void.
+/* [meta.unary.comp]: a scalar type is an arithmetic type, an enumeration, a
+ * pointer, a pointer to member, or nullptr_t, possibly cv-qualified. */
+template <class T>
+struct is_scalar
+  : integral_constant<
+      bool,
+      is_arithmetic<T>::value || is_enum<T>::value || is_pointer<T>::value ||
+        is_member_pointer<T>::value || is_null_pointer<T>::value>
+{
+};
+
 template <class T>
 struct is_object
   : integral_constant<
@@ -943,6 +954,8 @@ template <class T>
 inline constexpr bool is_class_v = is_class<T>::value;
 template <class T>
 inline constexpr bool is_object_v = is_object<T>::value;
+template <class T>
+inline constexpr bool is_scalar_v = is_scalar<T>::value;
 template <class T>
 inline constexpr bool is_polymorphic_v = is_polymorphic<T>::value;
 template <class T>

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -497,7 +497,9 @@ struct is_reference : integral_constant<bool, is_lvalue_reference<T>::value ||
 // [meta.unary.comp]: an object type is any type that is not a function type,
 // not a reference type, and not cv void.
 /* [meta.unary.comp]: a scalar type is an arithmetic type, an enumeration, a
- * pointer, a pointer to member, or nullptr_t, possibly cv-qualified. */
+ * pointer, a pointer to member, or nullptr_t, possibly cv-qualified. Guarded
+ * because is_null_pointer -- and the trait itself -- are C++11. */
+#if __cplusplus >= 201103L
 template <class T>
 struct is_scalar
   : integral_constant<
@@ -506,6 +508,7 @@ struct is_scalar
         is_member_pointer<T>::value || is_null_pointer<T>::value>
 {
 };
+#endif
 
 template <class T>
 struct is_object


### PR DESCRIPTION
Two gaps the self-verification census turned up, each the **first** parse error
in 3 files of a 60-TU sample of ESBMC's own sources:

- `<type_traits>` had no `is_scalar`.
- `map`'s `lower_bound`, `upper_bound` and `equal_range` had no `const`
  overload, so none could be called on a `const std::map`. The non-const bodies
  only read, so the const overloads delegate through a non-const view of the
  same storage.

`is_scalar` is guarded for C++11 because it is defined in terms of
`is_null_pointer`, which is C++11-only — an unguarded first version made every
`--std c++03` translation unit including `<type_traits>` fail to parse, caught
by `github_3267_uint32_no_stdint_cxx03`, `github_5868_fstream_cxx03` and
`github_5868_iterator_ops{,_fail}`.

`basic_string::find_last_not_of` is missing too and was in an earlier draft, but
it is **left out deliberately**: every function in that search family is too
slow to execute, including the existing `find_first_not_of`, which times out on
unpatched master. I could not write a regression test that covers it.

Refs #5868
