### PR TITLE
[python] Skip frontend-inserted branches in --dead-code-check

### DIFF
--- a/regression/goto-coverage/branch_cov_11/test.desc
+++ b/regression/goto-coverage/branch_cov_11/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.cpp
 --branch-coverage-claims --unwind 3 --no-unwinding-assertions
-^Branch Coverage: 83\.33
+^Branch Coverage: 75%
 ^COVERAGE ANALYSIS INCOMPLETE
 reason: the unwinding bound cut off

--- a/regression/python/github_3712/test.desc
+++ b/regression/python/github_3712/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.py
 --unwind 30 --branch-function-coverage --no-standard-checks --bitwuzla
-^Function Entry Points & Branches : 11
-^Reached : 11
+^Function Entry Points & Branches : 3
+^Reached : 3
 ^Branch Coverage: 100%
 ^.*function entry:.*validate_start_with_letter.*$
 ^COVERAGE ANALYSIS INCOMPLETE

--- a/regression/python/github_7296-guards/main.py
+++ b/regression/python/github_7296-guards/main.py
@@ -1,0 +1,16 @@
+def run():
+    d = {"a": 1, "b": 2}
+    s = "hello"
+    xs = [10, 20, 30]
+    q = 9 // 3
+    assert d["a"] + d["b"] + xs[2] + q == 36
+    assert s[1] == "e"
+    assert xs.index(20) == 1
+
+
+def main():
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/github_7296-guards/test.desc
+++ b/regression/python/github_7296-guards/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--dead-code-check
+^No provably-dead code found\.$
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7296-live/main.py
+++ b/regression/python/github_7296-live/main.py
@@ -1,0 +1,13 @@
+def classify(n: int) -> int:
+    values = [1, 2, 3]
+    if n > 0 and n < 0:
+        return values[0]
+    return values[1]
+
+
+def main():
+    assert classify(5) == 2
+
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/github_7296-live/test.desc
+++ b/regression/python/github_7296-live/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--dead-code-check
+main\.py:3: dead code: unreachable branch
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7296/main.py
+++ b/regression/python/github_7296/main.py
@@ -1,0 +1,14 @@
+# The IndexError guard on a subscript and the exception-propagation edge after
+# a call are frontend instrumentation, not branches of this program: an
+# unreachable bounds check is the proof the subscript is safe.
+def first(values):
+    return values[0]
+
+
+def main():
+    values = [1, 2, 3]
+    assert first(values) == 1
+
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/github_7296/test.desc
+++ b/regression/python/github_7296/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--dead-code-check
+^No provably-dead code found\.$
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1088,6 +1088,20 @@ static void report_dead_code(
   sarif_dead_code(options, findings, dead_stores);
 }
 
+/// Coverage numerator over the branch instrumentation. reached_claims records
+/// every claim symex refuted, including ones outside the instrumentation (an
+/// uncaught exception, say), so its raw size can exceed the goal count and
+/// report over 100% (#7296). all_claims is the instrumented set.
+static size_t
+count_reached_goals(const std::unordered_set<std::string> &reached_claims)
+{
+  size_t reached = 0;
+  for (const auto &[comment, loc] : goto_coveraget::all_claims)
+    if (reached_claims.count(comment + "\t" + loc))
+      ++reached;
+  return reached;
+}
+
 void report_coverage(
   const optionst &options,
   std::unordered_set<std::string> &reached_claims,
@@ -1305,9 +1319,7 @@ void report_coverage(
   else if (is_branch_cov)
   {
     const size_t total = goto_coveraget::total_branch;
-    // this also included the non-unwinding-assertions
-    // which is not what we want
-    const size_t tracked_instance = reached_claims.size();
+    const size_t tracked_instance = count_reached_goals(reached_claims);
     log_success("\n[Coverage]\n");
     log_result("Branches : {}", total);
     log_result("Reached : {}", tracked_instance);
@@ -1331,9 +1343,7 @@ void report_coverage(
     //! Might got incorrect total number when using --k-induction
     //! due to that the symex->goto_functions has been simplified
     const size_t total = goto_coveraget::total_func_branch;
-    // this also included the non-unwinding-assertions
-    // which is not what we want
-    const size_t tracked_instance = reached_claims.size();
+    const size_t tracked_instance = count_reached_goals(reached_claims);
     log_success("\n[Coverage]\n");
     log_result("Function Entry Points & Branches : {}", total);
     log_result("Reached : {}", tracked_instance);

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -1644,6 +1644,7 @@ private:
     auto g = body.insert(std::next(call));
     g->make_goto(dest, thrown);
     g->location = call->location;
+    g->location.property("skipped");
     g->function = call->function;
   }
 };

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -1670,6 +1670,7 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     guard.cond() = is_zero;
     guard.then_case() = throw_code;
     guard.location() = div_loc;
+    guard.location().property("skipped");
     add_instruction(guard);
   }
 

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -296,6 +296,7 @@ code_blockt python_converter::create_capture_cells(
     bind.then_case() = code_assignt(cell, nondet);
     bind.else_case() = code_assignt(cell, source_expr);
     bind.location() = location;
+    bind.location().property("skipped");
     bindings.copy_to_operands(bind);
 
     code_assignt mark(is_bound, gen_boolean(true));

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -717,6 +717,7 @@ void dynamic_type_handler::guard_zero_division(
   guard.cond() = build_and(type_ok, is_zero);
   guard.then_case() = throw_code;
   guard.location() = location;
+  guard.location().property("skipped");
   converter_.add_instruction(guard);
 }
 

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -956,6 +956,7 @@ exprt function_call_expr::build_constant_from_arg() const
         guard.cond() = migrate_expr_back(not2tc(valid2));
         guard.then_case() = throw_code;
         guard.location() = loc;
+        guard.location().property("skipped");
         converter_.add_instruction(guard);
 
         return sh.handle_string_to_float(expr, loc);
@@ -3516,6 +3517,7 @@ exprt function_call_expr::handle_math_function_dispatch()
     guard.cond() = domain_check;
     guard.then_case() = raise_code;
     guard.location() = loc;
+    guard.location().property("skipped");
 
     // Add the guard to the current block
     converter_.current_block->copy_to_operands(guard);
@@ -3552,6 +3554,7 @@ exprt function_call_expr::handle_math_function_dispatch()
     guard.cond() = domain_check;
     guard.then_case() = raise_code;
     guard.location() = loc;
+    guard.location().property("skipped");
     converter_.current_block->copy_to_operands(guard);
     return converter_.get_math_handler().handle_log(arg_expr, call_);
   }
@@ -3591,6 +3594,7 @@ exprt function_call_expr::handle_math_function_dispatch()
     guard.cond() = domain_check;
     guard.then_case() = raise_code;
     guard.location() = loc;
+    guard.location().property("skipped");
 
     converter_.current_block->copy_to_operands(guard);
 

--- a/src/python-frontend/math/complex_handler.cpp
+++ b/src/python-frontend/math/complex_handler.cpp
@@ -172,6 +172,7 @@ exprt complex_handler::complex_div(
   guard.cond() = denom_is_zero;
   guard.then_case() = raise_code;
   guard.location() = loc;
+  guard.location().property("skipped");
 
   converter_.current_block->copy_to_operands(guard);
   return normal_result;

--- a/src/python-frontend/python-dict/dict_access.cpp
+++ b/src/python-frontend/python-dict/dict_access.cpp
@@ -118,6 +118,7 @@ exprt python_dict_handler::handle_dict_subscript(
     key_check.cond() = key_not_found;
     key_check.then_case() = throw_block;
     key_check.location() = location;
+    key_check.location().property("skipped");
     converter_.add_instruction(key_check);
   }
 
@@ -563,6 +564,7 @@ void python_dict_handler::handle_dict_subscript_assign(
   if_stmt.then_case() = update_block;
   if_stmt.else_case() = insert_block;
   if_stmt.location() = location;
+  if_stmt.location().property("skipped");
 
   target_block.copy_to_operands(if_stmt);
 }
@@ -728,6 +730,7 @@ void python_dict_handler::handle_dict_delete(
   if_stmt.then_case() = delete_block;
   if_stmt.else_case() = raise_code;
   if_stmt.location() = location;
+  if_stmt.location().property("skipped");
 
   target_block.copy_to_operands(if_stmt);
 }

--- a/src/python-frontend/python-dict/dict_methods.cpp
+++ b/src/python-frontend/python-dict/dict_methods.cpp
@@ -272,6 +272,7 @@ exprt python_dict_handler::handle_dict_get(
   if_stmt.then_case() = then_block;
   if_stmt.else_case() = else_block;
   if_stmt.location() = location;
+  if_stmt.location().property("skipped");
   converter_.add_instruction(if_stmt);
 
   return build_symbol(result_var);
@@ -584,6 +585,7 @@ exprt python_dict_handler::handle_dict_setdefault(
   if_stmt.then_case() = then_block;
   if_stmt.else_case() = else_block;
   if_stmt.location() = location;
+  if_stmt.location().property("skipped");
   converter_.add_instruction(if_stmt);
 
   return build_symbol(result_var);
@@ -893,6 +895,7 @@ exprt python_dict_handler::handle_dict_pop(
   if_stmt.then_case() = then_block;
   if_stmt.else_case() = else_block;
   if_stmt.location() = location;
+  if_stmt.location().property("skipped");
   converter_.add_instruction(if_stmt);
 
   return build_symbol(result_var);
@@ -1153,6 +1156,7 @@ exprt python_dict_handler::handle_dict_popitem(
   if_stmt.then_case() = empty_block;
   if_stmt.else_case() = nonempty_block;
   if_stmt.location() = location;
+  if_stmt.location().property("skipped");
   converter_.add_instruction(if_stmt);
 
   return build_symbol(result_var);

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -161,6 +161,7 @@ exprt python_list::build_list_at_call(
     guard.cond() = migrate_expr_back(oob);
     guard.then_case() = throw_code;
     guard.location() = location;
+    guard.location().property("skipped");
     converter_.add_instruction(guard);
   }
 
@@ -619,6 +620,7 @@ exprt python_list::index_bool_mask_rows(
     guard.cond() = migrate_expr_back(oob);
     guard.then_case() = throw_code;
     guard.location() = location;
+    guard.location().property("skipped");
     converter_.add_instruction(guard);
   }
 
@@ -1088,6 +1090,7 @@ exprt python_list::resolve_fixed_axis_index(
     guard.cond() = migrate_expr_back(oob);
     guard.then_case() = throw_code;
     guard.location() = location;
+    guard.location().property("skipped");
     converter_.add_instruction(guard);
   }
 
@@ -2152,6 +2155,7 @@ exprt python_list::normalize_and_scale_index(
   normalize_guard.cond() = idx_lt_zero;
   normalize_guard.then_case() = normalize;
   normalize_guard.location() = loc;
+  normalize_guard.location().property("skipped");
   converter_.add_instruction(normalize_guard);
 
   const type2tc ll_type2 = migrate_type(ll_type);
@@ -2171,6 +2175,7 @@ exprt python_list::normalize_and_scale_index(
   oob_guard.cond() = migrate_expr_back(or2tc(still_negative, past_end));
   oob_guard.then_case() = throw_code;
   oob_guard.location() = loc;
+  oob_guard.location().property("skipped");
   converter_.add_instruction(oob_guard);
 
   exprt scaled =
@@ -4057,6 +4062,7 @@ exprt python_list::handle_index_access(
     norm_guard.cond() = idx_lt_zero;
     norm_guard.then_case() = normalize;
     norm_guard.location() = loc;
+    norm_guard.location().property("skipped");
     converter_.add_instruction(norm_guard);
 
     // --- 4. OOB check: if (idx < 0 || idx >= (ll)len) raise IndexError ---
@@ -4077,6 +4083,7 @@ exprt python_list::handle_index_access(
     oob_guard.cond() = migrate_expr_back(or2tc(still_neg, idx_ge_len));
     oob_guard.then_case() = throw_code;
     oob_guard.location() = loc;
+    oob_guard.location().property("skipped");
     converter_.add_instruction(oob_guard);
 
     // --- 5. __python_str_slice(array, idx, idx+1, 1) ---

--- a/src/python-frontend/python-list/list_construction.cpp
+++ b/src/python-frontend/python-list/list_construction.cpp
@@ -73,6 +73,7 @@ exprt python_list::build_symbolic_fill_list(
     guard.cond() = build_less_than(size, gen_zero(size.type()));
     guard.then_case() = throw_code;
     guard.location() = location;
+    guard.location().property("skipped");
     converter_.add_instruction(guard);
   }
 

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -1391,5 +1391,6 @@ exprt python_list::build_remove_list_call(
   guard.cond() = migrate_expr_back(not2tc(rr2));
   guard.then_case() = throw_code;
   guard.location() = elem_info.location;
+  guard.location().property("skipped");
   return guard;
 }

--- a/src/python-frontend/python-list/list_query.cpp
+++ b/src/python-frontend/python-list/list_query.cpp
@@ -771,6 +771,7 @@ exprt python_list::build_min_max_for_mixed_numeric(
     ite.cond() = condition;
     ite.then_case() = code_assignt(result, elem);
     ite.location() = loc;
+    ite.location().property("skipped");
     converter_.add_instruction(ite);
   }
 
@@ -882,6 +883,7 @@ exprt python_list::build_index_list_call(
   guard.cond() = not_found;
   guard.then_case() = throw_code;
   guard.location() = elem_info.location;
+  guard.location().property("skipped");
   converter_.add_instruction(guard);
 
   return build_symbol(idx);
@@ -950,6 +952,7 @@ exprt python_list::build_index_range_list_call(
   guard.cond() = not_found;
   guard.then_case() = throw_code;
   guard.location() = elem_info.location;
+  guard.location().property("skipped");
   converter_.add_instruction(guard);
 
   return build_symbol(idx);

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -2429,6 +2429,7 @@ exprt string_handler::build_string_index_result(
   if_stmt.cond() = not_found;
   if_stmt.then_case() = raise_code;
   if_stmt.location() = location;
+  if_stmt.location().property("skipped");
   converter_.add_instruction(if_stmt);
 
   return build_symbol(find_result);


### PR DESCRIPTION
The Python frontend's runtime-error guards (IndexError, KeyError, ValueError,
ZeroDivisionError) and the exception-propagation edge `remove_exceptions` adds
after each call carried a user-source location and no `skipped` property, so
`--dead-code-check` probed them and reported CWE-561 on clean programs. Tagging
them matches the existing short-circuit lowering; the `while <call>()` exit
branch stays probed since it is the user's own condition.

Fixes #7296