### PR TITLE
[om] Make std::string's primitives converge, and fix rfind

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_string_assign_converges/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_assign_converges/main.cpp
@@ -1,0 +1,27 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string a("abc");
+  std::string b("xy");
+
+  // Copying one std::string into another used to scan to a NUL over a
+  // symbolic buffer and never terminate.
+  a = b;
+  assert(a.size() == 2);
+  assert(a[0] == 'x');
+  assert(a[1] == 'y');
+  assert(a.c_str()[2] == '\0');
+
+  // Self-assignment.
+  b = b;
+  assert(b.size() == 2);
+
+  // Assigning a longer string over a shorter one.
+  std::string c("z");
+  c = a;
+  assert(c.size() == 2);
+  assert(c[1] == 'y');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_assign_converges/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_assign_converges/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_assign_converges_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_assign_converges_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string a("abc");
+  std::string b("xy");
+  a = b;
+  // Assignment replaces the contents, so a is "xy" and its size is 2.
+  assert(a.size() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_assign_converges_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_assign_converges_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_string_concat_converges/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_concat_converges/main.cpp
@@ -1,0 +1,18 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string a("ab");
+  std::string b("cd");
+
+  std::string ab = a + b;
+  assert(ab.size() == 4);
+  assert(ab[0] == 'a');
+  assert(ab[3] == 'd');
+
+  std::string ac = a + 'z';
+  assert(ac.size() == 3);
+  assert(ac[2] == 'z');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_concat_converges/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_concat_converges/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_concat_converges_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_concat_converges_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string a("ab");
+  std::string b("cd");
+  std::string ab = a + b;
+  // Concatenation keeps both operands, so the result is four characters.
+  assert(ab.size() == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_concat_converges_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_concat_converges_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_converges/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_converges/main.cpp
@@ -1,0 +1,14 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("abcabc");
+
+  // [string.find]: the lowest matching position at or after pos.
+  assert(s.find('b') == 1);
+  assert(s.find('b', 2) == 4);
+  assert(s.find('z') == std::string::npos);
+  assert(s.find("bc") == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_converges/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_converges/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_converges_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_converges_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("abcabc");
+  // find returns the LOWEST matching position, so this is 1, not 4.
+  assert(s.find('b') == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_converges_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_converges_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges/main.cpp
@@ -1,0 +1,14 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("xxabc");
+
+  // [string.find.first.not.of] / [string.find.first.of]
+  assert(s.find_first_not_of('x') == 2);
+  assert(s.find_first_of('a') == 2);
+  assert(s.find_first_not_of("x") == 2);
+  assert(s.find_first_of("ba") == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("xxabc");
+  // The first character not in "x" is at index 2, not 0.
+  assert(s.find_first_not_of('x') == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_find_first_converges_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_string_rfind/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_rfind/main.cpp
@@ -1,0 +1,19 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("abcabc");
+
+  // [string.rfind]: the highest position at or before pos holding c.
+  assert(s.rfind('a') == 3);
+  assert(s.rfind('a', 2) == 0);
+  assert(s.rfind('z') == std::string::npos);
+
+  std::string one("abc");
+  assert(one.rfind('a') == 0);
+
+  // [string.find.last.of]
+  assert(s.find_last_of('b') == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_rfind/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_rfind/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_rfind_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_rfind_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("abc");
+  // 'a' is at index 0 and nowhere else, so rfind is 0, not npos.
+  assert(s.rfind('a') == std::string::npos);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_rfind_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_rfind_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2678,10 +2678,21 @@ __ESBMC_HIDE:
   if (len == 0 || slen == 0)
     return npos;
   size_t start = (pos >= len) ? len - 1 : pos;
-  for (size_t i = start + 1; i-- > 0;)
-    for (size_t j = 0; j < slen; j++)
+  /* Concrete trip counts: start and slen are symbolic, and a reverse
+   * counter from start can wrap below zero as a size_t. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (k > start)
+      break;
+    size_t i = start - k;
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
       if (this->str[i] == s.str[j])
         return i;
+    }
+  }
   return npos;
 }
 
@@ -2697,10 +2708,21 @@ __ESBMC_HIDE:
   if (len == 0 || slen == 0)
     return npos;
   size_t start = (pos >= len) ? len - 1 : pos;
-  for (size_t i = start + 1; i-- > 0;)
-    for (size_t j = 0; j < slen; j++)
+  /* Concrete trip counts: start and slen are symbolic, and a reverse
+   * counter from start can wrap below zero as a size_t. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (k > start)
+      break;
+    size_t i = start - k;
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
       if (this->str[i] == s[j])
         return i;
+    }
+  }
   return npos;
 }
 
@@ -2719,9 +2741,15 @@ __ESBMC_HIDE:
   if (len == 0)
     return npos;
   size_t start = (pos >= len) ? len - 1 : pos;
-  for (size_t i = start + 1; i-- > 0;)
+  /* Concrete trip count; see the note on find_last_of above. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (k > start)
+      break;
+    size_t i = start - k;
     if (this->str[i] == c)
       return i;
+  }
   return npos;
 }
 
@@ -2729,12 +2757,23 @@ template <typename CharT, typename Traits, typename Alloc>
 size_t basic_string<CharT, Traits, Alloc>::rfind(char c, size_t pos) const
 {
 __ESBMC_HIDE:
-  int i;
-  int len = this->length();
-  for (i = len; i > 0; i--)
+  /* [string.rfind]: the highest position at or before pos holding c. The
+   * previous loop started at str[len] -- the terminator, one past the last
+   * character -- stopped before index 0, and ignored pos entirely, so
+   * rfind('a') on "abc" reported npos. */
+  size_t len = this->length();
+  if (len == 0)
+    return npos;
+  size_t start = (pos >= len) ? len - 1 : pos;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (k > start)
+      break;
+    size_t i = start - k;
     if (this->str[i] == c)
       return i;
-  return npos; // Return npos when the character is not found
+  }
+  return npos;
 }
 
 template <typename CharT, typename Traits, typename Alloc>

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2910,20 +2910,26 @@ basic_string<CharT, Traits, Alloc> operator+(
   basic_string<CharT, Traits, Alloc> lhs,
   basic_string<CharT, Traits, Alloc> rhs)
 {
-  int totalLength = lhs.size();
-  totalLength += rhs.size();
-  int i, j, k;
+  /* Concrete trip counts: both lengths are symbolic, so the original
+   * loops never converged and `a + b` did not terminate. */
+  size_t llen = lhs.size();
+  size_t rlen = rhs.size();
   basic_string<CharT, Traits, Alloc> result;
-  for (i = 0; i < lhs.size(); i++)
+  size_t n = 0;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
-    result.str[i] = lhs.str[i];
+    if (k >= llen)
+      break;
+    result.str[n++] = lhs.str[k];
   }
-  for (j = i, k = 0; j < totalLength; j++, k++)
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
-    result.str[j] = rhs.str[k];
+    if (k >= rlen)
+      break;
+    result.str[n++] = rhs.str[k];
   }
-  result.str[j] = '\0';
-  result._size = totalLength;
+  result.str[n] = '\0';
+  result._size = n;
   return result;
 }
 
@@ -2931,20 +2937,26 @@ template <typename CharT, typename Traits, typename Alloc>
 basic_string<CharT, Traits, Alloc>
 operator+(basic_string<CharT, Traits, Alloc> lhs, char *rhs)
 {
-  int totalLength = lhs.size();
-  totalLength += strlen(rhs);
-  int i, j, k;
+  /* Concrete trip counts: both lengths are symbolic, so the original
+   * loops never converged and `a + b` did not terminate. */
+  size_t llen = lhs.size();
+  size_t rlen = strlen(rhs);
   basic_string<CharT, Traits, Alloc> result;
-  for (i = 0; i < lhs.size(); i++)
+  size_t n = 0;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
-    result.str[i] = lhs.str[i];
+    if (k >= llen)
+      break;
+    result.str[n++] = lhs.str[k];
   }
-  for (j = i, k = 0; j < totalLength; j++, k++)
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
-    result.str[j] = rhs[k];
+    if (k >= rlen)
+      break;
+    result.str[n++] = rhs[k];
   }
-  result.str[j] = '\0';
-  result._size = totalLength;
+  result.str[n] = '\0';
+  result._size = n;
   return result;
 }
 
@@ -2956,13 +2968,17 @@ operator+(basic_string<CharT, Traits, Alloc> lhs, char rhc)
   totalLength += 1;
   int i;
   basic_string<CharT, Traits, Alloc> result;
-  for (i = 0; i < lhs.size(); i++)
+  /* Concrete trip count; lhs.size() is symbolic. */
+  size_t n = 0;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
-    result.str[i] = lhs.str[i];
+    if (k >= lhs.size())
+      break;
+    result.str[n++] = lhs.str[k];
   }
-  result.str[i] = rhc;
-  result.str[i + 1] = '\0';
-  result._size = totalLength;
+  result.str[n] = rhc;
+  result.str[n + 1] = '\0';
+  result._size = n + 1;
   return result;
 }
 

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2507,10 +2507,21 @@ __ESBMC_HIDE:
   size_t slen = strlen(s);
   if (pos >= len || slen == 0)
     return npos;
-  for (size_t i = pos; i < len; i++)
-    for (size_t j = 0; j < slen; j++)
+  /* Concrete trip counts from 0: len/slen are symbolic and a counter
+   * starting at the symbolic pos can wrap, so neither loop converged. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    size_t i = pos + k;
+    if (i >= len)
+      break;
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
       if (this->str[i] == s[j])
         return i;
+    }
+  }
   return npos;
 }
 
@@ -2525,10 +2536,21 @@ __ESBMC_HIDE:
   size_t slen = s.length();
   if (pos >= len || slen == 0)
     return npos;
-  for (size_t i = pos; i < len; i++)
-    for (size_t j = 0; j < slen; j++)
+  /* Concrete trip counts from 0: len/slen are symbolic and a counter
+   * starting at the symbolic pos can wrap, so neither loop converged. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    size_t i = pos + k;
+    if (i >= len)
+      break;
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
       if (this->str[i] == s.str[j])
         return i;
+    }
+  }
   return npos;
 }
 
@@ -2540,9 +2562,16 @@ __ESBMC_HIDE:
   size_t len = this->length();
   if (pos >= len)
     return npos;
-  for (size_t i = pos; i < len; i++)
+  /* Concrete trip count from 0: len is symbolic and a counter starting
+   * at the symbolic pos can wrap. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    size_t i = pos + k;
+    if (i >= len)
+      break;
     if (this->str[i] == c)
       return i;
+  }
   return npos;
 }
 
@@ -2557,15 +2586,24 @@ __ESBMC_HIDE:
   size_t slen = s.length();
   if (pos >= len)
     return npos;
-  for (size_t i = pos; i < len; i++)
+  /* Concrete trip counts from 0: len/slen are symbolic and a counter
+   * starting at the symbolic pos can wrap, so neither loop converged. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
+    size_t i = pos + k;
+    if (i >= len)
+      break;
     bool found = false;
-    for (size_t j = 0; j < slen; j++)
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
       if (this->str[i] == s.str[j])
       {
         found = true;
         break;
       }
+    }
     if (!found)
       return i;
   }
@@ -2583,15 +2621,24 @@ __ESBMC_HIDE:
   size_t slen = strlen(s);
   if (pos >= len)
     return npos;
-  for (size_t i = pos; i < len; i++)
+  /* Concrete trip counts from 0: len/slen are symbolic and a counter
+   * starting at the symbolic pos can wrap, so neither loop converged. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
+    size_t i = pos + k;
+    if (i >= len)
+      break;
     bool found = false;
-    for (size_t j = 0; j < slen; j++)
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
       if (this->str[i] == s[j])
       {
         found = true;
         break;
       }
+    }
     if (!found)
       return i;
   }
@@ -2606,9 +2653,16 @@ __ESBMC_HIDE:
   size_t len = this->length();
   if (pos >= len)
     return npos;
-  for (size_t i = pos; i < len; i++)
+  /* Concrete trip count from 0: len is symbolic and a counter starting
+   * at the symbolic pos can wrap. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    size_t i = pos + k;
+    if (i >= len)
+      break;
     if (this->str[i] != c)
       return i;
+  }
   return npos;
 }
 

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1069,6 +1069,21 @@ typedef basic_string<wchar_t> wstring;
 
 namespace std
 {
+/* strcpy scans to a NUL, which over a symbolic buffer never converges: copying
+ * one std::string into another did not terminate. The trip count here is the
+ * fixed buffer size, which a string can never exceed. */
+static void __esbmc_string_copy(char *dst, const char *src, size_t n)
+{
+__ESBMC_HIDE:
+  for (size_t i = 0; i < STRING_CAPACITY; i++)
+  {
+    if (i >= n)
+      break;
+    dst[i] = src[i];
+  }
+  dst[n] = '\0';
+}
+
 template <typename CharT, typename Traits, typename Alloc>
 basic_string<CharT, Traits, Alloc>::basic_string()
 {
@@ -1499,7 +1514,7 @@ basic_string<CharT, Traits, Alloc>::operator=(
 {
 __ESBMC_HIDE:
   this->_size = str.length();
-  strcpy(this->str, str.str);
+  __esbmc_string_copy(this->str, str.str, this->_size);
   return *this;
 }
 
@@ -1512,7 +1527,7 @@ __ESBMC_HIDE:
   if (this == &str)
     return *this;
   this->_size = str.length();
-  strcpy(this->str, str.str);
+  __esbmc_string_copy(this->str, str.str, this->_size);
   return *this;
 }
 

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1933,11 +1933,21 @@ static size_t __esbmc_string_find(
 __ESBMC_HIDE:
   if (pos > hlen || nlen > hlen - pos)
     return (size_t)-1;
-  for (size_t xpos = pos; xpos + nlen <= hlen; xpos++)
+  /* Both trip counts are the fixed buffer size, and both counters start at a
+   * concrete 0: a bound taken from hlen/nlen is symbolic, and a counter that
+   * starts at the symbolic pos can wrap, so neither loop would converge. */
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
   {
+    size_t xpos = pos + k;
+    if (xpos + nlen > hlen)
+      break;
     size_t i = 0;
-    while (i < nlen && hay[xpos + i] == needle[i])
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (i >= nlen || hay[xpos + i] != needle[i])
+        break;
       i++;
+    }
     if (i == nlen)
       return xpos;
   }


### PR DESCRIPTION
`std::string`'s search, copy and concatenation primitives never converged, so
most of the class could not be executed at all. Same root cause throughout as
#7173: `_size` comes from `strlen`, so it stays symbolic even for a literal, and
ESBMC unwinds **syntactically**, so a loop bounded by `length()` never closes.

| primitive | on master | with this PR |
|---|---|---|
| `a = b` (assignment, was `strcpy`) | never terminates | ~3 s |
| `s.find(...)` | never terminates | ~3 s |
| `find_first_of` / `find_first_not_of` (6 overloads) | never terminates | ~5 s |
| `rfind(char)`, `find_last_of` (4 loops) | never terminates | ~5 s |
| `a + b` (3 overloads) | never terminates | ~3 s |

**`rfind(char)` was also giving a wrong answer.** It started at `str[len]` — the
terminator, one past the last character — stopped before index 0, and ignored
`pos` entirely:

```cpp
std::string s("abc");
assert(s.rfind('a') == 0);   // VERIFICATION FAILED on master; holds under clang++
```

A false positive on correct code, pinned by `github_5868_string_rfind_fail`.

Every loop had **two** hazards, not one: a symbolic *bound* (`len`, `slen`,
`size()`), and a counter starting at a symbolic *`pos`*/`start` that a `size_t`
can wrap past — forwards, or below zero for the reverse searches. Both are fixed
by counting from a concrete 0 to the fixed buffer size and deriving the index.

Note for reviewers: these loops now run to `STRING_CAPACITY`, so assertions are
not free — an eight-assertion `find` test took 57 s against CI's 120 s per-test
cap, so each test here is kept to four or five assertions (~3-5 s).

Refs #5868
