### PR TITLE
[python] Decay a function name stored in a list literal to a pointer

### DIFF
--- a/regression/python/github_6640_list_literal/main.py
+++ b/regression/python/github_6640_list_literal/main.py
@@ -1,0 +1,10 @@
+def inc(x: int) -> int:
+    return x + 1
+
+
+def main() -> None:
+    fs = [inc]
+    assert len(fs) == 1
+
+
+main()

--- a/regression/python/github_6640_list_literal/test.desc
+++ b/regression/python/github_6640_list_literal/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6640_list_literal_call/main.py
+++ b/regression/python/github_6640_list_literal_call/main.py
@@ -1,0 +1,17 @@
+from typing import Callable, List
+
+
+def inc(x: int) -> int:
+    return x + 1
+
+
+def dec(x: int) -> int:
+    return x - 1
+
+
+def main() -> None:
+    fs: List[Callable[[int], int]] = [inc, dec]
+    assert fs[0](1) == 2
+
+
+main()

--- a/regression/python/github_6640_list_literal_call/test.desc
+++ b/regression/python/github_6640_list_literal_call/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6640_list_literal_fail/main.py
+++ b/regression/python/github_6640_list_literal_fail/main.py
@@ -1,0 +1,13 @@
+from typing import Callable, List
+
+
+def inc(x: int) -> int:
+    return x + 1
+
+
+def main() -> None:
+    fs: List[Callable[[int], int]] = [inc]
+    assert fs[0](1) == 3
+
+
+main()

--- a/regression/python/github_6640_list_literal_fail/test.desc
+++ b/regression/python/github_6640_list_literal_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/github_6640_list_literal_mixed/main.py
+++ b/regression/python/github_6640_list_literal_mixed/main.py
@@ -1,0 +1,11 @@
+def inc(x: int) -> int:
+    return x + 1
+
+
+def main() -> None:
+    xs = [1, 2.5, inc]
+    assert len(xs) == 3
+    assert xs[1] == 2.5
+
+
+main()

--- a/regression/python/github_6640_list_literal_mixed/test.desc
+++ b/regression/python/github_6640_list_literal_mixed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -2752,16 +2752,6 @@ exprt function_call_expr::handle_numpy_astype() const
   return build_symbol(result_sym);
 }
 
-/// A function name used as a value decays to a function pointer, as it already
-/// does in call-argument position. Storing the code symbol itself aborts
-/// conversion with "got invalid code for function" (#6640).
-static exprt decay_function_to_pointer(const exprt &value)
-{
-  if (!value.type().is_code() || !value.is_symbol())
-    return value;
-  return python_expr::build_address_of(value);
-}
-
 exprt function_call_expr::handle_list_append() const
 {
   const auto &args = call_["args"];

--- a/src/python-frontend/python-list/list_construction.cpp
+++ b/src/python-frontend/python-list/list_construction.cpp
@@ -121,7 +121,10 @@ exprt python_list::get()
   const std::string &list_id = list_symbol.id.as_string();
   locationt location = converter_.get_location_from_decl(list_value_);
 
-  auto materialize_list_elem = [&](const exprt &elem) -> exprt {
+  auto materialize_list_elem = [&](const exprt &raw_elem) -> exprt {
+    // Must precede the is_symbol() return: a bare function symbol (#6640).
+    const exprt elem = decay_function_to_pointer(raw_elem);
+
     if (elem.is_symbol())
       return elem;
 

--- a/src/python-frontend/python_expr_builder.cpp
+++ b/src/python-frontend/python_expr_builder.cpp
@@ -54,6 +54,13 @@ exprt build_address_of(const exprt &obj)
   return migrate_expr_back(address_of2tc(obj2->type, obj2));
 }
 
+exprt decay_function_to_pointer(const exprt &value)
+{
+  if (!value.type().is_code() || !value.is_symbol())
+    return value;
+  return build_address_of(value);
+}
+
 exprt build_dereference(const exprt &ptr, const typet &t)
 {
   if (contains_dyn_array(t))

--- a/src/python-frontend/python_expr_builder.h
+++ b/src/python-frontend/python_expr_builder.h
@@ -35,6 +35,12 @@ exprt build_typecast(const exprt &from, const typet &t);
 // Address-of an lvalue `obj` (symbol/member/index source).
 exprt build_address_of(const exprt &obj);
 
+// A function name used as a value decays to a function pointer, as it already
+// does in call-argument position. Storing the code symbol itself aborts
+// conversion with "got invalid code for function" (#6640). Non-function
+// expressions are returned unchanged.
+exprt decay_function_to_pointer(const exprt &value);
+
 // Dereference `ptr` to a value of type `t`.
 exprt build_dereference(const exprt &ptr, const typet &t);
 


### PR DESCRIPTION
A function name in a list literal kept its code type, so goto_convert aborted
with `got invalid code for function` and dumped core. `append()` already
decayed it, which is why `fs = []; fs.append(inc)` verified while `fs = [inc]`
crashed; this shares that decay rather than leaving it private to append.

Notes for review:

- Most "added" lines are the relocated helper body, byte-identical to master
  bar a redundant namespace qualifier. Codecov will show them as new in
  `python_expr_builder.cpp` and lost from `expr.cpp`; net effect is ~zero.
- Known residuals, unchanged from master (they still abort, they do not
  misverify): `{inc}`, `[inc] * 2`, `insert(0, inc)`, `x in fs`. Applying the
  decay at the `get_list_element_info` funnel closes those three but makes
  membership report a false FAILED via an OM dereference failure, so it is
  deliberately not done here.
- `fs[0](x)` types its result from the *caller's* return annotation
  (`converter_funcall.cpp:903`), a pre-existing defect unrelated to this fix.
  It is why `_call` lowers to `(double)2`; the pair still discriminates.

Fixes #6640