### PR TITLE
[python] Dispatch explicit __getitem__/__len__/__contains__ calls

### DIFF
--- a/regression/python/dunder_getitem_len_contains/main.py
+++ b/regression/python/dunder_getitem_len_contains/main.py
@@ -1,0 +1,10 @@
+def run():
+    w = {"a": 10, "b": 20}
+    xs = [1, 2, 3]
+    assert w.__len__() == 2
+    assert xs.__len__() == 3
+    assert w.__contains__("a")
+    assert xs.__getitem__(1) == 2
+
+
+run()

--- a/regression/python/dunder_getitem_len_contains/test.desc
+++ b/regression/python/dunder_getitem_len_contains/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dunder_getitem_wrong_value_fail/main.py
+++ b/regression/python/dunder_getitem_wrong_value_fail/main.py
@@ -1,0 +1,8 @@
+def run():
+    w = {"a": 10, "b": 20}
+    # 20 is w["b"], not w["a"]: the call must really read the dict, not just
+    # avoid raising AttributeError.
+    assert w.__getitem__("a") == 20
+
+
+run()

--- a/regression/python/dunder_getitem_wrong_value_fail/test.desc
+++ b/regression/python/dunder_getitem_wrong_value_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/dunder_user_class/main.py
+++ b/regression/python/dunder_user_class/main.py
@@ -1,0 +1,27 @@
+class Box:
+    def __init__(self, n: int):
+        self.n = n
+
+    def __getitem__(self, i: int) -> int:
+        return self.n + i
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __contains__(self, v: int) -> bool:
+        return v < self.n
+
+
+def run():
+    b = Box(3)
+    # Rewriting the dunder call to the operator must keep dispatching back to
+    # the class's own definition.
+    assert b.__getitem__(2) == 5
+    assert b[2] == 5
+    assert b.__len__() == 3
+    assert len(b) == 3
+    assert b.__contains__(1)
+    assert 1 in b
+
+
+run()

--- a/regression/python/dunder_user_class/test.desc
+++ b/regression/python/dunder_user_class/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -1439,8 +1439,40 @@ class CoreVisitorsMixin:
         self.generic_visit(node)
         return node
 
+    _OPERATOR_DUNDERS = {"__getitem__": 1, "__len__": 0, "__contains__": 1}
+
+    def _maybe_rewrite_operator_dunder_call(self, node):
+        """Rewrite an explicit operator dunder call to the operator itself.
+
+        ``d.__getitem__(k)`` -> ``d[k]``, ``x.__len__()`` -> ``len(x)``,
+        ``x.__contains__(v)`` -> ``v in x``. The frontend models the operators
+        but not the method spelling, so the latter raised AttributeError and the
+        run failed on correct code. The two forms are equivalent in Python, and
+        for a user class defining the dunder the operator dispatches back to it.
+        """
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr in self._OPERATOR_DUNDERS
+                and not node.keywords and len(node.args) == self._OPERATOR_DUNDERS[node.func.attr]):
+            return None
+
+        receiver = node.func.value
+        if node.func.attr == "__getitem__":
+            rewritten = ast.Subscript(value=receiver, slice=node.args[0], ctx=ast.Load())
+        elif node.func.attr == "__len__":
+            rewritten = ast.Call(func=ast.Name(id="len", ctx=ast.Load()),
+                                 args=[receiver],
+                                 keywords=[])
+        else:
+            rewritten = ast.Compare(left=node.args[0], ops=[ast.In()], comparators=[receiver])
+
+        ast.copy_location(rewritten, node)
+        ast.fix_missing_locations(rewritten)
+        return self.visit(rewritten)
+
     def visit_Call(self, node):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,import-outside-toplevel,no-else-raise
         self._invalidate_list_literals_for_call(node)
+        rewritten_dunder = self._maybe_rewrite_operator_dunder_call(node)
+        if rewritten_dunder is not None:
+            return rewritten_dunder
         rewritten_dict_list = self._maybe_rewrite_dict_to_list_call(node)
         if rewritten_dict_list is not None:
             return rewritten_dict_list


### PR DESCRIPTION
The frontend models the subscript, `len()` and `in` operators but not their
method spellings, so these raised AttributeError and correct programs reported
VERIFICATION FAILED:

```python
w = {"a": 10, "b": 20}
xs = [1, 2, 3]
assert w.__getitem__("a") == 10   # was: uncaught exception: AttributeError
assert xs.__len__() == 3
assert w.__contains__("a")
```

Each is rewritten to its operator in the preprocessor. The forms are equivalent
in Python, and for a user class defining the dunder the operator dispatches back
to it — `dunder_user_class` asserts both spellings agree on such a class, and it
passes before and after, so it is a no-regression guard rather than a
discriminator.

`__setitem__` is left alone: it is a statement, not an expression, so it does not
fit this rewrite.

Based on master, independent of the #7313 → #7314 → #7315 stack. It is what that
stack's remaining gap needs, though: `sorted(d, key=d.__getitem__)` is refused
there because `d.__getitem__(k)` gave a wrong verdict, which this fixes.
