### PR TITLE
[python] Fill a call into an imported module from its defaults

### DIFF
--- a/regression/python/import_container_default/helper.py
+++ b/regression/python/import_container_default/helper.py
@@ -1,0 +1,11 @@
+def sizes(xs=[]):
+    return len(xs)
+
+
+def total(xs=[], base=0):
+    n = 0
+    i = 0
+    while i < len(xs):
+        n = n + xs[i]
+        i = i + 1
+    return n + base

--- a/regression/python/import_container_default/main.py
+++ b/regression/python/import_container_default/main.py
@@ -1,0 +1,10 @@
+# Each module is preprocessed on its own, so a call into an imported module
+# used to be converted without the arguments that module's defaults supply.
+# The omitted container default now reaches the callee as a real list.
+from helper import sizes, total
+
+assert sizes() == 0
+assert sizes([1, 2, 3]) == 3
+assert total() == 0
+assert total([1, 2, 3]) == 6
+assert total([1, 2], 10) == 13

--- a/regression/python/import_container_default/test.desc
+++ b/regression/python/import_container_default/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import_container_default_fail/helper.py
+++ b/regression/python/import_container_default_fail/helper.py
@@ -1,0 +1,2 @@
+def sizes(xs=[]):
+    return len(xs)

--- a/regression/python/import_container_default_fail/main.py
+++ b/regression/python/import_container_default_fail/main.py
@@ -1,0 +1,4 @@
+# The imported default is really measured, not assumed empty.
+from helper import sizes
+
+assert sizes() == 1

--- a/regression/python/import_container_default_fail/test.desc
+++ b/regression/python/import_container_default_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/mutable_default_container/main.py
+++ b/regression/python/mutable_default_container/main.py
@@ -1,0 +1,24 @@
+# A call that omits a parameter with a container default must receive that
+# container, not None. The preprocessor used to substitute None, so the
+# argument arrived as a null pointer and len() dereferenced it.
+
+
+class Node:
+    def __init__(self, value, successors=[]):
+        self.value = value
+        self.successors = successors
+
+
+def sizes(xs=[], m={}, s=set()):
+    return len(xs) + len(m) + len(s)
+
+
+n1 = Node(1)
+assert len(n1.successors) == 0
+
+n2 = Node(2, [n1])
+assert len(n2.successors) == 1
+assert len(n1.successors) == 0
+
+assert sizes() == 0
+assert sizes([1, 2]) == 2

--- a/regression/python/mutable_default_container/test.desc
+++ b/regression/python/mutable_default_container/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/mutable_default_container_fail/main.py
+++ b/regression/python/mutable_default_container_fail/main.py
@@ -1,0 +1,12 @@
+# The defaulted container is really measured, not assumed: an omitted argument
+# yields an empty list, so asserting otherwise is detected.
+
+
+class Node:
+    def __init__(self, value, successors=[]):
+        self.value = value
+        self.successors = successors
+
+
+n1 = Node(1)
+assert len(n1.successors) == 1

--- a/regression/python/mutable_default_container_fail/test.desc
+++ b/regression/python/mutable_default_container_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/mutable_default_shared/main.py
+++ b/regression/python/mutable_default_shared/main.py
@@ -1,0 +1,18 @@
+# Python evaluates a default once, at definition time, and shares the object
+# across calls -- the mutable-default gotcha. The default is hoisted to a
+# def-time variable rather than rebuilt per call site, so the accumulation
+# below is observable exactly as CPython reports it.
+
+
+def collect(x, acc=[]):
+    acc.append(x)
+    return len(acc)
+
+
+assert collect(1) == 1
+assert collect(2) == 2
+assert collect(3) == 3
+
+# An explicitly-passed container is independent of the shared default.
+assert collect(9, [7]) == 2
+assert collect(4) == 4

--- a/regression/python/mutable_default_shared/test.desc
+++ b/regression/python/mutable_default_shared/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -1093,28 +1093,8 @@ void python_converter::process_function_arguments(
         {
           exprt default_expr = get_expr(defaults[i]);
           type.arguments()[positional_index].default_value() = default_expr;
-
-          // If the default is a function pointer and the parameter was
-          // annotated as Any (void*), upgrade the parameter type to match.
-          // This enables indirect-call resolution for function-alias defaults
-          // like def h(op=g) where g = f (a named function).
-          if (
-            default_expr.type().is_pointer() &&
-            default_expr.type().subtype().is_code())
-          {
-            auto &param_arg = type.arguments()[positional_index];
-            if (param_arg.type() == any_type())
-            {
-              param_arg.type() = default_expr.type();
-              std::string param_id = param_arg.cmt_identifier().as_string();
-              if (!param_id.empty())
-              {
-                symbolt *param_sym = symbol_table_.find_symbol(param_id);
-                if (param_sym)
-                  param_sym->set_type(default_expr.type());
-              }
-            }
-          }
+          upgrade_param_type_from_default(
+            type.arguments()[positional_index], default_expr);
         }
       }
     }
@@ -1131,6 +1111,8 @@ void python_converter::process_function_arguments(
       {
         exprt default_expr = get_expr(kw_defaults[i]);
         type.arguments()[kwonly_indices[i]].default_value() = default_expr;
+        upgrade_param_type_from_default(
+          type.arguments()[kwonly_indices[i]], default_expr);
       }
     }
   }
@@ -1366,6 +1348,31 @@ typet python_converter::infer_return_type_from_body(const nlohmann::json &body)
   }
 
   return empty_typet();
+}
+
+/// A default value is direct evidence of an unannotated parameter's type. A
+/// function-pointer default enables indirect-call resolution (`def h(op=g)`);
+/// a container default keeps len()/subscript off the string path, and unlike
+/// the body-usage refinement below it holds inside an imported module too.
+void python_converter::upgrade_param_type_from_default(
+  code_typet::argumentt &param_arg,
+  const exprt &default_expr)
+{
+  if (param_arg.type() != any_type())
+    return;
+
+  const typet &default_type = default_expr.type();
+  const bool is_function_pointer =
+    default_type.is_pointer() && default_type.subtype().is_code();
+  if (!is_function_pointer && default_type != type_handler_.get_list_type())
+    return;
+
+  param_arg.type() = default_type;
+  const std::string param_id = param_arg.cmt_identifier().as_string();
+  if (param_id.empty())
+    return;
+  if (symbolt *param_sym = symbol_table_.find_symbol(param_id))
+    param_sym->set_type(default_type);
 }
 
 void python_converter::get_function_definition(

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -61,6 +61,8 @@ def reset_state() -> None:
     module_exports.clear()
     _reported_cycles.clear()
     _reported_resolution_failures.clear()
+    imported_signature_sources.clear()
+    default_helper_exports.clear()
 
 
 def _resolver_error(detail: str) -> None:
@@ -368,6 +370,41 @@ def filter_imports(tree: ast.AST) -> ast.AST:
     return tree
 
 
+# Preprocessors of every imported module, published so the entry module can
+# adopt their signatures before its own body is finalized.
+imported_signature_sources: list = []
+
+# Per-module def-time default helpers that an importing module may reference.
+default_helper_exports: dict = {}
+
+
+def ensure_default_helper_imports(tree: ast.AST) -> None:
+    """Import the def-time default helpers a filled call site now references.
+
+    A container default is hoisted to a module-level variable where the
+    function is defined; a call in another module reaches it only if the name
+    is imported alongside the function itself.
+    """
+    referenced = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and node.id.startswith("ESBMC_default_")
+    }
+    if not referenced:
+        return
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        owned = default_helper_exports.get(node.module)
+        if not owned:
+            continue
+        already = {alias.name for alias in node.names}
+        for helper in sorted(referenced & owned - already):
+            node.names.append(ast.alias(name=helper, asname=None))
+        ast.fix_missing_locations(node)
+
+
 def process_collected_imports(output_dir: str, callbacks: ResolverCallbacks) -> None:
     """Emit collected imports after transitive discovery converges.
 
@@ -409,6 +446,24 @@ def process_collected_imports(output_dir: str, callbacks: ResolverCallbacks) -> 
     for _module_name, (tree, _filename, preprocessor) in parsed_trees.items():
         preprocessor.finalize_module(tree)
 
+    # Each module was preprocessed in isolation, so it only knows its own call
+    # signatures. Publish them, now that every body has been visited, for the
+    # entry module to adopt before its own body is finalized: a call into an
+    # imported module is otherwise converted without the arguments that
+    # module's defaults would supply.
+    imported_signature_sources.clear()
+    imported_signature_sources.extend(
+        (name, pp) for name, (_tree, _filename, pp) in parsed_trees.items())
+
+    # A call site filled from those defaults references the def-time helper
+    # holding the container default, so it has to be emitted alongside the
+    # functions imported from its module. Kept out of `specific_names`, which
+    # also drives submodule emission -- a helper is a plain module global.
+    default_helper_exports.clear()
+    for module_name, preprocessor in imported_signature_sources:
+        if preprocessor.hoisted_default_names:
+            default_helper_exports[module_name] = set(preprocessor.hoisted_default_names)
+
     _emit_collected_import_json(parsed_trees, output_dir, callbacks)
 
 
@@ -419,7 +474,8 @@ def _emit_collected_import_json(
 ) -> None:
     for module_name, import_info in module_imports.items():
         imported_elements = None if import_info['import_all'] else [
-            ast.alias(name, None) for name in import_info['specific_names']
+            ast.alias(name, None) for name in (import_info['specific_names']
+                                               | default_helper_exports.get(module_name, set()))
         ]
 
         for name in sorted(import_info['specific_names']):

--- a/src/python-frontend/parser/parser_cli.py
+++ b/src/python-frontend/parser/parser_cli.py
@@ -207,9 +207,16 @@ def main(*, deps: CliDeps) -> int | None:
         ),
     )
 
+    for module_name, imported_preprocessor in import_resolver.imported_signature_sources:
+        import_info = import_resolver.module_imports.get(module_name)
+        if import_info is None or import_info['import_all']:
+            continue
+        preprocessor.adopt_module_signatures(imported_preprocessor, import_info['specific_names'])
+
     alias_seed, wrapper_seed = deps.compute_range_seed(tree, import_resolver)
     preprocessor.apply_range_rewrites(tree, alias_seed=alias_seed, wrapper_seed=wrapper_seed)
     tree = preprocessor.finalize_module(tree)
+    import_resolver.ensure_default_helper_imports(tree)
 
     processed_submodules = set()
     for node in ast.walk(tree):

--- a/src/python-frontend/preprocessor/ast_utils_mixin.py
+++ b/src/python-frontend/preprocessor/ast_utils_mixin.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 
 
 class AstUtilsMixin:
@@ -71,21 +72,28 @@ class AstUtilsMixin:
         ast.fix_missing_locations(assign)
         return assign
 
-    def generate_variable_copy(self, qualified_name, arg_node, default_name_node):
+    def generate_variable_copy(self, qualified_name, arg_node, default_node):
         """
-        Materialize a Name default value into a stable temporary variable.
+        Materialize a default value into a stable temporary variable, evaluated
+        once where the function is defined. Python evaluates defaults at
+        definition time and shares the resulting object across calls, so a
+        container default must be hoisted rather than rebuilt per call site.
         """
         func_part = self._sanitize_identifier_fragment(qualified_name)
         arg_part = self._sanitize_identifier_fragment(arg_node.arg)
         target_var = f"ESBMC_default_{func_part}_{arg_part}"
 
+        default_value = copy.deepcopy(default_node)
+        if isinstance(default_value, ast.Name):
+            default_value.ctx = ast.Load()
+
         assignment_node = ast.Assign(
-            targets=[self.create_name_node(target_var, ast.Store(), default_name_node)],
-            value=ast.Name(id=default_name_node.id, ctx=ast.Load()),
+            targets=[self.create_name_node(target_var, ast.Store(), default_node)],
+            value=default_value,
         )
-        self.ensure_all_locations(assignment_node, default_name_node)
+        self.ensure_all_locations(assignment_node, default_node)
         ast.fix_missing_locations(assignment_node)
-        target_ref = self.create_name_node(target_var, ast.Load(), default_name_node)
+        target_ref = self.create_name_node(target_var, ast.Load(), default_node)
         ast.fix_missing_locations(target_ref)
         return assignment_node, target_ref
 

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -1262,6 +1262,7 @@ class CoreVisitorsMixin:
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.args[-i], default_node)
                 self.functionDefaults[(qualified_name, arg_name)] = target_var
+                self.hoisted_default_names.add(target_var.id)
                 if is_method:
                     self._pending_method_default_inits.append(assignment_node)
                 else:
@@ -1278,6 +1279,7 @@ class CoreVisitorsMixin:
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.kwonlyargs[i], default)
                 self.functionDefaults[(qualified_name, kwarg_name)] = target_var
+                self.hoisted_default_names.add(target_var.id)
                 if is_method:
                     self._pending_method_default_inits.append(assignment_node)
                 else:

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -912,9 +912,6 @@ class CoreVisitorsMixin:
                 node.args.append(keywords[expected_args[i]])
                 continue
             default_val = self.functionDefaults[(function_name, expected_args[i])]
-            if isinstance(default_val, (ast.List, ast.Dict, ast.Set)):
-                node.args.append(ast.Constant(value=None))
-                continue
             if isinstance(default_val, ast.AST):
                 default_expr = copy.deepcopy(default_val)
                 if isinstance(default_expr, ast.Name):
@@ -1261,7 +1258,7 @@ class CoreVisitorsMixin:
             arg_name = node.args.args[-i].arg
             if isinstance(default_node, ast.Constant):
                 self.functionDefaults[(qualified_name, arg_name)] = default_node.value
-            elif isinstance(default_node, ast.Name):
+            elif isinstance(default_node, (ast.Name, ast.List, ast.Dict, ast.Set)):
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.args[-i], default_node)
                 self.functionDefaults[(qualified_name, arg_name)] = target_var
@@ -1277,7 +1274,7 @@ class CoreVisitorsMixin:
             kwarg_name = node.args.kwonlyargs[i].arg
             if isinstance(default, ast.Constant):
                 self.functionDefaults[(qualified_name, kwarg_name)] = default.value
-            elif isinstance(default, ast.Name):
+            elif isinstance(default, (ast.Name, ast.List, ast.Dict, ast.Set)):
                 assignment_node, target_var = self.generate_variable_copy(
                     qualified_name, node.args.kwonlyargs[i], default)
                 self.functionDefaults[(qualified_name, kwarg_name)] = target_var

--- a/src/python-frontend/preprocessor/module_lifecycle_mixin.py
+++ b/src/python-frontend/preprocessor/module_lifecycle_mixin.py
@@ -3,6 +3,30 @@ import ast
 
 class ModuleLifecycleMixin:
 
+    def adopt_module_signatures(self, other, imported_names):
+        """Learn an imported module's call signatures and defaults.
+
+        Each module gets its own Preprocessor, so a call to an imported
+        function is otherwise converted without the arguments its signature
+        defaults would supply.
+
+        Only plain module-level functions named in `imported_names` are taken.
+        The tables are keyed by bare name, so adopting wholesale would let
+        another module's `__init__` answer arity checks for a local class; and
+        a class model may deliberately simplify its constructor, so checking
+        calls against it here would reject ones the converter handles (#4665).
+        Own definitions win: a locally defined name keeps its own signature.
+        """
+        for table, source in (
+            (self.functionParams, other.functionParams),
+            (self.functionKwonlyParams, other.functionKwonlyParams),
+            (self.functionDefaults, other.functionDefaults),
+        ):
+            for key, value in source.items():
+                name = key[0] if isinstance(key, tuple) else key
+                if "." not in name and name in imported_names:
+                    table.setdefault(key, value)
+
     def finalize_module(self, node):
         """Run generic_visit and inject helper nodes requested during traversal."""
         # Per-module scope for the eq-only set and call-origin map.

--- a/src/python-frontend/preprocessor/preprocessor_state_mixin.py
+++ b/src/python-frontend/preprocessor/preprocessor_state_mixin.py
@@ -6,6 +6,7 @@ class PreprocessorStateMixin:
     def _init_preprocessor_state(self, module_name):  # pylint: disable=too-many-statements
         self.target_name = ""
         self.functionDefaults = {}
+        self.hoisted_default_names = set()
         self.functionParams = {}
         self.module_name = module_name
         self.is_range_loop = False

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -812,6 +812,12 @@ private:
   std::pair<std::string, typet>
   extract_type_info(const nlohmann::json &ast_node);
 
+  /// Types an unannotated (Any) parameter from its default value, when that
+  /// default carries a usable concrete type.
+  void upgrade_param_type_from_default(
+    code_typet::argumentt &param_arg,
+    const exprt &default_expr);
+
   void handle_array_unpacking(
     const nlohmann::json &ast_node,
     const nlohmann::json &target,


### PR DESCRIPTION
Each module is preprocessed by its own `Preprocessor`, so a call into an imported module was converted without the arguments that module's signature defaults supply. A container default then arrived as a null pointer and `len()` on it dereferenced NULL.

Each imported module's signatures are now published once every body has been visited, the entry module adopts them for the plain functions it imports, and the def-time default helpers those filled call sites reference are emitted alongside the imported functions. An unannotated parameter is also typed from a container default, which the existing body-usage refinement declines to do inside an imported module.

Scope: imported plain functions. An imported *class* with a container-default attribute still fails on a separate gap — `len()` on an untyped attribute — so the graph tests behind #4780 / #4781 are still not unblocked.

Stacks on #7185.
