### PR TITLE
[om] Add is_compound and filesystem::u8path

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_is_compound/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_compound/main.cpp
@@ -1,0 +1,13 @@
+#include <type_traits>
+struct S { int m; };
+int main()
+{
+  static_assert(!std::is_compound<int>::value, "arithmetic");
+  static_assert(!std::is_compound<void>::value, "void");
+  static_assert(std::is_compound<S>::value, "class");
+  static_assert(std::is_compound<int *>::value, "pointer");
+  static_assert(std::is_compound<int &>::value, "reference");
+  static_assert(std::is_compound<int[3]>::value, "array");
+  static_assert(std::is_compound_v<S>, "_v alias");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_compound/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_compound/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_is_compound_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_is_compound_fail/main.cpp
@@ -1,0 +1,9 @@
+#include <type_traits>
+#include <cassert>
+
+int main()
+{
+  // [meta.unary.comp]: int is fundamental, so it is not compound.
+  assert(std::is_compound<int>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_is_compound_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_is_compound_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/filesystem
+++ b/src/cpp/library/filesystem
@@ -132,6 +132,16 @@ inline bool equivalent(const path &a, const path &b)
   return a == b;
 }
 
+/* [fs.path.factory]: u8path builds a path from UTF-8 encoded source. This
+ * model's path already stores a narrow string, so it is the path constructor.
+ * The iterator-pair overload is deliberately absent rather than declared
+ * without a body, which would convert as a nondeterministic return. */
+template <class Source>
+inline path u8path(const Source &source)
+{
+  return path(source);
+}
+
 } // namespace filesystem
 } // namespace std
 

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -425,6 +425,13 @@ struct is_fundamental : integral_constant<
 {
 };
 
+// is_compound: everything that is not fundamental ([meta.unary.comp]).
+// Unguarded, like is_fundamental itself, which guards its own C++11 part.
+template <class T>
+struct is_compound : integral_constant<bool, !is_fundamental<T>::value>
+{
+};
+
 // is_pointer
 template <class T>
 struct is_pointer : false_type
@@ -924,6 +931,8 @@ template <class T>
 inline constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
 template <class T>
 inline constexpr bool is_fundamental_v = is_fundamental<T>::value;
+template <class T>
+inline constexpr bool is_compound_v = is_compound<T>::value;
 template <class T>
 inline constexpr bool is_integral_v = is_integral<T>::value;
 template <class T>


### PR DESCRIPTION
Two gaps from the self-verification census, measured on master `8fe879d8ac`:

- `std::filesystem::u8path` — the first parse error in **11** of a 60-TU sample.
- `std::is_compound` — the first parse error in **3** more.

`is_compound` is the complement of `is_fundamental` ([meta.unary.comp]) and is
unguarded because `is_fundamental` is: it guards its own C++11 part internally.
(Three earlier PRs in this series broke `--std c++03` by naming something that
was guarded, so this one was checked before writing.)

`u8path` ships **without a runtime test**, deliberately and with the reason
stated: the `path` model cannot be executed at all — even

```cpp
std::filesystem::path p("a"); p.empty();
```

times out on unpatched master, so no assertion over a `path` can converge. Its
effect is verified the only way available: `jimple-converter.cpp`, one of the 11,
no longer reports `u8path` among its errors and advances to a later wall. The
two regression tests here cover `is_compound`.

The iterator-pair overload of `u8path` is deliberately absent rather than
declared without a body, which would convert as a nondeterministic return.

Refs #5868
