### PR TITLE
[python] Give list.extend() the frontend's constant element width

### DIFF
--- a/regression/python/list_extend_elem_size/main.py
+++ b/regression/python/list_extend_elem_size/main.py
@@ -1,0 +1,27 @@
+# extend() applies one copy length to every element, so the frontend supplies a
+# width only when all recorded elements share it. Each arm is exercised here.
+
+# Uniform scalar width: the frontend passes 8.
+ints = [1, 2]
+ints.extend([3, 4])
+assert ints == [1, 2, 3, 4]
+
+floats = [1.5]
+floats.extend([2.5, 3.5])
+assert floats == [1.5, 2.5, 3.5]
+
+# Mixed widths: no single length, so the model keeps its elem->size fallback.
+mixed = [1]
+mixed.extend([2, "abc"])
+assert mixed[1] == 2
+assert mixed[2] == "abc"
+
+# Non-scalar elements: same fallback.
+nested = [[1, 2]]
+nested.extend([[3, 4]])
+assert nested[1][0] == 3
+
+# Strings differ in width element to element.
+words = ["a"]
+words.extend(["bb", "ccc"])
+assert words == ["a", "bb", "ccc"]

--- a/regression/python/list_extend_elem_size/test.desc
+++ b/regression/python/list_extend_elem_size/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_extend_elem_size_fail/main.py
+++ b/regression/python/list_extend_elem_size_fail/main.py
@@ -1,27 +1,6 @@
-# extend() applies one copy length to every element, so the frontend supplies a
-# width only when all recorded elements share it. Each arm is exercised here.
-
-# Uniform scalar width: the frontend passes 8.
+# The uniform-scalar-width arm, which is the one the negative pin needs; the
+# remaining arms are exercised by the passing twin, and carrying them here only
+# made the test unwind past the 120s cap on the macOS runner.
 ints = [1, 2]
 ints.extend([3, 4])
 assert ints[3] == 99
-
-floats = [1.5]
-floats.extend([2.5, 3.5])
-assert floats == [1.5, 2.5, 3.5]
-
-# Mixed widths: no single length, so the model keeps its elem->size fallback.
-mixed = [1]
-mixed.extend([2, "abc"])
-assert mixed[1] == 2
-assert mixed[2] == "abc"
-
-# Non-scalar elements: same fallback.
-nested = [[1, 2]]
-nested.extend([[3, 4]])
-assert nested[1][0] == 3
-
-# Strings differ in width element to element.
-words = ["a"]
-words.extend(["bb", "ccc"])
-assert words == ["a", "bb", "ccc"]

--- a/regression/python/list_extend_elem_size_fail/main.py
+++ b/regression/python/list_extend_elem_size_fail/main.py
@@ -1,0 +1,27 @@
+# extend() applies one copy length to every element, so the frontend supplies a
+# width only when all recorded elements share it. Each arm is exercised here.
+
+# Uniform scalar width: the frontend passes 8.
+ints = [1, 2]
+ints.extend([3, 4])
+assert ints[3] == 99
+
+floats = [1.5]
+floats.extend([2.5, 3.5])
+assert floats == [1.5, 2.5, 3.5]
+
+# Mixed widths: no single length, so the model keeps its elem->size fallback.
+mixed = [1]
+mixed.extend([2, "abc"])
+assert mixed[1] == 2
+assert mixed[2] == "abc"
+
+# Non-scalar elements: same fallback.
+nested = [[1, 2]]
+nested.extend([[3, 4]])
+assert nested[1][0] == 3
+
+# Strings differ in width element to element.
+words = ["a"]
+words.extend(["bb", "ccc"])
+assert words == ["a", "bb", "ccc"]

--- a/regression/python/list_extend_elem_size_fail/test.desc
+++ b/regression/python/list_extend_elem_size_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 12
+^VERIFICATION FAILED$
+^ *FAILED .*assertion .*value == 99$

--- a/regression/python/list_extend_unwind_invariant/main.py
+++ b/regression/python/list_extend_unwind_invariant/main.py
@@ -1,0 +1,9 @@
+# Extending a uniform-width list must not cost anything that scales with
+# --unwind: the constant element width keeps the copy off memcpy's byte loop.
+# Before the width was threaded this generated 15637 VCCs at --unwind 60.
+xs = [0, 1, 2, 3, 4, 5, 6, 7]
+ys = [8, 9, 10, 11, 12, 13, 14, 15]
+xs.extend(ys)
+assert len(xs) == 16
+assert xs[8] == 8
+assert xs[15] == 15

--- a/regression/python/list_extend_unwind_invariant/test.desc
+++ b/regression/python/list_extend_unwind_invariant/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 40
+^VERIFICATION SUCCESSFUL$
+^Generated [0-9]{1,4} VCC\(s\)

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -695,7 +695,17 @@ size_t __ESBMC_list_index_range(
 
 /* ---------- extend list ---------- */
 
-void __ESBMC_list_extend(PyListObject *l, const PyListObject *other)
+// elem_size: the statically-known element byte width from the frontend, used
+// as the copy length so __ESBMC_copy_value sees a compile-time constant and
+// takes its branch-free fast path. Without it the length is the symbolic field
+// read elem->size, which drops the copy into memcpy's per-byte loop and
+// unwinds it once per element (__ESBMC_list_store_elem threads the same
+// constant for the same reason, see above). 0 means the frontend could not
+// supply a width and reproduces the previous behaviour exactly.
+void __ESBMC_list_extend(
+  PyListObject *l,
+  const PyListObject *other,
+  size_t elem_size)
 {
   if (!l || !other)
     return;
@@ -706,8 +716,9 @@ void __ESBMC_list_extend(PyListObject *l, const PyListObject *other)
     const PyObject *elem = &other->items[i];
 
     // Reuse the float-aware copier so the SMT model tracks size.
+    size_t copy_size = (elem_size != 0) ? elem_size : elem->size;
     void *copied_value =
-      __ESBMC_copy_value(elem->value, elem->size, elem->type_id, 0, NULL, 0);
+      __ESBMC_copy_value(elem->value, copy_size, elem->type_id, 0, NULL, 0);
 
     l->items[l->size].value = copied_value;
     l->items[l->size].float_idx = elem->float_idx;

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -898,6 +898,31 @@ exprt python_list::list_repetition(
   return build_symbol(*list_symbol);
 }
 
+BigInt python_list::uniform_scalar_elem_size(const std::string &list_id) const
+{
+  auto types = list_type_map.find(list_id);
+  if (types == list_type_map.end())
+    return 0;
+
+  BigInt width = 0;
+  bool seen = false;
+  for (const auto &entry : types->second)
+  {
+    const typet &elem_type = converter_.ns.follow(entry.second);
+    if (!(elem_type.is_signedbv() || elem_type.is_unsignedbv() ||
+          elem_type.is_floatbv() || elem_type.is_bool()))
+      return 0;
+
+    BigInt entry_width =
+      type_byte_size(migrate_type(elem_type), &converter_.name_space());
+    if (seen && entry_width != width)
+      return 0;
+    width = entry_width;
+    seen = true;
+  }
+  return width;
+}
+
 exprt python_list::build_extend_list_call(
   const symbolt &list,
   const nlohmann::json &op,
@@ -1111,34 +1136,8 @@ exprt python_list::build_extend_list_call(
   // element to be the same scalar width: extend applies one length to all of
   // them, so a mixed-width list must keep the model's symbolic elem->size
   // fallback (0).
-  BigInt elem_size_bytes = 0;
-  auto other_types = list_type_map.find(other_list_name);
-  if (actual_list.is_symbol() && other_types != list_type_map.end())
-  {
-    bool uniform = true;
-    bool seen = false;
-    for (const auto &entry : other_types->second)
-    {
-      const typet &elem_type = converter_.ns.follow(entry.second);
-      if (!(elem_type.is_signedbv() || elem_type.is_unsignedbv() ||
-            elem_type.is_floatbv() || elem_type.is_bool()))
-      {
-        uniform = false;
-        break;
-      }
-      BigInt width =
-        type_byte_size(migrate_type(elem_type), &converter_.name_space());
-      if (seen && width != elem_size_bytes)
-      {
-        uniform = false;
-        break;
-      }
-      elem_size_bytes = width;
-      seen = true;
-    }
-    if (!uniform)
-      elem_size_bytes = 0;
-  }
+  BigInt elem_size_bytes =
+    actual_list.is_symbol() ? uniform_scalar_elem_size(other_list_name) : 0;
 
   code_function_callt extend_func_call;
   extend_func_call.function() = build_symbol(*extend_func_sym);

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -1106,10 +1106,46 @@ exprt python_list::build_extend_list_call(
     }
   }
 
+  // The constant copy length for the model. Unlike build_shallow_copy_call,
+  // which reads only the last type-map entry, this requires *every* recorded
+  // element to be the same scalar width: extend applies one length to all of
+  // them, so a mixed-width list must keep the model's symbolic elem->size
+  // fallback (0).
+  BigInt elem_size_bytes = 0;
+  auto other_types = list_type_map.find(other_list_name);
+  if (actual_list.is_symbol() && other_types != list_type_map.end())
+  {
+    bool uniform = true;
+    bool seen = false;
+    for (const auto &entry : other_types->second)
+    {
+      const typet &elem_type = converter_.ns.follow(entry.second);
+      if (!(elem_type.is_signedbv() || elem_type.is_unsignedbv() ||
+            elem_type.is_floatbv() || elem_type.is_bool()))
+      {
+        uniform = false;
+        break;
+      }
+      BigInt width =
+        type_byte_size(migrate_type(elem_type), &converter_.name_space());
+      if (seen && width != elem_size_bytes)
+      {
+        uniform = false;
+        break;
+      }
+      elem_size_bytes = width;
+      seen = true;
+    }
+    if (!uniform)
+      elem_size_bytes = 0;
+  }
+
   code_function_callt extend_func_call;
   extend_func_call.function() = build_symbol(*extend_func_sym);
   extend_func_call.arguments().push_back(build_symbol(list));
   extend_func_call.arguments().push_back(actual_list);
+  extend_func_call.arguments().push_back(
+    from_integer(elem_size_bytes, size_type()));
   extend_func_call.type() = empty_typet();
   extend_func_call.location() = location;
 

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -653,6 +653,18 @@ public:
    */
   static size_t get_list_type_map_size(const std::string &list_id);
 
+  /**
+   * @brief The element byte width every recorded element of @p list_id shares,
+   *        or 0 when there is no single answer.
+   *
+   * The list models apply one copy length to every element, so a width is only
+   * usable when all of them agree. Non-scalar elements (nested lists, dicts)
+   * and mixed widths both yield 0, which keeps the model on its symbolic
+   * o->size path. Distinct from build_shallow_copy_call, which reads only the
+   * last type-map entry.
+   */
+  BigInt uniform_scalar_elem_size(const std::string &list_id) const;
+
   /** Compute the type_flag and float_type_id for a list, using the same
    *  encoding as __ESBMC_list_sort and __ESBMC_list_lt:
    *    0 = all-integer, 1 = all-float, 2 = string, 3 = mixed int+float.

--- a/src/python-frontend/set/python_set.cpp
+++ b/src/python-frontend/set/python_set.cpp
@@ -743,6 +743,9 @@ exprt python_set::build_set_union_call(
   extend_call.arguments().push_back(build_symbol(result_set));
   extend_call.arguments().push_back(
     lhs.type().is_pointer() ? lhs : build_address_of(lhs));
+  // No type map for a set built here, so no static width: 0 keeps the model on
+  // its symbolic elem->size path.
+  extend_call.arguments().push_back(from_integer(BigInt(0), size_type()));
   extend_call.type() = empty_typet();
   extend_call.location() = loc;
   converter_.add_instruction(extend_call);


### PR DESCRIPTION
The copy length was the symbolic field read `elem->size`, so every element
dropped into `memcpy`'s per-byte loop and unwound it once per element.
Passing the statically-known width — as `__ESBMC_list_store_elem` already
does — keeps the copy on `__ESBMC_copy_value`'s branch-free path.

| n, `--unwind 60` | before | after |
|---|---:|---:|
| 4, assignments | 5478 | 1104 |
| 8, assignments | 14970 | 2188 |
| 16, assignments | 46338 | 4644 |
| 16, VCCs | 55437 | 2845 |
| 8, memcpy unwindings | 486 | 0 |

The width is applied only when every recorded element shares it: `extend` uses
one length for all of them, so a mixed-width or non-scalar list keeps the
model's symbolic `elem->size` fallback. The set path passes 0, which is the
previous behaviour exactly. W2 of `docs/roadmap/symex-dead-work-cost-plan.md`.