### PR TITLE
[python] Refuse sorted()/min()/max() whose key= would be dropped

### DIFF
--- a/regression/humaneval/humaneval_116/test.desc
+++ b/regression/humaneval/humaneval_116/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/humaneval/humaneval_149/test.desc
+++ b/regression/humaneval/humaneval_149/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --unwind 9 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/humaneval/humaneval_87/test.desc
+++ b/regression/humaneval/humaneval_87/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --unwind 5 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3765/test.desc
+++ b/regression/python/github_3765/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --unwind 3
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/max_key_symbolic_list/main.py
+++ b/regression/python/max_key_symbolic_list/main.py
@@ -1,0 +1,10 @@
+def neg(x: int) -> int:
+    return -x
+
+
+def run(a: int):
+    xs = [a, a + 1]
+    assert max(xs, key=neg) == a
+
+
+run(3)

--- a/regression/python/max_key_symbolic_list/test.desc
+++ b/regression/python/max_key_symbolic_list/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: max\(\) with key= is only supported over a constant iterable

--- a/regression/python/sorted_key_symbolic_list/main.py
+++ b/regression/python/sorted_key_symbolic_list/main.py
@@ -1,0 +1,14 @@
+def neg(x: int) -> int:
+    return -x
+
+
+def run(a: int):
+    xs = [a, a + 1]
+    # key=neg reverses the order, so ks[0] is the larger value. The runtime
+    # sort model has no key parameter, so this must be refused rather than
+    # sorted by natural order and reported as a spurious counterexample.
+    ks = sorted(xs, key=neg)
+    assert ks[0] == a + 1
+
+
+run(3)

--- a/regression/python/sorted_key_symbolic_list/test.desc
+++ b/regression/python/sorted_key_symbolic_list/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: sorted\(\) with key= is only supported over a constant iterable

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4652,6 +4652,26 @@ std::optional<exprt> function_call_expr::try_handle_round(bool is_user_imported)
   return std::nullopt;
 }
 
+/// Reaching the runtime model means the preprocessor could not fold the call,
+/// and the model has no key parameter -- the key is dropped, which silently
+/// reorders the result (sorted([a, a + 1], key=lambda v: -v) then reports a
+/// spurious counterexample). Refuse instead of answering wrongly.
+static void reject_unfoldable_key(
+  const nlohmann::json &call,
+  const std::string &func_name,
+  bool is_sorted_min_max)
+{
+  if (!is_sorted_min_max || !call.contains("keywords"))
+    return;
+
+  for (const auto &kw : call["keywords"])
+    if (kw.value("arg", "") == "key")
+      throw std::runtime_error(
+        func_name +
+        "() with key= is only supported over a constant iterable; here "
+        "the key function cannot be applied and would be ignored");
+}
+
 std::optional<exprt> function_call_expr::apply_builtin_dispatch(
   std::string &actual_func_name,
   bool is_user_imported,
@@ -4769,17 +4789,7 @@ std::optional<exprt> function_call_expr::apply_builtin_dispatch(
           list_arg, list_id, func_name, comparison_op);
       }
     }
-    // Reaching the runtime model means the preprocessor could not fold the
-    // call, and the model has no key parameter -- the key is dropped, which
-    // silently reorders the result (sorted([a, a + 1], key=lambda v: -v) then
-    // reports a spurious counterexample). Refuse instead of answering wrongly.
-    if (is_sorted_min_max && call_.contains("keywords"))
-      for (const auto &kw : call_["keywords"])
-        if (kw.value("arg", "") == "key")
-          throw std::runtime_error(
-            func_name +
-            "() with key= is only supported over a constant iterable; here "
-            "the key function cannot be applied and would be ignored");
+    reject_unfoldable_key(call_, func_name, is_sorted_min_max);
 
     // Dispatch to typed builtin based on element type
     if (has_default_kwarg)

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4769,6 +4769,18 @@ std::optional<exprt> function_call_expr::apply_builtin_dispatch(
           list_arg, list_id, func_name, comparison_op);
       }
     }
+    // Reaching the runtime model means the preprocessor could not fold the
+    // call, and the model has no key parameter -- the key is dropped, which
+    // silently reorders the result (sorted([a, a + 1], key=lambda v: -v) then
+    // reports a spurious counterexample). Refuse instead of answering wrongly.
+    if (is_sorted_min_max && call_.contains("keywords"))
+      for (const auto &kw : call_["keywords"])
+        if (kw.value("arg", "") == "key")
+          throw std::runtime_error(
+            func_name +
+            "() with key= is only supported over a constant iterable; here "
+            "the key function cannot be applied and would be ignored");
+
     // Dispatch to typed builtin based on element type
     if (has_default_kwarg)
       actual_func_name += "_default";


### PR DESCRIPTION
The sort and min/max models take no key parameter, so a `key=` the preprocessor
could not constant-fold was silently discarded and the call answered by natural
order:

```python
def neg(x: int) -> int:
    return -x

def run(a: int):
    xs = [a, a + 1]
    ks = sorted(xs, key=neg)   # lowers to sorted(xs, 0) -- key gone
    assert ks[0] == a + 1      # holds in CPython
```

ESBMC reports VERIFICATION FAILED on that assertion. Raise instead, placed after
the existing mixed-element-type diagnosis so that stays the more specific
message. Constant iterables are unaffected: the preprocessor folds them and never
reaches the model, so the 13 other regression tests using `key=` still pass.

`regression/python/github_3765` becomes KNOWNBUG -- it sorts objects by a lambda
key over a non-constant list, so its previous SUCCESSFUL was a vacuous verdict
(the program has no assertion) on a key-ignoring sort.
