### PR TITLE
[om] Add cmath's integral overload for ldexp

### DIFF
--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral/main.cpp
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral/main.cpp
@@ -1,0 +1,20 @@
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  // [cmath.syn]: an integer argument converts to double. Without that
+  // overload the call is ambiguous between float, double and long double.
+  int mant = 3;
+  assert(std::ldexp(mant, 2) == 12.0);
+
+  unsigned u = 5;
+  assert(std::ldexp(u, 1) == 10.0);
+
+  long l = 7;
+  assert(std::ldexp(l, 0) == 7.0);
+
+  // The floating-point overloads must still win for floating arguments.
+  assert(std::ldexp(1.5, 2) == 6.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral/test.desc
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/main.cpp
@@ -1,0 +1,9 @@
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  int mant = 3;
+  assert(std::ldexp(mant, 2) == 13.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -167,10 +167,16 @@ inline long double ldexp(long double num, int exp)
 {
   return ::ldexpl(num, exp);
 }
-/* TODO:
+/* [cmath.syn]: the additional overloads that convert an integer argument to
+ * double. Without one, ldexp(int, int) is ambiguous -- int converts equally
+ * well to float, double and long double. nlohmann's binary_reader calls it
+ * that way. */
 template <typename Integer>
-double ldexp(Integer num, int exp);
- */
+inline typename enable_if<is_integral<Integer>::value, double>::type
+ldexp(Integer num, int exp)
+{
+  return ::ldexp(static_cast<double>(num), exp);
+}
 
 using ::modf;
 using ::modff;


### PR DESCRIPTION
`std::ldexp(n, e)` with an integral `n` was ambiguous — `int` converts equally well to the `float`, `double` and `long double` overloads — because [cmath.syn]'s additional overload taking an integer was left as a `TODO` in the header. nlohmann's `binary_reader` calls it that way, so every TU reaching that header collected four errors from it. `string_method_handler.cpp` goes from 13 errors to 9.

The macro-generated families (`CIMPORT1`/`CIMPORT2`) carry the same TODO. Adding overloads to all forty at once perturbs resolution far more widely than anything measured needs, so this fixes only the call that blocks.

Stacked on #7202. Differential sweep over `esbmc-cpp/cpp`: 905 tests, the only diffs are the two tests added here. Refs #5868.