### PR TITLE
[python] Keep tuple shape through enumerate over a list literal

### DIFF
--- a/regression/python/enumerate_tuple_elements/main.py
+++ b/regression/python/enumerate_tuple_elements/main.py
@@ -1,0 +1,35 @@
+# `for i, v in enumerate(pairs)` was lowered to a while loop whose value
+# variable is a bare-`tuple`-annotated subscript read, carrying no component
+# types, so a later `a, b = v` was handed an untyped value and refused to
+# unpack. Unrolling binds each tuple literal directly and keeps its shape, as
+# the nested-target form already did.
+from typing import List, Tuple
+
+pairs = [(1, 2), (3, 4)]
+total = 0
+for i, tpl in enumerate(pairs):
+    a, b = tpl
+    assert a < b
+    total = total + a + b
+assert total == 10
+assert i == 1
+
+# An explicit annotation takes the same path.
+typed: List[Tuple[int, int]] = [(5, 6), (7, 8)]
+for j, t2 in enumerate(typed):
+    c, d = t2
+    assert d == c + 1
+
+# A non-zero start is honoured.
+for k, t3 in enumerate(pairs, 2):
+    e, f = t3
+    assert e < f
+assert k == 3
+
+# Lists of non-tuple elements keep the ordinary lowering.
+nums = [10, 20, 30]
+seen = 0
+for m, n in enumerate(nums):
+    seen = seen + n
+assert seen == 60
+assert m == 2

--- a/regression/python/enumerate_tuple_elements/test.desc
+++ b/regression/python/enumerate_tuple_elements/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate_tuple_elements_fail/main.py
+++ b/regression/python/enumerate_tuple_elements_fail/main.py
@@ -1,0 +1,5 @@
+# The unpacked components are really read, not assumed.
+pairs = [(1, 2), (3, 4)]
+for i, tpl in enumerate(pairs):
+    a, b = tpl
+    assert a > b

--- a/regression/python/enumerate_tuple_elements_fail/test.desc
+++ b/regression/python/enumerate_tuple_elements_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -702,6 +702,11 @@ class LoopMixin:
         if target_info["type"] == "nested":
             return self._unroll_nested_enumerate_for(node, target_info)
 
+        if target_info["type"] == "unpacking":
+            literal, start = self._tuple_literal_enumerate_source(node)
+            if literal is not None:
+                return self._unroll_enumerate_over_tuples(node, target_info, literal, start)
+
         # Generate unique variable names for this enumerate loop level
         loop_id = self.enumerate_loop_counter
         self.enumerate_loop_counter += 1
@@ -812,6 +817,56 @@ class LoopMixin:
             self._reject_unsupported_loop(
                 node, f"enumerate() with a nested unpacking target is unsupported here: {blocker}")
         return literal, start
+
+    def _tuple_literal_enumerate_source(self, node):
+        """Return (list literal, start) when unrolling would preserve tuple shape.
+
+        `for i, v in enumerate(pairs)` is lowered to a while loop whose value
+        variable is a bare-`tuple`-annotated subscript read, which carries no
+        component types, so a later `a, b = v` is handed an untyped value and
+        refuses to unpack. Unrolling binds each tuple literal directly and
+        keeps its shape, exactly as the nested-target form already does.
+
+        Returns (None, None) when this does not apply, leaving the ordinary
+        lowering in place -- unlike the nested form, a plain value target is
+        fully supported there.
+        """
+        iterable, start_value = self._parse_enumerate_arguments(node.iter, node)
+        literal = self._resolve_list_literal_iterable(iterable)
+        start = self._static_int_value(start_value)
+        if (literal is None or start is None
+                or not self._can_safely_unroll_list_literal_for(node, literal)):
+            return None, None
+
+        # Only the tuple/list-element case loses type information; leave every
+        # other element kind to the ordinary lowering.
+        if not literal.elts or not all(
+                isinstance(elt, (ast.Tuple, ast.List)) for elt in literal.elts):
+            return None, None
+
+        return literal, start
+
+    def _unroll_enumerate_over_tuples(self, node, target_info, literal, start):
+        """Bind each tuple literal directly, keeping its shape."""
+        unrolled = []
+        for offset, elt in enumerate(literal.elts):
+            index_assign = ast.AnnAssign(
+                target=self.create_name_node(target_info["index_var"], ast.Store(), node),
+                annotation=self.create_name_node("int", ast.Load(), node),
+                value=self.create_constant_node(start + offset, node),
+                simple=1,
+            )
+            value_assign = ast.Assign(
+                targets=[self.create_name_node(target_info["value_var"], ast.Store(), node)],
+                value=copy.deepcopy(elt),
+            )
+            unrolled.extend([index_assign, value_assign])
+            unrolled.extend(copy.deepcopy(stmt) for stmt in node.body)
+
+        for stmt in unrolled:
+            self.ensure_all_locations(stmt, node)
+            ast.fix_missing_locations(stmt)
+        return unrolled
 
     def _unroll_nested_enumerate_for(self, node, target_info):
         """Unroll `for i, (a, b) in enumerate(seq)` over a statically known list.


### PR DESCRIPTION
`for i, v in enumerate(pairs)` is lowered to a while loop whose value variable is a bare-`tuple`-annotated subscript read. A bare `tuple` carries no component types, so a later `a, b = v` is handed an untyped value and refuses with `Cannot unpack empty` (or `Cannot unpack pointer` when the list is annotated `List[Tuple[int, int]]`).

Plain iteration does not have this problem because it is unrolled, and the nested-target form `for i, (a, b) in enumerate(seq)` already unrolls for exactly this reason. This extends that to a plain value target when the elements are tuple or list literals; every other element kind keeps the ordinary lowering.

Scope: this covers a statically resolvable list literal. `shortest_path_length` and `minimum_spanning_tree` enumerate a heap built at runtime, so they still hit `Cannot unpack signedbv` and stay KNOWNBUG.
