### PR TITLE
[om] Pull the remaining C99 math functions into namespace std

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads/main.cpp
@@ -1,0 +1,34 @@
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  // [cmath.syn]: the C99 additions whose return type or extra parameter does
+  // not fit the plain float/double/long double shape.
+  assert(std::scalbn(1.5, 3) == 12.0);
+  assert(std::scalbn(1.5f, 3) == 12.0f);
+  assert(std::scalbln(1.5, 3L) == 12.0);
+
+  assert(std::fma(2.0, 3.0, 4.0) == 10.0);
+  assert(std::fma(2.0f, 3.0f, 4.0f) == 10.0f);
+
+  int quo = 0;
+  assert(std::remquo(10.0, 3.0, &quo) == 1.0);
+  assert(quo == 3);
+
+  assert(std::lround(2.5) == 3L);
+  assert(std::llround(-2.5) == -3LL);
+  assert(std::lrint(2.0) == 2L);
+  assert(std::llrint(-2.0) == -2LL);
+  assert(std::isnan(std::nan("")));
+
+  // ilogb, logb and nexttoward have no model in ESBMC's libc, so only their
+  // overload sets are exercised; their values are nondet.
+  int e = std::ilogb(8.0) + std::ilogb(8.0f) + std::ilogb(8.0L);
+  long double b = std::logb(8.0) + std::logb(8.0f) + std::logb(8.0L);
+  long double t = std::nexttoward(1.0, 2.0L) + std::nexttoward(1.0f, 2.0L);
+  (void)e;
+  (void)b;
+  (void)t;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  int quo = 0;
+  // remquo yields the remainder, not the quotient.
+  assert(std::remquo(10.0, 3.0, &quo) == 3.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_cmath_std_overloads_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$
+^\s*assertion std::remquo\(10\.0, 3\.0, &quo\) == 3\.0$

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -126,6 +126,78 @@ CIMPORT2(copysign)
 CIMPORT2(remainder)
 CIMPORT2(nextafter)
 
+/* [cmath.syn]: the C99 functions whose return type or extra parameter does not
+ * fit CIMPORT1/CIMPORT2. math.h already declares the f/d/l triples. */
+#define CIMPORT1R(name, ret)                                                   \
+  using ::name##f;                                                             \
+  using ::name;                                                                \
+  using ::name##l;                                                             \
+  inline ret name(float num)                                                   \
+  {                                                                            \
+    return ::name##f(num);                                                     \
+  }                                                                            \
+  inline ret name(long double num)                                             \
+  {                                                                            \
+    return ::name##l(num);                                                     \
+  }
+
+CIMPORT1R(ilogb, int)
+CIMPORT1R(lround, long)
+CIMPORT1R(llround, long long)
+CIMPORT1R(lrint, long)
+CIMPORT1R(llrint, long long)
+
+#undef CIMPORT1R
+
+CIMPORT1(logb)
+
+#define CIMPORT2X(name, second)                                                \
+  using ::name##f;                                                             \
+  using ::name;                                                                \
+  using ::name##l;                                                             \
+  inline float name(float a, second b)                                         \
+  {                                                                            \
+    return ::name##f(a, b);                                                    \
+  }                                                                            \
+  inline long double name(long double a, second b)                             \
+  {                                                                            \
+    return ::name##l(a, b);                                                    \
+  }
+
+CIMPORT2X(scalbn, int)
+CIMPORT2X(scalbln, long)
+CIMPORT2X(nexttoward, long double)
+
+#undef CIMPORT2X
+
+using ::fmaf;
+using ::fma;
+using ::fmal;
+inline float fma(float a, float b, float c)
+{
+  return ::fmaf(a, b, c);
+}
+inline long double fma(long double a, long double b, long double c)
+{
+  return ::fmal(a, b, c);
+}
+
+using ::remquof;
+using ::remquo;
+using ::remquol;
+inline float remquo(float a, float b, int *quo)
+{
+  return ::remquof(a, b, quo);
+}
+inline long double remquo(long double a, long double b, int *quo)
+{
+  return ::remquol(a, b, quo);
+}
+
+using ::nanf;
+using ::nan;
+using ::nanl;
+
 using ::pow;
 #if !defined(__MATHCALL_VEC)
 using ::powf;


### PR DESCRIPTION
`<cmath>` imported only the functions whose signature fits `CIMPORT1`/`CIMPORT2`, so
`std::ilogb`, `logb`, `scalbn`, `scalbln`, `fma`, `remquo`, `lround`, `llround`,
`lrint`, `llrint`, `nexttoward` and `nan` did not resolve at all. Two new macros
cover the "different return type" and "non-floating second parameter" shapes
[cmath.syn] specifies; the rest is a plain `using ::` triple.

`std::ilogb` is the first parse error in 8 of a 60-TU sample of ESBMC's own
sources once #7337 lands, which is what surfaced this.

`ilogb`, `logb` and `nexttoward` have no model in ESBMC's libc and still return
nondet — the test exercises their overload sets only and says so. Modelling them
is a separate change. The other eight were value-checked against libc++.

Refs #5868