### PR TITLE
[om] Fix deque's back() return type and const_iterator conversion

### DIFF
--- a/regression/esbmc-cpp/deque/deque_back_reference/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_back_reference/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+#include <deque>
+
+int main()
+{
+  std::deque<int> d;
+  d.push_back(1);
+  d.push_back(2);
+  d.push_back(3);
+
+  d.back() = 42;
+  d.front() = 7;
+
+  assert(d.back() == 42);
+  assert(d.front() == 7);
+  assert(d[2] == 42);
+  assert(d[0] == 7);
+  assert(d[1] == 2);
+
+  int &r = d.back();
+  r -= 2;
+  assert(d.back() == 40);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_back_reference/test.desc
+++ b/regression/esbmc-cpp/deque/deque_back_reference/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_back_reference_fail/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_back_reference_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+#include <deque>
+
+int main()
+{
+  std::deque<int> d;
+  d.push_back(1);
+  d.push_back(2);
+
+  d.back() = 42;
+  assert(d.back() == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_back_reference_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_back_reference_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_back_reference_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_back_reference_fail/test.desc
@@ -2,3 +2,4 @@ CORE
 main.cpp
 --std=c++17 --incremental-bmc
 ^VERIFICATION FAILED$
+^\s*assertion d\.back\(\) == 2$

--- a/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+#include <deque>
+
+int main()
+{
+  std::deque<int> d;
+  d.push_back(1);
+  d.push_back(2);
+  d.push_back(3);
+
+  int s = 0;
+  for (std::deque<int>::const_iterator it = d.begin(); it != d.end(); ++it)
+    s += *it;
+  assert(s == 6);
+
+  std::deque<int>::const_iterator c = d.begin();
+  assert(*c == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator/test.desc
+++ b/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator_fail/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+#include <deque>
+
+int main()
+{
+  std::deque<int> d;
+  d.push_back(1);
+  d.push_back(2);
+
+  std::deque<int>::const_iterator c = d.begin();
+  assert(*c == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_iterator_to_const_iterator_fail/test.desc
@@ -2,3 +2,4 @@ CORE
 main.cpp
 --std=c++17 --incremental-bmc
 ^VERIFICATION FAILED$
+^\s*assertion \*c == 2$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -158,6 +158,12 @@ public:
       pos = i.pos;
       vec_pos = i.vec_pos;
     }
+    const_iterator(const iterator &i)
+    {
+      pointer = i.pointer;
+      pos = i.pos;
+      vec_pos = i.vec_pos;
+    }
     const_iterator()
     {
     }
@@ -716,7 +722,7 @@ public:
     return buf[1];
   }
 
-  value_type back()
+  reference back()
   {
     return buf[_size];
   }


### PR DESCRIPTION
Non-const `back()` returned `value_type`, so `d.back() = x` was a parse error
and mutations through it were lost; [sequence.reqmts] requires `reference`.
`const_iterator` also had no converting constructor from `iterator`, so
`const_iterator it = d.begin()` failed on a non-const deque. `map`, `set` and
`string` already carry that constructor — deque was the outlier.

Four regression tests pin both, including that a write through `back()` is
visible via `operator[]`; the two negative ones name the violated property, so a
dereference failure no longer passes for the assertion. Full `esbmc-cpp/deque`,
`queue` and `stack` suites are green (90 tests, 0 regressions).

Not covered: the mixed comparisons with `iterator` as the *left* operand
([tab:container.rev.req]), and the unguarded empty-deque `front()`/`back()` —
both pre-existing and left for follow-ups.

Refs #5868