### PR TITLE
[python] Run one match scan in str.replace()

### DIFF
--- a/regression/python/string-replace-single-scan-gate/main.py
+++ b/regression/python/string-replace-single-scan-gate/main.py
@@ -1,0 +1,6 @@
+def foo(x: str) -> None:
+    s = x.replace("aa", "x", 5)
+    assert s == "x-bb-x"
+
+
+foo("aa-bb-aa")

--- a/regression/python/string-replace-single-scan-gate/test.desc
+++ b/regression/python/string-replace-single-scan-gate/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 13
+^VERIFICATION SUCCESSFUL$
+^Symex completed in: [0-9.]+s \([0-9]{1,4} assignments\)$

--- a/regression/python/string-replace-single-scan/main.py
+++ b/regression/python/string-replace-single-scan/main.py
@@ -1,0 +1,13 @@
+def foo(x: str) -> None:
+    # count exhausted before the end: the scan stops early and everything
+    # past that point must be copied verbatim.
+    assert x.replace("aa", "x", 1) == "x-bb-aa"
+    assert x.replace("aa", "yy") == "yy-bb-yy"
+    assert x.replace("aa", "") == "-bb-"
+    # no match at all: the scan marks every position it steps over as a miss.
+    assert x.replace("zz", "q") == "aa-bb-aa"
+    # a needle that only fits in the tail the scan cannot reach.
+    assert x.replace("a-", "Q") == "aQbb-aa"
+
+
+foo("aa-bb-aa")

--- a/regression/python/string-replace-single-scan/test.desc
+++ b/regression/python/string-replace-single-scan/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 13
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-single-scan_fail/main.py
+++ b/regression/python/string-replace-single-scan_fail/main.py
@@ -1,0 +1,6 @@
+def foo(x: str) -> None:
+    # count=1 replaces only the first match, not every match.
+    assert x.replace("aa", "x", 1) == "x-bb-x"
+
+
+foo("aa-bb-aa")

--- a/regression/python/string-replace-single-scan_fail/test.desc
+++ b/regression/python/string-replace-single-scan_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 13
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -905,6 +905,14 @@ __ESBMC_HIDE:;
     return buffer;
   }
 
+  // The scan records its decision at every position it steps over, so the copy
+  // loop below can reuse it instead of re-running strncmp there; under
+  // symbolic execution the second scan unwinds in full just like the first.
+  // Marking in place rather than pre-zeroing keeps this to one loop: the copy
+  // loop treats everything at or past scan_end as a non-match, which covers
+  // both the tail this loop cannot reach and an early exit on count.
+  char *is_match = __ESBMC_alloca(len_s + 1);
+
   int remaining = count;
   size_t occurrences = 0;
   size_t i = 0;
@@ -912,6 +920,7 @@ __ESBMC_HIDE:;
   {
     if ((remaining != 0) && strncmp(s + i, old_sub, old_len) == 0)
     {
+      is_match[i] = 1;
       occurrences++;
       i += old_len;
       if (remaining > 0)
@@ -920,8 +929,10 @@ __ESBMC_HIDE:;
         break;
       continue;
     }
+    is_match[i] = 0;
     i++;
   }
+  size_t scan_end = i;
 
   long long diff = (long long)new_len - (long long)old_len;
   long long result_len_signed =
@@ -931,25 +942,15 @@ __ESBMC_HIDE:;
   size_t result_len = (size_t)result_len_signed;
   char *buffer = __ESBMC_alloca(result_len + 1);
 
-  remaining = count;
   i = 0;
   size_t pos = 0;
 
-  // Main replacement loop - use bounded iteration
+  // Both loops walk the same positions with the same skip rule, so the marks
+  // left above land exactly where this one would have matched.
   while (i < len_s)
   {
-    // Check if replacement is possible at current position
-    int do_replace = 0;
-    if (remaining != 0 && i + old_len <= len_s)
+    if (i < scan_end && is_match[i])
     {
-      // Use strncmp for comparison (ESBMC handles this better)
-      if (strncmp(s + i, old_sub, old_len) == 0)
-        do_replace = 1;
-    }
-
-    if (do_replace)
-    {
-      // Copy new_sub to buffer
       size_t k = 0;
       while (k < new_len)
       {
@@ -957,15 +958,10 @@ __ESBMC_HIDE:;
         pos++;
         k++;
       }
-      // Skip old_sub in source
       i = i + old_len;
-      // Decrement remaining replacements
-      if (remaining > 0)
-        remaining = remaining - 1;
     }
     else
     {
-      // Copy single character
       buffer[pos] = s[i];
       pos++;
       i++;


### PR DESCRIPTION
`__python_str_replace` scanned for matches twice: once to count occurrences
for sizing the output buffer, then again in the copy loop. Both scans are
O(len_s * old_len) and under symbolic execution both unwind in full. The scan
now marks each position it steps over and the copy loop reads those marks,
cutting a parameter-subject replace from 12,118 symex assignments to 8,135 at
`--unwind 13`, and 67,506 VCCs to 51,115 on a five-assertion program.

Behaviour is unchanged: 90 differential cases against CPython give the same
results as master, case for case, and the full `string*` suite is 471/12 here
against 470/13 on master — the one difference being the gate this PR adds.