### PR TITLE
[om] Template std::function's call target on its signature

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_function_signatures/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_function_signatures/main.cpp
@@ -1,0 +1,49 @@
+#include <functional>
+#include <cassert>
+
+static int g_seen = 0;
+static void sink(int x)
+{
+  g_seen = x;
+}
+
+struct pt
+{
+  int x;
+  int y;
+};
+
+int main()
+{
+  // The previous model routed every call through int invoke(int) /
+  // int invoke(int, int), so anything else truncated or did not compile.
+  std::function<double(double)> d = [](double x) { return x + 0.5; };
+  assert(d(2.0) == 2.5);
+
+  std::function<void(int)> v = sink;
+  v(7);
+  assert(g_seen == 7);
+
+  std::function<bool(int, int)> b = [](int a, int c) { return a < c; };
+  assert(b(1, 2));
+  assert(!b(2, 1));
+
+  std::function<int()> n = []() { return 42; };
+  assert(n() == 42);
+
+  std::function<int(pt)> s = [](pt p) { return p.x + p.y; };
+  pt p;
+  p.x = 3;
+  p.y = 4;
+  assert(s(p) == 7);
+
+  std::function<int(int, int, int)> t = [](int a, int c, int e) {
+    return a + c + e;
+  };
+  assert(t(1, 2, 3) == 6);
+
+  assert(static_cast<bool>(d));
+  std::function<int(int)> empty;
+  assert(!static_cast<bool>(empty));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_function_signatures/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_function_signatures/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_function_signatures_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_function_signatures_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <functional>
+#include <cassert>
+
+int main()
+{
+  std::function<double(double)> f = [](double x) { return x + 0.5; };
+  // The argument and result are doubles, so this is 2.5 -- routing the call
+  // through an int would truncate it to 2.
+  assert(f(2.0) == 2.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_function_signatures_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_function_signatures_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -75,36 +75,21 @@ reference_wrapper<const T> cref(reference_wrapper<T> t) noexcept
 template <class T>
 void cref(const T &&) = delete;
 
-// Base class for callable objects
+/* Type-erased call target for function<Ret(Args...)>. Templating on the
+ * signature is what lets a non-int signature work: the previous callable_base
+ * hard-coded `int invoke(int)` and `int invoke(int, int)`, so a
+ * function<double(double)> truncated its argument and its result on the way
+ * through and reported a spurious violation. */
+template <typename Ret, typename... Args>
 class callable_base
 {
 public:
   virtual ~callable_base() = default;
-  virtual int invoke(int, int) const
-  {
-    assert(false);
-    return 0;
-  }
-  virtual int invoke(int) const
-  {
-    assert(false);
-    return 0;
-  }
-  virtual bool invoke_bool(int, int) const
-  {
-    assert(false);
-    return false;
-  }
-  virtual bool invoke_bool(int) const
-  {
-    assert(false);
-    return false;
-  }
+  virtual Ret invoke(Args... args) const = 0;
 };
 
-// Wrapper for callable types (function pointers, lambdas, functors)
-template <typename Callable>
-class callable_wrapper : public callable_base
+template <typename Callable, typename Ret, typename... Args>
+class callable_wrapper : public callable_base<Ret, Args...>
 {
 private:
   Callable func;
@@ -114,60 +99,12 @@ public:
   {
   }
 
-  int invoke(int a, int b) const override
+  Ret invoke(Args... args) const override
   {
-    if constexpr (::std::is_invocable_v<Callable, int, int>)
-    {
-      return func(a, b);
-    }
-    else
-    {
-      assert(false);
-      return 0;
-    }
-  }
-
-  int invoke(int a) const override
-  {
-    if constexpr (::std::is_invocable_v<Callable, int>)
-    {
-      return func(a);
-    }
-    else
-    {
-      assert(false);
-      return 0;
-    }
-  }
-
-  bool invoke_bool(int a, int b) const override
-  {
-    if constexpr (::std::is_invocable_r_v<bool, Callable, int, int>)
-    {
-      return func(a, b);
-    }
-    else
-    {
-      assert(false);
-      return false;
-    }
-  }
-
-  bool invoke_bool(int a) const override
-  {
-    if constexpr (::std::is_invocable_r_v<bool, Callable, int>)
-    {
-      return func(a);
-    }
-    else
-    {
-      assert(false);
-      return false;
-    }
+    return func(::std::forward<Args>(args)...);
   }
 };
 
-// Standard-like std::function model
 template <typename Signature>
 class function;
 
@@ -175,7 +112,7 @@ template <typename Ret, typename... Args>
 class function<Ret(Args...)>
 {
 private:
-  callable_base *func = nullptr;
+  callable_base<Ret, Args...> *func = nullptr;
 
 public:
   function() = default;
@@ -184,14 +121,14 @@ public:
   {
     if (f)
     {
-      func = new callable_wrapper<Ret (*)(Args...)>(move(f));
+      func = new callable_wrapper<Ret (*)(Args...), Ret, Args...>(move(f));
     }
   }
 
   template <typename Callable>
   function(Callable f)
   {
-    func = new callable_wrapper<Callable>(move(f));
+    func = new callable_wrapper<Callable, Ret, Args...>(move(f));
   }
 
   function(const function &other) = delete;


### PR DESCRIPTION
`callable_base` hard-coded `int invoke(int)` and `int invoke(int, int)`, so
every call through a `std::function` was routed via `int`. Two consequences:

**A silent wrong result.** `std::function<double(double)>` compiled — `double`
converts to `int` — and truncated both its argument and its result, so ESBMC
reported a spurious violation on correct code:

```cpp
std::function<double(double)> f = [](double x) { return x + 0.5; };
double r = f(2.0);
assert(r == 2.5);   // VERIFICATION FAILED on master; holds under clang++
```

**A parse failure for everything else.** Any signature that would not convert
to those two — `void(int)`, `int()`, `int(pt)`, three arguments — failed with
`no matching member function for call to 'invoke'`. That was the first parse
error in 4 of a 60-TU sample of ESBMC's own sources.

Templating `callable_base` on `Ret` and `Args...` is the ordinary type-erasure
shape and fixes both. The test covers `double`, `void`, `bool`, a class-typed
argument, and 0-, 2- and 3-argument signatures, plus `operator bool` on an empty
`function`; the negative test pins the truncation specifically.

Refs #5868
