### PR TITLE
[om] Add basic_string::find_last_not_of

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_find_last_not_of/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_find_last_not_of/main.cpp
@@ -1,0 +1,15 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("abcxx");
+
+  // [string.find.last.not.of]
+  assert(s.find_last_not_of('x') == 2);
+  assert(s.find_last_not_of("x") == 2);
+
+  std::string all("xxx");
+  assert(all.find_last_not_of('x') == std::string::npos);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_find_last_not_of/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_find_last_not_of/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_find_last_not_of_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_find_last_not_of_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <string>
+#include <cassert>
+
+int main()
+{
+  std::string s("abcxx");
+  // The last character not in "x" is 'c' at index 2, not 4.
+  assert(s.find_last_not_of('x') == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_find_last_not_of_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_find_last_not_of_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -644,6 +644,11 @@ public:
     size_t pos = 0) const;
   size_t find_first_not_of(const char *s, size_t pos = 0) const;
   size_t find_first_not_of(char c, size_t pos = 0) const;
+  size_t find_last_not_of(
+    const basic_string<CharT, Traits, Alloc> &s,
+    size_t pos = npos) const;
+  size_t find_last_not_of(const char *s, size_t pos = npos) const;
+  size_t find_last_not_of(char c, size_t pos = npos) const;
   basic_string<CharT, Traits, Alloc> &erase(size_t pos = 0, size_t n = npos);
   basic_string<CharT, Traits, Alloc> &erase(size_t pos, size_t n, char *tmp);
   basic_string<CharT, Traits, Alloc> &erase(iterator it)
@@ -2593,6 +2598,98 @@ __ESBMC_HIDE:
     if (i >= len)
       break;
     if (this->str[i] == c)
+      return i;
+  }
+  return npos;
+}
+
+/* [string.find.last.not.of]: the highest position at or before pos holding a
+ * character that is not in s. The trip counts are the fixed buffer size for the
+ * reason the neighbouring searches record: a bound taken from the length is
+ * symbolic, and a reverse counter from a symbolic start wraps below zero. */
+template <typename CharT, typename Traits, typename Alloc>
+size_t basic_string<CharT, Traits, Alloc>::find_last_not_of(
+  const basic_string<CharT, Traits, Alloc> &s,
+  size_t pos) const
+{
+__ESBMC_HIDE:
+  __ESBMC_assert(s.str != NULL, "The parameter must be different than NULL");
+  size_t len = this->length();
+  size_t slen = s.length();
+  if (len == 0)
+    return npos;
+  size_t start = (pos >= len) ? len - 1 : pos;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (k > start)
+      break;
+    size_t i = start - k;
+    bool found = false;
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
+      if (this->str[i] == s.str[j])
+      {
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return i;
+  }
+  return npos;
+}
+
+template <typename CharT, typename Traits, typename Alloc>
+size_t basic_string<CharT, Traits, Alloc>::find_last_not_of(
+  const char *s,
+  size_t pos) const
+{
+__ESBMC_HIDE:
+  __ESBMC_assert(s != NULL, "The parameter must be different than NULL");
+  size_t len = this->length();
+  size_t slen = strlen(s);
+  if (len == 0)
+    return npos;
+  size_t start = (pos >= len) ? len - 1 : pos;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (k > start)
+      break;
+    size_t i = start - k;
+    bool found = false;
+    for (size_t j = 0; j < STRING_CAPACITY; j++)
+    {
+      if (j >= slen)
+        break;
+      if (this->str[i] == s[j])
+      {
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return i;
+  }
+  return npos;
+}
+
+template <typename CharT, typename Traits, typename Alloc>
+size_t
+basic_string<CharT, Traits, Alloc>::find_last_not_of(char c, size_t pos) const
+{
+__ESBMC_HIDE:
+  size_t len = this->length();
+  if (len == 0)
+    return npos;
+  size_t start = (pos >= len) ? len - 1 : pos;
+  for (size_t k = 0; k < STRING_CAPACITY; k++)
+  {
+    if (k > start)
+      break;
+    size_t i = start - k;
+    if (this->str[i] != c)
       return i;
   }
   return npos;


### PR DESCRIPTION
`basic_string::find_last_not_of` was the last member of the search family still
missing — the first parse error in a file of the 60-TU self-verification sample.

Its trip counts are the fixed buffer size, matching the neighbouring searches:
a bound taken from the length is symbolic, and a reverse counter from a symbolic
start wraps below zero as a `size_t`.

I wrote this function once before, in #7168, and **dropped it** — at the time
nothing in this family converged, `find_first_not_of` timed out on unpatched
master, and no regression test could cover it. That is no longer true after
#7173/#7175/#7177: the three cases here verify in about **3 s**.

Refs #5868
