### PR TITLE
[docs] Re-scope the plan's W4 against measurement

### DIFF
--- a/docs/roadmap/symex-dead-work-cost-plan.md
+++ b/docs/roadmap/symex-dead-work-cost-plan.md
@@ -1,13 +1,19 @@
 # Plan — cost paid for paths that cannot execute (the #7361 defect class)
 
-**Status:** survey complete, six work items identified, **none started**. No
-patch has been written or verified against any of them.
+**Status:** W1, W2, W3, W5.1 and W6 implemented and in review (PRs
+[#7432](https://github.com/esbmc/esbmc/pull/7432),
+[#7435](https://github.com/esbmc/esbmc/pull/7435),
+[#7436](https://github.com/esbmc/esbmc/pull/7436) — stacked on #7435 —
+[#7437](https://github.com/esbmc/esbmc/pull/7437),
+[#7438](https://github.com/esbmc/esbmc/pull/7438)). **W4 was re-scoped after
+measurement and not implemented as written**: §6 records why, and what replaces
+it. W5.2 is still an unlocalised investigation.
 **Origin:** [#7361](https://github.com/esbmc/esbmc/pull/7361), *"[python] Avoid
 duplicated shifts in `list.remove()`"*, which split a search loop and a shift
 loop that had been nested. This plan generalises that fix into a screening test
 (§2) and applies it across the Python and C++ operational models and the
 `memcpy`/`memcmp` intrinsics.
-**Last updated:** 2026-08-30.
+**Last updated:** 2026-08-30 (§6 re-scoped against measurement).
 
 **Measurement environment.** All numbers below were measured on an aarch64 macOS
 host against `build/src/esbmc/esbmc`, ESBMC 8.5.0, built from master
@@ -214,18 +220,20 @@ Python frontend does not produce.
 
 ---
 
-## 6. W4 — constant lists are not folded, though constant strings are
+## 6. W4 — re-scoped: folding is not this plan's defect class
 
-**Where.** `src/python-frontend/`. The constant folding added for `str` in
-PRs #7373, #7374 and #7375 has no `list` counterpart.
+**This item is not what the survey said it was.** As first written, W4 proposed
+constant-folding list operations, on the strength of the `str`-versus-`list`
+table below. Re-running §2's screening test against a build carrying W1, W2 and
+W3 shows that the operations it named do **not** pay an unwind tax, so they are
+outside the class this plan is about. What replaces W4 is stated at the end of
+this section.
 
-A Python program whose lists are entirely literal is decidable at conversion
-time. Strings already are; lists are handed to the C model and symbolically
-executed in full. This is the widest single gap in the Python frontend's cost
-profile, and it subsumes the common case of W1 and W3 without touching the
-model.
+### 6.1 The original observation, which still holds
 
-`str` operations over constant operands, `--unwind 24`, assignments:
+`str` operations over constant operands are decided at conversion time and cost
+essentially nothing, flat in the length of the string; `list` operations are
+handed to the C model. `--unwind 24`, assignments:
 
 | operation | n=4 | n=8 | n=16 |
 |---|---:|---:|---:|
@@ -235,27 +243,65 @@ model.
 | `s.split(…)` | 196 | 196 | 249 |
 | `s.upper()` | 129 | 161 | 225 |
 
-`list` operations over constant lists, `--unwind 60`, assignments:
+That asymmetry is real, and folding list operations would still be a speedup.
+It is simply a *different* optimisation: it removes real work by evaluating it
+early, rather than removing work that can never run.
 
-| operation | n=4 | n=8 | n=16 |
-|---|---:|---:|---:|
-| `xs.append(…)` | 360 | 572 | 996 |
-| `xs.index` / `xs.count` | 303 | 515 | 939 |
-| `x in xs` | 454 | 870 | 1,894 |
-| `xs == ys` | 707 | 1,503 | 3,671 |
-| `xs.copy()` | 837 | 1,633 | 3,513 |
-| `xs.extend(ys)` | 5,478 | 14,970 | 46,338 |
-| `xs.sort()` | 15,683 | 99,609 | error |
-| `xs[1:]` | 86,368 | 117,544 | timeout |
+### 6.2 What the screening test says
 
-**The two tables use different bounds and their absolute values are not
-comparable.** What is comparable is the shape: the `str` rows are flat in *n*,
-the `list` rows are flat in nothing. (`timeout` is the 200 s cap; `error` is
-`xs.sort()` at n=16 under `--unwind 60`.)
+§2's test is the arbiter: hold the program constant and raise `--unwind`; any
+growth is work on a path that cannot execute. Applied to every list operation
+at n=16, on a build carrying W1+W2+W3:
 
-**Fix.** Extend constant folding to list operations whose receiver and arguments
-are compile-time constants, in increasing order of difficulty: `index`, `count`,
-`in`, `==`, slicing with constant bounds, `sort`.
+| operation | u20 | u40 | u60 | unwind tax |
+|---|---:|---:|---:|---|
+| `append` | 996 | 996 | 996 | no |
+| `insert(0, …)` | 1,291 | 1,291 | 1,291 | no |
+| `pop(0)` | 1,165 | 1,165 | 1,165 | no |
+| `index` / `count` | 939 | 939 | 939 | no |
+| `reverse` | 1,172 | 1,172 | 1,172 | no |
+| `x in xs` | 1,894 | 1,894 | 1,894 | no |
+| `xs == ys` | 3,671 | 3,671 | 3,671 | no |
+| `copy` | 3,513 | 3,513 | 3,513 | no |
+| `sorted(xs)` | 1,877 | 1,877 | 1,877 | no |
+| **`remove`** | 2,122 | 2,382 | **2,642** | **yes** |
+| **`sum`** | 2,637 | 4,337 | **6,037** | **yes** |
+| **`max`** | 2,762 | 4,502 | **6,242** | **yes** |
+| **`xs[1:]`** | 4,556 | 8,136 | **11,716** | **yes** |
+
+Every operation W4 named — `index`, `count`, `in`, `==` — is flat. Two of them
+are moot for a further reason: `[10, 20, 30].index(20)` is **already folded**
+today (77 assignments, 1 VCC), and `x in [1, 2, 3]` costs 361 assignments.
+
+### 6.3 What is actually left, and why it is one item
+
+The four taxed rows share a single cause, confirmed from their unwinding
+profiles: **a loop whose trip count symex cannot decide.**
+
+| operation | the loop | why the bound does not fold |
+|---|---|---|
+| `sum` | injected Python model, line 265 | bound is the list length read at runtime |
+| `max` | injected Python model, line 41 | same |
+| `xs[1:]` | the slice lowering's own loop | bound is `__ESBMC_list_size(...)` |
+| `remove` | `list.c:1208`, the **shift** loop | starts at the symbolic found-index, so `j < l->size - 1` stays open |
+
+The `remove` row is worth stating plainly: #7361, the origin of this plan, split
+that routine's search and shift loops. The **search** loop now runs exactly *n*
+times. The **shift** loop still unwinds to the bound, because after the search
+`j` begins at a symbolic index. The fix that named this defect class left a
+residue of it behind.
+
+**W4 (revised).** Give a list model's loop a bound symex can decide when the
+list length is statically known. One change, four operations, and it is the
+same residual already flagged in #7436's description for slicing. `remove`
+needs more than a constant length — its start index is genuinely symbolic
+whenever the searched-for element is — so it may not fall to the same fix and
+should be measured separately before being assumed in scope.
+
+**The original W4 is not dropped, but it is not this plan.** Constant-folding
+list operations remains worthwhile on its own terms; it belongs in a
+frontend-performance item, not here, and should not be justified by this plan's
+screening test.
 
 ---
 
@@ -382,28 +428,49 @@ treatment is open.
 | W2 | Python OM + frontend | W6 | fix pattern already in the same file |
 | W3 | Python OM | W2 | shares W2's mechanism |
 | W5.1 | C++ OM | all others | `realloc` in `reserve` |
-| W4 | Python frontend | W1, W3 | largest, subsumes their common case |
+| W4 (revised) | Python models + frontend | W1–W3, W6 | decidable loop bounds; see §6.3 |
 | W5.2 | symex core | W5.1 | investigation, not a specified change |
 
 W6 and W1–W3 overlap deliberately: W6 makes the fallback cheap, W1–W3 stop
 reaching it. Either alone is an improvement; both together are the correct end
 state, because a model should not depend on an intrinsic's cap to be affordable.
 
+The order above was written before anything was built, and §10 warned it was
+ranked by reach rather than measured savings. W6 was ranked first for widest
+reach; that was wrong for the Python models, because a pointer with more than
+one candidate object defeats `memcmp_resolve_operand` before `n` is considered
+at all — 8 unwindings with two candidates against 0 with one, at *constant* `n`.
+Every Python list payload is its own `alloca`, so W6 does not fire there. W1–W3
+sidestep the intrinsic instead of relying on it, which is why they carried the
+Python gains.
+
 ---
 
 ## 10. What this plan does *not* establish
 
-- **No fix has been written, built or verified.** Every "fix" above is a
-  proposal derived from the measurement, not a tested change.
+- **W1, W2, W3, W5.1 and W6 are implemented and in review; nothing is merged.**
+  The measurements quoted inside each section are the survey's, taken before any
+  patch; the before/after numbers live in the pull requests. W4 was re-scoped
+  rather than implemented (§6) and W5.2 is still unlocalised, so two of the
+  seven items remain proposals.
 - **No verdict changes were observed or looked for.** Every program measured
   returns `VERIFICATION SUCCESSFUL` on master; this plan is about cost, and none
   of the items is a soundness finding.
 - **W5's symex half (§7, level 2) is unlocalised.** The reduction identifies the
   trigger; it does not identify the code that responds to it.
 - **The regression-suite impact is unmeasured.** How much of the suite's wall
-  time these items account for has not been quantified, so the ordering in §9 is
-  by reach and cost of the change, not by measured suite savings.
+  time these items account for has not been quantified, so the ordering in §9
+  was by reach and cost of the change, not by measured suite savings — which is
+  why it needed the correction recorded there.
 - **Per the repo's own rule, each item needs a regression *pair* and a
   mutation check.** For cost-only changes the pair pins the semantics the fix
-  must preserve, not the cost; a cost regression needs its own counted oracle,
-  which does not yet exist in `regression/`.
+  must preserve, and passes both before and after — so it cannot be
+  mutation-checked by reverting the fix, and must be checked against a
+  deliberately *wrong* version of the change instead.
+- **The counted cost oracle this section called for now exists.** Each
+  implemented item carries a test pinning `^Generated [0-9]{1,N} VCC\(s\)` at a
+  bound chosen so the digit count separates the patched binary from the
+  unpatched one, following the exact-count precedent in
+  `regression/esbmc/descending_pointer_walk`. Pick N by measurement: at
+  `--unwind 40` W5.1's control still fitted four digits and the oracle did not
+  bite, which `--unwind 80` fixed.


### PR DESCRIPTION
Re-running the plan's own screening test — hold the program constant, raise
`--unwind` — on a build carrying W1, W2 and W3 shows that every operation W4
named is **flat in the bound**, so none of them is in this plan's defect class:

| operation, n=16 | u20 | u40 | u60 | tax |
|---|---:|---:|---:|---|
| `index` / `count` | 939 | 939 | 939 | no |
| `x in xs` | 1894 | 1894 | 1894 | no |
| `xs == ys` | 3671 | 3671 | 3671 | no |
| `copy` | 3513 | 3513 | 3513 | no |
| **`remove`** | 2122 | 2382 | 2642 | **yes** |
| **`sum`** | 2637 | 4337 | 6037 | **yes** |
| **`max`** | 2762 | 4502 | 6242 | **yes** |
| **`xs[1:]`** | 4556 | 8136 | 11716 | **yes** |

`[10, 20, 30].index(20)` is also already folded today (1 VCC).

The four taxed rows share one cause — a loop whose trip count symex cannot
decide — so W4 becomes that single item instead of a folding campaign. Notably
`remove`'s **shift** loop still unwinds to the bound: #7361 split it from the
search loop, but the shift starts at a symbolic index, so the fix that named
this defect class left a residue of it behind.

Also records that §9's W6-first ordering was wrong for the Python models — a
pointer with two candidate objects defeats `memcmp_resolve_operand` before `n`
is considered, and every Python list payload is its own `alloca` — and refreshes
the status and non-claims sections. Constant folding is not dropped, just moved
out of this plan.

No code changes.