### PR TITLE
[om] Gate constexpr char_traits::length at C++17, as libc++ does

### DIFF
--- a/regression/esbmc-cpp/cpp/string_view_cxx14/main.cpp
+++ b/regression/esbmc-cpp/cpp/string_view_cxx14/main.cpp
@@ -1,0 +1,20 @@
+#include <string_view>
+#include <string>
+#include <cassert>
+
+/* The C++17 gate on char_traits::length must not cost C++14 the rest of
+ * string_view: libc++ offers the header, the counted constructor as a constant
+ * expression, and the string conversion in this mode. */
+constexpr std::string_view COUNTED("abc", 3);
+
+int main()
+{
+  static_assert(COUNTED.size() == 3, "constexpr counted ctor");
+
+  std::string_view sv("@base@");
+  assert(sv.size() == 6);
+
+  std::string s(sv);
+  assert(s.size() == 6);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/string_view_cxx14/test.desc
+++ b/regression/esbmc-cpp/cpp/string_view_cxx14/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++14
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/string_view_cxx14_constexpr_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/string_view_cxx14_constexpr_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <string_view>
+
+/* char_traits::length is constexpr only from C++17 (P0426R1), so this
+ * initialiser is not a constant expression in C++14. libc++ gates it the same
+ * way, as _LIBCPP_CONSTEXPR_SINCE_CXX17, and clang++ -std=c++14 rejects this. */
+constexpr std::string_view PREFIX = "@base@";
+
+int main()
+{
+  return (int)PREFIX.size();
+}

--- a/regression/esbmc-cpp/cpp/string_view_cxx14_constexpr_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/string_view_cxx14_constexpr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++14
+^ERROR: PARSING ERROR$

--- a/src/cpp/library/OM_compiler_defs.h
+++ b/src/cpp/library/OM_compiler_defs.h
@@ -19,13 +19,13 @@
 #  define OM_NULLPTR 0
 #endif
 
-// Relaxed constexpr: a function body with loops or multiple statements is
-// only constexpr from C++14. char_traits::length loops, so OM_CONSTEXPR
-// (which starts at C++11) would be ill-formed there.
-#if __cplusplus >= 201402L
-#  define OM_CONSTEXPR14 constexpr
+// char_traits members became constexpr in C++17 (P0426R1); libc++ gates them
+// the same way, as _LIBCPP_CONSTEXPR_SINCE_CXX17. Starting earlier would let a
+// constexpr string_view built from a literal compile here but not under clang.
+#if __cplusplus >= 201703L
+#  define OM_CONSTEXPR17 constexpr
 #else
-#  define OM_CONSTEXPR14
+#  define OM_CONSTEXPR17
 #endif
 
 // A static data member with an in-class initialiser. OM_CONSTEXPR alone is not

--- a/src/cpp/library/char_traits.h
+++ b/src/cpp/library/char_traits.h
@@ -61,7 +61,7 @@ struct char_traits
     return 0;
   }
 
-  static OM_CONSTEXPR14 std::size_t length(const char_type *s)
+  static OM_CONSTEXPR17 std::size_t length(const char_type *s)
   {
     std::size_t i = 0;
     while (!eq(s[i], char_type(0)))

--- a/src/cpp/library/string_view
+++ b/src/cpp/library/string_view
@@ -52,7 +52,7 @@ public:
   // [string.view.cons]: the default constructor leaves data() null, not
   // indeterminate.
   OM_CONSTEXPR basic_string_view() : str(nullptr), len(0) {}
-  OM_CONSTEXPR14 basic_string_view(const CharT *str)
+  OM_CONSTEXPR basic_string_view(const CharT *str)
     : str(str), len(Traits::length(str))
   {
   }


### PR DESCRIPTION
`char_traits::length` became `constexpr` in C++17 (P0426R1); libc++ spells this
`_LIBCPP_CONSTEXPR_SINCE_CXX17`. Starting at C++14 let a `constexpr` string_view
built from a literal compile under ESBMC but not under `clang++ -std=c++14`.

The converting constructor stays unconditionally `constexpr`, matching libc++,
so only the evaluation is gated. Follow-up to #7215.