### PR TITLE
[python] Run the tests unittest.main() discovers

### DIFF
--- a/regression/python/github_6745_unittest_main/main.py
+++ b/regression/python/github_6745_unittest_main/main.py
@@ -1,0 +1,16 @@
+import unittest
+
+
+class T(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.base = 2
+
+    def test_add(self) -> None:
+        self.assertEqual(self.base + 1, 3)
+
+    def test_compare(self) -> None:
+        self.assertTrue(self.base > 1)
+
+
+unittest.main()

--- a/regression/python/github_6745_unittest_main/test.desc
+++ b/regression/python/github_6745_unittest_main/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6745_unittest_main/test.desc
+++ b/regression/python/github_6745_unittest_main/test.desc
@@ -2,3 +2,6 @@ CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
+^\s*PASSED\s+\[assertEqual\.assertion\.1\]
+^\s*PASSED\s+\[assertTrue\.assertion\.1\]
+^\*\* 0 of 11 properties failed, 11 passed$

--- a/regression/python/github_6745_unittest_main_attr_fail/main.py
+++ b/regression/python/github_6745_unittest_main_attr_fail/main.py
@@ -1,0 +1,11 @@
+import unittest
+
+
+class T(unittest.TestCase):
+    expected = 3
+
+    def test_value(self) -> None:
+        self.assertEqual(1 + 1, self.expected)
+
+
+unittest.main()

--- a/regression/python/github_6745_unittest_main_attr_fail/test.desc
+++ b/regression/python/github_6745_unittest_main_attr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_6745_unittest_main_fail/main.py
+++ b/regression/python/github_6745_unittest_main_fail/main.py
@@ -1,0 +1,10 @@
+import unittest
+
+
+class T(unittest.TestCase):
+
+    def test_add(self) -> None:
+        self.assertEqual(1 + 1, 3)
+
+
+unittest.main()

--- a/regression/python/github_6745_unittest_main_fail/test.desc
+++ b/regression/python/github_6745_unittest_main_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_6745_unittest_main_guard_fail/main.py
+++ b/regression/python/github_6745_unittest_main_guard_fail/main.py
@@ -1,0 +1,11 @@
+import unittest as ut
+
+
+class T(ut.TestCase):
+
+    def test_broken(self) -> None:
+        self.assertLess(3, 2)
+
+
+if __name__ == "__main__":
+    ut.main()

--- a/regression/python/github_6745_unittest_main_guard_fail/test.desc
+++ b/regression/python/github_6745_unittest_main_guard_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_6745_unittest_main_inherited_fail/main.py
+++ b/regression/python/github_6745_unittest_main_inherited_fail/main.py
@@ -1,0 +1,19 @@
+import unittest
+
+
+class Base(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.value = 1
+
+    def test_value(self) -> None:
+        self.assertEqual(self.value, 1)
+
+
+class Derived(Base):
+
+    def setUp(self) -> None:
+        self.value = 2
+
+
+unittest.main()

--- a/regression/python/github_6745_unittest_main_inherited_fail/test.desc
+++ b/regression/python/github_6745_unittest_main_inherited_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_6745_unittest_main_inherited_fail/test.desc
+++ b/regression/python/github_6745_unittest_main_inherited_fail/test.desc
@@ -2,3 +2,5 @@ CORE
 main.py
 --incremental-bmc
 ^VERIFICATION FAILED$
+^\s*FAILED\s+\[assertEqual\.assertion\.1\]
+^\s*PASSED\s+\[setUp\.assertion\.2\]

--- a/regression/python/github_6745_unittest_main_skip/main.py
+++ b/regression/python/github_6745_unittest_main_skip/main.py
@@ -1,0 +1,17 @@
+import unittest
+
+
+class T(unittest.TestCase):
+
+    @unittest.skip("would fail if the runner did not skip it")
+    def test_skipped(self) -> None:
+        self.fail()
+
+    def helper(self) -> None:
+        self.fail()
+
+    def test_run(self) -> None:
+        self.assertEqual(1 + 1, 2)
+
+
+unittest.main()

--- a/regression/python/github_6745_unittest_main_skip/test.desc
+++ b/regression/python/github_6745_unittest_main_skip/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_6745_unittest_main_skip/test.desc
+++ b/regression/python/github_6745_unittest_main_skip/test.desc
@@ -2,3 +2,5 @@ CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
+^\s*PASSED\s+\[assertEqual\.assertion\.1\]
+^\*\* 0 of 1 properties failed, 1 passed$

--- a/src/python-frontend/preprocessor/__init__.py
+++ b/src/python-frontend/preprocessor/__init__.py
@@ -19,6 +19,7 @@ from preprocessor.module_rewrite_mixin import ModuleRewriteMixin
 from preprocessor.preprocessor_state_mixin import PreprocessorStateMixin
 from preprocessor.sequence_iterator_mixin import SequenceIteratorMixin
 from preprocessor.type_inference_mixin import TypeInferenceMixin
+from preprocessor.unittest_mixin import UnittestMixin
 from preprocessor.vararg_mixin import VarargMixin
 
 __all__ = ["Preprocessor"]
@@ -39,6 +40,7 @@ class Preprocessor(
         ModuleRewriteMixin,
         ModuleLifecycleMixin,
         SequenceIteratorMixin,
+        UnittestMixin,
         VarargMixin,
         PreprocessorStateMixin,
         AstUtilsMixin,

--- a/src/python-frontend/preprocessor/module_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/module_rewrite_mixin.py
@@ -417,6 +417,8 @@ class ModuleRewriteMixin:
 
     def prepare_module(self, node, alias_seed=frozenset(), wrapper_seed=None):
         """Run pre-visit analyses and range-alias/wrapper canonicalization."""
+        self.expand_unittest_main(node)
+
         for n in ast.walk(node):
             if isinstance(n, ast.Call) and isinstance(n.func, ast.Name):
                 self.called_names.add(n.func.id)

--- a/src/python-frontend/preprocessor/unittest_mixin.py
+++ b/src/python-frontend/preprocessor/unittest_mixin.py
@@ -1,0 +1,134 @@
+"""Expansion of unittest.main() into the calls its runner would make."""
+
+import ast
+
+_CASE_VAR_PREFIX = "__ESBMC_unittest_case_"
+
+
+class UnittestMixin:
+    """Run the test methods `unittest.main()` would discover.
+
+    The unittest operational model has no runner, so main() is a no-op: a file
+    whose only entry point is `unittest.main()` reaches verification with zero
+    VCCs and reports a vacuous VERIFICATION SUCCESSFUL (#6745). Each discovered
+    test method gets its own instance, as CPython does, so state a test writes
+    in setUp cannot leak into the next one.
+    """
+
+    def expand_unittest_main(self, module_node):
+        """Replace every unittest.main() with its discovered test-method calls."""
+        modules, mains, case_names = self._unittest_bindings(module_node)
+        if not modules and not mains:
+            return
+        cases = self._collect_test_cases(module_node, modules, case_names)
+        if cases:
+            self._expand_main_calls(module_node.body, (modules, mains), cases, 0)
+
+    @staticmethod
+    def _unittest_bindings(module_node):
+        """Names bound to the unittest module, to its main() and its TestCase."""
+        modules, mains, cases = set(), set(), set()
+        for stmt in ast.walk(module_node):
+            if isinstance(stmt, ast.Import):
+                for alias in stmt.names:
+                    if alias.name == "unittest":
+                        modules.add(alias.asname or alias.name)
+            elif isinstance(stmt, ast.ImportFrom) and stmt.module == "unittest":
+                for alias in stmt.names:
+                    bound = alias.asname or alias.name
+                    if alias.name == "main":
+                        mains.add(bound)
+                    elif alias.name == "TestCase":
+                        cases.add(bound)
+        return modules, mains, cases
+
+    @staticmethod
+    def _is_test_case_base(base, modules, case_names):
+        if isinstance(base, ast.Name):
+            return base.id in case_names
+        return (isinstance(base, ast.Attribute) and base.attr == "TestCase"
+                and isinstance(base.value, ast.Name) and base.value.id in modules)
+
+    @staticmethod
+    def _is_test_method(node):
+        # A decorated method is skipped: @unittest.skip and @expectedFailure
+        # both mean the runner does not count a failure from this method.
+        if not isinstance(node, ast.FunctionDef) or node.decorator_list:
+            return False
+        args = node.args
+        return (node.name.startswith("test") and len(args.args) == 1 and not args.posonlyargs
+                and not args.vararg and not args.kwonlyargs and not args.kwarg)
+
+    @classmethod
+    def _collect_test_cases(cls, module_node, modules, case_names):
+        """(class, sorted test methods) per TestCase subclass, in CPython's order.
+
+        A subclass runs the tests it inherits as well as its own, so a base
+        class's method is collected again for each subclass -- its setUp may
+        differ. A name redefined in the subclass body is not inherited twice.
+        """
+        known = dict.fromkeys(case_names, frozenset())
+        cases = []
+        for stmt in module_node.body:
+            if not isinstance(stmt, ast.ClassDef):
+                continue
+            bases = [b for b in stmt.bases if cls._is_test_case_base(b, modules, known)]
+            if not bases:
+                continue
+            inherited = set().union(*(known[b.id] for b in bases if isinstance(b, ast.Name)))
+            defined = {m.name for m in stmt.body if isinstance(m, ast.FunctionDef)}
+            methods = {m.name for m in stmt.body if cls._is_test_method(m)}
+            methods |= inherited - defined
+            known[stmt.name] = frozenset(methods)
+            if methods:
+                cases.append((stmt.name, sorted(methods)))
+        return cases
+
+    @staticmethod
+    def _is_main_call(stmt, names):
+        modules, mains = names
+        if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+            return False
+        func = stmt.value.func
+        if isinstance(func, ast.Name):
+            return func.id in mains
+        return (isinstance(func, ast.Attribute) and func.attr == "main"
+                and isinstance(func.value, ast.Name) and func.value.id in modules)
+
+    def _expand_main_calls(self, body, names, cases, index):
+        """Replace each main() in *body* in place; returns the next case index."""
+        expanded = []
+        for stmt in body:
+            if isinstance(stmt, ast.If):
+                index = self._expand_main_calls(stmt.body, names, cases, index)
+                index = self._expand_main_calls(stmt.orelse, names, cases, index)
+            elif self._is_main_call(stmt, names):
+                run, index = self._build_case_runs(cases, stmt, index)
+                expanded.extend(run)
+                continue
+            expanded.append(stmt)
+        body[:] = expanded
+        return index
+
+    def _build_case_runs(self, cases, source, index):
+        run = []
+        for class_name, methods in cases:
+            for method in methods:
+                var = f"{_CASE_VAR_PREFIX}{index}"
+                index += 1
+                run.append(
+                    ast.Assign(targets=[ast.Name(id=var, ctx=ast.Store())],
+                               value=self._call(ast.Name(id=class_name, ctx=ast.Load()))))
+                run.extend(
+                    ast.Expr(value=self._call(
+                        ast.Attribute(
+                            value=ast.Name(id=var, ctx=ast.Load()), attr=name, ctx=ast.Load())))
+                    for name in ("setUp", method, "tearDown"))
+        for stmt in run:
+            self.ensure_all_locations(stmt, source)
+            ast.fix_missing_locations(stmt)
+        return run, index
+
+    @staticmethod
+    def _call(func):
+        return ast.Call(func=func, args=[], keywords=[])


### PR DESCRIPTION
The unittest operational model has no runner, so `main()` was a no-op: a file
whose only entry point is `unittest.main()` reached verification with **zero
VCCs** and reported `VERIFICATION SUCCESSFUL` on a suite CPython fails. The
preprocessor now expands each `main()` into the instantiate/setUp/test/tearDown
calls the runner would make, in CPython's discovery order.

Notes for review:

- Discovery follows CPython: alphabetical method order, a fresh instance per
  test, decorated methods skipped (`@skip`/`@expectedFailure` mean the runner
  does not count a failure), and inherited test methods re-run under the
  subclass's own `setUp`.
- All six tests are mutation-checked: dropping the decorator guard flips
  `_skip`, dropping the inherited-method union flips `_inherited_fail`, dropping
  the `setUp`/`tearDown` calls flips `_unittest_main`, and reordering the
  `isinstance` check in `_is_test_method` crashes `_attr_fail`.
- `Refs`, not `Fixes`: #6745 is an umbrella covering the whole CPython suite.
  `test.support` and `sys.path`-aware module resolution are still open.
- Out of scope, pre-existing and unrelated to `main()`: `from unittest import
  TestCase` followed by `class T(TestCase)` does not resolve the model's
  methods (`ERROR: Function ...@F@assertEqual' not found`), which reproduces
  with no `main()` call at all. The tests therefore use `unittest.TestCase` /
  `import unittest as ut`. Happy to file that separately.

Refs #6745