### PR TITLE
[python] Let a tagged variable be rebound to a container

### DIFF
--- a/regression/python/dynamic_type_container_rebind/main.py
+++ b/regression/python/dynamic_type_container_rebind/main.py
@@ -1,0 +1,12 @@
+# Rebinding a tagged variable to a container gives the name a fresh slot of the
+# container's type, so the list is fully usable afterwards. Issue #7075: this
+# used to abort the frontend.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+x = [1, 2, 3]
+assert x[1] == 2
+assert len(x) == 3

--- a/regression/python/dynamic_type_container_rebind/test.desc
+++ b/regression/python/dynamic_type_container_rebind/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_container_rebind_fail/main.py
+++ b/regression/python/dynamic_type_container_rebind_fail/main.py
@@ -1,0 +1,10 @@
+# The rebound list is read for real rather than assumed: a wrong element value
+# is detected.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+x = [1, 2, 3]
+assert x[1] == 5

--- a/regression/python/dynamic_type_container_rebind_fail/test.desc
+++ b/regression/python/dynamic_type_container_rebind_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*assertion 2 == 5$

--- a/regression/python/dynamic_type_object_rebind/main.py
+++ b/regression/python/dynamic_type_object_rebind/main.py
@@ -1,0 +1,31 @@
+# The same rebind works for a class instance and for a tuple, and a later
+# scalar rebind still lands in a slot of its own.
+
+
+class P:
+    def __init__(self, v: int) -> None:
+        self.v: int = v
+
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+x = P(7)
+assert x.v == 7
+
+if cond:
+    y = 1
+else:
+    y = "a"
+y = (1, 2)
+assert y[0] == 1
+
+if cond:
+    z = 1
+else:
+    z = "a"
+z = [1, 2]
+z = 5
+assert z == 5

--- a/regression/python/dynamic_type_object_rebind/test.desc
+++ b/regression/python/dynamic_type_object_rebind/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -3039,43 +3039,127 @@ std::string python_converter::call_return_class(const nlohmann::json &rhs) const
   return json_utils::is_class(cls, *ast_json) ? cls : std::string();
 }
 
+symbolt *python_converter::mint_retyped_symbol(
+  const symbolt &orig,
+  const std::string &alias_key,
+  const typet &new_type,
+  const locationt &location,
+  const symbol_id &sid,
+  codet &target_block)
+{
+  std::string new_id;
+  unsigned gen = 1;
+  do
+  {
+    new_id = alias_key + "$ret" + std::to_string(gen++);
+  } while (symbol_table_.find_symbol(new_id) != nullptr);
+
+  symbolt new_symbol = create_symbol(
+    location.get_file().as_string(),
+    orig.name.as_string(),
+    new_id,
+    location,
+    new_type);
+  new_symbol.lvalue = true;
+  new_symbol.file_local = orig.file_local;
+  new_symbol.is_extern = false;
+
+  symbolt *new_symbol_ptr = symbol_table_.move_symbol_to_context(new_symbol);
+
+  // Locals need a declaration; module globals are not declared.
+  if (!current_func_name_.empty() && !is_global_variable(sid))
+  {
+    code_declt decl(symbol_expr(*new_symbol_ptr));
+    decl.location() = location;
+    target_block.copy_to_operands(decl);
+  }
+
+  retype_aliases_[alias_key] = new_id;
+  return new_symbol_ptr;
+}
+
+/// The Name a single-target Assign/AnnAssign binds, or a null json.
+static nlohmann::json assign_name_target(const nlohmann::json &ast_node)
+{
+  const std::string stmt_type = ast_node.value("_type", "");
+  nlohmann::json target;
+  if (
+    stmt_type == "Assign" && ast_node.contains("targets") &&
+    ast_node["targets"].size() == 1)
+    target = ast_node["targets"][0];
+  else if (stmt_type == "AnnAssign" && ast_node.contains("target"))
+    target = ast_node["target"];
+
+  if (target.is_object() && target.value("_type", "") == "Name")
+    return target;
+  return nlohmann::json();
+}
+
+bool python_converter::try_tagged_var_assign(
+  const nlohmann::json &ast_node,
+  codet &target_block)
+{
+  const nlohmann::json tag_target = assign_name_target(ast_node);
+  if (tag_target.is_null())
+    return false;
+
+  const std::string name = tag_target["id"].get<std::string>();
+  symbol_id tag_sid = create_symbol_id();
+  tag_sid.set_object(name);
+  const std::string tag_key = tag_sid.to_string();
+
+  // A rebind that already retyped the name away from its tagged slot wins: the
+  // live value is in the retype target, so this is an ordinary assignment to
+  // that symbol (#7075).
+  if (retype_aliases_.count(tag_key) || !dynamic_type_handler_.is_tagged(name))
+    return false;
+
+  if (ast_node.contains("value") && !ast_node["value"].is_null())
+  {
+    const locationt location = get_location_from_decl(ast_node);
+    exprt rhs = get_expr(ast_node["value"]);
+    if (
+      type_handler_.is_numeric_scalar_type(rhs.type()) ||
+      type_handler_.is_string_type(rhs.type()))
+    {
+      dynamic_type_handler_.assign(rhs, location, name, target_block);
+      return true;
+    }
+
+    // The tagged slot's payload is a fixed-width scalar copy, so it cannot
+    // hold a container or an object. Python rebinds the name outright, so give
+    // the new value its own slot and redirect later loads to it, exactly as
+    // the numeric<->string retype does (#7075). Restricted to the
+    // unconditional spine: inside a conditional body retype_aliases_ is
+    // reverted at the join, which would leave later reads observing the stale
+    // tagged value instead of the container.
+    symbolt *tag_symbol =
+      symbol_table_.find_symbol(dynamic_type_handler_.tagged_symbol_id(name));
+    if (
+      tag_symbol && current_class_name_.empty() && loop_body_depth_ == 0 &&
+      block_nesting_ == function_body_depth_ + 1 && !rhs.type().is_empty() &&
+      !rhs.type().is_code())
+    {
+      symbolt *fresh = mint_retyped_symbol(
+        *tag_symbol, tag_key, rhs.type(), location, tag_sid, target_block);
+      code_assignt assign(symbol_expr(*fresh), rhs);
+      assign.location() = location;
+      target_block.copy_to_operands(assign);
+      return true;
+    }
+  }
+
+  throw std::runtime_error(
+    "assigning a value of this type to a dynamically-typed variable "
+    "is not yet supported");
+}
+
 void python_converter::get_var_assign(
   const nlohmann::json &ast_node,
   codet &target_block)
 {
-  {
-    const std::string stmt_type = ast_node.value("_type", "");
-    nlohmann::json tag_target;
-    if (
-      stmt_type == "Assign" && ast_node.contains("targets") &&
-      ast_node["targets"].size() == 1)
-      tag_target = ast_node["targets"][0];
-    else if (stmt_type == "AnnAssign" && ast_node.contains("target"))
-      tag_target = ast_node["target"];
-
-    if (tag_target.is_object() && tag_target.value("_type", "") == "Name")
-    {
-      const std::string name = tag_target["id"].get<std::string>();
-      if (dynamic_type_handler_.is_tagged(name))
-      {
-        if (ast_node.contains("value") && !ast_node["value"].is_null())
-        {
-          exprt rhs = get_expr(ast_node["value"]);
-          if (
-            type_handler_.is_numeric_scalar_type(rhs.type()) ||
-            type_handler_.is_string_type(rhs.type()))
-          {
-            dynamic_type_handler_.assign(
-              rhs, get_location_from_decl(ast_node), name, target_block);
-            return;
-          }
-        }
-        throw std::runtime_error(
-          "assigning a value of this type to a dynamically-typed variable "
-          "is not yet supported");
-      }
-    }
-  }
+  if (try_tagged_var_assign(ast_node, target_block))
+    return;
 
   // Extract type information
   auto [lhs_type, element_type] = extract_type_info(ast_node);
@@ -3851,37 +3935,9 @@ void python_converter::get_var_assign(
           type_handler_, lhs.type(), rhs.type()) ||
         tuple_to_nontuple_rebind)
       {
-        std::string new_id;
-        unsigned gen = 1;
-        do
-        {
-          new_id = orig_id + "$ret" + std::to_string(gen++);
-        } while (symbol_table_.find_symbol(new_id) != nullptr);
+        symbolt *new_symbol_ptr = mint_retyped_symbol(
+          *lhs_symbol, orig_id, rhs.type(), location_begin, sid, target_block);
 
-        const std::string module_name = location_begin.get_file().as_string();
-        symbolt new_symbol = create_symbol(
-          module_name,
-          lhs_symbol->name.as_string(),
-          new_id,
-          location_begin,
-          rhs.type());
-        new_symbol.lvalue = true;
-        new_symbol.file_local = lhs_symbol->file_local;
-        new_symbol.is_extern = false;
-
-        symbolt *new_symbol_ptr =
-          symbol_table_.move_symbol_to_context(new_symbol);
-
-        // Locals need a declaration; module globals are not declared (matching
-        // the symbol-creation path above).
-        if (!current_func_name_.empty() && !is_global_variable(sid))
-        {
-          code_declt decl(symbol_expr(*new_symbol_ptr));
-          decl.location() = location_begin;
-          target_block.copy_to_operands(decl);
-        }
-
-        retype_aliases_[orig_id] = new_id;
         lhs_symbol = new_symbol_ptr;
         lhs = symbol_expr(*new_symbol_ptr);
         current_lhs = &lhs;

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -223,6 +223,16 @@ bool dynamic_type_handler::is_tagged(const std::string &name) const
   return sym && type_handler_.is_tagged_scalar_type(sym->get_type());
 }
 
+std::string
+dynamic_type_handler::tagged_symbol_id(const std::string &name) const
+{
+  symbol_id sid = converter_.create_symbol_id();
+  sid.set_object(name);
+  const std::string tag_id = sid.to_string();
+  auto alias = aliases_.find(tag_id);
+  return alias != aliases_.end() ? alias->second : tag_id;
+}
+
 std::vector<codet> dynamic_type_handler::build_tag_field_assigns(
   symbolt &tag_symbol,
   const exprt &rhs,
@@ -290,13 +300,8 @@ void dynamic_type_handler::assign(
   const std::string &name,
   codet &target_block)
 {
-  symbol_id sid = converter_.create_symbol_id();
-  sid.set_object(name);
-  std::string tag_id = sid.to_string();
-  auto alias = aliases_.find(tag_id);
-  if (alias != aliases_.end())
-    tag_id = alias->second;
-  symbolt *tag_symbol = converter_.symbol_table().find_symbol(tag_id);
+  symbolt *tag_symbol =
+    converter_.symbol_table().find_symbol(tagged_symbol_id(name));
   assert(
     tag_symbol &&
     "tagged scalar symbol must already be declared before its branches are "

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -44,6 +44,12 @@ public:
   bool is_tagged(const std::string &name) const;
 
   /**
+   * @brief The id of the symbol that currently holds `name`'s tagged object,
+   * following the alias created for a pre-existing variable
+   */
+  std::string tagged_symbol_id(const std::string &name) const;
+
+  /**
    * @brief Fills in the tagged-object fields for `name` from an
    * already-converted value
    */

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -818,6 +818,23 @@ private:
     exprt &rhs,
     codet &target_block);
 
+  /// Handles an assignment whose target is a dynamically-typed (tagged)
+  /// variable, returning false when the target is not tagged and the caller
+  /// should fall through to the ordinary assignment path.
+  bool
+  try_tagged_var_assign(const nlohmann::json &ast_node, codet &target_block);
+
+  /// Mints a fresh symbol of `new_type` to hold `orig`'s value from here on,
+  /// declares it in `target_block` when it is a local, and records the
+  /// redirection in retype_aliases_ under `alias_key`.
+  symbolt *mint_retyped_symbol(
+    const symbolt &orig,
+    const std::string &alias_key,
+    const typet &new_type,
+    const locationt &location,
+    const symbol_id &sid,
+    codet &target_block);
+
   void handle_list_literal_unpacking(
     const nlohmann::json &ast_node,
     const nlohmann::json &target,


### PR DESCRIPTION
Assigning a list, tuple or class instance to a dynamically-typed variable aborted the frontend, because the tagged slot only holds a fixed-width scalar copy. Python rebinds the name outright, so the new value now gets its own slot via the existing numeric<->string retype machinery.

The rebind is refused inside loop and conditional bodies, where `retype_aliases_` does not model the join.

Fixes #7075