### PR TITLE
[python] Add dynamic-typing ordered comparisons between tagged scalars and literals

### DIFF
--- a/regression/python/dynamic_type_scalar_tag_ordered_num/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+    assert not (x < 5)
+    assert x <= 5
+    assert not (5 > x)
+    assert 5 >= x
+else:
+    x = "a"

--- a/regression/python/dynamic_type_scalar_tag_ordered_num/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_ordered_num_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num_fail/main.py
@@ -1,0 +1,6 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+    assert x < 5

--- a/regression/python/dynamic_type_scalar_tag_ordered_num_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_ordered_str/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str/main.py
@@ -1,0 +1,10 @@
+cond = nondet_bool()
+if cond:
+    x = "a"
+    assert x < "b"
+    x = "ab"
+    assert x < "abc"
+    x = "abc"
+    assert not (x < "ab")
+else:
+    x = 1

--- a/regression/python/dynamic_type_scalar_tag_ordered_str/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_ordered_str_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str_fail/main.py
@@ -1,0 +1,6 @@
+cond = nondet_bool()
+if cond:
+    x = "a"
+else:
+    x = 1
+    assert x < "b"

--- a/regression/python/dynamic_type_scalar_tag_ordered_str_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/scalar.c
+++ b/src/c2goto/library/python/scalar.c
@@ -104,6 +104,57 @@ __ESBMC_HIDE:;
   return __python_scalar_bytes_equal(tagged->value, value, size);
 }
 
+// Three-way compare against a numeric literal (-1/0/1). Shared by
+// Lt/LtE/Gt/GtE -- the frontend composes the boolean from this against 0.
+int __python_scalar_cmp_num(
+  const PyObject *tagged,
+  int type_matches,
+  long long value)
+{
+__ESBMC_HIDE:;
+  __ESBMC_assert(
+    tagged && type_matches,
+    "TypeError: comparison not supported between these types");
+  if (!tagged || !type_matches)
+    return 0;
+  long long tagged_val = *(const long long *)tagged->value;
+  if (tagged_val < value)
+    return -1;
+  if (tagged_val > value)
+    return 1;
+  return 0;
+}
+
+// Lexicographic three-way compare against a literal str (-1/0/1). The loop
+// bound (`value_size`) is the literal's own compile-time length, not a
+// symbolic memcmp-style n. `.size`/`value_size` include the trailing '\0',
+// so the `i >= tagged->size` guard (stopping the read there) already gives
+// the correct prefix ordering ("ab" < "abc") for free.
+int __python_scalar_cmp_str(
+  const PyObject *tagged,
+  size_t type_id,
+  const char *value,
+  size_t value_size)
+{
+__ESBMC_HIDE:;
+  __ESBMC_assert(
+    tagged && tagged->type_id == type_id,
+    "TypeError: comparison not supported between these types");
+  if (!tagged || tagged->type_id != type_id)
+    return 0;
+
+  for (size_t i = 0; i < value_size; ++i)
+  {
+    if (i >= tagged->size)
+      return -1;
+    unsigned char a = ((const unsigned char *)tagged->value)[i];
+    unsigned char b = (unsigned char)value[i];
+    if (a != b)
+      return a < b ? -1 : 1;
+  }
+  return tagged->size > value_size ? 1 : 0;
+}
+
 // Models a runtime type mismatch (e.g. `x + 1` where `x` holds a str) as a
 // Python TypeError, the same way IndexError/KeyError are modeled elsewhere
 // in this library: an assert on the path that would have raised.

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -962,7 +962,7 @@ exprt python_converter::handle_tagged_scalar_binop(
   const nlohmann::json &right,
   const nlohmann::json &element)
 {
-  if (op == "Eq" || op == "NotEq")
+  if (op == "Eq" || op == "NotEq" || type_utils::is_ordered_comparison(op))
     return dynamic_type_handler_.handle_comparison(op, lhs, rhs);
   if (op == "Add" || op == "Sub" || op == "Div")
     return dynamic_type_handler_.handle_arithmetic(

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -3,6 +3,7 @@
 #include <python-frontend/python_expr_builder.h>
 #include <python-frontend/symbol_id.h>
 #include <python-frontend/type/type_handler.h>
+#include <python-frontend/type/type_utils.h>
 #include <python-frontend/string/string_handler.h>
 #include <python-frontend/exception/python_exception_handler.h>
 #include <util/arith/arith_tools.h>
@@ -418,7 +419,9 @@ void dynamic_type_handler::resolve_read(symbolt *&symbol) const
   }
 }
 
-exprt dynamic_type_handler::build_eq_literal(
+exprt dynamic_type_handler::build_literal_compare_call(
+  const std::string &num_func_name,
+  const std::string &str_func_name,
   const exprt &tagged,
   const exprt &literal)
 {
@@ -426,17 +429,17 @@ exprt dynamic_type_handler::build_eq_literal(
 
   if (literal.type().is_array())
   {
-    const symbolt *eq_str_func =
-      converter_.symbol_table().find_symbol("c:@F@__python_scalar_eq_str");
-    assert(eq_str_func && "__python_scalar_eq_str not found in symbol table");
+    const symbolt *str_func =
+      converter_.symbol_table().find_symbol("c:@F@" + str_func_name);
+    assert(
+      str_func && "tagged-vs-literal str helper not found in symbol table");
     exprt lit_type_id = type_handler_.tagged_scalar_type_id(literal.type());
     exprt lit_addr =
       converter_.get_string_handler().get_array_base_address(literal);
     exprt lit_size = type_handler_.tagged_scalar_byte_size(literal);
 
-    exprt call = build_call_expr(
-      *eq_str_func, int_type(), {tagged_addr, lit_type_id, lit_addr, lit_size});
-    return build_equal(call, from_integer(1, int_type()));
+    return build_call_expr(
+      *str_func, int_type(), {tagged_addr, lit_type_id, lit_addr, lit_size});
   }
 
   if (
@@ -453,11 +456,19 @@ exprt dynamic_type_handler::build_eq_literal(
     type_handler_.tagged_scalar_type_matches(tagged_type_id, literal.type()),
     int_type());
 
-  const symbolt *eq_num_func =
-    converter_.symbol_table().find_symbol("c:@F@__python_scalar_eq_num");
-  assert(eq_num_func && "__python_scalar_eq_num not found in symbol table");
-  exprt call = build_call_expr(
-    *eq_num_func, int_type(), {tagged_addr, type_matches, lit_value});
+  const symbolt *num_func =
+    converter_.symbol_table().find_symbol("c:@F@" + num_func_name);
+  assert(num_func && "tagged-vs-literal num helper not found in symbol table");
+  return build_call_expr(
+    *num_func, int_type(), {tagged_addr, type_matches, lit_value});
+}
+
+exprt dynamic_type_handler::build_eq_literal(
+  const exprt &tagged,
+  const exprt &literal)
+{
+  exprt call = build_literal_compare_call(
+    "__python_scalar_eq_num", "__python_scalar_eq_str", tagged, literal);
   return build_equal(call, from_integer(1, int_type()));
 }
 
@@ -468,9 +479,15 @@ exprt dynamic_type_handler::handle_comparison(
 {
   const bool lhs_tagged = type_handler_.is_tagged_scalar_type(lhs.type());
   const bool rhs_tagged = type_handler_.is_tagged_scalar_type(rhs.type());
+  const bool ordered = type_utils::is_ordered_comparison(op);
 
   if (lhs_tagged && rhs_tagged)
   {
+    if (ordered)
+      throw std::runtime_error(
+        "ordering two dynamically-typed variables directly is not yet "
+        "supported");
+
     const symbolt *eq_obj_func =
       converter_.symbol_table().find_symbol("c:@F@__python_scalar_eq_obj");
     assert(eq_obj_func && "__python_scalar_eq_obj not found in symbol table");
@@ -484,10 +501,40 @@ exprt dynamic_type_handler::handle_comparison(
     return op == "NotEq" ? build_not(equal) : equal;
   }
 
+  if (ordered)
+  {
+    // Comparison isn't symmetric like ==, so a literal on the left (e.g.
+    // `5 < x`) needs the operator mirrored before dispatch.
+    static const std::unordered_map<std::string, std::string> mirrored_op = {
+      {"Lt", "Gt"}, {"Gt", "Lt"}, {"LtE", "GtE"}, {"GtE", "LtE"}};
+    const std::string effective_op = lhs_tagged ? op : mirrored_op.at(op);
+    return lhs_tagged ? build_ordered_literal(effective_op, lhs, rhs)
+                      : build_ordered_literal(effective_op, rhs, lhs);
+  }
+
   exprt result =
     lhs_tagged ? build_eq_literal(lhs, rhs) : build_eq_literal(rhs, lhs);
 
   return op == "NotEq" ? build_not(result) : result;
+}
+
+exprt dynamic_type_handler::build_ordered_literal(
+  const std::string &op,
+  const exprt &tagged,
+  const exprt &literal)
+{
+  exprt cmp = build_literal_compare_call(
+    "__python_scalar_cmp_num", "__python_scalar_cmp_str", tagged, literal);
+
+  exprt zero = from_integer(BigInt(0), int_type());
+  if (op == "Lt")
+    return build_less_than(cmp, zero);
+  if (op == "LtE")
+    return build_less_equal(cmp, zero);
+  if (op == "Gt")
+    return build_greater_than(cmp, zero);
+  assert(op == "GtE" && "unexpected operator routed to build_ordered_literal");
+  return build_greater_equal(cmp, zero);
 }
 
 exprt dynamic_type_handler::build_add_literal(

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -74,8 +74,8 @@ public:
   void resolve_read(symbolt *&symbol) const;
 
   /**
-   * @brief Dispatches Eq/NotEq between a tagged-scalar operand and the
-   * other side
+   * @brief Dispatches Eq/NotEq/Lt/LtE/Gt/GtE between a tagged-scalar
+   * operand and the other side
    */
   exprt
   handle_comparison(const std::string &op, const exprt &lhs, const exprt &rhs);
@@ -164,7 +164,22 @@ private:
    */
   symbolt *find_tag_symbol(const std::string &name) const;
 
+  /**
+   * @brief Calls the num/str helper matching `literal`'s type (dispatch and
+   * argument-building shared by every tagged-vs-literal Eq/ordered compare)
+   * and returns its raw int result, undecoded
+   */
+  exprt build_literal_compare_call(
+    const std::string &num_func_name,
+    const std::string &str_func_name,
+    const exprt &tagged,
+    const exprt &literal);
+
   exprt build_eq_literal(const exprt &tagged, const exprt &literal);
+  exprt build_ordered_literal(
+    const std::string &op,
+    const exprt &tagged,
+    const exprt &literal);
   exprt build_add_literal(
     const exprt &tagged,
     const exprt &literal,


### PR DESCRIPTION
Adds ordered comparisons (<, <=, >, >=) between a tagged scalar and a literal, alongside the existing ==/!= support. The comparison dispatches to a shared three-way (-1/0/1) result, similar to how strcmp works, composed against zero with the right operator on the frontend side. Comparing a string tagged variable against a string literal reuses the literal's own length as the loop bound, which stays a compile-time constant regardless of the tagged operand's runtime length.

Follow-up to #7018. 