### PR TITLE
[om] Give the string constructor a concrete trip count

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges/main.cpp
@@ -1,0 +1,23 @@
+#include <string>
+#include <filesystem>
+#include <cassert>
+
+int main()
+{
+  // A conditional source defeats the NUL-scan folding that a plain literal
+  // gets, so this constructor used not to converge.
+  const char *x = "abc";
+  std::string s(x ? x : "");
+  assert(s.size() == 3);
+  assert(s[0] == 'a');
+  assert(s[2] == 'c');
+
+  std::string e(x ? "" : x);
+  assert(e.size() == 0);
+  assert(e.empty());
+
+  // <filesystem>'s path is built exactly that way.
+  std::filesystem::path p("a/b");
+  assert(!p.empty());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  const char *x = "abc";
+  std::string s(x ? x : "");
+  // The source has three characters, not zero.
+  assert(s.empty());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_string_ctor_converges_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1086,9 +1086,21 @@ basic_string<CharT, Traits, Alloc>::basic_string(const CharT *s)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(s != NULL, "basic_string<CharT, Traits, Alloc> invalid");
-  _size = strlen(s);
-
-  strcpy(str, s);
+  /* strlen and strcpy both scan to a NUL. That folds for a plain literal, but
+   * not once the source is a conditional -- `std::string(x ? x : "")`, which is
+   * how <filesystem>'s path is built -- and the constructor then never
+   * converged. Measuring the length while copying, bounded by the fixed buffer,
+   * removes both scans. */
+  size_t n = 0;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (s[k] == '\0')
+      break;
+    str[k] = s[k];
+    n++;
+  }
+  str[n] = '\0';
+  _size = n;
 }
 
 template <typename CharT, typename Traits, typename Alloc>


### PR DESCRIPTION
`basic_string(const CharT *)` used `strlen` then `strcpy`, both of which scan to
a NUL. That folds for a plain literal, but **not once the source is a
conditional**:

```cpp
const char *x = "abc";
std::string s(x);              // 2 s
std::string s(x ? x : "");     // never terminates on master
```

That second form is exactly how `<filesystem>`'s `path` is built
(`path(const char *s) : __p_(s ? s : "")`), which is why constructing a
`std::filesystem::path` could not be executed at all — even
`path p("a"); p.empty();`.

Measuring the length while copying, bounded by the fixed buffer, removes both
scans. `filesystem::path` goes from never terminating to about **3 s**.

Independent of #7173/#7175: this is the constructor, which those do not touch,
and it merges cleanly with them.

Refs #5868
