### PR TITLE
[python] Bound list_extend_elem_size at the depth it needs

### DIFF
--- a/regression/python/list_extend_elem_size/test.desc
+++ b/regression/python/list_extend_elem_size/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 12
+--unwind 6
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_extend_elem_size_fail/test.desc
+++ b/regression/python/list_extend_elem_size_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
---unwind 12
+--unwind 6
 ^VERIFICATION FAILED$
 ^ *FAILED .*assertion .*value == 99$


### PR DESCRIPTION
`list_extend_elem_size` asked for `--unwind 12` where 5 suffices. That cost 20.7s against
12.2s and put it close enough to the 120s per-test cap to time out on a loaded macOS runner,
failing an unrelated PR (#7445).

The bound is proven rather than guessed -- the test runs with unwinding assertions on, so an
insufficient bound fails loudly instead of passing vacuously:

| unwind | unwinding assertion | verdict |
|---|---|---|
| 4 | NOT CHECKED | `VERIFICATION FAILED` |
| 5 | PASSED | `VERIFICATION SUCCESSFUL` |
| 6 | PASSED | `VERIFICATION SUCCESSFUL` |

6 is used rather than the exact floor of 5, leaving one iteration of headroom. Timing at 6 is
12.03 / 12.35 / 12.21 / 12.65s against 20.65 / 20.79s at 12.

The `_fail` twin moves with it and still reports its pinned assertion. `--multi-property`, which
fixed the comparable `harness_queue_lifo` timeout in #7462, is *not* the lever here: it takes
this program past 250s. Per-claim solving suits some claim structures and not others.
