### PR TITLE
[python] Solve harness_queue_lifo per claim to stop it timing out CI

### DIFF
--- a/regression/python/harness_queue_lifo/test.desc
+++ b/regression/python/harness_queue_lifo/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc --unwind 10
+--incremental-bmc --unwind 10 --multi-property
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Bundled into one query, the 59 VCCs that survive simplification gave the solver a problem whose
cost swung between 11.6s and 27.0s across identical runs -- close enough to the 120s per-test
cap to fail an unrelated PR (#7445) on a loaded macOS runner. Solved per claim the same 67
properties discharge in 4.6s with a 7% spread.

| | mean | spread over 5 runs |
|---|---|---|
| before | 12.8s | 11.6 - 27.0s (2.3x) |
| after | 4.7s | 4.59 - 4.92s (7%) |

Verdict is unchanged: `VERIFICATION SUCCESSFUL`, 0 of 67 properties failed. Full 80-test
harness suite green; the test drops from 3rd slowest to 4.77s.

Two things measured and deliberately not done, so they are not retried:

- **The bound is not the lever.** unwind 4 and 10 produce identical counts (284 generated, 59
  remaining) because the program is straight-line -- the bound only reaches loops inside the
  operational model. Dropping `--incremental-bmc` costs 30s.
- **`--multi-property` is not a general fix for the other slow harness tests.** On the four
  others in the 11-18s band it is neutral to catastrophic: `harness_math_isqrt` 11.2 -> 18.5s,
  `harness_math_lcm` 11.1 -> 15.6s, `harness_nondet_dict_size` 11.2s -> a 250s timeout. Those
  four are also stable rather than flaky (1-1.6% spread), so they are slow, not at risk.

Fixes #7461
