### PR TITLE
[om] Align unordered_set's capacity with its siblings

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_unordered_set_capacity/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_set_capacity/main.cpp
@@ -1,0 +1,15 @@
+#include <unordered_set>
+#include <cassert>
+
+int main()
+{
+  // The container holds at least the 64 slots its siblings do.
+  std::unordered_set<int> s;
+  for (int i = 0; i < 64; i++)
+    s.insert(i);
+  assert(s.size() == 64);
+  assert(s.count(0) == 1);
+  assert(s.count(63) == 1);
+  assert(s.count(64) == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_unordered_set_capacity/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_unordered_set_capacity/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17 --unwind 70
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/unordered_set
+++ b/src/cpp/library/unordered_set
@@ -118,7 +118,11 @@ public:
 private:
     // TODO: Implement a hash table if needed.
     // Simple fixed-size array storage
-    static const size_t MAX_SIZE = 1024; // Small size for verification
+    /* 64, matching <unordered_map> and unordered_multiset below, for the
+     * reason <unordered_map> records: with std::string's inline buffer, 1024
+     * slots made one container ~140KB and solver encodings timed out. At 1024
+     * an unordered_set<std::string> could not be executed at all. */
+    static const size_t MAX_SIZE = 64;
     Key data_[MAX_SIZE];
     size_type size_;
     hasher hash_function_;


### PR DESCRIPTION
`unordered_set` kept **1024** slots while `unordered_map` and
`unordered_multiset` both use **64**, for the reason `<unordered_map>` already
records in a comment:

> with std::string's inline buffer, 1024 slots made one map ~140KB and solver
> encodings timed out

At 1024, an `unordered_set<std::string>` could not be executed at all.

**Measured, and the dependency stated honestly.** Capacity alone is not enough —
on master `unordered_set<std::string>` still times out with 64, because the
string primitives inside it do not converge. With **#7175** as well it verifies
in ~49 s. So this change removes one of the two blockers; the string-keyed
unlock arrives when both land.

The test here therefore uses `int` keys, which exercises the capacity on master
today. All 22 tests in the `unordered_set` suite pass at 64.

Refs #5868
