### PR TITLE
[om] Take the argument of string::compare by const reference

### DIFF
--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -477,12 +477,15 @@ public:
   size_t length() const;
   int compare(const basic_string<CharT, Traits, Alloc> &s) const;
   int compare(const char *s) const;
-  int compare(int pos1, size_t n1, basic_string<CharT, Traits, Alloc> &s) const;
+  int compare(
+    int pos1,
+    size_t n1,
+    const basic_string<CharT, Traits, Alloc> &s) const;
   int compare(int pos1, size_t n1, const char *s) const;
   int compare(
     size_t pos1,
     size_t n1,
-    basic_string<CharT, Traits, Alloc> &s,
+    const basic_string<CharT, Traits, Alloc> &s,
     size_t pos2,
     size_t n2) const;
   size_t find_first_of(
@@ -2445,7 +2448,7 @@ template <typename CharT, typename Traits, typename Alloc>
 int basic_string<CharT, Traits, Alloc>::compare(
   int pos1,
   size_t n1,
-  basic_string<CharT, Traits, Alloc> &s) const
+  const basic_string<CharT, Traits, Alloc> &s) const
 {
 __ESBMC_HIDE:
   __ESBMC_assert(
@@ -2458,7 +2461,7 @@ template <typename CharT, typename Traits, typename Alloc>
 int basic_string<CharT, Traits, Alloc>::compare(
   size_t pos1,
   size_t n1,
-  basic_string<CharT, Traits, Alloc> &s,
+  const basic_string<CharT, Traits, Alloc> &s,
   size_t pos2,
   size_t n2) const
 {


### PR DESCRIPTION
The two positional `compare` overloads took `basic_string&` rather than
`const basic_string&`, so comparing against a const string did not compile:

```
error: no matching member function for call to 'compare'
```

It was the first parse error in **4** of a 60-TU sample of ESBMC's own sources.

Adding `const` only widens what compiles — no call that resolved before
resolves differently — which matters here because this family **cannot be
executed**: `a.compare(b)` on two `std::string`s times out on unpatched master,
so no assertion over it converges and there is no runtime test to write.

The effect is verified the only way available, and the result is strong:
`value_set.cpp`, one of the 4, now parses with **0 errors** on an integration
build — this was its last blocker.

Two further deviations from [string.compare] are **left alone deliberately**,
because they are signature changes that could alter overload resolution and I
could not verify them for the same reason:

- `pos1` is `int` rather than `size_type`;
- the `(pos1, n1, const charT* s, n2)` overload is missing.

Refs #5868
