### PR TITLE
[contracts] Excuse every element the clause named

### DIFF
--- a/regression/function_contract/github_7184_assigns_two_elems/main.c
+++ b/regression/function_contract/github_7184_assigns_two_elems/main.c
@@ -1,0 +1,19 @@
+/* A clause naming two elements of the same array grants both. Swapping them is
+ * a write inside that frame, so it must verify -- and used to be rejected,
+ * because each element check excused only its own index (#7184). */
+void array_swap(int *arr, int n1, int n2)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(arr, 5 * sizeof(int)));
+  __ESBMC_requires(n1 >= 0 && n1 < 5);
+  __ESBMC_requires(n2 >= 0 && n2 < 5);
+  __ESBMC_assigns(arr[n1], arr[n2]);
+  __ESBMC_ensures(1);
+  int temp = arr[n1];
+  arr[n1] = arr[n2];
+  arr[n2] = temp;
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/function_contract/github_7184_assigns_two_elems/test.desc
+++ b/regression/function_contract/github_7184_assigns_two_elems/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enforce-contract array_swap --function array_swap
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/github_7184_assigns_two_elems_fail/main.c
+++ b/regression/function_contract/github_7184_assigns_two_elems_fail/main.c
@@ -1,0 +1,18 @@
+/* Widening the excusal to every named index must not excuse an index the
+ * clause never named: this body writes a third element and must be caught. */
+void set_third(int *arr, int n1, int n2, int n3)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(arr, 5 * sizeof(int)));
+  __ESBMC_requires(n1 >= 0 && n1 < 5);
+  __ESBMC_requires(n2 >= 0 && n2 < 5);
+  __ESBMC_requires(n3 >= 0 && n3 < 5);
+  __ESBMC_requires(n3 != n1 && n3 != n2);
+  __ESBMC_assigns(arr[n1], arr[n2]);
+  __ESBMC_ensures(1);
+  arr[n3] = 7;
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/function_contract/github_7184_assigns_two_elems_fail/test.desc
+++ b/regression/function_contract/github_7184_assigns_two_elems_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--enforce-contract set_third --function set_third
+^VERIFICATION FAILED$
+^.*arr\[j\] not in assigns clause.*$

--- a/regression/function_contract/github_7184_assigns_two_elems_one_write/main.c
+++ b/regression/function_contract/github_7184_assigns_two_elems_one_write/main.c
@@ -1,0 +1,17 @@
+/* Writing one of the two granted elements is still inside the frame. This
+ * shape failed even though the body touched a single named index, because the
+ * other element's check excused only the index it was built from (#7184). */
+void set_first(int *arr, int n1, int n2)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(arr, 5 * sizeof(int)));
+  __ESBMC_requires(n1 >= 0 && n1 < 5);
+  __ESBMC_requires(n2 >= 0 && n2 < 5);
+  __ESBMC_assigns(arr[n1], arr[n2]);
+  __ESBMC_ensures(1);
+  arr[n1] = 7;
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/function_contract/github_7184_assigns_two_elems_one_write/test.desc
+++ b/regression/function_contract/github_7184_assigns_two_elems_one_write/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--enforce-contract set_first --function set_first
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -3677,10 +3677,24 @@ void code_contractst::emit_arr_elem_assertions(
       add2tc(snap.arr_add_type, snap.arr_ptr, snap.witness_idx);
     expr2tc arr_at_j_after = dereference2tc(snap.elem_type, arr_plus_j);
 
-    // Guard: (j == declared_idx) || (arr[j] == snap)
-    expr2tc eq_idx = equality2tc(snap.witness_idx, snap.declared_idx);
-    expr2tc eq_val = equality2tc(arr_at_j_after, snap.snapshot_sym);
-    expr2tc guard = or2tc(eq_idx, eq_val);
+    // Guard: (j == any index the clause named on this array) || (arr[j] ==
+    // snap). Excusing only this target's own index rejects a body that writes
+    // a different element of the same array the clause also granted, which is
+    // a write inside its frame (#7184). The global-array path already ORs over
+    // every named index; this is the same rule for a pointer parameter.
+    expr2tc guard = equality2tc(arr_at_j_after, snap.snapshot_sym);
+    for (const auto &other : snapshots)
+    {
+      if (
+        to_symbol2t(other.arr_ptr).thename != to_symbol2t(snap.arr_ptr).thename)
+        continue;
+
+      guard = or2tc(
+        guard,
+        equality2tc(
+          snap.witness_idx,
+          typecast2tc(snap.witness_idx->type, other.declared_idx)));
+    }
 
     goto_programt::targett t = wrapper.add_instruction(ASSERT);
     t->guard = guard;


### PR DESCRIPTION
Closes #7184, though not for the reason the issue gives — see the comment there.

## The defect

An assigns clause naming two elements of the same array grants both. Each
Phase 2B check excused only the index it was built from:

```cpp
// Guard: (j == declared_idx) || (arr[j] == snap)
expr2tc eq_idx = equality2tc(snap.witness_idx, snap.declared_idx);
```

So for `__ESBMC_assigns(arr[n1], arr[n2])`, the check built from `n1` demands
every element other than `n1` is unchanged — including `n2`, which the clause
explicitly granted. A correct swap falsifies it.

No second write is needed to trigger it. On `a082fe7d1d`, this body writes a
single named index and is still rejected:

```c
void set_first(int *arr, int n1, int n2)
{
  __ESBMC_requires(__ESBMC_is_fresh(arr, 5 * sizeof(int)));
  __ESBMC_requires(n1 >= 0 && n1 < 5);
  __ESBMC_requires(n2 >= 0 && n2 < 5);
  __ESBMC_assigns(arr[n1], arr[n2]);
  arr[n1] = 7;
}
```

```
FAILED  assigns compliance: ...@set_first@arr[j] not in assigns clause (Phase 2B)
```

The witness of the `n2` check picks `j == n1`, sees that element changed, and
reports a violation of a frame that permits it.

## The fix

`emit_array_elem_frame` in `frame_enforcer.cpp` already implements the right
rule for a global array — it ORs over every index recorded for that array. This
does the same in `emit_arr_elem_assertions`, grouped by array pointer.

## Tests

- `github_7184_assigns_two_elems` — swap of two granted elements, must verify
- `github_7184_assigns_two_elems_one_write` — one write, two named indices, must
  verify
- `github_7184_assigns_two_elems_fail` — a write to an index the clause never
  named, must still be caught, so the widened excusal does not over-permit

`regression/function_contract` 405/405.

Independent of #7206, which fixes a second Phase 2B defect on the same code
path; each branch was built and tested on its own.

https://claude.ai/code/session_01MEkhmEkbhB4tUdSnqYntPA
