### PR TITLE
[docs] Say how to read a Benchexec run before blaming a PR for it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,20 @@ Look for the `python_user_main` function to see how Python source maps to GOTO i
 
 **5. Hypothesis tests** — Property-based tests in `unit/python-frontend/` test ESBMC's models against CPython. Run with: `uv run python -m pytest unit/python-frontend/ -v`
 
+## SV-COMP Benchmarking
+
+The `Run Benchexec` workflow is the only measurement of ESBMC's competition score. A number from it is easy to read as a verdict on the PR in front of you when it is nothing of the sort.
+
+**Label the PR.** When a change can move SV-COMP verdicts — anything under `goto-symex/`, `solvers/`, `pointer-analysis/`, `goto-programs/`, a frontend's semantics, an operational model, or `scripts/competitions/svcomp/` — add `needs-svcomp-run` alongside the area label, so it is not merged on the regression suite alone. Add `SV-COMP` when the competition setup itself is what changed.
+
+**Check the provenance of both runs before attributing a score move.** `gh run list --workflow "Run Benchexec"` prints each run's `headBranch`: runs described as "master" are routinely another PR's branch. The timeout and `ESBMC_OPTS` are `workflow_dispatch` inputs, recorded together with the CPU and RAM in the `<result …>` element of every `*.results.*.xml.bz2` in the `esbmc-result` artifact — a 30s run and a 900s run are not comparable, and neither are two different strategies. Master moves daily, so a baseline more than a few days older than the PR run measures master's drift rather than the PR.
+
+**Attribute per task, not per total.** Download both `esbmc-result` artifacts, parse the per-task `status` and `category` out of the XML, and diff the task sets. If the tasks a PR appears to lose are the same ones another branch's run already lost, the PR is not the cause; a third run from the same week on an unrelated branch settles it.
+
+**Read a per-task log before concluding the verifier regressed.** `*.logfiles.zip` in the artifact holds ESBMC's full stdout per task. `VERIFICATION FAILED` followed by `Unknown` is `esbmc-wrapper.py` failing to classify the output, not ESBMC failing to find the bug.
+
+**Changing what ESBMC prints is an interface change.** `parse_result()` in `scripts/competitions/svcomp/esbmc-wrapper.py` classifies each task by matching substrings of ESBMC's output, so a PR that adds, renames, or reformats a verdict line, a property comment, or a summary block must be checked against it — `python3 scripts/competitions/svcomp/test_esbmc_wrapper.py` covers the parsing — and carries `needs-svcomp-run`. PR #7064 added a per-property table listing every property including the unchecked ones; the wrapper read those rows and turned ~2600 correct-false verdicts into `Unknown` (#7250).
+
 ## Commit Conventions
 
 Prefix commits with a category tag in brackets, e.g., `[python]`, `[build]`, `[solver]`, `[om]` (operational model). Title: one line, imperative mood, <72 chars. Description: 2–4 lines explaining what changed and why. Reference the relevant issue/PR with `Fixes #N` when applicable.
@@ -230,5 +244,7 @@ Prefix commits with a category tag in brackets, e.g., `[python]`, `[build]`, `[s
 ## Issue and PR Labels
 
 Always apply at least one label when creating an issue or PR. Pick the label that matches the affected area — e.g. `python`, `clang-c-frontend`, `solver`, `build`, `docs`. Use `gh label list --repo esbmc/esbmc` to see the available labels, then `gh issue edit <N> --add-label <label>` or `gh pr edit <N> --add-label <label>`. If no existing label fits, ask the user rather than creating a new one.
+
+Add `needs-svcomp-run` on top of the area label whenever the change can move competition verdicts — see *SV-COMP Benchmarking* for what qualifies.
 
 For module-specific instructions, subdirectory CLAUDE.md files can be added (they load automatically when working in those directories).


### PR DESCRIPTION
Adds an *SV-COMP Benchmarking* section to `CLAUDE.md` (`AGENTS.md` symlinks to it): the provenance a score comparison needs (branch, timeout, `ESBMC_OPTS`, date, machine), per-task attribution instead of totals, and reading a per-task log before concluding the verifier regressed.

It also records that changing what ESBMC prints is an interface change against `parse_result()` in `esbmc-wrapper.py`, and adds the `needs-svcomp-run` label rule for PRs that can move competition verdicts. Prompted by #7064, whose new property table cost ~2600 correct-false verdicts unnoticed (#7250).