### PR TITLE
[goto-symex] Model a memcpy whose length is not a constant

### DIFF
--- a/regression/esbmc/memcpy_symbolic_length/main.c
+++ b/regression/esbmc/memcpy_symbolic_length/main.c
@@ -1,0 +1,24 @@
+/* A memcpy whose length is not a constant is modelled by unrolling to the
+   objects' own widths and guarding each byte with i < n, instead of deferring
+   to the C byte loop (which unwinds --unwind times per call). */
+#include <string.h>
+#include <assert.h>
+
+int main()
+{
+  char src[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  char dst[8] = {7, 7, 7, 7, 7, 7, 7, 7};
+
+  unsigned long n = nondet_ulong();
+  __ESBMC_assume(n == 3);
+
+  void *r = memcpy(dst, src, n);
+
+  assert(r == (void *)dst);
+  assert(dst[0] == 1);
+  assert(dst[2] == 3);
+  /* bytes at or past n are untouched */
+  assert(dst[3] == 7);
+  assert(dst[7] == 7);
+  return 0;
+}

--- a/regression/esbmc/memcpy_symbolic_length/test.desc
+++ b/regression/esbmc/memcpy_symbolic_length/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/memcpy_symbolic_length_fail/main.c
+++ b/regression/esbmc/memcpy_symbolic_length_fail/main.c
@@ -1,0 +1,24 @@
+/* A memcpy whose length is not a constant is modelled by unrolling to the
+   objects' own widths and guarding each byte with i < n, instead of deferring
+   to the C byte loop (which unwinds --unwind times per call). */
+#include <string.h>
+#include <assert.h>
+
+int main()
+{
+  char src[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  char dst[8] = {7, 7, 7, 7, 7, 7, 7, 7};
+
+  unsigned long n = nondet_ulong();
+  __ESBMC_assume(n == 3);
+
+  void *r = memcpy(dst, src, n);
+
+  assert(r == (void *)dst);
+  assert(dst[0] == 1);
+  assert(dst[2] == 3);
+  /* bytes at or past n are untouched */
+  assert(dst[3] == 4);
+  assert(dst[7] == 7);
+  return 0;
+}

--- a/regression/esbmc/memcpy_symbolic_length_fail/test.desc
+++ b/regression/esbmc/memcpy_symbolic_length_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 20
+^VERIFICATION FAILED$
+^ *FAILED .*assertion dst\[3\] == 4$

--- a/regression/esbmc/memcpy_symbolic_length_multiobject/main.c
+++ b/regression/esbmc/memcpy_symbolic_length_multiobject/main.c
@@ -1,0 +1,24 @@
+/* The symbolic-length model needs one concrete object per operand. A pointer
+   with two candidates declines to the C byte loop, which must still be
+   correct. */
+#include <string.h>
+#include <assert.h>
+
+int main()
+{
+  char a[8] = {1, 1, 1, 1, 1, 1, 1, 1};
+  char b[8] = {2, 2, 2, 2, 2, 2, 2, 2};
+  char d[8] = {0};
+
+  unsigned long i = nondet_ulong();
+  __ESBMC_assume(i < 2);
+  char *s = i ? a : b;
+
+  unsigned long n = nondet_ulong();
+  __ESBMC_assume(n == 4);
+
+  memcpy(d, s, n);
+  assert(d[0] == 1 || d[0] == 2);
+  assert(d[4] == 0);
+  return 0;
+}

--- a/regression/esbmc/memcpy_symbolic_length_multiobject/test.desc
+++ b/regression/esbmc/memcpy_symbolic_length_multiobject/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 100
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/memcpy_symbolic_length_oob_fail/main.c
+++ b/regression/esbmc/memcpy_symbolic_length_oob_fail/main.c
@@ -1,0 +1,15 @@
+/* The unrolled model covers only the bytes the objects actually have, so a
+   length that could exceed them must still be reported rather than dropped. */
+#include <string.h>
+
+int main()
+{
+  char src[8];
+  char dst[4];
+
+  unsigned long n = nondet_ulong();
+  __ESBMC_assume(n <= 8);
+
+  memcpy(dst, src, n); /* n may exceed dst's 4 bytes */
+  return 0;
+}

--- a/regression/esbmc/memcpy_symbolic_length_oob_fail/test.desc
+++ b/regression/esbmc/memcpy_symbolic_length_oob_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 20
+^VERIFICATION FAILED$
+^ *FAILED .*memcpy length exceeds object bounds$

--- a/regression/esbmc/memcpy_symbolic_length_unwind_invariant/main.c
+++ b/regression/esbmc/memcpy_symbolic_length_unwind_invariant/main.c
@@ -1,0 +1,18 @@
+/* The cost of a symbolic-length memcpy must not scale with --unwind: no byte
+   loop is emitted. Before this was modelled it was 98, 178, 338 and 658 symex
+   assignments at --unwind 10, 20, 40 and 80; it is now 29 at every bound; 322 VCCs at --unwind 80 became 4. */
+#include <string.h>
+#include <assert.h>
+
+int main()
+{
+  char src[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  char dst[8] = {0};
+
+  unsigned long n = nondet_ulong();
+  __ESBMC_assume(n <= 8);
+
+  memcpy(dst, src, n);
+  assert(n < 1 || dst[0] == 1);
+  return 0;
+}

--- a/regression/esbmc/memcpy_symbolic_length_unwind_invariant/test.desc
+++ b/regression/esbmc/memcpy_symbolic_length_unwind_invariant/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 80
+^VERIFICATION SUCCESSFUL$
+^Generated [0-9]{1,2} VCC\(s\)

--- a/regression/esbmc/memcpy_symbolic_length_wide/main.c
+++ b/regression/esbmc/memcpy_symbolic_length_wide/main.c
@@ -1,0 +1,21 @@
+/* Wider than the unrolling cap, so the symbolic-length model declines and the
+   C byte loop still handles it. */
+#include <string.h>
+#include <assert.h>
+
+int main()
+{
+  char src[96];
+  char dst[96];
+
+  for (int i = 0; i < 96; i++)
+    src[i] = 5;
+
+  unsigned long n = nondet_ulong();
+  __ESBMC_assume(n == 2);
+
+  memcpy(dst, src, n);
+  assert(dst[0] == 5);
+  assert(dst[1] == 5);
+  return 0;
+}

--- a/regression/esbmc/memcpy_symbolic_length_wide/test.desc
+++ b/regression/esbmc/memcpy_symbolic_length_wide/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 100
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions/memory_ops.cpp
+++ b/src/goto-symex/builtin_functions/memory_ops.cpp
@@ -659,6 +659,95 @@ static void offset_simplifier(expr2tc &e)
 // and then assigns it, so overlapping regions are handled correctly — i.e. it
 // already has memmove semantics. memcpy and memmove therefore differ only in
 // the C fallback they bump to (@p bump_name) when the optimisation can't apply.
+void goto_symext::memcpy_finish(
+  const code_function_call2t &func_call,
+  const expr2tc &dst_arg,
+  const expr2tc &src_arg)
+{
+  if (!options.get_bool_option("no-pointer-check"))
+  {
+    expr2tc null_sym = symbol2tc(dst_arg->type, "NULL");
+
+    expr2tc dst_null_check = not2tc(same_object2tc(dst_arg, null_sym));
+    cur_state->guard.guard_expr(dst_null_check);
+    claim(dst_null_check, " dereference failure: NULL pointer on DST");
+
+    expr2tc src_null_check = not2tc(same_object2tc(src_arg, null_sym));
+    cur_state->guard.guard_expr(src_null_check);
+    claim(src_null_check, " dereference failure: NULL pointer on SRC");
+  }
+
+  expr2tc ret_ref = func_call.ret;
+  if (!is_nil_expr(ret_ref))
+  {
+    dereference(ret_ref, dereferencet::READ);
+    symex_assign(code_assign2tc(ret_ref, dst_arg), false, cur_state->guard);
+  }
+}
+
+bool goto_symext::memcpy_symbolic_length(
+  const expr2tc &dst_arg,
+  const expr2tc &src_arg,
+  const expr2tc &n_arg)
+{
+  // Same cap and rationale as intrinsic_memcmp's: past this the ite chain
+  // costs more than the C loop it replaces.
+  static const uint64_t MAX_MEMCPY_UNROLL = 64;
+
+  // Passing 0 for the length puts the resolver in its symbolic-length mode:
+  // it reports the bytes available in each object instead of range-checking a
+  // constant read. (Named for memcmp, but the resolution is generic.)
+  expr2tc src_obj, dst_obj;
+  uint64_t src_off, dst_off, src_avail, dst_avail;
+  if (
+    !memcmp_resolve_operand(src_arg, 0, src_obj, src_off, src_avail) ||
+    !memcmp_resolve_operand(dst_arg, 0, dst_obj, dst_off, dst_avail, false))
+    return false;
+
+  const uint64_t nbytes = std::min(src_avail, dst_avail);
+  if (nbytes == 0 || nbytes > MAX_MEMCPY_UNROLL)
+    return false;
+
+  // Soundness: only the first nbytes bytes are modelled, so if n could exceed
+  // that the real memcpy would run past an object. Claim the bound rather than
+  // silently dropping the access, exactly as intrinsic_memcmp does.
+  if (
+    !options.get_bool_option("no-bounds-check") &&
+    !options.get_bool_option("no-pointer-check"))
+  {
+    expr2tc in_bounds =
+      lessthanequal2tc(n_arg, constant_int2tc(n_arg->type, BigInt(nbytes)));
+    guard2tc g = cur_state->guard;
+    claim(
+      implies2tc(g.as_expr(), in_bounds),
+      "dereference failure: memcpy length exceeds object bounds");
+  }
+
+  // Rebuild the destination a byte at a time, taking the source byte only
+  // where i < n. Both sides are read from the values *before* the assignment,
+  // so an overlapping copy keeps the memmove semantics the constant-length
+  // path already has.
+  const type2tc byte_t = get_uint_type(8);
+  const bool be = config.ansi_c.endianess == configt::ansi_ct::IS_BIG_ENDIAN;
+  const type2tc n_t = n_arg->type;
+
+  expr2tc res = dst_obj;
+  for (uint64_t i = 0; i < nbytes; ++i)
+  {
+    expr2tc src_byte =
+      byte_extract2tc(byte_t, src_obj, gen_ulong(src_off + i), be);
+    expr2tc dst_byte =
+      byte_extract2tc(byte_t, dst_obj, gen_ulong(dst_off + i), be);
+    expr2tc within = lessthan2tc(constant_int2tc(n_t, BigInt(i)), n_arg);
+    expr2tc new_byte = if2tc(byte_t, within, src_byte, dst_byte);
+    res =
+      byte_update2tc(dst_obj->type, res, gen_ulong(dst_off + i), new_byte, be);
+  }
+
+  symex_assign(code_assign2tc(dst_obj, res), false, cur_state->guard);
+  return true;
+}
+
 void goto_symext::intrinsic_memcpy_impl(
   reachability_treet &art,
   const code_function_call2t &func_call,
@@ -688,7 +777,7 @@ void goto_symext::intrinsic_memcpy_impl(
   // 3. Compute all DST addresses, memory check and compute operation result
 
   cur_state->rename(n_arg);
-  if (!n_arg || is_symbol2t(n_arg))
+  if (!n_arg)
   {
     bump_call(func_call, bump_name);
     return;
@@ -697,7 +786,15 @@ void goto_symext::intrinsic_memcpy_impl(
   simplify(n_arg);
   if (!is_constant_int2t(n_arg))
   {
-    bump_call(func_call, bump_name);
+    // A non-constant length used to go straight to the C byte loop, which then
+    // unwinds --unwind times on every call (docs/roadmap/
+    // symex-dead-work-cost-plan.md W6).
+    if (!memcpy_symbolic_length(dst_arg, src_arg, n_arg))
+    {
+      bump_call(func_call, bump_name);
+      return;
+    }
+    memcpy_finish(func_call, dst_arg, src_arg);
     return;
   }
 
@@ -890,27 +987,7 @@ void goto_symext::intrinsic_memcpy_impl(
         code_assign2tc(item.object, new_object), false, assignment_guard);
     }
   }
-  if (!options.get_bool_option("no-pointer-check"))
-  {
-    expr2tc null_sym = symbol2tc(dst_arg->type, "NULL");
-
-    expr2tc dst_same = same_object2tc(dst_arg, null_sym);
-    expr2tc dst_null_check = not2tc(same_object2tc(dst_arg, null_sym));
-    ex_state.cur_state->guard.guard_expr(dst_null_check);
-    claim(dst_null_check, " dereference failure: NULL pointer on DST");
-
-    expr2tc src_same = same_object2tc(src_arg, null_sym);
-    expr2tc src_null_check = not2tc(same_object2tc(src_arg, null_sym));
-    ex_state.cur_state->guard.guard_expr(src_null_check);
-    claim(src_null_check, " dereference failure: NULL pointer on SRC");
-  }
-
-  expr2tc ret_ref = func_call.ret;
-  if (!is_nil_expr(ret_ref))
-  {
-    dereference(ret_ref, dereferencet::READ);
-    symex_assign(code_assign2tc(ret_ref, dst_arg), false, cur_state->guard);
-  }
+  memcpy_finish(func_call, dst_arg, src_arg);
 }
 
 void goto_symext::intrinsic_memcpy(
@@ -939,7 +1016,8 @@ bool goto_symext::memcmp_resolve_operand(
   unsigned long number_of_bytes,
   expr2tc &object,
   uint64_t &offset,
-  uint64_t &avail_bytes)
+  uint64_t &avail_bytes,
+  bool rename_object)
 {
   internal_deref_items.clear();
   expr2tc deref = dereference2tc(get_empty_type(), ptr);
@@ -950,7 +1028,11 @@ bool goto_symext::memcmp_resolve_operand(
     return false;
 
   dereference_callbackt::internal_item item = internal_deref_items.front();
-  cur_state->rename(item.object);
+  // A caller that assigns to the object needs it unrenamed: renaming yields
+  // its current *value*, which is not an lvalue. symex_assign renames the RHS
+  // itself, so reads through the unrenamed object still see the current value.
+  if (rename_object)
+    cur_state->rename(item.object);
   cur_state->rename(item.offset);
   if (!item.object || !item.offset)
     return false;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -647,6 +647,25 @@ protected:
     reachability_treet &art,
     const code_function_call2t &func_call);
 
+  /** Models a memcpy/memmove whose length is not a constant, the case
+   *  intrinsic_memcpy_impl otherwise defers to the C byte loop (which then
+   *  unwinds --unwind times per call). Mirrors intrinsic_memcmp's symbolic-n
+   *  path: bound the copy by the objects' own widths, guard each byte position
+   *  with i < n, and claim n <= that bound so an over-long copy is still
+   *  reported. Returns false when the operands cannot be resolved, leaving the
+   *  caller to bump. */
+  bool memcpy_symbolic_length(
+    const expr2tc &dst_arg,
+    const expr2tc &src_arg,
+    const expr2tc &n_arg);
+
+  /** The NULL checks and return-value assignment shared by both of
+   *  intrinsic_memcpy_impl's paths. */
+  void memcpy_finish(
+    const code_function_call2t &func_call,
+    const expr2tc &dst_arg,
+    const expr2tc &src_arg);
+
   /** Helper for intrinsic_memcmp: resolve @p ptr to a single concrete
    *  primitive object with a constant offset, validating that an
    *  @p number_of_bytes read stays in bounds. Returns false (bump to the C
@@ -656,7 +675,8 @@ protected:
     unsigned long number_of_bytes,
     expr2tc &object,
     uint64_t &offset,
-    uint64_t &avail_bytes);
+    uint64_t &avail_bytes,
+    bool rename_object = true);
 
   /** Models __ESBMC_memmove. Identical optimisation to memcpy (the new value
    *  is built from the current src/dst bytes before assigning, so overlapping


### PR DESCRIPTION
`intrinsic_memcpy_impl` bumped to `__memcpy_impl`'s byte loop as soon as `n`
failed to simplify to a literal, so every such call cost `--unwind` iterations.
`intrinsic_memcmp`, in the same file, already solves exactly this. This ports
its design: bound the work by the operands' own widths, guard each byte
position with `i < n`, cap the unrolled width at 64, and claim `n <= bound` so
an over-long access is still reported rather than dropped.

| symbolic-length memcpy | before | after |
|---|---:|---:|
| assignments @ `--unwind 10` | 98 | 29 |
| assignments @ `--unwind 20` | 178 | 29 |
| assignments @ `--unwind 40` | 338 | 29 |
| assignments @ `--unwind 80` | 658 | 29 |
| VCCs @ `--unwind 80` | 322 | 4 |
| loop unwindings | 20 | 0 |

**Soundness.** A copy whose length may exceed the destination still fails, now
on the explicit claim (`memcpy length exceeds object bounds`) rather than the
byte loop's bounds check — `memcpy_symbolic_length_oob_fail` pins it, and that
test fails on the unpatched binary.

Operands that do not resolve to a single concrete object, and widths past the
cap, still defer to the C loop; `memcpy_symbolic_length_multiobject` and
`memcpy_symbolic_length_wide` cover those. `memcmp_resolve_operand` gains an
opt-out for renaming, because the destination has to stay an lvalue.

`memmove` shares the routine and is covered: overlap in both directions is in
the differential.

W6 of `docs/roadmap/symex-dead-work-cost-plan.md`.