### PR TITLE
[clang-c] Leave the for-init hoist's wrapper block unlocated at its close

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -5100,9 +5100,27 @@ of the patch, and the printer is exactly what the test reads.
 
 ### 115.4 Next
 
-The two three-test causes §114.2 deferred: the integer promotion missing at a
-comparison, and the array decay rendered as a cast rather than `&a[0]`. Both
-are spelling-level and neither has been reduced yet.
+The two three-test causes §114.2 deferred. The first reduces to two lines, and
+the trigger is not the comparison:
+
+```c
+__attribute__((aligned)) int g = 42;
+int main(void) { int p = 1; if (g == 42) p = 2; return p; }
+```
+
+```
+<         IF !((signed int)g == 42) THEN GOTO 1
+>         IF !(g == 42) THEN GOTO 1
+```
+
+Dropping the attribute makes the pair byte-identical, so what legacy emits is
+an *identity* cast: the alignment attribute leaves `g`'s type unequal to plain
+`signed int` in ESBMC's type model, and `gen_typecast_arithmetic` casts on that
+inequality. That puts it in §113.3's class rather than the promotion class it
+was tagged as — decide whether to mirror it before writing a slice.
+
+The array decay rendered as a cast rather than `&a[0]` (`github_6966_fail`,
+`memset-const-2`) has not been reduced yet.
 
 
 ## 114. The two-stage census §113.4 asked for — the residue is 24, not 133

--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -5013,6 +5013,98 @@ and the `migrate_expr` renaming warning. The measured 133 residue on the pinned
 sample wants a fresh cause census before another arm is written — the old one
 is stale, and §113.1 shows it was reading the wrong stage.
 
+## 115. §114.2's dominant cause closed — the hoist's wrapper block had no close
+## (2026-08-23)
+
+§114.1 diagnosed the 14-test `DEAD` divergence as `hoist_for_init`'s
+provenance and named `convert_block`'s `unwind_destructor_stack` as the site
+that reads it. The mechanism is one step earlier than that, and it is not a
+provenance choice at all.
+
+### 115.1 A default-constructed `locationt` is not nil
+
+`hoist_for_init` builds the wrapper block's close location as
+
+```cpp
+locationt end_location;
+if (!is_nil_expr(f.body) && is_code_block2t(f.body))
+  end_location = to_code_block2t(f.body).end_location;
+```
+
+and hands it to `code_block2tc`. When the loop body is not a block the variable
+is left default-constructed — and `irept::is_nil()` is `id() == "nil"`, so a
+default-constructed `locationt` (id `""`) is *empty but not nil*.
+`migrate_expr_back` guards only on nil:
+
+```cpp
+if (ref2.end_location.is_not_nil())
+  block.end_location(ref2.end_location);
+```
+
+so it wrote an empty `#end_location` onto the legacy block. `convert_block`
+then stamped that empty location on every destructor it unwound, and
+`goto_programt::output` renders an empty location as blank where it renders a
+nil one as `no location`. The legacy hoist never calls `end_location(...)` at
+all on this shape, which is why the two disagreed.
+
+`goto_convert_functions.cpp:1834-1839` already spells the correct idiom for the
+same question about the same field, with the same `else end_location.make_nil()`
+arm. Mirroring it is the whole patch.
+
+### 115.2 Result
+
+Reproducer (§114.1's, unchanged), `--no-irep2-native-body` on both sides:
+
+```
+<         // 48 no location
+>         // 48
+```
+
+is byte-identical after the patch, and a block-bodied control
+(`for (...) { s = s + i; }`) was byte-identical before and after — the shape
+the legacy hoist does set the close location on.
+
+Two-stage census re-run on a stride-8 list of `regression/esbmc` (233 entries,
+226 with a `.c` source), `--clang-c-irep2-adjust-only` against the legacy pass,
+blank lines and timing lines ignored:
+
+| goto program | before | after |
+|---|---:|---:|
+| same | 202 | **210** |
+| diff | **24** | **16** |
+| crash | 0 | 0 |
+
+Eight tests converge; none diverges that did not before. The 24 matches §114's
+count on the same suite, so the samples are comparable. Ten of those 24 carried
+a `no location` line in their diff; the eight that converged are the ones where
+it was the *only* cause, and the two that remain
+(`00_aiob_4_true-unreach-call`, `github_2572_2`) show it only as instruction
+renumbering downstream of a different divergence, not as a location mismatch of
+their own.
+
+The residue of 16 is the §114 tail, unmoved and untouched by this patch:
+integer promotion missing at a comparison, array decay rendered as a cast
+rather than `&a[0]`, the function-pointer identity cast §113.3 rules a
+"do not mirror", struct padding in an aggregate initialiser, and
+`POINTER_OFFSET` spelling.
+
+### 115.3 The gate, and what pins it
+
+`regression/esbmc/irep2_only_for_hoist_dead_location` asserts the `no location`
+line adjacent to the loop variable's `DEAD` under
+`--goto-functions-only --clang-c-irep2-adjust-only`. It is a positive regex, so
+it is mutation-checked the only way that means anything here: run it against
+the pre-patch binary, where the line reads `// 48` and the regex does not
+match. §39.1's fifth failure mode does not apply — the mutation is the absence
+of the patch, and the printer is exactly what the test reads.
+
+### 115.4 Next
+
+The two three-test causes §114.2 deferred: the integer promotion missing at a
+comparison, and the array decay rendered as a cast rather than `&a[0]`. Both
+are spelling-level and neither has been reduced yet.
+
+
 ## 114. The two-stage census §113.4 asked for — the residue is 24, not 133
 ## (2026-08-22)
 

--- a/regression/esbmc/irep2_only_for_hoist_dead_location/main.c
+++ b/regression/esbmc/irep2_only_for_hoist_dead_location/main.c
@@ -1,0 +1,9 @@
+/* A non-block for-body leaves the hoisted wrapper block with no end location,
+   so the DEAD unwound at its close is unlocated. */
+int main(void)
+{
+  int s = 0;
+  for (int i = 0; i < 3; i++)
+    s = s + i;
+  return s;
+}

--- a/regression/esbmc/irep2_only_for_hoist_dead_location/test.desc
+++ b/regression/esbmc/irep2_only_for_hoist_dead_location/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--goto-functions-only --clang-c-irep2-adjust-only
+//\s*\d+ no location\n[^\n]*DEAD [^\n]*@F@main@i$

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -402,9 +402,14 @@ void clang_c_adjust_irep2::hoist_for_init(expr2tc &expr)
   if (is_nil_expr(f.init))
     return;
 
+  // A default-constructed locationt is empty but not nil, and migrate_expr_back
+  // guards only on nil: left default it reaches convert_block, which stamps it
+  // on every destructor it unwinds. Same idiom as goto_convert_functions.cpp.
   locationt end_location;
   if (!is_nil_expr(f.body) && is_code_block2t(f.body))
     end_location = to_code_block2t(f.body).end_location;
+  else
+    end_location.make_nil();
 
   const expr2tc bare =
     code_for2tc(expr2tc(), f.cond, f.iter, f.body, f.location);


### PR DESCRIPTION
Closes the dominant divergence of the C IREP2 hop-off census (`docs/roadmap/scope-clang-c-irep2.md` §114.2).

`hoist_for_init` left the wrapper block's close location default-constructed when the loop body was not a block. A default-constructed `locationt` is empty but not nil, so `migrate_expr_back`'s nil guard let it through and `convert_block` stamped it on every destructor it unwound — a blank `DEAD` location where the legacy hoist leaves none. Mirrors the `make_nil` idiom `goto_convert_functions.cpp` already uses for the same field.

Stride-8 census over `regression/esbmc`, `--clang-c-irep2-adjust-only` vs the legacy pass: goto-program divergences 24 → 16, none new. `regression/esbmc` 1853/1853.

Refs #4715.
