### PR TITLE
[python] Give isinstance a verdict on dynamically-typed variables

### DIFF
--- a/regression/python/dynamic_type_isinstance_float/main.py
+++ b/regression/python/dynamic_type_isinstance_float/main.py
@@ -1,0 +1,12 @@
+# A tag can hold a float, so isinstance() against float is a real runtime
+# check on its type_id rather than a refusal. Issue #7075.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+x = 1.5
+assert isinstance(x, float)
+assert not isinstance(x, int)
+assert not isinstance(x, str)

--- a/regression/python/dynamic_type_isinstance_float/test.desc
+++ b/regression/python/dynamic_type_isinstance_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_isinstance_float_fail/main.py
+++ b/regression/python/dynamic_type_isinstance_float_fail/main.py
@@ -1,0 +1,10 @@
+# The float check is evaluated, not folded: asserting the wrong direction is
+# detected.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+x = 1.5
+assert not isinstance(x, float)

--- a/regression/python/dynamic_type_isinstance_float_fail/test.desc
+++ b/regression/python/dynamic_type_isinstance_float_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_isinstance_unholdable/main.py
+++ b/regression/python/dynamic_type_isinstance_unholdable/main.py
@@ -1,0 +1,19 @@
+# A tag only ever holds a bool, int, float or str, so an aggregate or a user
+# class can never match. Issue #7075: these used to abort the frontend.
+
+
+class C:
+    def __init__(self) -> None:
+        self.v: int = 0
+
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+assert not isinstance(x, list)
+assert not isinstance(x, dict)
+assert not isinstance(x, tuple)
+assert not isinstance(x, C)
+assert isinstance(x, object)

--- a/regression/python/dynamic_type_isinstance_unholdable/test.desc
+++ b/regression/python/dynamic_type_isinstance_unholdable/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_isinstance_unholdable_fail/main.py
+++ b/regression/python/dynamic_type_isinstance_unholdable_fail/main.py
@@ -1,0 +1,8 @@
+# The provably-false answer is asserted, not assumed away.
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+assert isinstance(x, list)

--- a/regression/python/dynamic_type_isinstance_unholdable_fail/test.desc
+++ b/regression/python/dynamic_type_isinstance_unholdable_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -556,7 +556,8 @@ exprt dynamic_type_handler::handle_arithmetic(
 
 exprt dynamic_type_handler::build_isinstance_check(
   const exprt &tagged,
-  const std::string &type_name) const
+  const std::string &type_name,
+  bool type_is_user_class) const
 {
   exprt tagged_type_id = build_member(tagged, "type_id", size_type());
 
@@ -568,6 +569,10 @@ exprt dynamic_type_handler::build_isinstance_check(
     return type_handler_.tagged_scalar_type_matches(
       tagged_type_id, long_long_int_type());
 
+  if (type_name == "float")
+    return build_equal(
+      tagged_type_id, type_handler_.tagged_scalar_type_id(double_type()));
+
   if (type_name == "str")
     return build_equal(
       tagged_type_id,
@@ -576,6 +581,23 @@ exprt dynamic_type_handler::build_isinstance_check(
   // object is Python's top type; every value is an instance of it.
   if (type_name == "object")
     return true_exprt();
+
+  // A tag only ever holds a bool, int, float or str -- get_var_assign refuses
+  // every other rvalue -- so no aggregate or user class can ever match (#7075).
+  static const std::unordered_set<std::string> unholdable = {
+    "NoneType",
+    "bytearray",
+    "bytes",
+    "complex",
+    "dict",
+    "frozenset",
+    "list",
+    "range",
+    "set",
+    "tuple",
+    "type"};
+  if (type_is_user_class || unholdable.count(type_name))
+    return false_exprt();
 
   throw std::runtime_error(
     "isinstance() against this type is not yet supported for a "

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -77,11 +77,14 @@ public:
     const locationt &location);
 
   /**
-   * @brief Builds isinstance(tagged, type_name)
+   * @brief Builds isinstance(tagged, type_name). `type_is_user_class` says
+   * whether `type_name` names a class defined in the program, which a tag can
+   * never hold
    */
   exprt build_isinstance_check(
     const exprt &tagged,
-    const std::string &type_name) const;
+    const std::string &type_name,
+    bool type_is_user_class) const;
 
   /**
    * @brief RAII: adds `dynamic_type_names` to the transient tagged-name set

--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -364,7 +364,7 @@ exprt function_call_expr::handle_isinstance() const
     // check instead of the static-type comparisons below.
     if (type_handler_.is_tagged_scalar_type(obj_expr.type()))
       return converter_.dynamic_type_handler_.build_isinstance_check(
-        obj_expr, type_name);
+        obj_expr, type_name, json_utils::is_class(type_name, converter_.ast()));
 
     // Special case: Check if object is None (null pointer)
     if (type_name == "NoneType")


### PR DESCRIPTION
`isinstance()` aborted the frontend for `float` and for every type a tagged variable cannot hold. A tag stores only a bool, int, float or str, so `float` now compares against the runtime `type_id` like the other scalars, and an aggregate or user class is answered `False` rather than refused.

This completes the last of the four abort paths documented in #7075. That issue was auto-closed early by #7178, which fixed only the container-rebind path; the isinstance path is still reachable on master and this PR closes it.
