### PR TITLE
[python] Dispatch list.sort() on type_flag, not the element width

### DIFF
--- a/regression/python/list_sort_dispatch/main.py
+++ b/regression/python/list_sort_dispatch/main.py
@@ -1,0 +1,22 @@
+# list.sort() dispatches on the frontend's type_flag, so every element family
+# must still sort by its own ordering, not by a byte comparison.
+ints = [7, 3, -2, 0, 3]
+ints.sort()
+assert ints == [-2, 0, 3, 3, 7]
+
+floats = [1.5, -0.5, 2.25]
+floats.sort()
+assert floats == [-0.5, 1.5, 2.25]
+
+bools = [True, False, True]
+bools.sort()
+assert bools == [False, True, True]
+
+mixed = [3, 1.5, -2]
+mixed.sort()
+assert mixed[0] == -2
+assert mixed[2] == 3
+
+words = ["ab", "", "a"]
+words.sort()
+assert words == ["", "a", "ab"]

--- a/regression/python/list_sort_dispatch/test.desc
+++ b/regression/python/list_sort_dispatch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_sort_dispatch_fail/main.py
+++ b/regression/python/list_sort_dispatch_fail/main.py
@@ -1,0 +1,22 @@
+# list.sort() dispatches on the frontend's type_flag, so every element family
+# must still sort by its own ordering, not by a byte comparison.
+ints = [7, 3, -2, 0, 3]
+ints.sort()
+assert ints[0] == 7
+
+floats = [1.5, -0.5, 2.25]
+floats.sort()
+assert floats == [-0.5, 1.5, 2.25]
+
+bools = [True, False, True]
+bools.sort()
+assert bools == [False, True, True]
+
+mixed = [3, 1.5, -2]
+mixed.sort()
+assert mixed[0] == -2
+assert mixed[2] == 3
+
+words = ["ab", "", "a"]
+words.sort()
+assert words == ["", "a", "ab"]

--- a/regression/python/list_sort_dispatch_fail/test.desc
+++ b/regression/python/list_sort_dispatch_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION FAILED$
+^ *FAILED .*assertion .*value == 7$

--- a/regression/python/list_sort_unwind_invariant/main.py
+++ b/regression/python/list_sort_unwind_invariant/main.py
@@ -1,0 +1,7 @@
+# Sorting an all-integer list must not cost anything that scales with --unwind:
+# the numeric arms are selected by the frontend's literal type_flag, so the
+# lexicographic memcmp arm is never symbolically executed here. Before that
+# dispatch was reordered this generated 51088 VCCs at --unwind 32.
+xs = [7, 6, 5, 4, 3, 2, 1, 0]
+xs.sort()
+assert xs == [0, 1, 2, 3, 4, 5, 6, 7]

--- a/regression/python/list_sort_unwind_invariant/test.desc
+++ b/regression/python/list_sort_unwind_invariant/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 32
+^VERIFICATION SUCCESSFUL$
+^Generated [0-9]{1,4} VCC\(s\)

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -1264,45 +1264,71 @@ void __ESBMC_list_sort(PyListObject *l, int type_flag, uint64_t float_type_id)
 
       bool prev_greater = false;
 
-      if (prev->size == 8 && type_flag == 0)
+      // Dispatch on type_flag, not on prev->size. type_flag is a literal from
+      // the frontend, so symex decides it and never enters the arm it did not
+      // select; prev->size is a field read through the element array, which
+      // does not fold, so leading with it made every numeric comparison also
+      // symex the memcmp below and unwind its byte loop to --unwind (#7361's
+      // defect class, docs/roadmap/symex-dead-work-cost-plan.md §3).
+      if (type_flag != 2)
       {
-        // All-integer list: compare as int64_t.
-        // Stays entirely in integer arithmetic — fast for the SMT solver.
-        int64_t a = *(const int64_t *)prev->value;
-        int64_t b = *(const int64_t *)tmp.value;
-        prev_greater = (a > b);
-      }
-      else if (prev->size == 8 && type_flag == 1)
-      {
-        // All-float list: read bits directly as IEEE 754 double.
-        double a = *(const double *)prev->value;
-        double b = *(const double *)tmp.value;
-        prev_greater = (a > b);
-      }
-      else if (prev->size == 8 && type_flag == 3)
-      {
-        // Mixed int + float list.
-        // Per-element dispatch: check each element's own type_id.
-        //   float element → read bits as double
-        //   int element   → numeric cast (double)(int64_t)  [exact up to 2^53]
-        double a = (prev->type_id == float_type_id)
-                     ? (*(const double *)prev->value)
-                     : ((double)(*(const int64_t *)prev->value));
-        double b = (tmp.type_id == float_type_id)
-                     ? (*(const double *)tmp.value)
-                     : ((double)(*(const int64_t *)tmp.value));
-        prev_greater = (a > b);
+        // Numeric list: no lexicographic arm. The frontend widens every
+        // numeric element to 8 bytes (bools arrive as bool_as_long), so the
+        // size-1 arm below is currently unreachable and kept only because
+        // removing it is a separate change; a byte compare of two numbers
+        // would be wrong anyway, which is why the memcmp arm is gone.
+        if (prev->size == 8)
+        {
+          if (type_flag == 0)
+          {
+            // All-integer list: compare as int64_t.
+            // Stays entirely in integer arithmetic — fast for the SMT solver.
+            int64_t a = *(const int64_t *)prev->value;
+            int64_t b = *(const int64_t *)tmp.value;
+            prev_greater = (a > b);
+          }
+          else if (type_flag == 1)
+          {
+            // All-float list: read bits directly as IEEE 754 double.
+            double a = *(const double *)prev->value;
+            double b = *(const double *)tmp.value;
+            prev_greater = (a > b);
+          }
+          else if (type_flag == 3)
+          {
+            // Mixed int + float list.
+            // Per-element dispatch: check each element's own type_id.
+            //   float element → read bits as double
+            //   int element   → numeric cast (double)(int64_t) [exact to 2^53]
+            double a = (prev->type_id == float_type_id)
+                         ? (*(const double *)prev->value)
+                         : ((double)(*(const int64_t *)prev->value));
+            double b = (tmp.type_id == float_type_id)
+                         ? (*(const double *)tmp.value)
+                         : ((double)(*(const int64_t *)tmp.value));
+            prev_greater = (a > b);
+          }
+        }
+        else if (prev->size == 1)
+        {
+          // bool / single-byte
+          uint8_t a = *(const uint8_t *)prev->value;
+          uint8_t b = *(const uint8_t *)tmp.value;
+          prev_greater = (a > b);
+        }
       }
       else if (prev->size == 1)
       {
-        // bool / single-byte
+        // The empty string, whose only byte is the terminator. Kept ahead of
+        // the memcmp arm so this reads exactly as it did before the dispatch
+        // was reordered.
         uint8_t a = *(const uint8_t *)prev->value;
         uint8_t b = *(const uint8_t *)tmp.value;
         prev_greater = (a > b);
       }
       else
       {
-        // type_flag == 2: string / lexicographic comparison.
+        // String / lexicographic comparison.
         //
         // Must use min(prev->size, tmp->size) as the memcmp length.
         // Using prev->size alone reads past the end of tmp's buffer when


### PR DESCRIPTION
Leading the comparison chain with `prev->size`, a field read that does not
fold, made every numeric sort also symbolically execute the lexicographic
`memcmp` arm and unwind its byte loop to `--unwind`. Dispatching on the
frontend's literal `type_flag` first prunes it: eight constant ints drop from
36451 to 4041 assignments at `--unwind 20`, and the cost is now flat in the
bound. W1 of `docs/roadmap/symex-dead-work-cost-plan.md`.
