### PR TITLE
[python] Infer forwarded parameter types to a fixpoint

### DIFF
--- a/regression/python/github_7254/main.py
+++ b/regression/python/github_7254/main.py
@@ -1,0 +1,9 @@
+def withdraw(balance, amount):
+    assert amount <= balance
+
+
+def process(initial_balance, withdrawals):
+    withdraw(initial_balance, withdrawals[0])
+
+
+process(100, [20])

--- a/regression/python/github_7254/test.desc
+++ b/regression/python/github_7254/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7254_conflict_fail/main.py
+++ b/regression/python/github_7254_conflict_fail/main.py
@@ -1,0 +1,18 @@
+def compare(a, b):
+    assert not (a < b)
+
+
+def direct(p, q):
+    compare(p, q)
+
+
+def indirect(s, t):
+    compare(s, t)
+
+
+def forward(u, v):
+    indirect(u, v)
+
+
+direct(5, 5)
+forward(1.2, 1.9)

--- a/regression/python/github_7254_conflict_fail/test.desc
+++ b/regression/python/github_7254_conflict_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_7254_erased_fail/main.py
+++ b/regression/python/github_7254_erased_fail/main.py
@@ -1,0 +1,14 @@
+def compare(a, b):
+    assert not (a < b)
+
+
+def floats():
+    compare(1.2, 1.9)
+
+
+def ints():
+    compare(9, 9)
+
+
+floats()
+ints()

--- a/regression/python/github_7254_erased_fail/test.desc
+++ b/regression/python/github_7254_erased_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_7254_fail/main.py
+++ b/regression/python/github_7254_fail/main.py
@@ -1,0 +1,9 @@
+def withdraw(balance, amount):
+    assert amount <= balance
+
+
+def process(initial_balance, withdrawals):
+    withdraw(initial_balance, withdrawals[0])
+
+
+process(20, [100])

--- a/regression/python/github_7254_fail/test.desc
+++ b/regression/python/github_7254_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^  assertion amount <= balance$
+^VERIFICATION FAILED$

--- a/regression/python/github_7254_str/main.py
+++ b/regression/python/github_7254_str/main.py
@@ -1,0 +1,9 @@
+def less(a, b):
+    assert a < b
+
+
+def outer(x, ys):
+    less(x, ys[0])
+
+
+outer("abc", ["abd"])

--- a/regression/python/github_7254_str/test.desc
+++ b/regression/python/github_7254_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7254_str_fail/main.py
+++ b/regression/python/github_7254_str_fail/main.py
@@ -1,0 +1,9 @@
+def less(a, b):
+    assert a < b
+
+
+def outer(x, ys):
+    less(x, ys[0])
+
+
+outer("abd", ["abc"])

--- a/regression/python/github_7254_str_fail/test.desc
+++ b/regression/python/github_7254_str_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^  assertion return_value\$_strcmp\$\d+ < 0$
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -538,6 +538,58 @@ exprt python_converter::get_logical_operator_expr(const nlohmann::json &element)
   }
   return build_boolean_chain(logical_expr);
 }
+// Sound over-approximation for a relational comparison that cannot be lowered
+// to a typed binop. Returns nil when the comparison lowers normally.
+static exprt relational_nondet_fallback(
+  const std::string &op,
+  const exprt &lhs,
+  const exprt &rhs,
+  const locationt &loc)
+{
+  auto nondet_comparison = [&loc](const char *reason) {
+    log_debug(
+      "python-binop",
+      "{} at {}:{} -- falling back to nondet bool",
+      reason,
+      loc.is_nil() ? std::string("<unknown>") : loc.get_file().as_string(),
+      loc.is_nil() ? std::string("?") : loc.get_line().as_string());
+    side_effect_expr_nondett nondet(bool_type());
+    nondet.location() = loc;
+    return nondet;
+  };
+
+  auto unresolved = [](const exprt &e) {
+    return e.type().is_empty() || e.type().is_nil();
+  };
+  // An operand whose type is unresolvable (e.g. the result of calling a
+  // generator function). Aborting here loses an entire verification run for
+  // what is often a frontend type-inference gap, not a real soundness issue.
+  // See #4807.
+  if (unresolved(lhs) || unresolved(rhs))
+    return nondet_comparison(
+      "unsupported comparison with unresolved operand type");
+
+  // Both operands carry the Any representation (void*), so nothing here knows
+  // whether they box numbers, strings or object references. Ordering them as
+  // pointers asserts SAME-OBJECT on two boxed values and compares offsets
+  // rather than the values (GitHub #7254); ordering them as integers would
+  // silently truncate a boxed float. Equality is excluded: it compares the
+  // handles, which is already correct for boxed values.
+  auto is_erased = [](const exprt &e) {
+    return e.type().is_pointer() && e.type().subtype().id() == "empty";
+  };
+  if (type_utils::is_ordered_comparison(op) && is_erased(lhs) && is_erased(rhs))
+    return nondet_comparison("ordered comparison between type-erased values");
+
+  // One side is a pointer-backed value (e.g. a list/dict variable reassigned
+  // across incompatible types in the same scope) and the other is not.
+  if (lhs.type().is_pointer() != rhs.type().is_pointer())
+    return nondet_comparison(
+      "unsupported comparison between pointer-backed and non-pointer values");
+
+  return nil_exprt();
+}
+
 // Attach source location from symbol table if expr is a symbol
 static void attach_symbol_location(exprt &expr, contextt &symbol_table)
 {
@@ -1560,9 +1612,7 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
   if (type_utils::is_relational_op(op))
   {
-    const bool lhs_invalid = lhs.type().is_empty() || lhs.type().is_nil();
-    const bool rhs_invalid = rhs.type().is_empty() || rhs.type().is_nil();
-    locationt loc = get_location_from_decl(element);
+    const locationt loc = get_location_from_decl(element);
 
     // Sound over-approximation when the comparison cannot be lowered to a
     // typed binop: either an operand's type is unresolvable, or one side is
@@ -1573,42 +1623,9 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     // returning nondet bool lets symbolic execution explore both outcomes
     // and keeps safety verification sound (we cannot conclude SAFE when
     // the real comparison would fail). See #4807.
-    auto nondet_comparison = [&](const char *reason) {
-      log_debug(
-        "python-binop",
-        "{} at {}:{} -- falling back to nondet bool",
-        reason,
-        loc.is_nil() ? std::string("<unknown>") : loc.get_file().as_string(),
-        loc.is_nil() ? std::string("?") : loc.get_line().as_string());
-      side_effect_expr_nondett nondet(bool_type());
-      nondet.location() = loc;
-      return nondet;
-    };
-
-    if (lhs_invalid || rhs_invalid)
-      return nondet_comparison(
-        "unsupported comparison with unresolved operand type");
-
-    // Both operands carry the Any representation (void*), so nothing here
-    // knows whether they box numbers, strings or object references. Ordering
-    // them as pointers asserts SAME-OBJECT on two boxed values and compares
-    // offsets rather than the values (GitHub #7254); ordering them as
-    // integers would silently truncate a boxed float. Neither is justified,
-    // so over-approximate. Equality is excluded: it compares the handles,
-    // which is already correct for boxed values.
-    auto is_erased = [](const exprt &e) {
-      return e.type().is_pointer() && e.type().subtype().id() == "empty";
-    };
-    if (
-      type_utils::is_ordered_comparison(op) && is_erased(lhs) && is_erased(rhs))
-      return nondet_comparison("ordered comparison between type-erased values");
-
-    const bool lhs_ptr = lhs.type().is_pointer();
-    const bool rhs_ptr = rhs.type().is_pointer();
-    if (lhs_ptr != rhs_ptr)
-      return nondet_comparison(
-        "unsupported comparison between pointer-backed and non-pointer "
-        "values");
+    exprt fallback = relational_nondet_fallback(op, lhs, rhs, loc);
+    if (fallback.is_not_nil())
+      return fallback;
   }
 
   if (needs_zero_division_guard(op, rhs))

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1589,6 +1589,20 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
       return nondet_comparison(
         "unsupported comparison with unresolved operand type");
 
+    // Both operands carry the Any representation (void*), so nothing here
+    // knows whether they box numbers, strings or object references. Ordering
+    // them as pointers asserts SAME-OBJECT on two boxed values and compares
+    // offsets rather than the values (GitHub #7254); ordering them as
+    // integers would silently truncate a boxed float. Neither is justified,
+    // so over-approximate. Equality is excluded: it compares the handles,
+    // which is already correct for boxed values.
+    auto is_erased = [](const exprt &e) {
+      return e.type().is_pointer() && e.type().subtype().id() == "empty";
+    };
+    if (
+      type_utils::is_ordered_comparison(op) && is_erased(lhs) && is_erased(rhs))
+      return nondet_comparison("ordered comparison between type-erased values");
+
     const bool lhs_ptr = lhs.type().is_pointer();
     const bool rhs_ptr = rhs.type().is_pointer();
     if (lhs_ptr != rhs_ptr)

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -4087,7 +4087,7 @@ void python_annotation<Json>::preprocess_method_calls(const Json &node)
 /// inside `def main(): ... f(local_var)` would fail to type-infer
 /// `local_var`, since `find_var_decl` searches by function name.
 template <class Json>
-void python_annotation<Json>::preprocess_function_calls(Json &root)
+bool python_annotation<Json>::preprocess_function_calls(Json &root)
 {
   // First pass: gather inferred argument types for every top-level
   // function call. Recurse into FunctionDef bodies so scope-dependent
@@ -4108,6 +4108,7 @@ void python_annotation<Json>::preprocess_function_calls(Json &root)
 
   // Second pass: for each top-level FunctionDef, if all observed call
   // sites agreed on a single type for a parameter, write the annotation.
+  bool annotated = false;
   for (Json &top_node : ast_["body"])
   {
     if (
@@ -4123,11 +4124,15 @@ void python_annotation<Json>::preprocess_function_calls(Json &root)
       if (param.contains("annotation") && !param["annotation"].is_null())
         continue;
       auto it = param_types.find({fname, i});
-      if (it == param_types.end() || it->second.size() != 1)
+      if (
+        it == param_types.end() || it->second.size() != 1 ||
+        *it->second.begin() == unresolved_arg_type())
         continue;
       add_parameter_annotation(param, *it->second.begin());
+      annotated = true;
     }
   }
+  return annotated;
 }
 
 template <class Json>
@@ -4160,12 +4165,15 @@ void python_annotation<Json>::collect_function_call_arg_types(
         for (size_t i = 0; i < call_args.size(); ++i)
         {
           std::string arg_type = get_argument_type(call_args[i]);
-          // Skip ambiguous / under-specified types: NoneType is `bool*`
-          // in the operational model (issue #3796) and Any leaves the
-          // type uninformative; both would lock in a misleading
-          // annotation for callers that pass a real value.
+          // Ambiguous / under-specified types: NoneType is `bool*` in the
+          // operational model (issue #3796) and Any leaves the type
+          // uninformative; both would lock in a misleading annotation for
+          // callers that pass a real value. Recorded rather than dropped so
+          // a parameter is annotated only once *every* call site resolves —
+          // an iterating pass must not commit to a type a later round
+          // contradicts (GitHub #7254).
           if (arg_type.empty() || arg_type == "NoneType" || arg_type == "Any")
-            continue;
+            arg_type = unresolved_arg_type();
           param_types[{func_name, i}].insert(arg_type);
         }
       }
@@ -4217,7 +4225,13 @@ void python_annotation<Json>::add_type_annotation()
   // inferred return type. Without this, attribute-chain lookups on
   // unannotated parameters (e.g. `resource.mutex.acquire()`) fail with a
   // cryptic "Variable mutex not found" — GitHub #4570.
-  preprocess_function_calls(ast_);
+  // Iterated: each round resolves the arguments the previous round annotated,
+  // carrying types one call-graph edge further — a callee whose caller's own
+  // parameters this pass types stays Any after a single round (GitHub #7254).
+  // Terminates because a round returns true only after annotating a parameter
+  // that had none, and annotated parameters are never revisited.
+  while (preprocess_function_calls(ast_))
+    ;
 
   // Second pass: add type annotations to global scope variables
   annotate_global_scope();

--- a/src/python-frontend/python_annotation/python_annotation.h
+++ b/src/python-frontend/python_annotation/python_annotation.h
@@ -65,7 +65,15 @@ public:
   // Entry points exercised by callers outside python_annotation.h.
   void preprocess_constructor_calls(const Json &node);
   void preprocess_method_calls(const Json &node);
-  void preprocess_function_calls(Json &root);
+  /// Sentinel recorded for a call-site argument this pass cannot type; never
+  /// a valid Python type name, so it can only block, never be annotated.
+  static const std::string &unresolved_arg_type()
+  {
+    static const std::string s = "<unresolved>";
+    return s;
+  }
+  /// @return true if this pass wrote at least one parameter annotation.
+  bool preprocess_function_calls(Json &root);
   void collect_function_call_arg_types(
     Json &node,
     std::map<std::pair<std::string, size_t>, std::set<std::string>>


### PR DESCRIPTION
Relational comparison of two unannotated Python parameters reported a
spurious CWE-469 same-object violation and a wrong verdict. The root cause is
in call-site parameter inference, not the comparison lowering: the pass ran
once, so types could not cross a call-graph edge.

Iterating it needs the conflict guard tightened, or a later round contradicts
an annotation an earlier one committed to. Comparisons whose operands stay
erased now over-approximate instead of ordering pointers.

Fixes #7254