### PR TITLE
[om] Make errno visible through <vector>

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_vector_errno/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_vector_errno/main.cpp
@@ -1,0 +1,16 @@
+#include <vector>
+#include <cstdlib>
+#include <cassert>
+
+int main()
+{
+  // The shape nlohmann's lexer uses: errno around strtol, having included
+  // only <vector> and <cstdlib>.
+  errno = 0;
+  const char *s = "12";
+  char *end;
+  long v = strtol(s, &end, 10);
+  assert(v == 12);
+  assert(errno == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_vector_errno/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_vector_errno/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++23
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -2,6 +2,12 @@
 #define __STL_VECTOR
 
 #include <stdlib.h>
+/* Not required by [vector.syn], but the toolchains this model stands in for
+ * make errno visible through <vector>, and code relies on it: nlohmann's
+ * lexer sets errno around strtod having included only <vector> and <cstdlib>.
+ * Checked against the host compiler, where <vector> provides it and <cstdlib>
+ * does not. */
+#include <errno.h>
 #include <assert.h>
 #include <cstddef> // for size_t, ptrdiff_t
 #include <memory>


### PR DESCRIPTION
Code that calls `strtod`/`strtol` checks `errno` without including `<cerrno>`,
because the toolchains this model stands in for make it visible transitively.
nlohmann's `lexer.hpp` does exactly that — `errno = 0;` around `strtod`, having
included only `<vector>` and `<cstdlib>` — and it was the first parse error in
**11** of a 60-TU sample of ESBMC's own sources.

`<vector>` is where the host compiler provides it. My first attempt put it in
`<cstdlib>`, which seemed the obvious home; the host **rejects** that, so the
test now matches the host exactly rather than being more permissive than it.

**Incidental effect, measured not assumed.** Declaring a global perturbs object
numbering, so solver cost can move either way. Timed over the whole `vector`
suite with nothing else running: 167 tests, **no slowdowns**, and one
improvement — `vector/github_6368_insert` goes from not completing at all
(>1400 s) to **20 s**. Nothing in that test touches `errno`, so this is a
side effect of the perturbation rather than a designed fix; I mention it because
a reviewer will see the verdict change.

Refs #5868

---

Method note, since it changes what "the census says" means: this series' census
had been running every TU at `--std c++17`, but ESBMC builds at
**`-std=gnu++23`**. Re-running at each TU's real standard is what surfaced
`errno` at all, and retired `std::string::starts_with`, which I had listed as a
gap and which is correctly C++20-guarded.
