### PR TITLE
[goto-coverage] Name the dead direction in --dead-code-check advisories

### DIFF
--- a/regression/esbmc/cwe_dead_code_guard_polarity/main.c
+++ b/regression/esbmc/cwe_dead_code_guard_polarity/main.c
@@ -1,10 +1,8 @@
 extern int __VERIFIER_nondet_int(void);
 
-// Pins the polarity of the guard named in a dead-code advisory: a probe
-// assert(c) that is never violated proves !c infeasible, so the advisory names
-// the opposite direction. `flag` also pins that the negation is derived from
-// the expression rather than by flipping the probe's comment text, which would
-// print "!flag" here — from_expr parenthesises by precedence.
+// Pins both polarities of the guard named in a dead-code advisory. `flag` also
+// pins that the negation is derived from the expression: flipping the probe's
+// comment text would print "!flag" here.
 int main(void)
 {
   _Bool flag = 0;

--- a/regression/esbmc/cwe_dead_code_guard_polarity/main.c
+++ b/regression/esbmc/cwe_dead_code_guard_polarity/main.c
@@ -1,0 +1,18 @@
+extern int __VERIFIER_nondet_int(void);
+
+// Pins the polarity of the guard named in a dead-code advisory: a probe
+// assert(c) that is never violated proves !c infeasible, so the advisory names
+// the opposite direction. `flag` also pins that the negation is derived from
+// the expression rather than by flipping the probe's comment text, which would
+// print "!flag" here — from_expr parenthesises by precedence.
+int main(void)
+{
+  _Bool flag = 0;
+  int x = __VERIFIER_nondet_int();
+  if (flag)
+    return 1;
+  __ESBMC_assume(x > 10);
+  if (x > 5)
+    return 0;
+  return 2;
+}

--- a/regression/esbmc/cwe_dead_code_guard_polarity/test.desc
+++ b/regression/esbmc/cwe_dead_code_guard_polarity/test.desc
@@ -1,8 +1,6 @@
 CORE
 main.c
 --dead-code-check
-^\[Dead code\]$
-:12: dead code: unreachable branch \[guard: flag\]$
-:15: dead code: unreachable branch \[guard: !\(x > 5\)\]$
-^  CWE: CWE-561$
+main\.c:10: dead code: unreachable branch \[guard: flag\]$
+main\.c:13: dead code: unreachable branch \[guard: !\(x > 5\)\]$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_dead_code_guard_polarity/test.desc
+++ b/regression/esbmc/cwe_dead_code_guard_polarity/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--dead-code-check
+^\[Dead code\]$
+:12: dead code: unreachable branch \[guard: flag\]$
+:15: dead code: unreachable branch \[guard: !\(x > 5\)\]$
+^  CWE: CWE-561$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7267-genuine-dead-code/test.desc
+++ b/regression/esbmc/github_7267-genuine-dead-code/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
 --dead-code-check
-main\.c:11: dead code: unreachable branch \[guard: !\(x > 10\)\]$
+main\.c:11: dead code: unreachable branch \[guard: x > 10\]$
 CWE-561
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dead_code_guard_polarity/main.py
+++ b/regression/python/dead_code_guard_polarity/main.py
@@ -1,0 +1,12 @@
+def find_max(a, b):
+    if a > b:
+        return a
+    return b
+
+
+def main():
+    result = find_max(10, 20)
+    assert result >= 20
+
+
+main()

--- a/regression/python/dead_code_guard_polarity/main.py
+++ b/regression/python/dead_code_guard_polarity/main.py
@@ -4,9 +4,4 @@ def find_max(a, b):
     return b
 
 
-def main():
-    result = find_max(10, 20)
-    assert result >= 20
-
-
-main()
+assert find_max(10, 20) == 20

--- a/regression/python/dead_code_guard_polarity/test.desc
+++ b/regression/python/dead_code_guard_polarity/test.desc
@@ -1,7 +1,5 @@
 CORE
 main.py
 --dead-code-check
-^\[Dead code\]$
-:2: dead code: unreachable branch \[guard: a > b\]$
-^  CWE: CWE-561$
+main\.py:2: dead code: unreachable branch \[guard: a > b\]$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dead_code_guard_polarity/test.desc
+++ b/regression/python/dead_code_guard_polarity/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.py
+--dead-code-check
+^\[Dead code\]$
+:2: dead code: unreachable branch \[guard: a > b\]$
+^  CWE: CWE-561$
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1024,15 +1024,14 @@ static bool is_kpath_maximal(const std::string &claim_sig)
 
 // Advisory dead-code reporter for --dead-code-check (CWE-561, issue #4495).
 //
-// Reuses the branch-coverage instrumentation: a probe (an instrumented
-// assertion over a branch guard) that multi_property_check never violated is
-// unreachable under all inputs up to the current unwinding bound — i.e. that
-// branch direction is dead. The dead set is therefore
-// `all_claims \ reached_claims`. The probe is `assert(c)`, so leaving it
-// unviolated proves `!c` infeasible: the advisory names the claim's recorded
-// negation, not its own comment. Findings are advisory: they are printed as a
-// separate [Dead code] section and, when --sarif-output is set, emitted at
-// SARIF note level. They never flip the verdict (see report_result).
+// Reuses the branch-coverage instrumentation: a probe `assert(c)` (an
+// instrumented assertion over a branch guard) that multi_property_check never
+// violated proves `!c` infeasible up to the current unwinding bound — so `!c`
+// is the dead direction, and the advisory names goto_coveraget::claim_negation
+// rather than the claim's own comment. The dead set is `all_claims \
+// reached_claims`. Findings are advisory: they are printed as a separate
+// [Dead code] section and, when --sarif-output is set, emitted at SARIF note
+// level. They never flip the verdict (see report_result).
 static void report_dead_code(
   const optionst &options,
   const std::unordered_set<std::string> &reached_claims,
@@ -1046,9 +1045,9 @@ static void report_dead_code(
     if (reached_claims.count(claim_sig))
       continue; // reachable branch direction — live code
 
-    const auto neg = goto_coveraget::claim_negation.find({comment, loc});
-    const std::string dead_guard =
-      neg == goto_coveraget::claim_negation.end() ? "" : neg->second;
+    // Populated in lockstep with all_claims, so the key is always present.
+    const std::string &dead_guard =
+      goto_coveraget::claim_negation.at({comment, loc});
 
     nlohmann::json parsed = parse_claim_location(loc);
     dead_code_finding_t f;

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1028,10 +1028,10 @@ static bool is_kpath_maximal(const std::string &claim_sig)
 // instrumented assertion over a branch guard) that multi_property_check never
 // violated proves `!c` infeasible up to the current unwinding bound — so `!c`
 // is the dead direction, and the advisory names goto_coveraget::claim_negation
-// rather than the claim's own comment. The dead set is `all_claims \
-// reached_claims`. Findings are advisory: they are printed as a separate
-// [Dead code] section and, when --sarif-output is set, emitted at SARIF note
-// level. They never flip the verdict (see report_result).
+// rather than the claim's own comment. The dead set is therefore
+// `all_claims \ reached_claims`. Findings are advisory: they are printed as a
+// separate [Dead code] section and, when --sarif-output is set, emitted at
+// SARIF note level. They never flip the verdict (see report_result).
 static void report_dead_code(
   const optionst &options,
   const std::unordered_set<std::string> &reached_claims,

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1028,7 +1028,9 @@ static bool is_kpath_maximal(const std::string &claim_sig)
 // assertion over a branch guard) that multi_property_check never violated is
 // unreachable under all inputs up to the current unwinding bound — i.e. that
 // branch direction is dead. The dead set is therefore
-// `all_claims \ reached_claims`. Findings are advisory: they are printed as a
+// `all_claims \ reached_claims`. The probe is `assert(c)`, so leaving it
+// unviolated proves `!c` infeasible: the advisory names the claim's recorded
+// negation, not its own comment. Findings are advisory: they are printed as a
 // separate [Dead code] section and, when --sarif-output is set, emitted at
 // SARIF note level. They never flip the verdict (see report_result).
 static void report_dead_code(
@@ -1044,13 +1046,17 @@ static void report_dead_code(
     if (reached_claims.count(claim_sig))
       continue; // reachable branch direction — live code
 
+    const auto neg = goto_coveraget::claim_negation.find({comment, loc});
+    const std::string dead_guard =
+      neg == goto_coveraget::claim_negation.end() ? "" : neg->second;
+
     nlohmann::json parsed = parse_claim_location(loc);
     dead_code_finding_t f;
     f.file = parsed["file"].get<std::string>();
     f.line = static_cast<unsigned>(parsed["line"].get<int>());
-    f.message = comment.empty()
+    f.message = dead_guard.empty()
                   ? "dead code: unreachable branch"
-                  : "dead code: unreachable branch [guard: " + comment + "]";
+                  : "dead code: unreachable branch [guard: " + dead_guard + "]";
     findings.push_back(std::move(f));
   }
 

--- a/src/esbmc/parseoptions/process_goto_program.cpp
+++ b/src/esbmc/parseoptions/process_goto_program.cpp
@@ -685,10 +685,10 @@ bool esbmc_parseoptionst::process_goto_program(
 
     // --dead-code-check reuses the branch-coverage instrumentation: each
     // conditional branch gets `assert(guard)` and `assert(!guard)` reachability
-    // probes, and a probe proven UNSAT means that branch direction is
-    // unreachable under all inputs — i.e. dead code. report_dead_code() reports
-    // those as CWE-561 note-level advisories without flipping the verdict (see
-    // bmc.cpp).
+    // probes. A probe `assert(c)` holds exactly when `!c` is infeasible, so an
+    // unviolated probe means the *opposite* direction is unreachable under all
+    // inputs — i.e. dead code. report_dead_code() reports those as CWE-561
+    // note-level advisories without flipping the verdict (see bmc.cpp).
     if (
       cmdline.isset("branch-coverage") ||
       cmdline.isset("branch-coverage-claims") ||

--- a/src/esbmc/parseoptions/process_goto_program.cpp
+++ b/src/esbmc/parseoptions/process_goto_program.cpp
@@ -685,10 +685,9 @@ bool esbmc_parseoptionst::process_goto_program(
 
     // --dead-code-check reuses the branch-coverage instrumentation: each
     // conditional branch gets `assert(guard)` and `assert(!guard)` reachability
-    // probes. A probe `assert(c)` holds exactly when `!c` is infeasible, so an
-    // unviolated probe means the *opposite* direction is unreachable under all
-    // inputs — i.e. dead code. report_dead_code() reports those as CWE-561
-    // note-level advisories without flipping the verdict (see bmc.cpp).
+    // probes, and an unviolated probe means the *opposite* direction is dead.
+    // report_dead_code() reports those as CWE-561 note-level advisories without
+    // flipping the verdict (see bmc.cpp).
     if (
       cmdline.isset("branch-coverage") ||
       cmdline.isset("branch-coverage-claims") ||

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -33,6 +33,8 @@ size_t goto_coveraget::total_kpath_spanning = 0;
 std::set<std::pair<std::string, std::string>>
   goto_coveraget::k_path_spanning_redundant;
 std::set<std::pair<std::string, std::string>> goto_coveraget::all_claims;
+std::map<std::pair<std::string, std::string>, std::string>
+  goto_coveraget::claim_negation;
 
 std::string goto_coveraget::get_filename_from_path(std::string path)
 {
@@ -905,6 +907,9 @@ std::set<std::pair<std::string, std::string>>
 goto_coveraget::get_total_cond_assert() const
 {
   std::set<std::pair<std::string, std::string>> total_cond_assert = {};
+  // Rebuilt in lockstep with the returned claim set, which callers assign to
+  // all_claims wholesale.
+  claim_negation.clear();
   forall_goto_functions (f_it, goto_functions)
   {
     if (f_it->second.body_available && f_it->first != "__ESBMC_main")
@@ -923,6 +928,8 @@ goto_coveraget::get_total_cond_assert() const
           std::pair<std::string, std::string> claim_pair = std::make_pair(
             it->location.comment().as_string(), it->location.as_string());
           total_cond_assert.insert(claim_pair);
+          claim_negation[claim_pair] =
+            from_expr(ns, "", gen_not_expr(it->guard));
         }
       }
     }
@@ -1212,7 +1219,7 @@ expr2tc goto_coveraget::gen_and_expr(const expr2tc &lhs, const expr2tc &rhs)
   return and2tc(_lhs, _rhs);
 }
 
-expr2tc goto_coveraget::gen_not_expr(const expr2tc &guard)
+expr2tc goto_coveraget::gen_not_expr(const expr2tc &guard) const
 {
   if (is_not2t(guard))
     return to_not2t(guard).value;

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -907,8 +907,8 @@ std::set<std::pair<std::string, std::string>>
 goto_coveraget::get_total_cond_assert() const
 {
   std::set<std::pair<std::string, std::string>> total_cond_assert = {};
-  // Rebuilt in lockstep with the returned claim set, which callers assign to
-  // all_claims wholesale.
+  // Rebuilt in lockstep with the returned claim set: every call site assigns
+  // it to all_claims, which report_dead_code indexes this map by.
   claim_negation.clear();
   forall_goto_functions (f_it, goto_functions)
   {

--- a/src/goto-programs/goto_coverage.h
+++ b/src/goto-programs/goto_coverage.h
@@ -98,11 +98,11 @@ public:
   // all instrumented claims (condition, location) for JSON report
   static std::set<std::pair<std::string, std::string>> all_claims;
   // Guard text of the opposite direction for each claim in all_claims, keyed
-  // the same way. A probe assert(c) that multi-property never violated proves
-  // !c infeasible, not c, so --dead-code-check reports this string rather than
-  // the claim's own comment. Kept as an expression-derived string because the
-  // two are not textual complements: from_expr parenthesises by precedence,
-  // so !flag negates to flag but a > b negates to !(a > b).
+  // the same way. A probe assert(c) left unviolated proves !c infeasible, so
+  // --dead-code-check names this rather than the claim's own comment. Derived
+  // from the expression, not by flipping the comment text: from_expr
+  // parenthesises by precedence, so !flag negates to flag but a > b negates
+  // to !(a > b).
   static std::map<std::pair<std::string, std::string>, std::string>
     claim_negation;
 

--- a/src/goto-programs/goto_coverage.h
+++ b/src/goto-programs/goto_coverage.h
@@ -2,6 +2,7 @@
 #include <goto-programs/goto_convert_class.h>
 #include <goto-programs/loop_unroll.h>
 #include <langapi/language_util.h>
+#include <map>
 #include <unordered_set>
 
 class goto_coveraget
@@ -67,7 +68,7 @@ public:
   void condition_coverage();
   expr2tc gen_not_eq_expr(const expr2tc &lhs, const expr2tc &rhs);
   expr2tc gen_and_expr(const expr2tc &lhs, const expr2tc &rhs);
-  expr2tc gen_not_expr(const expr2tc &expr);
+  expr2tc gen_not_expr(const expr2tc &expr) const;
   int get_total_instrument() const;
   int get_total_assert_instance() const;
   std::set<std::pair<std::string, std::string>> get_total_cond_assert() const;
@@ -96,6 +97,14 @@ public:
     k_path_spanning_redundant;
   // all instrumented claims (condition, location) for JSON report
   static std::set<std::pair<std::string, std::string>> all_claims;
+  // Guard text of the opposite direction for each claim in all_claims, keyed
+  // the same way. A probe assert(c) that multi-property never violated proves
+  // !c infeasible, not c, so --dead-code-check reports this string rather than
+  // the claim's own comment. Kept as an expression-derived string because the
+  // two are not textual complements: from_expr parenthesises by precedence,
+  // so !flag negates to flag but a > b negates to !(a > b).
+  static std::map<std::pair<std::string, std::string>, std::string>
+    claim_negation;
 
   std::string target_function = "";
   bool cov_assume_asserts = false;

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -201,10 +201,11 @@ inputs. Unlike a compiler's `-Wunreachable-code`, BMC-based detection is sound
 under non-trivial guards.
 
 Detection is off by default and enabled with `--dead-code-check`. It reuses the
-branch-coverage instrumentation: every conditional branch is probed with a
-reachability assertion, and any probe the solver proves unsatisfiable marks that
-branch direction as dead. Because it issues one solver query per branch probe,
-it can be slow on large programs — hence the default-off gate.
+branch-coverage instrumentation: each conditional branch is probed with a
+reachability assertion `assert(c)` per direction, and a probe the solver never
+violates marks the *opposite* direction, `!c`, as dead — that is the guard
+named in the finding. Because it issues one solver query per branch probe, it
+can be slow on large programs — hence the default-off gate.
 
 Findings are reported as:
 
@@ -225,11 +226,23 @@ coverage modes, instrumentation is keyed off the source locations of the input
 translation units, so it has no effect on a pre-compiled `.goto` binary.
 
 ```
+$ cat dead.c
+int f(void) { return 1; }
+
+int main(void)
+{
+  int x = 5;
+  if (x > 10)
+    f();
+  return 0;
+}
+
 $ esbmc dead.c --dead-code-check
 
 [Dead code]
 
-dead.c:9: dead code: unreachable branch [guard: x > 5]
+The following branches are unreachable up to the current unwinding bound:
+dead.c:6: dead code: unreachable branch [guard: x > 10]
   CWE: CWE-561
 
 VERIFICATION SUCCESSFUL


### PR DESCRIPTION
`--dead-code-check` named the guard of the *live* branch. A branch-coverage
probe is `assert(c)`, so a probe left unviolated proves `!c` infeasible — the
dead direction is `!c`, but `report_dead_code()` printed `c`.

Record each claim's negation from the guard expression at instrumentation time
and report that. Deriving it from the expression rather than flipping the
comment text matters: `from_expr` parenthesises by precedence, so `!flag`
negates to `flag` while `a > b` negates to `!(a > b)`.
