### PR TITLE
[solvers] Fix the simplifier equivalence check aborting in mk_eq

### DIFF
--- a/.github/workflows/simplifier-equivalence.yml
+++ b/.github/workflows/simplifier-equivalence.yml
@@ -4,7 +4,11 @@ name: Simplifier equivalence
 # of the CORE regression suite under it (esbmc/esbmc#4625). Every simplify()
 # rewrite is proved equivalent by an SMT solver; a rewrite that changes meaning
 # logs both expressions plus a witness and exits non-zero, so a failure here is
-# a simplifier soundness bug, not a verdict change.
+# a simplifier soundness bug, not a verdict change. A rewrite whose operand
+# sorts stop agreeing is reported the same way -- it would abort any backend's
+# mk_eq, so it is a defect whichever way it goes (esbmc/esbmc#7220). Shapes the
+# check cannot state are declined, and counted in the "N declined (M
+# ill-sorted)" line the run prints.
 #
 # The check is compiled out of every other build, so without this job the
 # enabled path is never built and would bit-rot. It runs on a schedule and on

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -673,17 +673,6 @@ void goto_checkt::shift_check(
   // get a signedness mismatch in the lessthan2tc below
   expr2tc left_op_type_size =
     constant_int2tc(right_op_type, BigInt(left_op_type->get_width()));
-#ifndef NDEBUG
-  // Be paranoid and verify that the size is the same regardless of which type we're using for the
-  // constant. In theory, we could have different signedness or width, but in practice
-  // those differences should not be relevant as the relevant numbers e.g. 32 or 64 can't
-  // cause wraparound issues.
-  expr2tc check2 = (equality2tc(
-    constant_int2tc(left_op_type, BigInt(left_op_type->get_width())),
-    constant_int2tc(right_op_type, BigInt(left_op_type->get_width()))));
-  simplify(check2);
-  assert(is_true(check2));
-#endif
 
   expr2tc right_op_size_check = lessthan2tc(right_op, left_op_type_size);
 

--- a/src/solvers/smt/simplification_equivalence.cpp
+++ b/src/solvers/smt/simplification_equivalence.cpp
@@ -41,6 +41,95 @@ bool has_unsupported_subexpr(const expr2tc &expr)
   return bad;
 }
 
+/** Width of the flat bitvector conversion builds for @p type, or 0 where it
+ *  builds no flat bitvector: bool, and the aggregates that meet through the
+ *  tuple/array flatteners instead. */
+unsigned bv_width(const type2tc &type)
+{
+  if (is_bv_type(type) || is_fixedbv_type(type) || is_floatbv_type(type))
+    return type->get_width();
+  return 0;
+}
+
+/** Will @p a and @p b convert to the same sort? Equal widths are not enough:
+ *  a float and a bitvector of the same width are different sorts, and only
+ *  a float pair takes convert_ast()'s fp.eq path. */
+bool sorts_match(const type2tc &a, const type2tc &b)
+{
+  return is_floatbv_type(a) == is_floatbv_type(b) && bv_width(a) == bv_width(b);
+}
+
+/** Node kinds whose two operands conversion requires to share a sort.
+ *
+ *  Shifts are deliberately absent: irep2 allows a shift count narrower than
+ *  the value, and convert_ast() casts it up (smt_solver.cpp, shl/ashr/lshr). */
+bool operands_must_share_sort(const expr2tc &expr)
+{
+  switch (expr->expr_id)
+  {
+  case expr2t::equality_id:
+  case expr2t::notequal_id:
+  case expr2t::lessthan_id:
+  case expr2t::lessthanequal_id:
+  case expr2t::greaterthan_id:
+  case expr2t::greaterthanequal_id:
+  case expr2t::add_id:
+  case expr2t::sub_id:
+  case expr2t::mul_id:
+  case expr2t::div_id:
+  case expr2t::modulus_id:
+  case expr2t::bitand_id:
+  case expr2t::bitor_id:
+  case expr2t::bitxor_id:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/** Would conversion of @p expr meet the operand-sort preconditions it asserts?
+ *
+ *  Every backend's mk_eq, mk_ite and their relational/arithmetic siblings open
+ *  with `assert(a->sort->get_data_width() == b->sort->get_data_width())`. An
+ *  assert is abort(), not a throw, so an ill-sorted term takes the process
+ *  down instead of the decline path in check() (esbmc/esbmc#7220).
+ *
+ *  This is a blacklist of the shapes known to assert, not a proof that what it
+ *  passes converts: a precondition not listed here still aborts. The source of
+ *  truth for the list is the assert cluster in each backend, bitwuzla_conv.cpp
+ *  being the readable one -- nothing links the two, so they drift. */
+bool sorts_agree(const expr2tc &expr)
+{
+  if (is_nil_expr(expr))
+    return true;
+
+  if (operands_must_share_sort(expr))
+  {
+    const expr2tc &side_1 = *expr->get_sub_expr(0);
+    const expr2tc &side_2 = *expr->get_sub_expr(1);
+    if (
+      is_nil_expr(side_1) || is_nil_expr(side_2) ||
+      !sorts_match(side_1->type, side_2->type))
+      return false;
+  }
+
+  // if2t cannot join the list above: its operands are (cond, true, false), so
+  // the pair mk_ite constrains is 1 and 2, not 0 and 1.
+  if (is_if2t(expr))
+  {
+    const if2t &branch = to_if2t(expr);
+    if (!sorts_match(branch.true_value->type, branch.false_value->type))
+      return false;
+  }
+
+  bool agree = true;
+  expr->foreach_operand([&agree](const expr2tc &e) {
+    if (agree)
+      agree = sorts_agree(e);
+  });
+  return agree;
+}
+
 /** "The simplifier preserved this value" as an SMT predicate.
  *
  *  For floats that is not `equality2t`: it lowers to `fp.eq`, under which
@@ -102,21 +191,45 @@ void collect_symbols(const expr2tc &e, std::set<expr2tc> &out)
 }
 } // namespace
 
+namespace
+{
+/** Counting lives here rather than in the installed callback so that a direct
+ *  caller -- the one-shot free function, the unit tests -- cannot move one
+ *  counter without the others and leave the report line self-contradictory. */
+simplification_equivalencet decline()
+{
+  ++simplification_check_stats::declined;
+  return simplification_equivalencet::skipped;
+}
+} // namespace
+
 simplification_equivalencet simplification_equivalence_checkert::check(
   const expr2tc &before,
   const expr2tc &after,
   std::string *witness)
 {
   if (is_nil_expr(before) || is_nil_expr(after))
-    return simplification_equivalencet::skipped;
+    return decline();
 
   // A rewrite that changes the type is not a value-preserving claim we can
   // state as an equality; the simplifier is not supposed to make them.
   if (before->type != after->type || !is_checkable_type(before->type))
-    return simplification_equivalencet::skipped;
+    return decline();
 
   if (has_unsupported_subexpr(before) || has_unsupported_subexpr(after))
-    return simplification_equivalencet::skipped;
+    return decline();
+
+  // An ill-sorted `before` predates the rewrite -- ESBMC built it that way and
+  // the normal pipeline never converts it in that form -- so it is a decline.
+  // Screening it first is what makes an ill-sorted `after` attributable: the
+  // rewrite introduced it, which is a defect whatever it did to the value.
+  if (!sorts_agree(before))
+  {
+    ++simplification_check_stats::ill_sorted;
+    return decline();
+  }
+  if (!sorts_agree(after))
+    return simplification_equivalencet::malformed;
 
   try
   {
@@ -151,21 +264,24 @@ simplification_equivalencet simplification_equivalence_checkert::check(
     switch (result)
     {
     case P_UNSATISFIABLE:
+      ++simplification_check_stats::proved;
       return simplification_equivalencet::equivalent;
     case P_SATISFIABLE:
       return simplification_equivalencet::differs;
     default:
       log_warning("simplifier equivalence check: solver gave no verdict");
-      return simplification_equivalencet::skipped;
+      return decline();
     }
   }
   catch (...)
   {
-    // Conversion rejects a shape by throwing; that is a decline, not a bug in
-    // the rewrite. The throw happened mid-frame, so the solver's state is no
-    // longer trustworthy -- drop it and let the next check build a fresh one.
+    // Conversion declines a shape by throwing (smt_casts.cpp); that is a
+    // decline, not a bug in the rewrite. It cannot report a violated
+    // precondition this way -- see sorts_agree(). The throw happened
+    // mid-frame, so the solver's state is no longer trustworthy: drop it and
+    // let the next check build a fresh one.
     ctx.reset();
-    return simplification_equivalencet::skipped;
+    return decline();
   }
 }
 
@@ -190,23 +306,18 @@ void install_simplification_equivalence_check(
   simplification_check::install(
     [checker](const expr2tc &before, const expr2tc &after) {
       std::string witness;
-      switch (checker->check(before, after, &witness))
-      {
-      case simplification_equivalencet::equivalent:
-        ++simplification_check_stats::proved;
+      const simplification_equivalencet verdict =
+        checker->check(before, after, &witness);
+      if (
+        verdict == simplification_equivalencet::equivalent ||
+        verdict == simplification_equivalencet::skipped)
         return;
-
-      case simplification_equivalencet::skipped:
-        ++simplification_check_stats::declined;
-        return;
-
-      case simplification_equivalencet::differs:
-        break;
-      }
 
       log_error(
-        "simplifier changed the meaning of an expression\n  before: {}\n  "
-        "after:  {}\n  where:  {}",
+        "{}\n  before: {}\n  after:  {}\n  where:  {}",
+        verdict == simplification_equivalencet::differs
+          ? "simplifier changed the meaning of an expression"
+          : "simplifier produced an expression whose operand sorts disagree",
         *before,
         *after,
         witness.empty() ? "(no free symbols)" : witness);
@@ -224,13 +335,18 @@ namespace simplification_check_stats
 {
 std::atomic<unsigned long> proved{0};
 std::atomic<unsigned long> declined{0};
+std::atomic<unsigned long> ill_sorted{0};
 
 void report()
 {
   const unsigned long p = proved.load();
   const unsigned long d = declined.load();
+  const unsigned long i = ill_sorted.load();
   if (p || d)
     log_status(
-      "simplifier equivalence check: {} rewrites proved, {} declined", p, d);
+      "simplifier equivalence check: {} rewrites proved, {} declined{}",
+      p,
+      d,
+      i ? fmt::format(" ({} ill-sorted)", i) : std::string());
 }
 } // namespace simplification_check_stats

--- a/src/solvers/smt/simplification_equivalence.cpp
+++ b/src/solvers/smt/simplification_equivalence.cpp
@@ -203,6 +203,27 @@ simplification_equivalencet decline()
 }
 } // namespace
 
+void simplification_equivalence_checkert::record_witness(
+  const expr2tc &before,
+  const expr2tc &after,
+  std::string &witness)
+{
+  std::set<expr2tc> symbols;
+  collect_symbols(before, symbols);
+  collect_symbols(after, symbols);
+
+  witness.clear();
+  for (const expr2tc &sym : symbols)
+  {
+    const expr2tc value = ctx->get(sym);
+    if (is_nil_expr(value))
+      continue;
+    if (!witness.empty())
+      witness += ", ";
+    witness += fmt::format("{} = {}", *sym, *value);
+  }
+}
+
 simplification_equivalencet simplification_equivalence_checkert::check(
   const expr2tc &before,
   const expr2tc &after,
@@ -242,22 +263,7 @@ simplification_equivalencet simplification_equivalence_checkert::check(
 
     // The model is only readable while the frame that produced it is live.
     if (result == P_SATISFIABLE && witness)
-    {
-      std::set<expr2tc> symbols;
-      collect_symbols(before, symbols);
-      collect_symbols(after, symbols);
-
-      witness->clear();
-      for (const expr2tc &sym : symbols)
-      {
-        const expr2tc value = ctx->get(sym);
-        if (is_nil_expr(value))
-          continue;
-        if (!witness->empty())
-          *witness += ", ";
-        *witness += fmt::format("{} = {}", *sym, *value);
-      }
-    }
+      record_witness(before, after, *witness);
 
     ctx->pop_ctx();
 

--- a/src/solvers/smt/simplification_equivalence.h
+++ b/src/solvers/smt/simplification_equivalence.h
@@ -15,6 +15,9 @@ enum class simplification_equivalencet
   equivalent,
   /** The solver found a valuation where they differ: a simplifier bug. */
   differs,
+  /** `after` has operands whose sorts disagree: also a simplifier bug, and one
+   *  that would abort any backend rather than yield a wrong answer. */
+  malformed,
   /** Not decided -- a shape the check declines, or a solver failure. */
   skipped
 };
@@ -31,7 +34,9 @@ class smt_convt;
  *  Free symbols stay free, so `equivalent` means equivalence under every
  *  valuation, not merely on some model. Declines (returns `skipped`) rather
  *  than guessing for shapes whose equality is not a plain SMT question --
- *  pointers, side effects, code, and anything the conversion rejects. */
+ *  pointers, side effects, code, and terms conversion cannot be asked to
+ *  build -- the last of which has to be screened up front, see sorts_agree()
+ *  in the implementation (esbmc/esbmc#7220). */
 class simplification_equivalence_checkert
 {
 public:
@@ -67,13 +72,17 @@ void install_simplification_equivalence_check(
   const namespacet &ns,
   const optionst &options);
 
-/** How much the installed checker actually decided. Without this a run that
- *  declined every rewrite is indistinguishable from one that proved them all,
- *  which is the failure mode that would make the whole check worthless. */
+/** How much check() actually decided, over every caller. Without this a run
+ *  that declined every rewrite is indistinguishable from one that proved them
+ *  all, which is the failure mode that would make the whole check worthless. */
 namespace simplification_check_stats
 {
 extern std::atomic<unsigned long> proved;
 extern std::atomic<unsigned long> declined;
+/** Of the declines, those whose `before` was already ill-sorted -- a defect
+ *  elsewhere in ESBMC rather than a limit of the check, so a nonzero count is
+ *  something to go and look at. */
+extern std::atomic<unsigned long> ill_sorted;
 
 void report();
 } // namespace simplification_check_stats

--- a/src/solvers/smt/simplification_equivalence.h
+++ b/src/solvers/smt/simplification_equivalence.h
@@ -53,6 +53,14 @@ public:
     std::string *witness = nullptr);
 
 private:
+  /** Format the live model's valuation of `before`/`after`'s free symbols into
+   *  @p witness. Only callable while the frame that produced the model is
+   *  still pushed. */
+  void record_witness(
+    const expr2tc &before,
+    const expr2tc &after,
+    std::string &witness);
+
   namespacet ns;
   optionst options;
   std::unique_ptr<smt_convt> ctx;

--- a/unit/solvers/simplification_equivalence.test.cpp
+++ b/unit/solvers/simplification_equivalence.test.cpp
@@ -10,6 +10,8 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
+#include <cstdio>
+#include <string>
 #include <irep2/irep2_utils.h>
 #include <solvers/smt/simplification_equivalence.h>
 #include <util/arith/arith_tools.h>
@@ -17,6 +19,7 @@
 #include <util/config/config.h>
 #include <util/config/options.h>
 #include <util/symtab/context.h>
+#include <util/message/message.h>
 #include <util/symtab/namespace.h>
 
 namespace
@@ -195,4 +198,192 @@ SCENARIO(
   // A declined shape resets the solver; the checker must keep working after.
   REQUIRE(checker.check(expr2tc(), x) == simplification_equivalencet::skipped);
   REQUIRE(checker.check(same, x) == simplification_equivalencet::equivalent);
+}
+
+SCENARIO(
+  "the checker screens operand sorts before converting",
+  "[solvers][simplifier]")
+{
+  // irep2 builds a relation without checking that its operands share a width
+  // (irep2_expr.h gives the relational constructors an empty body), but every
+  // backend's mk_eq asserts they do. An assert is abort(), so before #7220 the
+  // pairs below took the whole process down instead of reaching a verdict.
+  config.ansi_c.set_data_model(configt::LP64);
+  contextt ctx;
+  namespacet ns(ctx);
+  optionst options;
+
+  const expr2tc x = int_symbol("x");
+  const expr2tc zero32 = gen_zero(get_int32_type());
+  const expr2tc zero64 = gen_zero(get_int64_type());
+  const expr2tc mixed_width = equality2tc(x, zero64);
+  const expr2tc well_sorted = equality2tc(x, zero32);
+
+  GIVEN("an ill-sorted subterm in `before`")
+  {
+    THEN("it is declined and counted apart from the other declines")
+    {
+      const unsigned long seen = simplification_check_stats::ill_sorted.load();
+      REQUIRE(
+        check_simplification_equivalence(
+          mixed_width, gen_true_expr(), ns, options) ==
+        simplification_equivalencet::skipped);
+      REQUIRE(simplification_check_stats::ill_sorted.load() == seen + 1);
+    }
+    THEN("a bool compared against a 1-bit bitvector is declined too")
+    {
+      // bool and a 1-bit bitvector are distinct sorts however alike their bit
+      // counts look, so bool has to count as widthless rather than as 1.
+      const expr2tc bit = symbol2tc(unsignedbv_type2tc(1), "bit");
+      REQUIRE(
+        check_simplification_equivalence(
+          equality2tc(gen_true_expr(), bit), gen_true_expr(), ns, options) ==
+        simplification_equivalencet::skipped);
+    }
+  }
+
+  GIVEN("a well-sorted `before` rewritten into an ill-sorted `after`")
+  {
+    THEN("it reports malformed, not a decline")
+    {
+      REQUIRE(
+        check_simplification_equivalence(
+          well_sorted, mixed_width, ns, options) ==
+        simplification_equivalencet::malformed);
+    }
+  }
+
+  GIVEN("an if2t whose branches disagree")
+  {
+    // mk_ite asserts on the branch pair exactly as mk_eq does on its operands,
+    // and if2t's operands are (cond, true, false) -- so the screen has to look
+    // at 1 and 2, not at 0 and 1.
+    const expr2tc cond = symbol2tc(get_bool_type(), "c");
+    THEN("it is declined")
+    {
+      const expr2tc mixed = if2tc(get_int32_type(), cond, x, zero64);
+      REQUIRE(
+        check_simplification_equivalence(
+          equality2tc(mixed, x), gen_true_expr(), ns, options) ==
+        simplification_equivalencet::skipped);
+    }
+    THEN("matching branches are still decided")
+    {
+      const expr2tc same = if2tc(get_int32_type(), cond, x, x);
+      REQUIRE(
+        check_simplification_equivalence(same, x, ns, options) ==
+        simplification_equivalencet::equivalent);
+    }
+  }
+
+  GIVEN("a float compared against a bitvector of the same width")
+  {
+    // Equal widths, different sorts: only a float pair takes the fp.eq path,
+    // so the width assertion alone would let this through.
+    THEN("it is declined")
+    {
+      const expr2tc f = symbol2tc(float_type2(), "f");
+      REQUIRE(
+        check_simplification_equivalence(
+          equality2tc(f, x), gen_true_expr(), ns, options) ==
+        simplification_equivalencet::skipped);
+    }
+  }
+
+  GIVEN("a shift whose count is narrower than the value")
+  {
+    // irep2 allows this and convert_ast() casts the count up, so shifts must
+    // stay out of operands_must_share_sort -- declining them would quietly
+    // drop every narrow-count shift from the check's coverage.
+    THEN("it is decided, not declined")
+    {
+      const expr2tc shifted =
+        shl2tc(get_int32_type(), x, symbol2tc(get_uint8_type(), "n"));
+      REQUIRE(
+        check_simplification_equivalence(shifted, shifted, ns, options) ==
+        simplification_equivalencet::equivalent);
+    }
+  }
+
+  GIVEN("a well-sorted relation nested inside the pair")
+  {
+    // The screen must not decline what it can decide: x + 0 == x is true.
+    THEN("it is still decided by the solver")
+    {
+      const expr2tc before =
+        equality2tc(add2tc(get_int32_type(), x, zero32), x);
+      REQUIRE(
+        check_simplification_equivalence(
+          before, gen_true_expr(), ns, options) ==
+        simplification_equivalencet::equivalent);
+    }
+  }
+
+  GIVEN("a nil operand buried under a node the screen walks through")
+  {
+    // and2t/not2t are not in the shared-sort list, so the recursion descends
+    // into them -- and foreach_operand hands the delegate nil fields too.
+    THEN("the walk survives it and still declines on the ill-sorted sibling")
+    {
+      const unsigned long seen = simplification_check_stats::ill_sorted.load();
+      const expr2tc before = and2tc(not2tc(expr2tc()), mixed_width);
+      REQUIRE(
+        check_simplification_equivalence(
+          before, gen_true_expr(), ns, options) ==
+        simplification_equivalencet::skipped);
+      REQUIRE(simplification_check_stats::ill_sorted.load() == seen + 1);
+    }
+  }
+
+  GIVEN("a decline for a reason other than sorts")
+  {
+    // Negative control on the counter: without this, an increment moved to the
+    // generic skip path would go unnoticed and the signal would mean nothing.
+    THEN("the ill-sorted counter stays put")
+    {
+      const unsigned long seen = simplification_check_stats::ill_sorted.load();
+      const expr2tc p = symbol2tc(pointer_type2tc(get_int32_type()), "p");
+      REQUIRE(
+        check_simplification_equivalence(p, p, ns, options) ==
+        simplification_equivalencet::skipped);
+      REQUIRE(simplification_check_stats::ill_sorted.load() == seen);
+    }
+  }
+}
+
+SCENARIO(
+  "the equivalence check reports what it decided",
+  "[solvers][simplifier]")
+{
+  // The counter only earns its keep if the summary actually separates it from
+  // the other declines, so pin the rendered line rather than the call.
+  const unsigned long saved_proved = simplification_check_stats::proved.load();
+  const unsigned long saved_declined =
+    simplification_check_stats::declined.load();
+  const unsigned long saved_ill = simplification_check_stats::ill_sorted.load();
+
+  simplification_check_stats::proved = 7;
+  simplification_check_stats::declined = 5;
+  simplification_check_stats::ill_sorted = 3;
+
+  FILE *const saved_out = messaget::state.out;
+  FILE *const captured = tmpfile();
+  REQUIRE(captured != nullptr);
+  messaget::state.out = captured;
+  simplification_check_stats::report();
+  messaget::state.out = saved_out;
+
+  std::rewind(captured);
+  std::string text;
+  for (int c = std::fgetc(captured); c != EOF; c = std::fgetc(captured))
+    text += static_cast<char>(c);
+  std::fclose(captured);
+
+  simplification_check_stats::proved = saved_proved;
+  simplification_check_stats::declined = saved_declined;
+  simplification_check_stats::ill_sorted = saved_ill;
+
+  REQUIRE(
+    text.find("7 rewrites proved, 5 declined (3 ill-sorted)") !=
+    std::string::npos);
 }

--- a/unit/solvers/simplification_equivalence.test.cpp
+++ b/unit/solvers/simplification_equivalence.test.cpp
@@ -389,8 +389,9 @@ SCENARIO(
 
   std::rewind(captured);
   std::string text;
-  for (int c = std::fgetc(captured); c != EOF; c = std::fgetc(captured))
-    text += static_cast<char>(c);
+  char buf[256];
+  for (size_t n; (n = std::fread(buf, 1, sizeof(buf), captured)) > 0;)
+    text.append(buf, n);
   std::fclose(captured);
 
   simplification_check_stats::proved = saved_proved;

--- a/unit/solvers/simplification_equivalence.test.cpp
+++ b/unit/solvers/simplification_equivalence.test.cpp
@@ -253,6 +253,20 @@ SCENARIO(
     }
   }
 
+  GIVEN("a mismatch under a node other than a relation")
+  {
+    // operands_must_share_sort collapses twelve kinds onto one arm; drive an
+    // arithmetic/bitwise one too, so narrowing the list cannot pass unnoticed.
+    THEN("it is declined")
+    {
+      const expr2tc masked = bitand2tc(get_int32_type(), x, zero64);
+      REQUIRE(
+        check_simplification_equivalence(
+          equality2tc(masked, x), gen_true_expr(), ns, options) ==
+        simplification_equivalencet::skipped);
+    }
+  }
+
   GIVEN("an if2t whose branches disagree")
   {
     // mk_ite asserts on the branch pair exactly as mk_eq does on its operands,


### PR DESCRIPTION
goto_check's shift UB check folded an equality2t across two differently-typed
constants through simplify() -- the hook the equivalence checker installs on --
and no backend's mk_eq accepts mismatched operand widths. Remove it, and screen
operand sorts up front so a future one declines instead of aborting.

Fixes #7220