### PR TITLE
[build] Ignore CTest's Testing/ output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,9 @@ src/CPackSourceConfig.cmake
 *.dSYM/
 regression/**/test
 
+# CTest's output directory, created wherever ctest is invoked. Committing one
+# under regression/<suite>/ turns it into a phantom always-failing test case.
+**/Testing/
+
 # Generated doxygen API reference (see .config/Doxyfile)
 docs/html/


### PR DESCRIPTION
`ctest` writes `Testing/Temporary/` wherever it is invoked, and nothing stopped those files being committed — #7277 carried four of them before they were removed.

A committed `Testing/` under `regression/<suite>/` is picked up by the suite glob and becomes a phantom always-failing test case. No tracked path matches the new rule, so nothing existing is hidden.