### PR TITLE
[python] Type a lambda parameter from its call site

### DIFF
--- a/regression/python/github_7328/main.py
+++ b/regression/python/github_7328/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [(1, 2), (3, 4)]
+    k = lambda t: t[0]
+    assert k(c[0]) == 1
+
+
+f(3)

--- a/regression/python/github_7328/test.desc
+++ b/regression/python/github_7328/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7328_concat/main.py
+++ b/regression/python/github_7328_concat/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [(1, 2)] + [(3, 4)]
+    k = lambda t: t[0]
+    assert k(c[1]) == 3
+
+
+f(3)

--- a/regression/python/github_7328_concat/test.desc
+++ b/regression/python/github_7328_concat/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:3$

--- a/regression/python/github_7328_dynindex/main.py
+++ b/regression/python/github_7328_dynindex/main.py
@@ -1,0 +1,8 @@
+def f(n: int):
+    c = [(1, 2), (3, 4)]
+    i = 1
+    k = lambda t: t[0]
+    assert k(c[i]) == 3
+
+
+f(3)

--- a/regression/python/github_7328_dynindex/test.desc
+++ b/regression/python/github_7328_dynindex/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:4$

--- a/regression/python/github_7328_fail/main.py
+++ b/regression/python/github_7328_fail/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [(1, 2), (3, 4)]
+    k = lambda t: t[0]
+    assert k(c[0]) == 2
+
+
+f(3)

--- a/regression/python/github_7328_fail/test.desc
+++ b/regression/python/github_7328_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/github_7328_foreign/main.py
+++ b/regression/python/github_7328_foreign/main.py
@@ -1,0 +1,12 @@
+def f(n: int):
+    c = [(1, 2)]
+    k = lambda t: t[0]
+
+    def g():
+        d = [(1.5, 2.5)]
+        return k(d[0])
+
+    assert k(c[0]) == 1
+
+
+f(3)

--- a/regression/python/github_7328_foreign/test.desc
+++ b/regression/python/github_7328_foreign/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:3$

--- a/regression/python/github_7328_global/main.py
+++ b/regression/python/github_7328_global/main.py
@@ -1,0 +1,15 @@
+counter: int = 1
+
+
+def bump() -> None:
+    global counter
+    counter += 1
+
+
+def f(n: int) -> None:
+    c = [(1, 2)]
+    k = lambda t: t[0]
+    assert k(c[0]) == 1
+
+
+f(3)

--- a/regression/python/github_7328_global/test.desc
+++ b/regression/python/github_7328_global/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7328_global_fail/main.py
+++ b/regression/python/github_7328_global_fail/main.py
@@ -1,0 +1,15 @@
+counter: int = 1
+
+
+def bump() -> None:
+    global counter
+    counter += 1
+
+
+def f(n: int) -> None:
+    c = [(1, 2)]
+    k = lambda t: t[0]
+    assert k(c[0]) == 2
+
+
+f(3)

--- a/regression/python/github_7328_global_fail/test.desc
+++ b/regression/python/github_7328_global_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/github_7328_hetero/main.py
+++ b/regression/python/github_7328_hetero/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [(1, 2)] + [(3.5, 4.5)]
+    k = lambda t: t[0]
+    assert k(c[1]) == 3.5
+
+
+f(3)

--- a/regression/python/github_7328_hetero/test.desc
+++ b/regression/python/github_7328_hetero/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:3$

--- a/regression/python/github_7328_index/main.py
+++ b/regression/python/github_7328_index/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [(1, 2), (3.5, 4.5)]
+    k = lambda t: t[0]
+    assert k(c[1]) == 3.5
+
+
+f(3)

--- a/regression/python/github_7328_index/test.desc
+++ b/regression/python/github_7328_index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7328_index_fail/main.py
+++ b/regression/python/github_7328_index_fail/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [(1, 2), (3.5, 4.5)]
+    k = lambda t: t[0]
+    assert k(c[1]) == 1
+
+
+f(3)

--- a/regression/python/github_7328_index_fail/test.desc
+++ b/regression/python/github_7328_index_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/github_7328_list_elem/main.py
+++ b/regression/python/github_7328_list_elem/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [[1, 2], [3, 4]]
+    k = lambda t: t[0]
+    assert k(c[0]) == 1
+
+
+f(3)

--- a/regression/python/github_7328_list_elem/test.desc
+++ b/regression/python/github_7328_list_elem/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:3$

--- a/regression/python/github_7328_mixed/main.py
+++ b/regression/python/github_7328_mixed/main.py
@@ -1,0 +1,9 @@
+def f(n: int):
+    a = [(1, 2), (3, 4)]
+    b = [(1.5, 2.5)]
+    k = lambda t: t[0]
+    assert k(a[0]) == 1
+    assert k(b[0]) == 1.5
+
+
+f(3)

--- a/regression/python/github_7328_mixed/test.desc
+++ b/regression/python/github_7328_mixed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:4$

--- a/regression/python/github_7328_multicall/main.py
+++ b/regression/python/github_7328_multicall/main.py
@@ -1,0 +1,9 @@
+def f(n: int):
+    a = [(1, 2), (3, 4)]
+    b = [(5, 6)]
+    k = lambda t: t[0]
+    assert k(a[0]) == 1
+    assert k(b[0]) == 5
+
+
+f(3)

--- a/regression/python/github_7328_multicall/test.desc
+++ b/regression/python/github_7328_multicall/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7328_multicall_fail/main.py
+++ b/regression/python/github_7328_multicall_fail/main.py
@@ -1,0 +1,9 @@
+def f(n: int):
+    a = [(1, 2), (3, 4)]
+    b = [(5, 6)]
+    k = lambda t: t[0]
+    assert k(a[0]) == 1
+    assert k(b[0]) == 6
+
+
+f(3)

--- a/regression/python/github_7328_multicall_fail/test.desc
+++ b/regression/python/github_7328_multicall_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/github_7328_nested/main.py
+++ b/regression/python/github_7328_nested/main.py
@@ -1,0 +1,12 @@
+def f(n: int):
+    c = [(1, 2)]
+    k = lambda t: t[0]
+
+    def g():
+        c = [(1.5, 2.5)]
+        return k(c[0])
+
+    assert g() == 1.5
+
+
+f(3)

--- a/regression/python/github_7328_nested/test.desc
+++ b/regression/python/github_7328_nested/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:3$

--- a/regression/python/github_7328_oob_fail/main.py
+++ b/regression/python/github_7328_oob_fail/main.py
@@ -1,0 +1,7 @@
+def f(n: int):
+    c = [(1, 2), (3, 4)]
+    k = lambda t: t[0]
+    assert k(c[7]) == 1
+
+
+f(3)

--- a/regression/python/github_7328_oob_fail/test.desc
+++ b/regression/python/github_7328_oob_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:3$

--- a/regression/python/github_7328_shadow/main.py
+++ b/regression/python/github_7328_shadow/main.py
@@ -1,0 +1,7 @@
+def f(x: int):
+    c = [(1, 2), (3, 4)]
+    k = lambda x: x[0]
+    assert k(c[1]) == 3
+
+
+f(3)

--- a/regression/python/github_7328_shadow/test.desc
+++ b/regression/python/github_7328_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7328_str/main.py
+++ b/regression/python/github_7328_str/main.py
@@ -1,0 +1,8 @@
+def f(n: int):
+    c = [(1, 2)]
+    k = lambda t: t[0]
+    assert k(c[0]) == 1
+    assert k("ab") == "a"
+
+
+f(3)

--- a/regression/python/github_7328_str/test.desc
+++ b/regression/python/github_7328_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^ERROR: TypeError: 'float' object is not subscriptable at .*main\.py:3$

--- a/regression/python/github_7328_twolambda/main.py
+++ b/regression/python/github_7328_twolambda/main.py
@@ -1,0 +1,10 @@
+def f(n: int):
+    a = [(1, 2)]
+    b = [(3.5, 4.5)]
+    p = lambda t: t[0]
+    q = lambda u: u[0]
+    assert p(a[0]) == 1
+    assert q(b[0]) == 3.5
+
+
+f(3)

--- a/regression/python/github_7328_twolambda/test.desc
+++ b/regression/python/github_7328_twolambda/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7328_twolambda_fail/main.py
+++ b/regression/python/github_7328_twolambda_fail/main.py
@@ -1,0 +1,10 @@
+def f(n: int):
+    a = [(1, 2)]
+    b = [(3.5, 4.5)]
+    p = lambda t: t[0]
+    q = lambda u: u[0]
+    assert p(a[0]) == 1
+    assert q(b[0]) == 4.5
+
+
+f(3)

--- a/regression/python/github_7328_twolambda_fail/test.desc
+++ b/regression/python/github_7328_twolambda_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/src/python-frontend/lambda/python_lambda.cpp
+++ b/src/python-frontend/lambda/python_lambda.cpp
@@ -1,4 +1,5 @@
 #include <python-frontend/lambda/python_lambda.h>
+#include <python-frontend/python-list/python_list.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_expr_builder.h>
 #include <python-frontend/type/type_handler.h>
@@ -244,40 +245,183 @@ symbolt python_lambda::create_symbol(
   return symbol;
 }
 
+namespace
+{
+bool same_position(const nlohmann::json &a, const nlohmann::json &b)
+{
+  return a.value("lineno", -1) == b.value("lineno", -2) &&
+         a.value("col_offset", -1) == b.value("col_offset", -2);
+}
+
+// The statement list holding `lambda_node`'s binding, plus the name it binds.
+// A lambda is lowered eagerly at its assignment, so this is the only place a
+// later call through that name is still visible (#7328).
+const nlohmann::json *find_binding_scope(
+  const nlohmann::json &node,
+  const nlohmann::json &lambda_node,
+  std::string &bound_name)
+{
+  if (node.is_array())
+  {
+    for (const auto &stmt : node)
+    {
+      if (
+        stmt.value("_type", "") == "Assign" && stmt.contains("value") &&
+        stmt["value"].value("_type", "") == "Lambda" &&
+        same_position(stmt["value"], lambda_node) && stmt.contains("targets") &&
+        stmt["targets"].is_array() && stmt["targets"].size() == 1 &&
+        stmt["targets"][0].value("_type", "") == "Name")
+      {
+        bound_name = stmt["targets"][0].value("id", "");
+        return &node;
+      }
+    }
+  }
+
+  if (!node.is_structured())
+    return nullptr;
+
+  for (const auto &child : node.items())
+  {
+    const nlohmann::json *found =
+      find_binding_scope(child.value(), lambda_node, bound_name);
+    if (found != nullptr)
+      return found;
+  }
+  return nullptr;
+}
+
+// Argument `index` of the first call to `name` found under `node`.
+const nlohmann::json *find_call_argument(
+  const nlohmann::json &node,
+  const std::string &name,
+  size_t index)
+{
+  if (node.is_object() && node.value("_type", "") == "Call")
+  {
+    const nlohmann::json &func = node["func"];
+    if (
+      func.value("_type", "") == "Name" && func.value("id", "") == name &&
+      node.contains("args") && node["args"].is_array() &&
+      node["args"].size() > index)
+      return &node["args"][index];
+  }
+
+  if (!node.is_structured())
+    return nullptr;
+
+  for (const auto &child : node.items())
+  {
+    const nlohmann::json *found =
+      find_call_argument(child.value(), name, index);
+    if (found != nullptr)
+      return found;
+  }
+  return nullptr;
+}
+} // namespace
+
+std::vector<typet>
+python_lambda::call_site_argument_types(const nlohmann::json &element) const
+{
+  std::vector<typet> types;
+  if (
+    !element.contains("args") || !element["args"].contains("args") ||
+    !element["args"]["args"].is_array())
+    return types;
+
+  std::string bound_name;
+  const nlohmann::json *scope =
+    find_binding_scope(converter_.ast(), element, bound_name);
+  if (scope == nullptr || bound_name.empty())
+    return types;
+
+  const locationt location = converter_.get_location_from_decl(element);
+  const std::string prefix = "py:" + location.get_file().as_string() + "@F@" +
+                             converter_.get_current_func_name() + "@";
+
+  const size_t count = element["args"]["args"].size();
+  for (size_t i = 0; i < count; ++i)
+  {
+    typet resolved;
+    resolved.make_nil();
+    const nlohmann::json *arg = find_call_argument(*scope, bound_name, i);
+    if (arg != nullptr)
+    {
+      const std::string arg_kind = arg->value("_type", "");
+
+      // A subscript yields an element, whose registered type list_type_map
+      // recorded when the list literal was converted. A list-valued element is
+      // left alone: the list object pointer is not usable as a parameter type
+      // here, and typing it as one makes the solver reject the formula.
+      if (
+        arg_kind == "Subscript" && arg->contains("value") &&
+        (*arg)["value"].value("_type", "") == "Name")
+      {
+        typet elem = python_list::get_list_element_type(
+          prefix + (*arg)["value"].value("id", ""), 0);
+        if (
+          elem != typet() && elem != empty_typet() &&
+          elem != type_handler_.get_list_type())
+          resolved = elem;
+      }
+    }
+    types.push_back(resolved);
+  }
+  return types;
+}
+
+// A lambda parameter is typed by its annotation, else by string usage in the
+// body, else by the value the call site passes -- the `double` default rejects
+// any body that indexes its parameter (#7328).
+static typet lambda_parameter_type(
+  const nlohmann::json &arg,
+  const nlohmann::json &body_node,
+  const std::string &arg_name,
+  const typet &from_call_site)
+{
+  if (arg.contains("annotation") && !arg["annotation"].is_null())
+    return arg["annotation"].get<std::string>() == "str"
+             ? gen_pointer_type(signed_char_type())
+             : double_type();
+
+  if (is_param_used_as_string(body_node, arg_name))
+    return gen_pointer_type(signed_char_type());
+
+  if (from_call_site.is_not_nil() && from_call_site.id() != irep_idt())
+    return from_call_site;
+
+  return double_type();
+}
+
 void python_lambda::process_lambda_parameters(
   const nlohmann::json &args_node,
   code_typet &lambda_type,
   [[maybe_unused]] const std::string &lambda_id,
   const std::string &param_scope_id,
   const locationt &location,
-  const nlohmann::json &body_node)
+  const nlohmann::json &body_node,
+  const std::vector<typet> &call_site_types)
 {
   if (!args_node.contains("args") || !args_node["args"].is_array())
     return;
 
   std::string module_name = location.get_file().as_string();
 
+  size_t arg_index = 0;
   for (const auto &arg : args_node["args"])
   {
+    const size_t this_index = arg_index++;
     std::string arg_name = arg["arg"].get<std::string>();
 
     refuse_called_lambda_parameter(body_node, arg_name);
 
-    // Determine parameter type from annotation or infer from usage
-    typet param_type = double_type();
-
-    // Check for type annotation
-    if (arg.contains("annotation") && !arg["annotation"].is_null())
-    {
-      std::string annotation = arg["annotation"].get<std::string>();
-      if (annotation == "str")
-        param_type = gen_pointer_type(signed_char_type());
-    }
-    // Infer from usage in lambda body
-    else if (is_param_used_as_string(body_node, arg_name))
-    {
-      param_type = gen_pointer_type(signed_char_type());
-    }
+    const typet param_type = lambda_parameter_type(
+      arg,
+      body_node,
+      arg_name,
+      this_index < call_site_types.size() ? call_site_types[this_index]
+                                          : typet());
 
     // Each lambda parameter is modelled as two symbols:
     //
@@ -403,6 +547,10 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
   // Save the original function context
   std::string old_func = converter_.get_current_func_name();
 
+  // Resolve call-site argument types while the enclosing scope is still
+  // current: the names they mention are invisible from the lambda's own scope.
+  const std::vector<typet> call_site_types = call_site_argument_types(element);
+
   // Determine if we're in a lambda (function name starts with "lam")
   bool in_lambda = (old_func.find("lam") == 0);
 
@@ -446,7 +594,8 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
       lambda_id,
       param_scope_id,
       location,
-      element.contains("body") ? element["body"] : nlohmann::json());
+      element.contains("body") ? element["body"] : nlohmann::json(),
+      call_site_types);
 
   // Create lambda function symbol
   symbolt lambda_symbol = create_symbol(

--- a/src/python-frontend/lambda/python_lambda.cpp
+++ b/src/python-frontend/lambda/python_lambda.cpp
@@ -291,11 +291,14 @@ const nlohmann::json *find_binding_scope(
   return nullptr;
 }
 
-// Argument `index` of the first call to `name` found under `node`.
-const nlohmann::json *find_call_argument(
+// Argument `index` of every call to `name` under `node`. All of them, not just
+// the first: a lambda called with two different types has one frozen signature,
+// so committing to the first call's type would mistype the rest (#7328).
+void collect_call_arguments(
   const nlohmann::json &node,
   const std::string &name,
-  size_t index)
+  size_t index,
+  std::vector<const nlohmann::json *> &out)
 {
   if (node.is_object() && node.value("_type", "") == "Call")
   {
@@ -304,20 +307,14 @@ const nlohmann::json *find_call_argument(
       func.value("_type", "") == "Name" && func.value("id", "") == name &&
       node.contains("args") && node["args"].is_array() &&
       node["args"].size() > index)
-      return &node["args"][index];
+      out.push_back(&node["args"][index]);
   }
 
   if (!node.is_structured())
-    return nullptr;
+    return;
 
   for (const auto &child : node.items())
-  {
-    const nlohmann::json *found =
-      find_call_argument(child.value(), name, index);
-    if (found != nullptr)
-      return found;
-  }
-  return nullptr;
+    collect_call_arguments(child.value(), name, index, out);
 }
 } // namespace
 
@@ -345,17 +342,21 @@ python_lambda::call_site_argument_types(const nlohmann::json &element) const
   {
     typet resolved;
     resolved.make_nil();
-    const nlohmann::json *arg = find_call_argument(*scope, bound_name, i);
-    if (arg != nullptr)
+
+    std::vector<const nlohmann::json *> args;
+    collect_call_arguments(*scope, bound_name, i, args);
+
+    for (const nlohmann::json *arg : args)
     {
-      const std::string arg_kind = arg->value("_type", "");
+      typet from_arg;
+      from_arg.make_nil();
 
       // A subscript yields an element, whose registered type list_type_map
       // recorded when the list literal was converted. A list-valued element is
       // left alone: the list object pointer is not usable as a parameter type
       // here, and typing it as one makes the solver reject the formula.
       if (
-        arg_kind == "Subscript" && arg->contains("value") &&
+        arg->value("_type", "") == "Subscript" && arg->contains("value") &&
         (*arg)["value"].value("_type", "") == "Name")
       {
         typet elem = python_list::get_list_element_type(
@@ -363,8 +364,17 @@ python_lambda::call_site_argument_types(const nlohmann::json &element) const
         if (
           elem != typet() && elem != empty_typet() &&
           elem != type_handler_.get_list_type())
-          resolved = elem;
+          from_arg = elem;
       }
+
+      // Every call has to agree: one disagreeing call means the single frozen
+      // signature cannot serve them all, so leave the parameter as it was.
+      if (from_arg.is_nil() || (resolved.is_not_nil() && resolved != from_arg))
+      {
+        resolved.make_nil();
+        break;
+      }
+      resolved = from_arg;
     }
     types.push_back(resolved);
   }

--- a/src/python-frontend/lambda/python_lambda.cpp
+++ b/src/python-frontend/lambda/python_lambda.cpp
@@ -1,5 +1,6 @@
 #include <python-frontend/lambda/python_lambda.h>
 #include <optional>
+#include <set>
 #include <python-frontend/python-list/python_list.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_expr_builder.h>
@@ -254,9 +255,9 @@ bool same_position(const nlohmann::json &a, const nlohmann::json &b)
          a.value("col_offset", -1) == b.value("col_offset", -2);
 }
 
-// The statement list holding `lambda_node`'s binding, plus the name it binds.
-// A lambda is lowered eagerly at its assignment, so this is the only place a
-// later call through that name is still visible (#7328).
+// A lambda is lowered eagerly at its assignment, so the statement list holding
+// that assignment is the only place a later call through the bound name is
+// still visible (#7328).
 const nlohmann::json *find_binding_scope(
   const nlohmann::json &node,
   const nlohmann::json &lambda_node,
@@ -303,12 +304,24 @@ struct call_argument_scan
   bool foreign_scope_call = false;
 };
 
+// Python opens a new binding scope at each of these, so `name`'s argument
+// inside one may denote a different object than the enclosing prefix builds.
+bool opens_binding_scope(const std::string &kind)
+{
+  static const std::set<std::string> kinds = {
+    "FunctionDef",
+    "AsyncFunctionDef",
+    "Lambda",
+    "ListComp",
+    "SetComp",
+    "DictComp",
+    "GeneratorExp"};
+  return kinds.count(kind) != 0;
+}
+
 // Argument `index` of every call to `name` under `node`. All of them, not just
 // the first: a lambda called with two different types has one frozen signature,
 // so committing to the first call's type would mistype the rest (#7328).
-// A call inside a nested `def` is recorded but not collected: `name`'s argument
-// there may bind to a different object than the enclosing prefix resolves to,
-// so the scan is abandoned rather than answered wrongly.
 void collect_call_arguments(
   const nlohmann::json &node,
   const std::string &name,
@@ -320,9 +333,10 @@ void collect_call_arguments(
 
   if (kind == "Call")
   {
-    const nlohmann::json &func = node.value("func", nlohmann::json::object());
+    const auto func = node.find("func");
     if (
-      func.value("_type", "") == "Name" && func.value("id", "") == name &&
+      func != node.end() && func->is_object() &&
+      func->value("_type", "") == "Name" && func->value("id", "") == name &&
       node.contains("args") && node["args"].is_array() &&
       node["args"].size() > index)
     {
@@ -336,50 +350,94 @@ void collect_call_arguments(
   if (!node.is_structured())
     return;
 
-  const bool child_nested =
-    nested || kind == "FunctionDef" || kind == "AsyncFunctionDef";
+  const bool child_nested = nested || opens_binding_scope(kind);
 
   for (const auto &child : node.items())
     collect_call_arguments(child.value(), name, index, child_nested, out);
 }
 
-// The element type a `name[k]` argument selects, or nil when it cannot be
+// Only a list literal materialises each element into a symbol whose type is
+// what `name[k]` yields. Every other builder -- concatenation above all --
+// records the source expression's type while the list object stores something
+// else, so typing a parameter from that entry aborts the frontend on the
+// argument check ("got struct, expected struct") (#7328).
+bool binds_list_literal(const nlohmann::json &scope, const std::string &name)
+{
+  bool found = false;
+  for (const auto &stmt : scope)
+  {
+    if (!stmt.is_object())
+      continue;
+
+    // The frontend annotates a plain `x = [...]` into an AnnAssign, so both
+    // spellings have to be recognised here.
+    const std::string kind = stmt.value("_type", "");
+    const nlohmann::json *target = nullptr;
+    if (
+      kind == "Assign" && stmt.contains("targets") &&
+      stmt["targets"].is_array() && stmt["targets"].size() == 1)
+      target = &stmt["targets"][0];
+    else if (kind == "AnnAssign" && stmt.contains("target"))
+      target = &stmt["target"];
+
+    if (
+      target == nullptr || !target->is_object() ||
+      target->value("id", "") != name)
+      continue;
+
+    if (!stmt.contains("value") || stmt["value"].value("_type", "") != "List")
+      return false;
+    found = true;
+  }
+  return found;
+}
+
+// The element type a `name[k]` argument selects, or nothing when it cannot be
 // pinned down. A non-literal index names no single element type, and a
 // list-valued element is left alone: the list object pointer is not usable as
 // a parameter type here, and typing it as one makes the solver reject the
 // formula (#7328).
-typet subscript_element_type(
+std::optional<typet> subscript_element_type(
   const nlohmann::json &arg,
+  const nlohmann::json &scope,
   const std::string &prefix,
   const typet &list_type)
 {
-  typet result;
-  result.make_nil();
-
   if (
     arg.value("_type", "") != "Subscript" || !arg.contains("value") ||
     !arg["value"].is_object() || arg["value"].value("_type", "") != "Name" ||
     !arg.contains("slice"))
-    return result;
+    return std::nullopt;
 
   const nlohmann::json &slice = arg["slice"];
   if (
     !slice.is_object() || slice.value("_type", "") != "Constant" ||
     !slice.contains("value") || !slice["value"].is_number_unsigned())
-    return result;
+    return std::nullopt;
 
-  const typet elem = python_list::get_list_element_type(
-    prefix + arg["value"].value("id", ""), slice["value"].get<size_t>());
-  if (elem != typet() && elem != empty_typet() && elem != list_type)
-    result = elem;
-  return result;
+  const std::string base_name = arg["value"].value("id", "");
+  if (!binds_list_literal(scope, base_name))
+    return std::nullopt;
+
+  const std::string list_id = prefix + base_name;
+  const size_t index = slice["value"].get<size_t>();
+
+  // get_list_element_type() clamps an out-of-range index to element 0, so the
+  // recorded element id is what says the index names a real element.
+  if (python_list::get_list_element_id(list_id, index).empty())
+    return std::nullopt;
+
+  const typet elem = python_list::get_list_element_type(list_id, index);
+  if (elem == typet() || elem == empty_typet() || elem == list_type)
+    return std::nullopt;
+  return elem;
 }
 } // namespace
 
-std::vector<typet>
+std::vector<std::optional<typet>>
 python_lambda::call_site_argument_types(const nlohmann::json &element) const
 {
-  std::vector<typet> types;
+  std::vector<std::optional<typet>> types;
   if (
     !element.contains("args") || !element["args"].contains("args") ||
     !element["args"]["args"].is_array())
@@ -398,24 +456,26 @@ python_lambda::call_site_argument_types(const nlohmann::json &element) const
   const size_t count = element["args"]["args"].size();
   for (size_t i = 0; i < count; ++i)
   {
-    typet resolved;
-    resolved.make_nil();
+    std::optional<typet> resolved;
 
     call_argument_scan scan;
     collect_call_arguments(*scope, bound_name, i, false, scan);
+    if (scan.foreign_scope_call)
+    {
+      types.push_back(std::nullopt);
+      continue;
+    }
 
     for (const nlohmann::json *arg : scan.args)
     {
-      const typet from_arg =
-        subscript_element_type(*arg, prefix, type_handler_.get_list_type());
+      const std::optional<typet> from_arg = subscript_element_type(
+        *arg, *scope, prefix, type_handler_.get_list_type());
 
       // Every call has to agree: one disagreeing call means the single frozen
       // signature cannot serve them all, so leave the parameter as it was.
-      if (
-        scan.foreign_scope_call || from_arg.is_nil() ||
-        (resolved.is_not_nil() && resolved != from_arg))
+      if (!from_arg || (resolved && *resolved != *from_arg))
       {
-        resolved.make_nil();
+        resolved.reset();
         break;
       }
       resolved = from_arg;
@@ -425,14 +485,14 @@ python_lambda::call_site_argument_types(const nlohmann::json &element) const
   return types;
 }
 
-// A lambda parameter is typed by its annotation, else by string usage in the
-// body, else by the value the call site passes -- the `double` default rejects
-// any body that indexes its parameter (#7328).
+// The `double` default rejects any body that indexes its parameter (#7328), so
+// the call site is consulted when neither an annotation nor string usage says
+// otherwise.
 static typet lambda_parameter_type(
   const nlohmann::json &arg,
   const nlohmann::json &body_node,
   const std::string &arg_name,
-  const typet &from_call_site)
+  const std::optional<typet> &from_call_site)
 {
   if (arg.contains("annotation") && !arg["annotation"].is_null())
     return arg["annotation"].get<std::string>() == "str"
@@ -442,8 +502,8 @@ static typet lambda_parameter_type(
   if (is_param_used_as_string(body_node, arg_name))
     return gen_pointer_type(signed_char_type());
 
-  if (from_call_site.is_not_nil() && from_call_site.id() != irep_idt())
-    return from_call_site;
+  if (from_call_site)
+    return *from_call_site;
 
   return double_type();
 }
@@ -455,7 +515,7 @@ void python_lambda::process_lambda_parameters(
   const std::string &param_scope_id,
   const locationt &location,
   const nlohmann::json &body_node,
-  const std::vector<typet> &call_site_types)
+  const std::vector<std::optional<typet>> &call_site_types)
 {
   if (!args_node.contains("args") || !args_node["args"].is_array())
     return;
@@ -475,7 +535,7 @@ void python_lambda::process_lambda_parameters(
       body_node,
       arg_name,
       this_index < call_site_types.size() ? call_site_types[this_index]
-                                          : typet());
+                                          : std::nullopt);
 
     // Each lambda parameter is modelled as two symbols:
     //
@@ -603,7 +663,8 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
 
   // Resolve call-site argument types while the enclosing scope is still
   // current: the names they mention are invisible from the lambda's own scope.
-  const std::vector<typet> call_site_types = call_site_argument_types(element);
+  const std::vector<std::optional<typet>> call_site_types =
+    call_site_argument_types(element);
 
   // Determine if we're in a lambda (function name starts with "lam")
   bool in_lambda = (old_func.find("lam") == 0);

--- a/src/python-frontend/lambda/python_lambda.cpp
+++ b/src/python-frontend/lambda/python_lambda.cpp
@@ -1,4 +1,5 @@
 #include <python-frontend/lambda/python_lambda.h>
+#include <optional>
 #include <python-frontend/python-list/python_list.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_expr_builder.h>
@@ -265,6 +266,11 @@ const nlohmann::json *find_binding_scope(
   {
     for (const auto &stmt : node)
     {
+      // Not every ast2json array holds objects: Global/Nonlocal carry raw
+      // strings in `names`, and value() throws on those (#7328).
+      if (!stmt.is_object())
+        continue;
+
       if (
         stmt.value("_type", "") == "Assign" && stmt.contains("value") &&
         stmt["value"].value("_type", "") == "Lambda" &&
@@ -291,30 +297,82 @@ const nlohmann::json *find_binding_scope(
   return nullptr;
 }
 
+struct call_argument_scan
+{
+  std::vector<const nlohmann::json *> args;
+  bool foreign_scope_call = false;
+};
+
 // Argument `index` of every call to `name` under `node`. All of them, not just
 // the first: a lambda called with two different types has one frozen signature,
 // so committing to the first call's type would mistype the rest (#7328).
+// A call inside a nested `def` is recorded but not collected: `name`'s argument
+// there may bind to a different object than the enclosing prefix resolves to,
+// so the scan is abandoned rather than answered wrongly.
 void collect_call_arguments(
   const nlohmann::json &node,
   const std::string &name,
   size_t index,
-  std::vector<const nlohmann::json *> &out)
+  bool nested,
+  call_argument_scan &out)
 {
-  if (node.is_object() && node.value("_type", "") == "Call")
+  const std::string kind = node.is_object() ? node.value("_type", "") : "";
+
+  if (kind == "Call")
   {
-    const nlohmann::json &func = node["func"];
+    const nlohmann::json &func = node.value("func", nlohmann::json::object());
     if (
       func.value("_type", "") == "Name" && func.value("id", "") == name &&
       node.contains("args") && node["args"].is_array() &&
       node["args"].size() > index)
-      out.push_back(&node["args"][index]);
+    {
+      if (nested)
+        out.foreign_scope_call = true;
+      else
+        out.args.push_back(&node["args"][index]);
+    }
   }
 
   if (!node.is_structured())
     return;
 
+  const bool child_nested =
+    nested || kind == "FunctionDef" || kind == "AsyncFunctionDef";
+
   for (const auto &child : node.items())
-    collect_call_arguments(child.value(), name, index, out);
+    collect_call_arguments(child.value(), name, index, child_nested, out);
+}
+
+// The element type a `name[k]` argument selects, or nil when it cannot be
+// pinned down. A non-literal index names no single element type, and a
+// list-valued element is left alone: the list object pointer is not usable as
+// a parameter type here, and typing it as one makes the solver reject the
+// formula (#7328).
+typet subscript_element_type(
+  const nlohmann::json &arg,
+  const std::string &prefix,
+  const typet &list_type)
+{
+  typet result;
+  result.make_nil();
+
+  if (
+    arg.value("_type", "") != "Subscript" || !arg.contains("value") ||
+    !arg["value"].is_object() || arg["value"].value("_type", "") != "Name" ||
+    !arg.contains("slice"))
+    return result;
+
+  const nlohmann::json &slice = arg["slice"];
+  if (
+    !slice.is_object() || slice.value("_type", "") != "Constant" ||
+    !slice.contains("value") || !slice["value"].is_number_unsigned())
+    return result;
+
+  const typet elem = python_list::get_list_element_type(
+    prefix + arg["value"].value("id", ""), slice["value"].get<size_t>());
+  if (elem != typet() && elem != empty_typet() && elem != list_type)
+    result = elem;
+  return result;
 }
 } // namespace
 
@@ -343,33 +401,19 @@ python_lambda::call_site_argument_types(const nlohmann::json &element) const
     typet resolved;
     resolved.make_nil();
 
-    std::vector<const nlohmann::json *> args;
-    collect_call_arguments(*scope, bound_name, i, args);
+    call_argument_scan scan;
+    collect_call_arguments(*scope, bound_name, i, false, scan);
 
-    for (const nlohmann::json *arg : args)
+    for (const nlohmann::json *arg : scan.args)
     {
-      typet from_arg;
-      from_arg.make_nil();
-
-      // A subscript yields an element, whose registered type list_type_map
-      // recorded when the list literal was converted. A list-valued element is
-      // left alone: the list object pointer is not usable as a parameter type
-      // here, and typing it as one makes the solver reject the formula.
-      if (
-        arg->value("_type", "") == "Subscript" && arg->contains("value") &&
-        (*arg)["value"].value("_type", "") == "Name")
-      {
-        typet elem = python_list::get_list_element_type(
-          prefix + (*arg)["value"].value("id", ""), 0);
-        if (
-          elem != typet() && elem != empty_typet() &&
-          elem != type_handler_.get_list_type())
-          from_arg = elem;
-      }
+      const typet from_arg =
+        subscript_element_type(*arg, prefix, type_handler_.get_list_type());
 
       // Every call has to agree: one disagreeing call means the single frozen
       // signature cannot serve them all, so leave the parameter as it was.
-      if (from_arg.is_nil() || (resolved.is_not_nil() && resolved != from_arg))
+      if (
+        scan.foreign_scope_call || from_arg.is_nil() ||
+        (resolved.is_not_nil() && resolved != from_arg))
       {
         resolved.make_nil();
         break;

--- a/src/python-frontend/lambda/python_lambda.h
+++ b/src/python-frontend/lambda/python_lambda.h
@@ -5,6 +5,7 @@
 #include <util/irep/expr.h>
 #include <util/irep/std_code.h>
 #include <nlohmann/json.hpp>
+#include <optional>
 
 class python_converter;
 class type_handler;
@@ -45,11 +46,11 @@ private:
     const std::string &param_scope_id,
     const locationt &location,
     const nlohmann::json &body_node,
-    const std::vector<typet> &call_site_types);
+    const std::vector<std::optional<typet>> &call_site_types);
 
   // Per-parameter type taken from a call through the name this lambda is bound
-  // to; an entry is nil when no such call supplies that argument (#7328).
-  std::vector<typet>
+  // to; an entry is empty when no such call pins that argument down (#7328).
+  std::vector<std::optional<typet>>
   call_site_argument_types(const nlohmann::json &element) const;
 
   exprt process_lambda_body(

--- a/src/python-frontend/lambda/python_lambda.h
+++ b/src/python-frontend/lambda/python_lambda.h
@@ -44,7 +44,13 @@ private:
     const std::string &lambda_id,
     const std::string &param_scope_id,
     const locationt &location,
-    const nlohmann::json &body_node);
+    const nlohmann::json &body_node,
+    const std::vector<typet> &call_site_types);
+
+  // Per-parameter type taken from a call through the name this lambda is bound
+  // to; an entry is nil when no such call supplies that argument (#7328).
+  std::vector<typet>
+  call_site_argument_types(const nlohmann::json &element) const;
 
   exprt process_lambda_body(
     const nlohmann::json &body_node,


### PR DESCRIPTION
A lambda parameter defaulted to `double`, so a body that subscripts it was
rejected as `'float' object is not subscriptable`. Take the type from calls
through the bound name -- but only when every call agrees and the subscripted
name is bound to a list literal, since `list_type_map` describes what `name[k]`
yields for no other builder. Anything less certain keeps master's diagnostic.

Fixes #7328

Two notes for review: the nine tests pinning a conservative decline pass on
master too by construction (master declines everything) -- they gate the
guards, and were mutation-checked by relaxing each guard rather than by
reverting the fix. The comprehension entries in `opens_binding_scope` are
unpinned: a lambda called from inside a comprehension crashes on master
already, so no test can reach them yet.