### PR TITLE
[python] Do not annotate a loop value with a component-less Tuple

### DIFF
--- a/regression/python/enumerate_annotated_tuple_list/main.py
+++ b/regression/python/enumerate_annotated_tuple_list/main.py
@@ -1,0 +1,17 @@
+# A `List[Tuple[int, int]]` annotation yields only the element's head name, so
+# the loop value was annotated with a component-less `Tuple` and read back as
+# an opaque pointer that `a, b = tpl` could not unpack -- strictly worse than
+# the unannotated case, which types the value `Any` and works.
+from typing import List, Tuple
+
+pairs: List[Tuple[int, int]] = []
+pairs.append((1, 2))
+pairs.append((3, 4))
+
+total = 0
+for i, tpl in enumerate(pairs):
+    a, b = tpl
+    assert a < b
+    total = total + a + b
+assert total == 10
+assert i == 1

--- a/regression/python/enumerate_annotated_tuple_list/test.desc
+++ b/regression/python/enumerate_annotated_tuple_list/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate_annotated_tuple_list_fail/main.py
+++ b/regression/python/enumerate_annotated_tuple_list_fail/main.py
@@ -1,0 +1,9 @@
+# The unpacked components are really read, not assumed.
+from typing import List, Tuple
+
+pairs: List[Tuple[int, int]] = []
+pairs.append((1, 2))
+
+for i, tpl in enumerate(pairs):
+    a, b = tpl
+    assert a > b

--- a/regression/python/enumerate_annotated_tuple_list_fail/test.desc
+++ b/regression/python/enumerate_annotated_tuple_list_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$

--- a/regression/python/enumerate_tuple_elements/main.py
+++ b/regression/python/enumerate_tuple_elements/main.py
@@ -1,0 +1,35 @@
+# `for i, v in enumerate(pairs)` was lowered to a while loop whose value
+# variable is a bare-`tuple`-annotated subscript read, carrying no component
+# types, so a later `a, b = v` was handed an untyped value and refused to
+# unpack. Unrolling binds each tuple literal directly and keeps its shape, as
+# the nested-target form already did.
+from typing import List, Tuple
+
+pairs = [(1, 2), (3, 4)]
+total = 0
+for i, tpl in enumerate(pairs):
+    a, b = tpl
+    assert a < b
+    total = total + a + b
+assert total == 10
+assert i == 1
+
+# An explicit annotation takes the same path.
+typed: List[Tuple[int, int]] = [(5, 6), (7, 8)]
+for j, t2 in enumerate(typed):
+    c, d = t2
+    assert d == c + 1
+
+# A non-zero start is honoured.
+for k, t3 in enumerate(pairs, 2):
+    e, f = t3
+    assert e < f
+assert k == 3
+
+# Lists of non-tuple elements keep the ordinary lowering.
+nums = [10, 20, 30]
+seen = 0
+for m, n in enumerate(nums):
+    seen = seen + n
+assert seen == 60
+assert m == 2

--- a/regression/python/enumerate_tuple_elements/test.desc
+++ b/regression/python/enumerate_tuple_elements/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate_tuple_elements_fail/main.py
+++ b/regression/python/enumerate_tuple_elements_fail/main.py
@@ -1,0 +1,5 @@
+# The unpacked components are really read, not assumed.
+pairs = [(1, 2), (3, 4)]
+for i, tpl in enumerate(pairs):
+    a, b = tpl
+    assert a > b

--- a/regression/python/enumerate_tuple_elements_fail/test.desc
+++ b/regression/python/enumerate_tuple_elements_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -1044,6 +1044,13 @@ class LoopMixin:
         self.ensure_all_locations(subscript, node)
 
         element_type = self._get_element_type_from_container(annotation_id, iterable_node)
+        # A container annotation yields only the element's head name, so
+        # `List[Tuple[int, int]]` gives a component-less `Tuple`. Annotating the
+        # loop value with that types it as an opaque pointer and a later
+        # `a, b = v` cannot unpack it -- strictly worse than `Any`, which the
+        # unannotated path uses and which recovers the real type.
+        if element_type in ("Tuple", "tuple"):
+            element_type = "Any"
         ann_node = self.create_name_node(element_type, ast.Load(), node)
         user_value_assign = ast.AnnAssign(
             target=self.create_name_node(target_info["value_var"], ast.Store(), node),

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -702,6 +702,11 @@ class LoopMixin:
         if target_info["type"] == "nested":
             return self._unroll_nested_enumerate_for(node, target_info)
 
+        if target_info["type"] == "unpacking":
+            literal, start = self._tuple_literal_enumerate_source(node)
+            if literal is not None:
+                return self._unroll_enumerate_over_tuples(node, target_info, literal, start)
+
         # Generate unique variable names for this enumerate loop level
         loop_id = self.enumerate_loop_counter
         self.enumerate_loop_counter += 1
@@ -812,6 +817,56 @@ class LoopMixin:
             self._reject_unsupported_loop(
                 node, f"enumerate() with a nested unpacking target is unsupported here: {blocker}")
         return literal, start
+
+    def _tuple_literal_enumerate_source(self, node):
+        """Return (list literal, start) when unrolling would preserve tuple shape.
+
+        `for i, v in enumerate(pairs)` is lowered to a while loop whose value
+        variable is a bare-`tuple`-annotated subscript read, which carries no
+        component types, so a later `a, b = v` is handed an untyped value and
+        refuses to unpack. Unrolling binds each tuple literal directly and
+        keeps its shape, exactly as the nested-target form already does.
+
+        Returns (None, None) when this does not apply, leaving the ordinary
+        lowering in place -- unlike the nested form, a plain value target is
+        fully supported there.
+        """
+        iterable, start_value = self._parse_enumerate_arguments(node.iter, node)
+        literal = self._resolve_list_literal_iterable(iterable)
+        start = self._static_int_value(start_value)
+        if (literal is None or start is None
+                or not self._can_safely_unroll_list_literal_for(node, literal)):
+            return None, None
+
+        # Only the tuple/list-element case loses type information; leave every
+        # other element kind to the ordinary lowering.
+        if not literal.elts or not all(
+                isinstance(elt, (ast.Tuple, ast.List)) for elt in literal.elts):
+            return None, None
+
+        return literal, start
+
+    def _unroll_enumerate_over_tuples(self, node, target_info, literal, start):
+        """Bind each tuple literal directly, keeping its shape."""
+        unrolled = []
+        for offset, elt in enumerate(literal.elts):
+            index_assign = ast.AnnAssign(
+                target=self.create_name_node(target_info["index_var"], ast.Store(), node),
+                annotation=self.create_name_node("int", ast.Load(), node),
+                value=self.create_constant_node(start + offset, node),
+                simple=1,
+            )
+            value_assign = ast.Assign(
+                targets=[self.create_name_node(target_info["value_var"], ast.Store(), node)],
+                value=copy.deepcopy(elt),
+            )
+            unrolled.extend([index_assign, value_assign])
+            unrolled.extend(copy.deepcopy(stmt) for stmt in node.body)
+
+        for stmt in unrolled:
+            self.ensure_all_locations(stmt, node)
+            ast.fix_missing_locations(stmt)
+        return unrolled
 
     def _unroll_nested_enumerate_for(self, node, target_info):
         """Unroll `for i, (a, b) in enumerate(seq)` over a statically known list.


### PR DESCRIPTION
Annotating a list `List[Tuple[int, int]]` made `enumerate` over it *fail* where the same code with no annotation succeeds:

```python
pairs: List[Tuple[int, int]] = []   # ERROR: Cannot unpack pointer
pairs = []                          # VERIFICATION SUCCESSFUL
```

The container annotation yields only the element's head name, so the loop value was annotated with a component-less `Tuple`. That types it as an opaque pointer and a later `a, b = v` cannot unpack it — strictly worse than the `Any` the unannotated path uses, which recovers the real type. Fall back to `Any` for that case.

Stacks on #7201.
