### PR TITLE
[python] Avoid duplicated shifts in list.remove()

### DIFF
--- a/regression/python/list_remove12-nondet/main.py
+++ b/regression/python/list_remove12-nondet/main.py
@@ -1,0 +1,19 @@
+x: int = nondet_int()
+xs = [1, 2, 3, 2]
+
+if x == 1 or x == 2 or x == 3:
+    xs.remove(x)
+    assert len(xs) == 3
+
+    if x == 1:
+        assert xs[0] == 2
+        assert xs[1] == 3
+        assert xs[2] == 2
+    elif x == 2:
+        assert xs[0] == 1
+        assert xs[1] == 3
+        assert xs[2] == 2
+    else:
+        assert xs[0] == 1
+        assert xs[1] == 2
+        assert xs[2] == 2

--- a/regression/python/list_remove12-nondet/test.desc
+++ b/regression/python/list_remove12-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove12-nondet_fail/main.py
+++ b/regression/python/list_remove12-nondet_fail/main.py
@@ -1,0 +1,9 @@
+x: int = nondet_int()
+xs = [1, 2, 3, 2]
+
+if x == 1 or x == 2 or x == 3:
+    xs.remove(x)
+
+    if x == 2:
+        # remove() deletes only the first matching value.
+        assert xs[2] != 2

--- a/regression/python/list_remove12-nondet_fail/test.desc
+++ b/regression/python/list_remove12-nondet_fail/test.desc
@@ -2,4 +2,4 @@ CORE
 main.py
 --unwind 6
 ^VERIFICATION FAILED$
-^.*assertion .* != 2$
+^ *FAILED .*assertion .* != 2$

--- a/regression/python/list_remove12-nondet_fail/test.desc
+++ b/regression/python/list_remove12-nondet_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$
+^.*assertion .* != 2$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -1177,27 +1177,24 @@ bool __ESBMC_list_remove(
   while (i < l->size)
   {
     const PyObject *elem = &l->items[i];
-
-    if (elem->type_id == item_type_id && elem->size == item_size)
-    {
-      if (__ESBMC_values_equal(elem->value, item, item_size))
-      {
-        /* Shift elements left to fill the gap */
-        size_t j = i;
-        while (j < l->size - 1)
-        {
-          l->items[j] = l->items[j + 1];
-          j++;
-        }
-        l->size--;
-        return true; /* found and removed */
-      }
-    }
+    if (
+      elem->type_id == item_type_id && elem->size == item_size &&
+      __ESBMC_values_equal(elem->value, item, item_size))
+      break;
     i++;
   }
 
-  /* Item not found */
-  return false;
+  if (i == l->size)
+    return false;
+
+  size_t j = i;
+  while (j < l->size - 1)
+  {
+    l->items[j] = l->items[j + 1];
+    j++;
+  }
+  l->size--;
+  return true;
 }
 
 /* set.add(elem) — append elem to the underlying list iff it is not

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -1221,31 +1221,7 @@ bool __ESBMC_set_discard(
   size_t item_type_id,
   size_t item_size)
 {
-  __ESBMC_assert(s != NULL, "ValueError: set is null");
-
-  size_t i = 0;
-  while (i < s->size)
-  {
-    const PyObject *elem = &s->items[i];
-
-    if (elem->type_id == item_type_id && elem->size == item_size)
-    {
-      if (__ESBMC_values_equal(elem->value, item, item_size))
-      {
-        size_t j = i;
-        while (j < s->size - 1)
-        {
-          s->items[j] = s->items[j + 1];
-          j++;
-        }
-        s->size--;
-        return true;
-      }
-    }
-    i++;
-  }
-
-  return false;
+  return __ESBMC_list_remove(s, item, item_type_id, item_size);
 }
 
 void __ESBMC_list_sort(PyListObject *l, int type_flag, uint64_t float_type_id)


### PR DESCRIPTION
The `list.remove()` implementation did traversal and shifting in a nested loop, which is fine in normal execution. However with the symbolic execution backend, the shifting caused the symbolic equation to explode triangularly. This patch separates the two concerns, allowing a significant reduction in assignments and VCCs.

### Performance

The benchmark removes the first element of a 12-element list, forcing the longest descriptor shift:

```python
xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
xs.remove(0)
assert len(xs) == 11
assert xs[0] == 1
assert xs[10] == 11
```

Both binaries were built with the Python frontend enabled from the following commits:

- Baseline: `upstream/master` at `c00bdd53e7`
- Patch: `b48388614b`

The comparison used the repository's counterbalanced A/B runner with four pairs:

```sh
scripts/perf/ab_interleave.py \
  --a /tmp/esbmc-master \
  --b /tmp/esbmc-branch \
  --pairs 4 \
  --timeout 180 \
  -- /tmp/list_remove12.py --unwind 14
```

Both binaries reported `VERIFICATION SUCCESSFUL`.

| Metric | Master | Branch | Change |
|---|---:|---:|---:|
| Symex assignments | 2,272 | 1,631 | -28.2% |
| Generated VCCs | 2,024 | 1,165 | -42.4% |
| Remaining VCCs | 664 | 573 | -13.7% |
| Paired symex ratio | 1.000 | 0.337 | -66.3% |
| Paired BMC ratio | 1.000 | 0.437 | -56.3% |

Timing ratios are medians from the four counterbalanced pairs. Assignment and VCC counts were deterministic across all runs.

### Verification

- Python-enabled ESBMC build completed successfully.
- Regression harness unit suite: 10/10 passed.
- Dedicated symbolic success/failure regressions: 2/2 passed.
- Complete affected `list_remove` regression family: 15/15 passed.
- clang-format 11, YAPF, and patch whitespace checks passed.