### PR TITLE
[python] Return the list size directly so len() folds

### DIFF
--- a/regression/humaneval/humaneval_33/test.desc
+++ b/regression/humaneval/humaneval_33/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/humaneval/humaneval_37/test.desc
+++ b/regression/humaneval/humaneval_37/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 20 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3003_4_fail/test.desc
+++ b/regression/python/github_3003_4_fail/test.desc
@@ -1,5 +1,6 @@
 CORE
 main.py
 --multi-property --unwind 2 --no-bounds-check --no-pointer-check
-^\*\* 1 of 4 properties failed, 3 passed$
+^\*\* 2 of 5 properties failed, 3 passed$
 ^ +FAILED .*line +6 +assertion l != 0$
+^ +FAILED .*TypeError: object of this type has no len\(\)$

--- a/regression/python/github_4782_object_size/main.py
+++ b/regression/python/github_4782_object_size/main.py
@@ -3,8 +3,9 @@
 # graph traversal) used to dereference an empty/non-array deref item and crash
 # — SIGSEGV in release, assertion failure in debug. #5658 replaced the crash
 # (and the clean-diagnostic abort that followed it) with a nondet size model,
-# so this case no longer aborts, but the recursive set-based DFS still hits a
-# separate symbolic-list-size symex wall and times out — stays KNOWNBUG.
+# so this case no longer aborts. The recursive set-based DFS then hit a separate
+# symbolic-list-size symex wall and timed out; folding len() to the list's own
+# size closed that, and the case now verifies.
 class Node:
     def __init__(self, value=None, successors=[]):
         self.value = value

--- a/regression/python/github_4782_object_size/test.desc
+++ b/regression/python/github_4782_object_size/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_len_foldable_bound/main.py
+++ b/regression/python/list_len_foldable_bound/main.py
@@ -1,0 +1,22 @@
+# len() returns the list's size directly, so a loop bounded by it unwinds the
+# list's own length rather than --unwind. sum(), max(), min() and the slice
+# lowering are all bounded that way.
+xs = [3, 1, 4, 1, 5]
+
+assert len(xs) == 5
+assert sum(xs) == 14
+assert max(xs) == 5
+assert min(xs) == 1
+assert len(xs[1:]) == 4
+
+i: int = 0
+total: int = 0
+while i < len(xs):
+    total = total + xs[i]
+    i = i + 1
+assert total == 14
+
+xs.append(9)
+assert len(xs) == 6
+xs.pop()
+assert len(xs) == 5

--- a/regression/python/list_len_foldable_bound/test.desc
+++ b/regression/python/list_len_foldable_bound/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_len_foldable_bound_fail/main.py
+++ b/regression/python/list_len_foldable_bound_fail/main.py
@@ -1,0 +1,22 @@
+# len() returns the list's size directly, so a loop bounded by it unwinds the
+# list's own length rather than --unwind. sum(), max(), min() and the slice
+# lowering are all bounded that way.
+xs = [3, 1, 4, 1, 5]
+
+assert len(xs) == 5
+assert sum(xs) == 88
+assert max(xs) == 5
+assert min(xs) == 1
+assert len(xs[1:]) == 4
+
+i: int = 0
+total: int = 0
+while i < len(xs):
+    total = total + xs[i]
+    i = i + 1
+assert total == 14
+
+xs.append(9)
+assert len(xs) == 6
+xs.pop()
+assert len(xs) == 5

--- a/regression/python/list_len_foldable_bound_fail/test.desc
+++ b/regression/python/list_len_foldable_bound_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 12
+^VERIFICATION FAILED$
+^ *FAILED .*assertion .*sum.* == 88$

--- a/regression/python/list_len_unwind_invariant/main.py
+++ b/regression/python/list_len_unwind_invariant/main.py
@@ -1,0 +1,11 @@
+# A loop bounded by len() must cost the same at any --unwind: the bound folds
+# to the list's length. Before len() returned the size directly this was 1270,
+# 2230 and 3190 symex assignments at --unwind 20, 40 and 60; it is now 418.
+# In VCCs at --unwind 40: 1380 before, 276 after.
+xs = [1, 2, 3, 4]
+i: int = 0
+total: int = 0
+while i < len(xs):
+    total = total + xs[i]
+    i = i + 1
+assert total == 10

--- a/regression/python/list_len_unwind_invariant/test.desc
+++ b/regression/python/list_len_unwind_invariant/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 40
+^VERIFICATION SUCCESSFUL$
+^Generated [0-9]{1,3} VCC\(s\)

--- a/regression/quixbugs/next_permutation_fail/test.desc
+++ b/regression/quixbugs/next_permutation_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 3 --no-bounds-check --no-pointer-check --no-align-check --no-div-by-zero-check
 ^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -92,7 +92,15 @@ PyListObject *__ESBMC_list_create()
 
 size_t __ESBMC_list_size(const PyListObject *l)
 {
-  return l ? l->size : 0;
+  // Assert the null case rather than folding it to 0 with a conditional: a
+  // `l ? l->size : 0` return does not constant-propagate even when l is a
+  // concrete address, so every loop bounded by len() -- sum(), max(), the
+  // slice lowering -- unwound to --unwind instead of the list's own length
+  // (docs/roadmap/symex-dead-work-cost-plan.md W4). An assert keeps the null
+  // case reported, which is closer to CPython's TypeError than silently
+  // answering 0.
+  __ESBMC_assert(l != NULL, "TypeError: object of this type has no len()");
+  return l->size;
 }
 
 // ptr_free=1: payload has no pointer field, so we can reinterpret it as

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -100,6 +100,11 @@ size_t __ESBMC_list_size(const PyListObject *l)
   // case reported, which is closer to CPython's TypeError than silently
   // answering 0.
   __ESBMC_assert(l != NULL, "TypeError: object of this type has no len()");
+  // The claim above reports the null case; without also assuming it away the
+  // read below still runs on the failing path (--multi-property keeps going
+  // past a violated claim), dereferencing NULL for a garbage size and a
+  // spurious out-of-bounds report downstream.
+  __ESBMC_assume(l != NULL);
   return l->size;
 }
 


### PR DESCRIPTION
`__ESBMC_list_size` returned `l ? l->size : 0`, and a conditional on a pointer
does not constant-propagate even when `l` is a concrete address. Reduced to C,
a function returning `l->size` folds a `len()`-bounded loop to 4 unwindings;
the ternary form unwinds to `--unwind`. Direct field reads and writes through a
pointer parameter both fold — only the ternary loses it.

Every loop bounded by `len()` paid for that: `sum()`, `max()`, `min()` and the
slice lowering. Asserting the null case instead reports it rather than silently
answering 0 — closer to CPython's `TypeError` — and lets the bound fold.

| n=16, assignments | u20 | u40 | u60 |
|---|---:|---:|---:|
| `sum(xs)` before | 2637 | 4337 | 6037 |
| `sum(xs)` after | 1961 | 1961 | 1961 |
| `max(xs)` before | 2762 | 4502 | 6242 |
| `max(xs)` after | 1991 | 1991 | 1991 |
| `len()`-bounded loop before | 1270 | 2230 | 3190 |
| `len()`-bounded loop after | 418 | 418 | 418 |

**Mode C.** The removed null arm is unreachable across six drivers under both
Bitwuzla and Z3; forcing the probe makes every driver report
`reachability: unreachable code reached`, so those passes are not vacuous.

Note this also speeds up slicing, which #7436 addresses by a different route
(the element-copy width). The two overlap on `xs[1:]` and the gains are not
additive; each is measured against master independently.

Revised W4 of `docs/roadmap/symex-dead-work-cost-plan.md` (see #7439).