### PR TITLE
[regression] Add a consensus regression suite for ethcheck/spec.py

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -226,6 +226,7 @@ endif()
 if(ENABLE_PYTHON_FRONTEND)
     set(REGRESSIONS_PYTHON python)
     set(REGRESSIONS_PYTHON_INTENSIVE python-intensive)
+    set(REGRESSIONS_CONSENSUS consensus)
     set(REGRESSIONS_MOPSA mopsa)
     set(REGRESSIONS_NUMPY numpy)
     set(REGRESSIONS_HUMANEVAL humaneval)
@@ -340,6 +341,7 @@ if(APPLE)
                     ${REGRESSIONS_CHERI}
                     ${REGRESSIONS_PYTHON}
                     ${REGRESSIONS_PYTHON_INTENSIVE}
+                    ${REGRESSIONS_CONSENSUS}
                     ${REGRESSIONS_MOPSA}
                     ${REGRESSIONS_NUMPY}
                     ${REGRESSIONS_HUMANEVAL}
@@ -415,6 +417,7 @@ else()
                     ${REGRESSIONS_CHERI}
                     ${REGRESSIONS_PYTHON}
                     ${REGRESSIONS_PYTHON_INTENSIVE}
+                    ${REGRESSIONS_CONSENSUS}
                     ${REGRESSIONS_MOPSA}
                     ${REGRESSIONS_NUMPY}
                     ${REGRESSIONS_HUMANEVAL}

--- a/regression/consensus/bls_field_to_bytes/main.py
+++ b/regression/consensus/bls_field_to_bytes/main.py
@@ -1,0 +1,20 @@
+class uint256(int):
+    pass
+
+
+class BLSFieldElement(uint256):
+    pass
+
+
+Bytes32 = bytes
+
+
+BLS_MODULUS = 123
+
+
+KZG_ENDIANNESS = 'big'
+
+
+def bls_field_to_bytes(x: BLSFieldElement) -> Bytes32:
+    return int.to_bytes(x % BLS_MODULUS, 32, KZG_ENDIANNESS)
+

--- a/regression/consensus/bls_field_to_bytes/test.desc
+++ b/regression/consensus/bls_field_to_bytes/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc --function bls_field_to_bytes
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/bytes_to_uint64/main.py
+++ b/regression/consensus/bytes_to_uint64/main.py
@@ -1,0 +1,13 @@
+class uint64(int):
+    pass
+
+
+ENDIANNESS = 'little'
+
+
+def bytes_to_uint64(data: bytes) -> uint64:
+    """
+    Return the integer deserialization of ``data`` interpreted as ``ENDIANNESS``-endian.
+    """
+    return uint64(int.from_bytes(data, ENDIANNESS))
+

--- a/regression/consensus/bytes_to_uint64/test.desc
+++ b/regression/consensus/bytes_to_uint64/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function bytes_to_uint64
+^VERIFICATION FAILED$

--- a/regression/consensus/ceillog2/main.py
+++ b/regression/consensus/ceillog2/main.py
@@ -1,0 +1,9 @@
+class uint64(int):
+    pass
+
+
+def ceillog2(x: int) -> uint64:
+    if x < 1:
+        raise ValueError(f"ceillog2 accepts only positive values, x={x}")
+    return uint64((x - 1).bit_length())
+

--- a/regression/consensus/ceillog2/test.desc
+++ b/regression/consensus/ceillog2/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc --function ceillog2
+^VERIFICATION FAILED$

--- a/regression/consensus/compute_activation_exit_epoch/main.py
+++ b/regression/consensus/compute_activation_exit_epoch/main.py
@@ -1,0 +1,17 @@
+class uint64(int):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+MAX_SEED_LOOKAHEAD = uint64(4)
+
+
+def compute_activation_exit_epoch(epoch: Epoch) -> Epoch:
+    """
+    Return the epoch during which validator activations and exits initiated in ``epoch`` take effect.
+    """
+    return Epoch(epoch + 1 + MAX_SEED_LOOKAHEAD)
+

--- a/regression/consensus/compute_activation_exit_epoch/test.desc
+++ b/regression/consensus/compute_activation_exit_epoch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function compute_activation_exit_epoch
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/compute_epoch_at_slot/main.py
+++ b/regression/consensus/compute_epoch_at_slot/main.py
@@ -1,0 +1,21 @@
+class uint64(int):
+    pass
+
+
+class Slot(uint64):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+SLOTS_PER_EPOCH = uint64(32)
+
+
+def compute_epoch_at_slot(slot: Slot) -> Epoch:
+    """
+    Return the epoch number at ``slot``.
+    """
+    return Epoch(slot // SLOTS_PER_EPOCH)
+

--- a/regression/consensus/compute_epoch_at_slot/test.desc
+++ b/regression/consensus/compute_epoch_at_slot/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function compute_epoch_at_slot
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/compute_start_slot_at_epoch/main.py
+++ b/regression/consensus/compute_start_slot_at_epoch/main.py
@@ -1,0 +1,21 @@
+class uint64(int):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+class Slot(uint64):
+    pass
+
+
+SLOTS_PER_EPOCH = uint64(32)
+
+
+def compute_start_slot_at_epoch(epoch: Epoch) -> Slot:
+    """
+    Return the start slot of ``epoch``.
+    """
+    return Slot(epoch * SLOTS_PER_EPOCH)
+

--- a/regression/consensus/compute_start_slot_at_epoch/test.desc
+++ b/regression/consensus/compute_start_slot_at_epoch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function compute_start_slot_at_epoch
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/compute_sync_committee_period/main.py
+++ b/regression/consensus/compute_sync_committee_period/main.py
@@ -1,0 +1,14 @@
+class uint64(int):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD = uint64(256)
+
+
+def compute_sync_committee_period(epoch: Epoch) -> uint64:
+    return epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+

--- a/regression/consensus/compute_sync_committee_period/test.desc
+++ b/regression/consensus/compute_sync_committee_period/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function compute_sync_committee_period
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/compute_sync_committee_period_at_slot/main.py
+++ b/regression/consensus/compute_sync_committee_period_at_slot/main.py
@@ -1,0 +1,32 @@
+class uint64(int):
+    pass
+
+
+class Slot(uint64):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD = uint64(256)
+
+
+def compute_sync_committee_period(epoch: Epoch) -> uint64:
+    return epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+
+
+SLOTS_PER_EPOCH = uint64(32)
+
+
+def compute_epoch_at_slot(slot: Slot) -> Epoch:
+    """
+    Return the epoch number at ``slot``.
+    """
+    return Epoch(slot // SLOTS_PER_EPOCH)
+
+
+def compute_sync_committee_period_at_slot(slot: Slot) -> uint64:
+    return compute_sync_committee_period(compute_epoch_at_slot(slot))
+

--- a/regression/consensus/compute_sync_committee_period_at_slot/test.desc
+++ b/regression/consensus/compute_sync_committee_period_at_slot/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function compute_sync_committee_period_at_slot
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/current_sync_committee_gindex_at_slot/main.py
+++ b/regression/consensus/current_sync_committee_gindex_at_slot/main.py
@@ -1,0 +1,19 @@
+class uint64(int):
+    pass
+
+
+class Slot(uint64):
+    pass
+
+
+class GeneralizedIndex(int):
+    pass
+
+
+CURRENT_SYNC_COMMITTEE_GINDEX = GeneralizedIndex(54)
+
+
+def current_sync_committee_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+    # pylint: disable=unused-argument
+    return CURRENT_SYNC_COMMITTEE_GINDEX
+

--- a/regression/consensus/current_sync_committee_gindex_at_slot/test.desc
+++ b/regression/consensus/current_sync_committee_gindex_at_slot/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function current_sync_committee_gindex_at_slot
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/finalized_root_gindex_at_slot/main.py
+++ b/regression/consensus/finalized_root_gindex_at_slot/main.py
@@ -1,0 +1,19 @@
+class uint64(int):
+    pass
+
+
+class Slot(uint64):
+    pass
+
+
+class GeneralizedIndex(int):
+    pass
+
+
+FINALIZED_ROOT_GINDEX = GeneralizedIndex(105)
+
+
+def finalized_root_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+    # pylint: disable=unused-argument
+    return FINALIZED_ROOT_GINDEX
+

--- a/regression/consensus/finalized_root_gindex_at_slot/test.desc
+++ b/regression/consensus/finalized_root_gindex_at_slot/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function finalized_root_gindex_at_slot
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/floorlog2/main.py
+++ b/regression/consensus/floorlog2/main.py
@@ -1,0 +1,9 @@
+class uint64(int):
+    pass
+
+
+def floorlog2(x: int) -> uint64:
+    if x < 1:
+        raise ValueError(f"floorlog2 accepts only positive values, x={x}")
+    return uint64(x.bit_length() - 1)
+

--- a/regression/consensus/floorlog2/test.desc
+++ b/regression/consensus/floorlog2/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc --function floorlog2
+^VERIFICATION FAILED$

--- a/regression/consensus/get_current_epoch/main.py
+++ b/regression/consensus/get_current_epoch/main.py
@@ -1,0 +1,37 @@
+class uint64(int):
+    pass
+
+
+Root = bytes
+
+
+class Slot(uint64):
+    pass
+
+
+class BeaconState:
+    genesis_time: uint64
+    genesis_validators_root: Root
+    slot: Slot
+
+
+class Epoch(uint64):
+    pass
+
+
+SLOTS_PER_EPOCH = uint64(32)
+
+
+def compute_epoch_at_slot(slot: Slot) -> Epoch:
+    """
+    Return the epoch number at ``slot``.
+    """
+    return Epoch(slot // SLOTS_PER_EPOCH)
+
+
+def get_current_epoch(state: BeaconState) -> Epoch:
+    """
+    Return the current epoch.
+    """
+    return compute_epoch_at_slot(state.slot)
+

--- a/regression/consensus/get_current_epoch/test.desc
+++ b/regression/consensus/get_current_epoch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function get_current_epoch
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/get_previous_epoch/main.py
+++ b/regression/consensus/get_previous_epoch/main.py
@@ -1,0 +1,48 @@
+class uint64(int):
+    pass
+
+
+Root = bytes
+
+
+class Slot(uint64):
+    pass
+
+
+class BeaconState:
+    genesis_time: uint64
+    genesis_validators_root: Root
+    slot: Slot
+
+
+class Epoch(uint64):
+    pass
+
+
+GENESIS_EPOCH = Epoch(0)
+
+
+SLOTS_PER_EPOCH = uint64(32)
+
+
+def compute_epoch_at_slot(slot: Slot) -> Epoch:
+    """
+    Return the epoch number at ``slot``.
+    """
+    return Epoch(slot // SLOTS_PER_EPOCH)
+
+
+def get_current_epoch(state: BeaconState) -> Epoch:
+    """
+    Return the current epoch.
+    """
+    return compute_epoch_at_slot(state.slot)
+
+
+def get_previous_epoch(state: BeaconState) -> Epoch:
+    """
+    Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
+    """
+    current_epoch = get_current_epoch(state)
+    return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else Epoch(current_epoch - 1)
+

--- a/regression/consensus/get_previous_epoch/test.desc
+++ b/regression/consensus/get_previous_epoch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function get_previous_epoch
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/get_subtree_index/main.py
+++ b/regression/consensus/get_subtree_index/main.py
@@ -1,0 +1,17 @@
+class GeneralizedIndex(int):
+    pass
+
+
+class uint64(int):
+    pass
+
+
+def floorlog2(x: int) -> uint64:
+    if x < 1:
+        raise ValueError(f"floorlog2 accepts only positive values, x={x}")
+    return uint64(x.bit_length() - 1)
+
+
+def get_subtree_index(generalized_index: GeneralizedIndex) -> uint64:
+    return uint64(generalized_index % 2**(floorlog2(generalized_index)))
+

--- a/regression/consensus/get_subtree_index/test.desc
+++ b/regression/consensus/get_subtree_index/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc --function get_subtree_index
+^VERIFICATION FAILED$

--- a/regression/consensus/hash_to_bls_field/main.py
+++ b/regression/consensus/hash_to_bls_field/main.py
@@ -1,0 +1,22 @@
+# hash() is not defined here: ESBMC's Python frontend routes it to the
+# operational-model stub in src/python-frontend/models/consensus.py.
+
+class uint256(int):
+    pass
+
+
+class BLSFieldElement(uint256):
+    pass
+
+
+KZG_ENDIANNESS = 'big'
+
+
+def hash_to_bls_field(data: bytes) -> BLSFieldElement:
+    """
+    Hash ``data`` and convert the output to a BLS scalar field element.
+    The output is not uniform over the BLS field.
+    """
+    hashed_data = hash(data)
+    return BLSFieldElement(int.from_bytes(hashed_data, KZG_ENDIANNESS)) #% BLS_MODULUS)
+

--- a/regression/consensus/hash_to_bls_field/test.desc
+++ b/regression/consensus/hash_to_bls_field/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function hash_to_bls_field
+^VERIFICATION FAILED$

--- a/regression/consensus/integer_squareroot/main.py
+++ b/regression/consensus/integer_squareroot/main.py
@@ -1,0 +1,23 @@
+class uint64(int):
+    pass
+
+
+UINT64_MAX = uint64(2**64 - 1)
+
+
+UINT64_MAX_SQRT = uint64(4294967295)
+
+
+def integer_squareroot(n: uint64) -> uint64:
+    """
+    Return the largest integer ``x`` such that ``x**2 <= n``.
+    """
+    if n == UINT64_MAX:
+        return UINT64_MAX_SQRT
+    x = n
+    y = (x + 1) // 2
+    while y < x:
+        x = y
+        y = (x + n // x) // 2
+    return x
+

--- a/regression/consensus/integer_squareroot/test.desc
+++ b/regression/consensus/integer_squareroot/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc --function integer_squareroot --unwind 8 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/is_active_validator/main.py
+++ b/regression/consensus/is_active_validator/main.py
@@ -1,0 +1,34 @@
+Bytes32 = bytes
+
+
+class uint64(int):
+    pass
+
+
+class Gwei(uint64):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+class Validator:#(Container):
+#    pubkey: BLSPubkey
+    withdrawal_credentials: Bytes32  # Commitment to pubkey for withdrawals
+    effective_balance: Gwei  # Balance at stake
+#    slashed: boolean
+    slashed: bool
+    # Status epochs
+    activation_eligibility_epoch: Epoch  # When criteria for activation were met
+    activation_epoch: Epoch
+    exit_epoch: Epoch
+    withdrawable_epoch: Epoch  # When validator can withdraw funds
+
+
+def is_active_validator(validator: Validator, epoch: Epoch) -> bool:
+    """
+    Check if ``validator`` is active.
+    """
+    return validator.activation_epoch <= epoch < validator.exit_epoch
+

--- a/regression/consensus/is_active_validator/test.desc
+++ b/regression/consensus/is_active_validator/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function is_active_validator
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/is_eligible_for_activation_queue/main.py
+++ b/regression/consensus/is_eligible_for_activation_queue/main.py
@@ -1,0 +1,43 @@
+Bytes32 = bytes
+
+
+class uint64(int):
+    pass
+
+
+class Gwei(uint64):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+class Validator:#(Container):
+#    pubkey: BLSPubkey
+    withdrawal_credentials: Bytes32  # Commitment to pubkey for withdrawals
+    effective_balance: Gwei  # Balance at stake
+#    slashed: boolean
+    slashed: bool
+    # Status epochs
+    activation_eligibility_epoch: Epoch  # When criteria for activation were met
+    activation_epoch: Epoch
+    exit_epoch: Epoch
+    withdrawable_epoch: Epoch  # When validator can withdraw funds
+
+
+FAR_FUTURE_EPOCH = Epoch(2**64 - 1)
+
+
+MAX_EFFECTIVE_BALANCE = Gwei(32000000000)
+
+
+def is_eligible_for_activation_queue(validator: Validator) -> bool:
+    """
+    Check if ``validator`` is eligible to be placed into the activation queue.
+    """
+    return (
+        validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
+        and validator.effective_balance == MAX_EFFECTIVE_BALANCE
+    )
+

--- a/regression/consensus/is_eligible_for_activation_queue/test.desc
+++ b/regression/consensus/is_eligible_for_activation_queue/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc --function is_eligible_for_activation_queue
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/is_power_of_two/main.py
+++ b/regression/consensus/is_power_of_two/main.py
@@ -1,0 +1,7 @@
+# Polynomial commitments
+def is_power_of_two(value: int) -> bool:
+    """
+    Check if ``value`` is a power of two integer.
+    """
+    return (value > 0) and (value & (value - 1) == 0)
+

--- a/regression/consensus/is_power_of_two/test.desc
+++ b/regression/consensus/is_power_of_two/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function is_power_of_two
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/is_shuffling_stable/main.py
+++ b/regression/consensus/is_shuffling_stable/main.py
@@ -1,0 +1,14 @@
+class uint64(int):
+    pass
+
+
+class Slot(uint64):
+    pass
+
+
+SLOTS_PER_EPOCH = uint64(32)
+
+
+def is_shuffling_stable(slot: Slot) -> bool:
+    return slot % SLOTS_PER_EPOCH != 0
+

--- a/regression/consensus/is_shuffling_stable/test.desc
+++ b/regression/consensus/is_shuffling_stable/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function is_shuffling_stable
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/is_slashable_validator/main.py
+++ b/regression/consensus/is_slashable_validator/main.py
@@ -1,0 +1,34 @@
+Bytes32 = bytes
+
+
+class uint64(int):
+    pass
+
+
+class Gwei(uint64):
+    pass
+
+
+class Epoch(uint64):
+    pass
+
+
+class Validator:#(Container):
+#    pubkey: BLSPubkey
+    withdrawal_credentials: Bytes32  # Commitment to pubkey for withdrawals
+    effective_balance: Gwei  # Balance at stake
+#    slashed: boolean
+    slashed: bool
+    # Status epochs
+    activation_eligibility_epoch: Epoch  # When criteria for activation were met
+    activation_epoch: Epoch
+    exit_epoch: Epoch
+    withdrawable_epoch: Epoch  # When validator can withdraw funds
+
+
+def is_slashable_validator(validator: Validator, epoch: Epoch) -> bool:
+    """
+    Check if ``validator`` is slashable.
+    """
+    return (not validator.slashed) and (validator.activation_epoch <= epoch < validator.withdrawable_epoch)
+

--- a/regression/consensus/is_slashable_validator/test.desc
+++ b/regression/consensus/is_slashable_validator/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function is_slashable_validator
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/next_sync_committee_gindex_at_slot/main.py
+++ b/regression/consensus/next_sync_committee_gindex_at_slot/main.py
@@ -1,0 +1,19 @@
+class uint64(int):
+    pass
+
+
+class Slot(uint64):
+    pass
+
+
+class GeneralizedIndex(int):
+    pass
+
+
+NEXT_SYNC_COMMITTEE_GINDEX = GeneralizedIndex(55)
+
+
+def next_sync_committee_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
+    # pylint: disable=unused-argument
+    return NEXT_SYNC_COMMITTEE_GINDEX
+

--- a/regression/consensus/next_sync_committee_gindex_at_slot/test.desc
+++ b/regression/consensus/next_sync_committee_gindex_at_slot/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function next_sync_committee_gindex_at_slot
+^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/saturating_sub/main.py
+++ b/regression/consensus/saturating_sub/main.py
@@ -1,0 +1,6 @@
+def saturating_sub(a: int, b: int) -> int:
+    """
+    Computes a - b, saturating at numeric bounds.
+    """
+    return a - b if a > b else 0
+

--- a/regression/consensus/saturating_sub/test.desc
+++ b/regression/consensus/saturating_sub/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --function saturating_sub
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
ethcheck (esbmc/ethcheck) runs ESBMC against a set of Ethereum consensus specification functions.
This PR adds a regression/consensus/<fn> folder per function so a future change to the Python frontend can't quietly break that support.