### PR TITLE
[esbmc] Report properties under --k-induction-parallel too

### DIFF
--- a/regression/k-induction-parallel/property_report_bug/main.c
+++ b/regression/k-induction-parallel/property_report_bug/main.c
@@ -1,0 +1,9 @@
+/* The per-property report, and the CWE line its rows carry, must appear under
+   --k-induction-parallel too: the base-case child holds the verdicts and is
+   the process whose result decides the run. */
+int main(void)
+{
+  int *p = 0;
+  *p = 42;
+  return 0;
+}

--- a/regression/k-induction-parallel/property_report_bug/test.desc
+++ b/regression/k-induction-parallel/property_report_bug/test.desc
@@ -1,0 +1,6 @@
+THOROUGH
+main.c
+--k-induction-parallel
+^  FAILED +\[main\.null-pointer-dereference\.1\]  line 7  dereference failure: NULL pointer$
+^\*\* 1 of 2 properties failed, 1 passed$
+^VERIFICATION FAILED$

--- a/regression/k-induction-parallel/property_report_safe/main.c
+++ b/regression/k-induction-parallel/property_report_safe/main.c
@@ -1,0 +1,11 @@
+/* A proven-safe parallel run: the deciding child carries no assertion
+   verdicts, so it reports no table. Pins that the verdict is still correct. */
+#include <assert.h>
+int main(void)
+{
+  unsigned n = 0;
+  while (n < 10)
+    n++;
+  assert(n == 10);
+  return 0;
+}

--- a/regression/k-induction-parallel/property_report_safe/test.desc
+++ b/regression/k-induction-parallel/property_report_safe/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--k-induction-parallel
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -3131,9 +3131,6 @@ void bmct::seed_property_verdicts(const symex_target_equationt &eq) const
 
 bool bmct::reports_final_verdict(smt_resultt res) const
 {
-  if (options.get_bool_option("k-induction-parallel"))
-    return false;
-
   const bool fc = options.get_bool_option("forward-condition");
   const bool is = options.get_bool_option("inductive-step");
 


### PR DESCRIPTION
`reports_final_verdict()` returned false outright whenever `k-induction-parallel`
was set, so a parallel run printed the counterexample and the verdict but not the
per-property table that sequential `--k-induction` prints — and with it the CWE
rows a user noticed were missing.

The per-phase rules below that guard already pick out the deciding process, so
removing it is enough: the base-case child holds the verdicts and reports when it
finds a bug, while the forward-condition and inductive-step children run with
`no-assertions` and stay silent because `report_property_verdicts` returns early
on an empty map. A proven-safe parallel run therefore still prints no table, as
before; that asymmetry with sequential mode is left alone here, since the
deciding child has no verdicts to report.
