### PR TITLE
[build] Static aarch64 Linux build via trimmed LLVM 22 archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,12 @@ jobs:
       canon-names: true
 
   build-linux-arm64:
-    name: Homebrew compatibility check (Linux ARM64, LLVM 22)
+    name: Static Linux ARM64 build
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-      - name: Install LLVM 22
-        run: |
-          wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update
-          sudo apt-get install -y llvm-22 clang-22 libclang-22-dev libclang-cpp22-dev
-      - name: Build ESBMC
-        run: ./scripts/build.sh -b RelWithDebInfo -S OFF -c 22 -e OFF
+      - name: Build ESBMC (static, downloaded LLVM 22)
+        run: ./scripts/build.sh -b RelWithDebInfo -e OFF
 
   build-info:
     uses: ./.github/workflows/build-info.yml

--- a/scripts/cmake/Options.cmake
+++ b/scripts/cmake/Options.cmake
@@ -59,7 +59,9 @@ option(CORE_REGRESSION_ONLY "Only add tests in the regression that are CORE (def
 # PRE-BUILT DEPENDENCIES
 #############################
 
-# these URLs are all for an x86_64 target
+# Pre-built LLVM toolchains. Windows ships upstream's x86_64 archive; Linux
+# x86_64 uses a hand-trimmed archive on the ESBMC release, Linux aarch64 uses
+# the trimmed archive produced by esbmc/llvm (same LLVM major, 22).
 if(WIN32)
   set(DEFAULT_LLVM_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.4/clang+llvm-22.1.4-x86_64-pc-windows-msvc.tar.xz")
   set(DEFAULT_LLVM_NAME "clang+llvm-22.1.4-x86_64-pc-windows-msvc")
@@ -70,8 +72,17 @@ if(WIN32)
   set(MATHSAT_URL "https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-win64-msvc.zip")
   set(MATHSAT_NAME "mathsat-5.6.10-win64-msvc")
 else()
-  set(DEFAULT_LLVM_URL "https://github.com/esbmc/esbmc/releases/download/v8.3/clang+llvm-22.1.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz")
-  set(DEFAULT_LLVM_NAME "clang+llvm-22.1.6-x86_64-linux-gnu-ubuntu-22.04")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    # Trimmed from upstream LLVM-22.1.6-Linux-ARM64 by esbmc/llvm's
+    # tools/trim.sh (see the Build trimmed LLVM archive workflow there). The
+    # archive's top-level directory is preserved verbatim so SetupLocalLLVM's
+    # ${CMAKE_BINARY_DIR}/LLVM/${ESBMC_LLVM_NAME} extraction contract holds.
+    set(DEFAULT_LLVM_URL "https://github.com/esbmc/llvm/releases/download/llvm-22.1.6-armv8/LLVM-22.1.6-Linux-ARM64-esbmc.tar.xz")
+    set(DEFAULT_LLVM_NAME "LLVM-22.1.6-Linux-ARM64")
+  else()
+    set(DEFAULT_LLVM_URL "https://github.com/esbmc/esbmc/releases/download/v8.3/clang+llvm-22.1.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz")
+    set(DEFAULT_LLVM_NAME "clang+llvm-22.1.6-x86_64-linux-gnu-ubuntu-22.04")
+  endif()
 
   set(DEFAULT_CHERI_LLVM_URL "https://github.com/XLiZHI/esbmc/releases/download/v17/clang-cheri-17.zip")
   set(DEFAULT_CHERI_LLVM_NAME "clang-cheri-17")


### PR DESCRIPTION
The x86_64 Linux release links a self-hosted, trimmed LLVM 22 archive so `esbmc-linux.zip` has no runtime LLVM dependency. No equivalent existed for aarch64: upstream only publishes an 11 GB full install (too big for a CI runner), so the arm64 build had nothing static to link against and `esbmc-linux-armv8.zip` could not be produced.

This adds the missing half in two repos:

**esbmc/llvm** (new): `tools/trim.sh` deterministically trims an upstream LLVM release tarball to the static archives, CMake package config, Clang resource headers, public headers and tblgen binaries that ESBMC's static link consumes. A `workflow_dispatch` workflow runs it on `ubuntu-24.04-arm` and publishes a tagged release asset. The method is committed, so the archive is reproducible rather than hand-made (the x86_64 one was trimmed locally with no recorded steps).

**esbmc/esbmc** (this PR): `Options.cmake` points Linux aarch64 at the trimmed `LLVM-22.1.6-Linux-ARM64-esbmc.tar.xz` from `esbmc/llvm` so the static link resolves against per-component `.a` files instead of a distro `libLLVM.so`. `release.yml`'s arm64 job drops the apt.llvm.org shared build and exercises this static path directly. Both Linux assets now build against LLVM 22.

Fixes #7236. Blocks #7229 (the armv8 asset PR cannot ship a working static binary without this).