### PR TITLE
[python] Keep sorted()'s key= scan off shapes it cannot lower

### DIFF
--- a/regression/python/sorted_key_dict_items_view/main.py
+++ b/regression/python/sorted_key_dict_items_view/main.py
@@ -1,0 +1,8 @@
+def run():
+    d = {1: 30, 2: 10}
+    d[3] = 20
+    ps = sorted(d.items(), key=sum)
+    assert ps[0][0] == 2
+
+
+run()

--- a/regression/python/sorted_key_dict_items_view/test.desc
+++ b/regression/python/sorted_key_dict_items_view/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: sorted\(\) with key= is only supported over a constant iterable

--- a/regression/python/sorted_key_imported_func/keyfuncs.py
+++ b/regression/python/sorted_key_imported_func/keyfuncs.py
@@ -1,0 +1,2 @@
+def value_of(p) -> int:
+    return p[1]

--- a/regression/python/sorted_key_imported_func/main.py
+++ b/regression/python/sorted_key_imported_func/main.py
@@ -1,0 +1,10 @@
+from keyfuncs import value_of
+
+
+def run():
+    xs = [(1, 30), (2, 10)]
+    ps = sorted(xs, key=value_of)
+    assert ps[0][0] == 2
+
+
+run()

--- a/regression/python/sorted_key_imported_func/test.desc
+++ b/regression/python/sorted_key_imported_func/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: sorted\(\) with key= is only supported over a constant iterable

--- a/regression/python/sorted_key_tuple_elems_no_subscript/main.py
+++ b/regression/python/sorted_key_tuple_elems_no_subscript/main.py
@@ -1,0 +1,8 @@
+def run():
+    xs = [(1, 9), (2, 1)]
+    ks = sorted(xs, key=sum)
+    u, v = ks[0]
+    assert u == 2
+
+
+run()

--- a/regression/python/sorted_key_tuple_elems_no_subscript/test.desc
+++ b/regression/python/sorted_key_tuple_elems_no_subscript/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/ast_utils_mixin.py
+++ b/src/python-frontend/preprocessor/ast_utils_mixin.py
@@ -5,6 +5,13 @@ import copy
 class AstUtilsMixin:
 
     @staticmethod
+    def subscripts_name(node, name):
+        """True when ``node`` contains a subscript of the bare name ``name``."""
+        return any(
+            isinstance(n, ast.Subscript) and isinstance(n.value, ast.Name) and n.value.id == name
+            for n in ast.walk(node))
+
+    @staticmethod
     def _sanitize_identifier_fragment(fragment):
         return "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in fragment)
 

--- a/src/python-frontend/preprocessor/generator_mixin.py
+++ b/src/python-frontend/preprocessor/generator_mixin.py
@@ -1203,6 +1203,31 @@ class GeneratorMixin:
             return None
         return key_kw
 
+    def _key_indexes_element(self, key_value):
+        """True when applying ``key_value`` subscripts the element it is given.
+
+        A key bound by assignment rather than by a def reads as not indexing,
+        so such a call is still lowered to a scan.
+        """
+        if isinstance(key_value, ast.Lambda):
+            return self.subscripts_name(key_value.body, key_value.args.args[0].arg)
+        return isinstance(key_value, ast.Name) and key_value.id in self._param_subscripting_funcs
+
+    def _is_scan_supported(self, iterable_expr, key_value):
+        """True when a sort scan lowers to operations the frontend models.
+
+        The scan copies the iterable with a full slice and applies the key to
+        each element, and two shapes exceed what the frontend models: copying a
+        dict view does not terminate at the default unwind, and an element the
+        key subscripts raises a spurious IndexError. Declining leaves
+        reject_unfoldable_key to report the unsupported key, which beats a hang
+        or a wrong verdict.
+        """
+        if (isinstance(iterable_expr, ast.Call) and isinstance(iterable_expr.func, ast.Attribute)
+                and iterable_expr.func.attr in ("keys", "values", "items")):
+            return False
+        return not self._key_indexes_element(key_value)
+
     def _lower_sorted_key_scan(self, call_node):
         """Lower ``sorted(iterable, key=f)`` to an explicit insertion sort.
 
@@ -1218,7 +1243,7 @@ class GeneratorMixin:
         caller's list, and ``sorted`` must not.
         """
         key_kw = self._scan_key_argument(call_node, ("sorted", ))
-        if key_kw is None:
+        if key_kw is None or not self._is_scan_supported(call_node.args[0], key_kw.value):
             return None
 
         n = self.minmax_key_counter

--- a/src/python-frontend/preprocessor/module_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/module_rewrite_mixin.py
@@ -329,6 +329,23 @@ class ModuleRewriteMixin:
             if len(params) == 1
         }
 
+    def _collect_param_subscripting_funcs(self, module_node):
+        """Names that may index the first argument they are called with.
+
+        Covers defs whose body subscripts their first parameter, plus every
+        imported name, whose body this scan cannot see. Keyed on name alone, so
+        a nested or rebound def of the same name counts too: over-refusing
+        costs a clear error, under-refusing costs a verdict.
+        """
+        names = set()
+        for stmt in ast.walk(module_node):
+            if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+                names.update(alias.asname or alias.name for alias in stmt.names)
+            elif (isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.args.args
+                  and self.subscripts_name(stmt, stmt.args.args[0].arg)):
+                names.add(stmt.name)
+        return names
+
     @staticmethod
     def collect_range_wrappers(module_node):
         """Collect trivial def f(p): return range(...) wrappers at module scope."""
@@ -423,6 +440,7 @@ class ModuleRewriteMixin:
         self._scan_sequence_iterators(node)
         self._scan_module_vararg_defs(node)
         self._single_return_funcs = self._collect_single_return_funcs(node)
+        self._param_subscripting_funcs = self._collect_param_subscripting_funcs(node)
         self.apply_range_rewrites(node, alias_seed=alias_seed, wrapper_seed=wrapper_seed)
 
     def _scan_dict_literal_bindings_and_calls(self, node):

--- a/src/python-frontend/preprocessor/preprocessor_state_mixin.py
+++ b/src/python-frontend/preprocessor/preprocessor_state_mixin.py
@@ -81,6 +81,7 @@ class PreprocessorStateMixin:
         self.dict_literal_values = {}
         # Module-level ``def f(p): return <expr>``: name -> (param, expr).
         self._single_return_funcs = {}
+        self._param_subscripting_funcs = set()
         # Map var -> RHS Call node; used by _apply_assert_eq_rewrites to
         # substitute the Name back to its defining call.
         self._assignment_call_origins = {}


### PR DESCRIPTION
The insertion-sort lowering from #7314 runs before the refusal from #7348 and
intercepts the shapes that refusal covers, turning 16 `sorted_key_*` tests red
on master: a dict view's slice copy does not terminate at the default unwind,
and an element the key subscripts reaches the callee as a subscripted parameter
and reports a spurious IndexError. Decline both so the existing error answers.