### PR TITLE
[python] Pass a container default instead of None

### DIFF
--- a/regression/python/mutable_default_container/main.py
+++ b/regression/python/mutable_default_container/main.py
@@ -1,0 +1,24 @@
+# A call that omits a parameter with a container default must receive that
+# container, not None. The preprocessor used to substitute None, so the
+# argument arrived as a null pointer and len() dereferenced it.
+
+
+class Node:
+    def __init__(self, value, successors=[]):
+        self.value = value
+        self.successors = successors
+
+
+def sizes(xs=[], m={}, s=set()):
+    return len(xs) + len(m) + len(s)
+
+
+n1 = Node(1)
+assert len(n1.successors) == 0
+
+n2 = Node(2, [n1])
+assert len(n2.successors) == 1
+assert len(n1.successors) == 0
+
+assert sizes() == 0
+assert sizes([1, 2]) == 2

--- a/regression/python/mutable_default_container/test.desc
+++ b/regression/python/mutable_default_container/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/mutable_default_container_fail/main.py
+++ b/regression/python/mutable_default_container_fail/main.py
@@ -1,0 +1,12 @@
+# The defaulted container is really measured, not assumed: an omitted argument
+# yields an empty list, so asserting otherwise is detected.
+
+
+class Node:
+    def __init__(self, value, successors=[]):
+        self.value = value
+        self.successors = successors
+
+
+n1 = Node(1)
+assert len(n1.successors) == 1

--- a/regression/python/mutable_default_container_fail/test.desc
+++ b/regression/python/mutable_default_container_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/mutable_default_shared/main.py
+++ b/regression/python/mutable_default_shared/main.py
@@ -1,0 +1,18 @@
+# Python evaluates a default once, at definition time, and shares the object
+# across calls -- the mutable-default gotcha. The default is hoisted to a
+# def-time variable rather than rebuilt per call site, so the accumulation
+# below is observable exactly as CPython reports it.
+
+
+def collect(x, acc=[]):
+    acc.append(x)
+    return len(acc)
+
+
+assert collect(1) == 1
+assert collect(2) == 2
+assert collect(3) == 3
+
+# An explicitly-passed container is independent of the shared default.
+assert collect(9, [7]) == 2
+assert collect(4) == 4

--- a/regression/python/mutable_default_shared/test.desc
+++ b/regression/python/mutable_default_shared/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/ast_utils_mixin.py
+++ b/src/python-frontend/preprocessor/ast_utils_mixin.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 
 
 class AstUtilsMixin:
@@ -71,21 +72,28 @@ class AstUtilsMixin:
         ast.fix_missing_locations(assign)
         return assign
 
-    def generate_variable_copy(self, qualified_name, arg_node, default_name_node):
+    def generate_variable_copy(self, qualified_name, arg_node, default_node):
         """
-        Materialize a Name default value into a stable temporary variable.
+        Materialize a default value into a stable temporary variable, evaluated
+        once where the function is defined. Python evaluates defaults at
+        definition time and shares the resulting object across calls, so a
+        container default must be hoisted rather than rebuilt per call site.
         """
         func_part = self._sanitize_identifier_fragment(qualified_name)
         arg_part = self._sanitize_identifier_fragment(arg_node.arg)
         target_var = f"ESBMC_default_{func_part}_{arg_part}"
 
+        default_value = copy.deepcopy(default_node)
+        if isinstance(default_value, ast.Name):
+            default_value.ctx = ast.Load()
+
         assignment_node = ast.Assign(
-            targets=[self.create_name_node(target_var, ast.Store(), default_name_node)],
-            value=ast.Name(id=default_name_node.id, ctx=ast.Load()),
+            targets=[self.create_name_node(target_var, ast.Store(), default_node)],
+            value=default_value,
         )
-        self.ensure_all_locations(assignment_node, default_name_node)
+        self.ensure_all_locations(assignment_node, default_node)
         ast.fix_missing_locations(assignment_node)
-        target_ref = self.create_name_node(target_var, ast.Load(), default_name_node)
+        target_ref = self.create_name_node(target_var, ast.Load(), default_node)
         ast.fix_missing_locations(target_ref)
         return assignment_node, target_ref
 

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -912,9 +912,6 @@ class CoreVisitorsMixin:
                 node.args.append(keywords[expected_args[i]])
                 continue
             default_val = self.functionDefaults[(function_name, expected_args[i])]
-            if isinstance(default_val, (ast.List, ast.Dict, ast.Set)):
-                node.args.append(ast.Constant(value=None))
-                continue
             if isinstance(default_val, ast.AST):
                 default_expr = copy.deepcopy(default_val)
                 if isinstance(default_expr, ast.Name):
@@ -1261,7 +1258,7 @@ class CoreVisitorsMixin:
             arg_name = node.args.args[-i].arg
             if isinstance(default_node, ast.Constant):
                 self.functionDefaults[(qualified_name, arg_name)] = default_node.value
-            elif isinstance(default_node, ast.Name):
+            elif isinstance(default_node, (ast.Name, ast.List, ast.Dict, ast.Set)):
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.args[-i], default_node)
                 self.functionDefaults[(qualified_name, arg_name)] = target_var
@@ -1277,7 +1274,7 @@ class CoreVisitorsMixin:
             kwarg_name = node.args.kwonlyargs[i].arg
             if isinstance(default, ast.Constant):
                 self.functionDefaults[(qualified_name, kwarg_name)] = default.value
-            elif isinstance(default, ast.Name):
+            elif isinstance(default, (ast.Name, ast.List, ast.Dict, ast.Set)):
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.kwonlyargs[i], default)
                 self.functionDefaults[(qualified_name, kwarg_name)] = target_var


### PR DESCRIPTION
A call that omitted a parameter whose default is a list, dict or set literal had that argument rewritten to `ast.Constant(None)` by the preprocessor. The callee then received a null pointer, and `len()` on it lowered to `strlen` over NULL — a dereference failure reported as `VERIFICATION FAILED` on programs CPython runs fine.

Such defaults are now hoisted into the def-time helper variable already used for `Name` defaults. That fixes the null, and as a side effect models Python's evaluated-once, shared-across-calls default semantics — the mutable-default gotcha — which `mutable_default_shared` pins.

Scope: this covers defaults declared in the module under verification. Defaults in an *imported* module are not yet reached, so the graph tests behind #4780 / #4781, whose `node.py` is imported, are not unblocked by this PR alone.
