### PR TITLE
[python] Keep a dict view's element types when it is sliced

### DIFF
--- a/regression/python/dict_keys_slice_elem_type/main.py
+++ b/regression/python/dict_keys_slice_elem_type/main.py
@@ -1,0 +1,9 @@
+def run():
+    w = {(1, 2): 10, (3, 4): 20}
+    vs = list(w.keys())[0:2]
+    u, v = vs[1]
+    assert u == 3
+    assert v == 4
+
+
+run()

--- a/regression/python/dict_keys_slice_elem_type/test.desc
+++ b/regression/python/dict_keys_slice_elem_type/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_keys_slice_order_fail/main.py
+++ b/regression/python/dict_keys_slice_order_fail/main.py
@@ -1,0 +1,10 @@
+def run():
+    w = {(1, 2): 10, (3, 4): 20}
+    ks = list(w.keys())[:]
+    u, v = ks[0]
+    # (3, 4) is ks[1], not ks[0]: the slice must keep the elements in order,
+    # not merely keep them unpackable.
+    assert u == 3
+
+
+run()

--- a/regression/python/dict_keys_slice_order_fail/test.desc
+++ b/regression/python/dict_keys_slice_order_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/dict_values_slice_elem_type/main.py
+++ b/regression/python/dict_values_slice_elem_type/main.py
@@ -1,0 +1,9 @@
+def run():
+    w = {"a": (1, 2), "b": (3, 4)}
+    vs = list(w.values())[:]
+    u, v = vs[0]
+    assert u == 1
+    assert v == 2
+
+
+run()

--- a/regression/python/dict_values_slice_elem_type/test.desc
+++ b/regression/python/dict_values_slice_elem_type/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -1,4 +1,5 @@
 #include "python_list_internal.h"
+#include <python-frontend/python-dict/python_dict_handler.h>
 #include <python-frontend/numpy/ndarray_descriptor.h>
 #include <algorithm>
 #include <optional>
@@ -2256,6 +2257,40 @@ exprt python_list::normalize_negative_slice_bound(
     if2tc(size_t2, greaterthan2tc(abs2, len2), clamped2, converted2));
 }
 
+/// A dict view (d.keys()[:] / d.values()[:]) is a member expression, so
+/// handle_range_slice's element-by-element copy never runs and its id-keyed
+/// fallbacks cannot reach it: the entries live under the dict's internal list
+/// id. Without this the slice result is untyped and a tuple element reads back
+/// as a bare pointer, which unpacking then rejects.
+void python_list::copy_dict_view_elem_types(
+  const exprt &array,
+  const std::string &sliced_id)
+{
+  if (!list_type_map[sliced_id].empty() || array.id() != exprt::member)
+    return;
+
+  const exprt &dict_sym = array.op0();
+  const std::string component =
+    to_member_expr(array).get_component_name().as_string();
+  if (!dict_sym.is_symbol() || (component != "keys" && component != "values"))
+    return;
+
+  const std::string &src = python_dict_handler::get_internal_list_id(
+    dict_sym.identifier().as_string(), component == "keys");
+  if (!src.empty())
+    copy_type_info(src, sliced_id);
+
+  // Tuple values are recorded under $dict_value_types$ rather than the
+  // values-list id, so the copy above is a no-op for them.
+  if (component == "values" && list_type_map[sliced_id].empty())
+  {
+    const typet tuple_t =
+      converter_.get_dict_handler()->recorded_tuple_value_type(dict_sym);
+    if (!tuple_t.is_nil() && !tuple_t.is_empty())
+      add_type_info_entry(sliced_id, std::string(), tuple_t);
+  }
+}
+
 exprt python_list::handle_range_slice(
   const exprt &array,
   const nlohmann::json &slice_node)
@@ -2892,6 +2927,9 @@ exprt python_list::handle_range_slice(
   // numbers[:-1]), or where the source is a function parameter rather than a
   // locally constructed list, so list_type_map has no entries for it.
   const std::string &sliced_id = sliced_list.id.as_string();
+
+  copy_dict_view_elem_types(array, sliced_id);
+
   if (list_type_map[sliced_id].empty())
   {
     if (

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -732,6 +732,11 @@ private:
   exprt
   handle_range_slice(const exprt &array, const nlohmann::json &slice_node);
 
+  // Propagate a dict view's element types onto its slice result. Split out for
+  // the same reason as normalize_negative_slice_bound below.
+  void
+  copy_dict_view_elem_types(const exprt &array, const std::string &sliced_id);
+
   // handle_range_slice's process_bound: normalizes a literal negative bound
   // (-k) to logical_len - k, clamped for an out-of-range k -- see the call
   // site's own comment for why the clamp differs by step direction. Split


### PR DESCRIPTION
```python
w = {(1, 2): 10, (3, 4): 20}
ks = list(w.keys())[:]
u, v = ks[0]          # ERROR: Cannot unpack pointer
```

Slicing a dict view produced an untyped list, so a tuple element read back as a
bare pointer. A view is a member expression, so neither `handle_range_slice`'s
element-by-element copy nor its id-keyed fallbacks could reach the entries —
those live under the dict's internal list id. Copy from there instead, and for
tuple values from `$dict_value_types$`, where they are recorded rather than under
the values-list id (the same wrinkle `converter_stmt.cpp` already works around
for a bare `d.values()`).

`list(d.keys())` without the slice, and slicing a plain list of tuples, were both
already correct — only the combination was broken.

Based on master. Found while working the `key=` stack: it is one of two things
still blocking `sorted(d, key=d.__getitem__)` and hence
`regression/quixbugs/minimum_spanning_tree` (#4791).
