### PR TITLE
[docs] Link the VS Code, web and Claude Code integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ This installs `esbmc` together with its bundled SMT solvers (Z3, Bitwuzla).
 
 You can also download the latest ESBMC binary for Ubuntu and Windows from the [releases page](https://github.com/esbmc/esbmc/releases).
 
+## Editor and tool integration
+
+Three companion front-ends run ESBMC outside the terminal:
+
+- **Visual Studio Code** — the [ESBMC extension](https://github.com/esbmc/vscode-esbmc) verifies the file you are editing and reports results in the integrated terminal.
+- **Web interface** — [ESBMC-Web](https://github.com/esbmc/esbmc-web) is a self-hosted browser GUI for C, C++ and Python, with a flag picker and an interactive dashboard for violations and counterexamples.
+- **Claude Code** — the [ESBMC plugin](https://github.com/esbmc/agent-marketplace) provides `/verify` and `/audit` commands, a verification skill, reference documentation, and examples.
+
+See [Editor and tool integration](https://esbmc.github.io/docs/integrations) for details, and the [GitHub Action](https://esbmc.github.io/docs/github-action) to run ESBMC in CI.
+
 ## Building ESBMC
 
 See the [building instructions](https://esbmc.github.io/docs/development/building) document.
@@ -316,10 +326,6 @@ ESBMC is open-source software mainly distributed under the Apache License 2.0. I
 We'd be extremely happy to receive contributions to improve ESBMC (under the terms of the Apache License 2.0). Please file a pull request against the public GitHub repo if you'd like to submit anything. General discussion and release announcements will be made via GitHub. Please post an issue on GitHub and contact us about research or collaboration.
 
 Please review the [developer documentation](https://esbmc.github.io/blob/master/CONTRIBUTIONS.md) if you want to contribute to ESBMC.
-
-## Claude Code Plugin
-
-A [Claude Code](https://docs.anthropic.com/claude-code) plugin for ESBMC is available at [esbmc/agent-marketplace](https://github.com/esbmc/agent-marketplace). It provides `/verify` and `/audit` commands, a verification skill, reference documentation, and examples for using ESBMC within Claude Code.
 
 ## Differences from CBMC
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -17,6 +17,7 @@ requests landed in early August — Python function contracts, a user-facing
 {{< card link="https://github.com/esbmc/esbmc/releases/latest" title="Latest Release" icon="github" >}}
 {{< card link="https://github.com/esbmc/esbmc-web" title="Web Interface" icon="external-link" >}}
 {{< card link="https://github.com/esbmc/vscode-esbmc" title="VSCode Extension" icon="external-link" >}}
+{{< card link="https://github.com/esbmc/agent-marketplace" title="Claude Code Plugin" icon="external-link" >}}
 {{< card link="https://esbmc.github.io/esbmc-ai" title="ESBMC-AI" icon="external-link" >}}
 {{< /cards >}}
 

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -37,6 +37,7 @@ thread interleavings. Each reported violation is annotated with its matching
 {{< card link="/docs/function-contracts" title="Function Contracts" >}}
 {{< card link="/docs/loop-invariants" title="Loop Invariants" >}}
 {{< card link="/docs/coverage" title="Coverage" >}}
+{{< card link="/docs/integrations" title="Editor Integration" >}}
 {{< card link="/docs/c-cpp" title="C / C++" >}}
 {{< card link="/docs/python" title="Python" >}}
 {{< card link="/docs/ld" title="Ladder Diagram" >}}

--- a/website/content/docs/integrations.md
+++ b/website/content/docs/integrations.md
@@ -1,0 +1,64 @@
+---
+title: Editor and Tool Integration
+weight: 16
+---
+
+Besides the command line, ESBMC has three interactive front-ends — an editor
+extension, a browser GUI and a plugin for an AI coding agent. All three drive
+the same `esbmc` binary, so everything under [Usage](/docs/usage) applies to
+them too. For verification in CI rather than at the keyboard, see
+[GitHub Action](/docs/github-action).
+
+{{< cards >}}
+{{< card link="https://github.com/esbmc/vscode-esbmc" title="VS Code Extension" icon="external-link" >}}
+{{< card link="https://github.com/esbmc/esbmc-web" title="Web Interface" icon="external-link" >}}
+{{< card link="https://github.com/esbmc/agent-marketplace" title="Claude Code Plugin" icon="external-link" >}}
+{{< /cards >}}
+
+## Visual Studio Code
+
+[vscode-esbmc](https://github.com/esbmc/vscode-esbmc) verifies the file you are
+editing without leaving the editor. It contributes four command-palette entries:
+
+- `ESBMC: Verify file` — run ESBMC on the active C, C++, Python, Solidity or
+  Jimple file and stream the output to the integrated terminal;
+- `ESBMC: Verify file with Local AI` — run ESBMC on the current file and, when
+  a property fails, ask a local [Ollama](https://ollama.com) model to explain
+  the counterexample in a separate output channel. It ignores the `esbmc.*`
+  settings and needs Ollama serving `llama3.1:8b`;
+- `ESBMC: Install latest version` and `ESBMC: Update to latest version` —
+  download and unpack the latest release into `$HOME/bin`, so you do not need
+  ESBMC on your `PATH` beforehand.
+
+It requires VS Code 1.68 or later. The install and update commands are Linux
+only; elsewhere, install ESBMC first via [Setup](/docs/setup).
+
+The extension is not on the VS Code Marketplace yet, so build the `.vsix` from
+source and install it from the Extensions view — the repository README has the
+walkthrough. Sideloading this way does not pull in the extension's dependency
+on `mindaro-dev.file-downloader`, which the install and update commands need.
+Publishing to the Marketplace and Open VSX is tracked in
+[vscode-esbmc#15](https://github.com/esbmc/vscode-esbmc/issues/15).
+
+## Web interface
+
+[ESBMC-Web](https://github.com/esbmc/esbmc-web) is a browser GUI for C, C++ and
+Python. You write or upload a file — plus any dependency headers or modules —
+pick the checks and solver from a form rather than remembering flag names, and
+read the result either as the raw ESBMC log or as a dashboard that tabulates
+each violation with its file, function and line and shows the counterexample.
+
+It is self-hosted rather than a public service. A Flask backend shells out to
+your local `esbmc` and exposes its API on `http://127.0.0.1:5000`; the frontend
+is a static page you open from disk at `frontend/index.html`. The repository
+documents a WSL path for Windows and a manual install for Linux and macOS.
+
+## Claude Code
+
+The [ESBMC plugin](https://github.com/esbmc/agent-marketplace) brings ESBMC into
+[Claude Code](https://docs.anthropic.com/claude-code) for C, C++, Python,
+Solidity and Java/Kotlin. It provides a `/verify` command for a quick check of a
+source file, an `/audit` command that runs several verification passes for a
+security review, and a skill that triggers automatically when a conversation
+turns to verifying code — together with reference documentation, examples and
+utility scripts.


### PR DESCRIPTION
Adds an "Editor and tool integration" section to the README and a matching docs
page on esbmc.org covering vscode-esbmc, esbmc-web and the Claude Code plugin.
The former standalone "Claude Code Plugin" README section is folded into it.

The Marketplace listing and install badge are deferred until esbmc/vscode-esbmc#15
lands; the page links the repo and that issue in the meantime.

Fixes #7237