### PR TITLE
[clang-c] Locate the implicit callee the IREP2 hop-off synthesises

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -4787,3 +4787,104 @@ tail padding.
 `sizeof(struct s)` is **not** a usable probe: clang folds it in its own AST, so
 it reads 8 on both paths and a verdict test built on it passes against the
 control. The first draft of this test did exactly that and proved nothing.
+
+## 110. The census re-run after the sixteen PRs landed (2026-08-22)
+
+§104 closed the census with "every measured divergence is owned by an open PR".
+Those PRs are merged, so the question is what the symbol-table gap looks like
+now. Re-measured on master at `595f52b025` over `regression/esbmc`,
+`--clang-c-irep2-adjust-only` versus the legacy pass, blank-line differences
+ignored:
+
+| | tests |
+|---|---:|
+| whole suite | **693 same, 1147 differing, 1 skipped** |
+| stride-8 sample | 90 same, 138 differing |
+
+The suite figure is the first one taken; §101's 78-of-120 was a prefix of the
+same suite before any of the sixteen landed, so the two are not comparable and
+neither is offered as a delta. The stride sample is what the causes below are
+counted on.
+
+### 110.1 The dominant cause does not reach the goto program
+
+| cause | tests | note |
+|---|---:|---|
+| `(void)0` vs `0` in a conditional arm | 89 | §110.2 |
+| untagged residue | 22 | §110.4 |
+| implicit callee has no location | 13 | §110.3, fixed here |
+| indentation only | 11 | printer, from the §105 for-init hoist |
+| `migrate_expr` renaming warning | 4 | |
+| `volatile` dropped from a DECL statement | 1 | symbol keeps it; the statement does not |
+| padding | 1 | |
+
+### 110.2 `(void)0` is a legacy artefact, and mirroring it would be wrong
+
+Reduced:
+
+```c
+void f(void);
+int main() { int x = 1; x ? f() : (void)0; return 0; }
+```
+
+Legacy prints `(_Bool)x ? f() : 0;`, the hop-off `(_Bool)x ? f() : (void)0;`.
+The source says `(void)0`, so the hop-off is the faithful one. `adjust_if`
+compares whole `typet` ireps and casts *both* arms when *either* differs, so an
+attribute-only difference between the conditional's type and an arm's is enough
+to fire it; `do_typecast` then folds the cast into the constant. `adjust_if_expr`
+compares interned `type2tc`, which are equal, and leaves the arm alone.
+
+`--goto-functions-only` on the reduction is byte-identical between the two
+paths: `goto_convert` drops the void arm either way. So this is §39.1's "a
+caller downstream re-does the work" row of the parent document — 64 % of the
+remaining symbol-table gap is a difference that no consumer sees, and the arm
+that would close it does not get written.
+
+### 110.3 The implicit callee's location, which is a real loss
+
+`declare_implicit_callee` synthesises the symbol for a callee with no visible
+declaration. It read the location off `code_function_call2t::location`, and
+took none at all in the other branch: `sideeffect2t` has no location field, so
+a bare `assert(x == 1);` — which is a `sideeffect2t` of kind `function_call`
+under a `code_expression2t`, not a `code_function_call2t` — produced a symbol
+with an empty `Location`. 13 of the 138 differing tests are only this.
+
+The statement's location is the call's **only when the call is the whole
+statement**, so that is the one position it is taken from: `adjust_expr`
+declares the callee from `code_expression2t` before recursing, passing the
+statement's location, and the generic arm keeps declaring the rest unlocated.
+The narrower shapes — `a = f();`, `if (f())`, `return f();` — keep the call's
+own column in the legacy pass and are left as they were rather than given the
+statement's column, which would be the right line and the wrong one. Closing
+those needs a `locationt` on `sideeffect2t`, on the pattern the `code_*2t`
+kinds already use; that is a separate change and is not made here.
+
+Result on the stride sample: **106 same, 123 differing**, and no test acquires a
+divergence it did not have.
+
+| mutant | killed by |
+|---|---|
+| location not passed (master) | `..._implicit_callee_location` |
+| location not passed, nested statement | `..._implicit_callee_location_stmt` |
+
+Both tests were run against the unpatched arm and fail there. The second one
+exists because the first would also pass if the location were taken from the
+enclosing function rather than the statement.
+
+### 110.4 The untagged residue names four more causes
+
+Read rather than tallied, per §104.2:
+
+- **A cast lost at a call argument** — `atexit((void (*)())(&free_g2))` legacy
+  versus `atexit(&free_g2)`. The conversion #7091 ported does not cover a
+  function-pointer parameter.
+- **The hop-off aborts outright** on `builtin_memcpy` and `cwe_uninit_array_vla`
+  — the whole symbol table is missing. This is the by-name union tag the header
+  comment on `clang_c_adjust_irep2` already documents.
+- **`(signed int)b += a` versus `b += a`** — the coupled arith-assign
+  conversion, `scope-coupled-arith-assign-conversion.md`.
+- **Printer-only**: `+1` versus `1`, and the float literal suffix
+  (`1.175494e-38f` versus `1.175494e-38`).
+
+The abort is the one worth taking next: it is not a spelling difference but a
+hard stop, and it puts two tests beyond measurement rather than merely differing.

--- a/regression/esbmc/irep2_only_implicit_callee_location/main.c
+++ b/regression/esbmc/irep2_only_implicit_callee_location/main.c
@@ -1,0 +1,10 @@
+/* No <assert.h>: `assert` is implicitly declared, so the adjuster synthesises
+   the callee symbol. A sideeffect2t carries no location of its own, so the
+   symbol's has to come from the enclosing statement. */
+int main(void)
+{
+  int x = 1;
+
+  assert(x == 1);
+  return 0;
+}

--- a/regression/esbmc/irep2_only_implicit_callee_location/test.desc
+++ b/regression/esbmc/irep2_only_implicit_callee_location/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--clang-c-irep2-adjust-only --symbol-table-only
+^Symbol\.+: c:@F@assert$
+^Location\.+: file .*main\.c line 8 column 3 function main$

--- a/regression/esbmc/irep2_only_implicit_callee_location_stmt/main.c
+++ b/regression/esbmc/irep2_only_implicit_callee_location_stmt/main.c
@@ -1,0 +1,17 @@
+/* Nested expression statements: the walk restores the enclosing statement's
+   location on the way out, so a call in a loop body does not inherit the one
+   belonging to a statement it is not inside. */
+int main(void)
+{
+  int a = 0;
+
+  outer(a);
+
+  while (a)
+  {
+    inner(a);
+    a = 0;
+  }
+
+  return 0;
+}

--- a/regression/esbmc/irep2_only_implicit_callee_location_stmt/test.desc
+++ b/regression/esbmc/irep2_only_implicit_callee_location_stmt/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--clang-c-irep2-adjust-only --symbol-table-only
+^Symbol\.+: c:@F@outer$
+^Location\.+: file .*main\.c line 8 column 3 function main$
+^Symbol\.+: c:@F@inner$
+^Location\.+: file .*main\.c line 12 column 5 function main$

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -114,6 +114,14 @@ void clang_c_adjust_irep2::adjust_expr(expr2tc &expr)
   if (is_nil_expr(expr))
     return;
 
+  // Before the recursion, so the located spelling wins over the unlocated one
+  // the walk would otherwise reach first.
+  if (sole_adjuster && is_code_expression2t(expr))
+  {
+    const code_expression2t &stmt = to_code_expression2t(expr);
+    declare_implicit_callee(stmt.operand, stmt.location);
+  }
+
   expr->Foreach_operand([this](expr2tc &op) { adjust_expr(op); });
 
   if (is_index2t(expr))
@@ -777,7 +785,9 @@ void clang_c_adjust_irep2::adjust_complex_unary(expr2tc &expr)
   expr = constant_struct2tc(ct, std::vector<expr2tc>{re, im});
 }
 
-void clang_c_adjust_irep2::declare_implicit_callee(const expr2tc &expr)
+void clang_c_adjust_irep2::declare_implicit_callee(
+  const expr2tc &expr,
+  const locationt &stmt_location)
 {
   // A bare `f(x);` statement is a sideeffect2t of kind function_call, not a
   // code_function_call2t; both spellings reach here.
@@ -789,13 +799,19 @@ void clang_c_adjust_irep2::declare_implicit_callee(const expr2tc &expr)
     callee = call.function;
     loc = call.location;
   }
-  else
+  else if (is_sideeffect2t(expr))
   {
     const sideeffect2t &se = to_sideeffect2t(expr);
     if (se.kind != sideeffect_allockind::function_call)
       return;
     callee = se.operand;
+    // sideeffect2t has no location of its own. The enclosing statement's is
+    // the call's only when the call is the whole statement, which is the one
+    // position this is passed from.
+    loc = stmt_location;
   }
+  else
+    return;
 
   if (is_nil_expr(callee) || !is_symbol2t(callee))
     return;

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -64,7 +64,9 @@ private:
   /// symbol in the context; clang_c_adjust::adjust_side_effect_function_call
   /// declares one. That is a symbol-table side effect rather than an expression
   /// rewrite, so it ports independently of the rest of that arm (§70).
-  void declare_implicit_callee(const expr2tc &expr);
+  void declare_implicit_callee(
+    const expr2tc &expr,
+    const locationt &stmt_location = locationt());
 
   /// IREP2 form of clang_c_adjust::adjust_expr_{unary,binary}_boolean's live
   /// half. Their type write is dead for C (§58.1); the operand conversion is


### PR DESCRIPTION
A callee with no visible declaration got a symbol with an empty `Location` under `--clang-c-irep2-adjust-only`, because a `sideeffect2t` call carries no location of its own. It now takes the enclosing statement's, in the one position where that is the call's own.

Also re-censuses the C hop-off on master now that the sixteen PRs of §104 have landed, and records that the dominant remaining symbol-table difference is erased by `goto_convert`.

Part of #4715.