### PR TITLE
[python] Extend dynamic typing to tagged arithmetic and elif chains

### DIFF
--- a/regression/python/dynamic_type_branch_join_knownbug/main.py
+++ b/regression/python/dynamic_type_branch_join_knownbug/main.py
@@ -1,7 +1,9 @@
-# Runtime type diverges across branches (int vs str). ESBMC does not yet
-# support arithmetic on a variable whose type differs per branch, so it
-# refuses with a clean error. Correct verdict, once supported: VERIFICATION
-# FAILED ("ab" == 3 is False).
+# Runtime type diverges across branches (int vs str). '-'/'/' between two
+# such variables works now, but '+' still refuses with a clean error, since
+# a genuine str+str path would need string concatenation between two
+# tagged operands (unlike '-'/'/', which never apply to str in Python).
+# Correct verdict, once '+' is supported: VERIFICATION FAILED ("ab" == 3 is
+# False).
 cond = nondet_bool()
 if cond:
     x = 1

--- a/regression/python/dynamic_type_elif_dangling_no_tag/main.py
+++ b/regression/python/dynamic_type_elif_dangling_no_tag/main.py
@@ -1,0 +1,9 @@
+# No final else, so x should stay a plain int, not get tagged.
+cond1 = nondet_bool()
+cond2 = nondet_bool()
+if cond1:
+    x = 1
+    assert x == 1
+elif cond2:
+    x = 2
+    assert x == 2

--- a/regression/python/dynamic_type_elif_dangling_no_tag/main.py
+++ b/regression/python/dynamic_type_elif_dangling_no_tag/main.py
@@ -1,9 +1,16 @@
-# No final else, so x should stay a plain int, not get tagged.
+# No final else, so x/y should stay plain scalars, not get tagged. x + y
+# would fail to convert if both got tagged (Add between two tagged
+# operands isn't supported), so this pins the untagged case rather than
+# checking a value that would hold either way.
 cond1 = nondet_bool()
 cond2 = nondet_bool()
 if cond1:
     x = 1
-    assert x == 1
+    y = 10
+    z = x + y
+    assert z == 11
 elif cond2:
-    x = 2
-    assert x == 2
+    x = "a"
+    y = "b"
+    z = x + y
+    assert z == "ab"

--- a/regression/python/dynamic_type_elif_dangling_no_tag/test.desc
+++ b/regression/python/dynamic_type_elif_dangling_no_tag/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_elif_join/main.py
+++ b/regression/python/dynamic_type_elif_join/main.py
@@ -1,0 +1,10 @@
+cond1 = nondet_bool()
+cond2 = nondet_bool()
+if cond1:
+    x = 1
+elif cond2:
+    x = 2
+else:
+    x = "a"
+
+assert x == 1 or x == 2 or x == "a"

--- a/regression/python/dynamic_type_elif_join/test.desc
+++ b/regression/python/dynamic_type_elif_join/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_elif_join_deep/main.py
+++ b/regression/python/dynamic_type_elif_join_deep/main.py
@@ -1,0 +1,13 @@
+cond1 = nondet_bool()
+cond2 = nondet_bool()
+cond3 = nondet_bool()
+if cond1:
+    x = 1
+elif cond2:
+    x = 2
+elif cond3:
+    x = "a"
+else:
+    x = "b"
+
+assert x == 1 or x == 2 or x == "a" or x == "b"

--- a/regression/python/dynamic_type_elif_join_deep/test.desc
+++ b/regression/python/dynamic_type_elif_join_deep/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_elif_join_deep_fail/main.py
+++ b/regression/python/dynamic_type_elif_join_deep_fail/main.py
@@ -1,0 +1,13 @@
+cond1 = nondet_bool()
+cond2 = nondet_bool()
+cond3 = nondet_bool()
+if cond1:
+    x = 1
+elif cond2:
+    x = 2
+elif cond3:
+    x = "a"
+else:
+    x = "b"
+
+assert x == 1

--- a/regression/python/dynamic_type_elif_join_deep_fail/test.desc
+++ b/regression/python/dynamic_type_elif_join_deep_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_elif_join_fail/main.py
+++ b/regression/python/dynamic_type_elif_join_fail/main.py
@@ -1,0 +1,10 @@
+cond1 = nondet_bool()
+cond2 = nondet_bool()
+if cond1:
+    x = 1
+elif cond2:
+    x = 2
+else:
+    x = "a"
+
+assert x == 1

--- a/regression/python/dynamic_type_elif_join_fail/test.desc
+++ b/regression/python/dynamic_type_elif_join_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_nested_then_join/main.py
+++ b/regression/python/dynamic_type_nested_then_join/main.py
@@ -1,0 +1,11 @@
+cond1 = nondet_bool()
+cond2 = nondet_bool()
+if cond1:
+    if cond2:
+        x = 1
+    else:
+        x = 2
+else:
+    x = "a"
+
+assert x == 1 or x == 2 or x == "a"

--- a/regression/python/dynamic_type_nested_then_join/test.desc
+++ b/regression/python/dynamic_type_nested_then_join/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_nested_then_join_fail/main.py
+++ b/regression/python/dynamic_type_nested_then_join_fail/main.py
@@ -1,0 +1,11 @@
+cond1 = nondet_bool()
+cond2 = nondet_bool()
+if cond1:
+    if cond2:
+        x = 1
+    else:
+        x = 2
+else:
+    x = "a"
+
+assert x == 1

--- a/regression/python/dynamic_type_nested_then_join_fail/test.desc
+++ b/regression/python/dynamic_type_nested_then_join_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_div_dyn/main.py
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 10
+    y = 2
+    z = x / y
+    assert z == 5
+else:
+    x = "a"
+    y = "b"

--- a/regression/python/dynamic_type_scalar_tag_div_dyn/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_div_dyn_catch/main.py
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn_catch/main.py
@@ -1,0 +1,15 @@
+cond = nondet_bool()
+if cond:
+    x = 10
+    y = 0
+else:
+    x = "a"
+    y = "b"
+
+if cond:
+    caught = 0
+    try:
+        z = x / y
+    except ZeroDivisionError:
+        caught = 1
+    assert caught == 1

--- a/regression/python/dynamic_type_scalar_tag_div_dyn_catch/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn_catch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_div_dyn_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn_fail/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 10
+    y = 2
+    z = x / y
+    assert z == 6
+else:
+    x = "a"
+    y = "b"

--- a/regression/python/dynamic_type_scalar_tag_div_dyn_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_div_dyn_typeerror/main.py
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn_typeerror/main.py
@@ -1,0 +1,11 @@
+# x/y diverge in opposite polarity, so x / y is a num/str mismatch
+# either way, an uncaught TypeError regardless of cond.
+cond = nondet_bool()
+if cond:
+    x = 5
+    y = "b"
+else:
+    x = "a"
+    y = 3
+
+z = x / y

--- a/regression/python/dynamic_type_scalar_tag_div_dyn_typeerror/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_div_dyn_typeerror/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_sub_dyn/main.py
+++ b/regression/python/dynamic_type_scalar_tag_sub_dyn/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+    y = 3
+    z = x - y
+    assert z == 2
+else:
+    x = "a"
+    y = "b"

--- a/regression/python/dynamic_type_scalar_tag_sub_dyn/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_sub_dyn/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_sub_dyn_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_sub_dyn_fail/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+    y = 3
+    z = x - y
+    assert z == 3
+else:
+    x = "a"
+    y = "b"

--- a/regression/python/dynamic_type_scalar_tag_sub_dyn_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_sub_dyn_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_sub_dyn_typeerror/main.py
+++ b/regression/python/dynamic_type_scalar_tag_sub_dyn_typeerror/main.py
@@ -1,0 +1,11 @@
+# x/y diverge in opposite polarity, so x - y is a num/str mismatch
+# either way, an uncaught TypeError regardless of cond.
+cond = nondet_bool()
+if cond:
+    x = 5
+    y = "b"
+else:
+    x = "a"
+    y = 3
+
+z = x - y

--- a/regression/python/dynamic_type_scalar_tag_sub_dyn_typeerror/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_sub_dyn_typeerror/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/scalar.c
+++ b/src/c2goto/library/python/scalar.c
@@ -187,3 +187,35 @@ __ESBMC_HIDE:;
   return tagged_is_left ? (double)tagged_val / (double)value
                         : (double)value / (double)tagged_val;
 }
+
+// Both operands tagged, so lhs/rhs already match the AST order.
+long long __python_scalar_sub_num_dyn(
+  const PyObject *lhs,
+  int lhs_is_num,
+  const PyObject *rhs,
+  int rhs_is_num)
+{
+__ESBMC_HIDE:;
+  __ESBMC_assert(
+    lhs && rhs && lhs_is_num && rhs_is_num,
+    "TypeError: unsupported operand type(s) for -");
+  if (!lhs || !rhs || !lhs_is_num || !rhs_is_num)
+    return 0;
+  return *(const long long *)lhs->value - *(const long long *)rhs->value;
+}
+
+double __python_scalar_div_num_dyn(
+  const PyObject *lhs,
+  int lhs_is_num,
+  const PyObject *rhs,
+  int rhs_is_num)
+{
+__ESBMC_HIDE:;
+  __ESBMC_assert(
+    lhs && rhs && lhs_is_num && rhs_is_num,
+    "TypeError: unsupported operand type(s) for /");
+  if (!lhs || !rhs || !lhs_is_num || !rhs_is_num)
+    return 0.0;
+  return (double)(*(const long long *)lhs->value) /
+         (double)(*(const long long *)rhs->value);
+}

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -76,6 +76,44 @@ classify_branch_literal_assigns(const nlohmann::json &block)
   return types;
 }
 
+// Recursively collects, per name, the literal kinds an elif chain's leaves
+// assign it. Returns false for a dangling elif with no final else.
+bool collect_orelse_literal_kinds(
+  const nlohmann::json &orelse,
+  std::unordered_map<std::string, std::unordered_set<std::string>> &kinds,
+  std::unordered_map<std::string, int> &leaf_count,
+  int &leaf_total)
+{
+  if (
+    orelse.is_array() && orelse.size() == 1 && orelse[0].is_object() &&
+    orelse[0].value("_type", "") == "If")
+  {
+    const auto &elif = orelse[0];
+    if (!elif.contains("orelse") || elif["orelse"].empty())
+      return false;
+
+    leaf_total++;
+    if (elif.contains("body"))
+      for (const auto &[name, kind] :
+           classify_branch_literal_assigns(elif["body"]))
+      {
+        kinds[name].insert(kind);
+        leaf_count[name]++;
+      }
+
+    return collect_orelse_literal_kinds(
+      elif["orelse"], kinds, leaf_count, leaf_total);
+  }
+
+  leaf_total++;
+  for (const auto &[name, kind] : classify_branch_literal_assigns(orelse))
+  {
+    kinds[name].insert(kind);
+    leaf_count[name]++;
+  }
+  return true;
+}
+
 // Classifies a single `return <literal>` statement: "num", "str", or "" if
 // it isn't a literal return.
 std::string classify_return_literal_kind(const nlohmann::json &ret_stmt)
@@ -144,12 +182,23 @@ std::unordered_set<std::string> dynamic_type_handler::detect_dynamic_type_names(
 
   if (!if_node.contains("orelse") || if_node["orelse"].empty())
     return dynamic_type_names;
-  auto else_types = classify_branch_literal_assigns(if_node["orelse"]);
 
-  for (const auto &[name, then_kind] : then_types)
+  std::unordered_map<std::string, std::unordered_set<std::string>> kinds;
+  std::unordered_map<std::string, int> leaf_count;
+  int leaf_total = 1; // the "then" branch is the first leaf
+  for (const auto &[name, kind] : then_types)
   {
-    auto it = else_types.find(name);
-    if (it == else_types.end() || it->second == then_kind)
+    kinds[name].insert(kind);
+    leaf_count[name]++;
+  }
+
+  if (!collect_orelse_literal_kinds(
+        if_node["orelse"], kinds, leaf_count, leaf_total))
+    return dynamic_type_names;
+
+  for (const auto &[name, kind_set] : kinds)
+  {
+    if (leaf_count[name] != leaf_total || kind_set.size() < 2)
       continue;
 
     symbol_id sid = converter_.create_symbol_id();

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -593,10 +593,18 @@ exprt dynamic_type_handler::handle_arithmetic(
   // Equality can settle a type_id mismatch without knowing either type;
   // arithmetic cannot, since it needs the concrete type to pick an operation.
   if (lhs_tagged && rhs_tagged)
+  {
+    // '+' could be str concatenation, which needs a runtime size on both
+    // sides -- left unsupported. '-'/'/' never apply to str in Python.
+    if (op == "Sub")
+      return build_sub_tagged(lhs, rhs);
+    if (op == "Div")
+      return build_div_tagged(lhs, rhs, location);
     throw std::runtime_error(
       "'" + op +
       "' between two dynamically-typed variables directly is "
       "not yet supported");
+  }
 
   if (op == "Add")
     return lhs_tagged ? build_add_literal(lhs, rhs, /*tagged_is_left=*/true)
@@ -609,6 +617,72 @@ exprt dynamic_type_handler::handle_arithmetic(
   assert(op == "Div" && "unexpected operator routed to handle_arithmetic");
   return lhs_tagged ? build_div_literal(lhs, rhs, true, location)
                     : build_div_literal(rhs, lhs, false, location);
+}
+
+exprt dynamic_type_handler::build_sub_tagged(const exprt &lhs, const exprt &rhs)
+{
+  const symbolt *sub_func =
+    converter_.symbol_table().find_symbol("c:@F@__python_scalar_sub_num_dyn");
+  assert(sub_func && "__python_scalar_sub_num_dyn not found in symbol table");
+
+  exprt lhs_type_id = build_member(lhs, "type_id", size_type());
+  exprt rhs_type_id = build_member(rhs, "type_id", size_type());
+  exprt lhs_is_num = build_typecast(
+    type_handler_.tagged_scalar_type_matches(lhs_type_id, long_long_int_type()),
+    int_type());
+  exprt rhs_is_num = build_typecast(
+    type_handler_.tagged_scalar_type_matches(rhs_type_id, long_long_int_type()),
+    int_type());
+
+  return build_call_expr(
+    *sub_func,
+    signedbv_typet(config.ansi_c.long_long_int_width),
+    {build_address_of(lhs), lhs_is_num, build_address_of(rhs), rhs_is_num});
+}
+
+exprt dynamic_type_handler::build_div_tagged(
+  const exprt &lhs,
+  const exprt &rhs,
+  const locationt &location)
+{
+  const symbolt *div_func =
+    converter_.symbol_table().find_symbol("c:@F@__python_scalar_div_num_dyn");
+  assert(div_func && "__python_scalar_div_num_dyn not found in symbol table");
+
+  exprt lhs_type_id = build_member(lhs, "type_id", size_type());
+  exprt rhs_type_id = build_member(rhs, "type_id", size_type());
+  exprt lhs_is_num =
+    type_handler_.tagged_scalar_type_matches(lhs_type_id, long_long_int_type());
+  exprt rhs_is_num =
+    type_handler_.tagged_scalar_type_matches(rhs_type_id, long_long_int_type());
+
+  // A catchable raise, not an assert, so it's guarded only when both
+  // operands are numeric.
+  exprt rhs_numeric_value = build_dereference(
+    build_typecast(
+      build_member(rhs, "value", pointer_typet(empty_typet())),
+      pointer_typet(signedbv_typet(config.ansi_c.long_long_int_width))),
+    signedbv_typet(config.ansi_c.long_long_int_width));
+  exprt is_zero = build_equal(
+    rhs_numeric_value, from_integer(BigInt(0), rhs_numeric_value.type()));
+
+  exprt raise = converter_.get_exception_handler().gen_exception_raise(
+    "ZeroDivisionError", "division by zero");
+  code_expressiont throw_code(raise);
+
+  code_ifthenelset guard;
+  guard.cond() = build_and(build_and(lhs_is_num, rhs_is_num), is_zero);
+  guard.then_case() = throw_code;
+  guard.location() = location;
+  converter_.add_instruction(guard);
+
+  return build_call_expr(
+    *div_func,
+    double_type(),
+    {build_address_of(lhs),
+     build_typecast(lhs_is_num, int_type()),
+     build_address_of(rhs),
+     build_typecast(rhs_is_num, int_type())});
 }
 
 exprt dynamic_type_handler::build_isinstance_check(

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -76,37 +76,34 @@ classify_branch_literal_assigns(const nlohmann::json &block)
   return types;
 }
 
-// Recursively collects, per name, the literal kinds an elif chain's leaves
-// assign it. Returns false for a dangling elif with no final else.
-bool collect_orelse_literal_kinds(
-  const nlohmann::json &orelse,
+// Recursively collects, per name, the literal kinds assigned to it across
+// every leaf reachable from `block` -- following a nested If (an elif in
+// orelse, or a plain nested if/else in body) into both of its arms.
+// Returns false if any such nested If is dangling (no final else).
+bool collect_branch_literal_kinds(
+  const nlohmann::json &block,
   std::unordered_map<std::string, std::unordered_set<std::string>> &kinds,
   std::unordered_map<std::string, int> &leaf_count,
   int &leaf_total)
 {
   if (
-    orelse.is_array() && orelse.size() == 1 && orelse[0].is_object() &&
-    orelse[0].value("_type", "") == "If")
+    block.is_array() && block.size() == 1 && block[0].is_object() &&
+    block[0].value("_type", "") == "If")
   {
-    const auto &elif = orelse[0];
-    if (!elif.contains("orelse") || elif["orelse"].empty())
+    const auto &nested = block[0];
+    if (
+      !nested.contains("body") || !nested.contains("orelse") ||
+      nested["orelse"].empty())
       return false;
 
-    leaf_total++;
-    if (elif.contains("body"))
-      for (const auto &[name, kind] :
-           classify_branch_literal_assigns(elif["body"]))
-      {
-        kinds[name].insert(kind);
-        leaf_count[name]++;
-      }
-
-    return collect_orelse_literal_kinds(
-      elif["orelse"], kinds, leaf_count, leaf_total);
+    return collect_branch_literal_kinds(
+             nested["body"], kinds, leaf_count, leaf_total) &&
+           collect_branch_literal_kinds(
+             nested["orelse"], kinds, leaf_count, leaf_total);
   }
 
   leaf_total++;
-  for (const auto &[name, kind] : classify_branch_literal_assigns(orelse))
+  for (const auto &[name, kind] : classify_branch_literal_assigns(block))
   {
     kinds[name].insert(kind);
     leaf_count[name]++;
@@ -175,24 +172,17 @@ std::unordered_set<std::string> dynamic_type_handler::detect_dynamic_type_names(
 
   if (!if_node.contains("body"))
     return dynamic_type_names;
-
-  auto then_types = classify_branch_literal_assigns(if_node["body"]);
-  if (then_types.empty())
-    return dynamic_type_names;
-
   if (!if_node.contains("orelse") || if_node["orelse"].empty())
     return dynamic_type_names;
 
   std::unordered_map<std::string, std::unordered_set<std::string>> kinds;
   std::unordered_map<std::string, int> leaf_count;
-  int leaf_total = 1; // the "then" branch is the first leaf
-  for (const auto &[name, kind] : then_types)
-  {
-    kinds[name].insert(kind);
-    leaf_count[name]++;
-  }
+  int leaf_total = 0;
 
-  if (!collect_orelse_literal_kinds(
+  if (!collect_branch_literal_kinds(
+        if_node["body"], kinds, leaf_count, leaf_total))
+    return dynamic_type_names;
+  if (!collect_branch_literal_kinds(
         if_node["orelse"], kinds, leaf_count, leaf_total))
     return dynamic_type_names;
 
@@ -609,17 +599,7 @@ exprt dynamic_type_handler::build_div_literal(
       pointer_typet(signedbv_typet(config.ansi_c.long_long_int_width))),
     signedbv_typet(config.ansi_c.long_long_int_width));
   exprt divisor = tagged_is_left ? lit_value : tagged_numeric_value;
-  exprt is_zero = build_equal(divisor, from_integer(BigInt(0), divisor.type()));
-
-  exprt raise = converter_.get_exception_handler().gen_exception_raise(
-    "ZeroDivisionError", "division by zero");
-  code_expressiont throw_code(raise);
-
-  code_ifthenelset guard;
-  guard.cond() = build_and(type_matches, is_zero);
-  guard.then_case() = throw_code;
-  guard.location() = location;
-  converter_.add_instruction(guard);
+  guard_zero_division(divisor, type_matches, location);
 
   return build_call_expr(
     *div_func,
@@ -705,25 +685,13 @@ exprt dynamic_type_handler::build_div_tagged(
   exprt rhs_is_num =
     type_handler_.tagged_scalar_type_matches(rhs_type_id, long_long_int_type());
 
-  // A catchable raise, not an assert, so it's guarded only when both
-  // operands are numeric.
   exprt rhs_numeric_value = build_dereference(
     build_typecast(
       build_member(rhs, "value", pointer_typet(empty_typet())),
       pointer_typet(signedbv_typet(config.ansi_c.long_long_int_width))),
     signedbv_typet(config.ansi_c.long_long_int_width));
-  exprt is_zero = build_equal(
-    rhs_numeric_value, from_integer(BigInt(0), rhs_numeric_value.type()));
-
-  exprt raise = converter_.get_exception_handler().gen_exception_raise(
-    "ZeroDivisionError", "division by zero");
-  code_expressiont throw_code(raise);
-
-  code_ifthenelset guard;
-  guard.cond() = build_and(build_and(lhs_is_num, rhs_is_num), is_zero);
-  guard.then_case() = throw_code;
-  guard.location() = location;
-  converter_.add_instruction(guard);
+  guard_zero_division(
+    rhs_numeric_value, build_and(lhs_is_num, rhs_is_num), location);
 
   return build_call_expr(
     *div_func,
@@ -732,6 +700,24 @@ exprt dynamic_type_handler::build_div_tagged(
      build_typecast(lhs_is_num, int_type()),
      build_address_of(rhs),
      build_typecast(rhs_is_num, int_type())});
+}
+
+void dynamic_type_handler::guard_zero_division(
+  const exprt &divisor,
+  const exprt &type_ok,
+  const locationt &location)
+{
+  exprt is_zero = build_equal(divisor, from_integer(BigInt(0), divisor.type()));
+
+  exprt raise = converter_.get_exception_handler().gen_exception_raise(
+    "ZeroDivisionError", "division by zero");
+  code_expressiont throw_code(raise);
+
+  code_ifthenelset guard;
+  guard.cond() = build_and(type_ok, is_zero);
+  guard.then_case() = throw_code;
+  guard.location() = location;
+  converter_.add_instruction(guard);
 }
 
 exprt dynamic_type_handler::build_isinstance_check(

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -170,6 +170,11 @@ private:
     const exprt &literal,
     bool tagged_is_left,
     const locationt &location);
+  exprt build_sub_tagged(const exprt &lhs, const exprt &rhs);
+  exprt build_div_tagged(
+    const exprt &lhs,
+    const exprt &rhs,
+    const locationt &location);
 
   python_converter &converter_;
   type_handler &type_handler_;

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -21,8 +21,8 @@ public:
   dynamic_type_handler(python_converter &converter, type_handler &type_handler);
 
   /**
-   * @brief Names of variables whose two branches assign
-   * genuinely incompatible literal types
+   * @brief Names assigned genuinely incompatible literal types across an
+   * if/elif/.../else chain, where every branch assigns the name
    */
   std::unordered_set<std::string>
   detect_dynamic_type_names(const nlohmann::json &if_node) const;

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -21,8 +21,9 @@ public:
   dynamic_type_handler(python_converter &converter, type_handler &type_handler);
 
   /**
-   * @brief Names assigned genuinely incompatible literal types across an
-   * if/elif/.../else chain, where every branch assigns the name
+   * @brief Names assigned genuinely incompatible literal types across
+   * every branch of `if_node`, following nested if/else (including elif)
+   * on either side; a name must be assigned in every branch to qualify
    */
   std::unordered_set<std::string>
   detect_dynamic_type_names(const nlohmann::json &if_node) const;
@@ -174,6 +175,15 @@ private:
   exprt build_div_tagged(
     const exprt &lhs,
     const exprt &rhs,
+    const locationt &location);
+
+  /**
+   * @brief Emits a catchable ZeroDivisionError raise, guarded so it only
+   * fires when `type_ok` holds and `divisor` is zero
+   */
+  void guard_zero_division(
+    const exprt &divisor,
+    const exprt &type_ok,
     const locationt &location);
 
   python_converter &converter_;


### PR DESCRIPTION
Local-variable divergence detection only recognized a plain two-branch if/else, so an elif chain was invisible to it, and this wasn't just a coverage gap. It actually broke the join. `if c1: x = 1 elif c2: x = 2 else: x = "a"` left `x` an untagged int on the `c1` path, and only got tagged once the converter recursed into the elif's own if/else. Detection now recurses through the whole elif chain, requiring every branch to assign the name for it to qualify. `-` and `/` between two tagged operands (e.g. `x - y` where both diverge between int and str across the same if/else) now work, dispatching to new C models that read both operands' type_id/value directly and raising a TypeError when either side turns out non-numeric.