### PR TITLE
[om] Give list, set and map their [container.requirements] comparisons

### DIFF
--- a/regression/esbmc-cpp/cpp/github_5868_container_relational/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_container_relational/main.cpp
@@ -1,0 +1,57 @@
+#include <list>
+#include <set>
+#include <map>
+#include <cassert>
+
+int main()
+{
+  // lexicographical, not by size: {1,3} < {2} in every ordered container.
+  std::list<int> la, lb;
+  la.push_back(1); la.push_back(3);
+  lb.push_back(2);
+  assert(la < lb);
+  assert(!(lb < la));
+  assert(la <= lb && lb > la && lb >= la && la != lb);
+
+  std::set<int> sa, sb;
+  sa.insert(1); sa.insert(3);
+  sb.insert(2);
+  assert(sa < sb);
+  assert(!(sb < sa));
+  assert(sa <= sb && sb > sa && sb >= sa && sa != sb);
+
+  std::multiset<int> ma, mb;
+  ma.insert(1); ma.insert(3);
+  mb.insert(2);
+  assert(ma < mb);
+  assert(!(mb < ma));
+
+  // a prefix is smaller
+  std::set<int> p;
+  p.insert(1);
+  assert(p < sa);
+  assert(!(sa < p));
+
+  // map orders on the key first, the mapped value breaks a tie
+  std::map<int, int> x, y;
+  x.insert(std::pair<int, int>(1, 5));
+  y.insert(std::pair<int, int>(1, 9));
+  assert(x < y);
+  assert(!(y < x));
+  assert(x != y);
+  y.clear();
+  y.insert(std::pair<int, int>(2, 0));
+  assert(x < y);
+
+  std::map<int, int> z;
+  z.insert(std::pair<int, int>(1, 5));
+  assert(x == z);
+  assert(x <= z && x >= z);
+
+  std::multimap<int, int> qa, qb;
+  qa.insert(std::pair<int, int>(1, 1));
+  qb.insert(std::pair<int, int>(1, 2));
+  assert(qa < qb);
+  assert(qb > qa);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_container_relational/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_container_relational/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_5868_container_relational_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_5868_container_relational_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <set>
+#include <cassert>
+
+int main()
+{
+  std::set<int> a, b;
+  a.insert(1);
+  a.insert(3);
+  b.insert(2);
+
+  // Ordering by size instead of lexicographically would make {2} < {1,3}.
+  assert(b < a);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_5868_container_relational_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_5868_container_relational_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$
+^\s*assertion b < a$

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -913,18 +913,21 @@ void advance(list<int>::iterator &it, int n)
       --it;
 }
 
-bool operator==(const list<int> &x, const list<int> &y)
+/* [container.requirements]: the comparisons are templates over the element
+ * type, not the two hardcoded instantiations this used to carry -- a
+ * list<char> could not be compared at all. The static step bound is what stops
+ * ESBMC unrolling speculatively to --unwind instead of to LIST_MAX_SIZE. */
+template <class T>
+bool operator==(const list<T> &x, const list<T> &y)
 {
   if (x._size != y._size)
     return false;
-  list<int>::size_type ix = x._sentinel_next;
-  list<int>::size_type iy = y._sentinel_next;
-  // Static step bound so ESBMC stops unrolling at LIST_MAX_SIZE
-  // (== SENTINEL) instead of speculatively unrolling to --unwind.
-  for (list<int>::size_type step = 0; step < list<int>::SENTINEL; step++)
+  typename list<T>::size_type ix = x._sentinel_next;
+  typename list<T>::size_type iy = y._sentinel_next;
+  for (typename list<T>::size_type step = 0; step < list<T>::SENTINEL; step++)
   {
-    if (ix == list<int>::SENTINEL)
-      return iy == list<int>::SENTINEL;
+    if (ix == list<T>::SENTINEL)
+      return iy == list<T>::SENTINEL;
     if (x._storage.buf[ix].data != y._storage.buf[iy].data)
       return false;
     ix = x._storage.buf[ix].next_idx;
@@ -933,32 +936,52 @@ bool operator==(const list<int> &x, const list<int> &y)
   return true;
 }
 
-bool operator!=(const list<int> &x, const list<int> &y)
+template <class T>
+bool operator!=(const list<T> &x, const list<T> &y)
 {
   return !(x == y);
 }
 
-bool operator==(const list<double> &x, const list<double> &y)
+/* The ordering is the lexicographical comparison of the two ranges, so the
+ * first differing element decides it and the lengths matter only when one
+ * range is a prefix of the other. */
+template <class T>
+bool operator<(const list<T> &x, const list<T> &y)
 {
-  if (x._size != y._size)
-    return false;
-  list<double>::size_type ix = x._sentinel_next;
-  list<double>::size_type iy = y._sentinel_next;
-  for (list<double>::size_type step = 0; step < list<double>::SENTINEL; step++)
+  typename list<T>::size_type ix = x._sentinel_next;
+  typename list<T>::size_type iy = y._sentinel_next;
+  for (typename list<T>::size_type step = 0; step < list<T>::SENTINEL; step++)
   {
-    if (ix == list<double>::SENTINEL)
-      return iy == list<double>::SENTINEL;
-    if (x._storage.buf[ix].data != y._storage.buf[iy].data)
+    if (ix == list<T>::SENTINEL)
+      return iy != list<T>::SENTINEL;
+    if (iy == list<T>::SENTINEL)
+      return false;
+    if (x._storage.buf[ix].data < y._storage.buf[iy].data)
+      return true;
+    if (y._storage.buf[iy].data < x._storage.buf[ix].data)
       return false;
     ix = x._storage.buf[ix].next_idx;
     iy = y._storage.buf[iy].next_idx;
   }
-  return true;
+  return false;
 }
 
-bool operator!=(const list<double> &x, const list<double> &y)
+template <class T>
+bool operator>(const list<T> &x, const list<T> &y)
 {
-  return !(x == y);
+  return y < x;
+}
+
+template <class T>
+bool operator<=(const list<T> &x, const list<T> &y)
+{
+  return !(y < x);
+}
+
+template <class T>
+bool operator>=(const list<T> &x, const list<T> &y)
+{
+  return !(x < y);
 }
 
 } // namespace std

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -1238,6 +1238,59 @@ public:
       return _pair;
     }
   }
+
+  bool operator==(const map &y) const
+  {
+    if (this->_size != y._size)
+      return false;
+    for (int i = 0; i < this->_size; i++)
+    {
+      if (!(this->_key[i] == y._key[i]) || !(this->_value[i] == y._value[i]))
+        return false;
+    }
+    return true;
+  }
+
+  bool operator!=(const map &y) const
+  {
+    return !(*this == y);
+  }
+
+  /* [container.requirements]: equality is element-wise over the two ranges,
+   * and the ordering is their lexicographical comparison over value_type --
+   * pair, so the key decides first and the mapped value breaks a tie.
+   * _key[0.._size) is kept sorted by insert(). */
+  bool operator<(const map &y) const
+  {
+    int n = this->_size < y._size ? this->_size : y._size;
+    for (int i = 0; i < n; i++)
+    {
+      if (key_compare()(this->_key[i], y._key[i]))
+        return true;
+      if (key_compare()(y._key[i], this->_key[i]))
+        return false;
+      if (this->_value[i] < y._value[i])
+        return true;
+      if (y._value[i] < this->_value[i])
+        return false;
+    }
+    return this->_size < y._size;
+  }
+
+  bool operator>(const map &y) const
+  {
+    return y < *this;
+  }
+
+  bool operator<=(const map &y) const
+  {
+    return !(y < *this);
+  }
+
+  bool operator>=(const map &y) const
+  {
+    return !(*this < y);
+  }
 };
 
 // [associative.reqmts]: the Allocator parameter completes the signature. The
@@ -2278,6 +2331,42 @@ public:
         return true;
     }
     return false;
+  }
+
+  /* [container.requirements]: equality is element-wise over the two ranges,
+   * and the ordering is their lexicographical comparison over value_type --
+   * pair, so the key decides first and the mapped value breaks a tie.
+   * _key[0.._size) is kept sorted by insert(). */
+  bool operator<(const multimap &y) const
+  {
+    int n = this->_size < y._size ? this->_size : y._size;
+    for (int i = 0; i < n; i++)
+    {
+      if (key_compare()(this->_key[i], y._key[i]))
+        return true;
+      if (key_compare()(y._key[i], this->_key[i]))
+        return false;
+      if (this->_value[i] < y._value[i])
+        return true;
+      if (y._value[i] < this->_value[i])
+        return false;
+    }
+    return this->_size < y._size;
+  }
+
+  bool operator>(const multimap &y) const
+  {
+    return y < *this;
+  }
+
+  bool operator<=(const multimap &y) const
+  {
+    return !(y < *this);
+  }
+
+  bool operator>=(const multimap &y) const
+  {
+    return !(*this < y);
   }
 };
 } // namespace std

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -777,6 +777,53 @@ public:
   {
     return make_pair(lower_bound(x), upper_bound(x));
   }
+
+  /* [container.requirements]: equality is element-wise over the two ranges,
+   * and the ordering is their lexicographical comparison -- the first
+   * differing element decides it, and the sizes matter only when one range is
+   * a prefix of the other. buf[0.._size) is kept sorted by insert(). */
+  bool operator==(const multiset &rhv) const
+  {
+    if (_size != rhv._size)
+      return false;
+    for (size_t i = 0; i < _size; i++)
+      if (!(buf[i] == rhv.buf[i]))
+        return false;
+    return true;
+  }
+
+  bool operator!=(const multiset &rhv) const
+  {
+    return !(*this == rhv);
+  }
+
+  bool operator<(const multiset &rhv) const
+  {
+    size_t n = _size < rhv._size ? _size : rhv._size;
+    for (size_t i = 0; i < n; i++)
+    {
+      if (buf[i] < rhv.buf[i])
+        return true;
+      if (rhv.buf[i] < buf[i])
+        return false;
+    }
+    return _size < rhv._size;
+  }
+
+  bool operator>(const multiset &rhv) const
+  {
+    return rhv < *this;
+  }
+
+  bool operator<=(const multiset &rhv) const
+  {
+    return !(rhv < *this);
+  }
+
+  bool operator>=(const multiset &rhv) const
+  {
+    return !(*this < rhv);
+  }
 };
 
 template <
@@ -1534,6 +1581,53 @@ public:
   pair<const_iterator, const_iterator> equal_range(const key_type &x) const
   {
     return make_pair(lower_bound(x), upper_bound(x));
+  }
+
+  /* [container.requirements]: equality is element-wise over the two ranges,
+   * and the ordering is their lexicographical comparison -- the first
+   * differing element decides it, and the sizes matter only when one range is
+   * a prefix of the other. buf[0.._size) is kept sorted by insert(). */
+  bool operator==(const set &rhv) const
+  {
+    if (_size != rhv._size)
+      return false;
+    for (size_t i = 0; i < _size; i++)
+      if (!(buf[i] == rhv.buf[i]))
+        return false;
+    return true;
+  }
+
+  bool operator!=(const set &rhv) const
+  {
+    return !(*this == rhv);
+  }
+
+  bool operator<(const set &rhv) const
+  {
+    size_t n = _size < rhv._size ? _size : rhv._size;
+    for (size_t i = 0; i < n; i++)
+    {
+      if (buf[i] < rhv.buf[i])
+        return true;
+      if (rhv.buf[i] < buf[i])
+        return false;
+    }
+    return _size < rhv._size;
+  }
+
+  bool operator>(const set &rhv) const
+  {
+    return rhv < *this;
+  }
+
+  bool operator<=(const set &rhv) const
+  {
+    return !(rhv < *this);
+  }
+
+  bool operator>=(const set &rhv) const
+  {
+    return !(*this < rhv);
   }
 };
 


### PR DESCRIPTION
`set`, `multiset` and `map` had no container-level relational operators at all;
`multimap` had only `==`/`!=`; and `<list>`'s `==`/`!=` were two hardcoded free
functions for `list<int>` and `list<double>`, so `list<char>` could not be
compared and no ordered container had `<`.

`const map<irep_idt, irept>` and `const list<xmlt>` comparisons are first parse
errors in ESBMC's own sources; the 60-TU self-parse sample goes from 23 to 25
clean.

The ordering is lexicographical, as `<vector>` and `<deque>` already spell it —
comparing sizes instead would make `{2} < {1, 3}`, which is what the negative
test pins. `<list>`'s loops keep their static step bound so ESBMC still stops
unrolling at `LIST_MAX_SIZE`. Every assertion in the positive test was
cross-checked against libc++.

Fallout: 437 tests over six `esbmc-cpp` suites, 0 verdict diffs.

Refs #5868