### PR TITLE
[smt] Do not push nil operands onto the conversion work stack

### DIFF
--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -471,7 +471,14 @@ smt_astt smt_solver_baset::convert_ast(const expr2tc &expr)
       // foreach_operand (both fold over K::fields), so no operand is skipped.
       const size_t n = node->get_num_sub_exprs();
       for (size_t i = n; i-- > 0;)
-        stack.emplace_back(*node->get_sub_expr(i), false);
+      {
+        // Optional operand slots are nil for some kinds (sideeffect2t's
+        // operand and size); pushing one hashes a null container below.
+        const expr2tc *sub = node->get_sub_expr(i);
+        if (sub == nullptr || is_nil_expr(*sub))
+          continue;
+        stack.emplace_back(*sub, false);
+      }
       continue;
     }
 


### PR DESCRIPTION
`convert_ast`'s work stack pushes every slot `get_sub_expr` reports, including
the optional ones that are nil for kinds such as `sideeffect2t`. The next
iteration looks that node up in `smt_cache`, hashing a null container: SIGSEGV.

A nil child has nothing to convert, so skip it.

Reached from the CBMC `--binary` path, where a `sideeffect2t` with unset
`operand`/`size` survives to SMT conversion.

**No test here on purpose.** A single expression traverses both this loop and
`convert_ast_node`'s `foreach_operand` path, so the crash persists until both
fixes are in and a test added here would still fail. The unit test lands in the
stacked follow-up, #7470, which covers both.