### PR TITLE
[om] Add has_virtual_destructor and the uninitialized_ algorithms

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit/main.cpp
@@ -1,0 +1,35 @@
+#include <type_traits>
+#include <memory>
+#include <cstdlib>
+#include <cassert>
+
+struct plain
+{
+  int a;
+};
+struct virt
+{
+  virtual ~virt()
+  {
+  }
+};
+
+int main()
+{
+  // [meta.unary.prop]
+  static_assert(std::has_virtual_destructor<virt>::value, "virtual dtor");
+  static_assert(!std::has_virtual_destructor<plain>::value, "plain");
+  static_assert(!std::has_virtual_destructor<int>::value, "int");
+  static_assert(std::has_virtual_destructor_v<virt>, "_v alias");
+
+  // [uninitialized.construct]
+  int src[2] = {1, 2};
+  int *dst = static_cast<int *>(malloc(sizeof(int) * 2));
+  if (dst == NULL)
+    return 0;
+  std::uninitialized_move(src, src + 2, dst);
+  assert(dst[0] == 1);
+  assert(dst[1] == 2);
+  free(dst);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <type_traits>
+#include <cassert>
+
+struct plain
+{
+  int a;
+};
+
+int main()
+{
+  // plain has no virtual destructor.
+  assert(std::has_virtual_destructor<plain>::value);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_has_virtual_dtor_uninit_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_5868_uninitialized_n/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_uninitialized_n/main.cpp
@@ -1,0 +1,22 @@
+#include <memory>
+#include <cstdlib>
+#include <cassert>
+
+int main()
+{
+  int src[2] = {1, 2};
+  int *dst = static_cast<int *>(malloc(sizeof(int) * 2));
+  if (dst == NULL)
+    return 0;
+
+  // [uninitialized.construct]: the _n forms take a count.
+  std::uninitialized_copy_n(src, 2, dst);
+  assert(dst[0] == 1);
+  assert(dst[1] == 2);
+
+  std::uninitialized_fill_n(dst, 2, 7);
+  assert(dst[0] == 7);
+  assert(dst[1] == 7);
+  free(dst);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_uninitialized_n/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_uninitialized_n/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -1109,6 +1109,37 @@ void uninitialized_fill(
     ::new (static_cast<void *>(&*first))
       typename iterator_traits<ForwardIterator>::value_type(value);
 }
+
+/* The _n forms, which take a count rather than an end iterator. */
+template <class InputIterator, class Size, class ForwardIterator>
+ForwardIterator
+uninitialized_copy_n(InputIterator first, Size n, ForwardIterator result)
+{
+  for (Size i = 0; i < n; ++i, ++first, ++result)
+    ::new (static_cast<void *>(&*result))
+      typename iterator_traits<ForwardIterator>::value_type(*first);
+  return result;
+}
+
+template <class InputIterator, class Size, class ForwardIterator>
+ForwardIterator
+uninitialized_move_n(InputIterator first, Size n, ForwardIterator result)
+{
+  for (Size i = 0; i < n; ++i, ++first, ++result)
+    ::new (static_cast<void *>(&*result))
+      typename iterator_traits<ForwardIterator>::value_type(::std::move(*first));
+  return result;
+}
+
+template <class ForwardIterator, class Size, class T>
+ForwardIterator
+uninitialized_fill_n(ForwardIterator first, Size n, const T &value)
+{
+  for (Size i = 0; i < n; ++i, ++first)
+    ::new (static_cast<void *>(&*first))
+      typename iterator_traits<ForwardIterator>::value_type(value);
+  return first;
+}
 #endif
 
 } // namespace std

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -1071,6 +1071,46 @@ public:
 };
 #endif
 
+#if __cplusplus >= 201103L
+/* [uninitialized.construct]: construct the destination range in place from the
+ * source, rather than assigning over objects that do not exist yet.
+ * uninitialized_move is C++17; the other two are older but were missing too. */
+template <class InputIterator, class ForwardIterator>
+ForwardIterator uninitialized_copy(
+  InputIterator first,
+  InputIterator last,
+  ForwardIterator result)
+{
+  for (; first != last; ++first, ++result)
+    ::new (static_cast<void *>(&*result))
+      typename iterator_traits<ForwardIterator>::value_type(*first);
+  return result;
+}
+
+template <class InputIterator, class ForwardIterator>
+ForwardIterator uninitialized_move(
+  InputIterator first,
+  InputIterator last,
+  ForwardIterator result)
+{
+  for (; first != last; ++first, ++result)
+    ::new (static_cast<void *>(&*result))
+      typename iterator_traits<ForwardIterator>::value_type(::std::move(*first));
+  return result;
+}
+
+template <class ForwardIterator, class T>
+void uninitialized_fill(
+  ForwardIterator first,
+  ForwardIterator last,
+  const T &value)
+{
+  for (; first != last; ++first)
+    ::new (static_cast<void *>(&*first))
+      typename iterator_traits<ForwardIterator>::value_type(value);
+}
+#endif
+
 } // namespace std
 
 #endif

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -313,6 +313,14 @@ struct is_polymorphic : integral_constant<bool, __is_polymorphic(T)>
 {
 };
 
+// has_virtual_destructor ([meta.unary.prop]). Unguarded, like is_polymorphic
+// above: the Clang builtin is valid pre-C++11.
+template <class T>
+struct has_virtual_destructor
+  : integral_constant<bool, __has_virtual_destructor(T)>
+{
+};
+
 // is_union
 template <class T>
 struct is_union : integral_constant<bool, __is_union(T)>
@@ -1102,6 +1110,9 @@ template <class T>
 inline constexpr bool is_scalar_v = is_scalar<T>::value;
 template <class T>
 inline constexpr bool is_polymorphic_v = is_polymorphic<T>::value;
+template <class T>
+inline constexpr bool has_virtual_destructor_v =
+  has_virtual_destructor<T>::value;
 template <class T>
 inline constexpr bool is_trivially_default_constructible_v =
   is_trivially_default_constructible<T>::value;


### PR DESCRIPTION
Gaps from the self-verification census, measured on master:

- `std::has_virtual_destructor` — the first parse error in **3** of a 60-TU
  sample.
- `std::uninitialized_move` — the first parse error in **2** more, and
  `uninitialized_fill_n` in **2** more again.

`uninitialized_copy`, `uninitialized_fill` and all three `_n` forms were missing
alongside them, so the whole [uninitialized.construct] set is added.

`has_virtual_destructor` is unguarded, like the `is_polymorphic` beside it,
since the Clang builtin is valid pre-C++11 — checked before writing, after
earlier PRs in this series broke `--std c++03` by naming something guarded. The
algorithms are C++11-guarded because `uninitialized_move` needs `std::move`.

Refs #5868
