### PR TITLE
[om] Add locale's toupper and tolower convenience forms

### DIFF
--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral/main.cpp
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral/main.cpp
@@ -1,0 +1,20 @@
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  // [cmath.syn]: an integer argument converts to double. Without that
+  // overload the call is ambiguous between float, double and long double.
+  int mant = 3;
+  assert(std::ldexp(mant, 2) == 12.0);
+
+  unsigned u = 5;
+  assert(std::ldexp(u, 1) == 10.0);
+
+  long l = 7;
+  assert(std::ldexp(l, 0) == 7.0);
+
+  // The floating-point overloads must still win for floating arguments.
+  assert(std::ldexp(1.5, 2) == 6.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral/test.desc
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/main.cpp
@@ -1,0 +1,9 @@
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  int mant = 3;
+  assert(std::ldexp(mant, 2) == 13.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cmath_ldexp_integral_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/locale_convenience/main.cpp
+++ b/regression/esbmc-cpp/cpp/locale_convenience/main.cpp
@@ -1,0 +1,14 @@
+#include <locale>
+#include <cassert>
+
+int main()
+{
+  // [locale.convenience]: the two-argument forms boost's property_tree uses.
+  std::locale loc;
+
+  assert(std::toupper('a', loc) == 'A');
+  assert(std::toupper('Z', loc) == 'Z');
+  assert(std::tolower('Q', loc) == 'q');
+  assert(std::tolower('7', loc) == '7');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/locale_convenience/test.desc
+++ b/regression/esbmc-cpp/cpp/locale_convenience/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/locale_convenience_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/locale_convenience_fail/main.cpp
@@ -1,0 +1,9 @@
+#include <locale>
+#include <cassert>
+
+int main()
+{
+  std::locale loc;
+  assert(std::toupper('a', loc) == 'a');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/locale_convenience_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/locale_convenience_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -167,10 +167,16 @@ inline long double ldexp(long double num, int exp)
 {
   return ::ldexpl(num, exp);
 }
-/* TODO:
+/* [cmath.syn]: the additional overloads that convert an integer argument to
+ * double. Without one, ldexp(int, int) is ambiguous -- int converts equally
+ * well to float, double and long double. nlohmann's binary_reader calls it
+ * that way. */
 template <typename Integer>
-double ldexp(Integer num, int exp);
- */
+inline typename enable_if<is_integral<Integer>::value, double>::type
+ldexp(Integer num, int exp)
+{
+  return ::ldexp(static_cast<double>(num), exp);
+}
 
 using ::modf;
 using ::modff;

--- a/src/cpp/library/locale
+++ b/src/cpp/library/locale
@@ -2,6 +2,7 @@
 #define STL_LOCALE
 
 #include <ctime>
+#include "cctype" /* ::toupper, ::tolower */
 #include "string"
 #include "iterator"
 #include "iostream"
@@ -702,6 +703,22 @@ bool locale::operator()(const string &s1, const string &s2) const
     use_facet<collate<charT> >(*this).compare(
       s1.data(), s1.data() + s1.size(), s2.data(), s2.data() + s2.size()) <
     0);
+}
+
+/* [locale.convenience]: the character conversions. The standard defines them
+ * as use_facet<ctype<charT>>(loc).toupper(c); the ctype facet above is
+ * declared but has no definition, so these model the classic locale directly
+ * and ignore loc. boost's property_tree calls toupper(c, loc). */
+template <class charT>
+inline charT toupper(charT c, const locale &)
+{
+  return static_cast<charT>(::toupper(static_cast<int>(c)));
+}
+
+template <class charT>
+inline charT tolower(charT c, const locale &)
+{
+  return static_cast<charT>(::tolower(static_cast<int>(c)));
 }
 
 } // namespace std


### PR DESCRIPTION
`<locale>` declared the `ctype` facet but not [locale.convenience]'s two-argument `toupper`/`tolower`, which boost's `property_tree` calls as `toupper(c, loc)`. `build_goto_trace.cpp` goes from 16 errors to 12 (the next wall there is the stream OM).

The standard defines these through `use_facet<ctype<charT>>(loc)`; the facet here is declared with no definition, so delegating would yield a nondet result and nothing assertable. They model the classic locale directly instead — the only one this header populates — and ignore the locale argument, which is stated in the header comment.

Stacked on #7204. Differential sweep over `esbmc-cpp/cpp`: 907 tests, the only diffs are the two tests added here. Refs #5868.