### PR TITLE
[util] Fold a relation between two boolean constants

### DIFF
--- a/docs/roadmap/jbmc-goto-binary-poc-plan.md
+++ b/docs/roadmap/jbmc-goto-binary-poc-plan.md
@@ -963,6 +963,32 @@ programs that *use* strings, not to every program that merely links
 to fail and JBMC does not. That is a known pointer-model difference (§5), not a
 JVM-semantics gap.
 
+#### 4.1.8 The `<clinit>` recursion was a simplifier gap (Run 10)
+
+**Resolved: both fixtures now verify with no `--unwind` at all.** The
+recursion was never unbounded in the program. `clinit_wrapper` guards its
+body with `clinit_already_run == 0` and sets the flag to 1 before calling
+`<clinit>`, which calls the wrapper back, so one round trip ends it. Symex
+propagated the flag correctly -- `--symex-trace` shows the guard renaming to
+`1 != 0` -- but `do_simplify` left that constant comparison standing, so
+neither branch was decided and symex re-entered the body ~1000 times.
+
+The cause is in `simplify_relations` (`src/util/expr/expr_simplifier.cpp`):
+it dispatches the constant-vs-constant fold on the *operand* type and had
+cases for bv, fixedbv, floatbv and pointer, but none for `bool`. Two
+`constant_bool` operands therefore fell through unfolded. Java reaches this
+where C does not, because C's `_Bool b; b == 0` widens `b` to an integer
+first, making the comparison a bv one; CBMC's Java lowering compares two
+booleans directly.
+
+With the `bool` case added, `T4Virtual` verifies SUCCESSFUL in 0.7 s with no
+bound and unwinding assertions on, and `T4VirtualFail` still reports FAILED.
+The §4.1.7 caveat above is therefore discharged: the SUCCESSFUL verdict is no
+longer "ESBMC agrees with JBMC at this bound". Note the caveat was real --
+recursion truncation is silent, since ESBMC's unwinding assertions cover
+loops, not recursive calls, so the old `--unwind 6` verdict would not have
+announced a too-small bound.
+
 > **Fixture caveat found in passing.** A `symtab2gb` binary has no
 > `__CPROVER__start`, so ESBMC wraps the *boilerplate* main and the fixture's
 > own `main` is never called — the warning at `goto_program.cpp:262` says so,

--- a/regression/goto-transcoder/jbmc_virtual_dispatch/test.desc
+++ b/regression/goto-transcoder/jbmc_virtual_dispatch/test.desc
@@ -1,4 +1,4 @@
 CORE
 jbmc_virtual_dispatch.goto
---binary --unwind 6 --force-malloc-success
+--binary --force-malloc-success
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-transcoder/jbmc_virtual_dispatch_fail/test.desc
+++ b/regression/goto-transcoder/jbmc_virtual_dispatch_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 jbmc_virtual_dispatch_fail.goto
---binary --unwind 6 --force-malloc-success
+--binary --force-malloc-success
 ^VERIFICATION FAILED$

--- a/src/util/expr/expr_simplifier.cpp
+++ b/src/util/expr/expr_simplifier.cpp
@@ -3484,6 +3484,92 @@ expr2tc address_of2t::do_simplify() const
   return expr2tc();
 }
 
+/// Fold a relation between two constants. The constant kind and the comparison
+/// itself are per-domain, so this dispatches on the operand type; C compares
+/// two booleans only after widening them to int, but a Java goto binary
+/// compares them directly. Split out of simplify_relations, whose own decision
+/// count is already over the complexity gate's threshold.
+template <template <typename> class TFunctor>
+static expr2tc simplify_constant_relation(
+  const type2tc &type,
+  const expr2tc &side_1,
+  const expr2tc &side_2)
+{
+  expr2tc simpl_res;
+
+  if (is_bv_type(side_1) || is_bv_type(side_2))
+  {
+    std::function<bool(const expr2tc &)> is_constant =
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
+
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
+
+    simpl_res =
+      TFunctor<BigInt &>::simplify(side_1, side_2, is_constant, get_value);
+  }
+  else if (is_fixedbv_type(side_1) || is_fixedbv_type(side_2))
+  {
+    std::function<bool(const expr2tc &)> is_constant =
+      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
+
+    std::function<fixedbvt &(expr2tc &)> get_value =
+      [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
+
+    simpl_res =
+      TFunctor<fixedbvt &>::simplify(side_1, side_2, is_constant, get_value);
+  }
+  else if (is_floatbv_type(side_1) || is_floatbv_type(side_2))
+  {
+    std::function<bool(const expr2tc &)> is_constant =
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+
+    std::function<ieee_floatt &(expr2tc &)> get_value =
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
+
+    simpl_res =
+      TFunctor<ieee_floatt &>::simplify(side_1, side_2, is_constant, get_value);
+  }
+  else if (is_bool_type(side_1) || is_bool_type(side_2))
+  {
+    std::function<bool(const expr2tc &)> is_constant =
+      (bool (*)(const expr2tc &)) & is_constant_bool2t;
+
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
+      return to_constant_bool2t(c).value;
+    };
+
+    simpl_res =
+      TFunctor<bool &>::simplify(side_1, side_2, is_constant, get_value);
+  }
+  else if (is_pointer_type(side_1) || is_pointer_type(side_2))
+  {
+    std::function<bool(const expr2tc &)> is_constant =
+      [&](const expr2tc &t) -> bool {
+      if (is_pointer_type(t) && is_symbol2t(t))
+      {
+        symbol2t s = to_symbol2t(t);
+        if (s.thename == "NULL")
+          return true;
+      }
+      return false;
+    };
+
+    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int {
+      return 0xbadbeef;
+    };
+
+    simpl_res = TFunctor<int>::simplify(side_1, side_2, is_constant, get_value);
+  }
+  else
+    return expr2tc();
+
+  return typecast_check_return(type, simpl_res);
+}
+
 template <template <typename> class TFunctor, typename constructor>
 static expr2tc simplify_relations(
   const type2tc &type,
@@ -3559,71 +3645,8 @@ static expr2tc simplify_relations(
     return expr2tc();
   }
 
-  expr2tc simpl_res;
-
-  if (is_bv_type(simplified_side_1) || is_bv_type(simplified_side_2))
-  {
-    std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
-
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
-
-    simpl_res = TFunctor<BigInt &>::simplify(
-      simplified_side_1, simplified_side_2, is_constant, get_value);
-  }
-  else if (
-    is_fixedbv_type(simplified_side_1) || is_fixedbv_type(simplified_side_2))
-  {
-    std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
-
-    std::function<fixedbvt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
-
-    simpl_res = TFunctor<fixedbvt &>::simplify(
-      simplified_side_1, simplified_side_2, is_constant, get_value);
-  }
-  else if (
-    is_floatbv_type(simplified_side_1) || is_floatbv_type(simplified_side_2))
-  {
-    std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
-
-    std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
-
-    simpl_res = TFunctor<ieee_floatt &>::simplify(
-      simplified_side_1, simplified_side_2, is_constant, get_value);
-  }
-  else if (
-    is_pointer_type(simplified_side_1) || is_pointer_type(simplified_side_2))
-  {
-    std::function<bool(const expr2tc &)> is_constant =
-      [&](const expr2tc &t) -> bool {
-      if (is_pointer_type(t) && is_symbol2t(t))
-      {
-        symbol2t s = to_symbol2t(t);
-        if (s.thename == "NULL")
-          return true;
-      }
-      return false;
-    };
-
-    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int {
-      return 0xbadbeef;
-    };
-
-    simpl_res = TFunctor<int>::simplify(
-      simplified_side_1, simplified_side_2, is_constant, get_value);
-  }
-  else
-    return expr2tc();
-
-  return typecast_check_return(type, simpl_res);
+  return simplify_constant_relation<TFunctor>(
+    type, simplified_side_1, simplified_side_2);
 }
 
 template <template <typename> class TFunctor, typename constructor>

--- a/src/util/expr/expr_simplifier.cpp
+++ b/src/util/expr/expr_simplifier.cpp
@@ -1,4 +1,5 @@
 #include <limits>
+#include <type_traits>
 
 #include <util/arith/arith_tools.h>
 #include <util/expr/base_type.h>
@@ -4082,6 +4083,18 @@ expr2tc notequal2t::do_simplify() const
   return simplify_relations<Notequaltor, notequal2t>(type, side_1, side_2);
 }
 
+/// A bool constant is never negative, and GCC rejects `bool < 0` outright
+/// (-Wbool-compare), so the sign shortcut below has to be skipped for the
+/// bool instantiation rather than merely evaluate to false.
+template <class T>
+static bool is_negative_constant(const T &v)
+{
+  if constexpr (std::is_same_v<std::remove_cv_t<T>, bool>)
+    return false;
+  else
+    return v < 0;
+}
+
 template <class constant_type>
 struct Lessthantor
 {
@@ -4095,7 +4108,7 @@ struct Lessthantor
     if (is_constant(op1))
     {
       expr2tc c1 = op1;
-      if ((get_value(c1) < 0) && is_unsignedbv_type(op2))
+      if (is_negative_constant(get_value(c1)) && is_unsignedbv_type(op2))
         return gen_true_expr();
     }
 
@@ -4169,7 +4182,7 @@ struct Greaterthantor
     if (is_constant(op2))
     {
       expr2tc c2 = op2;
-      if ((get_value(c2) < 0) && is_unsignedbv_type(op1))
+      if (is_negative_constant(get_value(c2)) && is_unsignedbv_type(op1))
         return gen_true_expr();
     }
 

--- a/unit/util/simplify2t.test.cpp
+++ b/unit/util/simplify2t.test.cpp
@@ -1856,6 +1856,29 @@ TEST_CASE("int->bool->int does not fold", "[typecast][bool]")
 
 // TODO: Tests that should be valid but... not yet!
 
+TEST_CASE("Boolean constants compare: true != false", "[relation][bool]")
+{
+  const expr2tc expr = notequal2tc(gen_true_expr(), gen_false_expr());
+  const expr2tc result = expr->simplify();
+  REQUIRE(is_constant_bool2t(result));
+  REQUIRE(to_constant_bool2t(result).value);
+}
+TEST_CASE("Boolean constants compare: true == false", "[relation][bool]")
+{
+  const expr2tc expr = equality2tc(gen_true_expr(), gen_false_expr());
+  const expr2tc result = expr->simplify();
+  REQUIRE(is_constant_bool2t(result));
+  REQUIRE(!to_constant_bool2t(result).value);
+}
+TEST_CASE("A symbolic boolean comparison is left alone", "[relation][bool]")
+{
+  const expr2tc b = symbol2tc(get_bool_type(), "b");
+  const expr2tc expr = notequal2tc(b, gen_false_expr());
+  // simplify() returns nil when it changes nothing.
+  const expr2tc result = expr->simplify();
+  REQUIRE((is_nil_expr(result) || !is_constant_bool2t(result)));
+}
+
 #if 0
 TEST_CASE("Division simplification: 0 / x = 0", "[arithmetic][div]")
 {


### PR DESCRIPTION
`simplify_relations` dispatched the constant fold on the operand type with no
`bool` case, so `true != false` stood unfolded and symex could decide neither
branch of a guard over it, unwinding JBMC's `clinit_wrapper` ~1000 times. The
operand dispatch moves into its own function to stay under the complexity gate.
