### PR TITLE
[om] Add base() to list's reverse_iterator

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base/main.cpp
@@ -1,0 +1,25 @@
+#include <list>
+#include <cassert>
+
+int main()
+{
+  std::list<int> l;
+  l.push_back(1);
+  l.push_back(2);
+  l.push_back(3);
+
+  // [reverse.iter.conv]: &*rit == &*(rit.base() - 1), so rbegin().base() is
+  // end() and rend().base() is begin().
+  std::list<int>::reverse_iterator r = l.rbegin();
+  assert(*r == 3);
+  assert(r.base() == l.end());
+
+  std::list<int>::reverse_iterator e = l.rend();
+  assert(e.base() == l.begin());
+  assert(*e.base() == 1);
+
+  ++r;
+  assert(*r == 2);
+  assert(*r.base() == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <list>
+#include <cassert>
+
+int main()
+{
+  std::list<int> l;
+  l.push_back(1);
+  l.push_back(2);
+  std::list<int>::reverse_iterator r = l.rbegin();
+  // base() is one step FORWARD of what the reverse iterator denotes, so
+  // rbegin().base() is end(), not the last element.
+  assert(*r.base() == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_reverse_iterator_base_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -251,6 +251,17 @@ public:
     reverse_iterator(const reverse_iterator &x) : owner(x.owner), idx(x.idx)
     {
     }
+
+    /* [reverse.iter.conv]: base() is the underlying iterator, one step forward
+     * of what this one denotes -- &*rit == &*(rit.base() - 1). At rend the
+     * index is the sentinel, whose _next_idx is the sentinel again, so begin()
+     * has to be named directly. */
+    iterator base() const
+    {
+      if (idx == SENTINEL)
+        return iterator(owner, owner->_sentinel_next);
+      return iterator(owner, owner->_next_idx(idx));
+    }
     reverse_iterator &operator=(const reverse_iterator &x)
     {
       owner = x.owner;


### PR DESCRIPTION
[reverse.iter.conv] gives every reverse iterator a `base()`, and `list`'s did
not have one — the first parse error in a file of the 60-TU self-verification
sample (`std::list<goto_programt::instructiont>::reverse_iterator`).

`base()` is the underlying iterator one step *forward* of what the reverse
iterator denotes, so `&*rit == &*(rit.base() - 1)`. The edge case worth noting:
at `rend()` the stored index is the sentinel, and `_next_idx(SENTINEL)` is the
sentinel again, so `begin()` is named directly rather than stepped to. The test
covers `rbegin().base() == end()`, `rend().base() == begin()` and a middle
position.

`vector`'s and `deque`'s reverse iterators hold a pointer rather than an index,
so they need a different expression; only `list`'s was reached by the sample, and
they are left for a follow-up rather than guessed at.

Refs #5868
