### PR TITLE
[clang-c] Rewrite *a to a[0] in the IREP2 adjust pass

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -6720,3 +6720,103 @@ whole guard kills all five; dropping only the pointer half kills the three that
 exercise it, so each half is separately load-bearing. This is the same family as §110's
 base-name defect: the matcher's name test is a prefix where it means an exact
 name, and each shape that reaches it wrongly has to be closed as it is found.
+
+
+## 132. The unported dereference arm was an encoder abort (2026-08-29)
+
+§131.4 named the array decay as the next cause, on the strength of two tests
+sharing a tag. They do not share a mechanism, and they point in opposite
+directions:
+
+| test | legacy | hop-off |
+|---|---|---|
+| `github_169` | `ASSIGN b[0]=…` | `ASSIGN *b=…` |
+| `github_1210-1-struct` | `memcpy(&JJ, …)` | `memcpy(&JJ[0], …)` |
+
+The first is the hop-off failing to decay, the second is the hop-off decaying
+where legacy does not. `github_1210-1-struct` declares `extern struct
+incomplete JJ;`, so it is a question about following a symbol type to an
+incomplete one, not about decay at all. It keeps its own slice. This section is
+`github_169`.
+
+### 132.1 The comment was wrong, and not by a spelling
+
+`clang_c_adjust::adjust_dereference` has three arms: rewrite `*a` to `a[0]`
+when the operand `is_array_like`, retype to the pointer's subtype otherwise,
+and re-take the address when the result is code-typed.
+`clang_c_adjust_irep2::adjust_dereference` ported only the third, above a
+comment saying the other two "retype a node the migration already builds with
+the right type, so no corpus input distinguishes them".
+
+`github_169` distinguishes them, and reducing it shows the difference is not a
+rendering:
+
+```c
+int main(void) { int a[3]; *a = 7; __ESBMC_assert(a[0] == 7, "x"); }
+```
+
+Under `--clang-c-irep2-adjust-only` on master this **aborts**:
+
+```
+Generated 6 VCC(s), 4 remaining after simplification
+ERROR: Unexpected type in int/ptr typecast          (exit 134)
+```
+
+The dereference reaches the encoder as a pointer built from an array rather
+than a named element. A VLA -- `github_169`'s own shape, `char *b[argc]` --
+aborts the same way. The goto-level census scored this as two diverging lines;
+it is a crash.
+
+### 132.2 The vector half is not reproduced
+
+Legacy's guard is `is_array_like`, which is `vector || array ||
+incomplete_array`. Only the array half is ported:
+
+- **vector** -- clang rejects `*v` on one: `indirection requires pointer
+  operand ('v4' (vector of 4 'int' values) invalid)`. No accepted C input
+  reaches the arm, so reproducing it would be dead instrumentation. Measured,
+  not assumed.
+- **incomplete_array** -- needs no arm of its own: `migrate_type` turns it into
+  `array_type2t` with `size_is_infinite` (migrate.cpp:359), which
+  `is_array_type` already admits.
+
+### 132.3 Result
+
+The stride-7 residue goes 11 -> 10. Three tests, each failing on a master
+control binary built from this same tree:
+
+| test | pins |
+|---|---|
+| `irep2_only_deref_array` | the rewrite on a fixed-size array |
+| `irep2_only_deref_array_fail` | `*a` writes `a[0]`, not `a[1]` -- names the property |
+| `irep2_only_deref_array_vla` | the variably-modified shape `github_169` reduced to |
+
+Unlike §131 these do move a verdict, because the unported arm aborted rather
+than diverging quietly: the control exits 134 on all three.
+
+### 132.4 Next
+
+`github_1210-1-struct`, split out above. Reduced and confirmed rather than
+inferred this time:
+
+```c
+struct incomplete;
+extern struct incomplete JJ;
+void take(void *p);
+int main(void) { take(&JJ); }
+```
+
+```
+legacy:  FUNCTION_CALL:  take((void *)(&JJ))
+hop-off: FUNCTION_CALL:  take((void *)(&JJ[0]))
+```
+
+The suspect is that legacy's `adjust_address_of` tests
+`is_array_like(op.type())` on the *unfollowed* type, so a symbol type naming an
+incomplete struct does not match, while the migration resolves it and the
+IREP2 arm decays. Which of the two is right is the open question -- unlike
+§132, the hop-off is the side doing more work here, so the answer may be to
+stop decaying rather than to port an arm.
+
+Four tags have now dissolved on inspection in this scope, and every one of them
+was read from a census table rather than from a reduction. Reduce first.

--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -6749,7 +6749,15 @@ comment saying the other two "retype a node the migration already builds with
 the right type, so no corpus input distinguishes them".
 
 `github_169` distinguishes them, and reducing it shows the difference is not a
-rendering:
+rendering. It has three symptoms, not one:
+
+| symptom | shapes |
+|---|---|
+| `ERROR: Unexpected type in int/ptr typecast`, exit 134 | 1-D, VLA, 2-D, struct and union member, typedef, compound literal, `extern`/`static`/`const` array, and `github_169`'s own `char *b[argc]` |
+| `ERROR: Can't construct rvalue reference to array type during dereference`, exit 134 | `*p->v` through a struct pointer, `**a` on an array-typed parameter |
+| `VERIFICATION FAILED` -- a **wrong verdict, no crash** | `*"abc"`, `&*a` |
+
+The loud one first:
 
 ```c
 int main(void) { int a[3]; *a = 7; __ESBMC_assert(a[0] == 7, "x"); }
@@ -6777,7 +6785,8 @@ incomplete_array`. Only the array half is ported:
   reaches the arm, so reproducing it would be dead instrumentation. Measured,
   not assumed.
 - **incomplete_array** -- needs no arm of its own: `migrate_type` turns it into
-  `array_type2t` with `size_is_infinite` (migrate.cpp:359), which
+  `array_type2t` with `size_is_infinite` (`util/irep/migrate.cpp`'s
+  `incomplete_array` arm), which
   `is_array_type` already admits.
 
 ### 132.3 Result
@@ -6790,9 +6799,20 @@ control binary built from this same tree:
 | `irep2_only_deref_array` | the rewrite on a fixed-size array |
 | `irep2_only_deref_array_fail` | `*a` writes `a[0]`, not `a[1]` -- names the property |
 | `irep2_only_deref_array_vla` | the variably-modified shape `github_169` reduced to |
+| `irep2_only_deref_array_strlit` | the **wrong-verdict** class, which the other three cannot reach |
 
-Unlike §131 these do move a verdict, because the unported arm aborted rather
-than diverging quietly: the control exits 134 on all three.
+The first three all fail on the control the same way -- the process aborts --
+so together they distinguish only "crashes" from "does not crash". That is not
+enough: `char c = *"abc"; assert(c == 'a');` is `SUCCESSFUL` on legacy and
+`FAILED` on the unpatched hop-off, with no crash at all. A regression that
+reintroduced only the quiet half would pass all three. `..._strlit` is the one
+that guards it, and it is the test this section nearly shipped without --
+the first draft asserted the arm "aborted rather than diverging quietly",
+which the reduction above refutes.
+
+The divergence is always in the safe direction: the unpatched hop-off reports
+`FAILED` where legacy reports `SUCCESSFUL`, never the reverse, so the cost was
+precision rather than soundness.
 
 ### 132.4 Next
 

--- a/regression/esbmc/irep2_only_deref_array/main.c
+++ b/regression/esbmc/irep2_only_deref_array/main.c
@@ -1,0 +1,11 @@
+// `*a` on an array is `a[0]`. Left as a dereference the IREP2 adjust pass
+// handed the encoder a pointer built from an array and it aborted there.
+int main(void)
+{
+  int a[3] = {0, 0, 0};
+
+  *a = 7;
+
+  __ESBMC_assert(a[0] == 7, "*a assigns the first element");
+  return 0;
+}

--- a/regression/esbmc/irep2_only_deref_array/test.desc
+++ b/regression/esbmc/irep2_only_deref_array/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--clang-c-irep2-adjust-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/irep2_only_deref_array_fail/main.c
+++ b/regression/esbmc/irep2_only_deref_array_fail/main.c
@@ -1,0 +1,10 @@
+// Anti-vacuity twin: `*a` writes a[0], not a[1], so the equality is refuted.
+int main(void)
+{
+  int a[3] = {0, 0, 0};
+
+  *a = 7;
+
+  __ESBMC_assert(a[1] == 7, "*a assigns the second element");
+  return 0;
+}

--- a/regression/esbmc/irep2_only_deref_array_fail/test.desc
+++ b/regression/esbmc/irep2_only_deref_array_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--clang-c-irep2-adjust-only
+^VERIFICATION FAILED$
+^  \*a assigns the second element$

--- a/regression/esbmc/irep2_only_deref_array_strlit/main.c
+++ b/regression/esbmc/irep2_only_deref_array_strlit/main.c
@@ -1,0 +1,10 @@
+// The quiet half of the same defect. `*"abc"` dereferences an array without
+// reaching the encoder's int/ptr cast, so the unported arm did not abort here
+// -- it returned a wrong verdict, which a crash-class test cannot catch.
+int main(void)
+{
+  char c = *"abc";
+
+  __ESBMC_assert(c == 'a', "*\"abc\" is the first character");
+  return 0;
+}

--- a/regression/esbmc/irep2_only_deref_array_strlit/test.desc
+++ b/regression/esbmc/irep2_only_deref_array_strlit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--clang-c-irep2-adjust-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/irep2_only_deref_array_vla/main.c
+++ b/regression/esbmc/irep2_only_deref_array_vla/main.c
@@ -1,0 +1,12 @@
+// Same rewrite on a variably-modified array, which is the shape github_169
+// reduced to (`char *b[argc]; *b = a;`).
+int main(void)
+{
+  int n = 3;
+  int a[n];
+
+  *a = 7;
+
+  __ESBMC_assert(a[0] == 7, "*a assigns the first element of a VLA");
+  return 0;
+}

--- a/regression/esbmc/irep2_only_deref_array_vla/test.desc
+++ b/regression/esbmc/irep2_only_deref_array_vla/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--clang-c-irep2-adjust-only
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -991,6 +991,7 @@ void clang_c_adjust_irep2::adjust_expression_statement(expr2tc &expr)
 /// `*v` on one ("indirection requires pointer operand"), so no input reaches
 /// that half and it is not reproduced here. Incomplete arrays need no arm of
 /// their own -- migrate_type gives them array_type2t with size_is_infinite.
+/// Not every shape aborts: `*"abc"` returned a wrong verdict instead.
 ///
 /// Then: dereferencing a pointer to a function yields a function designator,
 /// which converts straight back to a pointer (C11 6.3.2.1p4) -- so `*f` is `f`,

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -981,17 +981,35 @@ void clang_c_adjust_irep2::adjust_expression_statement(expr2tc &expr)
     stmt.location);
 }
 
-/// Dereferencing a pointer to a function yields a function designator, which
-/// converts straight back to a pointer (C11 6.3.2.1p4) -- so `*f` is `f`, and
-/// `******f` too. clang_c_adjust::adjust_dereference re-takes the address for
-/// exactly this case; left bare, the code-typed dereference reaches a consumer
+/// `*a` on an array is `a[0]` (C11 6.5.3.2p4 through the 6.3.2.1p3 decay), and
+/// clang_c_adjust::adjust_dereference rewrites it to that index. Left as a
+/// dereference the node reaches the encoder as a pointer built from an array
+/// rather than a named element, and it aborts there: `Unexpected type in
+/// int/ptr typecast`.
+///
+/// Legacy tests `is_array_like`, which also admits a vector; clang rejects
+/// `*v` on one ("indirection requires pointer operand"), so no input reaches
+/// that half and it is not reproduced here. Incomplete arrays need no arm of
+/// their own -- migrate_type gives them array_type2t with size_is_infinite.
+///
+/// Then: dereferencing a pointer to a function yields a function designator,
+/// which converts straight back to a pointer (C11 6.3.2.1p4) -- so `*f` is `f`,
+/// and `******f` too. Left bare, the code-typed dereference reaches a consumer
 /// that wants a pointer.
 ///
-/// Only that arm is ported: the array and pointer-subtype arms above it
-/// retype a node the migration already builds with the right type, so no
-/// corpus input distinguishes them.
+/// Legacy's remaining arm retypes the node to the pointer's subtype; the
+/// migration already builds that type, so no corpus input distinguishes it.
 void clang_c_adjust_irep2::adjust_dereference(expr2tc &expr)
 {
+  const expr2tc pointer = to_dereference2t(expr).value;
+  const type2tc op_type = ns.follow(pointer->type);
+
+  if (is_array_type(op_type))
+    expr = index2tc(
+      to_array_type(op_type).subtype,
+      pointer,
+      gen_zero(migrate_type(index_type())));
+
   if (!is_code_type(expr->type))
     return;
 


### PR DESCRIPTION
`clang_c_adjust::adjust_dereference` rewrites `*a` on an array to `a[0]`. The IREP2
counterpart ported only the code-typed arm, above a comment saying no corpus input
distinguished the others. `github_169` does, and not by a spelling: left as a
dereference the node reaches the encoder as a pointer built from an array and aborts
it — `ERROR: Unexpected type in int/ptr typecast`, exit 134, on `int a[3]; *a = 7;`.

Only the array half of legacy's `is_array_like` is reproduced: clang rejects `*v` on
a vector, so that half is unreachable, and an incomplete array already migrates to
`array_type2t` with `size_is_infinite`. Gated behind `--clang-c-irep2-adjust-only`.
Detail in `docs/roadmap/scope-clang-c-irep2.md` §132.

Refs #4715.
