### PR TITLE
[om] Add the generic nothrow and trivially constructible traits

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially/main.cpp
@@ -1,0 +1,49 @@
+#include <type_traits>
+
+struct trivial
+{
+  int a;
+};
+
+struct throwing
+{
+  throwing()
+  {
+    throw 1;
+  }
+};
+
+struct nontrivial
+{
+  nontrivial()
+  {
+  }
+  ~nontrivial()
+  {
+  }
+};
+
+int main()
+{
+  // [meta.unary.prop]
+  static_assert(std::is_nothrow_default_constructible<int>::value, "int");
+  static_assert(std::is_nothrow_default_constructible<trivial>::value, "pod");
+  static_assert(
+    !std::is_nothrow_default_constructible<throwing>::value, "throws");
+
+  static_assert(std::is_nothrow_constructible<int>::value, "0 args");
+  static_assert(std::is_nothrow_constructible<int, int>::value, "1 arg");
+  static_assert(std::is_nothrow_assignable<int &, int>::value, "assign");
+
+  static_assert(std::is_trivially_constructible<trivial>::value, "trivial");
+  static_assert(!std::is_trivially_constructible<nontrivial>::value, "nontrivial");
+  static_assert(std::is_trivially_copy_constructible<trivial>::value, "copy");
+  static_assert(std::is_trivially_move_constructible<trivial>::value, "move");
+  static_assert(std::is_trivially_assignable<int &, int>::value, "assignable");
+  static_assert(std::is_trivially_copy_assignable<trivial>::value, "copy assign");
+  static_assert(std::is_trivially_move_assignable<trivial>::value, "move assign");
+
+  static_assert(std::is_nothrow_default_constructible_v<int>, "_v alias");
+  static_assert(std::is_trivially_constructible_v<trivial>, "_v alias");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially_fail/main.cpp
@@ -1,0 +1,17 @@
+#include <type_traits>
+#include <cassert>
+
+struct throwing
+{
+  throwing()
+  {
+    throw 1;
+  }
+};
+
+int main()
+{
+  // Its default constructor throws, so the trait is false.
+  assert(std::is_nothrow_default_constructible<throwing>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_nothrow_trivially_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -786,6 +786,80 @@ struct is_nothrow_move_assignable
 {
 };
 
+/* [meta.unary.prop]: the generic nothrow/trivially forms. The specialised ones
+ * above were written out individually; these are the ones they are defined in
+ * terms of, and were missing. All sit inside the C++11 guard already opened
+ * above, since they name add_rvalue_reference. */
+template <class T, class... Args>
+struct is_nothrow_constructible
+  : integral_constant<bool, __is_nothrow_constructible(T, Args...)>
+{
+};
+
+template <class T>
+struct is_nothrow_default_constructible
+  : integral_constant<bool, __is_nothrow_constructible(T)>
+{
+};
+
+template <class T, class U>
+struct is_nothrow_assignable
+  : integral_constant<bool, __is_nothrow_assignable(T, U)>
+{
+};
+
+template <class T, class... Args>
+struct is_trivially_constructible
+  : integral_constant<bool, __is_trivially_constructible(T, Args...)>
+{
+};
+
+template <class T>
+struct is_trivially_copy_constructible
+  : integral_constant<
+      bool,
+      __is_trivially_constructible(
+        T,
+        typename add_lvalue_reference<const T>::type)>
+{
+};
+
+template <class T>
+struct is_trivially_move_constructible
+  : integral_constant<
+      bool,
+      __is_trivially_constructible(
+        T,
+        typename add_rvalue_reference<T>::type)>
+{
+};
+
+template <class T, class U>
+struct is_trivially_assignable
+  : integral_constant<bool, __is_trivially_assignable(T, U)>
+{
+};
+
+template <class T>
+struct is_trivially_copy_assignable
+  : integral_constant<
+      bool,
+      __is_trivially_assignable(
+        typename add_lvalue_reference<T>::type,
+        typename add_lvalue_reference<const T>::type)>
+{
+};
+
+template <class T>
+struct is_trivially_move_assignable
+  : integral_constant<
+      bool,
+      __is_trivially_assignable(
+        typename add_lvalue_reference<T>::type,
+        typename add_rvalue_reference<T>::type)>
+{
+};
+
 /* Storage aligned for any object of size Len. The standard's default is the
  * strictest alignment any such object could need, which __BIGGEST_ALIGNMENT__
  * bounds from above. */
@@ -1009,6 +1083,18 @@ inline constexpr bool is_trivially_default_constructible_v =
 template <class T>
 inline constexpr bool is_trivially_destructible_v =
   is_trivially_destructible<T>::value;
+template <class T, class... Args>
+inline constexpr bool is_nothrow_constructible_v =
+  is_nothrow_constructible<T, Args...>::value;
+template <class T>
+inline constexpr bool is_nothrow_default_constructible_v =
+  is_nothrow_default_constructible<T>::value;
+template <class T, class U>
+inline constexpr bool is_nothrow_assignable_v =
+  is_nothrow_assignable<T, U>::value;
+template <class T, class... Args>
+inline constexpr bool is_trivially_constructible_v =
+  is_trivially_constructible<T, Args...>::value;
 template <class T>
 inline constexpr bool is_array_v = is_array<T>::value;
 template <class T>


### PR DESCRIPTION
`<type_traits>` had `is_nothrow_move_constructible`, `is_nothrow_copy_assignable`
and their siblings written out individually, but **not the generic forms they are
defined in terms of** — all nine of these were missing:

`is_nothrow_constructible`, `is_nothrow_default_constructible`,
`is_nothrow_assignable`, `is_trivially_constructible`,
`is_trivially_copy_constructible`, `is_trivially_move_constructible`,
`is_trivially_assignable`, `is_trivially_copy_assignable`,
`is_trivially_move_assignable`.

`is_nothrow_default_constructible` was the first parse error in **11** of a 60-TU
sample of ESBMC's own sources, and `is_trivially_constructible` in **3** more.

Each maps to the Clang builtin the existing specialised traits already use, and
all sit inside the `#if __cplusplus >= 201103L` already open at that point, since
they name `add_rvalue_reference` — checked before writing, after three earlier
PRs in this series broke `--std c++03` by naming something guarded.

Refs #5868
