### PR TITLE
[esbmc] Record violated properties on --show-cex BMC runs

### DIFF
--- a/regression/esbmc/github_7256-kind/main.c
+++ b/regression/esbmc/github_7256-kind/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+int main()
+{
+  unsigned n, i, s = 0;
+  __ESBMC_assume(n <= 3);
+
+  for (i = 0; i < n; i++)
+    s += 1;
+
+  assert(s != 2);
+  return 0;
+}

--- a/regression/esbmc/github_7256-kind/test.desc
+++ b/regression/esbmc/github_7256-kind/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--result-only --k-induction --show-cex
+^  FAILED +\[main\.assertion\.2\]  line 11  assertion s != 2$
+^\*\* 1 of 2 properties failed, 1 not checked$
+^VERIFICATION FAILED$
+\A(?![\s\S]*produced no model)[\s\S]*\Z

--- a/regression/esbmc/github_7256-showcex-trace/main.c
+++ b/regression/esbmc/github_7256-showcex-trace/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+unsigned int nondet_uint(void);
+int main(void)
+{
+  unsigned int n = nondet_uint();
+  unsigned int i, s = 0;
+  for (i = 0; i < n; i++)
+    s = s + 1;
+  assert(s == n);
+  return 0;
+}

--- a/regression/esbmc/github_7256-showcex-trace/test.desc
+++ b/regression/esbmc/github_7256-showcex-trace/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-induction --max-k-step 3 --show-cex
+^VERIFICATION UNKNOWN$
+^Violated property:$
+^  assertion s == n$
+\A(?![\s\S]*FAILED)[\s\S]*\Z

--- a/regression/esbmc/github_7256/main.c
+++ b/regression/esbmc/github_7256/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 3;
+  assert(x > 100);
+  assert(x != 3);
+  return 0;
+}

--- a/regression/esbmc/github_7256/test.desc
+++ b/regression/esbmc/github_7256/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--result-only --show-cex
+^  FAILED +\[main\.assertion\.1\]  line 6  assertion x > 100$
+^\*\* 1 of 2 properties failed, 1 not checked$
+^VERIFICATION FAILED$
+\A(?![\s\S]*produced no model)[\s\S]*\Z

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -538,19 +538,15 @@ void bmct::report_trace(smt_resultt &res, const symex_target_equationt &eq)
     // read, so there is no trace to build and dereferencing it would crash.
     if (!runtime_solver)
       break;
-    if (!bs && show_cex)
-    {
-      // --show-cex on an inductive-step or forward-condition SAT: that model
-      // starts from a havoc'd state, so it witnesses no violation of the
-      // program and must not reach a verdict (multi_property_check draws the
-      // same line at its `is ? Unknown : Failed`).
-      error_trace(*runtime_solver, eq);
-    }
-    else if (!is && !fc)
-    {
+    // An inductive-step or forward-condition model starts from a havoc'd
+    // state, so it witnesses no violation of the program and must not reach a
+    // verdict (multi_property_check draws the same line at its
+    // `is ? Unknown : Failed`). Printing that trace under --show-cex is a
+    // separate decision from recording it, so the two conditions are separate.
+    if (!is && !fc)
       record_violated_properties(*runtime_solver, eq);
+    if ((!bs && show_cex) || (!is && !fc))
       error_trace(*runtime_solver, eq);
-    }
     break;
 
   default:


### PR DESCRIPTION
`report_trace()` sent every `--show-cex` run into the arm intended for
inductive-step and forward-condition models, whose condition tests neither, so a
plain BMC run recorded no verdict and printed "0 properties failed" above
`VERIFICATION FAILED`. Recording and trace printing are now separate decisions,
leaving the havoc'd-state guard intact.

Fixes #7256
