### PR TITLE
[python] Run finally on the return/break/continue exit edges

### DIFF
--- a/regression/python/try_else_finally_escape/main.py
+++ b/regression/python/try_else_finally_escape/main.py
@@ -1,6 +1,6 @@
-# An escaping return/break/continue in the else clause of a try/finally would
-# bypass the appended finally, so this shape is refused with a clean diagnostic
-# rather than a silently-wrong verdict. (Valid Python; refused, not verified.)
+# An escaping return in the else clause of a try/finally gets the finally
+# copied in front of it, so it no longer bypasses it. The else clause runs on
+# the no-exception path, so f() returns 3 as under CPython (issue #7076).
 def f():
     try:
         pass

--- a/regression/python/try_else_finally_escape/test.desc
+++ b/regression/python/try_else_finally_escape/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --unwind 2
-^ERROR: try/finally with return/break/continue in the try, except, else, or finally body is not supported$
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_finally_break_continue/main.py
+++ b/regression/python/try_finally_break_continue/main.py
@@ -1,0 +1,56 @@
+# A break leaving a try/finally runs the finally too, as do returns from an
+# except handler and from an else clause. Issue #7076.
+
+
+class Box:
+    def __init__(self) -> None:
+        self.v: int = 0
+
+
+def breaks_out(b: Box) -> int:
+    i: int = 0
+    while i < 4:
+        try:
+            if i == 2:
+                break
+        finally:
+            b.v = b.v + 1
+        i = i + 1
+    return i
+
+
+def returns_from_handler(b: Box) -> int:
+    try:
+        raise ValueError("x")
+    except ValueError:
+        return 3
+    finally:
+        b.v = 8
+
+
+def returns_from_else(b: Box) -> int:
+    try:
+        b.v = 1
+    except ValueError:
+        b.v = 2
+    else:
+        return 4
+    finally:
+        b.v = b.v + 10
+
+
+def main() -> None:
+    b = Box()
+    assert breaks_out(b) == 2
+    assert b.v == 3
+
+    b2 = Box()
+    assert returns_from_handler(b2) == 3
+    assert b2.v == 8
+
+    b3 = Box()
+    assert returns_from_else(b3) == 4
+    assert b3.v == 11
+
+
+main()

--- a/regression/python/try_finally_break_continue/test.desc
+++ b/regression/python/try_finally_break_continue/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 4
+--unwind 8
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/try_finally_return/main.py
+++ b/regression/python/try_finally_return/main.py
@@ -1,12 +1,33 @@
-# A return/break/continue that escapes a try with a finally is rejected: the
-# current lowering appends the finally on the fall-through path, which such a
-# jump would bypass. ESBMC refuses it rather than return an unsound verdict.
-# (This is valid Python, so it runs cleanly under CPython.)
-def h() -> int:
+# `return` inside a try/finally runs the finally on its way out, and the
+# returned expression is evaluated before the finally does. Issue #7076: this
+# used to be refused during conversion.
+
+
+class Box:
+    def __init__(self) -> None:
+        self.v: int = 0
+
+
+def cleanup_runs(b: Box) -> int:
     try:
         return 1
     finally:
-        pass
+        b.v = 7
 
 
-print(h())
+def value_is_evaluated_first() -> int:
+    x: int = 1
+    try:
+        return x
+    finally:
+        x = 2
+
+
+def main() -> None:
+    b = Box()
+    assert cleanup_runs(b) == 1
+    assert b.v == 7
+    assert value_is_evaluated_first() == 1
+
+
+main()

--- a/regression/python/try_finally_return_fail/main.py
+++ b/regression/python/try_finally_return_fail/main.py
@@ -1,0 +1,23 @@
+# The finally really does run on the return path: asserting that it did not is
+# detected.
+
+
+class Box:
+    def __init__(self) -> None:
+        self.v: int = 0
+
+
+def f(b: Box) -> int:
+    try:
+        return 1
+    finally:
+        b.v = 7
+
+
+def main() -> None:
+    b = Box()
+    assert f(b) == 1
+    assert b.v == 0
+
+
+main()

--- a/regression/python/try_finally_return_fail/test.desc
+++ b/regression/python/try_finally_return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/try_finally_return_in_handler/main.py
+++ b/regression/python/try_finally_return_in_handler/main.py
@@ -1,7 +1,6 @@
-# A return inside an except handler escapes the try; the appended finally on
-# the fall-through path would be bypassed, so this shape is refused rather than
-# verified unsoundly. (Valid Python -- finally runs before the return under
-# CPython, so it executes cleanly and exits 0 here.)
+# A return inside an except handler escapes the try, so the finally is copied
+# in front of it and runs before control leaves. Issue #7076: this shape used
+# to be refused during conversion.
 def f() -> int:
     try:
         raise ValueError()
@@ -11,4 +10,4 @@ def f() -> int:
         pass
 
 
-print(f())
+assert f() == 1

--- a/regression/python/try_finally_return_in_handler/test.desc
+++ b/regression/python/try_finally_return_in_handler/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --unwind 1
-^ERROR: try/finally with return/break/continue in the try, except, else, or finally body is not supported$
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/exception/python_exception_handler.cpp
+++ b/src/python-frontend/exception/python_exception_handler.cpp
@@ -80,32 +80,39 @@ void python_exception_handler::get_try_statement(
 
   // Python's `finally` runs on every exit path: normal completion, a caught
   // exception, an *uncaught* exception (run finally, then re-raise), and a
-  // return/break/continue that leaves the try. We model the first three by
+  // return/break/continue that leaves the try. The first three are modelled by
   // duplicating the finally body on the normal path (after the try/catch) and
-  // inside a catch-all handler that re-raises. A return/break/continue inside
-  // the try body, an except handler, or the finally body would bypass that
-  // appended finally and silently change the result, so refuse those with a
-  // clean diagnostic rather than return an unsound verdict.
+  // inside a catch-all handler that re-raises; the fourth by copying it in
+  // front of each escaping statement (#7076).
+  nlohmann::json try_body = element["body"];
+  nlohmann::json else_body =
+    element.contains("orelse") ? element["orelse"] : nlohmann::json::array();
+  nlohmann::json handlers = element["handlers"];
+
   if (has_finally)
   {
-    bool escapes = body_has_escaping_control_flow(element["body"], false) ||
-                   body_has_escaping_control_flow(element["finalbody"], false);
-    // The else clause is appended to the try body below, so an escaping
-    // return/break/continue there would bypass the appended finally just like
-    // one in the try body — scan it too.
-    if (element.contains("orelse"))
-      escapes =
-        escapes || body_has_escaping_control_flow(element["orelse"], false);
-    for (const auto &h : element["handlers"])
-      if (h.contains("body"))
-        escapes = escapes || body_has_escaping_control_flow(h["body"], false);
-    if (escapes)
+    // A finally that itself returns overrides an in-flight return or a
+    // propagating exception, and a break/continue there swallows one; neither
+    // is modelled, so those shapes are still refused. So is an escape nested
+    // under a try or with, whose own cleanup would have to run first.
+    if (
+      body_has_escaping_control_flow(element["finalbody"], false) ||
+      escape_in_nested_cleanup_scope(try_body, false) ||
+      escape_in_nested_cleanup_scope(else_body, false) ||
+      escape_in_nested_cleanup_scope(handlers, false))
       throw std::runtime_error(
         "try/finally with return/break/continue in the try, except, else, or "
         "finally body is not supported");
+
+    const nlohmann::json &finalbody = element["finalbody"];
+    try_body = inject_finally_before_escapes(try_body, finalbody, false);
+    else_body = inject_finally_before_escapes(else_body, finalbody, false);
+    for (auto &h : handlers)
+      if (h.is_object() && h.contains("body"))
+        h["body"] = inject_finally_before_escapes(h["body"], finalbody, false);
   }
 
-  exprt try_block = converter_.get_block(element["body"]);
+  exprt try_block = converter_.get_block(try_body);
 
   // The `else` clause runs after the try body completes without an exception.
   // Append it to the try body: on the normal path it runs right after the body,
@@ -113,14 +120,14 @@ void python_exception_handler::get_try_statement(
   // so it is correctly skipped. (An exception raised inside the else itself is
   // caught by this try's handlers here rather than propagating, a minor
   // deviation from CPython that is out of scope.)
-  if (element.contains("orelse") && !element["orelse"].empty())
+  if (!else_body.empty())
   {
-    exprt else_block = converter_.get_block(element["orelse"]);
+    exprt else_block = converter_.get_block(else_body);
     for (const auto &op : else_block.operands())
       try_block.copy_to_operands(op);
   }
 
-  exprt handler = converter_.get_block(element["handlers"]);
+  exprt handler = converter_.get_block(handlers);
 
   // A bare `except:` already catches every exception, so the fall-through
   // finally below runs after it on the exception path too. Appending a second
@@ -129,7 +136,7 @@ void python_exception_handler::get_try_statement(
   // dropping the user's handler. So synthesise the finally-rethrow catch-all
   // only when no bare `except:` is present.
   bool has_catch_all = false;
-  for (const auto &h : element["handlers"])
+  for (const auto &h : handlers)
     if (h["type"].is_null())
       has_catch_all = true;
 
@@ -174,6 +181,168 @@ void python_exception_handler::get_try_statement(
   }
 }
 
+namespace
+{
+bool is_function_scope(const std::string &t)
+{
+  return t == "FunctionDef" || t == "AsyncFunctionDef" || t == "Lambda";
+}
+
+bool is_loop_scope(const std::string &t)
+{
+  return t == "For" || t == "AsyncFor" || t == "While";
+}
+
+/// A construct that runs cleanup of its own on an escaping exit edge.
+bool is_cleanup_scope(const std::string &t)
+{
+  return t == "Try" || t == "TryStar" || t == "With" || t == "AsyncWith";
+}
+
+/// A return/break/continue that leaves the enclosing try. break/continue are
+/// captured by a nested loop, so they escape only outside one.
+bool is_escaping_stmt(const std::string &t, bool in_loop)
+{
+  if (t == "Return")
+    return true;
+  return (t == "Break" || t == "Continue") && !in_loop;
+}
+
+void copy_location(const nlohmann::json &from, nlohmann::json &to)
+{
+  for (const char *k : {"lineno", "col_offset", "end_lineno", "end_col_offset"})
+    if (from.contains(k))
+      to[k] = from[k];
+}
+
+nlohmann::json make_name_node(
+  const std::string &id,
+  const nlohmann::json &loc,
+  const char *ctx)
+{
+  nlohmann::json name;
+  name["_type"] = "Name";
+  name["id"] = id;
+  name["ctx"] = {{"_type", ctx}};
+  copy_location(loc, name);
+  return name;
+}
+} // namespace
+
+void python_exception_handler::emit_finally_then_escape(
+  const nlohmann::json &stmt,
+  const nlohmann::json &finalbody,
+  nlohmann::json &out)
+{
+  // CPython evaluates the returned expression before running the finally, so
+  // spill it to a temporary rather than re-ordering the two.
+  std::string spill_name;
+  if (
+    stmt.value("_type", "") == "Return" && stmt.contains("value") &&
+    !stmt["value"].is_null())
+  {
+    spill_name = "_esbmc_finally_ret_" + std::to_string(++finally_spill_count_);
+    nlohmann::json spill;
+    spill["_type"] = "Assign";
+    spill["targets"] =
+      nlohmann::json::array({make_name_node(spill_name, stmt, "Store")});
+    spill["value"] = stmt["value"];
+    copy_location(stmt, spill);
+    out.push_back(spill);
+  }
+
+  for (const auto &f : finalbody)
+    out.push_back(f);
+
+  nlohmann::json exit_stmt = stmt;
+  if (!spill_name.empty())
+    exit_stmt["value"] = make_name_node(spill_name, stmt, "Load");
+  out.push_back(exit_stmt);
+}
+
+nlohmann::json python_exception_handler::inject_finally_before_escapes(
+  const nlohmann::json &body,
+  const nlohmann::json &finalbody,
+  bool in_loop)
+{
+  if (!body.is_array())
+    return body;
+
+  nlohmann::json out = nlohmann::json::array();
+  for (const auto &stmt : body)
+  {
+    const std::string t = stmt.is_object() ? stmt.value("_type", "") : "";
+
+    if (is_escaping_stmt(t, in_loop))
+    {
+      emit_finally_then_escape(stmt, finalbody, out);
+      continue;
+    }
+
+    // A nested function or lambda captures its own return/break/continue.
+    if (t.empty() || is_function_scope(t))
+    {
+      out.push_back(stmt);
+      continue;
+    }
+
+    const bool child_in_loop = in_loop || is_loop_scope(t);
+    nlohmann::json rewritten = stmt;
+    for (const char *key : {"body", "orelse", "finalbody"})
+      if (stmt.contains(key) && stmt[key].is_array())
+        rewritten[key] =
+          inject_finally_before_escapes(stmt[key], finalbody, child_in_loop);
+    out.push_back(rewritten);
+  }
+  return out;
+}
+
+bool python_exception_handler::escape_in_nested_cleanup_children(
+  const nlohmann::json &node,
+  bool in_loop)
+{
+  for (const char *key : {"body", "orelse", "finalbody"})
+    if (
+      node.contains(key) && escape_in_nested_cleanup_scope(node[key], in_loop))
+      return true;
+
+  if (!node.contains("handlers") || !node["handlers"].is_array())
+    return false;
+  for (const auto &h : node["handlers"])
+    if (
+      h.is_object() && h.contains("body") &&
+      escape_in_nested_cleanup_scope(h["body"], in_loop))
+      return true;
+  return false;
+}
+
+bool python_exception_handler::escape_in_nested_cleanup_scope(
+  const nlohmann::json &node,
+  bool in_loop)
+{
+  if (node.is_array())
+  {
+    for (const auto &stmt : node)
+      if (escape_in_nested_cleanup_scope(stmt, in_loop))
+        return true;
+    return false;
+  }
+  if (!node.is_object())
+    return false;
+
+  const std::string t = node.value("_type", "");
+  if (is_function_scope(t))
+    return false;
+
+  // A nested try or with runs cleanup of its own on the same exit edge; the
+  // two would have to be ordered innermost-first, which this rewrite does not
+  // model.
+  if (is_cleanup_scope(t))
+    return body_has_escaping_control_flow(node, in_loop);
+
+  return escape_in_nested_cleanup_children(node, in_loop || is_loop_scope(t));
+}
+
 // True if `node` contains a return/break/continue that transfers control out of
 // the enclosing try. `return` always escapes (we never descend into a nested
 // function/lambda, which would capture it); `break`/`continue` escape only when
@@ -194,17 +363,14 @@ bool python_exception_handler::body_has_escaping_control_flow(
     return false;
 
   const std::string t = node.value("_type", "");
-  if (t == "Return")
+  if (is_escaping_stmt(t, in_loop))
     return true;
-  if (t == "Break" || t == "Continue")
-    return !in_loop;
   // Nested functions/lambdas capture every return/break/continue within them.
-  if (t == "FunctionDef" || t == "AsyncFunctionDef" || t == "Lambda")
+  if (is_function_scope(t) || t == "Break" || t == "Continue")
     return false;
 
   // A loop captures break/continue in its own body/orelse.
-  const bool child_in_loop =
-    in_loop || t == "For" || t == "AsyncFor" || t == "While";
+  const bool child_in_loop = in_loop || is_loop_scope(t);
 
   for (const char *key : {"body", "orelse", "finalbody"})
     if (

--- a/src/python-frontend/exception/python_exception_handler.h
+++ b/src/python-frontend/exception/python_exception_handler.h
@@ -51,6 +51,16 @@ public:
   static bool
   body_has_escaping_control_flow(const nlohmann::json &node, bool in_loop);
 
+  /// True if an escaping return/break/continue sits inside a nested try or
+  /// with, whose own cleanup must run before this finally. Duplicating this
+  /// finally there would order the two wrongly, so such shapes are refused.
+  static bool
+  escape_in_nested_cleanup_scope(const nlohmann::json &node, bool in_loop);
+
+  /// escape_in_nested_cleanup_scope's walk over a statement's child bodies.
+  static bool
+  escape_in_nested_cleanup_children(const nlohmann::json &node, bool in_loop);
+
   /**
    * Convert a Python raise statement.
    *
@@ -144,6 +154,25 @@ private:
   // ------------------------------------------------------------------
   // Internal helpers
   // ------------------------------------------------------------------
+
+  /// Copies `finalbody` in front of every return/break/continue in `body` that
+  /// leaves the enclosing try, so those exit edges run the finally as CPython
+  /// does. A returned expression is spilled to a temporary first, because
+  /// CPython evaluates it before the finally runs.
+  nlohmann::json inject_finally_before_escapes(
+    const nlohmann::json &body,
+    const nlohmann::json &finalbody,
+    bool in_loop);
+
+  /// Appends `finalbody` followed by `stmt` to `out`, spilling a returned
+  /// expression to a temporary first.
+  void emit_finally_then_escape(
+    const nlohmann::json &stmt,
+    const nlohmann::json &finalbody,
+    nlohmann::json &out);
+
+  /// Names the spill temporaries inject_finally_before_escapes introduces.
+  unsigned finally_spill_count_ = 0;
 
   /** Create a temporary boolean symbol used by assertion helpers. */
   symbolt create_assert_temp_variable(const locationt &location) const;


### PR DESCRIPTION
`try`/`finally` refused any `return`, `break` or `continue` in its bodies, because the lowering duplicated the finally only onto normal completion and the exception path. It is now copied in front of each escaping statement too, with a returned expression spilled to a temporary first since CPython evaluates it before the finally runs.

A finally that itself escapes, and an escape nested under another `try` or `with` — where the two cleanups would need innermost-first ordering — are still refused. Three tests that pinned the old refusal now pin the verdict instead.

Fixes #7076