### PR TITLE
[python] Recover a bare list parameter's element type from its callers

### DIFF
--- a/regression/python/bare_list_param_conflicting_calls/main.py
+++ b/regression/python/bare_list_param_conflicting_calls/main.py
@@ -1,0 +1,14 @@
+# Call sites that disagree on the element type leave the parameter untyped
+# rather than letting the first one win for the rest.
+
+
+def size_of(xs: list) -> int:
+    return len(xs)
+
+
+def main() -> None:
+    assert size_of([5, 3]) == 2
+    assert size_of(["a", "b", "c"]) == 3
+
+
+main()

--- a/regression/python/bare_list_param_conflicting_calls/test.desc
+++ b/regression/python/bare_list_param_conflicting_calls/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bare_list_param_elem_type/main.py
+++ b/regression/python/bare_list_param_elem_type/main.py
@@ -1,0 +1,30 @@
+# A bare `list` annotation names no element type, so a subscript of the
+# parameter used to read as Any: arithmetic on it raised a spurious TypeError
+# and equality silently evaluated false. The element type is recovered from
+# the call sites instead. Issue #7187.
+
+
+def use(xs: list) -> int:
+    return xs[0] + 0
+
+
+def cmp_(xs: list) -> int:
+    if xs[0] == 5:
+        return 1
+    return 0
+
+
+def use_typed(xs: list[int]) -> int:
+    return xs[0] + 0
+
+
+def main() -> None:
+    xs = [5, 3]
+    assert use(xs) == 5
+    assert cmp_(xs) == 1
+    assert use_typed(xs) == 5
+    # A list literal at the call site types the parameter just as a name does.
+    assert use([7, 1]) == 7
+
+
+main()

--- a/regression/python/bare_list_param_elem_type/test.desc
+++ b/regression/python/bare_list_param_elem_type/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bare_list_param_elem_type_fail/main.py
+++ b/regression/python/bare_list_param_elem_type_fail/main.py
@@ -1,0 +1,14 @@
+# The recovered element type is really used: the read yields the list's value,
+# so asserting a different one is detected.
+
+
+def use(xs: list) -> int:
+    return xs[0] + 0
+
+
+def main() -> None:
+    xs = [5, 3]
+    assert use(xs) == 6
+
+
+main()

--- a/regression/python/bare_list_param_elem_type_fail/test.desc
+++ b/regression/python/bare_list_param_elem_type_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -755,6 +755,127 @@ static bool param_used_in_variable_index_subscript(
   return false;
 }
 
+/// Element type a bare `list` parameter receives, taken from the call sites
+/// that can be resolved statically. `list` alone carries no element type, so
+/// a subscript of such a parameter otherwise reads as Any and neither
+/// arithmetic nor equality on the result behaves (#7187). Every resolvable
+/// call site must agree, so a second caller passing a different element type
+/// cannot silently inherit the first one's.
+/// The list literal a call argument denotes, directly or through the binding
+/// of a Name. Returns false when the argument is not a statically resolvable
+/// list.
+static bool list_literal_for_call_arg(
+  const nlohmann::json &arg,
+  const std::string &enclosing_function,
+  const nlohmann::json &ast,
+  nlohmann::json &out)
+{
+  if (!arg.is_object())
+    return false;
+
+  out = arg;
+  if (arg.value("_type", "") == "Name" && arg.contains("id"))
+  {
+    const nlohmann::json decl = json_utils::find_var_decl(
+      arg["id"].get<std::string>(), enclosing_function, ast);
+    if (
+      !decl.is_object() || !decl.contains("value") ||
+      !decl["value"].is_object())
+      return false;
+    out = decl["value"];
+  }
+
+  return out.value("_type", "") == "List";
+}
+
+/// Element type a bare `list` parameter receives, taken from the call sites
+/// that can be resolved statically. `list` alone carries no element type, so
+/// a subscript of such a parameter otherwise reads as Any and neither
+/// arithmetic nor equality on the result behaves (#7187). Every resolvable
+/// call site must agree, so a second caller passing a different element type
+/// cannot silently inherit the first one's.
+/// Records the element type of a list-annotated parameter, so a subscript of
+/// it reads at the right type. `list[T]` states it; a bare `list` has it
+/// recovered from the call sites (#7187).
+void python_converter::seed_list_param_element_type(
+  const nlohmann::json &element,
+  const symbol_id &id,
+  const std::string &arg_id,
+  size_t param_index)
+{
+  const nlohmann::json &annotation = element["annotation"];
+  const std::string kind = annotation.value("_type", "");
+
+  if (
+    kind == "Subscript" && annotation.contains("value") &&
+    annotation["value"].contains("id"))
+  {
+    const std::string container = annotation["value"]["id"].get<std::string>();
+    if (container != "List" && container != "list")
+      return;
+    const typet elem_type = type_handler_.get_list_type(element).subtype();
+    if (!elem_type.is_empty())
+      python_list::add_type_info_entry(arg_id, "", elem_type);
+    return;
+  }
+
+  const std::string ann_id = annotation.value("id", "");
+  if (
+    kind != "Name" || (ann_id != "list" && ann_id != "List") ||
+    !current_class_name_.empty())
+    return;
+
+  typet elem_type;
+  if (infer_list_elem_type_from_call_sites(
+        id.get_function(), param_index, elem_type))
+    python_list::add_type_info_entry(arg_id, "", elem_type);
+}
+
+bool python_converter::infer_list_elem_type_from_call_sites(
+  const std::string &func_name,
+  size_t param_index,
+  typet &out) const
+{
+  std::vector<numpy_param_call_site> call_sites;
+  collect_call_sites(*ast_json, "", call_sites);
+
+  bool found = false;
+  typet resolved;
+  for (const numpy_param_call_site &site : call_sites)
+  {
+    const nlohmann::json &call = *site.call;
+    if (
+      !call.contains("func") || !call["func"].is_object() ||
+      call["func"].value("_type", "") != "Name" ||
+      call["func"].value("id", "") != func_name || !call.contains("args") ||
+      call["args"].size() <= param_index)
+      continue;
+
+    nlohmann::json literal;
+    if (!list_literal_for_call_arg(
+          call["args"][param_index],
+          site.enclosing_function,
+          *ast_json,
+          literal))
+      continue;
+
+    python_list list_helper(const_cast<python_converter &>(*this), literal);
+    const typet candidate = list_helper.infer_literal_element_type(literal);
+    if (candidate == typet() || candidate.is_empty())
+      continue;
+
+    // Disagreeing call sites leave the parameter untyped rather than pick one.
+    if (found && resolved != candidate)
+      return false;
+    resolved = candidate;
+    found = true;
+  }
+
+  if (found)
+    out = resolved;
+  return found;
+}
+
 bool python_converter::try_infer_numpy_param_type(
   const std::string &func_name,
   size_t param_index,
@@ -998,21 +1119,7 @@ size_t python_converter::register_function_argument(
     get_typechecker().cache_annotation_types(
       *stored_param, element["annotation"]);
 
-    if (
-      element["annotation"].contains("_type") &&
-      element["annotation"]["_type"] == "Subscript" &&
-      element["annotation"].contains("value") &&
-      element["annotation"]["value"].contains("id"))
-    {
-      const std::string container_name =
-        element["annotation"]["value"]["id"].get<std::string>();
-      if (container_name == "List" || container_name == "list")
-      {
-        typet elem_type = type_handler_.get_list_type(element).subtype();
-        if (!elem_type.is_empty())
-          python_list::add_type_info_entry(arg_id, "", elem_type);
-      }
-    }
+    seed_list_param_element_type(element, id, arg_id, inserted_index);
   }
 
   // If the parameter is class-typed (e.g. Foo), copy instance attributes from

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -2280,6 +2280,31 @@ void python_list::handle_slice_assignment(
   converter_.add_instruction(converter_.convert_expression_to_code(call));
 }
 
+/// A bare `list` annotation names no element type, so the read would carry
+/// none and neither arithmetic nor equality on it would behave. Recover what
+/// the call sites told us about this parameter, seeded when the function was
+/// converted (#7187). Returns `annotated` unchanged when this is not a
+/// bare-`list` parameter, or nothing was inferred for it.
+typet python_list::bare_list_param_elem_type(
+  const nlohmann::json &param_node,
+  const std::string &param_id,
+  const typet &annotated)
+{
+  if (
+    !param_node.contains("annotation") || !param_node["annotation"].is_object())
+    return annotated;
+
+  const nlohmann::json &annotation = param_node["annotation"];
+  const std::string ann_id = annotation.value("id", "");
+  if (
+    annotation.value("_type", "") != "Name" ||
+    (ann_id != "list" && ann_id != "List"))
+    return annotated;
+
+  const typet inferred = get_list_element_type(param_id, 0);
+  return inferred.is_empty() ? annotated : inferred;
+}
+
 exprt python_list::handle_index_access(
   const exprt &array,
   const nlohmann::json &slice_node)
@@ -2453,6 +2478,9 @@ exprt python_list::handle_index_access(
     {
       elem_type =
         get_elem_type_from_annotation(list_node, converter_.get_type_handler());
+
+      elem_type = bare_list_param_elem_type(
+        list_node, array.identifier().as_string(), elem_type);
     }
     else if (
       slice_node["_type"] == "Constant" || slice_node["_type"] == "BinOp" ||

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -299,6 +299,12 @@ public:
    *                        a concrete element expression.
    * @param elem_type       ESBMC type of the element.
    */
+  /// Element type recovered for a bare `list` parameter, or a nil type.
+  static typet bare_list_param_elem_type(
+    const nlohmann::json &param_node,
+    const std::string &param_id,
+    const typet &annotated);
+
   static void add_type_info_entry(
     const std::string &list_symbol_id,
     const std::string &elem_id,

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -812,6 +812,19 @@ private:
   std::pair<std::string, typet>
   extract_type_info(const nlohmann::json &ast_node);
 
+  /// Records a list-annotated parameter's element type for subscript reads.
+  void seed_list_param_element_type(
+    const nlohmann::json &element,
+    const symbol_id &id,
+    const std::string &arg_id,
+    size_t param_index);
+
+  /// Recovers a bare `list` parameter's element type from its call sites.
+  bool infer_list_elem_type_from_call_sites(
+    const std::string &func_name,
+    size_t param_index,
+    typet &out) const;
+
   void handle_array_unpacking(
     const nlohmann::json &ast_node,
     const nlohmann::json &target,


### PR DESCRIPTION
A `list` annotation names no element type, so a subscript of the parameter read as Any: arithmetic on the result raised a spurious `TypeError` and equality silently evaluated false, while the identical body annotated `list[int]` worked.

The element type is now inferred from the statically resolvable call sites — a list literal, or a name bound to one — and seeded where the `list[T]` annotation already seeds one, so the read picks it up. Call sites that disagree leave the parameter untyped rather than letting the first one win.

Fixes #7187
