### PR TITLE
[om] Add the rank trait

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_rank/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_rank/main.cpp
@@ -1,0 +1,14 @@
+#include <type_traits>
+
+int main()
+{
+  // [meta.unary.prop.query]: the number of array dimensions.
+  static_assert(std::rank<int>::value == 0, "scalar");
+  static_assert(std::rank<int[]>::value == 1, "unbounded");
+  static_assert(std::rank<int[3]>::value == 1, "bounded");
+  static_assert(std::rank<int[3][4]>::value == 2, "two dimensions");
+  static_assert(std::rank<int[3][4][5]>::value == 3, "three dimensions");
+  static_assert(std::rank<int *>::value == 0, "pointer is not an array");
+  static_assert(std::rank_v<int[2][2]> == 2, "_v alias");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_rank/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_rank/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_rank_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_rank_fail/main.cpp
@@ -1,0 +1,9 @@
+#include <type_traits>
+#include <cassert>
+
+int main()
+{
+  // int[3][4] has two dimensions, not one.
+  assert(std::rank<int[3][4]>::value == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_rank_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_rank_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -387,6 +387,21 @@ struct extent<T[_Ip], _Np> : extent<T, _Np - 1>
 {
 };
 
+// rank ([meta.unary.prop.query]): the number of array dimensions. Unguarded,
+// like the extent above it.
+template <class T>
+struct rank : integral_constant<size_t, 0>
+{
+};
+template <class T>
+struct rank<T[]> : integral_constant<size_t, rank<T>::value + 1>
+{
+};
+template <class T, size_t _Np>
+struct rank<T[_Np]> : integral_constant<size_t, rank<T>::value + 1>
+{
+};
+
 // is_same
 template <class T, class U>
 struct is_same : false_type
@@ -1124,6 +1139,8 @@ template <class T>
 inline constexpr bool is_array_v = is_array<T>::value;
 template <class T>
 inline constexpr size_t extent_v = extent<T>::value;
+template <class T>
+inline constexpr size_t rank_v = rank<T>::value;
 template <class T, class U>
 inline constexpr bool is_same_v = is_same<T, U>::value;
 template <class T>


### PR DESCRIPTION
`<type_traits>` had `extent` but not `rank`, so `std::rank` was the first parse
error in **3** of a 60-TU sample of ESBMC's own sources.

Unguarded, like the `extent` it sits beside — checked before writing, after
earlier PRs in this series broke `--std c++03` by naming something guarded.

Refs #5868
