### PR TITLE
[goto-programs] Synthesise affine loop invariants for k-induction

### DIFF
--- a/regression/esbmc/synth_loop_invariant_branchy/main.c
+++ b/regression/esbmc/synth_loop_invariant_branchy/main.c
@@ -1,0 +1,22 @@
+/* The body branches, so the per-iteration effect is not affine and the
+ * recogniser declines. Declining must stay silent and must not disturb the
+ * verdict: the loop is bounded, so BMC still proves the property. */
+#include <assert.h>
+
+int main(void)
+{
+  unsigned int i = 0;
+  unsigned int s = 0;
+
+  while (i < 6)
+  {
+    if (i % 2 == 0)
+      s = s + 1;
+    else
+      s = s + 2;
+    i++;
+  }
+
+  assert(s == 9);
+  return 0;
+}

--- a/regression/esbmc/synth_loop_invariant_branchy/test.desc
+++ b/regression/esbmc/synth_loop_invariant_branchy/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--synthesise-loop-invariants
+\A(?![\s\S]*Synthesised loop invariants)[\s\S]*\Z
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/synth_loop_invariant_call/main.c
+++ b/regression/esbmc/synth_loop_invariant_call/main.c
@@ -1,0 +1,23 @@
+/* A call in the body can write the counter or an accumulator out of sight, so
+ * the recogniser declines rather than summarise a body it cannot see. */
+#include <assert.h>
+
+static unsigned int step(unsigned int x)
+{
+  return x + 1;
+}
+
+int main(void)
+{
+  unsigned int i = 0;
+  unsigned int s = 0;
+
+  while (i < 4)
+  {
+    s = s + step(0);
+    i = i + 1;
+  }
+
+  assert(s == 4);
+  return 0;
+}

--- a/regression/esbmc/synth_loop_invariant_call/test.desc
+++ b/regression/esbmc/synth_loop_invariant_call/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--synthesise-loop-invariants
+\A(?![\s\S]*Synthesised loop invariants)[\s\S]*\Z
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/synth_loop_invariant_counter/main.c
+++ b/regression/esbmc/synth_loop_invariant_counter/main.c
@@ -1,0 +1,15 @@
+/* Counter-only loop: the synthesised bound (i < n || i == n || i == 0) is
+ * enough on its own; no accumulator conjunct is needed. */
+#include <assert.h>
+
+int main(void)
+{
+  unsigned int n;
+  unsigned int i = 0;
+
+  while (i < n)
+    i++;
+
+  assert(i == n || n == 0);
+  return 0;
+}

--- a/regression/esbmc/synth_loop_invariant_counter/test.desc
+++ b/regression/esbmc/synth_loop_invariant_counter/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--synthesise-loop-invariants
+^Synthesised loop invariants for 1 loop$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/synth_loop_invariant_fail/main.c
+++ b/regression/esbmc/synth_loop_invariant_fail/main.c
@@ -1,0 +1,23 @@
+/* The synthesised invariant is established and preserved, but the property is
+ * genuinely false (off by one). Synthesis must not mask the violation. */
+#include <stdint.h>
+#include <assert.h>
+
+int main(void)
+{
+  uint64_t i = 1;
+  uint64_t sn = 0;
+  uint32_t n;
+  uint64_t a;
+
+  __ESBMC_assume(n >= 1);
+
+  while (i <= n)
+  {
+    sn = sn + a;
+    i++;
+  }
+
+  assert(sn == (uint64_t)n * a + 1);
+  return 0;
+}

--- a/regression/esbmc/synth_loop_invariant_fail/test.desc
+++ b/regression/esbmc/synth_loop_invariant_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--synthesise-loop-invariants
+^Synthesised loop invariants for 1 loop$
+^VERIFICATION FAILED$

--- a/regression/esbmc/synth_loop_invariant_interval/main.c
+++ b/regression/esbmc/synth_loop_invariant_interval/main.c
@@ -1,0 +1,26 @@
+/* Same program as synth_loop_invariant_sum, run with --interval-analysis.
+ * That pass rewrites the loop head into the simplified `IF i > n GOTO exit`,
+ * which has no not2t to strip, and moves the back-edge target ahead of the
+ * guard; the recogniser must still match, and the marker must still land where
+ * goto_loop_invariant's extractor searches. */
+#include <stdint.h>
+#include <assert.h>
+
+int main(void)
+{
+  uint64_t i = 1;
+  uint64_t sn = 0;
+  uint32_t n;
+  uint64_t a;
+
+  __ESBMC_assume(n >= 1);
+
+  while (i <= n)
+  {
+    sn = sn + a;
+    i++;
+  }
+
+  assert(sn == (uint64_t)n * a);
+  return 0;
+}

--- a/regression/esbmc/synth_loop_invariant_interval/test.desc
+++ b/regression/esbmc/synth_loop_invariant_interval/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--synthesise-loop-invariants --interval-analysis
+^Synthesised loop invariants for 1 loop$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/synth_loop_invariant_step2/main.c
+++ b/regression/esbmc/synth_loop_invariant_step2/main.c
@@ -1,0 +1,19 @@
+/* Non-unit step: the closed form would need a division by the step, which is a
+ * solver hazard, so the recogniser only accepts i = i + 1 and declines here.
+ * Declining must leave the verdict alone. */
+#include <assert.h>
+
+int main(void)
+{
+  unsigned int i = 0;
+  unsigned int s = 0;
+
+  while (i < 10)
+  {
+    s = s + 1;
+    i = i + 2;
+  }
+
+  assert(s == 5);
+  return 0;
+}

--- a/regression/esbmc/synth_loop_invariant_step2/test.desc
+++ b/regression/esbmc/synth_loop_invariant_step2/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--synthesise-loop-invariants
+\A(?![\s\S]*Synthesised loop invariants)[\s\S]*\Z
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/synth_loop_invariant_sum/main.c
+++ b/regression/esbmc/synth_loop_invariant_sum/main.c
@@ -1,0 +1,25 @@
+/* Affine accumulator: k-induction with --interval-analysis cannot prove this.
+ * The interval domain is non-relational, so at the loop head it knows only
+ * i in [1, UINT64_MAX] and nothing tying sn to i and a.
+ * --synthesise-loop-invariants derives sn == (i - 1) * a. */
+#include <stdint.h>
+#include <assert.h>
+
+int main(void)
+{
+  uint64_t i = 1;
+  uint64_t sn = 0;
+  uint32_t n;
+  uint64_t a;
+
+  __ESBMC_assume(n >= 1);
+
+  while (i <= n)
+  {
+    sn = sn + a;
+    i++;
+  }
+
+  assert(sn == (uint64_t)n * a);
+  return 0;
+}

--- a/regression/esbmc/synth_loop_invariant_sum/test.desc
+++ b/regression/esbmc/synth_loop_invariant_sum/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--synthesise-loop-invariants
+^Synthesised loop invariants for 1 loop$
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -565,6 +565,11 @@ const struct group_opt_templ all_cmd_options[] = {
      "Verify using loop invariant havoc abstraction (standalone mode). Cuts "
      "the loop, so cost is independent of the bound; the only mode that "
      "reasons about the loop exit condition"},
+    {"synthesise-loop-invariants",
+     NULL,
+     "Synthesise invariants for affine counter/accumulator loops and discharge "
+     "them with the loop-invariant havoc schema; implies "
+     "--loop-invariant-check and --multi-property"},
     {"loop-frame-rule",
      NULL,
      "Enable frame rule for loop invariant checking "

--- a/src/esbmc/parseoptions/command_line_options.cpp
+++ b/src/esbmc/parseoptions/command_line_options.cpp
@@ -576,6 +576,23 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     cmdline.isset("inductive-step"))
     options.set_option("add-symex-value-sets", true);
 
+  // The invariant schema emits establishment, preservation and the post-loop
+  // use as three independent obligations. Bundling them into one query makes
+  // the solver carry every multiplier term at once: on the accumulator loop in
+  // regression/esbmc/synth_loop_invariant_sum each obligation discharges in
+  // about a second alone, while the bundle does not finish in 120s. Solve them
+  // separately by default.
+  //
+  // base-case is set alongside it for the same reason the explicit
+  // --multi-property does below: multi_property_check only runs when both are
+  // on, so setting multi-property alone would silently leave the bundled
+  // encoding in place.
+  if (cmdline.isset("synthesise-loop-invariants"))
+  {
+    options.set_option("multi-property", true);
+    options.set_option("base-case", true);
+  }
+
   // Default-enable the vacuity probe under --loop-invariant-check (the
   // standalone Hoare-rewrite mode). A loop invariant that implies the guard
   // makes the post-loop continuation unreachable; without this probe every
@@ -588,7 +605,8 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   if (cmdline.isset("no-vacuity-check"))
     options.set_option("check-vacuity", false);
   else if (
-    cmdline.isset("check-vacuity") || cmdline.isset("loop-invariant-check"))
+    cmdline.isset("check-vacuity") || cmdline.isset("loop-invariant-check") ||
+    cmdline.isset("synthesise-loop-invariants"))
     options.set_option("check-vacuity", true);
 
   // Conflicting strategies: --termination checks a different property and

--- a/src/esbmc/parseoptions/process_goto_program.cpp
+++ b/src/esbmc/parseoptions/process_goto_program.cpp
@@ -32,6 +32,7 @@
 #include <esbmc/ranking_synthesis.h>
 #include <esbmc/non_termination.h>
 #include <goto-programs/goto_loop_simplify.h>
+#include <goto-programs/goto_invariant_synthesis.h>
 #include <goto-programs/goto_loop_invariant.h>
 #include <goto-programs/abstract-interpretation/interval_analysis.h>
 #include <goto-programs/abstract-interpretation/gcse.h>
@@ -441,16 +442,25 @@ bool esbmc_parseoptionst::process_goto_program(
     }
     else
     {
+      // --synthesise-loop-invariants supplies the invariants that
+      // --loop-invariant-check discharges, so it implies that mode.
+      const bool wants_loop_invariant =
+        cmdline.isset("loop-invariant-check") ||
+        cmdline.isset("synthesise-loop-invariants");
+
       // --k-induction and --loop-invariant-check are independent and may
       // both be specified.  remove_no_op only needs to run once.
-      if (is_k_induction || cmdline.isset("loop-invariant-check"))
+      if (is_k_induction || wants_loop_invariant)
         remove_no_op(goto_functions);
 
       if (is_k_induction)
         disable_is_if_unsound(goto_k_induction(goto_functions, ns));
 
-      if (cmdline.isset("loop-invariant-check"))
+      if (wants_loop_invariant)
       {
+        if (cmdline.isset("synthesise-loop-invariants"))
+          goto_synthesise_loop_invariants(goto_functions);
+
         bool use_frame_rule = cmdline.isset("loop-frame-rule");
         goto_loop_invariant(goto_functions, context, use_frame_rule);
       }

--- a/src/goto-programs/CMakeLists.txt
+++ b/src/goto-programs/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(gotoprograms goto_convert.cpp goto_function.cpp goto_main.cpp
   goto_program_serialization.cpp goto_function_serialization.cpp
   read_bin_goto_object.cpp read_cbmc_goto_object.cpp cbmc_adapter.cpp goto_program_irep.cpp format_strings.cpp
   loop_numbers.cpp goto_loops.cpp goto_loop_simplify.cpp write_goto_binary.cpp
-  goto_k_induction.cpp goto_termination.cpp loopst.cpp goto_coverage.cpp goto_coverage_rm.cpp k_path_spanning.cpp goto_cfg.cpp goto_loop_invariant.cpp
+  goto_k_induction.cpp goto_termination.cpp loopst.cpp goto_coverage.cpp goto_coverage_rm.cpp k_path_spanning.cpp goto_cfg.cpp goto_loop_invariant.cpp goto_invariant_synthesis.cpp
   goto_atomicity_check.cpp frame_enforcer.cpp contracts/contracts.cpp)
 add_library(gotoalgorithms loop_unroll.cpp mark_decl_as_non_det.cpp assign_params_as_non_det.cpp goto_check_uninit_vars.cpp goto_check_unchecked_return.cpp dead_store_analysis.cpp goto_check_excessive_alloc.cpp)
 

--- a/src/goto-programs/goto_invariant_synthesis.cpp
+++ b/src/goto-programs/goto_invariant_synthesis.cpp
@@ -1,0 +1,426 @@
+#include <goto-programs/goto_invariant_synthesis.h>
+#include <goto-programs/goto_loops.h>
+#include <goto-programs/loopst.h>
+#include <irep2/irep2_expr.h>
+#include <irep2/irep2_utils.h>
+#include <util/expr/expr_util.h>
+#include <util/irep/std_expr.h>
+#include <algorithm>
+#include <map>
+#include <vector>
+
+namespace
+{
+/// How far back from the loop head to look for the entry assignment of a
+/// counter/accumulator. The scan stops early at any control flow, so this is
+/// only a guard against walking a very long straight-line prologue.
+constexpr size_t kMaxEntryScanBack = 64;
+
+bool mentions_modified_var(
+  const expr2tc &expr,
+  const loopst::loop_varst &modified)
+{
+  if (!expr)
+    return false;
+
+  if (modified.find(expr) != modified.end())
+    return true;
+
+  bool found = false;
+  expr->foreach_operand([&modified, &found](const expr2tc &sub) {
+    if (!found && mentions_modified_var(sub, modified))
+      found = true;
+  });
+  return found;
+}
+
+/// The loop's entry condition. The head IF holds the *exit* condition: a while
+/// loop is lowered to `IF !(cond) GOTO exit`, but a pass that simplifies the
+/// guard (--interval-analysis does) leaves the equivalent `IF i > n GOTO exit`
+/// with no not2t to strip. Negate and simplify, which covers both spellings.
+bool guard_condition(const goto_programt::targett &head_if, expr2tc &cond)
+{
+  const expr2tc &g = head_if->guard;
+  if (is_nil_expr(g))
+    return false;
+
+  cond = is_not2t(g) ? to_not2t(g).value : not2tc(g);
+  simplify(cond);
+  return true;
+}
+
+/// Split `cond` into counter and bound for the `<`/`<=` shapes this pass
+/// handles, and report which one it was. Other comparisons (and decrementing
+/// loops) are left to a later revision.
+bool split_bound(
+  const expr2tc &cond,
+  expr2tc &counter,
+  expr2tc &bound,
+  bool &inclusive)
+{
+  if (is_lessthanequal2t(cond))
+  {
+    counter = to_lessthanequal2t(cond).side_1;
+    bound = to_lessthanequal2t(cond).side_2;
+    inclusive = true;
+    return true;
+  }
+  if (is_lessthan2t(cond))
+  {
+    counter = to_lessthan2t(cond).side_1;
+    bound = to_lessthan2t(cond).side_2;
+    inclusive = false;
+    return true;
+  }
+  return false;
+}
+
+/// True when the instruction cannot appear in a body this pass is willing to
+/// summarise. Branches would make the per-iteration effect conditional, and a
+/// call or return can write the counter or accumulator out of sight.
+bool breaks_straight_line(const goto_programt::targett &it)
+{
+  return it->is_goto() || it->is_function_call() || it->is_return() ||
+         it->is_throw() || it->is_catch() || it->is_atomic_begin() ||
+         it->is_atomic_end();
+}
+
+/// `lhs = lhs + addend` — the only body assignment shape recognised here.
+bool is_self_increment(
+  const expr2tc &target,
+  const expr2tc &source,
+  expr2tc &addend)
+{
+  if (!is_add2t(source))
+    return false;
+
+  const auto &add = to_add2t(source);
+  if (add.side_1 == target)
+  {
+    addend = add.side_2;
+    return true;
+  }
+  if (add.side_2 == target)
+  {
+    addend = add.side_1;
+    return true;
+  }
+  return false;
+}
+
+bool is_constant_one(const expr2tc &expr)
+{
+  return is_constant_int2t(expr) && to_constant_int2t(expr).value == 1;
+}
+
+/// True when a LOOP_INVARIANT already sits in the window goto_loop_invariant's
+/// extractor searches. Both would be folded into one conjunction, so adding a
+/// guess next to a user-written invariant risks failing the user's own proof.
+bool has_user_invariant(
+  const goto_programt::targett &head,
+  const goto_programt::targett &begin)
+{
+  goto_programt::targett it = head;
+  for (size_t steps = 0; it != begin && steps < kMaxEntryScanBack; ++steps)
+  {
+    --it;
+    if (it->is_loop_invariant())
+      return true;
+    if (breaks_straight_line(it))
+      return false;
+  }
+  return false;
+}
+
+/// Value of `var` on entry to the loop: the nearest preceding assignment in the
+/// straight-line prologue, provided its RHS cannot change inside the loop.
+/// Returns false when the scan meets control flow first, so the value we would
+/// report might not be the one that reaches the head.
+bool entry_value(
+  const goto_programt::targett &head,
+  const goto_programt::targett &begin,
+  const expr2tc &var,
+  const loopst::loop_varst &modified,
+  expr2tc &value)
+{
+  goto_programt::targett it = head;
+  for (size_t steps = 0; it != begin && steps < kMaxEntryScanBack; ++steps)
+  {
+    --it;
+
+    if (breaks_straight_line(it))
+      return false;
+
+    if (!it->is_assign())
+      continue;
+
+    const auto &assign = to_code_assign2t(it->code);
+    if (assign.target != var)
+      continue;
+
+    if (mentions_modified_var(assign.source, modified))
+      return false;
+
+    value = assign.source;
+    return true;
+  }
+  return false;
+}
+
+/// The two-disjunct bound `(i <op> B) || i == E` is established only when the
+/// counter's entry value cannot sit past the loop's exit value. Working the
+/// cases through for a constant i0:
+///
+///   `<=`, E = B+1: establishment fails iff i0 > B and i0 != B+1. At i0 == 1
+///                  the first conjunct forces B == 0, which makes E == 1 == i0,
+///                  so it cannot fail; at i0 == 0 it cannot fail either.
+///                  i0 >= 2 admits B <= i0 - 2 and does fail.
+///   `<`,  E = B:   establishment fails iff i0 > B, which only i0 == 0 rules
+///                  out.
+///
+/// Anything else would need the third disjunct `i == i0`, and that costs the
+/// solver the equality it needs at the loop exit — see the header.
+bool entry_admits_two_disjunct_bound(const expr2tc &entry, bool inclusive)
+{
+  if (!is_constant_int2t(entry))
+    return false;
+
+  const BigInt &v = to_constant_int2t(entry).value;
+  return v == 0 || (inclusive && v == 1);
+}
+
+struct accumulatort
+{
+  expr2tc var;
+  expr2tc addend;
+  expr2tc entry;
+};
+
+struct affine_loopt
+{
+  expr2tc counter;
+  expr2tc bound;
+  expr2tc counter_entry;
+  bool inclusive = true;
+  std::vector<accumulatort> accumulators;
+};
+
+/// Match the loop against the affine counter/accumulator shape. Every rejection
+/// here costs only a missed invariant, so the tests are deliberately strict.
+bool recognise_affine_loop(
+  goto_functiont &goto_function,
+  const loopst &loop,
+  goto_programt::targett &head_out,
+  affine_loopt &out)
+{
+  goto_programt::targett head = loop.effective_loop_head();
+  const goto_programt::targett exit = loop.get_original_loop_exit();
+  if (!head->is_goto() || head == exit)
+    return false;
+
+  expr2tc cond;
+  if (!guard_condition(head, cond))
+    return false;
+  if (!split_bound(cond, out.counter, out.bound, out.inclusive))
+    return false;
+
+  const auto &modified = loop.get_modified_loop_vars();
+  if (!is_symbol2t(out.counter) || modified.find(out.counter) == modified.end())
+    return false;
+  if (mentions_modified_var(out.bound, modified))
+    return false;
+
+  // Summarise the body. Anything that is not a plain assignment, or a second
+  // write to a variable we already summarised, makes the per-iteration effect
+  // something this pass cannot express in closed form.
+  std::map<std::string, std::pair<expr2tc, expr2tc>> writes;
+  for (goto_programt::targett it = std::next(head); it != exit; ++it)
+  {
+    if (breaks_straight_line(it))
+      return false;
+    if (!it->is_assign())
+      continue;
+
+    const auto &assign = to_code_assign2t(it->code);
+    if (!is_symbol2t(assign.target))
+      return false;
+
+    expr2tc addend;
+    if (!is_self_increment(assign.target, assign.source, addend))
+      return false;
+
+    if (!writes
+           .emplace(
+             assign.target->pretty(), std::make_pair(assign.target, addend))
+           .second)
+      return false;
+  }
+
+  const auto counter_write = writes.find(out.counter->pretty());
+  if (
+    counter_write == writes.end() ||
+    !is_constant_one(counter_write->second.second))
+    return false;
+
+  const goto_programt::targett begin = goto_function.body.instructions.begin();
+  if (!entry_value(head, begin, out.counter, modified, out.counter_entry))
+    return false;
+  if (!entry_admits_two_disjunct_bound(out.counter_entry, out.inclusive))
+    return false;
+
+  // Every remaining modified variable must be an accumulator whose
+  // per-iteration addend is loop-invariant. A variable we cannot classify means
+  // we have misread the loop, so reject rather than emit a summary alongside
+  // it.
+  for (const auto &var : modified)
+  {
+    if (var == out.counter)
+      continue;
+    if (!is_symbol2t(var))
+      return false;
+
+    const auto write = writes.find(var->pretty());
+    if (write == writes.end())
+      return false;
+
+    accumulatort acc;
+    acc.var = var;
+    acc.addend = write->second.second;
+    if (mentions_modified_var(acc.addend, modified))
+      return false;
+    if (!entry_value(head, begin, acc.var, modified, acc.entry))
+      return false;
+
+    out.accumulators.push_back(acc);
+  }
+
+  // loop_varst is hashed on interned-string order, which varies between runs;
+  // sort so the emitted invariants are identical across invocations.
+  std::sort(
+    out.accumulators.begin(),
+    out.accumulators.end(),
+    [](const accumulatort &a, const accumulatort &b) {
+      return a.var->pretty() < b.var->pretty();
+    });
+
+  head_out = head;
+  return true;
+}
+
+/// (i <op> B) || i == E, where E is the value the counter holds once the guard
+/// first fails. See the header for why this is a disjunction and not the
+/// tighter `i <= B + 1`, and why it stays at exactly two disjuncts.
+expr2tc build_bound_invariant(const affine_loopt &shape, const expr2tc &cond)
+{
+  expr2tc exit_value = shape.bound;
+  if (shape.inclusive)
+    exit_value = add2tc(
+      shape.bound->type, shape.bound, constant_int2tc(shape.bound->type, 1));
+
+  expr2tc inv = or2tc(
+    cond,
+    equality2tc(shape.counter, typecast2tc(shape.counter->type, exit_value)));
+  simplify(inv);
+  return inv;
+}
+
+/// s == s0 + (i - i0) * e. Exact under the wrapping arithmetic ESBMC gives the
+/// operand types: the product only depends on (i - i0) modulo the accumulator's
+/// width, so narrowing the counter difference to that width is
+/// value-preserving.
+expr2tc
+build_accumulator_invariant(const affine_loopt &shape, const accumulatort &acc)
+{
+  const type2tc &t = acc.var->type;
+  const expr2tc elapsed = typecast2tc(
+    t,
+    sub2tc(
+      shape.counter->type,
+      shape.counter,
+      typecast2tc(shape.counter->type, shape.counter_entry)));
+
+  expr2tc inv = equality2tc(
+    acc.var,
+    add2tc(
+      t,
+      typecast2tc(t, acc.entry),
+      mul2tc(t, elapsed, typecast2tc(t, acc.addend))));
+  simplify(inv);
+  return inv;
+}
+
+/// Attach the synthesised conjuncts as a LOOP_INVARIANT immediately before the
+/// loop head. A plain list insert is used rather than insert_swap: the latter
+/// moves the head's content down, which would leave the back-edge targeting the
+/// marker instead of the guard, and the extractor in goto_loop_invariant walks
+/// strictly backwards from the head and would then never see it.
+void emit_invariant(
+  goto_functiont &goto_function,
+  const goto_programt::targett &insert_before,
+  const goto_programt::targett &head,
+  const affine_loopt &shape,
+  const expr2tc &cond)
+{
+  goto_programt::instructiont inv;
+  inv.type = LOOP_INVARIANT;
+  inv.location = head->location;
+  inv.function = head->function;
+
+  inv.add_loop_invariant(build_bound_invariant(shape, cond));
+  for (const auto &acc : shape.accumulators)
+    inv.add_loop_invariant(build_accumulator_invariant(shape, acc));
+
+  goto_function.body.instructions.insert(insert_before, inv);
+}
+
+} // namespace
+
+void goto_synthesise_loop_invariants(goto_functionst &goto_functions)
+{
+  size_t synthesised = 0;
+
+  Forall_goto_functions (it, goto_functions)
+  {
+    if (!it->second.body_available || it->second.body.hide)
+      continue;
+
+    goto_loopst loops(it->first, goto_functions, it->second);
+    for (auto &loop : loops.get_loops())
+    {
+      if (loop.get_modified_loop_vars().empty())
+        continue;
+
+      goto_programt::targett head;
+      affine_loopt shape;
+      if (!recognise_affine_loop(it->second, loop, head, shape))
+        continue;
+
+      // goto_loop_invariant's extractor walks backwards from the *original*
+      // loop head, which --interval-analysis can leave pointing at an ASSUME
+      // ahead of the guard. Anchor on that instruction, not on the effective
+      // head, or the marker lands after the point the extractor searches from.
+      const goto_programt::targett anchor = loop.get_original_loop_head();
+
+      // A user-written invariant on this loop is authoritative; a synthesised
+      // one would be a second LOOP_INVARIANT that the extractor folds into the
+      // same conjunction, so a rejected guess would fail the user's proof.
+      if (has_user_invariant(anchor, it->second.body.instructions.begin()))
+        continue;
+
+      expr2tc cond;
+      if (!guard_condition(head, cond))
+        continue;
+
+      emit_invariant(it->second, anchor, head, shape, cond);
+      ++synthesised;
+    }
+  }
+
+  if (synthesised)
+    log_status(
+      "Synthesised loop invariants for {} loop{}",
+      synthesised,
+      synthesised == 1 ? "" : "s");
+
+  goto_functions.update();
+}

--- a/src/goto-programs/goto_invariant_synthesis.h
+++ b/src/goto-programs/goto_invariant_synthesis.h
@@ -1,0 +1,39 @@
+#ifndef GOTO_PROGRAMS_GOTO_INVARIANT_SYNTHESIS_H_
+#define GOTO_PROGRAMS_GOTO_INVARIANT_SYNTHESIS_H_
+
+#include <goto-programs/goto_functions.h>
+
+/// Synthesise loop invariants for affine counter/accumulator loops and attach
+/// them as LOOP_INVARIANT instructions, exactly as if the user had written
+/// __ESBMC_loop_invariant(). The subsequent goto_loop_invariant pass discharges
+/// them through its assert/havoc-assume/assert schema, so a wrong candidate
+/// fails an assertion rather than being assumed: synthesis cannot make an
+/// unsound proof, only a spurious failure or a useless invariant.
+///
+/// Recognised shape, for a loop whose head is `IF !(i <op> B) GOTO exit` with
+/// straight-line body:
+///
+///   i = i + 1                  counter, unit step
+///   s = s + e                  accumulator, e free of loop-modified vars
+///
+/// yields, with i0/s0 the entry values and E the exit value of i,
+///
+///   (i <op> B) || i == E                   counter bound
+///   s == s0 + (i - i0) * e                 accumulator closed form
+///
+/// The bound is emitted as a disjunction rather than the tighter `i <= B + 1`
+/// so that negating the guard at the loop exit yields the *equality* i == E by
+/// disjunct elimination. Substituting that equality lets the two `* e` terms
+/// share a multiplier; the inequality form instead leaves the solver proving
+/// two 64-bit multiplier circuits equivalent, which does not terminate.
+///
+/// For the same reason the bound stays at exactly two disjuncts. A third arm
+/// covering a loop that never runs (`i == i0`) is what a general entry value
+/// would need, but it leaves two multiplier branches alive at the exit and the
+/// query stops terminating; measured on the accumulator loop above, two
+/// disjuncts discharge in ~1s where three do not finish in 120s. Synthesis is
+/// therefore restricted to the entry values for which two disjuncts are already
+/// establishable — see entry_admits_two_disjunct_bound.
+void goto_synthesise_loop_invariants(goto_functionst &goto_functions);
+
+#endif /* GOTO_PROGRAMS_GOTO_INVARIANT_SYNTHESIS_H_ */


### PR DESCRIPTION
k-induction cannot prove a property that needs a relation between a loop
counter and an accumulator: the interval domain is non-relational, so at the
loop head it knows only the counter's range and nothing tying the accumulator
to it. `--synthesise-loop-invariants` recognises affine counter/accumulator
loops and emits the closed form as a `LOOP_INVARIANT`, which the existing
`goto_loop_invariant` schema discharges.

Invariants are asserted, never assumed, so a wrong candidate fails a claim
rather than producing an unsound proof. The flag is opt-in and off by default.

Motivating case (`regression/esbmc/synth_loop_invariant_sum`) goes from
`VERIFICATION UNKNOWN` under `--k-induction --interval-analysis` to
`VERIFICATION SUCCESSFUL` in about a second.

Notes for reviewers:

- The counter bound is emitted as `(i <op> B) || i == E`, not the tighter
  `i <= B + 1`. Negating the guard at the exit then yields the *equality* by
  disjunct elimination, letting the two `* e` terms share a multiplier; the
  inequality form leaves the solver proving two 64-bit multipliers equivalent
  and does not terminate. It stays at exactly two disjuncts for the same
  reason, which is why synthesis is restricted to entry values 0 and 1.
- The flag implies `--multi-property` (and `base-case`, which gates
  `multi_property_check`): the three obligations discharge in ~1s each
  separately and do not finish in 120s bundled.
- `code-reviewer` and `esbmc-coverage-pr` Mode B were not run; added-line
  coverage is unmeasured.
