### PR TITLE
[regression] Say why the BFS timeout budget still applies

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -598,10 +598,13 @@ set(_slow_regression_tests
     # "NameError: name 'Queue' is not defined" because aliased deque imports
     # were not resolved. With PR #5008 the alias fix and popleft/appendleft
     # support land, so ESBMC now reaches the real BFS symex (deque + set +
-    # 6-node graph), which does not converge under --incremental-bmc due to
-    # the __memcpy_impl loop in the list OM (string.c:278). These stay
-    # KNOWNBUG; the larger inner timeout lets testing_tool record the KNOWNBUG
-    # verdict instead of ctest hard-killing the run.
+    # 6-node graph). breadth_first_search still does not converge under
+    # --incremental-bmc, due to the __memcpy_impl loop in the list OM
+    # (string.c:278), and stays KNOWNBUG: the larger inner timeout lets
+    # testing_tool record the KNOWNBUG verdict instead of ctest hard-killing
+    # the run. breadth_first_search_fail is CORE since #7235 and reaches its
+    # VERIFICATION FAILED at ~123s on the DebugOpt Linux runner, so the 2x
+    # budget is what keeps it off the 120s cap -- removing it flaps the test.
     "regression/quixbugs/breadth_first_search"
     "regression/quixbugs/breadth_first_search_fail"
     # reverse_linked_list used to fast-crash with a SIGSEGV when comparing a


### PR DESCRIPTION
#7235 made `quixbugs/breadth_first_search_fail` CORE, but the slow-test entry
still reads "these stay KNOWNBUG" — the rationale that would justify dropping
the 2x budget. At ~123s against the 120s cap, that budget is now what keeps a
CORE test off the cap rather than what records a KNOWNBUG verdict.