### PR TITLE
[docs] Sync the website with user-facing changes since #6983

### DIFF
--- a/website/content/docs/c-cpp/supported-features.md
+++ b/website/content/docs/c-cpp/supported-features.md
@@ -223,6 +223,8 @@ Other exception behaviour:
 | Feature | Standard |
 | --- | --- |
 | Structured bindings, including binding by reference and over `std::tuple` | C++17 |
+| `if` and `switch` init-statements | C++17 |
+| Class template argument deduction for an aggregate | C++20 |
 | Three-way comparison `<=>`, including pointer, floating-point and side-effecting operands | C++20 |
 | A defaulted friend `operator<=>` / `operator==`, with both operands bound | C++20 |
 | Parenthesized aggregate initialization | C++20 |
@@ -241,53 +243,63 @@ by regression tests under `regression/esbmc-cpp*`.
 | Header | Notes |
 | --- | --- |
 | `<vector>` | Including `data()`, `emplace_back`, `shrink_to_fit`, `cbegin`/`cend`; the destructor frees its buffer. Elements are constructed into the raw buffer, so a vector of a non-trivial element type works |
-| `<list>` | Const `front`/`back`/`rbegin`/`rend`, `cbegin`/`cend` |
-| `<deque>` | Const iteration |
-| `<map>` | Const `at`, `emplace`, `try_emplace`, `insert_or_assign`, C++20 `contains` |
+| `<list>`, `<forward_list>` | Const `front`/`back`/`rbegin`/`rend`, `cbegin`/`cend`; `emplace`, `emplace_back`, `emplace_front`; `reverse_iterator::base()`; the iterator carries its `iterator_traits` typedefs. Both may hold an incomplete element type, so a node that points back at its own container compiles |
+| `<deque>` | Const iteration; lexicographic `<`/`<=`/`>`/`>=` with const-qualified comparators |
+| `<map>` | Const `at`, `emplace`, `try_emplace`, `insert_or_assign`, C++20 `contains`; const `find`/`count`/`lower_bound`/`upper_bound`/`equal_range`. Const iterators compare by position rather than by a cached pair, so two iterators into equal-keyed entries stay distinct. `mapped_type` may be incomplete |
 | `<set>` | Const-correct const iterators, `emplace`, C++20 `contains` |
-| `<unordered_map>`, `<unordered_set>` | |
+| `<unordered_map>`, `<unordered_set>` | `<unordered_set>` provides `std::unordered_multiset` too |
 | `<array>` | `iterator` / `const_iterator` typedefs; usable in C++11 |
 | `<queue>`, `<stack>`, `<bitset>` | Includes `std::priority_queue` |
-| `<iterator>` | `iterator_traits` and the iterator tags; `advance`, `distance`, `next`, `prev`; the range accessors including the reverse forms `rbegin` / `rend` / `crbegin` / `crend` |
+| `<iterator>` | `iterator_traits` and the iterator tags; `advance`, `distance`, `next`, `prev` — stepped one element at a time for an iterator that is not random-access, instead of requiring `+=`; the range accessors including the reverse forms `rbegin` / `rend` / `crbegin` / `crend` and the free `size` / `empty` / `data` |
 | `<valarray>` | |
 
 `std::multimap` and `std::multiset` track `std::map` and `std::set`, including
 `contains` and `cbegin`/`cend`.
 
+The ordered and unordered containers take their `Allocator` template
+parameter, so a container spelled with an explicit allocator names the same
+type it does in a host build. `size_type` is unsigned, iterator dereference is
+const-qualified, and `vector`'s iterator-pair constructor is constrained so it
+does not hijack `vector<int>(3, 0)`.
+
 ### Strings and streams
 
 | Header | Notes |
 | --- | --- |
-| `<string>` | `(const char*, size_t)` range and fill constructors; length-aware `operator<`/`operator>`/`operator<=`/`operator>=` including free overloads against `const char*`; `const` `substr(pos, n)`; C++20 `starts_with`/`ends_with`; `at` throws `std::out_of_range`; the full `sto*` family (`stoi`, `stol`, `stoll`, `stoul`, `stoull`, `stof`, `stod`, `stold`) |
-| `<string_view>` | Search members, `string` → `string_view` conversion, `hash<string_view>` |
+| `<string>` | `(const char*, size_t)` range and fill constructors; length-aware `operator<`/`operator>`/`operator<=`/`operator>=` including free overloads against `const char*`; `const` `substr(pos, n)`; C++20 `starts_with`/`ends_with`; `at` throws `std::out_of_range`; `clear`, `find_last_not_of`; the full `sto*` family (`stoi`, `stol`, `stoll`, `stoul`, `stoull`, `stof`, `stod`, `stold`). The iterators carry their `iterator_traits` typedefs, `compare` takes its argument by const reference, and `operator+` accepts a `const CharT*`. `size`, `resize`, `max_size` and `rfind` agree with the standard, and the constructor and comparison loops run to a concrete trip count so they converge under a bound |
+| `<string_view>` | An instantiation of `basic_string_view`, so `wstring_view` and friends name the same template. Search members, `string` → `string_view` conversion, `hash<string_view>` |
 | `<iostream>`, `<istream>`, `<ostream>`, `<ios>`, `<iosfwd>` | Standard stream objects, `ios::widen`/`narrow`, `ios::exceptions`, `ios::copyfmt` |
-| `<sstream>`, `<fstream>`, `<streambuf>`, `<iomanip>` | `ostringstream` accumulates into the buffer its `str()` reports |
+| `<sstream>`, `<fstream>`, `<streambuf>`, `<iomanip>` | `ostringstream` accumulates into the buffer its `str()` reports; the string streams are templated on their character type and `streambuf` is an instantiation of `basic_streambuf`; `operator<<` is modelled for the built-in types; `<iomanip>` has `std::put_time` |
 | `<locale>` | |
+
+`char_traits` is reachable without including `<string>`, its single-return
+members are `constexpr`, and `char_traits<char>` compares as `unsigned char`
+([char.traits.specializations.char] p2).
 
 ### Utilities and type support
 
 | Header | Notes |
 | --- | --- |
-| `<type_traits>` | Classification traits and the `_t` / `_v` forms, including `is_trivial`, `is_standard_layout`, `is_aggregate`, `is_assignable` and the copy/move/destructible variants, `remove_cvref`, `aligned_storage`, `invoke_result`, and the logical traits `conjunction` / `disjunction` / `negation` |
+| `<type_traits>` | Classification traits and the `_t` / `_v` forms, including `is_trivial`, `is_standard_layout`, `is_aggregate`, `is_assignable` and the copy/move/destructible variants, `remove_cvref`, `aligned_storage`, `invoke_result`, and the logical traits `conjunction` / `disjunction` / `negation`. Also `is_object`, `is_scalar`, `is_compound`, `is_fundamental`, `rank`, `add_cv`, `add_volatile`, `has_virtual_destructor`, `is_member_object_pointer`, `is_member_function_pointer`, `is_default_constructible`, `is_move_constructible` / `is_move_assignable`, and the `is_nothrow_*` and `is_trivially_*_constructible` families. `is_convertible` is defined by copy-initialization rather than `static_cast`, so an explicit constructor no longer makes it `true` ([meta.rel]) |
 | `<utility>` | Including `index_sequence_for` and C++23 `std::unreachable` |
-| `<functional>`, `<memory>`, `<initializer_list>` | `<functional>` has the transparent operation functors (`plus<>`, `less<>`, …); `<memory>` has `std::allocate_shared` and a correct default-constructed `unique_ptr` |
-| `<tuple>` | `std::tie`, `std::ignore`, structured binding over a tuple |
-| `<optional>` | `emplace`, `swap`, `std::make_optional` |
+| `<functional>`, `<memory>`, `<initializer_list>` | `<functional>` has the transparent operation functors (`plus<>`, `less<>`, …), `std::reference_wrapper` with `ref`/`cref` and its call operator, `std::placeholders`, and a `std::function` whose call target is templated on its signature; `<memory>` has `std::allocate_shared`, a correct default-constructed `unique_ptr`, the `uninitialized_copy` / `uninitialized_fill` family, and an `allocator_traits` that works with a minimal allocator — `rebind_alloc`, the nothrow copy traits, and `construct`/`destroy` templated on the pointee |
+| `<tuple>` | `std::tie`, `std::ignore`, structured binding over a tuple, `tuple_size_v` |
+| `<optional>` | `emplace`, `swap`, `std::make_optional`; comparison and ordering against a bare value as well as another `optional` |
 | `<variant>`, `<any>` | `std::visit` calls the visitor on the currently held alternative; the converting constructor does not hijack copies |
 | `<expected>` | C++23 |
 | `<compare>` | Includable before C++20 |
 | `<source_location>`, `<span>`, `<bit>` | C++20 |
 | `<typeinfo>`, `<exception>`, `<stdexcept>`, `<system_error>`, `<new>` | |
 | `<limits>` | Works under `--std c++11` and `c++14` |
-| `<filesystem>` | |
+| `<filesystem>` | `filesystem::u8path`, `path::u8string`, `path::generic_string`; `std::error_code` is visible through the header |
 
 ### Algorithms and numerics
 
 | Header | Notes |
 | --- | --- |
-| `<algorithm>` | Including the C++11 algorithms |
+| `<algorithm>` | Including the C++11 algorithms and `move_backward` |
 | `<numeric>` | `iota`, `gcd`, `lcm`, `reduce` |
-| `<cmath>` | The floating-point classifiers `std::isnan`, `std::isinf`, `std::isfinite`, `std::isnormal` and `std::signbit` are re-declared as `std::` overloads lowered to ESBMC's native FP intrinsics |
+| `<cmath>` | The floating-point classifiers `std::isnan`, `std::isinf`, `std::isfinite`, `std::isnormal` and `std::signbit` are re-declared as `std::` overloads lowered to ESBMC's native FP intrinsics. `fmod`, `remainder` and `remquo` lower to the solver's exact FP remainder rather than being computed as `x - y*(int)(x/y)`, which double-rounded and overflowed the cast for a large quotient |
 | `<complex>`, `<random>` | |
 
 ### Time

--- a/website/content/docs/function-contracts.md
+++ b/website/content/docs/function-contracts.md
@@ -92,6 +92,16 @@ __ESBMC_ensures(counter == __ESBMC_old(counter) + 1);
 `__ESBMC_old` works on any expression: a global variable, a field of a struct,
 or a value reachable through a pointer.
 
+It also works under a quantifier, as `__ESBMC_old(r->coeffs[j])` inside an
+`__ESBMC_forall` over `j`. A quantified index cannot be snapshotted one element
+at a time — the snapshot is taken once, before the body runs, while `j` still
+ranges — so the whole region is copied at entry and indexed afterwards. That
+needs a named object to copy: an array wrapped in a struct, or an array named
+directly, both work. A bare `int r[N]` parameter (which is a pointer, with its
+extent stated only in an `__ESBMC_is_fresh` clause the rewrite never sees) and
+an `int (*r)[N]` parameter are declined, and say so
+([#7057](https://github.com/esbmc/esbmc/issues/7057)).
+
 ## What a function may modify: `__ESBMC_assigns`
 
 Consider a function that is supposed to update one global and leave another
@@ -130,6 +140,8 @@ stronger guarantees.
 | `__ESBMC_assigns(p->field)`                 | A field via pointer                |
 | `__ESBMC_assigns(*p)`                       | Whatever a pointer points to       |
 | `__ESBMC_assigns(arr[i])`                   | A single array element             |
+| `__ESBMC_assigns(arr)`                      | Every element of the array         |
+| `__ESBMC_assigns(p->sub->field)`            | A path through more than one pointer, rooted at a parameter |
 | `__ESBMC_assigns(x, y, z)`                  | Multiple targets (up to 5)         |
 | `__ESBMC_assigns()` or `__ESBMC_assigns(0)` | Nothing — declares a pure function |
 
@@ -384,8 +396,13 @@ esbmc file.c --enforce-contract find_min --function find_min --z3
 allocated block of at least `size` bytes that does not alias any existing
 memory.
 
-In `requires`: the caller must provide a freshly allocated pointer. In
+In `requires`: the caller must provide a pointer to a block of its own. In
 `ensures`: the function promises to return a freshly allocated block.
+
+"Fresh" is about separation and extent, not about the heap: a caller can
+discharge a `requires`-side `__ESBMC_is_fresh(p, n)` by passing the address of
+an object with automatic storage, as long as that object really is disjoint
+from the other arguments and really does extend `n` bytes.
 
 Because a fresh block aliases nothing, a `requires`-side `__ESBMC_is_fresh` is
 also how a contract states that a pointer parameter is separate from the
@@ -572,7 +589,7 @@ $ esbmc counter.py --enforce-contract add
 $ esbmc counter.py --enforce-contract "py:counter.py@C@Counter@F@add"
 ```
 
-### No `__ESBMC_old` for parameters
+### `__ESBMC_old` over scalars
 
 Python passes scalars by value, so a parameter named in `ensures` already
 denotes its value at entry, even when the body reassigns it:
@@ -585,9 +602,31 @@ def bump(x: int) -> int:
     return x
 ```
 
-`__ESBMC_old` is therefore unnecessary for parameters, and is not yet supported
-in Python. It remains necessary in C, and will be needed in Python once
-contracts reach mutable state.
+`__ESBMC_old` is therefore unnecessary for a parameter, but it is available, and
+it is what a clause over a *global* needs — a global does change under the body:
+
+```python
+count: int = 0
+
+def bump(k: int) -> int:
+    global count
+    __ESBMC_requires(k > 0)
+    __ESBMC_ensures(count == __ESBMC_old(count) + k)
+    count = count + k
+    return count
+```
+
+It works under both `--enforce-contract` and `--replace-call-with-contract`, and
+snapshots `int`, `float` and `bool`. Anything else is named and refused rather
+than snapshotted as something it is not:
+
+```
+ERROR: __ESBMC_old at line 3 takes 'l', which is not an int, float or bool;
+       only scalars can be snapshotted by the Python frontend yet
+```
+
+`__ESBMC_old` in a `requires` is likewise rejected — a precondition already
+speaks about the pre-state.
 
 ### A clause must be a pure expression
 
@@ -637,7 +676,7 @@ determined.
 | `list`, `str`, class instances, unannotated parameters | supported when the clause does not mention them |
 | methods | supported |
 | globals in a clause | supported |
-| `__ESBMC_old` | not supported, and not needed for parameters (above) |
+| `__ESBMC_old` | supported over `int`, `float` and `bool`, in `ensures` only; not needed for parameters (above) |
 | `__ESBMC_assigns` | not supported |
 | `__ESBMC_is_fresh` | not supported |
 | `__ESBMC_forall` / `__ESBMC_exists` | not supported |
@@ -710,14 +749,24 @@ is honoured when enforcing — the lvalue gets its own allocation — but
 replacement keys the separation obligation on a parameter position and emits
 nothing for these forms.
 
-**Global array element assigns is unsupported.** `__ESBMC_assigns(global[i])`
-does not work correctly for global arrays. Use `__ESBMC_assigns(global)` (the
-whole array) as a conservative alternative.
+**A two-dimensional global past the element-wise cap keeps the whole-array
+check.** `__ESBMC_assigns(global[i])` is checked element-wise up to a cap on the
+array's extent. Past the cap ESBMC falls back to asserting the whole array
+unchanged, which the write the clause itself names then falsifies — so a large
+`int m[300][4]` with `__ESBMC_assigns(m[i])` reports a spurious frame violation.
+The element-wise form cannot be used there because reading an array-typed
+element back out of the snapshot is the same gap that stops `__ESBMC_old` over
+an array ([#7057](https://github.com/esbmc/esbmc/issues/7057)). Below the cap,
+and for one-dimensional globals, the element-wise check applies.
 
-**Multi-level pointer assigns is unsupported.** `__ESBMC_assigns(*p)` and
-`__ESBMC_assigns(p->field)` work for a single level of indirection. Patterns
-like `__ESBMC_assigns(p->sub->field)` are not classified and violations on the
-untracked sub-fields will not be caught.
+**A multi-level assigns path must be rooted at a parameter, and does not reach
+past it.** `__ESBMC_assigns(o->sub->a)` is classified when `o` is a pointer
+parameter: the check then holds every other field of `*o` unchanged, so a write
+to `o->x` is caught. It does not extend through the inner pointer — a write to
+`o->sub->b` is not reported, and a body that reassigns `o->sub` itself verifies
+— because the pointee of `o->sub` is not a parameter and has nothing to root a
+snapshot at. A path rooted at a *global* pointer (`__ESBMC_assigns(g->sub->a)`)
+still generates no verification conditions at all.
 
 **Quantifiers require Z3.** `__ESBMC_forall` and `__ESBMC_exists` are not
 supported by Boolector or other backends. Pass `--z3` when using quantified

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -10,7 +10,7 @@ weight: 4
 - `for` loops support direct iteration over `range()`, lists, strings (including the result of a `str(...)` call, e.g. `for digit in str(n)`), tuples, and generators (functions using `yield` and generator expressions).
 - `for ... else` and `while ... else` are supported: the `else` clause is lowered into a did-not-break flag, so it runs only when the loop completes without `break` (a `break` inside a nested loop stays bound to that inner loop).
 - List, set, dictionary, and generator comprehensions are supported. Dictionary comprehensions populate a real dict (see [Supported Features — Dictionaries](./supported-features#dictionaries)); the iterable must be a `range(...)`, a list of tuples, or a `d.items()` view (with an optional `if` filter). Comprehensions over other iterables (e.g. another dict comprehension or an arbitrary generator) may not be handled.
-- Iteration over dictionaries via `d.keys()`, `d.values()`, and `d.items()` is supported inside `for` loops (see [Supported Features — Dictionaries](./supported-features#dictionaries)). The destructuring form `for u, v in d:` over a dict with tuple keys works for **local dict literals** and for **unannotated parameter dicts** with scalar or integer-tuple keys (recovered from the call sites). String-tuple-keyed parameter dicts are still not handled ([#5571](https://github.com/esbmc/esbmc/issues/5571)).
+- Iteration over dictionaries via `d.keys()`, `d.values()`, and `d.items()` is supported inside `for` loops (see [Supported Features — Dictionaries](./supported-features#dictionaries)). The destructuring form `for u, v in d:` over a dict with tuple keys works for **local dict literals** and for **unannotated parameter dicts** with scalar or integer-tuple keys (recovered from the call sites); so do the deferred form `for edge in d:` followed by `u, v = edge`, and iteration over `sorted(d)`. Passing a custom `key=` to `sorted` disables that path, and string-tuple-keyed parameter dicts are still not handled ([#5571](https://github.com/esbmc/esbmc/issues/5571)).
 
 ## Lists
 
@@ -61,6 +61,17 @@ weight: 4
 - Most `str.*()` methods now degrade to a sound nondeterministic over-approximation when the receiver is not a compile-time constant (see [Supported Features — Strings](./supported-features#strings)). A growing set have precise runtime operational models: the case transforms `swapcase`, `upper`, `lower`, `capitalize`, `title` (which cap the receiver at ~255 characters, asserting on longer input — `upper` truncates instead); the predicates `isupper`, `islower`, `isalpha`, `isdigit`, `isalnum`, `isspace`; `count`; and `find`/`rfind`. `str.join` likewise has a precise model (bounded to a 511-character result) when its iterable is a variable whose initialiser cannot be folded (e.g. a `List[str]` parameter), but falls back to a nondet `char *` when the iterable is a non-foldable expression such as `sorted(...)`, a comprehension, or a function-call result. Other methods (`casefold`, `isnumeric`, `isidentifier`, `removeprefix`, `removesuffix`, `center`, `ljust`, `rjust`, `zfill`, `expandtabs`, `partition`, `format`, `format_map`, `splitlines`, etc.) return a nondet value of the appropriate shape, so assertions on their specific functional result will report `VERIFICATION FAILED` on symbolic input.
 - `partition()` on a non-constant receiver returns `("", "", "")` — the same shape Python uses when the separator is not found.
 - `splitlines()` on a non-constant receiver returns an empty list.
+
+## Dynamic Typing
+
+A variable whose type diverges across an `if`/`else` is carried as a tagged
+value (see [Supported Features — Dynamic Typing](./supported-features#dynamic-typing)),
+within these bounds:
+
+- A tag holds one of `bool`, `int`, `float` or `str`. `isinstance` against an aggregate or a user class is therefore answered `False`, not consulted.
+- Arithmetic (`+`, `-`, `*`, `/`) is supported against a **literal** operand; `+` additionally concatenates strings.
+- `x is None` is folded only against a literal `None`. A computed operand is not folded, since that would drop its side effects.
+- Rebinding a tagged variable to a list, tuple or class instance is refused inside a loop or a conditional body, where the join of the retyped aliases is not modelled.
 
 ## Union and Any Types
 
@@ -118,13 +129,15 @@ weight: 4
 - Element-wise `np.add`/`np.subtract`/`np.multiply`/`np.divide`/`np.power` support literal list-backed 1D/2D inputs with NumPy-style broadcasting. Runtime-constructed inputs and higher-dimensional inputs are rejected with deterministic frontend errors rather than falling through to the SMT backend.
 - Only the NumPy functions listed in [Supported Features — NumPy](./supported-features#numpy-module-numpy) have executable support.
 - The reductions (`sum`/`prod`/`min`/`max`/`mean`/`argmin`/`argmax`), comparison/logical ufuncs (`greater`/`less`/`equal`/`logical_*`/`where`), and constructors (`arange`/`full`/`eye`/`identity`/`linspace`) are constant-folded over list-backed (1D/2D) inputs and constant shapes; runtime-constructed inputs and higher-rank shapes are rejected with deterministic frontend errors.
+- `np.arange()` materialises its result at conversion time, so its arguments must be constant — a name bound to a literal is resolved first, but a function parameter is rejected with `TypeError: numpy.arange() currently supports constant numeric inputs only` rather than routed through the operational model's while loop, which did not terminate in practice. A range past 10000 elements is declined for the same reason, and `step=0` raises `ValueError`.
+- Only a 1-D, unit-stride slice with literal bounds, assigned to a bare name, becomes a real view onto the base array. A symbolic bound, a non-unit stride, or a higher-rank slice still produces an independent copy, so a write through one is not observed by the other.
 - `np.arccos`, `np.fmod`, `np.transpose`, `np.dot`, and `np.matmul` now lower to executable models (they were previously type-inference-only stubs), each under a stated restriction: `np.arccos` rejects runtime 2D arrays; `np.fmod` rejects `np.array(...)`-wrapped operands (`Unsupported operation: numpy.fmod on array operands`); `np.transpose` is limited to 2D and rejects higher rank; `np.dot`/`np.matmul` cover 1D/2D integer and float inputs.
 - `numpy.linalg.det` supports constant numeric 2x2 and 3x3 matrices. Other `numpy.linalg` operations, complex determinants, runtime-constructed matrices, and larger matrix sizes are not supported.
 
 ## Exception Handling
 
 - Core built-in exception types are supported, but not all Python standard library exceptions; custom exception hierarchies with complex inheritance patterns may not be fully handled.
-- `try`/`finally` is supported (including bare `try`/`finally`), but two shapes are refused at parse time rather than lowered unsoundly: a non-empty `else` clause on the `try` (a pre-existing gap — `orelse` is silently dropped today), and a `return`/`break`/`continue` that escapes the `try`, an `except` handler, or the `finally` body (it would bypass the appended `finally`).
+- `try`/`finally` is supported (including bare `try`/`finally`), and a `return`/`break`/`continue` escaping the `try`, a handler, or the `finally` runs the `finally` first. Three shapes are still refused at parse time rather than lowered unsoundly: a non-empty `else` clause on the `try` (a pre-existing gap — `orelse` is silently dropped today), a `finally` that itself escapes, and an escape nested under another `try` or `with`, where the two cleanups would have to run innermost-first.
 
 ## Methods Without an Operational Model
 

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -33,6 +33,9 @@ This page is a reference of all Python language constructs, data structures, and
 - **Variable inference**: Variables annotated with `Any` that are assigned from function calls inherit the function's inferred return type
 - **`Optional[T]` equality**: Equality (`==`, `!=`, `is`, `is not`) between an `Optional[T]` value and a matching primitive succeeds after an `is not None` round-trip — the primitive side is implicitly cast to the pointer-backed representation. Ordered comparisons (`<`, `>`, `<=`, `>=`) on `Optional[T]` are deliberately disabled (they would compare addresses, not values).
 - **`Optional[T]` return type**: A function annotated `-> Optional[T]` (the `typing.Optional` subscript form) lowers to a `T*` pointer with `None` encoded as `NULL`, so a body that returns `None` on some path verifies correctly. `None` comparisons (`is`, `is not`, `==`, `!=`) applied directly to such a call — `f() is None`, `f() == None` — are evaluated against the function's return type rather than collapsed to a constant. (The dedicated `Optional<T>` struct representation is used for the PEP 604 `T | None` annotation with primitive `T`, not for the `Optional[T]` subscript form.)
+- **Parameter type recovery**: A bare `list` annotation, or no annotation at all, does not stop the parameter being typed. A body that uses the parameter as a list (`len(x)`, `x[i]`, a list mutator, or an unpack such as `first, *rest = arr`) refines it to the list model — in an imported module as well as the entry file — and the *element* type is recovered from the statically resolvable call sites when they agree on one, so `x[i] + 1` behaves as it does under a `list[T]` annotation instead of reading as `Any`
+- **Default arguments**: A parameter whose default is a `list`, `dict` or `set` literal receives that container when the argument is omitted, rather than `None`. Defaults are also filled in for a call into an imported module and for an imported class's constructor
+- **Callables in containers**: A function name stored in a list decays to a function pointer, so a callable read back out of the list can be invoked
 - **Lambda expressions**: Single-expression lambdas with multiple parameters; converted to regular functions and stored as function pointers; can be assigned to variables and called indirectly
 
 ## Object-Oriented Programming
@@ -210,7 +213,7 @@ Byte sequences and integer class methods:
 ## Error Handling
 
 - **`try`/`except`** blocks with multiple handlers and `except ExceptionType as var` binding
-- **`try`/`finally`** blocks: the `finally` body runs on normal completion, after a caught exception, and when an exception propagates uncaught (run `finally`, then re-raise). Bare `try`/`finally` (no `except`) is supported. Shapes that cannot be lowered soundly are refused with a clean diagnostic (see [Limitations](./limitations#exception-handling))
+- **`try`/`finally`** blocks: the `finally` body runs on normal completion, after a caught exception, when an exception propagates uncaught (run `finally`, then re-raise), and on the `return` / `break` / `continue` edges that escape the `try`, a handler, or the `finally` itself. A returned expression is spilled to a temporary before the `finally` runs, as CPython evaluates it first. Bare `try`/`finally` (no `except`) is supported. Shapes that cannot be lowered soundly are refused with a clean diagnostic (see [Limitations](./limitations#exception-handling))
 - **`raise`** statements with exception instantiation and custom messages; bare `raise` re-raises the active exception inside an `except` handler
 - **`assert`** statements for property verification
 - **`__ESBMC_assume`** for constraining non-deterministic inputs
@@ -320,6 +323,45 @@ if x > 0:
     __ESBMC_cover(x > 100)  # Is this branch reachable?
 ```
 
+## Dynamic Typing
+
+A variable whose type diverges across an `if`/`else` — `x = 1` in one branch and
+`x = "hello"` in the other — is given a *tagged* representation carrying a
+runtime type tag alongside the value, instead of being forced to one branch's
+type. This covers a variable created inside the branches and one that already
+had a native type before them:
+
+```python
+def main() -> None:
+    flag: bool = __VERIFIER_nondet_bool()
+    x = 1
+    if flag:
+        x = "hello"
+    else:
+        x = 2
+    assert isinstance(x, str) or isinstance(x, int)
+    assert not isinstance(x, float)
+```
+
+Supported on a tagged variable:
+
+- **`isinstance(x, T)`** for `bool`, `int`, `float` and `str`, compared against
+  the runtime tag. An aggregate or user class is answered `False` rather than
+  refused, since a tag cannot hold one.
+- **`x is None`**, folded against a literal `None` — a tagged variable never
+  holds one.
+- **`==` between two tagged variables**, dispatched on the tag, with the numeric
+  arm fixed-width and the `str` arm under a compile-time bound.
+- **`+`, `-`, `*`, `/` against a literal**, numeric, plus string concatenation
+  for `+`.
+- **Rebinding to a container** — a list, tuple or class instance assigned to a
+  tagged variable gets its own slot, as Python rebinds the name outright.
+- **Function return values**: a function whose `return` statements diverge in
+  type across an `if`/`else` reconciles both branches into one tagged return
+  type, instead of the type of whichever `return` was reached first.
+
+See [Limitations](./limitations#dynamic-typing) for what a tag cannot hold.
+
 ## Strict Type Checking
 
 The `--strict-types` flag enables type compatibility validation for function arguments at verification time. When a type mismatch is detected, a `TypeError` is generated with a descriptive message. Instance methods, class methods, and static methods are all handled with appropriate implicit-parameter awareness.
@@ -348,7 +390,7 @@ The `--strict-types` flag enables type compatibility validation for function arg
 | `pow(b, e, m)` | 3-argument modular exponentiation: exact `BigInt` for constant integer operands; symbolic operands raise an unsupported diagnostic rather than emit unsound floating-point modulo |
 | `format(value[, spec])` | Builtin formatting (distinct from the `str.format()` method). Constant-folds a literal integer with a bare presentation-type spec (`'d'`/`'x'`/`'X'`/`'o'`/`'b'` or empty) — `format(255, "x")` → `"ff"` (no `0x`/`0o`/`0b` prefix, leading `-` for negatives, `LLONG_MIN`-safe) — and a constant string with the default spec to itself. A **typeless float spec** (no presentation type) is folded too: width, alignment, sign and zero-padding (`format(1.5, "10")`, `format(-1.5, "08")`, `format(1.5, "=+10")`) render the digits through the shared shortest-repr renderer and then pad, and `,`/`_` grouping groups the integer part by 3 as CPython does (`format(1234.5, ",")` → `"1,234.5"`). Combinations that are *not* modelled — typeless precision (`format(1.5, ".2")`), grouping with an explicit float type (`",.1f"`), grouping plus zero/`=` padding (`"08,"`) — and variable arguments raise a clean error rather than a wrong fold |
 | `callable(obj)`, `issubclass(cls, base)` | Resolved at compile time from the symbol table and AST class hierarchy |
-| `len` | Works on lists, sets, strings, tuples |
+| `len` | Works on lists, sets, strings, tuples. On a class instance it dispatches to `__len__`, walking the ancestry so an inherited one is found; a class that defines none raises `TypeError` as CPython does, rather than measuring the struct with `strlen` and answering 0 |
 | `range` | Used in `for` loops |
 | `min(a, b)`, `max(a, b)` | Two-argument form only; promotes `int` to `float` |
 | `min([...])`, `max([...])` | Single-list form; supports `int`, `float`, and `str` element types. The `key=` argument is honoured over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms (the winning element is returned; ties break toward the first occurrence) |
@@ -362,10 +404,14 @@ The `--strict-types` flag enables type compatibility validation for function arg
 | `reversed(iter)` | Lowered to an index-based `while` loop in `for` form; `reversed(range(...))` is rewritten to an equivalent forward `range(...)` |
 | `filter(pred, iter)` | Lowered to an index-based `while` loop guarded by `pred` in `for` form |
 | `list()` | Zero-arg constructor lowers to an empty list literal. `list(iterable)` over a list, `range`, or tuple (`list((2, 3))`, `list(t)`) builds a real list; `list("abc")` over a constant string yields a list of single-character strings. `list(bytes)` is rejected with a clean diagnostic (CPython would produce a list of ints). |
-| `isinstance(obj, type)` | Runtime type checking |
+| `isinstance(obj, type)` | Runtime type checking, including over a [dynamically-typed](#dynamic-typing) variable |
 | `float("nan")`, `float("inf")` | Special values (case-insensitive, whitespace-tolerant) |
 | `input()` | Modelled as nondeterministic string, max 256 chars |
 | `print(...)` | Arguments evaluated for side effects; no output produced |
+
+`sum`, `min`, `max` and `sorted` over a **generator expression** keep the
+generator's `if` clauses, so `sum(x for x in xs if x > 2)` filters rather than
+summing every element.
 
 ## Complex Math Module (`cmath`)
 
@@ -510,17 +556,19 @@ All `os` functions use nondeterministic modelling to verify both success and fai
 
 Partial executable support for list-backed arrays, element-wise arithmetic, selected math functions, and small determinants, now covering 1-D, 2-D, and 3-D (n-D) shapes. Some APIs remain stubs for type inference only.
 
-**Array construction**: `np.array(l)`, `np.zeros(shape)`, `np.ones(shape)` for 1-D, 2-D, and 3-D shapes, including explicit constructor `dtype` coercion for literal `bool`, `int`, and `float` inputs; `np.arange(n)`, `np.full(shape, value)`, `np.eye(N[, M])`, `np.identity(n)`, and `np.linspace(start, stop, num)`. **Symbolic shapes** are handled: a nondeterministic dimension such as `np.zeros(n)` with a constrained `n` yields an array of the corresponding length (`len(a) == 0` when `n == 0`)
+**Array construction**: `np.array(l)`, `np.zeros(shape)`, `np.ones(shape)` for 1-D, 2-D, and 3-D shapes, including explicit constructor `dtype` coercion for literal `bool`, `int`, and `float` inputs; `np.arange([start, ]stop[, step])`, `np.full(shape, value)`, `np.eye(N[, M])`, `np.identity(n)`, and `np.linspace(start, stop, num)`. **Symbolic shapes** are handled: a nondeterministic dimension such as `np.zeros(n)` with a constrained `n` yields an array of the corresponding length (`len(a) == 0` when `n == 0`)
 
 **Indexing**: n-D tuple indexing `a[i, j, k]` on 2-D and 3-D arrays (`a[0, 0, 0]`, `a[1, 1, 1]`); supplying more indices than the array has dimensions is rejected. **Boolean-mask selection** `a[mask]` returns the elements where a same-length boolean array is `True` (an all-`False` mask yields an empty array); a non-boolean or symbolic mask is rejected
 
 **Slicing**: bounded 1-D slicing `a[i:j]` on a list-backed array returns a new `list[T]` (bounded, open-ended `a[i:]`/`a[:j]`, and full-copy `a[:]` forms), with the slice typed as the element type rather than collapsing to a scalar. **2-D slicing** selects whole rows (`a[i, :]`) and whole columns (`a[:, j]`)
 
+**Views**: a 1-D, unit-stride slice with literal bounds assigned to a bare name (`v = a[1:3]`) is a real **view** — `v` points into `a`'s own buffer, so writes through either are observed by the other, and `len(v)`, `v.shape` and `v.ndim` report the view's own length rather than the base buffer's. Every other view-like expression, including a slice with a symbolic bound, still copies
+
 **Shape manipulation**: `np.reshape(a, shape)` (2-D and 3-D targets; an incompatible element count is rejected), `np.flatten(a)` / `np.ravel(a)` (row-major 1-D view), `np.squeeze(a)` (drop unit-length axes; a non-unit axis is rejected), `np.stack([a, b, ...])` (join arrays along a new leading axis, e.g. 1-D → 2-D), `np.concatenate([a, b, ...])` (join along the existing axis), and `a.astype(dtype)` (dtype conversion; `astype` to a complex dtype is rejected)
 
 **Reductions**: `np.sum(a)`, `np.prod(a)`, `np.min(a)`, `np.max(a)`, `np.mean(a)`, `np.std(a)`, `np.var(a)`, `np.argmin(a)`, `np.argmax(a)` over list-backed arrays. The reductions, `transpose` and `flatten` accept arrays built by any constructor (`zeros`, `ones`, `full`, `eye`, `identity`, `linspace`, `arange`), not only `np.array(<literal>)`. The method spellings (`a.sum()`, `a.min()`, `a.prod()`, `a.transpose()`, `a.flatten()`, …) are rewritten to the module form in any expression context — e.g. `assert a.min() == 0` — not just on the right-hand side of an assignment
 
-**Comparison and logical ufuncs**: `np.greater`, `np.greater_equal`, `np.less`, `np.less_equal`, `np.equal`, `np.not_equal`, `np.logical_and`, `np.logical_or`, `np.logical_not`, and `np.where(cond, a, b)` (element-wise select; also the scalar-condition form `np.where(False, 1, 2)`)
+**Comparison and logical ufuncs**: `np.greater`, `np.greater_equal`, `np.less`, `np.less_equal`, `np.equal`, `np.not_equal`, `np.logical_and`, `np.logical_or`, `np.logical_not`, and `np.where(cond, a, b)` (element-wise select; also the scalar-condition form `np.where(False, 1, 2)`). One of these may be **chained** as another numpy call's argument, nested directly or through an intermediate variable, instead of the inner result being silently substituted
 
 **Element-wise arithmetic**: `np.add(a, b)`, `np.subtract(a, b)`, `np.multiply(a, b)`, `np.divide(a, b)`, `np.power(a, b)` on literal list-backed inputs, with NumPy-style broadcasting for 1D/2D shapes
 

--- a/website/content/docs/usage.md
+++ b/website/content/docs/usage.md
@@ -541,6 +541,66 @@ The assumption is scoped to the entry point only, and it does not imply the
 parameters are distinct pointers: `f(NULL, NULL)` is a conforming call
 (C11 6.7.3.1p4), so `a != b` still does not follow.
 
+## Per-property results
+
+Every verification run ends with a `** Results:` block naming each property,
+grouped by file and function in source order. It is printed whatever the
+strategy — plain BMC, `--incremental-bmc`, `--k-induction` — and `--result-only`
+keeps it while suppressing the rest of the output (a coverage run reports its
+own goals instead):
+
+```sh
+esbmc file.c --result-only
+```
+
+```
+** Results:
+file.c, function main
+  PASSED       [main.assertion.1]  line 5  A1
+  FAILED       [main.assertion.2]  line 6  A2
+
+** 1 of 2 properties failed, 1 passed
+
+VERIFICATION FAILED
+```
+
+A property is reported `NOT CHECKED` rather than `PASSED` when the run never
+separated it. A default run stops at the first violation, so the properties
+after it were never decided, and saying they passed would be wrong:
+
+```
+  PASSED       [main.assertion.1]  line 5  addition commutes
+  FAILED       [main.assertion.2]  line 8  a is not one
+  NOT CHECKED  [main.assertion.3]  line 9  a is not two
+
+** 1 of 3 properties failed, 1 passed, 1 not checked
+   (this mode stops at the first violation; use --multi-property for a verdict on every property)
+```
+
+Adding `--multi-property` decides all three, and appends the solver and its
+decision-procedure time to the summary.
+
+## Bounding the stack
+
+```sh
+esbmc file.c --stack-limit 8192
+esbmc file.c --total-stack-limit 65536
+```
+
+`--stack-limit` bounds a *single* stack frame, so a deep recursion whose
+individual frames each fit never trips it. `--total-stack-limit` bounds the
+combined size of all live frames instead, which is what a real stack budget
+constrains. ESBMC's own operational models are excluded from the total, so the
+bound stays calibratable against the program's own frames.
+
+Both bounds are given in **bits**, not bytes. The total is accounted per
+symbolic path at declaration points, and over-approximates for spawned threads.
+A violation names the declaration that crossed the bound:
+
+```
+Total stack limit property was violated when declaring buf
+```
+
 ## Multiple Property Verification
 
 ```sh
@@ -718,6 +778,14 @@ shell, so it can include options or chain commands (the tools must be on
 - `cvc5 -L smt2 -m`
 
 Remember to quote the `CMD` string when invoking ESBMC.
+
+A backend that cannot decide a goal says so rather than ending the run without a
+verdict. Under the integer/real encoding (`--ir`, `--ir-ieee`) Z3's `smt` tactic
+is incomplete for nonlinear real arithmetic, so the tactic chain falls back to
+`qfnra-nlsat` on exactly the goals `smt` abandoned, and declines anything
+outside QF_NRA. Bitwuzla returns a query term unchanged when evaluating it would
+need a quantifier it never registered; that is reported as an unknown value, as
+the Z3 backend already did.
 
 ### Symmetry breaking
 

--- a/website/content/news/development-update-late-august-2026.md
+++ b/website/content/news/development-update-late-august-2026.md
@@ -1,0 +1,129 @@
+---
+title: "Development Update: Late August 2026"
+date: 2026-08-22T07:30:00+01:00
+draft: false
+tags:
+  - ESBMC
+  - FormalVerification
+  - ModelChecking
+  - OpenSource
+---
+
+A follow-up to the [previous update](/news/development-update-august-2026): another
+175 or so pull requests landed on `master` between 13 and 22 August. Here are
+the highlights.
+
+**Every run names every property.**
+[#7064](https://github.com/esbmc/esbmc/pull/7064) prints the per-property
+`** Results:` block on every run, not only under `--multi-property`, and
+`--result-only` no longer suppresses it — so `esbmc --result-only file.c` now
+names what it checked. Properties a single-property run never separated are
+reported `NOT CHECKED` rather than `PASSED`, since a run that stops at the
+first violation cannot decide the rest.
+
+**Python gets dynamic typing.**
+A variable whose type diverges across an `if`/`else` is carried as a tagged
+value instead of being forced to one branch's type. Building on [#6535](https://github.com/esbmc/esbmc/pull/6535), the
+mechanism now covers reassignment and arithmetic
+([#7018](https://github.com/esbmc/esbmc/pull/7018)), `isinstance`
+([#7117](https://github.com/esbmc/esbmc/pull/7117),
+[#7179](https://github.com/esbmc/esbmc/pull/7179)), `is` and `==` comparisons
+([#7135](https://github.com/esbmc/esbmc/pull/7135)), rebinding to a container
+([#7178](https://github.com/esbmc/esbmc/pull/7178)) and function return values
+([#7162](https://github.com/esbmc/esbmc/pull/7162)) — most of which previously
+aborted the frontend or crashed symbolic execution outright.
+
+**Contracts frame what they name.**
+An `__ESBMC_assigns` clause naming an array now frames the whole array rather
+than element `[0]` ([#7019](https://github.com/esbmc/esbmc/pull/7019)), a
+multi-level path such as `o->sub->a` is rooted at its parameter instead of
+generating zero verification conditions
+([#7068](https://github.com/esbmc/esbmc/pull/7068)), and the element-level frame
+rule was corrected to evaluate its index in the pre-state
+([#7069](https://github.com/esbmc/esbmc/pull/7069),
+[#7107](https://github.com/esbmc/esbmc/pull/7107),
+[#7217](https://github.com/esbmc/esbmc/pull/7217)). `__ESBMC_old` works under a
+quantifier ([#6964](https://github.com/esbmc/esbmc/pull/6964)), a named object
+satisfies `__ESBMC_is_fresh`
+([#7036](https://github.com/esbmc/esbmc/pull/7036)), and a replaced call's
+`ensures` now speaks about the value the call returned
+([#7033](https://github.com/esbmc/esbmc/pull/7033)). On the Python side,
+`__ESBMC_old` is lowered for scalars
+([#7038](https://github.com/esbmc/esbmc/pull/7038)), completing the scalar
+contract MVP ([#6942](https://github.com/esbmc/esbmc/pull/6942)).
+
+**A large C++ standard-library push.**
+Around fifty operational-model pull requests landed. New this fortnight:
+`std::reference_wrapper` with `ref`/`cref`
+([#7147](https://github.com/esbmc/esbmc/pull/7147),
+[#7213](https://github.com/esbmc/esbmc/pull/7213)),
+`std::unordered_multiset` ([#7156](https://github.com/esbmc/esbmc/pull/7156)),
+`<chrono>` clocks and `time_point`
+([#6985](https://github.com/esbmc/esbmc/pull/6985)), `std::put_time` and
+`std::placeholders` ([#7132](https://github.com/esbmc/esbmc/pull/7132)),
+`filesystem::u8path` and the `path` string accessors
+([#7169](https://github.com/esbmc/esbmc/pull/7169),
+[#7180](https://github.com/esbmc/esbmc/pull/7180)), and a long list of
+`<type_traits>` additions. The containers took their `Allocator` template
+parameter ([#7163](https://github.com/esbmc/esbmc/pull/7163),
+[#7167](https://github.com/esbmc/esbmc/pull/7167)), `std::function`'s call
+target is templated on its signature
+([#7171](https://github.com/esbmc/esbmc/pull/7171)), and `basic_string`'s
+`size`, `resize`, `max_size` and `rfind` were brought into line with the
+standard ([#7145](https://github.com/esbmc/esbmc/pull/7145),
+[#7175](https://github.com/esbmc/esbmc/pull/7175)).
+
+**Nothing in `/tmp` for C and C++ runs.**
+[#6517](https://github.com/esbmc/esbmc/pull/6517) serves the bundled clang
+headers, C++ operational models and internal libc to clang from memory instead
+of extracting them — 320 files and 7.1 MB of `/tmp` traffic per C run, 488 files
+and 8.0 MB per C++ run, both now zero, with wall clock unchanged. The
+operational models are compiled straight out of the same store
+([#6766](https://github.com/esbmc/esbmc/pull/6766)) and the Python models moved
+to their own blob ([#7058](https://github.com/esbmc/esbmc/pull/7058)). Python
+and Solidity still extract, since a forked `python3` or `solc` can only read
+real files.
+
+**A bound on the whole stack.**
+[#6970](https://github.com/esbmc/esbmc/pull/6970) adds `--total-stack-limit`,
+which sums the live frames rather than bounding one at a time, so a recursion
+whose individual frames each fit is caught. ESBMC's own operational models are
+excluded, so the bound stays calibratable against a real stack budget.
+
+**Soundness and precision.**
+The pointer analysis resolves pointers an aggregate holds at an offset
+([#6981](https://github.com/esbmc/esbmc/pull/6981)) and reports misaligned reads
+from pointer arrays ([#6979](https://github.com/esbmc/esbmc/pull/6979)) — both
+were false `SUCCESSFUL` results on ordinary C. A pointer whose object id is a
+free variable can no longer be placed at address zero
+([#6999](https://github.com/esbmc/esbmc/pull/6999)). `fmod`, `remainder` and
+`remquo` lower to the solver's exact FP remainder instead of
+`x - y*(int)(x/y)`, which returned 64.0 for `fmod(1e18, 3.0)`
+([#7015](https://github.com/esbmc/esbmc/pull/7015)). Two backends that used to
+end a run with no verdict now report one
+([#7065](https://github.com/esbmc/esbmc/pull/7065),
+[#7078](https://github.com/esbmc/esbmc/pull/7078)).
+
+**Python type inference and NumPy.**
+A bare `list` parameter, or an unannotated one, recovers its element type from
+the call sites ([#7192](https://github.com/esbmc/esbmc/pull/7192),
+[#7199](https://github.com/esbmc/esbmc/pull/7199)), including in an imported
+module ([#7198](https://github.com/esbmc/esbmc/pull/7198)). `try`/`finally` runs
+the cleanup on the `return`/`break`/`continue` edges
+([#7181](https://github.com/esbmc/esbmc/pull/7181)), `len()` on a class without
+`__len__` raises `TypeError` instead of measuring the struct with `strlen` and
+answering 0 — which had silently emptied `for` loops
+([#7131](https://github.com/esbmc/esbmc/pull/7131),
+[#7137](https://github.com/esbmc/esbmc/pull/7137)) — and a generator's `if`
+clauses survive being consumed by `sum`, `min`, `max` or `sorted`
+([#7214](https://github.com/esbmc/esbmc/pull/7214)). In NumPy, `arange` is
+materialised at conversion time
+([#7020](https://github.com/esbmc/esbmc/pull/7020)), logical calls chain as
+arguments to other calls ([#7089](https://github.com/esbmc/esbmc/pull/7089)),
+and a 1-D unit-stride slice is a real view onto the base array rather than a
+copy ([#7144](https://github.com/esbmc/esbmc/pull/7144)).
+
+The website documentation has been updated to match. As always, the full list is
+in the [commit history](https://github.com/esbmc/esbmc/commits/master/) — and if
+you hit a bug or a missing feature, we would love an
+[issue report](https://github.com/esbmc/esbmc/issues).


### PR DESCRIPTION
Documents the always-on per-property `** Results:` block (#7064), `--total-stack-limit` (#6970), Python dynamic typing (#7018–#7179), the late-August C++ operational-model batch, and the array and multi-level `__ESBMC_assigns` frame fixes.

Corrects the claims that work invalidated — Python `__ESBMC_old`, the try/finally escape refusal, and the two contract limitations #7068/#7069 narrowed rather than removed. Adds a late-August development update to /news.

Hugo builds clean; the doc examples were run against the 8.4.0 binary.