### PR TITLE
[om] Make vector's and set's size_type unsigned

### DIFF
--- a/regression/esbmc-cpp/cpp/container_size_type_unsigned/main.cpp
+++ b/regression/esbmc-cpp/cpp/container_size_type_unsigned/main.cpp
@@ -1,0 +1,29 @@
+#include <vector>
+#include <set>
+#include <type_traits>
+#include <cassert>
+
+int main()
+{
+  // [container.requirements]: size_type is an unsigned integer type.
+  static_assert(
+    std::is_unsigned<std::vector<int>::size_type>::value, "vector size_type");
+  static_assert(
+    std::is_unsigned<std::set<int>::size_type>::value, "set size_type");
+
+  // The observable consequence: size() - 1 on an empty container wraps.
+  std::vector<int> v;
+  assert(v.size() - 1 > 1000);
+
+  std::set<int> s;
+  assert(s.size() - 1 > 1000);
+
+  // Ordinary use is unchanged.
+  v.push_back(1);
+  v.push_back(2);
+  assert(v.size() == 2);
+  assert(v.size() - 1 == 1);
+  s.insert(3);
+  assert(s.size() == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/container_size_type_unsigned/test.desc
+++ b/regression/esbmc-cpp/cpp/container_size_type_unsigned/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/container_size_type_unsigned_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/container_size_type_unsigned_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<int> v;
+  // Wrong: the wrapped value is huge, not negative-ish small.
+  assert(v.size() - 1 < 1000);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/container_size_type_unsigned_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/container_size_type_unsigned_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/vector_count_value_ctor/main.cpp
+++ b/regression/esbmc-cpp/cpp/vector_count_value_ctor/main.cpp
@@ -1,0 +1,30 @@
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  // [sequence.reqmts]: with both arguments integral, the (count, value)
+  // constructor must win. The iterator-pair template must not participate.
+  std::vector<double> d(3, 0);
+  assert(d.size() == 3);
+  assert(d[0] == 0.0);
+
+  std::vector<long long> l(3, 7);
+  assert(l.size() == 3);
+  assert(l[2] == 7);
+
+  std::vector<unsigned> u(2, 5);
+  assert(u[1] == 5u);
+
+  // size_type is int here, so this one already worked -- keep it pinned.
+  std::vector<int> i(4, 9);
+  assert(i.size() == 4);
+  assert(i[3] == 9);
+
+  // The iterator-pair constructor must still be selected for real iterators.
+  int a[3] = {1, 2, 3};
+  std::vector<int> v(a, a + 3);
+  assert(v.size() == 3);
+  assert(v[2] == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vector_count_value_ctor/test.desc
+++ b/regression/esbmc-cpp/cpp/vector_count_value_ctor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/vector_count_value_ctor_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/vector_count_value_ctor_fail/main.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<double> d(3, 2);
+  assert(d[1] == 3.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vector_count_value_ctor_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/vector_count_value_ctor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -35,7 +35,7 @@ public:
   typedef Compare key_compare;
   typedef Compare value_compare;
 
-  typedef int size_type;
+  typedef size_t size_type;
   typedef int difference_type;
 
   class iterator
@@ -798,7 +798,7 @@ public:
   typedef Compare key_compare;
   typedef Compare value_compare;
 
-  typedef int size_type;
+  typedef size_t size_type;
   typedef int difference_type;
 
   class iterator

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -304,7 +304,7 @@ public:
   // types:
   typedef T &reference;
   typedef const T &const_reference;
-  typedef int size_type;
+  typedef size_t size_type;
   typedef int difference_type;
   typedef T value_type;
   typedef T *pointer;

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -9,6 +9,7 @@
 #include "OM_compiler_defs.h" // OM_NULLPTR
 
 #include <utility> /* std::move */
+#include "type_traits" /* enable_if, is_integral */
 #include <new>     /* placement-new */
 #if __cplusplus >= 201103L
 #  include <initializer_list>
@@ -380,8 +381,17 @@ public:
     _capacity = n;
   }
 
+  /* [sequence.reqmts]: this constructor must not participate in overload
+   * resolution unless InputIt qualifies as an input iterator. Unconstrained,
+   * vector<T> v(3, 0) deduced InputIt = int and instantiated *t++ on an int.
+   * Only vector<int> escaped, because size_type is int here and the
+   * (size_type, const T&) overload then tied and won as the non-template. */
   template <typename InputIt>
-  vector(InputIt t, InputIt addr, const Allocator &alloc = Allocator())
+  vector(
+    InputIt t,
+    InputIt addr,
+    const Allocator &alloc = Allocator(),
+    typename enable_if<!is_integral<InputIt>::value>::type * = OM_NULLPTR)
     : _size(0), _capacity(1)
   {
     int count = 0;


### PR DESCRIPTION
[container.requirements] says `size_type` is an unsigned integer type. `vector` and `set` typedef'd it to `int`, so `size() - 1` on an empty container went to `-1` instead of wrapping:

```cpp
std::vector<int> v;
assert(v.size() - 1 > 1000);   // holds under real C++; ESBMC said VERIFICATION FAILED
```

That is a false positive, and the same gap analyses any program relying on the wrap with the wrong semantics. `string` already used `size_t`; `list`, `deque` and `map` were unsigned — only these two were signed.

**Stacked on #7219, and it must not merge without it.** The two defects share a root cause: `size_type` being `int` is exactly what made `vector<int>(3, 0)` tie on conversions and select the correct overload, masking the unconstrained iterator-pair constructor. Removing the signedness removes that accidental protection — on master alone this change regresses `vector_emplace_back` and `github_7149_const_relational` to `PARSING ERROR`. With #7219's constraint in place, both stay green.

The decrementing loops in both headers already cast to `int` explicitly and `_size` carries an asserted `>= 0` invariant, so the flip is confined to the public return type. Tests pin the property twice — `static_assert(is_unsigned<...>)` on both `size_type`s and the observable wrap — plus `size() - 1 == 1` on a non-empty vector, so the fix cannot pass by making ordinary arithmetic wrong. Parses under `gnu++23`, `c++17`, `c++11`, `c++03`.

Differential sweep over `esbmc-cpp/cpp`: 905 tests, the only diffs are the four tests this stack adds. Refs #5868.