### PR TITLE
[python] Keep a popped object's type when its pop is converted twice

### DIFF
--- a/regression/python/deque_class_element/main.py
+++ b/regression/python/deque_class_element/main.py
@@ -1,0 +1,23 @@
+# The breadth_first_search idiom: objects go through a deque and come back out
+# with their identity intact. One syntactic popleft() used to consume two
+# element-type entries, so the second conversion fell back to the deque model's
+# `list[int]` annotation and the popped object arrived as an int.
+from collections import deque
+
+
+class Node:
+    def __init__(self, v: int) -> None:
+        self.v: int = v
+
+
+a = Node(1)
+b = Node(2)
+
+q = deque()
+q.append(a)
+q.append(b)
+
+front = q.popleft()
+assert front is a
+assert front.v == 1
+assert q.popleft() is b

--- a/regression/python/deque_class_element/test.desc
+++ b/regression/python/deque_class_element/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/deque_class_element_fail/main.py
+++ b/regression/python/deque_class_element_fail/main.py
@@ -1,0 +1,18 @@
+# The identity is really compared, not assumed: the front of the deque is not
+# the element appended last.
+from collections import deque
+
+
+class Node:
+    def __init__(self, v: int) -> None:
+        self.v: int = v
+
+
+a = Node(1)
+b = Node(2)
+
+q = deque()
+q.append(a)
+q.append(b)
+
+assert q.popleft() is b

--- a/regression/python/deque_class_element_fail/test.desc
+++ b/regression/python/deque_class_element_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/is_ptr_vs_nonptr_diagnostic/main.py
+++ b/regression/python/is_ptr_vs_nonptr_diagnostic/main.py
@@ -1,7 +1,7 @@
-# An object popped from a deque comes back with an integer type, so comparing
-# it with the object by identity built an equality whose operands differ in
-# width -- every solver backend asserted on it. The construct is still
-# unsupported; it must report that rather than abort.
+# An object popped from a deque used to come back with an integer type, so
+# comparing it with the object by identity built an equality whose operands
+# differed in width; the frontend reported that rather than aborting. The
+# popped element now keeps its type, so the identity holds as CPython reports.
 from collections import deque as Queue
 
 

--- a/regression/python/is_ptr_vs_nonptr_diagnostic/test.desc
+++ b/regression/python/is_ptr_vs_nonptr_diagnostic/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: 'is' between a pointer and a non-pointer
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_annotated_class_pop/main.py
+++ b/regression/python/list_annotated_class_pop/main.py
@@ -1,0 +1,17 @@
+# An annotation that disagrees with what is actually stored must not win over
+# the recorded element type: the object popped back out is still the object,
+# not an int reinterpreted from its pointer.
+from typing import List
+
+
+class Node:
+    def __init__(self, v: int) -> None:
+        self.v: int = v
+
+
+a = Node(1)
+q: List[int] = []
+q.append(a)
+b = q.pop()
+assert b is a
+assert b.v == 1

--- a/regression/python/list_annotated_class_pop/test.desc
+++ b/regression/python/list_annotated_class_pop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -1107,9 +1107,20 @@ exprt python_list::build_pop_list_call(
   const std::string &list_id = list.id.as_string();
   typet elem_type;
 
+  // One syntactic pop() consumes one list_type_map entry, but the assignment
+  // path converts its RHS more than once; replay the first answer rather than
+  // consuming a second entry (#4780).
+  const std::string site = list_id + ":" + location.get_line().as_string() +
+                           ":" + location.get_column().as_string();
+  auto memo_it = pop_elem_type_memo.find(site);
+  if (memo_it != pop_elem_type_memo.end())
+    elem_type = memo_it->second;
+
   // Try to get element type from list_type_map (use last element for default pop)
   auto type_map_it = list_type_map.find(list_id);
-  if (type_map_it != list_type_map.end() && !type_map_it->second.empty())
+  if (
+    elem_type == typet() && type_map_it != list_type_map.end() &&
+    !type_map_it->second.empty())
   {
     // Get the last element's type (since default pop() pops from the end)
     size_t last_idx = type_map_it->second.size() - 1;
@@ -1117,6 +1128,7 @@ exprt python_list::build_pop_list_call(
 
     // Remove the popped element from type map to maintain consistency
     type_map_it->second.pop_back();
+    pop_elem_type_memo[site] = elem_type;
   }
 
   // If type map lookup failed, try to infer from list declaration

--- a/src/python-frontend/python-list/list_type_map.cpp
+++ b/src/python-frontend/python-list/list_type_map.cpp
@@ -243,3 +243,5 @@ void python_list::reverse_type_info(const std::string &list_id)
     return;
   std::reverse(it->second.begin(), it->second.end());
 }
+
+std::unordered_map<std::string, typet> python_list::pop_elem_type_memo{};

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -723,4 +723,11 @@ private:
 
   // <list_id, <elem_id, elem_type>>
   static std::unordered_map<std::string, TypeInfo> list_type_map;
+
+  /// Element type already handed out for one syntactic pop() site, keyed by
+  /// list symbol and source position. The assignment path converts its RHS
+  /// more than once, and build_pop_list_call consumes a list_type_map entry
+  /// per call, so without this the second conversion of a single pop() sees an
+  /// empty map and falls back to the list's annotation (#4780).
+  static std::unordered_map<std::string, typet> pop_elem_type_memo;
 };


### PR DESCRIPTION
`build_pop_list_call` consumed one `list_type_map` entry per call, but the assignment path converts its RHS more than once. The second conversion of a single `pop()` found the map empty and fell back to the list annotation, so an object popped from a `deque` (modelled as `list[int]`) or from an int-annotated list arrived as an int and `is` refused to compare it against its own pointer.

The element type is now memoised per syntactic pop site, so a repeated conversion replays the first answer instead of consuming a second entry. Distinct pops still consume the map in order.

Unblocks the first of several conversion errors in #4780 / #4781; those tests hit later gaps and stay KNOWNBUG.
