### PR TITLE
[python] Carry the signature of a spelled Callable annotation

### DIFF
--- a/regression/python/github_6640_callable_return/main.py
+++ b/regression/python/github_6640_callable_return/main.py
@@ -1,0 +1,23 @@
+# A callable chosen at runtime, returned, and then called through the variable
+# holding it. The spelled signature is what lets the call recover its return
+# type; both branches of the choice must resolve to the right function (#6640).
+from typing import Callable
+
+
+def inc(m: int) -> int:
+    return m + 1
+
+
+def century(m: int) -> int:
+    return m + 100
+
+
+def pick(c: bool) -> Callable[[int], int]:
+    return inc if c else century
+
+
+h: Callable[[int], int] = pick(True)
+assert h(1) == 2
+
+k: Callable[[int], int] = pick(False)
+assert k(1) == 101

--- a/regression/python/github_6640_callable_return/test.desc
+++ b/regression/python/github_6640_callable_return/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6640_callable_return_fail/main.py
+++ b/regression/python/github_6640_callable_return_fail/main.py
@@ -1,0 +1,22 @@
+# pick(True) selects inc, so h(1) is 2. Resolving the function pointer to the
+# other branch -- or leaving it unconstrained -- must not prove 101 (#6640).
+from typing import Callable
+
+
+def inc(m: int) -> int:
+    return m + 1
+
+
+def century(m: int) -> int:
+    return m + 100
+
+
+def pick(c: bool) -> Callable[[int], int]:
+    return inc if c else century
+
+
+h: Callable[[int], int] = pick(True)
+assert h(1) == 101
+
+k: Callable[[int], int] = pick(False)
+assert k(1) == 101

--- a/regression/python/github_6640_callable_return_fail/test.desc
+++ b/regression/python/github_6640_callable_return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/github_6640_callable_return_inferred/main.py
+++ b/regression/python/github_6640_callable_return_inferred/main.py
@@ -1,0 +1,23 @@
+# The same runtime-chosen callable, bound to a variable the annotation pass
+# types for us. A bare `Callable` returns void, so a call through it used to be
+# nondet -- worse than leaving the return unannotated (#6640).
+from typing import Callable
+
+
+def inc(m: int) -> int:
+    return m + 1
+
+
+def century(m: int) -> int:
+    return m + 100
+
+
+def pick(c: bool) -> Callable[[int], int]:
+    return inc if c else century
+
+
+h = pick(True)
+assert h(1) == 2
+
+k = pick(False)
+assert k(1) == 101

--- a/regression/python/github_6640_callable_return_inferred/test.desc
+++ b/regression/python/github_6640_callable_return_inferred/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -606,31 +606,6 @@ void python_converter::get_attributes_from_self(
            annotation["value"].value("id", "") == "Callable";
   };
 
-  // Carry the signature when it is spelled: `Callable[[A, B], R]` parses as
-  // Subscript(slice=Tuple([List([A, B]), R])). A member typed `R (*)(A, B)`
-  // lets a call through it recover the return type; the bare pointer would
-  // leave the result nondet. Anything else (bare `Callable`, or an unspelled
-  // signature) keeps the generic function pointer.
-  auto callable_member_type =
-    [&](const nlohmann::json &annotation, const nlohmann::json &stmt) -> typet {
-    code_typet fn_type;
-    fn_type.return_type() = empty_typet();
-    const auto &slice = annotation["slice"];
-    if (
-      slice.is_object() && slice.value("_type", "") == "Tuple" &&
-      slice.contains("elts") && slice["elts"].size() == 2 &&
-      slice["elts"][0].value("_type", "") == "List")
-    {
-      for (const auto &arg : slice["elts"][0]["elts"])
-        fn_type.arguments().push_back(
-          code_typet::argumentt(get_type_from_annotation(arg, stmt)));
-      fn_type.return_type() = get_type_from_annotation(slice["elts"][1], stmt);
-    }
-    return fn_type.return_type().is_nil()
-             ? type_handler_.get_typet(std::string("Callable"))
-             : gen_pointer_type(fn_type);
-  };
-
   for (const auto &stmt : method_body)
   {
     if (
@@ -679,7 +654,7 @@ void python_converter::get_attributes_from_self(
         // form breaks (regression/python/callable4), so the mapping stays
         // local to members.
         typet type = is_callable_annotation(stmt["annotation"])
-                       ? callable_member_type(stmt["annotation"], stmt)
+                       ? get_callable_type(stmt["annotation"], stmt)
                        : get_type_from_annotation(stmt["annotation"], stmt);
         if (type.is_nil() || type.is_empty())
         {
@@ -837,7 +812,7 @@ void python_converter::get_attributes_from_self(
           if (
             param != param_annotations.end() &&
             is_callable_annotation(param->second))
-            type = callable_member_type(param->second, stmt);
+            type = get_callable_type(param->second, stmt);
         }
       }
 

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -436,6 +436,20 @@ bool body_returns_list_value(const nlohmann::json &body)
 
 // Return true if 'param_name' has any attribute written (x.attr = ...)
 // anywhere in 'body' (recursive scan over nested blocks).
+/// A subscripted annotation spelled with either of @p name or @p alt, e.g.
+/// `Tuple[int, str]` -- the form that carries arguments, as opposed to a bare
+/// `Tuple`.
+static bool is_subscripted_as(
+  const nlohmann::json &return_type,
+  const nlohmann::json &node,
+  const char *name,
+  const char *alt = nullptr)
+{
+  if (node["_type"] != "Subscript")
+    return false;
+  return return_type == name || (alt && return_type == alt);
+}
+
 static bool param_is_mutated_in_body(
   const std::string &param_name,
   const nlohmann::json &body)
@@ -1653,14 +1667,12 @@ void python_converter::get_function_definition(
       // String return types should be pointers, not arrays
       type.return_type() = gen_pointer_type(char_type());
     }
-    else if (
-      (return_type == "Tuple" || return_type == "tuple") &&
-      return_node["_type"] == "Subscript")
+    else if (is_subscripted_as(return_type, return_node, "Tuple", "tuple"))
     {
       type.return_type() =
         tuple_handler_->get_tuple_type_from_annotation(return_node);
     }
-    else if (return_type == "Callable" && return_node["_type"] == "Subscript")
+    else if (is_subscripted_as(return_type, return_node, "Callable"))
     {
       // A function returning a callable is the general shape of #6640: the
       // caller binds the result to a variable and calls through it, so the
@@ -1668,7 +1680,7 @@ void python_converter::get_function_definition(
       // pointer has an empty return type, which leaves every such call nondet.
       type.return_type() = get_callable_type(return_node, function_node);
     }
-    else if (return_type == "Optional" && return_node["_type"] == "Subscript")
+    else if (is_subscripted_as(return_type, return_node, "Optional"))
     {
       // Optional[T]: delegate to the annotation handler, which builds either
       // an Optional<T> struct (for primitive T) or a T* pointer (for str /

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -1660,6 +1660,14 @@ void python_converter::get_function_definition(
       type.return_type() =
         tuple_handler_->get_tuple_type_from_annotation(return_node);
     }
+    else if (return_type == "Callable" && return_node["_type"] == "Subscript")
+    {
+      // A function returning a callable is the general shape of #6640: the
+      // caller binds the result to a variable and calls through it, so the
+      // return type has to carry the signature. The generic `Callable`
+      // pointer has an empty return type, which leaves every such call nondet.
+      type.return_type() = get_callable_type(return_node, function_node);
+    }
     else if (return_type == "Optional" && return_node["_type"] == "Subscript")
     {
       // Optional[T]: delegate to the annotation handler, which builds either

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -467,6 +467,19 @@ void python_converter::adjust_statement_types(exprt &lhs, exprt &rhs) const
     }
   }
 }
+/// True when @p spelling names the built-in @p lower / @p upper and no
+/// user-defined class of that name shadows it.
+static bool names_builtin(
+  const std::string &spelling,
+  const char *lower,
+  const char *upper,
+  const nlohmann::json &ast)
+{
+  if (spelling != lower && spelling != upper)
+    return false;
+  return !json_utils::is_class(spelling, ast);
+}
+
 std::pair<std::string, typet>
 python_converter::extract_type_info(const nlohmann::json &var_node)
 {
@@ -528,13 +541,9 @@ python_converter::extract_type_info(const nlohmann::json &var_node)
 
     // User-defined classes named "list"/"List" or "dict"/"Dict" take priority
     // over the built-in types when used as a plain Name annotation.
-    if (
-      (var_type_str == "dict" || var_type_str == "Dict") &&
-      !json_utils::is_class(var_type_str, *ast_json))
+    if (names_builtin(var_type_str, "dict", "Dict", *ast_json))
       var_typet = dict_handler_->get_dict_struct_type();
-    else if (
-      (var_type_str == "list" || var_type_str == "List") &&
-      !json_utils::is_class(var_type_str, *ast_json))
+    else if (names_builtin(var_type_str, "list", "List", *ast_json))
       var_typet = type_handler_.get_list_type();
     else
       var_typet = type_handler_.get_typet(var_type_str, type_size);

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -515,6 +515,17 @@ python_converter::extract_type_info(const nlohmann::json &var_node)
     if (var_type_str.empty())
       return {var_type_str, var_typet};
 
+    // A spelled `Callable[[A], R]` keeps its signature, so a call through the
+    // variable recovers R. A bare one -- what the annotation pass infers for a
+    // variable bound to a function value -- resolves to a pointer whose code
+    // type returns void, leaving that call nondet: worse than no annotation at
+    // all, since an unannotated binding takes the callee's own return type. So
+    // defer to the RHS instead (#6640).
+    if (var_type_str == "Callable")
+      return {
+        var_type_str,
+        ann.contains("slice") ? get_callable_type(ann, var_node) : typet()};
+
     // User-defined classes named "list"/"List" or "dict"/"Dict" take priority
     // over the built-in types when used as a plain Name annotation.
     if (

--- a/src/python-frontend/converter/converter_types.cpp
+++ b/src/python-frontend/converter/converter_types.cpp
@@ -176,6 +176,33 @@ python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
   return inner_type;
 }
 
+/// `Callable[[A, B], R]` as `R (*)(A, B)`, which parses as
+/// Subscript(slice=Tuple([List([A, B]), R])). Carrying the signature lets a
+/// call through the value recover the return type; a bare `Callable`, or one
+/// whose signature is not spelled, keeps the generic function pointer, whose
+/// empty return type leaves every call through it nondet.
+typet python_converter::get_callable_type(
+  const nlohmann::json &annotation,
+  const nlohmann::json &stmt)
+{
+  code_typet fn_type;
+  const nlohmann::json &slice = annotation["slice"];
+  if (
+    slice.is_object() && slice.value("_type", "") == "Tuple" &&
+    slice.contains("elts") && slice["elts"].size() == 2 &&
+    slice["elts"][0].value("_type", "") == "List")
+  {
+    for (const auto &arg : slice["elts"][0]["elts"])
+      fn_type.arguments().push_back(
+        code_typet::argumentt(get_type_from_annotation(arg, stmt)));
+    fn_type.return_type() = get_type_from_annotation(slice["elts"][1], stmt);
+  }
+
+  return fn_type.return_type().is_nil()
+           ? type_handler_.get_typet(std::string("Callable"))
+           : gen_pointer_type(fn_type);
+}
+
 typet python_converter::get_type_from_annotation(
   const nlohmann::json &annotation_node,
   const nlohmann::json &element)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -125,6 +125,12 @@ public:
     const nlohmann::json &element);
 
   std::string get_op(const std::string &op, const typet &type) const;
+  /// `Callable[[A, B], R]` as the function-pointer type `R (*)(A, B)`; the
+  /// generic `Callable` pointer when the signature is not spelled.
+  typet get_callable_type(
+    const nlohmann::json &annotation,
+    const nlohmann::json &stmt);
+
   typet get_type_from_annotation(
     const nlohmann::json &annotation_node,
     const nlohmann::json &element);


### PR DESCRIPTION
A `Callable[[A], R]` annotation resolved to the generic function pointer, whose
code type returns void, so a call through the value it types was nondet. That
made `-> Callable[[int], int]` worse than no annotation at all, since an
unannotated binding takes the callee's own return type. Carry the spelled
signature on returns and variables, and defer a bare `Callable` to the RHS.

Refs #6640