### PR TITLE
[om] Reallocate std::vector's buffer in place in reserve()

### DIFF
--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc/main.cpp
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc/main.cpp
@@ -1,0 +1,41 @@
+// reserve() reallocates in place rather than allocating a second buffer and
+// copying, so the elements already stored must survive every growth.
+#include <vector>
+#include <cassert>
+
+struct P
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(7);
+  v.push_back(8);
+  v.reserve(64); // crosses the default capacity, so the body runs
+  assert(v[0] == 7);
+  assert(v[1] == 8);
+  assert(v.size() == 2);
+
+  for (int i = 0; i < 18; i++)
+    v.push_back(i);
+  assert(v.size() == 20);
+  assert(v[0] == 7);
+  assert(v[19] == 17);
+
+  std::vector<P> s;
+  for (int i = 0; i < 12; i++)
+  {
+    P p;
+    p.a = i;
+    p.b = i * 2;
+    s.push_back(p);
+  }
+  assert(s[0].a == 0);
+  assert(s[11].a == 11);
+  assert(s[11].b == 22);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc/test.desc
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 40
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc_fail/main.cpp
@@ -1,0 +1,41 @@
+// reserve() reallocates in place rather than allocating a second buffer and
+// copying, so the elements already stored must survive every growth.
+#include <vector>
+#include <cassert>
+
+struct P
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(7);
+  v.push_back(8);
+  v.reserve(64); // crosses the default capacity, so the body runs
+  assert(v[0] == 7);
+  assert(v[1] == 8);
+  assert(v.size() == 2);
+
+  for (int i = 0; i < 18; i++)
+    v.push_back(i);
+  assert(v.size() == 20);
+  assert(v[0] == 7);
+  assert(v[19] == 999);
+
+  std::vector<P> s;
+  for (int i = 0; i < 12; i++)
+  {
+    P p;
+    p.a = i;
+    p.b = i * 2;
+    s.push_back(p);
+  }
+  assert(s[0].a == 0);
+  assert(s[11].a == 11);
+  assert(s[11].b == 22);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 40
+^VERIFICATION FAILED$
+^ *FAILED .*assertion v\[19\] == 999$

--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested/main.cpp
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested/main.cpp
@@ -1,0 +1,22 @@
+// reserve() reallocates in place, so a non-trivial element's own heap buffer
+// must survive the growth. The elements here cross the default capacity of 10,
+// which the github_6368 tests do not: they store a single element, so
+// reserve()'s body never runs.
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<std::vector<int> > v;
+  for (int i = 0; i < 12; i++)
+  {
+    std::vector<int> row;
+    row.push_back(i);
+    v.push_back(row);
+  }
+  assert(v.size() == 12);
+  assert(v[0].size() == 1);
+  assert(v[0][0] == 0);
+  assert(v[11][0] == 11);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested/test.desc
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 16
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested_fail/main.cpp
@@ -1,0 +1,22 @@
+// reserve() reallocates in place, so a non-trivial element's own heap buffer
+// must survive the growth. The elements here cross the default capacity of 10,
+// which the github_6368 tests do not: they store a single element, so
+// reserve()'s body never runs.
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<std::vector<int> > v;
+  for (int i = 0; i < 12; i++)
+  {
+    std::vector<int> row;
+    row.push_back(i);
+    v.push_back(row);
+  }
+  assert(v.size() == 12);
+  assert(v[0].size() == 1);
+  assert(v[0][0] == 0);
+  assert(v[11][0] == 555);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/vector_reserve_realloc_nested_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 16
+^VERIFICATION FAILED$
+^ *FAILED .*assertion v\[11\]\[0\] == 555$

--- a/regression/esbmc-cpp/cpp/vector_reserve_unwind_invariant/main.cpp
+++ b/regression/esbmc-cpp/cpp/vector_reserve_unwind_invariant/main.cpp
@@ -1,0 +1,17 @@
+// Once reserve() has run, push_back must not re-enter its loop: the cost of
+// this program is independent of --unwind: 831 VCCs at 40, 80 and 120.
+// Before reserve() reallocated in place it was 9076, 17236 and 25396.
+#include <vector>
+#include <cassert>
+
+int main()
+{
+  std::vector<int> v;
+  v.reserve(20);
+  for (int i = 0; i < 8; i++)
+    v.push_back(i);
+  assert(v[0] == 0);
+  assert(v[7] == 7);
+  assert(v.size() == 8);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/vector_reserve_unwind_invariant/test.desc
+++ b/regression/esbmc-cpp/cpp/vector_reserve_unwind_invariant/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 80
+^VERIFICATION SUCCESSFUL$
+^Generated [0-9]{1,4} VCC\(s\)

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -705,12 +705,13 @@ public:
     if (n > _capacity)
     {
       // realloc in place, as assign() already does: it preserves [0, _size),
-      // so no copy loop is needed, and buf keeps pointing at one dynamic
-      // object. malloc/copy/free gave buf a second candidate object, and a
-      // write through a multi-candidate pointer drops constant propagation for
-      // the sibling fields _size and _capacity -- after which push_back could
-      // not decide `_size == _capacity` and re-entered this loop on every
-      // call (docs/roadmap/symex-dead-work-cost-plan.md W5).
+      // so no copy loop is needed, and it does not assign a fresh heap pointer
+      // into buf. That assignment is what cost us: a struct propagates as a
+      // constant only when every field does, and a malloc'd address never
+      // does, so storing one into buf dropped the constants of the sibling
+      // fields _size and _capacity. push_back could then not decide
+      // `_size == _capacity` and re-entered this loop on every call
+      // (docs/roadmap/symex-dead-work-cost-plan.md W5).
       buf = static_cast<T *>(realloc(buf, sizeof(T) * n));
       __ESBMC_assume(buf);
       _capacity = n;

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -704,15 +704,15 @@ public:
   {
     if (n > _capacity)
     {
-      T *new_buf = static_cast<T *>(malloc(sizeof(T) * n));
-      __ESBMC_assume(new_buf);
-
-      // copy over existing values
-      for (int i = 0; i < _size; i++)
-        __construct_at(new_buf + i, buf[i]);
-
-      free(buf); // free old memory
-      buf = new_buf;
+      // realloc in place, as assign() already does: it preserves [0, _size),
+      // so no copy loop is needed, and buf keeps pointing at one dynamic
+      // object. malloc/copy/free gave buf a second candidate object, and a
+      // write through a multi-candidate pointer drops constant propagation for
+      // the sibling fields _size and _capacity -- after which push_back could
+      // not decide `_size == _capacity` and re-entered this loop on every
+      // call (docs/roadmap/symex-dead-work-cost-plan.md W5).
+      buf = static_cast<T *>(realloc(buf, sizeof(T) * n));
+      __ESBMC_assume(buf);
       _capacity = n;
     }
   }


### PR DESCRIPTION
The malloc/copy/free form assigned a fresh heap pointer into `buf`, and that
alone drops constant propagation for the sibling fields `_size` and
`_capacity`: a struct propagates as a constant only when *every* field's value
does (`goto_symex_state.cpp:313`), and a malloc'd address never does. Ablation
confirms the write through the pointer is not involved — assigning `&local` or
`NULL` into `buf` keeps the siblings constant, assigning a malloc'd pointer
does not, with no write in either case. `push_back` could then no longer
decide `_size == _capacity`, so it re-entered `reserve()`'s copy loop on every
call and unwound it to `--unwind`. `realloc` preserves `[0, _size)` in one
object, which `assign()` already relies on.

| shape | before | after |
|---|---:|---:|
| `reserve(20)` + 8 push_back, u40 | 11072 | 1981 |
| `reserve(200)` + 8 push_back, u40 | 11072 | 2029 |
| growing to 16, u20 | 3697 | 1488 |
| growing to 32, u36 | 42249 | 6032 |

The cost is now **flat in the bound**: 831 VCCs at `--unwind` 40, 80 and 120,
against 9076 / 17236 / 25396 before. The only loop left in the trace is the
program's own.

Note the `github_6368` tests store a single element, so `reserve()`'s body never
runs in them and they do not exercise this path; `vector_reserve_realloc_nested`
crosses the default capacity of 10 with `vector<vector<int>>` to cover it.

W5.1 of `docs/roadmap/symex-dead-work-cost-plan.md`.
