### PR TITLE
[goto-coverage] Drop the unguarded lookup in report_dead_code

### DIFF
--- a/regression/esbmc/cwe_dead_code_guard_polarity/main.c
+++ b/regression/esbmc/cwe_dead_code_guard_polarity/main.c
@@ -1,8 +1,8 @@
 extern int __VERIFIER_nondet_int(void);
 
 // Pins both polarities of the guard named in a dead-code advisory. `flag` also
-// pins that the negation is derived from the expression: flipping the probe's
-// comment text would print "!flag" here.
+// pins expression-level negation: the surviving probe's comment is "!flag", so
+// printing it gives "!flag" and wrapping it in !(...) gives "!(!flag)".
 int main(void)
 {
   _Bool flag = 0;

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1028,10 +1028,11 @@ static bool is_kpath_maximal(const std::string &claim_sig)
 // instrumented assertion over a branch guard) that multi_property_check never
 // violated proves `!c` infeasible up to the current unwinding bound — so `!c`
 // is the dead direction, and the advisory names goto_coveraget::claim_negation
-// rather than the claim's own comment. The dead set is therefore
-// `all_claims \ reached_claims`. Findings are advisory: they are printed as a
-// separate [Dead code] section and, when --sarif-output is set, emitted at
-// SARIF note level. They never flip the verdict (see report_result).
+// rather than the claim's own comment. claim_negation is keyed by, and rebuilt
+// with, goto_coveraget::all_claims, so the dead set is exactly the entries
+// below that reached_claims does not hold. Findings are advisory: they are
+// printed as a separate [Dead code] section and, when --sarif-output is set,
+// emitted at SARIF note level. They never flip the verdict (see report_result).
 static void report_dead_code(
   const optionst &options,
   const std::unordered_set<std::string> &reached_claims,
@@ -1039,15 +1040,11 @@ static void report_dead_code(
 {
   std::vector<dead_code_finding_t> findings;
 
-  for (const auto &[comment, loc] : goto_coveraget::all_claims)
+  for (const auto &[claim, dead_guard] : goto_coveraget::claim_negation)
   {
-    const std::string claim_sig = comment + "\t" + loc;
-    if (reached_claims.count(claim_sig))
+    const auto &[comment, loc] = claim;
+    if (reached_claims.count(comment + "\t" + loc))
       continue; // reachable branch direction — live code
-
-    // Populated in lockstep with all_claims, so the key is always present.
-    const std::string &dead_guard =
-      goto_coveraget::claim_negation.at({comment, loc});
 
     nlohmann::json parsed = parse_claim_location(loc);
     dead_code_finding_t f;

--- a/src/goto-programs/goto_coverage.h
+++ b/src/goto-programs/goto_coverage.h
@@ -100,9 +100,9 @@ public:
   // Guard text of the opposite direction for each claim in all_claims, keyed
   // the same way. A probe assert(c) left unviolated proves !c infeasible, so
   // --dead-code-check names this rather than the claim's own comment. Derived
-  // from the expression, not by flipping the comment text: from_expr
-  // parenthesises by precedence, so !flag negates to flag but a > b negates
-  // to !(a > b).
+  // from the expression, not by rewriting the comment text: gen_not_expr drops
+  // a leading not2t, so the comment "!flag" gives "flag" and not "!(!flag)",
+  // and from_expr re-parenthesises by precedence, so "x > 5" gives "!(x > 5)".
   static std::map<std::pair<std::string, std::string>, std::string>
     claim_negation;
 


### PR DESCRIPTION
Follow-up to #7295 (already merged). Review of that PR turned up one
robustness defect and two inaccurate rationale comments.

### `report_dead_code` lookup

`report_dead_code` iterated `goto_coveraget::all_claims` and then indexed
`goto_coveraget::claim_negation` with `std::map::at()`. The two are built in
lockstep in `get_total_cond_assert()`, so the key is present today — but the
invariant is only documented in a comment, and `at()` turns any future drift
into an uncaught `std::out_of_range` (ESBMC terminating instead of printing a
report) rather than a degraded advisory.

Iterating `claim_negation` directly keys the loop off a single container. The
map's key type and comparator are identical to the set's and the key set is
`all_claims` by construction, so **iteration order and report output are
unchanged**; it also drops a per-claim temporary `pair<string,string>` copy and
a redundant O(log n) lookup.

### Comment corrections

- `goto_coverage.h`: the note said `from_expr` parenthesisation is why `!flag`
  negates to `flag`. Parenthesisation only explains the `a > b` → `!(a > b)`
  half; `!flag` → `flag` is `gen_not_expr` (goto_coverage.cpp:1222) stripping a
  leading `not2t`.
- `cwe_dead_code_guard_polarity/main.c`: the mutation note claimed flipping the
  probe's comment text would print `!flag`. A naive text flip of the surviving
  probe's comment `!flag` yields `!(!flag)`; `!flag` is what the *old* code
  printed by not flipping at all.

The test comment is held to exactly three lines so the `main.c:10` /
`main.c:13` pins in `test.desc` still resolve.

### Verification

- `git clang-format --diff upstream/master` — no changes to the touched lines.
- `-fsyntax-only -Wall -Wextra` using the real `compile_commands.json` command
  for `bmc.cpp` — clean, no warnings. This exercises the nested structured
  binding over `std::pair<const Key, T>`, the only real risk in the edit.

No local test run: this tree's build directory predates master by a month, so
CI is the verification. Behaviour is output-identical by construction, and
`cwe_dead_code_guard_polarity`, `python/dead_code_guard_polarity` and
`github_7267-genuine-dead-code` are the tests that cover it.

Follow-up issues for the findings not addressed here: #7302 (k-path guard is
double-negated), #7303 (claim_negation duplicates all_claims), #7304
(const getter rebuilds global state), #7305 (SARIF polarity untested).
