### PR TITLE
[smt] Skip nil operands in convert_ast_node's default case

### DIFF
--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -471,7 +471,14 @@ smt_astt smt_solver_baset::convert_ast(const expr2tc &expr)
       // foreach_operand (both fold over K::fields), so no operand is skipped.
       const size_t n = node->get_num_sub_exprs();
       for (size_t i = n; i-- > 0;)
-        stack.emplace_back(*node->get_sub_expr(i), false);
+      {
+        // Optional operand slots are nil for some kinds (sideeffect2t's
+        // operand and size); pushing one hashes a null container below.
+        const expr2tc *sub = node->get_sub_expr(i);
+        if (sub == nullptr || is_nil_expr(*sub))
+          continue;
+        stack.emplace_back(*sub, false);
+      }
       continue;
     }
 

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -639,13 +639,10 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
 
   default:
   {
-    // Convert all the arguments and store them in 'args'. foreach_operand
-    // visits nil slots too; converting one hashes a null container, and the
-    // per-kind handler below reports an unsupported kind anyway.
+    // Convert all the arguments and store them in 'args'.
     args.reserve(expr->get_num_sub_exprs());
     expr->foreach_operand([this, &args](const expr2tc &e) {
-      if (!is_nil_expr(e))
-        args.push_back(convert_ast(e));
+      args.push_back(is_nil_expr(e) ? nullptr : convert_ast(e));
     });
   }
   }

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -639,10 +639,14 @@ smt_astt smt_solver_baset::convert_ast_node(const expr2tc &expr)
 
   default:
   {
-    // Convert all the arguments and store them in 'args'.
+    // Convert all the arguments and store them in 'args'. foreach_operand
+    // visits nil slots too; converting one hashes a null container, and the
+    // per-kind handler below reports an unsupported kind anyway.
     args.reserve(expr->get_num_sub_exprs());
-    expr->foreach_operand(
-      [this, &args](const expr2tc &e) { args.push_back(convert_ast(e)); });
+    expr->foreach_operand([this, &args](const expr2tc &e) {
+      if (!is_nil_expr(e))
+        args.push_back(convert_ast(e));
+    });
   }
   }
 

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -468,7 +468,9 @@ smt_astt smt_solver_baset::convert_ast(const expr2tc &expr)
       // matching the recursive foreach_operand order — fresh-symbol numbering
       // and cache-insertion order then stay identical to recursive conversion.
       // get_sub_expr() visits the same slots in the same order as
-      // foreach_operand (both fold over K::fields), so no operand is skipped.
+      // foreach_operand (both fold over K::fields), so the two traversals
+      // agree on every non-nil slot; nil slots are skipped here and placed
+      // as null entries there, neither of which is converted.
       const size_t n = node->get_num_sub_exprs();
       for (size_t i = n; i-- > 0;)
       {

--- a/unit/solvers/CMakeLists.txt
+++ b/unit/solvers/CMakeLists.txt
@@ -49,3 +49,6 @@ new_unit_test(simplification_equivalence_test
 # it. `solvers` rather than a named backend -- whichever is built in answers.
 new_unit_test(tuple_node_update_test "tuple_node_update.test.cpp"
               "solvers;util_esbmc;filesystem;bigint")
+
+new_unit_test(nil_operand_test "nil_operand.test.cpp"
+              "solvers;util_esbmc;filesystem;bigint")

--- a/unit/solvers/nil_operand.test.cpp
+++ b/unit/solvers/nil_operand.test.cpp
@@ -44,10 +44,16 @@ SCENARIO("converting a nil operand slot is reported, not crashed on",
 
     THEN("convert_ast aborts with a diagnostic instead of segfaulting")
     {
+      // The child marks the pipe once the solver exists and it is about to
+      // call convert_ast, so an abort in create_solver cannot satisfy this.
+      int fds[2];
+      REQUIRE(pipe(fds) == 0);
+
       pid_t pid = fork();
       REQUIRE(pid >= 0);
       if (pid == 0)
       {
+        close(fds[0]);
         // Silence the diagnostic and Catch2's signal report. Consume the
         // freopen results to satisfy -Werror=unused-result.
         if (
@@ -58,12 +64,23 @@ SCENARIO("converting a nil operand slot is reported, not crashed on",
         namespacet ns(ctx);
         optionst options;
         std::unique_ptr<smt_convt> solver{create_solver("", ns, options)};
+        const char mark = 'x';
+        if (write(fds[1], &mark, 1) != 1)
+          _exit(3);
         (void)solver->convert_ast(nondet);
         _exit(0); // unreachable: the kind is unsupported
       }
 
+      close(fds[1]);
+      char mark = 0;
+      const ssize_t got = read(fds[0], &mark, 1);
+      close(fds[0]);
+
       int status = 0;
       REQUIRE(waitpid(pid, &status, 0) == pid);
+      // Reached convert_ast: the abort below is its doing, not the solver's.
+      REQUIRE(got == 1);
+      REQUIRE(mark == 'x');
       REQUIRE(WIFSIGNALED(status));
       // The point of the fix: SIGABRT (reported) rather than SIGSEGV (crash).
       REQUIRE(WTERMSIG(status) != SIGSEGV);

--- a/unit/solvers/nil_operand.test.cpp
+++ b/unit/solvers/nil_operand.test.cpp
@@ -1,0 +1,74 @@
+// convert_ast must not descend into nil operand slots.
+//
+// Several expression kinds carry optional operands that are nil -- a
+// sideeffect2t built by gen_nondet leaves both `operand` and `size` unset.
+// Both conversion paths used to hand those slots on regardless: the work
+// stack in convert_ast pushed them and then hashed a null container into
+// smt_cache, and convert_ast_node's default case passed them to convert_ast
+// via foreach_operand. Either way the result was a SIGSEGV.
+//
+// The contract is that an unconvertible kind is reported, not crashed on, so
+// the test forks and requires SIGABRT (the diagnostic path) rather than
+// SIGSEGV. Unreachable from C input, where such a sideeffect is removed
+// before symex ends, so only a direct call states it.
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <memory>
+
+#include <irep2/irep2_utils.h>
+#include <solvers/smt/smt_conv.h>
+#include <solvers/solve.h>
+#include <util/config/config.h>
+#include <util/config/options.h>
+#include <util/symtab/context.h>
+#include <util/symtab/namespace.h>
+
+#if !defined(_WIN32)
+#  include <csignal>
+#  include <sys/wait.h>
+#  include <unistd.h>
+
+SCENARIO("converting a nil operand slot is reported, not crashed on",
+         "[solvers][smt]")
+{
+  config.ansi_c.set_data_model(configt::LP64);
+
+  GIVEN("a sideeffect whose operand and size slots are both nil")
+  {
+    // gen_nondet leaves every optional slot unset.
+    const expr2tc nondet = gen_nondet(get_int32_type());
+    REQUIRE(is_sideeffect2t(nondet));
+    REQUIRE(is_nil_expr(to_sideeffect2t(nondet).operand));
+    REQUIRE(is_nil_expr(to_sideeffect2t(nondet).size));
+
+    THEN("convert_ast aborts with a diagnostic instead of segfaulting")
+    {
+      pid_t pid = fork();
+      REQUIRE(pid >= 0);
+      if (pid == 0)
+      {
+        // Silence the diagnostic and Catch2's signal report. Consume the
+        // freopen results to satisfy -Werror=unused-result.
+        if (
+          !freopen("/dev/null", "w", stderr) ||
+          !freopen("/dev/null", "w", stdout))
+          _exit(2);
+        contextt ctx;
+        namespacet ns(ctx);
+        optionst options;
+        std::unique_ptr<smt_convt> solver{create_solver("", ns, options)};
+        (void)solver->convert_ast(nondet);
+        _exit(0); // unreachable: the kind is unsupported
+      }
+
+      int status = 0;
+      REQUIRE(waitpid(pid, &status, 0) == pid);
+      REQUIRE(WIFSIGNALED(status));
+      // The point of the fix: SIGABRT (reported) rather than SIGSEGV (crash).
+      REQUIRE(WTERMSIG(status) != SIGSEGV);
+      REQUIRE(WTERMSIG(status) == SIGABRT);
+    }
+  }
+}
+#endif

--- a/unit/solvers/nil_operand.test.cpp
+++ b/unit/solvers/nil_operand.test.cpp
@@ -29,8 +29,9 @@
 #  include <sys/wait.h>
 #  include <unistd.h>
 
-SCENARIO("converting a nil operand slot is reported, not crashed on",
-         "[solvers][smt]")
+SCENARIO(
+  "converting a nil operand slot is reported, not crashed on",
+  "[solvers][smt]")
 {
   config.ansi_c.set_data_model(configt::LP64);
 


### PR DESCRIPTION
Stacked on #7469 — review that first. Based on `fix/smt-nil-operand-work-stack`,
so retarget to `master` once that merges.

`foreach_operand` visits every operand slot, including the optional ones that
are nil for kinds such as `sideeffect2t`, and the default case of
`convert_ast_node` hands each to `convert_ast`. Converting a nil operand hashes
a null container: SIGSEGV.

Skip them; the per-kind handler reports an unsupported kind instead.

This does not renumber `args` for any conversion that previously worked: an
expression carrying a nil slot crashed here before, so only already-broken
paths change shape. That is the claim most worth checking.

**Test** (`unit/solvers/nil_operand.test.cpp`) covers this and #7469 together: a
`sideeffect2t` from `gen_nondet` traverses both loops, so the crash persists
until both are in. It forks and requires SIGABRT rather than SIGSEGV — the
contract is that an unconvertible kind is reported, not crashed on. Verified to
fail on `master`.