### PR TITLE
[om] Add path::u8string and path::generic_string

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_path_u8string/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_path_u8string/main.cpp
@@ -1,0 +1,15 @@
+#include <filesystem>
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::filesystem::path p("a/b");
+
+  // [fs.path.native.obs]: this model stores a narrow string, so u8string and
+  // generic_string yield the same sequence as string().
+  assert(p.u8string().size() == 3);
+  assert(p.generic_string().size() == 3);
+  assert(!p.u8string().empty());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_path_u8string/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_path_u8string/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_path_u8string_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_path_u8string_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <filesystem>
+#include <cassert>
+
+int main()
+{
+  std::filesystem::path p("a/b");
+  // The path holds three characters, so u8string() is not empty.
+  assert(p.u8string().empty());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_path_u8string_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_path_u8string_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/filesystem
+++ b/src/cpp/library/filesystem
@@ -72,6 +72,18 @@ public:
   {
     return __p_;
   }
+  /* [fs.path.native.obs]: u8string returns the path in UTF-8. This model
+   * stores a narrow string, so it is the same sequence as string(); the C++20
+   * std::u8string return type is not modelled. generic_string is the same
+   * again, since the generic and native formats coincide here. */
+  ::std::string u8string() const
+  {
+    return __p_;
+  }
+  ::std::string generic_string() const
+  {
+    return __p_;
+  }
   bool empty() const noexcept
   {
     return __p_.empty();


### PR DESCRIPTION
`std::filesystem::path::u8string` was the first parse error in **11** of a 60-TU
sample of ESBMC's own sources — the counterpart to the `u8path` factory added in
#7169.

The model stores a narrow string, so `u8string()` and `generic_string()` yield
the same sequence as `string()`. The C++20 `std::u8string` return type is not
modelled, and the comment says so.

Rebased onto master now that #7177 has merged, so this is a single commit
touching only `<filesystem>` and its tests. Constructing a `path` did not
converge before #7177, which is why this waited on it.

Refs #5868
