### PR TITLE
[docs] Sync the website with user-facing changes since #7240

### DIFF
--- a/website/content/docs/c-cpp/limitations.md
+++ b/website/content/docs/c-cpp/limitations.md
@@ -44,9 +44,14 @@ should not, or vice versa.
 
 ## Inheritance and polymorphism
 
-Virtual dispatch through a non-first base under multiple inheritance relies on
-Clang's `ASTRecordLayout` in a way that is known to be brittle
-([#3894](https://github.com/esbmc/esbmc/issues/3894)). Some
+Base-subobject displacements — the override thunk adapting a `Base*` receiver,
+both arms of `dynamic_cast`, and derived-to-base conversions under a virtual
+base — are now taken from ESBMC's own class layout rather than Clang's
+`ASTRecordLayout`, which disagreed with it under the Itanium primary-base rule
+([#3894](https://github.com/esbmc/esbmc/issues/3894)). A hierarchy containing a
+virtual base keeps a flattened layout that cannot express every shape; the
+remaining ones are pinned as `KNOWNBUG` under
+`regression/esbmc-cpp/inheritance/`. Some
 inheritance/polymorphism regressions remain marked `KNOWNBUG`
 ([#4399](https://github.com/esbmc/esbmc/issues/4399)), as do some of the
 `gcc-template-tests` ([#4398](https://github.com/esbmc/esbmc/issues/4398)).

--- a/website/content/docs/c-cpp/supported-features.md
+++ b/website/content/docs/c-cpp/supported-features.md
@@ -176,6 +176,9 @@ case. See [Limitations](./limitations#constructor-and-destructor-ordering).
   across bases, override thunks keyed by each base's virtual name and adjusted
   by the indirect base's cumulative offset, and catch-by-base binding re-offset
   for multiple-inheritance thrown types
+- Under a virtual base, a derived-to-base conversion onto a non-first base is
+  displaced, so the base's methods, constructor and destructor address the
+  base subobject rather than the derived object's leading storage
 - Virtual dispatch through a non-arrow member expression — `(*p).f()` and
   `ref.f()` dispatch virtually
 

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -254,6 +254,14 @@ VERIFICATION SUCCESSFUL
   `if`/loop guard. Canonical CWE-561 shapes with no branch guard — statements
   after an unconditional `return`/`abort`, or entirely unreferenced functions —
   are *not* detected; they simply report no dead code.
+- **Only user-written branches are probed.** A guard already folded to a
+  constant (`if (1)`) is not probed, and neither are the branches the Python
+  frontend inserts on its own behalf — the `IndexError` / `KeyError` /
+  `ValueError` / `ZeroDivisionError` guards and the exception-propagation edge
+  after each call — so a clean program reports no dead code. The
+  constant-evaluation fold that replaces a provable Python `assert` with
+  `assert True` is disabled under this flag, so code reachable only through a
+  call inside that assertion is still explored.
 - **Bounded, and beyond-bound branches read as dead.** A branch that becomes
   reachable only past the unwinding bound is cut like any other beyond-bound
   path and is therefore listed as unreachable — the report is explicitly scoped

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -32,10 +32,10 @@ weight: 4
 
 ## Built-in Functions
 
-- `min()` and `max()` support two-argument form and single-list form only (`default` is supported). The `key` keyword argument is honoured only over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms; any other key (symbolic elements, a user function, a non-constant key) silently falls back to ignoring `key`.
+- `min()` and `max()` support two-argument form and single-list form only (`default` is supported). The `key` keyword argument is honoured only over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms; any other key (symbolic elements, a user function, a non-constant key) is refused with a named error rather than silently answered in natural order.
 - `any()` and `all()` currently support only list literals as arguments. `any()` rejects other iterables with a parse-time error; `all()` may trigger a dereference failure on non-list iterables.
 - `sum()` supports `int` and `float` element types only.
-- `sorted()` supports `int`, `float`, and `str` element types only; the `key` keyword argument is not supported (`reverse` is supported).
+- `sorted()` supports `int`, `float`, and `str` element types, plus a homogeneous list of tuples (the element types are carried through, so `for u, v in sorted(pairs)` unpacks). `reverse=` is supported; a `key=` is honoured only where the preprocessor can constant-fold the call, and is otherwise refused with a named error.
 - `input()` is modelled as a nondeterministic string with a maximum length of 256 characters (under-approximation).
 - `print()` evaluates each argument expression once (so safety checks and call side effects reach the GOTO program) but produces no actual output during verification.
 - `enumerate()` supports the iterable + `start` keyword forms; nested or unusually-shaped iterables are not exercised by the regression suite and may surface edge cases.
@@ -69,7 +69,8 @@ value (see [Supported Features — Dynamic Typing](./supported-features#dynamic-
 within these bounds:
 
 - A tag holds one of `bool`, `int`, `float` or `str`. `isinstance` against an aggregate or a user class is therefore answered `False`, not consulted.
-- Arithmetic (`+`, `-`, `*`, `/`) is supported against a **literal** operand; `+` additionally concatenates strings.
+- Arithmetic (`+`, `-`, `*`, `/`) is supported against a **literal** operand, and `-` and `/` between two tagged operands; `+` additionally concatenates strings. A non-numeric operand raises `TypeError`.
+- Divergence is detected across an `if`/`elif`/`else` chain only when every branch assigns the name; a chain with a branch that leaves it unassigned is not tagged.
 - `x is None` is folded only against a literal `None`. A computed operand is not folded, since that would drop its side effects.
 - Rebinding a tagged variable to a list, tuple or class instance is refused inside a loop or a conditional body, where the join of the retyped aliases is not modelled.
 
@@ -130,7 +131,7 @@ within these bounds:
 - Only the NumPy functions listed in [Supported Features — NumPy](./supported-features#numpy-module-numpy) have executable support.
 - The reductions (`sum`/`prod`/`min`/`max`/`mean`/`argmin`/`argmax`), comparison/logical ufuncs (`greater`/`less`/`equal`/`logical_*`/`where`), and constructors (`arange`/`full`/`eye`/`identity`/`linspace`) are constant-folded over list-backed (1D/2D) inputs and constant shapes; runtime-constructed inputs and higher-rank shapes are rejected with deterministic frontend errors.
 - `np.arange()` materialises its result at conversion time, so its arguments must be constant — a name bound to a literal is resolved first, but a function parameter is rejected with `TypeError: numpy.arange() currently supports constant numeric inputs only` rather than routed through the operational model's while loop, which did not terminate in practice. A range past 10000 elements is declined for the same reason, and `step=0` raises `ValueError`.
-- Only a 1-D, unit-stride slice with literal bounds, assigned to a bare name, becomes a real view onto the base array. A symbolic bound, a non-unit stride, or a higher-rank slice still produces an independent copy, so a write through one is not observed by the other.
+- A view onto the base array needs literal bounds and a fixed-shape 1-D or 2-D source: 1-D slices (any step, including reversed), 2-D row and column views, `np.diagonal`, `np.ravel` and `a.flat[i]` alias the buffer; a symbolic bound or index, or a 3-D source, still produces an independent copy. `np.diagonal` is read-only, and a diagonal used inline (`np.diagonal(a)[i]`) rather than bound to a name is declined. `np.fill_diagonal` requires a value whose length matches the diagonal exactly.
 - `np.arccos`, `np.fmod`, `np.transpose`, `np.dot`, and `np.matmul` now lower to executable models (they were previously type-inference-only stubs), each under a stated restriction: `np.arccos` rejects runtime 2D arrays; `np.fmod` rejects `np.array(...)`-wrapped operands (`Unsupported operation: numpy.fmod on array operands`); `np.transpose` is limited to 2D and rejects higher rank; `np.dot`/`np.matmul` cover 1D/2D integer and float inputs.
 - `numpy.linalg.det` supports constant numeric 2x2 and 3x3 matrices. Other `numpy.linalg` operations, complex determinants, runtime-constructed matrices, and larger matrix sizes are not supported.
 

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -36,6 +36,9 @@ This page is a reference of all Python language constructs, data structures, and
 - **Parameter type recovery**: A bare `list` annotation, or no annotation at all, does not stop the parameter being typed. A body that uses the parameter as a list (`len(x)`, `x[i]`, a list mutator, or an unpack such as `first, *rest = arr`) refines it to the list model — in an imported module as well as the entry file — and the *element* type is recovered from the statically resolvable call sites when they agree on one, so `x[i] + 1` behaves as it does under a `list[T]` annotation instead of reading as `Any`
 - **Default arguments**: A parameter whose default is a `list`, `dict` or `set` literal receives that container when the argument is omitted, rather than `None`. Defaults are also filled in for a call into an imported module and for an imported class's constructor
 - **Callables in containers**: A function name stored in a list decays to a function pointer, so a callable read back out of the list can be invoked
+- **Closures**: a nested `def` may read a scalar of the enclosing function and write through a captured list (`c[0] += 1`), provided nothing rebinds the captured name after the `def`; a nested `c = [9]` binds its own local rather than the enclosing list
+- **`Callable[[A], R]` annotations** on a return type or a variable carry the spelled signature, so a call through the value returns `R` rather than a nondeterministic value; a bare `Callable` takes its signature from the assigned function
+- **Dunder spellings of operators**: `d.__getitem__(k)`, `xs.__len__()` and `d.__contains__(k)` are rewritten to `d[k]`, `len(xs)` and `k in d`, and dispatch to a user class's own dunder as the operators do
 - **Lambda expressions**: Single-expression lambdas with multiple parameters; converted to regular functions and stored as function pointers; can be assigned to variables and called indirectly
 
 ## Object-Oriented Programming
@@ -325,7 +328,8 @@ if x > 0:
 
 ## Dynamic Typing
 
-A variable whose type diverges across an `if`/`else` — `x = 1` in one branch and
+A variable whose type diverges across an `if`/`else` — or an `if`/`elif`/`else`
+chain in which every branch assigns it — `x = 1` in one branch and
 `x = "hello"` in the other — is given a *tagged* representation carrying a
 runtime type tag alongside the value, instead of being forced to one branch's
 type. This covers a variable created inside the branches and one that already
@@ -353,7 +357,8 @@ Supported on a tagged variable:
 - **`==` between two tagged variables**, dispatched on the tag, with the numeric
   arm fixed-width and the `str` arm under a compile-time bound.
 - **`+`, `-`, `*`, `/` against a literal**, numeric, plus string concatenation
-  for `+`.
+  for `+`; **`-` and `/` between two tagged operands**, raising `TypeError`
+  when either turns out non-numeric.
 - **Rebinding to a container** — a list, tuple or class instance assigned to a
   tagged variable gets its own slot, as Python rebinds the name outright.
 - **Function return values**: a function whose `return` statements diverge in
@@ -393,10 +398,10 @@ The `--strict-types` flag enables type compatibility validation for function arg
 | `len` | Works on lists, sets, strings, tuples. On a class instance it dispatches to `__len__`, walking the ancestry so an inherited one is found; a class that defines none raises `TypeError` as CPython does, rather than measuring the struct with `strlen` and answering 0 |
 | `range` | Used in `for` loops |
 | `min(a, b)`, `max(a, b)` | Two-argument form only; promotes `int` to `float` |
-| `min([...])`, `max([...])` | Single-list form; supports `int`, `float`, and `str` element types. The `key=` argument is honoured over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms (the winning element is returned; ties break toward the first occurrence) |
+| `min([...])`, `max([...])` | Single-list form; supports `int`, `float`, and `str` element types. The `key=` argument is honoured over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms (the winning element is returned; ties break toward the first occurrence); any other `key=` is refused rather than dropped |
 | `sum([...])` | Sum of list elements; supports `int` and `float` |
 | `sum(range(EXPR))` | Single-arg `sum` of a single-arg `range` is rewritten to the Gauss closed form `EXPR * (EXPR - 1) // 2 if EXPR > 0 else 0`, yielding an exact value (and `0` for `EXPR <= 0`) instead of a nondet result |
-| `sorted(iterable)` | Returns a new sorted list; supports `int`, `float`, and `str` elements |
+| `sorted(iterable)` | Returns a new sorted list; supports `int`, `float`, and `str` elements and homogeneous lists of tuples, whose element types are carried through (as `reversed()` and `list()` also do). `key=` is honoured only where the call constant-folds and is refused otherwise |
 | `any([...])` | List literals only; short-circuit OR logic |
 | `all([...])` | List literals only; short-circuit AND logic |
 | `enumerate(iterable, start=0)` | Tuple unpacking and single-variable forms; optional `start` |
@@ -562,7 +567,7 @@ Partial executable support for list-backed arrays, element-wise arithmetic, sele
 
 **Slicing**: bounded 1-D slicing `a[i:j]` on a list-backed array returns a new `list[T]` (bounded, open-ended `a[i:]`/`a[:j]`, and full-copy `a[:]` forms), with the slice typed as the element type rather than collapsing to a scalar. **2-D slicing** selects whole rows (`a[i, :]`) and whole columns (`a[:, j]`)
 
-**Views**: a 1-D, unit-stride slice with literal bounds assigned to a bare name (`v = a[1:3]`) is a real **view** — `v` points into `a`'s own buffer, so writes through either are observed by the other, and `len(v)`, `v.shape` and `v.ndim` report the view's own length rather than the base buffer's. Every other view-like expression, including a slice with a symbolic bound, still copies
+**Views**: a slice or selection with literal bounds assigned to a bare name is a real **view** onto `a`'s own buffer, so writes through either side are observed by the other, and `len(v)`, `v.shape` and `v.ndim` report the view's own extent: 1-D slices with any step (`a[1:3]`, `a[::2]`, `a[::-1]`), 2-D row views (`a[0]`, `a[-1]`) and column views (`a[:, j]`), `np.ravel(a)` / `a.ravel()` / `a.flat[i]` (writable, contiguous), and `np.diagonal(a, offset=k)` / `a.diagonal()` (read-only). `np.trace(a)` and `np.fill_diagonal(a, v)` reuse the same offset arithmetic as a reduction and an in-place write. Rebinding the base array detaches its live views. A slice with a symbolic bound still copies
 
 **Shape manipulation**: `np.reshape(a, shape)` (2-D and 3-D targets; an incompatible element count is rejected), `np.flatten(a)` / `np.ravel(a)` (row-major 1-D view), `np.squeeze(a)` (drop unit-length axes; a non-unit axis is rejected), `np.stack([a, b, ...])` (join arrays along a new leading axis, e.g. 1-D → 2-D), `np.concatenate([a, b, ...])` (join along the existing axis), and `a.astype(dtype)` (dtype conversion; `astype` to a complex dtype is rejected)
 

--- a/website/content/docs/usage.md
+++ b/website/content/docs/usage.md
@@ -765,6 +765,15 @@ SMT-LIB2 solver given via `--bitwuzllob-model-prog CMD` /
 `--neurosym-model-prog CMD` (e.g. `"z3 -in"`). Neither backend is ever picked
 implicitly, and NeuroSym rejects `--ir` and incremental strategies.
 
+Floating-point arithmetic is encoded with the SMT floating-point theory
+(`fp.add`, `fp.lt`, …) on every backend that offers it — Bitwuzla, Z3, MathSAT,
+CVC4/CVC5 — and lowered to bit-vectors elsewhere. `--fp2bv` forces the
+bit-vector lowering on any backend, which is the encoding to reach for when a
+property depends on the sign of a NaN: the theory cannot represent it
+([#7021](https://github.com/esbmc/esbmc/issues/7021)). `fmod`, `remainder` and
+`remquo` are always lowered through a bit-vector round-trip, since the theory's
+`fp.rem` is far slower to solve.
+
 An alternative default solver can be set with `--default-solver SOLVER` (the
 name without the `--`), which suits a shell alias or the `ESBMC_OPTS`
 environment variable. The `CMD` for the SMTLIB backend is interpreted by the

--- a/website/content/news/development-update-end-of-august-2026.md
+++ b/website/content/news/development-update-end-of-august-2026.md
@@ -1,0 +1,129 @@
+---
+title: "Development Update: End of August 2026"
+date: 2026-08-26T18:00:00+01:00
+draft: false
+tags:
+  - ESBMC
+  - FormalVerification
+  - ModelChecking
+  - OpenSource
+---
+
+A short follow-up to the [late-August update](/news/development-update-late-august-2026):
+roughly 80 pull requests landed on `master` between 22 and 26 August. Here are
+the ones a user will notice.
+
+**Bitwuzla now uses its native floating-point theory.**
+[#7022](https://github.com/esbmc/esbmc/pull/7022) implements the SMT
+floating-point theory on the Bitwuzla backend — the default solver — so floats
+are encoded with `fp.add` and friends instead of ESBMC's own bit-vector
+lowering. On symbolic-input FP queries it measured 1.2–13× faster, and 303
+FP-touching regression tests agree on every verdict. `--fp2bv` opts back into
+the old encoding; `fmod`/`remainder` keep a bit-vector round-trip because
+`fp.rem` is two orders of magnitude slower on the solver side. One known gap:
+the theory cannot represent the sign of a NaN
+([#7021](https://github.com/esbmc/esbmc/issues/7021)).
+
+**A cross-run proof cache.**
+[#7143](https://github.com/esbmc/esbmc/pull/7143) adds `--proof-cache <dir>`,
+which keys every discharged claim on a hash of its sliced SSA cone, the build
+and the options that affect what is verified, and skips the solver on a hit.
+Only proved (UNSAT) claims are stored; `--proof-cache-verify` solves anyway and
+reports any mismatch. The full write-up is on the new
+[Proof cache](/docs/proof-cache) page.
+
+**Verdicts and property tables that were missing.**
+A plain BMC run under `--show-cex` recorded no verdict and printed
+"0 properties failed" above `VERIFICATION FAILED`
+([#7258](https://github.com/esbmc/esbmc/pull/7258)); `--k-induction-parallel`
+skipped the per-property table — and with it the CWE rows — that sequential
+`--k-induction` prints ([#7262](https://github.com/esbmc/esbmc/pull/7262)). An
+unknown `--function` on a `.goto` binary now reports an error rather than
+aborting ([#7263](https://github.com/esbmc/esbmc/pull/7263)), and a goto binary
+produced by another tool prints in C syntax instead of crashing the
+counterexample printer ([#7264](https://github.com/esbmc/esbmc/pull/7264)). The
+SV-COMP wrapper was taught to read the per-property table introduced by #7064,
+which had been turning ~2500 correct-false verdicts into `Unknown`
+([#7250](https://github.com/esbmc/esbmc/pull/7250)).
+
+**`--dead-code-check` reports the dead direction and fewer false advisories.**
+The advisory named the guard of the *live* branch; it now names the direction
+that is actually unreachable
+([#7295](https://github.com/esbmc/esbmc/pull/7295)). It no longer reports
+CWE-561 on `if (1)` ([#7277](https://github.com/esbmc/esbmc/pull/7277)), on
+code reachable only through a call inside a constant-folded Python `assert`
+([#7279](https://github.com/esbmc/esbmc/pull/7279)), or on the `IndexError` /
+`KeyError` / `ZeroDivisionError` guards and exception-propagation edges the
+Python frontend inserts itself
+([#7307](https://github.com/esbmc/esbmc/pull/7307)).
+
+**Pointer arithmetic below an object.**
+Three stacked fixes ([#7222](https://github.com/esbmc/esbmc/pull/7222),
+[#7224](https://github.com/esbmc/esbmc/pull/7224),
+[#7228](https://github.com/esbmc/esbmc/pull/7228)) make `p - k` on a `void *`
+move in the right direction, report a `p[-1]` underflow that a wrapping offset
+used to hide, and compare pointer offsets signed so that `p >= b` is false for
+`p = b - 1`. A harness that walks `for (p = end; p >= begin; p--)` over a struct
+or scalar now reports out of bounds, as it already did over an array. Every
+multi-byte heap write on a big-endian target was byte-reversed against the read
+that stitched it back ([#7276](https://github.com/esbmc/esbmc/pull/7276)).
+
+**C++ base subobjects under ESBMC's own layout.**
+The thunk adapting a `Base*` receiver and both arms of `dynamic_cast` sized
+their adjustment with clang's record layout, but ESBMC lays classes out itself,
+so under the Itanium primary-base rule dispatch and member access disagreed on
+which object they were touching
+([#7243](https://github.com/esbmc/esbmc/pull/7243)). A derived-to-base
+conversion onto a non-first base under a virtual base is now displaced, so the
+base's methods, constructor and destructor address the right storage
+([#7241](https://github.com/esbmc/esbmc/pull/7241),
+[#7292](https://github.com/esbmc/esbmc/pull/7292)). `string_view` became a
+literal type and gained its `std::string` conversion
+([#7215](https://github.com/esbmc/esbmc/pull/7215),
+[#7253](https://github.com/esbmc/esbmc/pull/7253)), and `timegm` is modelled
+beside `mktime` ([#7273](https://github.com/esbmc/esbmc/pull/7273)).
+
+**Python: closures, dunders and dynamic typing.**
+A nested `def` reading an enclosing function's scalar is bound to a captured
+cell rather than an unconstrained frame local
+([#7297](https://github.com/esbmc/esbmc/pull/7297)); writing `c[0] += 1` from
+a nested function mutates the enclosing list
+([#7225](https://github.com/esbmc/esbmc/pull/7225),
+[#7227](https://github.com/esbmc/esbmc/pull/7227)). `Callable[[A], R]`
+annotations carry their signature, so a call through the value is no longer
+nondet ([#7298](https://github.com/esbmc/esbmc/pull/7298)). Explicit
+`__getitem__`, `__len__` and `__contains__` calls dispatch to their operators
+([#7316](https://github.com/esbmc/esbmc/pull/7316)). Dynamic typing now covers
+`elif` chains and `-`/`/` between two tagged operands
+([#7281](https://github.com/esbmc/esbmc/pull/7281)). Call-site parameter
+inference iterates to a fixpoint, fixing a spurious CWE-469 on a comparison of
+two unannotated parameters ([#7257](https://github.com/esbmc/esbmc/pull/7257)),
+and a comprehension target that shadows an outer variable gets its own name
+([#7235](https://github.com/esbmc/esbmc/pull/7235)).
+
+**Python: `sorted()` and friends stop lying.**
+`sorted()`, `min()` and `max()` with a `key=` the preprocessor cannot fold used
+to drop the key silently and answer in natural order; they are now refused
+with a named error ([#7313](https://github.com/esbmc/esbmc/pull/7313)).
+`sorted()`, `reversed()` and `list()` keep their argument's element type, so a
+list of tuples still unpacks after sorting
+([#7310](https://github.com/esbmc/esbmc/pull/7310)), and slicing a dict view
+keeps its element types too
+([#7318](https://github.com/esbmc/esbmc/pull/7318)). A subscript on the
+right-hand side of an assignment emits one bounds check rather than two — a 20%
+drop in symex assignments on a double-subscript loop
+([#7309](https://github.com/esbmc/esbmc/pull/7309)).
+
+**NumPy views.**
+Row views (`a[0]`, `a[-1]`), column views (`a[:, j]`), strided and reversed 1-D
+slices (`a[::2]`, `a[::-1]`), `np.diagonal`, `np.ravel` and `a.flat[i]` are
+now pointer-backed views onto the base buffer, so writes through either side
+are observed by the other and `len`, `.shape` and `.ndim` report the view's own
+extent ([#7193](https://github.com/esbmc/esbmc/pull/7193),
+[#7261](https://github.com/esbmc/esbmc/pull/7261)). `np.trace` and
+`np.fill_diagonal` reuse the same offset arithmetic.
+
+The website documentation has been updated to match. As always, the full list is
+in the [commit history](https://github.com/esbmc/esbmc/commits/master/) — and if
+you hit a bug or a missing feature, we would love an
+[issue report](https://github.com/esbmc/esbmc/issues).


### PR DESCRIPTION
Adds an end-of-August news post covering the ~80 pull requests merged between #7240 and #7335, and updates the docs they affect: Bitwuzla's native FP theory and `--fp2bv`, the `--dead-code-check` exclusions, Python closures/dunders/`sorted key=`/dynamic typing, NumPy views, and the C++ base-subobject layout fixes.

Follow-up to #7240.