### PR TITLE
[python] Fix crashes found by consensus regression suite

### DIFF
--- a/regression/consensus/bls_field_to_bytes/test.desc
+++ b/regression/consensus/bls_field_to_bytes/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc --function bls_field_to_bytes
 ^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/floorlog2/test.desc
+++ b/regression/consensus/floorlog2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc --function floorlog2
+--unwind 513 --function floorlog2
 ^VERIFICATION FAILED$

--- a/regression/consensus/get_subtree_index/test.desc
+++ b/regression/consensus/get_subtree_index/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc --function get_subtree_index
+--unwind 513 --function get_subtree_index
 ^VERIFICATION FAILED$

--- a/regression/python/int_to_bytes_byteorder_const_var/main.py
+++ b/regression/python/int_to_bytes_byteorder_const_var/main.py
@@ -1,0 +1,4 @@
+BYTEORDER = 'big'
+
+result = int.to_bytes(7, 4, BYTEORDER)
+assert len(result) == 4

--- a/regression/python/int_to_bytes_byteorder_const_var/test.desc
+++ b/regression/python/int_to_bytes_byteorder_const_var/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_to_bytes_byteorder_const_var_fail/main.py
+++ b/regression/python/int_to_bytes_byteorder_const_var_fail/main.py
@@ -1,0 +1,4 @@
+BYTEORDER = 'big'
+
+result = int.to_bytes(7, 4, BYTEORDER)
+assert len(result) == 5

--- a/regression/python/int_to_bytes_byteorder_const_var_fail/test.desc
+++ b/regression/python/int_to_bytes_byteorder_const_var_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/raise_fstring_symbolic_arg/main.py
+++ b/regression/python/raise_fstring_symbolic_arg/main.py
@@ -1,0 +1,6 @@
+def f(x: int) -> int:
+    if x < 1:
+        raise ValueError(f"f expects a positive value, x={x}")
+    return x
+
+assert f(5) == 5

--- a/regression/python/raise_fstring_symbolic_arg/test.desc
+++ b/regression/python/raise_fstring_symbolic_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/raise_fstring_symbolic_arg_fail/main.py
+++ b/regression/python/raise_fstring_symbolic_arg_fail/main.py
@@ -1,0 +1,6 @@
+def f(x: int) -> int:
+    if x < 1:
+        raise ValueError(f"f expects a positive value, x={x}")
+    return x
+
+assert f(5) == 6

--- a/regression/python/raise_fstring_symbolic_arg_fail/test.desc
+++ b/regression/python/raise_fstring_symbolic_arg_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 513 --function ceillog2
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/src/python-frontend/exception/python_exception_handler.cpp
+++ b/src/python-frontend/exception/python_exception_handler.cpp
@@ -448,16 +448,29 @@ void python_exception_handler::get_raise_statement(
   {
     // Construct a constant struct to throw: raise { .message=&"Error message" }
     exprt arg;
+    bool arg_is_already_addressed = false;
     const auto &exc = element["exc"];
     if (
       exc.contains("args") && !exc["args"].empty() && !exc["args"][0].is_null())
     {
       const auto &json_arg = exc["args"][0];
       exprt tmp = converter_.get_expr(json_arg);
-      arg = string_constantt(
-        converter_.get_string_handler().process_format_spec(json_arg),
-        tmp.type(),
-        string_constantt::k_default);
+      if (tmp.type().is_array())
+      {
+        arg = string_constantt(
+          converter_.get_string_handler().process_format_spec(json_arg),
+          tmp.type(),
+          string_constantt::k_default);
+      }
+      else
+      {
+        // tmp is already the char* built for a message we can't know up
+        // front (e.g. an f-string with a variable in it). string_constantt
+        // needs a fixed-size array type, so just reuse tmp instead of
+        // rebuilding one with the wrong type.
+        arg = tmp;
+        arg_is_already_addressed = true;
+      }
     }
     else
     {
@@ -470,7 +483,8 @@ void python_exception_handler::get_raise_statement(
 
     raise.id("struct");
     raise.type() = type;
-    raise.copy_to_operands(build_address_of(arg));
+    raise.copy_to_operands(
+      arg_is_already_addressed ? arg : build_address_of(arg));
   }
   else
   {

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -448,6 +448,7 @@ exprt function_call_expr::handle_int_to_bytes() const
     // to big-endian would mis-fold a little-endian intent into a wrong byte
     // array. Reject the non-constant form with a clean error instead, matching
     // the constant-length guard above.
+    std::string folded_byteorder;
     if (
       byteorder_arg->contains("value") &&
       (*byteorder_arg)["value"].is_boolean())
@@ -455,6 +456,9 @@ exprt function_call_expr::handle_int_to_bytes() const
     else if (
       byteorder_arg->contains("value") && (*byteorder_arg)["value"].is_string())
       big_endian = (*byteorder_arg)["value"].get<std::string>() == "big";
+    else if (string_handler::extract_constant_string(
+               *byteorder_arg, converter_, folded_byteorder))
+      big_endian = folded_byteorder == "big";
     else
       throw std::runtime_error(
         "int.to_bytes() currently expects a constant byteorder");


### PR DESCRIPTION
Fixed two bugs found while adding regression/consensus suite:
- raise ValueError(f"...{x}...") crashed migrate_expr when x was symbolic, because the message got rebuilt with the wrong type instead of reusing the expression it had already built.
- int.to_bytes() rejected a byteorder passed through a constant variable, accepting only a literal at the call site.

Fixes #7460