### PR TITLE
[contracts] Name the object a forwarded pointer addresses

### DIFF
--- a/regression/function_contract/github_7464_is_fresh_extent_too_small_fail/main.c
+++ b/regression/function_contract/github_7464_is_fresh_extent_too_small_fail/main.c
@@ -1,0 +1,23 @@
+/* The forwarded case must still check the extent, not merely stop reporting a
+ * free VALID_OBJECT. `buf` holds 4 ints; the callee's contract demands 8, so
+ * the call site cannot discharge it. */
+void callee(int *p, unsigned n)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(p, n * sizeof(int)));
+  __ESBMC_requires(n > 0);
+  __ESBMC_assigns(p[0]);
+  __ESBMC_ensures(p[0] == 1);
+  p[0] = 1;
+}
+
+void mid(int *p)
+{
+  callee(p, 8);
+}
+
+int main(void)
+{
+  int buf[4];
+  mid(buf);
+  return 0;
+}

--- a/regression/function_contract/github_7464_is_fresh_extent_too_small_fail/test.desc
+++ b/regression/function_contract/github_7464_is_fresh_extent_too_small_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--replace-call-with-contract callee
+^VERIFICATION FAILED$
+^ +FAILED.*contract requires$

--- a/regression/function_contract/github_7464_is_fresh_forwarded_ptr/main.c
+++ b/regression/function_contract/github_7464_is_fresh_forwarded_ptr/main.c
@@ -1,0 +1,24 @@
+/* A replace-side __ESBMC_is_fresh must hold for the object the pointer names,
+ * not for the syntax the call site happens to use. `buf` is the same stack
+ * array in both calls; only the second reaches the callee through a parameter. */
+void callee(int *p, unsigned n)
+{
+  __ESBMC_requires(__ESBMC_is_fresh(p, n * sizeof(int)));
+  __ESBMC_requires(n > 0);
+  __ESBMC_assigns(p[0]);
+  __ESBMC_ensures(p[0] == 1);
+  p[0] = 1;
+}
+
+void mid(int *p, unsigned n)
+{
+  callee(p, n);
+}
+
+int main(void)
+{
+  int buf[8];
+  callee(buf, 8);
+  mid(buf, 8);
+  return 0;
+}

--- a/regression/function_contract/github_7464_is_fresh_forwarded_ptr/test.desc
+++ b/regression/function_contract/github_7464_is_fresh_forwarded_ptr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--replace-call-with-contract callee
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -2665,7 +2665,13 @@ expr2tc code_contractst::replace_is_fresh_temps(
           lessthanequal2tc(off, have),
           lessthanequal2tc(n, sub2tc(size_type2(), have, off)));
 
-        return and2tc(valid_obj, or2tc(not2tc(is_dynamic), fits));
+        // The !is_dynamic escape was here because DYNAMIC_SIZE says nothing
+        // about automatic storage, so demanding the extent would have rejected
+        // every stack caller (#6542). symex now resolves DYNAMIC_SIZE and
+        // VALID_OBJECT against the object the value set names (#7464), so the
+        // extent is meaningful there too, and the escape would only make the
+        // check vacuous for exactly the callers it was meant to admit.
+        return and2tc(valid_obj, fits);
       }
     }
   }

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -953,6 +953,13 @@ protected:
    *  @param expr Expression we're replacing the contents of.
    */
   void replace_dynamic_allocation(expr2tc &expr);
+
+  /// The named object \p ptr addresses, resolved through the value set, or nil.
+  expr2tc value_set_named_object(const expr2tc &ptr);
+  bool resolve_valid_object_by_value_set(expr2tc &expr, const expr2tc &obj_ref);
+  bool resolve_dynamic_size_by_value_set(expr2tc &expr);
+  void replace_valid_object(expr2tc &expr);
+  void replace_dynamic_size(expr2tc &expr);
   void default_replace_dynamic_allocation(expr2tc &expr);
 
   /**

--- a/src/goto-symex/symex_valid_object.cpp
+++ b/src/goto-symex/symex_valid_object.cpp
@@ -20,6 +20,131 @@ static const expr2tc *get_object(const expr2tc &expr)
   return nullptr;
 }
 
+/// The named object \p ptr addresses, resolved through the value set, or nil.
+///
+/// A pointer reaching a check through a parameter or a local variable is a
+/// plain symbol, so the syntactic address_of tests below find no name and the
+/// check falls back on __ESBMC_alloc and DYNAMIC_SIZE. Neither is maintained
+/// for automatic storage, so the solver may pick a live stack object invalid
+/// or size it arbitrarily, and a caller cannot discharge an is_fresh
+/// precondition it plainly satisfies (#7464).
+expr2tc goto_symext::value_set_named_object(const expr2tc &ptr)
+{
+  expr2tc p = ptr;
+  while (is_typecast2t(p))
+    p = to_typecast2t(p).from;
+
+  if (is_address_of2t(p) || !is_pointer_type(p->type))
+    return expr2tc();
+
+  value_setst::valuest targets;
+  cur_state->value_set.get_value_set(p, targets);
+  if (targets.size() != 1 || !is_object_descriptor2t(targets.front()))
+    return expr2tc();
+
+  const expr2tc &obj = to_object_descriptor2t(targets.front()).object;
+  if (is_nil_expr(obj))
+    return expr2tc();
+
+  const expr2tc *base = get_object(obj);
+  if (base == nullptr)
+    return expr2tc();
+
+  const symbolt *sym = ns.lookup(to_symbol2t(*base).thename);
+  if (sym == nullptr || sym->get_type().dynamic())
+    return expr2tc();
+
+  // The enforce harness backs a pointer parameter whose contract states no
+  // extent with one element of stack (emit_struct_stack_backing, #6212). That
+  // object stands in for whatever the caller would pass; reading an extent off
+  // it would hand the contract the very guarantee it failed to state.
+  if (id2string(sym->id).rfind("__ESBMC_harness_ptr_", 0) == 0)
+    return expr2tc();
+
+  return *base;
+}
+
+/// Decide VALID_OBJECT from the object the value set names, if it names one.
+///
+/// is_valid_object() answers false for every automatic object: the scope
+/// tracking it would need is #if 0'd out at the end of this file. The syntactic
+/// path never reaches it, because a named object returns its declared extent
+/// and drops this conjunct. Do the same once the value set has named the
+/// object: a pointer it resolves addresses a live object, and the extent is
+/// checked separately (#7464).
+bool goto_symext::resolve_valid_object_by_value_set(
+  expr2tc &expr,
+  const expr2tc &obj_ref)
+{
+  if (is_nil_expr(value_set_named_object(obj_ref)))
+    return false;
+
+  expr = gen_true_expr();
+  return true;
+}
+
+/// Size an object with automatic or static storage by its type.
+///
+/// DYNAMIC_SIZE is maintained for the heap alone, so it says nothing about the
+/// extent an is_fresh precondition has to compare against for such an object
+/// (#7464).
+bool goto_symext::resolve_dynamic_size_by_value_set(expr2tc &expr)
+{
+  expr2tc named = value_set_named_object(to_dynamic_size2t(expr).value);
+  if (is_nil_expr(named))
+    return false;
+
+  expr = constant_int2tc(size_type2(), type_byte_size(named->type, &ns));
+  return true;
+}
+
+/// Decide VALID_OBJECT / DEALLOCATED_OBJ against the object the pointer names.
+void goto_symext::replace_valid_object(expr2tc &expr)
+{
+  expr2tc &obj_ref = (is_valid_object2t(expr))
+                       ? to_valid_object2t(expr).value
+                       : to_deallocated_obj2t(expr).value;
+
+  if (resolve_valid_object_by_value_set(expr, obj_ref))
+    return;
+
+  if (is_address_of2t(obj_ref))
+  {
+    expr2tc &obj_operand = to_address_of2t(obj_ref).ptr_obj;
+
+    const expr2tc *identifier = get_object(obj_operand);
+
+    if (identifier != nullptr)
+    {
+      expr2tc base_ident = *identifier;
+      cur_state->get_original_name(base_ident);
+
+      const symbolt &symbol = *ns.lookup(to_symbol2t(*identifier).thename);
+
+      // dynamic?
+      if (symbol.get_type().dynamic())
+      {
+        // TODO
+      }
+      else
+      {
+        expr = is_valid_object(symbol) ? gen_true_expr() : gen_false_expr();
+        return; // done
+      }
+    }
+  }
+
+  // default behavior
+  default_replace_dynamic_allocation(expr);
+}
+
+/// Size the object DYNAMIC_SIZE names, falling back to the heap-only table.
+void goto_symext::replace_dynamic_size(expr2tc &expr)
+{
+  if (!resolve_dynamic_size_by_value_set(expr))
+    default_replace_dynamic_allocation(expr);
+}
+
 void goto_symext::replace_dynamic_allocation(expr2tc &expr)
 {
   if (is_nil_expr(expr))
@@ -29,43 +154,11 @@ void goto_symext::replace_dynamic_allocation(expr2tc &expr)
 
   if (is_valid_object2t(expr) || is_deallocated_obj2t(expr))
   {
-    expr2tc &obj_ref = (is_valid_object2t(expr))
-                         ? to_valid_object2t(expr).value
-                         : to_deallocated_obj2t(expr).value;
-
-    if (is_address_of2t(obj_ref))
-    {
-      expr2tc &obj_operand = to_address_of2t(obj_ref).ptr_obj;
-
-      const expr2tc *identifier = get_object(obj_operand);
-
-      if (identifier != nullptr)
-      {
-        expr2tc base_ident = *identifier;
-        cur_state->get_original_name(base_ident);
-
-        const symbolt &symbol = *ns.lookup(to_symbol2t(*identifier).thename);
-
-        // dynamic?
-        if (symbol.get_type().dynamic())
-        {
-          // TODO
-        }
-        else
-        {
-          expr = is_valid_object(symbol) ? gen_true_expr() : gen_false_expr();
-          return; // done
-        }
-      }
-    }
-
-    // default behavior
-    default_replace_dynamic_allocation(expr);
+    replace_valid_object(expr);
   }
   else if (is_dynamic_size2t(expr))
   {
-    // default behavior
-    default_replace_dynamic_allocation(expr);
+    replace_dynamic_size(expr);
   }
   else if (is_invalid_pointer2t(expr))
   {


### PR DESCRIPTION
Fixes #7464.

## The defect

A replace-side `__ESBMC_is_fresh` was decided by how the call site spells the
pointer, not by which object it names:

| call site | before | after |
|---|---|---|
| `callee(buf, 8)` | `SUCCESSFUL` | `SUCCESSFUL` |
| `callee(&buf[0], 8)` | `SUCCESSFUL` | `SUCCESSFUL` |
| forwarded through a pointer parameter | **`FAILED`** | `SUCCESSFUL` |
| through a local `int *q = buf` | **`FAILED`** | `SUCCESSFUL` |

## Why

Three things had to line up, and the third is the one that matters.

`named_base_object` (`contracts.cpp:2560`) only recognises a syntactic
`address_of` over a non-pointer symbol. A pointer arriving as a parameter is a
plain `symbol2t`, so the condition falls back on `__ESBMC_alloc` and
`DYNAMIC_SIZE`.

Neither is maintained for automatic storage — `dynamic_allocation.cpp` says so
outright — and `is_valid_object()` returns false for every such object, because
the scope tracking it would need is `#if 0`'d out. So the solver may call a live
stack object invalid.

The `!is_dynamic ||` escape was added to keep stack callers working despite
that. It does, but by skipping the extent check entirely for exactly those
callers: `is_dynamic` is false for a stack object, so the disjunction is
discharged without ever comparing the extent. That half is an unsoundness in
the same family as #6212.

## The fix

symex resolves `VALID_OBJECT` and `DYNAMIC_SIZE` against the object the value
set names, so both are meaningful for automatic and static storage, and the
escape goes — the extent is now checked rather than skipped.

Harness-created objects are excluded. `emit_struct_stack_backing` gives a
pointer parameter a one-element stack backing *because* the contract states no
extent (#6212, and it warns as much). Reading an extent off one would hand the
contract the guarantee it failed to state — that is what
`replace_is_fresh_requires_weak_caller_fail` pins, and an earlier version of
this patch tripped it.

## Tests

- `github_7464_is_fresh_forwarded_ptr` — the same stack array reached directly
  and through a parameter; must verify. **Mutation-checked: it flips to FAILED
  with the fix reverted.**
- `github_7464_is_fresh_extent_too_small_fail` — `buf[4]` against a contract
  demanding 8 ints; must be rejected.

In the interest of not overclaiming: the `_fail` test is **not** a gate on this
diff. Its output is byte-identical before and after, because on `master` the
run already fails for the other reason. It earns its place differently — it
caught a wrong version of this patch during development, one that made the
forwarded case pass by treating the object as valid without restoring the
extent check, i.e. vacuously.

`regression/function_contract` 428/428, `loop-invariants` 81/81.

## Scope

This changes when a caller can discharge an `is_fresh` precondition, and it
makes the extent check bite where it previously did not, so a contract that was
passing on an unstated extent will now report `FAILED`. Labelled
`needs-svcomp-run` accordingly.
