### PR TITLE
[python] Constant-fold str.find/rfind/index/rindex on constants

### DIFF
--- a/regression/python/string-find-const-fold-semantics/main.py
+++ b/regression/python/string-find-const-fold-semantics/main.py
@@ -1,0 +1,10 @@
+s = "hello world"
+
+assert s.find("o") == 4
+assert s.rfind("o") == 7
+assert s.find("zz") == -1
+assert s.rfind("zz") == -1
+assert s.index("world") == 6
+assert s.rindex("l") == 9
+assert s.find("") == 0
+assert s.rfind("") == 11

--- a/regression/python/string-find-const-fold-semantics/test.desc
+++ b/regression/python/string-find-const-fold-semantics/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 16
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-find-const-fold-semantics_fail/main.py
+++ b/regression/python/string-find-const-fold-semantics_fail/main.py
@@ -1,0 +1,4 @@
+s = "hello world"
+
+# rfind() reports the last occurrence, not the first.
+assert s.rfind("o") == 4

--- a/regression/python/string-find-const-fold-semantics_fail/test.desc
+++ b/regression/python/string-find-const-fold-semantics_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 16
+^VERIFICATION FAILED$

--- a/regression/python/string-find-const-fold/main.py
+++ b/regression/python/string-find-const-fold/main.py
@@ -1,0 +1,5 @@
+s = "hello world"
+i = s.find("world")
+j = s.rfind("o")
+assert i == 6
+assert j == 7

--- a/regression/python/string-find-const-fold/test.desc
+++ b/regression/python/string-find-const-fold/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--goto-functions-only
+^ *ASSIGN i=6;$
+^ *ASSIGN j=7;$

--- a/regression/python/string-index-const-fold-miss_fail/main.py
+++ b/regression/python/string-index-const-fold-miss_fail/main.py
@@ -1,0 +1,6 @@
+s = "hello"
+
+# index() raises ValueError when absent, so the fold must decline the miss
+# and leave the model to report it.
+i = s.index("zz")
+assert i >= 0

--- a/regression/python/string-index-const-fold-miss_fail/test.desc
+++ b/regression/python/string-index-const-fold-miss_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 16
+^VERIFICATION FAILED$
+^ *FAILED .*ValueError

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -3112,6 +3112,7 @@ exprt string_handler::handle_string_attribute_call(
         *this,
         method_name,
         call_json,
+        receiver_json,
         args,
         keyword_values,
         get_receiver_expr,

--- a/src/python-frontend/string/string_method_dispatch.h
+++ b/src/python-frontend/string/string_method_dispatch.h
@@ -39,6 +39,7 @@ std::optional<exprt> dispatch_search_string_methods(
   string_handler &self,
   const std::string &method_name,
   const nlohmann::json &call_json,
+  const nlohmann::json &receiver_json,
   const nlohmann::json &args,
   const keyword_valuest &keyword_values,
   const std::function<exprt()> &get_receiver_expr,

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -891,10 +891,60 @@ static search_args_parsedt parse_string_search_args(
   return parsed;
 }
 
+// Fold subject.find/rfind/index/rindex(sub) when both operands are
+// compile-time constant str. Otherwise the call reaches __python_str_find with
+// two constant arrays and the model's bounded scan loops unwind against
+// --unwind rather than the known length.
+//
+// index/rindex raise ValueError when the needle is absent, so a miss falls
+// through to the model rather than being folded to a value here.
+static std::optional<exprt> fold_constant_search(
+  const std::string &method_name,
+  const nlohmann::json &receiver_json,
+  const nlohmann::json &args,
+  const exprt &receiver,
+  python_converter &converter)
+{
+  exprt recv = receiver;
+  if (recv.is_symbol())
+  {
+    const symbolt *sym =
+      converter.find_symbol(to_symbol_expr(recv).get_identifier().as_string());
+    if (sym && !sym->get_value().is_nil())
+      recv = sym->get_value();
+  }
+
+  // bytes are an int array and carry their own literal fold; only str here.
+  const typet &recv_type = recv.type();
+  if (!recv_type.is_array() || recv_type.subtype() != char_type())
+    return std::nullopt;
+
+  std::string haystack, needle;
+  if (
+    args.size() != 1 ||
+    !string_handler::extract_constant_string(receiver_json, converter, haystack) ||
+    !string_handler::extract_constant_string(args[0], converter, needle))
+    return std::nullopt;
+
+  const bool reverse = (method_name == "rfind" || method_name == "rindex");
+  const std::size_t hit =
+    reverse ? haystack.rfind(needle) : haystack.find(needle);
+
+  if (hit == std::string::npos)
+  {
+    if (method_name == "index" || method_name == "rindex")
+      return std::nullopt;
+    return from_integer(-1, int_type());
+  }
+
+  return from_integer(static_cast<long long>(hit), int_type());
+}
+
 std::optional<exprt> dispatch_search_string_methods(
   string_handler &self,
   const std::string &method_name,
   const nlohmann::json &call_json,
+  const nlohmann::json &receiver_json,
   const nlohmann::json &args,
   const keyword_valuest &keyword_values,
   const std::function<exprt()> &get_receiver_expr,
@@ -907,6 +957,11 @@ std::optional<exprt> dispatch_search_string_methods(
     return std::nullopt;
 
   exprt obj_expr = get_receiver_expr();
+
+  if (
+    std::optional<exprt> folded = fold_constant_search(
+      method_name, receiver_json, args, obj_expr, converter))
+    return folded;
   search_args_parsedt parsed =
     parse_string_search_args(method_name, args, keyword_values, converter);
 

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -922,7 +922,8 @@ static std::optional<exprt> fold_constant_search(
   std::string haystack, needle;
   if (
     args.size() != 1 ||
-    !string_handler::extract_constant_string(receiver_json, converter, haystack) ||
+    !string_handler::extract_constant_string(
+      receiver_json, converter, haystack) ||
     !string_handler::extract_constant_string(args[0], converter, needle))
     return std::nullopt;
 


### PR DESCRIPTION
`"hello world".find("world")` reached `__python_str_find` with both operands
constant arrays, so the model's bounded scan loops unwound against `--unwind`
rather than the known length: 6,181 symex assignments and 1,042 VCCs for nine
assertions, against 78 and 9 once folded.

The literal fold already here covers bytes only, so str had none. Gated on a
char-array receiver to leave bytes on its own path, and index/rindex decline a
miss so the model still raises ValueError.