### PR TITLE
[python] Emit one bounds check per subscript, not two

### DIFF
--- a/regression/python/github_7296-negative-index/main.py
+++ b/regression/python/github_7296-negative-index/main.py
@@ -1,0 +1,9 @@
+def main():
+    xs = [10, 20, 30]
+    i = -1
+    t = xs[i]
+    assert t == 30
+
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/github_7296-negative-index/test.desc
+++ b/regression/python/github_7296-negative-index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7296-oob-caught/main.py
+++ b/regression/python/github_7296-oob-caught/main.py
@@ -1,0 +1,12 @@
+def main():
+    xs = [10, 20, 30]
+    i = 5
+    try:
+        t = xs[i]
+        assert False
+    except IndexError:
+        assert True
+
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/github_7296-oob-caught/test.desc
+++ b/regression/python/github_7296-oob-caught/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7296-single-bounds-check/main.py
+++ b/regression/python/github_7296-single-bounds-check/main.py
@@ -1,0 +1,9 @@
+def main():
+    xs = [10, 20, 30]
+    i = 1
+    t = xs[i]
+    assert t == 20
+
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/github_7296-single-bounds-check/test.desc
+++ b/regression/python/github_7296-single-bounds-check/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--goto-functions-only
+\A(?:(?!=list_size\(xs\))[\s\S])*=list_size\(xs\)(?:(?!=list_size\(xs\))[\s\S])*\Z

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -88,7 +88,10 @@ exprt python_list::build_list_at_call(
   // execution step purely to prove what the index's type already guarantees.
   const bool index_may_be_negative = !index.type().is_unsignedbv();
 
-  if (!index_may_be_negative)
+  // A discarded type probe only reads this call's type, and the real RHS
+  // build re-emits the whole check; normalizing here would emit a second
+  // __ESBMC_list_size call and IndexError guard per subscript assignment.
+  if (!index_may_be_negative || converter_.in_rhs_type_probe_)
   {
     exprt index_as_size = build_typecast(index, size_type());
     exprt list_at_call = build_call_expr(


### PR DESCRIPTION
`create_symbol_for_unannotated_assign` converts an assignment's RHS once purely
to read its type, and that discarded probe made `python_list::at()` emit a whole
`__ESBMC_list_size` call plus IndexError guard that the real RHS build then
emitted again — so `t = xs[i]` cost two while `if xs[i] > 0` cost one. The probe
only reads the call's type, which the negative-index normalization does not
change, so it now takes the same short-circuit already used for numpy views.
On an 8-iteration double-subscript loop symex drops from 1818 to 1448
assignments (-20%).

Reported as the secondary defect in #7296.