### PR TITLE
[irep2] Remove the never-released --irep2-native-body no-op

### DIFF
--- a/docs/roadmap/scope-coupled-arith-assign-conversion.md
+++ b/docs/roadmap/scope-coupled-arith-assign-conversion.md
@@ -215,9 +215,9 @@ coupling achieves this.
 ### Phase 3 — the flip
 
 Make `python_adjust` the sole adjuster; `--python-irep2-adjust-only` becomes
-the default with an opt-out, mirroring how the W1-loc keystone shipped
-(`--irep2-native-body` → deprecated no-op, `--no-irep2-native-body` the escape
-hatch, `src/esbmc/options.cpp:964-975`).
+the default with an opt-out, mirroring how the W1-loc keystone shipped: only
+the `--no-` escape hatch is a real option (`src/esbmc/options.cpp:1036`); the
+positive flag was never released and has been removed.
 
 ## 5. Gates
 

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a declaration
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion a declaration
 // whose type has a destructor (`T t(base);`) or whose initializer needs
 // lowering (`T u = T(base + 5);`) is delegated to the legacy convert_decl,
 // rather than forcing a whole-function fallback, so the statements around it --

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a declaration
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion a declaration
 // whose type has a destructor (`T t(base);`) or whose initializer needs
 // lowering (`T u = T(base + 5);`) is delegated to the legacy convert_decl,
 // rather than forcing a whole-function fallback, so the statements around it --

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_decl_dtor_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a `return` that
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion a `return` that
 // runs while a local object's destructor is still on the stack is delegated to
 // the legacy convert_return, which captures the value into a temporary, runs the
 // destructor (C++ [stmt.return]: after the value is computed, before the jump)

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01_fail/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a `return` that
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion a `return` that
 // runs while a local object's destructor is still on the stack is delegated to
 // the legacy convert_return, which captures the value into a temporary, runs the
 // destructor (C++ [stmt.return]: after the value is computed, before the jump)

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_return_dtor_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): the --irep2-native-body code_expression2t
+// W1-loc Phase C (esbmc/esbmc#4715): the IREP2-native code_expression2t
 // handler now lowers a full-expression temporary_object natively (the guard
 // that previously fell back was over-conservative). A result-used temporary
 // whose ~M is deferred to the enclosing scope's exit leaves a destructor

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_temp_dtor_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body the
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion the
 // code_expression2t handler now delegates a code cpp-throw operand to the
 // legacy convert() (as convert_expression's is_code branch does), so f() -- an
 // `if` guarding a `throw` -- converts natively instead of falling back on the

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body the
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion the
 // code_expression2t handler now delegates a code cpp-throw operand to the
 // legacy convert() (as convert_expression's is_code branch does), so f() -- an
 // `if` guarding a `throw` -- converts natively instead of falling back on the

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_throw_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a source-level
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion a source-level
 // try/catch (code_cpp_catch2t) is delegated to the legacy convert()/convert_catch
 // rather than forcing a whole-function fallback, so the statements around it --
 // the local declarations and the trailing return here -- convert natively while

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/main.cpp
@@ -1,6 +1,6 @@
 // __ESBMC_assert is a built-in intrinsic; no include needed.
 
-// W1-loc Phase C (esbmc/esbmc#4715): under --irep2-native-body a source-level
+// W1-loc Phase C (esbmc/esbmc#4715): under native conversion a source-level
 // try/catch (code_cpp_catch2t) is delegated to the legacy convert()/convert_catch
 // rather than forcing a whole-function fallback, so the statements around it --
 // the local declarations and the trailing return here -- convert natively while

--- a/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4715_irep2_native_body_trycatch_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_4715_irep2_native_body_return_nil_loc_01/test.desc
+++ b/regression/esbmc-solidity/github_4715_irep2_native_body_return_nil_loc_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract MyContract --irep2-native-body --goto-functions-only
+--sol contract.sol --contract MyContract --goto-functions-only
 transfer \(sol:@C@MyContract@F@\$transfer#0\):\n[\s\S]*?// \d+ \n\s+RETURN: 1\n\s+// \d+ \n\s+2: RETURN: 0

--- a/regression/esbmc-solidity/github_4715_irep2_native_body_void_return_diag_01/test.desc
+++ b/regression/esbmc-solidity/github_4715_irep2_native_body_void_return_diag_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract C --irep2-native-body --goto-functions-only
+--sol contract.sol --contract C --goto-functions-only
 ^WARNING: function should not return value$

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body IREP2-native assign dispatcher (W1-loc
+// Exercises the IREP2-native assign dispatcher (W1-loc
 // spike Phase C, esbmc/esbmc#4715): the decl-free bodies of set()/set2()/
 // store() are all side-effect-free, non-atomic assignments, so goto_convert
 // consumes each code_assign2t natively (stored directly, no legacy round-trip)

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/main.c
@@ -3,7 +3,7 @@
 // natively does not corrupt the assigned values or suppress bug detection: the
 // value stored by the native code_assign2t in set() must reach main(), so the
 // wrong-value assertion is a reachable violation reported as VERIFICATION
-// FAILED under --irep2-native-body.
+// FAILED under native conversion.
 #include <assert.h>
 
 void set(int *p, int v)

--- a/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_assign_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_call_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_call_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body IREP2-native code_function_call2t
+// Exercises the IREP2-native code_function_call2t
 // dispatcher on the C frontend (W1-loc spike Phase C, esbmc/esbmc#4715):
 // bump()/reset()'s bodies are side-effect-free assignments, and each call
 // from bump_twice()/run() is a bare "foo();" statement (return value

--- a/regression/esbmc/github_4715_irep2_native_body_call_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_call_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_call_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_call_01_fail/main.c
@@ -1,7 +1,7 @@
 // _fail sibling of github_4715_irep2_native_body_call_01 (W1-loc spike
 // Phase C, esbmc/esbmc#4715). Pins that a genuine violation through native
 // call statements is still reported as VERIFICATION FAILED, not silently
-// dropped, under --irep2-native-body: run() returns 5, so the wrong-value
+// dropped, under native conversion: run() returns 5, so the wrong-value
 // assertion is a reachable violation.
 #include <assert.h>
 

--- a/regression/esbmc/github_4715_irep2_native_body_call_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_call_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_decl_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_decl_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body IREP2-native code_decl2t dispatcher (W1-loc
+// Exercises the IREP2-native code_decl2t dispatcher (W1-loc
 // spike Phase C, esbmc/esbmc#4715): compute()'s body declares trivial-type
 // locals with side-effect-free initializers, so goto_convert consumes each
 // code_decl2t natively (DECL + side-effect-free ASSIGN, no legacy round-trip)

--- a/regression/esbmc/github_4715_irep2_native_body_decl_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_decl_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_decl_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_decl_01_fail/main.c
@@ -3,7 +3,7 @@
 // (DECL + ASSIGN + scope-exit DEAD) neither corrupts the declared values nor
 // suppresses bug detection: compute() still leaves g == 12, so the wrong-value
 // assertion is a reachable violation reported as VERIFICATION FAILED under
-// --irep2-native-body.
+// native conversion.
 #include <assert.h>
 
 int g;

--- a/regression/esbmc/github_4715_irep2_native_body_decl_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_decl_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_decl_nil_loc_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_decl_nil_loc_01/main.c
@@ -4,8 +4,8 @@
 // which materialises an empty (id "", non-nil) #location, while code_decl2t
 // carries a properly nil one -- so the native path emitted a nil location where
 // legacy emitted an empty-but-present one. The GOTO dump renders the two
-// differently ("no location" vs blank), which is how this surfaced as a
-// --irep2-native-body byte-identity divergence. The DECL keeps the nil location
+// differently ("no location" vs blank), which is how this surfaced as an
+// IREP2-native byte-identity divergence. The DECL keeps the nil location
 // in both paths: convert_decl emits it before that mutable access happens.
 int my_func(int stat_loc)
 {

--- a/regression/esbmc/github_4715_irep2_native_body_decl_nil_loc_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_decl_nil_loc_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body --goto-functions-only
+--goto-functions-only
 DECL union [^\n]*compound-literal\$1;\n\s+// \d+ \n\s+ASSIGN

--- a/regression/esbmc/github_4715_irep2_native_body_dowhile_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_dowhile_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body dispatcher's code_dowhile2t handling
+// Exercises the IREP2-native dispatcher's code_dowhile2t handling
 // (W1-loc spike Phase C, esbmc/esbmc#4715). The loops below convert natively
 // end to end: a plain do/while, one whose body uses break and continue (whose
 // targets this kind installs), and a nested pair.

--- a/regression/esbmc/github_4715_irep2_native_body_dowhile_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_dowhile_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_dowhile_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_dowhile_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_dowhile_cond_loc_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_dowhile_cond_loc_01/main.c
@@ -1,5 +1,5 @@
 // Pins the do/while condition branch's source location under
-// --irep2-native-body (W1-loc spike Phase C, esbmc/esbmc#4715).
+// native conversion (W1-loc spike Phase C, esbmc/esbmc#4715).
 //
 // convert_dowhile reads that location off the condition *operand*
 // (code.op0().find_location()), which the legacy path populates via

--- a/regression/esbmc/github_4715_irep2_native_body_dowhile_cond_loc_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_dowhile_cond_loc_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body --goto-functions-only
+--goto-functions-only
 main\.c line 17 column 3 function countdown\n\s+IF t > 0 THEN GOTO

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body IREP2-native code_expression2t dispatcher
+// Exercises the IREP2-native code_expression2t dispatcher
 // (W1-loc spike Phase C, esbmc/esbmc#4715): the decl-free bodies of touch() and
 // discard() contain side-effect-free expression statements (`x;`, `(void)a;`,
 // `b;`) that goto_convert consumes natively as OTHER instructions (code2 stored

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/main.c
@@ -3,7 +3,7 @@
 // statements natively as OTHER instructions neither corrupts the following
 // assignment nor suppresses bug detection: g is still x+1 after touch(), so the
 // wrong-value assertion is a reachable violation reported as VERIFICATION FAILED
-// under --irep2-native-body.
+// under native conversion.
 #include <assert.h>
 
 int g;

--- a/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_expr_assign_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_assign_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 12 --irep2-native-body
+--unwind 12
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_expr_assign_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_assign_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 12 --irep2-native-body
+--unwind 12
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_expr_sideeffect_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_sideeffect_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_expr_sideeffect_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_expr_sideeffect_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_for_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_for_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body dispatcher's code_for2t handling (W1-loc
+// Exercises the IREP2-native dispatcher's code_for2t handling (W1-loc
 // spike Phase C, esbmc/esbmc#4715). Each of these converts natively end to
 // end: a for with a declaration in the init, a nested pair, one whose body
 // uses break and continue, and one with the iteration statement omitted

--- a/regression/esbmc/github_4715_irep2_native_body_for_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_for_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_for_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_for_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_goto_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_goto_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 6 --irep2-native-body
+--unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_goto_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_goto_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 6 --irep2-native-body
+--unwind 6
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_goto_rollback_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_goto_rollback_01/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
---irep2-native-body --error-label ERROR --goto-functions-only
+--error-label ERROR --goto-functions-only
 // Labels: ERROR
 ASSERT

--- a/regression/esbmc/github_4715_irep2_native_body_goto_rollback_02/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_goto_rollback_02/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 6 --irep2-native-body
+--unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body IREP2-native code_ifthenelse2t dispatcher
+// Exercises the IREP2-native code_ifthenelse2t dispatcher
 // (W1-loc spike Phase C, esbmc/esbmc#4715): classify() has both branches
 // side-effect-free, so goto_convert consumes the whole if/else natively as the
 // general branch shape (v: if(!c) goto y; w: P; x: goto z; y: Q; z: ;), with no

--- a/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01_fail/main.c
@@ -2,7 +2,7 @@
 // Phase C, esbmc/esbmc#4715). Pins that consuming if/else natively neither
 // corrupts branch results nor suppresses bug detection: classify(-5) is -1, so
 // the wrong-value assertion is a reachable violation reported as VERIFICATION
-// FAILED under --irep2-native-body.
+// FAILED under native conversion.
 #include <assert.h>
 
 int classify(int x)

--- a/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_ifthenelse_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_leaf_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_leaf_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body IREP2-native leaf dispatcher (W1-loc spike
+// Exercises the IREP2-native leaf dispatcher (W1-loc spike
 // Phase C, esbmc/esbmc#4715): nop()'s skip-only body and noop()'s empty body
 // are consumed natively by goto_convert (code_block2t/code_skip2t read
 // directly, no legacy round-trip), while main() (decl + assert) falls back to

--- a/regression/esbmc/github_4715_irep2_native_body_leaf_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_leaf_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_leaf_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_leaf_01_fail/main.c
@@ -1,7 +1,7 @@
 // _fail sibling of github_4715_irep2_native_body_leaf_01 (W1-loc spike Phase C,
 // esbmc/esbmc#4715). Pins that consuming the decl-free bodies natively does not
 // suppress bug detection: the reachable assertion violation in main() must
-// still be reported as VERIFICATION FAILED under --irep2-native-body.
+// still be reported as VERIFICATION FAILED under native conversion.
 #include <assert.h>
 
 void nop(void)

--- a/regression/esbmc/github_4715_irep2_native_body_leaf_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_leaf_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_return_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_return_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body IREP2-native code_return2t dispatcher (W1-loc
+// Exercises the IREP2-native code_return2t dispatcher (W1-loc
 // spike Phase C, esbmc/esbmc#4715): inc()/doubled() are value-returning functions
 // whose bodies reduce to a side-effect-free return, so goto_convert consumes each
 // code_return2t natively (a RETURN carrying the statement's own value, then an

--- a/regression/esbmc/github_4715_irep2_native_body_return_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_return_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_return_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_return_01_fail/main.c
@@ -3,7 +3,7 @@
 // end-of-function GOTO, with the trailing-goto block guard suppressing the local's
 // DEAD) neither corrupts the returned values nor suppresses bug detection:
 // inc(5)+doubled(6) is 18, so the wrong-value assertion is a reachable violation
-// reported as VERIFICATION FAILED under --irep2-native-body.
+// reported as VERIFICATION FAILED under native conversion.
 #include <assert.h>
 
 int inc(int p)

--- a/regression/esbmc/github_4715_irep2_native_body_return_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_return_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_rollback_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_rollback_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 4 --irep2-native-body
+--unwind 4
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_rollback_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_rollback_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 4 --irep2-native-body
+--unwind 4
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_sideeffect_cond_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_sideeffect_cond_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body dispatcher's side-effecting-condition
+// Exercises the IREP2-native dispatcher's side-effecting-condition
 // slices for code_for2t, code_dowhile2t and code_switch2t (W1-loc spike Phase
 // C, esbmc/esbmc#4715). Each kind was first landed for the side-effect-free
 // condition only, where the lowering preamble is empty and the back-edge /

--- a/regression/esbmc/github_4715_irep2_native_body_sideeffect_cond_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_sideeffect_cond_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_sideeffect_cond_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_sideeffect_cond_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_switch_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_switch_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body dispatcher's code_switch2t /
+// Exercises the IREP2-native dispatcher's code_switch2t /
 // code_switch_case2t handling (W1-loc spike Phase C, esbmc/esbmc#4715). Each of
 // these converts natively end to end: consecutive case labels sharing an arm,
 // fallthrough, a switch with no default, a default that is not last, a nested

--- a/regression/esbmc/github_4715_irep2_native_body_switch_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_switch_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_switch_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_switch_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_while_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_while_01/main.c
@@ -1,4 +1,4 @@
-// Exercises the --irep2-native-body dispatcher's code_while2t handling on the
+// Exercises the IREP2-native dispatcher's code_while2t handling on the
 // C frontend (W1-loc spike Phase C, esbmc/esbmc#4715). A plain C assignment
 // *statement* (`s = s + i;`) is represented as a code_expression2t wrapping a
 // side-effecting assign expression, not a bare code_assign2t (unlike Python,

--- a/regression/esbmc/github_4715_irep2_native_body_while_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_while_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_while_01_fail/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_while_01_fail/main.c
@@ -1,7 +1,7 @@
 // _fail sibling of github_4715_irep2_native_body_while_01 (W1-loc spike Phase
 // C, esbmc/esbmc#4715). Pins that a genuine violation through a while loop is
 // still reported as VERIFICATION FAILED, not silently dropped, under
-// --irep2-native-body: sum_to(5) is 10, so the wrong-value assertion is a
+// native conversion: sum_to(5) is 10, so the wrong-value assertion is a
 // reachable violation.
 #include <assert.h>
 

--- a/regression/esbmc/github_4715_irep2_native_body_while_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_while_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---irep2-native-body
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_while_call_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_while_call_01/main.c
@@ -1,6 +1,6 @@
 // W1-loc spike Phase C (esbmc/esbmc#4715): pins that a `while` loop whose
 // condition is directly a function call (has_sideeffect(cond) true) converts
-// natively under --irep2-native-body, delegating to the shared
+// natively, delegating to the shared
 // generate_conditional_branch/remove_sideeffects helpers instead of falling
 // back to goto_convert_rec. The loop body's plain C reassignment statements
 // are themselves still unsupported natively (code_expression2t wrapping a

--- a/regression/esbmc/github_4715_irep2_native_body_while_call_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_while_call_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 6 --irep2-native-body
+--unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4715_irep2_native_body_while_call_01_fail/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_while_call_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 6 --irep2-native-body
+--unwind 6
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/main.c
+++ b/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/main.c
@@ -3,7 +3,7 @@
 // the location for each instruction it emits off the operand being lowered
 // rather than off the statement. IREP2 value expressions carry no location, so
 // the back-migrated condition arrived unlocated and those instructions came out
-// with no location at all under --irep2-native-body, while the legacy path had
+// with no location at all under native conversion, while the legacy path had
 // them stamped by restore_value_locations. countdown() below is deliberately
 // free of assignment statements so that it converts natively end to end on the
 // current supported-kind set -- adding one would make the whole function fall

--- a/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/test.desc
+++ b/regression/esbmc/github_4715_irep2_native_body_while_cond_loc_01/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
---irep2-native-body --goto-functions-only
+--goto-functions-only
 main\.c line 13 column 3 function countdown\n\s+ASSIGN tmp\$1=t;
 main\.c line 13 column 3 function countdown\n\s+ASSIGN t=t - 1;

--- a/regression/python/github_4715_irep2_native_body_assume_01/test.desc
+++ b/regression/python/github_4715_irep2_native_body_assume_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3 --irep2-native-body
+--unwind 3
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_native_body_assume_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_native_body_assume_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3 --irep2-native-body
+--unwind 3
 ^VERIFICATION FAILED$

--- a/regression/python/github_4715_irep2_native_body_break_continue_01/main.py
+++ b/regression/python/github_4715_irep2_native_body_break_continue_01/main.py
@@ -1,4 +1,4 @@
-# Exercises the --irep2-native-body IREP2-native code_break2t/code_continue2t
+# Exercises the IREP2-native code_break2t/code_continue2t
 # dispatcher (W1-loc spike Phase C, esbmc/esbmc#4715): with_break()'s and
 # with_continue()'s conditions and bodies are side-effect-free, so the whole
 # while loop -- including the break/continue statements themselves, each an

--- a/regression/python/github_4715_irep2_native_body_break_continue_01/test.desc
+++ b/regression/python/github_4715_irep2_native_body_break_continue_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 6 --no-unwinding-assertions --irep2-native-body
+--unwind 6 --no-unwinding-assertions
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_native_body_break_continue_01_fail/main.py
+++ b/regression/python/github_4715_irep2_native_body_break_continue_01_fail/main.py
@@ -2,7 +2,7 @@
 # spike Phase C, esbmc/esbmc#4715). Pins that consuming break/continue
 # natively neither corrupts the loop's result nor suppresses bug detection:
 # with_continue(5) is 13, so the wrong-value assertion is a reachable
-# violation reported as VERIFICATION FAILED under --irep2-native-body.
+# violation reported as VERIFICATION FAILED under native conversion.
 
 
 def with_continue(n: int) -> int:

--- a/regression/python/github_4715_irep2_native_body_break_continue_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_native_body_break_continue_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 6 --no-unwinding-assertions --irep2-native-body
+--unwind 6 --no-unwinding-assertions
 ^VERIFICATION FAILED$

--- a/regression/python/github_4715_irep2_native_body_call_01/main.py
+++ b/regression/python/github_4715_irep2_native_body_call_01/main.py
@@ -1,4 +1,4 @@
-# Exercises the --irep2-native-body IREP2-native code_function_call2t
+# Exercises the IREP2-native code_function_call2t
 # dispatcher (W1-loc spike Phase C, esbmc/esbmc#4715): bump()/reset()'s
 # global-variable bodies are side-effect-free assignments, and each call to
 # them from bump_twice()/run() is a bare "foo();" statement (return value

--- a/regression/python/github_4715_irep2_native_body_call_01/test.desc
+++ b/regression/python/github_4715_irep2_native_body_call_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3 --irep2-native-body
+--unwind 3
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_native_body_call_01_fail/main.py
+++ b/regression/python/github_4715_irep2_native_body_call_01_fail/main.py
@@ -2,7 +2,7 @@
 # C, esbmc/esbmc#4715). Pins that consuming bare call statements natively
 # neither corrupts the accumulated global nor suppresses bug detection:
 # run() returns 5, so the wrong-value assertion is a reachable violation
-# reported as VERIFICATION FAILED under --irep2-native-body.
+# reported as VERIFICATION FAILED under native conversion.
 
 g: int = 0
 

--- a/regression/python/github_4715_irep2_native_body_call_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_native_body_call_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3 --irep2-native-body
+--unwind 3
 ^VERIFICATION FAILED$

--- a/regression/python/github_4715_irep2_native_body_forloop_01/test.desc
+++ b/regression/python/github_4715_irep2_native_body_forloop_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 6 --irep2-native-body
+--unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_native_body_forloop_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_native_body_forloop_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 6 --irep2-native-body
+--unwind 6
 ^VERIFICATION FAILED$

--- a/regression/python/github_4715_irep2_native_body_py_01/main.py
+++ b/regression/python/github_4715_irep2_native_body_py_01/main.py
@@ -1,4 +1,4 @@
-# Pins the experimental --irep2-native-body flag (W1-loc spike Phase C,
+# Pins the IREP2-native body path (W1-loc spike Phase C,
 # esbmc/esbmc#4715). Until the IREP2-native goto_convert dispatcher supports a
 # body's statement kinds it falls back to the legacy round-trip, so the verdict
 # must stay VERIFICATION SUCCESSFUL, byte-identical to a run without the flag.

--- a/regression/python/github_4715_irep2_native_body_py_01/test.desc
+++ b/regression/python/github_4715_irep2_native_body_py_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 5 --no-unwinding-assertions --irep2-native-body
+--unwind 5 --no-unwinding-assertions
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_native_body_py_01_fail/main.py
+++ b/regression/python/github_4715_irep2_native_body_py_01_fail/main.py
@@ -1,6 +1,6 @@
 # _fail sibling of github_4715_irep2_native_body_py_01 (W1-loc spike Phase C,
 # esbmc/esbmc#4715). Pins the load-bearing half of "byte-identical": under
-# --irep2-native-body the body must STILL be converted (via the fallback until
+# native conversion the body must STILL be converted (via the fallback until
 # the native dispatcher is complete), so a genuine assertion violation is
 # surfaced as VERIFICATION FAILED and not silently suppressed by skipping
 # goto_convert_rec.
@@ -16,7 +16,7 @@ def test():
     while w < 3:
         w += 1
 
-    assert x == 5, "x is 3, not 5 -- must be detected under --irep2-native-body"
+    assert x == 5, "x is 3, not 5 -- must be detected under native conversion"
     assert w == 3
 
 

--- a/regression/python/github_4715_irep2_native_body_py_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_native_body_py_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 5 --no-unwinding-assertions --irep2-native-body
+--unwind 5 --no-unwinding-assertions
 ^VERIFICATION FAILED$

--- a/regression/python/github_4715_irep2_native_body_while_01/main.py
+++ b/regression/python/github_4715_irep2_native_body_while_01/main.py
@@ -1,4 +1,4 @@
-# Exercises the --irep2-native-body IREP2-native code_while2t dispatcher
+# Exercises the IREP2-native code_while2t dispatcher
 # (W1-loc spike Phase C, esbmc/esbmc#4715): sum_to()'s loop condition and body
 # are both side-effect-free (Python assignment is a genuine statement, unlike
 # C's expression-statement-wrapped assign, so the body's code_assign2t nodes

--- a/regression/python/github_4715_irep2_native_body_while_01/test.desc
+++ b/regression/python/github_4715_irep2_native_body_while_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 6 --no-unwinding-assertions --irep2-native-body
+--unwind 6 --no-unwinding-assertions
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4715_irep2_native_body_while_01_fail/main.py
+++ b/regression/python/github_4715_irep2_native_body_while_01_fail/main.py
@@ -2,7 +2,7 @@
 # C, esbmc/esbmc#4715). Pins that consuming the while loop natively neither
 # corrupts the accumulated values nor suppresses bug detection: sum_to(5) is
 # 10, so the wrong-value assertion is a reachable violation reported as
-# VERIFICATION FAILED under --irep2-native-body.
+# VERIFICATION FAILED under native conversion.
 
 
 def sum_to(n: int) -> int:

--- a/regression/python/github_4715_irep2_native_body_while_01_fail/test.desc
+++ b/regression/python/github_4715_irep2_native_body_while_01_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 6 --no-unwinding-assertions --irep2-native-body
+--unwind 6 --no-unwinding-assertions
 ^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -1033,11 +1033,6 @@ const struct group_opt_templ all_cmd_options[] = {
      "always lowers function bodies through the IREP2 round-trip "
      "(migrate legacy codet → code_*2t → codet) since V.4.4; the legacy "
      "bypass and the --no-irep2-bodies escape hatch have been removed."},
-    {"irep2-native-body",
-     NULL,
-     "Deprecated no-op (accepted for backward compatibility). Function bodies "
-     "are routed to the IREP2-native goto_convert by default since the W1-loc "
-     "keystone concluded; --no-irep2-native-body opts out."},
     {"no-irep2-native-body",
      NULL,
      "Convert function bodies through the whole-body legacy round-trip "


### PR DESCRIPTION
`--irep2-native-body` was a deprecated no-op whose introducing commit never
shipped in a release, and nothing in `src/` ever read it. Remove it and strip
the token from 63 `test.desc` flags lines; `--irep2-bodies` stays because it did
ship in v8.4, and the live `--no-irep2-native-body` escape hatch is untouched.

Refs #4715
