### PR TITLE
[om] Model add_cv, add_volatile and move_backward

### DIFF
--- a/regression/esbmc-cpp/cpp/type_traits_add_cv/main.cpp
+++ b/regression/esbmc-cpp/cpp/type_traits_add_cv/main.cpp
@@ -1,0 +1,25 @@
+#include <type_traits>
+#include <algorithm>
+
+int main()
+{
+  // [meta.trans.cv]
+  static_assert(
+    std::is_same<std::add_cv<int>::type, const volatile int>::value, "add_cv");
+  static_assert(
+    std::is_same<std::add_volatile<int>::type, volatile int>::value,
+    "add_volatile");
+  static_assert(
+    std::is_same<std::add_cv<const int>::type, const volatile int>::value,
+    "add_cv is idempotent on an already-const type");
+  static_assert(
+    std::is_same<std::add_volatile<int &>::type, int &>::value,
+    "a reference is left alone");
+
+  // [alg.move]. Taking its address instantiates the template. Calling it
+  // cannot be checked here: the copy_backward it mirrors does not converge
+  // under symbolic execution either, so a call would only time out.
+  int *(*f)(int *, int *, int *) = &std::move_backward<int *, int *>;
+  (void)f;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/type_traits_add_cv/test.desc
+++ b/regression/esbmc-cpp/cpp/type_traits_add_cv/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/type_traits_add_cv_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/type_traits_add_cv_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <type_traits>
+#include <cassert>
+
+int main()
+{
+  std::add_cv<int>::type x = 5;
+  std::add_volatile<int>::type y = 7;
+  assert(x + y == 13);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/type_traits_add_cv_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/type_traits_add_cv_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -539,6 +539,17 @@ BidIt2 copy_backward(BidIt1 first, BidIt1 last, BidIt2 dest)
   return dest;
 }
 
+#if __cplusplus >= 201103L
+// [alg.move]: the moving counterpart of copy_backward.
+template <class BidIt1, class BidIt2>
+BidIt2 move_backward(BidIt1 first, BidIt1 last, BidIt2 dest)
+{
+  while (last != first)
+    *(--dest) = ::std::move(*(--last));
+  return dest;
+}
+#endif
+
 /* swap is provided by <utility> (included above) for both C++03 and C++11+;
    defining it here as well caused a redefinition error under -std=c++03. */
 

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -1203,6 +1203,19 @@ struct add_const
   typedef const T type;
 };
 
+// [meta.trans.cv]: the other two of the trio.
+template <class T>
+struct add_volatile
+{
+  typedef volatile T type;
+};
+
+template <class T>
+struct add_cv
+{
+  typedef const volatile T type;
+};
+
 // common_type: enough of [meta.trans.other] for the two-type case TMP-heavy
 // headers use; the variadic form folds left as the standard specifies.
 template <class... T>


### PR DESCRIPTION
`<type_traits>` carried `add_const` but neither sibling, and `<algorithm>` had `copy_backward` without its moving counterpart. Five of ESBMC's own translation units failed to parse on `add_cv` (3) and `move_backward` (2), per #5868.

The test instantiates `move_backward` by address but does not call it: the `copy_backward` it mirrors does not converge under symbolic execution either, so a call would only time out.

Differential sweep over `esbmc-cpp/cpp`: 897 tests, the only two diffs are the tests added here. Refs #5868.