### PR TITLE
[test] Pin IEEE multiply-by-zero in both operand orders

### DIFF
--- a/regression/esbmc/gcc_vector_float_scalar_mul/main.c
+++ b/regression/esbmc/gcc_vector_float_scalar_mul/main.c
@@ -1,0 +1,16 @@
+typedef float v4f __attribute__((vector_size(16)));
+
+/* vector-by-scalar, which gcc_vector_float_arith does not reach: the scalar
+ * operand is broadcast, so a fold returning it would type the result wrongly.
+ * Both operand orders, since a fold may inspect either side. */
+int main()
+{
+  v4f a = {1.5f, -2.5f, 3.5f, 4.5f};
+  v4f zr = a * 0.0f;
+  v4f zl = 0.0f * a;
+  v4f o = a * 1.0f;
+  __ESBMC_assert(zr[0] == 0.0f && zr[2] == 0.0f, "scalar zero on the right");
+  __ESBMC_assert(zl[0] == 0.0f && zl[2] == 0.0f, "scalar zero on the left");
+  __ESBMC_assert(o[1] == -2.5f, "scalar one broadcasts");
+  return 0;
+}

--- a/regression/esbmc/gcc_vector_float_scalar_mul/test.desc
+++ b/regression/esbmc/gcc_vector_float_scalar_mul/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/float_mul_zero_absorber/main.c
+++ b/regression/floats/float_mul_zero_absorber/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float(void);
+
+/* x * 0 is not 0 under IEEE 754: it is NaN when x is infinite or NaN
+ * (IEEE 754-2019 sec 7.2), and the sign of a zero product is the XOR of the
+ * operand signs (sec 6.3). Both operand orders, because a fold that inspects
+ * only one side is caught by only one of them. */
+int main()
+{
+  float i = nondet_float();
+  __ESBMC_assume(isinf(i));
+  assert(isnan(i * 0.0f));
+  assert(isnan(0.0f * i));
+
+  float n = nondet_float();
+  __ESBMC_assume(isnan(n));
+  assert(isnan(n * 0.0f));
+  assert(isnan(0.0f * n));
+
+  float a = nondet_float();
+  __ESBMC_assume(a < 0.0f && isfinite(a));
+  assert(signbit(a * 0.0f));
+  assert(signbit(0.0f * a));
+
+  return 0;
+}

--- a/regression/floats/float_mul_zero_absorber/test.desc
+++ b/regression/floats/float_mul_zero_absorber/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--floatbv
+^VERIFICATION SUCCESSFUL$
+\A(?![\s\S]*FAILED)[\s\S]*\Z

--- a/regression/floats/float_mul_zero_absorber_fail/main.c
+++ b/regression/floats/float_mul_zero_absorber_fail/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float(void);
+
+int main()
+{
+  float i = nondet_float();
+  __ESBMC_assume(isinf(i));
+  assert(i * 0.0f == 0.0f);
+  return 0;
+}

--- a/regression/floats/float_mul_zero_absorber_fail/test.desc
+++ b/regression/floats/float_mul_zero_absorber_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv
+^VERIFICATION FAILED$


### PR DESCRIPTION
`x * 0` was pinned by two incidental tests, each blind to one operand order:
`Float13` catches a fold that reads `side_1`, `Float-flags-simp1` one that reads
`side_2`, and neither test is about the absorber. This adds a dedicated case
covering NaN, infinity and zero-sign with symbolic operands in both orders, its
failing counterpart, and a vector-by-scalar case that `gcc_vector_float_arith`
does not reach.

Tests only; no source change. Each was mutation-checked against two unsound
folds (one reading each operand) and shown to fail on both.
