### PR TITLE
[ld] Reject POU bodies the front end cannot translate

### DIFF
--- a/regression/ld/body_fbd_unsupported_fail/fbd.ld
+++ b/regression/ld/body_fbd_unsupported_fail/fbd.ld
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- FBD body wiring TRUE to both A and B: P1 is violated every scan (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="Mutex"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="Mutex" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <FBD>
+          <inVariable localId="1"><expression>TRUE</expression></inVariable>
+          <outVariable localId="2">
+            <connectionPointIn><connection refLocalId="1"/></connectionPointIn>
+            <expression>A</expression></outVariable>
+          <outVariable localId="3">
+            <connectionPointIn><connection refLocalId="1"/></connectionPointIn>
+            <expression>B</expression></outVariable>
+        </FBD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/body_fbd_unsupported_fail/props.yaml
+++ b/regression/ld/body_fbd_unsupported_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [A, B]
+    description: "Coils A and B must never be simultaneously energised"

--- a/regression/ld/body_fbd_unsupported_fail/test.desc
+++ b/regression/ld/body_fbd_unsupported_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+fbd.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: UnsupportedConstruct\(FBD body of POU 'Mutex', tier=2\)$
+^ERROR: PARSING ERROR$

--- a/regression/ld/body_ladder_diagram_safe/alias.ld
+++ b/regression/ld/body_ladder_diagram_safe/alias.ld
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- <ladderDiagram> is the schema's second spelling of an LD body. The body
+     whitelist has to accept it: rejecting it would drop live rungs, and the
+     invariant fails if either rung goes missing (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="Alias"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="Alias" pouType="program">
+      <interface>
+        <inputVars>
+          <variable name="Enable"><type><BOOL/></type></variable>
+        </inputVars>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <ladderDiagram>
+          <rung localId="1" lineNumber="1">
+            <contact variable="Enable"/>
+            <coil variable="A"/>
+          </rung>
+          <rung localId="2" lineNumber="2">
+            <contact variable="Enable" negated="true"/>
+            <coil variable="B"/>
+          </rung>
+        </ladderDiagram>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/body_ladder_diagram_safe/props.yaml
+++ b/regression/ld/body_ladder_diagram_safe/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "(!Enable || A) && (Enable || B)"
+    description: "Both rungs drive their coil every scan"

--- a/regression/ld/body_ladder_diagram_safe/test.desc
+++ b/regression/ld/body_ladder_diagram_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+alias.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/body_ld_in_transition_fail/props.yaml
+++ b/regression/ld/body_ld_in_transition_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [A, B]
+    description: "Coils A and B must never be simultaneously energised"

--- a/regression/ld/body_ld_in_transition_fail/test.desc
+++ b/regression/ld/body_ld_in_transition_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+trans.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: UnsupportedConstruct\(LD body of transition 'T1' of POU 'Mutex', tier=2\)$
+^ERROR: PARSING ERROR$

--- a/regression/ld/body_ld_in_transition_fail/trans.ld
+++ b/regression/ld/body_ld_in_transition_fail/trans.ld
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- parse() collects networks from POU bodies and SFC step actions only, so
+     a transition body's rungs reach nothing (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="Mutex"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="Mutex" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <rung localId="1" lineNumber="1"><coil variable="A"/></rung>
+        </LD>
+      </body>
+      <transitions>
+        <transition name="T1">
+          <body>
+            <LD>
+              <rung localId="2" lineNumber="2"><coil variable="B"/></rung>
+            </LD>
+          </body>
+        </transition>
+      </transitions>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/body_sfc_unsupported_fail/props.yaml
+++ b/regression/ld/body_sfc_unsupported_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [A, B]
+    description: "Coils A and B must never be simultaneously energised"

--- a/regression/ld/body_sfc_unsupported_fail/sfc.ld
+++ b/regression/ld/body_sfc_unsupported_fail/sfc.ld
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SFC body with an LD step action: the parser can reach the action's rungs,
+     but not the step sequencing that gates them (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="Mutex"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="Mutex" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <SFC>
+          <step localId="1" name="Init" initialStep="true"/>
+          <transition localId="2">
+            <condition><connectionPointIn><connection refLocalId="1"/></connectionPointIn></condition>
+          </transition>
+        </SFC>
+      </body>
+      <actions>
+        <action name="Drive">
+          <body>
+            <LD>
+              <rung localId="1" lineNumber="1"><coil variable="A"/></rung>
+              <rung localId="2" lineNumber="2"><coil variable="B"/></rung>
+            </LD>
+          </body>
+        </action>
+      </actions>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/body_sfc_unsupported_fail/test.desc
+++ b/regression/ld/body_sfc_unsupported_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+sfc.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: UnsupportedConstruct\(SFC body of POU 'Mutex', tier=2\)$
+^ERROR: PARSING ERROR$

--- a/regression/ld/body_st_unregistered_fb_fail/nopin.ld
+++ b/regression/ld/body_st_unregistered_fb_fail/nopin.ld
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- A function block's ST body is translated only once the definition
+     registers; with no output pin this one was dropped and its output
+     havocked instead, giving an unexplained counterexample (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="NOPIN"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="NOPIN" pouType="functionBlock">
+      <interface>
+        <localVars><variable name="i"><type><INT/></type></variable></localVars>
+      </interface>
+      <body><ST><![CDATA[
+i := 1;
+]]></ST></body>
+    </pou>
+    <pou name="MAIN" pouType="program">
+      <interface>
+        <outputVars><variable name="Safe"><type><BOOL/></type></variable></outputVars>
+      </interface>
+      <body>
+        <LD>
+          <block localId="10" typeName="NOPIN" instanceName="n0"/>
+          <outVariable localId="11"><expression>Safe</expression>
+            <connectionPointIn><connection refLocalId="10" formalParameter="OUT"/></connectionPointIn></outVariable>
+        </LD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/body_st_unregistered_fb_fail/props.yaml
+++ b/regression/ld/body_st_unregistered_fb_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "Safe"
+    description: "Safe is driven by the function block's output pin"

--- a/regression/ld/body_st_unregistered_fb_fail/test.desc
+++ b/regression/ld/body_st_unregistered_fb_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+nopin.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: UnsupportedConstruct\(ST body of POU 'NOPIN', tier=2\)$
+^ERROR: PARSING ERROR$

--- a/regression/ld/body_st_unsupported_fail/props.yaml
+++ b/regression/ld/body_st_unsupported_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [A, B]
+    description: "Coils A and B must never be simultaneously energised"

--- a/regression/ld/body_st_unsupported_fail/st.ld
+++ b/regression/ld/body_st_unsupported_fail/st.ld
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ST body driving A and B unconditionally: P1 is violated every scan (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="Mutex"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="Mutex" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <ST><xhtml xmlns="http://www.w3.org/1999/xhtml">A := TRUE;
+B := TRUE;
+</xhtml></ST>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/body_st_unsupported_fail/test.desc
+++ b/regression/ld/body_st_unsupported_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+st.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: UnsupportedConstruct\(ST body of POU 'Mutex', tier=2\)$
+^ERROR: PARSING ERROR$

--- a/regression/ld/body_vendor_adddata_safe/props.yaml
+++ b/regression/ld/body_vendor_adddata_safe/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: invariant
+    expression: "(!Enable || A) && (Enable || B)"
+    description: "Both rungs drive their coil every scan"

--- a/regression/ld/body_vendor_adddata_safe/test.desc
+++ b/regression/ld/body_vendor_adddata_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+vendor.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/ld/body_vendor_adddata_safe/vendor.ld
+++ b/regression/ld/body_vendor_adddata_safe/vendor.ld
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- <addData> (PLCopen's vendor extension point) and <documentation> each
+     nest a <body> under the POU that is not a POU body (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="Alias"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="Alias" pouType="program">
+      <interface>
+        <inputVars>
+          <variable name="Enable"><type><BOOL/></type></variable>
+        </inputVars>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <rung localId="1" lineNumber="1">
+            <contact variable="Enable"/>
+            <coil variable="A"/>
+          </rung>
+          <rung localId="2" lineNumber="2">
+            <contact variable="Enable" negated="true"/>
+            <coil variable="B"/>
+          </rung>
+        </LD>
+      </body>
+      <addData>
+        <data name="vendor.widget" handleUnknown="implementation">
+          <widget><body><canvas/></body></widget>
+        </data>
+      </addData>
+      <documentation>
+        <xhtml xmlns="http://www.w3.org/1999/xhtml"><body><p>Notes.</p></body></xhtml>
+      </documentation>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/empty_scan_cycle_fail/empty.ld
+++ b/regression/ld/empty_scan_cycle_fail/empty.ld
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- A translated body notation carrying no logic at all (#7354). -->
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="Mutex"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="Mutex" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD/>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/regression/ld/empty_scan_cycle_fail/props.yaml
+++ b/regression/ld/empty_scan_cycle_fail/props.yaml
@@ -1,0 +1,5 @@
+properties:
+  - id: P1
+    kind: mutual_exclusion
+    variables: [A, B]
+    description: "Coils A and B must never be simultaneously energised"

--- a/regression/ld/empty_scan_cycle_fail/test.desc
+++ b/regression/ld/empty_scan_cycle_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+empty.ld
+--ld-props props.yaml --k-induction --unlimited-k-steps
+^ERROR: .*no ladder logic was translated; the scan cycle would be empty and every property vacuous$
+^ERROR: PARSING ERROR$

--- a/src/ld-frontend/parser/plcopen_xml_parser.cpp
+++ b/src/ld-frontend/parser/plcopen_xml_parser.cpp
@@ -1019,6 +1019,60 @@ void PlcopenXmlParser::normalise(pugi_doc_wrapper &w)
 }
 
 // -----------------------------------------------------------------------
+// Untranslated POU bodies
+// -----------------------------------------------------------------------
+
+// A body the front end does not translate leaves the scan cycle empty, so every
+// property holds vacuously and the run reports a proof (#7354). Accept by
+// whitelist, so a notation added to the schema later fails closed.
+//
+// Both the location and the notation have to match what parse() collects
+// above: <addData> and <documentation> nest an unrelated <body> under the POU,
+// and a ladder body under <transitions> is collected by nobody.
+static void
+reject_untranslated_bodies(const pugi::xml_node &root, const LdAst &ast)
+{
+  for (auto xpath_node :
+       root.select_nodes("//pou/body/* | //pou/actions/action/body/* | "
+                         "//pou/transitions/transition/body/*"))
+  {
+    const pugi::xml_node lang = xpath_node.node();
+    const std::string tag = lang.name();
+
+    const pugi::xml_node holder = lang.parent().parent();
+    const std::string where = holder.name();
+    const pugi::xml_node pou =
+      where == "pou" ? holder : holder.parent().parent();
+    const std::string pou_name = pou.attribute("name").as_string();
+
+    if (
+      (tag == "LD" || tag == "ladderDiagram") &&
+      (where == "pou" || where == "action"))
+      continue;
+
+    // st_fb_translator inlines a function block's Structured Text body into
+    // the scan cycle, but only once the definition has registered: an FB with
+    // no output pin or an empty body is dropped, and dropping it silently is
+    // the same defect as dropping the body outright.
+    const bool translated_fb_body =
+      tag == "ST" &&
+      std::string(pou.attribute("pouType").as_string()) == "functionBlock" &&
+      std::any_of(
+        ast.user_fb_defs.begin(),
+        ast.user_fb_defs.end(),
+        [&pou_name](const UserFBDef &d) { return d.type_name == pou_name; });
+    if (translated_fb_body)
+      continue;
+
+    const std::string site =
+      where == "pou" ? "POU '" + pou_name + "'"
+                     : where + " '" + holder.attribute("name").as_string() +
+                         "' of POU '" + pou_name + "'";
+    throw UnsupportedConstructError(tag + " body of " + site, 2);
+  }
+}
+
+// -----------------------------------------------------------------------
 // Top-level parse()
 // -----------------------------------------------------------------------
 
@@ -1261,6 +1315,9 @@ LdAst PlcopenXmlParser::parse(const std::string &path)
           inst.out_wires.push_back({pv, pin});
     }
   }
+
+  // Last, so the function-block definitions above are already registered.
+  reject_untranslated_bodies(root, ast);
 
   return ast;
 }

--- a/src/ld-frontend/semantics/type_checker.cpp
+++ b/src/ld-frontend/semantics/type_checker.cpp
@@ -1,4 +1,5 @@
 #include <ld-frontend/semantics/type_checker.h>
+#include <algorithm>
 #include <sstream>
 
 // -----------------------------------------------------------------------
@@ -174,6 +175,21 @@ void TypeChecker::check_rung_element(const RungElement &elem)
 void TypeChecker::check(const LdAst &ast)
 {
   build_var_type_map(ast);
+
+  // Second, independent guard on the vacuity of #7354: the parser's body
+  // whitelist is keyed on notation, this catches an empty model however it
+  // arose (empty <LD/>, namespace-prefixed document, a dropped element).
+  const bool has_logic =
+    std::any_of(
+      ast.networks.begin(),
+      ast.networks.end(),
+      [](const NetworkNode &n) { return !n.rungs.empty(); }) ||
+    !ast.user_fb_instances.empty();
+  if (!has_logic)
+    throw TypeCheckError(
+      ast.source_file +
+      ": no ladder logic was translated; the scan cycle "
+      "would be empty and every property vacuous");
 
   for (const auto &net : ast.networks)
     for (const auto &rung : net.rungs)

--- a/src/ld-frontend/verify/ld_verify.cpp
+++ b/src/ld-frontend/verify/ld_verify.cpp
@@ -1,6 +1,6 @@
 #include <ld-frontend/verify/ld_verify.h>
-#include <cstring>
 #include <sstream>
+#include <string_view>
 #include <vector>
 #include <cstdlib>
 
@@ -168,16 +168,15 @@ parse_violated_property(const std::string &output, LdVerifyResult &r)
 // which reads as a crash.
 static std::string no_verdict_description(const std::string &output)
 {
-  const char *prefix = "ERROR: ";
-  const size_t prefix_len = strlen(prefix);
+  static constexpr std::string_view prefix = "ERROR: ";
   std::istringstream ss(output);
   std::string line;
   while (std::getline(ss, line))
   {
     if (!line.empty() && line.back() == '\r')
       line.pop_back();
-    if (line.compare(0, prefix_len, prefix) == 0)
-      return line.substr(prefix_len);
+    if (std::string_view(line).starts_with(prefix))
+      return line.substr(prefix.size());
   }
   return "esbmc produced no verdict";
 }

--- a/src/ld-frontend/verify/ld_verify.cpp
+++ b/src/ld-frontend/verify/ld_verify.cpp
@@ -1,4 +1,5 @@
 #include <ld-frontend/verify/ld_verify.h>
+#include <cstring>
 #include <sstream>
 #include <vector>
 #include <cstdlib>
@@ -162,6 +163,25 @@ parse_violated_property(const std::string &output, LdVerifyResult &r)
   }
 }
 
+// Describes a run that printed no verdict. A rejected input carries the reason
+// on an "ERROR:" line naming the construct; reporting that beats "no verdict",
+// which reads as a crash.
+static std::string no_verdict_description(const std::string &output)
+{
+  const char *prefix = "ERROR: ";
+  const size_t prefix_len = strlen(prefix);
+  std::istringstream ss(output);
+  std::string line;
+  while (std::getline(ss, line))
+  {
+    if (!line.empty() && line.back() == '\r')
+      line.pop_back();
+    if (line.compare(0, prefix_len, prefix) == 0)
+      return line.substr(prefix_len);
+  }
+  return "esbmc produced no verdict";
+}
+
 // esbmc prints its verdict as a standalone, unindented line; match the whole
 // line so that descriptive text echoed into the counterexample cannot be
 // mistaken for a verdict.
@@ -310,7 +330,7 @@ LdVerifyResult LdVerifyRunner::run(const LdVerifyOptions &opts)
   {
     // No recognisable verdict: esbmc crashed, was killed, or rejected the input.
     r.verdict = LdVerifyResult::Verdict::Error;
-    r.description = "esbmc produced no verdict";
+    r.description = no_verdict_description(output);
     r.raw_output = output;
   }
 

--- a/tools/ld-verify/CMakeLists.txt
+++ b/tools/ld-verify/CMakeLists.txt
@@ -67,9 +67,17 @@ if(BUILD_TESTING)
     ${_ld_reg}/esd_manual_reset_fail/esd.ld
     --props ${_ld_reg}/esd_manual_reset_fail/props.yaml)
 
+  # Anchored on "description" so the assertion cannot be met by the raw_output
+  # echo, which master already emitted.
+  add_ld_verify_test(error-unsupported-body
+    "\"description\": \"UnsupportedConstruct\\(ST body of POU"
+    ${_ld_reg}/body_st_unsupported_fail/st.ld
+    --props ${_ld_reg}/body_st_unsupported_fail/props.yaml)
+
   # An input esbmc cannot parse yields no verdict line; that must surface as
   # ERROR rather than being folded into UNKNOWN.
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/malformed.ld "not a plcopen document")
-  add_ld_verify_test(error-no-verdict "\"result\": \"ERROR\""
+  add_ld_verify_test(error-no-verdict
+    "\"description\": \"[^\"]*No document element found"
     ${CMAKE_CURRENT_BINARY_DIR}/malformed.ld)
 endif()

--- a/unit/ld-frontend/fixtures/empty_ld_body.ld
+++ b/unit/ld-frontend/fixtures/empty_ld_body.ld
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="EmptyBody"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="EmptyBody" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD/>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/unit/ld-frontend/fixtures/fbd_program_body.ld
+++ b/unit/ld-frontend/fixtures/fbd_program_body.ld
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="FbdBody"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="FbdBody" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <FBD>
+          <inVariable localId="1"><expression>TRUE</expression></inVariable>
+          <outVariable localId="2">
+            <connectionPointIn><connection refLocalId="1"/></connectionPointIn>
+            <expression>A</expression></outVariable>
+        </FBD>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/unit/ld-frontend/fixtures/ladder_diagram_body.ld
+++ b/unit/ld-frontend/fixtures/ladder_diagram_body.ld
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="LadderAlias"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="LadderAlias" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <ladderDiagram>
+          <rung localId="1"><coil variable="A"/></rung>
+        </ladderDiagram>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/unit/ld-frontend/fixtures/ld_in_transition.ld
+++ b/unit/ld-frontend/fixtures/ld_in_transition.ld
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="TransBody"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="TransBody" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <rung localId="1"><coil variable="A"/></rung>
+        </LD>
+      </body>
+      <transitions>
+        <transition name="T1">
+          <body><LD><rung localId="2"><coil variable="B"/></rung></LD></body>
+        </transition>
+      </transitions>
+    </pou>
+  </pous>
+</project>

--- a/unit/ld-frontend/fixtures/sfc_with_ld_action.ld
+++ b/unit/ld-frontend/fixtures/sfc_with_ld_action.ld
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="SfcBody"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="SfcBody" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <SFC>
+          <step localId="1" name="Init" initialStep="true"/>
+        </SFC>
+      </body>
+      <actions>
+        <action name="Drive">
+          <body>
+            <LD>
+              <rung localId="1"><coil variable="A"/></rung>
+            </LD>
+          </body>
+        </action>
+      </actions>
+    </pou>
+  </pous>
+</project>

--- a/unit/ld-frontend/fixtures/st_program_body.ld
+++ b/unit/ld-frontend/fixtures/st_program_body.ld
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="StBody"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="StBody" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <ST><xhtml xmlns="http://www.w3.org/1999/xhtml">A := TRUE;
+B := TRUE;
+</xhtml></ST>
+      </body>
+    </pou>
+  </pous>
+</project>

--- a/unit/ld-frontend/fixtures/vendor_extension_bodies.ld
+++ b/unit/ld-frontend/fixtures/vendor_extension_bodies.ld
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0200">
+  <fileHeader companyName="SAFE-LD" productVersion="1.0" creationDateTime="2026-08-27"/>
+  <contentHeader name="VendorBodies"/>
+  <types/>
+  <instances/>
+  <pous>
+    <pou name="VendorBodies" pouType="program">
+      <interface>
+        <outputVars>
+          <variable name="A"><type><BOOL/></type></variable>
+          <variable name="B"><type><BOOL/></type></variable>
+        </outputVars>
+      </interface>
+      <body>
+        <LD>
+          <rung localId="1"><coil variable="A"/></rung>
+        </LD>
+      </body>
+      <addData>
+        <data name="vendor.widget" handleUnknown="implementation">
+          <widget><body><canvas/></body></widget>
+        </data>
+      </addData>
+      <documentation>
+        <xhtml xmlns="http://www.w3.org/1999/xhtml"><body><p>Notes.</p></body></xhtml>
+      </documentation>
+    </pou>
+  </pous>
+</project>

--- a/unit/ld-frontend/test_parser.cpp
+++ b/unit/ld-frontend/test_parser.cpp
@@ -69,6 +69,57 @@ TEST_CASE("unknown rung element throws UnsupportedConstructError", "[parser]")
     parser.parse(fixture("unknown_element.ld")), UnsupportedConstructError);
 }
 
+// Assert the reason, not just the type: parse_rung_element throws the same
+// exception, so the type alone would not distinguish a wrong rejection.
+TEST_CASE("untranslated POU body throws UnsupportedConstructError", "[parser]")
+{
+  auto [file, reason] = GENERATE(
+    std::make_pair("st_program_body.ld", "ST body of POU 'StBody'"),
+    std::make_pair("fbd_program_body.ld", "FBD body of POU 'FbdBody'"),
+    std::make_pair("sfc_with_ld_action.ld", "SFC body of POU 'SfcBody'"));
+
+  PlcopenXmlParser parser;
+  REQUIRE_THROWS_WITH(parser.parse(fixture(file)), Catch::Contains(reason));
+}
+
+// <addData> and <documentation> nest a <body> that is not a POU body.
+TEST_CASE("vendor addData and documentation bodies are ignored", "[parser]")
+{
+  PlcopenXmlParser parser;
+  LdAst ast = parser.parse(fixture("vendor_extension_bodies.ld"));
+
+  REQUIRE(ast.networks.size() == 1);
+  REQUIRE(ast.networks[0].rungs.size() == 1);
+}
+
+// parse() collects no network from a transition body (#7354).
+TEST_CASE("ladder in a transition body is rejected", "[parser]")
+{
+  PlcopenXmlParser parser;
+  REQUIRE_THROWS_WITH(
+    parser.parse(fixture("ld_in_transition.ld")),
+    Catch::Contains("LD body of transition 'T1'"));
+}
+
+TEST_CASE("ladderDiagram body is accepted", "[parser]")
+{
+  PlcopenXmlParser parser;
+  LdAst ast = parser.parse(fixture("ladder_diagram_body.ld"));
+
+  REQUIRE(ast.networks.size() == 1);
+  REQUIRE(ast.networks[0].rungs.size() == 1);
+}
+
+TEST_CASE("empty LD body parses but carries no rung", "[parser]")
+{
+  PlcopenXmlParser parser;
+  LdAst ast = parser.parse(fixture("empty_ld_body.ld"));
+
+  REQUIRE(ast.networks.size() == 1);
+  REQUIRE(ast.networks[0].rungs.empty());
+  REQUIRE(ast.user_fb_instances.empty());
+}
+
 // -----------------------------------------------------------------------
 // TypeChecker tests
 // -----------------------------------------------------------------------
@@ -137,6 +188,19 @@ TEST_CASE("empty coil variable rejected by type checker", "[type_checker]")
 {
   TypeChecker tc;
   REQUIRE_THROWS_AS(tc.check(make_coil_ast("", true)), TypeCheckError);
+}
+
+// An empty scan cycle makes every property vacuous (#7354).
+TEST_CASE("empty scan cycle rejected by type checker", "[type_checker]")
+{
+  LdAst ast;
+  ast.source_file = "<test>";
+  NetworkNode net;
+  net.name = "main";
+  ast.networks.push_back(net);
+
+  TypeChecker tc;
+  REQUIRE_THROWS_AS(tc.check(ast), TypeCheckError);
 }
 
 static LdAst make_timer_ast(bool omit_et)

--- a/website/content/docs/ld/limitations.md
+++ b/website/content/docs/ld/limitations.md
@@ -50,6 +50,15 @@ supported and the known restrictions.
 
 - **Input format.** Programs must be supplied as PLCopen XML. Other LD
   serialisations are not parsed.
+- **POU body notations.** Only `<LD>` / `<ladderDiagram>` bodies, and the `<ST>`
+  body of a function block, are translated. A POU whose body is `<ST>`, `<FBD>`,
+  `<SFC>` or `<IL>` is rejected with
+  `UnsupportedConstruct(<notation> body of POU '<name>', tier=2)`. Ladder nested
+  in `<SFC>` step actions is rejected with the rest of the chart: the step and
+  transition sequencing that gates those actions is not modelled, so running
+  them is a different program. Rejecting rather than skipping is deliberate —
+  a body that is skipped leaves the scan cycle empty, and every property then
+  holds vacuously.
 - **`TP` pulse timers.** `TP` blocks are modelled with `TON` (on-delay)
   semantics: `Q` rises after `IN` has been held for `PT` ticks, rather than
   emitting a fixed-width pulse on a rising edge of `IN`. Properties that depend


### PR DESCRIPTION
The LD front end collected networks only from `<LD>`/`<ladderDiagram>` bodies, so an `<ST>`, `<FBD>`, `<SFC>` or `<IL>` body was never visited: the scan cycle came out empty and every property held vacuously, reporting SUCCESSFUL on a program that violates it in every scan.

Reject an untranslated body by whitelist, keyed on both the body location and its notation so a vendor `<addData>` or `<documentation>` body is not mistaken for a POU body, and guard the empty scan cycle independently in the type checker.

Fixes #7354